### PR TITLE
fix(relayer): dry-run before sending txs

### DIFF
--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -196,7 +196,7 @@ pub mod test {
 
         /// Submit this operation to the blockchain and report if it was successful
         /// or not.
-        async fn submit(&mut self) {
+        async fn submit(&mut self) -> PendingOperationResult {
             todo!()
         }
 

--- a/rust/main/agents/relayer/src/msg/op_submitter.rs
+++ b/rust/main/agents/relayer/src/msg/op_submitter.rs
@@ -371,18 +371,17 @@ async fn submit_single_operation(
             // Not expected to hit this case in `submit`, but it's here for completeness
         }
         PendingOperationResult::Success | PendingOperationResult::Confirm(_) => {
-            send_and_confirm_op(op, confirm_queue, metrics).await
+            confirm_op(op, confirm_queue, metrics).await
         }
     }
 }
 
-async fn send_and_confirm_op(
+async fn confirm_op(
     mut op: QueueOperation,
     confirm_queue: &mut OpQueue,
     metrics: &SerialSubmitterMetrics,
 ) {
     let destination = op.destination_domain().clone();
-    op.submit().await;
     debug!(?op, "Operation submitted");
     op.set_next_attempt_after(CONFIRM_DELAY);
     confirm_queue

--- a/rust/main/agents/relayer/src/msg/op_submitter.rs
+++ b/rust/main/agents/relayer/src/msg/op_submitter.rs
@@ -371,17 +371,18 @@ async fn submit_single_operation(
             // Not expected to hit this case in `submit`, but it's here for completeness
         }
         PendingOperationResult::Success | PendingOperationResult::Confirm(_) => {
-            confirm_op(op, confirm_queue, metrics).await
+            send_and_confirm_op(op, confirm_queue, metrics).await
         }
     }
 }
 
-async fn confirm_op(
+async fn send_and_confirm_op(
     mut op: QueueOperation,
     confirm_queue: &mut OpQueue,
     metrics: &SerialSubmitterMetrics,
 ) {
     let destination = op.destination_domain().clone();
+    op.submit().await;
     debug!(?op, "Operation submitted");
     op.set_next_attempt_after(CONFIRM_DELAY);
     confirm_queue

--- a/rust/main/agents/relayer/src/msg/op_submitter.rs
+++ b/rust/main/agents/relayer/src/msg/op_submitter.rs
@@ -539,7 +539,7 @@ impl OperationBatch {
         };
 
         if !excluded_ops.is_empty() {
-            warn!(excluded_ops=?excluded_ops, "Either the batch tx would revert, or the operations would revert in the batch. Sending back to the prepare queue.");
+            warn!(excluded_ops=?excluded_ops, "Either the batch tx would revert, or the operations would revert in the batch. Falling back to serial submission.");
             OperationBatch::new(excluded_ops, self.domain)
                 .submit_serially(prepare_queue, confirm_queue, metrics)
                 .await;

--- a/rust/main/agents/relayer/src/msg/op_submitter.rs
+++ b/rust/main/agents/relayer/src/msg/op_submitter.rs
@@ -12,6 +12,7 @@ use hyperlane_core::BatchResult;
 use hyperlane_core::ConfirmReason::*;
 use hyperlane_core::PendingOperation;
 use hyperlane_core::PendingOperationStatus;
+use hyperlane_core::ReprepareReason;
 use itertools::Either;
 use itertools::Itertools;
 use prometheus::{IntCounter, IntGaugeVec};
@@ -182,6 +183,7 @@ impl SerialSubmitter {
                 &task_monitor,
                 submit_task(
                     domain.clone(),
+                    prepare_queue.clone(),
                     submit_queue,
                     confirm_queue.clone(),
                     max_batch_size,
@@ -310,6 +312,7 @@ async fn prepare_task(
 #[instrument(skip_all, fields(%domain))]
 async fn submit_task(
     domain: HyperlaneDomain,
+    mut prepare_queue: OpQueue,
     mut submit_queue: OpQueue,
     mut confirm_queue: OpQueue,
     max_batch_size: u32,
@@ -331,7 +334,7 @@ async fn submit_task(
             }
             std::cmp::Ordering::Greater => {
                 OperationBatch::new(batch, domain.clone())
-                    .submit(&mut confirm_queue, &metrics)
+                    .submit(&mut prepare_queue, &mut confirm_queue, &metrics)
                     .await;
             }
         }
@@ -486,7 +489,12 @@ struct OperationBatch {
 }
 
 impl OperationBatch {
-    async fn submit(self, confirm_queue: &mut OpQueue, metrics: &SerialSubmitterMetrics) {
+    async fn submit(
+        self,
+        prepare_queue: &mut OpQueue,
+        confirm_queue: &mut OpQueue,
+        metrics: &SerialSubmitterMetrics,
+    ) {
         let excluded_ops = match self.try_submit_as_batch(metrics).await {
             Ok(batch_result) => {
                 Self::handle_batch_result(self.operations, batch_result, confirm_queue).await
@@ -498,10 +506,17 @@ impl OperationBatch {
         };
 
         if !excluded_ops.is_empty() {
-            warn!(excluded_ops=?excluded_ops, "Either the batch tx would revert, or the operations would revert in the batch. Falling back to serial submission.");
-            OperationBatch::new(excluded_ops, self.domain)
-                .submit_serially(confirm_queue, metrics)
-                .await;
+            warn!(excluded_ops=?excluded_ops, "Either the batch tx would revert, or the operations would revert in the batch. Sending back to the prepare queue.");
+            for op in excluded_ops {
+                prepare_queue
+                    .push(
+                        op,
+                        Some(PendingOperationStatus::Retry(
+                            ReprepareReason::BatchSimulationFailure,
+                        )),
+                    )
+                    .await
+            }
         }
     }
 
@@ -562,12 +577,6 @@ impl OperationBatch {
             confirm_queue
                 .push(op, Some(PendingOperationStatus::Confirm(SubmittedBySelf)))
                 .await;
-        }
-    }
-
-    async fn submit_serially(self, confirm_queue: &mut OpQueue, metrics: &SerialSubmitterMetrics) {
-        for op in self.operations.into_iter() {
-            submit_single_operation(op, confirm_queue, metrics).await;
         }
     }
 }

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -338,11 +338,12 @@ impl PendingOperation for PendingMessage {
 
         // To avoid spending gas on a tx that will revert, dry-run just before submitting.
         if let Some(metadata) = self.metadata.as_ref() {
-            if let Err(_) = self
+            if self
                 .ctx
                 .destination_mailbox
                 .process_estimate_costs(&self.message, metadata)
                 .await
+                .is_err()
             {
                 return self.on_reprepare::<String>(None, ReprepareReason::ErrorEstimatingGas);
             }

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -76,6 +76,9 @@ pub struct PendingMessage {
     #[new(default)]
     #[serde(skip_serializing)]
     submission_outcome: Option<TxOutcome>,
+    #[new(default)]
+    #[serde(skip_serializing)]
+    metadata: Option<Vec<u8>>,
 }
 
 impl Debug for PendingMessage {
@@ -254,6 +257,7 @@ impl PendingOperation for PendingMessage {
                 return self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata);
             }
         };
+        self.metadata = metadata.clone();
 
         let Some(metadata) = metadata else {
             return self.on_reprepare::<String>(None, ReprepareReason::CouldNotFetchMetadata);
@@ -269,7 +273,7 @@ impl PendingOperation for PendingMessage {
             .process_estimate_costs(&self.message, &metadata)
             .await
         {
-            Ok(metadata) => metadata,
+            Ok(tx_cost_estimate) => tx_cost_estimate,
             Err(err) => {
                 return self.on_reprepare(Some(err), ReprepareReason::ErrorEstimatingGas);
             }
@@ -331,6 +335,17 @@ impl PendingOperation for PendingMessage {
             .submission_data
             .clone()
             .expect("Pending message must be prepared before it can be submitted");
+
+        if let Some(metadata) = self.metadata.clone() {
+            if let Err(_) = self
+                .ctx
+                .destination_mailbox
+                .process_estimate_costs(&self.message, &metadata)
+                .await
+            {
+                return;
+            }
+        }
 
         // We use the estimated gas limit from the prior call to
         // `process_estimate_costs` to avoid a second gas estimation.

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -337,14 +337,14 @@ impl PendingOperation for PendingMessage {
             .expect("Pending message must be prepared before it can be submitted");
 
         // To avoid spending gas on a tx that will revert, dry-run just before submitting.
-        if let Some(metadata) = self.metadata.clone() {
+        if let Some(metadata) = self.metadata.as_ref() {
             if let Err(_) = self
                 .ctx
                 .destination_mailbox
-                .process_estimate_costs(&self.message, &metadata)
+                .process_estimate_costs(&self.message, metadata)
                 .await
             {
-                return self.on_reprepare::<String>(None, ReprepareReason::RevertedOrReorged);
+                return self.on_reprepare::<String>(None, ReprepareReason::ErrorEstimatingGas);
             }
         }
 

--- a/rust/main/hyperlane-core/src/traits/pending_operation.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation.rs
@@ -197,6 +197,9 @@ pub enum ReprepareReason {
     #[strum(to_string = "Error estimating costs for process call")]
     /// Error estimating costs for process call
     ErrorEstimatingGas,
+    #[strum(to_string = "Simulating message in batch failed")]
+    /// Error simulating message in batch
+    BatchSimulationFailure,
     #[strum(to_string = "Error checking if message meets gas payment requirement")]
     /// Error checking if message meets gas payment requirement
     ErrorCheckingGasRequirement,

--- a/rust/main/hyperlane-core/src/traits/pending_operation.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation.rs
@@ -200,9 +200,6 @@ pub enum ReprepareReason {
     #[strum(to_string = "Error estimating costs for process call")]
     /// Error estimating costs for process call
     ErrorEstimatingGas,
-    #[strum(to_string = "Simulating message in batch failed")]
-    /// Error simulating message in batch
-    BatchSimulationFailure,
     #[strum(to_string = "Error checking if message meets gas payment requirement")]
     /// Error checking if message meets gas payment requirement
     ErrorCheckingGasRequirement,

--- a/rust/main/hyperlane-core/src/traits/pending_operation.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation.rs
@@ -83,7 +83,7 @@ pub trait PendingOperation: Send + Sync + Debug + TryBatchAs<HyperlaneMessage> {
     async fn prepare(&mut self) -> PendingOperationResult;
 
     /// Submit this operation to the blockchain
-    async fn submit(&mut self);
+    async fn submit(&mut self) -> PendingOperationResult;
 
     /// Set the outcome of the `submit` call
     fn set_submission_outcome(&mut self, outcome: TxOutcome);
@@ -188,6 +188,9 @@ pub enum ReprepareReason {
     #[strum(to_string = "Error getting message metadata builder")]
     /// Error getting message metadata builder
     ErrorGettingMetadataBuilder,
+    #[strum(to_string = "Error submitting")]
+    /// Error submitting
+    ErrorSubmitting,
     #[strum(to_string = "Error building metadata")]
     /// Error building metadata
     ErrorBuildingMetadata,


### PR DESCRIPTION
### Description

Fixes a bug in the individual submission logic. There is a race condition where a message can become undeliverable between when it was simulated in the `prepare` step and when it's actually submitted.

### Context
The bug was discovered as part of batched messages but affects chains without batching too.

- when delivery fails inside batch submission simulation, we fall back to individual submission
- individual submission doesn't simulate the tx outcome, and instead just submits directly
    - this is wrong, because the batch may cause messages to become undeliverable for long periods of time (such as when a mint cap is reached)
    - I believe simulation used to happen in the individual submission step, but we switched to using the already computed gas estimate from the IGP check in the `prepare` step, to save an RPC call
- this results in senders being charged from their IGP allowance unnecessarily, and messages becoming undeliverable due to insufficient gas

The correct flow requires three delivery simulations:
1. in the `prepare` step, to estimate gas and check the IGP policy
2. in the batch submission logic, to filter messages that are made invalid by earlier messages in the batch
3. right before submitting again, in case the batch caused the message to not be deliverable

### Solution
Dry-run right before submitting an operation, and if it fails send it back to the prep queue

