### PR TITLE
chore: add scroll gasPrice override

### DIFF
--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -2706,7 +2706,10 @@
       "validatorAnnounce": "0xd83A4F747fE80Ed98839e05079B1B7Fe037b1638",
       "staticMerkleRootWeightedMultisigIsmFactory": "0xcb0D04010584AA5244b5826c990eeA4c16BeAC8C",
       "staticMessageIdWeightedMultisigIsmFactory": "0x609707355a53d2aAb6366f48E2b607C599D26B29",
-      "technicalStack": "other"
+      "technicalStack": "other",
+      "transactionOverrides": {
+        "gasPrice": 200000000
+      }
     },
     "sei": {
       "aggregationHook": "0x40514BD46C57455933Be8BAedE96C4F0Ba3507D6",

--- a/typescript/infra/config/environments/mainnet3/chains.ts
+++ b/typescript/infra/config/environments/mainnet3/chains.ts
@@ -31,6 +31,14 @@ export const chainMetadataOverrides: ChainMap<Partial<ChainMetadata>> = {
       gasPrice: 1 * 10 ** 9, // 1 gwei
     },
   },
+  scroll: {
+    transactionOverrides: {
+      // Scroll doesn't use EIP 1559 and the gas price that's returned is sometimes
+      // too low for the transaction to be included in a reasonable amount of time -
+      // this often leads to transaction underpriced issues.
+      gasPrice: 2 * 10 ** 8, // 0.2 gwei
+    },
+  },
   sei: {
     // Sei's `eth_feeHistory` is not to spec and incompatible with ethers-rs,
     // so we force legacy transactions by setting a gas price.


### PR DESCRIPTION
### Description

chore: add back the scroll gasPrice override

relayer's unaffected because we override that to 0.8 gwei

### Drive-by changes

update agent config

### Related issues

key funder :'(

### Backward compatibility

yes

### Testing

manual?