### PR TITLE
Do not make empty queries to coingecko

### DIFF
--- a/typescript/sdk/src/gas/token-prices.ts
+++ b/typescript/sdk/src/gas/token-prices.ts
@@ -104,10 +104,12 @@ export class CoinGeckoTokenPriceGetter implements TokenPriceGetter {
     }
 
     const toQuery = chains.filter((c) => !this.cache.isFresh(c));
-    try {
-      await this.queryTokenPrices(toQuery);
-    } catch (e) {
-      warn('Failed to query token prices', e);
+    if (toQuery.length > 0) {
+      try {
+        await this.queryTokenPrices(toQuery);
+      } catch (e) {
+        warn('Failed to query token prices', e);
+      }
     }
     return chains.map((chain) => this.cache.fetch(chain));
   }


### PR DESCRIPTION
### Description

When we have a fresh cache entry for every chain we want prices for we shouldn't make a query with no token IDs.