### PR TITLE
feat: implement `create()` for `EvmHookModule`

### DIFF
--- a/.changeset/shy-countries-heal.md
+++ b/.changeset/shy-countries-heal.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Implement `create()` for the `EvmHookModule`

--- a/.changeset/shy-countries-heal.md
+++ b/.changeset/shy-countries-heal.md
@@ -2,4 +2,5 @@
 '@hyperlane-xyz/sdk': minor
 ---
 
-Implement `create()` for the `EvmHookModule`
+- Enables creation of new Hooks through the `EvmHookModule`.
+- Introduces an `EvmModuleDeployer` to perform the barebones tasks of deploying contracts/proxies.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -329,7 +329,7 @@ jobs:
 
   cli-e2e:
     runs-on: larger-runner
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main') || github.event_name == 'merge_group'
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main' || github.base_ref == 'cli-2.0') || github.event_name == 'merge_group'
     needs: [yarn-build, checkout-registry]
     strategy:
       matrix:

--- a/typescript/cli/src/avs/stakeRegistry.ts
+++ b/typescript/cli/src/avs/stakeRegistry.ts
@@ -119,7 +119,7 @@ async function readOperatorFromEncryptedJson(
     message: 'Enter the password for the operator key file: ',
   });
 
-  return await Wallet.fromEncryptedJson(encryptedJson, keyFilePassword);
+  return Wallet.fromEncryptedJson(encryptedJson, keyFilePassword);
 }
 
 async function getOperatorSignature(

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -8,7 +8,6 @@ import {
   HypERC721Deployer,
   HyperlaneAddresses,
   HyperlaneContractsMap,
-  HyperlaneDeployer,
   HyperlaneProxyFactoryDeployer,
   MultiProvider,
   TOKEN_TYPE_TO_STANDARD,
@@ -196,7 +195,6 @@ async function deployAndResolveWarpIsm(
         chain,
         warpConfig,
         multiProvider,
-        ismFactoryDeployer,
         {
           domainRoutingIsmFactory: chainAddresses.domainRoutingIsmFactory,
           staticAggregationHookFactory:
@@ -227,7 +225,6 @@ async function createWarpIsm(
   chain: string,
   warpConfig: WarpRouteDeployConfig,
   multiProvider: MultiProvider,
-  ismFactoryDeployer: HyperlaneDeployer<any, any>,
   factoryAddresses: HyperlaneAddresses<any>,
 ): Promise<string> {
   const {
@@ -240,9 +237,8 @@ async function createWarpIsm(
   const evmIsmModule = await EvmIsmModule.create({
     chain,
     multiProvider,
-    deployer: ismFactoryDeployer,
     mailbox: warpConfig[chain].mailbox,
-    factories: {
+    proxyFactoryFactories: {
       domainRoutingIsmFactory,
       staticAggregationHookFactory,
       staticAggregationIsmFactory,

--- a/typescript/cli/src/validator/address.ts
+++ b/typescript/cli/src/validator/address.ts
@@ -24,7 +24,7 @@ export async function getValidatorAddress({
   region?: string;
   bucket?: string;
   keyId?: string;
-}) {
+}): Promise<void> {
   if (!bucket && !keyId) {
     throw new Error('Must provide either an S3 bucket or a KMS Key ID.');
   }
@@ -38,7 +38,7 @@ export async function getValidatorAddress({
   assert(secretKey, 'No secret access key set.');
   assert(region, 'No AWS region set.');
 
-  let validatorAddress;
+  let validatorAddress: string;
   if (bucket) {
     validatorAddress = await getAddressFromBucket(
       bucket,
@@ -68,7 +68,7 @@ async function getAddressFromBucket(
   accessKeyId: string,
   secretAccessKey: string,
   region: string,
-) {
+): Promise<string> {
   const s3Client = new S3Client({
     region: region,
     credentials: {
@@ -101,7 +101,7 @@ async function getAddressFromKey(
   accessKeyId: string,
   secretAccessKey: string,
   region: string,
-) {
+): Promise<string> {
   const client = new KMSClient({
     region: region,
     credentials: {
@@ -138,28 +138,28 @@ function getEthereumAddress(publicKey: Buffer): string {
   return `0x${address.slice(-40)}`; // take last 20 bytes as ethereum address
 }
 
-async function getAccessKeyId(skipConfirmation: boolean) {
+async function getAccessKeyId(skipConfirmation: boolean): Promise<string> {
   if (skipConfirmation) throw new Error('No AWS access key ID set.');
   else
-    return await input({
+    return input({
       message:
         'Please enter AWS access key ID or use the AWS_ACCESS_KEY_ID environment variable.',
     });
 }
 
-async function getSecretAccessKey(skipConfirmation: boolean) {
+async function getSecretAccessKey(skipConfirmation: boolean): Promise<string> {
   if (skipConfirmation) throw new Error('No AWS secret access key set.');
   else
-    return await input({
+    return input({
       message:
         'Please enter AWS secret access key or use the AWS_SECRET_ACCESS_KEY environment variable.',
     });
 }
 
-async function getRegion(skipConfirmation: boolean) {
+async function getRegion(skipConfirmation: boolean): Promise<string> {
   if (skipConfirmation) throw new Error('No AWS region set.');
   else
-    return await input({
+    return input({
       message:
         'Please enter AWS region or use the AWS_REGION environment variable.',
     });

--- a/typescript/sdk/src/deploy/EvmModuleDeployer.ts
+++ b/typescript/sdk/src/deploy/EvmModuleDeployer.ts
@@ -1,0 +1,288 @@
+import { ethers } from 'ethers';
+import { Logger } from 'pino';
+
+import {
+  StaticAddressSetFactory,
+  StaticThresholdAddressSetFactory,
+  TransparentUpgradeableProxy__factory,
+} from '@hyperlane-xyz/core';
+import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
+import { Address, rootLogger } from '@hyperlane-xyz/utils';
+
+import { HyperlaneContracts, HyperlaneFactories } from '../contracts/types.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+import { ChainMap, ChainName } from '../types.js';
+
+import { isProxy, proxyConstructorArgs } from './proxy.js';
+import { ContractVerifier } from './verify/ContractVerifier.js';
+import {
+  ContractVerificationInput,
+  ExplorerLicenseType,
+} from './verify/types.js';
+import { getContractVerificationInput } from './verify/utils.js';
+
+export class EvmModuleDeployer<Factories extends HyperlaneFactories> {
+  public verificationInputs: ChainMap<ContractVerificationInput[]> = {};
+
+  constructor(
+    protected readonly multiProvider: MultiProvider,
+    protected readonly factories: Factories,
+    protected readonly logger = rootLogger.child({
+      module: 'EvmModuleDeployer',
+    }),
+    protected readonly contractVerifier = new ContractVerifier(
+      multiProvider,
+      {},
+      coreBuildArtifact,
+      ExplorerLicenseType.MIT,
+    ),
+  ) {}
+
+  // Deploys a contract from a factory
+  public async deployContractFromFactory<F extends ethers.ContractFactory>({
+    chain,
+    factory,
+    contractName,
+    constructorArgs,
+    initializeArgs,
+  }: {
+    chain: ChainName;
+    factory: F;
+    contractName: string;
+    constructorArgs: Parameters<F['deploy']>;
+    initializeArgs?: Parameters<Awaited<ReturnType<F['deploy']>>['initialize']>;
+  }): Promise<ReturnType<F['deploy']>> {
+    this.logger.info(
+      `Deploy ${contractName} on ${chain} with constructor args (${constructorArgs.join(
+        ', ',
+      )})`,
+    );
+    const contract = await this.multiProvider.handleDeploy(
+      chain,
+      factory,
+      constructorArgs,
+    );
+
+    if (initializeArgs) {
+      this.logger.debug(`Initialize ${contractName} on ${chain}`);
+      const overrides = this.multiProvider.getTransactionOverrides(chain);
+      const initTx = await contract.initialize(...initializeArgs, overrides);
+      await this.multiProvider.handleTx(chain, initTx);
+    }
+
+    const verificationInput = getContractVerificationInput(
+      contractName,
+      contract,
+      factory.bytecode,
+    );
+    this.addVerificationArtifacts({ chain, artifacts: [verificationInput] });
+
+    // try verifying contract
+    try {
+      await this.contractVerifier?.verifyContract(chain, verificationInput);
+    } catch (error) {
+      // log error but keep deploying, can also verify post-deployment if needed
+      this.logger.debug(`Error verifying contract: ${error}`);
+    }
+
+    return contract;
+  }
+
+  /**
+   * Deploys a contract with a specified name.
+   *
+   * This is a generic function capable of deploying any contract type, defined within the `Factories` type, to a specified chain.
+   *
+   * @param {ChainName} chain - The name of the chain on which the contract is to be deployed.
+   * @param {K} contractKey - The key identifying the factory to use for deployment.
+   * @param {string} contractName - The name of the contract to deploy. This must match the contract source code.
+   * @param {Parameters<Factories[K]['deploy']>} constructorArgs - Arguments for the contract's constructor.
+   * @param {Parameters<Awaited<ReturnType<Factories[K]['deploy']>>['initialize']>?} initializeArgs - Optional arguments for the contract's initialization function.
+   * @param {boolean} shouldRecover - Flag indicating whether to attempt recovery if deployment fails.
+   * @returns {Promise<HyperlaneContracts<Factories>[K]>} A promise that resolves to the deployed contract instance.
+   */
+  public async deployContractWithName<K extends keyof Factories>({
+    chain,
+    contractKey,
+    contractName,
+    constructorArgs,
+    initializeArgs,
+  }: {
+    chain: ChainName;
+    contractKey: K;
+    contractName: string;
+    constructorArgs: Parameters<Factories[K]['deploy']>;
+    initializeArgs?: Parameters<
+      Awaited<ReturnType<Factories[K]['deploy']>>['initialize']
+    >;
+  }): Promise<HyperlaneContracts<Factories>[K]> {
+    const contract = await this.deployContractFromFactory({
+      chain,
+      factory: this.factories[contractKey],
+      contractName,
+      constructorArgs,
+      initializeArgs,
+    });
+    return contract;
+  }
+
+  // Deploys a contract with the same name as the contract key
+  public async deployContract<K extends keyof Factories>({
+    chain,
+    contractKey,
+    constructorArgs,
+    initializeArgs,
+  }: {
+    chain: ChainName;
+    contractKey: K;
+    constructorArgs: Parameters<Factories[K]['deploy']>;
+    initializeArgs?: Parameters<
+      Awaited<ReturnType<Factories[K]['deploy']>>['initialize']
+    >;
+  }): Promise<HyperlaneContracts<Factories>[K]> {
+    return this.deployContractWithName({
+      chain,
+      contractKey,
+      contractName: contractKey.toString(),
+      constructorArgs,
+      initializeArgs,
+    });
+  }
+
+  // Deploys the Implementation and Proxy for a given contract
+  public async deployProxiedContract<K extends keyof Factories>({
+    chain,
+    contractKey,
+    contractName,
+    proxyAdmin,
+    constructorArgs,
+    initializeArgs,
+  }: {
+    chain: ChainName;
+    contractKey: K;
+    contractName: string;
+    proxyAdmin: string;
+    constructorArgs: Parameters<Factories[K]['deploy']>;
+    initializeArgs?: Parameters<HyperlaneContracts<Factories>[K]['initialize']>;
+  }): Promise<HyperlaneContracts<Factories>[K]> {
+    // Try to initialize the implementation even though it may not be necessary
+    const implementation = await this.deployContractWithName({
+      chain,
+      contractKey,
+      contractName,
+      constructorArgs,
+      initializeArgs,
+    });
+
+    // Initialize the proxy the same way
+    return this.deployProxy({
+      chain,
+      implementation,
+      proxyAdmin,
+      initializeArgs,
+    });
+  }
+
+  // Deploys a proxy for a given implementation contract
+  protected async deployProxy<C extends ethers.Contract>({
+    chain,
+    implementation,
+    proxyAdmin,
+    initializeArgs,
+  }: {
+    chain: ChainName;
+    implementation: C;
+    proxyAdmin: string;
+    initializeArgs?: Parameters<C['initialize']>;
+  }): Promise<C> {
+    const isProxied = await isProxy(
+      this.multiProvider.getProvider(chain),
+      implementation.address,
+    );
+    if (isProxied) {
+      // if the implementation is already a proxy, do not deploy a new proxy
+      return implementation;
+    }
+
+    const constructorArgs = proxyConstructorArgs(
+      implementation,
+      proxyAdmin,
+      initializeArgs,
+    );
+    const proxy = await this.deployContractFromFactory({
+      chain,
+      factory: new TransparentUpgradeableProxy__factory(),
+      contractName: 'TransparentUpgradeableProxy',
+      constructorArgs,
+    });
+
+    return implementation.attach(proxy.address) as C;
+  }
+
+  // Adds verification artifacts to the verificationInputs map
+  protected addVerificationArtifacts({
+    chain,
+    artifacts,
+  }: {
+    chain: ChainName;
+    artifacts: ContractVerificationInput[];
+  }): void {
+    this.verificationInputs[chain] = this.verificationInputs[chain] || [];
+    artifacts.forEach((artifact) => {
+      this.verificationInputs[chain].push(artifact);
+    });
+  }
+
+  // Static deploy function used by Hook and ISM modules.
+  public static async deployStaticAddressSet({
+    chain,
+    factory,
+    values,
+    logger,
+    threshold = values.length,
+    multiProvider,
+  }: {
+    chain: ChainName;
+    factory: StaticThresholdAddressSetFactory | StaticAddressSetFactory;
+    values: Address[];
+    logger: Logger;
+    threshold?: number;
+    multiProvider: MultiProvider;
+  }): Promise<Address> {
+    const address = await factory['getAddress(address[],uint8)'](
+      values,
+      threshold,
+    );
+    const code = await multiProvider.getProvider(chain).getCode(address);
+    if (code === '0x') {
+      logger.debug(
+        `Deploying new ${threshold} of ${values.length} address set to ${chain}`,
+      );
+      const overrides = multiProvider.getTransactionOverrides(chain);
+      const hash = await factory['deploy(address[],uint8)'](
+        values,
+        threshold,
+        overrides,
+      );
+      await multiProvider.handleTx(chain, hash);
+    } else {
+      logger.debug(
+        `Recovered ${threshold} of ${values.length} address set on ${chain}: ${address}`,
+      );
+    }
+
+    // TODO: figure out how to get the constructor arguments for manual deploy TXs
+    // const verificationInput = buildVerificationInput(
+    //   NAME,
+    //   ADDRESS,
+    //   CONSTRUCTOR_ARGS,
+    // );
+    // await this.deployer.verifyContract(
+    //   this.chainName,
+    //   verificationInput,
+    //   logger,
+    // );
+
+    return address;
+  }
+}

--- a/typescript/sdk/src/deploy/EvmModuleDeployer.ts
+++ b/typescript/sdk/src/deploy/EvmModuleDeployer.ts
@@ -91,14 +91,13 @@ export class EvmModuleDeployer<Factories extends HyperlaneFactories> {
   /**
    * Deploys a contract with a specified name.
    *
-   * This is a generic function capable of deploying any contract type, defined within the `Factories` type, to a specified chain.
+   * This function is capable of deploying any contract type defined within the `Factories` type to a specified chain.
    *
    * @param {ChainName} chain - The name of the chain on which the contract is to be deployed.
    * @param {K} contractKey - The key identifying the factory to use for deployment.
    * @param {string} contractName - The name of the contract to deploy. This must match the contract source code.
    * @param {Parameters<Factories[K]['deploy']>} constructorArgs - Arguments for the contract's constructor.
    * @param {Parameters<Awaited<ReturnType<Factories[K]['deploy']>>['initialize']>?} initializeArgs - Optional arguments for the contract's initialization function.
-   * @param {boolean} shouldRecover - Flag indicating whether to attempt recovery if deployment fails.
    * @returns {Promise<HyperlaneContracts<Factories>[K]>} A promise that resolves to the deployed contract instance.
    */
   public async deployContractWithName<K extends keyof Factories>({

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -590,6 +590,7 @@ export abstract class HyperlaneDeployer<
       new TransparentUpgradeableProxy__factory(),
       'TransparentUpgradeableProxy',
       constructorArgs,
+      undefined,
     );
 
     return implementation.attach(proxy.address) as C;
@@ -703,6 +704,7 @@ export abstract class HyperlaneDeployer<
     proxyAdmin: string,
     constructorArgs: Parameters<Factories[K]['deploy']>,
     initializeArgs?: Parameters<HyperlaneContracts<Factories>[K]['initialize']>,
+    shouldRecover = true,
   ): Promise<HyperlaneContracts<Factories>[K]> {
     // Try to initialize the implementation even though it may not be necessary
     const implementation = await this.deployContractWithName(
@@ -711,6 +713,7 @@ export abstract class HyperlaneDeployer<
       contractName,
       constructorArgs,
       initializeArgs,
+      shouldRecover,
     );
 
     // Initialize the proxy the same way

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -457,24 +457,6 @@ export abstract class HyperlaneDeployer<
     return contract;
   }
 
-  async deployNewContract<K extends keyof Factories>(
-    chain: ChainName,
-    contractKey: K,
-    constructorArgs: Parameters<Factories[K]['deploy']>,
-    initializeArgs?: Parameters<
-      Awaited<ReturnType<Factories[K]['deploy']>>['initialize']
-    >,
-  ): Promise<HyperlaneContracts<Factories>[K]> {
-    return this.deployContractWithName(
-      chain,
-      contractKey,
-      contractKey.toString(),
-      constructorArgs,
-      initializeArgs,
-      false,
-    );
-  }
-
   async deployContract<K extends keyof Factories>(
     chain: ChainName,
     contractKey: K,
@@ -590,7 +572,6 @@ export abstract class HyperlaneDeployer<
       new TransparentUpgradeableProxy__factory(),
       'TransparentUpgradeableProxy',
       constructorArgs,
-      undefined,
     );
 
     return implementation.attach(proxy.address) as C;
@@ -704,7 +685,6 @@ export abstract class HyperlaneDeployer<
     proxyAdmin: string,
     constructorArgs: Parameters<Factories[K]['deploy']>,
     initializeArgs?: Parameters<HyperlaneContracts<Factories>[K]['initialize']>,
-    shouldRecover = true,
   ): Promise<HyperlaneContracts<Factories>[K]> {
     // Try to initialize the implementation even though it may not be necessary
     const implementation = await this.deployContractWithName(
@@ -713,7 +693,6 @@ export abstract class HyperlaneDeployer<
       contractName,
       constructorArgs,
       initializeArgs,
-      shouldRecover,
     );
 
     // Initialize the proxy the same way

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -457,6 +457,24 @@ export abstract class HyperlaneDeployer<
     return contract;
   }
 
+  async deployNewContract<K extends keyof Factories>(
+    chain: ChainName,
+    contractKey: K,
+    constructorArgs: Parameters<Factories[K]['deploy']>,
+    initializeArgs?: Parameters<
+      Awaited<ReturnType<Factories[K]['deploy']>>['initialize']
+    >,
+  ): Promise<HyperlaneContracts<Factories>[K]> {
+    return this.deployContractWithName(
+      chain,
+      contractKey,
+      contractKey.toString(),
+      constructorArgs,
+      initializeArgs,
+      false,
+    );
+  }
+
   async deployContract<K extends keyof Factories>(
     chain: ChainName,
     contractKey: K,

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -204,7 +204,7 @@ describe('EvmHookModule', async () => {
     };
   });
 
-  // Helper method for checking whether ISM module matches a given config
+  // Helper method for checking whether Hook module matches a given config
   async function hookModuleMatchesConfig({
     hook,
     config,
@@ -236,10 +236,10 @@ describe('EvmHookModule', async () => {
     ).to.be.true;
   });
 
-  // create a new ISM and verify that it matches the config
+  // create a new Hook and verify that it matches the config
   async function createHook(
     config: HookConfig,
-  ): Promise<{ ism: EvmHookModule; initialHookAddress: Address }> {
+  ): Promise<{ hook: EvmHookModule; initialHookAddress: Address }> {
     console.log('Creating hook with config: ', stringifyObject(config));
     const hook = await EvmHookModule.create({
       chain,
@@ -250,7 +250,7 @@ describe('EvmHookModule', async () => {
     });
     testConfig = config;
     testHook = hook;
-    return { ism: hook, initialHookAddress: hook.serialize().deployedHook };
+    return { hook, initialHookAddress: hook.serialize().deployedHook };
   }
 
   describe('create', async () => {
@@ -362,7 +362,7 @@ describe('EvmHookModule', async () => {
     // });
 
     for (let i = 0; i < 16; i++) {
-      it(`deploys a random ism config #${i}`, async () => {
+      it(`deploys a random hook config #${i}`, async () => {
         // random config with depth 0-2
         const config = randomHookConfig();
         await createHook(config);

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -37,13 +37,8 @@ const hookTypes = Object.values(HookType);
 
 function randomHookType(): HookType {
   // OP_STACK filtering is temporary until we have a way to deploy the required contracts
-  // PROTOCOL_FEE filtering is temporary until we fix initialization of the protocol fee hook
-  // ROUTING/FALLBACK_ROUTING filtering is temporary until we fix ownership of domain hooks
   const filteredHookTypes = hookTypes.filter(
-    (type) =>
-      type !== HookType.OP_STACK &&
-      type !== HookType.ROUTING &&
-      type !== HookType.FALLBACK_ROUTING,
+    (type) => type !== HookType.OP_STACK,
   );
   return filteredHookTypes[
     Math.floor(Math.random() * filteredHookTypes.length)
@@ -316,12 +311,14 @@ describe('EvmHookModule', async () => {
         owner: randomAddress(),
         type: HookType.ROUTING,
         domains: Object.fromEntries(
-          testChains.map((c) => [
-            c,
-            {
-              type: HookType.MERKLE_TREE,
-            },
-          ]),
+          testChains
+            .filter((c) => c !== TestChainName.test4)
+            .map((c) => [
+              c,
+              {
+                type: HookType.MERKLE_TREE,
+              },
+            ]),
         ),
       };
       await createHook(config);
@@ -333,12 +330,14 @@ describe('EvmHookModule', async () => {
         type: HookType.FALLBACK_ROUTING,
         fallback: { type: HookType.MERKLE_TREE },
         domains: Object.fromEntries(
-          testChains.map((c) => [
-            c,
-            {
-              type: HookType.MERKLE_TREE,
-            },
-          ]),
+          testChains
+            .filter((c) => c !== TestChainName.test4)
+            .map((c) => [
+              c,
+              {
+                type: HookType.MERKLE_TREE,
+              },
+            ]),
         ),
       };
       await createHook(config);
@@ -378,5 +377,116 @@ describe('EvmHookModule', async () => {
         await createHook(config);
       });
     }
+
+    it('regression test #1', async () => {
+      const config: HookConfig = {
+        type: HookType.AGGREGATION,
+        hooks: [
+          {
+            owner: '0xebe67f0a423fd1c4af21debac756e3238897c665',
+            type: HookType.INTERCHAIN_GAS_PAYMASTER,
+            beneficiary: '0xfe3be5940327305aded56f20359761ef85317554',
+            oracleKey: '0xebe67f0a423fd1c4af21debac756e3238897c665',
+            overhead: {
+              test1: 18,
+              test2: 85,
+              test3: 23,
+              test4: 69,
+            },
+            oracleConfig: {
+              test1: {
+                tokenExchangeRate: BigNumber.from('1032586497157'),
+                gasPrice: BigNumber.from('1026942205817'),
+              },
+              test2: {
+                tokenExchangeRate: BigNumber.from('81451154935'),
+                gasPrice: BigNumber.from('1231220057593'),
+              },
+              test3: {
+                tokenExchangeRate: BigNumber.from('31347320275'),
+                gasPrice: BigNumber.from('21944956734'),
+              },
+              test4: {
+                tokenExchangeRate: BigNumber.from('1018619796544'),
+                gasPrice: BigNumber.from('1124484183261'),
+              },
+            },
+          },
+          {
+            owner: '0xcc803fc9e6551b9eaaebfabbdd5af3eccea252ff',
+            type: HookType.ROUTING,
+            domains: {
+              test1: {
+                type: HookType.MERKLE_TREE,
+              },
+              test2: {
+                owner: '0x7e43dfa88c4a5d29a8fcd69883b7f6843d465ca3',
+                type: HookType.INTERCHAIN_GAS_PAYMASTER,
+                beneficiary: '0x762e71a849a3825613cf5cbe70bfff27d0fe7766',
+                oracleKey: '0x7e43dfa88c4a5d29a8fcd69883b7f6843d465ca3',
+                overhead: {
+                  test1: 46,
+                  test2: 34,
+                  test3: 47,
+                  test4: 24,
+                },
+                oracleConfig: {
+                  test1: {
+                    tokenExchangeRate: BigNumber.from('1132883204938'),
+                    gasPrice: BigNumber.from('1219466305935'),
+                  },
+                  test2: {
+                    tokenExchangeRate: BigNumber.from('938422264723'),
+                    gasPrice: BigNumber.from('229134538568'),
+                  },
+                  test3: {
+                    tokenExchangeRate: BigNumber.from('69699594189'),
+                    gasPrice: BigNumber.from('475781234236'),
+                  },
+                  test4: {
+                    tokenExchangeRate: BigNumber.from('1027245678936'),
+                    gasPrice: BigNumber.from('502686418976'),
+                  },
+                },
+              },
+              test3: {
+                type: HookType.MERKLE_TREE,
+              },
+              test4: {
+                owner: '0xa1ce72b70566f2cba6000bfe6af50f0f358f49d7',
+                type: HookType.INTERCHAIN_GAS_PAYMASTER,
+                beneficiary: '0x9796c0c49c61fe01eb1a8ba56d09b831f6da8603',
+                oracleKey: '0xa1ce72b70566f2cba6000bfe6af50f0f358f49d7',
+                overhead: {
+                  test1: 71,
+                  test2: 16,
+                  test3: 37,
+                  test4: 13,
+                },
+                oracleConfig: {
+                  test1: {
+                    tokenExchangeRate: BigNumber.from('443874625350'),
+                    gasPrice: BigNumber.from('799154764503'),
+                  },
+                  test2: {
+                    tokenExchangeRate: BigNumber.from('915348561750'),
+                    gasPrice: BigNumber.from('1124345797215'),
+                  },
+                  test3: {
+                    tokenExchangeRate: BigNumber.from('930832717805'),
+                    gasPrice: BigNumber.from('621743941770'),
+                  },
+                  test4: {
+                    tokenExchangeRate: BigNumber.from('147394981623'),
+                    gasPrice: BigNumber.from('766494385983'),
+                  },
+                },
+              },
+            },
+          },
+        ],
+      };
+      await createHook(config);
+    });
   });
 });

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -37,7 +37,7 @@ const hookTypes = Object.values(HookType);
 function randomHookType(): HookType {
   // OP_STACK filtering is temporary until we have a way to deploy the required contracts
   const filteredHookTypes = hookTypes.filter(
-    (type) => type !== HookType.OP_STACK,
+    (type) => type !== HookType.OP_STACK && type !== HookType.CUSTOM,
   );
   return filteredHookTypes[
     Math.floor(Math.random() * filteredHookTypes.length)
@@ -254,6 +254,11 @@ describe('EvmHookModule', async () => {
   }
 
   describe('create', async () => {
+    it('deploys a hook of type CUSTOM', async () => {
+      const config: HookConfig = randomAddress();
+      await createHook(config);
+    });
+
     it('deploys a hook of type MERKLE_TREE', async () => {
       const config: MerkleTreeHookConfig = {
         type: HookType.MERKLE_TREE,

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -1,0 +1,259 @@
+/* eslint-disable no-console */
+import { expect } from 'chai';
+import { BigNumber } from 'ethers';
+import hre from 'hardhat';
+
+import {
+  Address,
+  configDeepEquals,
+  normalizeConfig,
+  stringifyObject,
+} from '@hyperlane-xyz/utils';
+
+import { TestChainName, testChains } from '../consts/testChains.js';
+import { HyperlaneAddresses, HyperlaneContracts } from '../contracts/types.js';
+import { TestCoreDeployer } from '../core/TestCoreDeployer.js';
+import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDeployer.js';
+import { ProxyFactoryFactories } from '../deploy/contracts.js';
+import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+import { randomAddress, randomInt } from '../test/testUtils.js';
+
+import { EvmHookModule } from './EvmHookModule.js';
+import { HyperlaneHookDeployer } from './HyperlaneHookDeployer.js';
+import { HookConfig, HookType } from './types.js';
+
+const hookTypes = Object.values(HookType);
+
+function randomHookType(): HookType {
+  const filteredHookTypes = hookTypes.filter(
+    (type) => type !== HookType.OP_STACK,
+  );
+  return filteredHookTypes[
+    Math.floor(Math.random() * filteredHookTypes.length)
+  ];
+}
+
+function randomHookConfig(
+  depth = 0,
+  maxDepth = 2,
+  providedHookType?: HookType,
+): HookConfig {
+  const hookType: HookType = providedHookType ?? randomHookType();
+
+  if (depth >= maxDepth) {
+    if (hookType === HookType.AGGREGATION || hookType === HookType.ROUTING) {
+      return { type: HookType.MERKLE_TREE };
+    }
+  }
+
+  switch (hookType) {
+    case HookType.MERKLE_TREE:
+      return { type: hookType };
+
+    case HookType.AGGREGATION:
+      return {
+        type: hookType,
+        hooks: [
+          randomHookConfig(depth + 1, maxDepth),
+          randomHookConfig(depth + 1, maxDepth),
+        ],
+      };
+
+    case HookType.INTERCHAIN_GAS_PAYMASTER: {
+      const owner = randomAddress();
+      return {
+        owner,
+        type: hookType,
+        beneficiary: randomAddress(),
+        oracleKey: owner,
+        overhead: Object.fromEntries(
+          testChains.map((c) => [c, Math.floor(Math.random() * 100)]),
+        ),
+        oracleConfig: Object.fromEntries(
+          testChains.map((c) => [
+            c,
+            {
+              tokenExchangeRate: BigNumber.from(randomInt(1234567891234)),
+              gasPrice: BigNumber.from(randomInt(1234567891234)),
+            },
+          ]),
+        ),
+      };
+    }
+
+    case HookType.PROTOCOL_FEE:
+      return {
+        owner: randomAddress(),
+        type: hookType,
+        maxProtocolFee: Math.floor(Math.random() * 1000).toString(),
+        protocolFee: Math.floor(Math.random() * 100).toString(),
+        beneficiary: randomAddress(),
+      };
+
+    case HookType.OP_STACK:
+      return {
+        owner: randomAddress(),
+        type: hookType,
+        nativeBridge: randomAddress(),
+        destinationChain: 'testChain',
+      };
+
+    case HookType.ROUTING:
+      return {
+        owner: randomAddress(),
+        type: hookType,
+        domains: Object.fromEntries(
+          testChains.map((c) => [c, randomHookConfig(depth + 1, maxDepth)]),
+        ),
+      };
+
+    case HookType.FALLBACK_ROUTING:
+      return {
+        owner: randomAddress(),
+        type: hookType,
+        fallback: randomHookConfig(depth + 1, maxDepth),
+        domains: Object.fromEntries(
+          testChains.map((c) => [c, randomHookConfig(depth + 1, maxDepth)]),
+        ),
+      };
+
+    case HookType.PAUSABLE:
+      return {
+        owner: randomAddress(),
+        type: hookType,
+      };
+
+    default:
+      throw new Error(`Unsupported Hook type: ${hookType}`);
+  }
+}
+
+describe('EvmHookModule', async () => {
+  let multiProvider: MultiProvider;
+  let hookDeployer: HyperlaneHookDeployer;
+
+  let mailboxAddress: Address;
+  let proxyAdminAddress: Address;
+
+  const chain = TestChainName.test4;
+  let factoryAddresses: HyperlaneAddresses<ProxyFactoryFactories>;
+  let factoryContracts: HyperlaneContracts<ProxyFactoryFactories>;
+
+  beforeEach(async () => {
+    const [signer] = await hre.ethers.getSigners();
+    multiProvider = MultiProvider.createTestMultiProvider({ signer });
+
+    const ismFactoryDeployer = new HyperlaneProxyFactoryDeployer(multiProvider);
+    const contractsMap = await ismFactoryDeployer.deploy(
+      multiProvider.mapKnownChains(() => ({})),
+    );
+
+    // get addresses of factories for the chain
+    factoryContracts = contractsMap[chain];
+    factoryAddresses = Object.keys(factoryContracts).reduce((acc, key) => {
+      acc[key] =
+        contractsMap[chain][key as keyof ProxyFactoryFactories].address;
+      return acc;
+    }, {} as Record<string, Address>) as HyperlaneAddresses<ProxyFactoryFactories>;
+
+    // legacy HyperlaneIsmFactory is required to do a core deploy
+    const legacyIsmFactory = new HyperlaneIsmFactory(
+      contractsMap,
+      multiProvider,
+    );
+
+    // core deployer for tests
+    const testCoreDeployer = new TestCoreDeployer(
+      multiProvider,
+      legacyIsmFactory,
+    );
+
+    // mailbox and proxy admin for the core deploy
+    const { mailbox, proxyAdmin } = (
+      await testCoreDeployer.deployApp()
+    ).getContracts(chain);
+    mailboxAddress = mailbox.address;
+    proxyAdminAddress = proxyAdmin.address;
+
+    hookDeployer = testCoreDeployer.hookDeployer;
+  });
+
+  // Helper method for checking whether ISM module matches a given config
+  async function hookModuleMatchesConfig({
+    hook,
+    config,
+  }: {
+    hook: EvmHookModule;
+    config: HookConfig;
+  }): Promise<boolean> {
+    const derivedConfig = await hook.read();
+    const matches = configDeepEquals(
+      normalizeConfig(derivedConfig),
+      normalizeConfig(config),
+    );
+    if (!matches) {
+      console.error(
+        'Derived config:',
+        stringifyObject(normalizeConfig(derivedConfig)),
+      );
+      console.error(
+        'Expected config:',
+        stringifyObject(normalizeConfig(config)),
+      );
+    }
+    return matches;
+  }
+
+  // hook module and config for testing
+  let testHook: EvmHookModule;
+  let testConfig: HookConfig;
+
+  // expect that the hook matches the config after all tests
+  afterEach(async () => {
+    expect(
+      await hookModuleMatchesConfig({ hook: testHook, config: testConfig }),
+    ).to.be.true;
+  });
+
+  // create a new ISM and verify that it matches the config
+  async function createHook(
+    config: HookConfig,
+  ): Promise<{ ism: EvmHookModule; initialHookAddress: Address }> {
+    const hook = await EvmHookModule.create({
+      chain,
+      config,
+      deployer: hookDeployer,
+      factories: factoryAddresses,
+      mailbox: mailboxAddress,
+      proxyAdmin: proxyAdminAddress,
+      multiProvider,
+    });
+    testHook = hook;
+    testConfig = config;
+    return { ism: hook, initialHookAddress: hook.serialize().deployedHook };
+  }
+
+  describe('create', async () => {
+    for (const hookType of Object.values(HookType)) {
+      if (hookType === HookType.OP_STACK) {
+        console.log('Skipping OP_STACK hook type');
+        continue;
+      }
+
+      it(`deploys a hook of type ${hookType}`, async () => {
+        const config = randomHookConfig(0, 2, hookType);
+        console.log('Creating hook with config:', config);
+        await createHook(config);
+      });
+    }
+
+    for (let i = 0; i < 16; i++) {
+      it(`deploys a random ism config #${i}`, async () => {
+        const config = randomHookConfig();
+        console.log('Creating hook with config:', config);
+        await createHook(config);
+      });
+    }
+  });
+});

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import { expect } from 'chai';
-import { BigNumber } from 'ethers';
 import hre from 'hardhat';
 
 import {
@@ -98,8 +97,8 @@ function randomHookConfig(
           testChains.map((c) => [
             c,
             {
-              tokenExchangeRate: BigNumber.from(randomInt(1234567891234)),
-              gasPrice: BigNumber.from(randomInt(1234567891234)),
+              tokenExchangeRate: randomInt(1234567891234).toString(),
+              gasPrice: randomInt(1234567891234).toString(),
             },
           ]),
         ),
@@ -148,6 +147,7 @@ function randomHookConfig(
       return {
         owner: randomAddress(),
         type: hookType,
+        paused: false,
       };
 
     default:
@@ -285,8 +285,8 @@ describe('EvmHookModule', async () => {
           testChains.map((c) => [
             c,
             {
-              tokenExchangeRate: BigNumber.from(randomInt(1234567891234)),
-              gasPrice: BigNumber.from(randomInt(1234567891234)),
+              tokenExchangeRate: randomInt(1234567891234).toString(),
+              gasPrice: randomInt(1234567891234).toString(),
             },
           ]),
         ),
@@ -355,6 +355,7 @@ describe('EvmHookModule', async () => {
       const config: PausableHookConfig = {
         owner: randomAddress(),
         type: HookType.PAUSABLE,
+        paused: false,
       };
       await createHook(config);
     });
@@ -395,20 +396,20 @@ describe('EvmHookModule', async () => {
             },
             oracleConfig: {
               test1: {
-                tokenExchangeRate: BigNumber.from('1032586497157'),
-                gasPrice: BigNumber.from('1026942205817'),
+                tokenExchangeRate: '1032586497157',
+                gasPrice: '1026942205817',
               },
               test2: {
-                tokenExchangeRate: BigNumber.from('81451154935'),
-                gasPrice: BigNumber.from('1231220057593'),
+                tokenExchangeRate: '81451154935',
+                gasPrice: '1231220057593',
               },
               test3: {
-                tokenExchangeRate: BigNumber.from('31347320275'),
-                gasPrice: BigNumber.from('21944956734'),
+                tokenExchangeRate: '31347320275',
+                gasPrice: '21944956734',
               },
               test4: {
-                tokenExchangeRate: BigNumber.from('1018619796544'),
-                gasPrice: BigNumber.from('1124484183261'),
+                tokenExchangeRate: '1018619796544',
+                gasPrice: '1124484183261',
               },
             },
           },
@@ -432,20 +433,20 @@ describe('EvmHookModule', async () => {
                 },
                 oracleConfig: {
                   test1: {
-                    tokenExchangeRate: BigNumber.from('1132883204938'),
-                    gasPrice: BigNumber.from('1219466305935'),
+                    tokenExchangeRate: '1132883204938',
+                    gasPrice: '1219466305935',
                   },
                   test2: {
-                    tokenExchangeRate: BigNumber.from('938422264723'),
-                    gasPrice: BigNumber.from('229134538568'),
+                    tokenExchangeRate: '938422264723',
+                    gasPrice: '229134538568',
                   },
                   test3: {
-                    tokenExchangeRate: BigNumber.from('69699594189'),
-                    gasPrice: BigNumber.from('475781234236'),
+                    tokenExchangeRate: '69699594189',
+                    gasPrice: '475781234236',
                   },
                   test4: {
-                    tokenExchangeRate: BigNumber.from('1027245678936'),
-                    gasPrice: BigNumber.from('502686418976'),
+                    tokenExchangeRate: '1027245678936',
+                    gasPrice: '502686418976',
                   },
                 },
               },
@@ -465,20 +466,20 @@ describe('EvmHookModule', async () => {
                 },
                 oracleConfig: {
                   test1: {
-                    tokenExchangeRate: BigNumber.from('443874625350'),
-                    gasPrice: BigNumber.from('799154764503'),
+                    tokenExchangeRate: '443874625350',
+                    gasPrice: '799154764503',
                   },
                   test2: {
-                    tokenExchangeRate: BigNumber.from('915348561750'),
-                    gasPrice: BigNumber.from('1124345797215'),
+                    tokenExchangeRate: '915348561750',
+                    gasPrice: '1124345797215',
                   },
                   test3: {
-                    tokenExchangeRate: BigNumber.from('930832717805'),
-                    gasPrice: BigNumber.from('621743941770'),
+                    tokenExchangeRate: '930832717805',
+                    gasPrice: '621743941770',
                   },
                   test4: {
-                    tokenExchangeRate: BigNumber.from('147394981623'),
-                    gasPrice: BigNumber.from('766494385983'),
+                    tokenExchangeRate: '147394981623',
+                    gasPrice: '766494385983',
                   },
                 },
               },

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -1,45 +1,97 @@
-import { Address, ProtocolType, rootLogger } from '@hyperlane-xyz/utils';
+import { BigNumber, ethers } from 'ethers';
 
+import {
+  DomainRoutingHook,
+  DomainRoutingHook__factory,
+  FallbackDomainRoutingHook,
+  IL1CrossDomainMessenger__factory,
+  IPostDispatchHook__factory,
+  InterchainGasPaymaster,
+  OPStackHook,
+  OPStackIsm__factory,
+  ProtocolFee,
+  StaticAggregationHook,
+  StaticAggregationHookFactory__factory,
+  StaticAggregationHook__factory,
+  StorageGasOracle,
+} from '@hyperlane-xyz/core';
+import {
+  Address,
+  ProtocolType,
+  addressToBytes32,
+  configDeepEquals,
+  normalizeConfig,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
+
+import { TOKEN_EXCHANGE_RATE_SCALE } from '../consts/igp.js';
 import { HyperlaneAddresses } from '../contracts/types.js';
 import {
   HyperlaneModule,
   HyperlaneModuleParams,
 } from '../core/AbstractHyperlaneModule.js';
 import { HyperlaneDeployer } from '../deploy/HyperlaneDeployer.js';
+import { ProxyFactoryFactories } from '../deploy/contracts.js';
+import { IgpConfig } from '../gas/types.js';
+import { EvmIsmModule } from '../ism/EvmIsmModule.js';
+import { IsmType, OpStackIsmConfig } from '../ism/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
+import { ChainNameOrId } from '../types.js';
 
 import { EvmHookReader } from './EvmHookReader.js';
-import { HookFactories } from './contracts.js';
-import { HookConfig } from './types.js';
+import { DeployedHook } from './contracts.js';
+import {
+  AggregationHookConfig,
+  DomainRoutingHookConfig,
+  FallbackRoutingHookConfig,
+  HookConfig,
+  HookType,
+  IgpHookConfig,
+  OpStackHookConfig,
+  ProtocolFeeHookConfig,
+} from './types.js';
 
-// WIP example implementation of EvmHookModule
+type HookModuleAddresses = {
+  deployedHook: Address;
+  mailbox: Address;
+  proxyAdmin: Address;
+};
+
 export class EvmHookModule extends HyperlaneModule<
   ProtocolType.Ethereum,
   HookConfig,
-  HyperlaneAddresses<HookFactories> & {
-    deployedHook: Address;
-  }
+  HyperlaneAddresses<ProxyFactoryFactories> & HookModuleAddresses
 > {
-  protected logger = rootLogger.child({ module: 'EvmHookModule' });
-  protected reader: EvmHookReader;
+  protected readonly logger = rootLogger.child({ module: 'EvmHookModule' });
+  protected readonly reader: EvmHookReader;
+
+  // Adding these to reduce how often we need to grab from MultiProvider.
+  public readonly chainName: string;
+  // We use domainId here because MultiProvider.getDomainId() will always
+  // return a number, and EVM the domainId and chainId are the same.
+  public readonly domainId: number;
 
   protected constructor(
     protected readonly multiProvider: MultiProvider,
     protected readonly deployer: HyperlaneDeployer<any, any>,
     args: HyperlaneModuleParams<
       HookConfig,
-      HyperlaneAddresses<HookFactories> & {
-        deployedHook: Address;
-      }
+      HyperlaneAddresses<ProxyFactoryFactories> & HookModuleAddresses
     >,
   ) {
     super(args);
-    this.reader = new EvmHookReader(multiProvider, args.chain);
+    this.reader = new EvmHookReader(multiProvider, this.args.chain);
+
+    this.chainName = this.multiProvider.getChainName(this.args.chain);
+    this.domainId = this.multiProvider.getDomainId(this.chainName);
   }
 
   public async read(): Promise<HookConfig> {
-    return this.reader.deriveHookConfig(this.args.addresses.deployedHook);
+    const config = await this.reader.deriveHookConfig(
+      this.args.addresses.deployedHook,
+    );
+    return normalizeConfig(config);
   }
 
   public async update(_config: HookConfig): Promise<AnnotatedEV5Transaction[]> {
@@ -47,7 +99,476 @@ export class EvmHookModule extends HyperlaneModule<
   }
 
   // manually write static create function
-  public static create(_config: HookConfig): Promise<EvmHookModule> {
-    throw new Error('not implemented');
+  public static async create({
+    chain,
+    config,
+    deployer,
+    factories,
+    mailbox,
+    proxyAdmin,
+    multiProvider,
+  }: {
+    chain: ChainNameOrId;
+    config: HookConfig;
+    deployer: HyperlaneDeployer<any, any>;
+    factories: HyperlaneAddresses<ProxyFactoryFactories>;
+    mailbox: Address;
+    proxyAdmin: Address;
+    multiProvider: MultiProvider;
+  }): Promise<EvmHookModule> {
+    // instantiate new EvmHookModule
+    const module = new EvmHookModule(multiProvider, deployer, {
+      addresses: {
+        ...factories,
+        mailbox,
+        proxyAdmin,
+        deployedHook: ethers.constants.AddressZero,
+      },
+      chain,
+      config,
+    });
+
+    // deploy hook and assign address to module
+    const deployedHook = await module.deploy({ config });
+    module.args.addresses.deployedHook = deployedHook.address;
+
+    return module;
+  }
+
+  // Updates a routing hook
+  async updateRoutingHook({
+    current,
+    target,
+  }: {
+    current: DomainRoutingHookConfig | FallbackRoutingHookConfig;
+    target: DomainRoutingHookConfig | FallbackRoutingHookConfig;
+  }): Promise<AnnotatedEV5Transaction[]> {
+    // Deploy a new fallback hook if the fallback config has changed
+    if (
+      target.type === HookType.FALLBACK_ROUTING &&
+      !configDeepEquals(
+        target.fallback,
+        (current as FallbackRoutingHookConfig).fallback,
+      )
+    ) {
+      const hook = await this.deploy({ config: target });
+      this.args.addresses.deployedHook = hook.address;
+    }
+
+    // Compute delta between current and target domain configurations
+    const routingUpdates: DomainRoutingHook.HookConfigStruct[] = [];
+    const routingInterface = DomainRoutingHook__factory.createInterface();
+
+    // Iterate over the target domains and compare with the current configuration
+    for (const [dest, targetDomainConfig] of Object.entries(target.domains)) {
+      const destDomain = this.multiProvider.tryGetDomainId(dest);
+      if (!destDomain) {
+        this.logger.warn(`Domain not found in MultiProvider: ${dest}`);
+        continue;
+      }
+
+      // If the domain is not in the current config or the config has changed, deploy a new hook
+      // TODO: in-place updates per domain as a future optimization
+      if (!configDeepEquals(current.domains[dest], targetDomainConfig)) {
+        const domainHook = await this.deploy({
+          config: targetDomainConfig,
+        });
+
+        routingUpdates.push({
+          destination: destDomain,
+          hook: domainHook.address,
+        });
+      }
+    }
+
+    // Return if no updates are required
+    if (routingUpdates.length === 0) {
+      return [];
+    }
+
+    // Create tx for setting hooks
+    return [
+      {
+        annotation: 'Updating routing hooks...',
+        chainId: this.domainId,
+        to: this.args.addresses.deployedHook,
+        data: routingInterface.encodeFunctionData('setHooks', [routingUpdates]),
+      },
+    ];
+  }
+
+  protected async deploy({
+    config,
+  }: {
+    config: HookConfig;
+  }): Promise<DeployedHook> {
+    // If it's a custom ISM, just return a base ISM
+    if (typeof config === 'string') {
+      // TODO: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3773
+      // we can remove the ts-ignore once we have a proper type for custom ISMs
+      // @ts-ignore
+      return IPostDispatchHook__factory.connect(
+        config,
+        this.multiProvider.getSignerOrProvider(this.args.chain),
+      );
+    }
+
+    switch (config.type) {
+      case HookType.MERKLE_TREE:
+        return this.deployer.deployContract(this.chainName, config.type, [
+          this.args.addresses.mailbox,
+        ]);
+      case HookType.INTERCHAIN_GAS_PAYMASTER:
+        return this.deployIgpHook({ config });
+      case HookType.AGGREGATION:
+        return this.deployAggregationHook({ config });
+      case HookType.PROTOCOL_FEE:
+        return this.deployProtocolFeeHook({ config });
+      case HookType.OP_STACK:
+        return this.deployOpStackHook({ config });
+      case HookType.ROUTING:
+      case HookType.FALLBACK_ROUTING:
+        return this.deployRoutingHook({ config });
+      case HookType.PAUSABLE: {
+        return this.deployer.deployContract(this.chainName, config.type, []);
+      }
+      default:
+        throw new Error(`Unsupported hook config: ${config}`);
+    }
+  }
+
+  protected async deployProtocolFeeHook({
+    config,
+  }: {
+    config: ProtocolFeeHookConfig;
+  }): Promise<ProtocolFee> {
+    this.logger.debug('Deploying ProtocolFeeHook...');
+    return this.deployer.deployContract(this.chainName, HookType.PROTOCOL_FEE, [
+      config.maxProtocolFee,
+      config.protocolFee,
+      config.beneficiary,
+      config.owner,
+    ]);
+  }
+
+  protected async deployAggregationHook({
+    config,
+  }: {
+    config: AggregationHookConfig;
+  }): Promise<StaticAggregationHook> {
+    this.logger.debug('Deploying AggregationHook...');
+
+    // deploy subhooks
+    const aggregatedHooks = await Promise.all(
+      config.hooks.map(async (hookConfig) => {
+        const subhook = await this.deploy({ config: hookConfig });
+        return subhook.address;
+      }),
+    );
+
+    // deploy aggregation hook
+    this.logger.debug(
+      `Deploying aggregation hook of type ${config.hooks.map((h) =>
+        typeof h === 'string' ? h : h.type,
+      )}...`,
+    );
+    const signer = this.multiProvider.getSigner(this.chainName);
+    const factory = StaticAggregationHookFactory__factory.connect(
+      this.args.addresses.staticAggregationHookFactory,
+      signer,
+    );
+    const address = await EvmIsmModule.deployStaticAddressSet({
+      chain: this.chainName,
+      factory,
+      values: aggregatedHooks,
+      logger: this.logger,
+      multiProvider: this.multiProvider,
+    });
+
+    // return aggregation hook
+    return StaticAggregationHook__factory.connect(address, signer);
+  }
+
+  protected async deployOpStackHook({
+    config,
+  }: {
+    config: OpStackHookConfig;
+  }): Promise<OPStackHook> {
+    const chain = this.chainName;
+    const mailbox = this.args.addresses.mailbox;
+    this.logger.debug(
+      'Deploying OPStackHook for %s to %s...',
+      chain,
+      config.destinationChain,
+    );
+
+    // fetch l2 messenger address from l1 messenger
+    const l1Messenger = IL1CrossDomainMessenger__factory.connect(
+      config.nativeBridge,
+      this.multiProvider.getSignerOrProvider(chain),
+    );
+    const l2Messenger: Address = await l1Messenger.OTHER_MESSENGER();
+    // deploy opstack ism
+    const ismConfig: OpStackIsmConfig = {
+      type: IsmType.OP_STACK,
+      origin: chain,
+      nativeBridge: l2Messenger,
+    };
+
+    // deploy opstack ism
+    const opStackIsmAddress = (
+      await EvmIsmModule.create({
+        chain,
+        config: ismConfig,
+        deployer: this.deployer,
+        factories: this.args.addresses,
+        mailbox: mailbox,
+        multiProvider: this.multiProvider,
+      })
+    ).serialize().deployedIsm;
+
+    // connect to ISM
+    const opstackIsm = OPStackIsm__factory.connect(
+      opStackIsmAddress,
+      this.multiProvider.getSignerOrProvider(chain),
+    );
+
+    // deploy opstack hook
+    const hook = await this.deployer.deployContract(chain, HookType.OP_STACK, [
+      mailbox,
+      this.multiProvider.getDomainId(config.destinationChain),
+      addressToBytes32(opstackIsm.address),
+      config.nativeBridge,
+    ]);
+
+    const overrides = this.multiProvider.getTransactionOverrides(chain);
+
+    // set authorized hook on opstack ism
+    const authorizedHook = await opstackIsm.authorizedHook();
+    if (authorizedHook === addressToBytes32(hook.address)) {
+      this.logger.debug(
+        'Authorized hook already set on ism %s',
+        opstackIsm.address,
+      );
+      return hook;
+    } else if (
+      authorizedHook !== addressToBytes32(ethers.constants.AddressZero)
+    ) {
+      this.logger.debug(
+        'Authorized hook mismatch on ism %s, expected %s, got %s',
+        opstackIsm.address,
+        addressToBytes32(hook.address),
+        authorizedHook,
+      );
+      throw new Error('Authorized hook mismatch');
+    }
+
+    // check if mismatch and redeploy hook
+    this.logger.debug(
+      'Setting authorized hook %s on ism % on destination %s',
+      hook.address,
+      opstackIsm.address,
+      config.destinationChain,
+    );
+    await this.multiProvider.handleTx(
+      config.destinationChain,
+      opstackIsm.setAuthorizedHook(addressToBytes32(hook.address), overrides),
+    );
+
+    return hook;
+  }
+
+  protected async deployRoutingHook({
+    config,
+  }: {
+    config: DomainRoutingHookConfig | FallbackRoutingHookConfig;
+  }): Promise<DomainRoutingHook> {
+    // originally set owner to deployer so we can set hooks
+    // ownership transferred by the end of an update() step
+    const deployerAddress = await this.multiProvider
+      .getSigner(this.chainName)
+      .getAddress();
+
+    let routingHook: DomainRoutingHook | FallbackDomainRoutingHook;
+    if (config.type === HookType.FALLBACK_ROUTING) {
+      // deploy fallback hook
+      const fallbackHook = await this.deploy({ config: config.fallback });
+      // deploy routing hook with fallback
+      routingHook = await this.deployer.deployContract(
+        this.chainName,
+        HookType.FALLBACK_ROUTING,
+        [this.args.addresses.mailbox, deployerAddress, fallbackHook.address],
+      );
+    } else {
+      // deploy routing hook
+      routingHook = await this.deployer.deployContract(
+        this.chainName,
+        HookType.ROUTING,
+        [this.args.addresses.mailbox, deployerAddress],
+      );
+    }
+
+    // obtain update TXs for setting hooks and transferring ownership
+    const updateTxs = await this.updateRoutingHook({
+      current: {
+        ...config,
+        domains: {},
+      },
+      target: config,
+    });
+
+    // apply updates
+    for (const tx of updateTxs) {
+      await this.multiProvider.sendTransaction(this.chainName, tx);
+    }
+
+    // return a fully configured routing hook
+    return routingHook;
+  }
+
+  protected async deployIgpHook({
+    config,
+  }: {
+    config: IgpHookConfig;
+  }): Promise<InterchainGasPaymaster> {
+    this.logger.debug('Deploying IGP as hook...');
+
+    // Deploy the StorageGasOracle
+    const storageGasOracle = await this.deployStorageGasOracle({
+      config,
+    });
+
+    // Deploy the InterchainGasPaymaster
+    const interchainGasPaymaster = await this.deployInterchainGasPaymaster({
+      storageGasOracle,
+      config,
+    });
+
+    // Return an ownership transfer transaction if required
+    await interchainGasPaymaster['transferOwnership(address)'](
+      config.oracleKey,
+    );
+
+    return interchainGasPaymaster;
+  }
+
+  protected async deployInterchainGasPaymaster({
+    storageGasOracle,
+    config,
+  }: {
+    storageGasOracle: StorageGasOracle;
+    config: IgpConfig;
+  }): Promise<InterchainGasPaymaster> {
+    const deployerAddress = await this.multiProvider.getSignerAddress(
+      this.chainName,
+    );
+    const igp = await this.deployer.deployProxiedContract(
+      this.chainName,
+      'interchainGasPaymaster',
+      'interchainGasPaymaster',
+      this.args.addresses.proxyAdmin,
+      [],
+      [deployerAddress, config.beneficiary],
+    );
+
+    const gasParamsToSet: InterchainGasPaymaster.GasParamStruct[] = [];
+    for (const [remote, gasOverhead] of Object.entries(config.overhead)) {
+      // TODO: add back support for non-EVM remotes.
+      // Previously would check core metadata for non EVMs and fallback to multiprovider for custom EVMs
+      const remoteDomain = this.multiProvider.tryGetDomainId(remote);
+      if (!remoteDomain) {
+        this.logger.warn(
+          `Skipping overhead ${this.chainName} -> ${remote}. Expected if the remote is a non-EVM chain.`,
+        );
+        continue;
+      }
+
+      this.logger.debug(
+        `Setting gas params for ${this.chainName} -> ${remote}: gasOverhead = ${gasOverhead} gasOracle = ${storageGasOracle.address}`,
+      );
+      gasParamsToSet.push({
+        remoteDomain,
+        config: {
+          gasOverhead,
+          gasOracle: storageGasOracle.address,
+        },
+      });
+    }
+
+    if (gasParamsToSet.length > 0) {
+      await this.multiProvider.handleTx(
+        this.chainName,
+        igp.setDestinationGasConfigs(
+          gasParamsToSet,
+          this.multiProvider.getTransactionOverrides(this.chainName),
+        ),
+      );
+    }
+
+    return igp;
+  }
+
+  protected async deployStorageGasOracle({
+    config,
+  }: {
+    config: IgpConfig;
+  }): Promise<StorageGasOracle> {
+    const gasOracle = await this.deployer.deployContract(
+      this.chainName,
+      'storageGasOracle',
+      [],
+    );
+
+    if (!config.oracleConfig) {
+      this.logger.debug('No oracle config provided, skipping...');
+      return gasOracle;
+    }
+
+    this.logger.info(`Configuring gas oracle from ${this.chainName}...`);
+    const configsToSet: Array<StorageGasOracle.RemoteGasDataConfigStruct> = [];
+
+    for (const [remote, desired] of Object.entries(config.oracleConfig)) {
+      // TODO: add back support for non-EVM remotes.
+      // Previously would check core metadata for non EVMs and fallback to multiprovider for custom EVMs
+      const remoteDomain = this.multiProvider.tryGetDomainId(remote);
+      if (!remoteDomain) {
+        this.logger.warn(
+          `Skipping gas oracle ${this.chainName} -> ${remote}.` +
+            ' Expected if the remote is a non-EVM chain or the remote domain is not the in the MultiProvider.',
+        );
+        continue;
+      }
+
+      configsToSet.push({
+        remoteDomain,
+        ...desired,
+      });
+
+      // Log an example remote gas cost
+      const exampleRemoteGas = (config.overhead[remote] ?? 200_000) + 50_000;
+      const exampleRemoteGasCost = BigNumber.from(desired.tokenExchangeRate)
+        .mul(desired.gasPrice)
+        .mul(exampleRemoteGas)
+        .div(TOKEN_EXCHANGE_RATE_SCALE);
+      this.logger.info(
+        `${
+          this.chainName
+        } -> ${remote}: ${exampleRemoteGas} remote gas cost: ${ethers.utils.formatEther(
+          exampleRemoteGasCost,
+        )}`,
+      );
+    }
+
+    if (configsToSet.length > 0) {
+      await this.multiProvider.handleTx(
+        this.chainName,
+        gasOracle.setRemoteGasDataConfigs(
+          configsToSet,
+          this.multiProvider.getTransactionOverrides(this.chainName),
+        ),
+      );
+    }
+
+    return gasOracle;
   }
 }

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -520,6 +520,7 @@ export class EvmHookModule extends HyperlaneModule<
       this.args.addresses.proxyAdmin,
       [],
       [deployerAddress, config.beneficiary],
+      false,
     );
 
     const gasParamsToSet: InterchainGasPaymaster.GasParamStruct[] = [];

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -248,7 +248,7 @@ export class EvmHookModule extends HyperlaneModule<
       case HookType.MERKLE_TREE:
         return this.deployer.deployContract({
           chain: this.chain,
-          contractKey: config.type,
+          contractKey: HookType.MERKLE_TREE,
           constructorArgs: [this.args.addresses.mailbox],
         });
       case HookType.INTERCHAIN_GAS_PAYMASTER:
@@ -528,8 +528,8 @@ export class EvmHookModule extends HyperlaneModule<
 
     const igp = await this.deployer.deployProxiedContract({
       chain: this.chain,
-      contractKey: 'interchainGasPaymaster',
-      contractName: 'interchainGasPaymaster',
+      contractKey: HookType.INTERCHAIN_GAS_PAYMASTER,
+      contractName: HookType.INTERCHAIN_GAS_PAYMASTER,
       proxyAdmin: this.args.addresses.proxyAdmin,
       constructorArgs: [],
       initializeArgs: [deployerAddress, config.beneficiary],

--- a/typescript/sdk/src/ism/EvmIsmModule.hardhat-test.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.hardhat-test.ts
@@ -50,37 +50,42 @@ function randomModuleType(): ModuleType {
 const randomIsmConfig = (depth = 0, maxDepth = 2): IsmConfig => {
   const moduleType =
     depth == maxDepth ? ModuleType.MERKLE_ROOT_MULTISIG : randomModuleType();
-  if (moduleType === ModuleType.MERKLE_ROOT_MULTISIG) {
-    const n = randomInt(5, 1);
-    return randomMultisigIsmConfig(randomInt(n, 1), n);
-  } else if (moduleType === ModuleType.ROUTING) {
-    const config: RoutingIsmConfig = {
-      type: IsmType.ROUTING,
-      owner: randomAddress(),
-      domains: Object.fromEntries(
-        testChains.map((c) => [c, randomIsmConfig(depth + 1)]),
-      ),
-    };
-    return config;
-  } else if (moduleType === ModuleType.AGGREGATION) {
-    const n = randomInt(5, 1);
-    const modules = new Array<number>(n)
-      .fill(0)
-      .map(() => randomIsmConfig(depth + 1));
-    const config: AggregationIsmConfig = {
-      type: IsmType.AGGREGATION,
-      threshold: randomInt(n, 1),
-      modules,
-    };
-    return config;
-  } else if (moduleType === ModuleType.NULL) {
-    const config: TrustedRelayerIsmConfig = {
-      type: IsmType.TRUSTED_RELAYER,
-      relayer: randomAddress(),
-    };
-    return config;
-  } else {
-    throw new Error(`Unsupported ISM type: ${moduleType}`);
+  switch (moduleType) {
+    case ModuleType.MERKLE_ROOT_MULTISIG: {
+      const n = randomInt(5, 1);
+      return randomMultisigIsmConfig(randomInt(n, 1), n);
+    }
+    case ModuleType.ROUTING: {
+      const config: RoutingIsmConfig = {
+        type: IsmType.ROUTING,
+        owner: randomAddress(),
+        domains: Object.fromEntries(
+          testChains.map((c) => [c, randomIsmConfig(depth + 1)]),
+        ),
+      };
+      return config;
+    }
+    case ModuleType.AGGREGATION: {
+      const n = randomInt(5, 1);
+      const modules = new Array<number>(n)
+        .fill(0)
+        .map(() => randomIsmConfig(depth + 1));
+      const config: AggregationIsmConfig = {
+        type: IsmType.AGGREGATION,
+        threshold: randomInt(n, 1),
+        modules,
+      };
+      return config;
+    }
+    case ModuleType.NULL: {
+      const config: TrustedRelayerIsmConfig = {
+        type: IsmType.TRUSTED_RELAYER,
+        relayer: randomAddress(),
+      };
+      return config;
+    }
+    default:
+      throw new Error(`Unsupported ISM type: ${moduleType}`);
   }
 };
 

--- a/typescript/sdk/src/ism/EvmIsmModule.hardhat-test.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.hardhat-test.ts
@@ -91,7 +91,6 @@ const randomIsmConfig = (depth = 0, maxDepth = 2): IsmConfig => {
 
 describe('EvmIsmModule', async () => {
   let multiProvider: MultiProvider;
-  let ismFactoryDeployer: HyperlaneProxyFactoryDeployer;
   let exampleRoutingConfig: RoutingIsmConfig;
   let mailboxAddress: Address;
   let newMailboxAddress: Address;
@@ -106,10 +105,9 @@ describe('EvmIsmModule', async () => {
     fundingAccount = funder;
     multiProvider = MultiProvider.createTestMultiProvider({ signer });
 
-    ismFactoryDeployer = new HyperlaneProxyFactoryDeployer(multiProvider);
-    const contractsMap = await ismFactoryDeployer.deploy(
-      multiProvider.mapKnownChains(() => ({})),
-    );
+    const contractsMap = await new HyperlaneProxyFactoryDeployer(
+      multiProvider,
+    ).deploy(multiProvider.mapKnownChains(() => ({})));
 
     // get addresses of factories for the chain
     factoryContracts = contractsMap[chain];
@@ -191,8 +189,7 @@ describe('EvmIsmModule', async () => {
     const ism = await EvmIsmModule.create({
       chain,
       config,
-      deployer: ismFactoryDeployer,
-      factories: factoryAddresses,
+      proxyFactoryFactories: factoryAddresses,
       mailbox: mailboxAddress,
       multiProvider,
     });

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -382,6 +382,8 @@ export class EvmIsmModule extends HyperlaneModule<
           new OPStackIsm__factory(),
           IsmType.OP_STACK,
           [config.nativeBridge],
+          undefined,
+          false,
         );
 
       case IsmType.PAUSABLE:
@@ -390,6 +392,8 @@ export class EvmIsmModule extends HyperlaneModule<
           new PausableIsm__factory(),
           IsmType.PAUSABLE,
           [config.owner],
+          undefined,
+          false,
         );
 
       case IsmType.TRUSTED_RELAYER:
@@ -402,6 +406,8 @@ export class EvmIsmModule extends HyperlaneModule<
           new TrustedRelayerIsm__factory(),
           IsmType.TRUSTED_RELAYER,
           [this.args.addresses.mailbox, config.relayer],
+          undefined,
+          false,
         );
 
       case IsmType.TEST_ISM:
@@ -410,6 +416,8 @@ export class EvmIsmModule extends HyperlaneModule<
           new TestIsm__factory(),
           IsmType.TEST_ISM,
           [],
+          undefined,
+          false,
         );
 
       default:

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -92,9 +92,18 @@ export class EvmIsmModule extends HyperlaneModule<
     super(params);
 
     this.reader = new EvmIsmReader(multiProvider, params.chain);
-    const { mailbox: _, deployedIsm: __, ...addresses } = params.addresses;
     this.factories = attachAndConnectContracts(
-      addresses,
+      {
+        staticMerkleRootMultisigIsmFactory:
+          params.addresses.staticMerkleRootMultisigIsmFactory,
+        staticMessageIdMultisigIsmFactory:
+          params.addresses.staticMessageIdMultisigIsmFactory,
+        staticAggregationIsmFactory:
+          params.addresses.staticAggregationIsmFactory,
+        staticAggregationHookFactory:
+          params.addresses.staticAggregationHookFactory,
+        domainRoutingIsmFactory: params.addresses.domainRoutingIsmFactory,
+      },
       proxyFactoryFactories,
       multiProvider.getSigner(params.chain),
     );

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -16,8 +16,6 @@ import {
   OPStackIsm__factory,
   Ownable__factory,
   PausableIsm__factory,
-  StaticAddressSetFactory,
-  StaticThresholdAddressSetFactory,
   TestIsm__factory,
   TrustedRelayerIsm__factory,
 } from '@hyperlane-xyz/core';
@@ -39,11 +37,12 @@ import {
   HyperlaneModule,
   HyperlaneModuleParams,
 } from '../core/AbstractHyperlaneModule.js';
-import { HyperlaneDeployer } from '../deploy/HyperlaneDeployer.js';
+import { EvmModuleDeployer } from '../deploy/EvmModuleDeployer.js';
 import {
   ProxyFactoryFactories,
   proxyFactoryFactories,
 } from '../deploy/contracts.js';
+import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
 import { ChainName, ChainNameOrId } from '../types.js';
@@ -73,6 +72,7 @@ export class EvmIsmModule extends HyperlaneModule<
 > {
   protected readonly logger = rootLogger.child({ module: 'EvmIsmModule' });
   protected readonly reader: EvmIsmReader;
+  protected readonly deployer: EvmModuleDeployer<any>;
   protected readonly factories: HyperlaneContracts<ProxyFactoryFactories>;
 
   // Adding these to reduce how often we need to grab from MultiProvider.
@@ -83,15 +83,22 @@ export class EvmIsmModule extends HyperlaneModule<
 
   protected constructor(
     protected readonly multiProvider: MultiProvider,
-    protected readonly deployer: HyperlaneDeployer<any, any>,
     params: HyperlaneModuleParams<
       IsmConfig,
       HyperlaneAddresses<ProxyFactoryFactories> & IsmModuleAddresses
     >,
+    contractVerifier?: ContractVerifier,
   ) {
     super(params);
 
     this.reader = new EvmIsmReader(multiProvider, params.chain);
+    this.deployer = new EvmModuleDeployer(
+      this.multiProvider,
+      {},
+      this.logger,
+      contractVerifier,
+    );
+
     this.factories = attachAndConnectContracts(
       {
         staticMerkleRootMultisigIsmFactory:
@@ -149,9 +156,9 @@ export class EvmIsmModule extends HyperlaneModule<
 
     // Else, we have to figure out what an update for this ISM entails
 
-    // If target config is a custom ISM, just update the address
-    // if config -> custom ISM, update address
-    // if custom ISM -> custom ISM, update address
+    // If target config is an address ISM, just update the address
+    // if config -> address ISM, update address
+    // if address ISM -> address ISM, update address
     if (typeof targetConfig === 'string') {
       // TODO: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3773
       this.args.addresses.deployedIsm = targetConfig;
@@ -160,7 +167,7 @@ export class EvmIsmModule extends HyperlaneModule<
 
     // Check if we need to deploy a new ISM
     if (
-      // if custom ISM -> config, do a new deploy
+      // if address ISM -> config, do a new deploy
       typeof currentConfig === 'string' ||
       // if config -> config, AND types are different, do a new deploy
       currentConfig.type !== targetConfig.type ||
@@ -251,21 +258,23 @@ export class EvmIsmModule extends HyperlaneModule<
   }
 
   // manually write static create function
-  public static async create(params: {
+  public static async create({
+    chain,
+    config,
+    proxyFactoryFactories,
+    mailbox,
+    multiProvider,
+  }: {
     chain: ChainNameOrId;
     config: IsmConfig;
-    deployer: HyperlaneDeployer<any, any>;
-    factories: HyperlaneAddresses<ProxyFactoryFactories>;
+    proxyFactoryFactories: HyperlaneAddresses<ProxyFactoryFactories>;
     mailbox: Address;
     multiProvider: MultiProvider;
   }): Promise<EvmIsmModule> {
-    const { chain, config, deployer, factories, mailbox, multiProvider } =
-      params;
-
     // instantiate new EvmIsmModule
-    const module = new EvmIsmModule(multiProvider, deployer, {
+    const module = new EvmIsmModule(multiProvider, {
       addresses: {
-        ...factories,
+        ...proxyFactoryFactories,
         mailbox,
         deployedIsm: ethers.constants.AddressZero,
       },
@@ -339,10 +348,10 @@ export class EvmIsmModule extends HyperlaneModule<
   }: {
     config: C;
   }): Promise<DeployedIsm> {
-    // If it's a custom ISM, just return a base ISM
+    // If it's an address ISM, just return a base ISM
     if (typeof config === 'string') {
       // TODO: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3773
-      // we can remove the ts-ignore once we have a proper type for custom ISMs
+      // we can remove the ts-ignore once we have a proper type for address ISMs
       // @ts-ignore
       return IInterchainSecurityModule__factory.connect(
         config,
@@ -377,48 +386,40 @@ export class EvmIsmModule extends HyperlaneModule<
         });
 
       case IsmType.OP_STACK:
-        return this.deployer.deployContractFromFactory(
-          this.chain,
-          new OPStackIsm__factory(),
-          IsmType.OP_STACK,
-          [config.nativeBridge],
-          undefined,
-          false,
-        );
+        return this.deployer.deployContractFromFactory({
+          chain: this.chain,
+          factory: new OPStackIsm__factory(),
+          contractName: IsmType.OP_STACK,
+          constructorArgs: [config.nativeBridge],
+        });
 
       case IsmType.PAUSABLE:
-        return this.deployer.deployContractFromFactory(
-          this.chain,
-          new PausableIsm__factory(),
-          IsmType.PAUSABLE,
-          [config.owner],
-          undefined,
-          false,
-        );
+        return this.deployer.deployContractFromFactory({
+          chain: this.chain,
+          factory: new PausableIsm__factory(),
+          contractName: IsmType.PAUSABLE,
+          constructorArgs: [config.owner],
+        });
 
       case IsmType.TRUSTED_RELAYER:
         assert(
           this.args.addresses.mailbox,
           `Mailbox address is required for deploying ${ismType}`,
         );
-        return this.deployer.deployContractFromFactory(
-          this.chain,
-          new TrustedRelayerIsm__factory(),
-          IsmType.TRUSTED_RELAYER,
-          [this.args.addresses.mailbox, config.relayer],
-          undefined,
-          false,
-        );
+        return this.deployer.deployContractFromFactory({
+          chain: this.chain,
+          factory: new TrustedRelayerIsm__factory(),
+          contractName: IsmType.TRUSTED_RELAYER,
+          constructorArgs: [this.args.addresses.mailbox, config.relayer],
+        });
 
       case IsmType.TEST_ISM:
-        return this.deployer.deployContractFromFactory(
-          this.chain,
-          new TestIsm__factory(),
-          IsmType.TEST_ISM,
-          [],
-          undefined,
-          false,
-        );
+        return this.deployer.deployContractFromFactory({
+          chain: this.chain,
+          factory: new TestIsm__factory(),
+          contractName: IsmType.TEST_ISM,
+          constructorArgs: [],
+        });
 
       default:
         throw new Error(`Unsupported ISM type ${ismType}`);
@@ -438,7 +439,7 @@ export class EvmIsmModule extends HyperlaneModule<
         ? 'staticMerkleRootMultisigIsmFactory'
         : 'staticMessageIdMultisigIsmFactory';
 
-    const address = await EvmIsmModule.deployStaticAddressSet({
+    const address = await EvmModuleDeployer.deployStaticAddressSet({
       chain: this.chain,
       factory: this.factories[factoryName],
       values: config.validators,
@@ -562,7 +563,7 @@ export class EvmIsmModule extends HyperlaneModule<
     }
 
     const factoryName = 'staticAggregationIsmFactory';
-    const address = await EvmIsmModule.deployStaticAddressSet({
+    const address = await EvmModuleDeployer.deployStaticAddressSet({
       chain: this.chain,
       factory: this.factories[factoryName],
       values: addresses,
@@ -593,61 +594,6 @@ export class EvmIsmModule extends HyperlaneModule<
 
     // Update the mailbox address in the arguments
     this.args.addresses.mailbox = newMailboxAddress;
-  }
-
-  // Public so it can be reused by the hook module.
-  // Caller of this function is responsible for verifying the contract
-  // because they know exactly which factory is being called.
-  public static async deployStaticAddressSet({
-    chain,
-    factory,
-    values,
-    logger,
-    threshold = values.length,
-    multiProvider,
-  }: {
-    chain: ChainName;
-    factory: StaticThresholdAddressSetFactory | StaticAddressSetFactory;
-    values: Address[];
-    logger: Logger;
-    threshold?: number;
-    multiProvider: MultiProvider;
-  }): Promise<Address> {
-    const address = await factory['getAddress(address[],uint8)'](
-      values,
-      threshold,
-    );
-    const code = await multiProvider.getProvider(chain).getCode(address);
-    if (code === '0x') {
-      logger.debug(
-        `Deploying new ${threshold} of ${values.length} address set to ${chain}`,
-      );
-      const overrides = multiProvider.getTransactionOverrides(chain);
-      const hash = await factory['deploy(address[],uint8)'](
-        values,
-        threshold,
-        overrides,
-      );
-      await multiProvider.handleTx(chain, hash);
-    } else {
-      logger.debug(
-        `Recovered ${threshold} of ${values.length} address set on ${chain}: ${address}`,
-      );
-    }
-
-    // TODO: figure out how to get the constructor arguments for manual deploy TXs
-    // const verificationInput = buildVerificationInput(
-    //   NAME,
-    //   ADDRESS,
-    //   CONSTRUCTOR_ARGS,
-    // );
-    // await this.deployer.verifyContract(
-    //   this.chainName,
-    //   verificationInput,
-    //   logger,
-    // );
-
-    return address;
   }
 
   // filtering out domains which are not part of the multiprovider

--- a/typescript/sdk/src/ism/metadata/multisig.ts
+++ b/typescript/sdk/src/ism/metadata/multisig.ts
@@ -220,7 +220,15 @@ export class MultisigMetadataBuilder implements MetadataBuilder {
     return toHexString(buf);
   }
 
-  static decodeSimplePrefix(metadata: string) {
+  static decodeSimplePrefix(metadata: string): {
+    signatureOffset: number;
+    type: IsmType;
+    checkpoint: {
+      root: string;
+      index: number;
+      merkle_tree_hook_address: string;
+    };
+  } {
     const buf = fromHexString(metadata);
     const merkleTree = toHexString(buf.subarray(0, 32));
     const root = toHexString(buf.subarray(32, 64));
@@ -251,7 +259,16 @@ export class MultisigMetadataBuilder implements MetadataBuilder {
     return toHexString(buf);
   }
 
-  static decodeProofPrefix(metadata: string) {
+  static decodeProofPrefix(metadata: string): {
+    signatureOffset: number;
+    type: IsmType;
+    checkpoint: {
+      root: string;
+      index: number;
+      merkle_tree_hook_address: string;
+    };
+    proof: MerkleProof;
+  } {
     const buf = fromHexString(metadata);
     const merkleTree = toHexString(buf.subarray(0, 32));
     const messageIndex = buf.readUint32BE(32);

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -97,7 +97,7 @@ export class HyperlaneSmartProvider
     this.supportedMethods = [...supportedMethods.values()];
   }
 
-  async getPriorityFee() {
+  async getPriorityFee(): Promise<BigNumber> {
     try {
       return BigNumber.from(await this.perform('maxPriorityFeePerGas', {}));
     } catch (error) {

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -305,7 +305,7 @@ export class EvmHypXERC20LockboxAdapter
     );
   }
 
-  async getMintLimit() {
+  async getMintLimit(): Promise<bigint> {
     const xERC20 = await this.hypXERC20Lockbox.xERC20();
 
     const limit = await IXERC20__factory.connect(
@@ -316,7 +316,7 @@ export class EvmHypXERC20LockboxAdapter
     return BigInt(limit.toString());
   }
 
-  async getBurnLimit() {
+  async getBurnLimit(): Promise<bigint> {
     const xERC20 = await this.hypXERC20Lockbox.xERC20();
 
     const limit = await IXERC20__factory.connect(
@@ -348,7 +348,7 @@ export class EvmHypXERC20Adapter
     );
   }
 
-  async getMintLimit() {
+  async getMintLimit(): Promise<bigint> {
     const xERC20 = await this.hypXERC20.wrappedToken();
 
     const limit = await IXERC20__factory.connect(
@@ -359,7 +359,7 @@ export class EvmHypXERC20Adapter
     return BigInt(limit.toString());
   }
 
-  async getBurnLimit() {
+  async getBurnLimit(): Promise<bigint> {
     const xERC20 = await this.hypXERC20.wrappedToken();
 
     const limit = await IXERC20__factory.connect(

--- a/typescript/sdk/src/token/config.ts
+++ b/typescript/sdk/src/token/config.ts
@@ -18,7 +18,7 @@ export const CollateralExtensions = [
   TokenType.collateralVault,
 ];
 
-export const gasOverhead = (tokenType: TokenType) => {
+export const gasOverhead = (tokenType: TokenType): number => {
   switch (tokenType) {
     case TokenType.fastSynthetic:
     case TokenType.synthetic:

--- a/typescript/utils/src/objects.ts
+++ b/typescript/utils/src/objects.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual } from 'node:assert/strict';
 import { stringify as yamlStringify } from 'yaml';
 
 import { ethersBigNumberSerializer, rootLogger } from './logging.js';
+import { WithAddress } from './types.js';
 import { assert } from './validation.js';
 
 export function isObject(item: any) {
@@ -157,7 +158,7 @@ export function stringifyObject(
 }
 
 // Function to recursively remove 'address' properties and lowercase string properties
-export function normalizeConfig(obj: any): any {
+export function normalizeConfig(obj: WithAddress<any>): any {
   if (Array.isArray(obj)) {
     return obj.map(normalizeConfig);
   } else if (obj !== null && typeof obj === 'object') {

--- a/typescript/utils/src/objects.ts
+++ b/typescript/utils/src/objects.ts
@@ -143,7 +143,7 @@ export function arrayToObject(keys: Array<string>, val = true) {
 }
 
 export function stringifyObject(
-  object: object,
+  object: any,
   format: 'json' | 'yaml' = 'yaml',
   space?: number,
 ): string {


### PR DESCRIPTION
resolves https://github.com/hyperlane-xyz/issues/issues/1153

- enables creation of new Hooks through the EvmHookModule
- introduce `EvmModuleDeployer`
	- separate from `HyperlaneDeployer`
	- contains some basic methods to deploy a contract/proxy
	- reduces module necessity HyperlaneDeployer

IN PROGRESS:
- [x] tests
	- [x] figure out why randomly generated routing/fallbackrouting hooks fail
	- [x] figure out why protocol fee hooks fail
![image](https://github.com/hyperlane-xyz/hyperlane-monorepo/assets/10051819/4cba7af3-4e72-49f6-8f98-fd7fea147282)
