### PR TITLE
chore: add back Osmosis relaying / validator

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -86,7 +86,6 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     moonbeam: true,
     neutron: true,
     optimism: true,
-    // Experiencing some issues with RPCs
     osmosis: true,
     polygon: true,
     polygonzkevm: true,
@@ -141,7 +140,6 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     // At the moment, we only relay between Neutron and Manta Pacific on the neutron context.
     neutron: false,
     optimism: true,
-    // Experiencing some issues with RPCs
     osmosis: true,
     polygon: true,
     polygonzkevm: true,

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -87,7 +87,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     neutron: true,
     optimism: true,
     // Experiencing some issues with RPCs
-    osmosis: false,
+    osmosis: true,
     polygon: true,
     polygonzkevm: true,
     proofofplay: true,
@@ -140,8 +140,8 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     moonbeam: true,
     // At the moment, we only relay between Neutron and Manta Pacific on the neutron context.
     neutron: false,
+    optimism: true,
     // Experiencing some issues with RPCs
-    optimism: false,
     osmosis: true,
     polygon: true,
     polygonzkevm: true,


### PR DESCRIPTION
### Description

- seems I accidentally disabled optimism relaying before, yikes
- adding back for Skip to play around with

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
