### PR TITLE
chore: print validator when listing checkpoint indices

### DIFF
--- a/typescript/infra/scripts/list-validator-checkpoint-indices.ts
+++ b/typescript/infra/scripts/list-validator-checkpoint-indices.ts
@@ -39,11 +39,12 @@ async function main() {
         chain,
         identifier,
         index,
+        validator,
       };
     },
   );
 
-  console.table(indices, ['chain', 'index', 'identifier']);
+  console.table(indices, ['chain', 'index', 'identifier', 'validator']);
 }
 
 main().catch(console.error);


### PR DESCRIPTION
### Description

Minor addition to make it easy to figure out which validator is behind (from the multisig consts mapping)
