### PR TITLE
Validator announce signers

### DIFF
--- a/rust/agents/validator/src/validator.rs
+++ b/rust/agents/validator/src/validator.rs
@@ -226,6 +226,14 @@ impl Validator {
     }
 
     async fn announce(&self) -> Result<()> {
+        if self.core.settings.chains[self.origin_chain.name()]
+            .signer
+            .is_none()
+        {
+            warn!(origin_chain=%self.origin_chain, "Cannot announce validator without a signer; make sure a signer is set for the origin chain");
+            return Ok(());
+        }
+
         // Sign and post the validator announcement
         let announcement = Announcement {
             validator: self.signer.eth_address(),


### PR DESCRIPTION
### Description

This handles a bug where we did not default the chain signer to the validator signature for EVM chains and also handles the case where we might try to announce without setting a chain signer for other chains.

### Drive-by changes

Not really a change but I looked into #2457 and I noticed the validators already check that signers are set for all destination chains so I think the error was just for validators which this PR fixes.

### Related issues

- Fixes #2458
- Fixes  #2457

### Backward compatibility

Yes

### Testing

Unit Tests