### PR TITLE
Update message processor gauge first

### DIFF
--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -9,10 +9,7 @@ use tokio::{
 use tracing::{debug, info_span, instrument, instrument::Instrumented, Instrument};
 
 use hyperlane_base::CoreMetrics;
-use hyperlane_core::{
-    db::{DbError, HyperlaneDB},
-    HyperlaneDomain, HyperlaneMessage,
-};
+use hyperlane_core::{db::HyperlaneDB, HyperlaneDomain, HyperlaneMessage};
 
 use crate::{merkle_tree_builder::MerkleTreeBuilder, settings::matching_list::MatchingList};
 
@@ -72,7 +69,7 @@ impl MessageProcessor {
     /// If the message with self.message_nonce is found and has previously
     /// been marked as processed, increments self.message_nonce and returns
     /// None.
-    fn try_get_unprocessed_message(&mut self) -> Result<Option<HyperlaneMessage>, DbError> {
+    fn try_get_unprocessed_message(&mut self) -> Result<Option<HyperlaneMessage>> {
         // First, see if we can find the message so we can update the gauge.
         if let Some(message) = self.db.message_by_nonce(self.message_nonce)? {
             // Update the latest nonce gauge if the message is destined for one
@@ -85,22 +82,22 @@ impl MessageProcessor {
             if self
                 .db
                 .retrieve_message_processed(self.message_nonce)?
-                .is_some()
+                .is_none()
             {
+                Ok(Some(message))
+            } else {
                 debug!(
                     msg_nonce=?self.message_nonce,
                     "Message already marked as processed in DB");
                 self.message_nonce += 1;
-                return Ok(None);
+                Ok(None)
             }
-
-            return Ok(Some(message));
         } else {
             debug!(
                 msg_nonce=?self.message_nonce,
                 "No message found in DB for nonce");
-            return Ok(None);
-        };
+            Ok(None)
+        }
     }
 
     /// One round of processing, extracted from infinite work loop for
@@ -108,14 +105,14 @@ impl MessageProcessor {
     async fn tick(&mut self) -> Result<()> {
         // Scan until we find next nonce without delivery confirmation.
         if let Some(message) = self.try_get_unprocessed_message()? {
-            debug!(msg=?message, msg_id=?message.id(), msg_nonce=message.nonce, "Working on message");
+            debug!(msg=?message, "Working on message");
 
             // Skip if not whitelisted.
             if !self.whitelist.msg_matches(&message, true) {
                 debug!(
-                    id=?message.id(),
-                    destination=message.destination,
-                    nonce=message.nonce,
+                    msg_id=?message.id(),
+                    msg_destination=message.destination,
+                    msg_nonce=message.nonce,
                     whitelist=?self.whitelist,
                     "Message not whitelisted, skipping");
                 self.message_nonce += 1;
@@ -125,9 +122,9 @@ impl MessageProcessor {
             // Skip if the message is blacklisted
             if self.blacklist.msg_matches(&message, false) {
                 debug!(
-                    id=?message.id(),
-                    destination=message.destination,
-                    nonce=message.nonce,
+                    msg_id=?message.id(),
+                    msg_destination=message.destination,
+                    msg_nonce=message.nonce,
                     blacklist=?self.blacklist,
                     "Message blacklisted, skipping");
                 self.message_nonce += 1;
@@ -137,9 +134,9 @@ impl MessageProcessor {
             // Skip if the message is intended for a destination we do not service
             if self.send_channels.get(&message.destination).is_none() {
                 debug!(
-                    id=?message.id(),
-                    destination=message.destination,
-                    nonce=message.nonce,
+                    msg_id=?message.id(),
+                    msg_destination=message.destination,
+                    msg_nonce=message.nonce,
                     "Message destined for unknown domain, skipping");
                 self.message_nonce += 1;
                 return Ok(());
@@ -160,6 +157,7 @@ impl MessageProcessor {
 
             // Finally, build the submit arg and dispatch it to the submitter.
             let submit_args = SubmitMessageArgs::new(message.clone());
+            // Guaranteed to exist as we return early above if it does not.
             let send_channel = self.send_channels.get(&message.destination).unwrap();
             send_channel.send(submit_args)?;
             self.message_nonce += 1;

--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -9,7 +9,10 @@ use tokio::{
 use tracing::{debug, info_span, instrument, instrument::Instrumented, Instrument};
 
 use hyperlane_base::CoreMetrics;
-use hyperlane_core::{db::{HyperlaneDB, DbError}, HyperlaneDomain, HyperlaneMessage};
+use hyperlane_core::{
+    db::{DbError, HyperlaneDB},
+    HyperlaneDomain, HyperlaneMessage,
+};
 
 use crate::{merkle_tree_builder::MerkleTreeBuilder, settings::matching_list::MatchingList};
 
@@ -64,19 +67,16 @@ impl MessageProcessor {
     }
 
     /// Tries to get the next message to process.
-    /// 
+    ///
     /// If no message with self.message_nonce is found, returns None.
     /// If the message with self.message_nonce is found and has previously
     /// been marked as processed, increments self.message_nonce and returns
     /// None.
     fn try_get_unprocessed_message(&mut self) -> Result<Option<HyperlaneMessage>, DbError> {
         // First, see if we can find the message so we can update the gauge.
-        if let Some(message) = self
-            .db
-            .message_by_nonce(self.message_nonce)?
-        {
+        if let Some(message) = self.db.message_by_nonce(self.message_nonce)? {
             // Update the latest nonce gauge if the message is destined for one
-            // of the domains we service. 
+            // of the domains we service.
             if let Some(metrics) = self.metrics.get(message.destination) {
                 metrics.set(message.nonce as i64);
             }
@@ -142,7 +142,7 @@ impl MessageProcessor {
                     nonce=message.nonce,
                     "Message destined for unknown domain, skipping");
                 self.message_nonce += 1;
-                return Ok(())
+                return Ok(());
             }
 
             // Feed the message to the prover sync
@@ -167,7 +167,6 @@ impl MessageProcessor {
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
         Ok(())
-
     }
 }
 


### PR DESCRIPTION
### Description

Fixes a bug introduced when I updated the processor, where the latest nonce gauge will not update until the relayer sees a new message that hasn't been delivered.

This means the gauge hangs out at 0 for a while after the relayer restarts.

Fixed by updating the gauge first-thing in the processor loop.

### Drive-by changes

- Minor refactor of message processor `tick()`

