### PR TITLE
fix: StorageGasOracle.sol constructor

### DIFF
--- a/solidity/contracts/hooks/igp/StorageGasOracle.sol
+++ b/solidity/contracts/hooks/igp/StorageGasOracle.sol
@@ -38,6 +38,9 @@ contract StorageGasOracle is IGasOracle, Ownable {
         uint128 gasPrice;
     }
 
+    // ============ Constructor ============
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
     // ============ External Functions ============
 
     /**


### PR DESCRIPTION
### Description

`StorageGasOracle` is `Ownable` and must have a constructor.

```
Compiler run failed:
Error (3415): No arguments passed to the base constructor. Specify the arguments or mark "StorageGasOracle" as abstract.
  --> solidity/contracts/hooks/igp/StorageGasOracle.sol:15:1:
   |
15 | contract StorageGasOracle is IGasOracle, Ownable {
   | ^ (Relevant source part starts here and spans across multiple lines).
Note: Base constructor parameters:
  --> node_modules/@openzeppelin/contracts/access/Ownable.sol:38:16:
   |
38 |     constructor(address initialOwner) {
   |                ^^^^^^^^^^^^^^^^^^^^^^
```