### PR TITLE
fix: fix CI tests to correctly use registry from `main`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -326,7 +326,7 @@ jobs:
   cli-e2e:
     runs-on: larger-runner
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main')
-    needs: [yarn-build]
+    needs: [yarn-build, checkout-registry]
     strategy:
       matrix:
         include:
@@ -382,6 +382,17 @@ jobs:
             !./rust
           key: ${{ github.event.pull_request.head.sha || github.sha }}
 
+      # A workaround for relative paths not being supported by actions/cache.
+      # See https://github.com/actions/upload-artifact/issues/176#issuecomment-1367855630.
+      - run: echo "REGISTRY_URI_ABSOLUTE=$(realpath $REGISTRY_URI)" >> $GITHUB_ENV
+
+      - name: registry-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.REGISTRY_URI_ABSOLUTE }}
+          key: hyperlane-registry-${{ github.event.pull_request.head.sha || github.sha }}
+
       - name: cargo-cache
         uses: actions/cache@v3
         with:
@@ -394,7 +405,7 @@ jobs:
 
   env-test:
     runs-on: ubuntu-latest
-    needs: [yarn-build]
+    needs: [yarn-build, checkout-registry]
     strategy:
       fail-fast: false
       matrix:
@@ -421,6 +432,17 @@ jobs:
             ./*
             !./rust
           key: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      # A workaround for relative paths not being supported by actions/cache.
+      # See https://github.com/actions/upload-artifact/issues/176#issuecomment-1367855630.
+      - run: echo "REGISTRY_URI_ABSOLUTE=$(realpath $REGISTRY_URI)" >> $GITHUB_ENV
+
+      - name: registry-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.REGISTRY_URI_ABSOLUTE }}
+          key: hyperlane-registry-${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Fork test ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }} deployment
         run: cd typescript/infra && ./fork.sh ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }}


### PR DESCRIPTION
### Description

As part of #3788, we moved to using the registry's `main` branch in CI. I accidentally didn't include this for other non-required tests that I didn't realize were failing, and then automerge merged that PR. This ensures the registry is usable by these other tests

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
