### PR TITLE
Reduce message retries

### DIFF
--- a/rust/agents/relayer/src/msg/mod.rs
+++ b/rust/agents/relayer/src/msg/mod.rs
@@ -35,7 +35,7 @@ pub struct SubmitMessageArgs {
     pub proof: Proof,
     pub enqueue_time: Instant,
     num_retries: u32,
-    last_attempted_at: Instant,
+    last_attempted_at: Option<Instant>,
 }
 
 impl SubmitMessageArgs {
@@ -53,7 +53,7 @@ impl SubmitMessageArgs {
             proof,
             enqueue_time,
             num_retries: 0,
-            last_attempted_at: Instant::now(),
+            last_attempted_at: None,
         }
     }
 }

--- a/rust/agents/relayer/src/msg/mod.rs
+++ b/rust/agents/relayer/src/msg/mod.rs
@@ -1,8 +1,7 @@
 use std::cmp::Ordering;
+use std::time::Instant;
 
 use abacus_core::{accumulator::merkle::Proof, CommittedMessage, MultisigSignedCheckpoint};
-
-use tokio::time::Instant;
 
 pub mod gas_payment;
 pub mod gelato_submitter;
@@ -36,6 +35,7 @@ pub struct SubmitMessageArgs {
     pub proof: Proof,
     pub enqueue_time: Instant,
     num_retries: u32,
+    last_attempted_at: Option<Instant>,
 }
 
 impl SubmitMessageArgs {
@@ -53,6 +53,7 @@ impl SubmitMessageArgs {
             proof,
             enqueue_time,
             num_retries: 0,
+            last_attempted_at: None,
         }
     }
 }

--- a/rust/agents/relayer/src/msg/mod.rs
+++ b/rust/agents/relayer/src/msg/mod.rs
@@ -35,7 +35,7 @@ pub struct SubmitMessageArgs {
     pub proof: Proof,
     pub enqueue_time: Instant,
     num_retries: u32,
-    last_attempted_at: Option<Instant>,
+    last_attempted_at: Instant,
 }
 
 impl SubmitMessageArgs {
@@ -53,7 +53,7 @@ impl SubmitMessageArgs {
             proof,
             enqueue_time,
             num_retries: 0,
-            last_attempted_at: None,
+            last_attempted_at: Instant::now(),
         }
     }
 }

--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -1,11 +1,13 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use eyre::Result;
 use prometheus::IntGauge;
 use tokio::{
     sync::{mpsc, watch},
     task::JoinHandle,
-    time::Instant,
 };
 use tracing::{debug, info_span, instrument, instrument::Instrumented, warn, Instrument};
 

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -27,7 +27,7 @@ use super::{gas_payment::GasPaymentEnforcer, SubmitMessageArgs};
 /// message delivery latency and delivery order), as well as message delivery eligibility (e.g.
 /// due to (non-)existence of source chain gas payments).
 ///
-/// Messages which failed delivery due to a retrievable error are also retained within the
+/// Messages which failed delivery due to a retriable error are also retained within the
 /// SerialSubmitter, and will eventually be retried according to our prioritization rule.
 ///
 /// Finally, the SerialSubmitter ensures that message delivery is robust to destination chain

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -202,10 +202,10 @@ impl SerialSubmitter {
             None => return Ok(()),
         };
 
-        if msg.num_retries >= 2 {
+        if msg.num_retries >= 4 {
             let required_duration = Duration::from_secs(match msg.num_retries {
-                i if i < 2 => unreachable!(),
-                i if (2..8).contains(&i) => 60,        // wait 1 min
+                i if i < 4 => unreachable!(),
+                i if (4..8).contains(&i) => 60,        // wait 1 min
                 i if (8..16).contains(&i) => 60 * 5,   // wait 5 min
                 i if (16..24).contains(&i) => 60 * 30, // wait 30 min
                 _ => 60 * 60,                          // max timeout of 1hr beyond that

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -202,13 +202,12 @@ impl SerialSubmitter {
         };
 
         if let Some(last_attempted_at) = msg.last_attempted_at {
-            if msg.num_retries > 1 {
+            if msg.num_retries >= 10 {
                 let required_duration = Duration::from_secs(match msg.num_retries {
-                    0 | 1 => unreachable!(),
-                    2 => 60,              // give it a short 1 min timeout
-                    3 | 4 | 5 => 60 * 5,  // wait 5 min
-                    6 | 7 | 8 => 60 * 30, // wait 30 min
-                    _ => 60 * 60,         // max timeout of 1hr beyond that
+                    i if i < 10 => unreachable!(),
+                    i if i > 10 && i < 20 => 60 * 5,  // wait 5 min
+                    i if i > 20 && i < 30 => 60 * 30, // wait 30 min
+                    _ => 60 * 60, // max timeout of 1hr beyond that
                 });
                 if Instant::now().duration_since(last_attempted_at) < required_duration {
                     self.run_queue.push_back(msg);

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -5,7 +5,8 @@ use std::time::{Duration, Instant};
 use eyre::{bail, Result};
 use prometheus::{Histogram, IntCounter, IntGauge};
 use tokio::sync::mpsc::{self, error::TryRecvError};
-use tokio::task::{yield_now, JoinHandle};
+use tokio::task::JoinHandle;
+use tokio::time::sleep;
 use tracing::{debug, info, info_span, instrument, instrument::Instrumented, warn, Instrument};
 
 use abacus_base::{CoreMetrics, InboxContracts};
@@ -149,7 +150,7 @@ impl SerialSubmitter {
     async fn work_loop(&mut self) -> Result<()> {
         loop {
             self.tick().await?;
-            yield_now().await;
+            sleep(Duration::from_secs(1)).await;
         }
     }
 

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -207,7 +207,7 @@ impl SerialSubmitter {
                     i if i < 10 => unreachable!(),
                     i if i > 10 && i < 20 => 60 * 5,  // wait 5 min
                     i if i > 20 && i < 30 => 60 * 30, // wait 30 min
-                    _ => 60 * 60, // max timeout of 1hr beyond that
+                    _ => 60 * 60,                     // max timeout of 1hr beyond that
                 });
                 if Instant::now().duration_since(last_attempted_at) < required_duration {
                     self.run_queue.push_back(msg);

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -205,9 +205,10 @@ impl SerialSubmitter {
         if msg.num_retries >= 4 {
             let required_duration = Duration::from_secs(match msg.num_retries {
                 i if i < 4 => unreachable!(),
-                i if (4..8).contains(&i) => 60,        // wait 1 min
-                i if (8..16).contains(&i) => 60 * 5,   // wait 5 min
-                i if (16..24).contains(&i) => 60 * 30, // wait 30 min
+                i if (4..8).contains(&i) => 10,        // wait 10 sec
+                i if (8..16).contains(&i) => 60,       // wait 1 min
+                i if (16..24).contains(&i) => 60 * 5,  // wait 5 min
+                i if (24..32).contains(&i) => 60 * 30, // wait 30 min
                 _ => 60 * 60,                          // max timeout of 1hr beyond that
             });
             if Instant::now().duration_since(msg.last_attempted_at) < required_duration {

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -185,7 +185,7 @@ impl SerialSubmitter {
         for msg in self.wait_queue.drain(..).rev() {
             // TODO(webbhorn): Check against interchain gas paymaster. If now enough payment,
             // promote to run queue.
-            self.run_queue.push_front(msg.into());
+            self.run_queue.push_front(msg);
         }
 
         self.metrics

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -201,18 +201,16 @@ impl SerialSubmitter {
             None => return Ok(()),
         };
 
-        if let Some(last_attempted_at) = msg.last_attempted_at {
-            if msg.num_retries >= 10 {
-                let required_duration = Duration::from_secs(match msg.num_retries {
-                    i if i < 10 => unreachable!(),
-                    i if i > 10 && i < 20 => 60 * 5,  // wait 5 min
-                    i if i > 20 && i < 30 => 60 * 30, // wait 30 min
-                    _ => 60 * 60,                     // max timeout of 1hr beyond that
-                });
-                if Instant::now().duration_since(last_attempted_at) < required_duration {
-                    self.run_queue.push_back(msg);
-                    return Ok(());
-                }
+        if msg.num_retries >= 10 {
+            let required_duration = Duration::from_secs(match msg.num_retries {
+                i if i < 10 => unreachable!(),
+                i if i > 10 && i < 20 => 60 * 5,  // wait 5 min
+                i if i > 20 && i < 30 => 60 * 30, // wait 30 min
+                _ => 60 * 60,                     // max timeout of 1hr beyond that
+            });
+            if Instant::now().duration_since(msg.last_attempted_at) < required_duration {
+                self.run_queue.push_back(msg);
+                return Ok(());
             }
         }
 

--- a/typescript/infra/config/environments/mainnet/agent.ts
+++ b/typescript/infra/config/environments/mainnet/agent.ts
@@ -23,7 +23,7 @@ export const abacus: AgentConfig<MainnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-9b17834',
+    tag: 'sha-d599c2d',
   },
   aws: {
     region: 'us-east-1',

--- a/typescript/infra/config/environments/mainnet/agent.ts
+++ b/typescript/infra/config/environments/mainnet/agent.ts
@@ -23,7 +23,7 @@ export const abacus: AgentConfig<MainnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-d599c2d',
+    tag: 'sha-6bdb257',
   },
   aws: {
     region: 'us-east-1',

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -26,7 +26,7 @@ export const abacus: AgentConfig<TestnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-d599c2d',
+    tag: 'sha-6bdb257',
   },
   aws: {
     region: 'us-east-1',

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -26,7 +26,7 @@ export const abacus: AgentConfig<TestnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-a58c245',
+    tag: 'sha-d599c2d',
   },
   aws: {
     region: 'us-east-1',


### PR DESCRIPTION
### Description

Quick fix to make it so that messages are not constituently being retired if they fail to be sent. This does not evict messages, but it does provide a bandaid for now to reduce the RPC calls we are making. It also hard-codes in the waits for now so that if someone is testing with a message thy won't have to possible wait for days after they fix the issue that was preventing a message from being sent.

We should also be able to port this change to v2 pretty easily.

### Drive-by changes

Minor cleanup to imports.

### Related issues

- #1405

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Manual (e2e)
