### PR TITLE
Bump neutron gas price

### DIFF
--- a/rust/config/mainnet3_config.json
+++ b/rust/config/mainnet3_config.json
@@ -433,7 +433,7 @@
       "canonicalAsset": "untrn",
       "prefix": "neutron",
       "gasPrice": {
-        "amount": "0.5",
+        "amount": "0.57",
         "denom": "untrn"
       },
       "index": {

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -108,7 +108,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '86b7f98-20231207-153805',
+      tag: '67585a2-20231220-223937',
     },
     gasPaymentEnforcement: [
       {


### PR DESCRIPTION
### Description

Updates the neutron gas price to be slightly above the min that was recently updated :| https://github.com/cosmos/chain-registry/blob/master/neutron/chain.json#L20

Deployed the Neutron relayer to include our recent changes that allow for the gas price to be easily configured

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
