### PR TITLE
Allow loading config files from the CONFIG_FILES env var

### DIFF
--- a/rust/hyperlane-base/src/macros.rs
+++ b/rust/hyperlane-base/src/macros.rs
@@ -123,7 +123,6 @@ pub fn _new_settings<'de, T: Deserialize<'de>>(name: &str) -> eyre::Result<T> {
 
     load_settings_object::<T, &str>(
         name,
-        Some(&env::var("BASE_CONFIG").unwrap_or_else(|_| "base".into())),
         &[],
     )
 }

--- a/rust/hyperlane-base/src/macros.rs
+++ b/rust/hyperlane-base/src/macros.rs
@@ -119,10 +119,6 @@ macro_rules! decl_settings {
 #[doc(hidden)]
 pub fn _new_settings<'de, T: Deserialize<'de>>(name: &str) -> eyre::Result<T> {
     use crate::settings::loader::load_settings_object;
-    use std::env;
 
-    load_settings_object::<T, &str>(
-        name,
-        &[],
-    )
+    load_settings_object::<T, &str>(name, &[])
 }


### PR DESCRIPTION
### Description

This PR implements a `CONFIG_FILES` env var which allows operators of the agents to specify a comma separated list of paths from which the agent should load (partial) config files. This should superseed the current method of specifying `RUN_ENV` and `BASE_CONFIG` (which is still supported).


### Related issues

- Fixes #1576 

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None, since it is backwards compatible


### Testing

_What kind of testing have these changes undergone?_

Manual
