### PR TITLE
Temporary inEVM gas payment enforcement, add back whitelist to RC config

### DIFF
--- a/solidity/test/test/TestSendReceiver.t.sol
+++ b/solidity/test/test/TestSendReceiver.t.sol
@@ -98,9 +98,14 @@ contract TestSendReceiverTest is Test {
         vm.assume(blockNumber > 0);
         vm.roll(blockNumber);
 
+        console.log("blockNumber: ", blockNumber);
+        console.log("blockNumber 1: ", uint256(blockhash(blockNumber - 1)));
+        console.logBytes32(blockhash(blockNumber - 1));
+        // console.log("blockNumber: ", string(blockhash(blockNumber)));
+
         // blockhash(n) = n for forge tests
         // previousBlockHash() = blockhash(n-1) = n-1
-        if (blockNumber % 16 == 1) {
+        if (uint256(blockhash(blockNumber - 1)) % 16 == 0) {
             vm.expectRevert("block hash ends in 0"); // blockhash(n-1) ends in 0
         } else {
             vm.expectEmit(true, true, true, false, address(testSendReceiver)); // Process

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -25,9 +25,9 @@ import arbitrumTIAAddresses from './warp/arbitrum-TIA-addresses.json';
 import injectiveInevmAddresses from './warp/injective-inevm-addresses.json';
 import mantaTIAAddresses from './warp/manta-TIA-addresses.json';
 
-// const releaseCandidateHelloworldMatchingList = routerMatchingList(
-//   helloWorld[Contexts.ReleaseCandidate].addresses,
-// );
+const releaseCandidateHelloworldMatchingList = routerMatchingList(
+  helloWorld[Contexts.ReleaseCandidate].addresses,
+);
 
 const repo = 'gcr.io/abacus-labs-dev/hyperlane-agent';
 
@@ -175,7 +175,7 @@ const releaseCandidate: RootAgentConfig = {
       repo,
       tag: '9736164-20240307-131918',
     },
-    // whitelist: releaseCandidateHelloworldMatchingList,
+    whitelist: releaseCandidateHelloworldMatchingList,
     gasPaymentEnforcement,
     transactionGasLimit: 750000,
     // Skipping arbitrum because the gas price estimates are inclusive of L1

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -131,9 +131,17 @@ const hyperlane: RootAgentConfig = {
     docker: {
       repo,
       // Includes Cosmos block-by-block indexing.
-      tag: '9736164-20240307-131918',
+      tag: 'c2bf423-20240308-164604',
     },
-    gasPaymentEnforcement,
+    gasPaymentEnforcement: [
+      // Temporary measure to ensure all inEVM warp route messages are delivered -
+      // we saw some issues with IGP indexing.
+      {
+        type: GasPaymentEnforcementPolicyType.None,
+        matchingList: routerMatchingList(injectiveInevmAddresses),
+      },
+      ...gasPaymentEnforcement,
+    ],
     metricAppContexts: [
       {
         name: 'helloworld',


### PR DESCRIPTION
### Description

- Stops enforcing gas payments on the inEVM / Injective warp route
- Looks like we've been running the RC validator without a whitelist - this ensures it only tries to relay between the helloworld RC

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
