### PR TITLE
fix: Remove call to GetBlock for Sealevel for time being

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/interchain_gas.rs
@@ -12,7 +12,7 @@ use tracing::{info, instrument};
 use hyperlane_core::{
     config::StrOrIntParseError, ChainCommunicationError, ChainResult, ContractLocator,
     HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneProvider, Indexed, Indexer,
-    InterchainGasPaymaster, InterchainGasPayment, LogMeta, SequenceAwareIndexer, H256, U256,
+    InterchainGasPaymaster, InterchainGasPayment, LogMeta, SequenceAwareIndexer, H256, H512, U256,
 };
 
 use crate::account::{search_accounts_by_discriminator, search_and_validate_account};
@@ -91,7 +91,7 @@ impl InterchainGasPaymaster for SealevelInterchainGasPaymaster {}
 pub struct SealevelInterchainGasPaymasterIndexer {
     rpc_client: SealevelRpcClient,
     igp: SealevelInterchainGasPaymaster,
-    log_meta_composer: LogMetaComposer,
+    _log_meta_composer: LogMetaComposer,
 }
 
 /// IGP payment data on Sealevel
@@ -122,7 +122,7 @@ impl SealevelInterchainGasPaymasterIndexer {
         Ok(Self {
             rpc_client,
             igp,
-            log_meta_composer,
+            _log_meta_composer: log_meta_composer,
         })
     }
 
@@ -168,13 +168,24 @@ impl SealevelInterchainGasPaymasterIndexer {
             gas_amount: gas_payment_account.gas_amount.into(),
         };
 
-        let log_meta = self
-            .interchain_payment_log_meta(
-                U256::from(sequence_number),
-                &valid_payment_pda_pubkey,
-                &gas_payment_account.slot,
-            )
-            .await?;
+        // let log_meta = self
+        //     .interchain_payment_log_meta(
+        //         U256::from(sequence_number),
+        //         &valid_payment_pda_pubkey,
+        //         &gas_payment_account.slot,
+        //     )
+        //     .await?;
+
+        let log_meta = LogMeta {
+            address: self.igp.program_id.to_bytes().into(),
+            block_number: gas_payment_account.slot,
+            // TODO: get these when building out scraper support.
+            // It's inconvenient to get these :|
+            block_hash: H256::zero(),
+            transaction_id: H512::zero(),
+            transaction_index: 0,
+            log_index: U256::zero(),
+        };
 
         Ok(SealevelGasPayment::new(
             Indexed::new(igp_payment).with_sequence(
@@ -185,19 +196,6 @@ impl SealevelInterchainGasPaymasterIndexer {
             log_meta,
             H256::from(gas_payment_account.igp.to_bytes()),
         ))
-    }
-
-    async fn interchain_payment_log_meta(
-        &self,
-        log_index: U256,
-        payment_pda_pubkey: &Pubkey,
-        payment_pda_slot: &Slot,
-    ) -> ChainResult<LogMeta> {
-        let block = self.rpc_client.get_block(*payment_pda_slot).await?;
-
-        self.log_meta_composer
-            .log_meta(block, log_index, payment_pda_pubkey, payment_pda_slot)
-            .map_err(Into::<ChainCommunicationError>::into)
     }
 
     fn interchain_payment_account(&self, account: &Account) -> ChainResult<Pubkey> {
@@ -212,6 +210,19 @@ impl SealevelInterchainGasPaymasterIndexer {
             )
         })?;
         Ok(expected_pubkey)
+    }
+
+    async fn _interchain_payment_log_meta(
+        &self,
+        log_index: U256,
+        payment_pda_pubkey: &Pubkey,
+        payment_pda_slot: &Slot,
+    ) -> ChainResult<LogMeta> {
+        let block = self.rpc_client.get_block(*payment_pda_slot).await?;
+
+        self._log_meta_composer
+            .log_meta(block, log_index, payment_pda_pubkey, payment_pda_slot)
+            .map_err(Into::<ChainCommunicationError>::into)
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/interchain_gas.rs
@@ -184,7 +184,7 @@ impl SealevelInterchainGasPaymasterIndexer {
             block_hash: H256::zero(),
             transaction_id: H512::zero(),
             transaction_index: 0,
-            log_index: U256::zero(),
+            log_index: sequence_number.into(),
         };
 
         Ok(SealevelGasPayment::new(

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -716,13 +716,24 @@ impl SealevelMailboxIndexer {
         let hyperlane_message =
             HyperlaneMessage::read_from(&mut &dispatched_message_account.encoded_message[..])?;
 
-        let log_meta = self
-            .dispatch_message_log_meta(
-                U256::from(nonce),
-                &valid_message_storage_pda_pubkey,
-                &dispatched_message_account.slot,
-            )
-            .await?;
+        // let log_meta = self
+        //     .dispatch_message_log_meta(
+        //         U256::from(nonce),
+        //         &valid_message_storage_pda_pubkey,
+        //         &dispatched_message_account.slot,
+        //     )
+        //     .await?;
+
+        let log_meta = LogMeta {
+            address: self.program_id.to_bytes().into(),
+            block_number: dispatched_message_account.slot,
+            // TODO: get these when building out scraper support.
+            // It's inconvenient to get these :|
+            block_hash: H256::zero(),
+            transaction_id: H512::zero(),
+            transaction_index: 0,
+            log_index: U256::zero(),
+        };
 
         Ok((hyperlane_message.into(), log_meta))
     }
@@ -741,7 +752,7 @@ impl SealevelMailboxIndexer {
         Ok(expected_pubkey)
     }
 
-    async fn dispatch_message_log_meta(
+    async fn _dispatch_message_log_meta(
         &self,
         log_index: U256,
         message_storage_pda_pubkey: &Pubkey,
@@ -798,13 +809,24 @@ impl SealevelMailboxIndexer {
             .into_inner();
         let message_id = delivered_message_account.message_id;
 
-        let log_meta = self
-            .delivered_message_log_meta(
-                U256::from(nonce),
-                &valid_message_storage_pda_pubkey,
-                &delivered_message_account.slot,
-            )
-            .await?;
+        // let log_meta = self
+        //     .delivered_message_log_meta(
+        //         U256::from(nonce),
+        //         &valid_message_storage_pda_pubkey,
+        //         &delivered_message_account.slot,
+        //     )
+        //     .await?;
+
+        let log_meta = LogMeta {
+            address: self.program_id.to_bytes().into(),
+            block_number: delivered_message_account.slot,
+            // TODO: get these when building out scraper support.
+            // It's inconvenient to get these :|
+            block_hash: H256::zero(),
+            transaction_id: H512::zero(),
+            transaction_index: 0,
+            log_index: U256::zero(),
+        };
 
         Ok((message_id.into(), log_meta))
     }
@@ -821,7 +843,7 @@ impl SealevelMailboxIndexer {
         Ok(expected_pubkey)
     }
 
-    async fn delivered_message_log_meta(
+    async fn _delivered_message_log_meta(
         &self,
         log_index: U256,
         message_storage_pda_pubkey: &Pubkey,


### PR DESCRIPTION
### Description

Remove call to GetBlock for Sealevel for time being

### Related issues

https://discord.com/channels/935678348330434570/935679524534911007/1306588981185740811

### Backward compatibility

Yes

### Testing

E2E Test for Ethereum and Sealevel