### PR TITLE
Half the relayer timeout on v2

### DIFF
--- a/rust/chains/hyperlane-ethereum/src/tx.rs
+++ b/rust/chains/hyperlane-ethereum/src/tx.rs
@@ -43,7 +43,7 @@ where
 
     info!(?to, %data, ?tx_hash, "Dispatched tx");
 
-    match tokio::time::timeout(Duration::from_secs(300), dispatched).await {
+    match tokio::time::timeout(Duration::from_secs(150), dispatched).await {
         // all good
         Ok(Ok(Some(receipt))) => {
             info!(?tx_hash, "confirmed transaction");


### PR DESCRIPTION
On nautilus, we are having trouble getting txs confirmed, but we are waiting for 5 minutes before attempting. This reduces it to half that