### PR TITLE
chore: split cli e2e into separate job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,30 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
+  cli-e2e:
+    runs-on: ubuntu-latest
+    needs: [yarn-install]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: foundry-install
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: yarn-build
+        uses: ./.github/actions/yarn-build-with-cache
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout registry
+        uses: ./.github/actions/checkout-registry
+
+      - name: CLI e2e tests
+        run: yarn --cwd typescript/cli test:e2e
+
   agent-configs:
     runs-on: ubuntu-latest
     needs: [yarn-install]
@@ -218,7 +242,7 @@ jobs:
         run: |
           if [[ -n "$(git diff ${{ github.event.pull_request.head.sha || github.sha }} ${{ github.event.pull_request.base.sha }} -- ./rust)" ]]; then
             echo "rust_changes=true" >> $GITHUB_OUTPUT
-            echo "$(git diff ${{ github.event.pull_request.head.sha || github.sha }} ${{ github.event.pull_request.base.sha }} -- ./rust)" 
+            echo "$(git diff ${{ github.event.pull_request.head.sha || github.sha }} ${{ github.event.pull_request.base.sha }} -- ./rust)"
           else
             echo "rust_changes=false" >> $GITHUB_OUTPUT
           fi

--- a/typescript/cli/.mocharc-e2e.json
+++ b/typescript/cli/.mocharc-e2e.json
@@ -1,6 +1,6 @@
 {
   "extensions": ["ts"],
-  "spec": ["src/**/*.test.*"],
+  "spec": ["src/**/*.e2e-test.ts"],
   "node-option": [
     "experimental-specifier-resolution=node",
     "loader=ts-node/esm"

--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -47,7 +47,8 @@
     "clean": "rm -rf ./dist",
     "lint": "eslint . --ext .ts",
     "prettier": "prettier --write ./src ./examples",
-    "test:ci": "./scripts/all-test.sh",
+    "test:ci": "yarn mocha --config .mocharc.json",
+    "test:e2e": "./scripts/run-e2e-test.sh",
     "version:update": "echo \"export const VERSION = '$npm_package_version';\" > src/version.ts"
   },
   "files": [

--- a/typescript/cli/scripts/run-e2e-test.sh
+++ b/typescript/cli/scripts/run-e2e-test.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 
 function cleanup() {
-  set +e 
+  set +e
   pkill -f anvil
   rm -rf /tmp/anvil2
   rm -rf /tmp/anvil3
   rm -f ./test-configs/anvil/chains/anvil2/addresses.yaml
   rm -f ./test-configs/anvil/chains/anvil3/addresses.yaml
-  set -e 
+  set -e
 }
 
 cleanup
 
-echo "Starting anvil2 and anvil3 chain"
+echo "Starting anvil2 and anvil3 chain for E2E tests"
 anvil --chain-id 31338 -p 8555 --state /tmp/anvil2/state --gas-price 1 > /dev/null &
 anvil --chain-id 31347 -p 8600 --state /tmp/anvil3/state --gas-price 1 > /dev/null &
 
-echo "Running all tests"
-yarn mocha --config .mocharc.json
+echo "Running E2E tests"
+yarn mocha --config .mocharc-e2e.json
 
 cleanup
 
-echo "Done all tests"
+echo "Completed E2E tests"


### PR DESCRIPTION
### Description

chore: split cli e2e into separate job

before:
![image](https://github.com/user-attachments/assets/bb19243f-fc38-478e-b94c-f39020756964)

after:
![image](https://github.com/user-attachments/assets/6ebcb783-1d07-4350-8823-5cc5df7c5c65)

### Drive-by changes

na

### Related issues

`yarn-test` step sometimes taking even 15 mins nowadays, half of which is e2e tests

### Backward compatibility

yes

### Testing

ci