### PR TITLE
chore: root repo vscode settings for `rust-analyzer`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "./rust/main/Cargo.toml",
+        "./rust/sealevel/Cargo.toml",
+    ],
+}


### PR DESCRIPTION
### Description

`rust-analyzer` only detects workspaces that are 1 directory deep in the source tree, otherwise it has to be configured with the path to workspaces. This PR checks in `.vscode` settings with paths to the rust workspaces. 

This also fixes the issue where someone checks out the monorepo to make TS changes but can't commit because our husky precommit setups assumes that rust workspaces have already been built (which `rust-analyzer` does implicitly).

Noting that the problem is only there if the repo isn't opened using the `mono.code-workspace` setting, which people I talked to don't use (other than @paulbalaji)