### PR TITLE
Use anonymous S3 client for reading in S3 checkpoint syncer

### DIFF
--- a/rust/abacus-base/src/types/checkpoint_syncer.rs
+++ b/rust/abacus-base/src/types/checkpoint_syncer.rs
@@ -40,11 +40,11 @@ impl CheckpointSyncerConf {
                 LocalStorage::new(path, latest_index_gauge),
             )),
             CheckpointSyncerConf::S3 { bucket, region } => {
-                Ok(CheckpointSyncers::S3(S3Storage::new(
+                Ok(CheckpointSyncers::S3(Box::new(S3Storage::new(
                     bucket,
                     region.parse().expect("invalid s3 region"),
                     latest_index_gauge,
-                )))
+                ))))
             }
         }
     }
@@ -88,8 +88,9 @@ impl MultisigCheckpointSyncerConf {
 pub enum CheckpointSyncers {
     /// A local checkpoint syncer
     Local(LocalStorage),
-    /// A checkpoint syncer on s3
-    S3(S3Storage),
+    /// A checkpoint syncer on S3.
+    /// Boxed due to large size difference between variants.
+    S3(Box<S3Storage>),
 }
 
 #[async_trait]

--- a/typescript/infra/scripts/verify-validator.ts
+++ b/typescript/infra/scripts/verify-validator.ts
@@ -3,7 +3,6 @@ import yargs from 'yargs';
 
 import { AllChains, ChainNameToDomainId } from '@hyperlane-xyz/sdk';
 
-// import { utils } from '@hyperlane-xyz/utils';
 import { S3Validator } from '../src/agents/aws/validator';
 
 function getArgs() {
@@ -14,10 +13,10 @@ function getArgs() {
     .describe('address', 'address of the validator to inspect')
     .demandOption('address')
     .string('address')
-    .describe('prospective', 'S3 bucket of the prospective validator')
+    .describe('prospective', 'S3 bucket URL of the prospective validator')
     .demandOption('prospective')
     .string('prospective')
-    .describe('control', 'S3 bucket of the the known (control) validator')
+    .describe('control', 'S3 bucket URL of the the known (control) validator')
     .demandOption('control')
     .string('control').argv;
 }


### PR DESCRIPTION
### Description

We've been unable to read from public S3 buckets that are outside our AWS account. While the S3 buckets are public, AWS didn't seem to accept credentials from an AWS account other than the S3 bucket's account.

The workaround is to use "anonymous" credentials (i.e. no credentials) for these requests.

I spent a tiny bit of time to try to understand why we're able to do this in Typescript but didn't want to spend too much time there because it was clear the solution is to just not use credentials. Fwiw it seems like in Typescript there are credentials in the HTTP header and we don't see any issues! My best guess is the headers / credentials are handled slightly differently and it has a meaningful impact.

### Drive-by changes

* Clippy complained that the difference in the variant sizes of  the `CheckpointSyncers` enum is too high - that's why there's the new `Box<>`. Just gonna err on the side of trusting Clippy here. (Context https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant)
* When running the `verify-validator` script, it wasn't immediately clear to me that S3 bucket URLs are what were expected, so changed it to say that in the help message

### Related issues

- Fixes #1084

### Backward compatibility

Fully backward compatible

### Testing

Ran a relayer locally, confirmed it wasn't able to read S3 objects from buckets we don't operate, and was able to make S3 successful reads