### PR TITLE
fix: warn on submodule metadata builder failures

### DIFF
--- a/.changeset/popular-cars-burn.md
+++ b/.changeset/popular-cars-burn.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+fix: warn on submodule metadata builder failures


### PR DESCRIPTION
### Description

Adds useful logs to aggregation ISM metadata builder.

### Drive-by changes

None

### Related issues

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4520

### Backward compatibility

Yes

### Testing

Manual
