### PR TITLE
fix: disable initializers in xERC20 adapters

### DIFF
--- a/solidity/contracts/token/extensions/HypXERC20.sol
+++ b/solidity/contracts/token/extensions/HypXERC20.sol
@@ -8,7 +8,9 @@ contract HypXERC20 is HypERC20Collateral {
     constructor(
         address _xerc20,
         address _mailbox
-    ) HypERC20Collateral(_xerc20, _mailbox) {}
+    ) HypERC20Collateral(_xerc20, _mailbox) {
+        _disableInitializers();
+    }
 
     function _transferFromSender(
         uint256 _amountOrId

--- a/solidity/contracts/token/extensions/HypXERC20Lockbox.sol
+++ b/solidity/contracts/token/extensions/HypXERC20Lockbox.sol
@@ -18,6 +18,7 @@ contract HypXERC20Lockbox is HypERC20Collateral {
         lockbox = IXERC20Lockbox(_lockbox);
         xERC20 = lockbox.XERC20();
         approveLockbox();
+        _disableInitializers();
     }
 
     /**


### PR DESCRIPTION
### Description

- Follow OZ best practice from https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#initializing_the_implementation_contract

### Backward compatibility

Yes

### Testing

Unit tests