### PR TITLE
Update ethers-rs to include QuorumProvider fix

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1418,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.17.0"
-source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-09-12-01#1cbb788589d84758ed63d3fed9bd252523d74664"
+source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-10-28-01#9dd5eb30de0f2c629614c39e867eb45ef275f915"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1432,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.17.0"
-source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-09-12-01#1cbb788589d84758ed63d3fed9bd252523d74664"
+source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-10-28-01#9dd5eb30de0f2c629614c39e867eb45ef275f915"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1443,7 +1443,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.17.0"
-source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-09-12-01#1cbb788589d84758ed63d3fed9bd252523d74664"
+source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-10-28-01#9dd5eb30de0f2c629614c39e867eb45ef275f915"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1461,7 +1461,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.17.0"
-source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-09-12-01#1cbb788589d84758ed63d3fed9bd252523d74664"
+source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-10-28-01#9dd5eb30de0f2c629614c39e867eb45ef275f915"
 dependencies = [
  "Inflector",
  "cfg-if",
@@ -1484,7 +1484,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.17.0"
-source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-09-12-01#1cbb788589d84758ed63d3fed9bd252523d74664"
+source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-10-28-01#9dd5eb30de0f2c629614c39e867eb45ef275f915"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1498,7 +1498,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.17.0"
-source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-09-12-01#1cbb788589d84758ed63d3fed9bd252523d74664"
+source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-10-28-01#9dd5eb30de0f2c629614c39e867eb45ef275f915"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.17.0"
-source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-09-12-01#1cbb788589d84758ed63d3fed9bd252523d74664"
+source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-10-28-01#9dd5eb30de0f2c629614c39e867eb45ef275f915"
 dependencies = [
  "ethers-core",
  "getrandom",
@@ -1545,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.17.0"
-source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-09-12-01#1cbb788589d84758ed63d3fed9bd252523d74664"
+source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-10-28-01#9dd5eb30de0f2c629614c39e867eb45ef275f915"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -1590,7 +1590,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.17.0"
-source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-09-12-01#1cbb788589d84758ed63d3fed9bd252523d74664"
+source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-10-28-01#9dd5eb30de0f2c629614c39e867eb45ef275f915"
 dependencies = [
  "async-trait",
  "auto_impl 1.0.1",
@@ -1626,7 +1626,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.17.0"
-source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-09-12-01#1cbb788589d84758ed63d3fed9bd252523d74664"
+source = "git+https://github.com/abacus-network/ethers-rs?tag=2022-10-28-01#9dd5eb30de0f2c629614c39e867eb45ef275f915"
 dependencies = [
  "async-trait",
  "coins-bip32",

--- a/rust/abacus-base/Cargo.toml
+++ b/rust/abacus-base/Cargo.toml
@@ -10,7 +10,7 @@ tokio = { version = "1", features = ["rt", "macros"] }
 config = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
-ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01" }
+ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01" }
 thiserror = { version = "1.0", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 futures-util = "0.3"

--- a/rust/abacus-core/Cargo.toml
+++ b/rust/abacus-core/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 
 [dependencies]
 auto_impl = "1.0"
-ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01", default-features = false, features = ['legacy'] }
-ethers-signers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01", features=["aws"] }
-ethers-providers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01", features=["ws", "rustls"] }
+ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01", default-features = false, features = ['legacy'] }
+ethers-signers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01", features=["aws"] }
+ethers-providers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01", features=["ws", "rustls"] }
 config = "0.13"
 hex = "0.4.3"
 sha3 = "0.9.1"

--- a/rust/abacus-test/Cargo.toml
+++ b/rust/abacus-test/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 tokio = { version = "1", features = ["rt", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
-ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01" }
+ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01" }
 thiserror = { version = "1.0", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 futures-util = "0.3"

--- a/rust/agents/relayer/Cargo.toml
+++ b/rust/agents/relayer/Cargo.toml
@@ -9,8 +9,8 @@ coingecko = { git = "https://github.com/hyperlane-xyz/coingecko-rs", tag = "2022
 config = "0.13"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = { version = "1.0", default-features = false }
-ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01" }
-ethers-contract = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01", features=["legacy"] }
+ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01" }
+ethers-contract = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01", features=["legacy"] }
 thiserror = { version = "1.0", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 futures-util = "0.3"

--- a/rust/agents/scraper/Cargo.toml
+++ b/rust/agents/scraper/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 async-trait = { version = "0.1", default-features = false }
 chrono = "0.4"
 config = "0.13"
-ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01" }
+ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01" }
 eyre = "0.6"
 hex = "0.4"
 itertools = "0.10"

--- a/rust/agents/validator/Cargo.toml
+++ b/rust/agents/validator/Cargo.toml
@@ -8,7 +8,7 @@ tokio = { version = "1", features = ["rt", "macros"] }
 config = "0.13"
 serde = "1.0"
 serde_json = { version = "1.0", default-features = false }
-ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01" }
+ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01" }
 thiserror = { version = "1.0", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 futures-util = "0.3"

--- a/rust/chains/abacus-ethereum/Cargo.toml
+++ b/rust/chains/abacus-ethereum/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 # Main block
 serde = "1.0"
 serde_json = { version = "1.0", default-features = false }
-ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01", features = ["abigen"] }
-ethers-signers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01", features = ["aws"] }
-ethers-contract = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01", features=["legacy"] }
+ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01", features = ["abigen"] }
+ethers-signers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01", features = ["aws"] }
+ethers-contract = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01", features=["legacy"] }
 async-trait = { version = "0.1", default-features = false }
 thiserror = { version = "1.0", default-features = false }
 tracing = "0.1"

--- a/rust/ethers-prometheus/Cargo.toml
+++ b/rust/ethers-prometheus/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 prometheus = "0.13"
-ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01" }
+ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01" }
 derive_builder = "0.11"
 async-trait = { version = "0.1", default-features = false }
 futures = "0.3"

--- a/rust/gelato/Cargo.toml
+++ b/rust/gelato/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = { version = "0.1", default-features = false }
-ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01" }
+ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 serde_repr = "0.1.9"

--- a/rust/utils/abigen/Cargo.toml
+++ b/rust/utils/abigen/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-09-12-01" }
+ethers = { git = "https://github.com/abacus-network/ethers-rs", tag = "2022-10-28-01" }
 Inflector = "0.11"


### PR DESCRIPTION
### Description

Updates the ethers-rs to include https://github.com/hyperlane-xyz/ethers-rs/pull/5

### Drive-by changes

none

### Related issues

- Related #1160 

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Deployed to testnet2 rc with a similar version using the new ethers-rs version
