### PR TITLE
fix: cosmos balance parsing

### DIFF
--- a/rust/chains/hyperlane-cosmos/src/providers/grpc.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/grpc.rs
@@ -238,7 +238,7 @@ impl WasmGrpcProvider {
             .balance
             .ok_or_else(|| ChainCommunicationError::from_other_str("account not present"))?;
 
-        Ok(balance.amount.parse()?)
+        Ok(U256::from_dec_str(&balance.amount)?)
     }
 
     /// Queries an account.


### PR DESCRIPTION
@tkporter reported that cosmos balance strings were being interpreted as hex when parsed, causing them to appear much larger. This fixes by parsing as decimal.

Tested manually by checking the metrics endpoint.