### PR TITLE
Blacklist (optimism)goerli griefer, deploy w/ new image on testnet4

### DIFF
--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -3,6 +3,7 @@ import {
   GasPaymentEnforcementPolicyType,
   RpcConsensusType,
   chainMetadata,
+  getDomainId,
 } from '@hyperlane-xyz/sdk';
 
 import {
@@ -50,7 +51,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '6360cc8-20240122-140607',
+      tag: 'c9ef41c-20240126-172723',
     },
     blacklist: [
       ...releaseCandidateHelloworldMatchingList,
@@ -59,6 +60,24 @@ const hyperlane: RootAgentConfig = {
         // from spam txs to the old TestRecipient before we were charging for
         // gas, we blacklist the old TestRecipient address.
         recipientAddress: '0xBC3cFeca7Df5A45d61BC60E7898E63670e1654aE',
+      },
+      // OptimismGoerli griefers:
+      {
+        destinationDomain: getDomainId(chainMetadata.optimismgoerli),
+        recipientAddress: [
+          '0xed4de02c6f4cb1161bdfefdb2fcdeef4546fa36c',
+          '0x723192fc414fe536b414117a4b2c5a7b71f912e3',
+          '0x5a48723d80a7ee3be6855ca293059b5287ee6689',
+        ],
+      },
+      // Goerli griefers:
+      {
+        destinationDomain: getDomainId(chainMetadata.goerli),
+        recipientAddress: [
+          '0x0461c69ff7f29cfb5efd36b9d377fdfc95418c2b',
+          '0xe747c82ed8560ba137b24a3a97ff7504b50c3e91',
+          '0x6ad92511ee4a3835bde9b1bfd7063023b56a8c56',
+        ],
       },
     ],
     gasPaymentEnforcement,
@@ -75,7 +94,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '6360cc8-20240122-140607',
+      tag: 'c9ef41c-20240126-172723',
     },
     chains: validatorChainConfig(Contexts.Hyperlane),
   },
@@ -96,7 +115,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '6360cc8-20240122-140607',
+      tag: 'c9ef41c-20240126-172723',
     },
     whitelist: [...releaseCandidateHelloworldMatchingList],
     gasPaymentEnforcement,
@@ -109,7 +128,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '6360cc8-20240122-140607',
+      tag: 'c9ef41c-20240126-172723',
     },
     chains: validatorChainConfig(Contexts.ReleaseCandidate),
   },


### PR DESCRIPTION
### Description

Blacklists a griefer that sent a bunch of messages before we had IGPs properly configured on testnet4

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
