### PR TITLE
Remove deprecated phase from metric

### DIFF
--- a/rust/hyperlane-base/src/metrics/core.rs
+++ b/rust/hyperlane-base/src/metrics/core.rs
@@ -283,8 +283,6 @@ impl CoreMetrics {
     /// The following phases are implemented:
     /// - `dispatch`: Highest nonce which has been indexed on the mailbox
     ///   contract syncer and stored in the relayer DB.
-    /// - `signed_offchain_checkpoint`: Highest nonce of a checkpoint which is
-    ///   known to have been signed by a quorum of validators.
     /// - `processor_loop`: Highest nonce which the MessageProcessor loop has
     ///   gotten to but not attempted to send it.
     /// - `message_processed`: When a nonce was processed as part of the


### PR DESCRIPTION
### Description

Removed a deprecated phase from the metric docs. I had gotten confused why the metric was not working so this helps clear that up.

### Drive-by changes

None

### Related issues

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None