### PR TITLE
Even higher sol fees

### DIFF
--- a/rust/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/chains/hyperlane-sealevel/src/mailbox.rs
@@ -64,10 +64,12 @@ const SPL_NOOP: &str = "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV";
 // TODO: consider a more sane value and/or use IGP gas payments instead.
 const PROCESS_COMPUTE_UNITS: u32 = 700_000;
 
-/// 0.0000035 SOL, in lamports.
+/// 0.0001 SOL, in lamports.
 /// A typical tx fee without a prioritization fee is 0.000005 SOL, or
 /// 5000 lamports. (Example: https://explorer.solana.com/tx/fNd3xVeBzFHeuzr8dXQxLGiHMzTeYpykSV25xWzNRaHtzzjvY9A3MzXh1ZsK2JncRHkwtuWrGEwGXVhFaUCYhtx)
-const PROCESS_DESIRED_PRIORITIZATION_FEE_LAMPORTS_PER_TX: u64 = 3500;
+/// See average priority fees here https://solanacompass.com/statistics/fees
+/// to inform what to spend here.
+const PROCESS_DESIRED_PRIORITIZATION_FEE_LAMPORTS_PER_TX: u64 = 100000;
 
 /// In micro-lamports. Multiply this by the compute units to figure out
 /// the additional cost of processing a message, in addition to the mandatory

--- a/rust/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/chains/hyperlane-sealevel/src/mailbox.rs
@@ -64,12 +64,12 @@ const SPL_NOOP: &str = "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV";
 // TODO: consider a more sane value and/or use IGP gas payments instead.
 const PROCESS_COMPUTE_UNITS: u32 = 700_000;
 
-/// 0.0001 SOL, in lamports.
+/// 0.0009 SOL, in lamports.
 /// A typical tx fee without a prioritization fee is 0.000005 SOL, or
 /// 5000 lamports. (Example: https://explorer.solana.com/tx/fNd3xVeBzFHeuzr8dXQxLGiHMzTeYpykSV25xWzNRaHtzzjvY9A3MzXh1ZsK2JncRHkwtuWrGEwGXVhFaUCYhtx)
 /// See average priority fees here https://solanacompass.com/statistics/fees
 /// to inform what to spend here.
-const PROCESS_DESIRED_PRIORITIZATION_FEE_LAMPORTS_PER_TX: u64 = 100000;
+const PROCESS_DESIRED_PRIORITIZATION_FEE_LAMPORTS_PER_TX: u64 = 900000;
 
 /// In micro-lamports. Multiply this by the compute units to figure out
 /// the additional cost of processing a message, in addition to the mandatory

--- a/typescript/infra/config/environments/mainnet2/agent.ts
+++ b/typescript/infra/config/environments/mainnet2/agent.ts
@@ -127,7 +127,7 @@ const hyperlane: RootAgentConfig = {
     connectionType: AgentConnectionType.HttpFallback,
     docker: {
       repo,
-      tag: 'e5defad-20240307-100803',
+      tag: 'df25748-20240312-100110',
     },
     blacklist: [
       ...releaseCandidateHelloworldMatchingList,


### PR DESCRIPTION
### Description

Average tips from https://solanacompass.com/statistics/fees show 0.0001 SOL per TX now. This bumps the prio fee to that

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
