### PR TITLE
fix: fetch the registry's `main` branch in the monorepo Docker image

### DIFF
--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -79,4 +79,3 @@ jobs:
           # To always fetch the latest registry, we use the date as the cache key
           build-args: |
             REGISTRY_CACHE=${{ env.TAG_DATE }}
-

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -79,3 +79,4 @@ jobs:
           # To always fetch the latest registry, we use the date as the cache key
           build-args: |
             REGISTRY_CACHE=${{ env.TAG_DATE }}
+

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -78,4 +78,4 @@ jobs:
           cache-to: type=gha,mode=max
           # To always fetch the latest registry, we use the date as the cache key
           build-args: |
-            REGISTRY_CACHE=${{ env.TAG_DATE }}
+            REGISTRY_CACHE=${{ steps.taggen.outputs.TAG_DATE }}

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -74,3 +74,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # To always fetch the latest registry, we use the date as the cache key
+          build-args:
+          - REGISTRY_CACHE=${{ env.TAG_DATE }}

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -8,6 +8,7 @@ on:
     paths:
       # For now, because this image is only used to use `infra`, we just build for infra changes
       - 'typescript/infra/**'
+      - 'Dockerfile'
 concurrency:
   group: build-push-monorepo-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -79,3 +79,4 @@ jobs:
           # To always fetch the latest registry, we use the date as the cache key
           build-args: |
             REGISTRY_CACHE=${{ steps.taggen.outputs.TAG_DATE }}
+

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -77,5 +77,5 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # To always fetch the latest registry, we use the date as the cache key
-          build-args:
-          - REGISTRY_CACHE=${{ env.TAG_DATE }}
+          build-args: |
+            REGISTRY_CACHE=${{ env.TAG_DATE }}

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -79,4 +79,3 @@ jobs:
           # To always fetch the latest registry, we use the date as the cache key
           build-args: |
             REGISTRY_CACHE=${{ steps.taggen.outputs.TAG_DATE }}
-

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -9,6 +9,7 @@ on:
       # For now, because this image is only used to use `infra`, we just build for infra changes
       - 'typescript/infra/**'
       - 'Dockerfile'
+      - '.dockerignore'
 concurrency:
   group: build-push-monorepo-${{ github.ref }}
   cancel-in-progress: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,3 +27,9 @@ COPY typescript ./typescript
 COPY solidity ./solidity
 
 RUN yarn build
+
+# To allow us to avoid caching the registry clone, we use a build-time arg to force
+# the below steps to be re-run if this arg is changed.
+ARG REGISTRY_CACHE="default"
+
+RUN git clone https://github.com/hyperlane-xyz/hyperlane-registry.git /hyperlane-registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,9 @@ COPY solidity ./solidity
 
 RUN yarn build
 
+ENV REGISTRY_URI="/hyperlane-registry"
 # To allow us to avoid caching the registry clone, we use a build-time arg to force
 # the below steps to be re-run if this arg is changed.
 ARG REGISTRY_CACHE="default"
 
-RUN git clone https://github.com/hyperlane-xyz/hyperlane-registry.git /hyperlane-registry
+RUN git clone https://github.com/hyperlane-xyz/hyperlane-registry.git "$REGISTRY_URI"


### PR DESCRIPTION
### Description

Infra services require the presence of a registry. This is expected to be found at the env var REGISTRY_URI. This PR fetches the latest registry from `main` and uses that as the registry in the monorepo image for infra services / scripts to make use of. To prevent caching of this git clone, we use a build-time arg such that if the arg changes, any later layers in the image will be ran. See https://stackoverflow.com/a/73501716

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

- Partially fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3827 - we'll need a deploy to fully close it out

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
