### PR TITLE
Export developer-relevant addresses as hyperlaneCoreAddresses

### DIFF
--- a/typescript/sdk/src/consts/environments/index.ts
+++ b/typescript/sdk/src/consts/environments/index.ts
@@ -1,3 +1,5 @@
+import { objMap } from '../../utils/objects';
+
 import mainnet from './mainnet.json';
 import test from './test.json';
 import testnet2 from './testnet2.json';
@@ -7,3 +9,18 @@ export const environments = {
   testnet2,
   mainnet,
 };
+
+// Export developer-relevant addresses
+export const hyperlaneCoreAddresses = objMap(
+  { ...testnet2, ...mainnet },
+  (_chain, addresses) => ({
+    outbox: addresses.outbox.proxy,
+    connectionManager: addresses.connectionManager,
+    interchainGasPaymaster: addresses.interchainGasPaymaster.proxy,
+    inboxes: objMap(
+      // @ts-ignore
+      addresses.inboxes,
+      (_remoteChain, inboxAddresses) => inboxAddresses.inbox.proxy,
+    ),
+  }),
+);

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -4,7 +4,10 @@ export {
   chainConnectionConfigs,
   testChainConnectionConfigs,
 } from './consts/chainConnectionConfigs';
-export { environments as coreEnvironments } from './consts/environments';
+export {
+  environments as coreEnvironments,
+  hyperlaneCoreAddresses,
+} from './consts/environments';
 
 export {
   ChainMap,


### PR DESCRIPTION
### Description

This PR gives a simple mapping for developers who just want to access the core addresses. This avoids the need to select the environment first and then understand the address structure, while not needing to construct an `AbacusCore` object (for which you would need a MultiProvider)