### PR TITLE
do not exit if @safe-global/protocol-kit/**/Multi_send.ts dne

### DIFF
--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -66,7 +66,7 @@
   ],
   "license": "Apache-2.0",
   "scripts": {
-    "build": "yarn build:fixSafeGlobalLib && tsc",
+    "build": "yarn build:fixSafeGlobalLib; tsc",
     "build:fixSafeGlobalLib": "rm -rf ../../node_modules/@safe-global/protocol-kit/dist/typechain/src/web3-v1/**/Multi_send.ts",
     "dev": "tsc --watch",
     "check": "tsc --noEmit",


### PR DESCRIPTION
### Description

* do not exit if `@safe-global/protocol-kit/**/Multi_send.ts` dne
* This fixes an issue where successfully building the sdk 2+ times exits out, when instead `tsc` should always be executed

### Drive-by changes

* n/a

### Related issues

* n/a

### Backward compatibility

* yes

### Testing

* manual
