### PR TITLE
Deploy liquidity layer to testnet3

### DIFF
--- a/typescript/infra/config/environments/testnet3/middleware.ts
+++ b/typescript/infra/config/environments/testnet3/middleware.ts
@@ -6,7 +6,7 @@ import { environment } from './chains';
 export const liquidityLayerRelayerConfig: LiquidityLayerRelayerConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-    tag: 'sha-760a16b',
+    tag: 'sha-437f701',
   },
   namespace: environment,
   prometheusPushGateway:

--- a/typescript/infra/config/environments/testnet3/middleware/liquidity-layer/addresses.json
+++ b/typescript/infra/config/environments/testnet3/middleware/liquidity-layer/addresses.json
@@ -1,0 +1,24 @@
+{
+  "goerli": {
+    "circleBridgeAdapter": "0xfe9d88aA85c5917822C804b949BcEDE832C02ce2",
+    "portalAdapter": "0x68D753982e89CC083917863F6dc9738448B91ef9",
+    "router": "0x2abe0860D81FB4242C748132bD69D125D88eaE26"
+  },
+  "fuji": {
+    "circleBridgeAdapter": "0xfe9d88aA85c5917822C804b949BcEDE832C02ce2",
+    "portalAdapter": "0x68D753982e89CC083917863F6dc9738448B91ef9",
+    "router": "0x2abe0860D81FB4242C748132bD69D125D88eaE26"
+  },
+  "mumbai": {
+    "portalAdapter": "0x68D753982e89CC083917863F6dc9738448B91ef9",
+    "router": "0x2abe0860D81FB4242C748132bD69D125D88eaE26"
+  },
+  "bsctestnet": {
+    "portalAdapter": "0x68D753982e89CC083917863F6dc9738448B91ef9",
+    "router": "0x2abe0860D81FB4242C748132bD69D125D88eaE26"
+  },
+  "alfajores": {
+    "portalAdapter": "0x68D753982e89CC083917863F6dc9738448B91ef9",
+    "router": "0x2abe0860D81FB4242C748132bD69D125D88eaE26"
+  }
+}

--- a/typescript/infra/config/environments/testnet3/middleware/liquidity-layer/verification.json
+++ b/typescript/infra/config/environments/testnet3/middleware/liquidity-layer/verification.json
@@ -1,0 +1,84 @@
+{
+  "goerli": [
+    {
+      "name": "LiquidityLayerRouter",
+      "address": "0x2abe0860D81FB4242C748132bD69D125D88eaE26",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "CircleBridgeAdapter",
+      "address": "0xfe9d88aA85c5917822C804b949BcEDE832C02ce2",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "PortalAdapter",
+      "address": "0x68D753982e89CC083917863F6dc9738448B91ef9",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "fuji": [
+    {
+      "name": "LiquidityLayerRouter",
+      "address": "0x2abe0860D81FB4242C748132bD69D125D88eaE26",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "CircleBridgeAdapter",
+      "address": "0xfe9d88aA85c5917822C804b949BcEDE832C02ce2",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "PortalAdapter",
+      "address": "0x68D753982e89CC083917863F6dc9738448B91ef9",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "mumbai": [
+    {
+      "name": "LiquidityLayerRouter",
+      "address": "0x2abe0860D81FB4242C748132bD69D125D88eaE26",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "PortalAdapter",
+      "address": "0x68D753982e89CC083917863F6dc9738448B91ef9",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "bsctestnet": [
+    {
+      "name": "LiquidityLayerRouter",
+      "address": "0x2abe0860D81FB4242C748132bD69D125D88eaE26",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "PortalAdapter",
+      "address": "0x68D753982e89CC083917863F6dc9738448B91ef9",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "alfajores": [
+    {
+      "name": "LiquidityLayerRouter",
+      "address": "0x2abe0860D81FB4242C748132bD69D125D88eaE26",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "PortalAdapter",
+      "address": "0x68D753982e89CC083917863F6dc9738448B91ef9",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ]
+}

--- a/typescript/infra/helm/liquidity-layer-relayers/templates/env-var-external-secret.yaml
+++ b/typescript/infra/helm/liquidity-layer-relayers/templates/env-var-external-secret.yaml
@@ -21,7 +21,7 @@ spec:
           update-on-redeploy: "{{ now }}"
       data:
         GCP_SECRET_OVERRIDES_ENABLED: "true"
-        GCP_SECRET_OVERRIDE_ABACUS_{{ .Values.hyperlane.runEnv | upper }}_KEY_DEPLOYER: {{ print "'{{ .deployer_key | toString }}'" }}
+        GCP_SECRET_OVERRIDE_HYPERLANE_{{ .Values.hyperlane.runEnv | upper }}_KEY_DEPLOYER: {{ print "'{{ .deployer_key | toString }}'" }}
 {{/*
    * For each network, create an environment variable with the RPC endpoint.
    * The templating of external-secrets will use the data section below to know how

--- a/typescript/sdk/src/deploy/verify/ContractVerifier.ts
+++ b/typescript/sdk/src/deploy/verify/ContractVerifier.ts
@@ -64,7 +64,7 @@ export class ContractVerifier<Chain extends ChainName> extends MultiGeneric<
     options?: Record<string, string>,
   ): Promise<any> {
     const chainConnection = this.multiProvider.getChainConnection(chain);
-    const apiUrl = `${chainConnection.getApiUrl()}/api`;
+    const apiUrl = chainConnection.getApiUrl();
 
     const params = new URLSearchParams({
       apikey: this.apiKeys[chain],

--- a/typescript/sdk/src/providers/ChainConnection.ts
+++ b/typescript/sdk/src/providers/ChainConnection.ts
@@ -38,7 +38,7 @@ export class ChainConnection {
   }
 
   getApiUrl(): string {
-    return this.blockExplorerApiUrl;
+    return this.blockExplorerApiUrl + '/api';
   }
 
   async handleTx(


### PR DESCRIPTION
### Description

This PR deploys the liqudity layer to testnet3. Also fixes the retrieval of explorerApiUrls and a minor abacus artifact from the helm chart.


### Related issues

- Fixes #1539 

### Backward compatibility
Yes

None


### Testing

_What kind of testing have these changes undergone?_

Manual