### PR TITLE
feat(cli): Add output of hyperlane warp read to file 

### DIFF
--- a/.changeset/pretty-dots-look.md
+++ b/.changeset/pretty-dots-look.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Add output of hyperlane warp read to ./configs/warp-route-deployment.yaml

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -161,7 +161,7 @@ export const init: CommandModuleWithContext<{
 export const read: CommandModuleWithContext<{
   chain?: string;
   address?: string;
-  out?: string;
+  config?: string;
   symbol?: string;
 }> = {
   command: 'read',
@@ -179,9 +179,19 @@ export const read: CommandModuleWithContext<{
       'Address of the router contract to read.',
       false,
     ),
-    out: outputFileCommandOption(),
+    config: outputFileCommandOption(
+      './configs/warp-route-deployment.yaml',
+      false,
+      'The path to output a Warp Config JSON or YAML file.',
+    ),
   },
-  handler: async ({ context, chain, address, out, symbol }) => {
+  handler: async ({
+    context,
+    chain,
+    address,
+    config: configFilePath,
+    symbol,
+  }) => {
     logGray('Hyperlane Warp Reader');
     logGray('---------------------');
 
@@ -252,9 +262,11 @@ export const read: CommandModuleWithContext<{
       ),
     );
 
-    if (out) {
-      writeYamlOrJson(out, config, 'yaml');
-      logGreen(`✅ Warp route config written successfully to ${out}:\n`);
+    if (configFilePath) {
+      writeYamlOrJson(configFilePath, config, 'yaml');
+      logGreen(
+        `✅ Warp route config written successfully to ${configFilePath}:\n`,
+      );
     } else {
       logGreen(`✅ Warp route config read successfully:\n`);
     }


### PR DESCRIPTION
### Description
- Add output of `hyperlane warp read` to ./configs/warp-route-deployment.yaml, similar to `hyperlane core read`

Fixes bug bash issue: "warp read gives you more info than the config/addresses file in .hyperlane"

### Backward compatibility
Yes

### Testing
Manual
