### PR TITLE
feat: build head of PRs instead of merge commit

### DIFF
--- a/.github/workflows/agent-release-artifacts.yml
+++ b/.github/workflows/agent-release-artifacts.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq crossbuild-essential-arm64 crossbuild-essential-armhf
-          
+
           # some additional configuration for cross-compilation on linux
           cat >>~/.cargo/config <<EOF
           [target.aarch64-unknown-linux-gnu]

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -36,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
 
       - name: Generate tag data

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -34,6 +34,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Generate tag data
         id: taggen
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -54,6 +56,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
 
       - name: yarn-cache

--- a/.github/workflows/storage-analysis.yml
+++ b/.github/workflows/storage-analysis.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
 
       - uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # check out full history
           fetch-depth: 0
 
       - name: yarn-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
 
       - name: yarn-cache
@@ -54,6 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
           fetch-depth: 0
 
@@ -71,7 +73,7 @@ jobs:
           path: |
             ./*
             !./rust
-          key: ${{ github.sha }}
+          key: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: build
         run: yarn build
@@ -82,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # check out full history
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: yarn-cache
@@ -111,6 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
           fetch-depth: 0
 
@@ -123,7 +126,7 @@ jobs:
           path: |
             ./*
             !./rust
-          key: ${{ github.sha }}
+          key: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Unit Tests
         run: yarn test:ci
@@ -134,6 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
           fetch-depth: 0
 
@@ -151,7 +155,7 @@ jobs:
           path: |
             ./*
             !./rust
-          key: ${{ github.sha }}
+          key: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Metadata Health Check
         run: yarn workspace @hyperlane-xyz/sdk run test:metadata
@@ -166,6 +170,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
 
       - name: foundry-install
@@ -205,7 +210,7 @@ jobs:
           path: |
             ./*
             !./rust
-          key: ${{ github.sha }}
+          key: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: cargo-cache
         uses: actions/cache@v3
@@ -251,6 +256,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: foundry-install
         uses: onbjerg/foundry-toolchain@v1
@@ -261,7 +268,7 @@ jobs:
           path: |
             ./*
             !./rust
-          key: ${{ github.sha }}
+          key: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Fork test ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }} deployment
         run: cd typescript/infra && ./fork.sh ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }}
@@ -273,6 +280,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: yarn-cache
@@ -289,7 +297,7 @@ jobs:
           path: |
             ./*
             !./rust
-          key: ${{ github.sha }}
+          key: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: foundry-install
         uses: onbjerg/foundry-toolchain@v1


### PR DESCRIPTION
With our current repo settings for PRs, github checks out the merge commit with main instead of the actual HEAD of the PR. It feels counter-intuitive for CI to build the merge commit each time rather than the commit one has pushed, considering we require branches to be up to date with main before merging anyway.

This can also cause problems when deploying RCs, because your RC monorepo builds (e.g. for keyfunder, kathy) would unintentionally include changes that are not in your RC branch. Experienced first hand as part of https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3190.

This change ensures that when running in a PR context it uses the intended HEAD of the PR, rather than the unintended merge commit with main.