### PR TITLE
feat: Dispatch messages before and after start of the agents

### DIFF
--- a/rust/main/utils/run-locally/src/cosmos/mod.rs
+++ b/rust/main/utils/run-locally/src/cosmos/mod.rs
@@ -574,7 +574,7 @@ fn run_locally() {
     }
 }
 
-fn dispatch(osmosisd: &PathBuf, linker: &str, nodes: &Vec<CosmosNetwork>) -> u32 {
+fn dispatch(osmosisd: &Path, linker: &str, nodes: &[CosmosNetwork]) -> u32 {
     let mut dispatched_messages = 0;
     for node in nodes.iter() {
         let targets = nodes
@@ -593,7 +593,7 @@ fn dispatch(osmosisd: &PathBuf, linker: &str, nodes: &Vec<CosmosNetwork>) -> u32
         for target in targets {
             dispatched_messages += 1;
             let cli = OsmosisCLI::new(
-                osmosisd.clone(),
+                osmosisd.to_path_buf(),
                 node.launch_resp.home_path.to_str().unwrap(),
             );
 


### PR DESCRIPTION
### Description

Dispatch messages before and after start of the agents so that we test both forward and backward looking sequence based indexers.

### Related issues

- Successfully scrape Cosmos chains in e2e test #3355

### Backward compatibility

Yes

### Testing

- E2E Cosmos Test
- Manual check on E2E Cosmos Test logs
