### PR TITLE
Handle reverting queries

### DIFF
--- a/solidity/contracts/Call.sol
+++ b/solidity/contracts/Call.sol
@@ -5,3 +5,8 @@ struct Call {
     address to;
     bytes data;
 }
+
+struct Result {
+    bool success;
+    bytes data;
+}


### PR DESCRIPTION
### Description

> InterchainQueryRouter is the Router contract used to poll view
functions on a remote chain. By design, the InterchainQueryRouter on
the remote chain will perform a callback on the origin chain to
communicate the results of the calls. The calls on the remote chain
are performed through the function OwnableMulticall._call(), called
by InterchainQueryRouter._handle().
> In case of a failed call, OwnableMulticall._call() will revert, so
the flow of InterchainQueryRouter._handle() will stop before calling
_dispatch() which would take care of sending the callback to the
origin chain.
> In this case, the origin chain will receive no callbacks, and will
not be informed of the failed call on the remote chain. Even if the
call failed and there is no value to communicate to the origin chain,
a flag informing of the failure should be sent back.

 - Use `staticcall` instead of `call` on destination chain to mitigate unintended side effects of contracts authenticating InterchainQueryRouter address for callbacks
 - Results will always be returned to the source chain but only the calls which produced successful results will have corresponding callbacks invoked

### Related issues

- Fixes #1712 

### Backward compatibility

No

### Testing

Unit Tests
