### PR TITLE
Use external function visibility where possible

### DIFF
--- a/solidity/contracts/Mailbox.sol
+++ b/solidity/contracts/Mailbox.sol
@@ -228,7 +228,7 @@ contract Mailbox is
      * @return root The root of the Mailbox's merkle tree.
      * @return index The index of the last element in the tree.
      */
-    function latestCheckpoint() public view returns (bytes32, uint32) {
+    function latestCheckpoint() external view returns (bytes32, uint32) {
         return (root(), count() - 1);
     }
 

--- a/solidity/contracts/isms/MultisigIsm.sol
+++ b/solidity/contracts/isms/MultisigIsm.sol
@@ -199,7 +199,7 @@ contract MultisigIsm is IMultisigIsm, Ownable {
      * @param _message Formatted Hyperlane message (see Message.sol).
      */
     function verify(bytes calldata _metadata, bytes calldata _message)
-        public
+        external
         view
         returns (bool)
     {

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -37,7 +37,7 @@ contract InterchainAccountRouter is Router, IInterchainAccountRouter {
         address _mailbox,
         address _interchainGasPaymaster,
         address _interchainSecurityModule
-    ) public initializer {
+    ) external initializer {
         // Transfer ownership of the contract to `msg.sender`
         __Router_initialize(
             _mailbox,
@@ -47,7 +47,7 @@ contract InterchainAccountRouter is Router, IInterchainAccountRouter {
     }
 
     function initialize(address _mailbox, address _interchainGasPaymaster)
-        public
+        external
         initializer
     {
         // Transfer ownership of the contract to `msg.sender`

--- a/solidity/contracts/middleware/InterchainQueryRouter.sol
+++ b/solidity/contracts/middleware/InterchainQueryRouter.sol
@@ -35,7 +35,7 @@ contract InterchainQueryRouter is
         address _mailbox,
         address _interchainGasPaymaster,
         address _interchainSecurityModule
-    ) public initializer {
+    ) external initializer {
         // Transfer ownership of the contract to `msg.sender`
         __Router_initialize(
             _mailbox,
@@ -45,7 +45,7 @@ contract InterchainQueryRouter is
     }
 
     function initialize(address _mailbox, address _interchainGasPaymaster)
-        public
+        external
         initializer
     {
         // Transfer ownership of the contract to `msg.sender`

--- a/solidity/contracts/middleware/liquidity-layer/LiquidityLayerRouter.sol
+++ b/solidity/contracts/middleware/liquidity-layer/LiquidityLayerRouter.sol
@@ -23,7 +23,7 @@ contract LiquidityLayerRouter is Router, ILiquidityLayerRouter {
         address _mailbox,
         address _interchainGasPaymaster,
         address _interchainSecurityModule
-    ) public initializer {
+    ) external initializer {
         // Transfer ownership of the contract to `msg.sender`
         __Router_initialize(
             _mailbox,
@@ -33,7 +33,7 @@ contract LiquidityLayerRouter is Router, ILiquidityLayerRouter {
     }
 
     function initialize(address _mailbox, address _interchainGasPaymaster)
-        public
+        external
         initializer
     {
         // Transfer ownership of the contract to `msg.sender`

--- a/solidity/contracts/middleware/liquidity-layer/adapters/CircleBridgeAdapter.sol
+++ b/solidity/contracts/middleware/liquidity-layer/adapters/CircleBridgeAdapter.sol
@@ -70,7 +70,7 @@ contract CircleBridgeAdapter is ILiquidityLayerAdapter, Router {
         address _circleBridge,
         address _circleMessageTransmitter,
         address _liquidityLayerRouter
-    ) public initializer {
+    ) external initializer {
         // Transfer ownership of the contract to deployer
         _transferOwnership(_owner);
 


### PR DESCRIPTION
### Description

> public functions that are never called by the contract should be
declared external to save gas.
> Path: monorepo/solidity/contracts/Mailbox.sol : latestCheckpoint()
> monorepo/solidity/contracts/isms/MultisigIsm.sol : verify()
> monorepo/solidity/contracts/middleware/InterchainAccountRouter.sol :
initialize(), getInterchainAccount()
> monorepo/solidity/contracts/middleware/InterchainQueryRouter.sol :
initialize()
> monorepo/solidity/contracts/middleware/liquidity-layer/LiquidityLayer
Router.sol : initialize()
> monorepo/solidity/contracts/middleware/liquidity-layer/adapters/Circl
eBridgeAdapter.sol : initialize()

### Backward compatibility

No

### Testing

Unit Tests
