### PR TITLE
fix: set profile overrides in root manifest

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -195,6 +195,73 @@ ya-gcp = { version = "0.11.1", features = ["storage"] }
 ## TODO: remove this
 cosmwasm-schema = "1.2.7"
 
+[profile.release.package.access-control]
+overflow-checks = true
+
+[profile.release.package.account-utils]
+overflow-checks = true
+
+[profile.release.package.ecdsa-signature]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-connection-client]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-token-lib]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-interchain-security-module-interface]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-message-recipient-interface]
+overflow-checks = true
+
+[profile.release.package.multisig-ism]
+overflow-checks = true
+
+[profile.release.package.serializable-account-meta]
+overflow-checks = true
+
+[profile.release.package.hyperlane-test-transaction-utils]
+overflow-checks = true
+
+[profile.release.package.hyperlane-test-utils]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-mailbox]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-igp]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-igp-test]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-token]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-token-collateral]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-token-native]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-multisig-ism-message-id]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-test-ism]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-mailbox-test]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-test-send-receiver]
+overflow-checks = true
+
+[profile.release.package.hyperlane-sealevel-validator-announce]
+overflow-checks = true
+
+
 [workspace.dependencies.ethers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"

--- a/rust/sealevel/libraries/access-control/Cargo.toml
+++ b/rust/sealevel/libraries/access-control/Cargo.toml
@@ -12,6 +12,3 @@ solana-program.workspace = true
 
 [lib]
 crate-type = ["cdylib", "lib"]
-
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/libraries/account-utils/Cargo.toml
+++ b/rust/sealevel/libraries/account-utils/Cargo.toml
@@ -14,6 +14,3 @@ spl-type-length-value.workspace = true
 
 [lib]
 crate-type = ["cdylib", "lib"]
-
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/libraries/ecdsa-signature/Cargo.toml
+++ b/rust/sealevel/libraries/ecdsa-signature/Cargo.toml
@@ -16,6 +16,3 @@ getrandom = { workspace = true, features = ["custom"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]
-
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/libraries/hyperlane-sealevel-connection-client/Cargo.toml
+++ b/rust/sealevel/libraries/hyperlane-sealevel-connection-client/Cargo.toml
@@ -18,6 +18,3 @@ hyperlane-sealevel-igp = { path = "../../programs/hyperlane-sealevel-igp", featu
 
 [lib]
 crate-type = ["cdylib", "lib"]
-
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/Cargo.toml
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/Cargo.toml
@@ -30,5 +30,3 @@ serializable-account-meta = { path = "../serializable-account-meta" }
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/libraries/interchain-security-module-interface/Cargo.toml
+++ b/rust/sealevel/libraries/interchain-security-module-interface/Cargo.toml
@@ -13,5 +13,3 @@ spl-type-length-value.workspace = true
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/libraries/message-recipient-interface/Cargo.toml
+++ b/rust/sealevel/libraries/message-recipient-interface/Cargo.toml
@@ -18,5 +18,3 @@ getrandom = { workspace = true, features = ["custom"] }
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/libraries/multisig-ism/Cargo.toml
+++ b/rust/sealevel/libraries/multisig-ism/Cargo.toml
@@ -24,5 +24,3 @@ hex.workspace = true
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/libraries/serializable-account-meta/Cargo.toml
+++ b/rust/sealevel/libraries/serializable-account-meta/Cargo.toml
@@ -12,5 +12,3 @@ solana-program.workspace = true
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/libraries/test-transaction-utils/Cargo.toml
+++ b/rust/sealevel/libraries/test-transaction-utils/Cargo.toml
@@ -13,5 +13,3 @@ solana-sdk.workspace = true
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/libraries/test-utils/Cargo.toml
+++ b/rust/sealevel/libraries/test-utils/Cargo.toml
@@ -25,5 +25,3 @@ serializable-account-meta = { path = "../serializable-account-meta" }
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/programs/hyperlane-sealevel-igp-test/Cargo.toml
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp-test/Cargo.toml
@@ -18,5 +18,3 @@ solana-program-test.workspace = true
 solana-sdk.workspace = true
 hyperlane-test-utils = { path = "../../libraries/test-utils" }
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/programs/hyperlane-sealevel-igp/Cargo.toml
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp/Cargo.toml
@@ -28,5 +28,3 @@ serde = { workspace = true, optional = true }
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/programs/hyperlane-sealevel-token-collateral/Cargo.toml
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-collateral/Cargo.toml
@@ -38,5 +38,3 @@ hyperlane-sealevel-test-ism = { path = "../ism/test-ism", features = ["no-entryp
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/programs/hyperlane-sealevel-token-native/Cargo.toml
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-native/Cargo.toml
@@ -38,5 +38,3 @@ tarpc = "~0.29"
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/programs/hyperlane-sealevel-token/Cargo.toml
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/Cargo.toml
@@ -38,5 +38,3 @@ hyperlane-sealevel-test-ism = { path = "../ism/test-ism", features = ["no-entryp
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/Cargo.toml
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/Cargo.toml
@@ -38,5 +38,3 @@ rand = "0.8.5"
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/programs/ism/test-ism/Cargo.toml
+++ b/rust/sealevel/programs/ism/test-ism/Cargo.toml
@@ -25,5 +25,3 @@ hyperlane-test-transaction-utils = { path = "../../../libraries/test-transaction
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/programs/mailbox-test/Cargo.toml
+++ b/rust/sealevel/programs/mailbox-test/Cargo.toml
@@ -35,5 +35,3 @@ serializable-account-meta = { path = "../../libraries/serializable-account-meta"
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/programs/mailbox/Cargo.toml
+++ b/rust/sealevel/programs/mailbox/Cargo.toml
@@ -40,5 +40,3 @@ log.workspace = true
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/programs/test-send-receiver/Cargo.toml
+++ b/rust/sealevel/programs/test-send-receiver/Cargo.toml
@@ -25,5 +25,3 @@ serializable-account-meta = { path = "../../libraries/serializable-account-meta"
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true

--- a/rust/sealevel/programs/validator-announce/Cargo.toml
+++ b/rust/sealevel/programs/validator-announce/Cargo.toml
@@ -28,5 +28,3 @@ hyperlane-test-utils ={ path = "../../libraries/test-utils" }
 [lib]
 crate-type = ["cdylib", "lib"]
 
-[profile.release]
-overflow-checks = true


### PR DESCRIPTION
### Description

Fixes `cargo build-sbf` warnings by moving all profile overrides to `rust/Cargo.toml`, so they actually take effect.

### Related issues

- Fixes https://github.com/hyperlane-xyz/issues/issues/1368

### Backward compatibility

Yes

### Testing

Manually, by initializing `inbox.processed_count` to `u64::MAX - 1`, and then observing logs in e2e:
```
13: Program log: About to increment processed count. Current count: 18446744073709551615
14: Program log: panicked at 'attempt to add with overflow', sealevel/programs/mailbox/src/processor.rs:386:5
```
The panic occurs at `inbox.processed_count += 1;`