### PR TITLE
refactor: Rename InterchainAccountRouter tests for easier reuse

### DIFF
--- a/solidity/contracts/mock/MockHyperlaneEnvironment.sol
+++ b/solidity/contracts/mock/MockHyperlaneEnvironment.sol
@@ -8,8 +8,8 @@ import "../test/TestIsm.sol";
 import {TypeCasts} from "../libs/TypeCasts.sol";
 
 contract MockHyperlaneEnvironment {
-    uint32 originDomain;
-    uint32 destinationDomain;
+    uint32 public originDomain;
+    uint32 public destinationDomain;
 
     mapping(uint32 => MockMailbox) public mailboxes;
     mapping(uint32 => TestInterchainGasPaymaster) public igps;


### PR DESCRIPTION
### Description

Minor refactor of test 
