### PR TITLE
Make relayer require destination chains

### DIFF
--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -66,16 +66,12 @@ impl BaseAgent for Relayer {
         let core = settings.build_hyperlane_core(metrics.clone());
         let db = DB::from_path(&settings.db)?;
 
-        let chain_names: Vec<_> = if let Some(ref remotes) = settings.destinationchainnames {
-            // Use defined remote chains + the origin chain
-            remotes
-                .split(',')
-                .chain([settings.originchainname.as_str()])
-                .collect()
-        } else {
-            // If not provided, default to using every chain listed in self.chains.
-            settings.chains.keys().map(String::as_str).collect()
-        };
+        // Use defined remote chains + the origin chain
+        let chain_names: Vec<_> = settings
+            .destinationchainnames
+            .split(',')
+            .chain([settings.originchainname.as_str()])
+            .collect();
 
         let mailboxes = settings
             .build_all_mailboxes(chain_names.as_slice(), &metrics, db.clone())

--- a/rust/agents/relayer/src/settings/mod.rs
+++ b/rust/agents/relayer/src/settings/mod.rs
@@ -38,9 +38,8 @@ decl_settings!(Relayer {
     db: String,
     // The name of the origin chain
     originchainname: String,
-    // Optional list of destination chains. If none are provided, ALL chains in chain_setup
-    // will be used, excluding the origin chain.
-    destinationchainnames: Option<String>,
+    // Comma separated list of destination chains.
+    destinationchainnames: String,
     /// The gas payment enforcement configuration
     gaspaymentenforcement: GasPaymentEnforcementConfig,
     /// This is optional. If no whitelist is provided ALL messages will be considered on the

--- a/rust/helm/hyperlane-agent/templates/relayer-statefulset.yaml
+++ b/rust/helm/hyperlane-agent/templates/relayer-statefulset.yaml
@@ -56,9 +56,13 @@ spec:
             name: {{ include "agent-common.fullname" . }}-relayer-secret
         env:
 {{- include "agent-common.config-env-vars" (dict "config" .Values.hyperlane.relayer.config "agent_name" "relayer") | indent 10 }}
+{{- $relayerChainNames := list }}
           {{- range .Values.hyperlane.relayerChains }}
 {{- include "agent-common.config-env-vars" (dict "config" .signer "agent_name" "base" "key_name_prefix" (printf "CHAINS_%s_SIGNER_" (.name | upper))) | indent 10 }}
+{{- $relayerChainNames = append $relayerChainNames .name }}
           {{- end }}
+          - name: HYP_RELAYER_DESTINATIONCHAINNAMES
+            value: {{ without $relayerChainNames .Values.hyperlane.relayer.config.originChainName | join "," }}
           {{- if .Values.hyperlane.tracing.uri }}
           - name: HYP_BASE_TRACING_JAEGER_NAME
             value: {{ include "agent-common.fullname" . }}-relayer

--- a/rust/hyperlane-base/src/settings/loader.rs
+++ b/rust/hyperlane-base/src/settings/loader.rs
@@ -111,6 +111,7 @@ pub(crate) fn load_settings_object<'de, T: Deserialize<'de>, S: AsRef<str>>(
                 Some("urls") => err = err.context(MISSING_URLS_CTX),
                 Some("url") => err = err.context(MISSING_URL_CTX),
                 Some("db") => err = err.context(MISSING_DB_CTX),
+                Some("v") => err = err.context(MISSING_DESTINATION_CHAIN_NAMES_CTX),
                 _ => {}
             }
 
@@ -119,7 +120,8 @@ pub(crate) fn load_settings_object<'de, T: Deserialize<'de>, S: AsRef<str>>(
     }
 }
 
-/// Some constant strings that we want to compose. `concat!` requires literals so this provides them.
+/// Some constant strings that we want to compose. `concat!` requires literals
+/// so this provides them.
 macro_rules! str_lits {
     (bp) => { "Debugging tips, please ensure: " };
     (env) => { "an env such as `HYP_BASE_CHAINS_ALFAJORES_CONNECTION_TYPE` means the full `chains.alfajores` object must be valid" };
@@ -213,3 +215,8 @@ const MISSING_URL_CTX: &str = concat!(
 );
 
 const MISSING_DB_CTX: &str = concat!(str_lits!(bp), "(1) `db` config string is specified");
+
+const MISSING_DESTINATION_CHAIN_NAMES_CTX: &str = concat!(
+    str_lits!(bp),
+    "(1) `destinationchainnames` is specified as a comma separated list of chains the relayer should deliver messages to"
+);


### PR DESCRIPTION
### Description

The relayer now requires a list of destination chains that it will operate on. This also updates the helm chart to maintain current funcunality.

### Drive-by changes

No

### Related issues

- Fixes #1687

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

Yes


### Testing

_What kind of testing have these changes undergone?_

Manual - Verified with a dry-run that it is correctly generating the list of destination chains
