### PR TITLE
Updating the relayer and validator images to 2023-07-25 version

### DIFF
--- a/typescript/infra/config/environments/mainnet2/agent.ts
+++ b/typescript/infra/config/environments/mainnet2/agent.ts
@@ -69,7 +69,7 @@ const hyperlane: RootAgentConfig = {
     connectionType: AgentConnectionType.HttpFallback,
     docker: {
       repo,
-      tag: '2deb9b8-20230602-205342',
+      tag: 'ed7569d-20230725-171222',
     },
     blacklist: [
       ...releaseCandidateHelloworldMatchingList,
@@ -83,7 +83,7 @@ const hyperlane: RootAgentConfig = {
   validators: {
     docker: {
       repo,
-      tag: '497db63-20230614-174455',
+      tag: 'ed7569d-20230725-171222',
     },
     connectionType: AgentConnectionType.HttpQuorum,
     chains: validatorChainConfig(Contexts.Hyperlane),
@@ -105,7 +105,7 @@ const releaseCandidate: RootAgentConfig = {
     connectionType: AgentConnectionType.HttpFallback,
     docker: {
       repo,
-      tag: 'aa92fe3-20230717-210518',
+      tag: 'ed7569d-20230725-171222',
     },
     whitelist: releaseCandidateHelloworldMatchingList,
     gasPaymentEnforcement,
@@ -117,7 +117,7 @@ const releaseCandidate: RootAgentConfig = {
   validators: {
     docker: {
       repo,
-      tag: 'aa92fe3-20230717-210518',
+      tag: 'ed7569d-20230725-171222',
     },
     connectionType: AgentConnectionType.HttpQuorum,
     chains: validatorChainConfig(Contexts.ReleaseCandidate),

--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -118,7 +118,7 @@ const releaseCandidate: RootAgentConfig = {
     connectionType: AgentConnectionType.HttpFallback,
     docker: {
       repo,
-      tag: 'f03257a-20230714-154845',
+      tag: 'aa92fe3-20230717-210518',
     },
     whitelist: [
       ...releaseCandidateHelloworldMatchingList,
@@ -170,7 +170,7 @@ const releaseCandidate: RootAgentConfig = {
     connectionType: AgentConnectionType.HttpFallback,
     docker: {
       repo,
-      tag: '497db63-20230614-174455',
+      tag: 'aa92fe3-20230717-210518',
     },
     chains: validatorChainConfig(Contexts.ReleaseCandidate),
   },

--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -72,7 +72,7 @@ const hyperlane: RootAgentConfig = {
     connectionType: AgentConnectionType.HttpFallback,
     docker: {
       repo,
-      tag: 'f03257a-20230714-154845',
+      tag: 'ed7569d-20230725-171222',
     },
     blacklist: [
       ...releaseCandidateHelloworldMatchingList,
@@ -89,7 +89,7 @@ const hyperlane: RootAgentConfig = {
     connectionType: AgentConnectionType.HttpFallback,
     docker: {
       repo,
-      tag: '497db63-20230614-174455',
+      tag: 'ed7569d-20230725-171222',
     },
     chainDockerOverrides: {
       [chainMetadata.solanadevnet.name]: {
@@ -118,7 +118,7 @@ const releaseCandidate: RootAgentConfig = {
     connectionType: AgentConnectionType.HttpFallback,
     docker: {
       repo,
-      tag: 'aa92fe3-20230717-210518',
+      tag: 'ed7569d-20230725-171222',
     },
     whitelist: [
       ...releaseCandidateHelloworldMatchingList,
@@ -170,7 +170,7 @@ const releaseCandidate: RootAgentConfig = {
     connectionType: AgentConnectionType.HttpFallback,
     docker: {
       repo,
-      tag: 'aa92fe3-20230717-210518',
+      tag: 'ed7569d-20230725-171222',
     },
     chains: validatorChainConfig(Contexts.ReleaseCandidate),
   },


### PR DESCRIPTION
### Description

- Updating both rc and hyperlane testnet3 and mainnet2 versions for relayers and validators to `ed7569d-20230725-171222` image which has the necessary changes for `AggregationISM` and `NullMetadataISM`

### Drive-by changes

None

### Related issues

- Release: https://github.com/hyperlane-xyz/hyperlane-monorepo/releases/tag/agents-2023-07-25

### Backward compatibility

Yes


### Testing

Manual
