### PR TITLE
Provider config and build path

### DIFF
--- a/rust/agents/scraper/src/agent.rs
+++ b/rust/agents/scraper/src/agent.rs
@@ -96,17 +96,17 @@ impl Scraper {
         let ctx = || format!("Loading chain {chain_name}");
         Ok(Contracts {
             provider: config
-                .try_provider(chain_name, metrics)
+                .build_provider(chain_name, metrics)
                 .await
                 .with_context(ctx)?
                 .into(),
             mailbox: config
-                .try_mailbox(chain_name, metrics)
+                .build_mailbox(chain_name, metrics)
                 .await
                 .with_context(ctx)?
                 .into(),
             indexer: config
-                .try_mailbox_indexer(chain_name, metrics)
+                .build_mailbox_indexer(chain_name, metrics)
                 .await
                 .with_context(ctx)?
                 .into(),

--- a/rust/chains/hyperlane-ethereum/src/interchain_gas.rs
+++ b/rust/chains/hyperlane-ethereum/src/interchain_gas.rs
@@ -18,7 +18,7 @@ use hyperlane_core::{
 use crate::contracts::interchain_gas_paymaster::{
     InterchainGasPaymaster as EthereumInterchainGasPaymasterInternal, INTERCHAINGASPAYMASTER_ABI,
 };
-use crate::trait_builder::MakeableWithProvider;
+use crate::trait_builder::BuildableWithProvider;
 
 impl<M> Display for EthereumInterchainGasPaymasterInternal<M>
 where
@@ -35,10 +35,10 @@ pub struct InterchainGasPaymasterIndexerBuilder {
 }
 
 #[async_trait]
-impl MakeableWithProvider for InterchainGasPaymasterIndexerBuilder {
+impl BuildableWithProvider for InterchainGasPaymasterIndexerBuilder {
     type Output = Box<dyn InterchainGasPaymasterIndexer>;
 
-    async fn make_with_provider<M: Middleware + 'static>(
+    async fn build_with_provider<M: Middleware + 'static>(
         &self,
         provider: M,
         locator: &ContractLocator,
@@ -133,10 +133,10 @@ where
 pub struct InterchainGasPaymasterBuilder {}
 
 #[async_trait]
-impl MakeableWithProvider for InterchainGasPaymasterBuilder {
+impl BuildableWithProvider for InterchainGasPaymasterBuilder {
     type Output = Box<dyn InterchainGasPaymaster>;
 
-    async fn make_with_provider<M: Middleware + 'static>(
+    async fn build_with_provider<M: Middleware + 'static>(
         &self,
         provider: M,
         locator: &ContractLocator,

--- a/rust/chains/hyperlane-ethereum/src/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/mailbox.rs
@@ -18,7 +18,7 @@ use hyperlane_core::{
 };
 
 use crate::contracts::mailbox::{Mailbox as EthereumMailboxInternal, ProcessCall, MAILBOX_ABI};
-use crate::trait_builder::MakeableWithProvider;
+use crate::trait_builder::BuildableWithProvider;
 use crate::tx::report_tx;
 
 impl<M> std::fmt::Display for EthereumMailboxInternal<M>
@@ -35,10 +35,10 @@ pub struct MailboxIndexerBuilder {
 }
 
 #[async_trait]
-impl MakeableWithProvider for MailboxIndexerBuilder {
+impl BuildableWithProvider for MailboxIndexerBuilder {
     type Output = Box<dyn MailboxIndexer>;
 
-    async fn make_with_provider<M: Middleware + 'static>(
+    async fn build_with_provider<M: Middleware + 'static>(
         &self,
         provider: M,
         locator: &ContractLocator,
@@ -140,10 +140,10 @@ where
 pub struct MailboxBuilder {}
 
 #[async_trait]
-impl MakeableWithProvider for MailboxBuilder {
+impl BuildableWithProvider for MailboxBuilder {
     type Output = Box<dyn Mailbox>;
 
-    async fn make_with_provider<M: Middleware + 'static>(
+    async fn build_with_provider<M: Middleware + 'static>(
         &self,
         provider: M,
         locator: &ContractLocator,

--- a/rust/chains/hyperlane-ethereum/src/multisig_ism.rs
+++ b/rust/chains/hyperlane-ethereum/src/multisig_ism.rs
@@ -21,7 +21,7 @@ use hyperlane_core::{
 };
 
 use crate::contracts::multisig_ism::{MultisigIsm as EthereumMultisigIsmInternal, MULTISIGISM_ABI};
-use crate::trait_builder::MakeableWithProvider;
+use crate::trait_builder::BuildableWithProvider;
 
 #[derive(Debug)]
 struct Timestamped<Value> {
@@ -88,10 +88,10 @@ where
 pub struct MultisigIsmBuilder {}
 
 #[async_trait]
-impl MakeableWithProvider for MultisigIsmBuilder {
+impl BuildableWithProvider for MultisigIsmBuilder {
     type Output = Box<dyn MultisigIsm>;
 
-    async fn make_with_provider<M: Middleware + 'static>(
+    async fn build_with_provider<M: Middleware + 'static>(
         &self,
         provider: M,
         locator: &ContractLocator,

--- a/rust/chains/hyperlane-ethereum/src/provider.rs
+++ b/rust/chains/hyperlane-ethereum/src/provider.rs
@@ -13,7 +13,7 @@ use hyperlane_core::{
     BlockInfo, ContractLocator, HyperlaneChain, HyperlaneProvider, TxnInfo, TxnReceiptInfo, H256,
 };
 
-use crate::MakeableWithProvider;
+use crate::BuildableWithProvider;
 
 /// Connection to an ethereum provider. Useful for querying information about
 /// the blockchain.
@@ -94,10 +94,10 @@ where
 pub struct HyperlaneProviderBuilder {}
 
 #[async_trait]
-impl MakeableWithProvider for HyperlaneProviderBuilder {
+impl BuildableWithProvider for HyperlaneProviderBuilder {
     type Output = Box<dyn HyperlaneProvider>;
 
-    async fn make_with_provider<M: Middleware + 'static>(
+    async fn build_with_provider<M: Middleware + 'static>(
         &self,
         provider: M,
         locator: &ContractLocator,

--- a/rust/chains/hyperlane-ethereum/src/trait_builder.rs
+++ b/rust/chains/hyperlane-ethereum/src/trait_builder.rs
@@ -26,14 +26,14 @@ const HTTP_CLIENT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// A trait for dynamic trait creation with provider initialization.
 #[async_trait]
-pub trait MakeableWithProvider {
+pub trait BuildableWithProvider {
     /// The type that will be created.
     type Output;
 
     /// Construct a new instance of the associated trait using a connection
     /// config. This is the first step and will wrap the provider with
     /// metrics and a signer as needed.
-    async fn make_with_connection(
+    async fn build_with_connection_conf(
         &self,
         conn: ConnectionConf,
         locator: &ContractLocator,
@@ -159,21 +159,21 @@ pub trait MakeableWithProvider {
         M: Middleware + 'static,
     {
         Ok(if let Some(signer) = signer {
-            let signing_provider = make_signing_provider(provider, signer).await?;
-            self.make_with_provider(signing_provider, locator)
+            let signing_provider = build_signing_provider(provider, signer).await?;
+            self.build_with_provider(signing_provider, locator)
         } else {
-            self.make_with_provider(provider, locator)
+            self.build_with_provider(provider, locator)
         }
         .await)
     }
 
     /// Construct a new instance of the associated trait using a provider.
-    async fn make_with_provider<M>(&self, provider: M, locator: &ContractLocator) -> Self::Output
+    async fn build_with_provider<M>(&self, provider: M, locator: &ContractLocator) -> Self::Output
     where
         M: Middleware + 'static;
 }
 
-async fn make_signing_provider<M: Middleware>(
+async fn build_signing_provider<M: Middleware>(
     provider: M,
     signer: Signers,
 ) -> Result<SignerMiddleware<NonceManagerMiddleware<M>, Signers>, M::Error> {

--- a/rust/hyperlane-base/src/agent.rs
+++ b/rust/hyperlane-base/src/agent.rs
@@ -116,7 +116,7 @@ pub async fn agent_main<A: BaseAgent>() -> Result<()> {
     let settings = A::Settings::new().map_err(|e| e.into())?;
     let core_settings: &Settings = settings.as_ref();
 
-    let metrics = settings.as_ref().try_into_metrics(A::AGENT_NAME)?;
+    let metrics = settings.as_ref().metrics(A::AGENT_NAME)?;
     core_settings.tracing.start_tracing(&metrics)?;
     let agent = A::from_settings(settings, metrics.clone()).await?;
     let _ = metrics.run_http_server();

--- a/rust/hyperlane-base/src/settings/chains.rs
+++ b/rust/hyperlane-base/src/settings/chains.rs
@@ -1,18 +1,18 @@
 use ethers::signers::Signer;
 use eyre::Context;
+use eyre::Result;
 use serde::Deserialize;
 
 use ethers_prometheus::middleware::{
     ChainInfo, ContractInfo, PrometheusMiddlewareConf, WalletInfo,
 };
 use hyperlane_core::{
-    ContractLocator, HyperlaneAbi, HyperlaneProvider, InterchainGasPaymaster, Mailbox, MultisigIsm,
-    Signers,
+    ContractLocator, HyperlaneAbi, HyperlaneProvider, InterchainGasPaymaster,
+    InterchainGasPaymasterIndexer, Mailbox, MailboxIndexer, MultisigIsm, Signers,
 };
 use hyperlane_ethereum::{
-    ConnectionConf, EthereumInterchainGasPaymasterAbi, EthereumMailboxAbi, EthereumMultisigIsmAbi,
-    HyperlaneProviderBuilder, InterchainGasPaymasterBuilder, MailboxBuilder, MakeableWithProvider,
-    MultisigIsmBuilder,
+    BuildableWithProvider, ConnectionConf, EthereumInterchainGasPaymasterAbi, EthereumMailboxAbi,
+    EthereumMultisigIsmAbi,
 };
 
 use crate::CoreMetrics;
@@ -94,8 +94,8 @@ impl IndexSettings {
     }
 }
 
-/// A chain setup is a domain ID, an address on that chain (where the mailbox is deployed) and
-/// details for connecting to the chain API.
+/// A chain setup is a domain ID, an address on that chain (where the mailbox is
+/// deployed) and details for connecting to the chain API.
 #[derive(Clone, Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ChainSetup {
@@ -124,88 +124,170 @@ pub struct ChainSetup {
 }
 
 impl ChainSetup {
+    /// Try to convert the chain settings into an HyperlaneProvider.
+    pub async fn build_provider(
+        &self,
+        signer: Option<Signers>,
+        metrics: &CoreMetrics,
+    ) -> Result<Box<dyn HyperlaneProvider>> {
+        let metrics_conf = self.metrics_conf(metrics.agent_name(), &signer);
+
+        match &self.chain {
+            ChainConf::Ethereum(conf) => {
+                hyperlane_ethereum::HyperlaneProviderBuilder {}
+                    .build_with_connection_conf(
+                        conf.clone(),
+                        &self.locator("0x0000000000000000000000000000000000000000")?,
+                        signer,
+                        Some(|| metrics.json_rpc_client_metrics()),
+                        Some((metrics.provider_metrics(), metrics_conf)),
+                    )
+                    .await
+            }
+        }
+        .context("Building provider")
+    }
+
+    /// Try to convert the chain setting into a Mailbox contract
+    pub async fn build_mailbox(
+        &self,
+        signer: Option<Signers>,
+        metrics: &CoreMetrics,
+    ) -> Result<Box<dyn Mailbox>> {
+        let metrics_conf = self.metrics_conf(metrics.agent_name(), &signer);
+        let locator = self.locator(&self.addresses.mailbox)?;
+        match &self.chain {
+            ChainConf::Ethereum(conf) => {
+                hyperlane_ethereum::MailboxBuilder {}
+                    .build_with_connection_conf(
+                        conf.clone(),
+                        &locator,
+                        signer,
+                        Some(|| metrics.json_rpc_client_metrics()),
+                        Some((metrics.provider_metrics(), metrics_conf)),
+                    )
+                    .await
+            }
+        }
+        .context("Building mailbox")
+    }
+
+    /// Try to convert the chain settings into a mailbox indexer
+    pub async fn build_mailbox_indexer(
+        &self,
+        signer: Option<Signers>,
+        metrics: &CoreMetrics,
+    ) -> Result<Box<dyn MailboxIndexer>> {
+        let metrics_conf = self.metrics_conf(metrics.agent_name(), &signer);
+        let locator = self.locator(&self.addresses.mailbox)?;
+
+        match &self.chain {
+            ChainConf::Ethereum(conf) => {
+                hyperlane_ethereum::MailboxIndexerBuilder {
+                    finality_blocks: self.finality_blocks(),
+                }
+                .build_with_connection_conf(
+                    conf.clone(),
+                    &locator,
+                    signer,
+                    Some(|| metrics.json_rpc_client_metrics()),
+                    Some((metrics.provider_metrics(), metrics_conf)),
+                )
+                .await
+            }
+        }
+        .context("Building mailbox indexer")
+    }
+
+    /// Try to convert the chain setting into an interchain gas paymaster
+    /// contract
+    pub async fn build_interchain_gas_paymaster(
+        &self,
+        signer: Option<Signers>,
+        metrics: &CoreMetrics,
+    ) -> Result<Box<dyn InterchainGasPaymaster>> {
+        let metrics_conf = self.metrics_conf(metrics.agent_name(), &signer);
+        let locator = self.locator(&self.addresses.interchain_gas_paymaster)?;
+
+        match &self.chain {
+            ChainConf::Ethereum(conf) => {
+                hyperlane_ethereum::InterchainGasPaymasterBuilder {}
+                    .build_with_connection_conf(
+                        conf.clone(),
+                        &locator,
+                        signer,
+                        Some(|| metrics.json_rpc_client_metrics()),
+                        Some((metrics.provider_metrics(), metrics_conf)),
+                    )
+                    .await
+            }
+        }
+        .context("Building IGP")
+    }
+
+    /// Try to convert the chain settings into a IGP indexer
+    pub async fn build_interchain_gas_paymaster_indexer(
+        &self,
+        signer: Option<Signers>,
+        metrics: &CoreMetrics,
+    ) -> Result<Box<dyn InterchainGasPaymasterIndexer>> {
+        let metrics_conf = self.metrics_conf(metrics.agent_name(), &signer);
+        let locator = self.locator(&self.addresses.interchain_gas_paymaster)?;
+
+        match &self.chain {
+            ChainConf::Ethereum(conf) => {
+                hyperlane_ethereum::InterchainGasPaymasterIndexerBuilder {
+                    mailbox_address: self.addresses.mailbox.parse()?,
+                    finality_blocks: self.finality_blocks(),
+                }
+                .build_with_connection_conf(
+                    conf.clone(),
+                    &locator,
+                    signer,
+                    Some(|| metrics.json_rpc_client_metrics()),
+                    Some((metrics.provider_metrics(), metrics_conf)),
+                )
+                .await
+            }
+        }
+        .context("Building IGP indexer")
+    }
+
+    /// Try to convert the chain setting into a Multisig Ism contract
+    pub async fn build_multisig_ism(
+        &self,
+        signer: Option<Signers>,
+        metrics: &CoreMetrics,
+    ) -> Result<Box<dyn MultisigIsm>> {
+        let metrics_conf = self.metrics_conf(metrics.agent_name(), &signer);
+        let locator = self.locator(&self.addresses.multisig_ism)?;
+
+        match &self.chain {
+            ChainConf::Ethereum(conf) => {
+                hyperlane_ethereum::MultisigIsmBuilder {}
+                    .build_with_connection_conf(
+                        conf.clone(),
+                        &locator,
+                        signer,
+                        Some(|| metrics.json_rpc_client_metrics()),
+                        Some((metrics.provider_metrics(), metrics_conf)),
+                    )
+                    .await
+            }
+        }
+        .context("Building multisig ISM")
+    }
+
     /// Get the number of blocks until finality
-    pub fn finality_blocks(&self) -> u32 {
+    fn finality_blocks(&self) -> u32 {
         self.finality_blocks
             .parse::<u32>()
             .expect("could not parse finality_blocks")
     }
 
-    /// Try to convert the chain settings into an HyperlaneProvider.
-    pub async fn try_into_provider(
-        &self,
-        metrics: &CoreMetrics,
-    ) -> eyre::Result<Box<dyn HyperlaneProvider>> {
-        let builder = HyperlaneProviderBuilder {};
-        let metrics_conf = {
-            let mut cfg = self.metrics_conf.clone();
-
-            if cfg.chain.is_none() {
-                cfg.chain = Some(ChainInfo {
-                    name: Some(self.name.clone()),
-                });
-            }
-
-            cfg
-        };
-
-        let address = match &self.chain {
-            ChainConf::Ethereum(_) => "0x0000000000000000000000000000000000000000",
-        };
-        self.build(address, None, metrics, metrics_conf, builder)
-            .await
-    }
-
-    /// Try to convert the chain setting into a Mailbox contract
-    pub async fn try_into_mailbox(
-        &self,
-        signer: Option<Signers>,
-        metrics: &CoreMetrics,
-    ) -> eyre::Result<Box<dyn Mailbox>> {
-        let metrics_conf = self.metrics_conf(metrics.agent_name(), &signer);
-        let address = &self.addresses.mailbox;
-        let builder = MailboxBuilder {};
-        self.build(address, signer, metrics, metrics_conf, builder)
-            .await
-            .context("Building mailbox")
-    }
-
-    /// Try to convert the chain setting into an interchain gas paymaster
-    /// contract
-    pub async fn try_into_interchain_gas_paymaster(
-        &self,
-        signer: Option<Signers>,
-        metrics: &CoreMetrics,
-    ) -> eyre::Result<Box<dyn InterchainGasPaymaster>> {
-        let metrics_conf = self.metrics_conf(metrics.agent_name(), &signer);
-        let address = &self.addresses.interchain_gas_paymaster;
-        let builder = InterchainGasPaymasterBuilder {};
-        self.build(address, signer, metrics, metrics_conf, builder)
-            .await
-            .context("Building IGP")
-    }
-
-    /// Try to convert the chain setting into a Multisig Ism contract
-    pub async fn try_into_multisig_ism(
-        &self,
-        signer: Option<Signers>,
-        metrics: &CoreMetrics,
-    ) -> eyre::Result<Box<dyn MultisigIsm>> {
-        let address = &self.addresses.multisig_ism;
-        let builder = MultisigIsmBuilder {};
-        let metrics_conf = self.metrics_conf(metrics.agent_name(), &signer);
-        self.build(address, signer, metrics, metrics_conf, builder)
-            .await
-            .context("Building multisig ISM")
-    }
-
     /// Get a clone of the metrics conf with correctly configured contract
     /// information.
-    pub fn metrics_conf(
-        &self,
-        agent_name: &str,
-        signer: &Option<Signers>,
-    ) -> PrometheusMiddlewareConf {
+    fn metrics_conf(&self, agent_name: &str, signer: &Option<Signers>) -> PrometheusMiddlewareConf {
         let mut cfg = self.metrics_conf.clone();
 
         if cfg.chain.is_none() {
@@ -243,31 +325,16 @@ impl ChainSetup {
         cfg
     }
 
-    /// Try to convert the chain setting into a contract
-    pub async fn build<B: MakeableWithProvider + Sync>(
-        &self,
-        address: &str,
-        signer: Option<Signers>,
-        metrics: &CoreMetrics,
-        metrics_conf: PrometheusMiddlewareConf,
-        builder: B,
-    ) -> eyre::Result<B::Output> {
-        match &self.chain {
-            ChainConf::Ethereum(conf) => {
-                builder
-                    .make_with_connection(
-                        conf.clone(),
-                        &ContractLocator {
-                            chain_name: self.name.clone(),
-                            domain: self.domain.parse().expect("invalid uint"),
-                            address: address.parse::<ethers::types::Address>()?.into(),
-                        },
-                        signer,
-                        Some(|| metrics.json_rpc_client_metrics()),
-                        Some((metrics.provider_metrics(), metrics_conf)),
-                    )
-                    .await
-            }
-        }
+    fn locator(&self, address: &str) -> Result<ContractLocator> {
+        Ok(ContractLocator {
+            chain_name: self.name.clone(),
+            domain: self.domain.parse().context("invalid uint")?,
+            address: match self.chain {
+                ChainConf::Ethereum(_) => address
+                    .parse::<ethers::types::Address>()
+                    .context("Invalid ethereum address")?
+                    .into(),
+            },
+        })
     }
 }

--- a/rust/hyperlane-base/src/settings/mod.rs
+++ b/rust/hyperlane-base/src/settings/mod.rs
@@ -321,10 +321,10 @@ macro_rules! delegate_fn {
 }
 
 impl Settings {
-    delegate_fn!(build_provider -> dyn HyperlaneProvider);
-    delegate_fn!(build_mailbox -> dyn Mailbox);
     delegate_fn!(build_interchain_gas_paymaster -> dyn InterchainGasPaymaster);
+    delegate_fn!(build_interchain_gas_paymaster_indexer -> dyn InterchainGasPaymasterIndexer);
+    delegate_fn!(build_mailbox -> dyn Mailbox);
     delegate_fn!(build_mailbox_indexer -> dyn MailboxIndexer);
     delegate_fn!(build_multisig_ism -> dyn MultisigIsm);
-    delegate_fn!(build_interchain_gas_paymaster_indexer -> dyn InterchainGasPaymasterIndexer);
+    delegate_fn!(build_provider -> dyn HyperlaneProvider);
 }

--- a/rust/hyperlane-base/src/settings/mod.rs
+++ b/rust/hyperlane-base/src/settings/mod.rs
@@ -4,10 +4,10 @@
 //!
 //! Hyperlane Agents have a shared core, which contains connection info for rpc,
 //! relevant contract addresses on each chain, etc. In addition, each agent has
-//! agent-specific settings. By convention above, we represent these as a base config
-//! per-Mailbox contract, and a "partial" config per agent. On bootup, the agent
-//! loads the configuration, establishes RPC connections, and monitors each
-//! configured chain.
+//! agent-specific settings. By convention above, we represent these as a base
+//! config per-Mailbox contract, and a "partial" config per agent. On bootup,
+//! the agent loads the configuration, establishes RPC connections, and monitors
+//! each configured chain.
 //!
 //! All agents share the [`Settings`] struct in this crate, and then define any
 //! additional `Settings` in their own crate. By convention this is done in
@@ -88,7 +88,6 @@ use hyperlane_core::{
     HyperlaneProvider, InterchainGasPaymaster, InterchainGasPaymasterIndexer, Mailbox,
     MailboxIndexer, MultisigIsm, Signers,
 };
-use hyperlane_ethereum::{InterchainGasPaymasterIndexerBuilder, MailboxIndexerBuilder};
 pub use signers::SignerConf;
 
 use crate::{settings::trace::TracingConfig, CachingInterchainGasPaymaster};
@@ -162,13 +161,13 @@ impl Settings {
         };
 
         let mailboxes = self
-            .try_into_mailboxes(chain_names.as_slice(), &metrics, db.clone())
+            .build_all_mailboxes(chain_names.as_slice(), &metrics, db.clone())
             .await?;
         let interchain_gas_paymasters = self
-            .try_into_interchain_gas_paymasters(chain_names.as_slice(), &metrics, db.clone())
+            .build_all_interchain_gas_paymasters(chain_names.as_slice(), &metrics, db.clone())
             .await?;
         let multisig_isms = self
-            .try_into_multisig_isms(chain_names.as_slice(), &metrics)
+            .build_all_multisig_isms(chain_names.as_slice(), &metrics)
             .await?;
 
         Ok(HyperlaneAgentCore {
@@ -187,7 +186,7 @@ impl Settings {
     }
 
     /// Try to get a map of chain name -> mailbox contract
-    pub async fn try_into_mailboxes(
+    pub async fn build_all_mailboxes(
         &self,
         chain_names: &[&str],
         metrics: &CoreMetrics,
@@ -196,7 +195,7 @@ impl Settings {
         let mut result = HashMap::new();
         for &chain_name in chain_names {
             let mailbox = self
-                .try_caching_mailbox(chain_name, db.clone(), metrics)
+                .build_caching_mailbox(chain_name, db.clone(), metrics)
                 .await?;
             result.insert(chain_name.into(), mailbox);
         }
@@ -204,7 +203,7 @@ impl Settings {
     }
 
     /// Try to get a map of chain name -> interchain gas paymaster contract
-    pub async fn try_into_interchain_gas_paymasters(
+    pub async fn build_all_interchain_gas_paymasters(
         &self,
         chain_names: &[&str],
         metrics: &CoreMetrics,
@@ -213,7 +212,7 @@ impl Settings {
         let mut result = HashMap::new();
         for &chain_name in chain_names {
             let mailbox = self
-                .try_caching_interchain_gas_paymaster(chain_name, db.clone(), metrics)
+                .build_caching_interchain_gas_paymaster(chain_name, db.clone(), metrics)
                 .await?;
             result.insert(chain_name.into(), mailbox);
         }
@@ -221,52 +220,28 @@ impl Settings {
     }
 
     /// Try to get a map of chain name -> multisig ism contract
-    pub async fn try_into_multisig_isms(
+    pub async fn build_all_multisig_isms(
         &self,
         chain_names: &[&str],
         metrics: &CoreMetrics,
     ) -> eyre::Result<HashMap<String, Arc<dyn MultisigIsm>>> {
         let mut result: HashMap<String, Arc<dyn MultisigIsm>> = HashMap::new();
         for &chain_name in chain_names {
-            let multisig_ism = self.try_multisig_ism(chain_name, metrics).await?;
+            let multisig_ism = self.build_multisig_ism(chain_name, metrics).await?;
             result.insert(chain_name.into(), multisig_ism.into());
         }
         Ok(result)
     }
 
-    /// Try to get an HyperlaneProvider
-    pub async fn try_provider(
-        &self,
-        chain_name: &str,
-        metrics: &CoreMetrics,
-    ) -> eyre::Result<Box<dyn HyperlaneProvider>> {
-        self.chains
-            .get(chain_name)
-            .ok_or_else(|| eyre!("No chain setup found for {chain_name}"))?
-            .try_into_provider(metrics)
-            .await
-    }
-
-    /// Try to get a Mailbox
-    pub async fn try_mailbox(
-        &self,
-        chain_name: &str,
-        metrics: &CoreMetrics,
-    ) -> eyre::Result<Box<dyn Mailbox>> {
-        let signer = self.get_signer(chain_name).await;
-        let setup = self.try_chain_setup(chain_name)?;
-        setup.try_into_mailbox(signer, metrics).await
-    }
-
     /// Try to get a CachingMailbox
-    async fn try_caching_mailbox(
+    async fn build_caching_mailbox(
         &self,
         chain_name: &str,
         db: DB,
         metrics: &CoreMetrics,
     ) -> eyre::Result<CachingMailbox> {
-        let mailbox = self.try_mailbox(chain_name, metrics).await?;
-        let indexer = self.try_mailbox_indexer(chain_name, metrics).await?;
+        let mailbox = self.build_mailbox(chain_name, metrics).await?;
+        let indexer = self.build_mailbox_indexer(chain_name, metrics).await?;
         let hyperlane_db = HyperlaneDB::new(chain_name, db);
         Ok(CachingMailbox::new(
             mailbox.into(),
@@ -275,31 +250,18 @@ impl Settings {
         ))
     }
 
-    /// Try to get an IGP
-    pub async fn try_interchain_gas_paymaster(
-        &self,
-        chain_name: &str,
-        metrics: &CoreMetrics,
-    ) -> eyre::Result<Box<dyn InterchainGasPaymaster>> {
-        let signer = self.get_signer(chain_name).await;
-        let setup = self.try_chain_setup(chain_name)?;
-        setup
-            .try_into_interchain_gas_paymaster(signer, metrics)
-            .await
-    }
-
     /// Try to get a CachingInterchainGasPaymaster
-    async fn try_caching_interchain_gas_paymaster(
+    async fn build_caching_interchain_gas_paymaster(
         &self,
         chain_name: &str,
         db: DB,
         metrics: &CoreMetrics,
     ) -> eyre::Result<CachingInterchainGasPaymaster> {
         let interchain_gas_paymaster = self
-            .try_interchain_gas_paymaster(chain_name, metrics)
+            .build_interchain_gas_paymaster(chain_name, metrics)
             .await?;
         let indexer = self
-            .try_interchain_gas_paymaster_indexer(chain_name, metrics)
+            .build_interchain_gas_paymaster_indexer(chain_name, metrics)
             .await?;
         let hyperlane_db = HyperlaneDB::new(chain_name, db);
         Ok(CachingInterchainGasPaymaster::new(
@@ -309,73 +271,15 @@ impl Settings {
         ))
     }
 
-    /// Try to get a Multisig ISM
-    pub async fn try_multisig_ism(
-        &self,
-        chain_name: &str,
-        metrics: &CoreMetrics,
-    ) -> eyre::Result<Box<dyn MultisigIsm>> {
-        let signer = self.get_signer(chain_name).await;
-        let chain_setup = self.try_chain_setup(chain_name)?;
-        chain_setup.try_into_multisig_ism(signer, metrics).await
-    }
-
-    /// Try to get an indexer object for a given mailbox
-    pub async fn try_mailbox_indexer(
-        &self,
-        chain_name: &str,
-        metrics: &CoreMetrics,
-    ) -> eyre::Result<Box<dyn MailboxIndexer>> {
-        let chain_setup = self.try_chain_setup(chain_name)?;
-        let signer = self.get_signer(&chain_setup.name).await;
-        let metrics_conf = chain_setup.metrics_conf(metrics.agent_name(), &signer);
-        chain_setup
-            .build(
-                &chain_setup.addresses.mailbox,
-                signer,
-                metrics,
-                metrics_conf,
-                MailboxIndexerBuilder {
-                    finality_blocks: chain_setup.finality_blocks(),
-                },
-            )
-            .await
-            .context("Building mailbox indexer")
-    }
-
-    /// Try to get an indexer object for a given interchain gas paymaster
-    async fn try_interchain_gas_paymaster_indexer(
-        &self,
-        chain_name: &str,
-        metrics: &CoreMetrics,
-    ) -> eyre::Result<Box<dyn InterchainGasPaymasterIndexer>> {
-        let chain_setup = self.try_chain_setup(chain_name)?;
-        let signer = self.get_signer(&chain_setup.name).await;
-        let metrics_conf = chain_setup.metrics_conf(metrics.agent_name(), &signer);
-        chain_setup
-            .build(
-                &chain_setup.addresses.interchain_gas_paymaster,
-                signer,
-                metrics,
-                metrics_conf,
-                InterchainGasPaymasterIndexerBuilder {
-                    mailbox_address: chain_setup.addresses.mailbox.parse()?,
-                    finality_blocks: chain_setup.finality_blocks(),
-                },
-            )
-            .await
-            .context("Building mailbox indexer")
-    }
-
     /// Try to get the chain setup for the provided chain name
-    pub fn try_chain_setup(&self, chain_name: &str) -> eyre::Result<&ChainSetup> {
+    pub fn chain_setup(&self, chain_name: &str) -> eyre::Result<&ChainSetup> {
         self.chains
             .get(chain_name)
             .ok_or_else(|| eyre!("No chain setup found for {chain_name}"))
     }
 
     /// Create the core metrics from the settings given the name of the agent.
-    pub fn try_into_metrics(&self, name: &str) -> eyre::Result<Arc<CoreMetrics>> {
+    pub fn metrics(&self, name: &str) -> eyre::Result<Arc<CoreMetrics>> {
         Ok(Arc::new(CoreMetrics::new(
             name,
             self.metrics
@@ -398,4 +302,29 @@ impl Settings {
             tracing: self.tracing.clone(),
         }
     }
+}
+
+/// Generate a call to ChainSetup for the given builder
+macro_rules! delegate_fn {
+    ($name:ident -> $ret:ty) => {
+        /// Delegates building to ChainSetup
+        pub async fn $name(
+            &self,
+            chain_name: &str,
+            metrics: &CoreMetrics,
+        ) -> eyre::Result<Box<$ret>> {
+            let signer = self.get_signer(chain_name).await;
+            let setup = self.chain_setup(chain_name)?;
+            setup.$name(signer, metrics).await
+        }
+    };
+}
+
+impl Settings {
+    delegate_fn!(build_provider -> dyn HyperlaneProvider);
+    delegate_fn!(build_mailbox -> dyn Mailbox);
+    delegate_fn!(build_interchain_gas_paymaster -> dyn InterchainGasPaymaster);
+    delegate_fn!(build_mailbox_indexer -> dyn MailboxIndexer);
+    delegate_fn!(build_multisig_ism -> dyn MultisigIsm);
+    delegate_fn!(build_interchain_gas_paymaster_indexer -> dyn InterchainGasPaymasterIndexer);
 }


### PR DESCRIPTION
### Description

Pulled in some minor refactors form my rabbit hole earlier into dynamic providers

- Renamed `MakeableWithProvider` to `BuildableWithProvider` to better represent how it is used
- Renamed all `try_into_` functions in this chain to `build_` since it did not actually convert `self` and was therefore a misnomer
- Cut back on code duplication with a delegation macro
- Refactored how chains is structured to prepare for new chains

### Drive-by changes


### Related issues

- Relates to https://github.com/hyperlane-xyz/issues/issues/277
- Relates to https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/1362

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Manual
Unit Tests
