### PR TITLE
Info log in validator when polling checkpoints

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,8 +13,20 @@ _Are there any minor or drive-by changes also included?_
 ### Backward compatibility
 
 _Are these changes backward compatible?_
+
+Yes
+No
+
 _Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_
+
+None
+Yes
+
 
 ### Testing
 
 _What kind of testing have these changes undergone?_
+
+None
+Manual
+Unit Tests

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -82,7 +82,7 @@ impl ValidatorSubmitter {
         // https://github.com/abacus-network/abacus-monorepo/issues/575 for
         // more details.
         while self.outbox.count().await? == 0 {
-            info!("waiting for non-zero outbox size");
+            info!("Waiting for non-zero outbox size");
             sleep(Duration::from_secs(self.interval)).await;
         }
 
@@ -105,10 +105,16 @@ impl ValidatorSubmitter {
                 .latest_checkpoint_observed
                 .set(latest_checkpoint.index as i64);
 
+            info!(
+                latest_signed_checkpoint_index=?current_index,
+                latest_known_checkpoint_index=?latest_checkpoint.index,
+                "Polled latest checkpoint"
+            );
+
             if current_index < latest_checkpoint.index {
                 let signed_checkpoint = latest_checkpoint.sign_with(self.signer.as_ref()).await?;
 
-                info!(signature = ?signed_checkpoint, signer=?self.signer, "Sign latest checkpoint");
+                info!(signature = ?signed_checkpoint, signer=?self.signer, "Signed new latest checkpoint");
                 current_index = latest_checkpoint.index;
 
                 self.checkpoint_syncer

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -127,7 +127,6 @@ impl ValidatorSubmitter {
                 info!(
                     latest_signed_checkpoint_index=?current_index,
                     latest_known_checkpoint_index=?latest_checkpoint.index,
-                    latest_known_checkpoint_root=?latest_checkpoint.root,
                     "Latest checkpoint infos"
                 );
             }

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -114,7 +114,7 @@ impl ValidatorSubmitter {
             if current_index < latest_checkpoint.index {
                 let signed_checkpoint = latest_checkpoint.sign_with(self.signer.as_ref()).await?;
 
-                info!(signature = ?signed_checkpoint, signer=?self.signer, "Signed new latest checkpoint");
+                info!(signed_checkpoint = ?signed_checkpoint, signer=?self.signer, "Signed new latest checkpoint");
                 current_index = latest_checkpoint.index;
 
                 self.checkpoint_syncer


### PR DESCRIPTION
### Description

Following some feedback, it's not super clear if a validator is working correctly because we don't log much

### Drive-by changes

Minor log changes

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None
