### PR TITLE
Deploy TestRecipient & TestTokenRecipient on arbitrum and optimism goerli

### DIFF
--- a/typescript/infra/config/environments/testnet2/testrecipient/addresses.json
+++ b/typescript/infra/config/environments/testnet2/testrecipient/addresses.json
@@ -22,5 +22,13 @@
   "moonbasealpha": {
     "TestRecipient": "0xBC3cFeca7Df5A45d61BC60E7898E63670e1654aE",
     "TestTokenRecipient": "0x36597C9C49F3c5887A86466398480ddB66aD0759"
+  },
+  "optimismgoerli": {
+    "TestRecipient": "0xBC3cFeca7Df5A45d61BC60E7898E63670e1654aE",
+    "TestTokenRecipient": "0x7785a37f53BbF694E6b524c2e8bD6BB6671eCEa6"
+  },
+  "arbitrumgoerli": {
+    "TestRecipient": "0xBC3cFeca7Df5A45d61BC60E7898E63670e1654aE",
+    "TestTokenRecipient": "0x7785a37f53BbF694E6b524c2e8bD6BB6671eCEa6"
   }
 }

--- a/typescript/infra/config/environments/testnet2/testrecipient/verification.json
+++ b/typescript/infra/config/environments/testnet2/testrecipient/verification.json
@@ -118,5 +118,33 @@
       "isProxy": false,
       "constructorArguments": ""
     }
+  ],
+  "optimismgoerli": [
+    {
+      "name": "TestRecipient",
+      "address": "0xBC3cFeca7Df5A45d61BC60E7898E63670e1654aE",
+      "isProxy": false,
+      "constructorArguments": ""
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x7785a37f53BbF694E6b524c2e8bD6BB6671eCEa6",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
+  ],
+  "arbitrumgoerli": [
+    {
+      "name": "TestRecipient",
+      "address": "0xBC3cFeca7Df5A45d61BC60E7898E63670e1654aE",
+      "isProxy": false,
+      "constructorArguments": ""
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x7785a37f53BbF694E6b524c2e8bD6BB6671eCEa6",
+      "isProxy": false,
+      "constructorArguments": ""
+    }
   ]
 }


### PR DESCRIPTION
### Description

**Don't merge yet - need to figure out how to get the same address for TestTokenRecipient**. Looks like the salt and bytecode have both changed

The test recipients weren't deployed to Arbitrum Goerli or Optimism Goerli

Note I had to do some funky stuff - I guess the EOA deploying the TestRecipient has to be the mainnet deployer key, but the EOA for TestTokenRecipient was supposed to be the testnet2 deployer

### Drive-by changes

_Are there any minor or drive-by changes also included?_

### Related issues

- Fixes #[issue number here]

### Backward compatibility

_Are these changes backward compatible?_

Yes
No

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None
Yes


### Testing

_What kind of testing have these changes undergone?_

None
Manual
Unit Tests
