### PR TITLE
fix(evm): only create signer provider when needed

### DIFF
--- a/rust/chains/hyperlane-ethereum/src/contracts/interchain_gas.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/interchain_gas.rs
@@ -38,6 +38,7 @@ pub struct InterchainGasPaymasterIndexerBuilder {
 #[async_trait]
 impl BuildableWithProvider for InterchainGasPaymasterIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<InterchainGasPayment>>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
@@ -176,6 +177,7 @@ pub struct InterchainGasPaymasterBuilder {}
 #[async_trait]
 impl BuildableWithProvider for InterchainGasPaymasterBuilder {
     type Output = Box<dyn InterchainGasPaymaster>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/contracts/mailbox.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/mailbox.rs
@@ -52,6 +52,7 @@ pub struct SequenceIndexerBuilder {
 #[async_trait]
 impl BuildableWithProvider for SequenceIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<HyperlaneMessage>>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
@@ -74,6 +75,7 @@ pub struct DeliveryIndexerBuilder {
 #[async_trait]
 impl BuildableWithProvider for DeliveryIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<H256>>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
@@ -245,6 +247,7 @@ pub struct MailboxBuilder {}
 #[async_trait]
 impl BuildableWithProvider for MailboxBuilder {
     type Output = Box<dyn Mailbox>;
+    const NEEDS_SIGNER: bool = true;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/contracts/merkle_tree_hook.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/merkle_tree_hook.rs
@@ -44,6 +44,7 @@ pub struct MerkleTreeHookBuilder {}
 #[async_trait]
 impl BuildableWithProvider for MerkleTreeHookBuilder {
     type Output = Box<dyn MerkleTreeHook>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
@@ -62,6 +63,7 @@ pub struct MerkleTreeHookIndexerBuilder {
 #[async_trait]
 impl BuildableWithProvider for MerkleTreeHookIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<MerkleTreeInsertion>>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/contracts/validator_announce.rs
+++ b/rust/chains/hyperlane-ethereum/src/contracts/validator_announce.rs
@@ -34,6 +34,7 @@ pub struct ValidatorAnnounceBuilder {}
 #[async_trait]
 impl BuildableWithProvider for ValidatorAnnounceBuilder {
     type Output = Box<dyn ValidatorAnnounce>;
+    const NEEDS_SIGNER: bool = true;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/ism/aggregation_ism.rs
+++ b/rust/chains/hyperlane-ethereum/src/ism/aggregation_ism.rs
@@ -23,6 +23,7 @@ pub struct AggregationIsmBuilder {}
 #[async_trait]
 impl BuildableWithProvider for AggregationIsmBuilder {
     type Output = Box<dyn AggregationIsm>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/ism/ccip_read_ism.rs
+++ b/rust/chains/hyperlane-ethereum/src/ism/ccip_read_ism.rs
@@ -23,6 +23,7 @@ pub struct CcipReadIsmBuilder {}
 #[async_trait]
 impl BuildableWithProvider for CcipReadIsmBuilder {
     type Output = Box<dyn CcipReadIsm>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/ism/interchain_security_module.rs
+++ b/rust/chains/hyperlane-ethereum/src/ism/interchain_security_module.rs
@@ -27,6 +27,7 @@ pub struct InterchainSecurityModuleBuilder {}
 #[async_trait]
 impl BuildableWithProvider for InterchainSecurityModuleBuilder {
     type Output = Box<dyn InterchainSecurityModule>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/ism/multisig_ism.rs
+++ b/rust/chains/hyperlane-ethereum/src/ism/multisig_ism.rs
@@ -32,6 +32,7 @@ pub struct MultisigIsmBuilder {}
 #[async_trait]
 impl BuildableWithProvider for MultisigIsmBuilder {
     type Output = Box<dyn MultisigIsm>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/ism/routing_ism.rs
+++ b/rust/chains/hyperlane-ethereum/src/ism/routing_ism.rs
@@ -23,6 +23,7 @@ pub struct RoutingIsmBuilder {}
 #[async_trait]
 impl BuildableWithProvider for RoutingIsmBuilder {
     type Output = Box<dyn RoutingIsm>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
+++ b/rust/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
@@ -170,6 +170,7 @@ pub struct HyperlaneProviderBuilder {}
 #[async_trait]
 impl BuildableWithProvider for HyperlaneProviderBuilder {
     type Output = Box<dyn HyperlaneProvider>;
+    const NEEDS_SIGNER: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -52,6 +52,9 @@ pub trait BuildableWithProvider {
     /// The type that will be created.
     type Output;
 
+    /// Whether this provider requires a signer
+    const NEEDS_SIGNER: bool;
+
     /// Construct a new instance of the associated trait using a connection
     /// config. This is the first step and will wrap the provider with
     /// metrics and a signer as needed.
@@ -210,11 +213,13 @@ pub trait BuildableWithProvider {
         M: Middleware + 'static,
     {
         Ok(if let Some(signer) = signer {
+            println!("Building provider with siger");
             let signing_provider = wrap_with_signer(provider, signer)
                 .await
                 .map_err(ChainCommunicationError::from_other)?;
             self.build_with_provider(signing_provider, conn, locator)
         } else {
+            println!("Building provider without siger");
             self.build_with_provider(provider, conn, locator)
         }
         .await)

--- a/rust/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -213,13 +213,11 @@ pub trait BuildableWithProvider {
         M: Middleware + 'static,
     {
         Ok(if let Some(signer) = signer {
-            println!("Building provider with siger");
             let signing_provider = wrap_with_signer(provider, signer)
                 .await
                 .map_err(ChainCommunicationError::from_other)?;
             self.build_with_provider(signing_provider, conn, locator)
         } else {
-            println!("Building provider without siger");
             self.build_with_provider(provider, conn, locator)
         }
         .await)

--- a/rust/hyperlane-base/src/settings/chains.rs
+++ b/rust/hyperlane-base/src/settings/chains.rs
@@ -782,7 +782,10 @@ impl ChainConf {
     where
         B: BuildableWithProvider + Sync,
     {
-        let signer = self.ethereum_signer().await?;
+        let mut signer = None;
+        if B::NEEDS_SIGNER {
+            signer = self.ethereum_signer().await?;
+        }
         let metrics_conf = self.metrics_conf();
         let rpc_metrics = Some(metrics.json_rpc_client_metrics());
         let middleware_metrics = Some((metrics.provider_metrics(), metrics_conf));


### PR DESCRIPTION
### Description

Adds an associated const to all ethereum provider builders to specify whether a signer is needed. For an e2e run with 20 messages, we now have 12 providers built with signers at the beginning (3 of which are validator announce), and 708 providers built without a signer. This should hopefully fix the gas escalator memory leak.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
