### PR TITLE
feat: support duplicate chainIds with unique domainIds

### DIFF
--- a/.changeset/thin-bananas-explain.md
+++ b/.changeset/thin-bananas-explain.md
@@ -1,0 +1,7 @@
+---
+'@hyperlane-xyz/utils': minor
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+Support duplicate chainIds with unique domainIds

--- a/typescript/cli/src/config/submit.ts
+++ b/typescript/cli/src/config/submit.ts
@@ -1,11 +1,9 @@
 import { stringify as yamlStringify } from 'yaml';
 
 import {
-  PopulatedTransactions,
-  PopulatedTransactionsSchema,
+  AnnotatedEV5Transaction,
   SubmissionStrategy,
 } from '@hyperlane-xyz/sdk';
-import { PopulatedTransaction } from '@hyperlane-xyz/sdk';
 import { MultiProvider } from '@hyperlane-xyz/sdk';
 import { assert, errorToString } from '@hyperlane-xyz/utils';
 
@@ -72,20 +70,19 @@ export async function runSubmit({
  */
 function getChainFromTxs(
   multiProvider: MultiProvider,
-  transactions: PopulatedTransactions,
+  transactions: AnnotatedEV5Transaction[],
 ) {
   const firstTransaction = transactions[0];
   const sameChainIds = transactions.every(
-    (t: PopulatedTransaction) => t.chainId === firstTransaction.chainId,
+    (t: AnnotatedEV5Transaction) => t.chainId === firstTransaction.chainId,
   );
   assert(sameChainIds, 'Transactions must be submitted on the same chains');
 
-  return multiProvider.getChainName(firstTransaction.domainId);
+  return multiProvider.getChainName(firstTransaction.chain);
 }
 
-function getTransactions(transactionsFilepath: string): PopulatedTransactions {
-  const transactionsFileContent = readYamlOrJson<any[]>(
-    transactionsFilepath.trim(),
-  );
-  return PopulatedTransactionsSchema.parse(transactionsFileContent);
+function getTransactions(
+  transactionsFilepath: string,
+): AnnotatedEV5Transaction[] {
+  return readYamlOrJson<AnnotatedEV5Transaction[]>(transactionsFilepath.trim());
 }

--- a/typescript/cli/src/config/submit.ts
+++ b/typescript/cli/src/config/submit.ts
@@ -80,7 +80,7 @@ function getChainFromTxs(
   );
   assert(sameChainIds, 'Transactions must be submitted on the same chains');
 
-  return multiProvider.getChainName(firstTransaction.chainId);
+  return multiProvider.getChainName(firstTransaction.domainId);
 }
 
 function getTransactions(transactionsFilepath: string): PopulatedTransactions {

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -783,8 +783,8 @@ class ContextFunder {
   ) {
     const l1Chain = L2ToL1[l2Chain];
     const crossChainMessenger = new CrossChainMessenger({
-      l1ChainId: this.multiProvider.getDomainId(l1Chain),
-      l2ChainId: this.multiProvider.getDomainId(l2Chain),
+      l1ChainId: this.multiProvider.getEvmChainId(l1Chain),
+      l2ChainId: this.multiProvider.getEvmChainId(l2Chain),
       l1SignerOrProvider: this.multiProvider.getSignerOrProvider(l1Chain),
       l2SignerOrProvider: this.multiProvider.getSignerOrProvider(l2Chain),
     });

--- a/typescript/infra/src/utils/safe.ts
+++ b/typescript/infra/src/utils/safe.ts
@@ -119,7 +119,7 @@ export async function deleteSafeTx(
   safeTxHash: string,
 ): Promise<void> {
   const signer = multiProvider.getSigner(chain);
-  const domainId = multiProvider.getDomainId(chain);
+  const chainId = multiProvider.getChainId(chain);
   const txServiceUrl =
     multiProvider.getChainMetadata(chain).gnosisSafeTransactionServiceUrl;
 
@@ -176,7 +176,7 @@ export async function deleteSafeTx(
       domain: {
         name: 'Safe Transaction Service',
         version: '1.0',
-        chainId: domainId,
+        chainId,
         verifyingContract: safeAddress,
       },
       primaryType: 'DeleteRequest',

--- a/typescript/sdk/src/core/AbstractHyperlaneModule.ts
+++ b/typescript/sdk/src/core/AbstractHyperlaneModule.ts
@@ -1,17 +1,8 @@
 import { Logger } from 'pino';
 
-import { Ownable__factory } from '@hyperlane-xyz/core';
-import {
-  Address,
-  Annotated,
-  ProtocolType,
-  eqAddress,
-} from '@hyperlane-xyz/utils';
+import { Annotated, ProtocolType } from '@hyperlane-xyz/utils';
 
-import {
-  AnnotatedEV5Transaction,
-  ProtocolTypedTransaction,
-} from '../providers/ProviderType.js';
+import { ProtocolTypedTransaction } from '../providers/ProviderType.js';
 import { ChainNameOrId } from '../types.js';
 
 export type HyperlaneModuleParams<
@@ -41,41 +32,7 @@ export abstract class HyperlaneModule<
   public abstract read(): Promise<TConfig>;
   public abstract update(
     config: TConfig,
-  ): Promise<Annotated<ProtocolTypedTransaction<TProtocol>['transaction'][]>>;
-
-  /**
-   * Transfers ownership of a contract to a new owner.
-   *
-   * @param actualOwner - The current owner of the contract.
-   * @param expectedOwner - The expected new owner of the contract.
-   * @param deployedAddress - The address of the deployed contract.
-   * @param chainId - The chain ID of the network the contract is deployed on.
-   * @returns An array of annotated EV5 transactions that need to be executed to update the owner.
-   */
-  static createTransferOwnershipTx(params: {
-    actualOwner: Address;
-    expectedOwner: Address;
-    deployedAddress: Address;
-    chainId: number;
-  }): AnnotatedEV5Transaction[] {
-    const { actualOwner, expectedOwner, deployedAddress, chainId } = params;
-    const updateTransactions: AnnotatedEV5Transaction[] = [];
-    if (eqAddress(actualOwner, expectedOwner)) {
-      return [];
-    }
-
-    updateTransactions.push({
-      annotation: `Transferring ownership of ${deployedAddress} from current owner ${actualOwner} to new owner ${expectedOwner}`,
-      chainId,
-      to: deployedAddress,
-      data: Ownable__factory.createInterface().encodeFunctionData(
-        'transferOwnership(address)',
-        [expectedOwner],
-      ),
-    });
-
-    return updateTransactions;
-  }
+  ): Promise<Annotated<ProtocolTypedTransaction<TProtocol>['transaction']>[]>;
 
   // /*
   //   Types and static methods can be challenging. Ensure each implementation includes a static create function.

--- a/typescript/sdk/src/core/EvmCoreModule.hardhat-test.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.hardhat-test.ts
@@ -128,7 +128,7 @@ describe('EvmCoreModule', async () => {
 
       // Check that it's actually a mailbox by calling one of it's methods
       expect(await mailboxContract.localDomain()).to.equal(
-        multiProvider.getChainId(CHAIN),
+        multiProvider.getDomainId(CHAIN),
       );
     });
 

--- a/typescript/sdk/src/core/EvmCoreModule.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.ts
@@ -14,6 +14,7 @@ import {
 import { HyperlaneAddresses } from '../contracts/types.js';
 import { DeployedCoreAddresses } from '../core/schemas.js';
 import { CoreConfig } from '../core/types.js';
+import { EvmModuleDeployer } from '../deploy/EvmModuleDeployer.js';
 import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDeployer.js';
 import {
   ProxyFactoryFactories,
@@ -126,6 +127,7 @@ export class EvmCoreModule extends HyperlaneModule<
         this.multiProvider.getProvider(this.domainId),
       );
       updateTransactions.push({
+        chain: this.chainName,
         annotation: `Setting default ISM for Mailbox ${mailbox} to ${deployedIsm}`,
         chainId: this.chainId,
         to: contractToUpdate.address,
@@ -196,11 +198,12 @@ export class EvmCoreModule extends HyperlaneModule<
     actualConfig: CoreConfig,
     expectedConfig: CoreConfig,
   ): AnnotatedEV5Transaction[] {
-    return EvmCoreModule.createTransferOwnershipTx({
+    return EvmModuleDeployer.createTransferOwnershipTx({
       actualOwner: actualConfig.owner,
       expectedOwner: expectedConfig.owner,
       deployedAddress: this.args.addresses.mailbox,
       chainId: this.chainId,
+      chain: this.chainName,
     });
   }
 

--- a/typescript/sdk/src/core/EvmCoreModule.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.ts
@@ -46,9 +46,8 @@ export class EvmCoreModule extends HyperlaneModule<
   protected coreReader: EvmCoreReader;
   public readonly chainName: string;
 
-  // We use domainId here because MultiProvider.getDomainId() will always
-  // return a number, and EVM the domainId and chainId are the same.
   public readonly domainId: Domain;
+  public readonly chainId: Domain;
 
   constructor(
     protected readonly multiProvider: MultiProvider,
@@ -57,7 +56,8 @@ export class EvmCoreModule extends HyperlaneModule<
     super(args);
     this.coreReader = new EvmCoreReader(multiProvider, this.args.chain);
     this.chainName = this.multiProvider.getChainName(this.args.chain);
-    this.domainId = multiProvider.getDomainId(args.chain);
+    this.domainId = this.multiProvider.getDomainId(this.args.chain);
+    this.chainId = this.multiProvider.getEvmChainId(this.args.chain);
   }
 
   /**
@@ -127,7 +127,7 @@ export class EvmCoreModule extends HyperlaneModule<
       );
       updateTransactions.push({
         annotation: `Setting default ISM for Mailbox ${mailbox} to ${deployedIsm}`,
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: contractToUpdate.address,
         data: contractToUpdate.interface.encodeFunctionData('setDefaultIsm', [
           deployedIsm,
@@ -200,7 +200,7 @@ export class EvmCoreModule extends HyperlaneModule<
       actualOwner: actualConfig.owner,
       expectedOwner: expectedConfig.owner,
       deployedAddress: this.args.addresses.mailbox,
-      chainId: this.domainId,
+      chainId: this.chainId,
     });
   }
 

--- a/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
@@ -143,8 +143,12 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       mailbox,
       defaultHook.address,
       (_mailbox) => _mailbox.defaultHook(),
-      (_mailbox, _hook) =>
-        _mailbox.populateTransaction.setDefaultHook(_hook, { ...txOverrides }),
+      async (_mailbox, _hook) => {
+        const tx = await _mailbox.populateTransaction.setDefaultHook(_hook, {
+          ...txOverrides,
+        });
+        return { ...tx, chain };
+      },
     );
 
     await this.configureHook(
@@ -152,8 +156,12 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       mailbox,
       requiredHook.address,
       (_mailbox) => _mailbox.requiredHook(),
-      (_mailbox, _hook) =>
-        _mailbox.populateTransaction.setRequiredHook(_hook, { ...txOverrides }),
+      async (_mailbox, _hook) => {
+        const tx = await _mailbox.populateTransaction.setRequiredHook(_hook, {
+          ...txOverrides,
+        });
+        return { ...tx, chain };
+      },
     );
 
     await this.configureIsm(
@@ -161,8 +169,10 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       mailbox,
       defaultIsm,
       (_mailbox) => _mailbox.defaultIsm(),
-      (_mailbox, _module) =>
-        _mailbox.populateTransaction.setDefaultIsm(_module),
+      async (_mailbox, _module) => {
+        const tx = await _mailbox.populateTransaction.setDefaultIsm(_module);
+        return { ...tx, chain };
+      },
     );
 
     return mailbox;

--- a/typescript/sdk/src/core/TestRecipientDeployer.ts
+++ b/typescript/sdk/src/core/TestRecipientDeployer.ts
@@ -53,7 +53,12 @@ export class TestRecipientDeployer extends HyperlaneDeployer<
         testRecipient,
         config.interchainSecurityModule,
         (tr) => tr.interchainSecurityModule(),
-        (tr, ism) => tr.populateTransaction.setInterchainSecurityModule(ism),
+        async (tr, ism) => {
+          const tx = await tr.populateTransaction.setInterchainSecurityModule(
+            ism,
+          );
+          return { tx, chain };
+        },
       );
     } else {
       this.logger.warn(`No ISM config provided for TestRecipient on ${chain}`);

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -26,6 +26,8 @@ import {
 } from '@hyperlane-xyz/core';
 import {
   Address,
+  Domain,
+  EvmChainId,
   ProtocolType,
   addressToBytes32,
   deepEquals,
@@ -49,7 +51,7 @@ import { EvmIsmModule } from '../ism/EvmIsmModule.js';
 import { ArbL2ToL1IsmConfig, IsmType, OpStackIsmConfig } from '../ism/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
-import { ChainNameOrId } from '../types.js';
+import { ChainName, ChainNameOrId } from '../types.js';
 import { normalizeConfig } from '../utils/ism.js';
 
 import { EvmHookReader } from './EvmHookReader.js';
@@ -85,10 +87,9 @@ export class EvmHookModule extends HyperlaneModule<
   protected readonly deployer: EvmModuleDeployer<HookFactories & IgpFactories>;
 
   // Adding these to reduce how often we need to grab from MultiProvider.
-  public readonly chain: string;
-  // We use domainId here because MultiProvider.getDomainId() will always
-  // return a number, and EVM the domainId and chainId are the same.
-  public readonly domainId: number;
+  public readonly chain: ChainName;
+  public readonly domainId: Domain;
+  public readonly chainId: EvmChainId;
 
   // Transaction overrides for the chain
   protected readonly txOverrides: Partial<ethers.providers.TransactionRequest>;
@@ -117,6 +118,7 @@ export class EvmHookModule extends HyperlaneModule<
 
     this.chain = this.multiProvider.getChainName(this.args.chain);
     this.domainId = this.multiProvider.getDomainId(this.chain);
+    this.chainId = this.multiProvider.getEvmChainId(this.chain);
 
     this.txOverrides = this.multiProvider.getTransactionOverrides(this.chain);
   }
@@ -211,7 +213,7 @@ export class EvmHookModule extends HyperlaneModule<
     if (!eqAddress(targetConfig.owner, owner)) {
       updateTxs.push({
         annotation: 'Transferring ownership of ownable Hook...',
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: this.args.addresses.deployedHook,
         data: Ownable__factory.createInterface().encodeFunctionData(
           'transferOwnership(address)',
@@ -313,7 +315,7 @@ export class EvmHookModule extends HyperlaneModule<
 
       updateTxs.push({
         annotation: `Updating paused state to ${targetConfig.paused}`,
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: this.args.addresses.deployedHook,
         data,
       });
@@ -336,7 +338,7 @@ export class EvmHookModule extends HyperlaneModule<
     if (!eqAddress(currentConfig.beneficiary, targetConfig.beneficiary)) {
       updateTxs.push({
         annotation: `Updating beneficiary from ${currentConfig.beneficiary} to ${targetConfig.beneficiary}`,
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: this.args.addresses.deployedHook,
         data: igpInterface.encodeFunctionData('setBeneficiary(address)', [
           targetConfig.beneficiary,
@@ -437,7 +439,7 @@ export class EvmHookModule extends HyperlaneModule<
         annotation: `Updating overhead for domains ${Object.keys(
           targetOverheads,
         ).join(', ')}...`,
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: interchainGasPaymaster,
         data: InterchainGasPaymaster__factory.createInterface().encodeFunctionData(
           'setDestinationGasConfigs((uint32,(address,uint96))[])',
@@ -503,7 +505,7 @@ export class EvmHookModule extends HyperlaneModule<
         annotation: `Updating gas oracle config for domains ${Object.keys(
           targetOracleConfig,
         ).join(', ')}...`,
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: gasOracle,
         data: StorageGasOracle__factory.createInterface().encodeFunctionData(
           'setRemoteGasDataConfigs((uint32,uint128,uint128)[])',
@@ -534,7 +536,7 @@ export class EvmHookModule extends HyperlaneModule<
     if (currentConfig.protocolFee !== targetConfig.protocolFee) {
       updateTxs.push({
         annotation: `Updating protocol fee from ${currentConfig.protocolFee} to ${targetConfig.protocolFee}`,
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: this.args.addresses.deployedHook,
         data: protocolFeeInterface.encodeFunctionData(
           'setProtocolFee(uint256)',
@@ -547,7 +549,7 @@ export class EvmHookModule extends HyperlaneModule<
     if (currentConfig.beneficiary !== targetConfig.beneficiary) {
       updateTxs.push({
         annotation: `Updating beneficiary from ${currentConfig.beneficiary} to ${targetConfig.beneficiary}`,
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: this.args.addresses.deployedHook,
         data: protocolFeeInterface.encodeFunctionData(
           'setBeneficiary(address)',
@@ -595,7 +597,7 @@ export class EvmHookModule extends HyperlaneModule<
     return [
       {
         annotation: 'Updating routing hooks...',
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: this.args.addresses.deployedHook,
         data: DomainRoutingHook__factory.createInterface().encodeFunctionData(
           'setHooks((uint32,address)[])',
@@ -831,7 +833,7 @@ export class EvmHookModule extends HyperlaneModule<
     const chain = this.chain;
     const mailbox = this.args.addresses.mailbox;
 
-    const destinationChain = this.multiProvider.getChainId(
+    const destinationChain = this.multiProvider.getDomainId(
       config.destinationChain,
     );
     if (typeof destinationChain !== 'number') {

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -212,6 +212,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Return an ownership transfer transaction if required
     if (!eqAddress(targetConfig.owner, owner)) {
       updateTxs.push({
+        chain: this.chain,
         annotation: 'Transferring ownership of ownable Hook...',
         chainId: this.chainId,
         to: this.args.addresses.deployedHook,
@@ -314,6 +315,7 @@ export class EvmHookModule extends HyperlaneModule<
         : pausableInterface.encodeFunctionData('unpause');
 
       updateTxs.push({
+        chain: this.chain,
         annotation: `Updating paused state to ${targetConfig.paused}`,
         chainId: this.chainId,
         to: this.args.addresses.deployedHook,
@@ -337,6 +339,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Update beneficiary if changed
     if (!eqAddress(currentConfig.beneficiary, targetConfig.beneficiary)) {
       updateTxs.push({
+        chain: this.chain,
         annotation: `Updating beneficiary from ${currentConfig.beneficiary} to ${targetConfig.beneficiary}`,
         chainId: this.chainId,
         to: this.args.addresses.deployedHook,
@@ -436,6 +439,7 @@ export class EvmHookModule extends HyperlaneModule<
 
     return [
       {
+        chain: this.chain,
         annotation: `Updating overhead for domains ${Object.keys(
           targetOverheads,
         ).join(', ')}...`,
@@ -502,6 +506,7 @@ export class EvmHookModule extends HyperlaneModule<
 
     return [
       {
+        chain: this.chain,
         annotation: `Updating gas oracle config for domains ${Object.keys(
           targetOracleConfig,
         ).join(', ')}...`,
@@ -535,6 +540,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Update protocol fee if changed
     if (currentConfig.protocolFee !== targetConfig.protocolFee) {
       updateTxs.push({
+        chain: this.chain,
         annotation: `Updating protocol fee from ${currentConfig.protocolFee} to ${targetConfig.protocolFee}`,
         chainId: this.chainId,
         to: this.args.addresses.deployedHook,
@@ -548,6 +554,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Update beneficiary if changed
     if (currentConfig.beneficiary !== targetConfig.beneficiary) {
       updateTxs.push({
+        chain: this.chain,
         annotation: `Updating beneficiary from ${currentConfig.beneficiary} to ${targetConfig.beneficiary}`,
         chainId: this.chainId,
         to: this.args.addresses.deployedHook,
@@ -596,6 +603,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Create tx for setting hooks
     return [
       {
+        chain: this.chain,
         annotation: 'Updating routing hooks...',
         chainId: this.chainId,
         to: this.args.addresses.deployedHook,

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -312,15 +312,8 @@ export {
   excludeProviderMethods,
 } from './providers/SmartProvider/ProviderMethods.js';
 export { HyperlaneSmartProvider } from './providers/SmartProvider/SmartProvider.js';
-export {
-  PopulatedTransactionSchema,
-  PopulatedTransactionsSchema,
-} from './providers/transactions/schemas.js';
-export {
-  CallData,
-  PopulatedTransaction,
-  PopulatedTransactions,
-} from './providers/transactions/types.js';
+
+export { CallData } from './providers/transactions/types.js';
 
 export { SubmitterMetadataSchema } from './providers/transactions/submitter/schemas.js';
 export { TxSubmitterInterface } from './providers/transactions/submitter/TxSubmitterInterface.js';

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -22,6 +22,7 @@ import {
 import {
   Address,
   Domain,
+  EvmChainId,
   ProtocolType,
   addBufferToGasLimit,
   assert,
@@ -79,9 +80,8 @@ export class EvmIsmModule extends HyperlaneModule<
 
   // Adding these to reduce how often we need to grab from MultiProvider.
   public readonly chain: ChainName;
-  // We use domainId here because MultiProvider.getDomainId() will always
-  // return a number, and EVM the domainId and chainId are the same.
   public readonly domainId: Domain;
+  public readonly chainId: EvmChainId;
 
   constructor(
     protected readonly multiProvider: MultiProvider,
@@ -124,6 +124,7 @@ export class EvmIsmModule extends HyperlaneModule<
 
     this.chain = this.multiProvider.getChainName(this.args.chain);
     this.domainId = this.multiProvider.getDomainId(this.chain);
+    this.chainId = this.multiProvider.getEvmChainId(this.chain);
   }
 
   public async read(): Promise<IsmConfig> {
@@ -221,7 +222,7 @@ export class EvmIsmModule extends HyperlaneModule<
     if (!eqAddress(targetConfig.owner, owner)) {
       updateTxs.push({
         annotation: 'Transferring ownership of ownable ISM...',
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: this.args.addresses.deployedIsm,
         data: Ownable__factory.createInterface().encodeFunctionData(
           'transferOwnership(address)',
@@ -312,7 +313,7 @@ export class EvmIsmModule extends HyperlaneModule<
       const domainId = this.multiProvider.getDomainId(origin);
       updateTxs.push({
         annotation: `Setting new ISM for origin ${origin}...`,
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: this.args.addresses.deployedIsm,
         data: routingIsmInterface.encodeFunctionData('set(uint32,address)', [
           domainId,
@@ -326,7 +327,7 @@ export class EvmIsmModule extends HyperlaneModule<
       const domainId = this.multiProvider.getDomainId(origin);
       updateTxs.push({
         annotation: `Unenrolling originDomain ${domainId} from preexisting routing ISM at ${this.args.addresses.deployedIsm}...`,
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: this.args.addresses.deployedIsm,
         data: routingIsmInterface.encodeFunctionData('remove(uint32)', [
           domainId,

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -221,6 +221,7 @@ export class EvmIsmModule extends HyperlaneModule<
     // Return an ownership transfer transaction if required
     if (!eqAddress(targetConfig.owner, owner)) {
       updateTxs.push({
+        chain: this.chain,
         annotation: 'Transferring ownership of ownable ISM...',
         chainId: this.chainId,
         to: this.args.addresses.deployedIsm,
@@ -312,6 +313,7 @@ export class EvmIsmModule extends HyperlaneModule<
 
       const domainId = this.multiProvider.getDomainId(origin);
       updateTxs.push({
+        chain: this.chain,
         annotation: `Setting new ISM for origin ${origin}...`,
         chainId: this.chainId,
         to: this.args.addresses.deployedIsm,
@@ -326,6 +328,7 @@ export class EvmIsmModule extends HyperlaneModule<
     for (const origin of domainsToUnenroll) {
       const domainId = this.multiProvider.getDomainId(origin);
       updateTxs.push({
+        chain: this.chain,
         annotation: `Unenrolling originDomain ${domainId} from preexisting routing ISM at ${this.args.addresses.deployedIsm}...`,
         chainId: this.chainId,
         to: this.args.addresses.deployedIsm,

--- a/typescript/sdk/src/metadata/ChainMetadataManager.ts
+++ b/typescript/sdk/src/metadata/ChainMetadataManager.ts
@@ -1,6 +1,12 @@
 import { Logger } from 'pino';
 
-import { ProtocolType, exclude, pick, rootLogger } from '@hyperlane-xyz/utils';
+import {
+  EvmChainId,
+  ProtocolType,
+  exclude,
+  pick,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
 
 import { ChainMap, ChainName, ChainNameOrId } from '../types.js';
 
@@ -90,7 +96,7 @@ export class ChainMetadataManager<MetaExt = {}> {
     if (this.metadata[chainNameOrId]) return this.metadata[chainNameOrId];
     // Otherwise search by chain id and domain id
     const chainMetadata = Object.values(this.metadata).find(
-      (m) => m.chainId == chainNameOrId || m.domainId == chainNameOrId,
+      (m) => m.domainId == chainNameOrId,
     );
     return chainMetadata || null;
   }
@@ -161,6 +167,21 @@ export class ChainMetadataManager<MetaExt = {}> {
    */
   getChainId(chainNameOrId: ChainNameOrId): number | string {
     return this.getChainMetadata(chainNameOrId).chainId;
+  }
+
+  /**
+   * Get the id for a given EVM chain name or domain id
+   * @throws if chain's metadata has not been set
+   */
+  getEvmChainId(chainNameOrId: ChainNameOrId): EvmChainId {
+    const { protocol, chainId } = this.getChainMetadata(chainNameOrId);
+    if (protocol !== ProtocolType.Ethereum) {
+      throw new Error(`Chain is not an EVM chain: ${chainNameOrId}`);
+    }
+    if (typeof chainId !== 'number') {
+      throw new Error(`Chain ID is not a number: ${chainId}`);
+    }
+    return chainId;
   }
 
   /**

--- a/typescript/sdk/src/metadata/ChainMetadataManager.ts
+++ b/typescript/sdk/src/metadata/ChainMetadataManager.ts
@@ -62,31 +62,24 @@ export class ChainMetadataManager<MetaExt = {}> {
 
   /**
    * Add a chain to the MultiProvider
-   * @throws if chain's name or domain/chain ID collide
+   * @throws if chain's name or domain ID collide
    */
   addChain(metadata: ChainMetadata<MetaExt>): void {
     ChainMetadataSchema.parse(metadata);
     // Ensure no two chains have overlapping names/domainIds/chainIds
     for (const chainMetadata of Object.values(this.metadata)) {
-      const { name, chainId, domainId } = chainMetadata;
+      const { name, domainId } = chainMetadata;
       if (name == metadata.name)
         throw new Error(`Duplicate chain name: ${name}`);
-      // Chain and Domain Ids should be globally unique
-      const idCollision =
-        chainId == metadata.chainId ||
-        domainId == metadata.chainId ||
-        (metadata.domainId &&
-          (chainId == metadata.domainId || domainId == metadata.domainId));
-      if (idCollision)
-        throw new Error(
-          `Chain/Domain id collision: ${name} and ${metadata.name}`,
-        );
+      // Domain Ids should be globally unique
+      if (domainId == metadata.domainId)
+        throw new Error(`Domain ID collision: ${name} and ${metadata.name}`);
     }
     this.metadata[metadata.name] = metadata;
   }
 
   /**
-   * Get the metadata for a given chain name, chain id, or domain id
+   * Get the metadata for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   tryGetChainMetadata(
@@ -94,7 +87,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   ): ChainMetadata<MetaExt> | null {
     // First check if it's a chain name
     if (this.metadata[chainNameOrId]) return this.metadata[chainNameOrId];
-    // Otherwise search by chain id and domain id
+    // Otherwise search by domain id
     const chainMetadata = Object.values(this.metadata).find(
       (m) => m.domainId == chainNameOrId,
     );
@@ -102,7 +95,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the metadata for a given chain name, chain id, or domain id
+   * Get the metadata for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   getChainMetadata(chainNameOrId: ChainNameOrId): ChainMetadata<MetaExt> {
@@ -125,7 +118,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Returns true if the given chain name, chain id, or domain id is
+   * Returns true if the given chain name or domain id is
    * include in this manager's metadata, false otherwise
    */
   hasChain(chainNameOrId: ChainNameOrId): boolean {
@@ -133,14 +126,14 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the name for a given chain name, chain id, or domain id
+   * Get the name for a given chain name or domain id
    */
   tryGetChainName(chainNameOrId: ChainNameOrId): string | null {
     return this.tryGetChainMetadata(chainNameOrId)?.name ?? null;
   }
 
   /**
-   * Get the name for a given chain name, chain id, or domain id
+   * Get the name for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   getChainName(chainNameOrId: ChainNameOrId): string {
@@ -155,14 +148,14 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the id for a given chain name, chain id, or domain id
+   * Get the id for a given chain name or domain id
    */
   tryGetChainId(chainNameOrId: ChainNameOrId): number | string | null {
     return this.tryGetChainMetadata(chainNameOrId)?.chainId ?? null;
   }
 
   /**
-   * Get the id for a given chain name, chain id, or domain id
+   * Get the id for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   getChainId(chainNameOrId: ChainNameOrId): number | string {
@@ -192,7 +185,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the domain id for a given chain name, chain id, or domain id
+   * Get the domain id for a given chain name or domain id
    */
   tryGetDomainId(chainNameOrId: ChainNameOrId): number | null {
     const metadata = this.tryGetChainMetadata(chainNameOrId);
@@ -201,7 +194,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the domain id for a given chain name, chain id, or domain id
+   * Get the domain id for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   getDomainId(chainNameOrId: ChainNameOrId): number {
@@ -211,14 +204,14 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the protocol type for a given chain name, chain id, or domain id
+   * Get the protocol type for a given chain name or domain id
    */
   tryGetProtocol(chainNameOrId: ChainNameOrId): ProtocolType | null {
     return this.tryGetChainMetadata(chainNameOrId)?.protocol ?? null;
   }
 
   /**
-   * Get the protocol type for a given chain name, chain id, or domain id
+   * Get the protocol type for a given chain name or domain id
    * @throws if chain's metadata or protocol has not been set
    */
   getProtocol(chainNameOrId: ChainNameOrId): ProtocolType {
@@ -226,7 +219,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the domain ids for a list of chain names, chain ids, or domain ids
+   * Get the domain ids for a list of chain names or domain ids
    * @throws if any chain's metadata has not been set
    */
   getDomainIds(chainNamesOrIds: Array<ChainName | number>): number[] {
@@ -261,7 +254,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the RPC details for a given chain name, chain id, or domain id.
+   * Get the RPC details for a given chain name or domain id.
    * Optional index for metadata containing more than one RPC.
    * @throws if chain's metadata has not been set
    */
@@ -278,7 +271,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get an RPC URL for a given chain name, chain id, or domain id
+   * Get an RPC URL for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   getRpcUrl(chainNameOrId: ChainNameOrId, index = 0): string {
@@ -288,7 +281,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get an RPC concurrency level for a given chain name, chain id, or domain id
+   * Get an RPC concurrency level for a given chain name or domain id
    */
   tryGetRpcConcurrency(chainNameOrId: ChainNameOrId, index = 0): number | null {
     const { concurrency } = this.getRpc(chainNameOrId, index);
@@ -296,7 +289,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get a block explorer URL for a given chain name, chain id, or domain id
+   * Get a block explorer URL for a given chain name or domain id
    */
   tryGetExplorerUrl(chainNameOrId: ChainNameOrId): string | null {
     const metadata = this.tryGetChainMetadata(chainNameOrId);
@@ -305,7 +298,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get a block explorer URL for a given chain name, chain id, or domain id
+   * Get a block explorer URL for a given chain name or domain id
    * @throws if chain's metadata or block explorer data has no been set
    */
   getExplorerUrl(chainNameOrId: ChainNameOrId): string {
@@ -315,7 +308,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get a block explorer's API for a given chain name, chain id, or domain id
+   * Get a block explorer's API for a given chain name or domain id
    */
   tryGetExplorerApi(chainNameOrId: ChainName | number): {
     apiUrl: string;
@@ -328,7 +321,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get a block explorer API for a given chain name, chain id, or domain id
+   * Get a block explorer API for a given chain name or domain id
    * @throws if chain's metadata or block explorer data has no been set
    */
   getExplorerApi(chainNameOrId: ChainName | number): {
@@ -343,7 +336,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get a block explorer's API URL for a given chain name, chain id, or domain id
+   * Get a block explorer's API URL for a given chain name or domain id
    */
   tryGetExplorerApiUrl(chainNameOrId: ChainNameOrId): string | null {
     const metadata = this.tryGetChainMetadata(chainNameOrId);
@@ -352,7 +345,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get a block explorer API URL for a given chain name, chain id, or domain id
+   * Get a block explorer API URL for a given chain name or domain id
    * @throws if chain's metadata or block explorer data has no been set
    */
   getExplorerApiUrl(chainNameOrId: ChainNameOrId): string {

--- a/typescript/sdk/src/middleware/account/InterchainAccount.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.ts
@@ -1,4 +1,4 @@
-import { BigNumber, PopulatedTransaction } from 'ethers';
+import { BigNumber } from 'ethers';
 
 import { InterchainAccountRouter } from '@hyperlane-xyz/core';
 import {
@@ -14,6 +14,7 @@ import {
   HyperlaneContractsMap,
 } from '../../contracts/types.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
+import { AnnotatedEV5Transaction } from '../../providers/ProviderType.js';
 import { RouterApp } from '../../router/RouterApps.js';
 import { ChainName } from '../../types.js';
 
@@ -147,7 +148,7 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
     innerCalls,
     config,
     hookMetadata,
-  }: GetCallRemoteSettings): Promise<PopulatedTransaction> {
+  }: GetCallRemoteSettings): Promise<AnnotatedEV5Transaction> {
     const localRouter = this.router(this.contractsMap[chain]);
     const remoteDomain = this.multiProvider.getDomainId(destination);
     const quote = await localRouter['quoteGasPayment(uint32)'](remoteDomain);
@@ -172,7 +173,7 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
       hookMetadata ?? '0x',
       { value: quote },
     );
-    return callEncoded;
+    return { ...callEncoded, chain };
   }
 
   async getAccountConfig(

--- a/typescript/sdk/src/providers/MultiProvider.ts
+++ b/typescript/sdk/src/providers/MultiProvider.ts
@@ -84,7 +84,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Get an Ethers provider for a given chain name, chain id, or domain id
+   * Get an Ethers provider for a given chain name or domain id
    */
   tryGetProvider(chainNameOrId: ChainNameOrId): Provider | null {
     const metadata = this.tryGetChainMetadata(chainNameOrId);
@@ -108,7 +108,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Get an Ethers provider for a given chain name, chain id, or domain id
+   * Get an Ethers provider for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   getProvider(chainNameOrId: ChainNameOrId): Provider {
@@ -119,7 +119,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Sets an Ethers provider for a given chain name, chain id, or domain id
+   * Sets an Ethers provider for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   setProvider(chainNameOrId: ChainNameOrId, provider: Provider): Provider {
@@ -144,7 +144,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Get an Ethers signer for a given chain name, chain id, or domain id
+   * Get an Ethers signer for a given chain name or domain id
    * If signer is not yet connected, it will be connected
    */
   tryGetSigner(chainNameOrId: ChainNameOrId): Signer | null {
@@ -159,7 +159,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Get an Ethers signer for a given chain name, chain id, or domain id
+   * Get an Ethers signer for a given chain name or domain id
    * If signer is not yet connected, it will be connected
    * @throws if chain's metadata or signer has not been set
    */
@@ -170,7 +170,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Get an Ethers signer for a given chain name, chain id, or domain id
+   * Get an Ethers signer for a given chain name or domain id
    * @throws if chain's metadata or signer has not been set
    */
   async getSignerAddress(chainNameOrId: ChainNameOrId): Promise<Address> {
@@ -180,7 +180,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Sets an Ethers Signer for a given chain name, chain id, or domain id
+   * Sets an Ethers Signer for a given chain name or domain id
    * @throws if chain's metadata has not been set or shared signer has already been set
    */
   setSigner(chainNameOrId: ChainNameOrId, signer: Signer): Signer {
@@ -295,7 +295,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Get the transaction overrides for a given chain name, chain id, or domain id
+   * Get the transaction overrides for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   getTransactionOverrides(

--- a/typescript/sdk/src/providers/ProviderType.ts
+++ b/typescript/sdk/src/providers/ProviderType.ts
@@ -22,6 +22,7 @@ import type {
   TransactionReceipt as VTransactionReceipt,
 } from 'viem';
 
+import { ChainName } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
 export enum ProviderType {
@@ -192,6 +193,7 @@ export interface EthersV5Transaction
 }
 
 export interface AnnotatedEV5Transaction extends EV5Transaction {
+  chain: ChainName;
   annotation?: string;
 }
 

--- a/typescript/sdk/src/providers/transactions/schemas.test.ts
+++ b/typescript/sdk/src/providers/transactions/schemas.test.ts
@@ -9,6 +9,7 @@ describe('transactions schemas', () => {
   const ADDRESS_MOCK: Address = '0x1234567890123456789012345678901234567890';
   const DATA_MOCK: string = '0xabcdef';
   const CHAIN_ID_MOCK: number = 1;
+  const DOMAIN_ID_MOCK: number = 1;
   const VALUE_MOCK: string = '100';
 
   const INVALID_ADDRESS: Address = '0x1';
@@ -19,6 +20,7 @@ describe('transactions schemas', () => {
         to: ADDRESS_MOCK,
         data: DATA_MOCK,
         chainId: CHAIN_ID_MOCK,
+        domainId: DOMAIN_ID_MOCK,
       };
       const result = PopulatedTransactionSchema.safeParse(
         validPopulatedTransaction,
@@ -31,6 +33,7 @@ describe('transactions schemas', () => {
         to: INVALID_ADDRESS,
         data: DATA_MOCK,
         chainId: CHAIN_ID_MOCK,
+        domainId: DOMAIN_ID_MOCK,
       };
       const result = PopulatedTransactionSchema.safeParse(
         invalidPopulatedTransaction,

--- a/typescript/sdk/src/providers/transactions/schemas.test.ts
+++ b/typescript/sdk/src/providers/transactions/schemas.test.ts
@@ -2,45 +2,15 @@ import { expect } from 'chai';
 
 import { Address } from '@hyperlane-xyz/utils';
 
-import { CallDataSchema, PopulatedTransactionSchema } from './schemas.js';
-import { CallData, PopulatedTransaction } from './types.js';
+import { CallDataSchema } from './schemas.js';
+import { CallData } from './types.js';
 
 describe('transactions schemas', () => {
   const ADDRESS_MOCK: Address = '0x1234567890123456789012345678901234567890';
   const DATA_MOCK: string = '0xabcdef';
-  const CHAIN_ID_MOCK: number = 1;
-  const DOMAIN_ID_MOCK: number = 1;
   const VALUE_MOCK: string = '100';
 
   const INVALID_ADDRESS: Address = '0x1';
-
-  describe('PopulatedTransactionSchema', () => {
-    it('should parse valid PopulatedTransaction', () => {
-      const validPopulatedTransaction: PopulatedTransaction = {
-        to: ADDRESS_MOCK,
-        data: DATA_MOCK,
-        chainId: CHAIN_ID_MOCK,
-        domainId: DOMAIN_ID_MOCK,
-      };
-      const result = PopulatedTransactionSchema.safeParse(
-        validPopulatedTransaction,
-      );
-      expect(result.success).to.be.true;
-    });
-
-    it('should fail parsing invalid PopulatedTransaction', () => {
-      const invalidPopulatedTransaction: PopulatedTransaction = {
-        to: INVALID_ADDRESS,
-        data: DATA_MOCK,
-        chainId: CHAIN_ID_MOCK,
-        domainId: DOMAIN_ID_MOCK,
-      };
-      const result = PopulatedTransactionSchema.safeParse(
-        invalidPopulatedTransaction,
-      );
-      expect(result.success).to.be.false;
-    });
-  });
 
   describe('CallDataSchema', () => {
     it('should parse valid CallData', () => {

--- a/typescript/sdk/src/providers/transactions/schemas.ts
+++ b/typescript/sdk/src/providers/transactions/schemas.ts
@@ -4,17 +4,6 @@ import { ZHash } from '../../metadata/customZodTypes.js';
 
 export const BigNumberSchema = z.string();
 
-export const PopulatedTransactionSchema = z.object({
-  to: ZHash,
-  data: z.string(),
-  domainId: z.number(),
-});
-
-export const PopulatedTransactionsSchema =
-  PopulatedTransactionSchema.array().refine((txs) => txs.length > 0, {
-    message: 'Populated Transactions cannot be empty',
-  });
-
 export const CallDataSchema = z.object({
   to: ZHash,
   data: z.string(),

--- a/typescript/sdk/src/providers/transactions/schemas.ts
+++ b/typescript/sdk/src/providers/transactions/schemas.ts
@@ -8,6 +8,7 @@ export const PopulatedTransactionSchema = z.object({
   to: ZHash,
   data: z.string(),
   chainId: z.number(),
+  domainId: z.number(),
 });
 
 export const PopulatedTransactionsSchema =

--- a/typescript/sdk/src/providers/transactions/schemas.ts
+++ b/typescript/sdk/src/providers/transactions/schemas.ts
@@ -7,7 +7,6 @@ export const BigNumberSchema = z.string();
 export const PopulatedTransactionSchema = z.object({
   to: ZHash,
   data: z.string(),
-  chainId: z.number(),
   domainId: z.number(),
 });
 

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.ts
@@ -67,8 +67,8 @@ export class EV5GnosisSafeTxSubmitter implements EV5TxSubmitterInterface {
       this.props.safeAddress,
     );
     const safeTransactionBatch: any[] = txs.map(
-      ({ to, data, value, chainId }: PopulatedTransaction) => {
-        const txChain = this.multiProvider.getChainName(chainId);
+      ({ to, data, value, domainId }: PopulatedTransaction) => {
+        const txChain = this.multiProvider.getChainName(domainId);
         assert(
           txChain === this.props.chain,
           `Invalid PopulatedTransaction: Cannot submit ${txChain} tx to ${this.props.chain} submitter.`,

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.ts
@@ -6,7 +6,7 @@ import { Address, assert, rootLogger } from '@hyperlane-xyz/utils';
 // @ts-ignore
 import { canProposeSafeTransactions, getSafe, getSafeService } from '../../../../utils/gnosisSafe.js';
 import { MultiProvider } from '../../../MultiProvider.js';
-import { PopulatedTransaction, PopulatedTransactions } from '../../types.js';
+import { AnnotatedEV5Transaction } from '../../../ProviderType.js';
 import { TxSubmitterType } from '../TxSubmitterTypes.js';
 
 import { EV5TxSubmitterInterface } from './EV5TxSubmitterInterface.js';
@@ -62,16 +62,15 @@ export class EV5GnosisSafeTxSubmitter implements EV5TxSubmitterInterface {
     );
   }
 
-  public async submit(...txs: PopulatedTransactions): Promise<any[]> {
+  public async submit(...txs: AnnotatedEV5Transaction[]): Promise<any[]> {
     const nextNonce: number = await this.safeService.getNextNonce(
       this.props.safeAddress,
     );
     const safeTransactionBatch: any[] = txs.map(
-      ({ to, data, value, domainId }: PopulatedTransaction) => {
-        const txChain = this.multiProvider.getChainName(domainId);
+      ({ to, data, value, chain }: AnnotatedEV5Transaction) => {
         assert(
-          txChain === this.props.chain,
-          `Invalid PopulatedTransaction: Cannot submit ${txChain} tx to ${this.props.chain} submitter.`,
+          chain === this.props.chain,
+          `Invalid PopulatedTransaction: Cannot submit ${chain} tx to ${this.props.chain} submitter.`,
         );
         return { to, data, value: value?.toString() ?? '0' };
       },

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5ImpersonatedAccountTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5ImpersonatedAccountTxSubmitter.ts
@@ -8,7 +8,7 @@ import {
   stopImpersonatingAccount,
 } from '../../../../utils/fork.js';
 import { MultiProvider } from '../../../MultiProvider.js';
-import { PopulatedTransactions } from '../../types.js';
+import { AnnotatedEV5Transaction } from '../../../ProviderType.js';
 import { TxSubmitterType } from '../TxSubmitterTypes.js';
 
 import { EV5JsonRpcTxSubmitter } from './EV5JsonRpcTxSubmitter.js';
@@ -30,7 +30,7 @@ export class EV5ImpersonatedAccountTxSubmitter extends EV5JsonRpcTxSubmitter {
   }
 
   public async submit(
-    ...txs: PopulatedTransactions
+    ...txs: AnnotatedEV5Transaction[]
   ): Promise<TransactionReceipt[]> {
     const impersonatedAccount = await impersonateAccount(
       this.props.userAddress,

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
@@ -24,8 +24,11 @@ export class EV5JsonRpcTxSubmitter implements EV5TxSubmitterInterface {
   ): Promise<TransactionReceipt[]> {
     const receipts: TransactionReceipt[] = [];
     for (const tx of txs) {
-      assert(tx.chainId, 'Invalid PopulatedTransaction: Missing chainId field');
-      const txChain = this.multiProvider.getChainName(tx.chainId);
+      assert(
+        tx.domainId,
+        'Invalid PopulatedTransaction: Missing domainId field',
+      );
+      const txChain = this.multiProvider.getChainName(tx.domainId);
       const receipt: ContractReceipt = await this.multiProvider.sendTransaction(
         txChain,
         tx,

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
@@ -2,10 +2,10 @@ import { TransactionReceipt } from '@ethersproject/providers';
 import { ContractReceipt } from 'ethers';
 import { Logger } from 'pino';
 
-import { assert, rootLogger } from '@hyperlane-xyz/utils';
+import { rootLogger } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../../../MultiProvider.js';
-import { PopulatedTransactions } from '../../types.js';
+import { AnnotatedEV5Transaction } from '../../../ProviderType.js';
 import { TxSubmitterType } from '../TxSubmitterTypes.js';
 
 import { EV5TxSubmitterInterface } from './EV5TxSubmitterInterface.js';
@@ -20,21 +20,16 @@ export class EV5JsonRpcTxSubmitter implements EV5TxSubmitterInterface {
   constructor(public readonly multiProvider: MultiProvider) {}
 
   public async submit(
-    ...txs: PopulatedTransactions
+    ...txs: AnnotatedEV5Transaction[]
   ): Promise<TransactionReceipt[]> {
     const receipts: TransactionReceipt[] = [];
     for (const tx of txs) {
-      assert(
-        tx.domainId,
-        'Invalid PopulatedTransaction: Missing domainId field',
-      );
-      const txChain = this.multiProvider.getChainName(tx.domainId);
       const receipt: ContractReceipt = await this.multiProvider.sendTransaction(
-        txChain,
+        tx.chain,
         tx,
       );
       this.logger.debug(
-        `Submitted PopulatedTransaction on ${txChain}: ${receipt.transactionHash}`,
+        `Submitted transaction on ${tx.chain}: ${receipt.transactionHash}`,
       );
       receipts.push(receipt);
     }

--- a/typescript/sdk/src/providers/transactions/transformer/ethersV5/EV5InterchainAccountTxTransformer.ts
+++ b/typescript/sdk/src/providers/transactions/transformer/ethersV5/EV5InterchainAccountTxTransformer.ts
@@ -9,11 +9,8 @@ import {
 } from '../../../../middleware/account/InterchainAccount.js';
 import { ChainName } from '../../../../types.js';
 import { MultiProvider } from '../../../MultiProvider.js';
-import {
-  CallData,
-  PopulatedTransaction,
-  PopulatedTransactions,
-} from '../../types.js';
+import { AnnotatedEV5Transaction } from '../../../ProviderType.js';
+import { CallData } from '../../types.js';
 import { TxTransformerType } from '../TxTransformerTypes.js';
 
 import { EV5TxTransformerInterface } from './EV5TxTransformerInterface.js';
@@ -39,16 +36,17 @@ export class EV5InterchainAccountTxTransformer
   }
 
   public async transform(
-    ...txs: PopulatedTransactions
+    ...txs: AnnotatedEV5Transaction[]
   ): Promise<ethers.PopulatedTransaction[]> {
     const txChainsToInnerCalls: Record<ChainName, CallData[]> = txs.reduce(
       (
         txChainToInnerCalls: Record<ChainName, CallData[]>,
-        { to, data, domainId }: PopulatedTransaction,
+        { to, data, chain }: AnnotatedEV5Transaction,
       ) => {
-        const txChain = this.multiProvider.getChainName(domainId);
-        txChainToInnerCalls[txChain] ||= [];
-        txChainToInnerCalls[txChain].push({ to, data });
+        assert(to, 'Invalid transaction: to is required');
+        assert(data, 'Invalid transaction: data is required');
+        txChainToInnerCalls[chain] ||= [];
+        txChainToInnerCalls[chain].push({ to, data });
         return txChainToInnerCalls;
       },
       {},

--- a/typescript/sdk/src/providers/transactions/transformer/ethersV5/EV5InterchainAccountTxTransformer.ts
+++ b/typescript/sdk/src/providers/transactions/transformer/ethersV5/EV5InterchainAccountTxTransformer.ts
@@ -44,9 +44,9 @@ export class EV5InterchainAccountTxTransformer
     const txChainsToInnerCalls: Record<ChainName, CallData[]> = txs.reduce(
       (
         txChainToInnerCalls: Record<ChainName, CallData[]>,
-        { to, data, chainId }: PopulatedTransaction,
+        { to, data, domainId }: PopulatedTransaction,
       ) => {
-        const txChain = this.multiProvider.getChainName(chainId);
+        const txChain = this.multiProvider.getChainName(domainId);
         txChainToInnerCalls[txChain] ||= [];
         txChainToInnerCalls[txChain].push({ to, data });
         return txChainToInnerCalls;

--- a/typescript/sdk/src/providers/transactions/types.ts
+++ b/typescript/sdk/src/providers/transactions/types.ts
@@ -1,17 +1,5 @@
-import { ethers } from 'ethers';
 import { z } from 'zod';
 
-import {
-  CallDataSchema,
-  PopulatedTransactionSchema,
-  PopulatedTransactionsSchema,
-} from './schemas.js';
-
-export type PopulatedTransaction = z.infer<typeof PopulatedTransactionSchema> &
-  ethers.PopulatedTransaction;
-export type PopulatedTransactions = z.infer<
-  typeof PopulatedTransactionsSchema
-> &
-  ethers.PopulatedTransaction[];
+import { CallDataSchema } from './schemas.js';
 
 export type CallData = z.infer<typeof CallDataSchema>;

--- a/typescript/sdk/src/types.ts
+++ b/typescript/sdk/src/types.ts
@@ -1,12 +1,12 @@
 import type { ethers } from 'ethers';
 
-import type { ChainId, Domain } from '@hyperlane-xyz/utils';
+import type { Domain } from '@hyperlane-xyz/utils';
 
 // An alias for string to clarify type is a chain name
 export type ChainName = string;
 // A map of chain names to a value type
 export type ChainMap<Value> = Record<string, Value>;
 
-export type ChainNameOrId = ChainName | ChainId | Domain;
+export type ChainNameOrId = ChainName | Domain;
 
 export type Connection = ethers.providers.Provider | ethers.Signer;

--- a/typescript/sdk/src/utils/gnosisSafe.js
+++ b/typescript/sdk/src/utils/gnosisSafe.js
@@ -48,8 +48,8 @@ export async function getSafe(chain, multiProvider, safeAddress) {
   const signer = multiProvider.getSigner(chain);
   const ethAdapter = new EthersAdapter({ ethers, signerOrProvider: signer });
 
-  // Get the domain id for the given chain
-  const domainId = multiProvider.getDomainId(chain);
+  // Get the chain id of the given chain
+  const chainId = multiProvider.getChainId(chain);
 
   // Get the safe version
   const safeService = getSafeService(chain, multiProvider);
@@ -66,11 +66,11 @@ export async function getSafe(chain, multiProvider, safeAddress) {
       safeDeploymentsVersions[safeVersion];
     multiSend = getMultiSendDeployment({
       version: multiSendVersion,
-      network: domainId,
+      network: chainId,
     });
     multiSendCallOnly = getMultiSendCallOnlyDeployment({
       version: multiSendCallOnlyVersion,
-      network: domainId,
+      network: chainId,
     });
   }
 
@@ -78,13 +78,12 @@ export async function getSafe(chain, multiProvider, safeAddress) {
     ethAdapter,
     safeAddress,
     contractNetworks: {
-      // DomainId == ChainId for EVM Chains
-      [domainId]: {
+      [chainId]: {
         // Use the safe address for multiSendAddress and multiSendCallOnlyAddress
         // if the contract is not deployed or if the version is not found.
-        multiSendAddress: multiSend?.networkAddresses[domainId] || safeAddress,
+        multiSendAddress: multiSend?.networkAddresses[chainId] || safeAddress,
         multiSendCallOnlyAddress:
-          multiSendCallOnly?.networkAddresses[domainId] || safeAddress,
+          multiSendCallOnly?.networkAddresses[chainId] || safeAddress,
       },
     },
   });

--- a/typescript/utils/src/index.ts
+++ b/typescript/utils/src/index.ts
@@ -140,6 +140,7 @@ export {
   Checkpoint,
   CheckpointWithId,
   Domain,
+  EvmChainId,
   HexString,
   MerkleProof,
   MessageStatus,

--- a/typescript/utils/src/types.ts
+++ b/typescript/utils/src/types.ts
@@ -17,6 +17,7 @@ export const ProtocolSmallestUnit = {
 
 /********* BASIC TYPES *********/
 export type Domain = number;
+export type EvmChainId = number;
 export type ChainId = string | number;
 export type Address = string;
 export type AddressBytes32 = string;

--- a/typescript/utils/src/types.ts
+++ b/typescript/utils/src/types.ts
@@ -114,5 +114,6 @@ export type ParsedLegacyMultisigIsmMetadata = {
 };
 
 export type Annotated<T> = T & {
+  chain: string; // TODO: Change to ChainName after moving to SDK from Utils
   annotation?: string;
 };


### PR DESCRIPTION
The problem has surfaced twice now of multiple chains reusing the same chainid:
	- celo classic testnet & celo L2 testnet
	- molten & shape

This PR allows the set of chain metadata to include unique chains/domains that share the same chainId under the hood. This required changes in multiple places where we assumed that the domainId/chainId would be the same for EVM chains (no such assumption was made on other EVMs).

Also required updating the types in the submitters because they were using their own types instead of the existing ones for some reason.

Touches:
- evm core/ism/hook/warp modules
- tx submitters
- multiprovider + chain metadata manager
- safe service