### PR TITLE
WIP: rocksdb migrations

### DIFF
--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -6,6 +6,7 @@ use std::{
 
 use async_trait::async_trait;
 use eyre::Result;
+use hyperlane_base::migrations::migrate;
 use hyperlane_base::{MessageContractSync, WatermarkContractSync};
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::{
@@ -235,6 +236,7 @@ impl BaseAgent for Relayer {
 
     #[allow(clippy::async_yields_async)]
     async fn run(self) -> Instrumented<JoinHandle<Result<()>>> {
+        migrate(&self.dbs).unwrap();
         let mut tasks = vec![];
 
         // send channels by destination chain

--- a/rust/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -21,16 +21,16 @@ use super::{
 // these keys MUST not be given multiple uses in case multiple agents are
 // started with the same database and domain.
 
-const MESSAGE_ID: &str = "message_id_";
-const MESSAGE_DISPATCHED_BLOCK_NUMBER: &str = "message_dispatched_block_number_";
-const MESSAGE: &str = "message_";
-const NONCE_PROCESSED: &str = "nonce_processed_";
-const GAS_PAYMENT_FOR_MESSAGE_ID: &str = "gas_payment_for_message_id_v2_";
-const GAS_PAYMENT_META_PROCESSED: &str = "gas_payment_meta_processed_v3_";
-const GAS_EXPENDITURE_FOR_MESSAGE_ID: &str = "gas_expenditure_for_message_id_v2_";
-const PENDING_MESSAGE_RETRY_COUNT_FOR_MESSAGE_ID: &str =
+pub const MESSAGE_ID: &str = "message_id_";
+pub const MESSAGE_DISPATCHED_BLOCK_NUMBER: &str = "message_dispatched_block_number_";
+pub const MESSAGE: &str = "message_";
+pub const NONCE_PROCESSED: &str = "nonce_processed_";
+pub const GAS_PAYMENT_FOR_MESSAGE_ID: &str = "gas_payment_for_message_id_v2_";
+pub const GAS_PAYMENT_META_PROCESSED: &str = "gas_payment_meta_processed_v3_";
+pub const GAS_EXPENDITURE_FOR_MESSAGE_ID: &str = "gas_expenditure_for_message_id_v2_";
+pub const PENDING_MESSAGE_RETRY_COUNT_FOR_MESSAGE_ID: &str =
     "pending_message_retry_count_for_message_id_";
-const LATEST_INDEXED_GAS_PAYMENT_BLOCK: &str = "latest_indexed_gas_payment_block";
+pub const LATEST_INDEXED_GAS_PAYMENT_BLOCK: &str = "latest_indexed_gas_payment_block";
 
 type DbResult<T> = std::result::Result<T, DbError>;
 

--- a/rust/hyperlane-base/src/db/rocks/iterator.rs
+++ b/rust/hyperlane-base/src/db/rocks/iterator.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use derive_new::new;
 use rocksdb::DBIterator;
 
 use hyperlane_core::{Decode, Encode};
@@ -23,6 +24,28 @@ where
             let (k, v) = r.expect("Database error when iterating prefixed keys");
             if k.strip_prefix(prefix).is_some() {
                 Some(V::read_from(&mut &v[..]).expect("!corrupt"))
+            } else {
+                None
+            }
+        })
+    }
+}
+
+#[derive(new)]
+pub struct RawPrefixIterator<'a> {
+    iter: DBIterator<'a>,
+    prefix: &'a [u8],
+}
+
+impl<'a> Iterator for RawPrefixIterator<'a> {
+    type Item = (Vec<u8>, Vec<u8>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let prefix = self.prefix;
+        self.iter.find_map(|r| {
+            let (k, v) = r.expect("Database error when iterating prefixed keys");
+            if k.strip_prefix(prefix).is_some() {
+                Some((k.to_vec(), v.to_vec()))
             } else {
                 None
             }

--- a/rust/hyperlane-base/src/db/rocks/typed_db.rs
+++ b/rust/hyperlane-base/src/db/rocks/typed_db.rs
@@ -1,3 +1,4 @@
+use core::fmt::Debug;
 use hyperlane_core::{Decode, Encode, HyperlaneDomain};
 
 use crate::db::{DbError, DB};
@@ -57,6 +58,7 @@ impl TypedDB {
         let prefixed_key = self.prefixed_key(prefix.as_ref(), key.as_ref());
         println!("Storing prefixed key: {:?}", prefixed_key);
         println!("prefix as bytes: {:?}", prefix.as_ref());
+        println!("key as bytes: {:?}", key.as_ref());
         println!(
             "prefix: {}",
             String::from_utf8(prefix.as_ref().to_vec()).unwrap()
@@ -78,12 +80,14 @@ impl TypedDB {
     }
 
     /// Store encodable kv pair
-    pub fn store_keyed_encodable<K: Encode, V: Encode>(
+    pub fn store_keyed_encodable<K: Encode + Debug, V: Encode>(
         &self,
         prefix: impl AsRef<[u8]>,
         key: &K,
         value: &V,
     ) -> Result<()> {
+        println!("key: {:?}", key);
+        println!("key as bytes: {:?}", key.to_vec());
         self.store_encodable(prefix, key.to_vec(), value)
     }
 

--- a/rust/hyperlane-base/src/lib.rs
+++ b/rust/hyperlane-base/src/lib.rs
@@ -27,5 +27,7 @@ pub use types::*;
 /// Hyperlane database utils
 pub mod db;
 
+pub mod migrations;
+
 #[cfg(feature = "oneline-eyre")]
 pub mod oneline_eyre;

--- a/rust/hyperlane-base/src/migrations/m1.rs
+++ b/rust/hyperlane-base/src/migrations/m1.rs
@@ -4,16 +4,17 @@ use std::{
     io::Write,
 };
 
-use hyperlane_core::{Decode, Encode, HyperlaneProtocolError, H512};
+use derive_new::new;
+use hyperlane_core::{Decode, Encode, HyperlaneDomain, HyperlaneProtocolError, H512};
 
 use eyre::Result;
 
-use crate::db::GAS_PAYMENT_META_PROCESSED;
+use crate::db::{domain_name_to_prefix, GAS_PAYMENT_META_PROCESSED};
 
 use super::Migration;
 
 /// Uniquely identifying metadata for an InterchainGasPayment
-#[derive(Debug)]
+#[derive(Debug, new)]
 pub struct OldInterchainGasPaymentMeta {
     /// The transaction id/hash in which the GasPayment log was emitted
     pub transaction_id: H512,
@@ -22,7 +23,7 @@ pub struct OldInterchainGasPaymentMeta {
 }
 
 /// Uniquely identifying metadata for an InterchainGasPayment
-#[derive(Debug)]
+#[derive(Debug, new)]
 pub struct NewInterchainGasPaymentMeta {
     /// The transaction id/hash in which the GasPayment log was emitted
     pub transaction_id: H512,
@@ -34,6 +35,33 @@ pub struct NewInterchainGasPaymentMeta {
     pub schema_version: u32,
 }
 
+// impl Decode for OldInterchainGasPaymentMeta {
+//     fn read_from<R>(reader: &mut R) -> Result<Self, HyperlaneProtocolError>
+//     where
+//         R: Read,
+//         Self: Sized,
+//     {
+//         Ok(Self {
+//             transaction_id: H512::read_from(reader)?,
+//             log_index: u64::read_from(reader)?,
+//         })
+//     }
+// }
+
+impl Encode for OldInterchainGasPaymentMeta {
+    fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
+    where
+        W: Write,
+    {
+        let mut written = 0;
+        written += self.transaction_id.write_to(writer)?;
+        written += self.log_index.write_to(writer)?;
+        // written += self.block_number.write_to(writer)?;
+        // written += self.schema_version.write_to(writer)?;
+        Ok(written)
+    }
+}
+
 impl Decode for OldInterchainGasPaymentMeta {
     fn read_from<R>(reader: &mut R) -> Result<Self, HyperlaneProtocolError>
     where
@@ -43,6 +71,8 @@ impl Decode for OldInterchainGasPaymentMeta {
         Ok(Self {
             transaction_id: H512::read_from(reader)?,
             log_index: u64::read_from(reader)?,
+            // block_number: u64::read_from(reader)?,
+            // schema_version: u32::read_from(reader)?,
         })
     }
 }
@@ -79,13 +109,30 @@ impl Decode for NewInterchainGasPaymentMeta {
 pub struct InterchainGasPaymentMetaMigrationV0;
 
 impl Migration for InterchainGasPaymentMetaMigrationV0 {
-    fn migrate(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(Vec<u8>, Vec<u8>)> {
-        if let Ok(x) = NewInterchainGasPaymentMeta::read_from(&mut key.as_slice()) {
-            println!("Already migrated: {:?}", x);
-            // Already migrated
-            return Err(eyre::eyre!("Already migrated"));
-        }
-        let old_key = OldInterchainGasPaymentMeta::read_from(&mut key.as_slice())?;
+    fn migrate(
+        &self,
+        key: Vec<u8>,
+        value: Vec<u8>,
+        domain: &HyperlaneDomain,
+    ) -> Result<(Vec<u8>, Vec<u8>)> {
+        // Need to include the prefix, so it is stripped from the key
+        // if let Ok(x) = NewInterchainGasPaymentMeta::read_from(&mut key.as_slice()) {
+        //     println!("Already migrated key: {:?}, new value: {:?}", key, x);
+        //     // Already migrated
+        //     return Err(eyre::eyre!("Already migrated"));
+        // }
+
+        let domain_as_prefix = domain_name_to_prefix(domain);
+        let domain_as_ref: &[u8] = domain_as_prefix.as_ref();
+        println!("domain prefix_as_ref: {:?}", domain_as_ref);
+        let key_without_domain_prefix = key.strip_prefix(domain_as_ref).unwrap();
+        let prefix = self.prefix_key();
+        let prefix_as_ref: &[u8] = prefix.as_ref();
+        println!("prefix_as_ref: {:?}", prefix_as_ref);
+        let mut key_without_prefix = key_without_domain_prefix
+            .strip_prefix(prefix_as_ref)
+            .unwrap();
+        let old_key = OldInterchainGasPaymentMeta::read_from(&mut key_without_prefix)?;
         println!("Successfully decoded old key: {:?}", old_key);
 
         // No need to check if the old key matches the migration version, since the old type has no schema version
@@ -114,13 +161,72 @@ impl Display for InterchainGasPaymentMetaMigrationV0 {
 
 #[cfg(test)]
 mod test {
-    // TODO: add test that stores the kv pair in the old format in a db,
-    // runs the migration, checks that the new format is stored in the db,
-    // checks that the old format is not stored in the db, and runs the migration
-    // again to check that it fails
+    /*
+    TODO:
+    - encodes the old format to make sure decoding the new one fails
+    - add test that stores the kv pair in the old format in a db
+    - runs the migration
+    - checks that the new format is stored in the db
+    - checks that the old format is not stored in the db
+    - runs the migration again to check that it fails
+    */
 
     // Old format data:
-    // Migrating key: [102, 117, 106, 105, 95, 103, 97, 115, 95, 112, 97, 121, 109, 101, 110, 116, 95, 109, 101, 116, 97, 95, 112, 114, 111, 99, 101, 115, 115, 101, 100, 95, 118, 51, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 238, 187, 137, 58, 100, 37, 77, 117, 170, 199, 230, 149, 154, 141, 234, 63, 17, 195, 251, 21, 84, 136, 36, 116, 69, 27, 117, 32, 9, 112, 123, 8, 0, 0, 0, 0, 0, 0, 0, 7], value: [1]
-    // Migrating key: [102, 117, 106, 105, 95, 103, 97, 115, 95, 112, 97, 121, 109, 101, 110, 116, 95, 109, 101, 116, 97, 95, 112, 114, 111, 99, 101, 115, 115, 101, 100, 95, 118, 51, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 238, 197, 238, 148, 150, 23, 200, 41, 17, 42, 250, 54, 69, 70, 62, 97, 126, 82, 120, 90, 107, 98, 57, 188, 90, 173, 87, 1, 162, 140, 174, 238, 0, 0, 0, 0, 0, 0, 0, 8], value: [1]
-    // Migrating key: [102, 117, 106, 105, 95, 103, 97, 115, 95, 112, 97, 121, 109, 101, 110, 116, 95, 109, 101, 116, 97, 95, 112, 114, 111, 99, 101, 115, 115, 101, 100, 95, 118, 51, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 238, 205, 72, 88, 225, 26, 234, 175, 9, 196, 43, 158, 49, 48, 35, 200, 95, 197, 53, 253, 242, 181, 244, 40, 153, 83, 65, 38, 157, 109, 211, 124, 0, 0, 0, 0, 0, 0, 0, 2], value: [1]
+
+    // Migrating key: [102, 117, 106, 105, 95, 103, 97, 115, 95, 112, 97, 121, 109, 101, 110, 116, 95, 109, 101, 116, 97, 95, 112, 114, 111, 99, 101, 115, 115, 101, 100, 95, 118, 51, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 47, 115, 0, 237, 23, 87, 79, 178, 145, 223, 166, 244, 165, 251, 54, 88, 185, 17, 32, 123, 172, 115, 161, 225, 45, 84, 236, 221, 11, 229, 100, 0, 0, 0, 0, 0, 0, 0, 6], value: [1],
+    // Prefixed key:  [102, 117, 106, 105, 95, 103, 97, 115, 95, 112, 97, 121, 109, 101, 110, 116, 95, 102, 111, 114, 95, 109, 101, 115, 115, 97, 103, 101, 95, 105, 100, 95, 118, 50, 95, 122, 154, 96, 216, 124, 2, 112, 19, 66, 223, 104, 134, 10, 143, 93, 15, 134, 204, 21, 147, 23, 127, 120, 16, 247, 96, 211, 130, 89, 5, 190, 63]
+    // new key:       [102, 117, 106, 105, 95, 103, 97, 115, 95, 112, 97, 121, 109, 101, 110, 116, 95, 109, 101, 116, 97, 95, 112, 114, 111, 99, 101, 115, 115, 101, 100, 95, 118, 51, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 47, 115, 0, 237, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], new value: [1]
+    // Successfully decoded old key: OldInterchainGasPaymentMeta { transaction_id: 0x66756a695f6761735f7061796d656e745f6d6574615f70726f6365737365645f76335f0000000000000000000000000000000000000000000000000000000000, log_index: 906097332 }
+
+    // KV #2
+    // Migrating key: [102, 117, 106, 105, 95, 103, 97, 115, 95, 112, 97, 121, 109, 101, 110, 116, 95, 109, 101, 116, 97, 95, 112, 114, 111, 99, 101, 115, 115, 101, 100, 95, 118, 51, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 54, 1, 242, 180, 40, 39, 197, 126, 184, 139, 219, 52, 161, 186, 7, 118, 219, 57, 174, 45, 199, 184, 143, 215, 27, 245, 222, 196, 119, 46, 205, 0, 0, 0, 0, 0, 0, 0, 2], value: [1],
+    // key: InterchainGasPaymentMeta { transaction_id: 0x0000000000000000000000000000000000000000000000000000000000000000003601f2b42827c57eb88bdb34a1ba0776db39ae2dc7b88fd71bf5dec4772ecd, log_index: 2 }
+    // new key:       [102, 117, 106, 105, 95, 103, 97, 115, 95, 112, 97, 121, 109, 101, 110, 116, 95, 109, 101, 116, 97, 95, 112, 114, 111, 99, 101, 115, 115, 101, 100, 95, 118, 51, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 54, 1, 242, 180, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], new value: [1]
+    // Successfully decoded old key: OldInterchainGasPaymentMeta { transaction_id: 0x66756a695f6761735f7061796d656e745f6d6574615f70726f6365737365645f76335f0000000000000000000000000000000000000000000000000000000000, log_index: 2376419445 }
+
+    // Migrating key: [102, 117, 106, 105, 95, 103, 97, 115, 95, 112, 97, 121, 109, 101, 110, 116, 95, 109, 101, 116, 97, 95, 112, 114, 111, 99, 101, 115, 115, 101, 100, 95, 118, 51, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 141, 165, 72, 117, 188, 124, 122, 121, 247, 236, 39, 70, 198, 231, 221, 131, 62, 174, 67, 111, 217, 125, 64, 21, 20, 149, 78, 11, 249, 252, 3, 0, 0, 0, 0, 0, 0, 0, 2], value: [1],
+    // new key:       [102, 117, 106, 105, 95, 103, 97, 115, 95, 112, 97, 121, 109, 101, 110, 116, 95, 109, 101, 116, 97, 95, 112, 114, 111, 99, 101, 115, 115, 101, 100, 95, 118, 51, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 141, 165, 72, 117, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], new value: [1]
+    // Successfully decoded old key: OldInterchainGasPaymentMeta { transaction_id: 0x66756a695f6761735f7061796d656e745f6d6574615f70726f6365737365645f76335f0000000000000000000000000000000000000000000000000000000000, log_index: 2563575919 }
+
+    use std::str::FromStr;
+
+    use hyperlane_core::{Decode, Encode, HyperlaneDomain};
+
+    use crate::migrations::m1::{InterchainGasPaymentMetaMigrationV0, NewInterchainGasPaymentMeta};
+
+    use super::{Migration, OldInterchainGasPaymentMeta};
+
+    #[test]
+    fn it_cannot_decode_new_type_from_old_type() {
+        let old_value = OldInterchainGasPaymentMeta::new(hyperlane_core::H512::from_str("0x0000000000000000000000000000000000000000000000000000000000000000003601f2b42827c57eb88bdb34a1ba0776db39ae2dc7b88fd71bf5dec4772ecd").unwrap(), 2);
+        let encoded = old_value.to_vec();
+        let old_encoded_value = vec![
+            102, 117, 106, 105, 95, 103, 97, 115, 95, 112, 97, 121, 109, 101, 110, 116, 95, 109,
+            101, 116, 97, 95, 112, 114, 111, 99, 101, 115, 115, 101, 100, 95, 118, 51, 95, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 54, 1, 242, 180, 40, 39, 197, 126, 184, 139, 219, 52, 161, 186, 7, 118, 219, 57,
+            174, 45, 199, 184, 143, 215, 27, 245, 222, 196, 119, 46, 205, 0, 0, 0, 0, 0, 0, 0, 2,
+        ];
+
+        let prefix = InterchainGasPaymentMetaMigrationV0.prefix_key();
+        let prefix_as_ref: &[u8] = prefix.as_ref();
+        println!("prefix_as_ref: {:?}", prefix_as_ref);
+
+        let new_value =
+            NewInterchainGasPaymentMeta::read_from(&mut old_encoded_value.as_slice()).unwrap();
+        println!(
+            "Erroneously decoded new value from old encoding: {:?}",
+            new_value
+        );
+        println!("encoded version: {:?}", encoded);
+        let (migrated_key, migrated_value) = InterchainGasPaymentMetaMigrationV0
+            .migrate(
+                encoded,
+                vec![1],
+                &HyperlaneDomain::Known(hyperlane_core::KnownHyperlaneDomain::Fuji),
+            )
+            .unwrap();
+        let new_value =
+            NewInterchainGasPaymentMeta::read_from(&mut migrated_key.as_slice()).unwrap();
+    }
 }

--- a/rust/hyperlane-base/src/migrations/m1.rs
+++ b/rust/hyperlane-base/src/migrations/m1.rs
@@ -56,7 +56,23 @@ impl Encode for NewInterchainGasPaymentMeta {
         written += self.transaction_id.write_to(writer)?;
         written += self.log_index.write_to(writer)?;
         written += self.block_number.write_to(writer)?;
+        written += self.schema_version.write_to(writer)?;
         Ok(written)
+    }
+}
+
+impl Decode for NewInterchainGasPaymentMeta {
+    fn read_from<R>(reader: &mut R) -> Result<Self, HyperlaneProtocolError>
+    where
+        R: Read,
+        Self: Sized,
+    {
+        Ok(Self {
+            transaction_id: H512::read_from(reader)?,
+            log_index: u64::read_from(reader)?,
+            block_number: u64::read_from(reader)?,
+            schema_version: u32::read_from(reader)?,
+        })
     }
 }
 
@@ -64,19 +80,25 @@ pub struct InterchainGasPaymentMetaMigrationV0;
 
 impl Migration for InterchainGasPaymentMetaMigrationV0 {
     fn migrate(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(Vec<u8>, Vec<u8>)> {
-        let old_value = OldInterchainGasPaymentMeta::read_from(&mut value.as_slice())?;
+        if let Ok(x) = NewInterchainGasPaymentMeta::read_from(&mut key.as_slice()) {
+            println!("Already migrated: {:?}", x);
+            // Already migrated
+            return Err(eyre::eyre!("Already migrated"));
+        }
+        let old_key = OldInterchainGasPaymentMeta::read_from(&mut key.as_slice())?;
+        println!("Successfully decoded old key: {:?}", old_key);
 
-        // No need to check if the old value matches the migration version, since the old type has no schema version
+        // No need to check if the old key matches the migration version, since the old type has no schema version
 
-        let new_value = NewInterchainGasPaymentMeta {
-            transaction_id: old_value.transaction_id,
-            log_index: old_value.log_index,
+        let new_key = NewInterchainGasPaymentMeta {
+            transaction_id: old_key.transaction_id,
+            log_index: old_key.log_index,
             // Set the block number of previous entry to zero
             block_number: 0,
             schema_version: 1,
         };
-        let encoded_new_value = new_value.to_vec();
-        Ok((key, encoded_new_value))
+        let encoded_new_key = new_key.to_vec();
+        Ok((encoded_new_key, value))
     }
 
     fn prefix_key(&self) -> String {
@@ -88,4 +110,17 @@ impl Display for InterchainGasPaymentMetaMigrationV0 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "InterchainGasPaymentMetaMigrationV0")
     }
+}
+
+#[cfg(test)]
+mod test {
+    // TODO: add test that stores the kv pair in the old format in a db,
+    // runs the migration, checks that the new format is stored in the db,
+    // checks that the old format is not stored in the db, and runs the migration
+    // again to check that it fails
+
+    // Old format data:
+    // Migrating key: [102, 117, 106, 105, 95, 103, 97, 115, 95, 112, 97, 121, 109, 101, 110, 116, 95, 109, 101, 116, 97, 95, 112, 114, 111, 99, 101, 115, 115, 101, 100, 95, 118, 51, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 238, 187, 137, 58, 100, 37, 77, 117, 170, 199, 230, 149, 154, 141, 234, 63, 17, 195, 251, 21, 84, 136, 36, 116, 69, 27, 117, 32, 9, 112, 123, 8, 0, 0, 0, 0, 0, 0, 0, 7], value: [1]
+    // Migrating key: [102, 117, 106, 105, 95, 103, 97, 115, 95, 112, 97, 121, 109, 101, 110, 116, 95, 109, 101, 116, 97, 95, 112, 114, 111, 99, 101, 115, 115, 101, 100, 95, 118, 51, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 238, 197, 238, 148, 150, 23, 200, 41, 17, 42, 250, 54, 69, 70, 62, 97, 126, 82, 120, 90, 107, 98, 57, 188, 90, 173, 87, 1, 162, 140, 174, 238, 0, 0, 0, 0, 0, 0, 0, 8], value: [1]
+    // Migrating key: [102, 117, 106, 105, 95, 103, 97, 115, 95, 112, 97, 121, 109, 101, 110, 116, 95, 109, 101, 116, 97, 95, 112, 114, 111, 99, 101, 115, 115, 101, 100, 95, 118, 51, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 238, 205, 72, 88, 225, 26, 234, 175, 9, 196, 43, 158, 49, 48, 35, 200, 95, 197, 53, 253, 242, 181, 244, 40, 153, 83, 65, 38, 157, 109, 211, 124, 0, 0, 0, 0, 0, 0, 0, 2], value: [1]
 }

--- a/rust/hyperlane-base/src/migrations/m1.rs
+++ b/rust/hyperlane-base/src/migrations/m1.rs
@@ -1,0 +1,91 @@
+use std::{
+    fmt::{Display, Formatter},
+    io::Read,
+    io::Write,
+};
+
+use hyperlane_core::{Decode, Encode, HyperlaneProtocolError, H512};
+
+use eyre::Result;
+
+use crate::db::GAS_PAYMENT_META_PROCESSED;
+
+use super::Migration;
+
+/// Uniquely identifying metadata for an InterchainGasPayment
+#[derive(Debug)]
+pub struct OldInterchainGasPaymentMeta {
+    /// The transaction id/hash in which the GasPayment log was emitted
+    pub transaction_id: H512,
+    /// The index of the GasPayment log within the transaction's logs
+    pub log_index: u64,
+}
+
+/// Uniquely identifying metadata for an InterchainGasPayment
+#[derive(Debug)]
+pub struct NewInterchainGasPaymentMeta {
+    /// The transaction id/hash in which the GasPayment log was emitted
+    pub transaction_id: H512,
+    /// The index of the GasPayment log within the transaction's logs
+    pub log_index: u64,
+    /// The block number in which the GasPayment log was emitted
+    pub block_number: u64,
+    /// The storage schema version of this struct
+    pub schema_version: u32,
+}
+
+impl Decode for OldInterchainGasPaymentMeta {
+    fn read_from<R>(reader: &mut R) -> Result<Self, HyperlaneProtocolError>
+    where
+        R: Read,
+        Self: Sized,
+    {
+        Ok(Self {
+            transaction_id: H512::read_from(reader)?,
+            log_index: u64::read_from(reader)?,
+        })
+    }
+}
+
+impl Encode for NewInterchainGasPaymentMeta {
+    fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
+    where
+        W: Write,
+    {
+        let mut written = 0;
+        written += self.transaction_id.write_to(writer)?;
+        written += self.log_index.write_to(writer)?;
+        written += self.block_number.write_to(writer)?;
+        Ok(written)
+    }
+}
+
+pub struct InterchainGasPaymentMetaMigrationV0;
+
+impl Migration for InterchainGasPaymentMetaMigrationV0 {
+    fn migrate(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(Vec<u8>, Vec<u8>)> {
+        let old_value = OldInterchainGasPaymentMeta::read_from(&mut value.as_slice())?;
+
+        // No need to check if the old value matches the migration version, since the old type has no schema version
+
+        let new_value = NewInterchainGasPaymentMeta {
+            transaction_id: old_value.transaction_id,
+            log_index: old_value.log_index,
+            // Set the block number of previous entry to zero
+            block_number: 0,
+            schema_version: 1,
+        };
+        let encoded_new_value = new_value.to_vec();
+        Ok((key, encoded_new_value))
+    }
+
+    fn prefix_key(&self) -> String {
+        GAS_PAYMENT_META_PROCESSED.to_string()
+    }
+}
+
+impl Display for InterchainGasPaymentMetaMigrationV0 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "InterchainGasPaymentMetaMigrationV0")
+    }
+}

--- a/rust/hyperlane-base/src/migrations/mod.rs
+++ b/rust/hyperlane-base/src/migrations/mod.rs
@@ -6,11 +6,16 @@ use eyre::Result;
 use hyperlane_core::HyperlaneDomain;
 use rocksdb::WriteBatchWithTransaction;
 
-use crate::db::{iterator::RawPrefixIterator, HyperlaneRocksDB, TypedDB};
+use crate::db::{domain_name_to_prefix, iterator::RawPrefixIterator, HyperlaneRocksDB, TypedDB};
 
 pub trait Migration: Display {
     /// takes the old key and value and returns the new key and value, using raw formats
-    fn migrate(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(Vec<u8>, Vec<u8>)>;
+    fn migrate(
+        &self,
+        key: Vec<u8>,
+        value: Vec<u8>,
+        domain: &HyperlaneDomain,
+    ) -> Result<(Vec<u8>, Vec<u8>)>;
 
     fn prefix_key(&self) -> String;
 }
@@ -22,16 +27,20 @@ pub fn migrate(dbs: &HashMap<HyperlaneDomain, HyperlaneRocksDB>) -> Result<()> {
     for migration in migrations {
         println!("Running migration {}", migration.prefix_key());
         for (domain, db) in dbs {
-            println!("Migrating domain: {:?}", domain);
+            println!("Trying to migrate domain: {:?}", domain);
             let typed_db: &TypedDB = db.as_ref();
             let rocksdb = typed_db.as_ref();
             let raw_db_iterator = rocksdb.iterator();
             let prefix = db.prefixed_key(migration.prefix_key().as_ref(), &[]);
 
             let raw_iterator = RawPrefixIterator::new(raw_db_iterator, &prefix);
-            if let Some(updates) = batch_updates(&migration, raw_iterator) {
+            if let Some(updates) = batch_updates(&migration, raw_iterator, domain) {
+                let update_count = updates.len();
                 rocksdb.write(updates)?;
-                println!("Succesfully migrated domain: {:?}", domain);
+                println!(
+                    "Succesfully migrated {} records (including deletions) from domain: {:?}",
+                    update_count, domain
+                );
             }
         }
     }
@@ -41,26 +50,28 @@ pub fn migrate(dbs: &HashMap<HyperlaneDomain, HyperlaneRocksDB>) -> Result<()> {
 pub fn batch_updates<'a>(
     migration: &Box<dyn Migration>,
     raw_iterator: RawPrefixIterator<'a>,
+    domain: &HyperlaneDomain,
 ) -> Option<WriteBatchWithTransaction<false>> {
     let mut migration_updates = WriteBatchWithTransaction::<false>::default();
     for (k, v) in raw_iterator {
-        println!("Migrating key: {:?}, value: {:?}", k, v);
-        match migration.migrate(k.clone(), v) {
+        match migration.migrate(k.clone(), v.clone(), domain) {
             Ok((new_key, new_value)) => {
                 // In case the migration changes the key, we need to delete the old key
-                migration_updates.delete(k);
-                migration_updates.put(new_key, new_value);
+                migration_updates.delete(k.clone());
+                migration_updates.put(new_key.clone(), new_value.clone());
+                println!(
+                    "Migrating key: {:?}, value: {:?}, new key: {:?}, new value: {:?}",
+                    k, v, new_key, new_value
+                );
             }
             Err(e) => {
                 println!("Error migrating: {}", e);
-                return None;
             }
         }
-        // let Ok((new_key, new_value)) = migration.migrate(k, v)
-        //     else {
-        //         return None;
-        //     };
-        // migration_updates.put(new_key, new_value);
     }
-    Some(migration_updates)
+    if migration_updates.len() > 0 {
+        Some(migration_updates)
+    } else {
+        None
+    }
 }

--- a/rust/hyperlane-base/src/migrations/mod.rs
+++ b/rust/hyperlane-base/src/migrations/mod.rs
@@ -1,0 +1,64 @@
+mod m1;
+
+use std::{collections::HashMap, fmt::Display};
+
+use eyre::Result;
+use hyperlane_core::HyperlaneDomain;
+use rocksdb::WriteBatchWithTransaction;
+
+use crate::db::{iterator::RawPrefixIterator, HyperlaneRocksDB, TypedDB};
+
+pub trait Migration: Display {
+    /// takes the old key and value and returns the new key and value, using raw formats
+    fn migrate(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(Vec<u8>, Vec<u8>)>;
+
+    fn prefix_key(&self) -> String;
+}
+
+pub fn migrate(dbs: &HashMap<HyperlaneDomain, HyperlaneRocksDB>) -> Result<()> {
+    let migrations: Vec<Box<dyn Migration>> =
+        vec![Box::new(m1::InterchainGasPaymentMetaMigrationV0)];
+
+    for migration in migrations {
+        println!("Running migration {}", migration.prefix_key());
+        for (domain, db) in dbs {
+            println!("Migrating domain: {:?}", domain);
+            let typed_db: &TypedDB = db.as_ref();
+            let rocksdb = typed_db.as_ref();
+            let raw_db_iterator = rocksdb.iterator();
+            let prefix = db.prefixed_key(migration.prefix_key().as_ref(), &[]);
+
+            let raw_iterator = RawPrefixIterator::new(raw_db_iterator, &prefix);
+            if let Some(updates) = batch_updates(&migration, raw_iterator) {
+                rocksdb.write(updates)?;
+                println!("Succesfully migrated domain: {:?}", domain);
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn batch_updates<'a>(
+    migration: &Box<dyn Migration>,
+    raw_iterator: RawPrefixIterator<'a>,
+) -> Option<WriteBatchWithTransaction<false>> {
+    let mut migration_updates = WriteBatchWithTransaction::<false>::default();
+    for (k, v) in raw_iterator {
+        println!("Migrating key: {:?}, value: {:?}", k, v);
+        match migration.migrate(k, v) {
+            Ok((new_key, new_value)) => {
+                migration_updates.put(new_key, new_value);
+            }
+            Err(e) => {
+                println!("Error migrating: {}", e);
+                return None;
+            }
+        }
+        // let Ok((new_key, new_value)) = migration.migrate(k, v)
+        //     else {
+        //         return None;
+        //     };
+        // migration_updates.put(new_key, new_value);
+    }
+    Some(migration_updates)
+}

--- a/rust/hyperlane-base/src/migrations/mod.rs
+++ b/rust/hyperlane-base/src/migrations/mod.rs
@@ -45,8 +45,10 @@ pub fn batch_updates<'a>(
     let mut migration_updates = WriteBatchWithTransaction::<false>::default();
     for (k, v) in raw_iterator {
         println!("Migrating key: {:?}, value: {:?}", k, v);
-        match migration.migrate(k, v) {
+        match migration.migrate(k.clone(), v) {
             Ok((new_key, new_value)) => {
+                // In case the migration changes the key, we need to delete the old key
+                migration_updates.delete(k);
                 migration_updates.put(new_key, new_value);
             }
             Err(e) => {

--- a/rust/hyperlane-core/src/types/mod.rs
+++ b/rust/hyperlane-core/src/types/mod.rs
@@ -164,10 +164,10 @@ pub struct InterchainGasPaymentMeta {
     pub transaction_id: H512,
     /// The index of the GasPayment log within the transaction's logs
     pub log_index: u64,
-    /// The block number in which the GasPayment log was emitted
-    pub block_number: u64,
-    /// The storage schema version of this struct
-    pub schema_version: u32,
+    // /// The block number in which the GasPayment log was emitted
+    // pub block_number: u64,
+    // /// The storage schema version of this struct
+    // pub schema_version: u32,
 }
 
 impl Encode for InterchainGasPaymentMeta {
@@ -178,8 +178,8 @@ impl Encode for InterchainGasPaymentMeta {
         let mut written = 0;
         written += self.transaction_id.write_to(writer)?;
         written += self.log_index.write_to(writer)?;
-        written += self.block_number.write_to(writer)?;
-        written += self.schema_version.write_to(writer)?;
+        // written += self.block_number.write_to(writer)?;
+        // written += self.schema_version.write_to(writer)?;
         Ok(written)
     }
 }
@@ -193,8 +193,8 @@ impl Decode for InterchainGasPaymentMeta {
         Ok(Self {
             transaction_id: H512::read_from(reader)?,
             log_index: u64::read_from(reader)?,
-            block_number: u64::read_from(reader)?,
-            schema_version: u32::read_from(reader)?,
+            // block_number: u64::read_from(reader)?,
+            // schema_version: u32::read_from(reader)?,
         })
     }
 }
@@ -204,8 +204,8 @@ impl From<&LogMeta> for InterchainGasPaymentMeta {
         Self {
             transaction_id: meta.transaction_id,
             log_index: meta.log_index.as_u64(),
-            block_number: meta.block_number,
-            schema_version: 1,
+            // block_number: meta.block_number,
+            // schema_version: 1,
         }
     }
 }

--- a/rust/hyperlane-core/src/types/mod.rs
+++ b/rust/hyperlane-core/src/types/mod.rs
@@ -164,6 +164,10 @@ pub struct InterchainGasPaymentMeta {
     pub transaction_id: H512,
     /// The index of the GasPayment log within the transaction's logs
     pub log_index: u64,
+    /// The block number in which the GasPayment log was emitted
+    pub block_number: u64,
+    /// The storage schema version of this struct
+    pub schema_version: u32,
 }
 
 impl Encode for InterchainGasPaymentMeta {
@@ -174,6 +178,8 @@ impl Encode for InterchainGasPaymentMeta {
         let mut written = 0;
         written += self.transaction_id.write_to(writer)?;
         written += self.log_index.write_to(writer)?;
+        written += self.block_number.write_to(writer)?;
+        written += self.schema_version.write_to(writer)?;
         Ok(written)
     }
 }
@@ -187,6 +193,8 @@ impl Decode for InterchainGasPaymentMeta {
         Ok(Self {
             transaction_id: H512::read_from(reader)?,
             log_index: u64::read_from(reader)?,
+            block_number: u64::read_from(reader)?,
+            schema_version: u32::read_from(reader)?,
         })
     }
 }
@@ -196,6 +204,8 @@ impl From<&LogMeta> for InterchainGasPaymentMeta {
         Self {
             transaction_id: meta.transaction_id,
             log_index: meta.log_index.as_u64(),
+            block_number: meta.block_number,
+            schema_version: 1,
         }
     }
 }


### PR DESCRIPTION
### Description

Adds two new fields to `InterchainGasPaymentMeta` (`block_number` and `schema_version`), along with reusable migration logic for the rocksdb database that stores it.

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/2686


### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
