### PR TITLE
feat(HypERC20App): Support proxiedFactories in HypERC20App, extend HypERC20Checker with ProxiedRouterChecker

### DIFF
--- a/.changeset/curly-mangos-buy.md
+++ b/.changeset/curly-mangos-buy.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Support proxiedFactories in HypERC20App and extend HypERC20Checker with ProxiedRouterChecker

--- a/typescript/infra/scripts/check-deploy.ts
+++ b/typescript/infra/scripts/check-deploy.ts
@@ -13,6 +13,7 @@ import {
   InterchainQueryChecker,
   attachContractsMapAndGetForeignDeployments,
   hypERC20factories,
+  proxiedFactories,
 } from '@hyperlane-xyz/sdk';
 import { objFilter } from '@hyperlane-xyz/utils';
 
@@ -154,18 +155,21 @@ async function check() {
       throw new Error('Warp route id required for warp module');
     }
     const config = await getWarpConfig(multiProvider, envConfig, warpRouteId);
-    const addresses = getWarpAddresses(warpRouteId);
-    const filteredAddresses = Object.keys(addresses) // filter out changes not in config
+    const warpAddresses = getWarpAddresses(warpRouteId);
+    const filteredAddresses = Object.keys(warpAddresses) // filter out changes not in config
       .filter((key) => key in config)
       .reduce((obj, key) => {
-        obj[key] = addresses[key];
+        obj[key] = {
+          ...warpAddresses[key],
+          proxyAdmin: chainAddresses[key].proxyAdmin,
+        };
         return obj;
-      }, {} as typeof addresses);
+      }, {} as typeof warpAddresses);
 
     const { contractsMap, foreignDeployments } =
       attachContractsMapAndGetForeignDeployments(
         filteredAddresses,
-        hypERC20factories,
+        { ...hypERC20factories, ...proxiedFactories },
         multiProvider,
       );
 

--- a/typescript/sdk/src/core/HyperlaneCore.ts
+++ b/typescript/sdk/src/core/HyperlaneCore.ts
@@ -62,7 +62,6 @@ export class HyperlaneCore extends HyperlaneApp<CoreFactories> {
         owner: typeof owners === 'string' ? owners : owners[chain].owner,
         ownerOverrides:
           typeof owners === 'string' ? undefined : owners[chain].ownerOverrides,
-        proxyAdmin: contracts.proxyAdmin.address,
       }),
     );
     // filter for EVM chains

--- a/typescript/sdk/src/router/schemas.ts
+++ b/typescript/sdk/src/router/schemas.ts
@@ -24,21 +24,13 @@ export const RemoteRoutersSchema = z.record(
   RemoteRouterRouter,
 );
 
-const ProxyAdminConfigSchema = z.object({
-  proxyAdmin: z.string().optional(),
-});
-
 export const RouterConfigSchema = MailboxClientConfigSchema.merge(
   ForeignDeploymentConfigSchema,
-)
-  .merge(
-    z.object({
-      remoteRouters: RemoteRoutersSchema.optional(),
-    }),
-  )
-  // TODO: RouterConfigSchema is an artifact of the warp route deployment schema
-  // adding ProxyAdminConfigSchema is subtlety mixing config and artifact schemas, consider refactoring
-  .merge(ProxyAdminConfigSchema);
+).merge(
+  z.object({
+    remoteRouters: RemoteRoutersSchema.optional(),
+  }),
+);
 
 export const GasRouterConfigSchema = RouterConfigSchema.extend({
   gas: z.number().optional(),

--- a/typescript/sdk/src/token/app.ts
+++ b/typescript/sdk/src/token/app.ts
@@ -1,7 +1,11 @@
 import { Logger } from 'pino';
 
 import { TokenRouter } from '@hyperlane-xyz/core';
-import { ChainMap } from '@hyperlane-xyz/sdk';
+import {
+  ChainMap,
+  ProxiedFactories,
+  proxiedFactories,
+} from '@hyperlane-xyz/sdk';
 import { Address, objKeys } from '@hyperlane-xyz/utils';
 
 import { appFromAddressesMapHelper } from '../contracts/contracts.js';
@@ -15,9 +19,12 @@ import { GasRouterApp } from '../router/RouterApps.js';
 
 import { HypERC20Factories, hypERC20factories } from './contracts.js';
 
-export class HypERC20App extends GasRouterApp<HypERC20Factories, TokenRouter> {
+export class HypERC20App extends GasRouterApp<
+  HypERC20Factories & ProxiedFactories,
+  TokenRouter
+> {
   constructor(
-    contractsMap: HyperlaneContractsMap<HypERC20Factories>,
+    contractsMap: HyperlaneContractsMap<HypERC20Factories & ProxiedFactories>,
     multiProvider: MultiProvider,
     logger?: Logger,
     foreignDeployments: ChainMap<Address> = {},
@@ -35,12 +42,12 @@ export class HypERC20App extends GasRouterApp<HypERC20Factories, TokenRouter> {
   }
 
   static fromAddressesMap(
-    addressesMap: HyperlaneAddressesMap<HypERC20Factories>,
+    addressesMap: HyperlaneAddressesMap<HypERC20Factories & ProxiedFactories>,
     multiProvider: MultiProvider,
   ): HypERC20App {
     const helper = appFromAddressesMapHelper(
       addressesMap,
-      hypERC20factories,
+      { ...hypERC20factories, ...proxiedFactories },
       multiProvider,
     );
     return new HypERC20App(helper.contractsMap, helper.multiProvider);

--- a/typescript/sdk/src/token/checker.ts
+++ b/typescript/sdk/src/token/checker.ts
@@ -4,7 +4,8 @@ import { ERC20, ERC20__factory, HypERC20Collateral } from '@hyperlane-xyz/core';
 import { eqAddress } from '@hyperlane-xyz/utils';
 
 import { TokenMismatchViolation } from '../deploy/types.js';
-import { HyperlaneRouterChecker } from '../router/HyperlaneRouterChecker.js';
+import { ProxiedRouterChecker } from '../router/ProxiedRouterChecker.js';
+import { ProxiedFactories } from '../router/types.js';
 import { ChainName } from '../types.js';
 
 import { HypERC20App } from './app.js';
@@ -17,16 +18,14 @@ import {
 } from './schemas.js';
 import { TokenMetadata } from './types.js';
 
-export class HypERC20Checker extends HyperlaneRouterChecker<
-  HypERC20Factories,
+export class HypERC20Checker extends ProxiedRouterChecker<
+  HypERC20Factories & ProxiedFactories,
   HypERC20App,
   TokenRouterConfig
 > {
   async checkChain(chain: ChainName): Promise<void> {
     await super.checkChain(chain);
     await this.checkToken(chain);
-    // We have adapted this method to accept a proxyAdmin contract address parameter
-    await this.checkProxiedContracts(chain, this.configMap[chain].proxyAdmin);
   }
 
   async checkToken(chain: ChainName): Promise<void> {


### PR DESCRIPTION
### Description

- Extend `HypERC20Checker` with `ProxiedRouterChecker` so we can check for proxyAdmin violations (`checkProxiedContracts` is call in `checkChain`)
- Support passing `proxiedFactories` to `HypERC20App`  

### Fixes
- #4325 

### Testing

Manual