### PR TITLE
fix(sdk): account for unparsable scanner responses during contract verification

### DIFF
--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -123,7 +123,7 @@ export async function createWarpRouteDeployConfig({
 
   const result: WarpRouteDeployConfig = {};
   for (const chain of warpChains) {
-    logBlue(`Configuring warp route for chain ${chain}`);
+    logBlue(`${chain}: Configuring warp route...`);
     const type = await select({
       message: `Select ${chain}'s token type`,
       choices: TYPE_CHOICES,

--- a/typescript/sdk/src/deploy/verify/ContractVerifier.ts
+++ b/typescript/sdk/src/deploy/verify/ContractVerifier.ts
@@ -132,8 +132,8 @@ export class ContractVerifier {
       );
       throw new Error(
         `Failed to parse response from explorer (${apiUrl}, ${chain}): ${
-          response.statusText ?? 'UNKNOWN STATUS TEXT'
-        } (${response.status ?? 'UNKNOWN STATUS'})`,
+          response.statusText || 'UNKNOWN STATUS TEXT'
+        } (${response.status || 'UNKNOWN STATUS'})`,
       );
     }
 

--- a/typescript/sdk/src/deploy/verify/ContractVerifier.ts
+++ b/typescript/sdk/src/deploy/verify/ContractVerifier.ts
@@ -108,38 +108,58 @@ export class ContractVerifier {
         method: 'GET',
       });
     } else {
-      response = await fetch(url.toString(), {
+      const init: RequestInit = {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: params,
-      });
+      };
+      response = await fetch(url.toString(), init);
+    }
+    let responseJson;
+    try {
+      const responseTextString = await response.text();
+      responseJson = JSON.parse(responseTextString);
+    } catch (error) {
+      verificationLogger.trace(
+        {
+          failure: response.statusText,
+          status: response.status,
+          chain,
+          apiUrl,
+          family,
+        },
+        'Failed to parse response from explorer.',
+      );
+      throw new Error(
+        `Failed to parse response from explorer (${apiUrl}, ${chain}): ${
+          response.statusText ?? 'UNKNOWN STATUS TEXT'
+        } (${response.status ?? 'UNKNOWN STATUS'})`,
+      );
     }
 
-    const responseText = await response.text();
-    const result = JSON.parse(responseText);
-
-    if (result.message !== 'OK') {
+    if (responseJson.message !== 'OK') {
       let errorMessage;
 
-      switch (result.result) {
+      switch (responseJson.result) {
         case ExplorerApiErrors.VERIFICATION_PENDING:
           await sleep(5000);
           verificationLogger.trace(
             {
-              result: result.result,
+              result: responseJson.result,
             },
             'Verification still pending',
           );
           return this.submitForm(chain, action, verificationLogger, options);
         case ExplorerApiErrors.ALREADY_VERIFIED:
         case ExplorerApiErrors.ALREADY_VERIFIED_ALT:
+        case ExplorerApiErrors.NOT_VERIFIED:
         case ExplorerApiErrors.PROXY_FAILED:
         case ExplorerApiErrors.BYTECODE_MISMATCH:
-          errorMessage = `${result.message}: ${result.result}`;
+          errorMessage = `${responseJson.message}: ${responseJson.result}`;
           break;
         default:
           errorMessage = `Verification failed: ${
-            JSON.stringify(result.result) ?? response.statusText
+            JSON.stringify(responseJson.result) ?? response.statusText
           }`;
           break;
       }
@@ -150,20 +170,20 @@ export class ContractVerifier {
       }
     }
 
-    if (result.result === ExplorerApiErrors.UNKNOWN_UID) {
+    if (responseJson.result === ExplorerApiErrors.UNKNOWN_UID) {
       await sleep(1000); // wait 1 second
       return this.submitForm(chain, action, verificationLogger, options);
     }
 
-    if (result.result === ExplorerApiErrors.UNABLE_TO_VERIFY) {
+    if (responseJson.result === ExplorerApiErrors.UNABLE_TO_VERIFY) {
       const errorMessage = `Verification failed. ${
-        JSON.stringify(result.result) ?? response.statusText
+        JSON.stringify(responseJson.result) ?? response.statusText
       }`;
       verificationLogger.debug(errorMessage);
       throw new Error(`[${chain}] ${errorMessage}`);
     }
 
-    return result.result;
+    return responseJson.result;
   }
 
   private async isAlreadyVerified(

--- a/typescript/sdk/src/deploy/verify/types.ts
+++ b/typescript/sdk/src/deploy/verify/types.ts
@@ -61,6 +61,7 @@ export const EXPLORER_GET_ACTIONS = [
 export enum ExplorerApiErrors {
   ALREADY_VERIFIED = 'Contract source code already verified',
   ALREADY_VERIFIED_ALT = 'Already Verified',
+  NOT_VERIFIED = 'Contract source code not verified',
   VERIFICATION_PENDING = 'Pending in queue',
   PROXY_FAILED = 'A corresponding implementation contract was unfortunately not detected for the proxy address.',
   BYTECODE_MISMATCH = 'Fail - Unable to verify. Compiled contract deployment bytecode does NOT match the transaction deployment bytecode.',


### PR DESCRIPTION
### Description

- for certain failures, etherscan may return an html response we cannot parse with JSON.parse(). One such example is when our `sourceCode` is too large, due to including all build artifacts during contract verification.
- while the underlying issue is `Request Entity Too Large` for this failure, our verifier was crashing with:
```
   `Error verifying contract: SyntaxError: Unexpected token '<', "<html>
    <h"... is not valid JSON`
```
- this change accounts for unparsable scanner responses during contract verification, and gives our users insight into the underlying failure

### Drive-by changes

- minor log update
- also accounts for bug where we printed "Verification failed" every time we'd check if a contract had been verified or not before verifying

### Related issues

- https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4130

### Backward compatibility

- yes

### Testing

- manual
example output:
```
Pending https://bscscan.com/tx/0x47d9c0fd641b8689deb6cee2cb5f5d3651eb246be0a1de59d523b655c621140b (waiting 1 blocks for confirmation)
📝 Verifying implementation at 0xfFd1c0E31d1B18b51D1cfdBafbC679A97ACfb3Fa...
{
  failure: 'Request Entity Too Large',
  status: 413,
  chain: 'bsc',
  apiUrl: 'https://api.bscscan.com/api',
  family: 'etherscan'
} Failed to parse response from explorer.
Error verifying contract: Error: Failed to parse response from explorer (https://api.bscscan.com/api, bsc): Request Entity Too Large (413)
```