### PR TITLE
fix(sdk): Add collateralFiat support into Token.ts & TokenStandard.ts

### DIFF
--- a/.changeset/nine-lamps-boil.md
+++ b/.changeset/nine-lamps-boil.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Adds CollateralFiat to token mapping which will output the correct standard to the warp deploy artifact.

--- a/typescript/sdk/src/token/Token.test.ts
+++ b/typescript/sdk/src/token/Token.test.ts
@@ -47,6 +47,15 @@ const STANDARD_TO_TOKEN: Record<TokenStandard, TokenArgs | null> = {
     symbol: 'USDC',
     name: 'USDC',
   },
+  [TokenStandard.EvmHypCollateralFiat]: {
+    chainName: TestChainName.test3,
+    standard: TokenStandard.EvmHypCollateralFiat,
+    addressOrDenom: '0x31b5234A896FbC4b3e2F7237592D054716762131',
+    collateralAddressOrDenom: '0x64544969ed7ebf5f083679233325356ebe738930',
+    decimals: 18,
+    symbol: 'USDC',
+    name: 'USDC',
+  },
   [TokenStandard.EvmHypSynthetic]: {
     chainName: TestChainName.test2,
     standard: TokenStandard.EvmHypSynthetic,

--- a/typescript/sdk/src/token/Token.ts
+++ b/typescript/sdk/src/token/Token.ts
@@ -211,6 +211,10 @@ export class Token implements IToken {
       return new EvmHypCollateralAdapter(chainName, multiProvider, {
         token: addressOrDenom,
       });
+    } else if (standard === TokenStandard.EvmHypCollateralFiat) {
+      return new EvmHypCollateralAdapter(chainName, multiProvider, {
+        token: addressOrDenom,
+      });
     } else if (standard === TokenStandard.EvmHypSynthetic) {
       return new EvmHypSyntheticAdapter(chainName, multiProvider, {
         token: addressOrDenom,

--- a/typescript/sdk/src/token/TokenStandard.ts
+++ b/typescript/sdk/src/token/TokenStandard.ts
@@ -14,6 +14,7 @@ export enum TokenStandard {
   EvmNative = 'EvmNative',
   EvmHypNative = 'EvmHypNative',
   EvmHypCollateral = 'EvmHypCollateral',
+  EvmHypCollateralFiat = 'EvmHypCollateralFiat',
   EvmHypSynthetic = 'EvmHypSynthetic',
   EvmHypXERC20 = 'EvmHypXERC20',
   EvmHypXERC20Lockbox = 'EvmHypXERC20Lockbox',
@@ -49,6 +50,7 @@ export const TOKEN_STANDARD_TO_PROTOCOL: Record<TokenStandard, ProtocolType> = {
   EvmNative: ProtocolType.Ethereum,
   EvmHypNative: ProtocolType.Ethereum,
   EvmHypCollateral: ProtocolType.Ethereum,
+  EvmHypCollateralFiat: ProtocolType.Ethereum,
   EvmHypSynthetic: ProtocolType.Ethereum,
   EvmHypXERC20: ProtocolType.Ethereum,
   EvmHypXERC20Lockbox: ProtocolType.Ethereum,
@@ -108,6 +110,7 @@ export const MINT_LIMITED_STANDARDS = [
 export const TOKEN_HYP_STANDARDS = [
   TokenStandard.EvmHypNative,
   TokenStandard.EvmHypCollateral,
+  TokenStandard.EvmHypCollateralFiat,
   TokenStandard.EvmHypSynthetic,
   TokenStandard.EvmHypXERC20,
   TokenStandard.EvmHypXERC20Lockbox,
@@ -138,7 +141,7 @@ export const TOKEN_COSMWASM_STANDARDS = [
 export const TOKEN_TYPE_TO_STANDARD: Record<TokenType, TokenStandard> = {
   [TokenType.native]: TokenStandard.EvmHypNative,
   [TokenType.collateral]: TokenStandard.EvmHypCollateral,
-  [TokenType.collateralFiat]: TokenStandard.EvmHypCollateral,
+  [TokenType.collateralFiat]: TokenStandard.EvmHypCollateralFiat,
   [TokenType.XERC20]: TokenStandard.EvmHypXERC20,
   [TokenType.XERC20Lockbox]: TokenStandard.EvmHypXERC20Lockbox,
   [TokenType.collateralVault]: TokenStandard.EvmHypCollateral,


### PR DESCRIPTION
### Description
Adds CollateralFiat to token mapping which will output the correct `standard` to the warp deploy artifact.

### Related issues
https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4307

### Backward compatibility
Yes

### Testing
Manually tested with Beta (collateral) -> Gamma (CollateralFiat)
1. Deploy an ERC20 to represent USDC on beta
```
forge create contracts/test/ERC20Test.sol:ERC20Test \
--constructor-args "Test" "TS" 10000000000000000000000000 6 \
--rpc-url https://beta-op.rpc.caldera.xyz/http \
--private-key $HYP_KEY
```
2. Deploy a CollateralFiat on gamma
```
forge create contracts/test/ERC20Test.sol:FiatTokenTest \
--constructor-args "FiatTest" "FTS" 0 6 \
--rpc-url https://rpc-gamma-2bgo7wnh9d.t.conduit.xyz \
--private-key $HYP_KEY
```
3. warp init and deploy
4. Start up the ts relayer `hyperlane relayer --chains beta,gamma`
5. Add the deploy artifacts to UI
```
# warpRoutes.yaml
tokens:
  - chainName: beta
    standard: EvmHypCollateral
    decimals: 6
    symbol: TS
    name: Test
    addressOrDenom: "0x56D13Eb21a625EdA8438F55DF2C31dC3632034f5"
    collateralAddressOrDenom: "0x9BcC604D4381C5b0Ad12Ff3Bf32bEdE063416BC7"
    connections:
      - token: ethereum|gamma|0xA7c59f010700930003b33aB25a7a0679C860f29c
  - chainName: gamma
    standard: EvmHypCollateralFiat
    decimals: 6
    symbol: TS
    name: Test
    addressOrDenom: "0xA7c59f010700930003b33aB25a7a0679C860f29c"
    collateralAddressOrDenom: "0xD5ac451B0c50B9476107823Af206eD814a2e2580"
    connections:
      - token: ethereum|beta|0x56D13Eb21a625EdA8438F55DF2C31dC3632034f5

# chains.yaml
beta:
  displayName: Beta
  chainId: 7097927
  domainId: 7097927
  protocol: ethereum
  name: beta
  isTestnet: true
  rpcUrls:
    - http: https://beta-op.rpc.caldera.xyz/http
  nativeToken:
    symbol: ETH
    name: Ether
    decimals: 18
gamma:
  blockExplorers:
  - apiUrl: https://explorer-gamma-2bgo7wnh9d.t.conduit.xyz
    family: blockscout
    name: gamma explorer
    url: https://explorer-gamma-2bgo7wnh9d.t.conduit.xyz
  chainId: 69995
  displayName: Gamma
  domainId: 69995
  isTestnet: true
  name: gamma
  nativeToken:
    decimals: 18
    name: Ether
    symbol: ETH
  protocol: ethereum
  rpcUrls:
    - http: https://rpc-gamma-2bgo7wnh9d.t.conduit.xyz
```
7. Start up UI
