### PR TITLE
fix: Sealevel hyp token adapter fixes

### DIFF
--- a/.changeset/young-moose-march.md
+++ b/.changeset/young-moose-march.md
@@ -2,4 +2,5 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-Fix args for Sevelel hyp token adapters
+Fix arg validation for Sealevel HypNative adapters
+Allow extra properties in ChainMetadata objects

--- a/.changeset/young-moose-march.md
+++ b/.changeset/young-moose-march.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Fix args for Sevelel hyp token adapters

--- a/typescript/sdk/src/metadata/chainMetadataTypes.ts
+++ b/typescript/sdk/src/metadata/chainMetadataTypes.ts
@@ -249,11 +249,10 @@ export const ChainMetadataSchemaObject = z.object({
 });
 
 // Passthrough allows for extra fields to remain in the object (such as extensions consumers may want like `mailbox`)
-const ChainMetadataSchemaObjectExtensible =
-  ChainMetadataSchemaObject.passthrough();
+const ChainMetadataSchemaExtensible = ChainMetadataSchemaObject.passthrough();
 
 // Add refinements to the object schema to conditionally validate certain fields
-export const ChainMetadataSchema = ChainMetadataSchemaObjectExtensible.refine(
+export const ChainMetadataSchema = ChainMetadataSchemaExtensible.refine(
   (metadata) => {
     if (
       [ProtocolType.Ethereum, ProtocolType.Sealevel].includes(

--- a/typescript/sdk/src/metadata/chainMetadataTypes.ts
+++ b/typescript/sdk/src/metadata/chainMetadataTypes.ts
@@ -248,8 +248,12 @@ export const ChainMetadataSchemaObject = z.object({
     .describe('Properties to include when forming transaction requests.'),
 });
 
+// Passthrough allows for extra fields to remain in the object (such as extensions consumers may want like `mailbox`)
+const ChainMetadataSchemaObjectExtensible =
+  ChainMetadataSchemaObject.passthrough();
+
 // Add refinements to the object schema to conditionally validate certain fields
-export const ChainMetadataSchema = ChainMetadataSchemaObject.refine(
+export const ChainMetadataSchema = ChainMetadataSchemaObjectExtensible.refine(
   (metadata) => {
     if (
       [ProtocolType.Ethereum, ProtocolType.Sealevel].includes(
@@ -333,7 +337,9 @@ export const ChainMetadataSchema = ChainMetadataSchemaObject.refine(
     },
   );
 
-export type ChainMetadata<Ext = object> = z.infer<typeof ChainMetadataSchema> &
+export type ChainMetadata<Ext = object> = z.infer<
+  typeof ChainMetadataSchemaObject
+> &
   Ext;
 
 export type BlockExplorer = Exclude<

--- a/typescript/sdk/src/token/Token.ts
+++ b/typescript/sdk/src/token/Token.ts
@@ -170,13 +170,8 @@ export class Token implements IToken {
     multiProvider: MultiProtocolProvider<{ mailbox?: Address }>,
     destination?: ChainName,
   ): IHypTokenAdapter<unknown> {
-    const {
-      protocol,
-      standard,
-      chainName,
-      addressOrDenom,
-      collateralAddressOrDenom,
-    } = this;
+    const { standard, chainName, addressOrDenom, collateralAddressOrDenom } =
+      this;
     const chainMetadata = multiProvider.tryGetChainMetadata(chainName);
     const mailbox = chainMetadata?.mailbox;
 
@@ -190,19 +185,6 @@ export class Token implements IToken {
       `Token chain ${chainName} not found in multiProvider`,
     );
 
-    let sealevelAddresses;
-    if (protocol === ProtocolType.Sealevel) {
-      assert(mailbox, `Mailbox required for Sealevel hyp tokens`);
-      assert(
-        collateralAddressOrDenom,
-        `collateralAddressOrDenom required for Sealevel hyp tokens`,
-      );
-      sealevelAddresses = {
-        warpRouter: addressOrDenom,
-        token: collateralAddressOrDenom,
-        mailbox,
-      };
-    }
     if (standard === TokenStandard.EvmHypNative) {
       return new EvmHypNativeAdapter(chainName, multiProvider, {
         token: addressOrDenom,
@@ -232,24 +214,46 @@ export class Token implements IToken {
         token: addressOrDenom,
       });
     } else if (standard === TokenStandard.SealevelHypNative) {
+      assert(mailbox, `Mailbox required for Sealevel hyp tokens`);
       return new SealevelHypNativeAdapter(
         chainName,
         multiProvider,
-        sealevelAddresses!,
+        {
+          warpRouter: addressOrDenom,
+          mailbox,
+        },
         false,
       );
     } else if (standard === TokenStandard.SealevelHypCollateral) {
+      assert(mailbox, `Mailbox required for Sealevel hyp tokens`);
+      assert(
+        collateralAddressOrDenom,
+        `collateralAddressOrDenom required for Sealevel hyp collateral tokens`,
+      );
       return new SealevelHypCollateralAdapter(
         chainName,
         multiProvider,
-        sealevelAddresses!,
+        {
+          warpRouter: addressOrDenom,
+          token: collateralAddressOrDenom,
+          mailbox,
+        },
         false,
       );
     } else if (standard === TokenStandard.SealevelHypSynthetic) {
+      assert(mailbox, `Mailbox required for Sealevel hyp tokens`);
+      assert(
+        collateralAddressOrDenom,
+        `collateralAddressOrDenom required for Sealevel hyp collateral tokens`,
+      );
       return new SealevelHypSyntheticAdapter(
         chainName,
         multiProvider,
-        sealevelAddresses!,
+        {
+          warpRouter: addressOrDenom,
+          token: collateralAddressOrDenom,
+          mailbox,
+        },
         false,
       );
     } else if (standard === TokenStandard.CwHypNative) {

--- a/typescript/sdk/src/token/Token.ts
+++ b/typescript/sdk/src/token/Token.ts
@@ -244,7 +244,7 @@ export class Token implements IToken {
       assert(mailbox, `Mailbox required for Sealevel hyp tokens`);
       assert(
         collateralAddressOrDenom,
-        `collateralAddressOrDenom required for Sealevel hyp collateral tokens`,
+        `collateralAddressOrDenom required for Sealevel hyp synthetic tokens`,
       );
       return new SealevelHypSyntheticAdapter(
         chainName,

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -49,6 +49,8 @@ import {
   SealevelTransferRemoteSchema,
 } from './serialization.js';
 
+const NON_EXISTENT_ACCOUNT_ERROR = 'could not find account';
+
 // Interacts with native currencies
 export class SealevelNativeTokenAdapter
   extends BaseSealevelAdapter
@@ -106,11 +108,18 @@ export class SealevelTokenAdapter
   }
 
   async getBalance(owner: Address): Promise<bigint> {
-    const tokenPubKey = this.deriveAssociatedTokenAccount(new PublicKey(owner));
-    const response = await this.getProvider().getTokenAccountBalance(
-      tokenPubKey,
-    );
-    return BigInt(response.value.amount);
+    try {
+      const tokenPubKey = this.deriveAssociatedTokenAccount(
+        new PublicKey(owner),
+      );
+      const response = await this.getProvider().getTokenAccountBalance(
+        tokenPubKey,
+      );
+      return BigInt(response.value.amount);
+    } catch (error: any) {
+      if (error.message?.includes(NON_EXISTENT_ACCOUNT_ERROR)) return 0n;
+      throw error;
+    }
   }
 
   async getMetadata(_isNft?: boolean): Promise<TokenMetadata> {
@@ -610,11 +619,18 @@ export class SealevelHypSyntheticAdapter extends SealevelHypTokenAdapter {
   }
 
   override async getBalance(owner: Address): Promise<bigint> {
-    const tokenPubKey = this.deriveAssociatedTokenAccount(new PublicKey(owner));
-    const response = await this.getProvider().getTokenAccountBalance(
-      tokenPubKey,
-    );
-    return BigInt(response.value.amount);
+    try {
+      const tokenPubKey = this.deriveAssociatedTokenAccount(
+        new PublicKey(owner),
+      );
+      const response = await this.getProvider().getTokenAccountBalance(
+        tokenPubKey,
+      );
+      return BigInt(response.value.amount);
+    } catch (error: any) {
+      if (error.message?.includes(NON_EXISTENT_ACCOUNT_ERROR)) return 0n;
+      throw error;
+    }
   }
 
   deriveMintAuthorityAccount(): PublicKey {

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -108,10 +108,8 @@ export class SealevelTokenAdapter
   }
 
   async getBalance(owner: Address): Promise<bigint> {
+    const tokenPubKey = this.deriveAssociatedTokenAccount(new PublicKey(owner));
     try {
-      const tokenPubKey = this.deriveAssociatedTokenAccount(
-        new PublicKey(owner),
-      );
       const response = await this.getProvider().getTokenAccountBalance(
         tokenPubKey,
       );
@@ -619,10 +617,8 @@ export class SealevelHypSyntheticAdapter extends SealevelHypTokenAdapter {
   }
 
   override async getBalance(owner: Address): Promise<bigint> {
+    const tokenPubKey = this.deriveAssociatedTokenAccount(new PublicKey(owner));
     try {
-      const tokenPubKey = this.deriveAssociatedTokenAccount(
-        new PublicKey(owner),
-      );
       const response = await this.getProvider().getTokenAccountBalance(
         tokenPubKey,
       );

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -494,7 +494,7 @@ export class SealevelHypNativeAdapter extends SealevelHypTokenAdapter {
     },
     public readonly isSpl2022: boolean = false,
   ) {
-    // Pass in placeholder address to avoid errors for native token addresses (which as represented here as 0s)
+    // Pass in placeholder address for 'token' to avoid errors in the parent classes
     super(
       chainName,
       multiProvider,


### PR DESCRIPTION
### Description

- Fix arg validation for Sealevel HypNative adapters
- Increase Token.ts test coverage to Sealevel adapters
- Swallow getBalance errors for non-existent SVM accounts
- Allow extra properties in ChainMetadata objects

### Related issues

https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4499

### Backward compatibility

Yes

### Testing

Tested in Warp UI
