### PR TITLE
Ignore constructor and immutable OZ plugin errors

### DIFF
--- a/solidity/contracts/client/MailboxClient.sol
+++ b/solidity/contracts/client/MailboxClient.sol
@@ -14,8 +14,10 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 abstract contract MailboxClient is OwnableUpgradeable {
     using Message for bytes;
 
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IMailbox public immutable mailbox;
 
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     uint32 public immutable localDomain;
 
     IPostDispatchHook public hook;
@@ -50,6 +52,7 @@ abstract contract MailboxClient is OwnableUpgradeable {
         _;
     }
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _mailbox) onlyContract(_mailbox) {
         mailbox = IMailbox(_mailbox);
         localDomain = mailbox.localDomain();

--- a/solidity/contracts/client/Router.sol
+++ b/solidity/contracts/client/Router.sol
@@ -21,6 +21,7 @@ abstract contract Router is MailboxClient, IMessageRecipient {
 
     uint256[48] private __GAP; // gap for upgrade safety
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _mailbox) MailboxClient(_mailbox) {}
 
     // ============ External functions ============


### PR DESCRIPTION
The OpenZeppelin upgrade plugin will fail to deploy the Router contract because of the following errors:

```
@hyperlane-xyz/core/contracts/client/Router.sol:24: Contract `Router` has a constructor
    Define an initializer instead
    https://zpl.in/upgrades/error-001

@hyperlane-xyz/core/contracts/client/MailboxClient.sol:53: Contract `MailboxClient` has a constructor
    Define an initializer instead
    https://zpl.in/upgrades/error-001

@hyperlane-xyz/core/contracts/client/MailboxClient.sol:17: Variable `mailbox` is immutable
    Use a constant or mutable variable instead
    https://zpl.in/upgrades/error-005

@hyperlane-xyz/core/contracts/client/MailboxClient.sol:19: Variable `localDomain` is immutable
    Use a constant or mutable variable instead
    https://zpl.in/upgrades/error-005
```

All of these errors can be ignored as the constructors are used to set the immutables and the immutables can be read by the proxy w/o an issue.
