### PR TITLE
Support QuorumProvider (i.e. FallbackProvider) in kathy and key funder

### DIFF
--- a/typescript/infra/config/environments/mainnet/funding.ts
+++ b/typescript/infra/config/environments/mainnet/funding.ts
@@ -1,4 +1,5 @@
 import { KEY_ROLE_ENUM } from '../../../src/agents/roles';
+import { ConnectionType } from '../../../src/config/agent';
 import { KeyFunderConfig } from '../../../src/config/funding';
 import { Contexts } from '../../contexts';
 
@@ -18,4 +19,5 @@ export const keyFunderConfig: KeyFunderConfig = {
     [Contexts.Abacus]: [KEY_ROLE_ENUM.Relayer, KEY_ROLE_ENUM.Kathy],
     [Contexts.ReleaseCandidate]: [KEY_ROLE_ENUM.Relayer, KEY_ROLE_ENUM.Kathy],
   },
+  connectionType: ConnectionType.Http,
 };

--- a/typescript/infra/config/environments/mainnet/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet/helloworld.ts
@@ -1,4 +1,5 @@
 import { HelloWorldConfig } from '../../../src/config';
+import { ConnectionType } from '../../../src/config/agent';
 import { HelloWorldKathyRunMode } from '../../../src/config/helloworld';
 import { Contexts } from '../../contexts';
 
@@ -22,6 +23,7 @@ export const abacus: HelloWorldConfig<MainnetChains> = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
+    connectionType: ConnectionType.Http,
   },
 };
 
@@ -40,6 +42,7 @@ export const releaseCandidate: HelloWorldConfig<MainnetChains> = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
+    connectionType: ConnectionType.Http,
   },
 };
 

--- a/typescript/infra/config/environments/mainnet/index.ts
+++ b/typescript/infra/config/environments/mainnet/index.ts
@@ -1,6 +1,7 @@
 import { getMultiProviderForRole } from '../../../scripts/utils';
 import { KEY_ROLE_ENUM } from '../../../src/agents/roles';
 import { CoreEnvironmentConfig } from '../../../src/config';
+import { ConnectionType } from '../../../src/config/agent';
 import { Contexts } from '../../contexts';
 
 import { agents } from './agent';
@@ -20,7 +21,16 @@ export const environment: CoreEnvironmentConfig<MainnetChains> = {
   getMultiProvider: (
     context: Contexts = Contexts.Abacus,
     role: KEY_ROLE_ENUM = KEY_ROLE_ENUM.Deployer,
-  ) => getMultiProviderForRole(mainnetConfigs, environmentName, context, role),
+    connectionType?: ConnectionType,
+  ) =>
+    getMultiProviderForRole(
+      mainnetConfigs,
+      environmentName,
+      context,
+      role,
+      undefined,
+      connectionType,
+    ),
   agents,
   core,
   infra: infrastructure,

--- a/typescript/infra/config/environments/testnet2/funding.ts
+++ b/typescript/infra/config/environments/testnet2/funding.ts
@@ -1,4 +1,5 @@
 import { KEY_ROLE_ENUM } from '../../../src/agents/roles';
+import { ConnectionType } from '../../../src/config/agent';
 import { KeyFunderConfig } from '../../../src/config/funding';
 import { Contexts } from '../../contexts';
 
@@ -18,4 +19,5 @@ export const keyFunderConfig: KeyFunderConfig = {
     [Contexts.Abacus]: [KEY_ROLE_ENUM.Relayer, KEY_ROLE_ENUM.Kathy],
     [Contexts.ReleaseCandidate]: [KEY_ROLE_ENUM.Relayer, KEY_ROLE_ENUM.Kathy],
   },
+  connectionType: ConnectionType.HttpQuorum,
 };

--- a/typescript/infra/config/environments/testnet2/funding.ts
+++ b/typescript/infra/config/environments/testnet2/funding.ts
@@ -8,7 +8,7 @@ import { environment } from './chains';
 export const keyFunderConfig: KeyFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-    tag: 'sha-0d76398',
+    tag: 'sha-da9bc61',
   },
   cronSchedule: '45 * * * *', // Every hour at the 45 minute mark
   namespace: environment,

--- a/typescript/infra/config/environments/testnet2/helloworld.ts
+++ b/typescript/infra/config/environments/testnet2/helloworld.ts
@@ -12,7 +12,7 @@ export const abacus: HelloWorldConfig<TestnetChains> = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'sha-0d76398',
+      tag: 'sha-da9bc61',
     },
     chainsToSkip: [],
     runEnv: environment,
@@ -23,7 +23,7 @@ export const abacus: HelloWorldConfig<TestnetChains> = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
-    connectionType: ConnectionType.Http,
+    connectionType: ConnectionType.HttpQuorum,
   },
 };
 
@@ -32,7 +32,7 @@ export const releaseCandidate: HelloWorldConfig<TestnetChains> = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'sha-0d76398',
+      tag: 'sha-da9bc61',
     },
     chainsToSkip: [],
     runEnv: environment,

--- a/typescript/infra/config/environments/testnet2/helloworld.ts
+++ b/typescript/infra/config/environments/testnet2/helloworld.ts
@@ -1,4 +1,5 @@
 import { HelloWorldConfig } from '../../../src/config';
+import { ConnectionType } from '../../../src/config/agent';
 import { HelloWorldKathyRunMode } from '../../../src/config/helloworld';
 import { Contexts } from '../../contexts';
 
@@ -22,6 +23,7 @@ export const abacus: HelloWorldConfig<TestnetChains> = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
+    connectionType: ConnectionType.Http,
   },
 };
 
@@ -40,6 +42,7 @@ export const releaseCandidate: HelloWorldConfig<TestnetChains> = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
+    connectionType: ConnectionType.HttpQuorum,
   },
 };
 

--- a/typescript/infra/config/environments/testnet2/index.ts
+++ b/typescript/infra/config/environments/testnet2/index.ts
@@ -1,6 +1,7 @@
 import { getMultiProviderForRole } from '../../../scripts/utils';
 import { KEY_ROLE_ENUM } from '../../../src/agents/roles';
 import { CoreEnvironmentConfig } from '../../../src/config';
+import { ConnectionType } from '../../../src/config/agent';
 import { Contexts } from '../../contexts';
 
 import { agents } from './agent';
@@ -20,7 +21,16 @@ export const environment: CoreEnvironmentConfig<TestnetChains> = {
   getMultiProvider: (
     context: Contexts = Contexts.Abacus,
     role: KEY_ROLE_ENUM = KEY_ROLE_ENUM.Deployer,
-  ) => getMultiProviderForRole(testnetConfigs, environmentName, context, role),
+    connectionType?: ConnectionType,
+  ) =>
+    getMultiProviderForRole(
+      testnetConfigs,
+      environmentName,
+      context,
+      role,
+      undefined,
+      connectionType,
+    ),
   agents,
   core,
   infra: infrastructure,

--- a/typescript/infra/helm/helloworld-kathy/templates/_helpers.tpl
+++ b/typescript/infra/helm/helloworld-kathy/templates/_helpers.tpl
@@ -90,7 +90,11 @@ The helloworld-kathy container
 {{- end }}
 {{- if .Values.abacus.cycleOnce }}
   - --cycle-once
-  {{- end }}
+{{- end }}
+{{- if .Values.abacus.connectionType }}
+  - --connection-type
+  - {{ .Values.abacus.connectionType }}
+{{- end }}
   envFrom:
   - secretRef:
       name: {{ include "abacus.fullname" . }}-secret

--- a/typescript/infra/helm/helloworld-kathy/templates/external-secret.yaml
+++ b/typescript/infra/helm/helloworld-kathy/templates/external-secret.yaml
@@ -28,6 +28,9 @@ spec:
    * to replace the correct value in the created secret.
    */}}
         {{- range .Values.abacus.chains }}
+        {{- if eq .Values.abacus.connectionType "httpQuorum" }}
+        GCP_SECRET_OVERRIDE_{{ $.Values.abacus.runEnv | upper }}_RPC_ENDPOINTS_{{ . | upper }}: {{ printf "'{{ .%s_rpcs | toString }}'" . }}
+        {{- else }}
         GCP_SECRET_OVERRIDE_{{ $.Values.abacus.runEnv | upper }}_RPC_ENDPOINT_{{ . | upper }}: {{ printf "'{{ .%s_rpc | toString }}'" . }}
         {{- end }}
         {{- if .Values.abacus.aws }}
@@ -45,9 +48,15 @@ spec:
    * and associate it with the secret key networkname_rpc.
    */}}
   {{- range .Values.abacus.chains }}
+  {{- if eq .Values.abacus.connectionType "httpQuorum" }}
+  - secretKey: {{ printf "%s_rpcs" . }}
+    remoteRef:
+      key: {{ printf "%s-rpc-endpoints-%s" $.Values.abacus.runEnv . }}
+  {{- else }}
   - secretKey: {{ printf "%s_rpc" . }}
     remoteRef:
       key: {{ printf "%s-rpc-endpoint-%s" $.Values.abacus.runEnv . }}
+  {{- end }}
   {{- end }}
   {{- if .Values.abacus.aws }}
   - secretKey: aws_access_key_id

--- a/typescript/infra/helm/helloworld-kathy/templates/external-secret.yaml
+++ b/typescript/infra/helm/helloworld-kathy/templates/external-secret.yaml
@@ -28,10 +28,11 @@ spec:
    * to replace the correct value in the created secret.
    */}}
         {{- range .Values.abacus.chains }}
-        {{- if eq .Values.abacus.connectionType "httpQuorum" }}
+        {{- if eq $.Values.abacus.connectionType "httpQuorum" }}
         GCP_SECRET_OVERRIDE_{{ $.Values.abacus.runEnv | upper }}_RPC_ENDPOINTS_{{ . | upper }}: {{ printf "'{{ .%s_rpcs | toString }}'" . }}
         {{- else }}
         GCP_SECRET_OVERRIDE_{{ $.Values.abacus.runEnv | upper }}_RPC_ENDPOINT_{{ . | upper }}: {{ printf "'{{ .%s_rpc | toString }}'" . }}
+        {{- end }}
         {{- end }}
         {{- if .Values.abacus.aws }}
         AWS_ACCESS_KEY_ID: {{ print "'{{ .aws_access_key_id | toString }}'" }}
@@ -48,7 +49,7 @@ spec:
    * and associate it with the secret key networkname_rpc.
    */}}
   {{- range .Values.abacus.chains }}
-  {{- if eq .Values.abacus.connectionType "httpQuorum" }}
+  {{- if eq $.Values.abacus.connectionType "httpQuorum" }}
   - secretKey: {{ printf "%s_rpcs" . }}
     remoteRef:
       key: {{ printf "%s-rpc-endpoints-%s" $.Values.abacus.runEnv . }}

--- a/typescript/infra/helm/key-funder/templates/cron-job.yaml
+++ b/typescript/infra/helm/key-funder/templates/cron-job.yaml
@@ -30,6 +30,10 @@ spec:
             - -f
             - /addresses-secret/{{ $context }}-addresses.json
 {{- end }}
+{{- if .Values.abacus.connectionType }}
+            - --connection-type
+            - {{ .Values.abacus.connectionType }}
+{{- end }}
             env:
             - name: PROMETHEUS_PUSH_GATEWAY
               value: {{ .Values.infra.prometheusPushGateway }}

--- a/typescript/infra/helm/key-funder/templates/env-var-external-secret.yaml
+++ b/typescript/infra/helm/key-funder/templates/env-var-external-secret.yaml
@@ -28,6 +28,9 @@ spec:
    * to replace the correct value in the created secret.
    */}}
         {{- range .Values.abacus.chains }}
+        {{- if eq .Values.abacus.connectionType "httpQuorum" }}
+        GCP_SECRET_OVERRIDE_{{ $.Values.abacus.runEnv | upper }}_RPC_ENDPOINTS_{{ . | upper }}: {{ printf "'{{ .%s_rpcs | toString }}'" . }}
+        {{- else }}
         GCP_SECRET_OVERRIDE_{{ $.Values.abacus.runEnv | upper }}_RPC_ENDPOINT_{{ . | upper }}: {{ printf "'{{ .%s_rpc | toString }}'" . }}
         {{- end }}
   data:
@@ -39,7 +42,13 @@ spec:
    * and associate it with the secret key networkname_rpc.
    */}}
   {{- range .Values.abacus.chains }}
+  {{- if eq .Values.abacus.connectionType "httpQuorum" }}
+  - secretKey: {{ printf "%s_rpcs" . }}
+    remoteRef:
+      key: {{ printf "%s-rpc-endpoints-%s" $.Values.abacus.runEnv . }}
+  {{- else }}
   - secretKey: {{ printf "%s_rpc" . }}
     remoteRef:
       key: {{ printf "%s-rpc-endpoint-%s" $.Values.abacus.runEnv . }}
+  {{- end }}
   {{- end }}

--- a/typescript/infra/helm/key-funder/templates/env-var-external-secret.yaml
+++ b/typescript/infra/helm/key-funder/templates/env-var-external-secret.yaml
@@ -28,10 +28,11 @@ spec:
    * to replace the correct value in the created secret.
    */}}
         {{- range .Values.abacus.chains }}
-        {{- if eq .Values.abacus.connectionType "httpQuorum" }}
+        {{- if eq $.Values.abacus.connectionType "httpQuorum" }}
         GCP_SECRET_OVERRIDE_{{ $.Values.abacus.runEnv | upper }}_RPC_ENDPOINTS_{{ . | upper }}: {{ printf "'{{ .%s_rpcs | toString }}'" . }}
         {{- else }}
         GCP_SECRET_OVERRIDE_{{ $.Values.abacus.runEnv | upper }}_RPC_ENDPOINT_{{ . | upper }}: {{ printf "'{{ .%s_rpc | toString }}'" . }}
+        {{- end }}
         {{- end }}
   data:
   - secretKey: deployer_key
@@ -42,7 +43,7 @@ spec:
    * and associate it with the secret key networkname_rpc.
    */}}
   {{- range .Values.abacus.chains }}
-  {{- if eq .Values.abacus.connectionType "httpQuorum" }}
+  {{- if eq $.Values.abacus.connectionType "httpQuorum" }}
   - secretKey: {{ printf "%s_rpcs" . }}
     remoteRef:
       key: {{ printf "%s-rpc-endpoints-%s" $.Values.abacus.runEnv . }}

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -19,6 +19,7 @@ import {
   ReadOnlyCloudAgentKey,
 } from '../../src/agents/keys';
 import { KEY_ROLE_ENUM } from '../../src/agents/roles';
+import { ConnectionType } from '../../src/config/agent';
 import { ContextAndRoles, ContextAndRolesMap } from '../../src/config/funding';
 import { submitMetrics } from '../../src/utils/metrics';
 import {
@@ -110,6 +111,7 @@ async function main() {
       'f',
       'Files each containing JSON arrays of identifier and address objects for a single context. If not specified, key addresses are fetched from GCP/AWS and require sufficient credentials.',
     )
+
     .string('contexts-and-roles')
     .array('contexts-and-roles')
     .describe(
@@ -117,12 +119,25 @@ async function main() {
       'Array indicating contexts and the roles to fund for each context. Each element is expected as <context>=<role>,<role>,<role>...',
     )
     .coerce('contexts-and-roles', parseContextAndRolesMap)
-    .demandOption('contexts-and-roles').argv;
+    .demandOption('contexts-and-roles')
+
+    .string('connection-type')
+    .describe('connection-type', 'The provider connection type to use for RPCs')
+    .default('connection-type', ConnectionType.Http)
+    .choices('connection-type', [
+      ConnectionType.Http,
+      ConnectionType.HttpQuorum,
+    ])
+    .demandOption('connection-type').argv;
 
   const environment = assertEnvironment(argv.e as string);
   constMetricLabels.abacus_deployment = environment;
   const config = getCoreEnvironmentConfig(environment);
-  const multiProvider = await config.getMultiProvider();
+  const multiProvider = await config.getMultiProvider(
+    Contexts.Abacus, // Always fund from the abacus context
+    KEY_ROLE_ENUM.Deployer, // Always fund from the deployer
+    argv.connectionType,
+  );
 
   let contextFunders: ContextFunder[];
 

--- a/typescript/infra/scripts/helloworld/utils.ts
+++ b/typescript/infra/scripts/helloworld/utils.ts
@@ -17,6 +17,7 @@ import {
 import { Contexts } from '../../config/contexts';
 import { KEY_ROLE_ENUM } from '../../src/agents/roles';
 import { CoreEnvironmentConfig, DeployEnvironment } from '../../src/config';
+import { ConnectionType } from '../../src/config/agent';
 import { HelloWorldConfig } from '../../src/config/helloworld';
 
 export async function getConfiguration<Chain extends ChainName>(
@@ -49,6 +50,7 @@ export async function getApp<Chain extends ChainName>(
   context: Contexts,
   keyRole: KEY_ROLE_ENUM,
   keyContext: Contexts = context,
+  connectionType: ConnectionType = ConnectionType.Http,
 ) {
   const helloworldConfig = getHelloWorldConfig(coreConfig, context);
   const contracts = buildContracts(
@@ -58,6 +60,7 @@ export async function getApp<Chain extends ChainName>(
   const multiProvider: MultiProvider<any> = await coreConfig.getMultiProvider(
     keyContext,
     keyRole,
+    connectionType,
   );
   const core = HyperlaneCore.fromEnvironment(
     coreConfig.environment,

--- a/typescript/infra/scripts/utils.ts
+++ b/typescript/infra/scripts/utils.ts
@@ -18,6 +18,7 @@ import { getCloudAgentKey } from '../src/agents/key-utils';
 import { CloudAgentKey } from '../src/agents/keys';
 import { KEY_ROLE_ENUM } from '../src/agents/roles';
 import { CoreEnvironmentConfig, DeployEnvironment } from '../src/config';
+import { ConnectionType } from '../src/config/agent';
 import { fetchProvider } from '../src/config/chain';
 import { EnvironmentNames } from '../src/config/environment';
 import { assertContext } from '../src/utils/utils';
@@ -110,10 +111,11 @@ export async function getMultiProviderForRole<Chain extends ChainName>(
   context: Contexts,
   role: KEY_ROLE_ENUM,
   index?: number,
+  connectionType?: ConnectionType,
 ): Promise<MultiProvider<Chain>> {
   const connections = await promiseObjAll(
     objMap(txConfigs, async (chain, config) => {
-      const provider = await fetchProvider(environment, chain);
+      const provider = await fetchProvider(environment, chain, connectionType);
       const key = await getKeyForRole(environment, context, chain, role, index);
       const signer = await key.getSigner(provider);
       return {

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -5,6 +5,7 @@ import { ChainName, RetryJsonRpcProvider } from '@hyperlane-xyz/sdk';
 
 import { getSecretRpcEndpoint } from '../agents';
 
+import { ConnectionType } from './agent';
 import { DeployEnvironment } from './environment';
 
 const CELO_CHAIN_NAMES = new Set(['alfajores', 'baklava', 'celo']);
@@ -28,8 +29,15 @@ const providerBuilder = (url: string, chainName: ChainName, retry = true) => {
 export async function fetchProvider(
   environment: DeployEnvironment,
   chainName: ChainName,
-  quorum = false,
+  connectionType: ConnectionType = ConnectionType.Http,
 ) {
+  if (
+    connectionType !== ConnectionType.Http &&
+    connectionType !== ConnectionType.HttpQuorum
+  ) {
+    throw Error(`Unsupported connectionType: ${connectionType}`);
+  }
+  const quorum = connectionType === ConnectionType.HttpQuorum;
   const rpc = await getSecretRpcEndpoint(environment, chainName, quorum);
   if (quorum) {
     return new ethers.providers.FallbackProvider(

--- a/typescript/infra/src/config/environment.ts
+++ b/typescript/infra/src/config/environment.ts
@@ -10,7 +10,7 @@ import { Contexts } from '../../config/contexts';
 import { environments } from '../../config/environments';
 import { KEY_ROLE_ENUM } from '../agents/roles';
 
-import { AgentConfig } from './agent';
+import { AgentConfig, ConnectionType } from './agent';
 import { KeyFunderConfig } from './funding';
 import { HelloWorldConfig } from './helloworld';
 import { InfrastructureConfig } from './infrastructure';
@@ -32,6 +32,7 @@ export type CoreEnvironmentConfig<Chain extends ChainName> = {
   getMultiProvider: (
     context?: Contexts,
     role?: KEY_ROLE_ENUM,
+    connectionType?: ConnectionType,
   ) => Promise<MultiProvider<Chain>>;
   helloWorld?: Partial<Record<Contexts, HelloWorldConfig<Chain>>>;
   keyFunderConfig?: KeyFunderConfig;

--- a/typescript/infra/src/config/funding.ts
+++ b/typescript/infra/src/config/funding.ts
@@ -1,7 +1,7 @@
 import { Contexts } from '../../config/contexts';
 import { KEY_ROLE_ENUM } from '../agents/roles';
 
-import { DockerConfig } from './agent';
+import { ConnectionType, DockerConfig } from './agent';
 
 export interface ContextAndRoles {
   context: Contexts;
@@ -17,4 +17,5 @@ export interface KeyFunderConfig {
   contextFundingFrom: Contexts;
   contextsAndRolesToFund: ContextAndRolesMap;
   prometheusPushGateway: string;
+  connectionType: ConnectionType.Http | ConnectionType.HttpQuorum;
 }

--- a/typescript/infra/src/config/helloworld.ts
+++ b/typescript/infra/src/config/helloworld.ts
@@ -1,6 +1,6 @@
 import { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
 
-import { DockerConfig } from './agent';
+import { ConnectionType, DockerConfig } from './agent';
 
 export enum HelloWorldKathyRunMode {
   // Sends messages between all pairwise chains
@@ -27,6 +27,9 @@ export interface HelloWorldKathyConfig<Chain extends ChainName> {
   messageSendTimeout: number;
   /** How long kathy should wait before giving up on waiting for the message to be received (milliseconds). */
   messageReceiptTimeout: number;
+
+  // Whether to use a single HTTP provider or a quorum of HTTP providers
+  connectionType: ConnectionType.Http | ConnectionType.HttpQuorum;
 }
 
 export interface HelloWorldConfig<Chain extends ChainName> {

--- a/typescript/infra/src/funding/deploy-key-funder.ts
+++ b/typescript/infra/src/funding/deploy-key-funder.ts
@@ -36,6 +36,7 @@ function getKeyFunderHelmValues<Chain extends ChainName>(
       chains: agentConfig.contextChainNames,
       contextFundingFrom: keyFunderConfig.contextFundingFrom,
       contextsAndRolesToFund: keyFunderConfig.contextsAndRolesToFund,
+      connectionType: keyFunderConfig.connectionType,
     },
     image: {
       repository: keyFunderConfig.docker.repo,

--- a/typescript/infra/src/helloworld/kathy.ts
+++ b/typescript/infra/src/helloworld/kathy.ts
@@ -75,6 +75,7 @@ function getHelloworldKathyHelmValues<Chain extends ChainName>(
       messageReceiptTimeout: kathyConfig.messageReceiptTimeout,
       cycleOnce,
       fullCycleTime,
+      connectionType: kathyConfig.connectionType,
     },
     image: {
       repository: kathyConfig.docker.repo,


### PR DESCRIPTION
### Description

* Allows the key funder and kathy scripts to be configured to use a QuorumProvider (really in ethers-js jargon this is a FallbackProvider)
* Deployed this to testnet2 for the key funder & kathy - upon this merging I'll deploy to testnet2 again from a `main` commit and do the same for mainnet

### Drive-by changes

Not really

### Related issues

https://github.com/abacus-network/abacus-monorepo/issues/872 and https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/873 are related, though not closing them out yet

### Backward compatibility

This is actually backward compatible - yargs doesn't complain if there is a flag provided that it isn't aware of, so we can still deploy old versions of kathy/key funder using the new infra

### Testing

Deployed to testnet2
