### PR TITLE
fix: add msgvalue check against metadata for `_sendMessageId()`

### DIFF
--- a/solidity/contracts/hooks/ArbL2ToL1Hook.sol
+++ b/solidity/contracts/hooks/ArbL2ToL1Hook.sol
@@ -74,7 +74,8 @@ contract ArbL2ToL1Hook is AbstractMessageIdAuthHook {
         bytes calldata metadata,
         bytes memory payload
     ) internal override {
-        arbSys.sendTxToL1{value: metadata.msgValue(0)}(
+        uint256 excess = msg.value - (metadata.msgValue(0) + GAS_QUOTE);
+        arbSys.sendTxToL1{value: metadata.msgValue(0) + excess}(
             TypeCasts.bytes32ToAddress(ism),
             payload
         );


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
