### PR TITLE
Deploy to testnet3 with arbitrum enforcement

### DIFF
--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -29,7 +29,7 @@ export const hyperlane: AgentConfig = {
   context: Contexts.Hyperlane,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-agent',
-    tag: '19d9450-20230315-153147',
+    tag: '81ad229-20230316-173735',
   },
   aws: {
     region: 'us-east-1',
@@ -53,19 +53,6 @@ export const hyperlane: AgentConfig = {
           // https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/1605
           matchingList: interchainQueriesMatchingList,
         },
-        // Don't enforce amounts for messages to arbitrumgoerli yet
-        {
-          type: GasPaymentEnforcementPolicyType.Minimum,
-          payment: '1',
-          matchingList: [
-            {
-              originDomain: '*',
-              destinationDomain: chainMetadata.arbitrumgoerli.domainId,
-              senderAddress: '*',
-              recipientAddress: '*',
-            },
-          ],
-        },
         // Default policy is OnChainFeeQuoting
         {
           type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
@@ -82,7 +69,7 @@ export const releaseCandidate: AgentConfig = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-agent',
-    tag: '19d9450-20230315-153147',
+    tag: '81ad229-20230316-173735',
   },
   aws: {
     region: 'us-east-1',
@@ -100,19 +87,6 @@ export const releaseCandidate: AgentConfig = {
         {
           type: GasPaymentEnforcementPolicyType.None,
           matchingList: interchainQueriesMatchingList,
-        },
-        // Don't enforce amounts for messages to arbitrumgoerli yet
-        {
-          type: GasPaymentEnforcementPolicyType.Minimum,
-          payment: '1',
-          matchingList: [
-            {
-              originDomain: '*',
-              destinationDomain: chainMetadata.arbitrumgoerli.domainId,
-              senderAddress: '*',
-              recipientAddress: '*',
-            },
-          ],
         },
         // Default policy is OnChainFeeQuoting
         {


### PR DESCRIPTION
### Description

Start enforcing arbitrum gas amounts after #1949 

### Drive-by changes

none

### Related issues

related: #1610 

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Deployed and sent some messages
