### PR TITLE
fix(sdk): Renzo Fraxtal Deploy Fixes

### DIFF
--- a/.changeset/nice-planes-kiss.md
+++ b/.changeset/nice-planes-kiss.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Add 'isInitialized' check before initializing implementation contract (for contracts that disableInitializers in constructors).

--- a/typescript/infra/scripts/generate-renzo-warp-route-config.ts
+++ b/typescript/infra/scripts/generate-renzo-warp-route-config.ts
@@ -15,6 +15,8 @@ import { symmetricDifference } from '@hyperlane-xyz/utils';
 const lockbox = '0xC8140dA31E6bCa19b287cC35531c2212763C2059';
 const xERC20 = '0x2416092f143378750bb29b79eD961ab195CcEea5';
 const lockboxChain = 'ethereum';
+// over the default 100k to account for xerc20 gas + ISM overhead over the default ISM https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/49f41d9759fd515bfd89e6e22e799c41b27b4119/typescript/sdk/src/router/GasRouterDeployer.ts#L14
+const warpRouteOverheadGas = 200_000;
 
 const chainsToDeploy = [
   'arbitrum',
@@ -123,6 +125,7 @@ async function main() {
                     : TokenType.XERC20,
                 token: chain === lockboxChain ? lockbox : xERC20,
                 owner: zeroAddress,
+                gas: warpRouteOverheadGas,
                 mailbox: (await registry.getChainAddresses(chain))!.mailbox,
                 interchainSecurityModule: {
                   type: IsmType.AGGREGATION,

--- a/typescript/infra/scripts/generate-renzo-warp-route-config.ts
+++ b/typescript/infra/scripts/generate-renzo-warp-route-config.ts
@@ -10,6 +10,7 @@ import {
   WarpRouteDeployConfigSchema,
   buildAggregationIsmConfigs,
 } from '@hyperlane-xyz/sdk';
+import { symmetricDifference } from '@hyperlane-xyz/utils';
 
 const lockbox = '0xC8140dA31E6bCa19b287cC35531c2212763C2059';
 const xERC20 = '0x2416092f143378750bb29b79eD961ab195CcEea5';
@@ -24,6 +25,7 @@ const chainsToDeploy = [
   'mode',
   'linea',
   'ethereum',
+  'fraxtal',
 ];
 
 const ezEthValidators = {
@@ -83,12 +85,29 @@ const ezEthValidators = {
       '0x1fd889337F60986aa57166bc5AC121eFD13e4fdd', // Everclear
     ],
   },
+  fraxtal: {
+    threshold: 1,
+    validators: [
+      '0xe986f457965227A05DCF984C8d0C29e01253c44d', // Renzo
+      '0x25B3A88f7CfD3C9F7d7e32b295673A16a6Ddbd91', // luganodes
+    ],
+  },
 };
 const zeroAddress = '0x0000000000000000000000000000000000000001';
 
 async function main() {
   const registry = new GithubRegistry();
-
+  const diff = symmetricDifference(
+    new Set(chainsToDeploy),
+    new Set(Object.keys(ezEthValidators)),
+  );
+  if (diff.size > 0) {
+    throw new Error(
+      `chainsToDeploy !== validatorConfig, diff is ${Array.from(diff).join(
+        ', ',
+      )}`,
+    );
+  }
   const tokenConfig: WarpRouteDeployConfig =
     Object.fromEntries<TokenRouterConfig>(
       await Promise.all(

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -407,7 +407,7 @@ export abstract class HyperlaneDeployer<
         )
       ) {
         this.logger.debug(
-          'Skipping: Contract ${contractName} (${contract.address}) on ${chain} is already initialized',
+          `Skipping: Contract ${contractName} (${contract.address}) on ${chain} is already initialized`,
         );
       } else {
         this.logger.debug(

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -410,7 +410,7 @@ export abstract class HyperlaneDeployer<
           'Skipping: Contract ${contractName} (${contract.address}) on ${chain} is already initialized',
         );
       } else {
-        this.logger.debug(`Initialize ${contractName} on ${chain}`);
+        this.logger.debug(`Initializing ${contractName} (${contract.address}) on ${chain}...`);
         const overrides = this.multiProvider.getTransactionOverrides(chain);
         const initTx = await contract.initialize(...initializeArgs, overrides);
         await this.multiProvider.handleTx(chain, initTx);

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -410,11 +410,15 @@ export abstract class HyperlaneDeployer<
           'Skipping: Contract ${contractName} (${contract.address}) on ${chain} is already initialized',
         );
       } else {
-        this.logger.debug(`Initializing ${contractName} (${contract.address}) on ${chain}...`);
+        this.logger.debug(
+          `Initializing ${contractName} (${contract.address}) on ${chain}...`,
+        );
         const overrides = this.multiProvider.getTransactionOverrides(chain);
         const initTx = await contract.initialize(...initializeArgs, overrides);
         const receipt = await this.multiProvider.handleTx(chain, initTx);
-        this.logger.debug(`Successfully initialized ${contractName} (${contract.address}) on ${chain}: ${receipt.transactionHash});
+        this.logger.debug(
+          `Successfully initialized ${contractName} (${contract.address}) on ${chain}: ${receipt.transactionHash}`,
+        );
       }
     }
 

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -407,7 +407,7 @@ export abstract class HyperlaneDeployer<
         )
       ) {
         this.logger.debug(
-          'Skipping initialization because contract is already initialized',
+          'Skipping: Contract ${contractName} (${contract.address}) on ${chain} is already initialized',
         );
       } else {
         this.logger.debug(`Initialize ${contractName} on ${chain}`);

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -413,7 +413,8 @@ export abstract class HyperlaneDeployer<
         this.logger.debug(`Initializing ${contractName} (${contract.address}) on ${chain}...`);
         const overrides = this.multiProvider.getTransactionOverrides(chain);
         const initTx = await contract.initialize(...initializeArgs, overrides);
-        await this.multiProvider.handleTx(chain, initTx);
+        const receipt = await this.multiProvider.handleTx(chain, initTx);
+        this.logger.debug(`Successfully initialized ${contractName} (${contract.address}) on ${chain}: ${receipt.transactionHash});
       }
     }
 

--- a/typescript/sdk/src/deploy/proxy.ts
+++ b/typescript/sdk/src/deploy/proxy.ts
@@ -25,6 +25,18 @@ export async function proxyImplementation(
   return ethers.utils.getAddress(storageValue.slice(26));
 }
 
+export async function isInitialized(
+  provider: ethers.providers.Provider,
+  contract: Address,
+): Promise<boolean> {
+  // Using OZ's Initializable 4.9 which keeps it at the 0x0 slot
+  const storageValue = await provider.getStorageAt(contract, '0x0');
+  return (
+    storageValue ===
+    '0x00000000000000000000000000000000000000000000000000000000000000ff'
+  );
+}
+
 export async function proxyAdmin(
   provider: ethers.providers.Provider,
   proxy: Address,

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
@@ -344,6 +344,7 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
           new DefaultFallbackRoutingIsm__factory(),
           [mailbox],
         );
+        // TODO: Should verify contract here
         logger.debug('Initialising fallback routing ISM ...');
         receipt = await this.multiProvider.handleTx(
           destination,
@@ -374,6 +375,7 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
             gasLimit: estimatedGas.add(estimatedGas.div(10)), // 10% buffer
           },
         );
+        // TODO: Should verify contract here
         receipt = await this.multiProvider.handleTx(destination, tx);
 
         // TODO: Break this out into a generalized function


### PR DESCRIPTION
### Description

- Initialized check before initializing implementation contract (for contracts that disableInitializers in constructors)
- set gas overrides for renzo warp route deploys
- check that validators are set
- add TODOs for verifying routing ISMs (probably should be removed @ltyu )
