### PR TITLE
Cherrypick key refactor onto v2

### DIFF
--- a/solidity/test/isms/DomainRoutingIsm.t.sol
+++ b/solidity/test/isms/DomainRoutingIsm.t.sol
@@ -53,7 +53,7 @@ contract DomainRoutingIsmTest is Test {
             vm.expectEmit(true, true, false, true);
             emit ModuleSet(_domains[i], _isms[i]);
         }
-        ism = factory.deploy(_domains, _isms);
+        ism = factory.deploy(address(this), _domains, _isms);
         for (uint256 i = 0; i < count; ++i) {
             assertEq(address(ism.modules(_domains[i])), address(_isms[i]));
         }

--- a/solidity/test/isms/DomainRoutingIsm.t.sol
+++ b/solidity/test/isms/DomainRoutingIsm.t.sol
@@ -53,7 +53,7 @@ contract DomainRoutingIsmTest is Test {
             vm.expectEmit(true, true, false, true);
             emit ModuleSet(_domains[i], _isms[i]);
         }
-        ism = factory.deploy(address(this), _domains, _isms);
+        ism = factory.deploy(_domains, _isms);
         for (uint256 i = 0; i < count; ++i) {
             assertEq(address(ism.modules(_domains[i])), address(_isms[i]));
         }

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -12,16 +12,15 @@ import {
   MultiProvider,
 } from '@hyperlane-xyz/sdk';
 import {
-  Address,
   error,
   log,
+  objFilter,
   objMap,
   promiseObjAll,
   warn,
 } from '@hyperlane-xyz/utils';
 
 import { Contexts } from '../../config/contexts';
-import { parseKeyIdentifier } from '../../src/agents/agent';
 import { KeyAsAddress, getRoleKeysPerChain } from '../../src/agents/key-utils';
 import {
   BaseCloudAgentKey,
@@ -35,6 +34,7 @@ import { submitMetrics } from '../../src/utils/metrics';
 import {
   assertContext,
   assertRole,
+  isEthereumProtocolChain,
   readJSONAtPath,
 } from '../../src/utils/utils';
 import { getAgentConfig, getArgs, getEnvironmentConfig } from '../utils';
@@ -270,6 +270,21 @@ class ContextFunder {
     public readonly rolesToFund: Role[],
     public readonly skipIgpClaim: boolean,
   ) {
+    // At the moment, only blessed EVM chains are supported
+    roleKeysPerChain = objFilter(
+      roleKeysPerChain,
+      (chain, _roleKeys): _roleKeys is Record<Role, BaseCloudAgentKey[]> => {
+        const valid =
+          isEthereumProtocolChain(chain) &&
+          multiProvider.tryGetChainName(chain) !== null;
+        if (!valid) {
+          warn('Skipping funding for non-blessed or non-Ethereum chain', {
+            chain,
+          });
+        }
+        return valid;
+      },
+    );
     this.igp = HyperlaneIgp.fromEnvironment(
       deployEnvToSdkEnv[this.environment],
       multiProvider,

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -5,18 +5,24 @@ import { format } from 'util';
 
 import {
   AgentConnectionType,
-  AllChains,
   ChainMap,
   ChainName,
   Chains,
   HyperlaneIgp,
   MultiProvider,
 } from '@hyperlane-xyz/sdk';
-import { error, log, warn } from '@hyperlane-xyz/utils';
+import {
+  Address,
+  error,
+  log,
+  objMap,
+  promiseObjAll,
+  warn,
+} from '@hyperlane-xyz/utils';
 
 import { Contexts } from '../../config/contexts';
 import { parseKeyIdentifier } from '../../src/agents/agent';
-import { getAllCloudAgentKeys } from '../../src/agents/key-utils';
+import { KeyAsAddress, getRoleKeysPerChain } from '../../src/agents/key-utils';
 import {
   BaseCloudAgentKey,
   ReadOnlyCloudAgentKey,
@@ -24,7 +30,7 @@ import {
 import { DeployEnvironment } from '../../src/config';
 import { deployEnvToSdkEnv } from '../../src/config/environment';
 import { ContextAndRoles, ContextAndRolesMap } from '../../src/config/funding';
-import { AgentRole, Role } from '../../src/roles';
+import { Role } from '../../src/roles';
 import { submitMetrics } from '../../src/utils/metrics';
 import {
   assertContext,
@@ -217,9 +223,9 @@ async function main() {
       ContextFunder.fromSerializedAddressFile(
         environment,
         multiProvider,
-        path,
         argv.contextsAndRoles,
         argv.skipIgpClaim,
+        path,
       ),
     );
   } else {
@@ -254,10 +260,12 @@ async function main() {
 class ContextFunder {
   igp: HyperlaneIgp;
 
+  keysToFundPerChain: ChainMap<BaseCloudAgentKey[]>;
+
   constructor(
     public readonly environment: DeployEnvironment,
     public readonly multiProvider: MultiProvider,
-    public readonly keys: BaseCloudAgentKey[],
+    roleKeysPerChain: ChainMap<Record<Role, BaseCloudAgentKey[]>>,
     public readonly context: Contexts,
     public readonly rolesToFund: Role[],
     public readonly skipIgpClaim: boolean,
@@ -266,66 +274,86 @@ class ContextFunder {
       deployEnvToSdkEnv[this.environment],
       multiProvider,
     );
+    this.keysToFundPerChain = objMap(roleKeysPerChain, (_chain, roleKeys) => {
+      return Object.keys(roleKeys).reduce((agg, roleStr) => {
+        const role = roleStr as Role;
+        if (this.rolesToFund.includes(role)) {
+          return [...agg, ...roleKeys[role]];
+        }
+        return agg;
+      }, [] as BaseCloudAgentKey[]);
+    });
   }
 
   static fromSerializedAddressFile(
     environment: DeployEnvironment,
     multiProvider: MultiProvider,
-    path: string,
     contextsAndRolesToFund: ContextAndRolesMap,
     skipIgpClaim: boolean,
+    filePath: string,
   ) {
     log('Reading identifiers and addresses from file', {
-      path,
+      filePath,
     });
-    const idsAndAddresses = readJSONAtPath(path);
-    const keys: BaseCloudAgentKey[] = idsAndAddresses
-      .filter((idAndAddress: any) => {
-        const parsed = parseKeyIdentifier(idAndAddress.identifier);
-        // Filter out any invalid chain names. This can happen if we're running an old
-        // version of this script but the list of identifiers (expected to be stored in GCP secrets)
-        // references newer chains.
-        return (
-          parsed.chainName === undefined ||
-          (AllChains as string[]).includes(parsed.chainName)
-        );
-      })
-      .map((idAndAddress: any) =>
-        ReadOnlyCloudAgentKey.fromSerializedAddress(
-          idAndAddress.identifier,
-          idAndAddress.address,
-        ),
-      );
-
-    const context = keys[0].context;
-    // Ensure all keys have the same context, just to be safe
-    for (const key of keys) {
-      if (key.context !== context) {
-        throw Error(
-          `Expected all keys at path ${path} to have context ${context}, found ${key.context}`,
-        );
-      }
+    // A big array of KeyAsAddress, including keys that we may not care about.
+    const allIdsAndAddresses: KeyAsAddress[] = readJSONAtPath(filePath);
+    if (!allIdsAndAddresses.length) {
+      throw Error(`Expected at least one key in file ${filePath}`);
     }
 
-    const rolesToFund = contextsAndRolesToFund[context];
-    if (!rolesToFund) {
-      throw Error(
-        `Expected context ${context} to be defined in contextsAndRolesToFund`,
-      );
-    }
+    // Arbitrarily pick the first key to get the context
+    const firstKey = allIdsAndAddresses[0];
+    const context = ReadOnlyCloudAgentKey.fromSerializedAddress(
+      firstKey.identifier,
+      firstKey.address,
+    ).context;
 
-    log('Read keys for context from file', {
-      path,
-      keyCount: keys.length,
+    // Indexed by the identifier for quicker lookup
+    const idsAndAddresses: Record<string, KeyAsAddress> =
+      allIdsAndAddresses.reduce((agg, idAndAddress) => {
+        agg[idAndAddress.identifier] = idAndAddress;
+        return agg;
+      }, {} as Record<string, KeyAsAddress>);
+
+    const agentConfig = getAgentConfig(context, environment);
+    // Unfetched keys per chain and role, so we know which keys
+    // we need. We'll use this to create a corresponding object
+    // of ReadOnlyCloudAgentKeys using addresses found in the
+    // serialized address file.
+    const roleKeysPerChain = getRoleKeysPerChain(agentConfig);
+
+    const readOnlyKeysPerChain = objMap(
+      roleKeysPerChain,
+      (_chain, roleKeys) => {
+        return objMap(roleKeys, (_role, keys) => {
+          return keys.map((key) => {
+            const idAndAddress = idsAndAddresses[key.identifier];
+            if (!idAndAddress) {
+              throw Error(
+                `Expected key identifier ${key.identifier} to be in file ${filePath}`,
+              );
+            }
+            return ReadOnlyCloudAgentKey.fromSerializedAddress(
+              idAndAddress.identifier,
+              idAndAddress.address,
+            );
+          });
+        });
+      },
+    );
+
+    log('Successfully read keys for context from file', {
+      filePath,
+      readOnlyKeysPerChain,
       context,
     });
 
     return new ContextFunder(
       environment,
       multiProvider,
-      keys,
+      readOnlyKeysPerChain,
       context,
-      rolesToFund,
+      contextsAndRolesToFund[context]!,
       skipIgpClaim,
     );
   }
@@ -341,12 +369,22 @@ class ContextFunder {
     skipIgpClaim: boolean,
   ) {
     const agentConfig = getAgentConfig(context, environment);
-    const keys = getAllCloudAgentKeys(agentConfig);
-    await Promise.all(keys.map((key) => key.fetch()));
+    const roleKeysPerChain = getRoleKeysPerChain(agentConfig);
+    // Fetch all the keys
+    await promiseObjAll(
+      objMap(roleKeysPerChain, (_chain, roleKeys) => {
+        return promiseObjAll(
+          objMap(roleKeys, (_role, keys) => {
+            return Promise.all(keys.map((key) => key.fetch()));
+          }),
+        );
+      }),
+    );
+
     return new ContextFunder(
       environment,
       multiProvider,
-      keys,
+      roleKeysPerChain,
       context,
       rolesToFund,
       skipIgpClaim,
@@ -356,10 +394,9 @@ class ContextFunder {
   // Funds all the roles in this.rolesToFund
   // Returns whether a failure occurred.
   async fund(): Promise<boolean> {
-    let failureOccurred = false;
-
-    const chainKeys = this.getChainKeys();
-    const promises = Object.entries(chainKeys).map(async ([chain, keys]) => {
+    const chainKeyEntries = Object.entries(this.keysToFundPerChain);
+    const promises = chainKeyEntries.map(async ([chain, keys]) => {
+      let failureOccurred = false;
       if (keys.length > 0) {
         if (!this.skipIgpClaim) {
           failureOccurred ||= await gracefullyHandleError(
@@ -379,36 +416,27 @@ class ContextFunder {
         const failure = await this.attemptToFundKey(key, chain);
         failureOccurred ||= failure;
       }
+      return failureOccurred;
     });
 
-    try {
-      await Promise.all(promises);
-    } catch (e) {
-      error('Unhandled error when funding key', { error: format(e) });
-      failureOccurred = true;
-    }
+    // A failure occurred if any of the promises rejected or
+    // if any of them resolved with true, indicating a failure
+    // somewhere along the way
+    const failureOccurred = (await Promise.allSettled(promises)).reduce(
+      (failureAgg, result, i) => {
+        if (result.status === 'rejected') {
+          error('Funding promise for chain rejected', {
+            chain: chainKeyEntries[i][0],
+            error: format(result.reason),
+          });
+          return true;
+        }
+        return result.value || failureAgg;
+      },
+      false,
+    );
 
     return failureOccurred;
-  }
-
-  private getChainKeys() {
-    const chainKeys: ChainMap<BaseCloudAgentKey[]> = Object.fromEntries(
-      // init with empty arrays
-      AllChains.map((c) => [c, []]),
-    );
-    for (const role of this.rolesToFund) {
-      const keys = this.getKeysWithRole(role);
-      for (const key of keys) {
-        const chains = getAgentConfig(
-          key.context,
-          key.environment,
-        ).contextChainNames;
-        for (const chain of chains[role as AgentRole]) {
-          chainKeys[chain].push(key);
-        }
-      }
-    }
-    return chainKeys;
   }
 
   private async attemptToFundKey(
@@ -665,10 +693,6 @@ class ContextFunder {
           ),
         ),
       );
-  }
-
-  private getKeysWithRole(role: Role) {
-    return this.keys.filter((k) => k.role === role);
   }
 }
 

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -26,7 +26,7 @@ import {
   buildHelmChartDependencies,
   helmifyValues,
 } from '../utils/helm';
-import { execCmd } from '../utils/utils';
+import { execCmd, isEthereumProtocolChain } from '../utils/utils';
 
 import { AgentGCPKey } from './gcp';
 
@@ -127,7 +127,8 @@ export abstract class AgentHelmManager {
   }
 
   connectionType(chain: ChainName): AgentConnectionType {
-    if (chainMetadata[chain].protocol == ProtocolType.Sealevel) {
+    // Non-Ethereum chains only support Http
+    if (!isEthereumProtocolChain(chain)) {
       return AgentConnectionType.Http;
     }
 

--- a/typescript/infra/src/agents/key-utils.ts
+++ b/typescript/infra/src/agents/key-utils.ts
@@ -1,7 +1,9 @@
-import { ChainName, chainMetadata } from '@hyperlane-xyz/sdk';
-import { ProtocolType } from '@hyperlane-xyz/utils';
+import { ChainMap, ChainName, chainMetadata } from '@hyperlane-xyz/sdk';
+import { objMap } from '@hyperlane-xyz/utils';
 
 import { Contexts } from '../../config/contexts';
+import { getHelloWorldConfig } from '../../scripts/helloworld/utils';
+import { getEnvironmentConfig } from '../../scripts/utils';
 import {
   AgentContextConfig,
   DeployEnvironment,
@@ -9,132 +11,293 @@ import {
 } from '../config';
 import { Role } from '../roles';
 import { fetchGCPSecret, setGCPSecret } from '../utils/gcloud';
-import { execCmd } from '../utils/utils';
+import { execCmd, isEthereumProtocolChain } from '../utils/utils';
 
 import { AgentAwsKey } from './aws/key';
 import { AgentGCPKey } from './gcp';
 import { CloudAgentKey } from './keys';
 
-interface KeyAsAddress {
+export interface KeyAsAddress {
   identifier: string;
   address: string;
 }
 
-export function getRelayerCloudAgentKeys(
-  agentConfig: AgentContextConfig,
-): Array<CloudAgentKey> {
-  if (!agentConfig.aws) {
-    return [
-      new AgentGCPKey(agentConfig.runEnv, agentConfig.context, Role.Relayer),
-    ];
-  }
+// ==================
+// Functions for getting keys
+// ==================
 
-  const keys = [];
-  keys.push(new AgentAwsKey(agentConfig, Role.Relayer));
-  const hasNonEthereumChains = !!agentConfig.contextChainNames[
-    Role.Relayer
-  ].find(isNotEthereumProtocolChain);
-  // If there are any non-ethereum chains, we also want hex keys.
-  if (hasNonEthereumChains) {
-    keys.push(
-      new AgentGCPKey(agentConfig.runEnv, agentConfig.context, Role.Relayer),
+// Returns a nested object of the shape:
+// {
+//   [chain]: {
+//     [role]: keys[],
+//   }
+// }
+//
+// Note that some types of keys are used on multiple different chains
+// and may be duplicated in the returned object. E.g. the deployer key
+// or the relayer key, etc
+export function getRoleKeysPerChain(
+  agentConfig: RootAgentConfig,
+): ChainMap<Record<Role, CloudAgentKey[]>> {
+  return objMap(getRoleKeyMapPerChain(agentConfig), (_chain, roleKeys) => {
+    return objMap(roleKeys, (_role, keys) => {
+      return Object.values(keys);
+    });
+  });
+}
+
+// Returns a nested object of the shape:
+// {
+//   [chain]: {
+//     [role]: {
+//       // To guarantee no key duplicates, the key identifier is used as the key
+//       [key identifier]: key
+//     }
+//   }
+// }
+function getRoleKeyMapPerChain(
+  agentConfig: RootAgentConfig,
+): ChainMap<Record<Role, Record<string, CloudAgentKey>>> {
+  const keysPerChain: ChainMap<Record<Role, Record<string, CloudAgentKey>>> =
+    {};
+
+  const setValidatorKeys = () => {
+    const validators = agentConfig.validators;
+    for (const chainName of agentConfig.contextChainNames.validator) {
+      let chainValidatorKeys = {};
+
+      const validatorCount =
+        validators?.chains[chainName].validators.length ?? 0;
+      for (let index = 0; index < validatorCount; index++) {
+        const { validator, chainSigner } = getValidatorKeysForChain(
+          agentConfig,
+          chainName,
+          index,
+        );
+        chainValidatorKeys = {
+          ...chainValidatorKeys,
+          [validator.identifier]: validator,
+          [chainSigner.identifier]: chainSigner,
+        };
+      }
+      keysPerChain[chainName] = {
+        ...keysPerChain[chainName],
+        [Role.Validator]: chainValidatorKeys,
+      };
+    }
+  };
+
+  const setRelayerKeys = () => {
+    for (const chainName of agentConfig.contextChainNames.relayer) {
+      const relayerKey = getRelayerKeyForChain(agentConfig, chainName);
+      keysPerChain[chainName] = {
+        ...keysPerChain[chainName],
+        [Role.Relayer]: {
+          [relayerKey.identifier]: relayerKey,
+        },
+      };
+    }
+  };
+
+  const setKathyKeys = () => {
+    const envConfig = getEnvironmentConfig(agentConfig.runEnv);
+    const helloWorldConfig = getHelloWorldConfig(
+      envConfig,
+      agentConfig.context,
     );
+    // Kathy is only needed on chains where the hello world contracts are deployed.
+    for (const chainName of Object.keys(helloWorldConfig.addresses)) {
+      const kathyKey = getKathyKeyForChain(agentConfig, chainName);
+      keysPerChain[chainName] = {
+        ...keysPerChain[chainName],
+        [Role.Kathy]: {
+          [kathyKey.identifier]: kathyKey,
+        },
+      };
+    }
+  };
+
+  const setDeployerKeys = () => {
+    const deployerKey = getDeployerKey(agentConfig);
+    // Default to using the relayer keys for the deployer keys
+    for (const chainName of agentConfig.contextChainNames.relayer) {
+      keysPerChain[chainName] = {
+        ...keysPerChain[chainName],
+        [Role.Deployer]: {
+          [deployerKey.identifier]: deployerKey,
+        },
+      };
+    }
+  };
+
+  for (const role of agentConfig.rolesWithKeys) {
+    switch (role) {
+      case Role.Validator:
+        setValidatorKeys();
+        break;
+      case Role.Relayer:
+        setRelayerKeys();
+        break;
+      case Role.Kathy:
+        setKathyKeys();
+        break;
+      case Role.Deployer:
+        setDeployerKeys();
+        break;
+      default:
+        throw Error(`Unsupported role with keys ${role}`);
+    }
   }
-  return keys;
+
+  return keysPerChain;
 }
 
-export function getKathyCloudAgentKeys(
-  agentConfig: AgentContextConfig,
+// Gets a big array of all keys.
+export function getAllCloudAgentKeys(
+  agentConfig: RootAgentConfig,
 ): Array<CloudAgentKey> {
-  const gcpKey = new AgentGCPKey(
-    agentConfig.runEnv,
-    agentConfig.context,
-    Role.Kathy,
-  );
-  if (!agentConfig.aws) {
-    return [gcpKey];
-  }
+  const keysPerChain = getRoleKeyMapPerChain(agentConfig);
 
-  // Return both GCP and AWS keys for Kathy even if the agentConfig is configured
-  // to use AWS. Non-Ethereum chains require GCP keys.
-  return [gcpKey, new AgentAwsKey(agentConfig, Role.Kathy)];
+  const keysByIdentifier = Object.keys(keysPerChain).reduce(
+    (acc, chainName) => {
+      const chainKeyRoles = keysPerChain[chainName];
+      // All keys regardless of role
+      const chainKeys = Object.keys(chainKeyRoles).reduce((acc, role) => {
+        const roleKeys = chainKeyRoles[role as Role];
+        return {
+          ...acc,
+          ...roleKeys,
+        };
+      }, {});
+
+      return {
+        ...acc,
+        ...chainKeys,
+      };
+    },
+    {},
+  );
+
+  return Object.values(keysByIdentifier);
 }
 
-// If getting all keys for relayers or validators, it's recommended to use
-// `getRelayerCloudAgentKeys` or `getValidatorCloudAgentKeys` instead.
+// Gets a specific key. The chain name or index is required depending on the role.
+// For this reason, using this function is only encouraged if the caller
+// knows they want a specific key relating to a specific role.
 export function getCloudAgentKey(
   agentConfig: AgentContextConfig,
   role: Role,
   chainName?: ChainName,
   index?: number,
 ): CloudAgentKey {
-  // Non-evm Kathy is always GCP-based but does not index by chain
-  if (
-    role === Role.Kathy &&
-    chainName &&
-    isNotEthereumProtocolChain(chainName)
-  ) {
-    return new AgentGCPKey(agentConfig.runEnv, agentConfig.context, role);
+  switch (role) {
+    case Role.Validator:
+      if (chainName === undefined || index === undefined) {
+        throw Error(`Must provide chainName and index for validator key`);
+      }
+      // For now just get the validator key, and not the chain signer.
+      return getValidatorKeysForChain(agentConfig, chainName, index).validator;
+    case Role.Relayer:
+      if (chainName === undefined) {
+        throw Error(`Must provide chainName for relayer key`);
+      }
+      return getRelayerKeyForChain(agentConfig, chainName);
+    case Role.Kathy:
+      if (chainName === undefined) {
+        throw Error(`Must provide chainName for kathy key`);
+      }
+      return getKathyKeyForChain(agentConfig, chainName);
+    case Role.Deployer:
+      return getDeployerKey(agentConfig);
+    default:
+      throw Error(`Unsupported role ${role}`);
   }
-  // Otherwise use an AWS key except for the deployer
-  else if (!!agentConfig.aws && role !== Role.Deployer) {
-    return new AgentAwsKey(agentConfig, role, chainName, index);
-  } else {
-    // Fallback to GCP
-    return new AgentGCPKey(
-      agentConfig.runEnv,
-      agentConfig.context,
-      role,
-      chainName,
-      index,
-    );
+}
+
+// ==================
+// Keys for specific roles
+// ==================
+
+// Gets the relayer key used for signing txs to the provided chain.
+export function getRelayerKeyForChain(
+  agentConfig: AgentContextConfig,
+  chainName: ChainName,
+): CloudAgentKey {
+  // If AWS is enabled and the chain is an Ethereum-based chain, we want to use
+  // an AWS key.
+  if (agentConfig.aws && isEthereumProtocolChain(chainName)) {
+    return new AgentAwsKey(agentConfig, Role.Relayer);
   }
+
+  return new AgentGCPKey(agentConfig.runEnv, agentConfig.context, Role.Relayer);
 }
 
-export function getValidatorCloudAgentKeys(
-  agentConfig: RootAgentConfig,
-): Array<CloudAgentKey> {
-  // For each chainName, create validatorCount keys
-  if (!agentConfig.validators) return [];
-  const validators = agentConfig.validators;
-  return agentConfig.contextChainNames[Role.Validator]
-    .filter((chainName) => !!validators.chains[chainName])
-    .flatMap((chainName) =>
-      validators.chains[chainName].validators.map((_, index) =>
-        getCloudAgentKey(agentConfig, Role.Validator, chainName, index),
-      ),
-    );
-}
-
-export function getAllCloudAgentKeys(
-  agentConfig: RootAgentConfig,
-): Array<CloudAgentKey> {
-  const keys = [];
-  if ((agentConfig.rolesWithKeys ?? []).includes(Role.Relayer))
-    keys.push(...getRelayerCloudAgentKeys(agentConfig));
-  if ((agentConfig.rolesWithKeys ?? []).includes(Role.Validator))
-    keys.push(...getValidatorCloudAgentKeys(agentConfig));
-  if ((agentConfig.rolesWithKeys ?? []).includes(Role.Kathy))
-    keys.push(...getKathyCloudAgentKeys(agentConfig));
-
-  for (const role of agentConfig.rolesWithKeys) {
-    if (role == Role.Relayer || role == Role.Validator || role == Role.Kathy)
-      continue;
-    keys.push(getCloudAgentKey(agentConfig, role));
+// Gets the kathy key used for signing txs to the provided chain.
+// Note this is basically a dupe of getRelayerKeyForChain, but to encourage
+// consumers to be aware of what role they're using, and to keep the door open
+// for future per-role deviations, we have separate functions.
+export function getKathyKeyForChain(
+  agentConfig: AgentContextConfig,
+  chainName: ChainName,
+): CloudAgentKey {
+  // If AWS is enabled and the chain is an Ethereum-based chain, we want to use
+  // an AWS key.
+  if (agentConfig.aws && isEthereumProtocolChain(chainName)) {
+    return new AgentAwsKey(agentConfig, Role.Kathy);
   }
-  return keys;
+
+  return new AgentGCPKey(agentConfig.runEnv, agentConfig.context, Role.Kathy);
 }
 
-export async function deleteAgentKeys(agentConfig: AgentContextConfig) {
-  const keys = getAllCloudAgentKeys(agentConfig);
-  await Promise.all(keys.map((key) => key.delete()));
-  await execCmd(
-    `gcloud secrets delete ${addressesIdentifier(
-      agentConfig.runEnv,
-      agentConfig.context,
-    )} --quiet`,
-  );
+// Returns the deployer key. This is always a GCP key, not chain specific,
+// and in the Hyperlane context.
+export function getDeployerKey(agentConfig: AgentContextConfig): CloudAgentKey {
+  return new AgentGCPKey(agentConfig.runEnv, Contexts.Hyperlane, Role.Deployer);
 }
+
+// Returns the validator signer key and the chain signer key for the given validator for
+// the given chain and index.
+// The validator signer key is used to sign checkpoints and can be AWS regardless of the
+// chain protocol type. The chain signer is dependent on the chain protocol type.
+export function getValidatorKeysForChain(
+  agentConfig: AgentContextConfig,
+  chainName: ChainName,
+  index: number,
+): {
+  validator: CloudAgentKey;
+  chainSigner: CloudAgentKey;
+} {
+  const validator = agentConfig.aws
+    ? new AgentAwsKey(agentConfig, Role.Validator, chainName, index)
+    : new AgentGCPKey(
+        agentConfig.runEnv,
+        agentConfig.context,
+        Role.Validator,
+        chainName,
+        index,
+      );
+
+  // If the chain is Ethereum-based, we can just use the validator key (even if it's AWS-based)
+  // as the chain signer. Otherwise, we need to use a GCP key.
+  const chainSigner = isEthereumProtocolChain(chainName)
+    ? validator
+    : new AgentGCPKey(
+        agentConfig.runEnv,
+        agentConfig.context,
+        Role.Validator,
+        chainName,
+        index,
+      );
+
+  return {
+    validator,
+    chainSigner,
+  };
+}
+
+// ==================
+// Functions for managing keys
+// ==================
 
 export async function createAgentKeysIfNotExists(
   agentConfig: AgentContextConfig,
@@ -151,6 +314,17 @@ export async function createAgentKeysIfNotExists(
     agentConfig.runEnv,
     agentConfig.context,
     keys.map((key) => key.serializeAsAddress()),
+  );
+}
+
+export async function deleteAgentKeys(agentConfig: AgentContextConfig) {
+  const keys = getAllCloudAgentKeys(agentConfig);
+  await Promise.all(keys.map((key) => key.delete()));
+  await execCmd(
+    `gcloud secrets delete ${addressesIdentifier(
+      agentConfig.runEnv,
+      agentConfig.context,
+    )} --quiet`,
   );
 }
 
@@ -193,30 +367,6 @@ async function persistAddresses(
   );
 }
 
-// This function returns all keys for a given mailbox chain in a dictionary where the key is the identifier
-export async function fetchKeysForChain(
-  agentConfig: RootAgentConfig,
-  chainNames: ChainName | ChainName[],
-): Promise<Record<string, CloudAgentKey>> {
-  if (!Array.isArray(chainNames)) chainNames = [chainNames];
-
-  // Get all keys for the chainNames. Include keys where chainNames is undefined,
-  // which are keys that are not chain-specific but should still be included
-  const keys = await Promise.all(
-    getAllCloudAgentKeys(agentConfig)
-      .filter(
-        (key) =>
-          key.chainName === undefined || chainNames.includes(key.chainName),
-      )
-      .map(async (key) => {
-        await key.fetch();
-        return [key.identifier, key];
-      }),
-  );
-
-  return Object.fromEntries(keys);
-}
-
 async function fetchGCPKeyAddresses(
   environment: DeployEnvironment,
   context: Contexts,
@@ -232,9 +382,4 @@ function addressesIdentifier(
   context: Contexts,
 ) {
   return `${context}-${environment}-key-addresses`;
-}
-
-function isNotEthereumProtocolChain(chainName: ChainName) {
-  if (!chainMetadata[chainName]) throw new Error(`Unknown chain ${chainName}`);
-  return chainMetadata[chainName].protocol !== ProtocolType.Ethereum;
 }

--- a/typescript/infra/src/roles.ts
+++ b/typescript/infra/src/roles.ts
@@ -3,7 +3,6 @@ export enum Role {
   Relayer = 'relayer',
   Scraper = 'scraper',
   Deployer = 'deployer',
-  Bank = 'bank',
   Kathy = 'kathy',
 }
 
@@ -11,7 +10,6 @@ export const ALL_KEY_ROLES = [
   Role.Validator,
   Role.Relayer,
   Role.Deployer,
-  Role.Bank,
   Role.Kathy,
 ];
 

--- a/typescript/infra/src/utils/utils.ts
+++ b/typescript/infra/src/utils/utils.ts
@@ -11,7 +11,7 @@ import {
   CoreChainName,
   chainMetadata,
 } from '@hyperlane-xyz/sdk';
-import { objMerge } from '@hyperlane-xyz/utils';
+import { ProtocolType, objMerge } from '@hyperlane-xyz/utils';
 
 import { Contexts } from '../../config/contexts';
 import { Role } from '../roles';
@@ -272,4 +272,9 @@ export function mustGetChainNativeTokenDecimals(chain: ChainName): number {
     throw new Error(`No native token for chain ${chain}`);
   }
   return metadata.nativeToken.decimals;
+}
+
+export function isEthereumProtocolChain(chainName: ChainName) {
+  if (!chainMetadata[chainName]) throw new Error(`Unknown chain ${chainName}`);
+  return chainMetadata[chainName].protocol === ProtocolType.Ethereum;
 }


### PR DESCRIPTION
### Description

- cherry-picks #3023 
- makes some additional small changes required to work well with key funder, specifically to filter out non-EVM chains and non-blessed chains (like Nautilus). The latter is because the environment specific multiprovider doesn't include non-blessed chains like Nautilus, and adding it messes up a bunch of our other core tooling
- small change to #3023 to read in helloworld contract addresses from the correct environment that i will bring to `main` too

### Drive-by changes

n/a

### Related issues

Part of #3024 

### Backward compatibility

ye

### Testing

ran funding script locally
