### PR TITLE
Expose Mailbox.recipientIsm() as a public function

### DIFF
--- a/solidity/contracts/Mailbox.sol
+++ b/solidity/contracts/Mailbox.sol
@@ -263,7 +263,11 @@ contract Mailbox is
      * @param _recipient The message recipient whose ISM should be returned.
      * @return The ISM to use for `_recipient`.
      */
-    function recipientIsm(address _recipient) public view returns (address) {
+    function recipientIsm(address _recipient)
+        public
+        view
+        returns (IInterchainSecurityModule)
+    {
         // Use a default interchainSecurityModule if one is not specified by the
         // recipient.
         // This is useful for backwards compatibility and for convenience as
@@ -274,10 +278,10 @@ contract Mailbox is
         returns (IInterchainSecurityModule _val) {
             // If the recipient specifies a zero address, use the default ISM.
             if (address(_val) != address(0)) {
-                return address(_val);
+                return _val;
             }
         } catch {}
-        return address(defaultIsm);
+        return defaultIsm;
     }
 
     // ============ Internal Functions ============

--- a/solidity/contracts/Mailbox.sol
+++ b/solidity/contracts/Mailbox.sol
@@ -192,8 +192,8 @@ contract Mailbox is
         delivered[_id] = true;
 
         // Verify the message via the ISM.
-        IInterchainSecurityModule _ism = _recipientIsm(
-            ISpecifiesInterchainSecurityModule(_message.recipientAddress())
+        IInterchainSecurityModule _ism = IInterchainSecurityModule(
+            recipientIsm(_message.recipientAddress())
         );
         require(_ism.verify(_metadata, _message), "!module");
 
@@ -257,6 +257,29 @@ contract Mailbox is
         return _isPaused();
     }
 
+    /**
+     * @notice Returns the ISM to use for the recipient, defaulting to the
+     * default ISM if none is specified.
+     * @param _recipient The message recipient whose ISM should be returned.
+     * @return The ISM to use for `_recipient`.
+     */
+    function recipientIsm(address _recipient) public view returns (address) {
+        // Use a default interchainSecurityModule if one is not specified by the
+        // recipient.
+        // This is useful for backwards compatibility and for convenience as
+        // recipients are not mandated to specify an ISM.
+        try
+            ISpecifiesInterchainSecurityModule(_recipient)
+                .interchainSecurityModule()
+        returns (IInterchainSecurityModule _val) {
+            // If the recipient specifies a zero address, use the default ISM.
+            if (address(_val) != address(0)) {
+                return address(_val);
+            }
+        } catch {}
+        return address(defaultIsm);
+    }
+
     // ============ Internal Functions ============
 
     /**
@@ -267,31 +290,5 @@ contract Mailbox is
         require(Address.isContract(_module), "!contract");
         defaultIsm = IInterchainSecurityModule(_module);
         emit DefaultIsmSet(_module);
-    }
-
-    /**
-     * @notice Returns the ISM to use for the recipient, defaulting to the
-     * default ISM if none is specified.
-     * @param _recipient The message recipient whose ISM should be returned.
-     * @return The ISM to use for `_recipient`.
-     */
-    function _recipientIsm(ISpecifiesInterchainSecurityModule _recipient)
-        internal
-        view
-        returns (IInterchainSecurityModule)
-    {
-        // Use a default interchainSecurityModule if one is not specified by the
-        // recipient.
-        // This is useful for backwards compatibility and for convenience as
-        // recipients are not mandated to specify an ISM.
-        try _recipient.interchainSecurityModule() returns (
-            IInterchainSecurityModule _val
-        ) {
-            // If the recipient specifies a zero address, use the default ISM.
-            if (address(_val) != address(0)) {
-                return _val;
-            }
-        } catch {}
-        return defaultIsm;
     }
 }

--- a/solidity/contracts/test/TestRecipient.sol
+++ b/solidity/contracts/test/TestRecipient.sol
@@ -2,8 +2,13 @@
 pragma solidity >=0.8.0;
 
 import {IMessageRecipient} from "../../interfaces/IMessageRecipient.sol";
+import {IInterchainSecurityModule, ISpecifiesInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
 
-contract TestRecipient is IMessageRecipient {
+contract TestRecipient is
+    IMessageRecipient,
+    ISpecifiesInterchainSecurityModule
+{
+    IInterchainSecurityModule public interchainSecurityModule;
     bytes32 public lastSender;
     bytes public lastData;
 
@@ -17,6 +22,10 @@ contract TestRecipient is IMessageRecipient {
     );
 
     event ReceivedCall(address indexed caller, uint256 amount, string message);
+
+    function setInterchainSecurityModule(address _ism) external {
+        interchainSecurityModule = IInterchainSecurityModule(_ism);
+    }
 
     function handle(
         uint32 _origin,

--- a/solidity/interfaces/IMailbox.sol
+++ b/solidity/interfaces/IMailbox.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.8.0;
 
+import {IInterchainSecurityModule} from "./IInterchainSecurityModule.sol";
+
 interface IMailbox {
     function localDomain() external view returns (uint32);
 
@@ -19,5 +21,8 @@ interface IMailbox {
 
     function latestCheckpoint() external view returns (bytes32, uint32);
 
-    function recipientIsm(address _recipient) external view returns (address);
+    function recipientIsm(address _recipient)
+        external
+        view
+        returns (IInterchainSecurityModule);
 }

--- a/solidity/interfaces/IMailbox.sol
+++ b/solidity/interfaces/IMailbox.sol
@@ -18,4 +18,6 @@ interface IMailbox {
     function root() external view returns (bytes32);
 
     function latestCheckpoint() external view returns (bytes32, uint32);
+
+    function recipientIsm(address _recipient) external view returns (address);
 }

--- a/solidity/test/mailbox.test.ts
+++ b/solidity/test/mailbox.test.ts
@@ -14,6 +14,7 @@ import {
   TestIsm__factory,
   TestMailbox,
   TestMailbox__factory,
+  TestRecipient,
   TestRecipient__factory,
 } from '../types';
 
@@ -101,6 +102,28 @@ describe('Mailbox', async () => {
         );
 
       expect(actualId).equals(id);
+    });
+  });
+
+  describe('#recipientIsm', () => {
+    let recipient: TestRecipient;
+    beforeEach(async () => {
+      const recipientF = new TestRecipient__factory(signer);
+      recipient = await recipientF.deploy();
+    });
+
+    it('Returns the default module when unspecified', async () => {
+      expect(await mailbox.recipientIsm(recipient.address)).to.equal(
+        await mailbox.defaultIsm(),
+      );
+    });
+
+    it('Returns the recipient module when specified', async () => {
+      const recipientIsm = mailbox.address;
+      await recipient.setInterchainSecurityModule(recipientIsm);
+      expect(await mailbox.recipientIsm(recipient.address)).to.equal(
+        recipientIsm,
+      );
     });
   });
 


### PR DESCRIPTION
### Description

This PR exposes `Mailbox.recipientIsm()` as a public function.

This makes for a quality-of-life improvement for relayers. Rather than having to duplicate the logic in `Mailbox` to determine what ISM a `Mailbox` will use for message verification, relayers can call this view function directly.


### Drive-by changes

None

### Related issues

None

### Backward compatibility

Yes


### Testing

Unit Tests
