### PR TITLE
Remove testnet3 relayer blacklist

### DIFF
--- a/rust/helm/hyperlane-agent/templates/configmap.yaml
+++ b/rust/helm/hyperlane-agent/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "agent-common.labels" . | nindent 4 }}
 data:
   RUN_ENV: {{ .Values.hyperlane.runEnv | quote }}
-  ONELINE_BACKTRACES: true
+  ONELINE_BACKTRACES: "true"
   BASE_CONFIG: {{ .Values.hyperlane.baseConfig }}
   RUST_BACKTRACE: {{ .Values.hyperlane.rustBacktrace }}
   HYP_BASE_DB: {{ .Values.hyperlane.dbPath }}

--- a/typescript/infra/config/environments/mainnet2/agent.ts
+++ b/typescript/infra/config/environments/mainnet2/agent.ts
@@ -54,7 +54,7 @@ export const hyperlane: AgentConfig = {
       gasPaymentEnforcement: {
         policy: {
           type: GasPaymentEnforcementPolicyType.Minimum,
-          payment: BigInt(1),
+          payment: 1,
         },
         // To continue relaying interchain query callbacks, we whitelist
         // all messages between interchain query routers.
@@ -91,11 +91,11 @@ export const releaseCandidate: AgentConfig = {
       gasPaymentEnforcement: {
         policy: {
           type: GasPaymentEnforcementPolicyType.Minimum,
-          payment: BigInt(1),
+          payment: 1,
         },
         whitelist: interchainQueriesMatchingList,
       },
-      transactionGasLimit: BigInt(750000),
+      transactionGasLimit: 750000,
       // Skipping arbitrum because the gas price estimates are inclusive of L1
       // fees which leads to wildly off predictions.
       skipTransactionGasLimitFor: [chainMetadata.arbitrum.chainId],

--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -44,14 +44,11 @@ export const hyperlane: AgentConfig = {
   validators,
   relayer: {
     default: {
-      blacklist: [
-        ...releaseCandidateHelloworldMatchingList,
-        { recipientAddress: '0xBC3cFeca7Df5A45d61BC60E7898E63670e1654aE' },
-      ],
+      blacklist: releaseCandidateHelloworldMatchingList,
       gasPaymentEnforcement: {
         policy: {
           type: GasPaymentEnforcementPolicyType.Minimum,
-          payment: BigInt(1),
+          payment: 1,
         },
         // To continue relaying interchain query callbacks, we whitelist
         // all messages between interchain query routers.
@@ -88,11 +85,11 @@ export const releaseCandidate: AgentConfig = {
       gasPaymentEnforcement: {
         policy: {
           type: GasPaymentEnforcementPolicyType.Minimum,
-          payment: BigInt(1), // require 1 wei
+          payment: 1, // require 1 wei
         },
         whitelist: interchainQueriesMatchingList,
       },
-      transactionGasLimit: BigInt(750000),
+      transactionGasLimit: 750000,
       // Skipping arbitrum because the gas price estimates are inclusive of L1
       // fees which leads to wildly off predictions.
       skipTransactionGasLimitFor: [chainMetadata.arbitrumgoerli.chainId],

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -351,7 +351,6 @@ export async function runAgentHelmCommand(
         outboxChainName,
         agentConfig,
       )} --namespace ${agentConfig.namespace}`,
-
       {},
       false,
       true,

--- a/typescript/infra/src/config/agent.ts
+++ b/typescript/infra/src/config/agent.ts
@@ -1,3 +1,5 @@
+import { BigNumberish } from 'ethers';
+
 import { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
 import { types } from '@hyperlane-xyz/utils';
 
@@ -54,7 +56,7 @@ export type GasPaymentEnforcementPolicy =
     }
   | {
       type: GasPaymentEnforcementPolicyType.Minimum;
-      payment: bigint;
+      payment: BigNumberish;
     }
   | {
       type: GasPaymentEnforcementPolicyType.MeetsEstimatedCost;
@@ -70,7 +72,7 @@ interface BaseRelayerConfig {
   gasPaymentEnforcement: GasPaymentEnforcementConfig;
   whitelist?: MatchingList;
   blacklist?: MatchingList;
-  transactionGasLimit?: bigint;
+  transactionGasLimit?: BigNumberish;
   skipTransactionGasLimitFor?: number[];
 }
 


### PR DESCRIPTION
### Description

Now that we pay for gas on testnet, no need to blacklist. Mainnet will follow soon

### Drive-by changes

Some fixes to the deploy tooling:
* BigInt isn't able to be used with JSON.stringify out of the box (https://github.com/GoogleChromeLabs/jsbi/issues/30). Instead moved to the ethers BigNumberish
* Configmaps don't like unquoted bools - they want strings and otherwise complain

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

_What kind of testing have these changes undergone?_

Deployed testnet3
