### PR TITLE
Cosmos stubs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -260,6 +260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base58"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,7 +729,7 @@ dependencies = [
  "digest 0.10.6",
  "getrandom",
  "hmac 0.12.1",
- "k256",
+ "k256 0.11.6",
  "lazy_static",
  "serde",
  "sha2 0.10.6",
@@ -898,6 +904,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "cosmos-sdk-proto"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73c9d2043a9e617b0d602fbc0a0ecd621568edbf3a9774890a6d562389bd8e1c"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tendermint-proto",
+]
+
+[[package]]
+name = "cosmrs"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af13955d6f356272e6def9ff5e2450a7650df536d8934f47052a20c76513d2f6"
+dependencies = [
+ "cosmos-sdk-proto",
+ "ecdsa 0.16.7",
+ "eyre",
+ "getrandom",
+ "k256 0.13.1",
+ "rand_core",
+ "serde",
+ "serde_json",
+ "subtle-encoding",
+ "tendermint",
+ "thiserror",
+]
+
+[[package]]
 name = "counter"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1026,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
+dependencies = [
+ "generic-array 0.14.7",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1092,19 @@ checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
 dependencies = [
  "nix",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core",
+ "subtle-ng",
+ "zeroize",
 ]
 
 [[package]]
@@ -1233,6 +1294,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
+dependencies = [
+ "const-oid 0.9.2",
+ "zeroize",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.2",
  "crypto-common",
  "subtle",
 ]
@@ -1406,8 +1478,45 @@ checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der 0.6.1",
  "elliptic-curve 0.12.3",
- "rfc6979",
- "signature",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
+dependencies = [
+ "der 0.7.7",
+ "digest 0.10.6",
+ "elliptic-curve 0.13.5",
+ "rfc6979 0.4.0",
+ "signature 2.1.0",
+ "spki 0.7.2",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb04eee5d9d907f29e80ee6b0e78f7e2c82342c63e3580d8c4f69d9d5aad963"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.1.0",
+]
+
+[[package]]
+name = "ed25519-consensus"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex 0.4.3",
+ "rand_core",
+ "sha2 0.9.9",
+ "zeroize",
 ]
 
 [[package]]
@@ -1422,7 +1531,7 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "crypto-bigint 0.3.2",
  "der 0.5.1",
  "generic-array 0.14.7",
@@ -1437,16 +1546,35 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
  "digest 0.10.6",
- "ff",
+ "ff 0.12.1",
  "generic-array 0.14.7",
- "group",
- "pkcs8",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
  "rand_core",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.2",
+ "digest 0.10.6",
+ "ff 0.13.0",
+ "generic-array 0.14.7",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
+ "rand_core",
+ "sec1 0.7.2",
  "subtle",
  "zeroize",
 ]
@@ -1680,7 +1808,7 @@ dependencies = [
  "ethabi",
  "generic-array 0.14.7",
  "hex 0.4.3",
- "k256",
+ "k256 0.11.6",
  "once_cell",
  "open-fastrlp",
  "proc-macro2",
@@ -1810,7 +1938,7 @@ dependencies = [
  "rusoto_core",
  "rusoto_kms",
  "sha2 0.10.6",
- "spki",
+ "spki 0.6.0",
  "thiserror",
  "tracing",
 ]
@@ -1872,6 +2000,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,6 +2019,16 @@ dependencies = [
  "rand",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "flex-error"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
+dependencies = [
+ "eyre",
+ "paste",
 ]
 
 [[package]]
@@ -2436,6 +2584,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2479,7 +2628,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core",
  "subtle",
 ]
@@ -2858,6 +3018,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperlane-cosmos"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "cosmrs",
+ "hyperlane-core",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
 name = "hyperlane-ethereum"
 version = "0.1.0"
 dependencies = [
@@ -3108,10 +3283,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if",
- "ecdsa",
+ "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
  "sha2 0.10.6",
  "sha3 0.10.7",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+dependencies = [
+ "cfg-if",
+ "ecdsa 0.16.7",
+ "elliptic-curve 0.13.5",
+ "once_cell",
+ "sha2 0.10.6",
+ "signature 2.1.0",
 ]
 
 [[package]]
@@ -4038,7 +4227,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der 0.6.1",
- "spki",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.7",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -4182,6 +4381,38 @@ dependencies = [
  "parking_lot 0.12.1",
  "protobuf",
  "thiserror",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -4433,6 +4664,16 @@ dependencies = [
  "crypto-bigint 0.4.9",
  "hmac 0.12.1",
  "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -5104,10 +5345,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
+ "base16ct 0.1.1",
  "der 0.6.1",
  "generic-array 0.14.7",
- "pkcs8",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.7",
+ "generic-array 0.14.7",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -5198,6 +5453,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c5113243e4a3a1c96587342d067f3e6b0f50790b6cf40d2868eb647a3eef0e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5217,6 +5481,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -5369,6 +5644,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+dependencies = [
+ "digest 0.10.6",
+ "rand_core",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5422,6 +5707,16 @@ checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der 0.7.7",
 ]
 
 [[package]]
@@ -5606,6 +5901,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
+name = "subtle-encoding"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5653,6 +5963,55 @@ dependencies = [
  "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a46ec6b25b028097ab682ffae11d09d64fe1e2535833b902f26a278a0f88a705"
+dependencies = [
+ "bytes",
+ "digest 0.10.6",
+ "ed25519",
+ "ed25519-consensus",
+ "flex-error",
+ "futures",
+ "k256 0.13.1",
+ "num-traits",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "ripemd",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.10.6",
+ "signature 2.1.0",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto",
+ "time 0.3.20",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23c8ff0e6634eb4c3c4aeed45076dc97dac91aac5501a905a67fa222e165b"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "num-derive",
+ "num-traits",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time 0.3.20",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "agents/relayer",
     "agents/scraper",
     "agents/validator",
+    "chains/hyperlane-cosmos",
     "chains/hyperlane-ethereum",
     "chains/hyperlane-fuel",
     "ethers-prometheus",
@@ -30,6 +31,7 @@ version = "0.1.0"
 async-trait = { version = "0.1" }
 color-eyre = { version = "0.6" }
 config = "~0.13.3"
+cosmrs = { version = "0.14", default-features = false }
 derive-new = "0.5"
 derive_more = "0.99"
 enum_dispatch = "0.3"

--- a/rust/chains/hyperlane-cosmos/.gitignore
+++ b/rust/chains/hyperlane-cosmos/.gitignore
@@ -1,0 +1,1 @@
+src/contracts

--- a/rust/chains/hyperlane-cosmos/Cargo.toml
+++ b/rust/chains/hyperlane-cosmos/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "hyperlane-cosmos"
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+publish.workspace = true
+version.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+cosmrs = { workspace = true, features = [] }
+serde.workspace = true
+tokio.workspace = true
+tracing-futures.workspace = true
+tracing.workspace = true
+url.workspace = true
+thiserror.worskace = true
+
+hyperlane-core = { path = "../../hyperlane-core" }
+
+# These should only be used if it _must_ be used to interop with the inner library,
+# all errors exported from a chain crate should be using thiserror or handrolled to
+# make error handling easier.
+# eyre = "never"
+# anyhow = never

--- a/rust/chains/hyperlane-cosmos/Cargo.toml
+++ b/rust/chains/hyperlane-cosmos/Cargo.toml
@@ -11,11 +11,11 @@ version.workspace = true
 async-trait.workspace = true
 cosmrs = { workspace = true, features = [] }
 serde.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 tracing-futures.workspace = true
 tracing.workspace = true
 url.workspace = true
-thiserror.worskace = true
 
 hyperlane-core = { path = "../../hyperlane-core" }
 

--- a/rust/chains/hyperlane-cosmos/build.rs
+++ b/rust/chains/hyperlane-cosmos/build.rs
@@ -1,0 +1,8 @@
+use std::fs;
+
+fn main() {
+    // TODO: build the cosmos contracts/bindings
+    fs::create_dir_all("src/contracts").expect("failed to create contracts dir");
+    fs::write("src/contracts/mod.rs", "// TODO: this should be generated")
+        .expect("failed to write contracts/mod.rs");
+}

--- a/rust/chains/hyperlane-cosmos/src/interchain_gas.rs
+++ b/rust/chains/hyperlane-cosmos/src/interchain_gas.rs
@@ -1,0 +1,44 @@
+use async_trait::async_trait;
+use hyperlane_core::{
+    ChainResult, HyperlaneChain, HyperlaneContract, Indexer, InterchainGasPaymaster,
+};
+use hyperlane_core::{HyperlaneDomain, HyperlaneProvider, InterchainGasPayment, LogMeta, H256};
+
+#[derive(Debug)]
+pub struct CosmosInterchainGasPaymaster {}
+
+impl HyperlaneContract for CosmosInterchainGasPaymaster {
+    fn address(&self) -> H256 {
+        todo!()
+    }
+}
+
+impl HyperlaneChain for CosmosInterchainGasPaymaster {
+    fn domain(&self) -> &HyperlaneDomain {
+        todo!()
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        todo!()
+    }
+}
+
+impl InterchainGasPaymaster for CosmosInterchainGasPaymaster {}
+
+#[derive(Debug)]
+pub struct CosmosInterchainGasPaymasterIndexer {}
+
+#[async_trait]
+impl Indexer<InterchainGasPayment> for CosmosInterchainGasPaymasterIndexer {
+    async fn fetch_logs(
+        &self,
+        from_block: u32,
+        to_block: u32,
+    ) -> ChainResult<Vec<(InterchainGasPayment, LogMeta)>> {
+        todo!()
+    }
+
+    async fn get_finalized_block_number(&self) -> ChainResult<u32> {
+        todo!()
+    }
+}

--- a/rust/chains/hyperlane-cosmos/src/interchain_gas.rs
+++ b/rust/chains/hyperlane-cosmos/src/interchain_gas.rs
@@ -4,6 +4,7 @@ use hyperlane_core::{
 };
 use hyperlane_core::{HyperlaneDomain, HyperlaneProvider, InterchainGasPayment, LogMeta, H256};
 
+/// A reference to a InterchainGasPaymaster contract on some Cosmos chain
 #[derive(Debug)]
 pub struct CosmosInterchainGasPaymaster {}
 
@@ -25,6 +26,7 @@ impl HyperlaneChain for CosmosInterchainGasPaymaster {
 
 impl InterchainGasPaymaster for CosmosInterchainGasPaymaster {}
 
+/// A reference to a InterchainGasPaymasterIndexer contract on some Cosmos chain
 #[derive(Debug)]
 pub struct CosmosInterchainGasPaymasterIndexer {}
 

--- a/rust/chains/hyperlane-cosmos/src/lib.rs
+++ b/rust/chains/hyperlane-cosmos/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
-
 // TODO: Remove once we start filling things in
 #![allow(unused_variables)]
 

--- a/rust/chains/hyperlane-cosmos/src/lib.rs
+++ b/rust/chains/hyperlane-cosmos/src/lib.rs
@@ -1,5 +1,8 @@
+//! Implementation of hyperlane for cosmos.
+
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+
 // TODO: Remove once we start filling things in
 #![allow(unused_variables)]
 

--- a/rust/chains/hyperlane-cosmos/src/lib.rs
+++ b/rust/chains/hyperlane-cosmos/src/lib.rs
@@ -1,0 +1,21 @@
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+// TODO: Remove once we start filling things in
+#![allow(unused_variables)]
+
+pub use self::{
+    interchain_gas::*, mailbox::*, multisig_ism::*, provider::*, routing_ism::*, trait_builder::*,
+    validator_announce::*,
+};
+
+mod contracts;
+mod interchain_gas;
+mod mailbox;
+mod multisig_ism;
+mod provider;
+mod routing_ism;
+mod trait_builder;
+mod validator_announce;
+
+/// Safe default imports of commonly used traits/types.
+pub mod prelude {}

--- a/rust/chains/hyperlane-cosmos/src/mailbox.rs
+++ b/rust/chains/hyperlane-cosmos/src/mailbox.rs
@@ -1,0 +1,121 @@
+use std::fmt::{Debug, Formatter};
+use std::num::NonZeroU64;
+
+use async_trait::async_trait;
+use tracing::instrument;
+
+use hyperlane_core::{
+    accumulator::incremental::IncrementalMerkle, utils::fmt_bytes, ChainResult, Checkpoint,
+    HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneMessage, HyperlaneProvider,
+    Indexer, LogMeta, Mailbox, TxCostEstimate, TxOutcome, H256, U256,
+};
+
+pub struct CosmosMailbox {}
+
+impl HyperlaneContract for CosmosMailbox {
+    fn address(&self) -> H256 {
+        todo!()
+    }
+}
+
+impl HyperlaneChain for CosmosMailbox {
+    fn domain(&self) -> &HyperlaneDomain {
+        todo!()
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        todo!()
+    }
+}
+
+impl Debug for CosmosMailbox {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self as &dyn HyperlaneContract)
+    }
+}
+
+#[async_trait]
+impl Mailbox for CosmosMailbox {
+    #[instrument(level = "debug", err, ret, skip(self))]
+    async fn count(&self, lag: Option<NonZeroU64>) -> ChainResult<u32> {
+        todo!()
+    }
+
+    #[instrument(level = "debug", err, ret, skip(self))]
+    async fn tree(&self, lag: Option<NonZeroU64>) -> ChainResult<IncrementalMerkle> {
+        todo!()
+    }
+
+    #[instrument(level = "debug", err, ret, skip(self))]
+    async fn delivered(&self, id: H256) -> ChainResult<bool> {
+        todo!()
+    }
+
+    #[instrument(level = "debug", err, ret, skip(self))]
+    async fn latest_checkpoint(&self, lag: Option<NonZeroU64>) -> ChainResult<Checkpoint> {
+        todo!()
+    }
+
+    #[instrument(err, ret, skip(self))]
+    async fn default_ism(&self) -> ChainResult<H256> {
+        todo!()
+    }
+
+    #[instrument(err, ret, skip(self))]
+    async fn recipient_ism(&self, recipient: H256) -> ChainResult<H256> {
+        todo!()
+    }
+
+    #[instrument(err, ret, skip(self))]
+    async fn process(
+        &self,
+        message: &HyperlaneMessage,
+        metadata: &[u8],
+        tx_gas_limit: Option<U256>,
+    ) -> ChainResult<TxOutcome> {
+        todo!()
+    }
+
+    #[instrument(err, ret, skip(self), fields(msg=%message, metadata=%fmt_bytes(metadata)))]
+    async fn process_estimate_costs(
+        &self,
+        message: &HyperlaneMessage,
+        metadata: &[u8],
+    ) -> ChainResult<TxCostEstimate> {
+        todo!()
+    }
+
+    fn process_calldata(&self, message: &HyperlaneMessage, metadata: &[u8]) -> Vec<u8> {
+        todo!()
+    }
+}
+
+/// Struct that retrieves event data for a Cosmos Mailbox contract
+#[derive(Debug)]
+pub struct CosmosMailboxIndexer {}
+
+#[async_trait]
+impl Indexer<HyperlaneMessage> for CosmosMailboxIndexer {
+    async fn fetch_logs(
+        &self,
+        from: u32,
+        to: u32,
+    ) -> ChainResult<Vec<(HyperlaneMessage, LogMeta)>> {
+        todo!()
+    }
+
+    async fn get_finalized_block_number(&self) -> ChainResult<u32> {
+        todo!()
+    }
+}
+
+#[async_trait]
+impl Indexer<H256> for CosmosMailboxIndexer {
+    async fn fetch_logs(&self, from: u32, to: u32) -> ChainResult<Vec<(H256, LogMeta)>> {
+        todo!()
+    }
+
+    async fn get_finalized_block_number(&self) -> ChainResult<u32> {
+        todo!()
+    }
+}

--- a/rust/chains/hyperlane-cosmos/src/mailbox.rs
+++ b/rust/chains/hyperlane-cosmos/src/mailbox.rs
@@ -10,6 +10,7 @@ use hyperlane_core::{
     Indexer, LogMeta, Mailbox, TxCostEstimate, TxOutcome, H256, U256,
 };
 
+/// A reference to a Mailbox contract on some Cosmos chain
 pub struct CosmosMailbox {}
 
 impl HyperlaneContract for CosmosMailbox {

--- a/rust/chains/hyperlane-cosmos/src/multisig_ism.rs
+++ b/rust/chains/hyperlane-cosmos/src/multisig_ism.rs
@@ -1,0 +1,35 @@
+use async_trait::async_trait;
+use hyperlane_core::{
+    ChainResult, HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneMessage,
+    HyperlaneProvider, MultisigIsm, H256,
+};
+
+#[derive(Debug)]
+pub struct CosmosMultisigIsm {}
+
+impl HyperlaneContract for CosmosMultisigIsm {
+    fn address(&self) -> H256 {
+        todo!()
+    }
+}
+
+impl HyperlaneChain for CosmosMultisigIsm {
+    fn domain(&self) -> &HyperlaneDomain {
+        todo!()
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        todo!()
+    }
+}
+
+#[async_trait]
+impl MultisigIsm for CosmosMultisigIsm {
+    /// Returns the validator and threshold needed to verify message
+    async fn validators_and_threshold(
+        &self,
+        message: &HyperlaneMessage,
+    ) -> ChainResult<(Vec<H256>, u8)> {
+        todo!()
+    }
+}

--- a/rust/chains/hyperlane-cosmos/src/multisig_ism.rs
+++ b/rust/chains/hyperlane-cosmos/src/multisig_ism.rs
@@ -4,6 +4,7 @@ use hyperlane_core::{
     HyperlaneProvider, MultisigIsm, H256,
 };
 
+/// A reference to a MultisigIsm contract on some Cosmos chain
 #[derive(Debug)]
 pub struct CosmosMultisigIsm {}
 

--- a/rust/chains/hyperlane-cosmos/src/provider.rs
+++ b/rust/chains/hyperlane-cosmos/src/provider.rs
@@ -4,6 +4,7 @@ use hyperlane_core::{
     BlockInfo, ChainResult, HyperlaneChain, HyperlaneDomain, HyperlaneProvider, TxnInfo, H256,
 };
 
+/// A wrapper around a cosmos provider to get generic blockchain information.
 #[derive(Debug)]
 pub struct CosmosProvider {}
 

--- a/rust/chains/hyperlane-cosmos/src/provider.rs
+++ b/rust/chains/hyperlane-cosmos/src/provider.rs
@@ -1,0 +1,33 @@
+use async_trait::async_trait;
+
+use hyperlane_core::{
+    BlockInfo, ChainResult, HyperlaneChain, HyperlaneDomain, HyperlaneProvider, TxnInfo, H256,
+};
+
+#[derive(Debug)]
+pub struct CosmosProvider {}
+
+impl HyperlaneChain for CosmosProvider {
+    fn domain(&self) -> &HyperlaneDomain {
+        todo!()
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        todo!()
+    }
+}
+
+#[async_trait]
+impl HyperlaneProvider for CosmosProvider {
+    async fn get_block_by_hash(&self, hash: &H256) -> ChainResult<BlockInfo> {
+        todo!()
+    }
+
+    async fn get_txn_by_hash(&self, hash: &H256) -> ChainResult<TxnInfo> {
+        todo!()
+    }
+
+    async fn is_contract(&self, address: &H256) -> ChainResult<bool> {
+        todo!()
+    }
+}

--- a/rust/chains/hyperlane-cosmos/src/routing_ism.rs
+++ b/rust/chains/hyperlane-cosmos/src/routing_ism.rs
@@ -5,6 +5,7 @@ use hyperlane_core::{
     HyperlaneProvider, RoutingIsm, H256,
 };
 
+/// A reference to a RoutingIsm contract on some Cosmos chain
 #[derive(Debug)]
 pub struct CosmosRoutingIsm {}
 

--- a/rust/chains/hyperlane-cosmos/src/routing_ism.rs
+++ b/rust/chains/hyperlane-cosmos/src/routing_ism.rs
@@ -1,0 +1,32 @@
+use async_trait::async_trait;
+
+use hyperlane_core::{
+    ChainResult, HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneMessage,
+    HyperlaneProvider, RoutingIsm, H256,
+};
+
+#[derive(Debug)]
+pub struct CosmosRoutingIsm {}
+
+impl HyperlaneContract for CosmosRoutingIsm {
+    fn address(&self) -> H256 {
+        todo!()
+    }
+}
+
+impl HyperlaneChain for CosmosRoutingIsm {
+    fn domain(&self) -> &HyperlaneDomain {
+        todo!()
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        todo!()
+    }
+}
+
+#[async_trait]
+impl RoutingIsm for CosmosRoutingIsm {
+    async fn route(&self, message: &HyperlaneMessage) -> ChainResult<H256> {
+        todo!()
+    }
+}

--- a/rust/chains/hyperlane-cosmos/src/trait_builder.rs
+++ b/rust/chains/hyperlane-cosmos/src/trait_builder.rs
@@ -1,0 +1,46 @@
+use hyperlane_core::config::{ConfigErrResultExt, ConfigPath, ConfigResult, FromRawConf};
+use url::Url;
+
+#[derive(Debug, Clone)]
+pub struct ConnectionConf {
+    // TODO: more settings?
+    url: Url,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct RawConnectionConf {
+    // TODO: more settings?
+    url: Option<String>,
+}
+
+/// An error type when parsing a connection configuration.
+#[derive(thiserror::Error, Debug)]
+pub enum ConnectionConfError {
+    /// Missing `url` for connection configuration
+    #[error("Missing `url` for connection configuration")]
+    MissingConnectionUrl,
+    /// Invalid `url` for connection configuration
+    #[error("Invalid `url` for connection configuration: `{0}` ({1})")]
+    InvalidConnectionUrl(String, url::ParseError),
+}
+
+impl FromRawConf<'_, RawConnectionConf> for ConnectionConf {
+    fn from_config_filtered(
+        raw: RawConnectionConf,
+        cwp: &ConfigPath,
+        _filter: (),
+    ) -> ConfigResult<Self> {
+        use ConnectionConfError::*;
+        match raw {
+            RawConnectionConf { url: Some(url) } => Ok(Self {
+                url: url
+                    .parse()
+                    .map_err(|e| InvalidConnectionUrl(url, e))
+                    .into_config_result(|| cwp.join("url"))?,
+            }),
+            RawConnectionConf { url: None } => {
+                Err(MissingConnectionUrl).into_config_result(|| cwp.join("url"))
+            }
+        }
+    }
+}

--- a/rust/chains/hyperlane-cosmos/src/trait_builder.rs
+++ b/rust/chains/hyperlane-cosmos/src/trait_builder.rs
@@ -1,12 +1,15 @@
 use hyperlane_core::config::{ConfigErrResultExt, ConfigPath, ConfigResult, FromRawConf};
 use url::Url;
 
+/// Cosmos connection configuration
 #[derive(Debug, Clone)]
 pub struct ConnectionConf {
     // TODO: more settings?
+    #[allow(dead_code)]
     url: Url,
 }
 
+/// Raw Cosmos connection configuration used for better deserialization errors.
 #[derive(Debug, serde::Deserialize)]
 pub struct RawConnectionConf {
     // TODO: more settings?

--- a/rust/chains/hyperlane-cosmos/src/validator_announce.rs
+++ b/rust/chains/hyperlane-cosmos/src/validator_announce.rs
@@ -5,6 +5,7 @@ use hyperlane_core::{
     HyperlaneProvider, SignedType, TxOutcome, ValidatorAnnounce, H256, U256,
 };
 
+/// A reference to a ValidatorAnnounce contract on some Cosmos chain
 #[derive(Debug)]
 pub struct CosmosValidatorAnnounce {}
 

--- a/rust/chains/hyperlane-cosmos/src/validator_announce.rs
+++ b/rust/chains/hyperlane-cosmos/src/validator_announce.rs
@@ -1,0 +1,50 @@
+use async_trait::async_trait;
+
+use hyperlane_core::{
+    Announcement, ChainResult, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
+    HyperlaneProvider, SignedType, TxOutcome, ValidatorAnnounce, H256, U256,
+};
+
+#[derive(Debug)]
+pub struct CosmosValidatorAnnounce {}
+
+impl HyperlaneContract for CosmosValidatorAnnounce {
+    fn address(&self) -> H256 {
+        todo!()
+    }
+}
+
+impl HyperlaneChain for CosmosValidatorAnnounce {
+    fn domain(&self) -> &HyperlaneDomain {
+        todo!()
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        todo!()
+    }
+}
+
+#[async_trait]
+impl ValidatorAnnounce for CosmosValidatorAnnounce {
+    async fn get_announced_storage_locations(
+        &self,
+        validators: &[H256],
+    ) -> ChainResult<Vec<Vec<String>>> {
+        todo!()
+    }
+
+    async fn announce(
+        &self,
+        announcement: SignedType<Announcement>,
+        tx_gas_limit: Option<U256>,
+    ) -> ChainResult<TxOutcome> {
+        todo!()
+    }
+
+    async fn announce_tokens_needed(
+        &self,
+        announcement: SignedType<Announcement>,
+    ) -> ChainResult<U256> {
+        todo!()
+    }
+}

--- a/rust/chains/hyperlane-ethereum/Cargo.toml
+++ b/rust/chains/hyperlane-ethereum/Cargo.toml
@@ -17,6 +17,7 @@ ethers-signers.workspace = true
 ethers.workspace = true
 hex = "0.4.3"
 num = "0.4"
+num-traits.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -28,7 +29,12 @@ url.workspace = true
 
 hyperlane-core = { path = "../../hyperlane-core" }
 ethers-prometheus = { path = "../../ethers-prometheus", features = ["serde"] }
-num-traits.workspace = true
+
+# These should only be used if it _must_ be used to interop with the inner library,
+# all errors exported from a chain crate should be using thiserror or handrolled to
+# make error handling easier.
+# eyre = "never"
+# anyhow = never
 
 [build-dependencies]
 abigen = { path = "../../utils/abigen", features = ["ethers"] }

--- a/rust/chains/hyperlane-fuel/Cargo.toml
+++ b/rust/chains/hyperlane-fuel/Cargo.toml
@@ -19,5 +19,11 @@ url.workspace = true
 
 hyperlane-core = { path = "../../hyperlane-core" }
 
+# These should only be used if it _must_ be used to interop with the inner library,
+# all errors exported from a chain crate should be using thiserror or handrolled to
+# make error handling easier.
+# eyre = "never"
+# anyhow = never
+
 [build-dependencies]
 abigen = { path = "../../utils/abigen", features = ["fuels"] }

--- a/rust/chains/hyperlane-fuel/src/lib.rs
+++ b/rust/chains/hyperlane-fuel/src/lib.rs
@@ -5,12 +5,10 @@
 // TODO: Remove once we start filling things in
 #![allow(unused_variables)]
 
-pub use interchain_gas::*;
-pub use mailbox::*;
-pub use multisig_ism::*;
-pub use provider::*;
-pub use routing_ism::*;
-pub use trait_builder::*;
+pub use self::{
+    interchain_gas::*, mailbox::*, multisig_ism::*, provider::*, routing_ism::*, trait_builder::*,
+    validator_announce::*,
+};
 
 mod contracts;
 mod conversions;
@@ -20,6 +18,7 @@ mod multisig_ism;
 mod provider;
 mod routing_ism;
 mod trait_builder;
+mod validator_announce;
 
 /// Safe default imports of commonly used traits/types.
 pub mod prelude {

--- a/rust/chains/hyperlane-fuel/src/validator_announce.rs
+++ b/rust/chains/hyperlane-fuel/src/validator_announce.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
 
 use hyperlane_core::{
-    ChainResult, HyperlaneChain, HyperlaneContract, HyperlaneDomain, ValidatorAnnounce, H256,
+    Announcement, ChainResult, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
+    HyperlaneProvider, SignedType, TxOutcome, ValidatorAnnounce, H256, U256,
 };
 
 /// A reference to a ValidatorAnnounce contract on some Fuel chain
@@ -18,6 +19,10 @@ impl HyperlaneChain for FuelValidatorAnnounce {
     fn domain(&self) -> &HyperlaneDomain {
         todo!()
     }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        todo!()
+    }
 }
 
 #[async_trait]
@@ -26,6 +31,21 @@ impl ValidatorAnnounce for FuelValidatorAnnounce {
         &self,
         validators: &[H256],
     ) -> ChainResult<Vec<Vec<String>>> {
+        todo!()
+    }
+
+    async fn announce(
+        &self,
+        announcement: SignedType<Announcement>,
+        tx_gas_limit: Option<U256>,
+    ) -> ChainResult<TxOutcome> {
+        todo!()
+    }
+
+    async fn announce_tokens_needed(
+        &self,
+        announcement: SignedType<Announcement>,
+    ) -> ChainResult<U256> {
         todo!()
     }
 }


### PR DESCRIPTION
### Description

Adds stubs for Cosmos support.

CC: @yorhodes 

### Drive-by changes

A few minor changes to keep things consistent between the chain crates.

### Related issues

- Fixes #2422 

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None

### Testing

_What kind of testing have these changes undergone?_

None