### PR TITLE
feat: add account -> owner mapping in ICA router

### DIFF
--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -38,6 +38,11 @@ contract InterchainAccountRouter is Router {
     using TypeCasts for address;
     using TypeCasts for bytes32;
 
+    struct AccountOwner {
+        uint32 origin;
+        bytes32 owner; // remote owner
+    }
+
     // ============ Constants ============
 
     address internal implementation;
@@ -46,7 +51,7 @@ contract InterchainAccountRouter is Router {
     // ============ Public Storage ============
     mapping(uint32 => bytes32) public isms;
     // reverse lookup from the ICA account to the remote owner
-    mapping(address => bytes32) public accountOwners;
+    mapping(address => AccountOwner) public accountOwners;
 
     // ============ Upgrade Gap ============
 
@@ -396,7 +401,7 @@ contract InterchainAccountRouter is Router {
         if (!Address.isContract(_account)) {
             bytes memory _bytecode = MinimalProxy.bytecode(implementation);
             _account = payable(Create2.deploy(0, _salt, _bytecode));
-            accountOwners[_account] = _owner;
+            accountOwners[_account] = AccountOwner(_origin, _owner);
             emit InterchainAccountCreated(_origin, _owner, _ism, _account);
         }
         return OwnableMulticall(_account);

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -45,6 +45,8 @@ contract InterchainAccountRouter is Router {
 
     // ============ Public Storage ============
     mapping(uint32 => bytes32) public isms;
+    // reverse lookup from the ICA account to the remote owner
+    mapping(address => bytes32) public accountOwners;
 
     // ============ Upgrade Gap ============
 
@@ -394,6 +396,7 @@ contract InterchainAccountRouter is Router {
         if (!Address.isContract(_account)) {
             bytes memory _bytecode = MinimalProxy.bytecode(implementation);
             _account = payable(Create2.deploy(0, _salt, _bytecode));
+            accountOwners[_account] = _owner;
             emit InterchainAccountCreated(_origin, _owner, _ism, _account);
         }
         return OwnableMulticall(_account);

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -320,6 +320,24 @@ contract InterchainAccountRouterTest is Test {
         assertEq(address(igp).balance, expectedGasPayment);
     }
 
+    function testFuzz_getDeployedInterchainAccount_checkAccountOwners(
+        address owner
+    ) public {
+        // act
+        ica = destinationRouter.getDeployedInterchainAccount(
+            origin,
+            owner,
+            address(originRouter),
+            address(environment.isms(destination))
+        );
+
+        // assert
+        assertEq(
+            destinationRouter.accountOwners(address(ica)),
+            owner.addressToBytes32()
+        );
+    }
+
     function testFuzz_singleCallRemoteWithDefault(bytes32 data) public {
         // arrange
         originRouter.enrollRemoteRouterAndIsm(

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -331,11 +331,12 @@ contract InterchainAccountRouterTest is Test {
             address(environment.isms(destination))
         );
 
-        // assert
-        assertEq(
-            destinationRouter.accountOwners(address(ica)),
-            owner.addressToBytes32()
+        (uint32 domain, bytes32 ownerBytes) = destinationRouter.accountOwners(
+            address(ica)
         );
+        // assert
+        assertEq(domain, origin);
+        assertEq(ownerBytes, owner.addressToBytes32());
     }
 
     function testFuzz_singleCallRemoteWithDefault(bytes32 data) public {


### PR DESCRIPTION
### Description

- added accountOwner mapping to the ICA router for easier tracking of remote owners for the transaction type inference by the AppGovernor

### Drive-by changes

none

### Related issues

none

### Backward compatibility

yes

### Testing

unit
