### PR TITLE
Fix toucan testnet2 whitelist and increase mainnet kathy frequency

### DIFF
--- a/typescript/infra/config/environments/mainnet/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet/helloworld.ts
@@ -27,7 +27,7 @@ export const abacus: HelloWorldConfig<MainnetChains> = {
     namespace: environment,
     runConfig: {
       mode: HelloWorldKathyRunMode.Service,
-      fullCycleTime: 1000 * 60 * 60 * 48, // every 48 hours
+      fullCycleTime: 1000 * 60 * 60 * 2, // every 2 hours
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -75,15 +75,15 @@ export const abacus: AgentConfig<TestnetChains> = {
         // Allow bidirectional messaging between Mumbai/Alfajores Toucan contracts
         {
           sourceAddress: '0xdb45A8869f94c15954e282F28e272f5597063e9A',
-          sourceDomain: 1000, // alfajores
+          sourceDomain: 80001, // mumbai
           destinationAddress: '0xf9a49993DF24366AB8EDf617C080ca36a4ADb86e',
-          destinationDomain: 80001, // mumbai
+          destinationDomain: 1000, // alfajores
         },
         {
           sourceAddress: '0xf9a49993DF24366AB8EDf617C080ca36a4ADb86e',
-          sourceDomain: 80001, // mumbai
+          sourceDomain: 1000, // alfajores
           destinationAddress: '0xdb45A8869f94c15954e282F28e272f5597063e9A',
-          destinationDomain: 1000, // alfajores
+          destinationDomain: 80001, // mumbai
         },
         // Allow bidirectional messaging between Mumbai/Alfajores Helloworld contracts
         {


### PR DESCRIPTION
### Description

- Swap domain IDs in toucan whitelist
- Bump mainnet kathy frequency to one message per hr alternating between celo and polygon
- 
### Drive-by changes

None
