### PR TITLE
Use estimateGas in msg debugger

### DIFF
--- a/typescript/infra/scripts/debug-message.ts
+++ b/typescript/infra/scripts/debug-message.ts
@@ -128,7 +128,7 @@ async function checkMessage(
   );
 
   try {
-    await recipient.callStatic.handle(
+    await recipient.estimateGas.handle(
       message.parsed.origin,
       message.parsed.sender,
       message.parsed.body,
@@ -138,10 +138,12 @@ async function checkMessage(
       'Calling recipient `handle` function from the inbox does not revert',
     );
   } catch (err: any) {
-    console.error(
-      `Error calling recipient \`handle\` function from the inbox`,
-      err,
-    );
+    console.error(`Error calling recipient \`handle\` function from the inbox`);
+    if (err.reason) {
+      console.error('Reason: ', err.reason);
+    } else {
+      console.error(err);
+    }
   }
 }
 


### PR DESCRIPTION
### Description

On the suggestion of @jmrossy , changed this to the estimateGas which should properly throw an exception in all reversion cases.


### Related issues

- Fixes https://github.com/hyperlane-xyz/issues/issues/201

### Backward compatibility

Yes

### Testing

Tried with `yarn ts-node scripts/debug-message.ts --tx-hash 0x17d6cb51afa2c2ab10be0ce78496c9ffc0899dc25f2943dc332f4b1bcdee856c --origin-chain fuji -e testnet2`