### PR TITLE
chore: migrate CI rust cache to buildjet

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,10 +43,11 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          cache-all-crates: true
-          cache-provider: buildjet
           prefix-key: "v3"
           shared-key: "rust-cache"
+          cache-all-crates: "true"
+          cache-provider: "buildjet"
+          save-if: "false"
           workspaces: |
             ./rust
       - name: Free disk space
@@ -75,10 +76,11 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          cache-all-crates: true
-          cache-provider: buildjet
           prefix-key: "v3"
           shared-key: "rust-cache"
+          cache-all-crates: "true"
+          cache-provider: "buildjet"
+          save-if: "false"
           workspaces: |
             ./rust
       - name: Free disk space

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,9 +43,10 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
+          cache-all-crates: true
+          cache-provider: buildjet
           prefix-key: "v3"
           shared-key: "rust-cache"
-          cache-all-crates: true
           workspaces: |
             ./rust
       - name: Free disk space
@@ -74,9 +75,10 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
+          cache-all-crates: true
+          cache-provider: buildjet
           prefix-key: "v3"
           shared-key: "rust-cache"
-          cache-all-crates: true
           workspaces: |
             ./rust
       - name: Free disk space

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v3-rust"
+          prefix-key: "v3"
+          shared-key: "rust-cache"
           cache-all-crates: true
           workspaces: |
             ./rust
@@ -73,7 +74,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v3-rust"
+          prefix-key: "v3"
+          shared-key: "rust-cache"
           cache-all-crates: true
           workspaces: |
             ./rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v3-rust"
+          cache-all-crates: true
           workspaces: |
             ./rust
       - name: Free disk space
@@ -73,6 +74,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "v3-rust"
+          cache-all-crates: true
           workspaces: |
             ./rust
       - name: Free disk space

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,10 +212,11 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          cache-all-crates: true
-          cache-provider: buildjet
-          prefix-key: "v3"
+          prefix-key: "v3-e2e"
           shared-key: "rust-cache"
+          cache-all-crates: "true"
+          cache-provider: "buildjet"
+          save-if: ${{ matrix.e2e-type == 'non-cosmwasm' }}
           workspaces: |
             ./rust
 
@@ -302,10 +303,10 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          cache-all-crates: true
-          cache-provider: buildjet
           prefix-key: "v3"
           shared-key: "rust-cache"
+          cache-all-crates: "true"
+          cache-provider: "buildjet"
           workspaces: |
             ./rust
 
@@ -367,10 +368,11 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          cache-all-crates: true
-          cache-provider: buildjet
           prefix-key: "v3"
           shared-key: "rust-cache"
+          cache-all-crates: "true"
+          cache-provider: "buildjet"
+          save-if: "false"
           workspaces: |
             ./rust
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,8 +212,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-${{ runner.os }}-rust-cache"
-          shared-key: ${{ matrix.e2e-type }}
+          prefix-key: "v3-rust"
+          cache-all-crates: true
           workspaces: |
             ./rust
 
@@ -300,8 +300,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-${{ runner.os }}-rust-cache"
-          shared-key: "cli-e2e"
+          prefix-key: "v3-rust"
+          cache-all-crates: true
           workspaces: |
             ./rust
 
@@ -363,8 +363,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-${{ runner.os }}-rust-cache"
-          shared-key: "cli-e2e"
+          prefix-key: "v3-rust"
+          cache-all-crates: true
           workspaces: |
             ./rust
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,9 +212,10 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
+          cache-all-crates: true
+          cache-provider: buildjet
           prefix-key: "v3"
           shared-key: "rust-cache"
-          cache-all-crates: true
           workspaces: |
             ./rust
 
@@ -301,9 +302,10 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
+          cache-all-crates: true
+          cache-provider: buildjet
           prefix-key: "v3"
           shared-key: "rust-cache"
-          cache-all-crates: true
           workspaces: |
             ./rust
 
@@ -365,9 +367,10 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
+          cache-all-crates: true
+          cache-provider: buildjet
           prefix-key: "v3"
           shared-key: "rust-cache"
-          cache-all-crates: true
           workspaces: |
             ./rust
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,7 +212,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v3-rust"
+          prefix-key: "v3"
+          shared-key: "rust-cache"
           cache-all-crates: true
           workspaces: |
             ./rust
@@ -300,7 +301,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v3-rust"
+          prefix-key: "v3"
+          shared-key: "rust-cache"
           cache-all-crates: true
           workspaces: |
             ./rust
@@ -363,7 +365,8 @@ jobs:
       - name: rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v3-rust"
+          prefix-key: "v3"
+          shared-key: "rust-cache"
           cache-all-crates: true
           workspaces: |
             ./rust


### PR DESCRIPTION
- chore: migrate CI rust cache to buildjet
- benefits: https://buildjet.com/for-github-actions/blog/launch-buildjet-cache#buildjet-cache-benefits
	- 20GB/week free cache is 2x what GHA provides

could also consider trying the drop-in npm setup/caching that buildjet could provide
