### PR TITLE
Mailbox PDA for each message that is processed

### DIFF
--- a/rust/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/chains/hyperlane-sealevel/src/mailbox.rs
@@ -848,6 +848,7 @@ mod contract {
         pub local_domain: u32,
         pub inbox_bump_seed: u8,
         pub default_ism: Pubkey,
+        pub processed_count: u64,
     }
     impl Default for Inbox {
         fn default() -> Self {
@@ -855,6 +856,7 @@ mod contract {
                 local_domain: 0,
                 inbox_bump_seed: 0,
                 default_ism: Pubkey::from_str(DEFAULT_ISM).unwrap(),
+                processed_count: 0,
             }
         }
     }

--- a/rust/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/chains/hyperlane-sealevel/src/mailbox.rs
@@ -1154,8 +1154,8 @@ mod contract {
 
             Ok(Self {
                 discriminator,
-                nonce: u32::from_be_bytes(nonce),
-                slot: u64::from_be_bytes(slot),
+                nonce: u32::from_le_bytes(nonce),
+                slot: u64::from_le_bytes(slot),
                 unique_message_pubkey: Pubkey::new_from_array(unique_message_pubkey),
                 encoded_message,
             })

--- a/rust/sealevel/client/src/main.rs
+++ b/rust/sealevel/client/src/main.rs
@@ -460,16 +460,18 @@ fn process_mailbox_cmd(mut ctx: Context, cmd: MailboxCmd) {
                     mailbox_processed_message_pda_seeds!(delivered.message_id),
                     &delivered.program_id,
                 );
-            let account_result = ctx.client.get_account(&processed_message_account_key);
-            let delivered = if let Ok(account) = account_result {
-                account.data.len() > 0
-            } else {
-                false
-            };
-            if delivered {
-                println!("Message delivered");
-            } else {
+            let account = ctx
+                .client
+                .get_account_with_commitment(
+                    &processed_message_account_key,
+                    CommitmentConfig::finalized(),
+                )
+                .unwrap()
+                .value;
+            if account.is_none() {
                 println!("Message not delivered");
+            } else {
+                println!("Message delivered");
             }
         }
     };

--- a/rust/sealevel/client/src/main.rs
+++ b/rust/sealevel/client/src/main.rs
@@ -13,8 +13,8 @@ use hyperlane_sealevel_mailbox::{
         VERSION,
     },
     mailbox_dispatched_message_pda_seeds, mailbox_inbox_pda_seeds,
-    mailbox_message_dispatch_authority_pda_seeds, mailbox_outbox_pda_seeds, spl_noop,
-    ID as MAILBOX_PROG_ID,
+    mailbox_message_dispatch_authority_pda_seeds, mailbox_outbox_pda_seeds,
+    mailbox_processed_message_pda_seeds, spl_noop, ID as MAILBOX_PROG_ID,
 };
 use hyperlane_sealevel_recipient_echo::ID as RECIPIENT_ECHO_PROG_ID;
 use hyperlane_sealevel_token::{
@@ -83,6 +83,7 @@ enum MailboxSubCmd {
     Query(Query),
     Send(Outbox),
     Receive(Inbox),
+    Delivered(Delivered),
 }
 
 #[derive(Args)]
@@ -133,6 +134,14 @@ struct Inbox {
     program_id: Pubkey,
     #[arg(long, default_value_t = DEFAULT_ISM_PROG_ID)]
     ism: Pubkey,
+}
+
+#[derive(Args)]
+struct Delivered {
+    #[arg(long, short, default_value_t = MAILBOX_PROG_ID)]
+    program_id: Pubkey,
+    #[arg(long, short)]
+    message_id: H256,
 }
 
 // Actual content depends on which ISM is used.
@@ -444,6 +453,24 @@ fn process_mailbox_cmd(mut ctx: Context, cmd: MailboxCmd) {
             ctx.client
                 .confirm_transaction_with_spinner(&signature, &recent_blockhash, ctx.commitment)
                 .unwrap();
+        }
+        MailboxSubCmd::Delivered(delivered) => {
+            let (processed_message_account_key, _processed_message_account_bump) =
+                Pubkey::find_program_address(
+                    mailbox_processed_message_pda_seeds!(delivered.message_id),
+                    &delivered.program_id,
+                );
+            let account_result = ctx.client.get_account(&processed_message_account_key);
+            let delivered = if let Ok(account) = account_result {
+                account.data.len() > 0
+            } else {
+                false
+            };
+            if delivered {
+                println!("Message delivered");
+            } else {
+                println!("Message not delivered");
+            }
         }
     };
 }

--- a/rust/sealevel/libraries/access-control/src/lib.rs
+++ b/rust/sealevel/libraries/access-control/src/lib.rs
@@ -1,4 +1,4 @@
-use solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, msg};
+use solana_program::{account_info::AccountInfo, msg, program_error::ProgramError, pubkey::Pubkey};
 
 pub trait AccessControl {
     fn owner(&self) -> Option<&Pubkey>;

--- a/rust/sealevel/programs/mailbox/src/accounts.rs
+++ b/rust/sealevel/programs/mailbox/src/accounts.rs
@@ -1,6 +1,6 @@
 //! Hyperlane Sealevel Mailbox data account layouts.
 
-use std::{collections::HashSet, io::Read, str::FromStr as _};
+use std::{io::Read, str::FromStr as _};
 
 use access_control::AccessControl;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -136,8 +136,6 @@ pub type InboxAccount = AccountData<Inbox>;
 pub struct Inbox {
     pub local_domain: u32,
     pub inbox_bump_seed: u8,
-    // Note: 10MB account limit is around ~300k entries.
-    pub delivered: HashSet<H256>,
     pub default_ism: Pubkey,
 }
 
@@ -146,7 +144,6 @@ impl Default for Inbox {
         Self {
             local_domain: 0,
             inbox_bump_seed: 0,
-            delivered: Default::default(),
             default_ism: Pubkey::from_str(DEFAULT_ISM).unwrap(),
         }
     }

--- a/rust/sealevel/programs/mailbox/src/pda_seeds.rs
+++ b/rust/sealevel/programs/mailbox/src/pda_seeds.rs
@@ -117,3 +117,28 @@ macro_rules! mailbox_process_authority_pda_seeds {
         ]
     }};
 }
+
+/// The PDA seeds relating to the Mailbox's process authority for a particular recipient.
+#[macro_export]
+macro_rules! mailbox_processed_message_pda_seeds {
+    ($message_id_h256:expr) => {{
+        &[
+            b"hyperlane",
+            b"-",
+            b"processed_message",
+            b"-",
+            $message_id_h256.as_bytes(),
+        ]
+    }};
+
+    ($message_id_h256:expr, $bump_seed:expr) => {{
+        &[
+            b"hyperlane",
+            b"-",
+            b"processed_message",
+            b"-",
+            $message_id_h256.as_bytes(),
+            &[$bump_seed],
+        ]
+    }};
+}

--- a/rust/utils/sealevel-test.bash
+++ b/rust/utils/sealevel-test.bash
@@ -189,7 +189,8 @@ test_token() {
     "${BIN_DIR}/hyperlane-sealevel-client" -k "${KEYPAIR}" token query "${token_type}" --program-id "${program_id}"
 
     # Wait for token transfer message to appear in inbox.
-    while "${BIN_DIR}/hyperlane-sealevel-client" -k "${KEYPAIR}" mailbox query | grep -q 'delivered: {}'
+    # This ID was manually gotten from running the Relayer and observing the logs - fragile, I know!
+    while "${BIN_DIR}/hyperlane-sealevel-client" -k "${KEYPAIR}" mailbox delivered --message-id 0xbacfe0c091894423458e1fc28f03e2c130c592c5ce1550a69c0289671a3d6628 | grep -q 'Message not delivered'
     do
         sleep 3
     done


### PR DESCRIPTION
### Description

* When a message is processed, a PDA based off its message ID is created
* I decided to put the actual message ID in the contents of the account to make indexing possible, and added a sequence number in there based off the # of processed messages so that indexing is easier
* Removed the `delivered` hashmap

### Drive-by changes

n/a

### Related issues

- Fixes #2208 

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Unit Tests, works end to end
