### PR TITLE
Deploy AggregationISM to testnet3 core

### DIFF
--- a/typescript/infra/config/environments/testnet3/core.ts
+++ b/typescript/infra/config/environments/testnet3/core.ts
@@ -1,25 +1,20 @@
 import {
+  AggregationIsmConfig,
   ChainMap,
   CoreConfig,
-  ModuleType,
-  RoutingIsmConfig,
-  defaultMultisigIsmConfigs,
   objMap,
 } from '@hyperlane-xyz/sdk';
 
-import { chainNames } from './chains';
+import { Contexts } from '../../contexts';
+
+import { aggregationIsm } from './aggregationIsm';
 import { owners } from './owners';
 
 export const core: ChainMap<CoreConfig> = objMap(owners, (local, owner) => {
-  const defaultIsm: RoutingIsmConfig = {
-    type: ModuleType.ROUTING,
-    owner,
-    domains: Object.fromEntries(
-      Object.entries(defaultMultisigIsmConfigs).filter(
-        ([chain]) => chain !== local && chainNames.includes(chain),
-      ),
-    ),
-  };
+  const defaultIsm: AggregationIsmConfig = aggregationIsm(
+    local,
+    Contexts.Hyperlane,
+  );
   return {
     owner,
     defaultIsm,

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -193,9 +193,9 @@ export abstract class HyperlaneDeployer<
         currentIsm = await mailbox.defaultIsm();
       }
 
-      // set interchain security module if not already set (and configured)
-      let configuredIsm;
       if (config.interchainSecurityModule) {
+        // set interchain security module if not already set (and configured)
+        let configuredIsm;
         if (typeof config.interchainSecurityModule === 'string') {
           configuredIsm = config.interchainSecurityModule;
         } else if (this.options?.ismFactory) {

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -3,6 +3,8 @@ import { Contract, ethers } from 'ethers';
 
 import {
   HyperlaneConnectionClient,
+  Mailbox,
+  Mailbox__factory,
   Ownable,
   ProxyAdmin,
   ProxyAdmin__factory,
@@ -181,7 +183,15 @@ export abstract class HyperlaneDeployer<
         );
       }
 
-      const currentIsm = await connectionClient.interchainSecurityModule();
+      let currentIsm = await connectionClient.interchainSecurityModule();
+      // in case the above returns zero address, fetch the defaultISM from the mailbox
+      if (currentIsm === ethers.constants.AddressZero) {
+        const mailbox: Mailbox = Mailbox__factory.connect(
+          config.mailbox,
+          connectionClient.signer,
+        );
+        currentIsm = await mailbox.defaultIsm();
+      }
 
       // set interchain security module if not already set (and configured)
       let configuredIsm;
@@ -206,13 +216,6 @@ export abstract class HyperlaneDeployer<
           const ism = await this.options.ismFactory.deploy(
             local,
             config.interchainSecurityModule,
-          );
-          await this.multiProvider.handleTx(
-            local,
-            connectionClient.setInterchainSecurityModule(
-              ism.address,
-              txOverrides,
-            ),
           );
           configuredIsm = ism.address;
         } else {


### PR DESCRIPTION
### Description

- Deployed the AggregationISM configured with default multisig validators on Testnet

### Drive-by changes

- Fixed edge case of handling zero address for `connectionClient.interchainSecurityModule`

### Related issues

- Fixes #2477

### Backward compatibility

  Yes

### Testing

Manual
