### PR TITLE
feat: use multiple `mpsc` channels instead of `broadcast` for async interface

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3951,9 +3951,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -5077,7 +5077,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi 0.3.9",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -5525,13 +5525,14 @@ checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5845,7 +5846,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -10079,22 +10080,21 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
  "tracing",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10109,9 +10109,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -173,7 +173,7 @@ tendermint-rpc = { version = "0.32.0", features = ["http-client", "tokio"] }
 thiserror = "1.0"
 time = "0.3"
 tiny-keccak = "2.0.2"
-tokio = { version = "1", features = ["parking_lot", "tracing"] }
+tokio = { version = "1.37", features = ["parking_lot", "tracing"] }
 tokio-metrics = { version = "0.3.1", default-features = false }
 tokio-test = "0.4"
 toml_edit = "0.19.14"

--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -21,8 +21,8 @@ use hyperlane_core::{
 };
 use tokio::{
     sync::{
-        broadcast::{Receiver, Sender},
-        mpsc::{self, UnboundedSender},
+        broadcast::Sender as BroadcastSender,
+        mpsc::{self, Receiver as MpscReceiver, UnboundedSender},
         RwLock,
     },
     task::JoinHandle,
@@ -309,7 +309,7 @@ impl BaseAgent for Relayer {
                 }));
             tasks.push(console_server.instrument(info_span!("Tokio console server")));
         }
-        let sender = Sender::<MessageRetryRequest>::new(ENDPOINT_MESSAGES_QUEUE_SIZE);
+        let sender = BroadcastSender::<MessageRetryRequest>::new(ENDPOINT_MESSAGES_QUEUE_SIZE);
         // send channels by destination chain
         let mut send_channels = HashMap::with_capacity(self.destination_chains.len());
         let mut prep_queues = HashMap::with_capacity(self.destination_chains.len());
@@ -350,7 +350,7 @@ impl BaseAgent for Relayer {
         }
 
         for origin in &self.origin_chains {
-            let maybe_broadcaster = self
+            let mut maybe_broadcaster = self
                 .message_syncs
                 .get(origin)
                 .and_then(|sync| sync.get_broadcaster());
@@ -358,7 +358,7 @@ impl BaseAgent for Relayer {
             tasks.push(
                 self.run_interchain_gas_payment_sync(
                     origin,
-                    maybe_broadcaster.clone().map(|b| b.subscribe()),
+                    maybe_broadcaster.as_mut().map(|b| b.get_receiver()),
                     task_monitor.clone(),
                 )
                 .await,
@@ -366,7 +366,7 @@ impl BaseAgent for Relayer {
             tasks.push(
                 self.run_merkle_tree_hook_syncs(
                     origin,
-                    maybe_broadcaster.map(|b| b.subscribe()),
+                    maybe_broadcaster.as_mut().map(|b| b.get_receiver()),
                     task_monitor.clone(),
                 )
                 .await,
@@ -428,7 +428,7 @@ impl Relayer {
     async fn run_interchain_gas_payment_sync(
         &self,
         origin: &HyperlaneDomain,
-        tx_id_receiver: Option<Receiver<H512>>,
+        tx_id_receiver: Option<MpscReceiver<H512>>,
         task_monitor: TaskMonitor,
     ) -> Instrumented<JoinHandle<()>> {
         let index_settings = self.as_ref().settings.chains[origin.name()].index_settings();
@@ -453,7 +453,7 @@ impl Relayer {
     async fn run_merkle_tree_hook_syncs(
         &self,
         origin: &HyperlaneDomain,
-        tx_id_receiver: Option<Receiver<H512>>,
+        tx_id_receiver: Option<MpscReceiver<H512>>,
         task_monitor: TaskMonitor,
     ) -> Instrumented<JoinHandle<()>> {
         let index_settings = self.as_ref().settings.chains[origin.name()].index.clone();

--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -9,6 +9,7 @@ use derive_more::AsRef;
 use eyre::Result;
 use futures_util::future::try_join_all;
 use hyperlane_base::{
+    broadcast::BroadcastMpscSender,
     db::{HyperlaneRocksDB, DB},
     metrics::{AgentMetrics, MetricsUpdater},
     settings::ChainConf,
@@ -358,7 +359,7 @@ impl BaseAgent for Relayer {
             tasks.push(
                 self.run_interchain_gas_payment_sync(
                     origin,
-                    maybe_broadcaster.as_mut().map(|b| b.get_receiver()),
+                    BroadcastMpscSender::map_get_receiver(maybe_broadcaster.as_mut()).await,
                     task_monitor.clone(),
                 )
                 .await,
@@ -366,7 +367,7 @@ impl BaseAgent for Relayer {
             tasks.push(
                 self.run_merkle_tree_hook_syncs(
                     origin,
-                    maybe_broadcaster.as_mut().map(|b| b.get_receiver()),
+                    BroadcastMpscSender::map_get_receiver(maybe_broadcaster.as_mut()).await,
                     task_monitor.clone(),
                 )
                 .await,

--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -351,7 +351,7 @@ impl BaseAgent for Relayer {
         }
 
         for origin in &self.origin_chains {
-            let mut maybe_broadcaster = self
+            let maybe_broadcaster = self
                 .message_syncs
                 .get(origin)
                 .and_then(|sync| sync.get_broadcaster());
@@ -359,7 +359,7 @@ impl BaseAgent for Relayer {
             tasks.push(
                 self.run_interchain_gas_payment_sync(
                     origin,
-                    BroadcastMpscSender::map_get_receiver(maybe_broadcaster.as_mut()).await,
+                    BroadcastMpscSender::map_get_receiver(maybe_broadcaster.as_ref()).await,
                     task_monitor.clone(),
                 )
                 .await,
@@ -367,7 +367,7 @@ impl BaseAgent for Relayer {
             tasks.push(
                 self.run_merkle_tree_hook_syncs(
                     origin,
-                    BroadcastMpscSender::map_get_receiver(maybe_broadcaster.as_mut()).await,
+                    BroadcastMpscSender::map_get_receiver(maybe_broadcaster.as_ref()).await,
                     task_monitor.clone(),
                 )
                 .await,

--- a/rust/agents/scraper/src/agent.rs
+++ b/rust/agents/scraper/src/agent.rs
@@ -4,14 +4,12 @@ use async_trait::async_trait;
 use derive_more::AsRef;
 use futures::future::try_join_all;
 use hyperlane_base::{
-    metrics::AgentMetrics, settings::IndexSettings, BaseAgent, ChainMetrics, ContractSyncMetrics,
-    ContractSyncer, CoreMetrics, HyperlaneAgentCore, MetricsUpdater, SyncOptions,
+    broadcast::BroadcastMpscSender, metrics::AgentMetrics, settings::IndexSettings, BaseAgent,
+    ChainMetrics, ContractSyncMetrics, ContractSyncer, CoreMetrics, HyperlaneAgentCore,
+    MetricsUpdater, SyncOptions,
 };
 use hyperlane_core::{Delivery, HyperlaneDomain, HyperlaneMessage, InterchainGasPayment, H512};
-use tokio::{
-    sync::broadcast::{Receiver, Sender},
-    task::JoinHandle,
-};
+use tokio::{sync::mpsc::Receiver as MpscReceiver, task::JoinHandle};
 use tracing::{info_span, instrument::Instrumented, trace, Instrument};
 
 use crate::{chain_scraper::HyperlaneSqlDb, db::ScraperDb, settings::ScraperSettings};
@@ -138,7 +136,7 @@ impl Scraper {
         let domain = scraper.domain.clone();
 
         let mut tasks = Vec::with_capacity(2);
-        let (message_indexer, maybe_broadcaster) = self
+        let (message_indexer, mut maybe_broadcaster) = self
             .build_message_indexer(
                 domain.clone(),
                 self.core_metrics.clone(),
@@ -155,7 +153,7 @@ impl Scraper {
                 self.contract_sync_metrics.clone(),
                 db.clone(),
                 index_settings.clone(),
-                maybe_broadcaster.clone().map(|b| b.subscribe()),
+                maybe_broadcaster.as_mut().map(|b| b.get_receiver()),
             )
             .await,
         );
@@ -166,7 +164,7 @@ impl Scraper {
                 self.contract_sync_metrics.clone(),
                 db,
                 index_settings.clone(),
-                maybe_broadcaster.map(|b| b.subscribe()),
+                maybe_broadcaster.as_mut().map(|b| b.get_receiver()),
             )
             .await,
         );
@@ -187,7 +185,10 @@ impl Scraper {
         contract_sync_metrics: Arc<ContractSyncMetrics>,
         db: HyperlaneSqlDb,
         index_settings: IndexSettings,
-    ) -> (Instrumented<JoinHandle<()>>, Option<Sender<H512>>) {
+    ) -> (
+        Instrumented<JoinHandle<()>>,
+        Option<BroadcastMpscSender<H512>>,
+    ) {
         let sync = self
             .as_ref()
             .settings
@@ -215,7 +216,7 @@ impl Scraper {
         contract_sync_metrics: Arc<ContractSyncMetrics>,
         db: HyperlaneSqlDb,
         index_settings: IndexSettings,
-        tx_id_receiver: Option<Receiver<H512>>,
+        tx_id_receiver: Option<MpscReceiver<H512>>,
     ) -> Instrumented<JoinHandle<()>> {
         let sync = self
             .as_ref()
@@ -245,7 +246,7 @@ impl Scraper {
         contract_sync_metrics: Arc<ContractSyncMetrics>,
         db: HyperlaneSqlDb,
         index_settings: IndexSettings,
-        tx_id_receiver: Option<Receiver<H512>>,
+        tx_id_receiver: Option<MpscReceiver<H512>>,
     ) -> Instrumented<JoinHandle<()>> {
         let sync = self
             .as_ref()

--- a/rust/agents/scraper/src/agent.rs
+++ b/rust/agents/scraper/src/agent.rs
@@ -136,7 +136,7 @@ impl Scraper {
         let domain = scraper.domain.clone();
 
         let mut tasks = Vec::with_capacity(2);
-        let (message_indexer, mut maybe_broadcaster) = self
+        let (message_indexer, maybe_broadcaster) = self
             .build_message_indexer(
                 domain.clone(),
                 self.core_metrics.clone(),
@@ -163,7 +163,7 @@ impl Scraper {
                 self.contract_sync_metrics.clone(),
                 db,
                 index_settings.clone(),
-                BroadcastMpscSender::<H512>::map_get_receiver(maybe_broadcaster.as_mut()).await,
+                BroadcastMpscSender::<H512>::map_get_receiver(maybe_broadcaster.as_ref()).await,
             )
             .await,
         );

--- a/rust/chains/hyperlane-ethereum/src/contracts/interchain_gas.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/interchain_gas.rs
@@ -38,6 +38,7 @@ pub struct InterchainGasPaymasterIndexerBuilder {
 #[async_trait]
 impl BuildableWithProvider for InterchainGasPaymasterIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<InterchainGasPayment>>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
@@ -176,6 +177,7 @@ pub struct InterchainGasPaymasterBuilder {}
 #[async_trait]
 impl BuildableWithProvider for InterchainGasPaymasterBuilder {
     type Output = Box<dyn InterchainGasPaymaster>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/contracts/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/mailbox.rs
@@ -52,6 +52,7 @@ pub struct SequenceIndexerBuilder {
 #[async_trait]
 impl BuildableWithProvider for SequenceIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<HyperlaneMessage>>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
@@ -74,6 +75,7 @@ pub struct DeliveryIndexerBuilder {
 #[async_trait]
 impl BuildableWithProvider for DeliveryIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<H256>>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
@@ -245,6 +247,7 @@ pub struct MailboxBuilder {}
 #[async_trait]
 impl BuildableWithProvider for MailboxBuilder {
     type Output = Box<dyn Mailbox>;
+    const NEEDS_SIGNER: bool = true;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/contracts/merkle_tree_hook.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/merkle_tree_hook.rs
@@ -44,6 +44,7 @@ pub struct MerkleTreeHookBuilder {}
 #[async_trait]
 impl BuildableWithProvider for MerkleTreeHookBuilder {
     type Output = Box<dyn MerkleTreeHook>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
@@ -62,6 +63,7 @@ pub struct MerkleTreeHookIndexerBuilder {
 #[async_trait]
 impl BuildableWithProvider for MerkleTreeHookIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<MerkleTreeInsertion>>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/contracts/validator_announce.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/validator_announce.rs
@@ -34,6 +34,7 @@ pub struct ValidatorAnnounceBuilder {}
 #[async_trait]
 impl BuildableWithProvider for ValidatorAnnounceBuilder {
     type Output = Box<dyn ValidatorAnnounce>;
+    const NEEDS_SIGNER: bool = true;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/ism/aggregation_ism.rs
+++ b/rust/chains/hyperlane-ethereum/src/ism/aggregation_ism.rs
@@ -23,6 +23,7 @@ pub struct AggregationIsmBuilder {}
 #[async_trait]
 impl BuildableWithProvider for AggregationIsmBuilder {
     type Output = Box<dyn AggregationIsm>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/ism/ccip_read_ism.rs
+++ b/rust/chains/hyperlane-ethereum/src/ism/ccip_read_ism.rs
@@ -23,6 +23,7 @@ pub struct CcipReadIsmBuilder {}
 #[async_trait]
 impl BuildableWithProvider for CcipReadIsmBuilder {
     type Output = Box<dyn CcipReadIsm>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/ism/interchain_security_module.rs
+++ b/rust/chains/hyperlane-ethereum/src/ism/interchain_security_module.rs
@@ -27,6 +27,7 @@ pub struct InterchainSecurityModuleBuilder {}
 #[async_trait]
 impl BuildableWithProvider for InterchainSecurityModuleBuilder {
     type Output = Box<dyn InterchainSecurityModule>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/ism/multisig_ism.rs
+++ b/rust/chains/hyperlane-ethereum/src/ism/multisig_ism.rs
@@ -32,6 +32,7 @@ pub struct MultisigIsmBuilder {}
 #[async_trait]
 impl BuildableWithProvider for MultisigIsmBuilder {
     type Output = Box<dyn MultisigIsm>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/ism/routing_ism.rs
+++ b/rust/chains/hyperlane-ethereum/src/ism/routing_ism.rs
@@ -23,6 +23,7 @@ pub struct RoutingIsmBuilder {}
 #[async_trait]
 impl BuildableWithProvider for RoutingIsmBuilder {
     type Output = Box<dyn RoutingIsm>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
+++ b/rust/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
@@ -170,6 +170,7 @@ pub struct HyperlaneProviderBuilder {}
 #[async_trait]
 impl BuildableWithProvider for HyperlaneProviderBuilder {
     type Output = Box<dyn HyperlaneProvider>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -52,6 +52,9 @@ pub trait BuildableWithProvider {
     /// The type that will be created.
     type Output;
 
+    /// Whether this provider requires a signer
+    const NEEDS_SIGNER: bool;
+
     /// Construct a new instance of the associated trait using a connection
     /// config. This is the first step and will wrap the provider with
     /// metrics and a signer as needed.
@@ -210,11 +213,13 @@ pub trait BuildableWithProvider {
         M: Middleware + 'static,
     {
         Ok(if let Some(signer) = signer {
+            println!("Building provider with siger");
             let signing_provider = wrap_with_signer(provider, signer)
                 .await
                 .map_err(ChainCommunicationError::from_other)?;
             self.build_with_provider(signing_provider, conn, locator)
         } else {
+            println!("Building provider without siger");
             self.build_with_provider(provider, conn, locator)
         }
         .await)

--- a/rust/hyperlane-base/src/contract_sync/broadcast.rs
+++ b/rust/hyperlane-base/src/contract_sync/broadcast.rs
@@ -1,0 +1,32 @@
+use derive_new::new;
+use eyre::Result;
+use hyperlane_core::H512;
+use tokio::sync::mpsc::{Receiver as MpscReceiver, Sender as MpscSender};
+
+#[derive(Debug, Clone, new)]
+/// Wrapper around a vec of mpsc senders that broadcasts messages to all of them.
+/// This is a workaround to get an async interface for `send`, so senders are blocked if any of the receiving channels is full,
+/// rather than overwriting old messages (as the `broadcast` channel ring buffer implementation does).
+pub struct BroadcastMpscSender<T> {
+    capacity: usize,
+    #[new(default)]
+    sender: Vec<MpscSender<T>>,
+}
+
+impl BroadcastMpscSender<H512> {
+    /// Send a message to all the receiving channels.
+    // This will block if at least of the receiving channels is full
+    pub async fn send(&self, txid: H512) -> Result<()> {
+        for sender in &self.sender {
+            sender.send(txid).await?
+        }
+        Ok(())
+    }
+
+    /// Get a receiver channel that will receive messages broadcasted by all the senders
+    pub fn get_receiver(&mut self) -> MpscReceiver<H512> {
+        let (sender, receiver) = tokio::sync::mpsc::channel(self.capacity);
+        self.sender.push(sender);
+        receiver
+    }
+}

--- a/rust/hyperlane-base/src/contract_sync/broadcast.rs
+++ b/rust/hyperlane-base/src/contract_sync/broadcast.rs
@@ -34,7 +34,7 @@ impl BroadcastMpscSender<H512> {
     }
 
     /// Get a receiver channel that will receive messages broadcasted by all the senders
-    pub async fn get_receiver(&mut self) -> MpscReceiver<H512> {
+    pub async fn get_receiver(&self) -> MpscReceiver<H512> {
         let (sender, receiver) = tokio::sync::mpsc::channel(self.capacity);
 
         self.sender.lock().await.push(sender);
@@ -42,7 +42,7 @@ impl BroadcastMpscSender<H512> {
     }
 
     /// Utility function map an option of `BroadcastMpscSender` to an option of `MpscReceiver`
-    pub async fn map_get_receiver(maybe_self: Option<&mut Self>) -> Option<MpscReceiver<H512>> {
+    pub async fn map_get_receiver(maybe_self: Option<&Self>) -> Option<MpscReceiver<H512>> {
         if let Some(s) = maybe_self {
             Some(s.get_receiver().await)
         } else {

--- a/rust/hyperlane-base/src/contract_sync/broadcast.rs
+++ b/rust/hyperlane-base/src/contract_sync/broadcast.rs
@@ -24,7 +24,7 @@ pub struct BroadcastMpscSender<T> {
 
 impl BroadcastMpscSender<H512> {
     /// Send a message to all the receiving channels.
-    // This will block if at least of the receiving channels is full
+    // This will block if at least one of the receiving channels is full
     pub async fn send(&self, txid: H512) -> Result<()> {
         let senders = self.sender.lock().await;
         for sender in &*senders {

--- a/rust/hyperlane-base/src/contract_sync/broadcast.rs
+++ b/rust/hyperlane-base/src/contract_sync/broadcast.rs
@@ -1,7 +1,12 @@
+use std::sync::Arc;
+
 use derive_new::new;
 use eyre::Result;
 use hyperlane_core::H512;
-use tokio::sync::mpsc::{Receiver as MpscReceiver, Sender as MpscSender};
+use tokio::sync::{
+    mpsc::{Receiver as MpscReceiver, Sender as MpscSender},
+    Mutex,
+};
 
 #[derive(Debug, Clone, new)]
 /// Wrapper around a vec of mpsc senders that broadcasts messages to all of them.
@@ -9,24 +14,39 @@ use tokio::sync::mpsc::{Receiver as MpscReceiver, Sender as MpscSender};
 /// rather than overwriting old messages (as the `broadcast` channel ring buffer implementation does).
 pub struct BroadcastMpscSender<T> {
     capacity: usize,
+    /// To make this safe to `Clone`, the sending end has to be in an arc-mutex.
+    /// Otherwise it would be possible to call `get_receiver` and create new receiver-sender pairs, whose sender is later dropped
+    /// because the other `BroadcastMpscSender`s have no reference to it. The receiver would then point to a closed
+    /// channel. So all instances of `BroadcastMpscSender` have to point to the entire set of senders.
     #[new(default)]
-    sender: Vec<MpscSender<T>>,
+    sender: Arc<Mutex<Vec<MpscSender<T>>>>,
 }
 
 impl BroadcastMpscSender<H512> {
     /// Send a message to all the receiving channels.
     // This will block if at least of the receiving channels is full
     pub async fn send(&self, txid: H512) -> Result<()> {
-        for sender in &self.sender {
+        let senders = self.sender.lock().await;
+        for sender in &*senders {
             sender.send(txid).await?
         }
         Ok(())
     }
 
     /// Get a receiver channel that will receive messages broadcasted by all the senders
-    pub fn get_receiver(&mut self) -> MpscReceiver<H512> {
+    pub async fn get_receiver(&mut self) -> MpscReceiver<H512> {
         let (sender, receiver) = tokio::sync::mpsc::channel(self.capacity);
-        self.sender.push(sender);
+
+        self.sender.lock().await.push(sender);
         receiver
+    }
+
+    /// Utility function map an option of `BroadcastMpscSender` to an option of `MpscReceiver`
+    pub async fn map_get_receiver(maybe_self: Option<&mut Self>) -> Option<MpscReceiver<H512>> {
+        if let Some(s) = maybe_self {
+            Some(s.get_receiver().await)
+        } else {
+            None
+        }
     }
 }

--- a/rust/hyperlane-base/src/contract_sync/cursors/mod.rs
+++ b/rust/hyperlane-base/src/contract_sync/cursors/mod.rs
@@ -13,9 +13,8 @@ pub enum CursorType {
     RateLimited,
 }
 
-// H256 * 1M = 32MB per origin chain worst case
-// With one such channel per origin chain.
-const TX_ID_CHANNEL_CAPACITY: Option<usize> = Some(1_000_000);
+// H256 * 100k = ~3.2MB per origin chain
+const TX_ID_CHANNEL_CAPACITY: Option<usize> = Some(100_000);
 
 pub trait Indexable {
     /// Returns the configured cursor type of this type for the given domain, (e.g. `SequenceAware` or `RateLimited`)

--- a/rust/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/hyperlane-base/src/contract_sync/mod.rs
@@ -123,11 +123,11 @@ where
                     );
                 }
                 Err(TryRecvError::Empty) => {
-                    trace!("No txid received");
+                    trace!("No tx id received");
                     break;
                 }
                 Err(err) => {
-                    warn!(?err, "Error receiving txid from channel");
+                    warn!(?err, "Error receiving tx id from channel");
                     break;
                 }
             }

--- a/rust/hyperlane-base/src/settings/chains.rs
+++ b/rust/hyperlane-base/src/settings/chains.rs
@@ -782,7 +782,10 @@ impl ChainConf {
     where
         B: BuildableWithProvider + Sync,
     {
-        let signer = self.ethereum_signer().await?;
+        let mut signer = None;
+        if B::NEEDS_SIGNER {
+            signer = self.ethereum_signer().await?;
+        }
         let metrics_conf = self.metrics_conf();
         let rpc_metrics = Some(metrics.json_rpc_client_metrics());
         let middleware_metrics = Some((metrics.provider_metrics(), metrics_conf));

--- a/rust/utils/run-locally/src/invariants.rs
+++ b/rust/utils/run-locally/src/invariants.rs
@@ -67,9 +67,7 @@ pub fn termination_invariants_met(
     const HYPER_INCOMING_BODY_LOG_MESSAGE: &str = "incoming body completed";
 
     // Only noticed 1 or 2 items in the txid logs, but also included 3 out of caution
-    const TX_ID_INDEXING_SINGLE_LOG_MESSAGE: &str = "Found log(s) for tx id num_logs=1";
-    const TX_ID_INDEXING_DOUBLE_LOG_MESSAGE: &str = "Found log(s) for tx id num_logs=2";
-    const TX_ID_INDEXING_TRIPLE_LOG_MESSAGE: &str = "Found log(s) for tx id num_logs=3";
+    const TX_ID_INDEXING_LOG_MESSAGE: &str = "Found log(s) for tx id";
 
     let relayer_logfile = File::open(log_file_path)?;
     let invariant_logs = &[
@@ -77,9 +75,7 @@ pub fn termination_invariants_met(
         LOOKING_FOR_EVENTS_LOG_MESSAGE,
         GAS_EXPENDITURE_LOG_MESSAGE,
         HYPER_INCOMING_BODY_LOG_MESSAGE,
-        TX_ID_INDEXING_SINGLE_LOG_MESSAGE,
-        TX_ID_INDEXING_DOUBLE_LOG_MESSAGE,
-        TX_ID_INDEXING_TRIPLE_LOG_MESSAGE,
+        TX_ID_INDEXING_LOG_MESSAGE,
     ];
     let log_counts = get_matching_lines(&relayer_logfile, invariant_logs);
     // Zero insertion messages don't reach `submit` stage where gas is spent, so we only expect these logs for the other messages.
@@ -102,23 +98,17 @@ pub fn termination_invariants_met(
         log_counts.get(LOOKING_FOR_EVENTS_LOG_MESSAGE).unwrap() > &0,
         "Didn't find any logs about looking for events in index range"
     );
-    let total_tx_id_log_count = log_counts
-        .get(TX_ID_INDEXING_SINGLE_LOG_MESSAGE)
-        .unwrap_or(&0)
-        + 2 * log_counts
-            .get(TX_ID_INDEXING_DOUBLE_LOG_MESSAGE)
-            .unwrap_or(&0)
-        + 3 * log_counts
-            .get(TX_ID_INDEXING_TRIPLE_LOG_MESSAGE)
-            .unwrap_or(&0);
+    let total_tx_id_log_count = log_counts.get(TX_ID_INDEXING_LOG_MESSAGE).unwrap();
     assert!(
         // there are 3 txid-indexed events:
         // - relayer: merkle insertion and gas payment
         // - scraper: gas payment
-        total_tx_id_log_count as u64 >= config.kathy_messages * 3,
+        // some logs are emitted for multiple events, so requiring there to be at least
+        // `config.kathy_messages` logs is a reasonable approximation
+        *total_tx_id_log_count as u64 >= config.kathy_messages,
         "Didn't find as many tx id logs as expected. Found {} and expected {}",
         total_tx_id_log_count,
-        config.kathy_messages * 3
+        config.kathy_messages
     );
     assert!(
         log_counts.get(HYPER_INCOMING_BODY_LOG_MESSAGE).is_none(),

--- a/rust/utils/run-locally/src/invariants.rs
+++ b/rust/utils/run-locally/src/invariants.rs
@@ -116,7 +116,9 @@ pub fn termination_invariants_met(
         // - relayer: merkle insertion and gas payment
         // - scraper: gas payment
         total_tx_id_log_count as u64 >= config.kathy_messages * 3,
-        "Didn't find any logs about looking for events in index range"
+        "Didn't find as many tx id logs as expected. Found {} and expected {}",
+        total_tx_id_log_count,
+        config.kathy_messages * 3
     );
     assert!(
         log_counts.get(HYPER_INCOMING_BODY_LOG_MESSAGE).is_none(),

--- a/rust/utils/run-locally/src/invariants.rs
+++ b/rust/utils/run-locally/src/invariants.rs
@@ -66,7 +66,6 @@ pub fn termination_invariants_met(
     const LOOKING_FOR_EVENTS_LOG_MESSAGE: &str = "Looking for events in index range";
     const HYPER_INCOMING_BODY_LOG_MESSAGE: &str = "incoming body completed";
 
-    // Only noticed 1 or 2 items in the txid logs, but also included 3 out of caution
     const TX_ID_INDEXING_LOG_MESSAGE: &str = "Found log(s) for tx id";
 
     let relayer_logfile = File::open(log_file_path)?;
@@ -104,7 +103,8 @@ pub fn termination_invariants_met(
         // - relayer: merkle insertion and gas payment
         // - scraper: gas payment
         // some logs are emitted for multiple events, so requiring there to be at least
-        // `config.kathy_messages` logs is a reasonable approximation
+        // `config.kathy_messages` logs is a reasonable approximation, since all three of these events
+        // are expected to be logged for each message.
         *total_tx_id_log_count as u64 >= config.kathy_messages,
         "Didn't find as many tx id logs as expected. Found {} and expected {}",
         total_tx_id_log_count,


### PR DESCRIPTION
### Description

Follow up to https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4180

Lowers txid broadcast channel capacity from 1M to 30k and refactors it to use a vec of `mpsc` under the hood.

### Context
The heap profiler showed that each new chain takes up 100MB of memory because of the txid broadcast channel. In addition to this, the tokio broadcast channel is a ring buffer where new items simply overwrite old items, making it hard to safely lower the capacity. 

As such, to be able to safely lower the capacity of this channel, usage of `tokio`'s `broadcast` channel is replaced with a `Vec` of `mpsc`s, which offer an async `send` interface for backpressure. So instead of overwriting old items, senders will block on sends, which makes sense in our case as we absolutely don't want to miss items. The submitter is slower than the indexer based on empirical observation, so blocking on channel size doesn't bottleneck throughput.

I noticed the max number of channel items we can reach is 29k, by running the RC relayer after an 8 day break, during which around 160k messages were submitted. Lowering the capacity to 30k should cause us to only encounter backpressure in very rare cases, and the footprint of this channel would lower from 100MB to 3MB.

### Drive-by changes

The delivery indexer in the scraper is no longer passed a txid receiver, since message deliveries are not expected to occur in the same tx as message dispatches.

### Related issues

- Fixes https://github.com/hyperlane-xyz/issues/issues/1293

### Testing

E2E, by adding invariants to make sure txid indexing works
