### PR TITLE
feat: reintroduce `ism read` and `hook read` commands

### DIFF
--- a/.changeset/new-taxis-fry.md
+++ b/.changeset/new-taxis-fry.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Reintroduce `ism read` and `hook read` commands

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -329,7 +329,7 @@ jobs:
 
   cli-e2e:
     runs-on: larger-runner
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main') || github.event_name == 'merge_group'
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main' || github.base_ref == 'cli-2.0') || github.event_name == 'merge_group'
     needs: [yarn-build, checkout-registry]
     strategy:
       matrix:

--- a/rust/config/mainnet_config.json
+++ b/rust/config/mainnet_config.json
@@ -19,7 +19,7 @@
       "chainId": 888888888,
       "displayName": "Ancient8",
       "domainId": 888888888,
-      "domainRoutingIsm": "0xB6F0f1267B01C27326F61a4B4fe2c73751802685",
+      "domainRoutingIsm": "0x477145b11E1a71fEb658d96A0E27F19495121504",
       "domainRoutingIsmFactory": "0x1052eF3419f26Bec74Ed7CEf4a4FA6812Bc09908",
       "fallbackRoutingHook": "0x5E01d8F34b629E3f92d69546bbc4142A7Adee7e9",
       "gasCurrencyCoinGeckoId": "ethereum",
@@ -27,7 +27,7 @@
         "from": 2507127
       },
       "interchainGasPaymaster": "0x8F1E22d309baa69D398a03cc88E9b46037e988AA",
-      "interchainSecurityModule": "0xBd3C7253F08c040eDB9c54e7CD4f8a5fd1eb935D",
+      "interchainSecurityModule": "0xa10686c87d47C8b78c846E77BE2f96607C7c44F4",
       "isTestnet": false,
       "mailbox": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
       "merkleTreeHook": "0x811808Dd29ba8B0FC6C0ec0b5537035E59745162",
@@ -38,7 +38,7 @@
         "symbol": "ETH"
       },
       "pausableHook": "0x66DC49405Ae2956f7E87FEAa9fE8f506C8987462",
-      "pausableIsm": "0xcf678903c003651DB0bb933820259A16ea9d95e4",
+      "pausableIsm": "0xF8DbA46fF9D8ef650052c89CA2Df793FaBc375F9",
       "protocol": "ethereum",
       "protocolFee": "0xE0C452DDA7506f0F4dE5C8C1d383F7aD866eA4F0",
       "proxyAdmin": "0x0761b0827849abbf7b0cC09CE14e1C93D87f5004",
@@ -48,7 +48,7 @@
         }
       ],
       "staticAggregationHookFactory": "0xEb9FcFDC9EfDC17c1EC5E1dc085B98485da213D6",
-      "staticAggregationIsm": "0xBd3C7253F08c040eDB9c54e7CD4f8a5fd1eb935D",
+      "staticAggregationIsm": "0xc6ec1364d1ce3E963Fa65A0bDF57eC722478e1FB",
       "staticAggregationIsmFactory": "0x8F7454AC98228f3504Bb91eA3D8Adafe6406110A",
       "staticMerkleRootMultisigIsmFactory": "0x2C1FAbEcd7bFBdEBF27CcdB67baADB38b6Df90fC",
       "staticMessageIdMultisigIsmFactory": "0x8b83fefd896fAa52057798f6426E9f0B080FCCcE",
@@ -86,7 +86,7 @@
       "interchainAccountIsm": "0xfa8bfcE55B3A0631dF38257615cEF7FCD3523A48",
       "interchainAccountRouter": "0xCD0CFFf6eFD943b4b81f2c15847730dbcD30e3aE",
       "interchainGasPaymaster": "0x3b6044acd6767f017e99318AA6Ef93b7B06A5a22",
-      "interchainSecurityModule": "0x96845a0469363f90779f6D5cd49D79bDDAc69429",
+      "interchainSecurityModule": "0xd12C017529BE32c23150313F1E473B76e6B19773",
       "mailbox": "0x979Ca5202784112f4738403dBec5D0F3B9daabB9",
       "merkleTreeHook": "0x748040afB89B8FdBb992799808215419d36A0930",
       "name": "arbitrum",
@@ -152,7 +152,7 @@
       "interchainAccountIsm": "0x786c26C1857032617c215f265509d6E44e44Bfe3",
       "interchainAccountRouter": "0xA967A6CE0e73fAf672843DECaA372511996E8852",
       "interchainGasPaymaster": "0x95519ba800BBd0d34eeAE026fEc620AD978176C0",
-      "interchainSecurityModule": "0xe7a61510EA7197281b49e5bdf1798608d5132595",
+      "interchainSecurityModule": "0xB7D96FcD923267640BcffC7c3F23530E6C7A4209",
       "mailbox": "0xFf06aFcaABaDDd1fb08371f9ccA15D73D51FeBD6",
       "merkleTreeHook": "0x84eea61D679F42D92145fA052C89900CBAccE95A",
       "name": "avalanche",
@@ -218,7 +218,7 @@
       "interchainAccountIsm": "0x861908E6c8F992537F557da5Fb5876836036b347",
       "interchainAccountRouter": "0xa85F9e4fdA2FFF1c07f2726a630443af3faDF830",
       "interchainGasPaymaster": "0xc3F23848Ed2e04C0c6d41bd7804fa8f89F940B94",
-      "interchainSecurityModule": "0x77bE0b5aE400675063Ce2B2B0d692D9341f4b193",
+      "interchainSecurityModule": "0xe7aaFbA826B0bDC60aD09b7b8cA8175c9A89cE0b",
       "mailbox": "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D",
       "merkleTreeHook": "0x19dc38aeae620380430C200a6E990D5Af5480117",
       "name": "base",
@@ -275,11 +275,12 @@
       "domainRoutingIsmFactory": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
       "fallbackRoutingHook": "0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa",
       "gasCurrencyCoinGeckoId": "ethereum",
+      "gnosisSafeTransactionServiceUrl": "https://transaction.blast-safe.io",
       "index": {
         "from": 2496427
       },
       "interchainGasPaymaster": "0xB3fCcD379ad66CED0c91028520C64226611A48c9",
-      "interchainSecurityModule": "0x208263bB303B2a737642fB13C765F106a2591be8",
+      "interchainSecurityModule": "0xdE516712D58166257E03254BD596CA726417a837",
       "mailbox": "0x3a867fCfFeC2B790970eeBDC9023E75B0a172aa7",
       "merkleTreeHook": "0xC9B8ea6230d6687a4b13fD3C0b8f0Ec607B26465",
       "name": "blast",
@@ -338,7 +339,7 @@
       "interchainAccountIsm": "0xB274Bbbc1df5f1d1763216A93d473fde6f5de043",
       "interchainAccountRouter": "0x4BBd67dC995572b40Dc6B3eB6CdE5185a5373868",
       "interchainGasPaymaster": "0x78E25e7f84416e69b9339B0A6336EB6EFfF6b451",
-      "interchainSecurityModule": "0xfA360ff588623A026BF19A1801F2A8F1f045fa33",
+      "interchainSecurityModule": "0x4C23e778aF68a54cb59A44581b90E78b35763C83",
       "mailbox": "0x2971b9Aec44bE4eb673DF1B88cDB57b96eefe8a4",
       "merkleTreeHook": "0xFDb9Cd5f9daAA2E4474019405A328a88E7484f26",
       "name": "bsc",
@@ -411,7 +412,7 @@
       "interchainAccountIsm": "0x30a8DEc5318e2aAa9ad5b069fC606c4CfF6f5676",
       "interchainAccountRouter": "0x4ED23E3885e1651E62564F78817D91865beba575",
       "interchainGasPaymaster": "0x571f1435613381208477ac5d6974310d88AC7cB7",
-      "interchainSecurityModule": "0x0dcb01D4ABfa73fadB17C4B0e8cd52A38BD52c66",
+      "interchainSecurityModule": "0x1b90cCF49e45a87F751b344864e4246D1a57a100",
       "mailbox": "0x50da3B3907A08a24fe4999F4Dcf337E8dC7954bb",
       "merkleTreeHook": "0x04dB778f05854f26E67e0a66b740BBbE9070D366",
       "name": "celo",
@@ -476,7 +477,7 @@
       "interchainAccountIsm": "0x609707355a53d2aAb6366f48E2b607C599D26B29",
       "interchainAccountRouter": "0x8dBae9B1616c46A20591fE0006Bf015E28ca5cC9",
       "interchainGasPaymaster": "0x9e6B1022bE9BBF5aFd152483DAD9b88911bC8611",
-      "interchainSecurityModule": "0x8CE0c6cAf18DbF5882b35F26E28412f3E9AbDeca",
+      "interchainSecurityModule": "0x355F2c5532521ca6Df8A908641Ed69eD0619466d",
       "mailbox": "0xc005dc82818d67AF737725bD4bf75435d065D239",
       "merkleTreeHook": "0x48e6c30B97748d1e2e03bf3e9FbE3890ca5f8CCA",
       "name": "ethereum",
@@ -542,7 +543,7 @@
       "interchainAccountIsm": "0x5a56dff3D92D635372718f86e6dF09C1129CFf53",
       "interchainAccountRouter": "0x5E59EBAedeB691408EBAcF6C37218fa2cFcaC9f2",
       "interchainGasPaymaster": "0xDd260B99d302f0A3fF885728c086f729c06f227f",
-      "interchainSecurityModule": "0x5DB7edF8C1CF91e34895dB2e4b28d8b9C68ddC7B",
+      "interchainSecurityModule": "0x613D9ab2dd6cCFa2763d86FdEE3d96C4Ef4C2E96",
       "mailbox": "0xaD09d78f4c6b9dA2Ae82b1D34107802d380Bb74f",
       "merkleTreeHook": "0x2684C6F89E901987E1FdB7649dC5Be0c57C61645",
       "name": "gnosis",
@@ -592,11 +593,13 @@
         "reorgPeriod": 0
       },
       "chainId": 2525,
+      "customHook": "0xA376b27212D608324808923Add679A2c9FAFe9Da",
       "displayName": "Injective EVM",
       "displayNameShort": "inEVM",
       "domainId": 2525,
       "domainRoutingIsm": "0xBD70Ea9D599a0FC8158B026797177773C3445730",
       "domainRoutingIsmFactory": "0x1052eF3419f26Bec74Ed7CEf4a4FA6812Bc09908",
+      "fallbackRoutingHook": "0xA376b27212D608324808923Add679A2c9FAFe9Da",
       "gasCurrencyCoinGeckoId": "injective-protocol",
       "index": {
         "from": 18972465
@@ -604,7 +607,7 @@
       "interchainAccountIsm": "0x31894E7a734540B343d67E491148EB4FC9f7A45B",
       "interchainAccountRouter": "0x4E55aDA3ef1942049EA43E904EB01F4A0a9c39bd",
       "interchainGasPaymaster": "0x19dc38aeae620380430C200a6E990D5Af5480117",
-      "interchainSecurityModule": "0x440f7AD246F3e75df88a6338E8A33e91DA4B2B05",
+      "interchainSecurityModule": "0xC1a7a7b15d2B243f7c6Dbbdd6e8A2C2434cdf7BF",
       "mailbox": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
       "merkleTreeHook": "0x0972954923a1e2b2aAb04Fa0c4a0797e5989Cd65",
       "name": "inevm",
@@ -629,6 +632,7 @@
       "staticMerkleRootMultisigIsmFactory": "0x2C1FAbEcd7bFBdEBF27CcdB67baADB38b6Df90fC",
       "staticMessageIdMultisigIsmFactory": "0x8b83fefd896fAa52057798f6426E9f0B080FCCcE",
       "storageGasOracle": "0x6119E37Bd66406A1Db74920aC79C15fB8411Ba76",
+      "testRecipient": "0x28291a7062afA569104bEd52F7AcCA3dD2FafD11",
       "timelockController": "0x0000000000000000000000000000000000000000",
       "validatorAnnounce": "0x15ab173bDB6832f9b64276bA128659b0eD77730B"
     },
@@ -713,7 +717,7 @@
       "interchainAccountIsm": "0xA34ceDf9068C5deE726C67A4e1DCfCc2D6E2A7fD",
       "interchainAccountRouter": "0x0f6fF770Eda6Ba1433C39cCf47d4059b254224Aa",
       "interchainGasPaymaster": "0x0D63128D887159d63De29497dfa45AFc7C699AE4",
-      "interchainSecurityModule": "0xEda7cCD2A8CF717dc997D0002e363e4D10bF5c0d",
+      "interchainSecurityModule": "0x83319BD846D54E49C850027191D094D5E9114339",
       "isTestnet": false,
       "mailbox": "0x3a464f746D23Ab22155710f44dB16dcA53e0775E",
       "merkleTreeHook": "0x149db7afD694722747035d5AEC7007ccb6F8f112",
@@ -724,6 +728,7 @@
         "symbol": "ETH"
       },
       "pausableHook": "0x7556a0E61d577D921Cba8Fca0d7D6299d36E607E",
+      "pausableIsm": "0x6119B76720CcfeB3D256EC1b91218EEfFD6756E1",
       "protocol": "ethereum",
       "protocolFee": "0xd83A4F747fE80Ed98839e05079B1B7Fe037b1638",
       "proxyAdmin": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
@@ -733,6 +738,7 @@
         }
       ],
       "staticAggregationHookFactory": "0x0761b0827849abbf7b0cC09CE14e1C93D87f5004",
+      "staticAggregationIsm": "0x845A3feB4BcdC32a457c4051F67d3950FC6Fd1d1",
       "staticAggregationIsmFactory": "0x1052eF3419f26Bec74Ed7CEf4a4FA6812Bc09908",
       "staticMerkleRootMultisigIsmFactory": "0x8F7454AC98228f3504Bb91eA3D8Adafe6406110A",
       "staticMessageIdMultisigIsmFactory": "0xEb9FcFDC9EfDC17c1EC5E1dc085B98485da213D6",
@@ -743,6 +749,7 @@
       "validatorAnnounce": "0x2fa5F5C96419C222cDbCeC797D696e6cE428A7A9"
     },
     "mode": {
+      "aggregationHook": "0x80D80cfBa98dD2d456ECd43Dcc1f852D5C4EeD7a",
       "blockExplorers": [
         {
           "apiUrl": "https://explorer.mode.network/api",
@@ -759,14 +766,16 @@
       "chainId": 34443,
       "displayName": "Mode",
       "domainId": 34443,
+      "domainRoutingIsm": "0xB6F0f1267B01C27326F61a4B4fe2c73751802685",
       "domainRoutingIsmFactory": "0x1052eF3419f26Bec74Ed7CEf4a4FA6812Bc09908",
       "fallbackRoutingHook": "0x8F1E22d309baa69D398a03cc88E9b46037e988AA",
       "gasCurrencyCoinGeckoId": "ethereum",
+      "gnosisSafeTransactionServiceUrl": "https://transaction-mode.safe.optimism.io",
       "index": {
         "from": 6817759
       },
       "interchainGasPaymaster": "0x931dFCc8c1141D6F532FD023bd87DAe0080c835d",
-      "interchainSecurityModule": "0x8dfE6790DbB2Ecc1bEdb0eECfc1Ff467Ae5d8C89",
+      "interchainSecurityModule": "0xEe9443bc2Df7C10327077c605120CDd95e8Ca75F",
       "mailbox": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
       "merkleTreeHook": "0xE2ee936bEa8e42671c400aC96dE198E06F2bA2A6",
       "name": "mode",
@@ -776,6 +785,7 @@
         "symbol": "ETH"
       },
       "pausableHook": "0xA1ac41d8A663fd317cc3BD94C7de92dC4BA4a882",
+      "pausableIsm": "0xe243Fb51d91c5DE62afAbE44F7Ed2D4DC51668C6",
       "protocol": "ethereum",
       "protocolFee": "0xea820f9BCFD5E16a0dd42071EB61A29874Ad81A4",
       "proxyAdmin": "0x0761b0827849abbf7b0cC09CE14e1C93D87f5004",
@@ -785,6 +795,7 @@
         }
       ],
       "staticAggregationHookFactory": "0xEb9FcFDC9EfDC17c1EC5E1dc085B98485da213D6",
+      "staticAggregationIsm": "0x6BdA2074b7edCE8c4e4cD3D35517267468Aed93F",
       "staticAggregationIsmFactory": "0x8F7454AC98228f3504Bb91eA3D8Adafe6406110A",
       "staticMerkleRootMultisigIsmFactory": "0x2C1FAbEcd7bFBdEBF27CcdB67baADB38b6Df90fC",
       "staticMessageIdMultisigIsmFactory": "0x8b83fefd896fAa52057798f6426E9f0B080FCCcE",
@@ -811,6 +822,7 @@
       "chainId": 1284,
       "displayName": "Moonbeam",
       "domainId": 1284,
+      "domainRoutingIsm": "0x7Faa23CEdA03364A79e05259e07D5E358E7400F7",
       "domainRoutingIsmFactory": "0x8061Af3A459093540d17823D651BC5E2A92669a7",
       "fallbackRoutingHook": "0x6C2D6eA0969F7Aa0A850CCA88c7BFACa563B2361",
       "gnosisSafeTransactionServiceUrl": "https://transaction.multisig.moonbeam.network",
@@ -820,7 +832,7 @@
       "interchainAccountIsm": "0x799eA6f430f5CA901b59335fFC2fA10531106009",
       "interchainAccountRouter": "0x6b142f596FFc761ac3fFaaC1ecaDe54f4EE09977",
       "interchainGasPaymaster": "0x14760E32C0746094cF14D97124865BC7F0F7368F",
-      "interchainSecurityModule": "0x373836DFa82f2D27ec79Ca32A197Aa1665F0E1e9",
+      "interchainSecurityModule": "0x3db9D7c5cD0Aa312AB1262C711C10DeBA8303388",
       "mailbox": "0x094d03E751f49908080EFf000Dd6FD177fd44CC3",
       "merkleTreeHook": "0x87403b85f6f316e7ba91ba1fa6C3Fb7dD4095547",
       "name": "moonbeam",
@@ -830,6 +842,7 @@
         "symbol": "GLMR"
       },
       "pausableHook": "0xe28f2AEEB42ee83CAd068D9A9a449c8b868C137f",
+      "pausableIsm": "0x58062b26193B28000Cd991Df767f3A2674502de8",
       "protocol": "ethereum",
       "protocolFee": "0xCd3e29A9D293DcC7341295996a118913F7c582c0",
       "proxyAdmin": "0x6A9cdA3dd1F593983BFd142Eb35e6ce4137bd5ce",
@@ -839,6 +852,7 @@
         }
       ],
       "staticAggregationHookFactory": "0x59cC3E7A49DdC4893eB8754c7908f96072A7DbE8",
+      "staticAggregationIsm": "0xDAAfa04d38d95f5B8418786AE0F7ee5B962ee92B",
       "staticAggregationIsmFactory": "0x40c6Abcb6A2CdC8882d4bEcaC47927005c7Bb8c2",
       "staticMerkleRootMultisigIsmFactory": "0xE2f485bc031Feb5a4C41C1967bf028653d75f0C3",
       "staticMessageIdMultisigIsmFactory": "0x84Df48F8f241f11d0fA302d09d73030429Bd9C73",
@@ -934,6 +948,7 @@
       "chainId": 10,
       "displayName": "Optimism",
       "domainId": 10,
+      "domainRoutingIsm": "0xDFfFCA9320E2c7530c61c4946B4c2376A1901dF2",
       "domainRoutingIsmFactory": "0xD2e905108c5e44dADA680274740f896Ea96Cf2Fb",
       "fallbackRoutingHook": "0xD4b132C6d4AA93A4247F1A91e1ED929c0572a43d",
       "gasCurrencyCoinGeckoId": "ethereum",
@@ -944,7 +959,7 @@
       "interchainAccountIsm": "0x0389faCac114023C123E22F3E54394944cAbcb48",
       "interchainAccountRouter": "0x33Ef006E7083BB38E0AFe3C3979F4e9b84415bf1",
       "interchainGasPaymaster": "0xD8A76C4D91fCbB7Cc8eA795DFDF870E48368995C",
-      "interchainSecurityModule": "0x04938856bE60c8e734ffDe5f720E2238302BE8D2",
+      "interchainSecurityModule": "0x32Ce76b9FfD0BbA0e43a2C27c2cAc90E82C48B95",
       "mailbox": "0xd4C1905BB1D26BC93DAC913e13CaCC278CdCC80D",
       "merkleTreeHook": "0x68eE9bec9B4dbB61f69D9D293Ae26a5AACb2e28f",
       "name": "optimism",
@@ -954,6 +969,7 @@
         "symbol": "ETH"
       },
       "pausableHook": "0xf753CA2269c8A7693ce1808b5709Fbf36a65D47A",
+      "pausableIsm": "0xD84D8114cCfa5c2403E56aBf754da529430704F0",
       "protocol": "ethereum",
       "protocolFee": "0xD71Ff941120e8f935b8b1E2C1eD72F5d140FF458",
       "proxyAdmin": "0xE047cb95FB3b7117989e911c6afb34771183fC35",
@@ -963,6 +979,7 @@
         }
       ],
       "staticAggregationHookFactory": "0x15DEeAB8dECDe553bb0B1F9C00984cbcae1af3D7",
+      "staticAggregationIsm": "0xdF6316DF574974110DCC94BB4E520B09Fe3CbEf9",
       "staticAggregationIsmFactory": "0x7491843F3A5Ba24E0f17a22645bDa04A1Ae2c584",
       "staticMerkleRootMultisigIsmFactory": "0xCA6Cb9Bc3cfF9E11003A06617cF934B684Bc78BC",
       "staticMessageIdMultisigIsmFactory": "0xAa4Be20E9957fE21602c74d7C3cF5CB1112EA9Ef",
@@ -1034,7 +1051,7 @@
       "interchainAccountIsm": "0x90384bC552e3C48af51Ef7D9473A9bF87431f5c7",
       "interchainAccountRouter": "0x5e80f3474825B61183c0F0f0726796F589082420",
       "interchainGasPaymaster": "0x0071740Bf129b05C4684abfbBeD248D80971cce2",
-      "interchainSecurityModule": "0xe289bD204Dbb4F3aaFA27Dbe5751C71e101CFD80",
+      "interchainSecurityModule": "0x1c39BD73C933c6B1b14685ABD28F996A6a0e306f",
       "mailbox": "0x5d934f4e2f797775e53561bB72aca21ba36B96BB",
       "merkleTreeHook": "0x73FbD25c3e817DC4B4Cd9d00eff6D83dcde2DfF6",
       "name": "polygon",
@@ -1093,6 +1110,7 @@
       "displayName": "Polygon zkEVM",
       "displayNameShort": "zkEVM",
       "domainId": 1101,
+      "domainRoutingIsm": "0x8b6862a784f634F4C8E1cbb04c9DA3dB637B7EaA",
       "domainRoutingIsmFactory": "0xe4057c5B0c43Dc18E36b08C39B419F190D29Ac2d",
       "fallbackRoutingHook": "0x01aE937A7B05d187bBCBE80F44F41879D3D335a4",
       "gasCurrencyCoinGeckoId": "ethereum",
@@ -1103,7 +1121,7 @@
       "interchainAccountIsm": "0xC49aF4965264FA7BB6424CE37aA06773ad177224",
       "interchainAccountRouter": "0xF15D70941dE2Bf95A23d6488eBCbedE0a444137f",
       "interchainGasPaymaster": "0x0D63128D887159d63De29497dfa45AFc7C699AE4",
-      "interchainSecurityModule": "0xf2BEE9D2c15Ba9D7e06799B5912dE1F05533c141",
+      "interchainSecurityModule": "0xb7556707f04BEF8888294C18c447bE1e4446bF7D",
       "mailbox": "0x3a464f746D23Ab22155710f44dB16dcA53e0775E",
       "merkleTreeHook": "0x149db7afD694722747035d5AEC7007ccb6F8f112",
       "name": "polygonzkevm",
@@ -1113,6 +1131,7 @@
         "symbol": "ETH"
       },
       "pausableHook": "0xc2FbB9411186AB3b1a6AFCCA702D1a80B48b197c",
+      "pausableIsm": "0x784b9D0f4eF9fb8444DfB5d24AB221C9D1A85395",
       "protocol": "ethereum",
       "protocolFee": "0xd83A4F747fE80Ed98839e05079B1B7Fe037b1638",
       "proxyAdmin": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
@@ -1125,14 +1144,17 @@
         }
       ],
       "staticAggregationHookFactory": "0x0761b0827849abbf7b0cC09CE14e1C93D87f5004",
+      "staticAggregationIsm": "0xAe7d2FA2aFc57Ce9F05930d403673A267b3efE50",
       "staticAggregationIsmFactory": "0x1052eF3419f26Bec74Ed7CEf4a4FA6812Bc09908",
       "staticMerkleRootMultisigIsmFactory": "0x8F7454AC98228f3504Bb91eA3D8Adafe6406110A",
       "staticMessageIdMultisigIsmFactory": "0xEb9FcFDC9EfDC17c1EC5E1dc085B98485da213D6",
       "storageGasOracle": "0x19dc38aeae620380430C200a6E990D5Af5480117",
+      "testRecipient": "0xD127D4549cb4A5B2781303a4fE99a10EAd13263A",
       "timelockController": "0x0000000000000000000000000000000000000000",
       "validatorAnnounce": "0x2fa5F5C96419C222cDbCeC797D696e6cE428A7A9"
     },
     "redstone": {
+      "aggregationHook": "0x7bC13D23eD161E152a05c71D037b4642EA61B8eF",
       "blockExplorers": [
         {
           "apiUrl": "https://explorer.redstone.xyz/api",
@@ -1149,6 +1171,7 @@
       "chainId": 690,
       "displayName": "Redstone",
       "domainId": 690,
+      "domainRoutingIsm": "0x5D1e7D7c5B9e6dDC8439F67F10c578f2A1084f6F",
       "domainRoutingIsmFactory": "0x0761b0827849abbf7b0cC09CE14e1C93D87f5004",
       "fallbackRoutingHook": "0xA1ac41d8A663fd317cc3BD94C7de92dC4BA4a882",
       "gasCurrencyCoinGeckoId": "ethereum",
@@ -1156,7 +1179,7 @@
         "from": 1797579
       },
       "interchainGasPaymaster": "0x2Fa570E83009eaEef3a1cbd496a9a30F05266634",
-      "interchainSecurityModule": "0xF4689C7fA4920C91a6EEEd59630C9C8da7a77D40",
+      "interchainSecurityModule": "0xD10AD7d927817558468Ce0F0ab1edEF8D230E2d8",
       "mailbox": "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D",
       "merkleTreeHook": "0x8F1E22d309baa69D398a03cc88E9b46037e988AA",
       "name": "redstone",
@@ -1166,6 +1189,7 @@
         "symbol": "ETH"
       },
       "pausableHook": "0xC9B8ea6230d6687a4b13fD3C0b8f0Ec607B26465",
+      "pausableIsm": "0xD53Fdbb7537aCa82bAf7cCA7204088f15b52796a",
       "protocol": "ethereum",
       "protocolFee": "0x26f32245fCF5Ad53159E875d5Cae62aEcf19c2d4",
       "proxyAdmin": "0x4Ed7d626f1E96cD1C0401607Bf70D95243E3dEd1",
@@ -1175,6 +1199,7 @@
         }
       ],
       "staticAggregationHookFactory": "0x1052eF3419f26Bec74Ed7CEf4a4FA6812Bc09908",
+      "staticAggregationIsm": "0x3Bb9244a2aBBb710c933e8D82Ff8F0C200F3c036",
       "staticAggregationIsmFactory": "0xEb9FcFDC9EfDC17c1EC5E1dc085B98485da213D6",
       "staticMerkleRootMultisigIsmFactory": "0x8b83fefd896fAa52057798f6426E9f0B080FCCcE",
       "staticMessageIdMultisigIsmFactory": "0x8F7454AC98228f3504Bb91eA3D8Adafe6406110A",
@@ -1200,10 +1225,11 @@
       "chainId": 534352,
       "displayName": "Scroll",
       "domainId": 534352,
+      "domainRoutingIsm": "0x4d02AfFc3F030c887e2f914B8B67E0B845e034fD",
       "domainRoutingIsmFactory": "0xe03dad16074BC5EEA9A9311257BF02Eb0B6AAA2b",
       "fallbackRoutingHook": "0xDa7cECb05C4aeB02c1aFDE277d4306a2da7Bd762",
       "gasCurrencyCoinGeckoId": "ethereum",
-      "gnosisSafeTransactionServiceUrl": "https://transaction.safe.scroll.xyz",
+      "gnosisSafeTransactionServiceUrl": "https://safe-transaction-scroll.safe.global",
       "index": {
         "chunk": 999,
         "from": 271840
@@ -1211,7 +1237,7 @@
       "interchainAccountIsm": "0xb89c6ED617f5F46175E41551350725A09110bbCE",
       "interchainAccountRouter": "0x9629c28990F11c31735765A6FD59E1E1bC197DbD",
       "interchainGasPaymaster": "0xBF12ef4B9f307463D3FB59c3604F294dDCe287E2",
-      "interchainSecurityModule": "0xaDc0cB48E8DB81855A930C0C1165ea3dCe4Ba5C7",
+      "interchainSecurityModule": "0x0E6aFC8a7b5223cAD7a7c346da1B2e6ECBaA93f0",
       "mailbox": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
       "merkleTreeHook": "0x6119E37Bd66406A1Db74920aC79C15fB8411Ba76",
       "name": "scroll",
@@ -1221,6 +1247,7 @@
         "symbol": "ETH"
       },
       "pausableHook": "0x4Eb82Ee35b0a1c1d776E3a3B547f9A9bA6FCC9f2",
+      "pausableIsm": "0x11Fa12DBaCe771E293e19743feA342e378C6341F",
       "protocol": "ethereum",
       "protocolFee": "0xc3F23848Ed2e04C0c6d41bd7804fa8f89F940B94",
       "proxyAdmin": "0x0761b0827849abbf7b0cC09CE14e1C93D87f5004",
@@ -1230,10 +1257,12 @@
         }
       ],
       "staticAggregationHookFactory": "0xEb9FcFDC9EfDC17c1EC5E1dc085B98485da213D6",
+      "staticAggregationIsm": "0xAC0F1820F1F3fEd26293B8714464ca431824f823",
       "staticAggregationIsmFactory": "0x8F7454AC98228f3504Bb91eA3D8Adafe6406110A",
       "staticMerkleRootMultisigIsmFactory": "0x2C1FAbEcd7bFBdEBF27CcdB67baADB38b6Df90fC",
       "staticMessageIdMultisigIsmFactory": "0x8b83fefd896fAa52057798f6426E9f0B080FCCcE",
       "storageGasOracle": "0x481171eb1aad17eDE6a56005B7F1aB00C581ef13",
+      "testRecipient": "0x674f4698d063cE4C0d604c88dD7D542De72f327f",
       "timelockController": "0x0000000000000000000000000000000000000000",
       "transactionOverrides": {
         "gasPrice": 2000000000
@@ -1269,7 +1298,7 @@
       "interchainAccountIsm": "0xD1E267d2d7876e97E217BfE61c34AB50FEF52807",
       "interchainAccountRouter": "0x1956848601549de5aa0c887892061fA5aB4f6fC4",
       "interchainGasPaymaster": "0x0D63128D887159d63De29497dfa45AFc7C699AE4",
-      "interchainSecurityModule": "0xf8F3AF5F6B8f319364c339c0b8cA5975481901eD",
+      "interchainSecurityModule": "0xA76F4620ac1e97d273B2C9Ca71805c8afD792098",
       "mailbox": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
       "merkleTreeHook": "0x149db7afD694722747035d5AEC7007ccb6F8f112",
       "name": "viction",
@@ -1303,6 +1332,7 @@
       "validatorAnnounce": "0x2fa5F5C96419C222cDbCeC797D696e6cE428A7A9"
     },
     "zetachain": {
+      "aggregationHook": "0x80D80cfBa98dD2d456ECd43Dcc1f852D5C4EeD7a",
       "blockExplorers": [
         {
           "apiUrl": "https://explorer.zetachain.com",
@@ -1319,6 +1349,7 @@
       "chainId": 7000,
       "displayName": "ZetaChain",
       "domainId": 7000,
+      "domainRoutingIsm": "0xaDc0cB48E8DB81855A930C0C1165ea3dCe4Ba5C7",
       "domainRoutingIsmFactory": "0x1052eF3419f26Bec74Ed7CEf4a4FA6812Bc09908",
       "fallbackRoutingHook": "0x8F1E22d309baa69D398a03cc88E9b46037e988AA",
       "gasCurrencyCoinGeckoId": "zetachain",
@@ -1326,7 +1357,7 @@
         "from": 3068132
       },
       "interchainGasPaymaster": "0x931dFCc8c1141D6F532FD023bd87DAe0080c835d",
-      "interchainSecurityModule": "0x8dfE6790DbB2Ecc1bEdb0eECfc1Ff467Ae5d8C89",
+      "interchainSecurityModule": "0x8fB4297373f1f11032856693Cf6eee5eC8d7FF4F",
       "mailbox": "0x2f2aFaE1139Ce54feFC03593FeE8AB2aDF4a85A7",
       "merkleTreeHook": "0xE2ee936bEa8e42671c400aC96dE198E06F2bA2A6",
       "name": "zetachain",
@@ -1336,6 +1367,7 @@
         "symbol": "ZETA"
       },
       "pausableHook": "0xA1ac41d8A663fd317cc3BD94C7de92dC4BA4a882",
+      "pausableIsm": "0x7b75b29caD47e10146e29BBf7BD9025e021a7023",
       "protocol": "ethereum",
       "protocolFee": "0xea820f9BCFD5E16a0dd42071EB61A29874Ad81A4",
       "proxyAdmin": "0x0761b0827849abbf7b0cC09CE14e1C93D87f5004",
@@ -1351,6 +1383,7 @@
         }
       ],
       "staticAggregationHookFactory": "0xEb9FcFDC9EfDC17c1EC5E1dc085B98485da213D6",
+      "staticAggregationIsm": "0x7CB2dbE36aF0C0893B1B3502358Bc3697343559c",
       "staticAggregationIsmFactory": "0x8F7454AC98228f3504Bb91eA3D8Adafe6406110A",
       "staticMerkleRootMultisigIsmFactory": "0x2C1FAbEcd7bFBdEBF27CcdB67baADB38b6Df90fC",
       "staticMessageIdMultisigIsmFactory": "0x8b83fefd896fAa52057798f6426E9f0B080FCCcE",

--- a/typescript/cli/src/avs/stakeRegistry.ts
+++ b/typescript/cli/src/avs/stakeRegistry.ts
@@ -119,7 +119,7 @@ async function readOperatorFromEncryptedJson(
     message: 'Enter the password for the operator key file: ',
   });
 
-  return await Wallet.fromEncryptedJson(encryptedJson, keyFilePassword);
+  return Wallet.fromEncryptedJson(encryptedJson, keyFilePassword);
 }
 
 async function getOperatorSignature(

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -120,7 +120,7 @@ export const read: CommandModuleWithContext<{
   config: string;
 }> = {
   command: 'read',
-  describe: 'Reads onchain ISM & Hook configurations for given addresses',
+  describe: 'Reads onchain Core configuration for a given mailbox address',
   builder: {
     chain: {
       ...chainCommandOption,

--- a/typescript/cli/src/commands/hook.ts
+++ b/typescript/cli/src/commands/hook.ts
@@ -1,0 +1,49 @@
+import { CommandModule } from 'yargs';
+
+import { CommandModuleWithContext } from '../context/types.js';
+import { readHookConfig } from '../hook/read.js';
+import { log, logGray } from '../logger.js';
+
+import {
+  addressCommandOption,
+  chainCommandOption,
+  outputFileCommandOption,
+} from './options.js';
+
+/**
+ * Parent command
+ */
+export const hookCommand: CommandModule = {
+  command: 'hook',
+  describe: 'Operations relating to Hooks',
+  builder: (yargs) => yargs.command(read).version(false).demandCommand(),
+  handler: () => log('Command required'),
+};
+
+// Examples for testing:
+// Fallback routing hook on polygon (may take 5s):
+//     hyperlane hook read --chain polygon --address 0xca4cCe24E7e06241846F5EA0cda9947F0507C40C
+// IGP hook on inevm (may take 5s):
+//     hyperlane hook read --chain inevm --address 0x19dc38aeae620380430C200a6E990D5Af5480117
+export const read: CommandModuleWithContext<{
+  chain: string;
+  address: string;
+  out: string;
+}> = {
+  command: 'read',
+  describe: 'Reads onchain Hook configuration for a given address',
+  builder: {
+    chain: {
+      ...chainCommandOption,
+      demandOption: true,
+    },
+    address: addressCommandOption('Address of the Hook to read.', true),
+    out: outputFileCommandOption(),
+  },
+  handler: async (args) => {
+    logGray('Hyperlane Hook Read');
+    logGray('------------------');
+    await readHookConfig(args);
+    process.exit(0);
+  },
+};

--- a/typescript/cli/src/commands/ism.ts
+++ b/typescript/cli/src/commands/ism.ts
@@ -1,0 +1,54 @@
+import { CommandModule } from 'yargs';
+
+import { CommandModuleWithContext } from '../context/types.js';
+import { readIsmConfig } from '../ism/read.js';
+import { log, logGray } from '../logger.js';
+
+import {
+  addressCommandOption,
+  chainCommandOption,
+  outputFileCommandOption,
+} from './options.js';
+
+/**
+ * Parent command
+ */
+export const ismCommand: CommandModule = {
+  command: 'ism',
+  describe: 'Operations relating to ISMs',
+  builder: (yargs) => yargs.command(read).version(false).demandCommand(),
+  handler: () => log('Command required'),
+};
+
+// Examples for testing:
+// Top-level aggregation ISM on celo (may take 10s)
+//     hyperlane ism read --chain celo --address 0x99e8E56Dce3402D6E09A82718937fc1cA2A9491E
+// Aggregation ISM for bsc domain on inevm (may take 5s)
+//     hyperlane ism read --chain inevm --address 0x79A7c7Fe443971CBc6baD623Fdf8019C379a7178
+// Test ISM on alfajores testnet
+//     hyperlane ism read --chain alfajores --address 0xdB52E4853b6A40D2972E6797E0BDBDb3eB761966
+export const read: CommandModuleWithContext<{
+  chain: string;
+  address: string;
+  out: string;
+}> = {
+  command: 'read',
+  describe: 'Reads onchain ISM configuration for a given address',
+  builder: {
+    chain: {
+      ...chainCommandOption,
+      demandOption: true,
+    },
+    address: addressCommandOption(
+      'Address of the Interchain Security Module to read.',
+      true,
+    ),
+    out: outputFileCommandOption(),
+  },
+  handler: async (argv) => {
+    logGray('Hyperlane ISM Read');
+    logGray('------------------');
+    await readIsmConfig(argv);
+    process.exit(0);
+  },
+};

--- a/typescript/cli/src/validator/address.ts
+++ b/typescript/cli/src/validator/address.ts
@@ -24,7 +24,7 @@ export async function getValidatorAddress({
   region?: string;
   bucket?: string;
   keyId?: string;
-}) {
+}): Promise<void> {
   if (!bucket && !keyId) {
     throw new Error('Must provide either an S3 bucket or a KMS Key ID.');
   }
@@ -38,7 +38,7 @@ export async function getValidatorAddress({
   assert(secretKey, 'No secret access key set.');
   assert(region, 'No AWS region set.');
 
-  let validatorAddress;
+  let validatorAddress: string;
   if (bucket) {
     validatorAddress = await getAddressFromBucket(
       bucket,
@@ -68,7 +68,7 @@ async function getAddressFromBucket(
   accessKeyId: string,
   secretAccessKey: string,
   region: string,
-) {
+): Promise<string> {
   const s3Client = new S3Client({
     region: region,
     credentials: {
@@ -101,7 +101,7 @@ async function getAddressFromKey(
   accessKeyId: string,
   secretAccessKey: string,
   region: string,
-) {
+): Promise<string> {
   const client = new KMSClient({
     region: region,
     credentials: {
@@ -138,28 +138,28 @@ function getEthereumAddress(publicKey: Buffer): string {
   return `0x${address.slice(-40)}`; // take last 20 bytes as ethereum address
 }
 
-async function getAccessKeyId(skipConfirmation: boolean) {
+async function getAccessKeyId(skipConfirmation: boolean): Promise<string> {
   if (skipConfirmation) throw new Error('No AWS access key ID set.');
   else
-    return await input({
+    return input({
       message:
         'Please enter AWS access key ID or use the AWS_ACCESS_KEY_ID environment variable.',
     });
 }
 
-async function getSecretAccessKey(skipConfirmation: boolean) {
+async function getSecretAccessKey(skipConfirmation: boolean): Promise<string> {
   if (skipConfirmation) throw new Error('No AWS secret access key set.');
   else
-    return await input({
+    return input({
       message:
         'Please enter AWS secret access key or use the AWS_SECRET_ACCESS_KEY environment variable.',
     });
 }
 
-async function getRegion(skipConfirmation: boolean) {
+async function getRegion(skipConfirmation: boolean): Promise<string> {
   if (skipConfirmation) throw new Error('No AWS region set.');
   else
-    return await input({
+    return input({
       message:
         'Please enter AWS region or use the AWS_REGION environment variable.',
     });

--- a/typescript/sdk/src/ism/metadata/multisig.ts
+++ b/typescript/sdk/src/ism/metadata/multisig.ts
@@ -220,7 +220,15 @@ export class MultisigMetadataBuilder implements MetadataBuilder {
     return toHexString(buf);
   }
 
-  static decodeSimplePrefix(metadata: string) {
+  static decodeSimplePrefix(metadata: string): {
+    signatureOffset: number;
+    type: IsmType;
+    checkpoint: {
+      root: string;
+      index: number;
+      merkle_tree_hook_address: string;
+    };
+  } {
     const buf = fromHexString(metadata);
     const merkleTree = toHexString(buf.subarray(0, 32));
     const root = toHexString(buf.subarray(32, 64));
@@ -251,7 +259,16 @@ export class MultisigMetadataBuilder implements MetadataBuilder {
     return toHexString(buf);
   }
 
-  static decodeProofPrefix(metadata: string) {
+  static decodeProofPrefix(metadata: string): {
+    signatureOffset: number;
+    type: IsmType;
+    checkpoint: {
+      root: string;
+      index: number;
+      merkle_tree_hook_address: string;
+    };
+    proof: MerkleProof;
+  } {
     const buf = fromHexString(metadata);
     const merkleTree = toHexString(buf.subarray(0, 32));
     const messageIndex = buf.readUint32BE(32);

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -97,7 +97,7 @@ export class HyperlaneSmartProvider
     this.supportedMethods = [...supportedMethods.values()];
   }
 
-  async getPriorityFee() {
+  async getPriorityFee(): Promise<BigNumber> {
     try {
       return BigNumber.from(await this.perform('maxPriorityFeePerGas', {}));
     } catch (error) {

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -305,7 +305,7 @@ export class EvmHypXERC20LockboxAdapter
     );
   }
 
-  async getMintLimit() {
+  async getMintLimit(): Promise<bigint> {
     const xERC20 = await this.hypXERC20Lockbox.xERC20();
 
     const limit = await IXERC20__factory.connect(
@@ -316,7 +316,7 @@ export class EvmHypXERC20LockboxAdapter
     return BigInt(limit.toString());
   }
 
-  async getBurnLimit() {
+  async getBurnLimit(): Promise<bigint> {
     const xERC20 = await this.hypXERC20Lockbox.xERC20();
 
     const limit = await IXERC20__factory.connect(
@@ -348,7 +348,7 @@ export class EvmHypXERC20Adapter
     );
   }
 
-  async getMintLimit() {
+  async getMintLimit(): Promise<bigint> {
     const xERC20 = await this.hypXERC20.wrappedToken();
 
     const limit = await IXERC20__factory.connect(
@@ -359,7 +359,7 @@ export class EvmHypXERC20Adapter
     return BigInt(limit.toString());
   }
 
-  async getBurnLimit() {
+  async getBurnLimit(): Promise<bigint> {
     const xERC20 = await this.hypXERC20.wrappedToken();
 
     const limit = await IXERC20__factory.connect(

--- a/typescript/sdk/src/token/config.ts
+++ b/typescript/sdk/src/token/config.ts
@@ -18,7 +18,7 @@ export const CollateralExtensions = [
   TokenType.collateralVault,
 ];
 
-export const gasOverhead = (tokenType: TokenType) => {
+export const gasOverhead = (tokenType: TokenType): number => {
   switch (tokenType) {
     case TokenType.fastSynthetic:
     case TokenType.synthetic:


### PR DESCRIPTION
the original functionality of these commands got lost across a couple of refactors

1. `ism read`/`hook read` was merged to become `core read`, which still had the purpose of "gimme config at this address"
2. then with a recent change, `core read` became "gimme the ism/hook configs relating to this mailbox address"

This PR adds the original functionality back of returning the ISM/Hook configs for *any* ISM/Hook address (on EVM)

drive-by:
- update mainnet config
- fix typescript linting errors/warnings