### PR TITLE
feat(testnet3): 1/2 aggregation ISM as default

### DIFF
--- a/typescript/infra/config/environments/testnet3/aggregationIsm.ts
+++ b/typescript/infra/config/environments/testnet3/aggregationIsm.ts
@@ -1,0 +1,25 @@
+import {
+  AggregationIsmConfig,
+  ModuleType,
+  MultisigIsmConfig,
+} from '@hyperlane-xyz/sdk';
+
+export const aggregationIsm = (
+  multisigIsmConfig: MultisigIsmConfig,
+): AggregationIsmConfig => {
+  const merkleRootMultisig: MultisigIsmConfig = {
+    ...multisigIsmConfig,
+    type: ModuleType.MERKLE_ROOT_MULTISIG,
+  };
+
+  const messageIdMultisig: MultisigIsmConfig = {
+    ...multisigIsmConfig,
+    type: ModuleType.MESSAGE_ID_MULTISIG,
+  };
+
+  return {
+    type: ModuleType.AGGREGATION,
+    modules: [merkleRootMultisig, messageIdMultisig],
+    threshold: 1,
+  };
+};

--- a/typescript/infra/config/environments/testnet3/core.ts
+++ b/typescript/infra/config/environments/testnet3/core.ts
@@ -7,6 +7,7 @@ import {
   objMap,
 } from '@hyperlane-xyz/sdk';
 
+import { aggregationIsm } from './aggregationIsm';
 import { chainNames } from './chains';
 import { owners } from './owners';
 
@@ -15,11 +16,15 @@ export const core: ChainMap<CoreConfig> = objMap(owners, (local, owner) => {
     type: ModuleType.ROUTING,
     owner,
     domains: Object.fromEntries(
-      Object.entries(defaultMultisigIsmConfigs).filter(
-        ([chain]) => chain !== local && chainNames.includes(chain),
-      ),
+      Object.entries(defaultMultisigIsmConfigs)
+        .filter(([chain]) => chain !== local && chainNames.includes(chain))
+        .map(([chain, multisigIsmConfig]) => [
+          chain,
+          aggregationIsm(multisigIsmConfig),
+        ]),
     ),
   };
+
   return {
     owner,
     defaultIsm,


### PR DESCRIPTION
### Description

Use 1/2 aggregation of merkle proof or message ID ISM on testnet

### Drive-by changes

_Are there any minor or drive-by changes also included?_

### Related issues

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/2224

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

Yes - Aggregation ISM needs to be deployed in the environment


### Testing

_What kind of testing have these changes undergone?_

None
