### PR TITLE
fix: log level order, cosmos logging nit

### DIFF
--- a/rust/chains/hyperlane-cosmos/src/providers/rpc.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/rpc.rs
@@ -240,7 +240,7 @@ impl WasmIndexer for CosmosWasmIndexer {
         T: Send + Sync + PartialEq + Debug + 'static,
     {
         let client = self.provider.rpc().clone();
-        debug!(?block_number, ?cursor_label, "Getting logs in block");
+        debug!(?block_number, cursor_label, domain=?self.provider.domain, "Getting logs in block");
 
         let (block, block_results) = tokio::join!(
             call_with_retry(|| { Box::pin(Self::get_block(client.clone(), block_number)) }),

--- a/rust/hyperlane-base/src/settings/trace/mod.rs
+++ b/rust/hyperlane-base/src/settings/trace/mod.rs
@@ -24,7 +24,7 @@ pub enum Level {
     /// Warn
     Warn = 2,
     /// Debug
-    Debug = 3,
+    Debug = 4,
     /// Trace
     Trace = 5,
     /// Trace + Additional logs from dependencies
@@ -32,7 +32,7 @@ pub enum Level {
     /// Info
     #[serde(other)]
     #[default]
-    Info = 4,
+    Info = 3,
 }
 
 impl From<Level> for LevelFilter {


### PR DESCRIPTION
### Description

Our logging prio order was off, double checked with [this crate](https://docs.rs/log/latest/log/enum.Level.html). Debug logs would be visible at `Info` level according to the previous rules.

### Drive-by changes

Removed the debug formatting of a cosmsos log field, so it's no longer surrounded in quotes (bc we'd get `cursor_label: ""InterchainGasPaymentCursor""`)

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
