### PR TITLE
feat: add block tag enum for validating reorgPeriod

### DIFF
--- a/.changeset/quiet-cooks-join.md
+++ b/.changeset/quiet-cooks-join.md
@@ -1,6 +1,6 @@
 ---
-'@hyperlane-xyz/cli': major
-'@hyperlane-xyz/sdk': major
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
 ---
 
 Restrict reorgPeriod string to one of ethereum's EthJsonRpcBlockParameterTag

--- a/.changeset/quiet-cooks-join.md
+++ b/.changeset/quiet-cooks-join.md
@@ -3,4 +3,4 @@
 '@hyperlane-xyz/sdk': minor
 ---
 
-Restrict reorgPeriod string to one of ethereum's EthJsonRpcBlockParameterTag
+Add `EthJsonRpcBlockParameterTag` enum for validating reorgPeriod

--- a/.changeset/quiet-cooks-join.md
+++ b/.changeset/quiet-cooks-join.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': major
+'@hyperlane-xyz/sdk': major
+---
+
+Restrict reorgPeriod string to one of ethereum's BlockParameterTags

--- a/.changeset/quiet-cooks-join.md
+++ b/.changeset/quiet-cooks-join.md
@@ -3,4 +3,4 @@
 '@hyperlane-xyz/sdk': major
 ---
 
-Restrict reorgPeriod string to one of ethereum's BlockParameterTags
+Restrict reorgPeriod string to one of ethereum's EthJsonRpcBlockParameterTag

--- a/typescript/cli/src/config/chain.ts
+++ b/typescript/cli/src/config/chain.ts
@@ -3,6 +3,7 @@ import { ethers } from 'ethers';
 import { stringify as yamlStringify } from 'yaml';
 
 import {
+  BlockParameterTags,
   ChainMetadata,
   ChainMetadataSchema,
   ExplorerFamily,
@@ -168,9 +169,9 @@ async function addBlockOrGasConfig(metadata: ChainMetadata): Promise<void> {
 }
 
 async function addBlockConfig(metadata: ChainMetadata): Promise<void> {
-  const parseReorgPeriod = (value: string) => {
+  const parseReorgPeriod = (value: string): number | BlockParameterTags => {
     const parsed = parseInt(value, 10);
-    return isNaN(parsed) ? value : parsed;
+    return isNaN(parsed) ? (value as BlockParameterTags) : parsed;
   };
 
   const wantBlockConfig = await confirm({
@@ -184,10 +185,16 @@ async function addBlockConfig(metadata: ChainMetadata): Promise<void> {
     });
     const blockReorgPeriod = await input({
       message:
-        'Enter no. of blocks before a transaction has a near-zero chance of reverting (0-500) or block tag:',
-      validate: (value) =>
-        isNaN(parseInt(value)) ||
-        (parseInt(value) >= 0 && parseInt(value) <= 500),
+        'Enter reorg period as number of blocks (0-500) or block tag (earliest, latest, safe, finalized, pending):',
+      validate: (value) => {
+        const parsedInt = parseInt(value, 10);
+        return (
+          Object.values(BlockParameterTags).includes(
+            value as BlockParameterTags,
+          ) ||
+          (!isNaN(parsedInt) && parsedInt >= 0 && parsedInt <= 500)
+        );
+      },
     });
     const blockTimeEstimate = await input({
       message: 'Enter the rough estimate of time per block in seconds (0-20):',

--- a/typescript/cli/src/config/chain.ts
+++ b/typescript/cli/src/config/chain.ts
@@ -187,7 +187,7 @@ async function addBlockConfig(metadata: ChainMetadata): Promise<void> {
     });
     const blockReorgPeriod = await input({
       message:
-        'Enter reorg period as number of blocks (0-500) or block tag (earliest, latest, safe, finalized, pending):',
+        'Enter no. of blocks before a transaction has a near-zero chance of reverting (0-500) or block tag (earliest, latest, safe, finalized, pending):',
       validate: (value) => {
         const parsedInt = parseInt(value, 10);
         return (

--- a/typescript/cli/src/config/chain.ts
+++ b/typescript/cli/src/config/chain.ts
@@ -3,9 +3,9 @@ import { ethers } from 'ethers';
 import { stringify as yamlStringify } from 'yaml';
 
 import {
-  BlockParameterTags,
   ChainMetadata,
   ChainMetadataSchema,
+  EthJsonRpcBlockParameterTag,
   ExplorerFamily,
   ZChainName,
 } from '@hyperlane-xyz/sdk';
@@ -169,9 +169,11 @@ async function addBlockOrGasConfig(metadata: ChainMetadata): Promise<void> {
 }
 
 async function addBlockConfig(metadata: ChainMetadata): Promise<void> {
-  const parseReorgPeriod = (value: string): number | BlockParameterTags => {
+  const parseReorgPeriod = (
+    value: string,
+  ): number | EthJsonRpcBlockParameterTag => {
     const parsed = parseInt(value, 10);
-    return isNaN(parsed) ? (value as BlockParameterTags) : parsed;
+    return isNaN(parsed) ? (value as EthJsonRpcBlockParameterTag) : parsed;
   };
 
   const wantBlockConfig = await confirm({
@@ -189,8 +191,8 @@ async function addBlockConfig(metadata: ChainMetadata): Promise<void> {
       validate: (value) => {
         const parsedInt = parseInt(value, 10);
         return (
-          Object.values(BlockParameterTags).includes(
-            value as BlockParameterTags,
+          Object.values(EthJsonRpcBlockParameterTag).includes(
+            value as EthJsonRpcBlockParameterTag,
           ) ||
           (!isNaN(parsedInt) && parsedInt >= 0 && parsedInt <= 500)
         );

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -196,6 +196,7 @@ export {
 export {
   BlockExplorer,
   BlockExplorerSchema,
+  EthJsonRpcBlockParameterTag as BlockParameterTags,
   ChainMetadata,
   ChainMetadataSchema,
   ChainMetadataSchemaObject,

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -196,7 +196,7 @@ export {
 export {
   BlockExplorer,
   BlockExplorerSchema,
-  EthJsonRpcBlockParameterTag as BlockParameterTags,
+  EthJsonRpcBlockParameterTag,
   ChainMetadata,
   ChainMetadataSchema,
   ChainMetadataSchemaObject,

--- a/typescript/sdk/src/metadata/chainMetadata.test.ts
+++ b/typescript/sdk/src/metadata/chainMetadata.test.ts
@@ -2,7 +2,11 @@ import { expect } from 'chai';
 
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
-import { ChainMetadata, isValidChainMetadata } from './chainMetadataTypes.js';
+import {
+  ChainMetadata,
+  EthJsonRpcBlockParameterTag,
+  isValidChainMetadata,
+} from './chainMetadataTypes.js';
 
 const minimalSchema: ChainMetadata = {
   chainId: 5,
@@ -68,7 +72,7 @@ describe('ChainMetadataSchema', () => {
         ...minimalSchema,
         blocks: {
           confirmations: 1,
-          reorgPeriod: 'finalized',
+          reorgPeriod: EthJsonRpcBlockParameterTag.Finalized,
         },
       }),
     ).to.eq(true);

--- a/typescript/sdk/src/metadata/chainMetadataTypes.ts
+++ b/typescript/sdk/src/metadata/chainMetadataTypes.ts
@@ -134,7 +134,7 @@ export const ChainMetadataSchemaObject = z.object({
         'Number of blocks to wait before considering a transaction confirmed.',
       ),
       reorgPeriod: z
-        .union([ZUint, z.nativeEnum(EthJsonRpcBlockParameterTag)])
+        .union([ZUint, z.string()])
         .optional()
         .describe(
           'Number of blocks before a transaction has a near-zero chance of reverting or block tag.',

--- a/typescript/sdk/src/metadata/chainMetadataTypes.ts
+++ b/typescript/sdk/src/metadata/chainMetadataTypes.ts
@@ -10,6 +10,14 @@ import { ChainMap } from '../types.js';
 
 import { ZChainName, ZNzUint, ZUint } from './customZodTypes.js';
 
+export enum EthJsonRpcBlockParameterTag {
+  Earliest = 'earliest',
+  Latest = 'latest',
+  Safe = 'safe',
+  Finalized = 'finalized',
+  Pending = 'pending',
+}
+
 export enum ExplorerFamily {
   Etherscan = 'etherscan',
   Blockscout = 'blockscout',
@@ -126,7 +134,7 @@ export const ChainMetadataSchemaObject = z.object({
         'Number of blocks to wait before considering a transaction confirmed.',
       ),
       reorgPeriod: z
-        .union([ZUint, z.string()])
+        .union([ZUint, z.nativeEnum(EthJsonRpcBlockParameterTag)])
         .optional()
         .describe(
           'Number of blocks before a transaction has a near-zero chance of reverting or block tag.',


### PR DESCRIPTION
### Description

- feat: add `EthJsonRpcBlockParameterTag` enum for validating reorgPeriod
- cli will check that reorgPeriod is either a number or one of the appropriate tags, but the underlying schema is still left loose to be forwards-compatible
- exporting the enum will also let us use this in unit tests on the registry side

### Drive-by changes

na

### Related issues

na

### Backward compatibility

ye

### Testing

ci