### PR TITLE
feat: reduce extraneous entries in generated registry/agent artifacts

### DIFF
--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -44,6 +44,7 @@ import { Role } from '../src/roles.js';
 import {
   assertContext,
   assertRole,
+  filterRemoteDomainMetadata,
   getInfraPath,
   inCIMode,
   readJSONAtPath,
@@ -418,17 +419,7 @@ export function writeAddresses(
   module: Modules,
   addressesMap: ChainMap<Record<string, Address>>,
 ) {
-  addressesMap = Object.fromEntries(
-    Object.entries(addressesMap).map(([chain, addresses]) => [
-      chain,
-      // Filter out any non-string writes
-      // e.g. remote domain metadata that might be present
-      objFilter(
-        addresses,
-        (_, value): value is string => typeof value === 'string',
-      ),
-    ]),
-  );
+  addressesMap = filterRemoteDomainMetadata(addressesMap);
 
   if (isRegistryModule(environment, module)) {
     for (const [chainName, addresses] of Object.entries(addressesMap)) {

--- a/typescript/infra/src/deployment/deploy.ts
+++ b/typescript/infra/src/deployment/deploy.ts
@@ -25,6 +25,7 @@ import {
   getAgentConfigJsonPath,
   writeAddresses,
 } from '../../scripts/agent-utils.js';
+import { getEnvironmentConfig } from '../../scripts/core-utils.js';
 import { DeployEnvironment, envNameToAgentEnv } from '../config/environment.js';
 import { getCosmosChainGasPrice } from '../config/gas-oracle.js';
 import {
@@ -121,16 +122,33 @@ export async function writeAgentConfig(
   multiProvider: MultiProvider,
   environment: DeployEnvironment,
 ) {
-  const addresses = getAddresses(environment, Modules.CORE);
-  const addressesForEnv = objFilter(
-    addresses,
-    (chain, _): _ is ChainAddresses => multiProvider.hasChain(chain),
+  // Get the addresses for the environment
+  const addressesMap = getAddresses(
+    environment,
+    Modules.CORE,
+  ) as ChainMap<ChainAddresses>;
+
+  // Filter out chains that are not supported by the multiProvider
+  // Explicitly extract only the necessary contracts
+  const addressesForEnv = Object.fromEntries(
+    Object.entries(addressesMap)
+      .filter(([chain, _]) => multiProvider.hasChain(chain))
+      .map(([chain, addresses]) => [
+        chain,
+        // Filter out any non-string writes
+        // e.g. remote domain metadata that might be present
+        objFilter(
+          addresses,
+          (_, value): value is string => typeof value === 'string',
+        ),
+      ]),
   );
 
   const core = HyperlaneCore.fromAddressesMap(addressesForEnv, multiProvider);
+
   // Write agent config indexing from the deployed Mailbox which stores the block number at deployment
   const startBlocks = await promiseObjAll(
-    objMap(addressesForEnv, async (chain, _) => {
+    objMap(addressesForEnv, async (chain: string, _) => {
       // If the index.from is specified in the chain metadata, use that.
       const indexFrom = multiProvider.getChainMetadata(chain).index?.from;
       if (indexFrom !== undefined) {
@@ -173,11 +191,17 @@ export async function writeAgentConfig(
 
   const agentConfig = buildAgentConfig(
     environmentChains,
-    multiProvider,
+    await getEnvironmentConfig(environment).getMultiProvider(
+      undefined,
+      undefined,
+      // Don't use secrets
+      false,
+    ),
     addressesForEnv as ChainMap<HyperlaneDeploymentArtifacts>,
     startBlocks,
     additionalConfig,
   );
+
   writeMergedJSONAtPath(
     getAgentConfigJsonPath(envNameToAgentEnv[environment]),
     agentConfig,

--- a/typescript/infra/src/deployment/deploy.ts
+++ b/typescript/infra/src/deployment/deploy.ts
@@ -11,7 +11,6 @@ import {
 } from '@hyperlane-xyz/sdk';
 import {
   ProtocolType,
-  objFilter,
   objMap,
   objMerge,
   promiseObjAll,
@@ -30,6 +29,7 @@ import { DeployEnvironment, envNameToAgentEnv } from '../config/environment.js';
 import { getCosmosChainGasPrice } from '../config/gas-oracle.js';
 import {
   chainIsProtocol,
+  filterRemoteDomainMetadata,
   readJSONAtPath,
   writeJsonAtPath,
   writeMergedJSONAtPath,
@@ -128,22 +128,7 @@ export async function writeAgentConfig(
     Modules.CORE,
   ) as ChainMap<ChainAddresses>;
 
-  // Filter out chains that are not supported by the multiProvider
-  // Explicitly extract only the necessary contracts
-  const addressesForEnv = Object.fromEntries(
-    Object.entries(addressesMap)
-      .filter(([chain, _]) => multiProvider.hasChain(chain))
-      .map(([chain, addresses]) => [
-        chain,
-        // Filter out any non-string writes
-        // e.g. remote domain metadata that might be present
-        objFilter(
-          addresses,
-          (_, value): value is string => typeof value === 'string',
-        ),
-      ]),
-  );
-
+  const addressesForEnv = filterRemoteDomainMetadata(addressesMap);
   const core = HyperlaneCore.fromAddressesMap(addressesForEnv, multiProvider);
 
   // Write agent config indexing from the deployed Mailbox which stores the block number at deployment

--- a/typescript/infra/src/utils/utils.ts
+++ b/typescript/infra/src/utils/utils.ts
@@ -8,8 +8,13 @@ import path, { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { parse as yamlParse } from 'yaml';
 
-import { ChainName, NativeToken } from '@hyperlane-xyz/sdk';
-import { ProtocolType, objMerge } from '@hyperlane-xyz/utils';
+import { ChainMap, ChainName, NativeToken } from '@hyperlane-xyz/sdk';
+import {
+  Address,
+  ProtocolType,
+  objFilter,
+  objMerge,
+} from '@hyperlane-xyz/utils';
 
 import { Contexts } from '../../config/contexts.js';
 import { testChainNames } from '../../config/environments/test/chains.js';
@@ -272,4 +277,22 @@ export function getInfraPath() {
 
 export function inCIMode() {
   return process.env.CI === 'true';
+}
+
+// Filter out chains that are not supported by the multiProvider
+// Filter out any value that is not a string e.g. remote domain metadata
+export function filterRemoteDomainMetadata(
+  addressesMap: ChainMap<Record<string, Address>>,
+): ChainMap<Record<string, Address>> {
+  return Object.fromEntries(
+    Object.entries(addressesMap).map(([chain, addresses]) => [
+      chain,
+      // Filter out any non-string writes
+      // e.g. remote domain metadata that might be present
+      objFilter(
+        addresses,
+        (_, value): value is string => typeof value === 'string',
+      ),
+    ]),
+  );
 }


### PR DESCRIPTION
- filters out remote domain metadata from configs written to disk
```
    "ancient8": {
      // this gets removed
      "arbitrum": {
        "aggregationHook": "0xblahblahblah",
        "interchainSecurityModule": "0xblahblah"
        ...etc
      },
      // keep the usual entries like this
      "aggregationHook": "0x1EF4ED658d542524d1D547ba2F94d3B038a55b8f",
      "batchContractAddress": "0x4C97D35c668EE5194a13c8DE8Afc18cce40C9F28",
      "blockExplorers": [
...etc
```
- no longer include secret overrides in the configs written to disk
	- i.e. use public registry RPCs and chain metadata (want our output to be like that of update-agent-config, but with updated contract addresses only)
