### PR TITLE
chore(infra): Remove RpcConsensusType usage in infra now that SmartProvider is used instead

### DIFF
--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -23,7 +23,6 @@ export const keyFunderConfig: KeyFunderConfig = {
     [Contexts.Hyperlane]: [Role.Relayer, Role.Kathy],
     [Contexts.ReleaseCandidate]: [Role.Relayer, Role.Kathy],
   },
-  connectionType: RpcConsensusType.Fallback,
   // desired balance config
   desiredBalancePerChain: {
     arbitrum: '0.5',

--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -1,5 +1,3 @@
-import { RpcConsensusType } from '@hyperlane-xyz/sdk';
-
 import { KeyFunderConfig } from '../../../src/config/funding.js';
 import { Role } from '../../../src/roles.js';
 import { Contexts } from '../../contexts.js';

--- a/typescript/infra/config/environments/mainnet3/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet3/helloworld.ts
@@ -1,5 +1,3 @@
-import { RpcConsensusType } from '@hyperlane-xyz/sdk';
-
 import {
   HelloWorldConfig,
   HelloWorldKathyRunMode,

--- a/typescript/infra/config/environments/mainnet3/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet3/helloworld.ts
@@ -26,7 +26,6 @@ export const hyperlane: HelloWorldConfig = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
-    connectionType: RpcConsensusType.Fallback,
     cyclesBetweenEthereumMessages: 1, // Skip 1 cycle of Ethereum, i.e. send/receive Ethereum messages every 5 days (not great since we still send like 12 in that cycle)
   },
 };
@@ -46,7 +45,6 @@ export const releaseCandidate: HelloWorldConfig = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
-    connectionType: RpcConsensusType.Fallback,
   },
 };
 

--- a/typescript/infra/config/environments/mainnet3/index.ts
+++ b/typescript/infra/config/environments/mainnet3/index.ts
@@ -1,5 +1,4 @@
 import { IRegistry } from '@hyperlane-xyz/registry';
-import { RpcConsensusType } from '@hyperlane-xyz/sdk';
 
 import {
   getKeysForRole,
@@ -42,7 +41,6 @@ export const environment: EnvironmentConfig = {
   getMultiProvider: async (
     context: Contexts = Contexts.Hyperlane,
     role: Role = Role.Deployer,
-    _connectionType?: RpcConsensusType,
     useSecrets?: boolean,
   ) =>
     getMultiProviderForRole(

--- a/typescript/infra/config/environments/mainnet3/liquidityLayer.ts
+++ b/typescript/infra/config/environments/mainnet3/liquidityLayer.ts
@@ -2,7 +2,6 @@ import {
   BridgeAdapterConfig,
   BridgeAdapterType,
   ChainMap,
-  RpcConsensusType,
 } from '@hyperlane-xyz/sdk';
 
 import { LiquidityLayerRelayerConfig } from '../../../src/config/middleware.js';

--- a/typescript/infra/config/environments/mainnet3/liquidityLayer.ts
+++ b/typescript/infra/config/environments/mainnet3/liquidityLayer.ts
@@ -50,5 +50,4 @@ export const relayerConfig: LiquidityLayerRelayerConfig = {
   namespace: environment,
   prometheusPushGateway:
     'http://prometheus-prometheus-pushgateway.monitoring.svc.cluster.local:9091',
-  connectionType: RpcConsensusType.Single,
 };

--- a/typescript/infra/config/environments/testnet4/funding.ts
+++ b/typescript/infra/config/environments/testnet4/funding.ts
@@ -1,5 +1,3 @@
-import { RpcConsensusType } from '@hyperlane-xyz/sdk';
-
 import { KeyFunderConfig } from '../../../src/config/funding.js';
 import { Role } from '../../../src/roles.js';
 import { Contexts } from '../../contexts.js';

--- a/typescript/infra/config/environments/testnet4/funding.ts
+++ b/typescript/infra/config/environments/testnet4/funding.ts
@@ -23,7 +23,6 @@ export const keyFunderConfig: KeyFunderConfig = {
     [Contexts.Hyperlane]: [Role.Relayer, Role.Kathy],
     [Contexts.ReleaseCandidate]: [Role.Relayer, Role.Kathy],
   },
-  connectionType: RpcConsensusType.Fallback,
   // desired balance config
   desiredBalancePerChain: {
     alfajores: '5',

--- a/typescript/infra/config/environments/testnet4/helloworld.ts
+++ b/typescript/infra/config/environments/testnet4/helloworld.ts
@@ -26,7 +26,6 @@ export const hyperlaneHelloworld: HelloWorldConfig = {
     },
     messageSendTimeout: 1000 * 60 * 10, // 10 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
-    connectionType: RpcConsensusType.Fallback,
   },
 };
 
@@ -45,7 +44,6 @@ export const releaseCandidateHelloworld: HelloWorldConfig = {
     },
     messageSendTimeout: 1000 * 60 * 8, // 8 min
     messageReceiptTimeout: 1000 * 60 * 20, // 20 min
-    connectionType: RpcConsensusType.Fallback,
   },
 };
 

--- a/typescript/infra/config/environments/testnet4/helloworld.ts
+++ b/typescript/infra/config/environments/testnet4/helloworld.ts
@@ -1,5 +1,3 @@
-import { RpcConsensusType } from '@hyperlane-xyz/sdk';
-
 import {
   HelloWorldConfig,
   HelloWorldKathyRunMode,

--- a/typescript/infra/config/environments/testnet4/index.ts
+++ b/typescript/infra/config/environments/testnet4/index.ts
@@ -1,5 +1,4 @@
 import { IRegistry } from '@hyperlane-xyz/registry';
-import { RpcConsensusType } from '@hyperlane-xyz/sdk';
 import { objMerge } from '@hyperlane-xyz/utils';
 
 import {
@@ -44,7 +43,6 @@ export const environment: EnvironmentConfig = {
   getMultiProvider: async (
     context: Contexts = Contexts.Hyperlane,
     role: Role = Role.Deployer,
-    _connectionType?: RpcConsensusType,
     useSecrets?: boolean,
   ) =>
     getMultiProviderForRole(

--- a/typescript/infra/config/environments/testnet4/middleware.ts
+++ b/typescript/infra/config/environments/testnet4/middleware.ts
@@ -1,5 +1,3 @@
-import { RpcConsensusType } from '@hyperlane-xyz/sdk';
-
 import { LiquidityLayerRelayerConfig } from '../../../src/config/middleware.js';
 
 import { environment } from './chains.js';

--- a/typescript/infra/config/environments/testnet4/middleware.ts
+++ b/typescript/infra/config/environments/testnet4/middleware.ts
@@ -12,5 +12,4 @@ export const liquidityLayerRelayerConfig: LiquidityLayerRelayerConfig = {
   namespace: environment,
   prometheusPushGateway:
     'http://prometheus-prometheus-pushgateway.monitoring.svc.cluster.local:9091',
-  connectionType: RpcConsensusType.Single,
 };

--- a/typescript/infra/helm/helloworld-kathy/templates/_helpers.tpl
+++ b/typescript/infra/helm/helloworld-kathy/templates/_helpers.tpl
@@ -91,10 +91,6 @@ The helloworld-kathy container
 {{- if .Values.hyperlane.cycleOnce }}
   - --cycle-once
 {{- end }}
-{{- if .Values.hyperlane.connectionType }}
-  - --connection-type
-  - {{ .Values.hyperlane.connectionType }}
-{{- end }}
 {{- if .Values.hyperlane.cyclesBetweenEthereumMessages }}
   - --cycles-between-ethereum-messages
   - "{{ .Values.hyperlane.cyclesBetweenEthereumMessages }}"

--- a/typescript/infra/helm/key-funder/templates/cron-job.yaml
+++ b/typescript/infra/helm/key-funder/templates/cron-job.yaml
@@ -29,10 +29,6 @@ spec:
             - --contexts-and-roles
             - {{ $context }}={{ join "," $roles }}
 {{- end }}
-{{- if .Values.hyperlane.connectionType }}
-            - --connection-type
-            - {{ .Values.hyperlane.connectionType }}
-{{- end }}
 {{- range $chain, $balance := .Values.hyperlane.desiredBalancePerChain }}
             - --desired-balance-per-chain
             - {{ $chain }}={{ $balance }}

--- a/typescript/infra/helm/liquidity-layer-relayers/templates/circle-relayer-deployment.yaml
+++ b/typescript/infra/helm/liquidity-layer-relayers/templates/circle-relayer-deployment.yaml
@@ -21,10 +21,6 @@ spec:
         - ./typescript/infra/scripts/middleware/circle-relayer.ts
         - -e
         - {{ .Values.hyperlane.runEnv }}
-{{- if .Values.hyperlane.connectionType }}
-        - --connection-type
-        - {{ .Values.hyperlane.connectionType }}
-{{- end }}
         envFrom:
         - secretRef:
             name: liquidity-layer-env-var-secret

--- a/typescript/infra/helm/liquidity-layer-relayers/templates/portal-relayer-deployment.yaml
+++ b/typescript/infra/helm/liquidity-layer-relayers/templates/portal-relayer-deployment.yaml
@@ -21,10 +21,6 @@ spec:
         - ./typescript/infra/scripts/middleware/portal-relayer.ts
         - -e
         - {{ .Values.hyperlane.runEnv }}
-{{- if .Values.hyperlane.connectionType }}
-        - --connection-type
-        - {{ .Values.hyperlane.connectionType }}
-{{- end }}
         envFrom:
         - secretRef:
             name: liquidity-layer-env-var-secret

--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -9,7 +9,6 @@ import {
   CoreConfig,
   MultiProtocolProvider,
   MultiProvider,
-  RpcConsensusType,
   collectValidators,
 } from '@hyperlane-xyz/sdk';
 import {

--- a/typescript/infra/scripts/agents/update-agent-config.ts
+++ b/typescript/infra/scripts/agents/update-agent-config.ts
@@ -9,7 +9,6 @@ async function main() {
   let multiProvider = await envConfig.getMultiProvider(
     undefined,
     undefined,
-    undefined,
     // Don't use secrets
     false,
   );

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -191,7 +191,6 @@ async function main() {
   const multiProvider = await config.getMultiProvider(
     Contexts.Hyperlane, // Always fund from the hyperlane context
     Role.Deployer, // Always fund from the deployer
-    argv.connectionType,
   );
 
   let contextFunders: ContextFunder[];

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -9,7 +9,6 @@ import {
   ChainName,
   HyperlaneIgp,
   MultiProvider,
-  RpcConsensusType,
 } from '@hyperlane-xyz/sdk';
 import { Address, objFilter, objMap, rootLogger } from '@hyperlane-xyz/utils';
 
@@ -176,11 +175,6 @@ async function main() {
       'Array indicating target balance to fund Kathy for each chain. Each element is expected as <chainName>=<balance>',
     )
     .coerce('desired-kathy-balance-per-chain', parseBalancePerChain)
-
-    .string('connection-type')
-    .describe('connection-type', 'The provider connection type to use for RPCs')
-    .default('connection-type', RpcConsensusType.Single)
-    .demandOption('connection-type')
 
     .boolean('skip-igp-claim')
     .describe('skip-igp-claim', 'If true, never claims funds from the IGP')

--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -11,7 +11,6 @@ import {
   MultiProtocolCore,
   MultiProvider,
   ProviderType,
-  RpcConsensusType,
   TypedTransactionReceipt,
   resolveOrDeployAccountOwner,
 } from '@hyperlane-xyz/sdk';
@@ -128,16 +127,6 @@ function getKathyArgs() {
       chainStrs.map((chainStr: string) => assertChain(chainStr)),
     )
 
-    .string('connection-type')
-    .describe('connection-type', 'The provider connection type to use for RPCs')
-    .default('connection-type', RpcConsensusType.Single)
-    .choices('connection-type', [
-      RpcConsensusType.Single,
-      RpcConsensusType.Quorum,
-      RpcConsensusType.Fallback,
-    ])
-    .demandOption('connection-type')
-
     .number('cycles-between-ethereum-messages')
     .describe(
       'cycles-between-ethereum-messages',
@@ -156,7 +145,6 @@ async function main(): Promise<boolean> {
     fullCycleTime,
     messageSendTimeout,
     messageReceiptTimeout,
-    connectionType,
     cyclesBetweenEthereumMessages,
   } = await getKathyArgs();
 
@@ -173,7 +161,6 @@ async function main(): Promise<boolean> {
       context,
       Role.Kathy,
       undefined,
-      connectionType,
     );
 
   const appChains = app.chains();

--- a/typescript/infra/scripts/helloworld/utils.ts
+++ b/typescript/infra/scripts/helloworld/utils.ts
@@ -8,7 +8,6 @@ import {
   MultiProtocolCore,
   MultiProtocolProvider,
   MultiProvider,
-  RpcConsensusType,
   attachContractsMap,
   attachContractsMapAndGetForeignDeployments,
   filterChainMapToProtocol,
@@ -28,7 +27,6 @@ export async function getHelloWorldApp(
   context: Contexts,
   keyRole: Role,
   keyContext: Contexts = context,
-  connectionType: RpcConsensusType = RpcConsensusType.Single,
 ) {
   const multiProvider: MultiProvider = await coreConfig.getMultiProvider(
     keyContext,
@@ -60,7 +58,6 @@ export async function getHelloWorldMultiProtocolApp(
   context: Contexts,
   keyRole: Role,
   keyContext: Contexts = context,
-  connectionType: RpcConsensusType = RpcConsensusType.Single,
 ) {
   const multiProvider: MultiProvider = await coreConfig.getMultiProvider(
     keyContext,

--- a/typescript/infra/scripts/helloworld/utils.ts
+++ b/typescript/infra/scripts/helloworld/utils.ts
@@ -33,7 +33,6 @@ export async function getHelloWorldApp(
   const multiProvider: MultiProvider = await coreConfig.getMultiProvider(
     keyContext,
     keyRole,
-    connectionType,
   );
   const helloworldConfig = getHelloWorldConfig(coreConfig, context);
 
@@ -66,7 +65,6 @@ export async function getHelloWorldMultiProtocolApp(
   const multiProvider: MultiProvider = await coreConfig.getMultiProvider(
     keyContext,
     keyRole,
-    connectionType,
   );
 
   const envAddresses = getEnvAddresses(coreConfig.environment);

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -8,8 +8,6 @@ import {
   ChainName,
   HyperlaneSmartProvider,
   ProviderRetryOptions,
-  RpcConsensusType,
-  RpcUrl,
 } from '@hyperlane-xyz/sdk';
 import { ProtocolType, objFilter, objMerge } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -26,7 +26,6 @@ export const defaultRetry: ProviderRetryOptions = {
 
 export async function fetchProvider(
   chainName: ChainName,
-  connectionType: RpcConsensusType = RpcConsensusType.Single,
 ): Promise<providers.Provider> {
   const chainMetadata = getChain(chainName);
   if (!chainMetadata) {
@@ -38,22 +37,13 @@ export async function fetchProvider(
     throw Error(`No RPC URLs found for chain: ${chainName}`);
   }
 
-  if (connectionType === RpcConsensusType.Single) {
-    return HyperlaneSmartProvider.fromRpcUrl(chainId, rpcData[0], defaultRetry);
-  } else if (
-    connectionType === RpcConsensusType.Quorum ||
-    connectionType === RpcConsensusType.Fallback
-  ) {
-    return new HyperlaneSmartProvider(
-      chainId,
-      rpcData.map((url) => ({ http: url })),
-      undefined,
-      // disable retry for quorum
-      connectionType === RpcConsensusType.Fallback ? defaultRetry : undefined,
-    );
-  } else {
-    throw Error(`Unsupported connectionType: ${connectionType}`);
-  }
+  return new HyperlaneSmartProvider(
+    chainId,
+    rpcData.map((url) => ({ http: url })),
+    undefined,
+    // disable retry for quorum
+    defaultRetry,
+  );
 }
 
 export function getChainMetadatas(chains: Array<ChainName>) {

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -39,7 +39,6 @@ export async function fetchProvider(
     chainId,
     rpcData.map((url) => ({ http: url })),
     undefined,
-    // disable retry for quorum
     defaultRetry,
   );
 }

--- a/typescript/infra/src/config/environment.ts
+++ b/typescript/infra/src/config/environment.ts
@@ -9,7 +9,6 @@ import {
   MultiProtocolProvider,
   MultiProvider,
   OwnableConfig,
-  RpcConsensusType,
 } from '@hyperlane-xyz/sdk';
 import { objKeys } from '@hyperlane-xyz/utils';
 
@@ -54,7 +53,6 @@ export type EnvironmentConfig = {
   getMultiProvider: (
     context?: Contexts,
     role?: Role,
-    connectionType?: RpcConsensusType,
     useSecrets?: boolean,
   ) => Promise<MultiProvider>;
   getKeys: (

--- a/typescript/infra/src/config/funding.ts
+++ b/typescript/infra/src/config/funding.ts
@@ -20,7 +20,6 @@ export interface KeyFunderConfig {
   contextsAndRolesToFund: ContextAndRolesMap;
   cyclesBetweenEthereumMessages?: number;
   prometheusPushGateway: string;
-  connectionType: RpcConsensusType;
   desiredBalancePerChain: ChainMap<string>;
   desiredKathyBalancePerChain: ChainMap<string>;
 }

--- a/typescript/infra/src/config/funding.ts
+++ b/typescript/infra/src/config/funding.ts
@@ -1,4 +1,4 @@
-import { ChainMap, RpcConsensusType } from '@hyperlane-xyz/sdk';
+import { ChainMap } from '@hyperlane-xyz/sdk';
 
 import { Contexts } from '../../config/contexts.js';
 import { FundableRole, Role } from '../roles.js';

--- a/typescript/infra/src/config/helloworld/types.ts
+++ b/typescript/infra/src/config/helloworld/types.ts
@@ -1,4 +1,4 @@
-import { ChainMap, ChainName, RpcConsensusType } from '@hyperlane-xyz/sdk';
+import { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
 
 import { DockerConfig } from '../agent/agent.js';
 

--- a/typescript/infra/src/config/helloworld/types.ts
+++ b/typescript/infra/src/config/helloworld/types.ts
@@ -29,7 +29,6 @@ export interface HelloWorldKathyConfig {
   messageReceiptTimeout: number;
 
   // Which type of provider to use
-  connectionType: RpcConsensusType;
   // How many cycles to skip between a cycles that send messages to/from Ethereum. Defaults to 0.
   cyclesBetweenEthereumMessages?: number;
 }

--- a/typescript/infra/src/config/middleware.ts
+++ b/typescript/infra/src/config/middleware.ts
@@ -5,6 +5,5 @@ import { DockerConfig } from './agent/agent.js';
 export interface LiquidityLayerRelayerConfig {
   docker: DockerConfig;
   namespace: string;
-  connectionType: RpcConsensusType.Single | RpcConsensusType.Quorum;
   prometheusPushGateway: string;
 }

--- a/typescript/infra/src/config/middleware.ts
+++ b/typescript/infra/src/config/middleware.ts
@@ -1,5 +1,3 @@
-import { RpcConsensusType } from '@hyperlane-xyz/sdk';
-
 import { DockerConfig } from './agent/agent.js';
 
 export interface LiquidityLayerRelayerConfig {

--- a/typescript/infra/src/funding/key-funder.ts
+++ b/typescript/infra/src/funding/key-funder.ts
@@ -48,7 +48,6 @@ function getKeyFunderHelmValues(
       chains: agentConfig.environmentChainNames,
       contextFundingFrom: keyFunderConfig.contextFundingFrom,
       contextsAndRolesToFund: keyFunderConfig.contextsAndRolesToFund,
-      connectionType: keyFunderConfig.connectionType,
       desiredBalancePerChain: keyFunderConfig.desiredBalancePerChain,
       desiredKathyBalancePerChain: keyFunderConfig.desiredKathyBalancePerChain,
     },

--- a/typescript/infra/src/helloworld/kathy.ts
+++ b/typescript/infra/src/helloworld/kathy.ts
@@ -85,7 +85,6 @@ function getHelloworldKathyHelmValues(
       messageReceiptTimeout: kathyConfig.messageReceiptTimeout,
       cycleOnce,
       fullCycleTime,
-      connectionType: kathyConfig.connectionType,
       cyclesBetweenEthereumMessages: kathyConfig.cyclesBetweenEthereumMessages,
     },
     image: {

--- a/typescript/infra/src/middleware/liquidity-layer-relayer.ts
+++ b/typescript/infra/src/middleware/liquidity-layer-relayer.ts
@@ -44,7 +44,6 @@ function getLiquidityLayerRelayerHelmValues(
       runEnv: agentConfig.runEnv,
       // Only used for fetching RPC urls as env vars
       chains: agentConfig.contextChainNames,
-      connectionType: relayerConfig.connectionType,
     },
     image: {
       repository: relayerConfig.docker.repo,


### PR DESCRIPTION


### Description

Removed references to RpcConsensusType where TS-based providers are used in infra

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
