### PR TITLE
Reduce metric cardinality

### DIFF
--- a/rust/abacus-base/src/metrics/provider.rs
+++ b/rust/abacus-base/src/metrics/provider.rs
@@ -2,7 +2,7 @@ use eyre::Result;
 
 use ethers_prometheus::middleware::*;
 
-use crate::{CoreMetrics, NETWORK_HISTOGRAM_BUCKETS};
+use crate::CoreMetrics;
 
 pub(crate) fn create_provider_metrics(metrics: &CoreMetrics) -> Result<MiddlewareMetrics> {
     Ok(MiddlewareMetricsBuilder::default()
@@ -36,11 +36,10 @@ pub(crate) fn create_provider_metrics(metrics: &CoreMetrics) -> Result<Middlewar
             LOG_QUERY_COUNT_HELP,
             LOGS_QUERY_COUNT_LABELS,
         )?)
-        .transaction_send_duration_seconds(metrics.new_histogram(
+        .transaction_send_duration_seconds(metrics.new_counter(
             "transaction_send_duration_seconds",
             TRANSACTION_SEND_DURATION_SECONDS_HELP,
             TRANSACTION_SEND_DURATION_SECONDS_LABELS,
-            NETWORK_HISTOGRAM_BUCKETS.into(),
         )?)
         .transaction_send_total(metrics.new_int_counter(
             "transaction_send_total",

--- a/rust/agents/relayer/src/msg/gelato_submitter/mod.rs
+++ b/rust/agents/relayer/src/msg/gelato_submitter/mod.rs
@@ -6,9 +6,9 @@ use abacus_core::db::AbacusDB;
 use abacus_core::{AbacusChain, AbacusDomain};
 use eyre::{bail, Result};
 use gelato::types::Chain;
-use prometheus::{Histogram, IntCounter, IntGauge};
+use prometheus::{IntCounter, IntGauge};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use tokio::time::{sleep, Duration, Instant};
+use tokio::time::{sleep, Duration};
 use tokio::{sync::mpsc::error::TryRecvError, task::JoinHandle};
 use tracing::{info_span, instrument::Instrumented, Instrument};
 
@@ -155,9 +155,6 @@ impl GelatoSubmitter {
         self.db.mark_leaf_as_processed(msg.leaf_index)?;
 
         self.metrics.active_sponsored_call_ops_gauge.sub(1);
-        self.metrics
-            .queue_duration_hist
-            .observe((Instant::now() - msg.enqueue_time).as_secs_f64());
         self.metrics.highest_submitted_leaf_index =
             std::cmp::max(self.metrics.highest_submitted_leaf_index, msg.leaf_index);
         self.metrics
@@ -170,7 +167,6 @@ impl GelatoSubmitter {
 
 #[derive(Debug)]
 pub(crate) struct GelatoSubmitterMetrics {
-    queue_duration_hist: Histogram,
     processed_gauge: IntGauge,
     messages_processed_count: IntCounter,
     active_sponsored_call_ops_gauge: IntGauge,
@@ -181,9 +177,6 @@ pub(crate) struct GelatoSubmitterMetrics {
 impl GelatoSubmitterMetrics {
     pub fn new(metrics: &CoreMetrics, outbox_chain: &str, inbox_chain: &str) -> Self {
         Self {
-            queue_duration_hist: metrics
-                .submitter_queue_duration_histogram()
-                .with_label_values(&[outbox_chain, inbox_chain]),
             messages_processed_count: metrics
                 .messages_processed_count()
                 .with_label_values(&[outbox_chain, inbox_chain]),

--- a/rust/agents/relayer/src/msg/gelato_submitter/mod.rs
+++ b/rust/agents/relayer/src/msg/gelato_submitter/mod.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use eyre::{bail, Result};
 use prometheus::{IntCounter, IntGauge};

--- a/rust/agents/relayer/src/msg/mod.rs
+++ b/rust/agents/relayer/src/msg/mod.rs
@@ -2,8 +2,6 @@ use std::cmp::Ordering;
 
 use abacus_core::{accumulator::merkle::Proof, CommittedMessage, MultisigSignedCheckpoint};
 
-use tokio::time::Instant;
-
 pub mod gas_payment;
 pub mod gelato_submitter;
 pub mod processor;
@@ -34,7 +32,6 @@ pub struct SubmitMessageArgs {
     pub committed_message: CommittedMessage,
     pub checkpoint: MultisigSignedCheckpoint,
     pub proof: Proof,
-    pub enqueue_time: Instant,
     num_retries: u32,
 }
 
@@ -44,14 +41,12 @@ impl SubmitMessageArgs {
         committed_message: CommittedMessage,
         checkpoint: MultisigSignedCheckpoint,
         proof: Proof,
-        enqueue_time: Instant,
     ) -> Self {
         SubmitMessageArgs {
             leaf_index,
             committed_message,
             checkpoint,
             proof,
-            enqueue_time,
             num_retries: 0,
         }
     }

--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -5,7 +5,6 @@ use prometheus::IntGauge;
 use tokio::{
     sync::{mpsc, watch},
     task::JoinHandle,
-    time::Instant,
 };
 use tracing::{debug, info_span, instrument, instrument::Instrumented, warn, Instrument};
 
@@ -203,7 +202,6 @@ impl MessageProcessor {
                 message,
                 checkpoint,
                 proof,
-                Instant::now(),
             );
             self.tx_msg.send(submit_args)?;
             self.message_leaf_index += 1;

--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{sync::Arc, time::Duration};
 
 use eyre::Result;
 use prometheus::IntGauge;
@@ -200,12 +197,8 @@ impl MessageProcessor {
                 self.message_leaf_index
             );
             // Finally, build the submit arg and dispatch it to the submitter.
-            let submit_args = SubmitMessageArgs::new(
-                self.message_leaf_index,
-                message,
-                checkpoint,
-                proof,
-            );
+            let submit_args =
+                SubmitMessageArgs::new(self.message_leaf_index, message, checkpoint, proof);
             self.tx_msg.send(submit_args)?;
             self.message_leaf_index += 1;
         } else {

--- a/typescript/infra/config/environments/mainnet/agent.ts
+++ b/typescript/infra/config/environments/mainnet/agent.ts
@@ -23,7 +23,7 @@ export const abacus: AgentConfig<MainnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-6bdb257',
+    tag: 'sha-01fc263',
   },
   aws: {
     region: 'us-east-1',

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -26,7 +26,7 @@ export const abacus: AgentConfig<TestnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-6bdb257',
+    tag: 'sha-01fc263',
   },
   aws: {
     region: 'us-east-1',


### PR DESCRIPTION
### Description

* Replaced histograms with counter + duration sums (we were not using the histogram buckets anyway)
* Removed submission time histogram for submitters

### Drive-by changes

None

### Related issues

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

Yes - slight change to metrics dashboards might be required


### Testing

_What kind of testing have these changes undergone?_

Manual
Unit Tests
