### PR TITLE
fix(sdk): Remove console.assert

### DIFF
--- a/typescript/sdk/src/ism/metadata/arbL2ToL1.ts
+++ b/typescript/sdk/src/ism/metadata/arbL2ToL1.ts
@@ -6,7 +6,6 @@ import {
   EventArgs,
 } from '@arbitrum/sdk';
 import { L2ToL1TxEvent } from '@arbitrum/sdk/dist/lib/abi/ArbSys.js';
-import { assert } from 'console';
 import { BigNumber, BytesLike, providers, utils } from 'ethers';
 
 import {
@@ -14,7 +13,7 @@ import {
   ArbSys__factory,
   IOutbox__factory,
 } from '@hyperlane-xyz/core';
-import { WithAddress, rootLogger } from '@hyperlane-xyz/utils';
+import { WithAddress, assert, rootLogger } from '@hyperlane-xyz/utils';
 
 import { HyperlaneCore } from '../../core/HyperlaneCore.js';
 import { ArbL2ToL1HookConfig } from '../../hook/types.js';


### PR DESCRIPTION
### Description
warp template UI throws
![image](https://github.com/user-attachments/assets/af854dee-ee0c-480c-b688-66f35642ba69)

### Backward compatibility

Yes

### Testing
Manual
