### PR TITLE
Use configured collateral token metadata

### DIFF
--- a/typescript/token/src/config.ts
+++ b/typescript/token/src/config.ts
@@ -32,7 +32,7 @@ export type SyntheticConfig = TokenMetadata & {
 export type CollateralConfig = {
   type: TokenType.collateral | TokenType.collateralUri;
   token: string;
-};
+} & Partial<ERC20Metadata>;
 export type NativeConfig = {
   type: TokenType.native;
 };

--- a/typescript/token/src/deploy.ts
+++ b/typescript/token/src/deploy.ts
@@ -83,6 +83,41 @@ export class HypERC20Deployer extends GasRouterDeployer<
     }
   }
 
+  // Gets the metadata for a collateral token, favoring the config
+  // and getting any on-chain metadata that is missing.
+  async getCollateralMetadata(
+    chain: ChainName,
+    config: CollateralConfig,
+  ): Promise<ERC20Metadata> {
+    const metadata = {
+      name: config.name,
+      symbol: config.symbol,
+      decimals: config.decimals,
+      totalSupply: 0,
+    };
+
+    if (
+      metadata.name &&
+      metadata.symbol &&
+      metadata.decimals !== undefined &&
+      metadata.decimals !== null
+    ) {
+      return metadata as ERC20Metadata;
+    }
+    const fetchedMetadata = await HypERC20Deployer.fetchMetadata(
+      this.multiProvider.getProvider(chain),
+      config,
+    );
+    // Filter out undefined values
+    const definedConfigMetadata = Object.fromEntries(
+      Object.entries(metadata).filter(([_, v]) => v !== undefined),
+    );
+    return {
+      ...fetchedMetadata,
+      ...definedConfigMetadata,
+    } as ERC20Metadata;
+  }
+
   protected async deployCollateral(
     chain: ChainName,
     config: HypERC20CollateralConfig,
@@ -165,8 +200,8 @@ export class HypERC20Deployer extends GasRouterDeployer<
 
     for (const [chain, config] of Object.entries(configMap)) {
       if (isCollateralConfig(config)) {
-        const collateralMetadata = await HypERC20Deployer.fetchMetadata(
-          this.multiProvider.getProvider(chain),
+        const collateralMetadata = await this.getCollateralMetadata(
+          chain,
           config,
         );
         tokenMetadata = {


### PR DESCRIPTION
### Description

Just copying the changes from https://github.com/hyperlane-xyz/hyperlane-token/pull/73, which I unfortunately didn't get in before the absorption

### Drive-by changes

_Are there any minor or drive-by changes also included?_

### Related issues

In the name of #2366 

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Unit Tests, used it in hyperlane-deploy when deploying synthetic tokens relating to a collateral warp route that lives on Solana
