### PR TITLE
fix: replace import console module with direct console

### DIFF
--- a/.changeset/gorgeous-owls-kiss.md
+++ b/.changeset/gorgeous-owls-kiss.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/ccip-server': patch
+'@hyperlane-xyz/infra': patch
+---
+
+replace import console module with direct console

--- a/typescript/ccip-server/src/services/HyperlaneService.ts
+++ b/typescript/ccip-server/src/services/HyperlaneService.ts
@@ -1,5 +1,3 @@
-import { info } from 'console';
-
 import { Message, MessageTx } from './explorerTypes';
 
 // These types are copied from hyperlane-explorer. TODO: export them so this file can use them directly.
@@ -21,7 +19,7 @@ class HyperlaneService {
    * @param id: Message id to look up
    */
   async getOriginBlockByMessageId(id: string): Promise<MessageTx> {
-    info(`Fetching block for id: ${id}`);
+    console.info(`Fetching block for id: ${id}`);
     const response = await fetch(
       `${this.baseUrl}?module=message&action=${API_ACTION.GetMessages}&id=${id}`,
     );

--- a/typescript/infra/scripts/announce-validators.ts
+++ b/typescript/infra/scripts/announce-validators.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs';
 import * as path from 'path';
 
 import { ChainName } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
 
 import { getChains } from '../config/registry.js';
 import { InfraS3Validator } from '../src/agents/aws/validator.js';
@@ -117,7 +118,10 @@ async function main() {
     const location = announcement.value.storage_location;
     const announcedLocations =
       await validatorAnnounce.getAnnouncedStorageLocations([address]);
-    console.assert(announcedLocations.length == 1);
+    assert(
+      announcedLocations.length == 1,
+      `Expected 1 announced location, got ${announcedLocations.length}`,
+    );
     const announced = announcedLocations[0].includes(location);
     if (!announced) {
       const signature = ethers.utils.joinSignature(announcement.signature);

--- a/typescript/infra/scripts/announce-validators.ts
+++ b/typescript/infra/scripts/announce-validators.ts
@@ -1,4 +1,3 @@
-import { assert } from 'console';
 import { ethers } from 'ethers';
 import { readFileSync } from 'fs';
 import * as path from 'path';
@@ -118,7 +117,7 @@ async function main() {
     const location = announcement.value.storage_location;
     const announcedLocations =
       await validatorAnnounce.getAnnouncedStorageLocations([address]);
-    assert(announcedLocations.length == 1);
+    console.assert(announcedLocations.length == 1);
     const announced = announcedLocations[0].includes(location);
     if (!announced) {
       const signature = ethers.utils.joinSignature(announcement.signature);


### PR DESCRIPTION
This PR addresses the restriction on using 'console' from module for follow [eslint rule](https://eslint.org/docs/latest/rules/no-restricted-imports). The changes include:

- Remove all import `console` module, use directly instead Such as: `import {log} from 'console` and `@hyperlane-xyz/utils`

### Changes

#### Added

#### Modified
- `services/HyperlaneService.ts`
- `scripts/annouce-validator.ts`

### Testing
- Everything work well. Just console

### Notes
- In the future, we should manage log on a unified logger instead of directly console