### PR TITLE
Add block pinned caching to env tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,7 +258,7 @@ jobs:
           - environment: mainnet3
             module: core
             chain: viction
-            block: 75692506
+            block: 75693314
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,16 +244,21 @@ jobs:
     needs: [yarn-build]
     strategy:
       matrix:
-        environment: [testnet4, mainnet3]
-        module: [core, igp, helloworld]
         include:
           - environment: testnet4
-            chain: sepolia
-          - environment: mainnet3
-            chain: arbitrum
-          - environment: mainnet3
-            chain: viction
             module: core
+            chain: sepolia
+            block: 5228018
+
+          - environment: mainnet3
+            module: core
+            chain: arbitrum
+            block: 177818653
+
+          - environment: mainnet3
+            module: core
+            chain: viction
+            block: 75692506
 
     steps:
       - uses: actions/checkout@v3
@@ -271,8 +276,15 @@ jobs:
             !./rust
           key: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Fork test ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }} deployment
-        run: cd typescript/infra && ./fork.sh ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }}
+      - name: fork-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.foundry/cache
+          key: ${{ runner.os }}-fork-cache
+
+      - name: Fork test ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }} deployment at block ${{matrix.block }}
+        run: cd typescript/infra && ./fork.sh ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }} ${{ matrix.block }}
 
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

- caches foundry forked RPCs to avoid flakiness in CI

### Drive-by changes

- requires manual block number changes when we make onchain changes


### Testing

- fork tests