### PR TITLE
feat: panics upon startup when RPC issues occur include the offending chain

### DIFF
--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -347,7 +347,9 @@ impl BaseAgent for Relayer {
                 Self::AGENT_NAME.to_string(),
             )
             .await
-            .unwrap();
+            .expect(&format!(
+                "Error created metrics updater for destination {dest_domain}"
+            ));
             tasks.push(metrics_updater.spawn());
         }
 
@@ -417,7 +419,10 @@ impl Relayer {
     ) -> Instrumented<JoinHandle<()>> {
         let index_settings = self.as_ref().settings.chains[origin.name()].index_settings();
         let contract_sync = self.message_syncs.get(origin).unwrap().clone();
-        let cursor = contract_sync.cursor(index_settings).await;
+        let cursor = contract_sync
+            .cursor(index_settings)
+            .await
+            .expect(&format!("Error getting cursor for origin {origin}"));
         tokio::spawn(TaskMonitor::instrument(&task_monitor, async move {
             contract_sync
                 .clone()
@@ -439,7 +444,10 @@ impl Relayer {
             .get(origin)
             .unwrap()
             .clone();
-        let cursor = contract_sync.cursor(index_settings).await;
+        let cursor = contract_sync
+            .cursor(index_settings)
+            .await
+            .expect(&format!("Error getting cursor for origin {origin}"));
         tokio::spawn(TaskMonitor::instrument(&task_monitor, async move {
             contract_sync
                 .clone()
@@ -460,7 +468,10 @@ impl Relayer {
     ) -> Instrumented<JoinHandle<()>> {
         let index_settings = self.as_ref().settings.chains[origin.name()].index.clone();
         let contract_sync = self.merkle_tree_hook_syncs.get(origin).unwrap().clone();
-        let cursor = contract_sync.cursor(index_settings).await;
+        let cursor = contract_sync
+            .cursor(index_settings)
+            .await
+            .expect(&format!("Error getting cursor for origin {origin}"));
         tokio::spawn(TaskMonitor::instrument(&task_monitor, async move {
             contract_sync
                 .clone()

--- a/rust/agents/scraper/src/agent.rs
+++ b/rust/agents/scraper/src/agent.rs
@@ -200,7 +200,10 @@ impl Scraper {
             )
             .await
             .unwrap();
-        let cursor = sync.cursor(index_settings.clone()).await;
+        let cursor = sync
+            .cursor(index_settings.clone())
+            .await
+            .expect(&format!("Error getting cursor for domain {domain}"));
         let maybe_broadcaser = sync.get_broadcaster();
         let task = tokio::spawn(async move { sync.sync("message_dispatch", cursor.into()).await })
             .instrument(
@@ -230,7 +233,10 @@ impl Scraper {
             .unwrap();
 
         let label = "message_delivery";
-        let cursor = sync.cursor(index_settings.clone()).await;
+        let cursor = sync
+            .cursor(index_settings.clone())
+            .await
+            .expect(&format!("Error getting cursor for domain {domain}"));
         // there is no txid receiver for delivery indexing, since delivery txs aren't batched with
         // other types of indexed txs / events
         tokio::spawn(async move { sync.sync(label, SyncOptions::new(Some(cursor), None)).await })
@@ -259,7 +265,10 @@ impl Scraper {
             .unwrap();
 
         let label = "gas_payment";
-        let cursor = sync.cursor(index_settings.clone()).await;
+        let cursor = sync
+            .cursor(index_settings.clone())
+            .await
+            .expect(&format!("Error getting cursor for domain {domain}"));
         tokio::spawn(async move {
             sync.sync(label, SyncOptions::new(Some(cursor), tx_id_receiver))
                 .await

--- a/rust/agents/validator/src/validator.rs
+++ b/rust/agents/validator/src/validator.rs
@@ -216,7 +216,10 @@ impl Validator {
         let index_settings =
             self.as_ref().settings.chains[self.origin_chain.name()].index_settings();
         let contract_sync = self.merkle_tree_hook_sync.clone();
-        let cursor = contract_sync.cursor(index_settings).await;
+        let cursor = contract_sync
+            .cursor(index_settings)
+            .await
+            .expect(&format!("Error getting cursor"));
         tokio::spawn(async move {
             contract_sync
                 .clone()


### PR DESCRIPTION
### Description

Some quick low hanging fruit to make debugging easier in the future. Today (https://discord.com/channels/935678348330434570/1273582453889699843) some chains were having RPC issues and it caused an agent deploy to panic upon startup. Debugging this was hard because the panic message just indicates an error is occurring, but doesn't say what the offending chain is!

Examples:
- https://cloudlogging.app.goo.gl/puQk7hm4fXyJhYKs8
- https://cloudlogging.app.goo.gl/5qZrbc2Ww4LWQXWC6
- https://cloudlogging.app.goo.gl/ZL7mKbBzzJaePtty9

All these panic happen when constructing the cursor, which isn't yet done in an indexing task. The quick and easy fix is to just use expect instead of unwrapIn 

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
