### PR TITLE
fix(cli): remove default for chain name

### DIFF
--- a/.changeset/bright-emus-double.md
+++ b/.changeset/bright-emus-double.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Removes default pattern for chain name when creating a new chain.

--- a/typescript/cli/src/config/chain.ts
+++ b/typescript/cli/src/config/chain.ts
@@ -1,7 +1,11 @@
 import { confirm, input } from '@inquirer/prompts';
 import { ethers } from 'ethers';
 
-import { ChainMetadata, ChainMetadataSchema } from '@hyperlane-xyz/sdk';
+import {
+  ChainMetadata,
+  ChainMetadataSchema,
+  ZChainName,
+} from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
 import { CommandContext } from '../context/types.js';
@@ -52,17 +56,10 @@ export async function createChainConfig({
   );
   const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
 
-  const name = await detectAndConfirmOrPrompt(
-    async () => {
-      const clientName = await provider.send('web3_clientVersion', []);
-      const port = rpcUrl.split(':').slice(-1);
-      const client = clientName.split('/')[0];
-      return `${client}${port}`;
-    },
-    'Enter (one word, lower case)',
-    'chain name',
-    'JSON RPC provider',
-  );
+  const name = await input({
+    message: 'Enter chain name (one word, lower case)',
+    validate: (chainName) => ZChainName.safeParse(chainName).success,
+  });
 
   const chainId = parseInt(
     await detectAndConfirmOrPrompt(

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -155,7 +155,7 @@ export {
 } from './ism/multisig.js';
 export { EvmIsmReader } from './ism/EvmIsmReader.js';
 export { collectValidators, moduleCanCertainlyVerify } from './ism/utils.js';
-export { ZHash } from './metadata/customZodTypes.js';
+export { ZChainName, ZHash } from './metadata/customZodTypes.js';
 export {
   BlockExplorer,
   ChainMetadata,


### PR DESCRIPTION
### Description

- simply prompts if not a lowercase one-word chain name, instead of sometimes returning incorrect chain name

### Drive-by changes

- none

### Related issues

- none

### Backward compatibility

- yes

### Testing

- manual w/ caldera: https://early-rabbits-throw.hub.caldera.xyz/