### PR TITLE
Loop with sleep of 5s

### DIFF
--- a/rust/agents/scraper/src/scraper/mod.rs
+++ b/rust/agents/scraper/src/scraper/mod.rs
@@ -337,6 +337,7 @@ impl SqlChainScraper {
         info!(from, chunk_size, chain_name, "Resuming chain sync");
 
         loop {
+            sleep(Duration::from_secs(5)).await;
             indexed_message_height.set(from as i64);
             indexed_deliveries_height.set(from as i64);
 


### PR DESCRIPTION
### Description

The scraper loop today loops "instantly", i.e. it does not have any notion of a loop interval. That causes excessively high counts of `eth_getBlockNumber` calls. This PR adds a manual loop interval of 5s until a more configurable change is made (probably one that orients itself at the block time).
