### PR TITLE
Fixes for run queue init delay

### DIFF
--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -162,7 +162,7 @@ impl MessageProcessor {
             send_channel.send(submit_args)?;
             self.message_nonce += 1;
         } else {
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
         Ok(())
     }

--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -70,33 +70,34 @@ impl MessageProcessor {
     /// been marked as processed, increments self.message_nonce and returns
     /// None.
     fn try_get_unprocessed_message(&mut self) -> Result<Option<HyperlaneMessage>> {
-        // First, see if we can find the message so we can update the gauge.
-        if let Some(message) = self.db.message_by_nonce(self.message_nonce)? {
-            // Update the latest nonce gauge if the message is destined for one
-            // of the domains we service.
-            if let Some(metrics) = self.metrics.get(message.destination) {
-                metrics.set(message.nonce as i64);
-            }
+        loop {
+            // First, see if we can find the message so we can update the gauge.
+            if let Some(message) = self.db.message_by_nonce(self.message_nonce)? {
+                // Update the latest nonce gauge if the message is destined for one
+                // of the domains we service.
+                if let Some(metrics) = self.metrics.get(message.destination) {
+                    metrics.set(message.nonce as i64);
+                }
 
-            // If this message has already been processed, on to the next one.
-            if self
-                .db
-                .retrieve_message_processed(self.message_nonce)?
-                .is_none()
-            {
-                Ok(Some(message))
-            } else {
-                debug!(
+                // If this message has already been processed, on to the next one.
+                if self
+                    .db
+                    .retrieve_message_processed(self.message_nonce)?
+                    .is_none()
+                {
+                    return Ok(Some(message))
+                } else {
+                    debug!(
                     msg_nonce=?self.message_nonce,
                     "Message already marked as processed in DB");
-                self.message_nonce += 1;
-                Ok(None)
-            }
-        } else {
-            debug!(
+                    self.message_nonce += 1;
+                }
+            } else {
+                debug!(
                 msg_nonce=?self.message_nonce,
                 "No message found in DB for nonce");
-            Ok(None)
+                return Ok(None)
+            }
         }
     }
 
@@ -162,7 +163,7 @@ impl MessageProcessor {
             send_channel.send(submit_args)?;
             self.message_nonce += 1;
         } else {
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
         Ok(())
     }

--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -85,7 +85,7 @@ impl MessageProcessor {
                     .retrieve_message_processed(self.message_nonce)?
                     .is_none()
                 {
-                    return Ok(Some(message))
+                    return Ok(Some(message));
                 } else {
                     debug!(
                     msg_nonce=?self.message_nonce,
@@ -96,7 +96,7 @@ impl MessageProcessor {
                 debug!(
                 msg_nonce=?self.message_nonce,
                 "No message found in DB for nonce");
-                return Ok(None)
+                return Ok(None);
             }
         }
     }

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -155,7 +155,7 @@ impl SerialSubmitter {
     async fn work_loop(&mut self) -> Result<()> {
         loop {
             self.tick().await?;
-            sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_millis(200)).await;
         }
     }
 


### PR DESCRIPTION
### Description

- Decreases the timeout for serial submitter to 200ms
- Updates the processor getting of unprocessed messages to loop until it hits the end or finds a message to send

### Drive-by changes

None

### Related issues

- https://discord.com/channels/935678348330434570/1067584368639492237

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

_What kind of testing have these changes undergone?_

None