### PR TITLE
Reduce rounds for e2e CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,4 +55,4 @@ jobs:
         env:
           E2E_CI_MODE: 'true'
           E2E_CI_TIMEOUT_SEC: '600'
-          E2E_KATHY_ROUNDS: '4'
+          E2E_KATHY_ROUNDS: '3'


### PR DESCRIPTION
### Description

Reduces the number of kathy rounds that are run in the CI which will reduce how long it takes to run and should fix the flakiness since we are not reducing the timeout.

### Drive-by changes

None

### Related issues

### Backward compatibility

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

Unit Tests
