### PR TITLE
Fix the ethereum domain id in the database for scraper

### DIFF
--- a/rust/agents/scraper/migration/src/m20221122_000001_create_table_domain.rs
+++ b/rust/agents/scraper/migration/src/m20221122_000001_create_table_domain.rs
@@ -74,7 +74,7 @@ const DOMAINS: &[RawDomain] = &[
     RawDomain {
         name: "ethereum",
         token: "ETH",
-        domain: 0x657468,
+        domain: 1,
         chain_id: 1,
         is_test_net: false,
         is_deprecated: false,


### PR DESCRIPTION
### Description

Minor fix to domain id for ethereum.

### Drive-by changes

### Related issues

### Backward compatibility

_Are these changes backward compatible?_

No

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

Yes


### Testing

_What kind of testing have these changes undergone?_

None
