### PR TITLE
Hook schema fixes

### DIFF
--- a/typescript/cli/src/config/hooks.ts
+++ b/typescript/cli/src/config/hooks.ts
@@ -6,7 +6,8 @@ import { z } from 'zod';
 import {
   ChainMap,
   ChainName,
-  GasOracleContractType,
+  HookConfig,
+  HookConfigSchema,
   HookType,
   HooksConfig,
 } from '@hyperlane-xyz/sdk';
@@ -21,51 +22,6 @@ import { CommandContext } from '../context/types.js';
 import { errorRed, log, logBlue, logGreen, logRed } from '../logger.js';
 import { runMultiChainSelectionStep } from '../utils/chains.js';
 import { mergeYamlOrJson, readYamlOrJson } from '../utils/files.js';
-
-const ProtocolFeeSchema = z.object({
-  type: z.literal(HookType.PROTOCOL_FEE),
-  owner: z.string(),
-  beneficiary: z.string(),
-  maxProtocolFee: z.string(),
-  protocolFee: z.string(),
-});
-
-const MerkleTreeSchema = z.object({
-  type: z.literal(HookType.MERKLE_TREE),
-});
-
-const IGPSchema = z.object({
-  type: z.literal(HookType.INTERCHAIN_GAS_PAYMASTER),
-  owner: z.string(),
-  beneficiary: z.string(),
-  overhead: z.record(z.number()),
-  gasOracleType: z.record(z.literal(GasOracleContractType.StorageGasOracle)),
-  oracleKey: z.string(),
-});
-
-const RoutingConfigSchema: z.ZodSchema<any> = z.lazy(() =>
-  z.object({
-    type: z.literal(HookType.ROUTING),
-    owner: z.string(),
-    domains: z.record(HookConfigSchema),
-  }),
-);
-
-const AggregationConfigSchema: z.ZodSchema<any> = z.lazy(() =>
-  z.object({
-    type: z.literal(HookType.AGGREGATION),
-    hooks: z.array(HookConfigSchema),
-  }),
-);
-
-const HookConfigSchema = z.union([
-  ProtocolFeeSchema,
-  MerkleTreeSchema,
-  IGPSchema,
-  RoutingConfigSchema,
-  AggregationConfigSchema,
-]);
-export type HookConfig = z.infer<typeof HookConfigSchema>;
 
 const HooksConfigSchema = z.object({
   required: HookConfigSchema,
@@ -296,10 +252,6 @@ export async function createIGPConfig(
     owner: ownerAddress,
     oracleKey: oracleKeyAddress,
     overhead: overheads,
-    gasOracleType: objMap(
-      overheads,
-      () => GasOracleContractType.StorageGasOracle,
-    ),
   };
 }
 

--- a/typescript/cli/src/deploy/core.ts
+++ b/typescript/cli/src/deploy/core.ts
@@ -6,7 +6,6 @@ import {
   ChainMap,
   ChainName,
   CoreConfig,
-  GasOracleContractType,
   HooksConfig,
   HyperlaneAddressesMap,
   HyperlaneContractsMap,
@@ -364,7 +363,6 @@ export function buildIgpConfigMap(
   const configMap: ChainMap<IgpConfig> = {};
   for (const chain of chains) {
     const overhead: ChainMap<number> = {};
-    const gasOracleType: ChainMap<GasOracleContractType> = {};
     for (const remote of chains) {
       if (chain === remote) continue;
       // TODO: accurate estimate of gas from ChainMap<ISMConfig>
@@ -378,12 +376,10 @@ export function buildIgpConfigMap(
         threshold,
         validatorsLength,
       );
-      gasOracleType[remote] = GasOracleContractType.StorageGasOracle;
     }
     configMap[chain] = {
       owner,
       beneficiary: owner,
-      gasOracleType,
       overhead,
       oracleKey: owner,
     };

--- a/typescript/cli/src/tests/hooks.test.ts
+++ b/typescript/cli/src/tests/hooks.test.ts
@@ -1,11 +1,6 @@
 import { expect } from 'chai';
 
-import {
-  ChainMap,
-  GasOracleContractType,
-  HookType,
-  HooksConfig,
-} from '@hyperlane-xyz/sdk';
+import { ChainMap, HookType, HooksConfig } from '@hyperlane-xyz/sdk';
 
 import { readHooksConfigMap } from '../config/hooks.js';
 
@@ -37,9 +32,6 @@ describe('readHooksConfigMap', () => {
                   beneficiary: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
                   owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
                   oracleKey: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-                  gasOracleType: {
-                    anvil2: GasOracleContractType.StorageGasOracle,
-                  },
                   overhead: { anvil2: 50000 },
                 },
               ],
@@ -70,9 +62,6 @@ describe('readHooksConfigMap', () => {
                   beneficiary: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
                   owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
                   oracleKey: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-                  gasOracleType: {
-                    anvil1: GasOracleContractType.StorageGasOracle,
-                  },
                   overhead: { anvil1: 50000 },
                 },
               ],

--- a/typescript/sdk/src/core/CoreDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/core/CoreDeployer.hardhat-test.ts
@@ -163,7 +163,7 @@ describe('core', async () => {
           const defaultHookTest = coreConfig[chainName]
             .defaultHook as HookConfig;
 
-          expect(defaultHookOnchain.type).to.be.equal(defaultHookTest.type);
+          expect(defaultHookOnchain).to.be.equal(defaultHookTest);
         }),
       );
     });

--- a/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
@@ -69,11 +69,6 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       proxyAdmin,
       [domain],
     );
-    // resolve the owner account so that the subsequent calls terminate early
-    config.owner = await this.resolveInterchainAccountAsOwner(
-      chain,
-      config.owner,
-    );
 
     let defaultIsm = await mailbox.defaultIsm();
     const matches = await moduleMatchesConfig(
@@ -111,15 +106,11 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
 
     // configure mailbox
     try {
-      const owner = await this.resolveInterchainAccountAsOwner(
-        chain,
-        config.owner,
-      );
       this.logger.debug('Initializing mailbox');
       await this.multiProvider.handleTx(
         chain,
         mailbox.initialize(
-          owner,
+          config.owner,
           defaultIsm,
           defaultHook.address,
           requiredHook.address,
@@ -199,7 +190,11 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       this.hookDeployer.deployedContracts[chain],
       this.hookDeployer.verificationInputs[chain],
     );
-    return hooks[config.type];
+    if (typeof config === 'string') {
+      return Object.values(hooks)[0];
+    } else {
+      return hooks[config.type];
+    }
   }
 
   async deployIsm(

--- a/typescript/sdk/src/deploy/HyperlaneAppChecker.ts
+++ b/typescript/sdk/src/deploy/HyperlaneAppChecker.ts
@@ -21,12 +21,10 @@ import {
   AccessControlViolation,
   BytecodeMismatchViolation,
   CheckerViolation,
-  Owner,
   OwnerViolation,
   ProxyAdminViolation,
   TimelockControllerViolation,
   ViolationType,
-  resolveOrDeployAccountOwner,
 } from './types.js';
 
 export abstract class HyperlaneAppChecker<
@@ -208,19 +206,12 @@ export abstract class HyperlaneAppChecker<
 
   protected async checkOwnership(
     chain: ChainName,
-    owner: Owner,
+    owner: Address,
     ownableOverrides?: Record<string, Address>,
   ): Promise<void> {
     const ownableContracts = await this.ownables(chain);
     for (const [name, contract] of Object.entries(ownableContracts)) {
       let expectedOwner = ownableOverrides?.[name] ?? owner;
-      if (typeof expectedOwner !== 'string') {
-        expectedOwner = await resolveOrDeployAccountOwner(
-          this.multiProvider,
-          chain,
-          expectedOwner,
-        );
-      }
       const actual = await contract.owner();
       if (!eqAddress(actual, expectedOwner)) {
         const violation: OwnerViolation = {

--- a/typescript/sdk/src/deploy/schemas.ts
+++ b/typescript/sdk/src/deploy/schemas.ts
@@ -1,9 +1,0 @@
-import { z } from 'zod';
-
-import { AccountConfigSchema } from '../middleware/account/schemas.js';
-
-export const OwnerSchema = z.union([z.string(), AccountConfigSchema]);
-
-export const OwnableConfigSchema = z.object({
-  owner: OwnerSchema,
-});

--- a/typescript/sdk/src/deploy/types.ts
+++ b/typescript/sdk/src/deploy/types.ts
@@ -8,44 +8,18 @@ import type {
 } from '@hyperlane-xyz/core';
 import { Address } from '@hyperlane-xyz/utils';
 
-import { deployInterchainAccount } from '../middleware/account/InterchainAccount.js';
-import { AccountConfig } from '../middleware/account/types.js';
-import { MultiProvider } from '../providers/MultiProvider.js';
+import { OwnableSchema, OwnerSchema } from '../schemas.js';
 import type { ChainName } from '../types.js';
-
-import { OwnableConfigSchema } from './schemas.js';
-
-export type Owner = Address | AccountConfig;
 
 /**
  * @remarks ownerOverrides is added outside of the Schema because zod handle generics in a weird way (uses functions)
  * @see https://stackoverflow.com/questions/74907523/creating-zod-schema-for-generic-interface
  */
 export type OwnableConfig<Keys extends PropertyKey = PropertyKey> = z.infer<
-  typeof OwnableConfigSchema
+  typeof OwnableSchema
 > & {
-  ownerOverrides?: Partial<Record<Keys, Address>>;
+  ownerOverrides?: Partial<Record<Keys, z.infer<typeof OwnerSchema>>>;
 };
-
-export async function resolveOrDeployAccountOwner(
-  multiProvider: MultiProvider,
-  chain: ChainName,
-  owner: Owner,
-): Promise<Address> {
-  if (typeof owner === 'string') {
-    return owner;
-  } else {
-    if (!owner.localRouter) {
-      throw new Error('localRouter is required for AccountConfig');
-    }
-    // submits a transaction to deploy an interchain account if the owner is an AccountConfig and the ICA isn't not deployed yet
-    return await deployInterchainAccount(multiProvider, chain, owner);
-  }
-}
-
-export function isOwnableConfig(config: object): config is OwnableConfig {
-  return 'owner' in config;
-}
 
 export interface CheckerViolation {
   chain: ChainName;

--- a/typescript/sdk/src/gas/oracle/types.ts
+++ b/typescript/sdk/src/gas/oracle/types.ts
@@ -1,17 +1,18 @@
 import { ethers } from 'ethers';
-
-import { StorageGasOracle } from '@hyperlane-xyz/core';
+import { z } from 'zod';
 
 import { TOKEN_EXCHANGE_RATE_DECIMALS } from '../../consts/igp.js';
 
-export enum GasOracleContractType {
-  StorageGasOracle = 'StorageGasOracle',
-}
+const BigNumberString = z.string().transform(ethers.BigNumber.from);
+
+export const StorageGasOracleConfigSchema = z.object({
+  gasPrice: BigNumberString,
+  tokenExchangeRate: BigNumberString,
+});
 
 // Gas data to configure on a single destination chain.
-export type StorageGasOracleConfig = Pick<
-  StorageGasOracle.RemoteGasDataConfigStructOutput,
-  'gasPrice' | 'tokenExchangeRate'
+export type StorageGasOracleConfig = z.output<
+  typeof StorageGasOracleConfigSchema
 >;
 
 export const formatGasOracleConfig = (

--- a/typescript/sdk/src/gas/types.ts
+++ b/typescript/sdk/src/gas/types.ts
@@ -7,10 +7,7 @@ import type { CheckerViolation, OwnableConfig } from '../deploy/types.js';
 import { ChainMap } from '../types.js';
 
 import { IgpFactories } from './contracts.js';
-import {
-  GasOracleContractType,
-  StorageGasOracleConfig,
-} from './oracle/types.js';
+import { StorageGasOracleConfig } from './oracle/types.js';
 
 export type IgpConfig = OwnableConfig<keyof IgpFactories> & {
   beneficiary: Address;
@@ -18,8 +15,6 @@ export type IgpConfig = OwnableConfig<keyof IgpFactories> & {
   overhead: ChainMap<number>;
   // TODO: require this
   oracleConfig?: ChainMap<StorageGasOracleConfig>;
-  // DEPRECATED
-  gasOracleType?: ChainMap<GasOracleContractType>;
 };
 
 export enum IgpViolationType {

--- a/typescript/sdk/src/hook/HyperlaneHookDeployer.ts
+++ b/typescript/sdk/src/hook/HyperlaneHookDeployer.ts
@@ -115,7 +115,7 @@ export class HyperlaneHookDeployer extends HyperlaneDeployer<
       config.maxProtocolFee,
       config.protocolFee,
       config.beneficiary,
-      await this.resolveInterchainAccountAsOwner(chain, config.owner),
+      config.owner,
     ]);
   }
 

--- a/typescript/sdk/src/hook/read.test.ts
+++ b/typescript/sdk/src/hook/read.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { ethers } from 'ethers';
+import { randomBytes } from 'ethers/lib/utils.js';
 import sinon from 'sinon';
 
 import {
@@ -117,11 +118,13 @@ describe('EvmHookReader', () => {
   it('should derive pausable config correctly', async () => {
     const mockAddress = generateRandomAddress();
     const mockOwner = generateRandomAddress();
+    const mockPaused = randomBytes(1)[0] % 2 === 0;
 
     // Mocking the connect method + returned what we need from contract object
     const mockContract = {
       hookType: sandbox.stub().resolves(OnchainHookType.PAUSABLE),
       owner: sandbox.stub().resolves(mockOwner),
+      paused: sandbox.stub().resolves(mockPaused),
     };
     sandbox
       .stub(PausableHook__factory, 'connect')
@@ -132,6 +135,7 @@ describe('EvmHookReader', () => {
 
     const expectedConfig: WithAddress<PausableHookConfig> = {
       owner: mockOwner,
+      paused: mockPaused,
       address: mockAddress,
       type: HookType.PAUSABLE,
     };

--- a/typescript/sdk/src/hook/read.ts
+++ b/typescript/sdk/src/hook/read.ts
@@ -157,7 +157,7 @@ export class EvmHookReader implements HookReader {
     const beneficiary = await hook.beneficiary();
 
     const overhead: IgpHookConfig['overhead'] = {};
-    const oracleConfig: IgpHookConfig['oracleConfig'] = {};
+    // const oracleConfig: IgpHookConfig['oracleConfig'] = {};
 
     let oracleKey: string | undefined;
 
@@ -169,12 +169,12 @@ export class EvmHookReader implements HookReader {
       async (domainId) => {
         const chainName = this.multiProvider.getChainName(domainId);
         try {
-          const { tokenExchangeRate, gasPrice } =
-            await hook.getExchangeRateAndGasPrice(domainId);
+          // const { tokenExchangeRate, gasPrice } =
+          //   await hook.getExchangeRateAndGasPrice(domainId);
+          // oracleConfig[chainName] = { tokenExchangeRate, gasPrice };
           const domainGasOverhead = await hook.destinationGasLimit(domainId, 0);
 
           overhead[chainName] = domainGasOverhead.toNumber();
-          oracleConfig[chainName] = { tokenExchangeRate, gasPrice };
 
           const { gasOracle } = await hook.destinationGasConfigs(domainId);
           const oracle = StorageGasOracle__factory.connect(
@@ -212,7 +212,7 @@ export class EvmHookReader implements HookReader {
       beneficiary,
       oracleKey: oracleKey ?? owner,
       overhead,
-      oracleConfig,
+      // oracleConfig,
     };
   }
 
@@ -330,9 +330,11 @@ export class EvmHookReader implements HookReader {
     const hook = PausableHook__factory.connect(address, this.provider);
     assert((await hook.hookType()) === OnchainHookType.PAUSABLE);
 
+    const paused = await hook.paused();
     const owner = await hook.owner();
     return {
       owner,
+      paused,
       address,
       type: HookType.PAUSABLE,
     };

--- a/typescript/sdk/src/hook/schemas.ts
+++ b/typescript/sdk/src/hook/schemas.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+
+import { OwnableSchema, PausableSchema } from '../schemas.js';
+
+import {
+  AggregationHookConfig,
+  DomainRoutingHookConfig,
+  FallbackRoutingHookConfig,
+  HookType,
+} from './types.js';
+
+export const ProtocolFeeSchema = OwnableSchema.extend({
+  type: z.literal(HookType.PROTOCOL_FEE),
+  beneficiary: z.string(),
+  maxProtocolFee: z.string(),
+  protocolFee: z.string(),
+});
+
+export const MerkleTreeSchema = z.object({
+  type: z.literal(HookType.MERKLE_TREE),
+});
+
+export const PausableHookSchema = PausableSchema.extend({
+  type: z.literal(HookType.PAUSABLE),
+});
+
+export const OpStackHookSchema = OwnableSchema.extend({
+  type: z.literal(HookType.OP_STACK),
+  nativeBridge: z.string(),
+  destinationChain: z.string(),
+});
+
+export const IgpSchema = OwnableSchema.extend({
+  type: z.literal(HookType.INTERCHAIN_GAS_PAYMASTER),
+  beneficiary: z.string(),
+  oracleKey: z.string(),
+  overhead: z.record(z.number()),
+  // TODO: Fix this
+  // oracleConfig: z.record(StorageGasOracleConfigSchema),
+});
+
+export const DomainRoutingHookConfigSchema: z.ZodSchema<DomainRoutingHookConfig> =
+  z.lazy(() =>
+    OwnableSchema.extend({
+      type: z.literal(HookType.ROUTING),
+      domains: z.record(HookConfigSchema),
+    }),
+  );
+
+export const FallbackRoutingHookConfigSchema: z.ZodSchema<FallbackRoutingHookConfig> =
+  z.lazy(() =>
+    OwnableSchema.extend({
+      type: z.literal(HookType.FALLBACK_ROUTING),
+      domains: z.record(HookConfigSchema),
+      fallback: HookConfigSchema,
+    }),
+  );
+
+export const AggregationHookConfigSchema: z.ZodSchema<AggregationHookConfig> =
+  z.lazy(() =>
+    z.object({
+      type: z.literal(HookType.AGGREGATION),
+      hooks: z.array(HookConfigSchema),
+    }),
+  );
+
+export const HookConfigSchema = z.union([
+  ProtocolFeeSchema,
+  PausableHookSchema,
+  OpStackHookSchema,
+  MerkleTreeSchema,
+  IgpSchema,
+  DomainRoutingHookConfigSchema,
+  FallbackRoutingHookConfigSchema,
+  AggregationHookConfigSchema,
+]);

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -1,8 +1,16 @@
-import { Address } from '@hyperlane-xyz/utils';
+import { z } from 'zod';
 
 import { OwnableConfig } from '../deploy/types.js';
-import { IgpConfig } from '../gas/types.js';
-import { ChainMap, ChainName } from '../types.js';
+import { ChainMap } from '../types.js';
+
+import {
+  HookConfigSchema,
+  IgpSchema,
+  MerkleTreeSchema,
+  OpStackHookSchema,
+  PausableHookSchema,
+  ProtocolFeeSchema,
+} from './schemas.js';
 
 // As found in IPostDispatchHook.sol
 export enum OnchainHookType {
@@ -29,58 +37,30 @@ export enum HookType {
   PAUSABLE = 'pausableHook',
 }
 
-export type MerkleTreeHookConfig = {
-  type: HookType.MERKLE_TREE;
-};
+export type MerkleTreeHookConfig = z.infer<typeof MerkleTreeSchema>;
+export type IgpHookConfig = z.infer<typeof IgpSchema>;
+export type ProtocolFeeHookConfig = z.infer<typeof ProtocolFeeSchema>;
+export type PausableHookConfig = z.infer<typeof PausableHookSchema>;
+export type OpStackHookConfig = z.infer<typeof OpStackHookSchema>;
 
+// explicitly typed to avoid zod circular dependency
 export type AggregationHookConfig = {
   type: HookType.AGGREGATION;
   hooks: Array<HookConfig>;
 };
-
-export type IgpHookConfig = IgpConfig & {
-  type: HookType.INTERCHAIN_GAS_PAYMASTER;
-};
-
-export type ProtocolFeeHookConfig = OwnableConfig & {
-  type: HookType.PROTOCOL_FEE;
-  maxProtocolFee: string;
-  protocolFee: string;
-  beneficiary: Address;
-};
-
-export type PausableHookConfig = OwnableConfig & {
-  type: HookType.PAUSABLE;
-};
-
-export type OpStackHookConfig = OwnableConfig & {
-  type: HookType.OP_STACK;
-  nativeBridge: Address;
-  destinationChain: ChainName;
-};
-
 export type RoutingHookConfig = OwnableConfig & {
   domains: ChainMap<HookConfig>;
 };
-
 export type DomainRoutingHookConfig = RoutingHookConfig & {
   type: HookType.ROUTING;
 };
-
 export type FallbackRoutingHookConfig = RoutingHookConfig & {
   type: HookType.FALLBACK_ROUTING;
   fallback: HookConfig;
 };
 
-export type HookConfig =
-  | MerkleTreeHookConfig
-  | AggregationHookConfig
-  | IgpHookConfig
-  | ProtocolFeeHookConfig
-  | OpStackHookConfig
-  | DomainRoutingHookConfig
-  | FallbackRoutingHookConfig
-  | PausableHookConfig;
+// TODO: union with Address
+export type HookConfig = z.infer<typeof HookConfigSchema>;
 
 export type HooksConfig = {
   required: HookConfig;

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -86,7 +86,6 @@ export {
   OwnableConfig,
   OwnerViolation,
   ViolationType,
-  resolveOrDeployAccountOwner,
 } from './deploy/types.js';
 export { ContractVerifier } from './deploy/verify/ContractVerifier.js';
 export { PostDeploymentContractVerifier } from './deploy/verify/PostDeploymentContractVerifier.js';
@@ -110,10 +109,7 @@ export {
   SealevelOverheadIgpDataSchema,
 } from './gas/adapters/serialization.js';
 export { IgpFactories, igpFactories } from './gas/contracts.js';
-export {
-  GasOracleContractType,
-  StorageGasOracleConfig,
-} from './gas/oracle/types.js';
+export { StorageGasOracleConfig } from './gas/oracle/types.js';
 export { CoinGeckoTokenPriceGetter } from './gas/token-prices.js';
 export {
   IgpBeneficiaryViolation,
@@ -125,6 +121,7 @@ export {
 } from './gas/types.js';
 export { HyperlaneHookDeployer } from './hook/HyperlaneHookDeployer.js';
 export { EvmHookReader } from './hook/read.js';
+export { HookConfigSchema } from './hook/schemas.js';
 export {
   AggregationHookConfig,
   DomainRoutingHookConfig,
@@ -145,6 +142,11 @@ export {
 } from './ism/multisig.js';
 export { EvmIsmReader } from './ism/read.js';
 export {
+  AggregationIsmConfigSchema,
+  IsmConfigObjectSchema,
+  IsmConfigSchema,
+} from './ism/schemas.js';
+export {
   AggregationIsmConfig,
   DeployedIsm,
   IsmConfig,
@@ -155,6 +157,7 @@ export {
   OpStackIsmConfig,
   PausableIsmConfig,
   RoutingIsmConfig,
+  TrustedRelayerIsmConfig,
 } from './ism/types.js';
 export { collectValidators, moduleCanCertainlyVerify } from './ism/utils.js';
 export {
@@ -331,6 +334,7 @@ export {
   SealevelRouterAdapter,
 } from './router/adapters/SealevelRouterAdapter.js';
 export { IGasRouterAdapter, IRouterAdapter } from './router/adapters/types.js';
+export { MailboxClientConfigSchema as mailboxClientConfigSchema } from './router/schemas.js';
 export {
   MailboxClientConfig as ConnectionClientConfig,
   ClientViolation as ConnectionClientViolation,
@@ -441,6 +445,11 @@ export {
   TokenFactories,
 } from './token/contracts.js';
 export { HypERC20Deployer, HypERC721Deployer } from './token/deploy.js';
+export {
+  WarpRouteDeployConfigSchema,
+  TokenRouterConfigSchema as tokenRouterConfigSchema,
+} from './token/schemas.js';
+export { TokenRouterConfig, WarpRouteDeployConfig } from './token/types.js';
 export { ChainMap, ChainName, ChainNameOrId, Connection } from './types.js';
 export { MultiGeneric } from './utils/MultiGeneric.js';
 export { getCosmosRegistryChain } from './utils/cosmos.js';
@@ -470,14 +479,6 @@ export {
   WarpTxCategory,
   WarpTypedTransaction,
 } from './warp/types.js';
-
-export { AggregationIsmConfigSchema } from './ism/schemas.js';
-export { MailboxClientConfigSchema as mailboxClientConfigSchema } from './router/schemas.js';
-export {
-  WarpRouteDeployConfigSchema,
-  TokenRouterConfigSchema as tokenRouterConfigSchema,
-} from './token/schemas.js';
-export { TokenRouterConfig, WarpRouteDeployConfig } from './token/types.js';
 
 // prettier-ignore
 // @ts-ignore

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
@@ -36,7 +36,6 @@ import {
   ProxyFactoryFactories,
   proxyFactoryFactories,
 } from '../deploy/contracts.js';
-import { resolveOrDeployAccountOwner } from '../deploy/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainMap, ChainName } from '../types.js';
 
@@ -151,13 +150,7 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
           destination,
           new PausableIsm__factory(),
           IsmType.PAUSABLE,
-          [
-            await resolveOrDeployAccountOwner(
-              this.multiProvider,
-              destination,
-              config.owner,
-            ),
-          ],
+          [config.owner],
         );
         await this.deployer.transferOwnershipOfContracts(destination, config, {
           [IsmType.PAUSABLE]: contract,
@@ -327,11 +320,6 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
       }
     } else {
       const isms: ChainMap<Address> = {};
-      const owner = await resolveOrDeployAccountOwner(
-        this.multiProvider,
-        destination,
-        config.owner,
-      );
       for (const origin of Object.keys(config.domains)) {
         const ism = await this.deploy({
           destination,
@@ -360,7 +348,7 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
         receipt = await this.multiProvider.handleTx(
           destination,
           routingIsm['initialize(address,uint32[],address[])'](
-            owner,
+            config.owner,
             safeConfigDomains,
             submoduleAddresses,
             overrides,
@@ -368,13 +356,8 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
         );
       } else {
         // deploying new domain routing ISM
-        const owner = await resolveOrDeployAccountOwner(
-          this.multiProvider,
-          destination,
-          config.owner,
-        );
         const tx = await domainRoutingIsmFactory.deploy(
-          owner,
+          config.owner,
           safeConfigDomains,
           submoduleAddresses,
           overrides,

--- a/typescript/sdk/src/ism/read.ts
+++ b/typescript/sdk/src/ism/read.ts
@@ -98,7 +98,14 @@ export class EvmIsmReader implements IsmReader {
       case ModuleType.CCIP_READ:
         throw new Error('CCIP_READ does not have a corresponding IsmType');
       default:
-        throw new Error('Unknown ModuleType');
+        this.logger.warn(`Unknown module type ${moduleType}`, {
+          moduleType,
+          address,
+        });
+        return {
+          type: moduleType,
+          address,
+        };
     }
   }
 

--- a/typescript/sdk/src/ism/schemas.ts
+++ b/typescript/sdk/src/ism/schemas.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
 
-import { OwnableConfigSchema } from '../deploy/schemas.js';
 import { ZHash } from '../index.js';
+import { OwnableSchema, PausableSchema } from '../schemas.js';
 
-import { AggregationIsmConfig, IsmConfig, IsmType } from './types.js';
+import { AggregationIsmConfig, IsmType, RoutingIsmConfig } from './types.js';
 
 export const TestIsmConfigSchema = z.object({
   type: z.literal(IsmType.TEST_ISM),
@@ -25,10 +25,9 @@ export const OpStackIsmConfigSchema = z.object({
   nativeBridge: z.string(),
 });
 
-export const PausableIsmConfigSchema = OwnableConfigSchema.and(
+export const PausableIsmConfigSchema = PausableSchema.and(
   z.object({
     type: z.literal(IsmType.PAUSABLE),
-    paused: z.boolean().optional(),
   }),
 );
 
@@ -41,40 +40,37 @@ export const MultisigIsmConfigSchema = MultisigConfigSchema.and(
   }),
 );
 
-export const RoutingIsmConfigSchema = OwnableConfigSchema.and(
-  z.object({
-    type: z.union([
-      z.literal(IsmType.ROUTING),
-      z.literal(IsmType.FALLBACK_ROUTING),
-    ]),
-    domains: z.record(z.string(), z.nativeEnum(IsmType)),
-  }),
+export const RoutingIsmConfigSchema: z.ZodSchema<RoutingIsmConfig> = z.lazy(
+  () =>
+    OwnableSchema.extend({
+      type: z.union([
+        z.literal(IsmType.ROUTING),
+        z.literal(IsmType.FALLBACK_ROUTING),
+      ]),
+      domains: z.record(IsmConfigSchema),
+    }),
 );
 
-export const AggregationIsmConfigSchema: z.ZodSchema<AggregationIsmConfig> =
-  z.lazy(() =>
-    z
-      .object({
-        type: z.literal(IsmType.AGGREGATION),
-        modules: z.array(IsmConfigSchema),
-        threshold: z.number(),
-      })
-      .refine((data) => {
-        if (data.threshold > data.modules.length) return false;
+export const AggregationIsmConfigSchema: z.ZodSchema<AggregationIsmConfig> = z
+  .lazy(() =>
+    z.object({
+      type: z.literal(IsmType.AGGREGATION),
+      modules: z.array(IsmConfigSchema),
+      threshold: z.number(),
+    }),
+  )
+  .refine((data) => data.threshold <= data.modules.length, {
+    message: 'Threshold must be less than or equal to the number of modules',
+  });
 
-        return true;
-      }),
-  );
+export const IsmConfigObjectSchema = z.union([
+  TestIsmConfigSchema,
+  OpStackIsmConfigSchema,
+  PausableIsmConfigSchema,
+  TrustedRelayerIsmConfigSchema,
+  MultisigIsmConfigSchema,
+  RoutingIsmConfigSchema,
+  AggregationIsmConfigSchema,
+]);
 
-export const IsmConfigSchema: z.ZodSchema<IsmConfig> = z.lazy(() =>
-  z.union([
-    z.string(),
-    TestIsmConfigSchema,
-    OpStackIsmConfigSchema,
-    PausableIsmConfigSchema,
-    TrustedRelayerIsmConfigSchema,
-    MultisigIsmConfigSchema,
-    RoutingIsmConfigSchema,
-    AggregationIsmConfigSchema,
-  ]),
-);
+export const IsmConfigSchema = z.union([z.string(), IsmConfigObjectSchema]);

--- a/typescript/sdk/src/ism/types.ts
+++ b/typescript/sdk/src/ism/types.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import {
   IAggregationIsm,
   IMultisigIsm,
@@ -11,6 +13,15 @@ import type { Address, Domain, ValueOf } from '@hyperlane-xyz/utils';
 
 import { OwnableConfig } from '../deploy/types.js';
 import { ChainMap } from '../types.js';
+
+import {
+  IsmConfigSchema,
+  MultisigIsmConfigSchema,
+  OpStackIsmConfigSchema,
+  PausableIsmConfigSchema,
+  TestIsmConfigSchema,
+  TrustedRelayerIsmConfigSchema,
+} from './schemas.js';
 
 // this enum should match the IInterchainSecurityModule.sol enum
 // meant for the relayer
@@ -65,18 +76,13 @@ export type MultisigConfig = {
   threshold: number;
 };
 
-export type MultisigIsmConfig = MultisigConfig & {
-  type: IsmType.MERKLE_ROOT_MULTISIG | IsmType.MESSAGE_ID_MULTISIG;
-};
-
-export type TestIsmConfig = {
-  type: IsmType.TEST_ISM;
-};
-
-export type PausableIsmConfig = OwnableConfig & {
-  type: IsmType.PAUSABLE;
-  paused?: boolean;
-};
+export type MultisigIsmConfig = z.infer<typeof MultisigIsmConfigSchema>;
+export type TestIsmConfig = z.infer<typeof TestIsmConfigSchema>;
+export type PausableIsmConfig = z.infer<typeof PausableIsmConfigSchema>;
+export type OpStackIsmConfig = z.infer<typeof OpStackIsmConfigSchema>;
+export type TrustedRelayerIsmConfig = z.infer<
+  typeof TrustedRelayerIsmConfigSchema
+>;
 
 export type RoutingIsmConfig = OwnableConfig & {
   type: IsmType.ROUTING | IsmType.FALLBACK_ROUTING;
@@ -89,26 +95,7 @@ export type AggregationIsmConfig = {
   threshold: number;
 };
 
-export type OpStackIsmConfig = {
-  type: IsmType.OP_STACK;
-  origin: Address;
-  nativeBridge: Address;
-};
-
-export type TrustedRelayerIsmConfig = {
-  type: IsmType.TRUSTED_RELAYER;
-  relayer: Address;
-};
-
-export type IsmConfig =
-  | Address
-  | RoutingIsmConfig
-  | MultisigIsmConfig
-  | AggregationIsmConfig
-  | OpStackIsmConfig
-  | TestIsmConfig
-  | PausableIsmConfig
-  | TrustedRelayerIsmConfig;
+export type IsmConfig = Address | z.infer<typeof IsmConfigSchema>;
 
 export type DeployedIsmType = {
   [IsmType.ROUTING]: IRoutingIsm;

--- a/typescript/sdk/src/ism/utils.ts
+++ b/typescript/sdk/src/ism/utils.ts
@@ -23,7 +23,6 @@ import {
 
 import { HyperlaneContracts } from '../contracts/types.js';
 import { ProxyFactoryFactories } from '../deploy/contracts.js';
-import { resolveOrDeployAccountOwner } from '../deploy/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainName } from '../types.js';
 
@@ -222,11 +221,7 @@ export async function moduleMatchesConfig(
       );
       // Check that the RoutingISM owner matches the config
       const owner = await routingIsm.owner();
-      const expectedOwner = await resolveOrDeployAccountOwner(
-        multiProvider,
-        chain,
-        config.owner,
-      );
+      const expectedOwner = config.owner;
       matches &&= eqAddress(owner, expectedOwner);
       // check if the mailbox matches the config for fallback routing
       if (config.type === IsmType.FALLBACK_ROUTING) {
@@ -314,11 +309,7 @@ export async function moduleMatchesConfig(
     case IsmType.PAUSABLE: {
       const pausableIsm = PausableIsm__factory.connect(moduleAddress, provider);
       const owner = await pausableIsm.owner();
-      const expectedOwner = await resolveOrDeployAccountOwner(
-        multiProvider,
-        chain,
-        config.owner,
-      );
+      const expectedOwner = config.owner;
       matches &&= eqAddress(owner, expectedOwner);
 
       if (config.paused) {
@@ -360,11 +351,7 @@ export async function routingModuleDelta(
   };
 
   // if owners don't match, we need to transfer ownership
-  const expectedOwner = await resolveOrDeployAccountOwner(
-    multiProvider,
-    destination,
-    config.owner,
-  );
+  const expectedOwner = config.owner;
   if (!eqAddress(owner, normalizeAddress(expectedOwner)))
     delta.owner = expectedOwner;
   if (config.type === IsmType.FALLBACK_ROUTING) {

--- a/typescript/sdk/src/middleware/account/InterchainAccountDeployer.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccountDeployer.ts
@@ -1,6 +1,7 @@
 import { ethers } from 'ethers';
 
 import { Router } from '@hyperlane-xyz/core';
+import { assert } from '@hyperlane-xyz/utils';
 
 import { HyperlaneContracts } from '../../contracts/types.js';
 import { ContractVerifier } from '../../deploy/verify/ContractVerifier.js';
@@ -49,9 +50,16 @@ export class InterchainAccountDeployer extends ProxiedRouterDeployer<
 
   async initializeArgs(chain: string, config: RouterConfig): Promise<any> {
     const owner = await this.multiProvider.getSignerAddress(chain);
+    if (config.interchainSecurityModule) {
+      assert(
+        typeof config.interchainSecurityModule === 'string',
+        'ISM objects not supported in ICA deployer',
+      );
+    }
+
     return [
       config.hook ?? ethers.constants.AddressZero,
-      config.interchainSecurityModule! as string, // deployed in deployContracts
+      config.interchainSecurityModule!,
       owner,
     ];
   }

--- a/typescript/sdk/src/router/ProxiedRouterDeployer.ts
+++ b/typescript/sdk/src/router/ProxiedRouterDeployer.ts
@@ -8,7 +8,6 @@ import {
 import { eqAddress } from '@hyperlane-xyz/utils';
 
 import { HyperlaneContracts } from '../contracts/types.js';
-import { resolveOrDeployAccountOwner } from '../deploy/types.js';
 import { ChainName } from '../types.js';
 
 import { HyperlaneRouterDeployer } from './HyperlaneRouterDeployer.js';
@@ -77,11 +76,7 @@ export abstract class ProxiedRouterDeployer<
         constants.AddressZero,
         this.multiProvider.getProvider(chain),
       );
-      adminOwner = await resolveOrDeployAccountOwner(
-        this.multiProvider,
-        chain,
-        config.owner,
-      );
+      adminOwner = config.owner;
     }
 
     await super.runIfOwner(chain, proxyAdmin, async () => {

--- a/typescript/sdk/src/router/schemas.ts
+++ b/typescript/sdk/src/router/schemas.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
-import { OwnableConfigSchema } from '../deploy/schemas.js';
 import { ZHash } from '../index.js';
 import { IsmConfigSchema } from '../ism/schemas.js';
+import { OwnableSchema } from '../schemas.js';
 
 export const ForeignDeploymentConfigSchema = z.object({
   foreignDeployment: z.string().optional(),
@@ -14,8 +14,6 @@ export const MailboxClientConfigSchema = z.object({
   interchainSecurityModule: IsmConfigSchema.optional(),
 });
 
-export const routerConfigSchema = MailboxClientConfigSchema.merge(
-  OwnableConfigSchema,
-)
+export const routerConfigSchema = MailboxClientConfigSchema.merge(OwnableSchema)
   .merge(ForeignDeploymentConfigSchema)
   .deepPartial();

--- a/typescript/sdk/src/schemas.ts
+++ b/typescript/sdk/src/schemas.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+import { isAddress } from '@hyperlane-xyz/utils';
+
+export const OwnerSchema = z.string().refine((v) => isAddress(v), {
+  message: 'Owner must be a valid address',
+});
+
+export const OwnableSchema = z.object({
+  owner: OwnerSchema,
+});
+
+export const PausableSchema = OwnableSchema.extend({
+  paused: z.boolean(),
+});


### PR DESCRIPTION
### Description

- Dedupes CLI and SDK ISM schemas
- Lifts Hook schemas from CLI into SDK

### Drive-by changes

- Removes interchain account ownership from owner schemas

### Related issues

- Fixes #3728 

### Backward compatibility

- No

### Testing

WIP