### PR TITLE
Use fallback provider in Hyperlane context kathys

### DIFF
--- a/typescript/infra/config/environments/mainnet2/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet2/helloworld.ts
@@ -23,7 +23,7 @@ export const hyperlane: HelloWorldConfig<MainnetChains> = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
-    connectionType: ConnectionType.Http,
+    connectionType: ConnectionType.HttpFallback,
     cyclesBetweenEthereumMessages: 3, // Skip 3 cycles of Ethereum, i.e. send/receive Ethereum messages every 32 hours.
   },
 };

--- a/typescript/infra/config/environments/testnet3/helloworld.ts
+++ b/typescript/infra/config/environments/testnet3/helloworld.ts
@@ -23,7 +23,7 @@ export const hyperlane: HelloWorldConfig<TestnetChains> = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
-    connectionType: ConnectionType.Http,
+    connectionType: ConnectionType.HttpFallback,
   },
 };
 

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -31,20 +31,27 @@ export async function fetchProvider(
   chainName: ChainName,
   connectionType: ConnectionType = ConnectionType.Http,
 ): Promise<ethers.providers.Provider> {
-  if (
-    connectionType !== ConnectionType.Http &&
-    connectionType !== ConnectionType.HttpQuorum
-  ) {
-    throw Error(`Unsupported connectionType: ${connectionType}`);
-  }
-  const quorum = connectionType === ConnectionType.HttpQuorum;
-  const rpc = await getSecretRpcEndpoint(environment, chainName, quorum);
-  if (quorum) {
-    return new ethers.providers.FallbackProvider(
-      (rpc as string[]).map((url) => providerBuilder(url, chainName)),
-      1, // a single provider is "quorum", but failure will cause failover to the next provider
-    );
-  } else {
-    return providerBuilder(rpc, chainName);
+  const single = connectionType === ConnectionType.Http;
+  const rpcData = await getSecretRpcEndpoint(environment, chainName, !single);
+  switch (connectionType) {
+    case ConnectionType.Http: {
+      return providerBuilder(rpcData, chainName);
+    }
+    case ConnectionType.HttpQuorum: {
+      return new ethers.providers.FallbackProvider(
+        (rpcData as string[]).map((url) =>
+          providerBuilder(url, chainName, false),
+        ), // disable retry for quorum
+      );
+    }
+    case ConnectionType.HttpFallback: {
+      return new ethers.providers.FallbackProvider(
+        (rpcData as string[]).map((url) => providerBuilder(url, chainName)),
+        1, // a single provider is "quorum", but failure will cause failover to the next provider
+      );
+    }
+    default: {
+      throw Error(`Unsupported connectionType: ${connectionType}`);
+    }
   }
 }

--- a/typescript/infra/src/config/helloworld.ts
+++ b/typescript/infra/src/config/helloworld.ts
@@ -28,8 +28,8 @@ export interface HelloWorldKathyConfig<Chain extends ChainName> {
   /** How long kathy should wait before giving up on waiting for the message to be received (milliseconds). */
   messageReceiptTimeout: number;
 
-  // Whether to use a single HTTP provider or a quorum of HTTP providers
-  connectionType: ConnectionType.Http | ConnectionType.HttpQuorum;
+  // Which type of provider to use
+  connectionType: Exclude<ConnectionType, ConnectionType.Ws>;
   // How many cycles to skip between a cycles that send messages to/from Ethereum. Defaults to 0.
   cyclesBetweenEthereumMessages?: number;
 }


### PR DESCRIPTION
### Description

This PR updates the hyperlane context Kathys to use HttpFallback providers.

### Drive-by changes

- Add back support for HttpQuorum providers in TS

### Related issues

- Fixes kathy reliability (hopefully)

### Backward compatibility


Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None