### PR TITLE
feat:smarter hook artifact caching

### DIFF
--- a/typescript/cli/src/deploy/core.ts
+++ b/typescript/cli/src/deploy/core.ts
@@ -275,7 +275,7 @@ async function executeDeploy({
   // 1. Deploy ISM factories to all deployable chains that don't have them.
   logBlue('Deploying ISM factory contracts');
   const ismFactoryDeployer = new HyperlaneProxyFactoryDeployer(multiProvider);
-  ismFactoryDeployer.cacheAddressesMap(mergedContractAddrs);
+  await ismFactoryDeployer.cacheAddressesMap(mergedContractAddrs);
 
   const ismFactoryConfig = chains.reduce((chainMap, curr) => {
     chainMap[curr] = {};
@@ -309,7 +309,7 @@ async function executeDeploy({
   // 4. Deploy core contracts to chains
   logBlue(`Deploying core contracts to ${chains.join(', ')}`);
   const coreDeployer = new HyperlaneCoreDeployer(multiProvider, ismFactory);
-  coreDeployer.cacheAddressesMap(mergedContractAddrs as any);
+  await coreDeployer.cacheAddressesMap(mergedContractAddrs as any);
   const coreConfigs = buildCoreConfigMap(
     owner,
     chains,
@@ -335,7 +335,7 @@ async function executeDeploy({
   log('Deploying test recipient contracts');
   const testRecipientConfig = buildTestRecipientConfigMap(chains, artifacts);
   const testRecipientDeployer = new TestRecipientDeployer(multiProvider);
-  testRecipientDeployer.cacheAddressesMap(mergedContractAddrs);
+  await testRecipientDeployer.cacheAddressesMap(mergedContractAddrs);
   const testRecipients = await testRecipientDeployer.deploy(
     testRecipientConfig,
   );

--- a/typescript/infra/src/deployment/deploy.ts
+++ b/typescript/infra/src/deployment/deploy.ts
@@ -44,7 +44,7 @@ export async function deployWithArtifacts<Config extends object>(
       console.error('Failed to load cached addresses');
     }
 
-    deployer.cacheAddressesMap(addressesMap);
+    await deployer.cacheAddressesMap(addressesMap);
   }
 
   process.on('SIGINT', async () => {

--- a/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
@@ -44,9 +44,11 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
     );
   }
 
-  cacheAddressesMap(addressesMap: ChainMap<CoreAddresses>): void {
-    this.hookDeployer.cacheAddressesMap(addressesMap);
-    super.cacheAddressesMap(addressesMap);
+  async cacheAddressesMap(
+    addressesMap: ChainMap<CoreAddresses>,
+  ): Promise<void> {
+    await this.hookDeployer.cacheAddressesMap(addressesMap);
+    await super.cacheAddressesMap(addressesMap);
   }
 
   async deployMailbox(

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -159,6 +159,18 @@ export abstract class HyperlaneDeployer<
     return undefined;
   }
 
+  // returns if ownable is owned by the signer
+  protected async checkIfOwner(
+    chain: ChainName,
+    ownable: Ownable,
+  ): Promise<boolean | undefined> {
+    return this.runIf(
+      chain,
+      await ownable.callStatic.owner(),
+      async () => true,
+    );
+  }
+
   protected async runIfOwner<T>(
     chain: ChainName,
     ownable: Ownable,

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -76,7 +76,9 @@ export abstract class HyperlaneDeployer<
     this.chainTimeoutMs = options?.chainTimeoutMs ?? 5 * 60 * 1000; // 5 minute timeout per chain
   }
 
-  cacheAddressesMap(addressesMap: HyperlaneAddressesMap<any>): void {
+  async cacheAddressesMap(
+    addressesMap: HyperlaneAddressesMap<any>,
+  ): Promise<void> {
     this.cachedAddresses = addressesMap;
   }
 

--- a/typescript/sdk/src/hook/HyperlaneHookDeployer.ts
+++ b/typescript/sdk/src/hook/HyperlaneHookDeployer.ts
@@ -63,13 +63,19 @@ export class HyperlaneHookDeployer extends HyperlaneDeployer<
           coreAddress,
           this.multiProvider.getProvider(chain),
         );
-        let isOwner = false;
+        let isOwnableOwner = false;
         try {
-          isOwner = (await this.checkIfOwner(chain, ownable)) || false;
+          // if ownable, then recover if owner
+          isOwnableOwner = (await this.checkIfOwner(chain, ownable)) || false;
         } catch (e) {
-          // if not ownable
+          // conditional fallacy implies tautological statement
+          // if !ownable, then recover
+          isOwnableOwner = true;
         }
-        if (!Object.keys(hookFactories).includes(addressKey) || isOwner) {
+        if (
+          !Object.keys(hookFactories).includes(addressKey) ||
+          isOwnableOwner
+        ) {
           filteredAddressMap[chain] = {
             ...filteredAddressMap[chain],
             [addressKey]: coreAddresses[addressKey as keyof CoreAddresses],

--- a/typescript/sdk/src/hook/HyperlaneHookDeployer.ts
+++ b/typescript/sdk/src/hook/HyperlaneHookDeployer.ts
@@ -83,8 +83,8 @@ export class HyperlaneHookDeployer extends HyperlaneDeployer<
         }
       }
     }
-    this.igpDeployer.cacheAddressesMap(filteredAddressMap);
-    super.cacheAddressesMap(filteredAddressMap);
+    await this.igpDeployer.cacheAddressesMap(filteredAddressMap);
+    await super.cacheAddressesMap(filteredAddressMap);
   }
 
   async deployContracts(


### PR DESCRIPTION
### Description

- Right now, we have special case logic for igp in cli/contexts.ts to exempt it from being cached because the cached artifact is from core which the PI deployment doesn't have access to. This is fragile and furthermore, as we add more such hooks, we'll need more special cased logic which is undesirable.

- The core issue here is the PI deployment's inability to configure hooks for their needs which stems from the fact that they're not the owned of the cached artifact. 
- The simplest solution here is to not cache contract address which are A. part of hook factories and B. not owned by the deployer. This makes sure we will never run into issue of the hook deployment caching AW addresses and trying to modify them for the PI deployment and return prematurely (because of the runIfOwner flow)
- Note A: we're filtering out artifacts in hookFactories, not their respective dependencies like storageGasOracle for interchainGasPaymaster so this still implies that the storageGasOracle may be wrongly recovered (we can either add it to hookFactories or  have some way of mapping each hook's dependency) cc @yorhodes 
- Note B: this approach may lead to false positives where we unnecessarily filter out non-ownable contracts but this is still a best solution than the status quo


### Drive-by changes

- removing the special case logic for igp recovery in CLI

### Related issues

None

### Backward compatibility

Yes

### Testing

Manual through CLI
