### PR TITLE
Add Neutron back to mainnet3_config.json

### DIFF
--- a/rust/config/mainnet3_config.json
+++ b/rust/config/mainnet3_config.json
@@ -465,6 +465,42 @@
         "from": 437300
       }
     },
+    "neutron": {
+      "name": "neutron",
+      "domainId": "1853125230",
+      "chainId": "neutron-1",
+      "mailbox": "0x848426d50eb2104d5c6381ec63757930b1c14659c40db8b8081e516e7c5238fc",
+      "interchainGasPaymaster": "0x504ee9ac43ec5814e00c7d21869a90ec52becb489636bdf893b7df9d606b5d67",
+      "validatorAnnounce": "0xf3aa0d652226e21ae35cd9035c492ae41725edc9036edf0d6a48701b153b90a0",
+      "merkleTreeHook": "0xcd30a0001cc1f436c41ef764a712ebabc5a144140e3fd03eafe64a9a24e4e27c",
+      "protocol": "cosmos",
+      "finalityBlocks": 1,
+      "rpcUrls": [
+        {
+          "http": "https://rpc-kralum.neutron-1.neutron.org"
+        }
+      ],
+      "grpcUrl": "https://grpc-kralum.neutron-1.neutron.org:80",
+      "canonicalAsset": "untrn",
+      "bech32Prefix": "neutron",
+      "gasPrice": {
+        "amount": "0.57",
+        "denom": "untrn"
+      },
+      "contractAddressBytes": 32,
+      "index": {
+        "from": 4000000,
+        "chunk": 100000
+      },
+      "blocks": {
+        "reorgPeriod": 1
+      },
+      "signer": {
+        "type": "cosmosKey",
+        "key": "0x5486418967eabc770b0fcb995f7ef6d9a72f7fc195531ef76c5109f44f51af26",
+        "prefix": "neutron"
+      }
+    },
     "injective": {
       "name": "injective",
       "domainId": "6909546",


### PR DESCRIPTION
### Description

Looks like https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3179/files#diff-edae1a4e631a67121d92119998e37740c0190bec5060e3c842cc86e4d3d26a4dL417 removed Neutron from mainnet3_config.json :(

Seems like the Typescript tooling may have overridden it accidentally? Will need to figure out what to do there

### Drive-by changes

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
