### PR TITLE
feat: add error handling for blocks and proper sender

### DIFF
--- a/rust/chains/hyperlane-cosmos/src/providers/mod.rs
+++ b/rust/chains/hyperlane-cosmos/src/providers/mod.rs
@@ -201,6 +201,11 @@ impl HyperlaneProvider for CosmosProvider {
             .map_err(|e| ChainCommunicationError::from_other_str("could not convert from proto"))?;
         let contract = H256::try_from(CosmosAccountId::new(&msg.contract))?;
 
+        // We calculate the sender and the nonce for the transaction.
+        // We use `payer` of the fees as the sender of the transaction and search for its
+        // signature information to find the nonce.
+        // If `payer` is not specified, we use the account which signed the transaction first, as
+        // the sender.
         let (sender, nonce) = tx
             .auth_info
             .fee

--- a/rust/hyperlane-core/src/error.rs
+++ b/rust/hyperlane-core/src/error.rs
@@ -170,19 +170,19 @@ impl ChainCommunicationError {
         Self::Other(HyperlaneCustomErrorWrapper(err))
     }
 
-    /// Creates a chain communication error of the other error variant from a static string
-    pub fn from_other_str(err: &'static str) -> Self {
+    /// Creates a chain communication error of the other error variant from a string slice
+    pub fn from_other_str(err: &str) -> Self {
         #[derive(Debug)]
         #[repr(transparent)]
-        struct StringError(&'static str);
+        struct StringError(String);
         impl Display for StringError {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-                f.write_str(self.0)
+                f.write_str(&self.0)
             }
         }
         impl StdError for StringError {}
 
-        Self::from_contract_error(StringError(err))
+        Self::from_contract_error(StringError(err.to_owned()))
     }
 
     /// Creates a chain communication error of the contract error variant from any other existing


### PR DESCRIPTION
### Description

* Use correct signer as sender
* Add error handling in getting block by hash

### Backward compatibility

Yes

### Testing

E2E Test for Cosmos (no implementation in invariant)
