### PR TITLE
Fix deploying validators when there's an empty validator set

### DIFF
--- a/rust/helm/hyperlane-agent/values.yaml
+++ b/rust/helm/hyperlane-agent/values.yaml
@@ -80,11 +80,11 @@ hyperlane:
         cpu: 100m
         memory: 256Mi
     # -- How long to wait between checking for updates
-    configs:
-      - interval:
-        reorgPeriod:
-        checkpointSyncers:
-        originChainName:
+    configs: []
+      # - interval:
+      #   reorgPeriod:
+      #   checkpointSyncers:
+      #   originChainName:
 
   relayer:
     enabled: false

--- a/typescript/infra/scripts/agents/utils.ts
+++ b/typescript/infra/scripts/agents/utils.ts
@@ -34,7 +34,14 @@ export class AgentCli {
         case Role.Validator:
           for (const chain of this.agentConfig.contextChainNames) {
             const key = `${role}-${chain}`;
-            managers[key] = new ValidatorHelmManager(this.agentConfig, chain);
+            const manager = new ValidatorHelmManager(this.agentConfig, chain);
+            if (manager.length === 0) {
+              console.log(
+                `No validators configured for chain ${chain}, skipping deploy`,
+              );
+              continue;
+            }
+            managers[key] = manager;
           }
           break;
         case Role.Relayer:


### PR DESCRIPTION
### Description

Turns out when there aren't any validators in the set, which is the case for solanadevnet & zbctestnet on the RC context (https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/infra/config/environments/testnet3/validators.ts#L195), the helm value `hyperlane.validator.configs` wasn't being overridden with CLI value args. So the `configs` in values.yaml, which has a length of 1 with some keys and empty values to illustrate (part of) the expected format of the config, was being used. So then in the Helm template we'd end up iterate through the configs of len 1 :(

The fix is to just set the default `configs` to `[]`

I also considered adding a check to just skip the chain if the validator set is 0, because there's usually no use in deploying them anyways. But we may be deploying to a chain that used to have a non-zero validator set that we now want to be 0, so we may as well just deploy it and deal with the fact that there will be some helm releases relating to a validator set of 0 🤷

### Drive-by changes

n/a

### Related issues

n/a

### Backward compatibility

backward compatible

### Testing

deployed