### PR TITLE
fix: temporarily disable dry-run in cli-advanced-e2e

### DIFF
--- a/typescript/cli/ci-advanced-test.sh
+++ b/typescript/cli/ci-advanced-test.sh
@@ -25,10 +25,10 @@ _main() {
 
     DEPLOYER=$(cast rpc eth_accounts | jq -r '.[0]');
 
-    run_hyperlane_deploy_core_dry_run;
-    run_hyperlane_deploy_warp_dry_run;
-
-    reset_anvil;
+    # TODO: fix `resetFork` after a dry-run. Related: https://github.com/foundry-rs/foundry/pull/8768
+    # run_hyperlane_deploy_core_dry_run;
+    # run_hyperlane_deploy_warp_dry_run;
+    # reset_anvil;
 
     run_hyperlane_deploy_core;
     run_hyperlane_deploy_warp;


### PR DESCRIPTION
fix: temporarily disable dry-run in cli-advanced-e2e
- until we fix the problem with our call to `resetFork` after a dry-run deployment
- our CI uses the latest nightly foundry releases, and this recent PR https://github.com/foundry-rs/foundry/pull/8768 has broken the fork reset. Ironically, this PR actually is a bugfix for something that was broken that we relied on.

Examples of failures:
- https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/10772795435/job/29873480020?pr=4441#step:12:133
- https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/10751285630/job/29818541086?pr=4448

Note that the `pi_with_core_chain` tests don't fail because they do not do a dry run