### PR TITLE
Reduce external logging

### DIFF
--- a/rust/hyperlane-base/src/settings/trace/mod.rs
+++ b/rust/hyperlane-base/src/settings/trace/mod.rs
@@ -79,7 +79,9 @@ impl TracingConfig {
         let mut target_layer = Targets::new().with_default(self.level);
         if self.level < Level::Trace {
             // only show hyper debug and trace logs at trace level
-            target_layer = target_layer.with_target("hyper", Level::Info)
+            target_layer = target_layer.with_target("hyper", Level::Info);
+            target_layer = target_layer.with_target("rusoto_core", Level::Info);
+            target_layer = target_layer.with_target("reqwest", Level::Info);
         }
         let fmt_layer: LogOutputLayer<_> = self.fmt.into();
         let err_layer = tracing_error::ErrorLayer::default();


### PR DESCRIPTION
### Description

Cuts out a few very verbose log targets that are not relevant for us at the debug level. Specifically `rusoto_core` and `reqwest` debug logs.

### Drive-by changes

None

### Related issues

- Mentioned in #1896

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Manual
