### PR TITLE
Fix flaky fuzz test

### DIFF
--- a/solidity/test/GasRouter.t.sol
+++ b/solidity/test/GasRouter.t.sol
@@ -91,22 +91,28 @@ contract GasRouterTest is Test {
         vm.deal(address(this), gas * gasPrice);
 
         setDestinationGas(originRouter, remoteDomain, gas);
+
+        uint256 requiredPayment = gas * gasPrice;
         vm.expectRevert("insufficient interchain gas payment");
-        originRouter.dispatchWithGas{value: gas * gasPrice - 1}(
+        originRouter.dispatchWithGas{value: requiredPayment - 1}(
             remoteDomain,
             ""
         );
-        vm.deal(address(this), gas * gasPrice + 1);
-        originRouter.dispatchWithGas{value: gas * gasPrice + 1}(
+
+        vm.deal(address(this), requiredPayment + 1);
+        originRouter.dispatchWithGas{value: requiredPayment + 1}(
             remoteDomain,
             ""
         );
         assertEq(refund, 1);
 
-        vm.deal(address(this), gas * gasPrice + 1);
+        // Reset the IGP balance to avoid a balance overflow
+        vm.deal(address(environment.igps(originDomain)), 0);
+
+        vm.deal(address(this), requiredPayment + 1);
         passRefund = false;
         vm.expectRevert("Interchain gas payment refund failed");
-        originRouter.dispatchWithGas{value: gas * gasPrice + 1}(
+        originRouter.dispatchWithGas{value: requiredPayment + 1}(
             remoteDomain,
             ""
         );


### PR DESCRIPTION
### Description

I *believe* this is the fix for the flaky fuzz tests we've been experiencing.

My theory is that the IGP's balance was overflowing by there being 2 subsequent `payForGas` calls with each payment being > `type(uint256).max / 2`.

I found that this test was the culprit by running specific fuzz tests we have. Then made the fix and ran it multiple times and never saw an overflow again

### Drive-by changes

n/a

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Unit Tests
