### PR TITLE
chore: deploy agents

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -372,7 +372,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '72d498f-20240828-092241',
+      tag: '707db4a-20240828-164024',
     },
     gasPaymentEnforcement: gasPaymentEnforcement,
     metricAppContexts,
@@ -381,7 +381,7 @@ const hyperlane: RootAgentConfig = {
   validators: {
     docker: {
       repo,
-      tag: '72d498f-20240828-092241',
+      tag: '707db4a-20240828-164024',
     },
     rpcConsensusType: RpcConsensusType.Quorum,
     chains: validatorChainConfig(Contexts.Hyperlane),
@@ -391,7 +391,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '72d498f-20240828-092241',
+      tag: '707db4a-20240828-164024',
     },
     resources: scraperResources,
   },
@@ -439,7 +439,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'dcd6dc5-20240716-120804',
+      tag: '707db4a-20240828-164024',
     },
     gasPaymentEnforcement: [
       {

--- a/typescript/infra/scripts/agents/deploy-agents.ts
+++ b/typescript/infra/scripts/agents/deploy-agents.ts
@@ -18,4 +18,9 @@ async function main() {
   await new AgentCli().runHelmCommand(HelmCommand.InstallOrUpgrade);
 }
 
-main().then(console.log).catch(console.error);
+main()
+  .then(console.log)
+  .catch((err) => {
+    console.error('Error deploying agents:', err);
+    process.exit(1);
+  });

--- a/typescript/infra/src/agents/aws/key.ts
+++ b/typescript/infra/src/agents/aws/key.ts
@@ -20,7 +20,7 @@ import { ethers } from 'ethers';
 import { Logger } from 'pino';
 
 import { AgentSignerKeyType, ChainName } from '@hyperlane-xyz/sdk';
-import { rootLogger, sleep } from '@hyperlane-xyz/utils';
+import { retryAsync, rootLogger, sleep } from '@hyperlane-xyz/utils';
 
 import { AgentContextConfig, AwsKeyConfig } from '../../config/agent/agent.js';
 import { Role } from '../../roles.js';
@@ -172,20 +172,23 @@ export class AgentAwsKey extends CloudAgentKey {
 
   // Gets the Key's ID if it exists, undefined otherwise
   async getId() {
-    try {
-      this.logger.debug('Attempting to describe key to get ID');
-      const keyDescription = await this.describeKey();
-      const keyId = keyDescription.KeyMetadata?.KeyId;
-      this.logger.debug(`Key ID retrieved: ${keyId}`);
-      return keyId;
-    } catch (err: any) {
-      if (err.name === 'NotFoundException') {
-        this.logger.debug('Key not found');
-        return undefined;
+    // Seeing intermittent errors with the AWS SDK, likely due to many concurrent requests
+    return retryAsync(async () => {
+      try {
+        this.logger.debug('Attempting to describe key to get ID');
+        const keyDescription = await this.describeKey();
+        const keyId = keyDescription.KeyMetadata?.KeyId;
+        this.logger.debug(`Key ID retrieved: ${keyId}`);
+        return keyId;
+      } catch (err: any) {
+        if (err.name === 'NotFoundException') {
+          this.logger.debug('Key not found');
+          return undefined;
+        }
+        this.logger.debug(`Error retrieving key ID: ${err}`);
+        throw err;
       }
-      this.logger.debug(`Error retrieving key ID: ${err}`);
-      throw err;
-    }
+    });
   }
 
   create() {


### PR DESCRIPTION
### Description

- deployed to include #4214 
- some drive-bys, e.g. one flaky AWS interaction, and to use a non-zero exit code if there's an error deploying agents

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
