### PR TITLE
feat: support getting owner ICA on multiple chains

### DIFF
--- a/typescript/infra/config/environments/mainnet3/owners.ts
+++ b/typescript/infra/config/environments/mainnet3/owners.ts
@@ -4,6 +4,7 @@ import { Address, objFilter, objMap } from '@hyperlane-xyz/utils';
 import { getMainnetAddresses } from '../../registry.js';
 
 import { ethereumChainNames } from './chains.js';
+import { supportedChainNames } from './supportedChainNames.js';
 
 export const timelocks: ChainMap<Address | undefined> = {
   arbitrum: '0xAC98b0cD1B64EA4fe133C6D2EDaf842cE5cF4b01',
@@ -59,11 +60,13 @@ export const safes: ChainMap<Address> = {
 export const icaOwnerChain = 'ethereum';
 
 // Found by running:
-// yarn tsx ./scripts/get-owner-ica.ts -e mainnet3 --ownerChain ethereum --destinationChain <chain>
-export const icas: ChainMap<Address> = {
+// yarn tsx ./scripts/get-owner-ica.ts -e mainnet3 --ownerChain ethereum --destinationChains <chain1> <chain2> ...
+export const icas: Partial<
+  Record<(typeof supportedChainNames)[number], Address>
+> = {
   viction: '0x23ed65DE22ac29Ec1C16E75EddB0cE3A187357b4',
   inevm: '0xFDF9EDcb2243D51f5f317b9CEcA8edD2bEEE036e',
-};
+} as const;
 
 export const DEPLOYER = '0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba';
 

--- a/typescript/infra/scripts/get-owner-ica.ts
+++ b/typescript/infra/scripts/get-owner-ica.ts
@@ -1,15 +1,11 @@
-import { ethers } from 'ethers';
-
 import { AccountConfig, InterchainAccount } from '@hyperlane-xyz/sdk';
-import { assert, eqAddress, rootLogger } from '@hyperlane-xyz/utils';
+import { Address, assert, eqAddress } from '@hyperlane-xyz/utils';
 
-import { getSecretRpcEndpoints } from '../src/agents/index.js';
-
-import { getArgs as getEnvArgs, withChainRequired } from './agent-utils.js';
+import { getArgs as getEnvArgs, withChainsRequired } from './agent-utils.js';
 import { getEnvironmentConfig, getHyperlaneCore } from './core-utils.js';
 
 function getArgs() {
-  return withChainRequired(getEnvArgs())
+  return withChainsRequired(getEnvArgs())
     .option('ownerChain', {
       type: 'string',
       description: 'Origin chain where the governing owner lives',
@@ -26,14 +22,14 @@ function getArgs() {
       description: 'Deploys the ICA if it does not exist',
       default: false,
     })
-    .alias('chain', 'destinationChain').argv;
+    .alias('chains', 'destinationChains').argv;
 }
 
 async function main() {
   const {
     environment,
     ownerChain,
-    chain,
+    chains,
     deploy,
     owner: ownerOverride,
   } = await getArgs();
@@ -45,7 +41,7 @@ async function main() {
     throw new Error(`No owner found for ${ownerChain}`);
   }
 
-  rootLogger.info(`Governance owner on ${ownerChain}: ${originOwner}`);
+  console.log(`Governance owner on ${ownerChain}: ${originOwner}`);
 
   const { chainAddresses } = await getHyperlaneCore(environment, multiProvider);
   const ica = InterchainAccount.fromAddressesMap(chainAddresses, multiProvider);
@@ -55,23 +51,22 @@ async function main() {
     owner: originOwner,
   };
 
-  const account = await ica.getAccount(chain, ownerConfig);
+  const results: Record<string, { ICA: Address; Deployed?: string }> = {};
+  for (const chain of chains) {
+    const account = await ica.getAccount(chain, ownerConfig);
+    results[chain] = { ICA: account };
 
-  rootLogger.info(`ICA on ${chain}: ${account}`);
-
-  if (deploy) {
-    // Ensuring the account was deployed
-    const deployedAccount = await ica.deployAccount(chain, ownerConfig);
-    // This shouldn't ever happen, but let's be safe
-    assert(
-      eqAddress(account, deployedAccount),
-      'Fatal mismatch between account and deployed account',
-    );
-
-    rootLogger.info(
-      `ICA deployed or recovered on ${chain}: ${deployedAccount}`,
-    );
+    if (deploy) {
+      const deployedAccount = await ica.deployAccount(chain, ownerConfig);
+      assert(
+        eqAddress(account, deployedAccount),
+        'Fatal mismatch between account and deployed account',
+      );
+      results[chain].Deployed = '✅';
+    }
   }
+
+  console.table(results);
 }
 
 main()


### PR DESCRIPTION
feat: support getting owner ICA on multiple chains
- change `chain` -> `chains` 
- print a cool table of chains and the ICAs on each destination chain for a given owner
- add as stronger type to the ICA address map const

getting ICAS:
<img width="845" alt="image" src="https://github.com/user-attachments/assets/088247fc-f7c9-4219-8c71-2af43e604efc">

getting ICAS with `--deploy`:
<img width="908" alt="image" src="https://github.com/user-attachments/assets/f03a0c75-c906-4822-89be-4c0af3907b11">
