### PR TITLE
Disable gelato for  now

### DIFF
--- a/typescript/infra/config/environments/mainnet/agent.ts
+++ b/typescript/infra/config/environments/mainnet/agent.ts
@@ -33,13 +33,13 @@ export const abacus: AgentConfig<MainnetChains> = {
   validatorSets: validators,
   gelato: {
     enabledChains: [
-      'bsc',
-      'ethereum',
-      'polygon',
-      'avalanche',
-      // Gelato is having issues with Arbitrum, so not using for now.
-      // 'arbitrum',
-      'optimism',
+      // 'bsc',
+      // 'ethereum',
+      // 'polygon',
+      // 'avalanche',
+      // // Gelato is having issues with Arbitrum, so not using for now.
+      // // 'arbitrum',
+      // 'optimism',
     ],
   },
   connectionType: ConnectionType.HttpQuorum,


### PR DESCRIPTION
Moonbeam relayer is having issues with delivering and we can't see the response, so disabling for now