### PR TITLE
Fix mainnet2 kathy image tag

### DIFF
--- a/typescript/infra/config/environments/mainnet2/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet2/helloworld.ts
@@ -12,7 +12,7 @@ export const hyperlane: HelloWorldConfig<MainnetChains> = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'sha-76d8c5e-20230208-232847',
+      tag: '76d8c5e-20230208-232847',
     },
     chainsToSkip: [],
     runEnv: environment,


### PR DESCRIPTION
### Description

Previous deploy (#1787 ) was with a non-existent tag.

### Drive-by changes

None

