### PR TITLE
CCIP Read metadata builder fix

### DIFF
--- a/rust/agents/relayer/src/msg/metadata/ccip_read.rs
+++ b/rust/agents/relayer/src/msg/metadata/ccip_read.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use derive_more::Deref;
 use derive_new::new;
-use ethers::{abi::AbiDecode, core::utils::hex::decode as hex_decode, utils::hex::ToHex};
+use ethers::{abi::AbiDecode, core::utils::hex::decode as hex_decode};
 use eyre::Context;
 use hyperlane_core::{utils::bytes_to_hex, HyperlaneMessage, RawHyperlaneMessage, H256};
 use hyperlane_ethereum::OffchainLookup;

--- a/rust/chains/hyperlane-cosmos/src/mailbox.rs
+++ b/rust/chains/hyperlane-cosmos/src/mailbox.rs
@@ -23,7 +23,7 @@ use once_cell::sync::Lazy;
 
 use crate::utils::{CONTRACT_ADDRESS_ATTRIBUTE_KEY, CONTRACT_ADDRESS_ATTRIBUTE_KEY_BASE64};
 use hyperlane_core::{
-    utils::fmt_bytes, ChainResult, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
+    utils::bytes_to_hex, ChainResult, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
     HyperlaneMessage, HyperlaneProvider, Indexer, LogMeta, Mailbox, TxCostEstimate, TxOutcome,
     H256, U256,
 };
@@ -203,7 +203,7 @@ impl Mailbox for CosmosMailbox {
         Ok(tx_response_to_outcome(response)?)
     }
 
-    #[instrument(err, ret, skip(self), fields(msg=%message, metadata=%fmt_bytes(metadata)))]
+    #[instrument(err, ret, skip(self), fields(msg=%message, metadata=%bytes_to_hex(metadata)))]
     async fn process_estimate_costs(
         &self,
         message: &HyperlaneMessage,

--- a/rust/chains/hyperlane-ethereum/src/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/mailbox.rs
@@ -13,7 +13,7 @@ use ethers_contract::builders::ContractCall;
 use tracing::instrument;
 
 use hyperlane_core::{
-    utils::fmt_bytes, ChainCommunicationError, ChainResult, ContractLocator, HyperlaneAbi,
+    utils::bytes_to_hex, ChainCommunicationError, ChainResult, ContractLocator, HyperlaneAbi,
     HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneMessage, HyperlaneProtocolError,
     HyperlaneProvider, Indexer, LogMeta, Mailbox, RawHyperlaneMessage, SequenceIndexer,
     TxCostEstimate, TxOutcome, H160, H256, U256,
@@ -327,7 +327,7 @@ where
             .into())
     }
 
-    #[instrument(skip(self), fields(metadata=%fmt_bytes(metadata)))]
+    #[instrument(skip(self), fields(metadata=%bytes_to_hex(metadata)))]
     async fn process(
         &self,
         message: &HyperlaneMessage,
@@ -341,7 +341,7 @@ where
         Ok(receipt.into())
     }
 
-    #[instrument(skip(self), fields(msg=%message, metadata=%fmt_bytes(metadata)))]
+    #[instrument(skip(self), fields(msg=%message, metadata=%bytes_to_hex(metadata)))]
     async fn process_estimate_costs(
         &self,
         message: &HyperlaneMessage,

--- a/rust/chains/hyperlane-ethereum/src/tx.rs
+++ b/rust/chains/hyperlane-ethereum/src/tx.rs
@@ -9,7 +9,7 @@ use ethers::{
 };
 use ethers_contract::builders::ContractCall;
 use ethers_core::types::BlockNumber;
-use hyperlane_core::{utils::fmt_bytes, ChainCommunicationError, ChainResult, H256, U256};
+use hyperlane_core::{utils::bytes_to_hex, ChainCommunicationError, ChainResult, H256, U256};
 use tracing::{error, info};
 
 use crate::Middleware;
@@ -26,7 +26,7 @@ where
     let data = tx
         .tx
         .data()
-        .map(|b| fmt_bytes(b))
+        .map(|b| bytes_to_hex(b))
         .unwrap_or_else(|| "None".into());
 
     let to = tx

--- a/rust/chains/hyperlane-fuel/src/mailbox.rs
+++ b/rust/chains/hyperlane-fuel/src/mailbox.rs
@@ -8,7 +8,7 @@ use fuels::prelude::{Bech32ContractId, WalletUnlocked};
 use tracing::instrument;
 
 use hyperlane_core::{
-    utils::fmt_bytes, ChainCommunicationError, ChainResult, ContractLocator, HyperlaneAbi,
+    utils::bytes_to_hex, ChainCommunicationError, ChainResult, ContractLocator, HyperlaneAbi,
     HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneMessage, HyperlaneProvider,
     Indexer, LogMeta, Mailbox, TxCostEstimate, TxOutcome, H256, U256,
 };
@@ -105,7 +105,7 @@ impl Mailbox for FuelMailbox {
         todo!()
     }
 
-    #[instrument(err, ret, skip(self), fields(msg=%message, metadata=%fmt_bytes(metadata)))]
+    #[instrument(err, ret, skip(self), fields(msg=%message, metadata=%bytes_to_hex(metadata)))]
     async fn process_estimate_costs(
         &self,
         message: &HyperlaneMessage,

--- a/rust/hyperlane-core/src/traits/signing.rs
+++ b/rust/hyperlane-core/src/traits/signing.rs
@@ -6,7 +6,7 @@ use serde::{
 };
 use std::fmt::{Debug, Formatter};
 
-use crate::utils::fmt_bytes;
+use crate::utils::bytes_to_hex;
 use crate::{Signature, H160, H256};
 
 /// An error incurred by a signer
@@ -99,7 +99,7 @@ impl<T: Signable + Serialize> Serialize for SignedType<T> {
         state.serialize_field("value", &self.value)?;
         state.serialize_field("signature", &self.signature)?;
         let sig: [u8; 65] = self.signature.into();
-        state.serialize_field("serialized_signature", &fmt_bytes(&sig))?;
+        state.serialize_field("serialized_signature", &bytes_to_hex(&sig))?;
         state.end()
     }
 }

--- a/rust/hyperlane-core/src/utils.rs
+++ b/rust/hyperlane-core/src/utils.rs
@@ -57,8 +57,8 @@ pub fn fmt_address_for_domain(domain: u32, addr: H256) -> String {
         .unwrap_or_else(|_| format!("{addr:?}"))
 }
 
-/// Pretty print a byte slice for logging
-pub fn fmt_bytes(bytes: &[u8]) -> String {
+/// Pretty print a byte slice, including a hex prefix
+pub fn bytes_to_hex(bytes: &[u8]) -> String {
     format!("0x{}", hex::encode(bytes))
 }
 


### PR DESCRIPTION
### Description

`H160`'s `ToString` implementation adds ellipsis points instead of outputting the full hex string, for some reason (e.g. `0xc66a…7b6f`). This will result in an error when `Mailbox.process` is called on the CCIP Read ISM.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
