### PR TITLE
feat: interchain account mirror

### DIFF
--- a/solidity/contracts/middleware/InterchainAccountMirror.sol
+++ b/solidity/contracts/middleware/InterchainAccountMirror.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+// ============ Internal Imports ============
+import {TypeCasts} from "../libs/TypeCasts.sol";
+import {InterchainAccountRouter} from "./InterchainAccountRouter.sol";
+import {CallLib} from "./libs/Call.sol";
+
+/**
+ * Format of data:
+ * [   0: ????] destination call data
+ * [ -72:  -40] destination call value
+ * [ -40:  -20] destination ICA router
+ * [ -20:     ] destination ISM
+ */
+library InterchainAccountMirrorCalldata {
+    function encode(
+        bytes calldata _data,
+        uint256 _value,
+        address _icaRouter,
+        address _ism
+    ) internal pure returns (bytes memory) {
+        return abi.encodePacked(_data, _value, _icaRouter, _ism);
+    }
+
+    function destinationValue(
+        bytes calldata data
+    ) internal pure returns (uint256) {
+        return uint256(bytes32(data[data.length - 72:data.length - 40]));
+    }
+
+    function destinationCalldata(
+        bytes calldata data
+    ) internal pure returns (bytes calldata) {
+        return data[:data.length - 40];
+    }
+
+    function destinationIcaRouter(
+        bytes calldata data
+    ) internal pure returns (address) {
+        return address(bytes20(data[data.length - 40:]));
+    }
+
+    function destinationIsm(
+        bytes calldata data
+    ) internal pure returns (address) {
+        return address(bytes20(data[data.length - 20:]));
+    }
+}
+
+contract InterchainAccountMirror {
+    using InterchainAccountMirrorCalldata for bytes;
+    using TypeCasts for address;
+
+    uint32 immutable destination;
+    address immutable target;
+
+    address immutable deployer;
+
+    InterchainAccountRouter immutable icaRouter;
+
+    constructor(
+        uint32 _destination,
+        address _target,
+        InterchainAccountRouter _icaRouter
+    ) {
+        deployer = msg.sender;
+        destination = _destination;
+        target = _target;
+        icaRouter = _icaRouter;
+    }
+
+    modifier onlyDeployer() {
+        require(msg.sender == deployer, "sender not deployer");
+        _;
+    }
+
+    // solhint-disable-next-line no-complex-fallback
+    fallback() external payable onlyDeployer {
+        CallLib.Call[] memory calls = new CallLib.Call[](1);
+        calls[0] = CallLib.Call({
+            to: target.addressToBytes32(),
+            value: msg.data.destinationValue(),
+            data: msg.data.destinationCalldata()
+        });
+        icaRouter.callRemoteWithOverrides{value: msg.value}(
+            destination,
+            msg.data.destinationIcaRouter().addressToBytes32(),
+            msg.data.destinationIsm().addressToBytes32(),
+            calls
+        );
+    }
+}

--- a/solidity/contracts/middleware/InterchainAccountMirror.sol
+++ b/solidity/contracts/middleware/InterchainAccountMirror.sol
@@ -52,31 +52,32 @@ contract InterchainAccountMirror {
     using InterchainAccountMirrorCalldata for bytes;
     using TypeCasts for address;
 
+    address immutable owner;
+
     uint32 immutable destination;
     address immutable target;
-
-    address immutable deployer;
 
     InterchainAccountRouter immutable icaRouter;
 
     constructor(
+        address _owner,
         uint32 _destination,
         address _target,
         InterchainAccountRouter _icaRouter
     ) {
-        deployer = msg.sender;
+        owner = _owner;
         destination = _destination;
         target = _target;
         icaRouter = _icaRouter;
     }
 
-    modifier onlyDeployer() {
-        require(msg.sender == deployer, "sender not deployer");
+    modifier onlyOwner() {
+        require(msg.sender == owner, "sender not owner");
         _;
     }
 
     // solhint-disable-next-line no-complex-fallback
-    fallback() external payable onlyDeployer {
+    fallback() external payable onlyOwner {
         CallLib.Call[] memory calls = new CallLib.Call[](1);
         calls[0] = CallLib.Call({
             to: target.addressToBytes32(),

--- a/solidity/contracts/middleware/InterchainAccountMirror.sol
+++ b/solidity/contracts/middleware/InterchainAccountMirror.sol
@@ -7,9 +7,6 @@ import {InterchainAccountRouter} from "./InterchainAccountRouter.sol";
 import {CallLib} from "./libs/Call.sol";
 import {InterchainAccountMirrorCalldata} from "./libs/InterchainAccountMirrorCalldata.sol";
 
-// ============ External Imports ============
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-
 contract InterchainAccountMirror {
     using InterchainAccountMirrorCalldata for bytes;
 

--- a/solidity/contracts/middleware/InterchainAccountMirror.sol
+++ b/solidity/contracts/middleware/InterchainAccountMirror.sol
@@ -5,48 +5,7 @@ pragma solidity ^0.8.13;
 import {TypeCasts} from "../libs/TypeCasts.sol";
 import {InterchainAccountRouter} from "./InterchainAccountRouter.sol";
 import {CallLib} from "./libs/Call.sol";
-
-/**
- * Format of data:
- * [   0: ????] destination call data
- * [ -72:  -40] destination call value
- * [ -40:  -20] destination ICA router
- * [ -20:     ] destination ISM
- */
-library InterchainAccountMirrorCalldata {
-    function encode(
-        bytes calldata _data,
-        uint256 _value,
-        address _icaRouter,
-        address _ism
-    ) internal pure returns (bytes memory) {
-        return abi.encodePacked(_data, _value, _icaRouter, _ism);
-    }
-
-    function destinationValue(
-        bytes calldata data
-    ) internal pure returns (uint256) {
-        return uint256(bytes32(data[data.length - 72:data.length - 40]));
-    }
-
-    function destinationCalldata(
-        bytes calldata data
-    ) internal pure returns (bytes calldata) {
-        return data[:data.length - 40];
-    }
-
-    function destinationIcaRouter(
-        bytes calldata data
-    ) internal pure returns (address) {
-        return address(bytes20(data[data.length - 40:]));
-    }
-
-    function destinationIsm(
-        bytes calldata data
-    ) internal pure returns (address) {
-        return address(bytes20(data[data.length - 20:]));
-    }
-}
+import {InterchainAccountMirrorCalldata} from "./libs/InterchainAccountMirrorCalldata.sol";
 
 contract InterchainAccountMirror {
     using InterchainAccountMirrorCalldata for bytes;

--- a/solidity/contracts/middleware/InterchainAccountMirrorFactory.sol
+++ b/solidity/contracts/middleware/InterchainAccountMirrorFactory.sol
@@ -5,15 +5,16 @@ pragma solidity ^0.8.13;
 import {InterchainAccountMirror} from "./InterchainAccountMirror.sol";
 import {InterchainAccountRouter} from "./InterchainAccountRouter.sol";
 
+// ============ External Imports ============
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
 contract InterchainAccountMirrorFactory {
     InterchainAccountRouter immutable icaRouter;
 
     event InterchainAccountMirrorDeployed(
-        address indexed owner,
         uint32 indexed destination,
-        address indexed target,
+        bytes32 indexed target,
+        address indexed owner,
         address mirror
     );
 
@@ -21,25 +22,24 @@ contract InterchainAccountMirrorFactory {
         icaRouter = InterchainAccountRouter(_icaRouter);
     }
 
-    function mirror(
+    function deployMirror(
+        address owner,
         uint32 destination,
-        address target
+        bytes32 target
     ) external returns (address mirror) {
-        bytes32 salt = keccak256(
-            abi.encodePacked(msg.sender, destination, target)
-        );
+        bytes32 salt = keccak256(abi.encodePacked(owner, destination, target));
         mirror = address(
             new InterchainAccountMirror{salt: salt}(
-                msg.sender,
+                icaRouter,
                 destination,
                 target,
-                icaRouter
+                owner
             )
         );
         emit InterchainAccountMirrorDeployed(
-            msg.sender,
             destination,
             target,
+            owner,
             mirror
         );
     }

--- a/solidity/contracts/middleware/InterchainAccountMirrorFactory.sol
+++ b/solidity/contracts/middleware/InterchainAccountMirrorFactory.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+// ============ Internal Imports ============
+import {InterchainAccountMirror} from "./InterchainAccountMirror.sol";
+import {InterchainAccountRouter} from "./InterchainAccountRouter.sol";
+
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
+
+contract InterchainAccountMirrorFactory {
+    InterchainAccountRouter immutable icaRouter;
+
+    event InterchainAccountMirrorDeployed(
+        address indexed owner,
+        uint32 indexed destination,
+        address indexed target,
+        address mirror
+    );
+
+    constructor(address _icaRouter) {
+        icaRouter = InterchainAccountRouter(_icaRouter);
+    }
+
+    function mirror(
+        uint32 destination,
+        address target
+    ) external returns (address mirror) {
+        bytes32 salt = keccak256(
+            abi.encodePacked(msg.sender, destination, target)
+        );
+        mirror = address(
+            new InterchainAccountMirror{salt: salt}(
+                msg.sender,
+                destination,
+                target,
+                icaRouter
+            )
+        );
+        emit InterchainAccountMirrorDeployed(
+            msg.sender,
+            destination,
+            target,
+            mirror
+        );
+    }
+}

--- a/solidity/contracts/middleware/InterchainAccountMirrorFactory.sol
+++ b/solidity/contracts/middleware/InterchainAccountMirrorFactory.sol
@@ -26,9 +26,9 @@ contract InterchainAccountMirrorFactory {
         address owner,
         uint32 destination,
         bytes32 target
-    ) external returns (address mirror) {
+    ) external returns (address payable mirror) {
         bytes32 salt = keccak256(abi.encodePacked(owner, destination, target));
-        mirror = address(
+        mirror = payable(
             new InterchainAccountMirror{salt: salt}(
                 icaRouter,
                 destination,

--- a/solidity/contracts/middleware/libs/InterchainAccountMirrorCalldata.sol
+++ b/solidity/contracts/middleware/libs/InterchainAccountMirrorCalldata.sol
@@ -4,41 +4,45 @@ pragma solidity ^0.8.13;
 /**
  * Format of data:
  * [   0: ????] destination call data
- * [ -72:  -40] destination call value
- * [ -40:  -20] destination ICA router
- * [ -20:     ] destination ISM
+ * [ -96:  -64] destination call value
+ * [ -64:  -32] destination ICA router
+ * [ -32:     ] destination ISM
  */
 library InterchainAccountMirrorCalldata {
+    uint32 internal constant VALUE_OFFSET = 96;
+    uint32 internal constant ICA_ROUTER_OFFSET = 64;
+    uint32 internal constant ISM_OFFSET = 32;
+
     function encode(
         bytes calldata _data,
         uint256 _value,
-        address _icaRouter,
-        address _ism
+        bytes32 _icaRouter,
+        bytes32 _ism
     ) internal pure returns (bytes memory) {
         return abi.encodePacked(_data, _value, _icaRouter, _ism);
-    }
-
-    function destinationValue(
-        bytes calldata data
-    ) internal pure returns (uint256) {
-        return uint256(bytes32(data[data.length - 72:data.length - 40]));
     }
 
     function destinationCalldata(
         bytes calldata data
     ) internal pure returns (bytes calldata) {
-        return data[:data.length - 40];
+        return data[:data.length - VALUE_OFFSET];
+    }
+
+    function destinationValue(
+        bytes calldata data
+    ) internal pure returns (uint256) {
+        return uint256(bytes32(data[data.length - VALUE_OFFSET:]));
     }
 
     function destinationIcaRouter(
         bytes calldata data
-    ) internal pure returns (address) {
-        return address(bytes20(data[data.length - 40:]));
+    ) internal pure returns (bytes32) {
+        return bytes32(data[data.length - ICA_ROUTER_OFFSET:]);
     }
 
     function destinationIsm(
         bytes calldata data
-    ) internal pure returns (address) {
-        return address(bytes20(data[data.length - 20:]));
+    ) internal pure returns (bytes32) {
+        return bytes32(data[data.length - ISM_OFFSET:]);
     }
 }

--- a/solidity/contracts/middleware/libs/InterchainAccountMirrorCalldata.sol
+++ b/solidity/contracts/middleware/libs/InterchainAccountMirrorCalldata.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+/**
+ * Format of data:
+ * [   0: ????] destination call data
+ * [ -72:  -40] destination call value
+ * [ -40:  -20] destination ICA router
+ * [ -20:     ] destination ISM
+ */
+library InterchainAccountMirrorCalldata {
+    function encode(
+        bytes calldata _data,
+        uint256 _value,
+        address _icaRouter,
+        address _ism
+    ) internal pure returns (bytes memory) {
+        return abi.encodePacked(_data, _value, _icaRouter, _ism);
+    }
+
+    function destinationValue(
+        bytes calldata data
+    ) internal pure returns (uint256) {
+        return uint256(bytes32(data[data.length - 72:data.length - 40]));
+    }
+
+    function destinationCalldata(
+        bytes calldata data
+    ) internal pure returns (bytes calldata) {
+        return data[:data.length - 40];
+    }
+
+    function destinationIcaRouter(
+        bytes calldata data
+    ) internal pure returns (address) {
+        return address(bytes20(data[data.length - 40:]));
+    }
+
+    function destinationIsm(
+        bytes calldata data
+    ) internal pure returns (address) {
+        return address(bytes20(data[data.length - 20:]));
+    }
+}

--- a/solidity/test/InterchainAccountMirror.t.sol
+++ b/solidity/test/InterchainAccountMirror.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {InterchainAccountMirrorCalldata} from "../contracts/middleware/libs/InterchainAccountMirrorCalldata.sol";
+import {InterchainAccountMirror} from "../contracts/middleware/InterchainAccountMirror.sol";
+import {InterchainAccountMirrorFactory} from "../contracts/middleware/InterchainAccountMirrorFactory.sol";
+import {InterchainAccountRouter} from "../contracts/middleware/InterchainAccountRouter.sol";
+import {CallLib} from "../contracts/middleware/libs/Call.sol";
+
+contract InterchainAccountMirrorTest is Test {
+    event InterchainAccountMirrorDeployed(
+        uint32 indexed destination,
+        bytes32 indexed target,
+        address indexed owner,
+        address mirror
+    );
+
+    address icaRouter = address(0x32);
+
+    InterchainAccountMirrorFactory icaMirrorFactory;
+
+    function setUp() public {
+        icaMirrorFactory = new InterchainAccountMirrorFactory(icaRouter);
+    }
+
+    function test(
+        address owner,
+        bytes calldata data,
+        uint256 value,
+        uint32 destination,
+        bytes32 target,
+        bytes32 destinationIcaRouter,
+        bytes32 destinationIsmAddress
+    ) public payable {
+        vm.expectEmit(true, true, true, false);
+        emit InterchainAccountMirrorDeployed(
+            destination,
+            target,
+            owner,
+            address(0x0) // assume CREATE2 works as expected
+        );
+        address payable mirror = icaMirrorFactory.deployMirror(
+            owner,
+            destination,
+            target
+        );
+
+        // EvmError: Create Collision
+        vm.expectRevert();
+        icaMirrorFactory.deployMirror(owner, destination, target);
+
+        bytes memory callData = InterchainAccountMirrorCalldata.encode(
+            data,
+            value,
+            destinationIcaRouter,
+            destinationIsmAddress
+        );
+
+        vm.expectRevert("InterchainAccountMirror: only owner");
+        mirror.call(callData);
+
+        CallLib.Call[] memory calls = new CallLib.Call[](1);
+        calls[0] = CallLib.Call(target, value, data);
+
+        bytes memory expectedCallData = abi.encodeWithSignature(
+            "callRemoteWithOverrides(uint32,bytes32,bytes32,(bytes32,uint256,bytes)[])",
+            destination,
+            destinationIcaRouter,
+            destinationIsmAddress,
+            calls
+        );
+        vm.prank(owner);
+        vm.expectCall(icaRouter, msg.value, expectedCallData);
+        mirror.call{value: msg.value}(callData);
+    }
+}

--- a/solidity/test/InterchainAccountMirror.t.sol
+++ b/solidity/test/InterchainAccountMirror.t.sol
@@ -34,12 +34,13 @@ contract InterchainAccountMirrorTest is Test {
         bytes32 destinationIcaRouter,
         bytes32 destinationIsmAddress
     ) public payable {
+        // do not match against fourth argument (mirror address)
         vm.expectEmit(true, true, true, false);
         emit InterchainAccountMirrorDeployed(
             destination,
             target,
             owner,
-            address(0x0) // assume CREATE2 works as expected
+            address(0x0) // no need to assert CREATE2 derivation correctness
         );
         address payable mirror = icaMirrorFactory.deployMirror(
             owner,


### PR DESCRIPTION
### Description

See [(internal) notion spec](https://www.notion.so/hyperlanexyz/Governance-Contracts-Spec-Internal-b93e36ac8bd9472b8aa60be6dac7975a?pvs=4) for motivation. 

Implements an origin-side "mirror" to Interchain Accounts that exposes a "transparent" local address space interface to a target contract on a destination chain. 

Introduces a factory for deploying these mirrors with Create2 for committing to a specific `destination`, `target`, and `owner` tuple.

Does not use OpenZeppelin `Ownable` for immutable Create2 derivation on `owner`.

### Drive-by changes

None

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

Yes

### Testing

Unit Tests