### PR TITLE
fix: on SVM collateral warp routes, specify the mint when transferring out as readonly

### DIFF
--- a/rust/sealevel/programs/hyperlane-sealevel-token-collateral/src/plugin.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-collateral/src/plugin.rs
@@ -444,7 +444,7 @@ impl HyperlaneSealevelTokenPlugin for CollateralPlugin {
             vec![
                 AccountMeta::new_readonly(token.plugin_data.spl_token_program, false).into(),
                 AccountMeta::new_readonly(spl_associated_token_account::id(), false).into(),
-                AccountMeta::new(token.plugin_data.mint, false).into(),
+                AccountMeta::new_readonly(token.plugin_data.mint, false).into(),
                 AccountMeta::new(recipient_associated_token_account, false).into(),
                 AccountMeta::new(ata_payer_account_key, false).into(),
                 AccountMeta::new(token.plugin_data.escrow, false).into(),


### PR DESCRIPTION
### Description

- This was surfaced a while back but we never made the tweak -- on the collateral warp routes, the account infos exposed to the relayer informing it how to process a message ask for the token mint to be writeable. This isn't necessary - it can be read-only because nothing is changing in the data of the token mint. A consequence of this is that we need to pay higher fees for accounts that have very high contention (like USDC)
- We have strong test coverage here - if this change wasn't possible, our Sealevel tests would fail

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
