### PR TITLE
feat: implement hyperlane core read to return CoreConfig 

### DIFF
--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -58,10 +58,6 @@ export function readIsmConfig(filePath: string) {
   return parsedConfig;
 }
 
-export function isValildIsmConfig(config: any) {
-  return IsmConfigSchema.safeParse(config).success;
-}
-
 const ISM_TYPE_DESCRIPTIONS: Record<IsmType, string> = {
   [IsmType.MESSAGE_ID_MULTISIG]: 'Validators need to sign just this messageId',
   [IsmType.MERKLE_ROOT_MULTISIG]:


### PR DESCRIPTION
### Description
- Updates `hl core read` to output a single `CoreConfig` file

### Related issues
- Fixes #3880

### Backward compatibility
Yes

### Testing
Manual
