### PR TITLE
chore: try speed up agent image build

### DIFF
--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -28,7 +28,6 @@ jobs:
 
   build-and-push-to-gcr:
     runs-on: ubuntu-latest
-
     # uses check-env to determine if secrets.GCLOUD_SERVICE_KEY is defined
     needs: [check-env]
     if: needs.check-env.outputs.gcloud-service-key == 'true'
@@ -37,11 +36,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
       - name: Generate tag data
         id: taggen
         run: |
           echo "TAG_DATE=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
           echo "TAG_SHA=$(echo '${{ github.event.pull_request.head.sha || github.sha }}' | cut -b 1-7)" >> $GITHUB_OUTPUT
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -54,14 +55,38 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=raw,value=${{ steps.taggen.outputs.TAG_SHA }}-${{ steps.taggen.outputs.TAG_DATE }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Login to GCR
         uses: docker/login-action@v3
         with:
           registry: gcr.io
           username: _json_key
           password: ${{ secrets.GCLOUD_SERVICE_KEY }}
+
+      - name: Cache mounts
+        uses: actions/cache@v4
+        id: mount-cache
+        with:
+          path: |
+            usr-src-target
+            usr-local-cargo-registry
+            usr-local-cargo-git
+          key: cache-${{ hashFiles('./rust/Dockerfile') }}
+
+      - name: Inject cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          cache-map: |
+            {
+              "usr-src-target": "/usr/src/target",
+              "usr-local-cargo-registry": "/usr/local/cargo/registry",
+              "usr-local-cargo-git": "/usr/local/cargo/git"
+            }
+          skip-extraction: ${{ steps.mount-cache.outputs.cache-hit }}
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -74,7 +74,10 @@ jobs:
             usr-src-target
             usr-local-cargo-registry
             usr-local-cargo-git
-          key: cache-${{ hashFiles('./rust/Dockerfile') }}
+          key: cache-${{ hashFiles('./rust/Cargo.lock') }}-${{ hashFiles('./rust/Dockerfile') }}
+          restore-keys: |
+            cache-${{ hashFiles('./rust/Cargo.lock') }}-
+            cache-
 
       - name: Inject cache into docker
         uses: reproducible-containers/buildkit-cache-dance@v3

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -3,7 +3,7 @@
 FROM rust:1.72.1 as builder
 WORKDIR /usr/src
 
-# 1a: Prepare for static linking
+# Step 1: Prepare for static linking and install necessary tools
 RUN apt-get update && \
     apt-get dist-upgrade -y && \
     apt-get install -y musl-tools clang && \
@@ -11,7 +11,7 @@ RUN apt-get update && \
 
 RUN mkdir rust
 
-# Add workspace to workdir
+# Step 2: Copy the actual source code
 COPY rust/agents rust/agents
 COPY rust/chains rust/chains
 COPY rust/hyperlane-base rust/hyperlane-base
@@ -28,7 +28,7 @@ COPY .git .git
 
 WORKDIR /usr/src/rust
 
-# Build binaries
+# Step 3: Build binaries
 RUN \
   --mount=id=cargo,type=cache,sharing=locked,target=/usr/src/target \
   --mount=id=cargo-home-registry,type=cache,sharing=locked,target=/usr/local/cargo/registry \
@@ -39,7 +39,7 @@ RUN \
     cp /usr/src/rust/target/release/relayer /release && \
     cp /usr/src/rust/target/release/scraper /release
 
-## 2: Copy the binaries to release image
+# Step 4: Set up the release image
 FROM ubuntu:22.04
 RUN apt-get update && \
     apt-get install -y \
@@ -49,15 +49,19 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-COPY rust/config ./config
 COPY --from=builder /release/* .
 
+# Step 5: Copy config files
+COPY rust/config ./config
+
+# Step 6: Set up permissions and directories
 RUN chmod 777 /app &&  \
     mkdir /usr/share/hyperlane/ && \
     chmod 1000 /usr/share/hyperlane && \
     mkdir /data/ && \
     chown -R 1000 /data/
 
+# Step 7: Set up the user and entrypoint
 USER 1000
 ENTRYPOINT ["tini", "--"]
 CMD ["./validator"]

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -51,15 +51,15 @@ RUN apt-get update && \
 WORKDIR /app
 COPY --from=builder /release/* .
 
-# Step 5: Copy config files
-COPY rust/config ./config
-
-# Step 6: Set up permissions and directories
+# Step 5: Set up permissions and directories
 RUN chmod 777 /app &&  \
     mkdir /usr/share/hyperlane/ && \
     chmod 1000 /usr/share/hyperlane && \
     mkdir /data/ && \
     chown -R 1000 /data/
+
+# Step 6: Copy config files
+COPY rust/config ./config
 
 # Step 7: Set up the user and entrypoint
 USER 1000

--- a/rust/config/mainnet_config.json
+++ b/rust/config/mainnet_config.json
@@ -920,7 +920,7 @@
       "blocks": {
         "confirmations": 1,
         "estimateBlockTime": 2,
-        "reorgPeriod": 1
+        "reorgPeriod": 2
       },
       "chainId": 252,
       "deployer": {
@@ -1179,8 +1179,7 @@
     },
     "injective": {
       "bech32Prefix": "inj",
-      "blockExplorers": [
-      ],
+      "blockExplorers": [],
       "blocks": {
         "confirmations": 1,
         "estimateBlockTime": 1,


### PR DESCRIPTION
chore: try speed up agent image build

As the config is what is mostly changing when we're looking at new agent builds for rollouts, here we move the config in a separate step, to improve layer caching.