### PR TITLE
feat: support WebIdentityProvider for AWS credentials [#2168].

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2810,6 +2810,7 @@ dependencies = [
  "rusoto_core",
  "rusoto_kms",
  "rusoto_s3",
+ "rusoto_sts",
  "serde",
  "serde_json",
  "static_assertions",
@@ -4626,6 +4627,21 @@ dependencies = [
  "serde",
  "sha2 0.9.9",
  "tokio",
+]
+
+[[package]]
+name = "rusoto_sts"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1643f49aa67cb7cb895ebac5a2ff3f991c6dbdc58ad98b28158cd5706aecd1d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "rusoto_core",
+ "serde_urlencoded",
+ "xml-rs",
 ]
 
 [[package]]

--- a/rust/hyperlane-base/Cargo.toml
+++ b/rust/hyperlane-base/Cargo.toml
@@ -58,6 +58,7 @@ opentelemetry-zipkin = { version = "0.16", default-features = false, features = 
 rusoto_core = "*"
 rusoto_kms = "*"
 rusoto_s3 = "*"
+rusoto_sts = "*"
 
 lazy_static = "1.4"
 once_cell = "1.16"

--- a/rust/hyperlane-base/src/settings/aws_credentials.rs
+++ b/rust/hyperlane-base/src/settings/aws_credentials.rs
@@ -1,0 +1,47 @@
+use async_trait::async_trait;
+use rusoto_core::credential::{
+    AutoRefreshingProvider, AwsCredentials, CredentialsError, EnvironmentProvider,
+    ProvideAwsCredentials,
+};
+use rusoto_sts::WebIdentityProvider;
+
+/// Provides AWS credentials from multiple possible sources using a priority order.
+/// The following sources are checked in order for credentials when calling credentials. More sources may be supported in future if a need be.
+/// 1) Environment variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+/// 2) `WebIdentityProvider`: by default, configured from environment variables `AWS_WEB_IDENTITY_TOKEN_FILE`,
+/// `AWS_ROLE_ARN` and `AWS_ROLE_SESSION_NAME`. Uses OpenID Connect bearer token to retrieve AWS IAM credentials
+/// from [AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html).
+/// The primary use case is running Hyperlane agents in AWS Kubernetes cluster (EKS) configured
+/// with [IAM Roles for Service Accounts (IRSA)](https://aws.amazon.com/blogs/containers/diving-into-iam-roles-for-service-accounts/).
+/// The IRSA approach follows security best practices and allows for key rotation.
+pub(crate) struct AwsChainCredentialsProvider {
+    environment_provider: EnvironmentProvider,
+    web_identity_provider: AutoRefreshingProvider<WebIdentityProvider>,
+}
+
+impl AwsChainCredentialsProvider {
+    pub fn new() -> Self {
+        // Wrap the `WebIdentityProvider` to a caching `AutoRefreshingProvider`.
+        // By default, the `WebIdentityProvider` requests AWS Credentials on each call to `credentials()`
+        // To save the CPU/network and AWS bills, the `AutoRefreshingProvider` allows to cache the credentials until the expire.
+        let auto_refreshing_provider =
+            AutoRefreshingProvider::new(WebIdentityProvider::from_k8s_env())
+                .expect("Always returns Ok(...)");
+        AwsChainCredentialsProvider {
+            environment_provider: EnvironmentProvider::default(),
+            web_identity_provider: auto_refreshing_provider,
+        }
+    }
+}
+
+#[async_trait]
+impl ProvideAwsCredentials for AwsChainCredentialsProvider {
+    async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+        if let Ok(creds) = self.environment_provider.credentials().await {
+            Ok(creds)
+        } else {
+            // Propagate errors from the 'WebIdentityProvider'.
+            self.web_identity_provider.credentials().await
+        }
+    }
+}

--- a/rust/hyperlane-base/src/settings/mod.rs
+++ b/rust/hyperlane-base/src/settings/mod.rs
@@ -79,6 +79,8 @@ pub use base::*;
 pub use chains::{ChainConf, ChainConnectionConf, CoreContractAddresses};
 pub use signers::{RawSignerConf, SignerConf};
 
+/// AWS Credentials provider.
+pub(crate) mod aws_credentials;
 mod base;
 /// Chain configuration
 pub mod chains;

--- a/rust/hyperlane-base/src/settings/signers.rs
+++ b/rust/hyperlane-base/src/settings/signers.rs
@@ -1,12 +1,12 @@
 use async_trait::async_trait;
 use ethers::prelude::{AwsSigner, LocalWallet};
 use eyre::{bail, eyre, Context, Report};
-use rusoto_core::credential::EnvironmentProvider;
 use rusoto_core::{HttpClient, Region};
 use rusoto_kms::KmsClient;
 use serde::Deserialize;
 use tracing::instrument;
 
+use super::aws_credentials::AwsChainCredentialsProvider;
 use hyperlane_core::{config::*, H256};
 
 use crate::settings::KMS_CLIENT;
@@ -109,7 +109,7 @@ impl BuildableWithSignerConf for hyperlane_ethereum::Signers {
                 let client = KMS_CLIENT.get_or_init(|| {
                     KmsClient::new_with_client(
                         rusoto_core::Client::new_with(
-                            EnvironmentProvider::default(),
+                            AwsChainCredentialsProvider::new(),
                             HttpClient::new().unwrap(),
                         ),
                         region.clone(),

--- a/rust/hyperlane-base/src/types/s3_storage.rs
+++ b/rust/hyperlane-base/src/types/s3_storage.rs
@@ -7,12 +7,13 @@ use futures_util::TryStreamExt;
 use once_cell::sync::OnceCell;
 use prometheus::IntGauge;
 use rusoto_core::{
-    credential::{Anonymous, AwsCredentials, EnvironmentProvider, StaticProvider},
+    credential::{Anonymous, AwsCredentials, StaticProvider},
     HttpClient, Region, RusotoError,
 };
 use rusoto_s3::{GetObjectError, GetObjectRequest, PutObjectRequest, S3Client, S3};
 use tokio::time::timeout;
 
+use crate::settings::aws_credentials::AwsChainCredentialsProvider;
 use hyperlane_core::{SignedAnnouncement, SignedCheckpoint};
 
 use crate::CheckpointSyncer;
@@ -93,7 +94,7 @@ impl S3Storage {
         self.authenticated_client.get_or_init(|| {
             S3Client::new_with(
                 HttpClient::new().unwrap(),
-                EnvironmentProvider::default(),
+                AwsChainCredentialsProvider::new(),
                 self.region.clone(),
             )
         })


### PR DESCRIPTION
### Description

Support of web identity AWS credentials: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/2168

### Drive-by changes

`WebIdentityProvider` resides in `rusoto_sts`, I had to add a dependency on `rusoto_sts = "*"`.

### Backward compatibility

_Are these changes backward compatible?_

Yes. The newly added `AwsChainCredentialsProvider` preserves 100% compatibility with clients using `EnvironmentProvider`. We tested the following scenarios:
1) Run agent with `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` credentials — the current default behavior  — works as before.
2) Without envs from p.1 but with `AWS_WEB_IDENTITY_TOKEN_FILE` / `AWS_ROLE_ARN` / `AWS_ROLE_SESSION_NAME` injected by AWS EKS pod identity [webhook](https://github.com/aws/amazon-eks-pod-identity-webhook) — works well. We ran the agents for 24+ hours to make sure the JWT gets refreshed automatically.
3) Without any envs — the app expectedly fails with "environment variable not found" error.

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

Manual: we deployed a Hyperlane agent Docker image built from our [fork](https://github.com/tvl-labs/hyperlane-monorepo/pkgs/container/hyperlane-monorepo).