### PR TITLE
Fix AWS KMS Signer connection issues

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-02-10-01#fe5d88220fc15d99ed19ae20e80ef7985673fa9a"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1602,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-02-10-01#fe5d88220fc15d99ed19ae20e80ef7985673fa9a"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1613,7 +1613,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-02-10-01#fe5d88220fc15d99ed19ae20e80ef7985673fa9a"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-02-10-01#fe5d88220fc15d99ed19ae20e80ef7985673fa9a"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
 dependencies = [
  "Inflector",
  "cfg-if",
@@ -1655,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-02-10-01#fe5d88220fc15d99ed19ae20e80ef7985673fa9a"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1669,7 +1669,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-02-10-01#fe5d88220fc15d99ed19ae20e80ef7985673fa9a"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1699,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-02-10-01#fe5d88220fc15d99ed19ae20e80ef7985673fa9a"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
 dependencies = [
  "ethers-core",
  "getrandom",
@@ -1715,7 +1715,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-02-10-01#fe5d88220fc15d99ed19ae20e80ef7985673fa9a"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -1761,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-02-10-01#fe5d88220fc15d99ed19ae20e80ef7985673fa9a"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
 dependencies = [
  "async-trait",
  "auto_impl 1.1.0",
@@ -1797,7 +1797,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-02-10-01#fe5d88220fc15d99ed19ae20e80ef7985673fa9a"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
 dependencies = [
  "async-trait",
  "coins-bip32",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,11 +33,11 @@ config = "~0.13.3"
 derive-new = "0.5"
 derive_more = "0.99"
 enum_dispatch = "0.3"
-ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-02-10-01" }
-ethers-contract = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-02-10-01", features = ["legacy"] }
-ethers-core = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-02-10-01" }
-ethers-providers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-02-10-01" }
-ethers-signers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-02-10-01", features = ["aws"] }
+ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-06-01" }
+ethers-contract = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-06-01", features = ["legacy"] }
+ethers-core = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-06-01" }
+ethers-providers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-06-01" }
+ethers-signers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-06-01", features = ["aws"] }
 eyre = "0.6"
 fuels = "0.38"
 fuels-code-gen = "0.38"

--- a/rust/chains/hyperlane-ethereum/src/signers.rs
+++ b/rust/chains/hyperlane-ethereum/src/signers.rs
@@ -12,7 +12,7 @@ pub enum Signers {
     /// A wallet instantiated with a locally stored private key
     Local(LocalWallet),
     /// A signer using a key stored in aws kms
-    Aws(AwsSigner<'static>),
+    Aws(AwsSigner),
 }
 
 impl From<LocalWallet> for Signers {
@@ -21,8 +21,8 @@ impl From<LocalWallet> for Signers {
     }
 }
 
-impl From<AwsSigner<'static>> for Signers {
-    fn from(s: AwsSigner<'static>) -> Self {
+impl From<AwsSigner> for Signers {
+    fn from(s: AwsSigner) -> Self {
         Signers::Aws(s)
     }
 }

--- a/rust/ethers-prometheus/Cargo.toml
+++ b/rust/ethers-prometheus/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 
 [dependencies]
 prometheus = "0.13"
-ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-02-10-01" }
+ethers = { git = "https://github.com/hyperlane-xyz/ethers-rs", tag = "2023-06-01" }
 derive_builder = "0.12"
 derive-new = "0.5"
 async-trait = { version = "0.1", default-features = false }

--- a/rust/hyperlane-base/src/settings/mod.rs
+++ b/rust/hyperlane-base/src/settings/mod.rs
@@ -72,9 +72,6 @@
 //! 5. Arguments passed to the agent on the command line.
 //!    E.g. `--originChainName ethereum`
 
-use once_cell::sync::OnceCell;
-use rusoto_kms::KmsClient;
-
 pub use base::*;
 pub use chains::{ChainConf, ChainConnectionConf, CoreContractAddresses};
 pub use signers::{RawSignerConf, SignerConf};
@@ -89,5 +86,3 @@ pub(crate) mod loader;
 mod signers;
 /// Tracing subscriber management
 pub mod trace;
-
-static KMS_CLIENT: OnceCell<KmsClient> = OnceCell::new();

--- a/rust/hyperlane-base/src/settings/signers.rs
+++ b/rust/hyperlane-base/src/settings/signers.rs
@@ -9,8 +9,6 @@ use tracing::instrument;
 use super::aws_credentials::AwsChainCredentialsProvider;
 use hyperlane_core::{config::*, H256};
 
-use crate::settings::KMS_CLIENT;
-
 /// Signer types
 #[derive(Default, Debug, Clone)]
 pub enum SignerConf {
@@ -106,17 +104,15 @@ impl BuildableWithSignerConf for hyperlane_ethereum::Signers {
                 ),
             )),
             SignerConf::Aws { id, region } => {
-                let client = KMS_CLIENT.get_or_init(|| {
-                    KmsClient::new_with_client(
-                        rusoto_core::Client::new_with(
-                            AwsChainCredentialsProvider::new(),
-                            HttpClient::new().unwrap(),
-                        ),
-                        region.clone(),
-                    )
-                });
+                let client = KmsClient::new_with_client(
+                    rusoto_core::Client::new_with(
+                        AwsChainCredentialsProvider::new(),
+                        HttpClient::new().unwrap(),
+                    ),
+                    region.clone(),
+                );
 
-                let signer = AwsSigner::new(client.clone(), id, 0).await?;
+                let signer = AwsSigner::new(client, id, 0).await?;
                 hyperlane_ethereum::Signers::Aws(signer)
             }
             SignerConf::Node => bail!("Node signer"),

--- a/rust/hyperlane-base/src/settings/signers.rs
+++ b/rust/hyperlane-base/src/settings/signers.rs
@@ -116,7 +116,7 @@ impl BuildableWithSignerConf for hyperlane_ethereum::Signers {
                     )
                 });
 
-                let signer = AwsSigner::new(client, id, 0).await?;
+                let signer = AwsSigner::new(client.clone(), id, 0).await?;
                 hyperlane_ethereum::Signers::Aws(signer)
             }
             SignerConf::Node => bail!("Node signer"),


### PR DESCRIPTION
### Description

- Update ethers-rs fork
- Create new KMS client instead of using OnceCell

### Backward compatibility

Yes
No

### Testing

Running validator locally with replica of validator DB