### PR TITLE
chore: increase env-test timeout to 10 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -410,7 +410,7 @@ jobs:
       MAINNET3_ARBITRUM_RPC_URLS: ${{ secrets.MAINNET3_ARBITRUM_RPC_URLS }}
       MAINNET3_OPTIMISM_RPC_URLS: ${{ secrets.MAINNET3_OPTIMISM_RPC_URLS }}
 
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [yarn-build]
     strategy:
       fail-fast: false


### PR DESCRIPTION
chore: increase env-test timeout to 10 minutes
- to give even more headroom in case some tests take longer
- trying to rule out chance of timeouts affecting the success/failure of a test https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/10704561765/job/29678091884?pr=4395#step:6:1210