### PR TITLE
chore: bump Solana-origin nautilus fees

### DIFF
--- a/rust/sealevel/environments/mainnet2/gas-oracle-configs.json
+++ b/rust/sealevel/environments/mainnet2/gas-oracle-configs.json
@@ -4,7 +4,7 @@
         "gasOracle": {
             "type": "remoteGasData",
             "tokenExchangeRate": "100000000000000000000",
-            "gasPrice": "3000000000",
+            "gasPrice": "300000000000",
             "tokenDecimals": 18
         }
     },
@@ -12,8 +12,8 @@
         "domain": 22222,
         "gasOracle": {
             "type": "remoteGasData",
-            "tokenExchangeRate": "4700000000000000",
-            "gasPrice": "1000000000",
+            "tokenExchangeRate": "6010517751000000",
+            "gasPrice": "3000000000000",
             "tokenDecimals": 18
         }
     }

--- a/rust/sealevel/environments/mainnet2/gas-oracle-configs.json
+++ b/rust/sealevel/environments/mainnet2/gas-oracle-configs.json
@@ -13,7 +13,7 @@
         "gasOracle": {
             "type": "remoteGasData",
             "tokenExchangeRate": "6010517751000000",
-            "gasPrice": "3000000000000",
+            "gasPrice": "12000000000000",
             "tokenDecimals": 18
         }
     }


### PR DESCRIPTION
### Description

Solana-origin fees to Nautilus are now about 25 cents. It used to be sub-cent. Nautilus origin is about 71 cents (37.889581133408400000 ZBC) at the moment, so this is left untouched.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
