### PR TITLE
fix: temporarily skip flaky MultisigMetadataBuilder test

### DIFF
--- a/typescript/sdk/src/ism/metadata/multisig.test.ts
+++ b/typescript/sdk/src/ism/metadata/multisig.test.ts
@@ -50,7 +50,8 @@ const fixtures: Fixture<MultisigMetadata>[] = files
     return { decoded, encoded: contents.encoded };
   });
 
-describe('MultisigMetadataBuilder', () => {
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('MultisigMetadataBuilder', () => {
   fixtures.forEach((fixture, i) => {
     it(`should encode fixture ${i}`, () => {
       expect(MultisigMetadataBuilder.encode(fixture.decoded)).to.equal(


### PR DESCRIPTION
example of test that flakes fairly regularly: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/10316932362/job/28560341286#step:6:1022

