### PR TITLE
chore: update nautilus rpc url

### DIFF
--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -8,6 +8,7 @@ on:
     paths:
       # For now, because this image is only used to use `infra`, we just build for infra changes
       - 'typescript/infra/**'
+      - 'typescript/sdk/**'
 concurrency:
   group: build-push-monorepo-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -9,6 +9,8 @@ on:
       # For now, because this image is only used to use `infra`, we just build for infra changes
       - 'typescript/infra/**'
       - 'typescript/sdk/**'
+      - 'typescript/utils/**'
+      - 'solidity/contracts/**'
 concurrency:
   group: build-push-monorepo-${{ github.ref }}
   cancel-in-progress: true

--- a/typescript/infra/scripts/warp-routes/helm.ts
+++ b/typescript/infra/scripts/warp-routes/helm.ts
@@ -28,7 +28,7 @@ function getWarpRoutesHelmValues() {
   const values = {
     image: {
       repository: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: '962d34b-20230905-194531',
+      tag: '6ceaec5-20240821-085628',
     },
   };
   return helmifyValues(values);

--- a/typescript/sdk/src/consts/chainMetadata.ts
+++ b/typescript/sdk/src/consts/chainMetadata.ts
@@ -588,7 +588,7 @@ export const nautilus: ChainMetadata = {
   },
   rpcUrls: [
     {
-      http: 'https://api.nautilus.nautchain.xyz',
+      http: 'https://api.evm.nautilus.prod.eclipsenetwork.xyz',
     },
   ],
   blocks: {


### PR DESCRIPTION
### Description

for warp route monitoring
Note my confidence in the warp route deployment tooling in infra is low on v2 - so I just edited the sts

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
