### PR TITLE
still allow getting testnet3 secrets via externalsecrets, use `mustFromJson` in helm templates

### DIFF
--- a/rust/helm/hyperlane-agent/templates/external-secret.yaml
+++ b/rust/helm/hyperlane-agent/templates/external-secret.yaml
@@ -27,7 +27,7 @@ spec:
    */}}
         {{- range .Values.hyperlane.chains }}
         {{- if not .disabled }}
-        HYP_BASE_CHAINS_{{ .name | upper }}_CUSTOMRPCURLS: {{ printf "'{{ .%s_rpcs | fromJson | join \",\" }}'" .name }}
+        HYP_BASE_CHAINS_{{ .name | upper }}_CUSTOMRPCURLS: {{ printf "'{{ .%s_rpcs | mustFromJson | join \",\" }}'" .name }}
         {{- end }}
         {{- end }}
   data:

--- a/typescript/infra/config/environments/testnet4/infrastructure.ts
+++ b/typescript/infra/config/environments/testnet4/infrastructure.ts
@@ -35,8 +35,10 @@ export const infrastructure: InfrastructureConfig = {
     accessibleGCPSecretPrefixes: [
       'hyperlane-testnet-',
       'testnet-',
+      'hyperlane-testnet3-',
+      'rc-testnet3-',
+      'testnet3-',
       'hyperlane-testnet4-',
-      'flowcarbon-testnet4-',
       'rc-testnet4-',
       'testnet4-',
     ],


### PR DESCRIPTION
### Description

- a single external-secrets instance lives on the cluster, and we are running testnet3 and testnet4 on the same cluster
- json parsing errors were silently swallowed, moved to `mustFromJson` to prevent this

### Drive-by changes

n/a

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
