### PR TITLE
docs: Rectify typographical inaccuracies

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,4 +1,4 @@
-# A Github action that using codespell to check spelling.
+# A Github action that uses codespell to check spelling.
 # see .codespell/* for configs
 # https://github.com/codespell-project/codespell
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -324,7 +324,7 @@ jobs:
     steps:
       - name: Report Matrix Result
         run: |
-          echo "All e2e-matrix jobs have completed."
+          echo "All e2e-matrix jobs have been completed."
           # You can add additional commands here to report the result as needed
 
   cli-e2e:

--- a/rust/.vscode/extensions.json
+++ b/rust/.vscode/extensions.json
@@ -2,7 +2,7 @@
   // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
   // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 
-  // List of extensions which should be recommended for users of this workspace.
+  // List of extensions that should be recommended for users of this workspace.
   "recommendations": [
     "rust-lang.rust-analyzer",
     "tamasfe.even-better-toml",

--- a/rust/agents/relayer/src/merkle_tree/processor.rs
+++ b/rust/agents/relayer/src/merkle_tree/processor.rs
@@ -44,7 +44,7 @@ impl ProcessorExt for MerkleTreeProcessor {
         self.db.domain()
     }
 
-    /// One round of processing, extracted from infinite work loop for
+    /// One round of processing, extracted from an infinite work loop for
     /// testing purposes.
     async fn tick(&mut self) -> Result<()> {
         if let Some(insertion) = self.next_unprocessed_leaf()? {

--- a/rust/agents/relayer/src/msg/gas_payment/mod.rs
+++ b/rust/agents/relayer/src/msg/gas_payment/mod.rs
@@ -185,7 +185,7 @@ mod test {
                 hyperlane_db,
             );
 
-            // Ensure that message without any payment is considered as not meeting the
+            // Ensure that a message without any payment is considered as not meeting the
             // requirement because it doesn't match the GasPaymentEnforcementPolicy
             assert_eq!(
                 enforcer

--- a/rust/agents/relayer/src/msg/mod.rs
+++ b/rust/agents/relayer/src/msg/mod.rs
@@ -23,7 +23,7 @@
 //!   - SpeculativeSerializedSubmitter (batches with higher optimistic nonces,
 //!     recovery behavior)
 //!   - FallbackProviderSubmitter (Serialized, but if some RPC provider sucks,
-//!   switch everyone to new one)
+//!   switch everyone to a new one)
 
 pub(crate) mod gas_payment;
 pub(crate) mod metadata;

--- a/rust/agents/relayer/src/msg/op_submitter.rs
+++ b/rust/agents/relayer/src/msg/op_submitter.rs
@@ -41,7 +41,7 @@ use super::op_queue::OpQueue;
 /// incorporates both user-visible metrics and message operation readiness
 /// checks.
 ///
-/// Operations which failed processing due to a retriable error are also
+/// Operations that failed processing due to a retriable error are also
 /// retained within the SerialSubmitter, and will eventually be retried
 /// according to our prioritization rule.
 ///

--- a/rust/agents/relayer/src/msg/pending_message.rs
+++ b/rust/agents/relayer/src/msg/pending_message.rs
@@ -229,7 +229,7 @@ impl PendingOperation for PendingMessage {
             return self.on_reprepare();
         };
 
-        // Go ahead and attempt processing of message to destination chain.
+        // Go ahead and attempt processing of message to the destination chain.
         debug!(
             ?gas_limit,
             ?tx_cost_estimate,


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.