### PR TITLE
fix: override default with merkle hook for self relay

### DIFF
--- a/.changeset/bright-rings-jam.md
+++ b/.changeset/bright-rings-jam.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/cli": patch
+---
+
+Override default with merkle hook for self relay

--- a/typescript/cli/src/send/message.ts
+++ b/typescript/cli/src/send/message.ts
@@ -84,11 +84,6 @@ async function executeDelivery({
   const chainAddresses = await registry.getAddresses();
   const core = HyperlaneCore.fromAddressesMap(chainAddresses, multiProvider);
 
-  const hook = chainAddresses[origin]?.customHook;
-  if (hook) {
-    logBlue(`Using custom hook ${hook} for ${origin} -> ${destination}`);
-  }
-
   try {
     const recipient = chainAddresses[destination].testRecipient;
     if (!recipient) {
@@ -102,8 +97,8 @@ async function executeDelivery({
       destination,
       formattedRecipient,
       messageBody,
-      hook,
-      undefined,
+      // override the the default hook (with IGP) for self-relay to avoid race condition with the production relayer
+      selfRelay ? chainAddresses[origin].merkleTreeHook : undefined,
     );
     logBlue(`Sent message from ${origin} to ${recipient} on ${destination}.`);
     logBlue(`Message ID: ${message.id}`);

--- a/typescript/cli/src/send/transfer.ts
+++ b/typescript/cli/src/send/transfer.ts
@@ -144,6 +144,7 @@ async function executeDelivery({
     throw new Error('Error validating transfer');
   }
 
+  // TODO: override hook address for self-relay
   const transferTxs = await warpCore.getTransferRemoteTxs({
     originTokenAmount: new TokenAmount(amount, token),
     destination,


### PR DESCRIPTION
### Description

- Race condition in CLI `send message --relay`

### Related issues

- Related to https://github.com/hyperlane-xyz/v3-docs/issues/174

### Backward compatibility

Yes

### Testing

Manual

<img width="1506" alt="Screenshot 2024-09-24 at 3 15 41 PM" src="https://github.com/user-attachments/assets/862aeae0-0ff7-42a1-8223-83b70e52ef04">


