### PR TITLE
chore: add symbol text when insuficient balance for pay gas

### DIFF
--- a/.changeset/empty-waves-speak.md
+++ b/.changeset/empty-waves-speak.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+chore: add symbol text when insuficient balance for pay gas

--- a/.changeset/empty-waves-speak.md
+++ b/.changeset/empty-waves-speak.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/cli': patch
 ---
 
-chore: add symbol text when insuficient balance for pay gas
+Display token symbol when balance is insufficient for command

--- a/typescript/cli/src/utils/balances.ts
+++ b/typescript/cli/src/utils/balances.ts
@@ -28,7 +28,7 @@ export async function nativeBalancesAreSufficient(
       const symbol =
         multiProvider.getChainMetadata(chain).nativeToken?.symbol ?? 'ETH';
       logRed(
-        `WARNING: ${address} has low balance on ${chain}. At least ${minBalance} recommended but found ${balance} ${symbol}`,
+        `WARNING: ${address} has low balance on ${chain}. At least ${minBalance} ${symbol} recommended but found ${balance} ${symbol}`,
       );
       sufficientBalances.push(false);
     }


### PR DESCRIPTION
### Description
Update text symbol when warning insuficient balance

```diff
- `WARNING: ${address} has low balance on ${chain}. At least ${minBalance} recommended but found ${balance} ${symbol}`
+ `WARNING: ${address} has low balance on ${chain}. At least ${minBalance} ${symbol} recommended but found ${balance} ${symbol}`
```