### PR TITLE
Adding message leaf index to InterchainAccountRouter

### DIFF
--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -38,8 +38,9 @@ contract InterchainAccountRouter is Router {
 
     function dispatch(uint32 _destinationDomain, Call[] calldata calls)
         external
+        returns (uint256)
     {
-        _dispatch(_destinationDomain, abi.encode(msg.sender, calls));
+        return _dispatch(_destinationDomain, abi.encode(msg.sender, calls));
     }
 
     function getInterchainAccount(uint32 _origin, address _sender)


### PR DESCRIPTION
### Description

_What's included in this PR?_

This change causes InterchainAccountRouter.dispatch(...) to return the message leaf index of the dispatched message.

### Drive-by changes

_Are there any minor or drive-by changes also included?_

No

### Related issues

- Fixes #1233 

### Backward compatibility

_Are these changes backward compatible?_

No

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

Potentially

### Testing

None
