### PR TITLE
Add gap back to MailboxClient

### DIFF
--- a/solidity/contracts/client/MailboxClient.sol
+++ b/solidity/contracts/client/MailboxClient.sol
@@ -22,6 +22,8 @@ abstract contract MailboxClient is OwnableUpgradeable {
 
     IInterchainSecurityModule public interchainSecurityModule;
 
+    uint256[48] private __GAP; // gap for upgrade safety
+
     // ============ Modifiers ============
     modifier onlyContract(address _contract) {
         require(


### PR DESCRIPTION
The gap should ensure MailboxClient is
upgrade-safe as long as future additions
to the contract reduce the gap properly.