### PR TITLE
Reclaim funds from old relayer keys

### DIFF
--- a/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
+++ b/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
@@ -92,11 +92,11 @@ async function transferForEnv(ctx: Contexts, env: DeployEnvironment) {
       }
     }
     if (!errorOccurred) {
-      // await fromKey.delete();
-      // console.log('Deleted key', {
-      //   from: fromKey.identifier,
-      //   fromKey: fromKey.address,
-      // });
+      await fromKey.delete();
+      console.log('Deleted key', {
+        from: fromKey.identifier,
+        fromKey: fromKey.address,
+      });
     }
   }
 }

--- a/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
+++ b/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
@@ -175,8 +175,12 @@ async function transfer(
     maxPriorityFeePerGas: formatEther(feeData.maxPriorityFeePerGas ?? 0),
     transferTx,
   });
-  const receipt = await signer.sendTransaction(transferTx);
-
+  const response = await signer.sendTransaction(transferTx);
+  console.log('Transfer sent', {
+    ...logCtx,
+    response,
+  });
+  const receipt = await provider.waitForTransaction(response.hash);
   console.log('Transferred funds', {
     ...logCtx,
     receipt,

--- a/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
+++ b/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
@@ -143,23 +143,12 @@ async function transfer(
     return;
   }
 
-  // transferTx.value = initialBalance.sub(costToTransfer);
-  transferTx.value = BigNumber.from(1);
+  transferTx.value = initialBalance.sub(costToTransfer);
   transferTx.gasLimit = gasToTransfer;
-  // transferTx.maxFeePerGas = gasPrice;
 
   console.debug('Sending transaction');
   const receipt = await signer.sendTransaction(transferTx);
 
-  // let receipt;
-  // try {
-  //   receipt = await multiProvider.sendTransaction(chain, transferTx);
-  // } catch (err) {
-  //   console.debug('Sending transaction failed, retrying with gasPrice', err);
-  //   delete transferTx.maxFeePerGas;
-  //   transferTx.gasPrice = gasPrice;
-  //   receipt = await multiProvider.sendTransaction(chain, transferTx);
-  // }
   console.log('Transferred funds', {
     ...logCtx,
     initialBalance: formatEther(initialBalance),

--- a/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
+++ b/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
@@ -55,7 +55,7 @@ async function transferForEnv(ctx: Contexts, env: DeployEnvironment) {
   // always transfer to the main hyperlane context
   const toKey = getCloudAgentKey(
     getAgentConfig(Contexts.Hyperlane, envConfig),
-    Role.Relayer,
+    Role.Deployer,
   );
   await toKey.fetch();
 

--- a/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
+++ b/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
@@ -1,0 +1,138 @@
+import { PopulatedTransaction } from 'ethers';
+import { formatEther } from 'ethers/lib/utils';
+
+import {
+  AgentConnectionType,
+  ChainName,
+  Chains,
+  HyperlaneIgp,
+  MultiProvider,
+  ProtocolType,
+  chainMetadata,
+} from '@hyperlane-xyz/sdk';
+
+import { Contexts } from '../config/contexts';
+import { AgentAwsKey } from '../src/agents/aws';
+import { getCloudAgentKey } from '../src/agents/key-utils';
+import { BaseAgentKey } from '../src/agents/keys';
+import { AgentContextConfig } from '../src/config';
+import {
+  DeployEnvironment,
+  deployEnvToSdkEnv,
+} from '../src/config/environment';
+import { Role } from '../src/roles';
+
+import { getAgentConfig, getEnvironmentConfig } from './utils';
+
+const ENVIRONMENTS: DeployEnvironment[] = ['mainnet2', 'testnet3'];
+
+async function main() {
+  for (const ctx of Object.values(Contexts)) {
+    for (const env of ENVIRONMENTS) {
+      const envConfig = getEnvironmentConfig(env);
+      const agentConfig = getAgentConfig(ctx, envConfig);
+
+      // always fund from the current context and relayer role to the new relayer key
+      const multiProvider = await envConfig.getMultiProvider(
+        ctx,
+        Role.Relayer,
+        AgentConnectionType.Http,
+      );
+      const igp = HyperlaneIgp.fromEnvironment(
+        deployEnvToSdkEnv[env],
+        multiProvider,
+      );
+
+      const toKey = getCloudAgentKey(agentConfig, Role.Relayer);
+
+      for (const chain of Object.values(Chains)) {
+        await transfer(chain, agentConfig, igp, multiProvider, toKey);
+      }
+    }
+  }
+}
+
+async function transfer(
+  chain: Chains,
+  agentConfig: AgentContextConfig,
+  igp: HyperlaneIgp,
+  multiProvider: MultiProvider,
+  toKey: BaseAgentKey,
+) {
+  if (chainMetadata[chain].protocol != ProtocolType.Ethereum) return;
+  const fromKey = new OldRelayerAwsKey(agentConfig, chain);
+
+  const igpContract = igp.getContracts(chain).interchainGasPaymaster;
+
+  const igpBalance = await multiProvider
+    .getProvider(chain)
+    .getBalance(igpContract.address);
+  const claimIgpFundsTx = await igpContract.populateTransaction.claim();
+  const gasToClaimIgpFunds = await multiProvider.estimateGas(
+    chain,
+    claimIgpFundsTx,
+  );
+  let gasPrice = await multiProvider.getProvider(chain).getGasPrice();
+  const costToClaimIgpFunds = gasPrice.mul(gasToClaimIgpFunds);
+  if (igpBalance.gt(costToClaimIgpFunds)) {
+    // only claim if the cost to do so is less than the balance we are claiming
+    // await multiProvider.sendTransaction(chain, claimIgpFundsTx);
+    console.log('Claimed IGP funds', {
+      igpAddress: igpContract.address,
+      igpBalance: formatEther(igpBalance),
+      cost: formatEther(costToClaimIgpFunds),
+      tx: claimIgpFundsTx,
+    });
+    // update gas price since we might have waited a while
+    gasPrice = await multiProvider.getProvider(chain).getGasPrice();
+  } else {
+    console.log('IGP balance too low to claim', {
+      igpAddress: igpContract.address,
+      igpBalance: formatEther(igpBalance),
+      cost: formatEther(costToClaimIgpFunds),
+    });
+  }
+
+  const currentBalance = await multiProvider
+    .getProvider(chain)
+    .getBalance(fromKey.address);
+  const transferTx: PopulatedTransaction = {
+    to: toKey.address,
+    value: currentBalance,
+  };
+  const gasToTransfer = await multiProvider.estimateGas(chain, transferTx);
+  const costToTransfer = gasToTransfer.mul(gasPrice);
+  if (costToTransfer.gt(currentBalance)) {
+    console.log('Not enough funds to transfer', {
+      address: fromKey.address,
+      balance: formatEther(currentBalance),
+    });
+    return;
+  }
+  transferTx.value = currentBalance.sub(costToTransfer);
+  transferTx.gasLimit = gasToTransfer;
+  // await multiProvider.sendTransaction(chain, transferTx);
+  console.log('Transferred funds', {
+    originalBalance: formatEther(currentBalance),
+    finalBalance: formatEther(
+      await multiProvider.getProvider(chain).getBalance(fromKey.address),
+    ),
+    destinationBalance: formatEther(
+      await multiProvider.getProvider(chain).getBalance(toKey.address),
+    ),
+    gas: costToTransfer,
+    transferTx,
+  });
+}
+
+class OldRelayerAwsKey extends AgentAwsKey {
+  constructor(config: AgentContextConfig, chainName: ChainName) {
+    super(config, Role.Relayer, chainName);
+  }
+
+  get identifier(): string {
+    return `${this.context}-${this.environment}-key-${this.chainName}-${this.role}`;
+  }
+}
+
+main().then(console.log).catch(console.error);

--- a/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
+++ b/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
@@ -21,7 +21,7 @@ import { Role } from '../src/roles';
 
 import { getAgentConfig, getEnvironmentConfig } from './utils';
 
-const ENVIRONMENTS: DeployEnvironment[] = ['mainnet2'];
+const ENVIRONMENTS: DeployEnvironment[] = ['testnet3', 'mainnet2'];
 
 const L2Chains: ChainName[] = [
   Chains.optimism,
@@ -75,7 +75,7 @@ async function transferForEnv(ctx: Contexts, env: DeployEnvironment) {
     const fromKey = new OldRelayerAwsKey(agentConfig, relayerOriginChain);
     await fromKey.fetch();
     // start all the promises and then wait for them to finish
-    const promises = chainsForEnv.map((chain) =>
+    const promises = [].map((chain) =>
       transfer(chain, agentConfig, providers[chain], fromKey, toKey),
     );
     for (const p of promises) {
@@ -92,8 +92,8 @@ async function transferForEnv(ctx: Contexts, env: DeployEnvironment) {
       }
     }
     if (!errorOccurred) {
-      await fromKey.delete();
-      console.log('Deleted key', {
+      await fromKey.disable();
+      console.log('Disabled key', {
         from: fromKey.identifier,
         fromKey: fromKey.address,
       });

--- a/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
+++ b/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
@@ -21,8 +21,7 @@ import { Role } from '../src/roles';
 
 import { getAgentConfig, getEnvironmentConfig } from './utils';
 
-// const ENVIRONMENTS: DeployEnvironment[] = ['mainnet2', 'testnet3'];
-const ENVIRONMENTS: DeployEnvironment[] = ['testnet3'];
+const ENVIRONMENTS: DeployEnvironment[] = ['mainnet2'];
 
 const L2Chains: ChainName[] = [
   Chains.optimism,
@@ -38,14 +37,14 @@ async function main() {
     }
   }
 
-  // const envConfig = getEnvironmentConfig('testnet3');
+  // const envConfig = getEnvironmentConfig('mainnet2');
   // const agentConfig = getAgentConfig(Contexts.Hyperlane, envConfig);
-  // const from = new OldRelayerAwsKey(agentConfig, Chains.mumbai);
-  // const to = getCloudAgentKey(agentConfig, Role.Relayer);
-  // const provider = await fetchProvider('testnet3', Chains.bsctestnet);
+  // const from = new OldRelayerAwsKey(agentConfig, Chains.bsc);
+  // const to = getCloudAgentKey(agentConfig, Role.Deployer);
+  // const provider = await fetchProvider('mainnet2', Chains.optimism);
   //
   // await Promise.all([from.fetch(), to.fetch()]);
-  // await transfer(Chains.bsctestnet, agentConfig, provider, from, to);
+  // await transfer(Chains.optimism, agentConfig, provider, from, to);
 }
 
 async function transferForEnv(ctx: Contexts, env: DeployEnvironment) {
@@ -93,11 +92,11 @@ async function transferForEnv(ctx: Contexts, env: DeployEnvironment) {
       }
     }
     if (!errorOccurred) {
-      await fromKey.delete();
-      console.log('Deleted key', {
-        from: fromKey.identifier,
-        fromKey: fromKey.address,
-      });
+      // await fromKey.delete();
+      // console.log('Deleted key', {
+      //   from: fromKey.identifier,
+      //   fromKey: fromKey.address,
+      // });
     }
   }
 }
@@ -160,7 +159,11 @@ async function transfer(
     transferTx.gasPrice = gasPrice;
   }
 
-  if (L2Chains.includes(chain)) {
+  if (chain == Chains.optimism) {
+    // I give up, the correct way to do this is make a contract call against the gas oracle with an
+    // RLP encoded version of the txn, but this is probably close enough to work most of the time.
+    costToTransfer = costToTransfer.add(BigNumber.from(4e-5 * 1e18));
+  } else if (L2Chains.includes(chain)) {
     // 25% extra for l1 security fees
     costToTransfer = costToTransfer.mul(5).div(4);
   }

--- a/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
+++ b/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
@@ -14,7 +14,7 @@ import { Contexts } from '../config/contexts';
 import { AgentAwsKey } from '../src/agents/aws';
 import { getCloudAgentKey } from '../src/agents/key-utils';
 import { CloudAgentKey } from '../src/agents/keys';
-import { AgentContextConfig, DeployEnvironment } from '../src/config';
+import { AgentContextConfig } from '../src/config';
 import { Role } from '../src/roles';
 
 import { getAgentConfig, getEnvironmentConfig } from './utils';
@@ -45,51 +45,58 @@ async function main() {
   const from = new OldRelayerAwsKey(agentConfig, Chains.fuji);
   const to = getCloudAgentKey(agentConfig, Role.Relayer);
   await Promise.all([from.fetch(), to.fetch()]);
-  await transfer(Chains.optimismgoerli, agentConfig, multiProvider, from, to);
+  await transfer(
+    Chains.fuji,
+    Chains.optimismgoerli,
+    agentConfig,
+    multiProvider,
+    from,
+    to,
+  );
 }
 
-// @ts-ignore
-async function transferForEnv(ctx: Contexts, env: DeployEnvironment) {
-  const envConfig = getEnvironmentConfig(env);
-  const agentConfig = getAgentConfig(ctx, envConfig);
-
-  // always fund from the current context and relayer role to the new relayer key
-  const multiProvider = await envConfig.getMultiProvider(
-    ctx,
-    Role.Relayer,
-    AgentConnectionType.Http,
-  );
-
-  const toKey = getCloudAgentKey(agentConfig, Role.Relayer);
-  await toKey.fetch();
-
-  const chainsForEnv = Object.keys(envConfig.chainMetadataConfigs).filter(
-    (chain) => chainMetadata[chain].protocol == ProtocolType.Ethereum,
-  );
-  for (const originChain of chainsForEnv) {
-    try {
-      const fromKey = new OldRelayerAwsKey(agentConfig, originChain);
-      await fromKey.fetch();
-      for (const chain of chainsForEnv) {
-        await transfer(chain, agentConfig, multiProvider, fromKey, toKey);
-      }
-      await fromKey.delete();
-      console.log('Deleted key', {
-        from: fromKey.identifier,
-        fromKey: fromKey.address,
-      });
-    } catch (err) {
-      console.error('Error transferring funds', {
-        ctx,
-        env,
-        originChain,
-        err,
-      });
-    }
-  }
-}
+// async function transferForEnv(ctx: Contexts, env: DeployEnvironment) {
+//   const envConfig = getEnvironmentConfig(env);
+//   const agentConfig = getAgentConfig(ctx, envConfig);
+//
+//   // always fund from the current context and relayer role to the new relayer key
+//   const multiProvider = await envConfig.getMultiProvider(
+//     ctx,
+//     Role.Relayer,
+//     AgentConnectionType.Http,
+//   );
+//
+//   const toKey = getCloudAgentKey(agentConfig, Role.Relayer);
+//   await toKey.fetch();
+//
+//   const chainsForEnv = Object.keys(envConfig.chainMetadataConfigs).filter(
+//     (chain) => chainMetadata[chain].protocol == ProtocolType.Ethereum,
+//   );
+//   for (const originChain of chainsForEnv) {
+//     try {
+//       const fromKey = new OldRelayerAwsKey(agentConfig, originChain);
+//       await fromKey.fetch();
+//       for (const chain of chainsForEnv) {
+//         await transfer(chain, agentConfig, multiProvider, fromKey, toKey);
+//       }
+//       await fromKey.delete();
+//       console.log('Deleted key', {
+//         from: fromKey.identifier,
+//         fromKey: fromKey.address,
+//       });
+//     } catch (err) {
+//       console.error('Error transferring funds', {
+//         ctx,
+//         env,
+//         originChain,
+//         err,
+//       });
+//     }
+//   }
+// }
 
 async function transfer(
+  signerChain: ChainName,
   chain: ChainName,
   agentConfig: AgentContextConfig,
   multiProvider: MultiProvider,
@@ -107,16 +114,26 @@ async function transfer(
   console.log('Processing key', logCtx);
 
   const transferTx: PopulatedTransaction = {
+    from: fromKey.address,
     to: toKey.address,
     value: BigNumber.from(0),
   };
-  const [gasPrice, gasToTransfer, initialBalance] = await Promise.all([
+
+  console.debug('Estimating gas');
+  const gasToTransfer = await multiProvider.estimateGas(chain, transferTx);
+
+  console.debug('Getting gas price');
+  const [gasPrice, initialBalance] = await Promise.all([
     multiProvider.getProvider(chain).getGasPrice(),
-    multiProvider.estimateGas(chain, transferTx),
     multiProvider.getProvider(chain).getBalance(fromKey.address),
   ]);
 
   let costToTransfer = gasToTransfer.mul(gasPrice);
+
+  if (L2Chains.includes(chain))
+    // L2 chains have a gateway fee
+    costToTransfer = costToTransfer.mul(2);
+
   if (costToTransfer.gt(initialBalance)) {
     console.log('Not enough funds to transfer', {
       ...logCtx,
@@ -125,28 +142,39 @@ async function transfer(
     return;
   }
 
-  if (L2Chains.includes(chain))
-    // L2 chains have a gateway fee
-    costToTransfer = costToTransfer.mul(3).div(2);
-
-  transferTx.value = initialBalance.sub(costToTransfer);
+  // transferTx.value = initialBalance.sub(costToTransfer);
+  transferTx.value = BigNumber.from(1);
   transferTx.gasLimit = gasToTransfer;
-  transferTx.maxFeePerGas = gasPrice;
+  // transferTx.maxFeePerGas = gasPrice;
 
-  let receipt;
-  try {
-    receipt = await multiProvider.sendTransaction(chain, transferTx);
-  } catch (err) {
-    delete transferTx.maxFeePerGas;
-    transferTx.gasPrice = gasPrice;
-    receipt = await multiProvider.sendTransaction(chain, transferTx);
-  }
+  console.debug('Sending transaction');
+  const preparedTx = await multiProvider.prepareTx(
+    signerChain,
+    transferTx,
+    fromKey.address,
+  );
+
+  // const receipt = await multiProvider.sendTransaction(chain, transferTx);
+  const receipt = await multiProvider
+    .getSigner(chain)
+    .sendTransaction(preparedTx);
+
+  // let receipt;
+  // try {
+  //   receipt = await multiProvider.sendTransaction(chain, transferTx);
+  // } catch (err) {
+  //   console.debug('Sending transaction failed, retrying with gasPrice', err);
+  //   delete transferTx.maxFeePerGas;
+  //   transferTx.gasPrice = gasPrice;
+  //   receipt = await multiProvider.sendTransaction(chain, transferTx);
+  // }
   console.log('Transferred funds', {
     ...logCtx,
     initialBalance: formatEther(initialBalance),
     transferred: formatEther(transferTx.value),
     cost: formatEther(costToTransfer),
-    transferTx,
+    // transferTx,
+    preparedTx,
     receipt,
   });
 }

--- a/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
+++ b/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
@@ -49,17 +49,27 @@ async function main() {
         (chain) => chainMetadata[chain].protocol == ProtocolType.Ethereum,
       );
       for (const originChain of chainsForEnv) {
-        const fromKey = new OldRelayerAwsKey(agentConfig, originChain);
-        await fromKey.fetch();
-        for (const chain of chainsForEnv) {
-          await transfer(
-            chain,
-            agentConfig,
-            igp,
-            multiProvider,
-            fromKey,
-            toKey,
-          );
+        try {
+          const fromKey = new OldRelayerAwsKey(agentConfig, originChain);
+          await fromKey.fetch();
+          for (const chain of chainsForEnv) {
+            await transfer(
+              chain,
+              agentConfig,
+              igp,
+              multiProvider,
+              fromKey,
+              toKey,
+            );
+          }
+          await fromKey.delete();
+        } catch (err) {
+          console.error('Error transferring funds', {
+            ctx,
+            env,
+            originChain,
+            err,
+          });
         }
       }
     }
@@ -148,7 +158,6 @@ async function transfer(
     cost: formatEther(costToTransfer),
     transferTx,
   });
-  // await fromKey.delete();
 }
 
 class OldRelayerAwsKey extends AgentAwsKey {

--- a/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
+++ b/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
@@ -72,7 +72,7 @@ async function transferForEnv(ctx: Contexts, env: DeployEnvironment) {
   );
 
   for (const relayerOriginChain of chainsForEnv) {
-    let errorOccured = false;
+    let errorOccurred = false;
     const fromKey = new OldRelayerAwsKey(agentConfig, relayerOriginChain);
     await fromKey.fetch();
     // start all the promises and then wait for them to finish
@@ -83,7 +83,7 @@ async function transferForEnv(ctx: Contexts, env: DeployEnvironment) {
       try {
         await p;
       } catch (err) {
-        errorOccured = true;
+        errorOccurred = true;
         console.error('Error transferring funds', {
           ctx,
           env,
@@ -92,7 +92,7 @@ async function transferForEnv(ctx: Contexts, env: DeployEnvironment) {
         });
       }
     }
-    if (!errorOccured) {
+    if (!errorOccurred) {
       // await fromKey.delete();
       // console.log('Deleted key', {
       //   from: fromKey.identifier,
@@ -126,10 +126,10 @@ async function transfer(
     value: BigNumber.from(0),
   };
 
-  console.debug('Estimating gas');
+  console.debug('Estimating gas', logCtx);
   const gasToTransfer = await provider.estimateGas(transferTx);
 
-  console.debug('Getting gas price');
+  console.debug('Getting gas price', logCtx);
   const [initialBalance, feeData] = await Promise.all([
     provider.getBalance(fromKey.address),
     provider.getFeeData(),
@@ -205,10 +205,14 @@ async function transfer(
     }
   } while (!receipt);
 
-  console.log('Transferred funds', {
-    ...logCtx,
-    receipt,
-  });
+  if (!receipt.status) {
+    throw Error('Transfer failed: ' + JSON.stringify({ ...logCtx, receipt }));
+  } else {
+    console.log('Transferred funds', {
+      ...logCtx,
+      receipt,
+    });
+  }
 }
 
 class OldRelayerAwsKey extends AgentAwsKey {

--- a/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
+++ b/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
@@ -52,7 +52,11 @@ async function transferForEnv(ctx: Contexts, env: DeployEnvironment) {
   const envConfig = getEnvironmentConfig(env);
   const agentConfig = getAgentConfig(ctx, envConfig);
 
-  const toKey = getCloudAgentKey(agentConfig, Role.Relayer);
+  // always transfer to the main hyperlane context
+  const toKey = getCloudAgentKey(
+    getAgentConfig(Contexts.Hyperlane, envConfig),
+    Role.Relayer,
+  );
   await toKey.fetch();
 
   const chainsForEnv = Object.keys(envConfig.chainMetadataConfigs).filter(

--- a/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
+++ b/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
@@ -23,7 +23,8 @@ import { Role } from '../src/roles';
 
 import { getAgentConfig, getEnvironmentConfig } from './utils';
 
-const ENVIRONMENTS: DeployEnvironment[] = ['mainnet2', 'testnet3'];
+// const ENVIRONMENTS: DeployEnvironment[] = ['mainnet2', 'testnet3'];
+const ENVIRONMENTS: DeployEnvironment[] = ['testnet3'];
 
 async function main() {
   for (const ctx of Object.values(Contexts)) {
@@ -61,7 +62,7 @@ async function transferForEnv(ctx: Contexts, env: DeployEnvironment) {
       for (const chain of chainsForEnv) {
         await transfer(chain, agentConfig, igp, multiProvider, fromKey, toKey);
       }
-      await fromKey.delete();
+      // await fromKey.delete();
     } catch (err) {
       console.error('Error transferring funds', {
         ctx,
@@ -142,6 +143,8 @@ async function transfer(
   }
   transferTx.value = currentBalance.sub(costToTransfer);
   transferTx.gasLimit = gasToTransfer;
+  transferTx.gasPrice = gasPrice;
+
   // await multiProvider.sendTransaction(chain, transferTx);
   console.log('Transferred funds', {
     ...logCtx,

--- a/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
+++ b/typescript/infra/scripts/migrate-funds-from-aws-keys.ts
@@ -93,11 +93,11 @@ async function transferForEnv(ctx: Contexts, env: DeployEnvironment) {
       }
     }
     if (!errorOccurred) {
-      // await fromKey.delete();
-      // console.log('Deleted key', {
-      //   from: fromKey.identifier,
-      //   fromKey: fromKey.address,
-      // });
+      await fromKey.delete();
+      console.log('Deleted key', {
+        from: fromKey.identifier,
+        fromKey: fromKey.address,
+      });
     }
   }
 }

--- a/typescript/infra/src/agents/aws/key.ts
+++ b/typescript/infra/src/agents/aws/key.ts
@@ -5,6 +5,7 @@ import {
   DeleteAliasCommand,
   DescribeKeyCommand,
   DescribeKeyCommandOutput,
+  DisableKeyCommand,
   GetPublicKeyCommand,
   KMSClient,
   KeySpec,
@@ -109,6 +110,12 @@ export class AgentAwsKey extends CloudAgentKey {
       await sleep(1000);
     }
     await this.fetch();
+  }
+
+  async disable() {
+    const client = await this.getClient();
+    const args = { KeyId: await this.getId() };
+    await client.send(new DisableKeyCommand(args));
   }
 
   async delete() {

--- a/typescript/infra/src/agents/aws/key.ts
+++ b/typescript/infra/src/agents/aws/key.ts
@@ -13,6 +13,7 @@ import {
   ListAliasesCommandOutput,
   OriginType,
   PutKeyPolicyCommand,
+  ScheduleKeyDeletionCommand,
   UpdateAliasCommand,
 } from '@aws-sdk/client-kms';
 import { KmsEthersSigner } from 'aws-kms-ethers-signer';
@@ -111,7 +112,13 @@ export class AgentAwsKey extends CloudAgentKey {
   }
 
   async delete() {
-    throw Error('Not implemented yet');
+    const client = await this.getClient();
+    await client.send(
+      new ScheduleKeyDeletionCommand({
+        KeyId: await this.getId(),
+        PendingWindowInDays: 30,
+      }),
+    );
   }
 
   // Allows the `userArn` to use the key


### PR DESCRIPTION
### Description

Simple script to migrate funds from the old relayer keys to the new ones. This PR will probably not get merged but act as a historic record since this is a one-off script.

### Drive-by changes

_Are there any minor or drive-by changes also included?_

### Related issues

- Fixes hyperlane-xyz/issues#468

### Backward compatibility

_Are these changes backward compatible?_

No

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

Yes


### Testing

_What kind of testing have these changes undergone?_

Manual
