### PR TITLE
fix(validator): announce directly if no gas estimate

### DIFF
--- a/rust/agents/validator/src/validator.rs
+++ b/rust/agents/validator/src/validator.rs
@@ -213,14 +213,14 @@ impl Validator {
                         hash=?outcome.txid,
                         gas_used=?outcome.gas_used,
                         gas_price=?outcome.gas_price,
-                        "Transaction attempting to announce validator reverted"
+                        "Transaction attempting to announce validator reverted. Make sure you have enough ETH in your account to pay for gas."
                     );
                 }
             }
             Err(e) => {
                 error!(
                     error=?e,
-                    "Failed to announce validator"
+                    "Failed to announce validator. Make sure you have enough ETH in your account to pay for gas."
                 );
             }
         }

--- a/rust/agents/validator/src/validator.rs
+++ b/rust/agents/validator/src/validator.rs
@@ -217,9 +217,9 @@ impl Validator {
                     );
                 }
             }
-            Err(e) => {
+            Err(err) => {
                 error!(
-                    error=?e,
+                    ?err,
                     "Failed to announce validator. Make sure you have enough ETH in your account to pay for gas."
                 );
             }

--- a/rust/chains/hyperlane-ethereum/src/validator_announce.rs
+++ b/rust/chains/hyperlane-ethereum/src/validator_announce.rs
@@ -138,15 +138,20 @@ where
         let validator = announcement.value.validator;
         let Ok(contract_call) = self
             .announce_contract_call(announcement, None)
-            .await else {
+            .await
+        else {
                 trace!("Unable to get announce contract call");
                 return None;
-            };
-        let Ok(balance) = self.provider.get_balance(validator, None).await else {
+        };
+
+        let Ok(balance) = self.provider.get_balance(validator, None).await
+        else {
             trace!("Unable to query balance");
             return None;
         };
-        let Some(max_cost) = contract_call.tx.max_cost() else {
+
+        let Some(max_cost) = contract_call.tx.max_cost()
+        else {
             trace!("Unable to get announce max cost");
             return None;
         };

--- a/rust/chains/hyperlane-ethereum/src/validator_announce.rs
+++ b/rust/chains/hyperlane-ethereum/src/validator_announce.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use ethers::providers::{Middleware, ProviderError};
+use ethers::providers::Middleware;
 
 use ethers_contract::builders::ContractCall;
 use hyperlane_core::{
@@ -13,6 +13,7 @@ use hyperlane_core::{
     HyperlaneDomain, HyperlaneProvider, SignedType, TxOutcome, ValidatorAnnounce, H160, H256, U256,
 };
 use tracing::instrument;
+use tracing::log::trace;
 
 use crate::contracts::i_validator_announce::{
     IValidatorAnnounce as EthereumValidatorAnnounceInternal, IVALIDATORANNOUNCE_ABI,
@@ -132,21 +133,24 @@ where
         Ok(storage_locations)
     }
 
-    async fn announce_tokens_needed(
-        &self,
-        announcement: SignedType<Announcement>,
-    ) -> ChainResult<U256> {
+    #[instrument(ret, skip(self))]
+    async fn announce_tokens_needed(&self, announcement: SignedType<Announcement>) -> Option<U256> {
         let validator = announcement.value.validator;
-        let contract_call = self.announce_contract_call(announcement, None).await?;
-        if let Ok(balance) = self.provider.get_balance(validator, None).await {
-            if let Some(cost) = contract_call.tx.max_cost() {
-                Ok(cost.saturating_sub(balance))
-            } else {
-                Err(ProviderError::CustomError("Unable to get announce max cost".into()).into())
-            }
-        } else {
-            Err(ProviderError::CustomError("Unable to query balance".into()).into())
-        }
+        let Ok(contract_call) = self
+            .announce_contract_call(announcement, None)
+            .await else {
+                trace!("Unable to get announce contract call");
+                return None;
+            };
+        let Ok(balance) = self.provider.get_balance(validator, None).await else {
+            trace!("Unable to query balance");
+            return None;
+        };
+        let Some(max_cost) = contract_call.tx.max_cost() else {
+            trace!("Unable to get announce max cost");
+            return None;
+        };
+        Some(max_cost.saturating_sub(balance))
     }
 
     #[instrument(err, ret, skip(self))]

--- a/rust/hyperlane-core/src/traits/validator_announce.rs
+++ b/rust/hyperlane-core/src/traits/validator_announce.rs
@@ -24,9 +24,6 @@ pub trait ValidatorAnnounce: HyperlaneContract + Send + Sync + Debug {
     ) -> ChainResult<TxOutcome>;
 
     /// Returns the number of additional tokens needed to pay for the announce
-    /// transaction.
-    async fn announce_tokens_needed(
-        &self,
-        announcement: SignedType<Announcement>,
-    ) -> ChainResult<U256>;
+    /// transaction. Return `None` if the needed tokens canno tbe determined.
+    async fn announce_tokens_needed(&self, announcement: SignedType<Announcement>) -> Option<U256>;
 }

--- a/rust/hyperlane-test/src/mocks/validator_announce.rs
+++ b/rust/hyperlane-test/src/mocks/validator_announce.rs
@@ -22,7 +22,7 @@ mock! {
         fn _announce_tokens_needed(
             &self,
             announcement: SignedType<Announcement>,
-        ) -> ChainResult<U256>;
+        ) -> Option<U256>;
     }
 }
 
@@ -64,10 +64,7 @@ impl ValidatorAnnounce for MockValidatorAnnounceContract {
     ) -> ChainResult<TxOutcome> {
         self._announce(announcement, tx_gas_limit)
     }
-    async fn announce_tokens_needed(
-        &self,
-        announcement: SignedType<Announcement>,
-    ) -> ChainResult<U256> {
+    async fn announce_tokens_needed(&self, announcement: SignedType<Announcement>) -> Option<U256> {
         self._announce_tokens_needed(announcement)
     }
 }


### PR DESCRIPTION
### Description

It has been reported that `contract_call.tx.max_cost()` can fail / not exist on some networks. When that's the case, default to assuming no additional validator gas is required and just send the tx. If the tx fails, report the failure and suggest that gas may be insufficient in the logged error.

### Drive-by changes

None

### Related issues

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/2426

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

None