### PR TITLE
fix(cli): hide large configs in core read command

### DIFF
--- a/.changeset/spotty-ducks-sell.md
+++ b/.changeset/spotty-ducks-sell.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Update hyperlane core read to log the config terminal "preview", only if the number of lines is < 250

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -1,4 +1,3 @@
-import { stringify as yamlStringify } from 'yaml';
 import { CommandModule } from 'yargs';
 
 import { EvmCoreReader } from '@hyperlane-xyz/sdk';
@@ -12,7 +11,7 @@ import { runCoreDeploy } from '../deploy/core.js';
 import { evaluateIfDryRunFailure } from '../deploy/dry-run.js';
 import { errorRed, log, logGray, logGreen } from '../logger.js';
 import {
-  indentYamlOrJson,
+  logYamlIfUnderMaxLines,
   readYamlOrJson,
   writeYamlOrJson,
 } from '../utils/files.js';
@@ -146,7 +145,7 @@ export const read: CommandModuleWithContext<{
       const coreConfig = await evmCoreReader.deriveCoreConfig(mailbox);
       writeYamlOrJson(configFilePath, coreConfig, 'yaml');
       logGreen(`✅ Core config written successfully to ${configFilePath}:\n`);
-      log(indentYamlOrJson(yamlStringify(coreConfig, null, 2), 4));
+      logYamlIfUnderMaxLines(coreConfig, 250);
     } catch (e: any) {
       errorRed(
         `❌ Failed to read core config for mailbox ${mailbox} on ${chain}:`,

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -11,7 +11,6 @@ import { runCoreDeploy } from '../deploy/core.js';
 import { evaluateIfDryRunFailure } from '../deploy/dry-run.js';
 import { errorRed, log, logGray, logGreen } from '../logger.js';
 import {
-  MAX_READ_LINE_OUTPUT,
   logYamlIfUnderMaxLines,
   readYamlOrJson,
   writeYamlOrJson,

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -146,7 +146,7 @@ export const read: CommandModuleWithContext<{
       const coreConfig = await evmCoreReader.deriveCoreConfig(mailbox);
       writeYamlOrJson(configFilePath, coreConfig, 'yaml');
       logGreen(`✅ Core config written successfully to ${configFilePath}:\n`);
-      logYamlIfUnderMaxLines(coreConfig, MAX_READ_LINE_OUTPUT);
+      logYamlIfUnderMaxLines(coreConfig);
     } catch (e: any) {
       errorRed(
         `❌ Failed to read core config for mailbox ${mailbox} on ${chain}:`,

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -11,6 +11,7 @@ import { runCoreDeploy } from '../deploy/core.js';
 import { evaluateIfDryRunFailure } from '../deploy/dry-run.js';
 import { errorRed, log, logGray, logGreen } from '../logger.js';
 import {
+  MAX_READ_LINE_OUTPUT,
   logYamlIfUnderMaxLines,
   readYamlOrJson,
   writeYamlOrJson,
@@ -145,7 +146,7 @@ export const read: CommandModuleWithContext<{
       const coreConfig = await evmCoreReader.deriveCoreConfig(mailbox);
       writeYamlOrJson(configFilePath, coreConfig, 'yaml');
       logGreen(`✅ Core config written successfully to ${configFilePath}:\n`);
-      logYamlIfUnderMaxLines(coreConfig, 250);
+      logYamlIfUnderMaxLines(coreConfig, MAX_READ_LINE_OUTPUT);
     } catch (e: any) {
       errorRed(
         `❌ Failed to read core config for mailbox ${mailbox} on ${chain}:`,

--- a/typescript/cli/src/utils/files.ts
+++ b/typescript/cli/src/utils/files.ts
@@ -238,8 +238,8 @@ export function indentYamlOrJson(str: string, indentLevel: number): string {
  */
 export function logYamlIfUnderMaxLines(
   obj: any,
-  maxLines: number,
-  margin = 2,
+  maxLines: number = MAX_READ_LINE_OUTPUT,
+  margin: number = 2,
 ): void {
   const asYamlString = yamlStringify(obj, null, margin);
   const lineCounter = new LineCounter();

--- a/typescript/cli/src/utils/files.ts
+++ b/typescript/cli/src/utils/files.ts
@@ -3,7 +3,12 @@ import select from '@inquirer/select';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { parse as yamlParse, stringify as yamlStringify } from 'yaml';
+import {
+  LineCounter,
+  parse,
+  parse as yamlParse,
+  stringify as yamlStringify,
+} from 'yaml';
 
 import { objMerge } from '@hyperlane-xyz/utils';
 
@@ -220,4 +225,23 @@ export function indentYamlOrJson(str: string, indentLevel: number): string {
     .split('\n')
     .map((line) => indent + line)
     .join('\n');
+}
+
+/**
+ * Logs the YAML representation of an object if the number of lines is less than the specified maximum.
+ *
+ * @param obj - The object to be converted to YAML.
+ * @param maxLines - The maximum number of lines allowed for the YAML representation.
+ * @param margin - The number of spaces to use for indentation (default is 2).
+ */
+export function logYamlIfUnderMaxLines(
+  obj: any,
+  maxLines: number,
+  margin = 2,
+): void {
+  const asYamlString = yamlStringify(obj, null, margin);
+  const lineCounter = new LineCounter();
+  parse(asYamlString, { lineCounter });
+
+  log(lineCounter.lineStarts.length < maxLines ? asYamlString : '');
 }

--- a/typescript/cli/src/utils/files.ts
+++ b/typescript/cli/src/utils/files.ts
@@ -14,6 +14,8 @@ import { objMerge } from '@hyperlane-xyz/utils';
 
 import { log } from '../logger.js';
 
+export const MAX_READ_LINE_OUTPUT = 250;
+
 export type FileFormat = 'yaml' | 'json';
 
 export type ArtifactsFile = {


### PR DESCRIPTION
### Description
This PR adds a helper function that logs the config terminal "preview", _only_ if the number of lines is < 250 for `hyperlane core read`.

### Related issues
- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4191

Yes

### Testing
Manual
- `yarn build && yarn hyperlane core read --mailbox 0x2f9DB5616fa3fAd1aB06cB2C906830BA63d135e3  --chain fraxtal `
- And tried with a deployed one to test out lines < 250
