### PR TITLE
fix(cli): re-enable space key for multiselect prompt

### DIFF
--- a/.changeset/clean-dingos-switch.md
+++ b/.changeset/clean-dingos-switch.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+re-enable space key for multiselect cli prompt

--- a/typescript/cli/src/utils/chains.ts
+++ b/typescript/cli/src/utils/chains.ts
@@ -90,7 +90,7 @@ export async function runMultiChainSelectionStep({
           ? { ...choice, checked: true }
           : choice,
       ),
-      instructions: `Use TAB key to select at least ${requireNumber} chains, then press ENTER to proceed. Type to search for a specific chain.`,
+      instructions: `Use the TAB or the SPACE key to select at least ${requireNumber} chains, then press ENTER to proceed. Type to search for a specific chain.`,
       theme: {
         style: {
           // The leading space is needed because the help tip will be tightly close to the message header

--- a/typescript/cli/src/utils/input.ts
+++ b/typescript/cli/src/utils/input.ts
@@ -13,7 +13,7 @@ import {
   useState,
 } from '@inquirer/core';
 import figures from '@inquirer/figures';
-import { KeypressEvent, confirm, input } from '@inquirer/prompts';
+import { KeypressEvent, confirm, input, isSpaceKey } from '@inquirer/prompts';
 import type { PartialDeep } from '@inquirer/type';
 import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
@@ -373,9 +373,9 @@ function getHelpTips({
   let helpTipBottom = '';
   const defaultTopHelpTip =
     instructions ??
-    `(Press ${theme.style.key('tab')} to select, and ${theme.style.key(
-      'enter',
-    )} to proceed`;
+    `(Press ${theme.style.key('tab')} or ${theme.style.key(
+      'space',
+    )} to select, and ${theme.style.key('enter')} to proceed`;
   const defaultBottomHelpTip = `\n${theme.style.help(
     '(Use arrow keys to reveal more choices)',
   )}`;
@@ -587,7 +587,10 @@ export const searchableCheckBox = createPrompt(
           );
           setActive(next);
         }
-      } else if (key.name === 'tab' && optionState.options.length > 0) {
+      } else if (
+        (key.name === 'tab' || isSpaceKey(key)) &&
+        optionState.options.length > 0
+      ) {
         // Avoid the message header to be printed again in the console
         rl.clearLine(0);
 


### PR DESCRIPTION
### Description

Re-enables space key press for multi-select prompt

### Drive-by changes

- None

### Backward compatibility

- YES

### Testing

- Manual
