### PR TITLE
feat: deploy to abstracttestnet, treasuretopaz

### DIFF
--- a/.changeset/happy-suits-double.md
+++ b/.changeset/happy-suits-double.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Deploy to abstracttestnet and treasuretopaz

--- a/.registryrc
+++ b/.registryrc
@@ -1,1 +1,1 @@
-a797d721ecfb7bf3b6f31fb6eaf2b9001cadc3db
+f217569de02bf46f3eede192b223eb6983ca7fb6

--- a/rust/main/config/testnet_config.json
+++ b/rust/main/config/testnet_config.json
@@ -31,7 +31,7 @@
       "interchainAccountIsm": "0x6895d3916B94b386fAA6ec9276756e16dAe7480E",
       "interchainAccountRouter": "0xEbA64c8a9b4a61a9210d5fe7E4375380999C821b",
       "interchainGasPaymaster": "0x44769b0f4a6f01339e131a691cc2eebbb519d297",
-      "interchainSecurityModule": "0x863502F430eF41d4B3CC5C5eB3688Bc3310D3Bbd",
+      "interchainSecurityModule": "0xDf1d3c37FfA6134767911B8876305afc187dA207",
       "isTestnet": true,
       "mailbox": "0xEf9F292fcEBC3848bF4bB92a96a04F9ECBb78E59",
       "merkleTreeHook": "0x221FA9CBaFcd6c1C3d206571Cf4427703e023FFa",
@@ -94,7 +94,7 @@
         "from": 49690504
       },
       "interchainGasPaymaster": "0xc756cFc1b7d0d4646589EDf10eD54b201237F5e8",
-      "interchainSecurityModule": "0x7A1dB57297a154B674D53FD88e95C7823F8291B5",
+      "interchainSecurityModule": "0x69a84432Ba4FaD95FC5850aCD613C6daD286908C",
       "isTestnet": true,
       "mailbox": "0x598facE78a4302f11E3de0bee1894Da0b2Cb71F8",
       "merkleTreeHook": "0xAD34A66Bf6dB18E858F6B686557075568c6E031C",
@@ -162,7 +162,7 @@
         "from": 13851043
       },
       "interchainGasPaymaster": "0x28B02B97a850872C4D33C3E024fab6499ad96564",
-      "interchainSecurityModule": "0xDf6D05775678B9dF90578C4A84c9dE9E9f2D6601",
+      "interchainSecurityModule": "0x2945eCB46AE83B1A37b589A9c1219061522A73aD",
       "isTestnet": true,
       "mailbox": "0x6966b0E55883d49BFB24539356a2f8A673E02039",
       "merkleTreeHook": "0x86fb9F1c124fB20ff130C41a79a432F770f67AFD",
@@ -232,7 +232,7 @@
       "interchainAccountIsm": "0xa9D8Ec959F34272B1a56D09AF00eeee58970d3AE",
       "interchainAccountRouter": "0x6d2B3e304E58c2a19f1492E7cf15CaF63Ce6e0d2",
       "interchainGasPaymaster": "0x0dD20e410bdB95404f71c5a4e7Fa67B892A5f949",
-      "interchainSecurityModule": "0xe5118b2832be3F0fdBAbFC60D5a7BD7282F6B4f0",
+      "interchainSecurityModule": "0x0c29F3Ce8995b41eB8c2b3E1eC33c3fa10C8cf91",
       "isTestnet": true,
       "mailbox": "0xF9F6F5646F478d5ab4e20B0F910C92F1CCC9Cc6D",
       "merkleTreeHook": "0xc6cbF39A747f5E28d1bDc8D9dfDAb2960Abd5A8f",
@@ -301,7 +301,7 @@
         "from": 4950
       },
       "interchainGasPaymaster": "0xeC7eb4196Bd601DEa7585A744FbFB4CF11278450",
-      "interchainSecurityModule": "0x51a989e43452f9E38ec760A44D9D625256Ebc2a2",
+      "interchainSecurityModule": "0xa25786D36B5a5eDeCAf75142dD056B1Ed1473f44",
       "isTestnet": true,
       "mailbox": "0x6966b0E55883d49BFB24539356a2f8A673E02039",
       "merkleTreeHook": "0x4926a10788306D84202A2aDbd290b7743146Cc17",
@@ -402,7 +402,7 @@
         "from": 1606754
       },
       "interchainGasPaymaster": "0x28B02B97a850872C4D33C3E024fab6499ad96564",
-      "interchainSecurityModule": "0x44de9cE0f2ab382dEb479e5Afaf3D74Ea31EdE89",
+      "interchainSecurityModule": "0x1AFC8F84cAE294C3E6d3Ddb031946B93f08272b5",
       "isTestnet": true,
       "mailbox": "0x6966b0E55883d49BFB24539356a2f8A673E02039",
       "merkleTreeHook": "0x86fb9F1c124fB20ff130C41a79a432F770f67AFD",
@@ -468,7 +468,7 @@
       "interchainAccountIsm": "0xfaB4815BDC5c60c6bD625459C8577aFdD79D9311",
       "interchainAccountRouter": "0xeEF6933122894fF217a7dd07510b3D64b747e29b",
       "interchainGasPaymaster": "0x6895d3916B94b386fAA6ec9276756e16dAe7480E",
-      "interchainSecurityModule": "0x20c00D11720a6530216e2BDECC44D5B5447EcFe2",
+      "interchainSecurityModule": "0x7b5AD17cdAbdED0C29B161c647DA32dCE51AB13B",
       "isTestnet": true,
       "mailbox": "0x5b6CFf85442B851A8e6eaBd2A4E4507B5135B3B0",
       "merkleTreeHook": "0x9ff6ac3dAf63103620BBf76136eA1AFf43c2F612",
@@ -534,7 +534,7 @@
         "from": 1543015
       },
       "interchainGasPaymaster": "0x5CBf4e70448Ed46c2616b04e9ebc72D29FF0cfA9",
-      "interchainSecurityModule": "0xc9C22400Fa73f9Ee5edd4E330461bC63D33B0203",
+      "interchainSecurityModule": "0x16738b80D39Fa0652F2D853c3E6235Afb7cA6dDc",
       "isTestnet": true,
       "mailbox": "0x46f7C5D896bbeC89bE1B19e4485e59b4Be49e9Cc",
       "merkleTreeHook": "0x98AAE089CaD930C64a76dD2247a2aC5773a4B8cE",
@@ -599,7 +599,7 @@
         "from": 15833917
       },
       "interchainGasPaymaster": "0x28B02B97a850872C4D33C3E024fab6499ad96564",
-      "interchainSecurityModule": "0xDa949Fe06145546b0cD6865c6346A770A07FC600",
+      "interchainSecurityModule": "0x81B81B3b296ecf99d5bAC0DE4e5fF7a3ceECf08b",
       "isTestnet": true,
       "mailbox": "0x6966b0E55883d49BFB24539356a2f8A673E02039",
       "merkleTreeHook": "0x86fb9F1c124fB20ff130C41a79a432F770f67AFD",
@@ -727,7 +727,7 @@
         "from": 10634605
       },
       "interchainGasPaymaster": "0x6c13643B3927C57DB92c790E4E3E7Ee81e13f78C",
-      "interchainSecurityModule": "0xD6D5Aed44d2EdF7f0F73dE7860BDb5E02ef478C1",
+      "interchainSecurityModule": "0x428a2384F6013A9c561737E9A58288e071470192",
       "isTestnet": true,
       "mailbox": "0x54148470292C24345fb828B003461a9444414517",
       "merkleTreeHook": "0xddf4C3e791caCaFd26D7fb275549739B38ae6e75",
@@ -802,7 +802,7 @@
       "interchainAccountIsm": "0xE023239c8dfc172FF008D8087E7442d3eBEd9350",
       "interchainAccountRouter": "0xe17c37212d785760E8331D4A4395B17b34Ba8cDF",
       "interchainGasPaymaster": "0x86fb9F1c124fB20ff130C41a79a432F770f67AFD",
-      "interchainSecurityModule": "0xEb786a246FFBd9AA9609872570F789A11268D874",
+      "interchainSecurityModule": "0xb9A0fa05Fcce52605f0142c1A5Aca32f223eB961",
       "isTestnet": true,
       "mailbox": "0x3C5154a193D6e2955650f9305c8d80c18C814A68",
       "merkleTreeHook": "0x863E8c26621c52ACa1849C53500606e73BA272F0",
@@ -880,7 +880,7 @@
       "interchainAccountIsm": "0x83a3068B719F764d413625dA77468ED74789ae02",
       "interchainAccountRouter": "0x8e131c8aE5BF1Ed38D05a00892b6001a7d37739d",
       "interchainGasPaymaster": "0x6f2756380FD49228ae25Aa7F2817993cB74Ecc56",
-      "interchainSecurityModule": "0xcB9775E2BBDb651BFf0919f07f82291Edf60b46c",
+      "interchainSecurityModule": "0x5bC248C8010848067919fA73F4555AeE95Df38a4",
       "isTestnet": true,
       "mailbox": "0xfFAEF09B3cd11D9b20d1a19bECca54EEC2884766",
       "merkleTreeHook": "0x4917a9746A7B6E0A57159cCb7F5a6744247f2d0d",
@@ -990,7 +990,7 @@
         "from": 3111622
       },
       "interchainGasPaymaster": "0xeC7eb4196Bd601DEa7585A744FbFB4CF11278450",
-      "interchainSecurityModule": "0x150120ab53A79F08CdA1BC966D67497B3a4850C7",
+      "interchainSecurityModule": "0x8a833B1230A75712a767e81556F1Ad612A0F76F3",
       "isTestnet": true,
       "mailbox": "0x6966b0E55883d49BFB24539356a2f8A673E02039",
       "merkleTreeHook": "0x4926a10788306D84202A2aDbd290b7743146Cc17",
@@ -1078,7 +1078,7 @@
       "interchainAccountIsm": "0xA2cf52064c921C11adCd83588CbEa08cc3bfF5d8",
       "interchainAccountRouter": "0xa3AB7E6cE24E6293bD5320A53329Ef2f4DE73fCA",
       "interchainGasPaymaster": "0x04438ef7622f5412f82915F59caD4f704C61eA48",
-      "interchainSecurityModule": "0x502aAc4F3EB74859da30b51B027a886FC13c70Ff",
+      "interchainSecurityModule": "0x5e39968B0435332dE915C2FF62fD373fBbbb7C75",
       "mailbox": "0xDDcFEcF17586D08A5740B7D91735fcCE3dfe3eeD",
       "merkleTreeHook": "0x6c13643B3927C57DB92c790E4E3E7Ee81e13f78C",
       "pausableHook": "0x783c4a0bB6663359281aD4a637D5af68F83ae213",
@@ -1138,7 +1138,7 @@
       "interchainAccountIsm": "0xD356C996277eFb7f75Ee8bd61b31cC781A12F54f",
       "interchainAccountRouter": "0x867f2089D09903f208AeCac84E599B90E5a4A821",
       "interchainGasPaymaster": "0xA2cf52064c921C11adCd83588CbEa08cc3bfF5d8",
-      "interchainSecurityModule": "0x67cd2504Eb4702AA84B1A74289D18Db8Cf536006",
+      "interchainSecurityModule": "0x97b1e5FBF33d82fAD9C3Aa0fF901e9B9d63090E3",
       "mailbox": "0xDDcFEcF17586D08A5740B7D91735fcCE3dfe3eeD",
       "merkleTreeHook": "0xD5eB5fa3f470eBBB93a4A58C644c87031268a04A",
       "pausableHook": "0x51A0a100e7BC63Ea7821A3a023B6F17fb94FF011",
@@ -1206,7 +1206,7 @@
       "interchainAccountIsm": "0xFfa913705484C9BAea32Ffe9945BeA099A1DFF72",
       "interchainAccountRouter": "0xB5fB1F5410a2c2b7deD462d018541383968cB01c",
       "interchainGasPaymaster": "0xD5eB5fa3f470eBBB93a4A58C644c87031268a04A",
-      "interchainSecurityModule": "0xB0719a2fA10CAdE7bD8a5f18Db855235FA29c42a",
+      "interchainSecurityModule": "0xAfDF88EB9447e412c89304F34813c5564307709b",
       "mailbox": "0xB08d78F439e55D02C398519eef61606A5926245F",
       "merkleTreeHook": "0x783c4a0bB6663359281aD4a637D5af68F83ae213",
       "pausableHook": "0x66b71A4e18FbE09a6977A6520B47fEDdffA82a1c",
@@ -1267,7 +1267,7 @@
       "interchainAccountIsm": "0xD356C996277eFb7f75Ee8bd61b31cC781A12F54f",
       "interchainAccountRouter": "0x867f2089D09903f208AeCac84E599B90E5a4A821",
       "interchainGasPaymaster": "0xA2cf52064c921C11adCd83588CbEa08cc3bfF5d8",
-      "interchainSecurityModule": "0x9C75f6faE951262f5c4930aea3b8210D987519AD",
+      "interchainSecurityModule": "0xe5B27D2198EEacf4FeC7d558CdE3b4fDCe4d37f9",
       "mailbox": "0xDDcFEcF17586D08A5740B7D91735fcCE3dfe3eeD",
       "merkleTreeHook": "0xD5eB5fa3f470eBBB93a4A58C644c87031268a04A",
       "pausableHook": "0x51A0a100e7BC63Ea7821A3a023B6F17fb94FF011",
@@ -1395,7 +1395,7 @@
       "interchainAccountIsm": "0xD356C996277eFb7f75Ee8bd61b31cC781A12F54f",
       "interchainAccountRouter": "0x867f2089D09903f208AeCac84E599B90E5a4A821",
       "interchainGasPaymaster": "0xA2cf52064c921C11adCd83588CbEa08cc3bfF5d8",
-      "interchainSecurityModule": "0xe7cfc362943cd36091Ce1f96a75D271D04A896d2",
+      "interchainSecurityModule": "0x8714Caec7020c611DA73811E897A879C22d7C396",
       "mailbox": "0xDDcFEcF17586D08A5740B7D91735fcCE3dfe3eeD",
       "merkleTreeHook": "0xD5eB5fa3f470eBBB93a4A58C644c87031268a04A",
       "pausableHook": "0x51A0a100e7BC63Ea7821A3a023B6F17fb94FF011",
@@ -1459,7 +1459,7 @@
       "interchainAccountIsm": "0xD356C996277eFb7f75Ee8bd61b31cC781A12F54f",
       "interchainAccountRouter": "0x867f2089D09903f208AeCac84E599B90E5a4A821",
       "interchainGasPaymaster": "0xA2cf52064c921C11adCd83588CbEa08cc3bfF5d8",
-      "interchainSecurityModule": "0x95ff7ef38d87DD7C0850268934197dAC5b626d41",
+      "interchainSecurityModule": "0x0511f73F8D734e0fc9df1E6C0937592a3A371B18",
       "mailbox": "0xDDcFEcF17586D08A5740B7D91735fcCE3dfe3eeD",
       "merkleTreeHook": "0xD5eB5fa3f470eBBB93a4A58C644c87031268a04A",
       "pausableHook": "0x51A0a100e7BC63Ea7821A3a023B6F17fb94FF011",
@@ -1710,7 +1710,7 @@
       "interchainAccountIsm": "0x39c85C84876479694A2470c0E8075e9d68049aFc",
       "interchainAccountRouter": "0x80fE4Cb8c70fc60B745d4ffD4403c27a8cBC9e02",
       "interchainGasPaymaster": "0xfBeaF07855181f8476B235Cf746A7DF3F9e386Fb",
-      "interchainSecurityModule": "0x39454E12262c13E3C5148F5af0dA6Bfae7c6CFEb",
+      "interchainSecurityModule": "0x3865c419335B36d9CE240b515124Ab1c33927004",
       "mailbox": "0x33dB966328Ea213b0f76eF96CA368AB37779F065",
       "merkleTreeHook": "0xEa7e618Bee8927fBb2fA20Bc41eE8DEA51838aAD",
       "pausableHook": "0x4fE19d49F45854Da50b6009258929613EC92C147",
@@ -1773,7 +1773,7 @@
       "interchainAccountIsm": "0xc08675806BA844467E559E45E4bB59e66778bDcd",
       "interchainAccountRouter": "0x39c85C84876479694A2470c0E8075e9d68049aFc",
       "interchainGasPaymaster": "0xa3AB7E6cE24E6293bD5320A53329Ef2f4DE73fCA",
-      "interchainSecurityModule": "0xc87fF93d00B60274233292351E0A42709E90B27e",
+      "interchainSecurityModule": "0x4B310268158B842cbE65A216714C6A7D1d087155",
       "mailbox": "0xDDcFEcF17586D08A5740B7D91735fcCE3dfe3eeD",
       "merkleTreeHook": "0x086E902d2f99BcCEAa28B31747eC6Dc5fd43B1bE",
       "pausableHook": "0xe0B988062A0C6492177d64823Ab95a9c256c2a5F",
@@ -1836,7 +1836,7 @@
       "interchainAccountIsm": "0x3ca332A585FDB9d4FF51f2FA8999eA32184D3606",
       "interchainAccountRouter": "0x4eC139a771eBdD3b0a0b67bb7E08960210882d44",
       "interchainGasPaymaster": "0xa3AB7E6cE24E6293bD5320A53329Ef2f4DE73fCA",
-      "interchainSecurityModule": "0xC1E52cBA12c4efC8d14A0370fB96169272d6752A",
+      "interchainSecurityModule": "0xAd6172DA241CE5DC38a32E0E375FD0A1889b9E48",
       "mailbox": "0xDDcFEcF17586D08A5740B7D91735fcCE3dfe3eeD",
       "merkleTreeHook": "0x086E902d2f99BcCEAa28B31747eC6Dc5fd43B1bE",
       "pausableHook": "0xe0B988062A0C6492177d64823Ab95a9c256c2a5F",
@@ -1899,7 +1899,7 @@
       "interchainAccountIsm": "0xBF2C366530C1269d531707154948494D3fF4AcA7",
       "interchainAccountRouter": "0xBdf49bE2201A1c4B13023F0a407196C6Adb32680",
       "interchainGasPaymaster": "0xD356C996277eFb7f75Ee8bd61b31cC781A12F54f",
-      "interchainSecurityModule": "0x6895eF0fd1A2Be31eFDf626E37CEc8C234C9f515",
+      "interchainSecurityModule": "0xa6570241124A6534801d1eba13F46078Dc7d1974",
       "mailbox": "0xDDcFEcF17586D08A5740B7D91735fcCE3dfe3eeD",
       "merkleTreeHook": "0xFfa913705484C9BAea32Ffe9945BeA099A1DFF72",
       "pausableHook": "0xc76E477437065093D353b7d56c81ff54D167B0Ab",
@@ -1970,7 +1970,7 @@
       "interchainAccountIsm": "0x342B5630Ba1C1e4d3048E51Dad208201aF52692c",
       "interchainAccountRouter": "0xe036768e48Cb0D42811d2bF0748806FCcBfCd670",
       "interchainGasPaymaster": "0x867f2089D09903f208AeCac84E599B90E5a4A821",
-      "interchainSecurityModule": "0xeCd57d428E571B407AC491171ffDD6A9875efCCC",
+      "interchainSecurityModule": "0xbe84F098eE49c32395edA629737AD3f4c0542ADA",
       "mailbox": "0xDDcFEcF17586D08A5740B7D91735fcCE3dfe3eeD",
       "merkleTreeHook": "0xB5fB1F5410a2c2b7deD462d018541383968cB01c",
       "pausableHook": "0x7483faD0Bc297667664A43A064bA7c9911659f57",
@@ -2029,7 +2029,7 @@
       "domainRoutingIsmFactory": "0x44b764045BfDC68517e10e783E69B376cef196B2",
       "fallbackRoutingHook": "0xD356C996277eFb7f75Ee8bd61b31cC781A12F54f",
       "interchainGasPaymaster": "0x54Bd02f0f20677e9846F8E9FdB1Abc7315C49C38",
-      "interchainSecurityModule": "0x16977B194B3d61aA30F70A5521ac6bbfaa4CF460",
+      "interchainSecurityModule": "0x3490059390DDc4de38822488A1D63B4e131D0Aaf",
       "mailbox": "0xDDcFEcF17586D08A5740B7D91735fcCE3dfe3eeD",
       "merkleTreeHook": "0x4fE19d49F45854Da50b6009258929613EC92C147",
       "pausableHook": "0x01812D60958798695391dacF092BAc4a715B1718",
@@ -2048,6 +2048,121 @@
       "validatorAnnounce": "0xBdf49bE2201A1c4B13023F0a407196C6Adb32680",
       "index": {
         "from": 1915290
+      }
+    },
+    "abstracttestnet": {
+      "blockExplorers": [
+        {
+          "apiUrl": "https://api-explorer-verify.testnet.abs.xyz/contract_verification",
+          "family": "etherscan",
+          "name": "Abstract Block Explorer",
+          "url": "https://explorer.testnet.abs.xyz"
+        }
+      ],
+      "blocks": {
+        "confirmations": 1,
+        "estimateBlockTime": 1,
+        "reorgPeriod": 0
+      },
+      "chainId": 11124,
+      "deployer": {
+        "name": "Abacus Works",
+        "url": "https://www.hyperlane.xyz"
+      },
+      "displayName": "Abstract Testnet",
+      "domainId": 11124,
+      "isTestnet": true,
+      "name": "abstracttestnet",
+      "nativeToken": {
+        "decimals": 18,
+        "name": "Ethereum",
+        "symbol": "ETH"
+      },
+      "protocol": "ethereum",
+      "rpcUrls": [
+        {
+          "http": "https://api.testnet.abs.xyz"
+        }
+      ],
+      "technicalStack": "zksync",
+      "domainRoutingIsm": "0x7ca1b3fa385F3585f8ab58c0bC90A421689141B8",
+      "domainRoutingIsmFactory": "0x0000000000000000000000000000000000000000",
+      "fallbackDomainRoutingHook": "0x623f284257f133E8bE7c74f6D4D684B61FE8923a",
+      "fallbackRoutingHook": "0x623f284257f133E8bE7c74f6D4D684B61FE8923a",
+      "interchainGasPaymaster": "0xbAaE1B4e953190b05C757F69B2F6C46b9548fa4f",
+      "interchainSecurityModule": "0x7ca1b3fa385F3585f8ab58c0bC90A421689141B8",
+      "mailbox": "0x28f448885bEaaF662f8A9A6c9aF20fAd17A5a1DC",
+      "merkleTreeHook": "0x7fa6009b59F139813eA710dB5496976eE8D80E64",
+      "proxyAdmin": "0xfbA0c57A6BA24B5440D3e2089222099b4663B98B",
+      "staticAggregationHookFactory": "0x0000000000000000000000000000000000000000",
+      "staticAggregationIsmFactory": "0x0000000000000000000000000000000000000000",
+      "staticMerkleRootMultisigIsmFactory": "0x0000000000000000000000000000000000000000",
+      "staticMerkleRootWeightedMultisigIsmFactory": "0x0000000000000000000000000000000000000000",
+      "staticMessageIdMultisigIsmFactory": "0x0000000000000000000000000000000000000000",
+      "staticMessageIdWeightedMultisigIsmFactory": "0x0000000000000000000000000000000000000000",
+      "storageGasOracle": "0x5F1bADC7e28B9b4C98f58dB4e5841e5bf63A7A52",
+      "testRecipient": "0x9EC79CA89DeF61BFa2f38cD4fCC137b9e49d60dD",
+      "validatorAnnounce": "0xfE9a467831a28Ec3D54deCCf0A2A41fa77dDD1D7",
+      "index": {
+        "from": 964305
+      }
+    },
+    "treasuretopaz": {
+      "blockExplorers": [
+        {
+          "apiUrl": "https://rpc-explorer-verify.topaz.treasure.lol/contract_verification",
+          "family": "etherscan",
+          "name": "Treasure Topaz Block Explorer",
+          "url": "https://topaz.treasurescan.io"
+        }
+      ],
+      "blocks": {
+        "confirmations": 1,
+        "estimateBlockTime": 1,
+        "reorgPeriod": 0
+      },
+      "chainId": 978658,
+      "deployer": {
+        "name": "Abacus Works",
+        "url": "https://www.hyperlane.xyz"
+      },
+      "displayName": "Treasure Topaz Testnet",
+      "displayNameShort": "Treasure Testnet",
+      "domainId": 978658,
+      "isTestnet": true,
+      "name": "treasuretopaz",
+      "nativeToken": {
+        "decimals": 18,
+        "name": "MAGIC",
+        "symbol": "MAGIC"
+      },
+      "protocol": "ethereum",
+      "rpcUrls": [
+        {
+          "http": "https://rpc.topaz.treasure.lol"
+        }
+      ],
+      "technicalStack": "zksync",
+      "domainRoutingIsm": "0x7ca1b3fa385F3585f8ab58c0bC90A421689141B8",
+      "domainRoutingIsmFactory": "0x0000000000000000000000000000000000000000",
+      "fallbackDomainRoutingHook": "0x623f284257f133E8bE7c74f6D4D684B61FE8923a",
+      "fallbackRoutingHook": "0x623f284257f133E8bE7c74f6D4D684B61FE8923a",
+      "interchainGasPaymaster": "0xbAaE1B4e953190b05C757F69B2F6C46b9548fa4f",
+      "interchainSecurityModule": "0x7ca1b3fa385F3585f8ab58c0bC90A421689141B8",
+      "mailbox": "0x28f448885bEaaF662f8A9A6c9aF20fAd17A5a1DC",
+      "merkleTreeHook": "0x7fa6009b59F139813eA710dB5496976eE8D80E64",
+      "proxyAdmin": "0xfbA0c57A6BA24B5440D3e2089222099b4663B98B",
+      "staticAggregationHookFactory": "0x0000000000000000000000000000000000000000",
+      "staticAggregationIsmFactory": "0x0000000000000000000000000000000000000000",
+      "staticMerkleRootMultisigIsmFactory": "0x0000000000000000000000000000000000000000",
+      "staticMerkleRootWeightedMultisigIsmFactory": "0x0000000000000000000000000000000000000000",
+      "staticMessageIdMultisigIsmFactory": "0x0000000000000000000000000000000000000000",
+      "staticMessageIdWeightedMultisigIsmFactory": "0x0000000000000000000000000000000000000000",
+      "storageGasOracle": "0x5F1bADC7e28B9b4C98f58dB4e5841e5bf63A7A52",
+      "testRecipient": "0x9EC79CA89DeF61BFa2f38cD4fCC137b9e49d60dD",
+      "validatorAnnounce": "0xfE9a467831a28Ec3D54deCCf0A2A41fa77dDD1D7",
+      "index": {
+        "from": 86008
       }
     }
   },

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -41,6 +41,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
   typeof testnet4SupportedChainNames
 > = {
   [Role.Validator]: {
+    abstracttestnet: true,
     alephzeroevmtestnet: true,
     alfajores: true,
     arbitrumsepolia: true,
@@ -70,9 +71,11 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     sonictestnet: true,
     suavetoliman: true,
     superpositiontestnet: true,
+    treasuretopaz: true,
     unichaintestnet: true,
   },
   [Role.Relayer]: {
+    abstracttestnet: true,
     alephzeroevmtestnet: true,
     alfajores: true,
     arbitrumsepolia: true,
@@ -102,9 +105,11 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     sonictestnet: true,
     suavetoliman: true,
     superpositiontestnet: true,
+    treasuretopaz: true,
     unichaintestnet: true,
   },
   [Role.Scraper]: {
+    abstracttestnet: true,
     alephzeroevmtestnet: true,
     alfajores: true,
     arbitrumsepolia: true,
@@ -136,6 +141,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     sonictestnet: true,
     suavetoliman: true,
     superpositiontestnet: false,
+    treasuretopaz: true,
     unichaintestnet: true,
   },
 };

--- a/typescript/infra/config/environments/testnet4/aw-validators/hyperlane.json
+++ b/typescript/infra/config/environments/testnet4/aw-validators/hyperlane.json
@@ -93,5 +93,11 @@
   },
   "unichaintestnet": {
     "validators": ["0x5e99961cf71918308c3b17ef21b5f515a4f86fe5"]
+  },
+  "abstracttestnet": {
+    "validators": ["0x7655bc4c9802bfcb3132b8822155b60a4fbbce3e"]
+  },
+  "treasuretopaz": {
+    "validators": ["0x9750849beda0a7870462d4685f953fe39033a5ae"]
   }
 }

--- a/typescript/infra/config/environments/testnet4/core/verification.json
+++ b/typescript/infra/config/environments/testnet4/core/verification.json
@@ -2130,5 +2130,121 @@
       "constructorArguments": "000000000000000000000000ddcfecf17586d08a5740b7d91735fcce3dfe3eed",
       "isProxy": false
     }
+  ],
+  "treasuretopaz": [
+    {
+      "name": "ProxyAdmin",
+      "address": "0xfbA0c57A6BA24B5440D3e2089222099b4663B98B",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "Mailbox",
+      "address": "0x5f33Bf018C55CD3034ac06e6DA41162F5acc2fF7",
+      "constructorArguments": "00000000000000000000000000000000000000000000000000000000000eeee2",
+      "isProxy": false
+    },
+    {
+      "name": "TransparentUpgradeableProxy",
+      "address": "0x28f448885bEaaF662f8A9A6c9aF20fAd17A5a1DC",
+      "constructorArguments": "0000000000000000000000005f33bf018c55cd3034ac06e6da41162f5acc2ff7000000000000000000000000fba0c57a6ba24b5440d3e2089222099b4663b98b00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000",
+      "isProxy": true,
+      "expectedimplementation": "0x5f33Bf018C55CD3034ac06e6DA41162F5acc2fF7"
+    },
+    {
+      "name": "MerkleTreeHook",
+      "address": "0x7fa6009b59F139813eA710dB5496976eE8D80E64",
+      "constructorArguments": "00000000000000000000000028f448885beaaf662f8a9a6c9af20fad17a5a1dc",
+      "isProxy": false
+    },
+    {
+      "name": "FallbackDomainRoutingHook",
+      "address": "0x623f284257f133E8bE7c74f6D4D684B61FE8923a",
+      "constructorArguments": "00000000000000000000000028f448885beaaf662f8a9a6c9af20fad17a5a1dc000000000000000000000000fad1c94469700833717fa8a3017278bc1ca8031c0000000000000000000000007fa6009b59f139813ea710db5496976ee8d80e64",
+      "isProxy": false
+    },
+    {
+      "name": "StorageGasOracle",
+      "address": "0x5F1bADC7e28B9b4C98f58dB4e5841e5bf63A7A52",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0xeBe8D0e2BD026D12Ca5e51edA3B0D2b413e83c9c",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "TransparentUpgradeableProxy",
+      "address": "0xbAaE1B4e953190b05C757F69B2F6C46b9548fa4f",
+      "constructorArguments": "000000000000000000000000ebe8d0e2bd026d12ca5e51eda3b0d2b413e83c9c000000000000000000000000fba0c57a6ba24b5440d3e2089222099b4663b98b00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000044485cc955000000000000000000000000fad1c94469700833717fa8a3017278bc1ca8031c000000000000000000000000fad1c94469700833717fa8a3017278bc1ca8031c00000000000000000000000000000000000000000000000000000000",
+      "isProxy": true,
+      "expectedimplementation": "0xeBe8D0e2BD026D12Ca5e51edA3B0D2b413e83c9c"
+    },
+    {
+      "name": "ValidatorAnnounce",
+      "address": "0xfE9a467831a28Ec3D54deCCf0A2A41fa77dDD1D7",
+      "constructorArguments": "00000000000000000000000028f448885beaaf662f8a9a6c9af20fad17a5a1dc",
+      "isProxy": false
+    }
+  ],
+  "abstracttestnet": [
+    {
+      "name": "ProxyAdmin",
+      "address": "0xfbA0c57A6BA24B5440D3e2089222099b4663B98B",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "Mailbox",
+      "address": "0x5f33Bf018C55CD3034ac06e6DA41162F5acc2fF7",
+      "constructorArguments": "0000000000000000000000000000000000000000000000000000000000002b74",
+      "isProxy": false
+    },
+    {
+      "name": "TransparentUpgradeableProxy",
+      "address": "0x28f448885bEaaF662f8A9A6c9aF20fAd17A5a1DC",
+      "constructorArguments": "0000000000000000000000005f33bf018c55cd3034ac06e6da41162f5acc2ff7000000000000000000000000fba0c57a6ba24b5440d3e2089222099b4663b98b00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000",
+      "isProxy": true,
+      "expectedimplementation": "0x5f33Bf018C55CD3034ac06e6DA41162F5acc2fF7"
+    },
+    {
+      "name": "MerkleTreeHook",
+      "address": "0x7fa6009b59F139813eA710dB5496976eE8D80E64",
+      "constructorArguments": "00000000000000000000000028f448885beaaf662f8a9a6c9af20fad17a5a1dc",
+      "isProxy": false
+    },
+    {
+      "name": "FallbackDomainRoutingHook",
+      "address": "0x623f284257f133E8bE7c74f6D4D684B61FE8923a",
+      "constructorArguments": "00000000000000000000000028f448885beaaf662f8a9a6c9af20fad17a5a1dc000000000000000000000000fad1c94469700833717fa8a3017278bc1ca8031c0000000000000000000000007fa6009b59f139813ea710db5496976ee8d80e64",
+      "isProxy": false
+    },
+    {
+      "name": "StorageGasOracle",
+      "address": "0x5F1bADC7e28B9b4C98f58dB4e5841e5bf63A7A52",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0xeBe8D0e2BD026D12Ca5e51edA3B0D2b413e83c9c",
+      "constructorArguments": "",
+      "isProxy": false
+    },
+    {
+      "name": "TransparentUpgradeableProxy",
+      "address": "0xbAaE1B4e953190b05C757F69B2F6C46b9548fa4f",
+      "constructorArguments": "000000000000000000000000ebe8d0e2bd026d12ca5e51eda3b0d2b413e83c9c000000000000000000000000fba0c57a6ba24b5440d3e2089222099b4663b98b00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000044485cc955000000000000000000000000fad1c94469700833717fa8a3017278bc1ca8031c000000000000000000000000fad1c94469700833717fa8a3017278bc1ca8031c00000000000000000000000000000000000000000000000000000000",
+      "isProxy": true,
+      "expectedimplementation": "0xeBe8D0e2BD026D12Ca5e51edA3B0D2b413e83c9c"
+    },
+    {
+      "name": "ValidatorAnnounce",
+      "address": "0xfE9a467831a28Ec3D54deCCf0A2A41fa77dDD1D7",
+      "constructorArguments": "00000000000000000000000028f448885beaaf662f8a9a6c9af20fad17a5a1dc",
+      "isProxy": false
+    }
   ]
 }

--- a/typescript/infra/config/environments/testnet4/funding.ts
+++ b/typescript/infra/config/environments/testnet4/funding.ts
@@ -26,6 +26,7 @@ export const keyFunderConfig: KeyFunderConfig<
   },
   // desired balance config
   desiredBalancePerChain: {
+    abstracttestnet: '0.1',
     alephzeroevmtestnet: '2',
     alfajores: '5',
     arbitrumsepolia: '0.1',
@@ -57,6 +58,7 @@ export const keyFunderConfig: KeyFunderConfig<
     sonictestnet: '1',
     suavetoliman: '0.1',
     superpositiontestnet: '1',
+    treasuretopaz: '5',
     unichaintestnet: '0.1',
   },
   desiredKathyBalancePerChain: {

--- a/typescript/infra/config/environments/testnet4/gasPrices.json
+++ b/typescript/infra/config/environments/testnet4/gasPrices.json
@@ -1,4 +1,8 @@
 {
+  "abstracttestnet": {
+    "amount": "0.060764843",
+    "decimals": 9
+  },
   "alephzeroevmtestnet": {
     "amount": "40.0",
     "decimals": 9
@@ -16,11 +20,11 @@
     "decimals": 9
   },
   "basesepolia": {
-    "amount": "0.001000308",
+    "amount": "0.00236715",
     "decimals": 9
   },
   "berabartio": {
-    "amount": "1.550227134",
+    "amount": "10.832064411",
     "decimals": 9
   },
   "bsctestnet": {
@@ -32,7 +36,7 @@
     "decimals": 9
   },
   "citreatestnet": {
-    "amount": "1.5",
+    "amount": "5.032361163",
     "decimals": 9
   },
   "connextsepolia": {
@@ -56,7 +60,7 @@
     "decimals": 9
   },
   "holesky": {
-    "amount": "0.318071759",
+    "amount": "0.760231049",
     "decimals": 9
   },
   "inksepolia": {
@@ -68,19 +72,19 @@
     "decimals": 9
   },
   "optimismsepolia": {
-    "amount": "0.001000253",
+    "amount": "0.001000256",
     "decimals": 9
   },
   "polygonamoy": {
-    "amount": "35.0",
+    "amount": "56.722205902",
     "decimals": 9
   },
   "scrollsepolia": {
-    "amount": "22.997979926",
+    "amount": "2.398017347",
     "decimals": 9
   },
   "sepolia": {
-    "amount": "6.302602541",
+    "amount": "4.349910601",
     "decimals": 9
   },
   "solanatestnet": {
@@ -88,7 +92,7 @@
     "decimals": 9
   },
   "soneiumtestnet": {
-    "amount": "0.001000273",
+    "amount": "0.001000259",
     "decimals": 9
   },
   "sonictestnet": {
@@ -96,15 +100,19 @@
     "decimals": 9
   },
   "suavetoliman": {
-    "amount": "1.0",
+    "amount": "2.0736",
     "decimals": 9
   },
   "superpositiontestnet": {
     "amount": "0.01",
     "decimals": 9
   },
+  "treasuretopaz": {
+    "amount": "0.060735501",
+    "decimals": 9
+  },
   "unichaintestnet": {
-    "amount": "0.00100027",
+    "amount": "0.001000264",
     "decimals": 9
   }
 }

--- a/typescript/infra/config/environments/testnet4/supportedChainNames.ts
+++ b/typescript/infra/config/environments/testnet4/supportedChainNames.ts
@@ -1,5 +1,6 @@
 // Placing them here instead of adjacent chains file to avoid circular dep
 export const testnet4SupportedChainNames = [
+  'abstracttestnet',
   'alephzeroevmtestnet',
   'alfajores',
   'arbitrumsepolia',
@@ -29,6 +30,7 @@ export const testnet4SupportedChainNames = [
   'sonictestnet',
   'suavetoliman',
   'superpositiontestnet',
+  'treasuretopaz',
   'unichaintestnet',
 ] as const;
 

--- a/typescript/infra/config/environments/testnet4/tokenPrices.json
+++ b/typescript/infra/config/environments/testnet4/tokenPrices.json
@@ -1,4 +1,5 @@
 {
+  "abstracttestnet": "10",
   "alephzeroevmtestnet": "10",
   "alfajores": "10",
   "arbitrumsepolia": "10",
@@ -25,5 +26,6 @@
   "sonictestnet": "10",
   "suavetoliman": "10",
   "superpositiontestnet": "10",
+  "treasuretopaz": "10",
   "unichaintestnet": "10"
 }

--- a/typescript/infra/config/environments/testnet4/validators.ts
+++ b/typescript/infra/config/environments/testnet4/validators.ts
@@ -368,5 +368,30 @@ export const validatorChainConfig = (
         'inksepolia',
       ),
     },
+
+    abstracttestnet: {
+      interval: 5,
+      reorgPeriod: getReorgPeriod('abstracttestnet'),
+      validators: validatorsConfig(
+        {
+          [Contexts.Hyperlane]: ['0x7655bc4c9802bfcb3132b8822155b60a4fbbce3e'],
+          [Contexts.ReleaseCandidate]: [],
+          [Contexts.Neutron]: [],
+        },
+        'abstracttestnet',
+      ),
+    },
+    treasuretopaz: {
+      interval: 5,
+      reorgPeriod: getReorgPeriod('treasuretopaz'),
+      validators: validatorsConfig(
+        {
+          [Contexts.Hyperlane]: ['0x9750849beda0a7870462d4685f953fe39033a5ae'],
+          [Contexts.ReleaseCandidate]: [],
+          [Contexts.Neutron]: [],
+        },
+        'treasuretopaz',
+      ),
+    },
   };
 };

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -19,8 +19,12 @@ import { DeployEnvironment } from './environment.js';
 // Temporarily skip some chains
 export const chainsToSkip: ChainName[] = [
   // TODO: remove once zksync PR is merged into main
+  // mainnets
   'zksync',
   'zeronetwork',
+  // testnets
+  'abstracttestnet',
+  'treasuretopaz',
 
   // Oct 16 batch
   'lumia',

--- a/typescript/sdk/src/consts/multisigIsm.ts
+++ b/typescript/sdk/src/consts/multisigIsm.ts
@@ -3,6 +3,11 @@ import { ChainMap } from '../types.js';
 
 // TODO: consider migrating these to the registry too
 export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
+  abstracttestnet: {
+    threshold: 1,
+    validators: ['0x7655bc4c9802bfcb3132b8822155b60a4fbbce3e'],
+  },
+
   alephzeroevmmainnet: {
     threshold: 1,
     validators: ['0x33f20e6e775747d60301c6ea1c50e51f0389740c'],
@@ -869,6 +874,11 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
       '0xcf0211fafbb91fd9d06d7e306b30032dc3a1934f', // merkly
       '0xe271ef9a6e312540f099a378865432fa73f26689', // tangle
     ],
+  },
+
+  treasuretopaz: {
+    threshold: 1,
+    validators: ['0x9750849beda0a7870462d4685f953fe39033a5ae'],
   },
 
   unichaintestnet: {


### PR DESCRIPTION
### Description

- deploy to abstracttestnet, treasuretopaz
	- standard deployments from this branch
	- zksync deployments themselves done from https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4761

### Drive-by changes

- testnet igp

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

manual