### PR TITLE
Use new contract ABI in agents

### DIFF
--- a/rust/abacus-base/src/inbox.rs
+++ b/rust/abacus-base/src/inbox.rs
@@ -109,15 +109,15 @@ impl AbacusCommon for CachingInbox {
         self.inbox.validator_manager().await
     }
 
-    async fn checkpointed_root(&self) -> Result<H256, ChainCommunicationError> {
-        self.inbox.checkpointed_root().await
+    async fn latest_cached_root(&self) -> Result<H256, ChainCommunicationError> {
+        self.inbox.latest_cached_root().await
     }
 
-    async fn latest_checkpoint(
+    async fn latest_cached_checkpoint(
         &self,
         maybe_lag: Option<u64>,
     ) -> Result<Checkpoint, ChainCommunicationError> {
-        self.inbox.latest_checkpoint(maybe_lag).await
+        self.inbox.latest_cached_checkpoint(maybe_lag).await
     }
 }
 
@@ -255,22 +255,22 @@ impl AbacusCommon for InboxVariants {
         }
     }
 
-    async fn checkpointed_root(&self) -> Result<H256, ChainCommunicationError> {
+    async fn latest_cached_root(&self) -> Result<H256, ChainCommunicationError> {
         match self {
-            InboxVariants::Ethereum(inbox) => inbox.checkpointed_root().await,
-            InboxVariants::Mock(mock_inbox) => mock_inbox.checkpointed_root().await,
-            InboxVariants::Other(inbox) => inbox.checkpointed_root().await,
+            InboxVariants::Ethereum(inbox) => inbox.latest_cached_root().await,
+            InboxVariants::Mock(mock_inbox) => mock_inbox.latest_cached_root().await,
+            InboxVariants::Other(inbox) => inbox.latest_cached_root().await,
         }
     }
 
-    async fn latest_checkpoint(
+    async fn latest_cached_checkpoint(
         &self,
         maybe_lag: Option<u64>,
     ) -> Result<Checkpoint, ChainCommunicationError> {
         match self {
-            InboxVariants::Ethereum(inbox) => inbox.latest_checkpoint(maybe_lag).await,
-            InboxVariants::Mock(mock_inbox) => mock_inbox.latest_checkpoint(maybe_lag).await,
-            InboxVariants::Other(inbox) => inbox.latest_checkpoint(maybe_lag).await,
+            InboxVariants::Ethereum(inbox) => inbox.latest_cached_checkpoint(maybe_lag).await,
+            InboxVariants::Mock(mock_inbox) => mock_inbox.latest_cached_checkpoint(maybe_lag).await,
+            InboxVariants::Other(inbox) => inbox.latest_cached_checkpoint(maybe_lag).await,
         }
     }
 }

--- a/rust/abacus-base/src/outbox.rs
+++ b/rust/abacus-base/src/outbox.rs
@@ -98,8 +98,8 @@ impl Outbox for CachingOutbox {
         self.outbox.count().await
     }
 
-    async fn create_checkpoint(&self) -> Result<TxOutcome, ChainCommunicationError> {
-        self.outbox.create_checkpoint().await
+    async fn cache_checkpoint(&self) -> Result<TxOutcome, ChainCommunicationError> {
+        self.outbox.cache_checkpoint().await
     }
 }
 
@@ -149,15 +149,15 @@ impl AbacusCommon for CachingOutbox {
         self.outbox.validator_manager().await
     }
 
-    async fn checkpointed_root(&self) -> Result<H256, ChainCommunicationError> {
-        self.outbox.checkpointed_root().await
+    async fn latest_cached_root(&self) -> Result<H256, ChainCommunicationError> {
+        self.outbox.latest_cached_root().await
     }
 
-    async fn latest_checkpoint(
+    async fn latest_cached_checkpoint(
         &self,
         maybe_lag: Option<u64>,
     ) -> Result<Checkpoint, ChainCommunicationError> {
-        self.outbox.latest_checkpoint(maybe_lag).await
+        self.outbox.latest_cached_checkpoint(maybe_lag).await
     }
 }
 
@@ -257,11 +257,11 @@ impl Outbox for OutboxVariants {
         }
     }
 
-    async fn create_checkpoint(&self) -> Result<TxOutcome, ChainCommunicationError> {
+    async fn cache_checkpoint(&self) -> Result<TxOutcome, ChainCommunicationError> {
         match self {
-            OutboxVariants::Ethereum(outbox) => outbox.create_checkpoint().await,
-            OutboxVariants::Mock(mock_outbox) => mock_outbox.create_checkpoint().await,
-            OutboxVariants::Other(outbox) => outbox.create_checkpoint().await,
+            OutboxVariants::Ethereum(outbox) => outbox.cache_checkpoint().await,
+            OutboxVariants::Mock(mock_outbox) => mock_outbox.cache_checkpoint().await,
+            OutboxVariants::Other(outbox) => outbox.cache_checkpoint().await,
         }
     }
 }
@@ -300,22 +300,24 @@ impl AbacusCommon for OutboxVariants {
         }
     }
 
-    async fn checkpointed_root(&self) -> Result<H256, ChainCommunicationError> {
+    async fn latest_cached_root(&self) -> Result<H256, ChainCommunicationError> {
         match self {
-            OutboxVariants::Ethereum(outbox) => outbox.checkpointed_root().await,
-            OutboxVariants::Mock(mock_outbox) => mock_outbox.checkpointed_root().await,
-            OutboxVariants::Other(outbox) => outbox.checkpointed_root().await,
+            OutboxVariants::Ethereum(outbox) => outbox.latest_cached_root().await,
+            OutboxVariants::Mock(mock_outbox) => mock_outbox.latest_cached_root().await,
+            OutboxVariants::Other(outbox) => outbox.latest_cached_root().await,
         }
     }
 
-    async fn latest_checkpoint(
+    async fn latest_cached_checkpoint(
         &self,
         maybe_lag: Option<u64>,
     ) -> Result<Checkpoint, ChainCommunicationError> {
         match self {
-            OutboxVariants::Ethereum(outbox) => outbox.latest_checkpoint(maybe_lag).await,
-            OutboxVariants::Mock(mock_outbox) => mock_outbox.latest_checkpoint(maybe_lag).await,
-            OutboxVariants::Other(outbox) => outbox.latest_checkpoint(maybe_lag).await,
+            OutboxVariants::Ethereum(outbox) => outbox.latest_cached_checkpoint(maybe_lag).await,
+            OutboxVariants::Mock(mock_outbox) => {
+                mock_outbox.latest_cached_checkpoint(maybe_lag).await
+            }
+            OutboxVariants::Other(outbox) => outbox.latest_cached_checkpoint(maybe_lag).await,
         }
     }
 }

--- a/rust/abacus-core/src/traits/mod.rs
+++ b/rust/abacus-core/src/traits/mod.rs
@@ -102,10 +102,10 @@ pub trait AbacusCommon: Sync + Send + std::fmt::Debug {
     async fn validator_manager(&self) -> Result<H256, ChainCommunicationError>;
 
     /// Fetch the current root.
-    async fn checkpointed_root(&self) -> Result<H256, ChainCommunicationError>;
+    async fn latest_cached_root(&self) -> Result<H256, ChainCommunicationError>;
 
     /// Return the latest checkpointed root and its index.
-    async fn latest_checkpoint(
+    async fn latest_cached_checkpoint(
         &self,
         lag: Option<u64>,
     ) -> Result<Checkpoint, ChainCommunicationError>;

--- a/rust/abacus-core/src/traits/outbox.rs
+++ b/rust/abacus-core/src/traits/outbox.rs
@@ -25,7 +25,7 @@ pub trait Outbox: AbacusCommon + Send + Sync + std::fmt::Debug {
     /// This isn't called `checkpoint` to avoid a conflict with the MockOutboxContract,
     /// which has a conflicting `checkpoint` function automatically created by the mockall
     /// library's automocking attribute macro.
-    async fn create_checkpoint(&self) -> Result<TxOutcome, ChainCommunicationError>;
+    async fn cache_checkpoint(&self) -> Result<TxOutcome, ChainCommunicationError>;
 }
 
 /// Interface for retrieving event data emitted specifically by the outbox

--- a/rust/abacus-test/src/mocks/inbox.rs
+++ b/rust/abacus-test/src/mocks/inbox.rs
@@ -34,11 +34,11 @@ mock! {
 
         pub fn _validator_manager(&self) -> Result<H256, ChainCommunicationError> {}
 
-        pub fn _checkpointed_root(&self) -> Result<H256, ChainCommunicationError> {}
+        pub fn _latest_cached_root(&self) -> Result<H256, ChainCommunicationError> {}
 
         pub fn _message_status(&self, leaf: H256) -> Result<MessageStatus, ChainCommunicationError> {}
 
-        pub fn _latest_checkpoint(&self, maybe_lag: Option<u64>) -> Result<Checkpoint, ChainCommunicationError> {}
+        pub fn _latest_cached_checkpoint(&self, maybe_lag: Option<u64>) -> Result<Checkpoint, ChainCommunicationError> {}
     }
 }
 
@@ -85,14 +85,14 @@ impl AbacusCommon for MockInboxContract {
         self._validator_manager()
     }
 
-    async fn checkpointed_root(&self) -> Result<H256, ChainCommunicationError> {
-        self._checkpointed_root()
+    async fn latest_cached_root(&self) -> Result<H256, ChainCommunicationError> {
+        self._latest_cached_root()
     }
 
-    async fn latest_checkpoint(
+    async fn latest_cached_checkpoint(
         &self,
         maybe_lag: Option<u64>,
     ) -> Result<Checkpoint, ChainCommunicationError> {
-        self._latest_checkpoint(maybe_lag)
+        self._latest_cached_checkpoint(maybe_lag)
     }
 }

--- a/rust/abacus-test/src/mocks/outbox.rs
+++ b/rust/abacus-test/src/mocks/outbox.rs
@@ -28,7 +28,7 @@ mock! {
 
         pub fn _count(&self) -> Result<u32, ChainCommunicationError> {}
 
-        pub fn _create_checkpoint(&self) -> Result<TxOutcome, ChainCommunicationError> {}
+        pub fn _cache_checkpoint(&self) -> Result<TxOutcome, ChainCommunicationError> {}
 
         // Common
         pub fn _name(&self) -> &str {}
@@ -39,9 +39,9 @@ mock! {
 
         pub fn _state(&self) -> Result<State, ChainCommunicationError> {}
 
-        pub fn _checkpointed_root(&self) -> Result<H256, ChainCommunicationError> {}
+        pub fn _latest_cached_root(&self) -> Result<H256, ChainCommunicationError> {}
 
-        pub fn _latest_checkpoint(&self, maybe_lag: Option<u64>) -> Result<Checkpoint, ChainCommunicationError> {}
+        pub fn _latest_cached_checkpoint(&self, maybe_lag: Option<u64>) -> Result<Checkpoint, ChainCommunicationError> {}
     }
 }
 
@@ -65,8 +65,8 @@ impl Outbox for MockOutboxContract {
         self._count()
     }
 
-    async fn create_checkpoint(&self) -> Result<TxOutcome, ChainCommunicationError> {
-        self._create_checkpoint()
+    async fn cache_checkpoint(&self) -> Result<TxOutcome, ChainCommunicationError> {
+        self._cache_checkpoint()
     }
 }
 
@@ -88,14 +88,14 @@ impl AbacusCommon for MockOutboxContract {
         self._validator_manager()
     }
 
-    async fn checkpointed_root(&self) -> Result<H256, ChainCommunicationError> {
-        self._checkpointed_root()
+    async fn latest_cached_root(&self) -> Result<H256, ChainCommunicationError> {
+        self._latest_cached_root()
     }
 
-    async fn latest_checkpoint(
+    async fn latest_cached_checkpoint(
         &self,
         maybe_lag: Option<u64>,
     ) -> Result<Checkpoint, ChainCommunicationError> {
-        self._latest_checkpoint(maybe_lag)
+        self._latest_cached_checkpoint(maybe_lag)
     }
 }

--- a/rust/agents/kathy/src/kathy.rs
+++ b/rust/agents/kathy/src/kathy.rs
@@ -79,7 +79,7 @@ impl Kathy {
 
                         let count = outbox.count().await?;
                         if count > 1 {
-                            outbox.create_checkpoint().await?;
+                            outbox.cache_checkpoint().await?;
                         }
                         drop(guard);
                     }

--- a/rust/agents/relayer/src/checkpoint_relayer.rs
+++ b/rust/agents/relayer/src/checkpoint_relayer.rs
@@ -176,7 +176,11 @@ impl CheckpointRelayer {
 
     #[instrument(ret, err, skip(self), fields(inbox_name = self.inbox_contracts.inbox.name()), level = "info")]
     async fn main_loop(mut self) -> Result<()> {
-        let latest_inbox_checkpoint = self.inbox_contracts.inbox.latest_checkpoint(None).await?;
+        let latest_inbox_checkpoint = self
+            .inbox_contracts
+            .inbox
+            .latest_cached_checkpoint(None)
+            .await?;
         let mut onchain_checkpoint_index = latest_inbox_checkpoint.index;
         self.inbox_checkpoint_gauge
             .set(onchain_checkpoint_index as i64);

--- a/rust/agents/relayer/src/message_processor.rs
+++ b/rust/agents/relayer/src/message_processor.rs
@@ -97,13 +97,13 @@ impl MessageProcessor {
                     MessageStatus::None => {
                         if message_leaf_index >= self.prover_sync.count() {
                             // gotta find a root that includes the message
-                            let latest_checkpoint = self
+                            let latest_cached_checkpoint = self
                                 .inbox
-                                .latest_checkpoint(Some(self.reorg_period))
+                                .latest_cached_checkpoint(Some(self.reorg_period))
                                 .await?;
 
                             self.prover_sync
-                                .update_to_checkpoint(&latest_checkpoint)
+                                .update_to_checkpoint(&latest_cached_checkpoint)
                                 .await?;
 
                             if message_leaf_index >= self.prover_sync.count() {

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -44,7 +44,7 @@ impl ValidatorSubmitter {
                 sleep(Duration::from_secs(self.interval)).await;
 
                 // Check the current checkpoint
-                let checkpoint = self.outbox.latest_checkpoint(reorg_period).await?;
+                let checkpoint = self.outbox.latest_cached_checkpoint(reorg_period).await?;
 
                 if current_index < checkpoint.index {
                     let signed_checkpoint = checkpoint.sign_with(self.signer.as_ref()).await?;

--- a/rust/chains/abacus-ethereum/abis/Inbox.abi.json
+++ b/rust/chains/abacus-ethereum/abis/Inbox.abi.json
@@ -26,7 +26,20 @@
         "type": "uint256"
       }
     ],
-    "name": "Checkpoint",
+    "name": "CheckpointCached",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
     "type": "event"
   },
   {
@@ -69,6 +82,18 @@
         "internalType": "bytes32",
         "name": "messageHash",
         "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "leafIndex",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[32]",
+        "name": "proof",
+        "type": "bytes32[32]"
       }
     ],
     "name": "Process",
@@ -100,22 +125,9 @@
         "type": "uint256"
       }
     ],
-    "name": "checkpoint",
+    "name": "cacheCheckpoint",
     "outputs": [],
     "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "checkpointedRoot",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -126,7 +138,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "checkpoints",
+    "name": "cachedCheckpoints",
     "outputs": [
       {
         "internalType": "uint256",
@@ -148,16 +160,6 @@
         "internalType": "address",
         "name": "_validatorManager",
         "type": "address"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "_checkpointedRoot",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_checkpointedIndex",
-        "type": "uint256"
       }
     ],
     "name": "initialize",
@@ -167,7 +169,7 @@
   },
   {
     "inputs": [],
-    "name": "latestCheckpoint",
+    "name": "latestCachedCheckpoint",
     "outputs": [
       {
         "internalType": "bytes32",
@@ -178,6 +180,19 @@
         "internalType": "uint256",
         "name": "index",
         "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "latestCachedRoot",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
       }
     ],
     "stateMutability": "view",

--- a/rust/chains/abacus-ethereum/abis/InboxValidatorManager.abi.json
+++ b/rust/chains/abacus-ethereum/abis/InboxValidatorManager.abi.json
@@ -63,6 +63,19 @@
     "inputs": [
       {
         "indexed": false,
+        "internalType": "bytes[]",
+        "name": "signatures",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "Quorum",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
         "internalType": "uint256",
         "name": "threshold",
         "type": "uint256"
@@ -113,7 +126,7 @@
         "type": "bytes[]"
       }
     ],
-    "name": "checkpoint",
+    "name": "cacheCheckpoint",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/rust/chains/abacus-ethereum/abis/Outbox.abi.json
+++ b/rust/chains/abacus-ethereum/abis/Outbox.abi.json
@@ -26,7 +26,7 @@
         "type": "uint256"
       }
     ],
-    "name": "Checkpoint",
+    "name": "CheckpointCached",
     "type": "event"
   },
   {
@@ -64,6 +64,19 @@
     "anonymous": false,
     "inputs": [],
     "name": "Fail",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
     "type": "event"
   },
   {
@@ -126,22 +139,9 @@
   },
   {
     "inputs": [],
-    "name": "checkpoint",
+    "name": "cacheCheckpoint",
     "outputs": [],
     "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "checkpointedRoot",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -152,7 +152,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "checkpoints",
+    "name": "cachedCheckpoints",
     "outputs": [
       {
         "internalType": "uint256",
@@ -226,24 +226,31 @@
     "type": "function"
   },
   {
-    "inputs": [
+    "inputs": [],
+    "name": "latestCachedCheckpoint",
+    "outputs": [
       {
         "internalType": "bytes32",
-        "name": "_root",
+        "name": "root",
         "type": "bytes32"
       },
       {
         "internalType": "uint256",
-        "name": "_index",
+        "name": "index",
         "type": "uint256"
       }
     ],
-    "name": "isCheckpoint",
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "latestCachedRoot",
     "outputs": [
       {
-        "internalType": "bool",
+        "internalType": "bytes32",
         "name": "",
-        "type": "bool"
+        "type": "bytes32"
       }
     ],
     "stateMutability": "view",
@@ -255,12 +262,12 @@
     "outputs": [
       {
         "internalType": "bytes32",
-        "name": "root",
+        "name": "",
         "type": "bytes32"
       },
       {
         "internalType": "uint256",
-        "name": "index",
+        "name": "",
         "type": "uint256"
       }
     ],

--- a/rust/chains/abacus-ethereum/src/inbox.rs
+++ b/rust/chains/abacus-ethereum/src/inbox.rs
@@ -113,7 +113,7 @@ where
     ) -> Result<Vec<CheckpointWithMeta>> {
         let mut events = self
             .contract
-            .checkpoint_filter()
+            .checkpoint_cached_filter()
             .from_block(from)
             .to_block(to)
             .query_with_meta()
@@ -230,17 +230,17 @@ where
     }
 
     #[tracing::instrument(err)]
-    async fn checkpointed_root(&self) -> Result<H256, ChainCommunicationError> {
-        Ok(self.contract.checkpointed_root().call().await?.into())
+    async fn latest_cached_root(&self) -> Result<H256, ChainCommunicationError> {
+        Ok(self.contract.latest_cached_root().call().await?.into())
     }
 
     #[tracing::instrument(err, skip(self))]
-    async fn latest_checkpoint(
+    async fn latest_cached_checkpoint(
         &self,
         maybe_lag: Option<u64>,
     ) -> Result<Checkpoint, ChainCommunicationError> {
         // This should probably moved into its own trait
-        let base_call = self.contract.latest_checkpoint();
+        let base_call = self.contract.latest_cached_checkpoint();
         let call_with_lag = match maybe_lag {
             Some(lag) => {
                 let tip = self
@@ -255,7 +255,7 @@ where
         };
         let (root, index) = call_with_lag.call().await?;
         Ok(Checkpoint {
-            // This is inefficient, but latest_checkpoint should never be called
+            // This is inefficient, but latest_cached_checkpoint should never be called
             outbox_domain: self.remote_domain().await?,
             root: root.into(),
             index: index.as_u32(),

--- a/rust/chains/abacus-ethereum/src/outbox.rs
+++ b/rust/chains/abacus-ethereum/src/outbox.rs
@@ -108,7 +108,7 @@ where
     ) -> Result<Vec<CheckpointWithMeta>> {
         let mut events = self
             .contract
-            .checkpoint_filter()
+            .checkpoint_cached_filter()
             .from_block(from)
             .to_block(to)
             .query_with_meta()
@@ -248,17 +248,17 @@ where
     }
 
     #[tracing::instrument(err, skip(self))]
-    async fn checkpointed_root(&self) -> Result<H256, ChainCommunicationError> {
-        Ok(self.contract.checkpointed_root().call().await?.into())
+    async fn latest_cached_root(&self) -> Result<H256, ChainCommunicationError> {
+        Ok(self.contract.latest_cached_root().call().await?.into())
     }
 
     #[tracing::instrument(err, skip(self))]
-    async fn latest_checkpoint(
+    async fn latest_cached_checkpoint(
         &self,
         maybe_lag: Option<u64>,
     ) -> Result<Checkpoint, ChainCommunicationError> {
         // This should probably moved into its own trait
-        let base_call = self.contract.latest_checkpoint();
+        let base_call = self.contract.latest_cached_checkpoint();
         let call_with_lag = match maybe_lag {
             Some(lag) => {
                 let tip = self
@@ -312,8 +312,8 @@ where
     }
 
     #[tracing::instrument(err, skip(self))]
-    async fn create_checkpoint(&self) -> Result<TxOutcome, ChainCommunicationError> {
-        let tx = self.contract.checkpoint();
+    async fn cache_checkpoint(&self) -> Result<TxOutcome, ChainCommunicationError> {
+        let tx = self.contract.cache_checkpoint();
 
         Ok(report_tx(tx).await?.into())
     }

--- a/rust/chains/abacus-ethereum/src/validator_manager.rs
+++ b/rust/chains/abacus-ethereum/src/validator_manager.rs
@@ -96,7 +96,7 @@ where
         &self,
         multisig_signed_checkpoint: &MultisigSignedCheckpoint,
     ) -> Result<TxOutcome, ChainCommunicationError> {
-        let tx = self.contract.checkpoint(
+        let tx = self.contract.cache_checkpoint(
             self.inbox_address,
             multisig_signed_checkpoint.checkpoint.root.to_fixed_bytes(),
             multisig_signed_checkpoint.checkpoint.index.into(),


### PR DESCRIPTION
Following https://github.com/abacus-network/abacus-monorepo/pull/475, the contracts fell out of sync with the Rust agents. This brings them back to working together by updating the ABI and using some new names