### PR TITLE
ensure multiprovider is mutated on dry-run

### DIFF
--- a/typescript/cli/src/context/context.ts
+++ b/typescript/cli/src/context/context.ts
@@ -99,8 +99,8 @@ export async function getDryRunContext(
   logBlue(`Dry-running against chain: ${chain}`);
   await verifyAnvil();
 
-  const multiProvider = await getMultiProvider(registry);
-  await forkNetworkToMultiProvider(multiProvider, chain);
+  let multiProvider = await getMultiProvider(registry);
+  multiProvider = await forkNetworkToMultiProvider(multiProvider, chain);
 
   const { impersonatedKey, impersonatedSigner } = await getImpersonatedSigner({
     fromAddress,
@@ -114,7 +114,7 @@ export async function getDryRunContext(
     chainMetadata: multiProvider.metadata,
     key: impersonatedKey,
     signer: impersonatedSigner,
-    multiProvider: multiProvider,
+    multiProvider,
     skipConfirmation: !!skipConfirmation,
     isDryRun: true,
     dryRunChain: chain,

--- a/typescript/cli/src/deploy/dry-run.ts
+++ b/typescript/cli/src/deploy/dry-run.ts
@@ -19,12 +19,14 @@ import { toUpperCamelCase } from './utils.js';
 export async function forkNetworkToMultiProvider(
   multiProvider: MultiProvider,
   chain: string,
-) {
+): Promise<MultiProvider> {
   multiProvider = multiProvider.extendChainMetadata({
     [chain]: { blocks: { confirmations: 0 } },
   });
 
   await setFork(multiProvider, chain);
+
+  return multiProvider;
 }
 
 /**


### PR DESCRIPTION
### Description

- ensures multiprovider is mutated on dry-run

### Drive-by changes

- none

### Related issues

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3862

### Backward compatibility

- Yes

### Testing

- ci-test