### PR TITLE
Fix HyperlaneCore and add tests

### DIFF
--- a/typescript/infra/scripts/govern.ts
+++ b/typescript/infra/scripts/govern.ts
@@ -15,7 +15,9 @@ async function check() {
   const multiProvider = await config.getMultiProvider();
 
   // environments union doesn't work well with typescript
+  console.log('blah');
   const core = HyperlaneCore.fromEnvironment(environment, multiProvider as any);
+  console.log('bleh');
 
   const coreChecker = new HyperlaneCoreChecker<any>(
     multiProvider,

--- a/typescript/sdk/src/core/HyperlaneCore.test.ts
+++ b/typescript/sdk/src/core/HyperlaneCore.test.ts
@@ -1,0 +1,17 @@
+import { chainConnectionConfigs } from '../consts/chainConnectionConfigs';
+import { MultiProvider } from '../providers/MultiProvider';
+
+import { HyperlaneCore } from './HyperlaneCore';
+
+describe('HyperlaneCore', () => {
+  describe('fromEnvironment', () => {
+    it('creates an object for mainnet', async () => {
+      const multiProvider = new MultiProvider(chainConnectionConfigs);
+      HyperlaneCore.fromEnvironment('mainnet', multiProvider);
+    });
+    it('creates an object for testnet2', async () => {
+      const multiProvider = new MultiProvider(chainConnectionConfigs);
+      HyperlaneCore.fromEnvironment('testnet2', multiProvider);
+    });
+  });
+});

--- a/typescript/sdk/src/core/contracts.ts
+++ b/typescript/sdk/src/core/contracts.ts
@@ -1,12 +1,15 @@
 import {
   AbacusConnectionManager,
   AbacusConnectionManager__factory,
+  Create2Factory__factory,
   Inbox,
   InboxValidatorManager,
   InboxValidatorManager__factory,
   Inbox__factory,
+  InterchainAccountRouter__factory,
   InterchainGasPaymaster,
   InterchainGasPaymaster__factory,
+  InterchainQueryRouter__factory,
   Outbox,
   OutboxValidatorManager,
   OutboxValidatorManager__factory,
@@ -56,6 +59,9 @@ const outboxFactories = {
 };
 
 export const coreFactories = {
+  interchainAccountRouter: new InterchainAccountRouter__factory(),
+  interchainQueryRouter: new InterchainQueryRouter__factory(),
+  create2Factory: new Create2Factory__factory(),
   connectionManager: new AbacusConnectionManager__factory(),
   upgradeBeaconController: new UpgradeBeaconController__factory(),
   interchainGasPaymaster: new InterchainGasPaymaster__factory(),


### PR DESCRIPTION
### Description

This PR fixes a bug introduced in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/1210 in `HyperlaneCore.fromEnvironment` by adding the missing factories to `hyperlaneCoreFactories`.

It also adds tests to ensure that this cannot fail silently again.

