### PR TITLE
writeJSON with new line at the end

### DIFF
--- a/typescript/infra/src/utils/utils.ts
+++ b/typescript/infra/src/utils/utils.ts
@@ -158,7 +158,7 @@ export function writeJSON(directory: string, filename: string, obj: any) {
   }
   fs.writeFileSync(
     path.join(directory, filename),
-    JSON.stringify(obj, null, 2),
+    JSON.stringify(obj, null, 2) + '\n',
   );
 }
 


### PR DESCRIPTION
Sick of having this show up in the diff, best practice is to have a new line at the end. 