### PR TITLE
Proper RPC Useage fix

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1204,10 +1204,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "difference"
-version = "2.0.0"
+name = "difflib"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -1302,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "downcast"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dunce"
@@ -1740,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
 ]
@@ -1780,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "1.2.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "funty"
@@ -2603,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.10.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab571328afa78ae322493cacca3efac6a0f2e0a67305b4df31fd439ef129ac0"
+checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -2618,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.10.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e25b214433f669161f414959594216d8e6ba83b6679d3db96899c0b4639033"
+checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -3313,12 +3313,13 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "predicates"
-version = "1.0.8"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
+checksum = "ed6bd09a7f7e68f3f0bf710fb7ab9c4615a488b58b5f653382a687701e458c92"
 dependencies = [
- "difference",
+ "difflib",
  "float-cmp",
+ "itertools",
  "normalize-line-endings",
  "predicates-core",
  "regex",

--- a/rust/abacus-base/Cargo.toml
+++ b/rust/abacus-base/Cargo.toml
@@ -21,7 +21,7 @@ tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3", features = ["json"] }
 rocksdb = "0.18"
-mockall = "0.10.2"
+mockall = "0.11"
 
 backtrace = { version = "0.3", optional = true }
 backtrace-oneline = { path = "../utils/backtrace-oneline", optional = true }

--- a/rust/abacus-base/src/agent.rs
+++ b/rust/abacus-base/src/agent.rs
@@ -132,8 +132,6 @@ pub async fn agent_main<A: BaseAgent>() -> Result<()> {
     crate::oneline_eyre::install()?;
     #[cfg(all(feature = "color_eyre", not(feature = "oneline-errors")))]
     color_eyre::install()?;
-    #[cfg(not(any(feature = "color-eyre", feature = "oneline-eyre")))]
-    eyre::install()?;
 
     let settings = A::Settings::new().map_err(|e| e.into())?;
     let core_settings: &AgentSettings = settings.as_ref();

--- a/rust/abacus-base/src/contract_sync/cursor.rs
+++ b/rust/abacus-base/src/contract_sync/cursor.rs
@@ -7,7 +7,7 @@ use tokio::time::sleep;
 use abacus_core::{Indexer, SyncBlockRangeCursor};
 
 /// Tool for handling the logic of what the next block range that should be
-/// queried is and also handing rate limiting. Rate limiting is automatically
+/// queried is and also handling rate limiting. Rate limiting is automatically
 /// performed by `next_range`.
 pub struct RateLimitedSyncBlockRangeCursor<I> {
     indexer: I,

--- a/rust/abacus-base/src/contract_sync/cursor.rs
+++ b/rust/abacus-base/src/contract_sync/cursor.rs
@@ -1,0 +1,92 @@
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use eyre::Result;
+use tokio::time::sleep;
+
+use abacus_core::{Indexer, SyncBlockRangeCursor};
+
+/// Tool for handling the logic of what the next block range that should be
+/// queried is and also handing rate limiting. Rate limiting is automatically
+/// performed by `next_range`.
+pub struct RateLimitedSyncBlockRangeCursor<I> {
+    indexer: I,
+    tip: u32,
+    last_tip_update: Instant,
+    chunk_size: u32,
+    from: u32,
+}
+
+impl<I> RateLimitedSyncBlockRangeCursor<I>
+where
+    I: Indexer,
+{
+    /// Construct a new contract sync helper.
+    pub async fn new(indexer: I, chunk_size: u32, initial_height: u32) -> Result<Self> {
+        let tip = indexer.get_finalized_block_number().await?;
+        Ok(Self {
+            indexer,
+            tip,
+            chunk_size,
+            last_tip_update: Instant::now(),
+            from: initial_height,
+        })
+    }
+
+    /// Wait based on how close we are to the tip and update the tip,
+    /// i.e. the highest block we may scrape.
+    async fn rate_limit(&mut self) -> Result<()> {
+        if self.from + self.chunk_size < self.tip {
+            // If doing the full chunk wouldn't exceed the already known tip,
+            // we don't necessarily need to fetch the new tip. Sleep a tiny bit
+            // so that we can catch up to the tip relatively quickly.
+            sleep(Duration::from_secs(1)).await;
+            Ok(())
+        } else {
+            // We are close to the tip.
+            if self.last_tip_update.elapsed() < Duration::from_secs(30) {
+                // Sleep a little longer because we have caught up.
+                sleep(Duration::from_secs(10)).await;
+            } else {
+                // We are probably not caught up yet. This would happen if we
+                // started really far behind so now it is very likely the tip
+                // has moved a significant distance. We don't want to wait in
+                // this case any more than we normally would.
+                sleep(Duration::from_secs(1)).await;
+            }
+
+            match self.indexer.get_finalized_block_number().await {
+                Ok(tip) => {
+                    // we retrieved a new tip value, go ahead and update.
+                    self.last_tip_update = Instant::now();
+                    self.tip = tip;
+                    Ok(())
+                }
+                Err(e) => {
+                    // we are failing to make a basic query, we should wait before retrying.
+                    sleep(Duration::from_secs(10)).await;
+                    Err(e)
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl<I: Indexer> SyncBlockRangeCursor for RateLimitedSyncBlockRangeCursor<I> {
+    fn current_position(&self) -> u32 {
+        self.from
+    }
+
+    async fn next_range(&mut self) -> Result<(u32, u32)> {
+        self.rate_limit().await?;
+        let to = u32::min(self.tip, self.from + self.chunk_size);
+        let from = to.saturating_sub(self.chunk_size);
+        self.from = to + 1;
+        Ok((from, to))
+    }
+
+    fn backtrack(&mut self, start_from: u32) {
+        self.from = u32::min(start_from, self.from);
+    }
+}

--- a/rust/abacus-base/src/contract_sync/interchain_gas.rs
+++ b/rust/abacus-base/src/contract_sync/interchain_gas.rs
@@ -1,11 +1,10 @@
 use tokio::task::JoinHandle;
 use tracing::{info, info_span, instrument::Instrumented, Instrument};
 
-use abacus_core::InterchainGasPaymasterIndexer;
+use abacus_core::{InterchainGasPaymasterIndexer, SyncBlockRangeCursor};
 
-use crate::{
-    contract_sync::schema::InterchainGasPaymasterContractSyncDB, ContractSync, SyncBlockRangeCursor,
-};
+use crate::contract_sync::cursor::RateLimitedSyncBlockRangeCursor;
+use crate::{contract_sync::schema::InterchainGasPaymasterContractSyncDB, ContractSync};
 
 const GAS_PAYMENTS_LABEL: &str = "gas_payments";
 
@@ -35,7 +34,7 @@ where
             let initial_height = db
                 .retrieve_latest_indexed_gas_payment_block()
                 .map_or(config_initial_height, |b| b + 1);
-            SyncBlockRangeCursor::new(
+            RateLimitedSyncBlockRangeCursor::new(
                 indexer.clone(),
                 self.index_settings.chunk_size(),
                 initial_height,

--- a/rust/abacus-base/src/contract_sync/interchain_gas.rs
+++ b/rust/abacus-base/src/contract_sync/interchain_gas.rs
@@ -50,6 +50,7 @@ where
             indexed_height.set(start_block as i64);
 
             loop {
+                let start_block = sync_helper.current_position();
                 let Ok((from, to)) = sync_helper.next_range().await else { continue };
 
                 let gas_payments = indexer.fetch_gas_payments(from, to).await?;
@@ -72,7 +73,7 @@ where
 
                 stored_messages.inc_by(new_payments_processed);
 
-                db.store_latest_indexed_gas_payment_block(to)?;
+                db.store_latest_indexed_gas_payment_block(start_block)?;
                 indexed_height.set(to as i64);
             }
         })

--- a/rust/abacus-base/src/contract_sync/interchain_gas.rs
+++ b/rust/abacus-base/src/contract_sync/interchain_gas.rs
@@ -30,7 +30,7 @@ where
             .stored_events
             .with_label_values(&[GAS_PAYMENTS_LABEL, &self.chain_name]);
 
-        let mut sync_helper = {
+        let sync_helper = {
             let config_initial_height = self.index_settings.from();
             let initial_height = db
                 .retrieve_latest_indexed_gas_payment_block()
@@ -43,6 +43,8 @@ where
         };
 
         tokio::spawn(async move {
+            let mut sync_helper = sync_helper.await?;
+
             let start_block = sync_helper.current_position();
             info!(from = start_block, "[GasPayments]: resuming indexer");
             indexed_height.set(start_block as i64);

--- a/rust/abacus-base/src/contract_sync/interchain_gas.rs
+++ b/rust/abacus-base/src/contract_sync/interchain_gas.rs
@@ -49,9 +49,7 @@ where
             indexed_height.set(start_block as i64);
 
             loop {
-                let start_block = cursor.current_position();
                 let Ok((from, to)) = cursor.next_range().await else { continue };
-
                 let gas_payments = indexer.fetch_gas_payments(from, to).await?;
 
                 info!(
@@ -72,7 +70,7 @@ where
 
                 stored_messages.inc_by(new_payments_processed);
 
-                db.store_latest_indexed_gas_payment_block(start_block)?;
+                db.store_latest_indexed_gas_payment_block(from)?;
                 indexed_height.set(to as i64);
             }
         })

--- a/rust/abacus-base/src/contract_sync/mod.rs
+++ b/rust/abacus-base/src/contract_sync/mod.rs
@@ -1,19 +1,15 @@
 // TODO: Reapply tip buffer
 // TODO: Reapply metrics
 
-use std::time::{Duration, Instant};
-
-use eyre::Result;
-use tokio::time::sleep;
-
 use abacus_core::db::AbacusDB;
-use abacus_core::Indexer;
+pub use cursor::*;
 pub use interchain_gas::*;
 pub use metrics::ContractSyncMetrics;
 pub use outbox::*;
 
 use crate::settings::IndexSettings;
 
+mod cursor;
 mod interchain_gas;
 /// Tools for working with message continuity.
 pub mod last_message;
@@ -50,107 +46,6 @@ impl<I> ContractSync<I> {
             indexer,
             index_settings,
             metrics,
-        }
-    }
-}
-
-/// Tool for handling the logic of what the next block range that should be
-/// queried is and also handing rate limiting. Rate limiting is automatically
-/// performed by `next_range`.
-pub struct SyncBlockRangeCursor<I> {
-    indexer: I,
-    tip: u32,
-    last_tip_update: Instant,
-    chunk_size: u32,
-    from: u32,
-}
-
-impl<I> SyncBlockRangeCursor<I>
-where
-    I: Indexer,
-{
-    /// Construct a new contract sync helper.
-    pub async fn new(indexer: I, chunk_size: u32, initial_height: u32) -> Result<Self> {
-        let tip = indexer.get_finalized_block_number().await?;
-        Ok(Self {
-            indexer,
-            tip,
-            chunk_size,
-            last_tip_update: Instant::now(),
-            from: initial_height,
-        })
-    }
-
-    /// Returns the current `from` position of the scraper. Note that
-    /// `next_range` may return a `from` value that is lower than this in order
-    /// to have some overlap.
-    pub fn current_position(&self) -> u32 {
-        self.from
-    }
-
-    /// Get the next block range `(from, to)` which should be fetched (this
-    /// returns an inclusive range such as (0,50), (51,100), ...). This
-    /// will automatically rate limit based on how far we are from the
-    /// highest block we can scrape according to
-    /// `get_finalized_block_number`.
-    ///
-    /// In reality this will often return a from value that overlaps with the
-    /// previous range to help ensure that we scrape everything even if the
-    /// provider failed to respond in full previously.
-    ///
-    /// This assumes the caller will call next_range again automatically on Err,
-    /// but it returns the error to allow for tailored logging or different end
-    /// cases.
-    pub async fn next_range(&mut self) -> Result<(u32, u32)> {
-        self.rate_limit().await?;
-        let to = u32::min(self.tip, self.from + self.chunk_size);
-        let from = to.saturating_sub(self.chunk_size);
-        self.from = to + 1;
-        Ok((from, to))
-    }
-
-    /// If there was an issue when a range of data was fetched, this rolls back
-    /// so the next range fetched will be from `start_from`. Note that it is a
-    /// no-op if a later block value is specified.
-    pub fn backtrack(&mut self, start_from: u32) {
-        self.from = u32::min(start_from, self.from);
-    }
-
-    /// Wait based on how close we are to the tip and update the tip,
-    /// i.e. the highest block we may scrape.
-    async fn rate_limit(&mut self) -> Result<()> {
-        if self.from + self.chunk_size < self.tip {
-            // If doing the full chunk wouldn't exceed the already known tip,
-            // we don't necessarily need to fetch the new tip. Sleep a tiny bit
-            // so that we can catch up to the tip relatively quickly.
-            sleep(Duration::from_secs(1)).await;
-            Ok(())
-        } else {
-            // We are close to the tip.
-            if self.last_tip_update.elapsed() < Duration::from_secs(30) {
-                // Sleep a little longer because we have caught up.
-                sleep(Duration::from_secs(10)).await;
-            } else {
-                // We are probably not caught up yet. This would happen if we
-                // started really far behind so now it is very likely the tip
-                // has moved a significant distance. We don't want to wait in
-                // this case any more than we normally would.
-                sleep(Duration::from_secs(1)).await;
-            }
-
-            match self.indexer.get_finalized_block_number().await {
-                Ok(tip) => {
-                    // we retrieved a new tip value, go ahead and update.
-                    self.last_tip_update = Instant::now();
-                    self.tip = tip;
-                    Ok(())
-                }
-                Err(e) => {
-                    // we are failing to make a basic query, we should wait before retrying.
-                    sleep(Duration::from_secs(10)).await;
-                    Err(e)
-                }
-            }
         }
     }
 }

--- a/rust/abacus-base/src/contract_sync/mod.rs
+++ b/rust/abacus-base/src/contract_sync/mod.rs
@@ -57,7 +57,7 @@ impl<I> ContractSync<I> {
 /// Tool for handling the logic of what the next block range that should be
 /// queried is and also handing rate limiting. Rate limiting is automatically
 /// performed by `next_range`.
-pub struct ContractSyncHelper<I> {
+pub struct SyncBlockRangeCursor<I> {
     indexer: I,
     tip: u32,
     last_tip_update: Instant,
@@ -65,7 +65,7 @@ pub struct ContractSyncHelper<I> {
     from: u32,
 }
 
-impl<I> ContractSyncHelper<I>
+impl<I> SyncBlockRangeCursor<I>
 where
     I: Indexer,
 {

--- a/rust/abacus-base/src/contract_sync/mod.rs
+++ b/rust/abacus-base/src/contract_sync/mod.rs
@@ -1,7 +1,7 @@
 // TODO: Reapply tip buffer
 // TODO: Reapply metrics
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use eyre::Result;
 use tokio::time::sleep;
@@ -58,7 +58,9 @@ impl<I> ContractSync<I> {
 /// queried is and also handing rate limiting. Rate limiting is automatically
 /// performed by `next_range`.
 pub struct ContractSyncHelper<I> {
-    indexer: I,ˆ
+    indexer: I,
+    tip: u32,
+    last_tip_update: Instant,
     chunk_size: u32,
     from: u32,
 }
@@ -68,12 +70,15 @@ where
     I: Indexer,
 {
     /// Construct a new contract sync helper.
-    pub fn new(indexer: I, chunk_size: u32, initial_height: u32) -> Self {
-        Self {
+    pub async fn new(indexer: I, chunk_size: u32, initial_height: u32) -> Result<Self> {
+        let tip = indexer.get_finalized_block_number().await?;
+        Ok(Self {
             indexer,
+            tip,
             chunk_size,
+            last_tip_update: Instant::now(),
             from: initial_height,
-        }
+        })
     }
 
     /// Returns the current `from` position of the scraper. Note that
@@ -97,8 +102,8 @@ where
     /// but it returns the error to allow for tailored logging or different end
     /// cases.
     pub async fn next_range(&mut self) -> Result<(u32, u32)> {
-        let tip = self.rate_limit().await?;
-        let to = u32::min(tip, self.from + self.chunk_size);
+        self.rate_limit().await?;
+        let to = u32::min(self.tip, self.from + self.chunk_size);
         let from = to.saturating_sub(self.chunk_size);
         self.from = to + 1;
         Ok((from, to))
@@ -111,23 +116,41 @@ where
         self.from = u32::min(start_from, self.from);
     }
 
-    /// Wait based on how close we are to the tip and then return the new tip,
+    /// Wait based on how close we are to the tip and update the tip,
     /// i.e. the highest block we may scrape.
-    async fn rate_limit(&self) -> Result<u32> {
-        let tip = match self.indexer.get_finalized_block_number().await {
-            Ok(tip) => tip,
-            Err(e) => {
-                // we are failing to make a basic query, we should wait before retrying.
-                sleep(Duration::from_secs(10)).await;
-                return Err(e);
-            }
-        };
-        if self.from + self.chunk_size < tip {
+    async fn rate_limit(&mut self) -> Result<()> {
+        if self.from + self.chunk_size < self.tip {
+            // If doing the full chunk wouldn't exceed the already known tip,
+            // we don't necessarily need to fetch the new tip. Sleep a tiny bit
+            // so that we can catch up to the tip relatively quickly.
             sleep(Duration::from_secs(1)).await;
-            Ok(tip)
+            Ok(())
         } else {
-            sleep(Duration::from_secs(10)).await;
-            self.indexer.get_finalized_block_number().await
+            // We are close to the tip.
+            if (Instant::now() - self.last_tip_update) < Duration::from_secs(30) {
+                // Sleep a little longer because we have caught up.
+                sleep(Duration::from_secs(10)).await;
+            } else {
+                // We are probably not caught up yet. This would happen if we
+                // started really far behind so now it is very likely the tip
+                // has moved a significant distance. We don't want to wait in
+                // this case any more than we normally would.
+                sleep(Duration::from_secs(1)).await;
+            }
+
+            match self.indexer.get_finalized_block_number().await {
+                Ok(tip) => {
+                    // we retrieved a new tip value, go ahead and update.
+                    self.last_tip_update = Instant::now();
+                    self.tip = tip;
+                    Ok(())
+                }
+                Err(e) => {
+                    // we are failing to make a basic query, we should wait before retrying.
+                    sleep(Duration::from_secs(10)).await;
+                    Err(e)
+                }
+            }
         }
     }
 }

--- a/rust/abacus-base/src/contract_sync/mod.rs
+++ b/rust/abacus-base/src/contract_sync/mod.rs
@@ -127,7 +127,7 @@ where
             Ok(())
         } else {
             // We are close to the tip.
-            if (Instant::now() - self.last_tip_update) < Duration::from_secs(30) {
+            if self.last_tip_update.elapsed() < Duration::from_secs(30) {
                 // Sleep a little longer because we have caught up.
                 sleep(Duration::from_secs(10)).await;
             } else {

--- a/rust/abacus-base/src/contract_sync/outbox.rs
+++ b/rust/abacus-base/src/contract_sync/outbox.rs
@@ -403,6 +403,8 @@ mod test {
                 mock_cursor.expect__current_position().returning(|| 161);
                 mock_cursor.expect__next_range().returning(|| {
                     Box::pin(async move {
+                        // this sleep should be longer than the test timeout since we don't actually
+                        // want to yield any more values at this point.
                         sleep(Duration::from_secs(100)).await;
                         Ok((161, 161))
                     })

--- a/rust/abacus-base/src/contract_sync/outbox.rs
+++ b/rust/abacus-base/src/contract_sync/outbox.rs
@@ -108,7 +108,13 @@ where
 
             loop {
                 let start_block = cursor.current_position();
-                let Ok((from, to)) = cursor.next_range().await else { continue };
+                let (from, to) = match cursor.next_range().await {
+                    Ok(range) => range,
+                    Err(err) => {
+                        warn!(error = %err, "[Messages]: failed to get next block range");
+                        continue;
+                    }
+                };
 
                 let mut sorted_messages: Vec<_> = indexer
                     .fetch_sorted_messages(from, to)

--- a/rust/abacus-base/src/contract_sync/outbox.rs
+++ b/rust/abacus-base/src/contract_sync/outbox.rs
@@ -36,7 +36,7 @@ where
         let message_leaf_index = self.metrics.message_leaf_index.clone();
         let chain_name = self.chain_name.clone();
 
-        let mut sync_helper = {
+        let sync_helper = {
             let config_initial_height = self.index_settings.from();
             let initial_height = db
                 .retrieve_latest_valid_message_range_start_block()
@@ -84,6 +84,8 @@ where
         //    Note this means we only handle this case upon observing messages in some range [C,D]
         //    that indicate a previously indexed range may have missed some messages.
         tokio::spawn(async move {
+            let mut sync_helper = sync_helper.await?;
+
             let start_block = sync_helper.current_position();
             let mut last_valid_range_start_block = start_block;
             info!(from = start_block, "[Messages]: resuming indexer from latest valid message range start block");

--- a/rust/abacus-base/src/lib.rs
+++ b/rust/abacus-base/src/lib.rs
@@ -5,7 +5,8 @@
 //! Implementations of the `Outbox` and `Inbox` traits on different chains
 //! ought to live here.
 
-#![forbid(unsafe_code)]
+// Forbid unsafe code outside of tests
+#![cfg_attr(not(test), forbid(unsafe_code))]
 #![warn(missing_docs)]
 #![warn(unused_extern_crates)]
 

--- a/rust/abacus-core/src/traits/cursor.rs
+++ b/rust/abacus-core/src/traits/cursor.rs
@@ -1,9 +1,11 @@
 use async_trait::async_trait;
+use auto_impl::auto_impl;
 use eyre::Result;
 
 /// Tool for handling the logic of what the next block range that should be
 /// queried and may perform rate limiting on `next_range` queries.
 #[async_trait]
+#[auto_impl(Box)]
 pub trait SyncBlockRangeCursor {
     /// Returns the current `from` position of the scraper. Note that
     /// `next_range` may return a `from` value that is lower than this in order

--- a/rust/abacus-core/src/traits/cursor.rs
+++ b/rust/abacus-core/src/traits/cursor.rs
@@ -1,0 +1,32 @@
+use async_trait::async_trait;
+use eyre::Result;
+
+/// Tool for handling the logic of what the next block range that should be
+/// queried and may perform rate limiting on `next_range` queries.
+#[async_trait]
+pub trait SyncBlockRangeCursor {
+    /// Returns the current `from` position of the scraper. Note that
+    /// `next_range` may return a `from` value that is lower than this in order
+    /// to have some overlap.
+    fn current_position(&self) -> u32;
+
+    /// Get the next block range `(from, to)` which should be fetched (this
+    /// returns an inclusive range such as (0,50), (51,100), ...). This
+    /// will automatically rate limit based on how far we are from the
+    /// highest block we can scrape according to
+    /// `get_finalized_block_number`.
+    ///
+    /// In reality this will often return a from value that overlaps with the
+    /// previous range to help ensure that we scrape everything even if the
+    /// provider failed to respond in full previously.
+    ///
+    /// This assumes the caller will call next_range again automatically on Err,
+    /// but it returns the error to allow for tailored logging or different end
+    /// cases.
+    async fn next_range(&mut self) -> Result<(u32, u32)>;
+
+    /// If there was an issue when a range of data was fetched, this rolls back
+    /// so the next range fetched will be from `start_from`. Note that it is a
+    /// no-op if a later block value is specified.
+    fn backtrack(&mut self, start_from: u32);
+}

--- a/rust/abacus-core/src/traits/mod.rs
+++ b/rust/abacus-core/src/traits/mod.rs
@@ -13,6 +13,7 @@ use ethers::{
 use eyre::Result;
 
 pub use common::*;
+pub use cursor::*;
 pub use encode::*;
 pub use inbox::*;
 pub use indexer::*;
@@ -24,6 +25,7 @@ pub use validator_manager::*;
 use crate::{db::DbError, utils::domain_hash, AbacusError};
 
 mod common;
+mod cursor;
 mod encode;
 mod inbox;
 mod indexer;

--- a/rust/abacus-test/Cargo.toml
+++ b/rust/abacus-test/Cargo.toml
@@ -12,7 +12,7 @@ thiserror = { version = "1.0", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 futures-util = "0.3"
 eyre = "0.6"
-mockall = "0.10.2"
+mockall = "0.11"
 rand = "0.8.3"
 rocksdb = "0.18"
 tempfile = "3.3"

--- a/rust/abacus-test/src/mocks/cursor.rs
+++ b/rust/abacus-test/src/mocks/cursor.rs
@@ -4,14 +4,13 @@ use abacus_core::SyncBlockRangeCursor;
 use async_trait::async_trait;
 use eyre::Result;
 use mockall::mock;
+use std::future::Future;
 
 mock! {
     pub SyncBlockRangeCursor {
-        pub fn _new(chunk_size: u32, initial_height: u32) -> Result<Self> {}
+        pub fn _next_range(&mut self) -> impl Future<Output=Result<(u32, u32)>> + Send {}
 
         pub fn _current_position(&self) -> u32 {}
-
-        pub fn _next_range(&mut self) -> Result<(u32, u32)> {}
 
         pub fn _backtrack(&mut self, start_from: u32) {}
     }
@@ -24,7 +23,7 @@ impl SyncBlockRangeCursor for MockSyncBlockRangeCursor {
     }
 
     async fn next_range(&mut self) -> Result<(u32, u32)> {
-        self._next_range()
+        self._next_range().await
     }
 
     fn backtrack(&mut self, start_from: u32) {

--- a/rust/abacus-test/src/mocks/cursor.rs
+++ b/rust/abacus-test/src/mocks/cursor.rs
@@ -1,0 +1,33 @@
+#![allow(non_snake_case)]
+
+use abacus_core::SyncBlockRangeCursor;
+use async_trait::async_trait;
+use eyre::Result;
+use mockall::mock;
+
+mock! {
+    pub SyncBlockRangeCursor {
+        pub fn _new(chunk_size: u32, initial_height: u32) -> Result<Self> {}
+
+        pub fn _current_position(&self) -> u32 {}
+
+        pub fn _next_range(&mut self) -> Result<(u32, u32)> {}
+
+        pub fn _backtrack(&mut self, start_from: u32) {}
+    }
+}
+
+#[async_trait]
+impl SyncBlockRangeCursor for MockSyncBlockRangeCursor {
+    fn current_position(&self) -> u32 {
+        self._current_position()
+    }
+
+    async fn next_range(&mut self) -> Result<(u32, u32)> {
+        self._next_range()
+    }
+
+    fn backtrack(&mut self, start_from: u32) {
+        self._backtrack(start_from)
+    }
+}

--- a/rust/abacus-test/src/mocks/mod.rs
+++ b/rust/abacus-test/src/mocks/mod.rs
@@ -7,5 +7,8 @@ pub mod inbox;
 /// Mock indexer
 pub mod indexer;
 
+/// Mock SyncBlockRangeCursor
+pub mod cursor;
+
 pub use indexer::MockIndexer;
 pub use outbox::MockOutboxContract;

--- a/rust/agents/scraper/src/chain_scraper/mod.rs
+++ b/rust/agents/scraper/src/chain_scraper/mod.rs
@@ -88,10 +88,6 @@ impl SqlChainScraper {
         self.remotes.keys().copied()
     }
 
-    pub async fn get_finalized_block_number(&self) -> Result<u32> {
-        self.local.indexer.get_finalized_block_number().await
-    }
-
     /// Sync contract data and other blockchain with the current chain state.
     /// This will create a long-running task that should be spawned.
     pub fn sync(self) -> impl Future<Output = Result<()>> + Send + 'static {

--- a/rust/agents/scraper/src/chain_scraper/sync.rs
+++ b/rust/agents/scraper/src/chain_scraper/sync.rs
@@ -115,7 +115,13 @@ impl Syncer {
         loop {
             debug_assert_eq!(self.local.outbox.local_domain(), self.local_domain());
             let start_block = self.sync_cursor.current_position();
-            let Ok((from, to)) = self.sync_cursor.next_range().await else { continue };
+            let (from, to) = match self.sync_cursor.next_range().await {
+                Ok(range) => range,
+                Err(err) => {
+                    warn!(error = %err, "failed to get next block range");
+                    continue;
+                }
+            };
 
             let (sorted_messages, deliveries) = self.scrape_range(from, to).await?;
 

--- a/rust/agents/scraper/src/chain_scraper/sync.rs
+++ b/rust/agents/scraper/src/chain_scraper/sync.rs
@@ -1,16 +1,15 @@
-use std::cmp::min;
 use std::collections::HashMap;
 use std::ops::Deref;
-use std::time::Duration;
+use std::sync::Arc;
 
+use abacus_base::ContractSyncHelper;
 use ethers::prelude::H256;
 use eyre::Result;
 use prometheus::{IntCounter, IntGauge, IntGaugeVec};
-use tokio::time::sleep;
 use tracing::{debug, info, instrument, warn};
 
 use abacus_base::last_message::validate_message_continuity;
-use abacus_core::{name_from_domain_id, CommittedMessage, ListValidity};
+use abacus_core::{name_from_domain_id, CommittedMessage, ListValidity, OutboxIndexer};
 
 use crate::chain_scraper::{Delivery, RawMsgWithMeta, SqlChainScraper, TxnWithIdAndTime};
 
@@ -30,9 +29,8 @@ pub(super) struct Syncer {
     stored_deliveries: IntCounter,
     missed_messages: IntCounter,
     message_leaf_index: IntGaugeVec,
-    chunk_size: u32,
+    sync_helper: ContractSyncHelper<Arc<dyn OutboxIndexer>>,
 
-    from: u32,
     last_valid_range_start_block: u32,
     last_leaf_index: u32,
 }
@@ -79,9 +77,12 @@ impl Syncer {
         let message_leaf_index = scraper.metrics.message_leaf_index.clone();
 
         let chunk_size = scraper.chunk_size;
-        let from = scraper.cursor.height().await as u32;
-        let last_valid_range_start_block = from;
+        let initial_height = scraper.cursor.height().await as u32;
+        let last_valid_range_start_block = initial_height;
         let last_leaf_index = scraper.last_message_leaf_index().await?.unwrap_or(0);
+
+        let sync_helper =
+            { ContractSyncHelper::new(scraper.local.indexer.clone(), chunk_size, initial_height) };
 
         Ok(Self {
             scraper,
@@ -91,8 +92,7 @@ impl Syncer {
             stored_deliveries,
             missed_messages,
             message_leaf_index,
-            chunk_size,
-            from,
+            sync_helper,
             last_valid_range_start_block,
             last_leaf_index,
         })
@@ -101,25 +101,17 @@ impl Syncer {
     /// Sync contract and other blockchain data with the current chain state.
     #[instrument(skip(self), fields(chain_name = self.chain_name(), chink_size = self.chunk_size))]
     pub async fn run(mut self) -> Result<()> {
-        info!(from = self.from, "Resuming chain sync");
-        self.indexed_message_height.set(self.from as i64);
-        self.indexed_deliveries_height.set(self.from as i64);
+        let start_block = self.sync_helper.current_position();
+        info!(from = start_block, "Resuming chain sync");
+        self.indexed_message_height.set(start_block as i64);
+        self.indexed_deliveries_height.set(start_block as i64);
 
         loop {
-            sleep(Duration::from_secs(5)).await;
-
-            let Ok(tip) = self.get_finalized_block_number().await else {
-                continue;
-            };
-            if tip <= self.from {
-                sleep(Duration::from_secs(10)).await;
-                continue;
-            }
-
-            let to = min(tip, self.from + self.chunk_size);
-            let full_chunk_from = to.checked_sub(self.chunk_size).unwrap_or_default();
             debug_assert_eq!(self.local.outbox.local_domain(), self.local_domain());
-            let (sorted_messages, deliveries) = self.scrape_range(full_chunk_from, to).await?;
+            let start_block = self.sync_helper.current_position();
+            let Ok((from, to)) = self.sync_helper.next_range().await else { continue };
+
+            let (sorted_messages, deliveries) = self.scrape_range(from, to).await?;
 
             let validation = validate_message_continuity(
                 Some(self.last_leaf_index),
@@ -130,18 +122,16 @@ impl Syncer {
                     let max_leaf_index_of_batch =
                         self.record_data(sorted_messages, deliveries).await?;
 
-                    self.cursor.update(full_chunk_from as u64).await;
+                    self.cursor.update(from as u64).await;
                     if let Some(idx) = max_leaf_index_of_batch {
                         self.last_leaf_index = idx;
                     }
-                    self.last_valid_range_start_block = full_chunk_from;
-                    self.from = to + 1;
+                    self.last_valid_range_start_block = from;
                     self.indexed_message_height.set(to as i64);
                     self.indexed_deliveries_height.set(to as i64);
                 }
                 ListValidity::Empty => {
                     let _ = self.record_data(sorted_messages, deliveries).await?;
-                    self.from = to + 1;
                     self.indexed_message_height.set(to as i64);
                     self.indexed_deliveries_height.set(to as i64);
                 }
@@ -149,20 +139,24 @@ impl Syncer {
                     self.missed_messages.inc();
                     warn!(
                         last_leaf_index = self.last_leaf_index,
-                        start_block = self.from,
+                        start_block = from,
                         end_block = to,
                         last_valid_range_start_block = self.last_valid_range_start_block,
                         "Found invalid continuation in range. Re-indexing from the start block of the last successful range."
                     );
-                    self.from = self.last_valid_range_start_block;
-                    self.indexed_message_height.set(self.from as i64);
-                    self.indexed_deliveries_height.set(self.from as i64);
+                    self.sync_helper
+                        .backtrack(self.last_valid_range_start_block);
+                    self.indexed_message_height
+                        .set(self.last_valid_range_start_block as i64);
+                    self.indexed_deliveries_height
+                        .set(self.last_valid_range_start_block as i64);
                 }
                 ListValidity::ContainsGaps => {
                     self.missed_messages.inc();
+                    self.sync_helper.backtrack(start_block);
                     warn!(
                         last_leaf_index = self.last_leaf_index,
-                        start_block = self.from,
+                        start_block = from,
                         end_block = to,
                         last_valid_range_start_block = self.last_valid_range_start_block,
                         "Found gaps in the message in range, re-indexing the same range."

--- a/rust/agents/scraper/src/chain_scraper/sync.rs
+++ b/rust/agents/scraper/src/chain_scraper/sync.rs
@@ -82,7 +82,8 @@ impl Syncer {
         let last_leaf_index = scraper.last_message_leaf_index().await?.unwrap_or(0);
 
         let sync_helper =
-            { ContractSyncHelper::new(scraper.local.indexer.clone(), chunk_size, initial_height) };
+            ContractSyncHelper::new(scraper.local.indexer.clone(), chunk_size, initial_height)
+                .await?;
 
         Ok(Self {
             scraper,


### PR DESCRIPTION
### Description

Two main things I wanted to do in this PR

1) End some of the duplication between the indexers
2) Implement a more robust RPC rate limiter

### Drive-by changes

No

### Related issues

- Fixes #1255 

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

_What kind of testing have these changes undergone?_

Manual
Unit Tests
