### PR TITLE
chore(contracts): made processInboundMessage payable to mock send value via mailbox.process

### DIFF
--- a/.changeset/six-drinks-eat.md
+++ b/.changeset/six-drinks-eat.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/core': minor
+---
+
+Made processInboundMessage payable to send value via mailbox.process

--- a/solidity/contracts/Mailbox.sol
+++ b/solidity/contracts/Mailbox.sol
@@ -10,7 +10,7 @@ import {IInterchainSecurityModule, ISpecifiesInterchainSecurityModule} from "./i
 import {IPostDispatchHook} from "./interfaces/hooks/IPostDispatchHook.sol";
 import {IMessageRecipient} from "./interfaces/IMessageRecipient.sol";
 import {IMailbox} from "./interfaces/IMailbox.sol";
-import {PackageVersioned} from "contracts/PackageVersioned.sol";
+import {PackageVersioned} from "./PackageVersioned.sol";
 
 // ============ External Imports ============
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
@@ -56,6 +56,7 @@ contract Mailbox is
         address processor;
         uint48 blockNumber;
     }
+
     mapping(bytes32 => Delivery) internal deliveries;
 
     // ============ Events ============

--- a/solidity/contracts/mock/MockMailbox.sol
+++ b/solidity/contracts/mock/MockMailbox.sol
@@ -78,8 +78,8 @@ contract MockMailbox is Mailbox {
         inboundProcessedNonce++;
     }
 
-    function processInboundMessage(uint32 _nonce) public {
+    function processInboundMessage(uint32 _nonce) public payable {
         bytes memory _message = inboundMessages[_nonce];
-        Mailbox(address(this)).process("", _message);
+        Mailbox(address(this)).process{value: msg.value}("", _message);
     }
 }


### PR DESCRIPTION
### Description

processInboundMessage needs to be payable for mocking sending value for ICA router call 

### Drive-by changes

None

### Related issues

None

### Backward compatibility

Yes

### Testing

None
