### PR TITLE
fix: derived token supply to 0

### DIFF
--- a/.changeset/bright-horses-give.md
+++ b/.changeset/bright-horses-give.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Fix initial total supply of synthetic token deployments to 0


### PR DESCRIPTION
### Description

Token deployer should always derive token metadata's total supply to 0, otherwise the collateral token's total supply will be minted initially on the synthetic, creating 2x the desired total supply.

### Related issues

- Regression introduced by https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3820
- opens https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4013

### Backward compatibility

Yes

### Testing

Unit Tests
