### PR TITLE
fix: add replay protection to `AbstractMessageIdAuthHook` and `AbstractMessageIdAuthorizedIsm`

### DIFF
--- a/solidity/contracts/hooks/libs/AbstractMessageIdAuthHook.sol
+++ b/solidity/contracts/hooks/libs/AbstractMessageIdAuthHook.sol
@@ -41,6 +41,10 @@ abstract contract AbstractMessageIdAuthHook is
     // Domain of chain on which the ISM is deployed
     uint32 public immutable destinationDomain;
 
+    // ============ Public Storage ============
+
+    mapping(bytes32 => bool) private processedMessages;
+
     // ============ Constructor ============
 
     constructor(
@@ -86,6 +90,12 @@ abstract contract AbstractMessageIdAuthHook is
             AbstractMessageIdAuthorizedIsm.verifyMessageId,
             id
         );
+        require(
+            !processedMessages[id],
+            "AbstractMessageIdAuthHook: message already processed"
+        );
+
+        processedMessages[id] = true;
         _sendMessageId(metadata, payload);
     }
 

--- a/solidity/contracts/hooks/libs/AbstractMessageIdAuthHook.sol
+++ b/solidity/contracts/hooks/libs/AbstractMessageIdAuthHook.sol
@@ -43,6 +43,7 @@ abstract contract AbstractMessageIdAuthHook is
 
     // ============ Public Storage ============
 
+    // for replay protection, each message id should be processed only once
     mapping(bytes32 => bool) private processedMessages;
 
     // ============ Constructor ============

--- a/solidity/contracts/hooks/libs/AbstractPostDispatchHook.sol
+++ b/solidity/contracts/hooks/libs/AbstractPostDispatchHook.sol
@@ -26,8 +26,6 @@ abstract contract AbstractPostDispatchHook is IPostDispatchHook {
     using Message for bytes;
     using StandardHookMetadata for bytes;
 
-    mapping(bytes32 => bool) private processedMessages;
-
     // ============ External functions ============
 
     /// @inheritdoc IPostDispatchHook
@@ -48,14 +46,6 @@ abstract contract AbstractPostDispatchHook is IPostDispatchHook {
             supportsMetadata(metadata),
             "AbstractPostDispatchHook: invalid metadata variant"
         );
-
-        // replay protection
-        bytes32 messageId = message.id();
-        require(
-            !processedMessages[messageId],
-            "AbstractPostDispatchHook: message already processed"
-        );
-        processedMessages[messageId] = true;
 
         _postDispatch(metadata, message);
     }

--- a/solidity/contracts/hooks/libs/AbstractPostDispatchHook.sol
+++ b/solidity/contracts/hooks/libs/AbstractPostDispatchHook.sol
@@ -14,7 +14,6 @@ pragma solidity >=0.8.0;
 @@@@@@@@@       @@@@@@@@*/
 
 // ============ Internal Imports ============
-import {Message} from "../../libs/Message.sol";
 import {StandardHookMetadata} from "./StandardHookMetadata.sol";
 import {IPostDispatchHook} from "../../interfaces/hooks/IPostDispatchHook.sol";
 
@@ -23,7 +22,6 @@ import {IPostDispatchHook} from "../../interfaces/hooks/IPostDispatchHook.sol";
  * @notice Abstract post dispatch hook supporting the current global hook metadata variant.
  */
 abstract contract AbstractPostDispatchHook is IPostDispatchHook {
-    using Message for bytes;
     using StandardHookMetadata for bytes;
 
     // ============ External functions ============
@@ -46,7 +44,6 @@ abstract contract AbstractPostDispatchHook is IPostDispatchHook {
             supportsMetadata(metadata),
             "AbstractPostDispatchHook: invalid metadata variant"
         );
-
         _postDispatch(metadata, message);
     }
 

--- a/solidity/contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol
+++ b/solidity/contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol
@@ -123,6 +123,11 @@ abstract contract AbstractMessageIdAuthorizedIsm is
             msg.value < 2 ** VERIFIED_MASK_INDEX,
             "AbstractMessageIdAuthorizedIsm: msg.value must be less than 2^255"
         );
+        uint256 currentValue = verifiedMessages[messageId];
+        require(
+            !currentValue.isBitSet(VERIFIED_MASK_INDEX),
+            "AbstractMessageIdAuthorizedIsm: message already verified"
+        );
 
         verifiedMessages[messageId] = msg.value.setBit(VERIFIED_MASK_INDEX);
         emit ReceivedMessage(messageId);

--- a/solidity/contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol
+++ b/solidity/contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol
@@ -123,9 +123,8 @@ abstract contract AbstractMessageIdAuthorizedIsm is
             msg.value < 2 ** VERIFIED_MASK_INDEX,
             "AbstractMessageIdAuthorizedIsm: msg.value must be less than 2^255"
         );
-        uint256 currentValue = verifiedMessages[messageId];
         require(
-            !currentValue.isBitSet(VERIFIED_MASK_INDEX),
+            !isVerified(messageId),
             "AbstractMessageIdAuthorizedIsm: message already verified"
         );
 

--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -132,9 +132,6 @@ contract ArbL2ToL1IsmTest is Test {
 
     function test_postDispatch_revertsWhen_replayed() public {
         deployAll();
-
-        // bytes memory encodedHookData = abi.encodeCall(AbstractMessageIdAuthorizedIsm.verifyMessageId, (messageId));
-
         l2Mailbox.updateLatestDispatchedId(messageId);
 
         // First legitimate call
@@ -152,7 +149,6 @@ contract ArbL2ToL1IsmTest is Test {
             AbstractMessageIdAuthorizedIsm.verifyMessageId,
             (messageId)
         );
-
         uint256 initialValue = 1 ether;
 
         // first legitimate verification
@@ -213,8 +209,7 @@ contract ArbL2ToL1IsmTest is Test {
         vm.deal(address(arbBridge), 1 ether);
         arbBridge.setL2ToL1Sender(address(hook));
         assertTrue(ism.verify(encodedOutboxTxMetadata, encodedMessage));
-
-        assertTrue(ism.verify(encodedOutboxTxMetadata, encodedMessage));
+        assertEq(address(testRecipient).balance, 1 ether);
     }
 
     function test_verify_statefulVerify() public {

--- a/solidity/test/isms/OPStackIsm.t.sol
+++ b/solidity/test/isms/OPStackIsm.t.sol
@@ -305,9 +305,7 @@ contract OPStackIsmTest is Test {
 
     function testFork_verifyMessageId_revertsWhen_replayed() public {
         deployAll();
-
         vm.selectFork(optimismFork);
-
         uint256 initialValue = 1 ether;
 
         // first legitimate message

--- a/solidity/test/isms/OPStackIsm.t.sol
+++ b/solidity/test/isms/OPStackIsm.t.sol
@@ -227,7 +227,7 @@ contract OPStackIsmTest is Test {
         opHook.postDispatch(testMetadata, encodedMessage);
 
         // attempt to replay the same message
-        vm.expectRevert("AbstractPostDispatchHook: message already processed");
+        vm.expectRevert("AbstractMessageIdAuthHook: message already processed");
         opHook.postDispatch(testMetadata, encodedMessage);
     }
 


### PR DESCRIPTION
### Description

Problem: 

Chainlight - "... the AbstractMessageIdAuthHook.postDispatch() does not verify whether the msg.sender is a Mailbox or whether the message is being replayed. Consequently, an attacker can resend the same interchain message immediately after Mailbox.dispatch() is called.

For example, suppose Alice sends an interchain message with 1 ether using the OP Stack ISM from L1. The Mailbox.dispatch() calls OPStackHook.postDispatch(), followed by the OPStackISM.verifyMessageId(messageId) being triggered in L2 by the deposit transaction. Under normal circumstances, when releaseValueToRecipient() is invoked, the verifiedMessages[messageId] (1 ether) will be transferred to the recipient.

However, an attacker can replay the message with 0 msg.value by calling OPStackHook.postDispatch() immediately after the user calls Mailbox.dispatch(). This causes OPStackISM.verifyMEssageId(messageId) to be called again, leading to verifiedMessages[messageId] being set 0 + VERIFIED_MASK. Since the verifiedMessages value is overwritten with 0, the user's funds become permanently locked within the ISM." 

Solution:

Add replay protection to both the `AbstractMessageIdAuthHook.postDispatch()` and `AbstractMessageIdAuthorizedIsm.verifyMessageId()` to ensure the same message cannot be replayed on either side. Why both:

- In the future, we may implement an ISM that doesn't require a verifyMessageId caching call before the verify call, and in that scenario, this attack vector can still be realized. 
- Even with replay protection on the hook side, some native or 3rd bridges may have the ability to retry messages (this is not the case for Optimism or Arbitrum) so it's useful to enable replay here too.

Adding replay protection on both sides might seem a bit redundant, but it's more of a precautionary measure, premeditating future hook-ISM design pitfalls.

### Drive-by changes

None

### Related issues

- fixes https://github.com/chainlight-io/2024-08-hyperlane/issues/3

### Backward compatibility

No, but not deployed to any mainnet

### Testing

Unit tests
