### PR TITLE
Adjust Goerli finality from 7 to 2

### DIFF
--- a/rust/config/testnet2/alfajores_config.json
+++ b/rust/config/testnet2/alfajores_config.json
@@ -48,7 +48,7 @@
       "domain": "5",
       "name": "goerli",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "2",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/arbitrumgoerli_config.json
+++ b/rust/config/testnet2/arbitrumgoerli_config.json
@@ -62,7 +62,7 @@
       "domain": "5",
       "name": "goerli",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "2",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/bsctestnet_config.json
+++ b/rust/config/testnet2/bsctestnet_config.json
@@ -48,7 +48,7 @@
       "domain": "5",
       "name": "goerli",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "2",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/fuji_config.json
+++ b/rust/config/testnet2/fuji_config.json
@@ -48,7 +48,7 @@
       "domain": "5",
       "name": "goerli",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "2",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/goerli_config.json
+++ b/rust/config/testnet2/goerli_config.json
@@ -109,7 +109,7 @@
     "domain": "5",
     "name": "goerli",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "7",
+    "finalityBlocks": "2",
     "connection": {
       "type": "http",
       "url": ""

--- a/rust/config/testnet2/moonbasealpha_config.json
+++ b/rust/config/testnet2/moonbasealpha_config.json
@@ -62,7 +62,7 @@
       "domain": "5",
       "name": "goerli",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "2",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/mumbai_config.json
+++ b/rust/config/testnet2/mumbai_config.json
@@ -48,7 +48,7 @@
       "domain": "5",
       "name": "goerli",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "2",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/optimismgoerli_config.json
+++ b/rust/config/testnet2/optimismgoerli_config.json
@@ -62,7 +62,7 @@
       "domain": "5",
       "name": "goerli",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "2",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/scraper_config.json
+++ b/rust/config/testnet2/scraper_config.json
@@ -62,7 +62,7 @@
       "domain": "5",
       "name": "goerli",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "2",
       "connection": {
         "type": "http",
         "url": ""
@@ -152,7 +152,7 @@
       "domain": "5",
       "name": "goerli",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "2",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/sdk/src/consts/chainMetadata.ts
+++ b/typescript/sdk/src/consts/chainMetadata.ts
@@ -107,7 +107,7 @@ export const fuji: ChainMetadata = {
 
 export const goerli: ChainMetadata = {
   id: 5,
-  finalityBlocks: 7,
+  finalityBlocks: 2,
 };
 
 export const optimismgoerli: ChainMetadata = {


### PR DESCRIPTION
### Description

This PR adjusts the safe finality period of Goerli from 7 to 2. Now that the merge is complete, Goerli is much less likely to significantly reorg, and the responsiveness of the relayer and scraper (who wait for finality) is worth the very minor risk of reorgs.

### Related issues

- Fixes #1195 
