### PR TITLE
feat: add script to set rpc secrets from registry

### DIFF
--- a/typescript/infra/scripts/secret-rpc-urls/set-rpc-urls-from-registry.ts
+++ b/typescript/infra/scripts/secret-rpc-urls/set-rpc-urls-from-registry.ts
@@ -1,0 +1,39 @@
+import { getRegistryForEnvironment } from '../../src/config/chain.js';
+import { setAndVerifyRpcUrls } from '../../src/utils/rpcUrls.js';
+import { getArgs, withChains } from '../agent-utils.js';
+
+async function main() {
+  const { environment, chains } = await withChains(getArgs()).argv;
+
+  if (!chains || chains.length === 0) {
+    console.error('No chains provided, Exiting.');
+    process.exit(1);
+  }
+
+  console.log(
+    `Setting RPC URLs for chains: ${chains.join(
+      ', ',
+    )} in ${environment} environment`,
+  );
+
+  const registry = await getRegistryForEnvironment(environment, chains);
+
+  for (const chain of chains) {
+    console.log(`\nSetting RPC URLs for chain: ${chain}`);
+    const chainMetadata = await registry.getChainMetadata(chain);
+    if (!chainMetadata) {
+      console.error(`Chain ${chain} not found in registry. Continuing...`);
+      continue;
+    }
+
+    const rpcUrlsArray = chainMetadata.rpcUrls.map((rpc) => rpc.http);
+    await setAndVerifyRpcUrls(environment, chain, rpcUrlsArray);
+  }
+}
+
+main()
+  .then()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/typescript/infra/scripts/secret-rpc-urls/set-rpc-urls.ts
+++ b/typescript/infra/scripts/secret-rpc-urls/set-rpc-urls.ts
@@ -1,31 +1,5 @@
-import { confirm } from '@inquirer/prompts';
-import { ethers } from 'ethers';
-
-import {
-  getSecretRpcEndpoints,
-  getSecretRpcEndpointsLatestVersionName,
-  secretRpcEndpointsExist,
-  setSecretRpcEndpoints,
-} from '../../src/agents/index.js';
-import { disableGCPSecretVersion } from '../../src/utils/gcloud.js';
-import { isEthereumProtocolChain } from '../../src/utils/utils.js';
+import { setAndVerifyRpcUrls } from '../../src/utils/rpcUrls.js';
 import { getArgs, withChainRequired, withRpcUrls } from '../agent-utils.js';
-
-async function testProviders(rpcUrlsArray: string[]): Promise<boolean> {
-  let providersSucceeded = true;
-  for (const url of rpcUrlsArray) {
-    const provider = new ethers.providers.StaticJsonRpcProvider(url);
-    try {
-      const blockNumber = await provider.getBlockNumber();
-      console.log(`Valid provider for ${url} with block number ${blockNumber}`);
-    } catch (e) {
-      console.error(`Provider failed: ${url}`);
-      providersSucceeded = false;
-    }
-  }
-
-  return providersSucceeded;
-}
 
 async function main() {
   const { environment, chain, rpcUrls } = await withRpcUrls(
@@ -42,74 +16,7 @@ async function main() {
     process.exit(1);
   }
 
-  const secretPayload = JSON.stringify(rpcUrlsArray);
-
-  const secretExists = await secretRpcEndpointsExist(environment, chain);
-  if (!secretExists) {
-    console.log(
-      `No secret rpc urls found for ${chain} in ${environment} environment\n`,
-    );
-  } else {
-    const currentSecrets = await getSecretRpcEndpoints(environment, chain);
-    console.log(
-      `Current secrets found for ${chain} in ${environment} environment:\n${JSON.stringify(
-        currentSecrets,
-        null,
-        2,
-      )}\n`,
-    );
-  }
-
-  const confirmedSet = await confirm({
-    message: `Are you sure you want to set the following RPC URLs for ${chain} in ${environment}?\n${secretPayload}\n`,
-  });
-
-  if (!confirmedSet) {
-    console.log('Exiting without setting secret.');
-    process.exit(0);
-  }
-
-  if (isEthereumProtocolChain(chain)) {
-    console.log('\nTesting providers...');
-    const testPassed = await testProviders(rpcUrlsArray);
-    if (!testPassed) {
-      console.error('At least one provider failed. Exiting.');
-      process.exit(1);
-    }
-
-    const confirmedProviders = await confirm({
-      message: `All providers passed. Do you want to continue setting the secret?\n`,
-    });
-
-    if (!confirmedProviders) {
-      console.log('Exiting without setting secret.');
-      process.exit(0);
-    }
-  } else {
-    console.log(
-      'Skipping provider testing as chain is not an Ethereum protocol chain.',
-    );
-  }
-
-  let latestVersionName;
-  if (secretExists) {
-    latestVersionName = await getSecretRpcEndpointsLatestVersionName(
-      environment,
-      chain,
-    );
-  }
-  console.log(`Setting secret...`);
-  await setSecretRpcEndpoints(environment, chain, secretPayload);
-  console.log(`Added secret version!`);
-
-  if (latestVersionName) {
-    try {
-      await disableGCPSecretVersion(latestVersionName);
-      console.log(`Disabled previous version of the secret!`);
-    } catch (e) {
-      console.log(`Could not disable previous version of the secret`);
-    }
-  }
+  await setAndVerifyRpcUrls(environment, chain, rpcUrlsArray);
 }
 
 main()

--- a/typescript/infra/src/utils/rpcUrls.ts
+++ b/typescript/infra/src/utils/rpcUrls.ts
@@ -41,7 +41,7 @@ export async function setAndVerifyRpcUrls(
     await confirmSetSecrets(environment, chain, secretPayload);
     await testProvidersIfNeeded(chain, rpcUrlsArray);
     await updateSecretAndDisablePrevious(environment, chain, secretPayload);
-  } catch (error) {
+  } catch (error: any) {
     console.error(
       `Error occurred while setting RPC URLs for ${chain}:`,
       error.message,

--- a/typescript/infra/src/utils/rpcUrls.ts
+++ b/typescript/infra/src/utils/rpcUrls.ts
@@ -1,6 +1,8 @@
 import { confirm } from '@inquirer/prompts';
 import { ethers } from 'ethers';
 
+import { timeout } from '@hyperlane-xyz/utils';
+
 import {
   getSecretRpcEndpoints,
   getSecretRpcEndpointsLatestVersionName,
@@ -16,7 +18,7 @@ export async function testProviders(rpcUrlsArray: string[]): Promise<boolean> {
   for (const url of rpcUrlsArray) {
     const provider = new ethers.providers.StaticJsonRpcProvider(url);
     try {
-      const blockNumber = await provider.getBlockNumber();
+      const blockNumber = await timeout(provider.getBlockNumber(), 5000);
       console.log(`Valid provider for ${url} with block number ${blockNumber}`);
     } catch (e) {
       console.error(`Provider failed: ${url}`);

--- a/typescript/infra/src/utils/rpcUrls.ts
+++ b/typescript/infra/src/utils/rpcUrls.ts
@@ -1,0 +1,139 @@
+import { confirm } from '@inquirer/prompts';
+import { ethers } from 'ethers';
+
+import {
+  getSecretRpcEndpoints,
+  getSecretRpcEndpointsLatestVersionName,
+  secretRpcEndpointsExist,
+  setSecretRpcEndpoints,
+} from '../agents/index.js';
+
+import { disableGCPSecretVersion } from './gcloud.js';
+import { isEthereumProtocolChain } from './utils.js';
+
+export async function testProviders(rpcUrlsArray: string[]): Promise<boolean> {
+  let providersSucceeded = true;
+  for (const url of rpcUrlsArray) {
+    const provider = new ethers.providers.StaticJsonRpcProvider(url);
+    try {
+      const blockNumber = await provider.getBlockNumber();
+      console.log(`Valid provider for ${url} with block number ${blockNumber}`);
+    } catch (e) {
+      console.error(`Provider failed: ${url}`);
+      providersSucceeded = false;
+    }
+  }
+
+  return providersSucceeded;
+}
+
+export async function setAndVerifyRpcUrls(
+  environment: string,
+  chain: string,
+  rpcUrlsArray: string[],
+): Promise<void> {
+  const secretPayload = JSON.stringify(rpcUrlsArray);
+
+  try {
+    await displayCurrentSecrets(environment, chain);
+    await confirmSetSecrets(environment, chain, secretPayload);
+    await testProvidersIfNeeded(chain, rpcUrlsArray);
+    await updateSecretAndDisablePrevious(environment, chain, secretPayload);
+  } catch (error) {
+    console.error(
+      `Error occurred while setting RPC URLs for ${chain}:`,
+      error.message,
+    );
+    return;
+  }
+}
+
+async function displayCurrentSecrets(
+  environment: string,
+  chain: string,
+): Promise<void> {
+  const secretExists = await secretRpcEndpointsExist(environment, chain);
+  if (!secretExists) {
+    console.log(
+      `No secret rpc urls found for ${chain} in ${environment} environment\n`,
+    );
+  } else {
+    const currentSecrets = await getSecretRpcEndpoints(environment, chain);
+    console.log(
+      `Current secrets found for ${chain} in ${environment} environment:\n${JSON.stringify(
+        currentSecrets,
+        null,
+        2,
+      )}\n`,
+    );
+  }
+}
+
+async function confirmSetSecrets(
+  environment: string,
+  chain: string,
+  secretPayload: string,
+): Promise<void> {
+  const confirmedSet = await confirm({
+    message: `Are you sure you want to set the following RPC URLs for ${chain} in ${environment}?\n${secretPayload}\n`,
+  });
+
+  if (!confirmedSet) {
+    console.log('Continuing without setting secret.');
+    throw new Error('User cancelled operation');
+  }
+}
+
+async function testProvidersIfNeeded(
+  chain: string,
+  rpcUrlsArray: string[],
+): Promise<void> {
+  if (isEthereumProtocolChain(chain)) {
+    console.log('\nTesting providers...');
+    const testPassed = await testProviders(rpcUrlsArray);
+    if (!testPassed) {
+      console.error('At least one provider failed.');
+      throw new Error('Provider test failed');
+    }
+
+    const confirmedProviders = await confirm({
+      message: `All providers passed. Do you want to continue setting the secret?\n`,
+    });
+
+    if (!confirmedProviders) {
+      console.log('Continuing without setting secret.');
+      throw new Error('User cancelled operation after provider test');
+    }
+  } else {
+    console.log(
+      'Skipping provider testing as chain is not an Ethereum protocol chain.',
+    );
+  }
+}
+
+async function updateSecretAndDisablePrevious(
+  environment: string,
+  chain: string,
+  secretPayload: string,
+): Promise<void> {
+  const secretExists = await secretRpcEndpointsExist(environment, chain);
+  let latestVersionName;
+  if (secretExists) {
+    latestVersionName = await getSecretRpcEndpointsLatestVersionName(
+      environment,
+      chain,
+    );
+  }
+  console.log(`Setting secret...`);
+  await setSecretRpcEndpoints(environment, chain, secretPayload);
+  console.log(`Added secret version!`);
+
+  if (latestVersionName) {
+    try {
+      await disableGCPSecretVersion(latestVersionName);
+      console.log(`Disabled previous version of the secret!`);
+    } catch (e) {
+      console.log(`Could not disable previous version of the secret`);
+    }
+  }
+}


### PR DESCRIPTION
resolves https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4227

- add `set-rpc-urls-from-registry` script to set secrets by reading in contents of registry
	- example usage: `yarn tsx scripts/secret-rpc-urls/set-rpc-urls-from-registry.ts -e mainnet3 -c base zircuit arbitrum`
- refactored `set-rpc-urls` to reuse logic across both scripts