### PR TITLE
Generalize matching list agent config fn

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../src/config';
 import {
   GasPaymentEnforcementConfig,
+  matchingList,
   routerMatchingList,
 } from '../../../src/config/agent/relayer';
 import { ALL_KEY_ROLES, Role } from '../../../src/roles';
@@ -160,11 +161,11 @@ const hyperlane: RootAgentConfig = {
       },
       {
         name: 'inevm_ethereum_usdc',
-        matchingList: routerMatchingList(inevmEthereumUsdcAddresses),
+        matchingList: matchingList(inevmEthereumUsdcAddresses),
       },
       {
         name: 'inevm_ethereum_usdt',
-        matchingList: routerMatchingList(inevmEthereumUsdtAddresses),
+        matchingList: matchingList(inevmEthereumUsdtAddresses),
       },
       {
         name: 'viction_ethereum_eth',

--- a/typescript/infra/config/environments/mainnet3/warp/inevm-USDC-addresses.json
+++ b/typescript/infra/config/environments/mainnet3/warp/inevm-USDC-addresses.json
@@ -1,10 +1,8 @@
 {
   "inevm": {
-    "router": "0x8358D8291e3bEDb04804975eEa0fe9fe0fAfB147",
-    "type": "HypERC20"
+    "synthetic": "0x8358D8291e3bEDb04804975eEa0fe9fe0fAfB147"
   },
   "ethereum": {
-    "router": "0xED56728fb977b0bBdacf65bCdD5e17Bb7e84504f",
-    "type": "HypERC20Collateral"
+    "collateral": "0xED56728fb977b0bBdacf65bCdD5e17Bb7e84504f"
   }
 }

--- a/typescript/infra/config/environments/mainnet3/warp/inevm-USDT-addresses.json
+++ b/typescript/infra/config/environments/mainnet3/warp/inevm-USDT-addresses.json
@@ -1,10 +1,8 @@
 {
   "inevm": {
-    "router": "0x97423A68BAe94b5De52d767a17aBCc54c157c0E5",
-    "type": "HypERC20"
+    "synthetic": "0x97423A68BAe94b5De52d767a17aBCc54c157c0E5"
   },
   "ethereum": {
-    "router": "0xab852e67bf03E74C89aF67C4BA97dd1088D3dA19",
-    "type": "HypERC20Collateral"
+    "collateral": "0xab852e67bf03E74C89aF67C4BA97dd1088D3dA19"
   }
 }

--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -177,7 +177,9 @@ export function matchingList<F extends HyperlaneFactories>(
       }
 
       const uniqueAddresses = (addresses: HyperlaneAddresses<F>) =>
-        [...new Set(Object.values(addresses))].map((s) => addressToBytes32(s));
+        Array.from(new Set(Object.values(addresses)).values()).map((s) =>
+          addressToBytes32(s),
+        );
 
       matchingList.push({
         originDomain: getDomainId(chainMetadata[source]),

--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -4,6 +4,7 @@ import {
   AgentConfig,
   ChainMap,
   GasPaymentEnforcement,
+  HyperlaneAddresses,
   HyperlaneAddressesMap,
   HyperlaneFactories,
   MatchingList,
@@ -163,7 +164,6 @@ export function routerMatchingList(
 // Create a matching list for the given contract addresses
 export function matchingList<F extends HyperlaneFactories>(
   addressesMap: HyperlaneAddressesMap<F>,
-  contracts?: Array<keyof F>,
 ): MatchingList {
   const chains = Object.keys(addressesMap);
 
@@ -176,17 +176,15 @@ export function matchingList<F extends HyperlaneFactories>(
         continue;
       }
 
-      const sources = addressesMap[source];
-      const destinations = addressesMap[destination];
+      const uniqueAddresses = (addresses: HyperlaneAddresses<F>) =>
+        [...new Set(Object.values(addresses))].map((s) => addressToBytes32(s));
 
-      for (const contract of contracts ?? Object.keys(sources)) {
-        matchingList.push({
-          originDomain: getDomainId(chainMetadata[source]),
-          senderAddress: addressToBytes32(sources[contract]),
-          destinationDomain: getDomainId(chainMetadata[destination]),
-          recipientAddress: addressToBytes32(destinations[contract]),
-        });
-      }
+      matchingList.push({
+        originDomain: getDomainId(chainMetadata[source]),
+        senderAddress: uniqueAddresses(addressesMap[source]),
+        destinationDomain: getDomainId(chainMetadata[destination]),
+        recipientAddress: uniqueAddresses(addressesMap[destination]),
+      });
     }
   }
 


### PR DESCRIPTION
### Description

Generalizes `routerMatchingList` to `matchingList` for use with asymmetric app artifacts

### Drive-by changes

- migrate to `matchingList` for some app context agent config

### Related issues

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3441

### Backward compatibility

- Yes

### Testing

Unit tests