### PR TITLE
Deploy agents

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -130,7 +130,8 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '54aeb64-20240206-163119',
+      // Just prior to Cosmos block-by-block indexing.
+      tag: '02d5549-20240228-203344',
     },
     gasPaymentEnforcement,
     metricAppContexts: [
@@ -149,7 +150,19 @@ const hyperlane: RootAgentConfig = {
   validators: {
     docker: {
       repo,
-      tag: '54aeb64-20240206-163119',
+      tag: 'dd8ac43-20240306-113016',
+    },
+    chainDockerOverrides: {
+      // Because we're still ironing out issues with recent block-by-block indexing
+      // for Cosmos chains, and we want to avoid the regression in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3257
+      // that allows validator tasks to silently fail, we use the commit just prior
+      // to 3257.
+      [Chains.injective]: {
+        tag: '02e64c9-20240214-170702',
+      },
+      [Chains.neutron]: {
+        tag: '02e64c9-20240214-170702',
+      },
     },
     rpcConsensusType: RpcConsensusType.Quorum,
     chains: validatorChainConfig(Contexts.Hyperlane),
@@ -208,7 +221,8 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '54aeb64-20240206-163119',
+      // Just prior to Cosmos block-by-block indexing.
+      tag: '02d5549-20240228-203344',
     },
     gasPaymentEnforcement: [
       {

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -112,7 +112,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'db9ff2d-20240228-143928',
+      tag: 'dd8ac43-20240306-113016',
     },
     blacklist: [
       ...releaseCandidateHelloworldMatchingList,
@@ -159,7 +159,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'db9ff2d-20240228-143928',
+      tag: 'dd8ac43-20240306-113016',
     },
     chains: validatorChainConfig(Contexts.Hyperlane),
   },
@@ -167,7 +167,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'db9ff2d-20240228-143928',
+      tag: 'dd8ac43-20240306-113016',
     },
   },
 };
@@ -181,7 +181,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'db9ff2d-20240228-143928',
+      tag: 'dd8ac43-20240306-113016',
     },
     whitelist: [...releaseCandidateHelloworldMatchingList],
     gasPaymentEnforcement,
@@ -194,7 +194,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'db9ff2d-20240228-143928',
+      tag: 'dd8ac43-20240306-113016',
     },
     chains: validatorChainConfig(Contexts.ReleaseCandidate),
   },

--- a/typescript/infra/config/relayer.json
+++ b/typescript/infra/config/relayer.json
@@ -1,7 +1,7 @@
 {
   "mainnet3": {
     "hyperlane": "0x74cae0ecc47b02ed9b9d32e000fd70b9417970c5",
-    "neutron": "",
+    "neutron": "0x03787bc64a4f352b4ad172947473342028513ef3",
     "rc": "0x09b96417602ed6ac76651f7a8c4860e60e3aa6d0"
   },
   "test": {

--- a/typescript/infra/src/agents/key-utils.ts
+++ b/typescript/infra/src/agents/key-utils.ts
@@ -418,7 +418,16 @@ async function persistAddressesLocally(
     }
   }
   if (!relayer) throw new Error('No Relayer found in awsCloudAgentKeys');
-  if (!kathy) throw new Error('No Kathy found in awsCloudAgentKeys');
+  if (agentConfig.context === Contexts.Hyperlane) {
+    if (!kathy) throw new Error('No Kathy found in awsCloudAgentKeys');
+    await persistRoleAddressesToLocalArtifacts(
+      Role.Kathy,
+      agentConfig.runEnv,
+      agentConfig.context,
+      kathy,
+      kathyAddresses,
+    );
+  }
   await persistRoleAddressesToLocalArtifacts(
     Role.Relayer,
     agentConfig.runEnv,
@@ -426,13 +435,7 @@ async function persistAddressesLocally(
     relayer,
     relayerAddresses,
   );
-  await persistRoleAddressesToLocalArtifacts(
-    Role.Kathy,
-    agentConfig.runEnv,
-    agentConfig.context,
-    kathy,
-    kathyAddresses,
-  );
+
   await persistValidatorAddressesToLocalArtifacts(multisigValidatorKeys);
 }
 


### PR DESCRIPTION
### Description

- Deploys:
  - all mainnet3 & testnet4 validators to include #3361 - though bc of issues with Cosmos block-by-block indexing, the Cosmos validators are deployed from just prior to #3257
  - testnet4 relayer is at tip, mainnet3 relayers which include Cosmos chains are from just prior to Cosmos block-by-block indexing

### Drive-by changes

Was unable to deploy to the Neutron context because we don't have a Kathy key for Neutron. Fixed this

### Related issues

n/a

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
