### PR TITLE
Ignore errors during message processing in TipProver

### DIFF
--- a/solidity/core/contracts/test/bad-recipient/RandomBadRecipient.sol
+++ b/solidity/core/contracts/test/bad-recipient/RandomBadRecipient.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.6.11;
+
+import {IMessageRecipient} from "../../../interfaces/IMessageRecipient.sol";
+
+contract BadRandomRecipient is IMessageRecipient {
+    event Handled(bytes32 blockHash);
+
+    function handle(
+        uint32,
+        bytes32,
+        bytes memory
+    ) external override {
+        bool isBlockHashEven = uint256(blockhash(block.number - 1)) % 2 == 0;
+        require(isBlockHashEven, "block hash is odd");
+        emit Handled(blockhash(block.number - 1));
+    }
+}

--- a/solidity/core/test/badrecipient.test.ts
+++ b/solidity/core/test/badrecipient.test.ts
@@ -1,0 +1,41 @@
+import { ethers } from 'hardhat';
+
+import { BadRandomRecipient__factory } from '../types';
+import { utils } from '@abacus-network/utils';
+import { expect } from 'chai';
+
+describe('BadRecipient', () => {
+  describe('RandomBadRecipient', () => {
+    it('randomly handles a message', async () => {
+      const [signer] = await ethers.getSigners();
+      const signerAddress = await signer.getAddress();
+      const recipientFactory = new BadRandomRecipient__factory(signer);
+      const recipient = await recipientFactory.deploy();
+
+      // Didn't know how else to test the randomness
+      let successes = 0;
+      let failures = 0;
+      for (let i = 0; i < 10; i++) {
+        try {
+          // "Inject randomness"
+          await signer.sendTransaction({
+            from: signerAddress,
+            to: signerAddress,
+            value: 1,
+          });
+          await recipient.handle(
+            0,
+            utils.addressToBytes32(recipient.address),
+            '0x1234',
+          );
+          successes += 1;
+        } catch (error) {
+          failures += 1;
+        }
+      }
+
+      expect(successes).to.be.greaterThan(1);
+      expect(failures).to.be.greaterThan(1);
+    });
+  });
+});

--- a/typescript/deploy/hardhat.config.ts
+++ b/typescript/deploy/hardhat.config.ts
@@ -2,7 +2,7 @@ import '@nomiclabs/hardhat-waffle';
 import '@nomiclabs/hardhat-etherscan';
 import { task } from 'hardhat/config';
 import { types, utils } from '@abacus-network/utils';
-import { TestRecipient__factory } from '@abacus-network/core';
+import { BadRandomRecipient__factory } from '@abacus-network/core';
 
 import { sleep } from './src/utils/utils';
 import {
@@ -79,7 +79,7 @@ task('kathy', 'Dispatches random abacus messages')
 
     // Deploy a recipient
     const [signer] = await hre.ethers.getSigners();
-    const recipientF = new TestRecipient__factory(signer);
+    const recipientF = new BadRandomRecipient__factory(signer);
     const recipient = await recipientF.deploy();
     await recipient.deployTransaction.wait();
 


### PR DESCRIPTION
This PR fixes #272 

It also changes the default recipient in the kathy tasks to be one that basically fails at random. There are probably certain errors that should just be retried in the context of of the TipProver, filed https://github.com/abacus-network/abacus-monorepo/issues/282. For now this should be fine as the dominant source of errors would be reverts most likely (and maybe polygon issues), and for those the lagged message processor is the better place to address