### PR TITLE
Implement OptimisticISM with a single submodule use case

### DIFF
--- a/solidity/contracts/interfaces/IInterchainSecurityModule.sol
+++ b/solidity/contracts/interfaces/IInterchainSecurityModule.sol
@@ -8,7 +8,8 @@ interface IInterchainSecurityModule {
         AGGREGATION,
         LEGACY_MULTISIG,
         MERKLE_ROOT_MULTISIG,
-        MESSAGE_ID_MULTISIG
+        MESSAGE_ID_MULTISIG,
+        OPTIMISTIC
     }
 
     /**

--- a/solidity/contracts/interfaces/isms/IOptimisticIsm.sol
+++ b/solidity/contracts/interfaces/isms/IOptimisticIsm.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.6.11;
+
+import {IInterchainSecurityModule} from "../IInterchainSecurityModule.sol";
+
+interface IOptimisticIsm is IInterchainSecurityModule {
+    /**
+     * @notice Pre-verifies _message using the currently configuered submodule
+     * @dev before calling verify, the ISM will call preVerify to ensure that the message is valid
+     * @param _metadata Formatted arbitrary bytes that can be specified by an off-chain relayer
+     * @param _message Formatted Hyperlane message (see Message.sol).
+     * @return Whether or not the message is valid
+     */
+    function preVerify(bytes calldata _metadata, bytes calldata _message)
+        external
+        returns (bool);
+
+    /**
+     * @notice Marks an ISM as fraudulent
+     * @param ism The address of ISM to mark as fraudulent
+     */
+    function markFraudulent(address ism) external;
+}

--- a/solidity/contracts/isms/optimistic/AbstractOptimisticIsm.sol
+++ b/solidity/contracts/isms/optimistic/AbstractOptimisticIsm.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+// ============ Internal Imports ============
+import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
+import {IOptimisticIsm} from "../../interfaces/isms/IOptimisticIsm.sol";
+import {Message} from "../../libs/Message.sol";
+
+/**
+ * @title AbstractOptimisticIsm
+ * @notice Optimistic ISMs pre-verify messages before routing them to the correct ISM
+ * @dev The relayer must call preVerify then wait for the fraud window to pass before calling verify
+ * For optimistic verification to succeed, three conditions must be satisfied:
+ * 1. the message was pre-verified
+ * 2. the submodule used to pre-verify the message has not been flagged as compromised by m-of-n watchers
+ * 3. the fraud window has elapsed
+ */
+abstract contract AbstractOptimisticIsm is IOptimisticIsm {
+    // ============ Public Storage ============
+    // Mapping to track if a module is flagged as fraudulent by a watcher
+    mapping(address => mapping(address => bool)) public fraudulent;
+
+    // Mapping to count the unique number of times an ISM has been flagged as fraudulent
+    mapping(address => uint256) public fraudulentCounter;
+
+    // Mapping to store pre-verification data of a message using its ID
+    mapping(bytes32 => PreVerificationData) public preVerification;
+
+    // ============= Structs =============
+    struct PreVerificationData {
+        address submodule;
+        uint96 timestamp;
+    }
+
+    // ============ Constants ============
+
+    // solhint-disable-next-line const-name-snakecase
+    uint8 public constant moduleType =
+        uint8(IInterchainSecurityModule.Types.OPTIMISTIC);
+
+    // ============ Virtual Functions ============
+    // ======= OVERRIDE THESE TO IMPLEMENT =======
+
+    /**
+     * @notice Marks an ISM as fraudulent
+     * @param ism The address of ISM to mark as fraudulent
+     */
+    function markFraudulent(address ism) external virtual;
+
+    /**
+     * @notice Returns the list of watchers and threshold used for this optimistic ISM
+     * @param _message Formatted Hyperlane message (see Message.sol).
+     * @return watchers The list of watchers
+     * @return threshold The threshold of watchers needed to mark an ISM as fraudulent
+     */
+    function watchersAndThreshold(bytes calldata _message)
+        public
+        view
+        virtual
+        returns (address[] memory watchers, uint8 threshold);
+
+    /**
+     * @notice Returns the ISM responsible for verifying _message
+     * @dev Can change based on the content of _message
+     * @param _message Formatted Hyperlane message (see Message.sol).
+     * @return module The ISM to use to verify _message
+     */
+    function submodule(bytes calldata _message)
+        public
+        view
+        virtual
+        returns (IInterchainSecurityModule);
+
+    /**
+     * @notice Returns the fraud window for a given message
+     * @param _message Formatted Hyperlane message (see Message.sol).
+     */
+    function fraudWindow(bytes calldata _message)
+        public
+        view
+        virtual
+        returns (uint256);
+
+    // ============ Public Functions ============
+
+    /**
+     * @notice Pre-verifies _message using the currently configuered submodule
+     * @dev before calling verify, a relayer will call preVerify to ensure that the message is valid
+     * @param _metadata Formatted arbitrary bytes that can be specified by an off-chain relayer
+     * @param _message Formatted Hyperlane message (see Message.sol).
+     * @return Whether or not the message is valid
+     */
+    function preVerify(bytes calldata _metadata, bytes calldata _message)
+        public
+        returns (bool)
+    {
+        IInterchainSecurityModule _submodule = submodule(_message);
+        bytes32 _id = Message.id(_message);
+        PreVerificationData memory _pvd = preVerification[_id];
+        require(_pvd.submodule == address(0), "preVerified");
+        preVerification[_id] = PreVerificationData({
+            submodule: address(_submodule),
+            timestamp: uint96(block.timestamp)
+        });
+        require(_submodule.verify(_metadata, _message), "!verify");
+        return true;
+    }
+
+    /**
+     * @notice Routes _metadata and _message to the correct ISM
+     * @dev For optimistic verification to succeed three conditions must be satisfied
+     * 1. the message was pre-verfied by the submodule
+     * 2. the submodule used to pre-verify the message has not been flagged as compromised by m-of-n watchers
+     * 3. fraud window has elapsed
+     * @param _message Formatted Hyperlane message (see Message.sol).
+     */
+    function verify(bytes calldata, bytes calldata _message)
+        public
+        returns (bool)
+    {
+        bytes32 _id = Message.id(_message);
+        PreVerificationData memory _pvd = preVerification[_id];
+        require(_pvd.timestamp > 0, "!isPreVerified");
+        require(
+            _pvd.timestamp + fraudWindow(_message) < block.timestamp,
+            "!fraudWindow"
+        );
+        (, uint8 _threshold) = watchersAndThreshold(_message);
+        require(
+            fraudulentCounter[_pvd.submodule] < _threshold,
+            "!fraudThreshold"
+        );
+        delete preVerification[_id];
+        return true;
+    }
+}

--- a/solidity/contracts/isms/optimistic/StaticOptimisticIsm.sol
+++ b/solidity/contracts/isms/optimistic/StaticOptimisticIsm.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+import {AbstractOptimisticIsm} from "./AbstractOptimisticIsm.sol";
+import {MetaProxy} from "../../libs/MetaProxy.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
+import {Message} from "../../libs/Message.sol";
+
+abstract contract AbstractMetaProxyOptimisticIsm is AbstractOptimisticIsm {
+    /**
+     * @inheritdoc AbstractOptimisticIsm
+     */
+    function watchersAndThreshold(bytes calldata)
+        public
+        view
+        virtual
+        override
+        returns (address[] memory, uint8)
+    {
+        return abi.decode(MetaProxy.metadata(), (address[], uint8));
+    }
+}
+
+contract StaticOptimisticIsm is
+    AbstractMetaProxyOptimisticIsm,
+    OwnableUpgradeable,
+    AccessControlUpgradeable
+{
+    // ============ Public Storage ============
+    // Storage for the constant Opt-ISM Watcher role's identifier
+    bytes32 public constant OPTIMISTIC_ISM_WATCHER_ROLE =
+        keccak256("OPTIMISTIC_ISM_WATCHER_ROLE");
+
+    // The address of the static Interchain Security Module
+    address public staticModule;
+
+    // The length of the static fraud window
+    uint96 public staticFraudWindow;
+
+    // ============ Events ============
+    event SubmoduleSet(address ism);
+    event FraudWindowSet(uint256 fraudWindow);
+
+    // ============ Initializer ============
+
+    /**
+     * @notice Initializes the contract with a specified owner and ISM module.
+     * @param _owner The address of the owner of this contract.
+     * @param _module The address of the Interchain Security Module to be used.
+     * @param _fraudWindowDuration The length of the fraud window in seconds.
+     */
+    function initialize(
+        address _owner,
+        address _module,
+        uint256 _fraudWindowDuration
+    ) public initializer {
+        __Ownable_init();
+        transferOwnership(_owner);
+        _setSubmodule(_module);
+        _setFraudWindowDuration(_fraudWindowDuration);
+
+        // Set up access control
+        (address[] memory watchers, ) = this.watchersAndThreshold("");
+        for (uint256 i = 0; i < watchers.length; i++) {
+            _setupRole(OPTIMISTIC_ISM_WATCHER_ROLE, watchers[i]);
+        }
+    }
+
+    // ============= Modifiers =============
+    modifier onlyWatcher() {
+        require(hasRole(OPTIMISTIC_ISM_WATCHER_ROLE, msg.sender), "!watcher");
+        _;
+    }
+
+    // ============ External Functions ============
+
+    /**
+     * @notice Sets a new static Interchain Security Module
+     * @param _ism The address of the new Interchain Security Module
+     */
+    function setSubmodule(address _ism) external onlyOwner {
+        _setSubmodule(_ism);
+    }
+
+    /**
+     * @notice Marks an ISM as fraudulent
+     * @dev This function can only be called by a watcher
+     * @param ism The address of ISM to mark as fraudulent
+     */
+    function markFraudulent(address ism) external override onlyWatcher {
+        require(ism != address(0), "address(0)");
+        require(!fraudulent[ism][msg.sender], "already fraudulent");
+        fraudulent[ism][msg.sender] = true;
+        fraudulentCounter[ism]++;
+    }
+
+    // ============ Public Functions ============
+
+    /**
+     * @notice Returns the currently active ISM
+     * @return module The ISM to use to verify _message
+     */
+    function submodule(bytes calldata)
+        public
+        view
+        override
+        returns (IInterchainSecurityModule)
+    {
+        return IInterchainSecurityModule(staticModule);
+    }
+
+    /**
+     * @notice Returns the length of the fraud window
+     * @return The length of the fraud window
+     */
+    function fraudWindow(bytes calldata)
+        public
+        view
+        override
+        returns (uint256)
+    {
+        return staticFraudWindow;
+    }
+
+    // ============ Internal Functions ============
+    function _setSubmodule(address ism) internal {
+        require(ism != address(0), "address(0)");
+        staticModule = ism;
+        emit SubmoduleSet(ism);
+    }
+
+    function _setFraudWindowDuration(uint256 _fraudWindowDuration) internal {
+        require(_fraudWindowDuration > 0, "window==0");
+        staticFraudWindow = uint96(_fraudWindowDuration);
+        emit FraudWindowSet(_fraudWindowDuration);
+    }
+}

--- a/solidity/contracts/isms/optimistic/StaticOptimisticIsmFactory.sol
+++ b/solidity/contracts/isms/optimistic/StaticOptimisticIsmFactory.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+import {StaticMOfNAddressSetFactory} from "../../libs/StaticMOfNAddressSetFactory.sol";
+import {StaticOptimisticIsm} from "./StaticOptimisticIsm.sol";
+
+contract StaticOptimisticIsmFactory is StaticMOfNAddressSetFactory {
+    function _deployImplementation() internal override returns (address) {
+        return address(new StaticOptimisticIsm());
+    }
+}

--- a/solidity/test/isms/OptimisticIsm.t.sol
+++ b/solidity/test/isms/OptimisticIsm.t.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import {IOptimisticIsm} from "../../contracts/interfaces/isms/IOptimisticIsm.sol";
+import {StaticOptimisticIsm} from "../../contracts/isms/optimistic/StaticOptimisticIsm.sol";
+import {StaticOptimisticIsmFactory} from "../../contracts/isms/optimistic/StaticOptimisticIsmFactory.sol";
+import {TestIsm, MOfNTestUtils} from "./IsmTestUtils.sol";
+
+contract OptimisticIsmTest is Test {
+    uint256 constant FRAUD_WINDOW = 7 days;
+    StaticOptimisticIsmFactory factory;
+    StaticOptimisticIsm ism;
+    address submodule;
+    bytes metadata;
+
+    function setUp() public {
+        factory = new StaticOptimisticIsmFactory();
+    }
+
+    function deployOptimisticIsmWithWatchers(
+        uint8 m,
+        uint8 n,
+        bytes32 seed
+    ) internal returns (address[] memory) {
+        bytes32 randomness = seed;
+        address[] memory watchers = new address[](n);
+        for (uint256 i = 0; i < n; i++) {
+            randomness = keccak256(abi.encode(randomness));
+            address randomAddress = address(uint160(uint256(randomness)));
+            watchers[i] = address(randomAddress);
+        }
+        ism = StaticOptimisticIsm(factory.deploy(watchers, m));
+        randomness = keccak256(abi.encode(randomness));
+        metadata = abi.encode(randomness);
+        submodule = address(new TestIsm(metadata));
+        ism.initialize(address(this), submodule, FRAUD_WINDOW);
+        return watchers;
+    }
+
+    function testPreVerify(
+        uint8 m,
+        uint8 n,
+        bytes32 seed
+    ) public {
+        vm.assume(0 < m && m <= n && n < 10);
+        deployOptimisticIsmWithWatchers(m, n, seed);
+
+        assertTrue(ism.preVerify(metadata, ""));
+    }
+
+    function testPreVerify_revertsWithWrongMetadata(
+        uint8 m,
+        uint8 n,
+        bytes32 seed
+    ) public {
+        vm.assume(0 < m && m <= n && n < 10);
+        deployOptimisticIsmWithWatchers(m, n, seed);
+
+        bytes memory wrongMetadata = abi.encode(keccak256(metadata));
+        vm.expectRevert(bytes("!verify"));
+        ism.preVerify(wrongMetadata, "");
+    }
+
+    function testVerify_revertsWithoutPreVerify(
+        uint8 m,
+        uint8 n,
+        bytes32 seed
+    ) public {
+        vm.assume(0 < m && m <= n && n < 10);
+        deployOptimisticIsmWithWatchers(m, n, seed);
+
+        vm.expectRevert(bytes("!isPreVerified"));
+        ism.verify(metadata, "");
+    }
+
+    function testVerify_revertsBeforeFraudWindowCloses(
+        uint8 m,
+        uint8 n,
+        bytes32 seed
+    ) public {
+        vm.assume(0 < m && m <= n && n < 10);
+        deployOptimisticIsmWithWatchers(m, n, seed);
+
+        ism.preVerify(metadata, "");
+        // skip the fraud window timestamp
+        vm.warp(block.timestamp + FRAUD_WINDOW / 2);
+        vm.expectRevert(bytes("!fraudWindow"));
+        ism.verify(metadata, "");
+    }
+
+    function testVerify_revertsIfSubmoduleIsFraudulent(
+        uint8 m,
+        uint8 n,
+        bytes32 seed
+    ) public {
+        vm.assume(0 < m && m <= n && n < 10);
+        address[] memory watchers = deployOptimisticIsmWithWatchers(m, n, seed);
+
+        ism.preVerify(metadata, "");
+        // call markFraudulent for m watchers
+        for (uint256 i = 0; i < m; i++) {
+            vm.prank(watchers[i]);
+            ism.markFraudulent(submodule);
+        }
+        vm.warp(block.timestamp + FRAUD_WINDOW + 1);
+        vm.expectRevert(bytes("!fraudThreshold"));
+        ism.verify(metadata, "");
+    }
+
+    function testVerify(
+        uint8 m,
+        uint8 n,
+        bytes32 seed
+    ) public {
+        vm.assume(0 < m && m <= n && n < 10);
+        address[] memory watchers = deployOptimisticIsmWithWatchers(m, n, seed);
+
+        ism.preVerify(metadata, "");
+        // call markFraudulent for m - 1 watchers
+        for (uint256 i = 0; i < m - 1; i++) {
+            vm.prank(watchers[i]);
+            ism.markFraudulent(submodule);
+        }
+        vm.warp(block.timestamp + FRAUD_WINDOW + 1);
+        assertTrue(ism.verify(metadata, ""));
+    }
+
+    function testVerify_passesWithEmptyMetadata(
+        uint8 m,
+        uint8 n,
+        bytes32 seed
+    ) public {
+        vm.assume(0 < m && m <= n && n < 10);
+        deployOptimisticIsmWithWatchers(m, n, seed);
+
+        ism.preVerify(metadata, "");
+        vm.warp(block.timestamp + FRAUD_WINDOW + 1);
+        assertTrue(ism.verify("", ""));
+    }
+
+    function testWatchersAndThreshold(
+        uint8 m,
+        uint8 n,
+        bytes32 seed
+    ) public {
+        vm.assume(0 < m && m <= n && n < 10);
+        address[] memory expectedWatchers = deployOptimisticIsmWithWatchers(
+            m,
+            n,
+            seed
+        );
+
+        (address[] memory actualWatchers, uint8 actualThreshold) = ism
+            .watchersAndThreshold("");
+        assertEq(abi.encode(actualWatchers), abi.encode(expectedWatchers));
+        assertEq(actualThreshold, m);
+    }
+}


### PR DESCRIPTION
### Description

Implement OptimisticISM with a single submodule use case



### Drive-by changes

interface IInterchainSecurityModule's enum Types was increased by 1 to accommodate OPTIMISTIC type.

### Related issues



### Backward compatibility

_Are these changes backward compatible?_

Since existing enum was touched, must review if any 

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

_What kind of testing have these changes undergone?_

Unit Tests are included in the OptimisticIsm.t.sol test file, containing tests for functionalities and edge cases of the new contracts.


