### PR TITLE
chore: transfer ownership for cbBTC warp deploy on Flow <> Ethereum

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumFlowCbBTCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumFlowCbBTCWarpConfig.ts
@@ -12,11 +12,12 @@ import {
   RouterConfigWithoutOwner,
   tokens,
 } from '../../../../../src/config/warp.js';
-import { DEPLOYER } from '../../owners.js';
 
+// Flow team Safe
 const ethereumOwner = '0x58C3FB862a4F5f038C24F8506BE378e9415c5B6C';
 const ethereumOwnerConfig = getOwnerConfigForAddress(ethereumOwner);
 
+// Flow team Safe
 const flowOwner = '0xa507DFccA02727B46cBdC600C57E89b2b55E5330';
 const flowOwnerConfig = getOwnerConfigForAddress(flowOwner);
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumFlowCbBTCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumFlowCbBTCWarpConfig.ts
@@ -14,9 +14,11 @@ import {
 } from '../../../../../src/config/warp.js';
 import { DEPLOYER } from '../../owners.js';
 
-// Keep on our deployer for now until we get an address from Flow
-const owner = DEPLOYER;
-const ownerConfig = getOwnerConfigForAddress(owner);
+const ethereumOwner = '0x58C3FB862a4F5f038C24F8506BE378e9415c5B6C';
+const ethereumOwnerConfig = getOwnerConfigForAddress(ethereumOwner);
+
+const flowOwner = '0xa507DFccA02727B46cBdC600C57E89b2b55E5330';
+const flowOwnerConfig = getOwnerConfigForAddress(flowOwner);
 
 export const getEthereumFlowCbBTCWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
@@ -24,7 +26,7 @@ export const getEthereumFlowCbBTCWarpConfig = async (
 ): Promise<ChainMap<TokenRouterConfig>> => {
   const ethereum: TokenRouterConfig = {
     ...routerConfig.ethereum,
-    ...ownerConfig,
+    ...ethereumOwnerConfig,
     type: TokenType.collateral,
     token: tokens.ethereum.cbBTC,
     interchainSecurityModule: ethers.constants.AddressZero,
@@ -32,7 +34,7 @@ export const getEthereumFlowCbBTCWarpConfig = async (
 
   const flowmainnet: TokenRouterConfig = {
     ...routerConfig.flowmainnet,
-    ...ownerConfig,
+    ...flowOwnerConfig,
     type: TokenType.synthetic,
     interchainSecurityModule: ethers.constants.AddressZero,
   };

--- a/typescript/infra/scripts/check/check-utils.ts
+++ b/typescript/infra/scripts/check/check-utils.ts
@@ -14,6 +14,7 @@ import {
   InterchainAccountConfig,
   InterchainQuery,
   InterchainQueryChecker,
+  MultiProvider,
   attachContractsMapAndGetForeignDeployments,
   hypERC20factories,
   proxiedFactories,
@@ -72,9 +73,13 @@ export async function getGovernor(
   chains?: string[],
   fork?: string,
   govern?: boolean,
+  multiProvider: MultiProvider | undefined = undefined,
 ) {
   const envConfig = getEnvironmentConfig(environment);
-  let multiProvider = await envConfig.getMultiProvider();
+  // If the multiProvider is not passed in, get it from the environment
+  if (!multiProvider) {
+    multiProvider = await envConfig.getMultiProvider();
+  }
 
   // must rotate to forked provider before building core contracts
   if (fork) {

--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -4,6 +4,7 @@ import { Gauge, Registry } from 'prom-client';
 import { warpConfigGetterMap } from '../../config/warp.js';
 import { submitMetrics } from '../../src/utils/metrics.js';
 import { Modules } from '../agent-utils.js';
+import { getEnvironmentConfig } from '../core-utils.js';
 
 import {
   getCheckWarpDeployArgs,
@@ -15,6 +16,10 @@ import {
 async function main() {
   const { environment, asDeployer, chains, fork, context, pushMetrics } =
     await getCheckWarpDeployArgs().argv;
+
+  const envConfig = getEnvironmentConfig(environment);
+  // Get the multiprovider once to avoid recreating it for each warp route
+  const multiProvider = await envConfig.getMultiProvider();
 
   const metricsRegister = new Registry();
   const checkerViolationsGauge = new Gauge(
@@ -38,6 +43,8 @@ async function main() {
         warpRouteId,
         chains,
         fork,
+        false,
+        multiProvider,
       );
 
       await governor.check();

--- a/typescript/infra/src/config/environment.ts
+++ b/typescript/infra/src/config/environment.ts
@@ -109,6 +109,8 @@ export function getOwnerConfigForAddress(owner: string): OwnableConfig {
   return {
     owner,
     // To ensure that any other overrides aren't applied
-    ownerOverrides: {},
+    ownerOverrides: {
+      proxyAdmin: owner,
+    },
   };
 }


### PR DESCRIPTION
### Description

- Transfers ownership of the cbBTC warp route between flow and ethereum
- A fix to ensure that proxy admin ownership is set

### Drive-by changes

- a driveby to prevent rebuilding the multiprovider tons of times in the check warp deploy script

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
