### PR TITLE
feat: Add smart provider log setter

### DIFF
--- a/.changeset/shiny-cups-help.md
+++ b/.changeset/shiny-cups-help.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Add logic to set smart provider log level to disable provider logs during Warp TokenType derive

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -133,7 +133,7 @@ async function executeDeploy(params: DeployParams) {
   const ismFactoryDeployer = new HyperlaneProxyFactoryDeployer(multiProvider);
 
   // For each chain in WarpRouteConfig, deploy each Ism Factory, if it's not in the registry
-  // Then return a modified config with the ism address as a string
+  // Then return a modified config with the ism address as a string.
   const modifiedConfig = await deployAndResolveWarpIsm(
     config,
     multiProvider,

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -133,7 +133,7 @@ async function executeDeploy(params: DeployParams) {
   const ismFactoryDeployer = new HyperlaneProxyFactoryDeployer(multiProvider);
 
   // For each chain in WarpRouteConfig, deploy each Ism Factory, if it's not in the registry
-  // Then return a modified config with the ism address as a string.
+  // Then return a modified config with the ism address as a string
   const modifiedConfig = await deployAndResolveWarpIsm(
     config,
     multiProvider,

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -240,7 +240,6 @@ describe('EvmHookModule', async () => {
   async function createHook(
     config: HookConfig,
   ): Promise<{ hook: EvmHookModule; initialHookAddress: Address }> {
-    console.log('Creating hook with config: ', stringifyObject(config));
     const hook = await EvmHookModule.create({
       chain,
       config,

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -1,5 +1,5 @@
 import { BigNumber, providers, utils } from 'ethers';
-import { Logger } from 'pino';
+import pino, { Logger } from 'pino';
 
 import {
   raceWithContext,
@@ -95,6 +95,11 @@ export class HyperlaneSmartProvider
     }
 
     this.supportedMethods = [...supportedMethods.values()];
+  }
+
+
+  setLogLevel(level: pino.LevelWithSilentOrString) {
+    this.logger.level = level;
   }
 
   async getPriorityFee(): Promise<BigNumber> {

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -276,7 +276,7 @@ export class HyperlaneSmartProvider
           providerResultPromises.push(resultPromise);
           pIndex += 1;
         } else if (result.status === ProviderStatus.Error) {
-          this.logger.warn(
+          this.logger.debug(
             `Error from provider #${pIndex}: ${result.error} - ${
               !isLastProvider ? ' Triggering next provider.' : ''
             }`,

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -97,7 +97,6 @@ export class HyperlaneSmartProvider
     this.supportedMethods = [...supportedMethods.values()];
   }
 
-
   setLogLevel(level: pino.LevelWithSilentOrString) {
     this.logger.level = level;
   }

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -226,8 +226,8 @@ export class EvmERC20WarpRouteReader {
    * @param level - The log level to set, e.g. 'debug', 'info', 'warn', 'error'.
    */
   protected setSmartProviderLogLevel(level: string) {
-    if ('setLogLevel' in this.provider) {
-      (this.provider as HyperlaneSmartProvider).setLogLevel(level);
+    if (this.provider instanceof HyperlaneSmartProvider) {
+      this.provider.setLogLevel(level);
     }
   }
 }

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -226,7 +226,8 @@ export class EvmERC20WarpRouteReader {
    * @param level - The log level to set, e.g. 'debug', 'info', 'warn', 'error'.
    */
   protected setSmartProviderLogLevel(level: string) {
-    if (this.provider instanceof HyperlaneSmartProvider) {
+    if ('setLogLevel' in this.provider) {
+      //@ts-ignore
       this.provider.setLogLevel(level);
     }
   }

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -6,7 +6,6 @@ import {
   HypERC20__factory,
 } from '@hyperlane-xyz/core';
 import {
-  HyperlaneSmartProvider,
   MailboxClientConfig,
   TokenRouterConfig,
   TokenType,


### PR DESCRIPTION
### Description
- Add logic to enable setting of log levels to the SmartProvider. 
- Add logic to set log level to `silent` in the beginning of `deriveTokenType()`, and then resetting it after.

### Related issues
- Fixes #4006 

### Backward compatibility
Yes

### Testing
Manual
