### PR TITLE
fix: don't reuse prefix key in relayer

### DIFF
--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -23,6 +23,7 @@ const MESSAGE_DISPATCHED_BLOCK_NUMBER: &str = "message_dispatched_block_number_"
 const MESSAGE: &str = "message_";
 const NONCE_PROCESSED: &str = "nonce_processed_";
 const GAS_PAYMENT_BY_SEQUENCE: &str = "gas_payment_by_sequence_";
+const GAS_PAYMENT_BLOCK_BY_SEQUENCE: &str = "gas_payment_block_by_sequence_";
 const HIGHEST_SEEN_MESSAGE_NONCE: &str = "highest_seen_message_nonce_";
 const GAS_PAYMENT_FOR_MESSAGE_ID: &str = "gas_payment_sequence_for_message_id_v2_";
 const GAS_PAYMENT_META_PROCESSED: &str = "gas_payment_meta_processed_v3_";
@@ -390,6 +391,7 @@ impl HyperlaneSequenceAwareIndexerStoreReader<MerkleTreeInsertion> for Hyperlane
 impl HyperlaneSequenceAwareIndexerStoreReader<InterchainGasPayment> for HyperlaneRocksDB {
     /// Gets data by its sequence.
     async fn retrieve_by_sequence(&self, sequence: u32) -> Result<Option<InterchainGasPayment>> {
+        println!("retrieving gas payment by sequence {}", sequence);
         Ok(self.retrieve_gas_payment_by_sequence(&sequence)?)
     }
 
@@ -516,7 +518,7 @@ make_store_and_retrieve!(
 );
 make_store_and_retrieve!(pub(self), interchain_gas_payment_data_by_gas_payment_key, GAS_PAYMENT_FOR_MESSAGE_ID, GasPaymentKey, InterchainGasPaymentData);
 make_store_and_retrieve!(pub(self), gas_payment_by_sequence, GAS_PAYMENT_BY_SEQUENCE, u32, InterchainGasPayment);
-make_store_and_retrieve!(pub(self), gas_payment_block_by_sequence, GAS_PAYMENT_BY_SEQUENCE, u32, u64);
+make_store_and_retrieve!(pub(self), gas_payment_block_by_sequence, GAS_PAYMENT_BLOCK_BY_SEQUENCE, u32, u64);
 make_store_and_retrieve!(
     pub,
     pending_message_retry_count_by_message_id,


### PR DESCRIPTION
### Description

This PR fixes a bug @tkporter flagged, which would cause agents to reindex every igp payment on restart (but luckily with no impact on message processing).

Unfortunately the same DB prefix key was used to store different items: `gas_payment_by_sequence` and `gas_payment_block_by_sequence`, with the latter overwriting the former. Sequence indexing relies on `gas_payment_by_sequence` to know whether a certain payment was already indexed - if not, it queries an RPC for it and stores it in the db. But because `gas_payment_by_sequence` would get overwritten and thus corrupted, checking whether a certain `gas_payment_by_sequence` is already in the db would fail with a decoding error, and because errors are treated as if the payment just wasn't indexed yet, the RPC call would be made again.

Fortunately no migration is required, since just re-running the relayer will cause it to overwrite the old corrupted entries with correct ones, and would also create new prefix entries for the igp blocks.

