### PR TITLE
Fix e2e by merging IGP addresses into agent configs

### DIFF
--- a/rust/utils/run-locally/src/main.rs
+++ b/rust/utils/run-locally/src/main.rs
@@ -339,11 +339,13 @@ fn main() -> ExitCode {
         "--chain",
         "test1",
     ]);
-    announce
+    let status = announce
         .current_dir("../typescript/infra")
         .stdout(Stdio::piped())
-        .spawn()
-        .expect("Failed to announce validator");
+        .status()
+        .expect("Failed to announce validator")
+        .success();
+    assert!(status, "Failed to announce validator");
 
     println!("Setup complete! Agents running in background...");
     println!("Ctrl+C to end execution...");

--- a/typescript/infra/scripts/deploy.ts
+++ b/typescript/infra/scripts/deploy.ts
@@ -115,11 +115,11 @@ async function main() {
 
   const verification = path.join(modulePath, 'verification.json');
 
-  // do not cache for test environment
-  const cache =
-    environment === 'test' ? undefined : { addresses, verification };
+  const cache = { addresses, verification };
+  // do not read cache for test environment
+  const readCache = environment !== 'test';
 
-  await deployWithArtifacts(deployer, cache, fork);
+  await deployWithArtifacts(deployer, cache, readCache, fork);
 }
 
 main()

--- a/typescript/infra/src/deploy.ts
+++ b/typescript/infra/src/deploy.ts
@@ -17,9 +17,10 @@ export async function deployWithArtifacts(
     addresses: string;
     verification: string;
   },
+  readCache: boolean = true,
   fork?: ChainName,
 ) {
-  if (cache) {
+  if (cache && readCache) {
     let addresses = {};
     try {
       addresses = readJSONAtPath(cache.addresses);

--- a/typescript/sdk/src/consts/environments/test.json
+++ b/typescript/sdk/src/consts/environments/test.json
@@ -1,8 +1,25 @@
 {
   "test1": {
-    "storageGasOracle": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
+    "storageGasOracle": "0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1",
+    "validatorAnnounce": "0x0165878A594ca255338adfa4d48449f69242Eb8F",
+    "proxyAdmin": "0x59b670e9fA9D0A427751Af201D676719a970857b",
+    "mailbox": {
+      "kind": "Transparent",
+      "proxy": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
+      "implementation": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9"
+    },
+    "interchainGasPaymaster": {
+      "kind": "Transparent",
+      "proxy": "0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f",
+      "implementation": "0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44"
+    },
+    "defaultIsmInterchainGasPaymaster": "0x7a2088a1bFc9d81c55368AE168C2C02570cB814F",
+    "multisigIsm": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+  },
+  "test2": {
+    "storageGasOracle": "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E",
     "validatorAnnounce": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
-    "proxyAdmin": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
+    "proxyAdmin": "0x67d269191c92Caf3cD7723F116c85e6E9bf55933",
     "mailbox": {
       "kind": "Transparent",
       "proxy": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
@@ -10,44 +27,27 @@
     },
     "interchainGasPaymaster": {
       "kind": "Transparent",
-      "proxy": "0x0165878A594ca255338adfa4d48449f69242Eb8F",
-      "implementation": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707"
+      "proxy": "0x84eA74d481Ee0A5332c457a4d796187F6Ba67fEB",
+      "implementation": "0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690"
     },
-    "defaultIsmInterchainGasPaymaster": "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
-    "multisigIsm": "0x5FbDB2315678afecb367f032d93F642f64180aa3"
-  },
-  "test2": {
-    "storageGasOracle": "0x68B1D87F95878fE05B998F19b66F4baba5De1aed",
-    "validatorAnnounce": "0x09635F643e140090A9A8Dcd712eD6285858ceBef",
-    "proxyAdmin": "0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE",
-    "mailbox": {
-      "kind": "Transparent",
-      "proxy": "0x7a2088a1bFc9d81c55368AE168C2C02570cB814F",
-      "implementation": "0x4A679253410272dd5232B3Ff7cF5dbB88f295319"
-    },
-    "interchainGasPaymaster": {
-      "kind": "Transparent",
-      "proxy": "0xc6e7DF5E7b4f2A278906862b61205850344D4e7d",
-      "implementation": "0x3Aa5ebB10DC797CAC828524e59A333d0A371443c"
-    },
-    "defaultIsmInterchainGasPaymaster": "0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1",
-    "multisigIsm": "0x9A676e781A523b5d0C0e43731313A708CB607508"
+    "defaultIsmInterchainGasPaymaster": "0xa82fF9aFd8f496c3d6ac40E2a0F282E47488CFc9",
+    "multisigIsm": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853"
   },
   "test3": {
-    "storageGasOracle": "0x84eA74d481Ee0A5332c457a4d796187F6Ba67fEB",
-    "validatorAnnounce": "0x4826533B4897376654Bb4d4AD88B7faFD0C98528",
-    "proxyAdmin": "0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690",
+    "storageGasOracle": "0x95401dc811bb5740090279Ba06cfA8fcF6113778",
+    "validatorAnnounce": "0xc6e7DF5E7b4f2A278906862b61205850344D4e7d",
+    "proxyAdmin": "0xf5059a5D33d5853360D16C683c16e67980206f36",
     "mailbox": {
+      "kind": "Transparent",
+      "proxy": "0x3Aa5ebB10DC797CAC828524e59A333d0A371443c",
+      "implementation": "0x68B1D87F95878fE05B998F19b66F4baba5De1aed"
+    },
+    "interchainGasPaymaster": {
       "kind": "Transparent",
       "proxy": "0x70e0bA845a1A0F2DA3359C97E0285013525FFC49",
       "implementation": "0x998abeb3E57409262aE5b751f60747921B33613E"
     },
-    "interchainGasPaymaster": {
-      "kind": "Transparent",
-      "proxy": "0xa82fF9aFd8f496c3d6ac40E2a0F282E47488CFc9",
-      "implementation": "0x9E545E3C0baAB3E08CdfD552C960A1050f373042"
-    },
-    "defaultIsmInterchainGasPaymaster": "0x851356ae760d987E095750cCeb3bC6014560891C",
-    "multisigIsm": "0xc5a5C42992dECbae36851359345FE25997F5C42d"
+    "defaultIsmInterchainGasPaymaster": "0x99bbA657f2BbC93c02D617f8bA121cB8Fc104Acf",
+    "multisigIsm": "0x9A676e781A523b5d0C0e43731313A708CB607508"
   }
 }

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -95,6 +95,7 @@ export {
   queryAnnotatedEvents,
   TSContract,
 } from './events';
+export { IgpContracts } from './gas/contracts';
 export { HyperlaneIgp } from './gas/HyperlaneIgp';
 export { HyperlaneIgpChecker } from './gas/HyperlaneIgpChecker';
 export { HyperlaneIgpDeployer } from './gas/HyperlaneIgpDeployer';


### PR DESCRIPTION
### Description

Merges the IGP addresses into the agent configs. The e2e tests are failing because the generated `test_config.json` agent config doesn't have the IGP addresses in there

This means that you need to run `deploy-core` before `deploy-igp` -- which feels reasonable?
Open to also merging in deploy-core, but was worried there that you could end up deploying core that uses old IGP addresses

### Drive-by changes

n/a

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Ran locally and saw the config was created as expected
