### PR TITLE
Solana and Nautilus RC validators

### DIFF
--- a/typescript/infra/config/environments/mainnet2/validators.ts
+++ b/typescript/infra/config/environments/mainnet2/validators.ts
@@ -138,7 +138,9 @@ export const validatorChainConfig = (
             '0x28aa072634dd41d19471640237852e807bd9901f',
             '0x8a93ba04f4e30064660670cb581d9aa10df78929',
           ],
-          [Contexts.ReleaseCandidate]: [],
+          [Contexts.ReleaseCandidate]: [
+            '0x8cc7dbfb5de339e4133f3af059c927ec383ace38',
+          ],
         },
         'solana',
       ),
@@ -153,7 +155,9 @@ export const validatorChainConfig = (
             '0x12b583ce1623b7de3fc727ccccda24dcab1fe022',
             '0xc8b996a421ff1e203070c709c1af93944c049cc0',
           ],
-          [Contexts.ReleaseCandidate]: [],
+          [Contexts.ReleaseCandidate]: [
+            '0xdaf2e5ddaf2532753dc78bb6fbb0a10204c888c1',
+          ],
         },
         'nautilus',
       ),

--- a/typescript/infra/config/environments/testnet3/validators.ts
+++ b/typescript/infra/config/environments/testnet3/validators.ts
@@ -192,7 +192,9 @@ export const validatorChainConfig = (
             '0x72840388d5ab57323bc4f6e6d3ddedfd5cc911f0',
             '0xd4b2a50c53fc6614bb3cd3198e0fdc03f5da973f',
           ],
-          [Contexts.ReleaseCandidate]: [],
+          [Contexts.ReleaseCandidate]: [
+            '0xc2ccc4eab0e8d441235d661e39341ae16c3bf8cd',
+          ],
         },
         'proteustestnet',
       ),
@@ -207,7 +209,9 @@ export const validatorChainConfig = (
             '0x9c20a149dfa09ea9f77f5a7ca09ed44f9c025133',
             '0x967c5ecdf2625ae86580bd203b630abaaf85cd62',
           ],
-          [Contexts.ReleaseCandidate]: [],
+          [Contexts.ReleaseCandidate]: [
+            '0x21b9eff4d1a6d3122596c7fb80315bf094b6e5c2',
+          ],
         },
         'solanadevnet',
       ),


### PR DESCRIPTION
### Description

Adds addresses of the rc validator keys for solana, nautilus and their testnet counterparts

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
