### PR TITLE
Add env spec to chains list CLI command

### DIFF
--- a/typescript/cli/src/commands/chains.ts
+++ b/typescript/cli/src/commands/chains.ts
@@ -32,7 +32,21 @@ export const chainsCommand: CommandModule = {
 const listCommand: CommandModule = {
   command: 'list',
   describe: 'List all core chains included in the Hyperlane SDK',
-  handler: () => {
+  builder: (yargs) =>
+    yargs
+      .option('mainnet', {
+        alias: 'm',
+        describe: 'Only list mainnet chains',
+      })
+      .option('testnet', {
+        alias: 't',
+        describe: 'Only list testnet chains',
+      })
+      .conflicts('mainnet', 'testnet'),
+  handler: (args) => {
+    const mainnet = args.mainnet as string | undefined;
+    const testnet = args.testnet as string | undefined;
+
     const serializer = (chains: string[]) =>
       chains.reduce<any>((result, chain) => {
         result[chain] = {
@@ -41,13 +55,22 @@ const listCommand: CommandModule = {
         };
         return result;
       }, {});
+    const logMainnet = () => {
+      logBlue('\nHyperlane core mainnet chains:');
+      logGray('------------------------------');
+      logTable(serializer(Mainnets));
+    };
+    const logTestnet = () => {
+      logBlue('\nHyperlane core testnet chains:');
+      logGray('------------------------------');
+      logTable(serializer(Testnets));
+    };
 
-    logBlue('Hyperlane core mainnet chains:');
-    logGray('------------------------------');
-    logTable(serializer(Mainnets));
-    logBlue('\nHyperlane core testnet chains:');
-    logGray('------------------------------');
-    logTable(serializer(Testnets));
+    if (mainnet) return logMainnet();
+    else if (testnet) return logTestnet();
+
+    logMainnet();
+    logTestnet();
   },
 };
 


### PR DESCRIPTION
### Description

* Added environment specification to the `hyperlane chains list` CLI command
* Provides CLI-users with the option to specify `--testnet` | `-t` or `--mainnet` | `-m` to only display chains for that environment

### Drive-by changes

* None

### Related issues

* None

### Backward compatibility

* Yes

### Testing

* Manual
  * `yarn hyperlane chains list --help`
```
Options:
      --help     Show help                                             [boolean]
  -m, --mainnet  Only list mainnet chains
  -t, --testnet  Only list testnet chains
```
  * `yarn hyperlane chains list -m`
```
Hyperlane core mainnet chains:
------------------------------
...
```
  * `yarn hyperlane chains list -t`
```
Hyperlane core testnet chains:
------------------------------
...
```
  * `yarn hyperlane chains list -m -t`
```
Error: Arguments mainnet and testnet are mutually exclusive

hyperlane chains list

List all core chains included in the Hyperlane SDK
```
  * `yarn hyperlane chains list`

```
Hyperlane core testnet chains:
------------------------------
...
Hyperlane core mainnet chains:
------------------------------
...
```