### PR TITLE
fix: sort cosmwasm funds by denom

### DIFF
--- a/.changeset/red-nails-trade.md
+++ b/.changeset/red-nails-trade.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Sorted cwNative funds by denom in transfer tx

--- a/typescript/sdk/src/token/adapters/CosmWasmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/CosmWasmTokenAdapter.ts
@@ -394,6 +394,7 @@ export class CwHypNativeAdapter
     const { addressOrDenom: igpDenom, amount: igpAmount } = interchainGas;
     assert(igpDenom, 'Interchain gas denom required for Cosmos');
 
+    // If more than one denom is used as funds, they must be sorted by the denom
     const funds: Coin[] =
       collateralDenom === igpDenom
         ? [
@@ -411,7 +412,7 @@ export class CwHypNativeAdapter
               amount: igpAmount.toString(),
               denom: igpDenom,
             },
-          ];
+          ].sort((a, b) => a.denom.localeCompare(b.denom));
 
     return this.cw20adapter.prepareRouter(
       {


### PR DESCRIPTION
### Description
CosmWasm `ExecuteContract` message require that the attached `funds` attached are sorted by denom ([ref](https://github.com/CosmWasm/wasmd/blob/1d0c66c4cfdf996d12d044638b685b9d09bbd7c1/x/wasm/types/tx.go#L131) and [ref](https://github.com/cosmos/cosmos-sdk/blob/19e0de5e0aab223b8a0dc53a0717ff0120dcb51a/types/coin.go#L270)). 

The current hyperlane-sdk [implementation](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/092ce5fd392eeec2782949062ff084e25ee68e6e/typescript/sdk/src/token/adapters/CosmWasmTokenAdapter.ts#L405-L414) does not have sorting, which causes both the message simulation and submission to fail.  

### Drive-by changes
No

### Related issues
#4384 

### Backward compatibility
Yes

### Testing
Manual
