### PR TITLE
chore: new relayer gas policies

### DIFF
--- a/typescript/infra/config/environments/mainnet2/agent.ts
+++ b/typescript/infra/config/environments/mainnet2/agent.ts
@@ -86,11 +86,7 @@ const gasPaymentEnforcement: GasPaymentEnforcementConfig[] = [
       ...interchainQueriesMatchingList,
       {
         originDomain: [getDomainId(chainMetadata.bsc)],
-        senderAddress: [
-          '0xC27980812E2E66491FD457D488509b7E04144b98',
-          // bsc routers
-          ...bscNautilusWarpRoutes.map((r) => r.router),
-        ],
+        senderAddress: bscNautilusWarpRoutes.map((r) => r.router),
         destinationDomain: '*',
         recipientAddress: '*',
       },

--- a/typescript/infra/config/environments/mainnet2/agent.ts
+++ b/typescript/infra/config/environments/mainnet2/agent.ts
@@ -78,6 +78,15 @@ const gasPaymentEnforcement: GasPaymentEnforcementConfig[] = [
   },
   {
     type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+    matchingList: [
+      {
+        originDomain: [getDomainId(chainMetadata.solana)],
+        // solana -> nautilus warp route
+        senderAddress: ['EJqwFjvVJSAxH8Ur2PYuMfdvoJeutjmH6GkoEFQ4MdSa'],
+        destinationDomain: '*',
+        recipientAddress: '*',
+      },
+    ],
   },
 ];
 

--- a/typescript/infra/config/environments/mainnet2/agent.ts
+++ b/typescript/infra/config/environments/mainnet2/agent.ts
@@ -1,6 +1,5 @@
 import {
   AgentConnectionType,
-  ChainMap,
   chainMetadata,
   getDomainId,
   hyperlaneEnvironments,
@@ -13,10 +12,7 @@ import {
   allAgentChainNames,
   routerMatchingList,
 } from '../../../src/config';
-import {
-  GasPaymentEnforcementConfig,
-  MatchingList,
-} from '../../../src/config/agent/relayer';
+import { GasPaymentEnforcementConfig } from '../../../src/config/agent/relayer';
 import { ALL_KEY_ROLES, Role } from '../../../src/roles';
 import { Contexts } from '../../contexts';
 
@@ -102,15 +98,6 @@ const gasPaymentEnforcement: GasPaymentEnforcementConfig[] = [
   },
   {
     type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
-    matchingList: [
-      {
-        originDomain: [getDomainId(chainMetadata.solana)],
-        // solana -> nautilus warp route
-        senderAddress: ['EJqwFjvVJSAxH8Ur2PYuMfdvoJeutjmH6GkoEFQ4MdSa'],
-        destinationDomain: '*',
-        recipientAddress: '*',
-      },
-    ],
   },
 ];
 

--- a/typescript/infra/config/environments/mainnet2/agent.ts
+++ b/typescript/infra/config/environments/mainnet2/agent.ts
@@ -2,6 +2,7 @@ import {
   AgentConnectionType,
   ChainMap,
   chainMetadata,
+  getDomainId,
   hyperlaneEnvironments,
 } from '@hyperlane-xyz/sdk';
 import { objMap } from '@hyperlane-xyz/utils';
@@ -59,7 +60,21 @@ const gasPaymentEnforcement: GasPaymentEnforcementConfig[] = [
     // all messages between interchain query routers.
     // This whitelist will become more strict with
     // https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/1605
-    matchingList: interchainQueriesMatchingList,
+    matchingList: [
+      ...interchainQueriesMatchingList,
+      {
+        originDomain: [getDomainId(chainMetadata.solana)],
+        senderAddress: '*',
+        destinationDomain: '*',
+        recipientAddress: '*',
+      },
+      {
+        originDomain: [getDomainId(chainMetadata.bsc)],
+        senderAddress: ['0xC27980812E2E66491FD457D488509b7E04144b98'],
+        destinationDomain: '*',
+        recipientAddress: '*',
+      },
+    ],
   },
   {
     type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,

--- a/typescript/infra/config/environments/mainnet2/agent.ts
+++ b/typescript/infra/config/environments/mainnet2/agent.ts
@@ -53,6 +53,32 @@ const contextBase = {
   },
 } as const;
 
+const bscNautilusWarpRoutes: Array<{ router: string }> = [
+  {
+    router: '0xC27980812E2E66491FD457D488509b7E04144b98',
+  },
+  // ETH
+  {
+    router: '0x2a6822dc5639b3fe70de6b65b9ff872e554162fa',
+  },
+  // USDC
+  {
+    router: '0x6937a62f93a56D2AE9392Fa1649b830ca37F3ea4',
+  },
+  // BTC
+  {
+    router: '0xB3545006A532E8C23ebC4e33d5ab2232Cafc35Ad',
+  },
+  // USDT
+  {
+    router: '0xb7d36720a16A1F9Cfc1f7910Ac49f03965401a36',
+  },
+  // POSE
+  {
+    router: '0x807D2C6c3d64873Cc729dfC65fB717C3E05e682f',
+  },
+];
+
 const gasPaymentEnforcement: GasPaymentEnforcementConfig[] = [
   {
     type: GasPaymentEnforcementPolicyType.None,
@@ -63,14 +89,12 @@ const gasPaymentEnforcement: GasPaymentEnforcementConfig[] = [
     matchingList: [
       ...interchainQueriesMatchingList,
       {
-        originDomain: [getDomainId(chainMetadata.solana)],
-        senderAddress: '*',
-        destinationDomain: '*',
-        recipientAddress: '*',
-      },
-      {
         originDomain: [getDomainId(chainMetadata.bsc)],
-        senderAddress: ['0xC27980812E2E66491FD457D488509b7E04144b98'],
+        senderAddress: [
+          '0xC27980812E2E66491FD457D488509b7E04144b98',
+          // bsc routers
+          ...bscNautilusWarpRoutes.map((r) => r.router),
+        ],
         destinationDomain: '*',
         recipientAddress: '*',
       },
@@ -90,71 +114,6 @@ const gasPaymentEnforcement: GasPaymentEnforcementConfig[] = [
   },
 ];
 
-const nautilusWarpRoutes: Array<ChainMap<{ router: string }>> = [
-  {
-    bsc: {
-      router: '0xC27980812E2E66491FD457D488509b7E04144b98',
-    },
-    nautilus: {
-      router: '0x4501bBE6e731A4bC5c60C03A77435b2f6d5e9Fe7',
-    },
-    solana: {
-      router:
-        '0xc5ba229fa2822fe65ac2bd0a93d8371d75292c3415dd381923c1088a3308528b',
-    },
-  },
-  // ETH
-  {
-    bsc: {
-      router: '0x2a6822dc5639b3fe70de6b65b9ff872e554162fa',
-    },
-    nautilus: {
-      router: '0x182E8d7c5F1B06201b102123FC7dF0EaeB445a7B',
-    },
-  },
-  // USDC
-  {
-    bsc: {
-      router: '0x6937a62f93a56D2AE9392Fa1649b830ca37F3ea4',
-    },
-    nautilus: {
-      router: '0xB2723928400AE5778f6A3C69D7Ca9e90FC430180',
-    },
-  },
-  // BTC
-  {
-    bsc: {
-      router: '0xB3545006A532E8C23ebC4e33d5ab2232Cafc35Ad',
-    },
-    nautilus: {
-      router: '0x61DDB465eEA5bc3708Cf8B53156aC91a77A2f029',
-    },
-  },
-  // USDT
-  {
-    bsc: {
-      router: '0xb7d36720a16A1F9Cfc1f7910Ac49f03965401a36',
-    },
-    nautilus: {
-      router: '0xBDa330Ea8F3005C421C8088e638fBB64fA71b9e0',
-    },
-  },
-  // POSE
-  {
-    bsc: {
-      router: '0x807D2C6c3d64873Cc729dfC65fB717C3E05e682f',
-    },
-    nautilus: {
-      router: '0xA1ac41d8A663fd317cc3BD94C7de92dC4BA4a882',
-    },
-  },
-];
-
-const nautilusWarpRouteMatchingList = nautilusWarpRoutes.reduce(
-  (agg, warpRoute) => [...agg, ...routerMatchingList(warpRoute)],
-  [] as MatchingList,
-);
-
 const hyperlane: RootAgentConfig = {
   ...contextBase,
   context: Contexts.Hyperlane,
@@ -172,17 +131,7 @@ const hyperlane: RootAgentConfig = {
         recipientAddress: '0xBC3cFeca7Df5A45d61BC60E7898E63670e1654aE',
       },
     ],
-    gasPaymentEnforcement: [
-      // Don't require gas payments for ZBC bridging.
-      // In practice, gas payments are forced to still occur due to on-chain fee quoting.
-      // We need this because the IGP that's paid on BSC isn't the "canonical" one (it's from a PI deployment),
-      // and because the Solana warp route does not yet have an IGP configured.
-      {
-        type: GasPaymentEnforcementPolicyType.None,
-        matchingList: nautilusWarpRouteMatchingList,
-      },
-      ...gasPaymentEnforcement,
-    ],
+    gasPaymentEnforcement,
   },
   validators: {
     docker: {

--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -61,12 +61,7 @@ const gasPaymentEnforcement: GasPaymentEnforcementConfig[] = [
       ...interchainQueriesMatchingList,
       {
         originDomain: [getDomainId(chainMetadata.solanadevnet)],
-        senderAddress: [
-          // hyperlane context helloworld router on solanadevnet
-          'CXQX54kdkU5GqdRJjCmHpwHfEMgFb5SeBmMWntP2Ds7J',
-          // non-IGP-paying warp route on solanadevnet
-          'PJH5QAbxAqrrnSXfH3GHR8icua8CDFZmo97z91xmpvx',
-        ],
+        senderAddress: '*',
         destinationDomain: '*',
         recipientAddress: '*',
       },

--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -61,7 +61,10 @@ const gasPaymentEnforcement: GasPaymentEnforcementConfig[] = [
       ...interchainQueriesMatchingList,
       {
         originDomain: [getDomainId(chainMetadata.solanadevnet)],
-        senderAddress: '*',
+        senderAddress: [
+          // hyperlane context helloworld router on solanadevnet
+          'CXQX54kdkU5GqdRJjCmHpwHfEMgFb5SeBmMWntP2Ds7J',
+        ],
         destinationDomain: '*',
         recipientAddress: '*',
       },


### PR DESCRIPTION
### Description

New relayer gas payment policies for testnet3 and mainnet2, based on these rules:

- ~~leave `PJH5QAbxAqrrnSXfH3GHR8icua8CDFZmo97z91xmpvx` in the `GasPaymentEnforcementPolicyType.None` matching list until we move its ownership~~
- don't enforce gas payments:
  - from the helloworld router on solanadevnet
  - from solana devnet and mainnet warp routes to anything
    - with the exception of `EJqwFjvVJSAxH8Ur2PYuMfdvoJeutjmH6GkoEFQ4MdSa`, which now has an igp configured (`HksFWQM1EXJJ5mxo2uZoMfmksXHaNhCunh71NqcQQHZ8`)
  - from the bsc/bsctestnet routers of all the warp routes
  - for interchain queries on both testnet3 and mainnet2

### Related issues

- Fixes https://github.com/hyperlane-xyz/issues/issues/570

### Backward compatibility

Yes

### Testing
 None
