### PR TITLE
feat(infra): Add xERC20 limits monitoring capabilities

### DIFF
--- a/solidity/contracts/test/ERC20Test.sol
+++ b/solidity/contracts/test/ERC20Test.sol
@@ -86,6 +86,18 @@ contract XERC20Test is ERC20Test, IXERC20 {
     ) external view returns (uint256) {
         return type(uint256).max;
     }
+
+    function mintingMaxLimitOf(
+        address _bridge
+    ) external view returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function burningMaxLimitOf(
+        address _bridge
+    ) external view returns (uint256) {
+        return type(uint256).max;
+    }
 }
 
 contract XERC20LockboxTest is IXERC20Lockbox {

--- a/solidity/contracts/token/interfaces/IXERC20.sol
+++ b/solidity/contracts/token/interfaces/IXERC20.sol
@@ -54,4 +54,25 @@ interface IXERC20 is IERC20 {
     function mintingCurrentLimitOf(
         address _bridge
     ) external view returns (uint256 _limit);
+
+    /**
+     * @notice Returns the max limit of a minter
+     *
+     * @param _minter The minter we are viewing the limits of
+     *  @return _limit The limit the minter has
+     */
+    function mintingMaxLimitOf(
+        address _minter
+    ) external view returns (uint256 _limit);
+
+    /**
+     * @notice Returns the max limit of a bridge
+     *
+     * @param _bridge the bridge we are viewing the limits of
+     * @return _limit The limit the bridge has
+     */
+
+    function burningMaxLimitOf(
+        address _bridge
+    ) external view returns (uint256 _limit);
 }

--- a/typescript/infra/config/environments/mainnet3/warp/EZETH-deployments.yaml
+++ b/typescript/infra/config/environments/mainnet3/warp/EZETH-deployments.yaml
@@ -1,0 +1,12 @@
+description: Hyperlane Warp Route artifacts
+timestamp: '2024-04-15T16:00:00.000Z'
+deployer: Abacus Works (Hyperlane)
+data:
+  config:
+    bsc:
+      protocolType: ethereum
+      type: xERC20
+      name: Renzo Restaked ETH
+      symbol: ezETH
+      hypAddress: '0x6266e803057fa68C35018C3FB0B59db7129C23BB'
+      decimals: 18

--- a/typescript/infra/config/environments/mainnet3/warp/EZETH-deployments.yaml
+++ b/typescript/infra/config/environments/mainnet3/warp/EZETH-deployments.yaml
@@ -1,12 +1,69 @@
 description: Hyperlane Warp Route artifacts
-timestamp: '2024-04-15T16:00:00.000Z'
+timestamp: '2024-06-04T16:00:00.000Z'
 deployer: Abacus Works (Hyperlane)
 data:
   config:
+    ethereum:
+      protocolType: ethereum
+      type: xERC20Lockbox
+      name: Renzo Restaked ETH
+      symbol: ezETH
+      hypAddress: '0xdFf621F952c23972dFD3A9E5d7B9f6339e9c078B'
+      tokenAddress: '0x2416092f143378750bb29b79eD961ab195CcEea5'
+      decimals: 18
     bsc:
       protocolType: ethereum
       type: xERC20
       name: Renzo Restaked ETH
       symbol: ezETH
       hypAddress: '0x6266e803057fa68C35018C3FB0B59db7129C23BB'
+      tokenAddress: '0x2416092f143378750bb29b79eD961ab195CcEea5'
+      decimals: 18
+    arbitrum:
+      protocolType: ethereum
+      type: xERC20
+      name: Renzo Restaked ETH
+      symbol: ezETH
+      hypAddress: '0xC8F280d3eC30746f77c28695827d309d16939BF1'
+      tokenAddress: '0x2416092f143378750bb29b79eD961ab195CcEea5'
+      decimals: 18
+    optimism:
+      protocolType: ethereum
+      type: xERC20
+      name: Renzo Restaked ETH
+      symbol: ezETH
+      hypAddress: '0x1d1a210E71398c17FD7987eDF1dc347539bB541F'
+      tokenAddress: '0x2416092f143378750bb29b79eD961ab195CcEea5'
+      decimals: 18
+    base:
+      protocolType: ethereum
+      type: xERC20
+      name: Renzo Restaked ETH
+      symbol: ezETH
+      hypAddress: '0x584BA77ec804f8B6A559D196661C0242C6844F49'
+      tokenAddress: '0x2416092f143378750bb29b79eD961ab195CcEea5'
+      decimals: 18
+    blast:
+      protocolType: ethereum
+      type: xERC20
+      name: Renzo Restaked ETH
+      symbol: ezETH
+      hypAddress: '0x8C603c6BDf8a9d548fC5D2995750Cc25eF59183b'
+      tokenAddress: '0x2416092f143378750bb29b79eD961ab195CcEea5'
+      decimals: 18
+    mode:
+      protocolType: ethereum
+      type: xERC20
+      name: Renzo Restaked ETH
+      symbol: ezETH
+      hypAddress: '0xcd95B8dF351400BF4cbAb340b6EfF2454aDB299E'
+      tokenAddress: '0x2416092f143378750bb29b79eD961ab195CcEea5'
+      decimals: 18
+    linea:
+      protocolType: ethereum
+      type: xERC20
+      name: Renzo Restaked ETH
+      symbol: ezETH
+      hypAddress: '0xcd95B8dF351400BF4cbAb340b6EfF2454aDB299E'
+      tokenAddress: '0x2416092f143378750bb29b79eD961ab195CcEea5'
       decimals: 18

--- a/typescript/infra/scripts/warp-routes/monitor-warp-routes-balances.ts
+++ b/typescript/infra/scripts/warp-routes/monitor-warp-routes-balances.ts
@@ -90,7 +90,7 @@ async function main(): Promise<boolean> {
   const tokenConfig: WarpRouteConfig =
     readWarpRouteConfig(filePath).data.config;
 
-  // await checkTokenBalances(checkFrequency, tokenConfig);
+  await checkTokenBalances(checkFrequency, tokenConfig);
 
   if (
     Object.values(tokenConfig).some((token) => token.type === TokenType.XERC20)
@@ -366,7 +366,6 @@ async function checkXERC20Limits(checkFrequency: number) {
 
   setInterval(async () => {
     try {
-      logger.info('Checking xERC20 limits');
       const xERC20Limits = await getXerc20Limits(warpCoreConfig, multiProvider);
       logger.info('xERC20 Limits:', xERC20Limits);
       updateXERC20LimitsMetrics(xERC20Limits);

--- a/typescript/infra/scripts/warp-routes/monitor-warp-routes-balances.ts
+++ b/typescript/infra/scripts/warp-routes/monitor-warp-routes-balances.ts
@@ -90,12 +90,13 @@ async function main(): Promise<boolean> {
   const tokenConfig: WarpRouteConfig =
     readWarpRouteConfig(filePath).data.config;
 
-  await checkTokenBalances(checkFrequency, tokenConfig);
-
+  // TODO: eventually support token balance checks for xERC20 token type
   if (
     Object.values(tokenConfig).some((token) => token.type === TokenType.XERC20)
   ) {
     await checkXERC20Limits(checkFrequency);
+  } else {
+    await checkTokenBalances(checkFrequency, tokenConfig);
   }
 
   return true;
@@ -344,11 +345,11 @@ function getXerc20Limits(
 async function checkXERC20Limits(checkFrequency: number) {
   const registry = await getRegistry();
   const symbol = 'EZETH';
-  const matching = await registry.getWarpRoutes({
+  const EZETHWarpRouteConfigMap = await registry.getWarpRoutes({
     symbol,
   });
 
-  const routes = Object.entries(matching);
+  const routes = Object.entries(EZETHWarpRouteConfigMap);
 
   let warpCoreConfig: WarpCoreConfig;
   if (routes.length === 0) {


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

- Add support for pushing limits metrics for xERC20 wrap routes
- For now only push limits metrics for xERC20 wrap routes, not yet supporting warp route balances 

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->
 - Fixes #4047 
### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
Manual