### PR TITLE
feat(checkToken): Support checking token config for xERC20Lockbox type

### DIFF
--- a/.changeset/gentle-chicken-hammer.md
+++ b/.changeset/gentle-chicken-hammer.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Support xERC20Lockbox in checkToken


### PR DESCRIPTION
### Description

- When setting up the warp configuration for an `xERC20Lockbox` contract, we pass the lockbox address in the token field for the config and we lookup the underlying ERC20 token in the smart contract constructor https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/1579ca221c2741764207d1d2fa9f8383ac633d55/solidity/contracts/token/extensions/HypXERC20Lockbox.sol#L17 
- This change accounts for this setup when checking for `CollateralTokenMismatch` violations

### Testing

Manual