### PR TITLE
feat(cli): add 'hyperlane warp config' command

### DIFF
--- a/.changeset/great-cycles-tickle.md
+++ b/.changeset/great-cycles-tickle.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Adds 'hyperlane warp config'.

--- a/typescript/cli/cli.ts
+++ b/typescript/cli/cli.ts
@@ -23,6 +23,7 @@ import {
 import { sendCommand } from './src/commands/send.js';
 import { statusCommand } from './src/commands/status.js';
 import { validatorCommand } from './src/commands/validator.js';
+import { warpCommand } from './src/commands/warp.js';
 import { contextMiddleware } from './src/context/context.js';
 import { configureLogger, errorRed } from './src/logger.js';
 import { checkVersion } from './src/utils/version-check.js';
@@ -61,6 +62,7 @@ try {
     .command(sendCommand)
     .command(statusCommand)
     .command(validatorCommand)
+    .command(warpCommand)
     .version(VERSION)
     .demandCommand()
     .strict()

--- a/typescript/cli/src/commands/config.ts
+++ b/typescript/cli/src/commands/config.ts
@@ -3,14 +3,11 @@ import { CommandModule } from 'yargs';
 import { createChainConfig, readChainConfigs } from '../config/chain.js';
 import { readIsmConfig } from '../config/ism.js';
 import { readMultisigConfig } from '../config/multisig.js';
-import {
-  createWarpRouteDeployConfig,
-  readWarpRouteDeployConfig,
-} from '../config/warp.js';
+import { readWarpRouteDeployConfig } from '../config/warp.js';
 import { CommandModuleWithContext } from '../context/types.js';
 import { log, logGreen } from '../logger.js';
 
-import { inputFileCommandOption, outputFileCommandOption } from './options.js';
+import { inputFileCommandOption } from './options.js';
 
 /**
  * Parent command
@@ -34,11 +31,7 @@ const createCommand: CommandModule = {
   command: 'create',
   describe: 'Create a new Hyperlane config',
   builder: (yargs) =>
-    yargs
-      .command(createChainConfigCommand)
-      .command(createWarpRouteDeployConfigCommand)
-      .version(false)
-      .demandCommand(),
+    yargs.command(createChainConfigCommand).version(false).demandCommand(),
   handler: () => log('Command required'),
 };
 
@@ -47,20 +40,6 @@ const createChainConfigCommand: CommandModuleWithContext<{}> = {
   describe: 'Create a new, minimal Hyperlane chain config (aka chain metadata)',
   handler: async ({ context }) => {
     await createChainConfig({ context });
-    process.exit(0);
-  },
-};
-
-const createWarpRouteDeployConfigCommand: CommandModuleWithContext<{
-  out: string;
-}> = {
-  command: 'warp',
-  describe: 'Create a new Warp Route deployment config',
-  builder: {
-    out: outputFileCommandOption('./configs/warp-route-deployment.yaml'),
-  },
-  handler: async ({ context, out }) => {
-    await createWarpRouteDeployConfig({ context, outPath: out });
     process.exit(0);
   },
 };

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -1,0 +1,41 @@
+import { CommandModule } from 'yargs';
+
+import { createWarpRouteDeployConfig } from '../config/warp.js';
+import { CommandModuleWithContext } from '../context/types.js';
+import { log } from '../logger.js';
+
+import { outputFileCommandOption } from './options.js';
+
+/**
+ * Parent command
+ */
+export const warpCommand: CommandModule = {
+  command: 'warp',
+  describe: 'Manage Hyperlane warp routes',
+  builder: (yargs) => yargs.command(config).version(false).demandCommand(),
+  handler: () => log('Command required'),
+};
+
+export const config: CommandModuleWithContext<{
+  ismAdvanced: boolean;
+  out: string;
+}> = {
+  command: 'config',
+  describe: 'Create a warp route configuration.',
+  builder: {
+    ismAdvanced: {
+      type: 'boolean',
+      describe: 'Create an advanced ISM & hook configuration',
+      default: false,
+    },
+    out: outputFileCommandOption('./configs/warp-route-deployment.yaml'),
+  },
+  handler: async ({ context, ismAdvanced, out }) => {
+    await createWarpRouteDeployConfig({
+      context,
+      outPath: out,
+      shouldUseDefault: !ismAdvanced,
+    });
+    process.exit(0);
+  },
+};

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -189,7 +189,7 @@ export async function createMultisigConfig(
   };
 }
 
-async function createTrustedRelayerConfig(
+export async function createTrustedRelayerConfig(
   context: CommandContext,
 ): Promise<TrustedRelayerIsmConfig> {
   const relayer = await detectAndConfirmOrPrompt(

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -143,7 +143,7 @@ export async function createWarpRouteDeployConfig({
     );
 
     const interchainSecurityModule = shouldUseDefault
-      ? await createDefaultWarpIsmConfig(context, chain, warpChains)
+      ? await createDefaultWarpIsmConfig(context, chain)
       : await createIsmConfig(context, chain, warpChains);
 
     switch (type) {
@@ -199,18 +199,12 @@ export function readWarpRouteConfig(filePath: string): WarpCoreConfig {
 async function createDefaultWarpIsmConfig(
   context: CommandContext,
   remote: ChainName,
-  origins: ChainName[],
 ) {
   return {
     type: IsmType.AGGREGATION,
     modules: [
       await createTrustedRelayerConfig(context),
-      await createRoutingConfig(
-        context,
-        IsmType.FALLBACK_ROUTING,
-        remote,
-        origins,
-      ),
+      await createRoutingConfig(context, IsmType.FALLBACK_ROUTING, remote, []),
     ],
     threshold: 1,
   };

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -3,6 +3,7 @@ import { input, select } from '@inquirer/prompts';
 import {
   ChainMap,
   ChainName,
+  IsmConfig,
   IsmType,
   MailboxClientConfig,
   TokenType,
@@ -199,7 +200,7 @@ export function readWarpRouteConfig(filePath: string): WarpCoreConfig {
 async function createDefaultWarpIsmConfig(
   context: CommandContext,
   remote: ChainName,
-) {
+): Promise<IsmConfig> {
   return {
     type: IsmType.AGGREGATION,
     modules: [


### PR DESCRIPTION
### Description

* adds new `hyperlane warp config` command
* this replaces previous `hl config create warp` control flow

### Related issues

- fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3537

### Backward compatibility

* yes

### Testing

* [x] manual
* [ ] ci-test
