### PR TITLE
fix:support Plume Testnet as a Arbitrum Nitro rollup

### DIFF
--- a/rust/hyperlane-core/src/chain.rs
+++ b/rust/hyperlane-core/src/chain.rs
@@ -86,6 +86,8 @@ pub enum KnownHyperlaneDomain {
 
     Injective = 6909546,
 
+    PlumeTestnet = 161221135,
+
     // -- Local test chains --
     /// Test1 local chain
     Test1 = 13371,
@@ -204,7 +206,7 @@ impl KnownHyperlaneDomain {
             ],
             Testnet: [
                 Goerli, Mumbai, Fuji, ArbitrumGoerli, OptimismGoerli, BinanceSmartChainTestnet,
-                Alfajores, MoonbaseAlpha, Sepolia, PolygonZkEvmTestnet, LineaGoerli, ScrollSepolia, Chiado
+                Alfajores, MoonbaseAlpha, Sepolia, PolygonZkEvmTestnet, LineaGoerli, ScrollSepolia, Chiado, PlumeTestnet
             ],
             LocalTestChain: [Test1, Test2, Test3, FuelTest1, SealevelTest1, SealevelTest2, CosmosTest99990, CosmosTest99991],
         })
@@ -218,7 +220,7 @@ impl KnownHyperlaneDomain {
                 Ethereum, Goerli, Sepolia, Polygon, Mumbai, Avalanche, Fuji, Arbitrum, ArbitrumGoerli,
                 Optimism, OptimismGoerli, BinanceSmartChain, BinanceSmartChainTestnet, Celo, Gnosis,
                 Alfajores, Moonbeam, MoonbaseAlpha, PolygonZkEvmTestnet, LineaGoerli, ScrollSepolia,
-                Chiado, MantaPacific, Test1, Test2, Test3
+                Chiado, MantaPacific, PlumeTestnet, Test1, Test2, Test3
             ],
             HyperlaneDomainProtocol::Fuel: [FuelTest1],
             HyperlaneDomainProtocol::Sealevel: [SealevelTest1, SealevelTest2],
@@ -379,7 +381,9 @@ impl HyperlaneDomain {
         matches!(
             self,
             HyperlaneDomain::Known(
-                KnownHyperlaneDomain::Arbitrum | KnownHyperlaneDomain::ArbitrumGoerli,
+                KnownHyperlaneDomain::Arbitrum
+                    | KnownHyperlaneDomain::ArbitrumGoerli
+                    | KnownHyperlaneDomain::PlumeTestnet,
             )
         )
     }


### PR DESCRIPTION
### Description

Arbitrum Nitro rollups are pre1559 and hence the gas quote is wrong, refer to the below issue for more details.

- As per @tkporter's suggestion, adds plume testnet to the `is_arbitrum_nitro()` chains for a quick fix

### Drive-by changes

None

### Related issues

- fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3310

### Backward compatibility

Yes

### Testing

None