### PR TITLE
H02: OwnableMulticall followup

### DIFF
--- a/solidity/contracts/OwnableMulticall.sol
+++ b/solidity/contracts/OwnableMulticall.sol
@@ -16,7 +16,7 @@ contract OwnableMulticall is OwnableUpgradeable {
     }
 
     function initialize() external initializer {
-        _transferOwnership(msg.sender);
+        __Ownable_init();
     }
 
     function proxyCalls(Call[] calldata calls) external onlyOwner {


### PR DESCRIPTION
- Use `Ownable_init` instead of `transferOwnership`

### Testing

Unit Tests
