### PR TITLE
Fix long validator name for polygonzkevmtestnet

### DIFF
--- a/rust/helm/hyperlane-agent/templates/_helpers.tpl
+++ b/rust/helm/hyperlane-agent/templates/_helpers.tpl
@@ -1,6 +1,7 @@
 {{/*
 We truncate at 63 chars - (11 + (len $suffix)) because the controller-revision-hash label adds an 11 character suffix
-to the pod name. See https://github.com/kubernetes/kubernetes/issues/64023
+to the pod name, and we want the -validator suffix to still be present, but are happy to truncate the preceding name.
+See https://github.com/kubernetes/kubernetes/issues/64023 for controller-revision-hash details.
 */}}
 {{- define "validator.fullname" -}}
 {{- $suffix := "-validator" }}

--- a/rust/helm/hyperlane-agent/templates/_helpers.tpl
+++ b/rust/helm/hyperlane-agent/templates/_helpers.tpl
@@ -1,0 +1,8 @@
+{{/*
+We truncate at 63 chars - (11 + (len $suffix)) because the controller-revision-hash label adds an 11 character suffix
+to the pod name. See https://github.com/kubernetes/kubernetes/issues/64023
+*/}}
+{{- define "validator.fullname" -}}
+{{- $suffix := "-validator" }}
+{{- include "agent-common.fullname" . | trunc (int (sub 63 (add 11 (len $suffix)))) | trimSuffix "-" }}{{ print $suffix }}
+{{- end }}

--- a/rust/helm/hyperlane-agent/templates/validator-configmap.yaml
+++ b/rust/helm/hyperlane-agent/templates/validator-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "agent-common.fullname" . }}-validator
+  name: {{ include "validator.fullname" . }}
   labels:
     {{- include "agent-common.labels" . | nindent 4 }}
 data:

--- a/rust/helm/hyperlane-agent/templates/validator-external-secret.yaml
+++ b/rust/helm/hyperlane-agent/templates/validator-external-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ include "agent-common.fullname" . }}-validator-external-secret
+  name: {{ include "validator.fullname" . }}-external-secret
   labels:
     {{- include "agent-common.labels" . | nindent 4 }}
   annotations:
@@ -14,7 +14,7 @@ spec:
   refreshInterval: "1h"
   # The secret that will be created
   target:
-    name: {{ include "agent-common.fullname" . }}-validator-secret
+    name: {{ include "validator.fullname" . }}-secret
     template:
       type: Opaque
       metadata:

--- a/rust/helm/hyperlane-agent/templates/validator-statefulset.yaml
+++ b/rust/helm/hyperlane-agent/templates/validator-statefulset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "agent-common.fullname" . }}-validator
+  name: {{ include "validator.fullname" . }}
   labels:
     {{- include "agent-common.labels" . | nindent 4 }}
     app.kubernetes.io/component: validator
@@ -12,7 +12,7 @@ spec:
       {{- include "agent-common.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: validator
   replicas: {{ len .Values.hyperlane.validator.configs }}
-  serviceName: {{ include "agent-common.fullname" . }}-validator
+  serviceName: {{ include "validator.fullname" . }}
   template:
     metadata:
       annotations:
@@ -58,7 +58,7 @@ spec:
         - secretRef:
             name: {{ include "agent-common.fullname" . }}-secret
         - secretRef:
-            name: {{ include "agent-common.fullname" . }}-validator-secret
+            name: {{ include "validator.fullname" . }}-secret
         env:
           - name: REPLICA_NAME
             valueFrom:
@@ -79,10 +79,10 @@ spec:
       volumes:
       - name: config-env-vars
         configMap:
-          name: {{ include "agent-common.fullname" . }}-validator
+          name: {{ include "validator.fullname" . }}
       - name: secret-env-vars
         secret:
-          secretName: {{ include "agent-common.fullname" . }}-validator-secret
+          secretName: {{ include "validator.fullname" . }}-secret
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
### Description

* polygonzkevmtestnet's validator name was too long because of the `controller-revision-hash` label, see https://github.com/kubernetes/kubernetes/issues/64023
* Seeks to preserve the `-validator` suffix in the name, but truncates the earlier bit - in practice this results in validator pods like `polygonzkevmtestnet-validator-hyperlane-ag-validator-0`. This felt like the most backward compatible change -- of course we could consider trying to get a name like `polygonzkevmtestnet-hyperlane-agent-validator-0` but this would break backward compatibility more dramatically because we'd need to change all the other validator pods. Imo we should just really avoid long chain names or consider a more breaking change to our infra

### Drive-by changes

n/a

### Related issues

n/a

### Backward compatibility

Mostly

### Testing

Deployed
