### PR TITLE
chore: set env-test timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -404,7 +404,7 @@ jobs:
 
   env-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 3
     needs: [yarn-build]
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -404,6 +404,7 @@ jobs:
 
   env-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     needs: [yarn-build]
     strategy:
       fail-fast: false


### PR DESCRIPTION
- chore: set env-test timeout
- to avoid machines spinning idly for hours/days in jobs like this https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/9872063807/job/27261501530?pr=3888#step:6:44