### PR TITLE
Fetch Proofs directly instead of the DB

### DIFF
--- a/rust/abacus-core/src/db/abacus_db.rs
+++ b/rust/abacus-core/src/db/abacus_db.rs
@@ -25,6 +25,7 @@ static LATEST_ROOT: &str = "update_latest_root_";
 static LATEST_LEAF_INDEX: &str = "latest_known_leaf_index_";
 static LATEST_LEAF_INDEX_FOR_DESTINATION: &str = "latest_known_leaf_index_for_destination_";
 static UPDATER_PRODUCED_UPDATE: &str = "updater_produced_update_";
+static LEAF_PROCESS_STATUS: &str = "leaf_process_status_";
 
 /// DB handle for storing data tied to a specific home.
 ///
@@ -397,5 +398,20 @@ impl AbacusDB {
         previous_root: H256,
     ) -> Result<Option<SignedUpdate>, DbError> {
         self.retrieve_keyed_decodable(UPDATER_PRODUCED_UPDATE, &previous_root)
+    }
+
+    /// Mark leaf as processed
+    pub fn mark_leaf_as_processed(&self, leaf_index: u32) -> Result<(), DbError> {
+        debug!(leaf_index = ?leaf_index, "mark leaf as processed");
+        self.store_keyed_encodable(LEAF_PROCESS_STATUS, &leaf_index, &(1 as u32))
+    }
+
+    /// Retrieve leaf processing status
+    pub fn retrieve_leaf_processing_status(
+        &self,
+        leaf_index: u32,
+    ) -> Result<Option<bool>, DbError> {
+        let value: Option<u32> = self.retrieve_keyed_decodable(LEAF_PROCESS_STATUS, &leaf_index)?;
+        Ok(value.map(|x| x == 1))
     }
 }

--- a/rust/agents/relayer/src/checkpoint_relayer.rs
+++ b/rust/agents/relayer/src/checkpoint_relayer.rs
@@ -12,6 +12,7 @@ pub(crate) struct CheckpointRelayer {
     polling_interval: u64,
     /// The minimum latency in seconds between two relayed checkpoints on the inbox
     submission_latency: u64,
+    immediate_message_processing: bool,
     db: AbacusDB,
     inbox: Arc<CachingInbox>,
     prover_sync: MerkleTreeBuilder,
@@ -22,12 +23,14 @@ impl CheckpointRelayer {
     pub(crate) fn new(
         polling_interval: u64,
         submission_latency: u64,
+        immediate_message_processing: bool,
         db: AbacusDB,
         inbox: Arc<CachingInbox>,
         checkpoint_syncer: CheckpointSyncers,
     ) -> Self {
         Self {
             polling_interval,
+            immediate_message_processing,
             submission_latency,
             prover_sync: MerkleTreeBuilder::new(db.clone()),
             db,
@@ -87,28 +90,30 @@ impl CheckpointRelayer {
                 onchain_checkpoint_index,
                 latest_signed_checkpoint.clone(),
             );
+
             self.prover_sync.update_from_batch(&batch)?;
             self.inbox
                 .submit_checkpoint(&latest_signed_checkpoint)
                 .await?;
 
-            // TODO: sign in parallel
-            // TODO: While this is not signed in parallel, the relayer should be configurable to not process messages so that collisions are not happening
-            for message in &batch.messages {
-                match self.prover_sync.get_proof(message.leaf_index) {
-                    Ok(proof) => {
-                        // Ignore errors and expect the lagged message processor to retry
-                        match self.inbox.prove_and_process(&message.message, &proof).await {
-                            Ok(outcome) => {
-                                info!(txHash=?outcome.txid, leaf_index=message.leaf_index, "CheckpointRelayer processed message")
-                            }
-                            Err(error) => {
-                                error!(error=?error, leaf_index=message.leaf_index, "CheckpointRelayer encountered error while processing message, ignoring")
+            if self.immediate_message_processing {
+                // TODO: sign in parallel
+                for message in &batch.messages {
+                    match self.prover_sync.get_proof(message.leaf_index) {
+                        Ok(proof) => {
+                            // Ignore errors and expect the lagged message processor to retry
+                            match self.inbox.prove_and_process(&message.message, &proof).await {
+                                Ok(outcome) => {
+                                    info!(txHash=?outcome.txid, leaf_index=message.leaf_index, "CheckpointRelayer processed message")
+                                }
+                                Err(error) => {
+                                    error!(error=?error, leaf_index=message.leaf_index, "CheckpointRelayer encountered error while processing message, ignoring")
+                                }
                             }
                         }
-                    }
-                    Err(err) => {
-                        error!(error=?err, "Checkpoint relayer was unable fetch proof for message processing")
+                        Err(err) => {
+                            error!(error=?err, "Checkpoint relayer was unable to fetch proof for message processing")
+                        }
                     }
                 }
             }

--- a/rust/agents/relayer/src/settings.rs
+++ b/rust/agents/relayer/src/settings.rs
@@ -7,6 +7,10 @@ decl_settings!(Relayer {
     pollinginterval: String,
     /// The minimum latency in seconds between two relayed checkpoints on the inbox
     submissionlatency: String,
+    /// The maxinmum number of times a processor will try to process a message
+    maxretries: String,
+    /// Whether the CheckpointRelayer should try to immediately process messages
+    relayermessageprocessing: String,
     /// The checkpoint syncer configuration
     checkpointsyncer: abacus_base::CheckpointSyncerConf,
 });


### PR DESCRIPTION
We are using a "stateful merkle tree" in CheckpointRelayer and MessageProcessor which is more appropriate as, conversely to optics, not all merkle roots are "valid" since checkpoints are not guaranteed to make it on-chain.

Previously, we used the DB as the storage for those proofs as we increment the tree, however that had two problems:
1. A separate process using the DB to process messages might conflict with the process that updates the tree from a new signed, but not yet on-chain-submitted checkpoint.
2. CheckpointRelayer and MessageProcessor shared the same "DB + entity" which caused them to share the same "pointers to proofs" for a given leaf_index and that could cause for invalid proofs as well.

Thus this PR moves to fetch proofs directly from the "in-memory" tree representation instead of the DB