### PR TITLE
fix(contracts): assume no zero address for beneficiary address in `ProtocolFee` fuzz test

### DIFF
--- a/solidity/test/hooks/ProtocolFee.t.sol
+++ b/solidity/test/hooks/ProtocolFee.t.sol
@@ -73,6 +73,7 @@ contract ProtocolFeeTest is Test {
     }
 
     function testSetBeneficiary(address beneficiary) public {
+        vm.assume(beneficiary != address(0));
         vm.expectEmit(true, true, true, true);
         emit ProtocolFee.BeneficiarySet(beneficiary);
         fees.setBeneficiary(beneficiary);


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
