### PR TITLE
Prevent AWS KMS throttling in validator

### DIFF
--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -57,7 +57,7 @@ impl ValidatorSubmitter {
         }
     }
 
-    #[instrument(err, skip(self), fields(domain=%self.mailbox.domain()))]
+    #[instrument(err, skip(self, tree), fields(domain=%self.mailbox.domain()))]
     pub(crate) async fn checkpoint_submitter(
         self,
         mut tree: IncrementalMerkle,


### PR DESCRIPTION
### Description

Observed in validator
```
Request ID: Some("c0cc123e-da52-47f4-a2d3-aeddd034a2f5") Body: {"__type":"ThrottlingException","message":"You have exceeded the rate at which you may call KMS. Reduce the frequency of your calls."}
```

- Add sleep and checkpoint sync cache for rate limit

### Drive-by changes

- Skip tree in checkpoint submitter span

### Backward compatibility

Yes

### Testing

Local testing