### PR TITLE
add node options to hyperlane CLI script to ignore ExperimentalWarning

### DIFF
--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -30,7 +30,7 @@
     "typescript": "^5.1.6"
   },
   "scripts": {
-    "hyperlane": "node ./dist/cli.js",
+    "hyperlane": "NODE_OPTIONS='--experimental-loader ts-node/esm/transpile-only --no-warnings=ExperimentalWarning' node ./dist/cli.js",
     "build": "yarn version:update && tsc",
     "dev": "yarn version:update && tsc --watch",
     "clean": "rm -rf ./dist",


### PR DESCRIPTION
### Description

* Adds node options to hyperlane CLI script to ignore ExperimentalWarning caused by ESM migration

### Drive-by changes

* None

### Related issues

* n/a

### Backward compatibility

* Yes

### Testing

* Manual
