### PR TITLE
chore: increase env-test timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -410,7 +410,7 @@ jobs:
       MAINNET3_ARBITRUM_RPC_URLS: ${{ secrets.MAINNET3_ARBITRUM_RPC_URLS }}
       MAINNET3_OPTIMISM_RPC_URLS: ${{ secrets.MAINNET3_OPTIMISM_RPC_URLS }}
 
-    timeout-minutes: 4
+    timeout-minutes: 5
     needs: [yarn-build]
     strategy:
       fail-fast: false


### PR DESCRIPTION
chore: increase env-test timeout
- viction is borderline 4mins, so upping it to 5 for more headroom