### PR TITLE
fix(sdk): Access correct consensus client when estimating cosmwasm txs

### DIFF
--- a/.changeset/chatty-suns-breathe.md
+++ b/.changeset/chatty-suns-breathe.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Fix issue with cosmos tx estimation

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -209,7 +209,7 @@ export async function estimateTransactionFeeCosmJsWasm({
   };
   const wasmClient = await provider.provider;
   // @ts-ignore access a private field here to extract client URL
-  const url: string = wasmClient.tmClient.client.url;
+  const url: string = wasmClient.cometClient.client.url;
   const stargateClient = StargateClient.connect(url);
 
   return estimateTransactionFeeCosmJs({


### PR DESCRIPTION
### Description

`tmClient` (i.e. TendermintClient) is now `cometClient`

### Related issues

Related to #4209 but not surfaced because of ts-ignore, which is necessary because the required data isn't surfaced properly by CosmJS

### Backward compatibility

Yes

### Testing

Tested in Warp UI
