### PR TITLE
fix: allow all log levels in release build

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -174,7 +174,7 @@ tokio = { version = "1", features = ["parking_lot"] }
 tokio-test = "0.4"
 toml_edit = "0.19.14"
 tonic = "0.9.2"
-tracing = { version = "0.1", features = ["release_max_level_debug"] }
+tracing = { version = "0.1" }
 tracing-error = "0.2"
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3", default-features = false }


### PR DESCRIPTION
### Description

Found the reason why we never had `trace` level logs in release builds - the `tracing` crate had a feature flag enabled that would wipe out all trace calls at compile time :(

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3823


### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
