### PR TITLE
chore(infra): strongly type `AgentChainConfig`

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -19,7 +19,10 @@ import { getDomainId } from '../../registry.js';
 
 import { environment } from './chains.js';
 import { helloWorld } from './helloworld.js';
-import { supportedChainNames } from './supportedChainNames.js';
+import {
+  mainnet3SupportedChainNames,
+  supportedChainNames,
+} from './supportedChainNames.js';
 import { validatorChainConfig } from './validators.js';
 import ancient8EthereumUsdcAddresses from './warp/ancient8-USDC-addresses.json';
 import arbitrumTIAAddresses from './warp/arbitrum-TIA-addresses.json';
@@ -33,9 +36,9 @@ import victionEthereumEthAddresses from './warp/viction-ETH-addresses.json';
 import victionEthereumUsdcAddresses from './warp/viction-USDC-addresses.json';
 import victionEthereumUsdtAddresses from './warp/viction-USDT-addresses.json';
 
-const releaseCandidateHelloworldMatchingList = routerMatchingList(
-  helloWorld[Contexts.ReleaseCandidate].addresses,
-);
+// const releaseCandidateHelloworldMatchingList = routerMatchingList(
+//   helloWorld[Contexts.ReleaseCandidate].addresses,
+// );
 
 const repo = 'gcr.io/abacus-labs-dev/hyperlane-agent';
 
@@ -44,7 +47,9 @@ const repo = 'gcr.io/abacus-labs-dev/hyperlane-agent';
 //
 // This is intentionally separate and not derived from the environment's supportedChainNames
 // to allow for more fine-grained control over which chains are enabled for each agent role.
-export const hyperlaneContextAgentChainConfig: AgentChainConfig = {
+export const hyperlaneContextAgentChainConfig: AgentChainConfig<
+  typeof mainnet3SupportedChainNames
+> = {
   // Generally, we run all production validators in the Hyperlane context.
   [Role.Validator]: {
     arbitrum: true,
@@ -150,7 +155,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig = {
 
 export const hyperlaneContextAgentChainNames = getAgentChainNamesFromConfig(
   hyperlaneContextAgentChainConfig,
-  supportedChainNames,
+  mainnet3SupportedChainNames,
 );
 
 const contextBase = {

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -15,7 +15,10 @@ import { Contexts } from '../../contexts.js';
 
 import { environment } from './chains.js';
 import { helloWorld } from './helloworld.js';
-import { supportedChainNames } from './supportedChainNames.js';
+import {
+  supportedChainNames,
+  testnet4SupportedChainNames,
+} from './supportedChainNames.js';
 import { validatorChainConfig } from './validators.js';
 import plumetestnetSepoliaAddresses from './warp/plumetestnet-sepolia-addresses.json';
 
@@ -30,7 +33,9 @@ const repo = 'gcr.io/abacus-labs-dev/hyperlane-agent';
 //
 // This is intentionally separate and not derived from the environment's supportedChainNames
 // to allow for more fine-grained control over which chains are enabled for each agent role.
-export const hyperlaneContextAgentChainConfig: AgentChainConfig = {
+export const hyperlaneContextAgentChainConfig: AgentChainConfig<
+  typeof testnet4SupportedChainNames
+> = {
   [Role.Validator]: {
     alfajores: true,
     bsctestnet: true,
@@ -70,7 +75,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig = {
 
 export const hyperlaneContextAgentChainNames = getAgentChainNamesFromConfig(
   hyperlaneContextAgentChainConfig,
-  supportedChainNames,
+  testnet4SupportedChainNames,
 );
 
 const contextBase = {

--- a/typescript/infra/src/config/agent/agent.ts
+++ b/typescript/infra/src/config/agent/agent.ts
@@ -2,7 +2,6 @@ import {
   AgentChainMetadata,
   AgentSignerAwsKey,
   AgentSignerKeyType,
-  ChainMap,
   ChainName,
   RpcConsensusType,
 } from '@hyperlane-xyz/sdk';
@@ -220,12 +219,15 @@ export function defaultChainSignerKeyConfig(chainName: ChainName): KeyConfig {
   }
 }
 
-export type AgentChainConfig = Record<AgentRole, ChainMap<boolean>>;
+export type AgentChainConfig<SupportedChains extends readonly ChainName[]> =
+  Record<AgentRole, Record<SupportedChains[number], boolean>>;
 
 /// Converts an AgentChainConfig to an AgentChainNames object.
-export function getAgentChainNamesFromConfig(
-  config: AgentChainConfig,
-  supportedChainNames: ChainName[],
+export function getAgentChainNamesFromConfig<
+  SupportedChains extends readonly ChainName[],
+>(
+  config: AgentChainConfig<SupportedChains>,
+  supportedChainNames: SupportedChains,
 ): AgentChainNames {
   ensureAgentChainConfigIncludesAllChainNames(config, supportedChainNames);
 
@@ -237,9 +239,11 @@ export function getAgentChainNamesFromConfig(
 }
 
 // Throws if any of the roles in the config do not have all the expected chain names.
-export function ensureAgentChainConfigIncludesAllChainNames(
-  config: AgentChainConfig,
-  expectedChainNames: ChainName[],
+export function ensureAgentChainConfigIncludesAllChainNames<
+  SupportedChains extends readonly ChainName[],
+>(
+  config: AgentChainConfig<SupportedChains>,
+  expectedChainNames: SupportedChains,
 ) {
   for (const [role, roleConfig] of Object.entries(config)) {
     const chainNames = Object.keys(roleConfig);

--- a/typescript/infra/test/agent-configs.test.ts
+++ b/typescript/infra/test/agent-configs.test.ts
@@ -1,11 +1,14 @@
 import { expect } from 'chai';
 
 import { hyperlaneContextAgentChainConfig as mainnet3AgentChainConfig } from '../config/environments/mainnet3/agent.js';
-import { supportedChainNames as mainnet3SupportedChainNames } from '../config/environments/mainnet3/supportedChainNames.js';
+import { mainnet3SupportedChainNames } from '../config/environments/mainnet3/supportedChainNames.js';
 import { hyperlaneContextAgentChainConfig as testnet4AgentChainConfig } from '../config/environments/testnet4/agent.js';
-import { supportedChainNames as testnet4SupportedChainNames } from '../config/environments/testnet4/supportedChainNames.js';
+import { testnet4SupportedChainNames } from '../config/environments/testnet4/supportedChainNames.js';
 import { getAgentConfigJsonPath } from '../scripts/agent-utils.js';
-import { ensureAgentChainConfigIncludesAllChainNames } from '../src/config/agent/agent.js';
+import {
+  AgentChainConfig,
+  ensureAgentChainConfigIncludesAllChainNames,
+} from '../src/config/agent/agent.js';
 import { AgentEnvironment } from '../src/config/environment.js';
 import { readJSONAtPath } from '../src/utils/utils.js';
 
@@ -34,7 +37,9 @@ describe('Agent configs', () => {
       it('AgentChainConfig specifies all chains for each role in the agent chain config', () => {
         // This will throw if there are any inconsistencies
         ensureAgentChainConfigIncludesAllChainNames(
-          config.agentChainConfig,
+          config.agentChainConfig as AgentChainConfig<
+            typeof config.supportedChainNames
+          >,
           config.supportedChainNames,
         );
       });


### PR DESCRIPTION
- follow on from https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4093
- ts errors in editor if a chain is missing from the config
- makes it easier to update `ValidatorBaseChainConfigMap` in future

one chain missing:
<img width="298" alt="image" src="https://github.com/hyperlane-xyz/hyperlane-monorepo/assets/10051819/0e3c6247-3967-4caa-afad-f7a16234a029">

multiple chains missing:
<img width="310" alt="image" src="https://github.com/hyperlane-xyz/hyperlane-monorepo/assets/10051819/241782ca-16a4-4b17-9873-706485e26649">
