### PR TITLE
fix: warp configure infinite loop

### DIFF
--- a/.changeset/sharp-geckos-wash.md
+++ b/.changeset/sharp-geckos-wash.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Fix createDefaultWarpIsmConfig to default to trusted relayer and fallback routing without prompts

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -147,7 +147,7 @@ export async function createWarpRouteDeployConfig({
 
     const interchainSecurityModule = advanced
       ? await createAdvancedIsmConfig(context)
-      : await createDefaultWarpIsmConfig(owner);
+      : createDefaultWarpIsmConfig(owner);
 
     switch (type) {
       case TokenType.collateral:
@@ -209,7 +209,7 @@ export function readWarpRouteConfig(filePath: string): WarpCoreConfig {
  * @param owner - The address of the owner of the ISM.
  * @returns The default Aggregation ISM configuration.
  */
-async function createDefaultWarpIsmConfig(owner: Address): Promise<IsmConfig> {
+function createDefaultWarpIsmConfig(owner: Address): IsmConfig {
   return {
     type: IsmType.AGGREGATION,
     modules: [

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -204,7 +204,7 @@ export function readWarpRouteConfig(filePath: string): WarpCoreConfig {
 /**
  * Creates a default configuration for an ISM with a TRUSTED_RELAYER and FALLBACK_ROUTING.
  *
- * Properties relayer and owner and both set as input owner.
+ * Properties relayer and owner are both set as input owner.
  *
  * @param owner - The address of the owner of the ISM.
  * @returns The default Aggregation ISM configuration.


### PR DESCRIPTION
### Description
- Fixes `hyperlane warp configure` ism selection looping by configuring a default Aggregation ISM with trusted relayer and fallback routing

### Related issues

- Fixes #3924 


### Backward compatibility
Yes

### Testing

Manual