### PR TITLE
Return entire deployedContracts object

### DIFF
--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -205,11 +205,16 @@ export class HypERC20Deployer extends GasRouterDeployer<
   }
 
   async deployContracts(chain: ChainName, config: HypERC20Config) {
-    const { [this.routerContractKey(config)]: router } =
-      await super.deployContracts(chain, config);
-
-    await this.configureClient(chain, router as MailboxClient, config);
-    return { [config.type]: router } as any;
+    const deployedContracts = await super.deployContracts(chain, config);
+    await this.configureClient(
+      chain,
+      deployedContracts[this.routerContractKey(config)],
+      config,
+    );
+    return {
+      [config.type]: deployedContracts[this.routerContractKey(config)], // router
+      ...deployedContracts,
+    } as any;
   }
 
   async buildTokenMetadata(

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -104,7 +104,7 @@ export class HypERC20Deployer extends GasRouterDeployer<
   }
 
   async initializeArgs(_: ChainName, config: HypERC20Config): Promise<any> {
-    // ISM config can be an object, but is not supported right now
+    // ISM config can be an object, but is not supported right now.
     if (typeof config.interchainSecurityModule === 'object') {
       throw new Error('Token deployer does not support ISM objects currently');
     }
@@ -207,11 +207,7 @@ export class HypERC20Deployer extends GasRouterDeployer<
   async deployContracts(chain: ChainName, config: HypERC20Config) {
     const deployedContracts = await super.deployContracts(chain, config);
     const router = deployedContracts[this.routerContractKey(config)];
-    await this.configureClient(
-      chain,
-      router,
-      config,
-    );
+    await this.configureClient(chain, router, config);
     return {
       [config.type]: router,
       ...deployedContracts,

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -206,13 +206,14 @@ export class HypERC20Deployer extends GasRouterDeployer<
 
   async deployContracts(chain: ChainName, config: HypERC20Config) {
     const deployedContracts = await super.deployContracts(chain, config);
+    const router = deployedContracts[this.routerContractKey(config)];
     await this.configureClient(
       chain,
-      deployedContracts[this.routerContractKey(config)],
+      router,
       config,
     );
     return {
-      [config.type]: deployedContracts[this.routerContractKey(config)], // router
+      [config.type]: router,
       ...deployedContracts,
     } as any;
   }


### PR DESCRIPTION
### Description
Returns the deployedContracts object in token deployer

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

- Fixes #3585 

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes
-->

### Testing
None

