### PR TITLE
Deploy testnet4 & mainnet3 agents with image that includes merkle tree indexing fix

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -42,14 +42,14 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '2e1db12-20231025-013013',
+      tag: '1bee32a-20231121-121303',
     },
     gasPaymentEnforcement,
   },
   validators: {
     docker: {
       repo,
-      tag: '2e1db12-20231025-013013',
+      tag: '1bee32a-20231121-121303',
     },
     rpcConsensusType: RpcConsensusType.Quorum,
     chains: validatorChainConfig(Contexts.Hyperlane),
@@ -58,7 +58,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '2e1db12-20231025-013013',
+      tag: '1bee32a-20231121-121303',
     },
   },
 };

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -49,7 +49,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'fd890d2-20231024-132022',
+      tag: '1bee32a-20231121-121303',
     },
     blacklist: [
       ...releaseCandidateHelloworldMatchingList,
@@ -66,7 +66,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'fd890d2-20231024-132022',
+      tag: '1bee32a-20231121-121303',
     },
     chains: validatorChainConfig(Contexts.Hyperlane),
   },
@@ -74,7 +74,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'fd890d2-20231024-132022',
+      tag: '1bee32a-20231121-121303',
     },
   },
 };


### PR DESCRIPTION
### Description

Image from the latest PR to trevor/new-featv3-cosmos-oct-28, which is https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/2912

This includes a fix to merkle tree indexing so it indexes it in the same way as messages

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
