### PR TITLE
Add GCP addresses for Allconfigs consumers

### DIFF
--- a/typescript/optics-deploy/scripts/dev/check-deploy.ts
+++ b/typescript/optics-deploy/scripts/dev/check-deploy.ts
@@ -6,6 +6,7 @@ import * as mumbai from '../../config/testnets/mumbai';
 import { checkCoreDeploys, InvariantViolationCollector } from '../../src/checks';
 import { makeAllConfigs } from '../../src/config';
 import { configPath } from './agentConfig';
+import { addAgentGCPAddresses } from '../../src/agents';
 
 const governorDomain = alfajores.chain.domain;
 
@@ -14,11 +15,11 @@ async function check() {
   await checkCoreDeploys(
     configPath,
     await Promise.all([
-      makeAllConfigs(alfajores, (_) => _.devConfig),
-      makeAllConfigs(kovan, (_) => _.devConfig),
-      makeAllConfigs(gorli, (_) => _.devConfig),
-      makeAllConfigs(fuji, (_) => _.devConfig),
-      makeAllConfigs(mumbai, (_) => _.devConfig),
+      makeAllConfigs(alfajores, (_) => addAgentGCPAddresses('dev', _.devConfig)),
+      makeAllConfigs(kovan, (_) => addAgentGCPAddresses('dev', _.devConfig)),
+      makeAllConfigs(gorli, (_) => addAgentGCPAddresses('dev', _.devConfig)),
+      makeAllConfigs(fuji, (_) => addAgentGCPAddresses('dev', _.devConfig)),
+      makeAllConfigs(mumbai, (_) => addAgentGCPAddresses('dev', _.devConfig)),
     ]),
     governorDomain,
     invariantViolationCollector.handleViolation

--- a/typescript/optics-deploy/scripts/dev/update-optics-provider.ts
+++ b/typescript/optics-deploy/scripts/dev/update-optics-provider.ts
@@ -6,13 +6,16 @@ import * as mumbai from '../../config/testnets/mumbai';
 import { updateProviderDomain } from '../../src/provider';
 import { configPath } from './agentConfig';
 import { makeAllConfigs } from '../../src/config';
+import { addAgentGCPAddresses } from '../../src/agents';
 
+async function updateProviderDomains() {
+  updateProviderDomain('dev', configPath, await Promise.all([
+    makeAllConfigs(alfajores, (_) => addAgentGCPAddresses('dev', _.devConfig)),
+    makeAllConfigs(kovan, (_) => addAgentGCPAddresses('dev', _.devConfig)),
+    makeAllConfigs(gorli, (_) => addAgentGCPAddresses('dev', _.devConfig)),
+    makeAllConfigs(fuji, (_) => addAgentGCPAddresses('dev', _.devConfig)),
+    makeAllConfigs(mumbai, (_) => addAgentGCPAddresses('dev', _.devConfig)),
+  ]));
+}
 
-updateProviderDomain('dev', configPath, [
-  makeAllConfigs(alfajores, (_) => _.devConfig),
-  makeAllConfigs(kovan, (_) => _.devConfig),
-  makeAllConfigs(gorli, (_) => _.devConfig),
-  makeAllConfigs(fuji, (_) => _.devConfig),
-  makeAllConfigs(mumbai, (_) => _.devConfig),
-]);
-
+updateProviderDomains().then(console.log).catch(console.error)

--- a/typescript/optics-deploy/src/config.ts
+++ b/typescript/optics-deploy/src/config.ts
@@ -9,6 +9,6 @@ export interface AllConfigs {
 }
 
 // The accessor is necessary as a network may have multiple core configs
-export function makeAllConfigs<V>(data: V, coreConfigAccessor: (data: V) => CoreConfig) {
-  return { ...data, coreConfig: coreConfigAccessor(data) };
+export async function makeAllConfigs<V>(data: V, coreConfigAccessor: (data: V) => Promise<CoreConfig>) {
+  return { ...data, coreConfig: await coreConfigAccessor(data) };
 }


### PR DESCRIPTION
`AllConfigs`/`makeAllConfigs` still used the checked-in version of `CoreConfig` which for `dev` environments no longer is the source of truth for the agent keys, thus `makeAllConfigs` needs to be able to have an async `coreConfigAccessor` which can handle the fact that fetching addresses from GCP at runtime is async. This PR also updates the two consumers of `AllConfigs` to inject the GCP addresses which is necessary to make `check-deploy` work