### PR TITLE
feat: add stdout.rows to pagesize calculation with DEFAULT_PAGE_SIZE

### DIFF
--- a/.changeset/wise-cobras-juggle.md
+++ b/.changeset/wise-cobras-juggle.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Add stdout.rows to pagesize calculation with DEFAULT_PAGE_SIZE

--- a/typescript/cli/src/utils/chains.ts
+++ b/typescript/cli/src/utils/chains.ts
@@ -9,6 +9,7 @@ import { log, logRed, logTip } from '../logger.js';
 // A special value marker to indicate user selected
 // a new chain in the list
 const NEW_CHAIN_MARKER = '__new__';
+const DEFAULT_PAGE_SIZE = 15;
 
 export async function runSingleChainSelectionStep(
   chainMetadata: ChainMap<ChainMetadata>,
@@ -18,7 +19,7 @@ export async function runSingleChainSelectionStep(
   const chain = (await select({
     message,
     choices,
-    pageSize: 30,
+    pageSize: process.stdout.rows - 2 || DEFAULT_PAGE_SIZE, // subtract 2, to exclude previous prompt text
   })) as string;
   handleNewChain([chain]);
   return chain;
@@ -35,7 +36,7 @@ export async function runMultiChainSelectionStep(
     const chains = (await checkbox({
       message,
       choices,
-      pageSize: 30,
+      pageSize: process.stdout.rows - 2 || DEFAULT_PAGE_SIZE, // subtract 2, to exclude previous prompt text
     })) as string[];
     handleNewChain(chains);
     if (requireMultiple && chains?.length < 2) {

--- a/typescript/cli/src/utils/chains.ts
+++ b/typescript/cli/src/utils/chains.ts
@@ -9,7 +9,15 @@ import { log, logRed, logTip } from '../logger.js';
 // A special value marker to indicate user selected
 // a new chain in the list
 const NEW_CHAIN_MARKER = '__new__';
-const DEFAULT_PAGE_SIZE = 15;
+
+// Returns a dynamic pageSize based on process.stdout.rows
+const calculatePageSize = (
+  skipSize: number = 0, // number of lines to skip. Can be used to skip previous prompts
+  defaultPageSize: number = 15, // default when pageSize is too small
+) =>
+  process.stdout.rows > skipSize
+    ? process.stdout.rows - skipSize
+    : defaultPageSize;
 
 export async function runSingleChainSelectionStep(
   chainMetadata: ChainMap<ChainMetadata>,
@@ -19,7 +27,7 @@ export async function runSingleChainSelectionStep(
   const chain = (await select({
     message,
     choices,
-    pageSize: process.stdout.rows - 2 || DEFAULT_PAGE_SIZE, // subtract 2, to exclude previous prompt text
+    pageSize: calculatePageSize(2),
   })) as string;
   handleNewChain([chain]);
   return chain;
@@ -36,7 +44,7 @@ export async function runMultiChainSelectionStep(
     const chains = (await checkbox({
       message,
       choices,
-      pageSize: process.stdout.rows - 2 || DEFAULT_PAGE_SIZE, // subtract 2, to exclude previous prompt text
+      pageSize: calculatePageSize(2),
     })) as string[];
     handleNewChain(chains);
     if (requireMultiple && chains?.length < 2) {

--- a/typescript/cli/src/utils/chains.ts
+++ b/typescript/cli/src/utils/chains.ts
@@ -6,18 +6,11 @@ import { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
 
 import { log, logRed, logTip } from '../logger.js';
 
+import { calculatePageSize } from './cli-options.js';
+
 // A special value marker to indicate user selected
 // a new chain in the list
 const NEW_CHAIN_MARKER = '__new__';
-
-// Returns a dynamic pageSize based on process.stdout.rows
-const calculatePageSize = (
-  skipSize: number = 0, // number of lines to skip. Can be used to skip previous prompts
-  defaultPageSize: number = 15, // default when pageSize is too small
-) =>
-  process.stdout.rows > skipSize
-    ? process.stdout.rows - skipSize
-    : defaultPageSize;
 
 export async function runSingleChainSelectionStep(
   chainMetadata: ChainMap<ChainMetadata>,

--- a/typescript/cli/src/utils/cli-options.ts
+++ b/typescript/cli/src/utils/cli-options.ts
@@ -1,0 +1,17 @@
+// Functions used to manipulate CLI specific options
+
+/**
+ * Calculates the page size for a CLI Terminal output, taking into account the number of lines to skip and a default page size.
+ *
+ * @param skipSize - The number of lines to skip, which can be used to skip previous prompts.
+ * @param defaultPageSize - The default page size to use if the terminal height is too small.
+ * @returns The calculated pageSize, which is the terminal height minus the skip size, or the default page size if the terminal height is too small.
+ */
+export function calculatePageSize(
+  skipSize: number = 0,
+  defaultPageSize: number = 15,
+) {
+  return process.stdout.rows > skipSize
+    ? process.stdout.rows - skipSize
+    : defaultPageSize;
+}


### PR DESCRIPTION
### Description
- Add process.stdout.rows to pageSize adjustment for chain selection
- Defaults to 15 if process.stdout.rows < 0

### Backward compatibility
Yes

### Testing
Manual
