### PR TITLE
Transfer ownership in Mailbox initializer

### DIFF
--- a/solidity/contracts/Mailbox.sol
+++ b/solidity/contracts/Mailbox.sol
@@ -112,11 +112,21 @@ contract Mailbox is
         localDomain = _localDomain;
     }
 
-    // ============ Initializer ============
+    // ============ Initializers ============
 
     function initialize(address _defaultIsm) external initializer {
         __PausableReentrancyGuard_init();
         __Ownable_init();
+        _setDefaultIsm(_defaultIsm);
+    }
+
+    function initialize(address _owner, address _defaultIsm)
+        external
+        initializer
+    {
+        __PausableReentrancyGuard_init();
+        __Ownable_init();
+        transferOwnership(_owner);
         _setDefaultIsm(_defaultIsm);
     }
 

--- a/typescript/infra/config/environments/test/core.ts
+++ b/typescript/infra/config/environments/test/core.ts
@@ -3,20 +3,24 @@ import { ChainMap, CoreConfig } from '@hyperlane-xyz/sdk';
 import { TestChains } from './chains';
 
 export const core: ChainMap<TestChains, CoreConfig> = {
-  // Hardhat accounts 1-4
+  // Owner is hardhat account 0
+  // Validators are hardhat accounts 1-3
   test1: {
+    owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     multisigIsm: {
       validators: ['0x70997970c51812dc3a010c7d01b50e0d17dc79c8'],
       threshold: 1,
     },
   },
   test2: {
+    owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     multisigIsm: {
       validators: ['0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc'],
       threshold: 1,
     },
   },
   test3: {
+    owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     multisigIsm: {
       validators: ['0x90f79bf6eb2c4f870365e785982e1f101e93b906'],
       threshold: 1,

--- a/typescript/infra/config/environments/testnet3/core.ts
+++ b/typescript/infra/config/environments/testnet3/core.ts
@@ -7,6 +7,7 @@ export const core: ChainMap<TestnetChains, CoreConfig> = objMap(
   validators,
   (_, validatorSet) => {
     return {
+      owner: '0xfaD1C94469700833717Fa8a3017278BC1cA8031C',
       multisigIsm: {
         validators: validatorSet.validators.map((v) => v.address),
         threshold: validatorSet.threshold,

--- a/typescript/sdk/src/core/TestCoreDeployer.ts
+++ b/typescript/sdk/src/core/TestCoreDeployer.ts
@@ -16,8 +16,9 @@ import { coreFactories } from './contracts';
 
 const nonZeroAddress = ethers.constants.AddressZero.replace('00', '01');
 
-// dummy config as TestInbox and TestOutbox do not use deployed ValidatorManager
+// dummy config as TestInbox and TestOutbox do not use deployed ISM
 const testMultisigIsmConfig: CoreConfig = {
+  owner: nonZeroAddress,
   multisigIsm: {
     validators: [nonZeroAddress],
     threshold: 1,

--- a/typescript/sdk/src/deploy/core/HyperlaneCoreDeployer.ts
+++ b/typescript/sdk/src/deploy/core/HyperlaneCoreDeployer.ts
@@ -68,13 +68,14 @@ export class HyperlaneCoreDeployer<
     deployOpts?: DeployOptions,
   ): Promise<ProxiedContract<Mailbox, TransparentProxyAddresses>> {
     const domain = chainMetadata[chain].id;
+    const owner = this.configMap[chain].owner;
 
     const mailbox = await this.deployProxiedContract(
       chain,
       'mailbox',
       [domain],
       proxyAdmin,
-      [defaultIsmAddress],
+      [owner, defaultIsmAddress],
       deployOpts,
     );
     return mailbox;
@@ -204,8 +205,8 @@ export class HyperlaneCoreDeployer<
     owner: types.Address,
     chainConnection: ChainConnection,
   ): Promise<ethers.ContractReceipt[]> {
+    // Mailbox ownership is transferred upon initialization.
     const ownables: Ownable[] = [
-      coreContracts.mailbox.contract,
       coreContracts.multisigIsm,
       coreContracts.proxyAdmin,
     ];

--- a/typescript/sdk/src/deploy/core/types.ts
+++ b/typescript/sdk/src/deploy/core/types.ts
@@ -11,7 +11,7 @@ export type MultisigIsmConfig = {
 
 export type CoreConfig = {
   multisigIsm: MultisigIsmConfig;
-  owner?: types.Address;
+  owner: types.Address;
   remove?: boolean;
 };
 


### PR DESCRIPTION
### Description

This PR fixes a bug in which, post-deployment, the `Mailbox` owner wound up stuck as the `ProxyAdmin`.

It does so by allowing the `ProxyAdmin` to transfer ownership of the `Mailbox` in the initializer.

This went undetected on testnet because previously no owner was specified in the CoreConfig, under the assumption that everything would be owned by the deployer key by default.

To avoid missing this again, `owner` is made required in CoreConfig.

This will require a re-deploy of the testnet3 environment

### Drive-by changes

- Adds the ability for HyperlaneDeployer to recover CREATE2 deployed contracts
- Passes transaction overrides to deploy transactions where missing

### Backward compatibility

Yes

### Testing

Unit Tests
