### PR TITLE
chore: Bump registry version to 2.3.0

### DIFF
--- a/.changeset/purple-cherries-clean.md
+++ b/.changeset/purple-cherries-clean.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Improve chain metadata and address fetching from github registries

--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@aws-sdk/client-kms": "^3.577.0",
     "@aws-sdk/client-s3": "^3.577.0",
-    "@hyperlane-xyz/registry": "2.1.1",
+    "@hyperlane-xyz/registry": "2.3.0",
     "@hyperlane-xyz/sdk": "4.1.0",
     "@hyperlane-xyz/utils": "4.1.0",
     "@inquirer/prompts": "^3.0.0",

--- a/typescript/helloworld/package.json
+++ b/typescript/helloworld/package.json
@@ -4,7 +4,7 @@
   "version": "4.1.0",
   "dependencies": {
     "@hyperlane-xyz/core": "4.1.0",
-    "@hyperlane-xyz/registry": "2.1.1",
+    "@hyperlane-xyz/registry": "2.3.0",
     "@hyperlane-xyz/sdk": "4.1.0",
     "@openzeppelin/contracts-upgradeable": "^4.9.3",
     "ethers": "^5.7.2"

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -14,7 +14,7 @@
     "@ethersproject/providers": "^5.7.2",
     "@google-cloud/secret-manager": "^5.5.0",
     "@hyperlane-xyz/helloworld": "4.1.0",
-    "@hyperlane-xyz/registry": "2.1.1",
+    "@hyperlane-xyz/registry": "2.3.0",
     "@hyperlane-xyz/sdk": "4.1.0",
     "@hyperlane-xyz/utils": "4.1.0",
     "@nomiclabs/hardhat-etherscan": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5695,7 +5695,7 @@ __metadata:
     "@aws-sdk/client-s3": "npm:^3.577.0"
     "@ethersproject/abi": "npm:*"
     "@ethersproject/providers": "npm:*"
-    "@hyperlane-xyz/registry": "npm:2.1.1"
+    "@hyperlane-xyz/registry": "npm:2.3.0"
     "@hyperlane-xyz/sdk": "npm:4.1.0"
     "@hyperlane-xyz/utils": "npm:4.1.0"
     "@inquirer/prompts": "npm:^3.0.0"
@@ -5788,7 +5788,7 @@ __metadata:
   resolution: "@hyperlane-xyz/helloworld@workspace:typescript/helloworld"
   dependencies:
     "@hyperlane-xyz/core": "npm:4.1.0"
-    "@hyperlane-xyz/registry": "npm:2.1.1"
+    "@hyperlane-xyz/registry": "npm:2.3.0"
     "@hyperlane-xyz/sdk": "npm:4.1.0"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
     "@nomiclabs/hardhat-waffle": "npm:^2.0.6"
@@ -5837,7 +5837,7 @@ __metadata:
     "@ethersproject/providers": "npm:^5.7.2"
     "@google-cloud/secret-manager": "npm:^5.5.0"
     "@hyperlane-xyz/helloworld": "npm:4.1.0"
-    "@hyperlane-xyz/registry": "npm:2.1.1"
+    "@hyperlane-xyz/registry": "npm:2.3.0"
     "@hyperlane-xyz/sdk": "npm:4.1.0"
     "@hyperlane-xyz/utils": "npm:4.1.0"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
@@ -5890,13 +5890,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/registry@npm:2.1.1":
-  version: 2.1.1
-  resolution: "@hyperlane-xyz/registry@npm:2.1.1"
+"@hyperlane-xyz/registry@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@hyperlane-xyz/registry@npm:2.3.0"
   dependencies:
     yaml: "npm:^2"
     zod: "npm:^3.21.2"
-  checksum: e0e1f36b9bc43dfb1e4f7c512091b31c6f1b4046687d076fc16c91fd9204af1bdbe7898c8c29ada3c6830f6961bb5aa0933357b73d500595689171f99b992922
+  checksum: c74a7201ef3114f7ff8e055e31592612cb881c6945d498afbe906f45e3d25acd73ee785f3101f6b2dc2bcd3a625142611ad4c5424ab59a5783b4c15d3253e4d6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Update to latest registry for faster and more efficient chain metadata/address fetching

### Related issues

https://github.com/hyperlane-xyz/hyperlane-registry/issues/29


### Backward compatibility

Yes

### Testing

Ran CLI registry commands locally