### PR TITLE
E2E test `pkill` anvil

### DIFF
--- a/rust/utils/run-locally/src/ethereum.rs
+++ b/rust/utils/run-locally/src/ethereum.rs
@@ -23,7 +23,11 @@ pub fn start_anvil(config: Arc<Config>) -> AgentHandles {
 
     if !config.is_ci_env {
         // Kill any existing anvil processes just in case since it seems to have issues getting cleaned up
-        Program::new("pkill").raw_arg("-SIGKILL").cmd("anvil").run_ignore_code().join();
+        Program::new("pkill")
+            .raw_arg("-SIGKILL")
+            .cmd("anvil")
+            .run_ignore_code()
+            .join();
     }
     log!("Launching anvil...");
     let anvil_args = Program::new("anvil").flag("silent").filter_logs(|_| false); // for now do not keep any of the anvil logs

--- a/rust/utils/run-locally/src/ethereum.rs
+++ b/rust/utils/run-locally/src/ethereum.rs
@@ -21,6 +21,10 @@ pub fn start_anvil(config: Arc<Config>) -> AgentHandles {
     }
     yarn_monorepo.clone().cmd("build").run().join();
 
+    if !config.is_ci_env {
+        // Kill any existing anvil processes just in case since it seems to have issues getting cleaned up
+        Program::new("pkill").raw_arg("-SIGKILL").cmd("anvil").run_ignore_code().join();
+    }
     log!("Launching anvil...");
     let anvil_args = Program::new("anvil").flag("silent").filter_logs(|_| false); // for now do not keep any of the anvil logs
     let anvil = anvil_args.spawn("ETH");


### PR DESCRIPTION
### Description

Fixes a minor bug when testing locally where sometimes a failure in the e2e test will not correctly clean up anvil. This just runs `pkill -SIGKILL anvil` to clean it up if it was running.


### Drive-by changes

None

### Related issues


### Backward compatibility

Yes

### Testing

Manual