### PR TITLE
chore: more comprehensive rust caching

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,10 @@ jobs:
         with:
           prefix-key: 'v2-rust'
           shared-key: 'e2e'
+          cache-on-failure: "true"
+          # If `true` all crates will be cached, otherwise only dependent crates will be cached.
+          # Useful if additional crates are used for CI tooling.
+          cache-all-crates: "true"
           workspaces: |
             ./rust
       - name: node module cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           prefix-key: "v2-rust"
           shared-key: "test"
+          cache-on-failure: "true"
+          cache-all-crates: "true"
           workspaces: |
             ./rust
       - name: Free disk space
@@ -66,6 +68,8 @@ jobs:
         with:
           prefix-key: "v2-rust"
           shared-key: "lint"
+          cache-on-failure: "true"
+          cache-all-crates: "true"
           workspaces: |
             ./rust
       - name: Free disk space


### PR DESCRIPTION
### Description

Caches rust crates on pipeline failure and includes CI-specific crates in the cases. This may result in more frequent evictions but assumes recent builds are more relevant than old ones.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
