### PR TITLE
Cache for loop array lengths

### DIFF
--- a/solidity/contracts/OwnableMulticall.sol
+++ b/solidity/contracts/OwnableMulticall.sol
@@ -20,7 +20,8 @@ contract OwnableMulticall is OwnableUpgradeable {
     }
 
     function proxyCalls(Call[] calldata calls) external onlyOwner {
-        for (uint256 i = 0; i < calls.length; i += 1) {
+        uint256 length = calls.length;
+        for (uint256 i = 0; i < length; i += 1) {
             (bool success, bytes memory returnData) = calls[i].to.call(
                 calls[i].data
             );
@@ -36,8 +37,9 @@ contract OwnableMulticall is OwnableUpgradeable {
         internal
         returns (bytes[] memory resolveCalls)
     {
-        resolveCalls = new bytes[](callbacks.length);
-        for (uint256 i = 0; i < calls.length; i++) {
+        uint256 length = calls.length;
+        resolveCalls = new bytes[](length);
+        for (uint256 i = 0; i < length; i++) {
             (bool success, bytes memory returnData) = calls[i].to.call(
                 calls[i].data
             );
@@ -48,7 +50,8 @@ contract OwnableMulticall is OwnableUpgradeable {
 
     // TODO: deduplicate
     function proxyCallBatch(address to, bytes[] memory calls) internal {
-        for (uint256 i = 0; i < calls.length; i += 1) {
+        uint256 length = calls.length;
+        for (uint256 i = 0; i < length; i += 1) {
             (bool success, bytes memory returnData) = to.call(calls[i]);
             if (!success) {
                 assembly {

--- a/solidity/contracts/Router.sol
+++ b/solidity/contracts/Router.sol
@@ -71,8 +71,9 @@ abstract contract Router is HyperlaneConnectionClient, IMessageRecipient {
     // ============ External functions ============
     function domains() external view returns (uint32[] memory) {
         bytes32[] storage rawKeys = _routers.keys();
-        uint32[] memory keys = new uint32[](rawKeys.length);
-        for (uint256 i = 0; i < rawKeys.length; i++) {
+        uint256 length = rawKeys.length;
+        uint32[] memory keys = new uint32[](length);
+        for (uint256 i = 0; i < length; i++) {
             keys[i] = uint32(uint256(rawKeys[i]));
         }
         return keys;
@@ -109,7 +110,8 @@ abstract contract Router is HyperlaneConnectionClient, IMessageRecipient {
         bytes32[] calldata _addresses
     ) external virtual onlyOwner {
         require(_domains.length == _addresses.length, "!length");
-        for (uint256 i = 0; i < _domains.length; i += 1) {
+        uint256 length = _domains.length;
+        for (uint256 i = 0; i < length; i += 1) {
             _enrollRemoteRouter(_domains[i], _addresses[i]);
         }
     }

--- a/solidity/contracts/isms/MultisigIsm.sol
+++ b/solidity/contracts/isms/MultisigIsm.sol
@@ -99,10 +99,12 @@ contract MultisigIsm is IMultisigIsm, Ownable {
         uint32[] calldata _domains,
         address[][] calldata _validators
     ) external onlyOwner {
-        require(_domains.length == _validators.length, "!length");
-        for (uint256 i = 0; i < _domains.length; i += 1) {
+        uint256 domainsLength = _domains.length;
+        require(domainsLength == _validators.length, "!length");
+        for (uint256 i = 0; i < domainsLength; i += 1) {
             address[] calldata _domainValidators = _validators[i];
-            for (uint256 j = 0; j < _domainValidators.length; j += 1) {
+            uint256 validatorsLength = _domainValidators.length;
+            for (uint256 j = 0; j < validatorsLength; j += 1) {
                 _enrollValidator(_domains[i], _domainValidators[j]);
             }
             _updateCommitment(_domains[i]);
@@ -152,8 +154,9 @@ contract MultisigIsm is IMultisigIsm, Ownable {
         uint32[] calldata _domains,
         uint8[] calldata _thresholds
     ) external onlyOwner {
-        require(_domains.length == _thresholds.length, "!length");
-        for (uint256 i = 0; i < _domains.length; i += 1) {
+        uint256 length = _domains.length;
+        require(length == _thresholds.length, "!length");
+        for (uint256 i = 0; i < length; i += 1) {
             setThreshold(_domains[i], _thresholds[i]);
         }
     }


### PR DESCRIPTION
### Description

> Length computation for arrays is often included in the for loops
condition instead of being catched in a local variable.
> In these cases, the Solidity compiler will always read the length of
the array during each iteration.
> Instead, creating a new variable uint256 _length and iterating for
(uint256 i = 0; i < _length; ++i) will be much cheaper in terms of
Gas.
> This is most impactful for storage variable read operations, but it
is advised as a best practice in any case.

### Backward compatibility

No

### Testing

Unit Tests
