### PR TITLE
fix: increase wait time for postgres to be ready in cosmos e2e

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,6 +187,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main' || github.base_ref == 'cli-2.0') || github.event_name == 'merge_group'
     needs: [yarn-build]
     strategy:
+      fail-fast: false
       matrix:
         e2e-type: [cosmwasm, non-cosmwasm]
     steps:

--- a/rust/utils/run-locally/src/cosmos/mod.rs
+++ b/rust/utils/run-locally/src/cosmos/mod.rs
@@ -492,7 +492,7 @@ fn run_locally() {
         .cmd("postgres:14")
         .spawn("SQL", None);
 
-    sleep(Duration::from_secs(10));
+    sleep(Duration::from_secs(15));
 
     log!("Init postgres db...");
     Program::new(concat_path(format!("../../{AGENT_BIN_PATH}"), "init-db"))


### PR DESCRIPTION
## fix: increase wait time for postgres to be ready in cosmos e2e

increase time waiting for postgres to be ready, to reduce this sort of flake https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/10665491633/job/29559169324?pr=4410#step:13:2998 

based on the logs it looks like 10s is just on the border, adding an extra 5s to give headroom


## drive-by fix: disable fail-fast on e2e-matrix

currently only the non-cosmwasm tests are required to merge, therefore we should not fail the entire matrix if the cosmos job fails. This also means we can test that the issues we're seeing with the `cosmwasm` job do not affect the `non-cosmwasm` one.