### PR TITLE
Support priorityFee fetching from RPC and some better logging

### DIFF
--- a/.changeset/wild-deers-scream.md
+++ b/.changeset/wild-deers-scream.md
@@ -1,0 +1,6 @@
+---
+"@hyperlane-xyz/cli": patch
+"@hyperlane-xyz/sdk": patch
+---
+
+Support priorityFee fetching from RPC and some better logging

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -142,9 +142,12 @@ async function executeDeploy(params: DeployParams) {
     ismFactoryDeployer,
   );
 
+  logGreen('✅ ISM deployments complete');
+  log(`Deploying Warp contracts`);
+
   const deployedContracts = await deployer.deploy(modifiedConfig);
 
-  logGreen('✅ Hyp token deployments complete');
+  logGreen('✅ Warp contract deployments complete');
 
   const warpCoreConfig = await getWarpCoreConfig(params, deployedContracts);
   if (!isDryRun) {

--- a/typescript/sdk/src/providers/SmartProvider/HyperlaneEtherscanProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/HyperlaneEtherscanProvider.ts
@@ -24,6 +24,7 @@ export class HyperlaneEtherscanProvider
     ProviderMethod.Call,
     ProviderMethod.EstimateGas,
     ProviderMethod.SendTransaction,
+    ProviderMethod.MaxPriorityFeePerGas,
   ]);
 
   constructor(

--- a/typescript/sdk/src/providers/SmartProvider/HyperlaneJsonRpcProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/HyperlaneJsonRpcProvider.ts
@@ -32,6 +32,13 @@ export class HyperlaneJsonRpcProvider
     super(rpcConfig.connection ?? rpcConfig.http, network);
   }
 
+  prepareRequest(method: string, params: any): [string, any[]] {
+    if (method === ProviderMethod.MaxPriorityFeePerGas) {
+      return ['eth_maxPriorityFeePerGas', []];
+    }
+    return super.prepareRequest(method, params);
+  }
+
   async perform(method: string, params: any, reqId?: number): Promise<any> {
     if (this.options?.debug)
       this.logger.debug(
@@ -149,6 +156,10 @@ export class HyperlaneJsonRpcProvider
     }
 
     return combinedResults;
+  }
+
+  get maxPriorityFeePerGas(): Promise<BigNumber> {
+    return this.perform('eth_maxPriorityFeePerGas', {});
   }
 
   getBaseUrl(): string {

--- a/typescript/sdk/src/providers/SmartProvider/ProviderMethods.ts
+++ b/typescript/sdk/src/providers/SmartProvider/ProviderMethods.ts
@@ -16,6 +16,7 @@ export enum ProviderMethod {
   GetTransactionReceipt = 'getTransactionReceipt',
   GetLogs = 'getLogs',
   SendTransaction = 'sendTransaction',
+  MaxPriorityFeePerGas = 'maxPriorityFeePerGas',
 }
 
 export const AllProviderMethods = Object.values(ProviderMethod);

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -83,51 +83,61 @@ abstract class TokenDeployer<
     multiProvider: MultiProvider,
     configMap: WarpRouteDeployConfig,
   ): Promise<TokenMetadata | undefined> {
-    for (const [chain, config] of Object.entries(configMap)) {
-      if (isTokenMetadata(config)) {
-        return config;
-      }
-
-      if (isNativeConfig(config)) {
-        const nativeToken = multiProvider.getChainMetadata(chain).nativeToken;
-        if (nativeToken) {
-          return { totalSupply: 0, ...nativeToken };
+    try {
+      for (const [chain, config] of Object.entries(configMap)) {
+        if (isTokenMetadata(config)) {
+          return config;
         }
-      }
 
-      if (isCollateralConfig(config)) {
-        const provider = multiProvider.getProvider(chain);
+        if (isNativeConfig(config)) {
+          const nativeToken = multiProvider.getChainMetadata(chain).nativeToken;
+          if (nativeToken) {
+            return { totalSupply: 0, ...nativeToken };
+          }
+        }
 
-        if (config.isNft) {
-          const erc721 = ERC721Enumerable__factory.connect(
-            config.token,
-            provider,
-          );
-          const [name, symbol, totalSupply] = await Promise.all([
-            erc721.name(),
-            erc721.symbol(),
-            erc721.totalSupply(),
+        if (isCollateralConfig(config)) {
+          const provider = multiProvider.getProvider(chain);
+
+          if (config.isNft) {
+            const erc721 = ERC721Enumerable__factory.connect(
+              config.token,
+              provider,
+            );
+            const [name, symbol, totalSupply] = await Promise.all([
+              erc721.name(),
+              erc721.symbol(),
+              erc721.totalSupply(),
+            ]);
+            return {
+              name,
+              symbol,
+              totalSupply: totalSupply.toString(),
+            };
+          }
+
+          const erc20 = ERC20__factory.connect(config.token, provider);
+          const [name, symbol, totalSupply, decimals] = await Promise.all([
+            erc20.name(),
+            erc20.symbol(),
+            erc20.totalSupply(),
+            erc20.decimals(),
           ]);
+
           return {
             name,
             symbol,
             totalSupply: totalSupply.toString(),
+            decimals,
           };
         }
-
-        const erc20 = ERC20__factory.connect(config.token, provider);
-        const [name, symbol, totalSupply, decimals] = await Promise.all([
-          erc20.name(),
-          erc20.symbol(),
-          erc20.totalSupply(),
-          erc20.decimals(),
-        ]);
-
-        return { name, symbol, totalSupply: totalSupply.toString(), decimals };
       }
-    }
 
-    return undefined;
+      return undefined;
+    } catch (error) {
+      console.error(`Could not derive token metadata`, configMap, error);
+      return undefined;
+    }
   }
 
   async deploy(configMap: WarpRouteDeployConfig) {
@@ -135,6 +145,7 @@ abstract class TokenDeployer<
       this.multiProvider,
       configMap,
     );
+    this.logger.debug({ tokenMetadata }, `Derived token metadata`);
     const resolvedConfigMap = objMap(configMap, (_, config) => ({
       ...tokenMetadata,
       gas: gasOverhead(config.type),


### PR DESCRIPTION
### Description

Like title says, this PR allows the SmartProvider to fetch feeData from the RPC, if supported. Otherwise it falls back to the existing 1.5 gwei hardcoded value that ethers.js v5 has. On most L2s, that is a gross overestimate, resulting in so much wasted ETH.

### Drive-by changes

Some additional logging

### Backward compatibility

Yes

### Testing
Manual 