### PR TITLE
fix: remove redundant ``yarn install && yarn build`` from e2e

### DIFF
--- a/rust/utils/run-locally/src/ethereum/mod.rs
+++ b/rust/utils/run-locally/src/ethereum/mod.rs
@@ -19,12 +19,14 @@ mod multicall;
 pub fn start_anvil(config: Arc<Config>) -> AgentHandles {
     log!("Installing typescript dependencies...");
     let yarn_monorepo = Program::new("yarn").working_dir(MONOREPO_ROOT_PATH);
-    yarn_monorepo.clone().cmd("install").run().join();
     if !config.is_ci_env {
+        // test.yaml workflow installs dependencies
+        yarn_monorepo.clone().cmd("install").run().join();
         // don't need to clean in the CI
         yarn_monorepo.clone().cmd("clean").run().join();
+        // test.yaml workflow builds the monorepo
+        yarn_monorepo.clone().cmd("build").run().join();
     }
-    yarn_monorepo.clone().cmd("build").run().join();
 
     if !config.is_ci_env {
         // Kill any existing anvil processes just in case since it seems to have issues getting cleaned up


### PR DESCRIPTION
### Description

- test.yaml workflow already installs yarn dependencies and runs `yarn build` so it's redundant and wasteful to do the same in the main.rs file for run-locally which is dependent on yarn build as it is. So, I made it conditional if E2E_CI_MODE="false".

yarn install ~= 19s
yarn build ~= 1m33s

It should save us 1m52s in the usual longest running CI item.

### Drive-by changes

None

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

e2e
