### PR TITLE
Fix scraper deploy failure caused by infra config drift

### DIFF
--- a/typescript/infra/config/environments/testnet3/chains.ts
+++ b/typescript/infra/config/environments/testnet3/chains.ts
@@ -24,4 +24,4 @@ export const chainNames = Object.keys(testnetConfigs) as TestnetChains[];
 export const environment = 'testnet3';
 
 // Chains that we want to run agents for.
-export const agentChainNames = [...chainNames, 'solanadevnet', 'zbctestnet'];
+export const agentChainNames = [...chainNames];


### PR DESCRIPTION
### Description
The infra config should represent the currently deployed state. This brings it back into alignment. By deploying the version that was in the main branch I saw hard failures in the scraper.

https://cloudlogging.app.goo.gl/7w65L2Sin3cgKtw99

### Drive-by changes

None

### Related issues
https://discord.com/channels/935678348330434570/935679524534911007/1133827653338677310

### Backward compatibility
Yes

### Testing
Manual