### PR TITLE
Clear timeout in runWithTimeout

### DIFF
--- a/typescript/utils/src/utils.ts
+++ b/typescript/utils/src/utils.ts
@@ -355,7 +355,7 @@ export async function runWithTimeout<T>(
         timeoutMs,
       )),
   );
-  const ret = Promise.race([callback(), timeoutProm]);
+  const ret = await Promise.race([callback(), timeoutProm]);
   // @ts-ignore timeout gets set immediately by the promise constructor
   clearTimeout(timeout);
   return ret;

--- a/typescript/utils/src/utils.ts
+++ b/typescript/utils/src/utils.ts
@@ -347,11 +347,16 @@ export async function runWithTimeout<T>(
   timeoutMs: number,
   callback: () => Promise<T>,
 ): Promise<T | void> {
-  const timeout = new Promise<void>((_, reject) =>
-    setTimeout(
-      () => reject(new Error(`Timed out in ${timeoutMs}ms.`)),
-      timeoutMs,
-    ),
+  let timeout: NodeJS.Timeout;
+  const timeoutProm = new Promise<void>(
+    (_, reject) =>
+      (timeout = setTimeout(
+        () => reject(new Error(`Timed out in ${timeoutMs}ms.`)),
+        timeoutMs,
+      )),
   );
-  return Promise.race([callback(), timeout]);
+  const ret = Promise.race([callback(), timeoutProm]);
+  // @ts-ignore timeout gets set immediately by the promise constructor
+  clearTimeout(timeout);
+  return ret;
 }


### PR DESCRIPTION
### Description

Fixes a bug in which processes (e.g. e2e test) would hang until the timeout completed
