### PR TITLE
chore: bump validator resource requests

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -293,8 +293,8 @@ const relayerResources = {
 
 const validatorResources = {
   requests: {
-    cpu: '250m',
-    memory: '256Mi',
+    cpu: '500m',
+    memory: '1Gi',
   },
 };
 


### PR DESCRIPTION
### Description

See thread https://discord.com/channels/935678348330434570/935679524534911007/1271367720797077548 for context.

TLDR:
- upon starting up, validators tend to use more CPU and memory, and this scales a bit with # of messages previously dispatched on that chain
- nothing concerning, but we were exceeding the 75% usage / requests threshold on some of our alerts, so bumping to give some room

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
