### PR TITLE
Fix bug in postgres message coercion

### DIFF
--- a/rust/agents/scraper/src/db/message.rs
+++ b/rust/agents/scraper/src/db/message.rs
@@ -80,9 +80,9 @@ impl ScraperDb {
             Ok(Some(HyperlaneMessage {
                 // We do not write version to the DB.
                 version: 0,
-                origin: message.origin.try_into()?,
-                nonce: message.nonce.try_into()?,
-                destination: message.destination.try_into()?,
+                origin: message.origin as u32,
+                destination: message.destination as u32,
+                nonce: message.nonce as u32,
                 sender: bytes_to_address(message.sender)?,
                 recipient: bytes_to_address(message.recipient)?,
                 body: message.msg_body.unwrap_or(Vec::new()),

--- a/rust/hyperlane-base/src/contract_sync/cursor.rs
+++ b/rust/hyperlane-base/src/contract_sync/cursor.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use derive_new::new;
 use eyre::Result;
 use tokio::time::sleep;
-use tracing::{debug, warn};
+use tracing::{debug, warn, info};
 
 use hyperlane_core::{
     ChainResult, ContractSyncCursor, HyperlaneMessage, HyperlaneMessageStore,
@@ -61,12 +61,12 @@ impl MessageSyncCursor {
         // If we found messages, but did *not* find the message we were looking for,
         // we need to rewind to the block at which we found the last message.
         if !logs.is_empty() && !logs.iter().any(|m| m.0.nonce == self.next_nonce) {
-            debug!(next_nonce=?self.next_nonce, "Target nonce not found, rewinding");
+            warn!(next_nonce=?self.next_nonce, "Target nonce not found, rewinding");
             // If the previous nonce has been synced, rewind to the block number
             // at which it was dispatched. Otherwise, rewind all the way back to the start block.
             if let Some(block_number) = self.retrieve_dispatched_block_number(prev_nonce).await {
                 self.next_block = block_number;
-                debug!(block_number, "Rewound to previous known message");
+                warn!(block_number, "Rewound to previous known message");
             } else {
                 self.next_block = self.start_block;
             }
@@ -96,9 +96,11 @@ impl ForwardMessageSyncCursor {
                 .retrieve_dispatched_block_number(self.0.next_nonce)
                 .await
             {
+                debug!(next_block=block_number, "Fast forwarding next block");
                 // It's possible that eth_getLogs dropped logs from this block, therefore we cannot do block_number + 1.
                 self.0.next_block = block_number;
             }
+            debug!(next_nonce=self.0.next_nonce + 1, "Fast forwarding next nonce");
             self.0.next_nonce += 1;
         }
 

--- a/rust/hyperlane-base/src/contract_sync/cursor.rs
+++ b/rust/hyperlane-base/src/contract_sync/cursor.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use derive_new::new;
 use eyre::Result;
 use tokio::time::sleep;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use hyperlane_core::{
     ChainResult, ContractSyncCursor, HyperlaneMessage, HyperlaneMessageStore,

--- a/rust/hyperlane-base/src/contract_sync/cursor.rs
+++ b/rust/hyperlane-base/src/contract_sync/cursor.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use derive_new::new;
 use eyre::Result;
 use tokio::time::sleep;
-use tracing::{debug, warn, info};
+use tracing::{debug, info, warn};
 
 use hyperlane_core::{
     ChainResult, ContractSyncCursor, HyperlaneMessage, HyperlaneMessageStore,
@@ -96,11 +96,14 @@ impl ForwardMessageSyncCursor {
                 .retrieve_dispatched_block_number(self.0.next_nonce)
                 .await
             {
-                debug!(next_block=block_number, "Fast forwarding next block");
+                debug!(next_block = block_number, "Fast forwarding next block");
                 // It's possible that eth_getLogs dropped logs from this block, therefore we cannot do block_number + 1.
                 self.0.next_block = block_number;
             }
-            debug!(next_nonce=self.0.next_nonce + 1, "Fast forwarding next nonce");
+            debug!(
+                next_nonce = self.0.next_nonce + 1,
+                "Fast forwarding next nonce"
+            );
             self.0.next_nonce += 1;
         }
 


### PR DESCRIPTION
### Description

Goerli had a message dispatched (nonce=1964) with a destination domain that failed to be converted from i32 to u32 when being retrieved from the database. This fixes these bugs for domain ids and nonce and improves logs for this type of failure.

### Backward compatibility

Scraper needs to be redeployed

### Testing

Ran scraper locally against read replica of explorer DB
