### PR TITLE
chore: instantiate router config in warp generators

### DIFF
--- a/typescript/infra/scripts/generate-eclipse-usdt-warp-route-config.ts
+++ b/typescript/infra/scripts/generate-eclipse-usdt-warp-route-config.ts
@@ -5,10 +5,12 @@ import { WarpRouteDeployConfigSchema } from '@hyperlane-xyz/sdk';
 
 import { getEclipseEthereumUSDTWarpConfig } from '../config/environments/mainnet3/warp/configGetters/getEclipseEthereumUSDTWarpConfig.js';
 
+import { getRouterConfig } from './warp-routes/utils.js';
+
 async function main() {
-  // remove the argument in the function definition to call
-  // const tokenConfig = await getEclipseEthereumUSDTWarpConfig();
-  const parsed = WarpRouteDeployConfigSchema.safeParse('');
+  let routerConfig = await getRouterConfig();
+  const tokenConfig = await getEclipseEthereumUSDTWarpConfig(routerConfig);
+  const parsed = WarpRouteDeployConfigSchema.safeParse(tokenConfig);
 
   if (!parsed.success) {
     console.dir(parsed.error.format(), { depth: null });

--- a/typescript/infra/scripts/generate-eclipse-usdt-warp-route-config.ts
+++ b/typescript/infra/scripts/generate-eclipse-usdt-warp-route-config.ts
@@ -8,7 +8,7 @@ import { getEclipseEthereumUSDTWarpConfig } from '../config/environments/mainnet
 import { getRouterConfig } from './warp-routes/utils.js';
 
 async function main() {
-  let routerConfig = await getRouterConfig();
+  const routerConfig = await getRouterConfig();
   const tokenConfig = await getEclipseEthereumUSDTWarpConfig(routerConfig);
   const parsed = WarpRouteDeployConfigSchema.safeParse(tokenConfig);
 

--- a/typescript/infra/scripts/generate-eclipse-wbtc-warp-route-config.ts
+++ b/typescript/infra/scripts/generate-eclipse-wbtc-warp-route-config.ts
@@ -8,7 +8,7 @@ import { getEclipseEthereumWBTCWarpConfig } from '../config/environments/mainnet
 import { getRouterConfig } from './warp-routes/utils.js';
 
 async function main() {
-  let routerConfig = await getRouterConfig();
+  const routerConfig = await getRouterConfig();
   const tokenConfig = await getEclipseEthereumWBTCWarpConfig(routerConfig);
   const parsed = WarpRouteDeployConfigSchema.safeParse(tokenConfig);
 

--- a/typescript/infra/scripts/generate-eclipse-wbtc-warp-route-config.ts
+++ b/typescript/infra/scripts/generate-eclipse-wbtc-warp-route-config.ts
@@ -5,10 +5,12 @@ import { WarpRouteDeployConfigSchema } from '@hyperlane-xyz/sdk';
 
 import { getEclipseEthereumWBTCWarpConfig } from '../config/environments/mainnet3/warp/configGetters/getEclipseEthereumWBTCWarpConfig.js';
 
+import { getRouterConfig } from './warp-routes/utils.js';
+
 async function main() {
-  // remove the argument in the function definition to call
-  // const tokenConfig = await getEclipseEthereumWBTCWarpConfig();
-  const parsed = WarpRouteDeployConfigSchema.safeParse('');
+  let routerConfig = await getRouterConfig();
+  const tokenConfig = await getEclipseEthereumWBTCWarpConfig(routerConfig);
+  const parsed = WarpRouteDeployConfigSchema.safeParse(tokenConfig);
 
   if (!parsed.success) {
     console.dir(parsed.error.format(), { depth: null });

--- a/typescript/infra/scripts/warp-routes/utils.ts
+++ b/typescript/infra/scripts/warp-routes/utils.ts
@@ -1,0 +1,30 @@
+import { Contexts } from '../../config/contexts.js';
+import { Role } from '../../src/roles.js';
+import {
+  getArgs,
+  withBuildArtifactPath,
+  withChains,
+  withConcurrentDeploy,
+  withContext,
+} from '../agent-utils.js';
+import { getEnvironmentConfig, getHyperlaneCore } from '../core-utils.js';
+
+export async function getRouterConfig() {
+  const {
+    context = Contexts.Hyperlane,
+    environment,
+    chains,
+  } = await withContext(
+    withConcurrentDeploy(withChains(withBuildArtifactPath(getArgs()))),
+  ).argv;
+  const envConfig = getEnvironmentConfig(environment);
+
+  let multiProvider = await envConfig.getMultiProvider(
+    context,
+    Role.Deployer,
+    true,
+    chains,
+  );
+  const { core } = await getHyperlaneCore(environment, multiProvider);
+  return core.getRouterConfig(envConfig.owners);
+}


### PR DESCRIPTION
### Description

Uncomments generator code to actually instantiate a `routerConfig`, as recommended in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4799#discussion_r1826157666

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
