### PR TITLE
fix: obtain default multisend address correctly

### DIFF
--- a/.changeset/mighty-scissors-unite.md
+++ b/.changeset/mighty-scissors-unite.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Fix to correctly infer the default set of multisend addresses for a given chain, and update to latest safe-deployments patch release

--- a/typescript/infra/src/govern/multisend.ts
+++ b/typescript/infra/src/govern/multisend.ts
@@ -115,6 +115,7 @@ export class SafeMultiSend extends MultiSend {
       safeService,
       this.safeAddress,
       safeTransactionData,
+      true,
     );
     await this.proposeSafeTransaction(safeSdk, safeService, safeTransaction);
   }

--- a/typescript/infra/src/utils/safe.ts
+++ b/typescript/infra/src/utils/safe.ts
@@ -42,10 +42,12 @@ export async function createSafeTransaction(
   safeService: SafeApiKit.default,
   safeAddress: Address,
   safeTransactionData: MetaTransactionData[],
+  onlyCalls?: boolean,
 ): Promise<SafeTransaction> {
   const nextNonce = await safeService.getNextNonce(safeAddress);
   return safeSdk.createTransaction({
     safeTransactionData,
+    onlyCalls,
     options: { nonce: nextNonce },
   });
 }

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -11,7 +11,7 @@
     "@hyperlane-xyz/utils": "5.1.0",
     "@safe-global/api-kit": "1.3.0",
     "@safe-global/protocol-kit": "1.3.0",
-    "@safe-global/safe-deployments": "1.37.3",
+    "@safe-global/safe-deployments": "1.37.8",
     "@solana/spl-token": "^0.3.8",
     "@solana/web3.js": "^1.78.0",
     "@types/coingecko-api": "^1.0.10",

--- a/typescript/sdk/src/utils/gnosisSafe.js
+++ b/typescript/sdk/src/utils/gnosisSafe.js
@@ -67,12 +67,10 @@ export async function getSafe(chain, multiProvider, safeAddress) {
     multiSend = getMultiSendDeployment({
       version: multiSendVersion,
       network: domainId,
-      released: true,
     });
     multiSendCallOnly = getMultiSendCallOnlyDeployment({
       version: multiSendCallOnlyVersion,
       network: domainId,
-      released: true,
     });
   }
 
@@ -83,9 +81,9 @@ export async function getSafe(chain, multiProvider, safeAddress) {
       [domainId]: {
         // Use the safe address for multiSendAddress and multiSendCallOnlyAddress
         // if the contract is not deployed or if the version is not found
-        multiSendAddress: multiSend?.defaultAddress || safeAddress,
+        multiSendAddress: multiSend?.networkAddresses[domainId] || safeAddress,
         multiSendCallOnlyAddress:
-          multiSendCallOnly?.defaultAddress || safeAddress,
+          multiSendCallOnly?.networkAddresses[domainId] || safeAddress,
       },
     },
   });

--- a/typescript/sdk/src/utils/gnosisSafe.js
+++ b/typescript/sdk/src/utils/gnosisSafe.js
@@ -78,9 +78,10 @@ export async function getSafe(chain, multiProvider, safeAddress) {
     ethAdapter,
     safeAddress,
     contractNetworks: {
+      // DomainId == ChainId for EVM Chains
       [domainId]: {
         // Use the safe address for multiSendAddress and multiSendCallOnlyAddress
-        // if the contract is not deployed or if the version is not found
+        // if the contract is not deployed or if the version is not found.
         multiSendAddress: multiSend?.networkAddresses[domainId] || safeAddress,
         multiSendCallOnlyAddress:
           multiSendCallOnly?.networkAddresses[domainId] || safeAddress,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7814,7 +7814,7 @@ __metadata:
     "@nomiclabs/hardhat-waffle": "npm:^2.0.6"
     "@safe-global/api-kit": "npm:1.3.0"
     "@safe-global/protocol-kit": "npm:1.3.0"
-    "@safe-global/safe-deployments": "npm:1.37.3"
+    "@safe-global/safe-deployments": "npm:1.37.8"
     "@solana/spl-token": "npm:^0.3.8"
     "@solana/web3.js": "npm:^1.78.0"
     "@types/coingecko-api": "npm:^1.0.10"
@@ -10788,12 +10788,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@safe-global/safe-deployments@npm:1.37.3":
-  version: 1.37.3
-  resolution: "@safe-global/safe-deployments@npm:1.37.3"
+"@safe-global/safe-deployments@npm:1.37.8":
+  version: 1.37.8
+  resolution: "@safe-global/safe-deployments@npm:1.37.8"
   dependencies:
     semver: "npm:^7.6.2"
-  checksum: 3d1fcaac850a1d1100eaa5ff753c88c9bb889c678bb09248323c6b0c9d6228225a88be47973a89bb32829fe2d13ed17c21f854b9fdc29cc1b3c734021761f15c
+  checksum: bc8fce2c4d557e547a6cceebb611f9584d998dfb459cd50cf338409de986bed247ebca9425b0984a6e1a6accab42c7c4d1c68811e09cc981756183ba50a5e5a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fix: obtain default multisend address correctly
- should help decoding if we're using the expect set of multisend addresses
- also marks our multisend with `onlyCalls: true`

> The reason we can't use `defaultAddress` is because it's fixed to either `canonical` or `eip155` depending on the setting for `ethereum`, regardless of which actually is preferred for each given chain. however, the `networkAddresses` record has items in the correct order.
> See https://github.com/safe-global/safe-deployments/blob/b17349df0eb91cf3683eeae882c07f19188421d9/src/utils.ts#L29 for the implementation.

drive-by:
- bump up to latest safe-deployments patch


| Before | After |
|--------|-------|
| ![Before 1](https://github.com/user-attachments/assets/60b235c1-920b-4c18-b7d8-d50117f3c212) | ![After 1](https://github.com/user-attachments/assets/94cb1feb-04df-49cd-9b29-382917fb5731) |
| ![Before 2](https://github.com/user-attachments/assets/d5fd63e7-2b32-4095-9471-8dbbc8d516a3) | ![After 2](https://github.com/user-attachments/assets/17a04cd7-5fa8-4eae-9d4f-365233b8b39b) |

