### PR TITLE
fix: add gas buffer when sending message through HyperlaneCore

### DIFF
--- a/.changeset/wise-camels-repair.md
+++ b/.changeset/wise-camels-repair.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Set transaction overrides and add 10% gas limit buffer when sending message through HyperlaneCore.


### PR DESCRIPTION
### Description

estimates gas + adds gas limit buffer when sending a message through HyperlaneCore

### Drive-by changes

also sets tx overrides

### Related issues

> incremental merkle tree insertions have inconsistent gas usage so if there are multiple dispatch transactions in the mempool the gas estimation can become too low depending on the tx ordering 

bumping up the gas limit helps

[more context](https://discord.com/channels/935678348330434570/1295388159407947859/1295393090181267558)

### Backward compatibility

yes

### Testing

manual