### PR TITLE
chore: remove neutron-related deployments from testnet4 context

### DIFF
--- a/rust/config/testnet4_config.json
+++ b/rust/config/testnet4_config.json
@@ -1007,32 +1007,6 @@
       "index": {
         "from": 4558491
       }
-    },
-    "neutrontestnet": {
-      "name": "neutrontestnet",
-      "domainId": "33333",
-      "chainId": "duality-devnet",
-      "mailbox": "0xdb33c78ca39541dd740659fbfd86fdd601fe7225f10f26e87595c5b8df6bdcda",
-      "interchainGasPaymaster": "0xae38a168ced2b1cdafd7da5de2fbd22749b1ab52e88cd0b121f750a6c20a2814",
-      "validatorAnnounce": "0x29d5f702a35d4135d98abf52c62ddc0cfd74001663ec14d284edff7d0419fb58",
-      "merkleTreeHook": "0xb6aac0c4650129ded8e645e6ef8dcbba710623b826e5a1dae34158a27247c668",
-      "protocol": "cosmos",
-      "finalityBlocks": 1,
-      "rpcUrls": [
-        {
-          "http": "http://54.149.31.83:26657"
-        }
-      ],
-      "grpcUrl": "http://52.43.22.152:9090",
-      "canonicalAsset": "token",
-      "prefix": "dual",
-      "index": {
-        "from": 1,
-        "chunk": 100000
-      },
-      "blocks": {
-        "reorgPeriod": 1
-      }
     }
   },
   "defaultRpcConsensusType": "fallback"

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -107,28 +107,7 @@ const releaseCandidate: RootAgentConfig = {
   },
 };
 
-const neutron: RootAgentConfig = {
-  ...contextBase,
-  context: Contexts.Neutron,
-  rolesWithKeys: [Role.Relayer],
-  contextChainNames: {
-    relayer: [Chains.goerli],
-    validator: [],
-    scraper: [],
-  },
-  relayer: {
-    rpcConsensusType: RpcConsensusType.Fallback,
-    docker: {
-      repo,
-      tag: '86b7f98-20231207-153805',
-    },
-    gasPaymentEnforcement,
-    transactionGasLimit: 750000,
-  },
-};
-
 export const agents = {
   [Contexts.Hyperlane]: hyperlane,
   [Contexts.ReleaseCandidate]: releaseCandidate,
-  [Contexts.Neutron]: neutron,
 };

--- a/typescript/infra/config/environments/testnet4/chains.ts
+++ b/typescript/infra/config/environments/testnet4/chains.ts
@@ -27,7 +27,6 @@ export const ethereumTestnetConfigs: ChainMap<ChainMetadata> = {
 // Blessed non-Ethereum chains.
 export const nonEthereumTestnetConfigs: ChainMap<ChainMetadata> = {
   // solanadevnet: chainMetadata.solanadevnet,
-  // neutrontestnet: chainMetadata.neutrontestnet,
 };
 
 export const testnetConfigs: ChainMap<ChainMetadata> = {

--- a/typescript/infra/config/environments/testnet4/gas-oracle.ts
+++ b/typescript/infra/config/environments/testnet4/gas-oracle.ts
@@ -30,7 +30,6 @@ const gasPrices: ChainMap<BigNumber> = {
   polygonzkevmtestnet: ethers.utils.parseUnits('1', 'gwei'),
   chiado: ethers.utils.parseUnits('2', 'gwei'),
   // solanadevnet: ethers.BigNumber.from('28'),
-  neutrontestnet: ethers.utils.parseUnits('0.1', 'gwei'),
 };
 
 // Used to categorize rarity of testnet tokens & approximate exchange rates.
@@ -65,7 +64,6 @@ const chainTokenRarity: ChainMap<Rarity> = {
   polygonzkevmtestnet: Rarity.Common,
   chiado: Rarity.Common,
   // solanadevnet: Rarity.Common,
-  neutrontestnet: Rarity.Common,
 };
 
 // Gets the "value" of a testnet chain

--- a/typescript/infra/config/environments/testnet4/infrastructure.ts
+++ b/typescript/infra/config/environments/testnet4/infrastructure.ts
@@ -40,7 +40,6 @@ export const infrastructure: InfrastructureConfig = {
       'testnet3-',
       'hyperlane-testnet4-',
       'rc-testnet4-',
-      'neutron-testnet4-',
       'testnet4-',
     ],
   },

--- a/typescript/sdk/src/consts/chains.ts
+++ b/typescript/sdk/src/consts/chains.ts
@@ -49,7 +49,6 @@ export enum DeprecatedChains {
   rinkeby = 'rinkeby',
   optimismkovan = 'optimismkovan',
   optimismrinkeby = 'optimismrinkeby',
-  neutrontestnet = 'neutrontestnet',
 }
 
 export const AllDeprecatedChains = Object.keys(DeprecatedChains) as string[];

--- a/typescript/sdk/src/consts/multisigIsm.ts
+++ b/typescript/sdk/src/consts/multisigIsm.ts
@@ -191,14 +191,6 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
       '0x7885fae56dbcf5176657f54adbbd881dc6714132',
     ],
   },
-  neutrontestnet: {
-    threshold: 2,
-    validators: [
-      '0x5d2a99d67cd294a821de4fb25da6901ea8f89814',
-      '0xb57486243ce3bb3c38c50a582b8bbd20cb393589',
-      '0x661faee997654d14ead4ae48035883f05c3150cf',
-    ],
-  },
 
   optimism: {
     threshold: 2,


### PR DESCRIPTION
### Description

Removes most occurences of lines that contain the `neutron` string from the testnet4 context. Where validators are set (e.g. [here](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/3e685f9fb04fd1dd10b05250ade5b65150b75086/typescript/infra/config/environments/testnet4/validators.ts#L29)), the neutron context is required for type safety but can stay empty 