### PR TITLE
chore: fix documentation of inaccurate account list for SVM synthetic transfer_remote

### DIFF
--- a/rust/sealevel/programs/hyperlane-sealevel-token/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/src/processor.rs
@@ -120,10 +120,9 @@ fn initialize(program_id: &Pubkey, accounts: &[AccountInfo], init: Init) -> Prog
 /// 12. `[]` OPTIONAL - The Overhead IGP program, if the configured IGP is an Overhead IGP.
 /// 13. `[writeable]` The IGP account.
 ///      ---- End if ----
-/// 14. `[signer]` The token sender.
-/// 15. `[executable]` The spl_token_2022 program.
-/// 16. `[writeable]` The mint / mint authority PDA account.
-/// 17. `[writeable]` The token sender's associated token account, from which tokens will be burned.
+/// 14. `[executable]` The spl_token_2022 program.
+/// 15. `[writeable]` The mint / mint authority PDA account.
+/// 16. `[writeable]` The token sender's associated token account, from which tokens will be burned.
 fn transfer_remote(
     program_id: &Pubkey,
     accounts: &[AccountInfo],


### PR DESCRIPTION
### Description

Removes an account that is not actually expected

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
