### PR TITLE
fix: update moonbeam IGP overhead

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -393,7 +393,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'f36beb6-20240920-170532',
+      tag: '5cb1787-20240924-192934',
     },
     gasPaymentEnforcement: gasPaymentEnforcement,
     metricAppContexts,
@@ -427,7 +427,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'f36beb6-20240920-170532',
+      tag: '5cb1787-20240924-192934',
     },
     // We're temporarily (ab)using the RC relayer as a way to increase
     // message throughput.

--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -27,13 +27,19 @@ const tokenPrices: ChainMap<string> = rawTokenPrices;
 
 const FOREIGN_DEFAULT_OVERHEAD = 600_000; // cosmwasm warp route somewhat arbitrarily chosen
 
-const remoteOverhead = (remote: ChainName) =>
-  ethereumChainNames.includes(remote as any)
+function remoteOverhead(remote: ChainName) {
+  let overhead = ethereumChainNames.includes(remote as any)
     ? multisigIsmVerificationCost(
         defaultMultisigConfigs[remote].threshold,
         defaultMultisigConfigs[remote].validators.length,
       )
     : FOREIGN_DEFAULT_OVERHEAD; // non-ethereum overhead
+  if (remote === 'moonbeam') {
+    // Moonbeam has (roughly) 4x'd their gas costs, some context in https://discord.com/channels/935678348330434570/1287816893553705041
+    overhead *= 4;
+  }
+  return overhead;
+}
 
 // Gets the exchange rate of the remote quoted in local tokens
 function getTokenExchangeRate(local: ChainName, remote: ChainName): BigNumber {


### PR DESCRIPTION
### Description

Following a recent runtime upgrade, they dramatically increased gas costs. It seems like the impact is that some txs may use as much as 4x the normal gas price. But confusingly this is only for some types of txs that affect the "proof of validity".

Some context in the linked discord thread in the comment and in the tg chat with them

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
