### PR TITLE
feat: support duplicate chainIds with unique domainIds

### DIFF
--- a/.changeset/thin-bananas-explain.md
+++ b/.changeset/thin-bananas-explain.md
@@ -1,0 +1,7 @@
+---
+'@hyperlane-xyz/utils': major
+'@hyperlane-xyz/cli': major
+'@hyperlane-xyz/sdk': major
+---
+
+Support duplicate chainIds with unique domainIds

--- a/typescript/cli/src/deploy/core.ts
+++ b/typescript/cli/src/deploy/core.ts
@@ -126,7 +126,7 @@ export async function runCoreApply(params: ApplyParams) {
   if (transactions.length) {
     logGray('Updating deployed core contracts');
     for (const transaction of transactions) {
-      await multiProvider.sendTransaction(chain, transaction);
+      await multiProvider.sendTransaction(transaction);
     }
 
     logGreen(`Core config updated on ${chain}.`);

--- a/typescript/infra/scripts/funding/fund-deterministic-key-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-deterministic-key-from-deployer.ts
@@ -79,7 +79,7 @@ async function main() {
         logger.info(
           `Funding ${address} on chain '${chain}' with ${value} native tokens`,
         );
-        await multiProvider.sendTransaction(chain, {
+        await multiProvider.sendTransaction({
           chain,
           to: address,
           value,

--- a/typescript/infra/scripts/funding/fund-deterministic-key-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-deterministic-key-from-deployer.ts
@@ -80,6 +80,7 @@ async function main() {
           `Funding ${address} on chain '${chain}' with ${value} native tokens`,
         );
         await multiProvider.sendTransaction(chain, {
+          chain,
           to: address,
           value,
         });

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -784,8 +784,8 @@ class ContextFunder {
   ) {
     const l1Chain = L2ToL1[l2Chain];
     const crossChainMessenger = new CrossChainMessenger({
-      l1ChainId: this.multiProvider.getDomainId(l1Chain),
-      l2ChainId: this.multiProvider.getDomainId(l2Chain),
+      l1ChainId: this.multiProvider.getEvmChainId(l1Chain),
+      l2ChainId: this.multiProvider.getEvmChainId(l2Chain),
       l1SignerOrProvider: this.multiProvider.getSignerOrProvider(l1Chain),
       l2SignerOrProvider: this.multiProvider.getSignerOrProvider(l2Chain),
     });

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -623,9 +623,9 @@ class ContextFunder {
 
     if (igpBalance.gt(igpClaimThreshold)) {
       logger.info({ chain }, 'IGP balance exceeds claim threshold, claiming');
-      await this.multiProvider.sendTransaction(chain, {
-        ...(await igp.populateTransaction.claim()),
+      await this.multiProvider.sendTransaction({
         chain,
+        ...(await igp.populateTransaction.claim()),
       });
     } else {
       logger.info(
@@ -719,7 +719,7 @@ class ContextFunder {
       );
     }
 
-    const tx = await this.multiProvider.sendTransaction(chain, {
+    const tx = await this.multiProvider.sendTransaction({
       chain,
       to: key.address,
       value: fundingAmount,

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -623,10 +623,10 @@ class ContextFunder {
 
     if (igpBalance.gt(igpClaimThreshold)) {
       logger.info({ chain }, 'IGP balance exceeds claim threshold, claiming');
-      await this.multiProvider.sendTransaction(
+      await this.multiProvider.sendTransaction(chain, {
+        ...(await igp.populateTransaction.claim()),
         chain,
-        await igp.populateTransaction.claim(),
-      );
+      });
     } else {
       logger.info(
         { chain },
@@ -720,6 +720,7 @@ class ContextFunder {
     }
 
     const tx = await this.multiProvider.sendTransaction(chain, {
+      chain,
       to: key.address,
       value: fundingAmount,
     });

--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -232,13 +232,15 @@ async function main(): Promise<boolean> {
     messageReceiptSeconds.labels({ origin, remote }).inc(0);
   }
 
-  chains.map(async (chain) => {
-    return updateWalletBalanceMetricFor(
-      app,
-      chain,
-      coreConfig.owners[chain].owner,
-    );
-  });
+  await Promise.allSettled(
+    chains.map(async (chain) => {
+      return updateWalletBalanceMetricFor(
+        app,
+        chain,
+        coreConfig.owners[chain].owner,
+      );
+    }),
+  );
 
   // Incremented each time an entire cycle has occurred
   let currentCycle = 0;
@@ -431,10 +433,10 @@ async function sendMessage(
     let txReceipt: TypedTransactionReceipt;
     if (tx.type == ProviderType.EthersV5) {
       // Utilize the legacy evm-specific multiprovider utils to send the transaction
-      const receipt = await multiProvider.sendTransaction(
-        origin,
-        tx.transaction,
-      );
+      const receipt = await multiProvider.sendTransaction(origin, {
+        chain: origin,
+        ...tx.transaction,
+      });
       txReceipt = {
         type: ProviderType.EthersV5,
         receipt,

--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -433,7 +433,7 @@ async function sendMessage(
     let txReceipt: TypedTransactionReceipt;
     if (tx.type == ProviderType.EthersV5) {
       // Utilize the legacy evm-specific multiprovider utils to send the transaction
-      const receipt = await multiProvider.sendTransaction(origin, {
+      const receipt = await multiProvider.sendTransaction({
         chain: origin,
         ...tx.transaction,
       });

--- a/typescript/infra/src/govern/multisend.ts
+++ b/typescript/infra/src/govern/multisend.ts
@@ -33,7 +33,7 @@ export class SignerMultiSend extends MultiSend {
   async sendTransactions(calls: CallData[]) {
     for (const call of calls) {
       const estimate = await this.multiProvider.estimateGas(this.chain, call);
-      const receipt = await this.multiProvider.sendTransaction(this.chain, {
+      const receipt = await this.multiProvider.sendTransaction({
         chain: this.chain,
         gasLimit: addBufferToGasLimit(estimate),
         ...call,

--- a/typescript/infra/src/govern/multisend.ts
+++ b/typescript/infra/src/govern/multisend.ts
@@ -34,6 +34,7 @@ export class SignerMultiSend extends MultiSend {
     for (const call of calls) {
       const estimate = await this.multiProvider.estimateGas(this.chain, call);
       const receipt = await this.multiProvider.sendTransaction(this.chain, {
+        chain: this.chain,
         gasLimit: addBufferToGasLimit(estimate),
         ...call,
       });

--- a/typescript/infra/src/utils/safe.ts
+++ b/typescript/infra/src/utils/safe.ts
@@ -9,7 +9,7 @@ import chalk from 'chalk';
 import { ethers } from 'ethers';
 
 import {
-  ChainNameOrId,
+  ChainNameOrDomain,
   MultiProvider,
   getSafe,
   getSafeService,
@@ -17,7 +17,7 @@ import {
 import { Address, CallData } from '@hyperlane-xyz/utils';
 
 export async function getSafeAndService(
-  chain: ChainNameOrId,
+  chain: ChainNameOrDomain,
   multiProvider: MultiProvider,
   safeAddress: Address,
 ) {
@@ -54,7 +54,7 @@ export async function createSafeTransaction(
 }
 
 export async function proposeSafeTransaction(
-  chain: ChainNameOrId,
+  chain: ChainNameOrDomain,
   safeSdk: Safe.default,
   safeService: SafeApiKit.default,
   safeTransaction: SafeTransaction,
@@ -79,7 +79,7 @@ export async function proposeSafeTransaction(
 }
 
 export async function deleteAllPendingSafeTxs(
-  chain: ChainNameOrId,
+  chain: ChainNameOrDomain,
   multiProvider: MultiProvider,
   safeAddress: Address,
 ): Promise<void> {
@@ -113,7 +113,7 @@ export async function deleteAllPendingSafeTxs(
 }
 
 export async function deleteSafeTx(
-  chain: ChainNameOrId,
+  chain: ChainNameOrDomain,
   multiProvider: MultiProvider,
   safeAddress: Address,
   safeTxHash: string,

--- a/typescript/infra/src/utils/safe.ts
+++ b/typescript/infra/src/utils/safe.ts
@@ -119,7 +119,7 @@ export async function deleteSafeTx(
   safeTxHash: string,
 ): Promise<void> {
   const signer = multiProvider.getSigner(chain);
-  const domainId = multiProvider.getDomainId(chain);
+  const chainId = multiProvider.getChainId(chain);
   const txServiceUrl =
     multiProvider.getChainMetadata(chain).gnosisSafeTransactionServiceUrl;
 
@@ -176,7 +176,7 @@ export async function deleteSafeTx(
       domain: {
         name: 'Safe Transaction Service',
         version: '1.0',
-        chainId: domainId,
+        chainId,
         verifyingContract: safeAddress,
       },
       primaryType: 'DeleteRequest',

--- a/typescript/infra/test/govern.hardhat-test.ts
+++ b/typescript/infra/test/govern.hardhat-test.ts
@@ -81,6 +81,7 @@ export class HyperlaneTestGovernor extends HyperlaneAppGovernor<
   ): Promise<void> {
     for (const call of calls) {
       await this.checker.multiProvider.sendTransaction(chain, {
+        chain,
         to: call.to,
         data: call.data,
         value: call.value,

--- a/typescript/infra/test/govern.hardhat-test.ts
+++ b/typescript/infra/test/govern.hardhat-test.ts
@@ -80,7 +80,7 @@ export class HyperlaneTestGovernor extends HyperlaneAppGovernor<
     calls: CallData[],
   ): Promise<void> {
     for (const call of calls) {
-      await this.checker.multiProvider.sendTransaction(chain, {
+      await this.checker.multiProvider.sendTransaction({
         chain,
         to: call.to,
         data: call.data,

--- a/typescript/sdk/src/core/AbstractHyperlaneModule.ts
+++ b/typescript/sdk/src/core/AbstractHyperlaneModule.ts
@@ -1,17 +1,8 @@
 import { Logger } from 'pino';
 
-import { Ownable__factory } from '@hyperlane-xyz/core';
-import {
-  Address,
-  Annotated,
-  ProtocolType,
-  eqAddress,
-} from '@hyperlane-xyz/utils';
+import { Annotated, ProtocolType } from '@hyperlane-xyz/utils';
 
-import {
-  AnnotatedEV5Transaction,
-  ProtocolTypedTransaction,
-} from '../providers/ProviderType.js';
+import { ProtocolTypedTransaction } from '../providers/ProviderType.js';
 import { ChainNameOrId } from '../types.js';
 
 export type HyperlaneModuleParams<
@@ -41,41 +32,7 @@ export abstract class HyperlaneModule<
   public abstract read(): Promise<TConfig>;
   public abstract update(
     config: TConfig,
-  ): Promise<Annotated<ProtocolTypedTransaction<TProtocol>['transaction'][]>>;
-
-  /**
-   * Transfers ownership of a contract to a new owner.
-   *
-   * @param actualOwner - The current owner of the contract.
-   * @param expectedOwner - The expected new owner of the contract.
-   * @param deployedAddress - The address of the deployed contract.
-   * @param chainId - The chain ID of the network the contract is deployed on.
-   * @returns An array of annotated EV5 transactions that need to be executed to update the owner.
-   */
-  static createTransferOwnershipTx(params: {
-    actualOwner: Address;
-    expectedOwner: Address;
-    deployedAddress: Address;
-    chainId: number;
-  }): AnnotatedEV5Transaction[] {
-    const { actualOwner, expectedOwner, deployedAddress, chainId } = params;
-    const updateTransactions: AnnotatedEV5Transaction[] = [];
-    if (eqAddress(actualOwner, expectedOwner)) {
-      return [];
-    }
-
-    updateTransactions.push({
-      annotation: `Transferring ownership of ${deployedAddress} from current owner ${actualOwner} to new owner ${expectedOwner}`,
-      chainId,
-      to: deployedAddress,
-      data: Ownable__factory.createInterface().encodeFunctionData(
-        'transferOwnership(address)',
-        [expectedOwner],
-      ),
-    });
-
-    return updateTransactions;
-  }
+  ): Promise<Annotated<ProtocolTypedTransaction<TProtocol>['transaction']>[]>;
 
   // /*
   //   Types and static methods can be challenging. Ensure each implementation includes a static create function.

--- a/typescript/sdk/src/core/AbstractHyperlaneModule.ts
+++ b/typescript/sdk/src/core/AbstractHyperlaneModule.ts
@@ -3,14 +3,14 @@ import { Logger } from 'pino';
 import { Annotated, ProtocolType } from '@hyperlane-xyz/utils';
 
 import { ProtocolTypedTransaction } from '../providers/ProviderType.js';
-import { ChainNameOrId } from '../types.js';
+import { ChainNameOrDomain } from '../types.js';
 
 export type HyperlaneModuleParams<
   TConfig,
   TAddressMap extends Record<string, any>,
 > = {
   addresses: TAddressMap;
-  chain: ChainNameOrId;
+  chain: ChainNameOrDomain;
   config: TConfig;
 };
 

--- a/typescript/sdk/src/core/EvmCoreModule.hardhat-test.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.hardhat-test.ts
@@ -130,7 +130,7 @@ describe('EvmCoreModule', async () => {
 
       // Check that it's actually a mailbox by calling one of it's methods
       expect(await mailboxContract.localDomain()).to.equal(
-        multiProvider.getChainId(CHAIN),
+        multiProvider.getDomainId(CHAIN),
       );
     });
 

--- a/typescript/sdk/src/core/EvmCoreModule.hardhat-test.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.hardhat-test.ts
@@ -36,7 +36,7 @@ describe('EvmCoreModule', async () => {
   let timelockControllerContract: any;
   async function sendTxs(txs: AnnotatedEV5Transaction[]) {
     for (const tx of txs) {
-      await multiProvider.sendTransaction(CHAIN, tx);
+      await multiProvider.sendTransaction(tx);
     }
   }
   before(async () => {

--- a/typescript/sdk/src/core/EvmCoreModule.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.ts
@@ -17,6 +17,7 @@ import {
 } from '../contracts/types.js';
 import { DeployedCoreAddresses } from '../core/schemas.js';
 import { CoreConfig } from '../core/types.js';
+import { EvmModuleDeployer } from '../deploy/EvmModuleDeployer.js';
 import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDeployer.js';
 import {
   ProxyFactoryFactories,
@@ -137,6 +138,7 @@ export class EvmCoreModule extends HyperlaneModule<
         data: contractToUpdate.interface.encodeFunctionData('setDefaultIsm', [
           deployedIsm,
         ]),
+        chain: this.chainName,
       });
     }
 
@@ -201,11 +203,12 @@ export class EvmCoreModule extends HyperlaneModule<
     actualConfig: CoreConfig,
     expectedConfig: CoreConfig,
   ): AnnotatedEV5Transaction[] {
-    return EvmCoreModule.createTransferOwnershipTx({
+    return EvmModuleDeployer.createTransferOwnershipTx({
       actualOwner: actualConfig.owner,
       expectedOwner: expectedConfig.owner,
       deployedAddress: this.args.addresses.mailbox,
       chainId: this.domainId,
+      chain: this.chainName,
     });
   }
 

--- a/typescript/sdk/src/core/EvmCoreModule.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.ts
@@ -2,6 +2,7 @@ import { Mailbox, Mailbox__factory } from '@hyperlane-xyz/core';
 import {
   Address,
   Domain,
+  EvmChainId,
   ProtocolType,
   eqAddress,
   rootLogger,
@@ -31,7 +32,7 @@ import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { IsmConfig } from '../ism/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
-import { ChainNameOrId } from '../types.js';
+import { ChainNameOrDomain } from '../types.js';
 
 import {
   HyperlaneModule,
@@ -53,7 +54,7 @@ export class EvmCoreModule extends HyperlaneModule<
   public readonly chainName: string;
 
   public readonly domainId: Domain;
-  public readonly chainId: Domain;
+  public readonly chainId: EvmChainId;
 
   constructor(
     protected readonly multiProvider: MultiProvider,
@@ -218,7 +219,7 @@ export class EvmCoreModule extends HyperlaneModule<
    * @returns The created EvmCoreModule instance.
    */
   public static async create(params: {
-    chain: ChainNameOrId;
+    chain: ChainNameOrDomain;
     config: CoreConfig;
     multiProvider: MultiProvider;
     contractVerifier?: ContractVerifier;
@@ -248,7 +249,7 @@ export class EvmCoreModule extends HyperlaneModule<
   static async deploy(params: {
     config: CoreConfig;
     multiProvider: MultiProvider;
-    chain: ChainNameOrId;
+    chain: ChainNameOrDomain;
     contractVerifier?: ContractVerifier;
   }): Promise<DeployedCoreAddresses> {
     const { config, multiProvider, chain, contractVerifier } = params;
@@ -381,7 +382,7 @@ export class EvmCoreModule extends HyperlaneModule<
     proxyAdmin: Address;
     coreDeployer: HyperlaneCoreDeployer;
     multiProvider: MultiProvider;
-    chain: ChainNameOrId;
+    chain: ChainNameOrDomain;
   }): Promise<Mailbox> {
     const {
       config,

--- a/typescript/sdk/src/core/EvmCoreModule.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.ts
@@ -52,9 +52,8 @@ export class EvmCoreModule extends HyperlaneModule<
   protected coreReader: EvmCoreReader;
   public readonly chainName: string;
 
-  // We use domainId here because MultiProvider.getDomainId() will always
-  // return a number, and EVM the domainId and chainId are the same.
   public readonly domainId: Domain;
+  public readonly chainId: Domain;
 
   constructor(
     protected readonly multiProvider: MultiProvider,
@@ -63,7 +62,8 @@ export class EvmCoreModule extends HyperlaneModule<
     super(args);
     this.coreReader = new EvmCoreReader(multiProvider, this.args.chain);
     this.chainName = this.multiProvider.getChainName(this.args.chain);
-    this.domainId = multiProvider.getDomainId(args.chain);
+    this.domainId = this.multiProvider.getDomainId(this.args.chain);
+    this.chainId = this.multiProvider.getEvmChainId(this.args.chain);
   }
 
   /**
@@ -133,7 +133,7 @@ export class EvmCoreModule extends HyperlaneModule<
       );
       updateTransactions.push({
         annotation: `Setting default ISM for Mailbox ${mailbox} to ${deployedIsm}`,
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: contractToUpdate.address,
         data: contractToUpdate.interface.encodeFunctionData('setDefaultIsm', [
           deployedIsm,
@@ -207,7 +207,7 @@ export class EvmCoreModule extends HyperlaneModule<
       actualOwner: actualConfig.owner,
       expectedOwner: expectedConfig.owner,
       deployedAddress: this.args.addresses.mailbox,
-      chainId: this.domainId,
+      chainId: this.chainId,
       chain: this.chainName,
     });
   }

--- a/typescript/sdk/src/core/EvmCoreReader.ts
+++ b/typescript/sdk/src/core/EvmCoreReader.ts
@@ -12,7 +12,7 @@ import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
 import { EvmHookReader } from '../hook/EvmHookReader.js';
 import { EvmIsmReader } from '../ism/EvmIsmReader.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
-import { ChainNameOrId } from '../types.js';
+import { ChainNameOrDomain } from '../types.js';
 
 import { CoreConfig } from './types.js';
 
@@ -28,7 +28,7 @@ export class EvmCoreReader implements CoreReader {
 
   constructor(
     protected readonly multiProvider: MultiProvider,
-    protected readonly chain: ChainNameOrId,
+    protected readonly chain: ChainNameOrDomain,
     protected readonly concurrency: number = multiProvider.tryGetRpcConcurrency(
       chain,
     ) ?? DEFAULT_CONTRACT_READ_CONCURRENCY,

--- a/typescript/sdk/src/core/EvmIcaModule.ts
+++ b/typescript/sdk/src/core/EvmIcaModule.ts
@@ -8,7 +8,7 @@ import { InterchainAccountFactories } from '../middleware/account/contracts.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
 import { ProxiedRouterConfig } from '../router/types.js';
-import { ChainNameOrId } from '../types.js';
+import { ChainNameOrDomain } from '../types.js';
 
 import {
   HyperlaneModule,
@@ -58,7 +58,7 @@ export class EvmIcaModule extends HyperlaneModule<
     multiProvider,
     contractVerifier,
   }: {
-    chain: ChainNameOrId;
+    chain: ChainNameOrDomain;
     config: InterchainAccountConfig;
     multiProvider: MultiProvider;
     contractVerifier?: ContractVerifier;

--- a/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
@@ -143,8 +143,12 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       mailbox,
       defaultHook.address,
       (_mailbox) => _mailbox.defaultHook(),
-      (_mailbox, _hook) =>
-        _mailbox.populateTransaction.setDefaultHook(_hook, { ...txOverrides }),
+      async (_mailbox, _hook) => {
+        const tx = await _mailbox.populateTransaction.setDefaultHook(_hook, {
+          ...txOverrides,
+        });
+        return { ...tx, chain };
+      },
     );
 
     await this.configureHook(
@@ -152,8 +156,12 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       mailbox,
       requiredHook.address,
       (_mailbox) => _mailbox.requiredHook(),
-      (_mailbox, _hook) =>
-        _mailbox.populateTransaction.setRequiredHook(_hook, { ...txOverrides }),
+      async (_mailbox, _hook) => {
+        const tx = await _mailbox.populateTransaction.setRequiredHook(_hook, {
+          ...txOverrides,
+        });
+        return { ...tx, chain };
+      },
     );
 
     await this.configureIsm(
@@ -161,8 +169,10 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       mailbox,
       defaultIsm,
       (_mailbox) => _mailbox.defaultIsm(),
-      (_mailbox, _module) =>
-        _mailbox.populateTransaction.setDefaultIsm(_module),
+      async (_mailbox, _module) => {
+        const tx = await _mailbox.populateTransaction.setDefaultIsm(_module);
+        return { ...tx, chain };
+      },
     );
 
     return mailbox;

--- a/typescript/sdk/src/core/TestRecipientDeployer.ts
+++ b/typescript/sdk/src/core/TestRecipientDeployer.ts
@@ -53,7 +53,12 @@ export class TestRecipientDeployer extends HyperlaneDeployer<
         testRecipient,
         config.interchainSecurityModule,
         (tr) => tr.interchainSecurityModule(),
-        (tr, ism) => tr.populateTransaction.setInterchainSecurityModule(ism),
+        async (tr, ism) => {
+          const tx = await tr.populateTransaction.setInterchainSecurityModule(
+            ism,
+          );
+          return { ...tx, chain };
+        },
       );
     } else {
       this.logger.warn(`No ISM config provided for TestRecipient on ${chain}`);

--- a/typescript/sdk/src/deploy/EvmModuleDeployer.ts
+++ b/typescript/sdk/src/deploy/EvmModuleDeployer.ts
@@ -2,15 +2,22 @@ import { ethers } from 'ethers';
 import { Logger } from 'pino';
 
 import {
+  Ownable__factory,
   StaticAddressSetFactory,
   StaticThresholdAddressSetFactory,
   TransparentUpgradeableProxy__factory,
 } from '@hyperlane-xyz/core';
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
-import { Address, addBufferToGasLimit, rootLogger } from '@hyperlane-xyz/utils';
+import {
+  Address,
+  addBufferToGasLimit,
+  eqAddress,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
 
 import { HyperlaneContracts, HyperlaneFactories } from '../contracts/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
+import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
 import { ChainMap, ChainName } from '../types.js';
 
 import { isProxy, proxyConstructorArgs } from './proxy.js';
@@ -314,5 +321,43 @@ export class EvmModuleDeployer<Factories extends HyperlaneFactories> {
     // );
 
     return address;
+  }
+
+  /**
+   * Transfers ownership of a contract to a new owner.
+   *
+   * @param actualOwner - The current owner of the contract.
+   * @param expectedOwner - The expected new owner of the contract.
+   * @param deployedAddress - The address of the deployed contract.
+   * @param chainId - The chain ID of the network the contract is deployed on.
+   * @param chain - The name of the network the contract is deployed on.
+   * @returns An array of annotated EV5 transactions that need to be executed to update the owner.
+   */
+  static createTransferOwnershipTx(params: {
+    actualOwner: Address;
+    expectedOwner: Address;
+    deployedAddress: Address;
+    chainId: number;
+    chain: ChainName;
+  }): AnnotatedEV5Transaction[] {
+    const { actualOwner, expectedOwner, deployedAddress, chainId, chain } =
+      params;
+    const updateTransactions: AnnotatedEV5Transaction[] = [];
+    if (eqAddress(actualOwner, expectedOwner)) {
+      return [];
+    }
+
+    updateTransactions.push({
+      chain,
+      annotation: `Transferring ownership of ${deployedAddress} from current owner ${actualOwner} to new owner ${expectedOwner}`,
+      chainId,
+      to: deployedAddress,
+      data: Ownable__factory.createInterface().encodeFunctionData(
+        'transferOwnership(address)',
+        [expectedOwner],
+      ),
+    });
+
+    return updateTransactions;
   }
 }

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -253,7 +253,7 @@ describe('EvmHookModule', async () => {
     expect(txs.length).to.equal(n);
 
     for (const tx of txs) {
-      await multiProvider.sendTransaction(chain, tx);
+      await multiProvider.sendTransaction(tx);
     }
   }
 

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -51,7 +51,7 @@ import { EvmIsmModule } from '../ism/EvmIsmModule.js';
 import { ArbL2ToL1IsmConfig, IsmType, OpStackIsmConfig } from '../ism/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
-import { ChainName, ChainNameOrId } from '../types.js';
+import { ChainName, ChainNameOrDomain } from '../types.js';
 import { normalizeConfig } from '../utils/ism.js';
 
 import { EvmHookReader } from './EvmHookReader.js';
@@ -235,7 +235,7 @@ export class EvmHookModule extends HyperlaneModule<
     multiProvider,
     contractVerifier,
   }: {
-    chain: ChainNameOrId;
+    chain: ChainNameOrDomain;
     config: HookConfig;
     proxyFactoryFactories: HyperlaneAddresses<ProxyFactoryFactories>;
     coreAddresses: CoreAddresses;

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -210,6 +210,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Return an ownership transfer transaction if required
     if (!eqAddress(targetConfig.owner, owner)) {
       updateTxs.push({
+        chain: this.chain,
         annotation: 'Transferring ownership of ownable Hook...',
         chainId: this.domainId,
         to: this.args.addresses.deployedHook,
@@ -312,6 +313,7 @@ export class EvmHookModule extends HyperlaneModule<
         : pausableInterface.encodeFunctionData('unpause');
 
       updateTxs.push({
+        chain: this.chain,
         annotation: `Updating paused state to ${targetConfig.paused}`,
         chainId: this.domainId,
         to: this.args.addresses.deployedHook,
@@ -335,6 +337,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Update beneficiary if changed
     if (!eqAddress(currentConfig.beneficiary, targetConfig.beneficiary)) {
       updateTxs.push({
+        chain: this.chain,
         annotation: `Updating beneficiary from ${currentConfig.beneficiary} to ${targetConfig.beneficiary}`,
         chainId: this.domainId,
         to: this.args.addresses.deployedHook,
@@ -434,6 +437,7 @@ export class EvmHookModule extends HyperlaneModule<
 
     return [
       {
+        chain: this.chain,
         annotation: `Updating overhead for domains ${Object.keys(
           targetOverheads,
         ).join(', ')}...`,
@@ -500,6 +504,7 @@ export class EvmHookModule extends HyperlaneModule<
 
     return [
       {
+        chain: this.chain,
         annotation: `Updating gas oracle config for domains ${Object.keys(
           targetOracleConfig,
         ).join(', ')}...`,
@@ -533,6 +538,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Update protocol fee if changed
     if (currentConfig.protocolFee !== targetConfig.protocolFee) {
       updateTxs.push({
+        chain: this.chain,
         annotation: `Updating protocol fee from ${currentConfig.protocolFee} to ${targetConfig.protocolFee}`,
         chainId: this.domainId,
         to: this.args.addresses.deployedHook,
@@ -546,6 +552,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Update beneficiary if changed
     if (currentConfig.beneficiary !== targetConfig.beneficiary) {
       updateTxs.push({
+        chain: this.chain,
         annotation: `Updating beneficiary from ${currentConfig.beneficiary} to ${targetConfig.beneficiary}`,
         chainId: this.domainId,
         to: this.args.addresses.deployedHook,
@@ -594,6 +601,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Create tx for setting hooks
     return [
       {
+        chain: this.chain,
         annotation: 'Updating routing hooks...',
         chainId: this.domainId,
         to: this.args.addresses.deployedHook,

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -1030,7 +1030,7 @@ export class EvmHookModule extends HyperlaneModule<
 
     // Set the gas params for each remote
     for (const tx of configureTxs) {
-      await this.multiProvider.sendTransaction(this.chain, tx);
+      await this.multiProvider.sendTransaction(tx);
     }
 
     // Transfer igp to the configured owner
@@ -1063,7 +1063,7 @@ export class EvmHookModule extends HyperlaneModule<
 
     // Set the gas params for each remote
     for (const tx of configureTxs) {
-      await this.multiProvider.sendTransaction(this.chain, tx);
+      await this.multiProvider.sendTransaction(tx);
     }
 
     // Transfer gas oracle to the configured owner

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -27,7 +27,7 @@ import {
 
 import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
-import { ChainNameOrId } from '../types.js';
+import { ChainNameOrDomain } from '../types.js';
 import { HyperlaneReader } from '../utils/HyperlaneReader.js';
 
 import {
@@ -86,7 +86,7 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
 
   constructor(
     protected readonly multiProvider: MultiProvider,
-    protected readonly chain: ChainNameOrId,
+    protected readonly chain: ChainNameOrDomain,
     protected readonly concurrency: number = multiProvider.tryGetRpcConcurrency(
       chain,
     ) ?? DEFAULT_CONTRACT_READ_CONCURRENCY,

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -462,7 +462,7 @@ export {
   TOKEN_TYPE_TO_STANDARD,
   TokenStandard,
 } from './token/TokenStandard.js';
-export { ChainMap, ChainName, ChainNameOrId, Connection } from './types.js';
+export { ChainMap, ChainName, ChainNameOrDomain, Connection } from './types.js';
 export { getCosmosRegistryChain } from './utils/cosmos.js';
 export { filterByChains } from './utils/filter.js';
 export {

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -312,15 +312,7 @@ export {
   excludeProviderMethods,
 } from './providers/SmartProvider/ProviderMethods.js';
 export { HyperlaneSmartProvider } from './providers/SmartProvider/SmartProvider.js';
-export {
-  PopulatedTransactionSchema,
-  PopulatedTransactionsSchema,
-} from './providers/transactions/schemas.js';
-export {
-  CallData,
-  PopulatedTransaction,
-  PopulatedTransactions,
-} from './providers/transactions/types.js';
+export { CallData } from './providers/transactions/types.js';
 
 export { SubmitterMetadataSchema } from './providers/transactions/submitter/schemas.js';
 export { TxSubmitterInterface } from './providers/transactions/submitter/TxSubmitterInterface.js';

--- a/typescript/sdk/src/ism/EvmIsmModule.hardhat-test.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.hardhat-test.ts
@@ -186,7 +186,7 @@ describe('EvmIsmModule', async () => {
     expect(txs.length).to.equal(n);
 
     for (const tx of txs) {
-      await multiProvider.sendTransaction(chain, tx);
+      await multiProvider.sendTransaction(tx);
     }
   }
 

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -22,6 +22,7 @@ import {
 import {
   Address,
   Domain,
+  EvmChainId,
   ProtocolType,
   addBufferToGasLimit,
   assert,
@@ -79,9 +80,8 @@ export class EvmIsmModule extends HyperlaneModule<
 
   // Adding these to reduce how often we need to grab from MultiProvider.
   public readonly chain: ChainName;
-  // We use domainId here because MultiProvider.getDomainId() will always
-  // return a number, and EVM the domainId and chainId are the same.
   public readonly domainId: Domain;
+  public readonly chainId: EvmChainId;
 
   constructor(
     protected readonly multiProvider: MultiProvider,
@@ -124,6 +124,7 @@ export class EvmIsmModule extends HyperlaneModule<
 
     this.chain = this.multiProvider.getChainName(this.args.chain);
     this.domainId = this.multiProvider.getDomainId(this.chain);
+    this.chainId = this.multiProvider.getEvmChainId(this.chain);
   }
 
   public async read(): Promise<IsmConfig> {
@@ -222,7 +223,7 @@ export class EvmIsmModule extends HyperlaneModule<
       updateTxs.push({
         chain: this.chain,
         annotation: 'Transferring ownership of ownable ISM...',
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: this.args.addresses.deployedIsm,
         data: Ownable__factory.createInterface().encodeFunctionData(
           'transferOwnership(address)',
@@ -314,7 +315,7 @@ export class EvmIsmModule extends HyperlaneModule<
       updateTxs.push({
         chain: this.chain,
         annotation: `Setting new ISM for origin ${origin}...`,
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: this.args.addresses.deployedIsm,
         data: routingIsmInterface.encodeFunctionData('set(uint32,address)', [
           domainId,
@@ -329,7 +330,7 @@ export class EvmIsmModule extends HyperlaneModule<
       updateTxs.push({
         chain: this.chain,
         annotation: `Unenrolling originDomain ${domainId} from preexisting routing ISM at ${this.args.addresses.deployedIsm}...`,
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: this.args.addresses.deployedIsm,
         data: routingIsmInterface.encodeFunctionData('remove(uint32)', [
           domainId,

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -21,7 +21,6 @@ import {
 } from '@hyperlane-xyz/core';
 import {
   Address,
-  Domain,
   EvmChainId,
   ProtocolType,
   addBufferToGasLimit,
@@ -46,7 +45,7 @@ import {
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
-import { ChainName, ChainNameOrId } from '../types.js';
+import { ChainName, ChainNameOrDomain } from '../types.js';
 import { normalizeConfig } from '../utils/ism.js';
 import { findMatchingLogEvents } from '../utils/logUtils.js';
 
@@ -80,7 +79,6 @@ export class EvmIsmModule extends HyperlaneModule<
 
   // Adding these to reduce how often we need to grab from MultiProvider.
   public readonly chain: ChainName;
-  public readonly domainId: Domain;
   public readonly chainId: EvmChainId;
 
   constructor(
@@ -123,7 +121,6 @@ export class EvmIsmModule extends HyperlaneModule<
     );
 
     this.chain = this.multiProvider.getChainName(this.args.chain);
-    this.domainId = this.multiProvider.getDomainId(this.chain);
     this.chainId = this.multiProvider.getEvmChainId(this.chain);
   }
 
@@ -244,7 +241,7 @@ export class EvmIsmModule extends HyperlaneModule<
     multiProvider,
     contractVerifier,
   }: {
-    chain: ChainNameOrId;
+    chain: ChainNameOrDomain;
     config: IsmConfig;
     proxyFactoryFactories: HyperlaneAddresses<ProxyFactoryFactories>;
     mailbox: Address;

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -220,6 +220,7 @@ export class EvmIsmModule extends HyperlaneModule<
     // Return an ownership transfer transaction if required
     if (!eqAddress(targetConfig.owner, owner)) {
       updateTxs.push({
+        chain: this.chain,
         annotation: 'Transferring ownership of ownable ISM...',
         chainId: this.domainId,
         to: this.args.addresses.deployedIsm,
@@ -279,7 +280,7 @@ export class EvmIsmModule extends HyperlaneModule<
     logger: Logger;
   }): Promise<AnnotatedEV5Transaction[]> {
     const routingIsmInterface = DomainRoutingIsm__factory.createInterface();
-    const updateTxs = [];
+    const updateTxs: AnnotatedEV5Transaction[] = [];
 
     // filter out domains which are not part of the multiprovider
     current = {
@@ -311,6 +312,7 @@ export class EvmIsmModule extends HyperlaneModule<
 
       const domainId = this.multiProvider.getDomainId(origin);
       updateTxs.push({
+        chain: this.chain,
         annotation: `Setting new ISM for origin ${origin}...`,
         chainId: this.domainId,
         to: this.args.addresses.deployedIsm,
@@ -325,6 +327,7 @@ export class EvmIsmModule extends HyperlaneModule<
     for (const origin of domainsToUnenroll) {
       const domainId = this.multiProvider.getDomainId(origin);
       updateTxs.push({
+        chain: this.chain,
         annotation: `Unenrolling originDomain ${domainId} from preexisting routing ISM at ${this.args.addresses.deployedIsm}...`,
         chainId: this.domainId,
         to: this.args.addresses.deployedIsm,

--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -22,7 +22,7 @@ import {
 
 import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
-import { ChainNameOrId } from '../types.js';
+import { ChainNameOrDomain } from '../types.js';
 import { HyperlaneReader } from '../utils/HyperlaneReader.js';
 
 import {
@@ -62,7 +62,7 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
 
   constructor(
     protected readonly multiProvider: MultiProvider,
-    protected readonly chain: ChainNameOrId,
+    protected readonly chain: ChainNameOrDomain,
     protected readonly concurrency: number = multiProvider.tryGetRpcConcurrency(
       chain,
     ) ?? DEFAULT_CONTRACT_READ_CONCURRENCY,

--- a/typescript/sdk/src/metadata/ChainMetadataManager.ts
+++ b/typescript/sdk/src/metadata/ChainMetadataManager.ts
@@ -8,7 +8,7 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
-import { ChainMap, ChainName, ChainNameOrId } from '../types.js';
+import { ChainMap, ChainName, ChainNameOrDomain } from '../types.js';
 
 import {
   getExplorerAddressUrl,
@@ -83,13 +83,14 @@ export class ChainMetadataManager<MetaExt = {}> {
    * @throws if chain's metadata has not been set
    */
   tryGetChainMetadata(
-    chainNameOrId: ChainNameOrId,
+    chainNameOrDomain: ChainNameOrDomain,
   ): ChainMetadata<MetaExt> | null {
     // First check if it's a chain name
-    if (this.metadata[chainNameOrId]) return this.metadata[chainNameOrId];
+    if (this.metadata[chainNameOrDomain])
+      return this.metadata[chainNameOrDomain];
     // Otherwise search by domain id
     const chainMetadata = Object.values(this.metadata).find(
-      (m) => m.domainId == chainNameOrId,
+      (m) => m.domainId == chainNameOrDomain,
     );
     return chainMetadata || null;
   }
@@ -98,16 +99,18 @@ export class ChainMetadataManager<MetaExt = {}> {
    * Get the metadata for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
-  getChainMetadata(chainNameOrId: ChainNameOrId): ChainMetadata<MetaExt> {
-    const chainMetadata = this.tryGetChainMetadata(chainNameOrId);
+  getChainMetadata(
+    chainNameOrDomain: ChainNameOrDomain,
+  ): ChainMetadata<MetaExt> {
+    const chainMetadata = this.tryGetChainMetadata(chainNameOrDomain);
     if (!chainMetadata) {
-      throw new Error(`No chain metadata set for ${chainNameOrId}`);
+      throw new Error(`No chain metadata set for ${chainNameOrDomain}`);
     }
     return chainMetadata;
   }
 
-  getMaxBlockRange(chainNameOrId: ChainNameOrId): number {
-    const metadata = this.getChainMetadata(chainNameOrId);
+  getMaxBlockRange(chainNameOrDomain: ChainNameOrDomain): number {
+    const metadata = this.getChainMetadata(chainNameOrDomain);
     return Math.max(
       ...metadata.rpcUrls.map(
         ({ pagination }) =>
@@ -121,23 +124,23 @@ export class ChainMetadataManager<MetaExt = {}> {
    * Returns true if the given chain name or domain id is
    * include in this manager's metadata, false otherwise
    */
-  hasChain(chainNameOrId: ChainNameOrId): boolean {
-    return !!this.tryGetChainMetadata(chainNameOrId);
+  hasChain(chainNameOrDomain: ChainNameOrDomain): boolean {
+    return !!this.tryGetChainMetadata(chainNameOrDomain);
   }
 
   /**
    * Get the name for a given chain name or domain id
    */
-  tryGetChainName(chainNameOrId: ChainNameOrId): string | null {
-    return this.tryGetChainMetadata(chainNameOrId)?.name ?? null;
+  tryGetChainName(chainNameOrDomain: ChainNameOrDomain): string | null {
+    return this.tryGetChainMetadata(chainNameOrDomain)?.name ?? null;
   }
 
   /**
    * Get the name for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
-  getChainName(chainNameOrId: ChainNameOrId): string {
-    return this.getChainMetadata(chainNameOrId).name;
+  getChainName(chainNameOrDomain: ChainNameOrDomain): string {
+    return this.getChainMetadata(chainNameOrDomain).name;
   }
 
   /**
@@ -150,26 +153,26 @@ export class ChainMetadataManager<MetaExt = {}> {
   /**
    * Get the id for a given chain name or domain id
    */
-  tryGetChainId(chainNameOrId: ChainNameOrId): number | string | null {
-    return this.tryGetChainMetadata(chainNameOrId)?.chainId ?? null;
+  tryGetChainId(chainNameOrDomain: ChainNameOrDomain): number | string | null {
+    return this.tryGetChainMetadata(chainNameOrDomain)?.chainId ?? null;
   }
 
   /**
    * Get the id for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
-  getChainId(chainNameOrId: ChainNameOrId): number | string {
-    return this.getChainMetadata(chainNameOrId).chainId;
+  getChainId(chainNameOrDomain: ChainNameOrDomain): number | string {
+    return this.getChainMetadata(chainNameOrDomain).chainId;
   }
 
   /**
    * Get the id for a given EVM chain name or domain id
    * @throws if chain's metadata has not been set
    */
-  getEvmChainId(chainNameOrId: ChainNameOrId): EvmChainId {
-    const { protocol, chainId } = this.getChainMetadata(chainNameOrId);
+  getEvmChainId(chainNameOrDomain: ChainNameOrDomain): EvmChainId {
+    const { protocol, chainId } = this.getChainMetadata(chainNameOrDomain);
     if (protocol !== ProtocolType.Ethereum) {
-      throw new Error(`Chain is not an EVM chain: ${chainNameOrId}`);
+      throw new Error(`Chain is not an EVM chain: ${chainNameOrDomain}`);
     }
     if (typeof chainId !== 'number') {
       throw new Error(`Chain ID is not a number: ${chainId}`);
@@ -187,8 +190,8 @@ export class ChainMetadataManager<MetaExt = {}> {
   /**
    * Get the domain id for a given chain name or domain id
    */
-  tryGetDomainId(chainNameOrId: ChainNameOrId): number | null {
-    const metadata = this.tryGetChainMetadata(chainNameOrId);
+  tryGetDomainId(chainNameOrDomain: ChainNameOrDomain): number | null {
+    const metadata = this.tryGetChainMetadata(chainNameOrDomain);
     if (!metadata) return null;
     return getDomainId(metadata) ?? null;
   }
@@ -197,25 +200,25 @@ export class ChainMetadataManager<MetaExt = {}> {
    * Get the domain id for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
-  getDomainId(chainNameOrId: ChainNameOrId): number {
-    const domainId = this.tryGetDomainId(chainNameOrId);
-    if (!domainId) throw new Error(`No domain id set for ${chainNameOrId}`);
+  getDomainId(chainNameOrDomain: ChainNameOrDomain): number {
+    const domainId = this.tryGetDomainId(chainNameOrDomain);
+    if (!domainId) throw new Error(`No domain id set for ${chainNameOrDomain}`);
     return domainId;
   }
 
   /**
    * Get the protocol type for a given chain name or domain id
    */
-  tryGetProtocol(chainNameOrId: ChainNameOrId): ProtocolType | null {
-    return this.tryGetChainMetadata(chainNameOrId)?.protocol ?? null;
+  tryGetProtocol(chainNameOrDomain: ChainNameOrDomain): ProtocolType | null {
+    return this.tryGetChainMetadata(chainNameOrDomain)?.protocol ?? null;
   }
 
   /**
    * Get the protocol type for a given chain name or domain id
    * @throws if chain's metadata or protocol has not been set
    */
-  getProtocol(chainNameOrId: ChainNameOrId): ProtocolType {
-    return this.getChainMetadata(chainNameOrId).protocol;
+  getProtocol(chainNameOrDomain: ChainNameOrDomain): ProtocolType {
+    return this.getChainMetadata(chainNameOrDomain).protocol;
   }
 
   /**
@@ -259,13 +262,13 @@ export class ChainMetadataManager<MetaExt = {}> {
    * @throws if chain's metadata has not been set
    */
   getRpc(
-    chainNameOrId: ChainNameOrId,
+    chainNameOrDomain: ChainNameOrDomain,
     index = 0,
   ): ChainMetadata['rpcUrls'][number] {
-    const { rpcUrls } = this.getChainMetadata(chainNameOrId);
+    const { rpcUrls } = this.getChainMetadata(chainNameOrDomain);
     if (!rpcUrls?.length || !rpcUrls[index])
       throw new Error(
-        `No RPC configured at index ${index} for ${chainNameOrId}`,
+        `No RPC configured at index ${index} for ${chainNameOrDomain}`,
       );
     return rpcUrls[index];
   }
@@ -274,25 +277,29 @@ export class ChainMetadataManager<MetaExt = {}> {
    * Get an RPC URL for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
-  getRpcUrl(chainNameOrId: ChainNameOrId, index = 0): string {
-    const { http } = this.getRpc(chainNameOrId, index);
-    if (!http) throw new Error(`No RPC URL configured for ${chainNameOrId}`);
+  getRpcUrl(chainNameOrDomain: ChainNameOrDomain, index = 0): string {
+    const { http } = this.getRpc(chainNameOrDomain, index);
+    if (!http)
+      throw new Error(`No RPC URL configured for ${chainNameOrDomain}`);
     return http;
   }
 
   /**
    * Get an RPC concurrency level for a given chain name or domain id
    */
-  tryGetRpcConcurrency(chainNameOrId: ChainNameOrId, index = 0): number | null {
-    const { concurrency } = this.getRpc(chainNameOrId, index);
+  tryGetRpcConcurrency(
+    chainNameOrDomain: ChainNameOrDomain,
+    index = 0,
+  ): number | null {
+    const { concurrency } = this.getRpc(chainNameOrDomain, index);
     return concurrency ?? null;
   }
 
   /**
    * Get a block explorer URL for a given chain name or domain id
    */
-  tryGetExplorerUrl(chainNameOrId: ChainNameOrId): string | null {
-    const metadata = this.tryGetChainMetadata(chainNameOrId);
+  tryGetExplorerUrl(chainNameOrDomain: ChainNameOrDomain): string | null {
+    const metadata = this.tryGetChainMetadata(chainNameOrDomain);
     if (!metadata) return null;
     return getExplorerBaseUrl(metadata);
   }
@@ -301,21 +308,21 @@ export class ChainMetadataManager<MetaExt = {}> {
    * Get a block explorer URL for a given chain name or domain id
    * @throws if chain's metadata or block explorer data has no been set
    */
-  getExplorerUrl(chainNameOrId: ChainNameOrId): string {
-    const url = this.tryGetExplorerUrl(chainNameOrId);
-    if (!url) throw new Error(`No explorer url set for ${chainNameOrId}`);
+  getExplorerUrl(chainNameOrDomain: ChainNameOrDomain): string {
+    const url = this.tryGetExplorerUrl(chainNameOrDomain);
+    if (!url) throw new Error(`No explorer url set for ${chainNameOrDomain}`);
     return url;
   }
 
   /**
    * Get a block explorer's API for a given chain name or domain id
    */
-  tryGetExplorerApi(chainNameOrId: ChainName | number): {
+  tryGetExplorerApi(chainNameOrDomain: ChainName | number): {
     apiUrl: string;
     apiKey?: string;
     family?: ExplorerFamily;
   } | null {
-    const metadata = this.tryGetChainMetadata(chainNameOrId);
+    const metadata = this.tryGetChainMetadata(chainNameOrDomain);
     if (!metadata) return null;
     return getExplorerApi(metadata);
   }
@@ -324,22 +331,22 @@ export class ChainMetadataManager<MetaExt = {}> {
    * Get a block explorer API for a given chain name or domain id
    * @throws if chain's metadata or block explorer data has no been set
    */
-  getExplorerApi(chainNameOrId: ChainName | number): {
+  getExplorerApi(chainNameOrDomain: ChainName | number): {
     apiUrl: string;
     apiKey?: string;
     family?: ExplorerFamily;
   } {
-    const explorerApi = this.tryGetExplorerApi(chainNameOrId);
+    const explorerApi = this.tryGetExplorerApi(chainNameOrDomain);
     if (!explorerApi)
-      throw new Error(`No supported explorer api set for ${chainNameOrId}`);
+      throw new Error(`No supported explorer api set for ${chainNameOrDomain}`);
     return explorerApi;
   }
 
   /**
    * Get a block explorer's API URL for a given chain name or domain id
    */
-  tryGetExplorerApiUrl(chainNameOrId: ChainNameOrId): string | null {
-    const metadata = this.tryGetChainMetadata(chainNameOrId);
+  tryGetExplorerApiUrl(chainNameOrDomain: ChainNameOrDomain): string | null {
+    const metadata = this.tryGetChainMetadata(chainNameOrDomain);
     if (!metadata) return null;
     return getExplorerApiUrl(metadata);
   }
@@ -348,9 +355,10 @@ export class ChainMetadataManager<MetaExt = {}> {
    * Get a block explorer API URL for a given chain name or domain id
    * @throws if chain's metadata or block explorer data has no been set
    */
-  getExplorerApiUrl(chainNameOrId: ChainNameOrId): string {
-    const url = this.tryGetExplorerApiUrl(chainNameOrId);
-    if (!url) throw new Error(`No explorer api url set for ${chainNameOrId}`);
+  getExplorerApiUrl(chainNameOrDomain: ChainNameOrDomain): string {
+    const url = this.tryGetExplorerApiUrl(chainNameOrDomain);
+    if (!url)
+      throw new Error(`No explorer api url set for ${chainNameOrDomain}`);
     return url;
   }
 
@@ -358,10 +366,10 @@ export class ChainMetadataManager<MetaExt = {}> {
    * Get a block explorer URL for given chain's tx
    */
   tryGetExplorerTxUrl(
-    chainNameOrId: ChainNameOrId,
+    chainNameOrDomain: ChainNameOrDomain,
     response: { hash: string },
   ): string | null {
-    const metadata = this.tryGetChainMetadata(chainNameOrId);
+    const metadata = this.tryGetChainMetadata(chainNameOrDomain);
     if (!metadata) return null;
     return getExplorerTxUrl(metadata, response.hash);
   }
@@ -371,20 +379,20 @@ export class ChainMetadataManager<MetaExt = {}> {
    * @throws if chain's metadata or block explorer data has no been set
    */
   getExplorerTxUrl(
-    chainNameOrId: ChainNameOrId,
+    chainNameOrDomain: ChainNameOrDomain,
     response: { hash: string },
   ): string {
-    return `${this.getExplorerUrl(chainNameOrId)}/tx/${response.hash}`;
+    return `${this.getExplorerUrl(chainNameOrDomain)}/tx/${response.hash}`;
   }
 
   /**
    * Get a block explorer URL for given chain's address
    */
   async tryGetExplorerAddressUrl(
-    chainNameOrId: ChainNameOrId,
+    chainNameOrDomain: ChainNameOrDomain,
     address?: string,
   ): Promise<string | null> {
-    const metadata = this.tryGetChainMetadata(chainNameOrId);
+    const metadata = this.tryGetChainMetadata(chainNameOrDomain);
     if (!metadata || !address) return null;
     return getExplorerAddressUrl(metadata, address);
   }
@@ -394,12 +402,12 @@ export class ChainMetadataManager<MetaExt = {}> {
    * @throws if address or the chain's block explorer data has no been set
    */
   async getExplorerAddressUrl(
-    chainNameOrId: ChainNameOrId,
+    chainNameOrDomain: ChainNameOrDomain,
     address?: string,
   ): Promise<string> {
-    const url = await this.tryGetExplorerAddressUrl(chainNameOrId, address);
+    const url = await this.tryGetExplorerAddressUrl(chainNameOrDomain, address);
     if (!url)
-      throw new Error(`Missing data for address url for ${chainNameOrId}`);
+      throw new Error(`Missing data for address url for ${chainNameOrDomain}`);
     return url;
   }
 
@@ -408,11 +416,11 @@ export class ChainMetadataManager<MetaExt = {}> {
    * @throws if native token has not been set
    */
   async getNativeToken(
-    chainNameOrId: ChainNameOrId,
+    chainNameOrDomain: ChainNameOrDomain,
   ): Promise<NonNullable<ChainMetadata['nativeToken']>> {
-    const metadata = this.tryGetChainMetadata(chainNameOrId);
+    const metadata = this.tryGetChainMetadata(chainNameOrDomain);
     if (!metadata || !metadata.nativeToken) {
-      throw new Error(`Missing data for native token for ${chainNameOrId}`);
+      throw new Error(`Missing data for native token for ${chainNameOrDomain}`);
     }
     return metadata.nativeToken;
   }

--- a/typescript/sdk/src/metadata/ChainMetadataManager.ts
+++ b/typescript/sdk/src/metadata/ChainMetadataManager.ts
@@ -1,6 +1,12 @@
 import { Logger } from 'pino';
 
-import { ProtocolType, exclude, pick, rootLogger } from '@hyperlane-xyz/utils';
+import {
+  EvmChainId,
+  ProtocolType,
+  exclude,
+  pick,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
 
 import { ChainMap, ChainName, ChainNameOrId } from '../types.js';
 
@@ -90,7 +96,7 @@ export class ChainMetadataManager<MetaExt = {}> {
     if (this.metadata[chainNameOrId]) return this.metadata[chainNameOrId];
     // Otherwise search by chain id and domain id
     const chainMetadata = Object.values(this.metadata).find(
-      (m) => m.chainId == chainNameOrId || m.domainId == chainNameOrId,
+      (m) => m.domainId == chainNameOrId,
     );
     return chainMetadata || null;
   }
@@ -161,6 +167,21 @@ export class ChainMetadataManager<MetaExt = {}> {
    */
   getChainId(chainNameOrId: ChainNameOrId): number | string {
     return this.getChainMetadata(chainNameOrId).chainId;
+  }
+
+  /**
+   * Get the id for a given EVM chain name or domain id
+   * @throws if chain's metadata has not been set
+   */
+  getEvmChainId(chainNameOrId: ChainNameOrId): EvmChainId {
+    const { protocol, chainId } = this.getChainMetadata(chainNameOrId);
+    if (protocol !== ProtocolType.Ethereum) {
+      throw new Error(`Chain is not an EVM chain: ${chainNameOrId}`);
+    }
+    if (typeof chainId !== 'number') {
+      throw new Error(`Chain ID is not a number: ${chainId}`);
+    }
+    return chainId;
   }
 
   /**

--- a/typescript/sdk/src/metadata/ChainMetadataManager.ts
+++ b/typescript/sdk/src/metadata/ChainMetadataManager.ts
@@ -62,31 +62,24 @@ export class ChainMetadataManager<MetaExt = {}> {
 
   /**
    * Add a chain to the MultiProvider
-   * @throws if chain's name or domain/chain ID collide
+   * @throws if chain's name or domain ID collide
    */
   addChain(metadata: ChainMetadata<MetaExt>): void {
     ChainMetadataSchema.parse(metadata);
     // Ensure no two chains have overlapping names/domainIds/chainIds
     for (const chainMetadata of Object.values(this.metadata)) {
-      const { name, chainId, domainId } = chainMetadata;
+      const { name, domainId } = chainMetadata;
       if (name == metadata.name)
         throw new Error(`Duplicate chain name: ${name}`);
-      // Chain and Domain Ids should be globally unique
-      const idCollision =
-        chainId == metadata.chainId ||
-        domainId == metadata.chainId ||
-        (metadata.domainId &&
-          (chainId == metadata.domainId || domainId == metadata.domainId));
-      if (idCollision)
-        throw new Error(
-          `Chain/Domain id collision: ${name} and ${metadata.name}`,
-        );
+      // Domain Ids should be globally unique
+      if (domainId == metadata.domainId)
+        throw new Error(`Domain ID collision: ${name} and ${metadata.name}`);
     }
     this.metadata[metadata.name] = metadata;
   }
 
   /**
-   * Get the metadata for a given chain name, chain id, or domain id
+   * Get the metadata for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   tryGetChainMetadata(
@@ -94,7 +87,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   ): ChainMetadata<MetaExt> | null {
     // First check if it's a chain name
     if (this.metadata[chainNameOrId]) return this.metadata[chainNameOrId];
-    // Otherwise search by chain id and domain id
+    // Otherwise search by domain id
     const chainMetadata = Object.values(this.metadata).find(
       (m) => m.domainId == chainNameOrId,
     );
@@ -102,7 +95,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the metadata for a given chain name, chain id, or domain id
+   * Get the metadata for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   getChainMetadata(chainNameOrId: ChainNameOrId): ChainMetadata<MetaExt> {
@@ -125,7 +118,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Returns true if the given chain name, chain id, or domain id is
+   * Returns true if the given chain name or domain id is
    * include in this manager's metadata, false otherwise
    */
   hasChain(chainNameOrId: ChainNameOrId): boolean {
@@ -133,14 +126,14 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the name for a given chain name, chain id, or domain id
+   * Get the name for a given chain name or domain id
    */
   tryGetChainName(chainNameOrId: ChainNameOrId): string | null {
     return this.tryGetChainMetadata(chainNameOrId)?.name ?? null;
   }
 
   /**
-   * Get the name for a given chain name, chain id, or domain id
+   * Get the name for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   getChainName(chainNameOrId: ChainNameOrId): string {
@@ -155,14 +148,14 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the id for a given chain name, chain id, or domain id
+   * Get the id for a given chain name or domain id
    */
   tryGetChainId(chainNameOrId: ChainNameOrId): number | string | null {
     return this.tryGetChainMetadata(chainNameOrId)?.chainId ?? null;
   }
 
   /**
-   * Get the id for a given chain name, chain id, or domain id
+   * Get the id for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   getChainId(chainNameOrId: ChainNameOrId): number | string {
@@ -192,7 +185,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the domain id for a given chain name, chain id, or domain id
+   * Get the domain id for a given chain name or domain id
    */
   tryGetDomainId(chainNameOrId: ChainNameOrId): number | null {
     const metadata = this.tryGetChainMetadata(chainNameOrId);
@@ -201,7 +194,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the domain id for a given chain name, chain id, or domain id
+   * Get the domain id for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   getDomainId(chainNameOrId: ChainNameOrId): number {
@@ -211,14 +204,14 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the protocol type for a given chain name, chain id, or domain id
+   * Get the protocol type for a given chain name or domain id
    */
   tryGetProtocol(chainNameOrId: ChainNameOrId): ProtocolType | null {
     return this.tryGetChainMetadata(chainNameOrId)?.protocol ?? null;
   }
 
   /**
-   * Get the protocol type for a given chain name, chain id, or domain id
+   * Get the protocol type for a given chain name or domain id
    * @throws if chain's metadata or protocol has not been set
    */
   getProtocol(chainNameOrId: ChainNameOrId): ProtocolType {
@@ -226,7 +219,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the domain ids for a list of chain names, chain ids, or domain ids
+   * Get the domain ids for a list of chain names or domain ids
    * @throws if any chain's metadata has not been set
    */
   getDomainIds(chainNamesOrIds: Array<ChainName | number>): number[] {
@@ -261,7 +254,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get the RPC details for a given chain name, chain id, or domain id.
+   * Get the RPC details for a given chain name or domain id.
    * Optional index for metadata containing more than one RPC.
    * @throws if chain's metadata has not been set
    */
@@ -278,7 +271,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get an RPC URL for a given chain name, chain id, or domain id
+   * Get an RPC URL for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   getRpcUrl(chainNameOrId: ChainNameOrId, index = 0): string {
@@ -288,7 +281,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get an RPC concurrency level for a given chain name, chain id, or domain id
+   * Get an RPC concurrency level for a given chain name or domain id
    */
   tryGetRpcConcurrency(chainNameOrId: ChainNameOrId, index = 0): number | null {
     const { concurrency } = this.getRpc(chainNameOrId, index);
@@ -296,7 +289,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get a block explorer URL for a given chain name, chain id, or domain id
+   * Get a block explorer URL for a given chain name or domain id
    */
   tryGetExplorerUrl(chainNameOrId: ChainNameOrId): string | null {
     const metadata = this.tryGetChainMetadata(chainNameOrId);
@@ -305,7 +298,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get a block explorer URL for a given chain name, chain id, or domain id
+   * Get a block explorer URL for a given chain name or domain id
    * @throws if chain's metadata or block explorer data has no been set
    */
   getExplorerUrl(chainNameOrId: ChainNameOrId): string {
@@ -315,7 +308,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get a block explorer's API for a given chain name, chain id, or domain id
+   * Get a block explorer's API for a given chain name or domain id
    */
   tryGetExplorerApi(chainNameOrId: ChainName | number): {
     apiUrl: string;
@@ -328,7 +321,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get a block explorer API for a given chain name, chain id, or domain id
+   * Get a block explorer API for a given chain name or domain id
    * @throws if chain's metadata or block explorer data has no been set
    */
   getExplorerApi(chainNameOrId: ChainName | number): {
@@ -343,7 +336,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get a block explorer's API URL for a given chain name, chain id, or domain id
+   * Get a block explorer's API URL for a given chain name or domain id
    */
   tryGetExplorerApiUrl(chainNameOrId: ChainNameOrId): string | null {
     const metadata = this.tryGetChainMetadata(chainNameOrId);
@@ -352,7 +345,7 @@ export class ChainMetadataManager<MetaExt = {}> {
   }
 
   /**
-   * Get a block explorer API URL for a given chain name, chain id, or domain id
+   * Get a block explorer API URL for a given chain name or domain id
    * @throws if chain's metadata or block explorer data has no been set
    */
   getExplorerApiUrl(chainNameOrId: ChainNameOrId): string {

--- a/typescript/sdk/src/middleware/account/InterchainAccount.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.ts
@@ -1,4 +1,4 @@
-import { BigNumber, PopulatedTransaction } from 'ethers';
+import { BigNumber } from 'ethers';
 
 import { InterchainAccountRouter } from '@hyperlane-xyz/core';
 import {
@@ -14,6 +14,7 @@ import {
   HyperlaneContractsMap,
 } from '../../contracts/types.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
+import { AnnotatedEV5Transaction } from '../../providers/ProviderType.js';
 import { RouterApp } from '../../router/RouterApps.js';
 import { ChainName } from '../../types.js';
 
@@ -147,7 +148,7 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
     innerCalls,
     config,
     hookMetadata,
-  }: GetCallRemoteSettings): Promise<PopulatedTransaction> {
+  }: GetCallRemoteSettings): Promise<AnnotatedEV5Transaction> {
     const localRouter = this.router(this.contractsMap[chain]);
     const remoteDomain = this.multiProvider.getDomainId(destination);
     const quote = await localRouter['quoteGasPayment(uint32)'](remoteDomain);
@@ -172,7 +173,7 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
       hookMetadata ?? '0x',
       { value: quote },
     );
-    return callEncoded;
+    return { ...callEncoded, chain };
   }
 
   async getAccountConfig(

--- a/typescript/sdk/src/middleware/account/InterchainAccount.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.ts
@@ -201,7 +201,6 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
     hookMetadata,
   }: GetCallRemoteSettings): Promise<void> {
     await this.multiProvider.sendTransaction(
-      chain,
       this.getCallRemote({
         chain,
         destination,

--- a/typescript/sdk/src/providers/MultiProtocolProvider.ts
+++ b/typescript/sdk/src/providers/MultiProtocolProvider.ts
@@ -13,7 +13,7 @@ import {
 import { multiProtocolTestChainMetadata } from '../consts/testChains.js';
 import { ChainMetadataManager } from '../metadata/ChainMetadataManager.js';
 import type { ChainMetadata } from '../metadata/chainMetadataTypes.js';
-import type { ChainMap, ChainName, ChainNameOrId } from '../types.js';
+import type { ChainMap, ChainName, ChainNameOrDomain } from '../types.js';
 
 import { MultiProvider, MultiProviderOptions } from './MultiProvider.js';
 import {
@@ -122,10 +122,10 @@ export class MultiProtocolProvider<
   }
 
   tryGetProvider(
-    chainNameOrId: ChainNameOrId,
+    chainNameOrDomain: ChainNameOrDomain,
     type?: ProviderType,
   ): TypedProvider | null {
-    const metadata = this.tryGetChainMetadata(chainNameOrId);
+    const metadata = this.tryGetChainMetadata(chainNameOrDomain);
     if (!metadata) return null;
     const { protocol, name, chainId, rpcUrls } = metadata;
     type = type || PROTOCOL_TO_DEFAULT_PROVIDER_TYPE[protocol];
@@ -143,20 +143,20 @@ export class MultiProtocolProvider<
   }
 
   getProvider(
-    chainNameOrId: ChainNameOrId,
+    chainNameOrDomain: ChainNameOrDomain,
     type?: ProviderType,
   ): TypedProvider {
-    const provider = this.tryGetProvider(chainNameOrId, type);
+    const provider = this.tryGetProvider(chainNameOrDomain, type);
     if (!provider)
-      throw new Error(`No provider available for ${chainNameOrId}`);
+      throw new Error(`No provider available for ${chainNameOrDomain}`);
     return provider;
   }
 
   protected getSpecificProvider<T>(
-    chainNameOrId: ChainNameOrId,
+    chainNameOrDomain: ChainNameOrDomain,
     type: ProviderType,
   ): T {
-    const provider = this.getProvider(chainNameOrId, type);
+    const provider = this.getProvider(chainNameOrDomain, type);
     if (provider.type !== type)
       throw new Error(
         `Invalid provider type, expected ${type} but found ${provider.type}`,
@@ -165,51 +165,55 @@ export class MultiProtocolProvider<
   }
 
   getEthersV5Provider(
-    chainNameOrId: ChainNameOrId,
+    chainNameOrDomain: ChainNameOrDomain,
   ): EthersV5Provider['provider'] {
     return this.getSpecificProvider<EthersV5Provider['provider']>(
-      chainNameOrId,
+      chainNameOrDomain,
       ProviderType.EthersV5,
     );
   }
 
-  getViemProvider(chainNameOrId: ChainNameOrId): ViemProvider['provider'] {
+  getViemProvider(
+    chainNameOrDomain: ChainNameOrDomain,
+  ): ViemProvider['provider'] {
     return this.getSpecificProvider<ViemProvider['provider']>(
-      chainNameOrId,
+      chainNameOrDomain,
       ProviderType.Viem,
     );
   }
 
   getSolanaWeb3Provider(
-    chainNameOrId: ChainNameOrId,
+    chainNameOrDomain: ChainNameOrDomain,
   ): SolanaWeb3Provider['provider'] {
     return this.getSpecificProvider<SolanaWeb3Provider['provider']>(
-      chainNameOrId,
+      chainNameOrDomain,
       ProviderType.SolanaWeb3,
     );
   }
 
-  getCosmJsProvider(chainNameOrId: ChainNameOrId): CosmJsProvider['provider'] {
+  getCosmJsProvider(
+    chainNameOrDomain: ChainNameOrDomain,
+  ): CosmJsProvider['provider'] {
     return this.getSpecificProvider<CosmJsProvider['provider']>(
-      chainNameOrId,
+      chainNameOrDomain,
       ProviderType.CosmJs,
     );
   }
 
   getCosmJsWasmProvider(
-    chainNameOrId: ChainNameOrId,
+    chainNameOrDomain: ChainNameOrDomain,
   ): CosmJsWasmProvider['provider'] {
     return this.getSpecificProvider<CosmJsWasmProvider['provider']>(
-      chainNameOrId,
+      chainNameOrDomain,
       ProviderType.CosmJsWasm,
     );
   }
 
   setProvider(
-    chainNameOrId: ChainNameOrId,
+    chainNameOrDomain: ChainNameOrDomain,
     provider: TypedProvider,
   ): TypedProvider {
-    const chainName = this.getChainName(chainNameOrId);
+    const chainName = this.getChainName(chainNameOrDomain);
     this.providers[chainName] ||= {};
     this.providers[chainName][provider.type] = provider;
     return provider;
@@ -222,18 +226,18 @@ export class MultiProtocolProvider<
   }
 
   estimateTransactionFee({
-    chainNameOrId,
+    chainNameOrDomain,
     transaction,
     sender,
     senderPubKey,
   }: {
-    chainNameOrId: ChainNameOrId;
+    chainNameOrDomain: ChainNameOrDomain;
     transaction: TypedTransaction;
     sender: Address;
     senderPubKey?: HexString;
   }): Promise<TransactionFeeEstimate> {
-    const provider = this.getProvider(chainNameOrId, transaction.type);
-    const chainMetadata = this.getChainMetadata(chainNameOrId);
+    const provider = this.getProvider(chainNameOrDomain, transaction.type);
+    const chainMetadata = this.getChainMetadata(chainNameOrDomain);
     return estimateTransactionFee({
       transaction,
       provider,

--- a/typescript/sdk/src/providers/MultiProvider.ts
+++ b/typescript/sdk/src/providers/MultiProvider.ts
@@ -84,7 +84,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Get an Ethers provider for a given chain name, chain id, or domain id
+   * Get an Ethers provider for a given chain name or domain id
    */
   tryGetProvider(chainNameOrId: ChainNameOrId): Provider | null {
     const metadata = this.tryGetChainMetadata(chainNameOrId);
@@ -108,7 +108,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Get an Ethers provider for a given chain name, chain id, or domain id
+   * Get an Ethers provider for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   getProvider(chainNameOrId: ChainNameOrId): Provider {
@@ -119,7 +119,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Sets an Ethers provider for a given chain name, chain id, or domain id
+   * Sets an Ethers provider for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   setProvider(chainNameOrId: ChainNameOrId, provider: Provider): Provider {
@@ -144,7 +144,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Get an Ethers signer for a given chain name, chain id, or domain id
+   * Get an Ethers signer for a given chain name or domain id
    * If signer is not yet connected, it will be connected
    */
   tryGetSigner(chainNameOrId: ChainNameOrId): Signer | null {
@@ -159,7 +159,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Get an Ethers signer for a given chain name, chain id, or domain id
+   * Get an Ethers signer for a given chain name or domain id
    * If signer is not yet connected, it will be connected
    * @throws if chain's metadata or signer has not been set
    */
@@ -170,7 +170,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Get an Ethers signer for a given chain name, chain id, or domain id
+   * Get an Ethers signer for a given chain name or domain id
    * @throws if chain's metadata or signer has not been set
    */
   async getSignerAddress(chainNameOrId: ChainNameOrId): Promise<Address> {
@@ -180,7 +180,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Sets an Ethers Signer for a given chain name, chain id, or domain id
+   * Sets an Ethers Signer for a given chain name or domain id
    * @throws if chain's metadata has not been set or shared signer has already been set
    */
   setSigner(chainNameOrId: ChainNameOrId, signer: Signer): Signer {
@@ -295,7 +295,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
   }
 
   /**
-   * Get the transaction overrides for a given chain name, chain id, or domain id
+   * Get the transaction overrides for a given chain name or domain id
    * @throws if chain's metadata has not been set
    */
   getTransactionOverrides(

--- a/typescript/sdk/src/providers/MultiProvider.ts
+++ b/typescript/sdk/src/providers/MultiProvider.ts
@@ -404,7 +404,6 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
    * @throws if chain's metadata or signer has not been set or tx fails
    */
   async sendTransaction(
-    _: ChainNameOrId,
     txProm: AnnotatedEV5Transaction | Promise<AnnotatedEV5Transaction>,
   ): Promise<ContractReceipt> {
     const { chain, annotation, ...tx } = await txProm;

--- a/typescript/sdk/src/providers/MultiProvider.ts
+++ b/typescript/sdk/src/providers/MultiProvider.ts
@@ -404,18 +404,18 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
    * @throws if chain's metadata or signer has not been set or tx fails
    */
   async sendTransaction(
-    chainNameOrId: ChainNameOrId,
+    _: ChainNameOrId,
     txProm: AnnotatedEV5Transaction | Promise<AnnotatedEV5Transaction>,
   ): Promise<ContractReceipt> {
-    const { annotation, ...tx } = await txProm;
+    const { chain, annotation, ...tx } = await txProm;
     if (annotation) {
       this.logger.info(annotation);
     }
-    const txReq = await this.prepareTx(chainNameOrId, tx);
-    const signer = this.getSigner(chainNameOrId);
+    const txReq = await this.prepareTx(chain, tx);
+    const signer = this.getSigner(chain);
     const response = await signer.sendTransaction(txReq);
     this.logger.info(`Sent tx ${response.hash}`);
-    return this.handleTx(chainNameOrId, response);
+    return this.handleTx(chain, response);
   }
 
   /**

--- a/typescript/sdk/src/providers/ProviderType.ts
+++ b/typescript/sdk/src/providers/ProviderType.ts
@@ -25,6 +25,8 @@ import type {
 
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
+import { ChainName } from '../types.js';
+
 export enum ProviderType {
   EthersV5 = 'ethers-v5',
   Viem = 'viem',
@@ -201,6 +203,7 @@ export interface EthersV5Transaction
 }
 
 export interface AnnotatedEV5Transaction extends EV5Transaction {
+  chain: ChainName;
   annotation?: string;
 }
 

--- a/typescript/sdk/src/providers/transactions/schemas.test.ts
+++ b/typescript/sdk/src/providers/transactions/schemas.test.ts
@@ -2,42 +2,15 @@ import { expect } from 'chai';
 
 import { Address } from '@hyperlane-xyz/utils';
 
-import { CallDataSchema, PopulatedTransactionSchema } from './schemas.js';
-import { CallData, PopulatedTransaction } from './types.js';
+import { CallDataSchema } from './schemas.js';
+import { CallData } from './types.js';
 
 describe('transactions schemas', () => {
   const ADDRESS_MOCK: Address = '0x1234567890123456789012345678901234567890';
   const DATA_MOCK: string = '0xabcdef';
-  const CHAIN_ID_MOCK: number = 1;
   const VALUE_MOCK: string = '100';
 
   const INVALID_ADDRESS: Address = '0x1';
-
-  describe('PopulatedTransactionSchema', () => {
-    it('should parse valid PopulatedTransaction', () => {
-      const validPopulatedTransaction: PopulatedTransaction = {
-        to: ADDRESS_MOCK,
-        data: DATA_MOCK,
-        chainId: CHAIN_ID_MOCK,
-      };
-      const result = PopulatedTransactionSchema.safeParse(
-        validPopulatedTransaction,
-      );
-      expect(result.success).to.be.true;
-    });
-
-    it('should fail parsing invalid PopulatedTransaction', () => {
-      const invalidPopulatedTransaction: PopulatedTransaction = {
-        to: INVALID_ADDRESS,
-        data: DATA_MOCK,
-        chainId: CHAIN_ID_MOCK,
-      };
-      const result = PopulatedTransactionSchema.safeParse(
-        invalidPopulatedTransaction,
-      );
-      expect(result.success).to.be.false;
-    });
-  });
 
   describe('CallDataSchema', () => {
     it('should parse valid CallData', () => {

--- a/typescript/sdk/src/providers/transactions/schemas.ts
+++ b/typescript/sdk/src/providers/transactions/schemas.ts
@@ -4,17 +4,6 @@ import { ZHash } from '../../metadata/customZodTypes.js';
 
 export const BigNumberSchema = z.string();
 
-export const PopulatedTransactionSchema = z.object({
-  to: ZHash,
-  data: z.string(),
-  chainId: z.number(),
-});
-
-export const PopulatedTransactionsSchema =
-  PopulatedTransactionSchema.array().refine((txs) => txs.length > 0, {
-    message: 'Populated Transactions cannot be empty',
-  });
-
 export const CallDataSchema = z.object({
   to: ZHash,
   data: z.string(),

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxBuilder.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxBuilder.ts
@@ -6,8 +6,10 @@ import { assert } from '@hyperlane-xyz/utils';
 // @ts-ignore
 import { getSafe, getSafeService } from '../../../../utils/gnosisSafe.js';
 import { MultiProvider } from '../../../MultiProvider.js';
-import { GnosisTransactionBuilderPayload } from '../../../ProviderType.js';
-import { PopulatedTransaction, PopulatedTransactions } from '../../types.js';
+import {
+  AnnotatedEV5Transaction,
+  GnosisTransactionBuilderPayload,
+} from '../../../ProviderType.js';
 import { TxSubmitterType } from '../TxSubmitterTypes.js';
 
 import { EV5GnosisSafeTxSubmitter } from './EV5GnosisSafeTxSubmitter.js';
@@ -47,16 +49,16 @@ export class EV5GnosisSafeTxBuilder extends EV5GnosisSafeTxSubmitter {
   }
 
   /**
-   * Creates a Gnosis Safe transaction builder object using the PopulatedTransactions
+   * Creates a Gnosis Safe transaction builder object using the AnnotatedEV5Transaction[]
    *
-   * @param txs - An array of populated transactions
+   * @param txs - An array of annotated, populated transactions
    */
   public async submit(
-    ...txs: PopulatedTransactions
+    ...txs: AnnotatedEV5Transaction[]
   ): Promise<GnosisTransactionBuilderPayload> {
     const transactions: SafeTransactionData[] = await Promise.all(
       txs.map(
-        async (tx: PopulatedTransaction) =>
+        async (tx: AnnotatedEV5Transaction) =>
           (
             await this.createSafeTransaction(tx)
           ).data,

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.ts
@@ -7,7 +7,7 @@ import { Address, assert, rootLogger } from '@hyperlane-xyz/utils';
 // @ts-ignore
 import { canProposeSafeTransactions, getSafe, getSafeService } from '../../../../utils/gnosisSafe.js';
 import { MultiProvider } from '../../../MultiProvider.js';
-import { PopulatedTransaction, PopulatedTransactions } from '../../types.js';
+import { AnnotatedEV5Transaction } from '../../../ProviderType.js';
 import { TxSubmitterType } from '../TxSubmitterTypes.js';
 
 import { EV5TxSubmitterInterface } from './EV5TxSubmitterInterface.js';
@@ -67,12 +67,12 @@ export class EV5GnosisSafeTxSubmitter implements EV5TxSubmitterInterface {
     to,
     data,
     value,
-    chainId,
-  }: PopulatedTransaction): Promise<SafeTransaction> {
+    chain,
+  }: AnnotatedEV5Transaction): Promise<SafeTransaction> {
     const nextNonce: number = await this.safeService.getNextNonce(
       this.props.safeAddress,
     );
-    const txChain = this.multiProvider.getChainName(chainId);
+    const txChain = this.multiProvider.getChainName(chain);
     assert(
       txChain === this.props.chain,
       `Invalid PopulatedTransaction: Cannot submit ${txChain} tx to ${this.props.chain} submitter.`,
@@ -83,11 +83,11 @@ export class EV5GnosisSafeTxSubmitter implements EV5TxSubmitterInterface {
     });
   }
 
-  public async submit(...txs: PopulatedTransactions): Promise<any> {
+  public async submit(...txs: AnnotatedEV5Transaction[]): Promise<any> {
     return this.proposeIndividualTransactions(txs);
   }
 
-  private async proposeIndividualTransactions(txs: PopulatedTransactions) {
+  private async proposeIndividualTransactions(txs: AnnotatedEV5Transaction[]) {
     const safeTransactions: SafeTransaction[] = [];
     for (const tx of txs) {
       const safeTransaction = await this.createSafeTransaction(tx);

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.ts
@@ -67,12 +67,11 @@ export class EV5GnosisSafeTxSubmitter implements EV5TxSubmitterInterface {
     to,
     data,
     value,
-    chain,
+    chain: txChain,
   }: AnnotatedEV5Transaction): Promise<SafeTransaction> {
     const nextNonce: number = await this.safeService.getNextNonce(
       this.props.safeAddress,
     );
-    const txChain = this.multiProvider.getChainName(chain);
     assert(
       txChain === this.props.chain,
       `Invalid PopulatedTransaction: Cannot submit ${txChain} tx to ${this.props.chain} submitter.`,

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5ImpersonatedAccountTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5ImpersonatedAccountTxSubmitter.ts
@@ -8,7 +8,7 @@ import {
   stopImpersonatingAccount,
 } from '../../../../utils/fork.js';
 import { MultiProvider } from '../../../MultiProvider.js';
-import { PopulatedTransactions } from '../../types.js';
+import { AnnotatedEV5Transaction } from '../../../ProviderType.js';
 import { TxSubmitterType } from '../TxSubmitterTypes.js';
 
 import { EV5JsonRpcTxSubmitter } from './EV5JsonRpcTxSubmitter.js';
@@ -30,7 +30,7 @@ export class EV5ImpersonatedAccountTxSubmitter extends EV5JsonRpcTxSubmitter {
   }
 
   public async submit(
-    ...txs: PopulatedTransactions
+    ...txs: AnnotatedEV5Transaction[]
   ): Promise<TransactionReceipt[]> {
     const impersonatedAccount = await impersonateAccount(
       this.props.userAddress,

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
@@ -2,10 +2,10 @@ import { TransactionReceipt } from '@ethersproject/providers';
 import { ContractReceipt } from 'ethers';
 import { Logger } from 'pino';
 
-import { assert, rootLogger } from '@hyperlane-xyz/utils';
+import { rootLogger } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../../../MultiProvider.js';
-import { PopulatedTransactions } from '../../types.js';
+import { AnnotatedEV5Transaction } from '../../../ProviderType.js';
 import { TxSubmitterType } from '../TxSubmitterTypes.js';
 
 import { EV5TxSubmitterInterface } from './EV5TxSubmitterInterface.js';
@@ -20,18 +20,17 @@ export class EV5JsonRpcTxSubmitter implements EV5TxSubmitterInterface {
   constructor(public readonly multiProvider: MultiProvider) {}
 
   public async submit(
-    ...txs: PopulatedTransactions
+    ...txs: AnnotatedEV5Transaction[]
   ): Promise<TransactionReceipt[]> {
     const receipts: TransactionReceipt[] = [];
     for (const tx of txs) {
-      assert(tx.chainId, 'Invalid PopulatedTransaction: Missing chainId field');
-      const txChain = this.multiProvider.getChainName(tx.chainId);
+      const txChain = this.multiProvider.getChainName(tx.chain);
       const receipt: ContractReceipt = await this.multiProvider.sendTransaction(
         txChain,
         tx,
       );
       this.logger.debug(
-        `Submitted PopulatedTransaction on ${txChain}: ${receipt.transactionHash}`,
+        `Submitted populated transaction on ${txChain}: ${receipt.transactionHash}`,
       );
       receipts.push(receipt);
     }

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
@@ -24,13 +24,12 @@ export class EV5JsonRpcTxSubmitter implements EV5TxSubmitterInterface {
   ): Promise<TransactionReceipt[]> {
     const receipts: TransactionReceipt[] = [];
     for (const tx of txs) {
-      const txChain = this.multiProvider.getChainName(tx.chain);
       const receipt: ContractReceipt = await this.multiProvider.sendTransaction(
-        txChain,
+        tx.chain,
         tx,
       );
       this.logger.debug(
-        `Submitted populated transaction on ${txChain}: ${receipt.transactionHash}`,
+        `Submitted populated transaction on ${tx.chain}: ${receipt.transactionHash}`,
       );
       receipts.push(receipt);
     }

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
@@ -25,7 +25,6 @@ export class EV5JsonRpcTxSubmitter implements EV5TxSubmitterInterface {
     const receipts: TransactionReceipt[] = [];
     for (const tx of txs) {
       const receipt: ContractReceipt = await this.multiProvider.sendTransaction(
-        tx.chain,
         tx,
       );
       this.logger.debug(

--- a/typescript/sdk/src/providers/transactions/transformer/ethersV5/EV5InterchainAccountTxTransformer.ts
+++ b/typescript/sdk/src/providers/transactions/transformer/ethersV5/EV5InterchainAccountTxTransformer.ts
@@ -9,11 +9,8 @@ import {
 } from '../../../../middleware/account/InterchainAccount.js';
 import { ChainName } from '../../../../types.js';
 import { MultiProvider } from '../../../MultiProvider.js';
-import {
-  CallData,
-  PopulatedTransaction,
-  PopulatedTransactions,
-} from '../../types.js';
+import { AnnotatedEV5Transaction } from '../../../ProviderType.js';
+import { CallData } from '../../types.js';
 import { TxTransformerType } from '../TxTransformerTypes.js';
 
 import { EV5TxTransformerInterface } from './EV5TxTransformerInterface.js';
@@ -39,16 +36,17 @@ export class EV5InterchainAccountTxTransformer
   }
 
   public async transform(
-    ...txs: PopulatedTransactions
+    ...txs: AnnotatedEV5Transaction[]
   ): Promise<ethers.PopulatedTransaction[]> {
     const txChainsToInnerCalls: Record<ChainName, CallData[]> = txs.reduce(
       (
         txChainToInnerCalls: Record<ChainName, CallData[]>,
-        { to, data, chainId }: PopulatedTransaction,
+        { to, data, chain }: AnnotatedEV5Transaction,
       ) => {
-        const txChain = this.multiProvider.getChainName(chainId);
-        txChainToInnerCalls[txChain] ||= [];
-        txChainToInnerCalls[txChain].push({ to, data });
+        assert(to, 'Invalid transaction: Missing "to" address');
+        assert(data, 'Invalid transaction: Missing "data"');
+        txChainToInnerCalls[chain] ||= [];
+        txChainToInnerCalls[chain].push({ to, data });
         return txChainToInnerCalls;
       },
       {},

--- a/typescript/sdk/src/providers/transactions/types.ts
+++ b/typescript/sdk/src/providers/transactions/types.ts
@@ -1,17 +1,5 @@
-import { ethers } from 'ethers';
 import { z } from 'zod';
 
-import {
-  CallDataSchema,
-  PopulatedTransactionSchema,
-  PopulatedTransactionsSchema,
-} from './schemas.js';
-
-export type PopulatedTransaction = z.infer<typeof PopulatedTransactionSchema> &
-  ethers.PopulatedTransaction;
-export type PopulatedTransactions = z.infer<
-  typeof PopulatedTransactionsSchema
-> &
-  ethers.PopulatedTransaction[];
+import { CallDataSchema } from './schemas.js';
 
 export type CallData = z.infer<typeof CallDataSchema>;

--- a/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
@@ -79,7 +79,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
 
   async function sendTxs(txs: AnnotatedEV5Transaction[]) {
     for (const tx of txs) {
-      await multiProvider.sendTransaction(chain, tx);
+      await multiProvider.sendTransaction(tx);
     }
   }
 

--- a/typescript/sdk/src/token/EvmERC20WarpModule.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.ts
@@ -7,6 +7,7 @@ import { ContractVerifier, ExplorerLicenseType } from '@hyperlane-xyz/sdk';
 import {
   Address,
   Domain,
+  EvmChainId,
   ProtocolType,
   addressToBytes32,
   assert,
@@ -42,10 +43,10 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     module: 'EvmERC20WarpModule',
   });
   reader: EvmERC20WarpRouteReader;
+
   public readonly chainName: ChainName;
-  // We use domainId here because MultiProvider.getDomainId() will always
-  // return a number, and EVM the domainId and chainId are the same.
   public readonly domainId: Domain;
+  public readonly chainId: EvmChainId;
 
   constructor(
     protected readonly multiProvider: MultiProvider,
@@ -61,6 +62,8 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     this.reader = new EvmERC20WarpRouteReader(multiProvider, args.chain);
     this.domainId = multiProvider.getDomainId(args.chain);
     this.chainName = multiProvider.getChainName(args.chain);
+    this.chainId = multiProvider.getEvmChainId(args.chain);
+
     this.contractVerifier ??= new ContractVerifier(
       multiProvider,
       {},
@@ -140,7 +143,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
       updateTransactions.push({
         chain: this.chainName,
         annotation: `Enrolling Router ${this.args.addresses.deployedTokenRoute} on ${this.args.chain}`,
-        chainId: this.domainId,
+        chainId: this.chainId,
         to: contractToUpdate.address,
         data: contractToUpdate.interface.encodeFunctionData(
           'enrollRemoteRouters',
@@ -195,7 +198,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
         updateTransactions.push({
           chain: this.chainName,
           annotation: `Setting ISM for Warp Route to ${expectedDeployedIsm}`,
-          chainId: this.domainId,
+          chainId: this.chainId,
           to: contractToUpdate.address,
           data: contractToUpdate.interface.encodeFunctionData(
             'setInterchainSecurityModule',
@@ -223,7 +226,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
       actualOwner: actualConfig.owner,
       expectedOwner: expectedConfig.owner,
       deployedAddress: this.args.addresses.deployedTokenRoute,
-      chainId: this.domainId,
+      chainId: this.chainId,
       chain: this.chainName,
     });
   }

--- a/typescript/sdk/src/token/EvmERC20WarpModule.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.ts
@@ -312,7 +312,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     if (config.remoteRouters && !isObjEmpty(config.remoteRouters)) {
       const enrollRemoteTxs = await warpModule.update(config); // @TODO Remove when EvmERC20WarpModule.create can be used
       const onlyTxIndex = 0;
-      await multiProvider.sendTransaction(chain, enrollRemoteTxs[onlyTxIndex]);
+      await multiProvider.sendTransaction(enrollRemoteTxs[onlyTxIndex]);
     }
 
     return warpModule;

--- a/typescript/sdk/src/token/EvmERC20WarpModule.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.ts
@@ -25,7 +25,7 @@ import { EvmIsmModule } from '../ism/EvmIsmModule.js';
 import { DerivedIsmConfig } from '../ism/EvmIsmReader.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
-import { ChainName, ChainNameOrId } from '../types.js';
+import { ChainName, ChainNameOrDomain } from '../types.js';
 import { normalizeConfig } from '../utils/ism.js';
 
 import { EvmERC20WarpRouteReader } from './EvmERC20WarpRouteReader.js';
@@ -287,7 +287,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
    * @returns A new instance of the EvmERC20WarpHyperlaneModule.
    */
   public static async create(params: {
-    chain: ChainNameOrId;
+    chain: ChainNameOrDomain;
     config: TokenRouterConfig;
     multiProvider: MultiProvider;
     contractVerifier?: ContractVerifier;

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -24,7 +24,7 @@ import { EvmHookReader } from '../hook/EvmHookReader.js';
 import { EvmIsmReader } from '../ism/EvmIsmReader.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { RemoteRouters } from '../router/types.js';
-import { ChainNameOrId } from '../types.js';
+import { ChainNameOrDomain } from '../types.js';
 import { HyperlaneReader } from '../utils/HyperlaneReader.js';
 
 import { CollateralExtensions } from './config.js';
@@ -39,7 +39,7 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
 
   constructor(
     protected readonly multiProvider: MultiProvider,
-    protected readonly chain: ChainNameOrId,
+    protected readonly chain: ChainNameOrDomain,
     protected readonly concurrency: number = DEFAULT_CONTRACT_READ_CONCURRENCY,
   ) {
     super(multiProvider, chain);

--- a/typescript/sdk/src/types.ts
+++ b/typescript/sdk/src/types.ts
@@ -1,12 +1,12 @@
 import type { ethers } from 'ethers';
 
-import type { ChainId, Domain } from '@hyperlane-xyz/utils';
+import type { Domain } from '@hyperlane-xyz/utils';
 
 // An alias for string to clarify type is a chain name
 export type ChainName = string;
 // A map of chain names to a value type
 export type ChainMap<Value> = Record<string, Value>;
 
-export type ChainNameOrId = ChainName | ChainId | Domain;
+export type ChainNameOrId = ChainName | Domain;
 
 export type Connection = ethers.providers.Provider | ethers.Signer;

--- a/typescript/sdk/src/types.ts
+++ b/typescript/sdk/src/types.ts
@@ -7,6 +7,6 @@ export type ChainName = string;
 // A map of chain names to a value type
 export type ChainMap<Value> = Record<string, Value>;
 
-export type ChainNameOrId = ChainName | Domain;
+export type ChainNameOrDomain = ChainName | Domain;
 
 export type Connection = ethers.providers.Provider | ethers.Signer;

--- a/typescript/sdk/src/utils/HyperlaneReader.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.ts
@@ -3,14 +3,14 @@ import { LevelWithSilentOrString } from 'pino';
 
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { HyperlaneSmartProvider } from '../providers/SmartProvider/SmartProvider.js';
-import { ChainNameOrId } from '../types.js';
+import { ChainNameOrDomain } from '../types.js';
 
 export class HyperlaneReader {
   provider: providers.Provider;
 
   constructor(
     protected readonly multiProvider: MultiProvider,
-    protected readonly chain: ChainNameOrId,
+    protected readonly chain: ChainNameOrDomain,
   ) {
     this.provider = this.multiProvider.getProvider(chain);
   }

--- a/typescript/sdk/src/utils/gnosisSafe.js
+++ b/typescript/sdk/src/utils/gnosisSafe.js
@@ -48,8 +48,8 @@ export async function getSafe(chain, multiProvider, safeAddress) {
   const signer = multiProvider.getSigner(chain);
   const ethAdapter = new EthersAdapter({ ethers, signerOrProvider: signer });
 
-  // Get the domain id for the given chain
-  const domainId = multiProvider.getDomainId(chain);
+  // Get the chain id of the given chain
+  const chainId = multiProvider.getChainId(chain);
 
   // Get the safe version
   const safeService = getSafeService(chain, multiProvider);
@@ -66,11 +66,11 @@ export async function getSafe(chain, multiProvider, safeAddress) {
       safeDeploymentsVersions[safeVersion];
     multiSend = getMultiSendDeployment({
       version: multiSendVersion,
-      network: domainId,
+      network: chainId,
     });
     multiSendCallOnly = getMultiSendCallOnlyDeployment({
       version: multiSendCallOnlyVersion,
-      network: domainId,
+      network: chainId,
     });
   }
 
@@ -78,13 +78,12 @@ export async function getSafe(chain, multiProvider, safeAddress) {
     ethAdapter,
     safeAddress,
     contractNetworks: {
-      // DomainId == ChainId for EVM Chains
-      [domainId]: {
+      [chainId]: {
         // Use the safe address for multiSendAddress and multiSendCallOnlyAddress
         // if the contract is not deployed or if the version is not found.
-        multiSendAddress: multiSend?.networkAddresses[domainId] || safeAddress,
+        multiSendAddress: multiSend?.networkAddresses[chainId] || safeAddress,
         multiSendCallOnlyAddress:
-          multiSendCallOnly?.networkAddresses[domainId] || safeAddress,
+          multiSendCallOnly?.networkAddresses[chainId] || safeAddress,
       },
     },
   });

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -29,7 +29,7 @@ import {
 } from '../token/TokenStandard.js';
 import { EVM_TRANSFER_REMOTE_GAS_ESTIMATE } from '../token/adapters/EvmTokenAdapter.js';
 import { IHypXERC20Adapter } from '../token/adapters/ITokenAdapter.js';
-import { ChainName, ChainNameOrId } from '../types.js';
+import { ChainName, ChainNameOrDomain } from '../types.js';
 
 import {
   FeeConstantConfig,
@@ -125,7 +125,7 @@ export class WarpCore {
     destination,
   }: {
     originToken: IToken;
-    destination: ChainNameOrId;
+    destination: ChainNameOrDomain;
   }): Promise<TokenAmount> {
     this.logger.debug(`Fetching interchain transfer quote to ${destination}`);
     const { chainName: originName } = originToken;
@@ -183,7 +183,7 @@ export class WarpCore {
     interchainFee,
   }: {
     originToken: IToken;
-    destination: ChainNameOrId;
+    destination: ChainNameOrDomain;
     sender: Address;
     senderPubKey?: HexString;
     interchainFee?: TokenAmount;
@@ -223,7 +223,7 @@ export class WarpCore {
     if (txs.length === 1) {
       try {
         return this.multiProvider.estimateTransactionFee({
-          chainNameOrId: originMetadata.name,
+          chainNameOrDomain: originMetadata.name,
           transaction: txs[0],
           sender,
           senderPubKey,
@@ -270,7 +270,7 @@ export class WarpCore {
     interchainFee,
   }: {
     originToken: IToken;
-    destination: ChainNameOrId;
+    destination: ChainNameOrDomain;
     sender: Address;
     senderPubKey?: HexString;
     interchainFee?: TokenAmount;
@@ -312,7 +312,7 @@ export class WarpCore {
     interchainFee,
   }: {
     originTokenAmount: TokenAmount;
-    destination: ChainNameOrId;
+    destination: ChainNameOrDomain;
     sender: Address;
     recipient: Address;
     interchainFee?: TokenAmount;
@@ -380,7 +380,7 @@ export class WarpCore {
     senderPubKey,
   }: {
     originToken: IToken;
-    destination: ChainNameOrId;
+    destination: ChainNameOrDomain;
     sender: Address;
     senderPubKey?: HexString;
   }): Promise<WarpCoreFeeEstimate> {
@@ -420,7 +420,7 @@ export class WarpCore {
     feeEstimate,
   }: {
     balance: TokenAmount;
-    destination: ChainNameOrId;
+    destination: ChainNameOrDomain;
     sender: Address;
     senderPubKey?: HexString;
     feeEstimate?: WarpCoreFeeEstimate;
@@ -458,7 +458,7 @@ export class WarpCore {
     destination,
   }: {
     originTokenAmount: TokenAmount;
-    destination: ChainNameOrId;
+    destination: ChainNameOrDomain;
   }): Promise<boolean> {
     const { token: originToken, amount } = originTokenAmount;
     const destinationName = this.multiProvider.getChainName(destination);
@@ -547,7 +547,7 @@ export class WarpCore {
     senderPubKey,
   }: {
     originTokenAmount: TokenAmount;
-    destination: ChainNameOrId;
+    destination: ChainNameOrDomain;
     recipient: Address;
     sender: Address;
     senderPubKey?: HexString;
@@ -590,8 +590,8 @@ export class WarpCore {
    * Ensure the origin and destination chains are valid and known by this WarpCore
    */
   protected validateChains(
-    origin: ChainNameOrId,
-    destination: ChainNameOrId,
+    origin: ChainNameOrDomain,
+    destination: ChainNameOrDomain,
   ): Record<string, string> | null {
     if (!origin) return { origin: 'Origin chain required' };
     if (!destination) return { destination: 'Destination chain required' };
@@ -618,7 +618,7 @@ export class WarpCore {
    */
   protected validateRecipient(
     recipient: Address,
-    destination: ChainNameOrId,
+    destination: ChainNameOrDomain,
   ): Record<string, string> | null {
     const destinationMetadata =
       this.multiProvider.getChainMetadata(destination);
@@ -658,7 +658,7 @@ export class WarpCore {
    */
   protected async validateTokenBalances(
     originTokenAmount: TokenAmount,
-    destination: ChainNameOrId,
+    destination: ChainNameOrDomain,
     sender: Address,
     senderPubKey?: HexString,
   ): Promise<Record<string, string> | null> {
@@ -722,7 +722,7 @@ export class WarpCore {
    */
   protected async validateDestinationCollateral(
     originTokenAmount: TokenAmount,
-    destination: ChainNameOrId,
+    destination: ChainNameOrDomain,
   ): Promise<Record<string, string> | null> {
     const valid = await this.isDestinationCollateralSufficient({
       originTokenAmount,

--- a/typescript/utils/src/index.ts
+++ b/typescript/utils/src/index.ts
@@ -140,6 +140,7 @@ export {
   Checkpoint,
   CheckpointWithId,
   Domain,
+  EvmChainId,
   HexString,
   MerkleProof,
   MessageStatus,

--- a/typescript/utils/src/types.ts
+++ b/typescript/utils/src/types.ts
@@ -114,5 +114,6 @@ export type ParsedLegacyMultisigIsmMetadata = {
 };
 
 export type Annotated<T> = T & {
+  chain: string; // TODO: Change to ChainName after moving to SDK from Utils
   annotation?: string;
 };

--- a/typescript/utils/src/types.ts
+++ b/typescript/utils/src/types.ts
@@ -18,6 +18,7 @@ export const ProtocolSmallestUnit = {
 
 /********* BASIC TYPES *********/
 export type Domain = number;
+export type EvmChainId = number;
 export type ChainId = string | number;
 export type Address = string;
 export type AddressBytes32 = string;


### PR DESCRIPTION
### Description

This PR serves as a spike, not intended (atm) to be merged.

The problem has surfaced twice now of multiple chains reusing the same chainid:
	- celo classic testnet & celo L2 testnet
	- molten & shape

This PR allows the set of chain metadata to include unique chains/domains that share the same chainId under the hood. This required changes in multiple places where we assumed that the domainId/chainId would be the same for EVM chains (no such assumption was made on other EVMs).

Touches:
- evm core/ism/hook/warp modules
- multiprovider + chain metadata manager
- safe service
- renaming `ChainNameOrId` to `ChainNameOrDomain` (where bulk of the diff comes from)

### Drive-by changes

- since we now provide the `chain` as part of an annotated tx, we can simplify the `sendTransaction` call to one argument

### Related issues

https://www.notion.so/hyperlanexyz/Shape-Molten-Chain-ID-Clash-1156d35200d6806db7d7dc62a95c8085

### Backward compatibility

no

### Testing

ci