### PR TITLE
Check ACM address in HyperlaneRouterChecker

### DIFF
--- a/typescript/sdk/src/deploy/router/HyperlaneRouterChecker.ts
+++ b/typescript/sdk/src/deploy/router/HyperlaneRouterChecker.ts
@@ -24,6 +24,7 @@ export class HyperlaneRouterChecker<
   async checkChain(chain: Chain): Promise<void> {
     await this.checkEnrolledRouters(chain);
     await this.checkOwnership(chain);
+    await this.checkConnectionManager(chain);
   }
 
   async checkEnrolledRouters(chain: Chain): Promise<void> {
@@ -36,6 +37,18 @@ export class HyperlaneRouterChecker<
         const address = await router.routers(remoteChainId);
         utils.assert(address === utils.addressToBytes32(remoteRouter.address));
       }),
+    );
+  }
+
+  async checkConnectionManager(chain: Chain): Promise<void> {
+    const router = this.app.getContracts(chain).router;
+    const expectedConnectionManager = this.configMap[chain].connectionManager;
+
+    const routerConnectionManager = await router.abacusConnectionManager();
+
+    utils.assert(
+      expectedConnectionManager === routerConnectionManager,
+      `Incorrect ConnectionManager for ${chain}. Expected ${expectedConnectionManager}, found ${routerConnectionManager}`,
     );
   }
 


### PR DESCRIPTION
### Description

Adds a check for the ACM address in the HyperlaneRouterChecker. Noticed a discrepancy in ACM addresses

### Drive-by changes

n/a

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Manual - tried running it and it worked correctly
