### PR TITLE
fix(agents): add inevm to known domains and make igp indexing log war…

### DIFF
--- a/rust/agents/relayer/src/msg/pending_message.rs
+++ b/rust/agents/relayer/src/msg/pending_message.rs
@@ -193,7 +193,7 @@ impl PendingOperation for PendingMessage {
                 .await,
             "checking if message meets gas payment requirement"
         ) else {
-            info!(?tx_cost_estimate, "Gas payment requirement not met yet");
+            warn!(?tx_cost_estimate, "Gas payment requirement not met yet");
             return self.on_reprepare();
         };
 

--- a/rust/hyperlane-core/src/chain.rs
+++ b/rust/hyperlane-core/src/chain.rs
@@ -85,6 +85,7 @@ pub enum KnownHyperlaneDomain {
     Neutron = 1853125230,
 
     Injective = 6909546,
+    InEvm = 2525,
 
     PlumeTestnet = 161221135,
 
@@ -220,7 +221,7 @@ impl KnownHyperlaneDomain {
         many_to_one!(match self {
             Mainnet: [
                 Ethereum, Avalanche, Arbitrum, Polygon, Optimism, BinanceSmartChain, Celo,
-                Moonbeam, Gnosis, MantaPacific, Neutron, Injective
+                Moonbeam, Gnosis, MantaPacific, Neutron, Injective, InEvm
             ],
             Testnet: [
                 Goerli, Mumbai, Fuji, ArbitrumGoerli, OptimismGoerli, BinanceSmartChainTestnet,
@@ -237,7 +238,7 @@ impl KnownHyperlaneDomain {
             HyperlaneDomainProtocol::Ethereum: [
                 Ethereum, Goerli, Sepolia, Polygon, Mumbai, Avalanche, Fuji, Arbitrum, ArbitrumGoerli,
                 Optimism, OptimismGoerli, BinanceSmartChain, BinanceSmartChainTestnet, Celo, Gnosis,
-                Alfajores, Moonbeam, MoonbaseAlpha, PolygonZkEvmTestnet, LineaGoerli, ScrollSepolia,
+                Alfajores, Moonbeam, InEvm, MoonbaseAlpha, PolygonZkEvmTestnet, LineaGoerli, ScrollSepolia,
                 Chiado, MantaPacific, PlumeTestnet, Test1, Test2, Test3
             ],
             HyperlaneDomainProtocol::Fuel: [FuelTest1],
@@ -254,7 +255,7 @@ impl KnownHyperlaneDomain {
             HyperlaneDomainTechnicalStack::Other: [
                 Ethereum, Goerli, Sepolia, Polygon, Mumbai, Avalanche, Fuji, Optimism, OptimismGoerli,
                 BinanceSmartChain, BinanceSmartChainTestnet, Celo, Gnosis, Alfajores, Moonbeam, MoonbaseAlpha,
-                PolygonZkEvmTestnet, LineaGoerli, ScrollSepolia, Chiado, MantaPacific, Neutron, Injective,
+                PolygonZkEvmTestnet, LineaGoerli, ScrollSepolia, Chiado, MantaPacific, Neutron, Injective, InEvm,
                 Test1, Test2, Test3, FuelTest1, SealevelTest1, SealevelTest2, CosmosTest99990, CosmosTest99991
             ],
         })

--- a/solidity/test/test/TestSendReceiver.t.sol
+++ b/solidity/test/test/TestSendReceiver.t.sol
@@ -98,13 +98,7 @@ contract TestSendReceiverTest is Test {
         vm.assume(blockNumber > 0);
         vm.roll(blockNumber);
 
-        console.log("blockNumber: ", blockNumber);
-        console.log("blockNumber 1: ", uint256(blockhash(blockNumber - 1)));
-        console.logBytes32(blockhash(blockNumber - 1));
-        // console.log("blockNumber: ", string(blockhash(blockNumber)));
-
-        // blockhash(n) = n for forge tests
-        // previousBlockHash() = blockhash(n-1) = n-1
+        // previousBlockHash() = blockhash(n-1)
         if (uint256(blockhash(blockNumber - 1)) % 16 == 0) {
             vm.expectRevert("block hash ends in 0"); // blockhash(n-1) ends in 0
         } else {


### PR DESCRIPTION
### Description

adds inevm to known domains and makes igp indexing log warn level

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
