### PR TITLE
Temporarily disable moonbasealpha for testnet2

### DIFF
--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -127,7 +127,7 @@ export const releaseCandidate: AgentConfig<TestnetChains> = {
     region: 'us-east-1',
   },
   environmentChainNames: chainNames,
-  contextChainNames: chainNames,
+  contextChainNames: chainNames.filter((chain) => chain !== 'moonbasealpha'),
   validatorSets: validators,
   gelato: {
     enabledChains: [


### PR DESCRIPTION
### Description

Moonbasealpha is down, and causing issues for relayers. Will re-enable when back up.

### Drive-by changes

None. 
