### PR TITLE
feat: Fix GCS support: setting checkpointSyncer.type=gcs

### DIFF
--- a/rust/agents/validator/src/settings.rs
+++ b/rust/agents/validator/src/settings.rs
@@ -188,6 +188,40 @@ fn parse_checkpoint_syncer(syncer: ValueParser) -> ConfigResult<CheckpointSyncer
                 folder,
             })
         }
+        Some("gcs") => {
+            let bucket = syncer
+                .chain(&mut err)
+                .get_key("bucket")
+                .parse_string()
+                .end()
+                .map(str::to_owned);
+            let folder = syncer
+                .chain(&mut err)
+                .get_opt_key("folder")
+                .parse_string()
+                .end()
+                .map(str::to_owned);
+            let service_account_key = syncer
+                .chain(&mut err)
+                .get_opt_key("service_account_key")
+                .parse_string()
+                .end()
+                .map(str::to_owned);
+            let user_secrets = syncer
+                .chain(&mut err)
+                .get_opt_key("user_secrets")
+                .parse_string()
+                .end()
+                .map(str::to_owned);
+
+            cfg_unwrap_all!(&syncer.cwp, err: [bucket]);
+            err.into_result(CheckpointSyncerConf::Gcs {
+                bucket,
+                folder,
+                service_account_key,
+                user_secrets,
+            })
+        }
         Some(_) => {
             Err(eyre!("Unknown checkpoint syncer type")).into_config_result(|| &syncer.cwp + "type")
         }

--- a/typescript/infra/src/config/agent/validator.ts
+++ b/typescript/infra/src/config/agent/validator.ts
@@ -63,12 +63,14 @@ export interface HelmValidatorValues extends HelmStatefulSetValues {
 
 export type CheckpointSyncerConfig =
   | LocalCheckpointSyncerConfig
-  | S3CheckpointSyncerConfig;
+  | S3CheckpointSyncerConfig
+  | GcsCheckpointSyncerConfig;
 
 // These values are eventually passed to Rust, which expects the values to be camelCase
 export const enum CheckpointSyncerType {
   LocalStorage = 'localStorage',
   S3 = 's3',
+  Gcs = 'gcs',
 }
 
 export interface LocalCheckpointSyncerConfig {
@@ -78,6 +80,14 @@ export interface LocalCheckpointSyncerConfig {
 
 export type S3CheckpointSyncerConfig = S3Config & {
   type: CheckpointSyncerType.S3;
+};
+
+export type GcsCheckpointSyncerConfig = {
+  type: CheckpointSyncerType.Gcs;
+  bucket: string;
+  folder?: string;
+  service_account_key?: string;
+  user_secrets?: string;
 };
 
 export class ValidatorConfigHelper extends AgentConfigHelper<ValidatorConfig> {

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -381,6 +381,27 @@ export const ValidatorAgentConfigSchema = AgentConfigSchema.extend({
           ),
       })
       .describe('A checkpoint syncer that uses S3'),
+    z
+      .object({
+        type: z.literal('gcs'),
+        bucket: z.string().min(1),
+        folder: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('The folder to use, defaults to the root of the bucket'),
+        service_account_key: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('The path to GCS service account key file'),
+        user_secrets: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('The path to GCS user secret file'),
+      })
+      .describe('A checkpoint syncer that uses Google Cloud Storage'),
   ]),
   interval: ZUint.optional().describe(
     'How long to wait between checking for new checkpoints in seconds.',


### PR DESCRIPTION
### Description

Fixing the issue I described [earlier](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3156#issuecomment-2285659584) where the usage of GCS as an alternative to AWS although supported by Hyperlane Agents, in practice didn't work because the settings still didn't accept "gcs" as a checkpoint syncer type.

### Backward compatibility

Yes

### Testing

Manual
