### PR TITLE
fix: early strategy detection in warp apply

### DIFF
--- a/.changeset/dry-foxes-battle.md
+++ b/.changeset/dry-foxes-battle.md
@@ -2,4 +2,5 @@
 '@hyperlane-xyz/cli': minor
 ---
 
-Add strategyUrl detect and validation in the beginning of warp apply
+Add strategyUrl detect and validation in the beginning of `warp apply`
+Remove yaml transactions print from `warp apply`

--- a/.changeset/dry-foxes-battle.md
+++ b/.changeset/dry-foxes-battle.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Add strategyUrl detect and validation in the beginning of warp apply

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -9,8 +9,8 @@ import {
 } from '@hyperlane-xyz/core';
 import {
   ChainMap,
+  ChainSubmissionStrategySchema,
   EvmERC20WarpRouteReader,
-  SubmitterMetadataSchema,
   TokenStandard,
   WarpCoreConfig,
 } from '@hyperlane-xyz/sdk';
@@ -115,7 +115,8 @@ export const apply: CommandModuleWithWriteContext<{
       logRed(`Please specify either a symbol or warp config`);
       process.exit(0);
     }
-    if (strategyUrl) SubmitterMetadataSchema.parse(readYamlOrJson(strategyUrl));
+    if (strategyUrl)
+      ChainSubmissionStrategySchema.parse(readYamlOrJson(strategyUrl));
     const warpDeployConfig = await readWarpRouteDeployConfig(config);
 
     await runWarpRouteApply({

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -10,6 +10,7 @@ import {
 import {
   ChainMap,
   EvmERC20WarpRouteReader,
+  SubmitterMetadataSchema,
   TokenStandard,
   WarpCoreConfig,
 } from '@hyperlane-xyz/sdk';
@@ -30,6 +31,7 @@ import { log, logGray, logGreen, logRed, logTable } from '../logger.js';
 import { sendTestTransfer } from '../send/transfer.js';
 import {
   indentYamlOrJson,
+  readYamlOrJson,
   removeEndingSlash,
   writeYamlOrJson,
 } from '../utils/files.js';
@@ -113,6 +115,7 @@ export const apply: CommandModuleWithWriteContext<{
       logRed(`Please specify either a symbol or warp config`);
       process.exit(0);
     }
+    if (strategyUrl) SubmitterMetadataSchema.parse(readYamlOrJson(strategyUrl));
     const warpDeployConfig = await readWarpRouteDeployConfig(config);
 
     await runWarpRouteApply({

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -848,11 +848,6 @@ async function submitWarpApplyTransactions(
           `Transactions receipts successfully written to ${receiptPath}`,
         );
       }
-
-      logGreen(
-        `✅ Warp route update success with ${submitter.txSubmitterType} on ${chain}:\n\n`,
-        indentYamlOrJson(yamlStringify(transactionReceipts, null, 2), 0),
-      );
     }),
   );
 }


### PR DESCRIPTION
### Description
When using `warp apply`, a user may provide a `strategyUrl`. However, they won't know if 1) it's valid, and 2) if it even exists until much later. This adds the detection & validation early.

### Drive-by changes
Remove yaml print

### Backward compatibility
Yes

### Testing
Manual
