### PR TITLE
feat: weighted ISM factory deployments

### DIFF
--- a/typescript/infra/config/environments/mainnet3/ism/verification.json
+++ b/typescript/infra/config/environments/mainnet3/ism/verification.json
@@ -299,6 +299,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x25d668D37f20E6f396cB5DF1DFf5A3f2F568e707",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xADcB0c496906Bb713E51667383c1daf5C49d78DE",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x549F241472FccdA169E3202048aE2241231A7772",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x39085B802D94e62c7bb53F107FDf64ab4eaAe3b3",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "arbitrum": [
@@ -697,6 +751,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xEbA276cdC61D4BC954E80985aC8FD71453fDab8e",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xfD122f59ee8073528Cc5d36D5cc1451Bf1aF6923",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0xBbc6e404F8d841560261b036cA3468B55CB9f566",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x97c5dC51adAa04B3BefE63F4e62e4778219D9426",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0xF5C9D13D0a3308a06375fD09CACE3a6120711206",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xb5163440d5EBbdC23bC7A091466EB5a621093BFe",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x8eDC763c48Fa3EbC853cd198Ab5D0Eca1038fd58",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x01c0752455282BC139A325e479c6121E060a7bBd",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xe992DDf0345674b333e385A55b7CB6a4dC5Aa816",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "avalanche": [
@@ -1125,6 +1233,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x06b9dC1a6629122e7188698d20A92edbE966914f",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xeD8F4199e4409FDAe2AfD50dC7571f6771AadE50",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x86Bb7AC2BF6044289aEAFFC421b118E38C995c5a",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x3988b98C43C7A1f7C9D3edce6CeAD3b8a3F3d969",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x0a3E78c160daF8be96051D318d668F97182D60Bf",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xEdF170Da58598955e9a63DA43885842108969129",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x64D4EDcc87550b2439dC724992101fF2071f7411",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0xf44bae1e60bD5B895B2c5bAfF26C49B7e324E36C",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x52e09Fd675cA0c9380c82A3a87AAd295092C6420",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "base": [
@@ -1553,6 +1715,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x0d2FdC0264059C1334Aa28187E8628E1c9c6EC70",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x414B67F62b143d6db6E9b633168Dd6fd4DA20642",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x0d2123360ACB300AE9924d250f3c788FdE7e6B31",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0xcfacC141f090E5441D8F274659D43ec20F748b19",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x2504EeFD0b34Df6eAD7189482e4Dfab0F49Eb299",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "blast": [
@@ -1753,6 +1969,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x3b9f24fD2ecfed0d3A88fa7f0E4e5747671981D7",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x71DCcD21B912F7d4f636af0C9eA5DC0C10617354",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x7f51A658837A315134A97ff8B586d71B726B7e61",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x8Ea50255C282F89d1A14ad3F159437EE5EF0507f",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xA799f2c970F6cbc214485eFb61358F8251d6d3ea",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x06De94EfBE80A2804c5FDE2e7C4278a10575A272",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x05efFEe86e415ecc536403961482bBA2686E2dB2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "bob": [
@@ -1905,6 +2175,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xb89c6ED617f5F46175E41551350725A09110bbCE",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x45876f16Da5704BA663f4202F80933081284b30a",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0xa2401b57A8CCBF6AbD9b7e62e28811b2b523AB2B",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xd444D1a1AB40A462F11C506923894C1A68eb9F74",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "bsc": [
@@ -2201,6 +2525,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xDc3D51c58BDb84F4F209d2684151dfCa271e504f",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0x707609419b70DCb4C41Ef185d3C184814c61Af9c",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x769FeC9f1a1e3DD1891015A387C92Ee9631CB0bA",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0xf771dA1B909B67ca41dda9133E1C9934B5A2D8bb",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x1467aB848fCCdA65c2cCed0ebeBD0d95ad89E0D8",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x6f72BF0018a93689D9CD6BF59C7AAeA66F578Fc1",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xEC12f7d37eFf812360e78b50162D864bFC9687BE",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x058C7458193f1b28e2bF7547E3f7a6A719Fc0f59",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x447a901aE0cA26FB666F76143AEb9792582763DF",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "celo": [
@@ -2539,6 +2917,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x7F6cD932412508E9a8297CA626C56Ed3D279937F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xf422a4Af27e5fbDDAf799A1d92532Edd5dE58fF3",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x43379b54E27EA8387B34B5c15534E230d490f0A8",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x8d9dB8bbF91d7852F36a954229BDf6ec69A3ae00",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x866599CEaE5060D774EBAaE7e9f8A0431a8c1ED5",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x0f05deB9c5931c3F87209674B6d4c6df74F6DCBc",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xdfF87ec209a829F103BFC898636394C58EF79B7A",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x58924b11A3B03D533192Dd5a92bc358F5a970E34",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x05B12D76CCf3621Cc680e34b6667A6088e5eA778",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "cheesechain": [
@@ -2691,6 +3123,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x148CF67B8A242c1360bb2C93fCe203EC4d4f9B56",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xAAD3028b6c948134cf1202493297E5e6F609b613",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0xcd849e612Aaa138f03698C3Edb42a34117BFF631",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xEf30a87a0428cC597c1ff4D369C18FE2d7935248",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "cyber": [
@@ -2903,6 +3389,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x989B7307d266151BE763935C856493D968b2affF",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x58063F7A3eD60070e395C96FC95bD8fbDDf0BEB1",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x71388C9E25BE7b229B5d17Df7D4DB3F7DA7C962d",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xF52e545cf6f1382B611461A7F5793fc9FdDD80f1",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "degenchain": [
@@ -3115,6 +3655,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x71388C9E25BE7b229B5d17Df7D4DB3F7DA7C962d",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xF52e545cf6f1382B611461A7F5793fc9FdDD80f1",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x3E969bA938E6A993eeCD6F65b0dd8712B07dFe59",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xE8EF49a04b2bD84E6b28b059AD1db413684DfFBc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "endurance": [
@@ -3267,6 +3861,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xc441521bA37EaCd9af4f319CcdA27E9D48f74281",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x00948A9b4a8e367c222E70e32772B5481083BCE1",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x730f8a4128Fa8c53C777B62Baa1abeF94cAd34a9",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x6aeB57DE231093191f20929C407eA8ecb4B2Db58",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "ethereum": [
@@ -3605,6 +4253,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xD4dAcca08737d2a910b4Ad401f805F83D0C170f3",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0x5371942D3Ed75b10d77F0f4184dDc85cC35A1420",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0xc2cCfc65D2D5719E78a77EA5f6C10AA4cdEC6719",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x03862793C0EE59af3e475f7Ca67406b547FfD95c",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0xBbaDB49B1fD1A0574C8D2B0589Cd9b8A79452e67",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xA2502bF73e5313c1bf48E47C887cdcbf2640FA41",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x834e00bc940d239c3A3b13413cDFBa205f1B22fb",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x4272124Fba59CbA076D85375895f94B6a3485c3E",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x16c0Dbb3CAfF177a45C79023379803519EF59da9",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "fraxtal": [
@@ -3787,6 +4489,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x3b9f24fD2ecfed0d3A88fa7f0E4e5747671981D7",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0x71DCcD21B912F7d4f636af0C9eA5DC0C10617354",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x7f51A658837A315134A97ff8B586d71B726B7e61",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0xDFF18Bf286c9cDd0fC653a28616460Cf7443F8EF",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x3a49EcAC1031612D66fa20D6F40f214aCeAc2B4B",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x7947b7Fe737B4bd1D3387153f32148974066E591",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xf5150D0002b3814a056b9BA15f68cF4E6E73a8D1",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x1A41a365A693b6A7aED1a46316097d290f569F22",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x5e62B70862c81DC9f6db0D149104823e5204B27E",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "fusemainnet": [
@@ -3969,6 +4725,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xFbC64903760E8b606D80b1924599BD5548422e35",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xfa9701EE829A16f13B5F052dcbb835095AC2B2b0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x3292de58cff7ffb25873Ef1E5fb2470044Cc60f0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x84F7a463Bf148e3Cde0Af8C02E860F4627FeAb07",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0xeb1f47c14EF5710EaD4C2513b4B32b586a8CCAa7",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xe522A5DcA58e3ab7fEd2bf25DA3E8d90c14083a8",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x9E60F82fF6b9BfCd3C10A562155E17448458D290",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x53642476e24E28c3218E8Da44eDEBB4adB9DE13e",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xf756289caE324A0e48D6707df5D85cFb0Fc2bB77",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "gnosis": [
@@ -4403,6 +5213,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xe46CDa25130A89759F1Da00591D7a920CAe7667E",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xEeBd8F72573C5a08F18BeC0DbadCCD3365c06AEF",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x5aaF70a9944d2D7cf17153ea07632618b1e45C6F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x72AffdEd251dF55c7c89566c64B9961dbc3e7A23",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x901bFAC323Dc06b1302D82201F62729Dff39b20a",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xA37ce588515668632D9025272859D2E5bD3210BB",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x6680563b276e1Fc209165D9A3B69f72d7734846f",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x5B7365640c82F402C43A3961F3fD34Ae31f52931",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xCD0f89b9d7708D0D9865F08DB0E1e539Cf32515e",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "inevm": [
@@ -4615,6 +5479,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x8cFBC2F871477126597716FF92773B557014B20e",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xC26C8e3dFf8436f1EE5400b0ad72aD959001f5D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x45192cd669Fa8BeE012d7ea1300EF3b305277FF6",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x10B2fE827Da5cAE5b5f575F020EBe17E60f5eFe9",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "kroma": [
@@ -4767,6 +5685,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x9024A3902B542C87a5C4A2b3e15d60B2f087Dc3E",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xbc122528aE606ff3390c7376cb52077E35e17F0a",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x749848D7b783A328638C3ea74AcFcfb73c977CbE",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x5C28C7EA165222CA2f1B5dB1B1c7eA221dFe862c",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "linea": [
@@ -4949,6 +5921,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x3b9f24fD2ecfed0d3A88fa7f0E4e5747671981D7",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0x71DCcD21B912F7d4f636af0C9eA5DC0C10617354",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x7f51A658837A315134A97ff8B586d71B726B7e61",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0xDFF18Bf286c9cDd0fC653a28616460Cf7443F8EF",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x3a49EcAC1031612D66fa20D6F40f214aCeAc2B4B",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x11df2f96bC60DfE5A2ab193AD0FCC0a0336F22d0",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xB4540F906CEbb7621E51C8dd71febed951d4D932",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0xb0772086edF20278501bb2aF8D8efDe4B71C73Ce",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x815E7a03B08D6d7C97D1532c985eE3D7ddA5AB29",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "lisk": [
@@ -5065,6 +6091,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x71388C9E25BE7b229B5d17Df7D4DB3F7DA7C962d",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xF52e545cf6f1382B611461A7F5793fc9FdDD80f1",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x3E969bA938E6A993eeCD6F65b0dd8712B07dFe59",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xE8EF49a04b2bD84E6b28b059AD1db413684DfFBc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "lukso": [
@@ -5127,6 +6207,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x148CF67B8A242c1360bb2C93fCe203EC4d4f9B56",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xAAD3028b6c948134cf1202493297E5e6F609b613",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0xcd849e612Aaa138f03698C3Edb42a34117BFF631",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xEf30a87a0428cC597c1ff4D369C18FE2d7935248",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "mantapacific": [
@@ -5279,6 +6413,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x3b9f24fD2ecfed0d3A88fa7f0E4e5747671981D7",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x6C360932873629929ff3D9ffB70bD4cbC1606541",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x0A5d831c09204888B8791BF4E9c49445aD54f2C5",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x86a38989edb2ba15D049E53c46659Aeec1C92708",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0xc11f8Cf2343d3788405582F65B8af6A4F7a6FfC8",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xaf28225f25957ED48481421C0EdF7F6694B35cb9",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "mantle": [
@@ -5431,6 +6619,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xAAeb91195C025C9D35F8FF70e13049D8cD25703D",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x45E9aE2FCFf3d93DABC0075db6a8Ea1AC439c1b6",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x7eFF14440AbE077dBb05C7668079Bc1cD2CD9bd0",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xc307B7348734D71CAdD5718BE5c1045633b9eE57",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "merlin": [
@@ -5493,6 +6735,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xF15D70941dE2Bf95A23d6488eBCbedE0a444137f",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x4f4c227bB6c45bEd11322d869e09081ef91A06DF",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0xD7EcB0396406682a27E87F7946c25Ac531140959",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xf5a6768bE5e499099DFBE00a5ab851F4B80EE7C3",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "metis": [
@@ -5555,6 +6851,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xcd849e612Aaa138f03698C3Edb42a34117BFF631",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xEf30a87a0428cC597c1ff4D369C18FE2d7935248",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0xb129828B9EDa48192D0B2db35D0E40dCF51B3594",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xD3061b4E1069c8E1b28a806471C89419EC3df833",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "mint": [
@@ -5617,6 +6967,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xcd849e612Aaa138f03698C3Edb42a34117BFF631",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xEf30a87a0428cC597c1ff4D369C18FE2d7935248",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0xb129828B9EDa48192D0B2db35D0E40dCF51B3594",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xD3061b4E1069c8E1b28a806471C89419EC3df833",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "mode": [
@@ -5799,6 +7203,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xf4eDb63976d4AB444359f84D4379c8975461120C",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xFFCfb9D2d8d4A2A4aEc351fB50d6A0c10F0d1f3e",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0xf9609bB22847e0DB5F6fB8f95b84D25A19b46ac5",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xf07BB26219E839b05638058F010920737D169E7e",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "moonbeam": [
@@ -6071,6 +7529,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x28336d2b8783f2373bCFc173058EA932bf3b901C",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0x76FD8c164F380107631160d8Fd1f4Edc2719004D",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0xd5FF00DD9E737c9d1a197246738876fAF43e4aC0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x568De5f1639Fe7c9eba67f1191DE19eeCc77985B",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x2214b2AC96215d2FF1fffC84E4Af295d7497B013",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x13B09a1d80e93E03221e1F393B588C28a5dE9B69",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x6376F427722d5b5B3cD85a27b9E9ae2C55E82aFE",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x1E14479A04786900F32c916c11eE1EEf81B5a6bA",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x2b5e7FD12A39912437Ac6E960cbF5eF4b6E3912B",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "optimism": [
@@ -6379,6 +7891,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xC91A3282FE1eBc29AE494f10680006f152DcE316",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xb61544De4d3A103698AC57Fd62402627B8AC3cC2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0xD416cF29F961c090e9b9b8aF0970c86D93c2Ff61",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x315d8B4229134Fcb12B8955f0B5FC1310E56E764",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x71c5167429f522FA009D110954Cb08E0317d4d69",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x313b18228236bf89fc67cca152c62f1896eEa362",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x8F441749BBAbc8C3566d86fC5ae343253825FD3a",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x3A2e96403d076e9f953166A9E4c61bcD9D164CFe",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x808B812856AbC806838f6B1b68d50798Be0c664b",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "polygon": [
@@ -6717,6 +8283,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x14CEa5Df89Fa709409e83ebEA9518C5B6fb4B19B",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0x370815EdA08438c8F385a6f7AB5A2Dfa75008abC",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0xCC38436BFB9B9888be96b59d825E0fE5DC19e05c",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x5B8418082D87c96B7De689D0368756cddAbB35F5",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x6921808186c66558e91dF1233910862A94a57475",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x07CE1B0cFfa436AE2fb7Fbd7318648774FdA53f9",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xc1955c41df0959047fe2abb8f0A822Ae19c06247",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x9e22945bE593946618383B108CC5bce09eBA4C26",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x66a3Cc5aB789A7e0406CeA808500c4638c7c8B1D",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "polygonzkevm": [
@@ -7055,6 +8675,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x3b9f24fD2ecfed0d3A88fa7f0E4e5747671981D7",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x0741b6Fd92DA99E77E5eE78CFf74cB1689B3588e",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xc24f3ba8619Fe9db9b95fB616D6945779669e591",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x854bA316A59cAfFCe2CF4a8C2db688b5018F0bfe",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x882Ad0CcB25CDf928e2a9C899F23eC033C4113f7",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x8E0Ac7e48F210637124E77507562b46956e0981d",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "proofofplay": [
@@ -7117,6 +8791,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xcd849e612Aaa138f03698C3Edb42a34117BFF631",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xEf30a87a0428cC597c1ff4D369C18FE2d7935248",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0xb129828B9EDa48192D0B2db35D0E40dCF51B3594",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xD3061b4E1069c8E1b28a806471C89419EC3df833",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "real": [
@@ -7179,6 +8907,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x3b9f24fD2ecfed0d3A88fa7f0E4e5747671981D7",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x662771d29DFf0d7C36bB9BB6d4241a02e77585d9",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x9BBf34c1d6FB9cbDb3A941D2e67209D4243E390C",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x5d69BC38eF3eDb491c0b7186BEc4eC45c4013f93",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x97D997d934c37E35dEC301300eFd7B8885d7d99d",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "redstone": [
@@ -7361,6 +9143,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x3b9f24fD2ecfed0d3A88fa7f0E4e5747671981D7",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x794Fe7970EE45945b0ad2667f99A5bBc9ddfB5d7",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x169b5Cf1bA838c41C5832a39A016B696Da6ed2F2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x7B8AA8f23Ab6B0757eC6FC71894211376D9335b0",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x4c90b3835E1CE99d5F538a55bE214030B76988cd",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "sanko": [
@@ -7423,6 +9259,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x749848D7b783A328638C3ea74AcFcfb73c977CbE",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x5C28C7EA165222CA2f1B5dB1B1c7eA221dFe862c",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x148CF67B8A242c1360bb2C93fCe203EC4d4f9B56",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xAAD3028b6c948134cf1202493297E5e6F609b613",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "scroll": [
@@ -7761,6 +9651,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x9d9238fD3715281De2c8FC321135bF82EB66E932",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xcb0D04010584AA5244b5826c990eeA4c16BeAC8C",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xD09c2753282A0CD12aB2CC44Eb7565cC3E242E90",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x609707355a53d2aAb6366f48E2b607C599D26B29",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x7b9873548Ac18BC8463d1cf1a2f4B8d6Fcb6Fd0E",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "sei": [
@@ -7943,6 +9887,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xDf347f7602fFF536337c0B90cEC19CD6998427C4",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x9AC6b5169a2960a2fD97d84eAF1385B850d7Cd24",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x816CF11aDFF6De498823F739eAfe350E82ee845D",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x56AF9c0e0ca8aE615d4e63D2fAD71D20d36eaa36",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "taiko": [
@@ -8095,6 +10093,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x3b9f24fD2ecfed0d3A88fa7f0E4e5747671981D7",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xdf4aA3905e0391C7763e33CB6A08fFa97221D49B",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xA82A29c03E6A7dfAd13c49185Ca7D0e0FA483af3",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x72246331d057741008751AB3976a8297Ce7267Bc",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xD68246F65763f5447ffa41Aa87Eac94875E354d9",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "tangle": [
@@ -8157,6 +10209,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x148CF67B8A242c1360bb2C93fCe203EC4d4f9B56",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xAAD3028b6c948134cf1202493297E5e6F609b613",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0xcd849e612Aaa138f03698C3Edb42a34117BFF631",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xEf30a87a0428cC597c1ff4D369C18FE2d7935248",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "viction": [
@@ -8369,6 +10475,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x766fc1d3F6CFAE5A06Fe8D6b65a3012401Bd36Ba",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x686238065d3C07dC0DA629Cba9c6e3D466D27C13",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x9f4012ba9368FBb95F56c2Fc2D956df803D8779e",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x259bC8f3707155d749561f7adA3c04c63591fE66",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "worldchain": [
@@ -8521,6 +10681,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xe8d5590F2e969F9d21f0132f2b596273f8a03Ef2",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xDb5a0411ACFBE2d6576D5755b60E9D9C77cA4C87",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x9024A3902B542C87a5C4A2b3e15d60B2f087Dc3E",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xbc122528aE606ff3390c7376cb52077E35e17F0a",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "xai": [
@@ -8583,6 +10797,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x71388C9E25BE7b229B5d17Df7D4DB3F7DA7C962d",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xF52e545cf6f1382B611461A7F5793fc9FdDD80f1",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x3E969bA938E6A993eeCD6F65b0dd8712B07dFe59",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xE8EF49a04b2bD84E6b28b059AD1db413684DfFBc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "xlayer": [
@@ -8687,6 +10955,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x168DFF0Ad2b180F3801883Fe5Ae56d7E7d91D5f4",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x794920337875C8ac3B8C93Aeb8A78eeB10C8CBc9",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x6Fb36672365C7c797028C400A61c58c0ECc53cD2",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x666D4BdC8Af72549374DE632Bd7841c0Da47f46F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "zetachain": [
@@ -8809,6 +11131,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xF645AeA0b8D26c9DBdfdeF2DEe59F845715BE32F",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x38A16F12F574cE66E855F094725dC605c6775D1E",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x0ed553e7e5D55535457d1E778Ba96cF839c18442",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x40d174B413CEC1243d6C3F41beD479D59164D3BF",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "zircuit": [
@@ -8901,6 +11277,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4725F7b8037513915aAf6D6CBDE2920E28540dDc",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xAF03386044373E2fe26C5b1dCedF5a7e854a7a3F",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0x882CD0C5D50b6dD74b36Da4BDb059507fddEDdf2",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0x19930232E9aFC4f4F09d09fe2375680fAc2100D0",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0x12Ed1BbA182CbC63692F813651BD493B7445C874",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x13E83ac41e696856B6996263501fB3225AD5E6F5",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x4fECC7e169b04d0534E7171F32590562Ad56F896",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0x61374178e45F65fF9D6252d017Cd580FC60B7654",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x8413Cc171EC50D1350Fb311645776803cAE13038",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ],
   "zoramainnet": [
@@ -9023,6 +11453,60 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x43959DEdb22bf1dC2822d18dF45EB2A52915c7Ca",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootMultisigIsm"
+    },
+    {
+      "address": "0xcb45AbeF85F7Cc29A6b7E43e7f2255819E348c71",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdMultisigIsm"
+    },
+    {
+      "address": "0xeD2900EA95162bBe6305410c823CffD962342681",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationIsm"
+    },
+    {
+      "address": "0xb8135be3ac4E134144756BE98971c6ab203f6cfD",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticAggregationHook"
+    },
+    {
+      "address": "0xbd8F7C89b9c4E5c09A3719042Cd4ae2dF266f408",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x33AA12b4e8E79cA551Ca9D1F2eC7d2cE02129dd4",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xEE8AC41a812F20e7227506e9DC05761a2028e68D",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMerkleRootWeightedMultisigIsm"
+    },
+    {
+      "address": "0xB31553F20D7b06Eb8Eaefe29376146e1d276d091",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xdc124876DCFEA0732168824ad0aF04799B5FF6c3",
+      "constructorArguments": "",
+      "isProxy": true,
+      "name": "StaticMessageIdWeightedMultisigIsm"
     }
   ]
 }

--- a/typescript/infra/config/environments/testnet4/ism/verification.json
+++ b/typescript/infra/config/environments/testnet4/ism/verification.json
@@ -395,6 +395,18 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x374961678da5911083599314974B94094513F95c",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x1Fa22d908f5a5E7F5429D9146E5a3740D8AC10d7",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
     }
   ],
   "arbitrumsepolia": [
@@ -457,6 +469,18 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x1aFD5191738d365C8079e955E4cEdDfe7e01C62d",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xC81e6D1070aFA48DA4e4f35E744CC1aE43532a10",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
     }
   ],
   "basesepolia": [
@@ -549,6 +573,18 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xB057Fb841027a8554521DcCdeC3c3474CaC99AB5",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xe0B988062A0C6492177d64823Ab95a9c256c2a5F",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
     }
   ],
   "bsctestnet": [
@@ -879,6 +915,18 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xCa152b249791Adf7A09C6c1bdbAb05e4A594966e",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xaa80d23299861b7D7ab1bE665579029Ed9137BD1",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
     }
   ],
   "connextsepolia": [
@@ -971,6 +1019,18 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x8584590ad637C61C7cDF72eFF3381Ee1c3D1bC8E",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xcCB305B1f21e5FbC85D1DD7Be5cd8d5bf5B7f863",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
     }
   ],
   "ecotestnet": [
@@ -1063,6 +1123,18 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xA2cf52064c921C11adCd83588CbEa08cc3bfF5d8",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x628BC518ED1e0E8C6cbcD574EbA0ee29e7F6943E",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
     }
   ],
   "fuji": [
@@ -1441,6 +1513,18 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xff93F32997Ac5450995121385aCE96b184efe89E",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x8eAB8cBb9037e818C321f675c0bc2EA4649003CF",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
     }
   ],
   "holesky": [
@@ -1563,6 +1647,18 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xFb55597F07417b08195Ba674f4dd58aeC9B89FBB",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x0E18b28D98C2efDb59252c021320F203305b1B66",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
     }
   ],
   "moonbasealpha": [
@@ -1853,6 +1949,18 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xe0B988062A0C6492177d64823Ab95a9c256c2a5F",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x7c5B5bdA7F1d1F70A6678ABb4d894612Fc76498F",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
     }
   ],
   "plumetestnet": [
@@ -1975,6 +2083,18 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x7924A1569fE0b860F1eA3c7b4Ed97b5528946f83",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0xb04961F492f447A8bA10f6694Bd888C7619CD2D5",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
     }
   ],
   "polygonamoy": [
@@ -2037,6 +2157,18 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xe0B988062A0C6492177d64823Ab95a9c256c2a5F",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x7c5B5bdA7F1d1F70A6678ABb4d894612Fc76498F",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
     }
   ],
   "scrollsepolia": [
@@ -2245,6 +2377,18 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x339B46496D60b1b6B42e9715DeD8B3D2154dA0Bb",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x63dFf524F1c7361f4F1bf07D658Bf7f2d5Dd5B20",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
     }
   ],
   "sepolia": [
@@ -2473,6 +2617,18 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0x4afB48e864d308409d0D80E98fB7d5d6aA5b245f",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x196Ce28ED1Afdf015849ddEE82F03a903Bee9E94",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
     }
   ],
   "superpositiontestnet": [
@@ -2535,6 +2691,18 @@
       "constructorArguments": "",
       "isProxy": true,
       "name": "DomaingRoutingIsm"
+    },
+    {
+      "address": "0xE67CfA164cDa449Ae38a0a09391eF6bCDf8e4e2c",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMerkleRootWeightedMultisigIsmFactory"
+    },
+    {
+      "address": "0x867f2089D09903f208AeCac84E599B90E5a4A821",
+      "constructorArguments": "",
+      "isProxy": false,
+      "name": "StaticMessageIdWeightedMultisigIsmFactory"
     }
   ]
 }


### PR DESCRIPTION
### Description

- Adding staticMerkleRootWeightedMultisigIsmFactory and staticMessageIdWeightedMultisigIsmFactory verification outputs

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
