### PR TITLE
republish  as hpl-interface as hyperlane-cosmwasm-interface

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3959,27 +3959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hpl-interface"
-version = "0.0.6-rc6"
-source = "git+https://github.com/hyperlane-xyz/cosmwasm.git?tag=v0.0.6#c4485e00c89c2d57315503955946bf7f155e7a47"
-dependencies = [
- "bech32 0.9.1",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-storage-plus",
- "cw2",
- "cw20",
- "cw20-base",
- "ripemd",
- "schemars",
- "serde",
- "sha2 0.10.8",
- "sha3 0.10.8",
- "thiserror",
-]
-
-[[package]]
 name = "http"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4218,11 +4197,11 @@ dependencies = [
  "cosmrs",
  "derive-new",
  "hex 0.4.3",
- "hpl-interface",
  "http",
  "hyper",
  "hyper-tls",
  "hyperlane-core",
+ "hyperlane-cosmwasm-interface",
  "injective-protobuf",
  "injective-std",
  "once_cell",
@@ -4240,6 +4219,28 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "url",
+]
+
+[[package]]
+name = "hyperlane-cosmwasm-interface"
+version = "0.0.6-rc6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5e622014ab94f1e7f0acbe71df7c1384224261e2c76115807aaf24215970942"
+dependencies = [
+ "bech32 0.9.1",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-storage-plus",
+ "cw2",
+ "cw20",
+ "cw20-base",
+ "ripemd",
+ "schemars",
+ "serde",
+ "sha2 0.10.8",
+ "sha3 0.10.8",
+ "thiserror",
 ]
 
 [[package]]
@@ -7148,9 +7149,9 @@ dependencies = [
  "ctrlc",
  "eyre",
  "hex 0.4.3",
- "hpl-interface",
  "hyperlane-core",
  "hyperlane-cosmos",
+ "hyperlane-cosmwasm-interface",
  "jobserver",
  "k256 0.13.2",
  "macro_rules_attribute",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -91,10 +91,10 @@ bech32 = "0.9.1"
 elliptic-curve = "0.12.3"
 getrandom = { version = "0.2", features = ["js"] }
 hex = "0.4.3"
-hpl-interface = { git = "https://github.com/hyperlane-xyz/cosmwasm.git", tag="v0.0.6" }
 http = "*"
 hyper = "0.14"
 hyper-tls = "0.5.0"
+hyperlane-cosmwasm-interface = "=0.0.6-rc6"
 injective-protobuf = "0.2.2"
 injective-std = "0.1.5"
 itertools = "0.11.0"

--- a/rust/chains/hyperlane-cosmos/Cargo.toml
+++ b/rust/chains/hyperlane-cosmos/Cargo.toml
@@ -16,8 +16,8 @@ bech32 = { workspace = true }
 cosmrs = { workspace = true, features = ["cosmwasm", "tokio", "grpc", "rpc"] }
 derive-new = { workspace = true }
 hex = { workspace = true }
-hpl-interface.workspace = true
 http = { workspace = true }
+hyperlane-cosmwasm-interface.workspace = true
 hyper = { workspace = true }
 hyper-tls = { workspace = true }
 injective-protobuf = { workspace = true }

--- a/rust/chains/hyperlane-cosmos/src/interchain_security_module.rs
+++ b/rust/chains/hyperlane-cosmos/src/interchain_security_module.rs
@@ -82,7 +82,7 @@ impl InterchainSecurityModule for CosmosInterchainSecurityModule {
             .await?;
 
         let module_type_response =
-            serde_json::from_slice::<hpl_interface::ism::ModuleTypeResponse>(&data)?;
+            serde_json::from_slice::<hyperlane_cosmwasm_interface::ism::ModuleTypeResponse>(&data)?;
         Ok(IsmType(module_type_response.typ).into())
     }
 

--- a/rust/chains/hyperlane-cosmos/src/payloads/ism_routes.rs
+++ b/rust/chains/hyperlane-cosmos/src/payloads/ism_routes.rs
@@ -39,5 +39,5 @@ pub struct QueryIsmModuleTypeRequest {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct QueryIsmModuleTypeResponse {
     #[serde(rename = "type")]
-    pub typ: hpl_interface::ism::IsmType,
+    pub typ: hyperlane_cosmwasm_interface::ism::IsmType,
 }

--- a/rust/chains/hyperlane-cosmos/src/types.rs
+++ b/rust/chains/hyperlane-cosmos/src/types.rs
@@ -1,10 +1,10 @@
 use cosmrs::proto::cosmos::base::abci::v1beta1::TxResponse;
 use hyperlane_core::{ChainResult, ModuleType, TxOutcome, H256, U256};
 
-pub struct IsmType(pub hpl_interface::ism::IsmType);
+pub struct IsmType(pub hyperlane_cosmwasm_interface::ism::IsmType);
 
-impl From<hpl_interface::ism::IsmType> for IsmType {
-    fn from(value: hpl_interface::ism::IsmType) -> Self {
+impl From<hyperlane_cosmwasm_interface::ism::IsmType> for IsmType {
+    fn from(value: hyperlane_cosmwasm_interface::ism::IsmType) -> Self {
         IsmType(value)
     }
 }
@@ -12,14 +12,20 @@ impl From<hpl_interface::ism::IsmType> for IsmType {
 impl From<IsmType> for ModuleType {
     fn from(value: IsmType) -> Self {
         match value.0 {
-            hpl_interface::ism::IsmType::Unused => ModuleType::Unused,
-            hpl_interface::ism::IsmType::Routing => ModuleType::Routing,
-            hpl_interface::ism::IsmType::Aggregation => ModuleType::Aggregation,
-            hpl_interface::ism::IsmType::LegacyMultisig => ModuleType::MessageIdMultisig,
-            hpl_interface::ism::IsmType::MerkleRootMultisig => ModuleType::MerkleRootMultisig,
-            hpl_interface::ism::IsmType::MessageIdMultisig => ModuleType::MessageIdMultisig,
-            hpl_interface::ism::IsmType::Null => ModuleType::Null,
-            hpl_interface::ism::IsmType::CcipRead => ModuleType::CcipRead,
+            hyperlane_cosmwasm_interface::ism::IsmType::Unused => ModuleType::Unused,
+            hyperlane_cosmwasm_interface::ism::IsmType::Routing => ModuleType::Routing,
+            hyperlane_cosmwasm_interface::ism::IsmType::Aggregation => ModuleType::Aggregation,
+            hyperlane_cosmwasm_interface::ism::IsmType::LegacyMultisig => {
+                ModuleType::MessageIdMultisig
+            }
+            hyperlane_cosmwasm_interface::ism::IsmType::MerkleRootMultisig => {
+                ModuleType::MerkleRootMultisig
+            }
+            hyperlane_cosmwasm_interface::ism::IsmType::MessageIdMultisig => {
+                ModuleType::MessageIdMultisig
+            }
+            hyperlane_cosmwasm_interface::ism::IsmType::Null => ModuleType::Null,
+            hyperlane_cosmwasm_interface::ism::IsmType::CcipRead => ModuleType::CcipRead,
         }
     }
 }

--- a/rust/sealevel/environments/local-e2e/warp-routes/testwarproute/program-ids.json
+++ b/rust/sealevel/environments/local-e2e/warp-routes/testwarproute/program-ids.json
@@ -1,10 +1,10 @@
 {
-  "sealeveltest1": {
-    "hex": "0xa77b4e2ed231894cc8cb8eee21adcc705d8489bccc6b2fcf40a358de23e60b7b",
-    "base58": "CGn8yNtSD3aTTqJfYhUb6s1aVTN75NzwtsFKo1e83aga"
-  },
   "sealeveltest2": {
     "hex": "0x2317f9615d4ebc2419ad4b88580e2a80a03b2c7a60bc960de7d6934dbc37a87e",
     "base58": "3MzUPjP5LEkiHH82nEAe28Xtz9ztuMqWc8UmuKxrpVQH"
+  },
+  "sealeveltest1": {
+    "hex": "0xa77b4e2ed231894cc8cb8eee21adcc705d8489bccc6b2fcf40a358de23e60b7b",
+    "base58": "CGn8yNtSD3aTTqJfYhUb6s1aVTN75NzwtsFKo1e83aga"
   }
 }

--- a/rust/utils/run-locally/Cargo.toml
+++ b/rust/utils/run-locally/Cargo.toml
@@ -29,7 +29,7 @@ ureq = { workspace = true, default-features = false }
 which.workspace = true
 macro_rules_attribute.workspace = true
 regex.workspace = true
-hpl-interface.workspace = true
+hyperlane-cosmwasm-interface.workspace = true
 cosmwasm-schema.workspace = true
 
 [features]

--- a/rust/utils/run-locally/src/cosmos/crypto.rs
+++ b/rust/utils/run-locally/src/cosmos/crypto.rs
@@ -24,7 +24,7 @@ pub fn pub_to_addr(pub_key: &[u8], prefix: &str) -> String {
     let sha_hash = sha256_digest(pub_key);
     let rip_hash = ripemd160_digest(sha_hash);
 
-    let addr = hpl_interface::types::bech32_encode(prefix, &rip_hash).unwrap();
+    let addr = hyperlane_cosmwasm_interface::types::bech32_encode(prefix, &rip_hash).unwrap();
 
     addr.to_string()
 }

--- a/rust/utils/run-locally/src/cosmos/deploy.rs
+++ b/rust/utils/run-locally/src/cosmos/deploy.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use hpl_interface::{core, hook, igp, ism};
+use hyperlane_cosmwasm_interface::{core, hook, igp, ism};
 use macro_rules_attribute::apply;
 
 use crate::utils::as_task;

--- a/rust/utils/run-locally/src/cosmos/link.rs
+++ b/rust/utils/run-locally/src/cosmos/link.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use cosmwasm_schema::cw_serde;
-use hpl_interface::{
+use hyperlane_cosmwasm_interface::{
     core,
     ism::{self},
 };
@@ -101,7 +101,7 @@ fn link_network(
     let public_key = validator.priv_key.verifying_key().to_encoded_point(false);
     let public_key = public_key.as_bytes();
 
-    let hash = hpl_interface::types::keccak256_hash(&public_key[1..]);
+    let hash = hyperlane_cosmwasm_interface::types::keccak256_hash(&public_key[1..]);
 
     let mut bytes = [0u8; 20];
     bytes.copy_from_slice(&hash.as_slice()[12..]);

--- a/rust/utils/run-locally/src/cosmos/mod.rs
+++ b/rust/utils/run-locally/src/cosmos/mod.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, Instant};
 use std::{env, fs};
 
 use cosmwasm_schema::cw_serde;
-use hpl_interface::types::bech32_decode;
 use hyperlane_cosmos::RawCosmosAmount;
+use hyperlane_cosmwasm_interface::types::bech32_decode;
 use macro_rules_attribute::apply;
 use maplit::hashmap;
 use tempfile::tempdir;

--- a/rust/utils/run-locally/src/cosmos/types.rs
+++ b/rust/utils/run-locally/src/cosmos/types.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, path::PathBuf};
 
-use hpl_interface::types::bech32_decode;
 use hyperlane_cosmos::RawCosmosAmount;
+use hyperlane_cosmwasm_interface::types::bech32_decode;
 
 use super::{cli::OsmosisCLI, CosmosNetwork};
 


### PR DESCRIPTION
### Description

Replaces usage of `hpl-interface` with `hyperlane-cosmwasm-interface` and updates imports