### PR TITLE
Fix for CwTokenAdapter getBalance method

### DIFF
--- a/.changeset/gorgeous-needles-sparkle.md
+++ b/.changeset/gorgeous-needles-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Use getBalance instead of queryContractSmart for CwTokenAdapter

--- a/typescript/sdk/src/token/adapters/CosmWasmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/CosmWasmTokenAdapter.ts
@@ -121,12 +121,9 @@ export class CwTokenAdapter
   }
 
   async getBalance(address: Address): Promise<string> {
-    const resp = await this.queryToken<BalanceResponse>({
-      balance: {
-        address,
-      },
-    });
-    return resp.balance;
+    const provider = await this.getProvider();
+    const balance = await provider.getBalance(address, this.addresses.token);
+    return balance.amount;
   }
 
   async getMetadata(): Promise<CW20Metadata> {


### PR DESCRIPTION
### Description

Use getBalance instead of queryContractSmart for CwTokenAdapter

### Backward compatibility

Yes

### Testing

Tested in warp UI
