### PR TITLE
Increase injective reorg period

### DIFF
--- a/.changeset/curvy-geese-beam.md
+++ b/.changeset/curvy-geese-beam.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/sdk': patch
+'@hyperlane-xyz/infra': patch
+---
+
+Bumped injective reorg period

--- a/rust/config/mainnet3_config.json
+++ b/rust/config/mainnet3_config.json
@@ -474,7 +474,6 @@
       "validatorAnnounce": "0xf3aa0d652226e21ae35cd9035c492ae41725edc9036edf0d6a48701b153b90a0",
       "merkleTreeHook": "0xcd30a0001cc1f436c41ef764a712ebabc5a144140e3fd03eafe64a9a24e4e27c",
       "protocol": "cosmos",
-      "finalityBlocks": 1,
       "rpcUrls": [
         {
           "http": "https://rpc-kralum.neutron-1.neutron.org"
@@ -514,7 +513,6 @@
       "validatorAnnounce": "0x1fb225b2fcfbe75e614a1d627de97ff372242eed",
       "merkleTreeHook": "0x568ad3638447f07def384969f4ea39fae3802962",
       "protocol": "cosmos",
-      "finalityBlocks": 1,
       "rpcUrls": [
         {
           "http": "https://rpc-injective.goldenratiostaking.net:443"
@@ -537,7 +535,7 @@
         "chunk": 100000
       },
       "blocks": {
-        "reorgPeriod": 1
+        "reorgPeriod": 10
       }
     },
     "moonbeam": {

--- a/typescript/sdk/src/consts/chainMetadata.ts
+++ b/typescript/sdk/src/consts/chainMetadata.ts
@@ -452,8 +452,8 @@ export const injective: ChainMetadata = {
   blockExplorers: [],
   blocks: {
     confirmations: 1,
-    estimateBlockTime: 3,
-    reorgPeriod: 1,
+    estimateBlockTime: 1,
+    reorgPeriod: 10,
   },
   chainId: 'injective-1',
   displayName: 'Injective',


### PR DESCRIPTION
### Description

Seeing some issues possibly related to querying for logs in a range that an RPC server doesn't know about yet. Increasing the reorg period from 1 to 10 to be extra conservative

### Drive-by changes

rm'd the unused finalityBlocks from mainnet3_config.json

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
