### PR TITLE
feat: env var to set Jito tip as a stopgap

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -501,6 +501,11 @@ impl Mailbox for SealevelMailbox {
         // If we're using Jito, we need to send a tip to the Jito fee account.
         // Otherwise, we need to set the compute unit price.
         if self.use_jito() {
+            let tip: u64 = std::env::var("JITO_TIP_LAMPORTS")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(PROCESS_DESIRED_PRIORITIZATION_FEE_LAMPORTS_PER_TX);
+
             // The tip is a standalone transfer to a Jito fee account.
             // See https://github.com/jito-labs/mev-protos/blob/master/json_rpc/http.md#sendbundle.
             instructions.push(solana_sdk::system_instruction::transfer(
@@ -508,7 +513,7 @@ impl Mailbox for SealevelMailbox {
                 // A random Jito fee account, taken from the getFeeAccount RPC response:
                 // https://github.com/jito-labs/mev-protos/blob/master/json_rpc/http.md#gettipaccounts
                 &solana_sdk::pubkey!("DfXygSm4jCyNCybVYYK6DwvWqjKee8pbDmJGcLWNDXjh"),
-                PROCESS_DESIRED_PRIORITIZATION_FEE_LAMPORTS_PER_TX,
+                tip,
             ));
         }
         // "processed" level commitment does not guarantee finality.

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -454,7 +454,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'd834d81-20241125-135658',
+      tag: 'da277d9-20241128-121942',
     },
     gasPaymentEnforcement: gasPaymentEnforcement,
     metricAppContextsGetter,


### PR DESCRIPTION
### Description

- Intending to follow up with a more legit way of figuring out fees

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
