### PR TITLE
fix(cli): Remove getUri from core read logging

### DIFF
--- a/.changeset/sour-ladybugs-appear.md
+++ b/.changeset/sour-ladybugs-appear.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Remove registry.getUri() from core read logging to prevent registry error

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -189,7 +189,7 @@ export const read: CommandModuleWithContext<{
       mailbox = addresses?.mailbox;
       if (!mailbox) {
         throw new Error(
-          `${chain} mailbox not provided and none found in registry ${context.registry.getUri()}`,
+          `${chain} mailbox not provided and none found in registry.`,
         );
       }
     }


### PR DESCRIPTION
### Description
This removes the `getUri()` from a specific log because the function throws for MergeRegistry and ends up hiding the real error message.

### Backward compatibility
Yes

### Testing
Manual
