### PR TITLE
Avoid sinon import in exported lib files

### DIFF
--- a/typescript/sdk/src/test/multiProviderStubs.ts
+++ b/typescript/sdk/src/test/multiProviderStubs.ts
@@ -1,0 +1,31 @@
+import sinon from 'sinon';
+
+import { MultiProtocolProvider } from '../providers/MultiProtocolProvider.js';
+
+/**
+ * Takes a MultiProtocolProvider instance and stubs it's get*Provider methods to
+ * return mock providers. More provider methods can be added her as needed.
+ * Note: callers should call `sandbox.restore()` after tests complete.
+ */
+export function stubMultiProtocolProvider(
+  multiProvider: MultiProtocolProvider,
+): sinon.SinonSandbox {
+  const sandbox = sinon.createSandbox();
+  sandbox.stub(multiProvider, 'getEthersV5Provider').returns({
+    getBalance: async () => '100',
+  } as any);
+  sandbox.stub(multiProvider, 'getCosmJsProvider').returns({
+    getBalance: async () => ({ amount: '100' }),
+  } as any);
+  sandbox.stub(multiProvider, 'getCosmJsWasmProvider').returns({
+    getBalance: async () => ({ amount: '100' }),
+    queryContractSmart: async () => ({
+      type: { native: { fungible: { denom: 'denom' } } },
+    }),
+  } as any);
+  sandbox.stub(multiProvider, 'getSolanaWeb3Provider').returns({
+    getBalance: async () => '100',
+    getTokenAccountBalance: async () => ({ value: { amount: '100' } }),
+  } as any);
+  return sandbox;
+}

--- a/typescript/sdk/src/test/testUtils.ts
+++ b/typescript/sdk/src/test/testUtils.ts
@@ -1,5 +1,4 @@
 import { BigNumber, ethers } from 'ethers';
-import sinon from 'sinon';
 
 import { Address, exclude, objMap } from '@hyperlane-xyz/utils';
 
@@ -10,7 +9,6 @@ import { IgpFactories } from '../gas/contracts.js';
 import { IgpConfig } from '../gas/types.js';
 import { HookType } from '../hook/types.js';
 import { IsmType } from '../ism/types.js';
-import { MultiProtocolProvider } from '../providers/MultiProtocolProvider.js';
 import { RouterConfig } from '../router/types.js';
 import { ChainMap, ChainName } from '../types.js';
 
@@ -90,32 +88,4 @@ export function testIgpConfig(
       },
     ]),
   );
-}
-
-/**
- * Takes a MultiProtocolProvider instance and stubs it's get*Provider methods to
- * return mock providers. More provider methods can be added her as needed.
- * Note: callers should call `sandbox.restore()` after tests complete.
- */
-export function stubMultiProtocolProvider(
-  multiProvider: MultiProtocolProvider,
-): sinon.SinonSandbox {
-  const sandbox = sinon.createSandbox();
-  sandbox.stub(multiProvider, 'getEthersV5Provider').returns({
-    getBalance: async () => '100',
-  } as any);
-  sandbox.stub(multiProvider, 'getCosmJsProvider').returns({
-    getBalance: async () => ({ amount: '100' }),
-  } as any);
-  sandbox.stub(multiProvider, 'getCosmJsWasmProvider').returns({
-    getBalance: async () => ({ amount: '100' }),
-    queryContractSmart: async () => ({
-      type: { native: { fungible: { denom: 'denom' } } },
-    }),
-  } as any);
-  sandbox.stub(multiProvider, 'getSolanaWeb3Provider').returns({
-    getBalance: async () => '100',
-    getTokenAccountBalance: async () => ({ value: { amount: '100' } }),
-  } as any);
-  return sandbox;
 }

--- a/typescript/sdk/src/token/Token.test.ts
+++ b/typescript/sdk/src/token/Token.test.ts
@@ -11,7 +11,7 @@ import {
   testSealevelChain,
 } from '../consts/testChains.js';
 import { MultiProtocolProvider } from '../providers/MultiProtocolProvider.js';
-import { stubMultiProtocolProvider } from '../test/testUtils.js';
+import { stubMultiProtocolProvider } from '../test/multiProviderStubs.js';
 
 import { TokenArgs } from './IToken.js';
 import { Token } from './Token.js';


### PR DESCRIPTION
### Description

testUtils gets used by TestCoreDeployer which gets exported from the SDK, so we can't import sinon there. We should reorganize these test utils
