### PR TITLE
fix: `ArbL2ToL1Ism` will support msg.value

### DIFF
--- a/.changeset/stale-planets-dance.md
+++ b/.changeset/stale-planets-dance.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/sdk': minor
+'@hyperlane-xyz/core': minor
+---
+
+ArbL2ToL1Ism handles value via the executeTransaction branch

--- a/solidity/contracts/isms/hook/ArbL2ToL1Ism.sol
+++ b/solidity/contracts/isms/hook/ArbL2ToL1Ism.sol
@@ -61,8 +61,7 @@ contract ArbL2ToL1Ism is
         bytes calldata metadata,
         bytes calldata message
     ) external override returns (bool) {
-        bool verified = isVerified(message);
-        if (!verified) {
+        if (!isVerified(message)) {
             _verifyWithOutboxCall(metadata, message);
         }
         releaseValueToRecipient(message);
@@ -105,6 +104,11 @@ contract ArbL2ToL1Ism is
                 )
             );
 
+        // check if the sender of the l2 message is the authorized hook
+        require(
+            l2Sender == TypeCasts.bytes32ToAddress(authorizedHook),
+            "ArbL2ToL1Ism: l2Sender != authorizedHook"
+        );
         // this data is an abi encoded call of verifyMessageId(bytes32 messageId)
         require(data.length == 36, "ArbL2ToL1Ism: invalid data length");
         bytes32 messageId = message.id();

--- a/solidity/contracts/isms/hook/ArbL2ToL1Ism.sol
+++ b/solidity/contracts/isms/hook/ArbL2ToL1Ism.sol
@@ -63,7 +63,7 @@ contract ArbL2ToL1Ism is
     ) external override returns (bool) {
         bool verified = isVerified(message);
         if (!verified) {
-            require(_verifyWithOutboxCall(metadata, message));
+            _verifyWithOutboxCall(metadata, message);
         }
         releaseValueToRecipient(message);
         return true;
@@ -79,7 +79,7 @@ contract ArbL2ToL1Ism is
     function _verifyWithOutboxCall(
         bytes calldata metadata,
         bytes calldata message
-    ) internal returns (bool) {
+    ) internal {
         (
             bytes32[] memory proof,
             uint256 index,
@@ -129,8 +129,6 @@ contract ArbL2ToL1Ism is
             value,
             data
         );
-        // the above bridge call will revert if the verifyMessageId call fails
-        return true;
     }
 
     /// @inheritdoc AbstractMessageIdAuthorizedIsm

--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -221,9 +221,7 @@ contract ArbL2ToL1IsmTest is Test {
 
         arbBridge.setL2ToL1Sender(address(this));
 
-        vm.expectRevert(
-            "AbstractMessageIdAuthorizedIsm: sender is not the hook"
-        );
+        vm.expectRevert("ArbL2ToL1Ism: l2Sender != authorizedHook");
         ism.verify(encodedOutboxTxMetadata, encodedMessage);
     }
 

--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -121,10 +121,10 @@ contract ArbL2ToL1IsmTest is Test {
     function test_postDispatch_revertWhen_notLastDispatchedMessage() public {
         deployAll();
 
-        // vm.expectRevert(
-        //     "AbstractMessageIdAuthHook: message not latest dispatched"
-        // );
-        // hook.postDispatch(testMetadata, encodedMessage);
+        vm.expectRevert(
+            "AbstractMessageIdAuthHook: message not latest dispatched"
+        );
+        hook.postDispatch(testMetadata, encodedMessage);
     }
 
     function test_verify_outboxCall() public {
@@ -133,11 +133,14 @@ contract ArbL2ToL1IsmTest is Test {
         bytes memory encodedOutboxTxMetadata = _encodeOutboxTx(
             address(hook),
             address(ism),
-            messageId
+            messageId,
+            1 ether
         );
 
+        vm.deal(address(arbBridge), 1 ether);
         arbBridge.setL2ToL1Sender(address(hook));
         assertTrue(ism.verify(encodedOutboxTxMetadata, encodedMessage));
+        assertEq(address(testRecipient).balance, 1 ether);
     }
 
     function test_verify_statefulVerify() public {
@@ -190,7 +193,8 @@ contract ArbL2ToL1IsmTest is Test {
         bytes memory encodedOutboxTxMetadata = _encodeOutboxTx(
             address(hook),
             address(ism),
-            messageId
+            messageId,
+            1 ether
         );
 
         vm.etch(address(arbBridge), new bytes(0)); // this is a way to test that the arbBridge isn't called again
@@ -211,12 +215,15 @@ contract ArbL2ToL1IsmTest is Test {
         bytes memory encodedOutboxTxMetadata = _encodeOutboxTx(
             address(this),
             address(ism),
-            messageId
+            messageId,
+            0
         );
 
-        arbBridge.setL2ToL1Sender(address(hook));
+        arbBridge.setL2ToL1Sender(address(this));
 
-        vm.expectRevert("ArbL2ToL1Ism: l2Sender != authorizedHook");
+        vm.expectRevert(
+            "AbstractMessageIdAuthorizedIsm: sender is not the hook"
+        );
         ism.verify(encodedOutboxTxMetadata, encodedMessage);
     }
 
@@ -226,7 +233,8 @@ contract ArbL2ToL1IsmTest is Test {
         bytes memory encodedOutboxTxMetadata = _encodeOutboxTx(
             address(hook),
             address(this),
-            messageId
+            messageId,
+            0
         );
 
         arbBridge.setL2ToL1Sender(address(hook));
@@ -243,7 +251,8 @@ contract ArbL2ToL1IsmTest is Test {
         bytes memory encodedOutboxTxMetadata = _encodeOutboxTx(
             address(hook),
             address(ism),
-            incorrectMessageId
+            incorrectMessageId,
+            0
         );
 
         bytes memory encodedHookData = abi.encodeCall(
@@ -275,14 +284,13 @@ contract ArbL2ToL1IsmTest is Test {
         assertFalse(ism.verify(new bytes(0), encodedMessage));
     }
 
-    // function test_verify_withMsgValue
-
     /* ============ helper functions ============ */
 
     function _encodeOutboxTx(
         address _hook,
         address _ism,
-        bytes32 _messageId
+        bytes32 _messageId,
+        uint256 _value
     ) internal view returns (bytes memory) {
         bytes memory encodedHookData = abi.encodeCall(
             AbstractMessageIdAuthorizedIsm.verifyMessageId,
@@ -299,6 +307,7 @@ contract ArbL2ToL1IsmTest is Test {
                 MOCK_L2_BLOCK,
                 MOCK_L1_BLOCK,
                 block.timestamp,
+                _value,
                 encodedHookData
             );
     }

--- a/typescript/sdk/src/ism/metadata/arbL2ToL1.ts
+++ b/typescript/sdk/src/ism/metadata/arbL2ToL1.ts
@@ -26,7 +26,7 @@ import { MetadataBuilder, MetadataContext } from './builder.js';
 export type NitroChildToParentTransactionEvent = EventArgs<L2ToL1TxEvent>;
 export type ArbL2ToL1Metadata = Omit<
   NitroChildToParentTransactionEvent,
-  'hash' | 'callvalue'
+  'hash'
 > & {
   proof: BytesLike[]; // bytes32[16]
 };
@@ -227,9 +227,9 @@ export class ArbL2ToL1MetadataBuilder implements MetadataBuilder {
       outboxInterface.functions[
         'executeTransaction(bytes32[],uint256,address,address,uint256,uint256,uint256,uint256,bytes)'
       ].inputs;
-    const executeTransactionTypes = executeTransactionInputs
-      .map((input) => input.type)
-      .filter((_, index, array) => index !== array.length - 2); // remove callvalue from types (because the ArbL2ToL1Ism doesn't allow it)
+    const executeTransactionTypes = executeTransactionInputs.map(
+      (input) => input.type,
+    );
     return abiCoder.encode(executeTransactionTypes, [
       metadata.proof,
       metadata.position,
@@ -238,6 +238,7 @@ export class ArbL2ToL1MetadataBuilder implements MetadataBuilder {
       metadata.arbBlockNum,
       metadata.ethBlockNum,
       metadata.timestamp,
+      metadata.callvalue,
       metadata.data,
     ]);
   }


### PR DESCRIPTION
### Description

- Added support for msg.value by rearranging the `releaseValueToRecipient()` in the verify call

### Drive-by changes

- uncommented out `test_postDispatch_revertWhen_notLastDispatchedMessage` test

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

Unit tests