### PR TITLE
feat: try to verify ICAs when deploying

### DIFF
--- a/.changeset/angry-cats-share.md
+++ b/.changeset/angry-cats-share.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Attempt to verify when deploying ICAs

--- a/typescript/sdk/src/deploy/verify/ContractVerifier.ts
+++ b/typescript/sdk/src/deploy/verify/ContractVerifier.ts
@@ -201,8 +201,10 @@ export class ContractVerifier {
       );
     }
 
-    if (responseJson.message !== 'OK') {
+    if (responseJson.message !== 'OK' && response.statusText !== 'OK') {
       let errorMessage;
+
+      this.logger.error({ responseJson, response }, 'Verification failed');
 
       switch (responseJson.result) {
         case ExplorerApiErrors.VERIFICATION_PENDING:
@@ -271,7 +273,7 @@ export class ContractVerifier {
       : this.getImplementationData(chain, input, verificationLogger);
 
     try {
-      const guid: string = await this.submitForm(
+      const guid: string | undefined = await this.submitForm(
         chain,
         input.isProxy
           ? ExplorerApiActions.VERIFY_PROXY
@@ -279,6 +281,10 @@ export class ContractVerifier {
         verificationLogger,
         data,
       );
+
+      if (!guid) {
+        throw new Error(`GUID is undefined.`);
+      }
 
       verificationLogger.trace(
         { guid },

--- a/typescript/sdk/src/middleware/account/InterchainAccount.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.ts
@@ -193,22 +193,6 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
       this.logger.error({ error }, 'Failed to verify implementation contract');
       return;
     }
-
-    // Verify the proxy contract
-    try {
-      await this.contractVerifier.verifyContract(
-        destinationChain,
-        {
-          name: 'MinimalProxy',
-          address: destinationAccount,
-          isProxy: true,
-          expectedimplementation: implementationAddress,
-        },
-        this.logger,
-      );
-    } catch (error) {
-      this.logger.error({ error }, 'Failed to verify proxy contract');
-    }
   }
 
   // meant for ICA governance to return the populatedTx


### PR DESCRIPTION
feat: try to verify ICAs when deploying
- required some reverse engineering and reading of EIP-1167
- drive-by fixes to verifier
- drive-by update to infra get-owner-ica script
	- defaults to all supported chains in an env