### PR TITLE
fix: only run cargo fmt hook when rs files changed

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,9 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged
-cargo fmt --all --check --manifest-path rust/Cargo.toml
+
+# if any *.rs files have changed
+if git diff --staged --exit-code --name-only | grep -q -E ".*\.rs$"; then
+    echo "Running cargo fmt pre-commit hook"
+    cargo fmt --all --check --manifest-path rust/Cargo.toml
+fi


### PR DESCRIPTION
### Description

The `cargo fmt` pre-commit hook runs regardless of whether any `.rs` files have changed and this is interfering with unrelated workflows. This reduces the scope of the hook to commits with nonempty rust diffs.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
