### PR TITLE
Fix SDK attachContractsMap bug

### DIFF
--- a/typescript/sdk/src/contracts.ts
+++ b/typescript/sdk/src/contracts.ts
@@ -57,17 +57,16 @@ export function filterAddressesMap(
   addressesMap: HyperlaneAddressesMap<any>,
   factories: HyperlaneFactories,
 ): HyperlaneAddressesMap<typeof factories> {
+  const factoryKeys = Object.keys(factories);
   // Filter out addresses that we do not have factories for
   const pickedAddressesMap = objMap(addressesMap, (_, addresses) =>
-    pick(addresses, Object.keys(factories)),
+    pick(addresses, factoryKeys),
   );
   // Filter out chains for which we do not have a complete set of addresses
   return objFilter(
     pickedAddressesMap,
     (_, addresses): addresses is HyperlaneAddresses<typeof factories> => {
-      return Object.keys(factories)
-        .map((contract) => Object.keys(addresses).includes(contract))
-        .every(Boolean);
+      return Object.keys(addresses).every((a) => factoryKeys.includes(a));
     },
   );
 }

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -36,7 +36,7 @@ export {
   attachContractsMap,
   connectContracts,
   connectContractsMap,
-  filterAddresses,
+  filterAddressesMap,
   HyperlaneAddresses,
   HyperlaneAddressesMap,
   HyperlaneContracts,


### PR DESCRIPTION
### Description

attachContractsMap should filter out chains for which a complete set of addresses is not present

### Drive-by changes

None

