### PR TITLE
feat: prevent merge for PRs with do-not-merge label

### DIFF
--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -1,0 +1,17 @@
+name: Do Not Merge
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  do-not-merge:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'do-not-merge') }}
+    name: Prevent Merging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for label
+        run: |
+          echo "Pull request is labeled as 'do-not-merge'"
+          echo "This workflow fails so that the pull request cannot be merged"
+          exit 1


### PR DESCRIPTION
- Just an idea to have CI enforce `do-not-merge` labels
- If merged, will also require a repo admin adding this job to the set of required checks
- Implementation from https://www.neilmacy.co.uk/blog/github-action-to-block-merging