### PR TITLE
chore(sealevel igp indexing): reduce log verbosity

### DIFF
--- a/rust/chains/hyperlane-sealevel/src/interchain_gas.rs
+++ b/rust/chains/hyperlane-sealevel/src/interchain_gas.rs
@@ -264,7 +264,7 @@ impl Indexer<InterchainGasPayment> for SealevelInterchainGasPaymasterIndexer {
 
 #[async_trait]
 impl SequenceIndexer<InterchainGasPayment> for SealevelInterchainGasPaymasterIndexer {
-    #[instrument(level = "info", err, ret, skip(self))]
+    #[instrument(err, skip(self))]
     async fn sequence_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
         let program_data_account = self
             .rpc_client
@@ -283,11 +283,6 @@ impl SequenceIndexer<InterchainGasPayment> for SealevelInterchainGasPaymasterInd
             .try_into()
             .map_err(StrOrIntParseError::from)?;
         let tip = get_finalized_block_number(&self.rpc_client).await?;
-        info!(
-            ?payment_count,
-            ?tip,
-            "Fetched SealevelInterchainGasPaymasterIndexer sequence and tip"
-        );
         Ok((Some(payment_count), tip))
     }
 }

--- a/rust/hyperlane-base/src/contract_sync/eta_calculator.rs
+++ b/rust/hyperlane-base/src/contract_sync/eta_calculator.rs
@@ -24,6 +24,7 @@ pub(crate) struct SyncerEtaCalculator {
 
 impl SyncerEtaCalculator {
     /// Calculate the expected time to catch up to the tip of the blockchain.
+    #[instrument(err)]
     pub fn calculate(&mut self, current_block: u32, current_tip: u32) -> Duration {
         let now = Instant::now();
         let elapsed = now.duration_since(self.last_time).as_secs_f64();


### PR DESCRIPTION
Removes some unnecessary logs from the sealevel igp indexing fn. Also instruments the eta calculator in response to https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/2723

### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
