### PR TITLE
Add sleeps to indexing loops

### DIFF
--- a/rust/abacus-base/src/contract_sync/interchain_gas.rs
+++ b/rust/abacus-base/src/contract_sync/interchain_gas.rs
@@ -52,9 +52,8 @@ where
                 } else {
                     continue;
                 };
-                if tip.saturating_sub(chunk_size) / 2 <= from {
-                    // we are within half a chunk of the tip, go ahead and sleep for a little bit
-                    // longer
+                if tip <= from {
+                    // Sleep if caught up to tip
                     debug!(tip=?tip, from=?from, "[GasPayments]: caught up to tip, waiting for new block");
                     sleep(Duration::from_secs(20)).await;
                     continue;

--- a/rust/abacus-base/src/contract_sync/interchain_gas.rs
+++ b/rust/abacus-base/src/contract_sync/interchain_gas.rs
@@ -42,6 +42,7 @@ where
             info!(from = from, "[GasPayments]: resuming indexer from {from}");
 
             loop {
+                sleep(Duration::from_secs(2)).await;
                 indexed_height.set(from.into());
 
                 // Only index blocks considered final.
@@ -51,10 +52,11 @@ where
                 } else {
                     continue;
                 };
-                if tip <= from {
+                if tip.saturating_sub(chunk_size) / 2 <= from {
+                    // we are within half a chunk of the tip, go ahead and sleep for a little bit
+                    // longer
                     debug!(tip=?tip, from=?from, "[GasPayments]: caught up to tip, waiting for new block");
-                    // Sleep if caught up to tip
-                    sleep(Duration::from_secs(1)).await;
+                    sleep(Duration::from_secs(20)).await;
                     continue;
                 }
 

--- a/rust/abacus-base/src/contract_sync/interchain_gas.rs
+++ b/rust/abacus-base/src/contract_sync/interchain_gas.rs
@@ -42,8 +42,8 @@ where
             info!(from = from, "[GasPayments]: resuming indexer from {from}");
 
             loop {
-                sleep(Duration::from_secs(2)).await;
                 indexed_height.set(from.into());
+                sleep(Duration::from_secs(2)).await;
 
                 // Only index blocks considered final.
                 // If there's an error getting the block number, just start the loop over

--- a/rust/abacus-base/src/contract_sync/interchain_gas.rs
+++ b/rust/abacus-base/src/contract_sync/interchain_gas.rs
@@ -43,7 +43,7 @@ where
 
             loop {
                 indexed_height.set(from.into());
-                sleep(Duration::from_secs(2)).await;
+                sleep(Duration::from_secs(5)).await;
 
                 // Only index blocks considered final.
                 // If there's an error getting the block number, just start the loop over
@@ -55,7 +55,7 @@ where
                 if tip <= from {
                     // Sleep if caught up to tip
                     debug!(tip=?tip, from=?from, "[GasPayments]: caught up to tip, waiting for new block");
-                    sleep(Duration::from_secs(20)).await;
+                    sleep(Duration::from_secs(10)).await;
                     continue;
                 }
 

--- a/rust/abacus-base/src/contract_sync/outbox.rs
+++ b/rust/abacus-base/src/contract_sync/outbox.rs
@@ -463,7 +463,7 @@ mod test {
             );
 
             let sync_task = contract_sync.sync_outbox_messages();
-            let test_pass_fut = timeout(Duration::from_secs(30), async move {
+            let test_pass_fut = timeout(Duration::from_secs(90), async move {
                 let mut interval = interval(Duration::from_millis(20));
                 loop {
                     if abacus_db.message_by_leaf_index(0).expect("!db").is_some()

--- a/rust/abacus-base/src/contract_sync/outbox.rs
+++ b/rust/abacus-base/src/contract_sync/outbox.rs
@@ -88,8 +88,8 @@ where
             info!(from = from, "[Messages]: resuming indexer from latest valid message range start block");
 
             loop {
-                sleep(Duration::from_secs(2)).await;
                 indexed_height.set(from as i64);
+                sleep(Duration::from_secs(2)).await;
 
                 // Only index blocks considered final.
                 // If there's an error getting the block number, just start the loop over

--- a/rust/abacus-base/src/contract_sync/outbox.rs
+++ b/rust/abacus-base/src/contract_sync/outbox.rs
@@ -98,9 +98,8 @@ where
                 } else {
                     continue;
                 };
-                if tip.saturating_sub(chunk_size) / 2 <= from {
-                    // we are within half a chunk of the tip, go ahead and sleep for a little bit
-                    // longer
+                if tip <= from {
+                    // Sleep if caught up to tip
                     sleep(Duration::from_secs(20)).await;
                     continue;
                 }

--- a/rust/abacus-base/src/contract_sync/outbox.rs
+++ b/rust/abacus-base/src/contract_sync/outbox.rs
@@ -88,6 +88,7 @@ where
             info!(from = from, "[Messages]: resuming indexer from latest valid message range start block");
 
             loop {
+                sleep(Duration::from_secs(2)).await;
                 indexed_height.set(from as i64);
 
                 // Only index blocks considered final.
@@ -97,9 +98,10 @@ where
                 } else {
                     continue;
                 };
-                if tip <= from {
-                    // Sleep if caught up to tip
-                    sleep(Duration::from_secs(1)).await;
+                if tip.saturating_sub(chunk_size) / 2 <= from {
+                    // we are within half a chunk of the tip, go ahead and sleep for a little bit
+                    // longer
+                    sleep(Duration::from_secs(20)).await;
                     continue;
                 }
 

--- a/rust/abacus-base/src/contract_sync/outbox.rs
+++ b/rust/abacus-base/src/contract_sync/outbox.rs
@@ -89,7 +89,7 @@ where
 
             loop {
                 indexed_height.set(from as i64);
-                sleep(Duration::from_secs(2)).await;
+                sleep(Duration::from_secs(5)).await;
 
                 // Only index blocks considered final.
                 // If there's an error getting the block number, just start the loop over
@@ -100,7 +100,7 @@ where
                 };
                 if tip <= from {
                     // Sleep if caught up to tip
-                    sleep(Duration::from_secs(20)).await;
+                    sleep(Duration::from_secs(10)).await;
                     continue;
                 }
 

--- a/rust/abacus-base/src/settings/chains.rs
+++ b/rust/abacus-base/src/settings/chains.rs
@@ -1,4 +1,3 @@
-use ethers::abi::AbiEncode;
 use ethers::signers::Signer;
 use eyre::Context;
 use serde::Deserialize;
@@ -133,7 +132,7 @@ impl<T> ChainSetup<T> {
         let address = match &self.chain {
             ChainConf::Ethereum(_) => "0x0000000000000000000000000000000000000000",
         };
-        self.build(&address, None, metrics, metrics_conf, builder)
+        self.build(address, None, metrics, metrics_conf, builder)
             .await
             .context("Building provider")
     }

--- a/rust/abacus-base/src/settings/chains.rs
+++ b/rust/abacus-base/src/settings/chains.rs
@@ -131,10 +131,11 @@ impl<T> ChainSetup<T> {
         };
 
         let address = match &self.chain {
-            ChainConf::Ethereum(_) => ethers::types::Address::zero().encode_hex(),
+            ChainConf::Ethereum(_) => "0x0000000000000000000000000000000000000000",
         };
         self.build(&address, None, metrics, metrics_conf, builder)
             .await
+            .context("Building provider")
     }
 
     async fn build<B: MakeableWithProvider + Sync>(

--- a/rust/agents/scraper/src/scraper/mod.rs
+++ b/rust/agents/scraper/src/scraper/mod.rs
@@ -346,7 +346,7 @@ impl SqlChainScraper {
             } else {
                 continue;
             };
-            if tip / 2 <= from {
+            if tip <= from {
                 // Sleep if caught up to tip
                 sleep(Duration::from_secs(20)).await;
                 continue;

--- a/rust/agents/scraper/src/scraper/mod.rs
+++ b/rust/agents/scraper/src/scraper/mod.rs
@@ -337,9 +337,9 @@ impl SqlChainScraper {
         info!(from, chunk_size, chain_name, "Resuming chain sync");
 
         loop {
-            sleep(Duration::from_secs(2)).await;
             indexed_message_height.set(from as i64);
             indexed_deliveries_height.set(from as i64);
+            sleep(Duration::from_secs(2)).await;
 
             let tip = if let Ok(num) = self.get_finalized_block_number().await {
                 num

--- a/rust/agents/scraper/src/scraper/mod.rs
+++ b/rust/agents/scraper/src/scraper/mod.rs
@@ -346,9 +346,8 @@ impl SqlChainScraper {
             } else {
                 continue;
             };
-            if tip.saturating_sub(chunk_size) / 2 <= from {
-                // we are within half a chunk of the tip, go ahead and sleep for a little bit
-                // longer
+            if tip / 2 <= from {
+                // Sleep if caught up to tip
                 sleep(Duration::from_secs(20)).await;
                 continue;
             }

--- a/rust/agents/scraper/src/scraper/mod.rs
+++ b/rust/agents/scraper/src/scraper/mod.rs
@@ -339,7 +339,7 @@ impl SqlChainScraper {
         loop {
             indexed_message_height.set(from as i64);
             indexed_deliveries_height.set(from as i64);
-            sleep(Duration::from_secs(2)).await;
+            sleep(Duration::from_secs(5)).await;
 
             let tip = if let Ok(num) = self.get_finalized_block_number().await {
                 num
@@ -348,7 +348,7 @@ impl SqlChainScraper {
             };
             if tip <= from {
                 // Sleep if caught up to tip
-                sleep(Duration::from_secs(20)).await;
+                sleep(Duration::from_secs(10)).await;
                 continue;
             }
 

--- a/rust/agents/scraper/src/scraper/mod.rs
+++ b/rust/agents/scraper/src/scraper/mod.rs
@@ -337,6 +337,7 @@ impl SqlChainScraper {
         info!(from, chunk_size, chain_name, "Resuming chain sync");
 
         loop {
+            sleep(Duration::from_secs(2)).await;
             indexed_message_height.set(from as i64);
             indexed_deliveries_height.set(from as i64);
 
@@ -345,8 +346,10 @@ impl SqlChainScraper {
             } else {
                 continue;
             };
-            if tip <= from {
-                sleep(Duration::from_secs(1)).await;
+            if tip.saturating_sub(chunk_size) / 2 <= from {
+                // we are within half a chunk of the tip, go ahead and sleep for a little bit
+                // longer
+                sleep(Duration::from_secs(20)).await;
                 continue;
             }
 


### PR DESCRIPTION
### Description

* Adds a sleep to the indexing loops to reduce RPC calls
* Significantly increases the sleep duration when caught up

### Drive-by changes

None

### Related issues


### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Manual
E2E Test
