### PR TITLE
feat: CLI chain list derived from SDK contract addresses artifact

### DIFF
--- a/.changeset/cuddly-ravens-run.md
+++ b/.changeset/cuddly-ravens-run.md
@@ -1,0 +1,7 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Breaking: Update the `hyperlane chains list` command to accept an `env` (either 'mainnet' or 'testnet') to list chains for.
+
+Update `hyperlane chains list` command to pull the set of core chains from the contract addresses constant in the SDK.

--- a/typescript/cli/src/commands/chains.ts
+++ b/typescript/cli/src/commands/chains.ts
@@ -3,10 +3,9 @@ import { CommandModule } from 'yargs';
 import {
   Chains,
   CoreChainName,
-  Mainnets,
-  Testnets,
   chainMetadata,
   hyperlaneContractAddresses,
+  hyperlaneEnvironments,
 } from '@hyperlane-xyz/sdk';
 
 import { log, logBlue, logGray, logTable } from '../logger.js';
@@ -58,12 +57,12 @@ const listCommand: CommandModule = {
     const logMainnet = () => {
       logBlue('\nHyperlane core mainnet chains:');
       logGray('------------------------------');
-      logTable(serializer(Mainnets));
+      logTable(serializer(Object.keys(hyperlaneEnvironments.mainnet)));
     };
     const logTestnet = () => {
       logBlue('\nHyperlane core testnet chains:');
       logGray('------------------------------');
-      logTable(serializer(Testnets));
+      logTable(serializer(Object.keys(hyperlaneEnvironments.testnet)));
     };
 
     if (mainnet) return logMainnet();


### PR DESCRIPTION
resolves https://github.com/hyperlane-xyz/issues/issues/1066

- uses the list of deployed addresses from SDK to determine core mainnet/testnet chains
- tidy up `hyperlane chains list` command to accept `env` (either `mainnet` or `testnet`)

will do docs update to reflect updated chains list command

before:
![image](https://github.com/hyperlane-xyz/hyperlane-monorepo/assets/10051819/d8d35b25-951c-45aa-876d-df3a32ddc011)

after:
![image](https://github.com/hyperlane-xyz/hyperlane-monorepo/assets/10051819/99252b76-ed95-462c-bc7e-c85d9455ee39)
