### PR TITLE
fix: disable fail-fast on e2e-matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,6 +187,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main' || github.base_ref == 'cli-2.0') || github.event_name == 'merge_group'
     needs: [yarn-build]
     strategy:
+      fail-fast: false
       matrix:
         e2e-type: [cosmwasm, non-cosmwasm]
     steps:


### PR DESCRIPTION
fix: disable fail-fast on e2e-matrix

currently only the non-cosmwasm tests are required to merge, therefore we should not fail the entire matrix if the cosmos job fails. This also means we can test that the issues we're seeing with the `cosmwasm` job do not affect the `non-cosmwasm` one.