### PR TITLE
fix(cli): RPC errors while sending test messages

### DIFF
--- a/.changeset/calm-eels-care.md
+++ b/.changeset/calm-eels-care.md
@@ -3,4 +3,4 @@
 '@hyperlane-xyz/sdk': minor
 ---
 
-Fix deriving hook error that prevents warp and core test messages on the cli
+Gracefully handle RPC failures during warp send & fix deriving hook error that prevents warp and core test messages on the cli.

--- a/.changeset/calm-eels-care.md
+++ b/.changeset/calm-eels-care.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+Fix deriving hook error that prevents warp and core test messages on the cli

--- a/typescript/cli/src/deploy/core.ts
+++ b/typescript/cli/src/deploy/core.ts
@@ -83,8 +83,6 @@ export async function runCoreDeploy({
       chainName: chain,
       addresses: deployedAddresses,
     });
-
-    // @TODO implement writeAgentConfig
   }
 
   logGreen('✅ Core contract deployments complete:\n');

--- a/typescript/sdk/src/core/HyperlaneCore.ts
+++ b/typescript/sdk/src/core/HyperlaneCore.ts
@@ -8,6 +8,7 @@ import {
   AddressBytes32,
   ProtocolType,
   addressToBytes32,
+  assert,
   bytes32ToAddress,
   messageId,
   objFilter,
@@ -116,7 +117,9 @@ export class HyperlaneCore extends HyperlaneApp<CoreFactories> {
     const originChain = this.getOrigin(message);
     const hookReader = new EvmHookReader(this.multiProvider, originChain);
     const address = await this.getHookAddress(message);
-    return hookReader.deriveHookConfig(address);
+    const hookConfig = await hookReader.deriveHookConfig(address);
+    assert(hookConfig, `No hook config found for ${address}.`);
+    return hookConfig;
   }
 
   async buildMetadata(

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -20,6 +20,7 @@ import {
   Address,
   ProtocolType,
   addressToBytes32,
+  assert,
   configDeepEquals,
   rootLogger,
 } from '@hyperlane-xyz/utils';
@@ -108,9 +109,18 @@ export class EvmHookModule extends HyperlaneModule<
   }
 
   public async read(): Promise<HookConfig> {
-    return typeof this.args.config === 'string'
-      ? this.args.addresses.deployedHook
-      : this.reader.deriveHookConfig(this.args.addresses.deployedHook);
+    if (typeof this.args.config === 'string') {
+      return this.args.addresses.deployedHook;
+    } else {
+      const hookConfig = await this.reader.deriveHookConfig(
+        this.args.addresses.deployedHook,
+      );
+      assert(
+        hookConfig,
+        `No hook config found for ${this.args.addresses.deployedHook}`,
+      );
+      return hookConfig;
+    }
   }
 
   public async update(_config: HookConfig): Promise<AnnotatedEV5Transaction[]> {

--- a/typescript/sdk/src/hook/EvmHookReader.test.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.test.ts
@@ -204,7 +204,7 @@ describe('EvmHookReader', () => {
 
     // top-level method infers hook type
     const hookConfig = await evmHookReader.deriveHookConfig(mockAddress);
-    expect(hookConfig).to.deep.equal({});
+    expect(hookConfig).to.be.undefined;
   });
 
   /*

--- a/typescript/sdk/src/hook/EvmHookReader.test.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.test.ts
@@ -186,6 +186,27 @@ describe('EvmHookReader', () => {
     expect(config).to.deep.equal(hookConfig);
   });
 
+  it('should return an empty config if deriving fails', async () => {
+    const mockAddress = generateRandomAddress();
+    const mockOwner = generateRandomAddress();
+
+    // Mocking the connect method + returned what we need from contract object
+    const mockContract = {
+      // No type
+      owner: sandbox.stub().resolves(mockOwner),
+    };
+    sandbox
+      .stub(MerkleTreeHook__factory, 'connect')
+      .returns(mockContract as unknown as MerkleTreeHook);
+    sandbox
+      .stub(IPostDispatchHook__factory, 'connect')
+      .returns(mockContract as unknown as IPostDispatchHook);
+
+    // top-level method infers hook type
+    const hookConfig = await evmHookReader.deriveHookConfig(mockAddress);
+    expect(hookConfig).to.deep.equal({});
+  });
+
   /*
     Testing for more nested hook types can be done manually by reading from existing contracts onchain.
     Examples of nested hook types include:

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -88,13 +88,12 @@ export class EvmHookReader implements HookReader {
   async deriveHookConfig(address: Address): Promise<DerivedHookConfig> {
     try {
       const hook = IPostDispatchHook__factory.connect(address, this.provider);
-
-      const onchainHookType = await hook.hookType();
-      this.logger.debug('Deriving HookConfig', { address, onchainHookType });
+      this.logger.debug('Deriving HookConfig', { address });
 
       // Temporarily turn off SmartProvider logging
       // Provider errors are expected because deriving will call methods that may not exist in the Bytecode
       this.setSmartProviderLogLevel('silent');
+      const onchainHookType = await hook.hookType();
 
       switch (onchainHookType) {
         case OnchainHookType.ROUTING:

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -20,6 +20,7 @@ import {
   assert,
   concurrentMap,
   eqAddress,
+  getLogLevel,
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
@@ -85,33 +86,47 @@ export class EvmHookReader implements HookReader {
   }
 
   async deriveHookConfig(address: Address): Promise<DerivedHookConfig> {
-    const hook = IPostDispatchHook__factory.connect(address, this.provider);
-    const onchainHookType: OnchainHookType = await hook.hookType();
-    this.logger.debug('Deriving HookConfig', { address, onchainHookType });
+    try {
+      const hook = IPostDispatchHook__factory.connect(address, this.provider);
 
-    switch (onchainHookType) {
-      case OnchainHookType.ROUTING:
-        return this.deriveDomainRoutingConfig(address);
-      case OnchainHookType.AGGREGATION:
-        return this.deriveAggregationConfig(address);
-      case OnchainHookType.MERKLE_TREE:
-        return this.deriveMerkleTreeConfig(address);
-      case OnchainHookType.INTERCHAIN_GAS_PAYMASTER:
-        return this.deriveIgpConfig(address);
-      case OnchainHookType.FALLBACK_ROUTING:
-        return this.deriveFallbackRoutingConfig(address);
-      case OnchainHookType.PAUSABLE:
-        return this.derivePausableConfig(address);
-      case OnchainHookType.PROTOCOL_FEE:
-        return this.deriveProtocolFeeConfig(address);
-      // ID_AUTH_ISM could be OPStackHook, ERC5164Hook or LayerZeroV2Hook
-      // For now assume it's OP_STACK
-      case OnchainHookType.ID_AUTH_ISM:
-        return this.deriveOpStackConfig(address);
-      default:
-        throw new Error(
-          `Unsupported HookType: ${OnchainHookType[onchainHookType]}`,
-        );
+      const onchainHookType = await hook.hookType();
+      this.logger.debug('Deriving HookConfig', { address, onchainHookType });
+
+      // Temporarily turn off SmartProvider logging
+      // Provider errors are expected because deriving will call methods that may not exist in the Bytecode
+      this.setSmartProviderLogLevel('silent');
+
+      switch (onchainHookType) {
+        case OnchainHookType.ROUTING:
+          return this.deriveDomainRoutingConfig(address);
+        case OnchainHookType.AGGREGATION:
+          return this.deriveAggregationConfig(address);
+        case OnchainHookType.MERKLE_TREE:
+          return this.deriveMerkleTreeConfig(address);
+        case OnchainHookType.INTERCHAIN_GAS_PAYMASTER:
+          return this.deriveIgpConfig(address);
+        case OnchainHookType.FALLBACK_ROUTING:
+          return this.deriveFallbackRoutingConfig(address);
+        case OnchainHookType.PAUSABLE:
+          return this.derivePausableConfig(address);
+        case OnchainHookType.PROTOCOL_FEE:
+          return this.deriveProtocolFeeConfig(address);
+        // ID_AUTH_ISM could be OPStackHook, ERC5164Hook or LayerZeroV2Hook
+        // For now assume it's OP_STACK
+        case OnchainHookType.ID_AUTH_ISM:
+          return this.deriveOpStackConfig(address);
+        default:
+          throw new Error(
+            `Unsupported HookType: ${OnchainHookType[onchainHookType]}`,
+          );
+      }
+    } catch (e) {
+      this.logger.debug(
+        `Hook deriving failed for hook: ${address} with error ${e}`,
+      );
+      return {} as DerivedHookConfig;
+    } finally {
+      this.setSmartProviderLogLevel(getLogLevel()); // returns to original level defined by rootLogger
     }
   }
 
@@ -344,5 +359,17 @@ export class EvmHookReader implements HookReader {
       paused,
       type: HookType.PAUSABLE,
     };
+  }
+
+  /**
+   * Conditionally sets the log level for a smart provider.
+   *
+   * @param level - The log level to set, e.g. 'debug', 'info', 'warn', 'error'.
+   */
+  protected setSmartProviderLogLevel(level: string) {
+    if ('setLogLevel' in this.provider) {
+      //@ts-ignore
+      this.provider.setLogLevel(level);
+    }
   }
 }


### PR DESCRIPTION
### Description
This PR fixes RPC errors when trying to send a test message using the CLI for older chains that don't have tokenType (e.g., `hyperlane send message --relay --origin fuji --destination betaop`)

Additional details: https://discord.com/channels/935678348330434570/1254873902480359435/1255215832959811687

### Backward compatibility
Yes

### Testing
- tested with `hyperlane warp deploy` and then `hyperlane warp send --relay --warp $HOME/.hyperlane/deployments/warp_routes/ETH/alfajores-betaop-config.yaml`
- tested `hyperlane send message --relay --origin fuji --destination betaop`
- tested `hyperlane send message --relay --origin alfrajores --destination betaop`
- tested `hyperlane send message --relay --origin holesky --destination betaop`
- tested `hyperlane core read --mailbox 0xEf9F292fcEBC3848bF4bB92a96a04F9ECBb78E59 --chain alfajores `

