### PR TITLE
feat: implement hyperlane core config to return CoreConfig

### DIFF
--- a/.changeset/bright-islands-shake.md
+++ b/.changeset/bright-islands-shake.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+Implement hyperlane core config to return CoreConfig

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -1,6 +1,10 @@
 import { CommandModule } from 'yargs';
 
-import { HookConfigSchema, IsmConfig } from '@hyperlane-xyz/sdk';
+import {
+  HookConfigSchema,
+  IsmConfig,
+  IsmConfigSchema,
+} from '@hyperlane-xyz/sdk';
 
 import { createHookConfig } from '../config/hooks.js';
 import { createIsmConfig, createTrustedRelayerConfig } from '../config/ism.js';
@@ -86,6 +90,7 @@ export const config: CommandModuleWithContext<{
     );
 
     // Validate
+    IsmConfigSchema.parse(defaultIsm);
     HookConfigSchema.parse(requiredHook);
     HookConfigSchema.parse(defaultHook);
 

--- a/typescript/cli/src/commands/deploy.ts
+++ b/typescript/cli/src/commands/deploy.ts
@@ -18,6 +18,7 @@ import {
   dryRunCommandOption,
   fromAddressCommandOption,
   originCommandOption,
+  outputFileCommandOption,
   warpDeploymentConfigCommandOption,
 } from './options.js';
 
@@ -70,7 +71,7 @@ const agentCommand: CommandModuleWithContext<{
  * @param commandName - the deploy command key used to look up the deployFunction
  * @returns A command module used to deploy Hyperlane contracts.
  */
-export const deployCore: CommandModuleWithWriteContext<{
+export const deploy: CommandModuleWithWriteContext<{
   chain: string;
   config: string;
   dryRun: string;
@@ -80,12 +81,11 @@ export const deployCore: CommandModuleWithWriteContext<{
   describe: 'Deploy Hyperlane contracts',
   builder: {
     chain: chainCommandOption,
-    config: {
-      type: 'string',
-      description:
-        'The path to a JSON or YAML file with a core deployment config.',
-      demandOption: true,
-    },
+    config: outputFileCommandOption(
+      './configs/core-config.yaml',
+      false,
+      'The path to a JSON or YAML file with a core deployment config.',
+    ),
     'dry-run': dryRunCommandOption,
     'from-address': fromAddressCommandOption,
   },

--- a/typescript/cli/src/commands/options.ts
+++ b/typescript/cli/src/commands/options.ts
@@ -109,9 +109,10 @@ export const agentConfigCommandOption = (
 export const outputFileCommandOption = (
   defaultPath?: string,
   demandOption = false,
+  description = 'Output file path',
 ): Options => ({
   type: 'string',
-  description: 'Output file path',
+  description,
   default: defaultPath,
   alias: 'o',
   demandOption,

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -2,7 +2,6 @@ import { input, select } from '@inquirer/prompts';
 
 import {
   ChainMap,
-  ChainName,
   IsmConfig,
   IsmType,
   MailboxClientConfig,
@@ -144,8 +143,8 @@ export async function createWarpRouteDeployConfig({
     );
 
     const interchainSecurityModule = shouldUseDefault
-      ? await createDefaultWarpIsmConfig(context, chain)
-      : await createIsmConfig(context, chain, warpChains);
+      ? await createDefaultWarpIsmConfig(context)
+      : await createIsmConfig(context);
 
     switch (type) {
       case TokenType.collateral:
@@ -199,13 +198,12 @@ export function readWarpRouteConfig(filePath: string): WarpCoreConfig {
 
 async function createDefaultWarpIsmConfig(
   context: CommandContext,
-  remote: ChainName,
 ): Promise<IsmConfig> {
   return {
     type: IsmType.AGGREGATION,
     modules: [
       await createTrustedRelayerConfig(context),
-      await createRoutingConfig(context, IsmType.FALLBACK_ROUTING, remote, []),
+      await createRoutingConfig(context, IsmType.FALLBACK_ROUTING),
     ],
     threshold: 1,
   };

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -149,7 +149,7 @@ export abstract class HyperlaneDeployer<
       const deployPromise = runWithTimeout(this.chainTimeoutMs, async () => {
         const contracts = await this.deployContracts(chain, configMap[chain]);
         this.addDeployedContracts(chain, contracts);
-        this.logger.info({ chain }, 'Successfully deployed contracts');
+        this.logger.info(`Successfully deployed contracts on ${chain}`);
       });
       if (this.options.concurrentDeploy) {
         deployPromises.push(deployPromise);


### PR DESCRIPTION
### Description
- Updates `hl core config` to output a single `CoreConfig` file
- Makes `CoreConfig` single chain ie. remove ChainMap
- Removes `nativeTokenAndDecimals()` for fee calculation
- Add description as a prameter for `outputFileCommandOption()`

### Related issues
- Fixes #3877

### Backward compatibility
No, Outputs CoreConfig as a single file and no longer expecting 2 individual files

### Testing
Manual
