### PR TITLE
Ancient8 & viction agent deploy

### DIFF
--- a/rust/config/mainnet3_config.json
+++ b/rust/config/mainnet3_config.json
@@ -736,7 +736,8 @@
       "interchainGasPaymaster": "0x0D63128D887159d63De29497dfa45AFc7C699AE4",
       "protocolFee": "0xd83A4F747fE80Ed98839e05079B1B7Fe037b1638",
       "index": {
-        "from": 73573878
+        "from": 73573878,
+        "chunk": 1000
       }
     }
   },

--- a/rust/config/mainnet3_config.json
+++ b/rust/config/mainnet3_config.json
@@ -697,7 +697,8 @@
       "mailbox": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
       "validatorAnnounce": "0xd83A4F747fE80Ed98839e05079B1B7Fe037b1638",
       "index": {
-        "from": 271840
+        "from": 426670,
+        "chunk": 999
       }
     },
     "viction": {

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -43,14 +43,14 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '86b7f98-20231207-153805',
+      tag: '34611f0-20231218-204504',
     },
     gasPaymentEnforcement,
   },
   validators: {
     docker: {
       repo,
-      tag: '86b7f98-20231207-153805',
+      tag: '34611f0-20231218-204504',
     },
     rpcConsensusType: RpcConsensusType.Quorum,
     chains: validatorChainConfig(Contexts.Hyperlane),
@@ -59,7 +59,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '86b7f98-20231207-153805',
+      tag: '34611f0-20231218-204504',
     },
   },
 };
@@ -72,7 +72,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '86b7f98-20231207-153805',
+      tag: '34611f0-20231218-204504',
     },
     // whitelist: releaseCandidateHelloworldMatchingList,
     gasPaymentEnforcement,
@@ -84,7 +84,7 @@ const releaseCandidate: RootAgentConfig = {
   validators: {
     docker: {
       repo,
-      tag: '86b7f98-20231207-153805',
+      tag: '34611f0-20231218-204504',
     },
     rpcConsensusType: RpcConsensusType.Quorum,
     chains: validatorChainConfig(Contexts.ReleaseCandidate),
@@ -108,7 +108,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '86b7f98-20231207-153805',
+      tag: '34611f0-20231218-204504',
     },
     gasPaymentEnforcement: [
       {

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -50,7 +50,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '86b7f98-20231207-153805',
+      tag: '34611f0-20231218-204504',
     },
     blacklist: [
       ...releaseCandidateHelloworldMatchingList,
@@ -67,7 +67,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '86b7f98-20231207-153805',
+      tag: '34611f0-20231218-204504',
     },
     chains: validatorChainConfig(Contexts.Hyperlane),
   },
@@ -88,7 +88,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '86b7f98-20231207-153805',
+      tag: '34611f0-20231218-204504',
     },
     whitelist: [...releaseCandidateHelloworldMatchingList],
     gasPaymentEnforcement,
@@ -101,7 +101,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '86b7f98-20231207-153805',
+      tag: '34611f0-20231218-204504',
     },
     chains: validatorChainConfig(Contexts.ReleaseCandidate),
   },
@@ -120,7 +120,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '86b7f98-20231207-153805',
+      tag: '34611f0-20231218-204504',
     },
     gasPaymentEnforcement,
     transactionGasLimit: 750000,

--- a/typescript/infra/scripts/announce-validators.ts
+++ b/typescript/infra/scripts/announce-validators.ts
@@ -8,6 +8,7 @@ import { AllChains, ChainName, HyperlaneCore } from '@hyperlane-xyz/sdk';
 import { S3Validator } from '../src/agents/aws/validator';
 import { CheckpointSyncerType } from '../src/config';
 import { deployEnvToSdkEnv } from '../src/config/environment';
+import { isEthereumProtocolChain } from '../src/utils/utils';
 
 import {
   getAgentConfig,
@@ -80,8 +81,9 @@ async function main() {
       return;
     }
     await Promise.all(
-      Object.entries(agentConfig.validators.chains).map(
-        async ([chain, validatorChainConfig]) => {
+      Object.entries(agentConfig.validators.chains)
+        .filter(([chain, _]) => isEthereumProtocolChain(chain))
+        .map(async ([chain, validatorChainConfig]) => {
           for (const validatorBaseConfig of validatorChainConfig.validators) {
             if (
               validatorBaseConfig.checkpointSyncer.type ==
@@ -104,8 +106,7 @@ async function main() {
               chains.push(chain);
             }
           }
-        },
-      ),
+        }),
     );
   }
 


### PR DESCRIPTION
### Description

- viction RPC URL maxes out at 1K blocks for eth_getLogs
- restored the index params for scroll that were accidentally changed in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3067/files#diff-edae1a4e631a67121d92119998e37740c0190bec5060e3c842cc86e4d3d26a4dL701
- deploys the agents
- fixes announce-validators.ts if there are non-evm chains in the env

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
