### PR TITLE
fix(sdk): sourceCode entity too large for contract verification

### DIFF
--- a/.changeset/soft-tigers-explode.md
+++ b/.changeset/soft-tigers-explode.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Adds logic to prune and minify build artifacts to address 'entity size too large' error thrown from explorers. Note that the only identified instance of this issue is on BSC mainnet.

--- a/typescript/sdk/src/deploy/verify/types.ts
+++ b/typescript/sdk/src/deploy/verify/types.ts
@@ -14,6 +14,14 @@ export type SolidityStandardJsonInput = {
       content: string;
     };
   };
+  language: string;
+  settings: {
+    optimizer: {
+      enabled: boolean;
+      runs: number;
+    };
+    outputSelection: any;
+  };
 };
 
 export type BuildArtifact = {


### PR DESCRIPTION
### Description

- used BFS to traverse and prune the dependency graph of any named contract in the buildArtifact input to address 'entity size too large' error thrown from bsc mainnet etherscan explorer

### Drive-by changes

- none

### Related issues

- fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4164

### Backward compatibility

- yes

### Testing

- manual (bsc now verifying)