### PR TITLE
Add max message nonce gauge to relayer

### DIFF
--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -179,7 +179,7 @@ impl MessageProcessorMetrics {
         Self {
             max_last_known_message_nonce_gauge: metrics
                 .last_known_message_nonce()
-                .with_label_values(&["processor_loop", "maximum"]),
+                .with_label_values(&["processor_loop", "any", "any"]),
             last_known_message_nonce_gauges: gauges,
         }
     }

--- a/rust/hyperlane-base/src/metrics/core.rs
+++ b/rust/hyperlane-base/src/metrics/core.rs
@@ -276,9 +276,9 @@ impl CoreMetrics {
     ///
     /// Labels:
     /// - `phase`: The phase the nonce is being tracked at, see below.
-    /// - `origin`: Origin chain the message comes from.
+    /// - `origin`: Origin chain the message comes from. Can be "any"
     /// - `remote`: Remote chain for the message. This will skip values because
-    ///   the nonces are contiguous by origin not remote.
+    ///   the nonces are contiguous by origin not remote. Can be "any"
     ///
     /// The following phases are implemented:
     /// - `dispatch`: Highest nonce which has been indexed on the mailbox


### PR DESCRIPTION
### Description

Adds a domain-independent last known message nonce gauge to relayer

### Drive-by changes

None
### Related issues

- Fixes #1688 

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

_What kind of testing have these changes undergone?_

None

