### PR TITLE
fix: agent config artifact includes only chains user deployed to

### DIFF
--- a/typescript/cli/src/deploy/core.ts
+++ b/typescript/cli/src/deploy/core.ts
@@ -472,18 +472,20 @@ async function writeAgentConfig(
   multiProvider: MultiProvider,
 ) {
   const startBlocks: ChainMap<number> = {};
+  const core = HyperlaneCore.fromAddressesMap(artifacts, multiProvider);
+
   for (const chain of chains) {
-    const core = HyperlaneCore.fromAddressesMap(artifacts, multiProvider);
     const mailbox = core.getContracts(chain).mailbox;
     startBlocks[chain] = (await mailbox.deployedBlock()).toNumber();
   }
+
   const mergedAddressesMap = objMerge(
     sdkContractAddressesMap,
     artifacts,
   ) as ChainMap<HyperlaneDeploymentArtifacts>;
 
   const agentConfig = buildAgentConfig(
-    Object.keys(mergedAddressesMap),
+    chains, // Use only the chains that were deployed to
     multiProvider,
     mergedAddressesMap,
     startBlocks,


### PR DESCRIPTION
resolves https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3189

- only build agent config for chains deployed to
- drive-by retrieve HyperlaneCore outside of the loop

TODO:
- [x] check if it resolves bug with kurtosis deploy url
