### PR TITLE
fix: warp apply throws if submitter transactionReceipts is undefined

### DIFF
--- a/typescript/cli/examples/submit/strategy/json-rpc-chain-strategy.yaml
+++ b/typescript/cli/examples/submit/strategy/json-rpc-chain-strategy.yaml
@@ -1,3 +1,6 @@
-anvil1:
+anvil2:
+  submitter:
+    type: jsonRpc
+anvil3:
   submitter:
     type: jsonRpc

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -497,12 +497,10 @@ export async function runWarpRouteApply(
             });
           const transactionReceipts = await submitter.submit(...transactions);
 
-          if (transactionReceipts && transactionReceipts.length > 0) {
-            return logGreen(
-              `✅ Warp config update successfully submitted with ${submitter.txSubmitterType} on ${chain}:\n\n`,
-              indentYamlOrJson(yamlStringify(transactionReceipts, null, 2), 4),
-            );
-          }
+          return logGreen(
+            `✅ Warp config update successfully submitted with ${submitter.txSubmitterType} on ${chain}:\n\n`,
+            indentYamlOrJson(yamlStringify(transactionReceipts, null, 2), 4),
+          );
         } catch (e) {
           logRed(`Warp config on ${chain} failed to update.`, e);
         }
@@ -677,12 +675,10 @@ async function enrollRemoteRouters(
           strategyUrl,
         });
       const transactionReceipts = await submitter.submit(...mutatedConfigTxs);
-      if (transactionReceipts && transactionReceipts.length > 0) {
-        return logGreen(
-          `✅ Router enrollment update successfully submitted with ${submitter.txSubmitterType} on ${chain}:\n\n`,
-          indentYamlOrJson(yamlStringify(transactionReceipts, null, 2), 4),
-        );
-      }
+      return logGreen(
+        `✅ Router enrollment update successfully submitted with ${submitter.txSubmitterType} on ${chain}:\n\n`,
+        indentYamlOrJson(yamlStringify(transactionReceipts, null, 2), 4),
+      );
     }),
   );
 }

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -677,11 +677,12 @@ async function enrollRemoteRouters(
           strategyUrl,
         });
       const transactionReceipts = await submitter.submit(...mutatedConfigTxs);
-
-      return logGreen(
-        `✅ Router enrollment update successfully submitted with ${submitter.txSubmitterType} on ${chain}:\n\n`,
-        indentYamlOrJson(yamlStringify(transactionReceipts, null, 2), 4),
-      );
+      if (transactionReceipts && transactionReceipts.length > 0) {
+        return logGreen(
+          `✅ Router enrollment update successfully submitted with ${submitter.txSubmitterType} on ${chain}:\n\n`,
+          indentYamlOrJson(yamlStringify(transactionReceipts, null, 2), 4),
+        );
+      }
     }),
   );
 }

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -64,7 +64,7 @@ export async function updateOwner(
 /**
  * Extends the Warp route deployment with a new warp config
  */
-export async function extendWarpConfig(config: {
+export async function extendWarpConfig(params: {
   chain: string;
   chainToExtend: string;
   extendedConfig: TokenRouterConfig;
@@ -79,7 +79,7 @@ export async function extendWarpConfig(config: {
     warpCorePath,
     warpDeployPath,
     strategyUrl,
-  } = config;
+  } = params;
   const warpDeployConfig = await readWarpConfig(
     chain,
     warpCorePath,

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -64,13 +64,22 @@ export async function updateOwner(
 /**
  * Extends the Warp route deployment with a new warp config
  */
-export async function extendWarpConfig(
-  chain: string,
-  chainToExtend: string,
-  extendedConfig: TokenRouterConfig,
-  warpCorePath: string,
-  warpDeployPath: string,
-): Promise<string> {
+export async function extendWarpConfig(config: {
+  chain: string;
+  chainToExtend: string;
+  extendedConfig: TokenRouterConfig;
+  warpCorePath: string;
+  warpDeployPath: string;
+  strategyUrl?: string;
+}): Promise<string> {
+  const {
+    chain,
+    chainToExtend,
+    extendedConfig,
+    warpCorePath,
+    warpDeployPath,
+    strategyUrl,
+  } = config;
   const warpDeployConfig = await readWarpConfig(
     chain,
     warpCorePath,
@@ -78,7 +87,7 @@ export async function extendWarpConfig(
   );
   warpDeployConfig[chainToExtend] = extendedConfig;
   writeYamlOrJson(warpDeployPath, warpDeployConfig);
-  await hyperlaneWarpApply(warpDeployPath, warpCorePath);
+  await hyperlaneWarpApply(warpDeployPath, warpCorePath, strategyUrl);
 
   return warpDeployPath;
 }

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -26,6 +26,7 @@ export async function hyperlaneWarpDeploy(warpCorePath: string) {
 export async function hyperlaneWarpApply(
   warpDeployPath: string,
   warpCorePath: string,
+  strategyUrl = '',
 ) {
   return $`yarn workspace @hyperlane-xyz/cli run hyperlane warp apply \
         --registry ${REGISTRY_PATH} \
@@ -33,6 +34,7 @@ export async function hyperlaneWarpApply(
         --warp ${warpCorePath} \
         --key ${ANVIL_KEY} \
         --verbosity debug \
+        --strategy ${strategyUrl} \
         --yes`;
 }
 

--- a/typescript/cli/src/tests/warp-apply.e2e-test.ts
+++ b/typescript/cli/src/tests/warp-apply.e2e-test.ts
@@ -145,7 +145,7 @@ describe('WarpApply e2e tests', async function () {
     expect(remoteRouterKeys2).to.include(chain1Id);
   });
 
-  it.only('should extend an existing warp route with json strategy', async () => {
+  it('should extend an existing warp route with json strategy', async () => {
     // Read existing config into a file
     const warpConfigPath = `${TEMP_PATH}/warp-route-deployment-2.yaml`;
     await readWarpConfig(CHAIN_NAME_2, WARP_CORE_CONFIG_PATH_2, warpConfigPath);

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.ts
@@ -62,7 +62,7 @@ export class EV5GnosisSafeTxSubmitter implements EV5TxSubmitterInterface {
     );
   }
 
-  public async submit(...txs: PopulatedTransactions): Promise<void> {
+  public async submit(...txs: PopulatedTransactions): Promise<any[]> {
     const nextNonce: number = await this.safeService.getNextNonce(
       this.props.safeAddress,
     );
@@ -94,12 +94,14 @@ export class EV5GnosisSafeTxSubmitter implements EV5TxSubmitterInterface {
       `Submitting transaction proposal to ${this.props.safeAddress} on ${this.props.chain}: ${safeTxHash}`,
     );
 
-    return this.safeService.proposeTransaction({
+    const transactionReceipts = await this.safeService.proposeTransaction({
       safeAddress: this.props.safeAddress,
       safeTransactionData,
       safeTxHash,
       senderAddress,
       senderSignature,
     });
+
+    return transactionReceipts ?? [];
   }
 }


### PR DESCRIPTION
### Description
Fix to add conditional for `transactionReceipts` so that the yaml is only parsed when it is not `undefined`. 

### Drive-by changes
E2e tests for warp apply strategy

### Backward compatibility
Yes

### Testing
Manual/Unit Tests

