### PR TITLE
Add SetInterchainGasPaymaster instruction to warp route programs

### DIFF
--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/instruction.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/instruction.rs
@@ -32,6 +32,8 @@ pub enum Instruction {
     SetDestinationGasConfigs(Vec<GasRouterConfig>),
     /// Set the interchain security module. Only owner.
     SetInterchainSecurityModule(Option<Pubkey>),
+    /// Set the interchain gas paymaster program and account. Only owner.
+    SetInterchainGasPaymaster(Option<(Pubkey, InterchainGasPaymasterType)>),
     /// Transfer ownership of the program. Only owner.
     TransferOwnership(Option<Pubkey>),
 }

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
@@ -853,4 +853,32 @@ where
 
         Ok(())
     }
+
+    /// Lets the owner set the interchain gas paymaster.
+    ///
+    /// Accounts:
+    /// 0. [writeable] The token PDA account.
+    /// 1. [signer] The access control owner.
+    pub fn set_interchain_gas_paymaster(
+        program_id: &Pubkey,
+        accounts: &[AccountInfo],
+        igp: Option<(Pubkey, InterchainGasPaymasterType)>,
+    ) -> ProgramResult {
+        let accounts_iter = &mut accounts.iter();
+
+        // Account 0: Token account
+        let token_account = next_account_info(accounts_iter)?;
+        let mut token = HyperlaneToken::verify_account_and_fetch_inner(program_id, token_account)?;
+
+        // Account 1: Owner
+        let owner_account = next_account_info(accounts_iter)?;
+
+        // This errors if owner_account is not really the owner.
+        token.set_interchain_gas_paymaster_only_owner(owner_account, igp)?;
+
+        // Store the updated token account. No need to realloc, the size for the ISM is the same.
+        HyperlaneTokenAccount::<T>::from(token).store(token_account, false)?;
+
+        Ok(())
+    }
 }

--- a/rust/sealevel/programs/hyperlane-sealevel-token-collateral/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-collateral/src/processor.rs
@@ -4,6 +4,7 @@ use account_utils::DiscriminatorDecode;
 use hyperlane_sealevel_connection_client::{
     gas_router::GasRouterConfig, router::RemoteRouterConfig,
 };
+use hyperlane_sealevel_igp::accounts::InterchainGasPaymasterType;
 use hyperlane_sealevel_message_recipient_interface::{
     HandleInstruction, MessageRecipientInstruction,
 };
@@ -74,6 +75,9 @@ pub fn process_instruction(
         }
         TokenIxn::SetInterchainSecurityModule(new_ism) => {
             set_interchain_security_module(program_id, accounts, new_ism)
+        }
+        TokenIxn::SetInterchainGasPaymaster(new_igp) => {
+            set_interchain_gas_paymaster(program_id, accounts, new_igp)
         }
     }
     .map_err(|err| {
@@ -249,5 +253,20 @@ fn set_interchain_security_module(
 ) -> ProgramResult {
     HyperlaneSealevelToken::<CollateralPlugin>::set_interchain_security_module(
         program_id, accounts, new_ism,
+    )
+}
+
+/// Lets the owner set the interchain gas paymaster.
+///
+/// Accounts:
+/// 0. [writeable] The token PDA account.
+/// 1. [signer] The access control owner.
+fn set_interchain_gas_paymaster(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    new_igp: Option<(Pubkey, InterchainGasPaymasterType)>,
+) -> ProgramResult {
+    HyperlaneSealevelToken::<CollateralPlugin>::set_interchain_gas_paymaster(
+        program_id, accounts, new_igp,
     )
 }

--- a/rust/sealevel/programs/hyperlane-sealevel-token-collateral/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-collateral/tests/functional.rs
@@ -1604,4 +1604,172 @@ async fn test_set_interchain_security_module_errors_if_owner_not_signer() {
         result,
         TransactionError::InstructionError(0, InstructionError::InvalidArgument),
     );
+
+    // Also try using the non_owner as the payer and specifying the correct
+    // owner account, but the owner isn't a signer:
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &HyperlaneTokenInstruction::SetInterchainSecurityModule(new_ism)
+                .encode()
+                .unwrap(),
+            vec![
+                AccountMeta::new(hyperlane_token_accounts.token, false),
+                AccountMeta::new_readonly(payer.pubkey(), false),
+            ],
+        )],
+        Some(&mint_authority.pubkey()),
+        &[&mint_authority],
+        recent_blockhash,
+    );
+    let result = banks_client.process_transaction(transaction).await;
+    assert_transaction_error(
+        result,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature),
+    );
+}
+
+#[tokio::test]
+async fn test_set_interchain_gas_paymaster() {
+    let program_id = hyperlane_sealevel_token_collateral_id();
+    let spl_token_program_id = spl_token_2022::id();
+
+    let (mut banks_client, payer) = setup_client().await;
+
+    let (mint, _mint_authority) = initialize_mint(
+        &mut banks_client,
+        &payer,
+        LOCAL_DECIMALS,
+        &spl_token_program_id,
+    )
+    .await;
+
+    let hyperlane_token_accounts = initialize_hyperlane_token(
+        &program_id,
+        &mut banks_client,
+        &payer,
+        None,
+        &mint,
+        &spl_token_program_id,
+    )
+    .await
+    .unwrap();
+
+    let new_igp = Some((
+        Pubkey::new_unique(),
+        InterchainGasPaymasterType::OverheadIgp(Pubkey::new_unique()),
+    ));
+
+    // Set the IGP
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &HyperlaneTokenInstruction::SetInterchainGasPaymaster(new_igp.clone())
+                .encode()
+                .unwrap(),
+            vec![
+                AccountMeta::new(hyperlane_token_accounts.token, false),
+                AccountMeta::new_readonly(payer.pubkey(), true),
+            ],
+        )],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Verify the new IGP is set
+    let token_account_data = banks_client
+        .get_account(hyperlane_token_accounts.token)
+        .await
+        .unwrap()
+        .unwrap()
+        .data;
+    let token = HyperlaneTokenAccount::<CollateralPlugin>::fetch(&mut &token_account_data[..])
+        .unwrap()
+        .into_inner();
+    assert_eq!(token.interchain_gas_paymaster, new_igp);
+}
+
+#[tokio::test]
+async fn test_set_interchain_gas_paymaster_errors_if_owner_not_signer() {
+    let program_id = hyperlane_sealevel_token_collateral_id();
+    let spl_token_program_id = spl_token_2022::id();
+
+    let (mut banks_client, payer) = setup_client().await;
+
+    let (mint, _mint_authority) = initialize_mint(
+        &mut banks_client,
+        &payer,
+        LOCAL_DECIMALS,
+        &spl_token_program_id,
+    )
+    .await;
+
+    let hyperlane_token_accounts = initialize_hyperlane_token(
+        &program_id,
+        &mut banks_client,
+        &payer,
+        None,
+        &mint,
+        &spl_token_program_id,
+    )
+    .await
+    .unwrap();
+
+    let new_igp = Some((
+        Pubkey::new_unique(),
+        InterchainGasPaymasterType::OverheadIgp(Pubkey::new_unique()),
+    ));
+    let non_owner = new_funded_keypair(&mut banks_client, &payer, ONE_SOL_IN_LAMPORTS).await;
+
+    // Try setting the ISM using the mint authority key
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &HyperlaneTokenInstruction::SetInterchainGasPaymaster(new_igp.clone())
+                .encode()
+                .unwrap(),
+            vec![
+                AccountMeta::new(hyperlane_token_accounts.token, false),
+                AccountMeta::new_readonly(non_owner.pubkey(), true),
+            ],
+        )],
+        Some(&non_owner.pubkey()),
+        &[&non_owner],
+        recent_blockhash,
+    );
+    let result = banks_client.process_transaction(transaction).await;
+
+    assert_transaction_error(
+        result,
+        TransactionError::InstructionError(0, InstructionError::InvalidArgument),
+    );
+
+    // Also try using the non_owner as the payer and specifying the correct
+    // owner account, but the owner isn't a signer:
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &HyperlaneTokenInstruction::SetInterchainGasPaymaster(new_igp)
+                .encode()
+                .unwrap(),
+            vec![
+                AccountMeta::new(hyperlane_token_accounts.token, false),
+                AccountMeta::new_readonly(payer.pubkey(), false),
+            ],
+        )],
+        Some(&non_owner.pubkey()),
+        &[&non_owner],
+        recent_blockhash,
+    );
+    let result = banks_client.process_transaction(transaction).await;
+    assert_transaction_error(
+        result,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature),
+    );
 }

--- a/rust/sealevel/programs/hyperlane-sealevel-token-native/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-native/src/processor.rs
@@ -4,6 +4,7 @@ use account_utils::DiscriminatorDecode;
 use hyperlane_sealevel_connection_client::{
     gas_router::GasRouterConfig, router::RemoteRouterConfig,
 };
+use hyperlane_sealevel_igp::accounts::InterchainGasPaymasterType;
 use hyperlane_sealevel_message_recipient_interface::{
     HandleInstruction, MessageRecipientInstruction,
 };
@@ -74,6 +75,9 @@ pub fn process_instruction(
         }
         TokenIxn::SetInterchainSecurityModule(new_ism) => {
             set_interchain_security_module(program_id, accounts, new_ism)
+        }
+        TokenIxn::SetInterchainGasPaymaster(new_igp) => {
+            set_interchain_gas_paymaster(program_id, accounts, new_igp)
         }
     }
     .map_err(|err| {
@@ -239,5 +243,20 @@ fn set_interchain_security_module(
 ) -> ProgramResult {
     HyperlaneSealevelToken::<NativePlugin>::set_interchain_security_module(
         program_id, accounts, new_ism,
+    )
+}
+
+/// Lets the owner set the interchain gas paymaster.
+///
+/// Accounts:
+/// 0. [writeable] The token PDA account.
+/// 1. [signer] The access control owner.
+fn set_interchain_gas_paymaster(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    new_igp: Option<(Pubkey, InterchainGasPaymasterType)>,
+) -> ProgramResult {
+    HyperlaneSealevelToken::<NativePlugin>::set_interchain_gas_paymaster(
+        program_id, accounts, new_igp,
     )
 }

--- a/rust/sealevel/programs/hyperlane-sealevel-token-native/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-native/tests/functional.rs
@@ -1158,4 +1158,142 @@ async fn test_set_interchain_security_module_errors_if_owner_not_signer() {
         result,
         TransactionError::InstructionError(0, InstructionError::InvalidArgument),
     );
+
+    // Also try using the non_owner as the payer and specifying the correct
+    // owner account, but the owner isn't a signer:
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &HyperlaneTokenInstruction::SetInterchainSecurityModule(new_ism)
+                .encode()
+                .unwrap(),
+            vec![
+                AccountMeta::new(hyperlane_token_accounts.token, false),
+                AccountMeta::new_readonly(payer.pubkey(), false),
+            ],
+        )],
+        Some(&non_owner.pubkey()),
+        &[&non_owner],
+        recent_blockhash,
+    );
+    let result = banks_client.process_transaction(transaction).await;
+    assert_transaction_error(
+        result,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature),
+    );
+}
+
+#[tokio::test]
+async fn test_set_interchain_gas_paymaster() {
+    let program_id = hyperlane_sealevel_token_native_id();
+
+    let (mut banks_client, payer) = setup_client().await;
+
+    let hyperlane_token_accounts =
+        initialize_hyperlane_token(&program_id, &mut banks_client, &payer, None)
+            .await
+            .unwrap();
+
+    let new_igp = Some((
+        Pubkey::new_unique(),
+        InterchainGasPaymasterType::OverheadIgp(Pubkey::new_unique()),
+    ));
+
+    // Set the IGP
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &HyperlaneTokenInstruction::SetInterchainGasPaymaster(new_igp.clone())
+                .encode()
+                .unwrap(),
+            vec![
+                AccountMeta::new(hyperlane_token_accounts.token, false),
+                AccountMeta::new_readonly(payer.pubkey(), true),
+            ],
+        )],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Verify the new IGP is set
+    let token_account_data = banks_client
+        .get_account(hyperlane_token_accounts.token)
+        .await
+        .unwrap()
+        .unwrap()
+        .data;
+    let token = HyperlaneTokenAccount::<NativePlugin>::fetch(&mut &token_account_data[..])
+        .unwrap()
+        .into_inner();
+    assert_eq!(token.interchain_gas_paymaster, new_igp);
+}
+
+#[tokio::test]
+async fn test_set_interchain_gas_paymaster_errors_if_owner_not_signer() {
+    let program_id = hyperlane_sealevel_token_native_id();
+
+    let (mut banks_client, payer) = setup_client().await;
+
+    let hyperlane_token_accounts =
+        initialize_hyperlane_token(&program_id, &mut banks_client, &payer, None)
+            .await
+            .unwrap();
+
+    let new_igp = Some((
+        Pubkey::new_unique(),
+        InterchainGasPaymasterType::OverheadIgp(Pubkey::new_unique()),
+    ));
+    let non_owner = new_funded_keypair(&mut banks_client, &payer, ONE_SOL_IN_LAMPORTS).await;
+
+    // Try setting the ISM using the mint authority key
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &HyperlaneTokenInstruction::SetInterchainGasPaymaster(new_igp.clone())
+                .encode()
+                .unwrap(),
+            vec![
+                AccountMeta::new(hyperlane_token_accounts.token, false),
+                AccountMeta::new_readonly(non_owner.pubkey(), true),
+            ],
+        )],
+        Some(&non_owner.pubkey()),
+        &[&non_owner],
+        recent_blockhash,
+    );
+    let result = banks_client.process_transaction(transaction).await;
+
+    assert_transaction_error(
+        result,
+        TransactionError::InstructionError(0, InstructionError::InvalidArgument),
+    );
+
+    // Also try using the non_owner as the payer and specifying the correct
+    // owner account, but the owner isn't a signer:
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &HyperlaneTokenInstruction::SetInterchainGasPaymaster(new_igp)
+                .encode()
+                .unwrap(),
+            vec![
+                AccountMeta::new(hyperlane_token_accounts.token, false),
+                AccountMeta::new_readonly(payer.pubkey(), false),
+            ],
+        )],
+        Some(&non_owner.pubkey()),
+        &[&non_owner],
+        recent_blockhash,
+    );
+    let result = banks_client.process_transaction(transaction).await;
+    assert_transaction_error(
+        result,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature),
+    );
 }

--- a/rust/sealevel/programs/hyperlane-sealevel-token/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/src/processor.rs
@@ -4,6 +4,7 @@ use account_utils::DiscriminatorDecode;
 use hyperlane_sealevel_connection_client::{
     gas_router::GasRouterConfig, router::RemoteRouterConfig,
 };
+use hyperlane_sealevel_igp::accounts::InterchainGasPaymasterType;
 use hyperlane_sealevel_message_recipient_interface::{
     HandleInstruction, MessageRecipientInstruction,
 };
@@ -71,6 +72,9 @@ pub fn process_instruction(
         }
         TokenIxn::SetInterchainSecurityModule(new_ism) => {
             set_interchain_security_module(program_id, accounts, new_ism)
+        }
+        TokenIxn::SetInterchainGasPaymaster(new_igp) => {
+            set_interchain_gas_paymaster(program_id, accounts, new_igp)
         }
         TokenIxn::TransferOwnership(new_owner) => {
             transfer_ownership(program_id, accounts, new_owner)
@@ -242,5 +246,20 @@ fn set_interchain_security_module(
 ) -> ProgramResult {
     HyperlaneSealevelToken::<SyntheticPlugin>::set_interchain_security_module(
         program_id, accounts, new_ism,
+    )
+}
+
+/// Lets the owner set the interchain gas paymaster.
+///
+/// Accounts:
+/// 0. [writeable] The token PDA account.
+/// 1. [signer] The access control owner.
+fn set_interchain_gas_paymaster(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    new_igp: Option<(Pubkey, InterchainGasPaymasterType)>,
+) -> ProgramResult {
+    HyperlaneSealevelToken::<SyntheticPlugin>::set_interchain_gas_paymaster(
+        program_id, accounts, new_igp,
     )
 }

--- a/rust/sealevel/programs/hyperlane-sealevel-token/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/tests/functional.rs
@@ -1128,7 +1128,6 @@ async fn test_set_interchain_security_module() {
     let new_ism = Some(Pubkey::new_unique());
 
     // Set the ISM
-    // Transfer ownership
     let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
     let transaction = Transaction::new_signed_with_payer(
         &[Instruction::new_with_bytes(
@@ -1196,5 +1195,143 @@ async fn test_set_interchain_security_module_errors_if_owner_not_signer() {
     assert_transaction_error(
         result,
         TransactionError::InstructionError(0, InstructionError::InvalidArgument),
+    );
+
+    // Also try using the non_owner as the payer and specifying the correct
+    // owner account, but the owner isn't a signer:
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &HyperlaneTokenInstruction::SetInterchainSecurityModule(new_ism)
+                .encode()
+                .unwrap(),
+            vec![
+                AccountMeta::new(hyperlane_token_accounts.token, false),
+                AccountMeta::new_readonly(payer.pubkey(), false),
+            ],
+        )],
+        Some(&non_owner.pubkey()),
+        &[&non_owner],
+        recent_blockhash,
+    );
+    let result = banks_client.process_transaction(transaction).await;
+    assert_transaction_error(
+        result,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature),
+    );
+}
+
+#[tokio::test]
+async fn test_set_interchain_gas_paymaster() {
+    let program_id = hyperlane_sealevel_token_id();
+
+    let (mut banks_client, payer) = setup_client().await;
+
+    let hyperlane_token_accounts =
+        initialize_hyperlane_token(&program_id, &mut banks_client, &payer, None)
+            .await
+            .unwrap();
+
+    let new_igp = Some((
+        Pubkey::new_unique(),
+        InterchainGasPaymasterType::OverheadIgp(Pubkey::new_unique()),
+    ));
+
+    // Set the IGP
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &HyperlaneTokenInstruction::SetInterchainGasPaymaster(new_igp.clone())
+                .encode()
+                .unwrap(),
+            vec![
+                AccountMeta::new(hyperlane_token_accounts.token, false),
+                AccountMeta::new_readonly(payer.pubkey(), true),
+            ],
+        )],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Verify the new IGP is set
+    let token_account_data = banks_client
+        .get_account(hyperlane_token_accounts.token)
+        .await
+        .unwrap()
+        .unwrap()
+        .data;
+    let token = HyperlaneTokenAccount::<SyntheticPlugin>::fetch(&mut &token_account_data[..])
+        .unwrap()
+        .into_inner();
+    assert_eq!(token.interchain_gas_paymaster, new_igp);
+}
+
+#[tokio::test]
+async fn test_set_interchain_gas_paymaster_errors_if_owner_not_signer() {
+    let program_id = hyperlane_sealevel_token_id();
+
+    let (mut banks_client, payer) = setup_client().await;
+
+    let hyperlane_token_accounts =
+        initialize_hyperlane_token(&program_id, &mut banks_client, &payer, None)
+            .await
+            .unwrap();
+
+    let new_igp = Some((
+        Pubkey::new_unique(),
+        InterchainGasPaymasterType::OverheadIgp(Pubkey::new_unique()),
+    ));
+    let non_owner = new_funded_keypair(&mut banks_client, &payer, ONE_SOL_IN_LAMPORTS).await;
+
+    // Try setting the ISM using the mint authority key
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &HyperlaneTokenInstruction::SetInterchainGasPaymaster(new_igp.clone())
+                .encode()
+                .unwrap(),
+            vec![
+                AccountMeta::new(hyperlane_token_accounts.token, false),
+                AccountMeta::new_readonly(non_owner.pubkey(), true),
+            ],
+        )],
+        Some(&non_owner.pubkey()),
+        &[&non_owner],
+        recent_blockhash,
+    );
+    let result = banks_client.process_transaction(transaction).await;
+
+    assert_transaction_error(
+        result,
+        TransactionError::InstructionError(0, InstructionError::InvalidArgument),
+    );
+
+    // Also try using the non_owner as the payer and specifying the correct
+    // owner account, but the owner isn't a signer:
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &HyperlaneTokenInstruction::SetInterchainGasPaymaster(new_igp)
+                .encode()
+                .unwrap(),
+            vec![
+                AccountMeta::new(hyperlane_token_accounts.token, false),
+                AccountMeta::new_readonly(payer.pubkey(), false),
+            ],
+        )],
+        Some(&non_owner.pubkey()),
+        &[&non_owner],
+        recent_blockhash,
+    );
+    let result = banks_client.process_transaction(transaction).await;
+    assert_transaction_error(
+        result,
+        TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature),
     );
 }


### PR DESCRIPTION
### Description

Sadly I missed adding an instruction to allow a warp route owner to set the IGP. This adds that. We're deploying a warp route without an IGP for now because the UI hasn't been updated to work with IGP payments yet (which is required as the UI needs to handcraft specific accounts that are passed in). We'll probably wanna flip the switch to charging gas at some point, so want to make sure we're able to do that

The way the tests are set up involves a lot of code duplications - sorry 🙈 - we should revisit at some point as now isn't the time

### Drive-by changes

n/a

### Related issues

Related #2613 

### Backward compatibility

Fully backward compatible

### Testing

Unit / functional tests