### PR TITLE
chore: rust ci tests with full backtraces enabled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,7 +200,7 @@ jobs:
         if: matrix.e2e-type == 'cosmwasm'
         working-directory: ./rust
         env:
-          RUST_BACKTRACE: 1
+          RUST_BACKTRACE: 'full'
 
       - name: agent tests excluding CosmWasm
         run: cargo run --release --bin run-locally
@@ -210,6 +210,7 @@ jobs:
           E2E_CI_MODE: 'true'
           E2E_CI_TIMEOUT_SEC: '600'
           E2E_KATHY_MESSAGES: '20'
+          RUST_BACKTRACE: 'full'
 
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Currently there's no way to know exactly where a panic occurred in rust e2e. This adds full backtraces to show where the task `.join` that caused the panic was. For example, this line isn't visible in the regular backtrace and it shows that the panic happened when spawning the anvil task (if you check out commit `0cc48e164379d08a8f4c3703eaab79bb86e271d6`):
```
at [...]/hyperlane-monorepo/rust/utils/run-locally/src/main.rs:321:22
```

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
