### PR TITLE
fix: write merkle & IGP hook addresses if created by core deploy

### DIFF
--- a/typescript/sdk/src/core/EvmCoreModule.hardhat-test.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.hardhat-test.ts
@@ -105,10 +105,12 @@ describe('EvmCoreModule', async () => {
     });
 
     it('should deploy ISM factories', () => {
-      // Each ISM factory
-      const deployedContracts = evmCoreModule.serialize();
+      // Each ISM factory is a contract that is deployed by the core module
+      // Ignore IGP because it's not part of the default config
+      const { interchainGasPaymaster: _, ...coreContracts } =
+        evmCoreModule.serialize();
 
-      objMap(deployedContracts as any, (_, address) => {
+      objMap(coreContracts as any, (name, address) => {
         expect(address).to.exist;
         expect(address).to.not.equal(constants.AddressZero);
       });

--- a/typescript/sdk/src/core/EvmCoreModule.hardhat-test.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.hardhat-test.ts
@@ -110,7 +110,7 @@ describe('EvmCoreModule', async () => {
       const { interchainGasPaymaster: _, ...coreContracts } =
         evmCoreModule.serialize();
 
-      objMap(coreContracts as any, (name, address) => {
+      objMap(coreContracts as any, (_, address) => {
         expect(address).to.exist;
         expect(address).to.not.equal(constants.AddressZero);
       });

--- a/typescript/sdk/src/core/EvmCoreModule.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.ts
@@ -11,7 +11,10 @@ import {
   attachContractsMap,
   serializeContractsMap,
 } from '../contracts/contracts.js';
-import { HyperlaneAddresses } from '../contracts/types.js';
+import {
+  HyperlaneAddresses,
+  HyperlaneContractsMap,
+} from '../contracts/types.js';
 import { DeployedCoreAddresses } from '../core/schemas.js';
 import { CoreConfig } from '../core/types.js';
 import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDeployer.js';
@@ -20,6 +23,7 @@ import {
   proxyFactoryFactories,
 } from '../deploy/contracts.js';
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
+import { HookFactories } from '../hook/contracts.js';
 import { EvmIsmModule } from '../ism/EvmIsmModule.js';
 import { DerivedIsmConfig } from '../ism/EvmIsmReader.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
@@ -35,6 +39,7 @@ import {
 import { EvmCoreReader } from './EvmCoreReader.js';
 import { EvmIcaModule } from './EvmIcaModule.js';
 import { HyperlaneCoreDeployer } from './HyperlaneCoreDeployer.js';
+import { CoreFactories } from './contracts.js';
 import { CoreConfigSchema } from './schemas.js';
 
 export class EvmCoreModule extends HyperlaneModule<
@@ -315,9 +320,20 @@ export class EvmCoreModule extends HyperlaneModule<
       )
     ).address;
 
+    // Obtain addresses of every contract created by the deployer
+    // and extract only the merkleTreeHook and interchainGasPaymaster
+    const serializedContracts = serializeContractsMap(
+      coreDeployer.deployedContracts as HyperlaneContractsMap<
+        CoreFactories & HookFactories
+      >,
+    );
+    const { merkleTreeHook, interchainGasPaymaster } =
+      serializedContracts[chainName];
+
     // Set Core & extra addresses
     return {
       ...ismFactoryFactories,
+
       proxyAdmin,
       mailbox: mailbox.address,
       interchainAccountRouter,
@@ -325,6 +341,8 @@ export class EvmCoreModule extends HyperlaneModule<
       validatorAnnounce,
       timelockController,
       testRecipient,
+      merkleTreeHook,
+      interchainGasPaymaster,
     };
   }
 

--- a/typescript/sdk/src/core/schemas.ts
+++ b/typescript/sdk/src/core/schemas.ts
@@ -19,6 +19,8 @@ export const DeployedCoreAddressesSchema = ProxyFactoryFactoriesSchema.extend({
   timelockController: z.string().optional(),
   interchainAccountRouter: z.string(),
   interchainAccountIsm: z.string(),
+  merkleTreeHook: z.string().optional(),
+  interchainGasPaymaster: z.string().optional(),
 });
 
 export type DeployedCoreAddresses = z.infer<typeof DeployedCoreAddressesSchema>;


### PR DESCRIPTION
### Description

original:
there was a series of related problems that people are encountering with cli deploys where the merkleTreeHook is deployed but its address is not included in the artifacts. this PR was intended to bring parity with how infra does it, we can also update for now to only add the merkleTreeHook to the output to unblock the base problem people are having

update:
restricted to just `merkleTreeHook` and `interchainGasPaymaster` to provide MVP fix

![image](https://github.com/user-attachments/assets/9f38c3a8-5240-4cbe-a224-161a7a4da8af)

### Related issues

https://github.com/hyperlane-xyz/hyperlane-registry/pull/240#discussion_r1784297872
https://github.com/hyperlane-xyz/hyperlane-registry/pull/236#issuecomment-2383922133
https://github.com/hyperlane-xyz/hyperlane-registry/pull/237#discussion_r1782564051

### Backward compatibility

yes

### Testing

manual


