### PR TITLE
Deploy testnet2 & mainnet - all testnet2 contexts using QuorumProvider

### DIFF
--- a/typescript/infra/config/environments/mainnet/agent.ts
+++ b/typescript/infra/config/environments/mainnet/agent.ts
@@ -23,7 +23,7 @@ export const abacus: AgentConfig<MainnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-0d76398',
+    tag: 'sha-c2a948f',
   },
   aws: {
     region: 'us-east-1',
@@ -80,7 +80,7 @@ export const releaseCandidate: AgentConfig<MainnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-0d76398',
+    tag: 'sha-c2a948f',
   },
   aws: {
     region: 'us-east-1',

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -26,7 +26,7 @@ export const abacus: AgentConfig<TestnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-ebfd1c1',
+    tag: 'sha-c2a948f',
   },
   aws: {
     region: 'us-east-1',
@@ -92,7 +92,7 @@ export const flowcarbon: AgentConfig<TestnetChains> = {
   context: Contexts.Flowcarbon,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-0d76398',
+    tag: 'sha-c2a948f',
   },
   aws: {
     region: 'us-east-1',
@@ -124,7 +124,7 @@ export const releaseCandidate: AgentConfig<TestnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-ebfd1c1',
+    tag: 'sha-c2a948f',
   },
   aws: {
     region: 'us-east-1',


### PR DESCRIPTION
### Description

Mostly includes https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/1099. This PR deployed to testnet2 with quorumprovider from a commit on that branch, this PR deploys from a commit from main

### Drive-by changes

n/a

### Related issues
n/a

### Backward compatibility

Fully backward compatible

### Testing

deployed
