### PR TITLE
Use Polygon overrides when IGP claiming in key funder

### DIFF
--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -510,7 +510,10 @@ class ContextFunder {
       log('IGP balance exceeds claim threshold, claiming', {
         chain,
       });
-      await this.multiProvider.handleTx(chain, igp.contract.claim());
+      await this.multiProvider.sendTransaction(
+        chain,
+        await igp.contract.populateTransaction.claim(),
+      );
     } else {
       log('IGP balance does not exceed claim threshold, skipping', {
         chain,


### PR DESCRIPTION
### Description

For some extra context: #1934 and #1933 

Calling IGP.claim() was not using the Polygon tx defaults. Therefore we'd use a priority fee < 30 gwei and have txs be rejected :|

### Drive-by changes

none

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Ran locally
