### PR TITLE
Init OwnableUpgradeable in CircleBridgeAdapter

### DIFF
--- a/solidity/contracts/middleware/liquidity-layer/adapters/CircleBridgeAdapter.sol
+++ b/solidity/contracts/middleware/liquidity-layer/adapters/CircleBridgeAdapter.sol
@@ -74,7 +74,7 @@ contract CircleBridgeAdapter is ILiquidityLayerAdapter, Router {
         address _circleMessageTransmitter,
         address _liquidityLayerRouter
     ) external initializer {
-        // Transfer ownership of the contract to deployer
+        __Ownable_init();
         _transferOwnership(_owner);
 
         circleBridge = ICircleBridge(_circleBridge);


### PR DESCRIPTION
### Description

> H02. Upgradeability Errors
> CircleBridgeAdapter.sol is inheriting Router, but is not initializing it. Issue M09 is related to this situation.
> OwnableMulticall.sol is inheriting OwnableUpgradable, but is not initializing it.
> Path: monorepo/solidity/contracts/middleware/CircleBridgeAdapter.sol: initialize()
> Recommendation: Initialize the inherited upgradable contracts.

### Backward compatibility

Yes (deployment only)

### Testing

Unit tests