### PR TITLE
Limit keyfunder pods execution

### DIFF
--- a/typescript/infra/helm/key-funder/templates/cron-job.yaml
+++ b/typescript/infra/helm/key-funder/templates/cron-job.yaml
@@ -10,6 +10,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
+      activeDeadlineSeconds: 14400 # 60 * 60 * 4 seconds = 4 hours
       template:
         spec:
           restartPolicy: Never


### PR DESCRIPTION
### Description

Right now, the key funder process can stall, causing us to stall forever. This PR adds a limit to the job spec