### PR TITLE
ci: ignore `*.md` changes when triggering rust/test workflows

### DIFF
--- a/.github/workflows/rust-skipped.yml
+++ b/.github/workflows/rust-skipped.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - 'rust/**'
       - .github/workflows/rust.yml
+      - '*.md'
   # Support for merge queues
   merge_group:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'rust/**'
       - .github/workflows/rust.yml
+      - '!*.md'
   # Support for merge queues
   merge_group:
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - '*' # run against all branches
+    paths-ignore:
+      - '*.md'
   # Support for merge queues
   merge_group:
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
- skips unnecessary tests for PRs on just markdown changes e.g. README