### PR TITLE
Hacky solana balance monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 WORKDIR /hyperlane-monorepo
 

--- a/typescript/infra/config/environments/mainnet2/funding.ts
+++ b/typescript/infra/config/environments/mainnet2/funding.ts
@@ -9,7 +9,7 @@ import { environment } from './chains';
 export const keyFunderConfig: KeyFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-    tag: '98658d0-20231207-121541',
+    tag: '4798278-20240318-115942',
   },
   // We're currently using the same deployer key as mainnet.
   // To minimize nonce clobbering we offset the key funder cron


### PR DESCRIPTION
### Description

- See https://github.com/hyperlane-xyz/issues/issues/1047
- Intentionally going with a "hacky" short term approach because we consistently hit this, we're unlikely to prioritize a better solution for v3, and this change is only for v2 which we are in maintenance-only mode, so it's ok to hardcode these accounts

### Drive-by changes

- New monorepo base image to fix building, which requires node 18 apparently

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
