### PR TITLE
feat(cli): add 'source' to detectAndConfirmOrPrompt

### DIFF
--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -60,6 +60,7 @@ export const configure: CommandModuleWithContext<{
       async () => context.signer?.getAddress(),
       'Enter the desired',
       'owner address',
+      'signer',
     );
 
     // Create default Ism config (advanced or trusted)

--- a/typescript/cli/src/config/chain.ts
+++ b/typescript/cli/src/config/chain.ts
@@ -48,6 +48,7 @@ export async function createChainConfig({
     },
     'Enter http or https',
     'rpc url',
+    'JSON RPC provider',
   );
   const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
 
@@ -60,6 +61,7 @@ export async function createChainConfig({
     },
     'Enter (one word, lower case)',
     'chain name',
+    'JSON RPC provider',
   );
 
   const chainId = parseInt(
@@ -70,6 +72,7 @@ export async function createChainConfig({
       },
       'Enter a (number)',
       'chain id',
+      'JSON RPC provider',
     ),
     10,
   );

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -135,6 +135,7 @@ export async function createTrustedRelayerConfig(
     async () => context.signer?.getAddress(),
     'For trusted relayer ISM, enter',
     'relayer address',
+    'signer',
   );
   return {
     type: IsmType.TRUSTED_RELAYER,

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -114,6 +114,7 @@ export async function createWarpRouteDeployConfig({
     async () => context.signer?.getAddress(),
     'Enter the desired',
     'owner address',
+    'signer',
   );
 
   const warpChains = await runMultiChainSelectionStep(
@@ -140,6 +141,7 @@ export async function createWarpRouteDeployConfig({
       },
       `For ${chain}, enter the`,
       'mailbox address',
+      'hyperlane-registry',
     );
 
     const interchainSecurityModule = shouldUseDefault

--- a/typescript/cli/src/utils/chains.ts
+++ b/typescript/cli/src/utils/chains.ts
@@ -78,13 +78,16 @@ export async function detectAndConfirmOrPrompt(
   detect: () => Promise<string | undefined>,
   prompt: string,
   label: string,
+  source?: string,
 ): Promise<string> {
   let detectedValue: string | undefined;
   try {
     detectedValue = await detect();
     if (detectedValue) {
       const confirmed = await confirm({
-        message: `Detected ${label} as ${detectedValue}, is this correct?`,
+        message: `Detected ${label} as ${detectedValue}${
+          source ? ` from ${source}` : ''
+        }, is this correct?`,
       });
       if (confirmed) {
         return detectedValue;


### PR DESCRIPTION
### Description

- adds `source` field to detect and confirm prompt so users know where defaults are coming from

### Drive-by changes

- none

### Related issues

- none

### Backward compatibility

- yes

### Testing

- manual