### PR TITLE
Lower L2 funding multiplier from 10 to 5

### DIFF
--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -480,7 +480,7 @@ class ContextFunder {
       const bridgeAmount = await this.getFundingAmount(
         chain,
         funderAddress,
-        desiredBalanceEther.mul(10),
+        desiredBalanceEther.mul(5),
       );
       if (bridgeAmount.gt(0)) {
         await this.bridgeToL2(chain as L2Chain, funderAddress, bridgeAmount);


### PR DESCRIPTION
### Description

We increased the desired balances for relayers on L2s significantly to 0.5. The target key funder balance for L2s was previously 10x the relayer target balance - we probably shouldn't be bridging over 5 ETH. This lowers the multiplier to 5, so that we shoot for a 2.5 ETH key funder balance on L2s

### Drive-by changes

none

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None
