### PR TITLE
fix: use sortMapEntries in writeYaml

### DIFF
--- a/.changeset/five-timers-reflect.md
+++ b/.changeset/five-timers-reflect.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Fix the missing sorting in the YAML file generated

--- a/typescript/cli/src/config/chain.ts
+++ b/typescript/cli/src/config/chain.ts
@@ -95,7 +95,7 @@ export async function createChainConfig({
 
   const parseResult = ChainMetadataSchema.safeParse(metadata);
   if (parseResult.success) {
-    logGreen(`Chain config is valid, writing sorted to registry:`);
+    logGreen(`Chain config is valid, writing unsorted to registry:`);
     const metadataYaml = yamlStringify(metadata, {
       indent: 2,
       sortMapEntries: true,

--- a/typescript/cli/src/config/chain.ts
+++ b/typescript/cli/src/config/chain.ts
@@ -95,8 +95,11 @@ export async function createChainConfig({
 
   const parseResult = ChainMetadataSchema.safeParse(metadata);
   if (parseResult.success) {
-    logGreen(`Chain config is valid, writing to registry:`);
-    const metadataYaml = yamlStringify(metadata, null, 2);
+    logGreen(`Chain config is valid, writing sorted to registry:`);
+    const metadataYaml = yamlStringify(metadata, {
+      indent: 2,
+      sortMapEntries: true,
+    });
     log(indentYamlOrJson(metadataYaml, 4));
     await context.registry.updateChain({ chainName: metadata.name, metadata });
   } else {

--- a/typescript/cli/src/utils/files.ts
+++ b/typescript/cli/src/utils/files.ts
@@ -90,7 +90,10 @@ export function tryReadYamlAtPath<T>(filepath: string): T | null {
 }
 
 export function writeYaml(filepath: string, obj: any) {
-  writeFileAtPath(filepath, yamlStringify(obj, null, 2) + '\n');
+  writeFileAtPath(
+    filepath,
+    yamlStringify(obj, { indent: 2, sortMapEntries: true }) + '\n',
+  );
 }
 
 export function mergeYaml<T extends Record<string, any>>(


### PR DESCRIPTION
### Description

It includes usage of sortMapEntries option in yamlStringify function called in writeYaml function.

### Drive-by changes

None

### Related issues

- Fixes #4057 

### Backward compatibility

Yes
Because I've converted the argument 2 into the indent option as documented in yaml library.

### Testing

Manual by trying to reproduce the issue in the same way.
