### PR TITLE
feat(cli): display formatted deployment plan to confirm core deploy

### DIFF
--- a/typescript/cli/src/deploy/utils.ts
+++ b/typescript/cli/src/deploy/utils.ts
@@ -157,7 +157,7 @@ export function toUpperCamelCase(string: string) {
 }
 
 function transformChainMetadataForDisplay(chainMetadata: ChainMetadata) {
-  const transformedChainMetadata = {
+  return {
     Name: chainMetadata.name,
     'Display Name': chainMetadata.displayName,
     'Chain ID': chainMetadata.chainId,
@@ -168,6 +168,4 @@ function transformChainMetadataForDisplay(chainMetadata: ChainMetadata) {
     'Native Token: Name': chainMetadata.nativeToken?.name,
     'Native Token: Decimals': chainMetadata.nativeToken?.decimals,
   };
-
-  return transformedChainMetadata;
 }


### PR DESCRIPTION
### Description

- Displays formatted deployment plan to confirm core deploy

### Drive-by changes

- none

### Related issues

- Fixes P1

### Backward compatibility

- yes
 
### Testing

- Output:
```
➜  cli git:(cli-2.0) ✗ hl core deploy --registry $HOME/workplace/Hyperlane/hyperlane-registry
Hyperlane CLI

Hyperlane permissionless deployment
------------------------------------------------
? Select chain to connect: alpha

Deployment plan
===============
Transaction signer and owner of new contracts: 0x16F4898F47c085C41d7Cc6b1dc72B91EA617dcBb
Deploying core contracts to network: alpha
┌────────────────────────┬──────────────────────────────────────────────┐
│ (index)                │ Values                                       │
├────────────────────────┼──────────────────────────────────────────────┤
│ Name                   │ 'alpha'                                      │
│ Display Name           │ 'Alpha'                                      │
│ Chain ID               │ 75904                                        │
│ Domain ID              │ 75904                                        │
│ Protocol               │ 'ethereum'                                   │
│ JSON RPC URL           │ 'https://alpha-tk.rpc.caldera.xyz/http' │
│ Native Token: Symbol   │ 'ETH'                                        │
│ Native Token: Name     │ 'Ether'                                      │
│ Native Token: Decimals │ 18                                           │
└────────────────────────┴──────────────────────────────────────────────┘
Note: There are several contracts required for each chain, but contracts in your provided registries will be skipped.
? Is this deployment plan correct? (Y/n)
```
