### PR TITLE
feat(infra): supporting generating warp configs for EVM routes

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getAncient8EthereumUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getAncient8EthereumUSDCWarpConfig.ts
@@ -9,7 +9,7 @@ import {
   defaultMultisigConfigs,
 } from '@hyperlane-xyz/sdk';
 
-import { tokens } from '../../../../src/config/warp.js';
+import { tokens } from '../../../../../src/config/warp.js';
 
 export const getAncient8EthereumUSDCWarpConfig = async (
   routerConfig: ChainMap<RouterConfig>,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumInevmUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumInevmUSDCWarpConfig.ts
@@ -1,0 +1,45 @@
+import { ethers } from 'ethers';
+
+import {
+  ChainMap,
+  RouterConfig,
+  TokenRouterConfig,
+  TokenType,
+  buildAggregationIsmConfigs,
+  defaultMultisigConfigs,
+} from '@hyperlane-xyz/sdk';
+
+import { tokens } from '../../../../../src/config/warp.js';
+
+export const getEthereumInevmUSDCWarpConfig = async (
+  routerConfig: ChainMap<RouterConfig>,
+): Promise<ChainMap<TokenRouterConfig>> => {
+  // TODO: seems to be evidence that this ISM should have been set https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3233/commits/dc8d50c9c49cdea8417fbe9dad090dc13f078fff
+  // checker tooling suggests that it has not been set zero address for ISM is being used
+  // run yarn tsx ./scripts/check-deploy.ts -e mainnet3 -f ethereum -m warp --warpRouteId USDC/ethereum-inevm
+
+  const ismConfig = buildAggregationIsmConfigs(
+    'ethereum',
+    ['inevm'],
+    defaultMultisigConfigs,
+  ).inevm;
+
+  const ethereum: TokenRouterConfig = {
+    ...routerConfig.ethereum,
+    type: TokenType.collateral,
+    token: tokens.ethereum.USDC,
+    hook: '0xb87AC8EA4533AE017604E44470F7c1E550AC6F10', // aggregation of IGP and Merkle, arbitrary config not supported for now
+    interchainSecurityModule: ismConfig,
+  };
+
+  const inevm: TokenRouterConfig = {
+    ...routerConfig.inevm,
+    type: TokenType.synthetic,
+    interchainSecurityModule: ethers.constants.AddressZero,
+  };
+
+  return {
+    ethereum,
+    inevm,
+  };
+};

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumInevmUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumInevmUSDTWarpConfig.ts
@@ -1,0 +1,44 @@
+import { ethers } from 'ethers';
+
+import {
+  ChainMap,
+  RouterConfig,
+  TokenRouterConfig,
+  TokenType,
+  buildAggregationIsmConfigs,
+  defaultMultisigConfigs,
+} from '@hyperlane-xyz/sdk';
+
+import { tokens } from '../../../../../src/config/warp.js';
+
+export const getEthereumInevmUSDTWarpConfig = async (
+  routerConfig: ChainMap<RouterConfig>,
+): Promise<ChainMap<TokenRouterConfig>> => {
+  // TODO: there may be evidence that this ISM should have been set https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3233/commits/dc8d50c9c49cdea8417fbe9dad090dc13f078fff, although the USDC token address is being used in the commit
+  // checker tooling suggests that this ISM has not been set, zero address for ISM is being used
+  // run yarn tsx ./scripts/check-deploy.ts -e mainnet3 -f ethereum -m warp --warpRouteId USDT/ethereum-inevm
+  const ismConfig = buildAggregationIsmConfigs(
+    'ethereum',
+    ['inevm'],
+    defaultMultisigConfigs,
+  ).inevm;
+
+  const ethereum: TokenRouterConfig = {
+    ...routerConfig.ethereum,
+    type: TokenType.collateral,
+    token: tokens.ethereum.USDT,
+    hook: '0xb87AC8EA4533AE017604E44470F7c1E550AC6F10',
+    interchainSecurityModule: ismConfig,
+  };
+
+  const inevm: TokenRouterConfig = {
+    ...routerConfig.inevm,
+    type: TokenType.synthetic,
+    interchainSecurityModule: ethers.constants.AddressZero,
+  };
+
+  return {
+    ethereum,
+    inevm,
+  };
+};

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionETHWarpConfig.ts
@@ -1,0 +1,40 @@
+import {
+  ChainMap,
+  RouterConfig,
+  TokenRouterConfig,
+  TokenType,
+  buildAggregationIsmConfigs,
+  defaultMultisigConfigs,
+} from '@hyperlane-xyz/sdk';
+
+export const getEthereumVictionETHWarpConfig = async (
+  routerConfig: ChainMap<RouterConfig>,
+): Promise<ChainMap<TokenRouterConfig>> => {
+  const ismConfig = buildAggregationIsmConfigs(
+    'ethereum',
+    ['viction'],
+    defaultMultisigConfigs,
+  ).viction;
+
+  const viction: TokenRouterConfig = {
+    ...routerConfig.viction,
+    type: TokenType.synthetic,
+    name: 'ETH',
+    symbol: 'ETH',
+    decimals: 18,
+    totalSupply: 0,
+    gas: 50_000,
+  };
+
+  const ethereum: TokenRouterConfig = {
+    ...routerConfig.ethereum,
+    type: TokenType.native,
+    gas: 65_000,
+    interchainSecurityModule: ismConfig,
+  };
+
+  return {
+    viction,
+    ethereum,
+  };
+};

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDCWarpConfig.ts
@@ -1,0 +1,44 @@
+import {
+  ChainMap,
+  RouterConfig,
+  TokenRouterConfig,
+  TokenType,
+  buildAggregationIsmConfigs,
+  defaultMultisigConfigs,
+} from '@hyperlane-xyz/sdk';
+
+import { tokens } from '../../../../../src/config/warp.js';
+
+export const getEthereumVictionUSDCWarpConfig = async (
+  routerConfig: ChainMap<RouterConfig>,
+): Promise<ChainMap<TokenRouterConfig>> => {
+  // commit that the config was copied from https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3067/commits/7ed5b460034ea5e140c6ff86bcd6baf6ebb824c4#diff-fab5dd1a27c76e4310699c57ccf92ab6274ef0acf17e079b17270cedf4057775R109
+  const ismConfig = buildAggregationIsmConfigs(
+    'ethereum',
+    ['viction'],
+    defaultMultisigConfigs,
+  ).viction;
+
+  const viction: TokenRouterConfig = {
+    ...routerConfig.viction,
+    type: TokenType.synthetic,
+    name: 'USDC',
+    symbol: 'USDC',
+    decimals: 18,
+    totalSupply: 0,
+    gas: 75_000,
+  };
+
+  const ethereum: TokenRouterConfig = {
+    ...routerConfig.ethereum,
+    type: TokenType.collateral,
+    token: tokens.ethereum.USDC,
+    gas: 65_000,
+    interchainSecurityModule: ismConfig,
+  };
+
+  return {
+    viction,
+    ethereum,
+  };
+};

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDTWarpConfig.ts
@@ -1,0 +1,43 @@
+import {
+  ChainMap,
+  RouterConfig,
+  TokenRouterConfig,
+  TokenType,
+  buildAggregationIsmConfigs,
+  defaultMultisigConfigs,
+} from '@hyperlane-xyz/sdk';
+
+import { tokens } from '../../../../../src/config/warp.js';
+
+export const getEthereumVictionUSDTWarpConfig = async (
+  routerConfig: ChainMap<RouterConfig>,
+): Promise<ChainMap<TokenRouterConfig>> => {
+  const ismConfig = buildAggregationIsmConfigs(
+    'ethereum',
+    ['viction'],
+    defaultMultisigConfigs,
+  ).viction;
+
+  const viction: TokenRouterConfig = {
+    ...routerConfig.viction,
+    type: TokenType.synthetic,
+    name: 'USDT',
+    symbol: 'USDT',
+    decimals: 6,
+    totalSupply: 0,
+    gas: 75_000,
+  };
+
+  const ethereum: TokenRouterConfig = {
+    ...routerConfig.ethereum,
+    type: TokenType.collateral,
+    token: tokens.ethereum.USDT,
+    gas: 65_000,
+    interchainSecurityModule: ismConfig,
+  };
+
+  return {
+    viction,
+    ethereum,
+  };
+};

--- a/typescript/infra/config/environments/mainnet3/warp/getAncient8EthereumUSDCWrapConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/getAncient8EthereumUSDCWrapConfig.ts
@@ -1,0 +1,49 @@
+import { ethers } from 'ethers';
+
+import {
+  ChainMap,
+  RouterConfig,
+  TokenRouterConfig,
+  TokenType,
+  buildAggregationIsmConfigs,
+  defaultMultisigConfigs,
+} from '@hyperlane-xyz/sdk';
+
+import { tokens } from '../../../../src/config/warp.js';
+
+export const getAncient8EthereumUSDCWarpConfig = async (
+  routerConfig: ChainMap<RouterConfig>,
+): Promise<ChainMap<TokenRouterConfig>> => {
+  const ismConfig = buildAggregationIsmConfigs(
+    'ethereum',
+    ['ancient8'],
+    defaultMultisigConfigs,
+  ).ancient8;
+
+  const ethereum: TokenRouterConfig = {
+    ...routerConfig.ethereum,
+    type: TokenType.collateral,
+    token: tokens.ethereum.USDC,
+    interchainSecurityModule: ismConfig,
+    // This hook was recovered from running the deploy script
+    // for the hook module. The hook configuration is the Ethereum
+    // default hook for the Ancient8 remote (no routing).
+    hook: '0x19b2cF952b70b217c90FC408714Fbc1acD29A6A8',
+  };
+
+  // @ts-ignore - The types as they stand require a synthetic to specify
+  // TokenMetadata, but in practice these are actually inferred from a
+  // collateral config. To avoid needing to specify the TokenMetadata, just
+  // ts-ignore for synthetic tokens.
+  const ancient8: TokenRouterConfig = {
+    ...routerConfig.ancient8,
+    type: TokenType.synthetic,
+    // Uses the default ISM
+    interchainSecurityModule: ethers.constants.AddressZero,
+  };
+
+  return {
+    ethereum,
+    ancient8,
+  };
+};

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -8,14 +8,42 @@ import {
 import { getHyperlaneCore } from '../scripts/core-utils.js';
 import { EnvironmentConfig } from '../src/config/environment.js';
 
-import { getAncient8EthereumUSDCWarpConfig } from './environments/mainnet3/warp/getAncient8EthereumUSDCWrapConfig.js';
+import { getAncient8EthereumUSDCWarpConfig } from './environments/mainnet3/warp/configGetters/getAncient8EthereumUSDCWarpConfig.js';
+import { getEthereumInevmUSDCWarpConfig } from './environments/mainnet3/warp/configGetters/getEthereumInevmUSDCWarpConfig.js';
+import { getEthereumInevmUSDTWarpConfig } from './environments/mainnet3/warp/configGetters/getEthereumInevmUSDTWarpConfig.js';
+import { getEthereumVictionETHWarpConfig } from './environments/mainnet3/warp/configGetters/getEthereumVictionETHWarpConfig.js';
+import { getEthereumVictionUSDCWarpConfig } from './environments/mainnet3/warp/configGetters/getEthereumVictionUSDCWarpConfig.js';
+import { getEthereumVictionUSDTWarpConfig } from './environments/mainnet3/warp/configGetters/getEthereumVictionUSDTWarpConfig.js';
+
+export enum WarpRouteIds {
+  Ancient8EthereumUSDC = 'USDC/ancient8-ethereum',
+  ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismEZETH = 'EZETH/arbitrum-base-blast-bsc-ethereum-fraxtal-linea-mode-optimism',
+  ArbitrumNeutronEclip = 'ECLIP/arbitrum-neutron',
+  ArbitrumNeutronTIA = 'TIA/arbitrum-neutron',
+  EthereumInevmUSDC = 'USDC/ethereum-inevm',
+  EthereumInevmUSDT = 'USDT/ethereum-inevm',
+  EthereumVictionETH = 'ETH/ethereum-viction',
+  EthereumVictionUSDC = 'USDC/ethereum-viction',
+  EthereumVictionUSDT = 'USDT/ethereum-viction',
+  InevmInjectiveINJ = 'INJ/inevm-injective',
+  MantapacificNeutronTIA = 'TIA/mantapacific-neutron',
+}
 
 export const warpConfigGetterMap: Record<
   string,
   (routerConfig: ChainMap<RouterConfig>) => Promise<ChainMap<TokenRouterConfig>>
 > = {
-  // will make the keys an enum
-  'USDC/ancient8-ethereum': getAncient8EthereumUSDCWarpConfig,
+  [WarpRouteIds.Ancient8EthereumUSDC]: getAncient8EthereumUSDCWarpConfig,
+  [WarpRouteIds.EthereumInevmUSDC]: getEthereumInevmUSDCWarpConfig,
+  [WarpRouteIds.EthereumInevmUSDT]: getEthereumInevmUSDTWarpConfig,
+  // [WarpRouteIds.ArbitrumNeutronEclip]: getArbitrumNeutronEclipWarpConfig, // TODO
+  // [WarpRouteIds.ArbitrumNeutronTIA]: getArbitrumNeutronTiaWarpConfig, // TODO
+  // [WarpRouteIds.ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismEZETH]: getArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismEZETHWarpConfig, // TODO
+  // [WarpRouteIds.InevmInjectiveINJ]: getInevmInjectiveINJWarpConfig, // TODO
+  [WarpRouteIds.EthereumVictionETH]: getEthereumVictionETHWarpConfig,
+  [WarpRouteIds.EthereumVictionUSDC]: getEthereumVictionUSDCWarpConfig,
+  [WarpRouteIds.EthereumVictionUSDT]: getEthereumVictionUSDTWarpConfig,
+  // [WarpRouteIds.MantapacificNeutronTIA]: getEthereumVictionUSDTWarpConfig, // TODO
 };
 
 export async function getWarpConfig(
@@ -26,10 +54,10 @@ export async function getWarpConfig(
   const { core } = await getHyperlaneCore(envConfig.environment, multiProvider);
   const routerConfig = core.getRouterConfig(envConfig.owners);
 
-  const getWarpConfig = warpConfigGetterMap[warpRouteId];
-  if (!getWarpConfig) {
+  const warpConfigGetter = warpConfigGetterMap[warpRouteId];
+  if (!warpConfigGetter) {
     throw new Error(`Unknown warp route: ${warpRouteId}`);
   }
 
-  return getWarpConfig(routerConfig);
+  return warpConfigGetter(routerConfig);
 }

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -1,73 +1,35 @@
-import { ethers } from 'ethers';
-
 import {
   ChainMap,
-  HyperlaneIsmFactory,
   MultiProvider,
+  RouterConfig,
   TokenRouterConfig,
-  TokenType,
-  buildAggregationIsmConfigs,
-  defaultMultisigConfigs,
 } from '@hyperlane-xyz/sdk';
 
-import { Modules, getAddresses } from '../scripts/agent-utils.js';
 import { getHyperlaneCore } from '../scripts/core-utils.js';
 import { EnvironmentConfig } from '../src/config/environment.js';
-import { tokens } from '../src/config/warp.js';
 
-import { DEPLOYER } from './environments/mainnet3/owners.js';
+import { getAncient8EthereumUSDCWarpConfig } from './environments/mainnet3/warp/getAncient8EthereumUSDCWrapConfig.js';
+
+export const warpConfigGetterMap: Record<
+  string,
+  (routerConfig: ChainMap<RouterConfig>) => Promise<ChainMap<TokenRouterConfig>>
+> = {
+  // will make the keys an enum
+  'USDC/ancient8-ethereum': getAncient8EthereumUSDCWarpConfig,
+};
 
 export async function getWarpConfig(
   multiProvider: MultiProvider,
   envConfig: EnvironmentConfig,
+  warpRouteId: string,
 ): Promise<ChainMap<TokenRouterConfig>> {
   const { core } = await getHyperlaneCore(envConfig.environment, multiProvider);
-  const ismFactory = HyperlaneIsmFactory.fromAddressesMap(
-    getAddresses(envConfig.environment, Modules.PROXY_FACTORY),
-    multiProvider,
-  );
-
-  const owner = DEPLOYER;
-
-  // "Manually" deploying an ISM because the warp deployer doesn't support
-  // ISM objects at the moment, and the deploy involves strictly recoverable ISMs.
-  const ism = await ismFactory.deploy({
-    destination: 'ethereum',
-    config: buildAggregationIsmConfigs(
-      'ethereum',
-      ['ancient8'],
-      defaultMultisigConfigs,
-    ).ancient8,
-  });
-
   const routerConfig = core.getRouterConfig(envConfig.owners);
 
-  const ethereum: TokenRouterConfig = {
-    ...routerConfig.ethereum,
-    type: TokenType.collateral,
-    token: tokens.ethereum.USDC,
-    interchainSecurityModule: ism.address,
-    // This hook was recovered from running the deploy script
-    // for the hook module. The hook configuration is the Ethereum
-    // default hook for the Ancient8 remote (no routing).
-    hook: '0x19b2cF952b70b217c90FC408714Fbc1acD29A6A8',
-    owner,
-  };
+  const getWarpConfig = warpConfigGetterMap[warpRouteId];
+  if (!getWarpConfig) {
+    throw new Error(`Unknown warp route: ${warpRouteId}`);
+  }
 
-  // @ts-ignore - The types as they stand require a synthetic to specify
-  // TokenMetadata, but in practice these are actually inferred from a
-  // collateral config. To avoid needing to specify the TokenMetadata, just
-  // ts-ignore for synthetic tokens.
-  const ancient8: TokenRouterConfig = {
-    ...routerConfig.ancient8,
-    type: TokenType.synthetic,
-    // Uses the default ISM
-    interchainSecurityModule: ethers.constants.AddressZero,
-    owner,
-  };
-
-  return {
-    ethereum,
-    ancient8,
-  };
+  return getWarpConfig(routerConfig);
 }

--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -51,6 +51,7 @@ import {
   filterRemoteDomainMetadata,
   getInfraPath,
   inCIMode,
+  readJSONAtPath,
   writeMergedJSONAtPath,
 } from '../src/utils/utils.js';
 
@@ -443,7 +444,7 @@ export function getAddresses(environment: DeployEnvironment, module: Modules) {
       return envChains.includes(chain);
     });
   } else {
-    throw new Error(`Cannot get addresses for module ${module}`);
+    return readJSONAtPath(getInfraLandfillPath(environment, module));
   }
 }
 

--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -435,11 +435,7 @@ function getInfraLandfillPath(environment: DeployEnvironment, module: Modules) {
   return path.join(getModuleDirectory(environment, module), 'addresses.json');
 }
 
-export function getAddresses(
-  environment: DeployEnvironment,
-  module: Modules,
-  warpRouteId?: string,
-) {
+export function getAddresses(environment: DeployEnvironment, module: Modules) {
   if (isRegistryModule(environment, module)) {
     const allAddresses = getChainAddresses();
     const envChains = getEnvChains(environment);
@@ -447,19 +443,22 @@ export function getAddresses(
       return envChains.includes(chain);
     });
   } else {
-    if (!warpRouteId) {
-      throw new Error('Warp route id required for warp module');
-    }
-
-    const registry = getRegistry();
-    const warpRouteConfig = registry.getWarpRoute(warpRouteId);
-
-    if (!warpRouteConfig) {
-      throw new Error(`Warp route config for ${warpRouteId} not found`);
-    }
-
-    return warpConfigToWarpAddresses(warpRouteConfig);
+    throw new Error(`Cannot get addresses for module ${module}`);
   }
+}
+
+export function getWarpAddresses(
+  environment: DeployEnvironment,
+  warpRouteId: string,
+) {
+  const registry = getRegistry();
+  const warpRouteConfig = registry.getWarpRoute(warpRouteId);
+
+  if (!warpRouteConfig) {
+    throw new Error(`Warp route config for ${warpRouteId} not found`);
+  }
+
+  return warpConfigToWarpAddresses(warpRouteConfig);
 }
 
 export function writeAddresses(

--- a/typescript/infra/scripts/check-deploy.ts
+++ b/typescript/infra/scripts/check-deploy.ts
@@ -29,8 +29,8 @@ import { logViolationDetails } from '../src/utils/violation.js';
 
 import {
   Modules,
-  getAddresses,
   getArgs as getRootArgs,
+  getWarpAddresses,
   withChain,
   withContext,
   withModuleAndFork,
@@ -153,7 +153,7 @@ async function check() {
       throw new Error('Warp route id required for warp module');
     }
     const config = await getWarpConfig(multiProvider, envConfig, warpRouteId);
-    const addresses = getAddresses(environment, Modules.WARP, warpRouteId);
+    const addresses = getWarpAddresses(environment, warpRouteId);
     const filteredAddresses = Object.keys(addresses) // filter out changes not in config
       .filter((key) => key in config)
       .reduce((obj, key) => {

--- a/typescript/infra/scripts/check-deploy.ts
+++ b/typescript/infra/scripts/check-deploy.ts
@@ -2,6 +2,8 @@ import { HelloWorldChecker } from '@hyperlane-xyz/helloworld';
 import {
   HypERC20App,
   HypERC20Checker,
+  HypERC20Factories,
+  HyperlaneAddressesMap,
   HyperlaneCoreChecker,
   HyperlaneIgp,
   HyperlaneIgpChecker,
@@ -32,12 +34,15 @@ import {
   withChain,
   withContext,
   withModuleAndFork,
+  withWarpRouteId,
 } from './agent-utils.js';
 import { getEnvironmentConfig, getHyperlaneCore } from './core-utils.js';
 import { getHelloWorldApp } from './helloworld/utils.js';
 
 function getArgs() {
-  return withChain(withModuleAndFork(withContext(getRootArgs())))
+  return withChain(
+    withWarpRouteId(withModuleAndFork(withContext(getRootArgs()))),
+  )
     .boolean('asDeployer')
     .default('asDeployer', false)
     .boolean('govern')
@@ -46,8 +51,16 @@ function getArgs() {
 }
 
 async function check() {
-  const { fork, govern, module, environment, context, chain, asDeployer } =
-    await getArgs();
+  const {
+    fork,
+    govern,
+    module,
+    environment,
+    context,
+    chain,
+    asDeployer,
+    warpRouteId,
+  } = await getArgs();
   const envConfig = getEnvironmentConfig(environment);
   let multiProvider = await envConfig.getMultiProvider();
 
@@ -136,15 +149,21 @@ async function check() {
     );
     governor = new ProxiedRouterGovernor(checker);
   } else if (module === Modules.WARP) {
-    const config = await getWarpConfig(multiProvider, envConfig);
-    const addresses = getAddresses(environment, Modules.WARP);
+    if (!warpRouteId) {
+      throw new Error('Warp route id required for warp module');
+    }
+    const config = await getWarpConfig(multiProvider, envConfig, warpRouteId);
+    const addresses = getAddresses(environment, Modules.WARP, warpRouteId);
     const filteredAddresses = Object.keys(addresses) // filter out changes not in config
       .filter((key) => key in config)
       .reduce((obj, key) => {
         obj[key] = addresses[key];
         return obj;
       }, {} as typeof addresses);
-    const app = HypERC20App.fromAddressesMap(filteredAddresses, multiProvider);
+    const app = HypERC20App.fromAddressesMap(
+      filteredAddresses as HyperlaneAddressesMap<HypERC20Factories>,
+      multiProvider,
+    );
 
     const checker = new HypERC20Checker(
       multiProvider,

--- a/typescript/infra/scripts/deploy.ts
+++ b/typescript/infra/scripts/deploy.ts
@@ -46,6 +46,7 @@ import {
   withConcurrentDeploy,
   withContext,
   withModuleAndFork,
+  withWarpRouteId,
 } from './agent-utils.js';
 import { getEnvironmentConfig, getHyperlaneCore } from './core-utils.js';
 
@@ -58,9 +59,12 @@ async function main() {
     buildArtifactPath,
     chains,
     concurrentDeploy,
+    warpRouteId,
   } = await withContext(
     withConcurrentDeploy(
-      withChains(withModuleAndFork(withBuildArtifactPath(getArgs()))),
+      withChains(
+        withModuleAndFork(withWarpRouteId(withBuildArtifactPath(getArgs()))),
+      ),
     ),
   ).argv;
   const envConfig = getEnvironmentConfig(environment);
@@ -116,11 +120,14 @@ async function main() {
       concurrentDeploy,
     );
   } else if (module === Modules.WARP) {
+    if (!warpRouteId) {
+      throw new Error('Warp route ID is required for WARP module');
+    }
     const ismFactory = HyperlaneIsmFactory.fromAddressesMap(
       getAddresses(envConfig.environment, Modules.PROXY_FACTORY),
       multiProvider,
     );
-    config = await getWarpConfig(multiProvider, envConfig);
+    config = await getWarpConfig(multiProvider, envConfig, warpRouteId);
     deployer = new HypERC20Deployer(
       multiProvider,
       ismFactory,

--- a/typescript/infra/scripts/get-warp-route-ids.ts
+++ b/typescript/infra/scripts/get-warp-route-ids.ts
@@ -1,0 +1,23 @@
+import { getRegistry } from '../config/registry.js';
+
+async function main() {
+  const registry = await getRegistry();
+
+  const registryContents = await registry.listRegistryContent();
+
+  const warpRoutes = registryContents.deployments.warpRoutes;
+  const warpRouteIds = Object.keys(warpRoutes);
+
+  const warpRouteIdsTable = warpRouteIds.map((warpRouteId) => {
+    return { 'Warp Route IDs': warpRouteId };
+  });
+
+  console.table(warpRouteIdsTable, ['Warp Route IDs']);
+}
+
+main()
+  .then()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/typescript/infra/src/config/warp.ts
+++ b/typescript/infra/src/config/warp.ts
@@ -5,5 +5,6 @@ import { Address } from '@hyperlane-xyz/utils';
 export const tokens: ChainMap<Record<string, Address>> = {
   ethereum: {
     USDC: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    USDT: '0xdac17f958d2ee523a2206206994597c13d831ec7',
   },
 };

--- a/typescript/infra/src/utils/violation.ts
+++ b/typescript/infra/src/utils/violation.ts
@@ -208,6 +208,22 @@ function preProcessConfig(config: any) {
 }
 
 function logViolationDetail(violation: CheckerViolation): void {
+  if (
+    typeof violation.expected === 'string' ||
+    typeof violation.actual === 'string'
+  ) {
+    if (typeof violation.expected === 'string') {
+      console.log(
+        `Address provided for expected config: ${violation.expected}`,
+      );
+    }
+    if (typeof violation.actual === 'string') {
+      console.log(`Address provided for actual config: ${violation.actual}`);
+    }
+    console.log('Config comparison not possible');
+    return;
+  }
+
   const preProcessedExpectedConfig = preProcessConfig(violation.expected);
   const preProcessedActualConfig = preProcessConfig(violation.actual);
 

--- a/typescript/sdk/src/router/HyperlaneRouterChecker.ts
+++ b/typescript/sdk/src/router/HyperlaneRouterChecker.ts
@@ -78,15 +78,6 @@ export class HyperlaneRouterChecker<
 
     const actualIsmAddress = await router.interchainSecurityModule();
 
-    if (
-      typeof config.interchainSecurityModule !== 'string' &&
-      !this.ismFactory
-    ) {
-      throw Error(
-        'ISM factory not provided to HyperlaneRouterChecker, cannot check object-based ISM config',
-      );
-    }
-
     const matches = await moduleMatchesConfig(
       chain,
       actualIsmAddress,

--- a/typescript/sdk/src/router/HyperlaneRouterChecker.ts
+++ b/typescript/sdk/src/router/HyperlaneRouterChecker.ts
@@ -1,8 +1,10 @@
+import { ethers } from 'ethers';
+
 import { addressToBytes32, assert, eqAddress } from '@hyperlane-xyz/utils';
 
 import { HyperlaneFactories } from '../contracts/types.js';
 import { HyperlaneAppChecker } from '../deploy/HyperlaneAppChecker.js';
-import { EvmIsmReader } from '../ism/EvmIsmReader.js';
+import { DerivedIsmConfig, EvmIsmReader } from '../ism/EvmIsmReader.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { moduleMatchesConfig } from '../ism/utils.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
@@ -74,39 +76,43 @@ export class HyperlaneRouterChecker<
       }
     }
 
-    if (config.interchainSecurityModule) {
-      const actualIsmAddress = await router.interchainSecurityModule();
-      if (
-        typeof config.interchainSecurityModule !== 'string' &&
-        !this.ismFactory
-      ) {
-        throw Error(
-          'ISM factory not provided to HyperlaneRouterChecker, cannot check object-based ISM config',
-        );
-      }
+    const actualIsmAddress = await router.interchainSecurityModule();
 
-      const matches = await moduleMatchesConfig(
-        chain,
-        actualIsmAddress,
-        config.interchainSecurityModule,
-        this.multiProvider,
-        this.ismFactory?.chainMap[chain] ?? ({} as any),
+    if (
+      typeof config.interchainSecurityModule !== 'string' &&
+      !this.ismFactory
+    ) {
+      throw Error(
+        'ISM factory not provided to HyperlaneRouterChecker, cannot check object-based ISM config',
       );
+    }
 
-      if (!matches) {
-        const ismReader = new EvmIsmReader(this.multiProvider, chain);
-        const derivedConfig = await ismReader.deriveIsmConfig(actualIsmAddress);
+    const matches = await moduleMatchesConfig(
+      chain,
+      actualIsmAddress,
+      config.interchainSecurityModule ?? ethers.constants.AddressZero,
+      this.multiProvider,
+      this.ismFactory?.chainMap[chain] ?? ({} as any),
+    );
 
-        const violation: ClientViolation = {
-          chain,
-          type: ClientViolationType.InterchainSecurityModule,
-          contract: router,
-          actual: derivedConfig,
-          expected: config.interchainSecurityModule,
-          description: `ISM config does not match deployed ISM`,
-        };
-        this.addViolation(violation);
+    if (!matches) {
+      const ismReader = new EvmIsmReader(this.multiProvider, chain);
+      let actualConfig: string | DerivedIsmConfig =
+        ethers.constants.AddressZero;
+      if (actualIsmAddress !== ethers.constants.AddressZero) {
+        actualConfig = await ismReader.deriveIsmConfig(actualIsmAddress);
       }
+
+      const violation: ClientViolation = {
+        chain,
+        type: ClientViolationType.InterchainSecurityModule,
+        contract: router,
+        actual: actualConfig,
+        expected:
+          config.interchainSecurityModule ?? ethers.constants.AddressZero,
+        description: `ISM config does not match deployed ISM`,
+      };
+      this.addViolation(violation);
     }
   }
 


### PR DESCRIPTION
### Description

- Add in code configs for EVM base warp routes
- Allow checker tooling (check-deploy) to read and run against the config
- Read Warp addresses from registry when run check-deploy for warp modules

### Drive-by changes

- clean up ISM config comparison violation message to handle ISM addressed

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

Yes

### Testing

Manual
