### PR TITLE
feat(infra): ensure check-deploy covers ownable ISMs

### DIFF
--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -22,6 +22,7 @@
     "@solana/web3.js": "^1.78.0",
     "asn1.js": "5.4.1",
     "aws-kms-ethers-signer": "^0.1.3",
+    "deep-object-diff": "^1.1.9",
     "dotenv": "^10.0.0",
     "json-stable-stringify": "^1.1.1",
     "prom-client": "^14.0.1",

--- a/typescript/infra/scripts/check-deploy.ts
+++ b/typescript/infra/scripts/check-deploy.ts
@@ -21,6 +21,7 @@ import { HyperlaneIgpGovernor } from '../src/govern/HyperlaneIgpGovernor.js';
 import { ProxiedRouterGovernor } from '../src/govern/ProxiedRouterGovernor.js';
 import { Role } from '../src/roles.js';
 import { impersonateAccount, useLocalProvider } from '../src/utils/fork.js';
+import { logViolationDetails } from '../src/utils/violation.js';
 
 import {
   Modules,
@@ -173,6 +174,9 @@ async function check() {
         'actual',
         'expected',
       ]);
+
+      logViolationDetails(violations);
+
       if (!fork) {
         throw new Error(
           `Checking ${module} deploy yielded ${violations.length} violations`,

--- a/typescript/infra/src/utils/violation.ts
+++ b/typescript/infra/src/utils/violation.ts
@@ -1,0 +1,206 @@
+import chalk from 'chalk';
+import { addedDiff, deletedDiff, updatedDiff } from 'deep-object-diff';
+import stringify from 'json-stable-stringify';
+import { fromError } from 'zod-validation-error';
+
+import {
+  CheckerViolation,
+  CoreViolationType,
+  IsmConfigSchema,
+  MailboxViolation,
+  MailboxViolationType,
+} from '@hyperlane-xyz/sdk';
+
+interface AnyObject {
+  [key: string]: any;
+}
+
+const ignoreFields = ['address', 'ownerOverrides'];
+
+function updatePath(json: AnyObject, path: string): string {
+  const pathParts = path.split('.');
+  const newPathParts: string[] = [];
+  let currentObject: AnyObject | undefined = json;
+
+  for (let i = 0; i < pathParts.length; i++) {
+    const part = pathParts[i];
+
+    if (currentObject && typeof currentObject === 'object') {
+      if ('type' in currentObject) {
+        newPathParts.push(currentObject.type);
+      }
+
+      if (part in currentObject) {
+        currentObject = currentObject[part];
+      } else {
+        currentObject = undefined;
+      }
+    }
+
+    newPathParts.push(part);
+  }
+
+  return newPathParts.join('.');
+}
+
+function toLowerCaseValues(obj: any): any {
+  if (typeof obj === 'string') {
+    return obj.toLowerCase();
+  }
+
+  if (typeof obj !== 'object' || obj === null) {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(toLowerCaseValues);
+  }
+
+  return Object.keys(obj).reduce((acc: any, key: string) => {
+    if (key !== 'type') {
+      acc[key] = toLowerCaseValues(obj[key]);
+    } else {
+      acc[key] = obj[key];
+    }
+    return acc;
+  }, {});
+}
+
+function sortArraysByType(obj: AnyObject): AnyObject {
+  if (Array.isArray(obj)) {
+    return obj
+      .sort((a, b) => {
+        if (a.type < b.type) return -1;
+        if (a.type > b.type) return 1;
+        return 0;
+      })
+      .map((item) => sortArraysByType(item));
+  } else if (typeof obj === 'object' && obj !== null) {
+    const sortedObj: AnyObject = {};
+    Object.keys(obj).forEach((key) => {
+      sortedObj[key] = sortArraysByType(obj[key]);
+    });
+    return sortedObj;
+  }
+  return obj;
+}
+
+function removeFields(obj: any): any {
+  if (Array.isArray(obj)) {
+    return obj.map(removeFields);
+  } else if (obj !== null && typeof obj === 'object') {
+    return Object.keys(obj).reduce((result: any, key: string) => {
+      if (!ignoreFields.includes(key)) {
+        result[key] = removeFields(obj[key]);
+      }
+      return result;
+    }, {});
+  } else {
+    return obj;
+  }
+}
+
+function logDiff(expected: AnyObject, actual: AnyObject): void {
+  const sortedExpected = sortArraysByType(expected);
+  const sortedActual = sortArraysByType(actual);
+
+  const sortedExpectedJson = stringify(sortedExpected, { space: 2 });
+  const sortedActualJson = stringify(sortedActual, { space: 2 });
+
+  const parsedSortedExpected = JSON.parse(sortedExpectedJson);
+  const parsedSortedActual = JSON.parse(sortedActualJson);
+
+  const added = addedDiff(parsedSortedExpected, parsedSortedActual);
+  const deleted = deletedDiff(parsedSortedExpected, parsedSortedActual);
+  const updated = updatedDiff(parsedSortedExpected, parsedSortedActual);
+
+  const logChanges = (
+    changes: AnyObject,
+    changeType: string,
+    color: (text: string) => string,
+    config: AnyObject,
+  ) => {
+    const logChange = (obj: AnyObject, path: string = '') => {
+      Object.keys(obj).forEach((key) => {
+        const currentPath = path ? `${path}.${key}` : key;
+        if (
+          typeof obj[key] === 'object' &&
+          obj[key] !== null &&
+          !Array.isArray(obj[key])
+        ) {
+          logChange(obj[key], currentPath);
+        } else {
+          console.log(
+            color(
+              `${changeType} ${updatePath(config, currentPath)}: ${stringify(
+                obj[key],
+                {
+                  space: 2,
+                },
+              )}`,
+            ),
+          );
+        }
+      });
+    };
+    logChange(changes);
+  };
+
+  logChanges(added, '+ Added to config:', chalk.green, parsedSortedActual);
+  logChanges(
+    deleted,
+    '- Deleted from config:',
+    chalk.red,
+    parsedSortedExpected,
+  );
+  logChanges(updated, '~ Updated config:', chalk.yellow, parsedSortedExpected);
+}
+
+function preProcessConfig(config: any) {
+  return removeFields(toLowerCaseValues(config));
+}
+
+export function logViolationDetails(violations: CheckerViolation[]): void {
+  for (const violation of violations) {
+    if (violation.type === CoreViolationType.Mailbox) {
+      const mailboxViolation = violation as MailboxViolation;
+
+      console.log(`Mailbox violation ${mailboxViolation.subType} details:`);
+
+      const preProcessedExpectedConfig = preProcessConfig(
+        mailboxViolation.expected,
+      );
+      const preProcessedActualConfig = preProcessConfig(
+        mailboxViolation.actual,
+      );
+
+      const expectedConfigResult = IsmConfigSchema.safeParse(
+        preProcessedExpectedConfig,
+      );
+
+      const actualConfigResult = IsmConfigSchema.safeParse(
+        preProcessedActualConfig,
+      );
+
+      if (!expectedConfigResult.success || !actualConfigResult.success) {
+        if (!expectedConfigResult.success) {
+          console.error(
+            'Failed to parse expected config',
+            fromError(expectedConfigResult.error).toString(),
+          );
+        }
+        if (!actualConfigResult.success) {
+          console.error(
+            'Failed to parse actual config',
+            fromError(actualConfigResult.error).toString(),
+          );
+        }
+        return;
+      }
+
+      if (mailboxViolation.subType === MailboxViolationType.DefaultIsm) {
+        logDiff(preProcessedExpectedConfig, preProcessedActualConfig);
+      }
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7468,6 +7468,7 @@ __metadata:
     asn1.js: "npm:5.4.1"
     aws-kms-ethers-signer: "npm:^0.1.3"
     chai: "npm:^4.3.6"
+    deep-object-diff: "npm:^1.1.9"
     dotenv: "npm:^10.0.0"
     ethereum-waffle: "npm:^4.0.10"
     ethers: "npm:^5.7.2"
@@ -16394,6 +16395,13 @@ __metadata:
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
   checksum: ec12d074aef5ae5e81fa470b9317c313142c9e8e2afe3f8efa124db309720db96d1d222b82b84c834e5f87e7a614b44a4684b6683583118b87c833b3be40d4d8
+  languageName: node
+  linkType: hard
+
+"deep-object-diff@npm:^1.1.9":
+  version: 1.1.9
+  resolution: "deep-object-diff@npm:1.1.9"
+  checksum: b9771cc1ca08a34e408309eaab967bd2ab697684abdfa1262f4283ced8230a9ace966322f356364ff71a785c6e9cc356b7596582e900da5726e6b87d4b2a1463
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
- check-deploy will surface violations when the on-chain ISM state differs from the config for core and warp modules

Example of running check-deploy when the warp config includes a new validator Vs on-chain ISM state

```
┌─────────┬────────────┬────────┬──────────────┬─────────────┬─────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┐
│ (index) │ chain      │ remote │ name         │ type        │ subType │ actual                                       │ expected                                     │
├─────────┼────────────┼────────┼──────────────┼─────────────┼─────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┤
│ 0       │ 'ethereum' │        │              │ 'ClientIsm' │         │ [Object]                                     │ [Object]                                     │
│ 1       │ 'ethereum' │        │ 'collateral' │ 'Owner'     │         │ '0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6' │ '0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba' │
└─────────┴────────────┴────────┴──────────────┴─────────────┴─────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┘
Connection client violation ClientIsm details:
+ Added to config staticAggregationIsm.modules.0.merkleRootMultisigIsm.validators.3: "0xbb5842ae0e05215b53df4787a29144efb7e67551"
+ Added to config staticAggregationIsm.modules.1.messageIdMultisigIsm.validators.3: "0xbb5842ae0e05215b53df4787a29144efb7e67551"
~ Updated config staticAggregationIsm.modules.0.merkleRootMultisigIsm.validators.0: "0x95c7bf235837cb5a609fe6c95870410b9f68bcff" -> "0x4d966438fe9e2b1e7124c87bbb90cb4f0f6c59a1"
~ Updated config staticAggregationIsm.modules.0.merkleRootMultisigIsm.validators.1: "0xa5a56e97fb46f0ac3a3d261e404acb998d9a6969" -> "0x95c7bf235837cb5a609fe6c95870410b9f68bcff"
~ Updated config staticAggregationIsm.modules.0.merkleRootMultisigIsm.validators.2: "0xbb5842ae0e05215b53df4787a29144efb7e67551" -> "0xa5a56e97fb46f0ac3a3d261e404acb998d9a6969"
~ Updated config staticAggregationIsm.modules.1.messageIdMultisigIsm.validators.0: "0x95c7bf235837cb5a609fe6c95870410b9f68bcff" -> "0x4d966438fe9e2b1e7124c87bbb90cb4f0f6c59a1"
~ Updated config staticAggregationIsm.modules.1.messageIdMultisigIsm.validators.1: "0xa5a56e97fb46f0ac3a3d261e404acb998d9a6969" -> "0x95c7bf235837cb5a609fe6c95870410b9f68bcff"
~ Updated config staticAggregationIsm.modules.1.messageIdMultisigIsm.validators.2: "0xbb5842ae0e05215b53df4787a29144efb7e67551" -> "0xa5a56e97fb46f0ac3a3d261e404acb998d9a6969"
```

### Backward compatibility

Yes

### Testing

Manual
