### PR TITLE
fix: add collateralChainName to warp read

### DIFF
--- a/.changeset/quick-bags-check.md
+++ b/.changeset/quick-bags-check.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Add `collateralChainName` to Warp Reader. Partial refactor of fetchTokenConfig().

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -514,6 +514,7 @@ export { MailboxClientConfigSchema as mailboxClientConfigSchema } from './router
 export {
   CollateralConfig,
   NativeConfig,
+  TokenConfig,
   TokenRouterConfigSchema,
   WarpRouteDeployConfigSchema,
   WarpRouteDeployConfigSchemaErrors,

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -230,7 +230,7 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
       if (chainMetadata.nativeToken) {
         const { name, symbol, decimals } = chainMetadata.nativeToken;
         return {
-          type: TokenType.native,
+          type,
           name,
           symbol,
           decimals,

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -65,14 +65,14 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
     // Derive the config type
     const type = await this.deriveTokenType(warpRouteAddress);
     const baseMetadata = await this.fetchMailboxClientConfig(warpRouteAddress);
-    const tokenMetadata = await this.fetchTokenConfig(type, warpRouteAddress);
+    const tokenConfig = await this.fetchTokenConfig(type, warpRouteAddress);
     const remoteRouters = await this.fetchRemoteRouters(warpRouteAddress);
     const proxyAdmin = await this.fetchProxyAdminConfig(warpRouteAddress);
     const destinationGas = await this.fetchDestinationGas(warpRouteAddress);
 
     return {
       ...baseMetadata,
-      ...tokenMetadata,
+      ...tokenConfig,
       remoteRouters,
       proxyAdmin,
       destinationGas,

--- a/typescript/sdk/src/token/config.ts
+++ b/typescript/sdk/src/token/config.ts
@@ -15,12 +15,6 @@ export enum TokenType {
   nativeScaled = 'nativeScaled',
 }
 
-export const CollateralExtensions = [
-  TokenType.collateral,
-  TokenType.collateralVault,
-  TokenType.collateralVaultRebase,
-];
-
 export const gasOverhead = (tokenType: TokenType): number => {
   switch (tokenType) {
     case TokenType.fastSynthetic:

--- a/typescript/sdk/src/token/schemas.ts
+++ b/typescript/sdk/src/token/schemas.ts
@@ -74,6 +74,7 @@ export const TokenConfigSchema = z.discriminatedUnion('type', [
   SyntheticConfigSchema,
   SyntheticRebaseConfigSchema,
 ]);
+export type TokenConfig = z.infer<typeof TokenConfigSchema>;
 
 export const TokenRouterConfigSchema = TokenConfigSchema.and(
   GasRouterConfigSchema,


### PR DESCRIPTION
### Description
Fixes "warp read does not return collateralChainName for rebase vault type"  and "warp check fails when checking the config because collateralChainName is missing" of CLI 5.6 Bug Bash

### Backward compatibility
Yes

### Testing
Manual/Unit Tests

