### PR TITLE
feat(sdk): Handle subdirectories for the folder in S3Validator

### DIFF
--- a/.changeset/tiny-lions-kiss.md
+++ b/.changeset/tiny-lions-kiss.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Handle subdirectories for the folder in S3Validator class

--- a/typescript/sdk/src/aws/validator.ts
+++ b/typescript/sdk/src/aws/validator.ts
@@ -39,7 +39,7 @@ export class S3Validator extends BaseValidator {
         const s3Config = {
           bucket: pieces[0],
           region: pieces[1],
-          folder: pieces[2],
+          folder: pieces.slice(2).join('/'),
           caching: true,
         };
         const s3Bucket = new S3Wrapper(s3Config);


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

- Set the folder in the `S3Config` to include any subdirectories and not just the first folder
- This brings the SDK inline with current behavior in the agents

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

- Fixes #4100 

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

Yes

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->

Manual