### PR TITLE
Support ICA/IQS functions without Call struct

### DIFF
--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -44,6 +44,16 @@ contract InterchainAccountRouter is Router, IInterchainAccountRouter {
         return _dispatch(_destinationDomain, abi.encode(msg.sender, calls));
     }
 
+    function dispatch(
+        uint32 _destinationDomain,
+        address target,
+        bytes calldata data
+    ) external returns (uint256) {
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({to: target, data: data});
+        return _dispatch(_destinationDomain, abi.encode(msg.sender, calls));
+    }
+
     function getInterchainAccount(uint32 _origin, address _sender)
         public
         view

--- a/solidity/contracts/middleware/InterchainQueryRouter.sol
+++ b/solidity/contracts/middleware/InterchainQueryRouter.sol
@@ -45,6 +45,26 @@ contract InterchainQueryRouter is
 
     /**
      * @param _destinationDomain Domain of destination chain
+     * @param target The address of the contract to query on destination chain.
+     * @param queryData The calldata of the view call to make on the destination chain.
+     * @param callback Callback function selector on `msg.sender` and optionally abi-encoded prefix arguments.
+     */
+    function query(
+        uint32 _destinationDomain,
+        address target,
+        bytes calldata queryData,
+        bytes calldata callback
+    ) external returns (uint256 leafIndex) {
+        // TODO: fix this ugly arrayification
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({to: target, data: queryData});
+        bytes[] memory callbacks = new bytes[](1);
+        callbacks[0] = callback;
+        leafIndex = query(_destinationDomain, calls, callbacks);
+    }
+
+    /**
+     * @param _destinationDomain Domain of destination chain
      * @param call Call (to and data packed struct) to be made on destination chain.
      * @param callback Callback function selector on `msg.sender` and optionally abi-encoded prefix arguments.
      */

--- a/solidity/contracts/mock/MockInterchainAccountRouter.sol
+++ b/solidity/contracts/mock/MockInterchainAccountRouter.sol
@@ -38,10 +38,24 @@ contract MockInterchainAccountRouter is IInterchainAccountRouter {
         originDomain = _originDomain;
     }
 
-    function dispatch(uint32, Call[] calldata calls)
-        external
+    function dispatch(uint32 _destinationDomain, Call[] calldata calls)
+        public
         returns (uint256)
     {
+        return _dispatch(_destinationDomain, calls);
+    }
+
+    function dispatch(
+        uint32 _destinationDomain,
+        address target,
+        bytes calldata data
+    ) external returns (uint256) {
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({to: target, data: data});
+        return _dispatch(_destinationDomain, calls);
+    }
+
+    function _dispatch(uint32, Call[] memory calls) internal returns (uint256) {
         pendingCalls[totalCalls] = PendingCall(
             originDomain,
             msg.sender,

--- a/solidity/interfaces/IInterchainAccountRouter.sol
+++ b/solidity/interfaces/IInterchainAccountRouter.sol
@@ -8,6 +8,12 @@ interface IInterchainAccountRouter {
         external
         returns (uint256);
 
+    function dispatch(
+        uint32 _destinationDomain,
+        address target,
+        bytes calldata data
+    ) external returns (uint256);
+
     function getInterchainAccount(uint32 _originDomain, address _sender)
         external
         view

--- a/solidity/interfaces/IInterchainQueryRouter.sol
+++ b/solidity/interfaces/IInterchainQueryRouter.sol
@@ -6,6 +6,13 @@ import {Call} from "../contracts/Call.sol";
 interface IInterchainQueryRouter {
     function query(
         uint32 _destinationDomain,
+        address target,
+        bytes calldata queryData,
+        bytes calldata callback
+    ) external returns (uint256);
+
+    function query(
+        uint32 _destinationDomain,
         Call calldata call,
         bytes calldata callback
     ) external returns (uint256);

--- a/typescript/sdk/src/middleware/accounts.hardhat-test.ts
+++ b/typescript/sdk/src/middleware/accounts.hardhat-test.ts
@@ -67,7 +67,9 @@ describe('InterchainAccountRouter', async () => {
       localDomain,
       signer.address,
     );
-    await local.dispatch(remoteDomain, [{ to: recipient.address, data }]);
+    await local['dispatch(uint32,(address,bytes)[])'](remoteDomain, [
+      { to: recipient.address, data },
+    ]);
     await coreApp.processMessages();
     expect(await recipient.lastCallMessage()).to.eql(fooMessage);
     expect(await recipient.lastCaller()).to.eql(icaAddress);


### PR DESCRIPTION
### Description

Support ICA/IQS functions without Call struct function signatures which may be more intuitive to some




### Drive-by changes

_Are there any minor or drive-by changes also included?_

### Related issues

- Fixes #1242 and fixes #1243

### Backward compatibility

_Are these changes backward compatible?_

Yes
No

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None
Yes


### Testing

_What kind of testing have these changes undergone?_

None
Manual
Unit Tests
