### PR TITLE
feat: support hook config objects in warp config

### DIFF
--- a/.changeset/brave-humans-draw.md
+++ b/.changeset/brave-humans-draw.md
@@ -1,0 +1,7 @@
+---
+'@hyperlane-xyz/infra': minor
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+Support hook config objects in warp config

--- a/typescript/cli/examples/hooks.yaml
+++ b/typescript/cli/examples/hooks.yaml
@@ -39,8 +39,10 @@ anvil1:
             oracleKey: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
             overhead:
               anvil2: 50000 # gas amount (number)
-            gasOracleType:
-              anvil2: StorageGasOracle
+            oracleConfig:
+              anvil2:
+                gasPrice: '1000000000000000000'
+                tokenExchangeRate: '1000000000000000000'
 anvil2:
   required:
     type: protocolFee
@@ -62,5 +64,7 @@ anvil2:
             oracleKey: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
             overhead:
               anvil1: 50000
-            gasOracleType:
-              anvil1: StorageGasOracle
+            oracleConfig:
+              anvil1:
+                gasPrice: '1000000000000000000'
+                tokenExchangeRate: '1000000000000000000'

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -1,7 +1,16 @@
 import { confirm, input, select } from '@inquirer/prompts';
 import { z } from 'zod';
 
-import { ChainMap, ChainName, IsmType, ZHash } from '@hyperlane-xyz/sdk';
+import {
+  AggregationIsmConfig,
+  ChainMap,
+  ChainName,
+  IsmConfig,
+  IsmConfigSchema,
+  IsmType,
+  MultisigIsmConfig,
+  TrustedRelayerIsmConfig,
+} from '@hyperlane-xyz/sdk';
 
 import { CommandContext } from '../context/types.js';
 import {
@@ -15,64 +24,14 @@ import {
 import { runMultiChainSelectionStep } from '../utils/chains.js';
 import { mergeYamlOrJson, readYamlOrJson } from '../utils/files.js';
 
-const MultisigIsmConfigSchema = z.object({
-  type: z.union([
-    z.literal(IsmType.MERKLE_ROOT_MULTISIG),
-    z.literal(IsmType.MESSAGE_ID_MULTISIG),
-  ]),
-  threshold: z.number(),
-  validators: z.array(ZHash),
-});
-
-const RoutingIsmConfigSchema: z.ZodSchema<any> = z.lazy(() =>
-  z.object({
-    type: z.union([
-      z.literal(IsmType.ROUTING),
-      z.literal(IsmType.FALLBACK_ROUTING),
-    ]),
-    owner: ZHash,
-    domains: z.record(IsmConfigSchema),
-  }),
-);
-
-const AggregationIsmConfigSchema: z.ZodSchema<any> = z
-  .lazy(() =>
-    z.object({
-      type: z.literal(IsmType.AGGREGATION),
-      modules: z.array(IsmConfigSchema),
-      threshold: z.number(),
-    }),
-  )
-  .refine(
-    // check ig modules.length >= threshold
-    (ismConfig) => {
-      return ismConfig.modules.length >= ismConfig.threshold;
-    },
-    {
-      message: 'Threshold cannot be greater than number of modules',
-    },
-  );
-
-const TestIsmConfigSchema = z.object({
-  type: z.literal(IsmType.TEST_ISM),
-});
-
-const TrustedRelayerIsmConfigSchema = z.object({
-  type: z.literal(IsmType.TRUSTED_RELAYER),
-  relayer: ZHash,
-});
-
-const IsmConfigSchema = z.union([
-  MultisigIsmConfigSchema,
-  RoutingIsmConfigSchema,
-  AggregationIsmConfigSchema,
-  TestIsmConfigSchema,
-  TrustedRelayerIsmConfigSchema,
-]);
 const IsmConfigMapSchema = z.record(IsmConfigSchema).refine(
   (ismConfigMap) => {
     // check if any key in IsmConfigMap is found in its own RoutingIsmConfigSchema.domains
     for (const [key, config] of Object.entries(ismConfigMap)) {
+      if (typeof config === 'string') {
+        continue;
+      }
+
       if (config.type === IsmType.ROUTING) {
         if (config.domains && key in config.domains) {
           return false;
@@ -86,8 +45,8 @@ const IsmConfigMapSchema = z.record(IsmConfigSchema).refine(
       'Cannot set RoutingIsm.domain to the same chain you are configuring',
   },
 );
-export type ZodIsmConfig = z.infer<typeof IsmConfigSchema>;
-export type ZodIsmConfigMap = z.infer<typeof IsmConfigMapSchema>;
+
+type IsmConfigMap = z.infer<typeof IsmConfigMapSchema>;
 
 export function parseIsmConfig(filePath: string) {
   const config = readYamlOrJson(filePath);
@@ -129,7 +88,7 @@ export async function createIsmConfigMap({
     true,
   );
 
-  const result: ZodIsmConfigMap = {};
+  const result: IsmConfigMap = {};
   for (const chain of chains) {
     log(`Setting values for chain ${chain}`);
     result[chain] = await createIsmConfig(chain, chains);
@@ -151,75 +110,60 @@ export async function createIsmConfigMap({
   }
 }
 
+const ISM_TYPE_DESCRIPTIONS: Record<IsmType, string> = {
+  [IsmType.MESSAGE_ID_MULTISIG]: 'Validators need to sign just this messageId',
+  [IsmType.MERKLE_ROOT_MULTISIG]:
+    'Validators need to sign the root of the merkle tree of all messages from origin chain',
+  [IsmType.ROUTING]:
+    'Each origin chain can be verified by the specified ISM type via RoutingISM',
+  [IsmType.FALLBACK_ROUTING]:
+    "You can specify ISM type for specific chains you like and fallback to mailbox's default ISM for other chains via DefaultFallbackRoutingISM",
+  [IsmType.AGGREGATION]:
+    'You can aggregate multiple ISMs into one ISM via AggregationISM',
+  [IsmType.TRUSTED_RELAYER]: 'Deliver messages from an authorized address',
+  [IsmType.TEST_ISM]:
+    'ISM where you can deliver messages without any validation (WARNING: only for testing, do not use in production)',
+  [IsmType.OP_STACK]: '',
+  [IsmType.PAUSABLE]: '',
+};
+
 export async function createIsmConfig(
   remote: ChainName,
   origins: ChainName[],
-): Promise<ZodIsmConfig> {
-  let lastConfig: ZodIsmConfig;
+): Promise<IsmConfig> {
   const moduleType = await select({
     message: 'Select ISM type',
-    choices: [
-      {
-        value: IsmType.MESSAGE_ID_MULTISIG,
-        description: 'Validators need to sign just this messageId',
-      },
-      {
-        value: IsmType.MERKLE_ROOT_MULTISIG,
-        description:
-          'Validators need to sign the root of the merkle tree of all messages from origin chain',
-      },
-      {
-        value: IsmType.ROUTING,
-        description:
-          'Each origin chain can be verified by the specified ISM type via RoutingISM',
-      },
-      {
-        value: IsmType.FALLBACK_ROUTING,
-        description:
-          "You can specify ISM type for specific chains you like and fallback to mailbox's default ISM for other chains via DefaultFallbackRoutingISM",
-      },
-      {
-        value: IsmType.AGGREGATION,
-        description:
-          'You can aggregate multiple ISMs into one ISM via AggregationISM',
-      },
-      {
-        value: IsmType.TRUSTED_RELAYER,
-        description: 'Deliver messages from an authorized address',
-      },
-      {
-        value: IsmType.TEST_ISM,
-        description:
-          'ISM where you can deliver messages without any validation (WARNING: only for testing, do not use in production)',
-      },
-    ],
+    choices: Object.values(IsmType).map((value) => ({
+      value,
+      description: ISM_TYPE_DESCRIPTIONS[value],
+    })),
     pageSize: 10,
   });
+
   if (
     moduleType === IsmType.MESSAGE_ID_MULTISIG ||
     moduleType === IsmType.MERKLE_ROOT_MULTISIG
   ) {
-    lastConfig = await createMultisigConfig(moduleType);
+    return createMultisigConfig(moduleType);
   } else if (
     moduleType === IsmType.ROUTING ||
     moduleType === IsmType.FALLBACK_ROUTING
   ) {
-    lastConfig = await createRoutingConfig(moduleType, remote, origins);
+    return createRoutingConfig(moduleType, remote, origins);
   } else if (moduleType === IsmType.AGGREGATION) {
-    lastConfig = await createAggregationConfig(remote, origins);
+    return createAggregationConfig(remote, origins);
   } else if (moduleType === IsmType.TEST_ISM) {
-    lastConfig = { type: IsmType.TEST_ISM };
+    return { type: IsmType.TEST_ISM };
   } else if (moduleType === IsmType.TRUSTED_RELAYER) {
-    lastConfig = await createTrustedRelayerConfig();
-  } else {
-    throw new Error(`Invalid ISM type: ${moduleType}}`);
+    return createTrustedRelayerConfig();
   }
-  return lastConfig;
+
+  throw new Error(`Invalid ISM type: ${moduleType}}`);
 }
 
 export async function createMultisigConfig(
   type: IsmType.MERKLE_ROOT_MULTISIG | IsmType.MESSAGE_ID_MULTISIG,
-): Promise<ZodIsmConfig> {
+): Promise<MultisigIsmConfig> {
   const thresholdInput = await input({
     message: 'Enter threshold of validators (number)',
   });
@@ -236,7 +180,7 @@ export async function createMultisigConfig(
   };
 }
 
-async function createTrustedRelayerConfig(): Promise<ZodIsmConfig> {
+async function createTrustedRelayerConfig(): Promise<TrustedRelayerIsmConfig> {
   const relayer = await input({
     message: 'Enter relayer address',
   });
@@ -249,7 +193,7 @@ async function createTrustedRelayerConfig(): Promise<ZodIsmConfig> {
 export async function createAggregationConfig(
   remote: ChainName,
   chains: ChainName[],
-): Promise<ZodIsmConfig> {
+): Promise<AggregationIsmConfig> {
   const isms = parseInt(
     await input({
       message: 'Enter the number of ISMs to aggregate (number)',
@@ -264,7 +208,7 @@ export async function createAggregationConfig(
     10,
   );
 
-  const modules: Array<ZodIsmConfig> = [];
+  const modules: Array<IsmConfig> = [];
   for (let i = 0; i < isms; i++) {
     modules.push(await createIsmConfig(remote, chains));
   }
@@ -279,14 +223,14 @@ export async function createRoutingConfig(
   type: IsmType.ROUTING | IsmType.FALLBACK_ROUTING,
   remote: ChainName,
   chains: ChainName[],
-): Promise<ZodIsmConfig> {
+): Promise<IsmConfig> {
   const owner = await input({
     message: 'Enter owner address',
   });
   const ownerAddress = owner;
   const origins = chains.filter((chain) => chain !== remote);
 
-  const domainsMap: ChainMap<ZodIsmConfig> = {};
+  const domainsMap: ChainMap<IsmConfig> = {};
   for (const chain of origins) {
     await confirm({
       message: `You are about to configure ISM from source chain ${chain}. Continue?`,

--- a/typescript/cli/src/deploy/core.ts
+++ b/typescript/cli/src/deploy/core.ts
@@ -6,8 +6,7 @@ import {
   ChainMap,
   ChainName,
   CoreConfig,
-  GasOracleContractType,
-  HooksConfig,
+  HookType,
   HyperlaneAddressesMap,
   HyperlaneContractsMap,
   HyperlaneCore,
@@ -27,7 +26,11 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { Address, objFilter, objMap, objMerge } from '@hyperlane-xyz/utils';
 
-import { presetHookConfigs, readHooksConfigMap } from '../config/hooks.js';
+import {
+  HooksConfig,
+  presetHookConfigs,
+  readHooksConfigMap,
+} from '../config/hooks.js';
 import { readIsmConfig } from '../config/ism.js';
 import { readMultisigConfig } from '../config/multisig.js';
 import { MINIMUM_CORE_DEPLOY_GAS } from '../consts.js';
@@ -370,7 +373,6 @@ export function buildIgpConfigMap(
   const configMap: ChainMap<IgpConfig> = {};
   for (const chain of chains) {
     const overhead: ChainMap<number> = {};
-    const gasOracleType: ChainMap<GasOracleContractType> = {};
     for (const remote of chains) {
       if (chain === remote) continue;
       // TODO: accurate estimate of gas from ChainMap<ISMConfig>
@@ -384,14 +386,14 @@ export function buildIgpConfigMap(
         threshold,
         validatorsLength,
       );
-      gasOracleType[remote] = GasOracleContractType.StorageGasOracle;
     }
     configMap[chain] = {
+      type: HookType.INTERCHAIN_GAS_PAYMASTER,
       owner,
       beneficiary: owner,
-      gasOracleType,
       overhead,
       oracleKey: owner,
+      oracleConfig: {},
     };
   }
   return configMap;

--- a/typescript/cli/src/tests/hooks.test.ts
+++ b/typescript/cli/src/tests/hooks.test.ts
@@ -1,19 +1,14 @@
 import { expect } from 'chai';
 
-import {
-  ChainMap,
-  GasOracleContractType,
-  HookType,
-  HooksConfig,
-} from '@hyperlane-xyz/sdk';
+import { HookType } from '@hyperlane-xyz/sdk';
 
-import { readHooksConfigMap } from '../config/hooks.js';
+import { HooksConfigMap, readHooksConfigMap } from '../config/hooks.js';
 
 describe('readHooksConfigMap', () => {
   it('parses and validates example correctly', () => {
     const hooks = readHooksConfigMap('examples/hooks.yaml');
 
-    const exampleHooksConfig: ChainMap<HooksConfig> = {
+    const exampleHooksConfig: HooksConfigMap = {
       anvil1: {
         required: {
           type: HookType.PROTOCOL_FEE,
@@ -37,10 +32,13 @@ describe('readHooksConfigMap', () => {
                   beneficiary: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
                   owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
                   oracleKey: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-                  gasOracleType: {
-                    anvil2: GasOracleContractType.StorageGasOracle,
-                  },
                   overhead: { anvil2: 50000 },
+                  oracleConfig: {
+                    anvil2: {
+                      gasPrice: '1000000000000000000',
+                      tokenExchangeRate: '1000000000000000000',
+                    },
+                  },
                 },
               ],
             },
@@ -70,10 +68,13 @@ describe('readHooksConfigMap', () => {
                   beneficiary: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
                   owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
                   oracleKey: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-                  gasOracleType: {
-                    anvil1: GasOracleContractType.StorageGasOracle,
-                  },
                   overhead: { anvil1: 50000 },
+                  oracleConfig: {
+                    anvil1: {
+                      gasPrice: '1000000000000000000',
+                      tokenExchangeRate: '1000000000000000000',
+                    },
+                  },
                 },
               ],
             },
@@ -87,6 +88,6 @@ describe('readHooksConfigMap', () => {
   it('parsing failure, missing internal key "overhead"', () => {
     expect(() => {
       readHooksConfigMap('src/tests/hooks/safe-parse-fail.yaml');
-    }).to.throw('Invalid hook config: anvil2,default => Invalid input');
+    }).to.throw();
   });
 });

--- a/typescript/cli/src/tests/hooks/safe-parse-fail.yaml
+++ b/typescript/cli/src/tests/hooks/safe-parse-fail.yaml
@@ -19,8 +19,6 @@ anvil1:
             oracleKey: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
             overhead:
               anvil2: 50000
-            gasOracleType:
-              anvil2: StorageGasOracle
 anvil2:
   required:
     type: protocolFee
@@ -40,5 +38,3 @@ anvil2:
             beneficiary: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
             owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
             oracleKey: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
-            gasOracleType:
-              anvil1: StorageGasOracle

--- a/typescript/cli/src/tests/ism.test.ts
+++ b/typescript/cli/src/tests/ism.test.ts
@@ -80,6 +80,8 @@ describe('readIsmConfig', () => {
   it('parsing failure, threshold > modules.length', () => {
     expect(function () {
       readIsmConfig('src/tests/ism/threshold-gt-modules-length-fail.yaml');
-    }).to.throw('Threshold cannot be greater than number of modules');
+    }).to.throw(
+      'Threshold must be less than or equal to the number of modules',
+    );
   });
 });

--- a/typescript/helloworld/src/deploy/deploy.ts
+++ b/typescript/helloworld/src/deploy/deploy.ts
@@ -36,6 +36,9 @@ export class HelloWorldDeployer extends HyperlaneRouterDeployer<
   // Custom contract deployment logic can go here
   // If no custom logic is needed, call deployContract for the router
   async deployContracts(chain: ChainName, config: HelloWorldConfig) {
+    if (typeof config.hook !== 'string') {
+      throw new Error('Hook address must be a string');
+    }
     const router = await this.deployContract(chain, 'router', [
       config.mailbox,
       config.hook ?? ethers.constants.AddressZero,

--- a/typescript/helloworld/src/deploy/deploy.ts
+++ b/typescript/helloworld/src/deploy/deploy.ts
@@ -36,13 +36,11 @@ export class HelloWorldDeployer extends HyperlaneRouterDeployer<
   // Custom contract deployment logic can go here
   // If no custom logic is needed, call deployContract for the router
   async deployContracts(chain: ChainName, config: HelloWorldConfig) {
-    if (typeof config.hook !== 'string') {
-      throw new Error('Hook address must be a string');
-    }
     const router = await this.deployContract(chain, 'router', [
       config.mailbox,
-      config.hook ?? ethers.constants.AddressZero,
+      ethers.constants.AddressZero,
     ]);
+    await super.configureClient(chain, router, config);
     return {
       router,
     };

--- a/typescript/infra/config/environments/mainnet3/core.ts
+++ b/typescript/infra/config/environments/mainnet3/core.ts
@@ -7,7 +7,6 @@ import {
   CoreConfig,
   FallbackRoutingHookConfig,
   HookType,
-  IgpHookConfig,
   IsmType,
   MerkleTreeHookConfig,
   MultisigConfig,
@@ -59,6 +58,7 @@ export const core: ChainMap<CoreConfig> = objMap(owners, (local, owner) => {
 
   const pausableIsm: PausableIsmConfig = {
     type: IsmType.PAUSABLE,
+    paused: false,
     owner: DEPLOYER, // keep pausable hot
   };
 
@@ -72,13 +72,11 @@ export const core: ChainMap<CoreConfig> = objMap(owners, (local, owner) => {
     type: HookType.MERKLE_TREE,
   };
 
-  const igpHook: IgpHookConfig = {
-    type: HookType.INTERCHAIN_GAS_PAYMASTER,
-    ...igp[local],
-  };
+  const igpHook = igp[local];
 
   const pausableHook: PausableHookConfig = {
     type: HookType.PAUSABLE,
+    paused: false,
     owner: DEPLOYER, // keep pausable hot
   };
   const aggregationHooks = objMap(

--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -3,6 +3,7 @@ import { BigNumber, ethers } from 'ethers';
 import {
   ChainMap,
   ChainName,
+  HookType,
   IgpConfig,
   TOKEN_EXCHANGE_RATE_DECIMALS,
   defaultMultisigConfigs,
@@ -57,20 +58,24 @@ const storageGasOracleConfig: AllStorageGasOracleConfigs =
     (local) => remoteOverhead(local),
   );
 
-export const igp: ChainMap<IgpConfig> = objMap(owners, (local, owner) => ({
-  ...owner,
-  ownerOverrides: {
-    ...owner.ownerOverrides,
-    interchainGasPaymaster: DEPLOYER,
-    storageGasOracle: DEPLOYER,
-  },
-  oracleKey: DEPLOYER,
-  beneficiary: DEPLOYER,
-  overhead: Object.fromEntries(
-    exclude(local, supportedChainNames).map((remote) => [
-      remote,
-      remoteOverhead(remote),
-    ]),
-  ),
-  oracleConfig: storageGasOracleConfig[local],
-}));
+export const igp: ChainMap<IgpConfig> = objMap(
+  owners,
+  (local, owner): IgpConfig => ({
+    type: HookType.INTERCHAIN_GAS_PAYMASTER,
+    ...owner,
+    ownerOverrides: {
+      ...owner.ownerOverrides,
+      interchainGasPaymaster: DEPLOYER,
+      storageGasOracle: DEPLOYER,
+    },
+    oracleKey: DEPLOYER,
+    beneficiary: DEPLOYER,
+    overhead: Object.fromEntries(
+      exclude(local, supportedChainNames).map((remote) => [
+        remote,
+        remoteOverhead(remote),
+      ]),
+    ),
+    oracleConfig: storageGasOracleConfig[local],
+  }),
+);

--- a/typescript/infra/config/environments/test/core.ts
+++ b/typescript/infra/config/environments/test/core.ts
@@ -6,7 +6,6 @@ import {
   CoreConfig,
   FallbackRoutingHookConfig,
   HookType,
-  IgpHookConfig,
   IsmType,
   MerkleTreeHookConfig,
   ProtocolFeeHookConfig,
@@ -34,10 +33,7 @@ export const core: ChainMap<CoreConfig> = objMap(owners, (local, owner) => {
     type: HookType.MERKLE_TREE,
   };
 
-  const igpHook: IgpHookConfig = {
-    type: HookType.INTERCHAIN_GAS_PAYMASTER,
-    ...igp[local],
-  };
+  const igpHook = igp[local];
 
   const aggregationHook: AggregationHookConfig = {
     type: HookType.AGGREGATION,

--- a/typescript/infra/config/environments/test/igp.ts
+++ b/typescript/infra/config/environments/test/igp.ts
@@ -1,7 +1,6 @@
 import {
   ChainMap,
-  ChainName,
-  GasOracleContractType,
+  HookType,
   IgpConfig,
   multisigIsmVerificationCost,
 } from '@hyperlane-xyz/sdk';
@@ -11,30 +10,25 @@ import { testChainNames } from './chains.js';
 import { multisigIsm } from './multisigIsm.js';
 import { owners } from './owners.js';
 
-function getGasOracles(local: ChainName) {
-  return Object.fromEntries(
-    exclude(local, testChainNames).map((name) => [
-      name,
-      GasOracleContractType.StorageGasOracle,
-    ]),
-  );
-}
-
-export const igp: ChainMap<IgpConfig> = objMap(owners, (chain, ownerConfig) => {
-  const overhead = Object.fromEntries(
-    exclude(chain, testChainNames).map((remote) => [
-      remote,
-      multisigIsmVerificationCost(
-        multisigIsm[remote].threshold,
-        multisigIsm[remote].validators.length,
-      ),
-    ]),
-  );
-  return {
-    oracleKey: ownerConfig.owner as Address, // owner can be AccountConfig
-    beneficiary: ownerConfig.owner as Address, // same as above
-    gasOracleType: getGasOracles(chain),
-    overhead,
-    ...ownerConfig,
-  };
-});
+export const igp: ChainMap<IgpConfig> = objMap(
+  owners,
+  (chain, ownerConfig): IgpConfig => {
+    const overhead = Object.fromEntries(
+      exclude(chain, testChainNames).map((remote) => [
+        remote,
+        multisigIsmVerificationCost(
+          multisigIsm[remote].threshold,
+          multisigIsm[remote].validators.length,
+        ),
+      ]),
+    );
+    return {
+      type: HookType.INTERCHAIN_GAS_PAYMASTER,
+      oracleKey: ownerConfig.owner as Address, // owner can be AccountConfig
+      beneficiary: ownerConfig.owner as Address, // same as above
+      overhead,
+      oracleConfig: {},
+      ...ownerConfig,
+    };
+  },
+);

--- a/typescript/infra/config/environments/testnet4/core.ts
+++ b/typescript/infra/config/environments/testnet4/core.ts
@@ -7,7 +7,6 @@ import {
   CoreConfig,
   FallbackRoutingHookConfig,
   HookType,
-  IgpHookConfig,
   IsmType,
   MerkleTreeHookConfig,
   MultisigConfig,
@@ -61,6 +60,7 @@ export const core: ChainMap<CoreConfig> = objMap(
 
     const pausableIsm: PausableIsmConfig = {
       type: IsmType.PAUSABLE,
+      paused: false,
       ...ownerConfig,
     };
 
@@ -74,13 +74,11 @@ export const core: ChainMap<CoreConfig> = objMap(
       type: HookType.MERKLE_TREE,
     };
 
-    const igpHook: IgpHookConfig = {
-      type: HookType.INTERCHAIN_GAS_PAYMASTER,
-      ...igp[local],
-    };
+    const igpHook = igp[local];
 
     const pausableHook: PausableHookConfig = {
       type: HookType.PAUSABLE,
+      paused: false,
       ...ownerConfig,
     };
 

--- a/typescript/infra/config/environments/testnet4/igp.ts
+++ b/typescript/infra/config/environments/testnet4/igp.ts
@@ -1,5 +1,6 @@
 import {
   ChainMap,
+  HookType,
   IgpConfig,
   defaultMultisigConfigs,
   multisigIsmVerificationCost,
@@ -10,21 +11,25 @@ import { storageGasOracleConfig } from './gas-oracle.js';
 import { owners } from './owners.js';
 import { supportedChainNames } from './supportedChainNames.js';
 
-export const igp: ChainMap<IgpConfig> = objMap(owners, (chain, ownerConfig) => {
-  return {
-    ...ownerConfig,
-    oracleKey: ownerConfig.owner as Address,
-    beneficiary: ownerConfig.owner as Address,
-    oracleConfig: storageGasOracleConfig[chain],
-    overhead: Object.fromEntries(
-      exclude(chain, supportedChainNames).map((remote) => [
-        remote,
-        multisigIsmVerificationCost(
-          // TODO: parameterize this
-          defaultMultisigConfigs[remote].threshold,
-          defaultMultisigConfigs[remote].validators.length,
-        ),
-      ]),
-    ),
-  };
-});
+export const igp: ChainMap<IgpConfig> = objMap(
+  owners,
+  (chain, ownerConfig): IgpConfig => {
+    return {
+      type: HookType.INTERCHAIN_GAS_PAYMASTER,
+      ...ownerConfig,
+      oracleKey: ownerConfig.owner as Address,
+      beneficiary: ownerConfig.owner as Address,
+      oracleConfig: storageGasOracleConfig[chain],
+      overhead: Object.fromEntries(
+        exclude(chain, supportedChainNames).map((remote) => [
+          remote,
+          multisigIsmVerificationCost(
+            // TODO: parameterize this
+            defaultMultisigConfigs[remote].threshold,
+            defaultMultisigConfigs[remote].validators.length,
+          ),
+        ]),
+      ),
+    };
+  },
+);

--- a/typescript/infra/scripts/check-deploy.ts
+++ b/typescript/infra/scripts/check-deploy.ts
@@ -10,7 +10,6 @@ import {
   InterchainAccountChecker,
   InterchainQuery,
   InterchainQueryChecker,
-  resolveOrDeployAccountOwner,
 } from '@hyperlane-xyz/sdk';
 
 import { Contexts } from '../config/contexts.js';
@@ -53,11 +52,7 @@ async function check() {
         [fork]: { blocks: { confirmations: 0 } },
       });
 
-      const owner = await resolveOrDeployAccountOwner(
-        multiProvider,
-        fork,
-        envConfig.core[fork].owner,
-      );
+      const owner = envConfig.core[fork].owner;
       const signer = await impersonateAccount(owner, 1e18);
 
       multiProvider.setSigner(fork, signer);

--- a/typescript/infra/scripts/deploy.ts
+++ b/typescript/infra/scripts/deploy.ts
@@ -7,7 +7,6 @@ import {
   ChainMap,
   ContractVerifier,
   ExplorerLicenseType,
-  FallbackRoutingHookConfig,
   HypERC20Deployer,
   HyperlaneCoreDeployer,
   HyperlaneDeployer,
@@ -25,7 +24,6 @@ import { objMap } from '@hyperlane-xyz/utils';
 
 import { Contexts } from '../config/contexts.js';
 import { core as coreConfig } from '../config/environments/mainnet3/core.js';
-import { DEPLOYER } from '../config/environments/mainnet3/owners.js';
 import { getEnvAddresses } from '../config/registry.js';
 import { getWarpConfig } from '../config/warp.js';
 import { deployWithArtifacts } from '../src/deployment/deploy.js';
@@ -198,11 +196,7 @@ async function main() {
     );
     // Config is intended to be changed for ad-hoc use cases:
     config = {
-      ethereum: {
-        ...(coreConfig.ethereum.defaultHook as FallbackRoutingHookConfig)
-          .domains.ancient8,
-        owner: DEPLOYER,
-      },
+      ethereum: coreConfig.ethereum.defaultHook,
     };
   } else {
     console.log(`Skipping ${module}, deployer unimplemented`);

--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -13,7 +13,6 @@ import {
   ProviderType,
   RpcConsensusType,
   TypedTransactionReceipt,
-  resolveOrDeployAccountOwner,
 } from '@hyperlane-xyz/sdk';
 import {
   Address,
@@ -248,12 +247,11 @@ async function main(): Promise<boolean> {
   }
 
   chains.map(async (chain) => {
-    const owner = await resolveOrDeployAccountOwner(
-      multiProvider,
+    return updateWalletBalanceMetricFor(
+      app,
       chain,
       coreConfig.owners[chain].owner,
     );
-    return updateWalletBalanceMetricFor(app, chain, owner);
   });
 
   // Incremented each time an entire cycle has occurred
@@ -372,11 +370,7 @@ async function main(): Promise<boolean> {
       messagesSendCount.labels({ ...labels, status: 'failure' }).inc();
       errorOccurred = true;
     }
-    const owner = await resolveOrDeployAccountOwner(
-      multiProvider,
-      origin,
-      coreConfig.owners[origin].owner,
-    );
+    const owner = coreConfig.owners[origin].owner;
     updateWalletBalanceMetricFor(app, origin, owner).catch((e) => {
       logger.warn('Failed to update wallet balance for chain', {
         chain: origin,

--- a/typescript/infra/test/govern.hardhat-test.ts
+++ b/typescript/infra/test/govern.hardhat-test.ts
@@ -26,7 +26,6 @@ import {
   TestChainName,
   TestCoreApp,
   TestCoreDeployer,
-  resolveOrDeployAccountOwner,
 } from '@hyperlane-xyz/sdk';
 import { Address, CallData, eqAddress } from '@hyperlane-xyz/utils';
 
@@ -134,11 +133,7 @@ describe('ICA governance', async () => {
       localRouter: remote.address,
     };
 
-    accountOwner = await resolveOrDeployAccountOwner(
-      multiProvider,
-      remoteChain,
-      accountConfig,
-    );
+    accountOwner = await icaApp.deployAccount(remoteChain, accountConfig);
 
     const recipientF = new TestRecipient__factory(signer);
     recipient = await recipientF.deploy();

--- a/typescript/sdk/src/core/CoreDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/core/CoreDeployer.hardhat-test.ts
@@ -8,7 +8,7 @@ import { objMap, promiseObjAll } from '@hyperlane-xyz/utils';
 import { TestChainName, testChains } from '../consts/testChains.js';
 import { HyperlaneContractsMap } from '../contracts/types.js';
 import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDeployer.js';
-import { HookConfig } from '../hook/types.js';
+import { DerivedHookConfig } from '../hook/EvmHookReader.js';
 import { DerivedIsmConfig } from '../ism/EvmIsmReader.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { AggregationIsmConfig, IsmType } from '../ism/types.js';
@@ -159,9 +159,9 @@ describe('core', async () => {
 
           // Cast because we don't expect the 'string' type
           const defaultHookOnchain =
-            coreConfigOnChain.defaultHook as HookConfig;
+            coreConfigOnChain.defaultHook as DerivedHookConfig;
           const defaultHookTest = coreConfig[chainName]
-            .defaultHook as HookConfig;
+            .defaultHook as DerivedHookConfig;
 
           expect(defaultHookOnchain.type).to.be.equal(defaultHookTest.type);
         }),

--- a/typescript/sdk/src/core/CoreDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/core/CoreDeployer.hardhat-test.ts
@@ -145,7 +145,7 @@ describe('core', async () => {
           const defaultIsmTest = coreConfig[chainName]
             .defaultIsm as DerivedIsmConfig;
 
-          expect(defaultIsmOnchain.type).to.be.equal(defaultIsmTest.type);
+          expect(defaultIsmOnchain).to.deep.equal(defaultIsmTest);
         }),
       );
     });
@@ -163,7 +163,7 @@ describe('core', async () => {
           const defaultHookTest = coreConfig[chainName]
             .defaultHook as DerivedHookConfig;
 
-          expect(defaultHookOnchain.type).to.be.equal(defaultHookTest.type);
+          expect(defaultHookOnchain).to.deep.equal(defaultHookTest);
         }),
       );
     });
@@ -177,10 +177,7 @@ describe('core', async () => {
           const requiredHookOnchain = coreConfigOnChain.requiredHook;
           const requiredHookTest = coreConfig[chainName].requiredHook;
 
-          // Test all the fields
-          objMap(requiredHookTest, (key, value) => {
-            expect(requiredHookOnchain[key]).to.be.equal(value);
-          });
+          expect(requiredHookOnchain).to.deep.equal(requiredHookTest);
         }),
       );
     });

--- a/typescript/sdk/src/core/CoreDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/core/CoreDeployer.hardhat-test.ts
@@ -140,7 +140,7 @@ describe('core', async () => {
           );
 
           // Cast because we don't expect the 'string' type
-          const defaultIsmOnchain =
+          const { address: _, ...defaultIsmOnchain } =
             coreConfigOnChain.defaultIsm as DerivedIsmConfig;
           const defaultIsmTest = coreConfig[chainName]
             .defaultIsm as DerivedIsmConfig;
@@ -158,7 +158,7 @@ describe('core', async () => {
           );
 
           // Cast because we don't expect the 'string' type
-          const defaultHookOnchain =
+          const { address: _, ...defaultHookOnchain } =
             coreConfigOnChain.defaultHook as DerivedHookConfig;
           const defaultHookTest = coreConfig[chainName]
             .defaultHook as DerivedHookConfig;
@@ -174,7 +174,8 @@ describe('core', async () => {
             chainName,
             contract.mailbox.address,
           );
-          const requiredHookOnchain = coreConfigOnChain.requiredHook;
+          const { address: _, ...requiredHookOnchain } =
+            coreConfigOnChain.requiredHook as DerivedHookConfig;
           const requiredHookTest = coreConfig[chainName].requiredHook;
 
           expect(requiredHookOnchain).to.deep.equal(requiredHookTest);

--- a/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
@@ -1,5 +1,6 @@
 import {
   IPostDispatchHook,
+  IPostDispatchHook__factory,
   Mailbox,
   TestRecipient,
   ValidatorAnnounce,
@@ -139,7 +140,7 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       await this.configureHook(
         chain,
         mailbox,
-        defaultHook,
+        defaultHook.address,
         (_mailbox) => _mailbox.defaultHook(),
         (_mailbox, _hook) =>
           _mailbox.populateTransaction.setDefaultHook(_hook, { ...overrides }),
@@ -148,7 +149,7 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       await this.configureHook(
         chain,
         mailbox,
-        requiredHook,
+        requiredHook.address,
         (_mailbox) => _mailbox.requiredHook(),
         (_mailbox, _hook) =>
           _mailbox.populateTransaction.setRequiredHook(_hook, { ...overrides }),
@@ -184,6 +185,13 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
     config: HookConfig,
     coreAddresses: Partial<CoreAddresses>,
   ): Promise<IPostDispatchHook> {
+    if (typeof config === 'string') {
+      return IPostDispatchHook__factory.connect(
+        config,
+        this.multiProvider.getProvider(chain),
+      );
+    }
+
     const hooks = await this.hookDeployer.deployContracts(
       chain,
       config,

--- a/typescript/sdk/src/core/schemas.ts
+++ b/typescript/sdk/src/core/schemas.ts
@@ -1,0 +1,9 @@
+import { HookConfigSchema } from '../hook/schemas.js';
+import { IsmConfigSchema } from '../ism/schemas.js';
+import { OwnableSchema } from '../schemas.js';
+
+export const CoreConfigSchema = OwnableSchema.extend({
+  defaultIsm: IsmConfigSchema,
+  defaultHook: HookConfigSchema,
+  requiredHook: HookConfigSchema,
+});

--- a/typescript/sdk/src/core/types.ts
+++ b/typescript/sdk/src/core/types.ts
@@ -1,18 +1,16 @@
+import { z } from 'zod';
+
 import type { Mailbox } from '@hyperlane-xyz/core';
 import type { Address, ParsedMessage } from '@hyperlane-xyz/utils';
 
 import type { UpgradeConfig } from '../deploy/proxy.js';
-import type { CheckerViolation, OwnableConfig } from '../deploy/types.js';
-import { HookConfig } from '../hook/types.js';
+import type { CheckerViolation } from '../deploy/types.js';
 import type { IsmConfig } from '../ism/types.js';
 import type { ChainName } from '../types.js';
 
-import { CoreFactories } from './contracts.js';
+import { CoreConfigSchema } from './schemas.js';
 
-export type CoreConfig = OwnableConfig<keyof CoreFactories> & {
-  defaultIsm: IsmConfig;
-  defaultHook: HookConfig;
-  requiredHook: HookConfig;
+export type CoreConfig = z.infer<typeof CoreConfigSchema> & {
   remove?: boolean;
   upgrade?: UpgradeConfig;
 };

--- a/typescript/sdk/src/deploy/HyperlaneAppChecker.ts
+++ b/typescript/sdk/src/deploy/HyperlaneAppChecker.ts
@@ -21,12 +21,10 @@ import {
   AccessControlViolation,
   BytecodeMismatchViolation,
   CheckerViolation,
-  Owner,
   OwnerViolation,
   ProxyAdminViolation,
   TimelockControllerViolation,
   ViolationType,
-  resolveOrDeployAccountOwner,
 } from './types.js';
 
 export abstract class HyperlaneAppChecker<
@@ -208,19 +206,12 @@ export abstract class HyperlaneAppChecker<
 
   protected async checkOwnership(
     chain: ChainName,
-    owner: Owner,
+    owner: Address,
     ownableOverrides?: Record<string, Address>,
   ): Promise<void> {
     const ownableContracts = await this.ownables(chain);
     for (const [name, contract] of Object.entries(ownableContracts)) {
       let expectedOwner = ownableOverrides?.[name] ?? owner;
-      if (typeof expectedOwner !== 'string') {
-        expectedOwner = await resolveOrDeployAccountOwner(
-          this.multiProvider,
-          chain,
-          expectedOwner,
-        );
-      }
       const actual = await contract.owner();
       if (!eqAddress(actual, expectedOwner)) {
         const violation: OwnerViolation = {

--- a/typescript/sdk/src/deploy/HyperlaneAppChecker.ts
+++ b/typescript/sdk/src/deploy/HyperlaneAppChecker.ts
@@ -211,7 +211,7 @@ export abstract class HyperlaneAppChecker<
   ): Promise<void> {
     const ownableContracts = await this.ownables(chain);
     for (const [name, contract] of Object.entries(ownableContracts)) {
-      let expectedOwner = ownableOverrides?.[name] ?? owner;
+      const expectedOwner = ownableOverrides?.[name] ?? owner;
       const actual = await contract.owner();
       if (!eqAddress(actual, expectedOwner)) {
         const violation: OwnerViolation = {

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -2,8 +2,6 @@ import { Contract, PopulatedTransaction, ethers } from 'ethers';
 import { Logger } from 'pino';
 
 import {
-  IPostDispatchHook,
-  IPostDispatchHook__factory,
   ITransparentUpgradeableProxy,
   MailboxClient,
   Ownable,
@@ -28,6 +26,7 @@ import {
   HyperlaneContractsMap,
   HyperlaneFactories,
 } from '../contracts/types.js';
+import { HookConfig } from '../hook/types.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { IsmConfig } from '../ism/types.js';
 import { moduleMatchesConfig } from '../ism/utils.js';
@@ -64,7 +63,7 @@ export interface DeployerOptions {
 }
 
 export abstract class HyperlaneDeployer<
-  Config extends object,
+  Config,
   Factories extends HyperlaneFactories,
 > {
   public verificationInputs: ChainMap<ContractVerificationInput[]> = {};
@@ -291,32 +290,31 @@ export abstract class HyperlaneDeployer<
   protected async configureHook<C extends Ownable>(
     chain: ChainName,
     contract: C,
-    targetHook: IPostDispatchHook,
+    config: HookConfig,
     getHook: (contract: C) => Promise<Address>,
     setHook: (contract: C, hook: Address) => Promise<PopulatedTransaction>,
   ): Promise<void> {
+    if (typeof config !== 'string') {
+      throw new Error('Legacy deployer does not support hook objects');
+    }
+
     const configuredHook = await getHook(contract);
-    if (!eqAddress(targetHook.address, configuredHook)) {
-      const result = await this.runIfOwner(chain, contract, async () => {
+    if (!eqAddress(config, configuredHook)) {
+      await this.runIfOwner(chain, contract, async () => {
         this.logger.debug(
-          `Set hook on ${chain} to ${targetHook.address}, currently is ${configuredHook}`,
+          `Set hook on ${chain} to ${config}, currently is ${configuredHook}`,
         );
         await this.multiProvider.sendTransaction(
           chain,
-          setHook(contract, targetHook.address),
+          setHook(contract, config),
         );
         const actualHook = await getHook(contract);
-        if (!eqAddress(targetHook.address, actualHook)) {
+        if (!eqAddress(config, actualHook)) {
           throw new Error(
-            `Set hook failed on ${chain}, wanted ${targetHook.address}, got ${actualHook}`,
+            `Set hook failed on ${chain}, wanted ${config}, got ${actualHook}`,
           );
         }
-        return true;
       });
-      // if the signer is not the owner, saving the hook address in the artifacts for later use for sending test messages, etc
-      if (!result) {
-        this.addDeployedContracts(chain, { customHook: targetHook });
-      }
     }
   }
 
@@ -332,10 +330,7 @@ export abstract class HyperlaneDeployer<
       await this.configureHook(
         local,
         client,
-        IPostDispatchHook__factory.connect(
-          config.hook,
-          this.multiProvider.getSignerOrProvider(local),
-        ),
+        config.hook,
         (_client) => _client.hook(),
         (_client, _hook) => _client.populateTransaction.setHook(_hook),
       );
@@ -719,10 +714,10 @@ export abstract class HyperlaneDeployer<
     return ret;
   }
 
-  async transferOwnershipOfContracts<K extends keyof Factories>(
+  async transferOwnershipOfContracts(
     chain: ChainName,
-    config: OwnableConfig<K>,
-    ownables: Partial<Record<K, Ownable>>,
+    config: OwnableConfig,
+    ownables: Partial<Record<string, Ownable>>,
   ): Promise<ethers.ContractReceipt[]> {
     const receipts: ethers.ContractReceipt[] = [];
     for (const [contractName, ownable] of Object.entries<Ownable | undefined>(
@@ -732,7 +727,7 @@ export abstract class HyperlaneDeployer<
         continue;
       }
       const current = await ownable.owner();
-      const owner = config.ownerOverrides?.[contractName as K] ?? config.owner;
+      const owner = config.ownerOverrides?.[contractName] ?? config.owner;
       if (!eqAddress(current, owner)) {
         this.logger.debug(
           { contractName, current, desiredOwner: owner },

--- a/typescript/sdk/src/deploy/types.ts
+++ b/typescript/sdk/src/deploy/types.ts
@@ -8,44 +8,10 @@ import type {
 } from '@hyperlane-xyz/core';
 import { Address } from '@hyperlane-xyz/utils';
 
-import { deployInterchainAccount } from '../middleware/account/InterchainAccount.js';
-import { AccountConfig } from '../middleware/account/types.js';
-import { MultiProvider } from '../providers/MultiProvider.js';
+import { OwnableSchema } from '../schemas.js';
 import type { ChainName } from '../types.js';
 
-import { OwnableConfigSchema } from './schemas.js';
-
-export type Owner = Address | AccountConfig;
-
-/**
- * @remarks ownerOverrides is added outside of the Schema because zod handle generics in a weird way (uses functions)
- * @see https://stackoverflow.com/questions/74907523/creating-zod-schema-for-generic-interface
- */
-export type OwnableConfig<Keys extends PropertyKey = PropertyKey> = z.infer<
-  typeof OwnableConfigSchema
-> & {
-  ownerOverrides?: Partial<Record<Keys, Address>>;
-};
-
-export async function resolveOrDeployAccountOwner(
-  multiProvider: MultiProvider,
-  chain: ChainName,
-  owner: Owner,
-): Promise<Address> {
-  if (typeof owner === 'string') {
-    return owner;
-  } else {
-    if (!owner.localRouter) {
-      throw new Error('localRouter is required for AccountConfig');
-    }
-    // submits a transaction to deploy an interchain account if the owner is an AccountConfig and the ICA isn't not deployed yet
-    return deployInterchainAccount(multiProvider, chain, owner);
-  }
-}
-
-export function isOwnableConfig(config: object): config is OwnableConfig {
-  return 'owner' in config;
-}
+export type OwnableConfig = z.infer<typeof OwnableSchema>;
 
 export interface CheckerViolation {
   chain: ChainName;

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -15,7 +15,10 @@ import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainName } from '../types.js';
 
 import { IgpFactories, igpFactories } from './contracts.js';
-import { bignumberify, serializeDifference } from './oracle/types.js';
+import {
+  oracleConfigToOracleData,
+  serializeDifference,
+} from './oracle/types.js';
 import { IgpConfig } from './types.js';
 
 export class HyperlaneIgpDeployer extends HyperlaneDeployer<
@@ -120,7 +123,7 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
 
       const actual = await gasOracle.remoteGasData(remoteDomain);
 
-      const desiredData = bignumberify(desired);
+      const desiredData = oracleConfigToOracleData(desired);
 
       if (
         !actual.gasPrice.eq(desired.gasPrice) ||

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -15,7 +15,7 @@ import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainName } from '../types.js';
 
 import { IgpFactories, igpFactories } from './contracts.js';
-import { serializeDifference } from './oracle/types.js';
+import { bignumberify, serializeDifference } from './oracle/types.js';
 import { IgpConfig } from './types.js';
 
 export class HyperlaneIgpDeployer extends HyperlaneDeployer<
@@ -120,22 +120,24 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
 
       const actual = await gasOracle.remoteGasData(remoteDomain);
 
+      const desiredData = bignumberify(desired);
+
       if (
         !actual.gasPrice.eq(desired.gasPrice) ||
         !actual.tokenExchangeRate.eq(desired.tokenExchangeRate)
       ) {
         this.logger.info(
-          `${chain} -> ${remote}: ${serializeDifference(actual, desired)}`,
+          `${chain} -> ${remote}: ${serializeDifference(actual, desiredData)}`,
         );
         configsToSet.push({
           remoteDomain,
-          ...desired,
+          ...desiredData,
         });
       }
 
       const exampleRemoteGas = (config.overhead[remote] ?? 200_000) + 50_000;
-      const exampleRemoteGasCost = desired.tokenExchangeRate
-        .mul(desired.gasPrice)
+      const exampleRemoteGasCost = desiredData.tokenExchangeRate
+        .mul(desiredData.gasPrice)
         .mul(exampleRemoteGas)
         .div(TOKEN_EXCHANGE_RATE_SCALE);
       this.logger.info(

--- a/typescript/sdk/src/gas/oracle/configure-gas-oracles.hardhat-test.ts
+++ b/typescript/sdk/src/gas/oracle/configure-gas-oracles.hardhat-test.ts
@@ -11,7 +11,7 @@ import { ChainMap } from '../../types.js';
 import { HyperlaneIgpDeployer } from '../HyperlaneIgpDeployer.js';
 import { IgpConfig } from '../types.js';
 
-import { bignumberify } from './types.js';
+import { oracleConfigToOracleData } from './types.js';
 
 describe('HyperlaneIgpDeployer', () => {
   const local = TestChainName.test1;
@@ -38,7 +38,9 @@ describe('HyperlaneIgpDeployer', () => {
     expect({
       gasPrice: deployedConfig.gasPrice,
       tokenExchangeRate: deployedConfig.tokenExchangeRate,
-    }).to.deep.equal(bignumberify(testConfig[local].oracleConfig![remote]));
+    }).to.deep.equal(
+      oracleConfigToOracleData(testConfig[local].oracleConfig![remote]),
+    );
   });
 
   it('should configure new oracle config', async () => {
@@ -57,6 +59,8 @@ describe('HyperlaneIgpDeployer', () => {
     expect({
       gasPrice: modifiedConfig.gasPrice,
       tokenExchangeRate: modifiedConfig.tokenExchangeRate,
-    }).to.deep.equal(bignumberify(testConfig[local].oracleConfig![remote]));
+    }).to.deep.equal(
+      oracleConfigToOracleData(testConfig[local].oracleConfig![remote]),
+    );
   });
 });

--- a/typescript/sdk/src/gas/oracle/configure-gas-oracles.hardhat-test.ts
+++ b/typescript/sdk/src/gas/oracle/configure-gas-oracles.hardhat-test.ts
@@ -11,6 +11,8 @@ import { ChainMap } from '../../types.js';
 import { HyperlaneIgpDeployer } from '../HyperlaneIgpDeployer.js';
 import { IgpConfig } from '../types.js';
 
+import { bignumberify } from './types.js';
+
 describe('HyperlaneIgpDeployer', () => {
   const local = TestChainName.test1;
   const remote = TestChainName.test2;
@@ -36,13 +38,13 @@ describe('HyperlaneIgpDeployer', () => {
     expect({
       gasPrice: deployedConfig.gasPrice,
       tokenExchangeRate: deployedConfig.tokenExchangeRate,
-    }).to.deep.equal(testConfig[local].oracleConfig![remote]);
+    }).to.deep.equal(bignumberify(testConfig[local].oracleConfig![remote]));
   });
 
   it('should configure new oracle config', async () => {
     testConfig[local].oracleConfig![remote] = {
-      tokenExchangeRate: utils.parseUnits('2', 'gwei'),
-      gasPrice: utils.parseUnits('3', 'gwei'),
+      tokenExchangeRate: utils.parseUnits('2', 'gwei').toString(),
+      gasPrice: utils.parseUnits('3', 'gwei').toString(),
     };
 
     const localContracts = await deployer.deployContracts(
@@ -55,6 +57,6 @@ describe('HyperlaneIgpDeployer', () => {
     expect({
       gasPrice: modifiedConfig.gasPrice,
       tokenExchangeRate: modifiedConfig.tokenExchangeRate,
-    }).to.deep.equal(testConfig[local].oracleConfig![remote]);
+    }).to.deep.equal(bignumberify(testConfig[local].oracleConfig![remote]));
   });
 });

--- a/typescript/sdk/src/gas/oracle/types.ts
+++ b/typescript/sdk/src/gas/oracle/types.ts
@@ -47,7 +47,10 @@ const serializePercentDifference = (
   return diff.isNegative() ? `${diff.toString()}%` : `+${diff.toString()}%`;
 };
 
-export const bignumberify = (config: StorageGasOracleConfig): OracleData => ({
+// TODO: replace once #3771 is fixed
+export const oracleConfigToOracleData = (
+  config: StorageGasOracleConfig,
+): OracleData => ({
   gasPrice: ethers.BigNumber.from(config.gasPrice),
   tokenExchangeRate: ethers.BigNumber.from(config.tokenExchangeRate),
 });

--- a/typescript/sdk/src/gas/oracle/types.ts
+++ b/typescript/sdk/src/gas/oracle/types.ts
@@ -1,21 +1,25 @@
 import { ethers } from 'ethers';
-
-import { StorageGasOracle } from '@hyperlane-xyz/core';
+import { z } from 'zod';
 
 import { TOKEN_EXCHANGE_RATE_DECIMALS } from '../../consts/igp.js';
 
-export enum GasOracleContractType {
-  StorageGasOracle = 'StorageGasOracle',
-}
+export const StorageGasOracleConfigSchema = z.object({
+  gasPrice: z.string(),
+  tokenExchangeRate: z.string(),
+});
 
 // Gas data to configure on a single destination chain.
-export type StorageGasOracleConfig = Pick<
-  StorageGasOracle.RemoteGasDataConfigStructOutput,
-  'gasPrice' | 'tokenExchangeRate'
+export type StorageGasOracleConfig = z.output<
+  typeof StorageGasOracleConfigSchema
 >;
 
+export type OracleData = {
+  tokenExchangeRate: ethers.BigNumber;
+  gasPrice: ethers.BigNumber;
+};
+
 export const formatGasOracleConfig = (
-  config: StorageGasOracleConfig,
+  config: OracleData,
 ): {
   tokenExchangeRate: string;
   gasPrice: string;
@@ -43,9 +47,14 @@ const serializePercentDifference = (
   return diff.isNegative() ? `${diff.toString()}%` : `+${diff.toString()}%`;
 };
 
+export const bignumberify = (config: StorageGasOracleConfig): OracleData => ({
+  gasPrice: ethers.BigNumber.from(config.gasPrice),
+  tokenExchangeRate: ethers.BigNumber.from(config.tokenExchangeRate),
+});
+
 export const serializeDifference = (
-  actual: StorageGasOracleConfig,
-  expected: StorageGasOracleConfig,
+  actual: OracleData,
+  expected: OracleData,
 ): string => {
   const gasPriceDiff = serializePercentDifference(
     actual.gasPrice,

--- a/typescript/sdk/src/gas/types.ts
+++ b/typescript/sdk/src/gas/types.ts
@@ -1,26 +1,14 @@
 import { BigNumber } from 'ethers';
+import { z } from 'zod';
 
 import { InterchainGasPaymaster } from '@hyperlane-xyz/core';
 import type { Address } from '@hyperlane-xyz/utils';
 
-import type { CheckerViolation, OwnableConfig } from '../deploy/types.js';
+import type { CheckerViolation } from '../deploy/types.js';
+import { IgpSchema } from '../hook/schemas.js';
 import { ChainMap } from '../types.js';
 
-import { IgpFactories } from './contracts.js';
-import {
-  GasOracleContractType,
-  StorageGasOracleConfig,
-} from './oracle/types.js';
-
-export type IgpConfig = OwnableConfig<keyof IgpFactories> & {
-  beneficiary: Address;
-  oracleKey: Address;
-  overhead: ChainMap<number>;
-  // TODO: require this
-  oracleConfig?: ChainMap<StorageGasOracleConfig>;
-  // DEPRECATED
-  gasOracleType?: ChainMap<GasOracleContractType>;
-};
+export type IgpConfig = z.infer<typeof IgpSchema>;
 
 export enum IgpViolationType {
   Beneficiary = 'Beneficiary',

--- a/typescript/sdk/src/hook/EvmHookReader.test.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { ethers } from 'ethers';
+import { randomBytes } from 'ethers/lib/utils.js';
 import sinon from 'sinon';
 
 import {
@@ -117,11 +118,13 @@ describe('EvmHookReader', () => {
   it('should derive pausable config correctly', async () => {
     const mockAddress = generateRandomAddress();
     const mockOwner = generateRandomAddress();
+    const mockPaused = randomBytes(1)[0] % 2 === 0;
 
     // Mocking the connect method + returned what we need from contract object
     const mockContract = {
       hookType: sandbox.stub().resolves(OnchainHookType.PAUSABLE),
       owner: sandbox.stub().resolves(mockOwner),
+      paused: sandbox.stub().resolves(mockPaused),
     };
     sandbox
       .stub(PausableHook__factory, 'connect')
@@ -132,6 +135,7 @@ describe('EvmHookReader', () => {
 
     const expectedConfig: WithAddress<PausableHookConfig> = {
       owner: mockOwner,
+      paused: mockPaused,
       address: mockAddress,
       type: HookType.PAUSABLE,
     };

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -7,6 +7,7 @@ import {
   FallbackDomainRoutingHook__factory,
   IPostDispatchHook__factory,
   InterchainGasPaymaster__factory,
+  MerkleTreeHook__factory,
   OPStackHook__factory,
   PausableHook__factory,
   ProtocolFee__factory,
@@ -41,7 +42,7 @@ import {
   RoutingHookConfig,
 } from './types.js';
 
-export type DerivedHookConfig = WithAddress<Exclude<HookConfig, Address>>;
+export type DerivedHookConfig = WithAddress<HookConfig>;
 
 export interface HookReader {
   deriveHookConfig(address: Address): Promise<WithAddress<HookConfig>>;
@@ -117,8 +118,8 @@ export class EvmHookReader implements HookReader {
   async deriveMerkleTreeConfig(
     address: Address,
   ): Promise<WithAddress<MerkleTreeHookConfig>> {
-    // const hook = MerkleTreeHook__factory.connect(address, this.provider);
-    // assert((await hook.hookType()) === OnchainHookType.MERKLE_TREE);
+    const hook = MerkleTreeHook__factory.connect(address, this.provider);
+    assert((await hook.hookType()) === OnchainHookType.MERKLE_TREE);
 
     return {
       address,
@@ -130,7 +131,7 @@ export class EvmHookReader implements HookReader {
     address: Address,
   ): Promise<WithAddress<AggregationHookConfig>> {
     const hook = StaticAggregationHook__factory.connect(address, this.provider);
-    // assert((await hook.hookType()) === OnchainHookType.AGGREGATION);
+    assert((await hook.hookType()) === OnchainHookType.AGGREGATION);
 
     const hooks = await hook.hooks(ethers.constants.AddressZero);
     const hookConfigs = await concurrentMap(
@@ -151,9 +152,9 @@ export class EvmHookReader implements HookReader {
       address,
       this.provider,
     );
-    // assert(
-    //   (await hook.hookType()) === OnchainHookType.INTERCHAIN_GAS_PAYMASTER,
-    // );
+    assert(
+      (await hook.hookType()) === OnchainHookType.INTERCHAIN_GAS_PAYMASTER,
+    );
 
     const owner = await hook.owner();
     const beneficiary = await hook.beneficiary();
@@ -173,13 +174,10 @@ export class EvmHookReader implements HookReader {
         try {
           const { tokenExchangeRate, gasPrice } =
             await hook.getExchangeRateAndGasPrice(domainId);
-          oracleConfig[chainName] = {
-            tokenExchangeRate: tokenExchangeRate.toString(),
-            gasPrice: gasPrice.toString(),
-          };
           const domainGasOverhead = await hook.destinationGasLimit(domainId, 0);
 
           overhead[chainName] = domainGasOverhead.toNumber();
+          oracleConfig[chainName] = { tokenExchangeRate, gasPrice };
 
           const { gasOracle } = await hook.destinationGasConfigs(domainId);
           const oracle = StorageGasOracle__factory.connect(
@@ -225,7 +223,7 @@ export class EvmHookReader implements HookReader {
     address: Address,
   ): Promise<WithAddress<ProtocolFeeHookConfig>> {
     const hook = ProtocolFee__factory.connect(address, this.provider);
-    // assert((await hook.hookType()) === OnchainHookType.PROTOCOL_FEE);
+    assert((await hook.hookType()) === OnchainHookType.PROTOCOL_FEE);
 
     const owner = await hook.owner();
     const maxProtocolFee = await hook.MAX_PROTOCOL_FEE();
@@ -247,7 +245,7 @@ export class EvmHookReader implements HookReader {
   ): Promise<WithAddress<OpStackHookConfig>> {
     const hook = OPStackHook__factory.connect(address, this.provider);
     const owner = await hook.owner();
-    // assert((await hook.hookType()) === OnchainHookType.ID_AUTH_ISM);
+    assert((await hook.hookType()) === OnchainHookType.ID_AUTH_ISM);
 
     const messengerContract = await hook.l1Messenger();
     const destinationDomain = await hook.destinationDomain();
@@ -267,7 +265,7 @@ export class EvmHookReader implements HookReader {
     address: Address,
   ): Promise<WithAddress<DomainRoutingHookConfig>> {
     const hook = DomainRoutingHook__factory.connect(address, this.provider);
-    // assert((await hook.hookType()) === OnchainHookType.ROUTING);
+    assert((await hook.hookType()) === OnchainHookType.ROUTING);
 
     const owner = await hook.owner();
     const domainHooks = await this.fetchDomainHooks(hook);
@@ -287,7 +285,7 @@ export class EvmHookReader implements HookReader {
       address,
       this.provider,
     );
-    // assert((await hook.hookType()) === OnchainHookType.FALLBACK_ROUTING);
+    assert((await hook.hookType()) === OnchainHookType.FALLBACK_ROUTING);
 
     const owner = await hook.owner();
     const domainHooks = await this.fetchDomainHooks(hook);
@@ -333,11 +331,11 @@ export class EvmHookReader implements HookReader {
     address: Address,
   ): Promise<WithAddress<PausableHookConfig>> {
     const hook = PausableHook__factory.connect(address, this.provider);
-    const paused = await hook.paused();
+    assert((await hook.hookType()) === OnchainHookType.PAUSABLE);
+
     const owner = await hook.owner();
     return {
       owner,
-      paused,
       address,
       type: HookType.PAUSABLE,
     };

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -177,7 +177,10 @@ export class EvmHookReader implements HookReader {
           const domainGasOverhead = await hook.destinationGasLimit(domainId, 0);
 
           overhead[chainName] = domainGasOverhead.toNumber();
-          oracleConfig[chainName] = { tokenExchangeRate, gasPrice };
+          oracleConfig[chainName] = {
+            tokenExchangeRate: tokenExchangeRate.toString(),
+            gasPrice: gasPrice.toString(),
+          };
 
           const { gasOracle } = await hook.destinationGasConfigs(domainId);
           const oracle = StorageGasOracle__factory.connect(
@@ -334,9 +337,11 @@ export class EvmHookReader implements HookReader {
     assert((await hook.hookType()) === OnchainHookType.PAUSABLE);
 
     const owner = await hook.owner();
+    const paused = await hook.paused();
     return {
       owner,
       address,
+      paused,
       type: HookType.PAUSABLE,
     };
   }

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -42,7 +42,7 @@ import {
   RoutingHookConfig,
 } from './types.js';
 
-export type DerivedHookConfig = WithAddress<HookConfig>;
+export type DerivedHookConfig = WithAddress<Exclude<HookConfig, Address>>;
 
 export interface HookReader {
   deriveHookConfig(address: Address): Promise<WithAddress<HookConfig>>;

--- a/typescript/sdk/src/hook/schemas.ts
+++ b/typescript/sdk/src/hook/schemas.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+
+import { StorageGasOracleConfigSchema } from '../gas/oracle/types.js';
+import { ZHash } from '../metadata/customZodTypes.js';
+import { OwnableSchema, PausableSchema } from '../schemas.js';
+
+import {
+  AggregationHookConfig,
+  DomainRoutingHookConfig,
+  FallbackRoutingHookConfig,
+  HookType,
+} from './types.js';
+
+export const ProtocolFeeSchema = OwnableSchema.extend({
+  type: z.literal(HookType.PROTOCOL_FEE),
+  beneficiary: z.string(),
+  maxProtocolFee: z.string(),
+  protocolFee: z.string(),
+});
+
+export const MerkleTreeSchema = z.object({
+  type: z.literal(HookType.MERKLE_TREE),
+});
+
+export const PausableHookSchema = PausableSchema.extend({
+  type: z.literal(HookType.PAUSABLE),
+});
+
+export const OpStackHookSchema = OwnableSchema.extend({
+  type: z.literal(HookType.OP_STACK),
+  nativeBridge: z.string(),
+  destinationChain: z.string(),
+});
+
+export const IgpSchema = OwnableSchema.extend({
+  type: z.literal(HookType.INTERCHAIN_GAS_PAYMASTER),
+  beneficiary: z.string(),
+  oracleKey: z.string(),
+  overhead: z.record(z.number()),
+  oracleConfig: z.record(StorageGasOracleConfigSchema),
+});
+
+export const DomainRoutingHookConfigSchema: z.ZodSchema<DomainRoutingHookConfig> =
+  z.lazy(() =>
+    OwnableSchema.extend({
+      type: z.literal(HookType.ROUTING),
+      domains: z.record(HookConfigSchema),
+    }),
+  );
+
+export const FallbackRoutingHookConfigSchema: z.ZodSchema<FallbackRoutingHookConfig> =
+  z.lazy(() =>
+    OwnableSchema.extend({
+      type: z.literal(HookType.FALLBACK_ROUTING),
+      domains: z.record(HookConfigSchema),
+      fallback: HookConfigSchema,
+    }),
+  );
+
+export const AggregationHookConfigSchema: z.ZodSchema<AggregationHookConfig> =
+  z.lazy(() =>
+    z.object({
+      type: z.literal(HookType.AGGREGATION),
+      hooks: z.array(HookConfigSchema),
+    }),
+  );
+
+export const HookConfigSchema = z.union([
+  ZHash,
+  ProtocolFeeSchema,
+  PausableHookSchema,
+  OpStackHookSchema,
+  MerkleTreeSchema,
+  IgpSchema,
+  DomainRoutingHookConfigSchema,
+  FallbackRoutingHookConfigSchema,
+  AggregationHookConfigSchema,
+]);

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -1,8 +1,16 @@
-import { Address } from '@hyperlane-xyz/utils';
+import { z } from 'zod';
 
 import { OwnableConfig } from '../deploy/types.js';
-import { IgpConfig } from '../gas/types.js';
-import { ChainMap, ChainName } from '../types.js';
+import { ChainMap } from '../types.js';
+
+import {
+  HookConfigSchema,
+  IgpSchema,
+  MerkleTreeSchema,
+  OpStackHookSchema,
+  PausableHookSchema,
+  ProtocolFeeSchema,
+} from './schemas.js';
 
 // As found in IPostDispatchHook.sol
 export enum OnchainHookType {
@@ -29,60 +37,26 @@ export enum HookType {
   PAUSABLE = 'pausableHook',
 }
 
-export type MerkleTreeHookConfig = {
-  type: HookType.MERKLE_TREE;
-};
+export type MerkleTreeHookConfig = z.infer<typeof MerkleTreeSchema>;
+export type IgpHookConfig = z.infer<typeof IgpSchema>;
+export type ProtocolFeeHookConfig = z.infer<typeof ProtocolFeeSchema>;
+export type PausableHookConfig = z.infer<typeof PausableHookSchema>;
+export type OpStackHookConfig = z.infer<typeof OpStackHookSchema>;
 
+// explicitly typed to avoid zod circular dependency
 export type AggregationHookConfig = {
   type: HookType.AGGREGATION;
   hooks: Array<HookConfig>;
 };
-
-export type IgpHookConfig = IgpConfig & {
-  type: HookType.INTERCHAIN_GAS_PAYMASTER;
-};
-
-export type ProtocolFeeHookConfig = OwnableConfig & {
-  type: HookType.PROTOCOL_FEE;
-  maxProtocolFee: string;
-  protocolFee: string;
-  beneficiary: Address;
-};
-
-export type PausableHookConfig = OwnableConfig & {
-  type: HookType.PAUSABLE;
-};
-
-export type OpStackHookConfig = OwnableConfig & {
-  type: HookType.OP_STACK;
-  nativeBridge: Address;
-  destinationChain: ChainName;
-};
-
 export type RoutingHookConfig = OwnableConfig & {
   domains: ChainMap<HookConfig>;
 };
-
 export type DomainRoutingHookConfig = RoutingHookConfig & {
   type: HookType.ROUTING;
 };
-
 export type FallbackRoutingHookConfig = RoutingHookConfig & {
   type: HookType.FALLBACK_ROUTING;
   fallback: HookConfig;
 };
 
-export type HookConfig =
-  | MerkleTreeHookConfig
-  | AggregationHookConfig
-  | IgpHookConfig
-  | ProtocolFeeHookConfig
-  | OpStackHookConfig
-  | DomainRoutingHookConfig
-  | FallbackRoutingHookConfig
-  | PausableHookConfig;
-
-export type HooksConfig = {
-  required: HookConfig;
-  default: HookConfig;
-};
+export type HookConfig = z.infer<typeof HookConfigSchema>;

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -152,6 +152,7 @@ export {
   OpStackIsmConfig,
   PausableIsmConfig,
   RoutingIsmConfig,
+  TrustedRelayerIsmConfig,
 } from './ism/types.js';
 export { collectValidators, moduleCanCertainlyVerify } from './ism/utils.js';
 export {
@@ -451,7 +452,7 @@ export {
   WarpTypedTransaction,
 } from './warp/types.js';
 
-export { AggregationIsmConfigSchema } from './ism/schemas.js';
+export { AggregationIsmConfigSchema, IsmConfigSchema } from './ism/schemas.js';
 export { MailboxClientConfigSchema as mailboxClientConfigSchema } from './router/schemas.js';
 export {
   WarpRouteDeployConfigSchema,

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -75,6 +75,7 @@ export {
   MailboxViolationType,
   ValidatorAnnounceViolation,
 } from './core/types.js';
+export { CoreConfigSchema } from './core/schemas.js';
 export { HyperlaneAppChecker } from './deploy/HyperlaneAppChecker.js';
 export {
   DeployerOptions,
@@ -86,7 +87,6 @@ export {
   OwnableConfig,
   OwnerViolation,
   ViolationType,
-  resolveOrDeployAccountOwner,
 } from './deploy/types.js';
 export { ContractVerifier } from './deploy/verify/ContractVerifier.js';
 export { PostDeploymentContractVerifier } from './deploy/verify/PostDeploymentContractVerifier.js';
@@ -110,10 +110,7 @@ export {
   SealevelOverheadIgpDataSchema,
 } from './gas/adapters/serialization.js';
 export { IgpFactories, igpFactories } from './gas/contracts.js';
-export {
-  GasOracleContractType,
-  StorageGasOracleConfig,
-} from './gas/oracle/types.js';
+export { StorageGasOracleConfig } from './gas/oracle/types.js';
 export { CoinGeckoTokenPriceGetter } from './gas/token-prices.js';
 export {
   IgpBeneficiaryViolation,
@@ -131,13 +128,13 @@ export {
   FallbackRoutingHookConfig,
   HookConfig,
   HookType,
-  HooksConfig,
   IgpHookConfig,
   MerkleTreeHookConfig,
   OpStackHookConfig,
   PausableHookConfig,
   ProtocolFeeHookConfig,
 } from './hook/types.js';
+export { HookConfigSchema } from './hook/schemas.js';
 export { HyperlaneIsmFactory } from './ism/HyperlaneIsmFactory.js';
 export {
   buildAggregationIsmConfigs,

--- a/typescript/sdk/src/ism/EvmIsmCreator.ts
+++ b/typescript/sdk/src/ism/EvmIsmCreator.ts
@@ -31,7 +31,6 @@ import {
 import { HyperlaneContracts } from '../contracts/types.js';
 import { HyperlaneDeployer } from '../deploy/HyperlaneDeployer.js';
 import { ProxyFactoryFactories } from '../deploy/contracts.js';
-import { resolveOrDeployAccountOwner } from '../deploy/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainMap, ChainName } from '../types.js';
 
@@ -171,17 +170,8 @@ export class EvmIsmCreator {
           destination,
           new PausableIsm__factory(),
           IsmType.PAUSABLE,
-          [
-            await resolveOrDeployAccountOwner(
-              this.multiProvider,
-              destination,
-              config.owner,
-            ),
-          ],
+          [config.owner],
         );
-        await this.deployer.transferOwnershipOfContracts(destination, config, {
-          [IsmType.PAUSABLE]: contract,
-        });
         break;
       case IsmType.TRUSTED_RELAYER:
         assert(
@@ -331,11 +321,7 @@ export class EvmIsmCreator {
       }
     } else {
       const isms: ChainMap<Address> = {};
-      const owner = await resolveOrDeployAccountOwner(
-        this.multiProvider,
-        destination,
-        config.owner,
-      );
+      const owner = config.owner;
 
       for (const origin of Object.keys(config.domains)) {
         const ism = await this.deploy({
@@ -416,11 +402,7 @@ export class EvmIsmCreator {
     );
 
     const isms: ChainMap<Address> = {};
-    const owner = await resolveOrDeployAccountOwner(
-      this.multiProvider,
-      destination,
-      config.owner,
-    );
+    const owner = config.owner;
 
     for (const origin of Object.keys(config.domains)) {
       const ism = await this.deploy({

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
@@ -36,7 +36,6 @@ import {
   ProxyFactoryFactories,
   proxyFactoryFactories,
 } from '../deploy/contracts.js';
-import { resolveOrDeployAccountOwner } from '../deploy/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainMap, ChainName } from '../types.js';
 
@@ -151,13 +150,7 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
           destination,
           new PausableIsm__factory(),
           IsmType.PAUSABLE,
-          [
-            await resolveOrDeployAccountOwner(
-              this.multiProvider,
-              destination,
-              config.owner,
-            ),
-          ],
+          [config.owner],
         );
         await this.deployer.transferOwnershipOfContracts(destination, config, {
           [IsmType.PAUSABLE]: contract,
@@ -327,11 +320,6 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
       }
     } else {
       const isms: ChainMap<Address> = {};
-      const owner = await resolveOrDeployAccountOwner(
-        this.multiProvider,
-        destination,
-        config.owner,
-      );
       for (const origin of Object.keys(config.domains)) {
         const ism = await this.deploy({
           destination,
@@ -360,7 +348,7 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
         receipt = await this.multiProvider.handleTx(
           destination,
           routingIsm['initialize(address,uint32[],address[])'](
-            owner,
+            config.owner,
             safeConfigDomains,
             submoduleAddresses,
             overrides,
@@ -368,13 +356,8 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
         );
       } else {
         // deploying new domain routing ISM
-        const owner = await resolveOrDeployAccountOwner(
-          this.multiProvider,
-          destination,
-          config.owner,
-        );
         const tx = await domainRoutingIsmFactory.deploy(
-          owner,
+          config.owner,
           safeConfigDomains,
           submoduleAddresses,
           overrides,

--- a/typescript/sdk/src/ism/metadata/builder.ts
+++ b/typescript/sdk/src/ism/metadata/builder.ts
@@ -75,6 +75,9 @@ export class BaseMetadataBuilder implements MetadataBuilder {
 
       case IsmType.MERKLE_ROOT_MULTISIG:
       case IsmType.MESSAGE_ID_MULTISIG:
+        if (typeof hook === 'string') {
+          throw new Error('Hook context must be an object (for multisig ISM)');
+        }
         const merkleTreeHook = deepFind(
           hook,
           (v): v is WithAddress<MerkleTreeHookConfig> =>

--- a/typescript/sdk/src/ism/types.ts
+++ b/typescript/sdk/src/ism/types.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import {
   IAggregationIsm,
   IMultisigIsm,
@@ -11,6 +13,15 @@ import type { Address, Domain, ValueOf } from '@hyperlane-xyz/utils';
 
 import { OwnableConfig } from '../deploy/types.js';
 import { ChainMap } from '../types.js';
+
+import {
+  IsmConfigSchema,
+  MultisigIsmConfigSchema,
+  OpStackIsmConfigSchema,
+  PausableIsmConfigSchema,
+  TestIsmConfigSchema,
+  TrustedRelayerIsmConfigSchema,
+} from './schemas.js';
 
 // this enum should match the IInterchainSecurityModule.sol enum
 // meant for the relayer
@@ -65,18 +76,19 @@ export type MultisigConfig = {
   threshold: number;
 };
 
-export type MultisigIsmConfig = MultisigConfig & {
-  type: IsmType.MERKLE_ROOT_MULTISIG | IsmType.MESSAGE_ID_MULTISIG;
-};
+export type MultisigIsmConfig = z.infer<typeof MultisigIsmConfigSchema>;
+export type TestIsmConfig = z.infer<typeof TestIsmConfigSchema>;
+export type PausableIsmConfig = z.infer<typeof PausableIsmConfigSchema>;
+export type OpStackIsmConfig = z.infer<typeof OpStackIsmConfigSchema>;
+export type TrustedRelayerIsmConfig = z.infer<
+  typeof TrustedRelayerIsmConfigSchema
+>;
 
-export type TestIsmConfig = {
-  type: IsmType.TEST_ISM;
-};
-
-export type PausableIsmConfig = OwnableConfig & {
-  type: IsmType.PAUSABLE;
-  paused?: boolean;
-};
+export type NullIsmConfig =
+  | TestIsmConfig
+  | PausableIsmConfig
+  | OpStackIsmConfig
+  | TrustedRelayerIsmConfig;
 
 export type RoutingIsmConfig = OwnableConfig & {
   type: IsmType.ROUTING | IsmType.FALLBACK_ROUTING;
@@ -89,29 +101,7 @@ export type AggregationIsmConfig = {
   threshold: number;
 };
 
-export type OpStackIsmConfig = {
-  type: IsmType.OP_STACK;
-  origin: Address;
-  nativeBridge: Address;
-};
-
-export type TrustedRelayerIsmConfig = {
-  type: IsmType.TRUSTED_RELAYER;
-  relayer: Address;
-};
-
-export type NullIsmConfig =
-  | PausableIsmConfig
-  | TestIsmConfig
-  | OpStackIsmConfig
-  | TrustedRelayerIsmConfig;
-
-export type IsmConfig =
-  | Address
-  | NullIsmConfig
-  | RoutingIsmConfig
-  | MultisigIsmConfig
-  | AggregationIsmConfig;
+export type IsmConfig = z.infer<typeof IsmConfigSchema>;
 
 export type DeployedIsmType = {
   [IsmType.ROUTING]: IRoutingIsm;

--- a/typescript/sdk/src/ism/utils.ts
+++ b/typescript/sdk/src/ism/utils.ts
@@ -23,7 +23,6 @@ import {
 
 import { HyperlaneContracts } from '../contracts/types.js';
 import { ProxyFactoryFactories } from '../deploy/contracts.js';
-import { resolveOrDeployAccountOwner } from '../deploy/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainName } from '../types.js';
 
@@ -222,11 +221,7 @@ export async function moduleMatchesConfig(
       );
       // Check that the RoutingISM owner matches the config
       const owner = await routingIsm.owner();
-      const expectedOwner = await resolveOrDeployAccountOwner(
-        multiProvider,
-        chain,
-        config.owner,
-      );
+      const expectedOwner = config.owner;
       matches &&= eqAddress(owner, expectedOwner);
       // check if the mailbox matches the config for fallback routing
       if (config.type === IsmType.FALLBACK_ROUTING) {
@@ -314,11 +309,7 @@ export async function moduleMatchesConfig(
     case IsmType.PAUSABLE: {
       const pausableIsm = PausableIsm__factory.connect(moduleAddress, provider);
       const owner = await pausableIsm.owner();
-      const expectedOwner = await resolveOrDeployAccountOwner(
-        multiProvider,
-        chain,
-        config.owner,
-      );
+      const expectedOwner = config.owner;
       matches &&= eqAddress(owner, expectedOwner);
 
       if (config.paused) {
@@ -360,11 +351,7 @@ export async function routingModuleDelta(
   };
 
   // if owners don't match, we need to transfer ownership
-  const expectedOwner = await resolveOrDeployAccountOwner(
-    multiProvider,
-    destination,
-    config.owner,
-  );
+  const expectedOwner = config.owner;
   if (!eqAddress(owner, normalizeAddress(expectedOwner)))
     delta.owner = expectedOwner;
   if (config.type === IsmType.FALLBACK_ROUTING) {

--- a/typescript/sdk/src/middleware/account/InterchainAccountDeployer.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccountDeployer.ts
@@ -1,6 +1,7 @@
 import { ethers } from 'ethers';
 
 import { Router } from '@hyperlane-xyz/core';
+import { assert } from '@hyperlane-xyz/utils';
 
 import { HyperlaneContracts } from '../../contracts/types.js';
 import { ContractVerifier } from '../../deploy/verify/ContractVerifier.js';
@@ -49,9 +50,16 @@ export class InterchainAccountDeployer extends ProxiedRouterDeployer<
 
   async initializeArgs(chain: string, config: RouterConfig): Promise<any> {
     const owner = await this.multiProvider.getSignerAddress(chain);
+    if (config.interchainSecurityModule) {
+      assert(
+        typeof config.interchainSecurityModule === 'string',
+        'ISM objects not supported in ICA deployer',
+      );
+    }
+
     return [
       config.hook ?? ethers.constants.AddressZero,
-      config.interchainSecurityModule! as string, // deployed in deployContracts
+      config.interchainSecurityModule!,
       owner,
     ];
   }

--- a/typescript/sdk/src/router/ProxiedRouterDeployer.ts
+++ b/typescript/sdk/src/router/ProxiedRouterDeployer.ts
@@ -9,7 +9,6 @@ import { eqAddress } from '@hyperlane-xyz/utils';
 
 import { HyperlaneContracts, HyperlaneFactories } from '../contracts/types.js';
 import { DeployerOptions } from '../deploy/HyperlaneDeployer.js';
-import { resolveOrDeployAccountOwner } from '../deploy/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainName } from '../types.js';
 
@@ -100,11 +99,7 @@ export abstract class ProxiedRouterDeployer<
         constants.AddressZero,
         this.multiProvider.getProvider(chain),
       );
-      adminOwner = await resolveOrDeployAccountOwner(
-        this.multiProvider,
-        chain,
-        config.owner,
-      );
+      adminOwner = config.owner;
     }
 
     await super.runIfOwner(chain, proxyAdmin, async () => {

--- a/typescript/sdk/src/router/schemas.ts
+++ b/typescript/sdk/src/router/schemas.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod';
 
-import { OwnableConfigSchema } from '../deploy/schemas.js';
+import { HookConfigSchema } from '../hook/schemas.js';
 import { IsmConfigSchema } from '../ism/schemas.js';
 import { ZHash } from '../metadata/customZodTypes.js';
+import { OwnableSchema } from '../schemas.js';
 
-export const MailboxClientConfigSchema = OwnableConfigSchema.extend({
+export const MailboxClientConfigSchema = OwnableSchema.extend({
   mailbox: ZHash,
-  hook: ZHash.optional(),
+  hook: HookConfigSchema.optional(),
   interchainSecurityModule: IsmConfigSchema.optional(),
 });
 

--- a/typescript/sdk/src/schemas.ts
+++ b/typescript/sdk/src/schemas.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+import { ZHash } from './metadata/customZodTypes.js';
+
+export const OwnableSchema = z.object({
+  owner: ZHash,
+  ownerOverrides: z.record(ZHash).optional(),
+});
+
+export const PausableSchema = OwnableSchema.extend({
+  paused: z.boolean(),
+});

--- a/typescript/sdk/src/test/testUtils.ts
+++ b/typescript/sdk/src/test/testUtils.ts
@@ -59,8 +59,8 @@ export function testCoreConfig(
 }
 
 const TEST_ORACLE_CONFIG = {
-  gasPrice: ethers.utils.parseUnits('1', 'gwei'),
-  tokenExchangeRate: ethers.utils.parseUnits('1', 10),
+  gasPrice: ethers.utils.parseUnits('1', 'gwei').toString(),
+  tokenExchangeRate: ethers.utils.parseUnits('1', 10).toString(),
 };
 
 export function testIgpConfig(
@@ -71,6 +71,7 @@ export function testIgpConfig(
     chains.map((local) => [
       local,
       {
+        type: HookType.INTERCHAIN_GAS_PAYMASTER,
         owner,
         oracleKey: owner,
         beneficiary: owner,

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -20,7 +20,7 @@ import { TokenMetadata } from './types.js';
 
 const { AddressZero } = ethers.constants;
 
-export class EvmWarpRouteReader {
+export class EvmERC20WarpRouteReader {
   provider: providers.Provider;
   evmHookReader: EvmHookReader;
   evmIsmReader: EvmIsmReader;
@@ -95,8 +95,9 @@ export class EvmWarpRouteReader {
     const derivedIsm = eqAddress(ism, AddressZero)
       ? undefined
       : await this.evmIsmReader.deriveIsmConfig(ism);
-    // TODO: add after https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3667 is fixed
-    const derivedHook = eqAddress(hook, AddressZero) ? undefined : hook;
+    const derivedHook = eqAddress(hook, AddressZero)
+      ? undefined
+      : await this.evmHookReader.deriveHookConfig(hook);
 
     return {
       mailbox,

--- a/typescript/sdk/src/token/deploy.hardhat-test.ts
+++ b/typescript/sdk/src/token/deploy.hardhat-test.ts
@@ -12,7 +12,7 @@ import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDe
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 
-import { EvmWarpRouteReader } from './EvmERC20WarpRouteReader.js';
+import { EvmERC20WarpRouteReader } from './EvmERC20WarpRouteReader.js';
 import { TokenType } from './config.js';
 import { HypERC20Deployer } from './deploy.js';
 import { TokenRouterConfig } from './schemas.js';
@@ -70,11 +70,14 @@ describe('TokenDeployer', async () => {
 
   for (const type of [TokenType.collateral, TokenType.synthetic]) {
     describe('ERC20WarpRouterReader', async () => {
-      let reader: EvmWarpRouteReader;
+      let reader: EvmERC20WarpRouteReader;
       let routerAddress: Address;
 
       before(() => {
-        reader = new EvmWarpRouteReader(multiProvider, TestChainName.test1);
+        reader = new EvmERC20WarpRouteReader(
+          multiProvider,
+          TestChainName.test1,
+        );
       });
 
       beforeEach(async () => {


### PR DESCRIPTION
### Description

- Adds support for hook config objects on warp config
- Adds core config schema

### Drive-by changes

- Removes ICA config from schemas (resolve at config time)

### Related issues

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3728
- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3667

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
