### PR TITLE
Add V2Compatibility middleware

### DIFF
--- a/solidity/contracts/Router.sol
+++ b/solidity/contracts/Router.sol
@@ -75,7 +75,7 @@ abstract contract Router is AbacusConnectionClient, IMessageRecipient {
 
     /**
      * @notice Batch version of `enrollRemoteRouter`
-     * @param _domains The domaisn of the remote Application Routers
+     * @param _domains The domains of the remote Application Routers
      * @param _routers The addresses of the remote Application Routers
      */
     function enrollRemoteRouters(

--- a/solidity/contracts/Router.sol
+++ b/solidity/contracts/Router.sol
@@ -74,6 +74,21 @@ abstract contract Router is AbacusConnectionClient, IMessageRecipient {
     }
 
     /**
+     * @notice Batch version of `enrollRemoteRouter`
+     * @param _domains The domaisn of the remote Application Routers
+     * @param _routers The addresses of the remote Application Routers
+     */
+    function enrollRemoteRouters(
+        uint32[] calldata _domains,
+        bytes32[] calldata _routers
+    ) external virtual onlyOwner {
+        require(_domains.length == _routers.length, "!length");
+        for (uint256 i = 0; i < _domains.length; i += 1) {
+            _enrollRemoteRouter(_domains[i], _routers[i]);
+        }
+    }
+
+    /**
      * @notice Handles an incoming message
      * @param _origin The origin domain
      * @param _sender The sender address

--- a/solidity/contracts/middleware/V2CompatibilityRouter.sol
+++ b/solidity/contracts/middleware/V2CompatibilityRouter.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import {Router} from "../Router.sol";
+import {TypeCasts} from "../libs/TypeCasts.sol";
+import {IMessageRecipient} from "../../interfaces/IMessageRecipient.sol";
+
+/*
+ * @title The Hello World App
+ * @dev You can use this simple app as a starting point for your own application.
+ */
+contract V2CompatibilityRouter is Router {
+    mapping(uint32 => uint32) v1ToV2Domain;
+    mapping(uint32 => uint32) v2ToV1Domain;
+
+    function initialize(
+        address _owner,
+        address _abacusConnectionManager,
+        address _interchainGasPaymaster
+    ) public initializer {
+        // Transfer ownership of the contract to deployer
+        _transferOwnership(_owner);
+        // Set the addresses for the ACM and IGP
+        // Alternatively, this could be done later in an initialize method
+        _setAbacusConnectionManager(_abacusConnectionManager);
+        _setInterchainGasPaymaster(_interchainGasPaymaster);
+    }
+
+    /**
+     * @notice Adds a domain ID mapping from v1/v2 domain IDs and vice versa
+     * @param _v1Domains An array of v1 domain IDs
+     * @param _v2Domains An array of v2 domain IDs
+     */
+    function mapDomains(
+        uint32[] calldata _v1Domains,
+        uint32[] calldata _v2Domains
+    ) external onlyOwner {
+        for (uint256 i = 0; i < _v1Domains.length; i += 1) {
+            v1ToV2Domain[_v1Domains[i]] = _v2Domains[i];
+            v2ToV1Domain[_v2Domains[i]] = _v1Domains[i];
+        }
+    }
+
+    /**
+     * @notice Dispatches a message to the destination domain & recipient. Takes v2 domain IDs and translates them to v1 domainIds where necessary.
+     * @param _v2Domain v2 Domain of destination chain
+     * @param _recipientAddress Address of recipient on destination chain as bytes32
+     * @param _messageBody Raw bytes content of message body
+     * @return The message ID inserted into the Mailbox's merkle tree
+     */
+    function dispatch(
+        uint32 _v2Domain,
+        bytes32 _recipientAddress,
+        bytes calldata _messageBody
+    ) external returns (bytes32) {
+        return
+            bytes32(
+                _dispatch(
+                    getV1Domain(_v2Domain),
+                    abi.encode(
+                        TypeCasts.addressToBytes32(msg.sender),
+                        _recipientAddress,
+                        _messageBody
+                    )
+                )
+            );
+    }
+
+    /**
+     * Calls the recipient of the message with the translated v2 domain ID
+     */
+    function _handle(
+        uint32 _originV1Domain,
+        bytes32, // router sender
+        bytes calldata _message
+    ) internal override {
+        (bytes32 _sender, bytes32 _recipient, bytes memory _messageBody) = abi
+            .decode(_message, (bytes32, bytes32, bytes));
+
+        IMessageRecipient(TypeCasts.bytes32ToAddress(_recipient)).handle(
+            getV2Domain(_originV1Domain),
+            _sender,
+            _messageBody
+        );
+    }
+
+    function getV1Domain(uint32 _v2Domain)
+        public
+        view
+        returns (uint32 v1Domain)
+    {
+        v1Domain = v2ToV1Domain[_v2Domain];
+        if (v1Domain == 0) {
+            v1Domain = _v2Domain;
+        }
+    }
+
+    function getV2Domain(uint32 _v1Domain)
+        public
+        view
+        returns (uint32 v2Domain)
+    {
+        v2Domain = v1ToV2Domain[_v1Domain];
+        if (v2Domain == 0) {
+            v2Domain = _v1Domain;
+        }
+    }
+}

--- a/solidity/contracts/middleware/V2CompatibilityRouter.sol
+++ b/solidity/contracts/middleware/V2CompatibilityRouter.sol
@@ -68,7 +68,6 @@ contract V2CompatibilityRouter is Router {
     /**
      * @notice The internal Router `handle` function which just extracts the true recipient of the message and passes the translated v2 domain ID
      * @param _originV1Domain the origin domain as specified by the v1 Inbox
-     * @param _sender The sender of the message which for middlewares is just the router on the origin chain
      * @param _message The wrapped message to include sender and recipient
      */
     function _handle(

--- a/solidity/contracts/middleware/V2CompatibilityRouter.sol
+++ b/solidity/contracts/middleware/V2CompatibilityRouter.sol
@@ -6,8 +6,8 @@ import {TypeCasts} from "../libs/TypeCasts.sol";
 import {IMessageRecipient} from "../../interfaces/IMessageRecipient.sol";
 
 /*
- * @title The Hello World App
- * @dev You can use this simple app as a starting point for your own application.
+ * @title V2CompatabilityRouter
+ * @dev You can use this middleware to deploy an app on v1 with the v2 interface
  */
 contract V2CompatibilityRouter is Router {
     mapping(uint32 => uint32) v1ToV2Domain;
@@ -21,7 +21,6 @@ contract V2CompatibilityRouter is Router {
         // Transfer ownership of the contract to deployer
         _transferOwnership(_owner);
         // Set the addresses for the ACM and IGP
-        // Alternatively, this could be done later in an initialize method
         _setAbacusConnectionManager(_abacusConnectionManager);
         _setInterchainGasPaymaster(_interchainGasPaymaster);
     }
@@ -67,7 +66,10 @@ contract V2CompatibilityRouter is Router {
     }
 
     /**
-     * Calls the recipient of the message with the translated v2 domain ID
+     * @notice The internal Router `handle` function which just extracts the true recipient of the message and passes the translated v2 domain ID
+     * @param _originV1Domain the origin domain as specified by the v1 Inbox
+     * @param _sender The sender of the message which for middlewares is just the router on the origin chain
+     * @param _message The wrapped message to include sender and recipient
      */
     function _handle(
         uint32 _originV1Domain,

--- a/solidity/test/V2CompatabilityMiddlewareRouter.t.sol
+++ b/solidity/test/V2CompatabilityMiddlewareRouter.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "../contracts/test/TestRecipient.sol";
+import {V2CompatibilityRouter} from "../contracts/middleware/V2CompatibilityRouter.sol";
+import {MockHyperlaneEnvironment} from "../contracts/mock/MockHyperlaneEnvironment.sol";
+
+import {TypeCasts} from "../contracts/libs/TypeCasts.sol";
+
+contract V2CompatibilityRouterTest is Test {
+    MockHyperlaneEnvironment testEnvironment;
+
+    V2CompatibilityRouter originRouter;
+    V2CompatibilityRouter destinationRouter;
+
+    TestRecipient recipient;
+
+    uint32 originDomain = 123;
+    uint32 destinationDomain = 321;
+
+    uint32 v2OriginDomain = 456;
+    uint32 v2DestinationDomain = 654;
+
+    function setUp() public {
+        originRouter = new V2CompatibilityRouter();
+        destinationRouter = new V2CompatibilityRouter();
+
+        testEnvironment = new MockHyperlaneEnvironment(
+            originDomain,
+            destinationDomain
+        );
+
+        originRouter.initialize(
+            address(this),
+            address(testEnvironment.connectionManager(originDomain)),
+            address(0)
+        );
+        destinationRouter.initialize(
+            address(this),
+            address(testEnvironment.connectionManager(destinationDomain)),
+            address(0)
+        );
+
+        uint32[] memory v1Domains = new uint32[](2);
+        v1Domains[0] = originDomain;
+        v1Domains[1] = destinationDomain;
+
+        uint32[] memory v2Domains = new uint32[](2);
+        v2Domains[0] = v2OriginDomain;
+        v2Domains[1] = v2DestinationDomain;
+
+        originRouter.mapDomains(v1Domains, v2Domains);
+        destinationRouter.mapDomains(v1Domains, v2Domains);
+
+        originRouter.enrollRemoteRouter(
+            destinationDomain,
+            TypeCasts.addressToBytes32(address(destinationRouter))
+        );
+        destinationRouter.enrollRemoteRouter(
+            originDomain,
+            TypeCasts.addressToBytes32(address(originRouter))
+        );
+
+        recipient = new TestRecipient();
+    }
+
+    function testCanSendMessageWithV2Domains(bytes calldata _messageBody)
+        public
+    {
+        originRouter.dispatch(
+            v2DestinationDomain,
+            TypeCasts.addressToBytes32(address(recipient)),
+            _messageBody
+        );
+
+        vm.expectCall(
+            address(recipient),
+            abi.encodeWithSelector(
+                recipient.handle.selector,
+                v2OriginDomain,
+                TypeCasts.addressToBytes32(address(this)),
+                _messageBody
+            )
+        );
+        testEnvironment.processNextPendingMessage();
+
+        assertEq(recipient.lastData(), _messageBody);
+        assertEq(
+            recipient.lastSender(),
+            TypeCasts.addressToBytes32(address(this))
+        );
+    }
+}

--- a/typescript/infra/config/environments/mainnet/middleware/v2compatibility/addresses.json
+++ b/typescript/infra/config/environments/mainnet/middleware/v2compatibility/addresses.json
@@ -1,0 +1,23 @@
+{
+  "bsc": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  },
+  "avalanche": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  },
+  "celo": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  },
+  "arbitrum": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  },
+  "optimism": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  },
+  "ethereum": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  },
+  "moonbeam": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  }
+}

--- a/typescript/infra/config/environments/mainnet/middleware/v2compatibility/verification.json
+++ b/typescript/infra/config/environments/mainnet/middleware/v2compatibility/verification.json
@@ -1,0 +1,66 @@
+{
+  "bsc": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "avalanche": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "polygon": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "celo": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "arbitrum": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "optimism": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "ethereum": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "moonbeam": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ]
+}

--- a/typescript/infra/config/environments/testnet2/middleware/v2compatibility/addresses.json
+++ b/typescript/infra/config/environments/testnet2/middleware/v2compatibility/addresses.json
@@ -1,0 +1,26 @@
+{
+  "alfajores": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  },
+  "fuji": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  },
+  "mumbai": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  },
+  "bsctestnet": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  },
+  "goerli": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  },
+  "moonbasealpha": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  },
+  "optimismgoerli": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  },
+  "arbitrumgoerli": {
+    "router": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec"
+  }
+}

--- a/typescript/infra/config/environments/testnet2/middleware/v2compatibility/verification.json
+++ b/typescript/infra/config/environments/testnet2/middleware/v2compatibility/verification.json
@@ -1,0 +1,66 @@
+{
+  "alfajores": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "fuji": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "mumbai": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "bsctestnet": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "goerli": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "moonbasealpha": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "optimismgoerli": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "arbitrumgoerli": [
+    {
+      "name": "V2CompatibilityRouter",
+      "address": "0x1d3aAC239538e6F1831C8708803e61A9EA299Eec",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ]
+}

--- a/typescript/infra/scripts/middleware/deploy-v2compatibility.ts
+++ b/typescript/infra/scripts/middleware/deploy-v2compatibility.ts
@@ -1,0 +1,60 @@
+import path from 'path';
+
+import {
+  ChainNameToDomainId,
+  HyperlaneCore,
+  V2CompatibilityRouterDeployer,
+  objMap,
+  v2CompatibilityFactories,
+} from '@hyperlane-xyz/sdk';
+
+import { deployWithArtifacts } from '../../src/deploy';
+import { getConfiguration } from '../helloworld/utils';
+import { mergeWithSdkContractAddressArtifacts } from '../merge-sdk-contract-addresses';
+import {
+  getCoreEnvironmentConfig,
+  getEnvironment,
+  getEnvironmentDirectory,
+} from '../utils';
+
+// similar to hello world deploy script but uses freshly funded account for consistent addresses across chains
+// should eventually be deduped
+async function main() {
+  const environment = await getEnvironment();
+  const coreConfig = getCoreEnvironmentConfig(environment);
+  const multiProvider = await coreConfig.getMultiProvider();
+  const core = HyperlaneCore.fromEnvironment(environment, multiProvider as any);
+
+  const dir = path.join(
+    getEnvironmentDirectory(environment),
+    'middleware/v2compatibility',
+  );
+
+  // config gcp deployer key as owner
+  const configMap = await getConfiguration(environment, multiProvider);
+  const v1Domains = Object.keys(configMap).map((_) => ChainNameToDomainId[_]);
+  // V2 Domain IDs are just the chain IDs
+  const v2Domains = await Promise.all(
+    Object.keys(configMap).map((_) =>
+      multiProvider
+        .getChainConnection(_)
+        .provider.getNetwork()
+        .then((_) => _.chainId),
+    ),
+  );
+
+  console.log(v1Domains, v2Domains);
+  const deployer = new V2CompatibilityRouterDeployer(
+    multiProvider,
+    objMap(configMap, (_, c) => ({ ...c, v1Domains, v2Domains })),
+    core,
+    'v2compatibilitymiddleware3',
+  );
+
+  await deployWithArtifacts(dir, v2CompatibilityFactories, deployer);
+  await mergeWithSdkContractAddressArtifacts(environment);
+}
+
+main()
+  .then(() => console.info('Deployment complete'))
+  .catch(console.error);

--- a/typescript/sdk/src/deploy/middleware/V2CompatibilityMiddlewareDeployer.ts
+++ b/typescript/sdk/src/deploy/middleware/V2CompatibilityMiddlewareDeployer.ts
@@ -1,0 +1,61 @@
+import { V2CompatibilityRouter__factory } from '@hyperlane-xyz/core';
+
+import { HyperlaneCore } from '../../core/HyperlaneCore';
+import {
+  V2CompatibilityContracts,
+  V2CompatibilityFactories,
+  v2CompatibilityFactories,
+} from '../../middleware';
+import { MultiProvider } from '../../providers/MultiProvider';
+import { ChainMap, ChainName } from '../../types';
+import { HyperlaneRouterDeployer } from '../router/HyperlaneRouterDeployer';
+import { RouterConfig } from '../router/types';
+
+export type V2CompatibilityConfig = RouterConfig & {
+  v1Domains: number[];
+  v2Domains: number[];
+};
+
+export class V2CompatibilityRouterDeployer<
+  Chain extends ChainName,
+> extends HyperlaneRouterDeployer<
+  Chain,
+  V2CompatibilityConfig,
+  V2CompatibilityContracts,
+  V2CompatibilityFactories
+> {
+  constructor(
+    multiProvider: MultiProvider<Chain>,
+    configMap: ChainMap<Chain, V2CompatibilityConfig>,
+    protected core: HyperlaneCore<Chain>,
+    protected create2salt = 'asdasdsd',
+  ) {
+    super(multiProvider, configMap, v2CompatibilityFactories, {});
+  }
+
+  // Custom contract deployment logic can go here
+  // If no custom logic is needed, call deployContract for the router
+  async deployContracts(
+    chain: Chain,
+    config: V2CompatibilityConfig,
+  ): Promise<V2CompatibilityContracts> {
+    const initCalldata =
+      V2CompatibilityRouter__factory.createInterface().encodeFunctionData(
+        'initialize',
+        [config.owner, config.connectionManager, config.interchainGasPaymaster],
+      );
+    const router = await this.deployContract(chain, 'router', [], {
+      create2Salt: this.create2salt + 'router',
+      initCalldata,
+    });
+
+    this.logger(`Set domain mapping`, config.v1Domains, config.v2Domains);
+    await this.multiProvider
+      .getChainConnection(chain)
+      .handleTx(router.mapDomains(config.v1Domains, config.v2Domains));
+
+    return {
+      router,
+    };
+  }
+}

--- a/typescript/sdk/src/deploy/router/HyperlaneRouterDeployer.ts
+++ b/typescript/sdk/src/deploy/router/HyperlaneRouterDeployer.ts
@@ -75,34 +75,43 @@ export abstract class HyperlaneRouterDeployer<
     );
     // Make all routers aware of each other.
     const deployedChains = Object.keys(contractsMap);
-    await promiseObjAll(
-      objMap(contractsMap, async (local, contracts) => {
-        const chainConnection = this.multiProvider.getChainConnection(local);
-        // only enroll chains which are deployed
-        const enrollChains = this.multiProvider
-          .remoteChains(local)
-          .filter((c) => deployedChains.includes(c));
-        for (const remote of enrollChains) {
+    for (const [chain, contracts] of Object.entries<RouterContracts>(
+      contractsMap,
+    )) {
+      const local = chain as Chain;
+      const chainConnection = this.multiProvider.getChainConnection(local);
+      // only enroll chains which are deployed
+      const deployedRemoteChains = this.multiProvider
+        .remoteChains(local)
+        .filter((c) => deployedChains.includes(c));
+      const enrollEntries = await Promise.all(
+        deployedRemoteChains.map(async (remote) => {
           const remoteDomain = chainMetadata[remote].id;
           const current = await contracts.router.routers(remoteDomain);
           const expected = utils.addressToBytes32(
             contractsMap[remote].router.address,
           );
-          if (current !== expected) {
-            await super.runIfOwner(local, contracts.router, async () => {
-              this.logger(`Enroll ${remote}'s router on ${local}`);
-              await chainConnection.handleTx(
-                contracts.router.enrollRemoteRouter(
-                  chainMetadata[remote].id,
-                  expected,
-                  chainConnection.overrides,
-                ),
-              );
-            });
-          }
-        }
-      }),
-    );
+          return current !== expected ? [remote, expected] : undefined;
+        }),
+      );
+      const entries = enrollEntries.filter(
+        (entry): entry is [Chain, string] => entry !== undefined,
+      );
+
+      const domains = entries.map(([chain]) => chainMetadata[chain].id);
+      const addresses = entries.map(([, address]) => address);
+
+      await super.runIfOwner(local, contracts.router, async () => {
+        this.logger(`Enroll remote (${domains}) routers on ${local}`);
+        await chainConnection.handleTx(
+          contracts.router.enrollRemoteRouters(
+            domains,
+            addresses,
+            chainConnection.overrides,
+          ),
+        );
+      });
+    }
   }
 
   async transferOwnership(

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -121,6 +121,10 @@ export {
   InterchainQueryDeployer,
 } from './deploy/middleware/deploy';
 export {
+  V2CompatibilityConfig,
+  V2CompatibilityRouterDeployer,
+} from './deploy/middleware/V2CompatibilityMiddlewareDeployer';
+export {
   LiquidityLayerDeployer,
   BridgeAdapterType,
   BridgeAdapterConfig,
@@ -134,6 +138,7 @@ export {
   interchainAccountFactories,
   interchainQueryFactories,
   liquidityLayerFactories,
+  v2CompatibilityFactories,
 } from './middleware';
 export { RouterConfig } from './deploy/router/types';
 export { getTestMultiProvider, getChainToOwnerMap } from './deploy/utils';

--- a/typescript/sdk/src/middleware.ts
+++ b/typescript/sdk/src/middleware.ts
@@ -9,6 +9,8 @@ import {
   LiquidityLayerRouter__factory,
   PortalAdapter,
   PortalAdapter__factory,
+  V2CompatibilityRouter,
+  V2CompatibilityRouter__factory,
 } from '@hyperlane-xyz/core';
 
 import { RouterContracts, RouterFactories } from './router';
@@ -46,3 +48,11 @@ export type LiquidityLayerContracts = RouterContracts<LiquidityLayerRouter> & {
   circleBridgeAdapter?: CircleBridgeAdapter;
   portalAdapter?: PortalAdapter;
 };
+
+export type V2CompatibilityFactories = RouterFactories<V2CompatibilityRouter>;
+
+export const v2CompatibilityFactories: V2CompatibilityFactories = {
+  router: new V2CompatibilityRouter__factory(),
+};
+
+export type V2CompatibilityContracts = RouterContracts<V2CompatibilityRouter>;


### PR DESCRIPTION
### Description

Adds V2Compatbility middleware that allows users to use the `V2CompatibilityRouter` in place of v2 mailboxes 
