### PR TITLE
Start scraper message_dispatch sync from high watermark

### DIFF
--- a/rust/agents/scraper/src/chain_scraper/mod.rs
+++ b/rust/agents/scraper/src/chain_scraper/mod.rs
@@ -65,6 +65,12 @@ impl HyperlaneSqlDb {
         &self.domain
     }
 
+    pub async fn last_message_nonce(&self) -> Result<Option<u32>> {
+        self.db
+            .last_message_nonce(self.domain.id(), &self.mailbox_address)
+            .await
+    }
+
     /// Takes a list of txn and block hashes and ensure they are all in the
     /// database. If any are not it will fetch the data and insert them.
     ///

--- a/rust/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/hyperlane-base/src/contract_sync/mod.rs
@@ -123,6 +123,7 @@ impl MessageContractSync {
     pub async fn forward_message_sync_cursor(
         &self,
         index_settings: IndexSettings,
+        next_nonce: u32,
     ) -> Box<dyn ContractSyncCursor<HyperlaneMessage>> {
         let forward_data = MessageSyncCursor::new(
             self.indexer.clone(),
@@ -130,7 +131,7 @@ impl MessageContractSync {
             index_settings.chunk_size,
             index_settings.from,
             index_settings.from,
-            0,
+            next_nonce,
         );
         Box::new(ForwardMessageSyncCursor::new(forward_data))
     }


### PR DESCRIPTION
### Description

This PR addresses an issue in which BSC RPC providers have a very hard time providing very old transactions.

This caused BSC scraping to fail, since the scraper had never actually indexed very early BSC messages (e.g. nonce 0).

By starting at the latest scraped nonce - 1, the scraper will bypass this issue.

### Drive-by changes

None

