### PR TITLE
Fix misleading config error to do with connection configs

### DIFF
--- a/rust/hyperlane-base/src/settings/chains.rs
+++ b/rust/hyperlane-base/src/settings/chains.rs
@@ -224,8 +224,8 @@ impl FromRawConf<'_, RawChainConf> for ChainConf {
 
         let domain = connection
             .as_ref()
-            .ok_or_else(|| eyre!("Missing `domain` configuration"))
-            .take_err(&mut err, || cwp + "domain")
+            .ok_or_else(|| eyre!("Missing `connection` configuration"))
+            .take_err(&mut err, || cwp + "connection")
             .and_then(|c: &ChainConnectionConf| {
                 let protocol = c.protocol();
                 let domain_id = raw


### PR DESCRIPTION
### Description

If you don't specify a connection config, atm the error message says you're missing the `domain`. I ran into this previously and found it hard to debug; a validator operator in discord also ran into this

### Drive-by changes

n/a

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None