### PR TITLE
Update base.rs - Fix Broken Link for Announce Your Validator

### DIFF
--- a/rust/agents/relayer/src/msg/metadata/base.rs
+++ b/rust/agents/relayer/src/msg/metadata/base.rs
@@ -413,7 +413,7 @@ impl BaseMetadataBuilder {
             }
             if checkpoint_syncers.get(&validator.into()).is_none() {
                 if validator_storage_locations.is_empty() {
-                    warn!(?validator, "Validator has not announced any storage locations; see https://docs.hyperlane.xyz/docs/operators/validators/announcing-your-validator");
+                    warn!(?validator, "Validator has not announced any storage locations; see https://docs.hyperlane.xyz/docs/operate/validators/run-validators#announcing-your-validator");
                 } else {
                     warn!(
                         ?validator,


### PR DESCRIPTION
Old: https://docs.hyperlane.xyz/docs/operators/validators/announcing-your-validator

New: https://docs.hyperlane.xyz/docs/operate/validators/run-validators#announcing-your-validator


### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
