### PR TITLE
Deploy new TestRecipients & blacklist old one on testnet

### DIFF
--- a/solidity/contracts/test/TestRecipient.sol
+++ b/solidity/contracts/test/TestRecipient.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.8.0;
 
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
 import {IMessageRecipient} from "../../interfaces/IMessageRecipient.sol";
 import {IInterchainSecurityModule, ISpecifiesInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
 
 contract TestRecipient is
+    Ownable,
     IMessageRecipient,
     ISpecifiesInterchainSecurityModule
 {
@@ -23,10 +26,6 @@ contract TestRecipient is
 
     event ReceivedCall(address indexed caller, uint256 amount, string message);
 
-    function setInterchainSecurityModule(address _ism) external {
-        interchainSecurityModule = IInterchainSecurityModule(_ism);
-    }
-
     function handle(
         uint32 _origin,
         bytes32 _sender,
@@ -41,5 +40,9 @@ contract TestRecipient is
         emit ReceivedCall(msg.sender, amount, message);
         lastCaller = msg.sender;
         lastCallMessage = message;
+    }
+
+    function setInterchainSecurityModule(address _ism) external onlyOwner {
+        interchainSecurityModule = IInterchainSecurityModule(_ism);
     }
 }

--- a/typescript/infra/config/environments/mainnet2/testrecipient/addresses.json
+++ b/typescript/infra/config/environments/mainnet2/testrecipient/addresses.json
@@ -1,0 +1,38 @@
+{
+  "bsc": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "avalanche": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "polygon": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "celo": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "arbitrum": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "optimism": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "ethereum": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "moonbeam": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "gnosis": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  }
+}

--- a/typescript/infra/config/environments/mainnet2/testrecipient/verification.json
+++ b/typescript/infra/config/environments/mainnet2/testrecipient/verification.json
@@ -1,0 +1,128 @@
+{
+  "bsc": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "avalanche": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "polygon": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "celo": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "arbitrum": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "optimism": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "ethereum": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "moonbeam": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "gnosis": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ]
+}

--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -43,7 +43,15 @@ export const hyperlane: AgentConfig = {
   validators,
   relayer: {
     default: {
-      blacklist: releaseCandidateHelloworldMatchingList,
+      blacklist: [
+        ...releaseCandidateHelloworldMatchingList,
+        {
+          // In an effort to reduce some giant retry queues that resulted
+          // from spam txs to the old TestRecipient before we were charging for
+          // gas, we blacklist the old TestRecipient address.
+          recipientAddress: '0xBC3cFeca7Df5A45d61BC60E7898E63670e1654aE',
+        },
+      ],
       gasPaymentEnforcement: [
         {
           type: GasPaymentEnforcementPolicyType.None,

--- a/typescript/infra/config/environments/testnet3/testrecipient/addresses.json
+++ b/typescript/infra/config/environments/testnet3/testrecipient/addresses.json
@@ -1,0 +1,38 @@
+{
+  "alfajores": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "fuji": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "mumbai": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "bsctestnet": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "goerli": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "sepolia": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "moonbasealpha": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "optimismgoerli": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  },
+  "arbitrumgoerli": {
+    "TestRecipient": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+    "TestTokenRecipient": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb"
+  }
+}

--- a/typescript/infra/config/environments/testnet3/testrecipient/verification.json
+++ b/typescript/infra/config/environments/testnet3/testrecipient/verification.json
@@ -1,0 +1,128 @@
+{
+  "alfajores": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "fuji": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "mumbai": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "bsctestnet": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "goerli": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "sepolia": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "moonbasealpha": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "optimismgoerli": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ],
+  "arbitrumgoerli": [
+    {
+      "name": "TestRecipient",
+      "address": "0x36FdA966CfffF8a9Cdc814f546db0e6378bFef35",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    },
+    {
+      "name": "TestTokenRecipient",
+      "address": "0x85ac1164878e017b67660a74ff1f41f3D05C02Bb",
+      "isProxy": false,
+      "constructorArguments": "0x"
+    }
+  ]
+}

--- a/typescript/infra/src/testcontracts/testrecipient.ts
+++ b/typescript/infra/src/testcontracts/testrecipient.ts
@@ -33,7 +33,7 @@ export class TestRecipientDeployer extends HyperlaneDeployer<
     );
   }
   async deployContracts(chain: ChainName) {
-    const deployer = this.multiProvider.getSignerAddress(chain);
+    const deployer = await this.multiProvider.getSignerAddress(chain);
     const TestRecipient = await this.deployContract(
       chain,
       'TestRecipient',
@@ -50,7 +50,7 @@ export class TestRecipientDeployer extends HyperlaneDeployer<
       chain,
       'TestTokenRecipient',
       [],
-      { create2Salt: 'TestTokenRecipient' },
+      { create2Salt: 'TestRecipient-March-17-2023' },
     );
     return {
       TestRecipient,

--- a/typescript/infra/src/testcontracts/testrecipient.ts
+++ b/typescript/infra/src/testcontracts/testrecipient.ts
@@ -33,11 +33,18 @@ export class TestRecipientDeployer extends HyperlaneDeployer<
     );
   }
   async deployContracts(chain: ChainName) {
+    const deployer = this.multiProvider.getSignerAddress(chain);
     const TestRecipient = await this.deployContract(
       chain,
       'TestRecipient',
       [],
-      { create2Salt: 'testtest32' },
+      {
+        create2Salt: 'TestRecipient-March-17-2023',
+        initCalldata: new TestRecipient__factory().interface.encodeFunctionData(
+          'transferOwnership',
+          [deployer],
+        ),
+      },
     );
     const TestTokenRecipient = await this.deployContract(
       chain,


### PR DESCRIPTION
### Description

Context https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/1956

### Drive-by changes

New TestRecipient salts, made TestRecipient ownable so that there's some access control on setting the ISM

### Related issues

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/1956

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Deployed