### PR TITLE
chore(cli): display new chain config after registry init

### DIFF
--- a/typescript/cli/src/config/chain.ts
+++ b/typescript/cli/src/config/chain.ts
@@ -1,5 +1,6 @@
 import { confirm, input } from '@inquirer/prompts';
 import { ethers } from 'ethers';
+import { stringify as yamlStringify } from 'yaml';
 
 import {
   ChainMetadata,
@@ -10,7 +11,7 @@ import { ProtocolType } from '@hyperlane-xyz/utils';
 
 import { CommandContext } from '../context/types.js';
 import { errorRed, log, logBlue, logGreen } from '../logger.js';
-import { readYamlOrJson } from '../utils/files.js';
+import { indentYamlOrJson, readYamlOrJson } from '../utils/files.js';
 import { detectAndConfirmOrPrompt } from '../utils/input.js';
 
 export function readChainConfigs(filePath: string) {
@@ -94,7 +95,9 @@ export async function createChainConfig({
 
   const parseResult = ChainMetadataSchema.safeParse(metadata);
   if (parseResult.success) {
-    logGreen(`Chain config is valid, writing to registry`);
+    logGreen(`Chain config is valid, writing to registry:`);
+    const metadataYaml = yamlStringify(metadata, null, 2);
+    log(indentYamlOrJson(metadataYaml, 4));
     await context.registry.updateChain({ chainName: metadata.name, metadata });
   } else {
     errorRed(


### PR DESCRIPTION
### Description

- displays new chain config after `hl registry init`

### Drive-by changes

- none

### Related issues

- fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4039

### Backward compatibility

- yes

### Testing

- manual
