### PR TITLE
Fix devConfig updaters and recoveryManagers

### DIFF
--- a/typescript/optics-deploy/config/testnets/alfajores.ts
+++ b/typescript/optics-deploy/config/testnets/alfajores.ts
@@ -22,9 +22,9 @@ export const chain = toChain(chainJson);
 
 export const devConfig: CoreConfig = {
   environment: 'dev',
-  updater: '0x4177372FD9581ceb2367e0Ce84adC5DAD9DF8D55',
+  updater: '0x91631845fab02614e53e5F5A68dFBB0E2f1a9B6d',
   watchers: ['0x20aC2FD664bA5406A7262967C34107e708dCb18E'],
-  recoveryManager: '0x24F6c874F56533d9a1422e85e5C7A806ED11c036',
+  recoveryManager: '0x4FbBB2b0820CF0cF027BbB58DC7F7f760BC0c57e',
   optimisticSeconds: 10,
   recoveryTimelock: 180,
   processGas: 850_000,

--- a/typescript/optics-deploy/config/testnets/fuji.ts
+++ b/typescript/optics-deploy/config/testnets/fuji.ts
@@ -23,9 +23,9 @@ export const chain = toChain(chainJson);
 
 export const devConfig: CoreConfig = {
   environment: 'dev',
-  updater: '0x4177372FD9581ceb2367e0Ce84adC5DAD9DF8D55',
+  updater: '0x91631845fab02614e53e5F5A68dFBB0E2f1a9B6d',
   watchers: ['0x20aC2FD664bA5406A7262967C34107e708dCb18E'],
-  recoveryManager: '0x24F6c874F56533d9a1422e85e5C7A806ED11c036',
+  recoveryManager: '0x4FbBB2b0820CF0cF027BbB58DC7F7f760BC0c57e',
   optimisticSeconds: 10,
   recoveryTimelock: 180,
   processGas: 850_000,

--- a/typescript/optics-deploy/config/testnets/gorli.ts
+++ b/typescript/optics-deploy/config/testnets/gorli.ts
@@ -23,9 +23,9 @@ export const chainJson: ChainJson = {
 
 export const devConfig: CoreConfig = {
   environment: 'dev',
-  updater: '0x4177372FD9581ceb2367e0Ce84adC5DAD9DF8D55',
+  updater: '0x91631845fab02614e53e5F5A68dFBB0E2f1a9B6d',
   watchers: ['0x20aC2FD664bA5406A7262967C34107e708dCb18E'],
-  recoveryManager: '0x24F6c874F56533d9a1422e85e5C7A806ED11c036',
+  recoveryManager: '0x4FbBB2b0820CF0cF027BbB58DC7F7f760BC0c57e',
   optimisticSeconds: 10,
   recoveryTimelock: 180,
   processGas: 850_000,

--- a/typescript/optics-deploy/config/testnets/kovan.ts
+++ b/typescript/optics-deploy/config/testnets/kovan.ts
@@ -24,11 +24,11 @@ export const chain = toChain(chainJson);
 
 export const devConfig: CoreConfig = {
   environment: 'dev',
-  updater: '0x4177372FD9581ceb2367e0Ce84adC5DAD9DF8D55',
+  updater: '0x91631845fab02614e53e5F5A68dFBB0E2f1a9B6d',
   optimisticSeconds: 10,
   watchers: ['0x20aC2FD664bA5406A7262967C34107e708dCb18E'],
   recoveryTimelock: 180,
-  recoveryManager: '0x24F6c874F56533d9a1422e85e5C7A806ED11c036',
+  recoveryManager: '0x4FbBB2b0820CF0cF027BbB58DC7F7f760BC0c57e',
   processGas: 850_000,
   reserveGas: 15_000,
 };

--- a/typescript/optics-deploy/config/testnets/mumbai.ts
+++ b/typescript/optics-deploy/config/testnets/mumbai.ts
@@ -23,9 +23,9 @@ export const chain = toChain(chainJson);
 
 export const devConfig: CoreConfig = {
   environment: 'dev',
-  updater: '0x4177372FD9581ceb2367e0Ce84adC5DAD9DF8D55',
+  updater: '0x91631845fab02614e53e5F5A68dFBB0E2f1a9B6d',
   watchers: ['0x20aC2FD664bA5406A7262967C34107e708dCb18E'],
-  recoveryManager: '0x24F6c874F56533d9a1422e85e5C7A806ED11c036',
+  recoveryManager: '0x4FbBB2b0820CF0cF027BbB58DC7F7f760BC0c57e',
   optimisticSeconds: 10,
   recoveryTimelock: 180,
   processGas: 850_000,


### PR DESCRIPTION
When I originally deployed the `dev` environment I did not check in the changes to the updater and recovery manager addresses for which the source of truth now lives in GCP secret manager.

Our config/secret management definitely needs streamlining