### PR TITLE
feat: add Everclear relayer app context

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -22,6 +22,7 @@ import { getDomainId } from '../../registry.js';
 import { environment } from './chains.js';
 import { helloWorld } from './helloworld.js';
 import aaveSenderAddresses from './misc-artifacts/aave-sender-addresses.json';
+import everclearSenderAddresses from './misc-artifacts/everclear-sender-addresses.json';
 import merklyEthAddresses from './misc-artifacts/merkly-eth-addresses.json';
 import merklyNftAddresses from './misc-artifacts/merkly-eth-addresses.json';
 import merklyErc20Addresses from './misc-artifacts/merkly-eth-addresses.json';
@@ -412,6 +413,12 @@ const metricAppContextsGetter = (): MetricAppContext[] => {
       // more poorly documented.
       name: 'aave',
       matchingList: senderMatchingList(aaveSenderAddresses),
+    },
+    {
+      // https://docs.everclear.org/resources/contracts/mainnet
+      // Messages between HubGateway (Everclear hub) <> EverclearSpoke (all other spoke chains)
+      name: 'everclear_gateway',
+      matchingList: senderMatchingList(everclearSenderAddresses),
     },
   ];
 };

--- a/typescript/infra/config/environments/mainnet3/misc-artifacts/everclear-sender-addresses.json
+++ b/typescript/infra/config/environments/mainnet3/misc-artifacts/everclear-sender-addresses.json
@@ -1,0 +1,20 @@
+{
+  "everclear": {
+    "sender": "0xEFfAB7cCEBF63FbEFB4884964b12259d4374FaAa"
+  },
+  "ethereum": {
+    "sender": "0x9ADA72CCbAfe94248aFaDE6B604D1bEAacc899A7"
+  },
+  "optimism": {
+    "sender": "0x9ADA72CCbAfe94248aFaDE6B604D1bEAacc899A7"
+  },
+  "bsc": {
+    "sender": "0x9ADA72CCbAfe94248aFaDE6B604D1bEAacc899A7"
+  },
+  "base": {
+    "sender": "0x9ADA72CCbAfe94248aFaDE6B604D1bEAacc899A7"
+  },
+  "arbitrum": {
+    "sender": "0x9ADA72CCbAfe94248aFaDE6B604D1bEAacc899A7"
+  }
+}


### PR DESCRIPTION
### Description

Tracks messages from the hub/spoke contracts here https://docs.everclear.org/resources/contracts/mainnet (HubGateway (Everclear hub) <> EverclearSpoke (all other spoke chains)). Went with sender tracking to help us flag if there are other new spokes that pop up

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
