### PR TITLE
feat(cli): add `warp --symbol` flag

### DIFF
--- a/.changeset/mean-books-clean.md
+++ b/.changeset/mean-books-clean.md
@@ -1,0 +1,7 @@
+---
+"@hyperlane-xyz/cli": minor
+"@hyperlane-xyz/helloworld": minor
+"@hyperlane-xyz/infra": minor
+---
+
+feat(cli): add `warp --symbol` flag

--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@aws-sdk/client-kms": "^3.577.0",
     "@aws-sdk/client-s3": "^3.577.0",
-    "@hyperlane-xyz/registry": "1.3.0",
+    "@hyperlane-xyz/registry": "^2.1.0",
     "@hyperlane-xyz/sdk": "3.15.0",
     "@hyperlane-xyz/utils": "3.15.0",
     "@inquirer/prompts": "^3.0.0",

--- a/typescript/cli/src/commands/options.ts
+++ b/typescript/cli/src/commands/options.ts
@@ -91,8 +91,6 @@ export const warpCoreConfigCommandOption: Options = {
   type: 'string',
   description: 'File path to Warp Route config',
   alias: 'w',
-  // TODO make this optional and have the commands get it from the registry
-  demandOption: true,
 };
 
 export const agentConfigCommandOption = (
@@ -148,6 +146,11 @@ export const dryRunCommandOption: Options = {
 export const chainCommandOption: Options = {
   type: 'string',
   description: 'The specific chain to perform operations with.',
+};
+
+export const symbolCommandOption: Options = {
+  type: 'string',
+  description: 'Token symbol (e.g. ETH, USDC)',
 };
 
 export const addressCommandOption = (

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -180,7 +180,7 @@ const send: CommandModuleWithWriteContext<
     warp?: string;
     symbol?: string;
     router?: string;
-    wei: string;
+    amount: string;
     recipient?: string;
   }
 > = {
@@ -215,7 +215,7 @@ const send: CommandModuleWithWriteContext<
     relay,
     symbol,
     warp,
-    wei,
+    amount,
     recipient,
   }) => {
     let warpCoreConfig: WarpCoreConfig;
@@ -233,7 +233,7 @@ const send: CommandModuleWithWriteContext<
       warpCoreConfig,
       origin,
       destination,
-      wei,
+      amount,
       recipient,
       timeoutSec: timeout,
       skipWaitForDelivery: quick,

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -195,7 +195,7 @@ export async function createWarpRouteDeployConfig({
 
 // Note, this is different than the function above which reads a config
 // for a DEPLOYMENT. This gets a config for using a warp route (aka WarpCoreConfig)
-export function readWarpRouteConfig(filePath: string): WarpCoreConfig {
+export function readWarpCoreConfig(filePath: string): WarpCoreConfig {
   const config = readYamlOrJson(filePath);
   if (!config) throw new Error(`No warp route config found at ${filePath}`);
   return WarpCoreConfigSchema.parse(config);

--- a/typescript/cli/src/send/transfer.ts
+++ b/typescript/cli/src/send/transfer.ts
@@ -10,7 +10,6 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { timeout } from '@hyperlane-xyz/utils';
 
-import { readWarpRouteConfig } from '../config/warp.js';
 import { MINIMUM_TEST_SEND_GAS } from '../consts.js';
 import { WriteCommandContext } from '../context/types.js';
 import { runPreflightChecksForChains } from '../deploy/utils.js';
@@ -20,7 +19,7 @@ import { runTokenSelectionStep } from '../utils/tokens.js';
 
 export async function sendTestTransfer({
   context,
-  warpConfigPath,
+  warpCoreConfig,
   origin,
   destination,
   wei,
@@ -30,7 +29,7 @@ export async function sendTestTransfer({
   selfRelay,
 }: {
   context: WriteCommandContext;
-  warpConfigPath: string;
+  warpCoreConfig: WarpCoreConfig;
   origin?: ChainName;
   destination?: ChainName;
   wei: string;
@@ -40,8 +39,6 @@ export async function sendTestTransfer({
   selfRelay?: boolean;
 }) {
   const { chainMetadata } = context;
-
-  const warpCoreConfig = readWarpRouteConfig(warpConfigPath);
 
   if (!origin) {
     origin = await runSingleChainSelectionStep(

--- a/typescript/cli/src/send/transfer.ts
+++ b/typescript/cli/src/send/transfer.ts
@@ -22,7 +22,7 @@ export async function sendTestTransfer({
   warpCoreConfig,
   origin,
   destination,
-  wei,
+  amount,
   recipient,
   timeoutSec,
   skipWaitForDelivery,
@@ -32,7 +32,7 @@ export async function sendTestTransfer({
   warpCoreConfig: WarpCoreConfig;
   origin?: ChainName;
   destination?: ChainName;
-  wei: string;
+  amount: string;
   recipient?: string;
   timeoutSec: number;
   skipWaitForDelivery: boolean;
@@ -67,7 +67,7 @@ export async function sendTestTransfer({
       origin,
       destination,
       warpCoreConfig,
-      wei,
+      amount,
       recipient,
       skipWaitForDelivery,
       selfRelay,
@@ -82,7 +82,7 @@ async function executeDelivery({
   origin,
   destination,
   warpCoreConfig,
-  wei,
+  amount,
   recipient,
   skipWaitForDelivery,
   selfRelay,
@@ -91,7 +91,7 @@ async function executeDelivery({
   origin: ChainName;
   destination: ChainName;
   warpCoreConfig: WarpCoreConfig;
-  wei: string;
+  amount: string;
   recipient?: string;
   skipWaitForDelivery: boolean;
   selfRelay?: boolean;
@@ -128,7 +128,7 @@ async function executeDelivery({
 
   const senderAddress = await signer.getAddress();
   const errors = await warpCore.validateTransfer({
-    originTokenAmount: token.amount(wei),
+    originTokenAmount: token.amount(amount),
     destination,
     recipient: recipient ?? senderAddress,
     sender: senderAddress,
@@ -139,7 +139,7 @@ async function executeDelivery({
   }
 
   const transferTxs = await warpCore.getTransferRemoteTxs({
-    originTokenAmount: new TokenAmount(wei, token),
+    originTokenAmount: new TokenAmount(amount, token),
     destination,
     sender: senderAddress,
     recipient: recipient ?? senderAddress,

--- a/typescript/helloworld/package.json
+++ b/typescript/helloworld/package.json
@@ -4,7 +4,7 @@
   "version": "3.15.0",
   "dependencies": {
     "@hyperlane-xyz/core": "3.15.0",
-    "@hyperlane-xyz/registry": "1.3.0",
+    "@hyperlane-xyz/registry": "^2.1.0",
     "@hyperlane-xyz/sdk": "3.15.0",
     "@openzeppelin/contracts-upgradeable": "^4.9.3",
     "ethers": "^5.7.2"

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -14,7 +14,7 @@
     "@ethersproject/providers": "^5.7.2",
     "@google-cloud/secret-manager": "^5.5.0",
     "@hyperlane-xyz/helloworld": "3.15.0",
-    "@hyperlane-xyz/registry": "1.3.0",
+    "@hyperlane-xyz/registry": "^2.1.0",
     "@hyperlane-xyz/sdk": "3.15.0",
     "@hyperlane-xyz/utils": "3.15.0",
     "@nomiclabs/hardhat-etherscan": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5683,7 +5683,7 @@ __metadata:
     "@aws-sdk/client-s3": "npm:^3.577.0"
     "@ethersproject/abi": "npm:*"
     "@ethersproject/providers": "npm:*"
-    "@hyperlane-xyz/registry": "npm:1.3.0"
+    "@hyperlane-xyz/registry": "npm:^2.1.0"
     "@hyperlane-xyz/sdk": "npm:3.15.0"
     "@hyperlane-xyz/utils": "npm:3.15.0"
     "@inquirer/prompts": "npm:^3.0.0"
@@ -5775,7 +5775,7 @@ __metadata:
   resolution: "@hyperlane-xyz/helloworld@workspace:typescript/helloworld"
   dependencies:
     "@hyperlane-xyz/core": "npm:3.15.0"
-    "@hyperlane-xyz/registry": "npm:1.3.0"
+    "@hyperlane-xyz/registry": "npm:^2.1.0"
     "@hyperlane-xyz/sdk": "npm:3.15.0"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
     "@nomiclabs/hardhat-waffle": "npm:^2.0.6"
@@ -5824,7 +5824,7 @@ __metadata:
     "@ethersproject/providers": "npm:^5.7.2"
     "@google-cloud/secret-manager": "npm:^5.5.0"
     "@hyperlane-xyz/helloworld": "npm:3.15.0"
-    "@hyperlane-xyz/registry": "npm:1.3.0"
+    "@hyperlane-xyz/registry": "npm:^2.1.0"
     "@hyperlane-xyz/sdk": "npm:3.15.0"
     "@hyperlane-xyz/utils": "npm:3.15.0"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
@@ -5876,13 +5876,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/registry@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@hyperlane-xyz/registry@npm:1.3.0"
+"@hyperlane-xyz/registry@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@hyperlane-xyz/registry@npm:2.1.0"
   dependencies:
     yaml: "npm:^2"
     zod: "npm:^3.21.2"
-  checksum: 2cbdfd9e8958d0babde7104dfb0c98def7edb5f87f5f4679b09467a6a9b531884f187fcbc16fd85b00e304ef8fa3beb0a0779555b2c3edc1936541a0e878a73d
+  checksum: cfcd441dcbb4886a4ecd90dffaeb7a0fd81c0a126423b23cf100cd554470fe88ceb35b41271d779f0390c42293fd2c799742eeff6dd42ca42f3c799a8e88b96b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

- This allows users to interact read warp routes from the registry with symbol identifier rather than chain/address

### Drive-by

Rename `wei` to `amount`

### Backward compatibility

No, outputs chain map

### Testing

- Manual

(single)
```sh
$ yarn hyperlane warp read --symbol EZETH
$ yarn hyperlane warp send --symbol EZETH
```

(multiple)
```sh
$ yarn hyperlane warp read --symbol USDC
$ yarn hyperlane warp send --symbol USDC
```
