### PR TITLE
fix: allow proxy admin addresses to be overridden

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseZeroNetworkCBBTCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseZeroNetworkCBBTCWarpConfig.ts
@@ -23,6 +23,10 @@ export const getBaseZeroNetworkCBBTCWarpConfig = async (
   const base: TokenRouterConfig = {
     ...routerConfig.base,
     ...abacusWorksEnvOwnerConfig.base,
+    proxyAdmin: {
+      ...abacusWorksEnvOwnerConfig.base,
+      address: '0x0FC41a92F526A8CD22060A4052e156502D6B9db0',
+    },
     type: TokenType.collateral,
     token: tokens.base.cbBTC,
     interchainSecurityModule: ISM_CONFIG,
@@ -31,6 +35,10 @@ export const getBaseZeroNetworkCBBTCWarpConfig = async (
   const zeronetwork: TokenRouterConfig = {
     ...routerConfig.zeronetwork,
     ...abacusWorksEnvOwnerConfig.zeronetwork,
+    proxyAdmin: {
+      ...abacusWorksEnvOwnerConfig.zeronetwork,
+      address: '0xDb0F69187750b52A637938Ea790fAE667123367c',
+    },
     type: TokenType.synthetic,
     interchainSecurityModule: ISM_CONFIG,
   };

--- a/typescript/infra/scripts/check/check-utils.ts
+++ b/typescript/infra/scripts/check/check-utils.ts
@@ -203,14 +203,17 @@ export async function getGovernor(
           ...warpAddresses[key],
         };
 
-        // if the owner in the config is an AW account, set the proxyAdmin to the AW singleton proxyAdmin
-        // this will ensure that the checker will check that any proxies are owned by the singleton proxyAdmin
-        const proxyAdmin = eqAddress(
-          config[key].owner,
-          envConfig.owners[key]?.owner,
-        )
-          ? chainAddresses[key]?.proxyAdmin
-          : undefined;
+        // Use the specified proxyAdmin if it is set in the config
+        let proxyAdmin = config[key].proxyAdmin?.address;
+        // If the owner in the config is an AW account and there is no proxyAdmin in the config,
+        // set the proxyAdmin to the AW singleton proxyAdmin.
+        // This will ensure that the checker will check that any proxies are owned by the singleton proxyAdmin.
+        if (
+          !proxyAdmin &&
+          eqAddress(config[key].owner, envConfig.owners[key]?.owner)
+        ) {
+          proxyAdmin = chainAddresses[key]?.proxyAdmin;
+        }
 
         if (proxyAdmin) {
           obj[key].proxyAdmin = proxyAdmin;


### PR DESCRIPTION
### Description

A bit annoying / clunky, but think this is probably the move for now. You'll need to specify the intended proxy admins for all the new warp routes

Methodology for easily getting the proxy admin contracts:
1. First do a check-deploy without --govern
```
yarn tsx ./scripts/check/check-deploy.ts -e mainnet3  -m warp --warpRouteId CBBTC/base-zeronetwork
```
2. copy all the "actual" addresses there and bring into the getter script

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
