### PR TITLE
Gracefully handle inconsistent RPC providers in ForwardMessageSyncCursor

### DIFF
--- a/rust/hyperlane-base/src/contract_sync/cursor.rs
+++ b/rust/hyperlane-base/src/contract_sync/cursor.rs
@@ -121,7 +121,10 @@ impl ForwardMessageSyncCursor {
                 Ok(Some((from, to, Duration::from_secs(0))))
             }
             Ordering::Greater => {
-                panic!("Cursor is ahead of mailbox, this should never happen.");
+                // Providers may be internally inconsistent, e.g. RPC request A could hit a node
+                // whose tip is N and subsequent RPC request B could hit a node whose tip is < N.
+                debug!("Cursor count is greater than Mailbox count");
+                Ok(None)
             }
         }
     }


### PR DESCRIPTION
### Description

RPC providers can be inconsistent. When a message has just been inserted into the mailbox, it's possible that one Mailbox.count() query returns N and a subsequent query returns N-1.

### Drive-by changes

None

