### PR TITLE
chore: restrict for how long the backward syncer can block

### DIFF
--- a/rust/hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs
+++ b/rust/hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs
@@ -14,7 +14,7 @@ use tracing::{debug, instrument, warn};
 
 use super::{LastIndexedSnapshot, TargetSnapshot};
 
-const MAX_BACWARD_SYNC_BLOCKING_TIME: Duration = Duration::from_secs(1);
+const MAX_BACKWARD_SYNC_BLOCKING_TIME: Duration = Duration::from_secs(5);
 
 /// A sequence-aware cursor that syncs backward until there are no earlier logs to index.
 pub(crate) struct BackwardSequenceAwareSyncCursor<T> {
@@ -74,7 +74,7 @@ impl<T: Debug> BackwardSequenceAwareSyncCursor<T> {
         tokio::select! {
             res = self.skip_indexed() => res?,
             // return early to allow the forward cursor to also make progress
-            _ = sleep(MAX_BACWARD_SYNC_BLOCKING_TIME) => { return Ok(None); }
+            _ = sleep(MAX_BACKWARD_SYNC_BLOCKING_TIME) => { return Ok(None); }
         };
 
         // If `self.current_indexing_snapshot` is None, we are synced and there are no more ranges to query.

--- a/rust/hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs
+++ b/rust/hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs
@@ -73,6 +73,7 @@ impl<T: Debug> BackwardSequenceAwareSyncCursor<T> {
         // Skip any already indexed logs.
         tokio::select! {
             res = self.skip_indexed() => res?,
+            // return early to allow the forward cursor to also make progress
             _ = sleep(MAX_BACWARD_SYNC_BLOCKING_TIME) => { return Ok(None); }
         };
 

--- a/rust/hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs
+++ b/rust/hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs
@@ -9,9 +9,12 @@ use hyperlane_core::{
     HyperlaneSequenceAwareIndexerStoreReader, IndexMode, Indexed, LogMeta, SequenceIndexed,
 };
 use itertools::Itertools;
+use tokio::time::sleep;
 use tracing::{debug, instrument, warn};
 
 use super::{LastIndexedSnapshot, TargetSnapshot};
+
+const MAX_BACWARD_SYNC_BLOCKING_TIME: Duration = Duration::from_secs(1);
 
 /// A sequence-aware cursor that syncs backward until there are no earlier logs to index.
 pub(crate) struct BackwardSequenceAwareSyncCursor<T> {
@@ -68,7 +71,10 @@ impl<T: Debug> BackwardSequenceAwareSyncCursor<T> {
     #[instrument(ret)]
     pub async fn get_next_range(&mut self) -> Result<Option<RangeInclusive<u32>>> {
         // Skip any already indexed logs.
-        self.skip_indexed().await?;
+        tokio::select! {
+            res = self.skip_indexed() => res?,
+            _ = sleep(MAX_BACWARD_SYNC_BLOCKING_TIME) => { return Ok(None); }
+        };
 
         // If `self.current_indexing_snapshot` is None, we are synced and there are no more ranges to query.
         // Otherwise, we query the next range, searching for logs prior to and including the current indexing snapshot.


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
