### PR TITLE
Rm finality blocks and refactor checkpoint_submitter to be resilient to edge cases

### DIFF
--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -229,7 +229,7 @@ mod test {
         ChainConf {
             domain: domain.clone(),
             signer: Default::default(),
-            finality_blocks: Default::default(),
+            reorg_period: Default::default(),
             addresses: Default::default(),
             connection: ChainConnectionConf::Ethereum(hyperlane_ethereum::ConnectionConf::Http {
                 url: "http://example.com".parse().unwrap(),

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -209,6 +209,7 @@ impl ValidatorSubmitter {
         Ok(())
     }
 
+    // Signs and submits any previously unsubmitted checkpoints.
     async fn sign_and_submit_checkpoints(
         &self,
         checkpoints: Vec<CheckpointWithMessageId>,

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -209,7 +209,7 @@ impl ValidatorSubmitter {
         Ok(())
     }
 
-    // Signs and submits any previously unsubmitted checkpoints.
+    /// Signs and submits any previously unsubmitted checkpoints.
     async fn sign_and_submit_checkpoints(
         &self,
         checkpoints: Vec<CheckpointWithMessageId>,

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -118,7 +118,7 @@ impl ValidatorSubmitter {
 
                 // compare against every queued checkpoint to prevent ingesting past target
                 if checkpoint == correctness_checkpoint {
-                    debug!(index = checkpoint.index, "Reached tree consistency");
+                    info!(index = checkpoint.index, "Reached tree consistency");
 
                     // drain and sign all checkpoints in the queue
                     for queued_checkpoint in checkpoint_queue.drain(..) {

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -98,7 +98,7 @@ impl ValidatorSubmitter {
             //
             // In this case, we just sleep a bit until we fetch a new latest checkpoint
             // that at least meets the tree.
-            if !checkpoint_exceeds_tree(&latest_checkpoint, &tree) {
+            if tree_exceeds_checkpoint(&latest_checkpoint, &tree) {
                 debug!(
                     ?latest_checkpoint,
                     tree_count = tree.count(),
@@ -128,7 +128,7 @@ impl ValidatorSubmitter {
     ) -> Result<()> {
         // This should never be called with a tree that is ahead of the correctness checkpoint.
         assert!(
-            !checkpoint_exceeds_tree(correctness_checkpoint, &tree),
+            tree_exceeds_checkpoint(correctness_checkpoint, &tree),
             "tree (count: {}) is ahead of correctness checkpoint {:?}",
             tree.count(),
             correctness_checkpoint,
@@ -317,11 +317,11 @@ impl ValidatorSubmitter {
     }
 }
 
-/// Returns whether the checkpoint's index exceeds that of the tree.
-fn checkpoint_exceeds_tree(checkpoint: &Checkpoint, tree: &IncrementalMerkle) -> bool {
+/// Returns whether the tree exceeds the checkpoint.
+fn tree_exceeds_checkpoint(checkpoint: &Checkpoint, tree: &IncrementalMerkle) -> bool {
     // tree.index() will panic if the tree is empty, so we use tree.count() instead
     // and convert the correctness_checkpoint.index to a count by adding 1.
-    checkpoint.index + 1 > tree.count() as u32
+    checkpoint.index + 1 < tree.count() as u32
 }
 
 #[derive(Clone)]

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -90,11 +90,8 @@ impl ValidatorSubmitter {
 
             // This can only happen if target_checkpoint is None and the latest checkpoint
             // fetched from onchain has an index that is behind the tree's index.
-            // The initial tree parameter, which is sometimes constructed from an onchain
-            // call to MerkleTreeHook.tree(), may have an index that is ahead of the latest checkpoint
-            // due to the call being made against a block later than the latest_checkpoint() call.
-            // This ideally shouldn't happen, but RPC providers are unreliable and sometimes make
-            // calls against inconsistent block tips.
+            // This may occur e.g. if RPC providers are unreliable and make calls against
+            // inconsistent block tips.
             //
             // In this case, we just sleep a bit until we fetch a new latest checkpoint
             // that at least meets the tree.

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -128,6 +128,7 @@ impl ValidatorSubmitter {
     }
 
     /// Submits signed checkpoints relating to the given tree until the correctness checkpoint (inclusive).
+    /// Only submits the signed checkpoints once the correctness checkpoint is reached.
     async fn submit_checkpoints_until_correctness_checkpoint(
         &self,
         tree: &mut IncrementalMerkle,

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -128,7 +128,7 @@ impl ValidatorSubmitter {
     ) -> Result<()> {
         // This should never be called with a tree that is ahead of the correctness checkpoint.
         assert!(
-            tree_exceeds_checkpoint(correctness_checkpoint, tree),
+            !tree_exceeds_checkpoint(correctness_checkpoint, tree),
             "tree (count: {}) is ahead of correctness checkpoint {:?}",
             tree.count(),
             correctness_checkpoint,

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -59,7 +59,7 @@ impl ValidatorSubmitter {
     }
 
     /// Submits signed checkpoints.
-    /// If a target checkpoint is provided, the provided tree must not be behind it, and
+    /// If a target checkpoint is provided, it must not be bethind the provided tree, and
     /// the submitter will only submit checkpoints until it reaches the target checkpoint.
     /// If a target checkpoint is not provided, the submitter will submit checkpoints indefinitely.
     #[instrument(err, skip(self, tree), fields(domain=%self.merkle_tree_hook.domain()))]

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -119,6 +119,8 @@ impl ValidatorSubmitter {
                     .latest_checkpoint_processed
                     .set(correctness_checkpoint.index as i64);
             }
+
+            sleep(self.interval).await;
         }
 
         // TODO: remove this once validator is tolerant of tasks exiting.
@@ -157,7 +159,7 @@ impl ValidatorSubmitter {
                 let message_id = insertion.message_id();
                 tree.ingest(message_id);
 
-                let checkpoint = self.checkpoint(&tree);
+                let checkpoint = self.checkpoint(tree);
 
                 checkpoint_queue.push(CheckpointWithMessageId {
                     checkpoint,
@@ -165,7 +167,7 @@ impl ValidatorSubmitter {
                 });
             } else {
                 // If we haven't yet indexed the next merkle tree insertion but know that
-                // it will soon exist (because the correctness checkpoint), wait a bit and
+                // it will soon exist (because we know the correctness checkpoint), wait a bit and
                 // try again.
                 sleep(Duration::from_millis(100)).await
             }
@@ -173,7 +175,7 @@ impl ValidatorSubmitter {
 
         // At this point we know that correctness_checkpoint.index == tree.index().
 
-        let checkpoint = self.checkpoint(&tree);
+        let checkpoint = self.checkpoint(tree);
 
         if checkpoint == *correctness_checkpoint {
             debug!(index = checkpoint.index, "Reached tree consistency");

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -128,7 +128,7 @@ impl ValidatorSubmitter {
     ) -> Result<()> {
         // This should never be called with a tree that is ahead of the correctness checkpoint.
         assert!(
-            tree_exceeds_checkpoint(correctness_checkpoint, &tree),
+            tree_exceeds_checkpoint(correctness_checkpoint, tree),
             "tree (count: {}) is ahead of correctness checkpoint {:?}",
             tree.count(),
             correctness_checkpoint,

--- a/rust/agents/validator/src/validator.rs
+++ b/rust/agents/validator/src/validator.rs
@@ -174,6 +174,9 @@ impl Validator {
             .tree(reorg_period)
             .await
             .expect("failed to get merkle tree");
+        // This function is only called after we have already checked that the
+        // merkle tree hook has count > 0, but we assert to be extra sure this is
+        // the case.
         assert!(tip_tree.count() > 0, "merkle tree is empty");
         let backfill_target = submitter.checkpoint(&tip_tree);
 

--- a/rust/chains/hyperlane-ethereum/src/interchain_gas.rs
+++ b/rust/chains/hyperlane-ethereum/src/interchain_gas.rs
@@ -31,7 +31,7 @@ where
 
 pub struct InterchainGasPaymasterIndexerBuilder {
     pub mailbox_address: H160,
-    pub finality_blocks: u32,
+    pub reorg_period: u32,
 }
 
 #[async_trait]
@@ -46,7 +46,7 @@ impl BuildableWithProvider for InterchainGasPaymasterIndexerBuilder {
         Box::new(EthereumInterchainGasPaymasterIndexer::new(
             Arc::new(provider),
             locator,
-            self.finality_blocks,
+            self.reorg_period,
         ))
     }
 }
@@ -59,7 +59,7 @@ where
 {
     contract: Arc<EthereumInterchainGasPaymasterInternal<M>>,
     provider: Arc<M>,
-    finality_blocks: u32,
+    reorg_period: u32,
 }
 
 impl<M> EthereumInterchainGasPaymasterIndexer<M>
@@ -67,14 +67,14 @@ where
     M: Middleware + 'static,
 {
     /// Create new EthereumInterchainGasPaymasterIndexer
-    pub fn new(provider: Arc<M>, locator: &ContractLocator, finality_blocks: u32) -> Self {
+    pub fn new(provider: Arc<M>, locator: &ContractLocator, reorg_period: u32) -> Self {
         Self {
             contract: Arc::new(EthereumInterchainGasPaymasterInternal::new(
                 locator.address,
                 provider.clone(),
             )),
             provider,
-            finality_blocks,
+            reorg_period,
         }
     }
 }
@@ -121,7 +121,7 @@ where
             .await
             .map_err(ChainCommunicationError::from_other)?
             .as_u32()
-            .saturating_sub(self.finality_blocks))
+            .saturating_sub(self.reorg_period))
     }
 }
 

--- a/rust/chains/hyperlane-ethereum/src/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/mailbox.rs
@@ -35,7 +35,7 @@ where
 }
 
 pub struct SequenceIndexerBuilder {
-    pub finality_blocks: u32,
+    pub reorg_period: u32,
 }
 
 #[async_trait]
@@ -50,13 +50,13 @@ impl BuildableWithProvider for SequenceIndexerBuilder {
         Box::new(EthereumMailboxIndexer::new(
             Arc::new(provider),
             locator,
-            self.finality_blocks,
+            self.reorg_period,
         ))
     }
 }
 
 pub struct DeliveryIndexerBuilder {
-    pub finality_blocks: u32,
+    pub reorg_period: u32,
 }
 
 #[async_trait]
@@ -71,7 +71,7 @@ impl BuildableWithProvider for DeliveryIndexerBuilder {
         Box::new(EthereumMailboxIndexer::new(
             Arc::new(provider),
             locator,
-            self.finality_blocks,
+            self.reorg_period,
         ))
     }
 }
@@ -84,7 +84,7 @@ where
 {
     contract: Arc<EthereumMailboxInternal<M>>,
     provider: Arc<M>,
-    finality_blocks: u32,
+    reorg_period: u32,
 }
 
 impl<M> EthereumMailboxIndexer<M>
@@ -92,7 +92,7 @@ where
     M: Middleware + 'static,
 {
     /// Create new EthereumMailboxIndexer
-    pub fn new(provider: Arc<M>, locator: &ContractLocator, finality_blocks: u32) -> Self {
+    pub fn new(provider: Arc<M>, locator: &ContractLocator, reorg_period: u32) -> Self {
         let contract = Arc::new(EthereumMailboxInternal::new(
             locator.address,
             provider.clone(),
@@ -100,7 +100,7 @@ where
         Self {
             contract,
             provider,
-            finality_blocks,
+            reorg_period,
         }
     }
 
@@ -112,7 +112,7 @@ where
             .await
             .map_err(ChainCommunicationError::from_other)?
             .as_u32()
-            .saturating_sub(self.finality_blocks))
+            .saturating_sub(self.reorg_period))
     }
 }
 

--- a/rust/chains/hyperlane-ethereum/src/merkle_tree_hook.rs
+++ b/rust/chains/hyperlane-ethereum/src/merkle_tree_hook.rs
@@ -52,7 +52,7 @@ impl BuildableWithProvider for MerkleTreeHookBuilder {
 }
 
 pub struct MerkleTreeHookIndexerBuilder {
-    pub finality_blocks: u32,
+    pub reorg_period: u32,
 }
 
 #[async_trait]
@@ -67,7 +67,7 @@ impl BuildableWithProvider for MerkleTreeHookIndexerBuilder {
         Box::new(EthereumMerkleTreeHookIndexer::new(
             Arc::new(provider),
             locator,
-            self.finality_blocks,
+            self.reorg_period,
         ))
     }
 }
@@ -80,7 +80,7 @@ where
 {
     contract: Arc<MerkleTreeHookContract<M>>,
     provider: Arc<M>,
-    finality_blocks: u32,
+    reorg_period: u32,
 }
 
 impl<M> EthereumMerkleTreeHookIndexer<M>
@@ -88,14 +88,14 @@ where
     M: Middleware + 'static,
 {
     /// Create new EthereumMerkleTreeHookIndexer
-    pub fn new(provider: Arc<M>, locator: &ContractLocator, finality_blocks: u32) -> Self {
+    pub fn new(provider: Arc<M>, locator: &ContractLocator, reorg_period: u32) -> Self {
         Self {
             contract: Arc::new(MerkleTreeHookContract::new(
                 locator.address,
                 provider.clone(),
             )),
             provider,
-            finality_blocks,
+            reorg_period,
         }
     }
 }
@@ -138,7 +138,7 @@ where
             .await
             .map_err(ChainCommunicationError::from_other)?
             .as_u32()
-            .saturating_sub(self.finality_blocks))
+            .saturating_sub(self.reorg_period))
     }
 }
 

--- a/rust/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -1,10 +1,6 @@
-use std::future::Future;
-use std::time::Duration;
-
 use async_trait::async_trait;
 use eyre::Result;
 use paste::paste;
-use tokio::time::sleep;
 use tracing::{debug, instrument, trace};
 
 use hyperlane_core::{
@@ -105,20 +101,6 @@ impl HyperlaneRocksDB {
         match id {
             None => Ok(None),
             Some(id) => self.retrieve_message_by_id(&id),
-        }
-    }
-
-    // TODO(james): this is a quick-fix for the prover_sync and I don't like it
-    /// poll db ever 100 milliseconds waiting for a leaf.
-    pub fn wait_for_message_nonce(&self, nonce: u32) -> impl Future<Output = DbResult<H256>> {
-        let slf = self.clone();
-        async move {
-            loop {
-                if let Some(id) = slf.retrieve_message_id_by_nonce(&nonce)? {
-                    return Ok(id);
-                }
-                sleep(Duration::from_millis(100)).await
-            }
         }
     }
 

--- a/rust/hyperlane-base/src/settings/chains.rs
+++ b/rust/hyperlane-base/src/settings/chains.rs
@@ -32,8 +32,8 @@ pub struct ChainConf {
     pub domain: HyperlaneDomain,
     /// Signer configuration for this chain
     pub signer: Option<SignerConf>,
-    /// Number of blocks until finality
-    pub finality_blocks: u32,
+    /// The reorg period of the chain, i.e. the number of blocks until finality
+    pub reorg_period: u32,
     /// Addresses of contracts on the chain
     pub addresses: CoreContractAddresses,
     /// The chain connection details
@@ -188,7 +188,7 @@ impl ChainConf {
                     &locator,
                     metrics,
                     h_eth::SequenceIndexerBuilder {
-                        finality_blocks: self.finality_blocks,
+                        reorg_period: self.reorg_period,
                     },
                 )
                 .await
@@ -218,7 +218,7 @@ impl ChainConf {
                     &locator,
                     metrics,
                     h_eth::DeliveryIndexerBuilder {
-                        finality_blocks: self.finality_blocks,
+                        reorg_period: self.reorg_period,
                     },
                 )
                 .await
@@ -280,7 +280,7 @@ impl ChainConf {
                     metrics,
                     h_eth::InterchainGasPaymasterIndexerBuilder {
                         mailbox_address: self.addresses.mailbox.into(),
-                        finality_blocks: self.finality_blocks,
+                        reorg_period: self.reorg_period,
                     },
                 )
                 .await
@@ -316,7 +316,7 @@ impl ChainConf {
                     &locator,
                     metrics,
                     h_eth::MerkleTreeHookIndexerBuilder {
-                        finality_blocks: self.finality_blocks,
+                        reorg_period: self.reorg_period,
                     },
                 )
                 .await

--- a/rust/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/hyperlane-base/src/settings/parser/mod.rs
@@ -125,10 +125,10 @@ fn parse_chain(
         .and_then(parse_signer)
         .end();
 
-    let finality_blocks = chain
+    let reorg_period = chain
         .chain(&mut err)
         .get_opt_key("blocks")
-        .get_key("confirmations")
+        .get_key("reorgPeriod")
         .parse_u32()
         .unwrap_or(1);
 
@@ -263,7 +263,7 @@ fn parse_chain(
     err.into_result(ChainConf {
         domain,
         signer,
-        finality_blocks,
+        reorg_period,
         addresses: CoreContractAddresses {
             mailbox,
             interchain_gas_paymaster,


### PR DESCRIPTION
### Description

* https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/532 wasn't actually fully closed out - finality_blocks was used still for indexing. Sadly testnet4 infra wasn't configuring finality blocks anymore, so we weren't indexing only finalized blocks. Moved fully to reorg_period
* Refactored `checkpoint_submitter` in light of races revealed by the above ^ problem. It used to assume that message indexing and the `latest_checkpoint()` call would align with one another, and wasn't resilient to the tree already being past the correctness checkpoint. A couple situations were possible before that aren't now:
  a. Indexing is ahead of the latest_checkpoint() call, which will result in tree ingesting the new indexed messages and the tree being ahead of the correctness checkpoint :(
  b. It's possible for the tree() call that constructs the tree initially to be made against a block that's after the next latest_checkpoint() call, which would result in the tree being ahead of the correctness checkpoint from the very beginning :(

### Drive-by changes

removed a function that wasn't being used anymore

### Related issues

https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/532

### Backward compatibility

Removes finality blocks entirely

### Testing

Builds, e2e
