### PR TITLE
 Polygon ZKevm hook and ism 

### DIFF
--- a/solidity/contracts/hooks/PolygonZkevmHook.sol
+++ b/solidity/contracts/hooks/PolygonZkevmHook.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+// ============ Internal Imports ============
+import {AbstractMessageIdAuthHook} from "./libs/AbstractMessageIdAuthHook.sol";
+import {StandardHookMetadata} from "./libs/StandardHookMetadata.sol";
+import {TypeCasts} from "../libs/TypeCasts.sol";
+import {Message} from "../libs/Message.sol";
+import {IPostDispatchHook} from "../interfaces/hooks/IPostDispatchHook.sol";
+
+// ============ External Imports ============
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {IPolygonZkEVMBridge} from "../interfaces/polygonZkevm/IPolygonZkEvmBridge.sol";
+
+/**
+ * @title PolygonZkevmHook
+ * @notice Message hook to inform the {Polygon zkEVM chain Ism} of messages published through
+ * the native Polygon zkEVM bridge bridge.
+ */
+contract PolygonZkevmHook is AbstractMessageIdAuthHook {
+    using StandardHookMetadata for bytes;
+    using Message for bytes;
+    using TypeCasts for bytes32;
+
+    // ============ Immutable Variables ============
+    IPolygonZkEVMBridge public immutable zkEvmBridge;
+
+    constructor(
+        address _mailbox,
+        uint32 _destinationDomain,
+        bytes32 _ism,
+        address _zkEvmBridge
+    ) AbstractMessageIdAuthHook(_mailbox, _destinationDomain, _ism) {
+        require(
+            Address.isContract(_zkEvmBridge),
+            "PolygonzkEVMHook: invalid cpManager contract"
+        );
+        zkEvmBridge = IPolygonZkEVMBridge(_zkEvmBridge);
+    }
+
+    /// @dev This value is hardcoded to 0 because the Polygon zkEVM bridge does not support fee quotes
+    function _quoteDispatch(
+        bytes calldata,
+        bytes calldata
+    ) internal pure override returns (uint256) {
+        return 0;
+    }
+
+    /// @inheritdoc AbstractMessageIdAuthHook
+    function _sendMessageId(
+        bytes calldata metadata,
+        bytes memory payload
+    ) internal override {
+        require(
+            metadata.msgValue(0) < 2 ** 255,
+            "PolygonzkEVMHook: msgValue must be less than 2 ** 255"
+        );
+
+        zkEvmBridge.bridgeMessage(
+            destinationDomain,
+            TypeCasts.bytes32ToAddress(ism),
+            false,
+            payload
+        );
+    }
+}

--- a/solidity/contracts/interfaces/polygonZkevm/IPolygonZkEVMBridge.sol
+++ b/solidity/contracts/interfaces/polygonZkevm/IPolygonZkEVMBridge.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0
+
+pragma solidity ^0.8.0;
+
+interface IPolygonZkEVMBridge {
+    /**
+     * @dev Thrown when sender is not the PolygonZkEVM address
+     */
+    error OnlyPolygonZkEVM();
+
+    /**
+     * @dev Thrown when the destination network is invalid
+     */
+    error DestinationNetworkInvalid();
+
+    /**
+     * @dev Thrown when the amount does not match msg.value
+     */
+    error AmountDoesNotMatchMsgValue();
+
+    /**
+     * @dev Thrown when user is bridging tokens and is also sending a value
+     */
+    error MsgValueNotZero();
+
+    /**
+     * @dev Thrown when the Ether transfer on claimAsset fails
+     */
+    error EtherTransferFailed();
+
+    /**
+     * @dev Thrown when the message transaction on claimMessage fails
+     */
+    error MessageFailed();
+
+    /**
+     * @dev Thrown when the global exit root does not exist
+     */
+    error GlobalExitRootInvalid();
+
+    /**
+     * @dev Thrown when the smt proof does not match
+     */
+    error InvalidSmtProof();
+
+    /**
+     * @dev Thrown when an index is already claimed
+     */
+    error AlreadyClaimed();
+
+    /**
+     * @dev Thrown when the owner of permit does not match the sender
+     */
+    error NotValidOwner();
+
+    /**
+     * @dev Thrown when the spender of the permit does not match this contract address
+     */
+    error NotValidSpender();
+
+    /**
+     * @dev Thrown when the amount of the permit does not match
+     */
+    error NotValidAmount();
+
+    /**
+     * @dev Thrown when the permit data contains an invalid signature
+     */
+    error NotValidSignature();
+
+    function bridgeAsset(
+        uint32 destinationNetwork,
+        address destinationAddress,
+        uint256 amount,
+        address token,
+        bool forceUpdateGlobalExitRoot,
+        bytes calldata permitData
+    ) external payable;
+
+    function bridgeMessage(
+        uint32 destinationNetwork,
+        address destinationAddress,
+        bool forceUpdateGlobalExitRoot,
+        bytes calldata metadata
+    ) external payable;
+
+    function claimAsset(
+        bytes32[32] calldata smtProof,
+        uint32 index,
+        bytes32 mainnetExitRoot,
+        bytes32 rollupExitRoot,
+        uint32 originNetwork,
+        address originTokenAddress,
+        uint32 destinationNetwork,
+        address destinationAddress,
+        uint256 amount,
+        bytes calldata metadata
+    ) external;
+
+    function claimMessage(
+        bytes32[32] calldata smtProof,
+        uint32 index,
+        bytes32 mainnetExitRoot,
+        bytes32 rollupExitRoot,
+        uint32 originNetwork,
+        address originAddress,
+        uint32 destinationNetwork,
+        address destinationAddress,
+        uint256 amount,
+        bytes calldata metadata
+    ) external;
+
+    function updateGlobalExitRoot() external;
+
+    function activateEmergencyState() external;
+
+    function deactivateEmergencyState() external;
+}

--- a/solidity/contracts/isms/hook/PolygonZkevmIsm.sol
+++ b/solidity/contracts/isms/hook/PolygonZkevmIsm.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+// ============ Internal Imports ============
+
+import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
+import {Message} from "../../libs/Message.sol";
+import {TypeCasts} from "../../libs/TypeCasts.sol";
+import {AbstractMessageIdAuthorizedIsm} from "./AbstractMessageIdAuthorizedIsm.sol";
+
+// ============ External Imports ============
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+contract PolygonZkevmIsm is AbstractMessageIdAuthorizedIsm {
+    // ============ Constants ============
+
+    uint8 public constant moduleType =
+        uint8(IInterchainSecurityModule.Types.NULL);
+
+    // ============ Constructor ============
+
+    constructor(address _l2Messenger) {
+        require(
+            Address.isContract(_l2Messenger),
+            "PolygonZkevmIsm: invalid L2Messenger"
+        );
+    }
+
+    // ============ Internal function ============
+
+    /**
+     * @notice Check if sender is authorized to message `verifyMessageId`.
+     */
+    function _isAuthorized() internal view override returns (bool) {
+        // TODO: implement
+    }
+}


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
This PR includes the hook and ISM contract for polygon's zkEVM chain.

The contracts utilise the polygon zkevm bridge contracts to make sure the origin of the cross chain message is trusted, this relies on the fact that zkevm bridge uses exit nodes to verify the integrity. 

more details can be found [here](https://docs.polygon.technology/zkEVM/architecture/protocol/zkevm-bridge/)


### Drive-by changes
 - nothing as of now
<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

- Fixes #2848

### Backward compatibility
Yes
<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing


🚧 Work in progress 🚧 
<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
