### PR TITLE
feat: parallelise e2e test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,6 +164,9 @@ jobs:
   e2e:
     runs-on: larger-runner
     needs: [yarn-build]
+    strategy:
+      matrix:
+        e2e-type: [cosmwasm, non-cosmwasm]
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -220,16 +223,16 @@ jobs:
             ~/.cargo
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('./rust/Cargo.lock') }}
 
-      - name: agent build
-        run: cargo build --release --bin run-locally
-        working-directory: ./rust
-
       - name: agent tests with CosmWasm
-        run: RUST_BACKTRACE=1 cargo test --release --package run-locally --bin run-locally --features cosmos -- cosmos::test --nocapture
+        run: cargo test --release --package run-locally --bin run-locally --features cosmos -- cosmos::test --nocapture
+        if: matrix.e2e-type == 'cosmwasm'
         working-directory: ./rust
+        env:
+          RUST_BACKTRACE: 1
 
       - name: agent tests excluding CosmWasm
-        run: ./target/release/run-locally
+        run: cargo run --release --package run-locally
+        if: matrix.e2e-type == 'non-cosmwasm'
         working-directory: ./rust
         env:
           E2E_CI_MODE: 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Metadata Health Check
         run: DEBUG=hyperlane yarn workspace @hyperlane-xyz/sdk run test:metadata
 
-  e2e:
+  e2e-matrix:
     runs-on: larger-runner
     needs: [yarn-build]
     strategy:
@@ -238,6 +238,16 @@ jobs:
           E2E_CI_MODE: 'true'
           E2E_CI_TIMEOUT_SEC: '600'
           E2E_KATHY_MESSAGES: '20'
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: [e2e-matrix]
+    if: always() # This ensures that the job runs even if the e2e jobs fail
+    steps:
+      - name: Report Matrix Result
+        run: |
+          echo "All e2e-matrix jobs have completed."
+          # You can add additional commands here to report the result as needed
 
   cli-e2e:
     runs-on: larger-runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,7 +231,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: agent tests excluding CosmWasm
-        run: cargo run --release --package run-locally
+        run: cargo run --release --bin run-locally
         if: matrix.e2e-type == 'non-cosmwasm'
         working-directory: ./rust
         env:


### PR DESCRIPTION
- parallelise cosmwasm and non-cosmwasm e2e tests
- no need to have an explicit agent build step
	- cc @daniel-savu 
- `e2e` status should still pass as it collates result from the matrix 

before: 26-30m
after: 15-20m

there's likely further optimisation that can be done by caching the agent build artifacts? but I think this should be good enough for now
