### PR TITLE
Rotate chain metadata RPC urls

### DIFF
--- a/typescript/sdk/src/consts/chainMetadata.ts
+++ b/typescript/sdk/src/consts/chainMetadata.ts
@@ -1037,6 +1037,9 @@ export const viction: ChainMetadata = {
   protocol: ProtocolType.Ethereum,
   rpcUrls: [
     {
+      http: 'https://rpc.tomochain.com/',
+    },
+    {
       http: 'https://viction.blockpi.network/v1/rpc/public',
     },
   ],

--- a/typescript/sdk/src/consts/chainMetadata.ts
+++ b/typescript/sdk/src/consts/chainMetadata.ts
@@ -853,6 +853,7 @@ export const sepolia: ChainMetadata = {
   nativeToken: etherToken,
   protocol: ProtocolType.Ethereum,
   rpcUrls: [
+    { http: 'https://ethereum-sepolia.publicnode.com' },
     { http: 'https://ethereum-sepolia.blockpi.network/v1/rpc/public' },
     { http: 'https://rpc.sepolia.org' },
   ],


### PR DESCRIPTION
### Description

- existing viction and sepolia RPC urls were failing on eth_getCode

### Testing

- CI fork tests