### PR TITLE
Wrap inner providers with RetryingProvider when using QuorumProvider, not the QuorumProvider itself

### DIFF
--- a/rust/chains/abacus-ethereum/src/retrying.rs
+++ b/rust/chains/abacus-ethereum/src/retrying.rs
@@ -190,7 +190,7 @@ impl JsonRpcClient for RetryingProvider<Http> {
                 }
             }
             Err(HttpClientError::SerdeJson { err, text }) => {
-                info!(attempt, next_backoff_ms, error = %err, "SerdeJson error in http provider");
+                info!(attempt, next_backoff_ms, error = %err, text = text,  "SerdeJson error in http provider");
                 HandleMethod::Retry(HttpClientError::SerdeJson { err, text })
             }
         })

--- a/rust/chains/abacus-ethereum/src/retrying.rs
+++ b/rust/chains/abacus-ethereum/src/retrying.rs
@@ -160,7 +160,7 @@ where
 impl JsonRpcClient for RetryingProvider<Http> {
     type Error = RetryingProviderError<Http>;
 
-    #[instrument(level = "error", skip_all, fields(method = %method))]
+    #[instrument(level = "error", skip_all, fields(method = %method, provider_host = %self.inner.url().host_str().unwrap_or("unknown")))]
     async fn request<T, R>(&self, method: &str, params: T) -> Result<R, Self::Error>
     where
         T: Debug + Serialize + Send + Sync,

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -26,7 +26,7 @@ export const abacus: AgentConfig<TestnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-73a9acd',
+    tag: 'sha-ebfd1c1',
   },
   aws: {
     region: 'us-east-1',
@@ -124,7 +124,7 @@ export const releaseCandidate: AgentConfig<TestnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-73a9acd',
+    tag: 'sha-ebfd1c1',
   },
   aws: {
     region: 'us-east-1',

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -26,7 +26,7 @@ export const abacus: AgentConfig<TestnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-a6e1e59',
+    tag: 'sha-73a9acd',
   },
   aws: {
     region: 'us-east-1',
@@ -124,7 +124,7 @@ export const releaseCandidate: AgentConfig<TestnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-a6e1e59',
+    tag: 'sha-73a9acd',
   },
   aws: {
     region: 'us-east-1',

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -26,7 +26,7 @@ export const abacus: AgentConfig<TestnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-7040e5c',
+    tag: 'sha-a6e1e59',
   },
   aws: {
     region: 'us-east-1',
@@ -37,7 +37,7 @@ export const abacus: AgentConfig<TestnetChains> = {
   gelato: {
     enabledChains: ['alfajores', 'mumbai', 'goerli'],
   },
-  connectionType: ConnectionType.Http,
+  connectionType: ConnectionType.HttpQuorum,
   validator: {
     default: {
       interval: 5,
@@ -124,7 +124,7 @@ export const releaseCandidate: AgentConfig<TestnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-7040e5c',
+    tag: 'sha-a6e1e59',
   },
   aws: {
     region: 'us-east-1',


### PR DESCRIPTION
### Description

The QuorumProvider somewhat exacerbated the age old issue of us first doing an `eth_blockNumber` RPC to get the block height and then a performing a subsequent RPC (like an `eth_call`) at that block height, but the servicing node isn't aware of that block height yet, so it returns an error.

This is for a few reasons - the first is that the QuorumProvider will almost always do that get-block-number-then-do-rpc-at-that-block-number because it needs to ensure that all inner providers are performing the RPC at the same block height. Before QuorumProvider, for chains with instant finality, we were able to get around requesting specific block number and instead would default to the `"latest"` block tag for RPCs.

The other reason is that we were wrapping the QuorumProvider with RetryingProvider, meaning if there was an issue in a getting a quorum from inner providers, then a quorum would be retried, meaning each inner provider will once again perform both RPCs. Each retry, the second RPC will not reference the original block height, but the block height from that retry. This can be pretty bad-- e.g. if there's a 10% chance that a quorum of inner providers cannot be reached because of this issue, and the retrying provider does at most 3 attempts, there's a 0.1^3 = 0.1% chance that all retries will fail, which can be bad depending on how gracefully the calling code handles RPC issues. E.g. the validators, until https://github.com/hyperlane-xyz/abacus-monorepo/issues/1050 is done, can panic due to this.

So instead, we should wrap the *inner* providers as RetryingProviders - this way, an inner provider will first perform the first eth_blockNumber RPC (this generally should not fail, but it will retry if it does!), and then the second eth_call RPC (or some other RPC) at the requested block height. If the second RPC fails like it often does because the servicing node doesn't know of the requested block height yet, the retrying provider will retry *that specific RPC* at the same requested block height. Because the retrying provider sleeps a bit between retries and the same block height is used, we can generally expect this to always resolve at some point. Also, because the QuorumProvider will consider a quorum as reached as soon as the minimum required # of successful inner RPCs has finished, it's not really a concern that some inner providers experiencing intermittent issues & sleeping between retries will cause long times to quorum.

### Drive-by changes

None

### Related issues

none

### Backward compatibility

Fully backward compatible

### Testing

Ran a local optimismkovan validator using QuorumProvider and logs reflected expected behavior
