### PR TITLE
fix: send_value fuzz test for ICA

### DIFF
--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -623,7 +623,9 @@ contract InterchainAccountRouterTest is Test {
     }
 
     function testFuzz_sendValue(uint256 value) public {
-        vm.assume(value > 0 && value <= address(this).balance);
+        vm.assume(
+            value > 0 && value <= address(this).balance + gasPaymentQuote
+        );
         payable(address(ica)).transfer(value);
 
         bytes memory data = abi.encodeCall(this.receiveValue, (value));

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -624,7 +624,7 @@ contract InterchainAccountRouterTest is Test {
 
     function testFuzz_sendValue(uint256 value) public {
         vm.assume(
-            value > 0 && value <= address(this).balance + gasPaymentQuote
+            value > 0 && value <= address(this).balance - gasPaymentQuote
         );
         payable(address(ica)).transfer(value);
 


### PR DESCRIPTION
### Description

make sure we assume `value <= balance - gasQuote`

### Drive-by changes

none

### Related issues

- fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3468

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

fuzz
