### PR TITLE
fix: Add data directory owned by user 1000

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -48,7 +48,9 @@ COPY --from=builder /release/* .
 
 RUN chmod 777 /app &&  \
     mkdir /usr/share/hyperlane/ && \
-    chmod 1000 /usr/share/hyperlane
+    chmod 1000 /usr/share/hyperlane && \
+    mkdir /data/ && \
+    chown -R 1000 /data/
 
 USER 1000
 ENTRYPOINT ["tini", "--"]


### PR DESCRIPTION
### Description

Process user used in Dockerfile can now read and write to any volume mounted under the `/data/` directory.

### Drive-by changes

N/A

### Related issues

Fixes: 2691

### Backward compatibility

Yes

### Testing

Manual

I've built the image locally and tested that we can mount any kind of docker volume under the `/data/` directory
