### PR TITLE
1k block chunk for scroll indexing

### DIFF
--- a/rust/config/mainnet3_config.json
+++ b/rust/config/mainnet3_config.json
@@ -625,7 +625,8 @@
       "mailbox": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
       "validatorAnnounce": "0xd83A4F747fE80Ed98839e05079B1B7Fe037b1638",
       "index": {
-        "from": 426670
+        "from": 426670,
+        "chunk": 1000
       }
     }
   },

--- a/rust/config/mainnet3_config.json
+++ b/rust/config/mainnet3_config.json
@@ -626,7 +626,7 @@
       "validatorAnnounce": "0xd83A4F747fE80Ed98839e05079B1B7Fe037b1638",
       "index": {
         "from": 426670,
-        "chunk": 1000
+        "chunk": 999
       }
     }
   },


### PR DESCRIPTION
### Description

RPC URLs on scroll max out at 1k

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
