### PR TITLE
chore(cli): format message stdout during hl send message

### DIFF
--- a/typescript/cli/src/config/chain.ts
+++ b/typescript/cli/src/config/chain.ts
@@ -10,8 +10,8 @@ import { ProtocolType } from '@hyperlane-xyz/utils';
 
 import { CommandContext } from '../context/types.js';
 import { errorRed, log, logBlue, logGreen } from '../logger.js';
-import { detectAndConfirmOrPrompt } from '../utils/chains.js';
 import { readYamlOrJson } from '../utils/files.js';
+import { detectAndConfirmOrPrompt } from '../utils/input.js';
 
 export function readChainConfigs(filePath: string) {
   log(`Reading file configs in ${filePath}`);

--- a/typescript/cli/src/config/core.ts
+++ b/typescript/cli/src/config/core.ts
@@ -4,8 +4,8 @@ import { CoreConfigSchema, HookConfig, IsmConfig } from '@hyperlane-xyz/sdk';
 
 import { CommandContext } from '../context/types.js';
 import { errorRed, log, logBlue, logGreen } from '../logger.js';
-import { detectAndConfirmOrPrompt } from '../utils/chains.js';
 import { indentYamlOrJson, writeYamlOrJson } from '../utils/files.js';
+import { detectAndConfirmOrPrompt } from '../utils/input.js';
 
 import {
   createHookConfig,

--- a/typescript/cli/src/config/hooks.ts
+++ b/typescript/cli/src/config/hooks.ts
@@ -21,6 +21,7 @@ import { CommandContext } from '../context/types.js';
 import { errorRed, logBlue, logGreen, logRed } from '../logger.js';
 import {
   detectAndConfirmOrPrompt,
+  inputWithInfo,
   runMultiChainSelectionStep,
 } from '../utils/chains.js';
 import { readYamlOrJson } from '../utils/files.js';
@@ -153,15 +154,17 @@ export const createProtocolFeeConfig = callWithConfigCreationLogs(
     // TODO: input in gwei, wei, etc
     const maxProtocolFee = advanced
       ? toWei(
-          await input({
-            message: `Enter max protocol fee for protocol fee hook (in wei):`,
+          await inputWithInfo({
+            message: `Enter max protocol fee for protocol fee hook (wei):`,
+            info: `The max protocol fee (ProtocolFee.MAX_PROTOCOL_FEE) is the maximum value the protocol fee on the ProtocolFee hook contract can ever be set to.\nDefault is set to ${MAX_PROTOCOL_FEE_DEFAULT} wei; between 0.001 and 0.1 wei is recommended.`,
           }),
         )
       : MAX_PROTOCOL_FEE_DEFAULT;
     const protocolFee = advanced
       ? toWei(
-          await input({
-            message: `Enter protocol fee for protocol fee hook (in wei):`,
+          await inputWithInfo({
+            message: `Enter protocol fee for protocol fee hook (wei):`,
+            info: `The protocol fee is the fee collected by the beneficiary of the ProtocolFee hook for every transaction executed with this hook.\nDefault is set to 0 wei; must be less than max protocol fee of ${maxProtocolFee}.`,
           }),
         )
       : PROTOCOL_FEE_DEFAULT;
@@ -169,7 +172,7 @@ export const createProtocolFeeConfig = callWithConfigCreationLogs(
       errorRed(
         `Protocol fee (${protocolFee}) cannot be greater than max protocol fee (${maxProtocolFee}).`,
       );
-      throw new Error('Invalid protocol fee.');
+      throw new Error(`Invalid protocol fee (${protocolFee}).`);
     }
     return {
       type: HookType.PROTOCOL_FEE,

--- a/typescript/cli/src/config/hooks.ts
+++ b/typescript/cli/src/config/hooks.ts
@@ -19,12 +19,9 @@ import {
 
 import { CommandContext } from '../context/types.js';
 import { errorRed, logBlue, logGreen, logRed } from '../logger.js';
-import {
-  detectAndConfirmOrPrompt,
-  inputWithInfo,
-  runMultiChainSelectionStep,
-} from '../utils/chains.js';
+import { runMultiChainSelectionStep } from '../utils/chains.js';
 import { readYamlOrJson } from '../utils/files.js';
+import { detectAndConfirmOrPrompt, inputWithInfo } from '../utils/input.js';
 
 import { callWithConfigCreationLogs } from './utils.js';
 

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -19,11 +19,9 @@ import {
   logBoldUnderlinedRed,
   logRed,
 } from '../logger.js';
-import {
-  detectAndConfirmOrPrompt,
-  runMultiChainSelectionStep,
-} from '../utils/chains.js';
+import { runMultiChainSelectionStep } from '../utils/chains.js';
 import { readYamlOrJson } from '../utils/files.js';
+import { detectAndConfirmOrPrompt } from '../utils/input.js';
 
 import { callWithConfigCreationLogs } from './utils.js';
 

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -16,15 +16,13 @@ import { Address, assert, objMap, promiseObjAll } from '@hyperlane-xyz/utils';
 
 import { CommandContext } from '../context/types.js';
 import { errorRed, log, logBlue, logGreen } from '../logger.js';
-import {
-  detectAndConfirmOrPrompt,
-  runMultiChainSelectionStep,
-} from '../utils/chains.js';
+import { runMultiChainSelectionStep } from '../utils/chains.js';
 import {
   indentYamlOrJson,
   readYamlOrJson,
   writeYamlOrJson,
 } from '../utils/files.js';
+import { detectAndConfirmOrPrompt } from '../utils/input.js';
 
 import { createAdvancedIsmConfig } from './ism.js';
 

--- a/typescript/cli/src/deploy/core.ts
+++ b/typescript/cli/src/deploy/core.ts
@@ -1,9 +1,12 @@
+import { stringify as yamlStringify } from 'yaml';
+
 import { ChainName, CoreConfig, EvmCoreModule } from '@hyperlane-xyz/sdk';
 
 import { MINIMUM_CORE_DEPLOY_GAS } from '../consts.js';
 import { WriteCommandContext } from '../context/types.js';
-import { logBlue } from '../logger.js';
+import { log, logBlue, logGreen } from '../logger.js';
 import { runSingleChainSelectionStep } from '../utils/chains.js';
+import { indentYamlOrJson } from '../utils/files.js';
 
 import {
   completeDeploy,
@@ -83,5 +86,7 @@ export async function runCoreDeploy({
 
     // @TODO implement writeAgentConfig
   }
-  logBlue('Deployment is complete!');
+
+  logGreen('✅ Core contract deployments complete:\n');
+  log(indentYamlOrJson(yamlStringify(deployedAddresses, null, 2), 4));
 }

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -143,15 +143,14 @@ async function executeDeploy(params: DeployParams) {
 
   const deployedContracts = await deployer.deploy(modifiedConfig);
 
+  const warpCoreConfig = await getWarpCoreConfig(params, deployedContracts);
   logGreen('✅ Warp contract deployments complete');
 
-  const warpCoreConfig = await getWarpCoreConfig(params, deployedContracts);
   if (!isDryRun) {
-    log('Writing deployment artifacts');
+    log('Writing deployment artifacts...');
     await registry.addWarpRoute(warpCoreConfig);
   }
   log(indentYamlOrJson(yamlStringify(warpCoreConfig, null, 2), 4));
-  logBlue('Deployment is complete!');
 }
 
 async function deployAndResolveWarpIsm(

--- a/typescript/cli/src/send/message.ts
+++ b/typescript/cli/src/send/message.ts
@@ -1,3 +1,5 @@
+import { stringify as yamlStringify } from 'yaml';
+
 import { ChainName, HyperlaneCore } from '@hyperlane-xyz/sdk';
 import { addressToBytes32, timeout } from '@hyperlane-xyz/utils';
 
@@ -6,6 +8,7 @@ import { CommandContext, WriteCommandContext } from '../context/types.js';
 import { runPreflightChecksForChains } from '../deploy/utils.js';
 import { errorRed, log, logBlue, logGreen } from '../logger.js';
 import { runSingleChainSelectionStep } from '../utils/chains.js';
+import { indentYamlOrJson } from '../utils/files.js';
 
 export async function sendTestMessage({
   context,
@@ -103,7 +106,7 @@ async function executeDelivery({
     );
     logBlue(`Sent message from ${origin} to ${recipient} on ${destination}.`);
     logBlue(`Message ID: ${message.id}`);
-    log(`Message: ${JSON.stringify(message)}`);
+    log(`Message:\n${indentYamlOrJson(yamlStringify(message, null, 2), 4)}`);
 
     if (selfRelay) {
       log('Attempting self-relay of message');

--- a/typescript/cli/src/utils/chains.ts
+++ b/typescript/cli/src/utils/chains.ts
@@ -4,9 +4,10 @@ import chalk from 'chalk';
 
 import { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
 
-import { log, logRed, logTip } from '../logger.js';
+import { log, logGray, logRed, logTip } from '../logger.js';
 
 import { calculatePageSize } from './cli-options.js';
+import { indentYamlOrJson } from './files.js';
 
 // A special value marker to indicate user selected
 // a new chain in the list
@@ -98,4 +99,30 @@ export async function detectAndConfirmOrPrompt(
     // eslint-disable-next-line no-empty
   } catch (e) {}
   return input({ message: `${prompt} ${label}:`, default: detectedValue });
+}
+
+const INFO_COMMAND: string = 'i';
+const DOCS_NOTICE: string =
+  'For more information, please visit https://docs.hyperlane.xyz.';
+
+export async function inputWithInfo({
+  message,
+  info = 'No additional information available.',
+  defaultAnswer,
+}: {
+  message: string;
+  info?: string;
+  defaultAnswer?: string;
+}): Promise<string> {
+  let answer: string = '';
+  do {
+    answer = await input({
+      message: message.concat(` [enter '${INFO_COMMAND}' for more info]`),
+      default: defaultAnswer,
+    });
+    answer = answer.trim().toLowerCase();
+    const indentedInfo = indentYamlOrJson(`${info}\n${DOCS_NOTICE}\n`, 4);
+    if (answer === INFO_COMMAND) logGray(indentedInfo);
+  } while (answer === INFO_COMMAND);
+  return answer;
 }

--- a/typescript/cli/src/utils/chains.ts
+++ b/typescript/cli/src/utils/chains.ts
@@ -1,13 +1,12 @@
-import { Separator, checkbox, confirm, input } from '@inquirer/prompts';
+import { Separator, checkbox } from '@inquirer/prompts';
 import select from '@inquirer/select';
 import chalk from 'chalk';
 
 import { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
 
-import { log, logGray, logRed, logTip } from '../logger.js';
+import { log, logRed, logTip } from '../logger.js';
 
 import { calculatePageSize } from './cli-options.js';
-import { indentYamlOrJson } from './files.js';
 
 // A special value marker to indicate user selected
 // a new chain in the list
@@ -75,54 +74,4 @@ function handleNewChain(chainNames: string[]) {
     );
     process.exit(0);
   }
-}
-
-export async function detectAndConfirmOrPrompt(
-  detect: () => Promise<string | undefined>,
-  prompt: string,
-  label: string,
-  source?: string,
-): Promise<string> {
-  let detectedValue: string | undefined;
-  try {
-    detectedValue = await detect();
-    if (detectedValue) {
-      const confirmed = await confirm({
-        message: `Detected ${label} as ${detectedValue}${
-          source ? ` from ${source}` : ''
-        }, is this correct?`,
-      });
-      if (confirmed) {
-        return detectedValue;
-      }
-    }
-    // eslint-disable-next-line no-empty
-  } catch (e) {}
-  return input({ message: `${prompt} ${label}:`, default: detectedValue });
-}
-
-const INFO_COMMAND: string = 'i';
-const DOCS_NOTICE: string =
-  'For more information, please visit https://docs.hyperlane.xyz.';
-
-export async function inputWithInfo({
-  message,
-  info = 'No additional information available.',
-  defaultAnswer,
-}: {
-  message: string;
-  info?: string;
-  defaultAnswer?: string;
-}): Promise<string> {
-  let answer: string = '';
-  do {
-    answer = await input({
-      message: message.concat(` [enter '${INFO_COMMAND}' for more info]`),
-      default: defaultAnswer,
-    });
-    answer = answer.trim().toLowerCase();
-    const indentedInfo = indentYamlOrJson(`${info}\n${DOCS_NOTICE}\n`, 4);
-    if (answer === INFO_COMMAND) logGray(indentedInfo);
-  } while (answer === INFO_COMMAND);
-  return answer;
 }

--- a/typescript/cli/src/utils/input.ts
+++ b/typescript/cli/src/utils/input.ts
@@ -1,0 +1,55 @@
+import { confirm, input } from '@inquirer/prompts';
+
+import { logGray } from '../logger.js';
+
+import { indentYamlOrJson } from './files.js';
+
+export async function detectAndConfirmOrPrompt(
+  detect: () => Promise<string | undefined>,
+  prompt: string,
+  label: string,
+  source?: string,
+): Promise<string> {
+  let detectedValue: string | undefined;
+  try {
+    detectedValue = await detect();
+    if (detectedValue) {
+      const confirmed = await confirm({
+        message: `Detected ${label} as ${detectedValue}${
+          source ? ` from ${source}` : ''
+        }, is this correct?`,
+      });
+      if (confirmed) {
+        return detectedValue;
+      }
+    }
+    // eslint-disable-next-line no-empty
+  } catch (e) {}
+  return input({ message: `${prompt} ${label}:`, default: detectedValue });
+}
+
+const INFO_COMMAND: string = 'i';
+const DOCS_NOTICE: string =
+  'For more information, please visit https://docs.hyperlane.xyz.';
+
+export async function inputWithInfo({
+  message,
+  info = 'No additional information available.',
+  defaultAnswer,
+}: {
+  message: string;
+  info?: string;
+  defaultAnswer?: string;
+}): Promise<string> {
+  let answer: string = '';
+  do {
+    answer = await input({
+      message: message.concat(` [enter '${INFO_COMMAND}' for more info]`),
+      default: defaultAnswer,
+    });
+    answer = answer.trim().toLowerCase();
+    const indentedInfo = indentYamlOrJson(`${info}\n${DOCS_NOTICE}\n`, 4);
+    if (answer === INFO_COMMAND) logGray(indentedInfo);
+  } while (answer === INFO_COMMAND);
+  return answer;
+}


### PR DESCRIPTION
### Description

- formats message stdout during hl send message

### Drive-by changes

- none

### Related issues

- P1

### Backward compatibility

- yes

### Testing

- manual

example output:
```
➜  cli git:(06-20-fix_cli_add_units_and_explanation_to_protocol_fee_input) ✗ hl send message --relay --registry $HOME/workplace/Hyperlane/hyperlane-registry
Hyperlane CLI

? Select the origin chain fuji
? Select the destination chain brown
Running pre-flight checks for chains...
✅ Chains are valid
✅ Signer is valid
✅ Balances are sufficient
Dispatching message
Pending https://testnet.snowtrace.io/tx/0x5d0793052ad6df340242f332a218b14a8182b083bebbf5666faac83f7c20ed66 (waiting 3 blocks for confirmation)
Sent message from fuji to 0xb2b1125501aA997b912A0fa32f74B3041C0c4FcB on brown.
Message ID: 0x2ba918e23225a7dc67ec803cff998cbe9beefd45c7243422349035dcac5e20d0
Message:
    parsed:
      version: 3
      nonce: 2605
      origin: 43113
      sender: "0x00000000000000000000000016f4898f47c085c41d7cc6b1dc72b91ea617dcbb"
      destination: 6700087
      recipient: "0x000000000000000000000000b2b1125501aa997b912a0fa32f74b3041c0c4fcb"
      body: "0x48656c6c6f21"
      originChain: fuji
      destinationChain: brown
    id: "0x2ba918e23225a7dc67ec803cff998cbe9beefd45c7243422349035dcac5e20d0"
    message: "0x0300000a2d0000a86900000000000000000000000016f4898f47c085c41d7cc6b1d\
      c72b91ea617dcbb00663c37000000000000000000000000b2b1125501aa997b912a0fa32f74b3\
      041c0c4fcb48656c6c6f21"
```