### PR TITLE
Feat: add rustfmt

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,5 +6,5 @@ yarn lint-staged
 # if any *.rs files have changed
 if git diff --staged --exit-code --name-only | grep -q -E ".*\.rs$"; then
     echo "Running cargo fmt pre-commit hook"
-    cargo fmt --all --check --manifest-path rust/Cargo.toml
+    cargo +nightly fmt --all --check --manifest-path rust/Cargo.toml
 fi

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -1,0 +1,2 @@
+imports_granularity = "Crate"
+group_imports = "One"


### PR DESCRIPTION
### Description

add rustfmt

### Drive-by changes

- add rustfmt
- modify precommit husky file
  - I add `+nightly` flag, because [import-graduiarity](https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=#imports_granularity) in not yet stable. 

### Related issues


- Fixes #2877 


### Backward compatibility

Yes

### Testing

Manual Tests:
1. run
`cargo +nightly fmt --all --check --manifest-path rust/Cargo.toml`
in root folder
2. commit something to test husky 

TODO: I only run fmt in check mode and haven't applied the change, should I apply?