### PR TITLE
Quickstart fixes

### DIFF
--- a/solidity/contracts/Call.sol
+++ b/solidity/contracts/Call.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+struct Call {
+    address to;
+    bytes data;
+}

--- a/solidity/contracts/OwnableMulticall.sol
+++ b/solidity/contracts/OwnableMulticall.sol
@@ -4,11 +4,7 @@ pragma solidity ^0.8.13;
 // ============ External Imports ============
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-
-struct Call {
-    address to;
-    bytes data;
-}
+import {Call} from "./Call.sol";
 
 /*
  * @title OwnableMulticall

--- a/solidity/contracts/middleware/InterchainQueryRouter.sol
+++ b/solidity/contracts/middleware/InterchainQueryRouter.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {OwnableMulticall, Call} from "../OwnableMulticall.sol";
+import {IInterchainQueryRouter} from "../../interfaces/IInterchainQueryRouter.sol";
 
 // ============ External Imports ============
 import {Router} from "../Router.sol";
@@ -9,7 +10,11 @@ import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
-contract InterchainQueryRouter is Router, OwnableMulticall {
+contract InterchainQueryRouter is
+    Router,
+    OwnableMulticall,
+    IInterchainQueryRouter
+{
     enum Action {
         DISPATCH,
         RESOLVE
@@ -47,13 +52,13 @@ contract InterchainQueryRouter is Router, OwnableMulticall {
         uint32 _destinationDomain,
         Call calldata call,
         bytes calldata callback
-    ) external {
+    ) external returns (uint256 leafIndex) {
         // TODO: fix this ugly arrayification
         Call[] memory calls = new Call[](1);
         calls[0] = call;
         bytes[] memory callbacks = new bytes[](1);
         callbacks[0] = callback;
-        query(_destinationDomain, calls, callbacks);
+        leafIndex = query(_destinationDomain, calls, callbacks);
     }
 
     /**
@@ -65,12 +70,12 @@ contract InterchainQueryRouter is Router, OwnableMulticall {
         uint32 _destinationDomain,
         Call[] memory calls,
         bytes[] memory callbacks
-    ) public {
+    ) public returns (uint256 leafIndex) {
         require(
             calls.length == callbacks.length,
             "InterchainQueryRouter: calls and callbacks must be same length"
         );
-        _dispatch(
+        leafIndex = _dispatch(
             _destinationDomain,
             abi.encode(Action.DISPATCH, msg.sender, calls, callbacks)
         );

--- a/solidity/contracts/mock/MockHyperlaneEnvironment.sol
+++ b/solidity/contracts/mock/MockHyperlaneEnvironment.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import "../contracts/mock/MockOutbox.sol";
-import "../contracts/mock/MockInbox.sol";
-import "../contracts/AbacusConnectionManager.sol";
-import "../contracts/middleware/InterchainQueryRouter.sol";
+import "./MockOutbox.sol";
+import "./MockInbox.sol";
+import "../AbacusConnectionManager.sol";
+import "../middleware/InterchainQueryRouter.sol";
 
-import {TypeCasts} from "../contracts/libs/TypeCasts.sol";
+import {TypeCasts} from "../libs/TypeCasts.sol";
 
 contract MockHyperlaneEnvironment {
     uint32 originDomain;

--- a/solidity/interfaces/IInterchainAccountRouter.sol
+++ b/solidity/interfaces/IInterchainAccountRouter.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.6.11;
+
+import {Call} from "../contracts/OwnableMulticall.sol";
+
+interface IInterchainAccountRouter {
+    function dispatch(uint32 _destinationDomain, Call[] calldata calls)
+        external
+        returns (uint256);
+
+    function getInterchainAccount(uint32 _originDomain, address _sender)
+        external
+        view
+        returns (address);
+}

--- a/solidity/interfaces/IInterchainAccountRouter.sol
+++ b/solidity/interfaces/IInterchainAccountRouter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.11;
 
-import {Call} from "../contracts/OwnableMulticall.sol";
+import {Call} from "../contracts/Call.sol";
 
 interface IInterchainAccountRouter {
     function dispatch(uint32 _destinationDomain, Call[] calldata calls)

--- a/solidity/interfaces/IInterchainQueryRouter.sol
+++ b/solidity/interfaces/IInterchainQueryRouter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.11;
 
-import {Call} from "../contracts/OwnableMulticall.sol";
+import {Call} from "../contracts/Call.sol";
 
 interface IInterchainQueryRouter {
     function query(

--- a/solidity/interfaces/IInterchainQueryRouter.sol
+++ b/solidity/interfaces/IInterchainQueryRouter.sol
@@ -1,21 +1,18 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.11;
 
-struct Call {
-    address to;
-    bytes data;
-}
+import {Call} from "../contracts/OwnableMulticall.sol";
 
 interface IInterchainQueryRouter {
     function query(
         uint32 _destinationDomain,
         Call calldata call,
         bytes calldata callback
-    ) external;
+    ) external returns (uint256);
 
     function query(
         uint32 _destinationDomain,
         Call[] calldata calls,
         bytes[] calldata callbacks
-    ) external;
+    ) external returns (uint256);
 }

--- a/solidity/test/MockInterchainAccount.t.sol
+++ b/solidity/test/MockInterchainAccount.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import {TypeCasts} from "../contracts/libs/TypeCasts.sol";
+
+import "../contracts/mock/MockInterchainAccountRouter.sol";
+
+contract MockInterchainAccountTest is Test {
+    OwnableMulticall ownee;
+    MockInterchainAccountRouter router;
+    uint32 originDomain = 1;
+    uint32 remoteDomain = 2;
+
+    function setUp() public {
+        router = new MockInterchainAccountRouter(originDomain);
+
+        address ownerICA = router.getInterchainAccount(
+            originDomain,
+            address(this)
+        );
+        // Sets the ownee owner to the ICA of the owner;
+        ownee = new OwnableMulticall();
+        ownee.transferOwnership(ownerICA);
+    }
+
+    function testSettingNewOwner(address newOwner) public {
+        vm.assume(newOwner != address(0x0));
+
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({
+            to: address(ownee),
+            data: abi.encodeWithSelector(
+                ownee.transferOwnership.selector,
+                newOwner
+            )
+        });
+        router.dispatch(remoteDomain, calls);
+        router.processNextPendingCall();
+        assertEq(ownee.owner(), newOwner);
+    }
+}

--- a/solidity/test/TestQuerySender.t.sol
+++ b/solidity/test/TestQuerySender.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import "forge-std/Test.sol";
 import {InterchainQueryRouter} from "../contracts/middleware/InterchainQueryRouter.sol";
 import {TestQuerySender} from "../contracts/test/TestQuerySender.sol";
-import {MockHyperlaneEnvironment} from "./MockHyperlaneEnvironment.sol";
+import {MockHyperlaneEnvironment} from "../contracts/mock/MockHyperlaneEnvironment.sol";
 
 import {MockToken} from "../contracts/mock/MockToken.sol";
 

--- a/solidity/test/TokenBridgeRouter.t.sol
+++ b/solidity/test/TokenBridgeRouter.t.sol
@@ -8,7 +8,7 @@ import {MockToken} from "../contracts/mock/MockToken.sol";
 import {TestTokenRecipient} from "../contracts/test/TestTokenRecipient.sol";
 import {MockCircleMessageTransmitter} from "../contracts/mock/MockCircleMessageTransmitter.sol";
 import {MockCircleBridge} from "../contracts/mock/MockCircleBridge.sol";
-import {MockHyperlaneEnvironment} from "./MockHyperlaneEnvironment.sol";
+import {MockHyperlaneEnvironment} from "../contracts/mock/MockHyperlaneEnvironment.sol";
 
 import {TypeCasts} from "../contracts/libs/TypeCasts.sol";
 

--- a/typescript/sdk/src/consts/environments/index.ts
+++ b/typescript/sdk/src/consts/environments/index.ts
@@ -1,6 +1,6 @@
-import { Address } from '@hyperlane-xyz/utils/dist/src/types';
+import { types } from '@hyperlane-xyz/utils';
 
-import { ForgivingCompleteChainMap } from '../../types';
+import { LooseChainMap } from '../../types';
 import { objMap } from '../../utils/objects';
 
 import mainnet from './mainnet.json';
@@ -12,6 +12,16 @@ export const environments = {
   testnet2,
   mainnet,
 };
+
+type HyperlaneCoreAddressMap = LooseChainMap<{
+  outbox: types.Address;
+  connectionManager: types.Address;
+  interchainGasPaymaster: types.Address;
+  interchainAccountRouter: types.Address;
+  interchainQueryRouter: types.Address;
+  create2Factory: types.Address;
+  inboxes: Record<string, types.Address>;
+}>;
 
 // Export developer-relevant addresses
 export const hyperlaneCoreAddresses = objMap(
@@ -29,12 +39,4 @@ export const hyperlaneCoreAddresses = objMap(
       (_remoteChain, inboxAddresses) => inboxAddresses.inbox.proxy,
     ),
   }),
-) as ForgivingCompleteChainMap<{
-  outbox: Address;
-  connectionManager: Address;
-  interchainGasPaymaster: Address;
-  interchainAccountRouter: Address;
-  interchainQueryRouter: Address;
-  create2Factory: Address;
-  inboxes: Record<string, Address>;
-}>;
+) as HyperlaneCoreAddressMap;

--- a/typescript/sdk/src/consts/environments/index.ts
+++ b/typescript/sdk/src/consts/environments/index.ts
@@ -1,3 +1,6 @@
+import { Address } from '@hyperlane-xyz/utils/dist/src/types';
+
+import { ForgivingCompleteChainMap } from '../../types';
 import { objMap } from '../../utils/objects';
 
 import mainnet from './mainnet.json';
@@ -26,4 +29,12 @@ export const hyperlaneCoreAddresses = objMap(
       (_remoteChain, inboxAddresses) => inboxAddresses.inbox.proxy,
     ),
   }),
-);
+) as ForgivingCompleteChainMap<{
+  outbox: Address;
+  connectionManager: Address;
+  interchainGasPaymaster: Address;
+  interchainAccountRouter: Address;
+  interchainQueryRouter: Address;
+  create2Factory: Address;
+  inboxes: Record<string, Address>;
+}>;

--- a/typescript/sdk/src/domains.ts
+++ b/typescript/sdk/src/domains.ts
@@ -1,6 +1,6 @@
 import { chainMetadata } from './consts/chainMetadata';
 import { AllChains } from './consts/chains';
-import { ChainName, ForgivingCompleteChainMap } from './types';
+import { ChainName, LooseChainMap } from './types';
 
 export const DomainIdToChainName = Object.fromEntries(
   AllChains.map((chain) => {
@@ -12,4 +12,4 @@ export const DomainIdToChainName = Object.fromEntries(
 
 export const ChainNameToDomainId = Object.fromEntries(
   AllChains.map((chain) => [chain, chainMetadata[chain].id]),
-) as ForgivingCompleteChainMap<number>;
+) as LooseChainMap<number>;

--- a/typescript/sdk/src/domains.ts
+++ b/typescript/sdk/src/domains.ts
@@ -1,6 +1,6 @@
 import { chainMetadata } from './consts/chainMetadata';
 import { AllChains } from './consts/chains';
-import { ChainName, CompleteChainMap } from './types';
+import { ChainName, ForgivingCompleteChainMap } from './types';
 
 export const DomainIdToChainName = Object.fromEntries(
   AllChains.map((chain) => {
@@ -12,4 +12,4 @@ export const DomainIdToChainName = Object.fromEntries(
 
 export const ChainNameToDomainId = Object.fromEntries(
   AllChains.map((chain) => [chain, chainMetadata[chain].id]),
-) as CompleteChainMap<number>;
+) as ForgivingCompleteChainMap<number>;

--- a/typescript/sdk/src/types.ts
+++ b/typescript/sdk/src/types.ts
@@ -6,10 +6,7 @@ import type { Chains } from './consts/chains';
 export type ChainName = keyof typeof Chains;
 // A full object map of all chains to a value type
 export type CompleteChainMap<Value> = Record<ChainName, Value>;
-export type ForgivingCompleteChainMap<Value> = Record<
-  ChainName | string,
-  Value
->;
+export type LooseChainMap<Value> = Record<ChainName | string, Value>;
 // A partial object map of some chains to a value type
 export type PartialChainMap<Value> = Partial<CompleteChainMap<Value>>;
 // A map of some specific subset of chains to a value type

--- a/typescript/sdk/src/types.ts
+++ b/typescript/sdk/src/types.ts
@@ -6,6 +6,10 @@ import type { Chains } from './consts/chains';
 export type ChainName = keyof typeof Chains;
 // A full object map of all chains to a value type
 export type CompleteChainMap<Value> = Record<ChainName, Value>;
+export type ForgivingCompleteChainMap<Value> = Record<
+  ChainName | string,
+  Value
+>;
 // A partial object map of some chains to a value type
 export type PartialChainMap<Value> = Partial<CompleteChainMap<Value>>;
 // A map of some specific subset of chains to a value type


### PR DESCRIPTION
### Description

- Have InterchainAccountRouter and MockInterchainAccountRouter conform to IInterchainAccountRouter
- Have InterchainQueryRouter conform to IInterchainQueryRouter
- Made `ChainNameToDomainId` more forgiving type wise
- Loosen type of hyperlaneCoreAddresses



### Related issues

- Fixes #1163 

### Backward compatibility

_Are these changes backward compatible?_

No, new middleware routers will have to be deployed

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

Yes, deploys from this commit won't yield the same bytecode and thus same contract addresses for middleware contracts


### Testing

_What kind of testing have these changes undergone?_

Unit Tests
