### PR TITLE
Correct span field "chunk_size" for scraper

### DIFF
--- a/rust/agents/scraper/src/chain_scraper/sync.rs
+++ b/rust/agents/scraper/src/chain_scraper/sync.rs
@@ -105,7 +105,7 @@ impl Syncer {
     }
 
     /// Sync contract and other blockchain data with the current chain state.
-    #[instrument(skip(self), fields(chain_name = self.chain_name(), chink_size = self.chunk_size))]
+    #[instrument(skip(self), fields(chain_name = self.chain_name(), chunk_size = self.chunk_size))]
     pub async fn run(mut self) -> Result<()> {
         let start_block = self.sync_cursor.current_position();
         info!(from = start_block, "Resuming chain sync");


### PR DESCRIPTION
### Description

Noticed this when poking through some logs

### Drive-by changes

n/a

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None
