### PR TITLE
use `warn` logging level for eta errors

### DIFF
--- a/rust/hyperlane-base/src/contract_sync/eta_calculator.rs
+++ b/rust/hyperlane-base/src/contract_sync/eta_calculator.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use derive_new::new;
-use tracing::debug;
+use tracing::warn;
 
 /// Calculates the expected time to catch up to the tip of the blockchain.
 #[derive(new)]
@@ -66,7 +66,7 @@ impl SyncerEtaCalculator {
             {
                 Ok(eta) => eta,
                 Err(e) => {
-                    debug!(error=?e, tip=?current_tip, block=?current_block, rate=?effective_rate, "Failed to calculate the eta");
+                    warn!(error=?e, tip=?current_tip, block=?current_block, rate=?effective_rate, "Failed to calculate the eta");
                     default_duration
                 }
             }


### PR DESCRIPTION
### Description

the `debug!` logs either are not occurring very often, or are not displayed at all in the gcp logs

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
