### PR TITLE
Move back to non-quorum Http provider for kathy/key funder

### DIFF
--- a/typescript/infra/config/environments/mainnet/funding.ts
+++ b/typescript/infra/config/environments/mainnet/funding.ts
@@ -19,5 +19,5 @@ export const keyFunderConfig: KeyFunderConfig = {
     [Contexts.Abacus]: [KEY_ROLE_ENUM.Relayer, KEY_ROLE_ENUM.Kathy],
     [Contexts.ReleaseCandidate]: [KEY_ROLE_ENUM.Relayer, KEY_ROLE_ENUM.Kathy],
   },
-  connectionType: ConnectionType.HttpQuorum,
+  connectionType: ConnectionType.Http,
 };

--- a/typescript/infra/config/environments/mainnet/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet/helloworld.ts
@@ -42,7 +42,7 @@ export const releaseCandidate: HelloWorldConfig<MainnetChains> = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
-    connectionType: ConnectionType.HttpQuorum,
+    connectionType: ConnectionType.Http,
   },
 };
 

--- a/typescript/infra/config/environments/testnet2/funding.ts
+++ b/typescript/infra/config/environments/testnet2/funding.ts
@@ -19,5 +19,5 @@ export const keyFunderConfig: KeyFunderConfig = {
     [Contexts.Abacus]: [KEY_ROLE_ENUM.Relayer, KEY_ROLE_ENUM.Kathy],
     [Contexts.ReleaseCandidate]: [KEY_ROLE_ENUM.Relayer, KEY_ROLE_ENUM.Kathy],
   },
-  connectionType: ConnectionType.HttpQuorum,
+  connectionType: ConnectionType.Http,
 };

--- a/typescript/infra/config/environments/testnet2/helloworld.ts
+++ b/typescript/infra/config/environments/testnet2/helloworld.ts
@@ -23,7 +23,7 @@ export const abacus: HelloWorldConfig<TestnetChains> = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
-    connectionType: ConnectionType.HttpQuorum,
+    connectionType: ConnectionType.Http,
   },
 };
 
@@ -42,7 +42,7 @@ export const releaseCandidate: HelloWorldConfig<TestnetChains> = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
-    connectionType: ConnectionType.HttpQuorum,
+    connectionType: ConnectionType.Http,
   },
 };
 


### PR DESCRIPTION
### Description

https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/1117 but for all other places we use HttpQuorum in TS. We can go back to HttpQuorum with https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/1119

### Drive-by changes

none

### Related issues

none

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

_What kind of testing have these changes undergone?_

Deployed

