### PR TITLE
feat: add deploy support for IsmConfig in WarpConfig

### DIFF
--- a/.changeset/late-rings-attack.md
+++ b/.changeset/late-rings-attack.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': patch
+'@hyperlane-xyz/sdk': patch
+---
+
+Adds deployment support for IsmConfig within a WarpRouteConfig

--- a/typescript/cli/src/deploy/dry-run.ts
+++ b/typescript/cli/src/deploy/dry-run.ts
@@ -21,7 +21,7 @@ export async function forkNetworkToMultiProvider(
   chain: string,
 ) {
   multiProvider = multiProvider.extendChainMetadata({
-    [chain]: { blocks: { confirmations: 0 } },
+    [chain]: { blocks: { confirmations: 1 } },
   });
 
   await setFork(multiProvider, chain);

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -1,4 +1,5 @@
 import { confirm } from '@inquirer/prompts';
+import { stringify as yamlStringify } from 'yaml';
 
 import { IRegistry } from '@hyperlane-xyz/registry';
 import {
@@ -25,7 +26,11 @@ import { readWarpRouteDeployConfig } from '../config/warp.js';
 import { MINIMUM_WARP_DEPLOY_GAS } from '../consts.js';
 import { WriteCommandContext } from '../context/types.js';
 import { log, logBlue, logGray, logGreen, logTable } from '../logger.js';
-import { isFile, runFileSelectionStep } from '../utils/files.js';
+import {
+  indentYamlOrJson,
+  isFile,
+  runFileSelectionStep,
+} from '../utils/files.js';
 
 import {
   completeDeploy,
@@ -146,7 +151,7 @@ async function executeDeploy(params: DeployParams) {
     log('Writing deployment artifacts');
     await registry.addWarpRoute(warpCoreConfig);
   }
-  log(JSON.stringify(warpCoreConfig, null, 2));
+  log(indentYamlOrJson(yamlStringify(warpCoreConfig, null, 2), 4));
   logBlue('Deployment is complete!');
 }
 
@@ -183,7 +188,9 @@ async function deployAndResolveWarpIsm(
         ) as Record<string, string>;
       }
 
-      logGray(`Creating ${config.type} Ism for chain ${chain}`);
+      logGray(
+        `Creating ${config.interchainSecurityModule.type} Ism for ${config.type} token on ${chain} chain`,
+      );
 
       const deployedIsm = await createWarpIsm(
         chain,
@@ -203,7 +210,9 @@ async function deployAndResolveWarpIsm(
         },
       );
 
-      logGreen(`Finished creating ${config.type} Ism for chain ${chain}`);
+      logGreen(
+        `Finished creating ${config.interchainSecurityModule.type} Ism for ${config.type} token on ${chain} chain`,
+      );
       return { ...warpConfig[chain], interchainSecurityModule: deployedIsm };
     }),
   );

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -135,7 +135,7 @@ async function executeDeploy(params: DeployParams) {
     ismFactoryDeployer,
   );
 
-  // For each chain in WarpRouteConfig, deploy and return a modified config with the ISM as address strings
+  // For each chain in deployedFactoriesAddresses, deploy and return a modified config with the ISM as address strings
   // We need an address because the Deployer cannot handle IsmConfig objects directly
   const modifiedConfig = await deployWarpIsm(
     config,
@@ -176,7 +176,7 @@ async function fetchOrDeployIsmFactoryAddresses(
 }
 
 /**
- * Deploys the Warp ISM for each chain in the provided `WarpRouteDeployConfig`.
+ * Deploys the Warp ISM for each chain in the provided `deployedFactoriesAddresses`.
  * @returns IsmConfig with each Ism as an address string
  */
 async function deployWarpIsm(

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -158,7 +158,22 @@ async function deployAndResolveWarpIsm(
 ): Promise<WarpRouteDeployConfig> {
   return promiseObjAll(
     objMap(warpConfig, async (chain, config) => {
-      logGray('Loading Registry factory addresses');
+      // Skip deployment if Ism is empty, or a string
+      if (
+        !config.interchainSecurityModule ||
+        typeof config.interchainSecurityModule === 'string'
+      ) {
+        logGray(
+          `Config Ism is ${
+            !config.interchainSecurityModule
+              ? 'empty'
+              : config.interchainSecurityModule
+          }, skipping deployment`,
+        );
+        return config;
+      }
+
+      logBlue('Loading Registry factory addresses');
       let chainAddresses = await registry.getChainAddresses(chain); // Can includes other addresses
 
       if (!chainAddresses) {
@@ -188,7 +203,7 @@ async function deployAndResolveWarpIsm(
         },
       );
 
-      logGray(`Finished creating ${config.type} Ism for chain ${chain}`);
+      logGreen(`Finished creating ${config.type} Ism for chain ${chain}`);
       return { ...warpConfig[chain], interchainSecurityModule: deployedIsm };
     }),
   );

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -143,7 +143,6 @@ async function executeDeploy(params: DeployParams) {
     deployedFactoriesAddresses,
     ismFactoryDeployer,
   );
-  console.log('modifiedConfig', modifiedConfig);
   const deployedContracts = await deployer.deploy(modifiedConfig);
 
   logGreen('✅ Hyp token deployments complete');
@@ -186,7 +185,6 @@ async function deployWarpIsm(
   deployedFactoriesAddresses: HyperlaneAddressesMap<any>,
   ismFactoryDeployer: HyperlaneDeployer<any, any>,
 ) {
-  console.log('deployedFactoriesAddresses', deployedFactoriesAddresses);
   return promiseObjAll(
     objMap(
       deployedFactoriesAddresses,

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -165,8 +165,10 @@ async function fetchOrDeployIsmFactoryAddresses(
     objMap(config, async (chain, _config) => {
       const chainAddresses = await registry.getChainAddresses(chain);
       if (chainAddresses) {
+        logGray('Registry factory addresses loaded');
         return chainAddresses; // Can includes other addresses
       } else {
+        logGray('Registry factory addresses not found, deploying');
         return serializeContracts(
           await ismFactoryDeployer.deployContracts(chain),
         );

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -507,3 +507,4 @@ export { canProposeSafeTransactions, getSafe, getSafeDelegates, getSafeService }
 
 export { EvmCoreModule, DeployedCoreAdresses } from './core/EvmCoreModule.js';
 export { EvmERC20WarpModule } from './token/EvmERC20WarpModule.js';
+export { EvmIsmModule } from './ism/EvmIsmModule.js';

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -538,6 +538,7 @@ export class EvmIsmModule extends HyperlaneModule<
     logger: Logger;
   }): Promise<IAggregationIsm> {
     const addresses: Address[] = [];
+    // Needs to be deployed sequentially because Ethers will throw `Error: replacement fee too low`
     for (const module of config.modules) {
       const submodule = await this.deploy({ config: module });
       addresses.push(submodule.address);

--- a/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
@@ -210,40 +210,4 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
     );
     await validateCoreValues(nativeContract);
   });
-
-  it('should create with an IsmConfig', async () => {
-    const config: TokenRouterConfig = {
-      ...baseConfig,
-      type: TokenType.collateral,
-      token: token.address,
-      interchainSecurityModule: {
-        type: IsmType.AGGREGATION,
-        modules: [
-          {
-            type: IsmType.TRUSTED_RELAYER,
-            relayer: signer.address,
-          },
-          {
-            type: IsmType.FALLBACK_ROUTING,
-            domains: {},
-            owner: signer.address,
-          },
-        ],
-        threshold: 1,
-      },
-    };
-
-    // Deploy using WarpModule
-    const evmERC20WarpModule = await EvmERC20WarpModule.create({
-      chain,
-      config,
-      multiProvider,
-    });
-
-    // Let's derive it's onchain token type
-    const { deployedTokenRoute } = evmERC20WarpModule.serialize();
-    const tokenType: TokenType =
-      await evmERC20WarpModule.reader.deriveTokenType(deployedTokenRoute);
-    expect(tokenType).to.equal(TokenType.collateral);
-  });
 });

--- a/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
@@ -16,7 +16,6 @@ import {
 } from '@hyperlane-xyz/core';
 import {
   HyperlaneContractsMap,
-  IsmType,
   RouterConfig,
   TestChainName,
 } from '@hyperlane-xyz/sdk';

--- a/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
@@ -211,7 +211,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
     await validateCoreValues(nativeContract);
   });
 
-  it.only('should create with an IsmConfig', async () => {
+  it('should create with an IsmConfig', async () => {
     const config: TokenRouterConfig = {
       ...baseConfig,
       type: TokenType.collateral,

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -65,10 +65,6 @@ abstract class TokenDeployer<
   }
 
   async initializeArgs(_: ChainName, config: TokenRouterConfig): Promise<any> {
-    // ISM config can be an object, but is not supported right now.
-    if (typeof config.interchainSecurityModule === 'object') {
-      throw new Error('Token deployer does not support ISM objects currently');
-    }
     const defaultArgs = [
       config.hook ?? constants.AddressZero,
       config.interchainSecurityModule ?? constants.AddressZero,


### PR DESCRIPTION
### Description
Adds deployment support for IsmConfig within a WarpRouteConfig

### Drive-by changes
- Update dry-run confirmation to 1

### Related issues
- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3933

### Backward compatibility
Yes

### Testing
Manual
- [x] Deploy Warp with Ism as object
- [x] Deploy Warp with Ism as string
- [x] Deploy Warp with Ism as empty
- [x] Deploy synthetic on sepolia and collateral holesky with default ism config (aggregation, trusted, domain)
- [x] Deploy collateral on sepolia with default ism config (aggregation, trusted, domain)
