### PR TITLE
Redeploy routing ISM factories

### DIFF
--- a/.changeset/five-spoons-complain.md
+++ b/.changeset/five-spoons-complain.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/infra': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+Redeploy Routing ISM Factories

--- a/typescript/infra/config/environments/mainnet3/ism/verification.json
+++ b/typescript/infra/config/environments/mainnet3/ism/verification.json
@@ -119,6 +119,72 @@
       "address": "0xe6a4646EE138e282A36c0665Ad028ccdC3E525E2",
       "constructorArguments": "",
       "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x7F6cD932412508E9a8297CA626C56Ed3D279937F",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xf422a4Af27e5fbDDAf799A1d92532Edd5dE58fF3",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x43379b54E27EA8387B34B5c15534E230d490f0A8",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x8d9dB8bbF91d7852F36a954229BDf6ec69A3ae00",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0x2A2c22B0a8615ad24839fA6Af302E896Af32d1a3",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x866599CEaE5060D774EBAaE7e9f8A0431a8c1ED5",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x7F6cD932412508E9a8297CA626C56Ed3D279937F",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xf422a4Af27e5fbDDAf799A1d92532Edd5dE58fF3",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x43379b54E27EA8387B34B5c15534E230d490f0A8",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x8d9dB8bbF91d7852F36a954229BDf6ec69A3ae00",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x866599CEaE5060D774EBAaE7e9f8A0431a8c1ED5",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "ethereum": [
@@ -239,6 +305,72 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0x65f02B4fB2F0ccAb58955e4b816EebD4DFCbBaFf",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xD4dAcca08737d2a910b4Ad401f805F83D0C170f3",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x5371942D3Ed75b10d77F0f4184dDc85cC35A1420",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xc2cCfc65D2D5719E78a77EA5f6C10AA4cdEC6719",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x03862793C0EE59af3e475f7Ca67406b547FfD95c",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0x28fA9552F19039b450498B0d8e5DEAe0d0aAc559",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xBbaDB49B1fD1A0574C8D2B0589Cd9b8A79452e67",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xD4dAcca08737d2a910b4Ad401f805F83D0C170f3",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x5371942D3Ed75b10d77F0f4184dDc85cC35A1420",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xc2cCfc65D2D5719E78a77EA5f6C10AA4cdEC6719",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x03862793C0EE59af3e475f7Ca67406b547FfD95c",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xBbaDB49B1fD1A0574C8D2B0589Cd9b8A79452e67",
       "constructorArguments": "",
       "isProxy": true
     }
@@ -363,6 +495,72 @@
       "address": "0x61ca653A1F61A69E6498c45874237C4f1D8fC645",
       "constructorArguments": "",
       "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x06b9dC1a6629122e7188698d20A92edbE966914f",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xeD8F4199e4409FDAe2AfD50dC7571f6771AadE50",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x86Bb7AC2BF6044289aEAFFC421b118E38C995c5a",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x3988b98C43C7A1f7C9D3edce6CeAD3b8a3F3d969",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0x28F7907911C7E321c596686AE6D1F20516450037",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x0a3E78c160daF8be96051D318d668F97182D60Bf",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x06b9dC1a6629122e7188698d20A92edbE966914f",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xeD8F4199e4409FDAe2AfD50dC7571f6771AadE50",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x86Bb7AC2BF6044289aEAFFC421b118E38C995c5a",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x3988b98C43C7A1f7C9D3edce6CeAD3b8a3F3d969",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x0a3E78c160daF8be96051D318d668F97182D60Bf",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "polygon": [
@@ -485,6 +683,72 @@
       "address": "0x42cCAacf2666E92114F649b578056eDCeBdA8ba7",
       "constructorArguments": "",
       "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x14CEa5Df89Fa709409e83ebEA9518C5B6fb4B19B",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x370815EdA08438c8F385a6f7AB5A2Dfa75008abC",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xCC38436BFB9B9888be96b59d825E0fE5DC19e05c",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x5B8418082D87c96B7De689D0368756cddAbB35F5",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0x0d0E816eE4557689d34fAd5885C53b9393C1D9fA",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x6921808186c66558e91dF1233910862A94a57475",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x14CEa5Df89Fa709409e83ebEA9518C5B6fb4B19B",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x370815EdA08438c8F385a6f7AB5A2Dfa75008abC",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xCC38436BFB9B9888be96b59d825E0fE5DC19e05c",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x5B8418082D87c96B7De689D0368756cddAbB35F5",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x6921808186c66558e91dF1233910862A94a57475",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "bsc": [
@@ -563,6 +827,72 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0x4EFFb1d1B817c0D2823729b343ac079431182eE2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xDc3D51c58BDb84F4F209d2684151dfCa271e504f",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x707609419b70DCb4C41Ef185d3C184814c61Af9c",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x769FeC9f1a1e3DD1891015A387C92Ee9631CB0bA",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0xf771dA1B909B67ca41dda9133E1C9934B5A2D8bb",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0xe6Af5720d34213C805C08e2470aea979e3F72F75",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x1467aB848fCCdA65c2cCed0ebeBD0d95ad89E0D8",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xDc3D51c58BDb84F4F209d2684151dfCa271e504f",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x707609419b70DCb4C41Ef185d3C184814c61Af9c",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x769FeC9f1a1e3DD1891015A387C92Ee9631CB0bA",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0xf771dA1B909B67ca41dda9133E1C9934B5A2D8bb",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x1467aB848fCCdA65c2cCed0ebeBD0d95ad89E0D8",
       "constructorArguments": "",
       "isProxy": true
     }
@@ -657,6 +987,72 @@
       "address": "0x35E536a6465632d2De568F0f22c514EfEE38aEA5",
       "constructorArguments": "",
       "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xC91A3282FE1eBc29AE494f10680006f152DcE316",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xb61544De4d3A103698AC57Fd62402627B8AC3cC2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xD416cF29F961c090e9b9b8aF0970c86D93c2Ff61",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x315d8B4229134Fcb12B8955f0B5FC1310E56E764",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0xD2e905108c5e44dADA680274740f896Ea96Cf2Fb",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x71c5167429f522FA009D110954Cb08E0317d4d69",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xC91A3282FE1eBc29AE494f10680006f152DcE316",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xb61544De4d3A103698AC57Fd62402627B8AC3cC2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xD416cF29F961c090e9b9b8aF0970c86D93c2Ff61",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x315d8B4229134Fcb12B8955f0B5FC1310E56E764",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x71c5167429f522FA009D110954Cb08E0317d4d69",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "arbitrum": [
@@ -747,6 +1143,72 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0xc0Ce143F44ADc65d35fB0d24436Eaa953380dF97",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xEbA276cdC61D4BC954E80985aC8FD71453fDab8e",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xfD122f59ee8073528Cc5d36D5cc1451Bf1aF6923",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xBbc6e404F8d841560261b036cA3468B55CB9f566",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x97c5dC51adAa04B3BefE63F4e62e4778219D9426",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0xa2931C37957f3079d3B21b877d56E1db930e02a5",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xF5C9D13D0a3308a06375fD09CACE3a6120711206",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xEbA276cdC61D4BC954E80985aC8FD71453fDab8e",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xfD122f59ee8073528Cc5d36D5cc1451Bf1aF6923",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xBbc6e404F8d841560261b036cA3468B55CB9f566",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x97c5dC51adAa04B3BefE63F4e62e4778219D9426",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xF5C9D13D0a3308a06375fD09CACE3a6120711206",
       "constructorArguments": "",
       "isProxy": true
     }
@@ -871,6 +1333,72 @@
       "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
       "constructorArguments": "",
       "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0xe03dad16074BC5EEA9A9311257BF02Eb0B6AAA2b",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x9d9238fD3715281De2c8FC321135bF82EB66E932",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x9d9238fD3715281De2c8FC321135bF82EB66E932",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "base": [
@@ -993,6 +1521,72 @@
       "address": "0x3b9f24fD2ecfed0d3A88fa7f0E4e5747671981D7",
       "constructorArguments": "",
       "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0x7E27456a839BFF31CA642c060a2b68414Cb6e503",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x0d2FdC0264059C1334Aa28187E8628E1c9c6EC70",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x0d2FdC0264059C1334Aa28187E8628E1c9c6EC70",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "polygonzkevm": [
@@ -1113,6 +1707,72 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0x71DCcD21B912F7d4f636af0C9eA5DC0C10617354",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x3b9f24fD2ecfed0d3A88fa7f0E4e5747671981D7",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0xe4057c5B0c43Dc18E36b08C39B419F190D29Ac2d",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x0741b6Fd92DA99E77E5eE78CFf74cB1689B3588e",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x3b9f24fD2ecfed0d3A88fa7f0E4e5747671981D7",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x0741b6Fd92DA99E77E5eE78CFf74cB1689B3588e",
       "constructorArguments": "",
       "isProxy": true
     }
@@ -1333,6 +1993,72 @@
       "address": "0xc4c11C88AbF6087150273b2c39B27878d137a920",
       "constructorArguments": "",
       "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xe46CDa25130A89759F1Da00591D7a920CAe7667E",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xEeBd8F72573C5a08F18BeC0DbadCCD3365c06AEF",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x5aaF70a9944d2D7cf17153ea07632618b1e45C6F",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x72AffdEd251dF55c7c89566c64B9961dbc3e7A23",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0xbB5Df000113e767dE11343A16f83De733e5bCC0F",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x901bFAC323Dc06b1302D82201F62729Dff39b20a",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xe46CDa25130A89759F1Da00591D7a920CAe7667E",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xEeBd8F72573C5a08F18BeC0DbadCCD3365c06AEF",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x5aaF70a9944d2D7cf17153ea07632618b1e45C6F",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x72AffdEd251dF55c7c89566c64B9961dbc3e7A23",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x901bFAC323Dc06b1302D82201F62729Dff39b20a",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "moonbeam": [
@@ -1423,6 +2149,110 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0xE8d610DC4Baf01070FD2f223d45f84d8801D90B1",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x28336d2b8783f2373bCFc173058EA932bf3b901C",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x76FD8c164F380107631160d8Fd1f4Edc2719004D",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xd5FF00DD9E737c9d1a197246738876fAF43e4aC0",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x568De5f1639Fe7c9eba67f1191DE19eeCc77985B",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0x8061Af3A459093540d17823D651BC5E2A92669a7",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x2214b2AC96215d2FF1fffC84E4Af295d7497B013",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x28336d2b8783f2373bCFc173058EA932bf3b901C",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x76FD8c164F380107631160d8Fd1f4Edc2719004D",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xd5FF00DD9E737c9d1a197246738876fAF43e4aC0",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x568De5f1639Fe7c9eba67f1191DE19eeCc77985B",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x2214b2AC96215d2FF1fffC84E4Af295d7497B013",
+      "constructorArguments": "",
+      "isProxy": true
+    }
+  ],
+  "mantapacific": [
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x3b9f24fD2ecfed0d3A88fa7f0E4e5747671981D7",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0x8358D8291e3bEDb04804975eEa0fe9fe0fAfB147",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x6C360932873629929ff3D9ffB70bD4cbC1606541",
       "constructorArguments": "",
       "isProxy": true
     }

--- a/typescript/infra/config/environments/mainnet3/owners.ts
+++ b/typescript/infra/config/environments/mainnet3/owners.ts
@@ -16,6 +16,7 @@ export const safes: ChainMap<Address> = {
   base: '0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba',
   scroll: '0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba',
   polygonzkevm: '0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba',
+  mantapacific: '0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba',
 };
 
 // export const owners = safes;

--- a/typescript/infra/config/environments/testnet4/ism/verification.json
+++ b/typescript/infra/config/environments/testnet4/ism/verification.json
@@ -185,6 +185,126 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0x94087079Bf22D8e2BCE02e2180e738C3F21dD44E"
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x826Ab153e944cE1B251aBD174071DF70d71132D7",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x78ebeCE0fCAa39F0F0C422E87EBd6BcB708aa763",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xd93F514f36d528DCDc3af1C92788f1bf1f480A7f",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x019e0a350D85eF67250dD88CD6477ad5E0c6E31e",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xd5ab9FaC601Ed731d5e9c87E5977D2e5fD380666",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x826Ab153e944cE1B251aBD174071DF70d71132D7",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x78ebeCE0fCAa39F0F0C422E87EBd6BcB708aa763",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xd93F514f36d528DCDc3af1C92788f1bf1f480A7f",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x019e0a350D85eF67250dD88CD6477ad5E0c6E31e",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xd5ab9FaC601Ed731d5e9c87E5977D2e5fD380666",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x826Ab153e944cE1B251aBD174071DF70d71132D7",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x78ebeCE0fCAa39F0F0C422E87EBd6BcB708aa763",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xd93F514f36d528DCDc3af1C92788f1bf1f480A7f",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x019e0a350D85eF67250dD88CD6477ad5E0c6E31e",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xd5ab9FaC601Ed731d5e9c87E5977D2e5fD380666",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x826Ab153e944cE1B251aBD174071DF70d71132D7",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x78ebeCE0fCAa39F0F0C422E87EBd6BcB708aa763",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xd93F514f36d528DCDc3af1C92788f1bf1f480A7f",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x019e0a350D85eF67250dD88CD6477ad5E0c6E31e",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xd5ab9FaC601Ed731d5e9c87E5977D2e5fD380666",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "fuji": [
@@ -377,6 +497,132 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0x930c36A0c978B0b86B544859692A1D94c5148204"
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x0683D0258A162a87E1F25C454BaA4e9E9DE46B0a",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xd3262339D39103a4b41379b183b0311B78c9a11F",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x6716Ef4e72c74e66eB40198B16b4379a763fCEd8",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0xBDD7Cfb61D7ae89343b428D3E527BDA9705c4EAC",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0x683a81E0e1a238dcA7341e04c08d3bba6f0Cb74f",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xD47593C21C2429de56AcA808bb2Bbc236c6311DE",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x0683D0258A162a87E1F25C454BaA4e9E9DE46B0a",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xd3262339D39103a4b41379b183b0311B78c9a11F",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x6716Ef4e72c74e66eB40198B16b4379a763fCEd8",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0xBDD7Cfb61D7ae89343b428D3E527BDA9705c4EAC",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xD47593C21C2429de56AcA808bb2Bbc236c6311DE",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x0683D0258A162a87E1F25C454BaA4e9E9DE46B0a",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xd3262339D39103a4b41379b183b0311B78c9a11F",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x6716Ef4e72c74e66eB40198B16b4379a763fCEd8",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0xBDD7Cfb61D7ae89343b428D3E527BDA9705c4EAC",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xD47593C21C2429de56AcA808bb2Bbc236c6311DE",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x0683D0258A162a87E1F25C454BaA4e9E9DE46B0a",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xd3262339D39103a4b41379b183b0311B78c9a11F",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x6716Ef4e72c74e66eB40198B16b4379a763fCEd8",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0xBDD7Cfb61D7ae89343b428D3E527BDA9705c4EAC",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xD47593C21C2429de56AcA808bb2Bbc236c6311DE",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "mumbai": [
@@ -459,6 +705,132 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0x4A6B11110c45125D73c366C4F9CD320Be2aA60B4"
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xEd57F6Eb1750610b3879F7F5093267AF10b3a67D",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x4265E4082290e2beF66670A0fb117F3aA0aa126D",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xE0978760a9E66E6B9101eAA08A73155C5F61d29D",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0xe18F31FCd00D8DA65A11610a55458d84b2700a3d",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0x832Ea28749C93C05E5AaF8207E4e61Bd56aE3877",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x0d48031f320feEa2b2a71DCf678bC42bE8f73B45",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xEd57F6Eb1750610b3879F7F5093267AF10b3a67D",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x4265E4082290e2beF66670A0fb117F3aA0aa126D",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xE0978760a9E66E6B9101eAA08A73155C5F61d29D",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0xe18F31FCd00D8DA65A11610a55458d84b2700a3d",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x0d48031f320feEa2b2a71DCf678bC42bE8f73B45",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xEd57F6Eb1750610b3879F7F5093267AF10b3a67D",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x4265E4082290e2beF66670A0fb117F3aA0aa126D",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xE0978760a9E66E6B9101eAA08A73155C5F61d29D",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0xe18F31FCd00D8DA65A11610a55458d84b2700a3d",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x0d48031f320feEa2b2a71DCf678bC42bE8f73B45",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xEd57F6Eb1750610b3879F7F5093267AF10b3a67D",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x4265E4082290e2beF66670A0fb117F3aA0aa126D",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xE0978760a9E66E6B9101eAA08A73155C5F61d29D",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0xe18F31FCd00D8DA65A11610a55458d84b2700a3d",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x0d48031f320feEa2b2a71DCf678bC42bE8f73B45",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "bsctestnet": [
@@ -621,6 +993,78 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0xf9E264C10E9176c97c22790E0Ece8D98927Bca71"
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x9b13f3d75797951f463D61092Bba7947c8cEb25c",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x25069c25466B1F21E0D22f467a5f91bc7b24b515",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x25adfb5Ddf378EC77cd5842Ff33B96277E4DD29b",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x3938ED4c6b5a7f9947C44e58e36a864F03228175",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x9b13f3d75797951f463D61092Bba7947c8cEb25c",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x25069c25466B1F21E0D22f467a5f91bc7b24b515",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x25adfb5Ddf378EC77cd5842Ff33B96277E4DD29b",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x3938ED4c6b5a7f9947C44e58e36a864F03228175",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x9b13f3d75797951f463D61092Bba7947c8cEb25c",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x25069c25466B1F21E0D22f467a5f91bc7b24b515",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x25adfb5Ddf378EC77cd5842Ff33B96277E4DD29b",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x3938ED4c6b5a7f9947C44e58e36a864F03228175",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "goerli": [
@@ -783,6 +1227,42 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0x84e9B533555E76a8E9B95daCCbdeE8d3cFA2F5D4"
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xcc493EB29FC244004436a69354771F2C38aFC4c9",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x6A995F21a74332BCc280597807DF6Af3e4833f83",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x8D090384691b7a5ED7f418Ddf8135438913EFDcc",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0xDd4b9980b52A5e786fA903b2190aaFDdA461dED5",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0xeB998dC788E2c1e772d198d32e50890544776e75",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xDF3dbca700227925C39cAF902919f94571A50755",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "sepolia": [
@@ -945,6 +1425,42 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0x67543F48DBe592F1A15FD9aE37b1AbD104c70cf3"
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0xbe94Cd5d0973dB4A6E63Cb9e6b2b2042D99F9Bcd",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x218C5DFb7C2bC1e051FCFebBa8C6D66Dda28617E",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x3dD1aB6B71EBfEd239869365FE5B8b47E0507d89",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x4BC580FF77Dd1Eb320E96D34FddC97F0F04D3feD",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0x3F100cBBE5FD5466BdB4B3a15Ac226957e7965Ad",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x9b0CC3BD9030CE269EF3124Bb36Cf954a490688e",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "moonbasealpha": [
@@ -1107,6 +1623,42 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0xCd76aC44337BbA003bb4Bed2Ac37604148F36bA9"
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x97B07A8BCc0d212A4C76679b303A4C6441BB6186",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0xb1Fc72f251A6b6c37CD4Ef8f9287578BCc7CE9Eb",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x13b6Cb8d51C7e15e5fFee432CBB1d4614972A87e",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x713496A1477a08230E526a4e9449FCCE4d6523e9",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0xE8F752e5C4E1A6a2e3eAfa42d44D601A22d78f2b",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x063C2D908EAb532Cd207F309F0fd176ae6b2e1d1",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "optimismgoerli": [
@@ -1279,6 +1831,42 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0xE2B83e0E3fd5Cd37b969aB3cA4Fcb92b9bc59612"
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x76E4295E6d4bB5Be6314da5759fD0a9003BA522E",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x12D2e2B9bB44a34eb6a284861be742EE852b4Fc1",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x4287827a2F143ab05B708D54f1c47585D4F2aFaB",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0xAA3A04799E5Fb6daf989d952802FC8d0dADA44fe",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0xce8E9D701A1DFfe672c1d8dB20De2B3fa6F4437D",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xEDff0A731Fb99a85181d84F46a473d5754dA236C",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "arbitrumgoerli": [
@@ -1451,6 +2039,36 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0xC204a9864A10d52995E71FE5cc1fDaAA9f7D6FCB"
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x4186a6C7aa0D0be93Eda994279974CD2a1E59aE2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x2f0354820d0Da451be63D20D63AbE028DF3cb9A0",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xc5a060a9aC418FafD4eF03334A9973762157C867",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x4e2F4E576b622E3246df8430CeeCb63eA28749Ef",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x6bc6101acBFD309d7B9540c1d6B50c9985742399",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "basegoerli": [
@@ -1625,6 +2243,126 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0x7d5dCb6cbE5391fc041Fdf1ce2CdFC7E28cc39Bb"
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x4863236F3a05A1A1F0850fF8cd09afeBAE82d953",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x10c9FF6EEE4BaD29734322467f541C84001422C2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xD6B8D6C372e07f67FeAb75403c0Ec88E3cce7Ab7",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x8CF9aB5F805072A007dAd0ae56E0099e83B14b61",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xFa0dF1B35c4328BdE032e0F850693355C381c42d",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x4863236F3a05A1A1F0850fF8cd09afeBAE82d953",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x10c9FF6EEE4BaD29734322467f541C84001422C2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xD6B8D6C372e07f67FeAb75403c0Ec88E3cce7Ab7",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x8CF9aB5F805072A007dAd0ae56E0099e83B14b61",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xFa0dF1B35c4328BdE032e0F850693355C381c42d",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x4863236F3a05A1A1F0850fF8cd09afeBAE82d953",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x10c9FF6EEE4BaD29734322467f541C84001422C2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xD6B8D6C372e07f67FeAb75403c0Ec88E3cce7Ab7",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x8CF9aB5F805072A007dAd0ae56E0099e83B14b61",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xFa0dF1B35c4328BdE032e0F850693355C381c42d",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x4863236F3a05A1A1F0850fF8cd09afeBAE82d953",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x10c9FF6EEE4BaD29734322467f541C84001422C2",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0xD6B8D6C372e07f67FeAb75403c0Ec88E3cce7Ab7",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x8CF9aB5F805072A007dAd0ae56E0099e83B14b61",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xFa0dF1B35c4328BdE032e0F850693355C381c42d",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "polygonzkevmtestnet": [
@@ -1773,6 +2511,42 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0xE5cA56294dA5Bd490D5Bc489B177B002ad16AF83"
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x99B304925A08aba9305bC0A8FccBf71B4290c5EF",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x33999AB153F68D481AAB1B238368Ffd1Fe81F360",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x3e6F45B03314bD21BcE4201666d483291575E391",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0x87935eB971eaA9826060261b07a919451dfd0409",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0xc08675806BA844467E559E45E4bB59e66778bDcd",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0x772E6fa7a868C94e6031683AD13E821e6649d60C",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ],
   "scrollsepolia": [
@@ -1915,6 +2689,42 @@
     {
       "name": "DomaingRoutingIsm",
       "address": "0x7fFe8C9c17F46F94D784E148FbadD4bF66477722"
+    },
+    {
+      "name": "StaticMerkleRootMultisigIsm",
+      "address": "0x33999AB153F68D481AAB1B238368Ffd1Fe81F360",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticMessageIdMultisigIsm",
+      "address": "0x3e6F45B03314bD21BcE4201666d483291575E391",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationIsm",
+      "address": "0x87935eB971eaA9826060261b07a919451dfd0409",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "StaticAggregationHook",
+      "address": "0xE5cA56294dA5Bd490D5Bc489B177B002ad16AF83",
+      "constructorArguments": "",
+      "isProxy": true
+    },
+    {
+      "name": "RoutingIsmFactory",
+      "address": "0x17866ebE0e503784a9461d3e753dEeD0d3F61153",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "DomaingRoutingIsm",
+      "address": "0xea80345322520d37770dbDeD3FE9c53ba93E70D8",
+      "constructorArguments": "",
+      "isProxy": true
     }
   ]
 }

--- a/typescript/sdk/src/consts/environments/mainnet.json
+++ b/typescript/sdk/src/consts/environments/mainnet.json
@@ -6,13 +6,13 @@
     "messageIdMultisigIsmFactory": "0xEa5Be2AD66BB1BA321B7aCf0A079fBE304B09Ca0",
     "aggregationIsmFactory": "0x81AdDD9Ca89105063DaDEBd5B4408551Ce850E22",
     "aggregationHookFactory": "0xFeeB86e70e4a640cDd29636CCE19BD6fe8628135",
-    "routingIsmFactory": "0xF0752A65ffB2153EaE53F6a70c858a87022d5c56",
     "mailbox": "0x5d934f4e2f797775e53561bB72aca21ba36B96BB",
     "merkleTreeHook": "0x73FbD25c3e817DC4B4Cd9d00eff6D83dcde2DfF6",
     "interchainGasPaymaster": "0x0071740Bf129b05C4684abfbBeD248D80971cce2",
     "aggregationHook": "0x34dAb05650Cf590088bA18aF9d597f3e081bCc47",
     "protocolFee": "0xF8F3629e308b4758F8396606405989F8D8C9c578",
-    "validatorAnnounce": "0x454E1a1E1CA8B51506090f1b5399083658eA4Fc5"
+    "validatorAnnounce": "0x454E1a1E1CA8B51506090f1b5399083658eA4Fc5",
+    "routingIsmFactory": "0x0d0E816eE4557689d34fAd5885C53b9393C1D9fA"
   },
   "bsc": {
     "storageGasOracle": "0x91d23D603d60445411C06e6443d81395593B7940",
@@ -21,13 +21,13 @@
     "messageIdMultisigIsmFactory": "0x4B1d8352E35e3BDE36dF5ED2e73C24E35c4a96b7",
     "aggregationIsmFactory": "0x38B3878c4fb44d201DA924c4a04bae3EE728c065",
     "aggregationHookFactory": "0xe70E86a7D1e001D419D71F960Cb6CaD59b6A3dB6",
-    "routingIsmFactory": "0xc40481D13419BC8090e6AD07074Ef39E538c09CE",
     "mailbox": "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4",
     "merkleTreeHook": "0xFDb9Cd5f9daAA2E4474019405A328a88E7484f26",
     "interchainGasPaymaster": "0x78E25e7f84416e69b9339B0A6336EB6EFfF6b451",
     "aggregationHook": "0x402Fc106576462a892355d69ACF03D46A888ae88",
     "protocolFee": "0xA8Aa5f14a5463a78E45CC068F11c867949F3E367",
-    "validatorAnnounce": "0x7024078130D9c2100fEA474DAD009C2d1703aCcd"
+    "validatorAnnounce": "0x7024078130D9c2100fEA474DAD009C2d1703aCcd",
+    "routingIsmFactory": "0xe6Af5720d34213C805C08e2470aea979e3F72F75"
   },
   "arbitrum": {
     "storageGasOracle": "0xD3805207b65d99C075ceA938Fa7c0587026a5DF5",
@@ -36,13 +36,13 @@
     "messageIdMultisigIsmFactory": "0x12Df53079d399a47e9E730df095b712B0FDFA791",
     "aggregationIsmFactory": "0xD4883084389fC1Eeb4dAfB2ADcFc36B711c310EB",
     "aggregationHookFactory": "0x9B5f440bBb64Fee337F37e03362b628711Ea09C7",
-    "routingIsmFactory": "0xC020F8A7b00178dFA0fcC75C159e14b79F8e5c63",
     "merkleTreeHook": "0x748040afB89B8FdBb992799808215419d36A0930",
     "interchainGasPaymaster": "0x3b6044acd6767f017e99318AA6Ef93b7B06A5a22",
     "aggregationHook": "0xe0cb37cFc47296f1c4eD77EFf92Aed478644d10c",
     "protocolFee": "0xD0199067DACb8526e7dc524a9a7DCBb57Cd25421",
     "mailbox": "0x979Ca5202784112f4738403dBec5D0F3B9daabB9",
-    "validatorAnnounce": "0x1df063280C4166AF9a725e3828b4dAC6c7113B08"
+    "validatorAnnounce": "0x1df063280C4166AF9a725e3828b4dAC6c7113B08",
+    "routingIsmFactory": "0xa2931C37957f3079d3B21b877d56E1db930e02a5"
   },
   "optimism": {
     "storageGasOracle": "0x27e88AeB8EA4B159d81df06355Ea3d20bEB1de38",
@@ -51,13 +51,13 @@
     "messageIdMultisigIsmFactory": "0xAa4Be20E9957fE21602c74d7C3cF5CB1112EA9Ef",
     "aggregationIsmFactory": "0x7491843F3A5Ba24E0f17a22645bDa04A1Ae2c584",
     "aggregationHookFactory": "0x15DEeAB8dECDe553bb0B1F9C00984cbcae1af3D7",
-    "routingIsmFactory": "0x89E3530137aD51743536443a3EC838b502E72eb7",
     "merkleTreeHook": "0x68eE9bec9B4dbB61f69D9D293Ae26a5AACb2e28f",
     "interchainGasPaymaster": "0xD8A76C4D91fCbB7Cc8eA795DFDF870E48368995C",
     "aggregationHook": "0x4ccC6d8eB79f2a1EC9bcb0f211fef7907631F91f",
     "protocolFee": "0xD71Ff941120e8f935b8b1E2C1eD72F5d140FF458",
     "mailbox": "0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D",
-    "validatorAnnounce": "0x30f5b08e01808643221528BB2f7953bf2830Ef38"
+    "validatorAnnounce": "0x30f5b08e01808643221528BB2f7953bf2830Ef38",
+    "routingIsmFactory": "0xD2e905108c5e44dADA680274740f896Ea96Cf2Fb"
   },
   "moonbeam": {
     "storageGasOracle": "0x448b7ADB0dA36d41AA2AfDc9d63b97541A7b3819",
@@ -66,13 +66,13 @@
     "messageIdMultisigIsmFactory": "0x84Df48F8f241f11d0fA302d09d73030429Bd9C73",
     "aggregationIsmFactory": "0x40c6Abcb6A2CdC8882d4bEcaC47927005c7Bb8c2",
     "aggregationHookFactory": "0x59cC3E7A49DdC4893eB8754c7908f96072A7DbE8",
-    "routingIsmFactory": "0x98Aa6239FfCcEc73A662a5e5e26Bc3fD7c7291B7",
     "mailbox": "0x094d03E751f49908080EFf000Dd6FD177fd44CC3",
     "merkleTreeHook": "0x87403b85f6f316e7ba91ba1fa6C3Fb7dD4095547",
     "interchainGasPaymaster": "0x14760E32C0746094cF14D97124865BC7F0F7368F",
     "aggregationHook": "0x23cca255aE83F57F39EAf9D14fB9FdaDF22D5863",
     "protocolFee": "0xCd3e29A9D293DcC7341295996a118913F7c582c0",
-    "validatorAnnounce": "0x8c1001eBee6F25b31863A55EadfF149aF88B356F"
+    "validatorAnnounce": "0x8c1001eBee6F25b31863A55EadfF149aF88B356F",
+    "routingIsmFactory": "0x8061Af3A459093540d17823D651BC5E2A92669a7"
   },
   "gnosis": {
     "storageGasOracle": "0x5E01d8F34b629E3f92d69546bbc4142A7Adee7e9",
@@ -82,19 +82,18 @@
     "aggregationIsmFactory": "0x11EF91d17c5ad3330DbCa709a8841743d3Af6819",
     "aggregationHookFactory": "0xbC8AA096dabDf4A0200BB9f8D4Cbb644C3D86d7B",
     "mailbox": "0xaD09d78f4c6b9dA2Ae82b1D34107802d380Bb74f",
-    "routingIsmFactory": "0xd9Cc2e652A162bb93173d1c44d46cd2c0bbDA59D",
     "merkleTreeHook": "0x2684C6F89E901987E1FdB7649dC5Be0c57C61645",
     "interchainGasPaymaster": "0xDd260B99d302f0A3fF885728c086f729c06f227f",
     "aggregationHook": "0xdD1FA1C12496474c1dDC67a658Ba81437F818861",
     "protocolFee": "0x9c2214467Daf9e2e1F45b36d08ce0b9C65BFeA88",
-    "validatorAnnounce": "0x87ED6926abc9E38b9C7C19f835B41943b622663c"
+    "validatorAnnounce": "0x87ED6926abc9E38b9C7C19f835B41943b622663c",
+    "routingIsmFactory": "0xbB5Df000113e767dE11343A16f83De733e5bCC0F"
   },
   "base": {
     "merkleRootMultisigIsmFactory": "0x8b83fefd896fAa52057798f6426E9f0B080FCCcE",
     "messageIdMultisigIsmFactory": "0x8F7454AC98228f3504Bb91eA3D8Adafe6406110A",
     "aggregationIsmFactory": "0xEb9FcFDC9EfDC17c1EC5E1dc085B98485da213D6",
     "aggregationHookFactory": "0x1052eF3419f26Bec74Ed7CEf4a4FA6812Bc09908",
-    "routingIsmFactory": "0x0761b0827849abbf7b0cC09CE14e1C93D87f5004",
     "proxyAdmin": "0x4Ed7d626f1E96cD1C0401607Bf70D95243E3dEd1",
     "mailbox": "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D",
     "merkleTreeHook": "0x19dc38aeae620380430C200a6E990D5Af5480117",
@@ -102,14 +101,14 @@
     "interchainGasPaymaster": "0xc3F23848Ed2e04C0c6d41bd7804fa8f89F940B94",
     "aggregationHook": "0x13f3d4B0Ee0a713430fded9E18f7fb6c91A6E41F",
     "protocolFee": "0x99ca8c74cE7Cfa9d72A51fbb05F9821f5f826b3a",
-    "validatorAnnounce": "0x182E8d7c5F1B06201b102123FC7dF0EaeB445a7B"
+    "validatorAnnounce": "0x182E8d7c5F1B06201b102123FC7dF0EaeB445a7B",
+    "routingIsmFactory": "0x7E27456a839BFF31CA642c060a2b68414Cb6e503"
   },
   "scroll": {
     "merkleRootMultisigIsmFactory": "0x2C1FAbEcd7bFBdEBF27CcdB67baADB38b6Df90fC",
     "messageIdMultisigIsmFactory": "0x8b83fefd896fAa52057798f6426E9f0B080FCCcE",
     "aggregationIsmFactory": "0x8F7454AC98228f3504Bb91eA3D8Adafe6406110A",
     "aggregationHookFactory": "0xEb9FcFDC9EfDC17c1EC5E1dc085B98485da213D6",
-    "routingIsmFactory": "0x1052eF3419f26Bec74Ed7CEf4a4FA6812Bc09908",
     "merkleTreeHook": "0x6119E37Bd66406A1Db74920aC79C15fB8411Ba76",
     "proxyAdmin": "0x0761b0827849abbf7b0cC09CE14e1C93D87f5004",
     "storageGasOracle": "0x481171eb1aad17eDE6a56005B7F1aB00C581ef13",
@@ -117,14 +116,14 @@
     "aggregationHook": "0x9Bc0FAf446E128a618A88a2F28960Fb2Ca169faE",
     "protocolFee": "0xc3F23848Ed2e04C0c6d41bd7804fa8f89F940B94",
     "mailbox": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
-    "validatorAnnounce": "0xd83A4F747fE80Ed98839e05079B1B7Fe037b1638"
+    "validatorAnnounce": "0xd83A4F747fE80Ed98839e05079B1B7Fe037b1638",
+    "routingIsmFactory": "0xe03dad16074BC5EEA9A9311257BF02Eb0B6AAA2b"
   },
   "polygonzkevm": {
     "merkleRootMultisigIsmFactory": "0x8F7454AC98228f3504Bb91eA3D8Adafe6406110A",
     "messageIdMultisigIsmFactory": "0xEb9FcFDC9EfDC17c1EC5E1dc085B98485da213D6",
     "aggregationIsmFactory": "0x1052eF3419f26Bec74Ed7CEf4a4FA6812Bc09908",
     "aggregationHookFactory": "0x0761b0827849abbf7b0cC09CE14e1C93D87f5004",
-    "routingIsmFactory": "0x4Ed7d626f1E96cD1C0401607Bf70D95243E3dEd1",
     "merkleTreeHook": "0x149db7afD694722747035d5AEC7007ccb6F8f112",
     "proxyAdmin": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
     "storageGasOracle": "0x19dc38aeae620380430C200a6E990D5Af5480117",
@@ -132,7 +131,8 @@
     "aggregationHook": "0x8464aF853363B8d6844070F68b0AB34Cb6523d0F",
     "protocolFee": "0xd83A4F747fE80Ed98839e05079B1B7Fe037b1638",
     "mailbox": "0x3a464f746D23Ab22155710f44dB16dcA53e0775E",
-    "validatorAnnounce": "0x2fa5F5C96419C222cDbCeC797D696e6cE428A7A9"
+    "validatorAnnounce": "0x2fa5F5C96419C222cDbCeC797D696e6cE428A7A9",
+    "routingIsmFactory": "0xe4057c5B0c43Dc18E36b08C39B419F190D29Ac2d"
   },
   "celo": {
     "storageGasOracle": "0xD9A9966E7dA9a7f0032bF449FB12696a638E673C",
@@ -141,13 +141,13 @@
     "messageIdMultisigIsmFactory": "0xaB402f227e892Ef37C105bf06619c0fa106a1fB2",
     "aggregationIsmFactory": "0x1722dd970a1F56040712129f5Eeb76B003fd7500",
     "aggregationHookFactory": "0xc3745652EFB8555A8b064A0EA78d295133d326D2",
-    "routingIsmFactory": "0xec748b5623f0B50E4c5eB1CFa7Bd46C3213608b6",
     "merkleTreeHook": "0x04dB778f05854f26E67e0a66b740BBbE9070D366",
     "interchainGasPaymaster": "0x571f1435613381208477ac5d6974310d88AC7cB7",
     "aggregationHook": "0xc65890329066FB20c339Bc5C22f1756e9D3a4fF5",
     "protocolFee": "0x89886d431f9c3eEE64DCD6dAbA3f7D689D98D899",
     "mailbox": "0x50da3B3907A08a24fe4999F4Dcf337E8dC7954bb",
-    "validatorAnnounce": "0xCeF677b65FDaA6804d4403083bb12B8dB3991FE1"
+    "validatorAnnounce": "0xCeF677b65FDaA6804d4403083bb12B8dB3991FE1",
+    "routingIsmFactory": "0x2A2c22B0a8615ad24839fA6Af302E896Af32d1a3"
   },
   "ethereum": {
     "storageGasOracle": "0xc9a103990A8dB11b4f627bc5CD1D0c2685484Ec5",
@@ -156,13 +156,13 @@
     "messageIdMultisigIsmFactory": "0xfA21D9628ADce86531854C2B7ef00F07394B0B69",
     "aggregationIsmFactory": "0x46FA191Ad972D9674Ed752B69f9659A0d7b22846",
     "aggregationHookFactory": "0x6D2555A8ba483CcF4409C39013F5e9a3285D3C9E",
-    "routingIsmFactory": "0xCb74c6aE411236CEE6803619916694BE86cF5987",
     "merkleTreeHook": "0x48e6c30B97748d1e2e03bf3e9FbE3890ca5f8CCA",
     "interchainGasPaymaster": "0x9e6B1022bE9BBF5aFd152483DAD9b88911bC8611",
     "aggregationHook": "0xb87AC8EA4533AE017604E44470F7c1E550AC6F10",
     "protocolFee": "0x8B05BF30F6247a90006c5837eA63C7905D79e6d8",
     "mailbox": "0xc005dc82818d67AF737725bD4bf75435d065D239",
-    "validatorAnnounce": "0xCe74905e51497b4adD3639366708b821dcBcff96"
+    "validatorAnnounce": "0xCe74905e51497b4adD3639366708b821dcBcff96",
+    "routingIsmFactory": "0x28fA9552F19039b450498B0d8e5DEAe0d0aAc559"
   },
   "avalanche": {
     "storageGasOracle": "0x175821F30AdCAA4bbB72Ce98eF76C2E0De2C3f21",
@@ -171,20 +171,19 @@
     "messageIdMultisigIsmFactory": "0x8819D653DF5b1FC0DdB32189a2704E471AF8483c",
     "aggregationIsmFactory": "0xa5E13796eB7d2EDCc88012c8cfF90D69B51FcF9f",
     "aggregationHookFactory": "0x3bF6Ac986C7Af9A9Ac356C0e99C0041EFd8D96e7",
-    "routingIsmFactory": "0xA9Ddc70f50009aF8bDB312aA757B4304b0F7BbB3",
     "merkleTreeHook": "0x84eea61D679F42D92145fA052C89900CBAccE95A",
     "interchainGasPaymaster": "0x95519ba800BBd0d34eeAE026fEc620AD978176C0",
     "aggregationHook": "0x0165a22BA489F7DA37DAf6397781777D9FCB5708",
     "protocolFee": "0xEc4AdA26E51f2685279F37C8aE62BeAd8212D597",
     "mailbox": "0xFf06aFcaABaDDd1fb08371f9ccA15D73D51FeBD6",
-    "validatorAnnounce": "0x9Cad0eC82328CEE2386Ec14a12E81d070a27712f"
+    "validatorAnnounce": "0x9Cad0eC82328CEE2386Ec14a12E81d070a27712f",
+    "routingIsmFactory": "0x28F7907911C7E321c596686AE6D1F20516450037"
   },
   "mantapacific": {
     "merkleRootMultisigIsmFactory": "0x8F7454AC98228f3504Bb91eA3D8Adafe6406110A",
     "messageIdMultisigIsmFactory": "0xEb9FcFDC9EfDC17c1EC5E1dc085B98485da213D6",
     "aggregationIsmFactory": "0x1052eF3419f26Bec74Ed7CEf4a4FA6812Bc09908",
     "aggregationHookFactory": "0x0761b0827849abbf7b0cC09CE14e1C93D87f5004",
-    "routingIsmFactory": "0x4Ed7d626f1E96cD1C0401607Bf70D95243E3dEd1",
     "proxyAdmin": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
     "mailbox": "0x3a464f746D23Ab22155710f44dB16dcA53e0775E",
     "domainRoutingIsm": "0xDEed16fe4b1c9b2a93483EDFf34C77A9b57D31Ff",
@@ -193,6 +192,7 @@
     "merkleTreeHook": "0x149db7afD694722747035d5AEC7007ccb6F8f112",
     "aggregationHook": "0x8464aF853363B8d6844070F68b0AB34Cb6523d0F",
     "protocolFee": "0xd83A4F747fE80Ed98839e05079B1B7Fe037b1638",
-    "validatorAnnounce": "0x2fa5F5C96419C222cDbCeC797D696e6cE428A7A9"
+    "validatorAnnounce": "0x2fa5F5C96419C222cDbCeC797D696e6cE428A7A9",
+    "routingIsmFactory": "0x8358D8291e3bEDb04804975eEa0fe9fe0fAfB147"
   }
 }

--- a/typescript/sdk/src/consts/environments/testnet.json
+++ b/typescript/sdk/src/consts/environments/testnet.json
@@ -4,7 +4,6 @@
     "messageIdMultisigIsmFactory": "0x54148470292C24345fb828B003461a9444414517",
     "aggregationIsmFactory": "0x589C201a07c26b4725A4A829d772f24423da480B",
     "aggregationHookFactory": "0xDDcFEcF17586D08A5740B7D91735fcCE3dfe3eeD",
-    "routingIsmFactory": "0x33dB966328Ea213b0f76eF96CA368AB37779F065",
     "proxyAdmin": "0x05Ea36Caee7d92C173334C9D97DcD39ABdCB2b69",
     "mailbox": "0x58483b754Abb1E8947BE63d6b95DF75b8249543A",
     "validatorAnnounce": "0x679Dc08cC3A4acFeea2f7CAFAa37561aE0b41Ce7",
@@ -13,14 +12,14 @@
     "interchainGasPaymaster": "0x28B02B97a850872C4D33C3E024fab6499ad96564",
     "aggregationHook": "0x168e606fE4A9c8d7F83a3aAA132E831f153e4bAa",
     "protocolFee": "0xEe421285728284000ec6c6C55C6F9161faeFfa99",
-    "fallbackRoutingHook": "0x2C6dD6768E669EDB7b53f26067C1C4534862c3de"
+    "fallbackRoutingHook": "0x2C6dD6768E669EDB7b53f26067C1C4534862c3de",
+    "routingIsmFactory": "0xb6242d549d4b19a20684397790AFa555b16Bc979"
   },
   "arbitrumgoerli": {
     "merkleRootMultisigIsmFactory": "0x17D58eBb5Ea0E2d360c877E119FAef4C4052e6B9",
     "messageIdMultisigIsmFactory": "0x922CeEe9e8832a047e6aD68Df4F079F271b73Ac3",
     "aggregationIsmFactory": "0xC5Bb8CDD44B6c56695df45c7AA8012a97dD6ED13",
     "aggregationHookFactory": "0x39a8711BF44165A2292Cb5cB43229659c2Bb11c9",
-    "routingIsmFactory": "0x735491727b9a1206E16AF4964aF68d5BB9122333",
     "proxyAdmin": "0x00DFB81Bfc45fa03060b605273147F274ea807E5",
     "mailbox": "0x13dABc0351407d5aAa0A50003a166A73b4febfDc",
     "validatorAnnounce": "0x4a01EEBa1CC20F47A2e60aE4ec932051601FcB9e",
@@ -29,14 +28,14 @@
     "interchainGasPaymaster": "0x76189acFA212298d7022624a4633411eE0d2f26F",
     "aggregationHook": "0xf852EB6b98d84A4296754043a56759a0Ae0E06df",
     "protocolFee": "0x0358ba0D90ED2d90fB8cBb610F27C274D8077a0B",
-    "fallbackRoutingHook": "0xEdA6f85f4761A1f9e42FD40CA5a4E8Ce1C764015"
+    "fallbackRoutingHook": "0xEdA6f85f4761A1f9e42FD40CA5a4E8Ce1C764015",
+    "routingIsmFactory": "0x4D6b4fe86cA1B49ea9CcDFA92F97e4EA0C27Cef2"
   },
   "optimismgoerli": {
     "merkleRootMultisigIsmFactory": "0xAbC25d7daDD748948F5cC912A807b0f8FcBb56a9",
     "messageIdMultisigIsmFactory": "0x7868B6026E36C4b6E2ca6a0CaBDb1A6D0CcC443B",
     "aggregationIsmFactory": "0xf666A33C451E8371907aD22dd545E1678fCa1582",
     "aggregationHookFactory": "0x00cE81F7B02e0673815a8b0A54e62AeabDE78685",
-    "routingIsmFactory": "0x1807e7d67F00393a49c445E367face82D65d86c7",
     "proxyAdmin": "0x800b4be4Dc91E56DE934D9f16888d113eFf89Ebb",
     "mailbox": "0xB5f021728Ea6223E3948Db2da61d612307945eA2",
     "validatorAnnounce": "0x24D31e12E4d3bc2C46C994FcE0c828b218A1aeAb",
@@ -45,14 +44,14 @@
     "interchainGasPaymaster": "0x02A7661273528EfF3d78CBE7CbD1a717b28B89fC",
     "aggregationHook": "0x1C8A2588b8038BF9B7b1b60dD0EdF5b995A45599",
     "protocolFee": "0x962e30F6A3ECDA85c7fa1FcF38cD04efA991Ee20",
-    "fallbackRoutingHook": "0xc775c748F8c9F5443151Fd989e8B61375657474d"
+    "fallbackRoutingHook": "0xc775c748F8c9F5443151Fd989e8B61375657474d",
+    "routingIsmFactory": "0xce8E9D701A1DFfe672c1d8dB20De2B3fa6F4437D"
   },
   "scrollsepolia": {
     "merkleRootMultisigIsmFactory": "0x275aCcCa81cAD931dC6fB6E49ED233Bc99Bed4A7",
     "messageIdMultisigIsmFactory": "0xeb6f11189197223c656807a83B0DD374f9A6dF44",
     "aggregationIsmFactory": "0x16B710b86CAd07E6F1C531861a16F5feC29dba37",
     "aggregationHookFactory": "0x44b764045BfDC68517e10e783E69B376cef196B2",
-    "routingIsmFactory": "0xC2E36cd6e32e194EE11f15D9273B64461A4D49A2",
     "proxyAdmin": "0x598facE78a4302f11E3de0bee1894Da0b2Cb71F8",
     "mailbox": "0x3C5154a193D6e2955650f9305c8d80c18C814A68",
     "validatorAnnounce": "0x527768930D889662Fe7ACF64294871e86e4C2381",
@@ -61,14 +60,14 @@
     "interchainGasPaymaster": "0x86fb9F1c124fB20ff130C41a79a432F770f67AFD",
     "aggregationHook": "0x7b63Aa270335F8896717c2A809205F4b650E4268",
     "protocolFee": "0x5821f3B6eE05F3dC62b43B74AB1C8F8E6904b1C8",
-    "fallbackRoutingHook": "0xE1CCB130389f687bf745Dd6dc05E50da17d9ea96"
+    "fallbackRoutingHook": "0xE1CCB130389f687bf745Dd6dc05E50da17d9ea96",
+    "routingIsmFactory": "0x17866ebE0e503784a9461d3e753dEeD0d3F61153"
   },
   "alfajores": {
     "merkleRootMultisigIsmFactory": "0xa9C7e306C0941896CA1fd528aA59089571D8D67E",
     "messageIdMultisigIsmFactory": "0xC1b8c0e56D6a34940Ee2B86172450B54AFd633A7",
     "aggregationIsmFactory": "0x4bE8AC22f506B1504C93C3A5b1579C5e7c550D9C",
     "aggregationHookFactory": "0x71bB34Ee833467443628CEdFAA188B2387827Cee",
-    "routingIsmFactory": "0x37308d498bc7B0f002cb02Cf8fA01770dC2169c8",
     "proxyAdmin": "0x4eDBf5846D973c53AF478cf62aB5bC92807521e3",
     "mailbox": "0xEf9F292fcEBC3848bF4bB92a96a04F9ECBb78E59",
     "validatorAnnounce": "0x3726EE36a2A9e11a40d1ffD7D9A1A16e0154cDA0",
@@ -77,14 +76,14 @@
     "interchainGasPaymaster": "0x44769b0f4a6f01339e131a691cc2eebbb519d297",
     "aggregationHook": "0xdBabD76358897E68E4964647C1fb8Bf524f5EFdB",
     "protocolFee": "0xC9D50584F08Bf6cCD1004d14c7062044b45E3b48",
-    "fallbackRoutingHook": "0x3528B1aeF3a3d29E0eae90ad777A2b4A6a48aC3F"
+    "fallbackRoutingHook": "0x3528B1aeF3a3d29E0eae90ad777A2b4A6a48aC3F",
+    "routingIsmFactory": "0x30d9A03762431F8A917a0C469E7A62Bf55092Ca6"
   },
   "polygonzkevmtestnet": {
     "merkleRootMultisigIsmFactory": "0xfc6e546510dC9d76057F1f76633FCFfC188CB213",
     "messageIdMultisigIsmFactory": "0x275aCcCa81cAD931dC6fB6E49ED233Bc99Bed4A7",
     "aggregationIsmFactory": "0xeb6f11189197223c656807a83B0DD374f9A6dF44",
     "aggregationHookFactory": "0x16B710b86CAd07E6F1C531861a16F5feC29dba37",
-    "routingIsmFactory": "0x44b764045BfDC68517e10e783E69B376cef196B2",
     "proxyAdmin": "0x666a24F62f7A97BA33c151776Eb3D9441a059eB8",
     "mailbox": "0x598facE78a4302f11E3de0bee1894Da0b2Cb71F8",
     "validatorAnnounce": "0x7914A3349107A7295Bbf2374db5A973d73D1b324",
@@ -93,14 +92,14 @@
     "interchainGasPaymaster": "0xAD34A66Bf6dB18E858F6B686557075568c6E031C",
     "aggregationHook": "0x0Fd2C6F0Ad45e766660b9fDebCF36a2AD69536D1",
     "protocolFee": "0xddf4C3e791caCaFd26D7fb275549739B38ae6e75",
-    "fallbackRoutingHook": "0xBF2C366530C1269d531707154948494D3fF4AcA7"
+    "fallbackRoutingHook": "0xBF2C366530C1269d531707154948494D3fF4AcA7",
+    "routingIsmFactory": "0xc08675806BA844467E559E45E4bB59e66778bDcd"
   },
   "sepolia": {
     "merkleRootMultisigIsmFactory": "0x0a71AcC99967829eE305a285750017C4916Ca269",
     "messageIdMultisigIsmFactory": "0xFEb9585b2f948c1eD74034205a7439261a9d27DD",
     "aggregationIsmFactory": "0xC83e12EF2627ACE445C298e6eC418684918a6002",
     "aggregationHookFactory": "0x160C28C92cA453570aD7C031972b58d5Dd128F72",
-    "routingIsmFactory": "0x3603458990BfEb30f99E61B58427d196814D8ce1",
     "proxyAdmin": "0x97Bbc6bBaFa5Ce3b2FA966c121Af63bD09e940f8",
     "storageGasOracle": "0x71775B071F77F1ce52Ece810ce084451a3045FFe",
     "interchainGasPaymaster": "0x6f2756380FD49228ae25Aa7F2817993cB74Ecc56",
@@ -109,14 +108,14 @@
     "mailbox": "0xfFAEF09B3cd11D9b20d1a19bECca54EEC2884766",
     "merkleTreeHook": "0x4917a9746A7B6E0A57159cCb7F5a6744247f2d0d",
     "validatorAnnounce": "0xE6105C59480a1B7DD3E4f28153aFdbE12F4CfCD9",
-    "fallbackRoutingHook": "0x17Dc724B7a2F09141C13b8AC33B396073785c2BC"
+    "fallbackRoutingHook": "0x17Dc724B7a2F09141C13b8AC33B396073785c2BC",
+    "routingIsmFactory": "0x3F100cBBE5FD5466BdB4B3a15Ac226957e7965Ad"
   },
   "fuji": {
     "merkleRootMultisigIsmFactory": "0x93F50Ac4E5663DAAb03508008d592f6260964f62",
     "messageIdMultisigIsmFactory": "0x90e1F9918F304645e4F6324E5C0EAc70138C84Ce",
     "aggregationIsmFactory": "0xF588129ed84F219A1f0f921bE7Aa1B2176516858",
     "aggregationHookFactory": "0x99554CC33cBCd6EDDd2f3fc9c7C9194Cb3b5df1E",
-    "routingIsmFactory": "0xf9271189Cb30AD1F272f1A9EB2272224135B9350",
     "proxyAdmin": "0x378dA02f7dC3c23A8B5ecE32b8056CdF01e8d477",
     "mailbox": "0x5b6CFf85442B851A8e6eaBd2A4E4507B5135B3B0",
     "validatorAnnounce": "0x4f7179A691F8a684f56cF7Fed65171877d30739a",
@@ -125,14 +124,14 @@
     "interchainGasPaymaster": "0x6895d3916B94b386fAA6ec9276756e16dAe7480E",
     "aggregationHook": "0x8E9b4006171c6B75111823e7545Ee5400CEce0B3",
     "protocolFee": "0xEbA64c8a9b4a61a9210d5fe7E4375380999C821b",
-    "fallbackRoutingHook": "0xc684f7F50DB4b2563218512e021fBdd0BeD6b57E"
+    "fallbackRoutingHook": "0xc684f7F50DB4b2563218512e021fBdd0BeD6b57E",
+    "routingIsmFactory": "0x683a81E0e1a238dcA7341e04c08d3bba6f0Cb74f"
   },
   "bsctestnet": {
     "merkleRootMultisigIsmFactory": "0x3E235B90197E1D6b5DB5ad5aD49f2c1ED6406382",
     "messageIdMultisigIsmFactory": "0x0D96aF0c01c4bbbadaaF989Eb489c8783F35B763",
     "aggregationIsmFactory": "0x40613dE82d672605Ab051C64079022Bb4F8bDE4f",
     "aggregationHookFactory": "0xa1145B39F1c7Ef9aA593BC1DB1634b00CC020942",
-    "routingIsmFactory": "0xea12ECFD1f241da323e93F12b4ed936403990190",
     "proxyAdmin": "0xb12282d2E838Aa5f2A4F9Ee5f624a77b7199A078",
     "storageGasOracle": "0x124EBCBC018A5D4Efe639f02ED86f95cdC3f6498",
     "interchainGasPaymaster": "0x0dD20e410bdB95404f71c5a4e7Fa67B892A5f949",
@@ -148,7 +147,6 @@
     "messageIdMultisigIsmFactory": "0xDdB54502A8e2a31C48148C62A8a9E83a693d6173",
     "aggregationIsmFactory": "0x8a176773d54292123d271FA0B9C7C8Def4c3a31b",
     "aggregationHookFactory": "0x6bc243963f80AEa80948e8538bB114d4122DD9c5",
-    "routingIsmFactory": "0xd16c3f34d6A2e62185aC61f76F83D3AA1E969018",
     "proxyAdmin": "0x0EdB3604D230963ecE9d83963164CFe2fDef576B",
     "storageGasOracle": "0xeC34c715ee6d050b2172E8aF650Db779561266C1",
     "interchainGasPaymaster": "0x0cD26594ea6c6526927C0F5225AC09F6288e7140",
@@ -157,14 +155,14 @@
     "merkleTreeHook": "0x28c294C61D3dE053462d2Cfa5d5f8c8D70605A59",
     "mailbox": "0x49cfd6Ef774AcAb14814D699e3F7eE36Fdfba932",
     "validatorAnnounce": "0x3c182AD9cA8A71bc107Ef440C2667E8360e1158E",
-    "fallbackRoutingHook": "0xd9E546CBB9577dC6346EdB40b24E86aE52487ab8"
+    "fallbackRoutingHook": "0xd9E546CBB9577dC6346EdB40b24E86aE52487ab8",
+    "routingIsmFactory": "0xeB998dC788E2c1e772d198d32e50890544776e75"
   },
   "moonbasealpha": {
     "merkleRootMultisigIsmFactory": "0xA59Ba0A8D4ea5A5DC9c8B0101ba7E6eE6C3399A4",
     "messageIdMultisigIsmFactory": "0x8f919348F9C4619A196Acb5e377f49E5E2C0B569",
     "aggregationIsmFactory": "0x0048FaB53526D9a0478f66D660059E3E3611FE3E",
     "aggregationHookFactory": "0x00DFB81Bfc45fa03060b605273147F274ea807E5",
-    "routingIsmFactory": "0x385C7f179168f5Da92c72E17AE8EF50F3874077f",
     "proxyAdmin": "0xb241991527F1C21adE14F55589E5940aC4852Fa0",
     "mailbox": "0x76189acFA212298d7022624a4633411eE0d2f26F",
     "merkleTreeHook": "0x155B1CD2f7Cbc58d403B9BE341FaB6CD77425175",
@@ -173,14 +171,14 @@
     "aggregationHook": "0xaA9d918C49Cea0D2a877252aFb7976B6e3A48623",
     "protocolFee": "0xe2A73F106902983452713F24Bd019F6eb8712986",
     "validatorAnnounce": "0x07543860AE9E72aBcF2Bae9827b23621A64Fa416",
-    "fallbackRoutingHook": "0xf666A33C451E8371907aD22dd545E1678fCa1582"
+    "fallbackRoutingHook": "0xf666A33C451E8371907aD22dd545E1678fCa1582",
+    "routingIsmFactory": "0xE8F752e5C4E1A6a2e3eAfa42d44D601A22d78f2b"
   },
   "mumbai": {
     "merkleRootMultisigIsmFactory": "0xda0780ed3eE577EfE0B856E00f983bF231603307",
     "messageIdMultisigIsmFactory": "0x23c2483ab814177bA79DCDCb5dFA1B105387AAB1",
     "aggregationIsmFactory": "0x54b0d9AB6a99E9C9425D20fa4D9eE9dbf067e886",
     "aggregationHookFactory": "0x54CA9De95B37365909364672D363D2ecFC4e1Af4",
-    "routingIsmFactory": "0x276C07098879f44F6C4a6ab91B6AAca6a56AD4B1",
     "merkleTreeHook": "0x9AF85731EDd41E2E50F81Ef8a0A69D2fB836EDf9",
     "proxyAdmin": "0xa99aD6B1c10E92DB8d3510f1865A6d2Ab43EAd58",
     "storageGasOracle": "0xBEd8Fd6d5c6cBd878479C25f4725C7c842a43821",
@@ -189,6 +187,7 @@
     "protocolFee": "0x244d1F7e30Be144A87602905baBF86630e8f39DC",
     "mailbox": "0x2d1889fe5B092CD988972261434F7E5f26041115",
     "validatorAnnounce": "0x99303EFF09332cDd93E8BC8b2F07b2416e4501e5",
-    "fallbackRoutingHook": "0x31191BA83143b4745745389fEe64990c65F36829"
+    "fallbackRoutingHook": "0x31191BA83143b4745745389fEe64990c65F36829",
+    "routingIsmFactory": "0x832Ea28749C93C05E5AaF8207E4e61Bd56aE3877"
   }
 }


### PR DESCRIPTION
### Description

Redeploys Routing ISM factories with new bytecode

### Related issues

https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3009 changed the routing ISM factory interface without redeploying

### Backward compatibility

No

### Testing

None
