### PR TITLE
feat: track ATA payer balances in warp monitors instead of key funder

### DIFF
--- a/.changeset/tough-roses-allow.md
+++ b/.changeset/tough-roses-allow.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Added getters to derive ATA payer accounts on Sealevel warp routes

--- a/.changeset/tough-roses-allow.md
+++ b/.changeset/tough-roses-allow.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': minor
 ---
 
-Added getters to derive ATA payer accounts on Sealevel warp routes
+Added a getter to derive ATA payer accounts on Sealevel warp routes

--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -1,3 +1,4 @@
+import { checkbox, select } from '@inquirer/prompts';
 import path, { join } from 'path';
 import yargs, { Argv } from 'yargs';
 
@@ -23,6 +24,7 @@ import {
 
 import { Contexts } from '../config/contexts.js';
 import { agents } from '../config/environments/agents.js';
+import { WarpRouteIds } from '../config/environments/mainnet3/warp/warpIds.js';
 import { validatorBaseConfigsFn } from '../config/environments/utils.js';
 import {
   getChain,
@@ -277,6 +279,40 @@ export function withTxHashes<T>(args: Argv<T>) {
     .array('txHashes')
     .demandOption('txHashes')
     .alias('t', 'txHashes');
+}
+
+// Interactively gets a single warp route ID
+export async function getWarpRouteIdInteractive() {
+  const choices = Object.values(WarpRouteIds).map((id) => ({
+    value: id,
+  }));
+  return select({
+    message: 'Select Warp Route ID',
+    choices,
+    pageSize: 30,
+  });
+}
+
+// Interactively gets multiple warp route IDs
+export async function getWarpRouteIdsInteractive() {
+  const choices = Object.values(WarpRouteIds).map((id) => ({
+    value: id,
+  }));
+
+  let selection: WarpRouteIds[] = [];
+
+  while (!selection.length) {
+    selection = await checkbox({
+      message: 'Select Warp Route IDs',
+      choices,
+      pageSize: 30,
+    });
+    if (!selection.length) {
+      console.log('Please select at least one Warp Route ID');
+    }
+  }
+
+  return selection;
 }
 
 // not requiring to build coreConfig to get agentConfig

--- a/typescript/infra/scripts/check/check-utils.ts
+++ b/typescript/infra/scripts/check/check-utils.ts
@@ -38,6 +38,7 @@ import { logViolationDetails } from '../../src/utils/violation.js';
 import {
   Modules,
   getArgs as getRootArgs,
+  getWarpRouteIdInteractive,
   withAsDeployer,
   withChains,
   withContext,
@@ -192,7 +193,7 @@ export async function getGovernor(
     governor = new ProxiedRouterGovernor(checker);
   } else if (module === Modules.WARP) {
     if (!warpRouteId) {
-      throw new Error('Warp route id required for warp module');
+      warpRouteId = await getWarpRouteIdInteractive();
     }
     const config = await getWarpConfig(multiProvider, envConfig, warpRouteId);
     const warpAddresses = getWarpAddresses(warpRouteId);

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -90,88 +90,6 @@ const MIN_DELTA_DENOMINATOR = ethers.BigNumber.from(10);
 const RC_FUNDING_DISCOUNT_NUMERATOR = ethers.BigNumber.from(2);
 const RC_FUNDING_DISCOUNT_DENOMINATOR = ethers.BigNumber.from(10);
 
-interface SealevelAccount {
-  pubkey: PublicKey;
-  walletName: string;
-}
-
-const sealevelAccountsToTrack: ChainMap<SealevelAccount[]> = {
-  solanamainnet: [
-    {
-      // WIF warp route ATA payer
-      pubkey: new PublicKey('R5oMfxcbjx4ZYK1B2Aic1weqwt2tQsRzFEGe5WJfAxh'),
-      walletName: 'WIF/eclipsemainnet-solanamainnet/ata-payer',
-    },
-    {
-      // USDC warp route ATA payer
-      pubkey: new PublicKey('A1XtL9mAzkNEpBPinrCpDRrPqVAFjgaxDk4ATFVoQVyc'),
-      walletName: 'USDC/eclipsemainnet-ethereum-solanamainnet/ata-payer',
-    },
-    {
-      // USDT warp route ATA payer
-      pubkey: new PublicKey('9i3kYQqMtkm4sw1w5SQ8ebKMmh4LPVYKZRMPaZeRfn37'),
-      walletName: 'USDT/eclipsemainnet-ethereum-solanamainnet/ata-payer',
-    },
-    {
-      // ORCA warp route ATA payer
-      pubkey: new PublicKey('HqAVwQA6rh1TGdyUHi2XqmCtBSyG3DZjjsCLRXWqyNuU'),
-      walletName: 'ORCA/eclipsemainnet-solanamainnet/ata-payer',
-    },
-  ],
-  eclipsemainnet: [
-    {
-      // WIF warp route ATA payer
-      pubkey: new PublicKey('HCQAfDd5ytAEidzR9g7CipjEGv2ZrSSZq1UY34oDFv8h'),
-      walletName: 'WIF/eclipsemainnet-solanamainnet/ata-payer',
-    },
-    {
-      // USDC warp route ATA payer
-      pubkey: new PublicKey('7arS1h8nwVVmmTVWSsu9rQ4WjLBN8iAi4DvHi8gWjBNC'),
-      walletName: 'USDC/eclipsemainnet-ethereum-solanamainnet/ata-payer',
-    },
-    {
-      // tETH warp route ATA payer
-      pubkey: new PublicKey('Hyy4jryRxgZm5pvuSx29fXxJ9J55SuDtXiCo89kmNuz5'),
-      walletName: 'tETH/eclipsemainnet-ethereum/ata-payer',
-    },
-    {
-      // SOL warp route ATA payer
-      pubkey: new PublicKey('CijxTbPs9JZxTUfo8Hmz2imxzHtKnDFD3kZP3RPy34uJ'),
-      walletName: 'SOL/eclipsemainnet-solanamainnet/ata-payer',
-    },
-    {
-      // stTIA warp route ATA payer
-      pubkey: new PublicKey('Bg3bAM3gEhdam5mbPqkiMi3mLZkoAieakMRdMHo6mbcn'),
-      walletName: 'stTIA/eclipsemainnet-stride/ata-payer',
-    },
-    {
-      // TIA warp route ATA payer
-      pubkey: new PublicKey('AZs4Rw6H6YwJBKoHBCfChCitHnHvQcVGgrJwGh4bKmAf'),
-      walletName: 'TIA/eclipsemainnet-stride/ata-payer',
-    },
-    {
-      // USDT warp route ATA payer
-      pubkey: new PublicKey('78s5TD48q89EZqHNC2bfsswQXn6n3sn1ecGgqXgJe4hL'),
-      walletName: 'USDT/eclipsemainnet-ethereum-solanamainnet/ata-payer',
-    },
-    {
-      // ORCA warp route ATA payer
-      pubkey: new PublicKey('3ZyZHoDRzfYg4ug6Tx4Zywe6M5Vt19vPZFx9Ag8qqnXu'),
-      walletName: 'ORCA/eclipsemainnet-solanamainnet/ata-payer',
-    },
-    {
-      // WBTC warp route ATA payer
-      pubkey: new PublicKey('BH9VfgYaCWbwuupzsTfSy67yR4dwuCbXmFRrm6aAH2NQ'),
-      walletName: 'WBTC/eclipsemainnet-ethereum/ata-payer',
-    },
-    // weETHs warp route ATA payer
-    {
-      pubkey: new PublicKey('F4Y6kHrq9qVnmkQhQibxh8nCU2quw5y25z7u8jSHMvtq'),
-      walletName: 'weETHs/eclipsemainnet-ethereum/ata-payer',
-    },
-  ],
-};
-
 // Funds key addresses for multiple contexts from the deployer key of the context
 // specified via the `--context` flag.
 // The --contexts-and-roles flag is used to specify the contexts and the key roles
@@ -548,13 +466,6 @@ class ContextFunder {
       false,
     );
 
-    if (
-      this.environment === 'mainnet3' &&
-      this.context === Contexts.Hyperlane
-    ) {
-      await this.updateSolanaWalletBalanceGauge();
-    }
-
     return failureOccurred;
   }
 
@@ -900,54 +811,6 @@ class ContextFunder {
           ),
         ),
       );
-  }
-
-  private async updateSolanaWalletBalanceGauge() {
-    for (const chain of Object.keys(sealevelAccountsToTrack) as ChainName[]) {
-      await this.updateSealevelWalletBalanceAccounts(
-        chain,
-        sealevelAccountsToTrack[chain],
-      );
-    }
-  }
-
-  private async updateSealevelWalletBalanceAccounts(
-    chain: ChainName,
-    accounts: SealevelAccount[],
-  ) {
-    const rpcUrls = await getSecretRpcEndpoints(this.environment, chain);
-    const provider = new Connection(rpcUrls[0], 'confirmed');
-
-    for (const { pubkey, walletName } of accounts) {
-      logger.info(
-        {
-          chain,
-          pubkey: pubkey.toString(),
-          walletName,
-        },
-        'Fetching sealevel wallet balance',
-      );
-      const balance = await provider.getBalance(pubkey);
-      logger.info(
-        {
-          balance,
-          chain,
-          pubkey: pubkey.toString(),
-          walletName,
-        },
-        'Retrieved sealevel chain wallet balance',
-      );
-      walletBalanceGauge
-        .labels({
-          chain,
-          wallet_address: pubkey.toString(),
-          wallet_name: walletName,
-          token_symbol: 'Native',
-          token_name: 'Native',
-          ...constMetricLabels,
-        })
-        .set(balance / 1e9);
-    }
   }
 }
 

--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -35,7 +35,10 @@ import { owners } from '../../config/environments/testnet4/owners.js';
 import { CloudAgentKey } from '../../src/agents/keys.js';
 import { DeployEnvironment } from '../../src/config/environment.js';
 import { Role } from '../../src/roles.js';
-import { startMetricsServer } from '../../src/utils/metrics.js';
+import {
+  getWalletBalanceGauge,
+  startMetricsServer,
+} from '../../src/utils/metrics.js';
 import { assertChain, diagonalize } from '../../src/utils/utils.js';
 import { getArgs, withContext } from '../agent-utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
@@ -70,19 +73,7 @@ const messageReceiptSeconds = new Counter({
   registers: [metricsRegister],
   labelNames: ['origin', 'remote'],
 });
-const walletBalance = new Gauge({
-  name: 'hyperlane_wallet_balance',
-  help: 'Current balance of eth and other tokens in the `tokens` map for the wallet addresses in the `wallets` set',
-  registers: [metricsRegister],
-  labelNames: [
-    'chain',
-    'wallet_address',
-    'wallet_name',
-    'token_address',
-    'token_symbol',
-    'token_name',
-  ],
-});
+const walletBalance = getWalletBalanceGauge(metricsRegister);
 
 /** The maximum number of messages we will allow to get queued up if we are sending too slowly. */
 const MAX_MESSAGES_ALLOWED_TO_SEND = 5;

--- a/typescript/infra/scripts/warp-routes/deploy-warp-monitor.ts
+++ b/typescript/infra/scripts/warp-routes/deploy-warp-monitor.ts
@@ -1,5 +1,4 @@
 import { checkbox } from '@inquirer/prompts';
-import yargs from 'yargs';
 
 import { Contexts } from '../../config/contexts.js';
 import { WarpRouteIds } from '../../config/environments/mainnet3/warp/warpIds.js';
@@ -9,6 +8,7 @@ import {
   assertCorrectKubeContext,
   getAgentConfig,
   getArgs,
+  getWarpRouteIdsInteractive,
   withWarpRouteId,
 } from '../agent-utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
@@ -39,27 +39,6 @@ async function main() {
     console.log(`Deploying Warp Monitor for Warp Route ID: ${id}`);
     await deployWarpMonitor(id);
   }
-}
-
-async function getWarpRouteIdsInteractive() {
-  const choices = Object.values(WarpRouteIds).map((id) => ({
-    value: id,
-  }));
-
-  let selection: WarpRouteIds[] = [];
-
-  while (!selection.length) {
-    selection = await checkbox({
-      message: 'Select Warp Route IDs to deploy',
-      choices,
-      pageSize: 30,
-    });
-    if (!selection.length) {
-      console.log('Please select at least one Warp Route ID');
-    }
-  }
-
-  return selection;
 }
 
 main()

--- a/typescript/infra/scripts/warp-routes/monitor/metrics.ts
+++ b/typescript/infra/scripts/warp-routes/monitor/metrics.ts
@@ -108,6 +108,9 @@ export function updateNativeWalletBalanceMetrics(balance: NativeWalletBalance) {
       token_name: 'Native',
     })
     .set(balance.balance);
+  logger.info('Native wallet balance updated', {
+    balanceInfo: balance,
+  });
 }
 
 export function updateXERC20LimitsMetrics(token: Token, limits: XERC20Limit) {

--- a/typescript/infra/scripts/warp-routes/monitor/metrics.ts
+++ b/typescript/infra/scripts/warp-routes/monitor/metrics.ts
@@ -3,7 +3,9 @@ import { Gauge, Registry } from 'prom-client';
 import { createWarpRouteConfigId } from '@hyperlane-xyz/registry';
 import { ChainName, Token, TokenStandard, WarpCore } from '@hyperlane-xyz/sdk';
 
-import { WarpRouteBalance, XERC20Limit } from './types.js';
+import { getWalletBalanceGauge } from '../../../src/utils/metrics.js';
+
+import { NativeWalletBalance, WarpRouteBalance, XERC20Limit } from './types.js';
 import { logger } from './utils.js';
 
 export const metricsRegister = new Registry();
@@ -43,6 +45,8 @@ const warpRouteCollateralValue = new Gauge({
   registers: [metricsRegister],
   labelNames: warpRouteMetricLabels,
 });
+
+const walletBalanceGauge = getWalletBalanceGauge(metricsRegister);
 
 const xERC20LimitsGauge = new Gauge({
   name: 'hyperlane_xerc20_limits',
@@ -92,6 +96,18 @@ export function updateTokenBalanceMetrics(
       'Wallet value updated for token',
     );
   }
+}
+
+export function updateNativeWalletBalanceMetrics(balance: NativeWalletBalance) {
+  walletBalanceGauge
+    .labels({
+      chain: balance.chain,
+      wallet_address: balance.walletAddress,
+      wallet_name: balance.walletName,
+      token_symbol: 'Native',
+      token_name: 'Native',
+    })
+    .set(balance.balance);
 }
 
 export function updateXERC20LimitsMetrics(token: Token, limits: XERC20Limit) {

--- a/typescript/infra/scripts/warp-routes/monitor/monitor-warp-route-balances.ts
+++ b/typescript/infra/scripts/warp-routes/monitor/monitor-warp-route-balances.ts
@@ -24,7 +24,11 @@ import {
 } from '../../../src/config/environment.js';
 import { fetchGCPSecret } from '../../../src/utils/gcloud.js';
 import { startMetricsServer } from '../../../src/utils/metrics.js';
-import { getArgs, withWarpRouteIdRequired } from '../../agent-utils.js';
+import {
+  getArgs,
+  getWarpRouteIdInteractive,
+  withWarpRouteId,
+} from '../../agent-utils.js';
 import { getEnvironmentConfig } from '../../core-utils.js';
 
 import {
@@ -37,13 +41,18 @@ import { NativeWalletBalance, WarpRouteBalance, XERC20Limit } from './types.js';
 import { logger, tryFn } from './utils.js';
 
 async function main() {
-  const { checkFrequency, environment, warpRouteId } =
-    await withWarpRouteIdRequired(getArgs())
-      .describe('checkFrequency', 'frequency to check balances in ms')
-      .demandOption('checkFrequency')
-      .alias('v', 'checkFrequency') // v as in Greek letter nu
-      .number('checkFrequency')
-      .parse();
+  const {
+    checkFrequency,
+    environment,
+    warpRouteId: warpRouteIdArg,
+  } = await withWarpRouteId(getArgs())
+    .describe('checkFrequency', 'frequency to check balances in ms')
+    .demandOption('checkFrequency')
+    .alias('v', 'checkFrequency') // v as in Greek letter nu
+    .number('checkFrequency')
+    .parse();
+
+  const warpRouteId = warpRouteIdArg || (await getWarpRouteIdInteractive());
 
   startMetricsServer(metricsRegister);
 

--- a/typescript/infra/scripts/warp-routes/monitor/monitor-warp-route-balances.ts
+++ b/typescript/infra/scripts/warp-routes/monitor/monitor-warp-route-balances.ts
@@ -122,6 +122,10 @@ async function updateTokenMetrics(
     }, 'Getting bridged balance and value'),
   ];
 
+  // For Sealevel collateral and synthetic tokens, there is an
+  // "Associated Token Account" (ATA) rent payer that has a balance
+  // that's used to pay for rent for the accounts that store user balances.
+  // This is necessary if the recipient has never received any tokens before.
   if (token.protocol === ProtocolType.Sealevel && !token.isNative()) {
     promises.push(
       tryFn(async () => {

--- a/typescript/infra/scripts/warp-routes/monitor/types.ts
+++ b/typescript/infra/scripts/warp-routes/monitor/types.ts
@@ -9,3 +9,10 @@ export interface WarpRouteBalance {
   balance: number;
   valueUSD?: number;
 }
+
+export interface NativeWalletBalance {
+  chain: string;
+  walletAddress: string;
+  walletName: string;
+  balance: number;
+}

--- a/typescript/infra/src/utils/metrics.ts
+++ b/typescript/infra/src/utils/metrics.ts
@@ -1,5 +1,5 @@
 import http from 'http';
-import { Pushgateway, Registry } from 'prom-client';
+import { Gauge, Pushgateway, Registry } from 'prom-client';
 import { format } from 'util';
 
 import { rootLogger } from '@hyperlane-xyz/utils';
@@ -65,4 +65,25 @@ export function startMetricsServer(register: Registry): http.Server {
         .catch((err) => logger.error(err));
     })
     .listen(parseInt(process.env['PROMETHEUS_PORT'] || '9090'));
+}
+
+export function getWalletBalanceGauge(
+  register: Registry,
+  additionalLabels: string[] = [],
+) {
+  return new Gauge({
+    // Mirror the rust/main/ethers-prometheus `wallet_balance` gauge metric.
+    name: 'hyperlane_wallet_balance',
+    help: 'Current balance of eth and other tokens in the `tokens` map for the wallet addresses in the `wallets` set',
+    registers: [register],
+    labelNames: [
+      'chain',
+      'wallet_address',
+      'wallet_name',
+      'token_address',
+      'token_symbol',
+      'token_name',
+      ...additionalLabels,
+    ],
+  });
 }

--- a/typescript/infra/src/utils/metrics.ts
+++ b/typescript/infra/src/utils/metrics.ts
@@ -74,7 +74,7 @@ export function getWalletBalanceGauge(
   return new Gauge({
     // Mirror the rust/main/ethers-prometheus `wallet_balance` gauge metric.
     name: 'hyperlane_wallet_balance',
-    help: 'Current balance of eth and other tokens in the `tokens` map for the wallet addresses in the `wallets` set',
+    help: 'Current balance of a wallet for a token',
     registers: [register],
     labelNames: [
       'chain',

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -446,6 +446,7 @@ export {
   SealevelHypCollateralAdapter,
   SealevelHypNativeAdapter,
   SealevelHypSyntheticAdapter,
+  SealevelHypTokenAdapter,
   SealevelNativeTokenAdapter,
   SealevelTokenAdapter,
 } from './token/adapters/SealevelTokenAdapter.js';

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -526,6 +526,14 @@ export abstract class SealevelHypTokenAdapter
     );
   }
 
+  // Should match https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/4b3537470eff0139163a2a7aa1d19fc708a992c6/rust/sealevel/programs/hyperlane-sealevel-token/src/plugin.rs#L43-L51
+  deriveAtaPayerAccount(): PublicKey {
+    return super.derivePda(
+      ['hyperlane_token', '-', 'ata_payer'],
+      this.warpProgramPubKey,
+    );
+  }
+
   /**
    * Fetches the median prioritization fee for transfers of the collateralAddress token.
    * @returns The median prioritization fee in micro-lamports
@@ -632,6 +640,10 @@ export class SealevelHypNativeAdapter extends SealevelHypTokenAdapter {
       ['hyperlane_token', '-', 'native_collateral'],
       this.warpProgramPubKey,
     );
+  }
+
+  deriveAtaPayerAccount(): PublicKey {
+    throw new Error('No ATA payer is used for native warp routes');
   }
 }
 


### PR DESCRIPTION
### Description

- We need to track balances of "ATA payer" accounts, which are accounts that have balances that are used to pay for rent for recipients that have never received a particular token before. The balance is in the native token as that's what the SVM uses to charge rent. Previously, we were tracking these in the key funder in a very manual and annoying process. Now, this is tracked automatically when a warp route monitor is set up.
- Removed the old logic in the key funder
- Consolidated some code to ensure the same gauge is used to track wallet balances throughout TS

What I'll do after this is merged:
- deploy an updated key funder to no longer track ATA payers
- deploy new warp route monitors with this

Example of the metric now included in the warp monitor:
```
# HELP hyperlane_wallet_balance Current balance of a wallet for a token
# TYPE hyperlane_wallet_balance gauge
hyperlane_wallet_balance{chain="eclipsemainnet",wallet_address="CijxTbPs9JZxTUfo8Hmz2imxzHtKnDFD3kZP3RPy34uJ",wallet_name="SOL/eclipsemainnet-solanamainnet/ata-payer",token_symbol="Native",token_name="Native"} 0.039941128

```

### Drive-by changes

- Some drive-bys to allow you to omit a warp route ID as a CLI arg to some scripts to get an interactive prompt. Found this useful as it's annoying to remember and type out the warp route ID structure

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
