### PR TITLE
Kathy keys using correct env/context helloworld chains, small fixes

### DIFF
--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -9,7 +9,7 @@ import { environment } from './chains';
 export const keyFunderConfig: KeyFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-    tag: 'e152268-20231205-122327',
+    tag: 'b86ebc1-20231207-123951',
   },
   // We're currently using the same deployer key as mainnet.
   // To minimize nonce clobbering we offset the key funder cron

--- a/typescript/infra/config/environments/testnet4/funding.ts
+++ b/typescript/infra/config/environments/testnet4/funding.ts
@@ -9,7 +9,7 @@ import { environment } from './chains';
 export const keyFunderConfig: KeyFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-    tag: 'e152268-20231205-122327',
+    tag: 'b86ebc1-20231207-123951',
   },
   // We're currently using the same deployer key as testnet2.
   // To minimize nonce clobbering we offset the key funder cron

--- a/typescript/infra/src/agents/key-utils.ts
+++ b/typescript/infra/src/agents/key-utils.ts
@@ -2,7 +2,8 @@ import { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
 import { objMap } from '@hyperlane-xyz/utils';
 
 import { Contexts } from '../../config/contexts';
-import { helloWorld } from '../../config/environments/mainnet3/helloworld';
+import { getHelloWorldConfig } from '../../scripts/helloworld/utils';
+import { getEnvironmentConfig } from '../../scripts/utils';
 import {
   AgentContextConfig,
   DeployEnvironment,
@@ -99,10 +100,13 @@ function getRoleKeyMapPerChain(
   };
 
   const setKathyKeys = () => {
+    const envConfig = getEnvironmentConfig(agentConfig.runEnv);
+    const helloWorldConfig = getHelloWorldConfig(
+      envConfig,
+      agentConfig.context,
+    );
     // Kathy is only needed on chains where the hello world contracts are deployed.
-    for (const chainName of Object.keys(
-      helloWorld[agentConfig.context]?.addresses || {},
-    )) {
+    for (const chainName of Object.keys(helloWorldConfig.addresses)) {
       const kathyKey = getKathyKeyForChain(agentConfig, chainName);
       keysPerChain[chainName] = {
         ...keysPerChain[chainName],

--- a/typescript/infra/src/funding/key-funder.ts
+++ b/typescript/infra/src/funding/key-funder.ts
@@ -44,7 +44,7 @@ function getKeyFunderHelmValues(
     hyperlane: {
       runEnv: agentConfig.runEnv,
       // Only used for fetching RPC urls as env vars
-      chains: agentConfig.contextChainNames.relayer, // temporary hack
+      chains: agentConfig.environmentChainNames,
       contextFundingFrom: keyFunderConfig.contextFundingFrom,
       contextsAndRolesToFund: keyFunderConfig.contextsAndRolesToFund,
       connectionType: keyFunderConfig.connectionType,


### PR DESCRIPTION
### Description

- Noticed an issue with #3023 where mainnet3 helloworld addresses were always used. This uses the correct environment and context
- Also noticed errors with key funder infra because the neutron rpc url wasn't present - fixed the previous hack to accommodate this
- Filter out non evm or blessed chains from key funder as well

### Drive-by changes

n/a

### Related issues

related to #3024 

### Backward compatibility

yes

### Testing

ran locally
