### PR TITLE
Finality blocks config

### DIFF
--- a/rust/agents/validator/src/settings.rs
+++ b/rust/agents/validator/src/settings.rs
@@ -19,8 +19,6 @@ decl_settings!(Validator,
         validator: SignerConf,
         /// The checkpoint syncer configuration
         checkpoint_syncer: CheckpointSyncerConf,
-        /// The reorg_period in blocks
-        reorg_period: u64,
         /// How frequently to check for new checkpoints
         interval: Duration,
     },
@@ -32,8 +30,6 @@ decl_settings!(Validator,
         validator: RawSignerConf,
         /// The checkpoint syncer configuration
         checkpointsyncer: Option<RawCheckpointSyncerConf>,
-        /// The reorg_period in blocks
-        reorgperiod: Option<StrOrInt>,
         /// How frequently to check for new checkpoints
         interval: Option<StrOrInt>,
     },
@@ -60,12 +56,6 @@ impl FromRawConf<'_, RawValidatorSettings> for ValidatorSettings {
                 r.parse_config(&cwp.join("checkpointsyncer"))
                     .take_config_err(&mut err)
             });
-
-        let reorg_period = raw
-            .reorgperiod
-            .ok_or_else(|| eyre!("Missing `reorgperiod`"))
-            .take_err(&mut err, || cwp + "reorgperiod")
-            .and_then(|r| r.try_into().take_err(&mut err, || cwp + "reorgperiod"));
 
         let interval = raw
             .interval
@@ -104,7 +94,6 @@ impl FromRawConf<'_, RawValidatorSettings> for ValidatorSettings {
             origin_chain: origin_chain.unwrap(),
             validator: validator.unwrap(),
             checkpoint_syncer: checkpoint_syncer.unwrap(),
-            reorg_period: reorg_period.unwrap(),
             interval: interval.unwrap(),
         })
     }

--- a/rust/hyperlane-base/src/settings/chains.rs
+++ b/rust/hyperlane-base/src/settings/chains.rs
@@ -425,7 +425,8 @@ impl ChainConf {
         .context("Building ValidatorAnnounce")
     }
 
-    /// Try to convert the chain setting into an InterchainSecurityModule contract
+    /// Try to convert the chain setting into an InterchainSecurityModule
+    /// contract
     pub async fn build_ism(
         &self,
         address: H256,


### PR DESCRIPTION
### Description

Remove redundant `reogperiod` and replace with `finalityBlocks`

### Drive-by changes

_Are there any minor or drive-by changes also included?_

### Related issues

- Blocked by #2070
- Fixes #532
- Might want to wait for #2098

### Backward compatibility

_Are these changes backward compatible?_

Yes
No

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None
Yes


### Testing

_What kind of testing have these changes undergone?_

None
Manual
Unit Tests
