### PR TITLE
Remote write abacus metrics

### DIFF
--- a/typescript/abacus-deploy/src/infrastructure/monitoring/prometheus.ts
+++ b/typescript/abacus-deploy/src/infrastructure/monitoring/prometheus.ts
@@ -78,7 +78,8 @@ async function getPrometheusConfig(
           write_relabel_configs: [
             {
               action: 'keep',
-              regex: '(container.*|optics.*|Optics.*|prometheus.*|ethereum.*|abacus.*)',
+              regex:
+                '(container.*|optics.*|Optics.*|prometheus.*|ethereum.*|abacus.*)',
               source_labels: ['__name__'],
             },
           ],


### PR DESCRIPTION
* This allows `abacus.*` prefixed prometheus metrics names to be remote written. I could see this getting annoying in the future if we forget that new metrics we add must be prefixed in a certain way-- there's a tradeoff of cost here for sure, so I'm personally okay keeping the remote write filtering as is for now
* Deployed on dev, testnet, and mainnet