### PR TITLE
Add mainnet moonbeam IQS & ICA addresses to SDK

### DIFF
--- a/typescript/sdk/src/consts/environments/mainnet.json
+++ b/typescript/sdk/src/consts/environments/mainnet.json
@@ -147,7 +147,9 @@
     },
     "defaultIsmInterchainGasPaymaster": "0x56f52c0A1ddcD557285f7CBc782D3d83096CE1Cc",
     "multisigIsm": "0xf3b1F415740A26568C45b1c771A737E31C198F09",
-    "create2Factory": "0xc97D8e6f57b0d64971453dDc6EB8483fec9d163a"
+    "create2Factory": "0xc97D8e6f57b0d64971453dDc6EB8483fec9d163a",
+    "interchainAccountRouter": "0xE0Be420779cAd6E2bEA1E4F7C02F996D9ED1fCB5",
+    "interchainQueryRouter": "0x234b19282985882d6d6fd54dEBa272271f4eb784"
   },
   "gnosis": {
     "validatorAnnounce": "0x9bBdef63594D5FFc2f370Fe52115DdFFe97Bc524",


### PR DESCRIPTION
### Description

Seems these must've been accidentally removed :/

### Drive-by changes

no

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None
