### PR TITLE
chore: Enable no-restricted-imports eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,13 @@
     "no-ex-assign": ["error"],
     "no-constant-condition": ["off"],
     "no-return-await": ["error"],
+    "no-restricted-imports": ["error", {
+      "name": "console",
+      "message": "Please use a logger and/or the utils' package assert"
+    }, {
+        "name": "fs",
+        "message": "Avoid use of node-specific libraries"
+    }],
     "guard-for-in": ["error"],
     "@typescript-eslint/ban-ts-comment": ["off"],
     "@typescript-eslint/explicit-module-boundary-types": ["off"],

--- a/typescript/cli/.eslintrc
+++ b/typescript/cli/.eslintrc
@@ -1,5 +1,6 @@
 {
   "rules": {
-    "no-console": ["off"]
+    "no-console": ["off"],
+    "no-restricted-imports": ["off"]
   }
 }

--- a/typescript/sdk/src/ism/metadata/aggregation.test.ts
+++ b/typescript/sdk/src/ism/metadata/aggregation.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 import { expect } from 'chai';
 import { ethers } from 'ethers';
 import { existsSync, readFileSync, readdirSync } from 'fs';

--- a/typescript/sdk/src/ism/metadata/arbL2ToL1.ts
+++ b/typescript/sdk/src/ism/metadata/arbL2ToL1.ts
@@ -6,7 +6,6 @@ import {
   EventArgs,
 } from '@arbitrum/sdk';
 import { L2ToL1TxEvent } from '@arbitrum/sdk/dist/lib/abi/ArbSys.js';
-import { assert } from 'console';
 import { BigNumber, BytesLike, providers, utils } from 'ethers';
 
 import {
@@ -14,7 +13,7 @@ import {
   ArbSys__factory,
   IOutbox__factory,
 } from '@hyperlane-xyz/core';
-import { WithAddress, rootLogger } from '@hyperlane-xyz/utils';
+import { WithAddress, assert, rootLogger } from '@hyperlane-xyz/utils';
 
 import { HyperlaneCore } from '../../core/HyperlaneCore.js';
 import { ArbL2ToL1HookConfig } from '../../hook/types.js';

--- a/typescript/sdk/src/ism/metadata/multisig.test.ts
+++ b/typescript/sdk/src/ism/metadata/multisig.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 import { expect } from 'chai';
 import { existsSync, readFileSync, readdirSync } from 'fs';
 

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -27,8 +27,9 @@ import {
   SmartProviderOptions,
 } from './types.js';
 
-export const getSmartProviderErrorMessage = (errorMsg: string) =>
-  `${errorMsg}: RPC request failed. Check RPC validity. To override RPC URLs, see: https://docs.hyperlane.xyz/docs/deploy-hyperlane-troubleshooting#override-rpc-urls`;
+export function getSmartProviderErrorMessage(errorMsg: string): string {
+  return `${errorMsg}: RPC request failed. Check RPC validity. To override RPC URLs, see: https://docs.hyperlane.xyz/docs/deploy-hyperlane-troubleshooting#override-rpc-urls`;
+}
 
 // This is a partial list. If needed, check the full list for more: https://docs.ethers.org/v5/api/utils/logger/#errors
 const RPC_SERVER_ERRORS = [

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 import { expect } from 'chai';
 import fs from 'fs';
 import sinon from 'sinon';


### PR DESCRIPTION
### Description

Incorrect imports from node-specific global libs, especially for `assert` are very common. This won't catch all possible mistakes but it will help avoid future problems like https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4327 

### Backward compatibility

Yes
