### PR TITLE
feat: Added coinGeckoId as an optional property of the TokenConfigSchema

### DIFF
--- a/.changeset/thirty-actors-wonder.md
+++ b/.changeset/thirty-actors-wonder.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Added coinGeckoId as an optional property of the TokenConfigSchema

--- a/typescript/sdk/src/token/IToken.ts
+++ b/typescript/sdk/src/token/IToken.ts
@@ -47,6 +47,10 @@ export const TokenConfigSchema = z.object({
     .array(TokenConnectionConfigSchema)
     .optional()
     .describe('The list of token connections (e.g. warp or IBC)'),
+  coinGeckoId: z
+    .string()
+    .optional()
+    .describe('The CoinGecko id of the token, used for price lookups'),
 });
 
 export type TokenArgs = Omit<


### PR DESCRIPTION
### Description

- Ripped out of https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/4835, which is necessary so I can merge and release https://github.com/hyperlane-xyz/hyperlane-registry/pull/370 before 4835

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
