### PR TITLE
fix: fix VERGEN_GIT_SHA population in Docker image

### DIFF
--- a/.github/workflows/rust-skipped.yml
+++ b/.github/workflows/rust-skipped.yml
@@ -5,15 +5,15 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      - 'rust/**'
+      - 'rust/main/**'
+      - 'rust/sealevel/**'
       - .github/workflows/rust.yml
   pull_request:
     branches: [main]
     paths-ignore:
-      - 'rust/**'
+      - 'rust/main/**'
+      - 'rust/sealevel/**'
       - .github/workflows/rust.yml
-  # Support for merge queues
-  merge_group:
 
 env:
   CARGO_TERM_COLOR: always

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -25,6 +25,8 @@ COPY rust/sealevel rust/sealevel
 COPY rust/main/Cargo.toml rust/main/.
 COPY rust/main/Cargo.lock rust/main/.
 
+# Required for VERGEN_GIT_SHA to be populated
+COPY .git .git
 
 WORKDIR /usr/src/rust/main
 


### PR DESCRIPTION
### Description

Was accidentally removed in #4438. Wonder if there's an easy way to have tests fail if this doesn't work?

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
