### PR TITLE
fix(cli): hyperlane core apply logging fix

### DIFF
--- a/.changeset/chilly-cups-tap.md
+++ b/.changeset/chilly-cups-tap.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Fix logging for hyperlane core apply

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -65,7 +65,7 @@ export const apply: CommandModuleWithWriteContext<{
     ),
   },
   handler: async ({ context, chain, config: configFilePath }) => {
-    logGray(`Hyperlane Warp Apply`);
+    logGray(`Hyperlane Core Apply`);
     logGray('--------------------');
 
     const addresses = (await context.registry.getChainAddresses(


### PR DESCRIPTION
### Description
Fixes `hyperlane core apply` to say "Hyperlane Core Apply"

### Backward compatibility
Yes

### Testing
Manual
