### PR TITLE
Relayer and Mailbox program supports fetching of recipient isms

### DIFF
--- a/rust/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/chains/hyperlane-sealevel/src/mailbox.rs
@@ -109,6 +109,7 @@ impl SealevelMailbox {
         self.outbox
     }
 
+    /// Simulates an Instruction that will return a list of AccountMetas.
     pub async fn get_account_metas(
         &self,
         instruction: Instruction,
@@ -157,6 +158,8 @@ impl SealevelMailbox {
         Ok(vec![])
     }
 
+    /// Gets the account metas required for the recipient's
+    /// `MessageRecipientInstruction::InterchainSecurityModule` instruction.
     pub async fn get_ism_getter_account_metas(
         &self,
         recipient_program_id: Pubkey,
@@ -179,6 +182,7 @@ impl SealevelMailbox {
         self.get_account_metas(instruction, payer).await
     }
 
+    /// Gets the account metas required for the recipient's `MessageRecipientInstruction::Handle` instruction.
     pub async fn get_handle_account_metas(
         &self,
         message: &HyperlaneMessage,

--- a/rust/sealevel/Cargo.lock
+++ b/rust/sealevel/Cargo.lock
@@ -1652,6 +1652,7 @@ dependencies = [
  "log",
  "num-derive",
  "num-traits",
+ "serializable-account-meta",
  "solana-program",
  "spl-noop",
  "testing_logger",

--- a/rust/sealevel/programs/hyperlane-sealevel-token-native/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-native/src/processor.rs
@@ -37,6 +37,10 @@ pub fn process_instruction(
                 );
                 Ok(())
             }
+            MessageRecipientInstruction::InterchainSecurityModuleAccountMetas => {
+                // No account metas are required, no return data necessary.
+                Ok(())
+            }
             MessageRecipientInstruction::Handle(handle) => transfer_from_remote(
                 program_id,
                 accounts,

--- a/rust/sealevel/programs/hyperlane-sealevel-token/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/src/processor.rs
@@ -37,6 +37,10 @@ pub fn process_instruction(
                 );
                 Ok(())
             }
+            MessageRecipientInstruction::InterchainSecurityModuleAccountMetas => {
+                // No account metas are required, no return data necessary.
+                Ok(())
+            }
             MessageRecipientInstruction::Handle(handle) => transfer_from_remote(
                 program_id,
                 accounts,

--- a/rust/sealevel/programs/mailbox/Cargo.toml
+++ b/rust/sealevel/programs/mailbox/Cargo.toml
@@ -13,6 +13,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "=1.14.13"
 thiserror = "1.0"
+serializable-account-meta = { path = "../../libraries/serializable-account-meta" }
 hyperlane-sealevel-message-recipient-interface = { path = "../../libraries/message-recipient-interface" }
 hyperlane-sealevel-interchain-security-module-interface = { path = "../../libraries/interchain-security-module-interface" }
 

--- a/rust/sealevel/programs/mailbox/src/accounts.rs
+++ b/rust/sealevel/programs/mailbox/src/accounts.rs
@@ -8,7 +8,7 @@ use solana_program::{
     account_info::AccountInfo, clock::Slot, program_error::ProgramError, pubkey::Pubkey,
 };
 
-use crate::{error::Error, DEFAULT_ISM, DEFAULT_ISM_ACCOUNTS};
+use crate::{error::Error, DEFAULT_ISM};
 
 pub trait SizedData {
     fn size(&self) -> usize;
@@ -137,8 +137,7 @@ pub struct Inbox {
     pub inbox_bump_seed: u8,
     // Note: 10MB account limit is around ~300k entries.
     pub delivered: HashSet<H256>,
-    pub ism: Pubkey,
-    pub ism_accounts: Vec<Pubkey>,
+    pub default_ism: Pubkey,
 }
 
 impl Default for Inbox {
@@ -147,12 +146,7 @@ impl Default for Inbox {
             local_domain: 0,
             inbox_bump_seed: 0,
             delivered: Default::default(),
-            // TODO can declare_id!() or similar be used for these to compute at compile time?
-            ism: Pubkey::from_str(DEFAULT_ISM).unwrap(),
-            ism_accounts: DEFAULT_ISM_ACCOUNTS
-                .iter()
-                .map(|account| Pubkey::from_str(account).unwrap())
-                .collect(),
+            default_ism: Pubkey::from_str(DEFAULT_ISM).unwrap(),
         }
     }
 }

--- a/rust/sealevel/programs/mailbox/src/instruction.rs
+++ b/rust/sealevel/programs/mailbox/src/instruction.rs
@@ -15,6 +15,7 @@ pub enum Instruction {
     Init(Init),
     InboxProcess(InboxProcess),
     InboxSetDefaultModule(InboxSetDefaultModule),
+    InboxGetRecipientIsm(u32, Pubkey),
     OutboxDispatch(OutboxDispatch),
     OutboxGetCount(OutboxQuery),
     OutboxGetLatestCheckpoint(OutboxQuery),

--- a/rust/sealevel/programs/mailbox/src/lib.rs
+++ b/rust/sealevel/programs/mailbox/src/lib.rs
@@ -18,4 +18,3 @@ solana_program::declare_id!("692KZJaoe2KRcD6uhCQDLLXnLNA5ZLnfvdqjE4aX9iu1");
 
 // FIXME set a sane default
 pub(crate) static DEFAULT_ISM: &str = "F6dVnLFioQ8hKszqPsmjWPwHn2dJfebgMfztWrzL548V";
-pub(crate) static DEFAULT_ISM_ACCOUNTS: &[&str] = &[];

--- a/rust/sealevel/programs/mailbox/src/lib.rs
+++ b/rust/sealevel/programs/mailbox/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod accounts;
 pub mod error;
 pub mod instruction;
+pub mod pda_seeds;
 pub mod processor;
 
 pub use hyperlane_core;

--- a/rust/sealevel/programs/mailbox/src/pda_seeds.rs
+++ b/rust/sealevel/programs/mailbox/src/pda_seeds.rs
@@ -1,0 +1,119 @@
+//! This file contains the PDA seeds for the Mailbox program.
+
+/// PDA seeds for the Inbox account.
+#[macro_export]
+macro_rules! mailbox_inbox_pda_seeds {
+    ($local_domain:expr) => {{
+        &[
+            b"hyperlane",
+            b"-",
+            &$local_domain.to_le_bytes(),
+            b"-",
+            b"inbox",
+        ]
+    }};
+
+    ($local_domain:expr, $bump_seed:expr) => {{
+        &[
+            b"hyperlane",
+            b"-",
+            &$local_domain.to_le_bytes(),
+            b"-",
+            b"inbox",
+            &[$bump_seed],
+        ]
+    }};
+}
+
+/// PDA seeds for the Outbox account.
+#[macro_export]
+macro_rules! mailbox_outbox_pda_seeds {
+    ($local_domain:expr) => {{
+        &[
+            b"hyperlane",
+            b"-",
+            &$local_domain.to_le_bytes(),
+            b"-",
+            b"outbox",
+        ]
+    }};
+
+    ($local_domain:expr, $bump_seed:expr) => {{
+        &[
+            b"hyperlane",
+            b"-",
+            &$local_domain.to_le_bytes(),
+            b"-",
+            b"outbox",
+            &[$bump_seed],
+        ]
+    }};
+}
+
+/// Gets the PDA seeds for a message storage account that's
+/// based upon the pubkey of a unique message account.
+#[macro_export]
+macro_rules! mailbox_dispatched_message_pda_seeds {
+    ($unique_message_pubkey:expr) => {{
+        &[
+            b"hyperlane",
+            b"-",
+            b"dispatched_message",
+            b"-",
+            $unique_message_pubkey.as_ref(),
+        ]
+    }};
+
+    ($unique_message_pubkey:expr, $bump_seed:expr) => {{
+        &[
+            b"hyperlane",
+            b"-",
+            b"dispatched_message",
+            b"-",
+            $unique_message_pubkey.as_ref(),
+            &[$bump_seed],
+        ]
+    }};
+}
+
+/// The PDA seeds relating to a program's dispatch authority.
+#[macro_export]
+macro_rules! mailbox_message_dispatch_authority_pda_seeds {
+    () => {{
+        &[b"hyperlane_dispatcher", b"-", b"dispatch_authority"]
+    }};
+
+    ($bump_seed:expr) => {{
+        &[
+            b"hyperlane_dispatcher",
+            b"-",
+            b"dispatch_authority",
+            &[$bump_seed],
+        ]
+    }};
+}
+
+/// The PDA seeds relating to the Mailbox's process authority for a particular recipient.
+#[macro_export]
+macro_rules! mailbox_process_authority_pda_seeds {
+    ($recipient_pubkey:expr) => {{
+        &[
+            b"hyperlane",
+            b"-",
+            b"process_authority",
+            b"-",
+            $recipient_pubkey.as_ref(),
+        ]
+    }};
+
+    ($recipient_pubkey:expr, $bump_seed:expr) => {{
+        &[
+            b"hyperlane",
+            b"-",
+            b"process_authority",
+            b"-",
+            $recipient_pubkey.as_ref(),
+            &[$bump_seed],
+        ]
+    }};
+}

--- a/rust/sealevel/programs/mailbox/src/processor.rs
+++ b/rust/sealevel/programs/mailbox/src/processor.rs
@@ -34,126 +34,13 @@ use crate::{
         InboxProcess, InboxSetDefaultModule, Init, Instruction as MailboxIxn, OutboxDispatch,
         OutboxQuery, MAX_MESSAGE_BODY_BYTES, VERSION,
     },
+    mailbox_dispatched_message_pda_seeds, mailbox_inbox_pda_seeds,
+    mailbox_message_dispatch_authority_pda_seeds, mailbox_outbox_pda_seeds,
+    mailbox_process_authority_pda_seeds,
 };
 
 #[cfg(not(feature = "no-entrypoint"))]
 entrypoint!(process_instruction);
-
-#[macro_export]
-macro_rules! mailbox_inbox_pda_seeds {
-    ($local_domain:expr) => {{
-        &[
-            b"hyperlane",
-            b"-",
-            &$local_domain.to_le_bytes(),
-            b"-",
-            b"inbox",
-        ]
-    }};
-
-    ($local_domain:expr, $bump_seed:expr) => {{
-        &[
-            b"hyperlane",
-            b"-",
-            &$local_domain.to_le_bytes(),
-            b"-",
-            b"inbox",
-            &[$bump_seed],
-        ]
-    }};
-}
-
-#[macro_export]
-macro_rules! mailbox_outbox_pda_seeds {
-    ($local_domain:expr) => {{
-        &[
-            b"hyperlane",
-            b"-",
-            &$local_domain.to_le_bytes(),
-            b"-",
-            b"outbox",
-        ]
-    }};
-
-    ($local_domain:expr, $bump_seed:expr) => {{
-        &[
-            b"hyperlane",
-            b"-",
-            &$local_domain.to_le_bytes(),
-            b"-",
-            b"outbox",
-            &[$bump_seed],
-        ]
-    }};
-}
-
-/// Gets the PDA seeds for a message storage account that's
-/// based upon the pubkey of a unique message account.
-#[macro_export]
-macro_rules! mailbox_dispatched_message_pda_seeds {
-    ($unique_message_pubkey:expr) => {{
-        &[
-            b"hyperlane",
-            b"-",
-            b"dispatched_message",
-            b"-",
-            $unique_message_pubkey.as_ref(),
-        ]
-    }};
-
-    ($unique_message_pubkey:expr, $bump_seed:expr) => {{
-        &[
-            b"hyperlane",
-            b"-",
-            b"dispatched_message",
-            b"-",
-            $unique_message_pubkey.as_ref(),
-            &[$bump_seed],
-        ]
-    }};
-}
-
-/// The PDA seeds relating to a program's dispatch authority.
-#[macro_export]
-macro_rules! mailbox_message_dispatch_authority_pda_seeds {
-    () => {{
-        &[b"hyperlane_dispatcher", b"-", b"dispatch_authority"]
-    }};
-
-    ($bump_seed:expr) => {{
-        &[
-            b"hyperlane_dispatcher",
-            b"-",
-            b"dispatch_authority",
-            &[$bump_seed],
-        ]
-    }};
-}
-
-/// The PDA seeds relating to the Mailbox's process authority for a particular recipient.
-#[macro_export]
-macro_rules! mailbox_process_authority_pda_seeds {
-    ($recipient_pubkey:expr) => {{
-        &[
-            b"hyperlane",
-            b"-",
-            b"process_authority",
-            b"-",
-            $recipient_pubkey.as_ref(),
-        ]
-    }};
-
-    ($recipient_pubkey:expr, $bump_seed:expr) => {{
-        &[
-            b"hyperlane",
-            b"-",
-            b"process_authority",
-            b"-",
-            $recipient_pubkey.as_ref(),
-            &[$bump_seed],
-        ]
-    }};
-}
 
 pub fn process_instruction(
     program_id: &Pubkey,
@@ -978,7 +865,7 @@ mod test {
 
         process_instruction(&mailbox_program_id, &accounts, &instruction_data).unwrap();
         testing_logger::validate(|logs| {
-            assert_eq!(logs.len(), 4);
+            assert_eq!(logs.len(), 5);
             assert_eq!(logs[0].level, log::Level::Info);
             assert_eq!(
                 logs[0].body,
@@ -997,6 +884,11 @@ mod test {
             assert_eq!(logs[3].level, log::Level::Info);
             assert_eq!(
                 logs[3].body,
+                "SyscallStubs: sol_invoke_signed() not available"
+            );
+            assert_eq!(logs[4].level, log::Level::Info);
+            assert_eq!(
+                logs[4].body,
                 format!("Hyperlane inbox processed message {:?}", message.id()),
             );
         });

--- a/rust/sealevel/programs/mailbox/src/processor.rs
+++ b/rust/sealevel/programs/mailbox/src/processor.rs
@@ -1,5 +1,6 @@
 //! Entrypoint, dispatch, and execution for the Hyperlane Sealevel mailbox instruction.
 
+use borsh::BorshDeserialize;
 use hyperlane_core::{Decode, Encode, HyperlaneMessage, H256};
 #[cfg(not(feature = "no-entrypoint"))]
 use solana_program::entrypoint;
@@ -9,7 +10,7 @@ use solana_program::{
     entrypoint::ProgramResult,
     instruction::{AccountMeta, Instruction},
     msg,
-    program::{invoke, invoke_signed, set_return_data},
+    program::{get_return_data, invoke, invoke_signed, set_return_data},
     program_error::ProgramError,
     pubkey::Pubkey,
     system_instruction,
@@ -244,13 +245,14 @@ fn initialize(program_id: &Pubkey, accounts: &[AccountInfo], init: Init) -> Prog
 /// Process a message.
 ///
 // Accounts:
-// 0.     [writable] Inbox PDA
-// 1.     [] Mailbox process authority for the message recipient.
-// 2.     [executable] SPL noop
-// 3.     [executable] ISM
-// 4..N.  [??] ISM accounts, if present
-// N+1.   [executable] Recipient program
-// N+2..M [??] Recipient accounts
+// 0.      [writable] Inbox PDA
+// 1.      [] Mailbox process authority for the message recipient.
+// 2..N    [??] Accounts required to invoke the recipient's InterchainSecurityModule instruction.
+// N+1.    [executable] SPL noop
+// N+2.    [executable] ISM
+// N+2..M. [??] ISM accounts, if present
+// M+1.    [executable] Recipient program
+// M+2..K. [??] Recipient accounts
 fn inbox_process(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -260,7 +262,6 @@ fn inbox_process(
 
     let message = HyperlaneMessage::read_from(&mut std::io::Cursor::new(&process.message))
         .map_err(|_| ProgramError::from(Error::MalformattedHyperlaneMessage))?;
-    // TODO remove?
     if message.version != VERSION {
         return Err(ProgramError::from(Error::UnsupportedMessageVersion));
     }
@@ -295,20 +296,54 @@ fn inbox_process(
         return Err(ProgramError::InvalidArgument);
     }
 
-    // Account 2: SPL Noop program.
+    let spl_noop_id = spl_noop::id();
+
+    // Accounts 2..N: the accounts required for getting the ISM the recipient wants to use.
+    let mut get_ism_accounts = vec![];
+    let mut get_ism_account_metas = vec![];
+    loop {
+        // Expect there to always be a new account as we loop through it
+        // because there are accounts after the ISM accounts that are expected.
+        let next_account = accounts_iter.peek().ok_or(ProgramError::InvalidArgument)?;
+        // We expect the account after this list of accounts to be the SPL noop.
+        if next_account.key == &spl_noop_id {
+            break;
+        }
+
+        let account = next_account_info(accounts_iter)?;
+        let meta = AccountMeta {
+            pubkey: *account.key,
+            is_signer: account.is_signer,
+            is_writable: account.is_writable,
+        };
+
+        get_ism_accounts.push(account.clone());
+        get_ism_account_metas.push(meta);
+    }
+
+    // Call into the recipient program to get the ISM to use.
+    let ism = get_recipient_ism(
+        &recipient_program_id,
+        get_ism_accounts,
+        get_ism_account_metas,
+        inbox.ism,
+    )?;
+
+    // Account N: SPL Noop program.
     let spl_noop = next_account_info(accounts_iter)?;
-    if spl_noop.key != &spl_noop::id() || !spl_noop.executable {
+    if spl_noop.key != &spl_noop_id || !spl_noop.executable {
         return Err(ProgramError::InvalidArgument);
     }
 
-    // Account 3: The ISM.
-    // TODO get this from the recipient!
+    // Account N+1: The ISM.
     let ism_account = next_account_info(accounts_iter)?;
-    if &inbox.ism != ism_account.key {
+    if &ism != ism_account.key {
         return Err(ProgramError::from(Error::AccountOutOfOrder));
     }
-    let mut ism_accounts = vec![];
-    let mut ism_account_metas = vec![];
+
+    // Account N+2..M: The accounts required for ISM verification.
+    let mut ism_verify_accounts = vec![];
+    let mut ism_verify_account_metas = vec![];
     loop {
         // Expect there to always be a new account as we loop through it
         // because there are accounts after the ISM accounts that are expected.
@@ -323,15 +358,17 @@ fn inbox_process(
             is_signer: info.is_signer,
             is_writable: info.is_writable,
         };
-        ism_accounts.push(info.clone());
-        ism_account_metas.push(meta);
+        ism_verify_accounts.push(info.clone());
+        ism_verify_account_metas.push(meta);
     }
 
-    // Account N+1: The recipient program.
+    // Account M+1: The recipient program.
     let recipient_account = next_account_info(accounts_iter)?;
     if &recipient_program_id != recipient_account.key || !recipient_account.executable {
         return Err(ProgramError::from(Error::AccountOutOfOrder));
     }
+
+    // Account M+2..K: The accounts required for the recipient program handler.
     let mut recp_accounts = vec![process_authority_account.clone()];
     let mut recp_account_metas = vec![AccountMeta {
         pubkey: *process_authority_account.key,
@@ -352,11 +389,14 @@ fn inbox_process(
         metadata: process.metadata,
         message: process.message,
     });
-    let verify =
-        Instruction::new_with_bytes(inbox.ism, &verify_instruction.encode()?, ism_account_metas);
-    invoke(&verify, &ism_accounts)?;
+    let verify = Instruction::new_with_bytes(
+        inbox.ism,
+        &verify_instruction.encode()?,
+        ism_verify_account_metas,
+    );
+    invoke(&verify, &ism_verify_accounts)?;
 
-    // Mark the message as delivered
+    // Mark the message as delivered.
     let id = message.id();
     if inbox.delivered.contains(&id) {
         return Err(ProgramError::from(Error::DuplicateMessage));
@@ -370,7 +410,7 @@ fn inbox_process(
         message.body,
     ));
     let recieve = Instruction::new_with_bytes(
-        message.recipient.0.into(),
+        recipient_program_id,
         &recp_ixn.encode()?,
         recp_account_metas,
     );
@@ -396,6 +436,44 @@ fn inbox_process(
     // FIXME store before or after recipient cpi? What if fail to write but recipient cpi okay?
     InboxAccount::from(inbox).store(inbox_account, true)?;
     Ok(())
+}
+
+/// Get the ISM to use for a recipient program.
+///
+/// Expects `account_infos` and `account_metas` to be those required
+/// to make the CPI into the recipient program with the InterchainSecurityModule
+/// instruction.
+fn get_recipient_ism(
+    recipient_program_id: &Pubkey,
+    account_infos: Vec<AccountInfo>,
+    account_metas: Vec<AccountMeta>,
+    default_ism: Pubkey,
+) -> Result<Pubkey, ProgramError> {
+    let get_ism = MessageRecipientInstruction::InterchainSecurityModule;
+    let get_ism_instruction = Instruction::new_with_bytes(
+        recipient_program_id.clone(),
+        &get_ism.encode()?,
+        account_metas,
+    );
+    invoke(&get_ism_instruction, &account_infos)?;
+
+    // Default to the default ISM.
+    let ism = if let Some((returning_program_id, returned_data)) = get_return_data() {
+        if &returning_program_id != recipient_program_id {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        // If the recipient program returned data, use that as the ISM.
+        // If they returned an encoded Option::<Pubkey>::None, then use
+        // the default ISM.
+        Option::<Pubkey>::try_from_slice(&returned_data[..])
+            .map_err(|err| ProgramError::BorshIoError(err.to_string()))?
+            .unwrap_or(default_ism)
+    } else {
+        // If no return data, default to the default ISM.
+        default_ism
+    };
+
+    Ok(ism)
 }
 
 // TODO: must be onlyOwner


### PR DESCRIPTION
### Description

* Fixes #2209 
* The relayer doesn't yet get the list of account metas that the ISM.verify instruction uses - this is coming next!
* Removes the ism / ism_accounts from the Inbox data & replaces with just "default_ism"

### Drive-by changes
no
### Related issues

- Fixes #2209

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Unit Tests & ran end to end locally 😎 
