### PR TITLE
Prevent calls to `Mailbox.recipientIsm` when the recipient of a message isn't a contract

### DIFF
--- a/rust/agents/relayer/src/msg/metadata_builder.rs
+++ b/rust/agents/relayer/src/msg/metadata_builder.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
-use tracing::{debug, info, instrument};
+use tracing::{debug, info, instrument, trace};
 
 use hyperlane_base::{CachingMailbox, ChainSetup, CoreMetrics, MultisigCheckpointSyncer};
-use hyperlane_core::{HyperlaneMessage, Mailbox, MultisigIsm};
+use hyperlane_core::{HyperlaneChain, HyperlaneMessage, Mailbox, MultisigIsm};
 
 use crate::merkle_tree_builder::MerkleTreeBuilder;
 
@@ -37,6 +37,21 @@ impl MetadataBuilder {
         message: &HyperlaneMessage,
         mailbox: CachingMailbox,
     ) -> eyre::Result<Option<Vec<u8>>> {
+        // The Mailbox's `recipientIsm` function will revert if
+        // the recipient is not a contract. This can pose issues with
+        // our use of the RetryingProvider, which will continuously retry
+        // the eth_call to the `recipientIsm` function.
+        // As a workaround, we avoid the call entirely if the recipient is
+        // not a contract.
+        let provider = mailbox.provider();
+        if !provider.is_contract(&message.recipient).await? {
+            trace!(
+                recipient=?message.recipient,
+                "Recipient is not a contract, not fetching metadata"
+            );
+            return Ok(None);
+        }
+
         let ism_address = mailbox.recipient_ism(message.recipient).await?;
         let multisig_ism = self
             .chain_setup

--- a/rust/agents/relayer/src/msg/metadata_builder.rs
+++ b/rust/agents/relayer/src/msg/metadata_builder.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
-use tracing::{debug, info, instrument, trace};
+use tracing::{debug, info, instrument};
 
 use hyperlane_base::{CachingMailbox, ChainSetup, CoreMetrics, MultisigCheckpointSyncer};
 use hyperlane_core::{HyperlaneChain, HyperlaneMessage, Mailbox, MultisigIsm};
@@ -45,7 +45,7 @@ impl MetadataBuilder {
         // not a contract.
         let provider = mailbox.provider();
         if !provider.is_contract(&message.recipient).await? {
-            trace!(
+            debug!(
                 recipient=?message.recipient,
                 "Recipient is not a contract, not fetching metadata"
             );

--- a/rust/chains/hyperlane-ethereum/src/interchain_gas.rs
+++ b/rust/chains/hyperlane-ethereum/src/interchain_gas.rs
@@ -10,7 +10,7 @@ use tracing::instrument;
 
 use hyperlane_core::{
     ChainCommunicationError, ChainResult, ContractLocator, HyperlaneAbi, HyperlaneChain,
-    HyperlaneContract, HyperlaneDomain, Indexer, InterchainGasPaymaster,
+    HyperlaneContract, HyperlaneDomain, HyperlaneProvider, Indexer, InterchainGasPaymaster,
     InterchainGasPaymasterIndexer, InterchainGasPayment, InterchainGasPaymentMeta,
     InterchainGasPaymentWithMeta, H160, H256,
 };
@@ -19,6 +19,7 @@ use crate::contracts::interchain_gas_paymaster::{
     InterchainGasPaymaster as EthereumInterchainGasPaymasterInternal, INTERCHAINGASPAYMASTER_ABI,
 };
 use crate::trait_builder::BuildableWithProvider;
+use crate::EthereumProvider;
 
 impl<M> Display for EthereumInterchainGasPaymasterInternal<M>
 where
@@ -182,6 +183,13 @@ where
 {
     fn domain(&self) -> &HyperlaneDomain {
         &self.domain
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        Box::new(EthereumProvider::new(
+            self.contract.client(),
+            self.domain.clone(),
+        ))
     }
 }
 

--- a/rust/chains/hyperlane-ethereum/src/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/mailbox.rs
@@ -14,13 +14,14 @@ use tracing::instrument;
 use hyperlane_core::{
     ChainCommunicationError, ChainResult, Checkpoint, ContractLocator, HyperlaneAbi,
     HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneMessage, HyperlaneProtocolError,
-    Indexer, LogMeta, Mailbox, MailboxIndexer, RawHyperlaneMessage, TxCostEstimate, TxOutcome,
-    H256, U256,
+    HyperlaneProvider, Indexer, LogMeta, Mailbox, MailboxIndexer, RawHyperlaneMessage,
+    TxCostEstimate, TxOutcome, H256, U256,
 };
 
 use crate::contracts::mailbox::{Mailbox as EthereumMailboxInternal, ProcessCall, MAILBOX_ABI};
 use crate::trait_builder::BuildableWithProvider;
 use crate::tx::report_tx;
+use crate::EthereumProvider;
 
 impl<M> std::fmt::Display for EthereumMailboxInternal<M>
 where
@@ -214,6 +215,13 @@ where
 {
     fn domain(&self) -> &HyperlaneDomain {
         &self.domain
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        Box::new(EthereumProvider::new(
+            self.provider.clone(),
+            self.domain.clone(),
+        ))
     }
 }
 

--- a/rust/chains/hyperlane-ethereum/src/multisig_ism.rs
+++ b/rust/chains/hyperlane-ethereum/src/multisig_ism.rs
@@ -12,12 +12,13 @@ use tracing::instrument;
 use hyperlane_core::accumulator::merkle::Proof;
 use hyperlane_core::{
     ChainResult, ContractLocator, HyperlaneAbi, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
-    HyperlaneMessage, MultisigIsm, MultisigSignedCheckpoint, RawHyperlaneMessage,
-    SignatureWithSigner, H256,
+    HyperlaneMessage, HyperlaneProvider, MultisigIsm, MultisigSignedCheckpoint,
+    RawHyperlaneMessage, SignatureWithSigner, H256,
 };
 
 use crate::contracts::multisig_ism::{MultisigIsm as EthereumMultisigIsmInternal, MULTISIGISM_ABI};
 use crate::trait_builder::BuildableWithProvider;
+use crate::EthereumProvider;
 
 impl<M> std::fmt::Display for EthereumMultisigIsmInternal<M>
 where
@@ -73,6 +74,13 @@ where
 {
     fn domain(&self) -> &HyperlaneDomain {
         &self.domain
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        Box::new(EthereumProvider::new(
+            self.contract.client(),
+            self.domain.clone(),
+        ))
     }
 }
 

--- a/rust/chains/hyperlane-fuel/src/interchain_gas.rs
+++ b/rust/chains/hyperlane-fuel/src/interchain_gas.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use hyperlane_core::{HyperlaneDomain, H256};
+use hyperlane_core::{HyperlaneDomain, HyperlaneProvider, H256};
 
 use hyperlane_core::{
     ChainResult, HyperlaneChain, HyperlaneContract, Indexer, InterchainGasPaymaster,
@@ -18,6 +18,10 @@ impl HyperlaneContract for FuelInterchainGasPaymaster {
 
 impl HyperlaneChain for FuelInterchainGasPaymaster {
     fn domain(&self) -> &HyperlaneDomain {
+        todo!()
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
         todo!()
     }
 }

--- a/rust/chains/hyperlane-fuel/src/mailbox.rs
+++ b/rust/chains/hyperlane-fuel/src/mailbox.rs
@@ -8,8 +8,8 @@ use tracing::instrument;
 
 use hyperlane_core::{
     ChainCommunicationError, ChainResult, Checkpoint, ContractLocator, HyperlaneAbi,
-    HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneMessage, Indexer, LogMeta,
-    Mailbox, MailboxIndexer, TxCostEstimate, TxOutcome, H256, U256,
+    HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneMessage, HyperlaneProvider,
+    Indexer, LogMeta, Mailbox, MailboxIndexer, TxCostEstimate, TxOutcome, H256, U256,
 };
 
 use crate::{
@@ -49,6 +49,10 @@ impl HyperlaneContract for FuelMailbox {
 impl HyperlaneChain for FuelMailbox {
     fn domain(&self) -> &HyperlaneDomain {
         &self.domain
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        todo!()
     }
 }
 

--- a/rust/chains/hyperlane-fuel/src/multisig_ism.rs
+++ b/rust/chains/hyperlane-fuel/src/multisig_ism.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use hyperlane_core::{
     accumulator::merkle::Proof, ChainResult, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
-    HyperlaneMessage, MultisigIsm, MultisigSignedCheckpoint, H256,
+    HyperlaneMessage, HyperlaneProvider, MultisigIsm, MultisigSignedCheckpoint, H256,
 };
 
 /// A reference to a MultisigIsm contract on some Fuel chain
@@ -17,6 +17,10 @@ impl HyperlaneContract for FuelMultisigIsm {
 
 impl HyperlaneChain for FuelMultisigIsm {
     fn domain(&self) -> &HyperlaneDomain {
+        todo!()
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
         todo!()
     }
 }

--- a/rust/chains/hyperlane-fuel/src/provider.rs
+++ b/rust/chains/hyperlane-fuel/src/provider.rs
@@ -12,6 +12,10 @@ impl HyperlaneChain for FuelProvider {
     fn domain(&self) -> &HyperlaneDomain {
         todo!()
     }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        todo!()
+    }
 }
 
 #[async_trait]
@@ -21,6 +25,10 @@ impl HyperlaneProvider for FuelProvider {
     }
 
     async fn get_txn_by_hash(&self, hash: &H256) -> ChainResult<TxnInfo> {
+        todo!()
+    }
+
+    async fn is_contract(&self, address: &H256) -> ChainResult<bool> {
         todo!()
     }
 }

--- a/rust/hyperlane-base/src/mailbox.rs
+++ b/rust/hyperlane-base/src/mailbox.rs
@@ -11,7 +11,7 @@ use tracing::{info_span, Instrument};
 use hyperlane_core::db::HyperlaneDB;
 use hyperlane_core::{
     ChainResult, Checkpoint, HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneMessage,
-    Mailbox, MailboxIndexer, TxCostEstimate, TxOutcome, H256, U256,
+    HyperlaneProvider, Mailbox, MailboxIndexer, TxCostEstimate, TxOutcome, H256, U256,
 };
 
 use crate::chains::IndexSettings;
@@ -139,6 +139,10 @@ impl Mailbox for CachingMailbox {
 impl HyperlaneChain for CachingMailbox {
     fn domain(&self) -> &HyperlaneDomain {
         self.mailbox.domain()
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        self.mailbox.provider()
     }
 }
 

--- a/rust/hyperlane-core/src/traits/deployed.rs
+++ b/rust/hyperlane-core/src/traits/deployed.rs
@@ -1,4 +1,4 @@
-use crate::{HyperlaneDomain, H256};
+use crate::{HyperlaneDomain, HyperlaneProvider, H256};
 use std::fmt;
 
 /// Interface for features of something deployed on/in a domain or is otherwise
@@ -7,6 +7,8 @@ use std::fmt;
 pub trait HyperlaneChain {
     /// Return the domain
     fn domain(&self) -> &HyperlaneDomain;
+    /// A provider for the chain
+    fn provider(&self) -> Box<dyn HyperlaneProvider>;
 }
 
 /// Interface for a deployed contract.

--- a/rust/hyperlane-core/src/traits/provider.rs
+++ b/rust/hyperlane-core/src/traits/provider.rs
@@ -21,6 +21,9 @@ pub trait HyperlaneProvider: HyperlaneChain + Send + Sync + Debug {
 
     /// Get txn info for a given txn hash
     async fn get_txn_by_hash(&self, hash: &H256) -> ChainResult<TxnInfo>;
+
+    /// Returns whether a contract exists at the provided address
+    async fn is_contract(&self, address: &H256) -> ChainResult<bool>;
 }
 
 /// Errors when querying for provider information.

--- a/rust/hyperlane-test/src/mocks/mailbox.rs
+++ b/rust/hyperlane-test/src/mocks/mailbox.rs
@@ -14,6 +14,8 @@ mock! {
 
         pub fn _domain(&self) -> &HyperlaneDomain {}
 
+        pub fn _provider(&self) -> Box<dyn HyperlaneProvider> {}
+
         pub fn _domain_hash(&self) -> H256 {}
 
         pub fn _raw_message_by_id(
@@ -109,6 +111,10 @@ impl Mailbox for MockMailboxContract {
 impl HyperlaneChain for MockMailboxContract {
     fn domain(&self) -> &HyperlaneDomain {
         self._domain()
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        self._provider()
     }
 }
 


### PR DESCRIPTION
### Description

Had a few relayer operators run into this today:
If a recipient doesn't have any code at the destination, the call to [Mailbox.recipientIsm](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/Mailbox.sol#L265) will revert. The try/catch already in there unfortunately isn't sufficient to prevent this (see here https://ethereum.stackexchange.com/questions/129150/solidity-try-catch-call-to-external-non-existent-address-method)

This conflicts with our use of the RetryingProvider, which pretty much assumes we never will intentionally make an `eth_call` that reverts. We end up retrying the eth_call a bunch of times, holding up progress in the serial submitter and providing a bunch of scary logs

This PR:
* Adds a `provider` fn to the `HyperlaneChain` trait, so that you can get access to a provider from a contract without reconstructing it from scratch
* Adds `is_contract`, which returns if there's code at the provided address
* Stops fetching metadata if the recipient is not a contract

### Drive-by changes

none

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None yet
