### PR TITLE
Add access control library, make Mailbox default ISM setting only owner

### DIFF
--- a/rust/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/chains/hyperlane-sealevel/src/mailbox.rs
@@ -850,6 +850,7 @@ mod contract {
     pub struct Outbox {
         pub local_domain: u32,
         pub outbox_bump_seed: u8,
+        pub owner: Option<Pubkey>,
         pub tree: MerkleTree,
     }
 

--- a/rust/sealevel/Cargo.lock
+++ b/rust/sealevel/Cargo.lock
@@ -1651,6 +1651,7 @@ dependencies = [
 name = "hyperlane-sealevel-mailbox"
 version = "0.1.0"
 dependencies = [
+ "access-control",
  "base64 0.13.1",
  "borsh",
  "bs58",

--- a/rust/sealevel/Cargo.lock
+++ b/rust/sealevel/Cargo.lock
@@ -13,6 +13,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "access-control"
+version = "0.1.0"
+dependencies = [
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,6 +1682,7 @@ dependencies = [
 name = "hyperlane-sealevel-multisig-ism-message-id"
 version = "0.1.0"
 dependencies = [
+ "access-control",
  "borsh",
  "hex",
  "hyperlane-core",

--- a/rust/sealevel/Cargo.toml
+++ b/rust/sealevel/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "programs/ism/multisig-ism-message-id",
     "programs/hyperlane-sealevel-token",
     "programs/hyperlane-sealevel-token-native",
+    "libraries/access-control",
     "libraries/interchain-security-module-interface",
     "libraries/message-recipient-interface",
     "libraries/multisig-ism",

--- a/rust/sealevel/libraries/access-control/Cargo.toml
+++ b/rust/sealevel/libraries/access-control/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "access-control"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+no-entrypoint = []
+
+[dependencies]
+solana-program = "=1.14.13"
+
+[dev-dependencies]
+solana-program-test = "=1.14.13"
+solana-sdk = "=1.14.13"
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/rust/sealevel/libraries/access-control/src/lib.rs
+++ b/rust/sealevel/libraries/access-control/src/lib.rs
@@ -1,0 +1,190 @@
+use solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
+
+pub trait AccessControl {
+    fn owner(&self) -> Option<&Pubkey>;
+
+    /// Returns Ok(()) if `maybe_owner` is the owner and is a signer.
+    fn ensure_owner_signer(&self, maybe_owner: &AccountInfo) -> Result<(), ProgramError> {
+        // Owner cannot be None.
+        let owner = self.owner().ok_or(ProgramError::InvalidArgument)?;
+
+        if !maybe_owner.is_signer {
+            return Err(ProgramError::MissingRequiredSignature);
+        }
+        if owner != maybe_owner.key {
+            return Err(ProgramError::InvalidArgument);
+        }
+        Ok(())
+    }
+
+    /// Note this does not check that the existing owner is a signer,
+    /// nor does it serialize the change to the account.
+    fn set_owner(&mut self, new_owner: Option<Pubkey>) -> Result<(), ProgramError>;
+
+    /// Sets ownership if the `existing_owner` is the current owner and is a signer.
+    /// Errors if `existing_owner` is not a signer or is not the current owner.
+    /// Note this does not serialize the change to the account.
+    fn transfer_ownership(
+        &mut self,
+        maybe_existing_owner: &AccountInfo,
+        new_owner: Option<Pubkey>,
+    ) -> Result<(), ProgramError> {
+        self.ensure_owner_signer(maybe_existing_owner)?;
+        self.set_owner(new_owner)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    struct TestAccessControl {
+        owner: Option<Pubkey>,
+    }
+
+    impl AccessControl for TestAccessControl {
+        fn owner(&self) -> Option<&Pubkey> {
+            self.owner.as_ref()
+        }
+
+        fn set_owner(&mut self, new_owner: Option<Pubkey>) -> Result<(), ProgramError> {
+            self.owner = new_owner;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_ensure_owner_signer() {
+        let owner = Pubkey::new_unique();
+        let access_control = TestAccessControl { owner: Some(owner) };
+
+        let mut owner_account_lamports = 0;
+        let mut owner_account_data = vec![0; 0];
+        // Is a signer and the owner
+        let owner_account_info = AccountInfo::new(
+            &owner,
+            true,
+            false,
+            &mut owner_account_lamports,
+            &mut owner_account_data,
+            &owner,
+            false,
+            0,
+        );
+        assert_eq!(
+            access_control.ensure_owner_signer(&owner_account_info),
+            Ok(())
+        );
+
+        // Not a signer, is the owner
+        let owner_account_info = AccountInfo::new(
+            &owner,
+            false,
+            false,
+            &mut owner_account_lamports,
+            &mut owner_account_data,
+            &owner,
+            false,
+            0,
+        );
+        assert_eq!(
+            access_control.ensure_owner_signer(&owner_account_info),
+            Err(ProgramError::MissingRequiredSignature),
+        );
+
+        // Is a signer, not the owner
+        let non_owner = Pubkey::new_unique();
+        let owner_account_info = AccountInfo::new(
+            &non_owner,
+            true,
+            false,
+            &mut owner_account_lamports,
+            &mut owner_account_data,
+            &owner,
+            false,
+            0,
+        );
+        assert_eq!(
+            access_control.ensure_owner_signer(&owner_account_info),
+            Err(ProgramError::InvalidArgument),
+        );
+    }
+
+    #[test]
+    fn test_transfer_ownership() {
+        let owner = Pubkey::new_unique();
+        let mut access_control = TestAccessControl { owner: Some(owner) };
+
+        let mut owner_account_lamports = 0;
+        let mut owner_account_data = vec![0; 0];
+        // Is a signer and the owner
+        let owner_account_info = AccountInfo::new(
+            &owner,
+            true,
+            false,
+            &mut owner_account_lamports,
+            &mut owner_account_data,
+            &owner,
+            false,
+            0,
+        );
+
+        let new_owner = Pubkey::new_unique();
+        // Transfer ownership to new_owner
+        assert_eq!(
+            access_control.transfer_ownership(&owner_account_info, Some(new_owner)),
+            Ok(())
+        );
+        assert_eq!(access_control.owner, Some(new_owner));
+
+        // Now the old owner shouldn't be able to transfer ownership anymore
+        assert_eq!(
+            access_control.transfer_ownership(&owner_account_info, Some(new_owner)),
+            Err(ProgramError::InvalidArgument),
+        );
+
+        // The new owner now, but not a signer
+        let owner_account_info = AccountInfo::new(
+            &new_owner,
+            false,
+            false,
+            &mut owner_account_lamports,
+            &mut owner_account_data,
+            &owner,
+            false,
+            0,
+        );
+
+        // Ensure it can't transfer ownership because it's not a signer
+        assert_eq!(
+            access_control.transfer_ownership(&owner_account_info, None),
+            Err(ProgramError::MissingRequiredSignature),
+        );
+
+        // The new owner now, but a signer
+        let owner_account_info = AccountInfo::new(
+            &new_owner,
+            true,
+            false,
+            &mut owner_account_lamports,
+            &mut owner_account_data,
+            &owner,
+            false,
+            0,
+        );
+
+        // Transfer ownership to None
+        assert_eq!(
+            access_control.transfer_ownership(&owner_account_info, None),
+            Ok(())
+        );
+        assert_eq!(access_control.owner, None);
+
+        // Now the "new owner" shouldn't be able to transfer ownership anymore
+        // because the owner is None
+        assert_eq!(
+            access_control.transfer_ownership(&owner_account_info, None),
+            Err(ProgramError::InvalidArgument),
+        );
+    }
+}

--- a/rust/sealevel/libraries/access-control/src/lib.rs
+++ b/rust/sealevel/libraries/access-control/src/lib.rs
@@ -1,4 +1,4 @@
-use solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
+use solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, msg};
 
 pub trait AccessControl {
     fn owner(&self) -> Option<&Pubkey>;
@@ -30,7 +30,9 @@ pub trait AccessControl {
         new_owner: Option<Pubkey>,
     ) -> Result<(), ProgramError> {
         self.ensure_owner_signer(maybe_existing_owner)?;
-        self.set_owner(new_owner)
+        self.set_owner(new_owner)?;
+        msg!("Ownership transferred to {:?}", new_owner);
+        Ok(())
     }
 }
 

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/Cargo.toml
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/Cargo.toml
@@ -12,6 +12,7 @@ multisig-ism = { path = "../../../libraries/multisig-ism" }
 num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "=1.14.13"
+access-control = { path = "../../../libraries/access-control" }
 hyperlane-core = { path = "../../../hyperlane-core" }
 hyperlane-sealevel-mailbox = { path = "../../mailbox", features = ["no-entrypoint"] }
 hyperlane-sealevel-interchain-security-module-interface = { path = "../../../libraries/interchain-security-module-interface" }

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/src/accounts.rs
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/src/accounts.rs
@@ -43,3 +43,18 @@ impl AccessControlData {
 }
 
 pub type AccessControlAccount = AccountData<AccessControlData>;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_access_control_data_size() {
+        let data = AccessControlData {
+            bump_seed: 0,
+            owner: Pubkey::new_unique(),
+        };
+        let serialized = data.try_to_vec().unwrap();
+        assert_eq!(data.size(), serialized.len());
+    }
+}

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/src/accounts.rs
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/src/accounts.rs
@@ -1,9 +1,10 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 
+use access_control::AccessControl;
 use hyperlane_sealevel_mailbox::accounts::{AccountData, SizedData};
-use solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
+use solana_program::{program_error::ProgramError, pubkey::Pubkey};
 
-use crate::{error::Error, instruction::ValidatorsAndThreshold};
+use crate::instruction::ValidatorsAndThreshold;
 
 /// The data of a "domain data" PDA account.
 /// One of these exists for each domain that's been enrolled.
@@ -19,25 +20,23 @@ pub type DomainDataAccount = AccountData<DomainData>;
 #[derive(BorshSerialize, BorshDeserialize, Debug, Default, PartialEq)]
 pub struct AccessControlData {
     pub bump_seed: u8,
-    pub owner: Pubkey,
+    pub owner: Option<Pubkey>,
 }
 
 impl SizedData for AccessControlData {
     fn size(&self) -> usize {
-        // 1 byte bump seed + 32 byte owner pubkey
-        1 + 32
+        // 1 byte bump seed + 1 byte Option variant + 32 byte owner pubkey
+        1 + 1 + 32
     }
 }
 
-impl AccessControlData {
-    pub fn ensure_owner_signer(&self, maybe_owner: &AccountInfo) -> Result<(), ProgramError> {
-        if !maybe_owner.is_signer {
-            return Err(ProgramError::MissingRequiredSignature);
-        }
+impl AccessControl for AccessControlData {
+    fn owner(&self) -> Option<&Pubkey> {
+        self.owner.as_ref()
+    }
 
-        if self.owner != *maybe_owner.key {
-            return Err(Error::AccountNotOwner.into());
-        }
+    fn set_owner(&mut self, new_owner: Option<Pubkey>) -> Result<(), ProgramError> {
+        self.owner = new_owner;
         Ok(())
     }
 }
@@ -52,7 +51,7 @@ mod test {
     fn test_access_control_data_size() {
         let data = AccessControlData {
             bump_seed: 0,
-            owner: Pubkey::new_unique(),
+            owner: Some(Pubkey::new_unique()),
         };
         let serialized = data.try_to_vec().unwrap();
         assert_eq!(data.size(), serialized.len());

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/src/instruction.rs
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/src/instruction.rs
@@ -33,7 +33,7 @@ pub enum Instruction {
     /// Accounts:
     /// 0. `[signer]` The current access control owner.
     /// 1. `[]` The access control PDA account.
-    SetOwner(Option<Pubkey>),
+    TransferOwnership(Option<Pubkey>),
 }
 
 impl TryFrom<&[u8]> for Instruction {

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/src/instruction.rs
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/src/instruction.rs
@@ -33,7 +33,7 @@ pub enum Instruction {
     /// Accounts:
     /// 0. `[signer]` The current access control owner.
     /// 1. `[]` The access control PDA account.
-    SetOwner(Pubkey),
+    SetOwner(Option<Pubkey>),
 }
 
 impl TryFrom<&[u8]> for Instruction {

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/src/processor.rs
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/src/processor.rs
@@ -167,7 +167,9 @@ pub fn process_instruction(
         // Gets the owner of this program from the access control account.
         Instruction::GetOwner => get_owner(program_id, accounts),
         // Sets the owner of this program in the access control account.
-        Instruction::SetOwner(new_owner) => set_owner(program_id, accounts, new_owner),
+        Instruction::TransferOwnership(new_owner) => {
+            transfer_ownership(program_id, accounts, new_owner)
+        }
     }
 }
 
@@ -503,12 +505,12 @@ fn access_control_data(
     Ok(*access_control_data)
 }
 
-/// Sets a new access control owner.
+/// Transfers ownership to a new access control owner.
 ///
 /// Accounts:
 /// 0. `[signer]` The current access control owner.
 /// 1. `[]` The access control PDA account.
-fn set_owner(
+fn transfer_ownership(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     new_owner: Option<Pubkey>,
@@ -696,7 +698,7 @@ pub mod test {
     }
 
     #[test]
-    fn test_set_owner() {
+    fn test_transfer_ownership() {
         let program_id = id();
 
         let owner_key = Pubkey::new_unique();
@@ -748,7 +750,7 @@ pub mod test {
         let result = process_instruction(
             &program_id,
             &accounts,
-            Instruction::SetOwner(Some(new_owner_key))
+            Instruction::TransferOwnership(Some(new_owner_key))
                 .try_to_vec()
                 .unwrap()
                 .as_slice(),
@@ -761,7 +763,7 @@ pub mod test {
         process_instruction(
             &program_id,
             &accounts,
-            Instruction::SetOwner(Some(new_owner_key))
+            Instruction::TransferOwnership(Some(new_owner_key))
                 .try_to_vec()
                 .unwrap()
                 .as_slice(),
@@ -784,7 +786,7 @@ pub mod test {
         let result = process_instruction(
             &program_id,
             &accounts,
-            Instruction::SetOwner(Some(new_owner_key))
+            Instruction::TransferOwnership(Some(new_owner_key))
                 .try_to_vec()
                 .unwrap()
                 .as_slice(),

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/tests/functional.rs
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/tests/functional.rs
@@ -151,7 +151,7 @@ async fn test_initialize() {
         access_control,
         Box::new(AccessControlData {
             bump_seed: access_control_pda_bump_seed,
-            owner: payer.pubkey(),
+            owner: Some(payer.pubkey()),
         }),
     );
 }

--- a/rust/sealevel/programs/mailbox/Cargo.toml
+++ b/rust/sealevel/programs/mailbox/Cargo.toml
@@ -13,6 +13,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "=1.14.13"
 thiserror = "1.0"
+access-control = { path = "../../libraries/access-control" }
 serializable-account-meta = { path = "../../libraries/serializable-account-meta" }
 hyperlane-sealevel-message-recipient-interface = { path = "../../libraries/message-recipient-interface" }
 hyperlane-sealevel-interchain-security-module-interface = { path = "../../libraries/interchain-security-module-interface" }

--- a/rust/sealevel/programs/mailbox/src/accounts.rs
+++ b/rust/sealevel/programs/mailbox/src/accounts.rs
@@ -2,6 +2,7 @@
 
 use std::{collections::HashSet, io::Read, str::FromStr as _};
 
+use access_control::AccessControl;
 use borsh::{BorshDeserialize, BorshSerialize};
 use hyperlane_core::{accumulator::incremental::IncrementalMerkle as MerkleTree, H256};
 use solana_program::{
@@ -157,7 +158,19 @@ pub type OutboxAccount = AccountData<Outbox>;
 pub struct Outbox {
     pub local_domain: u32,
     pub outbox_bump_seed: u8,
+    pub owner: Option<Pubkey>,
     pub tree: MerkleTree,
+}
+
+impl AccessControl for Outbox {
+    fn owner(&self) -> Option<&Pubkey> {
+        self.owner.as_ref()
+    }
+
+    fn set_owner(&mut self, owner: Option<Pubkey>) -> Result<(), ProgramError> {
+        self.owner = owner;
+        Ok(())
+    }
 }
 
 pub type DispatchedMessageAccount = AccountData<DispatchedMessage>;

--- a/rust/sealevel/programs/mailbox/src/instruction.rs
+++ b/rust/sealevel/programs/mailbox/src/instruction.rs
@@ -20,6 +20,8 @@ pub enum Instruction {
     OutboxGetCount(OutboxQuery),
     OutboxGetLatestCheckpoint(OutboxQuery),
     OutboxGetRoot(OutboxQuery),
+    GetOwner(OutboxQuery),
+    TransferOwnership(OutboxQuery, Option<Pubkey>),
 }
 
 impl Instruction {


### PR DESCRIPTION
### Description

* Adds an `AccessControl` trait in a new `access-control` library
* Makes the Mailbox support ownership, and requires default ISM setting to be done by the owner
* Moves the multisig ism to using the AccessControl library

### Drive-by changes

no

### Related issues

- Sets the scene for #2218

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Unit Tests & ran end to end
