### PR TITLE
Graceful handling of errors with key funder's IGP claim or L2 bridging

### DIFF
--- a/typescript/infra/scripts/announce-validators.ts
+++ b/typescript/infra/scripts/announce-validators.ts
@@ -53,21 +53,28 @@ async function main() {
     multiProvider,
   );
 
-  const announcements = [];
+  const announcements: {
+    storageLocation: string;
+    announcement: any;
+  }[] = [];
   const chains: ChainName[] = [];
   if (location) {
     chains.push(chain!);
     if (location.startsWith('s3://')) {
       const validator = await S3Validator.fromStorageLocation(location);
-      announcements.push(await validator.getAnnouncement());
+      announcements.push({
+        storageLocation: validator.storageLocation(),
+        announcement: await validator.getAnnouncement(),
+      });
     } else if (location.startsWith('file://')) {
       const announcementFilepath = path.join(
         location.substring(7),
         'announcement.json',
       );
-      announcements.push(
-        JSON.parse(readFileSync(announcementFilepath, 'utf-8')),
-      );
+      announcements.push({
+        storageLocation: location,
+        announcement: JSON.parse(readFileSync(announcementFilepath, 'utf-8')),
+      });
     } else {
       throw new Error(`Unknown location type %{location}`);
     }
@@ -94,10 +101,10 @@ async function main() {
                 validatorBaseConfig.checkpointSyncer.bucket,
                 validatorBaseConfig.checkpointSyncer.region,
               );
-              announcements.push([
-                validatorBaseConfig.name,
-                await validator.getAnnouncement(),
-              ]);
+              announcements.push({
+                storageLocation: validator.storageLocation(),
+                announcement: await validator.getAnnouncement(),
+              });
               chains.push(chain);
             }
           }
@@ -107,9 +114,9 @@ async function main() {
   }
 
   for (let i = 0; i < announcements.length; i++) {
-    const [name, announcement] = announcements[i];
+    const { storageLocation, announcement } = announcements[i];
     if (!announcement) {
-      console.info(`No announcement for ${name}`);
+      console.info(`No announcement for storageLocation ${storageLocation}`);
     }
     const chain = chains[i];
     const contracts = core.getContracts(chain);

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -372,24 +372,6 @@ class ContextFunder {
   async fund(): Promise<boolean> {
     let failureOccurred = false;
 
-    // Returns whether an error occurred
-    const gracefullyHandleError = async (
-      fn: () => Promise<void>,
-      chain: ChainName,
-      errorMessage: string,
-    ) => {
-      try {
-        await fn();
-        return false;
-      } catch (err) {
-        error(errorMessage, {
-          chain,
-          error: format(err),
-        });
-      }
-      return true;
-    };
-
     const promises = Object.entries(this.getChainKeys()).map(
       async ([chain, keys]) => {
         if (keys.length > 0) {
@@ -774,6 +756,24 @@ function parseContextAndRoles(str: string): ContextAndRoles {
     context,
     roles,
   };
+}
+
+// Returns whether an error occurred
+async function gracefullyHandleError(
+  fn: () => Promise<void>,
+  chain: ChainName,
+  errorMessage: string,
+): Promise<boolean> {
+  try {
+    await fn();
+    return false;
+  } catch (err) {
+    error(errorMessage, {
+      chain,
+      error: format(err),
+    });
+  }
+  return true;
 }
 
 main().catch((err) => {

--- a/typescript/infra/src/agents/aws/s3.ts
+++ b/typescript/infra/src/agents/aws/s3.ts
@@ -14,6 +14,7 @@ export interface S3Receipt<T = unknown> {
 export class S3Wrapper {
   private readonly client: S3Client;
   readonly bucket: string;
+  readonly region: string;
 
   static fromBucketUrl(bucketUrl: string): S3Wrapper {
     const match = bucketUrl.match(S3_BUCKET_REGEX);
@@ -23,6 +24,7 @@ export class S3Wrapper {
 
   constructor(bucket: string, region: string) {
     this.bucket = bucket;
+    this.region = region;
     this.client = new S3Client({ region });
   }
 

--- a/typescript/infra/src/agents/aws/validator.ts
+++ b/typescript/infra/src/agents/aws/validator.ts
@@ -39,6 +39,7 @@ const checkpointKey = (checkpointIndex: number) =>
   `checkpoint_${checkpointIndex}.json`;
 const LATEST_KEY = 'checkpoint_latest_index.json';
 const ANNOUNCEMENT_KEY = 'announcement.json';
+const LOCATION_PREFIX = 's3://';
 
 /**
  * Extension of BaseValidator that includes AWS S3 utilities.
@@ -60,9 +61,8 @@ export class S3Validator extends BaseValidator {
   static async fromStorageLocation(
     storageLocation: string,
   ): Promise<S3Validator> {
-    const prefix = 's3://';
-    if (storageLocation.startsWith(prefix)) {
-      const suffix = storageLocation.slice(prefix.length);
+    if (storageLocation.startsWith(LOCATION_PREFIX)) {
+      const suffix = storageLocation.slice(LOCATION_PREFIX.length);
       const pieces = suffix.split('/');
       if (pieces.length == 2) {
         const s3Bucket = new S3Wrapper(pieces[0], pieces[1]);
@@ -170,6 +170,10 @@ export class S3Validator extends BaseValidator {
     }
 
     return checkpointMetrics.slice(-1 * count);
+  }
+
+  storageLocation(): string {
+    return `${LOCATION_PREFIX}/${this.s3Bucket.bucket}/${this.s3Bucket.region}`;
   }
 
   private async getCheckpointReceipt(


### PR DESCRIPTION
### Description

Noticed that if an IGP claim fails, it's not gracefully handled

### Drive-by changes

none

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Ran locally
