### PR TITLE
Separating out merkle tree hook indexer

### DIFF
--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -133,6 +133,16 @@ impl BaseAgent for Relayer {
                     .collect(),
             )
             .await?;
+        let merkle_tree_hook_syncs = settings
+            .build_merkle_tree_hook_indexers(
+                settings.origin_chains.iter(),
+                &metrics,
+                &contract_sync_metrics,
+                dbs.iter()
+                    .map(|(d, db)| (d.clone(), Arc::new(db.clone()) as _))
+                    .collect(),
+            )
+            .await?;
 
         let whitelist = Arc::new(settings.whitelist);
         let blacklist = Arc::new(settings.blacklist);

--- a/rust/chains/hyperlane-ethereum/abis/Mailbox.abi.json
+++ b/rust/chains/hyperlane-ethereum/abis/Mailbox.abi.json
@@ -16,6 +16,19 @@
       {
         "indexed": true,
         "internalType": "address",
+        "name": "hook",
+        "type": "address"
+      }
+    ],
+    "name": "DefaultHookSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "module",
         "type": "address"
       }
@@ -101,12 +114,6 @@
   },
   {
     "anonymous": false,
-    "inputs": [],
-    "name": "Paused",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
     "inputs": [
       {
         "indexed": true,
@@ -145,22 +152,16 @@
   },
   {
     "anonymous": false,
-    "inputs": [],
-    "name": "Unpaused",
-    "type": "event"
-  },
-  {
-    "inputs": [],
-    "name": "MAX_MESSAGE_BODY_BYTES",
-    "outputs": [
+    "inputs": [
       {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
+        "indexed": true,
+        "internalType": "address",
+        "name": "hook",
+        "type": "address"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "name": "RequiredHookSet",
+    "type": "event"
   },
   {
     "inputs": [],
@@ -177,12 +178,12 @@
   },
   {
     "inputs": [],
-    "name": "count",
+    "name": "defaultHook",
     "outputs": [
       {
-        "internalType": "uint32",
+        "internalType": "contract IPostDispatchHook",
         "name": "",
-        "type": "uint32"
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -205,7 +206,7 @@
     "inputs": [
       {
         "internalType": "bytes32",
-        "name": "",
+        "name": "_id",
         "type": "bytes32"
       }
     ],
@@ -218,6 +219,92 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "deployedBlock",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "destinationDomain",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "recipientAddress",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "messageBody",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "metadata",
+        "type": "bytes"
+      },
+      {
+        "internalType": "contract IPostDispatchHook",
+        "name": "hook",
+        "type": "address"
+      }
+    ],
+    "name": "dispatch",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "destinationDomain",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "recipientAddress",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "messageBody",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "hookMetadata",
+        "type": "bytes"
+      }
+    ],
+    "name": "dispatch",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -246,7 +333,7 @@
         "type": "bytes32"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -260,6 +347,16 @@
         "internalType": "address",
         "name": "_defaultIsm",
         "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_defaultHook",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_requiredHook",
+        "type": "address"
       }
     ],
     "name": "initialize",
@@ -269,12 +366,12 @@
   },
   {
     "inputs": [],
-    "name": "isPaused",
+    "name": "latestDispatchedId",
     "outputs": [
       {
-        "internalType": "bool",
+        "internalType": "bytes32",
         "name": "",
-        "type": "bool"
+        "type": "bytes32"
       }
     ],
     "stateMutability": "view",
@@ -282,13 +379,8 @@
   },
   {
     "inputs": [],
-    "name": "latestCheckpoint",
+    "name": "localDomain",
     "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      },
       {
         "internalType": "uint32",
         "name": "",
@@ -300,7 +392,7 @@
   },
   {
     "inputs": [],
-    "name": "localDomain",
+    "name": "nonce",
     "outputs": [
       {
         "internalType": "uint32",
@@ -325,13 +417,6 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "pause",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
         "internalType": "bytes",
@@ -346,7 +431,147 @@
     ],
     "name": "process",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "processedAt",
+    "outputs": [
+      {
+        "internalType": "uint48",
+        "name": "",
+        "type": "uint48"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "processor",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "destinationDomain",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "recipientAddress",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "messageBody",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "metadata",
+        "type": "bytes"
+      },
+      {
+        "internalType": "contract IPostDispatchHook",
+        "name": "hook",
+        "type": "address"
+      }
+    ],
+    "name": "quoteDispatch",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "destinationDomain",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "recipientAddress",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "messageBody",
+        "type": "bytes"
+      }
+    ],
+    "name": "quoteDispatch",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "destinationDomain",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "recipientAddress",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "messageBody",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "defaultHookMetadata",
+        "type": "bytes"
+      }
+    ],
+    "name": "quoteDispatch",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -377,15 +602,28 @@
   },
   {
     "inputs": [],
-    "name": "root",
+    "name": "requiredHook",
     "outputs": [
       {
-        "internalType": "bytes32",
+        "internalType": "contract IPostDispatchHook",
         "name": "",
-        "type": "bytes32"
+        "type": "address"
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_hook",
+        "type": "address"
+      }
+    ],
+    "name": "setDefaultHook",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -405,31 +643,24 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "newOwner",
+        "name": "_hook",
         "type": "address"
       }
     ],
-    "name": "transferOwnership",
+    "name": "setRequiredHook",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "tree",
-    "outputs": [
+    "inputs": [
       {
-        "internalType": "uint256",
-        "name": "count",
-        "type": "uint256"
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "unpause",
+    "name": "transferOwnership",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/rust/chains/hyperlane-ethereum/abis/MerkleTreeHook.abi.json
+++ b/rust/chains/hyperlane-ethereum/abis/MerkleTreeHook.abi.json
@@ -11,17 +11,23 @@
     "type": "constructor"
   },
   {
-    "inputs": [],
-    "name": "branch",
-    "outputs": [
+    "anonymous": false,
+    "inputs": [
       {
-        "internalType": "bytes32[32]",
-        "name": "",
-        "type": "bytes32[32]"
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "messageId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "index",
+        "type": "uint32"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "name": "InsertedIntoTree",
+    "type": "event"
   },
   {
     "inputs": [],

--- a/rust/chains/hyperlane-ethereum/src/lib.rs
+++ b/rust/chains/hyperlane-ethereum/src/lib.rs
@@ -40,6 +40,10 @@ mod interchain_security_module;
 
 /// MultisigIsm abi
 #[cfg(not(doctest))]
+mod merkle_tree_hook;
+
+/// MultisigIsm abi
+#[cfg(not(doctest))]
 mod multisig_ism;
 
 /// RoutingIsm abi

--- a/rust/chains/hyperlane-ethereum/src/lib.rs
+++ b/rust/chains/hyperlane-ethereum/src/lib.rs
@@ -12,7 +12,7 @@ use ethers::prelude::{abi, Lazy, Middleware};
 pub use self::{
     aggregation_ism::*, ccip_read_ism::*, config::*, config::*, interchain_gas::*,
     interchain_gas::*, interchain_security_module::*, interchain_security_module::*, mailbox::*,
-    mailbox::*, multisig_ism::*, provider::*, routing_ism::*, rpc_clients::*, signers::*,
+    mailbox::*, multisig_ism::*, merkle_tree_hook::*, provider::*, routing_ism::*, rpc_clients::*, signers::*,
     singleton_signer::*, trait_builder::*, validator_announce::*,
 };
 
@@ -38,7 +38,7 @@ mod interchain_gas;
 #[cfg(not(doctest))]
 mod interchain_security_module;
 
-/// MultisigIsm abi
+/// Merkle tree hook abi
 #[cfg(not(doctest))]
 mod merkle_tree_hook;
 

--- a/rust/chains/hyperlane-ethereum/src/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/mailbox.rs
@@ -259,7 +259,7 @@ where
     }
 
     // TODO: make this cache the required hook address at construction time
-    async fn merkle_tree_hook(&self) -> ChainResult<MerkleTreeHook<M>> {
+    pub async fn merkle_tree_hook(&self) -> ChainResult<MerkleTreeHook<M>> {
         let address = self.contract.required_hook().call().await?;
         Ok(MerkleTreeHook::new(address, self.provider.clone()))
     }

--- a/rust/chains/hyperlane-ethereum/src/merkle_tree_hook.rs
+++ b/rust/chains/hyperlane-ethereum/src/merkle_tree_hook.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ethers::prelude::Middleware;
+use tracing::instrument;
+
+use hyperlane_core::{H160, ContractLocator, Indexer, H256, IndexRange::{self, BlockRange}, ChainResult, LogMeta, ChainCommunicationError};
+
+use crate::contracts::merkle_tree_hook::MerkleTreeHook as MerkleTreeHookInternal;
+
+pub struct MerkleTreeHookIndexerBuilder {
+    pub merkle_tree_hook_address: H160,
+    pub finality_blocks: u32,
+}
+
+#[derive(Debug)]
+/// Struct that retrieves event data for an Ethereum MerkleTreeHook
+pub struct EthereumMerkleTreeHookIndexer<M>
+where
+    M: Middleware,
+{
+    contract: Arc<MerkleTreeHookInternal<M>>,
+    provider: Arc<M>,
+    finality_blocks: u32,
+}
+
+impl<M> EthereumMerkleTreeHookIndexer<M>
+where
+    M: Middleware + 'static,
+{
+    /// Create new EthereumInterchainGasPaymasterIndexer
+    pub fn new(provider: Arc<M>, locator: &ContractLocator, finality_blocks: u32) -> Self {
+        Self {
+            contract: Arc::new(MerkleTreeHookInternal::new(
+                locator.address,
+                provider.clone(),
+            )),
+            provider,
+            finality_blocks,
+        }
+    }
+}
+
+#[async_trait]
+impl<M> Indexer<H256> for EthereumMerkleTreeHookIndexer<M>
+where
+    M: Middleware + 'static,
+{
+    #[instrument(err, skip(self))]
+    async fn fetch_logs(
+        &self,
+        range: IndexRange,
+    ) -> ChainResult<Vec<(H256, LogMeta)>> {
+        let BlockRange(range) = range else {
+            return Err(ChainCommunicationError::from_other_str(
+                "EthereumMerkleTreeHookIndexer only supports block-based indexing",
+            ));
+        };
+
+        // let events = self.contract.inserted
+
+        // TODO
+    }
+
+    #[instrument(level = "debug", err, ret, skip(self))]
+    async fn get_finalized_block_number(&self) -> ChainResult<u32> {
+        Ok(self
+            .provider
+            .get_block_number()
+            .await
+            .map_err(ChainCommunicationError::from_other)?
+            .as_u32()
+            .saturating_sub(self.finality_blocks))
+    }
+}

--- a/rust/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -152,6 +152,28 @@ impl HyperlaneRocksDB {
         Ok(true)
     }
 
+    /// If the provided gas payment, identified by its metadata, has not been
+    /// processed, processes the gas payment and records it as processed.
+    /// Returns whether the gas payment was processed for the first time.
+    pub fn process_tree_insertion(
+        &self,
+        index: u32,
+        leaf: H256,
+        log_meta: &LogMeta,
+    ) -> DbResult<bool> {
+        let merkle_tree_meta = log_meta.into();
+        // double insertions are ok, so no need to check if it's already been processed
+
+        // Set the gas payment as processed
+        self.store_processed_by_gas_payment_meta(&merkle_tree_meta, &true)?;
+
+        // Update the total gas payment for the message to include the payment
+        // self.update_gas_payment_by_message_id(payment)?;
+
+        // Return true to indicate the gas payment was processed for the first time
+        Ok(true)
+    }
+
     /// Processes the gas expenditure and store the total expenditure for the
     /// message.
     pub fn process_gas_expenditure(&self, expenditure: InterchainGasExpenditure) -> DbResult<()> {
@@ -246,6 +268,23 @@ impl HyperlaneLogStore<InterchainGasPayment> for HyperlaneRocksDB {
             debug!(payments = new, "Wrote new gas payments to database");
         }
         Ok(new)
+    }
+}
+
+#[async_trait]
+impl HyperlaneLogStore<H256> for HyperlaneRocksDB {
+    /// Store a list of interchain gas payments and their associated metadata.
+    #[instrument(skip_all)]
+    async fn store_logs(&self, leaves: &[(H256, LogMeta)]) -> Result<u32> {
+        let mut insertions = 0;
+        for (leaf, meta) in leaves {
+            // send index
+            if self.process_tree_insertion(insertions, *leaf, meta)? {
+                insertions += 1;
+            }
+            // ingest_leaf into merkleTree
+        }
+        Ok(insertions)
     }
 }
 

--- a/rust/hyperlane-base/src/settings/base.rs
+++ b/rust/hyperlane-base/src/settings/base.rs
@@ -255,4 +255,5 @@ impl Settings {
     build_indexer_fns!(build_delivery_indexer, build_delivery_indexers -> dyn HyperlaneWatermarkedLogStore<Delivery>, WatermarkContractSync<Delivery>);
     build_indexer_fns!(build_message_indexer, build_message_indexers -> dyn HyperlaneMessageStore, MessageContractSync);
     build_indexer_fns!(build_interchain_gas_payment_indexer, build_interchain_gas_payment_indexers -> dyn HyperlaneWatermarkedLogStore<InterchainGasPayment>, WatermarkContractSync<InterchainGasPayment>);
+    build_indexer_fns!(build_merkle_tree_hook_indexer, build_merkle_tree_hook_indexers -> dyn HyperlaneWatermarkedLogStore<H256>, WatermarkContractSync<H256>);
 }

--- a/rust/hyperlane-base/src/settings/chains.rs
+++ b/rust/hyperlane-base/src/settings/chains.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use ethers::prelude::Selector;
 use eyre::{eyre, Context, Result};
-use h_eth::EthereumMailboxIndexer;
+use h_eth::*;
 use serde::Deserialize;
 
 use ethers_prometheus::middleware::{
@@ -487,14 +487,13 @@ impl ChainConf {
         
         match &self.connection()? {
             ChainConnectionConf::Ethereum(conf) => {
-                let mailbox = EthereumMailbox::new(conf, locator);
-                let merkle_tree_hook = mailbox.merkle_tree_hook().await.unwrap();
+                // TODO: fix how do I get the merkle tree address without provider here from mailbox?
                 self.build_ethereum(
                     conf,
                     &locator,
                     metrics,
                     h_eth::MerkleTreeHookIndexerBuilder {
-                        merkle_tree_hook_address: merkle_tree_hook.address, 
+                        merkle_tree_hook_address: self.addresses.mailbox.into(), 
                         finality_blocks: self.finality_blocks,
                     },
                 )
@@ -502,7 +501,7 @@ impl ChainConf {
             }
             ChainConnectionConf::Fuel(_) => todo!(),
             ChainConnectionConf::Sealevel(_) => todo!(),
-        }
+        }.context(ctx)
     }
 
     /// Try to convert the chain settings into a ValidatorAnnounce


### PR DESCRIPTION
### Description

- Separate out merkle tree insertion
- Store the leaves in RockDB
- 

### Drive-by changes

None

### Related issues

- Fixes https://github.com/hyperlane-xyz/issues/issues/561
- Related to #2720 

### Backward compatibility

No

### Testing

None
