### PR TITLE
Fix SignedType backwards compatibility on deserialization

### DIFF
--- a/rust/hyperlane-core/src/traits/signing.rs
+++ b/rust/hyperlane-core/src/traits/signing.rs
@@ -73,6 +73,8 @@ pub trait Signable: Sized {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SignedType<T: Signable> {
     /// The value which was signed
+    #[serde(alias = "checkpoint")]
+    #[serde(alias = "announcement")]
     pub value: T,
     /// The signature for the value
     pub signature: Signature,


### PR DESCRIPTION
### Description

Quick fix to add a couple aliases to support the old format.

### Drive-by changes

None.

### Related issues

- https://discord.com/channels/935678348330434570/1065751999313891458
- https://discord.com/channels/935678348330434570/1067180600886300724

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Manual
Unit Tests
