### PR TITLE
fix(cli): Add collateralAddressOrDenom for collateralVault

### DIFF
--- a/.changeset/slimy-kiwis-divide.md
+++ b/.changeset/slimy-kiwis-divide.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Add collateralAddressOrDenom for collateralVault

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -14,10 +14,10 @@ import {
   ProxyFactoryFactoriesAddresses,
   TOKEN_TYPE_TO_STANDARD,
   TokenFactories,
-  TokenType,
   WarpCoreConfig,
   WarpRouteDeployConfig,
   getTokenConnectionId,
+  isCollateralConfig,
   isTokenMetadata,
   serializeContracts,
 } from '@hyperlane-xyz/sdk';
@@ -289,8 +289,10 @@ async function getWarpCoreConfig(
   // First pass, create token configs
   for (const [chainName, contract] of Object.entries(contracts)) {
     const config = warpDeployConfig[chainName];
-    const collateralAddressOrDenom =
-      config.type === TokenType.collateral ? config.token : undefined;
+    const collateralAddressOrDenom = isCollateralConfig(config)
+      ? config.token // gets set in the above deriveTokenMetadata()
+      : undefined;
+
     warpCoreConfig.tokens.push({
       chainName,
       standard: TOKEN_TYPE_TO_STANDARD[config.type],

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -5,6 +5,7 @@ import {
   ERC20__factory,
   ERC721Enumerable__factory,
   GasRouter,
+  IERC4626__factory,
   IXERC20Lockbox__factory,
 } from '@hyperlane-xyz/core';
 import { TokenType } from '@hyperlane-xyz/sdk';
@@ -124,13 +125,24 @@ abstract class TokenDeployer<
           };
         }
 
-        const token =
-          config.type === TokenType.XERC20Lockbox
-            ? await IXERC20Lockbox__factory.connect(
-                config.token,
-                provider,
-              ).callStatic.ERC20()
-            : config.token;
+        let token: string;
+        switch (config.type) {
+          case TokenType.XERC20Lockbox:
+            token = await IXERC20Lockbox__factory.connect(
+              config.token,
+              provider,
+            ).callStatic.ERC20();
+            break;
+          case TokenType.collateralVault:
+            token = await IERC4626__factory.connect(
+              config.token,
+              provider,
+            ).asset();
+            break;
+          default:
+            token = config.token;
+            break;
+        }
 
         const erc20 = ERC20__factory.connect(token, provider);
         const [name, symbol, decimals] = await Promise.all([


### PR DESCRIPTION
### Description
- Adds `collateralAddressOrDenom` for collateralVault to fix send issue reported by Cheesechain
- This issue arose when the underlying asset (USDC) has a decimal of 6. This is due to `collateralAddressOrDenom` being missing in the warp artifacts for `collateralVault` causing a fee to be assessed in a decimal (18) much greater than the underlying (6). 

### Backward compatibility
Yes

### Testing
Manual
