### PR TITLE
fix(CLI): do not double info log approval requirement

### DIFF
--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -528,7 +528,7 @@ export class WarpCore {
       token.addressOrDenom,
       amount,
     );
-    this.logger.info(
+    this.logger.debug(
       `Approval is${isRequired ? '' : ' not'} required for transfer of ${
         token.symbol
       }`,


### PR DESCRIPTION
### Description

Got this log during `warp send`

```
Approval is required for transfer of deUSD
Approval required for transfer of deUSD
Approval is required for transfer of deUSD
Approval required for transfer of deUSD
```
