### PR TITLE
Fix initializing existing mailbox with failing gas estimation

### DIFF
--- a/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
@@ -109,7 +109,10 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       if (
         !e.message.includes('already initialized') &&
         // Some RPC providers dont return the revert reason (nor allow ethers to parse it), so we have to check the message
-        !e.message.includes('Reverted 0x08c379a')
+        !e.message.includes('Reverted 0x08c379a') &&
+        // Handle situation where the gas estimation fails on the call function,
+        // then the real error reason is not available in `e.message`, but rather in `e.error.reason`
+        !e.error?.reason?.includes('already initialized')
       ) {
         throw e;
       }


### PR DESCRIPTION
### Description

I had an issue with the `hyperlane deploy core` script and it was caused by trying to initialize the existing mailbox contract. The deploy script already has an error handling for that specific reason, but it doesn't work if the call fails during the dry run when estimating gas.  In that case, the returned error looks like this:

```json
{
  "reason": "cannot estimate gas; transaction may fail or may require manual gas limit",
  "code": "UNPREDICTABLE_GAS_LIMIT",
  "error": {
    "reason": "execution reverted: Initializable: contract is already initialized",
    "code": "UNPREDICTABLE_GAS_LIMIT",
    "method": "estimateGas",
    "transaction": {
      "from": "0xD4643110b33D92783A5bF29D41b2d14a2Db69016",
      "gasPrice": {
        "type": "BigNumber",
        "hex": "0x0b165100c3"
      },
      "to": "0xD4C4582cB9B0e63B180fEFefAE78dB486B736299",
      "data": "0xf8c8765e000000000000000000000000d4643110b33d92783a5bf29d41b2d14a2db690160000000000000000000000006ccb17924989f8a7091c685ac8b45d2ff5692282000000000000000000000000ae7a25753380e9c0f9a8887de1caef75d81351fc000000000000000000000000f97c7ab2700da42c5fb86d20ef728be545ce09e9",
      "accessList": null
    },
    "error": {
      "reason": "processing response error",
      "code": "SERVER_ERROR",
      "body": "{\"jsonrpc\":\"2.0\",\"id\":83,\"error\":{\"code\":3,\"message\":\"execution reverted: Initializable: contract is already initialized\",\"data\":\"0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002e496e697469616c697a61626c653a20636f6e747261637420697320616c726561647920696e697469616c697a6564000000000000000000000000000000000000\"}}\n",
      "error": {
        "code": 3,
        "data": "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002e496e697469616c697a61626c653a20636f6e747261637420697320616c726561647920696e697469616c697a6564000000000000000000000000000000000000"
      },
      "requestBody": "{\"method\":\"eth_estimateGas\",\"params\":[{\"gasPrice\":\"0xb165100c3\",\"from\":\"0xd4643110b33d92783a5bf29d41b2d14a2db69016\",\"to\":\"0xd4c4582cb9b0e63b180fefefae78db486b736299\",\"data\":\"0xf8c8765e000000000000000000000000d4643110b33d92783a5bf29d41b2d14a2db690160000000000000000000000006ccb17924989f8a7091c685ac8b45d2ff5692282000000000000000000000000ae7a25753380e9c0f9a8887de1caef75d81351fc000000000000000000000000f97c7ab2700da42c5fb86d20ef728be545ce09e9\"}],\"id\":83,\"jsonrpc\":\"2.0\"}",
      "requestMethod": "POST",
      "url": "https://rpc.qtestnet.org"
    }
  },
  "tx": {
    "data": "0xf8c8765e000000000000000000000000d4643110b33d92783a5bf29d41b2d14a2db690160000000000000000000000006ccb17924989f8a7091c685ac8b45d2ff5692282000000000000000000000000ae7a25753380e9c0f9a8887de1caef75d81351fc000000000000000000000000f97c7ab2700da42c5fb86d20ef728be545ce09e9",
    "to": {},
    "from": "0xD4643110b33D92783A5bF29D41b2d14a2Db69016",
    "gasPrice": {
      "type": "BigNumber",
      "hex": "0x0b165100c3"
    },
    "type": 0,
    "nonce": {},
    "gasLimit": {},
    "chainId": {}
  }
}
```

Here we can see that the real error reason for the error is nested in `e.error.reason`, but the current error handling for calling initialize on an already initialized mailbox contract only handles situations where the error reason is included in `e.message` which is not available when the transaction fails during the gas estimation phase.

https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/2b49baab02e921843f6915543e6fd68457e4b94d/typescript/sdk/src/core/HyperlaneCoreDeployer.ts#L108-L117



### Drive-by changes

Add additional check to handle a situation when the transaction fails during the gas estimation phase:
```ts
// Handle situation where the gas estimation fails on the call function,
// then the real error reason is not available in `e.message`, but rather in `e.error.reason`
!e.error?.reason?.includes('already initialized')
```


### Related issues

No related issue, I discovered the issue during my unsuccessful tries of invoking the core deployment script.

### Backward compatibility

Yes

### Testing

Manual
