### PR TITLE
Set a provider timeout

### DIFF
--- a/typescript/sdk/src/metadata/chainMetadataTypes.ts
+++ b/typescript/sdk/src/metadata/chainMetadataTypes.ts
@@ -5,6 +5,7 @@ export enum ProtocolType {
   Sealevel = 'sealevel',
   Fuel = 'fuel',
 }
+
 // A type that also allows for literal values of the enum
 export type ProtocolTypeValue = `${ProtocolType}`;
 
@@ -18,6 +19,7 @@ export enum ExplorerFamily {
   Blockscout = 'blockscout',
   Other = 'other',
 }
+
 // A type that also allows for literal values of the enum
 export type ExplorerFamilyValue = `${ExplorerFamily}`;
 
@@ -128,6 +130,11 @@ export const ChainMetadataSchema = z.object({
           .describe(
             'Default retry settings to be used by a provider such as MultiProvider.',
           ),
+        timeout: z
+          .number()
+          .positive()
+          .optional()
+          .describe('Provider request timeout in ms.'),
       }),
     )
     .nonempty()

--- a/typescript/sdk/src/providers/MultiProvider.ts
+++ b/typescript/sdk/src/providers/MultiProvider.ts
@@ -30,7 +30,7 @@ const DEFAULT_RETRY_OPTIONS: RetryProviderOptions = {
   baseRetryMs: 250,
 };
 
-const DEFAULT_PROVIDER_TIMEOUT: number = 1000 * 60 * 5; // 5 min
+export const DEFAULT_PROVIDER_TIMEOUT: number = 1000 * 30; // 30s
 
 export function defaultProviderBuilder(
   rpcUrls: ChainMetadata['rpcUrls'],


### PR DESCRIPTION
### Description

After observing the behavior of kathy, it seems like the service hang due to a non-responsive request. This PR is a fairly minor change that specifies a default timeout and allows specifying it in the chain metadata.

This specifically targets the behavior of this line in ethers
https://github.com/ethers-io/ethers.js/blob/bcc4d8c8701cfe980742b7d33dc7b0ee4fc48fec/src.ts/providers/provider.ts#L1487

which seems to allow the application to hang indefinitely under certain cases if no timeout is set.

Word of warning on this PR. I don't personally have a ton of context for working on this and I might be misunderstanding the consequences of this change. I am hoping someone who knows more about the TS lib will be able to validate that this is both 1) a sane default and 2) a good action to take.

### Drive-by changes
None

### Related issues
Related to and documented observations here
https://discord.com/channels/935678348330434570/1133779194711646281

### Backward compatibility

Yes

### Testing

None