### PR TITLE
Update sealevel multisig ism to be compatible with CheckpointWithMessageId

### DIFF
--- a/rust/sealevel/Cargo.lock
+++ b/rust/sealevel/Cargo.lock
@@ -719,6 +719,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +939,19 @@ name = "derivation-path"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "rustc_version",
+ "syn 1.0.103",
+]
 
 [[package]]
 name = "dialoguer"
@@ -1611,6 +1630,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "bs58",
+ "derive_more",
  "getrandom 0.2.8",
  "lazy_static",
  "num-derive",

--- a/rust/sealevel/hyperlane-core/Cargo.toml
+++ b/rust/sealevel/hyperlane-core/Cargo.toml
@@ -15,6 +15,7 @@ strum = { version = "0.24", features = ["derive"] }
 strum_macros = "0.24"
 num-traits = "0.2"
 num-derive = "0.3"
+derive_more = "0.99"
 
 # https://github.com/solana-labs/solana/blob/master/docs/src/developing/on-chain-programs/developing-rust.md#depending-on-rand
 getrandom = { version = "0.2.2", features = ["custom"] }

--- a/rust/sealevel/hyperlane-core/src/types/checkpoint.rs
+++ b/rust/sealevel/hyperlane-core/src/types/checkpoint.rs
@@ -1,8 +1,11 @@
+use derive_more::Deref;
 use sha3::digest::Update;
 use sha3::{Digest, Keccak256};
 
 use crate::{Signable, H256};
 
+/// An Hyperlane checkpoint
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct Checkpoint {
     /// The mailbox address
     pub mailbox_address: H256,
@@ -12,7 +15,15 @@ pub struct Checkpoint {
     pub root: H256,
     /// The index of the checkpoint
     pub index: u32,
-    /// The ID of the message at the index.
+}
+
+/// A Hyperlane (checkpoint, messageId) tuple
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Deref)]
+pub struct CheckpointWithMessageId {
+    /// existing Hyperlane checkpoint struct
+    #[deref]
+    pub checkpoint: Checkpoint,
+    /// hash of message emitted from mailbox checkpoint.index
     pub message_id: H256,
 }
 
@@ -27,6 +38,24 @@ impl Signable for Checkpoint {
                 .chain(domain_hash(self.mailbox_address, self.mailbox_domain))
                 .chain(self.root)
                 .chain(self.index.to_be_bytes())
+                .finalize()
+                .as_slice(),
+        )
+    }
+}
+
+impl Signable for CheckpointWithMessageId {
+    /// A hash of the checkpoint contents.
+    /// The EIP-191 compliant version of this hash is signed by validators.
+    fn signing_hash(&self) -> H256 {
+        // sign:
+        // domain_hash(mailbox_address, mailbox_domain) || root || index (as u32) || message_id
+        H256::from_slice(
+            Keccak256::new()
+                .chain(domain_hash(self.mailbox_address, self.mailbox_domain))
+                .chain(self.root)
+                .chain(self.index.to_be_bytes())
+                .chain(self.message_id)
                 .finalize()
                 .as_slice(),
         )

--- a/rust/sealevel/libraries/multisig-ism/src/test_data.rs
+++ b/rust/sealevel/libraries/multisig-ism/src/test_data.rs
@@ -2,12 +2,12 @@
 //! Useful for use in unit & integration tests, which can't import from
 //! each other.
 
-use hyperlane_core::{Checkpoint, HyperlaneMessage, H160, H256};
+use hyperlane_core::{Checkpoint, CheckpointWithMessageId, HyperlaneMessage, Signable, H160, H256};
 use std::str::FromStr;
 
 pub struct MultisigIsmTestData {
     pub message: HyperlaneMessage,
-    pub checkpoint: Checkpoint,
+    pub checkpoint: CheckpointWithMessageId,
     pub validators: Vec<H160>,
     pub signatures: Vec<Vec<u8>>,
 }
@@ -32,44 +32,48 @@ pub fn get_multisig_ism_test_data() -> MultisigIsmTestData {
         body: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
     };
 
-    let checkpoint = Checkpoint {
-        mailbox_address: H256::from_str(
-            "0xabababababababababababababababababababababababababababababababab",
-        )
-        .unwrap(),
-        mailbox_domain: ORIGIN_DOMAIN,
-        root: H256::from_str("0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd")
+    let checkpoint = CheckpointWithMessageId {
+        checkpoint: Checkpoint {
+            mailbox_address: H256::from_str(
+                "0xabababababababababababababababababababababababababababababababab",
+            )
             .unwrap(),
-        index: 69,
+            mailbox_domain: ORIGIN_DOMAIN,
+            root: H256::from_str(
+                "0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+            )
+            .unwrap(),
+            index: 69,
+        },
         message_id: message.id(),
     };
 
     // checkpoint.signing_hash() is equal to:
-    // 0xb7f083667def5ba8a9b22af4faa336e2f5219bfa976a474034a67a9b5b71f13e
+    // 0x4fc33ff33d5e9305a2d87f7824d1b943ba219cff4c153ae8fd39b0d8620fc332
 
     // Validator 0:
     // Address: 0xE3DCDBbc248cE191bDc271f3FCcd0d95911BFC5D
     // Private Key: 0x788aa7213bd92ff92017d767fde0d75601425818c8e4b21e87314c2a4dcd6091
     let validator_0 = H160::from_str("0xE3DCDBbc248cE191bDc271f3FCcd0d95911BFC5D").unwrap();
-    //   > await (new ethers.Wallet('0x788aa7213bd92ff92017d767fde0d75601425818c8e4b21e87314c2a4dcd6091')).signMessage(ethers.utils.arrayify('0xb7f083667def5ba8a9b22af4faa336e2f5219bfa976a474034a67a9b5b71f13e'))
-    //   '0xba6ac92e3e1156c572ad2a9ba8bfc3a5e9492dfe9d0d00c6522682306614969a181962c07c64f8df863ded67ecc628fb19e4998e0521c4555b380a69b0afbf0c1b'
-    let signature_0 = hex::decode("ba6ac92e3e1156c572ad2a9ba8bfc3a5e9492dfe9d0d00c6522682306614969a181962c07c64f8df863ded67ecc628fb19e4998e0521c4555b380a69b0afbf0c1b").unwrap();
+    // > await (new ethers.Wallet('0x788aa7213bd92ff92017d767fde0d75601425818c8e4b21e87314c2a4dcd6091')).signMessage(ethers.utils.arrayify('0x4fc33ff33d5e9305a2d87f7824d1b943ba219cff4c153ae8fd39b0d8620fc332'))
+    // '0x3a06cc01fef07025ee5ae9e29ae783338fe11f5c21af383fb8cc5878a2ea3616125c230ec07b059eaebb842af0a51040ad3214f9050cccef36b5c21c9c9cc4ba1b'
+    let signature_0 = hex::decode("3a06cc01fef07025ee5ae9e29ae783338fe11f5c21af383fb8cc5878a2ea3616125c230ec07b059eaebb842af0a51040ad3214f9050cccef36b5c21c9c9cc4ba1b").unwrap();
 
     // Validator 1:
     // Address: 0xb25206874C24733F05CC0dD11924724A8E7175bd
     // Private Key: 0x4a599de3915f404d84a2ebe522bfe7032ebb1ca76a65b55d6eb212b129043a0e
     let validator_1 = H160::from_str("0xb25206874C24733F05CC0dD11924724A8E7175bd").unwrap();
-    //   > await (new ethers.Wallet('0x4a599de3915f404d84a2ebe522bfe7032ebb1ca76a65b55d6eb212b129043a0e')).signMessage(ethers.utils.arrayify('0xb7f083667def5ba8a9b22af4faa336e2f5219bfa976a474034a67a9b5b71f13e'))
-    //   '0x9034ee44173817edf63c223b5761e3a7580adf34ed6239b25da3e4f9b5c5d6230d903672de6744827f128b89b74be3c3f3ea367a618162f239f1b6d4aae66eec1c'
-    let signature_1 = hex::decode("9034ee44173817edf63c223b5761e3a7580adf34ed6239b25da3e4f9b5c5d6230d903672de6744827f128b89b74be3c3f3ea367a618162f239f1b6d4aae66eec1c").unwrap();
+    // > await (new ethers.Wallet('0x4a599de3915f404d84a2ebe522bfe7032ebb1ca76a65b55d6eb212b129043a0e')).signMessage(ethers.utils.arrayify('0x4fc33ff33d5e9305a2d87f7824d1b943ba219cff4c153ae8fd39b0d8620fc332'))
+    // '0xfd34aac152ec85a79211c990f308c7e719145e2e67e48f2d10db4347d3a9102131254eccbcd0fe389afad96b88d368192b33649336893dfe1bbad43901d1bef71b'
+    let signature_1 = hex::decode("fd34aac152ec85a79211c990f308c7e719145e2e67e48f2d10db4347d3a9102131254eccbcd0fe389afad96b88d368192b33649336893dfe1bbad43901d1bef71b").unwrap();
 
     // Validator 2:
     // Address: 0x28b8d0E2bBfeDe9071F8Ff3DaC9CcE3d3176DBd3
     // Private Key: 0x2cc76d56db9924ddc3388164454dfea9edd2d5f5da81102fd3594fc7c5281515
     let validator_2 = H160::from_str("0x28b8d0E2bBfeDe9071F8Ff3DaC9CcE3d3176DBd3").unwrap();
-    //   > await (new ethers.Wallet('0x2cc76d56db9924ddc3388164454dfea9edd2d5f5da81102fd3594fc7c5281515')).signMessage(ethers.utils.arrayify('0xb7f083667def5ba8a9b22af4faa336e2f5219bfa976a474034a67a9b5b71f13e'))
-    //   '0x2b228823c04b9dd37577763043127fe3307074bb45968302c6111e8e334c3cd25292061618f392549c81351ae9e08d5c4a1e0b9947b79a30f8d693257e8818731c'
-    let signature_2 = hex::decode("2b228823c04b9dd37577763043127fe3307074bb45968302c6111e8e334c3cd25292061618f392549c81351ae9e08d5c4a1e0b9947b79a30f8d693257e8818731c").unwrap();
+    // > await (new ethers.Wallet('0x2cc76d56db9924ddc3388164454dfea9edd2d5f5da81102fd3594fc7c5281515')).signMessage(ethers.utils.arrayify('0x4fc33ff33d5e9305a2d87f7824d1b943ba219cff4c153ae8fd39b0d8620fc332'))
+    // '0x85992e471002c40730d2b91831ba40cd8ffcebf4905646c25b7b6abb7575f25d19395045466e833b7700e233bfa5836f0a459da05bf817efd6cb4f55bcaec4b51c'
+    let signature_2 = hex::decode("85992e471002c40730d2b91831ba40cd8ffcebf4905646c25b7b6abb7575f25d19395045466e833b7700e233bfa5836f0a459da05bf817efd6cb4f55bcaec4b51c").unwrap();
 
     MultisigIsmTestData {
         message,

--- a/rust/sealevel/libraries/multisig-ism/src/test_data.rs
+++ b/rust/sealevel/libraries/multisig-ism/src/test_data.rs
@@ -2,7 +2,7 @@
 //! Useful for use in unit & integration tests, which can't import from
 //! each other.
 
-use hyperlane_core::{Checkpoint, CheckpointWithMessageId, HyperlaneMessage, Signable, H160, H256};
+use hyperlane_core::{Checkpoint, CheckpointWithMessageId, HyperlaneMessage, H160, H256};
 use std::str::FromStr;
 
 pub struct MultisigIsmTestData {

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/src/processor.rs
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/src/processor.rs
@@ -1,4 +1,4 @@
-use hyperlane_core::{Checkpoint, Decode, HyperlaneMessage, IsmType};
+use hyperlane_core::{Checkpoint, CheckpointWithMessageId, Decode, HyperlaneMessage, IsmType};
 
 use access_control::AccessControl;
 use account_utils::create_pda_account;
@@ -250,11 +250,13 @@ fn verify(
     let validators_and_threshold = validators_and_threshold(program_id, accounts, message.origin)?;
 
     let multisig_ism = MultisigIsm::new(
-        Checkpoint {
-            mailbox_address: metadata.origin_mailbox,
-            mailbox_domain: message.origin,
-            root: metadata.merkle_root,
-            index: message.nonce,
+        CheckpointWithMessageId {
+            checkpoint: Checkpoint {
+                mailbox_address: metadata.origin_mailbox,
+                mailbox_domain: message.origin,
+                root: metadata.merkle_root,
+                index: message.nonce,
+            },
             message_id: message.id(),
         },
         metadata.validator_signatures,


### PR DESCRIPTION
### Description

Fixes #2347, changes tests as required

### Drive-by changes

no

### Related issues

- Fixes #2347 

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Unit Tests
