### PR TITLE
chore: revert to using a 10 min relayer `CONFIRM_DELAY`

### DIFF
--- a/rust/agents/relayer/src/msg/pending_message.rs
+++ b/rust/agents/relayer/src/msg/pending_message.rs
@@ -28,7 +28,7 @@ pub const CONFIRM_DELAY: Duration = if cfg!(any(test, feature = "test-utils")) {
     Duration::from_secs(5)
 } else {
     // Wait 1 min after submitting the message before confirming in normal/production mode
-    Duration::from_secs(60)
+    Duration::from_secs(60 * 10)
 };
 
 /// The message context contains the links needed to submit a message. Each


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
