### PR TITLE
feat: Remove unique chain id index from db migration script

### DIFF
--- a/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
@@ -490,7 +490,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Domain::TimeUpdated).timestamp().not_null())
                     .col(ColumnDef::new(Domain::Name).text().not_null())
                     .col(ColumnDef::new(Domain::NativeToken).text().not_null())
-                    .col(ColumnDef::new(Domain::ChainId).big_unsigned().unique_key())
+                    .col(ColumnDef::new(Domain::ChainId).big_unsigned())
                     .col(ColumnDef::new(Domain::IsTestNet).boolean().not_null())
                     .col(ColumnDef::new(Domain::IsDeprecated).boolean().not_null())
                     .to_owned(),

--- a/rust/main/agents/scraper/src/db/generated/domain.rs
+++ b/rust/main/agents/scraper/src/db/generated/domain.rs
@@ -65,7 +65,7 @@ impl ColumnTrait for Column {
             Self::TimeUpdated => ColumnType::DateTime.def(),
             Self::Name => ColumnType::Text.def(),
             Self::NativeToken => ColumnType::Text.def(),
-            Self::ChainId => ColumnType::BigInteger.def().null().unique(),
+            Self::ChainId => ColumnType::BigInteger.def().null(),
             Self::IsTestNet => ColumnType::Boolean.def(),
             Self::IsDeprecated => ColumnType::Boolean.def(),
         }


### PR DESCRIPTION
### Description

Remove unique chain id index from db migration script

### Related issues

- Contributes into https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4798

### Backward compatibility

Yes

### Testing

Manual run of DB migration script
