### PR TITLE
feat(sdk): Support proxyAdmin checks for admins not owned by AW

### DIFF
--- a/.changeset/grumpy-taxis-shout.md
+++ b/.changeset/grumpy-taxis-shout.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Support proxyAdmin checks for non AW owned warp router contracts

--- a/typescript/infra/scripts/check-deploy.ts
+++ b/typescript/infra/scripts/check-deploy.ts
@@ -167,7 +167,7 @@ async function check() {
           config[key].owner,
           envConfig.owners[key].owner,
         )
-          ? chainAddresses[key].proxyAdmin
+          ? chainAddresses[key]?.proxyAdmin
           : undefined;
 
         if (proxyAdmin) {

--- a/typescript/infra/scripts/check-deploy.ts
+++ b/typescript/infra/scripts/check-deploy.ts
@@ -15,7 +15,7 @@ import {
   hypERC20factories,
   proxiedFactories,
 } from '@hyperlane-xyz/sdk';
-import { objFilter } from '@hyperlane-xyz/utils';
+import { eqAddress, objFilter } from '@hyperlane-xyz/utils';
 
 import { Contexts } from '../config/contexts.js';
 import { DEPLOYER } from '../config/environments/mainnet3/owners.js';
@@ -161,8 +161,19 @@ async function check() {
       .reduce((obj, key) => {
         obj[key] = {
           ...warpAddresses[key],
-          proxyAdmin: chainAddresses[key].proxyAdmin,
         };
+
+        const proxyAdmin = eqAddress(
+          config[key].owner,
+          envConfig.owners[key].owner,
+        )
+          ? chainAddresses[key].proxyAdmin
+          : undefined;
+
+        if (proxyAdmin) {
+          obj[key].proxyAdmin = proxyAdmin;
+        }
+
         return obj;
       }, {} as typeof warpAddresses);
 

--- a/typescript/infra/scripts/check-deploy.ts
+++ b/typescript/infra/scripts/check-deploy.ts
@@ -163,6 +163,8 @@ async function check() {
           ...warpAddresses[key],
         };
 
+        // if the owner in the config is an AW account, set the proxyAdmin to the AW singleton proxyAdmin
+        // this will ensure that the checker will check that any proxies are owned by the singleton proxyAdmin
         const proxyAdmin = eqAddress(
           config[key].owner,
           envConfig.owners[key].owner,

--- a/typescript/infra/src/govern/HyperlaneAppGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneAppGovernor.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from 'ethers';
 import prompts from 'prompts';
 
+import { ProxyAdmin__factory } from '@hyperlane-xyz/core';
 import { Ownable__factory } from '@hyperlane-xyz/core';
 import {
   ChainMap,
@@ -435,9 +436,13 @@ export abstract class HyperlaneAppGovernor<
   }
 
   async handleProxyAdminViolation(violation: ProxyAdminViolation) {
-    const code = await this.checker.multiProvider
-      .getProvider(violation.chain)
-      .getCode(violation.expectedProxyAdmin.address);
+    const provider = this.checker.multiProvider.getProvider(violation.chain);
+    const code = await provider.getCode(violation.expected);
+
+    const expectedProxyAdmin = ProxyAdmin__factory.connect(
+      violation.expected,
+      provider,
+    );
 
     let call;
     if (code !== '0x') {
@@ -446,17 +451,17 @@ export abstract class HyperlaneAppGovernor<
         chain: violation.chain,
         call: {
           to: violation.actual,
-          data: violation.expectedProxyAdmin.interface.encodeFunctionData(
+          data: expectedProxyAdmin.interface.encodeFunctionData(
             'changeProxyAdmin',
-            [violation.proxy.address, violation.expected],
+            [violation.proxyAddress, violation.expected],
           ),
           value: BigNumber.from(0),
-          description: `Change proxyAdmin of transparent proxy ${violation.proxy.address} from ${violation.actual} to ${violation.expected}`,
+          description: `Change proxyAdmin of transparent proxy ${violation.proxyAddress} from ${violation.actual} to ${violation.expected}`,
         },
       };
     } else {
       throw new Error(
-        `Admin for proxy ${violation.proxy.address} is not a ProxyAdmin contract`,
+        `Admin for proxy ${violation.proxyAddress} is not a ProxyAdmin contract`,
       );
     }
 

--- a/typescript/infra/src/govern/HyperlaneAppGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneAppGovernor.ts
@@ -438,11 +438,7 @@ export abstract class HyperlaneAppGovernor<
   async handleProxyAdminViolation(violation: ProxyAdminViolation) {
     const provider = this.checker.multiProvider.getProvider(violation.chain);
     const code = await provider.getCode(violation.expected);
-
-    const expectedProxyAdmin = ProxyAdmin__factory.connect(
-      violation.expected,
-      provider,
-    );
+    const proxyAdminInterface = ProxyAdmin__factory.createInterface();
 
     let call;
     if (code !== '0x') {
@@ -451,10 +447,10 @@ export abstract class HyperlaneAppGovernor<
         chain: violation.chain,
         call: {
           to: violation.actual,
-          data: expectedProxyAdmin.interface.encodeFunctionData(
-            'changeProxyAdmin',
-            [violation.proxyAddress, violation.expected],
-          ),
+          data: proxyAdminInterface.encodeFunctionData('changeProxyAdmin', [
+            violation.proxyAddress,
+            violation.expected,
+          ]),
           value: BigNumber.from(0),
           description: `Change proxyAdmin of transparent proxy ${violation.proxyAddress} from ${violation.actual} to ${violation.expected}`,
         },

--- a/typescript/sdk/src/core/HyperlaneCoreChecker.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreChecker.ts
@@ -41,7 +41,11 @@ export class HyperlaneCoreChecker extends HyperlaneAppChecker<
       return;
     }
 
-    await this.checkProxiedContracts(chain);
+    await this.checkProxiedContracts(
+      chain,
+      config.owner,
+      config.ownerOverrides,
+    );
     await this.checkMailbox(chain);
     await this.checkBytecodes(chain);
     await this.checkValidatorAnnounce(chain);

--- a/typescript/sdk/src/deploy/HyperlaneAppChecker.ts
+++ b/typescript/sdk/src/deploy/HyperlaneAppChecker.ts
@@ -84,7 +84,7 @@ export abstract class HyperlaneAppChecker<
     owner: Address,
     ownableOverrides?: Record<string, Address>,
   ): Promise<void> {
-    // expectedProxyAdminAddress may be undefined, this means that expectedProxyAdminAddress is not set in the config/not known at deployment time/not using a singleton proxyAdmin
+    // expectedProxyAdminAddress may be undefined, this means that proxyAdmin is not set in the config/not known at deployment time
     const expectedProxyAdminAddress =
       this.app.getContracts(chain).proxyAdmin?.address;
     const provider = this.multiProvider.getProvider(chain);
@@ -114,7 +114,7 @@ export abstract class HyperlaneAppChecker<
             }
           } else {
             // config does not define an expected ProxyAdmin address, this means that checkOwnership will not be able to check the ownership of the ProxyAdmin contract
-            // as it is not explicitly defined in the config. We therefore check the ownership of the ProxyAdmin contract against the owner of the contracts here
+            // as it is not explicitly defined in the config. We therefore check the ownership of the ProxyAdmin contract here.
             const actualProxyAdminContract = ProxyAdmin__factory.connect(
               actualProxyAdminAddress,
               provider,

--- a/typescript/sdk/src/deploy/types.ts
+++ b/typescript/sdk/src/deploy/types.ts
@@ -4,9 +4,7 @@ import { z } from 'zod';
 import type {
   AccessControl,
   Ownable,
-  ProxyAdmin,
   TimelockController,
-  TransparentUpgradeableProxy,
 } from '@hyperlane-xyz/core';
 import { Address } from '@hyperlane-xyz/utils';
 
@@ -43,8 +41,7 @@ export interface OwnerViolation extends CheckerViolation {
 
 export interface ProxyAdminViolation extends CheckerViolation {
   type: ViolationType.ProxyAdmin;
-  expectedProxyAdmin: ProxyAdmin;
-  proxy: TransparentUpgradeableProxy;
+  proxyAddress: Address;
   name: string;
 }
 

--- a/typescript/sdk/src/gas/HyperlaneIgpChecker.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpChecker.ts
@@ -22,7 +22,7 @@ export class HyperlaneIgpChecker extends HyperlaneAppChecker<
 > {
   async checkChain(chain: ChainName): Promise<void> {
     await this.checkDomainOwnership(chain);
-    await this.checkProxiedContracts(chain);
+    await this.checkProxiedContracts(chain, this.configMap[chain].owner);
     await this.checkBytecodes(chain);
     await this.checkOverheadInterchainGasPaymaster(chain);
     await this.checkInterchainGasPaymaster(chain);

--- a/typescript/sdk/src/router/ProxiedRouterChecker.ts
+++ b/typescript/sdk/src/router/ProxiedRouterChecker.ts
@@ -1,3 +1,4 @@
+import { AddressesMap } from '../contracts/types.js';
 import { ChainName } from '../types.js';
 
 import { HyperlaneRouterChecker } from './HyperlaneRouterChecker.js';
@@ -9,13 +10,16 @@ export abstract class ProxiedRouterChecker<
   App extends RouterApp<Factories>,
   Config extends ProxiedRouterConfig,
 > extends HyperlaneRouterChecker<Factories, App, Config> {
-  getOwnableOverrides(chain: ChainName): any {
+  getOwnableOverrides(chain: ChainName): AddressesMap | undefined {
     const config = this.configMap[chain];
-    if (config.timelock) {
-      return {
+    let ownableOverrides = config?.ownerOverrides;
+    if (config?.timelock) {
+      ownableOverrides = {
+        ...ownableOverrides,
         proxyAdmin: this.app.getAddresses(chain).timelockController,
       };
     }
+    return ownableOverrides;
   }
 
   async checkOwnership(chain: ChainName): Promise<void> {

--- a/typescript/sdk/src/router/ProxiedRouterChecker.ts
+++ b/typescript/sdk/src/router/ProxiedRouterChecker.ts
@@ -9,16 +9,29 @@ export abstract class ProxiedRouterChecker<
   App extends RouterApp<Factories>,
   Config extends ProxiedRouterConfig,
 > extends HyperlaneRouterChecker<Factories, App, Config> {
-  async checkOwnership(chain: ChainName): Promise<void> {
+  getOwnableOverrides(chain: ChainName): any {
     const config = this.configMap[chain];
-    let ownableOverrides = config.ownerOverrides;
     if (config.timelock) {
-      ownableOverrides = {
+      return {
         proxyAdmin: this.app.getAddresses(chain).timelockController,
       };
     }
+  }
 
-    return super.checkOwnership(chain, config.owner, ownableOverrides);
+  async checkOwnership(chain: ChainName): Promise<void> {
+    return super.checkOwnership(
+      chain,
+      this.configMap[chain].owner,
+      this.getOwnableOverrides(chain),
+    );
+  }
+
+  async checkProxiedContracts(chain: ChainName): Promise<void> {
+    return super.checkProxiedContracts(
+      chain,
+      this.configMap[chain].owner,
+      this.getOwnableOverrides(chain),
+    );
   }
 
   async checkChain(chain: ChainName): Promise<void> {


### PR DESCRIPTION
### Description
- Support checking proxyAdmin owners for non AW proxy admins
- Stop assuming all proxyAdmins will be owned by AW
- This change was motivated by the need to have our checker tooling check Renzo Wapr routes, where Renzo owns the proxy routers

### Drive-by changes
- Clean up the interface for `ProxyAdminViolation`

### Testing

Manual
