### PR TITLE
Revert "refactor(IndexMode): remove `IndexRange`… (#2562)"

### DIFF
--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -266,11 +266,10 @@ impl Relayer {
         &self,
         origin: &HyperlaneDomain,
     ) -> Instrumented<JoinHandle<eyre::Result<()>>> {
-        let (index_settings, index_mode) =
-            self.as_ref().settings.chains[origin.name()].index_settings_and_mode();
+        let index_settings = self.as_ref().settings.chains[origin.name()].index.clone();
         let contract_sync = self.message_syncs.get(origin).unwrap().clone();
         let cursor = contract_sync
-            .forward_backward_message_sync_cursor(index_settings, index_mode)
+            .forward_backward_message_sync_cursor(index_settings)
             .await;
         tokio::spawn(async move {
             contract_sync
@@ -285,16 +284,13 @@ impl Relayer {
         &self,
         origin: &HyperlaneDomain,
     ) -> Instrumented<JoinHandle<eyre::Result<()>>> {
-        let (index_settings, index_mode) =
-            self.as_ref().settings.chains[origin.name()].index_settings_and_mode();
+        let index_settings = self.as_ref().settings.chains[origin.name()].index.clone();
         let contract_sync = self
             .interchain_gas_payment_syncs
             .get(origin)
             .unwrap()
             .clone();
-        let cursor = contract_sync
-            .rate_limited_cursor(index_settings, index_mode)
-            .await;
+        let cursor = contract_sync.rate_limited_cursor(index_settings).await;
         tokio::spawn(async move { contract_sync.clone().sync("gas_payments", cursor).await })
             .instrument(info_span!("ContractSync"))
     }

--- a/rust/agents/scraper/src/agent.rs
+++ b/rust/agents/scraper/src/agent.rs
@@ -234,7 +234,7 @@ macro_rules! spawn_sync_task {
                 .await
                 .unwrap();
             let cursor = sync
-                .$cursor(index_settings.clone(), domain.clone().index_mode())
+                .$cursor(index_settings.clone())
                 .await;
                 tokio::spawn(async move {
                     sync
@@ -275,11 +275,7 @@ impl Scraper {
             .unwrap_or(None)
             .unwrap_or(0);
         let cursor = sync
-            .forward_message_sync_cursor(
-                index_settings.clone(),
-                domain.index_mode(),
-                latest_nonce.saturating_sub(1),
-            )
+            .forward_message_sync_cursor(index_settings.clone(), latest_nonce.saturating_sub(1))
             .await;
         tokio::spawn(async move { sync.sync("message_dispatch", cursor).await }).instrument(
             info_span!("ChainContractSync", chain=%domain.name(), event="message_dispatch"),

--- a/rust/agents/validator/src/validator.rs
+++ b/rust/agents/validator/src/validator.rs
@@ -143,11 +143,12 @@ impl BaseAgent for Validator {
 
 impl Validator {
     async fn run_message_sync(&self) -> Instrumented<JoinHandle<Result<()>>> {
-        let (index_settings, index_mode) =
-            self.as_ref().settings.chains[self.origin_chain.name()].index_settings_and_mode();
+        let index_settings = self.as_ref().settings.chains[self.origin_chain.name()]
+            .index
+            .clone();
         let contract_sync = self.message_sync.clone();
         let cursor = contract_sync
-            .forward_backward_message_sync_cursor(index_settings, index_mode)
+            .forward_backward_message_sync_cursor(index_settings)
             .await;
         tokio::spawn(async move {
             contract_sync

--- a/rust/chains/hyperlane-fuel/src/interchain_gas.rs
+++ b/rust/chains/hyperlane-fuel/src/interchain_gas.rs
@@ -1,9 +1,7 @@
-use std::ops::RangeInclusive;
-
 use async_trait::async_trait;
 
 use hyperlane_core::{
-    ChainResult, HyperlaneChain, HyperlaneContract, Indexer, InterchainGasPaymaster,
+    ChainResult, HyperlaneChain, HyperlaneContract, IndexRange, Indexer, InterchainGasPaymaster,
 };
 use hyperlane_core::{HyperlaneDomain, HyperlaneProvider, InterchainGasPayment, LogMeta, H256};
 
@@ -37,7 +35,7 @@ pub struct FuelInterchainGasPaymasterIndexer {}
 impl Indexer<InterchainGasPayment> for FuelInterchainGasPaymasterIndexer {
     async fn fetch_logs(
         &self,
-        range: RangeInclusive<u32>,
+        range: IndexRange,
     ) -> ChainResult<Vec<(InterchainGasPayment, LogMeta)>> {
         todo!()
     }

--- a/rust/chains/hyperlane-fuel/src/mailbox.rs
+++ b/rust/chains/hyperlane-fuel/src/mailbox.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::num::NonZeroU64;
-use std::ops::RangeInclusive;
 
 use async_trait::async_trait;
 use fuels::prelude::{Bech32ContractId, WalletUnlocked};
@@ -11,7 +10,8 @@ use tracing::instrument;
 use hyperlane_core::{
     utils::fmt_bytes, ChainCommunicationError, ChainResult, Checkpoint, ContractLocator,
     HyperlaneAbi, HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneMessage,
-    HyperlaneProvider, Indexer, LogMeta, Mailbox, TxCostEstimate, TxOutcome, H256, U256,
+    HyperlaneProvider, IndexRange, Indexer, LogMeta, Mailbox, TxCostEstimate, TxOutcome, H256,
+    U256,
 };
 
 use crate::{
@@ -154,10 +154,7 @@ pub struct FuelMailboxIndexer {}
 
 #[async_trait]
 impl Indexer<HyperlaneMessage> for FuelMailboxIndexer {
-    async fn fetch_logs(
-        &self,
-        range: RangeInclusive<u32>,
-    ) -> ChainResult<Vec<(HyperlaneMessage, LogMeta)>> {
+    async fn fetch_logs(&self, range: IndexRange) -> ChainResult<Vec<(HyperlaneMessage, LogMeta)>> {
         todo!()
     }
 
@@ -168,7 +165,7 @@ impl Indexer<HyperlaneMessage> for FuelMailboxIndexer {
 
 #[async_trait]
 impl Indexer<H256> for FuelMailboxIndexer {
-    async fn fetch_logs(&self, range: RangeInclusive<u32>) -> ChainResult<Vec<(H256, LogMeta)>> {
+    async fn fetch_logs(&self, range: IndexRange) -> ChainResult<Vec<(H256, LogMeta)>> {
         todo!()
     }
 

--- a/rust/chains/hyperlane-sealevel/src/interchain_gas.rs
+++ b/rust/chains/hyperlane-sealevel/src/interchain_gas.rs
@@ -1,10 +1,8 @@
-use std::ops::RangeInclusive;
-
 use async_trait::async_trait;
 use hyperlane_core::{
     ChainResult, ContractLocator, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
-    HyperlaneProvider, Indexer, InterchainGasPaymaster, InterchainGasPayment, LogMeta,
-    SequenceIndexer, H256,
+    HyperlaneProvider, IndexRange, Indexer, InterchainGasPaymaster, InterchainGasPayment, LogMeta,
+    H256,
 };
 use tracing::{info, instrument};
 
@@ -63,7 +61,7 @@ impl Indexer<InterchainGasPayment> for SealevelInterchainGasPaymasterIndexer {
     #[instrument(err, skip(self))]
     async fn fetch_logs(
         &self,
-        _range: RangeInclusive<u32>,
+        _range: IndexRange,
     ) -> ChainResult<Vec<(InterchainGasPayment, LogMeta)>> {
         info!("Gas payment indexing not implemented for Sealevel");
         Ok(vec![])
@@ -74,13 +72,5 @@ impl Indexer<InterchainGasPayment> for SealevelInterchainGasPaymasterIndexer {
         // As a workaround to avoid gas payment indexing on Sealevel,
         // we pretend the block number is 1.
         Ok(1)
-    }
-}
-
-#[async_trait]
-impl SequenceIndexer<InterchainGasPayment> for SealevelInterchainGasPaymasterIndexer {
-    async fn sequence_at_tip(&self) -> ChainResult<(u32, u32)> {
-        info!("Gas payment indexing not implemented for Sealevel");
-        Ok((1, 1))
     }
 }

--- a/rust/hyperlane-core/src/chain.rs
+++ b/rust/hyperlane-core/src/chain.rs
@@ -9,7 +9,7 @@ use num_traits::FromPrimitive;
 use strum::{EnumIter, EnumString, IntoStaticStr};
 
 use crate::utils::many_to_one;
-use crate::{HyperlaneProtocolError, IndexMode, H160, H256};
+use crate::{HyperlaneProtocolError, H160, H256};
 
 #[derive(Debug, Clone)]
 pub struct Address(pub bytes::Bytes);
@@ -104,6 +104,17 @@ pub enum HyperlaneDomain {
         domain_type: HyperlaneDomainType,
         domain_protocol: HyperlaneDomainProtocol,
     },
+}
+
+impl HyperlaneDomain {
+    pub fn is_arbitrum_nitro(&self) -> bool {
+        matches!(
+            self,
+            HyperlaneDomain::Known(
+                KnownHyperlaneDomain::Arbitrum | KnownHyperlaneDomain::ArbitrumGoerli,
+            )
+        )
+    }
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -347,24 +358,6 @@ impl HyperlaneDomain {
                 domain_protocol, ..
             } => *domain_protocol,
         }
-    }
-
-    pub fn is_arbitrum_nitro(&self) -> bool {
-        matches!(
-            self,
-            HyperlaneDomain::Known(
-                KnownHyperlaneDomain::Arbitrum | KnownHyperlaneDomain::ArbitrumGoerli,
-            )
-        )
-    }
-
-    pub const fn index_mode(&self) -> IndexMode {
-        use HyperlaneDomainProtocol::*;
-        let protocol = self.domain_protocol();
-        many_to_one!(match protocol {
-            IndexMode::Block: [Ethereum],
-            IndexMode::Sequence : [Sealevel, Fuel],
-        })
     }
 }
 

--- a/rust/hyperlane-core/src/traits/cursor.rs
+++ b/rust/hyperlane-core/src/traits/cursor.rs
@@ -1,9 +1,9 @@
-use std::{ops::RangeInclusive, time::Duration};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 
-use crate::{ChainResult, LogMeta};
+use crate::{ChainResult, IndexRange, LogMeta};
 
 /// A cursor governs event indexing for a contract.
 #[async_trait]
@@ -23,7 +23,7 @@ pub trait ContractSyncCursor<T>: Send + Sync + 'static {
 /// The action that should be taken by the contract sync loop
 pub enum CursorAction {
     /// Direct the contract_sync task to query a block range (inclusive)
-    Query(RangeInclusive<u32>),
+    Query(IndexRange),
     /// Direct the contract_sync task to sleep for a duration
     Sleep(Duration),
 }

--- a/rust/hyperlane-core/src/traits/indexer.rs
+++ b/rust/hyperlane-core/src/traits/indexer.rs
@@ -24,12 +24,23 @@ pub enum IndexMode {
     Sequence,
 }
 
+/// An indexing range.
+#[derive(Debug, Clone)]
+pub enum IndexRange {
+    /// For block-based indexers
+    BlockRange(RangeInclusive<u32>),
+    /// For indexers that look for specific sequences, e.g. message nonces.
+    SequenceRange(RangeInclusive<u32>),
+}
+
+pub use IndexRange::*;
+
 /// Interface for an indexer.
 #[async_trait]
 #[auto_impl(&, Box, Arc,)]
 pub trait Indexer<T: Sized>: Send + Sync + Debug {
     /// Fetch list of logs between blocks `from` and `to`, inclusive.
-    async fn fetch_logs(&self, range: RangeInclusive<u32>) -> ChainResult<Vec<(T, LogMeta)>>;
+    async fn fetch_logs(&self, range: IndexRange) -> ChainResult<Vec<(T, LogMeta)>>;
 
     /// Get the chain's latest block number that has reached finality
     async fn get_finalized_block_number(&self) -> ChainResult<u32>;
@@ -42,12 +53,4 @@ pub trait Indexer<T: Sized>: Send + Sync + Debug {
 pub trait MessageIndexer: Indexer<HyperlaneMessage> + 'static {
     /// Return the latest finalized mailbox count and block number
     async fn fetch_count_at_tip(&self) -> ChainResult<(u32, u32)>;
-}
-
-/// Interface for indexing data in sequence. Currently used in non-EVM chains
-#[async_trait]
-#[auto_impl(&, Box, Arc)]
-pub trait SequenceIndexer<T>: Indexer<T> + 'static {
-    /// Return the latest finalized sequence and block number
-    async fn sequence_at_tip(&self) -> ChainResult<(u32, u32)>;
 }


### PR DESCRIPTION
This reverts commit 127294decc4077982c82044847ab6165c74c2ba0, to include a cursor bugfix in main and remove an IGP indexing bug added by that PR.

### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
