### PR TITLE
docs: Add hyperlane registry as prerequisite for e2e tests

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -88,7 +88,7 @@ env $(cat ./config/validator.fuji.env | grep -v "#" | xargs) ./target/debug/vali
 
 #### Automated E2E Test
 
-Clone `hyperlane-registiry` repo next to `hyperlane-monorepo` repo.
+Clone `hyperlane-registry` repo next to `hyperlane-monorepo` repo.
 
 To perform an automated e2e test of the agents locally, from within the `hyperlane-monorepo/rust` directory, run:
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -88,6 +88,8 @@ env $(cat ./config/validator.fuji.env | grep -v "#" | xargs) ./target/debug/vali
 
 #### Automated E2E Test
 
+Clone `hyperlane-registiry` repo next to `hyperlane-monorepo` repo.
+
 To perform an automated e2e test of the agents locally, from within the `hyperlane-monorepo/rust` directory, run:
 
 ```bash


### PR DESCRIPTION
### Description

E2E tests will fail if `hyperlane-registry` repo is not cloned next to the monorepo. This change adds it to the `rust/README.md` file.

### Testing

Checked how `rust/README.md` looks like in GitHub.
