### PR TITLE
Deploy agents

### DIFF
--- a/typescript/infra/config/environments/mainnet/agent.ts
+++ b/typescript/infra/config/environments/mainnet/agent.ts
@@ -23,7 +23,7 @@ export const abacus: AgentConfig<MainnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-f2bb187',
+    tag: 'sha-986b531',
   },
   aws: {
     region: 'us-east-1',
@@ -80,7 +80,7 @@ export const releaseCandidate: AgentConfig<MainnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-f2bb187',
+    tag: 'sha-986b531',
   },
   aws: {
     region: 'us-east-1',

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -26,7 +26,7 @@ export const abacus: AgentConfig<TestnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-f2bb187',
+    tag: 'sha-986b531',
   },
   aws: {
     region: 'us-east-1',
@@ -92,7 +92,7 @@ export const flowcarbon: AgentConfig<TestnetChains> = {
   context: Contexts.Flowcarbon,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-f2bb187',
+    tag: 'sha-986b531',
   },
   aws: {
     region: 'us-east-1',
@@ -124,7 +124,7 @@ export const releaseCandidate: AgentConfig<TestnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-f2bb187',
+    tag: 'sha-986b531',
   },
   aws: {
     region: 'us-east-1',


### PR DESCRIPTION
### Description

Deploys to testnet2 and mainnet mostly to include #1116

### Drive-by changes

none

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Sorta - see #1116 for the real breaking change

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

See #1116


### Testing

_What kind of testing have these changes undergone?_

Deployed
