### PR TITLE
Accurately use little endian encoding of nonce / slot in DispatchedMessage, small fixes

### DIFF
--- a/rust/hyperlane-base/src/settings/chains.rs
+++ b/rust/hyperlane-base/src/settings/chains.rs
@@ -243,8 +243,8 @@ impl FromRawConf<'_, RawChainConf> for ChainConf {
 
         let domain = connection
             .as_ref()
-            .ok_or_else(|| eyre!("Missing `domain` configuration"))
-            .take_err(&mut err, || cwp + "domain")
+            .ok_or_else(|| eyre!("Missing `connection` configuration"))
+            .take_err(&mut err, || cwp + "connection")
             .and_then(|c: &ChainConnectionConf| {
                 let protocol = c.protocol();
                 let domain_id = raw

--- a/rust/sealevel/README.md
+++ b/rust/sealevel/README.md
@@ -30,6 +30,8 @@ git clone git@github.com:Eclipse-Laboratories-Inc/solar-eclipse --branch steven/
 
 This is a fork (with some dependency fixes) of the eclipse fork of the `solana-program-library`. This contains "SPL" programs that are commonly used programs - stuff like the token program, etc.
 
+Note these instructions previously required a different remote and branch - make sure to move to this remote & branch if you ahven't already!
+
 1. Check out the branch `trevor/steven/eclipse-1.14.13/with-tlv-lib`:
 
 ```

--- a/rust/sealevel/client/src/main.rs
+++ b/rust/sealevel/client/src/main.rs
@@ -62,7 +62,7 @@ use solana_sdk::{
     transaction::Transaction,
 };
 
-use std::path::PathBuf;
+use std::{path::PathBuf, str::FromStr};
 
 mod cmd_utils;
 mod r#core;
@@ -320,7 +320,7 @@ struct TokenTransferRemote {
     destination_domain: u32,
     #[arg(long, short = 't', default_value_t = HYPERLANE_TOKEN_PROG_ID)]
     destination_token_program_id: Pubkey,
-    recipient: Pubkey,
+    recipient: String,
     #[arg(value_enum)]
     token_type: TokenType,
 }
@@ -856,6 +856,13 @@ fn process_token_cmd(mut ctx: Context, cmd: TokenCmd) {
             is_keypair(&xfer.sender).unwrap();
             let sender = read_keypair_file(xfer.sender).unwrap();
 
+            let recipient = if xfer.recipient.starts_with("0x") {
+                H256::from_str(&xfer.recipient).unwrap()
+            } else {
+                let pubkey = Pubkey::from_str(&xfer.recipient).unwrap();
+                H256::from_slice(&pubkey.to_bytes()[..])
+            };
+
             let (token_account, _token_bump) =
                 Pubkey::find_program_address(hyperlane_token_pda_seeds!(), &xfer.program_id);
             let (dispatch_authority_account, _dispatch_authority_bump) =
@@ -876,7 +883,7 @@ fn process_token_cmd(mut ctx: Context, cmd: TokenCmd) {
 
             let ixn = HtInstruction::TransferRemote(HtTransferRemote {
                 destination_domain: xfer.destination_domain,
-                recipient: xfer.recipient.to_bytes().into(),
+                recipient,
                 amount_or_id: xfer.amount.into(),
             });
 


### PR DESCRIPTION
### Description

* moved to using little endian encoding of some variables in the `DispatchedMessage` struct in the agents to match what's done on-chain
* Noticed an inaccurate config error message
* the `token enroll-remote-router` command now accepts H256 hex strings and pubkeys

### Drive-by changes

no

### Related issues

none

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

e2e test