### PR TITLE
Run rust fmt on pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged
-cargo fmt --all --manifest-path rust/Cargo.toml
+cargo fmt --all --check --manifest-path rust/Cargo.toml

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged
+cargo fmt --all --manifest-path rust/Cargo.toml

--- a/rust/hyperlane-core/src/accumulator/incremental.rs
+++ b/rust/hyperlane-core/src/accumulator/incremental.rs
@@ -100,7 +100,8 @@ mod test {
         let test_cases = test_utils::load_merkle_test_json();
 
         for test_case in test_cases.iter() {
-            let mut tree = IncrementalMerkle::default();
+            let mut tree = IncrementalMerkle::
+            default();
 
             // insert the leaves
             for leaf in test_case.leaves.iter() {

--- a/rust/hyperlane-core/src/accumulator/incremental.rs
+++ b/rust/hyperlane-core/src/accumulator/incremental.rs
@@ -100,8 +100,7 @@ mod test {
         let test_cases = test_utils::load_merkle_test_json();
 
         for test_case in test_cases.iter() {
-            let mut tree = IncrementalMerkle::
-            default();
+            let mut tree = IncrementalMerkle::default();
 
             // insert the leaves
             for leaf in test_case.leaves.iter() {


### PR DESCRIPTION
### Description
Tired of the workflow telling you to run `cargo fmt`? Worry no more, now on commit all your rust code will get checked so you don't have to wait for the pipeline to fail.

### Drive-by changes

None

### Related issues

### Backward compatibility

Yes

### Testing

manual