### PR TITLE
Message recipient `handle` account meta getter instructions

### DIFF
--- a/rust/sealevel/libraries/message-recipient-interface/src/lib.rs
+++ b/rust/sealevel/libraries/message-recipient-interface/src/lib.rs
@@ -52,6 +52,16 @@ const HANDLE_ACCOUNT_METAS_DISCRIMINATOR: [u8; Discriminator::LENGTH] =
     [194, 141, 30, 82, 241, 41, 169, 52];
 const HANDLE_ACCOUNT_METAS_DISCRIMINATOR_SLICE: &[u8] = &HANDLE_ACCOUNT_METAS_DISCRIMINATOR;
 
+/// Seeds for the PDA that's expected to be passed into the `HandleAccountMetas`
+/// instruction.
+pub const HANDLE_ACCOUNT_METAS_PDA_SEEDS: &[&[u8]] = &[
+    b"hyperlane-message-recipient",
+    b"-",
+    b"handle",
+    b"-",
+    b"account_metas",
+];
+
 // TODO: does this even need to be implemented?
 impl TlvDiscriminator for HandleInstruction {
     const TLV_DISCRIMINATOR: Discriminator = Discriminator::new(HANDLE_DISCRIMINATOR);

--- a/rust/sealevel/programs/hyperlane-sealevel-token/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/src/processor.rs
@@ -159,6 +159,10 @@ pub fn process_instruction(
                     message: handle.message,
                 },
             ),
+            MessageRecipientInstruction::HandleAccountMetas(_) => {
+                // TODO: not implemented yet!
+                Ok(())
+            }
         };
     }
 

--- a/rust/sealevel/programs/recipient/echo/src/lib.rs
+++ b/rust/sealevel/programs/recipient/echo/src/lib.rs
@@ -50,6 +50,10 @@ pub fn process_instruction(
         MessageRecipientInstruction::Handle(instruction) => {
             handle(program_id, accounts, instruction)
         }
+        MessageRecipientInstruction::HandleAccountMetas(_) => {
+            // No additional accounts required!
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
### Description

Final component of #2254 

Still need to actually move warp routes over, but going to do that as a part of the effort in #2219 

### Drive-by changes

no

### Related issues

- Fixes #2254

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

_What kind of testing have these changes undergone?_

Unit Tests
