### PR TITLE
feat(cli): Support agent config generation for all chains

### DIFF
--- a/typescript/cli/src/commands/options.ts
+++ b/typescript/cli/src/commands/options.ts
@@ -113,7 +113,6 @@ export const chainTargetsCommandOption: Options = {
   type: 'string',
   description: 'Comma-separated list of chain names',
   alias: 'c',
-  demandOption: true,
 };
 
 export const outputFileCommandOption = (

--- a/typescript/cli/src/commands/registry.ts
+++ b/typescript/cli/src/commands/registry.ts
@@ -113,17 +113,11 @@ const createAgentConfigCommand: CommandModuleWithContext<{
       false,
       'The path to output an agent config JSON file.',
     ),
-    skipPrompts: {
-      type: 'boolean',
-      description: 'Skip user prompts',
-      default: false,
-    },
   },
   handler: async ({
     context,
     chains,
     out,
-    skipPrompts,
   }: {
     context: CommandContext;
     chains?: string;
@@ -152,7 +146,6 @@ const createAgentConfigCommand: CommandModuleWithContext<{
       context,
       chains: chainNames,
       out,
-      skipPrompts,
     });
     process.exit(0);
   },

--- a/typescript/cli/src/config/prompts.ts
+++ b/typescript/cli/src/config/prompts.ts
@@ -1,0 +1,14 @@
+import { confirm } from '@inquirer/prompts';
+
+export const autoConfirm = async (
+  message: string,
+  skipConfirmation: boolean,
+  fn: () => void,
+): Promise<boolean> => {
+  if (skipConfirmation) {
+    fn();
+    return true;
+  }
+
+  return confirm({ message });
+};


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

- Support generating agent config for all supported chains
- Add user prompts: prompt user whether they want to zero the IGP addresses if not provided, prompt user whether they want to generate agent config anyway when schema validation fails
- Support skipping prompts, useful for CI

Example usage:

Specific chains

```
$yarn hyperlane registry agent-config --chains anvil8545
Hyperlane CLI

Creating agent config...
interchainGasPaymaster address is missing for anvil8545
? Would you like to set the interchainGasPaymaster address to 0x0 for anvil8545? yes

Agent config is invalid, this is possibly due to required contracts not being deployed. See details below:
Validation error: Required at "chains.anvil8545.merkleTreeHook"
? Would you like to continue anyway? yes

Writing agent config to file ./configs/agent-config.json
✅ Agent config successfully written to ./configs/agent-config.json
```

All chains
```
$yarn hyperlane registry agent-config
Hyperlane CLI

Creating agent config...
?
No chains provided, would you like to generate the agent config for all supported chains? yes
interchainGasPaymaster address is missing for sketchpad
? Would you like to set the interchainGasPaymaster address to 0x0 for sketchpad? yes
interchainGasPaymaster address is missing for anvil8545
? Would you like to set the interchainGasPaymaster address to 0x0 for anvil8545? yes

Agent config is invalid, this is possibly due to required contracts not being deployed. See details below:
Validation error: Required at "chains.anvil8545.merkleTreeHook"; Invalid at "chains.sketchpad.interchainSecurityModule"
? Would you like to continue anyway? yes

Writing agent config to file ./configs/agent-config.json
✅ Agent config successfully written to ./configs/agent-config.json
```

Skip prompts:

```
$yarn hyperlane registry agent-config --skipPrompts
Hyperlane CLI

Creating agent config...

No chains provided, generating agent config for all supported chains

Agent config is invalid, this is possibly due to required contracts not being deployed. See details below:
Validation error: Required at "chains.anvil8545.merkleTreeHook"; Required at "chains.anvil8545.interchainGasPaymaster"; Invalid at "chains.sketchpad.interchainGasPaymaster"; Invalid at "chains.sketchpad.interchainSecurityModule"
Creating agent config anyway...

Writing agent config to file ./configs/agent-config.json
✅ Agent config successfully written to ./configs/agent-config.json
```

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
Manual