### PR TITLE
feat: configure ICA owners

### DIFF
--- a/typescript/infra/config/environments/mainnet3/owners.ts
+++ b/typescript/infra/config/environments/mainnet3/owners.ts
@@ -22,7 +22,7 @@ export function localAccountRouters(): ChainMap<Address> {
   );
 }
 
-export const safes: ChainMap<Address | undefined> = {
+export const safes: ChainMap<Address> = {
   mantapacific: '0x03ed2D65f2742193CeD99D48EbF1F1D6F12345B6', // does not have a UI
   celo: '0x879038d6Fc9F6D5e2BA73188bd078486d77e1156',
   ethereum: '0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6',
@@ -55,22 +55,32 @@ export const safes: ChainMap<Address | undefined> = {
   endurance: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
 };
 
+export const icaOwnerChain = 'ethereum';
+
+// Found by running:
+// yarn tsx ./scripts/get-owner-ica.ts -e mainnet3 --ownerChain ethereum --destinationChain <chain>
+export const icas: ChainMap<Address> = {
+  viction: '0x23ed65DE22ac29Ec1C16E75EddB0cE3A187357b4',
+  inevm: '0xFDF9EDcb2243D51f5f317b9CEcA8edD2bEEE036e',
+};
+
 export const DEPLOYER = '0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba';
 
-// NOTE: if you wanna use ICA governance, you can do the following:
-// const localRouters = localAccountRouters();
-// owner: {origin: <HUB_CHAIN>, owner: <SAFE_ADDRESS>, localRouter: localRouters[chain]}
 export const ethereumChainOwners: ChainMap<OwnableConfig> = Object.fromEntries(
-  ethereumChainNames.map((local) => [
-    local,
-    {
-      owner: safes[local] ?? DEPLOYER,
-      ownerOverrides: {
-        proxyAdmin: timelocks[local] ?? safes[local] ?? DEPLOYER,
-        validatorAnnounce: DEPLOYER, // unused
-        testRecipient: DEPLOYER,
-        fallbackRoutingHook: DEPLOYER,
+  ethereumChainNames.map((local) => {
+    const owner = icas[local] ?? safes[local] ?? DEPLOYER;
+
+    return [
+      local,
+      {
+        owner,
+        ownerOverrides: {
+          proxyAdmin: timelocks[local] ?? owner,
+          validatorAnnounce: DEPLOYER, // unused
+          testRecipient: DEPLOYER,
+          fallbackRoutingHook: DEPLOYER,
+        },
       },
-    },
-  ]),
+    ];
+  }),
 );

--- a/typescript/infra/config/environments/mainnet3/owners.ts
+++ b/typescript/infra/config/environments/mainnet3/owners.ts
@@ -61,7 +61,8 @@ export const icaOwnerChain = 'ethereum';
 // yarn tsx ./scripts/get-owner-ica.ts -e mainnet3 --ownerChain ethereum --destinationChain <chain>
 export const icas: ChainMap<Address> = {
   viction: '0x23ed65DE22ac29Ec1C16E75EddB0cE3A187357b4',
-  inevm: '0xFDF9EDcb2243D51f5f317b9CEcA8edD2bEEE036e',
+  // inEVM ownership should be transferred to this ICA, and this should be uncommented
+  // inevm: '0xFDF9EDcb2243D51f5f317b9CEcA8edD2bEEE036e',
 };
 
 export const DEPLOYER = '0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba';

--- a/typescript/infra/config/environments/testnet4/helloworld.ts
+++ b/typescript/infra/config/environments/testnet4/helloworld.ts
@@ -13,7 +13,7 @@ export const hyperlaneHelloworld: HelloWorldConfig = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'efa9025-20240605-091304',
+      tag: '857338e-20240716-165320',
     },
     chainsToSkip: [],
     runEnv: environment,
@@ -32,7 +32,7 @@ export const releaseCandidateHelloworld: HelloWorldConfig = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: 'efa9025-20240605-091304',
+      tag: '857338e-20240716-165320',
     },
     chainsToSkip: [],
     runEnv: environment,


### PR DESCRIPTION
### Description

Successful ICA interactions here: https://www.notion.so/hyperlanexyz/Test-ICA-call-Ethereum-viction-inevm-f7bb4414554248cda038f19489267ec4?pvs=4#66c9651cda2a45b69c49533b24c06500

- Adds the viction ICA as the new owner
- Doesn't yet set the inEVM owner - it's in there but commented out. If it's added now, we'll start to have new contracts be owned by it, but it'll also result in a lot of violations. Happy to uncomment it if that seems better.
- Ideally the ICAs would be generated from the owner address on the ethereum chain, but atm the best way to do this is an eth_call, and we sadly can't do async calls. It's an option to write a non-async version that uses some fancy create2 logic in ts, but this felt like overkill. I can also write a test, but it feels a bit weird to have eth_calls to live networks on a test. For now I'm personally comfortable with us just taking on the maintenance burden of ensuring these are all correct.

### Drive-by changes

- Redeployed testnet4 kathy - I think the version that was live prior to this may not have been using private URLs

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
