### PR TITLE
docs: elaborate on censorship resistance of two ISMs.

### DIFF
--- a/solidity/contracts/isms/multisig/AbstractMerkleRootMultisigIsm.sol
+++ b/solidity/contracts/isms/multisig/AbstractMerkleRootMultisigIsm.sol
@@ -10,10 +10,16 @@ import {MerkleLib} from "../../libs/Merkle.sol";
 import {CheckpointLib} from "../../libs/CheckpointLib.sol";
 
 /**
- * @title MerkleRootMultisigIsm
- * @notice Provides abstract logic for verifying signatures on a merkle root
- * and a merkle proof of message inclusion in that root.
- * @dev Implement and use if you want strong censorship resistance guarantees.
+ * @title `AbstractMerkleRootMultisigIsm` — multi-sig ISM with the validators-censorship resistance guarantee.
+ * @notice This ISM allows using a newer signed checkpoint (say #33) to prove existence of an older message (#22) in the validators' MerkleTree.
+ * This guarantees censorship resistance as validators cannot hide a message
+ * by refusing to sign its checkpoint but later signing a checkpoint for a newer message.
+ * If validators decide to censor a message, they are left with only one option — to not produce checkpoints at all.
+ * Otherwise, the very next signed checkpoint (#33) can be used by any relayer to prove the previous message inclusion using this ISM.
+ * This is censorship resistance is missing in the sibling implementation `AbstractMessageIdMultisigIsm`,
+ * since it can only verify messages having the corresponding checkpoints.
+ * @dev Provides the default implementation of verifying signatures over a checkpoint and the message inclusion in that checkpoint.
+ * This abstract contract can be overridden for customizing the `validatorsAndThreshold()` (static or dynamic).
  * @dev May be adapted in future to support batch message verification against a single root.
  */
 abstract contract AbstractMerkleRootMultisigIsm is AbstractMultisigIsm {
@@ -26,12 +32,10 @@ abstract contract AbstractMerkleRootMultisigIsm is AbstractMultisigIsm {
     /**
      * @inheritdoc AbstractMultisigIsm
      */
-    function digest(bytes calldata _metadata, bytes calldata _message)
-        internal
-        pure
-        override
-        returns (bytes32)
-    {
+    function digest(
+        bytes calldata _metadata,
+        bytes calldata _message
+    ) internal pure override returns (bytes32) {
         // We verify a merkle proof of (messageId, index) I to compute root J
         bytes32 _root = MerkleLib.branchRoot(
             Message.id(_message),
@@ -52,13 +56,10 @@ abstract contract AbstractMerkleRootMultisigIsm is AbstractMultisigIsm {
     /**
      * @inheritdoc AbstractMultisigIsm
      */
-    function signatureAt(bytes calldata _metadata, uint256 _index)
-        internal
-        pure
-        virtual
-        override
-        returns (bytes memory signature)
-    {
+    function signatureAt(
+        bytes calldata _metadata,
+        uint256 _index
+    ) internal pure virtual override returns (bytes memory signature) {
         return MerkleRootMultisigIsmMetadata.signatureAt(_metadata, _index);
     }
 }

--- a/solidity/contracts/isms/multisig/AbstractMessageIdMultisigIsm.sol
+++ b/solidity/contracts/isms/multisig/AbstractMessageIdMultisigIsm.sol
@@ -9,9 +9,14 @@ import {Message} from "../../libs/Message.sol";
 import {CheckpointLib} from "../../libs/CheckpointLib.sol";
 
 /**
- * @title AbstractMessageIdMultisigIsm
- * @notice Provides abstract logic for verifying signatures on a message ID.
- * @dev Implement and use if you want fastest and cheapest security.
+ * @title `AbstractMessageIdMultisigIsm` — multi-sig ISM for the censorship-friendly validators.
+ * @notice This ISM minimizes gas/performance overhead of the checkpoints verification by compromising on the censorship resistance.
+ * For censorship resistance consider using `AbstractMerkleRootMultisigIsm`.
+ * If the validators (`validatorsAndThreshold`) skip messages by not sign checkpoints for them,
+ * the relayers will not be able to aggregate a quorum of signatures sufficient to deliver these messages via this ISM.
+ * Integrations are free to choose the trade-off between the censorship resistance and the gas/processing overhead.
+ * @dev Provides the default implementation of verifying signatures over a checkpoint related to a specific message ID.
+ * This abstract contract can be customized to change the `validatorsAndThreshold()` (static or dynamic).
  */
 abstract contract AbstractMessageIdMultisigIsm is AbstractMultisigIsm {
     // ============ Constants ============
@@ -23,12 +28,10 @@ abstract contract AbstractMessageIdMultisigIsm is AbstractMultisigIsm {
     /**
      * @inheritdoc AbstractMultisigIsm
      */
-    function digest(bytes calldata _metadata, bytes calldata _message)
-        internal
-        pure
-        override
-        returns (bytes32)
-    {
+    function digest(
+        bytes calldata _metadata,
+        bytes calldata _message
+    ) internal pure override returns (bytes32) {
         return
             CheckpointLib.digest(
                 Message.origin(_message),
@@ -42,13 +45,10 @@ abstract contract AbstractMessageIdMultisigIsm is AbstractMultisigIsm {
     /**
      * @inheritdoc AbstractMultisigIsm
      */
-    function signatureAt(bytes calldata _metadata, uint256 _index)
-        internal
-        pure
-        virtual
-        override
-        returns (bytes memory)
-    {
+    function signatureAt(
+        bytes calldata _metadata,
+        uint256 _index
+    ) internal pure virtual override returns (bytes memory) {
         return MessageIdMultisigIsmMetadata.signatureAt(_metadata, _index);
     }
 }


### PR DESCRIPTION
### Description

Add human readable elaboration on the "censorship resistance" provided by `MerkleRootMultisigIsm` and missing in `MessageIdMultisigIsm`

### Drive-by changes

No

### Related issues

There were several question from me in Discord to understand this concept.

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

None