### PR TITLE
Sealevel - make clippy happy

### DIFF
--- a/rust/chains/hyperlane-ethereum/src/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/mailbox.rs
@@ -9,8 +9,8 @@ use async_trait::async_trait;
 use ethers::abi::AbiEncode;
 use ethers::prelude::Middleware;
 use ethers_contract::builders::ContractCall;
-use hyperlane_core::accumulator::TREE_DEPTH;
 use hyperlane_core::accumulator::incremental::IncrementalMerkle;
+use hyperlane_core::accumulator::TREE_DEPTH;
 use tracing::instrument;
 
 use hyperlane_core::{

--- a/rust/chains/hyperlane-sealevel/src/interchain_security_module.rs
+++ b/rust/chains/hyperlane-sealevel/src/interchain_security_module.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use hyperlane_core::{
     ChainResult, ContractLocator, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
-    InterchainSecurityModule, H256, ModuleType,
+    InterchainSecurityModule, ModuleType, H256,
 };
 
 use crate::{solana::pubkey::Pubkey, ConnectionConf};

--- a/rust/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/chains/hyperlane-sealevel/src/mailbox.rs
@@ -10,10 +10,10 @@ use std::{
 use async_trait::async_trait;
 use borsh::{BorshDeserialize, BorshSerialize};
 use hyperlane_core::{
-    ChainCommunicationError, ChainResult, Checkpoint, ContractLocator, Decode as _, Encode as _,
-    HyperlaneAbi, HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneMessage,
-    HyperlaneProvider, IndexRange, Indexer, LogMeta, Mailbox, MessageIndexer, TxCostEstimate,
-    TxOutcome, H256, U256, accumulator::incremental::IncrementalMerkle,
+    accumulator::incremental::IncrementalMerkle, ChainCommunicationError, ChainResult, Checkpoint,
+    ContractLocator, Decode as _, Encode as _, HyperlaneAbi, HyperlaneChain, HyperlaneContract,
+    HyperlaneDomain, HyperlaneMessage, HyperlaneProvider, IndexRange, Indexer, LogMeta, Mailbox,
+    MessageIndexer, TxCostEstimate, TxOutcome, H256, U256,
 };
 use jsonrpc_core::futures_util::TryFutureExt;
 use tracing::{debug, error, instrument, trace, warn};
@@ -304,8 +304,7 @@ impl Mailbox for SealevelMailbox {
     async fn count(&self, _maybe_lag: Option<NonZeroU64>) -> ChainResult<u32> {
         let tree = self.tree(_maybe_lag).await?;
 
-            tree
-            .count()
+        tree.count()
             .try_into()
             .map_err(ChainCommunicationError::from_other)
     }
@@ -359,8 +358,7 @@ impl Mailbox for SealevelMailbox {
         let tree = self.tree(lag).await?;
 
         let root = tree.root();
-        let count: u32 = 
-            tree
+        let count: u32 = tree
             .count()
             .try_into()
             .map_err(ChainCommunicationError::from_other)?;

--- a/rust/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use eyre::Result;
 use paste::paste;
 use tokio::time::sleep;
-use tracing::{debug, trace, instrument};
+use tracing::{debug, instrument, trace};
 
 use hyperlane_core::{
     HyperlaneDomain, HyperlaneLogStore, HyperlaneMessage, HyperlaneMessageStore,

--- a/rust/hyperlane-base/src/settings/signers.rs
+++ b/rust/hyperlane-base/src/settings/signers.rs
@@ -155,10 +155,8 @@ impl BuildableWithSignerConf for hyperlane_sealevel::solana::signer::keypair::Ke
                 let secret = SecretKey::from_bytes(key.as_bytes())
                     .context("Invalid sealevel ed25519 secret key")?;
                 let public = PublicKey::from(&secret);
-                let keypair =
-                    Keypair::from_bytes(&ed25519_dalek::Keypair { secret, public }.to_bytes()[..])
-                        .context("Unable to create Keypair")?;
-                keypair
+                Keypair::from_bytes(&ed25519_dalek::Keypair { secret, public }.to_bytes()[..])
+                    .context("Unable to create Keypair")?
             }
             SignerConf::Aws { .. } => bail!("Aws signer is not supported by fuel"),
             SignerConf::Node => bail!("Node signer is not supported by fuel"),

--- a/rust/hyperlane-base/src/settings/trace/mod.rs
+++ b/rust/hyperlane-base/src/settings/trace/mod.rs
@@ -3,7 +3,6 @@ use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{
     filter::{LevelFilter, Targets},
     prelude::*,
-    EnvFilter,
 };
 
 pub use span_metrics::TimeSpanLifetime;
@@ -62,7 +61,6 @@ impl From<Level> for LevelFilter {
 pub struct TracingConfig {
     jaeger: Option<JaegerConfig>,
     zipkin: Option<ZipkinConfig>,
-    console: Option<()>,
     #[serde(default)]
     fmt: Style,
     #[serde(default)]
@@ -102,16 +100,7 @@ impl TracingConfig {
             subscriber.with(layer).try_init()?;
             return Ok(());
         }
-        // FIXME based on the return early logic, these should be an enum...
-        if let Some(_) = &self.console {
-            subscriber
-                .with(tracing_subscriber::fmt::layer())
-                .with(EnvFilter::from_default_env())
-                .try_init()?;
-            return Ok(());
-        }
         subscriber.try_init()?;
-
         Ok(())
     }
 }

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/instruction.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/instruction.rs
@@ -131,10 +131,10 @@ where
     }
     pub fn from_noop_cpi_ixn_data(data: &[u8]) -> Result<Self, EventError> {
         let mut data_iter = data.iter();
-        let version = data_iter.next().ok_or_else(|| EventError)?;
+        let version = data_iter.next().ok_or(EventError)?;
         let header_len = match version {
             0 => {
-                let label_len = usize::from(*data_iter.next().ok_or_else(|| EventError)?);
+                let label_len = usize::from(*data_iter.next().ok_or(EventError)?);
                 let expected_label = <D as EventLabel>::event_label();
                 if label_len != expected_label.len() {
                     return Err(EventError);

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/message.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/message.rs
@@ -43,7 +43,7 @@ impl Decode for TokenMessage {
 
         Ok(Self {
             recipient,
-            amount_or_id: U256::from(amount_or_id),
+            amount_or_id,
             metadata,
         })
     }

--- a/rust/sealevel/libraries/interchain-security-module-interface/src/lib.rs
+++ b/rust/sealevel/libraries/interchain-security-module-interface/src/lib.rs
@@ -58,10 +58,10 @@ impl InterchainSecurityModuleInstruction {
         let mut buf = vec![];
         match self {
             InterchainSecurityModuleInstruction::Type => {
-                buf.extend_from_slice(&TYPE_DISCRIMINATOR_SLICE[..]);
+                buf.extend_from_slice(TYPE_DISCRIMINATOR_SLICE);
             }
             InterchainSecurityModuleInstruction::Verify(instruction) => {
-                buf.extend_from_slice(&VERIFY_DISCRIMINATOR_SLICE[..]);
+                buf.extend_from_slice(VERIFY_DISCRIMINATOR_SLICE);
                 buf.extend_from_slice(
                     &instruction
                         .try_to_vec()
@@ -69,7 +69,7 @@ impl InterchainSecurityModuleInstruction {
                 );
             }
             InterchainSecurityModuleInstruction::VerifyAccountMetas(instruction) => {
-                buf.extend_from_slice(&VERIFY_ACCOUNT_METAS_DISCRIMINATOR_SLICE[..]);
+                buf.extend_from_slice(VERIFY_ACCOUNT_METAS_DISCRIMINATOR_SLICE);
                 buf.extend_from_slice(
                     &instruction
                         .try_to_vec()

--- a/rust/sealevel/libraries/message-recipient-interface/src/lib.rs
+++ b/rust/sealevel/libraries/message-recipient-interface/src/lib.rs
@@ -95,15 +95,13 @@ impl MessageRecipientInstruction {
         let mut buf = vec![];
         match self {
             MessageRecipientInstruction::InterchainSecurityModule => {
-                buf.extend_from_slice(&INTERCHAIN_SECURITY_MODULE_DISCRIMINATOR_SLICE[..]);
+                buf.extend_from_slice(INTERCHAIN_SECURITY_MODULE_DISCRIMINATOR_SLICE);
             }
             MessageRecipientInstruction::InterchainSecurityModuleAccountMetas => {
-                buf.extend_from_slice(
-                    &INTERCHAIN_SECURITY_MODULE_ACCOUNT_METAS_DISCRIMINATOR_SLICE[..],
-                );
+                buf.extend_from_slice(INTERCHAIN_SECURITY_MODULE_ACCOUNT_METAS_DISCRIMINATOR_SLICE);
             }
             MessageRecipientInstruction::Handle(instruction) => {
-                buf.extend_from_slice(&HANDLE_DISCRIMINATOR_SLICE[..]);
+                buf.extend_from_slice(HANDLE_DISCRIMINATOR_SLICE);
                 buf.extend_from_slice(
                     &instruction
                         .try_to_vec()
@@ -111,7 +109,7 @@ impl MessageRecipientInstruction {
                 );
             }
             MessageRecipientInstruction::HandleAccountMetas(instruction) => {
-                buf.extend_from_slice(&HANDLE_ACCOUNT_METAS_DISCRIMINATOR_SLICE[..]);
+                buf.extend_from_slice(HANDLE_ACCOUNT_METAS_DISCRIMINATOR_SLICE);
                 buf.extend_from_slice(
                     &instruction
                         .try_to_vec()

--- a/rust/sealevel/libraries/multisig-ism/src/interface.rs
+++ b/rust/sealevel/libraries/multisig-ism/src/interface.rs
@@ -43,13 +43,11 @@ impl MultisigIsmInstruction {
         let mut buf = vec![];
         match self {
             MultisigIsmInstruction::ValidatorsAndThreshold(message) => {
-                buf.extend_from_slice(&VALIDATORS_AND_THRESHOLD_DISCRIMINATOR_SLICE[..]);
+                buf.extend_from_slice(VALIDATORS_AND_THRESHOLD_DISCRIMINATOR_SLICE);
                 buf.extend_from_slice(&message[..]);
             }
             MultisigIsmInstruction::ValidatorsAndThresholdAccountMetas(message) => {
-                buf.extend_from_slice(
-                    &VALIDATORS_AND_THRESHOLD_ACCOUNT_METAS_DISCRIMINATOR_SLICE[..],
-                );
+                buf.extend_from_slice(VALIDATORS_AND_THRESHOLD_ACCOUNT_METAS_DISCRIMINATOR_SLICE);
                 buf.extend_from_slice(&message[..]);
             }
         }

--- a/rust/sealevel/libraries/serializable-account-meta/src/lib.rs
+++ b/rust/sealevel/libraries/serializable-account-meta/src/lib.rs
@@ -19,12 +19,12 @@ impl From<AccountMeta> for SerializableAccountMeta {
     }
 }
 
-impl Into<AccountMeta> for SerializableAccountMeta {
-    fn into(self) -> AccountMeta {
-        AccountMeta {
-            pubkey: self.pubkey,
-            is_signer: self.is_signer,
-            is_writable: self.is_writable,
+impl From<SerializableAccountMeta> for AccountMeta {
+    fn from(serializable_account_meta: SerializableAccountMeta) -> Self {
+        Self {
+            pubkey: serializable_account_meta.pubkey,
+            is_signer: serializable_account_meta.is_signer,
+            is_writable: serializable_account_meta.is_writable,
         }
     }
 }

--- a/rust/sealevel/programs/hyperlane-sealevel-token-collateral/src/plugin.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-collateral/src/plugin.rs
@@ -167,7 +167,7 @@ impl HyperlaneSealevelTokenPlugin for CollateralPlugin {
         // And initialize the escrow account.
         invoke(
             &initialize_account(
-                &spl_token_account_info.key,
+                spl_token_account_info.key,
                 escrow_account_info.key,
                 mint_account_info.key,
                 escrow_account_info.key,

--- a/rust/sealevel/programs/hyperlane-sealevel-token/src/plugin.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/src/plugin.rs
@@ -83,7 +83,8 @@ impl SyntheticPlugin {
         if mint_account_info.owner != &spl_token_2022::id() {
             return Err(ProgramError::IncorrectProgramId);
         }
-        return Ok(());
+
+        Ok(())
     }
 
     fn verify_ata_payer_account_info(
@@ -166,7 +167,7 @@ impl HyperlaneSealevelTokenPlugin for SyntheticPlugin {
 
         Ok(Self {
             mint: mint_key,
-            mint_bump: mint_bump,
+            mint_bump,
             ata_payer_bump,
         })
     }

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/src/error.rs
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/src/error.rs
@@ -29,9 +29,9 @@ pub enum Error {
     InvalidMetadata = 10,
 }
 
-impl Into<Error> for MultisigIsmError {
-    fn into(self) -> Error {
-        match self {
+impl From<MultisigIsmError> for Error {
+    fn from(err: MultisigIsmError) -> Self {
+        match err {
             MultisigIsmError::InvalidSignature => Error::InvalidSignature,
             MultisigIsmError::ThresholdNotMet => Error::ThresholdNotMet,
         }

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/src/processor.rs
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/src/processor.rs
@@ -281,7 +281,7 @@ fn verify_account_metas(
     let message = HyperlaneMessage::read_from(&mut &message_bytes[..])
         .map_err(|_| ProgramError::InvalidArgument)?;
     let (domain_pda_key, _) =
-        Pubkey::find_program_address(domain_data_pda_seeds!(message.origin), &program_id);
+        Pubkey::find_program_address(domain_data_pda_seeds!(message.origin), program_id);
 
     Ok(vec![AccountMeta::new_readonly(domain_pda_key, false).into()])
 }
@@ -317,7 +317,7 @@ fn get_validators_and_threshold_account_metas(
     domain: u32,
 ) -> Result<Vec<SerializableAccountMeta>, ProgramError> {
     let (domain_pda_key, _) =
-        Pubkey::find_program_address(domain_data_pda_seeds!(domain), &program_id);
+        Pubkey::find_program_address(domain_data_pda_seeds!(domain), program_id);
 
     Ok(vec![AccountMeta::new_readonly(domain_pda_key, false).into()])
 }

--- a/rust/sealevel/programs/mailbox/src/accounts.rs
+++ b/rust/sealevel/programs/mailbox/src/accounts.rs
@@ -80,9 +80,7 @@ where
     }
 
     pub fn fetch(buf: &mut &[u8]) -> Result<Self, ProgramError> {
-        Ok(Self::from(
-            Self::fetch_data(buf)?.unwrap_or_else(|| Box::<T>::default()),
-        ))
+        Ok(Self::from(Self::fetch_data(buf)?.unwrap_or_default()))
     }
 
     // Optimisically write then realloc on failure.

--- a/rust/sealevel/programs/mailbox/src/processor.rs
+++ b/rust/sealevel/programs/mailbox/src/processor.rs
@@ -462,11 +462,8 @@ fn get_recipient_ism(
     default_ism: Pubkey,
 ) -> Result<Pubkey, ProgramError> {
     let get_ism = MessageRecipientInstruction::InterchainSecurityModule;
-    let get_ism_instruction = Instruction::new_with_bytes(
-        recipient_program_id.clone(),
-        &get_ism.encode()?,
-        account_metas,
-    );
+    let get_ism_instruction =
+        Instruction::new_with_bytes(*recipient_program_id, &get_ism.encode()?, account_metas);
     invoke(&get_ism_instruction, &account_infos)?;
 
     // Default to the default ISM.


### PR DESCRIPTION
### Description

Finally caved and ran `cargo clippy` in `rust/` and `rust/sealevel`, this includes the fixes

### Drive-by changes

Removed console logging from the TracingConfig which was added earlier & doesn't seem to be needed

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Clippy is satisfied so I am too