### PR TITLE
chore: refactor MessagIdHook/ISM tests into a common `ExternalBridgeTest` contract

### DIFF
--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -147,11 +147,6 @@ contract ArbL2ToL1IsmTest is ExternalBridgeTest {
         assertEq(address(testRecipient).balance, 1 ether);
     }
 
-    function test_verify_revertsWhen_noStatefulOrOutbox() public {
-        vm.expectRevert();
-        ism.verify(new bytes(0), encodedMessage);
-    }
-
     function test_verify_revertsWhen_notAuthorizedHook() public {
         bytes memory encodedOutboxTxMetadata = _encodeOutboxTx(
             address(this),

--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -24,15 +24,12 @@ contract ArbL2ToL1IsmTest is ExternalBridgeTest {
     MockArbBridge internal arbBridge;
 
     function setUp() public override {
-        ORIGIN_DOMAIN = 42161;
-        DESTINATION_DOMAIN = 1;
-        GAS_QUOTE = 120_000;
-        super.setUp();
-
         // Arbitrum bridge mock setup
+        GAS_QUOTE = 120_000;
         vm.etch(L2_ARBSYS_ADDRESS, address(new MockArbSys()).code);
 
         deployAll();
+        super.setUp();
     }
 
     ///////////////////////////////////////////////////////////////////

--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -106,37 +106,6 @@ contract ArbL2ToL1IsmTest is ExternalBridgeTest {
         );
     }
 
-    function test_verify_statefulAndOutbox() public {
-        bytes memory encodedHookData = abi.encodeCall(
-            AbstractMessageIdAuthorizedIsm.verifyMessageId,
-            (messageId)
-        );
-
-        arbBridge.setL2ToL1Sender(address(hook));
-        arbBridge.executeTransaction{value: 1 ether}(
-            new bytes32[](0),
-            MOCK_LEAF_INDEX,
-            address(hook),
-            address(ism),
-            MOCK_L2_BLOCK,
-            MOCK_L1_BLOCK,
-            block.timestamp,
-            1 ether,
-            encodedHookData
-        );
-
-        bytes memory encodedOutboxTxMetadata = _encodeOutboxTx(
-            address(hook),
-            address(ism),
-            messageId,
-            1 ether
-        );
-
-        vm.etch(address(arbBridge), new bytes(0)); // this is a way to test that the arbBridge isn't called again
-        assertTrue(ism.verify(encodedOutboxTxMetadata, encodedMessage));
-        assertEq(address(testRecipient).balance, 1 ether);
-    }
-
     function test_verify_revertsWhen_notAuthorizedHook() public {
         bytes memory encodedOutboxTxMetadata = _encodeOutboxTx(
             address(this),

--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 pragma solidity ^0.8.13;
 
-import {Test} from "forge-std/Test.sol";
-
 import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
 import {MessageUtils} from "./IsmTestUtils.sol";
 import {TestMailbox} from "../../contracts/test/TestMailbox.sol";
@@ -29,7 +27,6 @@ contract ArbL2ToL1IsmTest is ExternalBridgeTest {
         ORIGIN_DOMAIN = 42161;
         DESTINATION_DOMAIN = 1;
         GAS_QUOTE = 120_000;
-        invalidMessageIdError = "ArbL2ToL1Ism: invalid message id";
         super.setUp();
 
         // Arbitrum bridge mock setup
@@ -94,7 +91,8 @@ contract ArbL2ToL1IsmTest is ExternalBridgeTest {
         bytes memory _encodedHookData,
         uint256 _msgValue
     ) internal override {
-        arbBridge.executeTransaction{value: _msgValue}(
+        vm.deal(address(arbBridge), _msgValue);
+        arbBridge.executeTransaction(
             new bytes32[](0),
             MOCK_LEAF_INDEX,
             address(hook),

--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -102,9 +102,11 @@ contract ArbL2ToL1IsmTest is ExternalBridgeTest {
         );
     }
 
-    function _setExternalOriginSender(address _sender) internal override {
-        unauthorizedHookError = "ArbL2ToL1Ism: l2Sender != authorizedHook";
+    function _setExternalOriginSender(
+        address _sender
+    ) internal override returns (bytes memory unauthorizedHookErrorMsg) {
         arbBridge.setL2ToL1Sender(_sender);
+        return "ArbL2ToL1Ism: l2Sender != authorizedHook";
     }
 
     function _encodeOutboxTx(

--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -92,10 +92,11 @@ contract ArbL2ToL1IsmTest is ExternalBridgeTest {
     }
 
     function _bridgeDestinationCall(
-        bytes memory _encodedHookData
+        bytes memory _encodedHookData,
+        uint256 _msgValue
     ) internal override {
         arbBridge.setL2ToL1Sender(address(hook));
-        arbBridge.executeTransaction{value: 1 ether}(
+        arbBridge.executeTransaction{value: _msgValue}(
             new bytes32[](0),
             MOCK_LEAF_INDEX,
             address(hook),
@@ -103,18 +104,10 @@ contract ArbL2ToL1IsmTest is ExternalBridgeTest {
             MOCK_L2_BLOCK,
             MOCK_L1_BLOCK,
             block.timestamp,
-            1 ether,
+            _msgValue,
             _encodedHookData
         );
     }
-
-    // function test_verify_statefulVerify() public {
-    //     bytes memory encodedHookData = abi.encodeCall(AbstractMessageIdAuthorizedIsm.verifyMessageId, (messageId));
-
-    //     vm.etch(address(arbBridge), new bytes(0)); // this is a way to test that the arbBridge isn't called again
-    //     assertTrue(ism.verify(new bytes(0), encodedMessage));
-    //     assertEq(address(testRecipient).balance, 1 ether);
-    // }
 
     function test_verify_statefulAndOutbox() public {
         bytes memory encodedHookData = abi.encodeCall(

--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -151,20 +151,6 @@ contract ArbL2ToL1IsmTest is ExternalBridgeTest {
         ism.verify(encodedOutboxTxMetadata, encodedMessage);
     }
 
-    function test_verify_revertsWhen_invalidIsm() public {
-        bytes memory encodedOutboxTxMetadata = _encodeOutboxTx(
-            address(hook),
-            address(this),
-            messageId,
-            0
-        );
-
-        arbBridge.setL2ToL1Sender(address(hook));
-
-        vm.expectRevert(); // BridgeCallFailed()
-        ism.verify(encodedOutboxTxMetadata, encodedMessage);
-    }
-
     function test_verify_revertsWhen_incorrectMessageId() public {
         bytes32 incorrectMessageId = keccak256("incorrect message id");
 

--- a/solidity/test/isms/ArbL2ToL1Ism.t.sol
+++ b/solidity/test/isms/ArbL2ToL1Ism.t.sol
@@ -65,7 +65,7 @@ contract ArbL2ToL1IsmTest is ExternalBridgeTest {
         ism.setAuthorizedHook(TypeCasts.addressToBytes32(address(hook)));
     }
 
-    function _expectOriginBridgeCall(
+    function _expectOriginExternalBridgeCall(
         bytes memory _encodedHookData
     ) internal override {
         vm.expectCall(
@@ -77,21 +77,18 @@ contract ArbL2ToL1IsmTest is ExternalBridgeTest {
         );
     }
 
-    function test_verify_outboxCall() public {
-        bytes memory encodedOutboxTxMetadata = _encodeOutboxTx(
-            address(hook),
-            address(ism),
-            messageId,
-            1 ether
-        );
-
-        vm.deal(address(arbBridge), 1 ether);
+    function _encodeExternalDestinationBridgeCall(
+        address _from,
+        address _to,
+        uint256 _msgValue,
+        bytes32 _messageId
+    ) internal override returns (bytes memory) {
+        vm.deal(address(arbBridge), _msgValue);
         arbBridge.setL2ToL1Sender(address(hook));
-        assertTrue(ism.verify(encodedOutboxTxMetadata, encodedMessage));
-        assertEq(address(testRecipient).balance, 1 ether);
+        return _encodeOutboxTx(_from, _to, _messageId, _msgValue);
     }
 
-    function _bridgeDestinationCall(
+    function _externalBridgeDestinationCall(
         bytes memory _encodedHookData,
         uint256 _msgValue
     ) internal override {

--- a/solidity/test/isms/ERC5164ISM.t.sol
+++ b/solidity/test/isms/ERC5164ISM.t.sol
@@ -137,11 +137,6 @@ contract ERC5164IsmTest is ExternalBridgeTest {
         assertFalse(ism.isVerified(encodedMessage));
     }
 
-    // override to assert false instead of revert
-    function test_verify_revertWhen_invalidMetadata() public override {
-        assertFalse(ism.verify(new bytes(0), encodedMessage));
-    }
-
     // SKIP - duplicate of test_verify_revertWhen_invalidMetadata
     function test_verify_revertsWhen_incorrectMessageId() public override {}
 
@@ -151,6 +146,8 @@ contract ERC5164IsmTest is ExternalBridgeTest {
     function test_verify_msgValue_asyncCall() public override {}
 
     function test_verify_msgValue_externalBridgeCall() public override {}
+
+    function test_verify_valueAlreadyClaimed(uint256) public override {}
 
     /* ============ helper functions ============ */
 

--- a/solidity/test/isms/ERC5164ISM.t.sol
+++ b/solidity/test/isms/ERC5164ISM.t.sol
@@ -116,7 +116,11 @@ contract ERC5164IsmTest is ExternalBridgeTest {
         );
     }
 
-    function test_postDispatch_RevertWhen_msgValueNotAllowed() public payable {
+    function test_verify_revertWhen_invalidMetadata() public override {
+        assertFalse(ism.verify(new bytes(0), encodedMessage));
+    }
+
+    function test_postDispatch_revertWhen_msgValueNotAllowed() public payable {
         originMailbox.updateLatestDispatchedId(messageId);
 
         vm.expectRevert("ERC5164Hook: no value allowed");

--- a/solidity/test/isms/ERC5164ISM.t.sol
+++ b/solidity/test/isms/ERC5164ISM.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 pragma solidity ^0.8.13;
 
-import {Test} from "forge-std/Test.sol";
+import "forge-std/console.sol";
 
 import {LibBit} from "../../contracts/libs/LibBit.sol";
 import {Message} from "../../contracts/libs/Message.sol";
@@ -17,8 +17,9 @@ import {ERC5164Ism} from "../../contracts/isms/hook/ERC5164Ism.sol";
 import {TestMailbox} from "../../contracts/test/TestMailbox.sol";
 import {TestRecipient} from "../../contracts/test/TestRecipient.sol";
 import {MockMessageDispatcher, MockMessageExecutor} from "../../contracts/mock/MockERC5164.sol";
+import {ExternalBridgeTest} from "./ExternalBridgeTest.sol";
 
-contract ERC5164IsmTest is Test {
+contract ERC5164IsmTest is ExternalBridgeTest {
     using LibBit for uint256;
     using TypeCasts for address;
     using Message for bytes;
@@ -27,22 +28,7 @@ contract ERC5164IsmTest is Test {
     IMessageDispatcher internal dispatcher;
     MockMessageExecutor internal executor;
 
-    ERC5164Hook internal hook;
-    ERC5164Ism internal ism;
-    TestMailbox internal originMailbox;
-    TestRecipient internal testRecipient;
-
-    uint32 internal constant TEST1_DOMAIN = 1;
-    uint32 internal constant TEST2_DOMAIN = 2;
-
-    uint8 internal constant VERSION = 0;
-    bytes internal testMessage =
-        abi.encodePacked("Hello from the other chain!");
     address internal alice = address(0x1);
-
-    // req for most tests
-    bytes encodedMessage = _encodeTestMessage(0, address(testRecipient));
-    bytes32 messageId = encodedMessage.id();
 
     event MessageDispatched(
         bytes32 indexed messageId,
@@ -56,15 +42,18 @@ contract ERC5164IsmTest is Test {
     ///                            SETUP                            ///
     ///////////////////////////////////////////////////////////////////
 
-    function setUp() public {
+    function setUp() public override {
+        ORIGIN_DOMAIN = 1;
+        DESTINATION_DOMAIN = 2;
+        super.setUp();
+
         dispatcher = new MockMessageDispatcher();
         executor = new MockMessageExecutor();
-        testRecipient = new TestRecipient();
-        originMailbox = new TestMailbox(TEST1_DOMAIN);
+        originMailbox = new TestMailbox(ORIGIN_DOMAIN);
         ism = new ERC5164Ism(address(executor));
         hook = new ERC5164Hook(
             address(originMailbox),
-            TEST2_DOMAIN,
+            DESTINATION_DOMAIN,
             address(ism).addressToBytes32(),
             address(dispatcher)
         );
@@ -100,7 +89,7 @@ contract ERC5164IsmTest is Test {
         vm.expectRevert("AbstractMessageIdAuthHook: invalid ISM");
         hook = new ERC5164Hook(
             address(originMailbox),
-            TEST2_DOMAIN,
+            DESTINATION_DOMAIN,
             address(0).addressToBytes32(),
             address(dispatcher)
         );
@@ -108,53 +97,28 @@ contract ERC5164IsmTest is Test {
         vm.expectRevert("ERC5164Hook: invalid dispatcher");
         hook = new ERC5164Hook(
             address(originMailbox),
-            TEST2_DOMAIN,
+            DESTINATION_DOMAIN,
             address(ism).addressToBytes32(),
             address(0)
         );
     }
 
-    function test_postDispatch() public {
-        bytes memory encodedHookData = abi.encodeCall(
-            AbstractMessageIdAuthorizedIsm.verifyMessageId,
-            (messageId)
-        );
-        originMailbox.updateLatestDispatchedId(messageId);
-
-        // note: not checking for messageId since this is implementation dependent on each vendor
-        vm.expectEmit(false, true, true, true, address(dispatcher));
-        emit MessageDispatched(
-            messageId,
-            address(hook),
-            TEST2_DOMAIN,
-            address(ism),
-            encodedHookData
-        );
-
-        hook.postDispatch(bytes(""), encodedMessage);
-    }
-
-    function testTypes() public {
+    function testTypes() public view {
         assertEq(hook.hookType(), uint8(IPostDispatchHook.Types.ID_AUTH_ISM));
         assertEq(ism.moduleType(), uint8(IInterchainSecurityModule.Types.NULL));
     }
 
-    function test_postDispatch_RevertWhen_ChainIDNotSupported() public {
-        encodedMessage = MessageUtils.formatMessage(
-            VERSION,
-            0,
-            TEST1_DOMAIN,
-            TypeCasts.addressToBytes32(address(this)),
-            3, // unsupported chain id
-            TypeCasts.addressToBytes32(address(testRecipient)),
-            testMessage
+    function _expectOriginExternalBridgeCall(
+        bytes memory _encodedHookData
+    ) internal override {
+        vm.expectEmit(false, true, true, true, address(dispatcher));
+        emit MessageDispatched(
+            messageId,
+            address(hook),
+            DESTINATION_DOMAIN,
+            address(ism),
+            _encodedHookData
         );
-        originMailbox.updateLatestDispatchedId(Message.id(encodedMessage));
-
-        vm.expectRevert(
-            "AbstractMessageIdAuthHook: invalid destination domain"
-        );
-        hook.postDispatch(bytes(""), encodedMessage);
     }
 
     function test_postDispatch_RevertWhen_msgValueNotAllowed() public payable {
@@ -164,69 +128,51 @@ contract ERC5164IsmTest is Test {
         hook.postDispatch{value: 1}(bytes(""), encodedMessage);
     }
 
-    /* ============ ISM.verifyMessageId ============ */
+    // override to omit direct external bridge call
+    function test_verify_revertsWhen_notAuthorizedHook() public override {
+        vm.prank(alice);
 
-    function test_verifyMessageId() public {
-        vm.startPrank(address(executor));
-
-        ism.verifyMessageId(messageId);
-        assertTrue(ism.verifiedMessages(messageId).isBitSet(255));
-
-        vm.stopPrank();
-    }
-
-    function test_verifyMessageId_RevertWhen_NotAuthorized() public {
-        vm.startPrank(alice);
-
-        // needs to be called by the authorized hook contract on Ethereum
         vm.expectRevert(
             "AbstractMessageIdAuthorizedIsm: sender is not the hook"
         );
         ism.verifyMessageId(messageId);
-
-        vm.stopPrank();
+        assertFalse(ism.isVerified(encodedMessage));
     }
 
-    /* ============ ISM.verify ============ */
-
-    function test_verify() public {
-        vm.startPrank(address(executor));
-
-        ism.verifyMessageId(messageId);
-
-        bool verified = ism.verify(new bytes(0), encodedMessage);
-        assertTrue(verified);
-
-        vm.stopPrank();
+    // override to assert false instead of revert
+    function test_verify_revertWhen_invalidMetadata() public override {
+        assertFalse(ism.verify(new bytes(0), encodedMessage));
     }
 
-    function test_verify_RevertWhen_InvalidMessage() public {
-        vm.startPrank(address(executor));
+    // SKIP - duplicate of test_verify_revertWhen_invalidMetadata
+    function test_verify_revertsWhen_incorrectMessageId() public override {}
 
-        ism.verifyMessageId(messageId);
+    function test_verify_revertsWhen_invalidIsm() public override {}
 
-        bytes memory invalidMessage = _encodeTestMessage(0, address(this));
-        bool verified = ism.verify(new bytes(0), invalidMessage);
-        assertFalse(verified);
+    // SKIP - 5164 ism does not support msg.value
+    function test_verify_msgValue_asyncCall() public override {}
 
-        vm.stopPrank();
-    }
+    function test_verify_msgValue_externalBridgeCall() public override {}
 
     /* ============ helper functions ============ */
 
-    function _encodeTestMessage(
-        uint32 _msgCount,
-        address _receipient
-    ) internal view returns (bytes memory) {
-        return
-            MessageUtils.formatMessage(
-                VERSION,
-                _msgCount,
-                TEST1_DOMAIN,
-                TypeCasts.addressToBytes32(address(this)),
-                TEST2_DOMAIN,
-                TypeCasts.addressToBytes32(_receipient),
-                testMessage
-            );
+    function _externalBridgeDestinationCall(
+        bytes memory _encodedHookData,
+        uint256 _msgValue
+    ) internal override {
+        vm.prank(address(executor));
+        ism.verifyMessageId(messageId);
+    }
+
+    function _encodeExternalDestinationBridgeCall(
+        address _from,
+        address _to,
+        uint256 _msgValue,
+        bytes32 _messageId
+    ) internal override returns (bytes memory) {
+        if (_from == address(hook)) {
+            vm.prank(address(executor));
+            ism.verifyMessageId{value: _msgValue}(messageId);
+        }
     }
 }

--- a/solidity/test/isms/ERC5164ISM.t.sol
+++ b/solidity/test/isms/ERC5164ISM.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 pragma solidity ^0.8.13;
 
-import "forge-std/console.sol";
-
 import {LibBit} from "../../contracts/libs/LibBit.sol";
 import {Message} from "../../contracts/libs/Message.sol";
 import {MessageUtils} from "./IsmTestUtils.sol";

--- a/solidity/test/isms/ERC5164ISM.t.sol
+++ b/solidity/test/isms/ERC5164ISM.t.sol
@@ -41,10 +41,6 @@ contract ERC5164IsmTest is ExternalBridgeTest {
     ///////////////////////////////////////////////////////////////////
 
     function setUp() public override {
-        ORIGIN_DOMAIN = 1;
-        DESTINATION_DOMAIN = 2;
-        super.setUp();
-
         dispatcher = new MockMessageDispatcher();
         executor = new MockMessageExecutor();
         originMailbox = new TestMailbox(ORIGIN_DOMAIN);
@@ -56,6 +52,7 @@ contract ERC5164IsmTest is ExternalBridgeTest {
             address(dispatcher)
         );
         ism.setAuthorizedHook(TypeCasts.addressToBytes32(address(hook)));
+        super.setUp();
     }
 
     ///////////////////////////////////////////////////////////////////

--- a/solidity/test/isms/ExternalBridgeTest.sol
+++ b/solidity/test/isms/ExternalBridgeTest.sol
@@ -142,6 +142,18 @@ abstract contract ExternalBridgeTest is Test {
         assertEq(address(testRecipient).balance, 1 ether);
     }
 
+    function test_verify_revertsWhen_invalidIsm() public {
+        bytes memory externalCalldata = _encodeExternalDestinationBridgeCall(
+            address(hook),
+            address(this),
+            0,
+            messageId
+        );
+
+        vm.expectRevert();
+        ism.verify(externalCalldata, encodedMessage);
+    }
+
     function _expectOriginExternalBridgeCall(
         bytes memory _encodedHookData
     ) internal virtual;

--- a/solidity/test/isms/ExternalBridgeTest.sol
+++ b/solidity/test/isms/ExternalBridgeTest.sol
@@ -16,8 +16,8 @@ abstract contract ExternalBridgeTest is Test {
     using MessageUtils for bytes;
 
     uint8 internal constant HYPERLANE_VERSION = 1;
-    uint32 internal ORIGIN_DOMAIN;
-    uint32 internal DESTINATION_DOMAIN;
+    uint32 internal constant ORIGIN_DOMAIN = 1;
+    uint32 internal constant DESTINATION_DOMAIN = 2;
     uint256 internal GAS_QUOTE;
 
     bytes internal unauthorizedHookError;
@@ -52,13 +52,9 @@ abstract contract ExternalBridgeTest is Test {
     }
 
     function test_postDispatch_revertWhen_chainIDNotSupported() public {
-        bytes memory message = MessageUtils.formatMessage(
-            0,
-            uint32(0),
-            DESTINATION_DOMAIN,
+        bytes memory message = originMailbox.buildOutboundMessage(
+            3,
             TypeCasts.addressToBytes32(address(this)),
-            3, // wrong domain
-            TypeCasts.addressToBytes32(address(testRecipient)),
             testMessage
         );
 
@@ -223,11 +219,7 @@ abstract contract ExternalBridgeTest is Test {
 
     function _encodeTestMessage() internal view returns (bytes memory) {
         return
-            MessageUtils.formatMessage(
-                HYPERLANE_VERSION,
-                uint32(0),
-                ORIGIN_DOMAIN,
-                TypeCasts.addressToBytes32(address(this)),
+            originMailbox.buildOutboundMessage(
                 DESTINATION_DOMAIN,
                 TypeCasts.addressToBytes32(address(testRecipient)),
                 testMessage

--- a/solidity/test/isms/ExternalBridgeTest.sol
+++ b/solidity/test/isms/ExternalBridgeTest.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT or Apache-2.0
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+import {StandardHookMetadata} from "../../contracts/hooks/libs/StandardHookMetadata.sol";
+import {TestMailbox} from "../../contracts/test/TestMailbox.sol";
+import {Message} from "../../contracts/libs/Message.sol";
+import {MessageUtils} from "./IsmTestUtils.sol";
+import {TestRecipient} from "../../contracts/test/TestRecipient.sol";
+import {AbstractMessageIdAuthorizedIsm} from "../../contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol";
+import {AbstractMessageIdAuthHook} from "../../contracts/hooks/libs/AbstractMessageIdAuthHook.sol";
+
+abstract contract ExternalBridgeTest is Test {
+    using TypeCasts for address;
+    using MessageUtils for bytes;
+
+    uint8 internal constant HYPERLANE_VERSION = 1;
+    uint32 internal ORIGIN_DOMAIN;
+    uint32 internal DESTINATION_DOMAIN;
+    uint256 internal GAS_QUOTE;
+    TestMailbox internal originMailbox;
+    TestMailbox internal destinationMailbox;
+    TestRecipient internal testRecipient;
+
+    AbstractMessageIdAuthHook internal hook;
+
+    bytes internal testMessage =
+        abi.encodePacked("Hello from the other chain!");
+    bytes internal testMetadata =
+        StandardHookMetadata.overrideRefundAddress(address(this));
+    bytes internal encodedMessage;
+    bytes32 internal messageId;
+
+    function setUp() public virtual {
+        testRecipient = new TestRecipient();
+        encodedMessage = _encodeTestMessage();
+        messageId = Message.id(encodedMessage);
+    }
+
+    function _encodeTestMessage() internal view returns (bytes memory) {
+        return
+            MessageUtils.formatMessage(
+                HYPERLANE_VERSION,
+                uint32(0),
+                ORIGIN_DOMAIN,
+                TypeCasts.addressToBytes32(address(this)),
+                DESTINATION_DOMAIN,
+                TypeCasts.addressToBytes32(address(testRecipient)),
+                testMessage
+            );
+    }
+
+    function _encodeHookData(
+        bytes32 _messageId
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encodeCall(
+                AbstractMessageIdAuthorizedIsm.verifyMessageId,
+                (_messageId)
+            );
+    }
+
+    function testFork_postDispatch_revertWhen_chainIDNotSupported() public {
+        bytes memory message = MessageUtils.formatMessage(
+            0,
+            uint32(0),
+            DESTINATION_DOMAIN,
+            TypeCasts.addressToBytes32(address(this)),
+            2, // wrong domain
+            TypeCasts.addressToBytes32(address(testRecipient)),
+            testMessage
+        );
+
+        destinationMailbox.updateLatestDispatchedId(Message.id(message));
+        vm.expectRevert(
+            "AbstractMessageIdAuthHook: invalid destination domain"
+        );
+        hook.postDispatch(testMetadata, message);
+    }
+
+    function test_postDispatch_revertWhen_notLastDispatchedMessage() public {
+        vm.expectRevert(
+            "AbstractMessageIdAuthHook: message not latest dispatched"
+        );
+        hook.postDispatch(testMetadata, encodedMessage);
+    }
+
+    function test_postDispatch() public {
+        bytes memory encodedHookData = _encodeHookData(messageId);
+        destinationMailbox.updateLatestDispatchedId(messageId);
+        _expectOriginBridgeCall(encodedHookData);
+
+        hook.postDispatch{value: GAS_QUOTE}(testMetadata, encodedMessage);
+    }
+
+    function _expectOriginBridgeCall(
+        bytes memory _encodedHookData
+    ) internal virtual;
+
+    // function testPostDispatch_RevertWhen_ChainIDNotSupported() public virtual;
+    // function testPostDispatch_RevertWhen_NotLastDispatchedMessage() public virtual;
+    // function testVerify_WithValue(uint256 _msgValue) public virtual;
+    // function testVerify_RevertWhen_InvalidMessage() public virtual;
+
+    // Add more common test cases as needed
+}

--- a/solidity/test/isms/ExternalBridgeTest.sol
+++ b/solidity/test/isms/ExternalBridgeTest.sol
@@ -40,6 +40,12 @@ abstract contract ExternalBridgeTest is Test {
         messageId = Message.id(encodedMessage);
     }
 
+    /* ============ hook.quoteDispatch ============ */
+
+    function test_quoteDispatch() public view {
+        assertEq(hook.quoteDispatch(testMetadata, encodedMessage), GAS_QUOTE);
+    }
+
     /* ============ Hook.postDispatch ============ */
 
     function test_postDispatch() public {
@@ -110,11 +116,8 @@ abstract contract ExternalBridgeTest is Test {
     /* ============ ISM.verify ============ */
 
     function test_verify_revertWhen_invalidMetadata() public virtual {
-        bool isValid;
-        try ism.verify(new bytes(0), encodedMessage) returns (bool _isValid) {
-            isValid = _isValid;
-        } catch {}
-        assertFalse(isValid);
+        vm.expectRevert();
+        assertFalse(ism.verify(new bytes(0), encodedMessage));
     }
 
     function test_verify_msgValue_asyncCall() public virtual {
@@ -180,17 +183,15 @@ abstract contract ExternalBridgeTest is Test {
         );
 
         // external call
-        bool isValid;
-        try ism.verify(externalCalldata, encodedMessage) returns (
-            bool _isValid
-        ) {
-            isValid = _isValid;
-        } catch {}
-        assertFalse(isValid);
+        vm.expectRevert();
+        assertFalse(ism.verify(externalCalldata, encodedMessage));
 
         // async call - native bridges might have try catch block to prevent revert
         try
-            this.externalBridgeDestinationCallWrapper(externalCalldata, 0)
+            this.externalBridgeDestinationCallWrapper(
+                _encodeHookData(incorrectMessageId),
+                0
+            )
         {} catch {}
         assertFalse(ism.isVerified(testMessage));
     }

--- a/solidity/test/isms/ExternalBridgeTest.sol
+++ b/solidity/test/isms/ExternalBridgeTest.sol
@@ -167,8 +167,18 @@ abstract contract ExternalBridgeTest is Test {
         ism.verify(externalCalldata, encodedMessage);
 
         // async call - native bridges might have try catch block to prevent revert
-        _externalBridgeDestinationCall(externalCalldata, 0);
+        try
+            this.externalBridgeDestinationCallWrapper(externalCalldata, 0)
+        {} catch {}
         assertFalse(ism.isVerified(testMessage));
+    }
+
+    // try catch block to prevent revert
+    function externalBridgeDestinationCallWrapper(
+        bytes memory _encodedHookData,
+        uint256 _msgValue
+    ) external {
+        _externalBridgeDestinationCall(_encodedHookData, _msgValue);
     }
 
     /* ============ helper functions ============ */

--- a/solidity/test/isms/ExternalBridgeTest.sol
+++ b/solidity/test/isms/ExternalBridgeTest.sol
@@ -105,6 +105,11 @@ abstract contract ExternalBridgeTest is Test {
         assertTrue(ism.isVerified(encodedMessage));
     }
 
+    function test_verify_revertWhen_invalidMetadata() public {
+        vm.expectRevert();
+        ism.verify(new bytes(0), encodedMessage);
+    }
+
     function _expectOriginBridgeCall(
         bytes memory _encodedHookData
     ) internal virtual;

--- a/solidity/test/isms/ExternalBridgeTest.sol
+++ b/solidity/test/isms/ExternalBridgeTest.sol
@@ -100,7 +100,7 @@ abstract contract ExternalBridgeTest is Test {
             AbstractMessageIdAuthorizedIsm.verifyMessageId,
             (messageId)
         );
-        _bridgeDestinationCall(encodedHookData);
+        _bridgeDestinationCall(encodedHookData, 0);
 
         assertTrue(ism.isVerified(encodedMessage));
     }
@@ -110,13 +110,24 @@ abstract contract ExternalBridgeTest is Test {
         ism.verify(new bytes(0), encodedMessage);
     }
 
+    function test_verify_msgValueWithAsyncCall() public {
+        bytes memory encodedHookData = _encodeHookData(messageId);
+        _bridgeDestinationCall(encodedHookData, 1 ether);
+
+        assertTrue(ism.verify(new bytes(0), encodedMessage));
+        assertEq(address(testRecipient).balance, 1 ether);
+    }
+
     function _expectOriginBridgeCall(
         bytes memory _encodedHookData
     ) internal virtual;
 
     function _bridgeDestinationCall(
-        bytes memory _encodedHookData
+        bytes memory _encodedHookData,
+        uint256 _msgValue
     ) internal virtual;
+
+    // function _encodeBridgeCall(address _to, uint256 _msgValue, bytes memory _data) internal view returns (bytes memory)
 
     // function testPostDispatch_RevertWhen_ChainIDNotSupported() public virtual;
     // function testPostDispatch_RevertWhen_NotLastDispatchedMessage() public virtual;

--- a/solidity/test/isms/ExternalBridgeTest.sol
+++ b/solidity/test/isms/ExternalBridgeTest.sol
@@ -42,6 +42,8 @@ abstract contract ExternalBridgeTest is Test {
         messageId = Message.id(encodedMessage);
     }
 
+    /* ============ Hook.postDispatch ============ */
+
     function test_postDispatch() public {
         bytes memory encodedHookData = _encodeHookData(messageId);
         originMailbox.updateLatestDispatchedId(messageId);
@@ -75,6 +77,8 @@ abstract contract ExternalBridgeTest is Test {
         hook.postDispatch(testMetadata, encodedMessage);
     }
 
+    /* ============ ISM.verifyMessageId ============ */
+
     function test_verifyMessageId_asyncCall() public {
         bytes memory encodedHookData = abi.encodeCall(
             AbstractMessageIdAuthorizedIsm.verifyMessageId,
@@ -96,6 +100,8 @@ abstract contract ExternalBridgeTest is Test {
         ism.verify(externalCalldata, encodedMessage);
         assertTrue(ism.isVerified(encodedMessage));
     }
+
+    /* ============ ISM.verify ============ */
 
     function test_verify_revertWhen_invalidMetadata() public virtual {
         vm.expectRevert();

--- a/solidity/test/isms/OPL2ToL1Ism.t.sol
+++ b/solidity/test/isms/OPL2ToL1Ism.t.sol
@@ -25,7 +25,6 @@ contract OPL2ToL1IsmTest is ExternalBridgeTest {
 
     MockOptimismPortal internal portal;
     MockOptimismMessenger internal l1Messenger;
-    OPL2ToL1Ism public ism;
 
     ///////////////////////////////////////////////////////////////////
     ///                            SETUP                            ///
@@ -47,9 +46,9 @@ contract OPL2ToL1IsmTest is ExternalBridgeTest {
     }
 
     function deployHook() public {
-        destinationMailbox = new TestMailbox(DESTINATION_DOMAIN);
+        originMailbox = new TestMailbox(ORIGIN_DOMAIN);
         hook = new OPL2ToL1Hook(
-            address(destinationMailbox),
+            address(originMailbox),
             DESTINATION_DOMAIN,
             TypeCasts.addressToBytes32(address(ism)),
             L2_MESSENGER_ADDRESS,
@@ -201,6 +200,21 @@ contract OPL2ToL1IsmTest is ExternalBridgeTest {
     }
 
     /* ============ helper functions ============ */
+
+    function _bridgeDestinationCall(
+        bytes memory _encodedHookData
+    ) internal override {
+        IOptimismPortal.WithdrawalTransaction
+            memory withdrawal = IOptimismPortal.WithdrawalTransaction({
+                nonce: MOCK_NONCE,
+                sender: L2_MESSENGER_ADDRESS,
+                target: address(l1Messenger),
+                value: 0,
+                gasLimit: uint256(GAS_QUOTE),
+                data: _encodeMessengerCalldata(address(ism), 0, messageId)
+            });
+        portal.finalizeWithdrawalTransaction(withdrawal);
+    }
 
     function _encodeMessengerCalldata(
         address _ism,

--- a/solidity/test/isms/OPL2ToL1Ism.t.sol
+++ b/solidity/test/isms/OPL2ToL1Ism.t.sol
@@ -109,17 +109,6 @@ contract OPL2ToL1IsmTest is ExternalBridgeTest {
         assertTrue(ism.verify(encodedWithdrawalTx, encodedMessage));
     }
 
-    function test_verify_revertsWhen_invalidIsm() public {
-        bytes memory encodedWithdrawalTx = _encodeFinalizeWithdrawalTx(
-            address(this),
-            0,
-            messageId
-        );
-
-        vm.expectRevert(); // evmRevert in MockOptimismPortal
-        ism.verify(encodedWithdrawalTx, encodedMessage);
-    }
-
     function test_verify_revertsWhen_incorrectMessageId() public {
         bytes32 incorrectMessageId = keccak256("incorrect message id");
 
@@ -170,7 +159,8 @@ contract OPL2ToL1IsmTest is ExternalBridgeTest {
 
     function _encodeExternalDestinationBridgeCall(
         address,
-        /*_from*/ address _to,
+        /*_from*/
+        address _to,
         uint256 _msgValue,
         bytes32 _messageId
     ) internal override returns (bytes memory) {

--- a/solidity/test/isms/OPL2ToL1Ism.t.sol
+++ b/solidity/test/isms/OPL2ToL1Ism.t.sol
@@ -29,18 +29,15 @@ contract OPL2ToL1IsmTest is ExternalBridgeTest {
     ///////////////////////////////////////////////////////////////////
 
     function setUp() public override {
-        ORIGIN_DOMAIN = 10;
-        DESTINATION_DOMAIN = 1;
-        GAS_QUOTE = 120_000;
-        super.setUp();
-
         // Optimism messenger mock setup
+        GAS_QUOTE = 120_000;
         vm.etch(
             L2_MESSENGER_ADDRESS,
             address(new MockOptimismMessenger()).code
         );
 
         deployAll();
+        super.setUp();
     }
 
     function deployHook() public {

--- a/solidity/test/isms/OPL2ToL1Ism.t.sol
+++ b/solidity/test/isms/OPL2ToL1Ism.t.sol
@@ -72,19 +72,9 @@ contract OPL2ToL1IsmTest is ExternalBridgeTest {
         ism.setAuthorizedHook(TypeCasts.addressToBytes32(address(hook)));
     }
 
-    function test_verify_directWithdrawalCall_revertsWhen_invalidSender()
-        public
-    {
-        l1Messenger.setXDomainMessageSender(address(this));
-
-        bytes memory encodedWithdrawalTx = _encodeFinalizeWithdrawalTx(
-            address(ism),
-            0,
-            messageId
-        );
-
-        vm.expectRevert(); // evmRevert in MockOptimismPortal
-        ism.verify(encodedWithdrawalTx, encodedMessage);
+    function _setExternalOriginSender(address _sender) internal override {
+        unauthorizedHookError = "AbstractMessageIdAuthorizedIsm: sender is not the hook";
+        l1Messenger.setXDomainMessageSender(_sender);
     }
 
     function test_verify_revertsWhen_incorrectMessageId() public {

--- a/solidity/test/isms/OPL2ToL1Ism.t.sol
+++ b/solidity/test/isms/OPL2ToL1Ism.t.sol
@@ -149,11 +149,6 @@ contract OPL2ToL1IsmTest is ExternalBridgeTest {
         assertTrue(ism.verify(encodedWithdrawalTx, encodedMessage));
     }
 
-    function test_verify_revertsWhen_noStatefulAndDirectWithdrawal() public {
-        vm.expectRevert();
-        ism.verify(new bytes(0), encodedMessage);
-    }
-
     function test_verify_revertsWhen_invalidIsm() public {
         bytes memory encodedWithdrawalTx = _encodeFinalizeWithdrawalTx(
             address(this),

--- a/solidity/test/isms/OPL2ToL1Ism.t.sol
+++ b/solidity/test/isms/OPL2ToL1Ism.t.sol
@@ -92,9 +92,11 @@ contract OPL2ToL1IsmTest is ExternalBridgeTest {
         return _encodeFinalizeWithdrawalTx(_to, _msgValue, _messageId);
     }
 
-    function _setExternalOriginSender(address _sender) internal override {
-        unauthorizedHookError = "AbstractMessageIdAuthorizedIsm: sender is not the hook";
+    function _setExternalOriginSender(
+        address _sender
+    ) internal override returns (bytes memory) {
         l1Messenger.setXDomainMessageSender(_sender);
+        return "AbstractMessageIdAuthorizedIsm: sender is not the hook";
     }
 
     function _externalBridgeDestinationCall(

--- a/solidity/test/isms/OPL2ToL1Ism.t.sol
+++ b/solidity/test/isms/OPL2ToL1Ism.t.sol
@@ -87,28 +87,6 @@ contract OPL2ToL1IsmTest is ExternalBridgeTest {
         ism.verify(encodedWithdrawalTx, encodedMessage);
     }
 
-    function test_verify_statefulAndDirectWithdrawal() public {
-        IOptimismPortal.WithdrawalTransaction
-            memory withdrawal = IOptimismPortal.WithdrawalTransaction({
-                nonce: MOCK_NONCE,
-                sender: L2_MESSENGER_ADDRESS,
-                target: address(l1Messenger),
-                value: 0,
-                gasLimit: uint256(GAS_QUOTE),
-                data: _encodeMessengerCalldata(address(ism), 0, messageId)
-            });
-        portal.finalizeWithdrawalTransaction(withdrawal);
-
-        bytes memory encodedWithdrawalTx = _encodeFinalizeWithdrawalTx(
-            address(ism),
-            0,
-            messageId
-        );
-
-        vm.etch(address(portal), new bytes(0)); // this is a way to test that the portal isn't called again
-        assertTrue(ism.verify(encodedWithdrawalTx, encodedMessage));
-    }
-
     function test_verify_revertsWhen_incorrectMessageId() public {
         bytes32 incorrectMessageId = keccak256("incorrect message id");
 

--- a/solidity/test/isms/OPL2ToL1Ism.t.sol
+++ b/solidity/test/isms/OPL2ToL1Ism.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 pragma solidity ^0.8.13;
 
-import {Test} from "forge-std/Test.sol";
-
 import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
 import {Message} from "../../contracts/libs/Message.sol";
 import {MessageUtils} from "./IsmTestUtils.sol";
@@ -34,7 +32,6 @@ contract OPL2ToL1IsmTest is ExternalBridgeTest {
         ORIGIN_DOMAIN = 10;
         DESTINATION_DOMAIN = 1;
         GAS_QUOTE = 120_000;
-        invalidMessageIdError = "OPL2ToL1Ism: invalid message id";
         super.setUp();
 
         // Optimism messenger mock setup

--- a/solidity/test/isms/OPL2ToL1Ism.t.sol
+++ b/solidity/test/isms/OPL2ToL1Ism.t.sol
@@ -15,57 +15,45 @@ import {TestRecipient} from "../../contracts/test/TestRecipient.sol";
 import {MockOptimismMessenger, MockOptimismPortal} from "../../contracts/mock/MockOptimism.sol";
 import {OPL2ToL1Hook} from "../../contracts/hooks/OPL2ToL1Hook.sol";
 import {OPL2ToL1Ism} from "../../contracts/isms/hook/OPL2ToL1Ism.sol";
+import {ExternalBridgeTest} from "./ExternalBridgeTest.sol";
 
-contract OPL2ToL1IsmTest is Test {
-    uint8 internal constant HYPERLANE_VERSION = 1;
-    uint32 internal constant MAINNET_DOMAIN = 1;
-    uint32 internal constant OPTIMISM_DOMAIN = 10;
-    uint32 internal constant GAS_QUOTE = 120_000;
-
+contract OPL2ToL1IsmTest is ExternalBridgeTest {
     address internal constant L2_MESSENGER_ADDRESS =
         0x4200000000000000000000000000000000000007;
 
     uint256 internal constant MOCK_NONCE = 0;
 
-    TestMailbox public l2Mailbox;
-    TestRecipient internal testRecipient;
-    bytes internal testMessage =
-        abi.encodePacked("Hello from the other chain!");
-    bytes internal encodedMessage;
-    bytes internal testMetadata =
-        StandardHookMetadata.overrideRefundAddress(address(this));
-    bytes32 internal messageId;
-
     MockOptimismPortal internal portal;
     MockOptimismMessenger internal l1Messenger;
-    OPL2ToL1Hook public hook;
     OPL2ToL1Ism public ism;
 
     ///////////////////////////////////////////////////////////////////
     ///                            SETUP                            ///
     ///////////////////////////////////////////////////////////////////
 
-    function setUp() public {
+    function setUp() public override {
+        ORIGIN_DOMAIN = 10;
+        DESTINATION_DOMAIN = 1;
+        GAS_QUOTE = 120_000;
+        super.setUp();
+
         // Optimism messenger mock setup
         vm.etch(
             L2_MESSENGER_ADDRESS,
             address(new MockOptimismMessenger()).code
         );
 
-        testRecipient = new TestRecipient();
-
-        encodedMessage = _encodeTestMessage();
-        messageId = Message.id(encodedMessage);
+        deployAll();
     }
 
     function deployHook() public {
-        l2Mailbox = new TestMailbox(OPTIMISM_DOMAIN);
+        destinationMailbox = new TestMailbox(DESTINATION_DOMAIN);
         hook = new OPL2ToL1Hook(
-            address(l2Mailbox),
-            MAINNET_DOMAIN,
+            address(destinationMailbox),
+            DESTINATION_DOMAIN,
             TypeCasts.addressToBytes32(address(ism)),
             L2_MESSENGER_ADDRESS,
-            GAS_QUOTE
+            uint32(GAS_QUOTE)
         );
     }
 
@@ -85,59 +73,19 @@ contract OPL2ToL1IsmTest is Test {
         ism.setAuthorizedHook(TypeCasts.addressToBytes32(address(hook)));
     }
 
-    function test_postDispatch() public {
-        deployAll();
-
-        bytes memory encodedHookData = abi.encodeCall(
-            AbstractMessageIdAuthorizedIsm.verifyMessageId,
-            (messageId)
-        );
-
-        l2Mailbox.updateLatestDispatchedId(messageId);
-
+    function _expectOriginBridgeCall(
+        bytes memory _encodedHookData
+    ) internal override {
         vm.expectCall(
             L2_MESSENGER_ADDRESS,
             abi.encodeCall(
                 ICrossDomainMessenger.sendMessage,
-                (address(ism), encodedHookData, GAS_QUOTE)
+                (address(ism), _encodedHookData, uint32(GAS_QUOTE))
             )
         );
-
-        hook.postDispatch{value: GAS_QUOTE}(testMetadata, encodedMessage);
-    }
-
-    function testFork_postDispatch_revertWhen_chainIDNotSupported() public {
-        deployAll();
-
-        bytes memory message = MessageUtils.formatMessage(
-            0,
-            uint32(0),
-            OPTIMISM_DOMAIN,
-            TypeCasts.addressToBytes32(address(this)),
-            2, // wrong domain
-            TypeCasts.addressToBytes32(address(testRecipient)),
-            testMessage
-        );
-
-        l2Mailbox.updateLatestDispatchedId(Message.id(message));
-        vm.expectRevert(
-            "AbstractMessageIdAuthHook: invalid destination domain"
-        );
-        hook.postDispatch(testMetadata, message);
-    }
-
-    function test_postDispatch_revertWhen_notLastDispatchedMessage() public {
-        deployAll();
-
-        vm.expectRevert(
-            "AbstractMessageIdAuthHook: message not latest dispatched"
-        );
-        hook.postDispatch(testMetadata, encodedMessage);
     }
 
     function test_verify_directWithdrawalCall() public {
-        deployAll();
-
         bytes memory encodedWithdrawalTx = _encodeFinalizeWithdrawalTx(
             address(ism),
             0,
@@ -150,7 +98,6 @@ contract OPL2ToL1IsmTest is Test {
     function test_verify_directWithdrawalCall_revertsWhen_invalidSender()
         public
     {
-        deployAll();
         l1Messenger.setXDomainMessageSender(address(this));
 
         bytes memory encodedWithdrawalTx = _encodeFinalizeWithdrawalTx(
@@ -164,8 +111,6 @@ contract OPL2ToL1IsmTest is Test {
     }
 
     function test_verify_statefulVerify() public {
-        deployAll();
-
         vm.deal(address(portal), 1 ether);
         IOptimismPortal.WithdrawalTransaction
             memory withdrawal = IOptimismPortal.WithdrawalTransaction({
@@ -184,8 +129,6 @@ contract OPL2ToL1IsmTest is Test {
     }
 
     function test_verify_statefulAndDirectWithdrawal() public {
-        deployAll();
-
         IOptimismPortal.WithdrawalTransaction
             memory withdrawal = IOptimismPortal.WithdrawalTransaction({
                 nonce: MOCK_NONCE,
@@ -208,15 +151,11 @@ contract OPL2ToL1IsmTest is Test {
     }
 
     function test_verify_revertsWhen_noStatefulAndDirectWithdrawal() public {
-        deployAll();
-
         vm.expectRevert();
         ism.verify(new bytes(0), encodedMessage);
     }
 
     function test_verify_revertsWhen_invalidIsm() public {
-        deployAll();
-
         bytes memory encodedWithdrawalTx = _encodeFinalizeWithdrawalTx(
             address(this),
             0,
@@ -228,8 +167,6 @@ contract OPL2ToL1IsmTest is Test {
     }
 
     function test_verify_revertsWhen_incorrectMessageId() public {
-        deployAll();
-
         bytes32 incorrectMessageId = keccak256("incorrect message id");
 
         bytes memory encodedWithdrawalTx = _encodeFinalizeWithdrawalTx(
@@ -265,28 +202,12 @@ contract OPL2ToL1IsmTest is Test {
 
     /* ============ helper functions ============ */
 
-    function _encodeTestMessage() internal view returns (bytes memory) {
-        return
-            MessageUtils.formatMessage(
-                HYPERLANE_VERSION,
-                uint32(0),
-                OPTIMISM_DOMAIN,
-                TypeCasts.addressToBytes32(address(this)),
-                MAINNET_DOMAIN,
-                TypeCasts.addressToBytes32(address(testRecipient)),
-                testMessage
-            );
-    }
-
     function _encodeMessengerCalldata(
         address _ism,
         uint256 _value,
         bytes32 _messageId
     ) internal view returns (bytes memory) {
-        bytes memory encodedHookData = abi.encodeCall(
-            AbstractMessageIdAuthorizedIsm.verifyMessageId,
-            (_messageId)
-        );
+        bytes memory encodedHookData = _encodeHookData(_messageId);
 
         return
             abi.encodeCall(

--- a/solidity/test/isms/OPL2ToL1Ism.t.sol
+++ b/solidity/test/isms/OPL2ToL1Ism.t.sol
@@ -72,16 +72,6 @@ contract OPL2ToL1IsmTest is ExternalBridgeTest {
         ism.setAuthorizedHook(TypeCasts.addressToBytes32(address(hook)));
     }
 
-    function test_verify_directWithdrawalCall() public {
-        bytes memory encodedWithdrawalTx = _encodeFinalizeWithdrawalTx(
-            address(ism),
-            0,
-            messageId
-        );
-
-        assertTrue(ism.verify(encodedWithdrawalTx, encodedMessage));
-    }
-
     function test_verify_directWithdrawalCall_revertsWhen_invalidSender()
         public
     {
@@ -166,7 +156,7 @@ contract OPL2ToL1IsmTest is ExternalBridgeTest {
 
     /* ============ helper functions ============ */
 
-    function _expectOriginBridgeCall(
+    function _expectOriginExternalBridgeCall(
         bytes memory _encodedHookData
     ) internal override {
         vm.expectCall(
@@ -178,9 +168,20 @@ contract OPL2ToL1IsmTest is ExternalBridgeTest {
         );
     }
 
-    function _bridgeDestinationCall(
+    function _encodeExternalDestinationBridgeCall(
+        address,
+        /*_from*/ address _to,
+        uint256 _msgValue,
+        bytes32 _messageId
+    ) internal override returns (bytes memory) {
+        vm.deal(address(portal), _msgValue);
+        return _encodeFinalizeWithdrawalTx(_to, _msgValue, _messageId);
+    }
+
+    function _externalBridgeDestinationCall(
         bytes memory,
-        /*_encodedHookData*/ uint256 _msgValue
+        /*_encodedHookData*/
+        uint256 _msgValue
     ) internal override {
         vm.deal(address(portal), _msgValue);
         IOptimismPortal.WithdrawalTransaction

--- a/solidity/test/isms/OPStackIsm.t.sol
+++ b/solidity/test/isms/OPStackIsm.t.sol
@@ -49,10 +49,7 @@ contract OPStackIsmTest is ExternalBridgeTest {
     event ReceivedMessage(bytes32 indexed messageId);
 
     function setUp() public override {
-        ORIGIN_DOMAIN = 1;
-        DESTINATION_DOMAIN = 10;
         GAS_QUOTE = 1_920_000; // optimism subsidized gas limit
-        super.setUp();
 
         vm.etch(
             L1_MESSENGER_ADDRESS,
@@ -66,6 +63,7 @@ contract OPStackIsmTest is ExternalBridgeTest {
         l2Messenger = MockOptimismMessenger(L2_MESSENGER_ADDRESS);
 
         deployAll();
+        super.setUp();
     }
 
     ///////////////////////////////////////////////////////////////////

--- a/solidity/test/isms/OPStackIsm.t.sol
+++ b/solidity/test/isms/OPStackIsm.t.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 pragma solidity ^0.8.13;
 
-import {Test} from "forge-std/Test.sol";
+import "forge-std/console.sol";
 
 import {LibBit} from "../../contracts/libs/LibBit.sol";
 import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
 import {StandardHookMetadata} from "../../contracts/hooks/libs/StandardHookMetadata.sol";
 import {StandardHookMetadata} from "../../contracts/hooks/libs/StandardHookMetadata.sol";
 import {AbstractMessageIdAuthorizedIsm} from "../../contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol";
+import {MockOptimismMessenger} from "../../contracts/mock/MockOptimism.sol";
 import {TestMailbox} from "../../contracts/test/TestMailbox.sol";
 import {Message} from "../../contracts/libs/Message.sol";
 import {MessageUtils} from "./IsmTestUtils.sol";
@@ -18,15 +19,13 @@ import {TestRecipient} from "../../contracts/test/TestRecipient.sol";
 import {NotCrossChainCall} from "@openzeppelin/contracts/crosschain/errors.sol";
 
 import {AddressAliasHelper} from "@eth-optimism/contracts/standards/AddressAliasHelper.sol";
-import {ICrossDomainMessenger, IL2CrossDomainMessenger} from "../../contracts/interfaces/optimism/ICrossDomainMessenger.sol";
+import {ICrossDomainMessenger} from "../../contracts/interfaces/optimism/ICrossDomainMessenger.sol";
+import {ExternalBridgeTest} from "./ExternalBridgeTest.sol";
 
-contract OPStackIsmTest is Test {
+contract OPStackIsmTest is ExternalBridgeTest {
     using LibBit for uint256;
     using TypeCasts for address;
     using MessageUtils for bytes;
-
-    uint256 internal mainnetFork;
-    uint256 internal optimismFork;
 
     address internal constant L1_MESSENGER_ADDRESS =
         0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1;
@@ -36,36 +35,12 @@ contract OPStackIsmTest is Test {
         0x4200000000000000000000000000000000000007;
 
     uint8 internal constant OPTIMISM_VERSION = 0;
-    uint8 internal constant HYPERLANE_VERSION = 1;
     uint256 internal constant DEFAULT_GAS_LIMIT = 1_920_000;
 
     address internal alice = address(0x1);
 
-    ICrossDomainMessenger internal l1Messenger;
-    IL2CrossDomainMessenger internal l2Messenger;
-    TestMailbox internal l1Mailbox;
-    OPStackIsm internal opISM;
-    OPStackHook internal opHook;
-
-    TestRecipient internal testRecipient;
-    bytes internal testMessage =
-        abi.encodePacked("Hello from the other chain!");
-    bytes internal testMetadata =
-        StandardHookMetadata.overrideRefundAddress(address(this));
-
-    bytes internal encodedMessage;
-    bytes32 internal messageId;
-
-    uint32 internal constant MAINNET_DOMAIN = 1;
-    uint32 internal constant OPTIMISM_DOMAIN = 10;
-
-    event SentMessage(
-        address indexed target,
-        address sender,
-        bytes message,
-        uint256 messageNonce,
-        uint256 gasLimit
-    );
+    MockOptimismMessenger internal l1Messenger;
+    MockOptimismMessenger internal l2Messenger;
 
     event RelayedMessage(bytes32 indexed msgHash);
 
@@ -73,469 +48,141 @@ contract OPStackIsmTest is Test {
 
     event ReceivedMessage(bytes32 indexed messageId);
 
-    function setUp() public {
-        // block numbers to fork from, chain data is cached to ../../forge-cache/
-        mainnetFork = vm.createFork(vm.rpcUrl("mainnet"), 18_992_500);
-        optimismFork = vm.createFork(vm.rpcUrl("optimism"), 114_696_811);
+    function setUp() public override {
+        ORIGIN_DOMAIN = 1;
+        DESTINATION_DOMAIN = 10;
+        GAS_QUOTE = 1_920_000; // optimism subsidized gas limit
+        super.setUp();
 
-        testRecipient = new TestRecipient();
+        vm.etch(
+            L1_MESSENGER_ADDRESS,
+            address(new MockOptimismMessenger()).code
+        );
+        vm.etch(
+            L2_MESSENGER_ADDRESS,
+            address(new MockOptimismMessenger()).code
+        );
+        l1Messenger = MockOptimismMessenger(L1_MESSENGER_ADDRESS);
+        l2Messenger = MockOptimismMessenger(L2_MESSENGER_ADDRESS);
 
-        encodedMessage = _encodeTestMessage();
-        messageId = Message.id(encodedMessage);
+        deployAll();
     }
 
     ///////////////////////////////////////////////////////////////////
     ///                            SETUP                            ///
     ///////////////////////////////////////////////////////////////////
 
-    function deployOptimismHook() public {
-        vm.selectFork(mainnetFork);
-
-        l1Messenger = ICrossDomainMessenger(L1_MESSENGER_ADDRESS);
-        l1Mailbox = new TestMailbox(MAINNET_DOMAIN);
-
-        opHook = new OPStackHook(
-            address(l1Mailbox),
-            OPTIMISM_DOMAIN,
-            TypeCasts.addressToBytes32(address(opISM)),
+    function deployHook() public {
+        originMailbox = new TestMailbox(ORIGIN_DOMAIN);
+        hook = new OPStackHook(
+            address(originMailbox),
+            DESTINATION_DOMAIN,
+            TypeCasts.addressToBytes32(address(ism)),
             L1_MESSENGER_ADDRESS
         );
-
-        vm.makePersistent(address(opHook));
     }
 
-    function deployOPStackIsm() public {
-        vm.selectFork(optimismFork);
-
-        l2Messenger = IL2CrossDomainMessenger(L2_MESSENGER_ADDRESS);
-        opISM = new OPStackIsm(L2_MESSENGER_ADDRESS);
-
-        vm.makePersistent(address(opISM));
+    function deployIsm() public {
+        ism = new OPStackIsm(L2_MESSENGER_ADDRESS);
     }
 
     function deployAll() public {
-        deployOPStackIsm();
-        deployOptimismHook();
+        deployIsm();
+        deployHook();
 
-        vm.selectFork(optimismFork);
-
-        opISM.setAuthorizedHook(TypeCasts.addressToBytes32(address(opHook)));
+        ism.setAuthorizedHook(TypeCasts.addressToBytes32(address(hook)));
+        l2Messenger.setXDomainMessageSender(address(hook));
         // for sending value
-        vm.deal(
-            AddressAliasHelper.applyL1ToL2Alias(L1_MESSENGER_ADDRESS),
-            2 ** 255
-        );
+        // vm.deal(AddressAliasHelper.applyL1ToL2Alias(L1_MESSENGER_ADDRESS), 2 ** 255);
     }
-
-    ///////////////////////////////////////////////////////////////////
-    ///                         FORK TESTS                          ///
-    ///////////////////////////////////////////////////////////////////
 
     /* ============ hook.quoteDispatch ============ */
 
-    function testFork_quoteDispatch() public {
-        deployAll();
-
-        vm.selectFork(mainnetFork);
-
-        assertEq(opHook.quoteDispatch(testMetadata, encodedMessage), 0);
+    function test_quoteDispatch() public view {
+        assertEq(hook.quoteDispatch(testMetadata, encodedMessage), 0);
     }
 
     /* ============ hook.postDispatch ============ */
 
-    function testFork_postDispatch() public {
-        deployAll();
-
-        vm.selectFork(mainnetFork);
-
-        bytes memory encodedHookData = abi.encodeCall(
-            AbstractMessageIdAuthorizedIsm.verifyMessageId,
-            (messageId)
+    function _expectOriginExternalBridgeCall(
+        bytes memory _encodedHookData
+    ) internal override {
+        vm.expectCall(
+            L1_MESSENGER_ADDRESS,
+            abi.encodeCall(
+                ICrossDomainMessenger.sendMessage,
+                (address(ism), _encodedHookData, uint32(GAS_QUOTE))
+            )
         );
-
-        uint40 testNonce = 123;
-        l1Mailbox.updateLatestDispatchedId(messageId);
-
-        vm.expectEmit(true, true, true, false, L1_MESSENGER_ADDRESS);
-        emit SentMessage(
-            address(opISM),
-            address(opHook),
-            encodedHookData,
-            testNonce,
-            DEFAULT_GAS_LIMIT
-        );
-        opHook.postDispatch(testMetadata, encodedMessage);
     }
 
-    function testFork_postDispatch_RevertWhen_ChainIDNotSupported() public {
-        deployAll();
-
-        vm.selectFork(mainnetFork);
-
-        bytes memory message = MessageUtils.formatMessage(
-            OPTIMISM_VERSION,
-            uint32(0),
-            MAINNET_DOMAIN,
-            TypeCasts.addressToBytes32(address(this)),
-            11, // wrong domain
-            TypeCasts.addressToBytes32(address(testRecipient)),
-            testMessage
+    function _externalBridgeDestinationCall(
+        bytes memory _encodedHookData,
+        uint256 _msgValue
+    ) internal override {
+        vm.deal(L2_MESSENGER_ADDRESS, _msgValue);
+        l2Messenger.relayMessage(
+            0,
+            address(hook),
+            address(ism),
+            _msgValue,
+            uint32(GAS_QUOTE),
+            _encodedHookData
         );
-
-        l1Mailbox.updateLatestDispatchedId(Message.id(message));
-        vm.expectRevert(
-            "AbstractMessageIdAuthHook: invalid destination domain"
-        );
-        opHook.postDispatch(testMetadata, message);
     }
 
-    function testFork_postDispatch_RevertWhen_TooMuchValue() public {
-        deployAll();
-
-        vm.selectFork(mainnetFork);
-
-        vm.deal(address(this), uint256(2 ** 255 + 1));
-        bytes memory excessValueMetadata = StandardHookMetadata
-            .overrideMsgValue(uint256(2 ** 255 + 1));
-
-        l1Mailbox.updateLatestDispatchedId(messageId);
-        vm.expectRevert(
-            "AbstractMessageIdAuthHook: msgValue must be less than 2 ** 255"
-        );
-        opHook.postDispatch(excessValueMetadata, encodedMessage);
+    function _encodeExternalDestinationBridgeCall(
+        address _from,
+        address _to,
+        uint256 _msgValue,
+        bytes32 _messageId
+    ) internal pure override returns (bytes memory) {
+        return new bytes(0);
     }
 
-    function testFork_postDispatch_RevertWhen_NotLastDispatchedMessage()
-        public
-    {
-        deployAll();
+    // SKIP - no external bridge call
+    function test_verifyMessageId_externalBridgeCall() public override {}
 
-        vm.selectFork(mainnetFork);
+    function test_verify_msgValue_externalBridgeCall() public override {}
 
-        vm.expectRevert(
-            "AbstractMessageIdAuthHook: message not latest dispatched"
-        );
-        opHook.postDispatch(testMetadata, encodedMessage);
-    }
+    function test_verify_revertsWhen_invalidIsm() public override {}
 
     /* ============ ISM.verifyMessageId ============ */
 
-    function testFork_verifyMessageId() public {
-        deployAll();
-
-        vm.selectFork(optimismFork);
-
-        bytes memory encodedHookData = abi.encodeCall(
-            AbstractMessageIdAuthorizedIsm.verifyMessageId,
-            (messageId)
-        );
-
-        (uint240 nonce, uint16 version) = decodeVersionedNonce(
-            l2Messenger.messageNonce()
-        );
-        uint256 versionedNonce = encodeVersionedNonce(nonce + 1, version);
-
-        bytes32 versionedHash = hashCrossDomainMessageV1(
-            versionedNonce,
-            address(opHook),
-            address(opISM),
-            0,
-            DEFAULT_GAS_LIMIT,
-            encodedHookData
-        );
-
-        vm.startPrank(
-            AddressAliasHelper.applyL1ToL2Alias(L1_MESSENGER_ADDRESS)
-        );
-
-        vm.expectEmit(true, false, false, false, address(opISM));
-        emit ReceivedMessage(messageId);
-
-        vm.expectEmit(true, false, false, false, L2_MESSENGER_ADDRESS);
-        emit RelayedMessage(versionedHash);
-
-        l2Messenger.relayMessage(
-            versionedNonce,
-            address(opHook),
-            address(opISM),
-            0,
-            DEFAULT_GAS_LIMIT,
-            encodedHookData
-        );
-
-        assertTrue(opISM.verifiedMessages(messageId).isBitSet(255));
-        vm.stopPrank();
-    }
-
-    function testFork_verifyMessageId_RevertWhen_NotAuthorized() public {
-        deployAll();
-
-        vm.selectFork(optimismFork);
-
+    function test_verify_revertsWhen_notAuthorizedHook() public override {
         // needs to be called by the canonical messenger on Optimism
         vm.expectRevert(NotCrossChainCall.selector);
-        opISM.verifyMessageId(messageId);
-
-        // set the xDomainMessageSender storage slot as alice
-        bytes32 key = bytes32(uint256(204));
-        bytes32 value = TypeCasts.addressToBytes32(alice);
-        vm.store(address(l2Messenger), key, value);
+        ism.verifyMessageId(messageId);
 
         vm.startPrank(L2_MESSENGER_ADDRESS);
+        _setExternalOriginSender(address(this));
 
         // needs to be called by the authorized hook contract on Ethereum
         vm.expectRevert(
             "AbstractMessageIdAuthorizedIsm: sender is not the hook"
         );
-        opISM.verifyMessageId(messageId);
+        ism.verifyMessageId(messageId);
+    }
+
+    function _setExternalOriginSender(address _sender) internal override {
+        l2Messenger.setXDomainMessageSender(_sender);
     }
 
     /* ============ ISM.verify ============ */
 
-    function testFork_verify() public {
-        deployAll();
-
-        vm.selectFork(optimismFork);
-
-        orchestrateRelayMessage(0, messageId);
-
-        bool verified = opISM.verify(new bytes(0), encodedMessage);
-        assertTrue(verified);
-    }
-
-    /// forge-config: default.fuzz.runs = 10
-    function testFork_verify_WithValue(uint256 _msgValue) public {
-        _msgValue = bound(_msgValue, 0, 2 ** 254);
-        deployAll();
-
-        orchestrateRelayMessage(_msgValue, messageId);
-
-        bool verified = opISM.verify(new bytes(0), encodedMessage);
-        assertTrue(verified);
-
-        assertEq(address(opISM).balance, 0);
-        assertEq(address(testRecipient).balance, _msgValue);
-    }
-
-    /// forge-config: default.fuzz.runs = 10
-    function testFork_verify_valueAlreadyClaimed(uint256 _msgValue) public {
-        _msgValue = bound(_msgValue, 0, 2 ** 254);
-        deployAll();
-
-        orchestrateRelayMessage(_msgValue, messageId);
-
-        bool verified = opISM.verify(new bytes(0), encodedMessage);
-        assertTrue(verified);
-
-        assertEq(address(opISM).balance, 0);
-        assertEq(address(testRecipient).balance, _msgValue);
-
-        // send more value to the ISM
-        vm.deal(address(opISM), _msgValue);
-
-        verified = opISM.verify(new bytes(0), encodedMessage);
-        // verified still true
-        assertTrue(verified);
-
-        assertEq(address(opISM).balance, _msgValue);
-        // value which was already sent
-        assertEq(address(testRecipient).balance, _msgValue);
-    }
-
-    function testFork_verify_tooMuchValue() public {
-        deployAll();
-
+    function test_verify_tooMuchValue() public {
         uint256 _msgValue = 2 ** 255 + 1;
 
-        vm.expectEmit(false, false, false, false, address(l2Messenger));
-        emit FailedRelayedMessage(messageId);
-        orchestrateRelayMessage(_msgValue, messageId);
+        vm.expectRevert(
+            "AbstractMessageIdAuthorizedIsm: msg.value must be less than 2^255"
+        );
+        _externalBridgeDestinationCall(_encodeHookData(messageId), _msgValue);
 
-        bool verified = opISM.verify(new bytes(0), encodedMessage);
-        assertFalse(verified);
+        assertFalse(ism.isVerified(encodedMessage));
 
-        assertEq(address(opISM).balance, 0);
+        assertEq(address(ism).balance, 0);
         assertEq(address(testRecipient).balance, 0);
     }
 
-    // sending over invalid message
-    function testFork_verify_RevertWhen_HyperlaneInvalidMessage() public {
-        deployAll();
-
-        orchestrateRelayMessage(0, messageId);
-
-        bytes memory invalidMessage = MessageUtils.formatMessage(
-            HYPERLANE_VERSION,
-            uint8(0),
-            MAINNET_DOMAIN,
-            TypeCasts.addressToBytes32(address(this)),
-            OPTIMISM_DOMAIN,
-            TypeCasts.addressToBytes32(address(this)), // wrong recipient
-            testMessage
-        );
-        bool verified = opISM.verify(new bytes(0), invalidMessage);
-        assertFalse(verified);
-    }
-
-    // invalid messageID in postDispatch
-    function testFork_verify_RevertWhen_InvalidOptimismMessageID() public {
-        deployAll();
-        vm.selectFork(optimismFork);
-
-        bytes memory invalidMessage = MessageUtils.formatMessage(
-            HYPERLANE_VERSION,
-            uint8(0),
-            MAINNET_DOMAIN,
-            TypeCasts.addressToBytes32(address(this)),
-            OPTIMISM_DOMAIN,
-            TypeCasts.addressToBytes32(address(this)),
-            testMessage
-        );
-        bytes32 _messageId = Message.id(invalidMessage);
-        orchestrateRelayMessage(0, _messageId);
-
-        bool verified = opISM.verify(new bytes(0), encodedMessage);
-        assertFalse(verified);
-    }
-
     /* ============ helper functions ============ */
-
-    function _encodeTestMessage() internal view returns (bytes memory) {
-        return
-            MessageUtils.formatMessage(
-                HYPERLANE_VERSION,
-                uint32(0),
-                MAINNET_DOMAIN,
-                TypeCasts.addressToBytes32(address(this)),
-                OPTIMISM_DOMAIN,
-                TypeCasts.addressToBytes32(address(testRecipient)),
-                testMessage
-            );
-    }
-
-    /// @dev from eth-optimism/contracts-bedrock/contracts/libraries/Hashing.sol
-    /// @notice Hashes a cross domain message based on the V1 (current) encoding.
-    /// @param _nonce    Message nonce.
-    /// @param _sender   Address of the sender of the message.
-    /// @param _target   Address of the target of the message.
-    /// @param _value    ETH value to send to the target.
-    /// @param _gasLimit Gas limit to use for the message.
-    /// @param _data     Data to send with the message.
-    /// @return Hashed cross domain message.
-    function hashCrossDomainMessageV1(
-        uint256 _nonce,
-        address _sender,
-        address _target,
-        uint256 _value,
-        uint256 _gasLimit,
-        bytes memory _data
-    ) internal pure returns (bytes32) {
-        return
-            keccak256(
-                encodeCrossDomainMessageV1(
-                    _nonce,
-                    _sender,
-                    _target,
-                    _value,
-                    _gasLimit,
-                    _data
-                )
-            );
-    }
-
-    /// @dev from eth-optimism/contracts-bedrock/contracts/libraries/Encoding.sol
-    /// @notice Encodes a cross domain message based on the V1 (current) encoding.
-    /// @param _nonce    Message nonce.
-    /// @param _sender   Address of the sender of the message.
-    /// @param _target   Address of the target of the message.
-    /// @param _value    ETH value to send to the target.
-    /// @param _gasLimit Gas limit to use for the message.
-    /// @param _data     Data to send with the message.
-    /// @return Encoded cross domain message.
-    function encodeCrossDomainMessageV1(
-        uint256 _nonce,
-        address _sender,
-        address _target,
-        uint256 _value,
-        uint256 _gasLimit,
-        bytes memory _data
-    ) internal pure returns (bytes memory) {
-        return
-            abi.encodeWithSignature(
-                "relayMessage(uint256,address,address,uint256,uint256,bytes)",
-                _nonce,
-                _sender,
-                _target,
-                _value,
-                _gasLimit,
-                _data
-            );
-    }
-
-    /// @dev from eth-optimism/contracts-bedrock/contracts/libraries/Encoding.sol
-    /// @notice Adds a version number into the first two bytes of a message nonce.
-    /// @param _nonce   Message nonce to encode into.
-    /// @param _version Version number to encode into the message nonce.
-    /// @return Message nonce with version encoded into the first two bytes.
-    function encodeVersionedNonce(
-        uint240 _nonce,
-        uint16 _version
-    ) internal pure returns (uint256) {
-        uint256 nonce;
-        assembly {
-            nonce := or(shl(240, _version), _nonce)
-        }
-        return nonce;
-    }
-
-    /// @dev from eth-optimism/contracts-bedrock/contracts/libraries/Encoding.sol
-    /// @notice Pulls the version out of a version-encoded nonce.
-    /// @param _nonce Message nonce with version encoded into the first two bytes.
-    /// @return Nonce without encoded version.
-    /// @return Version of the message.
-    function decodeVersionedNonce(
-        uint256 _nonce
-    ) internal pure returns (uint240, uint16) {
-        uint240 nonce;
-        uint16 version;
-        assembly {
-            nonce := and(
-                _nonce,
-                0x0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-            )
-            version := shr(240, _nonce)
-        }
-        return (nonce, version);
-    }
-
-    function orchestrateRelayMessage(
-        uint256 _msgValue,
-        bytes32 _messageId
-    ) internal {
-        vm.selectFork(optimismFork);
-
-        bytes memory encodedHookData = abi.encodeCall(
-            AbstractMessageIdAuthorizedIsm.verifyMessageId,
-            (_messageId)
-        );
-
-        (uint240 nonce, uint16 version) = decodeVersionedNonce(
-            l2Messenger.messageNonce()
-        );
-        uint256 versionedNonce = encodeVersionedNonce(nonce + 1, version);
-
-        vm.deal(
-            AddressAliasHelper.applyL1ToL2Alias(L1_MESSENGER_ADDRESS),
-            2 ** 256 - 1
-        );
-        vm.prank(AddressAliasHelper.applyL1ToL2Alias(L1_MESSENGER_ADDRESS));
-        l2Messenger.relayMessage{value: _msgValue}(
-            versionedNonce,
-            address(opHook),
-            address(opISM),
-            _msgValue,
-            DEFAULT_GAS_LIMIT,
-            encodedHookData
-        );
-    }
 }

--- a/solidity/test/isms/OPStackIsm.t.sol
+++ b/solidity/test/isms/OPStackIsm.t.sol
@@ -112,7 +112,7 @@ contract OPStackIsmTest is ExternalBridgeTest {
             L1_MESSENGER_ADDRESS,
             abi.encodeCall(
                 ICrossDomainMessenger.sendMessage,
-                (address(ism), _encodedHookData, uint32(GAS_QUOTE))
+                (address(ism), _encodedHookData, uint32(DEFAULT_GAS_LIMIT))
             )
         );
     }

--- a/solidity/test/isms/OPStackIsm.t.sol
+++ b/solidity/test/isms/OPStackIsm.t.sol
@@ -162,8 +162,11 @@ contract OPStackIsmTest is ExternalBridgeTest {
         ism.verifyMessageId(messageId);
     }
 
-    function _setExternalOriginSender(address _sender) internal override {
+    function _setExternalOriginSender(
+        address _sender
+    ) internal override returns (bytes memory) {
         l2Messenger.setXDomainMessageSender(_sender);
+        return "";
     }
 
     /* ============ ISM.verify ============ */


### PR DESCRIPTION
### Description

We currently have 6 different versions of ISMs derived from AbstractMessageIdAuthorizedIsm:
- OPL2ToL1
- ArbL2ToL1
- OPStack (L1->L2)
- ERC5164
- LayerZero
- PolygonPOS

But all of them have their own custom test suite right now, with widely overlapping testing areas. For standardizing the tests, I've created a base test contract `ExternalBridgeTest` that handles the common tests. This has a few benefits:
- harder to miss tests for known pitfalls like msg.value or asynchronicity assumption for verifyMessageId 
- less code duplication with each additional Ism

I have moved OPL2ToL1, ArbL2ToL1, OPStack, and ERC5164 to the new base test, and I'll forgo the rest for now because of the time sensitivity of audit remediations. I've created an issue tracking the remaining work here: https://github.com/hyperlane-xyz/issues/issues/1384

### Drive-by changes

None

### Related issues

Related to https://github.com/chainlight-io/2024-08-hyperlane/issues/3

### Backward compatibility

Yes

### Testing

Unit
