### PR TITLE
fix: require multiple chains in warp init

### DIFF
--- a/.changeset/fast-schools-battle.md
+++ b/.changeset/fast-schools-battle.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/cli": patch
+---
+
+Require multiple chains in warp init

--- a/.changeset/fast-schools-battle.md
+++ b/.changeset/fast-schools-battle.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/cli": patch
 ---
 
-Require multiple chains in warp init
+Require at least 1 chain selection in warp init

--- a/typescript/cli/src/config/hooks.ts
+++ b/typescript/cli/src/config/hooks.ts
@@ -262,12 +262,12 @@ export const createRoutingConfig = callWithConfigCreationLogs(
     advanced: boolean = false,
   ): Promise<HookConfig> => {
     const owner = await input({
-      message: 'Enter owner address for routing ISM',
+      message: 'Enter owner address for routing Hook',
     });
     const ownerAddress = owner;
     const chains = await runMultiChainSelectionStep(
       context.chainMetadata,
-      'Select chains for routing ISM',
+      'Select chains for routing Hook',
       1,
     );
 

--- a/typescript/cli/src/config/hooks.ts
+++ b/typescript/cli/src/config/hooks.ts
@@ -265,7 +265,11 @@ export const createRoutingConfig = callWithConfigCreationLogs(
       message: 'Enter owner address for routing ISM',
     });
     const ownerAddress = owner;
-    const chains = await runMultiChainSelectionStep(context.chainMetadata);
+    const chains = await runMultiChainSelectionStep(
+      context.chainMetadata,
+      'Select chains for routing ISM',
+      1,
+    );
 
     const domainsMap: ChainMap<HookConfig> = {};
     for (const chain of chains) {

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -226,11 +226,9 @@ export const createRoutingConfig = callWithConfigCreationLogs(
       message: 'Enter owner address for routing ISM',
     });
     const ownerAddress = owner;
-    const requireMultiple = true;
     const chains = await runMultiChainSelectionStep(
       context.chainMetadata,
       'Select chains to configure routing ISM for',
-      requireMultiple,
     );
 
     const domainsMap: ChainMap<IsmConfig> = {};
@@ -253,7 +251,7 @@ export const createFallbackRoutingConfig = callWithConfigCreationLogs(
     const chains = await runMultiChainSelectionStep(
       context.chainMetadata,
       'Select chains to configure fallback routing ISM for',
-      true,
+      1,
     );
 
     const domainsMap: ChainMap<IsmConfig> = {};

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -229,6 +229,7 @@ export const createRoutingConfig = callWithConfigCreationLogs(
     const chains = await runMultiChainSelectionStep(
       context.chainMetadata,
       'Select chains to configure routing ISM for',
+      1,
     );
 
     const domainsMap: ChainMap<IsmConfig> = {};

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -119,7 +119,7 @@ export async function createWarpRouteDeployConfig({
   const warpChains = await runMultiChainSelectionStep(
     context.chainMetadata,
     'Select chains to connect',
-    true, // require multiple
+    1,
   );
 
   const result: WarpRouteDeployConfig = {};

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -119,6 +119,7 @@ export async function createWarpRouteDeployConfig({
   const warpChains = await runMultiChainSelectionStep(
     context.chainMetadata,
     'Select chains to connect',
+    true, // require multiple
   );
 
   const result: WarpRouteDeployConfig = {};

--- a/typescript/cli/src/deploy/agent.ts
+++ b/typescript/cli/src/deploy/agent.ts
@@ -31,7 +31,7 @@ export async function runKurtosisAgentDeploy({
     const selectedRelayChains = await runMultiChainSelectionStep(
       context.chainMetadata,
       'Select chains to relay between',
-      true,
+      2,
     );
     relayChains = selectedRelayChains.join(',');
   }

--- a/typescript/cli/src/utils/chains.ts
+++ b/typescript/cli/src/utils/chains.ts
@@ -31,20 +31,22 @@ export async function runSingleChainSelectionStep(
 export async function runMultiChainSelectionStep(
   chainMetadata: ChainMap<ChainMetadata>,
   message = 'Select chains',
-  requireMultiple = false,
+  requireNumber = 0,
 ) {
   const networkType = await selectNetworkType();
   const choices = getChainChoices(chainMetadata, networkType);
   while (true) {
-    logTip('Use SPACE key to select chains, then press ENTER');
+    logTip(
+      `Use SPACE key to select at least ${requireNumber} chains, then press ENTER`,
+    );
     const chains = (await checkbox({
       message,
       choices,
       pageSize: calculatePageSize(2),
     })) as string[];
     handleNewChain(chains);
-    if (requireMultiple && chains?.length < 2) {
-      logRed('Please select at least 2 chains');
+    if (chains?.length < requireNumber) {
+      logRed(`Please select at least ${requireNumber} chains`);
       continue;
     }
     return chains;


### PR DESCRIPTION
### Description

Block on user selecting multiple chains in `hyperlane warp init`

### Drive-by

Adjust incorrect requirement of multiple chain selection in routing ISM builder

### Related issues

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4255

### Backward compatibility

Yes

### Testing

Manual
