### PR TITLE
Fix docs link

### DIFF
--- a/rust/hyperlane-base/src/settings/loader.rs
+++ b/rust/hyperlane-base/src/settings/loader.rs
@@ -109,7 +109,7 @@ where
                 formatted_config
             );
 
-            err.context("Config deserialization error, please check the config reference (https://docs.hyperlane.xyz/docs/operators/agent-configuration/reference)")
+            err.context("Config deserialization error, please check the config reference (https://docs.hyperlane.xyz/docs/operators/agent-configuration/configuration-reference)")
         }
     }
 }

--- a/rust/hyperlane-core/tests/chain_config.rs
+++ b/rust/hyperlane-core/tests/chain_config.rs
@@ -79,7 +79,7 @@ fn hyperlane_settings() -> Vec<Settings> {
                     panic!("!cfg({}): {:?}: {}", p, e, f);
                 });
             Settings::from_config(raw, &ConfigPath::default())
-                .context("Config parsing error, please check the config reference (https://docs.hyperlane.xyz/docs/operators/agent-configuration/reference)")
+                .context("Config parsing error, please check the config reference (https://docs.hyperlane.xyz/docs/operators/agent-configuration/configuration-reference)")
                 .unwrap()
         })
         .collect()


### PR DESCRIPTION
### Description

Minor fix to docs URL linked to by configuration errors.

### Drive-by changes

None

### Related issues

- https://discord.com/channels/935678348330434570/1096400530722537513

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None