### PR TITLE
feat: Generate cosmos account addresses for Injective

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body",
  "hyper",
  "itoa",
@@ -545,7 +545,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body",
  "mime",
  "rustversion",
@@ -1256,7 +1256,7 @@ dependencies = [
  "coins-core 0.8.7",
  "digest 0.10.7",
  "hmac 0.12.1",
- "k256 0.13.3",
+ "k256 0.13.4",
  "serde",
  "sha2 0.10.8",
  "thiserror",
@@ -1564,7 +1564,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "eyre",
  "getrandom 0.2.15",
- "k256 0.13.3",
+ "k256 0.13.4",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
@@ -1589,7 +1589,7 @@ checksum = "0f862b355f7e47711e0acfe6af92cb3fd8fd5936b66a9eaa338b51edabd1e77d"
 dependencies = [
  "digest 0.10.7",
  "ed25519-zebra 3.1.0",
- "k256 0.13.3",
+ "k256 0.13.4",
  "rand_core 0.6.4",
  "thiserror",
 ]
@@ -1608,7 +1608,7 @@ dependencies = [
  "digest 0.10.7",
  "ecdsa 0.16.9",
  "ed25519-zebra 4.0.3",
- "k256 0.13.3",
+ "k256 0.13.4",
  "num-traits",
  "p256",
  "rand_core 0.6.4",
@@ -1797,6 +1797,16 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto"
+version = "0.1.0"
+dependencies = [
+ "elliptic-curve 0.13.8",
+ "hex 0.4.3",
+ "k256 0.13.4",
+ "thiserror",
+]
 
 [[package]]
 name = "crypto-bigint"
@@ -2505,7 +2515,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
- "signature 2.2.0",
+ "signature 2.0.0",
  "spki 0.7.3",
 ]
 
@@ -2535,7 +2545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8 0.10.2",
- "signature 2.2.0",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -3078,7 +3088,7 @@ dependencies = [
  "getrandom 0.2.15",
  "hashers",
  "hex 0.4.3",
- "http 0.2.11",
+ "http 0.2.12",
  "once_cell",
  "parking_lot 0.11.2",
  "pin-project",
@@ -3484,7 +3494,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "ed25519-dalek 2.1.1",
  "fuel-types",
- "k256 0.13.3",
+ "k256 0.13.4",
  "lazy_static",
  "p256",
  "rand 0.8.5",
@@ -3979,7 +3989,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "indexmap 2.5.0",
  "slab",
  "tokio",
@@ -4074,7 +4084,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http 0.2.11",
+ "http 0.2.12",
  "httpdate",
  "mime",
  "sha1",
@@ -4086,7 +4096,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http 0.2.11",
+ "http 0.2.12",
 ]
 
 [[package]]
@@ -4230,9 +4240,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -4257,7 +4267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
@@ -4300,7 +4310,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body",
  "httparse",
  "httpdate",
@@ -4322,7 +4332,7 @@ dependencies = [
  "bytes",
  "futures",
  "headers",
- "http 0.2.11",
+ "http 0.2.12",
  "hyper",
  "hyper-rustls 0.22.1",
  "rustls-native-certs 0.5.0",
@@ -4357,7 +4367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "hyper",
  "log",
  "rustls 0.21.12",
@@ -4502,10 +4512,11 @@ dependencies = [
  "bech32 0.9.1",
  "cosmrs",
  "cosmwasm-std 2.1.3",
+ "crypto",
  "derive-new",
  "futures",
  "hex 0.4.3",
- "http 0.2.11",
+ "http 0.2.12",
  "hyper",
  "hyper-tls",
  "hyperlane-core",
@@ -5091,16 +5102,16 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "once_cell",
  "sha2 0.10.8",
- "signature 2.2.0",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -5480,7 +5491,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 0.2.11",
+ "http 0.2.12",
  "httparse",
  "log",
  "memchr",
@@ -7027,7 +7038,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body",
  "hyper",
  "hyper-rustls 0.24.2",
@@ -7228,7 +7239,7 @@ dependencies = [
  "hyperlane-cosmos",
  "hyperlane-cosmwasm-interface",
  "jobserver",
- "k256 0.13.3",
+ "k256 0.13.4",
  "macro_rules_attribute",
  "maplit",
  "nix 0.26.4",
@@ -7258,7 +7269,7 @@ dependencies = [
  "bytes",
  "crc32fast",
  "futures",
- "http 0.2.11",
+ "http 0.2.12",
  "hyper",
  "hyper-tls",
  "lazy_static",
@@ -7330,7 +7341,7 @@ dependencies = [
  "futures",
  "hex 0.4.3",
  "hmac 0.11.0",
- "http 0.2.11",
+ "http 0.2.12",
  "hyper",
  "log",
  "md-5 0.9.1",
@@ -8280,9 +8291,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
@@ -9391,7 +9402,7 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "chrono",
- "http 0.2.11",
+ "http 0.2.12",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -9430,7 +9441,7 @@ dependencies = [
  "ed25519-consensus",
  "flex-error",
  "futures",
- "k256 0.13.3",
+ "k256 0.13.4",
  "num-traits",
  "once_cell",
  "prost 0.11.9",
@@ -9441,7 +9452,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "sha2 0.10.8",
- "signature 2.2.0",
+ "signature 2.0.0",
  "subtle",
  "subtle-encoding",
  "tendermint-proto 0.32.2 (git+https://github.com/hyperlane-xyz/tendermint-rs.git?branch=trevor/0.32.2-fork)",
@@ -9507,7 +9518,7 @@ dependencies = [
  "flex-error",
  "futures",
  "getrandom 0.2.15",
- "http 0.2.11",
+ "http 0.2.12",
  "hyper",
  "hyper-proxy",
  "hyper-rustls 0.22.1",
@@ -9563,18 +9574,18 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -9891,7 +9902,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body",
  "hyper",
  "hyper-timeout",
@@ -9921,7 +9932,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "h2",
- "http 0.2.11",
+ "http 0.2.12",
  "http-body",
  "hyper",
  "hyper-timeout",
@@ -10103,7 +10114,7 @@ dependencies = [
  "base64 0.13.1",
  "byteorder",
  "bytes",
- "http 0.2.11",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -10375,7 +10386,7 @@ dependencies = [
  "hyperlane-cosmos",
  "hyperlane-ethereum",
  "hyperlane-test",
- "k256 0.13.3",
+ "k256 0.13.4",
  "prometheus",
  "reqwest",
  "serde",
@@ -10458,7 +10469,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "headers",
- "http 0.2.11",
+ "http 0.2.12",
  "hyper",
  "log",
  "mime",
@@ -10948,7 +10959,7 @@ checksum = "acaf2e321fc6f853572b372962fa253cba1b62a0025116bb463ce3c00b4394dc"
 dependencies = [
  "cfg-if",
  "futures",
- "http 0.2.11",
+ "http 0.2.12",
  "humantime-serde",
  "hyper",
  "hyper-rustls 0.24.2",
@@ -10994,7 +11005,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.1",
  "futures",
- "http 0.2.11",
+ "http 0.2.12",
  "hyper",
  "hyper-rustls 0.24.2",
  "itertools 0.10.5",

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "hyperlane-test",
   "utils/abigen",
   "utils/backtrace-oneline",
+  "utils/crypto",
   "utils/hex",
   "utils/run-locally",
 ]
@@ -68,10 +69,10 @@ futures-util = "0.3"
 generic-array = { version = "0.14", features = ["serde", "more_lengths"] }
 # Required for WASM support https://docs.rs/getrandom/latest/getrandom/#webassembly-support
 bech32 = "0.9.1"
-elliptic-curve = "0.12.3"
+elliptic-curve = "0.13.8"
 getrandom = { version = "0.2", features = ["js"] }
 hex = "0.4.3"
-http = "*"
+http = "0.2.12"
 hyper = "0.14"
 hyper-tls = "0.5.0"
 hyperlane-cosmwasm-interface = "=0.0.6-rc6"
@@ -80,7 +81,7 @@ injective-std = "=0.1.5"
 itertools = "*"
 jobserver = "=0.1.26"
 jsonrpc-core = "18.0"
-k256 = { version = "0.13.1", features = ["std", "ecdsa"] }
+k256 = { version = "0.13.4", features = ["arithmetic", "std", "ecdsa"] }
 log = "0.4"
 macro_rules_attribute = "0.2"
 maplit = "1.0"

--- a/rust/main/chains/hyperlane-cosmos/Cargo.toml
+++ b/rust/main/chains/hyperlane-cosmos/Cargo.toml
@@ -14,6 +14,7 @@ base64 = { workspace = true }
 bech32 = { workspace = true }
 cosmrs = { workspace = true, features = ["cosmwasm", "tokio", "grpc", "rpc"] }
 cosmwasm-std = { workspace = true }
+crypto = { path = "../../utils/crypto" }
 derive-new = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }

--- a/rust/main/chains/hyperlane-cosmos/src/error.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/error.rs
@@ -1,6 +1,9 @@
-use cosmrs::proto::prost;
-use hyperlane_core::ChainCommunicationError;
 use std::fmt::Debug;
+
+use cosmrs::proto::prost;
+
+use crypto::PublicKeyError;
+use hyperlane_core::ChainCommunicationError;
 
 /// Errors from the crates specific to the hyperlane-cosmos
 /// implementation.
@@ -58,5 +61,11 @@ pub enum HyperlaneCosmosError {
 impl From<HyperlaneCosmosError> for ChainCommunicationError {
     fn from(value: HyperlaneCosmosError) -> Self {
         ChainCommunicationError::from_other(value)
+    }
+}
+
+impl From<PublicKeyError> for HyperlaneCosmosError {
+    fn from(value: PublicKeyError) -> Self {
+        HyperlaneCosmosError::PublicKeyError(value.to_string())
     }
 }

--- a/rust/main/chains/hyperlane-cosmos/src/libs/account.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/libs/account.rs
@@ -1,7 +1,9 @@
 use cosmrs::{crypto::PublicKey, AccountId};
+use hyperlane_cosmwasm_interface::types::keccak256_hash;
 use tendermint::account::Id as TendermintAccountId;
 use tendermint::public_key::PublicKey as TendermintPublicKey;
 
+use crypto::decompress_public_key;
 use hyperlane_core::Error::Overflow;
 use hyperlane_core::{ChainCommunicationError, ChainResult, H256};
 
@@ -16,7 +18,18 @@ impl<'a> CosmosAccountId<'a> {
         Self { account_id }
     }
 
+    /// Calculate AccountId from public key depending on provided prefix
     pub fn account_id_from_pubkey(pub_key: PublicKey, prefix: &str) -> ChainResult<AccountId> {
+        match prefix {
+            "neutron" | "osmo" => Self::bitcoin_style(pub_key, prefix),
+            "inj" => Self::ethereum_style(pub_key, prefix),
+            &_ => Err(HyperlaneCosmosError::CosmosError(cosmrs::Error::Crypto))?,
+        }
+    }
+
+    /// Returns a Bitcoin style address: RIPEMD160(SHA256(pubkey))
+    /// Source: `<https://github.com/cosmos/cosmos-sdk/blob/177e7f45959215b0b4e85babb7c8264eaceae052/crypto/keys/secp256k1/secp256k1.go#L154>`
+    fn bitcoin_style(pub_key: PublicKey, prefix: &str) -> ChainResult<AccountId> {
         // Get the inner type
         let tendermint_pub_key = TendermintPublicKey::from(pub_key);
         // Get the RIPEMD160(SHA256(pub_key))
@@ -24,6 +37,23 @@ impl<'a> CosmosAccountId<'a> {
         // Bech32 encoding
         let account_id = AccountId::new(prefix, tendermint_id.as_bytes())
             .map_err(Into::<HyperlaneCosmosError>::into)?;
+
+        Ok(account_id)
+    }
+
+    /// Returns an Ethereum style address: KECCAK256(pubkey)[20]
+    /// Parameter `pub_key` is a compressed public key.
+    fn ethereum_style(pub_key: PublicKey, prefix: &str) -> ChainResult<AccountId> {
+        let decompressed_public_key = decompress_public_key(&pub_key.to_bytes())
+            .map_err(|e| HyperlaneCosmosError::PublicKeyError(e.to_string()))?;
+
+        let hash = keccak256_hash(&decompressed_public_key[1..]);
+
+        let mut bytes = [0u8; 20];
+        bytes.copy_from_slice(&hash.as_slice()[12..]);
+
+        let account_id =
+            AccountId::new(prefix, bytes.as_slice()).map_err(Into::<HyperlaneCosmosError>::into)?;
 
         Ok(account_id)
     }
@@ -55,3 +85,6 @@ impl TryFrom<CosmosAccountId<'_>> for H256 {
         (&account_id).try_into()
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/rust/main/chains/hyperlane-cosmos/src/libs/account.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/libs/account.rs
@@ -23,7 +23,7 @@ impl<'a> CosmosAccountId<'a> {
         match prefix {
             "neutron" | "osmo" => Self::bitcoin_style(pub_key, prefix),
             "inj" => Self::ethereum_style(pub_key, prefix),
-            &_ => Err(HyperlaneCosmosError::CosmosError(cosmrs::Error::Crypto))?,
+            _ => Err(HyperlaneCosmosError::CosmosError(cosmrs::Error::Crypto))?,
         }
     }
 

--- a/rust/main/chains/hyperlane-cosmos/src/libs/account.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/libs/account.rs
@@ -45,7 +45,7 @@ impl<'a> CosmosAccountId<'a> {
     /// Parameter `pub_key` is a compressed public key.
     fn ethereum_style(pub_key: PublicKey, prefix: &str) -> ChainResult<AccountId> {
         let decompressed_public_key = decompress_public_key(&pub_key.to_bytes())
-            .map_err(|e| HyperlaneCosmosError::PublicKeyError(e.to_string()))?;
+            .map_err(Into::<HyperlaneCosmosError>::into)?;
 
         let hash = keccak256_hash(&decompressed_public_key[1..]);
 

--- a/rust/main/chains/hyperlane-cosmos/src/libs/account/tests.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/libs/account/tests.rs
@@ -1,0 +1,70 @@
+use cosmrs::crypto::PublicKey;
+use cosmwasm_std::HexBinary;
+
+use crypto::decompress_public_key;
+
+use crate::libs::account::CosmosAccountId;
+
+const COMPRESSED_PUBLIC_KEY: &str =
+    "02962d010010b6eec66846322704181570d89e28236796579c535d2e44d20931f4";
+const INJECTIVE_ADDRESS: &str = "inj1m6ada382hfuxvuke4h9p4uswhn2qcca7mlg0dr";
+const NEUTRON_ADDRESS: &str = "neutron1mydju5alsmhnfsawy0j4lyns70l7qukgdgy45w";
+
+#[test]
+fn test_account_id() {
+    // given
+    let pub_key = compressed_public_key();
+
+    // when
+    let neutron_account_id = CosmosAccountId::account_id_from_pubkey(pub_key, "neutron").unwrap();
+    let injective_account_id = CosmosAccountId::account_id_from_pubkey(pub_key, "inj").unwrap();
+
+    // then
+    assert_eq!(neutron_account_id.as_ref(), NEUTRON_ADDRESS);
+    assert_eq!(injective_account_id.as_ref(), INJECTIVE_ADDRESS);
+}
+
+#[test]
+fn test_bitcoin_style() {
+    // given
+    let compressed = compressed_public_key();
+    let decompressed = decompressed_public_key();
+
+    // when
+    let from_compressed = CosmosAccountId::bitcoin_style(compressed, "neutron").unwrap();
+    let from_decompressed = CosmosAccountId::bitcoin_style(decompressed, "neutron").unwrap();
+
+    // then
+    assert_eq!(from_compressed.as_ref(), NEUTRON_ADDRESS);
+    assert_eq!(from_decompressed.as_ref(), NEUTRON_ADDRESS);
+}
+
+#[test]
+fn test_ethereum_style() {
+    // given
+    let compressed = compressed_public_key();
+    let decompressed = decompressed_public_key();
+
+    // when
+    let from_compressed = CosmosAccountId::ethereum_style(compressed, "inj").unwrap();
+    let from_decompressed = CosmosAccountId::ethereum_style(decompressed, "inj").unwrap();
+
+    // then
+    assert_eq!(from_compressed.as_ref(), INJECTIVE_ADDRESS);
+    assert_eq!(from_decompressed.as_ref(), INJECTIVE_ADDRESS);
+}
+
+fn compressed_public_key() -> PublicKey {
+    let hex = hex::decode(COMPRESSED_PUBLIC_KEY).unwrap();
+    let tendermint = tendermint::PublicKey::from_raw_secp256k1(&hex).unwrap();
+    let pub_key = PublicKey::from(tendermint);
+    pub_key
+}
+
+fn decompressed_public_key() -> PublicKey {
+    let hex = hex::decode(COMPRESSED_PUBLIC_KEY).unwrap();
+    let decompressed = decompress_public_key(&hex).unwrap();
+    let tendermint = tendermint::PublicKey::from_raw_secp256k1(&decompressed).unwrap();
+    let pub_key = PublicKey::from(tendermint);
+    pub_key
+}

--- a/rust/main/chains/hyperlane-cosmos/src/libs/address.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/libs/address.rs
@@ -20,8 +20,7 @@ pub struct CosmosAddress {
 }
 
 impl CosmosAddress {
-    /// Returns a Bitcoin style address: RIPEMD160(SHA256(pubkey))
-    /// Source: `<https://github.com/cosmos/cosmos-sdk/blob/177e7f45959215b0b4e85babb7c8264eaceae052/crypto/keys/secp256k1/secp256k1.go#L154>`
+    /// Calculates an account address depending on prefix
     pub fn from_pubkey(pubkey: PublicKey, prefix: &str) -> ChainResult<Self> {
         let account_id = CosmosAccountId::account_id_from_pubkey(pubkey, prefix)?;
         Self::from_account_id(account_id)
@@ -35,8 +34,7 @@ impl CosmosAddress {
         Self::from_pubkey(pubkey, prefix)
     }
 
-    /// Returns a Bitcoin style address calculated from Bech32 encoding
-    /// Source: `<https://github.com/cosmos/cosmos-sdk/blob/177e7f45959215b0b4e85babb7c8264eaceae052/crypto/keys/secp256k1/secp256k1.go#L154>`
+    /// Returns an account address calculated from Bech32 encoding
     pub fn from_account_id(account_id: AccountId) -> ChainResult<Self> {
         // Hex digest
         let digest = H256::try_from(&CosmosAccountId::new(&account_id))?;

--- a/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
@@ -139,7 +139,7 @@ impl CosmosProvider {
                     };
 
                     let proto = proto::cosmos::crypto::secp256k1::PubKey::from_any(&any)
-                        .map_err(HyperlaneCosmosError::Prost)?;
+                        .map_err(Into::<HyperlaneCosmosError>::into)?;
 
                     let decompressed = decompress_public_key(&proto.key)
                         .map_err(|e| HyperlaneCosmosError::PublicKeyError(e.to_string()))?;

--- a/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
@@ -1,8 +1,10 @@
+use std::str::FromStr;
+
 use async_trait::async_trait;
 use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::crypto::PublicKey;
-use cosmrs::tx::{MessageExt, SequenceNumber, SignerInfo};
-use cosmrs::{AccountId, Any, Coin, Tx};
+use cosmrs::tx::{MessageExt, SequenceNumber, SignerInfo, SignerPublicKey};
+use cosmrs::{proto, AccountId, Any, Coin, Tx};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use tendermint::hash::Algorithm;
@@ -11,6 +13,7 @@ use tendermint_rpc::{client::CompatMode, Client, HttpClient};
 use time::OffsetDateTime;
 use tracing::{error, warn};
 
+use crypto::decompress_public_key;
 use hyperlane_core::{
     BlockInfo, ChainCommunicationError, ChainInfo, ChainResult, ContractLocator, HyperlaneChain,
     HyperlaneDomain, HyperlaneProvider, TxnInfo, TxnReceiptInfo, H256, U256,
@@ -24,6 +27,9 @@ use crate::{ConnectionConf, CosmosAmount, HyperlaneCosmosError, Signer};
 
 /// Exponent value for atto units (10^-18).
 const ATTO_EXPONENT: u32 = 18;
+
+/// Injective public key type URL for protobuf Any
+const INJECTIVE_PUBLIC_KEY_TYPE_URL: &str = "/injective.crypto.v1beta1.ethsecp256k1.PubKey";
 
 /// Abstraction over a connection to a Cosmos chain
 #[derive(Debug, Clone)]
@@ -93,7 +99,8 @@ impl CosmosProvider {
             HyperlaneCosmosError::PublicKeyError("no public key for default signer".to_owned())
         })?;
 
-        let public_key = PublicKey::try_from(signer_public_key)?;
+        let key = self.normalize_public_key(signer_public_key)?;
+        let public_key = PublicKey::try_from(key)?;
 
         let account_id = CosmosAccountId::account_id_from_pubkey(
             public_key,
@@ -101,6 +108,46 @@ impl CosmosProvider {
         )?;
 
         Ok((account_id, signer_info.sequence))
+    }
+
+    fn normalize_public_key(
+        &self,
+        signer_public_key: SignerPublicKey,
+    ) -> ChainResult<SignerPublicKey> {
+        let public_key = match signer_public_key {
+            SignerPublicKey::Single(pk) => SignerPublicKey::from(pk),
+            SignerPublicKey::LegacyAminoMultisig(pk) => SignerPublicKey::from(pk),
+            SignerPublicKey::Any(pk) => {
+                if pk.type_url != INJECTIVE_PUBLIC_KEY_TYPE_URL {
+                    let msg = "we don't support this kind of TYPE_URL for public key";
+                    warn!(pk.type_url, msg);
+                    Err(HyperlaneCosmosError::PublicKeyError(msg.to_owned()))?
+                }
+
+                let any = Any {
+                    type_url: PublicKey::SECP256K1_TYPE_URL.to_owned(),
+                    value: pk.value,
+                };
+
+                let proto = proto::cosmos::crypto::secp256k1::PubKey::from_any(&any)
+                    .map_err(HyperlaneCosmosError::Prost)?;
+
+                let decompressed = decompress_public_key(&proto.key)
+                    .map_err(|e| HyperlaneCosmosError::PublicKeyError(e.to_string()))?;
+
+                let tendermint = tendermint::PublicKey::from_raw_secp256k1(&decompressed)
+                    .ok_or_else(|| {
+                        HyperlaneCosmosError::PublicKeyError(
+                            "cannot create tendermint public key".to_owned(),
+                        )
+                    })?;
+                let pub_key = PublicKey::from(tendermint);
+
+                SignerPublicKey::Single(pub_key)
+            }
+        };
+
+        Ok(public_key)
     }
 
     /// Calculates the sender and the nonce for the transaction.

--- a/rust/main/utils/crypto/Cargo.toml
+++ b/rust/main/utils/crypto/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "crypto"
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+publish.workspace = true
+version.workspace = true
+
+[dependencies]
+elliptic-curve = { workspace = true, features = ["sec1"] }
+hex = { workspace = true }
+k256 = { workspace = true }
+thiserror = { workspace = true }

--- a/rust/main/utils/crypto/src/key.rs
+++ b/rust/main/utils/crypto/src/key.rs
@@ -14,13 +14,19 @@ impl Display for PublicKeyError {
 }
 
 /// Decompresses public key of secp256k1 if it was compressed
+///
+/// Public key can be expressed in compressed or decompressed forms.
+/// Compressed form contains one byte as prefix and x component of the public key.
+/// Decompressed form contains one byte as prefix, x and y components of the public key.
 pub fn decompress_public_key(public_key: &[u8]) -> Result<Vec<u8>, PublicKeyError> {
     let elliptic: elliptic_curve::PublicKey<k256::Secp256k1> =
         elliptic_curve::PublicKey::from_sec1_bytes(public_key)
             .map_err(|e| PublicKeyError::Decode(e.to_string()))?;
+
+    // if public key was compressed, encoding into the point will decompress it.
     let point = elliptic.to_encoded_point(false);
-    let uncompressed = point.to_bytes().to_vec();
-    Ok(uncompressed)
+    let decompressed = point.to_bytes().to_vec();
+    Ok(decompressed)
 }
 
 #[cfg(test)]

--- a/rust/main/utils/crypto/src/key.rs
+++ b/rust/main/utils/crypto/src/key.rs
@@ -1,0 +1,45 @@
+use std::fmt::{Display, Formatter};
+
+use elliptic_curve::sec1::ToEncodedPoint;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PublicKeyError {
+    Decode(String),
+}
+
+impl Display for PublicKeyError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Decompresses public key of secp256k1 if it was compressed
+pub fn decompress_public_key(public_key: &[u8]) -> Result<Vec<u8>, PublicKeyError> {
+    let elliptic: elliptic_curve::PublicKey<k256::Secp256k1> =
+        elliptic_curve::PublicKey::from_sec1_bytes(public_key)
+            .map_err(|e| PublicKeyError::Decode(e.to_string()))?;
+    let point = elliptic.to_encoded_point(false);
+    let uncompressed = point.to_bytes().to_vec();
+    Ok(uncompressed)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::key::decompress_public_key;
+
+    #[test]
+    fn test_decompress_public_key() {
+        // given
+        let compressed = "02962d010010b6eec66846322704181570d89e28236796579c535d2e44d20931f4";
+        let hex = hex::decode(compressed).unwrap();
+
+        // when
+        let decompressed = hex::encode(decompress_public_key(&hex).unwrap());
+
+        // then
+        assert_eq!(
+            "04962d010010b6eec66846322704181570d89e28236796579c535d2e44d20931f40cb1152fb9e61ec7493a0d9a35d2e8a57198e109613854abdd3be5603d504008",
+            decompressed
+        );
+    }
+}

--- a/rust/main/utils/crypto/src/lib.rs
+++ b/rust/main/utils/crypto/src/lib.rs
@@ -1,0 +1,3 @@
+pub use key::decompress_public_key;
+
+mod key;

--- a/rust/main/utils/crypto/src/lib.rs
+++ b/rust/main/utils/crypto/src/lib.rs
@@ -1,3 +1,4 @@
 pub use key::decompress_public_key;
+pub use key::PublicKeyError;
 
 mod key;


### PR DESCRIPTION
### Description

Injective uses different logic on generating account addresses from public key. It is implemented in this PR so that sender address is correctly generated from signer info of transaction.

### Backward compatibility

Yes

### Testing

Added unit tests
Manual testing with Injective blockchain