### PR TITLE
Spin kathy back up for polygon/celo only

### DIFF
--- a/typescript/infra/config/environments/mainnet/agent.ts
+++ b/typescript/infra/config/environments/mainnet/agent.ts
@@ -81,28 +81,28 @@ export const abacus: AgentConfig<MainnetChains> = {
         // Allow bidirectional messaging between Polygon/Celo Toucan contracts
         {
           sourceAddress: '0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf',
-          sourceDomain: 'celo',
+          sourceDomain: '1667591279', // celo
           destinationAddress: '0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf',
-          destinationDomain: 'polygon',
+          destinationDomain: '1886350457', // polygon
         },
         {
           sourceAddress: '0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf',
-          sourceDomain: 'polygon',
+          sourceDomain: '1886350457', // polygon
           destinationAddress: '0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf',
-          destinationDomain: 'celo',
+          destinationDomain: '1667591279', // celo
         },
         // Allow bidirectional messaging between Polygon/Celo Helloworld contracts
         {
           sourceAddress: '0x37fcf9DAEFAb05939c6e299c1AB8e7430A5715c8',
-          sourceDomain: 'celo',
+          sourceDomain: '1667591279', // celo
           destinationAddress: '0xb3eCff91A3C3FB1A2F57DE2881a0Cab7b56E129b',
-          destinationDomain: 'polygon',
+          destinationDomain: '1886350457', // polygon
         },
         {
           sourceAddress: '0xb3eCff91A3C3FB1A2F57DE2881a0Cab7b56E129b',
-          sourceDomain: 'polygon',
+          sourceDomain: '1886350457', // polygon
           destinationAddress: '0x37fcf9DAEFAb05939c6e299c1AB8e7430A5715c8',
-          destinationDomain: 'celo',
+          destinationDomain: '1667591279', // celo
         },
       ],
       gasPaymentEnforcementPolicy: {

--- a/typescript/infra/config/environments/mainnet/agent.ts
+++ b/typescript/infra/config/environments/mainnet/agent.ts
@@ -78,7 +78,32 @@ export const abacus: AgentConfig<MainnetChains> = {
     default: {
       signedCheckpointPollingInterval: 5,
       whitelist: [
-        { destinationAddress: '0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf' },
+        // Allow bidirectional messaging between Polygon/Celo Toucan contracts
+        {
+          sourceAddress: '0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf',
+          sourceDomain: 'celo',
+          destinationAddress: '0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf',
+          destinationDomain: 'polygon',
+        },
+        {
+          sourceAddress: '0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf',
+          sourceDomain: 'polygon',
+          destinationAddress: '0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf',
+          destinationDomain: 'celo',
+        },
+        // Allow bidirectional messaging between Polygon/Celo Helloworld contracts
+        {
+          sourceAddress: '0x37fcf9DAEFAb05939c6e299c1AB8e7430A5715c8',
+          sourceDomain: 'celo',
+          destinationAddress: '0xb3eCff91A3C3FB1A2F57DE2881a0Cab7b56E129b',
+          destinationDomain: 'polygon',
+        },
+        {
+          sourceAddress: '0xb3eCff91A3C3FB1A2F57DE2881a0Cab7b56E129b',
+          sourceDomain: 'polygon',
+          destinationAddress: '0x37fcf9DAEFAb05939c6e299c1AB8e7430A5715c8',
+          destinationDomain: 'celo',
+        },
       ],
       gasPaymentEnforcementPolicy: {
         type: GasPaymentEnforcementPolicyType.None,

--- a/typescript/infra/config/environments/mainnet/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet/helloworld.ts
@@ -14,7 +14,15 @@ export const abacus: HelloWorldConfig<MainnetChains> = {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
       tag: 'sha-fcc80c8',
     },
-    chainsToSkip: [],
+    // Everything but Celo and Polygon
+    chainsToSkip: [
+      'bsc',
+      'avalanche',
+      'arbitrum',
+      'optimism',
+      'ethereum',
+      'moonbeam',
+    ],
     runEnv: environment,
     namespace: environment,
     runConfig: {

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -72,8 +72,32 @@ export const abacus: AgentConfig<TestnetChains> = {
     default: {
       signedCheckpointPollingInterval: 5,
       whitelist: [
-        { destinationAddress: '0xdb45A8869f94c15954e282F28e272f5597063e9A' },
-        { destinationAddress: '0xf9a49993DF24366AB8EDf617C080ca36a4ADb86e' },
+        // Allow bidirectional messaging between Mumbai/Alfajores Toucan contracts
+        {
+          sourceAddress: '0xdb45A8869f94c15954e282F28e272f5597063e9A',
+          sourceDomain: 'alfajores',
+          destinationAddress: '0xf9a49993DF24366AB8EDf617C080ca36a4ADb86e',
+          destinationDomain: 'mumbai',
+        },
+        {
+          sourceAddress: '0xf9a49993DF24366AB8EDf617C080ca36a4ADb86e',
+          sourceDomain: 'mumbai',
+          destinationAddress: '0xdb45A8869f94c15954e282F28e272f5597063e9A',
+          destinationDomain: 'alfajores',
+        },
+        // Allow bidirectional messaging between Mumbai/Alfajores Helloworld contracts
+        {
+          sourceAddress: '0x0FD5A339466638aD2746748dCfFF65A27f605de4',
+          sourceDomain: 'alfajores',
+          destinationAddress: '0x636bcE43104Ef1E61e93E84F0A324d037C258308',
+          destinationDomain: 'mumbai',
+        },
+        {
+          sourceAddress: '0x636bcE43104Ef1E61e93E84F0A324d037C258308',
+          sourceDomain: 'mumbai',
+          destinationAddress: '0x0FD5A339466638aD2746748dCfFF65A27f605de4',
+          destinationDomain: 'alfajores',
+        },
       ],
       gasPaymentEnforcementPolicy: {
         type: GasPaymentEnforcementPolicyType.None,

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -75,28 +75,28 @@ export const abacus: AgentConfig<TestnetChains> = {
         // Allow bidirectional messaging between Mumbai/Alfajores Toucan contracts
         {
           sourceAddress: '0xdb45A8869f94c15954e282F28e272f5597063e9A',
-          sourceDomain: 'alfajores',
+          sourceDomain: 1000, // alfajores
           destinationAddress: '0xf9a49993DF24366AB8EDf617C080ca36a4ADb86e',
-          destinationDomain: 'mumbai',
+          destinationDomain: 80001, // mumbai
         },
         {
           sourceAddress: '0xf9a49993DF24366AB8EDf617C080ca36a4ADb86e',
-          sourceDomain: 'mumbai',
+          sourceDomain: 80001, // mumbai
           destinationAddress: '0xdb45A8869f94c15954e282F28e272f5597063e9A',
-          destinationDomain: 'alfajores',
+          destinationDomain: 1000, // alfajores
         },
         // Allow bidirectional messaging between Mumbai/Alfajores Helloworld contracts
         {
           sourceAddress: '0x0FD5A339466638aD2746748dCfFF65A27f605de4',
-          sourceDomain: 'alfajores',
+          sourceDomain: 1000, // alfajores
           destinationAddress: '0x636bcE43104Ef1E61e93E84F0A324d037C258308',
-          destinationDomain: 'mumbai',
+          destinationDomain: 80001, // mumbai
         },
         {
           sourceAddress: '0x636bcE43104Ef1E61e93E84F0A324d037C258308',
-          sourceDomain: 'mumbai',
+          sourceDomain: 80001, // mumbai
           destinationAddress: '0x0FD5A339466638aD2746748dCfFF65A27f605de4',
-          destinationDomain: 'alfajores',
+          destinationDomain: 1000, // alfajores
         },
       ],
       gasPaymentEnforcementPolicy: {

--- a/typescript/infra/config/environments/testnet2/helloworld.ts
+++ b/typescript/infra/config/environments/testnet2/helloworld.ts
@@ -14,7 +14,15 @@ export const abacus: HelloWorldConfig<TestnetChains> = {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
       tag: 'sha-fcc80c8',
     },
-    chainsToSkip: [],
+    // Everything but Alfajores and Mumbai
+    chainsToSkip: [
+      'fuji',
+      'bsctestnet',
+      'goerli',
+      'moonbasealpha',
+      'optimismgoerli',
+      'arbitrumgoerli',
+    ],
     runEnv: environment,
     namespace: environment,
     runConfig: {


### PR DESCRIPTION
### Description

- Skip all chains other than Polygon and Celo in abacus context kathys
- Whitelist Polygon<->Celo and Alfajores<->Mumbai HelloWorld messages in abacus context relayer

### Drive-by changes

- Make Toucan relayer whitelist more specific
- 
### Related issues

- Fixes https://github.com/hyperlane-xyz/issues/issues/383
- 
### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None
