### PR TITLE
Reduce log noise

### DIFF
--- a/rust/chains/hyperlane-ethereum/src/interchain_security_module.rs
+++ b/rust/chains/hyperlane-ethereum/src/interchain_security_module.rs
@@ -96,7 +96,7 @@ impl<M> InterchainSecurityModule for EthereumInterchainSecurityModule<M>
 where
     M: Middleware + 'static,
 {
-    #[instrument(err, ret)]
+    #[instrument]
     async fn module_type(&self) -> ChainResult<ModuleType> {
         let module = self.contract.module_type().call().await?;
         if let Some(module_type) = ModuleType::from_u8(module) {

--- a/rust/chains/hyperlane-ethereum/src/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/mailbox.rs
@@ -428,7 +428,7 @@ where
         Ok(receipt.into())
     }
 
-    #[instrument(err, ret, skip(self), fields(msg=%message, metadata=%fmt_bytes(metadata)))]
+    #[instrument(ret, skip(self), fields(msg=%message, metadata=%fmt_bytes(metadata)))]
     async fn process_estimate_costs(
         &self,
         message: &HyperlaneMessage,

--- a/rust/chains/hyperlane-ethereum/src/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/mailbox.rs
@@ -291,7 +291,7 @@ impl<M> Mailbox for EthereumMailbox<M>
 where
     M: Middleware + 'static,
 {
-    #[instrument(level = "debug", err, ret, skip(self))]
+    #[instrument(skip(self))]
     async fn count(&self, maybe_lag: Option<NonZeroU64>) -> ChainResult<u32> {
         let base_call = self.contract.count();
         let call_with_lag = if let Some(lag) = maybe_lag {
@@ -309,12 +309,12 @@ where
         Ok(count)
     }
 
-    #[instrument(level = "debug", err, ret, skip(self))]
+    #[instrument(skip(self))]
     async fn delivered(&self, id: H256) -> ChainResult<bool> {
         Ok(self.contract.delivered(id.into()).call().await?)
     }
 
-    #[instrument(level = "debug", err, ret, skip(self))]
+    #[instrument(skip(self))]
     async fn latest_checkpoint(&self, maybe_lag: Option<NonZeroU64>) -> ChainResult<Checkpoint> {
         let base_call = self.contract.latest_checkpoint();
         let call_with_lag = match maybe_lag {
@@ -338,7 +338,7 @@ where
         })
     }
 
-    #[instrument(level = "debug", err, ret, skip(self))]
+    #[instrument(skip(self))]
     #[allow(clippy::needless_range_loop)]
     async fn tree(&self, lag: Option<NonZeroU64>) -> ChainResult<IncrementalMerkle> {
         let lag = lag.map(|v| v.get()).unwrap_or(0).into();
@@ -399,12 +399,12 @@ where
         Ok(tree)
     }
 
-    #[instrument(err, ret, skip(self))]
+    #[instrument(skip(self))]
     async fn default_ism(&self) -> ChainResult<H256> {
         Ok(self.contract.default_ism().call().await?.into())
     }
 
-    #[instrument(err, ret, skip(self))]
+    #[instrument(skip(self))]
     async fn recipient_ism(&self, recipient: H256) -> ChainResult<H256> {
         Ok(self
             .contract
@@ -414,7 +414,7 @@ where
             .into())
     }
 
-    #[instrument(err, ret, skip(self), fields(metadata=%fmt_bytes(metadata)))]
+    #[instrument(skip(self), fields(metadata=%fmt_bytes(metadata)))]
     async fn process(
         &self,
         message: &HyperlaneMessage,
@@ -428,7 +428,7 @@ where
         Ok(receipt.into())
     }
 
-    #[instrument(ret, skip(self), fields(msg=%message, metadata=%fmt_bytes(metadata)))]
+    #[instrument(skip(self), fields(msg=%message, metadata=%fmt_bytes(metadata)))]
     async fn process_estimate_costs(
         &self,
         message: &HyperlaneMessage,

--- a/rust/chains/hyperlane-ethereum/src/multisig_ism.rs
+++ b/rust/chains/hyperlane-ethereum/src/multisig_ism.rs
@@ -97,7 +97,7 @@ impl<M> MultisigIsm for EthereumMultisigIsm<M>
 where
     M: Middleware + 'static,
 {
-    #[instrument(err, ret)]
+    #[instrument(err)]
     async fn validators_and_threshold(
         &self,
         message: &HyperlaneMessage,

--- a/rust/chains/hyperlane-ethereum/src/routing_ism.rs
+++ b/rust/chains/hyperlane-ethereum/src/routing_ism.rs
@@ -86,7 +86,7 @@ impl<M> RoutingIsm for EthereumRoutingIsm<M>
 where
     M: Middleware + 'static,
 {
-    #[instrument(err, ret)]
+    #[instrument(err)]
     async fn route(&self, message: &HyperlaneMessage) -> ChainResult<H256> {
         let ism = self
             .contract


### PR DESCRIPTION
### Description

Seeing a ton of errors for process estimate costs even though they are fully being handled elsewhere and are also not really an error in the first place. This makes it harder as an operator to spot real errors so I think we should eliminate this error log. (We also already log this error elsewhere so it does not add any new information).

![image](https://github.com/hyperlane-xyz/hyperlane-monorepo/assets/4187749/f149a870-52f3-444c-aa62-84b6aa822f44)

This also targets the `ret` logs produced by tracing since many of them are unhelpful and most of the cases where we actually need a log we already have one.

### Drive-by changes

None

### Related issues

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None