### PR TITLE
feat(cli): add 'hyperlane warp send' command

### DIFF
--- a/.changeset/spotty-days-worry.md
+++ b/.changeset/spotty-days-worry.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Add warp send in favor of send transfer.

--- a/typescript/cli/ci-test.sh
+++ b/typescript/cli/ci-test.sh
@@ -245,7 +245,7 @@ run_hyperlane_send_message() {
     WARP_CONFIG_FILE="$REGISTRY_PATH/deployments/warp_routes/FAKE/${CHAIN1}-${CHAIN2}-config.yaml"
 
     echo -e "\nSending test warp transfer"
-    yarn workspace @hyperlane-xyz/cli run hyperlane send transfer \
+    yarn workspace @hyperlane-xyz/cli run hyperlane warp send \
         --registry $REGISTRY_PATH \
         --overrides " " \
         --origin ${CHAIN1} \

--- a/typescript/cli/src/commands/send.ts
+++ b/typescript/cli/src/commands/send.ts
@@ -10,7 +10,7 @@ import { sendTestMessage } from '../send/message.js';
  */
 export const sendCommand: CommandModule = {
   command: 'send',
-  describe: 'Send a test message or transfer',
+  describe: 'Send a test message',
   builder: (yargs) =>
     yargs.command(messageCommand).version(false).demandCommand(),
   handler: () => log('Command required'),

--- a/typescript/cli/src/commands/send.ts
+++ b/typescript/cli/src/commands/send.ts
@@ -4,9 +4,6 @@ import { CommandModule, Options } from 'yargs';
 import { CommandModuleWithWriteContext } from '../context/types.js';
 import { log } from '../logger.js';
 import { sendTestMessage } from '../send/message.js';
-import { sendTestTransfer } from '../send/transfer.js';
-
-import { warpCoreConfigCommandOption } from './options.js';
 
 /**
  * Parent command
@@ -15,11 +12,7 @@ export const sendCommand: CommandModule = {
   command: 'send',
   describe: 'Send a test message or transfer',
   builder: (yargs) =>
-    yargs
-      .command(messageCommand)
-      .command(transferCommand)
-      .version(false)
-      .demandCommand(),
+    yargs.command(messageCommand).version(false).demandCommand(),
   handler: () => log('Command required'),
 };
 
@@ -87,58 +80,6 @@ const messageCommand: CommandModuleWithWriteContext<
       origin,
       destination,
       messageBody: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(body)),
-      timeoutSec: timeout,
-      skipWaitForDelivery: quick,
-      selfRelay: relay,
-    });
-    process.exit(0);
-  },
-};
-
-/**
- * Transfer command
- */
-const transferCommand: CommandModuleWithWriteContext<
-  MessageOptionsArgTypes & {
-    warp: string;
-    router?: string;
-    wei: string;
-    recipient?: string;
-  }
-> = {
-  command: 'transfer',
-  describe: 'Send a test token transfer on a warp route',
-  builder: {
-    ...messageOptions,
-    warp: warpCoreConfigCommandOption,
-    wei: {
-      type: 'string',
-      description: 'Amount in wei to send',
-      default: 1,
-    },
-    recipient: {
-      type: 'string',
-      description: 'Token recipient address (defaults to sender)',
-    },
-  },
-  handler: async ({
-    context,
-    origin,
-    destination,
-    timeout,
-    quick,
-    relay,
-    warp,
-    wei,
-    recipient,
-  }) => {
-    await sendTestTransfer({
-      context,
-      warpConfigPath: warp,
-      origin,
-      destination,
-      wei,
-      recipient,
       timeoutSec: timeout,
       skipWaitForDelivery: quick,
       selfRelay: relay,

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -3,15 +3,21 @@ import { CommandModule } from 'yargs';
 import { EvmERC20WarpRouteReader } from '@hyperlane-xyz/sdk';
 
 import { createWarpRouteDeployConfig } from '../config/warp.js';
-import { CommandModuleWithContext } from '../context/types.js';
+import {
+  CommandModuleWithContext,
+  CommandModuleWithWriteContext,
+} from '../context/types.js';
 import { log, logGray, logGreen } from '../logger.js';
+import { sendTestTransfer } from '../send/transfer.js';
 import { writeFileAtPath } from '../utils/files.js';
 
 import {
   addressCommandOption,
   chainCommandOption,
   outputFileCommandOption,
+  warpCoreConfigCommandOption,
 } from './options.js';
+import { MessageOptionsArgTypes, messageOptions } from './send.js';
 
 /**
  * Parent command
@@ -20,7 +26,12 @@ export const warpCommand: CommandModule = {
   command: 'warp',
   describe: 'Manage Hyperlane warp routes',
   builder: (yargs) =>
-    yargs.command(config).command(read).version(false).demandCommand(),
+    yargs
+      .command(config)
+      .command(read)
+      .command(send)
+      .version(false)
+      .demandCommand(),
   handler: () => log('Command required'),
 };
 
@@ -85,6 +96,55 @@ export const read: CommandModuleWithContext<{
       logGreen(`✅ Warp route config read successfully:`);
       log(JSON.stringify(warpRouteConfig, null, 4));
     }
+    process.exit(0);
+  },
+};
+
+const send: CommandModuleWithWriteContext<
+  MessageOptionsArgTypes & {
+    warp: string;
+    router?: string;
+    wei: string;
+    recipient?: string;
+  }
+> = {
+  command: 'send',
+  describe: 'Send a test token transfer on a warp route',
+  builder: {
+    ...messageOptions,
+    warp: warpCoreConfigCommandOption,
+    wei: {
+      type: 'string',
+      description: 'Amount in wei to send',
+      default: 1,
+    },
+    recipient: {
+      type: 'string',
+      description: 'Token recipient address (defaults to sender)',
+    },
+  },
+  handler: async ({
+    context,
+    origin,
+    destination,
+    timeout,
+    quick,
+    relay,
+    warp,
+    wei,
+    recipient,
+  }) => {
+    await sendTestTransfer({
+      context,
+      warpConfigPath: warp,
+      origin,
+      destination,
+      wei,
+      recipient,
+      timeoutSec: timeout,
+      skipWaitForDelivery: quick,
+      selfRelay: relay,
+    });
     process.exit(0);
   },
 };


### PR DESCRIPTION
### Description

- adds `hl warp send` command in favor of `hl send transfer`

### Drive-by changes

* none

### Related issues

- fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3691

### Backward compatibility

- yes

### Testing

- ci-test: includes call to `hl warp send`
- manual: `hl warp send`
