### PR TITLE
feat: allow fork-testing of transfer ownership

### DIFF
--- a/typescript/infra/scripts/check-deploy.ts
+++ b/typescript/infra/scripts/check-deploy.ts
@@ -10,7 +10,6 @@ import {
   InterchainAccountChecker,
   InterchainQuery,
   InterchainQueryChecker,
-  resolveOrDeployAccountOwner,
 } from '@hyperlane-xyz/sdk';
 
 import { Contexts } from '../config/contexts.js';
@@ -54,12 +53,11 @@ async function check() {
         [fork]: { blocks: { confirmations: 0 } },
       });
 
-      const owner = await resolveOrDeployAccountOwner(
-        multiProvider,
-        fork,
-        envConfig.core[fork].owner,
+      // Hardcode deployer key as the one to impersonate
+      const signer = await impersonateAccount(
+        '0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba',
+        1e18,
       );
-      const signer = await impersonateAccount(owner, 1e18);
 
       multiProvider.setSigner(fork, signer);
     }

--- a/typescript/infra/src/govern/HyperlaneAppGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneAppGovernor.ts
@@ -62,7 +62,8 @@ export abstract class HyperlaneAppGovernor<
 
   async govern(confirm = true, chain?: ChainName) {
     if (this.checker.violations.length === 0) return;
-
+    // Reverse so that the mailbox transfer ownership is at the end
+    this.checker.violations.reverse();
     // 1. Produce calls from checker violations.
     await this.mapViolationsToCalls();
 
@@ -93,7 +94,6 @@ export abstract class HyperlaneAppGovernor<
         calls.map((c) =>
           console.log(`> > ${c.description} (to: ${c.to} data: ${c.data})`),
         );
-
         if (!requestConfirmation) return true;
 
         const { value: confirmed } = await prompts({
@@ -102,6 +102,7 @@ export abstract class HyperlaneAppGovernor<
           message: 'Can you confirm?',
           initial: false,
         });
+
         return !!confirmed;
       }
       return false;

--- a/typescript/infra/src/govern/HyperlaneAppGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneAppGovernor.ts
@@ -62,8 +62,6 @@ export abstract class HyperlaneAppGovernor<
 
   async govern(confirm = true, chain?: ChainName) {
     if (this.checker.violations.length === 0) return;
-    // Reverse so that the mailbox transfer ownership is at the end
-    this.checker.violations.reverse();
     // 1. Produce calls from checker violations.
     await this.mapViolationsToCalls();
 

--- a/typescript/sdk/src/core/HyperlaneCoreChecker.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreChecker.ts
@@ -39,7 +39,6 @@ export class HyperlaneCoreChecker extends HyperlaneAppChecker<
       return;
     }
 
-    await this.checkDomainOwnership(chain);
     await this.checkProxiedContracts(chain);
     await this.checkMailbox(chain);
     await this.checkBytecodes(chain);
@@ -47,6 +46,7 @@ export class HyperlaneCoreChecker extends HyperlaneAppChecker<
     if (config.upgrade) {
       await this.checkUpgrade(chain, config.upgrade);
     }
+    await this.checkDomainOwnership(chain);
   }
 
   async checkDomainOwnership(chain: ChainName): Promise<void> {


### PR DESCRIPTION
### Description

THIS PR SHOULD NOT BE MERGED.

This is some temp changes to test that the governor can resolve the violations to transferOwnership to a multisig.

### Drive-by changes

Changed that the prompting indeed is disabled during fork testing (probably should go in another PR)

### Backward compatibility

No


### Testing

Ran `./fork.sh mainnet3 core mode` and noted that the violations are resolved