### PR TITLE
add InsertedIntoTree event

### DIFF
--- a/solidity/contracts/hooks/MerkleTreeHook.sol
+++ b/solidity/contracts/hooks/MerkleTreeHook.sol
@@ -14,7 +14,7 @@ contract MerkleTreeHook is IPostDispatchHook, MailboxClient, Indexed {
     // An incremental merkle tree used to store outbound message IDs.
     MerkleLib.Tree internal _tree;
 
-    event InsertedIntoTree(bytes32 indexed messageId, uint32 indexed index);
+    event InsertedIntoTree(bytes32 messageId, uint32 index);
 
     constructor(address _mailbox) MailboxClient(_mailbox) {}
 

--- a/solidity/contracts/hooks/MerkleTreeHook.sol
+++ b/solidity/contracts/hooks/MerkleTreeHook.sol
@@ -14,6 +14,8 @@ contract MerkleTreeHook is IPostDispatchHook, MailboxClient, Indexed {
     // An incremental merkle tree used to store outbound message IDs.
     MerkleLib.Tree internal _tree;
 
+    event InsertedIntoTree(bytes32 indexed messageId, uint32 indexed index);
+
     constructor(address _mailbox) MailboxClient(_mailbox) {}
 
     function count() public view returns (uint32) {
@@ -39,7 +41,9 @@ contract MerkleTreeHook is IPostDispatchHook, MailboxClient, Indexed {
         require(msg.value == 0, "MerkleTreeHook: no value expected");
         bytes32 id = message.id();
         require(isLatestDispatched(id), "message not dispatching");
+
         _tree.insert(id);
+        emit InsertedIntoTree(id, count() - 1);
     }
 
     function quoteDispatch(

--- a/solidity/test/MerkleTreeHook.t.sol
+++ b/solidity/test/MerkleTreeHook.t.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT or Apache-2.0
+pragma solidity ^0.8.13;
+
+import {Test, console} from "forge-std/Test.sol";
+
+import {Message} from "../contracts/libs/Message.sol";
+import {TypeCasts} from "../contracts/libs/TypeCasts.sol";
+import {TestMerkleTreeHook} from "../contracts/test/TestMerkleTreeHook.sol";
+import {TestMailbox} from "../contracts/test/TestMailbox.sol";
+
+contract MerkleTreeHookTest is Test {
+    using Message for bytes;
+    using TypeCasts for address;
+
+    TestMailbox internal mailbox;
+    TestMerkleTreeHook internal hook;
+
+    uint32 internal constant ORIGIN = 11;
+    uint32 internal constant DESTINATION = 22;
+    address internal constant RECIPIENT = address(0xdeadbeef);
+    uint256 internal MSG_COUNT = 3;
+    bytes[3] internal testMessage;
+    bytes32[3] internal expectedRoots = [
+        bytes32(
+            0x10df2f89cb24ed6078fc3949b4870e94a7e32e40e8d8c6b7bd74ccc2c933d760
+        ),
+        bytes32(
+            0x080ef1c2cd394de78363ecb0a466c934b57de4abb5604a0684e571990eb7b073
+        ),
+        bytes32(
+            0xbf78ad252da524f1e733aa6b83514dd83225676b5828f888f01487108f8f7cc7
+        )
+    ];
+
+    event InsertedIntoTree(bytes32 indexed messageId, uint32 indexed index);
+
+    function setUp() public {
+        mailbox = new TestMailbox(ORIGIN);
+        hook = new TestMerkleTreeHook(address(mailbox));
+
+        for (uint256 i = 0; i < MSG_COUNT; i++) {
+            testMessage[i] = mailbox.buildOutboundMessage(
+                DESTINATION,
+                RECIPIENT.addressToBytes32(),
+                abi.encodePacked(i)
+            );
+        }
+    }
+
+    function testPostDispatch_emit() public {
+        for (uint32 i = 0; i < MSG_COUNT; i++) {
+            bytes memory currMessage = testMessage[i];
+            mailbox.updateLatestDispatchedId(currMessage.id());
+
+            vm.expectEmit(true, false, false, true);
+            emit InsertedIntoTree(currMessage.id(), i);
+            hook.postDispatch("", currMessage);
+
+            assertEq(hook.count(), i + 1);
+            assertEq(hook.root(), expectedRoots[i]);
+        }
+    }
+
+    function testQuoteDispatch() public {
+        for (uint256 i = 0; i < MSG_COUNT; i++) {
+            bytes memory currMessage = testMessage[i];
+
+            assertEq(hook.quoteDispatch("", currMessage), 0);
+        }
+    }
+}

--- a/solidity/test/MerkleTreeHook.t.sol
+++ b/solidity/test/MerkleTreeHook.t.sol
@@ -32,7 +32,7 @@ contract MerkleTreeHookTest is Test {
         )
     ];
 
-    event InsertedIntoTree(bytes32 indexed messageId, uint32 indexed index);
+    event InsertedIntoTree(bytes32 messageId, uint32 index);
 
     function setUp() public {
         mailbox = new TestMailbox(ORIGIN);
@@ -52,7 +52,7 @@ contract MerkleTreeHookTest is Test {
             bytes memory currMessage = testMessage[i];
             mailbox.updateLatestDispatchedId(currMessage.id());
 
-            vm.expectEmit(true, false, false, true);
+            vm.expectEmit(false, false, false, true);
             emit InsertedIntoTree(currMessage.id(), i);
             hook.postDispatch("", currMessage);
 

--- a/solidity/test/merkle.test.ts
+++ b/solidity/test/merkle.test.ts
@@ -1,31 +1,21 @@
 import { expect } from 'chai';
-import { keccak256 } from 'ethers/lib/utils';
 import { ethers } from 'hardhat';
 
-import { addressToBytes32 } from '@hyperlane-xyz/utils/dist/src/utils';
-
 import merkleTestCases from '../../vectors/merkle.json';
-import {
-  TestMailbox,
-  TestMailbox__factory,
-  TestMerkleTreeHook,
-  TestMerkleTreeHook__factory,
-} from '../types';
+import { TestMerkle, TestMerkle__factory } from '../types';
 
 describe('Merkle', async () => {
   for (const testCase of merkleTestCases) {
     const { testName, leaves, expectedRoot, proofs } = testCase;
 
     describe(testName, async () => {
-      let merkle: TestMerkleTreeHook;
-      let mailboxFactory: TestMailbox;
+      let merkle: TestMerkle;
 
       before(async () => {
         const [signer] = await ethers.getSigners();
-        mailboxFactory = await new TestMailbox__factory(signer).deploy(1);
 
-        const merkleFactory = new TestMerkleTreeHook__factory(signer);
-        merkle = await merkleFactory.deploy(mailboxFactory.address);
+        const merkleFactory = new TestMerkle__factory(signer);
+        merkle = await merkleFactory.deploy();
 
         //insert the leaves
         for (const leaf of leaves) {
@@ -43,19 +33,13 @@ describe('Merkle', async () => {
         expect(await merkle.root()).to.equal(expectedRoot);
       });
 
-      it("emit 'InsertedIntoTree' events on postDispatch", async () => {
-        const [signer] = await ethers.getSigners();
-        const message = await mailboxFactory.buildOutboundMessage(
-          1,
-          addressToBytes32(signer.address),
-          '0x',
-        );
-        const messageId = await keccak256(message);
-        await mailboxFactory.updateLatestDispatchedId(messageId);
-        await expect(merkle.postDispatch('0x', message, { value: 0 })).to.emit(
-          merkle,
-          'InsertedIntoTree',
-        );
+      it("can verify the leaves' proofs", async () => {
+        for (const proof of proofs) {
+          const { leaf, path, index } = proof;
+
+          const proofRoot = await merkle.branchRoot(leaf, path, index);
+          expect(proofRoot).to.equal(expectedRoot);
+        }
       });
     });
   }

--- a/solidity/test/merkle.test.ts
+++ b/solidity/test/merkle.test.ts
@@ -1,21 +1,31 @@
 import { expect } from 'chai';
+import { keccak256 } from 'ethers/lib/utils';
 import { ethers } from 'hardhat';
 
+import { addressToBytes32 } from '@hyperlane-xyz/utils/dist/src/utils';
+
 import merkleTestCases from '../../vectors/merkle.json';
-import { TestMerkle, TestMerkle__factory } from '../types';
+import {
+  TestMailbox,
+  TestMailbox__factory,
+  TestMerkleTreeHook,
+  TestMerkleTreeHook__factory,
+} from '../types';
 
 describe('Merkle', async () => {
   for (const testCase of merkleTestCases) {
     const { testName, leaves, expectedRoot, proofs } = testCase;
 
     describe(testName, async () => {
-      let merkle: TestMerkle;
+      let merkle: TestMerkleTreeHook;
+      let mailboxFactory: TestMailbox;
 
       before(async () => {
         const [signer] = await ethers.getSigners();
+        mailboxFactory = await new TestMailbox__factory(signer).deploy(1);
 
-        const merkleFactory = new TestMerkle__factory(signer);
-        merkle = await merkleFactory.deploy();
+        const merkleFactory = new TestMerkleTreeHook__factory(signer);
+        merkle = await merkleFactory.deploy(mailboxFactory.address);
 
         //insert the leaves
         for (const leaf of leaves) {
@@ -33,13 +43,19 @@ describe('Merkle', async () => {
         expect(await merkle.root()).to.equal(expectedRoot);
       });
 
-      it("can verify the leaves' proofs", async () => {
-        for (const proof of proofs) {
-          const { leaf, path, index } = proof;
-
-          const proofRoot = await merkle.branchRoot(leaf, path, index);
-          expect(proofRoot).to.equal(expectedRoot);
-        }
+      it("emit 'InsertedIntoTree' events on postDispatch", async () => {
+        const [signer] = await ethers.getSigners();
+        const message = await mailboxFactory.buildOutboundMessage(
+          1,
+          addressToBytes32(signer.address),
+          '0x',
+        );
+        const messageId = await keccak256(message);
+        await mailboxFactory.updateLatestDispatchedId(messageId);
+        await expect(merkle.postDispatch('0x', message, { value: 0 })).to.emit(
+          merkle,
+          'InsertedIntoTree',
+        );
       });
     });
   }


### PR DESCRIPTION
### Description

- Adding "InsertedIntoEvent" for standalone indexing of events by the agents

### Drive-by changes

None

### Related issues

#2313 

### Backward compatibility

Yes

### Testing

Unit tests
