### PR TITLE
feat(cli): add 'hyperlane core config' command

### DIFF
--- a/.changeset/hip-squids-lay.md
+++ b/.changeset/hip-squids-lay.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Adds 'hyperlane core config'.

--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
     "no-extra-boolean-cast": ["error"],
     "no-ex-assign": ["error"],
     "no-constant-condition": ["off"],
+    "no-return-await": ["error"],
     "guard-for-in": ["error"],
     "@typescript-eslint/ban-ts-comment": ["off"],
     "@typescript-eslint/explicit-module-boundary-types": ["off"],

--- a/typescript/cli/cli.ts
+++ b/typescript/cli/cli.ts
@@ -8,6 +8,7 @@ import './env.js';
 import { avsCommand } from './src/commands/avs.js';
 import { chainsCommand } from './src/commands/chains.js';
 import { configCommand } from './src/commands/config.js';
+import { coreCommand } from './src/commands/core.js';
 import { deployCommand } from './src/commands/deploy.js';
 import { hookCommand } from './src/commands/hook.js';
 import { ismCommand } from './src/commands/ism.js';
@@ -53,6 +54,7 @@ try {
     .command(avsCommand)
     .command(chainsCommand)
     .command(configCommand)
+    .command(coreCommand)
     .command(deployCommand)
     .command(hookCommand)
     .command(ismCommand)

--- a/typescript/cli/src/avs/stakeRegistry.ts
+++ b/typescript/cli/src/avs/stakeRegistry.ts
@@ -119,7 +119,7 @@ async function readOperatorFromEncryptedJson(
     message: 'Enter the password for the operator key file: ',
   });
 
-  return await Wallet.fromEncryptedJson(encryptedJson, keyFilePassword);
+  return Wallet.fromEncryptedJson(encryptedJson, keyFilePassword);
 }
 
 async function getOperatorSignature(

--- a/typescript/cli/src/commands/config.ts
+++ b/typescript/cli/src/commands/config.ts
@@ -1,12 +1,8 @@
 import { CommandModule } from 'yargs';
 
 import { createChainConfig, readChainConfigs } from '../config/chain.js';
-import { createHooksConfigMap } from '../config/hooks.js';
-import { createIsmConfigMap, readIsmConfig } from '../config/ism.js';
-import {
-  createMultisigConfig,
-  readMultisigConfig,
-} from '../config/multisig.js';
+import { readIsmConfig } from '../config/ism.js';
+import { readMultisigConfig } from '../config/multisig.js';
 import {
   createWarpRouteDeployConfig,
   readWarpRouteDeployConfig,
@@ -40,8 +36,6 @@ const createCommand: CommandModule = {
   builder: (yargs) =>
     yargs
       .command(createChainConfigCommand)
-      .command(createIsmConfigCommand)
-      .command(createHookConfigCommand)
       .command(createWarpRouteDeployConfigCommand)
       .version(false)
       .demandCommand(),
@@ -53,42 +47,6 @@ const createChainConfigCommand: CommandModuleWithContext<{}> = {
   describe: 'Create a new, minimal Hyperlane chain config (aka chain metadata)',
   handler: async ({ context }) => {
     await createChainConfig({ context });
-    process.exit(0);
-  },
-};
-
-const createIsmConfigCommand: CommandModuleWithContext<{
-  out: string;
-  advanced: boolean;
-}> = {
-  command: 'ism',
-  describe: 'Create a basic or advanced ISM config for a validator set',
-  builder: {
-    out: outputFileCommandOption('./configs/ism.yaml'),
-    advanced: {
-      type: 'boolean',
-      describe: 'Create an advanced ISM configuration',
-      default: false,
-    },
-  },
-  handler: async ({ context, out, advanced }) => {
-    if (advanced) {
-      await createIsmConfigMap({ context, outPath: out });
-    } else {
-      await createMultisigConfig({ context, outPath: out });
-    }
-    process.exit(0);
-  },
-};
-
-const createHookConfigCommand: CommandModuleWithContext<{ out: string }> = {
-  command: 'hooks',
-  describe: 'Create a new hooks config (required & default)',
-  builder: {
-    out: outputFileCommandOption('./configs/hooks.yaml'),
-  },
-  handler: async ({ context, out }) => {
-    await createHooksConfigMap({ context, outPath: out });
     process.exit(0);
   },
 };

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -1,0 +1,49 @@
+import { CommandModule } from 'yargs';
+
+import { createHooksConfigMap } from '../config/hooks.js';
+import { createIsmConfigMap } from '../config/ism.js';
+import { CommandModuleWithContext } from '../context/types.js';
+import { log } from '../logger.js';
+
+import { outputFileCommandOption } from './options.js';
+
+/**
+ * Parent command
+ */
+export const coreCommand: CommandModule = {
+  command: 'core',
+  describe: 'Manage core Hyperlane contracts & configs',
+  builder: (yargs) => yargs.command(config).version(false).demandCommand(),
+  handler: () => log('Command required'),
+};
+
+export const config: CommandModuleWithContext<{
+  ismAdvanced: boolean;
+  ismOut: string;
+  hooksOut: string;
+}> = {
+  command: 'config',
+  describe: 'Create a core configuration, including ISMs and hooks.',
+  builder: {
+    ismAdvanced: {
+      type: 'boolean',
+      describe: 'Create an advanced ISM & hook configuration',
+      default: false,
+    },
+    ismOut: outputFileCommandOption('./configs/ism.yaml'),
+    hooksOut: outputFileCommandOption('./configs/hooks.yaml'),
+  },
+  handler: async ({ context, ismAdvanced, ismOut, hooksOut }) => {
+    await createIsmConfigMap({
+      context,
+      outPath: ismOut,
+      shouldUseDefault: !ismAdvanced,
+    });
+    await createHooksConfigMap({
+      context,
+      outPath: hooksOut,
+    });
+
+    process.exit(0);
+  },
+};

--- a/typescript/cli/src/config/hooks.ts
+++ b/typescript/cli/src/config/hooks.ts
@@ -78,7 +78,7 @@ export async function createHooksConfigMap({
   const result: HooksConfigMap = {};
   for (const chain of chains) {
     for (const hookRequirements of ['required', 'default']) {
-      log(`Setting ${hookRequirements} hook for chain ${chain}`);
+      log(`\nSet ${hookRequirements} hook for chain ${chain}:`);
       const remotes = chains.filter((c) => c !== chain);
       result[chain] = {
         ...result[chain],
@@ -159,7 +159,7 @@ export async function createProtocolFeeConfig(
   chain: ChainName,
 ): Promise<HookConfig> {
   const owner = await input({
-    message: 'Enter owner address',
+    message: 'Enter owner address for protocol fee hook',
   });
   const ownerAddress = normalizeAddressEvm(owner);
   let beneficiary;
@@ -171,7 +171,7 @@ export async function createProtocolFeeConfig(
     beneficiary = ownerAddress;
   } else {
     beneficiary = await input({
-      message: 'Enter beneficiary address',
+      message: 'Enter beneficiary address for protocol fee hook',
     });
   }
   const beneficiaryAddress = normalizeAddressEvm(beneficiary);
@@ -181,7 +181,7 @@ export async function createProtocolFeeConfig(
       message: `Enter max protocol fee ${nativeTokenAndDecimals(
         context,
         chain,
-      )} e.g. 1.0)`,
+      )} e.g. 1.0) for protocol fee hook`,
     }),
   );
   const protocolFee = toWei(
@@ -189,7 +189,7 @@ export async function createProtocolFeeConfig(
       message: `Enter protocol fee in ${nativeTokenAndDecimals(
         context,
         chain,
-      )} e.g. 0.01)`,
+      )} e.g. 0.01) for protocol fee hook`,
     }),
   );
   if (BigNumberJs(protocolFee).gt(maxProtocolFee)) {
@@ -211,7 +211,7 @@ export async function createIGPConfig(
   remotes: ChainName[],
 ): Promise<HookConfig> {
   const owner = await input({
-    message: 'Enter owner address',
+    message: 'Enter owner address for IGP hook',
   });
   const ownerAddress = normalizeAddressEvm(owner);
   let beneficiary, oracleKey;
@@ -224,10 +224,10 @@ export async function createIGPConfig(
     oracleKey = ownerAddress;
   } else {
     beneficiary = await input({
-      message: 'Enter beneficiary address',
+      message: 'Enter beneficiary address for IGP hook',
     });
     oracleKey = await input({
-      message: 'Enter gasOracleKey address',
+      message: 'Enter gasOracleKey address for IGP hook',
     });
   }
   const beneficiaryAddress = normalizeAddressEvm(beneficiary);
@@ -236,7 +236,7 @@ export async function createIGPConfig(
   for (const chain of remotes) {
     const overhead = parseInt(
       await input({
-        message: `Enter overhead for ${chain} (eg 75000)`,
+        message: `Enter overhead for ${chain} (eg 75000) for IGP hook`,
       }),
     );
     overheads[chain] = overhead;
@@ -279,7 +279,7 @@ export async function createRoutingConfig(
   remotes: ChainName[],
 ): Promise<HookConfig> {
   const owner = await input({
-    message: 'Enter owner address',
+    message: 'Enter owner address for routing ISM',
   });
   const ownerAddress = owner;
 

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -21,7 +21,10 @@ import {
   logGreen,
   logRed,
 } from '../logger.js';
-import { runMultiChainSelectionStep } from '../utils/chains.js';
+import {
+  detectAndConfirmOrPrompt,
+  runMultiChainSelectionStep,
+} from '../utils/chains.js';
 import { mergeYamlOrJson, readYamlOrJson } from '../utils/files.js';
 
 const IsmConfigMapSchema = z.record(IsmConfigSchema).refine(
@@ -73,9 +76,11 @@ export function isValildIsmConfig(config: any) {
 export async function createIsmConfigMap({
   context,
   outPath,
+  shouldUseDefault = true,
 }: {
   context: CommandContext;
   outPath: string;
+  shouldUseDefault: boolean;
 }) {
   logBlue('Creating a new advanced ISM config');
   logBoldUnderlinedRed('WARNING: USE AT YOUR RISK.');
@@ -90,8 +95,10 @@ export async function createIsmConfigMap({
 
   const result: IsmConfigMap = {};
   for (const chain of chains) {
-    log(`Setting values for chain ${chain}`);
-    result[chain] = await createIsmConfig(chain, chains);
+    log(`\nSet values for chain ${chain}:`);
+    result[chain] = shouldUseDefault
+      ? await createTrustedRelayerConfig(context)
+      : await createIsmConfig(context, chain, chains);
 
     // TODO consider re-enabling. Disabling based on feedback from @nambrot for now.
     // repeat = await confirm({
@@ -128,6 +135,7 @@ const ISM_TYPE_DESCRIPTIONS: Record<IsmType, string> = {
 };
 
 export async function createIsmConfig(
+  context: CommandContext,
   remote: ChainName,
   origins: ChainName[],
 ): Promise<IsmConfig> {
@@ -149,13 +157,13 @@ export async function createIsmConfig(
     moduleType === IsmType.ROUTING ||
     moduleType === IsmType.FALLBACK_ROUTING
   ) {
-    return createRoutingConfig(moduleType, remote, origins);
+    return createRoutingConfig(context, moduleType, remote, origins);
   } else if (moduleType === IsmType.AGGREGATION) {
-    return createAggregationConfig(remote, origins);
+    return createAggregationConfig(context, remote, origins);
   } else if (moduleType === IsmType.TEST_ISM) {
     return { type: IsmType.TEST_ISM };
   } else if (moduleType === IsmType.TRUSTED_RELAYER) {
-    return createTrustedRelayerConfig();
+    return createTrustedRelayerConfig(context);
   }
 
   throw new Error(`Invalid ISM type: ${moduleType}}`);
@@ -165,12 +173,13 @@ export async function createMultisigConfig(
   type: IsmType.MERKLE_ROOT_MULTISIG | IsmType.MESSAGE_ID_MULTISIG,
 ): Promise<MultisigIsmConfig> {
   const thresholdInput = await input({
-    message: 'Enter threshold of validators (number)',
+    message: 'Enter threshold of validators (number) for multisig ISM',
   });
   const threshold = parseInt(thresholdInput, 10);
 
   const validatorsInput = await input({
-    message: 'Enter validator addresses (comma separated list)',
+    message:
+      'Enter validator addresses (comma separated list) for multisig ISM',
   });
   const validators = validatorsInput.split(',').map((v) => v.trim());
   return {
@@ -180,10 +189,14 @@ export async function createMultisigConfig(
   };
 }
 
-async function createTrustedRelayerConfig(): Promise<TrustedRelayerIsmConfig> {
-  const relayer = await input({
-    message: 'Enter relayer address',
-  });
+async function createTrustedRelayerConfig(
+  context: CommandContext,
+): Promise<TrustedRelayerIsmConfig> {
+  const relayer = await detectAndConfirmOrPrompt(
+    async () => context.signer?.getAddress(),
+    'For trusted relayer ISM, enter',
+    'relayer address',
+  );
   return {
     type: IsmType.TRUSTED_RELAYER,
     relayer,
@@ -191,6 +204,7 @@ async function createTrustedRelayerConfig(): Promise<TrustedRelayerIsmConfig> {
 }
 
 export async function createAggregationConfig(
+  context: CommandContext,
   remote: ChainName,
   chains: ChainName[],
 ): Promise<AggregationIsmConfig> {
@@ -203,14 +217,14 @@ export async function createAggregationConfig(
 
   const threshold = parseInt(
     await input({
-      message: 'Enter the threshold of ISMs to for verification (number)',
+      message: 'Enter the threshold of ISMs for verification (number)',
     }),
     10,
   );
 
   const modules: Array<IsmConfig> = [];
   for (let i = 0; i < isms; i++) {
-    modules.push(await createIsmConfig(remote, chains));
+    modules.push(await createIsmConfig(context, remote, chains));
   }
   return {
     type: IsmType.AGGREGATION,
@@ -220,12 +234,13 @@ export async function createAggregationConfig(
 }
 
 export async function createRoutingConfig(
+  context: CommandContext,
   type: IsmType.ROUTING | IsmType.FALLBACK_ROUTING,
   remote: ChainName,
   chains: ChainName[],
 ): Promise<IsmConfig> {
   const owner = await input({
-    message: 'Enter owner address',
+    message: 'Enter owner address for routing ISM',
   });
   const ownerAddress = owner;
   const origins = chains.filter((chain) => chain !== remote);
@@ -235,7 +250,7 @@ export async function createRoutingConfig(
     await confirm({
       message: `You are about to configure ISM from source chain ${chain}. Continue?`,
     });
-    const config = await createIsmConfig(chain, chains);
+    const config = await createIsmConfig(context, chain, chains);
     domainsMap[chain] = config;
   }
   return {

--- a/typescript/cli/src/utils/keys.ts
+++ b/typescript/cli/src/utils/keys.ts
@@ -68,7 +68,7 @@ async function addressToImpersonatedSigner(
   if (address.length != ETHEREUM_ADDRESS_LENGTH)
     throw new Error('Invalid address length.');
   else if (ethers.utils.isHexString(ensure0x(formattedKey)))
-    return await impersonateAccount(address);
+    return impersonateAccount(address);
   else throw new Error('Invalid address format');
 }
 
@@ -93,7 +93,7 @@ async function retrieveKey(
 ): Promise<string> {
   if (skipConfirmation) throw new Error(`No private key provided`);
   else
-    return await input({
+    return input({
       message: `Please enter private key or use the HYP_KEY environment variable.`,
     });
 }

--- a/typescript/cli/src/validator/address.ts
+++ b/typescript/cli/src/validator/address.ts
@@ -141,7 +141,7 @@ function getEthereumAddress(publicKey: Buffer): string {
 async function getAccessKeyId(skipConfirmation: boolean) {
   if (skipConfirmation) throw new Error('No AWS access key ID set.');
   else
-    return await input({
+    return input({
       message:
         'Please enter AWS access key ID or use the AWS_ACCESS_KEY_ID environment variable.',
     });
@@ -150,7 +150,7 @@ async function getAccessKeyId(skipConfirmation: boolean) {
 async function getSecretAccessKey(skipConfirmation: boolean) {
   if (skipConfirmation) throw new Error('No AWS secret access key set.');
   else
-    return await input({
+    return input({
       message:
         'Please enter AWS secret access key or use the AWS_SECRET_ACCESS_KEY environment variable.',
     });
@@ -159,7 +159,7 @@ async function getSecretAccessKey(skipConfirmation: boolean) {
 async function getRegion(skipConfirmation: boolean) {
   if (skipConfirmation) throw new Error('No AWS region set.');
   else
-    return await input({
+    return input({
       message:
         'Please enter AWS region or use the AWS_REGION environment variable.',
     });

--- a/typescript/sdk/src/core/CoreDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/core/CoreDeployer.hardhat-test.ts
@@ -127,7 +127,7 @@ describe('core', async () => {
     });
 
     async function deriveCoreConfig(chainName: string, mailboxAddress: string) {
-      return await new EvmCoreReader(multiProvider, chainName).deriveCoreConfig(
+      return new EvmCoreReader(multiProvider, chainName).deriveCoreConfig(
         mailboxAddress,
       );
     }

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -39,7 +39,7 @@ export class EvmHookModule extends HyperlaneModule<
   }
 
   public async read(): Promise<HookConfig> {
-    return await this.reader.deriveHookConfig(this.args.addresses.deployedHook);
+    return this.reader.deriveHookConfig(this.args.addresses.deployedHook);
   }
 
   public async update(_config: HookConfig): Promise<EthersV5Transaction[]> {

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -39,7 +39,7 @@ export class EvmIsmModule extends HyperlaneModule<
   }
 
   public async read(): Promise<IsmConfig> {
-    return await this.reader.deriveIsmConfig(this.args.addresses.deployedIsm);
+    return this.reader.deriveIsmConfig(this.args.addresses.deployedIsm);
   }
 
   public async update(_config: IsmConfig): Promise<EthersV5Transaction[]> {


### PR DESCRIPTION
### Description

* adds new `hyperlane core config` command
* this combines previous `hl config create ism` & `hl config create hook` control flows
* adds default ISM behaviour to aggregate `IsmType.TRUSTED_RELAYER` and the previous default fallback, `IsmType.MESSAGE_ID_MULTISIG`

### Related issues

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3688

### Backward compatibility

* yes

### Testing

* [x] manual
* [ ] ci-test
