### PR TITLE
feat: add zkSync enum variant to HyperlaneDomainTechnicalStack

### DIFF
--- a/rust/main/hyperlane-core/src/chain.rs
+++ b/rust/main/hyperlane-core/src/chain.rs
@@ -299,6 +299,7 @@ pub enum HyperlaneDomainTechnicalStack {
     OpStack,
     PolygonCDK,
     PolkadotSubstrate,
+    ZkSync,
     #[default]
     Other,
 }

--- a/rust/main/hyperlane-core/src/chain.rs
+++ b/rust/main/hyperlane-core/src/chain.rs
@@ -383,6 +383,7 @@ impl KnownHyperlaneDomain {
             HyperlaneDomainTechnicalStack::PolkadotSubstrate: [
                 Moonbeam, Tangle
             ],
+            HyperlaneDomainTechnicalStack::ZkSync: [],
             HyperlaneDomainTechnicalStack::Other: [
                 Avalanche, BinanceSmartChain, Celo, EclipseMainnet, Endurance, Ethereum,
                 FuseMainnet, Gnosis, Injective, Linea, Lukso, Neutron, Osmosis, Polygon,


### PR DESCRIPTION
### Description

To match the new TS schema

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
