### PR TITLE
chore: add eclipse warp routes to known app contexts

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../src/config/agent/relayer.js';
 import { ALL_KEY_ROLES, Role } from '../../../src/roles.js';
 import { Contexts } from '../../contexts.js';
-import { getDomainId } from '../../registry.js';
+import { getDomainId, getWarpAddresses } from '../../registry.js';
 
 import { environment } from './chains.js';
 import { helloWorld } from './helloworld.js';
@@ -32,11 +32,11 @@ import inevmEthereumUsdtAddresses from './warp/inevm-USDT-addresses.json';
 import injectiveInevmInjAddresses from './warp/injective-inevm-addresses.json';
 import mantaTIAAddresses from './warp/manta-TIA-addresses.json';
 import merklyEthAddresses from './warp/merkly-eth-addresses.json';
-import renzoEzEthAddressesV1 from './warp/renzo-ezETH-addresses-v1.json';
 import renzoEzEthAddressesV3 from './warp/renzo-ezETH-addresses-v3.json';
 import victionEthereumEthAddresses from './warp/viction-ETH-addresses.json';
 import victionEthereumUsdcAddresses from './warp/viction-USDC-addresses.json';
 import victionEthereumUsdtAddresses from './warp/viction-USDT-addresses.json';
+import { WarpRouteIds } from './warp/warpIds.js';
 
 // const releaseCandidateHelloworldMatchingList = routerMatchingList(
 //   helloWorld[Contexts.ReleaseCandidate].addresses,
@@ -328,9 +328,24 @@ const metricAppContexts = [
     matchingList: matchingList(renzoEzEthAddressesV3),
   },
   {
-    // preserving old addresses in case any transactions are still in flight and need to be processed
-    name: 'renzo_ezeth_old',
-    matchingList: matchingList(renzoEzEthAddressesV1),
+    name: 'eclipse_usdc',
+    matchingList: matchingList(
+      getWarpAddresses(WarpRouteIds.EthereumEclipseUSDC),
+    ),
+  },
+  {
+    name: 'eclipse_teth',
+    matchingList: matchingList(
+      getWarpAddresses(WarpRouteIds.EthereumEclipseTETH),
+    ),
+  },
+  {
+    name: 'eclipse_wif',
+    matchingList: matchingList(getWarpAddresses(WarpRouteIds.EclipseSolanaWIF)),
+  },
+  {
+    name: 'eclipse_sol',
+    matchingList: matchingList(getWarpAddresses(WarpRouteIds.EclipseSolanaSOL)),
   },
   // Hitting max env var size limits, see https://stackoverflow.com/questions/28865473/setting-environment-variable-to-a-large-value-argument-list-too-long#answer-28865503
   // {
@@ -378,7 +393,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '946dec8-20240919-151233',
+      tag: 'f36beb6-20240920-170532',
     },
     gasPaymentEnforcement: gasPaymentEnforcement,
     metricAppContexts,
@@ -412,7 +427,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '946dec8-20240919-151233',
+      tag: 'f36beb6-20240920-170532',
     },
     // We're temporarily (ab)using the RC relayer as a way to increase
     // message throughput.

--- a/typescript/infra/config/environments/mainnet3/aw-validators/rc.json
+++ b/typescript/infra/config/environments/mainnet3/aw-validators/rc.json
@@ -9,6 +9,12 @@
       "0x229d4dc6a740212da746b0e35314419a24bc2a5b"
     ]
   },
+  "astar": {
+    "validators": ["0x50792eee9574f1bcd002e2c6dddf2aa73b04e254"]
+  },
+  "astarzkevm": {
+    "validators": ["0x71e0a93f84548765cafc64d787eede19eea1ab06"]
+  },
   "avalanche": {
     "validators": [
       "0x2c7cf6d1796e37676ba95f056ff21bf536c6c2d3",
@@ -22,6 +28,9 @@
       "0x3b55d9febe02a9038ef8c867fa8bbfdd8d70f9b8",
       "0xed7703e06572768bb09e03d88e6b788d8800b9fb"
     ]
+  },
+  "bitlayer": {
+    "validators": ["0xec567167f07479bcd02a66c2ea66fd329cb9e22f"]
   },
   "blast": {
     "validators": ["0x5b32f226e472da6ca19abfe1a29d5d28102a2d1a"]
@@ -43,14 +52,20 @@
   "cheesechain": {
     "validators": ["0xa481835355309ed46540c742a1c04b58380aa7b4"]
   },
+  "coredao": {
+    "validators": ["0x9767df5bcebce5ca89fdca5efbfb3b891cf30c5b"]
+  },
   "cyber": {
     "validators": ["0x84976d5012da6b180462742f2edfae2f9d740c82"]
   },
   "degenchain": {
     "validators": ["0xac3734bb61e7ddda947b718b930c4067f0ccde7e"]
   },
+  "dogechain": {
+    "validators": ["0x1e74735379a96586ec31f0a31aa4ee86016404a9"]
+  },
   "eclipsemainnet": {
-    "validators": ["0xd188fbe099e2db077f4ebc1bf39bb22798500bfb"]
+    "validators": ["0x283065cb17f98386c2b3656650d8b85e05862c8e"]
   },
   "ethereum": {
     "validators": [
@@ -58,6 +73,12 @@
       "0xa5465cb5095a2e6093587e644d6121d6ed55c632",
       "0x87cf8a85465118aff9ec728ca157798201b1e368"
     ]
+  },
+  "everclear": {
+    "validators": ["0x1b4455316aa859c9b3d2b13868490b7c97a9da3e"]
+  },
+  "flare": {
+    "validators": ["0x35c3ce34f27def61c2d878ff7c3e35fbab08e92a"]
   },
   "fraxtal": {
     "validators": ["0x8c772b730c8deb333dded14cb462e577a06283da"]
@@ -107,6 +128,9 @@
   "mode": {
     "validators": ["0x2f04ed30b1c27ef8e9e6acd360728d9bd5c3a9e2"]
   },
+  "molten": {
+    "validators": ["0x2e433ffc514a874537ca2473af51ebba4c863409"]
+  },
   "moonbeam": {
     "validators": [
       "0x75e3cd4e909089ae6c9f3a42b1468b33eec84161",
@@ -114,12 +138,8 @@
       "0xcaa9c6e6efa35e4a8b47565f3ce98845fa638bf3"
     ]
   },
-  "neutron": {
-    "validators": [
-      "0x307a8fe091b8273c7ce3d277b161b4a2167279b1",
-      "0xb825c1bd020cb068f477b320f591b32e26814b5b",
-      "0x0a5b31090d4c3c207b9ea6708f938e328f895fce"
-    ]
+  "oortmainnet": {
+    "validators": ["0x83f406ff315e90ae9589fa7786bf700e7c7a06f1"]
   },
   "optimism": {
     "validators": [
@@ -164,8 +184,11 @@
   "sei": {
     "validators": ["0x846e48a7e85e5403cc690a347e1ad3c3dca11b6e"]
   },
+  "shibarium": {
+    "validators": ["0x7f52b98a0a3e1ced83cf4eced8c0fa61886e7268"]
+  },
   "solanamainnet": {
-    "validators": ["0xca84b665ab3fed784baf120909c54497c14c93c8"]
+    "validators": ["0x7bd1536cb7505cf2ea1dc6744127d91fbe87a2ad"]
   },
   "tangle": {
     "validators": ["0xd778d113975b2fe45eda424bf93c28f32a90b076"]
@@ -188,5 +211,12 @@
   },
   "zetachain": {
     "validators": ["0xa13d146b47242671466e4041f5fe68d22a2ffe09"]
+  },
+  "neutron": {
+    "validators": [
+      "0x307a8fe091b8273c7ce3d277b161b4a2167279b1",
+      "0xb825c1bd020cb068f477b320f591b32e26814b5b",
+      "0x0a5b31090d4c3c207b9ea6708f938e328f895fce"
+    ]
   }
 }

--- a/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
@@ -1,0 +1,17 @@
+export enum WarpRouteIds {
+  Ancient8EthereumUSDC = 'USDC/ancient8-ethereum',
+  ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismZircuitEZETH = 'EZETH/arbitrum-base-blast-bsc-ethereum-fraxtal-linea-mode-optimism-zircuit',
+  ArbitrumNeutronEclip = 'ECLIP/arbitrum-neutron',
+  ArbitrumNeutronTIA = 'TIA/arbitrum-neutron',
+  EclipseSolanaSOL = 'SOL/eclipsemainnet-solanamainnet',
+  EclipseSolanaWIF = 'WIF/eclipsemainnet-solanamainnet',
+  EthereumInevmUSDC = 'USDC/ethereum-inevm',
+  EthereumInevmUSDT = 'USDT/ethereum-inevm',
+  EthereumEclipseTETH = 'tETH/eclipsemainnet-ethereum',
+  EthereumEclipseUSDC = 'USDC/eclipsemainnet-ethereum-solanamainnet',
+  EthereumVictionETH = 'ETH/ethereum-viction',
+  EthereumVictionUSDC = 'USDC/ethereum-viction',
+  EthereumVictionUSDT = 'USDT/ethereum-viction',
+  InevmInjectiveINJ = 'INJ/inevm-injective',
+  MantapacificNeutronTIA = 'TIA/mantapacific-neutron',
+}

--- a/typescript/infra/config/registry.ts
+++ b/typescript/infra/config/registry.ts
@@ -5,6 +5,7 @@ import {
   ChainAddresses,
   MergedRegistry,
   PartialRegistry,
+  warpConfigToWarpAddresses,
 } from '@hyperlane-xyz/registry';
 import { FileSystemRegistry } from '@hyperlane-xyz/registry/fs';
 import {
@@ -88,6 +89,19 @@ export function getChainMetadata(): ChainMap<ChainMetadata> {
 
 export function getChainAddresses(): ChainMap<ChainAddresses> {
   return getRegistry().getAddresses();
+}
+
+export function getWarpAddresses(warpRouteId: string) {
+  const registry = getRegistry();
+  const warpRouteConfig = registry.getWarpRoute(warpRouteId);
+
+  if (!warpRouteConfig) {
+    throw new Error(
+      `Warp route config for ${warpRouteId} not found in registry`,
+    );
+  }
+
+  return warpConfigToWarpAddresses(warpRouteConfig);
 }
 
 export function getEnvChains(env: DeployEnvironment): ChainName[] {

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -21,22 +21,7 @@ import { getEthereumVictionUSDTWarpConfig } from './environments/mainnet3/warp/c
 import { getInevmInjectiveINJWarpConfig } from './environments/mainnet3/warp/configGetters/getInevmInjectiveINJWarpConfig.js';
 import { getMantapacificNeutronTiaWarpConfig } from './environments/mainnet3/warp/configGetters/getMantapacificNeutronTiaWarpConfig.js';
 import { getRenzoEZETHWarpConfig } from './environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConifg.js';
-
-export enum WarpRouteIds {
-  Ancient8EthereumUSDC = 'USDC/ancient8-ethereum',
-  ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismZircuitEZETH = 'EZETH/arbitrum-base-blast-bsc-ethereum-fraxtal-linea-mode-optimism-zircuit',
-  ArbitrumNeutronEclip = 'ECLIP/arbitrum-neutron',
-  ArbitrumNeutronTIA = 'TIA/arbitrum-neutron',
-  EthereumInevmUSDC = 'USDC/ethereum-inevm',
-  EthereumInevmUSDT = 'USDT/ethereum-inevm',
-  EthereumEclipseTETH = 'tETH/eclipsemainnet-ethereum',
-  EthereumEclipseUSDC = 'USDC/eclipsemainnet-ethereum-solanamainnet',
-  EthereumVictionETH = 'ETH/ethereum-viction',
-  EthereumVictionUSDC = 'USDC/ethereum-viction',
-  EthereumVictionUSDT = 'USDT/ethereum-viction',
-  InevmInjectiveINJ = 'INJ/inevm-injective',
-  MantapacificNeutronTIA = 'TIA/mantapacific-neutron',
-}
+import { WarpRouteIds } from './environments/mainnet3/warp/warpIds.js';
 
 type WarpConfigGetterWithConfig = (
   routerConfig: ChainMap<RouterConfig>,

--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -497,19 +497,6 @@ export function getAddresses(environment: DeployEnvironment, module: Modules) {
   }
 }
 
-export function getWarpAddresses(warpRouteId: string) {
-  const registry = getRegistry();
-  const warpRouteConfig = registry.getWarpRoute(warpRouteId);
-
-  if (!warpRouteConfig) {
-    throw new Error(
-      `Warp route config for ${warpRouteId} not found in registry`,
-    );
-  }
-
-  return warpConfigToWarpAddresses(warpRouteConfig);
-}
-
 export function writeAddresses(
   environment: DeployEnvironment,
   module: Modules,

--- a/typescript/infra/scripts/check/check-utils.ts
+++ b/typescript/infra/scripts/check/check-utils.ts
@@ -22,6 +22,7 @@ import { eqAddress, objFilter } from '@hyperlane-xyz/utils';
 
 import { Contexts } from '../../config/contexts.js';
 import { DEPLOYER } from '../../config/environments/mainnet3/owners.js';
+import { getWarpAddresses } from '../../config/registry.js';
 import { getWarpConfig } from '../../config/warp.js';
 import { DeployEnvironment } from '../../src/config/environment.js';
 import { HyperlaneAppGovernor } from '../../src/govern/HyperlaneAppGovernor.js';
@@ -35,7 +36,6 @@ import { logViolationDetails } from '../../src/utils/violation.js';
 import {
   Modules,
   getArgs as getRootArgs,
-  getWarpAddresses,
   withAsDeployer,
   withChains,
   withContext,

--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { Gauge, Registry } from 'prom-client';
 
-import { WarpRouteIds } from '../../config/warp.js';
+import { WarpRouteIds } from '../../config/environments/mainnet3/warp/warpIds.js';
 import { submitMetrics } from '../../src/utils/metrics.js';
 import { Modules } from '../agent-utils.js';
 


### PR DESCRIPTION
### Description

- adds a bunch of new app contexts related to the new warp routes
- rearranged some things to avoid circular deps
- deployed from a new image off main (following #4528 being merged too)
- I did an RC deploy, which updated the rc validators for the first time in a while

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
