### PR TITLE
add defaultDescription to yargs --key option

### DIFF
--- a/.changeset/wet-ghosts-turn.md
+++ b/.changeset/wet-ghosts-turn.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Adds defaultDescription to yargs --key option.

--- a/typescript/cli/src/commands/options.ts
+++ b/typescript/cli/src/commands/options.ts
@@ -45,6 +45,7 @@ export const keyCommandOption: Options = {
 Dry-run: An address to simulate transaction signing on a forked network`,
   alias: 'k',
   default: ENV.HYP_KEY,
+  defaultDescription: '***REDACTED***',
 };
 
 /* Command-specific options */

--- a/typescript/cli/src/commands/options.ts
+++ b/typescript/cli/src/commands/options.ts
@@ -45,7 +45,7 @@ export const keyCommandOption: Options = {
 Dry-run: An address to simulate transaction signing on a forked network`,
   alias: 'k',
   default: ENV.HYP_KEY,
-  defaultDescription: '***REDACTED***',
+  defaultDescription: 'process.env.HYP_KEY',
 };
 
 /* Command-specific options */


### PR DESCRIPTION
### Description

* Adds defaultDescription to yargs --key option to avoid printing sensitive data

### Drive-by changes

* None

### Related issues

* None

### Backward compatibility

* Yes

### Testing

* Manual
