### PR TITLE
Move to estimateRetryableTicket to get L2 gas for arbitrum chains

### DIFF
--- a/rust/agents/relayer/src/msg/gas_payment/mod.rs
+++ b/rust/agents/relayer/src/msg/gas_payment/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use async_trait::async_trait;
 use eyre::Result;
-use tracing::{error, trace};
+use tracing::{debug, error, trace};
 
 use hyperlane_core::{
     db::HyperlaneDB, HyperlaneMessage, InterchainGasExpenditure, InterchainGasPayment,
@@ -104,6 +104,13 @@ impl GasPaymentEnforcer {
                 ?policy,
                 ?whitelist,
                 "Message matched whitelist for policy"
+            );
+            debug!(
+                msg=%message,
+                ?policy,
+                ?current_payment,
+                ?current_expenditure,
+                "Evaluating if message meets gas payment requirement",
             );
             return policy
                 .message_meets_gas_payment_requirement(

--- a/rust/chains/hyperlane-ethereum/src/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/mailbox.rs
@@ -27,7 +27,7 @@ use crate::tx::report_tx;
 use crate::EthereumProvider;
 
 /// An amount of gas to add to the estimated gas
-const GAS_ESTIMATE_BUFFER: u32 = 100000;
+const GAS_ESTIMATE_BUFFER: u32 = 50000;
 
 impl<M> std::fmt::Display for EthereumMailboxInternal<M>
 where

--- a/rust/chains/hyperlane-ethereum/src/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/mailbox.rs
@@ -187,7 +187,7 @@ where
         // Arbitrum Nitro based chains are a special case for transaction cost estimation.
         // The gas amount that eth_estimateGas returns considers both L1 and L2 gas costs.
         // We use the NodeInterface, found at address(0xC8), to isolate the L2 gas costs.
-        // See https://developer.arbitrum.io/arbos/gas#nodeinterfacesol or https://github.com/OffchainLabs/nitro/blob/master/contracts/src/node-interface/NodeInterface.sol#L110
+        // See https://developer.arbitrum.io/arbos/gas#nodeinterfacesol or https://github.com/OffchainLabs/nitro/blob/master/contracts/src/node-interface/NodeInterface.sol#L25
         let arbitrum_node_interface = locator.domain.is_arbitrum_nitro().then(|| {
             Arc::new(ArbitrumNodeInterface::new(
                 H160::from_low_u64_be(0xC8),


### PR DESCRIPTION
### Description

* Moves to `estimateRetryableTicket` to get Arbitrum L2 gas

### Drive-by changes

none

### Related issues

- Fixes #1728

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Unit tests - haven't deployed yet tho
