### PR TITLE
H07: Add pragma to Create2Factory for custom errors

### DIFF
--- a/solidity/contracts/Create2Factory.sol
+++ b/solidity/contracts/Create2Factory.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copied from https://github.com/axelarnetwork/axelar-utils-solidity/commits/main/contracts/ConstAddressDeployer.sol
 
-pragma solidity ^0.8.0;
+// requires custom errors https://blog.soliditylang.org/2021/04/21/custom-errors/
+pragma solidity ^0.8.4;
 
 contract Create2Factory {
     error EmptyBytecode();


### PR DESCRIPTION
### Description

> The Create2Factory contract implements custom errors, a solidity
functionality introduced on version 0.8.4.
> The pragma version defined in the contract is ^0.8.0, making it
possible to raise compilation errors.

### Testing

None