### PR TITLE
feat: monitor sealevel ATA payer balances in the key funder

### DIFF
--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -10,7 +10,7 @@ export const keyFunderConfig: KeyFunderConfig<
 > = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-    tag: '9c056c7-20240911-154400',
+    tag: 'f4e0407-20240919-200424',
   },
   // We're currently using the same deployer/key funder key as mainnet2.
   // To minimize nonce clobbering we offset the key funder cron

--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -10,7 +10,7 @@ export const keyFunderConfig: KeyFunderConfig<
 > = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-    tag: 'f4e0407-20240919-200424',
+    tag: '877656c-20240919-202332',
   },
   // We're currently using the same deployer/key funder key as mainnet2.
   // To minimize nonce clobbering we offset the key funder cron

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -887,18 +887,24 @@ class ContextFunder {
     const provider = new Connection(rpcUrls[0], 'confirmed');
 
     for (const { pubkey, walletName } of accounts) {
-      logger.info('Fetching Solana wallet balance', {
-        chain,
-        pubkey: pubkey.toString(),
-        walletName,
-      });
+      logger.info(
+        {
+          chain,
+          pubkey: pubkey.toString(),
+          walletName,
+        },
+        'Fetching sealevel wallet balance',
+      );
       const balance = await provider.getBalance(pubkey);
-      logger.info('Got Solana wallet balance', {
-        balance,
-        chain,
-        pubkey: pubkey.toString(),
-        walletName,
-      });
+      logger.info(
+        {
+          balance,
+          chain,
+          pubkey: pubkey.toString(),
+          walletName,
+        },
+        'Got sealevel chain wallet balance',
+      );
       walletBalanceGauge
         .labels({
           chain,

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -893,7 +893,7 @@ class ContextFunder {
           pubkey: pubkey.toString(),
           walletName,
         },
-        'Got sealevel chain wallet balance',
+        'Retrieved sealevel chain wallet balance',
       );
       walletBalanceGauge
         .labels({

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -107,11 +107,6 @@ interface SealevelAccount {
 const sealevelAccountsToTrack: ChainMap<SealevelAccount[]> = {
   solanamainnet: [
     {
-      // The relayer
-      pubkey: new PublicKey('G5FM3UKwcBJ47PwLWLLY1RQpqNtTMgnqnd6nZGcJqaBp'),
-      walletName: 'relayer',
-    },
-    {
       // WIF warp route ATA payer
       pubkey: new PublicKey('R5oMfxcbjx4ZYK1B2Aic1weqwt2tQsRzFEGe5WJfAxh'),
       walletName: 'WIF/eclipsemainnet-solanamainnet/ata-payer',
@@ -123,11 +118,6 @@ const sealevelAccountsToTrack: ChainMap<SealevelAccount[]> = {
     },
   ],
   eclipsemainnet: [
-    {
-      // The relayer
-      pubkey: new PublicKey('G5FM3UKwcBJ47PwLWLLY1RQpqNtTMgnqnd6nZGcJqaBp'),
-      walletName: 'relayer',
-    },
     {
       // WIF warp route ATA payer
       pubkey: new PublicKey('HCQAfDd5ytAEidzR9g7CipjEGv2ZrSSZq1UY34oDFv8h'),


### PR DESCRIPTION
### Description

- Tested and set up alerts
- We already have the relayer balances from the agents themselves, so just need the ATA payers (which are responsible for paying for the rent of token accounts that don't yet exist when bridging in)
- Putting it here because it's easy and this is what we did in v2 (see #3432, which this is based off)

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
