### PR TITLE
Mattie/update retrying provider

### DIFF
--- a/rust/chains/abacus-ethereum/src/retrying.rs
+++ b/rust/chains/abacus-ethereum/src/retrying.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 use tokio::time::sleep;
 use tracing::{debug, error, info, instrument, trace, warn};
 
-use crate::{HttpClientError, QuorumProvider};
+use crate::HttpClientError;
 
 const METHODS_TO_NOT_RETRY: &[&str] = &[
     "eth_estimateGas",
@@ -193,61 +193,6 @@ impl JsonRpcClient for RetryingProvider<Http> {
                 info!(attempt, next_backoff_ms, error = %err, text = text,  "SerdeJson error in http provider");
                 HandleMethod::Retry(HttpClientError::SerdeJson { err, text })
             }
-        })
-        .await
-    }
-}
-
-#[async_trait]
-impl<C> JsonRpcClient for RetryingProvider<QuorumProvider<C>>
-where
-    C: JsonRpcClient + 'static,
-{
-    type Error = RetryingProviderError<QuorumProvider<C>>;
-
-    #[instrument(level = "error", skip_all, fields(method = %method))]
-    async fn request<T, R>(&self, method: &str, params: T) -> Result<R, Self::Error>
-    where
-        T: Debug + Serialize + Send + Sync,
-        R: DeserializeOwned,
-    {
-        use HandleMethod::*;
-        self.request_with_retry::<T, R>(method, params, |res, attempt, next_backoff_ms| {
-            let handling = match res {
-                Ok(v) => Accept(v),
-                Err(ProviderError::CustomError(e)) => Retry(ProviderError::CustomError(e)),
-                Err(ProviderError::EnsError(e)) => Retry(ProviderError::EnsError(e)),
-                Err(ProviderError::EnsNotOwned(e)) => Halt(ProviderError::EnsNotOwned(e)),
-                Err(ProviderError::HTTPError(e)) => Retry(ProviderError::HTTPError(e)),
-                Err(ProviderError::HexError(e)) => Halt(ProviderError::HexError(e)),
-                Err(ProviderError::JsonRpcClientError(e)) => {
-                    if METHODS_TO_NOT_RETRY.contains(&method) {
-                        Halt(ProviderError::JsonRpcClientError(e))
-                    } else {
-                        Retry(ProviderError::JsonRpcClientError(e))
-                    }
-                }
-                Err(ProviderError::SerdeJson(e)) => Retry(ProviderError::SerdeJson(e)),
-                Err(ProviderError::SignerUnavailable) => Halt(ProviderError::SignerUnavailable),
-                Err(ProviderError::UnsupportedNodeClient) => {
-                    Halt(ProviderError::UnsupportedNodeClient)
-                }
-                Err(ProviderError::UnsupportedRPC) => Halt(ProviderError::UnsupportedRPC),
-            };
-
-            match &handling {
-                Accept(_) => {
-                    trace!("Quorum reached successfully.");
-                }
-                Halt(e) => {
-                    error!(attempt, next_backoff_ms, error = %e, "Failed to reach quorum; not retrying.");
-                }
-                Retry(e) => {
-                    warn!(attempt, next_backoff_ms, error = %e, "Failed to reach quorum; suggesting retry.");
-                }
-            }
-
-            handling
         })
         .await
     }

--- a/rust/chains/abacus-ethereum/src/retrying.rs
+++ b/rust/chains/abacus-ethereum/src/retrying.rs
@@ -72,7 +72,7 @@ where
     /// The retrying provider logic which accepts a matcher function that can
     /// handle specific cases for different underlying provider
     /// implementations.
-    #[instrument(level = "error", skip_all, fields(method = %method))]
+    #[instrument(skip_all, fields(method = %method))]
     async fn request_with_retry<T, R>(
         &self,
         method: &str,
@@ -160,7 +160,7 @@ where
 impl JsonRpcClient for RetryingProvider<Http> {
     type Error = RetryingProviderError<Http>;
 
-    #[instrument(level = "error", skip(self), fields(provider_host = %self.inner.url().host_str().unwrap_or("unknown")))]
+    #[instrument(skip(self), fields(provider_host = %self.inner.url().host_str().unwrap_or("unknown")))]
     async fn request<T, R>(&self, method: &str, params: T) -> Result<R, Self::Error>
     where
         T: Debug + Serialize + Send + Sync,


### PR DESCRIPTION
### Description

This PR updates the logs in the retrying provider to be warnings on errors that it handles instead of info events. This will make it easier for operators to spot issues with nodes.

### Drive-by changes

* Fixed span levels in retrying provider
* Removed dead code for retrying quorum providers

### Related issues

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

_What kind of testing have these changes undergone?_

Manual
