### PR TITLE
feat(cli): Add existing mailbox confirmation to core deploy

### DIFF
--- a/.changeset/warm-zoos-smell.md
+++ b/.changeset/warm-zoos-smell.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Add check & confirm for existing mailbox to core deploy to allow users to decide if they want to deploy a new mailbox

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -28,6 +28,7 @@ import {
   dryRunCommandOption,
   fromAddressCommandOption,
   outputFileCommandOption,
+  skipConfirmationOption,
 } from './options.js';
 
 /**
@@ -108,9 +109,10 @@ export const deploy: CommandModuleWithWriteContext<{
     ),
     'dry-run': dryRunCommandOption,
     'from-address': fromAddressCommandOption,
+    'skip-confirmation': skipConfirmationOption,
   },
   handler: async ({ context, chain, config: configFilePath, dryRun }) => {
-    logGray(`Hyperlane permissionless deployment${dryRun ? ' dry-run' : ''}`);
+    logGray(`Hyperlane Core deployment${dryRun ? ' dry-run' : ''}`);
     logGray(`------------------------------------------------`);
 
     try {

--- a/typescript/cli/src/deploy/utils.ts
+++ b/typescript/cli/src/deploy/utils.ts
@@ -100,7 +100,7 @@ async function confirmExistingMailbox(
   const addresses = await context.registry.getChainAddresses(chain);
   if (addresses?.mailbox) {
     const isConfirmed = await confirm({
-      message: `Mailbox has already exists at ${addresses.mailbox}, registry artifacts will be overwritten`,
+      message: `Mailbox already exists at ${addresses.mailbox}. Are you sure you want to deploy a new mailbox and overwrite existing registry artifacts?`,
       default: false,
     });
 

--- a/typescript/cli/src/deploy/utils.ts
+++ b/typescript/cli/src/deploy/utils.ts
@@ -12,7 +12,7 @@ import {
 import { Address, ProtocolType } from '@hyperlane-xyz/utils';
 
 import { parseIsmConfig } from '../config/ism.js';
-import { WriteCommandContext } from '../context/types.js';
+import { CommandContext, WriteCommandContext } from '../context/types.js';
 import {
   log,
   logBlue,
@@ -86,10 +86,28 @@ export async function runDeployPlanStep({
   );
 
   if (skipConfirmation) return;
+  await confirmExistingMailbox(context, chain);
   const isConfirmed = await confirm({
     message: 'Is this deployment plan correct?',
   });
   if (!isConfirmed) throw new Error('Deployment cancelled');
+}
+
+async function confirmExistingMailbox(
+  context: CommandContext,
+  chain: ChainName,
+) {
+  const addresses = await context.registry.getChainAddresses(chain);
+  if (addresses?.mailbox) {
+    const isConfirmed = await confirm({
+      message: `Mailbox has already exists at ${addresses.mailbox}, registry artifacts will be overwritten`,
+      default: false,
+    });
+
+    if (!isConfirmed) {
+      throw Error('Deployment cancelled');
+    }
+  }
 }
 
 // from parsed types


### PR DESCRIPTION
### Description
Add check & confirm for existing mailbox to core deploy to allow users to decide if they want to deploy a new mailbox

### Drive-by changes
Add skip confirmation to core deploy

### Backward compatibility
Yes

### Testing
Manual
