### PR TITLE
feat: support multiple validator sets for a single app context in the relayer's observed validator metrics

### DIFF
--- a/rust/main/hyperlane-base/src/metrics/core.rs
+++ b/rust/main/hyperlane-base/src/metrics/core.rs
@@ -461,7 +461,7 @@ struct AppContextKey {
 
 /// If this period has elapsed since the last update, we will clear out the
 /// previous metrics for the app context.
-const VALIDATOR_SET_REFRESH_PERIOD: time::Duration = time::Duration::from_secs(60 * 3);
+const MIN_VALIDATOR_SET_REFRESH_PERIOD: time::Duration = time::Duration::from_secs(60 * 3);
 
 /// Manages metrics for observing sets of validators.
 pub struct ValidatorObservabilityMetricManager {
@@ -503,7 +503,7 @@ impl ValidatorObservabilityMetricManager {
             // to be called multiple times in a short period without clearing out
             // the metrics, e.g. when a message's ISM aggregates multiple different
             // validator sets.
-            if last_updated_at.elapsed() > VALIDATOR_SET_REFRESH_PERIOD {
+            if last_updated_at.elapsed() > MIN_VALIDATOR_SET_REFRESH_PERIOD {
                 for validator in prev_validators {
                     // We unwrap because an error here occurs if the # of labels
                     // provided is incorrect, and we'd like to loudly fail in e2e if that

--- a/rust/main/hyperlane-base/src/metrics/core.rs
+++ b/rust/main/hyperlane-base/src/metrics/core.rs
@@ -503,7 +503,7 @@ impl ValidatorObservabilityMetricManager {
 
         // First, attempt to clear out all previous metrics for the app context.
         // This is necessary because the set of validators may have changed.
-        if let Some(prev_validators) = app_context_validators.get_mut(&key) {
+        if let Some(prev_validators) = app_context_validators.get(&key) {
             // If the validator was last updated in the metrics more than
             // a certain period ago, remove it from the metrics.
             // Some leniency is given here to allow this function to be called

--- a/rust/main/hyperlane-base/src/metrics/core.rs
+++ b/rust/main/hyperlane-base/src/metrics/core.rs
@@ -467,6 +467,8 @@ const MIN_VALIDATOR_SET_REFRESH_PERIOD: time::Duration = time::Duration::from_se
 pub struct ValidatorObservabilityMetricManager {
     observed_validator_latest_index: IntGaugeVec,
 
+    // Cache of the validators for each app context, along with the time of the
+    // last time the metric was refreshed to tolerate validators that have been rotated out.
     app_context_validators: RwLock<HashMap<AppContextKey, (HashSet<H160>, time::Instant)>>,
 }
 
@@ -497,30 +499,40 @@ impl ValidatorObservabilityMetricManager {
 
         // First, attempt to clear out all previous metrics for the app context.
         // This is necessary because the set of validators may have changed.
-        if let Some((prev_validators, last_updated_at)) = app_context_validators.get(&key) {
-            // If the last update was more than this period ago, clear out the
-            // previous metrics. Some leniency is given here to allow this function
-            // to be called multiple times in a short period without clearing out
-            // the metrics, e.g. when a message's ISM aggregates multiple different
-            // validator sets.
-            if last_updated_at.elapsed() > MIN_VALIDATOR_SET_REFRESH_PERIOD {
-                for validator in prev_validators {
-                    // We unwrap because an error here occurs if the # of labels
-                    // provided is incorrect, and we'd like to loudly fail in e2e if that
-                    // happens.
-                    self.observed_validator_latest_index
-                        .remove_label_values(&[
-                            origin.as_ref(),
-                            destination.as_ref(),
-                            &format!("0x{:x}", validator).to_lowercase(),
-                            &app_context,
-                        ])
-                        .unwrap();
+        let (mut new_set, new_metric_refresh_time) =
+            if let Some((prev_validators, prev_metric_refresh_time)) =
+                app_context_validators.get(&key)
+            {
+                // If the last refresh to the metrics was more than this period ago, clear out the
+                // previous metrics. Some leniency is given here to allow this function
+                // to be called multiple times in a short period without clearing out
+                // the metrics, e.g. when a message's ISM aggregates multiple different
+                // validator sets.
+                if prev_metric_refresh_time.elapsed() > MIN_VALIDATOR_SET_REFRESH_PERIOD {
+                    for validator in prev_validators {
+                        // We unwrap because an error here occurs if the # of labels
+                        // provided is incorrect, and we'd like to loudly fail in e2e if that
+                        // happens.
+                        self.observed_validator_latest_index
+                            .remove_label_values(&[
+                                origin.as_ref(),
+                                destination.as_ref(),
+                                &format!("0x{:x}", validator).to_lowercase(),
+                                &app_context,
+                            ])
+                            .unwrap();
+                    }
+                    // Clear out the previous set of validators and update the time of the last metric refresh.
+                    (HashSet::new(), time::Instant::now())
+                } else {
+                    // If the last metric refresh was too recent, keep the previous set of validators
+                    // and the time of the last metric refresh.
+                    (prev_validators.clone(), prev_metric_refresh_time.clone())
                 }
-            }
-        }
-
-        let mut set = HashSet::new();
+            } else {
+                // If there was no previous set of validators, start with an empty set and the current time.
+                (HashSet::new(), time::Instant::now())
+            };
 
         // Then set the new metrics and update the cached set of validators.
         for (validator, latest_checkpoint) in latest_checkpoints {
@@ -534,9 +546,9 @@ impl ValidatorObservabilityMetricManager {
                 // If the latest checkpoint is None, set to -1 to indicate that
                 // the validator did not provide a valid latest checkpoint index.
                 .set(latest_checkpoint.map(|i| i as i64).unwrap_or(-1));
-            set.insert(*validator);
+            new_set.insert(*validator);
         }
-        app_context_validators.insert(key, (set, time::Instant::now()));
+        app_context_validators.insert(key, (new_set, new_metric_refresh_time));
     }
 
     /// Gauge for reporting recently observed latest checkpoint indices for validator sets.

--- a/rust/main/hyperlane-base/src/metrics/core.rs
+++ b/rust/main/hyperlane-base/src/metrics/core.rs
@@ -459,9 +459,9 @@ struct AppContextKey {
     app_context: String,
 }
 
-/// If this period has elapsed since the last update, we will clear out the
-/// previous metrics for the app context.
-const MIN_VALIDATOR_SET_REFRESH_PERIOD: time::Duration = time::Duration::from_secs(60 * 3);
+/// If this period has elapsed since a validator was last updated in the metrics,
+/// it will be removed from the metrics.
+const MIN_VALIDATOR_METRIC_RESET_PERIOD: time::Duration = time::Duration::from_secs(60 * 3);
 
 /// Manages metrics for observing sets of validators.
 pub struct ValidatorObservabilityMetricManager {
@@ -510,7 +510,7 @@ impl ValidatorObservabilityMetricManager {
             // multiple times in a short period without clearing out the metrics,
             // e.g. when a message's ISM aggregates multiple different validator sets.
             for (validator, last_updated_at) in prev_validators {
-                if last_updated_at.elapsed() < MIN_VALIDATOR_SET_REFRESH_PERIOD {
+                if last_updated_at.elapsed() < MIN_VALIDATOR_METRIC_RESET_PERIOD {
                     // If the last metric refresh was too recent, keep the validator
                     // and the time of its last metric update.
                     new_set.insert(*validator, *last_updated_at);


### PR DESCRIPTION
### Description

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4030
- The general idea of this change is that if the function `set_validator_latest_checkpoints` is called multiple times in a single message's metadata building, the reset of metrics relating to previously set validators now won't always occur. Atm, if two different multisig ISM validator sets are aggregated, they race each other to update the metric. With this change I expect the contention here to not occur anymore, and to still be able to handle changes in validator sets
- This is a bit of a quick fix rather than something super robust tbh - I think in a vacuum I'd prefer something not dependent on time but instead dependent on a context of what message is being processed or something. But at the moment we're seeing very noisy alerts because of this issue, so would like to fix it ASAP.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
