### PR TITLE
fix: use `ism.route(message)` for supporting self relay of ICA ISM

### DIFF
--- a/.changeset/sweet-houses-type.md
+++ b/.changeset/sweet-houses-type.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Fix ICA ISM self relay

--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -148,7 +148,9 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
         );
         return;
       }
-      const module = await ism.module(domainId);
+      const module = this.messageContext
+        ? await ism.route(this.messageContext.message)
+        : await ism.module(domainId);
       domains[chainName] = await this.deriveIsmConfig(module);
     });
 


### PR DESCRIPTION
### Description

ICA ISM does not implement `module(uint32)` but rather `route(message)`. This modifies ISM derivation with message context to use this function.

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

Yes

### Testing

Manual
