### PR TITLE
fix: more conservative batching gas estimates

### DIFF
--- a/rust/chains/hyperlane-ethereum/src/config.rs
+++ b/rust/chains/hyperlane-ethereum/src/config.rs
@@ -44,7 +44,8 @@ pub struct TransactionOverrides {
     /// If specified, non-1559 transactions will be used with this gas price.
     pub gas_price: Option<U256>,
     /// Gas limit to use for transactions.
-    /// If specified, all transactions will use this gas limit.
+    /// If unspecified, the gas limit will be estimated.
+    /// If specified, transactions will use `max(estimated_gas, gas_limit)`
     pub gas_limit: Option<U256>,
     /// Max fee per gas to use for EIP-1559 transactions.
     pub max_fee_per_gas: Option<U256>,

--- a/rust/chains/hyperlane-ethereum/src/contracts/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/mailbox.rs
@@ -425,8 +425,10 @@ where
             .into_iter()
             .collect::<ChainResult<Vec<_>>>()?;
 
-        let batch_call = multicall::batch::<_, ()>(&mut multicall, contract_calls);
-        let call = self.add_gas_overrides(batch_call, None).await?;
+        let batch = multicall::batch::<_, ()>(&mut multicall, contract_calls).await;
+        let call = self
+            .add_gas_overrides(batch.call, batch.individual_gas_estimates_sum)
+            .await?;
 
         let receipt = report_tx(call).await?;
         Ok(receipt.into())

--- a/rust/chains/hyperlane-ethereum/src/contracts/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/mailbox.rs
@@ -297,7 +297,6 @@ where
     }
 
     /// Returns a ContractCall that processes the provided message.
-    /// If the provided tx_gas_limit is None, gas estimation occurs.
     async fn process_contract_call(
         &self,
         message: &HyperlaneMessage,
@@ -426,9 +425,7 @@ where
             .collect::<ChainResult<Vec<_>>>()?;
 
         let batch = multicall::batch::<_, ()>(&mut multicall, contract_calls).await;
-        let call = self
-            .add_gas_overrides(batch.call, batch.individual_gas_estimates_sum)
-            .await?;
+        let call = self.add_gas_overrides(batch, None).await?;
 
         let receipt = report_tx(call).await?;
         Ok(receipt.into())

--- a/rust/chains/hyperlane-ethereum/src/contracts/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/mailbox.rs
@@ -424,8 +424,8 @@ where
             .into_iter()
             .collect::<ChainResult<Vec<_>>>()?;
 
-        let batch = multicall::batch::<_, ()>(&mut multicall, contract_calls).await;
-        let call = self.add_gas_overrides(batch, None).await?;
+        let batch_call = multicall::batch::<_, ()>(&mut multicall, contract_calls).await;
+        let call = self.add_gas_overrides(batch_call, None).await?;
 
         let receipt = report_tx(call).await?;
         Ok(receipt.into())

--- a/rust/chains/hyperlane-ethereum/src/contracts/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/mailbox.rs
@@ -422,7 +422,6 @@ where
             .collect::<ChainResult<Vec<_>>>()?;
 
         let batch_call = multicall::batch::<_, ()>(&mut multicall, contract_calls).await?;
-        // TODO: set the gas limit for the batch call via an override than as `.gas(...)`
         let call = self.add_gas_overrides(batch_call).await?;
 
         let receipt = report_tx(call).await?;

--- a/rust/chains/hyperlane-ethereum/src/contracts/multicall.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/multicall.rs
@@ -1,12 +1,20 @@
 use std::sync::Arc;
 
+use derive_new::new;
 use ethers::{abi::Detokenize, providers::Middleware};
 use ethers_contract::{builders::ContractCall, Multicall, MulticallResult, MulticallVersion};
-use hyperlane_core::{utils::hex_or_base58_to_h256, HyperlaneDomain, HyperlaneProvider};
+use hyperlane_core::{utils::hex_or_base58_to_h256, HyperlaneDomain, HyperlaneProvider, U256};
+use tracing::warn;
 
-use crate::{ConnectionConf, EthereumProvider};
+use crate::{tx::apply_gas_estimate_buffer, ConnectionConf, EthereumProvider};
 
 const ALLOW_BATCH_FAILURES: bool = true;
+
+/// Conservative estimate picked by withdrawing the gas used by individual calls from the total cost of `aggregate3`
+/// based on:
+/// - https://dashboard.tenderly.co/shared/simulation/63e85ac7-3ea9-475c-8218-a7c1dd508366/gas-usage
+/// - https://dashboard.tenderly.co/tx/arbitrum/0xad644e431dc53c3fc0a074a749d118ff5517346c3f28d8e2513610cc9ab5c91a/gas-usage
+const MULTICALL_OVERHEAD_PER_CALL: u64 = 3500;
 
 pub async fn build_multicall<M: Middleware + 'static>(
     provider: Arc<M>,
@@ -34,16 +42,45 @@ pub async fn build_multicall<M: Middleware + 'static>(
     Ok(multicall)
 }
 
-pub fn batch<M: Middleware, D: Detokenize>(
+#[derive(new)]
+pub struct MulticallContractCall<M: Middleware, D: Detokenize> {
+    pub call: ContractCall<M, D>,
+    pub individual_gas_estimates_sum: Option<U256>,
+}
+
+pub async fn batch<M, D>(
     multicall: &mut Multicall<M>,
     calls: Vec<ContractCall<M, D>>,
-) -> ContractCall<M, Vec<MulticallResult>> {
+) -> MulticallContractCall<M, Vec<MulticallResult>>
+where
+    M: Middleware + 'static,
+    D: Detokenize,
+{
     // clear any calls that were in the multicall beforehand
     multicall.clear_calls();
 
-    calls.into_iter().for_each(|call| {
-        multicall.add_call(call, ALLOW_BATCH_FAILURES);
-    });
+    let mut individual_estimates_sum = Some(U256::zero());
+    let overhead_per_call: U256 = MULTICALL_OVERHEAD_PER_CALL.into();
 
-    multicall.as_aggregate_3_value()
+    for call in calls.into_iter() {
+        match call.estimate_gas().await {
+            Ok(gas_estimate) => {
+                let gas_estimate: U256 = gas_estimate.into();
+                individual_estimates_sum =
+                    individual_estimates_sum.map(|sum| sum + gas_estimate + overhead_per_call);
+            }
+            Err(err) => {
+                warn!(?err, call=?call.tx, "Failed to estimate gas for call in batch");
+                // if we fail to estimate the gas, we can't accurately estimate the total gas
+                // Return a None instead of an error, because this is a non-critical failure
+                individual_estimates_sum = None;
+            }
+        }
+        multicall.add_call(call, ALLOW_BATCH_FAILURES);
+    }
+
+    // Add a buffer to this estimate, to match how gas is estimated for individual txs in `tx.rs::fill_tx_gas_params`
+    let individual_estimates_sum = individual_estimates_sum.map(apply_gas_estimate_buffer);
+
+    MulticallContractCall::new(multicall.as_aggregate_3_value(), individual_estimates_sum)
 }

--- a/rust/chains/hyperlane-ethereum/src/contracts/multicall.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/multicall.rs
@@ -55,7 +55,6 @@ where
     let mut individual_estimates_sum = Some(U256::zero());
     let overhead_per_call: U256 = MULTICALL_OVERHEAD_PER_CALL.into();
 
-    // sum over the `call.tx.gas() + overhead_per_call` for each call
     calls.into_iter().for_each(|call| {
         individual_estimates_sum = match call.tx.gas() {
             Some(gas_estimate) => {

--- a/rust/chains/hyperlane-ethereum/src/contracts/multicall.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/multicall.rs
@@ -10,7 +10,7 @@ use crate::{tx::apply_gas_estimate_buffer, ConnectionConf, EthereumProvider};
 
 const ALLOW_BATCH_FAILURES: bool = true;
 
-/// Conservative estimate picked by withdrawing the gas used by individual calls from the total cost of `aggregate3`
+/// Conservative estimate picked by subtracting the gas used by individual calls from the total cost of `aggregate3`
 /// based on:
 /// - https://dashboard.tenderly.co/shared/simulation/63e85ac7-3ea9-475c-8218-a7c1dd508366/gas-usage
 /// - https://dashboard.tenderly.co/tx/arbitrum/0xad644e431dc53c3fc0a074a749d118ff5517346c3f28d8e2513610cc9ab5c91a/gas-usage

--- a/rust/chains/hyperlane-ethereum/src/tx.rs
+++ b/rust/chains/hyperlane-ethereum/src/tx.rs
@@ -96,7 +96,7 @@ where
     M: Middleware + 'static,
     D: Detokenize,
 {
-    // Even if there is a configrued gas override, perform a gas estimation and keep the max, to avoid having the tx run out of gas.
+    // Even if there is a configured gas override, perform a gas estimation and keep the max, to avoid having the tx run out of gas.
     let estimated_gas_limit: U256 = apply_gas_estimate_buffer(tx.estimate_gas().await?.into());
     let gas_limit: U256 = if let Some(gas_limit) = transaction_overrides.gas_limit {
         estimated_gas_limit.max(gas_limit)

--- a/rust/chains/hyperlane-ethereum/src/tx.rs
+++ b/rust/chains/hyperlane-ethereum/src/tx.rs
@@ -17,7 +17,7 @@ use ethers_core::{
     },
 };
 use hyperlane_core::{utils::bytes_to_hex, ChainCommunicationError, ChainResult, H256, U256};
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use crate::{Middleware, TransactionOverrides};
 
@@ -103,6 +103,7 @@ where
     } else {
         estimated_gas_limit
     };
+    debug!(?estimated_gas_limit, gas_override=?transaction_overrides.gas_limit, used_gas_limit=?gas_limit, "Gas limit set for transaction");
 
     if let Some(gas_price) = transaction_overrides.gas_price {
         // If the gas price is set, we treat as a non-EIP-1559 chain.


### PR DESCRIPTION
### Description

Estimating gas isn't very accurate for Multicall txs that allow failures. This PR now estimates gas as: `max(batch_tx_estimate, individual_tx_estimates_sum)`, where `individual_tx_estimates_sum` estimates each individual tx and adds a conservative overhead that `Multicall.aggregate3` adds per subtx.

The aggregate3 overhead is calcualted based on some observed tenderly gas profiling results as follows.
- For [4 txs](https://dashboard.tenderly.co/shared/simulation/63e85ac7-3ea9-475c-8218-a7c1dd508366/gas-usage):
    - aggregate3 gas: 805,160
    - process costs: 290,091 + 168,711 + 168,711 + 168,711 = 796,224
    - overhead: 805,160 - 796,224 = 8,936 => 2,234 per subtx
- For [2 txs](https://dashboard.tenderly.co/tx/arbitrum/0xad644e431dc53c3fc0a074a749d118ff5517346c3f28d8e2513610cc9ab5c91a/gas-usage):
    - aggregate3 gas: 201,710
    - process costs: 103,011 + 92,512 = 195,523
    - overhead: 201,710 - 195,523 = 6,187 => 3,093 per subtx
- So will assume an overhead of 3500 `aggregate3` gas per message in batch


### Drive-by changes

This slightly changes the semantics of gas overrides. If a gas limit is configured, it will only guarantee that that's the minimum limit a tx can have. Now we use the `max(estimated_gas, gas_limit_override)` as the actual gas limit.
 
### Related issues

- Fixes https://github.com/hyperlane-xyz/issues/issues/1295

### Backward compatibility

Yes

### Testing

 I think it's ok to release to release and check the new log, to see the individual estimate vs the batch estimate and double-check which one is picked in the tx explorer
