### PR TITLE
feat: Add scraping of Sealevel transactions into E2E tests

### DIFF
--- a/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
@@ -462,6 +462,22 @@ const DOMAINS: &[RawDomain] = &[
         is_test_net: true,
         is_deprecated: false,
     },
+    RawDomain {
+        name: "sealeveltest1",
+        token: "SOL",
+        domain: 13375,
+        chain_id: 0,
+        is_test_net: true,
+        is_deprecated: false,
+    },
+    RawDomain {
+        name: "sealeveltest2",
+        token: "SOL",
+        domain: 13376,
+        chain_id: 0,
+        is_test_net: true,
+        is_deprecated: false,
+    },
 ];
 
 #[derive(DeriveMigrationName)]

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -718,7 +718,6 @@ impl SealevelMailboxIndexer {
 
         let log_meta = self
             .dispatch_message_log_meta(
-                U256::from(nonce),
                 &valid_message_storage_pda_pubkey,
                 &dispatched_message_account.slot,
             )
@@ -743,7 +742,6 @@ impl SealevelMailboxIndexer {
 
     async fn dispatch_message_log_meta(
         &self,
-        log_index: U256,
         message_storage_pda_pubkey: &Pubkey,
         message_account_slot: &Slot,
     ) -> ChainResult<LogMeta> {
@@ -755,12 +753,7 @@ impl SealevelMailboxIndexer {
             .await?;
 
         self.dispatch_message_log_meta_composer
-            .log_meta(
-                block,
-                log_index,
-                message_storage_pda_pubkey,
-                message_account_slot,
-            )
+            .log_meta(block, message_storage_pda_pubkey, message_account_slot)
             .map_err(Into::<ChainCommunicationError>::into)
     }
 
@@ -800,7 +793,6 @@ impl SealevelMailboxIndexer {
 
         let log_meta = self
             .delivered_message_log_meta(
-                U256::from(nonce),
                 &valid_message_storage_pda_pubkey,
                 &delivered_message_account.slot,
             )
@@ -823,7 +815,6 @@ impl SealevelMailboxIndexer {
 
     async fn delivered_message_log_meta(
         &self,
-        log_index: U256,
         message_storage_pda_pubkey: &Pubkey,
         message_account_slot: &Slot,
     ) -> ChainResult<LogMeta> {
@@ -835,12 +826,7 @@ impl SealevelMailboxIndexer {
             .await?;
 
         self.delivery_message_log_meta_composer
-            .log_meta(
-                block,
-                log_index,
-                message_storage_pda_pubkey,
-                message_account_slot,
-            )
+            .log_meta(block, message_storage_pda_pubkey, message_account_slot)
             .map_err(Into::<ChainCommunicationError>::into)
     }
 }

--- a/rust/main/hyperlane-core/src/chain.rs
+++ b/rust/main/hyperlane-core/src/chain.rs
@@ -169,6 +169,7 @@ pub enum KnownHyperlaneDomain {
     Sanko = 1996,
     Sei = 1329,
     SolanaMainnet = 1399811149,
+    Stride = 745,
     Taiko = 167000,
     Tangle = 5845,
     Viction = 88,
@@ -319,8 +320,8 @@ impl KnownHyperlaneDomain {
                 DegenChain, EclipseMainnet, Endurance, Ethereum, Fraxtal, FuseMainnet, Gnosis,
                 InEvm, Injective, Kroma, Linea, Lisk, Lukso, MantaPacific, Mantle, Merlin,
                 Metis, Mint, Mode, Moonbeam, Neutron, Optimism, Osmosis, Polygon, ProofOfPlay,
-                ReAl, Redstone, Sanko, Sei, SolanaMainnet, Taiko, Tangle, Viction, Worldchain, Xai,
-                Xlayer, Zetachain, Zircuit, ZoraMainnet,
+                ReAl, Redstone, Sanko, Sei, SolanaMainnet, Stride, Taiko, Tangle, Viction,
+                Worldchain, Xai, Xlayer, Zetachain, Zircuit, ZoraMainnet,
             ],
             Testnet: [
                 Alfajores, BinanceSmartChainTestnet, Chiado, ConnextSepolia, Fuji, Holesky, MoonbaseAlpha,
@@ -355,7 +356,7 @@ impl KnownHyperlaneDomain {
             HyperlaneDomainProtocol::Fuel: [FuelTest1],
             HyperlaneDomainProtocol::Sealevel: [EclipseMainnet, SolanaMainnet, SealevelTest1, SealevelTest2],
             HyperlaneDomainProtocol::Cosmos: [
-                Injective, Neutron, Osmosis,
+                Injective, Neutron, Stride, Osmosis,
 
                 // Local chains
                 CosmosTest99990, CosmosTest99991,
@@ -387,7 +388,7 @@ impl KnownHyperlaneDomain {
             HyperlaneDomainTechnicalStack::Other: [
                 Avalanche, BinanceSmartChain, Celo, EclipseMainnet, Endurance, Ethereum,
                 FuseMainnet, Gnosis, Injective, Linea, Lukso, Neutron, Osmosis, Polygon,
-                Sei, SolanaMainnet, Taiko, Viction, Zetachain,
+                Sei, SolanaMainnet, Stride, Taiko, Viction, Zetachain,
 
                 // Local chains
                 CosmosTest99990, CosmosTest99991, FuelTest1, SealevelTest1, SealevelTest2, Test1,

--- a/rust/main/utils/run-locally/src/main.rs
+++ b/rust/main/utils/run-locally/src/main.rs
@@ -448,18 +448,18 @@ fn main() -> ExitCode {
 
     state.push_agent(relayer_env.spawn("RLY", Some(&AGENT_LOGGING_DIR)));
 
+    log!("Setup complete! Agents running in background...");
+    log!("Ctrl+C to end execution...");
+
     if let Some((solana_config_path, (_, solana_path))) =
         solana_config_path.clone().zip(solana_paths.clone())
     {
-        // Send some sealevel messages before spinning up the agents, to test the backward indexing cursor
+        // Send some sealevel messages after spinning up the agents, to test the backward indexing cursor
         for _i in 0..(SOL_MESSAGES_EXPECTED / 2) {
             initiate_solana_hyperlane_transfer(solana_path.clone(), solana_config_path.clone())
                 .join();
         }
     }
-
-    log!("Setup complete! Agents running in background...");
-    log!("Ctrl+C to end execution...");
 
     // Send half the kathy messages after the relayer comes up
     kathy_env_double_insertion.clone().run().join();


### PR DESCRIPTION
### Description

Add scraping of Sealevel transactions into E2E tests

### Drive-by changes

- Add Stride as known Hyperlane domain
- Calculate log index for Sealevel chains from transaction itself

### Related issues

- Contributes into https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4273

### Backward compatibility

Yes

### Testing

Manual run of Scraper
E2E tests for Ethereum and Sealevel
