### PR TITLE
feat: AVS mainnet deployment

### DIFF
--- a/.changeset/strong-colts-hide.md
+++ b/.changeset/strong-colts-hide.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+AVS deployment on mainnet

--- a/solidity/script/avs/eigenlayer_addresses.json
+++ b/solidity/script/avs/eigenlayer_addresses.json
@@ -6,12 +6,52 @@
     "paymentCoordinator": "",
     "strategies": [
       {
+        "name": "swETH",
+        "strategy": "0x0Fe4F44beE93503346A3Ac9EE5A26b130a5796d6"
+      },
+      {
+        "name": "oETH",
+        "strategy": "0x13760F50a9d7377e4F20CB8CF9e4c26586c658ff"
+      },
+      {
+        "name": "rETH",
+        "strategy": "0x1BeE69b7dFFfA4E2d53C2a2Df135C388AD25dCD2"
+      },
+      {
+        "name": "mETH",
+        "strategy": "0x298aFB19A105D59E74658C4C334Ff360BadE6dd2"
+      },
+      {
         "name": "cbETH",
         "strategy": "0x54945180dB7943c0ed0FEE7EdaB2Bd24620256bc"
       },
       {
+        "name": "osETH",
+        "strategy": "0x57ba429517c3473B6d34CA9aCd56c0e735b94c02"
+      },
+      {
+        "name": "wBETH",
+        "strategy": "0x7CA911E83dabf90C90dD3De5411a10F1A6112184"
+      },
+      {
+        "name": "sfrxETH",
+        "strategy": "0x8CA7A5d6f3acd3A7A8bC468a8CD0FB14B6BD28b6"
+      },
+      {
         "name": "stETH",
         "strategy": "0x93c4b944D05dfe6df7645A86cd2206016c51564D"
+      },
+      {
+        "name": "ETHx",
+        "strategy": "0x9d7eD45EE2E8FC5482fa2428f15C971e6369011d"
+      },
+      {
+        "name": "ankrETH",
+        "strategy": "0xa4C637e0F704745D182e4D38cAb7E7485321d059"
+      },
+      {
+        "name": "lsETH",
+        "strategy": "0xAe60d8180437b5C34bB956822ac2710972584473"
       },
       {
         "name": "Beacon Chain ETH",

--- a/typescript/cli/src/avs/config.ts
+++ b/typescript/cli/src/avs/config.ts
@@ -16,4 +16,10 @@ export const avsAddresses: ChainMap<AVSContracts> = {
     ecdsaStakeRegistry: '0xFfa913705484C9BAea32Ffe9945BeA099A1DFF72',
     hyperlaneServiceManager: '0xc76E477437065093D353b7d56c81ff54D167B0Ab',
   },
+  ethereum: {
+    avsDirectory: '0x135dda560e946695d6f155dacafc6f1f25c1f5af',
+    proxyAdmin: '0x75EE15Ee1B4A75Fa3e2fDF5DF3253c25599cc659',
+    ecdsaStakeRegistry: '0x272CF0BB70D3B4f79414E0823B426d2EaFd48910',
+    hyperlaneServiceManager: '0xe8E59c6C8B56F2c178f63BCFC4ce5e5e2359c8fc',
+  },
 };

--- a/typescript/cli/src/avs/stakeRegistry.ts
+++ b/typescript/cli/src/avs/stakeRegistry.ts
@@ -24,12 +24,12 @@ export async function registerOperatorWithSignature({
   context,
   chain,
   operatorKeyPath,
-  avsSigningKey,
+  avsSigningKeyAddress,
 }: {
   context: WriteCommandContext;
   chain: ChainName;
   operatorKeyPath: string;
-  avsSigningKey: Address;
+  avsSigningKeyAddress: Address;
 }) {
   const { multiProvider } = context;
 
@@ -67,13 +67,13 @@ export async function registerOperatorWithSignature({
   }
 
   log(
-    `Registering operator ${operatorAsSigner.address} attesting ${avsSigningKey} with signature on ${chain}...`,
+    `Registering operator ${operatorAsSigner.address} attesting ${avsSigningKeyAddress} with signature on ${chain}...`,
   );
   await multiProvider.handleTx(
     chain,
     ecdsaStakeRegistry.registerOperatorWithSignature(
       operatorSignature,
-      avsSigningKey,
+      avsSigningKeyAddress,
     ),
   );
   logBlue(`Operator ${operatorAsSigner.address} registered to Hyperlane AVS`);

--- a/typescript/cli/src/commands/avs.ts
+++ b/typescript/cli/src/commands/avs.ts
@@ -40,7 +40,7 @@ export const registrationOptions: { [k: string]: Options } = {
     description: 'Path to the operator key file',
     demandOption: true,
   },
-  avsSigningKey: {
+  avsSigningKeyAddress: {
     type: 'string',
     description: 'Address of the AVS signing key',
     demandOption: true,
@@ -50,17 +50,22 @@ export const registrationOptions: { [k: string]: Options } = {
 const registerCommand: CommandModuleWithWriteContext<{
   chain: ChainName;
   operatorKeyPath: string;
-  avsSigningKey: Address;
+  avsSigningKeyAddress: Address;
 }> = {
   command: 'register',
   describe: 'Register operator with the AVS',
   builder: registrationOptions,
-  handler: async ({ context, chain, operatorKeyPath, avsSigningKey }) => {
+  handler: async ({
+    context,
+    chain,
+    operatorKeyPath,
+    avsSigningKeyAddress,
+  }) => {
     await registerOperatorWithSignature({
       context,
       chain,
       operatorKeyPath,
-      avsSigningKey,
+      avsSigningKeyAddress,
     });
     process.exit(0);
   },


### PR DESCRIPTION
### Description

- Added all the strategies used by EigenDA on mainnet here:https://github.com/Layr-Labs/eigenlayer-contracts?tab=readme-ov-file#deployments
- Deployed AVS contracts to mainnet 
- Added contract address to CLI 

(reminder: strategies are just LST tokens supported for restaking. These are not relevant for us but brings us to parity with most other AVSs).

### Drive-by changes

- `avsSigningKey` renamed to `avsSigningKeyAddress` as `avsSigningKey` may imply the private key and confuse operators.

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
