### PR TITLE
feat: add dry-run support for core deploy

### DIFF
--- a/typescript/cli/anvil-start.sh
+++ b/typescript/cli/anvil-start.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# NOTE: This script is intended to be run from the root of the repo
+
+echo -e "\nYou must have 'anvil' from Foundry installed to proceed."
+echo -e '\nTo install, run the following command:'
+echo -e '\tcurl -L https://foundry.paradigm.xyz | bash && foundryup && anvil\n'
+
+read -p 'Press enter to continue running anvil...'
+
+# Used by Anvil as export
+export ANVIL_IP_ADDR='127.0.0.1'
+# Passed to CLI option
+export ANVIL_PORT=8545
+
+echo -e "\nSpinning up anvil node at http://$ANVIL_IP_ADDR:$ANVIL_PORT..."
+
+anvil -p $ANVIL_PORT

--- a/typescript/cli/src/commands/deploy.ts
+++ b/typescript/cli/src/commands/deploy.ts
@@ -2,17 +2,28 @@ import { CommandModule } from 'yargs';
 
 import { runKurtosisAgentDeploy } from '../deploy/agent.js';
 import { runCoreDeploy } from '../deploy/core.js';
+import { evaluateIfDryRunFailure, verifyAnvil } from '../deploy/dry-run.js';
 import { runWarpRouteDeploy } from '../deploy/warp.js';
 import { log, logGray } from '../logger.js';
 import { ENV } from '../utils/env.js';
 
 import {
-  agentConfigurationOption,
+  AgentCommandOptions,
+  CoreCommandOptions,
+  WarpCommandOptions,
+  agentConfigCommandOption,
+  agentTargetsCommandOption,
   chainsCommandOption,
   coreArtifactsOption,
+  coreTargetsCommandOption,
+  dryRunOption,
+  hookCommandOption,
+  ismCommandOption,
   keyCommandOption,
+  originCommandOption,
   outDirCommandOption,
   skipConfirmationOption,
+  warpConfigCommandOption,
 } from './options.js';
 
 /**
@@ -38,17 +49,11 @@ const agentCommand: CommandModule = {
   command: 'kurtosis-agents',
   describe: 'Deploy Hyperlane agents with Kurtosis',
   builder: (yargs) =>
-    yargs.options({
-      origin: {
-        type: 'string',
-        description: 'The name of the origin chain to deploy to',
-      },
-      targets: {
-        type: 'string',
-        description: 'Comma separated list of chains to relay between',
-      },
+    yargs.options<AgentCommandOptions>({
+      origin: originCommandOption,
+      targets: agentTargetsCommandOption,
       chains: chainsCommandOption,
-      config: agentConfigurationOption,
+      config: agentConfigCommandOption,
     }),
   handler: async (argv: any) => {
     logGray('Hyperlane Agent Deployment with Kurtosis');
@@ -74,31 +79,18 @@ const coreCommand: CommandModule = {
   command: 'core',
   describe: 'Deploy core Hyperlane contracts',
   builder: (yargs) =>
-    yargs.options({
-      targets: {
-        type: 'string',
-        description:
-          'Comma separated list of chain names to which contracts will be deployed',
-      },
+    yargs.options<CoreCommandOptions>({
+      targets: coreTargetsCommandOption,
       chains: chainsCommandOption,
       artifacts: coreArtifactsOption,
-      ism: {
-        type: 'string',
-        description:
-          'A path to a JSON or YAML file with basic or advanced ISM configs (e.g. Multisig)',
-      },
-      hook: {
-        type: 'string',
-        description:
-          'A path to a JSON or YAML file with Hook configs (for every chain)',
-      },
+      ism: ismCommandOption,
+      hook: hookCommandOption,
       out: outDirCommandOption,
       key: keyCommandOption,
       yes: skipConfirmationOption,
+      'dry-run': dryRunOption,
     }),
   handler: async (argv: any) => {
-    logGray('Hyperlane permissionless core deployment');
-    logGray('----------------------------------------');
     const key: string = argv.key || ENV.HYP_KEY;
     const chainConfigPath: string = argv.chains;
     const outPath: string = argv.out;
@@ -109,16 +101,32 @@ const coreCommand: CommandModule = {
     const ismConfigPath: string = argv.ism;
     const hookConfigPath: string = argv.hook;
     const skipConfirmation: boolean = argv.yes;
-    await runCoreDeploy({
-      key,
-      chainConfigPath,
-      chains,
-      artifactsPath,
-      ismConfigPath,
-      hookConfigPath,
-      outPath,
-      skipConfirmation,
-    });
+    const dryRun: boolean = argv.dryRun;
+
+    logGray(
+      `Hyperlane permissionless core deployment${dryRun ? ' dry-run' : ''}`,
+    );
+    logGray('------------------------------------------------');
+
+    if (dryRun) await verifyAnvil();
+
+    try {
+      await runCoreDeploy({
+        key,
+        chainConfigPath,
+        chains,
+        artifactsPath,
+        ismConfigPath,
+        hookConfigPath,
+        outPath,
+        skipConfirmation,
+        dryRun,
+      });
+    } catch (error: any) {
+      evaluateIfDryRunFailure(error, dryRun);
+
+      throw new Error(error);
+    }
     process.exit(0);
   },
 };
@@ -130,13 +138,8 @@ const warpCommand: CommandModule = {
   command: 'warp',
   describe: 'Deploy Warp Route contracts',
   builder: (yargs) =>
-    yargs.options({
-      config: {
-        type: 'string',
-        description:
-          'A path to a JSON or YAML file with a warp route deployment config.',
-        default: './configs/warp-route-deployment.yaml',
-      },
+    yargs.options<WarpCommandOptions>({
+      config: warpConfigCommandOption,
       core: coreArtifactsOption,
       chains: chainsCommandOption,
       out: outDirCommandOption,

--- a/typescript/cli/src/commands/options.ts
+++ b/typescript/cli/src/commands/options.ts
@@ -1,4 +1,3 @@
-// A set of common options
 import { Options } from 'yargs';
 
 import { LogFormat, LogLevel } from '@hyperlane-xyz/utils';
@@ -15,10 +14,72 @@ export const logLevelCommandOption: Options = {
   choices: Object.values(LogLevel),
 };
 
-export const keyCommandOption: Options = {
+export type CommandOptions = {
+  chains: Options;
+};
+export type AgentCommandOptions = CommandOptions & {
+  origin: Options;
+  targets: Options;
+  config: Options;
+};
+export type CoreCommandOptions = CommandOptions & {
+  targets: Options;
+  artifacts: Options;
+  ism: Options;
+  hook: Options;
+  out: Options;
+  key: Options;
+  yes: Options;
+  'dry-run': Options;
+};
+export type WarpCommandOptions = CommandOptions & {
+  config: Options;
+  core: Options;
+  out: Options;
+  key: Options;
+  yes: Options;
+};
+
+export const coreTargetsCommandOption: Options = {
   type: 'string',
   description:
-    'A hex private key or seed phrase for transaction signing. Or use the HYP_KEY env var',
+    'Comma separated list of chain names to which contracts will be deployed',
+};
+
+export const agentTargetsCommandOption: Options = {
+  type: 'string',
+  description: 'Comma separated list of chains to relay between',
+};
+
+export const originCommandOption: Options = {
+  type: 'string',
+  description: 'The name of the origin chain to deploy to',
+};
+
+export const ismCommandOption: Options = {
+  type: 'string',
+  description:
+    'A path to a JSON or YAML file with basic or advanced ISM configs (e.g. Multisig)',
+};
+
+export const hookCommandOption: Options = {
+  type: 'string',
+  description:
+    'A path to a JSON or YAML file with Hook configs (for every chain)',
+};
+
+export const warpConfigCommandOption: Options = {
+  type: 'string',
+  description:
+    'A path to a JSON or YAML file with a warp route deployment config.',
+  default: './configs/warp-route-deployment.yaml',
+  alias: 'w',
+};
+
+export const keyCommandOption: Options = {
+  type: 'string',
+  description: `Default: A hex private key or seed phrase for transaction signing, or use the HYP_KEY env var.
+Dry-run: An address to simulate transaction signing on a forked network, or use the HYP_KEY env var.`,
   alias: 'k',
 };
 
@@ -48,7 +109,7 @@ export const warpConfigOption: Options = {
   alias: 'w',
 };
 
-export const agentConfigurationOption: Options = {
+export const agentConfigCommandOption: Options = {
   type: 'string',
   description: 'File path to agent configuration artifacts',
 };
@@ -73,4 +134,12 @@ export const skipConfirmationOption: Options = {
   description: 'Skip confirmation prompts',
   default: false,
   alias: 'y',
+};
+
+export const dryRunOption: Options = {
+  type: 'boolean',
+  description:
+    'Simulate deployment on forked network. Please ensure an anvil node instance is running during execution via `anvil`.',
+  default: false,
+  alias: 'd',
 };

--- a/typescript/cli/src/config/artifacts.ts
+++ b/typescript/cli/src/config/artifacts.ts
@@ -33,6 +33,10 @@ export function readDeploymentArtifacts(filePath: string) {
   return artifacts;
 }
 
+/**
+ * Prompts the user to specify deployment artifacts, or to generate new ones if none are present or selected.
+ * @returns the selected artifacts, or undefined if they are to be generated from scratch
+ */
 export async function runDeploymentArtifactStep({
   artifactsPath,
   message,
@@ -40,6 +44,7 @@ export async function runDeploymentArtifactStep({
   defaultArtifactsPath = './artifacts',
   defaultArtifactsNamePattern = 'core-deployment',
   skipConfirmation = false,
+  dryRun = false,
 }: {
   artifactsPath?: string;
   message?: string;
@@ -47,9 +52,11 @@ export async function runDeploymentArtifactStep({
   defaultArtifactsPath?: string;
   defaultArtifactsNamePattern?: string;
   skipConfirmation?: boolean;
+  dryRun?: boolean;
 }): Promise<HyperlaneContractsMap<any> | undefined> {
   if (!artifactsPath) {
     if (skipConfirmation) return undefined;
+    if (dryRun) defaultArtifactsNamePattern = 'dry-run_core-deployment';
 
     const useArtifacts = await confirm({
       message: message || 'Do you want use some existing contract addresses?',

--- a/typescript/cli/src/context.ts
+++ b/typescript/cli/src/context.ts
@@ -15,8 +15,10 @@ import { objFilter, objMap, objMerge } from '@hyperlane-xyz/utils';
 
 import { runDeploymentArtifactStep } from './config/artifacts.js';
 import { readChainConfigsIfExists } from './config/chain.js';
+import { forkNetworkToMultiProvider } from './deploy/dry-run.js';
+import { runSingleChainSelectionStep } from './utils/chains.js';
 import { readYamlOrJson } from './utils/files.js';
-import { keyToSigner } from './utils/keys.js';
+import { getImpersonatedSigner, getSigner } from './utils/keys.js';
 
 export const sdkContractAddressesMap: HyperlaneContractsMap<any> = {
   ...hyperlaneEnvironments.testnet,
@@ -47,16 +49,19 @@ export function getMergedContractAddresses(
   ) as HyperlaneContractsMap<any>;
 }
 
-interface ContextSettings {
+export type KeyConfig = {
+  key?: string;
+  promptMessage?: string;
+};
+
+export interface ContextSettings {
   chainConfigPath?: string;
+  chains?: ChainName[];
   coreConfig?: {
     coreArtifactsPath?: string;
     promptMessage?: string;
   };
-  keyConfig?: {
-    key?: string;
-    promptMessage?: string;
-  };
+  keyConfig?: KeyConfig;
   skipConfirmation?: boolean;
   warpConfig?: {
     warpConfigPath?: string;
@@ -65,6 +70,7 @@ interface ContextSettings {
 }
 
 interface CommandContextBase {
+  chains: string[];
   customChains: ChainMap<ChainMetadata>;
   multiProvider: MultiProvider;
 }
@@ -81,6 +87,10 @@ type CommandContext<P extends ContextSettings> = CommandContextBase &
     ? { warpCoreConfig: WarpCoreConfig }
     : { warpCoreConfig: undefined });
 
+/**
+ * Retrieves context for the user-selected command
+ * @returns context for the current command
+ */
 export async function getContext<P extends ContextSettings>({
   chainConfigPath,
   coreConfig,
@@ -90,19 +100,10 @@ export async function getContext<P extends ContextSettings>({
 }: P): Promise<CommandContext<P>> {
   const customChains = readChainConfigsIfExists(chainConfigPath);
 
-  let signer = undefined;
-  if (keyConfig) {
-    let key: string;
-    if (keyConfig.key) key = keyConfig.key;
-    else if (skipConfirmation) throw new Error('No key provided');
-    else
-      key = await input({
-        message:
-          keyConfig.promptMessage ||
-          'Please enter a private key or use the HYP_KEY environment variable.',
-      });
-    signer = keyToSigner(key);
-  }
+  const signer = await getSigner({
+    keyConfig,
+    skipConfirmation,
+  });
 
   let coreArtifacts = undefined;
   if (coreConfig) {
@@ -142,12 +143,71 @@ export async function getContext<P extends ContextSettings>({
   } as CommandContext<P>;
 }
 
+/**
+ * Retrieves dry-run context for the user-selected command
+ * @returns dry-run context for the current command
+ */
+export async function getDryRunContext<P extends ContextSettings>({
+  chainConfigPath,
+  chains,
+  coreConfig,
+  keyConfig,
+  skipConfirmation,
+}: P): Promise<CommandContext<P>> {
+  const customChains = readChainConfigsIfExists(chainConfigPath);
+
+  let coreArtifacts = undefined;
+  if (coreConfig) {
+    coreArtifacts =
+      (await runDeploymentArtifactStep({
+        artifactsPath: coreConfig.coreArtifactsPath,
+        message:
+          coreConfig.promptMessage ||
+          'Do you want to use some core deployment address artifacts? This is required for PI chains (non-core chains).',
+        skipConfirmation,
+      })) || {};
+  }
+
+  const multiProvider = getMultiProvider(customChains);
+
+  if (!chains?.length) {
+    if (skipConfirmation) throw new Error('No chains provided');
+    chains = [
+      await runSingleChainSelectionStep(
+        customChains,
+        'Select chain to dry-run against:',
+      ),
+    ];
+  }
+
+  await forkNetworkToMultiProvider(multiProvider, chains[0]);
+
+  const impersonatedSigner = await getImpersonatedSigner({
+    keyConfig,
+    skipConfirmation,
+  });
+
+  if (impersonatedSigner) multiProvider.setSharedSigner(impersonatedSigner);
+
+  return {
+    chains,
+    signer: impersonatedSigner,
+    multiProvider,
+    coreArtifacts,
+  } as CommandContext<P>;
+}
+
+/**
+ * Retrieves a new MultiProvider based on all known chain metadata & custom user chains
+ * @param customChains Custom chains specified by the user
+ * @returns a new MultiProvider
+ */
 export function getMultiProvider(
   customChains: ChainMap<ChainMetadata>,
   signer?: ethers.Signer,
 ) {
   const chainConfigs = { ...chainMetadata, ...customChains };
-  const mp = new MultiProvider(chainConfigs);
-  if (signer) mp.setSharedSigner(signer);
-  return mp;
+  const multiProvider = new MultiProvider(chainConfigs);
+  if (signer) multiProvider.setSharedSigner(signer);
+  return multiProvider;
 }

--- a/typescript/cli/src/deploy/core.ts
+++ b/typescript/cli/src/deploy/core.ts
@@ -36,6 +36,7 @@ import { readMultisigConfig } from '../config/multisig.js';
 import { MINIMUM_CORE_DEPLOY_GAS } from '../consts.js';
 import {
   getContext,
+  getDryRunContext,
   getMergedContractAddresses,
   sdkContractAddressesMap,
 } from '../context.js';
@@ -49,10 +50,12 @@ import {
 } from '../logger.js';
 import { runMultiChainSelectionStep } from '../utils/chains.js';
 import {
+  ArtifactsFile,
   prepNewArtifactsFiles,
   runFileSelectionStep,
   writeJson,
 } from '../utils/files.js';
+import { resetFork } from '../utils/fork.js';
 
 import {
   isISMConfig,
@@ -60,6 +63,9 @@ import {
   runPreflightChecksForChains,
 } from './utils.js';
 
+/**
+ * Executes the core deploy command.
+ */
 export async function runCoreDeploy({
   key,
   chainConfigPath,
@@ -69,6 +75,7 @@ export async function runCoreDeploy({
   artifactsPath,
   outPath,
   skipConfirmation,
+  dryRun,
 }: {
   key: string;
   chainConfigPath: string;
@@ -78,21 +85,35 @@ export async function runCoreDeploy({
   artifactsPath?: string;
   outPath: string;
   skipConfirmation: boolean;
+  dryRun: boolean;
 }) {
-  const { customChains, multiProvider, signer } = await getContext({
-    chainConfigPath,
-    keyConfig: { key },
-    skipConfirmation,
-  });
+  const context = dryRun
+    ? await getDryRunContext({
+        chainConfigPath,
+        chains,
+        keyConfig: { key },
+        skipConfirmation,
+      })
+    : await getContext({
+        chainConfigPath,
+        keyConfig: { key },
+        skipConfirmation,
+      });
 
-  if (!chains?.length) {
+  const customChains = context.customChains;
+  const multiProvider = context.multiProvider;
+  const signer = context.signer;
+
+  if (dryRun) chains = context.chains;
+  else if (!chains?.length) {
     if (skipConfirmation) throw new Error('No chains provided');
     chains = await runMultiChainSelectionStep(
       customChains,
-      'Select chains to connect',
+      'Select chains to connect:',
       true,
     );
   }
+
   const artifacts = await runArtifactStep(
     chains,
     skipConfirmation,
@@ -117,6 +138,7 @@ export async function runCoreDeploy({
     hooksConfig,
     outPath,
     skipConfirmation,
+    dryRun,
   };
 
   await runDeployPlanStep(deploymentParams);
@@ -125,12 +147,15 @@ export async function runCoreDeploy({
     minGas: MINIMUM_CORE_DEPLOY_GAS,
   });
   await executeDeploy(deploymentParams);
+
+  if (dryRun) await resetFork();
 }
 
 function runArtifactStep(
   selectedChains: ChainName[],
   skipConfirmation: boolean,
   artifactsPath?: string,
+  dryRun?: boolean,
 ) {
   logBlue(
     '\nDeployments can be totally new or can use some existing contract addresses.',
@@ -139,6 +164,7 @@ function runArtifactStep(
     artifactsPath,
     selectedChains,
     skipConfirmation,
+    dryRun,
   });
 }
 
@@ -236,6 +262,7 @@ interface DeployParams {
   hooksConfig?: ChainMap<HooksConfig>;
   outPath: string;
   skipConfirmation: boolean;
+  dryRun: boolean;
 }
 
 async function runDeployPlanStep({
@@ -272,13 +299,14 @@ async function executeDeploy({
   ismConfigs = {},
   multisigConfigs = {},
   hooksConfig = {},
+  dryRun,
 }: DeployParams) {
   logBlue('All systems ready, captain! Beginning deployment...');
 
-  const [contractsFilePath, agentFilePath] = prepNewArtifactsFiles(outPath, [
-    { filename: 'core-deployment', description: 'Contract addresses' },
-    { filename: 'agent-config', description: 'Agent configs' },
-  ]);
+  const [contractsFilePath, agentFilePath] = prepNewArtifactsFiles(
+    outPath,
+    getArtifactsFiles(dryRun),
+  );
 
   const owner = await signer.getAddress();
   const mergedContractAddrs = getMergedContractAddresses(artifacts, chains);
@@ -348,6 +376,24 @@ async function executeDeploy({
   logBlue('Deployment is complete!');
   logBlue(`Contract address artifacts are in ${contractsFilePath}`);
   logBlue(`Agent configs are in ${agentFilePath}`);
+}
+
+/**
+ * Retrieves artifacts file metadata for the current command.
+ * @param dryRun whether or not the current command is being dry-run
+ * @returns the artifacts files
+ */
+function getArtifactsFiles(dryRun: boolean): Array<ArtifactsFile> {
+  const coreDeploymentFile = {
+    filename: dryRun ? 'dry-run_core-deployment' : 'core-deployment',
+    description: 'Contract addresses',
+  };
+  const agentConfigFile = {
+    filename: dryRun ? 'dry-run_agent-config' : 'agent-config',
+    description: 'Agent configs',
+  };
+
+  return [coreDeploymentFile, agentConfigFile];
 }
 
 function buildIsmConfig(

--- a/typescript/cli/src/deploy/dry-run.ts
+++ b/typescript/cli/src/deploy/dry-run.ts
@@ -1,0 +1,50 @@
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+
+import { logGray, logGreen, warnYellow } from '../logger.js';
+import { ANVIL_RPC_METHODS, getLocalProvider, setFork } from '../utils/fork.js';
+
+/**
+ * Forks a provided network onto MultiProvider
+ * @param multiProvider the MultiProvider to be prepared
+ * @param chains the chain selection passed-in by the user
+ */
+export async function forkNetworkToMultiProvider(
+  multiProvider: MultiProvider,
+  chain: string,
+) {
+  multiProvider = multiProvider.extendChainMetadata({
+    [chain]: { blocks: { confirmations: 0 } },
+  });
+
+  await setFork(multiProvider, chain);
+}
+
+/**
+ * Ensures an anvil node is running locally.
+ */
+export async function verifyAnvil() {
+  logGray('Verifying anvil node is running...');
+
+  const provider = getLocalProvider();
+  try {
+    await provider.send(ANVIL_RPC_METHODS.NODE_INFO, []);
+  } catch (error: any) {
+    if (error.message.includes('missing response'))
+      throw new Error(`No active anvil node detected.
+\tPlease run \`anvil\` in a separate instance.`);
+  }
+
+  logGreen('Successfully verified anvil node is running ✅');
+}
+
+/**
+ * Evaluates if an error is related to the current dry-run.
+ * @param error the thrown error
+ * @param dryRun whether or not the current command is being dry-run
+ */
+export function evaluateIfDryRunFailure(error: any, dryRun: boolean) {
+  if (dryRun && error.message.includes('call revert exception'))
+    warnYellow(
+      '⛔️ [dry-run] The current RPC may not support forking. Please consider using a different RPC provider.',
+    );
+}

--- a/typescript/cli/src/logger.ts
+++ b/typescript/cli/src/logger.ts
@@ -45,6 +45,8 @@ export const logBoldUnderlinedRed = (...args: any) =>
   logColor('info', chalk.red.bold.underline, ...args);
 export const logTip = (...args: any) =>
   logColor('info', chalk.bgYellow, ...args);
+export const warnYellow = (...args: any) =>
+  logColor('warn', chalk.yellow, ...args);
 export const errorRed = (...args: any) => logColor('error', chalk.red, ...args);
 
 // No support for table in pino so print directly to console

--- a/typescript/cli/src/utils/env.ts
+++ b/typescript/cli/src/utils/env.ts
@@ -2,6 +2,8 @@ import z from 'zod';
 
 const envScheme = z.object({
   HYP_KEY: z.string().optional(),
+  ANVIL_IP_ADDR: z.string().optional(),
+  ANVIL_PORT: z.number().optional(),
 });
 
 const parsedEnv = envScheme.safeParse(process.env);

--- a/typescript/cli/src/utils/files.ts
+++ b/typescript/cli/src/utils/files.ts
@@ -12,6 +12,11 @@ import { getTimestampForFilename } from './time.js';
 
 export type FileFormat = 'yaml' | 'json';
 
+export type ArtifactsFile = {
+  filename: string;
+  description: string;
+};
+
 export function isFile(filepath: string) {
   if (!filepath) return false;
   try {
@@ -144,7 +149,7 @@ function resolveYamlOrJson(
 
 export function prepNewArtifactsFiles(
   outPath: string,
-  files: Array<{ filename: string; description: string }>,
+  files: Array<ArtifactsFile>,
 ) {
   const timestamp = getTimestampForFilename();
   const newPaths: string[] = [];

--- a/typescript/cli/src/utils/fork.ts
+++ b/typescript/cli/src/utils/fork.ts
@@ -1,0 +1,132 @@
+import { providers } from 'ethers';
+
+import { ChainName, MultiProvider } from '@hyperlane-xyz/sdk';
+import { Address } from '@hyperlane-xyz/utils';
+
+import { logGray, logGreen } from '../logger.js';
+import { warnYellow } from '../logger.js';
+
+import { ENV } from './env.js';
+
+const ENDPOINT_PREFIX = 'http';
+const DEFAULT_ANVIL_ENDPOINT = 'http://127.0.0.1:8545';
+const TRIMMED_ETHEREUM_ADDRESS_LENGTH = 40;
+
+export enum ANVIL_RPC_METHODS {
+  RESET = 'anvil_reset',
+  IMPERSONATE_ACCOUNT = 'anvil_impersonateAccount',
+  STOP_IMPERSONATING_ACCOUNT = 'anvil_stopImpersonatingAccount',
+  NODE_INFO = 'anvil_nodeInfo',
+}
+
+/**
+ * Resets the local node to it's original start (anvil [31337] at block zero).
+ */
+export const resetFork = async () => {
+  logGray(`Resetting forked network...`);
+
+  const provider = getLocalProvider();
+  await provider.send(ANVIL_RPC_METHODS.RESET, [
+    {
+      forking: {
+        jsonRpcUrl: DEFAULT_ANVIL_ENDPOINT,
+      },
+    },
+  ]);
+
+  logGreen(`Successfully reset forked network ✅`);
+};
+
+/**
+ * Forks a chain onto the local node at the latest block of the forked network.
+ * @param multiProvider the multiProvider with which to fork the network
+ * @param chain the network to fork
+ */
+export const setFork = async (
+  multiProvider: MultiProvider,
+  chain: ChainName | number,
+) => {
+  logGray(`Forking ${chain} for dry-run...`);
+
+  const provider = getLocalProvider();
+  const currentChainMetadata = multiProvider.metadata[chain];
+
+  await provider.send(ANVIL_RPC_METHODS.RESET, [
+    {
+      forking: {
+        jsonRpcUrl: currentChainMetadata.rpcUrls[0].http,
+      },
+    },
+  ]);
+
+  multiProvider.setProvider(chain, provider);
+
+  logGreen(`Successfully forked ${chain} for dry-run ✅`);
+};
+
+/**
+ * Impersonates an EOA for a provided address.
+ * @param address the address to impersonate
+ * @returns the impersonated signer
+ */
+export const impersonateAccount = async (
+  address: Address,
+): Promise<providers.JsonRpcSigner> => {
+  logGray(`Impersonating account (${address})...`);
+
+  const provider = getLocalProvider();
+  await provider.send(ANVIL_RPC_METHODS.IMPERSONATE_ACCOUNT, [address]);
+
+  logGreen(`Successfully impersonated account (${address}) ✅`);
+
+  return provider.getSigner(address);
+};
+
+/**
+ * Stops account impersonation.
+ * @param address the address to stop impersonating
+ */
+export const stopImpersonatingAccount = async (address: Address) => {
+  logGray(`Stopping account impersonation for address (${address})...`);
+
+  const trimmedAddress = address.substring(2);
+  if (trimmedAddress.length != TRIMMED_ETHEREUM_ADDRESS_LENGTH)
+    throw new Error(
+      `Cannot stop account impersonation: invalid address format: ${address}`,
+    );
+
+  const provider = getLocalProvider();
+  await provider.send(ANVIL_RPC_METHODS.STOP_IMPERSONATING_ACCOUNT, [
+    trimmedAddress,
+  ]);
+
+  logGreen(
+    `Successfully stopped account impersonation for address (${address}) ✅`,
+  );
+};
+
+/**
+ * Retrieves a local provider. Defaults to DEFAULT_ANVIL_ENDPOINT.
+ * @param urlOverride custom URL to overried the default endpoint
+ * @returns a local JSON-RPC provider
+ */
+export const getLocalProvider = (
+  urlOverride?: string,
+): providers.JsonRpcProvider => {
+  let envUrl;
+  if (ENV.ANVIL_IP_ADDR && ENV.ANVIL_PORT)
+    envUrl = `${ENDPOINT_PREFIX}${ENV.ANVIL_IP_ADDR}:${ENV.ANVIL_PORT}`;
+
+  if (urlOverride && !urlOverride.startsWith(ENDPOINT_PREFIX)) {
+    warnYellow(
+      `⚠️ Provided URL override (${urlOverride}) does not begin with ${ENDPOINT_PREFIX}. Defaulting to ${
+        envUrl ?? DEFAULT_ANVIL_ENDPOINT
+      }`,
+    );
+    urlOverride = undefined;
+  }
+
+  const url = urlOverride ?? envUrl ?? DEFAULT_ANVIL_ENDPOINT;
+
+  return new providers.JsonRpcProvider(url);
+};

--- a/typescript/cli/src/utils/keys.ts
+++ b/typescript/cli/src/utils/keys.ts
@@ -1,18 +1,109 @@
-import { ethers } from 'ethers';
+import { input } from '@inquirer/prompts';
+import { ethers, providers } from 'ethers';
 
-import { ensure0x } from '@hyperlane-xyz/utils';
+import { Address, ensure0x } from '@hyperlane-xyz/utils';
 
-export function keyToSigner(key: string) {
-  if (!key) throw new Error('No key provided');
+import { ContextSettings, KeyConfig } from '../context.js';
+
+import { impersonateAccount } from './fork.js';
+
+const ETHEREUM_ADDRESS_LENGTH = 42;
+const DEFAULT_KEY_TYPE = 'private key';
+const IMPERSONATED_KEY_TYPE = 'address';
+
+/**
+ * Retrieves a signer for the current command-context.
+ * @returns the signer
+ */
+export async function getSigner<P extends ContextSettings>({
+  keyConfig,
+  skipConfirmation,
+}: P): Promise<providers.JsonRpcSigner | ethers.Wallet | undefined> {
+  if (!keyConfig) return undefined;
+
+  const key = await retrieveKey(DEFAULT_KEY_TYPE, keyConfig, skipConfirmation);
+
+  return privateKeyToSigner(key);
+}
+
+/**
+ * Retrieves an impersonated signer for the current command-context.
+ * @returns the impersonated signer
+ */
+export async function getImpersonatedSigner<P extends ContextSettings>({
+  keyConfig,
+  skipConfirmation,
+}: P): Promise<providers.JsonRpcSigner | ethers.Wallet | undefined> {
+  if (!keyConfig) return undefined;
+
+  const key = await retrieveKey(
+    IMPERSONATED_KEY_TYPE,
+    keyConfig,
+    skipConfirmation,
+  );
+
+  return await addressToImpersonatedSigner(key);
+}
+
+/**
+ * Verifies the specified signer is valid.
+ * @param signer the signer to verify
+ */
+export function assertSigner(signer: ethers.Signer) {
+  if (!signer || !ethers.Signer.isSigner(signer))
+    throw new Error('Signer is invalid');
+}
+
+/**
+ * Generates a signer from an address.
+ * @param address an EOA address
+ * @returns a signer for the address
+ */
+async function addressToImpersonatedSigner(
+  address: Address,
+): Promise<providers.JsonRpcSigner> {
+  if (!address) throw new Error('No address provided');
+
+  const formattedKey = address.trim().toLowerCase();
+  if (address.length != ETHEREUM_ADDRESS_LENGTH)
+    throw new Error(
+      'Invalid address length. Please ensure you are passing an address and not a private key.',
+    );
+  else if (ethers.utils.isHexString(ensure0x(formattedKey)))
+    return await impersonateAccount(address);
+  else throw new Error('Invalid address format');
+}
+
+/**
+ * Generates a signer from a private key.
+ * @param key a private key
+ * @returns a signer for the private key
+ */
+function privateKeyToSigner(key: string): ethers.Wallet {
+  if (!key) throw new Error('No private key provided');
+
   const formattedKey = key.trim().toLowerCase();
   if (ethers.utils.isHexString(ensure0x(formattedKey)))
     return new ethers.Wallet(ensure0x(formattedKey));
   else if (formattedKey.split(' ').length >= 6)
     return ethers.Wallet.fromMnemonic(formattedKey);
-  else throw new Error('Invalid key format');
+  else throw new Error('Invalid private key format');
 }
 
-export function assertSigner(signer: ethers.Signer) {
-  if (!signer || !ethers.Signer.isSigner(signer))
-    throw new Error('Signer is invalid');
+async function retrieveKey(
+  keyType: string,
+  keyConfig: KeyConfig,
+  skipConfirmation: boolean | undefined,
+): Promise<string> {
+  let key: string;
+  if (keyConfig.key) key = keyConfig.key;
+  else if (skipConfirmation) throw new Error(`No ${keyType} provided`);
+  else
+    key = await input({
+      message:
+        keyConfig.promptMessage ||
+        `Please enter ${keyType} or use the HYP_KEY environment variable.`,
+    });
+
+  return key;
 }


### PR DESCRIPTION
**Closed in favor of https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3558**

### Description

* New feature to allow users to dry-run the core deploy script against a forked network of their choice
* To run: `yarn build && yarn hyperlane deploy core --dry-run` || `yarn build && yarn hyperlane deploy core -d`
* Externally enables: `hyperlane deploy core --dry-run` || `hyperlane deploy core -d`

### Drive-by changes

* For all touched paths:
  * Code cleanliness + reuse
  * Method docs
  * Minor changes for increased symmetry

### Related issues

* [Issue 819](https://github.com/hyperlane-xyz/issues/issues/819)

### Backward compatibility

* Yes

### Testing

* Note: `hl` == `yarn build && yarn hyperlane`. The below tests are only a sample and are not inclusive.

#### Manual Testing
  * With `anvil` NOT running in separate instance:
    * `hl deploy core -d`
      * Throws:
```
Error: No active anvil node detected.
        Please run `anvil` in a separate instance.
```
  * With `anvil` running in separate instance:
     * `hl deploy core -d --targets alfajores -k c0052e22df5d1f4ae7c51e254Xx00Xx0eb833453eaed6301xXxxx8a30d92d10a` (any private key)
       * Throws `Error: Invalid address length. Please ensure you are passing an address and not a private key.`
     * `hl deploy core -d --targets bsctestnet -k 0x16F4898F47c085C41d7Cc6b1dc0xX0xXX017dcBb` (any public address; BSC public RPC endpoint does not support forking)
     * Output: `⛔️ [dry-run] The current RPC may not support forking. Please consider using a different RPC provider.`
     * `hl deploy core -d --targets alfajores -k 0x16F4898F47c085C41d7Cc6b1dc0xX0xXX017dcBb` (any public address)
     * Output:
```
Verifying anvil node is running...
Successfully verified anvil node is running ✅
No chain config file provided
Forking alfajores for dry-run...
Successfully forked alfajores for dry-run ✅
Impersonating account (0x16F4898F47c085C41d7Cc6b1dc72B91EA617dcBb)...
Successfully impersonated account (0x16F4898F47c085C41d7Cc6b1dc72B91EA617dcBb) ✅
...
Core contracts deployed
Writing agent configs
Agent configs written
Deployment is complete!
Contract address artifacts are in artifacts/dry-run_core-deployment-2024-02-23-15-51-45.json
Agent configs are in artifacts/dry-run_agent-config-2024-02-23-15-51-45.json
Resetting forked network...
Successfully reset forked network ✅
```

#### CI Testing
  * Successful CI-backed integration/regression testing via `ci-test.sh` (includes script refactor)
