### PR TITLE
chore: parallelise cli e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,15 @@ jobs:
   cli-e2e:
     runs-on: ubuntu-latest
     needs: [yarn-install]
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - core
+          - relay
+          - warp-read
+          - warp-apply
+          - warp-deploy
     steps:
       - uses: actions/checkout@v4
         with:
@@ -132,6 +141,8 @@ jobs:
 
       - name: CLI e2e tests
         run: yarn --cwd typescript/cli test:e2e
+        env:
+          CLI_E2E_TEST: ${{ matrix.test }}
 
   agent-configs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
-  cli-e2e:
+  cli-e2e-matrix:
     runs-on: ubuntu-latest
     needs: [yarn-install]
     strategy:
@@ -139,10 +139,21 @@ jobs:
       - name: Checkout registry
         uses: ./.github/actions/checkout-registry
 
-      - name: CLI e2e tests
+      - name: CLI e2e tests (${{ matrix.test }})
         run: yarn --cwd typescript/cli test:e2e
         env:
           CLI_E2E_TEST: ${{ matrix.test }}
+
+  cli-e2e:
+    runs-on: ubuntu-latest
+    needs: cli-e2e-matrix
+    if: always()
+    steps:
+      - name: Check cli-e2e matrix status
+        if: ${{ needs.cli-e2e-matrix.result != 'success' }}
+        run: |
+          echo "CLI E2E tests failed"
+          exit 1
 
   agent-configs:
     runs-on: ubuntu-latest

--- a/typescript/cli/.mocharc-e2e.json
+++ b/typescript/cli/.mocharc-e2e.json
@@ -1,6 +1,5 @@
 {
   "extensions": ["ts"],
-  "spec": ["src/**/*.e2e-test.ts"],
   "node-option": [
     "experimental-specifier-resolution=node",
     "loader=ts-node/esm"

--- a/typescript/cli/scripts/run-e2e-test.sh
+++ b/typescript/cli/scripts/run-e2e-test.sh
@@ -16,11 +16,11 @@ anvil --chain-id 31338 -p 8555 --state /tmp/anvil2/state --gas-price 1 > /dev/nu
 anvil --chain-id 31347 -p 8600 --state /tmp/anvil3/state --gas-price 1 > /dev/null &
 
 echo "Running E2E tests"
-if [ -n "$CLI_E2E_TEST" ]; then
-  echo "Running only $CLI_E2E_TEST test"
-  yarn mocha --config .mocharc-e2e.json "src/**/$CLI_E2E_TEST.e2e-test.ts"
+if [ -n "${CLI_E2E_TEST}" ]; then
+  echo "Running only ${CLI_E2E_TEST} test"
+  yarn mocha --config .mocharc-e2e.json "src/**/${CLI_E2E_TEST}.e2e-test.ts"
 else
-  yarn mocha --config .mocharc-e2e.json
+  yarn mocha --config .mocharc-e2e.json "src/**/*.e2e-test.ts"
 fi
 
 cleanup

--- a/typescript/cli/scripts/run-e2e-test.sh
+++ b/typescript/cli/scripts/run-e2e-test.sh
@@ -16,7 +16,12 @@ anvil --chain-id 31338 -p 8555 --state /tmp/anvil2/state --gas-price 1 > /dev/nu
 anvil --chain-id 31347 -p 8600 --state /tmp/anvil3/state --gas-price 1 > /dev/null &
 
 echo "Running E2E tests"
-yarn mocha --config .mocharc-e2e.json
+if [ -n "$CLI_E2E_TEST" ]; then
+  echo "Running only $CLI_E2E_TEST test"
+  yarn mocha --config .mocharc-e2e.json "src/**/$CLI_E2E_TEST.e2e-test.ts"
+else
+  yarn mocha --config .mocharc-e2e.json
+fi
 
 cleanup
 


### PR DESCRIPTION
### Description

chore: parallelise cli e2e tests

before:
![image](https://github.com/user-attachments/assets/66914b6d-7d64-4689-a5c7-032d34963a7f)

after:
![image](https://github.com/user-attachments/assets/d35c91bb-98a3-40be-8432-1a2848394428)

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
