### PR TITLE
chore: include 10% gas estimate bump in EvmIsmModule

### DIFF
--- a/typescript/sdk/src/deploy/EvmModuleDeployer.ts
+++ b/typescript/sdk/src/deploy/EvmModuleDeployer.ts
@@ -258,11 +258,20 @@ export class EvmModuleDeployer<Factories extends HyperlaneFactories> {
         `Deploying new ${threshold} of ${values.length} address set to ${chain}`,
       );
       const overrides = multiProvider.getTransactionOverrides(chain);
-      const hash = await factory['deploy(address[],uint8)'](
+
+      // estimate gas
+      const estimatedGas = await factory.estimateGas['deploy(address[],uint8)'](
         values,
         threshold,
         overrides,
       );
+
+      // add 10% buffer
+      const hash = await factory['deploy(address[],uint8)'](values, threshold, {
+        ...overrides,
+        gasLimit: estimatedGas.add(estimatedGas.div(10)), // 10% buffer
+      });
+
       await multiProvider.handleTx(chain, hash);
     } else {
       logger.debug(

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -525,12 +525,23 @@ export class EvmIsmModule extends HyperlaneModule<
       signer,
     );
 
-    // deploying new domain routing ISM
-    const tx = await domainRoutingIsmFactory.deploy(
+    // estimate gas
+    const estimatedGas = await domainRoutingIsmFactory.estimateGas.deploy(
       owner,
       domainIds,
       submoduleAddresses,
       overrides,
+    );
+
+    // deploying new domain routing ISM, add 10% buffer
+    const tx = await domainRoutingIsmFactory.deploy(
+      owner,
+      domainIds,
+      submoduleAddresses,
+      {
+        ...overrides,
+        gasLimit: estimatedGas.add(estimatedGas.div(10)), // 10% buffer
+      },
     );
 
     const receipt = await this.multiProvider.handleTx(this.args.chain, tx);


### PR DESCRIPTION
- in the multiprovider we already do a 10% bump on the estimated gas, as a cover for unpredictable gas estimation
- we recently found that the ism factories do not do this, which caused problems in a recent hyperlane core deployment
- added this into the ism factories on `main`
- so we are ensuring that this change is properly reflected in the new ism module as well