### PR TITLE
fix: isObject utils fn should return only boolean value

### DIFF
--- a/.changeset/quiet-spoons-sleep.md
+++ b/.changeset/quiet-spoons-sleep.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/utils': patch
+---
+
+fix: isObject utils fn should return only boolean value

--- a/typescript/utils/src/objects.test.ts
+++ b/typescript/utils/src/objects.test.ts
@@ -4,6 +4,7 @@ import {
   deepCopy,
   deepEquals,
   diffObjMerge,
+  isObject,
   objMerge,
   objOmit,
 } from './objects.js';
@@ -72,6 +73,14 @@ describe('Object utilities', () => {
     const obj2 = { b: { c: ['arr1'] } };
     const omitted1_2 = objOmit(obj1, obj2, 10, false);
     expect(omitted1_2).to.eql({ a: 1, b: { d: 'string' } });
+  });
+
+  it('isObject', () => {
+    expect(isObject({})).to.be.true;
+    expect(isObject([])).to.be.false;
+    expect(isObject(null)).to.be.false;
+    expect(isObject(undefined)).to.be.false;
+    expect(isObject(42)).to.be.false;
   });
 
   describe('diffObjMerge', () => {

--- a/typescript/utils/src/objects.ts
+++ b/typescript/utils/src/objects.ts
@@ -5,8 +5,8 @@ import { ethersBigNumberSerializer } from './logging.js';
 import { isNullish } from './typeof.js';
 import { assert } from './validation.js';
 
-export function isObject(item: any) {
-  return item && typeof item === 'object' && !Array.isArray(item);
+export function isObject(item: any): boolean {
+  return !!item && typeof item === 'object' && !Array.isArray(item);
 }
 
 export function deepEquals(v1: any, v2: any) {


### PR DESCRIPTION
### Description
When `isObject` pass with param `null/undefined` it returns `null/undefined`

We should strict return boolean value
<!--
What's included in this PR?
-->

### Drive-by changes
```diff
export function isObject(item: any): boolean {
- return item && typeof item === 'object' && !Array.isArray(item);
+ return !!item && typeof item === 'object' && !Array.isArray(item);
}
```
<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing
Has updated with test `object.test.ts`
<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
