### PR TITLE
feat: Add ChainSubmissionStrategy and update hyperlane submit

### DIFF
--- a/.changeset/tricky-horses-repair.md
+++ b/.changeset/tricky-horses-repair.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+Add ChainSubmissionStrategySchema

--- a/typescript/cli/examples/submit/strategy/gnosis-ica-strategy.yaml
+++ b/typescript/cli/examples/submit/strategy/gnosis-ica-strategy.yaml
@@ -1,4 +1,3 @@
-chain: avalanche
 submitter:
   type: gnosisSafe
   chain: avalanche

--- a/typescript/cli/examples/submit/strategy/gnosis-strategy.yaml
+++ b/typescript/cli/examples/submit/strategy/gnosis-strategy.yaml
@@ -1,4 +1,3 @@
-chain: avalanche
 submitter:
   type: gnosisSafe
   chain: avalanche

--- a/typescript/cli/examples/submit/strategy/impersonated-account-strategy.yaml
+++ b/typescript/cli/examples/submit/strategy/impersonated-account-strategy.yaml
@@ -1,4 +1,3 @@
-chain: alfajores
 submitter:
   type: impersonatedAccount
   userAddress: '0x16F4898F47c085C41d7Cc6b1dc72B91EA617dcBb'

--- a/typescript/cli/examples/submit/strategy/json-rpc-strategy.yaml
+++ b/typescript/cli/examples/submit/strategy/json-rpc-strategy.yaml
@@ -1,3 +1,2 @@
-chain: alfajores
 submitter:
   type: jsonRpc

--- a/typescript/cli/src/commands/submit.ts
+++ b/typescript/cli/src/commands/submit.ts
@@ -1,6 +1,12 @@
+import {
+  SubmissionStrategy,
+  SubmissionStrategySchema,
+} from '@hyperlane-xyz/sdk';
+
 import { runSubmit } from '../config/submit.js';
 import { CommandModuleWithWriteContext } from '../context/types.js';
 import { logBlue, logGray } from '../logger.js';
+import { readYamlOrJson } from '../utils/files.js';
 
 import {
   dryRunCommandOption,
@@ -26,17 +32,38 @@ export const submitCommand: CommandModuleWithWriteContext<{
     'dry-run': dryRunCommandOption,
     receipts: outputFileCommandOption('./generated/transactions/receipts.yaml'),
   },
-  handler: async ({ context, transactions, receipts }) => {
+  handler: async ({
+    context,
+    transactions,
+    strategy: strategyUrl,
+    receipts,
+  }) => {
     logGray(`Hyperlane Submit`);
     logGray(`----------------`);
 
+    const submissionStrategy = readSubmissionStrategy(strategyUrl);
     await runSubmit({
       context,
       transactionsFilepath: transactions,
       receiptsFilepath: receipts,
+      submissionStrategy,
     });
 
     logBlue(`✅ Submission complete`);
     process.exit(0);
   },
 };
+
+/**
+ * Retrieves a submission strategy from the provided filepath.
+ * @param submissionStrategyFilepath a filepath to the submission strategy file
+ * @returns a formatted submission strategy
+ */
+export function readSubmissionStrategy(
+  submissionStrategyFilepath: string,
+): SubmissionStrategy {
+  const submissionStrategyFileContent = readYamlOrJson(
+    submissionStrategyFilepath.trim(),
+  );
+  return SubmissionStrategySchema.parse(submissionStrategyFileContent);
+}

--- a/typescript/cli/src/config/submit.ts
+++ b/typescript/cli/src/config/submit.ts
@@ -3,7 +3,10 @@ import { stringify as yamlStringify } from 'yaml';
 import {
   PopulatedTransactions,
   PopulatedTransactionsSchema,
+  SubmissionStrategy,
 } from '@hyperlane-xyz/sdk';
+import { PopulatedTransaction } from '@hyperlane-xyz/sdk';
+import { MultiProvider } from '@hyperlane-xyz/sdk';
 import { assert, errorToString } from '@hyperlane-xyz/utils';
 
 import { WriteCommandContext } from '../context/types.js';
@@ -19,25 +22,27 @@ export async function runSubmit({
   context,
   transactionsFilepath,
   receiptsFilepath,
+  submissionStrategy,
 }: {
   context: WriteCommandContext;
   transactionsFilepath: string;
   receiptsFilepath: string;
+  submissionStrategy: SubmissionStrategy;
 }) {
-  const { submissionStrategy, chainMetadata, multiProvider } = context;
+  const { chainMetadata, multiProvider } = context;
 
   assert(
     submissionStrategy,
     'Submission strategy required to submit transactions.\nPlease create a submission strategy. See examples in cli/examples/submit/strategy/*.',
   );
+  const transactions = getTransactions(transactionsFilepath);
+  const chain = getChainFromTxs(multiProvider, transactions);
 
-  const chain = submissionStrategy.chain;
   const protocol = chainMetadata[chain].protocol;
   const submitterBuilder = await getSubmitterBuilder<typeof protocol>({
     submissionStrategy,
     multiProvider,
   });
-  const transactions = getTransactions(transactionsFilepath);
 
   try {
     const transactionReceipts = await submitterBuilder.submit(...transactions);
@@ -55,6 +60,29 @@ export async function runSubmit({
     );
     throw new Error('Failed to submit transactions.');
   }
+}
+
+/**
+ * Retrieves the chain name from transactions[0].
+ *
+ * @param multiProvider - The MultiProvider instance to use for chain name lookup.
+ * @param transactions - The list of populated transactions.
+ * @returns The name of the chain that the transactions are submitted on.
+ * @throws If the transactions are not all on the same chain or chain is not found
+ */
+function getChainFromTxs(
+  multiProvider: MultiProvider,
+  transactions: PopulatedTransactions,
+) {
+  const firstTransaction = transactions.at(0);
+  assert(firstTransaction, 'Transactions empty');
+
+  const sameChainIds = transactions.every(
+    (t: PopulatedTransaction) => t.chainId === firstTransaction.chainId,
+  );
+  assert(sameChainIds, 'Transactions must be submitted on the same chains');
+
+  return multiProvider.getChainName(firstTransaction.chainId);
 }
 
 function getTransactions(transactionsFilepath: string): PopulatedTransactions {

--- a/typescript/cli/src/config/submit.ts
+++ b/typescript/cli/src/config/submit.ts
@@ -74,9 +74,7 @@ function getChainFromTxs(
   multiProvider: MultiProvider,
   transactions: PopulatedTransactions,
 ) {
-  const firstTransaction = transactions.at(0);
-  assert(firstTransaction, 'Transactions empty');
-
+  const firstTransaction = transactions[0];
   const sameChainIds = transactions.every(
     (t: PopulatedTransaction) => t.chainId === firstTransaction.chainId,
   );

--- a/typescript/cli/src/context/types.ts
+++ b/typescript/cli/src/context/types.ts
@@ -6,7 +6,6 @@ import type {
   ChainMap,
   ChainMetadata,
   MultiProvider,
-  SubmissionStrategy,
 } from '@hyperlane-xyz/sdk';
 
 export interface ContextSettings {
@@ -16,7 +15,6 @@ export interface ContextSettings {
   fromAddress?: string;
   requiresKey?: boolean;
   skipConfirmation?: boolean;
-  submissionStrategy?: SubmissionStrategy;
 }
 
 export interface CommandContext {
@@ -24,7 +22,6 @@ export interface CommandContext {
   chainMetadata: ChainMap<ChainMetadata>;
   multiProvider: MultiProvider;
   skipConfirmation: boolean;
-  submissionStrategy?: SubmissionStrategy;
   key?: string;
   signer?: ethers.Signer;
 }

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -336,9 +336,15 @@ export {
   EV5ImpersonatedAccountTxSubmitterProps,
 } from './providers/transactions/submitter/ethersV5/types.js';
 
-export { SubmissionStrategySchema } from './providers/transactions/submitter/builder/schemas.js';
+export {
+  SubmissionStrategySchema,
+  ChainSubmissionStrategySchema,
+} from './providers/transactions/submitter/builder/schemas.js';
 export { TxSubmitterBuilder } from './providers/transactions/submitter/builder/TxSubmitterBuilder.js';
-export { SubmissionStrategy } from './providers/transactions/submitter/builder/types.js';
+export {
+  SubmissionStrategy,
+  ChainSubmissionStrategy,
+} from './providers/transactions/submitter/builder/types.js';
 
 export { EV5GnosisSafeTxSubmitter } from './providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.js';
 export { EV5ImpersonatedAccountTxSubmitter } from './providers/transactions/submitter/ethersV5/EV5ImpersonatedAccountTxSubmitter.js';

--- a/typescript/sdk/src/providers/transactions/schemas.ts
+++ b/typescript/sdk/src/providers/transactions/schemas.ts
@@ -10,7 +10,10 @@ export const PopulatedTransactionSchema = z.object({
   chainId: z.number(),
 });
 
-export const PopulatedTransactionsSchema = PopulatedTransactionSchema.array();
+export const PopulatedTransactionsSchema =
+  PopulatedTransactionSchema.array().refine((txs) => txs.length > 0, {
+    message: 'Populated Transactions cannot be empty',
+  });
 
 export const CallDataSchema = z.object({
   to: ZHash,

--- a/typescript/sdk/src/providers/transactions/submitter/builder/schemas.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/builder/schemas.ts
@@ -5,7 +5,11 @@ import { TransformerMetadataSchema } from '../../transformer/schemas.js';
 import { SubmitterMetadataSchema } from '../schemas.js';
 
 export const SubmissionStrategySchema = z.object({
-  chain: ZChainName,
   submitter: SubmitterMetadataSchema,
   transforms: z.array(TransformerMetadataSchema).optional(),
 });
+
+export const ChainSubmissionStrategySchema = z.record(
+  ZChainName,
+  SubmissionStrategySchema,
+);

--- a/typescript/sdk/src/providers/transactions/submitter/builder/types.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/builder/types.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
 
-import { SubmissionStrategySchema } from './schemas.js';
+import {
+  ChainSubmissionStrategySchema,
+  SubmissionStrategySchema,
+} from './schemas.js';
 
 export type SubmissionStrategy = z.infer<typeof SubmissionStrategySchema>;
+export type ChainSubmissionStrategy = z.infer<
+  typeof ChainSubmissionStrategySchema
+>;


### PR DESCRIPTION
### Description
- This PR is a prerequisite for https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4225
- Adds `ChainSubmissionStrategy` which is a ChainMap of SubmissionStrategy
- Moves the submissionStrategy logic out of the context to allow `--strategy` to be used for both cases (mostly to not having to parse and validate 2 schemas in `getSubmissionStrategy()`)
- Adds logic to assume that all `--transactions` are of the same chainId with explicit validation

### Backward compatibility
Yes

### Testing
Manual
