### PR TITLE
Use gasEstimateComponents instead of gasEstimateL1Component for arbitrum gas

### DIFF
--- a/rust/agents/relayer/src/msg/gas_payment/mod.rs
+++ b/rust/agents/relayer/src/msg/gas_payment/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use async_trait::async_trait;
 use eyre::Result;
-use tracing::{error, trace};
+use tracing::{debug, error, trace};
 
 use hyperlane_core::{
     db::HyperlaneDB, HyperlaneMessage, InterchainGasExpenditure, InterchainGasPayment,
@@ -104,6 +104,13 @@ impl GasPaymentEnforcer {
                 ?policy,
                 ?whitelist,
                 "Message matched whitelist for policy"
+            );
+            debug!(
+                msg=%message,
+                ?policy,
+                ?current_payment,
+                ?current_expenditure,
+                "Evaluating if message meets gas payment requirement",
             );
             return policy
                 .message_meets_gas_payment_requirement(

--- a/rust/chains/hyperlane-ethereum/src/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/mailbox.rs
@@ -373,11 +373,15 @@ where
                 .call()
                 .await?;
             let l2_gas_estimate: U256 = gas_estimate.saturating_sub(l1_gas_estimate.into()).into();
-            // Very arbitrarily, we divide by 2 for a lower L2 gas estimate.
-            // We've observed L2 gas limits from NodeInterface.gasEstimateComponents to be grossly
-            // overestimated. The returned L2 gas is therefore not an upper bound on L2 gas usage,
-            // but a very rough estimation of L2 gas costs
-            Some(l2_gas_estimate / 2)
+            Some(l2_gas_estimate)
+
+            // IGNORE this doesn't work well:
+
+            // // Very arbitrarily, we divide by 2 for a lower L2 gas estimate.
+            // // We've observed L2 gas limits from NodeInterface.gasEstimateComponents to be grossly
+            // // overestimated. The returned L2 gas is therefore not an upper bound on L2 gas usage,
+            // // but a very rough estimation of L2 gas costs
+            // Some(l2_gas_estimate / 2)
         } else {
             None
         };

--- a/rust/chains/hyperlane-ethereum/src/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/mailbox.rs
@@ -351,26 +351,30 @@ where
         metadata: &[u8],
     ) -> ChainResult<TxCostEstimate> {
         let contract_call = self.process_contract_call(message, metadata, None).await?;
-        let gas_limit = contract_call
-            .tx
-            .gas()
-            .copied()
-            .ok_or(HyperlaneProtocolError::ProcessGasLimitRequired)?;
 
         // If we have a ArbitrumNodeInterface, we need to set the l2_gas_limit.
-        let l2_gas_limit = if let Some(arbitrum_node_interface) = &self.arbitrum_node_interface {
-            let (l1_gas_limit, _, _) = arbitrum_node_interface
-                .gas_estimate_l1_component(
-                    self.contract.address(),
-                    false, // Not a contract creation
-                    contract_call.calldata().unwrap_or_default(),
+        let (gas_limit, l2_gas_limit) =
+            if let Some(arbitrum_node_interface) = &self.arbitrum_node_interface {
+                let (gas_estimate, l1_gas_estimate, _, _) = arbitrum_node_interface
+                    .gas_estimate_components(
+                        self.contract.address(),
+                        false, // Not a contract creation
+                        contract_call.calldata().unwrap_or_default(),
+                    )
+                    .call()
+                    .await?;
+                (
+                    U256::from(gas_estimate),
+                    Some(gas_estimate.saturating_sub(l1_gas_estimate.into()).into()),
                 )
-                .call()
-                .await?;
-            Some(gas_limit.saturating_sub(l1_gas_limit.into()))
-        } else {
-            None
-        };
+            } else {
+                let gas_limit = contract_call
+                    .tx
+                    .gas()
+                    .copied()
+                    .ok_or(HyperlaneProtocolError::ProcessGasLimitRequired)?;
+                (gas_limit, None)
+            };
 
         let gas_price = self
             .provider

--- a/rust/hyperlane-core/src/types/mod.rs
+++ b/rust/hyperlane-core/src/types/mod.rs
@@ -124,18 +124,21 @@ pub struct TxCostEstimate {
     pub gas_limit: U256,
     /// The gas price for the transaction.
     pub gas_price: U256,
-    /// The amount of L2 gas for the transaction.
+    /// The rough estimation of the L2 gas for the transaction.
+    /// Because getting an accurate estimation of L2 gas used isn't
+    /// straightforward, this is intended to be an estimation and not
+    /// a hard upper bound of L2 gas.
     /// If Some, `gas_limit` is the sum of the gas limit
-    /// covering L1 costs and the L2 gas limit.
+    /// covering L1 costs and the L2 gas estimation.
     /// Only present for Arbitrum Nitro chains, where the gas amount
     /// is used to cover L1 and L2 costs. For details:
     /// https://medium.com/offchainlabs/understanding-arbitrum-2-dimensional-fees-fd1d582596c9
-    pub l2_gas_limit: Option<U256>,
+    pub l2_gas_estimate: Option<U256>,
 }
 
 impl TxCostEstimate {
     /// The gas limit to be used by gas enforcement policies.
     pub fn enforceable_gas_limit(&self) -> U256 {
-        self.l2_gas_limit.unwrap_or(self.gas_limit)
+        self.l2_gas_estimate.unwrap_or(self.gas_limit)
     }
 }

--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -82,7 +82,7 @@ export const releaseCandidate: AgentConfig = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-agent',
-    tag: '19d9450-20230315-153147',
+    tag: 'a7cf211-20230316-111634',
   },
   aws: {
     region: 'us-east-1',
@@ -100,19 +100,6 @@ export const releaseCandidate: AgentConfig = {
         {
           type: GasPaymentEnforcementPolicyType.None,
           matchingList: interchainQueriesMatchingList,
-        },
-        // Don't enforce amounts for messages to arbitrumgoerli yet
-        {
-          type: GasPaymentEnforcementPolicyType.Minimum,
-          payment: '1',
-          matchingList: [
-            {
-              originDomain: '*',
-              destinationDomain: chainMetadata.arbitrumgoerli.domainId,
-              senderAddress: '*',
-              recipientAddress: '*',
-            },
-          ],
         },
         // Default policy is OnChainFeeQuoting
         {

--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -283,8 +283,9 @@ async function main(): Promise<boolean> {
 
     // Skip Ethereum if we've been configured to do so for this cycle
     if (
-      (origin === 'ethereum' || destination === 'ethereum') &&
-      currentCycle % (cyclesBetweenEthereumMessages + 1) !== 0
+      ((origin === 'ethereum' || destination === 'ethereum') &&
+        currentCycle % (cyclesBetweenEthereumMessages + 1) !== 0) ||
+      destination !== 'arbitrumgoerli'
     ) {
       debug('Skipping message to/from Ethereum', {
         currentCycle,


### PR DESCRIPTION
### Description

DRAFT - opening to get an image I can deploy to testnet3 rc and play around with

See #1728 for full context

In playing around with the existing version where we:
1. Do a normal eth_estimateGas to get the "total" L1 + L2 gas limit
2. Then call gasEstimateL1Component to get the L1 gas limit so we can subtract and get the L2 gas limit

I noticed that it took a few minutes for a message to arbitrumgoerli to eventually observe an L2 gas limit that made sense. For a basic helloworld tx that should only use ~150k-200k L2 gas, sometimes logs were showing l2_gas_limit as 800k, 1M+, 400k, etc. My best guess is that because we were doing the eth_estimateGas in one step and then the L1 component in a separate step, there's a mismatch. The L1 amount seems to vary more over time than I expected

So I'm gonna try using `gasEstimateComponents` instead -- this returns the total L1+L2 gas as well as the L1 gas all in a single atomic step. The downside here is that the `gasEstimateComponents` call will revert if the call we're estimating reverts -- and because of the way we use retrying provider, this can have an unintentional effect of retrying the call that we really shouldn't be. Now that I'm thinking of things, I think there's some room for improvement wrt failed calls and retrying...

Anyways, not fully intending on merging this yet, this is more to help prove my theory and then I'll consider how we can safely use `gasEstimateComponents`

### Drive-by changes

_Are there any minor or drive-by changes also included?_

### Related issues

- Fixes #[issue number here]

### Backward compatibility

_Are these changes backward compatible?_

Yes
No

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None
Yes


### Testing

_What kind of testing have these changes undergone?_

None
Manual
Unit Tests
