### PR TITLE
feat: add more options to ChainTechnicalStack enum

### DIFF
--- a/.changeset/gorgeous-rockets-walk.md
+++ b/.changeset/gorgeous-rockets-walk.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Add opstack, polygoncdk, polkadotsubstrate and zksync to ChainTechnicalStack enum

--- a/typescript/sdk/src/metadata/chainMetadataTypes.ts
+++ b/typescript/sdk/src/metadata/chainMetadataTypes.ts
@@ -17,6 +17,10 @@ export enum ExplorerFamily {
 
 export enum ChainTechnicalStack {
   ArbitrumNitro = 'arbitrumnitro',
+  OpStack = 'opstack',
+  PolygonCDK = 'polygoncdk',
+  PolkadotSubstrate = 'polkadotsubstrate',
+  ZkSync = 'zksync',
   Other = 'other',
 }
 


### PR DESCRIPTION
### Description

Adding more technical stack options to the `ChainTechnicalStack` enum, to be used to populate metadata in the registry.

Including `zksync` pre-emptively.

### Drive-by changes

n/a

### Related issues

https://www.notion.so/hyperlanexyz/Adding-more-technical-stacks-to-chain-metadata-11a6d35200d68015a229da552928d4d9?pvs=4

### Backward compatibility

yes

### Testing

na