### PR TITLE
chore: include txids in indexing logs; add vscode config for rust-ana…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,5 @@ yarn-error.log
 
 .idea
 **/*.ignore
-/.vscode
-!/.vscode/*
 
 tsconfig.editor.json

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,7 @@ yarn-error.log
 
 .idea
 **/*.ignore
+/.vscode
+!/.vscode/*
 
 tsconfig.editor.json

--- a/mono.code-workspace
+++ b/mono.code-workspace
@@ -20,6 +20,10 @@
     "cSpell.words": [
       "hyperlane"
     ],
+    "rust-analyzer.linkedProjects": [
+      "./rust/main/Cargo.toml",
+      "./rust/sealevel/Cargo.toml",
+  ],
   },
   "folders": [
     {
@@ -33,7 +37,10 @@
       "path": "./solidity"
     },
     {
-      "path": "./rust"
+      "path": "./rust/main"
+    },
+    {
+      "path": "./rust/sealevel"
     }
   ],
   "extensions": {
@@ -66,6 +73,8 @@
       "yoavbls.pretty-ts-errors",
       // Yaml language support
       "redhat.vscode-yaml",
+      // Rust language support
+      "rust-lang.rust-analyzer"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": []

--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -31,6 +31,14 @@ use cursors::ForwardBackwardSequenceAwareSyncCursor;
 
 const SLEEP_DURATION: Duration = Duration::from_secs(5);
 
+#[derive(Debug, derive_new::new)]
+#[allow(dead_code)]
+/// Utility struct for pretty-printing indexed items.
+struct IndexedTxIdAndSequence {
+    tx_id: H512,
+    sequence: Option<u32>,
+}
+
 /// Entity that drives the syncing of an agent's db with on-chain data.
 /// Extracts chain-specific data (emitted checkpoints, messages, etc) from an
 /// `indexer` and fills the agent's db with this data.
@@ -172,7 +180,7 @@ where
                     ?range,
                     num_logs = logs_found,
                     estimated_time_to_sync = fmt_sync_time(eta),
-                    sequences = ?logs.iter().map(|(log, _)| log.sequence).collect::<Vec<_>>(),
+                    sequences = ?logs.iter().map(|(log, meta)| IndexedTxIdAndSequence::new(meta.transaction_id, log.sequence)).collect::<Vec<_>>(),
                     cursor = ?cursor,
                     "Found log(s) in index range"
                 );


### PR DESCRIPTION
- adds support for rust-analyzer with the new workspace split
- includes txids in agent indexing logs, to more easily link message_ids to their txid. @Mo-Hussain and I spent quite some time today trying to find the corresponding txid
