### PR TITLE
feat(infra): add check-warp-deply script that checks all AW managed w…

### DIFF
--- a/typescript/infra/fork.sh
+++ b/typescript/infra/fork.sh
@@ -39,7 +39,7 @@ execute_command() {
 }
 
 echo "Checking deploy"
-execute_command "yarn tsx ./scripts/check-deploy.ts -e $ENVIRONMENT -f $CHAIN -m $MODULE"
+execute_command "yarn tsx ./scripts/check/check-deploy.ts -e $ENVIRONMENT -f $CHAIN -m $MODULE"
 
 echo "Getting balance"
 DEPLOYER="0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba"
@@ -53,10 +53,10 @@ DEPLOY_DELTA="$((BEFORE-AFTER))"
 
 BEFORE=$(cast balance $DEPLOYER --rpc-url http://localhost:8545)
 echo "Checking deploy with --govern"
-execute_command "yarn tsx ./scripts/check-deploy.ts -e $ENVIRONMENT -f $CHAIN --govern -m $MODULE"
+execute_command "yarn tsx ./scripts/check/check-deploy.ts -e $ENVIRONMENT -f $CHAIN --govern -m $MODULE"
 
 AFTER=$(cast balance $DEPLOYER --rpc-url http://localhost:8545)
 GOVERN_DELTA="$((BEFORE-AFTER))"
 
 echo "Checking deploy without --govern"
-execute_command "yarn tsx ./scripts/check-deploy.ts -e $ENVIRONMENT -f $CHAIN -m $MODULE"
+execute_command "yarn tsx ./scripts/check/check-deploy.ts -e $ENVIRONMENT -f $CHAIN -m $MODULE"

--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -109,6 +109,16 @@ export function withContext<T>(args: Argv<T>) {
     .demandOption('context');
 }
 
+export function withAsDeployer<T>(args: Argv<T>) {
+  return args
+    .describe('asDeployer', 'Set signer to the deployer key')
+    .default('asDeployer', false);
+}
+
+export function withGovern<T>(args: Argv<T>) {
+  return args.boolean('govern').default('govern', false).alias('g', 'govern');
+}
+
 export function withChainRequired<T>(args: Argv<T>) {
   return withChain(args).demandOption('chain');
 }

--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -90,14 +90,18 @@ export function getArgs() {
     .alias('e', 'environment');
 }
 
-export function withModuleAndFork<T>(args: Argv<T>) {
+export function withFork<T>(args: Argv<T>) {
   return args
-    .choices('module', Object.values(Modules))
-    .demandOption('module', 'hyperlane module to deploy')
-    .alias('m', 'module')
     .describe('fork', 'network to fork')
     .choices('fork', getChains())
     .alias('f', 'fork');
+}
+
+export function withModule<T>(args: Argv<T>) {
+  return args
+    .choices('module', Object.values(Modules))
+    .demandOption('module', 'hyperlane module to deploy')
+    .alias('m', 'module');
 }
 
 export function withContext<T>(args: Argv<T>) {

--- a/typescript/infra/scripts/check/check-deploy.ts
+++ b/typescript/infra/scripts/check/check-deploy.ts
@@ -1,0 +1,12 @@
+import { check } from './check-utils.js';
+
+async function main() {
+  await check();
+}
+
+main()
+  .then()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/typescript/infra/scripts/check/check-utils.ts
+++ b/typescript/infra/scripts/check/check-utils.ts
@@ -2,7 +2,6 @@ import { HelloWorldChecker } from '@hyperlane-xyz/helloworld';
 import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
   ChainMap,
-  CheckerViolation,
   HypERC20App,
   HypERC20Checker,
   HyperlaneCore,
@@ -58,9 +57,7 @@ export function getCheckDeployArgs() {
   return withWarpRouteId(withModule(getCheckArgs()));
 }
 
-export async function check(
-  argv?: Record<string, any>,
-): Promise<void | CheckerViolation> {
+export async function check(argv?: Record<string, any>) {
   const {
     fork,
     govern,

--- a/typescript/infra/scripts/check/check-utils.ts
+++ b/typescript/infra/scripts/check/check-utils.ts
@@ -40,19 +40,22 @@ import {
   withAsDeployer,
   withChain,
   withContext,
+  withFork,
   withGovern,
-  withModuleAndFork,
+  withModule,
   withWarpRouteId,
 } from '../agent-utils.js';
 import { getEnvironmentConfig, getHyperlaneCore } from '../core-utils.js';
 import { getHelloWorldApp } from '../helloworld/utils.js';
 
-export function getCheckDeployArgs() {
+export function getCheckArgs() {
   return withAsDeployer(
-    withGovern(
-      withChain(withWarpRouteId(withModuleAndFork(withContext(getRootArgs())))),
-    ),
+    withGovern(withChain(withFork(withContext(getRootArgs())))),
   );
+}
+
+export function getCheckDeployArgs() {
+  return withWarpRouteId(withModule(getCheckArgs()));
 }
 
 export async function check(
@@ -105,6 +108,7 @@ export async function check(
     warpRouteId,
   );
 
+  // TODO: getGovernor should throw if module not implemented and this should be removed
   if (!governor) {
     return;
   }
@@ -295,7 +299,8 @@ const getGovernor = async (
     );
     governor = new ProxiedRouterGovernor(checker, ica);
   } else {
-    console.log(`Skipping ${module}, checker or governor unimplemented`);
+    // TODO: should we throw here instead?
+    console.log(`Skipping ${module}, checker or governor not implemented`);
     return;
   }
 

--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -1,26 +1,16 @@
+import chalk from 'chalk';
+
+import { WarpRouteIds } from '../../config/warp.js';
 import { Modules } from '../agent-utils.js';
 
-import { check, getCheckDeployArgs } from './check-utils.js';
-
-const WARP_ROUTE_IDS = [
-  'ECLIP/arbitrum-neutron',
-  'ETH/ethereum-viction',
-  'EZETH/arbitrum-base-blast-bsc-ethereum-fraxtal-linea-mode-optimism-zircuit',
-  'INJ/inevm-injective',
-  'TIA/arbitrum-neutron',
-  'TIA/mantapacific-neutron',
-  'USDC/ancient8-ethereum',
-  'USDC/ethereum-inevm',
-  'USDC/ethereum-viction',
-  'USDT/ethereum-inevm',
-  'USDT/ethereum-viction',
-];
+import { check, getCheckArgs } from './check-utils.js';
 
 async function checkWarp() {
-  const argv = await getCheckDeployArgs().argv;
+  const argv = await getCheckArgs().argv;
 
-  for (const warpRouteId of WARP_ROUTE_IDS) {
-    console.log(`Checking warp route ${warpRouteId}`);
+  // TODO: consider retrying this if check throws an error
+  for (const warpRouteId of Object.values(WarpRouteIds)) {
+    console.log(`\nChecking warp route ${warpRouteId}...`);
     try {
       await check({
         ...argv,
@@ -28,7 +18,7 @@ async function checkWarp() {
         module: Modules.WARP,
       });
     } catch (e) {
-      console.error(e);
+      console.log(chalk.red(`Error checking warp route ${warpRouteId}: ${e}`));
     }
   }
 }

--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -1,0 +1,41 @@
+import { Modules } from '../agent-utils.js';
+
+import { check, getCheckDeployArgs } from './check-utils.js';
+
+const WARP_ROUTE_IDS = [
+  'ECLIP/arbitrum-neutron',
+  'ETH/ethereum-viction',
+  'EZETH/arbitrum-base-blast-bsc-ethereum-fraxtal-linea-mode-optimism-zircuit',
+  'INJ/inevm-injective',
+  'TIA/arbitrum-neutron',
+  'TIA/mantapacific-neutron',
+  'USDC/ancient8-ethereum',
+  'USDC/ethereum-inevm',
+  'USDC/ethereum-viction',
+  'USDT/ethereum-inevm',
+  'USDT/ethereum-viction',
+];
+
+async function checkWarp() {
+  const argv = await getCheckDeployArgs().argv;
+
+  for (const warpRouteId of WARP_ROUTE_IDS) {
+    console.log(`Checking warp route ${warpRouteId}`);
+    try {
+      await check({
+        ...argv,
+        warpRouteId,
+        module: Modules.WARP,
+      });
+    } catch (e) {
+      console.error(e);
+    }
+  }
+}
+
+checkWarp()
+  .then()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/typescript/infra/scripts/deploy.ts
+++ b/typescript/infra/scripts/deploy.ts
@@ -45,7 +45,8 @@ import {
   withChains,
   withConcurrentDeploy,
   withContext,
-  withModuleAndFork,
+  withFork,
+  withModule,
   withWarpRouteId,
 } from './agent-utils.js';
 import { getEnvironmentConfig, getHyperlaneCore } from './core-utils.js';
@@ -63,7 +64,7 @@ async function main() {
   } = await withContext(
     withConcurrentDeploy(
       withChains(
-        withModuleAndFork(withWarpRouteId(withBuildArtifactPath(getArgs()))),
+        withModule(withFork(withWarpRouteId(withBuildArtifactPath(getArgs())))),
       ),
     ),
   ).argv;


### PR DESCRIPTION
### Description

- add a script that allows use to check the warp route deployments for all AW managed warp routes

### Drive-by changes

- split up check-deploy script into reusable method 
- move check-deploy into check directory in infra

### Testing

Manual
