### PR TITLE
fix: warp route deployment verification

### DIFF
--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -19,11 +19,9 @@ import {
   TokenType,
   WarpCoreConfig,
   getTokenConnectionId,
-} from '@hyperlane-xyz/sdk';
-import {
   hypERC20contracts,
   hypERC721contracts,
-} from '@hyperlane-xyz/sdk/dist/token/contracts.js';
+} from '@hyperlane-xyz/sdk';
 import { Address, ProtocolType, objMap } from '@hyperlane-xyz/utils';
 
 import { log, logBlue, logGray, logGreen } from '../../logger.js';

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -269,7 +269,7 @@ async function executeDeploy(params: DeployParams) {
 
   log('Writing deployment artifacts');
   writeTokenDeploymentArtifacts(contractsFilePath, deployedContracts, params);
-  writeWarpUiTokenConfig(tokenConfigPath, deployedContracts, params);
+  writeWarpConfig(tokenConfigPath, deployedContracts, params);
 
   logBlue('Deployment is complete!');
   logBlue(`Contract address artifacts are in ${contractsFilePath}`);
@@ -336,7 +336,7 @@ function writeTokenDeploymentArtifacts(
   writeJson(filePath, artifacts);
 }
 
-function writeWarpUiTokenConfig(
+function writeWarpConfig(
   filePath: string,
   contracts: HyperlaneContractsMap<TokenFactories>,
   { configMap, metadata, isNft }: DeployParams,

--- a/typescript/sdk/src/deploy/verify/ContractVerifier.ts
+++ b/typescript/sdk/src/deploy/verify/ContractVerifier.ts
@@ -73,7 +73,11 @@ export class ContractVerifier {
     verificationLogger: Debugger,
     options?: FormOptions<typeof action>,
   ): Promise<any> {
-    const { apiUrl, family } = this.multiProvider.getExplorerApi(chain);
+    const {
+      apiUrl,
+      apiKey = this.apiKeys[chain],
+      family,
+    } = this.multiProvider.getExplorerApi(chain);
     const params = new URLSearchParams();
     params.set('module', 'contract');
     params.set('action', action);
@@ -83,9 +87,9 @@ export class ContractVerifier {
       params.set(key, value);
     }
 
-    // only include apikey if provided & not blockscout
-    if (family !== ExplorerFamily.Blockscout && this.apiKeys[chain]) {
-      params.set('apikey', this.apiKeys[chain]);
+    if (family !== ExplorerFamily.Blockscout && apiKey) {
+      // only include apikey if provided & not blockscout
+      params.set('apikey', apiKey);
     }
 
     const url = new URL(apiUrl);

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -409,8 +409,8 @@ export {
   isUriConfig,
 } from './token/config';
 export {
-  HypERC20Factories,
-  HypERC721Factories,
+  hypERC20factories,
+  hypERC721factories,
   TokenFactories,
 } from './token/contracts';
 export { HypERC20Deployer, HypERC721Deployer } from './token/deploy';

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -409,8 +409,10 @@ export {
   isUriConfig,
 } from './token/config';
 export {
-  hypERC20factories,
-  hypERC721factories,
+  hypERC20contracts,
+  hypERC721contracts,
+  HypERC20Factories,
+  HypERC721Factories,
   TokenFactories,
 } from './token/contracts';
 export { HypERC20Deployer, HypERC721Deployer } from './token/deploy';

--- a/typescript/sdk/src/token/contracts.ts
+++ b/typescript/sdk/src/token/contracts.ts
@@ -14,24 +14,40 @@ import {
 
 import { TokenType } from './config';
 
+export const hypERC20contracts = {
+  [TokenType.fastCollateral]: 'FastHypERC20Collateral',
+  [TokenType.fastSynthetic]: 'FastHypERC20',
+  [TokenType.synthetic]: 'HypERC20',
+  [TokenType.collateral]: 'HypERC20Collateral',
+  [TokenType.collateralVault]: 'HypERC20CollateralVaultDeposit',
+  [TokenType.native]: 'HypNative',
+  [TokenType.nativeScaled]: 'HypNativeScaled',
+} as const;
+
 export const hypERC20factories = {
-  [TokenType.fastCollateral]: new FastHypERC20Collateral__factory(),
-  [TokenType.fastSynthetic]: new FastHypERC20__factory(),
-  [TokenType.synthetic]: new HypERC20__factory(),
-  [TokenType.collateral]: new HypERC20Collateral__factory(),
-  [TokenType.collateralVault]: new HypERC20CollateralVaultDeposit__factory(),
-  [TokenType.native]: new HypNative__factory(),
-  [TokenType.nativeScaled]: new HypNativeScaled__factory(),
+  FastHypERC20Collateral: new FastHypERC20Collateral__factory(),
+  FastHypERC20: new FastHypERC20__factory(),
+  HypERC20: new HypERC20__factory(),
+  HypERC20Collateral: new HypERC20Collateral__factory(),
+  HypERC20CollateralVaultDeposit: new HypERC20CollateralVaultDeposit__factory(),
+  HypNative: new HypNative__factory(),
+  HypNativeScaled: new HypNativeScaled__factory(),
 };
 export type HypERC20Factories = typeof hypERC20factories;
 
-export const hypERC721factories = {
-  [TokenType.collateralUri]: new HypERC721URICollateral__factory(),
-  [TokenType.collateral]: new HypERC721Collateral__factory(),
-  [TokenType.syntheticUri]: new HypERC721URIStorage__factory(),
-  [TokenType.synthetic]: new HypERC721__factory(),
-};
+export const hypERC721contracts = {
+  [TokenType.collateralUri]: 'HypERC721URICollateral',
+  [TokenType.collateral]: 'HypERC721Collateral',
+  [TokenType.syntheticUri]: 'HypERC721URIStorage',
+  [TokenType.synthetic]: 'HypERC721',
+} as const;
 
+export const hypERC721factories = {
+  HypERC721URICollateral: new HypERC721URICollateral__factory(),
+  HypERC721Collateral: new HypERC721Collateral__factory(),
+  HypERC721URIStorage: new HypERC721URIStorage__factory(),
+  HypERC721: new HypERC721__factory(),
+};
 export type HypERC721Factories = typeof hypERC721factories;
 
 export type TokenFactories = HypERC20Factories | HypERC721Factories;


### PR DESCRIPTION
fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3457

should fix the problem whilst also not breaking the format of existing artifact read/writes

drive-by fix to contractverifier - allows propagation of apikeys from custom chain metadata (e.g. chains.yaml)