### PR TITLE
chore: enable `osmosis` on relayer

### DIFF
--- a/rust/config/mainnet_config.json
+++ b/rust/config/mainnet_config.json
@@ -692,8 +692,7 @@
     },
     "injective": {
       "bech32Prefix": "inj",
-      "blockExplorers": [
-      ],
+      "blockExplorers": [],
       "blocks": {
         "confirmations": 1,
         "estimateBlockTime": 1,
@@ -1155,6 +1154,11 @@
           "http": "https://osmosis-rpc.publicnode.com"
         }
       ],
+      "signer": {
+        "key": "0x5486418967eabc770b0fcb995f7ef6d9a72f7fc195531ef76c5109f44f51af26",
+        "prefix": "osmo",
+        "type": "cosmosKey"
+      },
       "slip44": 118,
       "validatorAnnounce": "0xaf867da5b09a20ee49161d57f99477c0c42d100f34eb53da0d2eb7fc6c257235"
     },

--- a/rust/config/mainnet_config.json
+++ b/rust/config/mainnet_config.json
@@ -692,7 +692,8 @@
     },
     "injective": {
       "bech32Prefix": "inj",
-      "blockExplorers": [],
+      "blockExplorers": [
+      ],
       "blocks": {
         "confirmations": 1,
         "estimateBlockTime": 1,

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -93,7 +93,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig = {
     // At the moment, we only relay between Neutron and Manta Pacific on the neutron context.
     neutron: false,
     optimism: true,
-    osmosis: false,
+    osmosis: true,
     polygon: true,
     polygonzkevm: true,
     redstone: true,
@@ -123,6 +123,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig = {
     // Cannot scrape non-EVM chains
     neutron: false,
     optimism: true,
+    // Cannot scrape non-EVM chains
     osmosis: false,
     polygon: true,
     polygonzkevm: true,


### PR DESCRIPTION
- chore: enable `osmosis` on relayer
- drive-by add default chain signer/key/type to agent config
	- `signer.key` is copied from `neutron`