### PR TITLE
chore: disable arcadiatestnet until redeployment

### DIFF
--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -43,7 +43,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
   [Role.Validator]: {
     alfajores: true,
     arbitrumsepolia: true,
-    arcadiatestnet: true,
+    // arcadiatestnet: true,
     basesepolia: true,
     berabartio: true,
     bsctestnet: true,
@@ -73,7 +73,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
   [Role.Relayer]: {
     alfajores: true,
     arbitrumsepolia: true,
-    arcadiatestnet: true,
+    // arcadiatestnet: true,
     basesepolia: true,
     berabartio: true,
     bsctestnet: true,
@@ -103,7 +103,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
   [Role.Scraper]: {
     alfajores: true,
     arbitrumsepolia: true,
-    arcadiatestnet: true,
+    // arcadiatestnet: true,
     basesepolia: true,
     berabartio: true,
     bsctestnet: true,

--- a/typescript/infra/config/environments/testnet4/aw-validators/hyperlane.json
+++ b/typescript/infra/config/environments/testnet4/aw-validators/hyperlane.json
@@ -7,19 +7,13 @@
     ]
   },
   "arbitrumsepolia": {
-    "validators": [
-      "0x09fabfbca0b8bf042e2a1161ee5010d147b0f603"
-    ]
+    "validators": ["0x09fabfbca0b8bf042e2a1161ee5010d147b0f603"]
   },
   "basesepolia": {
-    "validators": [
-      "0x82e3b437a2944e3ff00258c93e72cd1ba5e0e921"
-    ]
+    "validators": ["0x82e3b437a2944e3ff00258c93e72cd1ba5e0e921"]
   },
   "berabartio": {
-    "validators": [
-      "0x541dd3cb282cf869d72883557badae245b63e1fd"
-    ]
+    "validators": ["0x541dd3cb282cf869d72883557badae245b63e1fd"]
   },
   "bsctestnet": {
     "validators": [
@@ -29,29 +23,19 @@
     ]
   },
   "camptestnet": {
-    "validators": [
-      "0x238f40f055a7ff697ea6dbff3ae943c9eae7a38e"
-    ]
+    "validators": ["0x238f40f055a7ff697ea6dbff3ae943c9eae7a38e"]
   },
   "citreatestnet": {
-    "validators": [
-      "0x60d7380a41eb95c49be18f141efd2fde5e3dba20"
-    ]
+    "validators": ["0x60d7380a41eb95c49be18f141efd2fde5e3dba20"]
   },
   "connextsepolia": {
-    "validators": [
-      "0xffbbec8c499585d80ef69eb613db624d27e089ab"
-    ]
+    "validators": ["0xffbbec8c499585d80ef69eb613db624d27e089ab"]
   },
   "ecotestnet": {
-    "validators": [
-      "0xb3191420d463c2af8bd9b4a395e100ec5c05915a"
-    ]
+    "validators": ["0xb3191420d463c2af8bd9b4a395e100ec5c05915a"]
   },
   "formtestnet": {
-    "validators": [
-      "0x72ad7fddf16d17ff902d788441151982fa31a7bc"
-    ]
+    "validators": ["0x72ad7fddf16d17ff902d788441151982fa31a7bc"]
   },
   "fuji": {
     "validators": [
@@ -61,24 +45,16 @@
     ]
   },
   "holesky": {
-    "validators": [
-      "0x7ab28ad88bb45867137ea823af88e2cb02359c03"
-    ]
+    "validators": ["0x7ab28ad88bb45867137ea823af88e2cb02359c03"]
   },
   "odysseytestnet": {
-    "validators": [
-      "0xcc0a6e2d6aa8560b45b384ced7aa049870b66ea3"
-    ]
+    "validators": ["0xcc0a6e2d6aa8560b45b384ced7aa049870b66ea3"]
   },
   "optimismsepolia": {
-    "validators": [
-      "0x03efe4d0632ee15685d7e8f46dea0a874304aa29"
-    ]
+    "validators": ["0x03efe4d0632ee15685d7e8f46dea0a874304aa29"]
   },
   "polygonamoy": {
-    "validators": [
-      "0xf0290b06e446b320bd4e9c4a519420354d7ddccd"
-    ]
+    "validators": ["0xf0290b06e446b320bd4e9c4a519420354d7ddccd"]
   },
   "scrollsepolia": {
     "validators": [
@@ -95,28 +71,18 @@
     ]
   },
   "soneiumtestnet": {
-    "validators": [
-      "0x2e2101020ccdbe76aeda1c27823b0150f43d0c63"
-    ]
+    "validators": ["0x2e2101020ccdbe76aeda1c27823b0150f43d0c63"]
   },
   "sonictestnet": {
-    "validators": [
-      "0x62e6591d00daec3fb658c3d19403828b4e9ddbb3"
-    ]
+    "validators": ["0x62e6591d00daec3fb658c3d19403828b4e9ddbb3"]
   },
   "suavetoliman": {
-    "validators": [
-      "0xf58f6e30aabba34e8dd7f79b3168507192e2cc9b"
-    ]
+    "validators": ["0xf58f6e30aabba34e8dd7f79b3168507192e2cc9b"]
   },
   "superpositiontestnet": {
-    "validators": [
-      "0x1d3168504b23b73cdf9c27f13bb0a595d7f1a96a"
-    ]
+    "validators": ["0x1d3168504b23b73cdf9c27f13bb0a595d7f1a96a"]
   },
   "unichaintestnet": {
-    "validators": [
-      "0x5e99961cf71918308c3b17ef21b5f515a4f86fe5"
-    ]
+    "validators": ["0x5e99961cf71918308c3b17ef21b5f515a4f86fe5"]
   }
 }

--- a/typescript/infra/config/environments/testnet4/aw-validators/hyperlane.json
+++ b/typescript/infra/config/environments/testnet4/aw-validators/hyperlane.json
@@ -7,16 +7,19 @@
     ]
   },
   "arbitrumsepolia": {
-    "validators": ["0x09fabfbca0b8bf042e2a1161ee5010d147b0f603"]
-  },
-  "arcadiatestnet": {
-    "validators": ["0x7ce5973d3f22971546efb86f5a0417c1248e92f5"]
+    "validators": [
+      "0x09fabfbca0b8bf042e2a1161ee5010d147b0f603"
+    ]
   },
   "basesepolia": {
-    "validators": ["0x82e3b437a2944e3ff00258c93e72cd1ba5e0e921"]
+    "validators": [
+      "0x82e3b437a2944e3ff00258c93e72cd1ba5e0e921"
+    ]
   },
   "berabartio": {
-    "validators": ["0x541dd3cb282cf869d72883557badae245b63e1fd"]
+    "validators": [
+      "0x541dd3cb282cf869d72883557badae245b63e1fd"
+    ]
   },
   "bsctestnet": {
     "validators": [
@@ -26,19 +29,29 @@
     ]
   },
   "camptestnet": {
-    "validators": ["0x238f40f055a7ff697ea6dbff3ae943c9eae7a38e"]
+    "validators": [
+      "0x238f40f055a7ff697ea6dbff3ae943c9eae7a38e"
+    ]
   },
   "citreatestnet": {
-    "validators": ["0x60d7380a41eb95c49be18f141efd2fde5e3dba20"]
+    "validators": [
+      "0x60d7380a41eb95c49be18f141efd2fde5e3dba20"
+    ]
   },
   "connextsepolia": {
-    "validators": ["0xffbbec8c499585d80ef69eb613db624d27e089ab"]
+    "validators": [
+      "0xffbbec8c499585d80ef69eb613db624d27e089ab"
+    ]
   },
   "ecotestnet": {
-    "validators": ["0xb3191420d463c2af8bd9b4a395e100ec5c05915a"]
+    "validators": [
+      "0xb3191420d463c2af8bd9b4a395e100ec5c05915a"
+    ]
   },
   "formtestnet": {
-    "validators": ["0x72ad7fddf16d17ff902d788441151982fa31a7bc"]
+    "validators": [
+      "0x72ad7fddf16d17ff902d788441151982fa31a7bc"
+    ]
   },
   "fuji": {
     "validators": [
@@ -48,16 +61,24 @@
     ]
   },
   "holesky": {
-    "validators": ["0x7ab28ad88bb45867137ea823af88e2cb02359c03"]
+    "validators": [
+      "0x7ab28ad88bb45867137ea823af88e2cb02359c03"
+    ]
   },
   "odysseytestnet": {
-    "validators": ["0xcc0a6e2d6aa8560b45b384ced7aa049870b66ea3"]
+    "validators": [
+      "0xcc0a6e2d6aa8560b45b384ced7aa049870b66ea3"
+    ]
   },
   "optimismsepolia": {
-    "validators": ["0x03efe4d0632ee15685d7e8f46dea0a874304aa29"]
+    "validators": [
+      "0x03efe4d0632ee15685d7e8f46dea0a874304aa29"
+    ]
   },
   "polygonamoy": {
-    "validators": ["0xf0290b06e446b320bd4e9c4a519420354d7ddccd"]
+    "validators": [
+      "0xf0290b06e446b320bd4e9c4a519420354d7ddccd"
+    ]
   },
   "scrollsepolia": {
     "validators": [
@@ -74,18 +95,28 @@
     ]
   },
   "soneiumtestnet": {
-    "validators": ["0x2e2101020ccdbe76aeda1c27823b0150f43d0c63"]
+    "validators": [
+      "0x2e2101020ccdbe76aeda1c27823b0150f43d0c63"
+    ]
   },
   "sonictestnet": {
-    "validators": ["0x62e6591d00daec3fb658c3d19403828b4e9ddbb3"]
+    "validators": [
+      "0x62e6591d00daec3fb658c3d19403828b4e9ddbb3"
+    ]
   },
   "suavetoliman": {
-    "validators": ["0xf58f6e30aabba34e8dd7f79b3168507192e2cc9b"]
+    "validators": [
+      "0xf58f6e30aabba34e8dd7f79b3168507192e2cc9b"
+    ]
   },
   "superpositiontestnet": {
-    "validators": ["0x1d3168504b23b73cdf9c27f13bb0a595d7f1a96a"]
+    "validators": [
+      "0x1d3168504b23b73cdf9c27f13bb0a595d7f1a96a"
+    ]
   },
   "unichaintestnet": {
-    "validators": ["0x5e99961cf71918308c3b17ef21b5f515a4f86fe5"]
+    "validators": [
+      "0x5e99961cf71918308c3b17ef21b5f515a4f86fe5"
+    ]
   }
 }

--- a/typescript/infra/config/environments/testnet4/funding.ts
+++ b/typescript/infra/config/environments/testnet4/funding.ts
@@ -28,7 +28,7 @@ export const keyFunderConfig: KeyFunderConfig<
   desiredBalancePerChain: {
     alfajores: '5',
     arbitrumsepolia: '0.1',
-    arcadiatestnet: '0.1',
+    // arcadiatestnet: '0.1',
     basesepolia: '0.1',
     berabartio: '0.1',
     bsctestnet: '5',

--- a/typescript/infra/config/environments/testnet4/supportedChainNames.ts
+++ b/typescript/infra/config/environments/testnet4/supportedChainNames.ts
@@ -2,7 +2,8 @@
 export const testnet4SupportedChainNames = [
   'alfajores',
   'arbitrumsepolia',
-  'arcadiatestnet',
+  // Disabling arcadiatestnet on Oct 29, 2024: chain reset and needs to be redeployed
+  // 'arcadiatestnet',
   'basesepolia',
   'berabartio',
   'bsctestnet',


### PR DESCRIPTION
### Description

chore: disable arcadiatestnet until redeployment
- testnet had to be reset

### Drive-by changes

- take down arcadiatestnet validator
- redeploy scraper, relayer, keyfunder without offending chain

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
