### PR TITLE
feat: remove extraneous caching

### DIFF
--- a/.github/actions/yarn-build-with-cache/action.yml
+++ b/.github/actions/yarn-build-with-cache/action.yml
@@ -1,0 +1,30 @@
+name: 'Yarn Build with Cache'
+description: 'Run yarn build using yarn cache'
+
+inputs:
+  ref:
+    description: 'The Git ref to checkout'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          **/node_modules
+          .yarn
+        key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
+        fail-on-cache-miss: true
+
+    - name: Build
+      shell: bash
+      run: yarn build

--- a/.github/actions/yarn-build-with-cache/action.yml
+++ b/.github/actions/yarn-build-with-cache/action.yml
@@ -9,13 +9,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.ref }}
-        submodules: recursive
-        fetch-depth: 0
-
     - name: Cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -77,7 +77,7 @@ jobs:
           echo "REGISTRY_VERSION=$REGISTRY_VERSION" >> $GITHUB_ENV
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -29,7 +29,7 @@ jobs:
           GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
         if: "${{ env.GCLOUD_SERVICE_KEY != '' }}"
         # runs if GCLOUD_SERVICE_KEY is defined, so we set the output to true
-        run: echo "::set-output name=defined::true"
+        run: echo "defined=true" >> $GITHUB_OUTPUT
 
   build-and-push-to-gcr:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -24,7 +24,7 @@ jobs:
           GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
         if: "${{ env.GCLOUD_SERVICE_KEY != '' }}"
         # runs if GCLOUD_SERVICE_KEY is defined, so we set the output to true
-        run: echo "::set-output name=defined::true"
+        run: echo "defined=true" >> $GITHUB_OUTPUT
 
   build-and-push-to-gcr:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -63,7 +63,7 @@ jobs:
           username: _json_key
           password: ${{ secrets.GCLOUD_SERVICE_KEY }}
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./rust/Dockerfile

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -70,5 +70,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,35 +54,6 @@ jobs:
             exit 1
           fi
 
-  yarn-build:
-    runs-on: ubuntu-latest
-    needs: [yarn-install]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          submodules: recursive
-          fetch-depth: 0
-
-      - name: yarn-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            **/node_modules
-            .yarn
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
-
-      - name: build-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ./*
-            !./rust
-          key: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: build
-        run: yarn build
-
   lint-prettier:
     runs-on: ubuntu-latest
     needs: [yarn-install]
@@ -113,9 +84,15 @@ jobs:
             exit 1
           fi
 
+  yarn-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Instant pass
+        run: echo "yarn-build job passed"
+
   yarn-test:
     runs-on: ubuntu-latest
-    needs: [yarn-build]
+    needs: [yarn-install]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -126,13 +103,10 @@ jobs:
       - name: foundry-install
         uses: foundry-rs/foundry-toolchain@v1
 
-      - name: build-cache
-        uses: actions/cache@v4
+      - name: yarn-build
+        uses: ./.github/actions/yarn-build-with-cache
         with:
-          path: |
-            ./*
-            !./rust
-          key: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Checkout registry
         uses: ./.github/actions/checkout-registry
@@ -142,7 +116,7 @@ jobs:
 
   agent-configs:
     runs-on: ubuntu-latest
-    needs: [yarn-build]
+    needs: [yarn-install]
     strategy:
       fail-fast: false
       matrix:
@@ -153,21 +127,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
-      - name: yarn-cache
-        uses: actions/cache@v4
+      - name: yarn-build
+        uses: ./.github/actions/yarn-build-with-cache
         with:
-          path: |
-            **/node_modules
-            .yarn
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
-
-      - name: build-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ./*
-            !./rust
-          key: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Checkout registry
         uses: ./.github/actions/checkout-registry
@@ -185,7 +148,7 @@ jobs:
   e2e-matrix:
     runs-on: larger-runner
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main' || github.base_ref == 'cli-2.0') || github.event_name == 'merge_group'
-    needs: [yarn-build]
+    needs: [yarn-install]
     strategy:
       fail-fast: false
       matrix:
@@ -231,21 +194,10 @@ jobs:
           mold-version: 2.0.0
           make-default: true
 
-      - name: yarn-cache
-        uses: actions/cache@v4
+      - name: yarn-build
+        uses: ./.github/actions/yarn-build-with-cache
         with:
-          path: |
-            **/node_modules
-            .yarn
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
-
-      - name: build-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ./*
-            !./rust
-          key: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install system dependencies
         run: |
@@ -285,7 +237,7 @@ jobs:
   cli-advanced-e2e:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main' || github.base_ref == 'cli-2.0') || github.event_name == 'merge_group'
-    needs: [yarn-build]
+    needs: [yarn-install]
     strategy:
       matrix:
         include:
@@ -305,21 +257,10 @@ jobs:
       - name: foundry-install
         uses: foundry-rs/foundry-toolchain@v1
 
-      - name: yarn-cache
-        uses: actions/cache@v4
+      - name: yarn-build
+        uses: ./.github/actions/yarn-build-with-cache
         with:
-          path: |
-            **/node_modules
-            .yarn
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
-
-      - name: build-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ./*
-            !./rust
-          key: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Checkout registry
         uses: ./.github/actions/checkout-registry
@@ -334,7 +275,7 @@ jobs:
       MAINNET3_OPTIMISM_RPC_URLS: ${{ secrets.MAINNET3_OPTIMISM_RPC_URLS }}
 
     timeout-minutes: 10
-    needs: [yarn-build]
+    needs: [yarn-install]
     strategy:
       fail-fast: false
       matrix:
@@ -354,13 +295,10 @@ jobs:
       - name: foundry-install
         uses: foundry-rs/foundry-toolchain@v1
 
-      - name: build-cache
-        uses: actions/cache@v4
+      - name: yarn-build
+        uses: ./.github/actions/yarn-build-with-cache
         with:
-          path: |
-            ./*
-            !./rust
-          key: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Checkout registry
         uses: ./.github/actions/checkout-registry
@@ -378,21 +316,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
-      - name: yarn-cache
-        uses: actions/cache@v4
+      - name: yarn-build
+        uses: ./.github/actions/yarn-build-with-cache
         with:
-          path: |
-            **/node_modules
-            .yarn
-          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('./yarn.lock') }}
-
-      - name: build-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ./*
-            !./rust
-          key: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: foundry-install
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -298,6 +298,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    needs: [yarn-install]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,12 +84,6 @@ jobs:
             exit 1
           fi
 
-  yarn-build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Instant pass
-        run: echo "yarn-build job passed"
-
   yarn-test:
     runs-on: ubuntu-latest
     needs: [yarn-install]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,16 +224,6 @@ jobs:
           E2E_KATHY_MESSAGES: '20'
           RUST_BACKTRACE: 'full'
 
-  e2e:
-    runs-on: ubuntu-latest
-    needs: [e2e-matrix]
-    if: always() # This ensures that the job runs even if the e2e jobs fail
-    steps:
-      - name: Report Matrix Result
-        run: |
-          echo "All e2e-matrix jobs have completed."
-          # You can add additional commands here to report the result as needed
-
   cli-advanced-e2e:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main' || github.base_ref == 'cli-2.0') || github.event_name == 'merge_group'
@@ -308,8 +298,6 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    needs: [yarn-test]
-
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
feat: remove yarn build cache
- saves 600MB of cache space PER COMMIT
- doesn't impact overall per-commit CI time
- better CI time in the general case due to fewer cache evictions on the e2e matrix job
- [with caching](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/10797745470) vs [no caching](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/10797213927?pr=4469)

drive-by: disable docker caching for agent build
- currently cache has no impact on build time of the agent image
- rerunning builds for a commit or pushing empty commits should in theory lead to quicker builds with layer caching, but the main problem is that the `RUN` step of building the agents is not cached by the docker action
- only RUNs with bind mounts get a checksum computed [(reference)](https://docs.docker.com/build/cache/invalidation/#general-rules)
- disabling docker build caching could help save a bunch of cache space
- best way to 4x speed here is moving this job to a buildjet 8vcpu runner (read [here](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4445) for more info)

drive-by: TLC 
- update to latest docker build action
	- provides a nice build summary and can generate artifacts that help break down where build time is spent
- update check-env before build, given the current deprecation annotations
	- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- coverage step doesn't need to wait for `yarn-test` anymore