### PR TITLE
Update ethers-rs to use lower max priority fee

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2616,7 +2616,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-11-08#938e9a68466cb6bae689cdd40746280ec85e4955"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -2630,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-11-08#938e9a68466cb6bae689cdd40746280ec85e4955"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -2641,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-11-08#938e9a68466cb6bae689cdd40746280ec85e4955"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -2659,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-11-08#938e9a68466cb6bae689cdd40746280ec85e4955"
 dependencies = [
  "Inflector",
  "cfg-if",
@@ -2683,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-11-08#938e9a68466cb6bae689cdd40746280ec85e4955"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -2697,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-11-08#938e9a68466cb6bae689cdd40746280ec85e4955"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-11-08#938e9a68466cb6bae689cdd40746280ec85e4955"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.11",
@@ -2743,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-11-08#938e9a68466cb6bae689cdd40746280ec85e4955"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-11-08#938e9a68466cb6bae689cdd40746280ec85e4955"
 dependencies = [
  "async-trait",
  "auto_impl 1.1.0",
@@ -2825,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-06-01#6c26645cc1707a3d9c987a603a513fb38a5edb3f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2023-11-08#938e9a68466cb6bae689cdd40746280ec85e4955"
 dependencies = [
  "async-trait",
  "coins-bip32",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -183,27 +183,27 @@ cosmwasm-schema = "1.2.7"
 [workspace.dependencies.ethers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2023-06-01"
+tag = "2023-11-08"
 
 [workspace.dependencies.ethers-contract]
 features = ["legacy"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2023-06-01"
+tag = "2023-11-08"
 
 [workspace.dependencies.ethers-core]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2023-06-01"
+tag = "2023-11-08"
 
 [workspace.dependencies.ethers-providers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2023-06-01"
+tag = "2023-11-08"
 
 [workspace.dependencies.ethers-signers]
 features = ["aws"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2023-06-01"
+tag = "2023-11-08"
 
 [patch.crates-io.curve25519-dalek]
 branch = "v3.2.2-relax-zeroize"


### PR DESCRIPTION
### Description

Cherry-picked the commit from https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/2903, which is now out of date

### Drive-by changes

n/a

### Related issues

n/a

### Backward compatibility


yes

### Testing

we're running the relayer with an image off of https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/2903
