### PR TITLE
Fix provider wrapping order

### DIFF
--- a/rust/abacus-base/src/metrics/json_rpc_client.rs
+++ b/rust/abacus-base/src/metrics/json_rpc_client.rs
@@ -12,11 +12,6 @@ pub(crate) fn create_json_rpc_client_metrics(
             REQUEST_COUNT_HELP,
             REQUEST_COUNT_LABELS,
         )?)
-        .request_failure_count(metrics.new_int_counter(
-            "request_failure_count",
-            REQUEST_FAILURE_COUNT_HELP,
-            REQUEST_FAILURE_COUNT_LABELS,
-        )?)
         .request_duration_seconds(metrics.new_counter(
             "request_duration_seconds",
             REQUEST_DURATION_SECONDS_HELP,

--- a/rust/abacus-base/src/settings/chains.rs
+++ b/rust/abacus-base/src/settings/chains.rs
@@ -156,7 +156,7 @@ impl<T> ChainSetup<T> {
                             address: address.parse::<ethers::types::Address>()?.into(),
                         },
                         signer,
-                        Some(|| metrics.json_rpc_client_metrics()),
+                        Some(metrics.json_rpc_client_metrics()),
                         Some((metrics.provider_metrics(), metrics_conf)),
                     )
                     .await

--- a/rust/chains/abacus-ethereum/src/retrying.rs
+++ b/rust/chains/abacus-ethereum/src/retrying.rs
@@ -2,6 +2,7 @@ use std::{fmt::Debug, str::FromStr, time::Duration};
 
 use async_trait::async_trait;
 use ethers::providers::{Http, JsonRpcClient, ProviderError};
+use ethers_prometheus::json_rpc_client::PrometheusJsonRpcClient;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 use thiserror::Error;
@@ -157,10 +158,10 @@ where
 }
 
 #[async_trait]
-impl JsonRpcClient for RetryingProvider<Http> {
-    type Error = RetryingProviderError<Http>;
+impl JsonRpcClient for RetryingProvider<PrometheusJsonRpcClient<Http>> {
+    type Error = RetryingProviderError<PrometheusJsonRpcClient<Http>>;
 
-    #[instrument(skip(self), fields(provider_host = %self.inner.url().host_str().unwrap_or("unknown")))]
+    #[instrument(skip(self), fields(provider_host = %self.inner.node_host(), chain_name = %self.inner.chain_name()))]
     async fn request<T, R>(&self, method: &str, params: T) -> Result<R, Self::Error>
     where
         T: Debug + Serialize + Send + Sync,

--- a/rust/chains/abacus-ethereum/src/trait_builder.rs
+++ b/rust/chains/abacus-ethereum/src/trait_builder.rs
@@ -38,12 +38,11 @@ pub trait MakeableWithProvider {
         conn: Connection,
         locator: &ContractLocator,
         signer: Option<Signers>,
-        rpc_metrics: Option<impl FnOnce() -> JsonRpcClientMetrics + Send>,
+        rpc_metrics: Option<JsonRpcClientMetrics>,
         middleware_metrics: Option<(MiddlewareMetrics, PrometheusMiddlewareConf)>,
     ) -> eyre::Result<Self::Output> {
         Ok(match conn {
             Connection::HttpQuorum { urls } => {
-                let rpc_metrics = rpc_metrics.map(|f| f());
                 let mut builder = QuorumProvider::builder().quorum(Quorum::Majority);
                 let http_client = Client::builder().timeout(HTTP_CLIENT_TIMEOUT).build()?;
                 for url in urls.split(',') {
@@ -58,15 +57,15 @@ pub trait MakeableWithProvider {
                     // RPCs being retried, while retrying at the inner provider
                     // level will result in only the second RPC being retried
                     // (the one with the error), which is the desired behavior.
-                    let retrying_provider =
-                        RetryingProvider::new(http_provider, Some(5), Some(1000));
                     let metrics_provider = self.wrap_rpc_with_metrics(
-                        retrying_provider,
+                        http_provider,
                         Url::parse(url)?,
                         &rpc_metrics,
                         &middleware_metrics,
                     );
-                    let weighted_provider = WeightedProvider::new(metrics_provider);
+                    let retrying_provider =
+                        RetryingProvider::new(metrics_provider, Some(5), Some(1000));
+                    let weighted_provider = WeightedProvider::new(retrying_provider);
                     builder = builder.add_provider(weighted_provider);
                 }
                 let quorum_provider = builder.build();
@@ -75,9 +74,15 @@ pub trait MakeableWithProvider {
             }
             Connection::Http { url } => {
                 let http_client = Client::builder().timeout(HTTP_CLIENT_TIMEOUT).build()?;
-                let http_provider = Http::new_with_client(url.parse::<Url>()?, http_client);
-                let retrying_http_provider: RetryingProvider<Http> =
-                    RetryingProvider::new(http_provider, None, None);
+                let parsed_url = url.parse::<Url>()?;
+                let http_provider = Http::new_with_client(parsed_url.clone(), http_client);
+                let metrics_provider = self.wrap_rpc_with_metrics(
+                    http_provider,
+                    parsed_url,
+                    &rpc_metrics,
+                    &middleware_metrics,
+                );
+                let retrying_http_provider = RetryingProvider::new(metrics_provider, None, None);
                 self.wrap_with_metrics(retrying_http_provider, locator, signer, middleware_metrics)
                     .await?
             }

--- a/rust/ethers-prometheus/src/json_rpc_client.rs
+++ b/rust/ethers-prometheus/src/json_rpc_client.rs
@@ -136,6 +136,23 @@ where
     }
 }
 
+impl<C> PrometheusJsonRpcClient<C> {
+    /// The "host" part of the URL this node is connecting to. E.g. `avalanche.api.onfinality.io`.
+    pub fn node_host(&self) -> &str {
+        self.config.node_host()
+    }
+
+    /// Chain name this RPC client is connected to.
+    pub fn chain_name(&self) -> &str {
+        self.config.chain_name()
+    }
+
+    /// The inner RpcClient implementation
+    pub fn inner(&self) -> &C {
+        &self.inner
+    }
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl<C> JsonRpcClient for PrometheusJsonRpcClient<C>


### PR DESCRIPTION
### Description

Noticed the metrics we are collecting for provider requests is actually not the number of requests we send to the underlying provider which means our error tracking is very wrong. The success count should be the same though. 

Also made a change to how we count errors to be more in-line with best practice and make it a little easier to see what is going on.

### Drive-by changes
None

### Related issues

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

Minor - does change the meaning/accuracy of the metric and changes how failures are reported.


### Testing

_What kind of testing have these changes undergone?_

Manual
