### PR TITLE
Reduce Kathy polling

### DIFF
--- a/typescript/helloworld/src/app/app.ts
+++ b/typescript/helloworld/src/app/app.ts
@@ -67,6 +67,12 @@ export class HelloWorldApp<
     return this.core.waitForMessageProcessing(receipt);
   }
 
+  async waitForMessageProcessed(
+    receipt: ethers.ContractReceipt,
+  ): Promise<void> {
+    return this.core.waitForMessageProcessed(receipt);
+  }
+
   async channelStats<From extends Chain>(
     from: From,
     to: Remotes<Chain, From>,

--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -413,7 +413,7 @@ async function sendMessage(
 
   try {
     await utils.timeout(
-      app.waitForMessageReceipt(receipt),
+      app.waitForMessageProcessed(receipt),
       messageReceiptTimeout,
       'Timeout waiting for message to be received',
     );

--- a/typescript/sdk/src/core/HyperlaneCore.ts
+++ b/typescript/sdk/src/core/HyperlaneCore.ts
@@ -2,7 +2,6 @@ import { BigNumber, ethers } from 'ethers';
 
 import { Inbox, Outbox, Outbox__factory } from '@hyperlane-xyz/core';
 import { types, utils } from '@hyperlane-xyz/utils';
-import { pollAsync } from '@hyperlane-xyz/utils/dist/src/utils';
 
 import { HyperlaneApp } from '../HyperlaneApp';
 import { environments } from '../consts/environments';
@@ -162,7 +161,7 @@ export class HyperlaneCore<
   ): Promise<void> {
     const hash = utils.messageHash(message.message, message.leafIndex);
     const { inbox } = this.getDestination(message);
-    await pollAsync(async () => {
+    await utils.pollAsync(async () => {
       const messageStatus = await inbox.messages(hash);
       if (messageStatus !== InboxMessageStatus.Processed) {
         throw new Error(

--- a/typescript/sdk/src/core/HyperlaneCore.ts
+++ b/typescript/sdk/src/core/HyperlaneCore.ts
@@ -2,6 +2,7 @@ import { BigNumber, ethers } from 'ethers';
 
 import { Inbox, Outbox, Outbox__factory } from '@hyperlane-xyz/core';
 import { types, utils } from '@hyperlane-xyz/utils';
+import { pollAsync } from '@hyperlane-xyz/utils/dist/src/utils';
 
 import { HyperlaneApp } from '../HyperlaneApp';
 import { environments } from '../consts/environments';
@@ -14,6 +15,7 @@ import { ChainMap, ChainName, Remotes } from '../types';
 import { objMap, pick } from '../utils/objects';
 
 import { CoreContracts, coreFactories } from './contracts';
+import { InboxMessageStatus } from './message';
 
 export type CoreEnvironment = keyof typeof environments;
 export type CoreEnvironmentChain<E extends CoreEnvironment> = Extract<
@@ -155,6 +157,22 @@ export class HyperlaneCore<
     });
   }
 
+  protected async waitForMessageWasProcessed(
+    message: DispatchedMessage,
+  ): Promise<void> {
+    const hash = utils.messageHash(message.message, message.leafIndex);
+    const { inbox } = this.getDestination(message);
+    await pollAsync(async () => {
+      const messageStatus = await inbox.messages(hash);
+      if (messageStatus !== InboxMessageStatus.Processed) {
+        throw new Error(
+          `Message ${message.leafIndex} ${hash} not yet processed`,
+        );
+      }
+    });
+    return;
+  }
+
   getDispatchedMessages(sourceTx: ethers.ContractReceipt): DispatchedMessage[] {
     const outbox = Outbox__factory.createInterface();
     const dispatchLogs = sourceTx.logs
@@ -182,5 +200,14 @@ export class HyperlaneCore<
   ): Promise<ethers.ContractReceipt[]> {
     const messages = this.getDispatchedMessages(sourceTx);
     return Promise.all(messages.map((msg) => this.waitForProcessReceipt(msg)));
+  }
+
+  async waitForMessageProcessed(
+    sourceTx: ethers.ContractReceipt,
+  ): Promise<void> {
+    const messages = this.getDispatchedMessages(sourceTx);
+    await Promise.all(
+      messages.map((msg) => this.waitForMessageWasProcessed(msg)),
+    );
   }
 }

--- a/typescript/sdk/src/core/message.ts
+++ b/typescript/sdk/src/core/message.ts
@@ -51,7 +51,6 @@ export enum MessageStatus {
 
 export enum InboxMessageStatus {
   None = 0,
-  Proven,
   Processed,
 }
 

--- a/typescript/utils/src/utils.ts
+++ b/typescript/utils/src/utils.ts
@@ -123,7 +123,7 @@ export async function retryAsync<T>(
 
 export async function pollAsync<T>(
   runner: () => Promise<T>,
-  delay = 500,
+  delayMs = 500,
   maxAttempts: number | undefined = undefined,
 ) {
   let attempts = 0;
@@ -135,7 +135,7 @@ export async function pollAsync<T>(
     } catch (error) {
       saveError = error;
       attempts += 1;
-      await sleep(delay);
+      await sleep(delayMs);
     }
   }
   throw saveError;

--- a/typescript/utils/src/utils.ts
+++ b/typescript/utils/src/utils.ts
@@ -121,6 +121,26 @@ export async function retryAsync<T>(
   throw saveError;
 }
 
+export async function pollAsync<T>(
+  runner: () => Promise<T>,
+  delay = 500,
+  maxAttempts: number | undefined = undefined,
+) {
+  let attempts = 0;
+  let saveError;
+  while (!maxAttempts || attempts < maxAttempts) {
+    try {
+      const ret = await runner();
+      return ret;
+    } catch (error) {
+      saveError = error;
+      attempts += 1;
+      await sleep(delay);
+    }
+  }
+  throw saveError;
+}
+
 export function median(a: number[]): number {
   const sorted = a.slice().sort();
   const mid = Math.floor(sorted.length / 2);


### PR DESCRIPTION
### Description

Instead of searching for events, this will make Kathy just poll for the delivery status on the inbox directly. This avoids costly RPC calls.