### PR TITLE
Add typescript tests to CI

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -20,18 +20,6 @@ jobs:
         with:
           runneros: ${{ runner.os }}
 
-  typescript-build:
-    runs-on: ubuntu-latest
-    needs: [typescript-install]
-    steps:
-      - uses: actions/checkout@v2
-      - name: npm install
-        uses: ./.github/workflows/npm
-        with:
-          runneros: ${{ runner.os }}
-
-      - name: build
-        run: npm run build
   typescript-lint:
     runs-on: ubuntu-latest
     needs: [typescript-install]
@@ -60,5 +48,7 @@ jobs:
         with:
           runneros: ${{ runner.os }}
 
+      - name: build
+        run: npm run build
       - name: test
         run: npm --prefix ./typescript/abacus-deploy run test


### PR DESCRIPTION
https://github.com/bridge-buddies/optics-monorepo/pull/152 changes meant that this was no longer being run in CI.