### PR TITLE
fix:don't prompt user for multisig config if chain is core

### DIFF
--- a/.changeset/ninety-seas-chew.md
+++ b/.changeset/ninety-seas-chew.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Allow users to config their own PI chain

--- a/.changeset/ninety-seas-chew.md
+++ b/.changeset/ninety-seas-chew.md
@@ -2,4 +2,7 @@
 '@hyperlane-xyz/cli': patch
 ---
 
-Allow users to config their own PI chain
+Allow users to only configure validators for their chain
+
+- Don't restrict user to having two chains for ism config
+- If the user accidentally picks two chains, we prompt them again to confirm if they don't want to use the hyperlane validators for their multisigConfig

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -107,7 +107,11 @@ export async function createIsmConfigMap({
 }) {
   logBlue('Creating a new ISM config');
   const customChains = readChainConfigsIfExists(chainConfigPath);
-  const chains = await runMultiChainSelectionStep(customChains);
+  const chains = await runMultiChainSelectionStep(
+    customChains,
+    'Select chains to configure ISM for',
+    true,
+  );
 
   const result: ZodIsmConfigMap = {};
   for (const chain of chains) {

--- a/typescript/cli/src/config/multisig.ts
+++ b/typescript/cli/src/config/multisig.ts
@@ -1,11 +1,7 @@
 import { confirm, input } from '@inquirer/prompts';
 import { z } from 'zod';
 
-import {
-  ChainMap,
-  MultisigConfig,
-  defaultMultisigConfigs,
-} from '@hyperlane-xyz/sdk';
+import { ChainMap, MultisigConfig } from '@hyperlane-xyz/sdk';
 import {
   Address,
   isValidAddress,
@@ -96,14 +92,7 @@ export async function createMultisigConfig({
       const reuseCoreConfig = await confirm({
         message: 'Use existing Hyperlane validators for this chain?',
       });
-      if (reuseCoreConfig) {
-        result[chain] = {
-          threshold: defaultMultisigConfigs[chain].threshold,
-          validators: defaultMultisigConfigs[chain].validators,
-        };
-        console.log(result[chain]);
-        continue;
-      }
+      if (reuseCoreConfig) continue;
     }
 
     const thresholdInput = await input({

--- a/typescript/cli/src/config/multisig.ts
+++ b/typescript/cli/src/config/multisig.ts
@@ -1,7 +1,11 @@
-import { input } from '@inquirer/prompts';
+import { confirm, input } from '@inquirer/prompts';
 import { z } from 'zod';
 
-import { ChainMap, MultisigConfig } from '@hyperlane-xyz/sdk';
+import {
+  ChainMap,
+  MultisigConfig,
+  defaultMultisigConfigs,
+} from '@hyperlane-xyz/sdk';
 import {
   Address,
   isValidAddress,
@@ -10,6 +14,7 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import { errorRed, log, logBlue, logGreen } from '../../logger.js';
+import { sdkContractAddressesMap } from '../context.js';
 import { runMultiChainSelectionStep } from '../utils/chains.js';
 import { FileFormat, mergeYamlOrJson, readYamlOrJson } from '../utils/files.js';
 
@@ -72,6 +77,9 @@ export async function createMultisigConfig({
   chainConfigPath: string;
 }) {
   logBlue('Creating a new multisig config');
+  log(
+    'Select your own chain below to run your own validators. If you want to reuse existing Hyperlane validators instead of running your own, do not select additional mainnet or testnet chains.',
+  );
   const customChains = readChainConfigsIfExists(chainConfigPath);
   const chains = await runMultiChainSelectionStep(customChains);
 
@@ -83,6 +91,19 @@ export async function createMultisigConfig({
     if (lastConfig && repeat) {
       result[chain] = lastConfig;
       continue;
+    }
+    if (Object.keys(sdkContractAddressesMap).includes(chain)) {
+      const reuseCoreConfig = await confirm({
+        message: 'Use existing Hyperlane validators for this chain?',
+      });
+      if (reuseCoreConfig) {
+        result[chain] = {
+          threshold: defaultMultisigConfigs[chain].threshold,
+          validators: defaultMultisigConfigs[chain].validators,
+        };
+        console.log(result[chain]);
+        continue;
+      }
     }
 
     const thresholdInput = await input({
@@ -111,7 +132,7 @@ export async function createMultisigConfig({
     mergeYamlOrJson(outPath, result, format);
   } else {
     errorRed(
-      `Multisig config is invalid, please see https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/cli/examples/multisig-ism.yaml for an example`,
+      `Multisig config is invalid, please see https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/cli/examples/ism.yaml for an example`,
     );
     throw new Error('Invalid multisig config');
   }

--- a/typescript/cli/src/deploy/agent.ts
+++ b/typescript/cli/src/deploy/agent.ts
@@ -33,6 +33,7 @@ export async function runKurtosisAgentDeploy({
     const selectedRelayChains = await runMultiChainSelectionStep(
       customChains,
       'Select chains to relay between',
+      true,
     );
     relayChains = selectedRelayChains.join(',');
   }

--- a/typescript/cli/src/deploy/core.ts
+++ b/typescript/cli/src/deploy/core.ts
@@ -85,6 +85,7 @@ export async function runCoreDeploy({
     chains = await runMultiChainSelectionStep(
       customChains,
       'Select chains to connect',
+      true,
     );
   }
   const artifacts = await runArtifactStep(chains, artifactsPath);

--- a/typescript/cli/src/utils/chains.ts
+++ b/typescript/cli/src/utils/chains.ts
@@ -32,7 +32,7 @@ export async function runSingleChainSelectionStep(
 export async function runMultiChainSelectionStep(
   customChains: ChainMap<ChainMetadata>,
   message = 'Select chains',
-  chainSelection = false,
+  requireMultiple = false,
 ) {
   const choices = getChainChoices(customChains);
   while (true) {
@@ -43,8 +43,11 @@ export async function runMultiChainSelectionStep(
       pageSize: 20,
     })) as string[];
     handleNewChain(chains);
-    if (chains?.length >= 2 || !chainSelection) return chains;
-    else logRed('Please select at least 2 chains');
+    if (requireMultiple && chains?.length < 2) {
+      logRed('Please select at least 2 chains');
+      continue;
+    }
+    return chains;
   }
 }
 

--- a/typescript/cli/src/utils/chains.ts
+++ b/typescript/cli/src/utils/chains.ts
@@ -5,7 +5,6 @@ import chalk from 'chalk';
 import {
   ChainMap,
   ChainMetadata,
-  ChainName,
   mainnetChainsMetadata,
   testnetChainsMetadata,
 } from '@hyperlane-xyz/sdk';
@@ -33,9 +32,9 @@ export async function runSingleChainSelectionStep(
 export async function runMultiChainSelectionStep(
   customChains: ChainMap<ChainMetadata>,
   message = 'Select chains',
-  chainsToFilterOut: ChainName[] = [],
+  chainSelection = false,
 ) {
-  const choices = getChainChoices(customChains, chainsToFilterOut);
+  const choices = getChainChoices(customChains);
   while (true) {
     logTip('Use SPACE key to select chains, then press ENTER');
     const chains = (await checkbox({
@@ -44,19 +43,14 @@ export async function runMultiChainSelectionStep(
       pageSize: 20,
     })) as string[];
     handleNewChain(chains);
-    if (chains?.length >= 2) return chains;
+    if (chains?.length >= 2 || !chainSelection) return chains;
     else logRed('Please select at least 2 chains');
   }
 }
 
-function getChainChoices(
-  customChains: ChainMap<ChainMetadata>,
-  chainsToFilterOut: ChainName[] = [],
-) {
+function getChainChoices(customChains: ChainMap<ChainMetadata>) {
   const chainsToChoices = (chains: ChainMetadata[]) =>
-    chains
-      .filter((chain) => !chainsToFilterOut.includes(chain.name))
-      .map((c) => ({ name: c.name, value: c.name }));
+    chains.map((c) => ({ name: c.name, value: c.name }));
   const choices: Parameters<typeof select>['0']['choices'] = [
     new Separator('--Custom Chains--'),
     ...chainsToChoices(Object.values(customChains)),


### PR DESCRIPTION
### Description

- don't restrict user to having two chains for ism config
- if the user accidentally picks two chains, we prompt them again to confirm if they don't want to use the hyperlane validators for their multisigconfig

### Drive-by changes

None

### Related issues

- fixes https://github.com/hyperlane-xyz/issues/issues/811

### Backward compatibility

Yes

### Testing

Manual between arbitrumgoerli and anvil1
