### PR TITLE
Update client.rs

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
@@ -98,16 +98,16 @@ impl SealevelRpcClient {
     }
 
     pub async fn get_block_height(&self) -> ChainResult<u32> {
-        let height = self
-            .0
-            .get_block_height_with_commitment(CommitmentConfig::finalized())
-            .await
-            .map_err(ChainCommunicationError::from_other)?
-            .try_into()
-            // FIXME solana block height is u64...
-            .expect("sealevel block height exceeds u32::MAX");
-        Ok(height)
-    }
+    let height = self
+        .0
+        .get_block_height_with_commitment(CommitmentConfig::finalized())
+        .await
+        .map_err(ChainCommunicationError::from_other)?;
+    let height_u32 = height.try_into().map_err(|_| {
+        ChainCommunicationError::from_other("Block height exceeds u32::MAX")
+    })?;
+    Ok(height_u32)
+}
 
     pub async fn get_multiple_accounts_with_finalized_commitment(
         &self,


### PR DESCRIPTION
I've modified the get_block_height function so that it converts the height variable directly to u32 after retrieving it. If this conversion fails, it returns an explicit error indicating that the height of the block exceeds the capacity of u32.

### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
