### PR TITLE
chore: unify rust cache

### DIFF
--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -63,7 +63,7 @@ jobs:
           username: _json_key
           password: ${{ secrets.GCLOUD_SERVICE_KEY }}
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./rust/Dockerfile

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v3-rust"
+          prefix-key: "v3"
+          shared-key: "rust-cache"
           cache-all-crates: true
           workspaces: |
             ./rust
@@ -73,7 +74,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v3-rust"
+          prefix-key: "v3"
+          shared-key: "rust-cache"
           cache-all-crates: true
           workspaces: |
             ./rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v3-rust"
+          cache-all-crates: true
           workspaces: |
             ./rust
       - name: Free disk space
@@ -73,6 +74,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v3-rust"
+          cache-all-crates: true
           workspaces: |
             ./rust
       - name: Free disk space

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,8 +212,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-${{ runner.os }}-rust-cache"
-          shared-key: ${{ matrix.e2e-type }}
+          prefix-key: "v3-rust"
+          cache-all-crates: true
           workspaces: |
             ./rust
 
@@ -300,8 +300,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-${{ runner.os }}-rust-cache"
-          shared-key: "cli-e2e"
+          prefix-key: "v3-rust"
+          cache-all-crates: true
           workspaces: |
             ./rust
 
@@ -363,8 +363,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-${{ runner.os }}-rust-cache"
-          shared-key: "cli-e2e"
+          prefix-key: "v3-rust"
+          cache-all-crates: true
           workspaces: |
             ./rust
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,7 +212,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v3-rust"
+          prefix-key: "v3"
+          shared-key: "rust-cache"
           cache-all-crates: true
           workspaces: |
             ./rust
@@ -300,7 +301,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v3-rust"
+          prefix-key: "v3"
+          shared-key: "rust-cache"
           cache-all-crates: true
           workspaces: |
             ./rust
@@ -363,7 +365,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v3-rust"
+          prefix-key: "v3"
+          shared-key: "rust-cache"
           cache-all-crates: true
           workspaces: |
             ./rust


### PR DESCRIPTION
chore: unify rust cache

- reduces the number of unique caches
- increases cache reuse
- greatly reduces over-aggressive cache eviction
- migrate e2e rust cache to buildjet
	- benefits: https://buildjet.com/for-github-actions/blog/launch-buildjet-cache#buildjet-cache-benefits
	- 20GB/week free cache is 2x what GHA provides

could also consider trying the drop-in npm setup/caching that buildjet could provide