### PR TITLE
Order signatures correctly

### DIFF
--- a/rust/hyperlane-core/src/types/checkpoint.rs
+++ b/rust/hyperlane-core/src/types/checkpoint.rs
@@ -176,7 +176,7 @@ pub struct SignatureWithSigner {
 pub struct MultisigSignedCheckpoint {
     /// The checkpoint
     pub checkpoint: Checkpoint,
-    /// Signatures over the checkpoint
+    /// Signatures over the checkpoint. No ordering guarantees.
     pub signatures: Vec<SignatureWithSigner>,
 }
 
@@ -208,13 +208,9 @@ impl TryFrom<&Vec<SignedCheckpointWithSigner>> for MultisigSignedCheckpoint {
         {
             return Err(MultisigSignedCheckpointError::InconsistentCheckpoints());
         }
-        // MultisigValidatorManagers expect signatures to be sorted by their signer in ascending
-        // order to prevent duplicates.
-        let mut sorted_signed_checkpoints = signed_checkpoints.clone();
-        sorted_signed_checkpoints.sort_by_key(|c| c.signer);
 
-        let signatures = sorted_signed_checkpoints
-            .iter()
+        let signatures = signed_checkpoints
+            .into_iter()
             .map(|c| SignatureWithSigner {
                 signature: c.signed_checkpoint.signature,
                 signer: c.signer,

--- a/rust/hyperlane-core/src/types/checkpoint.rs
+++ b/rust/hyperlane-core/src/types/checkpoint.rs
@@ -162,13 +162,22 @@ pub struct SignedCheckpointWithSigner {
     pub signed_checkpoint: SignedCheckpoint,
 }
 
+/// A signature and its signer.
+#[derive(Clone, Debug)]
+pub struct SignatureWithSigner {
+    /// The signature
+    pub signature: Signature,
+    /// The signer of the signature
+    pub signer: Address,
+}
+
 /// A checkpoint and multiple signatures
 #[derive(Clone, Debug)]
 pub struct MultisigSignedCheckpoint {
     /// The checkpoint
     pub checkpoint: Checkpoint,
-    /// Signatures over the checkpoint, sorted in ascending order by their signer's address
-    pub signatures: Vec<Signature>,
+    /// Signatures over the checkpoint
+    pub signatures: Vec<SignatureWithSigner>,
 }
 
 /// Error types for MultisigSignedCheckpoint
@@ -206,7 +215,10 @@ impl TryFrom<&Vec<SignedCheckpointWithSigner>> for MultisigSignedCheckpoint {
 
         let signatures = sorted_signed_checkpoints
             .iter()
-            .map(|c| c.signed_checkpoint.signature)
+            .map(|c| SignatureWithSigner {
+                signature: c.signed_checkpoint.signature,
+                signer: c.signer,
+            })
             .collect();
 
         Ok(MultisigSignedCheckpoint {


### PR DESCRIPTION
### Description

Sorts validator signatures by the order that the MultisigIsm contract expects.

Honestly the implementation feels a little heavyweight to me - wondering if there's an easier way of doing this that I didn't think of?

I considered caching the `ordering_map` alongside the validators, wondering if y'all feel I should do that

### Drive-by changes

n/a

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

no


### Testing

_What kind of testing have these changes undergone?_

Ran a relayer locally and it worked
