### PR TITLE
Deploy Fallback Provider to V1

### DIFF
--- a/rust/helm/abacus-agent/templates/external-secret.yaml
+++ b/rust/helm/abacus-agent/templates/external-secret.yaml
@@ -36,7 +36,7 @@ spec:
    */}}
         {{- range .Values.abacus.inboxChains }}
         {{- if not .disabled }}
-        {{- if eq .connection.type "httpQuorum" }}
+        {{- if or (eq .connection.type "httpQuorum") (eq .connection.type "httpFallback") }}
         HYP_BASE_INBOXES_{{ .name | upper }}_CONNECTION_URLS: {{ printf "'{{ .%s_rpcs | fromJson | join \",\" }}'" .name }}
         {{- else }}
         HYP_BASE_INBOXES_{{ .name | upper }}_CONNECTION_URL: {{ printf "'{{ .%s_rpc | toString }}'" .name }}
@@ -44,7 +44,7 @@ spec:
         {{- end }}
         {{- end }}
   data:
-  {{- if eq .Values.abacus.outboxChain.connection.type "httpQuorum" }}
+  {{- if or (eq .Values.abacus.outboxChain.connection.type "httpQuorum") (eq .Values.abacus.outboxChain.connection.type "httpFallback") }}
   - secretKey: outbox_rpcs
     remoteRef:
       key: {{ printf "%s-rpc-endpoints-%s" .Values.abacus.runEnv .Values.abacus.outboxChain.name }}
@@ -64,7 +64,7 @@ spec:
    */}}
   {{- range .Values.abacus.inboxChains }}
   {{- if not .disabled }}
-  {{- if eq .connection.type "httpQuorum" }}
+  {{- if or (eq .connection.type "httpQuorum") (eq .connection.type "httpFallback") }}
   - secretKey: {{ printf "%s_rpcs" .name }}
     remoteRef:
       key: {{ printf "%s-rpc-endpoints-%s" $.Values.abacus.runEnv .name }}

--- a/rust/helm/scraper/templates/configmap.yaml
+++ b/rust/helm/scraper/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
   {{- if not .disabled }}
   HYP_SCRAPER_{{ .name | upper }}_OUTBOX_DISABLED: "false"
   HYP_SCRAPER_{{ .name | upper }}_OUTBOX_CONNECTION_TYPE: {{ .connection.type }}
-  {{- if eq .connection.type "httpQuorum" }}
+  {{- if or (eq .connection.type "httpQuorum") (eq .connection.type "httpFallback") }}
   HYP_SCRAPER_{{ .name | upper }}_OUTBOX_CONNECTION_URLS: ""
   {{- else }}
   HYP_SCRAPER_{{ .name | upper }}_OUTBOX_CONNECTION_URL: ""

--- a/rust/helm/scraper/templates/external-secret.yaml
+++ b/rust/helm/scraper/templates/external-secret.yaml
@@ -29,7 +29,7 @@ spec:
    */}}
         {{- range .Values.abacus.outboxChains }}
         {{- if not .disabled }}
-        {{- if eq .connection.type "httpQuorum" }}
+        {{- if or (eq .connection.type "httpQuorum") (eq .connection.type "httpFallback") }}
         HYP_SCRAPER_{{ .name | upper }}_OUTBOX_CONNECTION_URLS: {{ printf "'{{ .%s_rpcs | fromJson | join \",\" }}'" .name }}
         {{- else }}
         HYP_SCRAPER_{{ .name | upper }}_OUTBOX_CONNECTION_URL: {{ printf "'{{ .%s_rpc | toString }}'" .name }}
@@ -43,7 +43,7 @@ spec:
    */}}
         {{- range .Values.abacus.inboxChains }}
         {{- if not .disabled }}
-        {{- if eq .connection.type "httpQuorum" }}
+        {{- if or (eq .connection.type "httpQuorum") (eq .connection.type "httpFallback") }}
         HYP_BASE_INBOXES_{{ .name | upper }}_CONNECTION_URLS: {{ printf "'{{ .%s_rpcs | fromJson | join \",\" }}'" .name }}
         {{- else }}
         HYP_BASE_INBOXES_{{ .name | upper }}_CONNECTION_URL: {{ printf "'{{ .%s_rpc | toString }}'" .name }}
@@ -61,7 +61,7 @@ spec:
    */}}
   {{- range .Values.abacus.inboxChains }}
   {{- if not .disabled }}
-  {{- if eq .connection.type "httpQuorum" }}
+  {{- if or (eq .connection.type "httpQuorum") (eq .connection.type "httpFallback") }}
   - secretKey: {{ printf "%s_rpcs" .name }}
     remoteRef:
       key: {{ printf "%s-rpc-endpoints-%s" $.Values.abacus.runEnv .name }}

--- a/typescript/infra/config/environments/mainnet/agent.ts
+++ b/typescript/infra/config/environments/mainnet/agent.ts
@@ -23,7 +23,7 @@ export const abacus: AgentConfig<MainnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-01fc263',
+    tag: 'sha-f8bcf0a',
   },
   aws: {
     region: 'us-east-1',
@@ -41,7 +41,7 @@ export const abacus: AgentConfig<MainnetChains> = {
       // 'optimism',
     ],
   },
-  connectionType: ConnectionType.HttpQuorum,
+  connectionType: ConnectionType.HttpFallback,
   validator: {
     default: {
       interval: 5,
@@ -96,7 +96,7 @@ export const releaseCandidate: AgentConfig<MainnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-9b17834',
+    tag: 'sha-f8bcf0a',
   },
   aws: {
     region: 'us-east-1',
@@ -114,7 +114,7 @@ export const releaseCandidate: AgentConfig<MainnetChains> = {
       // 'optimism',
     ],
   },
-  connectionType: ConnectionType.HttpQuorum,
+  connectionType: ConnectionType.HttpFallback,
   relayer: {
     default: {
       signedCheckpointPollingInterval: 5,

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -26,7 +26,7 @@ export const abacus: AgentConfig<TestnetChains> = {
   context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-01fc263',
+    tag: 'sha-f8bcf0a',
   },
   aws: {
     region: 'us-east-1',
@@ -41,7 +41,7 @@ export const abacus: AgentConfig<TestnetChains> = {
       // 'goerli',
     ],
   },
-  connectionType: ConnectionType.HttpQuorum,
+  connectionType: ConnectionType.HttpFallback,
   validator: {
     default: {
       interval: 5,
@@ -90,7 +90,7 @@ export const flowcarbon: AgentConfig<TestnetChains> = {
   context: Contexts.Flowcarbon,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-9b17834',
+    tag: 'sha-f8bcf0a',
   },
   aws: {
     region: 'us-east-1',
@@ -103,7 +103,7 @@ export const flowcarbon: AgentConfig<TestnetChains> = {
       // 'alfajores',
     ],
   },
-  connectionType: ConnectionType.HttpQuorum,
+  connectionType: ConnectionType.HttpFallback,
   relayer: {
     default: {
       signedCheckpointPollingInterval: 5,
@@ -124,7 +124,7 @@ export const releaseCandidate: AgentConfig<TestnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-01fc263',
+    tag: 'sha-f8bcf0a',
   },
   aws: {
     region: 'us-east-1',
@@ -139,7 +139,7 @@ export const releaseCandidate: AgentConfig<TestnetChains> = {
       // 'goerli',
     ],
   },
-  connectionType: ConnectionType.HttpQuorum,
+  connectionType: ConnectionType.HttpFallback,
   relayer: {
     default: {
       signedCheckpointPollingInterval: 5,

--- a/typescript/infra/src/config/agent.ts
+++ b/typescript/infra/src/config/agent.ts
@@ -239,6 +239,7 @@ export enum ConnectionType {
   Http = 'http',
   Ws = 'ws',
   HttpQuorum = 'httpQuorum',
+  HttpFallback = 'httpFallback',
 }
 
 export type RustConnection =


### PR DESCRIPTION
### Description

Changes v1 deployments to use the FallbackProvider for all operations.

- Updated helm
- Updated config
- Updated shas to the new commits that have been deployed

### Drive-by changes

None

### Related issues

- Fixes #1626 
- Fixes #1627 

### Backward compatibility

_Are these changes backward compatible?_

Yes


_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

Yes - fallback provider has to be disabled for older commits


### Testing

_What kind of testing have these changes undergone?_

Manual
