### PR TITLE
chore: add viction warp route labels to mainnet relayer

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -26,6 +26,9 @@ import inevmEthereumUsdcAddresses from './warp/inevm-USDC-addresses.json';
 import inevmEthereumUsdtAddresses from './warp/inevm-USDT-addresses.json';
 import injectiveInevmInjAddresses from './warp/injective-inevm-addresses.json';
 import mantaTIAAddresses from './warp/manta-TIA-addresses.json';
+import victionEthereumEthAddresses from './warp/viction-ETH-addresses.json';
+import victionEthereumUsdcAddresses from './warp/viction-USDC-addresses.json';
+import victionEthereumUsdtAddresses from './warp/viction-USDT-addresses.json';
 
 const releaseCandidateHelloworldMatchingList = routerMatchingList(
   helloWorld[Contexts.ReleaseCandidate].addresses,
@@ -162,6 +165,18 @@ const hyperlane: RootAgentConfig = {
       {
         name: 'inevm_ethereum_usdt',
         matchingList: routerMatchingList(inevmEthereumUsdtAddresses),
+      },
+      {
+        name: 'viction_ethereum_eth',
+        matchingList: routerMatchingList(victionEthereumEthAddresses),
+      },
+      {
+        name: 'viction_ethereum_usdc',
+        matchingList: routerMatchingList(victionEthereumUsdcAddresses),
+      },
+      {
+        name: 'viction_ethereum_usdt',
+        matchingList: routerMatchingList(victionEthereumUsdtAddresses),
       },
     ],
   },


### PR DESCRIPTION
### Description

The prepare queue alert will automatically pick up viction if warp route labels are set.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
