### PR TITLE
feat: `hyperlane config create chain` prompts for `displayName`

### DIFF
--- a/.changeset/new-timers-applaud.md
+++ b/.changeset/new-timers-applaud.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Add chain displayName prompt with default

--- a/typescript/cli/src/config/chain.ts
+++ b/typescript/cli/src/config/chain.ts
@@ -61,6 +61,11 @@ export async function createChainConfig({
     validate: (chainName) => ZChainName.safeParse(chainName).success,
   });
 
+  const displayName = await input({
+    message: 'Enter chain display name',
+    default: name[0].toUpperCase() + name.slice(1),
+  });
+
   const chainId = parseInt(
     await detectAndConfirmOrPrompt(
       async () => {
@@ -76,6 +81,7 @@ export async function createChainConfig({
 
   const metadata: ChainMetadata = {
     name,
+    displayName,
     chainId,
     domainId: chainId,
     protocol: ProtocolType.Ethereum,


### PR DESCRIPTION
### Description
- Add logic to `hyperlane config create chain` to prompt for `displayName`
![Screenshot 2024-06-14 at 4 33 26 PM](https://github.com/hyperlane-xyz/hyperlane-monorepo/assets/6251863/36e00fc4-f41a-4069-911f-4966bbb6f6e6)


### Backward compatibility

Yes

### Testing
Manual
