### PR TITLE
feat: E2E Test Cosmos Scraper Invariant

### DIFF
--- a/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
@@ -159,6 +159,10 @@ impl CosmosProvider {
         Ok(contract)
     }
 
+    /// Reports if transaction contains fees expressed in unsupported denominations
+    /// The only denomination we support at the moment is the one we express gas minimum price
+    /// in the configuration of a chain. If fees contain an entry in a different denomination,
+    /// we report it in the logs.
     fn report_unsupported_denominations(&self, tx: &Tx, tx_hash: &H256) {
         let supported_denomination = self.connection_conf.get_minimum_gas_price().denom;
         let unsupported_denominations = tx
@@ -173,6 +177,7 @@ impl CosmosProvider {
         if !unsupported_denominations.is_empty() {
             error!(
                 ?tx_hash,
+                ?supported_denomination,
                 ?unsupported_denominations,
                 "transaction contains fees in unsupported denominations, manual intervention is required");
         }

--- a/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
@@ -143,10 +143,12 @@ impl CosmosProvider {
             .cloned()
             .collect::<Vec<Any>>();
 
-        if contract_execution_messages.len() > 1 {
+        let contract_execution_messages_len = contract_execution_messages.len();
+        if contract_execution_messages_len > 1 {
             error!(
                 ?tx_hash,
-                "transaction contains multiple contract execution messages, scraper is using the first entry, manual intervention is required");
+                ?contract_execution_messages,
+                "transaction contains multiple contract execution messages, we are indexing the first entry only");
         }
 
         let any = contract_execution_messages.first().ok_or_else(|| {

--- a/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
@@ -140,7 +140,7 @@ impl CosmosProvider {
             .messages
             .iter()
             .filter(|a| a.type_url == "/cosmwasm.wasm.v1.MsgExecuteContract")
-            .map(|a| a.clone())
+            .cloned()
             .collect::<Vec<Any>>();
 
         if contract_execution_messages.len() > 1 {
@@ -149,7 +149,7 @@ impl CosmosProvider {
                 "transaction contains multiple contract execution messages, scraper is using the first entry, manual intervention is required");
         }
 
-        let any = contract_execution_messages.get(0).ok_or_else(|| {
+        let any = contract_execution_messages.first().ok_or_else(|| {
             ChainCommunicationError::from_other_str("could not find contract execution message")
         })?;
         let proto =

--- a/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
@@ -185,6 +185,17 @@ impl CosmosProvider {
         }
     }
 
+    /// Converts fees to a common denomination if necessary.
+    ///
+    /// Currently, we support Injective, Neutron and Osmosis. Fees in Injective are usually
+    /// expressed in `inj` which is 10^-18 of `INJ`, while fees in Neutron and Osmosis are
+    /// usually expressed in `untrn` and `uosmo`, respectively, which are 10^-6 of corresponding
+    /// `NTRN` and `OSMO`.
+    ///
+    /// This function will convert fees expressed in `untrn` and `uosmo` to 10^-18 of `NTRN` and
+    /// `OSMO` and it will keep fees expressed in `inj` as is.
+    ///
+    /// If fees are expressed in an unsupported denomination, they will be ignored.
     fn convert_fee(&self, coin: &Coin) -> U256 {
         let gas_price = self.connection_conf.get_minimum_gas_price();
         if coin.denom.as_ref() != gas_price.denom {

--- a/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
@@ -23,7 +23,7 @@ use crate::providers::rpc::CosmosRpcClient;
 use crate::{ConnectionConf, CosmosAmount, HyperlaneCosmosError, Signer};
 
 /// Exponent value for atto units (10^-18).
-static ATTO_EXPONENT: Lazy<u32> = Lazy::new(|| 18);
+const ATTO_EXPONENT: u32 = 18;
 
 /// Abstraction over a connection to a Cosmos chain
 #[derive(Debug, Clone)]
@@ -204,7 +204,7 @@ impl CosmosProvider {
             return U256::zero();
         }
 
-        let exponent = *ATTO_EXPONENT - native_token.decimals;
+        let exponent = ATTO_EXPONENT - native_token.decimals;
         let coefficient = U256::from(10u128.pow(exponent));
 
         let amount_in_native_denom = U256::from(coin.amount);

--- a/rust/main/chains/hyperlane-cosmos/src/providers/grpc/tests.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/grpc/tests.rs
@@ -7,7 +7,7 @@ use hyperlane_core::{ContractLocator, HyperlaneDomain, KnownHyperlaneDomain};
 
 use crate::address::CosmosAddress;
 use crate::grpc::{WasmGrpcProvider, WasmProvider};
-use crate::{ConnectionConf, CosmosAmount, RawCosmosAmount};
+use crate::{ConnectionConf, CosmosAmount, NativeToken, RawCosmosAmount};
 
 #[ignore]
 #[tokio::test]
@@ -64,6 +64,10 @@ fn provider(address: &str) -> WasmGrpcProvider {
             OperationBatchConfig {
                 batch_contract_address: None,
                 max_batch_size: 1,
+            },
+            NativeToken {
+                decimals: 6,
+                denom: "untrn".to_owned(),
             },
         ),
         CosmosAmount {

--- a/rust/main/chains/hyperlane-cosmos/src/trait_builder.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/trait_builder.rs
@@ -1,8 +1,9 @@
 use std::str::FromStr;
 
 use derive_new::new;
-use hyperlane_core::{config::OperationBatchConfig, ChainCommunicationError, FixedPointNumber};
 use url::Url;
+
+use hyperlane_core::{config::OperationBatchConfig, ChainCommunicationError, FixedPointNumber};
 
 /// Cosmos connection configuration
 #[derive(Debug, Clone)]
@@ -27,6 +28,8 @@ pub struct ConnectionConf {
     contract_address_bytes: usize,
     /// Operation batching configuration
     pub operation_batch: OperationBatchConfig,
+    /// Native Token
+    native_token: NativeToken,
 }
 
 /// Untyped cosmos amount
@@ -55,6 +58,15 @@ impl TryFrom<RawCosmosAmount> for CosmosAmount {
             amount: FixedPointNumber::from_str(&raw.amount)?,
         })
     }
+}
+
+/// Chain native token denomination and number of decimal places
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct NativeToken {
+    /// The number of decimal places in token which can be expressed by denomination
+    pub decimals: u32,
+    /// Denomination of the token
+    pub denom: String,
 }
 
 /// An error type when parsing a connection configuration.
@@ -108,6 +120,11 @@ impl ConnectionConf {
         self.gas_price.clone()
     }
 
+    /// Get the native token
+    pub fn get_native_token(&self) -> &NativeToken {
+        &self.native_token
+    }
+
     /// Get the number of bytes used to represent a contract address
     pub fn get_contract_address_bytes(&self) -> usize {
         self.contract_address_bytes
@@ -124,6 +141,7 @@ impl ConnectionConf {
         minimum_gas_price: RawCosmosAmount,
         contract_address_bytes: usize,
         operation_batch: OperationBatchConfig,
+        native_token: NativeToken,
     ) -> Self {
         Self {
             grpc_urls,
@@ -134,6 +152,7 @@ impl ConnectionConf {
             gas_price: minimum_gas_price,
             contract_address_bytes,
             operation_batch,
+            native_token,
         }
     }
 }

--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -11,22 +11,25 @@ use std::{
 
 use convert_case::{Case, Casing};
 use eyre::{eyre, Context};
-use h_cosmos::RawCosmosAmount;
-use hyperlane_core::{
-    cfg_unwrap_all, config::*, HyperlaneDomain, HyperlaneDomainProtocol,
-    HyperlaneDomainTechnicalStack, IndexMode,
-};
 use itertools::Itertools;
 use serde::Deserialize;
 use serde_json::Value;
 use url::Url;
 
-pub use self::json_value_parser::ValueParser;
-pub use super::envs::*;
+use h_cosmos::RawCosmosAmount;
+use hyperlane_core::{
+    cfg_unwrap_all, config::*, HyperlaneDomain, HyperlaneDomainProtocol,
+    HyperlaneDomainTechnicalStack, IndexMode,
+};
+
 use crate::settings::{
     chains::IndexSettings, parser::connection_parser::build_connection_conf, trace::TracingConfig,
     ChainConf, CoreContractAddresses, Settings, SignerConf,
 };
+
+pub use super::envs::*;
+
+pub use self::json_value_parser::ValueParser;
 
 mod connection_parser;
 mod json_value_parser;

--- a/rust/main/utils/run-locally/src/cosmos/mod.rs
+++ b/rust/main/utils/run-locally/src/cosmos/mod.rs
@@ -618,34 +618,34 @@ fn termination_invariants_met(
     messages_expected: u32,
     starting_relayer_balance: f64,
 ) -> eyre::Result<bool> {
-    let gas_payments_scraped = fetch_metric(
+    let expected_gas_payments = messages_expected;
+    let gas_payments_event_count = fetch_metric(
         &relayer_metrics_port.to_string(),
         "hyperlane_contract_sync_stored_events",
         &hashmap! {"data_type" => "gas_payment"},
     )?
     .iter()
     .sum::<u32>();
-    let expected_gas_payments = messages_expected;
-    if gas_payments_scraped != expected_gas_payments {
+    if gas_payments_event_count != expected_gas_payments {
         log!(
             "Relayer has indexed {} gas payments, expected {}",
-            gas_payments_scraped,
+            gas_payments_event_count,
             expected_gas_payments
         );
         return Ok(false);
     }
 
-    let delivered_messages_scraped = fetch_metric(
+    let msg_processed_count = fetch_metric(
         &relayer_metrics_port.to_string(),
         "hyperlane_operations_processed_count",
         &hashmap! {"phase" => "confirmed"},
     )?
     .iter()
     .sum::<u32>();
-    if delivered_messages_scraped != messages_expected {
+    if msg_processed_count != messages_expected {
         log!(
             "Relayer confirmed {} submitted messages, expected {}",
-            delivered_messages_scraped,
+            msg_processed_count,
             messages_expected
         );
         return Ok(false);

--- a/rust/main/utils/run-locally/src/cosmos/types.rs
+++ b/rust/main/utils/run-locally/src/cosmos/types.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, path::PathBuf};
 
-use hyperlane_cosmos::RawCosmosAmount;
+use hyperlane_cosmos::{NativeToken, RawCosmosAmount};
 use hyperlane_cosmwasm_interface::types::bech32_decode;
 
 use super::{cli::OsmosisCLI, CosmosNetwork};
@@ -125,6 +125,7 @@ pub struct AgentConfig {
     pub index: AgentConfigIndex,
     pub gas_price: RawCosmosAmount,
     pub contract_address_bytes: usize,
+    pub native_token: NativeToken,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
@@ -178,6 +179,10 @@ impl AgentConfig {
             },
             contract_address_bytes: 32,
             index: AgentConfigIndex { from: 1, chunk: 5 },
+            native_token: NativeToken {
+                decimals: 6,
+                denom: "uosmo".to_string(),
+            },
         }
     }
 }

--- a/rust/main/utils/run-locally/src/main.rs
+++ b/rust/main/utils/run-locally/src/main.rs
@@ -94,6 +94,9 @@ const MONOREPO_ROOT_PATH: &str = "../../";
 
 const ZERO_MERKLE_INSERTION_KATHY_MESSAGES: u32 = 10;
 
+const RELAYER_METRICS_PORT: &str = "9092";
+const SCRAPER_METRICS_PORT: &str = "9093";
+
 type DynPath = Box<dyn AsRef<Path>>;
 
 static RUN_LOG_WATCHERS: AtomicBool = AtomicBool::new(true);
@@ -210,7 +213,7 @@ fn main() -> ExitCode {
             multicall_address_string,
         )
         .hyp_env("CHAINS_TEST3_MAXBATCHSIZE", "5")
-        .hyp_env("METRICSPORT", "9092")
+        .hyp_env("METRICSPORT", RELAYER_METRICS_PORT)
         .hyp_env("DB", relayer_db.to_str().unwrap())
         .hyp_env("CHAINS_TEST1_SIGNER_KEY", RELAYER_KEYS[0])
         .hyp_env("CHAINS_TEST2_SIGNER_KEY", RELAYER_KEYS[1])
@@ -284,7 +287,7 @@ fn main() -> ExitCode {
         .hyp_env("CHAINS_TEST3_RPCCONSENSUSTYPE", "quorum")
         .hyp_env("CHAINS_TEST3_CUSTOMRPCURLS", "http://127.0.0.1:8545")
         .hyp_env("CHAINSTOSCRAPE", "test1,test2,test3")
-        .hyp_env("METRICSPORT", "9093")
+        .hyp_env("METRICSPORT", SCRAPER_METRICS_PORT)
         .hyp_env(
             "DB",
             "postgresql://postgres:47221c18c610@localhost:5432/postgres",


### PR DESCRIPTION
### Description

- Add metrics based Scraper invariant into E2E Test for Cosmos
- Report error if transaction contains multiple contract execution messages
- Report error if fee are expressed in unsupported denomination

### Related issues

- Successfully scrape Cosmos chains in e2e test #3355

### Backward compatibility

Yes

### Testing

E2E Testing
