### PR TITLE
Automatically detect and check ownership of ownables

### DIFF
--- a/typescript/sdk/src/core/HyperlaneCoreChecker.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreChecker.ts
@@ -40,13 +40,7 @@ export class HyperlaneCoreChecker extends HyperlaneAppChecker<
   async checkDomainOwnership(chain: ChainName): Promise<void> {
     const config = this.configMap[chain];
     if (config.owner) {
-      const contracts = this.app.getContracts(chain);
-      const ownables = [
-        contracts.proxyAdmin,
-        contracts.mailbox.contract,
-        contracts.multisigIsm,
-      ];
-      return this.checkOwnership(chain, config.owner, ownables);
+      return this.checkOwnership(chain, config.owner);
     }
   }
 

--- a/typescript/sdk/src/gas/HyperlaneIgpChecker.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpChecker.ts
@@ -31,13 +31,7 @@ export class HyperlaneIgpChecker extends HyperlaneAppChecker<
   async checkDomainOwnership(chain: ChainName): Promise<void> {
     const config = this.configMap[chain];
     if (config.owner) {
-      const contracts = this.app.getContracts(chain);
-      const ownables = [
-        contracts.proxyAdmin,
-        contracts.interchainGasPaymaster.contract,
-        contracts.defaultIsmInterchainGasPaymaster,
-      ];
-      return this.checkOwnership(chain, config.owner, ownables);
+      return this.checkOwnership(chain, config.owner);
     }
   }
 

--- a/typescript/sdk/src/proxy.ts
+++ b/typescript/sdk/src/proxy.ts
@@ -54,3 +54,18 @@ export class ProxiedContract<
     );
   }
 }
+
+export function isProxiedContract(
+  contract: unknown,
+): contract is ProxiedContract<any, any> {
+  // The presence of `implementation` is intentionally not checked
+  // to allow deploying new implementations by deleting the implementation
+  // from the artifacts
+  return (
+    contract !== null &&
+    typeof contract === 'object' &&
+    'addresses' in contract &&
+    'contract' in contract &&
+    isProxyAddresses((contract as any).addresses)
+  );
+}

--- a/typescript/sdk/src/router/HyperlaneRouterChecker.ts
+++ b/typescript/sdk/src/router/HyperlaneRouterChecker.ts
@@ -1,6 +1,5 @@
 import { ethers } from 'ethers';
 
-import { Ownable } from '@hyperlane-xyz/core';
 import { utils } from '@hyperlane-xyz/utils';
 
 import { HyperlaneApp } from '../HyperlaneApp';
@@ -17,8 +16,7 @@ export class HyperlaneRouterChecker<
 > extends HyperlaneAppChecker<App, Config> {
   checkOwnership(chain: ChainName): Promise<void> {
     const owner = this.configMap[chain].owner;
-    const ownables = this.ownables(chain);
-    return super.checkOwnership(chain, owner, ownables);
+    return super.checkOwnership(chain, owner);
   }
 
   async checkChain(chain: ChainName): Promise<void> {
@@ -58,9 +56,5 @@ export class HyperlaneRouterChecker<
         utils.assert(address === utils.addressToBytes32(remoteRouter.address));
       }),
     );
-  }
-
-  ownables(chain: ChainName): Ownable[] {
-    return [this.app.getContracts(chain).router];
   }
 }


### PR DESCRIPTION
### Description

Rather than hard code ownables, attempt to detect them

Manually confirmed that core/igp checkers check a superset of ownables than what was previously checked

### Drive-by changes

None

