### PR TITLE
chore: use larger runner for github actions

### DIFF
--- a/.github/workflows/agent-release-artifacts.yml
+++ b/.github/workflows/agent-release-artifacts.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
     outputs:
       tag_date: ${{ steps.taggen.outputs.TAG_DATE }}
       tag_sha: ${{ steps.taggen.outputs.TAG_SHA }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ defaults:
 
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,7 +67,9 @@ jobs:
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
       - name: build test
         run: cargo build --release --bin run-locally
-      - name: run test
+      - name: run CosmWasm test
+        run: cargo test --package run-locally --bin run-locally -- cosmos::test --nocapture
+      - name: run test (excluding CosmWasm)
         run: ./target/release/run-locally
         env:
           E2E_CI_MODE: 'true'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: '*'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,7 +68,7 @@ jobs:
       - name: build test
         run: cargo build --release --bin run-locally
       - name: run CosmWasm test
-        run: cargo test --package run-locally --bin run-locally -- cosmos::test --nocapture
+        run: RUST_BACKTRACE=1 cargo test --package run-locally --bin run-locally -- cosmos::test --nocapture
       - name: run test (excluding CosmWasm)
         run: ./target/release/run-locally
         env:

--- a/.github/workflows/mergify.yml.bak
+++ b/.github/workflows/mergify.yml.bak
@@ -24,7 +24,7 @@ on:
 jobs:
   automerge:
 
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
 
     steps:
       - name: automerge
@@ -38,7 +38,7 @@ jobs:
 
 # in rust.yml
   complete:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
     needs: [build, test, lint]
 
     steps:
@@ -52,7 +52,7 @@ jobs:
 
 # in solidity.yml
   complete:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
     needs: [install, lint, test]
 
     steps:

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   check-env:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
     # assign output from step to job output
     outputs:
       gcloud-service-key: ${{ steps.gcloud-service-key.outputs.defined }}
@@ -27,7 +27,7 @@ jobs:
         run: echo "::set-output name=defined::true"
 
   build-and-push-to-gcr:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
 
     # uses check-env to determine if secrets.GCLOUD_SERVICE_KEY is defined
     needs: [check-env]

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   yarn-install:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
     steps:
       - uses: actions/checkout@v3
         with:
@@ -39,7 +39,7 @@ jobs:
           fi
 
   yarn-build:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
     needs: [yarn-install]
     steps:
       - uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
         run: yarn build
 
   lint-prettier:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
     needs: [yarn-install]
     steps:
       - uses: actions/checkout@v3
@@ -94,7 +94,7 @@ jobs:
           fi
 
   test-ts:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
     needs: [yarn-build]
     steps:
       - uses: actions/checkout@v3
@@ -116,7 +116,7 @@ jobs:
         run: yarn workspace @hyperlane-xyz/infra run test
 
   # test-env:
-  #   runs-on: ubuntu-latest
+  #   runs-on: larger-runner
   #   needs: [yarn-build]
   #   strategy:
   #     matrix:
@@ -140,7 +140,7 @@ jobs:
     env:
       ETHERSCAN_API_KEY: ''
 
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
     needs: [yarn-build]
 
     steps:
@@ -189,7 +189,7 @@ jobs:
           sarif_file: ${{ steps.slither.outputs.sarif }}
 
   coverage-sol:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
     needs: [yarn-build]
 
     steps:

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   check-env:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
     # assign output from step to job output
     outputs:
       gcloud-service-key: ${{ steps.gcloud-service-key.outputs.defined }}
@@ -26,7 +26,7 @@ jobs:
         run: echo "::set-output name=defined::true"
 
   build-and-push-to-gcr:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
 
     # uses check-env to determine if secrets.GCLOUD_SERVICE_KEY is defined
     needs: [check-env]

--- a/.github/workflows/rust-skipped.yml
+++ b/.github/workflows/rust-skipped.yml
@@ -12,13 +12,13 @@ env:
 
 jobs:
   test-rs:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
 
     steps:
       - run: 'echo "No test required" '
 
   lint-rs:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
 
     steps:
       - run: 'echo "No lint required" '

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ defaults:
 
 jobs:
   test-rs:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
 
     steps:
       - uses: actions/checkout@v3
@@ -51,7 +51,7 @@ jobs:
         run: cargo test
 
   lint-rs:
-    runs-on: ubuntu-latest
+    runs-on: larger-runner
 
     steps:
       - uses: actions/checkout@v3

--- a/rust/utils/run-locally/src/cosmos/mod.rs
+++ b/rust/utils/run-locally/src/cosmos/mod.rs
@@ -504,7 +504,7 @@ fn run_locally() {
         relayer: hpl_rly.join(),
     };
 
-    sleep(Duration::from_secs(20)); // wait for a long time
+    sleep(Duration::from_secs(100)); // wait for a long time
 }
 
 #[cfg(test)]

--- a/rust/utils/run-locally/src/cosmos/utils.rs
+++ b/rust/utils/run-locally/src/cosmos/utils.rs
@@ -8,7 +8,6 @@ use crate::utils::TaskHandle;
 pub(crate) fn sed(from: &str, to: &str, file: &str) {
     Program::new("sed")
         .raw_arg("-i")
-        .cmd("")
         .cmd(format!("s/{from}/{to}/g"))
         .cmd(file)
         .run()

--- a/rust/utils/run-locally/src/cosmos/utils.rs
+++ b/rust/utils/run-locally/src/cosmos/utils.rs
@@ -8,6 +8,9 @@ use crate::utils::TaskHandle;
 pub(crate) fn sed(from: &str, to: &str, file: &str) {
     Program::new("sed")
         .raw_arg("-i")
+        // Temporary fix to get `sed` working on linux
+        // Note that this breaks the script on mac
+        // .cmd("")
         .cmd(format!("s/{from}/{to}/g"))
         .cmd(file)
         .run()


### PR DESCRIPTION
Size of rust build exceeds the storage space in the `ubuntu-latest` runner. `larger-runner` has more storage, but let's see if it also has all the system dependencies required to build