### PR TITLE
fix: prevent duplication in verification artifacts array

### DIFF
--- a/typescript/.changeset/tall-radios-grin.md
+++ b/typescript/.changeset/tall-radios-grin.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': major
+---
+
+fix(sdk): refactor `addVerificationArtifacts` for enhanced Artifact Deduplication in HyperlaneDeployer

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -185,10 +185,21 @@ export abstract class HyperlaneDeployer<
   ): void {
     this.verificationInputs[chain] = this.verificationInputs[chain] || [];
     artifacts.forEach((artifact) => {
-      this.verificationInputs[chain].push(artifact);
+      // Check existed before push into arrays
+      // All type is primitive values, use shadow compare here.
+      if (
+        !this.verificationInputs[chain].some(
+          (existingArtifact) =>
+            existingArtifact.name === artifact.name &&
+            existingArtifact.address === artifact.address &&
+            existingArtifact.constructorArguments ===
+              artifact.constructorArguments &&
+            existingArtifact.isProxy === artifact.isProxy,
+        )
+      ) {
+        this.verificationInputs[chain].push(artifact);
+      }
     });
-
-    // TODO: deduplicate
   }
 
   protected async runIf<T>(

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -52,6 +52,7 @@ import {
 import {
   buildVerificationInput,
   getContractVerificationInput,
+  shouldAddVerificationInput,
 } from './verify/utils.js';
 
 export interface DeployerOptions {
@@ -184,18 +185,10 @@ export abstract class HyperlaneDeployer<
     artifacts: ContractVerificationInput[],
   ): void {
     this.verificationInputs[chain] = this.verificationInputs[chain] || [];
+
     artifacts.forEach((artifact) => {
-      // Check existed before push into arrays
-      // All type is primitive values, use shadow compare here.
       if (
-        !this.verificationInputs[chain].some(
-          (existingArtifact) =>
-            existingArtifact.name === artifact.name &&
-            existingArtifact.address === artifact.address &&
-            existingArtifact.constructorArguments ===
-              artifact.constructorArguments &&
-            existingArtifact.isProxy === artifact.isProxy,
-        )
+        shouldAddVerificationInput(this.verificationInputs, chain, artifact)
       ) {
         this.verificationInputs[chain].push(artifact);
       }

--- a/typescript/sdk/src/deploy/verify/utils.test.ts
+++ b/typescript/sdk/src/deploy/verify/utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect } from '@jest/globals';
+
+import { ChainMap, ChainName } from '../../types.js';
+
+import { ContractVerificationInput } from './types.js';
+import { shouldAddVerificationInput } from './utils.js';
+
+describe('shouldAddVerificationInput', () => {
+  it('should return true if the artifact does not exist in the verification inputs', () => {
+    const verificationInputs: ChainMap<ContractVerificationInput[]> = {
+      Ethereum: [
+        {
+          name: 'ContractA',
+          address: '0x123',
+          constructorArguments: 'args',
+          isProxy: false,
+        },
+      ],
+    };
+    const newArtifact: ContractVerificationInput = {
+      name: 'ContractB',
+      address: '0x456',
+      constructorArguments: 'argsB',
+      isProxy: true,
+    };
+    const chain: ChainName = 'Ethereum';
+    expect(
+      shouldAddVerificationInput(verificationInputs, chain, newArtifact),
+    ).toBe(true);
+  });
+
+  it('should return false if the artifact already exists in the verification inputs', () => {
+    const verificationInputs: ChainMap<ContractVerificationInput[]> = {
+      Ethereum: [
+        {
+          name: 'ContractA',
+          address: '0x123',
+          constructorArguments: 'args',
+          isProxy: false,
+        },
+      ],
+    };
+    const existingArtifact: ContractVerificationInput = {
+      name: 'ContractA',
+      address: '0x123',
+      constructorArguments: 'args',
+      isProxy: false,
+    };
+    const chain: ChainName = 'Ethereum';
+    expect(
+      shouldAddVerificationInput(verificationInputs, chain, existingArtifact),
+    ).toBe(false);
+  });
+});

--- a/typescript/sdk/src/deploy/verify/utils.test.ts
+++ b/typescript/sdk/src/deploy/verify/utils.test.ts
@@ -1,17 +1,21 @@
-import { describe, expect } from '@jest/globals';
+import { expect } from 'chai';
 
+import { TestChainName } from '../../consts/testChains.js';
+import { randomAddress } from '../../test/testUtils.js';
 import { ChainMap, ChainName } from '../../types.js';
 
 import { ContractVerificationInput } from './types.js';
 import { shouldAddVerificationInput } from './utils.js';
 
 describe('shouldAddVerificationInput', () => {
+  const addressA = randomAddress();
+  const addressB = randomAddress();
   it('should return true if the artifact does not exist in the verification inputs', () => {
     const verificationInputs: ChainMap<ContractVerificationInput[]> = {
-      Ethereum: [
+      [TestChainName.test1]: [
         {
           name: 'ContractA',
-          address: '0x123',
+          address: addressA,
           constructorArguments: 'args',
           isProxy: false,
         },
@@ -19,22 +23,22 @@ describe('shouldAddVerificationInput', () => {
     };
     const newArtifact: ContractVerificationInput = {
       name: 'ContractB',
-      address: '0x456',
+      address: addressB,
       constructorArguments: 'argsB',
       isProxy: true,
     };
-    const chain: ChainName = 'Ethereum';
+    const chain: ChainName = TestChainName.test1;
     expect(
       shouldAddVerificationInput(verificationInputs, chain, newArtifact),
-    ).toBe(true);
+    ).to.equal(true);
   });
 
   it('should return false if the artifact already exists in the verification inputs', () => {
     const verificationInputs: ChainMap<ContractVerificationInput[]> = {
-      Ethereum: [
+      [TestChainName.test2]: [
         {
           name: 'ContractA',
-          address: '0x123',
+          address: addressA,
           constructorArguments: 'args',
           isProxy: false,
         },
@@ -42,13 +46,13 @@ describe('shouldAddVerificationInput', () => {
     };
     const existingArtifact: ContractVerificationInput = {
       name: 'ContractA',
-      address: '0x123',
+      address: addressA,
       constructorArguments: 'args',
       isProxy: false,
     };
-    const chain: ChainName = 'Ethereum';
+    const chain: ChainName = TestChainName.test2;
     expect(
       shouldAddVerificationInput(verificationInputs, chain, existingArtifact),
-    ).toBe(false);
+    ).to.equal(false);
   });
 });

--- a/typescript/sdk/src/deploy/verify/utils.ts
+++ b/typescript/sdk/src/deploy/verify/utils.ts
@@ -1,5 +1,7 @@
 import { ethers, utils } from 'ethers';
 
+import { eqAddress } from '@hyperlane-xyz/utils';
+
 import { ChainMap, ChainName } from '../../types.js';
 
 import { ContractVerificationInput } from './types.js';
@@ -62,7 +64,7 @@ export function shouldAddVerificationInput(
   return !verificationInputs[chain].some(
     (existingArtifact) =>
       existingArtifact.name === artifact.name &&
-      existingArtifact.address === artifact.address &&
+      eqAddress(existingArtifact.address, artifact.address) &&
       existingArtifact.constructorArguments === artifact.constructorArguments &&
       existingArtifact.isProxy === artifact.isProxy,
   );

--- a/typescript/sdk/src/deploy/verify/utils.ts
+++ b/typescript/sdk/src/deploy/verify/utils.ts
@@ -1,5 +1,7 @@
 import { ethers, utils } from 'ethers';
 
+import { ChainMap, ChainName } from '../../types.js';
+
 import { ContractVerificationInput } from './types.js';
 
 export function formatFunctionArguments(
@@ -43,4 +45,25 @@ export function getContractVerificationInput(
 ): ContractVerificationInput {
   const args = getConstructorArguments(contract, bytecode);
   return buildVerificationInput(name, contract.address, args, isProxy);
+}
+
+/**
+ * Check if the artifact should be added to the verification inputs.
+ * @param verificationInputs - The verification inputs for the chain.
+ * @param chain - The chain to check.
+ * @param artifact - The artifact to check.
+ * @returns
+ */
+export function shouldAddVerificationInput(
+  verificationInputs: ChainMap<ContractVerificationInput[]>,
+  chain: ChainName,
+  artifact: ContractVerificationInput,
+): boolean {
+  return !verificationInputs[chain].some(
+    (existingArtifact) =>
+      existingArtifact.name === artifact.name &&
+      existingArtifact.address === artifact.address &&
+      existingArtifact.constructorArguments === artifact.constructorArguments &&
+      existingArtifact.isProxy === artifact.isProxy,
+  );
 }


### PR DESCRIPTION
## Enhance Artifact Deduplication in HyperlaneDeployer
### Description
**Overview**:

The `addVerificationArtifacts` method in the `HyperlaneDeployer` class previously added verification artifacts without checking for duplicates, potentially leading to redundant data that could affect performance and reliability. This PR introduces a mechanism to prevent such duplication by implementing a shallow comparison check before adding new artifacts.

**Changes**:

- Modified the `addVerificationArtifacts` method to include a shallow comparison against existing artifacts.
- Used direct property comparisons to efficiently prevent the addition of duplicate entries.
- Ensured that the comparison handles large ABI-encoded strings efficiently by comparing string references.

**Benefits:**
- Efficiency: Reduces unnecessary processing and storage by avoiding duplicate entries.
- Accuracy: Ensures that the verification process uses a unique set of artifacts, improving the reliability of deployment verifications.
- Performance: Minimizes the overhead associated with handling large sets of data, particularly with large ABI-encoded strings.

**Testing:**
- Added unit tests to verify that duplicates are not added to the artifacts array.
- Ensured existing integration tests pass with the new changes, confirming backward compatibility and functional integrity.

This update streamlines the deployment process by ensuring that only necessary and unique verification artifacts are considered, thereby optimizing both memory usage and processing time during contract deployments.