### PR TITLE
feat: include `id` field in `list_operations` endpoint

### DIFF
--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -145,6 +145,10 @@ pub mod test {
                 destination_domain,
             }
         }
+
+        pub fn with_id(self, id: H256) -> Self {
+            Self { id, ..self }
+        }
     }
 
     impl TryBatchAs<HyperlaneMessage> for MockPendingOperation {}

--- a/rust/main/agents/relayer/src/server/list_messages.rs
+++ b/rust/main/agents/relayer/src/server/list_messages.rs
@@ -59,10 +59,7 @@ pub async fn format_queue(queue: OperationPriorityQueue) -> String {
         .lock()
         .await
         .iter()
-        .map(|reverse| {
-            // let t =
-            serde_json::to_value(OperationWithId::new(&reverse.0))
-        })
+        .map(|reverse| serde_json::to_value(OperationWithId::new(&reverse.0)))
         .collect();
     match res.and_then(|v| serde_json::to_string_pretty(&v)) {
         Ok(s) => s,

--- a/rust/main/agents/relayer/src/server/list_messages.rs
+++ b/rust/main/agents/relayer/src/server/list_messages.rs
@@ -133,6 +133,9 @@ mod tests {
             MockPendingOperation::new(2, DUMMY_DOMAIN.into())
                 .with_id(H256::from_str(id_2).unwrap()),
         ) as QueueOperation;
+
+        // The reason there already is an id inside `operation` here is because it's a field on `MockPendingOperation` - that field is
+        // missing on `PendingMessage` because it's derived, hence the need to hence the need to have it explicitly serialized alongside the operation.
         let expected_response = r#"[
   {
     "id": "0x1acbee9798118b11ebef0d94b0a2936eafd58e3bfab91b05da875825c4a1c39b",


### PR DESCRIPTION
### Description

The `id` field was missing if the serialized `PendingOperation` was a `PendingMessage`, which made it hard to look up the message in relayer logs or the explorer. This PR takes advantage of `id()` being a required method on `PendingOperation` to derive and display the ID as part of endpoint logic.

### Testing

Unit Tests

