### PR TITLE
chore: use new forge feature for filtering coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto  # strictly increasing coverage
+        threshold: 5% # buffer for coverage drop
+
 comment:
   layout: "header, diff, flags, components"  # show component info in the PR comment
   

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ coverage:
     project:
       default:
         target: auto  # strictly increasing coverage
-        threshold: 5% # buffer for coverage drop
+        threshold: 3% # buffer for coverage drop
 
 comment:
   layout: "header, diff, flags, components"  # show component info in the PR comment

--- a/solidity/.vscode/extensions.json
+++ b/solidity/.vscode/extensions.json
@@ -6,6 +6,7 @@
   "recommendations": [
     "JuanBlanco.solidity",
     "tintinweb.vscode-ethover",
+    "ryanluker.vscode-coverage-gutters"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/solidity/coverage.sh
+++ b/solidity/coverage.sh
@@ -3,29 +3,10 @@
 # exit on error
 set -e
 
-# generates lcov.info
+# exclude FastTokenRouter until https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/2806 is resolved
 forge coverage \
     --report lcov \
+    --report summary \
+    --no-match-coverage "(test|mock|node_modules|script|Fast)" \
     --no-match-test testFork \
     --ir-minimum # https://github.com/foundry-rs/foundry/issues/3357
-
-if ! command -v lcov &>/dev/null; then
-    echo "lcov is not installed. Installing..."
-    sudo apt-get install lcov
-fi
-
-lcov --version
-
-# exclude FastTokenRouter until https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/2806
-EXCLUDE="*test* *mock* *node_modules* *script* *FastHyp*"
-lcov \
-    --rc lcov_branch_coverage=1 \
-    --remove lcov.info $EXCLUDE \
-    --output-file forge-pruned-lcov.info \
-
-if [ "$CI" != "true" ]; then
-    genhtml forge-pruned-lcov.info \
-        --rc lcov_branch_coverage=1 \
-        --output-directory coverage
-    open coverage/index.html
-fi


### PR DESCRIPTION
### Description

- Remove lcov toolchain from coverage script in favor of new native forge features
- Require strictly increasing project coverage

### Drive-by changes

- Add coverage gutters to vscode recommendations for inline view

### Backward compatibility

Yes

### Testing

See codecov report comment
