### PR TITLE
chore: disable plumetestnet during airplane mode

### DIFF
--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -52,7 +52,8 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     fuji: true,
     holesky: true,
     optimismsepolia: true,
-    plumetestnet: true,
+    // Disabling plumetestnet on Sept 16, 2024: chain is paused for "airplane mode"
+    // plumetestnet: true,
     polygonamoy: true,
     scrollsepolia: true,
     sepolia: true,
@@ -70,7 +71,8 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     fuji: true,
     holesky: true,
     optimismsepolia: true,
-    plumetestnet: true,
+    // Disabling plumetestnet on Sept 16, 2024: chain is paused for "airplane mode"
+    // plumetestnet: true,
     polygonamoy: true,
     scrollsepolia: true,
     sepolia: true,
@@ -89,7 +91,8 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     fuji: true,
     holesky: true,
     optimismsepolia: true,
-    plumetestnet: true,
+    // Disabling plumetestnet on Sept 16, 2024: chain is paused for "airplane mode"
+    // plumetestnet: true,
     polygonamoy: true,
     scrollsepolia: true,
     sepolia: true,

--- a/typescript/infra/config/environments/testnet4/aw-validators/hyperlane.json
+++ b/typescript/infra/config/environments/testnet4/aw-validators/hyperlane.json
@@ -38,13 +38,6 @@
   "optimismsepolia": {
     "validators": ["0x03efe4d0632ee15685d7e8f46dea0a874304aa29"]
   },
-  "plumetestnet": {
-    "validators": [
-      "0xe765a214849f3ecdf00793b97d00422f2d408ea6",
-      "0xb59998f71efc65190a85ac5e81b66bd72a192a3b",
-      "0xc906470a73e6b5aad65a4ceb4acd73e3eaf80e2c"
-    ]
-  },
   "polygonamoy": {
     "validators": ["0xf0290b06e446b320bd4e9c4a519420354d7ddccd"]
   },

--- a/typescript/infra/config/environments/testnet4/funding.ts
+++ b/typescript/infra/config/environments/testnet4/funding.ts
@@ -10,7 +10,7 @@ export const keyFunderConfig: KeyFunderConfig<
 > = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-    tag: '874a58f-20240812-172413',
+    tag: '344aa49-20240916-102227',
   },
   // We're currently using the same deployer key as testnet2.
   // To minimize nonce clobbering we offset the key funder cron

--- a/typescript/infra/config/environments/testnet4/funding.ts
+++ b/typescript/infra/config/environments/testnet4/funding.ts
@@ -37,7 +37,8 @@ export const keyFunderConfig: KeyFunderConfig<
     fuji: '5',
     holesky: '5',
     optimismsepolia: '0.1',
-    plumetestnet: '0.2',
+    // Disabling plumetestnet on Sept 16, 2024: chain is paused for "airplane mode"
+    // plumetestnet: '0.2',
     polygonamoy: '0.2',
     scrollsepolia: '1',
     sepolia: '5',
@@ -57,7 +58,8 @@ export const keyFunderConfig: KeyFunderConfig<
     fuji: '1',
     holesky: '0',
     optimismsepolia: '0',
-    plumetestnet: '0.05',
+    // Disabling plumetestnet on Sept 16, 2024: chain is paused for "airplane mode"
+    // plumetestnet: '0.05',
     polygonamoy: '0',
     scrollsepolia: '1',
     sepolia: '1',
@@ -77,7 +79,8 @@ export const keyFunderConfig: KeyFunderConfig<
     fuji: '1',
     holesky: '1',
     optimismsepolia: '0.05',
-    plumetestnet: '0.1',
+    // Disabling plumetestnet on Sept 16, 2024: chain is paused for "airplane mode"
+    // plumetestnet: '0.1',
     polygonamoy: '0.1',
     scrollsepolia: '0.1',
     sepolia: '1',

--- a/typescript/infra/config/environments/testnet4/gas-oracle.ts
+++ b/typescript/infra/config/environments/testnet4/gas-oracle.ts
@@ -27,7 +27,8 @@ const gasPrices: Record<
   fuji: ethers.utils.parseUnits('30', 'gwei'),
   holesky: ethers.utils.parseUnits('10', 'gwei'),
   optimismsepolia: ethers.utils.parseUnits('0.5', 'gwei'),
-  plumetestnet: ethers.utils.parseUnits('0.01', 'gwei'),
+  // Disabling plumetestnet on Sept 16, 2024: chain is paused for "airplane mode"
+  // plumetestnet: ethers.utils.parseUnits('0.01', 'gwei'),
   polygonamoy: ethers.utils.parseUnits('100', 'gwei'),
   scrollsepolia: ethers.utils.parseUnits('0.5', 'gwei'),
   sepolia: ethers.utils.parseUnits('5', 'gwei'),
@@ -65,7 +66,8 @@ const chainTokenRarity: Record<
   fuji: Rarity.Rare,
   holesky: Rarity.Common,
   optimismsepolia: Rarity.Common,
-  plumetestnet: Rarity.Common,
+  // Disabling plumetestnet on Sept 16, 2024: chain is paused for "airplane mode"
+  // plumetestnet: Rarity.Common,
   polygonamoy: Rarity.Rare,
   scrollsepolia: Rarity.Rare,
   sepolia: Rarity.Mythic,

--- a/typescript/infra/config/environments/testnet4/supportedChainNames.ts
+++ b/typescript/infra/config/environments/testnet4/supportedChainNames.ts
@@ -10,7 +10,8 @@ export const testnet4SupportedChainNames = [
   'fuji',
   'holesky',
   'optimismsepolia',
-  'plumetestnet',
+  // Disabling plumetestnet on Sept 16, 2024: chain is paused for "airplane mode"
+  // 'plumetestnet',
   'polygonamoy',
   'scrollsepolia',
   'sepolia',

--- a/typescript/infra/scripts/funding/deploy-key-funder.ts
+++ b/typescript/infra/scripts/funding/deploy-key-funder.ts
@@ -1,12 +1,11 @@
 import { Contexts } from '../../config/contexts.js';
-import { environment } from '../../config/environments/mainnet3/chains.js';
 import { KeyFunderHelmManager } from '../../src/funding/key-funder.js';
 import { HelmCommand } from '../../src/utils/helm.js';
 import { assertCorrectKubeContext } from '../agent-utils.js';
 import { getConfigsBasedOnArgs } from '../core-utils.js';
 
 async function main() {
-  const { agentConfig, envConfig, context } = await getConfigsBasedOnArgs();
+  const { agentConfig, envConfig, environment } = await getConfigsBasedOnArgs();
   if (agentConfig.context != Contexts.Hyperlane)
     throw new Error(
       `Invalid context ${agentConfig.context}, must be ${Contexts.Hyperlane}`,


### PR DESCRIPTION
### Description

- Plumetestnet shut down https://miles.plumenetwork.xyz/ without a specific end date
- Removing it from the list of supported chains for now. Only updating infra workloads and nothing onchain atm

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
