### PR TITLE
feat(contracts): add nonce for monotonically increasing delivery ordering for `HypERC4626`

### DIFF
--- a/.changeset/red-actors-shop.md
+++ b/.changeset/red-actors-shop.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/core': patch
+---
+
+Added nonce to HypERC4626

--- a/solidity/contracts/mock/MockMailbox.sol
+++ b/solidity/contracts/mock/MockMailbox.sol
@@ -77,4 +77,9 @@ contract MockMailbox is Mailbox {
         Mailbox(address(this)).process("", _message);
         inboundProcessedNonce++;
     }
+
+    function processInboundMessage(uint32 _nonce) public {
+        bytes memory _message = inboundMessages[_nonce];
+        Mailbox(address(this)).process("", _message);
+    }
 }

--- a/solidity/contracts/token/extensions/HypERC4626.sol
+++ b/solidity/contracts/token/extensions/HypERC4626.sol
@@ -17,9 +17,12 @@ contract HypERC4626 is HypERC20 {
     using Message for bytes;
     using TokenMessage for bytes;
 
+    event ExchangeRateUpdated(uint256 newExchangeRate, uint32 rateUpdateNonce);
+
     uint256 public constant PRECISION = 1e10;
     uint32 public immutable collateralDomain;
     uint256 public exchangeRate; // 1e10
+    uint32 public previousNonce;
 
     constructor(
         uint8 _decimals,
@@ -66,7 +69,16 @@ contract HypERC4626 is HypERC20 {
         bytes calldata _message
     ) internal virtual override {
         if (_origin == collateralDomain) {
-            exchangeRate = abi.decode(_message.metadata(), (uint256));
+            (uint256 newExchangeRate, uint32 rateUpdateNonce) = abi.decode(
+                _message.metadata(),
+                (uint256, uint32)
+            );
+            // only update if the nonce is greater than the previous nonce
+            if (rateUpdateNonce > previousNonce) {
+                exchangeRate = newExchangeRate;
+                previousNonce = rateUpdateNonce;
+                emit ExchangeRateUpdated(exchangeRate, rateUpdateNonce);
+            }
         }
         super._handle(_origin, _sender, _message);
     }

--- a/solidity/contracts/token/extensions/HypERC4626Collateral.sol
+++ b/solidity/contracts/token/extensions/HypERC4626Collateral.sol
@@ -20,6 +20,8 @@ contract HypERC4626Collateral is HypERC20Collateral {
     uint256 public constant PRECISION = 1e10;
     bytes32 public constant NULL_RECIPIENT =
         0x0000000000000000000000000000000000000000000000000000000000000001;
+    // Nonce for the rate update, to ensure sequential updates
+    uint32 public rateUpdateNonce;
 
     constructor(
         ERC4626 _vault,
@@ -52,7 +54,12 @@ contract HypERC4626Collateral is HypERC20Collateral {
             vault.totalSupply(),
             Math.Rounding.Down
         );
-        bytes memory _tokenMetadata = abi.encode(_exchangeRate);
+
+        rateUpdateNonce++;
+        bytes memory _tokenMetadata = abi.encode(
+            _exchangeRate,
+            rateUpdateNonce
+        );
 
         bytes memory _tokenMessage = TokenMessage.format(
             _recipient,

--- a/solidity/test/token/HypERC4626Test.t.sol
+++ b/solidity/test/token/HypERC4626Test.t.sol
@@ -217,6 +217,7 @@ contract HypERC4626CollateralTest is HypTokenTest {
     }
 
     function testWithdrawalWithoutYield() public {
+        uint256 bobPrimaryBefore = primaryToken.balanceOf(BOB);
         _performRemoteTransferWithoutExpectation(0, transferAmount);
         assertEq(remoteToken.balanceOf(BOB), transferAmount);
 
@@ -227,10 +228,14 @@ contract HypERC4626CollateralTest is HypTokenTest {
             transferAmount
         );
         localMailbox.processNextInboundMessage();
-        assertEq(primaryToken.balanceOf(BOB), transferAmount);
+        assertEq(
+            primaryToken.balanceOf(BOB) - bobPrimaryBefore,
+            transferAmount
+        );
     }
 
     function testWithdrawalWithYield() public {
+        uint256 bobPrimaryBefore = primaryToken.balanceOf(BOB);
         _performRemoteTransferWithoutExpectation(0, transferAmount);
         assertEq(remoteToken.balanceOf(BOB), transferAmount);
 
@@ -249,13 +254,22 @@ contract HypERC4626CollateralTest is HypTokenTest {
         uint256 _expectedBal = transferAmount + _discountedYield();
 
         // BOB gets the yield even though it didn't rebase
-        assertApproxEqRelDecimal(_bobBal, _expectedBal, 1e14, 0);
-        assertTrue(_bobBal < _expectedBal, "Transfer remote should round down");
+        assertApproxEqRelDecimal(
+            _bobBal - bobPrimaryBefore,
+            _expectedBal,
+            1e14,
+            0
+        );
+        assertTrue(
+            _bobBal - bobPrimaryBefore < _expectedBal,
+            "Transfer remote should round down"
+        );
 
         assertEq(vault.accumulatedFees(), YIELD / 10);
     }
 
     function testWithdrawalAfterYield() public {
+        uint256 bobPrimaryBefore = primaryToken.balanceOf(BOB);
         _performRemoteTransferWithoutExpectation(0, transferAmount);
         assertEq(remoteToken.balanceOf(BOB), transferAmount);
 
@@ -274,7 +288,7 @@ contract HypERC4626CollateralTest is HypTokenTest {
         );
         localMailbox.processNextInboundMessage();
         assertApproxEqRelDecimal(
-            primaryToken.balanceOf(BOB),
+            primaryToken.balanceOf(BOB) - bobPrimaryBefore,
             transferAmount + _discountedYield(),
             1e14,
             0
@@ -331,6 +345,7 @@ contract HypERC4626CollateralTest is HypTokenTest {
     }
 
     function testWithdrawalAfterDrawdown() public {
+        uint256 bobPrimaryBefore = primaryToken.balanceOf(BOB);
         _performRemoteTransferWithoutExpectation(0, transferAmount);
         assertEq(remoteToken.balanceOf(BOB), transferAmount);
 
@@ -350,7 +365,7 @@ contract HypERC4626CollateralTest is HypTokenTest {
         );
         localMailbox.processNextInboundMessage();
         assertApproxEqRelDecimal(
-            primaryToken.balanceOf(BOB),
+            primaryToken.balanceOf(BOB) - bobPrimaryBefore,
             transferAmount - drawdown,
             1e14,
             0


### PR DESCRIPTION
### Description

- Added a `rateUpdateNonce` in `HypERC4626Collateral` and `previousNonce` in `HypERC4626` to ensure we only update the exchangeRate on the synthetic asset if the update was after the last recorded update. This is to make sure we don't update it to a stale exchange rate which may cause losses to users using the synthetic asset. 

### Drive-by changes

- `processInboundMessage` in MockMailbox` to simulate processing of messages out of order.

### Related issues

- fixes https://github.com/chainlight-io/2024-08-hyperlane/issues/12

### Backward compatibility

Yes

### Testing

Unit test
