### PR TITLE
Serialize concatenated signature

### DIFF
--- a/rust/hyperlane-core/src/traits/signing.rs
+++ b/rust/hyperlane-core/src/traits/signing.rs
@@ -92,7 +92,7 @@ impl<T: Signable + Serialize> Serialize for SignedType<T> {
         let mut state = serializer.serialize_struct("SignedType", 3)?;
         state.serialize_field("value", &self.value)?;
         state.serialize_field("signature", &self.signature)?;
-        let sig = <[u8; 65]>::from(self.signature);
+        let sig: [u8; 65] = self.signature.into();
         state.serialize_field("serialized_signature", &fmt_bytes(&sig))?;
         state.end()
     }

--- a/rust/hyperlane-core/src/types/checkpoint.rs
+++ b/rust/hyperlane-core/src/types/checkpoint.rs
@@ -125,7 +125,7 @@ impl TryFrom<&Vec<SignedCheckpointWithSigner>> for MultisigSignedCheckpoint {
         let signatures = signed_checkpoints
             .iter()
             .map(|c| SignatureWithSigner {
-                signature: c.signed_checkpoint.signature.signature,
+                signature: c.signed_checkpoint.signature,
                 signer: c.signer,
             })
             .collect();

--- a/rust/hyperlane-core/src/types/checkpoint.rs
+++ b/rust/hyperlane-core/src/types/checkpoint.rs
@@ -125,7 +125,7 @@ impl TryFrom<&Vec<SignedCheckpointWithSigner>> for MultisigSignedCheckpoint {
         let signatures = signed_checkpoints
             .iter()
             .map(|c| SignatureWithSigner {
-                signature: c.signed_checkpoint.signature,
+                signature: c.signed_checkpoint.signature.signature,
                 signer: c.signer,
             })
             .collect();


### PR DESCRIPTION
### Description

This PR modifies the serialization of signed types (i.e. announcements and checkpoints) to include the concatenated signature (i.e. the `serialized_signature` field).

Example:
```
{
  "value": {
    "validator": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
    "mailbox_address": "0x000000000000000000000000610178da211fef7d417bc0e6fed39f05609ad788",
    "mailbox_domain": 13371,
    "storage_location": "file:///var/folders/np/338cspjd73j9p52y9d_34r9w0000gn/T/.tmpaWomYN"
  },
  "signature": {
    "r": "0x8960ff5557b283d9799ddbdb3a24d454dee0fab534effc40f411fdc20ed9cef7",
    "s": "0x4ed1d8c1b2198b7a26b1a06c9b494e80c81aae54d2918494861fc7e52d3c8d21",
    "v": 27
  },
  "serialized_signature": "0x8960ff5557b283d9799ddbdb3a24d454dee0fab534effc40f411fdc20ed9cef74ed1d8c1b2198b7a26b1a06c9b494e80c81aae54d2918494861fc7e52d3c8d211b"
}
```


### Drive-by changes

None

### Related issues

- There must be but I can't find it...
 
### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Manual
