### PR TITLE
chore: drop some labels in remote writes to lower cardinality

### DIFF
--- a/typescript/infra/src/infrastructure/monitoring/prometheus.ts
+++ b/typescript/infra/src/infrastructure/monitoring/prometheus.ts
@@ -81,6 +81,10 @@ async function getPrometheusConfig(
                 '(container.*|optics.*|Optics.*|prometheus.*|ethereum.*|hyperlane.*|kube_pod_status_phase|kube_pod_container_status_restarts_total|kube_pod_container_resource_requests)',
               source_labels: ['__name__'],
             },
+            {
+              action: 'labeldrop',
+              regex: 'id|controller_revision_hash|name|uid|instance|node',
+            },
           ],
         },
       ],


### PR DESCRIPTION

- Labels chosen by looking at https://abacusworks.grafana.net/d/cardinality-management/cardinality-management-1-overview?var-datasource=grafanacloud-prom&from=2024-08-15T11:34:34.928Z&to=2024-08-16T11:34:34.929Z
- Motivating case: a GKE rolling upgrade recently resulting in some issues with the remote write where it complained about too many series https://abacusworks.grafana.net/d/cdn9jukg55bswb/usage-insights-5-metrics-ingestion?var-instance=$__all&viewPanel=panel-9&from=2024-08-16T10:04:52.962Z&to=2024-08-16T11:04:52.962Z (thread https://discord.com/channels/935678348330434570/1273952173037715458)
- Many of these labels would change whenever a pod would be restarted, a new deploy occurred, new nodes set up, etc
- Deployed to testnet4 and mainnet3 and observed the labels were dropped

### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
