### PR TITLE
Testnet3 gas amount enforcement

### DIFF
--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -53,9 +53,22 @@ export const hyperlane: AgentConfig = {
           // https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/1605
           matchingList: interchainQueriesMatchingList,
         },
+        // Don't enforce amounts for arbitrumgoerli yet
         {
           type: GasPaymentEnforcementPolicyType.Minimum,
           payment: '1',
+          matchingList: [
+            {
+              originDomain: '*',
+              destinationDomain: chainMetadata.arbitrumgoerli.domainId,
+              senderAddress: '*',
+              recipientAddress: '*',
+            },
+          ],
+        },
+        // Default policy is OnChainFeeQuoting
+        {
+          type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
         },
       ],
     },
@@ -88,6 +101,20 @@ export const releaseCandidate: AgentConfig = {
           type: GasPaymentEnforcementPolicyType.None,
           matchingList: interchainQueriesMatchingList,
         },
+        // Don't enforce amounts for arbitrumgoerli yet
+        {
+          type: GasPaymentEnforcementPolicyType.Minimum,
+          payment: '1',
+          matchingList: [
+            {
+              originDomain: '*',
+              destinationDomain: chainMetadata.arbitrumgoerli.domainId,
+              senderAddress: '*',
+              recipientAddress: '*',
+            },
+          ],
+        },
+        // Default policy is OnChainFeeQuoting
         {
           type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
         },

--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -29,7 +29,7 @@ export const hyperlane: AgentConfig = {
   context: Contexts.Hyperlane,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-agent',
-    tag: '0b10247-20230313-205739',
+    tag: '19d9450-20230315-153147',
   },
   aws: {
     region: 'us-east-1',
@@ -53,7 +53,7 @@ export const hyperlane: AgentConfig = {
           // https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/1605
           matchingList: interchainQueriesMatchingList,
         },
-        // Don't enforce amounts for arbitrumgoerli yet
+        // Don't enforce amounts for messages to arbitrumgoerli yet
         {
           type: GasPaymentEnforcementPolicyType.Minimum,
           payment: '1',
@@ -82,7 +82,7 @@ export const releaseCandidate: AgentConfig = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-agent',
-    tag: '1cbe5fd-20230309-202035',
+    tag: '19d9450-20230315-153147',
   },
   aws: {
     region: 'us-east-1',
@@ -101,7 +101,7 @@ export const releaseCandidate: AgentConfig = {
           type: GasPaymentEnforcementPolicyType.None,
           matchingList: interchainQueriesMatchingList,
         },
-        // Don't enforce amounts for arbitrumgoerli yet
+        // Don't enforce amounts for messages to arbitrumgoerli yet
         {
           type: GasPaymentEnforcementPolicyType.Minimum,
           payment: '1',


### PR DESCRIPTION
### Description

Deploys testnet3 to fully enforce gas amounts

Note this doesn't enforce for arbitrumgoerli yet -- when testing things it seemed there was some flakiness in gas amount enforcement for arbitrum that I allude to in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/1940. Working on a more robust fix here

### Drive-by changes

none

### Related issues

related #1610 - mainnet & arbitrum chains will come soon

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Deployed!
