### PR TITLE
Existing deployment support in Router tooling, small ISM factory fixes

### DIFF
--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
@@ -113,8 +113,14 @@ export class HyperlaneIsmFactory extends HyperlaneApp<IsmFactoryFactories> {
         .deploy();
       await this.multiProvider.handleTx(chain, multisig.deployTransaction);
       const originDomain = this.multiProvider.getDomainId(origin!);
-      await multisig.enrollValidators([originDomain], [config.validators]);
-      await multisig.setThreshold(originDomain, config.threshold);
+      await this.multiProvider.handleTx(
+        chain,
+        multisig.enrollValidators([originDomain], [config.validators]),
+      );
+      await this.multiProvider.handleTx(
+        chain,
+        multisig.setThreshold(originDomain, config.threshold),
+      );
       address = multisig.address;
     } else {
       const multisigIsmFactory =
@@ -163,7 +169,10 @@ export class HyperlaneIsmFactory extends HyperlaneApp<IsmFactoryFactories> {
       moduleAddress,
       this.multiProvider.getSigner(chain),
     );
-    await routingIsm.transferOwnership(config.owner);
+    await this.multiProvider.handleTx(
+      chain,
+      await routingIsm.transferOwnership(config.owner),
+    );
     const address = dispatchLogs[0].args['module'];
     return IRoutingIsm__factory.connect(address, signer);
   }

--- a/typescript/sdk/src/middleware/liquidity-layer/LiquidityLayerRouterDeployer.ts
+++ b/typescript/sdk/src/middleware/liquidity-layer/LiquidityLayerRouterDeployer.ts
@@ -5,7 +5,7 @@ import {
   LiquidityLayerRouter,
   PortalAdapter,
 } from '@hyperlane-xyz/core';
-import { utils } from '@hyperlane-xyz/utils';
+import { types, utils } from '@hyperlane-xyz/utils';
 
 import { HyperlaneContracts, HyperlaneContractsMap } from '../../contracts';
 import { MultiProvider } from '../../providers/MultiProvider';
@@ -86,9 +86,10 @@ export class LiquidityLayerDeployer extends ProxiedRouterDeployer<
   async enrollRemoteRouters(
     contractsMap: HyperlaneContractsMap<LiquidityLayerFactories>,
     configMap: ChainMap<LiquidityLayerConfig>,
+    additionalRouters: ChainMap<types.Address>,
   ): Promise<void> {
     this.logger(`Enroll LiquidityLayerRouters with each other`);
-    await super.enrollRemoteRouters(contractsMap, configMap);
+    await super.enrollRemoteRouters(contractsMap, configMap, additionalRouters);
 
     this.logger(`Enroll CircleBridgeAdapters with each other`);
     // Hack to allow use of super.enrollRemoteRouters
@@ -103,7 +104,7 @@ export class LiquidityLayerDeployer extends ProxiedRouterDeployer<
           liquidityLayerRouter: contracts.circleBridgeAdapter,
         }),
       ) as unknown as HyperlaneContractsMap<LiquidityLayerFactories>,
-      configMap,
+      {},
     );
 
     this.logger(`Enroll PortalAdapters with each other`);
@@ -120,6 +121,7 @@ export class LiquidityLayerDeployer extends ProxiedRouterDeployer<
         }),
       ) as unknown as HyperlaneContractsMap<LiquidityLayerFactories>,
       configMap,
+      additionalRouters,
     );
   }
 

--- a/typescript/sdk/src/middleware/liquidity-layer/LiquidityLayerRouterDeployer.ts
+++ b/typescript/sdk/src/middleware/liquidity-layer/LiquidityLayerRouterDeployer.ts
@@ -104,7 +104,8 @@ export class LiquidityLayerDeployer extends ProxiedRouterDeployer<
           liquidityLayerRouter: contracts.circleBridgeAdapter,
         }),
       ) as unknown as HyperlaneContractsMap<LiquidityLayerFactories>,
-      {},
+      configMap,
+      additionalRouters,
     );
 
     this.logger(`Enroll PortalAdapters with each other`);

--- a/typescript/sdk/src/middleware/liquidity-layer/LiquidityLayerRouterDeployer.ts
+++ b/typescript/sdk/src/middleware/liquidity-layer/LiquidityLayerRouterDeployer.ts
@@ -86,10 +86,10 @@ export class LiquidityLayerDeployer extends ProxiedRouterDeployer<
   async enrollRemoteRouters(
     contractsMap: HyperlaneContractsMap<LiquidityLayerFactories>,
     configMap: ChainMap<LiquidityLayerConfig>,
-    additionalRouters: ChainMap<types.Address>,
+    foreignRouters: ChainMap<types.Address>,
   ): Promise<void> {
     this.logger(`Enroll LiquidityLayerRouters with each other`);
-    await super.enrollRemoteRouters(contractsMap, configMap, additionalRouters);
+    await super.enrollRemoteRouters(contractsMap, configMap, foreignRouters);
 
     this.logger(`Enroll CircleBridgeAdapters with each other`);
     // Hack to allow use of super.enrollRemoteRouters
@@ -105,7 +105,7 @@ export class LiquidityLayerDeployer extends ProxiedRouterDeployer<
         }),
       ) as unknown as HyperlaneContractsMap<LiquidityLayerFactories>,
       configMap,
-      additionalRouters,
+      foreignRouters,
     );
 
     this.logger(`Enroll PortalAdapters with each other`);
@@ -122,7 +122,7 @@ export class LiquidityLayerDeployer extends ProxiedRouterDeployer<
         }),
       ) as unknown as HyperlaneContractsMap<LiquidityLayerFactories>,
       configMap,
-      additionalRouters,
+      foreignRouters,
     );
   }
 

--- a/typescript/sdk/src/router/GasRouterDeployer.ts
+++ b/typescript/sdk/src/router/GasRouterDeployer.ts
@@ -20,9 +20,9 @@ export abstract class GasRouterDeployer<
   async enrollRemoteRouters(
     contractsMap: HyperlaneContractsMap<Factories>,
     configMap: ChainMap<Config>,
-    additionalRouters: ChainMap<types.Address> = {},
+    foreignRouters: ChainMap<types.Address> = {},
   ): Promise<void> {
-    await super.enrollRemoteRouters(contractsMap, configMap, additionalRouters);
+    await super.enrollRemoteRouters(contractsMap, configMap, foreignRouters);
 
     this.logger(`Setting enrolled router destination gas...`);
     for (const [chain, contracts] of Object.entries(contractsMap)) {

--- a/typescript/sdk/src/router/GasRouterDeployer.ts
+++ b/typescript/sdk/src/router/GasRouterDeployer.ts
@@ -1,4 +1,5 @@
 import { GasRouter } from '@hyperlane-xyz/core';
+import { types } from '@hyperlane-xyz/utils';
 
 import {
   HyperlaneContracts,
@@ -19,8 +20,9 @@ export abstract class GasRouterDeployer<
   async enrollRemoteRouters(
     contractsMap: HyperlaneContractsMap<Factories>,
     configMap: ChainMap<Config>,
+    additionalRouters: ChainMap<types.Address> = {},
   ): Promise<void> {
-    await super.enrollRemoteRouters(contractsMap, configMap);
+    await super.enrollRemoteRouters(contractsMap, configMap, additionalRouters);
 
     this.logger(`Setting enrolled router destination gas...`);
     for (const [chain, contracts] of Object.entries(contractsMap)) {

--- a/typescript/sdk/src/router/HyperlaneRouterChecker.ts
+++ b/typescript/sdk/src/router/HyperlaneRouterChecker.ts
@@ -8,8 +8,10 @@ import { ChainName } from '../types';
 
 import { RouterApp } from './RouterApps';
 import {
+  ConnectionClientConfig,
   ConnectionClientViolation,
   ConnectionClientViolationType,
+  OwnableConfig,
   RouterConfig,
 } from './types';
 
@@ -33,7 +35,7 @@ export class HyperlaneRouterChecker<
     const router = this.app.router(this.app.getContracts(chain));
 
     const checkConnectionClientProperty = async (
-      property: keyof RouterConfig,
+      property: keyof (ConnectionClientConfig & OwnableConfig),
       violationType: ConnectionClientViolationType,
     ) => {
       const actual = await router[property]();

--- a/typescript/sdk/src/router/HyperlaneRouterDeployer.ts
+++ b/typescript/sdk/src/router/HyperlaneRouterDeployer.ts
@@ -115,7 +115,6 @@ export abstract class HyperlaneRouterDeployer<
           return current !== expected ? [remoteDomain, expected] : undefined;
         }),
       );
-
       const entries = enrollEntries.filter(
         (entry): entry is [number, string] => entry !== undefined,
       );

--- a/typescript/sdk/src/router/types.ts
+++ b/typescript/sdk/src/router/types.ts
@@ -11,7 +11,13 @@ export type OwnableConfig = {
   owner: types.Address;
 };
 
-export type RouterConfig = ConnectionClientConfig & OwnableConfig;
+export type ExistingDeploymentConfig = {
+  existingDeployment?: types.Address;
+};
+
+export type RouterConfig = ConnectionClientConfig &
+  OwnableConfig &
+  ExistingDeploymentConfig;
 
 export type GasConfig = {
   gas: number;

--- a/typescript/sdk/src/router/types.ts
+++ b/typescript/sdk/src/router/types.ts
@@ -11,13 +11,13 @@ export type OwnableConfig = {
   owner: types.Address;
 };
 
-export type ExistingDeploymentConfig = {
-  existingDeployment?: types.Address;
+export type ForeignDeploymentConfig = {
+  foreignDeployment?: types.Address;
 };
 
 export type RouterConfig = ConnectionClientConfig &
   OwnableConfig &
-  ExistingDeploymentConfig;
+  ForeignDeploymentConfig;
 
 export type GasConfig = {
   gas: number;


### PR DESCRIPTION
### Description

To accommodate warp routes that exist on EVM chains *and* other execution environments, we need the ability to enroll remote routers on EVM-based routers that weren't deployed by the router deployer. This adds a new optional `foreignDeployment` property to the `RouterConfig`, which means that deployment will not be attempted to this chain, but it will be enrolled as a remote router on any contracts that are deployed to. The general flow looks something like:
  * Deploy the warp route contracts on all EVM chains, enrolling each other as routers
  * Deploy the warp route contracts on the alt execution environment chains, also configuring the existing EVM contract deployments as `foreignDeployment`s so that they are enrolled as routers on the alt execution environment contracts
  * Now equipped with *all* the router addresses, any new non-EVM router addresses are configured as `foreignDeployment`s, which now enrolls these routers on the EVM chains

Note there's still a lot left to be desired even with this change -- e.g. much of the tooling expects the MultiProvider to include metadata (& even providers) for each and every chain. Because the MultiProvider is of course EVM only, things get a bit weird. For now, I've been able to deploy warp routes with configs relating to a sealevel chain successfully by just running a local Anvil instance and setting the RPC URL of the sealevel config to that anvil instance. We'll want to readdress this at some point, but for now I'd prefer to have a flow that just works and we can be more intentional about bigger deploy / tooling changes to support alt execution environments in the future

This also includes some small changes to the ISM factory - because we werent actually waiting for the `enrollValidators` tx to succeed before trying `setThreshold`, the gas estimation of `setThreshold` would fail because the threshold of 1 exceeded the current on-chain validator set size of 0. It also sometimes resulted in nonce contention

I was able to get everything in hyperlane-deploy working locally by having dependencies be local filepaths

The order of operations for things iiuc looks like:
1. Merge this
2. Ship new SDK version
3. Update hyperlane-token to use this new SDK version
4. Ship new hyperlane-token version
5. Update hyperlane-deploy to use the new SDK version and the new hyperlane-token

### Drive-by changes

none

### Related issues

- partially https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/2366

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

unit tests, ran deploy tooling