### PR TITLE
Changes to kathy and key funder to spend less on eth

### DIFF
--- a/typescript/infra/config/environments/mainnet/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet/helloworld.ts
@@ -24,6 +24,7 @@ export const abacus: HelloWorldConfig<MainnetChains> = {
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
     connectionType: ConnectionType.Http,
+    cycleBetweenEthereumMessages: 3, // Skip 3 cycles of Ethereum, i.e. send/receive Ethereum messages once a day.
   },
 };
 

--- a/typescript/infra/helm/key-funder/templates/cron-job.yaml
+++ b/typescript/infra/helm/key-funder/templates/cron-job.yaml
@@ -34,6 +34,10 @@ spec:
             - --connection-type
             - {{ .Values.abacus.connectionType }}
 {{- end }}
+{{- if .Values.abacus.cyclesBetweenEthereumMessages }}
+            - --cycles-between-ethereum-messages
+            - {{ .Values.abacus.cyclesBetweenEthereumMessages }}
+{{- end }}
             env:
             - name: PROMETHEUS_PUSH_GATEWAY
               value: {{ .Values.infra.prometheusPushGateway }}

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -59,8 +59,8 @@ const walletBalanceGauge = new Gauge({
 });
 metricsRegister.registerMetric(walletBalanceGauge);
 
-// Min delta is 1/10 of the desired balance
-const MIN_DELTA_NUMERATOR = ethers.BigNumber.from(1);
+// Min delta is 50% of the desired balance
+const MIN_DELTA_NUMERATOR = ethers.BigNumber.from(5);
 const MIN_DELTA_DENOMINATOR = ethers.BigNumber.from(10);
 
 const desiredBalancePerChain: CompleteChainMap<string> = {

--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -243,8 +243,9 @@ async function main(): Promise<boolean> {
   // Use to move to the next message in a cycle.
   // Returns true if we should stop sending messages.
   const nextMessage = async () => {
-    // Print stats once every cycle through the pairings.
+    // If it's the end of a cycle...
     if (cycleMessageCount == pairings.length - 1) {
+      // Print stats
       for (const [origin, destinationStats] of Object.entries(
         await app.stats(),
       )) {
@@ -266,11 +267,12 @@ async function main(): Promise<boolean> {
         // Return true to signify messages should stop being sent.
         return true;
       }
+    } else {
+      cycleMessageCount++;
     }
 
     // Move on to the next index
     currentPairingIndex = (currentPairingIndex + 1) % pairings.length;
-    cycleMessageCount++;
     // Return false to signify messages should continue to be sent.
     return false;
   };

--- a/typescript/infra/src/config/funding.ts
+++ b/typescript/infra/src/config/funding.ts
@@ -16,6 +16,7 @@ export interface KeyFunderConfig {
   namespace: string;
   contextFundingFrom: Contexts;
   contextsAndRolesToFund: ContextAndRolesMap;
+  cyclesBetweenEthereumMessages?: number;
   prometheusPushGateway: string;
   connectionType: ConnectionType.Http | ConnectionType.HttpQuorum;
 }

--- a/typescript/infra/src/config/helloworld.ts
+++ b/typescript/infra/src/config/helloworld.ts
@@ -30,6 +30,8 @@ export interface HelloWorldKathyConfig<Chain extends ChainName> {
 
   // Whether to use a single HTTP provider or a quorum of HTTP providers
   connectionType: ConnectionType.Http | ConnectionType.HttpQuorum;
+  // How many cycles to skip between a cycles that send messages to/from Ethereum. Defaults to 0.
+  cycleBetweenEthereumMessages?: number;
 }
 
 export interface HelloWorldConfig<Chain extends ChainName> {

--- a/typescript/infra/src/funding/deploy-key-funder.ts
+++ b/typescript/infra/src/funding/deploy-key-funder.ts
@@ -50,6 +50,8 @@ function getKeyFunderHelmValues<Chain extends ChainName>(
       chains: agentConfig.contextChainNames,
       contextFundingFrom: keyFunderConfig.contextFundingFrom,
       contextsAndRolesToFund: keyFunderConfig.contextsAndRolesToFund,
+      cyclesBetweenEthereumMessages:
+        keyFunderConfig.cyclesBetweenEthereumMessages,
       connectionType: keyFunderConfig.connectionType,
     },
     image: {


### PR DESCRIPTION
### Description

* Key funder now only tops up when the balance of a key is at 50% of what it should be (previously was 10%)
* Kathy now has `--cycles-between-ethereum-messages`. If it's 1, then every other full cycle messages to/from Ethereum are skipped. For mainnet, it's configured to 3, so at a pace of 1 cycle every 6 hours, this results in 1 cycle per day that sends messages to/from Ethereum

A bit clunky, but I figure Kathy is already a bit clunky 😄 

### Drive-by changes

None

### Related issues

- Fixes #1245

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

No - but to use `--cycles-between-ethereum-messages` the infra in this commit is needed


### Testing

_What kind of testing have these changes undergone?_

None (👀)
