### PR TITLE
fix(sdk): adjust timeouts based on explorer family & collate verif process

### DIFF
--- a/.changeset/tame-rocks-talk.md
+++ b/.changeset/tame-rocks-talk.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+ContractVerifier now adjusts timeouts based on explorer family, which helps with many rate-limiting related contract verification issues. In addition, the ContractVerifier verify logic has been greatly simplified to allowing for a predictable callstack + easy debugging.

--- a/typescript/sdk/src/deploy/verify/ContractVerifier.ts
+++ b/typescript/sdk/src/deploy/verify/ContractVerifier.ts
@@ -217,13 +217,7 @@ export class ContractVerifier {
   ): Promise<void> {
     const contractType: string = input.isProxy ? 'proxy' : 'implementation';
 
-    verificationLogger.debug(
-      {
-        name: input.name,
-        address: input.address,
-      },
-      `📝 Verifying ${contractType}...`,
-    );
+    verificationLogger.debug(`📝 Verifying ${contractType}...`);
 
     const data = input.isProxy
       ? this.getProxyData(input)
@@ -240,11 +234,7 @@ export class ContractVerifier {
       );
 
       verificationLogger.trace(
-        {
-          guid,
-          name: input.name,
-          address: input.address,
-        },
+        { guid },
         `Retrieved guid from verified ${contractType}.`,
       );
 
@@ -266,18 +256,12 @@ export class ContractVerifier {
           addressUrl: addressUrl
             ? `${addressUrl}#code`
             : `Could not retrieve ${contractType} explorer URL.`,
-          name: input.name,
-          address: input.address,
         },
         `✅ Successfully verified ${contractType}.`,
       );
     } catch (error) {
       verificationLogger.debug(
-        {
-          name: input.name,
-          address: input.address,
-          error,
-        },
+        { error },
         `Verification of ${contractType} failed`,
       );
       throw error;
@@ -291,14 +275,7 @@ export class ContractVerifier {
     guid: string,
     contractType: string,
   ): Promise<void> {
-    verificationLogger.trace(
-      {
-        guid,
-        name: input.name,
-        address: input.address,
-      },
-      `Checking ${contractType} status...`,
-    );
+    verificationLogger.trace({ guid }, `Checking ${contractType} status...`);
     await this.submitForm(
       chain,
       input.isProxy

--- a/typescript/sdk/src/deploy/verify/types.ts
+++ b/typescript/sdk/src/deploy/verify/types.ts
@@ -49,12 +49,12 @@ export enum ExplorerApiActions {
   GETSOURCECODE = 'getsourcecode',
   VERIFY_IMPLEMENTATION = 'verifysourcecode',
   VERIFY_PROXY = 'verifyproxycontract',
-  CHECK_STATUS = 'checkverifystatus',
+  CHECK_IMPLEMENTATION_STATUS = 'checkverifystatus',
   CHECK_PROXY_STATUS = 'checkproxyverification',
 }
 
 export const EXPLORER_GET_ACTIONS = [
-  ExplorerApiActions.CHECK_STATUS,
+  ExplorerApiActions.CHECK_IMPLEMENTATION_STATUS,
   ExplorerApiActions.CHECK_PROXY_STATUS,
   ExplorerApiActions.GETSOURCECODE,
 ];
@@ -80,14 +80,15 @@ export type FormOptions<Action extends ExplorerApiActions> =
         contractaddress: string;
         sourceCode: string;
         contractname: string;
-        constructorArguements?: string; // TYPO IS ENFORCED BY API
+        /* TYPO IS ENFORCED BY API */
+        constructorArguements?: string;
       }
     : Action extends ExplorerApiActions.VERIFY_PROXY
     ? {
         address: string;
         expectedimplementation: string;
       }
-    : Action extends ExplorerApiActions.CHECK_STATUS
+    : Action extends ExplorerApiActions.CHECK_IMPLEMENTATION_STATUS
     ? {
         guid: string;
       }


### PR DESCRIPTION
### Description

- adjusts timeouts based on explorer family
- collates verif process for maintainability/readability (this also makes timeouts more consistent)

### Drive-by changes

- none

### Related issues

- partially fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4130

### Backward compatibility

- yes

### Testing

- manual