### PR TITLE
Multisig ISM discriminator instructions

### DIFF
--- a/rust/sealevel/Cargo.lock
+++ b/rust/sealevel/Cargo.lock
@@ -2148,6 +2148,7 @@ dependencies = [
  "hex",
  "hyperlane-core",
  "solana-program",
+ "spl-type-length-value",
  "thiserror",
 ]
 

--- a/rust/sealevel/libraries/multisig-ism/Cargo.toml
+++ b/rust/sealevel/libraries/multisig-ism/Cargo.toml
@@ -12,6 +12,12 @@ solana-program = "=1.14.13"
 hyperlane-core = { path = "../../hyperlane-core" }
 thiserror = "1.0"
 
+[dependencies.spl-type-length-value]
+version = "0.1.0"
+git = "https://github.com/tkporter/eclipse-program-library"
+branch = "trevor/steven/eclipse-1.14.13/with-tlv-lib"
+features = ["borsh"]
+
 [dev-dependencies]
 hex = "0.4.3"
 

--- a/rust/sealevel/libraries/multisig-ism/src/interface.rs
+++ b/rust/sealevel/libraries/multisig-ism/src/interface.rs
@@ -1,0 +1,69 @@
+use solana_program::program_error::ProgramError;
+use spl_type_length_value::discriminator::Discriminator;
+
+/// Instructions that a Hyperlane Multisig ISM is expected to process.
+/// The first 8 bytes of the encoded instruction is a discriminator that
+/// allows programs to implement the required interface.
+#[derive(Eq, PartialEq, Debug)]
+pub enum MultisigIsmInstruction {
+    ValidatorsAndThreshold,
+}
+
+/// First 8 bytes of `hash::hashv(&[b"hyperlane-multisig-ism:validators-and-threshold"])`
+const VALIDATORS_AND_THRESHOLD_DISCRIMINATOR: [u8; Discriminator::LENGTH] =
+    [82, 96, 5, 220, 241, 173, 13, 50];
+const VALIDATORS_AND_THRESHOLD_DISCRIMINATOR_SLICE: &[u8] = &VALIDATORS_AND_THRESHOLD_DISCRIMINATOR;
+
+// TODO implement hyperlane-core's Encode & Decode?
+impl MultisigIsmInstruction {
+    pub fn encode(&self) -> Result<Vec<u8>, ProgramError> {
+        let mut buf = vec![];
+        match self {
+            MultisigIsmInstruction::ValidatorsAndThreshold => {
+                buf.extend_from_slice(&VALIDATORS_AND_THRESHOLD_DISCRIMINATOR_SLICE[..]);
+            }
+        }
+
+        Ok(buf)
+    }
+
+    pub fn decode(buf: &[u8]) -> Result<Self, ProgramError> {
+        if buf.len() < Discriminator::LENGTH {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+        let (discriminator, _) = buf.split_at(Discriminator::LENGTH);
+        match discriminator {
+            VALIDATORS_AND_THRESHOLD_DISCRIMINATOR_SLICE => Ok(Self::ValidatorsAndThreshold),
+            _ => Err(ProgramError::InvalidInstructionData),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use solana_program::hash::hashv;
+
+    #[test]
+    fn test_discriminator_slices() {
+        assert_eq!(
+            &hashv(&[b"hyperlane-multisig-ism:validators-and-threshold"]).to_bytes()
+                [..Discriminator::LENGTH],
+            VALIDATORS_AND_THRESHOLD_DISCRIMINATOR_SLICE,
+        );
+    }
+
+    #[test]
+    fn test_encode_decode_validators_and_threshold_instruction() {
+        let instruction = MultisigIsmInstruction::ValidatorsAndThreshold;
+
+        let encoded = instruction.encode().unwrap();
+        assert_eq!(
+            &encoded[..Discriminator::LENGTH],
+            VALIDATORS_AND_THRESHOLD_DISCRIMINATOR_SLICE,
+        );
+
+        let decoded = MultisigIsmInstruction::decode(&encoded).unwrap();
+        assert_eq!(instruction, decoded);
+    }
+}

--- a/rust/sealevel/libraries/multisig-ism/src/interface.rs
+++ b/rust/sealevel/libraries/multisig-ism/src/interface.rs
@@ -6,7 +6,8 @@ use spl_type_length_value::discriminator::Discriminator;
 /// allows programs to implement the required interface.
 #[derive(Eq, PartialEq, Debug)]
 pub enum MultisigIsmInstruction {
-    ValidatorsAndThreshold,
+    // Gets the validators and threshold for the provided message.
+    ValidatorsAndThreshold(Vec<u8>),
 }
 
 /// First 8 bytes of `hash::hashv(&[b"hyperlane-multisig-ism:validators-and-threshold"])`
@@ -19,8 +20,9 @@ impl MultisigIsmInstruction {
     pub fn encode(&self) -> Result<Vec<u8>, ProgramError> {
         let mut buf = vec![];
         match self {
-            MultisigIsmInstruction::ValidatorsAndThreshold => {
+            MultisigIsmInstruction::ValidatorsAndThreshold(message) => {
                 buf.extend_from_slice(&VALIDATORS_AND_THRESHOLD_DISCRIMINATOR_SLICE[..]);
+                buf.extend_from_slice(&message[..]);
             }
         }
 
@@ -31,9 +33,12 @@ impl MultisigIsmInstruction {
         if buf.len() < Discriminator::LENGTH {
             return Err(ProgramError::InvalidInstructionData);
         }
-        let (discriminator, _) = buf.split_at(Discriminator::LENGTH);
+        let (discriminator, rest) = buf.split_at(Discriminator::LENGTH);
         match discriminator {
-            VALIDATORS_AND_THRESHOLD_DISCRIMINATOR_SLICE => Ok(Self::ValidatorsAndThreshold),
+            VALIDATORS_AND_THRESHOLD_DISCRIMINATOR_SLICE => {
+                let message = rest.to_vec();
+                Ok(Self::ValidatorsAndThreshold(message))
+            },
             _ => Err(ProgramError::InvalidInstructionData),
         }
     }
@@ -55,7 +60,7 @@ mod test {
 
     #[test]
     fn test_encode_decode_validators_and_threshold_instruction() {
-        let instruction = MultisigIsmInstruction::ValidatorsAndThreshold;
+        let instruction = MultisigIsmInstruction::ValidatorsAndThreshold(vec![1, 2, 3, 4, 5]);
 
         let encoded = instruction.encode().unwrap();
         assert_eq!(

--- a/rust/sealevel/libraries/multisig-ism/src/lib.rs
+++ b/rust/sealevel/libraries/multisig-ism/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod error;
+pub mod interface;
 pub mod multisig;
 pub mod signature;
 

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/src/instruction.rs
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/src/instruction.rs
@@ -15,11 +15,6 @@ pub enum Instruction {
     /// 1. `[writable]` The access control PDA account.
     /// 2. `[executable]` The system program account.
     Initialize,
-    /// Input: domain ID to query.
-    ///
-    /// Accounts:
-    /// 0. `[]` The PDA relating to the provided domain.
-    GetValidatorsAndThreshold(u32),
     /// Input: domain ID, validators, & threshold to set.
     ///
     /// Accounts:

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/src/processor.rs
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/src/processor.rs
@@ -22,10 +22,7 @@ use crate::{
 };
 
 use hyperlane_sealevel_interchain_security_module_interface::InterchainSecurityModuleInstruction;
-use multisig_ism::{
-    interface::MultisigIsmInstruction,
-    multisig::MultisigIsm,
-};
+use multisig_ism::{interface::MultisigIsmInstruction, multisig::MultisigIsm};
 
 use borsh::BorshSerialize;
 
@@ -106,8 +103,11 @@ pub fn process_instruction(
     // Next, try to decode the instruction as a multisig ISM instruction.
     if let Ok(multisig_ism_instruction) = MultisigIsmInstruction::decode(instruction_data) {
         return match multisig_ism_instruction {
-            MultisigIsmInstruction::ValidatorsAndThreshold => {
-                get_validators_and_threshold(program_id, accounts, 0)
+            // Gets the validators and threshold to verify the provided message.
+            MultisigIsmInstruction::ValidatorsAndThreshold(message_bytes) => {
+                let message = HyperlaneMessage::read_from(&mut &message_bytes[..])
+                    .map_err(|_| ProgramError::InvalidArgument)?;
+                get_validators_and_threshold(program_id, accounts, message.origin)
             }
         };
     }
@@ -115,10 +115,6 @@ pub fn process_instruction(
     match Instruction::try_from(instruction_data)? {
         // Initializes the program.
         Instruction::Initialize => initialize(program_id, accounts),
-        // Gets the validators and threshold for a given domain.
-        Instruction::GetValidatorsAndThreshold(domain) => {
-            get_validators_and_threshold(program_id, accounts, domain)
-        }
         // Sets the validators and threshold for a given domain.
         Instruction::SetValidatorsAndThreshold(config) => {
             set_validators_and_threshold(program_id, accounts, config)

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/src/processor.rs
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/src/processor.rs
@@ -22,7 +22,10 @@ use crate::{
 };
 
 use hyperlane_sealevel_interchain_security_module_interface::InterchainSecurityModuleInstruction;
-use multisig_ism::multisig::MultisigIsm;
+use multisig_ism::{
+    interface::MultisigIsmInstruction,
+    multisig::MultisigIsm,
+};
 
 use borsh::BorshSerialize;
 
@@ -97,6 +100,15 @@ pub fn process_instruction(
                 verify_data.metadata,
                 verify_data.message,
             ),
+        };
+    }
+
+    // Next, try to decode the instruction as a multisig ISM instruction.
+    if let Ok(multisig_ism_instruction) = MultisigIsmInstruction::decode(instruction_data) {
+        return match multisig_ism_instruction {
+            MultisigIsmInstruction::ValidatorsAndThreshold => {
+                get_validators_and_threshold(program_id, accounts, 0)
+            }
         };
     }
 

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/tests/functional.rs
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/tests/functional.rs
@@ -270,7 +270,7 @@ async fn test_set_validators_and_threshold_creates_pda_account() {
         }),
     );
 
-    // For good measure, let's also use the MultisigIsmProgramInstruction::ValidatorsAndThreshold
+    // For good measure, let's also use the MultisigIsmInstruction::ValidatorsAndThreshold
     // instruction!
 
     let test_message = HyperlaneMessage {


### PR DESCRIPTION
### Description

* #2253 for the Multisig ISM's validators and threshold instruction

### Drive-by changes

None

### Related issues

- Fixes #2253 - final PR for that transition

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Unit Tests
