### PR TITLE
fix: ignore some testnet4 contracts to reduce prep queues, update testnet4 images, stop relaying solanatestnet

### DIFF
--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -174,7 +174,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '95f6421-20240912-094449',
+      tag: '73c232b-20240912-124300',
     },
     blacklist: [...releaseCandidateHelloworldMatchingList, ...relayBlacklist],
     gasPaymentEnforcement,
@@ -196,7 +196,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '95f6421-20240912-094449',
+      tag: '73c232b-20240912-124300',
     },
     chains: validatorChainConfig(Contexts.Hyperlane),
     resources: validatorResources,
@@ -205,7 +205,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '95f6421-20240912-094449',
+      tag: '73c232b-20240912-124300',
     },
     resources: scraperResources,
   },
@@ -220,7 +220,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '95f6421-20240912-094449',
+      tag: '73c232b-20240912-124300',
     },
     whitelist: [...releaseCandidateHelloworldMatchingList],
     blacklist: relayBlacklist,
@@ -232,7 +232,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '95f6421-20240912-094449',
+      tag: '73c232b-20240912-124300',
     },
     chains: validatorChainConfig(Contexts.ReleaseCandidate),
     resources: validatorResources,

--- a/typescript/infra/config/environments/testnet4/aw-validators/hyperlane.json
+++ b/typescript/infra/config/environments/testnet4/aw-validators/hyperlane.json
@@ -62,9 +62,6 @@
       "0xd3c75dcf15056012a4d74c483a0c6ea11d8c2b83"
     ]
   },
-  "solanatestnet": {
-    "validators": ["0xd4ce8fa138d4e083fc0e480cca0dbfa4f5f30bd5"]
-  },
   "superpositiontestnet": {
     "validators": ["0x1d3168504b23b73cdf9c27f13bb0a595d7f1a96a"]
   }


### PR DESCRIPTION
### Description

- Mitosis had previously done some load testing from sepolia to optimismsepolia | arbitrumsepolia, so there were prep queues of 235k+!
- Ignores the offending contracts whose mailboxes are different from the ones we deployed, so these messages are forever unprocessable:

```
$ cast call 0x3da95d8d0b98d7428dc2f864511e2650e34f7087 'mailbox()(address)' --rpc-url $(rpc arbitrumsepolia)
0xBA42Ee5864884C77a683E1dda390c6f6aE144167
$ addy arbitrumsepolia mailbox
0x598facE78a4302f11E3de0bee1894Da0b2Cb71F8
```

- Updates the image as a drive-by
- Stops relaying and validating on solantestnet, which is now old (doesn't include protocol fees) which is incompatible with the agents on `main`. This is because the account storage layout that the agents read has changed. Solantestnet isn't used for anything anymore because eclipsetestnet was also shut down

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
