### PR TITLE
Write agent config for core and IGP deploys

### DIFF
--- a/typescript/infra/scripts/deploy.ts
+++ b/typescript/infra/scripts/deploy.ts
@@ -115,11 +115,21 @@ async function main() {
 
   const verification = path.join(modulePath, 'verification.json');
 
-  // do not cache for test environment
-  const cache =
-    environment === 'test' ? undefined : { addresses, verification };
+  const cache = {
+    addresses,
+    verification,
+    read: environment !== 'test',
+    write: true,
+  };
+  const agentConfig = ['core', 'igp'].includes(module)
+    ? {
+        addresses,
+        environment,
+        multiProvider,
+      }
+    : undefined;
 
-  await deployWithArtifacts(deployer, cache, fork);
+  await deployWithArtifacts(deployer, cache, fork, agentConfig);
 }
 
 main()


### PR DESCRIPTION
### Description

This PR fixes the broken E2E tests by writing agent config after core *or* IGP deploys.

Rather than reading contract addresses from the deployed contracts, agent configs are built from the cached contract addresses in the SDK. Therefore, we must write (but not read) contract addresses when deploying to the test environment.

### Drive-by changes

