### PR TITLE
Add origin filter to relayer msg processor

### DIFF
--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -130,7 +130,7 @@ impl MessageProcessor {
             }
 
             // Skip if the message is intended for this origin
-            if msg.destination == self.domain().id() {
+            if destination == self.domain().id() {
                 debug!(?msg, "Message destined for self, skipping");
                 self.message_nonce += 1;
                 return Ok(());

--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -129,6 +129,13 @@ impl MessageProcessor {
                 return Ok(());
             }
 
+            // Skip if the message is intended for this origin
+            if msg.destination == self.domain().id() {
+                debug!(?msg, "Message destined for self, skipping");
+                self.message_nonce += 1;
+                return Ok(());
+            }
+
             // Skip if the message is intended for a destination we do not service
             if !self.send_channels.contains_key(&destination) {
                 debug!(?msg, "Message destined for unknown domain, skipping");


### PR DESCRIPTION
### Description

Ensures the relayer never attempts to process a message destined for it's own origin domain.

### Related issues

- Fixes https://github.com/hyperlane-xyz/issues/issues/464

### Backward compatibility

Yes


### Testing

E2E tests
