### PR TITLE
fix: Make main and sealevel workspaces compilable with our forked dependencies

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -2564,7 +2564,8 @@ dependencies = [
 [[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
-source = "git+https://github.com/Eclipse-Laboratories-Inc/ed25519-dalek?branch=main#7529d65506147b6cb24ca6d8f4fc062cac33b395"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek 3.2.2",
  "ed25519 1.5.3",
@@ -8353,7 +8354,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -8377,7 +8378,7 @@ dependencies = [
 [[package]]
 name = "solana-address-lookup-table-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -8397,7 +8398,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-utils"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -8414,7 +8415,7 @@ dependencies = [
 [[package]]
 name = "solana-cli-config"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -8429,7 +8430,7 @@ dependencies = [
 [[package]]
 name = "solana-client"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -8482,7 +8483,7 @@ dependencies = [
 [[package]]
 name = "solana-config-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bincode",
  "chrono",
@@ -8495,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "solana-faucet"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bincode",
  "byteorder",
@@ -8518,7 +8519,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "ahash 0.7.8",
  "blake3",
@@ -8551,7 +8552,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi-macro"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -8562,7 +8563,7 @@ dependencies = [
 [[package]]
 name = "solana-logger"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -8572,7 +8573,7 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "log",
  "solana-sdk",
@@ -8581,7 +8582,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -8594,7 +8595,7 @@ dependencies = [
 [[package]]
 name = "solana-net-utils"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bincode",
  "clap 3.2.25",
@@ -8615,7 +8616,7 @@ dependencies = [
 [[package]]
 name = "solana-perf"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "ahash 0.7.8",
  "bincode",
@@ -8641,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "solana-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -8689,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -8715,7 +8716,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -8724,7 +8725,7 @@ dependencies = [
 [[package]]
 name = "solana-remote-wallet"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "console",
  "dialoguer",
@@ -8742,7 +8743,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "assert_matches",
  "base64 0.13.1",
@@ -8792,7 +8793,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk-macro"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2 1.0.86",
@@ -8804,7 +8805,7 @@ dependencies = [
 [[package]]
 name = "solana-streamer"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -8832,7 +8833,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -8860,7 +8861,7 @@ dependencies = [
 [[package]]
 name = "solana-version"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "log",
  "rustc_version",
@@ -8875,7 +8876,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bincode",
  "log",
@@ -8895,7 +8896,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-sdk"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",

--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -8354,7 +8354,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -8378,7 +8378,7 @@ dependencies = [
 [[package]]
 name = "solana-address-lookup-table-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -8398,7 +8398,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-utils"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -8415,7 +8415,7 @@ dependencies = [
 [[package]]
 name = "solana-cli-config"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -8430,7 +8430,7 @@ dependencies = [
 [[package]]
 name = "solana-client"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -8483,7 +8483,7 @@ dependencies = [
 [[package]]
 name = "solana-config-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bincode",
  "chrono",
@@ -8496,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "solana-faucet"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bincode",
  "byteorder",
@@ -8519,7 +8519,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "ahash 0.7.8",
  "blake3",
@@ -8552,7 +8552,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi-macro"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -8563,7 +8563,7 @@ dependencies = [
 [[package]]
 name = "solana-logger"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -8573,7 +8573,7 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "log",
  "solana-sdk",
@@ -8582,7 +8582,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -8595,7 +8595,7 @@ dependencies = [
 [[package]]
 name = "solana-net-utils"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bincode",
  "clap 3.2.25",
@@ -8616,7 +8616,7 @@ dependencies = [
 [[package]]
 name = "solana-perf"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "ahash 0.7.8",
  "bincode",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "solana-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -8690,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -8716,7 +8716,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -8725,7 +8725,7 @@ dependencies = [
 [[package]]
 name = "solana-remote-wallet"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "console",
  "dialoguer",
@@ -8743,7 +8743,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "assert_matches",
  "base64 0.13.1",
@@ -8793,7 +8793,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk-macro"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2 1.0.86",
@@ -8805,7 +8805,7 @@ dependencies = [
 [[package]]
 name = "solana-streamer"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -8833,7 +8833,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -8861,7 +8861,7 @@ dependencies = [
 [[package]]
 name = "solana-version"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "log",
  "rustc_version",
@@ -8876,7 +8876,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bincode",
  "log",
@@ -8896,7 +8896,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-sdk"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -124,7 +124,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 sha2 = { version = "0.10.6", default-features = false }
 sha256 = "1.1.4"
- sha3 = "0.10"
+sha3 = "0.10"
 solana-account-decoder = "=1.14.13"
 solana-client = "=1.14.13"
 solana-sdk = "=1.14.13"

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -236,42 +236,42 @@ version = "=0.5.2"
 
 [patch.crates-io.solana-account-decoder]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-clap-utils]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-cli-config]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-client]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-program]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-sdk]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-transaction-status]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-zk-token-sdk]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.spl-associated-token-account]

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -124,26 +124,11 @@ serde_derive = "1.0"
 serde_json = "1.0"
 sha2 = { version = "0.10.6", default-features = false }
 sha256 = "1.1.4"
-sha3 = "0.10"
+ sha3 = "0.10"
 solana-account-decoder = "=1.14.13"
-solana-banks-client = "=1.14.13"
-solana-banks-interface = "=1.14.13"
-solana-banks-server = "=1.14.13"
-solana-clap-utils = "=1.14.13"
-solana-cli-config = "=1.14.13"
 solana-client = "=1.14.13"
-solana-program = "=1.14.13"
-solana-program-test = "=1.14.13"
 solana-sdk = "=1.14.13"
 solana-transaction-status = "=1.14.13"
-solana-zk-token-sdk = "=1.14.13"
-spl-associated-token-account = { version = "=1.1.2", features = [
-  "no-entrypoint",
-] }
-spl-noop = { version = "=0.1.3", features = ["no-entrypoint"] }
-spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.5.0", features = ["no-entrypoint"] }
-spl-type-length-value = "=0.1.0"
 static_assertions = "1.1"
 strum = "0.26.2"
 strum_macros = "0.26.2"
@@ -239,11 +224,6 @@ branch = "v3.2.2-relax-zeroize"
 git = "https://github.com/Eclipse-Laboratories-Inc/curve25519-dalek"
 version = "3.2.2"
 
-[patch.crates-io.ed25519-dalek]
-branch = "main"
-git = "https://github.com/Eclipse-Laboratories-Inc/ed25519-dalek"
-version = "1.0.1"
-
 [patch.crates-io.primitive-types]
 branch = "hyperlane"
 git = "https://github.com/hyperlane-xyz/parity-common.git"
@@ -256,42 +236,42 @@ version = "=0.5.2"
 
 [patch.crates-io.solana-account-decoder]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-clap-utils]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-cli-config]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-client]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-program]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-sdk]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-transaction-status]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-zk-token-sdk]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.spl-associated-token-account]

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
@@ -112,14 +112,14 @@ impl SealevelRpcClient {
         Ok(balance.into())
     }
 
-    pub async fn get_block(&self, height: u64) -> ChainResult<UiConfirmedBlock> {
+    pub async fn get_block(&self, slot: u64) -> ChainResult<UiConfirmedBlock> {
         let config = RpcBlockConfig {
             commitment: Some(CommitmentConfig::finalized()),
             max_supported_transaction_version: Some(0),
             ..Default::default()
         };
         self.0
-            .get_block_with_config(height, config)
+            .get_block_with_config(slot, config)
             .await
             .map_err(HyperlaneSealevelError::ClientError)
             .map_err(Into::into)
@@ -273,3 +273,6 @@ impl std::fmt::Debug for SealevelRpcClient {
         f.write_str("RpcClient { ... }")
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
@@ -1,0 +1,14 @@
+use crate::SealevelRpcClient;
+
+//#[tokio::test]
+async fn _test_get_block() {
+    // given
+    let client = SealevelRpcClient::new("<solana-rpc>".to_string());
+
+    // when
+    let slot = 301337842; // block which requires latest version of solana-client
+    let result = client.get_block(slot).await;
+
+    // then
+    assert!(result.is_ok());
+}

--- a/rust/main/hyperlane-base/src/settings/signers.rs
+++ b/rust/main/hyperlane-base/src/settings/signers.rs
@@ -126,10 +126,9 @@ impl BuildableWithSignerConf for Keypair {
         if let SignerConf::HexKey { key } = conf {
             let secret = SecretKey::from_bytes(key.as_bytes())
                 .context("Invalid sealevel ed25519 secret key")?;
-            Ok(
-                Keypair::from_bytes(&ed25519_dalek::Keypair::from(secret).to_bytes())
-                    .context("Unable to create Keypair")?,
-            )
+            let public = ed25519_dalek::PublicKey::from(&secret);
+            let dalek = ed25519_dalek::Keypair { secret, public };
+            Ok(Keypair::from_bytes(&dalek.to_bytes()).context("Unable to create Keypair")?)
         } else {
             bail!(format!("{conf:?} key is not supported by sealevel"));
         }

--- a/rust/rust-toolchain
+++ b/rust/rust-toolchain
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.72.1"
-profile = "default"

--- a/rust/sealevel/Cargo.lock
+++ b/rust/sealevel/Cargo.lock
@@ -4924,7 +4924,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -4948,7 +4948,7 @@ dependencies = [
 [[package]]
 name = "solana-address-lookup-table-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4968,7 +4968,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-client"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "borsh",
  "futures",
@@ -4984,7 +4984,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-interface"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "serde",
  "solana-sdk",
@@ -4994,7 +4994,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-server"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5013,7 +5013,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bincode",
  "byteorder",
@@ -5031,7 +5031,7 @@ dependencies = [
 [[package]]
 name = "solana-bucket-map"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "log",
  "memmap2",
@@ -5045,7 +5045,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-utils"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -5062,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "solana-cli-config"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "solana-client"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -5130,7 +5130,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -5139,7 +5139,7 @@ dependencies = [
 [[package]]
 name = "solana-config-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bincode",
  "chrono",
@@ -5152,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "solana-faucet"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bincode",
  "byteorder",
@@ -5175,7 +5175,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "ahash",
  "blake3",
@@ -5208,7 +5208,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi-macro"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -5219,7 +5219,7 @@ dependencies = [
 [[package]]
 name = "solana-logger"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "env_logger 0.9.3",
  "lazy_static",
@@ -5229,7 +5229,7 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "log",
  "solana-sdk",
@@ -5238,7 +5238,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -5251,7 +5251,7 @@ dependencies = [
 [[package]]
 name = "solana-net-utils"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bincode",
  "clap 3.2.25",
@@ -5272,7 +5272,7 @@ dependencies = [
 [[package]]
 name = "solana-perf"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "ahash",
  "bincode",
@@ -5298,7 +5298,7 @@ dependencies = [
 [[package]]
 name = "solana-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -5346,7 +5346,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -5372,7 +5372,7 @@ dependencies = [
 [[package]]
 name = "solana-program-test"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5396,7 +5396,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5405,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "solana-remote-wallet"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "console",
  "dialoguer",
@@ -5423,7 +5423,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "arrayref",
  "bincode",
@@ -5483,7 +5483,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "assert_matches",
  "base64 0.13.1",
@@ -5533,7 +5533,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk-macro"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2 1.0.86",
@@ -5545,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "solana-send-transaction-service"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -5559,7 +5559,7 @@ dependencies = [
 [[package]]
 name = "solana-stake-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bincode",
  "log",
@@ -5581,7 +5581,7 @@ dependencies = [
 [[package]]
 name = "solana-streamer"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -5609,7 +5609,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -5637,7 +5637,7 @@ dependencies = [
 [[package]]
 name = "solana-version"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "log",
  "rustc_version",
@@ -5652,7 +5652,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bincode",
  "log",
@@ -5672,7 +5672,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-proof-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.16",
@@ -5686,7 +5686,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-sdk"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
+source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2024-11-20#913db71a07f967f4c5c7e7f747cb48517cdbf09e"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",

--- a/rust/sealevel/Cargo.lock
+++ b/rust/sealevel/Cargo.lock
@@ -743,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
 dependencies = [
  "serde",
 ]
@@ -1255,6 +1255,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,7 +1425,8 @@ dependencies = [
 [[package]]
 name = "ed25519-dalek"
 version = "1.0.1"
-source = "git+https://github.com/Eclipse-Laboratories-Inc/ed25519-dalek?branch=main#7529d65506147b6cb24ca6d8f4fc062cac33b395"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -2385,7 +2406,7 @@ dependencies = [
  "bytes",
  "convert_case 0.6.0",
  "derive-new",
- "derive_more",
+ "derive_more 0.99.17",
  "eyre",
  "fixed-hash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getrandom 0.2.15",
@@ -4538,26 +4559,26 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.11.3"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
+checksum = "1aa7ffc1c0ef49b0452c6e2986abf2b07743320641ffd5fc63d552458e3b779b"
 dependencies = [
  "cfg-if",
- "derive_more",
+ "derive_more 1.0.0",
  "parity-scale-codec",
  "scale-info-derive",
 ]
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.3"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
+checksum = "46385cc24172cf615450267463f937c10072516359b3ff1cb24228a4a08bf951"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4903,7 +4924,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -4927,7 +4948,7 @@ dependencies = [
 [[package]]
 name = "solana-address-lookup-table-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4947,7 +4968,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-client"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "borsh",
  "futures",
@@ -4963,7 +4984,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-interface"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "serde",
  "solana-sdk",
@@ -4973,7 +4994,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-server"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4992,7 +5013,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bincode",
  "byteorder",
@@ -5010,7 +5031,7 @@ dependencies = [
 [[package]]
 name = "solana-bucket-map"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "log",
  "memmap2",
@@ -5024,7 +5045,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-utils"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -5041,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "solana-cli-config"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -5056,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "solana-client"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -5109,7 +5130,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -5118,7 +5139,7 @@ dependencies = [
 [[package]]
 name = "solana-config-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bincode",
  "chrono",
@@ -5131,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "solana-faucet"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bincode",
  "byteorder",
@@ -5154,7 +5175,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "ahash",
  "blake3",
@@ -5187,7 +5208,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi-macro"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -5198,7 +5219,7 @@ dependencies = [
 [[package]]
 name = "solana-logger"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "env_logger 0.9.3",
  "lazy_static",
@@ -5208,7 +5229,7 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "log",
  "solana-sdk",
@@ -5217,7 +5238,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -5230,7 +5251,7 @@ dependencies = [
 [[package]]
 name = "solana-net-utils"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bincode",
  "clap 3.2.25",
@@ -5251,7 +5272,7 @@ dependencies = [
 [[package]]
 name = "solana-perf"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "ahash",
  "bincode",
@@ -5277,7 +5298,7 @@ dependencies = [
 [[package]]
 name = "solana-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -5325,7 +5346,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -5351,7 +5372,7 @@ dependencies = [
 [[package]]
 name = "solana-program-test"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5375,7 +5396,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5384,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "solana-remote-wallet"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "console",
  "dialoguer",
@@ -5402,7 +5423,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "arrayref",
  "bincode",
@@ -5462,7 +5483,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "assert_matches",
  "base64 0.13.1",
@@ -5512,7 +5533,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk-macro"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2 1.0.86",
@@ -5524,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "solana-send-transaction-service"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -5538,7 +5559,7 @@ dependencies = [
 [[package]]
 name = "solana-stake-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bincode",
  "log",
@@ -5560,7 +5581,7 @@ dependencies = [
 [[package]]
 name = "solana-streamer"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -5588,7 +5609,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -5616,7 +5637,7 @@ dependencies = [
 [[package]]
 name = "solana-version"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "log",
  "rustc_version",
@@ -5631,7 +5652,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bincode",
  "log",
@@ -5651,7 +5672,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-proof-program"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.16",
@@ -5665,7 +5686,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-sdk"
 version = "1.14.13"
-source = "git+https://github.com/hyperlane-xyz/solana.git?tag=hyperlane-1.14.13-2023-07-04#62a6421cab862c77b9ac7a8d93f54f8b5b223af7"
+source = "git+https://github.com/hyperlane-xyz/solana.git?branch=ameten/hyperlane-1.14.13-compilable#c9c08f57983439c36ff90451e3f89c212d7163a4"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -6304,9 +6325,9 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.5.0",
  "toml_datetime",
@@ -6943,9 +6964,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/rust/sealevel/Cargo.toml
+++ b/rust/sealevel/Cargo.toml
@@ -268,52 +268,52 @@ version = "=0.5.2"
 
 [patch.crates-io.solana-account-decoder]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-banks-client]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-clap-utils]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-cli-config]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-client]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-program]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-program-test]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-sdk]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-transaction-status]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.solana-zk-token-sdk]
 git = "https://github.com/hyperlane-xyz/solana.git"
-branch = "ameten/hyperlane-1.14.13-compilable"
+tag = "hyperlane-1.14.13-2024-11-20"
 version = "=1.14.13"
 
 [patch.crates-io.spl-associated-token-account]

--- a/rust/sealevel/Cargo.toml
+++ b/rust/sealevel/Cargo.toml
@@ -256,11 +256,6 @@ branch = "v3.2.2-relax-zeroize"
 git = "https://github.com/Eclipse-Laboratories-Inc/curve25519-dalek"
 version = "3.2.2"
 
-[patch.crates-io.ed25519-dalek]
-branch = "main"
-git = "https://github.com/Eclipse-Laboratories-Inc/ed25519-dalek"
-version = "1.0.1"
-
 [patch.crates-io.primitive-types]
 branch = "hyperlane"
 git = "https://github.com/hyperlane-xyz/parity-common.git"
@@ -273,62 +268,52 @@ version = "=0.5.2"
 
 [patch.crates-io.solana-account-decoder]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-banks-client]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
-version = "=1.14.13"
-
-[patch.crates-io.solana-banks-interface]
-git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
-version = "=1.14.13"
-
-[patch.crates-io.solana-banks-server]
-git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-clap-utils]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-cli-config]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-client]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-program]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-program-test]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-sdk]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-transaction-status]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.solana-zk-token-sdk]
 git = "https://github.com/hyperlane-xyz/solana.git"
-tag = "hyperlane-1.14.13-2023-07-04"
+branch = "ameten/hyperlane-1.14.13-compilable"
 version = "=1.14.13"
 
 [patch.crates-io.spl-associated-token-account]

--- a/rust/sealevel/libraries/test-utils/src/igp.rs
+++ b/rust/sealevel/libraries/test-utils/src/igp.rs
@@ -49,7 +49,7 @@ pub async fn initialize_igp_accounts(
         GasOracle::RemoteGasData(RemoteGasData {
             token_exchange_rate: TOKEN_EXCHANGE_RATE_SCALE,
             gas_price: 1u128,
-            /// The number of decimals for the remote token.
+            // The number of decimals for the remote token.
             token_decimals: SOL_DECIMALS,
         }),
         None,

--- a/rust/sealevel/rust-toolchain
+++ b/rust/sealevel/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.72.1"
+channel = "1.75.0"
 profile = "default"


### PR DESCRIPTION
### Description

- Make main and sealevel workspaces compilable with our forked dependencies
- Make Sealevel client be able to parse block with new kind of instruction errors

### Backward compatibility

Yes

### Testing

E2E Ethereum and Sealevel tests
