### PR TITLE
chore: Remove ismFactoryAddresses from warpConfig

### DIFF
--- a/.changeset/empty-dodos-clap.md
+++ b/.changeset/empty-dodos-clap.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+Remove ismFactoryAddresses from warpConfig

--- a/typescript/sdk/src/router/schemas.ts
+++ b/typescript/sdk/src/router/schemas.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 
-import { ProxyFactoryFactoriesSchema } from '../deploy/schemas.js';
 import { HookConfigSchema } from '../hook/schemas.js';
 import { IsmConfigSchema } from '../ism/schemas.js';
 import { ZHash } from '../metadata/customZodTypes.js';
@@ -10,7 +9,6 @@ export const MailboxClientConfigSchema = OwnableSchema.extend({
   mailbox: ZHash,
   hook: HookConfigSchema.optional(),
   interchainSecurityModule: IsmConfigSchema.optional(),
-  ismFactoryAddresses: ProxyFactoryFactoriesSchema.optional(),
 });
 
 export const ForeignDeploymentConfigSchema = z.object({

--- a/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
@@ -123,6 +123,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       chain,
       config,
       multiProvider,
+      proxyFactoryFactories: ismFactoryAddresses,
     });
 
     // Let's derive it's onchain token type
@@ -151,6 +152,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       chain,
       config,
       multiProvider,
+      proxyFactoryFactories: ismFactoryAddresses,
     });
 
     // Let's derive it's onchain token type
@@ -187,6 +189,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       chain,
       config,
       multiProvider,
+      proxyFactoryFactories: ismFactoryAddresses,
     });
 
     // Let's derive it's onchain token type
@@ -219,6 +222,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       chain,
       config,
       multiProvider,
+      proxyFactoryFactories: ismFactoryAddresses,
     });
 
     // Let's derive it's onchain token type
@@ -249,6 +253,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       chain,
       config,
       multiProvider,
+      proxyFactoryFactories: ismFactoryAddresses,
     });
     const { remoteRouters } = await evmERC20WarpModule.read();
     expect(Object.keys(remoteRouters!).length).to.equal(numOfRouters);
@@ -285,13 +290,14 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         chain,
         config,
         multiProvider,
+        proxyFactoryFactories: ismFactoryAddresses,
       });
       const actualConfig = await evmERC20WarpModule.read();
 
       for (const interchainSecurityModule of ismConfigToUpdate) {
         const expectedConfig: TokenRouterConfig = {
           ...actualConfig,
-          ismFactoryAddresses,
+
           interchainSecurityModule,
         };
         await sendTxs(await evmERC20WarpModule.update(expectedConfig));
@@ -316,6 +322,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         chain,
         config,
         multiProvider,
+        proxyFactoryFactories: ismFactoryAddresses,
       });
       const actualConfig = await evmERC20WarpModule.read();
 
@@ -327,7 +334,6 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       };
       const expectedConfig: TokenRouterConfig = {
         ...actualConfig,
-        ismFactoryAddresses,
         interchainSecurityModule,
       };
 
@@ -374,11 +380,11 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         chain,
         config,
         multiProvider,
+        proxyFactoryFactories: ismFactoryAddresses,
       });
       const actualConfig = await evmERC20WarpModule.read();
       const expectedConfig: TokenRouterConfig = {
         ...actualConfig,
-        ismFactoryAddresses,
         interchainSecurityModule: {
           type: IsmType.ROUTING,
           owner: randomAddress(),
@@ -415,6 +421,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
           interchainSecurityModule: ismAddress,
         },
         multiProvider,
+        proxyFactoryFactories: ismFactoryAddresses,
       });
       const numOfRouters = Math.floor(Math.random() * 10);
       await sendTxs(
@@ -446,6 +453,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
           interchainSecurityModule: ismAddress,
         },
         multiProvider,
+        proxyFactoryFactories: ismFactoryAddresses,
       });
       const remoteRouters = randomRemoteRouters(1);
       await sendTxs(
@@ -498,6 +506,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
           interchainSecurityModule: ismAddress,
         },
         multiProvider,
+        proxyFactoryFactories: ismFactoryAddresses,
       });
 
       const currentConfig = await evmERC20WarpModule.read();
@@ -527,7 +536,6 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         ...baseConfig,
         type: TokenType.native,
         hook: hookAddress,
-        ismFactoryAddresses,
       };
 
       const owner = signer.address.toLowerCase();
@@ -538,6 +546,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
           interchainSecurityModule: ismAddress,
         },
         multiProvider,
+        proxyFactoryFactories: ismFactoryAddresses,
       });
 
       const currentConfig = await evmERC20WarpModule.read();
@@ -571,7 +580,6 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         ...baseConfig,
         type: TokenType.native,
         hook: hookAddress,
-        ismFactoryAddresses,
         remoteRouters: {
           [domain]: randomAddress(),
         },
@@ -584,6 +592,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
           ...config,
         },
         multiProvider,
+        proxyFactoryFactories: ismFactoryAddresses,
       });
       await sendTxs(
         await evmERC20WarpModule.update({


### PR DESCRIPTION
### Description
Remove `ismFactoryAddresses`, which was added to the WarpConfig to be used in `WarpModule`, and passed into `IsmModule`. 

This is tech debt that was added before passing in `addresses` via the constructor as done here: https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/111e24153250cf702ba8d31970daa855cf7954ec/typescript/sdk/src/ism/EvmIsmModule.ts#L65


### Backward compatibility
Yes

### Testing
Unit Tests

