### PR TITLE
Indicate no quorum checkpoint

### DIFF
--- a/rust/agents/relayer/src/msg/metadata/multisig/legacy_multisig.rs
+++ b/rust/agents/relayer/src/msg/metadata/multisig/legacy_multisig.rs
@@ -7,6 +7,7 @@ use derive_new::new;
 use eyre::{Context, Result};
 use hyperlane_base::MultisigCheckpointSyncer;
 use hyperlane_core::{HyperlaneMessage, H256};
+use tracing::debug;
 
 use crate::msg::metadata::BaseMetadataBuilder;
 
@@ -48,6 +49,8 @@ impl MultisigIsmMetadataBuilder for LegacyMultisigMetadataBuilder {
             .await
             .context(CTX)?
         else {
+            debug!(?message, highest_nonce, ?checkpoint_syncer
+                "No quorum checkpoint found for message");
             return Ok(None);
         };
 


### PR DESCRIPTION
### Description

Currently, when the validator is not signing, there is just a unhelpful "Could not fetch metadata" log line. This indicates that no quorum could be found at the debug level as well as adding the checkpoint syncer information

### Backward compatibility

Yes

### Testing

Manual
