### PR TITLE
feat: parse warp route artifacts with token-specific key names

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -14,6 +14,7 @@ import {
 import {
   GasPaymentEnforcementConfig,
   routerMatchingList,
+  warpRouteMatchingList,
 } from '../../../src/config/agent/relayer';
 import { ALL_KEY_ROLES, Role } from '../../../src/roles';
 import { Contexts } from '../../contexts';
@@ -22,7 +23,9 @@ import { environment, supportedChainNames } from './chains';
 import { helloWorld } from './helloworld';
 import { validatorChainConfig } from './validators';
 import arbitrumTIAAddresses from './warp/arbitrum-TIA-addresses.json';
-import injectiveInevmAddresses from './warp/injective-inevm-addresses.json';
+import injectiveInevmUsdcAddresses from './warp/inevm-USDC-addresses.json';
+import injectiveInevmUsdtAddresses from './warp/inevm-USDT-addresses.json';
+import injectiveInevmInjAddresses from './warp/injective-inevm-addresses.json';
 import mantaTIAAddresses from './warp/manta-TIA-addresses.json';
 
 const releaseCandidateHelloworldMatchingList = routerMatchingList(
@@ -138,7 +141,7 @@ const hyperlane: RootAgentConfig = {
       // we saw some issues with IGP indexing.
       {
         type: GasPaymentEnforcementPolicyType.None,
-        matchingList: routerMatchingList(injectiveInevmAddresses),
+        matchingList: routerMatchingList(injectiveInevmInjAddresses),
       },
       ...gasPaymentEnforcement,
     ],
@@ -151,7 +154,15 @@ const hyperlane: RootAgentConfig = {
       },
       {
         name: 'injective_inevm_inj',
-        matchingList: routerMatchingList(injectiveInevmAddresses),
+        matchingList: routerMatchingList(injectiveInevmInjAddresses),
+      },
+      {
+        name: 'injective_inevm_usdc',
+        matchingList: warpRouteMatchingList(injectiveInevmUsdcAddresses),
+      },
+      {
+        name: 'injective_inevm_usdt',
+        matchingList: warpRouteMatchingList(injectiveInevmUsdtAddresses),
       },
     ],
   },

--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -178,3 +178,30 @@ export function routerMatchingList(
 
   return matchingList;
 }
+
+type HypErc20Address = { HypERC20: string };
+type HypERC20CollateralAddress = { HypERC20Collateral: string };
+type HypErc721Address = { HypERC721: string };
+type HypErc721CollateralAddress = { HypERC721Collateral: string };
+type HypNativeAddress = { HypNativeAddress: string };
+
+type WarpRoute =
+  | HypErc20Address
+  | HypERC20CollateralAddress
+  | HypErc721Address
+  | HypErc721CollateralAddress
+  | HypNativeAddress;
+
+// Create a matching list for the given warp route addresses
+export function warpRouteMatchingList(
+  routers: ChainMap<WarpRoute>,
+): MatchingList {
+  let standardizedRouters: ChainMap<{ router: string }> = {};
+  Object.entries(routers).forEach(([chain, route]) => {
+    let routerAddress = Object.values(route);
+    // Due to duck typing there could be more than one value in the route object,
+    // but the line below assumes there is only one.
+    standardizedRouters[chain] = { router: routerAddress[0] };
+  });
+  return routerMatchingList(standardizedRouters);
+}


### PR DESCRIPTION
### Description

Looks like all warp route artifacts until now used to have keys named `router`. The artifacts for USDC and USDT inevm <> EVM have their keys named according to the token type (e.g. `HypERC20`, `HypERC20Collateral` etc). This adds a script to parse such files

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
