### PR TITLE
fix: re-add widgets ref to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ COPY .yarn/releases ./.yarn/releases
 COPY .yarn/patches ./.yarn/patches
 COPY typescript/utils/package.json ./typescript/utils/
 COPY typescript/sdk/package.json ./typescript/sdk/
+COPY typescript/widgets/package.json ./typescript/widgets/
 COPY typescript/helloworld/package.json ./typescript/helloworld/
 COPY typescript/cli/package.json ./typescript/cli/
 COPY typescript/infra/package.json ./typescript/infra/


### PR DESCRIPTION
fix: re-add widgets ref to Dockerfile

- originally merged: https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4216
- accidentally removed in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4215/commits/dcc883499fefca4fdf3172d512901c4459579937