### PR TITLE
Assert right kube context in more infra deploys

### DIFF
--- a/typescript/infra/scripts/deploy-infra-external-secrets.ts
+++ b/typescript/infra/scripts/deploy-infra-external-secrets.ts
@@ -1,11 +1,16 @@
 import { runExternalSecretsHelmCommand } from '../src/infrastructure/external-secrets/external-secrets';
 import { HelmCommand } from '../src/utils/helm';
 
-import { getCoreEnvironmentConfig, getEnvironment } from './utils';
+import {
+  assertCorrectKubeContext,
+  getCoreEnvironmentConfig,
+  getEnvironment,
+} from './utils';
 
 async function main() {
   const environment = await getEnvironment();
   const config = getCoreEnvironmentConfig(environment);
+  await assertCorrectKubeContext(config);
   return runExternalSecretsHelmCommand(
     HelmCommand.InstallOrUpgrade,
     config.infra,

--- a/typescript/infra/scripts/deploy-infra-monitoring.ts
+++ b/typescript/infra/scripts/deploy-infra-monitoring.ts
@@ -1,11 +1,16 @@
 import { runPrometheusHelmCommand } from '../src/infrastructure/monitoring/prometheus';
 import { HelmCommand } from '../src/utils/helm';
 
-import { getCoreEnvironmentConfig, getEnvironment } from './utils';
+import {
+  assertCorrectKubeContext,
+  getCoreEnvironmentConfig,
+  getEnvironment,
+} from './utils';
 
 async function main() {
   const environment = await getEnvironment();
   const config = getCoreEnvironmentConfig(environment);
+  await assertCorrectKubeContext(config);
   return runPrometheusHelmCommand(
     HelmCommand.InstallOrUpgrade,
     config.infra,


### PR DESCRIPTION
### Description

Assert right kube context in more infra deploys to avoid the external secrets situation
