### PR TITLE
fix: GCS correctly splitting storage location into bucket and folder (if present)

### DIFF
--- a/rust/main/hyperlane-base/src/settings/checkpoint_syncer.rs
+++ b/rust/main/hyperlane-base/src/settings/checkpoint_syncer.rs
@@ -73,21 +73,25 @@ impl FromStr for CheckpointSyncerConf {
             "gs" => {
                 let service_account_key = env::var(GCS_SERVICE_ACCOUNT_KEY).ok();
                 let user_secrets = env::var(GCS_USER_SECRET).ok();
-                if let Some(ind) = suffix.find('/') {
-                    let (bucket, folder) = suffix.split_at(ind);
-                    Ok(Self::Gcs {
+                let url_components = suffix.split('/').collect::<Vec<&str>>();
+                let (bucket, folder): (&str, Option<String>) = match url_components.len() {
+                    2 => Ok((url_components[0], None)),
+                    3 => Ok((url_components[0], Some(url_components[1].to_owned()))),
+                    _ => Err(eyre!("Error parsing storage location; could not split bucket and folder ({suffix})"))
+                }?;
+                match folder {
+                    None => Ok(CheckpointSyncerConf::Gcs {
+                        bucket: bucket.into(),
+                        folder: None,
+                        service_account_key,
+                        user_secrets,
+                    }),
+                    Some(folder) => Ok(CheckpointSyncerConf::Gcs {
                         bucket: bucket.into(),
                         folder: Some(folder.into()),
                         service_account_key,
                         user_secrets,
-                    })
-                } else {
-                    Ok(Self::Gcs {
-                        bucket: suffix.into(),
-                        folder: None,
-                        service_account_key,
-                        user_secrets,
-                    })
+                    }),
                 }
             }
             _ => Err(eyre!("Unknown storage location prefix `{prefix}`")),

--- a/rust/main/hyperlane-base/src/settings/checkpoint_syncer.rs
+++ b/rust/main/hyperlane-base/src/settings/checkpoint_syncer.rs
@@ -88,7 +88,7 @@ impl FromStr for CheckpointSyncerConf {
                     }),
                     Some(folder) => Ok(CheckpointSyncerConf::Gcs {
                         bucket: bucket.into(),
-                        folder: Some(folder.into()),
+                        folder: Some(folder),
                         service_account_key,
                         user_secrets,
                     }),

--- a/rust/main/hyperlane-base/tests/chain_config.rs
+++ b/rust/main/hyperlane-base/tests/chain_config.rs
@@ -92,7 +92,7 @@ fn chain_name_domain_records() -> BTreeSet<ChainCoordinate> {
         .flat_map(|x: &Settings| {
             x.chains.values().map(|v| ChainCoordinate {
                 name: v.domain.name().into(),
-                domain: (&v.domain).try_into().expect("Invalid domain id"),
+                domain: (&v.domain).into(),
             })
         })
         .collect()


### PR DESCRIPTION
### Description

Previously Checkpoint Syncer wasn't correctly parsing the storage location string. If no folder was provided, it treated the object name as folder, e.g. reading `gs://bucket-name/gcsLatestIndexKey` initialized StorageClient with bucket `bucket-name` and folder `gcsLatestIndexKey`. This was due to incorrect logic for splitting the string by `/` that expected a folder to be present.

In this PR I fixed this logic, treating a location with only one `/` as _bucket/object_ and with two `/`s as _bucket/folder/object_.

### Backward compatibility

Yes

### Testing

Manual
