### PR TITLE
fix: use merkle tree hook address from registry for self relay hook derivations

### DIFF
--- a/.changeset/fast-teachers-drum.md
+++ b/.changeset/fast-teachers-drum.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/cli": patch
+---
+
+fix: use merkle tree hook address from registry for self relay hook derivations

--- a/typescript/cli/src/send/message.ts
+++ b/typescript/cli/src/send/message.ts
@@ -9,6 +9,7 @@ import { runPreflightChecksForChains } from '../deploy/utils.js';
 import { errorRed, log, logBlue, logGreen } from '../logger.js';
 import { runSingleChainSelectionStep } from '../utils/chains.js';
 import { indentYamlOrJson } from '../utils/files.js';
+import { stubMerkleTreeConfig } from '../utils/relay.js';
 
 export async function sendTestMessage({
   context,
@@ -110,6 +111,11 @@ async function executeDelivery({
 
     if (selfRelay) {
       const relayer = new HyperlaneRelayer({ core });
+
+      const hookAddress = await core.getSenderHookAddress(message);
+      const merkleAddress = chainAddresses[origin].merkleTreeHook;
+      stubMerkleTreeConfig(relayer, origin, hookAddress, merkleAddress);
+
       log('Attempting self-relay of message');
       await relayer.relayMessage(dispatchTx);
       logGreen('Message was self-relayed!');

--- a/typescript/cli/src/send/transfer.ts
+++ b/typescript/cli/src/send/transfer.ts
@@ -20,6 +20,7 @@ import { runPreflightChecksForChains } from '../deploy/utils.js';
 import { log, logBlue, logGreen, logRed } from '../logger.js';
 import { runSingleChainSelectionStep } from '../utils/chains.js';
 import { indentYamlOrJson } from '../utils/files.js';
+import { stubMerkleTreeConfig } from '../utils/relay.js';
 import { runTokenSelectionStep } from '../utils/tokens.js';
 
 export async function sendTestTransfer({
@@ -171,6 +172,11 @@ async function executeDelivery({
 
   if (selfRelay) {
     const relayer = new HyperlaneRelayer({ core });
+
+    const hookAddress = await core.getSenderHookAddress(message);
+    const merkleAddress = chainAddresses[origin].merkleTreeHook;
+    stubMerkleTreeConfig(relayer, origin, hookAddress, merkleAddress);
+
     log('Attempting self-relay of transfer...');
     await relayer.relayMessage(transferTxReceipt, messageIndex, message);
     logGreen('Transfer was self-relayed!');

--- a/typescript/cli/src/status/message.ts
+++ b/typescript/cli/src/status/message.ts
@@ -7,6 +7,7 @@ import { assert } from '@hyperlane-xyz/utils';
 import { CommandContext } from '../context/types.js';
 import { log, logBlue, logGreen, logRed } from '../logger.js';
 import { runSingleChainSelectionStep } from '../utils/chains.js';
+import { stubMerkleTreeConfig } from '../utils/relay.js';
 
 export async function checkMessageStatus({
   context,
@@ -78,6 +79,11 @@ export async function checkMessageStatus({
     }
 
     const relayer = new HyperlaneRelayer({ core });
+
+    const hookAddress = await core.getSenderHookAddress(message);
+    const merkleAddress = chainAddresses[origin].merkleTreeHook;
+    stubMerkleTreeConfig(relayer, origin, hookAddress, merkleAddress);
+
     deliveredTx = await relayer.relayMessage(dispatchedReceipt);
   }
 

--- a/typescript/cli/src/utils/relay.ts
+++ b/typescript/cli/src/utils/relay.ts
@@ -1,8 +1,8 @@
 import { HookType, HyperlaneRelayer } from '@hyperlane-xyz/sdk';
 
 /**
-* Workaround helper for bypassing bad hook derivation when self-relaying.
-*/
+ * Workaround helper for bypassing bad hook derivation when self-relaying.
+ */
 export function stubMerkleTreeConfig(
   relayer: HyperlaneRelayer,
   chain: string,

--- a/typescript/cli/src/utils/relay.ts
+++ b/typescript/cli/src/utils/relay.ts
@@ -1,6 +1,8 @@
 import { HookType, HyperlaneRelayer } from '@hyperlane-xyz/sdk';
 
-// hack for bypassing bad hook derivation when self-relaying
+/**
+* Workaround helper for bypassing bad hook derivation when self-relaying.
+*/
 export function stubMerkleTreeConfig(
   relayer: HyperlaneRelayer,
   chain: string,

--- a/typescript/cli/src/utils/relay.ts
+++ b/typescript/cli/src/utils/relay.ts
@@ -1,0 +1,21 @@
+import { HookType, HyperlaneRelayer } from '@hyperlane-xyz/sdk';
+
+// hack for bypassing bad hook derivation when self-relaying
+export function stubMerkleTreeConfig(
+  relayer: HyperlaneRelayer,
+  chain: string,
+  hookAddress: string,
+  merkleAddress: string,
+) {
+  relayer.hydrate({
+    hook: {
+      [chain]: {
+        [hookAddress]: {
+          type: HookType.MERKLE_TREE,
+          address: merkleAddress,
+        },
+      },
+    },
+    ism: {},
+  });
+}


### PR DESCRIPTION
### Description

Circumvents bad hook derivation during self relay

### Related issues

- Fixes https://github.com/hyperlane-xyz/issues/issues/1320

### Backward compatibility

Yes

### Testing

manual warp send from sepolia origin
