### PR TITLE
fix(cli): no prompt on default hooks in hyperlane core configure

### DIFF
--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -11,7 +11,11 @@ import {
 import { runCoreDeploy } from '../deploy/core.js';
 import { evaluateIfDryRunFailure } from '../deploy/dry-run.js';
 import { log, logGray, logGreen } from '../logger.js';
-import { readYamlOrJson, writeYamlOrJson } from '../utils/files.js';
+import {
+  indentYamlOrJson,
+  readYamlOrJson,
+  writeYamlOrJson,
+} from '../utils/files.js';
 
 import {
   chainCommandOption,
@@ -144,7 +148,7 @@ export const read: CommandModuleWithContext<{
     logGreen(
       `✅ Warp route config written successfully to ${configFilePath}:\n`,
     );
-    log(yamlStringify(coreConfig, null, 2));
+    log(indentYamlOrJson(yamlStringify(coreConfig, null, 2), 4));
 
     process.exit(0);
   },

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -1,3 +1,4 @@
+import { stringify as yamlStringify } from 'yaml';
 import { CommandModule } from 'yargs';
 
 import { EvmCoreReader } from '@hyperlane-xyz/sdk';
@@ -9,7 +10,7 @@ import {
 } from '../context/types.js';
 import { runCoreDeploy } from '../deploy/core.js';
 import { evaluateIfDryRunFailure } from '../deploy/dry-run.js';
-import { log, logGray } from '../logger.js';
+import { log, logGray, logGreen } from '../logger.js';
 import { readYamlOrJson, writeYamlOrJson } from '../utils/files.js';
 
 import {
@@ -139,7 +140,11 @@ export const read: CommandModuleWithContext<{
     const evmCoreReader = new EvmCoreReader(context.multiProvider, chain);
     const coreConfig = await evmCoreReader.deriveCoreConfig(mailbox);
 
-    writeYamlOrJson(configFilePath, coreConfig);
+    writeYamlOrJson(configFilePath, coreConfig, 'yaml');
+    logGreen(
+      `✅ Warp route config written successfully to ${configFilePath}:\n`,
+    );
+    log(yamlStringify(coreConfig, null, 2));
 
     process.exit(0);
   },

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -2,18 +2,22 @@ import { CommandModule } from 'yargs';
 
 import { EvmCoreReader } from '@hyperlane-xyz/sdk';
 
+import { createCoreDeployConfig } from '../config/core.js';
+import {
+  CommandModuleWithContext,
+  CommandModuleWithWriteContext,
+} from '../context/types.js';
+import { runCoreDeploy } from '../deploy/core.js';
+import { evaluateIfDryRunFailure } from '../deploy/dry-run.js';
+import { log, logGray } from '../logger.js';
+import { readYamlOrJson, writeYamlOrJson } from '../utils/files.js';
+
 import {
   chainCommandOption,
   dryRunCommandOption,
   fromAddressCommandOption,
   outputFileCommandOption,
 } from './options.js';
-import { log, logGray } from '../logger.js';
-import { createCoreDeployConfig } from '../config/core.js';
-import { CommandModuleWithContext, CommandModuleWithWriteContext } from '../context/types.js';
-import { readYamlOrJson, writeYamlOrJson } from '../utils/files.js';
-import { runCoreDeploy } from '../deploy/core.js';
-import { evaluateIfDryRunFailure } from '../deploy/dry-run.js';
 
 /**
  * Parent command

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -12,7 +12,7 @@ import { evaluateIfDryRunFailure } from '../deploy/dry-run.js';
 import { runWarpRouteDeploy } from '../deploy/warp.js';
 import { log, logGray, logGreen } from '../logger.js';
 import { sendTestTransfer } from '../send/transfer.js';
-import { writeYamlOrJson } from '../utils/files.js';
+import { indentYamlOrJson, writeYamlOrJson } from '../utils/files.js';
 
 import {
   addressCommandOption,
@@ -135,7 +135,7 @@ export const read: CommandModuleWithContext<{
     } else {
       logGreen(`✅ Warp route config read successfully:\n`);
     }
-    log(yamlStringify(warpRouteConfig, null, 2));
+    log(indentYamlOrJson(yamlStringify(warpRouteConfig, null, 2), 4));
     process.exit(0);
   },
 };

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -72,24 +72,27 @@ export const deploy: CommandModuleWithWriteContext<{
 };
 
 export const configure: CommandModuleWithContext<{
-  ismAdvanced: boolean;
+  advanced: boolean;
   out: string;
 }> = {
   command: 'configure',
   describe: 'Create a warp route configuration.',
   builder: {
-    ismAdvanced: {
+    advanced: {
       type: 'boolean',
-      describe: 'Create an advanced ISM & hook configuration',
+      describe: 'Create an advanced ISM',
       default: false,
     },
     out: outputFileCommandOption('./configs/warp-route-deployment.yaml'),
   },
-  handler: async ({ context, ismAdvanced, out }) => {
+  handler: async ({ context, advanced, out }) => {
+    logGray('Hyperlane Warp Configure');
+    logGray('------------------------');
+
     await createWarpRouteDeployConfig({
       context,
       outPath: out,
-      shouldUseDefault: !ismAdvanced,
+      advanced,
     });
     process.exit(0);
   },

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -12,7 +12,7 @@ import { evaluateIfDryRunFailure } from '../deploy/dry-run.js';
 import { runWarpRouteDeploy } from '../deploy/warp.js';
 import { log, logGray, logGreen } from '../logger.js';
 import { sendTestTransfer } from '../send/transfer.js';
-import { writeFileAtPath } from '../utils/files.js';
+import { writeYamlOrJson } from '../utils/files.js';
 
 import {
   addressCommandOption,
@@ -130,12 +130,12 @@ export const read: CommandModuleWithContext<{
       address,
     );
     if (out) {
-      writeFileAtPath(out, JSON.stringify(warpRouteConfig, null, 4) + '\n');
-      logGreen(`✅ Warp route config written successfully to ${out}.`);
+      writeYamlOrJson(out, warpRouteConfig, 'yaml');
+      logGreen(`✅ Warp route config written successfully to ${out}:\n`);
     } else {
       logGreen(`✅ Warp route config read successfully:\n`);
-      log('\t' + yamlStringify(warpRouteConfig, null, 2));
     }
+    log(yamlStringify(warpRouteConfig, null, 2));
     process.exit(0);
   },
 };

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -1,3 +1,4 @@
+import { stringify as yamlStringify } from 'yaml';
 import { CommandModule } from 'yargs';
 
 import { EvmERC20WarpRouteReader } from '@hyperlane-xyz/sdk';
@@ -132,8 +133,8 @@ export const read: CommandModuleWithContext<{
       writeFileAtPath(out, JSON.stringify(warpRouteConfig, null, 4) + '\n');
       logGreen(`✅ Warp route config written successfully to ${out}.`);
     } else {
-      logGreen(`✅ Warp route config read successfully:`);
-      log(JSON.stringify(warpRouteConfig, null, 4));
+      logGreen(`✅ Warp route config read successfully:\n`);
+      log('\t' + yamlStringify(warpRouteConfig, null, 2));
     }
     process.exit(0);
   },

--- a/typescript/cli/src/config/core.ts
+++ b/typescript/cli/src/config/core.ts
@@ -5,7 +5,7 @@ import { CoreConfigSchema, HookConfig, IsmConfig } from '@hyperlane-xyz/sdk';
 import { CommandContext } from '../context/types.js';
 import { errorRed, log, logBlue, logGreen } from '../logger.js';
 import { detectAndConfirmOrPrompt } from '../utils/chains.js';
-import { writeYamlOrJson } from '../utils/files.js';
+import { indentYamlOrJson, writeYamlOrJson } from '../utils/files.js';
 
 import {
   createHookConfig,
@@ -63,7 +63,7 @@ export async function createCoreDeployConfig({
       requiredHook,
     });
     logBlue(`Core config is valid, writing to file ${configFilePath}:\n`);
-    log(yamlStringify(coreConfig, null, 2));
+    log(indentYamlOrJson(yamlStringify(coreConfig, null, 2), 4));
     writeYamlOrJson(configFilePath, coreConfig, 'yaml');
     logGreen('✅ Successfully created new core deployment config:');
   } catch (e) {

--- a/typescript/cli/src/config/core.ts
+++ b/typescript/cli/src/config/core.ts
@@ -23,7 +23,7 @@ export async function createCoreDeployConfig({
   configFilePath: string;
   advanced: boolean;
 }) {
-  logBlue('Creating a new core deployment config');
+  logBlue('Creating a new core deployment config...');
 
   const owner = await detectAndConfirmOrPrompt(
     async () => context.signer?.getAddress(),
@@ -63,7 +63,7 @@ export async function createCoreDeployConfig({
     logBlue(`Core config is valid, writing to file ${configFilePath}:\n`);
     log(indentYamlOrJson(yamlStringify(coreConfig, null, 2), 4));
     writeYamlOrJson(configFilePath, coreConfig, 'yaml');
-    logGreen('✅ Successfully created new core deployment config:');
+    logGreen('✅ Successfully created new core deployment config.');
   } catch (e) {
     errorRed(`Core deployment config is invalid.`);
     throw e;

--- a/typescript/cli/src/config/core.ts
+++ b/typescript/cli/src/config/core.ts
@@ -12,7 +12,7 @@ import {
   createMerkleTreeConfig,
   createProtocolFeeConfig,
 } from './hooks.js';
-import { createIsmConfig, createTrustedRelayerConfig } from './ism.js';
+import { createAdvancedIsmConfig, createTrustedRelayerConfig } from './ism.js';
 
 export async function createCoreDeployConfig({
   context,
@@ -32,11 +32,9 @@ export async function createCoreDeployConfig({
     'signer',
   );
 
-  const defaultIsm: IsmConfig = await createIsmConfig({
-    context,
-    advanced,
-    defaultFn: createTrustedRelayerConfig,
-  });
+  const defaultIsm: IsmConfig = advanced
+    ? await createAdvancedIsmConfig(context)
+    : await createTrustedRelayerConfig(context, advanced);
 
   let defaultHook: HookConfig, requiredHook: HookConfig;
   if (advanced) {

--- a/typescript/cli/src/config/core.ts
+++ b/typescript/cli/src/config/core.ts
@@ -43,7 +43,7 @@ export async function createCoreDeployConfig({
     defaultHook = await createHookConfig(context, 'Select default hook type');
     requiredHook = await createHookConfig(context, 'Select required hook type');
   } else {
-    defaultHook = createMerkleTreeConfig();
+    defaultHook = await createMerkleTreeConfig();
     requiredHook = await createProtocolFeeConfig();
   }
 

--- a/typescript/cli/src/config/core.ts
+++ b/typescript/cli/src/config/core.ts
@@ -64,7 +64,7 @@ export async function createCoreDeployConfig({
     });
     logBlue(`Core config is valid, writing to file ${configFilePath}:\n`);
     log(yamlStringify(coreConfig, null, 2));
-    writeYamlOrJson(configFilePath, coreConfig);
+    writeYamlOrJson(configFilePath, coreConfig, 'yaml');
     logGreen('✅ Successfully created new core deployment config:');
   } catch (e) {
     errorRed(`Core deployment config is invalid.`);

--- a/typescript/cli/src/config/core.ts
+++ b/typescript/cli/src/config/core.ts
@@ -30,6 +30,7 @@ export async function createCoreDeployConfig({
     async () => context.signer?.getAddress(),
     'Enter the desired',
     'owner address',
+    'signer',
   );
 
   const defaultIsm: IsmConfig = await createIsmConfigWithWarningOrDefault({

--- a/typescript/cli/src/config/core.ts
+++ b/typescript/cli/src/config/core.ts
@@ -1,0 +1,65 @@
+import { CoreConfigSchema, HookConfig, IsmConfig } from '@hyperlane-xyz/sdk';
+
+import { CommandContext } from '../context/types.js';
+import { errorRed, logBlue, logGreen } from '../logger.js';
+import { detectAndConfirmOrPrompt } from '../utils/chains.js';
+import { writeYamlOrJson } from '../utils/files.js';
+
+import {
+  createHookConfig,
+  createMerkleTreeConfig,
+  createProtocolFeeConfig,
+} from './hooks.js';
+import {
+  createIsmConfigWithWarningOrDefault,
+  createTrustedRelayerConfig,
+} from './ism.js';
+
+export async function createCoreDeployConfig({
+  context,
+  configFilePath,
+  advanced = false,
+}: {
+  context: CommandContext;
+  configFilePath: string;
+  advanced: boolean;
+}) {
+  logBlue('Creating a new core deployment config');
+
+  const owner = await detectAndConfirmOrPrompt(
+    async () => context.signer?.getAddress(),
+    'Enter the desired',
+    'owner address',
+  );
+
+  const defaultIsm: IsmConfig = await createIsmConfigWithWarningOrDefault({
+    context,
+    defaultFn: createTrustedRelayerConfig,
+    advanced,
+  });
+
+  let defaultHook: HookConfig, requiredHook: HookConfig;
+  if (advanced) {
+    defaultHook = await createHookConfig(context, 'Select default hook type');
+    requiredHook = await createHookConfig(context, 'Select required hook type');
+  } else {
+    defaultHook = createMerkleTreeConfig();
+    requiredHook = await createProtocolFeeConfig();
+  }
+
+  try {
+    const coreConfig = CoreConfigSchema.parse({
+      owner,
+      defaultIsm,
+      defaultHook,
+      requiredHook,
+    });
+    logBlue(`Core config is valid, writing to file ${configFilePath}`);
+    writeYamlOrJson(configFilePath, coreConfig);
+  } catch (e) {
+    errorRed(`Core deployment config is invalid.`);
+    throw e;
+  }
+
+  logGreen('✅ Successfully created new core deployment config');
+}

--- a/typescript/cli/src/config/hooks.ts
+++ b/typescript/cli/src/config/hooks.ts
@@ -167,9 +167,9 @@ export const createProtocolFeeConfig = callWithConfigCreationLogs(
       : PROTOCOL_FEE_DEFAULT;
     if (BigNumberJs(protocolFee).gt(maxProtocolFee)) {
       errorRed(
-        `Protocol fee (${protocolFee}) cannot be greater than max protocol fee (${maxProtocolFee})`,
+        `Protocol fee (${protocolFee}) cannot be greater than max protocol fee (${maxProtocolFee}).`,
       );
-      throw new Error('Invalid protocol fee');
+      throw new Error('Invalid protocol fee.');
     }
     return {
       type: HookType.PROTOCOL_FEE,

--- a/typescript/cli/src/config/hooks.ts
+++ b/typescript/cli/src/config/hooks.ts
@@ -82,6 +82,12 @@ export async function createHookConfig({
     message: selectMessage,
     choices: [
       {
+        value: HookType.AGGREGATION,
+        name: HookType.AGGREGATION,
+        description:
+          'Aggregate multiple hooks into a single hook (e.g. merkle tree + IGP) which will be called in sequence',
+      },
+      {
         value: HookType.MERKLE_TREE,
         name: HookType.MERKLE_TREE,
         description:
@@ -92,23 +98,17 @@ export async function createHookConfig({
         name: HookType.PROTOCOL_FEE,
         description: 'Charge fees for each message dispatch from this chain',
       },
-      {
-        value: HookType.AGGREGATION,
-        name: HookType.AGGREGATION,
-        description:
-          'Aggregate multiple hooks into a single hook (e.g. merkle tree + IGP) which will be called in sequence',
-      },
     ],
     pageSize: 10,
   });
 
   switch (hookType) {
+    case HookType.AGGREGATION:
+      return createAggregationConfig(context, advanced);
     case HookType.MERKLE_TREE:
       return createMerkleTreeConfig();
     case HookType.PROTOCOL_FEE:
       return createProtocolFeeConfig(context, advanced);
-    case HookType.AGGREGATION:
-      return createAggregationConfig(context, advanced);
     default:
       throw new Error(`Invalid hook type: ${hookType}`);
   }

--- a/typescript/cli/src/config/hooks.ts
+++ b/typescript/cli/src/config/hooks.ts
@@ -22,10 +22,7 @@ import { errorRed, logBlue, logGreen, logRed } from '../logger.js';
 import { runMultiChainSelectionStep } from '../utils/chains.js';
 import { readYamlOrJson } from '../utils/files.js';
 
-import {
-  callWithConfigCreationLogsAsync,
-  callWithConfigCreationLogsSync,
-} from './utils.js';
+import { callWithConfigCreationLogs } from './utils.js';
 
 // TODO: deprecate in favor of CoreConfigSchema
 const HooksConfigSchema = z.object({
@@ -106,14 +103,14 @@ export async function createHookConfig(
   }
 }
 
-export const createMerkleTreeConfig = callWithConfigCreationLogsSync(
-  (): HookConfig => {
+export const createMerkleTreeConfig = callWithConfigCreationLogs(
+  async (): Promise<HookConfig> => {
     return { type: HookType.MERKLE_TREE };
   },
   HookType.MERKLE_TREE,
 );
 
-export const createProtocolFeeConfig = callWithConfigCreationLogsAsync(
+export const createProtocolFeeConfig = callWithConfigCreationLogs(
   async (): Promise<HookConfig> => {
     const owner = await input({
       message: 'Enter owner address for protocol fee hook',
@@ -159,7 +156,7 @@ export const createProtocolFeeConfig = callWithConfigCreationLogsAsync(
 );
 
 // TODO: make this usable
-export const createIGPConfig = callWithConfigCreationLogsAsync(
+export const createIGPConfig = callWithConfigCreationLogs(
   async (remotes: ChainName[]): Promise<HookConfig> => {
     const owner = await input({
       message: 'Enter owner address for IGP hook',
@@ -204,7 +201,7 @@ export const createIGPConfig = callWithConfigCreationLogsAsync(
   HookType.INTERCHAIN_GAS_PAYMASTER,
 );
 
-export const createAggregationConfig = callWithConfigCreationLogsAsync(
+export const createAggregationConfig = callWithConfigCreationLogs(
   async (context: CommandContext): Promise<HookConfig> => {
     const hooksNum = parseInt(
       await input({
@@ -225,7 +222,7 @@ export const createAggregationConfig = callWithConfigCreationLogsAsync(
   HookType.AGGREGATION,
 );
 
-export const createRoutingConfig = callWithConfigCreationLogsAsync(
+export const createRoutingConfig = callWithConfigCreationLogs(
   async (context: CommandContext): Promise<HookConfig> => {
     const owner = await input({
       message: 'Enter owner address for routing ISM',

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -62,18 +62,18 @@ export function readIsmConfig(filePath: string) {
 }
 
 const ISM_TYPE_DESCRIPTIONS: Record<string, string> = {
-  [IsmType.MESSAGE_ID_MULTISIG]: 'Validators need to sign just this messageId',
-  [IsmType.MERKLE_ROOT_MULTISIG]:
-    'Validators need to sign the root of the merkle tree of all messages from origin chain',
-  [IsmType.ROUTING]:
-    'Each origin chain can be verified by the specified ISM type via RoutingISM',
-  [IsmType.FALLBACK_ROUTING]:
-    "You can specify ISM type for specific chains you like and fallback to mailbox's default ISM for other chains via DefaultFallbackRoutingISM",
   [IsmType.AGGREGATION]:
     'You can aggregate multiple ISMs into one ISM via AggregationISM',
-  [IsmType.TRUSTED_RELAYER]: 'Deliver messages from an authorized address',
+  [IsmType.FALLBACK_ROUTING]:
+    "You can specify ISM type for specific chains you like and fallback to mailbox's default ISM for other chains via DefaultFallbackRoutingISM",
+  [IsmType.MERKLE_ROOT_MULTISIG]:
+    'Validators need to sign the root of the merkle tree of all messages from origin chain',
+  [IsmType.MESSAGE_ID_MULTISIG]: 'Validators need to sign just this messageId',
+  [IsmType.ROUTING]:
+    'Each origin chain can be verified by the specified ISM type via RoutingISM',
   [IsmType.TEST_ISM]:
     'ISM where you can deliver messages without any validation (WARNING: only for testing, do not use in production)',
+  [IsmType.TRUSTED_RELAYER]: 'Deliver messages from an authorized address',
 };
 
 export async function createAdvancedIsmConfig(
@@ -91,16 +91,16 @@ export async function createAdvancedIsmConfig(
   });
 
   switch (moduleType) {
-    case IsmType.MESSAGE_ID_MULTISIG:
-      return createMessageIdMultisigConfig(context);
-    case IsmType.MERKLE_ROOT_MULTISIG:
-      return createMerkleRootMultisigConfig(context);
-    case IsmType.ROUTING:
-      return createRoutingConfig(context);
-    case IsmType.FALLBACK_ROUTING:
-      return createFallbackRoutingConfig(context);
     case IsmType.AGGREGATION:
       return createAggregationConfig(context);
+    case IsmType.FALLBACK_ROUTING:
+      return createFallbackRoutingConfig(context);
+    case IsmType.MERKLE_ROOT_MULTISIG:
+      return createMerkleRootMultisigConfig(context);
+    case IsmType.MESSAGE_ID_MULTISIG:
+      return createMessageIdMultisigConfig(context);
+    case IsmType.ROUTING:
+      return createRoutingConfig(context);
     case IsmType.TEST_ISM:
       return { type: IsmType.TEST_ISM };
     case IsmType.TRUSTED_RELAYER:

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -160,6 +160,7 @@ export const createTrustedRelayerConfig = callWithConfigCreationLogs(
       async () => context.signer?.getAddress(),
       'For trusted relayer ISM, enter',
       'relayer address',
+      'signer',
     );
     return {
       type: IsmType.TRUSTED_RELAYER,

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -19,7 +19,7 @@ import {
 } from '../utils/chains.js';
 import { readYamlOrJson } from '../utils/files.js';
 
-import { callWithConfigCreationLogsAsync } from './utils.js';
+import { callWithConfigCreationLogs } from './utils.js';
 
 const IsmConfigMapSchema = z.record(IsmConfigSchema).refine(
   (ismConfigMap) => {
@@ -110,7 +110,7 @@ export async function createIsmConfig(
   }
 }
 
-export const createMerkleRootMultisigConfig = callWithConfigCreationLogsAsync(
+export const createMerkleRootMultisigConfig = callWithConfigCreationLogs(
   async (): Promise<MultisigIsmConfig> => {
     const thresholdInput = await input({
       message:
@@ -132,7 +132,7 @@ export const createMerkleRootMultisigConfig = callWithConfigCreationLogsAsync(
   IsmType.MERKLE_ROOT_MULTISIG,
 );
 
-export const createMessageIdMultisigConfig = callWithConfigCreationLogsAsync(
+export const createMessageIdMultisigConfig = callWithConfigCreationLogs(
   async (): Promise<MultisigIsmConfig> => {
     const thresholdInput = await input({
       message:
@@ -154,7 +154,7 @@ export const createMessageIdMultisigConfig = callWithConfigCreationLogsAsync(
   IsmType.MESSAGE_ID_MULTISIG,
 );
 
-export const createTrustedRelayerConfig = callWithConfigCreationLogsAsync(
+export const createTrustedRelayerConfig = callWithConfigCreationLogs(
   async (context: CommandContext): Promise<TrustedRelayerIsmConfig> => {
     const relayer = await detectAndConfirmOrPrompt(
       async () => context.signer?.getAddress(),
@@ -169,7 +169,7 @@ export const createTrustedRelayerConfig = callWithConfigCreationLogsAsync(
   IsmType.TRUSTED_RELAYER,
 );
 
-export const createAggregationConfig = callWithConfigCreationLogsAsync(
+export const createAggregationConfig = callWithConfigCreationLogs(
   async (context: CommandContext): Promise<AggregationIsmConfig> => {
     const isms = parseInt(
       await input({
@@ -198,7 +198,7 @@ export const createAggregationConfig = callWithConfigCreationLogsAsync(
   IsmType.AGGREGATION,
 );
 
-export const createRoutingConfig = callWithConfigCreationLogsAsync(
+export const createRoutingConfig = callWithConfigCreationLogs(
   async (context: CommandContext): Promise<IsmConfig> => {
     const owner = await input({
       message: 'Enter owner address for routing ISM',
@@ -228,7 +228,7 @@ export const createRoutingConfig = callWithConfigCreationLogsAsync(
   IsmType.ROUTING,
 );
 
-export const createFallbackRoutingConfig = callWithConfigCreationLogsAsync(
+export const createFallbackRoutingConfig = callWithConfigCreationLogs(
   async (context: CommandContext): Promise<IsmConfig> => {
     const owner = await input({
       message: 'Enter owner address for fallback routing ISM',

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -1,4 +1,4 @@
-import { confirm, input, select } from '@inquirer/prompts';
+import { input, select } from '@inquirer/prompts';
 import { z } from 'zod';
 
 import {
@@ -12,7 +12,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 
 import { CommandContext } from '../context/types.js';
-import { logBlue, logBoldUnderlinedRed, logRed } from '../logger.js';
+import { log, logBlue, logBoldUnderlinedRed, logRed } from '../logger.js';
 import {
   detectAndConfirmOrPrompt,
   runMultiChainSelectionStep,
@@ -79,6 +79,12 @@ const ISM_TYPE_DESCRIPTIONS: Record<string, string> = {
 export async function createAdvancedIsmConfig(
   context: CommandContext,
 ): Promise<IsmConfig> {
+  logBlue('Creating a new advanced ISM config');
+  logBoldUnderlinedRed('WARNING: USE AT YOUR RISK.');
+  logRed(
+    'Advanced ISM configs require knowledge of different ISM types and how they work together topologically. If possible, use the basic ISM configs are recommended.',
+  );
+
   const moduleType = await select({
     message: 'Select ISM type',
     choices: Object.entries(ISM_TYPE_DESCRIPTIONS).map(
@@ -219,9 +225,7 @@ export const createRoutingConfig = callWithConfigCreationLogs(
 
     const domainsMap: ChainMap<IsmConfig> = {};
     for (const chain of chains) {
-      await confirm({
-        message: `You are about to configure routing ISM from source chain ${chain}. Continue?`,
-      });
+      log(`You are about to configure routing ISM from source chain ${chain}.`);
       const config = await createAdvancedIsmConfig(context);
       domainsMap[chain] = config;
     }
@@ -249,9 +253,9 @@ export const createFallbackRoutingConfig = callWithConfigCreationLogs(
 
     const domainsMap: ChainMap<IsmConfig> = {};
     for (const chain of chains) {
-      await confirm({
-        message: `You are about to configure fallback routing ISM from source chain ${chain}. Continue?`,
-      });
+      log(
+        `You are about to configure fallback routing ISM from source chain ${chain}.`,
+      );
       const config = await createAdvancedIsmConfig(context);
       domainsMap[chain] = config;
     }
@@ -263,24 +267,3 @@ export const createFallbackRoutingConfig = callWithConfigCreationLogs(
   },
   IsmType.FALLBACK_ROUTING,
 );
-
-export async function createIsmConfig({
-  context,
-  advanced = false,
-  defaultFn,
-}: {
-  context: CommandContext;
-  advanced: boolean;
-  defaultFn: (context: CommandContext) => Promise<IsmConfig>;
-}): Promise<IsmConfig> {
-  if (advanced) {
-    logBlue('Creating a new advanced ISM config');
-    logBoldUnderlinedRed('WARNING: USE AT YOUR RISK.');
-    logRed(
-      'Advanced ISM configs require knowledge of different ISM types and how they work together topologically. If possible, use the basic ISM configs are recommended.',
-    );
-    return createAdvancedIsmConfig(context);
-  }
-
-  return defaultFn(context);
-}

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -12,7 +12,13 @@ import {
 } from '@hyperlane-xyz/sdk';
 
 import { CommandContext } from '../context/types.js';
-import { log, logBlue, logBoldUnderlinedRed, logRed } from '../logger.js';
+import {
+  errorRed,
+  log,
+  logBlue,
+  logBoldUnderlinedRed,
+  logRed,
+} from '../logger.js';
 import {
   detectAndConfirmOrPrompt,
   runMultiChainSelectionStep,
@@ -112,7 +118,7 @@ export async function createAdvancedIsmConfig(
     case IsmType.TRUSTED_RELAYER:
       return createTrustedRelayerConfig(context, true);
     default:
-      throw new Error(`Invalid ISM type: ${moduleType}}`);
+      throw new Error(`Invalid ISM type: ${moduleType}.`);
   }
 }
 
@@ -120,14 +126,20 @@ export const createMerkleRootMultisigConfig = callWithConfigCreationLogs(
   async (): Promise<MultisigIsmConfig> => {
     const validatorsInput = await input({
       message:
-        'Enter validator addresses (comma separated list) for merkle root multisig ISM',
+        'Enter validator addresses (comma separated list) for merkle root multisig ISM:',
     });
     const validators = validatorsInput.split(',').map((v) => v.trim());
     const thresholdInput = await input({
       message:
-        'Enter threshold of validators (number) for merkle root multisig ISM',
+        'Enter threshold of validators (number) for merkle root multisig ISM:',
     });
     const threshold = parseInt(thresholdInput, 10);
+    if (threshold > validators.length) {
+      errorRed(
+        `Merkle root multisig signer threshold (${threshold}) cannot be greater than total number of validators (${validators.length}).`,
+      );
+      throw new Error('Invalid protocol fee.');
+    }
     return {
       type: IsmType.MERKLE_ROOT_MULTISIG,
       threshold,

--- a/typescript/cli/src/config/utils.ts
+++ b/typescript/cli/src/config/utils.ts
@@ -2,26 +2,11 @@ import { HookConfig, HookType, IsmConfig, IsmType } from '@hyperlane-xyz/sdk';
 
 import { logGray } from '../logger.js';
 
-export function callWithConfigCreationLogsSync<
-  T extends IsmType | HookType,
-  C extends IsmConfig | HookConfig,
->(fn: (...args: any[]) => C, type: T) {
-  return (...args: any[]): C => {
-    logGray(`Creating ${type}...`);
-    try {
-      const result = fn(...args);
-      return result;
-    } finally {
-      logGray(`Created ${type}`!);
-    }
-  };
-}
-
-export function callWithConfigCreationLogsAsync<
-  T extends IsmType | HookType,
-  C extends IsmConfig | HookConfig,
->(fn: (...args: any[]) => Promise<C>, type: T) {
-  return async (...args: any[]): Promise<C> => {
+export function callWithConfigCreationLogs<T extends IsmConfig | HookConfig>(
+  fn: (...args: any[]) => Promise<T>,
+  type: IsmType | HookType,
+) {
+  return async (...args: any[]): Promise<T> => {
     logGray(`Creating ${type}...`);
     try {
       const result = await fn(...args);

--- a/typescript/cli/src/config/utils.ts
+++ b/typescript/cli/src/config/utils.ts
@@ -12,7 +12,7 @@ export function callWithConfigCreationLogs<T extends IsmConfig | HookConfig>(
       const result = await fn(...args);
       return result;
     } finally {
-      logGray(`Created ${type}`!);
+      logGray(`Created ${type}!`);
     }
   };
 }

--- a/typescript/cli/src/config/utils.ts
+++ b/typescript/cli/src/config/utils.ts
@@ -1,0 +1,33 @@
+import { HookConfig, HookType, IsmConfig, IsmType } from '@hyperlane-xyz/sdk';
+
+import { logGray } from '../logger.js';
+
+export function callWithConfigCreationLogsSync<
+  T extends IsmType | HookType,
+  C extends IsmConfig | HookConfig,
+>(fn: (...args: any[]) => C, type: T) {
+  return (...args: any[]): C => {
+    logGray(`Creating ${type}...`);
+    try {
+      const result = fn(...args);
+      return result;
+    } finally {
+      logGray(`Created ${type}`!);
+    }
+  };
+}
+
+export function callWithConfigCreationLogsAsync<
+  T extends IsmType | HookType,
+  C extends IsmConfig | HookConfig,
+>(fn: (...args: any[]) => Promise<C>, type: T) {
+  return async (...args: any[]): Promise<C> => {
+    logGray(`Creating ${type}...`);
+    try {
+      const result = await fn(...args);
+      return result;
+    } finally {
+      logGray(`Created ${type}`!);
+    }
+  };
+}

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -113,7 +113,7 @@ export async function createWarpRouteDeployConfig({
   outPath: string;
   advanced: boolean;
 }) {
-  logBlue('Creating a new warp route deployment config');
+  logBlue('Creating a new warp route deployment config...');
 
   const owner = await detectAndConfirmOrPrompt(
     async () => context.signer?.getAddress(),
@@ -188,10 +188,10 @@ export async function createWarpRouteDeployConfig({
     logBlue(`Warp Route config is valid, writing to file ${outPath}:\n`);
     log(indentYamlOrJson(yamlStringify(warpRouteDeployConfig, null, 2), 4));
     writeYamlOrJson(outPath, warpRouteDeployConfig, 'yaml');
-    logGreen('✅ Successfully created new warp route deployment config');
+    logGreen('✅ Successfully created new warp route deployment config.');
   } catch (e) {
     errorRed(
-      `Warp route deployment config is invalid, please see https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/cli/examples/warp-route-deployment.yaml for an example`,
+      `Warp route deployment config is invalid, please see https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/cli/examples/warp-route-deployment.yaml for an example.`,
     );
     throw e;
   }

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -22,7 +22,7 @@ import {
 import { readYamlOrJson, writeYamlOrJson } from '../utils/files.js';
 
 import {
-  createIsmConfigWithWarningOrDefault,
+  createIsmConfig,
   createRoutingConfig,
   createTrustedRelayerConfig,
 } from './ism.js';
@@ -144,7 +144,7 @@ export async function createWarpRouteDeployConfig({
       'hyperlane-registry',
     );
 
-    const interchainSecurityModule = await createIsmConfigWithWarningOrDefault({
+    const interchainSecurityModule = await createIsmConfig({
       context,
       defaultFn: createDefaultWarpIsmConfig,
       advanced,

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -1,4 +1,5 @@
 import { input, select } from '@inquirer/prompts';
+import { stringify as yamlStringify } from 'yaml';
 
 import {
   ChainMap,
@@ -14,7 +15,7 @@ import {
 import { assert, objMap, promiseObjAll } from '@hyperlane-xyz/utils';
 
 import { CommandContext } from '../context/types.js';
-import { errorRed, logBlue, logGreen } from '../logger.js';
+import { errorRed, log, logBlue, logGreen } from '../logger.js';
 import {
   detectAndConfirmOrPrompt,
   runMultiChainSelectionStep,
@@ -181,17 +182,17 @@ export async function createWarpRouteDeployConfig({
   }
 
   try {
-    const parsed = WarpRouteDeployConfigSchema.parse(result);
-    logBlue(`Warp Route config is valid, writing to file ${outPath}`);
-    writeYamlOrJson(outPath, parsed);
+    const warpRouteDeployConfig = WarpRouteDeployConfigSchema.parse(result);
+    logBlue(`Warp Route config is valid, writing to file ${outPath}:\n`);
+    log(yamlStringify(warpRouteDeployConfig, null, 2));
+    writeYamlOrJson(outPath, warpRouteDeployConfig, 'yaml');
+    logGreen('✅ Successfully created new warp route deployment config');
   } catch (e) {
     errorRed(
       `Warp route deployment config is invalid, please see https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/cli/examples/warp-route-deployment.yaml for an example`,
     );
     throw e;
   }
-
-  logGreen('✅ Successfully created new warp route deployment config');
 }
 
 // Note, this is different than the function above which reads a config

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -20,7 +20,11 @@ import {
   detectAndConfirmOrPrompt,
   runMultiChainSelectionStep,
 } from '../utils/chains.js';
-import { readYamlOrJson, writeYamlOrJson } from '../utils/files.js';
+import {
+  indentYamlOrJson,
+  readYamlOrJson,
+  writeYamlOrJson,
+} from '../utils/files.js';
 
 import {
   createIsmConfig,
@@ -184,7 +188,7 @@ export async function createWarpRouteDeployConfig({
   try {
     const warpRouteDeployConfig = WarpRouteDeployConfigSchema.parse(result);
     logBlue(`Warp Route config is valid, writing to file ${outPath}:\n`);
-    log(yamlStringify(warpRouteDeployConfig, null, 2));
+    log(indentYamlOrJson(yamlStringify(warpRouteDeployConfig, null, 2), 4));
     writeYamlOrJson(outPath, warpRouteDeployConfig, 'yaml');
     logGreen('✅ Successfully created new warp route deployment config');
   } catch (e) {

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -27,7 +27,7 @@ import {
 } from '../utils/files.js';
 
 import {
-  createIsmConfig,
+  createAdvancedIsmConfig,
   createRoutingConfig,
   createTrustedRelayerConfig,
 } from './ism.js';
@@ -149,11 +149,9 @@ export async function createWarpRouteDeployConfig({
       'hyperlane-registry',
     );
 
-    const interchainSecurityModule = await createIsmConfig({
-      context,
-      defaultFn: createDefaultWarpIsmConfig,
-      advanced,
-    });
+    const interchainSecurityModule = advanced
+      ? await createAdvancedIsmConfig(context)
+      : await createDefaultWarpIsmConfig(context);
 
     switch (type) {
       case TokenType.collateral:

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -22,7 +22,7 @@ import {
 import { readYamlOrJson, writeYamlOrJson } from '../utils/files.js';
 
 import {
-  createIsmConfig,
+  createIsmConfigWithWarningOrDefault,
   createRoutingConfig,
   createTrustedRelayerConfig,
 } from './ism.js';
@@ -102,11 +102,11 @@ export function isValidWarpRouteDeployConfig(config: any) {
 export async function createWarpRouteDeployConfig({
   context,
   outPath,
-  shouldUseDefault = false,
+  advanced = false,
 }: {
   context: CommandContext;
   outPath: string;
-  shouldUseDefault: boolean;
+  advanced: boolean;
 }) {
   logBlue('Creating a new warp route deployment config');
 
@@ -144,9 +144,11 @@ export async function createWarpRouteDeployConfig({
       'hyperlane-registry',
     );
 
-    const interchainSecurityModule = shouldUseDefault
-      ? await createDefaultWarpIsmConfig(context)
-      : await createIsmConfig(context);
+    const interchainSecurityModule = await createIsmConfigWithWarningOrDefault({
+      context,
+      defaultFn: createDefaultWarpIsmConfig,
+      advanced,
+    });
 
     switch (type) {
       case TokenType.collateral:
@@ -180,7 +182,7 @@ export async function createWarpRouteDeployConfig({
 
   try {
     const parsed = WarpRouteDeployConfigSchema.parse(result);
-    logGreen(`Warp Route config is valid, writing to file ${outPath}`);
+    logBlue(`Warp Route config is valid, writing to file ${outPath}`);
     writeYamlOrJson(outPath, parsed);
   } catch (e) {
     errorRed(
@@ -188,6 +190,8 @@ export async function createWarpRouteDeployConfig({
     );
     throw e;
   }
+
+  logGreen('✅ Successfully created new warp route deployment config');
 }
 
 // Note, this is different than the function above which reads a config

--- a/typescript/cli/src/utils/chains.ts
+++ b/typescript/cli/src/utils/chains.ts
@@ -95,5 +95,5 @@ export async function detectAndConfirmOrPrompt(
     }
     // eslint-disable-next-line no-empty
   } catch (e) {}
-  return input({ message: `${prompt} ${label}`, default: detectedValue });
+  return input({ message: `${prompt} ${label}:`, default: detectedValue });
 }

--- a/typescript/cli/src/utils/files.ts
+++ b/typescript/cli/src/utils/files.ts
@@ -210,3 +210,11 @@ export async function runFileSelectionStep(
   if (filename) return filename;
   else throw new Error(`No filepath entered ${description}`);
 }
+
+export function indentYamlOrJson(str: string, indentLevel: number): string {
+  const indent = ' '.repeat(indentLevel);
+  return str
+    .split('\n')
+    .map((line) => indent + line)
+    .join('\n');
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5691,8 +5691,8 @@ __metadata:
     "@aws-sdk/client-kms": "npm:^3.577.0"
     "@aws-sdk/client-s3": "npm:^3.577.0"
     "@hyperlane-xyz/registry": "npm:1.3.0"
-    "@hyperlane-xyz/sdk": "npm:4.0.0-alpha"
-    "@hyperlane-xyz/utils": "npm:4.0.0-alpha"
+    "@hyperlane-xyz/sdk": "npm:4.0.0-alpha.0"
+    "@hyperlane-xyz/utils": "npm:4.0.0-alpha.0"
     "@inquirer/prompts": "npm:^3.0.0"
     "@types/mocha": "npm:^10.0.1"
     "@types/node": "npm:^18.14.5"
@@ -5736,12 +5736,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/core@npm:4.0.0-alpha, @hyperlane-xyz/core@workspace:solidity":
+"@hyperlane-xyz/core@npm:4.0.0-alpha.0, @hyperlane-xyz/core@workspace:solidity":
   version: 0.0.0-use.local
   resolution: "@hyperlane-xyz/core@workspace:solidity"
   dependencies:
     "@eth-optimism/contracts": "npm:^0.6.0"
-    "@hyperlane-xyz/utils": "npm:4.0.0-alpha"
+    "@hyperlane-xyz/utils": "npm:4.0.0-alpha.0"
     "@layerzerolabs/lz-evm-oapp-v2": "npm:2.0.2"
     "@layerzerolabs/solidity-examples": "npm:^1.1.0"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
@@ -5773,13 +5773,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/helloworld@npm:4.0.0-alpha, @hyperlane-xyz/helloworld@workspace:typescript/helloworld":
+"@hyperlane-xyz/helloworld@npm:4.0.0-alpha.0, @hyperlane-xyz/helloworld@workspace:typescript/helloworld":
   version: 0.0.0-use.local
   resolution: "@hyperlane-xyz/helloworld@workspace:typescript/helloworld"
   dependencies:
-    "@hyperlane-xyz/core": "npm:4.0.0-alpha"
+    "@hyperlane-xyz/core": "npm:4.0.0-alpha.0"
     "@hyperlane-xyz/registry": "npm:1.3.0"
-    "@hyperlane-xyz/sdk": "npm:4.0.0-alpha"
+    "@hyperlane-xyz/sdk": "npm:4.0.0-alpha.0"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
     "@nomiclabs/hardhat-waffle": "npm:^2.0.6"
     "@openzeppelin/contracts-upgradeable": "npm:^4.9.3"
@@ -5824,10 +5824,10 @@ __metadata:
     "@ethersproject/experimental": "npm:^5.7.0"
     "@ethersproject/hardware-wallets": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.2"
-    "@hyperlane-xyz/helloworld": "npm:4.0.0-alpha"
+    "@hyperlane-xyz/helloworld": "npm:4.0.0-alpha.0"
     "@hyperlane-xyz/registry": "npm:1.3.0"
-    "@hyperlane-xyz/sdk": "npm:4.0.0-alpha"
-    "@hyperlane-xyz/utils": "npm:4.0.0-alpha"
+    "@hyperlane-xyz/sdk": "npm:4.0.0-alpha.0"
+    "@hyperlane-xyz/utils": "npm:4.0.0-alpha.0"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
     "@nomiclabs/hardhat-etherscan": "npm:^3.0.3"
     "@nomiclabs/hardhat-waffle": "npm:^2.0.6"
@@ -5915,15 +5915,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/sdk@npm:4.0.0-alpha, @hyperlane-xyz/sdk@workspace:typescript/sdk":
+"@hyperlane-xyz/sdk@npm:4.0.0-alpha.0, @hyperlane-xyz/sdk@workspace:typescript/sdk":
   version: 0.0.0-use.local
   resolution: "@hyperlane-xyz/sdk@workspace:typescript/sdk"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.74.0"
     "@cosmjs/cosmwasm-stargate": "npm:^0.31.3"
     "@cosmjs/stargate": "npm:^0.31.3"
-    "@hyperlane-xyz/core": "npm:4.0.0-alpha"
-    "@hyperlane-xyz/utils": "npm:4.0.0-alpha"
+    "@hyperlane-xyz/core": "npm:4.0.0-alpha.0"
+    "@hyperlane-xyz/utils": "npm:4.0.0-alpha.0"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
     "@nomiclabs/hardhat-waffle": "npm:^2.0.6"
     "@safe-global/api-kit": "npm:1.3.0"
@@ -5975,7 +5975,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/utils@npm:4.0.0-alpha, @hyperlane-xyz/utils@workspace:typescript/utils":
+"@hyperlane-xyz/utils@npm:4.0.0-alpha.0, @hyperlane-xyz/utils@workspace:typescript/utils":
   version: 0.0.0-use.local
   resolution: "@hyperlane-xyz/utils@workspace:typescript/utils"
   dependencies:


### PR DESCRIPTION
### Description

* removes prompt on default hooks in `hyperlane core configure`
* required hook now defaults to protocol and default hook defaults to merkle

### Drive-by changes

- reshuffling `hyperlane warp configure` to accommodate the change as well (and maintain symmetry)

### Related issues

- fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3895

### Backward compatibility

- yes
### Testing

- manual
- ci-test