### PR TITLE
fix: compare to existing checkpoint and overwrite

### DIFF
--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -237,9 +237,18 @@ impl ValidatorSubmitter {
             .fetch_checkpoint(checkpoint.index)
             .await?;
         if existing.is_some() {
-            debug!(index = checkpoint.index, "Checkpoint already submitted");
-            return Ok(());
+            if existing.value == checkpoint {
+                debug!(index = checkpoint.index, "Checkpoint already submitted");
+                return Ok(());
+            }
+
+            error!(
+                existing = existing.value,
+                ?checkpoint,
+                "Existing checkpoint does not match new checkpoint"
+            );
         }
+
         let signed_checkpoint = self.signer.sign(checkpoint).await?;
         self.checkpoint_syncer
             .write_checkpoint(&signed_checkpoint)


### PR DESCRIPTION
### Description

Validator will now compare to existing checkpoints on the S3 bucket and overwrite them if they do not match. This may help us achieve a quorum on messages following incorrect/fraudulent checkpoints.

### Backward compatibility

Yes

### Testing

TODO