### PR TITLE
Add script for running local dev environment

### DIFF
--- a/solidity/abacus-core/package.json
+++ b/solidity/abacus-core/package.json
@@ -27,7 +27,7 @@
     "test": "test"
   },
   "scripts": {
-    "prettier": "prettier --write ./contracts ./libs ./test",
+    "prettier": "prettier --write ./contracts ./libs ./test ./scripts",
     "force-compile": "hardhat compile --force && hardhat typechain",
     "compile": "hardhat compile && hardhat typechain && npm run prettier && npm run copy-typechain",
     "copy-typechain": "mkdir -p ../../typescript/typechain/abacus-core/ && cp -r typechain/* ../../typescript/typechain/abacus-core/",

--- a/solidity/abacus-core/scripts/abacus.ts
+++ b/solidity/abacus-core/scripts/abacus.ts
@@ -2,17 +2,23 @@ import { ethers, waffle } from 'hardhat';
 import { AbacusDeployment, types, utils } from '../test';
 
 function sleep(ms: number) {
-    return new Promise( resolve => setTimeout(resolve, ms) );
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 const domains = [1000, 2000];
-const domainSummary = async (local: types.Domain, remote: types.Domain, abacus: AbacusDeployment) => {
-  const outbox = abacus.outbox(local)
-  const [outboxCheckpointRoot, outboxCheckpointIndex] = await outbox.latestCheckpoint()
-  const count = await outbox.tree()
+const domainSummary = async (
+  local: types.Domain,
+  remote: types.Domain,
+  abacus: AbacusDeployment,
+) => {
+  const outbox = abacus.outbox(local);
+  const [outboxCheckpointRoot, outboxCheckpointIndex] =
+    await outbox.latestCheckpoint();
+  const count = await outbox.tree();
 
-  const inbox = abacus.inbox(remote, local)
-  const [inboxCheckpointRoot, inboxCheckpointIndex] = await inbox.latestCheckpoint()
+  const inbox = abacus.inbox(remote, local);
+  const [inboxCheckpointRoot, inboxCheckpointIndex] =
+    await inbox.latestCheckpoint();
   const processFilter = inbox.filters.Process();
   const processes = await inbox.queryFilter(processFilter);
   const summary = {
@@ -22,7 +28,7 @@ const domainSummary = async (local: types.Domain, remote: types.Domain, abacus: 
       checkpoint: {
         root: outboxCheckpointRoot,
         index: outboxCheckpointIndex,
-      }
+      },
     },
     inbox: {
       local: remote,
@@ -33,24 +39,28 @@ const domainSummary = async (local: types.Domain, remote: types.Domain, abacus: 
         index: inboxCheckpointIndex,
       },
     },
-  }
-  return summary
-}
+  };
+  return summary;
+};
 
 async function main() {
   const [signer] = await ethers.getSigners();
   const abacus = await AbacusDeployment.fromDomains(domains, signer);
-  console.log("Abacus deployed");
-  let provider = waffle.provider
+  console.log('Abacus deployed');
+  let provider = waffle.provider;
   while (true) {
-    const rand = Math.random() < 0.5
+    const rand = Math.random() < 0.5;
     const local = rand ? domains[0] : domains[1];
     const remote = !rand ? domains[0] : domains[1];
-    const outbox = abacus.outbox(local)
+    const outbox = abacus.outbox(local);
     // Values for recipient and message don't matter
-    await outbox.dispatch(remote, utils.addressToBytes32(outbox.address), '0x1234')
-    console.log(await domainSummary(1000, 2000, abacus))
-    console.log(await domainSummary(2000, 1000, abacus))
+    await outbox.dispatch(
+      remote,
+      utils.addressToBytes32(outbox.address),
+      '0x1234',
+    );
+    console.log(await domainSummary(1000, 2000, abacus));
+    console.log(await domainSummary(2000, 1000, abacus));
     await sleep(5000);
   }
 }
@@ -63,4 +73,3 @@ main()
     console.error(error);
     process.exit(1);
   });
-


### PR DESCRIPTION
This PR adds a script in `abacus-core` for running a local dev environment.

In one tab, run:
```npm run node```

In another tab:
```npm run deploy```

This setup is intended to be replaced by a hardhat task as described in https://github.com/bridge-buddies/optics-monorepo/issues/173