### PR TITLE
Make some Checkpoint hash fns public and rename them too

### DIFF
--- a/rust/hyperlane-core/src/types/checkpoint.rs
+++ b/rust/hyperlane-core/src/types/checkpoint.rs
@@ -143,7 +143,9 @@ impl Decode for SignedCheckpoint {
 impl SignedCheckpoint {
     /// Recover the Ethereum address of the signer
     pub fn recover(&self) -> Result<Address, HyperlaneProtocolError> {
-        Ok(self.signature.recover(self.checkpoint.eth_signed_message_hash())?)
+        Ok(self
+            .signature
+            .recover(self.checkpoint.eth_signed_message_hash())?)
     }
 
     /// Check whether a message was signed by a specific address

--- a/rust/hyperlane-core/src/types/checkpoint.rs
+++ b/rust/hyperlane-core/src/types/checkpoint.rs
@@ -72,7 +72,9 @@ impl Decode for Checkpoint {
 }
 
 impl Checkpoint {
-    fn signing_hash(&self) -> H256 {
+    /// A hash of the checkpoint contents.
+    /// The EIP-191 compliant version of this hash is signed by validators.
+    pub fn signing_hash(&self) -> H256 {
         // sign:
         // domain_hash(mailbox_address, mailbox_domain) || root || index (as u32)
         H256::from_slice(
@@ -85,7 +87,8 @@ impl Checkpoint {
         )
     }
 
-    fn prepended_hash(&self) -> H256 {
+    /// EIP-191 compliant hash of the signing hash of the checkpoint.
+    pub fn eth_signed_message_hash(&self) -> H256 {
         hash_message(self.signing_hash())
     }
 
@@ -140,14 +143,14 @@ impl Decode for SignedCheckpoint {
 impl SignedCheckpoint {
     /// Recover the Ethereum address of the signer
     pub fn recover(&self) -> Result<Address, HyperlaneProtocolError> {
-        Ok(self.signature.recover(self.checkpoint.prepended_hash())?)
+        Ok(self.signature.recover(self.checkpoint.eth_signed_message_hash())?)
     }
 
     /// Check whether a message was signed by a specific address
     pub fn verify(&self, signer: Address) -> Result<(), HyperlaneProtocolError> {
         Ok(self
             .signature
-            .verify(self.checkpoint.prepended_hash(), signer)?)
+            .verify(self.checkpoint.eth_signed_message_hash(), signer)?)
     }
 }
 


### PR DESCRIPTION
### Description

To test some behavior of the Fuel/Sway contracts against the existing logic in the agent codebase, we need access to the hashed Checkpoint that validators sign. This makes the relevant functions public, and renames them to be a little more clear

### Drive-by changes

Minor rename

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

_What kind of testing have these changes undergone?_

CI tests
