### PR TITLE
Stop running proteustestnet agents

### DIFF
--- a/typescript/infra/config/environments/testnet3/agent.ts
+++ b/typescript/infra/config/environments/testnet3/agent.ts
@@ -118,9 +118,6 @@ const hyperlane: RootAgentConfig = {
       [chainMetadata.solanadevnet.name]: {
         tag: '79bad9d-20230706-190752',
       },
-      [chainMetadata.proteustestnet.name]: {
-        tag: 'c7c44b2-20230811-133851',
-      },
     },
     chains: validatorChainConfig(Contexts.Hyperlane),
   },

--- a/typescript/infra/config/environments/testnet3/chains.ts
+++ b/typescript/infra/config/environments/testnet3/chains.ts
@@ -42,11 +42,7 @@ export const ethereumChainNames = Object.keys(
 
 export const environment = 'testnet3';
 
-const validatorChainNames = [
-  ...supportedChainNames,
-  chainMetadata.proteustestnet.name,
-];
-
+const validatorChainNames = supportedChainNames;
 const relayerChainNames = validatorChainNames;
 
 export const agentChainNames: AgentChainNames = {


### PR DESCRIPTION
### Description

- Rpc urls are super flaky, stopping the validators and relayer support
- Keeping proteustestnet artifacts / chain metadata for now

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
