### PR TITLE
feat: start sending resource request metrics to grafana; bump scraper CPU requests

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -285,7 +285,7 @@ const validatorResources = {
 
 const scraperResources = {
   requests: {
-    cpu: '100m',
+    cpu: '2000m',
     memory: '4Gi',
   },
 };

--- a/typescript/infra/src/infrastructure/monitoring/prometheus.ts
+++ b/typescript/infra/src/infrastructure/monitoring/prometheus.ts
@@ -78,7 +78,7 @@ async function getPrometheusConfig(
             {
               action: 'keep',
               regex:
-                '(container.*|optics.*|Optics.*|prometheus.*|ethereum.*|hyperlane.*|kube_pod_status_phase|kube_pod_container_status_restarts_total)',
+                '(container.*|optics.*|Optics.*|prometheus.*|ethereum.*|hyperlane.*|kube_pod_status_phase|kube_pod_container_status_restarts_total|kube_pod_container_resource_requests)',
               source_labels: ['__name__'],
             },
           ],


### PR DESCRIPTION
### Description

- Starts sending `kube_pod_container_resource_requests` to grafana
- Useful for alerts that depend on the requests for a pod
- Deployed prom servers on testnet4 and mainnet3 with this config change
- Found that the scraper CPU requests are too low - bumped to 2 CPU - seemingly upon startup there's a pretty big CPU spike, so adjusted the requests to be within this spike.
- 
![Screen Shot 2024-07-17 at 12 36 29 PM](https://github.com/user-attachments/assets/9977afb4-79c6-4b7f-afb6-a898aab14e10)


### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
