### PR TITLE
feat: optimistic ISM

### DIFF
--- a/solidity/contracts/hooks/OptimisticHook.sol
+++ b/solidity/contracts/hooks/OptimisticHook.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+// ============ Internal Imports ============
+import {AbstractMessageIdAuthHook} from "./libs/AbstractMessageIdAuthHook.sol";
+import {StandardHookMetadata} from "./libs/StandardHookMetadata.sol";
+import {TypeCasts} from "../libs/TypeCasts.sol";
+import {Message} from "../libs/Message.sol";
+import {IPostDispatchHook} from "../interfaces/hooks/IPostDispatchHook.sol";
+import {InterchainAccountRouter} from "../middleware/InterchainAccountRouter.sol";
+
+// ============ External Imports ============
+import {ICrossDomainMessenger} from "../interfaces/optimism/ICrossDomainMessenger.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+/**
+ * @title Optimistic Hook
+ */
+contract OptimisticHook is AbstractMessageIdAuthHook {
+    using TypeCasts for bytes32;
+
+    InterchainAccountRouter public immutable interchainAccountRouter;
+
+    // ============ Constructor ============
+    constructor(
+        address _mailbox,
+        uint32 _destinationDomain,
+        bytes32 _ism,
+        address _interchainAccountRouter
+    ) AbstractMessageIdAuthHook(_mailbox, _destinationDomain, _ism) {
+        require(
+            Address.isContract(_interchainAccountRouter),
+            "OptimisticHook: invalid interchain account router"
+        );
+        interchainAccountRouter = InterchainAccountRouter(
+            _interchainAccountRouter
+        );
+    }
+
+    // ============ Internal functions ============
+    function _quoteDispatch(
+        bytes calldata,
+        bytes calldata
+    ) internal view override returns (uint256) {
+        return interchainAccountRouter.quoteGasPayment(destinationDomain);
+    }
+
+    /// @inheritdoc AbstractMessageIdAuthHook
+    function _sendMessageId(
+        bytes calldata /*metadata*/,
+        bytes memory payload
+    ) internal override {
+        interchainAccountRouter.callRemote{value: msg.value}(
+            destinationDomain,
+            ism.bytes32ToAddress(),
+            uint256(0),
+            payload
+        );
+    }
+}

--- a/solidity/contracts/isms/hook/OptimisticIsm.sol
+++ b/solidity/contracts/isms/hook/OptimisticIsm.sol
@@ -48,7 +48,7 @@ contract OptimisticIsm is IInterchainSecurityModule {
     function verify(
         bytes calldata,
         bytes calldata message
-    ) public returns (bool) {
+    ) external view returns (bool) {
         uint48 timestamp = preverifiedMessages[message.id()];
         require(timestamp > 0, "OptimisticIsm: message not preverified");
         return timestamp + optimisticWindow < block.timestamp;

--- a/solidity/contracts/isms/hook/OptimisticIsm.sol
+++ b/solidity/contracts/isms/hook/OptimisticIsm.sol
@@ -42,6 +42,10 @@ contract OptimisticIsm is IInterchainSecurityModule {
         uint8(IInterchainSecurityModule.Types.NULL);
 
     function verifyMessageId(bytes32 messageId) external {
+        require(
+            preverifiedMessages[messageId] == 0,
+            "OptimisticIsm: message already preverified"
+        );
         preverifiedMessages[messageId] = uint48(block.timestamp);
     }
 

--- a/solidity/contracts/isms/hook/OptimisticIsm.sol
+++ b/solidity/contracts/isms/hook/OptimisticIsm.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+// ============ Internal Imports ============
+import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
+import {Message} from "../../libs/Message.sol";
+import {TypeCasts} from "../../libs/TypeCasts.sol";
+import {AbstractMessageIdAuthorizedIsm} from "./AbstractMessageIdAuthorizedIsm.sol";
+
+// ============ External Imports ============
+import {CrossChainEnabledOptimism} from "@openzeppelin/contracts/crosschain/optimism/CrossChainEnabledOptimism.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+/**
+ * @title Optimistic ISM
+ */
+contract OptimisticIsm is IInterchainSecurityModule {
+    using Message for bytes;
+
+    mapping(bytes32 => uint48) public preverifiedMessages;
+
+    uint48 public immutable optimisticWindow;
+
+    constructor(uint48 _optimisticWindow) {
+        optimisticWindow = _optimisticWindow;
+    }
+
+    // ============ Constants ============
+    uint8 public constant moduleType =
+        uint8(IInterchainSecurityModule.Types.NULL);
+
+    function verifyMessageId(bytes32 messageId) external {
+        preverifiedMessages[messageId] = uint48(block.timestamp);
+    }
+
+    function verify(
+        bytes calldata,
+        bytes calldata message
+    ) public returns (bool) {
+        uint48 timestamp = preverifiedMessages[message.id()];
+        require(timestamp > 0, "OptimisticIsm: message not preverified");
+        return timestamp + optimisticWindow < block.timestamp;
+    }
+}


### PR DESCRIPTION
### Description

Uses 2 messages:
1. ICA call to `verifyMessageId` done in hook
2. `verify` call that requires optimistic window has elapsed since `verifyMessageID` was called

Requires that the optimistic hook is after the merkle hook when aggregated due to isLatestDispatched check

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

WIP
