### PR TITLE
chore: increase relayer memory in helm chart

### DIFF
--- a/rust/helm/hyperlane-agent/values.yaml
+++ b/rust/helm/hyperlane-agent/values.yaml
@@ -114,7 +114,7 @@ hyperlane:
     resources:
       requests:
         cpu: 500m
-        memory: 256Mi
+        memory: 512Mi
     config:
       relayChains: ''
       multisigCheckpointSyncer:


### PR DESCRIPTION
### Description

Updating the helm chart so we no longer exceed the requested memory. Checked the scraper and validators too and those have enough resources.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
