### PR TITLE
Portal relayer: don't throw if there's an error

### DIFF
--- a/typescript/infra/scripts/middleware/portal-relayer.ts
+++ b/typescript/infra/scripts/middleware/portal-relayer.ts
@@ -48,7 +48,13 @@ async function relayPortalTransfers() {
 
       // Poll for attestation data and submit
       for (const message of portalMessages) {
-        await app.attemptPortalTransferCompletion(message);
+        try {
+          await app.attemptPortalTransferCompletion(message);
+        } catch (err) {
+          console.error(
+            `Error attempting portal transfer completion. Message: ${message}, error: ${err}`,
+          );
+        }
       }
       await sleep(10000);
     }


### PR DESCRIPTION
### Description

When doing the DX games, I tried to transfer a token that hasn't had its wrapped representation created yet. The portal relayer we operate doesn't know how to create the new wrapped representation, so it just continually will try to process the transfer which reverts each time. When it reverts, the process throws. As a temporary fix, this doesn't throw on errors when processing transfers. This way we'll process future Portal transfers instead of erroring out before reaching them

Context:
https://www.notion.so/Trevor-Notes-eff6851b9d11475bb75e69b8b7e62e63
https://www.notion.so/DX-Games-4-Tickets-8ac7d78387fa4dc0bd87b9b6c9c9b06c

### Drive-by changes

none

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None
