### PR TITLE
fix(contracts): add check for valid mailbox and relayer in `TrustedRelayerIsm`

### DIFF
--- a/solidity/contracts/isms/TrustedRelayerIsm.sol
+++ b/solidity/contracts/isms/TrustedRelayerIsm.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============
 import {IInterchainSecurityModule} from "../interfaces/IInterchainSecurityModule.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {Message} from "../libs/Message.sol";
 import {Mailbox} from "../Mailbox.sol";
 
@@ -14,6 +15,14 @@ contract TrustedRelayerIsm is IInterchainSecurityModule {
     address public immutable trustedRelayer;
 
     constructor(address _mailbox, address _trustedRelayer) {
+        require(
+            _trustedRelayer != address(0),
+            "TrustedRelayerIsm: invalid relayer"
+        );
+        require(
+            Address.isContract(_mailbox),
+            "TrustedRelayerIsm: invalid mailbox"
+        );
         mailbox = Mailbox(_mailbox);
         trustedRelayer = _trustedRelayer;
     }

--- a/solidity/test/isms/TrustedRelayerIsm.t.sol
+++ b/solidity/test/isms/TrustedRelayerIsm.t.sol
@@ -29,6 +29,13 @@ contract TrustedRelayerIsmTest is Test {
         recipient.setInterchainSecurityModule(address(ism));
     }
 
+    function test_revertsWhen_invalidMailboxOrRelayer() public {
+        vm.expectRevert("TrustedRelayerIsm: invalid relayer");
+        new TrustedRelayerIsm(address(mailbox), address(0));
+        vm.expectRevert("TrustedRelayerIsm: invalid mailbox");
+        new TrustedRelayerIsm(relayer, relayer);
+    }
+
     function test_verify(
         uint32 origin,
         bytes32 sender,


### PR DESCRIPTION
### Description

- minor fix: add an isContract check for mailbox and non-zero check for relayer when instantiating TrustedRelayerIsm

### Drive-by changes

None

### Related issues

- partly fixes https://github.com/chainlight-io/2024-08-hyperlane/issues/14

### Backward compatibility

Yes

### Testing

Unit 
