### PR TITLE
feat(helm): Support configurable SecretStore type

### DIFF
--- a/rust/helm/agent-common/templates/_helpers.tpl
+++ b/rust/helm/agent-common/templates/_helpers.tpl
@@ -65,10 +65,10 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-The name of the ClusterSecretStore
+The name of the ClusterSecretStore/SecretStore
 */}}
-{{- define "agent-common.cluster-secret-store.name" -}}
-{{- default "external-secrets-gcp-cluster-secret-store" .Values.externalSecrets.clusterSecretStore }}
+{{- define "agent-common.secret-store.name" -}}
+{{- default "external-secrets-gcp-cluster-secret-store" .Values.externalSecrets.StoreName }}
 {{- end }}
 
 {{/*

--- a/rust/helm/hyperlane-agent/templates/external-secret.yaml
+++ b/rust/helm/hyperlane-agent/templates/external-secret.yaml
@@ -8,8 +8,8 @@ metadata:
     update-on-redeploy: "{{ now }}"
 spec:
   secretStoreRef:
-    name: {{ include "agent-common.cluster-secret-store.name" . }}
-    kind: ClusterSecretStore
+    name: {{ include "agent-common.secret-store.name" . }}
+    kind: {{ .Values.externalSecrets.StoreType }}
   refreshInterval: "1h"
   # The secret that will be created
   target:

--- a/rust/helm/hyperlane-agent/templates/relayer-external-secret.yaml
+++ b/rust/helm/hyperlane-agent/templates/relayer-external-secret.yaml
@@ -9,8 +9,8 @@ metadata:
     update-on-redeploy: "{{ now }}"
 spec:
   secretStoreRef:
-    name: {{ include "agent-common.cluster-secret-store.name" . }}
-    kind: ClusterSecretStore
+    name: {{ include "agent-common.secret-store.name" . }}
+    kind: {{ .Values.externalSecrets.StoreType }}
   refreshInterval: "1h"
   # The secret that will be created
   target:

--- a/rust/helm/hyperlane-agent/templates/scraper-external-secret.yaml
+++ b/rust/helm/hyperlane-agent/templates/scraper-external-secret.yaml
@@ -9,8 +9,8 @@ metadata:
     update-on-redeploy: "{{ now }}"
 spec:
   secretStoreRef:
-    name: {{ include "agent-common.cluster-secret-store.name" . }}
-    kind: ClusterSecretStore
+    name: {{ include "agent-common.secret-store.name" . }}
+    kind: {{ .Values.externalSecrets.StoreType }}
   refreshInterval: "1h"
   # The secret that will be created
   target:

--- a/rust/helm/hyperlane-agent/templates/validator-external-secret.yaml
+++ b/rust/helm/hyperlane-agent/templates/validator-external-secret.yaml
@@ -9,8 +9,8 @@ metadata:
     update-on-redeploy: "{{ now }}"
 spec:
   secretStoreRef:
-    name: {{ include "agent-common.cluster-secret-store.name" . }}
-    kind: ClusterSecretStore
+    name: {{ include "agent-common.secret-store.name" . }}
+    kind: {{ .Values.externalSecrets.StoreType }}
   refreshInterval: "1h"
   # The secret that will be created
   target:

--- a/rust/helm/hyperlane-agent/values.yaml
+++ b/rust/helm/hyperlane-agent/values.yaml
@@ -12,8 +12,11 @@ serviceAccount:
   annotations: {}
   name: ''
 
+# -- External Secret Store type and name
 externalSecrets:
-  clusterSecretStore:
+  # Available types: SecretStore, ClusterSecretStore
+  StoreType: ClusterSecretStore
+  StoreName:
 
 podAnnotations: {}
 podCommonLabels: {}


### PR DESCRIPTION
### Description

This PR makes the SecretStore type as configurable for all external secrets instead of using fixed `ClusterSecretStore` type.

### Drive-by changes

_Are there any minor or drive-by changes also included?_

### Related issues

- Fixes #[issue number here]

### Backward compatibility

_Are these changes backward compatible?_

No
`externalSecrets.clusterSecretStore` should be replaced with `externalSecrets.StoreName` in the values.

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

_What kind of testing have these changes undergone?_

Manual
