### PR TITLE
Use legacy feature for ethers-contract

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,7 +32,7 @@ color-eyre = { version = "0.6" }
 config = "~0.13.3"
 derive-new = "0.5"
 ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-02-10-01" }
-ethers-contract = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-02-10-01" }
+ethers-contract = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-02-10-01", features = ["legacy"] }
 ethers-providers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-02-10-01" }
 ethers-signers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-02-10-01", features = ["aws"] }
 eyre = "0.6"


### PR DESCRIPTION
### Description

Was accidentally removed in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/1975/files#diff-7bdd9f71c229927ffff28bd337aa4ab3ab960426cd17fe857afe922014dfe791L13

Using the legacy feature allows us to opt into EIP 1559 txs. We should clean this up at some point, this is so fragile

Decided to put the legacy feature at the workspace lvl because we'll probably not want to miss this again by accident

### Drive-by changes

n/a

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None