### PR TITLE
fix(cli): rollback gnosis tx builder protocol type

### DIFF
--- a/typescript/sdk/src/providers/ProviderType.ts
+++ b/typescript/sdk/src/providers/ProviderType.ts
@@ -5,7 +5,6 @@ import type {
 } from '@cosmjs/cosmwasm-stargate';
 import type { EncodeObject as CmTransaction } from '@cosmjs/proto-signing';
 import type { DeliverTxResponse, StargateClient } from '@cosmjs/stargate';
-import { SafeTransactionData } from '@safe-global/safe-core-sdk-types';
 import type {
   Connection,
   Transaction as SolTransaction,
@@ -39,7 +38,6 @@ export const PROTOCOL_TO_DEFAULT_PROVIDER_TYPE: Record<
   ProviderType
 > = {
   [ProtocolType.Ethereum]: ProviderType.EthersV5,
-  [ProtocolType.GnosisTxBuilder]: ProviderType.EthersV5,
   [ProtocolType.Sealevel]: ProviderType.SolanaWeb3,
   [ProtocolType.Cosmos]: ProviderType.CosmJsWasm,
 };
@@ -52,12 +50,6 @@ type ProtocolTypesMapping = {
     provider: EthersV5Provider;
     contract: EthersV5Contract;
     receipt: EthersV5TransactionReceipt;
-  };
-  [ProtocolType.GnosisTxBuilder]: {
-    transaction: EthersV5Transaction;
-    provider: EthersV5Provider;
-    contract: EthersV5Contract;
-    receipt: GnosisTransactionBuilderReceipt;
   };
   [ProtocolType.Sealevel]: {
     transaction: SolanaWeb3Transaction;
@@ -265,19 +257,6 @@ export interface CosmJsTransactionReceipt
   extends TypedTransactionReceiptBase<DeliverTxResponse> {
   type: ProviderType.CosmJs;
   receipt: DeliverTxResponse;
-}
-
-export interface GnosisTransactionBuilderReceipt
-  extends TypedTransactionReceiptBase<GnosisTransactionBuilderPayload> {
-  type: ProviderType.GnosisTxBuilder;
-  receipt: GnosisTransactionBuilderPayload;
-}
-
-export interface GnosisTransactionBuilderPayload {
-  version: string;
-  chainId: string;
-  meta: {};
-  transactions: SafeTransactionData[];
 }
 
 export interface CosmJsWasmTransactionReceipt

--- a/typescript/sdk/src/providers/providerBuilders.ts
+++ b/typescript/sdk/src/providers/providerBuilders.ts
@@ -135,7 +135,6 @@ export const protocolToDefaultProviderBuilder: Record<
   ProviderBuilderFn<TypedProvider>
 > = {
   [ProtocolType.Ethereum]: defaultEthersV5ProviderBuilder,
-  [ProtocolType.GnosisTxBuilder]: defaultEthersV5ProviderBuilder,
   [ProtocolType.Sealevel]: defaultSolProviderBuilder,
   [ProtocolType.Cosmos]: defaultCosmJsWasmProviderBuilder,
 };

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxBuilder.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxBuilder.ts
@@ -6,12 +6,19 @@ import { assert } from '@hyperlane-xyz/utils';
 // @ts-ignore
 import { getSafe, getSafeService } from '../../../../utils/gnosisSafe.js';
 import { MultiProvider } from '../../../MultiProvider.js';
-import { GnosisTransactionBuilderPayload } from '../../../ProviderType.js';
 import { PopulatedTransaction, PopulatedTransactions } from '../../types.js';
 import { TxSubmitterType } from '../TxSubmitterTypes.js';
 
 import { EV5GnosisSafeTxSubmitter } from './EV5GnosisSafeTxSubmitter.js';
 import { EV5GnosisSafeTxBuilderProps } from './types.js';
+
+// TODO: Use this return type in submit()
+export interface GnosisTransactionBuilderPayload {
+  version: string;
+  chainId: string;
+  meta: {};
+  transactions: SafeTransactionData[];
+}
 
 /**
  * This class is used to create a Safe Transaction Builder compatible object.
@@ -51,9 +58,7 @@ export class EV5GnosisSafeTxBuilder extends EV5GnosisSafeTxSubmitter {
    *
    * @param txs - An array of populated transactions
    */
-  public async submit(
-    ...txs: PopulatedTransactions
-  ): Promise<GnosisTransactionBuilderPayload> {
+  public async submit(...txs: PopulatedTransactions): Promise<any> {
     const transactions: SafeTransactionData[] = await Promise.all(
       txs.map(
         async (tx: PopulatedTransaction) =>

--- a/typescript/sdk/src/token/TokenStandard.ts
+++ b/typescript/sdk/src/token/TokenStandard.ts
@@ -159,7 +159,6 @@ export const TOKEN_TYPE_TO_STANDARD: Record<TokenType, TokenStandard> = {
 export const PROTOCOL_TO_NATIVE_STANDARD: Record<ProtocolType, TokenStandard> =
   {
     [ProtocolType.Ethereum]: TokenStandard.EvmNative,
-    [ProtocolType.GnosisTxBuilder]: TokenStandard.EvmNative,
     [ProtocolType.Cosmos]: TokenStandard.CosmosNative,
     [ProtocolType.Sealevel]: TokenStandard.SealevelNative,
   };

--- a/typescript/utils/src/types.ts
+++ b/typescript/utils/src/types.ts
@@ -5,7 +5,6 @@ export enum ProtocolType {
   Ethereum = 'ethereum',
   Sealevel = 'sealevel',
   Cosmos = 'cosmos',
-  GnosisTxBuilder = 'gnosisTxBuilder',
 }
 // A type that also allows for literal values of the enum
 export type ProtocolTypeValue = `${ProtocolType}`;


### PR DESCRIPTION
### Description
This rollsback the added ProtocolType for Gnosis safe which was added only for typing. Replace with `any` and will revisit

### Backward compatibility
Yes

### Testing
None
