### PR TITLE
chore: update USDC Ethereum router address in token-config

### DIFF
--- a/rust/sealevel/client/src/context.rs
+++ b/rust/sealevel/client/src/context.rs
@@ -155,8 +155,21 @@ impl<'ctx, 'rpc> TxnBuilder<'ctx, 'rpc> {
             );
         }
 
-        let message = Message::new(&self.instructions(), None);
-        let txn = Transaction::new_unsigned(message);
+        let message = Message::new(&self.instructions(), Some(&self.ctx.payer_pubkey));
+        // Useful for plugging into ledger-friendly tools
+        if std::env::var("TX_BINARY").is_ok() {
+            println!(
+                "\t==== Message as binary: ====\n\t{:?}",
+                bincode::serialize(&message)
+                    .unwrap()
+                    .iter()
+                    .map(|n| n.to_string())
+                    .collect::<Vec<String>>()
+                    .join(" ")
+            );
+        }
+
+        let txn = Transaction::new_unsigned(message.clone());
         println!(
             "\t==== Transaction in base58: ====\n\t{}",
             bs58::encode(bincode::serialize(&txn).unwrap()).into_string()

--- a/rust/sealevel/environments/mainnet3/warp-routes/eclipseusdc/token-config.json
+++ b/rust/sealevel/environments/mainnet3/warp-routes/eclipseusdc/token-config.json
@@ -18,6 +18,6 @@
     "type": "collateral",
     "decimals": 6,
     "token": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-    "foreignDeployment": "0xFc8F5272d690cf19732a7eD6f246aDF5fB8708dB"
+    "foreignDeployment": "0xe1de9910fe71cc216490ac7fcf019e13a34481d7"
   }
 }


### PR DESCRIPTION
### Description

- Updates the foreignDeployment to be the new one. Just the program-ids.json was updated
- A drive-by with some logging that helps me plug a tx into a script to submit ledger txs (this should eventually be built directly into the sealevel client, at which point we can remove this though)

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
