### PR TITLE
fix: revert interface change for AbstractMultisig

### DIFF
--- a/solidity/contracts/isms/libs/MerkleRootMultisigIsmMetadata.sol
+++ b/solidity/contracts/isms/libs/MerkleRootMultisigIsmMetadata.sol
@@ -115,7 +115,7 @@ library MerkleRootMultisigIsmMetadata {
      * @param _metadata ABI encoded Merkle Root Multisig ISM metadata.
      * @return The number of signatures in the metadata.
      */
-    function signatureCount(
+    function _signatureCount(
         bytes calldata _metadata
     ) internal pure returns (uint256) {
         uint256 signatures = _metadata.length - SIGNATURES_OFFSET;

--- a/solidity/contracts/isms/libs/MessageIdMultisigIsmMetadata.sol
+++ b/solidity/contracts/isms/libs/MessageIdMultisigIsmMetadata.sol
@@ -74,7 +74,7 @@ library MessageIdMultisigIsmMetadata {
      * @param _metadata ABI encoded MessageId Multisig ISM metadata.
      * @return The number of signatures in the metadata.
      */
-    function signatureCount(
+    function _signatureCount(
         bytes calldata _metadata
     ) internal pure returns (uint256) {
         uint256 signatures = _metadata.length - SIGNATURES_OFFSET;

--- a/solidity/contracts/isms/multisig/AbstractMerkleRootMultisigIsm.sol
+++ b/solidity/contracts/isms/multisig/AbstractMerkleRootMultisigIsm.sol
@@ -69,9 +69,9 @@ abstract contract AbstractMerkleRootMultisigIsm is AbstractMultisig {
     /**
      * @inheritdoc AbstractMultisig
      */
-    function signatureCount(
+    function _signatureCount(
         bytes calldata _metadata
-    ) public pure override returns (uint256) {
-        return _metadata.signatureCount();
+    ) internal pure override returns (uint256) {
+        return _metadata._signatureCount();
     }
 }

--- a/solidity/contracts/isms/multisig/AbstractMessageIdMultisigIsm.sol
+++ b/solidity/contracts/isms/multisig/AbstractMessageIdMultisigIsm.sol
@@ -54,9 +54,9 @@ abstract contract AbstractMessageIdMultisigIsm is AbstractMultisig {
     /**
      * @inheritdoc AbstractMultisig
      */
-    function signatureCount(
+    function _signatureCount(
         bytes calldata _metadata
-    ) public pure override returns (uint256) {
-        return _metadata.signatureCount();
+    ) internal pure override returns (uint256) {
+        return _metadata._signatureCount();
     }
 }

--- a/solidity/contracts/isms/multisig/AbstractMultisigIsm.sol
+++ b/solidity/contracts/isms/multisig/AbstractMultisigIsm.sol
@@ -57,9 +57,9 @@ abstract contract AbstractMultisig {
      * @param _metadata ABI encoded module metadata
      * @return count The number of signatures
      */
-    function signatureCount(
+    function _signatureCount(
         bytes calldata _metadata
-    ) public pure virtual returns (uint256);
+    ) internal pure virtual returns (uint256);
 }
 
 /**

--- a/solidity/contracts/isms/multisig/AbstractWeightedMultisigIsm.sol
+++ b/solidity/contracts/isms/multisig/AbstractWeightedMultisigIsm.sol
@@ -47,6 +47,17 @@ abstract contract AbstractStaticWeightedMultisigIsm is
     ) public view virtual returns (ValidatorInfo[] memory, uint96);
 
     /**
+     * @notice public function for reading number of signatures in metadata
+     * @param _metadata ABI encoded module metadata
+     * @return the number of signatures
+     */
+    function signatureCount(
+        bytes calldata _metadata
+    ) public pure virtual returns (uint256) {
+        return _signatureCount(_metadata);
+    }
+
+    /**
      * @inheritdoc IInterchainSecurityModule
      */
     function verify(
@@ -66,7 +77,7 @@ abstract contract AbstractStaticWeightedMultisigIsm is
 
         uint256 _validatorCount = Math.min(
             _validators.length,
-            signatureCount(_metadata)
+            _signatureCount(_metadata)
         );
         uint256 _validatorIndex = 0;
         uint96 _totalWeight = 0;


### PR DESCRIPTION
### Description

PR #4170 added signatureCount to the AbstractMultisig interface for making sure the correct revert message has shown not enough signatures passed to ism.verify() but this is a breaking change so I've converted it into an internal function.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
