### PR TITLE
feat:merge not replace agent artifacts

### DIFF
--- a/typescript/infra/src/deployment/deploy.ts
+++ b/typescript/infra/src/deployment/deploy.ts
@@ -15,8 +15,8 @@ import { getAgentConfigDirectory } from '../../scripts/agent-utils';
 import { DeployEnvironment } from '../config';
 import {
   readJSONAtPath,
-  writeJSON,
   writeJsonAtPath,
+  writeMergedJSON,
   writeMergedJSONAtPath,
 } from '../utils/utils';
 
@@ -143,7 +143,7 @@ export async function writeAgentConfig(
     addresses as ChainMap<HyperlaneDeploymentArtifacts>,
     startBlocks,
   );
-  writeJSON(
+  writeMergedJSON(
     getAgentConfigDirectory(),
     `${environment}_config.json`,
     agentConfig,


### PR DESCRIPTION
### Description

- Due to the inclusion-exclusion certain chains during deployment, the deployer make accidentally remove agent artifacts for a different unrelated chain which is undesirable. So, instead of just writing to file, we'll now merge with read obj and then write.

### Drive-by changes

None

### Related issues

None

### Backward compatibility

Yes

### Testing

Manual
