### PR TITLE
feat(envTests): Support using secret rpcs for CI env tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -409,7 +409,7 @@ jobs:
       MAINNET3_ARBITRUM_RPC_URLS: ${{ secrets.MAINNET3_ARBITRUM_RPC_URLS }}
       MAINNET3_OPTIMISM_RPC_URLS: ${{ secrets.MAINNET3_OPTIMISM_RPC_URLS }}
 
-    timeout-minutes: 6
+    timeout-minutes: 10
     needs: [yarn-build]
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -409,7 +409,7 @@ jobs:
       MAINNET3_ARBITRUM_RPC_URLS: ${{ secrets.MAINNET3_ARBITRUM_RPC_URLS }}
       MAINNET3_OPTIMISM_RPC_URLS: ${{ secrets.MAINNET3_OPTIMISM_RPC_URLS }}
 
-    timeout-minutes: 10
+    timeout-minutes: 6
     needs: [yarn-build]
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -436,6 +436,11 @@ jobs:
 
       - name: Checkout registry
         uses: ./.github/actions/checkout-registry
+      
+      - name: Check environment variables
+        run: |
+          echo "MAINNET3_ARBITRUM_RPC_URLS: ${MAINNET3_ARBITRUM_RPC_URLS:+set}"
+          echo "MAINNET3_OPTIMISM_RPC_URLS: ${MAINNET3_OPTIMISM_RPC_URLS:+set}"
 
       - name: Fork test ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }} deployment
         run: cd typescript/infra && LOG_FORMAT=pretty LOG_LEVEL=debug ./fork.sh ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -409,7 +409,7 @@ jobs:
       MAINNET3_ARBITRUM_RPC_URLS: ${{ secrets.MAINNET3_ARBITRUM_RPC_URLS }}
       MAINNET3_OPTIMISM_RPC_URLS: ${{ secrets.MAINNET3_OPTIMISM_RPC_URLS }}
 
-    timeout-minutes: 6
+    timeout-minutes: 4
     needs: [yarn-build]
     strategy:
       fail-fast: false
@@ -440,14 +440,9 @@ jobs:
 
       - name: Checkout registry
         uses: ./.github/actions/checkout-registry
-      
-      - name: Check environment variables
-        run: |
-          echo "MAINNET3_ARBITRUM_RPC_URLS: ${MAINNET3_ARBITRUM_RPC_URLS:+set}"
-          echo "MAINNET3_OPTIMISM_RPC_URLS: ${MAINNET3_OPTIMISM_RPC_URLS:+set}"
 
       - name: Fork test ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }} deployment
-        run: cd typescript/infra && LOG_FORMAT=pretty LOG_LEVEL=debug ./fork.sh ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }}
+        run: cd typescript/infra && ./fork.sh ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }}
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -438,7 +438,7 @@ jobs:
         uses: ./.github/actions/checkout-registry
 
       - name: Fork test ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }} deployment
-        run: cd typescript/infra && ./fork.sh ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }}
+        run: cd typescript/infra && LOG_FORMAT=pretty LOG_LEVEL=debug ./fork.sh ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }}
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -409,7 +409,7 @@ jobs:
       MAINNET3_ARBITRUM_RPC_URLS: ${{ secrets.MAINNET3_ARBITRUM_RPC_URLS }}
       MAINNET3_OPTIMISM_RPC_URLS: ${{ secrets.MAINNET3_OPTIMISM_RPC_URLS }}
 
-    timeout-minutes: 3
+    timeout-minutes: 6
     needs: [yarn-build]
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -405,6 +405,10 @@ jobs:
 
   env-test:
     runs-on: ubuntu-latest
+    env:
+      MAINNET3_ARBITRUM_RPC_URLS: ${{ secrets.MAINNET3_ARBITRUM_RPC_URLS }}
+      MAINNET3_OPTIMISM_RPC_URLS: ${{ secrets.MAINNET3_OPTIMISM_RPC_URLS }}
+
     timeout-minutes: 3
     needs: [yarn-build]
     strategy:

--- a/typescript/infra/fork.sh
+++ b/typescript/infra/fork.sh
@@ -11,7 +11,7 @@ if [ -z "$ENVIRONMENT" ] || [ -z "$MODULE" ] || [ -z "$CHAIN" ]; then
 fi
 
 # kill all child processes on exit
-trap 'jobs -p | xargs -r kill' EXIT
+trap 'jobs -p | xargs -r kill 2>/dev/null' EXIT
 
 # exit 1 on any subsequent failures
 set -e
@@ -58,6 +58,3 @@ GOVERN_DELTA="$((BEFORE-AFTER))"
 
 echo "Checking deploy without --govern"
 execute_command "yarn tsx ./scripts/check/check-deploy.ts -e $ENVIRONMENT -f $CHAIN -m $MODULE"
-
-kill -9 $ANVIL_PID
-wait $ANVIL_PID

--- a/typescript/infra/fork.sh
+++ b/typescript/infra/fork.sh
@@ -16,9 +16,7 @@ trap 'jobs -p | xargs -r kill' EXIT
 # exit 1 on any subsequent failures
 set -e
 
-RPC_URL=`LOG_LEVEL=error yarn tsx ./scripts/print-chain-metadatas.ts -e $ENVIRONMENT | jq -r ".$CHAIN.rpcUrls[0].http"`
-
-anvil --fork-url $RPC_URL --fork-retry-backoff 3 --compute-units-per-second 200 --gas-price 1 --silent &
+LOG_LEVEL=error yarn tsx ./scripts/run-anvil.ts -e $ENVIRONMENT -c $CHAIN &
 ANVIL_PID=$!
 
 while ! cast bn &> /dev/null; do
@@ -60,3 +58,6 @@ GOVERN_DELTA="$((BEFORE-AFTER))"
 
 echo "Checking deploy without --govern"
 execute_command "yarn tsx ./scripts/check/check-deploy.ts -e $ENVIRONMENT -f $CHAIN -m $MODULE"
+
+kill -9 $ANVIL_PID
+wait $ANVIL_PID

--- a/typescript/infra/fork.sh
+++ b/typescript/infra/fork.sh
@@ -11,7 +11,7 @@ if [ -z "$ENVIRONMENT" ] || [ -z "$MODULE" ] || [ -z "$CHAIN" ]; then
 fi
 
 # kill all child processes on exit
-trap 'jobs -p | xargs -r kill 2>/dev/null' EXIT
+trap 'jobs -p | xargs -r kill' EXIT
 
 # exit 1 on any subsequent failures
 set -e

--- a/typescript/infra/scripts/run-anvil.ts
+++ b/typescript/infra/scripts/run-anvil.ts
@@ -44,16 +44,6 @@ async function runAnvil(rpcUrl: string) {
     process.exit(1);
   });
 
-  process.on('SIGINT', () => {
-    console.log('Received SIGINT. Terminating Anvil...');
-    anvilProcess.kill('SIGINT');
-  });
-
-  process.on('SIGTERM', () => {
-    console.log('Received SIGTERM. Terminating Anvil...');
-    anvilProcess.kill('SIGTERM');
-  });
-
   return anvilProcess.pid;
 }
 

--- a/typescript/infra/scripts/run-anvil.ts
+++ b/typescript/infra/scripts/run-anvil.ts
@@ -30,6 +30,7 @@ async function runAnvil(rpcUrl: string) {
       '1',
     ],
     {
+      detached: false,
       stdio: ['ignore', 'ignore', 'ignore'],
     },
   );

--- a/typescript/infra/scripts/run-anvil.ts
+++ b/typescript/infra/scripts/run-anvil.ts
@@ -1,0 +1,70 @@
+import { spawn } from 'child_process';
+
+import { getArgs, withChainRequired } from './agent-utils.js';
+import { getEnvironmentConfig } from './core-utils.js';
+
+async function getRpcUrl() {
+  const { environment, chain } = await withChainRequired(getArgs()).argv;
+  const environmentConfig = getEnvironmentConfig(environment);
+  const registry = await environmentConfig.getRegistry(true);
+
+  const chainMetadata = await registry.getChainMetadata(chain);
+  if (!chainMetadata) {
+    throw Error(`Unsupported chain: ${chain}`);
+  }
+
+  return chainMetadata.rpcUrls[0].http;
+}
+
+async function runAnvil(rpcUrl: string) {
+  const anvilProcess = spawn(
+    'anvil',
+    [
+      '--fork-url',
+      rpcUrl,
+      '--fork-retry-backoff',
+      '3',
+      '--compute-units-per-second',
+      '200',
+      '--gas-price',
+      '1',
+    ],
+    {
+      stdio: ['ignore', 'ignore', 'ignore'],
+    },
+  );
+
+  anvilProcess.on('exit', (code) => {
+    console.log(`Anvil process exited with code ${code}`);
+    process.exit(code || 0);
+  });
+
+  anvilProcess.on('error', (err) => {
+    console.error(`Failed to start Anvil: ${err}`);
+    process.exit(1);
+  });
+
+  process.on('SIGINT', () => {
+    console.log('Received SIGINT. Terminating Anvil...');
+    anvilProcess.kill('SIGINT');
+  });
+
+  process.on('SIGTERM', () => {
+    console.log('Received SIGTERM. Terminating Anvil...');
+    anvilProcess.kill('SIGTERM');
+  });
+
+  return anvilProcess.pid;
+}
+
+async function main() {
+  const rpcUrl = await getRpcUrl();
+  const anvilPid = await runAnvil(rpcUrl);
+
+  console.log(`Anvil PID: ${anvilPid}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -153,8 +153,11 @@ export async function getSecretMetadataOverridesFromGitHubSecrets(
   const chainMetadataOverrides: ChainMap<Partial<ChainMetadata>> = {};
 
   for (const chain of chains) {
-    const rpcUrls =
-      process.env[`${deployEnv.toUpperCase()}_${chain.toUpperCase()}_RPC_URLS`];
+    const rpcUrlsEnv = `${deployEnv.toUpperCase()}_${chain.toUpperCase()}_RPC_URLS`;
+    debugLog(
+      `Looking for secret RPC URLs for chain ${chain} in env: ${rpcUrlsEnv}`,
+    );
+    const rpcUrls = process.env[rpcUrlsEnv];
     if (rpcUrls) {
       debugLog(`Found secret RPC URLs for chain ${chain}`);
       const metadataRpcUrls = rpcUrls

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -29,7 +29,7 @@ export async function fetchProvider(
     throw Error(`Unsupported chain: ${chainName}`);
   }
   const chainId = chainMetadata.chainId;
-  let rpcData = chainMetadata.rpcUrls.map((url) => url.http);
+  const rpcData = chainMetadata.rpcUrls.map((url) => url.http);
   if (rpcData.length === 0) {
     throw Error(`No RPC URLs found for chain: ${chainName}`);
   }
@@ -81,10 +81,12 @@ export async function getRegistryForEnvironment(
   useSecrets: boolean = true,
 ): Promise<IRegistry> {
   let overrides = defaultChainMetadataOverrides;
-  if (useSecrets && !inCIMode()) {
+  if (useSecrets) {
     overrides = objMerge(
       overrides,
-      await getSecretMetadataOverrides(deployEnv, chains),
+      !inCIMode()
+        ? await getSecretMetadataOverrides(deployEnv, chains)
+        : await getSecretMetadataOverridesFromGitHubSecrets(deployEnv, chains),
     );
   }
   const registry = getRegistryWithOverrides(overrides);
@@ -124,6 +126,36 @@ export async function getSecretMetadataOverrides(
     chainMetadataOverrides[chain] = {
       rpcUrls: metadataRpcUrls,
     };
+  }
+
+  return chainMetadataOverrides;
+}
+
+/**
+ * Gets chain metadata overrides from GitHub secrets.
+ * This function is intended to be used when running in CI/CD environments,
+ * where secrets are injected as environment variables.
+ * @param deployEnv The deploy environment.
+ * @param chains The chains to get metadata overrides for.
+ * @returns A partial chain metadata map with the secret overrides.
+ */
+export async function getSecretMetadataOverridesFromGitHubSecrets(
+  deployEnv: DeployEnvironment,
+  chains: string[],
+): Promise<ChainMap<Partial<ChainMetadata>>> {
+  const chainMetadataOverrides: ChainMap<Partial<ChainMetadata>> = {};
+
+  for (const chain of chains) {
+    const rpcUrls =
+      process.env[`${deployEnv.toUpperCase()}_${chain.toUpperCase()}_RPC_URLS`];
+    if (rpcUrls) {
+      const metadataRpcUrls = rpcUrls
+        .split(',')
+        .map((rpcUrl) => ({ http: rpcUrl })) as ChainMetadata['rpcUrls'];
+      chainMetadataOverrides[chain] = {
+        rpcUrls: metadataRpcUrls,
+      };
+    }
   }
 
   return chainMetadataOverrides;

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -8,12 +8,7 @@ import {
   HyperlaneSmartProvider,
   ProviderRetryOptions,
 } from '@hyperlane-xyz/sdk';
-import {
-  ProtocolType,
-  objFilter,
-  objMerge,
-  rootLogger,
-} from '@hyperlane-xyz/utils';
+import { ProtocolType, objFilter, objMerge } from '@hyperlane-xyz/utils';
 
 import { getChain, getRegistryWithOverrides } from '../../config/registry.js';
 import { getSecretRpcEndpoints } from '../agents/index.js';
@@ -25,8 +20,6 @@ export const defaultRetry: ProviderRetryOptions = {
   maxRetries: 6,
   baseRetryDelayMs: 50,
 };
-
-const debugLog = rootLogger.child({ module: 'infra:config:chain' }).debug;
 
 export async function fetchProvider(
   chainName: ChainName,
@@ -154,12 +147,8 @@ export async function getSecretMetadataOverridesFromGitHubSecrets(
 
   for (const chain of chains) {
     const rpcUrlsEnv = `${deployEnv.toUpperCase()}_${chain.toUpperCase()}_RPC_URLS`;
-    debugLog(
-      `Looking for secret RPC URLs for chain ${chain} in env: ${rpcUrlsEnv}`,
-    );
     const rpcUrls = process.env[rpcUrlsEnv];
     if (rpcUrls) {
-      debugLog(`Found secret RPC URLs for chain ${chain}`);
       const metadataRpcUrls = rpcUrls
         .split(',')
         .map((rpcUrl) => ({ http: rpcUrl })) as ChainMetadata['rpcUrls'];

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -8,7 +8,12 @@ import {
   HyperlaneSmartProvider,
   ProviderRetryOptions,
 } from '@hyperlane-xyz/sdk';
-import { ProtocolType, objFilter, objMerge } from '@hyperlane-xyz/utils';
+import {
+  ProtocolType,
+  objFilter,
+  objMerge,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
 
 import { getChain, getRegistryWithOverrides } from '../../config/registry.js';
 import { getSecretRpcEndpoints } from '../agents/index.js';
@@ -20,6 +25,8 @@ export const defaultRetry: ProviderRetryOptions = {
   maxRetries: 6,
   baseRetryDelayMs: 50,
 };
+
+const debugLog = rootLogger.child({ module: 'infra:config:chain' }).debug;
 
 export async function fetchProvider(
   chainName: ChainName,
@@ -149,6 +156,7 @@ export async function getSecretMetadataOverridesFromGitHubSecrets(
     const rpcUrls =
       process.env[`${deployEnv.toUpperCase()}_${chain.toUpperCase()}_RPC_URLS`];
     if (rpcUrls) {
+      debugLog(`Found secret RPC URLs for chain ${chain}`);
       const metadataRpcUrls = rpcUrls
         .split(',')
         .map((rpcUrl) => ({ http: rpcUrl })) as ChainMetadata['rpcUrls'];


### PR DESCRIPTION
### Description

- Use Arbitrum and Optimism private RPCs that are set in Github Secrets for env-test
- Increase env-test timeout to 4 mins for viction
- Adapt fork script so that it create anvil instance by calling a script

### Testing

Manual