### PR TITLE
feat: default to mailbox address in registry

### DIFF
--- a/.changeset/plenty-cameras-hide.md
+++ b/.changeset/plenty-cameras-hide.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/cli": patch
+---
+
+Default to mailbox address in registry

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -115,8 +115,8 @@ export const init: CommandModuleWithContext<{
 
 export const read: CommandModuleWithContext<{
   chain: string;
-  mailbox: string;
   config: string;
+  mailbox?: string;
 }> = {
   command: 'read',
   describe: 'Reads onchain Core configuration for a given mailbox address',
@@ -128,7 +128,6 @@ export const read: CommandModuleWithContext<{
     mailbox: {
       type: 'string',
       description: 'Mailbox address used to derive the core config',
-      demandOption: true,
     },
     config: outputFileCommandOption(
       './configs/core-config.yaml',
@@ -137,6 +136,16 @@ export const read: CommandModuleWithContext<{
     ),
   },
   handler: async ({ context, chain, mailbox, config: configFilePath }) => {
+    if (!mailbox) {
+      const addresses = await context.registry.getChainAddresses(chain);
+      mailbox = addresses?.mailbox;
+      if (!mailbox) {
+        throw new Error(
+          `${chain} mailbox not provided and none found in registry ${context.registry.getUri()}`,
+        );
+      }
+    }
+
     logGray('Hyperlane Core Read');
     logGray('-------------------');
 


### PR DESCRIPTION
### Description

```sh
yarn hyperlane core read --chain etherereum
```
will fetch mailbox address from registry

### Drive-by changes

None

### Backward compatibility

Yes

### Testing

Manual