### PR TITLE
Skip deprecated networks in kathy

### DIFF
--- a/typescript/infra/config/environments/testnet2/helloworld.ts
+++ b/typescript/infra/config/environments/testnet2/helloworld.ts
@@ -14,7 +14,7 @@ export const abacus: HelloWorldConfig<TestnetChains> = {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
       tag: 'sha-dcc84ea',
     },
-    chainsToSkip: [],
+    chainsToSkip: ['kovan', 'optimismkovan', 'arbitrumrinkeby'],
     runEnv: environment,
     namespace: environment,
     runConfig: {
@@ -34,7 +34,7 @@ export const releaseCandidate: HelloWorldConfig<TestnetChains> = {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
       tag: 'sha-dcc84ea',
     },
-    chainsToSkip: [],
+    chainsToSkip: ['kovan', 'optimismkovan', 'arbitrumrinkeby'],
     runEnv: environment,
     namespace: environment,
     runConfig: {


### PR DESCRIPTION
### Description

This PR stops sending to and from the deprecated networks in kathy. This should first trigger alerts in grafana for no messages sent. Eventually we'll remove them from the SDK and agent artifacts as well.

