### PR TITLE
Specify per-agent chains to deploy to in deploy-agents

### DIFF
--- a/typescript/infra/config/aggregationIsm.ts
+++ b/typescript/infra/config/aggregationIsm.ts
@@ -13,11 +13,11 @@ import { objFilter, objMap } from '@hyperlane-xyz/utils';
 import { DeployEnvironment } from '../src/config';
 
 import { Contexts } from './contexts';
-import { chainNames as mainnet2Chains } from './environments/mainnet2/chains';
+import { supportedChainNames as mainnet2Chains } from './environments/mainnet2/chains';
 import { owners as mainnet2Owners } from './environments/mainnet2/owners';
 import { chainNames as testChains } from './environments/test/chains';
 import { owners as testOwners } from './environments/test/owners';
-import { chainNames as testnet3Chains } from './environments/testnet3/chains';
+import { supportedChainNames as testnet3Chains } from './environments/testnet3/chains';
 import { owners as testnet3Owners } from './environments/testnet3/owners';
 import { rcMultisigIsmConfigs } from './multisigIsm';
 

--- a/typescript/infra/config/environments/mainnet2/agent.ts
+++ b/typescript/infra/config/environments/mainnet2/agent.ts
@@ -1,7 +1,6 @@
 import {
   AgentConnectionType,
   chainMetadata,
-  getDomainId,
   hyperlaneEnvironments,
 } from '@hyperlane-xyz/sdk';
 import { objMap } from '@hyperlane-xyz/utils';
@@ -9,6 +8,7 @@ import { objMap } from '@hyperlane-xyz/utils';
 import {
   GasPaymentEnforcementPolicyType,
   RootAgentConfig,
+  allAgentChainNames,
   routerMatchingList,
 } from '../../../src/config';
 import { GasPaymentEnforcementConfig } from '../../../src/config/agent/relayer';
@@ -42,7 +42,7 @@ const contextBase = {
   namespace: environment,
   runEnv: environment,
   contextChainNames: agentChainNames,
-  environmentChainNames: agentChainNames,
+  environmentChainNames: allAgentChainNames(agentChainNames),
   aws: {
     region: 'us-east-1',
   },

--- a/typescript/infra/config/environments/mainnet2/chains.ts
+++ b/typescript/infra/config/environments/mainnet2/chains.ts
@@ -48,8 +48,8 @@ export const environment = 'mainnet2';
 
 const validatorChainNames = [
   ...supportedChainNames,
-  'solanadevnet',
-  'proteustestnet',
+  chainMetadata.solana.name,
+  chainMetadata.nautilus.name,
 ];
 
 const relayerChainNames = validatorChainNames;

--- a/typescript/infra/config/environments/mainnet2/chains.ts
+++ b/typescript/infra/config/environments/mainnet2/chains.ts
@@ -1,5 +1,7 @@
 import { ChainMap, ChainMetadata, chainMetadata } from '@hyperlane-xyz/sdk';
 
+import { ALL_AGENT_ROLES, Role } from '../../../src/roles';
+
 export const mainnetConfigs: ChainMap<ChainMetadata> = {
   bsc: {
     ...chainMetadata.bsc,
@@ -39,12 +41,22 @@ export const mainnetConfigs: ChainMap<ChainMetadata> = {
 };
 
 export type MainnetChains = keyof typeof mainnetConfigs;
-export const chainNames = Object.keys(mainnetConfigs) as MainnetChains[];
+export const supportedChainNames = Object.keys(
+  mainnetConfigs,
+) as MainnetChains[];
 export const environment = 'mainnet2';
 
-// Chains that we want to run agents for.
-export const agentChainNames = [
-  ...chainNames,
-  chainMetadata.solana.name,
-  chainMetadata.nautilus.name,
+const validatorChainNames = [
+  ...supportedChainNames,
+  'solanadevnet',
+  'proteustestnet',
 ];
+
+const relayerChainNames = validatorChainNames;
+
+export type AgentRoles = typeof ALL_AGENT_ROLES;
+export const agentChainNames: Map<ALL_AGENT_ROLES, string[]> = new Map([
+  [Role.Validator, validatorChainNames],
+  [Role.Relayer, relayerChainNames],
+  [Role.Scraper, supportedChainNames],
+]);

--- a/typescript/infra/config/environments/mainnet2/chains.ts
+++ b/typescript/infra/config/environments/mainnet2/chains.ts
@@ -1,6 +1,6 @@
 import { ChainMap, ChainMetadata, chainMetadata } from '@hyperlane-xyz/sdk';
 
-import { ALL_AGENT_ROLES, Role } from '../../../src/roles';
+import { AgentChainNames, Role } from '../../../src/roles';
 
 export const mainnetConfigs: ChainMap<ChainMetadata> = {
   bsc: {
@@ -54,9 +54,8 @@ const validatorChainNames = [
 
 const relayerChainNames = validatorChainNames;
 
-export type AgentRoles = typeof ALL_AGENT_ROLES;
-export const agentChainNames: Map<ALL_AGENT_ROLES, string[]> = new Map([
-  [Role.Validator, validatorChainNames],
-  [Role.Relayer, relayerChainNames],
-  [Role.Scraper, supportedChainNames],
-]);
+export const agentChainNames: AgentChainNames = {
+  [Role.Validator]: validatorChainNames,
+  [Role.Relayer]: relayerChainNames,
+  [Role.Scraper]: supportedChainNames,
+};

--- a/typescript/infra/config/environments/mainnet2/gas-oracle.ts
+++ b/typescript/infra/config/environments/mainnet2/gas-oracle.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../src/config';
 import { TOKEN_EXCHANGE_RATE_DECIMALS } from '../../../src/config/gas-oracle';
 
-import { chainNames } from './chains';
+import { supportedChainNames } from './chains';
 
 // Overcharge by 30% to account for market making risk
 const TOKEN_EXCHANGE_RATE_MULTIPLIER = ethers.utils.parseUnits(
@@ -81,4 +81,8 @@ function getTokenExchangeRate(local: ChainName, remote: ChainName): BigNumber {
 }
 
 export const storageGasOracleConfig: AllStorageGasOracleConfigs =
-  getAllStorageGasOracleConfigs(chainNames, gasPrices, getTokenExchangeRate);
+  getAllStorageGasOracleConfigs(
+    supportedChainNames,
+    gasPrices,
+    getTokenExchangeRate,
+  );

--- a/typescript/infra/config/environments/mainnet2/igp.ts
+++ b/typescript/infra/config/environments/mainnet2/igp.ts
@@ -7,7 +7,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { exclude, objMap } from '@hyperlane-xyz/utils';
 
-import { MainnetChains, chainNames } from './chains';
+import { MainnetChains, supportedChainNames } from './chains';
 import { core } from './core';
 import { owners } from './owners';
 
@@ -17,7 +17,7 @@ const DEPLOYER_ADDRESS = '0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba';
 
 function getGasOracles(local: MainnetChains) {
   return Object.fromEntries(
-    exclude(local, chainNames).map((name) => [
+    exclude(local, supportedChainNames).map((name) => [
       name,
       GasOracleContractType.StorageGasOracle,
     ]),
@@ -33,7 +33,7 @@ export const igp: ChainMap<OverheadIgpConfig> = objMap(
       beneficiary: KEY_FUNDER_ADDRESS,
       gasOracleType: getGasOracles(chain),
       overhead: Object.fromEntries(
-        exclude(chain, chainNames).map((remote) => [
+        exclude(chain, supportedChainNames).map((remote) => [
           remote,
           multisigIsmVerificationCost(
             defaultMultisigIsmConfigs[remote].threshold,

--- a/typescript/infra/config/environments/test/agent.ts
+++ b/typescript/infra/config/environments/test/agent.ts
@@ -7,7 +7,7 @@ import {
 import { ALL_KEY_ROLES } from '../../../src/roles';
 import { Contexts } from '../../contexts';
 
-import { chainNames } from './chains';
+import { agentChainNames, chainNames } from './chains';
 import { validators } from './validators';
 
 const roleBase = {
@@ -23,7 +23,7 @@ const hyperlane: RootAgentConfig = {
   runEnv: 'test',
   context: Contexts.Hyperlane,
   rolesWithKeys: ALL_KEY_ROLES,
-  contextChainNames: chainNames,
+  contextChainNames: agentChainNames,
   environmentChainNames: chainNames,
   relayer: {
     ...roleBase,

--- a/typescript/infra/config/environments/test/chains.ts
+++ b/typescript/infra/config/environments/test/chains.ts
@@ -11,12 +11,8 @@ export const testConfigs: ChainMap<ChainMetadata> = {
 export type TestChains = keyof typeof testConfigs;
 export const chainNames = Object.keys(testConfigs) as TestChains[];
 
-const validatorChainNames = [...chainNames, 'solanadevnet', 'proteustestnet'];
-
-const relayerChainNames = validatorChainNames;
-
 export const agentChainNames: AgentChainNames = {
-  [Role.Validator]: validatorChainNames,
-  [Role.Relayer]: relayerChainNames,
+  [Role.Validator]: chainNames,
+  [Role.Relayer]: chainNames,
   [Role.Scraper]: chainNames,
 };

--- a/typescript/infra/config/environments/test/chains.ts
+++ b/typescript/infra/config/environments/test/chains.ts
@@ -1,5 +1,7 @@
 import { ChainMap, ChainMetadata, chainMetadata } from '@hyperlane-xyz/sdk';
 
+import { AgentChainNames, Role } from '../../../src/roles';
+
 export const testConfigs: ChainMap<ChainMetadata> = {
   test1: chainMetadata.test1,
   test2: chainMetadata.test2,
@@ -8,3 +10,13 @@ export const testConfigs: ChainMap<ChainMetadata> = {
 
 export type TestChains = keyof typeof testConfigs;
 export const chainNames = Object.keys(testConfigs) as TestChains[];
+
+const validatorChainNames = [...chainNames, 'solanadevnet', 'proteustestnet'];
+
+const relayerChainNames = validatorChainNames;
+
+export const agentChainNames: AgentChainNames = {
+  [Role.Validator]: validatorChainNames,
+  [Role.Relayer]: relayerChainNames,
+  [Role.Scraper]: chainNames,
+};

--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -9,12 +9,12 @@ import { objMap } from '@hyperlane-xyz/utils';
 import {
   GasPaymentEnforcementPolicyType,
   RootAgentConfig,
+  allAgentChainNames,
   routerMatchingList,
 } from '../../../src/config';
 import { GasPaymentEnforcementConfig } from '../../../src/config/agent/relayer';
 import { ALL_KEY_ROLES, Role } from '../../../src/roles';
 import { Contexts } from '../../contexts';
-import { supportedChainNames } from '../mainnet2/chains';
 
 import { agentChainNames, environment } from './chains';
 import { helloWorld } from './helloworld';
@@ -44,7 +44,7 @@ const contextBase = {
   namespace: environment,
   runEnv: environment,
   contextChainNames: agentChainNames,
-  environmentChainNames: agentChainNames,
+  environmentChainNames: allAgentChainNames(agentChainNames),
   aws: {
     region: 'us-east-1',
   },
@@ -67,7 +67,7 @@ const gasPaymentEnforcement: GasPaymentEnforcementConfig[] = [
 
 const hyperlane: RootAgentConfig = {
   ...contextBase,
-  contextChainNames: supportedChainNames,
+  contextChainNames: agentChainNames,
   context: Contexts.Hyperlane,
   rolesWithKeys: ALL_KEY_ROLES,
   relayer: {

--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -14,7 +14,7 @@ import {
 import { GasPaymentEnforcementConfig } from '../../../src/config/agent/relayer';
 import { ALL_KEY_ROLES, Role } from '../../../src/roles';
 import { Contexts } from '../../contexts';
-import { chainNames } from '../mainnet2/chains';
+import { supportedChainNames } from '../mainnet2/chains';
 
 import { agentChainNames, environment } from './chains';
 import { helloWorld } from './helloworld';
@@ -67,7 +67,7 @@ const gasPaymentEnforcement: GasPaymentEnforcementConfig[] = [
 
 const hyperlane: RootAgentConfig = {
   ...contextBase,
-  contextChainNames: chainNames,
+  contextChainNames: supportedChainNames,
   context: Contexts.Hyperlane,
   rolesWithKeys: ALL_KEY_ROLES,
   relayer: {

--- a/typescript/infra/config/environments/testnet3/chains.ts
+++ b/typescript/infra/config/environments/testnet3/chains.ts
@@ -1,6 +1,6 @@
 import { ChainMap, ChainMetadata, chainMetadata } from '@hyperlane-xyz/sdk';
 
-import { ALL_AGENT_ROLES, Role } from '../../../src/roles';
+import { ALL_AGENT_ROLES, AgentChainNames, Role } from '../../../src/roles';
 
 export const testnetConfigs: ChainMap<ChainMetadata> = {
   alfajores: chainMetadata.alfajores,
@@ -35,10 +35,8 @@ const validatorChainNames = [
 
 const relayerChainNames = validatorChainNames;
 
-export type AgentRoles = typeof ALL_AGENT_ROLES;
-export type AgentChainNames = Map<ALL_AGENT_ROLES, string[]>;
-export const agentChainNames: AgentChainNames = new Map([
-  [Role.Validator, validatorChainNames],
-  [Role.Relayer, relayerChainNames],
-  [Role.Scraper, supportedChainNames],
-]);
+export const agentChainNames: AgentChainNames = {
+  [Role.Validator]: validatorChainNames,
+  [Role.Relayer]: relayerChainNames,
+  [Role.Scraper]: supportedChainNames,
+};

--- a/typescript/infra/config/environments/testnet3/chains.ts
+++ b/typescript/infra/config/environments/testnet3/chains.ts
@@ -1,6 +1,6 @@
 import { ChainMap, ChainMetadata, chainMetadata } from '@hyperlane-xyz/sdk';
 
-import { ALL_AGENT_ROLES, AgentChainNames, Role } from '../../../src/roles';
+import { AgentChainNames, AgentRole, Role } from '../../../src/roles';
 
 export const testnetConfigs: ChainMap<ChainMetadata> = {
   alfajores: chainMetadata.alfajores,
@@ -29,8 +29,8 @@ export const environment = 'testnet3';
 
 const validatorChainNames = [
   ...supportedChainNames,
-  'solanadevnet',
-  'proteustestnet',
+  chainMetadata.solanadevnet.name,
+  chainMetadata.proteustestnet.name,
 ];
 
 const relayerChainNames = validatorChainNames;

--- a/typescript/infra/config/environments/testnet3/chains.ts
+++ b/typescript/infra/config/environments/testnet3/chains.ts
@@ -1,5 +1,7 @@
 import { ChainMap, ChainMetadata, chainMetadata } from '@hyperlane-xyz/sdk';
 
+import { ALL_AGENT_ROLES, Role } from '../../../src/roles';
+
 export const testnetConfigs: ChainMap<ChainMetadata> = {
   alfajores: chainMetadata.alfajores,
   fuji: chainMetadata.fuji,
@@ -20,12 +22,23 @@ export const testnetConfigs: ChainMap<ChainMetadata> = {
 
 // "Blessed" chains that we want core contracts for.
 export type TestnetChains = keyof typeof testnetConfigs;
-export const chainNames = Object.keys(testnetConfigs) as TestnetChains[];
+export const supportedChainNames = Object.keys(
+  testnetConfigs,
+) as TestnetChains[];
 export const environment = 'testnet3';
 
-// Chains that we want to run agents for.
-export const agentChainNames = [
-  ...chainNames,
+const validatorChainNames = [
+  ...supportedChainNames,
   'solanadevnet',
   'proteustestnet',
 ];
+
+const relayerChainNames = validatorChainNames;
+
+export type AgentRoles = typeof ALL_AGENT_ROLES;
+export type AgentChainNames = Map<ALL_AGENT_ROLES, string[]>;
+export const agentChainNames: AgentChainNames = new Map([
+  [Role.Validator, validatorChainNames],
+  [Role.Relayer, relayerChainNames],
+  [Role.Scraper, supportedChainNames],
+]);

--- a/typescript/infra/config/environments/testnet3/gas-oracle.ts
+++ b/typescript/infra/config/environments/testnet3/gas-oracle.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../src/config';
 import { TOKEN_EXCHANGE_RATE_DECIMALS } from '../../../src/config/gas-oracle';
 
-import { TestnetChains, chainNames } from './chains';
+import { TestnetChains, supportedChainNames } from './chains';
 
 // Overcharge by 30% to account for market making risk
 const TOKEN_EXCHANGE_RATE_MULTIPLIER = ethers.utils.parseUnits(
@@ -73,4 +73,8 @@ function getTokenExchangeRate(local: ChainName, remote: ChainName): BigNumber {
 }
 
 export const storageGasOracleConfig: AllStorageGasOracleConfigs =
-  getAllStorageGasOracleConfigs(chainNames, gasPrices, getTokenExchangeRate);
+  getAllStorageGasOracleConfigs(
+    supportedChainNames,
+    gasPrices,
+    getTokenExchangeRate,
+  );

--- a/typescript/infra/config/environments/testnet3/igp.ts
+++ b/typescript/infra/config/environments/testnet3/igp.ts
@@ -7,12 +7,12 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { exclude, objMap } from '@hyperlane-xyz/utils';
 
-import { TestnetChains, chainNames } from './chains';
+import { TestnetChains, supportedChainNames } from './chains';
 import { owners } from './owners';
 
 function getGasOracles(local: TestnetChains) {
   return Object.fromEntries(
-    exclude(local, chainNames).map((name) => [
+    exclude(local, supportedChainNames).map((name) => [
       name,
       GasOracleContractType.StorageGasOracle,
     ]),
@@ -28,7 +28,7 @@ export const igp: ChainMap<OverheadIgpConfig> = objMap(
       beneficiary: owner,
       gasOracleType: getGasOracles(chain),
       overhead: Object.fromEntries(
-        exclude(chain, chainNames).map((remote) => [
+        exclude(chain, supportedChainNames).map((remote) => [
           remote,
           multisigIsmVerificationCost(
             defaultMultisigIsmConfigs[remote].threshold,

--- a/typescript/infra/config/environments/testnet3/owners.ts
+++ b/typescript/infra/config/environments/testnet3/owners.ts
@@ -1,10 +1,10 @@
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 
-import { chainNames } from './chains';
+import { supportedChainNames } from './chains';
 
 const DEPLOYER_ADDRESS = '0xfaD1C94469700833717Fa8a3017278BC1cA8031C';
 
 export const owners: ChainMap<Address> = Object.fromEntries(
-  chainNames.map((chain) => [chain, DEPLOYER_ADDRESS]),
+  supportedChainNames.map((chain) => [chain, DEPLOYER_ADDRESS]),
 );

--- a/typescript/infra/scripts/agents/utils.ts
+++ b/typescript/infra/scripts/agents/utils.ts
@@ -32,7 +32,7 @@ export class AgentCli {
     for (const role of this.roles) {
       switch (role) {
         case Role.Validator:
-          for (const chain of this.agentConfig.contextChainNames) {
+          for (const chain of this.agentConfig.contextChainNames[role]) {
             if (chain !== 'solana' && chain !== 'nautilus') continue;
             const key = `${role}-${chain}`;
             managers[key] = new ValidatorHelmManager(this.agentConfig, chain);

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -24,7 +24,7 @@ import {
 import { DeployEnvironment } from '../../src/config';
 import { deployEnvToSdkEnv } from '../../src/config/environment';
 import { ContextAndRoles, ContextAndRolesMap } from '../../src/config/funding';
-import { Role } from '../../src/roles';
+import { AgentRole, Role } from '../../src/roles';
 import { submitMetrics } from '../../src/utils/metrics';
 import {
   assertContext,
@@ -403,7 +403,7 @@ class ContextFunder {
           key.context,
           key.environment,
         ).contextChainNames;
-        for (const chain of chains) {
+        for (const chain of chains[role as AgentRole]) {
           chainKeys[chain].push(key);
         }
       }

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -19,7 +19,7 @@ import {
   ScraperConfigHelper,
   ValidatorConfigHelper,
 } from '../config';
-import { ALL_AGENT_ROLES, Role } from '../roles';
+import { AgentRole, Role } from '../roles';
 import { fetchGCPSecret } from '../utils/gcloud';
 import {
   HelmCommand,
@@ -37,7 +37,7 @@ if (!fs.existsSync(HELM_CHART_PATH + 'Chart.yaml'))
   );
 
 export abstract class AgentHelmManager {
-  abstract readonly role: ALL_AGENT_ROLES;
+  abstract readonly role: AgentRole;
   abstract readonly helmReleaseName: string;
   readonly helmChartPath: string = HELM_CHART_PATH;
   protected abstract readonly config: AgentConfigHelper;
@@ -70,7 +70,7 @@ export abstract class AgentHelmManager {
       return;
     }
 
-    const values = helmifyValues(await this.helmValues(this.role));
+    const values = helmifyValues(await this.helmValues());
     if (action == HelmCommand.InstallOrUpgrade && !dryRun) {
       // Delete secrets to avoid them being stale
       const cmd = [
@@ -106,7 +106,7 @@ export abstract class AgentHelmManager {
     await execCmd(cmd, {}, false, true);
   }
 
-  async helmValues(role: ALL_AGENT_ROLES): Promise<HelmRootAgentValues> {
+  async helmValues(): Promise<HelmRootAgentValues> {
     const dockerImage = this.dockerImage();
     return {
       image: {
@@ -119,7 +119,7 @@ export abstract class AgentHelmManager {
         aws: !!this.config.aws,
         chains: this.config.environmentChainNames.map((name) => ({
           name,
-          disabled: !this.config.contextChainNames[role].includes(name),
+          disabled: !this.config.contextChainNames[this.role].includes(name),
           connection: { type: this.connectionType(name) },
         })),
       },
@@ -191,7 +191,7 @@ export class RelayerHelmManager extends OmniscientAgentHelmManager {
   }
 
   async helmValues(): Promise<HelmRootAgentValues> {
-    const values = await super.helmValues(Role.Relayer);
+    const values = await super.helmValues();
     values.hyperlane.relayer = {
       enabled: true,
       aws: this.config.requiresAwsCredentials,
@@ -222,7 +222,7 @@ export class ScraperHelmManager extends OmniscientAgentHelmManager {
   }
 
   async helmValues(): Promise<HelmRootAgentValues> {
-    const values = await super.helmValues(Role.Scraper);
+    const values = await super.helmValues();
     values.hyperlane.scraper = {
       enabled: true,
       config: await this.config.buildConfig(),
@@ -240,7 +240,7 @@ export class ValidatorHelmManager extends MultichainAgentHelmManager {
   constructor(config: RootAgentConfig, chainName: ChainName) {
     super(chainName);
     this.config = new ValidatorConfigHelper(config, chainName);
-    if (!this.config.contextChainNames[Role.Validator].includes(chainName))
+    if (!this.config.contextChainNames[this.role].includes(chainName))
       throw Error('Context does not support chain');
     if (!this.config.environmentChainNames.includes(chainName))
       throw Error('Environment does not support chain');
@@ -251,7 +251,7 @@ export class ValidatorHelmManager extends MultichainAgentHelmManager {
   }
 
   async helmValues(): Promise<HelmRootAgentValues> {
-    const helmValues = await super.helmValues(Role.Validator);
+    const helmValues = await super.helmValues();
     helmValues.hyperlane.validator = {
       enabled: true,
       configs: await this.config.buildConfig(),

--- a/typescript/infra/src/agents/key-utils.ts
+++ b/typescript/infra/src/agents/key-utils.ts
@@ -31,7 +31,7 @@ export function getRelayerCloudAgentKeys(
 
   const keys = [];
   keys.push(new AgentAwsKey(agentConfig, Role.Relayer));
-  const nonEthereumChains = agentConfig.contextChainNames.find(
+  const nonEthereumChains = agentConfig.contextChainNames[Role.Relayer].find(
     (chainName) => chainMetadata[chainName].protocol !== ProtocolType.Ethereum,
   );
   // If there are any non-ethereum chains, we also want hex keys.
@@ -71,7 +71,7 @@ export function getValidatorCloudAgentKeys(
   // For each chainName, create validatorCount keys
   if (!agentConfig.validators) return [];
   const validators = agentConfig.validators;
-  return agentConfig.contextChainNames.flatMap((chainName) =>
+  return agentConfig.contextChainNames[Role.Validator].flatMap((chainName) =>
     validators.chains[chainName].validators.map((_, index) =>
       getCloudAgentKey(agentConfig, Role.Validator, chainName, index),
     ),

--- a/typescript/infra/src/agents/key-utils.ts
+++ b/typescript/infra/src/agents/key-utils.ts
@@ -71,11 +71,13 @@ export function getValidatorCloudAgentKeys(
   // For each chainName, create validatorCount keys
   if (!agentConfig.validators) return [];
   const validators = agentConfig.validators;
-  return agentConfig.contextChainNames[Role.Validator].flatMap((chainName) =>
-    validators.chains[chainName].validators.map((_, index) =>
-      getCloudAgentKey(agentConfig, Role.Validator, chainName, index),
-    ),
-  );
+  return agentConfig.contextChainNames[Role.Validator]
+    .filter((chainName) => !!validators.chains[chainName])
+    .flatMap((chainName) =>
+      validators.chains[chainName].validators.map((_, index) =>
+        getCloudAgentKey(agentConfig, Role.Validator, chainName, index),
+      ),
+    );
 }
 
 export function getAllCloudAgentKeys(

--- a/typescript/infra/src/config/agent/agent.ts
+++ b/typescript/infra/src/config/agent/agent.ts
@@ -6,8 +6,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 
 import { Contexts } from '../../../config/contexts';
-import { AgentChainNames } from '../../../config/environments/testnet3/chains';
-import { Role } from '../../roles';
+import { AgentChainNames, Role } from '../../roles';
 import { DeployEnvironment } from '../environment';
 import { HelmImageValues } from '../infrastructure';
 
@@ -128,7 +127,7 @@ export class RootAgentConfigHelper implements AgentContextConfig {
   runEnv: DeployEnvironment;
   aws?: AwsConfig;
   rolesWithKeys: Role[];
-  contextChainNames: ChainName[];
+  contextChainNames: AgentChainNames;
   environmentChainNames: ChainName[];
 
   constructor(root: RootAgentConfig) {
@@ -188,3 +187,7 @@ export abstract class AgentConfigHelper<R = unknown>
     return this.docker;
   }
 }
+
+export const allAgentChainNames = (agentChainNames: AgentChainNames) => [
+  ...new Set(Object.values(agentChainNames).reduce((a, b) => a.concat(b), [])),
+];

--- a/typescript/infra/src/config/agent/agent.ts
+++ b/typescript/infra/src/config/agent/agent.ts
@@ -6,6 +6,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 
 import { Contexts } from '../../../config/contexts';
+import { AgentChainNames } from '../../../config/environments/testnet3/chains';
 import { Role } from '../../roles';
 import { DeployEnvironment } from '../environment';
 import { HelmImageValues } from '../infrastructure';
@@ -73,7 +74,7 @@ export interface AgentContextConfig extends AgentEnvConfig {
   // Roles to manage keys for
   rolesWithKeys: Role[];
   // Names of chains this context cares about (subset of environmentChainNames)
-  contextChainNames: ChainName[];
+  contextChainNames: AgentChainNames;
 }
 
 // incomplete common agent configuration for a role

--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -102,7 +102,7 @@ export class RelayerConfigHelper extends AgentConfigHelper<RelayerConfig> {
     const baseConfig = this.#relayerConfig!;
 
     const relayerConfig: RelayerConfig = {
-      relayChains: this.contextChainNames.join(','),
+      relayChains: this.contextChainNames[Role.Relayer].join(','),
       gasPaymentEnforcement: JSON.stringify(baseConfig.gasPaymentEnforcement),
     };
 
@@ -136,7 +136,7 @@ export class RelayerConfigHelper extends AgentConfigHelper<RelayerConfig> {
       await awsUser.createIfNotExists();
       const awsKey = (await awsUser.createKeyIfNotExists(this)).keyConfig;
       return Object.fromEntries(
-        this.contextChainNames.map((name) => {
+        this.contextChainNames[Role.Relayer].map((name) => {
           const chain = chainMetadata[name];
           // Sealevel chains always use hex keys
           if (chain?.protocol == ProtocolType.Sealevel) {
@@ -148,7 +148,10 @@ export class RelayerConfigHelper extends AgentConfigHelper<RelayerConfig> {
       );
     } else {
       return Object.fromEntries(
-        this.contextChainNames.map((name) => [name, { type: KeyType.Hex }]),
+        this.contextChainNames[Role.Relayer].map((name) => [
+          name,
+          { type: KeyType.Hex },
+        ]),
       );
     }
   }

--- a/typescript/infra/src/roles.ts
+++ b/typescript/infra/src/roles.ts
@@ -15,4 +15,10 @@ export const ALL_KEY_ROLES = [
   Role.Kathy,
 ];
 
-export const ALL_AGENT_ROLES = [Role.Validator, Role.Relayer, Role.Scraper];
+// Use a const assertion to tell the compiler to retain the literal array item types.
+export const ALL_AGENT_ROLES = [
+  Role.Validator,
+  Role.Relayer,
+  Role.Scraper,
+] as const;
+export type ALL_AGENT_ROLES = typeof ALL_AGENT_ROLES[number];

--- a/typescript/infra/src/roles.ts
+++ b/typescript/infra/src/roles.ts
@@ -22,3 +22,4 @@ export const ALL_AGENT_ROLES = [
   Role.Scraper,
 ] as const;
 export type ALL_AGENT_ROLES = typeof ALL_AGENT_ROLES[number];
+export type AgentChainNames = Record<ALL_AGENT_ROLES, string[]>;

--- a/typescript/infra/src/roles.ts
+++ b/typescript/infra/src/roles.ts
@@ -21,5 +21,5 @@ export const ALL_AGENT_ROLES = [
   Role.Relayer,
   Role.Scraper,
 ] as const;
-export type ALL_AGENT_ROLES = typeof ALL_AGENT_ROLES[number];
-export type AgentChainNames = Record<ALL_AGENT_ROLES, string[]>;
+export type AgentRole = typeof ALL_AGENT_ROLES[number];
+export type AgentChainNames = Record<AgentRole, string[]>;

--- a/typescript/sdk/src/consts/chains.ts
+++ b/typescript/sdk/src/consts/chains.ts
@@ -3,7 +3,6 @@
  * Must be string type to be used with Object.keys
  */
 export enum Chains {
-  solana = 'solana',
   alfajores = 'alfajores',
   arbitrum = 'arbitrum',
   arbitrumgoerli = 'arbitrumgoerli',
@@ -27,6 +26,7 @@ export enum Chains {
   test3 = 'test3',
   solanadevnet = 'solanadevnet',
   proteustestnet = 'proteustestnet',
+  solana = 'solana',
   nautilus = 'nautilus',
 }
 

--- a/typescript/sdk/src/consts/chains.ts
+++ b/typescript/sdk/src/consts/chains.ts
@@ -3,6 +3,7 @@
  * Must be string type to be used with Object.keys
  */
 export enum Chains {
+  solana = 'solana',
   alfajores = 'alfajores',
   arbitrum = 'arbitrum',
   arbitrumgoerli = 'arbitrumgoerli',
@@ -26,7 +27,6 @@ export enum Chains {
   test3 = 'test3',
   solanadevnet = 'solanadevnet',
   proteustestnet = 'proteustestnet',
-  solana = 'solana',
   nautilus = 'nautilus',
 }
 


### PR DESCRIPTION
### Description

In addition to the context, also configure the **chains** that an agent is deployable to.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/2664

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing
Dry-ran the script for the three agents. Output for the validator looks wrong though:
```
% npx ts-node typescript/infra/scripts/agents/deploy-agents.ts -e mainnet2 -r validator --dry-run
undefined
```

