### PR TITLE
Fix message log collision

### DIFF
--- a/rust/agents/relayer/src/msg/gas_payment/policies/meets_estimated_cost.rs
+++ b/rust/agents/relayer/src/msg/gas_payment/policies/meets_estimated_cost.rs
@@ -203,7 +203,7 @@ impl GasPaymentPolicy for GasPaymentPolicyMeetsEstimatedCost {
         let meets_requirement = *current_payment >= origin_token_tx_cost;
         if !meets_requirement {
             info!(
-                %message,
+                msg=%message,
                 ?tx_cost_estimate,
                 ?destination_token_tx_cost,
                 ?origin_token_tx_cost,
@@ -212,7 +212,7 @@ impl GasPaymentPolicy for GasPaymentPolicyMeetsEstimatedCost {
             );
         } else {
             debug!(
-                %message,
+                msg=%message,
                 ?tx_cost_estimate,
                 ?destination_token_tx_cost,
                 ?origin_token_tx_cost,

--- a/rust/agents/relayer/src/msg/gelato_submitter/sponsored_call_op.rs
+++ b/rust/agents/relayer/src/msg/gelato_submitter/sponsored_call_op.rs
@@ -66,7 +66,7 @@ impl SponsoredCallOp {
         Self(args)
     }
 
-    #[instrument(skip(self), fields(message=?self.message.message))]
+    #[instrument(skip(self), fields(msg=?self.message.message))]
     pub async fn run(&mut self) {
         loop {
             match self.tick().await {

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -228,17 +228,17 @@ impl SerialSubmitter {
 
         match self.process_message(&msg).await {
             Ok(true) => {
-                info!(message = %msg.message, "Message processed");
+                info!(msg=%msg.message, "Message processed");
                 self.record_message_process_success(&msg)?;
                 return Ok(());
             }
             Ok(false) => {
-                info!(message = %msg.message, "Message not processed");
+                info!(msg=%msg.message, "Message not processed");
             }
             // We expect this branch to be hit when there is unexpected behavior -
             // defined behavior like gas estimation failing will not hit this branch.
             Err(error) => {
-                error!(message = %msg.message, ?error, "Error occurred when attempting to process message");
+                error!(msg=%msg.message, ?error, "Error occurred when attempting to process message");
             }
         }
 
@@ -256,7 +256,7 @@ impl SerialSubmitter {
     /// been processed, Ok(true) is returned. If this message is unable to
     /// be processed, either due to failed gas estimation or an insufficient gas payment,
     /// Ok(false) is returned.
-    #[instrument(skip(self, msg), fields(message=?msg.message))]
+    #[instrument(skip(self, msg), fields(msg=?msg.message))]
     async fn process_message(&self, msg: &SubmitMessageArgs) -> Result<bool> {
         // If the message has already been processed, e.g. due to another relayer having already
         // processed, then mark it as already-processed, and move on to the next tick.

--- a/rust/chains/hyperlane-ethereum/src/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/mailbox.rs
@@ -302,7 +302,7 @@ where
         Ok(receipt.into())
     }
 
-    #[instrument(err, ret, skip(self), fields(message=%message, metadata=%fmt_bytes(metadata)))]
+    #[instrument(err, ret, skip(self), fields(msg=%message, metadata=%fmt_bytes(metadata)))]
     async fn process_estimate_costs(
         &self,
         message: &HyperlaneMessage,

--- a/rust/chains/hyperlane-fuel/src/mailbox.rs
+++ b/rust/chains/hyperlane-fuel/src/mailbox.rs
@@ -124,7 +124,7 @@ impl Mailbox for FuelMailbox {
         todo!()
     }
 
-    #[instrument(err, ret, skip(self), fields(message=%message, metadata=%fmt_bytes(metadata)))]
+    #[instrument(err, ret, skip(self), fields(msg=%message, metadata=%fmt_bytes(metadata)))]
     async fn process_estimate_costs(
         &self,
         message: &HyperlaneMessage,

--- a/rust/hyperlane-core/src/db/hyperlane_db.rs
+++ b/rust/hyperlane-core/src/db/hyperlane_db.rs
@@ -69,7 +69,7 @@ impl HyperlaneDB {
         // If this message is not building off the latest nonce, log it.
         if let Some(nonce) = self.retrieve_latest_nonce()? {
             if nonce != message.nonce - 1 {
-                debug!(%message, "Attempted to store message not building off latest nonce")
+                debug!(msg=%message, "Attempted to store message not building off latest nonce")
             }
         }
 
@@ -84,7 +84,7 @@ impl HyperlaneDB {
     pub fn store_message(&self, message: &HyperlaneMessage) -> Result<()> {
         let id = message.id();
 
-        info!(?message, "Storing new message in db",);
+        info!(msg=?message, "Storing new message in db",);
         self.store_message_id(message.nonce, message.destination, id)?;
         self.store_keyed_encodable(MESSAGE, &id, message)?;
         Ok(())


### PR DESCRIPTION
### Description

A recent PR (#1797) had switched from logging `HyperlaneMessages` as `msg` to `message` which collides with the default JSON format for the actual log text. Oops. This had not shown up in manual testing as I was using the pretty format instead of the JSON format.

This changes us to consistently using `msg`.

### Drive-by changes

None

### Related issues

- https://discord.com/channels/935678348330434570/935678739663192184/1075503502245249197

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

_What kind of testing have these changes undergone?_

Manual
