### PR TITLE
Handle additional error case in retrying provider

### DIFF
--- a/rust/chains/hyperlane-ethereum/src/rpc_clients/mod.rs
+++ b/rust/chains/hyperlane-ethereum/src/rpc_clients/mod.rs
@@ -58,7 +58,7 @@ fn categorize_client_response<R>(
             }
         }
         Err(JsonRpcError(e)) => {
-            let msg = e.message.to_ascii_lowercase().replace("_", " ");
+            let msg = e.message.to_ascii_lowercase().replace('_', " ");
             if e.code == 429
                 || msg.contains("429")
                 || msg.contains("rate limit")

--- a/rust/chains/hyperlane-ethereum/src/rpc_clients/mod.rs
+++ b/rust/chains/hyperlane-ethereum/src/rpc_clients/mod.rs
@@ -58,7 +58,7 @@ fn categorize_client_response<R>(
             }
         }
         Err(JsonRpcError(e)) => {
-            let msg = e.message.to_ascii_lowercase();
+            let msg = e.message.to_ascii_lowercase().replace("_", " ");
             if e.code == 429
                 || msg.contains("429")
                 || msg.contains("rate limit")
@@ -79,7 +79,7 @@ fn categorize_client_response<R>(
                 || (METHODS_TO_NOT_RETRY_ON_UNDERPRICED.contains(&method)
                     && msg.contains("underpriced"))
                 || (METHODS_TO_NOT_RETRY_ON_INSUFFICIENT_FUNDS.contains(&method)
-                    && msg.contains("insufficient funds"))
+                    && (msg.contains("insufficient funds") || msg.contains("insufficient balance")))
             {
                 // We don't want to retry errors that are probably not going to work if we keep
                 // retrying them or that indicate an error in higher-order logic and not


### PR DESCRIPTION
### Description

Adds a fix for this error message I noticed in the logs:
```
(code: 3, message: execution reverted: INSUFFICIENT_BALANCE, ...)
```

### Drive-by changes

None

### Related issues


### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None