### PR TITLE
chore(cli): display core artifacts after core deploy

### DIFF
--- a/typescript/cli/src/deploy/core.ts
+++ b/typescript/cli/src/deploy/core.ts
@@ -1,9 +1,12 @@
+import { stringify as yamlStringify } from 'yaml';
+
 import { ChainName, CoreConfig, EvmCoreModule } from '@hyperlane-xyz/sdk';
 
 import { MINIMUM_CORE_DEPLOY_GAS } from '../consts.js';
 import { WriteCommandContext } from '../context/types.js';
-import { logBlue } from '../logger.js';
+import { log, logBlue, logGreen } from '../logger.js';
 import { runSingleChainSelectionStep } from '../utils/chains.js';
+import { indentYamlOrJson } from '../utils/files.js';
 
 import {
   completeDeploy,
@@ -83,5 +86,7 @@ export async function runCoreDeploy({
 
     // @TODO implement writeAgentConfig
   }
-  logBlue('Deployment is complete!');
+
+  logGreen('✅ Core contract deployments complete:\n');
+  log(indentYamlOrJson(yamlStringify(deployedAddresses, null, 2), 4));
 }

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -143,15 +143,14 @@ async function executeDeploy(params: DeployParams) {
 
   const deployedContracts = await deployer.deploy(modifiedConfig);
 
+  const warpCoreConfig = await getWarpCoreConfig(params, deployedContracts);
   logGreen('✅ Warp contract deployments complete');
 
-  const warpCoreConfig = await getWarpCoreConfig(params, deployedContracts);
   if (!isDryRun) {
-    log('Writing deployment artifacts');
+    log('Writing deployment artifacts...');
     await registry.addWarpRoute(warpCoreConfig);
   }
   log(indentYamlOrJson(yamlStringify(warpCoreConfig, null, 2), 4));
-  logBlue('Deployment is complete!');
 }
 
 async function deployAndResolveWarpIsm(


### PR DESCRIPTION
### Description

- displays core artifacts to stdout after core deploy

### Drive-by changes

- none

### Related issues

- P1

### Backward compatibility

- y

### Testing

- manual

example output:
```
⛽️ Gas Usage Statistics
        - Gas required for core deploy on brown: 0.000020444175441289 ETH
Now updating chain brown at filesystem registry at /Users/nbayindirli/workplace/Hyperlane/hyperlane-registry
Done updating chain brown at filesystem registry
Now updating chain brown at filesystem registry at /Users/nbayindirli/.hyperlane
Done updating chain brown at filesystem registry
✅ Core contract deployments complete
    staticMerkleRootMultisigIsmFactory: "0x6Df928Ce3A9627eA3D276e8C680b8108040702E3"
    staticMessageIdMultisigIsmFactory: "0x35547488D84cd413107b2112726E6711744676db"
    staticAggregationIsmFactory: "0x50B52aAd80195daA77F7AacD5ea612d07aFa17Ea"
    staticAggregationHookFactory: "0xf3257D4E425aa89496B4a1A8769Adc14E292477b"
    domainRoutingIsmFactory: "0xD8955d6c4ce772d035E3be8787a9AA560ebB21dD"
    proxyAdmin: "0xb6CD436a0dD832210689c2514B5cfD0C095F4cb8"
    mailbox: "0x205A5d97111abe0C53C0459cF37013F16Ff67889"
    interchainAccountRouter: "0x181a94cCE733F33af622270178d862ea1ae87C06"
    interchainAccountIsm: "0x9b684a4380eeE42C183efa8EFaE469e131adC46E"
    validatorAnnounce: "0xE72c42e5267541a938b4f0392DfDcC2A5a8E5Dcf"
    testRecipient: "0xC75b591b6957332D1aE1ce6d2A14943FbA3A33F8"
```
