### PR TITLE
chore: reduce agents log verbosity, reword

### DIFF
--- a/rust/agents/relayer/src/merkle_tree/processor.rs
+++ b/rust/agents/relayer/src/merkle_tree/processor.rs
@@ -76,7 +76,7 @@ impl MerkleTreeProcessor {
                 .set(insertion.index() as i64);
             Some(insertion)
         } else {
-            trace!(leaf_index=?self.leaf_index, "No more messages found in DB for leaf index. Done processing.");
+            trace!(leaf_index=?self.leaf_index, "No merkle tree insertion found in DB for leaf index, waiting for it to be indexed");
             None
         };
         Ok(leaf)

--- a/rust/agents/relayer/src/merkle_tree/processor.rs
+++ b/rust/agents/relayer/src/merkle_tree/processor.rs
@@ -11,7 +11,7 @@ use hyperlane_base::db::HyperlaneRocksDB;
 use hyperlane_core::{HyperlaneDomain, MerkleTreeInsertion};
 use prometheus::IntGauge;
 use tokio::sync::RwLock;
-use tracing::debug;
+use tracing::trace;
 
 use crate::processor::ProcessorExt;
 
@@ -76,7 +76,7 @@ impl MerkleTreeProcessor {
                 .set(insertion.index() as i64);
             Some(insertion)
         } else {
-            debug!(leaf_index=?self.leaf_index, "No message found in DB for leaf index");
+            trace!(leaf_index=?self.leaf_index, "No more messages found in DB for leaf index. Done processing.");
             None
         };
         Ok(leaf)


### PR DESCRIPTION
There are way too many `No message found in DB for leaf index` logs to have them at debug level. Also the wording makes it seem like an error when it's not.