### PR TITLE
Deploy key funder and kathy

### DIFF
--- a/typescript/infra/config/environments/mainnet/funding.ts
+++ b/typescript/infra/config/environments/mainnet/funding.ts
@@ -8,7 +8,7 @@ import { environment } from './chains';
 export const keyFunderConfig: KeyFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-    tag: 'sha-0d76398',
+    tag: 'sha-dcc84ea',
   },
   cronSchedule: '45 * * * *', // Every hour at the 45 minute mark
   namespace: environment,
@@ -19,5 +19,5 @@ export const keyFunderConfig: KeyFunderConfig = {
     [Contexts.Abacus]: [KEY_ROLE_ENUM.Relayer, KEY_ROLE_ENUM.Kathy],
     [Contexts.ReleaseCandidate]: [KEY_ROLE_ENUM.Relayer, KEY_ROLE_ENUM.Kathy],
   },
-  connectionType: ConnectionType.Http,
+  connectionType: ConnectionType.HttpQuorum,
 };

--- a/typescript/infra/config/environments/mainnet/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet/helloworld.ts
@@ -12,7 +12,7 @@ export const abacus: HelloWorldConfig<MainnetChains> = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'sha-0d76398',
+      tag: 'sha-dcc84ea',
     },
     chainsToSkip: [],
     runEnv: environment,
@@ -23,7 +23,7 @@ export const abacus: HelloWorldConfig<MainnetChains> = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
-    connectionType: ConnectionType.Http,
+    connectionType: ConnectionType.HttpQuorum,
   },
 };
 
@@ -32,7 +32,7 @@ export const releaseCandidate: HelloWorldConfig<MainnetChains> = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'sha-0d76398',
+      tag: 'sha-dcc84ea',
     },
     chainsToSkip: [],
     runEnv: environment,
@@ -42,7 +42,7 @@ export const releaseCandidate: HelloWorldConfig<MainnetChains> = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
-    connectionType: ConnectionType.Http,
+    connectionType: ConnectionType.HttpQuorum,
   },
 };
 

--- a/typescript/infra/config/environments/testnet2/funding.ts
+++ b/typescript/infra/config/environments/testnet2/funding.ts
@@ -8,7 +8,7 @@ import { environment } from './chains';
 export const keyFunderConfig: KeyFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-    tag: 'sha-da9bc61',
+    tag: 'sha-dcc84ea',
   },
   cronSchedule: '45 * * * *', // Every hour at the 45 minute mark
   namespace: environment,

--- a/typescript/infra/config/environments/testnet2/helloworld.ts
+++ b/typescript/infra/config/environments/testnet2/helloworld.ts
@@ -12,7 +12,7 @@ export const abacus: HelloWorldConfig<TestnetChains> = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'sha-da9bc61',
+      tag: 'sha-dcc84ea',
     },
     chainsToSkip: [],
     runEnv: environment,
@@ -32,7 +32,7 @@ export const releaseCandidate: HelloWorldConfig<TestnetChains> = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'sha-da9bc61',
+      tag: 'sha-dcc84ea',
     },
     chainsToSkip: [],
     runEnv: environment,


### PR DESCRIPTION
### Description

* Deploys to include #1111
* Uses quorum provider in kathy and key funder in mainnet

### Drive-by changes

none

### Related issues

- Fixes #872 
- Fixes #873 

### Backward compatibility

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

deployed
