### PR TITLE
Correctly consider reorg period when indexing, set reorg period to 1 on Neutron

### DIFF
--- a/rust/chains/hyperlane-cosmos/src/interchain_gas.rs
+++ b/rust/chains/hyperlane-cosmos/src/interchain_gas.rs
@@ -59,8 +59,14 @@ pub struct CosmosInterchainGasPaymasterIndexer {
 
 impl CosmosInterchainGasPaymasterIndexer {
     /// create new Cosmos InterchainGasPaymasterIndexer agent
-    pub fn new(conf: ConnectionConf, locator: ContractLocator, event_type: String) -> Self {
-        let indexer: CosmosWasmIndexer = CosmosWasmIndexer::new(conf, locator, event_type.clone());
+    pub fn new(
+        conf: ConnectionConf,
+        locator: ContractLocator,
+        event_type: String,
+        reorg_period: u32,
+    ) -> Self {
+        let indexer: CosmosWasmIndexer =
+            CosmosWasmIndexer::new(conf, locator, event_type.clone(), reorg_period);
 
         Self {
             indexer: Box::new(indexer),
@@ -123,7 +129,7 @@ impl Indexer<InterchainGasPayment> for CosmosInterchainGasPaymasterIndexer {
     }
 
     async fn get_finalized_block_number(&self) -> ChainResult<u32> {
-        self.indexer.latest_block_height().await
+        self.indexer.get_finalized_block_number().await
     }
 }
 
@@ -131,7 +137,7 @@ impl Indexer<InterchainGasPayment> for CosmosInterchainGasPaymasterIndexer {
 impl SequenceIndexer<InterchainGasPayment> for CosmosInterchainGasPaymasterIndexer {
     async fn sequence_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
         // TODO: implement when cosmwasm scraper support is implemented
-        let tip = self.indexer.latest_block_height().await?;
+        let tip = self.get_finalized_block_number().await?;
         Ok((None, tip))
     }
 }

--- a/rust/chains/hyperlane-cosmos/src/mailbox.rs
+++ b/rust/chains/hyperlane-cosmos/src/mailbox.rs
@@ -326,7 +326,7 @@ impl Indexer<H256> for CosmosMailboxIndexer {
 #[async_trait]
 impl SequenceIndexer<H256> for CosmosMailboxIndexer {
     async fn sequence_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        let tip = self.indexer.get_finalized_block_number().await?;
+        let tip = Indexer::<H256>::get_finalized_block_number(&self).await?;
 
         // No sequence for message deliveries.
         Ok((None, tip))

--- a/rust/chains/hyperlane-cosmos/src/mailbox.rs
+++ b/rust/chains/hyperlane-cosmos/src/mailbox.rs
@@ -249,9 +249,11 @@ impl CosmosMailboxIndexer {
         locator: ContractLocator,
         signer: Signer,
         event_type: String,
+        reorg_period: u32,
     ) -> Self {
         let mailbox = CosmosMailbox::new(conf.clone(), locator.clone(), signer.clone());
-        let indexer: CosmosWasmIndexer = CosmosWasmIndexer::new(conf, locator, event_type);
+        let indexer: CosmosWasmIndexer =
+            CosmosWasmIndexer::new(conf, locator, event_type, reorg_period);
 
         Self {
             mailbox,
@@ -300,7 +302,7 @@ impl Indexer<HyperlaneMessage> for CosmosMailboxIndexer {
     }
 
     async fn get_finalized_block_number(&self) -> ChainResult<u32> {
-        self.indexer.latest_block_height().await
+        self.indexer.get_finalized_block_number().await
     }
 }
 
@@ -317,14 +319,14 @@ impl Indexer<H256> for CosmosMailboxIndexer {
     }
 
     async fn get_finalized_block_number(&self) -> ChainResult<u32> {
-        self.indexer.latest_block_height().await
+        self.indexer.get_finalized_block_number().await
     }
 }
 
 #[async_trait]
 impl SequenceIndexer<H256> for CosmosMailboxIndexer {
     async fn sequence_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        let tip = self.indexer.latest_block_height().await?;
+        let tip = self.indexer.get_finalized_block_number().await?;
 
         // No sequence for message deliveries.
         Ok((None, tip))
@@ -334,7 +336,7 @@ impl SequenceIndexer<H256> for CosmosMailboxIndexer {
 #[async_trait]
 impl SequenceIndexer<HyperlaneMessage> for CosmosMailboxIndexer {
     async fn sequence_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        let tip = self.indexer.latest_block_height().await?;
+        let tip = Indexer::<HyperlaneMessage>::get_finalized_block_number(&self).await?;
 
         let sequence = self.mailbox.nonce_at_block(Some(tip.into())).await?;
 

--- a/rust/chains/hyperlane-cosmos/src/merkle_tree_hook.rs
+++ b/rust/chains/hyperlane-cosmos/src/merkle_tree_hook.rs
@@ -160,16 +160,16 @@ const EVENT_TYPE: &str = "hpl_hook_merkle::post_dispatch";
 
 #[derive(Debug)]
 /// A reference to a MerkleTreeHookIndexer contract on some Cosmos chain
-pub struct CosmosMerkleeTreeHookIndexer {
+pub struct CosmosMerkleTreeHookIndexer {
     /// Cosmwasm indexer instance
     indexer: Box<CosmosWasmIndexer>,
 }
 
-impl CosmosMerkleeTreeHookIndexer {
+impl CosmosMerkleTreeHookIndexer {
     /// create new Cosmos MerkleTreeHookIndexer agent
-    pub fn new(conf: ConnectionConf, locator: ContractLocator) -> Self {
+    pub fn new(conf: ConnectionConf, locator: ContractLocator, reorg_period: u32) -> Self {
         let indexer: CosmosWasmIndexer =
-            CosmosWasmIndexer::new(conf, locator, EVENT_TYPE.to_string());
+            CosmosWasmIndexer::new(conf, locator, EVENT_TYPE.to_string(), reorg_period);
 
         Self {
             indexer: Box::new(indexer),
@@ -229,7 +229,7 @@ impl CosmosMerkleeTreeHookIndexer {
 }
 
 #[async_trait]
-impl Indexer<MerkleTreeInsertion> for CosmosMerkleeTreeHookIndexer {
+impl Indexer<MerkleTreeInsertion> for CosmosMerkleTreeHookIndexer {
     /// Fetch list of logs between `range` of blocks
     async fn fetch_logs(
         &self,
@@ -243,15 +243,15 @@ impl Indexer<MerkleTreeInsertion> for CosmosMerkleeTreeHookIndexer {
 
     /// Get the chain's latest block number that has reached finality
     async fn get_finalized_block_number(&self) -> ChainResult<u32> {
-        self.indexer.latest_block_height().await
+        self.indexer.get_finalized_block_number().await
     }
 }
 
 #[async_trait]
-impl SequenceIndexer<MerkleTreeInsertion> for CosmosMerkleeTreeHookIndexer {
+impl SequenceIndexer<MerkleTreeInsertion> for CosmosMerkleTreeHookIndexer {
     async fn sequence_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
         // TODO: implement when cosmos scraper support is implemented
-        let tip = self.indexer.latest_block_height().await?;
+        let tip = self.get_finalized_block_number().await?;
         Ok((None, tip))
     }
 }

--- a/rust/config/mainnet3_config.json
+++ b/rust/config/mainnet3_config.json
@@ -862,6 +862,9 @@
         "from": 4000000,
         "chunk": 100000
       },
+      "blocks": {
+        "reorgPeriod": 1
+      },
       "signer": {
         "type": "cosmosKey",
         "key": "0x5486418967eabc770b0fcb995f7ef6d9a72f7fc195531ef76c5109f44f51af26",

--- a/rust/config/testnet4_config.json
+++ b/rust/config/testnet4_config.json
@@ -990,6 +990,9 @@
       "index": {
         "from": 1,
         "chunk": 1000
+      },
+      "blocks": {
+        "reorgPeriod": 1
       }
     }
   },

--- a/rust/hyperlane-base/src/settings/chains.rs
+++ b/rust/hyperlane-base/src/settings/chains.rs
@@ -229,6 +229,7 @@ impl ChainConf {
                     locator,
                     signer.clone(),
                     "mailbox_dispatch".to_string(),
+                    self.reorg_period,
                 ));
                 Ok(indexer as Box<dyn SequenceIndexer<HyperlaneMessage>>)
             }
@@ -268,6 +269,7 @@ impl ChainConf {
                     locator,
                     signer,
                     "mailbox_process".to_string(),
+                    self.reorg_period,
                 ));
                 Ok(indexer as Box<dyn SequenceIndexer<H256>>)
             }
@@ -347,6 +349,7 @@ impl ChainConf {
                     conf.clone(),
                     locator,
                     "igp-core-pay-for-gas".to_string(),
+                    self.reorg_period,
                 ));
                 Ok(indexer as Box<dyn SequenceIndexer<InterchainGasPayment>>)
             }
@@ -384,9 +387,10 @@ impl ChainConf {
                 Ok(indexer as Box<dyn SequenceIndexer<MerkleTreeInsertion>>)
             }
             ChainConnectionConf::Cosmos(conf) => {
-                let indexer = Box::new(h_cosmos::CosmosMerkleeTreeHookIndexer::new(
+                let indexer = Box::new(h_cosmos::CosmosMerkleTreeHookIndexer::new(
                     conf.clone(),
                     locator,
+                    self.reorg_period,
                 ));
                 Ok(indexer as Box<dyn SequenceIndexer<MerkleTreeInsertion>>)
             }


### PR DESCRIPTION
### Description

Hopeful quick fix to indexing issues we're seeing. Leading theory is that the tx_search is asking for a block range that the servicing RPC node doesn't actually have state for.

Curious if @nambrot you feel we should go with a more conservative reorg period, maybe 2 blocks?

My personal theory is that this isn't just bad RPC load balancing, but that the tip that's returned is simply committed to but the state transition hasn't yet been executed, see https://github.com/CosmWasm/cosmwasm/blob/main/SEMANTICS.md#sdk-context

> First, the Tendermint engine will seek 2/3+ consensus on a list of transactions to be included in the next block. This is done without executing them. They are simply subjected to a minimal pre-filter by the Cosmos SDK module, to ensure they are validly formatted transactions, with sufficient gas fees, and signed by an account with sufficient fees to pay it. Notably, this means many transactions that error may be included in a block.
> Once a block is committed (typically every 5s or so), the transactions are then fed to the Cosmos SDK sequentially in order to execute them. Each one returns a result or error along with event logs, which are recorded in the TxResults section of the next block. The AppHash (or merkle proof or blockchain state) after executing the block is also included in the next block.

### Drive-by changes

Fix a typo for `CosmosMerkleTreeHookIndexer`

### Related issues

n/a

### Backward compatibility

non breaking

### Testing

None 😛 