### PR TITLE
refactor: finish removing unwraps

### DIFF
--- a/rust/chains/hyperlane-cosmos/src/aggregation_ism.rs
+++ b/rust/chains/hyperlane-cosmos/src/aggregation_ism.rs
@@ -60,8 +60,9 @@ impl AggregationIsm for CosmosAggregationIsm {
         let data = self.provider.wasm_query(payload, None).await?;
         let response: ModulesAndThresholdResponse = serde_json::from_slice(&data)?;
 
-        let modules: Vec<H256> = response.modules.into_iter().map(bech32_decode).collect();
+        let modules: ChainResult<Vec<H256>> =
+            response.modules.into_iter().map(bech32_decode).collect();
 
-        Ok((modules, response.threshold))
+        Ok((modules?, response.threshold))
     }
 }

--- a/rust/chains/hyperlane-cosmos/src/error.rs
+++ b/rust/chains/hyperlane-cosmos/src/error.rs
@@ -1,0 +1,22 @@
+// use bech32::Error;
+use hyperlane_core::ChainCommunicationError;
+
+/// Errors from the crates specific to the hyperlane-cosmos
+/// implementation.
+/// This error can then be converted into the broader error type
+/// in hyperlane-core using the `From` trait impl
+#[derive(Debug, thiserror::Error)]
+pub enum HyperlaneCosmosError {
+    /// bech32 error
+    #[error("{0}")]
+    Bech32(#[from] bech32::Error),
+    /// gRPC error
+    #[error("{0}")]
+    GrpcError(#[from] tonic::Status),
+}
+
+impl From<HyperlaneCosmosError> for ChainCommunicationError {
+    fn from(value: HyperlaneCosmosError) -> Self {
+        ChainCommunicationError::from_other(value)
+    }
+}

--- a/rust/chains/hyperlane-cosmos/src/error.rs
+++ b/rust/chains/hyperlane-cosmos/src/error.rs
@@ -1,4 +1,3 @@
-// use bech32::Error;
 use hyperlane_core::ChainCommunicationError;
 
 /// Errors from the crates specific to the hyperlane-cosmos

--- a/rust/chains/hyperlane-cosmos/src/lib.rs
+++ b/rust/chains/hyperlane-cosmos/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(unused_variables)]
 
 mod aggregation_ism;
+mod error;
 mod interchain_gas;
 mod interchain_security_module;
 mod libs;
@@ -21,10 +22,7 @@ mod utils;
 mod validator_announce;
 
 pub use self::{
-    aggregation_ism::*, interchain_gas::*, interchain_security_module::*, libs::*, mailbox::*,
-    merkle_tree_hook::*, multisig_ism::*, providers::*, routing_ism::*, signers::*,
+    aggregation_ism::*, error::*, interchain_gas::*, interchain_security_module::*, libs::*,
+    mailbox::*, merkle_tree_hook::*, multisig_ism::*, providers::*, routing_ism::*, signers::*,
     trait_builder::*, trait_builder::*, validator_announce::*, validator_announce::*,
 };
-
-/// Safe default imports of commonly used traits/types.
-pub mod prelude {}

--- a/rust/chains/hyperlane-cosmos/src/libs/verify.rs
+++ b/rust/chains/hyperlane-cosmos/src/libs/verify.rs
@@ -6,17 +6,20 @@ use hyperlane_core::{ChainCommunicationError, ChainResult, H160, H256};
 use ripemd::Ripemd160;
 use sha2::{Digest, Sha256};
 
-/// decode bech32 address to H256
-pub fn bech32_decode(addr: String) -> H256 {
-    let (_hrp, data, _variant) = bech32::decode(addr.as_str()).unwrap();
+use crate::HyperlaneCosmosError;
 
-    let value = Vec::<u8>::from_base32(&data).unwrap();
+/// decode bech32 address to H256
+pub fn bech32_decode(addr: String) -> ChainResult<H256> {
+    let (_hrp, data, _variant) =
+        bech32::decode(addr.as_str()).map_err(Into::<HyperlaneCosmosError>::into)?;
+
+    let value = Vec::<u8>::from_base32(&data).map_err(Into::<HyperlaneCosmosError>::into)?;
     let mut result: [u8; 32] = [0; 32];
 
     let start_point = cmp::max(0, 32 - value.len());
     result[start_point..32].copy_from_slice(value.as_slice());
 
-    H256::from(result)
+    Ok(H256::from(result))
 }
 
 /// encode H256 to bech32 address
@@ -81,8 +84,7 @@ pub fn pub_to_addr(pub_key: Vec<u8>, prefix: &str) -> ChainResult<String> {
 /// encode H256 to bech32 address
 pub fn priv_to_binary_addr(priv_key: Vec<u8>) -> ChainResult<H160> {
     let sha_hash = sha256_digest(
-        SigningKey::from_slice(priv_key.as_slice())
-            .unwrap()
+        SigningKey::from_slice(priv_key.as_slice())?
             .public_key()
             .to_bytes(),
     )?;
@@ -94,8 +96,7 @@ pub fn priv_to_binary_addr(priv_key: Vec<u8>) -> ChainResult<H160> {
 /// encode H256 to bech32 address
 pub fn priv_to_addr_string(prefix: String, priv_key: Vec<u8>) -> ChainResult<String> {
     let sha_hash = sha256_digest(
-        SigningKey::from_slice(priv_key.as_slice())
-            .unwrap()
+        SigningKey::from_slice(priv_key.as_slice())?
             .public_key()
             .to_bytes(),
     )?;

--- a/rust/chains/hyperlane-cosmos/src/mailbox.rs
+++ b/rust/chains/hyperlane-cosmos/src/mailbox.rs
@@ -149,7 +149,7 @@ impl Mailbox for CosmosMailbox {
         let response: mailbox::RecipientIsmResponse = serde_json::from_slice(&data)?;
 
         // convert Hex to H256
-        let ism = verify::bech32_decode(response.ism);
+        let ism = verify::bech32_decode(response.ism)?;
         Ok(ism)
     }
 

--- a/rust/chains/hyperlane-cosmos/src/merkle_tree_hook.rs
+++ b/rust/chains/hyperlane-cosmos/src/merkle_tree_hook.rs
@@ -4,9 +4,9 @@ use async_trait::async_trait;
 use base64::Engine;
 use cosmrs::tendermint::abci::EventAttribute;
 use hyperlane_core::{
-    accumulator::incremental::IncrementalMerkle, ChainResult, Checkpoint, ContractLocator,
-    HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneProvider, Indexer, LogMeta,
-    MerkleTreeHook, MerkleTreeInsertion, SequenceIndexer, H256,
+    accumulator::incremental::IncrementalMerkle, ChainCommunicationError, ChainResult, Checkpoint,
+    ContractLocator, HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneProvider,
+    Indexer, LogMeta, MerkleTreeHook, MerkleTreeInsertion, SequenceIndexer, H256,
 };
 use tracing::instrument;
 
@@ -94,12 +94,11 @@ impl MerkleTreeHook for CosmosMerkleTreeHook {
             .iter()
             .map(|s| s.as_str())
             .map(H256::from_str)
-            .collect::<Result<Vec<H256>, _>>()
-            .expect("fail to parse tree branch");
+            .collect::<Result<Vec<H256>, _>>()?;
 
-        let branch_res: [H256; 32] = branch
-            .try_into()
-            .expect("fail to convert tree branch to array");
+        let branch_res: [H256; 32] = branch.try_into().map_err(|_| {
+            ChainCommunicationError::from_other_str("Failed to build merkle branch array")
+        })?;
 
         Ok(IncrementalMerkle::new(branch_res, response.count as usize))
     }

--- a/rust/chains/hyperlane-cosmos/src/merkle_tree_hook.rs
+++ b/rust/chains/hyperlane-cosmos/src/merkle_tree_hook.rs
@@ -149,7 +149,7 @@ impl MerkleTreeHook for CosmosMerkleTreeHook {
         Ok(Checkpoint {
             merkle_tree_hook_address: self.address,
             mailbox_domain: self.domain.id(),
-            root: response.root.parse().unwrap(),
+            root: response.root.parse()?,
             index: response.count,
         })
     }

--- a/rust/chains/hyperlane-cosmos/src/multisig_ism.rs
+++ b/rust/chains/hyperlane-cosmos/src/multisig_ism.rs
@@ -75,12 +75,12 @@ impl MultisigIsm for CosmosMultisigIsm {
             .await?;
         let response: multisig_ism::VerifyInfoResponse = serde_json::from_slice(&data)?;
 
-        let validators: Vec<H256> = response
+        let validators: ChainResult<Vec<H256>> = response
             .validators
             .iter()
-            .map(|v| h160_to_h256(H160::from_str(v).unwrap()))
+            .map(|v| H160::from_str(v).map(h160_to_h256).map_err(Into::into))
             .collect();
 
-        Ok((validators, response.threshold))
+        Ok((validators?, response.threshold))
     }
 }

--- a/rust/chains/hyperlane-cosmos/src/providers/rpc.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/rpc.rs
@@ -125,7 +125,7 @@ impl WasmIndexer for CosmosWasmIndexer {
             let target_type = format!("{}-{}", Self::WASM_TYPE, self.event_type);
 
             // Get BlockHash from block_search
-            let client = self.get_client().unwrap();
+            let client = self.get_client()?;
 
             for tx in txs {
                 if tx.tx_result.code.is_err() {
@@ -139,7 +139,7 @@ impl WasmIndexer for CosmosWasmIndexer {
                     if event.kind.as_str() == target_type {
                         if let Some(msg) = parser(event.attributes.clone())? {
                             let meta = LogMeta {
-                                address: bech32_decode(contract_address.clone()),
+                                address: bech32_decode(contract_address.clone())?,
                                 block_number: tx.height.value(),
                                 // FIXME: block_hash is not available in tx_search
                                 block_hash: H256::zero(),

--- a/rust/chains/hyperlane-cosmos/src/routing_ism.rs
+++ b/rust/chains/hyperlane-cosmos/src/routing_ism.rs
@@ -72,6 +72,6 @@ impl RoutingIsm for CosmosRoutingIsm {
             .await?;
         let response: IsmRouteRespnose = serde_json::from_slice(&data)?;
 
-        Ok(bech32_decode(response.ism))
+        Ok(bech32_decode(response.ism)?)
     }
 }

--- a/rust/chains/hyperlane-cosmos/src/signers.rs
+++ b/rust/chains/hyperlane-cosmos/src/signers.rs
@@ -1,33 +1,59 @@
-use cosmrs::crypto::secp256k1::SigningKey;
+use cosmrs::crypto::{secp256k1::SigningKey, PublicKey};
+use hyperlane_core::ChainResult;
 
 use crate::verify;
 
 #[derive(Clone, Debug)]
 /// Signer for cosmos chain
 pub struct Signer {
-    /// prefix for signer address
+    /// public key
+    pub public_key: PublicKey,
+    /// precomputed address, because computing it is a fallible operation
+    /// and we want to avoid returning `Result`
+    pub address: String,
+    /// address prefix
     pub prefix: String,
-    pub(crate) private_key: Vec<u8>,
+    private_key: Vec<u8>,
 }
 
 impl Signer {
     /// create new signer
-    pub fn new(private_key: Vec<u8>, prefix: String) -> Self {
-        Self {
+    ///
+    /// # Arguments
+    /// * `private_key` - private key for signer
+    /// * `prefix` - prefix for signer address
+    pub fn new(private_key: Vec<u8>, prefix: String) -> ChainResult<Self> {
+        let address = Self::address(&private_key, &prefix)?;
+
+        let signing_key = Self::build_signing_key(&private_key)?;
+        SigningKey::from_slice(&private_key)?;
+        let public_key = signing_key.public_key();
+        Ok(Self {
+            public_key,
             private_key,
+            address,
             prefix,
-        }
+        })
     }
 
     /// get bech32 address
-    pub fn address(&self) -> String {
-        verify::pub_to_addr(
-            SigningKey::from_slice(self.private_key.as_slice())
-                .unwrap()
+    fn address(private_key: &Vec<u8>, prefix: &str) -> ChainResult<String> {
+        let address = verify::pub_to_addr(
+            SigningKey::from_slice(private_key.as_slice())?
                 .public_key()
                 .to_bytes(),
-            self.prefix.as_str(),
-        )
-        .unwrap()
+            prefix,
+        )?;
+        Ok(address)
+    }
+
+    /// Build a SigningKey from a private key. This cannot be
+    /// precompiled and stored in `Signer`, because `SigningKey` is not `Sync`.
+    pub fn signing_key(&self) -> ChainResult<SigningKey> {
+        Self::build_signing_key(&self.private_key)
+    }
+
+    fn build_signing_key(private_key: &Vec<u8>) -> ChainResult<SigningKey> {
+        Ok(SigningKey::from_slice(private_key.as_slice())?)
     }
 }

--- a/rust/chains/hyperlane-cosmos/src/validator_announce.rs
+++ b/rust/chains/hyperlane-cosmos/src/validator_announce.rs
@@ -123,8 +123,7 @@ impl ValidatorAnnounce for CosmosValidatorAnnounce {
             .await?;
 
         Ok(TxOutcome {
-            transaction_id: H256::from_slice(hex::decode(response.txhash).unwrap().as_slice())
-                .into(),
+            transaction_id: H256::from_slice(hex::decode(response.txhash)?.as_slice()).into(),
             executed: response.code == 0,
             gas_used: U256::from(response.gas_used),
             gas_price: U256::from(response.gas_wanted),

--- a/rust/hyperlane-base/src/settings/signers.rs
+++ b/rust/hyperlane-base/src/settings/signers.rs
@@ -152,7 +152,7 @@ impl BuildableWithSignerConf for hyperlane_cosmos::Signer {
             SignerConf::HexKey { .. } => bail!("HexKey signer is not supported by cosmos"),
             SignerConf::Aws { .. } => bail!("Aws signer is not supported by cosmos"),
             SignerConf::CosmosKey { key, prefix } => {
-                hyperlane_cosmos::Signer::new(key.as_bytes().to_vec(), prefix.clone())
+                hyperlane_cosmos::Signer::new(key.as_bytes().to_vec(), prefix.clone())?
             }
             SignerConf::Node => bail!("Node signer is not supported by cosmos"),
         })
@@ -161,6 +161,6 @@ impl BuildableWithSignerConf for hyperlane_cosmos::Signer {
 
 impl ChainSigner for hyperlane_cosmos::Signer {
     fn address_string(&self) -> String {
-        self.address()
+        self.address.clone()
     }
 }

--- a/rust/hyperlane-core/src/error.rs
+++ b/rust/hyperlane-core/src/error.rs
@@ -6,6 +6,7 @@ use std::ops::Deref;
 use crate::config::StrOrIntParseError;
 use cosmrs::proto::prost;
 use cosmrs::Error as CosmrsError;
+// use fixed_hash::rustc_hex::FromHexError;
 use std::string::FromUtf8Error;
 
 use crate::HyperlaneProviderError;
@@ -124,6 +125,9 @@ pub enum ChainCommunicationError {
     /// Int string parsing error
     #[error("{0}")]
     ParseIntError(#[from] std::num::ParseIntError),
+    /// Hash string parsing error
+    #[error("{0}")]
+    HashParsingError(#[from] fixed_hash::rustc_hex::FromHexError),
     /// Invalid Request
     #[error("Invalid Request: {msg:?}")]
     InvalidRequest {

--- a/rust/hyperlane-core/src/error.rs
+++ b/rust/hyperlane-core/src/error.rs
@@ -6,7 +6,6 @@ use std::ops::Deref;
 use crate::config::StrOrIntParseError;
 use cosmrs::proto::prost;
 use cosmrs::Error as CosmrsError;
-// use fixed_hash::rustc_hex::FromHexError;
 use std::string::FromUtf8Error;
 
 use crate::HyperlaneProviderError;


### PR DESCRIPTION
### Description

- Removes unwraps and expects from everywhere but `run-locally`
- Precomputes the `address` in `Signer` at construction time, to propagate the error early and keep signatures ergonomic by not requiring a `Result`. Couldn't also precompile `SigningKey` (the privkey type) because it's not `Sync` 😢
- Defines a `hyperlane-cosmos`-specific error enum (`HyperlaneCosmosError`), which can be converted to `ChainCommunicationError` with the `?` operator. This is a pattern we'd like to refactor towards in the future, to remove dependencies from `hyperlane-core` as much as possible
  - One inconvenience is that you need to `.map_err()` to `HyperlaneCosmosError` first, to use `?`. I wish `?` had deref coercion semantics where it'd keep covnerting until an error matches, but I assume this isn't possible because while you can only have a single `Deref` impl, you can have multiple `From<Err>` impls. 
  - Writing this I'm realising we could write a small macro to implement `From<Err> for ChainCommunicationError` for all the sub-errors of `HyperlaneCosmosError` et al (cc @tkporter)
