### PR TITLE
Fix fork tests 2, fixier

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -115,7 +115,7 @@ jobs:
     strategy:
       matrix:
         environment: [testnet3, mainnet2]
-        module: [core, igp, ica, iqs]
+        module: [core, igp]
 
     steps:
       - uses: actions/checkout@v3

--- a/typescript/infra/scripts/deploy.ts
+++ b/typescript/infra/scripts/deploy.ts
@@ -121,13 +121,15 @@ async function main() {
     read: environment !== 'test',
     write: true,
   };
-  const agentConfig = ['core', 'igp'].includes(module)
-    ? {
-        addresses,
-        environment,
-        multiProvider,
-      }
-    : undefined;
+  // Don't write agent config in fork tests
+  const agentConfig =
+    ['core', 'igp'].includes(module) && !fork
+      ? {
+          addresses,
+          environment,
+          multiProvider,
+        }
+      : undefined;
 
   await deployWithArtifacts(deployer, cache, fork, agentConfig);
 }

--- a/typescript/sdk/src/utils/objects.ts
+++ b/typescript/sdk/src/utils/objects.ts
@@ -40,8 +40,11 @@ export function promiseObjAll<K extends string, V>(obj: {
 // Get the subset of the object from key list
 export function pick<K extends string, V = any>(obj: Record<K, V>, keys: K[]) {
   const ret: Partial<Record<K, V>> = {};
+  const objKeys = Object.keys(obj);
   for (const key of keys) {
-    ret[key] = obj[key];
+    if (objKeys.includes(key)) {
+      ret[key] = obj[key];
+    }
   }
   return ret as Record<K, V>;
 }


### PR DESCRIPTION
### Description

Follow-up to #2062, fixes an issue where `pick` inserts a key into an object that wasn't originally present. 

This was causing HyperlaneApps to be instantiated with undefined addresses, which caused the fork tests to fail.

Also skips fork testing ICAs/IQS due to the IGP mismatch error

