### PR TITLE
Add link to reference

### DIFF
--- a/rust/hyperlane-core/tests/chain_config.rs
+++ b/rust/hyperlane-core/tests/chain_config.rs
@@ -3,6 +3,7 @@ use std::fs::read_to_string;
 use std::path::Path;
 
 use config::{Config, FileFormat};
+use eyre::Context;
 use walkdir::WalkDir;
 
 use hyperlane_base::{RawSettings, Settings};
@@ -77,7 +78,9 @@ fn hyperlane_settings() -> Vec<Settings> {
                 .unwrap_or_else(|e| {
                     panic!("!cfg({}): {:?}: {}", p, e, f);
                 });
-            Settings::from_config(raw, &ConfigPath::default()).unwrap()
+            Settings::from_config(raw, &ConfigPath::default())
+                .context("Config parsing error, please check the config reference (https://docs.hyperlane.xyz/docs/operators/agent-configuration/reference)")
+                .unwrap()
         })
         .collect()
 }


### PR DESCRIPTION
### Description

Forgot this in the other PR, just adds a link to the reference when there is a parsing error.

### Drive-by changes

None

### Related issues

- From #2070 

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None
