### PR TITLE
Better sanitization of announced validator locations

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,9 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - uses: actions/checkout@v3
         with:
           submodules: recursive
@@ -32,7 +35,6 @@ jobs:
       - name: node version
         run: |
           node --version
-          nvm ls
 
       - name: setup rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,6 +29,9 @@ jobs:
       - name: remove submodule locks
         run: git submodule foreach rm yarn.lock
 
+      - name: node version
+        run: node --version
+
       - name: setup rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,10 +32,6 @@ jobs:
       - name: remove submodule locks
         run: git submodule foreach rm yarn.lock
 
-      - name: node version
-        run: |
-          node --version
-
       - name: setup rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,9 @@ jobs:
         run: git submodule foreach rm yarn.lock
 
       - name: node version
-        run: node --version
+        run: |
+          node --version
+          nvm ls
 
       - name: setup rust
         uses: actions-rs/toolchain@v1

--- a/rust/agents/relayer/src/msg/metadata_builder.rs
+++ b/rust/agents/relayer/src/msg/metadata_builder.rs
@@ -12,6 +12,7 @@ use hyperlane_base::{
 use hyperlane_core::{
     HyperlaneChain, HyperlaneMessage, Mailbox, MultisigIsm, ValidatorAnnounce, H160, H256,
 };
+use std::str::FromStr;
 
 use crate::merkle_tree_builder::MerkleTreeBuilder;
 
@@ -138,7 +139,7 @@ impl MetadataBuilder {
         // Only use the most recently announced location for now.
         for (i, validator_storage_locations) in storage_locations.iter().enumerate() {
             for storage_location in validator_storage_locations.iter().rev() {
-                if let Some(conf) = CheckpointSyncerConf::from_storage_location(storage_location) {
+                if let Ok(conf) = CheckpointSyncerConf::from_str(storage_location) {
                     if let Ok(checkpoint_syncer) = conf.build(None) {
                         checkpoint_syncers
                             .insert(H160::from(validators[i]), checkpoint_syncer.into());

--- a/typescript/infra/config/environments/mainnet2/agent.ts
+++ b/typescript/infra/config/environments/mainnet2/agent.ts
@@ -30,7 +30,7 @@ export const hyperlane: AgentConfig<MainnetChains> = {
   context: Contexts.Hyperlane,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-agent',
-    tag: '207563b-20230215-165009',
+    tag: '69c49a3-20230220-224405',
   },
   aws: {
     region: 'us-east-1',
@@ -74,7 +74,7 @@ export const releaseCandidate: AgentConfig<MainnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-agent',
-    tag: '207563b-20230215-165009',
+    tag: '69c49a3-20230220-224405',
   },
   aws: {
     region: 'us-east-1',

--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -30,7 +30,7 @@ export const hyperlane: AgentConfig<TestnetChains> = {
   context: Contexts.Hyperlane,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-agent',
-    tag: '207563b-20230215-165009',
+    tag: '69c49a3-20230220-224405',
   },
   aws: {
     region: 'us-east-1',
@@ -71,7 +71,7 @@ export const releaseCandidate: AgentConfig<TestnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-agent',
-    tag: '207563b-20230215-165009',
+    tag: '69c49a3-20230220-224405',
   },
   aws: {
     region: 'us-east-1',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3959,16 +3959,71 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/helloworld@npm:1.1.3":
-  version: 1.1.3
-  resolution: "@hyperlane-xyz/helloworld@npm:1.1.3"
+"@hyperlane-xyz/helloworld@1.1.3, @hyperlane-xyz/helloworld@workspace:typescript/helloworld":
+  version: 0.0.0-use.local
+  resolution: "@hyperlane-xyz/helloworld@workspace:typescript/helloworld"
   dependencies:
     "@hyperlane-xyz/sdk": ^1.1.3
+    "@nomiclabs/hardhat-ethers": ^2.2.1
+    "@nomiclabs/hardhat-waffle": ^2.0.3
     "@openzeppelin/contracts-upgradeable": ^4.8.0
+    "@trivago/prettier-plugin-sort-imports": ^3.2.0
+    "@typechain/ethers-v5": 10.0.0
+    "@typechain/hardhat": ^6.0.0
+    "@types/mocha": ^9.1.0
+    "@typescript-eslint/eslint-plugin": ^5.27.0
+    "@typescript-eslint/parser": ^5.27.0
+    chai: ^4.3.0
+    eslint: ^8.16.0
+    eslint-config-prettier: ^8.5.0
+    ethereum-waffle: ^3.4.4
     ethers: ^5.7.2
-  checksum: 7d03bb651ec60ca95974c90eb494fc128e884b767f5d78c1be9a93d6187bbd0b75f6f1084a91211e57a7e2d8238f14400ae039c002d8355e13a77af6eb5144d5
-  languageName: node
-  linkType: hard
+    hardhat: ^2.8.4
+    hardhat-gas-reporter: ^1.0.7
+    prettier: ^2.4.1
+    prettier-plugin-solidity: ^1.0.0-beta.5
+    solhint: ^3.3.2
+    solhint-plugin-prettier: ^0.0.5
+    solidity-coverage: ^0.7.14
+    ts-node: ^10.8.0
+    typechain: 8.0.0
+    typescript: ^4.7.2
+  languageName: unknown
+  linkType: soft
+
+"@hyperlane-xyz/hyperlane-token@workspace:typescript/token":
+  version: 0.0.0-use.local
+  resolution: "@hyperlane-xyz/hyperlane-token@workspace:typescript/token"
+  dependencies:
+    "@hyperlane-xyz/core": 1.1.3
+    "@hyperlane-xyz/sdk": 1.1.3
+    "@hyperlane-xyz/utils": 1.1.3
+    "@nomiclabs/hardhat-ethers": ^2.2.1
+    "@nomiclabs/hardhat-waffle": ^2.0.3
+    "@openzeppelin/contracts-upgradeable": ^4.8.0
+    "@trivago/prettier-plugin-sort-imports": ^3.2.0
+    "@typechain/ethers-v5": 10.0.0
+    "@typechain/hardhat": ^6.0.0
+    "@types/mocha": ^9.1.0
+    "@typescript-eslint/eslint-plugin": ^5.27.0
+    "@typescript-eslint/parser": ^5.27.0
+    chai: ^4.3.0
+    eslint: ^8.16.0
+    eslint-config-prettier: ^8.5.0
+    ethereum-waffle: ^3.4.4
+    ethers: ^5.7.2
+    hardhat: ^2.8.4
+    hardhat-gas-reporter: ^1.0.7
+    prettier: ^2.4.1
+    prettier-plugin-solidity: ^1.0.0-beta.5
+    solhint: ^3.3.2
+    solhint-plugin-prettier: ^0.0.5
+    solidity-coverage: ^0.7.14
+    ts-node: ^10.8.0
+    typechain: 8.0.0
+    typescript: ^4.7.2
+  languageName: unknown
+  linkType: soft
 
 "@hyperlane-xyz/infra@workspace:typescript/infra":
   version: 0.0.0-use.local
@@ -17685,6 +17740,28 @@ __metadata:
   version: 2.6.0
   resolution: "type@npm:2.6.0"
   checksum: 80da01fcc0f6ed5a253dc326530e134000a8f66ea44b6d9687cde2f894f0d0b2486595b0cd040a64f7f79dc3120784236f8c9ef667a8aef03984e049b447cfb4
+  languageName: node
+  linkType: hard
+
+"typechain@npm:8.0.0":
+  version: 8.0.0
+  resolution: "typechain@npm:8.0.0"
+  dependencies:
+    "@types/prettier": ^2.1.1
+    debug: ^4.3.1
+    fs-extra: ^7.0.0
+    glob: 7.1.7
+    js-sha3: ^0.8.0
+    lodash: ^4.17.15
+    mkdirp: ^1.0.4
+    prettier: ^2.3.1
+    ts-command-line-args: ^2.2.0
+    ts-essentials: ^7.0.1
+  peerDependencies:
+    typescript: ">=4.3.0"
+  bin:
+    typechain: dist/cli/cli.js
+  checksum: c049cc84ac3cf3a5ed8374db750b7b9adcfc523bb1940e1b8bafef063297aed081a5378560c3fbccd1f5d130d32c9ba9678654dfe00d97fb1dfa17d04a933450
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3959,71 +3959,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/helloworld@1.1.3, @hyperlane-xyz/helloworld@workspace:typescript/helloworld":
-  version: 0.0.0-use.local
-  resolution: "@hyperlane-xyz/helloworld@workspace:typescript/helloworld"
+"@hyperlane-xyz/helloworld@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@hyperlane-xyz/helloworld@npm:1.1.3"
   dependencies:
     "@hyperlane-xyz/sdk": ^1.1.3
-    "@nomiclabs/hardhat-ethers": ^2.2.1
-    "@nomiclabs/hardhat-waffle": ^2.0.3
     "@openzeppelin/contracts-upgradeable": ^4.8.0
-    "@trivago/prettier-plugin-sort-imports": ^3.2.0
-    "@typechain/ethers-v5": 10.0.0
-    "@typechain/hardhat": ^6.0.0
-    "@types/mocha": ^9.1.0
-    "@typescript-eslint/eslint-plugin": ^5.27.0
-    "@typescript-eslint/parser": ^5.27.0
-    chai: ^4.3.0
-    eslint: ^8.16.0
-    eslint-config-prettier: ^8.5.0
-    ethereum-waffle: ^3.4.4
     ethers: ^5.7.2
-    hardhat: ^2.8.4
-    hardhat-gas-reporter: ^1.0.7
-    prettier: ^2.4.1
-    prettier-plugin-solidity: ^1.0.0-beta.5
-    solhint: ^3.3.2
-    solhint-plugin-prettier: ^0.0.5
-    solidity-coverage: ^0.7.14
-    ts-node: ^10.8.0
-    typechain: 8.0.0
-    typescript: ^4.7.2
-  languageName: unknown
-  linkType: soft
-
-"@hyperlane-xyz/hyperlane-token@workspace:typescript/token":
-  version: 0.0.0-use.local
-  resolution: "@hyperlane-xyz/hyperlane-token@workspace:typescript/token"
-  dependencies:
-    "@hyperlane-xyz/core": 1.1.3
-    "@hyperlane-xyz/sdk": 1.1.3
-    "@hyperlane-xyz/utils": 1.1.3
-    "@nomiclabs/hardhat-ethers": ^2.2.1
-    "@nomiclabs/hardhat-waffle": ^2.0.3
-    "@openzeppelin/contracts-upgradeable": ^4.8.0
-    "@trivago/prettier-plugin-sort-imports": ^3.2.0
-    "@typechain/ethers-v5": 10.0.0
-    "@typechain/hardhat": ^6.0.0
-    "@types/mocha": ^9.1.0
-    "@typescript-eslint/eslint-plugin": ^5.27.0
-    "@typescript-eslint/parser": ^5.27.0
-    chai: ^4.3.0
-    eslint: ^8.16.0
-    eslint-config-prettier: ^8.5.0
-    ethereum-waffle: ^3.4.4
-    ethers: ^5.7.2
-    hardhat: ^2.8.4
-    hardhat-gas-reporter: ^1.0.7
-    prettier: ^2.4.1
-    prettier-plugin-solidity: ^1.0.0-beta.5
-    solhint: ^3.3.2
-    solhint-plugin-prettier: ^0.0.5
-    solidity-coverage: ^0.7.14
-    ts-node: ^10.8.0
-    typechain: 8.0.0
-    typescript: ^4.7.2
-  languageName: unknown
-  linkType: soft
+  checksum: 7d03bb651ec60ca95974c90eb494fc128e884b767f5d78c1be9a93d6187bbd0b75f6f1084a91211e57a7e2d8238f14400ae039c002d8355e13a77af6eb5144d5
+  languageName: node
+  linkType: hard
 
 "@hyperlane-xyz/infra@workspace:typescript/infra":
   version: 0.0.0-use.local
@@ -17740,28 +17685,6 @@ __metadata:
   version: 2.6.0
   resolution: "type@npm:2.6.0"
   checksum: 80da01fcc0f6ed5a253dc326530e134000a8f66ea44b6d9687cde2f894f0d0b2486595b0cd040a64f7f79dc3120784236f8c9ef667a8aef03984e049b447cfb4
-  languageName: node
-  linkType: hard
-
-"typechain@npm:8.0.0":
-  version: 8.0.0
-  resolution: "typechain@npm:8.0.0"
-  dependencies:
-    "@types/prettier": ^2.1.1
-    debug: ^4.3.1
-    fs-extra: ^7.0.0
-    glob: 7.1.7
-    js-sha3: ^0.8.0
-    lodash: ^4.17.15
-    mkdirp: ^1.0.4
-    prettier: ^2.3.1
-    ts-command-line-args: ^2.2.0
-    ts-essentials: ^7.0.1
-  peerDependencies:
-    typescript: ">=4.3.0"
-  bin:
-    typechain: dist/cli/cli.js
-  checksum: c049cc84ac3cf3a5ed8374db750b7b9adcfc523bb1940e1b8bafef063297aed081a5378560c3fbccd1f5d130d32c9ba9678654dfe00d97fb1dfa17d04a933450
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Improves parsing/santization of announced validator locations

### Drive-by changes

- Use node v16.x in CI e2e tests

### Related issues

- Fixes [#[issue number here]](https://github.com/hyperlane-xyz/issues/issues/390)

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None



### Testing

_What kind of testing have these changes undergone?_

None

