### PR TITLE
fix(cli): blockchain reason error handling

### DIFF
--- a/.changeset/breezy-turkeys-march.md
+++ b/.changeset/breezy-turkeys-march.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Add ether's error reasoning handling to SmartProvider to show clearer error messages

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.foundry-test.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.foundry-test.ts
@@ -142,4 +142,39 @@ describe('SmartProvider', async () => {
 
     expect(erc20.address).to.not.be.empty;
   });
+
+  it('returns the blockchain error reason: "ERC20: transfer to zero address"', async () => {
+    const smartProvider = HyperlaneSmartProvider.fromRpcUrl(NETWORK, URL, {
+      maxRetries: 1,
+    });
+    const signer = new Wallet(PK, smartProvider);
+
+    const factory = new ERC20__factory(signer);
+    const token = await factory.deploy('fake', 'FAKE');
+    try {
+      await token.transfer(constants.AddressZero, 1000000);
+    } catch (e: any) {
+      expect(e.error.message).to.equal(
+        'execution reverted: revert: ERC20: transfer to the zero address',
+      );
+    }
+  });
+
+  it('returns the blockchain error reason: "ERC20: transfer amount exceeds balance"', async () => {
+    const smartProvider = HyperlaneSmartProvider.fromRpcUrl(NETWORK, URL, {
+      maxRetries: 1,
+    });
+    const signer = new Wallet(PK, smartProvider);
+
+    const factory = new ERC20__factory(signer);
+    const token = await factory.deploy('fake', 'FAKE');
+    try {
+      await token.transfer(signer.address, 1000000);
+    } catch (e: any) {
+      console.log('ERROR:', e);
+      expect(e.error.message).to.equal(
+        'execution reverted: revert: ERC20: transfer amount exceeds balance',
+      );
+    }
+  });
 });

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.foundry-test.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.foundry-test.ts
@@ -171,7 +171,6 @@ describe('SmartProvider', async () => {
     try {
       await token.transfer(signer.address, 1000000);
     } catch (e: any) {
-      console.log('ERROR:', e);
       expect(e.error.message).to.equal(
         'execution reverted: revert: ERC20: transfer amount exceeds balance',
       );

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.foundry-test.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.foundry-test.ts
@@ -3,6 +3,8 @@ import { errors as EthersError, Wallet, constants } from 'ethers';
 
 import { ERC20__factory } from '@hyperlane-xyz/core';
 
+import { randomAddress } from '../../test/testUtils.js';
+
 import {
   HyperlaneSmartProvider,
   getSmartProviderErrorMessage,
@@ -173,6 +175,25 @@ describe('SmartProvider', async () => {
     } catch (e: any) {
       expect(e.error.message).to.equal(
         'execution reverted: revert: ERC20: transfer amount exceeds balance',
+      );
+    }
+  });
+
+  it('returns the blockchain error reason: "insufficient funds for intrinsic transaction cost"', async () => {
+    const smartProvider = HyperlaneSmartProvider.fromRpcUrl(NETWORK, URL, {
+      maxRetries: 1,
+    });
+    const signer = new Wallet(PK, smartProvider);
+
+    try {
+      const balance = await signer.getBalance();
+      await signer.sendTransaction({
+        to: randomAddress(),
+        value: balance.add(1),
+      });
+    } catch (e: any) {
+      expect(e.message).to.equal(
+        'insufficient funds for intrinsic transaction cost',
       );
     }
   });

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -445,7 +445,10 @@ export class HyperlaneSmartProvider
     );
 
     if (rpcServerError) {
-      throw Error(getSmartProviderErrorMessage(rpcServerError.code));
+      throw Error(
+        rpcServerError.error?.message ?? // Server errors will not have a message if it's a connection issue
+          getSmartProviderErrorMessage(rpcServerError.code),
+      );
     } else if (timedOutError) {
       throw Error(getSmartProviderErrorMessage(ProviderStatus.Timeout));
     } else if (rpcBlockchainError) {

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -446,7 +446,7 @@ export class HyperlaneSmartProvider
 
     if (rpcServerError) {
       throw Error(
-        rpcServerError.error?.message ?? // Server errors will not have a message if it's a connection issue
+        rpcServerError.error?.message ?? // Server errors sometimes will not have an error.message
           getSmartProviderErrorMessage(rpcServerError.code),
       );
     } else if (timedOutError) {

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -30,7 +30,7 @@ import {
 export const getSmartProviderErrorMessage = (errorMsg: string) =>
   `${errorMsg}: RPC request failed. Check RPC validity. To override RPC URLs, see: https://docs.hyperlane.xyz/docs/deploy-hyperlane-troubleshooting#override-rpc-urls`;
 
-// This is a partial list. If needed, check the full list for more: https://docs.ethers.org/v5/api/utils/logger/#logging--Logger--errors
+// This is a partial list. If needed, check the full list for more: https://docs.ethers.org/v5/api/utils/logger/#errors
 const RPC_SERVER_ERRORS = [
   EthersError.NETWORK_ERROR,
   EthersError.NOT_IMPLEMENTED,

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -30,12 +30,23 @@ import {
 export const getSmartProviderErrorMessage = (errorMsg: string) =>
   `${errorMsg}: RPC request failed. Check RPC validity. To override RPC URLs, see: https://docs.hyperlane.xyz/docs/deploy-hyperlane-troubleshooting#override-rpc-urls`;
 
-// This is a partial list. If needed, check the full list for more: https://github.com/ethers-io/ethers.js/blob/fc66b8ad405df9e703d42a4b23bc452ec3be118f/src.ts/utils/errors.ts#L77-L85
+// This is a partial list. If needed, check the full list for more: https://docs.ethers.org/v5/api/utils/logger/#logging--Logger--errors
 const RPC_SERVER_ERRORS = [
+  EthersError.NETWORK_ERROR,
   EthersError.NOT_IMPLEMENTED,
   EthersError.SERVER_ERROR,
+  EthersError.TIMEOUT,
   EthersError.UNKNOWN_ERROR,
   EthersError.UNSUPPORTED_OPERATION,
+];
+
+const RPC_BLOCKCHAIN_ERRORS = [
+  EthersError.CALL_EXCEPTION,
+  EthersError.INSUFFICIENT_FUNDS,
+  EthersError.NONCE_EXPIRED,
+  EthersError.REPLACEMENT_UNDERPRICED,
+  EthersError.TRANSACTION_REPLACED,
+  EthersError.UNPREDICTABLE_GAS_LIMIT,
 ];
 const DEFAULT_MAX_RETRIES = 1;
 const DEFAULT_BASE_RETRY_DELAY_MS = 250; // 0.25 seconds
@@ -424,15 +435,20 @@ export class HyperlaneSmartProvider
     const rpcServerError = errors.find((e) =>
       RPC_SERVER_ERRORS.includes(e.code),
     );
-    const timedOutError = errors.find(
-      (e) => e.status === ProviderStatus.Timeout,
+
+    const rpcBlockchainError = errors.find((e) =>
+      RPC_BLOCKCHAIN_ERRORS.includes(e.code),
     );
+
     if (rpcServerError) {
       throw Error(getSmartProviderErrorMessage(rpcServerError.code));
-    } else if (timedOutError) {
-      throw Error(getSmartProviderErrorMessage(ProviderStatus.Timeout));
+    } else if (rpcBlockchainError) {
+      throw Error(rpcBlockchainError.reason ?? rpcBlockchainError.code);
     } else {
-      throw Error(getSmartProviderErrorMessage(ProviderStatus.Error)); // Assumes that all errors are of ProviderStatus.Error
+      this.logger.error(
+        'Unhandled error case in combined provider error handler',
+      );
+      throw Error(fallbackMsg);
     }
   }
 }

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -436,12 +436,18 @@ export class HyperlaneSmartProvider
       RPC_SERVER_ERRORS.includes(e.code),
     );
 
+    const timedOutError = errors.find(
+      (e) => e.status === ProviderStatus.Timeout,
+    );
+
     const rpcBlockchainError = errors.find((e) =>
       RPC_BLOCKCHAIN_ERRORS.includes(e.code),
     );
 
     if (rpcServerError) {
       throw Error(getSmartProviderErrorMessage(rpcServerError.code));
+    } else if (timedOutError) {
+      throw Error(getSmartProviderErrorMessage(ProviderStatus.Timeout));
     } else if (rpcBlockchainError) {
       throw Error(rpcBlockchainError.reason ?? rpcBlockchainError.code);
     } else {


### PR DESCRIPTION
### Description
Ethersjs [parses](https://github.com/ethers-io/ethers.js/blob/0bfa7f497dc5793b66df7adfb42c6b846c51d794/packages/providers/src.ts/etherscan-provider.ts#L129-L154) the [jsonrpc](https://www.jsonrpc.org/specification#response_object) responses into their own error codes and Error object. This is an attempt to add handling for blockchain specific errors such as: 
- `Error: execution reverted: MailboxClient: invalid mailbox`
- `Error: insufficient funds for intrinsic transaction cost`

Fixes Bug bash issues:
- "Balance was not sufficient to deploy even though I was told it was"
- “Replace RPC” error shown when mailbox is “invalid”

### Backward compatibility
Yes

### Testing
Manual


