### PR TITLE
Add Router#enrollRemoteRouters

### DIFF
--- a/solidity/contracts/Router.sol
+++ b/solidity/contracts/Router.sol
@@ -70,6 +70,20 @@ abstract contract Router is HyperlaneConnectionClient, IMessageRecipient {
     }
 
     /**
+     * @notice Batch version of `enrollRemoteRouter`
+     * @param _domains The domaisn of the remote Application Routers
+     * @param _routers The addresses of the remote Application Routers
+     */
+    function enrollRemoteRouters(
+        uint32[] calldata _domains,
+        bytes32[] calldata _routers
+    ) external virtual onlyOwner {
+        for (uint256 i = 0; i < _domains.length; i += 1) {
+            _enrollRemoteRouter(_domains[i], _routers[i]);
+        }
+    }
+
+    /**
      * @notice Handles an incoming message
      * @param _origin The origin domain
      * @param _sender The sender address

--- a/solidity/test/router.test.ts
+++ b/solidity/test/router.test.ts
@@ -110,6 +110,21 @@ describe('Router', async () => {
       expect(await router.mustHaveRemoteRouter(origin)).to.equal(remoteBytes);
     });
 
+    it('owner can enroll remote router using batch function', async () => {
+      const remote = nonOwner.address;
+      const remoteBytes = utils.addressToBytes32(nonOwner.address);
+      expect(await router.isRemoteRouter(origin, remoteBytes)).to.equal(false);
+      await expect(router.mustHaveRemoteRouter(origin)).to.be.revertedWith(
+        `No router enrolled for domain. Did you specify the right domain ID?`,
+      );
+      await router.enrollRemoteRouters(
+        [origin],
+        [utils.addressToBytes32(remote)],
+      );
+      expect(await router.isRemoteRouter(origin, remoteBytes)).to.equal(true);
+      expect(await router.mustHaveRemoteRouter(origin)).to.equal(remoteBytes);
+    });
+
     it('non-owner cannot enroll remote router', async () => {
       await expect(
         router


### PR DESCRIPTION
### Description

Adds a batch function for enrolling multiple remote routers. Added no consumption code yet until it is propagated through.

### Drive-by changes

_Are there any minor or drive-by changes also included?_

### Backward compatibility

_Are these changes backward compatible?_

No

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_


Yes - Once consuming code uses the batch function, it obviously doesn't work against older deployments


### Testing

_What kind of testing have these changes undergone?_

Unit Tests
