### PR TITLE
fix(e2e): hardcode kathy chains for e2e in send-test-messages.ts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,7 +188,7 @@ jobs:
 
   e2e-matrix:
     runs-on: larger-runner
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main') || github.event_name == 'merge_group'
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main' || github.base_ref == 'cli-2.0') || github.event_name == 'merge_group'
     needs: [yarn-build]
     strategy:
       matrix:
@@ -215,7 +215,7 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v2-${{ runner.os }}-rust-cache"
+          prefix-key: "v1-${{ runner.os }}-rust-cache"
           shared-key: ${{ matrix.e2e-type }}
           workspaces: |
             ./rust
@@ -266,7 +266,7 @@ jobs:
         working-directory: ./rust
         env:
           E2E_CI_MODE: 'true'
-          E2E_CI_TIMEOUT_SEC: '3600'
+          E2E_CI_TIMEOUT_SEC: '600'
           E2E_KATHY_MESSAGES: '20'
           RUST_BACKTRACE: 'full'
 
@@ -282,7 +282,7 @@ jobs:
 
   prebuild-cli-e2e:
     runs-on: larger-runner
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main') || github.event_name == 'merge_group'
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main' || github.base_ref == 'cli-2.0') || github.event_name == 'merge_group'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -331,7 +331,7 @@ jobs:
 
   cli-advanced-e2e:
     runs-on: larger-runner
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main') || github.event_name == 'merge_group'
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main' || github.base_ref == 'cli-2.0') || github.event_name == 'merge_group'
     needs: [yarn-build, prebuild-cli-e2e]
     strategy:
       matrix:

--- a/typescript/infra/scripts/send-test-messages.ts
+++ b/typescript/infra/scripts/send-test-messages.ts
@@ -102,6 +102,7 @@ async function main() {
 
   const signer = new Wallet(ANVIL_KEY);
   const multiProvider = MultiProvider.createTestMultiProvider({ signer });
+  delete multiProvider.metadata['test4'];
   const provider = multiProvider.getProvider(TestChainName.test1);
 
   const addresses = JSON.parse(

--- a/typescript/infra/scripts/send-test-messages.ts
+++ b/typescript/infra/scripts/send-test-messages.ts
@@ -103,13 +103,18 @@ async function main() {
   const { timeout, defaultHook, requiredHook, mineforever } = args;
   let messages = args.messages;
 
-  // Do not include test4 when creating the kathy multiprovider
+  // Limit the test chains to a subset of the known chains
+  // E2E in Rust only knows about test1, test2 and test3
   const kathyTestChains = [
     TestChainName.test1,
     TestChainName.test2,
     TestChainName.test3,
   ];
-  const { test4: _, ...kathyTestChainMetadata } = testChainMetadata;
+  const kathyTestChainMetadata = {
+    test1: testChainMetadata.test1,
+    test2: testChainMetadata.test2,
+    test3: testChainMetadata.test3,
+  };
 
   // Manually set up multiprovider for kathy test with our subset of test chains
   const signer = new Wallet(ANVIL_KEY);

--- a/typescript/sdk/src/consts/testChains.ts
+++ b/typescript/sdk/src/consts/testChains.ts
@@ -68,11 +68,6 @@ export const test3: ChainMetadata = {
 
 export const test4: ChainMetadata = {
   ...test1,
-  blocks: {
-    confirmations: 1,
-    estimateBlockTime: 3,
-    reorgPeriod: 2,
-  },
   chainId: 31337,
   displayName: 'Test 4',
   domainId: 31337,


### PR DESCRIPTION
resolves https://github.com/hyperlane-xyz/issues/issues/1291
- remove test4 from kathy test
- drive-by tidy-up of `test4` metadata
- resets e2e test timeout back to original figure
- reuse original e2e rust cache

gonna keep the original commits on here as a trail of thought