### PR TITLE
fix: add fallback to kurtosis terminal link

### DIFF
--- a/typescript/cli/src/deploy/agent.ts
+++ b/typescript/cli/src/deploy/agent.ts
@@ -69,6 +69,7 @@ export async function runKurtosisAgentDeploy({
   const kurtosisCloudLink = terminalLink(
     'Cmd+Click or Ctrl+Click here',
     kurtosisCloudUrl,
+    { fallback: () => kurtosisCloudUrl },
   );
 
   logGreen(


### PR DESCRIPTION
Users can run into an issue where the URL to deploy to kurtosis does not display correctly for unsupported terminals. I have ran into this myself with my mac setup.

It manifests as:
- "click here" text, no URL
- unformatted text with URL containing "no-width space" characters

Related issue: https://github.com/sindresorhus/terminal-link/issues/18#issuecomment-1068020361

As suggested by a comment on the above issue, we can add a fallback to the `terminalLink` call to simply print the URL as a backup.