### PR TITLE
fix:deploy-core ci writing unnecessary cache fix

### DIFF
--- a/typescript/infra/scripts/deploy.ts
+++ b/typescript/infra/scripts/deploy.ts
@@ -202,11 +202,6 @@ async function main() {
     return;
   }
 
-  // cache addresses for interchain account support
-  deployer.cacheAddressesMap(
-    getAddresses(environment, Modules.INTERCHAIN_ACCOUNTS),
-  );
-
   const modulePath = getModuleDirectory(environment, module, context);
 
   console.log(`Deploying to ${modulePath}`);

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -743,7 +743,7 @@ export abstract class HyperlaneDeployer<
         throw new Error('InterchainAccountRouter not deployed');
       }
       const router = InterchainAccount.fromAddressesMap(
-        this.cachedAddresses,
+        { chain: { router: routerAddress } },
         this.multiProvider,
       );
       // submits network transaction to deploy the account iff it doesn't exist


### PR DESCRIPTION
### Description


- For https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3483, I was passing in ica artifacts through the cachedAddressesMap function which in turn writes these addresses to the deploy addresses.json file and this causes chain not found error in the subsequent module deployments.

Fix
- Read from options.icaApp for the router address (extra step added to the runbook)

### Drive-by changes

None

### Related issues

- https://discord.com/channels/935678348330434570/1225043256782622730

### Backward compatibility

Yes

### Testing

local manual
