### PR TITLE
Post-rename deploy, use Gelato for mainnet rc

### DIFF
--- a/typescript/infra/config/environments/mainnet/agent.ts
+++ b/typescript/infra/config/environments/mainnet/agent.ts
@@ -23,7 +23,7 @@ export const abacus: AgentConfig<MainnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-7040e5c',
+    tag: 'sha-0d76398',
   },
   aws: {
     region: 'us-east-1',
@@ -80,7 +80,7 @@ export const releaseCandidate: AgentConfig<MainnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-7040e5c',
+    tag: 'sha-0d76398',
   },
   aws: {
     region: 'us-east-1',
@@ -88,6 +88,16 @@ export const releaseCandidate: AgentConfig<MainnetChains> = {
   environmentChainNames: chainNames,
   contextChainNames: chainNames,
   validatorSets: validators,
+  gelato: {
+    enabledChains: [
+      'bsc',
+      'ethereum',
+      'polygon',
+      'avalanche',
+      'arbitrum',
+      'optimism',
+    ],
+  },
   connectionType: ConnectionType.Http,
   relayer: {
     default: {

--- a/typescript/infra/config/environments/mainnet/funding.ts
+++ b/typescript/infra/config/environments/mainnet/funding.ts
@@ -7,7 +7,7 @@ import { environment } from './chains';
 export const keyFunderConfig: KeyFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-    tag: 'sha-f3509ac',
+    tag: 'sha-0d76398',
   },
   cronSchedule: '45 * * * *', // Every hour at the 45 minute mark
   namespace: environment,

--- a/typescript/infra/config/environments/mainnet/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet/helloworld.ts
@@ -11,7 +11,7 @@ export const abacus: HelloWorldConfig<MainnetChains> = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'sha-8b8fdde',
+      tag: 'sha-0d76398',
     },
     chainsToSkip: [],
     runEnv: environment,
@@ -30,7 +30,7 @@ export const releaseCandidate: HelloWorldConfig<MainnetChains> = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'sha-8b8fdde',
+      tag: 'sha-0d76398',
     },
     chainsToSkip: [],
     runEnv: environment,

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -26,7 +26,7 @@ export const abacus: AgentConfig<TestnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-7040e5c',
+    tag: 'sha-0d76398',
   },
   aws: {
     region: 'us-east-1',
@@ -92,7 +92,7 @@ export const flowcarbon: AgentConfig<TestnetChains> = {
   context: Contexts.Flowcarbon,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-7040e5c',
+    tag: 'sha-0d76398',
   },
   aws: {
     region: 'us-east-1',
@@ -124,7 +124,7 @@ export const releaseCandidate: AgentConfig<TestnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-7040e5c',
+    tag: 'sha-0d76398',
   },
   aws: {
     region: 'us-east-1',

--- a/typescript/infra/config/environments/testnet2/funding.ts
+++ b/typescript/infra/config/environments/testnet2/funding.ts
@@ -6,8 +6,8 @@ import { environment } from './chains';
 
 export const keyFunderConfig: KeyFunderConfig = {
   docker: {
-    repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-    tag: 'sha-27183b1',
+    repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
+    tag: 'sha-0d76398',
   },
   cronSchedule: '45 * * * *', // Every hour at the 45 minute mark
   namespace: environment,

--- a/typescript/infra/config/environments/testnet2/helloworld.ts
+++ b/typescript/infra/config/environments/testnet2/helloworld.ts
@@ -10,8 +10,8 @@ export const abacus: HelloWorldConfig<TestnetChains> = {
   addresses: abacusAddresses,
   kathy: {
     docker: {
-      repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-      tag: 'sha-1c67fc9',
+      repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
+      tag: 'sha-0d76398',
     },
     chainsToSkip: [],
     runEnv: environment,
@@ -29,8 +29,8 @@ export const releaseCandidate: HelloWorldConfig<TestnetChains> = {
   addresses: rcAddresses,
   kathy: {
     docker: {
-      repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-      tag: 'sha-1c67fc9',
+      repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
+      tag: 'sha-0d76398',
     },
     chainsToSkip: [],
     runEnv: environment,


### PR DESCRIPTION
### Description

* Deploys after the rename, mostly including #1077 
* Uses Gelato on mainnet rc, assuming this goes well I'll ship to the abacus context

### Drive-by changes

* Changed the monorepo img for testnet2 to use the new hyperlane name

### Related issues

n/a

### Backward compatibility

Mostly backward compatible - most infra was unchanged by the rename, but note that the monorepo image repository has changed

### Testing

deployed & see no issues
