### PR TITLE
Bump L2 desired balances

### DIFF
--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -111,8 +111,8 @@ const desiredBalancePerChain: ChainMap<string> = {
   sepolia: '0.5',
   moonbasealpha: '1',
   moonbeam: '0.5',
-  optimismgoerli: '0.3',
-  arbitrumgoerli: '0.1',
+  optimismgoerli: '0.5',
+  arbitrumgoerli: '0.5',
   gnosis: '0.1',
   // unused
   test1: '0',


### PR DESCRIPTION
### Description

With the goerli gas spike message 0x7052dc74be0f6a81007e2b10e11c11a70948b200c7c5a12fa80eab527ec641e0 requires 0.08 arb-eth to deliver and the relayer has 0.06, and we don't fund b/c 0.06 is > half of our desired of 0.1

Bumping to 0.5 for testnet L2s

We will probably need more goerli ETH

Once approved will deploy