### PR TITLE
fix(sdk): silence provider logs in deriveIsmConfig

### DIFF
--- a/.changeset/lazy-years-judge.md
+++ b/.changeset/lazy-years-judge.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Creates HyperlaneReader to re-use dyn provider log level & silences provider logs in deriveIsmConfig like deriveHookConfig.

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -147,9 +147,9 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
         this.logger.debug(`${customMessage}:\n\t${e}`);
       }
       throw new Error(`${customMessage}:\n\t${e}`);
+    } finally {
+      this.setSmartProviderLogLevel(getLogLevel()); // returns to original level defined by rootLogger
     }
-
-    this.setSmartProviderLogLevel(getLogLevel()); // returns to original level defined by rootLogger
 
     return derivedHookConfig;
   }

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -1,4 +1,4 @@
-import { ethers, providers } from 'ethers';
+import { ethers } from 'ethers';
 
 import {
   DomainRoutingHook,
@@ -27,6 +27,7 @@ import {
 import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainNameOrId } from '../types.js';
+import { HyperlaneReader } from '../utils/HyperlaneReader.js';
 
 import {
   AggregationHookConfig,
@@ -75,8 +76,7 @@ export interface HookReader {
   ): void;
 }
 
-export class EvmHookReader implements HookReader {
-  protected readonly provider: providers.Provider;
+export class EvmHookReader extends HyperlaneReader implements HookReader {
   protected readonly logger = rootLogger.child({ module: 'EvmHookReader' });
 
   constructor(
@@ -86,15 +86,15 @@ export class EvmHookReader implements HookReader {
       chain,
     ) ?? DEFAULT_CONTRACT_READ_CONCURRENCY,
   ) {
-    this.provider = multiProvider.getProvider(chain);
+    super(multiProvider, chain);
   }
 
   async deriveHookConfig(address: Address): Promise<DerivedHookConfig> {
-    let onchainHookType = undefined;
+    let onchainHookType: OnchainHookType | undefined = undefined;
     let derivedHookConfig: DerivedHookConfig;
     try {
       const hook = IPostDispatchHook__factory.connect(address, this.provider);
-      this.logger.debug('Deriving HookConfig', { address });
+      this.logger.debug('Deriving HookConfig:', { address });
 
       // Temporarily turn off SmartProvider logging
       // Provider errors are expected because deriving will call methods that may not exist in the Bytecode
@@ -387,18 +387,6 @@ export class EvmHookReader implements HookReader {
       paused,
       type: HookType.PAUSABLE,
     };
-  }
-
-  /**
-   * Conditionally sets the log level for a smart provider.
-   *
-   * @param level - The log level to set, e.g. 'debug', 'info', 'warn', 'error'.
-   */
-  protected setSmartProviderLogLevel(level: string): void {
-    if ('setLogLevel' in this.provider) {
-      //@ts-ignore
-      this.provider.setLogLevel(level);
-    }
   }
 
   assertHookType(

--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -107,9 +107,9 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
       const errorMessage = `Failed to derive ISM module type ${moduleType} (${address}):\n\t${e}`;
       this.logger.debug(errorMessage);
       throw new Error(errorMessage);
+    } finally {
+      this.setSmartProviderLogLevel(getLogLevel()); // returns to original level defined by rootLogger
     }
-
-    this.setSmartProviderLogLevel(getLogLevel()); // returns to original level defined by rootLogger
 
     return derivedIsmConfig;
   }

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -97,7 +97,7 @@ export class HyperlaneSmartProvider
     this.supportedMethods = [...supportedMethods.values()];
   }
 
-  setLogLevel(level: pino.LevelWithSilentOrString) {
+  setLogLevel(level: pino.LevelWithSilentOrString): void {
     this.logger.level = level;
   }
 

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -1,4 +1,4 @@
-import { BigNumber, constants, providers } from 'ethers';
+import { BigNumber, constants } from 'ethers';
 
 import {
   HypERC20CollateralVaultDeposit__factory,
@@ -25,15 +25,15 @@ import { EvmIsmReader } from '../ism/EvmIsmReader.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { RemoteRouters } from '../router/types.js';
 import { ChainNameOrId } from '../types.js';
+import { HyperlaneReader } from '../utils/HyperlaneReader.js';
 
 import { CollateralExtensions } from './config.js';
 import { TokenMetadata } from './types.js';
 
-export class EvmERC20WarpRouteReader {
+export class EvmERC20WarpRouteReader extends HyperlaneReader {
   protected readonly logger = rootLogger.child({
     module: 'EvmERC20WarpRouteReader',
   });
-  provider: providers.Provider;
   evmHookReader: EvmHookReader;
   evmIsmReader: EvmIsmReader;
 
@@ -42,7 +42,7 @@ export class EvmERC20WarpRouteReader {
     protected readonly chain: ChainNameOrId,
     protected readonly concurrency: number = DEFAULT_CONTRACT_READ_CONCURRENCY,
   ) {
-    this.provider = this.multiProvider.getProvider(chain);
+    super(multiProvider, chain);
     this.evmHookReader = new EvmHookReader(multiProvider, chain, concurrency);
     this.evmIsmReader = new EvmIsmReader(multiProvider, chain, concurrency);
   }
@@ -233,16 +233,5 @@ export class EvmERC20WarpRouteReader {
         }),
       ),
     );
-  }
-  /**
-   * Conditionally sets the log level for a smart provider.
-   *
-   * @param level - The log level to set, e.g. 'debug', 'info', 'warn', 'error'.
-   */
-  protected setSmartProviderLogLevel(level: string) {
-    if ('setLogLevel' in this.provider) {
-      //@ts-ignore
-      this.provider.setLogLevel(level);
-    }
   }
 }

--- a/typescript/sdk/src/utils/HyperlaneReader.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.ts
@@ -1,0 +1,28 @@
+import { providers } from 'ethers';
+import { LevelWithSilentOrString } from 'pino';
+
+import { MultiProvider } from '../providers/MultiProvider.js';
+import { HyperlaneSmartProvider } from '../providers/SmartProvider/SmartProvider.js';
+import { ChainNameOrId } from '../types.js';
+
+export class HyperlaneReader {
+  provider: providers.Provider;
+
+  constructor(
+    protected readonly multiProvider: MultiProvider,
+    protected readonly chain: ChainNameOrId,
+  ) {
+    this.provider = this.multiProvider.getProvider(chain);
+  }
+
+  /**
+   * Conditionally sets the log level for a smart provider.
+   *
+   * @param level - The log level to set, e.g. 'debug', 'info', 'warn', 'error'.
+   */
+  protected setSmartProviderLogLevel(level: LevelWithSilentOrString): void {
+    if ('setLogLevel' in this.provider) {
+      (this.provider as HyperlaneSmartProvider).setLogLevel(level);
+    }
+  }
+}


### PR DESCRIPTION
### Description

- silences provider logs in deriveIsmConfig, like deriveHookConfig
- created HyperlaneReader class for readers to extend in order to reuse `setSmartProviderLogLevel`

### Drive-by changes

- none

### Related issues

- fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4061

### Backward compatibility

- yes

### Testing

- manual
- ci