### PR TITLE
Fix alphabetical ordering of mainnet chains

### DIFF
--- a/typescript/sdk/src/consts/chains.ts
+++ b/typescript/sdk/src/consts/chains.ts
@@ -43,9 +43,9 @@ export const Mainnets = [
   Chains.bsc,
   Chains.celo,
   Chains.ethereum,
+  Chains.moonbeam,
   Chains.optimism,
   Chains.polygon,
-  Chains.moonbeam,
 ] as Array<ChainName>;
 
 export const Testnets = [


### PR DESCRIPTION
Fixing small oversight from #1449 