### PR TITLE
fix(ci): use the correct commit sha for agent/monorepo image tags

### DIFF
--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -10,6 +10,7 @@ on:
       - 'typescript/infra/**'
       - 'Dockerfile'
       - '.dockerignore'
+      - '.github/workflows/monorepo-docker.yml'
 
 concurrency:
   group: build-push-monorepo-${{ github.ref }}

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -47,7 +47,7 @@ jobs:
         id: taggen
         run: |
           echo "TAG_DATE=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
-          echo "TAG_SHA=$(echo '${{ github.sha }}' | cut -b 1-7)" >> $GITHUB_OUTPUT
+          echo "TAG_SHA=$(echo '${{ github.event.pull_request.head.sha || github.sha }}' | cut -b 1-7)" >> $GITHUB_OUTPUT
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -40,7 +40,7 @@ jobs:
         id: taggen
         run: |
           echo "TAG_DATE=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
-          echo "TAG_SHA=$(echo '${{ github.sha }}' | cut -b 1-7)" >> $GITHUB_OUTPUT
+          echo "TAG_SHA=$(echo '${{ github.event.pull_request.head.sha || github.sha }}' | cut -b 1-7)" >> $GITHUB_OUTPUT
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - 'rust/**'
+      - '.github/workflows/rust-docker.yml'
 concurrency:
   group: build-push-agents-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
- use the correct commit hash for the agent and monorepo image tag
- the actual checked out commit was correct, but this now ensures that the TAG_SHA matches the checked out commit hash
- drive-by ensure that workflow gets triggered on changes to itself