### PR TITLE
fix(contracts): access control to prevent DOS on `RateLimitHook`

### DIFF
--- a/solidity/contracts/hooks/warp-route/RateLimitedHook.sol
+++ b/solidity/contracts/hooks/warp-route/RateLimitedHook.sol
@@ -1,18 +1,47 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.8.0;
 
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+// ============ Internal Imports ============
 import {MailboxClient} from "contracts/client/MailboxClient.sol";
 import {IPostDispatchHook} from "contracts/interfaces/hooks/IPostDispatchHook.sol";
 import {Message} from "contracts/libs/Message.sol";
 import {TokenMessage} from "contracts/token/libs/TokenMessage.sol";
 import {RateLimited} from "contracts/libs/RateLimited.sol";
+import {AbstractPostDispatchHook} from "../libs/AbstractPostDispatchHook.sol";
 
-contract RateLimitedHook is IPostDispatchHook, MailboxClient, RateLimited {
+/*
+ * @title RateLimitedHook
+ * @author Abacus Works
+ * @notice A hook that rate limits the volume of token transfers to a destination using a bucket fill algorithm
+ */
+contract RateLimitedHook is
+    AbstractPostDispatchHook,
+    MailboxClient,
+    RateLimited
+{
     using Message for bytes;
     using TokenMessage for bytes;
 
+    /// @notice The address that is authorized to call this hook
+    address public immutable sender;
+    /// @notice A mapping of message IDs to whether they have been validated
     mapping(bytes32 messageId => bool validated) public messageValidated;
 
+    // ============ Modifiers ============
+
+    /// @notice Ensures that the message has not been validated yet
     modifier validateMessageOnce(bytes calldata _message) {
         bytes32 messageId = _message.id();
         require(!messageValidated[messageId], "MessageAlreadyValidated");
@@ -20,40 +49,48 @@ contract RateLimitedHook is IPostDispatchHook, MailboxClient, RateLimited {
         messageValidated[messageId] = true;
     }
 
+    /// @notice Ensures that the message was sent by the authorized sender
+    modifier onlySender(bytes calldata _message) {
+        require(_message.senderAddress() == sender, "InvalidSender");
+        _;
+    }
+
+    // ============ Constructor ============
+
     constructor(
         address _mailbox,
-        uint256 _maxCapacity
-    ) MailboxClient(_mailbox) RateLimited(_maxCapacity) {}
+        uint256 _maxCapacity,
+        address _sender
+    ) MailboxClient(_mailbox) RateLimited(_maxCapacity) {
+        require(_sender != address(0), "InvalidSender");
+        sender = _sender;
+    }
+
+    // ============ External Functions ============
 
     /// @inheritdoc IPostDispatchHook
     function hookType() external pure returns (uint8) {
         return uint8(IPostDispatchHook.Types.RATE_LIMITED);
     }
 
-    /// @inheritdoc IPostDispatchHook
-    function supportsMetadata(bytes calldata) external pure returns (bool) {
-        return false;
-    }
+    // ============ Internal Functions ============
 
-    /**
-     * Verify a message, rate limit, and increment the sender's limit.
-     * @dev ensures that this gets called by the Mailbox
-     */
-    function postDispatch(
+    /// @inheritdoc AbstractPostDispatchHook
+    function _postDispatch(
         bytes calldata,
         bytes calldata _message
-    ) external payable validateMessageOnce(_message) {
+    ) internal override onlySender(_message) validateMessageOnce(_message) {
         require(_isLatestDispatched(_message.id()), "InvalidDispatchedMessage");
 
         uint256 newAmount = _message.body().amount();
         validateAndConsumeFilledLevel(newAmount);
     }
 
-    /// @inheritdoc IPostDispatchHook
-    function quoteDispatch(
+    /// @inheritdoc AbstractPostDispatchHook
+    function _quoteDispatch(
         bytes calldata,
         bytes calldata
-    ) external pure returns (uint256) {
+    ) internal pure override returns (uint256) {
         return 0;
     }
 }


### PR DESCRIPTION
### Description

- Added onlySender to `RateLimitHook` to only allow a specific sender like a warp route to send messages through the hook.

### Drive-by changes

None

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
