### PR TITLE
Add priority to FallbackProviderConfig when building an ethers-js FallbackProvider

### DIFF
--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -1,3 +1,4 @@
+import { FallbackProviderConfig } from '@ethersproject/providers';
 import { ethers } from 'ethers';
 
 import { StaticCeloJsonRpcProvider } from '@hyperlane-xyz/celo-ethers-provider';
@@ -46,7 +47,18 @@ export async function fetchProvider(
     }
     case ConnectionType.HttpFallback: {
       return new ethers.providers.FallbackProvider(
-        (rpcData as string[]).map((url) => providerBuilder(url, chainName)),
+        (rpcData as string[]).map((url, index) => {
+          const fallbackProviderConfig: FallbackProviderConfig = {
+            provider: providerBuilder(url, chainName),
+            // Priority is used by the FallbackProvider to determine
+            // how to order providers using ascending ordering.
+            // When not specified, all providers have the same priority
+            // and are ordered randomly for each RPC.
+            priority: index,
+          };
+          console.log('fallbackProviderConfig', fallbackProviderConfig);
+          return fallbackProviderConfig;
+        }),
         1, // a single provider is "quorum", but failure will cause failover to the next provider
       );
     }


### PR DESCRIPTION
### Description

By default, ethers-js's FallbackProvider will assign each inner provider the same priority and then shuffle the providers for each request.

We want just basic falling back from first -> last. This makes use of the `priority` config to have consistent ordering. See https://docs.ethers.org/v5/api/providers/other/#FallbackProvider:

We noticed this when a URL that wasn't configured as the first one was getting consistently hit

### Drive-by changes

n/a

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

No, but will want to upgrade any monorepo images for things like kathy


### Testing

_What kind of testing have these changes undergone?_

None 
