### PR TITLE
Do not consider xERC20 a collateral standard 

### DIFF
--- a/.changeset/olive-geckos-behave.md
+++ b/.changeset/olive-geckos-behave.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Do not consider xERC20 a collateral standard to fix fungibility checking logic while maintaining mint limit checking

--- a/typescript/sdk/src/token/TokenStandard.ts
+++ b/typescript/sdk/src/token/TokenStandard.ts
@@ -94,12 +94,15 @@ export const TOKEN_NFT_STANDARDS = [
 export const TOKEN_COLLATERALIZED_STANDARDS = [
   TokenStandard.EvmHypCollateral,
   TokenStandard.EvmHypNative,
-  TokenStandard.EvmHypXERC20,
-  TokenStandard.EvmHypXERC20Lockbox,
   TokenStandard.SealevelHypCollateral,
   TokenStandard.SealevelHypNative,
   TokenStandard.CwHypCollateral,
   TokenStandard.CwHypNative,
+];
+
+export const MINT_LIMITED_STANDARDS = [
+  TokenStandard.EvmHypXERC20,
+  TokenStandard.EvmHypXERC20Lockbox,
 ];
 
 export const TOKEN_HYP_STANDARDS = [

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -22,6 +22,7 @@ import { Token } from '../token/Token.js';
 import { TokenAmount } from '../token/TokenAmount.js';
 import { parseTokenConnectionId } from '../token/TokenConnection.js';
 import {
+  MINT_LIMITED_STANDARDS,
   TOKEN_COLLATERALIZED_STANDARDS,
   TOKEN_STANDARD_TO_PROVIDER_TYPE,
   TokenStandard,
@@ -427,7 +428,10 @@ export class WarpCore {
       originToken.getConnectionForChain(destinationName)?.token;
     assert(destinationToken, `No connection found for ${destinationName}`);
 
-    if (!TOKEN_COLLATERALIZED_STANDARDS.includes(destinationToken.standard)) {
+    if (
+      !TOKEN_COLLATERALIZED_STANDARDS.includes(destinationToken.standard) &&
+      !MINT_LIMITED_STANDARDS.includes(destinationToken.standard)
+    ) {
       this.logger.debug(
         `${destinationToken.symbol} is not collateralized, skipping`,
       );


### PR DESCRIPTION
### Description

Here is another funky issue, @AlexBHarley added the xerc20 tokens to `TOKEN_COLLATERALIZED_STANDARDS` https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3911/files#diff-b98aa4b2eb3c8040524fa7f6d52d0fbbbc89fbac07485305664832f1742212aaR97 to be able to support collateral checking. However, that inadvertently broke our fungibility logic at https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/51bfff683e903a217efc15ae566c6e713c428b42/typescript/sdk/src/token/Token.ts#L416

Specifically, there is an assumption that any token config that is a collateral standard has `collateralAddressOrDenom`, which is not the case for `HypXERC20` since it doesn't really keep things in collateral (but conceptually it kinda does since mint/burn limits should be checked).

I don't feel strongly either way and would leave it to @jmrossy and @AlexBHarley  to hash it out, but for now, here is a PR that has more special cased (ugly) logic for destination "collateral" checking and removes it from `TOKEN_COLLATERALIZED_STANDARDS`
