### PR TITLE
feat: implement `OPL2ToL1Ism` contracts

### DIFF
--- a/.changeset/light-poets-teach.md
+++ b/.changeset/light-poets-teach.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/core': minor
+---
+
+Added hook/ism for using the Optimism native bridge for L2->L1 calls

--- a/solidity/contracts/hooks/OPL2ToL1Hook.sol
+++ b/solidity/contracts/hooks/OPL2ToL1Hook.sol
@@ -71,9 +71,11 @@ contract OPL2ToL1Hook is AbstractMessageIdAuthHook {
         bytes calldata metadata,
         bytes memory payload
     ) internal override {
-        uint256 _value = metadata.msgValue(0) -
-            _quoteDispatch(metadata[0:0], metadata[0:0]);
-        l2Messenger.sendMessage{value: _value}(
+        require(
+            msg.value >= metadata.msgValue(0) + GAS_QUOTE,
+            "OPL2ToL1Hook: insufficient msg.value"
+        );
+        l2Messenger.sendMessage{value: metadata.msgValue(0)}(
             TypeCasts.bytes32ToAddress(ism),
             payload,
             GAS_QUOTE

--- a/solidity/contracts/hooks/OPL2ToL1Hook.sol
+++ b/solidity/contracts/hooks/OPL2ToL1Hook.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+// ============ Internal Imports ============
+import {AbstractPostDispatchHook} from "./libs/AbstractMessageIdAuthHook.sol";
+import {AbstractMessageIdAuthHook} from "./libs/AbstractMessageIdAuthHook.sol";
+import {Mailbox} from "../Mailbox.sol";
+import {StandardHookMetadata} from "./libs/StandardHookMetadata.sol";
+import {Message} from "../libs/Message.sol";
+import {TypeCasts} from "../libs/TypeCasts.sol";
+import {IPostDispatchHook} from "../interfaces/hooks/IPostDispatchHook.sol";
+import {MailboxClient} from "../client/MailboxClient.sol";
+
+// ============ External Imports ============
+import {ICrossDomainMessenger} from "../interfaces/optimism/ICrossDomainMessenger.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+/**
+ * @title OPL2ToL1Hook
+ * @notice Message hook to inform the OPL2ToL1Ism of messages published through
+ * the native Optimism bridge.
+ * @notice This works only for L2 -> L1 messages and has the 7 day delay as specified by the OptimismPortal contract.
+ */
+contract OPL2ToL1Hook is AbstractMessageIdAuthHook {
+    using StandardHookMetadata for bytes;
+
+    // ============ Constants ============
+
+    // precompile contract on L2 for sending messages to L1
+    ICrossDomainMessenger public immutable l2Messenger;
+    // Immutable quote amount
+    uint32 public immutable GAS_QUOTE;
+
+    // ============ Constructor ============
+
+    constructor(
+        address _mailbox,
+        uint32 _destinationDomain,
+        bytes32 _ism,
+        address _l2Messenger,
+        uint32 _gasQuote
+    ) AbstractMessageIdAuthHook(_mailbox, _destinationDomain, _ism) {
+        GAS_QUOTE = _gasQuote;
+        l2Messenger = ICrossDomainMessenger(_l2Messenger);
+    }
+
+    /// @inheritdoc IPostDispatchHook
+    function hookType() external pure override returns (uint8) {
+        return uint8(IPostDispatchHook.Types.OP_L2_TO_L1);
+    }
+
+    /// @inheritdoc AbstractPostDispatchHook
+    function _quoteDispatch(
+        bytes calldata,
+        bytes calldata
+    ) internal view override returns (uint256) {
+        return GAS_QUOTE;
+    }
+
+    // ============ Internal functions ============
+
+    /// @inheritdoc AbstractMessageIdAuthHook
+    function _sendMessageId(
+        bytes calldata metadata,
+        bytes memory payload
+    ) internal override {
+        l2Messenger.sendMessage{value: metadata.msgValue(0)}(
+            TypeCasts.bytes32ToAddress(ism),
+            payload,
+            GAS_QUOTE
+        );
+    }
+}

--- a/solidity/contracts/hooks/OPL2ToL1Hook.sol
+++ b/solidity/contracts/hooks/OPL2ToL1Hook.sol
@@ -71,7 +71,9 @@ contract OPL2ToL1Hook is AbstractMessageIdAuthHook {
         bytes calldata metadata,
         bytes memory payload
     ) internal override {
-        l2Messenger.sendMessage{value: metadata.msgValue(0)}(
+        uint256 _value = metadata.msgValue(0) -
+            _quoteDispatch(metadata[0:0], metadata[0:0]);
+        l2Messenger.sendMessage{value: _value}(
             TypeCasts.bytes32ToAddress(ism),
             payload,
             GAS_QUOTE

--- a/solidity/contracts/hooks/OPL2ToL1Hook.sol
+++ b/solidity/contracts/hooks/OPL2ToL1Hook.sol
@@ -14,18 +14,13 @@ pragma solidity >=0.8.0;
 @@@@@@@@@       @@@@@@@@*/
 
 // ============ Internal Imports ============
-import {AbstractPostDispatchHook} from "./libs/AbstractMessageIdAuthHook.sol";
-import {AbstractMessageIdAuthHook} from "./libs/AbstractMessageIdAuthHook.sol";
-import {Mailbox} from "../Mailbox.sol";
+import {AbstractPostDispatchHook, AbstractMessageIdAuthHook} from "./libs/AbstractMessageIdAuthHook.sol";
 import {StandardHookMetadata} from "./libs/StandardHookMetadata.sol";
-import {Message} from "../libs/Message.sol";
 import {TypeCasts} from "../libs/TypeCasts.sol";
 import {IPostDispatchHook} from "../interfaces/hooks/IPostDispatchHook.sol";
-import {MailboxClient} from "../client/MailboxClient.sol";
 
 // ============ External Imports ============
 import {ICrossDomainMessenger} from "../interfaces/optimism/ICrossDomainMessenger.sol";
-import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
 /**
  * @title OPL2ToL1Hook

--- a/solidity/contracts/interfaces/IInterchainSecurityModule.sol
+++ b/solidity/contracts/interfaces/IInterchainSecurityModule.sol
@@ -13,7 +13,8 @@ interface IInterchainSecurityModule {
         CCIP_READ,
         ARB_L2_TO_L1,
         WEIGHT_MERKLE_ROOT_MULTISIG,
-        WEIGHT_MESSAGE_ID_MULTISIG
+        WEIGHT_MESSAGE_ID_MULTISIG,
+        OP_L2_TO_L1
     }
 
     /**

--- a/solidity/contracts/interfaces/hooks/IPostDispatchHook.sol
+++ b/solidity/contracts/interfaces/hooks/IPostDispatchHook.sol
@@ -26,7 +26,8 @@ interface IPostDispatchHook {
         PROTOCOL_FEE,
         LAYER_ZERO_V1,
         RATE_LIMITED,
-        ARB_L2_TO_L1
+        ARB_L2_TO_L1,
+        OP_L2_TO_L1
     }
 
     /**

--- a/solidity/contracts/interfaces/optimism/ICrossDomainMessenger.sol
+++ b/solidity/contracts/interfaces/optimism/ICrossDomainMessenger.sol
@@ -30,6 +30,8 @@ interface ICrossDomainMessenger {
     function xDomainMessageSender() external view returns (address);
 
     function OTHER_MESSENGER() external view returns (address);
+
+    function PORTAL() external view returns (address);
 }
 
 interface IL1CrossDomainMessenger is ICrossDomainMessenger {}

--- a/solidity/contracts/interfaces/optimism/IOptimismPortal.sol
+++ b/solidity/contracts/interfaces/optimism/IOptimismPortal.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IOptimismPortal {
+    /// @notice Struct representing a withdrawal transaction.
+    /// @custom:field nonce    Nonce of the withdrawal transaction
+    /// @custom:field sender   Address of the sender of the transaction.
+    /// @custom:field target   Address of the recipient of the transaction.
+    /// @custom:field value    Value to send to the recipient.
+    /// @custom:field gasLimit Gas limit of the transaction.
+    /// @custom:field data     Data of the transaction.
+    struct WithdrawalTransaction {
+        uint256 nonce;
+        address sender;
+        address target;
+        uint256 value;
+        uint256 gasLimit;
+        bytes data;
+    }
+
+    // function proveWithdrawalTransaction(
+    //     Types.WithdrawalTransaction memory _tx,
+    //     uint256 _l2OutputIndex,
+    //     Types.OutputRootProof calldata _outputRootProof,
+    //     bytes[] calldata _withdrawalProof
+    // ) external;
+
+    function finalizeWithdrawalTransaction(
+        WithdrawalTransaction memory _tx
+    ) external;
+}

--- a/solidity/contracts/interfaces/optimism/IOptimismPortal.sol
+++ b/solidity/contracts/interfaces/optimism/IOptimismPortal.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.0;
 
 interface IOptimismPortal {
-    error WithdrawalTransactionFailed();
-
     /// @notice Struct representing a withdrawal transaction.
     /// @custom:field nonce    Nonce of the withdrawal transaction
     /// @custom:field sender   Address of the sender of the transaction.

--- a/solidity/contracts/interfaces/optimism/IOptimismPortal.sol
+++ b/solidity/contracts/interfaces/optimism/IOptimismPortal.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.0;
 
 interface IOptimismPortal {
+    error WithdrawalTransactionFailed();
+
     /// @notice Struct representing a withdrawal transaction.
     /// @custom:field nonce    Nonce of the withdrawal transaction
     /// @custom:field sender   Address of the sender of the transaction.
@@ -17,13 +19,6 @@ interface IOptimismPortal {
         uint256 gasLimit;
         bytes data;
     }
-
-    // function proveWithdrawalTransaction(
-    //     Types.WithdrawalTransaction memory _tx,
-    //     uint256 _l2OutputIndex,
-    //     Types.OutputRootProof calldata _outputRootProof,
-    //     bytes[] calldata _withdrawalProof
-    // ) external;
 
     function finalizeWithdrawalTransaction(
         WithdrawalTransaction memory _tx

--- a/solidity/contracts/interfaces/optimism/IOptimismPortal.sol
+++ b/solidity/contracts/interfaces/optimism/IOptimismPortal.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // author: OP Labs
-// inferred from https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock
+// copied from https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock
 interface IOptimismPortal {
     /// @notice Struct representing a withdrawal transaction.
     /// @custom:field nonce    Nonce of the withdrawal transaction

--- a/solidity/contracts/interfaces/optimism/IOptimismPortal.sol
+++ b/solidity/contracts/interfaces/optimism/IOptimismPortal.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+// author: OP Labs
+// inferred from https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock
 interface IOptimismPortal {
     /// @notice Struct representing a withdrawal transaction.
     /// @custom:field nonce    Nonce of the withdrawal transaction
@@ -18,6 +20,8 @@ interface IOptimismPortal {
         bytes data;
     }
 
+    /// @notice Finalizes a withdrawal transaction.
+    /// @param _tx Withdrawal transaction to finalize.
     function finalizeWithdrawalTransaction(
         WithdrawalTransaction memory _tx
     ) external;

--- a/solidity/contracts/isms/hook/OPL2ToL1Ism.sol
+++ b/solidity/contracts/isms/hook/OPL2ToL1Ism.sol
@@ -68,7 +68,7 @@ contract OPL2ToL1Ism is
     ) external override returns (bool) {
         bool verified = isVerified(message);
         if (!verified) {
-            require(_verifyWithPortalCall(metadata, message));
+            _verifyWithPortalCall(metadata, message);
         }
         releaseValueToRecipient(message);
         return true;
@@ -83,7 +83,7 @@ contract OPL2ToL1Ism is
     function _verifyWithPortalCall(
         bytes calldata metadata,
         bytes calldata message
-    ) internal returns (bool) {
+    ) internal {
         require(
             metadata.checkCalldataLength(),
             "OPL2ToL1Ism: invalid data length"
@@ -97,10 +97,8 @@ contract OPL2ToL1Ism is
             metadata,
             (IOptimismPortal.WithdrawalTransaction)
         );
-        portal.finalizeWithdrawalTransaction(withdrawal);
-
         // if the finalizeWithdrawalTransaction call is successful, the message is verified
-        return true;
+        portal.finalizeWithdrawalTransaction(withdrawal);
     }
 
     /// @inheritdoc AbstractMessageIdAuthorizedIsm

--- a/solidity/contracts/isms/hook/OPL2ToL1Ism.sol
+++ b/solidity/contracts/isms/hook/OPL2ToL1Ism.sol
@@ -42,7 +42,7 @@ contract OPL2ToL1Ism is
     // module type for the ISM
     uint8 public constant moduleType =
         uint8(IInterchainSecurityModule.Types.OP_L2_TO_L1);
-    // bottom offset to the message id in the metadata ()
+    // bottom offset to the start of message id in the metadata
     uint8 public constant MESSAGE_ID_OFFSET = 88;
     // OptimismPortal contract on L1 to finalize withdrawal from L1
     IOptimismPortal public immutable portal;

--- a/solidity/contracts/isms/hook/OPL2ToL1Ism.sol
+++ b/solidity/contracts/isms/hook/OPL2ToL1Ism.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+// ============ Internal Imports ============
+
+import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
+import {TypeCasts} from "../../libs/TypeCasts.sol";
+import {Message} from "../../libs/Message.sol";
+import {AbstractMessageIdAuthorizedIsm} from "./AbstractMessageIdAuthorizedIsm.sol";
+
+// ============ External Imports ============
+
+import {IOptimismPortal} from "../../interfaces/optimism/IOptimismPortal.sol";
+import {CrossChainEnabledOptimism} from "@openzeppelin/contracts/crosschain/optimism/CrossChainEnabledOptimism.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+/**
+ * @title OPL2ToL1Ism
+ * @notice Uses the native Optimism bridge to verify interchain messages from L2 to L1.
+ */
+contract OPL2ToL1Ism is
+    CrossChainEnabledOptimism,
+    AbstractMessageIdAuthorizedIsm
+{
+    using Message for bytes;
+    // ============ Constants ============
+
+    // module type for the ISM
+    uint8 public constant moduleType =
+        uint8(IInterchainSecurityModule.Types.OP_L2_TO_L1);
+    // OptimismPortal contract on L1 to finalize withdrawal from L1
+    IOptimismPortal public portal;
+
+    // ============ Constructor ============
+
+    constructor(address _portal) CrossChainEnabledOptimism(_portal) {
+        require(
+            Address.isContract(_portal),
+            "OPL2ToL1Ism: invalid OptimismPortal contract"
+        );
+        portal = IOptimismPortal(_portal);
+    }
+
+    // ============ External Functions ============
+
+    /// @inheritdoc IInterchainSecurityModule
+    function verify(
+        bytes calldata metadata,
+        bytes calldata message
+    ) external override returns (bool) {
+        bool verified = isVerified(message);
+        if (verified) {
+            releaseValueToRecipient(message);
+        }
+        return verified || _verifyWithPortalCall(metadata, message);
+    }
+
+    // ============ Internal function ============
+
+    /**
+     * @notice Verify message directly using the portal.finalizeWithdrawal function.
+     * @dev This is a fallback in case the message is not verified by the stateful verify function first.
+     */
+    function _verifyWithPortalCall(
+        bytes calldata metadata,
+        bytes calldata message
+    ) internal returns (bool) {
+        (
+            uint256 nonce,
+            address sender,
+            address target,
+            uint256 value,
+            uint256 gasLimit,
+            bytes memory data
+        ) = abi.decode(
+                metadata,
+                (uint256, address, address, uint256, uint256, bytes)
+            );
+
+        // this data is an abi encoded call of verifyMessageId(bytes32 messageId)
+        require(data.length == 36, "OPL2ToL1Ism: invalid data length");
+        bytes32 messageId = message.id();
+        bytes32 convertedBytes;
+        assembly {
+            // data = 0x[4 bytes function signature][32 bytes messageId]
+            convertedBytes := mload(add(data, 36))
+        }
+        // check if the parsed message id matches the message id of the message
+        require(convertedBytes == messageId, "OPL2ToL1Ism: invalid message id");
+
+        // Types.WithdrawalTransaction memory withdrawal =
+        IOptimismPortal.WithdrawalTransaction
+            memory withdrawal = IOptimismPortal.WithdrawalTransaction({
+                nonce: nonce,
+                sender: sender,
+                target: target,
+                value: value,
+                gasLimit: gasLimit,
+                data: data
+            });
+
+        portal.finalizeWithdrawalTransaction(withdrawal);
+
+        // check if the sender of the l2 message is the authorized hook
+        require(_isAuthorized(), "OPL2ToL1Ism: unauthorized sender");
+
+        return true;
+    }
+
+    /// @inheritdoc AbstractMessageIdAuthorizedIsm
+    function _isAuthorized() internal view override returns (bool) {
+        return
+            _crossChainSender() == TypeCasts.bytes32ToAddress(authorizedHook);
+    }
+}

--- a/solidity/contracts/isms/hook/OPL2ToL1Ism.sol
+++ b/solidity/contracts/isms/hook/OPL2ToL1Ism.sol
@@ -67,10 +67,11 @@ contract OPL2ToL1Ism is
         bytes calldata message
     ) external override returns (bool) {
         bool verified = isVerified(message);
-        if (verified) {
-            releaseValueToRecipient(message);
+        if (!verified) {
+            require(_verifyWithPortalCall(metadata, message));
         }
-        return verified || _verifyWithPortalCall(metadata, message);
+        releaseValueToRecipient(message);
+        return true;
     }
 
     // ============ Internal function ============

--- a/solidity/contracts/libs/OPL2ToL1Metadata.sol
+++ b/solidity/contracts/libs/OPL2ToL1Metadata.sol
@@ -8,6 +8,18 @@ pragma solidity >=0.8.0;
 library OPL2ToL1Metadata {
     // bottom offset to the start of message id in the metadata
     uint256 private constant MESSAGE_ID_OFFSET = 88;
+    // from IOptimismPortal.WithdrawalTransaction
+    // Σ {
+    //      nonce                          = 32 bytes
+    //      PADDING + sender               = 32 bytes
+    //      PADDING + target               = 32 bytes
+    //      value                          = 32 bytes
+    //      gasLimit                       = 32 bytes
+    //      _data
+    //          OFFSET                      = 32 bytes
+    //          LENGTH                      = 32 bytes
+    // } = 252 bytes
+    uint256 private constant FIXED_METADATA_LENGTH = 252;
     // metadata here is double encoded call relayMessage(..., verifyMessageId)
     // Σ {
     //      _selector                       =  4 bytes
@@ -43,11 +55,8 @@ library OPL2ToL1Metadata {
     function checkCalldataLength(
         bytes calldata _metadata
     ) internal pure returns (bool) {
-        (, , , , , bytes memory messengerData) = abi.decode(
-            _metadata,
-            (uint256, address, address, uint256, uint256, bytes)
-        );
-
-        return messengerData.length == MESSENGER_CALLDATA_LENGTH;
+        return
+            _metadata.length ==
+            MESSENGER_CALLDATA_LENGTH + FIXED_METADATA_LENGTH;
     }
 }

--- a/solidity/contracts/libs/OPL2ToL1Metadata.sol
+++ b/solidity/contracts/libs/OPL2ToL1Metadata.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/**
+ * @title Hyperlane OPL2ToL1Metadata Library
+ * @notice Library for formatted metadata used by OPL2ToL1Ism
+ */
+library OPL2ToL1Metadata {
+    // bottom offset to the start of message id in the metadata
+    uint256 private constant MESSAGE_ID_OFFSET = 88;
+    // metadata here is double encoded call relayMessage(..., verifyMessageId)
+    // Σ {
+    //      _selector                       =  4 bytes
+    //      _nonce                          = 32 bytes
+    //      PADDING + _sender               = 32 bytes
+    //      PADDING + _target               = 32 bytes
+    //      _value                          = 32 bytes
+    //      _minGasLimit                    = 32 bytes
+    //      _data
+    //          OFFSET                      = 32 bytes
+    //          LENGTH                      = 32 bytes
+    //          PADDING + verifyMessageId   = 64 bytes
+    // } = 292 bytes
+    uint256 private constant MESSENGER_CALLDATA_LENGTH = 292;
+
+    /**
+     * @notice Returns the message ID.
+     * @param _metadata OptimismPortal.WithdrawalTransaction encoded calldata
+     * @return ID of `_metadata`
+     */
+    function messageId(
+        bytes calldata _metadata
+    ) internal pure returns (bytes32) {
+        uint256 metadataLength = _metadata.length;
+        return
+            bytes32(
+                _metadata[metadataLength - MESSAGE_ID_OFFSET:metadataLength -
+                    MESSAGE_ID_OFFSET +
+                    32]
+            );
+    }
+
+    function checkCalldataLength(
+        bytes calldata _metadata
+    ) internal pure returns (bool) {
+        (, , , , , bytes memory messengerData) = abi.decode(
+            _metadata,
+            (uint256, address, address, uint256, uint256, bytes)
+        );
+
+        return messengerData.length == MESSENGER_CALLDATA_LENGTH;
+    }
+}

--- a/solidity/contracts/mock/MockOptimism.sol
+++ b/solidity/contracts/mock/MockOptimism.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/console.sol";
+
+import {ICrossDomainMessenger} from "../interfaces/optimism/ICrossDomainMessenger.sol";
+import {IOptimismPortal} from "../interfaces/optimism/IOptimismPortal.sol";
+
+// for both L1 and L2
+contract MockOptimismMessenger is ICrossDomainMessenger {
+    address public xDomainMessageSender;
+    address public PORTAL;
+
+    function sendMessage(
+        address _target,
+        bytes calldata _message,
+        uint32 _gasLimit
+    ) external payable {}
+
+    function relayMessage(
+        uint256 _nonce,
+        address _sender,
+        address _target,
+        uint256 _value,
+        uint256 _minGasLimit,
+        bytes calldata _message
+    ) external payable {}
+
+    function OTHER_MESSENGER() external view returns (address) {}
+
+    function setXDomainMessageSender(address _sender) external {
+        xDomainMessageSender = _sender;
+    }
+
+    function setPORTAL(address _portal) external {
+        PORTAL = _portal;
+    }
+}
+
+contract MockOptimismPortal is IOptimismPortal {
+    function finalizeWithdrawalTransaction(
+        WithdrawalTransaction memory _tx
+    ) external {
+        (bool success, bytes memory returndata) = _tx.target.call{
+            value: _tx.value
+        }(_tx.data);
+        console.log("success: %s", success);
+        if (!success) {
+            revert WithdrawalTransactionFailed();
+        }
+    }
+}

--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -121,10 +121,10 @@ contract ArbL2ToL1IsmTest is Test {
     function test_postDispatch_revertWhen_notLastDispatchedMessage() public {
         deployAll();
 
-        vm.expectRevert(
-            "AbstractMessageIdAuthHook: message not latest dispatched"
-        );
-        hook.postDispatch(testMetadata, encodedMessage);
+        // vm.expectRevert(
+        //     "AbstractMessageIdAuthHook: message not latest dispatched"
+        // );
+        // hook.postDispatch(testMetadata, encodedMessage);
     }
 
     function test_verify_outboxCall() public {
@@ -274,6 +274,8 @@ contract ArbL2ToL1IsmTest is Test {
         vm.expectRevert();
         assertFalse(ism.verify(new bytes(0), encodedMessage));
     }
+
+    // function test_verify_withMsgValue
 
     /* ============ helper functions ============ */
 

--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -121,10 +121,10 @@ contract ArbL2ToL1IsmTest is Test {
     function test_postDispatch_revertWhen_notLastDispatchedMessage() public {
         deployAll();
 
-        // vm.expectRevert(
-        //     "AbstractMessageIdAuthHook: message not latest dispatched"
-        // );
-        // hook.postDispatch(testMetadata, encodedMessage);
+        vm.expectRevert(
+            "AbstractMessageIdAuthHook: message not latest dispatched"
+        );
+        hook.postDispatch(testMetadata, encodedMessage);
     }
 
     function test_verify_outboxCall() public {
@@ -274,8 +274,6 @@ contract ArbL2ToL1IsmTest is Test {
         vm.expectRevert();
         assertFalse(ism.verify(new bytes(0), encodedMessage));
     }
-
-    // function test_verify_withMsgValue
 
     /* ============ helper functions ============ */
 

--- a/solidity/test/isms/OPL2ToL1Ism.t.sol
+++ b/solidity/test/isms/OPL2ToL1Ism.t.sol
@@ -103,9 +103,7 @@ contract OPL2ToL1IsmTest is Test {
             )
         );
 
-        testMetadata = StandardHookMetadata.overrideMsgValue(GAS_QUOTE);
-
-        hook.postDispatch(testMetadata, encodedMessage);
+        hook.postDispatch{value: GAS_QUOTE}(testMetadata, encodedMessage);
     }
 
     function testFork_postDispatch_revertWhen_chainIDNotSupported() public {

--- a/solidity/test/isms/OPL2ToL1Ism.t.sol
+++ b/solidity/test/isms/OPL2ToL1Ism.t.sol
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: MIT or Apache-2.0
+pragma solidity ^0.8.13;
+
+import "forge-std/console.sol";
+
+import {Test} from "forge-std/Test.sol";
+
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+import {Message} from "../../contracts/libs/Message.sol";
+import {MessageUtils} from "./IsmTestUtils.sol";
+import {StandardHookMetadata} from "../../contracts/hooks/libs/StandardHookMetadata.sol";
+import {IOptimismPortal} from "../../contracts/interfaces/optimism/IOptimismPortal.sol";
+import {ICrossDomainMessenger} from "../../contracts/interfaces/optimism/ICrossDomainMessenger.sol";
+import {AbstractMessageIdAuthorizedIsm} from "../../contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol";
+import {TestMailbox} from "../../contracts/test/TestMailbox.sol";
+import {TestRecipient} from "../../contracts/test/TestRecipient.sol";
+import {MockOptimismMessenger, MockOptimismPortal} from "../../contracts/mock/MockOptimism.sol";
+import {OPL2ToL1Hook} from "../../contracts/hooks/OPL2ToL1Hook.sol";
+import {OPL2ToL1Ism} from "../../contracts/isms/hook/OPL2ToL1Ism.sol";
+
+contract OPL2ToL1IsmTest is Test {
+    uint8 internal constant HYPERLANE_VERSION = 1;
+    uint32 internal constant MAINNET_DOMAIN = 1;
+    uint32 internal constant OPTIMISM_DOMAIN = 10;
+    uint32 internal constant GAS_QUOTE = 120_000;
+
+    address internal constant L2_MESSENGER_ADDRESS =
+        0x4200000000000000000000000000000000000007;
+
+    uint256 internal constant MOCK_NONCE = 0;
+
+    TestMailbox public l2Mailbox;
+    TestRecipient internal testRecipient;
+    bytes internal testMessage =
+        abi.encodePacked("Hello from the other chain!");
+    bytes internal encodedMessage;
+    bytes internal testMetadata =
+        StandardHookMetadata.overrideRefundAddress(address(this));
+    bytes32 internal messageId;
+
+    MockOptimismPortal internal portal;
+    MockOptimismMessenger internal l1Messenger;
+    OPL2ToL1Hook public hook;
+    OPL2ToL1Ism public ism;
+
+    ///////////////////////////////////////////////////////////////////
+    ///                            SETUP                            ///
+    ///////////////////////////////////////////////////////////////////
+
+    function setUp() public {
+        // Optimism messenger mock setup
+        vm.etch(
+            L2_MESSENGER_ADDRESS,
+            address(new MockOptimismMessenger()).code
+        );
+
+        testRecipient = new TestRecipient();
+
+        encodedMessage = _encodeTestMessage();
+        messageId = Message.id(encodedMessage);
+    }
+
+    function deployHook() public {
+        l2Mailbox = new TestMailbox(OPTIMISM_DOMAIN);
+        hook = new OPL2ToL1Hook(
+            address(l2Mailbox),
+            MAINNET_DOMAIN,
+            TypeCasts.addressToBytes32(address(ism)),
+            L2_MESSENGER_ADDRESS,
+            GAS_QUOTE
+        );
+    }
+
+    function deployIsm() public {
+        l1Messenger = new MockOptimismMessenger();
+        portal = new MockOptimismPortal();
+        l1Messenger.setPORTAL(address(portal));
+
+        ism = new OPL2ToL1Ism(address(l1Messenger));
+    }
+
+    function deployAll() public {
+        deployIsm();
+        deployHook();
+
+        l1Messenger.setXDomainMessageSender(address(hook));
+        ism.setAuthorizedHook(TypeCasts.addressToBytes32(address(hook)));
+    }
+
+    function test_postDispatch() public {
+        deployAll();
+
+        bytes memory encodedHookData = abi.encodeCall(
+            AbstractMessageIdAuthorizedIsm.verifyMessageId,
+            (messageId)
+        );
+
+        l2Mailbox.updateLatestDispatchedId(messageId);
+
+        vm.expectCall(
+            L2_MESSENGER_ADDRESS,
+            abi.encodeCall(
+                ICrossDomainMessenger.sendMessage,
+                (address(ism), encodedHookData, GAS_QUOTE)
+            )
+        );
+        hook.postDispatch(testMetadata, encodedMessage);
+    }
+
+    function testFork_postDispatch_revertWhen_chainIDNotSupported() public {
+        deployAll();
+
+        bytes memory message = MessageUtils.formatMessage(
+            0,
+            uint32(0),
+            OPTIMISM_DOMAIN,
+            TypeCasts.addressToBytes32(address(this)),
+            2, // wrong domain
+            TypeCasts.addressToBytes32(address(testRecipient)),
+            testMessage
+        );
+
+        l2Mailbox.updateLatestDispatchedId(Message.id(message));
+        vm.expectRevert(
+            "AbstractMessageIdAuthHook: invalid destination domain"
+        );
+        hook.postDispatch(testMetadata, message);
+    }
+
+    function test_postDispatch_revertWhen_notLastDispatchedMessage() public {
+        deployAll();
+
+        vm.expectRevert(
+            "AbstractMessageIdAuthHook: message not latest dispatched"
+        );
+        hook.postDispatch(testMetadata, encodedMessage);
+    }
+
+    function test_verify_directWithdrawalCall() public {
+        deployAll();
+
+        bytes memory encodedOutboxTxMetadata = _encodeFinalizeWithdrawalTx(
+            address(ism),
+            0,
+            messageId
+        );
+
+        // arbBridge.setL2ToL1Sender(address(hook));
+        console.log("prank messenger: ", address(l1Messenger));
+        vm.startPrank(address(l1Messenger));
+        assertTrue(ism.verify(encodedOutboxTxMetadata, encodedMessage));
+    }
+
+    function test_verify_statefulVerify() public {
+        deployAll();
+
+        bytes memory encodedHookData = abi.encodeCall(
+            AbstractMessageIdAuthorizedIsm.verifyMessageId,
+            (messageId)
+        );
+
+        vm.deal(address(portal), 1 ether);
+        IOptimismPortal.WithdrawalTransaction
+            memory withdrawal = IOptimismPortal.WithdrawalTransaction({
+                nonce: MOCK_NONCE,
+                sender: L2_MESSENGER_ADDRESS,
+                target: address(ism),
+                value: 1 ether,
+                gasLimit: uint256(GAS_QUOTE),
+                data: encodedHookData
+            });
+        portal.finalizeWithdrawalTransaction(withdrawal);
+
+        vm.etch(address(portal), new bytes(0)); // this is a way to test that the portal isn't called again
+        assertTrue(ism.verify(new bytes(0), encodedMessage));
+        assertEq(address(testRecipient).balance, 1 ether);
+    }
+
+    function test_verify_statefulAndDirectWithdrawal() public {
+        deployAll();
+
+        bytes memory encodedHookData = abi.encodeCall(
+            AbstractMessageIdAuthorizedIsm.verifyMessageId,
+            (messageId)
+        );
+
+        vm.deal(address(portal), 1 ether);
+        IOptimismPortal.WithdrawalTransaction
+            memory withdrawal = IOptimismPortal.WithdrawalTransaction({
+                nonce: MOCK_NONCE,
+                sender: L2_MESSENGER_ADDRESS,
+                target: address(ism),
+                value: 1 ether,
+                gasLimit: uint256(GAS_QUOTE),
+                data: encodedHookData
+            });
+        portal.finalizeWithdrawalTransaction(withdrawal);
+
+        bytes memory encodedOutboxTxMetadata = _encodeFinalizeWithdrawalTx(
+            address(ism),
+            0,
+            messageId
+        );
+
+        vm.etch(address(portal), new bytes(0)); // this is a way to test that the arbBridge isn't called again
+        assertTrue(ism.verify(encodedOutboxTxMetadata, encodedMessage));
+        assertEq(address(testRecipient).balance, 1 ether);
+    }
+
+    function test_verify_revertsWhen_noStatefulAndDirectWithdrawal() public {
+        deployAll();
+
+        vm.expectRevert();
+        ism.verify(new bytes(0), encodedMessage);
+    }
+
+    function test_verify_revertsWhen_invalidIsm() public {
+        deployAll();
+
+        bytes memory encodedOutboxTxMetadata = _encodeFinalizeWithdrawalTx(
+            address(this),
+            0,
+            messageId
+        );
+
+        vm.expectRevert(); // WithdrawalTransactionFailed()
+        ism.verify(encodedOutboxTxMetadata, encodedMessage);
+    }
+
+    // function test_verify_revertsWhen_incorrectMessageId() public {
+    //     deployAll();
+
+    //     bytes32 incorrectMessageId = keccak256("incorrect message id");
+
+    //     bytes memory encodedOutboxTxMetadata = _encodeFinalizeWithdrawalTx(address(this), 0, messageId);
+
+    //     bytes memory encodedHookData =
+    //         abi.encodeCall(AbstractMessageIdAuthorizedIsm.verifyMessageId, (incorrectMessageId));
+
+    //     // through outbox call
+    //     vm.expectRevert("OPL2ToL1Ism: invalid message id");
+    //     ism.verify(encodedOutboxTxMetadata, encodedMessage);
+
+    //     // through statefulVerify
+    //     IOptimismPortal.WithdrawalTransaction memory withdrawal = IOptimismPortal.WithdrawalTransaction({
+    //         nonce: MOCK_NONCE,
+    //         sender: L2_MESSENGER_ADDRESS,
+    //         target: address(ism),
+    //         value: 0,
+    //         gasLimit: uint256(GAS_QUOTE),
+    //         data: encodedHookData
+    //     });
+    //     portal.finalizeWithdrawalTransaction(withdrawal);
+
+    //     vm.etch(address(portal), new bytes(0)); // to stop the outbox route
+    //     vm.expectRevert();
+    //     assertFalse(ism.verify(new bytes(0), encodedMessage));
+    // }
+
+    /* ============ helper functions ============ */
+
+    function _encodeFinalizeWithdrawalTx(
+        address _ism,
+        uint256 _value,
+        bytes32 _messageId
+    ) internal view returns (bytes memory) {
+        bytes memory encodedHookData = abi.encodeCall(
+            AbstractMessageIdAuthorizedIsm.verifyMessageId,
+            (_messageId)
+        );
+
+        return
+            abi.encode(
+                MOCK_NONCE,
+                L2_MESSENGER_ADDRESS,
+                _ism,
+                _value,
+                uint256(GAS_QUOTE),
+                encodedHookData
+            );
+    }
+
+    function _encodeTestMessage() internal view returns (bytes memory) {
+        return
+            MessageUtils.formatMessage(
+                HYPERLANE_VERSION,
+                uint32(0),
+                OPTIMISM_DOMAIN,
+                TypeCasts.addressToBytes32(address(this)),
+                MAINNET_DOMAIN,
+                TypeCasts.addressToBytes32(address(testRecipient)),
+                testMessage
+            );
+    }
+}

--- a/solidity/test/isms/OPL2ToL1Ism.t.sol
+++ b/solidity/test/isms/OPL2ToL1Ism.t.sol
@@ -102,6 +102,9 @@ contract OPL2ToL1IsmTest is Test {
                 (address(ism), encodedHookData, GAS_QUOTE)
             )
         );
+
+        testMetadata = StandardHookMetadata.overrideMsgValue(GAS_QUOTE);
+
         hook.postDispatch(testMetadata, encodedMessage);
     }
 

--- a/solidity/test/isms/OPL2ToL1Ism.t.sol
+++ b/solidity/test/isms/OPL2ToL1Ism.t.sol
@@ -158,7 +158,7 @@ contract OPL2ToL1IsmTest is Test {
             messageId
         );
 
-        vm.expectRevert(); // MockOptimismPortal.WithdrawalTransactionFailed()
+        vm.expectRevert(); // evmRevert in MockOptimismPortal
         ism.verify(encodedWithdrawalTx, encodedMessage);
     }
 
@@ -179,7 +179,7 @@ contract OPL2ToL1IsmTest is Test {
 
         vm.etch(address(portal), new bytes(0)); // this is a way to test that the portal isn't called again
         assertTrue(ism.verify(new bytes(0), encodedMessage));
-        assertEq(address(testRecipient).balance, 1 ether);
+        assertEq(address(testRecipient).balance, 1 ether); // testing msg.value
     }
 
     function test_verify_statefulAndDirectWithdrawal() public {
@@ -222,7 +222,7 @@ contract OPL2ToL1IsmTest is Test {
             messageId
         );
 
-        vm.expectRevert(); // WithdrawalTransactionFailed()
+        vm.expectRevert(); // evmRevert in MockOptimismPortal
         ism.verify(encodedWithdrawalTx, encodedMessage);
     }
 
@@ -264,6 +264,19 @@ contract OPL2ToL1IsmTest is Test {
 
     /* ============ helper functions ============ */
 
+    function _encodeTestMessage() internal view returns (bytes memory) {
+        return
+            MessageUtils.formatMessage(
+                HYPERLANE_VERSION,
+                uint32(0),
+                OPTIMISM_DOMAIN,
+                TypeCasts.addressToBytes32(address(this)),
+                MAINNET_DOMAIN,
+                TypeCasts.addressToBytes32(address(testRecipient)),
+                testMessage
+            );
+    }
+
     function _encodeMessengerCalldata(
         address _ism,
         uint256 _value,
@@ -301,19 +314,6 @@ contract OPL2ToL1IsmTest is Test {
                 _value,
                 uint256(GAS_QUOTE),
                 _encodeMessengerCalldata(_ism, _value, _messageId)
-            );
-    }
-
-    function _encodeTestMessage() internal view returns (bytes memory) {
-        return
-            MessageUtils.formatMessage(
-                HYPERLANE_VERSION,
-                uint32(0),
-                OPTIMISM_DOMAIN,
-                TypeCasts.addressToBytes32(address(this)),
-                MAINNET_DOMAIN,
-                TypeCasts.addressToBytes32(address(testRecipient)),
-                testMessage
             );
     }
 }


### PR DESCRIPTION
### Description

Implementing the `OPL2ToL1Hook` and OPL2ToL1Ism` contracts for using the Optimism native bridge for sending messages from the L2 to L1.
- Optimism needs double call encoding for the direct portal call because the portal itself calls the l1Messenger which then directs it to the ism.

### Drive-by changes

None

### Related issues

- fixes https://github.com/hyperlane-xyz/issues/issues/1346

### Backward compatibility

Yes

### Testing

Unit testing with mocks for OP contracts
