### PR TITLE
fix: Remove extra fields in warp core config

### DIFF
--- a/.changeset/quiet-ways-pay.md
+++ b/.changeset/quiet-ways-pay.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Remove extra fields from warp core config

--- a/typescript/utils/src/validation.ts
+++ b/typescript/utils/src/validation.ts
@@ -1,7 +1,7 @@
 export function assert<T>(
   predicate: T,
   errorMessage?: string,
-): asserts predicate is NonNullable<T> {
+): asserts predicate {
   if (!predicate) {
     throw new Error(errorMessage ?? 'Error');
   }


### PR DESCRIPTION
### Description

Remove extra fields in warp core configs.

Context: https://github.com/hyperlane-xyz/hyperlane-registry/pull/73
Discussion: https://discord.com/channels/935678348330434570/1255901895503908934

### Drive-by changes

Improve type assertion of `assert` util

### Backward compatibility

Yes

### Testing

Took configs from CLI e2e test artifact and tested it in registry CI.
