### PR TITLE
Build only the agent bins in docker

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -26,7 +26,7 @@ RUN \
   --mount=id=cargo,type=cache,sharing=locked,target=/usr/src/target \
   --mount=id=cargo-home-registry,type=cache,sharing=locked,target=/usr/local/cargo/registry \
   --mount=id=cargo-home-git,type=cache,sharing=locked,target=/usr/local/cargo/git \
-    cargo build --release && \
+    cargo build --release -p validator -p relayer -p scraper && \
     mkdir -p /release && \
     cp /usr/src/target/release/validator /release && \
     cp /usr/src/target/release/relayer /release && \


### PR DESCRIPTION
### Description

Minor change to slightly speed up agent image build times. We only need to build the agent binaries in the docker pipeline.

### Drive-by changes

None

### Related issues

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Unit Tests
