### PR TITLE
Fix payment enforcement config parsing bug

### DIFF
--- a/rust/agents/relayer/src/settings/mod.rs
+++ b/rust/agents/relayer/src/settings/mod.rs
@@ -122,9 +122,7 @@ impl FromRawConf<'_, RawGasPaymentEnforcementConf> for GasPaymentEnforcementConf
                 r.parse_config(cwp).take_config_err(&mut err)
             });
 
-        let matching_list = raw
-            .matching_list
-            .unwrap_or_default();
+        let matching_list = raw.matching_list.unwrap_or_default();
         err.into_result()?;
         Ok(Self {
             policy: policy.unwrap(),

--- a/rust/agents/relayer/src/settings/mod.rs
+++ b/rust/agents/relayer/src/settings/mod.rs
@@ -101,12 +101,12 @@ pub struct GasPaymentEnforcementConf {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 struct RawGasPaymentEnforcementConf {
     #[serde(flatten)]
     policy: Option<RawGasPaymentEnforcementPolicy>,
     #[serde(default)]
-    matching_list: Option<String>,
+    matching_list: Option<MatchingList>,
 }
 
 impl FromRawConf<'_, RawGasPaymentEnforcementConf> for GasPaymentEnforcementConf {
@@ -124,10 +124,6 @@ impl FromRawConf<'_, RawGasPaymentEnforcementConf> for GasPaymentEnforcementConf
 
         let matching_list = raw
             .matching_list
-            .and_then(|v| {
-                serde_json::from_str::<MatchingList>(&v)
-                    .take_err(&mut err, || cwp + "matching_list")
-            })
             .unwrap_or_default();
         err.into_result()?;
         Ok(Self {


### PR DESCRIPTION
### Description

Fixes a bug where we were first parsing the matching list as a string and then trying to convert it which was impacting the expected config type.

### Drive-by changes

None

### Related issues

- https://discord.com/channels/935678348330434570/1096400530722537513

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Unit Tests
