### PR TITLE
fix: reuse SDK transaction types in submitters

### DIFF
--- a/typescript/infra/scripts/funding/fund-deterministic-key-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-deterministic-key-from-deployer.ts
@@ -80,6 +80,7 @@ async function main() {
           `Funding ${address} on chain '${chain}' with ${value} native tokens`,
         );
         await multiProvider.sendTransaction(chain, {
+          chain,
           to: address,
           value,
         });

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -623,10 +623,10 @@ class ContextFunder {
 
     if (igpBalance.gt(igpClaimThreshold)) {
       logger.info({ chain }, 'IGP balance exceeds claim threshold, claiming');
-      await this.multiProvider.sendTransaction(
+      await this.multiProvider.sendTransaction(chain, {
+        ...(await igp.populateTransaction.claim()),
         chain,
-        await igp.populateTransaction.claim(),
-      );
+      });
     } else {
       logger.info(
         { chain },
@@ -720,6 +720,7 @@ class ContextFunder {
     }
 
     const tx = await this.multiProvider.sendTransaction(chain, {
+      chain,
       to: key.address,
       value: fundingAmount,
     });

--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -232,13 +232,15 @@ async function main(): Promise<boolean> {
     messageReceiptSeconds.labels({ origin, remote }).inc(0);
   }
 
-  chains.map(async (chain) => {
-    return updateWalletBalanceMetricFor(
-      app,
-      chain,
-      coreConfig.owners[chain].owner,
-    );
-  });
+  await Promise.allSettled(
+    chains.map(async (chain) => {
+      return updateWalletBalanceMetricFor(
+        app,
+        chain,
+        coreConfig.owners[chain].owner,
+      );
+    }),
+  );
 
   // Incremented each time an entire cycle has occurred
   let currentCycle = 0;
@@ -431,10 +433,10 @@ async function sendMessage(
     let txReceipt: TypedTransactionReceipt;
     if (tx.type == ProviderType.EthersV5) {
       // Utilize the legacy evm-specific multiprovider utils to send the transaction
-      const receipt = await multiProvider.sendTransaction(
-        origin,
-        tx.transaction,
-      );
+      const receipt = await multiProvider.sendTransaction(origin, {
+        chain: origin,
+        ...tx.transaction,
+      });
       txReceipt = {
         type: ProviderType.EthersV5,
         receipt,

--- a/typescript/infra/src/govern/multisend.ts
+++ b/typescript/infra/src/govern/multisend.ts
@@ -34,6 +34,7 @@ export class SignerMultiSend extends MultiSend {
     for (const call of calls) {
       const estimate = await this.multiProvider.estimateGas(this.chain, call);
       const receipt = await this.multiProvider.sendTransaction(this.chain, {
+        chain: this.chain,
         gasLimit: addBufferToGasLimit(estimate),
         ...call,
       });

--- a/typescript/infra/test/govern.hardhat-test.ts
+++ b/typescript/infra/test/govern.hardhat-test.ts
@@ -81,6 +81,7 @@ export class HyperlaneTestGovernor extends HyperlaneAppGovernor<
   ): Promise<void> {
     for (const call of calls) {
       await this.checker.multiProvider.sendTransaction(chain, {
+        chain,
         to: call.to,
         data: call.data,
         value: call.value,

--- a/typescript/sdk/src/core/AbstractHyperlaneModule.ts
+++ b/typescript/sdk/src/core/AbstractHyperlaneModule.ts
@@ -1,17 +1,8 @@
 import { Logger } from 'pino';
 
-import { Ownable__factory } from '@hyperlane-xyz/core';
-import {
-  Address,
-  Annotated,
-  ProtocolType,
-  eqAddress,
-} from '@hyperlane-xyz/utils';
+import { Annotated, ProtocolType } from '@hyperlane-xyz/utils';
 
-import {
-  AnnotatedEV5Transaction,
-  ProtocolTypedTransaction,
-} from '../providers/ProviderType.js';
+import { ProtocolTypedTransaction } from '../providers/ProviderType.js';
 import { ChainNameOrId } from '../types.js';
 
 export type HyperlaneModuleParams<
@@ -41,41 +32,7 @@ export abstract class HyperlaneModule<
   public abstract read(): Promise<TConfig>;
   public abstract update(
     config: TConfig,
-  ): Promise<Annotated<ProtocolTypedTransaction<TProtocol>['transaction'][]>>;
-
-  /**
-   * Transfers ownership of a contract to a new owner.
-   *
-   * @param actualOwner - The current owner of the contract.
-   * @param expectedOwner - The expected new owner of the contract.
-   * @param deployedAddress - The address of the deployed contract.
-   * @param chainId - The chain ID of the network the contract is deployed on.
-   * @returns An array of annotated EV5 transactions that need to be executed to update the owner.
-   */
-  static createTransferOwnershipTx(params: {
-    actualOwner: Address;
-    expectedOwner: Address;
-    deployedAddress: Address;
-    chainId: number;
-  }): AnnotatedEV5Transaction[] {
-    const { actualOwner, expectedOwner, deployedAddress, chainId } = params;
-    const updateTransactions: AnnotatedEV5Transaction[] = [];
-    if (eqAddress(actualOwner, expectedOwner)) {
-      return [];
-    }
-
-    updateTransactions.push({
-      annotation: `Transferring ownership of ${deployedAddress} from current owner ${actualOwner} to new owner ${expectedOwner}`,
-      chainId,
-      to: deployedAddress,
-      data: Ownable__factory.createInterface().encodeFunctionData(
-        'transferOwnership(address)',
-        [expectedOwner],
-      ),
-    });
-
-    return updateTransactions;
-  }
+  ): Promise<Annotated<ProtocolTypedTransaction<TProtocol>['transaction']>[]>;
 
   // /*
   //   Types and static methods can be challenging. Ensure each implementation includes a static create function.

--- a/typescript/sdk/src/core/EvmCoreModule.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.ts
@@ -17,6 +17,7 @@ import {
 } from '../contracts/types.js';
 import { DeployedCoreAddresses } from '../core/schemas.js';
 import { CoreConfig } from '../core/types.js';
+import { EvmModuleDeployer } from '../deploy/EvmModuleDeployer.js';
 import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDeployer.js';
 import {
   ProxyFactoryFactories,
@@ -137,6 +138,7 @@ export class EvmCoreModule extends HyperlaneModule<
         data: contractToUpdate.interface.encodeFunctionData('setDefaultIsm', [
           deployedIsm,
         ]),
+        chain: this.chainName,
       });
     }
 
@@ -201,11 +203,12 @@ export class EvmCoreModule extends HyperlaneModule<
     actualConfig: CoreConfig,
     expectedConfig: CoreConfig,
   ): AnnotatedEV5Transaction[] {
-    return EvmCoreModule.createTransferOwnershipTx({
+    return EvmModuleDeployer.createTransferOwnershipTx({
       actualOwner: actualConfig.owner,
       expectedOwner: expectedConfig.owner,
       deployedAddress: this.args.addresses.mailbox,
       chainId: this.domainId,
+      chain: this.chainName,
     });
   }
 

--- a/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
@@ -143,8 +143,12 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       mailbox,
       defaultHook.address,
       (_mailbox) => _mailbox.defaultHook(),
-      (_mailbox, _hook) =>
-        _mailbox.populateTransaction.setDefaultHook(_hook, { ...txOverrides }),
+      async (_mailbox, _hook) => {
+        const tx = await _mailbox.populateTransaction.setDefaultHook(_hook, {
+          ...txOverrides,
+        });
+        return { ...tx, chain };
+      },
     );
 
     await this.configureHook(
@@ -152,8 +156,12 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       mailbox,
       requiredHook.address,
       (_mailbox) => _mailbox.requiredHook(),
-      (_mailbox, _hook) =>
-        _mailbox.populateTransaction.setRequiredHook(_hook, { ...txOverrides }),
+      async (_mailbox, _hook) => {
+        const tx = await _mailbox.populateTransaction.setRequiredHook(_hook, {
+          ...txOverrides,
+        });
+        return { ...tx, chain };
+      },
     );
 
     await this.configureIsm(
@@ -161,8 +169,10 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       mailbox,
       defaultIsm,
       (_mailbox) => _mailbox.defaultIsm(),
-      (_mailbox, _module) =>
-        _mailbox.populateTransaction.setDefaultIsm(_module),
+      async (_mailbox, _module) => {
+        const tx = await _mailbox.populateTransaction.setDefaultIsm(_module);
+        return { ...tx, chain };
+      },
     );
 
     return mailbox;

--- a/typescript/sdk/src/core/TestRecipientDeployer.ts
+++ b/typescript/sdk/src/core/TestRecipientDeployer.ts
@@ -53,7 +53,12 @@ export class TestRecipientDeployer extends HyperlaneDeployer<
         testRecipient,
         config.interchainSecurityModule,
         (tr) => tr.interchainSecurityModule(),
-        (tr, ism) => tr.populateTransaction.setInterchainSecurityModule(ism),
+        async (tr, ism) => {
+          const tx = await tr.populateTransaction.setInterchainSecurityModule(
+            ism,
+          );
+          return { ...tx, chain };
+        },
       );
     } else {
       this.logger.warn(`No ISM config provided for TestRecipient on ${chain}`);

--- a/typescript/sdk/src/deploy/EvmModuleDeployer.ts
+++ b/typescript/sdk/src/deploy/EvmModuleDeployer.ts
@@ -2,15 +2,22 @@ import { ethers } from 'ethers';
 import { Logger } from 'pino';
 
 import {
+  Ownable__factory,
   StaticAddressSetFactory,
   StaticThresholdAddressSetFactory,
   TransparentUpgradeableProxy__factory,
 } from '@hyperlane-xyz/core';
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
-import { Address, addBufferToGasLimit, rootLogger } from '@hyperlane-xyz/utils';
+import {
+  Address,
+  addBufferToGasLimit,
+  eqAddress,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
 
 import { HyperlaneContracts, HyperlaneFactories } from '../contracts/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
+import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
 import { ChainMap, ChainName } from '../types.js';
 
 import { isProxy, proxyConstructorArgs } from './proxy.js';
@@ -314,5 +321,43 @@ export class EvmModuleDeployer<Factories extends HyperlaneFactories> {
     // );
 
     return address;
+  }
+
+  /**
+   * Transfers ownership of a contract to a new owner.
+   *
+   * @param actualOwner - The current owner of the contract.
+   * @param expectedOwner - The expected new owner of the contract.
+   * @param deployedAddress - The address of the deployed contract.
+   * @param chainId - The chain ID of the network the contract is deployed on.
+   * @param chain - The name of the network the contract is deployed on.
+   * @returns An array of annotated EV5 transactions that need to be executed to update the owner.
+   */
+  static createTransferOwnershipTx(params: {
+    actualOwner: Address;
+    expectedOwner: Address;
+    deployedAddress: Address;
+    chainId: number;
+    chain: ChainName;
+  }): AnnotatedEV5Transaction[] {
+    const { actualOwner, expectedOwner, deployedAddress, chainId, chain } =
+      params;
+    const updateTransactions: AnnotatedEV5Transaction[] = [];
+    if (eqAddress(actualOwner, expectedOwner)) {
+      return [];
+    }
+
+    updateTransactions.push({
+      chain,
+      annotation: `Transferring ownership of ${deployedAddress} from current owner ${actualOwner} to new owner ${expectedOwner}`,
+      chainId,
+      to: deployedAddress,
+      data: Ownable__factory.createInterface().encodeFunctionData(
+        'transferOwnership(address)',
+        [expectedOwner],
+      ),
+    });
+
+    return updateTransactions;
   }
 }

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -210,6 +210,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Return an ownership transfer transaction if required
     if (!eqAddress(targetConfig.owner, owner)) {
       updateTxs.push({
+        chain: this.chain,
         annotation: 'Transferring ownership of ownable Hook...',
         chainId: this.domainId,
         to: this.args.addresses.deployedHook,
@@ -312,6 +313,7 @@ export class EvmHookModule extends HyperlaneModule<
         : pausableInterface.encodeFunctionData('unpause');
 
       updateTxs.push({
+        chain: this.chain,
         annotation: `Updating paused state to ${targetConfig.paused}`,
         chainId: this.domainId,
         to: this.args.addresses.deployedHook,
@@ -335,6 +337,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Update beneficiary if changed
     if (!eqAddress(currentConfig.beneficiary, targetConfig.beneficiary)) {
       updateTxs.push({
+        chain: this.chain,
         annotation: `Updating beneficiary from ${currentConfig.beneficiary} to ${targetConfig.beneficiary}`,
         chainId: this.domainId,
         to: this.args.addresses.deployedHook,
@@ -434,6 +437,7 @@ export class EvmHookModule extends HyperlaneModule<
 
     return [
       {
+        chain: this.chain,
         annotation: `Updating overhead for domains ${Object.keys(
           targetOverheads,
         ).join(', ')}...`,
@@ -500,6 +504,7 @@ export class EvmHookModule extends HyperlaneModule<
 
     return [
       {
+        chain: this.chain,
         annotation: `Updating gas oracle config for domains ${Object.keys(
           targetOracleConfig,
         ).join(', ')}...`,
@@ -533,6 +538,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Update protocol fee if changed
     if (currentConfig.protocolFee !== targetConfig.protocolFee) {
       updateTxs.push({
+        chain: this.chain,
         annotation: `Updating protocol fee from ${currentConfig.protocolFee} to ${targetConfig.protocolFee}`,
         chainId: this.domainId,
         to: this.args.addresses.deployedHook,
@@ -546,6 +552,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Update beneficiary if changed
     if (currentConfig.beneficiary !== targetConfig.beneficiary) {
       updateTxs.push({
+        chain: this.chain,
         annotation: `Updating beneficiary from ${currentConfig.beneficiary} to ${targetConfig.beneficiary}`,
         chainId: this.domainId,
         to: this.args.addresses.deployedHook,
@@ -594,6 +601,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Create tx for setting hooks
     return [
       {
+        chain: this.chain,
         annotation: 'Updating routing hooks...',
         chainId: this.domainId,
         to: this.args.addresses.deployedHook,

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -312,15 +312,7 @@ export {
   excludeProviderMethods,
 } from './providers/SmartProvider/ProviderMethods.js';
 export { HyperlaneSmartProvider } from './providers/SmartProvider/SmartProvider.js';
-export {
-  PopulatedTransactionSchema,
-  PopulatedTransactionsSchema,
-} from './providers/transactions/schemas.js';
-export {
-  CallData,
-  PopulatedTransaction,
-  PopulatedTransactions,
-} from './providers/transactions/types.js';
+export { CallData } from './providers/transactions/types.js';
 
 export { SubmitterMetadataSchema } from './providers/transactions/submitter/schemas.js';
 export { TxSubmitterInterface } from './providers/transactions/submitter/TxSubmitterInterface.js';

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -220,6 +220,7 @@ export class EvmIsmModule extends HyperlaneModule<
     // Return an ownership transfer transaction if required
     if (!eqAddress(targetConfig.owner, owner)) {
       updateTxs.push({
+        chain: this.chain,
         annotation: 'Transferring ownership of ownable ISM...',
         chainId: this.domainId,
         to: this.args.addresses.deployedIsm,
@@ -279,7 +280,7 @@ export class EvmIsmModule extends HyperlaneModule<
     logger: Logger;
   }): Promise<AnnotatedEV5Transaction[]> {
     const routingIsmInterface = DomainRoutingIsm__factory.createInterface();
-    const updateTxs = [];
+    const updateTxs: AnnotatedEV5Transaction[] = [];
 
     // filter out domains which are not part of the multiprovider
     current = {
@@ -311,6 +312,7 @@ export class EvmIsmModule extends HyperlaneModule<
 
       const domainId = this.multiProvider.getDomainId(origin);
       updateTxs.push({
+        chain: this.chain,
         annotation: `Setting new ISM for origin ${origin}...`,
         chainId: this.domainId,
         to: this.args.addresses.deployedIsm,
@@ -325,6 +327,7 @@ export class EvmIsmModule extends HyperlaneModule<
     for (const origin of domainsToUnenroll) {
       const domainId = this.multiProvider.getDomainId(origin);
       updateTxs.push({
+        chain: this.chain,
         annotation: `Unenrolling originDomain ${domainId} from preexisting routing ISM at ${this.args.addresses.deployedIsm}...`,
         chainId: this.domainId,
         to: this.args.addresses.deployedIsm,

--- a/typescript/sdk/src/middleware/account/InterchainAccount.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.ts
@@ -1,4 +1,4 @@
-import { BigNumber, PopulatedTransaction } from 'ethers';
+import { BigNumber } from 'ethers';
 
 import { InterchainAccountRouter } from '@hyperlane-xyz/core';
 import {
@@ -14,6 +14,7 @@ import {
   HyperlaneContractsMap,
 } from '../../contracts/types.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
+import { AnnotatedEV5Transaction } from '../../providers/ProviderType.js';
 import { RouterApp } from '../../router/RouterApps.js';
 import { ChainName } from '../../types.js';
 
@@ -147,7 +148,7 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
     innerCalls,
     config,
     hookMetadata,
-  }: GetCallRemoteSettings): Promise<PopulatedTransaction> {
+  }: GetCallRemoteSettings): Promise<AnnotatedEV5Transaction> {
     const localRouter = this.router(this.contractsMap[chain]);
     const remoteDomain = this.multiProvider.getDomainId(destination);
     const quote = await localRouter['quoteGasPayment(uint32)'](remoteDomain);
@@ -172,7 +173,7 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
       hookMetadata ?? '0x',
       { value: quote },
     );
-    return callEncoded;
+    return { ...callEncoded, chain };
   }
 
   async getAccountConfig(

--- a/typescript/sdk/src/providers/MultiProvider.ts
+++ b/typescript/sdk/src/providers/MultiProvider.ts
@@ -404,18 +404,18 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
    * @throws if chain's metadata or signer has not been set or tx fails
    */
   async sendTransaction(
-    chainNameOrId: ChainNameOrId,
+    _: ChainNameOrId,
     txProm: AnnotatedEV5Transaction | Promise<AnnotatedEV5Transaction>,
   ): Promise<ContractReceipt> {
-    const { annotation, ...tx } = await txProm;
+    const { chain, annotation, ...tx } = await txProm;
     if (annotation) {
       this.logger.info(annotation);
     }
-    const txReq = await this.prepareTx(chainNameOrId, tx);
-    const signer = this.getSigner(chainNameOrId);
+    const txReq = await this.prepareTx(chain, tx);
+    const signer = this.getSigner(chain);
     const response = await signer.sendTransaction(txReq);
     this.logger.info(`Sent tx ${response.hash}`);
-    return this.handleTx(chainNameOrId, response);
+    return this.handleTx(chain, response);
   }
 
   /**

--- a/typescript/sdk/src/providers/ProviderType.ts
+++ b/typescript/sdk/src/providers/ProviderType.ts
@@ -25,6 +25,8 @@ import type {
 
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
+import { ChainName } from '../types.js';
+
 export enum ProviderType {
   EthersV5 = 'ethers-v5',
   Viem = 'viem',
@@ -201,6 +203,7 @@ export interface EthersV5Transaction
 }
 
 export interface AnnotatedEV5Transaction extends EV5Transaction {
+  chain: ChainName;
   annotation?: string;
 }
 

--- a/typescript/sdk/src/providers/transactions/schemas.test.ts
+++ b/typescript/sdk/src/providers/transactions/schemas.test.ts
@@ -2,42 +2,15 @@ import { expect } from 'chai';
 
 import { Address } from '@hyperlane-xyz/utils';
 
-import { CallDataSchema, PopulatedTransactionSchema } from './schemas.js';
-import { CallData, PopulatedTransaction } from './types.js';
+import { CallDataSchema } from './schemas.js';
+import { CallData } from './types.js';
 
 describe('transactions schemas', () => {
   const ADDRESS_MOCK: Address = '0x1234567890123456789012345678901234567890';
   const DATA_MOCK: string = '0xabcdef';
-  const CHAIN_ID_MOCK: number = 1;
   const VALUE_MOCK: string = '100';
 
   const INVALID_ADDRESS: Address = '0x1';
-
-  describe('PopulatedTransactionSchema', () => {
-    it('should parse valid PopulatedTransaction', () => {
-      const validPopulatedTransaction: PopulatedTransaction = {
-        to: ADDRESS_MOCK,
-        data: DATA_MOCK,
-        chainId: CHAIN_ID_MOCK,
-      };
-      const result = PopulatedTransactionSchema.safeParse(
-        validPopulatedTransaction,
-      );
-      expect(result.success).to.be.true;
-    });
-
-    it('should fail parsing invalid PopulatedTransaction', () => {
-      const invalidPopulatedTransaction: PopulatedTransaction = {
-        to: INVALID_ADDRESS,
-        data: DATA_MOCK,
-        chainId: CHAIN_ID_MOCK,
-      };
-      const result = PopulatedTransactionSchema.safeParse(
-        invalidPopulatedTransaction,
-      );
-      expect(result.success).to.be.false;
-    });
-  });
 
   describe('CallDataSchema', () => {
     it('should parse valid CallData', () => {

--- a/typescript/sdk/src/providers/transactions/schemas.ts
+++ b/typescript/sdk/src/providers/transactions/schemas.ts
@@ -4,17 +4,6 @@ import { ZHash } from '../../metadata/customZodTypes.js';
 
 export const BigNumberSchema = z.string();
 
-export const PopulatedTransactionSchema = z.object({
-  to: ZHash,
-  data: z.string(),
-  chainId: z.number(),
-});
-
-export const PopulatedTransactionsSchema =
-  PopulatedTransactionSchema.array().refine((txs) => txs.length > 0, {
-    message: 'Populated Transactions cannot be empty',
-  });
-
 export const CallDataSchema = z.object({
   to: ZHash,
   data: z.string(),

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxBuilder.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxBuilder.ts
@@ -6,8 +6,10 @@ import { assert } from '@hyperlane-xyz/utils';
 // @ts-ignore
 import { getSafe, getSafeService } from '../../../../utils/gnosisSafe.js';
 import { MultiProvider } from '../../../MultiProvider.js';
-import { GnosisTransactionBuilderPayload } from '../../../ProviderType.js';
-import { PopulatedTransaction, PopulatedTransactions } from '../../types.js';
+import {
+  AnnotatedEV5Transaction,
+  GnosisTransactionBuilderPayload,
+} from '../../../ProviderType.js';
 import { TxSubmitterType } from '../TxSubmitterTypes.js';
 
 import { EV5GnosisSafeTxSubmitter } from './EV5GnosisSafeTxSubmitter.js';
@@ -47,16 +49,16 @@ export class EV5GnosisSafeTxBuilder extends EV5GnosisSafeTxSubmitter {
   }
 
   /**
-   * Creates a Gnosis Safe transaction builder object using the PopulatedTransactions
+   * Creates a Gnosis Safe transaction builder object using the AnnotatedEV5Transaction[]
    *
-   * @param txs - An array of populated transactions
+   * @param txs - An array of annotated, populated transactions
    */
   public async submit(
-    ...txs: PopulatedTransactions
+    ...txs: AnnotatedEV5Transaction[]
   ): Promise<GnosisTransactionBuilderPayload> {
     const transactions: SafeTransactionData[] = await Promise.all(
       txs.map(
-        async (tx: PopulatedTransaction) =>
+        async (tx: AnnotatedEV5Transaction) =>
           (
             await this.createSafeTransaction(tx)
           ).data,

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.ts
@@ -7,7 +7,7 @@ import { Address, assert, rootLogger } from '@hyperlane-xyz/utils';
 // @ts-ignore
 import { canProposeSafeTransactions, getSafe, getSafeService } from '../../../../utils/gnosisSafe.js';
 import { MultiProvider } from '../../../MultiProvider.js';
-import { PopulatedTransaction, PopulatedTransactions } from '../../types.js';
+import { AnnotatedEV5Transaction } from '../../../ProviderType.js';
 import { TxSubmitterType } from '../TxSubmitterTypes.js';
 
 import { EV5TxSubmitterInterface } from './EV5TxSubmitterInterface.js';
@@ -67,12 +67,12 @@ export class EV5GnosisSafeTxSubmitter implements EV5TxSubmitterInterface {
     to,
     data,
     value,
-    chainId,
-  }: PopulatedTransaction): Promise<SafeTransaction> {
+    chain,
+  }: AnnotatedEV5Transaction): Promise<SafeTransaction> {
     const nextNonce: number = await this.safeService.getNextNonce(
       this.props.safeAddress,
     );
-    const txChain = this.multiProvider.getChainName(chainId);
+    const txChain = this.multiProvider.getChainName(chain);
     assert(
       txChain === this.props.chain,
       `Invalid PopulatedTransaction: Cannot submit ${txChain} tx to ${this.props.chain} submitter.`,
@@ -83,11 +83,11 @@ export class EV5GnosisSafeTxSubmitter implements EV5TxSubmitterInterface {
     });
   }
 
-  public async submit(...txs: PopulatedTransactions): Promise<any> {
+  public async submit(...txs: AnnotatedEV5Transaction[]): Promise<any> {
     return this.proposeIndividualTransactions(txs);
   }
 
-  private async proposeIndividualTransactions(txs: PopulatedTransactions) {
+  private async proposeIndividualTransactions(txs: AnnotatedEV5Transaction[]) {
     const safeTransactions: SafeTransaction[] = [];
     for (const tx of txs) {
       const safeTransaction = await this.createSafeTransaction(tx);

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5ImpersonatedAccountTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5ImpersonatedAccountTxSubmitter.ts
@@ -8,7 +8,7 @@ import {
   stopImpersonatingAccount,
 } from '../../../../utils/fork.js';
 import { MultiProvider } from '../../../MultiProvider.js';
-import { PopulatedTransactions } from '../../types.js';
+import { AnnotatedEV5Transaction } from '../../../ProviderType.js';
 import { TxSubmitterType } from '../TxSubmitterTypes.js';
 
 import { EV5JsonRpcTxSubmitter } from './EV5JsonRpcTxSubmitter.js';
@@ -30,7 +30,7 @@ export class EV5ImpersonatedAccountTxSubmitter extends EV5JsonRpcTxSubmitter {
   }
 
   public async submit(
-    ...txs: PopulatedTransactions
+    ...txs: AnnotatedEV5Transaction[]
   ): Promise<TransactionReceipt[]> {
     const impersonatedAccount = await impersonateAccount(
       this.props.userAddress,

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
@@ -2,10 +2,10 @@ import { TransactionReceipt } from '@ethersproject/providers';
 import { ContractReceipt } from 'ethers';
 import { Logger } from 'pino';
 
-import { assert, rootLogger } from '@hyperlane-xyz/utils';
+import { rootLogger } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../../../MultiProvider.js';
-import { PopulatedTransactions } from '../../types.js';
+import { AnnotatedEV5Transaction } from '../../../ProviderType.js';
 import { TxSubmitterType } from '../TxSubmitterTypes.js';
 
 import { EV5TxSubmitterInterface } from './EV5TxSubmitterInterface.js';
@@ -20,18 +20,17 @@ export class EV5JsonRpcTxSubmitter implements EV5TxSubmitterInterface {
   constructor(public readonly multiProvider: MultiProvider) {}
 
   public async submit(
-    ...txs: PopulatedTransactions
+    ...txs: AnnotatedEV5Transaction[]
   ): Promise<TransactionReceipt[]> {
     const receipts: TransactionReceipt[] = [];
     for (const tx of txs) {
-      assert(tx.chainId, 'Invalid PopulatedTransaction: Missing chainId field');
-      const txChain = this.multiProvider.getChainName(tx.chainId);
+      const txChain = this.multiProvider.getChainName(tx.chain);
       const receipt: ContractReceipt = await this.multiProvider.sendTransaction(
         txChain,
         tx,
       );
       this.logger.debug(
-        `Submitted PopulatedTransaction on ${txChain}: ${receipt.transactionHash}`,
+        `Submitted populated transaction on ${txChain}: ${receipt.transactionHash}`,
       );
       receipts.push(receipt);
     }

--- a/typescript/sdk/src/providers/transactions/transformer/ethersV5/EV5InterchainAccountTxTransformer.ts
+++ b/typescript/sdk/src/providers/transactions/transformer/ethersV5/EV5InterchainAccountTxTransformer.ts
@@ -9,11 +9,8 @@ import {
 } from '../../../../middleware/account/InterchainAccount.js';
 import { ChainName } from '../../../../types.js';
 import { MultiProvider } from '../../../MultiProvider.js';
-import {
-  CallData,
-  PopulatedTransaction,
-  PopulatedTransactions,
-} from '../../types.js';
+import { AnnotatedEV5Transaction } from '../../../ProviderType.js';
+import { CallData } from '../../types.js';
 import { TxTransformerType } from '../TxTransformerTypes.js';
 
 import { EV5TxTransformerInterface } from './EV5TxTransformerInterface.js';
@@ -39,16 +36,17 @@ export class EV5InterchainAccountTxTransformer
   }
 
   public async transform(
-    ...txs: PopulatedTransactions
+    ...txs: AnnotatedEV5Transaction[]
   ): Promise<ethers.PopulatedTransaction[]> {
     const txChainsToInnerCalls: Record<ChainName, CallData[]> = txs.reduce(
       (
         txChainToInnerCalls: Record<ChainName, CallData[]>,
-        { to, data, chainId }: PopulatedTransaction,
+        { to, data, chain }: AnnotatedEV5Transaction,
       ) => {
-        const txChain = this.multiProvider.getChainName(chainId);
-        txChainToInnerCalls[txChain] ||= [];
-        txChainToInnerCalls[txChain].push({ to, data });
+        assert(to, 'Invalid transaction: Missing "to" address');
+        assert(data, 'Invalid transaction: Missing "data"');
+        txChainToInnerCalls[chain] ||= [];
+        txChainToInnerCalls[chain].push({ to, data });
         return txChainToInnerCalls;
       },
       {},

--- a/typescript/sdk/src/providers/transactions/types.ts
+++ b/typescript/sdk/src/providers/transactions/types.ts
@@ -1,17 +1,5 @@
-import { ethers } from 'ethers';
 import { z } from 'zod';
 
-import {
-  CallDataSchema,
-  PopulatedTransactionSchema,
-  PopulatedTransactionsSchema,
-} from './schemas.js';
-
-export type PopulatedTransaction = z.infer<typeof PopulatedTransactionSchema> &
-  ethers.PopulatedTransaction;
-export type PopulatedTransactions = z.infer<
-  typeof PopulatedTransactionsSchema
-> &
-  ethers.PopulatedTransaction[];
+import { CallDataSchema } from './schemas.js';
 
 export type CallData = z.infer<typeof CallDataSchema>;

--- a/typescript/utils/src/types.ts
+++ b/typescript/utils/src/types.ts
@@ -114,5 +114,6 @@ export type ParsedLegacyMultisigIsmMetadata = {
 };
 
 export type Annotated<T> = T & {
+  chain: string; // TODO: Change to ChainName after moving to SDK from Utils
   annotation?: string;
 };


### PR DESCRIPTION
### Description

Updating the types in the submitters because they were using their own types instead of the existing ones for some reason. Also adding `chain` as an argument to the `Annotated` type, so that we can take advantage of this in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4599 and defend ourselves against futures where chainid/domainid are not the same for EVM

This also fixes the issue currently where there's a small type mismatch between submitters and modules

### Drive-by changes

- move `createTransferOwnershipTx` from the abstract hyperlane module to the evm module deployer, as it's EVM specific 

### Related issues

useful for https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4599, but also something that needs to be fixed itself

### Backward compatibility

Yes

### Testing

ci