### PR TITLE
Rename `hook-config.yaml` to `hooks.yaml` in `ci-test.sh`

### DIFF
--- a/typescript/cli/ci-test.sh
+++ b/typescript/cli/ci-test.sh
@@ -39,7 +39,7 @@ yarn workspace @hyperlane-xyz/cli run hyperlane deploy core \
     --chains ./examples/anvil-chains.yaml \
     --artifacts /tmp/empty-artifacts.json \
     --ism ./examples/ism.yaml \
-    --hook ./examples/hook-config.yaml \
+    --hook ./examples/hooks.yaml \
     --out /tmp \
     --key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
     --yes

--- a/typescript/cli/src/config/hooks.ts
+++ b/typescript/cli/src/config/hooks.ts
@@ -195,7 +195,7 @@ export async function createHooksConfigMap({
       mergeYamlOrJson(outPath, result, format);
     } else {
       errorRed(
-        `Hook config is invalid, please see https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/cli/examples/hook-config.yaml for an example`,
+        `Hook config is invalid, please see https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/cli/examples/hooks.yaml for an example`,
       );
       throw new Error('Invalid hook config');
     }


### PR DESCRIPTION
### Description

- CI fails otherwise

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

Manual
