### PR TITLE
fix: Do not consider xERC20 a collateral standard 2

### DIFF
--- a/.changeset/olive-geckos-behave.md
+++ b/.changeset/olive-geckos-behave.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Do not consider xERC20 a collateral standard to fix fungibility checking logic while maintaining mint limit checking

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -183,10 +183,7 @@ async function getWarpCoreConfig(
         return wrappedToken;
       }
 
-      if (
-        config.type === TokenType.collateral ||
-        config.type === TokenType.XERC20
-      ) {
+      if (config.type === TokenType.collateral) {
         return config.token;
       }
 

--- a/typescript/sdk/src/token/TokenStandard.ts
+++ b/typescript/sdk/src/token/TokenStandard.ts
@@ -94,12 +94,15 @@ export const TOKEN_NFT_STANDARDS = [
 export const TOKEN_COLLATERALIZED_STANDARDS = [
   TokenStandard.EvmHypCollateral,
   TokenStandard.EvmHypNative,
-  TokenStandard.EvmHypXERC20,
-  TokenStandard.EvmHypXERC20Lockbox,
   TokenStandard.SealevelHypCollateral,
   TokenStandard.SealevelHypNative,
   TokenStandard.CwHypCollateral,
   TokenStandard.CwHypNative,
+];
+
+export const MINT_LIMITED_STANDARDS = [
+  TokenStandard.EvmHypXERC20,
+  TokenStandard.EvmHypXERC20Lockbox,
 ];
 
 export const TOKEN_HYP_STANDARDS = [

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -22,6 +22,7 @@ import { Token } from '../token/Token.js';
 import { TokenAmount } from '../token/TokenAmount.js';
 import { parseTokenConnectionId } from '../token/TokenConnection.js';
 import {
+  MINT_LIMITED_STANDARDS,
   TOKEN_COLLATERALIZED_STANDARDS,
   TOKEN_STANDARD_TO_PROVIDER_TYPE,
   TokenStandard,
@@ -427,7 +428,10 @@ export class WarpCore {
       originToken.getConnectionForChain(destinationName)?.token;
     assert(destinationToken, `No connection found for ${destinationName}`);
 
-    if (!TOKEN_COLLATERALIZED_STANDARDS.includes(destinationToken.standard)) {
+    if (
+      !TOKEN_COLLATERALIZED_STANDARDS.includes(destinationToken.standard) &&
+      !MINT_LIMITED_STANDARDS.includes(destinationToken.standard)
+    ) {
       this.logger.debug(
         `${destinationToken.symbol} is not collateralized, skipping`,
       );


### PR DESCRIPTION
Amending https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3973 to ensure output of the CLI doesn't incorrectly add `collateralAddressOrDenom` to xERC20 configs.