### PR TITLE
chore: update clusters to use new prometheus version

### DIFF
--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -17,7 +17,7 @@ export const keyFunderConfig: KeyFunderConfig = {
   cronSchedule: '45 * * * *', // Every hour at the 45-minute mark
   namespace: environment,
   prometheusPushGateway:
-    'http://prometheus-pushgateway.monitoring.svc.cluster.local:9091',
+    'http://prometheus-prometheus-pushgateway.monitoring.svc.cluster.local:9091',
   contextFundingFrom: Contexts.Hyperlane,
   contextsAndRolesToFund: {
     [Contexts.Hyperlane]: [Role.Relayer, Role.Kathy],

--- a/typescript/infra/config/environments/mainnet3/infrastructure.ts
+++ b/typescript/infra/config/environments/mainnet3/infrastructure.ts
@@ -9,7 +9,7 @@ export const infrastructure: InfrastructureConfig = {
     prometheus: {
       deployName: 'prometheus',
       // Node exporter does not work with GKE Autopilot
-      nodeExporterEnabled: false,
+      nodeExporterEnabled: true,
       helmChart: {
         // See https://github.com/prometheus-community/helm-charts#usage
         repository: {
@@ -17,7 +17,7 @@ export const infrastructure: InfrastructureConfig = {
           url: 'https://prometheus-community.github.io/helm-charts',
         },
         name: 'prometheus',
-        version: '15.0.1',
+        version: '25.21.0',
       },
     },
   },

--- a/typescript/infra/config/environments/mainnet3/liquidityLayer.ts
+++ b/typescript/infra/config/environments/mainnet3/liquidityLayer.ts
@@ -49,6 +49,6 @@ export const relayerConfig: LiquidityLayerRelayerConfig = {
   },
   namespace: environment,
   prometheusPushGateway:
-    'http://prometheus-pushgateway.monitoring.svc.cluster.local:9091',
+    'http://prometheus-prometheus-pushgateway.monitoring.svc.cluster.local:9091',
   connectionType: RpcConsensusType.Single,
 };

--- a/typescript/infra/config/environments/testnet4/funding.ts
+++ b/typescript/infra/config/environments/testnet4/funding.ts
@@ -17,7 +17,7 @@ export const keyFunderConfig: KeyFunderConfig = {
   cronSchedule: '15 * * * *', // Every hour at the 15-minute mark
   namespace: environment,
   prometheusPushGateway:
-    'http://prometheus-pushgateway.monitoring.svc.cluster.local:9091',
+    'http://prometheus-prometheus-pushgateway.monitoring.svc.cluster.local:9091',
   contextFundingFrom: Contexts.Hyperlane,
   contextsAndRolesToFund: {
     [Contexts.Hyperlane]: [Role.Relayer, Role.Kathy],

--- a/typescript/infra/config/environments/testnet4/infrastructure.ts
+++ b/typescript/infra/config/environments/testnet4/infrastructure.ts
@@ -9,7 +9,7 @@ export const infrastructure: InfrastructureConfig = {
     prometheus: {
       deployName: 'prometheus',
       // Node exporter does not work with GKE Autopilot
-      nodeExporterEnabled: false,
+      nodeExporterEnabled: true,
       helmChart: {
         // See https://github.com/prometheus-community/helm-charts#usage
         repository: {
@@ -17,7 +17,7 @@ export const infrastructure: InfrastructureConfig = {
           url: 'https://prometheus-community.github.io/helm-charts',
         },
         name: 'prometheus',
-        version: '15.0.1',
+        version: '25.21.0',
       },
     },
   },

--- a/typescript/infra/config/environments/testnet4/middleware.ts
+++ b/typescript/infra/config/environments/testnet4/middleware.ts
@@ -11,6 +11,6 @@ export const liquidityLayerRelayerConfig: LiquidityLayerRelayerConfig = {
   },
   namespace: environment,
   prometheusPushGateway:
-    'http://prometheus-pushgateway.monitoring.svc.cluster.local:9091',
+    'http://prometheus-prometheus-pushgateway.monitoring.svc.cluster.local:9091',
   connectionType: RpcConsensusType.Single,
 };


### PR DESCRIPTION
### Description

GKE was complaining that the kube-state-metrics version we were running with was hitting deprecated APIs, I expect this to fix it.

Some minor changes to the infra setup meant that now the push gateway has a different service name, kinda annoyingly with a double `prometheus` in the name. I updated key funder to push to the new gateway

### Drive-by changes

We no longer use GKE autopilot, so started using the node exporter too

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
