### PR TITLE
chore: Revert "feat(hyp-ethereum): gas escalator middleware (#3852)"

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2725,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-06-27-2#df3510cdfdd18ee6e6e9b0d7bad61f405c8abc49"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-04-25#361b69b9561e11eb3cf8000a51de1985e2571785"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -2739,7 +2739,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-06-27-2#df3510cdfdd18ee6e6e9b0d7bad61f405c8abc49"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-04-25#361b69b9561e11eb3cf8000a51de1985e2571785"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -2750,7 +2750,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-06-27-2#df3510cdfdd18ee6e6e9b0d7bad61f405c8abc49"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-04-25#361b69b9561e11eb3cf8000a51de1985e2571785"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -2768,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-06-27-2#df3510cdfdd18ee6e6e9b0d7bad61f405c8abc49"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-04-25#361b69b9561e11eb3cf8000a51de1985e2571785"
 dependencies = [
  "Inflector",
  "cfg-if",
@@ -2792,7 +2792,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-06-27-2#df3510cdfdd18ee6e6e9b0d7bad61f405c8abc49"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-04-25#361b69b9561e11eb3cf8000a51de1985e2571785"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -2806,7 +2806,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-06-27-2#df3510cdfdd18ee6e6e9b0d7bad61f405c8abc49"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-04-25#361b69b9561e11eb3cf8000a51de1985e2571785"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -2836,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-06-27-2#df3510cdfdd18ee6e6e9b0d7bad61f405c8abc49"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-04-25#361b69b9561e11eb3cf8000a51de1985e2571785"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.12",
@@ -2852,7 +2852,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-06-27-2#df3510cdfdd18ee6e6e9b0d7bad61f405c8abc49"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-04-25#361b69b9561e11eb3cf8000a51de1985e2571785"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -2900,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-06-27-2#df3510cdfdd18ee6e6e9b0d7bad61f405c8abc49"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-04-25#361b69b9561e11eb3cf8000a51de1985e2571785"
 dependencies = [
  "async-trait",
  "auto_impl 1.1.0",
@@ -2936,7 +2936,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-06-27-2#df3510cdfdd18ee6e6e9b0d7bad61f405c8abc49"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-04-25#361b69b9561e11eb3cf8000a51de1985e2571785"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -4086,7 +4086,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -197,27 +197,27 @@ cosmwasm-schema = "1.2.7"
 [workspace.dependencies.ethers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-06-27-2"
+tag = "2024-04-25"
 
 [workspace.dependencies.ethers-contract]
 features = ["legacy"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-06-27-2"
+tag = "2024-04-25"
 
 [workspace.dependencies.ethers-core]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-06-27-2"
+tag = "2024-04-25"
 
 [workspace.dependencies.ethers-providers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-06-27-2"
+tag = "2024-04-25"
 
 [workspace.dependencies.ethers-signers]
 features = ["aws"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-06-27-2"
+tag = "2024-04-25"
 
 [patch.crates-io.curve25519-dalek]
 branch = "v3.2.2-relax-zeroize"

--- a/rust/chains/hyperlane-ethereum/src/tx.rs
+++ b/rust/chains/hyperlane-ethereum/src/tx.rs
@@ -44,7 +44,8 @@ where
         .cloned()
         .unwrap_or_else(|| NameOrAddress::Address(Default::default()));
 
-    info!(?to, %data, tx=?tx.tx, "Dispatching transaction");
+    info!(?to, %data, "Dispatching transaction");
+    // We can set the gas higher here!
     let dispatch_fut = tx.send();
     let dispatched = dispatch_fut
         .await?

--- a/rust/ethers-prometheus/src/middleware/mod.rs
+++ b/rust/ethers-prometheus/src/middleware/mod.rs
@@ -227,6 +227,7 @@ impl<M: Middleware> Middleware for PrometheusMiddleware<M> {
     ) -> Result<PendingTransaction<'_, Self::Provider>, Self::Error> {
         let start = Instant::now();
         let tx: TypedTransaction = tx.into();
+
         let chain = {
             let data = self.conf.read().await;
             chain_name(&data.chain).to_owned()

--- a/rust/utils/run-locally/src/invariants.rs
+++ b/rust/utils/run-locally/src/invariants.rs
@@ -80,12 +80,9 @@ pub fn termination_invariants_met(
     // EDIT: Having had a quick look, it seems like there are some legitimate reverts happening in the confirm step
     // (`Transaction attempting to process message either reverted or was reorged`)
     // in which case more gas expenditure logs than messages are expected.
-    let gas_expenditure_log_count = log_counts.get(GAS_EXPENDITURE_LOG_MESSAGE).unwrap();
     assert!(
-        gas_expenditure_log_count >= &total_messages_expected,
-        "Didn't record gas payment for all delivered messages. Got {} gas payment logs, expected at least {}",
-        gas_expenditure_log_count,
-        total_messages_expected
+        log_counts.get(GAS_EXPENDITURE_LOG_MESSAGE).unwrap() >= &total_messages_expected,
+        "Didn't record gas payment for all delivered messages"
     );
     // These tests check that we fixed https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3915, where some logs would not show up
     assert!(


### PR DESCRIPTION
This reverts commit c3c002a8fe4870c7e462cd5073365a7f9a2235bc.

### Description

The gas escalator took up to 28gb of memory, and even though it was only ever released on RC, it must have taken up too many cluster resources, ending up starving the `hyperlane` relayer. Reverting for now until we have a better idea

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
