### PR TITLE
feat: remove outbox param from `ArbL2ToL1Ism`

### DIFF
--- a/.changeset/tame-snakes-brush.md
+++ b/.changeset/tame-snakes-brush.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/core': patch
+---
+
+Removed outbox as param for ArbL2ToL1Ism

--- a/solidity/contracts/isms/hook/ArbL2ToL1Ism.sol
+++ b/solidity/contracts/isms/hook/ArbL2ToL1Ism.sol
@@ -13,7 +13,7 @@ pragma solidity >=0.8.0;
  @@@@@@@@@       @@@@@@@@@
 @@@@@@@@@       @@@@@@@@*/
 
-// ============ Internal Imports ============
+// ============ Internal Imports =============
 
 import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
 import {TypeCasts} from "../../libs/TypeCasts.sol";

--- a/solidity/contracts/isms/hook/ArbL2ToL1Ism.sol
+++ b/solidity/contracts/isms/hook/ArbL2ToL1Ism.sol
@@ -20,8 +20,9 @@ import {TypeCasts} from "../../libs/TypeCasts.sol";
 import {Message} from "../../libs/Message.sol";
 import {AbstractMessageIdAuthorizedIsm} from "./AbstractMessageIdAuthorizedIsm.sol";
 
-// ============ External Imports ============
+// ============ External Imports ===========
 
+import {IBridge} from "@arbitrum/nitro-contracts/src/bridge/IBridge.sol";
 import {IOutbox} from "@arbitrum/nitro-contracts/src/bridge/IOutbox.sol";
 import {CrossChainEnabledArbitrumL1} from "@openzeppelin/contracts/crosschain/arbitrum/CrossChainEnabledArbitrumL1.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
@@ -45,15 +46,12 @@ contract ArbL2ToL1Ism is
 
     // ============ Constructor ============
 
-    constructor(
-        address _bridge,
-        address _outbox
-    ) CrossChainEnabledArbitrumL1(_bridge) {
+    constructor(address _bridge) CrossChainEnabledArbitrumL1(_bridge) {
         require(
             Address.isContract(_bridge),
             "ArbL2ToL1Ism: invalid Arbitrum Bridge"
         );
-        arbOutbox = IOutbox(_outbox);
+        arbOutbox = IOutbox(IBridge(_bridge).activeOutbox());
     }
 
     // ============ External Functions ============

--- a/solidity/contracts/isms/hook/ArbL2ToL1Ism.sol
+++ b/solidity/contracts/isms/hook/ArbL2ToL1Ism.sol
@@ -13,14 +13,14 @@ pragma solidity >=0.8.0;
  @@@@@@@@@       @@@@@@@@@
 @@@@@@@@@       @@@@@@@@*/
 
-// ============ Internal Imports =============
+// ============ Internal Imports ============
 
 import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
 import {TypeCasts} from "../../libs/TypeCasts.sol";
 import {Message} from "../../libs/Message.sol";
 import {AbstractMessageIdAuthorizedIsm} from "./AbstractMessageIdAuthorizedIsm.sol";
 
-// ============ External Imports ===========
+// ============ External Imports ============
 
 import {IBridge} from "@arbitrum/nitro-contracts/src/bridge/IBridge.sol";
 import {IOutbox} from "@arbitrum/nitro-contracts/src/bridge/IOutbox.sol";

--- a/solidity/script/DeployArbHook.s.sol
+++ b/solidity/script/DeployArbHook.s.sol
@@ -19,7 +19,6 @@ contract DeployArbHook is Script {
     uint32 constant L1_DOMAIN = 11155111;
     address constant L1_MAILBOX = 0xfFAEF09B3cd11D9b20d1a19bECca54EEC2884766;
     address constant L1_BRIDGE = 0x38f918D0E9F1b721EDaA41302E399fa1B79333a9;
-    address constant L1_OUTBOX = 0x65f07C7D521164a4d5DaC6eB8Fac8DA067A3B78F;
     address constant L1_ISM = 0x096A1c034c7Ad113B6dB786b7BA852cB67025458; // placeholder
     bytes32 TEST_RECIPIENT =
         0x000000000000000000000000155b1cd2f7cbc58d403b9be341fab6cd77425175; // placeholder
@@ -33,7 +32,7 @@ contract DeployArbHook is Script {
 
         vm.startBroadcast(deployerPrivateKey);
 
-        ism = new ArbL2ToL1Ism(L1_BRIDGE, L1_OUTBOX);
+        ism = new ArbL2ToL1Ism(L1_BRIDGE);
 
         TestRecipient testRecipient = new TestRecipient();
         testRecipient.setInterchainSecurityModule(address(ism));

--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -114,7 +114,7 @@ contract ArbL2ToL1IsmTest is Test {
     function deployIsm() public {
         arbBridge = new MockArbBridge();
 
-        ism = new ArbL2ToL1Ism(address(arbBridge), address(arbBridge));
+        ism = new ArbL2ToL1Ism(address(arbBridge));
     }
 
     function deployAll() public {


### PR DESCRIPTION
### Description

- outbox contract can be derived from arbitrum's bridge contract so it's not useful to pass in

### Drive-by changes

None

### Related issues

None

### Backward compatibility

Yes

### Testing

Unit
