### PR TITLE
fix(sdk): Update smart provider logging to debug

### DIFF
--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -430,7 +430,7 @@ export class HyperlaneSmartProvider
     errors: any[],
     fallbackMsg: string,
   ): void {
-    this.logger.error(fallbackMsg);
+    this.logger.debug(fallbackMsg);
     if (errors.length === 0) throw new Error(fallbackMsg);
 
     const rpcServerError = errors.find((e) =>


### PR DESCRIPTION
### Description
This stops deriving errors such as `hyperlane ism read --address 0xc6608b648111020719d85163017a0dd2c9943d69 --chain fraxtal`
### Testing
Manual
