### PR TITLE
fix: update HyperlaneDomainTechnicalStack with latest stacks

### DIFF
--- a/rust/main/hyperlane-core/src/chain.rs
+++ b/rust/main/hyperlane-core/src/chain.rs
@@ -218,6 +218,9 @@ impl HyperlaneDomainProtocol {
 )]
 pub enum HyperlaneDomainTechnicalStack {
     ArbitrumNitro,
+    OpStack,
+    PolygonCDK,
+    PolkadotSubstrate,
     #[default]
     Other,
 }
@@ -291,19 +294,27 @@ impl KnownHyperlaneDomain {
                 // Test chains
                 ConnextSepolia, PlumeTestnet, SuperpositionTestnet
             ],
+            HyperlaneDomainTechnicalStack::OpStack: [
+                Ancient8, Blast, Bob, Cyber, Fraxtal, Kroma, Lisk, MantaPacific, Mantle, Metis,
+                Mint, Mode, Optimism, Redstone, Worldchain, Zircuit, ZoraMainnet
+            ],
+            HyperlaneDomainTechnicalStack::PolygonCDK: [
+                Merlin, Xlayer
+            ],
+            HyperlaneDomainTechnicalStack::PolkadotSubstrate: [
+                Moonbeam, Tangle
+            ],
             HyperlaneDomainTechnicalStack::Other: [
-                Ancient8, Avalanche, BinanceSmartChain, Blast, Bob, Celo, Cyber, EclipseMainnet, Endurance, Ethereum,
-                Fraxtal, Fuji, FuseMainnet, Gnosis, Injective, Kroma, Linea, Lisk, Lukso,
-                MantaPacific, Mantle, Merlin, Metis, Mint, Mode, Moonbeam, Neutron, Optimism, Osmosis,
-                Polygon, Redstone, Sei, SolanaMainnet, Taiko, Tangle, Viction, Worldchain, Xlayer, Zetachain,
-                Zircuit, ZoraMainnet,
+                Avalanche, BinanceSmartChain, Celo, EclipseMainnet, Endurance, Ethereum,
+                FuseMainnet, Gnosis, Injective, Linea, Lukso, Neutron, Osmosis, Polygon,
+                Sei, SolanaMainnet, Taiko, Viction, Zetachain,
 
                 // Local chains
                 CosmosTest99990, CosmosTest99991, FuelTest1, SealevelTest1, SealevelTest2, Test1,
                 Test2, Test3,
 
                 // Test chains
-                Alfajores, BinanceSmartChainTestnet, Chiado, Holesky, MoonbaseAlpha, ScrollSepolia,
+                Alfajores, BinanceSmartChainTestnet, Chiado, Fuji, Holesky, MoonbaseAlpha, ScrollSepolia,
                 Sepolia
            ],
         })


### PR DESCRIPTION
### Description

fix: update HyperlaneDomainTechnicalStack with latest stacks

We added new technical stacks, and updated these in registry, but did not update the enum in the agents. this caused a hard failure to load the configs when we tried deploying to prod.

Note: we're omiting `zksync` because that is soon to be moved from a "tech stack" into a "protocol type", and we have no chains in registry with a `zksync` technical stack configured yet anyway.

### Drive-by changes

update existing list of mainnets with "other" technical stack. can't just remove them right now because we have to ensure every value in the enum is mapped

### Related issues

na

### Backward compatibility

yes

### Testing

todo: fix e2e