### PR TITLE
Fix explorerAddressURL when no signer

### DIFF
--- a/typescript/sdk/src/providers/MultiProvider.ts
+++ b/typescript/sdk/src/providers/MultiProvider.ts
@@ -497,12 +497,16 @@ export class MultiProvider {
    */
   async tryGetExplorerAddressUrl(
     chainNameOrId: ChainName | number,
-    _address?: string,
+    address?: string,
   ): Promise<string | null> {
     const baseUrl = this.tryGetExplorerUrl(chainNameOrId);
-    const signer = this.tryGetSigner(chainNameOrId);
-    if (!baseUrl || !signer) return null;
-    const address = _address ?? (await signer.getAddress());
+    if (!baseUrl) return null;
+    if (!address) {
+      const signer = this.tryGetSigner(chainNameOrId);
+      if (!signer) return null;
+      return `${baseUrl}/${await signer.getAddress()}`;
+    }
+
     return `${baseUrl}/${address}`;
   }
 


### PR DESCRIPTION
### Description

Currently, if the MP doesn't have a signer, the function will always return null
