### PR TITLE
Fix client's usage of `--upgrade-authority` with stable version of solana-cli

### DIFF
--- a/rust/sealevel/client/src/cmd_utils.rs
+++ b/rust/sealevel/client/src/cmd_utils.rs
@@ -67,7 +67,6 @@ pub(crate) fn account_exists(client: &RpcClient, account: &Pubkey) -> Result<boo
 }
 
 pub(crate) fn deploy_program_idempotent(
-    payer: &Keypair,
     payer_path: &str,
     program_keypair: &Keypair,
     program_keypair_path: &str,
@@ -78,7 +77,6 @@ pub(crate) fn deploy_program_idempotent(
     let client = RpcClient::new(url.to_string());
     if !account_exists(&client, &program_keypair.pubkey())? {
         deploy_program(
-            payer,
             payer_path,
             program_keypair_path,
             program_path,
@@ -93,7 +91,6 @@ pub(crate) fn deploy_program_idempotent(
 }
 
 pub(crate) fn deploy_program(
-    payer: &Keypair,
     payer_path: &str,
     program_keypair_path: &str,
     program_path: &str,
@@ -111,7 +108,7 @@ pub(crate) fn deploy_program(
             "deploy",
             program_path,
             "--upgrade-authority",
-            payer.pubkey().to_string().as_str(),
+            payer_path,
             "--program-id",
             program_keypair_path,
         ],

--- a/rust/sealevel/client/src/core.rs
+++ b/rust/sealevel/client/src/core.rs
@@ -72,7 +72,6 @@ fn deploy_multisig_ism_message_id(
     let program_id = keypair.pubkey();
 
     deploy_program(
-        &ctx.payer,
         &ctx.payer_path,
         keypair_path.to_str().unwrap(),
         built_so_dir
@@ -121,7 +120,6 @@ fn deploy_mailbox(
     let program_id = keypair.pubkey();
 
     deploy_program(
-        &ctx.payer,
         &ctx.payer_path,
         keypair_path.to_str().unwrap(),
         built_so_dir
@@ -169,7 +167,6 @@ fn deploy_validator_announce(
     let program_id = keypair.pubkey();
 
     deploy_program(
-        &ctx.payer,
         &ctx.payer_path,
         keypair_path.to_str().unwrap(),
         built_so_dir

--- a/rust/sealevel/client/src/warp_route.rs
+++ b/rust/sealevel/client/src/warp_route.rs
@@ -330,7 +330,6 @@ fn deploy_warp_route(
     let program_id = keypair.pubkey();
 
     deploy_program_idempotent(
-        &ctx.payer,
         &ctx.payer_path,
         &keypair,
         keypair_path.to_str().unwrap(),


### PR DESCRIPTION
### Description

Using the current stable Solana version, the usage of --upgrade-authority changed

(new version after running `sh -c "$(curl -sSfL https://release.solana.com/stable/install)"`

```
$ solana --version
solana-cli 1.14.20 (src:87ce9bb7; feat:1879391783)
```

### Drive-by changes

n/a

### Related issues

n/a

### Backward compatibility

_Are these changes backward compatible?_

Yes

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None


### Testing

_What kind of testing have these changes undergone?_

Unit Tests, e2e tests
