### PR TITLE
Domain support in Mailboxes

### DIFF
--- a/solidity/core/contracts/mock/MockInbox.sol
+++ b/solidity/core/contracts/mock/MockInbox.sol
@@ -8,6 +8,7 @@ contract MockInbox {
     using TypeCasts for bytes32;
 
     struct PendingMessage {
+        uint32 originDomain;
         bytes32 sender;
         bytes32 recipient;
         bytes messageBody;
@@ -18,11 +19,13 @@ contract MockInbox {
     uint256 messageProcessed = 0;
 
     function addPendingMessage(
+        uint32 _originDomain,
         bytes32 _sender,
         bytes32 _recipient,
         bytes memory _messageBody
     ) external {
         pendingMessages[totalMessages] = PendingMessage(
+            _originDomain,
             _sender,
             _recipient,
             _messageBody
@@ -40,7 +43,7 @@ contract MockInbox {
         IMessageRecipient(recipient).handle(
             // This is completely arbitrary and consumers should not rely
             // on domain handling in the mock mailbox contracts.
-            1,
+            pendingMessage.originDomain,
             pendingMessage.sender,
             pendingMessage.messageBody
         );

--- a/solidity/core/contracts/mock/MockOutbox.sol
+++ b/solidity/core/contracts/mock/MockOutbox.sol
@@ -6,9 +6,11 @@ import {TypeCasts} from "../libs/TypeCasts.sol";
 
 contract MockOutbox {
     MockInbox inbox;
+    uint32 domain;
     using TypeCasts for address;
 
-    constructor(address _inbox) {
+    constructor(uint32 _domain, address _inbox) {
+        domain = _domain;
         inbox = MockInbox(_inbox);
     }
 
@@ -16,11 +18,13 @@ contract MockOutbox {
         uint32,
         bytes32 _recipientAddress,
         bytes calldata _messageBody
-    ) external {
+    ) external returns (uint256) {
         inbox.addPendingMessage(
+            domain,
             msg.sender.addressToBytes32(),
             _recipientAddress,
             _messageBody
         );
+        return 1;
     }
 }

--- a/solidity/core/test/mockMailbox.test.ts
+++ b/solidity/core/test/mockMailbox.test.ts
@@ -19,7 +19,6 @@ describe('Mock mailbox contracts', function () {
 
     const data = ethers.utils.toUtf8Bytes('This is a test message');
 
-    // Mailbox mocks do not handle domains currently, so this is arbitrary
     await outbox.dispatch(0, utils.addressToBytes32(recipient.address), data);
     await inbox.processNextPendingMessage();
 


### PR DESCRIPTION
### Description

Without this, you can't actually use the mock mailboxes when testing router applications since the domainID made no sense
