### PR TITLE
chore: deploy kathy

### DIFF
--- a/typescript/infra/config/environments/mainnet3/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet3/helloworld.ts
@@ -13,7 +13,7 @@ export const hyperlane: HelloWorldConfig = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'b22a0f4-20240523-140812',
+      tag: '857338e-20240716-165320',
     },
     chainsToSkip: [],
     runEnv: environment,
@@ -33,7 +33,7 @@ export const releaseCandidate: HelloWorldConfig = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'b22a0f4-20240523-140812',
+      tag: '857338e-20240716-165320',
     },
     chainsToSkip: [],
     runEnv: environment,


### PR DESCRIPTION
### Description

I didn't deploy kathy following https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3875 and we've hit some RPC issues

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
