### PR TITLE
feat(warpChecker): Support Renzo PZETH route

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
@@ -17,19 +17,3 @@ export enum WarpRouteIds {
   InevmInjectiveINJ = 'INJ/inevm-injective',
   MantapacificNeutronTIA = 'TIA/mantapacific-neutron',
 }
-
-// add new warp route ids here if they are supported by the checker tooling, add an entry to warpConfigGetterMap also
-export enum CheckerWarpRouteIds {
-  Ancient8EthereumUSDC = WarpRouteIds.Ancient8EthereumUSDC,
-  ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismSeiTaikoZircuitEZETH = WarpRouteIds.ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismSeiTaikoZircuitEZETH,
-  ArbitrumNeutronEclip = WarpRouteIds.ArbitrumNeutronEclip,
-  ArbitrumNeutronTIA = WarpRouteIds.ArbitrumNeutronTIA,
-  EthereumInevmUSDC = WarpRouteIds.EthereumInevmUSDC,
-  EthereumInevmUSDT = WarpRouteIds.EthereumInevmUSDT,
-  EthereumVictionETH = WarpRouteIds.EthereumVictionETH,
-  EthereumVictionUSDC = WarpRouteIds.EthereumVictionUSDC,
-  EthereumVictionUSDT = WarpRouteIds.EthereumVictionUSDT,
-  EthereumZircuitPZETH = WarpRouteIds.EthereumZircuitPZETH,
-  InevmInjectiveINJ = WarpRouteIds.InevmInjectiveINJ,
-  MantapacificNeutronTIA = WarpRouteIds.MantapacificNeutronTIA,
-}

--- a/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
@@ -21,7 +21,7 @@ export enum WarpRouteIds {
 // add new warp route ids here if they are supported by the checker tooling, add an entry to warpConfigGetterMap also
 export enum CheckerWarpRouteIds {
   Ancient8EthereumUSDC = WarpRouteIds.Ancient8EthereumUSDC,
-  ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismZircuitEZETH = WarpRouteIds.ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismZircuitEZETH,
+  ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismSeiTaikoZircuitEZETH = WarpRouteIds.ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismSeiTaikoZircuitEZETH,
   ArbitrumNeutronEclip = WarpRouteIds.ArbitrumNeutronEclip,
   ArbitrumNeutronTIA = WarpRouteIds.ArbitrumNeutronTIA,
   EthereumInevmUSDC = WarpRouteIds.EthereumInevmUSDC,

--- a/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
@@ -13,6 +13,23 @@ export enum WarpRouteIds {
   EthereumVictionETH = 'ETH/ethereum-viction',
   EthereumVictionUSDC = 'USDC/ethereum-viction',
   EthereumVictionUSDT = 'USDT/ethereum-viction',
+  EthereumZircuitPZETH = 'PZETH/ethereum-zircuit',
   InevmInjectiveINJ = 'INJ/inevm-injective',
   MantapacificNeutronTIA = 'TIA/mantapacific-neutron',
+}
+
+// add new warp route ids here if they are supported by the checker tooling, add an entry to warpConfigGetterMap also
+export enum CheckerWarpRouteIds {
+  Ancient8EthereumUSDC = WarpRouteIds.Ancient8EthereumUSDC,
+  ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismZircuitEZETH = WarpRouteIds.ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismZircuitEZETH,
+  ArbitrumNeutronEclip = WarpRouteIds.ArbitrumNeutronEclip,
+  ArbitrumNeutronTIA = WarpRouteIds.ArbitrumNeutronTIA,
+  EthereumInevmUSDC = WarpRouteIds.EthereumInevmUSDC,
+  EthereumInevmUSDT = WarpRouteIds.EthereumInevmUSDT,
+  EthereumVictionETH = WarpRouteIds.EthereumVictionETH,
+  EthereumVictionUSDC = WarpRouteIds.EthereumVictionUSDC,
+  EthereumVictionUSDT = WarpRouteIds.EthereumVictionUSDT,
+  EthereumZircuitPZETH = WarpRouteIds.EthereumZircuitPZETH,
+  InevmInjectiveINJ = WarpRouteIds.InevmInjectiveINJ,
+  MantapacificNeutronTIA = WarpRouteIds.MantapacificNeutronTIA,
 }

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -45,8 +45,8 @@ export const warpConfigGetterMap: Record<
   [WarpRouteIds.EthereumVictionETH]: getEthereumVictionETHWarpConfig,
   [WarpRouteIds.EthereumVictionUSDC]: getEthereumVictionUSDCWarpConfig,
   [WarpRouteIds.EthereumVictionUSDT]: getEthereumVictionUSDTWarpConfig,
-  [WarpRouteIds.MantapacificNeutronTIA]: getMantapacificNeutronTiaWarpConfig,
   [WarpRouteIds.EthereumZircuitPZETH]: getRenzoPZETHWarpConfig,
+  [WarpRouteIds.MantapacificNeutronTIA]: getMantapacificNeutronTiaWarpConfig,
 };
 
 export async function getWarpConfig(

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -21,7 +21,7 @@ import { getInevmInjectiveINJWarpConfig } from './environments/mainnet3/warp/con
 import { getMantapacificNeutronTiaWarpConfig } from './environments/mainnet3/warp/configGetters/getMantapacificNeutronTiaWarpConfig.js';
 import { getRenzoEZETHWarpConfig } from './environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.js';
 import { getRenzoPZETHWarpConfig } from './environments/mainnet3/warp/configGetters/getRenzoPZETHWarpConfig.js';
-import { CheckerWarpRouteIds } from './environments/mainnet3/warp/warpIds.js';
+import { WarpRouteIds } from './environments/mainnet3/warp/warpIds.js';
 
 type WarpConfigGetterWithConfig = (
   routerConfig: ChainMap<RouterConfig>,
@@ -33,21 +33,20 @@ export const warpConfigGetterMap: Record<
   string,
   WarpConfigGetterWithConfig | WarpConfigGetterWithoutConfig
 > = {
-  [CheckerWarpRouteIds.Ancient8EthereumUSDC]: getAncient8EthereumUSDCWarpConfig,
-  [CheckerWarpRouteIds.EthereumInevmUSDC]: getEthereumInevmUSDCWarpConfig,
-  [CheckerWarpRouteIds.EthereumInevmUSDT]: getEthereumInevmUSDTWarpConfig,
-  [CheckerWarpRouteIds.ArbitrumNeutronEclip]: getArbitrumNeutronEclipWarpConfig,
-  [CheckerWarpRouteIds.ArbitrumNeutronTIA]: getArbitrumNeutronTiaWarpConfig,
-  [CheckerWarpRouteIds.ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismSeiTaikoZircuitEZETH]:
+  [WarpRouteIds.Ancient8EthereumUSDC]: getAncient8EthereumUSDCWarpConfig,
+  [WarpRouteIds.EthereumInevmUSDC]: getEthereumInevmUSDCWarpConfig,
+  [WarpRouteIds.EthereumInevmUSDT]: getEthereumInevmUSDTWarpConfig,
+  [WarpRouteIds.ArbitrumNeutronEclip]: getArbitrumNeutronEclipWarpConfig,
+  [WarpRouteIds.ArbitrumNeutronTIA]: getArbitrumNeutronTiaWarpConfig,
+  [WarpRouteIds.ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismSeiTaikoZircuitEZETH]:
     getRenzoEZETHWarpConfig,
   [WarpRouteIds.InevmInjectiveINJ]: getInevmInjectiveINJWarpConfig,
-  [WarpRouteIds.EthereumEclipseTETH]: getEthereumEclipseTETHWarpConfig,
-  [WarpRouteIds.EthereumEclipseUSDC]: getEthereumEclipseUSDCWarpConfig,
   [WarpRouteIds.EthereumSeiFastUSD]: getEthereumSeiFastUSDWarpConfig,
   [WarpRouteIds.EthereumVictionETH]: getEthereumVictionETHWarpConfig,
   [WarpRouteIds.EthereumVictionUSDC]: getEthereumVictionUSDCWarpConfig,
   [WarpRouteIds.EthereumVictionUSDT]: getEthereumVictionUSDTWarpConfig,
   [WarpRouteIds.MantapacificNeutronTIA]: getMantapacificNeutronTiaWarpConfig,
+  [WarpRouteIds.EthereumZircuitPZETH]: getRenzoPZETHWarpConfig,
 };
 
 export async function getWarpConfig(

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -22,7 +22,8 @@ import { getEthereumVictionUSDTWarpConfig } from './environments/mainnet3/warp/c
 import { getInevmInjectiveINJWarpConfig } from './environments/mainnet3/warp/configGetters/getInevmInjectiveINJWarpConfig.js';
 import { getMantapacificNeutronTiaWarpConfig } from './environments/mainnet3/warp/configGetters/getMantapacificNeutronTiaWarpConfig.js';
 import { getRenzoEZETHWarpConfig } from './environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.js';
-import { WarpRouteIds } from './environments/mainnet3/warp/warpIds.js';
+import { getRenzoPZETHWarpConfig } from './environments/mainnet3/warp/configGetters/getRenzoPZETHWarpConfig.js';
+import { CheckerWarpRouteIds } from './environments/mainnet3/warp/warpIds.js';
 
 type WarpConfigGetterWithConfig = (
   routerConfig: ChainMap<RouterConfig>,
@@ -34,12 +35,12 @@ export const warpConfigGetterMap: Record<
   string,
   WarpConfigGetterWithConfig | WarpConfigGetterWithoutConfig
 > = {
-  [WarpRouteIds.Ancient8EthereumUSDC]: getAncient8EthereumUSDCWarpConfig,
-  [WarpRouteIds.EthereumInevmUSDC]: getEthereumInevmUSDCWarpConfig,
-  [WarpRouteIds.EthereumInevmUSDT]: getEthereumInevmUSDTWarpConfig,
-  [WarpRouteIds.ArbitrumNeutronEclip]: getArbitrumNeutronEclipWarpConfig,
-  [WarpRouteIds.ArbitrumNeutronTIA]: getArbitrumNeutronTiaWarpConfig,
-  [WarpRouteIds.ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismSeiTaikoZircuitEZETH]:
+  [CheckerWarpRouteIds.Ancient8EthereumUSDC]: getAncient8EthereumUSDCWarpConfig,
+  [CheckerWarpRouteIds.EthereumInevmUSDC]: getEthereumInevmUSDCWarpConfig,
+  [CheckerWarpRouteIds.EthereumInevmUSDT]: getEthereumInevmUSDTWarpConfig,
+  [CheckerWarpRouteIds.ArbitrumNeutronEclip]: getArbitrumNeutronEclipWarpConfig,
+  [CheckerWarpRouteIds.ArbitrumNeutronTIA]: getArbitrumNeutronTiaWarpConfig,
+  [CheckerWarpRouteIds.ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismZircuitEZETH]:
     getRenzoEZETHWarpConfig,
   [WarpRouteIds.InevmInjectiveINJ]: getInevmInjectiveINJWarpConfig,
   [WarpRouteIds.EthereumEclipseTETH]: getEthereumEclipseTETHWarpConfig,

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -11,8 +11,6 @@ import { EnvironmentConfig } from '../src/config/environment.js';
 import { getAncient8EthereumUSDCWarpConfig } from './environments/mainnet3/warp/configGetters/getAncient8EthereumUSDCWarpConfig.js';
 import { getArbitrumNeutronEclipWarpConfig } from './environments/mainnet3/warp/configGetters/getArbitrumNeutronEclipWarpConfig.js';
 import { getArbitrumNeutronTiaWarpConfig } from './environments/mainnet3/warp/configGetters/getArbitrumNeutronTiaWarpConfig.js';
-import { getEthereumEclipseTETHWarpConfig } from './environments/mainnet3/warp/configGetters/getEthereumEclipseTETHWarpConfig.js';
-import { getEthereumEclipseUSDCWarpConfig } from './environments/mainnet3/warp/configGetters/getEthereumEclipseUSDCWarpConfig.js';
 import { getEthereumInevmUSDCWarpConfig } from './environments/mainnet3/warp/configGetters/getEthereumInevmUSDCWarpConfig.js';
 import { getEthereumInevmUSDTWarpConfig } from './environments/mainnet3/warp/configGetters/getEthereumInevmUSDTWarpConfig.js';
 import { getEthereumSeiFastUSDWarpConfig } from './environments/mainnet3/warp/configGetters/getEthereumSeiFastUSDWarpConfig.js';
@@ -40,7 +38,7 @@ export const warpConfigGetterMap: Record<
   [CheckerWarpRouteIds.EthereumInevmUSDT]: getEthereumInevmUSDTWarpConfig,
   [CheckerWarpRouteIds.ArbitrumNeutronEclip]: getArbitrumNeutronEclipWarpConfig,
   [CheckerWarpRouteIds.ArbitrumNeutronTIA]: getArbitrumNeutronTiaWarpConfig,
-  [CheckerWarpRouteIds.ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismZircuitEZETH]:
+  [CheckerWarpRouteIds.ArbitrumBaseBlastBscEthereumFraxtalLineaModeOptimismSeiTaikoZircuitEZETH]:
     getRenzoEZETHWarpConfig,
   [WarpRouteIds.InevmInjectiveINJ]: getInevmInjectiveINJWarpConfig,
   [WarpRouteIds.EthereumEclipseTETH]: getEthereumEclipseTETHWarpConfig,

--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { Gauge, Registry } from 'prom-client';
 
-import { WarpRouteIds } from '../../config/environments/mainnet3/warp/warpIds.js';
+import { CheckerWarpRouteIds } from '../../config/environments/mainnet3/warp/warpIds.js';
 import { submitMetrics } from '../../src/utils/metrics.js';
 import { Modules } from '../agent-utils.js';
 
@@ -25,7 +25,7 @@ async function main() {
   const failedWarpRoutesChecks: string[] = [];
 
   // TODO: consider retrying this if check throws an error
-  for (const warpRouteId of Object.values(WarpRouteIds)) {
+  for (const warpRouteId of Object.values(CheckerWarpRouteIds)) {
     console.log(`\nChecking warp route ${warpRouteId}...`);
     const warpModule = Modules.WARP;
 

--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { Gauge, Registry } from 'prom-client';
 
-import { CheckerWarpRouteIds } from '../../config/environments/mainnet3/warp/warpIds.js';
+import { warpConfigGetterMap } from '../../config/warp.js';
 import { submitMetrics } from '../../src/utils/metrics.js';
 import { Modules } from '../agent-utils.js';
 
@@ -25,7 +25,7 @@ async function main() {
   const failedWarpRoutesChecks: string[] = [];
 
   // TODO: consider retrying this if check throws an error
-  for (const warpRouteId of Object.values(CheckerWarpRouteIds)) {
+  for (const warpRouteId of Object.keys(warpConfigGetterMap)) {
     console.log(`\nChecking warp route ${warpRouteId}...`);
     const warpModule = Modules.WARP;
 


### PR DESCRIPTION
### Description

- support Renzo PZETH warp route in checker

### Drive-by changes

- introduce `CheckerWarpRouteIds` enum for warp routes that are supported in the checker, eclipse and sol routes are not currently supported


### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->

Manual
