### PR TITLE
chore: don't ask for api key if it already exists

### DIFF
--- a/typescript/cli/src/context/context.ts
+++ b/typescript/cli/src/context/context.ts
@@ -195,6 +195,10 @@ export async function getOrRequestApiKeys(
   const apiKeys: ChainMap<string> = {};
 
   for (const chain of chains) {
+    if (chainMetadata[chain]?.blockExplorers?.[0]?.apiKey) {
+      apiKeys[chain] = chainMetadata[chain]!.blockExplorers![0]!.apiKey!;
+      continue;
+    }
     const wantApiKey = await confirm({
       default: false,
       message: `Do you want to use an API key to verify on this (${chain}) chain's block explorer`,


### PR DESCRIPTION
### Description

CLI will ask for API keys even if your (local) registry already includes the API key. This PR fixes that. 

Can't say i love the current code setup, it seems to me that it should be more like a pass on the registry and filter chains that don't have api keys, prompt for the api key and then persist that in the registry if its writable. But since i have so little context, kept it mostly this way to accomplish the desired product experience.
