### PR TITLE
Enforce a single local domain in the Mailbox

### DIFF
--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/accounts.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/accounts.rs
@@ -15,8 +15,6 @@ pub struct HyperlaneToken<T> {
     pub bump: u8,
     /// The address of the mailbox contract.
     pub mailbox: Pubkey,
-    /// The mailbox's local domain.
-    pub mailbox_local_domain: u32,
     /// The dispatch authority PDA's bump seed.
     pub dispatch_authority_bump: u8,
     /// Plugin-specific data.

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/instruction.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/instruction.rs
@@ -8,8 +8,6 @@ use solana_program::pubkey::Pubkey;
 pub struct Init {
     /// The address of the mailbox contract.
     pub mailbox: Pubkey,
-    /// The mailbox's local domain.
-    pub mailbox_local_domain: u32,
 }
 
 /// Transfers `amount_or_id` token to `recipient` on `destination` domain.

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
@@ -188,7 +188,6 @@ where
         let token: HyperlaneToken<T> = HyperlaneToken {
             bump: token_bump,
             mailbox: init.mailbox,
-            mailbox_local_domain: init.mailbox_local_domain,
             dispatch_authority_bump,
             plugin_data,
         };
@@ -257,10 +256,8 @@ where
         // TODO should I be using find_program_address...?
         // TODO why not just get it from the outbox account data?
         let mailbox_outbox_account = next_account_info(accounts_iter)?;
-        let (mailbox_outbox, _mailbox_outbox_bump) = Pubkey::find_program_address(
-            mailbox_outbox_pda_seeds!(token.mailbox_local_domain),
-            &token.mailbox,
-        );
+        let (mailbox_outbox, _mailbox_outbox_bump) =
+            Pubkey::find_program_address(mailbox_outbox_pda_seeds!(), &token.mailbox);
         if mailbox_outbox_account.key != &mailbox_outbox {
             return Err(ProgramError::InvalidArgument);
         }
@@ -300,7 +297,6 @@ where
             TokenMessage::new(xfer.recipient, xfer.amount_or_id, vec![]).to_vec();
         let mailbox_ixn = MailboxIxn::OutboxDispatch(MailboxOutboxDispatch {
             sender: *program_id,
-            local_domain: token.mailbox_local_domain,
             destination_domain: xfer.destination_domain,
             recipient: xfer.destination_program_id,
             message_body: token_xfer_message,

--- a/rust/sealevel/programs/hyperlane-sealevel-token/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/tests/functional.rs
@@ -76,9 +76,9 @@ async fn initialize_mailbox(
     local_domain: u32,
 ) -> MailboxAccounts {
     let (inbox_account, inbox_bump) =
-        Pubkey::find_program_address(mailbox_inbox_pda_seeds!(local_domain), mailbox_program_id);
+        Pubkey::find_program_address(mailbox_inbox_pda_seeds!(), mailbox_program_id);
     let (outbox_account, outbox_bump) =
-        Pubkey::find_program_address(mailbox_outbox_pda_seeds!(local_domain), mailbox_program_id);
+        Pubkey::find_program_address(mailbox_outbox_pda_seeds!(), mailbox_program_id);
 
     let ixn = MailboxInstruction::Init(InitMailbox {
         local_domain,
@@ -170,7 +170,6 @@ async fn test_initialize() {
                 program_id,
                 &HyperlaneTokenInstruction::Init(Init {
                     mailbox: hyperlane_sealevel_mailbox::id(),
-                    mailbox_local_domain: local_domain,
                 })
                 .into_instruction_data()
                 .unwrap(),

--- a/rust/sealevel/programs/mailbox/src/instruction.rs
+++ b/rust/sealevel/programs/mailbox/src/instruction.rs
@@ -15,13 +15,13 @@ pub enum Instruction {
     Init(Init),
     InboxProcess(InboxProcess),
     InboxSetDefaultModule(InboxSetDefaultModule),
-    InboxGetRecipientIsm(u32, Pubkey),
+    InboxGetRecipientIsm(Pubkey),
     OutboxDispatch(OutboxDispatch),
-    OutboxGetCount(OutboxQuery),
-    OutboxGetLatestCheckpoint(OutboxQuery),
-    OutboxGetRoot(OutboxQuery),
-    GetOwner(OutboxQuery),
-    TransferOwnership(OutboxQuery, Option<Pubkey>),
+    OutboxGetCount,
+    OutboxGetLatestCheckpoint,
+    OutboxGetRoot,
+    GetOwner,
+    TransferOwnership(Option<Pubkey>),
 }
 
 impl Instruction {
@@ -46,15 +46,9 @@ pub struct Init {
 pub struct OutboxDispatch {
     // The sender may not necessarily be the transaction payer so specify separately.
     pub sender: Pubkey,
-    pub local_domain: u32,
     pub destination_domain: u32,
     pub recipient: H256,
     pub message_body: Vec<u8>,
-}
-
-#[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq)]
-pub struct OutboxQuery {
-    pub local_domain: u32,
 }
 
 // Note: maximum transaction size is ~1kB, so will need to use accounts for large messages.
@@ -66,7 +60,6 @@ pub struct InboxProcess {
 
 #[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq)]
 pub struct InboxSetDefaultModule {
-    pub local_domain: u32,
     pub program_id: Pubkey,
     pub accounts: Vec<Pubkey>,
 }

--- a/rust/sealevel/programs/mailbox/src/pda_seeds.rs
+++ b/rust/sealevel/programs/mailbox/src/pda_seeds.rs
@@ -3,50 +3,24 @@
 /// PDA seeds for the Inbox account.
 #[macro_export]
 macro_rules! mailbox_inbox_pda_seeds {
-    ($local_domain:expr) => {{
-        &[
-            b"hyperlane",
-            b"-",
-            &$local_domain.to_le_bytes(),
-            b"-",
-            b"inbox",
-        ]
+    () => {{
+        &[b"hyperlane", b"-", b"inbox"]
     }};
 
-    ($local_domain:expr, $bump_seed:expr) => {{
-        &[
-            b"hyperlane",
-            b"-",
-            &$local_domain.to_le_bytes(),
-            b"-",
-            b"inbox",
-            &[$bump_seed],
-        ]
+    ($bump_seed:expr) => {{
+        &[b"hyperlane", b"-", b"inbox", &[$bump_seed]]
     }};
 }
 
 /// PDA seeds for the Outbox account.
 #[macro_export]
 macro_rules! mailbox_outbox_pda_seeds {
-    ($local_domain:expr) => {{
-        &[
-            b"hyperlane",
-            b"-",
-            &$local_domain.to_le_bytes(),
-            b"-",
-            b"outbox",
-        ]
+    () => {{
+        &[b"hyperlane", b"-", b"outbox"]
     }};
 
-    ($local_domain:expr, $bump_seed:expr) => {{
-        &[
-            b"hyperlane",
-            b"-",
-            &$local_domain.to_le_bytes(),
-            b"-",
-            b"outbox",
-            &[$bump_seed],
-        ]
+    ($bump_seed:expr) => {{
+        &[b"hyperlane", b"-", b"outbox", &[$bump_seed]]
     }};
 }
 

--- a/rust/sealevel/programs/mailbox/src/processor.rs
+++ b/rust/sealevel/programs/mailbox/src/processor.rs
@@ -1181,7 +1181,6 @@ mod test {
         };
         let dispatch = OutboxDispatch {
             sender: sender.clone(),
-            local_domain: hyperlane_message.origin,
             destination_domain: hyperlane_message.destination,
             recipient: hyperlane_message.recipient,
             message_body: hyperlane_message.body.clone(),


### PR DESCRIPTION
### Description

Before this PR, the Mailbox supported multiple different local domains. This moves to a single canonical local domain for the program's deployment

### Drive-by changes

n/a

### Related issues

- Fixes #2204 

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Unit Tests & ran end to end
