### PR TITLE
Add ISM to RouterDeployer.initConnectionClient

### DIFF
--- a/typescript/sdk/src/core/HyperlaneCore.ts
+++ b/typescript/sdk/src/core/HyperlaneCore.ts
@@ -82,7 +82,6 @@ export class HyperlaneCore<
       // TODO allow these to be more easily changed
       interchainGasPaymaster:
         contracts.defaultIsmInterchainGasPaymaster.address,
-      interchainSecurityModule: contracts.multisigIsm.address,
     };
   }
 

--- a/typescript/sdk/src/core/HyperlaneCore.ts
+++ b/typescript/sdk/src/core/HyperlaneCore.ts
@@ -79,9 +79,10 @@ export class HyperlaneCore<
     const contracts = this.getContracts(chain);
     return {
       mailbox: contracts.mailbox.address,
-      // TODO allow this to be more easily changed
+      // TODO allow these to be more easily changed
       interchainGasPaymaster:
         contracts.defaultIsmInterchainGasPaymaster.address,
+      interchainSecurityModule: contracts.multisigIsm.address,
     };
   }
 

--- a/typescript/sdk/src/deploy/router/HyperlaneRouterDeployer.ts
+++ b/typescript/sdk/src/deploy/router/HyperlaneRouterDeployer.ts
@@ -39,40 +39,28 @@ export abstract class HyperlaneRouterDeployer<
         const chainConnection = this.multiProvider.getChainConnection(local);
         // set mailbox if not already set (and configured)
         const mailbox = this.configMap[local].mailbox;
-        if (
-          mailbox &&
-          (await contracts.router.mailbox()) === ethers.constants.AddressZero
-        ) {
+        if (mailbox !== (await contracts.router.mailbox())) {
           this.logger(`Set mailbox on ${local}`);
           await chainConnection.handleTx(contracts.router.setMailbox(mailbox));
         }
 
         // set interchain gas paymaster if not already set (and configured)
-        const interchainGasPaymaster =
-          this.configMap[local].interchainGasPaymaster;
-        if (
-          interchainGasPaymaster &&
-          (await contracts.router.interchainGasPaymaster()) ===
-            ethers.constants.AddressZero
-        ) {
+        const igp = this.configMap[local].interchainGasPaymaster;
+        if (igp !== (await contracts.router.interchainGasPaymaster())) {
           this.logger(`Set interchain gas paymaster on ${local}`);
           await chainConnection.handleTx(
-            contracts.router.setInterchainGasPaymaster(interchainGasPaymaster),
+            contracts.router.setInterchainGasPaymaster(igp),
           );
         }
 
-        const interchainSecurityModule =
-          this.configMap[local].interchainSecurityModule;
+        const ism = this.configMap[local].interchainSecurityModule;
         if (
-          interchainSecurityModule &&
-          (await contracts.router.interchainSecurityModule()) ===
-            ethers.constants.AddressZero
+          ism &&
+          ism !== (await contracts.router.interchainSecurityModule())
         ) {
           this.logger(`Set interchain security module on ${local}`);
           await chainConnection.handleTx(
-            contracts.router.setInterchainSecurityModule(
-              interchainSecurityModule,
-            ),
+            contracts.router.setInterchainSecurityModule(ism),
           );
         }
       }),

--- a/typescript/sdk/src/deploy/router/HyperlaneRouterDeployer.ts
+++ b/typescript/sdk/src/deploy/router/HyperlaneRouterDeployer.ts
@@ -1,5 +1,4 @@
 import { debug } from 'debug';
-import { ethers } from 'ethers';
 
 import { utils } from '@hyperlane-xyz/utils';
 

--- a/typescript/sdk/src/deploy/router/HyperlaneRouterDeployer.ts
+++ b/typescript/sdk/src/deploy/router/HyperlaneRouterDeployer.ts
@@ -60,6 +60,21 @@ export abstract class HyperlaneRouterDeployer<
             contracts.router.setInterchainGasPaymaster(interchainGasPaymaster),
           );
         }
+
+        const interchainSecurityModule =
+          this.configMap[local].interchainSecurityModule;
+        if (
+          interchainSecurityModule &&
+          (await contracts.router.interchainSecurityModule()) ===
+            ethers.constants.AddressZero
+        ) {
+          this.logger(`Set interchain security module on ${local}`);
+          await chainConnection.handleTx(
+            contracts.router.setInterchainSecurityModule(
+              interchainSecurityModule,
+            ),
+          );
+        }
       }),
     );
   }


### PR DESCRIPTION
### Description

Ensures that the ISM in router deployment config is set once deployment is completed (irrespective of initializer/custom deployer)

### Drive-by changes

None

### Related issues



### Backward compatibility

Yes

### Testing

SDK unit tests (hijacked accounts router)
