### PR TITLE
Add timeout to inner HttpQuorum providers & all API requests, correctly record # of gas payment events processed

### DIFF
--- a/rust/abacus-base/src/contract_sync/interchain_gas.rs
+++ b/rust/abacus-base/src/contract_sync/interchain_gas.rs
@@ -72,11 +72,16 @@ where
                     "[GasPayments]: indexed block range"
                 );
 
+                let mut new_payments_processed: i64 = 0;
                 for gas_payment in gas_payments.iter() {
-                    db.process_gas_payment(gas_payment)?;
+                    // Attempt to process the gas payment, incrementing new_payments_processed
+                    // if it was processed for the first time.
+                    if db.process_gas_payment(gas_payment)? {
+                        new_payments_processed += 1;
+                    }
                 }
 
-                stored_messages.add(gas_payments.len().try_into()?);
+                stored_messages.add(new_payments_processed);
 
                 db.store_latest_indexed_gas_payment_block(to)?;
                 from = to + 1;

--- a/rust/abacus-base/src/types/s3_storage.rs
+++ b/rust/abacus-base/src/types/s3_storage.rs
@@ -18,7 +18,7 @@ use crate::CheckpointSyncer;
 /// The timeout for S3 requests. Rusoto doesn't offer timeout configuration
 /// out of the box, so S3 requests must be wrapped with a timeout.
 /// See https://github.com/rusoto/rusoto/issues/1795.
-const S3_REQUEST_TIMEOUT_SECONDS: u32 = 30;
+const S3_REQUEST_TIMEOUT_SECONDS: u64 = 30;
 
 #[derive(Clone)]
 /// Type for reading/writing to S3
@@ -65,7 +65,7 @@ impl S3Storage {
             ..Default::default()
         };
         timeout(
-            Duration::from_secs(S3_REQUEST_TIMEOUT_SECONDS.into()),
+            Duration::from_secs(S3_REQUEST_TIMEOUT_SECONDS),
             self.authenticated_client().put_object(req),
         )
         .await??;
@@ -80,7 +80,7 @@ impl S3Storage {
             ..Default::default()
         };
         let get_object_result = timeout(
-            Duration::from_secs(S3_REQUEST_TIMEOUT_SECONDS.into()),
+            Duration::from_secs(S3_REQUEST_TIMEOUT_SECONDS),
             self.anonymous_client().get_object(req),
         )
         .await?;

--- a/rust/abacus-core/src/db/abacus_db.rs
+++ b/rust/abacus-core/src/db/abacus_db.rs
@@ -236,15 +236,17 @@ impl AbacusDB {
 
     /// If the provided gas payment, identified by its metadata, has not been processed,
     /// processes the gas payment and records it as processed.
+    /// Returns whether the gas payment was processed for the first time.
     pub fn process_gas_payment(
         &self,
         gas_payment_with_meta: &InterchainGasPaymentWithMeta,
-    ) -> Result<(), DbError> {
+    ) -> Result<bool, DbError> {
         let meta = &gas_payment_with_meta.meta;
         // If the gas payment has already been processed, do nothing
         if self.retrieve_gas_payment_meta_processed(meta)? {
             trace!(gas_payment_with_meta=?gas_payment_with_meta, "Attempted to process an already-processed gas payment");
-            return Ok(());
+            // Return false to indicate the gas payment was already processed
+            return Ok(false);
         }
         // Set the gas payment as processed
         self.store_gas_payment_meta_processed(meta)?;
@@ -252,7 +254,8 @@ impl AbacusDB {
         // Update the total gas payment for the leaf to include the payment
         self.update_gas_payment_for_leaf(&gas_payment_with_meta.payment)?;
 
-        Ok(())
+        // Return true to indicate the gas payment was processed for the first time
+        Ok(true)
     }
 
     /// Record a gas payment, identified by its metadata, as processed

--- a/rust/agents/relayer/src/msg/gelato_submitter/mod.rs
+++ b/rust/agents/relayer/src/msg/gelato_submitter/mod.rs
@@ -21,6 +21,8 @@ use super::SubmitMessageArgs;
 
 mod sponsored_call_op;
 
+const HTTP_CLIENT_REQUEST_SECONDS: u64 = 30;
+
 #[derive(Debug)]
 pub(crate) struct GelatoSubmitter {
     /// The Gelato config.
@@ -56,6 +58,10 @@ impl GelatoSubmitter {
     ) -> Self {
         let (message_processed_sender, message_processed_receiver) =
             mpsc::unbounded_channel::<SubmitMessageArgs>();
+        let http_client = reqwest::ClientBuilder::new()
+            .timeout(Duration::from_secs(HTTP_CLIENT_REQUEST_SECONDS))
+            .build()
+            .unwrap();
         Self {
             message_receiver,
             inbox_gelato_chain: abacus_domain_id_to_gelato_chain(
@@ -65,7 +71,7 @@ impl GelatoSubmitter {
             inbox_contracts,
             db: abacus_db,
             gelato_config,
-            http_client: reqwest::Client::new(),
+            http_client,
             metrics,
             message_processed_sender,
             message_processed_receiver,


### PR DESCRIPTION
### Description

* Noticed an issue with the Fuji relayer, a Fuji validator, and a Mumbai validator over the weekend that I think could be related to a lack of timeouts in places where we do HTTP requests. I think the original PR to add timeouts to the Http connection type happened at the same time as the initial HttpQuorum PR so this wasn't added at the time, so I added a timeout to HttpQuorum inner providers. While I was at it, added timeouts in other places where we do HTTP requests
* Noticed that the prometheus counter tracking the # of total gas payment events processed was huge, turns out we were counting events we'd already processed

### Drive-by changes

none

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing
None