### PR TITLE
Deploy kathy w/ PolygonZkEvm fix

### DIFF
--- a/typescript/infra/config/environments/mainnet3/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet3/helloworld.ts
@@ -13,7 +13,7 @@ export const hyperlane: HelloWorldConfig = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'bbe8928-20231025-215311',
+      tag: 'e21e020-20231201-111649',
     },
     chainsToSkip: [],
     runEnv: environment,
@@ -34,7 +34,7 @@ export const releaseCandidate: HelloWorldConfig = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'bef2251-20231025-174850',
+      tag: 'e21e020-20231201-111649',
     },
     chainsToSkip: [],
     runEnv: environment,

--- a/typescript/infra/config/environments/testnet4/helloworld.ts
+++ b/typescript/infra/config/environments/testnet4/helloworld.ts
@@ -13,7 +13,7 @@ export const hyperlaneHelloworld: HelloWorldConfig = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: '52a8416-20231024-025635',
+      tag: 'e21e020-20231201-111649',
     },
     chainsToSkip: [],
     runEnv: environment,
@@ -33,7 +33,7 @@ export const releaseCandidateHelloworld: HelloWorldConfig = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: '52a8416-20231024-025635',
+      tag: 'e21e020-20231201-111649',
     },
     chainsToSkip: [],
     runEnv: environment,

--- a/typescript/infra/src/helloworld/kathy.ts
+++ b/typescript/infra/src/helloworld/kathy.ts
@@ -38,8 +38,6 @@ export async function runHelloworldKathyHelmCommand(
 
   const values = getHelloworldKathyHelmValues(agentConfig, kathyConfig);
 
-  console.log('kathy values: ', values);
-
   return execCmd(
     `helm ${helmCommand} ${getHelmReleaseName(
       agentConfig.context,
@@ -77,9 +75,9 @@ function getHelloworldKathyHelmValues(
       context: agentConfig.context,
       // This is just used for fetching secrets, and is not actually
       // the list of chains that kathy will send to. Because Kathy
-      // will fetch secrets for all chains, regardless of skipping them or
-      // not, we pass in all chains
-      chains: agentConfig.contextChainNames.relayer,
+      // will fetch secrets for all chains in the environment, regardless
+      // of skipping them or not, we pass in all chains
+      chains: agentConfig.environmentChainNames,
       aws: agentConfig.aws !== undefined,
 
       chainsToSkip: kathyConfig.chainsToSkip,


### PR DESCRIPTION
### Description

Deploy Kathy with #3001 

### Drive-by changes

Small fix to deploy kathy successfully - because the relayer chains doesn't include neutron and kathy will try to create a multiprovider for all chains the env, we need to use the environment chain names as the helm `hyperlane.chains` value

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
