### PR TITLE
fix: Use block slot instead of block height for Sealevel chains

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/interchain_gas.rs
@@ -257,7 +257,10 @@ impl Indexer<InterchainGasPayment> for SealevelInterchainGasPaymasterIndexer {
     #[instrument(level = "debug", err, ret, skip(self))]
     #[allow(clippy::blocks_in_conditions)] // TODO: `rustc` 1.80.1 clippy issue
     async fn get_finalized_block_number(&self) -> ChainResult<u32> {
-        self.rpc_client.get_block_height().await
+        // we should not report block height since SequenceAwareIndexer uses block slot in
+        // `latest_sequence_count_and_tip` and we should not report block slot here
+        // since block slot cannot be used as watermark
+        unimplemented!()
     }
 }
 
@@ -277,7 +280,7 @@ impl SequenceAwareIndexer<InterchainGasPayment> for SealevelInterchainGasPaymast
             .payment_count
             .try_into()
             .map_err(StrOrIntParseError::from)?;
-        let tip = self.rpc_client.get_block_height().await?;
+        let tip = self.igp.provider.rpc().get_slot().await?;
         Ok((Some(payment_count), tip))
     }
 }

--- a/rust/main/chains/hyperlane-sealevel/src/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/merkle_tree_hook.rs
@@ -93,7 +93,10 @@ impl Indexer<MerkleTreeInsertion> for SealevelMerkleTreeHookIndexer {
     }
 
     async fn get_finalized_block_number(&self) -> ChainResult<u32> {
-        Indexer::<HyperlaneMessage>::get_finalized_block_number(&self.0).await
+        // we should not report block height since SequenceAwareIndexer uses block slot in
+        // `latest_sequence_count_and_tip` and we should not report block slot here
+        // since block slot cannot be used as watermark
+        unimplemented!()
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
@@ -125,18 +125,6 @@ impl SealevelRpcClient {
             .map_err(Into::into)
     }
 
-    pub async fn get_block_height(&self) -> ChainResult<u32> {
-        let height = self
-            .0
-            .get_block_height_with_commitment(CommitmentConfig::finalized())
-            .await
-            .map_err(ChainCommunicationError::from_other)?
-            .try_into()
-            // FIXME solana block height is u64...
-            .expect("sealevel block height exceeds u32::MAX");
-        Ok(height)
-    }
-
     pub async fn get_multiple_accounts_with_finalized_commitment(
         &self,
         pubkeys: &[Pubkey],
@@ -181,6 +169,18 @@ impl SealevelRpcClient {
             .get_signature_statuses(signatures)
             .await
             .map_err(ChainCommunicationError::from_other)
+    }
+
+    pub async fn get_slot(&self) -> ChainResult<u32> {
+        let slot = self
+            .0
+            .get_slot_with_commitment(CommitmentConfig::finalized())
+            .await
+            .map_err(ChainCommunicationError::from_other)?
+            .try_into()
+            // FIXME solana block height is u64...
+            .expect("sealevel block slot exceeds u32::MAX");
+        Ok(slot)
     }
 
     pub async fn get_transaction(


### PR DESCRIPTION
### Description

Use block slot instead of block height for Sealevel chains

### Backward compatibility

Yes

### Testing

Manual run of validator against Solana mainnet
