### PR TITLE
feat: Add check if an address is a contract in Cosmos

### DIFF
--- a/rust/chains/hyperlane-cosmos/src/providers/grpc.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/grpc.rs
@@ -456,6 +456,13 @@ impl WasmGrpcProvider {
             sequence: base_account.sequence,
         })
     }
+
+    fn get_contract_address(&self) -> Result<&CosmosAddress, ChainCommunicationError> {
+        let contract_address = self.contract_address.as_ref().ok_or_else(|| {
+            ChainCommunicationError::from_other_str("No contract address available")
+        })?;
+        Ok(contract_address)
+    }
 }
 
 #[async_trait]
@@ -492,9 +499,7 @@ impl WasmProvider for WasmGrpcProvider {
     where
         T: Serialize + Send + Sync + Clone + Debug,
     {
-        let contract_address = self.contract_address.as_ref().ok_or_else(|| {
-            ChainCommunicationError::from_other_str("No contract address available")
-        })?;
+        let contract_address = self.get_contract_address()?;
         self.wasm_query_to(contract_address.address(), payload, block_height)
             .await
     }
@@ -541,9 +546,7 @@ impl WasmProvider for WasmGrpcProvider {
     }
 
     async fn wasm_contract_info(&self) -> ChainResult<ContractInfo> {
-        let contract_address = self.contract_address.as_ref().ok_or_else(|| {
-            ChainCommunicationError::from_other_str("No contract address available")
-        })?;
+        let contract_address = self.get_contract_address()?;
         self.wasm_contract_info_to(contract_address.address()).await
     }
 
@@ -582,9 +585,7 @@ impl WasmProvider for WasmGrpcProvider {
         T: Serialize + Send + Sync + Clone + Debug,
     {
         let signer = self.get_signer()?;
-        let contract_address = self.contract_address.as_ref().ok_or_else(|| {
-            ChainCommunicationError::from_other_str("No contract address available")
-        })?;
+        let contract_address = self.get_contract_address()?;
         let msgs = vec![MsgExecuteContract {
             sender: signer.address.clone(),
             contract: contract_address.address(),
@@ -652,9 +653,7 @@ impl WasmProvider for WasmGrpcProvider {
         // Estimating gas requires a signer, which we can reasonably expect to have
         // since we need one to send a tx with the estimated gas anyways.
         let signer = self.get_signer()?;
-        let contract_address = self.contract_address.as_ref().ok_or_else(|| {
-            ChainCommunicationError::from_other_str("No contract address available")
-        })?;
+        let contract_address = self.get_contract_address()?;
         let msg = MsgExecuteContract {
             sender: signer.address.clone(),
             contract: contract_address.address(),

--- a/rust/chains/hyperlane-cosmos/src/providers/grpc.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/grpc.rs
@@ -649,3 +649,6 @@ impl BlockNumberGetter for WasmGrpcProvider {
         self.latest_block_height().await
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/rust/chains/hyperlane-cosmos/src/providers/grpc/tests.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/grpc/tests.rs
@@ -1,0 +1,77 @@
+use std::str::FromStr;
+
+use url::Url;
+
+use hyperlane_core::config::OperationBatchConfig;
+use hyperlane_core::{ContractLocator, HyperlaneDomain, KnownHyperlaneDomain};
+
+use crate::address::CosmosAddress;
+use crate::grpc::{WasmGrpcProvider, WasmProvider};
+use crate::{ConnectionConf, CosmosAmount, RawCosmosAmount};
+
+#[ignore]
+#[tokio::test]
+async fn test_wasm_contract_info_success() {
+    // given
+    let provider = provider("neutron1sjzzd4gwkggy6hrrs8kxxatexzcuz3jecsxm3wqgregkulzj8r7qlnuef4");
+
+    // when
+    let result = provider.wasm_contract_info().await;
+
+    // then
+    assert!(result.is_ok());
+
+    let contract_info = result.unwrap();
+
+    assert_eq!(
+        contract_info.creator,
+        "neutron1dwnrgwsf5c9vqjxsax04pdm0mx007yrre4yyvm",
+    );
+    assert_eq!(
+        contract_info.admin,
+        "neutron1fqf5mprg3f5hytvzp3t7spmsum6rjrw80mq8zgkc0h6rxga0dtzqws3uu7",
+    );
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_wasm_contract_info_no_contract() {
+    // given
+    let provider = provider("neutron1dwnrgwsf5c9vqjxsax04pdm0mx007yrre4yyvm");
+
+    // when
+    let result = provider.wasm_contract_info().await;
+
+    // then
+    assert!(result.is_err());
+}
+
+fn provider(address: &str) -> WasmGrpcProvider {
+    let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Neutron);
+    let address = CosmosAddress::from_str(address).unwrap();
+    let locator = Some(ContractLocator::new(&domain, address.digest()));
+
+    WasmGrpcProvider::new(
+        domain.clone(),
+        ConnectionConf::new(
+            vec![Url::parse("http://grpc-kralum.neutron-1.neutron.org:80").unwrap()],
+            "https://rpc-kralum.neutron-1.neutron.org".to_owned(),
+            "neutron-1".to_owned(),
+            "neutron".to_owned(),
+            "untrn".to_owned(),
+            RawCosmosAmount::new("untrn".to_owned(), "0".to_owned()),
+            32,
+            OperationBatchConfig {
+                batch_contract_address: None,
+                max_batch_size: 1,
+            },
+        ),
+        CosmosAmount {
+            denom: "untrn".to_owned(),
+            amount: Default::default(),
+        },
+        locator,
+        None,
+    )
+    .unwrap()
+}

--- a/rust/chains/hyperlane-cosmos/src/providers/mod.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/mod.rs
@@ -5,9 +5,10 @@ use hyperlane_core::{
 };
 use tendermint_rpc::{client::CompatMode, HttpClient};
 
-use self::grpc::WasmGrpcProvider;
 use crate::grpc::WasmProvider;
 use crate::{ConnectionConf, CosmosAmount, HyperlaneCosmosError, Signer};
+
+use self::grpc::WasmGrpcProvider;
 
 /// cosmos grpc provider
 pub mod grpc;

--- a/rust/chains/hyperlane-cosmos/src/providers/mod.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/mod.rs
@@ -94,10 +94,7 @@ impl HyperlaneProvider for CosmosProvider {
     async fn is_contract(&self, address: &H256) -> ChainResult<bool> {
         match self.grpc_client.wasm_contract_info().await {
             Ok(c) => Ok(true),
-            Err(e) => {
-                info!("provided address is not a contract, address: {:?}", address);
-                Ok(false)
-            }
+            Err(e) => Ok(false),
         }
     }
 

--- a/rust/chains/hyperlane-cosmos/src/providers/mod.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/mod.rs
@@ -5,9 +5,9 @@ use hyperlane_core::{
 };
 use tendermint_rpc::{client::CompatMode, HttpClient};
 
-use crate::{ConnectionConf, CosmosAmount, HyperlaneCosmosError, Signer};
-
 use self::grpc::WasmGrpcProvider;
+use crate::grpc::WasmProvider;
+use crate::{ConnectionConf, CosmosAmount, HyperlaneCosmosError, Signer};
 
 /// cosmos grpc provider
 pub mod grpc;
@@ -89,7 +89,7 @@ impl HyperlaneProvider for CosmosProvider {
     }
 
     async fn is_contract(&self, _address: &H256) -> ChainResult<bool> {
-        // FIXME
+        let _ = self.grpc_client.wasm_contract_info().await?;
         Ok(true)
     }
 

--- a/rust/chains/hyperlane-cosmos/src/providers/mod.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/mod.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use tendermint_rpc::{client::CompatMode, HttpClient};
-use tracing::info;
 
 use hyperlane_core::{
     BlockInfo, ChainInfo, ChainResult, ContractLocator, HyperlaneChain, HyperlaneDomain,

--- a/rust/chains/hyperlane-cosmos/src/providers/mod.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/mod.rs
@@ -1,9 +1,11 @@
 use async_trait::async_trait;
+use tendermint_rpc::{client::CompatMode, HttpClient};
+use tracing::info;
+
 use hyperlane_core::{
     BlockInfo, ChainInfo, ChainResult, ContractLocator, HyperlaneChain, HyperlaneDomain,
     HyperlaneProvider, TxnInfo, H256, U256,
 };
-use tendermint_rpc::{client::CompatMode, HttpClient};
 
 use crate::grpc::WasmProvider;
 use crate::{ConnectionConf, CosmosAmount, HyperlaneCosmosError, Signer};
@@ -89,9 +91,14 @@ impl HyperlaneProvider for CosmosProvider {
         todo!() // FIXME
     }
 
-    async fn is_contract(&self, _address: &H256) -> ChainResult<bool> {
-        let _ = self.grpc_client.wasm_contract_info().await?;
-        Ok(true)
+    async fn is_contract(&self, address: &H256) -> ChainResult<bool> {
+        match self.grpc_client.wasm_contract_info().await {
+            Ok(c) => Ok(true),
+            Err(e) => {
+                info!("provided address is not a contract, address: {:?}", address);
+                Ok(false)
+            }
+        }
     }
 
     async fn get_balance(&self, address: String) -> ChainResult<U256> {


### PR DESCRIPTION
### Description

Currently, integration into Cosmos make an assumption that the address where a message should be delivered is a contract. This change allows Relayer to actually check if the recipient is a contract.

### Backward compatibility

Yes

### Testing

* Tested using E2E tests for Cosmos.
* Tested using auxiliary unit test (it is marked as ignored since it connects to real gRPC of Neutron).
