### PR TITLE
Better default stack traces

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -27,7 +27,7 @@ RUN \
   --mount=id=cargo,type=cache,sharing=locked,target=/usr/src/target \
   --mount=id=cargo-home-registry,type=cache,sharing=locked,target=/usr/local/cargo/registry \
   --mount=id=cargo-home-git,type=cache,sharing=locked,target=/usr/local/cargo/git \
-    cargo build --release --no-default-features --features oneline-errors && \
+    cargo build --release && \
     mkdir -p /release && \
     cp /usr/src/target/release/validator /release && \
     cp /usr/src/target/release/relayer /release && \

--- a/rust/agents/relayer/Cargo.toml
+++ b/rust/agents/relayer/Cargo.toml
@@ -33,5 +33,6 @@ tokio-test = "0.4"
 hyperlane-test = { path = "../../hyperlane-test" }
 
 [features]
-default = ["hyperlane-base/color-eyre"]
+default = ["color-eyre", "oneline-errors"]
 oneline-errors = ["hyperlane-base/oneline-errors"]
+color-eyre = ["hyperlane-base/color-eyre"]

--- a/rust/agents/scraper/Cargo.toml
+++ b/rust/agents/scraper/Cargo.toml
@@ -31,5 +31,6 @@ tokio-test = "0.4"
 hyperlane-test = { path = "../../hyperlane-test" }
 
 [features]
-default = ["hyperlane-base/color-eyre"]
+default = ["color-eyre", "oneline-errors"]
 oneline-errors = ["hyperlane-base/oneline-errors"]
+color-eyre = ["hyperlane-base/color-eyre"]

--- a/rust/agents/validator/Cargo.toml
+++ b/rust/agents/validator/Cargo.toml
@@ -27,5 +27,6 @@ tokio-test = "0.4"
 hyperlane-test = { path = "../../hyperlane-test" }
 
 [features]
-default = ["hyperlane-base/color-eyre"]
+default = ["color-eyre", "oneline-errors"]
 oneline-errors = ["hyperlane-base/oneline-errors"]
+color-eyre = ["hyperlane-base/color-eyre"]

--- a/rust/helm/hyperlane-agent/templates/configmap.yaml
+++ b/rust/helm/hyperlane-agent/templates/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "agent-common.labels" . | nindent 4 }}
 data:
   RUN_ENV: {{ .Values.hyperlane.runEnv | quote }}
+  ONELINE_ERRORS: true
   BASE_CONFIG: {{ .Values.hyperlane.baseConfig }}
   RUST_BACKTRACE: {{ .Values.hyperlane.rustBacktrace }}
   HYP_BASE_DB: {{ .Values.hyperlane.dbPath }}

--- a/rust/helm/hyperlane-agent/templates/configmap.yaml
+++ b/rust/helm/hyperlane-agent/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "agent-common.labels" . | nindent 4 }}
 data:
   RUN_ENV: {{ .Values.hyperlane.runEnv | quote }}
-  ONELINE_ERRORS: true
+  ONELINE_BACKTRACES: true
   BASE_CONFIG: {{ .Values.hyperlane.baseConfig }}
   RUST_BACKTRACE: {{ .Values.hyperlane.rustBacktrace }}
   HYP_BASE_DB: {{ .Values.hyperlane.dbPath }}

--- a/rust/hyperlane-base/Cargo.toml
+++ b/rust/hyperlane-base/Cargo.toml
@@ -63,5 +63,6 @@ color-eyre = "0.6"
 
 
 [features]
+default = ["oneline-errors", "color-eyre"]
 oneline-eyre = ["backtrace-oneline", "backtrace"]
 oneline-errors = ["oneline-eyre"]

--- a/rust/hyperlane-base/src/agent.rs
+++ b/rust/hyperlane-base/src/agent.rs
@@ -52,10 +52,15 @@ pub trait BaseAgent: Send + Sync + Debug {
 /// lifecycle. This assumes only a single agent is being run. This will
 /// initialize the metrics server and tracing as well.
 pub async fn agent_main<A: BaseAgent>() -> Result<()> {
-    #[cfg(feature = "oneline-errors")]
-    crate::oneline_eyre::install()?;
-    #[cfg(all(feature = "color_eyre", not(feature = "oneline-errors")))]
-    color_eyre::install()?;
+    if std::env::var("ONELINE_ERRORS").map(|v| v.to_lowercase()).as_deref() == Ok("true") {
+        #[cfg(feature = "oneline-errors")]
+        crate::oneline_eyre::install()?;
+        #[cfg(not(feature = "oneline-errors"))]
+        panic!("The oneline errors feature was not included");
+    } else {
+        #[cfg(feature = "color_eyre")]
+        color_eyre::install()?;
+    }
 
     let settings = A::Settings::new().map_err(|e| e.into())?;
     let core_settings: &Settings = settings.as_ref();

--- a/rust/hyperlane-base/src/agent.rs
+++ b/rust/hyperlane-base/src/agent.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -52,7 +53,11 @@ pub trait BaseAgent: Send + Sync + Debug {
 /// lifecycle. This assumes only a single agent is being run. This will
 /// initialize the metrics server and tracing as well.
 pub async fn agent_main<A: BaseAgent>() -> Result<()> {
-    if std::env::var("ONELINE_ERRORS").map(|v| v.to_lowercase()).as_deref() == Ok("true") {
+    if env::var("ONELINE_BACKTRACES")
+        .map(|v| v.to_lowercase())
+        .as_deref()
+        == Ok("true")
+    {
         #[cfg(feature = "oneline-errors")]
         crate::oneline_eyre::install()?;
         #[cfg(not(feature = "oneline-errors"))]

--- a/rust/hyperlane-base/src/settings/loader.rs
+++ b/rust/hyperlane-base/src/settings/loader.rs
@@ -74,7 +74,20 @@ pub(crate) fn load_settings_object<'de, T: Deserialize<'de>, S: AsRef<str>>(
                 .source(Some(filtered_env)),
         )
         .build()?;
-    let formatted_config = format!("{:#?}", config_deserializer).replace('\n', "\\n");
+
+    let formatted_config = {
+        let f = format!("{:#?}", config_deserializer);
+        if env::var("ONELINE_BACKTRACES")
+            .map(|v| v.to_lowercase())
+            .as_deref()
+            == Ok("true")
+        {
+            f.replace('\n', "\\n")
+        } else {
+            f
+        }
+    };
+
     match Config::try_deserialize(config_deserializer) {
         Ok(cfg) => Ok(cfg),
         Err(err) => {


### PR DESCRIPTION
### Description

Switches us to using color-eyre by default for stack traces. To use oneline error you now must both have the `oneline-errors` feature enabled (which happens by default) and set the `ONELINE_BACKTRACES` env var to `true` which is not default.

This way even when someone is running the docker image they will still get better backtraces by default.

### Drive-by changes

Updated the debug config print to also use oneline backtraces to decide whether to compress it all onto one line or not.

### Related issues

- Relates to #1850

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

_What kind of testing have these changes undergone?_

Manual
