### PR TITLE
Sealevel IGP debugging, temporarily change Sealevel gas payment policy

### DIFF
--- a/rust/sealevel/client/src/main.rs
+++ b/rust/sealevel/client/src/main.rs
@@ -422,9 +422,9 @@ struct PayForGasArgs {
     program_id: Pubkey,
     #[arg(long)]
     message_id: String,
-    #[arg(long, default_value_t = 13376)]
+    #[arg(long)]
     destination_domain: u32,
-    #[arg(long, default_value_t = 10000)]
+    #[arg(long)]
     gas: u64,
 }
 

--- a/rust/utils/run-locally/src/solana.rs
+++ b/rust/utils/run-locally/src/solana.rs
@@ -314,8 +314,10 @@ pub fn initiate_solana_hyperlane_transfer(
         sealevel_client(&solana_cli_tools_path, &solana_config_path)
             .cmd("igp")
             .cmd("pay-for-gas")
-            .cmd("GwHaw8ewMyzZn9vvrZEnTEAAYpLdkGYs195XWcLDCN4U")
-            .cmd(message_id)
+            .arg("program-id", "GwHaw8ewMyzZn9vvrZEnTEAAYpLdkGYs195XWcLDCN4U")
+            .arg("message-id", message_id)
+            .arg("destination-domain", SOLANA_REMOTE_CHAIN_ID)
+            .arg("gas", "100000")
             .run()
             .join();
     }

--- a/typescript/infra/config/environments/mainnet2/agent.ts
+++ b/typescript/infra/config/environments/mainnet2/agent.ts
@@ -91,11 +91,11 @@ const gasPaymentEnforcement: GasPaymentEnforcementConfig[] = [
         destinationDomain: '*',
         recipientAddress: '*',
       },
-      // Temporarily don't charge gas for Solana -> Nautilus as IGP indexing
-      // in the agents is currently incompatible with the deployed IGP.
+      // Temporarily don't charge gas for the Solana -> Nautilus ZBC warp route,
+      // as IGP indexing in the agents is currently incompatible with the deployed IGP.
       {
         originDomain: [getDomainId(chainMetadata.solana)],
-        senderAddress: '*',
+        senderAddress: ['EJqwFjvVJSAxH8Ur2PYuMfdvoJeutjmH6GkoEFQ4MdSa'],
         destinationDomain: [getDomainId(chainMetadata.nautilus)],
         recipientAddress: '*',
       },

--- a/typescript/infra/config/environments/mainnet2/agent.ts
+++ b/typescript/infra/config/environments/mainnet2/agent.ts
@@ -50,6 +50,7 @@ const contextBase = {
 } as const;
 
 const bscNautilusWarpRoutes: Array<{ router: string }> = [
+  // ZBC
   {
     router: '0xC27980812E2E66491FD457D488509b7E04144b98',
   },
@@ -71,7 +72,7 @@ const bscNautilusWarpRoutes: Array<{ router: string }> = [
   },
   // POSE
   {
-    router: '0x807D2C6c3d64873Cc729dfC65fB717C3E05e682f',
+    router: '0x97a2D58d30A2c838946194494207F7Cf50c25815',
   },
 ];
 
@@ -88,6 +89,14 @@ const gasPaymentEnforcement: GasPaymentEnforcementConfig[] = [
         originDomain: [getDomainId(chainMetadata.bsc)],
         senderAddress: bscNautilusWarpRoutes.map((r) => r.router),
         destinationDomain: '*',
+        recipientAddress: '*',
+      },
+      // Temporarily don't charge gas for Solana -> Nautilus as IGP indexing
+      // in the agents is currently incompatible with the deployed IGP.
+      {
+        originDomain: [getDomainId(chainMetadata.solana)],
+        senderAddress: '*',
+        destinationDomain: [getDomainId(chainMetadata.nautilus)],
         recipientAddress: '*',
       },
     ],


### PR DESCRIPTION
### Description

- Some small changes to help with debugging sealevel IGP
- Turns out the GasPaymentAccount data format onchain is different from the one in `main`. This causes IGP indexing to not work in the wild, but it works in e2e. Because we were planning to change the IGP anyways as we transfer ownership to Zebec, this isn't so bad - so temporarily just not enforcing ZBC warp route Solana -> Nautilus gas payments. In practice, we're still effectively enforcing gas payments because the warp route will pay for gas

### Drive-by changes

- Also added the new BSC POSE addy

### Related issues

n/a

### Backward compatibility

yes

### Testing

Deployed, poked around, used cmds