### PR TITLE
feat: transfer and call prototype

### DIFF
--- a/solidity/contracts/middleware/TransferAndCallRouter.sol
+++ b/solidity/contracts/middleware/TransferAndCallRouter.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {InterchainAccountRouter, CallLib} from "./InterchainAccountRouter.sol";
+import {TokenRouter} from "../token/libs/TokenRouter.sol";
+import {TypeCasts} from "../libs/TypeCasts.sol";
+
+contract TransferAndCall {
+    using TypeCasts for address;
+
+    InterchainAccountRouter public immutable interchainAccountRouter;
+
+    constructor(InterchainAccountRouter _interchainAccountRouter) {
+        interchainAccountRouter = _interchainAccountRouter;
+    }
+
+    function transferAndCall(
+        IERC20 asset, // not derivable from TokenRouter
+        TokenRouter warpRoute,
+        uint32 destination,
+        uint256 amount,
+        CallLib.Call[] calldata calls
+    ) public {
+        asset.transferFrom(msg.sender, address(this), amount);
+        address recipient = interchainAccountRouter.getRemoteInterchainAccount(
+            destination,
+            msg.sender
+        );
+        warpRoute.transferRemote(
+            destination,
+            recipient.addressToBytes32(),
+            amount
+        );
+        interchainAccountRouter.callRemote(destination, calls);
+    }
+}

--- a/solidity/contracts/middleware/TransferAndCallRouter.sol
+++ b/solidity/contracts/middleware/TransferAndCallRouter.sol
@@ -16,10 +16,10 @@ contract TransferAndCall {
     }
 
     function transferAndCall(
-        IERC20 asset, // not derivable from TokenRouter
-        TokenRouter warpRoute,
         uint32 destination,
         uint256 amount,
+        IERC20 asset, // not derivable from TokenRouter
+        TokenRouter warpRoute,
         CallLib.Call[] calldata calls
     ) public {
         asset.transferFrom(msg.sender, address(this), amount);


### PR DESCRIPTION
### Description

Compose warp routes with ICAs to warp an asset to the destination chain and then perform an abi encoded call from the account with the warped asset

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
