### PR TITLE
fix: ensure recipients on Sealevel warp transfers are 32 bytes

### DIFF
--- a/.changeset/olive-maps-applaud.md
+++ b/.changeset/olive-maps-applaud.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/utils': patch
+'@hyperlane-xyz/sdk': patch
+---
+
+Supported non-32 byte non-EVM recipients when sending warps from Sealevel

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -21,6 +21,7 @@ import {
   addressToBytes,
   eqAddress,
   median,
+  padBytesToLength,
 } from '@hyperlane-xyz/utils';
 
 import { BaseSealevelAdapter } from '../../app/MultiProtocolApp.js';
@@ -295,7 +296,7 @@ export abstract class SealevelHypTokenAdapter
       instruction: SealevelHypTokenInstruction.TransferRemote,
       data: new SealevelTransferRemoteInstruction({
         destination_domain: destination,
-        recipient: addressToBytes(recipient),
+        recipient: padBytesToLength(addressToBytes(recipient), 32),
         amount_or_id: BigInt(weiAmountOrId),
       }),
     });

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -18,7 +18,7 @@ import { deserializeUnchecked, serialize } from 'borsh';
 import {
   Address,
   Domain,
-  addressToBytes32,
+  addressToBytes,
   eqAddress,
   median,
 } from '@hyperlane-xyz/utils';
@@ -295,7 +295,7 @@ export abstract class SealevelHypTokenAdapter
       instruction: SealevelHypTokenInstruction.TransferRemote,
       data: new SealevelTransferRemoteInstruction({
         destination_domain: destination,
-        recipient: addressToBytes32(recipient),
+        recipient: addressToBytes(recipient),
         amount_or_id: BigInt(weiAmountOrId),
       }),
     });

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -18,7 +18,7 @@ import { deserializeUnchecked, serialize } from 'borsh';
 import {
   Address,
   Domain,
-  addressToBytes,
+  addressToBytes32,
   eqAddress,
   median,
 } from '@hyperlane-xyz/utils';
@@ -295,7 +295,7 @@ export abstract class SealevelHypTokenAdapter
       instruction: SealevelHypTokenInstruction.TransferRemote,
       data: new SealevelTransferRemoteInstruction({
         destination_domain: destination,
-        recipient: addressToBytes(recipient),
+        recipient: addressToBytes32(recipient),
         amount_or_id: BigInt(weiAmountOrId),
       }),
     });

--- a/typescript/utils/src/addresses.test.ts
+++ b/typescript/utils/src/addresses.test.ts
@@ -4,6 +4,7 @@ import {
   addressToBytes,
   bytesToProtocolAddress,
   isZeroishAddress,
+  padBytesToLength,
 } from './addresses.js';
 import { ProtocolType } from './types.js';
 
@@ -39,6 +40,17 @@ describe('Address utilities', () => {
       expect(() => addressToBytes(ETH_ZERO_ADDR)).to.throw(Error);
       expect(() => addressToBytes(COS_ZERO_ADDR)).to.throw(Error);
       expect(() => addressToBytes(SOL_ZERO_ADDR)).to.throw(Error);
+    });
+  });
+
+  describe('padBytesToLength', () => {
+    it('Pads bytes to a given length', () => {
+      const bytes = Buffer.from([1, 2, 3]);
+      expect(padBytesToLength(bytes, 5).equals(Buffer.from([0, 0, 1, 2, 3])));
+    });
+    it('Rejects bytes that exceed the target length', () => {
+      const bytes = Buffer.from([1, 2, 3]);
+      expect(() => padBytesToLength(bytes, 2)).to.throw(Error);
     });
   });
 

--- a/typescript/utils/src/addresses.ts
+++ b/typescript/utils/src/addresses.ts
@@ -316,6 +316,14 @@ export function bytesToBytes32(bytes: Uint8Array): string {
   );
 }
 
+// Pad bytes to a certain length, padding with 0s at the start
+export function padBytesToLength(bytes: Uint8Array, length: number) {
+  if (bytes.length > length) {
+    throw new Error(`bytes must be ${length} bytes or less`);
+  }
+  return Buffer.concat([Buffer.alloc(length - bytes.length), bytes]);
+}
+
 export function bytesToAddressEvm(bytes: Uint8Array): Address {
   return bytes32ToAddress(Buffer.from(bytes).toString('hex'));
 }

--- a/typescript/utils/src/index.ts
+++ b/typescript/utils/src/index.ts
@@ -35,6 +35,7 @@ export {
   normalizeAddressCosmos,
   normalizeAddressEvm,
   normalizeAddressSealevel,
+  padBytesToLength,
   shortenAddress,
   strip0x,
 } from './addresses.js';


### PR DESCRIPTION
### Description

Ran into an issue trying to send from Sealevel -> Cosmos where the recipient was 20 bytes. This hasn't been an issue so far because:
- no previous Sealevel -> Cosmos transfers have been done in the UI
- Sealevel -> EVM transfers are successful bc `addressToBytes` actually pads the 20 byte EVM addresses to 32 bytes
- Sealevel -> Sealevel transfers are fine because Sealevel addys are always 32 bytes

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
