### PR TITLE
chore: fix type typing

### DIFF
--- a/typescript/.changeset/clever-gifts-confess.md
+++ b/typescript/.changeset/clever-gifts-confess.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/infra': major
+---
+
+fix type typo ChainMap<unknown>

--- a/typescript/.changeset/clever-gifts-confess.md
+++ b/typescript/.changeset/clever-gifts-confess.md
@@ -1,5 +1,5 @@
 ---
-'@hyperlane-xyz/infra': major
+'@hyperlane-xyz/infra': patch
 ---
 
 fix type typo ChainMap<unknown>

--- a/typescript/infra/scripts/deploy.ts
+++ b/typescript/infra/scripts/deploy.ts
@@ -51,6 +51,8 @@ import {
 } from './agent-utils.js';
 import { getEnvironmentConfig, getHyperlaneCore } from './core-utils.js';
 
+type Config = object;
+
 async function main() {
   const {
     context = Contexts.Hyperlane,
@@ -250,7 +252,7 @@ async function main() {
   }
 
   await deployWithArtifacts({
-    configMap: config as ChainMap<unknown>, // TODO: fix this typing
+    configMap: config as ChainMap<Config>,
     deployer,
     cache,
     // Use chains if provided, otherwise deploy to all chains

--- a/typescript/utils/src/addresses.test.ts
+++ b/typescript/utils/src/addresses.test.ts
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import {
   addressToBytes,
   bytesToProtocolAddress,
-  ensure0x,
   isZeroishAddress,
 } from './addresses.js';
 import { ProtocolType } from './types.js';
@@ -59,13 +58,6 @@ describe('Address utilities', () => {
           ProtocolType.Ethereum,
         ),
       ).to.throw(Error);
-    });
-  });
-
-  describe('ensure0x', () => {
-    it('Make sure any string has startWith 0x', () => {
-      expect(ensure0x('0x123')).to.equal('0x123');
-      expect(ensure0x('123')).to.equal('0x123');
     });
   });
 });

--- a/typescript/utils/src/addresses.test.ts
+++ b/typescript/utils/src/addresses.test.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import {
   addressToBytes,
   bytesToProtocolAddress,
+  ensure0x,
   isZeroishAddress,
 } from './addresses.js';
 import { ProtocolType } from './types.js';
@@ -58,6 +59,13 @@ describe('Address utilities', () => {
           ProtocolType.Ethereum,
         ),
       ).to.throw(Error);
+    });
+  });
+
+  describe('ensure0x', () => {
+    it('Make sure any string has startWith 0x', () => {
+      expect(ensure0x('0x123')).to.equal('0x123');
+      expect(ensure0x('123')).to.equal('0x123');
     });
   });
 });


### PR DESCRIPTION
### Description
Fix type typo in `deploy.ts`

**Summary**
This pull request addresses a minor typo in the deploy.ts script. The type assertion for configMap was set `unknown`. It should have a name, or define exactly type

**Changes**
Corrected the type assertion for configMap from `ChainMap<unknown>` to `ChainMap<Config>`.

**Affected File**
`typescript/infra/scripts/deploy.ts`

**Detailed Explanation**


```diff
+ type Config = object;
- configMap: config as ChainMap<unknown>,
+ configMap: config as ChainMap<Config>,
```
This change ensures that the configMap is correctly typed, improving type safety and code readability.

**Testing**

**Additional Notes**
