### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,11 +49,6 @@ jobs:
             **/node_modules
             .yarn/cache
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
-      - name: node build cache
-        uses: actions/cache@v3
-        with:
-          path: ./*
-          key: ${{ github.sha }}
 
       - name: build test
         run: cargo build --release --bin run-locally

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,8 +45,10 @@ jobs:
       - name: node module cache
         uses: actions/cache@v3
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-cache4-${{ hashFiles('./yarn.lock') }}
+          path: |
+            **/node_modules
+            .yarn/cache
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
       - name: node build cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,4 +62,4 @@ jobs:
         env:
           E2E_CI_MODE: 'true'
           E2E_CI_TIMEOUT_SEC: '600'
-          E2E_KATHY_ROUNDS: '3'
+          E2E_KATHY_ROUNDS: '2'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,4 +60,4 @@ jobs:
         env:
           E2E_CI_MODE: 'true'
           E2E_CI_TIMEOUT_SEC: '600'
-          E2E_KATHY_ROUNDS: '1'
+          E2E_KATHY_ROUNDS: '3'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: e2e-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,8 +38,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v2-rust"
-          shared-key: "e2e"
+          prefix-key: 'v2-rust'
+          shared-key: 'e2e'
           workspaces: |
             ./rust
       - name: node module cache
@@ -60,4 +60,4 @@ jobs:
         env:
           E2E_CI_MODE: 'true'
           E2E_CI_TIMEOUT_SEC: '600'
-          E2E_KATHY_ROUNDS: '3'
+          E2E_KATHY_ROUNDS: '1'

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -30,7 +30,10 @@ jobs:
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: count-files
-        run: find node_modules -type f | wc -l
+        run: |
+          find node_modules -type f | wc -l
+          find .yarn -type f | wc -l
+          ls .yarn/
 
       - name: yarn-install
         run: |
@@ -43,7 +46,10 @@ jobs:
           fi
 
       - name: count-files
-        run: find node_modules -type f | wc -l
+        run: |
+          find node_modules -type f | wc -l
+          find .yarn -type f | wc -l
+          ls .yarn/
 
   yarn-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -29,12 +29,6 @@ jobs:
             .yarn/cache
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
-      - name: count-files
-        run: |
-          find node_modules -type f | wc -l
-          find .yarn -type f | wc -l
-          ls .yarn/
-
       - name: yarn-install
         run: |
           yarn install
@@ -44,12 +38,6 @@ jobs:
             git diff
             exit 1
           fi
-
-      - name: count-files
-        run: |
-          find node_modules -type f | wc -l
-          find .yarn -type f | wc -l
-          ls .yarn/
 
   yarn-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -31,7 +31,6 @@ jobs:
 
       - name: count-files
         run: |
-          yarn cache dir
           find node_modules -type f | wc -l
           find .yarn -type f | wc -l
           ls .yarn/

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: count-files
         run: |
+          yarn cache dir
           find node_modules -type f | wc -l
           find .yarn -type f | wc -l
           ls .yarn/

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -24,8 +24,10 @@ jobs:
       - name: yarn-cache
         uses: actions/cache@v3
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-cache4-${{ hashFiles('./yarn.lock') }}
+          path: |
+            '**/node_modules'
+            './.yarn/cache'
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: count-files
         run: find node_modules -type f | wc -l
@@ -57,8 +59,10 @@ jobs:
       - name: yarn-cache
         uses: actions/cache@v3
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-cache4-${{ hashFiles('./yarn.lock') }}
+          path: |
+            '**/node_modules'
+            './.yarn/cache'
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: build-cache
         uses: actions/cache@v3
@@ -76,8 +80,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-cache4-${{ hashFiles('./yarn.lock') }}
+          path: |
+            '**/node_modules'
+            './.yarn/cache'
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: lint-ts
         run: yarn lint-ts

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -25,8 +25,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            '**/node_modules'
-            '.yarn/cache'
+            **/node_modules
+            .yarn/cache
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: count-files
@@ -66,8 +66,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            '**/node_modules'
-            '.yarn/cache'
+            **/node_modules
+            .yarn/cache
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: build-cache
@@ -87,8 +87,8 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
-            '**/node_modules'
-            '.yarn/cache'
+            **/node_modules
+            .yarn/cache
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: lint-ts

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           path: |
             '**/node_modules'
-            './.yarn/cache'
+            '.yarn/cache'
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: count-files
@@ -67,7 +67,7 @@ jobs:
         with:
           path: |
             '**/node_modules'
-            './.yarn/cache'
+            '.yarn/cache'
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: build-cache
@@ -88,7 +88,7 @@ jobs:
         with:
           path: |
             '**/node_modules'
-            './.yarn/cache'
+            '.yarn/cache'
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
 
       - name: lint-ts

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -187,6 +187,6 @@ jobs:
         run: |
           sudo apt-get install lcov
           cd ./solidity
-          export BASE=$(lcov --summary ./hardhat-lcov.base.info | grep "lines" | sed 's/.*lines......:\ //' | sed 's/% (.*//')
-          export REF=$(lcov --summary ./coverage/lcov.info | grep "lines" | sed 's/.*lines......:\ //' | sed 's/% (.*//')
+          export BASE=$(lcov --summary ./lcov.base.info | grep "lines" | sed 's/.*lines......:\ //' | sed 's/% (.*//')
+          export REF=$(lcov --summary ./lcov.info | grep "lines" | sed 's/.*lines......:\ //' | sed 's/% (.*//')
           if [[ $REF < $BASE ]]; then exit 1; fi

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -27,6 +27,9 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-yarn-cache4-${{ hashFiles('./yarn.lock') }}
 
+      - name: ls-node-modules
+        run: ls ./node_modules
+
       - name: yarn-install
         # Check out the lockfile from main, reinstall, and then
         # verify the lockfile matches what was committed.

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -27,12 +27,10 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-yarn-cache4-${{ hashFiles('./yarn.lock') }}
 
-      - name: ls-node-modules
-        run: ls ./node_modules
+      - name: count-files
+        run: find node_modules -type f | wc -l
 
       - name: yarn-install
-        # Check out the lockfile from main, reinstall, and then
-        # verify the lockfile matches what was committed.
         run: |
           yarn install
           CHANGES=$(git status -s --ignore-submodules)
@@ -41,6 +39,9 @@ jobs:
             git diff
             exit 1
           fi
+
+      - name: count-files
+        run: find node_modules -type f | wc -l
 
   yarn-build:
     runs-on: ubuntu-latest

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -155,7 +155,7 @@ impl SerialSubmitter {
     async fn work_loop(&mut self) -> Result<()> {
         loop {
             self.tick().await?;
-            sleep(Duration::from_secs(1)).await;
+            sleep(Duration::from_millis(200)).await;
         }
     }
 

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -155,7 +155,7 @@ impl SerialSubmitter {
     async fn work_loop(&mut self) -> Result<()> {
         loop {
             self.tick().await?;
-            sleep(Duration::from_millis(200)).await;
+            sleep(Duration::from_secs(1)).await;
         }
     }
 

--- a/solidity/contracts/test/TestSendReceiver.sol
+++ b/solidity/contracts/test/TestSendReceiver.sol
@@ -60,8 +60,8 @@ contract TestSendReceiver is IMessageRecipient {
         bytes calldata
     ) external override {
         bytes32 blockHash = previousBlockHash();
-        bool isBlockHashEven = uint256(blockHash) % 2 == 0;
-        require(isBlockHashEven, "block hash is odd");
+        bool isBlockHashEndIn0 = uint256(blockHash) % 16 == 0;
+        require(!isBlockHashEndIn0, "block hash ends in 0");
         emit Handled(blockHash);
     }
 

--- a/solidity/test/testSendReceiver.test.ts
+++ b/solidity/test/testSendReceiver.test.ts
@@ -35,6 +35,6 @@ describe('TestSendReceiver', () => {
     }
 
     expect(successes).to.be.greaterThan(5);
-    expect(failures).to.be.greaterThan(5);
+    expect(failures).to.be.greaterThan(1);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3959,17 +3959,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/core@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@hyperlane-xyz/core@npm:1.1.0"
-  dependencies:
-    "@hyperlane-xyz/utils": 1.1.0
-    "@openzeppelin/contracts": ^4.8.0
-    "@openzeppelin/contracts-upgradeable": ^4.8.0
-  checksum: 39f0d0d253a14aec27e187f0e23b9875878eea6a6057421cd04932aa1951a881e5f4ad6953bb128e6d0786480c1b96155bb227cf7499bb89dc75c0483b74e14a
-  languageName: node
-  linkType: hard
-
 "@hyperlane-xyz/helloworld@1.1.0, @hyperlane-xyz/helloworld@workspace:typescript/helloworld":
   version: 0.0.0-use.local
   resolution: "@hyperlane-xyz/helloworld@workspace:typescript/helloworld"
@@ -4006,9 +3995,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hyperlane-xyz/hyperlane-token@workspace:typescript/token"
   dependencies:
-    "@hyperlane-xyz/core": 1.1.0
-    "@hyperlane-xyz/sdk": 1.1.0
-    "@hyperlane-xyz/utils": 1.1.0
+    "@hyperlane-xyz/core": 1.1.1
+    "@hyperlane-xyz/sdk": 1.1.1
+    "@hyperlane-xyz/utils": 1.1.1
     "@nomiclabs/hardhat-ethers": ^2.2.1
     "@nomiclabs/hardhat-waffle": ^2.0.3
     "@openzeppelin/contracts-upgradeable": ^4.8.0
@@ -4127,22 +4116,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/sdk@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@hyperlane-xyz/sdk@npm:1.1.0"
-  dependencies:
-    "@hyperlane-xyz/celo-ethers-provider": ^0.1.1
-    "@hyperlane-xyz/core": 1.1.0
-    "@hyperlane-xyz/utils": 1.1.0
-    "@wagmi/chains": ^0.1.3
-    coingecko-api: ^1.0.10
-    cross-fetch: ^3.1.5
-    debug: ^4.3.4
-    ethers: ^5.7.2
-  checksum: 413fb31f0811f1c0b4b6f881619fbd76a866076889b733929c92bd8add5b03b915fbe54150af3467da7350924f15462688b1c1247937139b11f3ebc3d5e10182
-  languageName: node
-  linkType: hard
-
 "@hyperlane-xyz/utils@1.1.1, @hyperlane-xyz/utils@workspace:typescript/utils":
   version: 0.0.0-use.local
   resolution: "@hyperlane-xyz/utils@workspace:typescript/utils"
@@ -4153,15 +4126,6 @@ __metadata:
     typescript: ^4.7.2
   languageName: unknown
   linkType: soft
-
-"@hyperlane-xyz/utils@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@hyperlane-xyz/utils@npm:1.1.0"
-  dependencies:
-    ethers: ^5.7.2
-  checksum: e2647b2e04b865f6de557225fca509d4a3a009ddba5ec0c5f44baedaf57be16c42f4d36ffd69acacb1dedc3f4babb5a362d2bce5ddc12b308963add0e415b8c2
-  languageName: node
-  linkType: hard
 
 "@jridgewell/gen-mapping@npm:^0.3.0":
   version: 0.3.1


### PR DESCRIPTION
### Description

Speeds up CI by:
- fixing node_modules caching
- sending fewer messages in the e2e test
- failing less frequently in the e2e test
- removing yarn build cache from e2e test which always misses 

### Drive-by changes

- Update hyperlane/token to latest main
- Fix coverage-sol to read proper files
- Never cancel in-progress e2e tests on main
