### PR TITLE
fix: another sealevel unit test flake

### DIFF
--- a/rust/sealevel/programs/mailbox-test/src/functional.rs
+++ b/rust/sealevel/programs/mailbox-test/src/functional.rs
@@ -979,7 +979,7 @@ async fn test_process_errors_if_message_already_processed() {
     .unwrap();
 
     // there's a race condition that isn't fixed by setting `CommitmentLevel::Confirmed`
-    // just wait a bit to ensure the account is created
+    // just wait a bit to ensure the message is processed
     sleep(std::time::Duration::from_secs(1));
 
     let result = process(

--- a/rust/sealevel/programs/mailbox-test/src/functional.rs
+++ b/rust/sealevel/programs/mailbox-test/src/functional.rs
@@ -1,3 +1,5 @@
+use std::thread::sleep;
+
 use borsh::BorshDeserialize;
 use hyperlane_core::{
     accumulator::incremental::IncrementalMerkle as MerkleTree, HyperlaneMessage, H256,
@@ -975,6 +977,10 @@ async fn test_process_errors_if_message_already_processed() {
     )
     .await
     .unwrap();
+
+    // there's a race condition that isn't fixed by setting `CommitmentLevel::Confirmed`
+    // just wait a bit to ensure the account is created
+    sleep(std::time::Duration::from_secs(1));
 
     let result = process(
         &mut banks_client,


### PR DESCRIPTION
Applies the same fix from https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4655 to a flake that showed up in this PRs CI: https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4693#event-15004545304