### PR TITLE
feat: add GcpValidator using GcpStorageWrapper

### DIFF
--- a/.changeset/polite-beds-begin.md
+++ b/.changeset/polite-beds-begin.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Introduce GcpValidator for retrieving announcements, checkpoints and metadata for a Validator posting to a GCP bucket. Uses GcpStorageWrapper for bucket operations.

--- a/typescript/infra/scripts/check/check-validator-version.ts
+++ b/typescript/infra/scripts/check/check-validator-version.ts
@@ -3,6 +3,7 @@ import { execSync } from 'child_process';
 import { ValidatorAnnounce__factory } from '@hyperlane-xyz/core';
 import {
   ChainName,
+  GcpValidator,
   S3Validator,
   defaultMultisigConfigs,
 } from '@hyperlane-xyz/sdk';
@@ -142,9 +143,14 @@ async function main() {
 
         // Get metadata from each storage location
         try {
-          const validatorInstance = await S3Validator.fromStorageLocation(
-            location,
-          );
+          let validatorInstance;
+          if (location.startsWith('gs://')) {
+            validatorInstance = await GcpValidator.fromStorageLocation(
+              location,
+            );
+          } else {
+            validatorInstance = await S3Validator.fromStorageLocation(location);
+          }
 
           const metadata = await validatorInstance.getMetadata();
           const gitSha = metadata?.git_sha;

--- a/typescript/infra/scripts/check/check-validator-version.ts
+++ b/typescript/infra/scripts/check/check-validator-version.ts
@@ -3,9 +3,8 @@ import { execSync } from 'child_process';
 import { ValidatorAnnounce__factory } from '@hyperlane-xyz/core';
 import {
   ChainName,
-  GcpValidator,
-  S3Validator,
   defaultMultisigConfigs,
+  getValidatorFromStorageLocation,
 } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 
@@ -143,14 +142,9 @@ async function main() {
 
         // Get metadata from each storage location
         try {
-          let validatorInstance;
-          if (location.startsWith('gs://')) {
-            validatorInstance = await GcpValidator.fromStorageLocation(
-              location,
-            );
-          } else {
-            validatorInstance = await S3Validator.fromStorageLocation(location);
-          }
+          const validatorInstance = await getValidatorFromStorageLocation(
+            location,
+          );
 
           const metadata = await validatorInstance.getMetadata();
           const gitSha = metadata?.git_sha;

--- a/typescript/infra/scripts/check/check-validator-version.ts
+++ b/typescript/infra/scripts/check/check-validator-version.ts
@@ -31,7 +31,7 @@ const acceptableValidatorVersions: Record<string, string> = {
   // 1.0.0
   'ffbe1dd82e2452dbc111b6fb469a34fb870da8f1': '1.0.0',
   // Tessellated's Own Build
-  '79453fcd972a1e62ba8ee604f0a4999c7b938582': 'tesselated-special-build',
+  '9b855686d3e2b3d6b81238ce51a576ff5e0f770f': 'tesselated-special-build',
 };
 
 type ValidatorInfo = {
@@ -167,7 +167,7 @@ async function main() {
           }
         } catch (error) {
           console.warn(
-            `Error getting metadata for validator ${validator} on chain ${chain}: ${error}`,
+            `Error getting metadata for ${validator} on chain ${chain}: ${error}`,
           );
           mismatchedValidators.push({
             chain,
@@ -191,7 +191,7 @@ async function main() {
 
   if (mismatchedValidators.length > 0) {
     console.log(
-      'Expecting validators to have one of the following git SHA:\n' +
+      '\nExpecting validators to have one of the following git SHA:\n' +
         Object.entries(acceptableValidatorVersions)
           .map(([key, value]) => `  • ${key} (${value})`)
           .join('\n'),

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -8,6 +8,7 @@
     "@chain-registry/types": "^0.50.14",
     "@cosmjs/cosmwasm-stargate": "^0.32.4",
     "@cosmjs/stargate": "^0.32.4",
+    "@google-cloud/storage": "7.14.0",
     "@hyperlane-xyz/core": "5.8.2",
     "@hyperlane-xyz/utils": "7.2.0",
     "@safe-global/api-kit": "1.3.0",

--- a/typescript/sdk/src/aws/validator.ts
+++ b/typescript/sdk/src/aws/validator.ts
@@ -15,7 +15,7 @@ const checkpointWithMessageIdKey = (checkpointIndex: number) =>
 const LATEST_KEY = 'checkpoint_latest_index.json';
 const ANNOUNCEMENT_KEY = 'announcement.json';
 const METADATA_KEY = 'metadata_latest.json';
-const LOCATION_PREFIX = 's3://';
+export const S3_LOCATION_PREFIX = 's3://';
 
 /**
  * Extension of BaseValidator that includes AWS S3 utilities.
@@ -34,8 +34,8 @@ export class S3Validator extends BaseValidator {
   static async fromStorageLocation(
     storageLocation: string,
   ): Promise<S3Validator> {
-    if (storageLocation.startsWith(LOCATION_PREFIX)) {
-      const suffix = storageLocation.slice(LOCATION_PREFIX.length);
+    if (storageLocation.startsWith(S3_LOCATION_PREFIX)) {
+      const suffix = storageLocation.slice(S3_LOCATION_PREFIX.length);
       const pieces = suffix.split('/');
       if (pieces.length >= 2) {
         const s3Config = {
@@ -112,7 +112,7 @@ export class S3Validator extends BaseValidator {
   }
 
   storageLocation(): string {
-    return `${LOCATION_PREFIX}/${this.s3Bucket.config.bucket}/${this.s3Bucket.config.region}`;
+    return `${S3_LOCATION_PREFIX}/${this.s3Bucket.config.bucket}/${this.s3Bucket.config.region}`;
   }
 
   getLatestCheckpointUrl(): string {

--- a/typescript/sdk/src/gcp/storage.ts
+++ b/typescript/sdk/src/gcp/storage.ts
@@ -67,7 +67,9 @@ export class GcpStorageWrapper {
 
       const result = {
         data: JSON.parse(body),
-        modified: new Date(metadata.updated ?? ''),
+        // If no updated date is provided, use the Unix epoch start
+        // 0 = Unix epoch start (1970-01-01T00:00:00.000Z)
+        modified: new Date(metadata.updated ?? 0),
       };
 
       if (this.cache) {
@@ -83,7 +85,7 @@ export class GcpStorageWrapper {
   }
 
   url(key: string): string {
-    const Key = this.formatKey(key);
-    return `https://storage.googleapis.com/${this.bucket}/${Key}`;
+    const formattedKey = this.formatKey(key);
+    return `https://storage.googleapis.com/${this.bucket}/${formattedKey}`;
   }
 }

--- a/typescript/sdk/src/gcp/storage.ts
+++ b/typescript/sdk/src/gcp/storage.ts
@@ -1,0 +1,110 @@
+import { Storage } from '@google-cloud/storage';
+
+export const GCS_BUCKET_REGEX =
+  /^(?:(?:https?:\/\/)?([^/]+)\.storage\.googleapis\.com\/?|gs:\/\/([^/]+))$/;
+
+export interface StorageReceipt<T = unknown> {
+  data: T;
+  modified: Date;
+}
+
+export interface StorageConfig {
+  bucket: string;
+  folder?: string;
+  caching?: boolean;
+  // Optional credentials config
+  projectId?: string;
+  keyFilename?: string;
+}
+
+export class GcpStorageWrapper {
+  private readonly client: Storage;
+  private readonly bucket: string;
+  private cache: Record<string, StorageReceipt<any>> | undefined;
+
+  static fromBucketUrl(bucketUrl: string): GcpStorageWrapper {
+    const match = bucketUrl.match(GCS_BUCKET_REGEX);
+    if (!match) throw new Error('Could not parse bucket url');
+    return new GcpStorageWrapper({
+      bucket: match[1],
+      caching: true,
+    });
+  }
+
+  constructor(readonly config: StorageConfig) {
+    this.client = new Storage({
+      projectId: config.projectId,
+      keyFilename: config.keyFilename,
+    });
+    this.bucket = config.bucket;
+    if (config.caching) {
+      this.cache = {};
+    }
+  }
+
+  // List items in the bucket with optional folder prefix
+  async listItems(): Promise<string[]> {
+    const bucket = this.client.bucket(this.bucket);
+    const options = this.config.folder
+      ? { prefix: this.config.folder + '/' }
+      : {};
+
+    try {
+      const [files] = await bucket.getFiles(options);
+      return files.map((file) => {
+        const fullPath = file.name;
+        // If there's a folder prefix, remove it from the returned paths
+        return this.config.folder
+          ? fullPath.slice(this.config.folder.length + 1)
+          : fullPath;
+      });
+    } catch (e) {
+      throw new Error(`Failed to list items in bucket: ${e}`);
+    }
+  }
+
+  formatKey(key: string): string {
+    return this.config.folder ? `${this.config.folder}/${key}` : key;
+  }
+
+  async getObject<T>(key: string): Promise<StorageReceipt<T> | undefined> {
+    const Key = this.formatKey(key);
+    if (this.cache?.[Key]) {
+      return this.cache![Key];
+    }
+
+    try {
+      const bucket = this.client.bucket(this.bucket);
+      const file = bucket.file(Key);
+      const [exists] = await file.exists();
+
+      if (!exists) {
+        return undefined;
+      }
+
+      const [metadata] = await file.getMetadata();
+      const [contents] = await file.download();
+      const body = contents.toString('utf-8');
+
+      const result = {
+        data: JSON.parse(body),
+        modified: new Date(metadata.updated ?? ''),
+      };
+
+      if (this.cache) {
+        this.cache[Key] = result;
+      }
+      return result;
+    } catch (e: any) {
+      if (e.code === 404) {
+        return undefined;
+      }
+      throw e;
+    }
+  }
+
+  url(key: string): string {
+    const Key = this.formatKey(key);
+    return `https://storage.googleapis.com/${this.bucket}/${Key}`;
+  }
+}

--- a/typescript/sdk/src/gcp/storage.ts
+++ b/typescript/sdk/src/gcp/storage.ts
@@ -42,27 +42,6 @@ export class GcpStorageWrapper {
     }
   }
 
-  // List items in the bucket with optional folder prefix
-  async listItems(): Promise<string[]> {
-    const bucket = this.client.bucket(this.bucket);
-    const options = this.config.folder
-      ? { prefix: this.config.folder + '/' }
-      : {};
-
-    try {
-      const [files] = await bucket.getFiles(options);
-      return files.map((file) => {
-        const fullPath = file.name;
-        // If there's a folder prefix, remove it from the returned paths
-        return this.config.folder
-          ? fullPath.slice(this.config.folder.length + 1)
-          : fullPath;
-      });
-    } catch (e) {
-      throw new Error(`Failed to list items in bucket: ${e}`);
-    }
-  }
-
   formatKey(key: string): string {
     return this.config.folder ? `${this.config.folder}/${key}` : key;
   }

--- a/typescript/sdk/src/gcp/validator.ts
+++ b/typescript/sdk/src/gcp/validator.ts
@@ -46,9 +46,11 @@ export class GcpValidator extends BaseValidator {
       const bucketName = storageLocation.slice(LOCATION_PREFIX.length);
       const pieces = bucketName.split('/');
       if (pieces.length >= 1) {
+        const storageFolder =
+          pieces.length > 1 ? pieces.slice(1).join('/') : undefined;
         const storageConfig = {
           bucket: pieces[0],
-          folder: pieces.slice(1).join('/'),
+          folder: storageFolder,
           caching: true,
         };
         const storage = new GcpStorageWrapper(storageConfig);

--- a/typescript/sdk/src/gcp/validator.ts
+++ b/typescript/sdk/src/gcp/validator.ts
@@ -71,10 +71,6 @@ export class GcpValidator extends BaseValidator {
     throw new Error(`Unable to parse location ${storageLocation}`);
   }
 
-  async listItems(): Promise<string[]> {
-    return this.storage.listItems();
-  }
-
   async getAnnouncement(): Promise<Announcement> {
     const { value } = await this.getSignedAnnouncement();
     return value;

--- a/typescript/sdk/src/gcp/validator.ts
+++ b/typescript/sdk/src/gcp/validator.ts
@@ -1,0 +1,134 @@
+import {
+  Announcement,
+  BaseValidator,
+  S3Announcement,
+  S3CheckpointWithId,
+  ValidatorConfig,
+  ValidatorMetadata,
+  isS3CheckpointWithId,
+} from '@hyperlane-xyz/utils';
+
+import { GcpStorageWrapper, StorageConfig } from './storage.js';
+
+const checkpointWithMessageIdKey = (checkpointIndex: number) =>
+  `checkpoint_${checkpointIndex}_with_id.json`;
+const LATEST_KEY = 'gcsLatestIndexKey';
+const ANNOUNCEMENT_KEY = 'gcsAnnouncementKey';
+const METADATA_KEY = 'gcsMetadataKey';
+const LOCATION_PREFIX = 'gs://';
+
+/**
+ * Extension of BaseValidator that includes GCP Cloud Storage utilities.
+ */
+export class GcpValidator extends BaseValidator {
+  public storage: GcpStorageWrapper;
+
+  constructor(
+    public validatorConfig: ValidatorConfig,
+    public storageConfig: StorageConfig,
+  ) {
+    super(validatorConfig);
+    this.storage = new GcpStorageWrapper(storageConfig);
+  }
+
+  static async fromStorageLocation(
+    storageLocation: string,
+  ): Promise<GcpValidator> {
+    // Remove trailing key if present
+    if (storageLocation.endsWith(ANNOUNCEMENT_KEY)) {
+      storageLocation = storageLocation.slice(0, -ANNOUNCEMENT_KEY.length);
+      // Remove trailing slash if present after removing key
+      if (storageLocation.endsWith('/')) {
+        storageLocation = storageLocation.slice(0, -1);
+      }
+    }
+    if (storageLocation.startsWith(LOCATION_PREFIX)) {
+      const bucketName = storageLocation.slice(LOCATION_PREFIX.length);
+      const pieces = bucketName.split('/');
+      if (pieces.length >= 1) {
+        const storageConfig = {
+          bucket: pieces[0],
+          folder: pieces.slice(1).join('/'),
+          caching: true,
+        };
+        const storage = new GcpStorageWrapper(storageConfig);
+        const announcement = await storage.getObject<S3Announcement>(
+          ANNOUNCEMENT_KEY,
+        );
+        if (!announcement) {
+          throw new Error('No announcement found');
+        }
+
+        const validatorConfig = {
+          address: announcement.data.value.validator,
+          localDomain: announcement.data.value.mailbox_domain,
+          mailbox: announcement.data.value.mailbox_address,
+        };
+
+        return new GcpValidator(validatorConfig, storageConfig);
+      }
+    }
+    throw new Error(`Unable to parse location ${storageLocation}`);
+  }
+
+  async listItems(): Promise<string[]> {
+    return this.storage.listItems();
+  }
+
+  async getAnnouncement(): Promise<Announcement> {
+    const { value } = await this.getSignedAnnouncement();
+    return value;
+  }
+
+  async getSignedAnnouncement(): Promise<S3Announcement> {
+    const resp = await this.storage.getObject<S3Announcement>(ANNOUNCEMENT_KEY);
+    if (!resp) {
+      throw new Error(`No announcement found for ${this.config.localDomain}`);
+    }
+
+    return resp.data;
+  }
+
+  async getMetadata(): Promise<ValidatorMetadata> {
+    const resp = await this.storage.getObject<ValidatorMetadata>(METADATA_KEY);
+    if (!resp) {
+      throw new Error(`No metadata found for ${this.config.localDomain}`);
+    }
+
+    return resp.data;
+  }
+
+  async getCheckpoint(index: number): Promise<S3CheckpointWithId | void> {
+    const key = checkpointWithMessageIdKey(index);
+    const checkpoint = await this.storage.getObject<S3CheckpointWithId>(key);
+    if (!checkpoint) {
+      return;
+    }
+
+    if (isS3CheckpointWithId(checkpoint.data)) {
+      return checkpoint.data;
+    } else {
+      throw new Error('Failed to parse checkpoint');
+    }
+  }
+
+  async getLatestCheckpointIndex(): Promise<number> {
+    const latestCheckpointIndex = await this.storage.getObject<number>(
+      LATEST_KEY,
+    );
+
+    if (!latestCheckpointIndex) return -1;
+
+    return latestCheckpointIndex.data;
+  }
+
+  storageLocation(): string {
+    return `${LOCATION_PREFIX}${this.storage.config.bucket}${
+      this.storage.config.folder ? '/' + this.storage.config.folder : ''
+    }`;
+  }
+
+  getLatestCheckpointUrl(): string {
+    return this.storage.url(LATEST_KEY);
+  }
+}

--- a/typescript/sdk/src/gcp/validator.ts
+++ b/typescript/sdk/src/gcp/validator.ts
@@ -15,7 +15,7 @@ const checkpointWithMessageIdKey = (checkpointIndex: number) =>
 const LATEST_KEY = 'gcsLatestIndexKey';
 const ANNOUNCEMENT_KEY = 'gcsAnnouncementKey';
 const METADATA_KEY = 'gcsMetadataKey';
-const LOCATION_PREFIX = 'gs://';
+export const GCP_LOCATION_PREFIX = 'gs://';
 
 /**
  * Extension of BaseValidator that includes GCP Cloud Storage utilities.
@@ -42,8 +42,8 @@ export class GcpValidator extends BaseValidator {
         storageLocation = storageLocation.slice(0, -1);
       }
     }
-    if (storageLocation.startsWith(LOCATION_PREFIX)) {
-      const bucketName = storageLocation.slice(LOCATION_PREFIX.length);
+    if (storageLocation.startsWith(GCP_LOCATION_PREFIX)) {
+      const bucketName = storageLocation.slice(GCP_LOCATION_PREFIX.length);
       const pieces = bucketName.split('/');
       if (pieces.length >= 1) {
         const storageFolder =
@@ -121,7 +121,7 @@ export class GcpValidator extends BaseValidator {
   }
 
   storageLocation(): string {
-    return `${LOCATION_PREFIX}${this.storage.config.bucket}${
+    return `${GCP_LOCATION_PREFIX}${this.storage.config.bucket}${
       this.storage.config.folder ? '/' + this.storage.config.folder : ''
     }`;
   }

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -513,6 +513,7 @@ export {
   getSealevelAccountDataSchema,
 } from './utils/sealevelSerialization.js';
 export { getChainIdFromTxs } from './utils/transactions.js';
+export { getValidatorFromStorageLocation } from './utils/validator.js';
 export {
   FeeConstantConfig,
   RouteBlacklist,

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -575,3 +575,4 @@ export {
 export { EvmIsmModule } from './ism/EvmIsmModule.js';
 export { AnnotatedEV5Transaction } from './providers/ProviderType.js';
 export { EvmERC20WarpModule } from './token/EvmERC20WarpModule.js';
+export { GcpValidator } from './gcp/validator.js';

--- a/typescript/sdk/src/utils/validator.ts
+++ b/typescript/sdk/src/utils/validator.ts
@@ -1,0 +1,9 @@
+import { S3Validator } from '../aws/validator.js';
+import { GcpValidator } from '../gcp/validator.js';
+
+export async function getValidatorFromStorageLocation(location: string) {
+  if (location.startsWith('gs://')) {
+    return GcpValidator.fromStorageLocation(location);
+  }
+  return S3Validator.fromStorageLocation(location);
+}

--- a/typescript/sdk/src/utils/validator.ts
+++ b/typescript/sdk/src/utils/validator.ts
@@ -1,9 +1,12 @@
-import { S3Validator } from '../aws/validator.js';
-import { GcpValidator } from '../gcp/validator.js';
+import { S3Validator, S3_LOCATION_PREFIX } from '../aws/validator.js';
+import { GCP_LOCATION_PREFIX, GcpValidator } from '../gcp/validator.js';
 
 export async function getValidatorFromStorageLocation(location: string) {
-  if (location.startsWith('gs://')) {
+  if (location.startsWith(GCP_LOCATION_PREFIX)) {
     return GcpValidator.fromStorageLocation(location);
+  } else if (location.startsWith(S3_LOCATION_PREFIX)) {
+    return S3Validator.fromStorageLocation(location);
+  } else {
+    throw new Error('Invalid storage location');
   }
-  return S3Validator.fromStorageLocation(location);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7205,12 +7205,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@google-cloud/paginator@npm:^5.0.0":
+  version: 5.0.2
+  resolution: "@google-cloud/paginator@npm:5.0.2"
+  dependencies:
+    arrify: "npm:^2.0.0"
+    extend: "npm:^3.0.2"
+  checksum: 10/b64ba2029b77fdcf3c827aea0b6d128122fd1d2f4aa8c1ba70747cba0659d4216a283769fb3bbeb8f726176f5282624637f02c30f118a010e05838411da0cb76
+  languageName: node
+  linkType: hard
+
+"@google-cloud/projectify@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@google-cloud/projectify@npm:4.0.0"
+  checksum: 10/fdccdda0b50855c35541d71c46a6603f3302ff1a00108d946272cb2167435da00e2a2da5963fe489f4f5a4a9eb6320abeb97d3269974a972ae89f5df8451922d
+  languageName: node
+  linkType: hard
+
+"@google-cloud/promisify@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@google-cloud/promisify@npm:4.0.0"
+  checksum: 10/c5de81321b3a5c567edcbe0b941fb32644611147f3ba22f20575918c225a979988a99bc2ebda05ac914fa8714b0a54c69be72c3f46c7a64c3b19db7d7fba8d04
+  languageName: node
+  linkType: hard
+
 "@google-cloud/secret-manager@npm:^5.5.0":
   version: 5.5.0
   resolution: "@google-cloud/secret-manager@npm:5.5.0"
   dependencies:
     google-gax: "npm:^4.0.3"
   checksum: 10/487267dab1e260a0da79012194bb61c85f8b02b642330fdec32cac1fe37900f0fd6709ff4928fe631ab227b0d758bd3e59b1e3dc1d0682de566a64ef4fb42bba
+  languageName: node
+  linkType: hard
+
+"@google-cloud/storage@npm:7.14.0":
+  version: 7.14.0
+  resolution: "@google-cloud/storage@npm:7.14.0"
+  dependencies:
+    "@google-cloud/paginator": "npm:^5.0.0"
+    "@google-cloud/projectify": "npm:^4.0.0"
+    "@google-cloud/promisify": "npm:^4.0.0"
+    abort-controller: "npm:^3.0.0"
+    async-retry: "npm:^1.3.3"
+    duplexify: "npm:^4.1.3"
+    fast-xml-parser: "npm:^4.4.1"
+    gaxios: "npm:^6.0.2"
+    google-auth-library: "npm:^9.6.3"
+    html-entities: "npm:^2.5.2"
+    mime: "npm:^3.0.0"
+    p-limit: "npm:^3.0.1"
+    retry-request: "npm:^7.0.0"
+    teeny-request: "npm:^9.0.0"
+    uuid: "npm:^8.0.0"
+  checksum: 10/0726fde2697da696637fab91ebd756354a58c1331f6a0b9ecc5011de4aae72cd9e1fe3e9564aee15c6a2118e45ed0ae8c3ac9685c6581db6107080f906a949e9
   languageName: node
   linkType: hard
 
@@ -7555,6 +7602,7 @@ __metadata:
     "@cosmjs/cosmwasm-stargate": "npm:^0.32.4"
     "@cosmjs/stargate": "npm:^0.32.4"
     "@eslint/js": "npm:^9.15.0"
+    "@google-cloud/storage": "npm:7.14.0"
     "@hyperlane-xyz/core": "npm:5.8.2"
     "@hyperlane-xyz/utils": "npm:7.2.0"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
@@ -17826,6 +17874,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"arrify@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "arrify@npm:2.0.1"
+  checksum: 10/067c4c1afd182806a82e4c1cb8acee16ab8b5284fbca1ce29408e6e91281c36bb5b612f6ddfbd40a0f7a7e0c75bf2696eb94c027f6e328d6e9c52465c98e4209
+  languageName: node
+  linkType: hard
+
 "as-table@npm:^1.0.36":
   version: 1.0.55
   resolution: "as-table@npm:1.0.55"
@@ -21019,7 +21074,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"duplexify@npm:^4.0.0, duplexify@npm:^4.1.2":
+"duplexify@npm:^4.0.0, duplexify@npm:^4.1.2, duplexify@npm:^4.1.3":
   version: 4.1.3
   resolution: "duplexify@npm:4.1.3"
   dependencies:
@@ -23147,6 +23202,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-xml-parser@npm:^4.4.1":
+  version: 4.5.0
+  resolution: "fast-xml-parser@npm:4.5.0"
+  dependencies:
+    strnum: "npm:^1.0.5"
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: 10/dc9571c10e7b57b5be54bcd2d92f50c446eb42ea5df347d253e94dd14eb99b5300a6d172e840f151e0721933ca2406165a8d9b316a6d777bf0596dc4fe1df756
+  languageName: node
+  linkType: hard
+
 "fastq@npm:^1.6.0":
   version: 1.13.0
   resolution: "fastq@npm:1.13.0"
@@ -23889,6 +23955,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gaxios@npm:^6.0.2":
+  version: 6.7.1
+  resolution: "gaxios@npm:6.7.1"
+  dependencies:
+    extend: "npm:^3.0.2"
+    https-proxy-agent: "npm:^7.0.1"
+    is-stream: "npm:^2.0.0"
+    node-fetch: "npm:^2.6.9"
+    uuid: "npm:^9.0.1"
+  checksum: 10/c85599162208884eadee91215ebbfa1faa412551df4044626cb561300e15193726e8f23d63b486533e066dadad130f58ed872a23acab455238d8d48b531a0695
+  languageName: node
+  linkType: hard
+
 "gcp-metadata@npm:^6.1.0":
   version: 6.1.0
   resolution: "gcp-metadata@npm:6.1.0"
@@ -24393,6 +24472,20 @@ __metadata:
     gtoken: "npm:^7.0.0"
     jws: "npm:^4.0.0"
   checksum: 10/10d5863493f9426107b0f6c4df244b1413a2cacff9589076f906924336d894fe8bc4153d4a3756cebec8a58784ff1a3900c621924f75f004908611fa46d3caa6
+  languageName: node
+  linkType: hard
+
+"google-auth-library@npm:^9.6.3":
+  version: 9.15.0
+  resolution: "google-auth-library@npm:9.15.0"
+  dependencies:
+    base64-js: "npm:^1.3.0"
+    ecdsa-sig-formatter: "npm:^1.0.11"
+    gaxios: "npm:^6.1.1"
+    gcp-metadata: "npm:^6.1.0"
+    gtoken: "npm:^7.0.0"
+    jws: "npm:^4.0.0"
+  checksum: 10/fba2db9732bbf1b3a3a2e2b45131ba8e8aba297377f1c104d0b2ab3386bbc1e02047f20b8a7afca1c6308492da1540104618f1c7b5cd539703552e10399c560e
   languageName: node
   linkType: hard
 
@@ -25074,6 +25167,13 @@ __metadata:
   dependencies:
     lru-cache: "npm:^10.0.1"
   checksum: 10/8f085df8a4a637d995f357f48b1e3f6fc1f9f92e82b33fb406415b5741834ed431a510a09141071001e8deea2eee43ce72786463e2aa5e5a70db8648c0eedeab
+  languageName: node
+  linkType: hard
+
+"html-entities@npm:^2.5.2":
+  version: 2.5.2
+  resolution: "html-entities@npm:2.5.2"
+  checksum: 10/4ec12ebdf2d5ba8192c68e1aef3c1e4a4f36b29246a0a88464fe278a54517d0196d3489af46a3145c7ecacb4fc5fd50497be19eb713b810acab3f0efcf36fdc2
   languageName: node
   linkType: hard
 
@@ -30013,7 +30113,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-limit@npm:^3.0.2, p-limit@npm:^3.1.0":
+"p-limit@npm:^3.0.1, p-limit@npm:^3.0.2, p-limit@npm:^3.1.0":
   version: 3.1.0
   resolution: "p-limit@npm:3.1.0"
   dependencies:
@@ -36311,7 +36411,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
+"uuid@npm:^8.0.0, uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:


### PR DESCRIPTION
### Description

Introduce GcpValidator for retrieving announcements, checkpoints and metadata for a Validator posting to a GCP bucket. Uses GcpStorageWrapper for bucket operations.

### Drive-by changes

update `check-validator-version` to read gcp buckets too

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

yes

### Testing

manual

before:
```
Error getting metadata for validator 0x14ADB9e3598c395Fe3290f3ba706C3816Aa78F59 on chain flowmainnet: Error: Unable to parse location gs://ff-hyperlane-validator-1/gcsAnnouncementKey

│ 18      │ 'flowmainnet'  │ '0x14ADB9e3598c395Fe3290f3ba706C3816Aa78F59' │ 'flow foundation' │ 'UNKNOWN'                                  │
```

after:
```
│ 22      │ 'flowmainnet'           │ '0x14ADB9e3598c395Fe3290f3ba706C3816Aa78F59' │ 'flow foundation' │ 'nov-7-batch'              │
```