### PR TITLE
feat: Scraper stores input data from Ethereum transactions

### DIFF
--- a/rust/main/agents/scraper/migration/bin/generate_entities.rs
+++ b/rust/main/agents/scraper/migration/bin/generate_entities.rs
@@ -57,8 +57,8 @@ impl Drop for PostgresDockerContainer {
 async fn main() -> Result<(), DbErr> {
     assert_eq!(
         std::env::current_dir().unwrap().file_name().unwrap(),
-        "rust",
-        "Must run from the rust dir"
+        "main",
+        "Must run from the rust/main dir"
     );
     let postgres = PostgresDockerContainer::start();
 

--- a/rust/main/agents/scraper/migration/src/m20230309_000003_create_table_transaction.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000003_create_table_transaction.rs
@@ -52,6 +52,13 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new_with_type(Transaction::Recipient, Address).borrow_mut())
                     .col(ColumnDef::new_with_type(Transaction::GasUsed, Wei).not_null())
                     .col(ColumnDef::new_with_type(Transaction::CumulativeGasUsed, Wei).not_null())
+                    .col(
+                        ColumnDef::new_with_type(
+                            Transaction::RawInputData,
+                            ColumnType::Binary(BlobSize::Blob(None)),
+                        )
+                        .borrow_mut(),
+                    )
                     .foreign_key(
                         ForeignKey::create()
                             .from_col(Transaction::BlockId)
@@ -128,4 +135,6 @@ pub enum Transaction {
     GasUsed,
     /// Cumulative gas used within the block after this was executed
     CumulativeGasUsed,
+    /// Raw input data from Ethereum transaction
+    RawInputData,
 }

--- a/rust/main/agents/scraper/src/db/generated/transaction.rs
+++ b/rust/main/agents/scraper/src/db/generated/transaction.rs
@@ -27,6 +27,7 @@ pub struct Model {
     pub recipient: Option<Vec<u8>>,
     pub gas_used: BigDecimal,
     pub cumulative_gas_used: BigDecimal,
+    pub raw_input_data: Option<Vec<u8>>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -45,6 +46,7 @@ pub enum Column {
     Recipient,
     GasUsed,
     CumulativeGasUsed,
+    RawInputData,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -85,6 +87,7 @@ impl ColumnTrait for Column {
             Self::Recipient => ColumnType::Binary(BlobSize::Blob(None)).def().null(),
             Self::GasUsed => ColumnType::Decimal(Some((78u32, 0u32))).def(),
             Self::CumulativeGasUsed => ColumnType::Decimal(Some((78u32, 0u32))).def(),
+            Self::RawInputData => ColumnType::Binary(BlobSize::Blob(None)).def().null(),
         }
     }
 }

--- a/rust/main/agents/scraper/src/db/txn.rs
+++ b/rust/main/agents/scraper/src/db/txn.rs
@@ -94,6 +94,7 @@ impl ScraperDb {
                     recipient: Set(txn.recipient.as_ref().map(address_to_bytes)),
                     max_fee_per_gas: Set(txn.max_fee_per_gas.map(u256_to_decimal)),
                     cumulative_gas_used: Set(u256_to_decimal(receipt.cumulative_gas_used)),
+                    raw_input_data: Set(txn.raw_input_data.clone()),
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
@@ -441,6 +441,7 @@ impl HyperlaneProvider for CosmosProvider {
                 cumulative_gas_used: U256::from(response.tx_result.gas_used),
                 effective_gas_price: Some(gas_price),
             }),
+            raw_input_data: None,
         };
 
         Ok(tx_info)

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
@@ -106,7 +106,7 @@ where
             })
             .transpose()?;
 
-        Ok(TxnInfo {
+        let txn_info = TxnInfo {
             hash: *hash,
             max_fee_per_gas: txn.max_fee_per_gas.map(Into::into),
             max_priority_fee_per_gas: txn.max_priority_fee_per_gas.map(Into::into),
@@ -116,7 +116,10 @@ where
             sender: txn.from.into(),
             recipient: txn.to.map(Into::into),
             receipt,
-        })
+            raw_input_data: Some(txn.input.to_vec()),
+        };
+
+        Ok(txn_info)
     }
 
     #[instrument(err, skip(self))]

--- a/rust/main/chains/hyperlane-fuel/src/provider.rs
+++ b/rust/main/chains/hyperlane-fuel/src/provider.rs
@@ -381,6 +381,7 @@ impl HyperlaneProvider for FuelProvider {
                     gas_price: Some(gas_price.into()),
                     recipient,
                     receipt: None,
+                    raw_input_data: None,
                 })
             }
             None => Err(ChainCommunicationError::CustomError(format!(

--- a/rust/main/chains/hyperlane-sealevel/src/provider.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/provider.rs
@@ -116,6 +116,7 @@ impl HyperlaneProvider for SealevelProvider {
             sender: Default::default(),
             recipient: None,
             receipt: Some(receipt),
+            raw_input_data: None,
         })
     }
 

--- a/rust/main/hyperlane-core/src/types/chain_data.rs
+++ b/rust/main/hyperlane-core/src/types/chain_data.rs
@@ -49,6 +49,8 @@ pub struct TxnInfo {
     /// If the txn has been processed, we can also report some additional
     /// information.
     pub receipt: Option<TxnReceiptInfo>,
+    /// Raw input data of a transaction
+    pub raw_input_data: Option<Vec<u8>>,
 }
 
 /// Information about the execution of a transaction.


### PR DESCRIPTION
### Description

Scraper stores input data from Ethereum transactions

### Related issues

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4778

### Backward compatibility

Yes

### Testing

Manual run of Scraper against 
1. local database
2. database restored from backup of production database
