### PR TITLE
fix: support TLS gRPC endpoints

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9822,6 +9822,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
+ "async-stream",
  "async-trait",
  "axum",
  "base64 0.21.5",
@@ -9836,7 +9837,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs 0.6.3",
+ "rustls-pemfile 1.0.4",
  "tokio",
+ "tokio-rustls 0.24.1",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/rust/chains/hyperlane-cosmos/Cargo.toml
+++ b/rust/chains/hyperlane-cosmos/Cargo.toml
@@ -29,7 +29,7 @@ tendermint = { workspace = true, features = ["rust-crypto", "secp256k1"] }
 tendermint-rpc = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tonic = { workspace = true }
+tonic = { workspace = true, features = ["transport", "tls", "tls-roots","tls-roots-common"] }
 tracing = { workspace = true }
 tracing-futures = { workspace = true }
 url = { workspace = true }


### PR DESCRIPTION
### Description

Supporting TLS gRPC endpoints is as simple as enabling the `tonic` crate features in this PR. However to maintain compatiblity with the plaintext endpoints, we need to always use `http` instead of `https`, otherwise `tonic` will try to establish a TLS connection to them and fail. 

### Related issues

- Fixes https://github.com/hyperlane-xyz/issues/issues/893

### Backward compatibility

No, in the sense that all prior plaintext urls need to be changed from `https` to `http`

### Testing

Manual
