### PR TITLE
Deploy agents, deploy on chain fee quoting to testnet3 rc

### DIFF
--- a/typescript/infra/config/environments/mainnet2/agent.ts
+++ b/typescript/infra/config/environments/mainnet2/agent.ts
@@ -29,7 +29,7 @@ export const hyperlane: AgentConfig = {
   context: Contexts.Hyperlane,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-agent',
-    tag: '69c49a3-20230220-224405',
+    tag: '1cbe5fd-20230309-202035',
   },
   aws: {
     region: 'us-east-1',
@@ -61,7 +61,7 @@ export const hyperlane: AgentConfig = {
         },
         {
           type: GasPaymentEnforcementPolicyType.Minimum,
-          payment: 1,
+          payment: '1',
         },
       ],
     },
@@ -75,7 +75,7 @@ export const releaseCandidate: AgentConfig = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-agent',
-    tag: '69c49a3-20230220-224405',
+    tag: '1cbe5fd-20230309-202035',
   },
   aws: {
     region: 'us-east-1',
@@ -96,7 +96,7 @@ export const releaseCandidate: AgentConfig = {
         },
         {
           type: GasPaymentEnforcementPolicyType.Minimum,
-          payment: 1,
+          payment: '1',
         },
       ],
       transactionGasLimit: 750000,

--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -29,7 +29,7 @@ export const hyperlane: AgentConfig = {
   context: Contexts.Hyperlane,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-agent',
-    tag: '69c49a3-20230220-224405',
+    tag: '1cbe5fd-20230309-202035',
   },
   aws: {
     region: 'us-east-1',
@@ -55,7 +55,7 @@ export const hyperlane: AgentConfig = {
         },
         {
           type: GasPaymentEnforcementPolicyType.Minimum,
-          payment: 1,
+          payment: '1',
         },
       ],
     },
@@ -69,7 +69,7 @@ export const releaseCandidate: AgentConfig = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-agent',
-    tag: '69c49a3-20230220-224405',
+    tag: '1cbe5fd-20230309-202035',
   },
   aws: {
     region: 'us-east-1',
@@ -90,7 +90,7 @@ export const releaseCandidate: AgentConfig = {
         },
         {
           type: GasPaymentEnforcementPolicyType.Minimum,
-          payment: 1, // require 1 wei
+          payment: '1', // require 1 wei
         },
       ],
       transactionGasLimit: 750000,

--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -89,8 +89,7 @@ export const releaseCandidate: AgentConfig = {
           matchingList: interchainQueriesMatchingList,
         },
         {
-          type: GasPaymentEnforcementPolicyType.Minimum,
-          payment: '1', // require 1 wei
+          type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
         },
       ],
       transactionGasLimit: 750000,

--- a/typescript/infra/src/config/agent.ts
+++ b/typescript/infra/src/config/agent.ts
@@ -56,7 +56,7 @@ export type GasPaymentEnforcementPolicy =
     }
   | {
       type: GasPaymentEnforcementPolicyType.Minimum;
-      payment: BigNumberish;
+      payment: string; // An integer string, may be 0x-prefixed
     };
 
 export type GasPaymentEnforcementConfig = GasPaymentEnforcementPolicy & {

--- a/typescript/infra/src/config/agent.ts
+++ b/typescript/infra/src/config/agent.ts
@@ -48,6 +48,7 @@ export enum GasPaymentEnforcementPolicyType {
   None = 'none',
   Minimum = 'minimum',
   MeetsEstimatedCost = 'meetsEstimatedCost',
+  OnChainFeeQuoting = 'onChainFeeQuoting',
 }
 
 export type GasPaymentEnforcementPolicy =
@@ -57,6 +58,10 @@ export type GasPaymentEnforcementPolicy =
   | {
       type: GasPaymentEnforcementPolicyType.Minimum;
       payment: string; // An integer string, may be 0x-prefixed
+    }
+  | {
+      type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting;
+      gasfraction?: string; // An optional string of "numerator / denominator", e.g. "1 / 2"
     };
 
 export type GasPaymentEnforcementConfig = GasPaymentEnforcementPolicy & {


### PR DESCRIPTION
### Description

* Routine agent deploy to all envs / contexts
* Fixed a JSON deserialization issue where a U256 must be a string and not a number
* Added the on chain fee quoting gas enforcement policy to infra
* Deployed to testnet3 rc with on chain fee quoting gas enforcement policy

### Drive-by changes

n/a

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

not really - but bc this includes an infra fix, you should deploy using this commit or later


### Testing

_What kind of testing have these changes undergone?_

Deployed
