### PR TITLE
feat:removing igp from preset hook config

### DIFF
--- a/.changeset/friendly-peas-roll.md
+++ b/.changeset/friendly-peas-roll.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Removed IGP from preset hook config

--- a/typescript/cli/src/deploy/core.ts
+++ b/typescript/cli/src/deploy/core.ts
@@ -328,7 +328,6 @@ async function executeDeploy({
     chains,
     defaultIsms,
     hooksConfig,
-    multisigConfigs,
   );
   const coreContracts = await coreDeployer.deploy(coreConfigs);
 
@@ -391,17 +390,9 @@ function buildCoreConfigMap(
   chains: ChainName[],
   defaultIsms: ChainMap<IsmConfig>,
   hooksConfig: ChainMap<HooksConfig>,
-  multisigConfigs: ChainMap<MultisigConfig>,
 ): ChainMap<CoreConfig> {
   return chains.reduce<ChainMap<CoreConfig>>((config, chain) => {
-    const hooks =
-      hooksConfig[chain] ??
-      presetHookConfigs(
-        owner,
-        chain,
-        chains.filter((c) => c !== chain),
-        multisigConfigs[chain], // if no multisig config, uses default 2/3
-      );
+    const hooks = hooksConfig[chain] ?? presetHookConfigs(owner);
     config[chain] = {
       owner,
       defaultIsm: defaultIsms[chain],


### PR DESCRIPTION
### Description

- To simplify the PI deployment, I've removed the igp from preset hook config which PI deployers use if they don't provide a hook config via the CLI.
- This means we don't need to deploy IGP or storage gas oracles and the PI deployer can spin up relayer with gas enforcement policy set to false.

### Drive-by changes

None

### Related issues

None

### Backward compatibility

Yes
### Testing

Manual
