### PR TITLE
feat(warpMonitor): Add validator_names label to warp balance monitor metric

### DIFF
--- a/typescript/infra/scripts/warp-routes/monitor/metrics.ts
+++ b/typescript/infra/scripts/warp-routes/monitor/metrics.ts
@@ -88,6 +88,10 @@ export function updateTokenBalanceMetrics(
       .filter((chainName) => chainName !== token.chainName)
       .sort()
       .join(','),
+    // we are assuming that all routes are using the defaultISM
+    // we could do a check to verify this however this would exclude routes like Renzo that include the defaultISM as part of an aggregation
+    // the goal of these metrics is to inform us of the Value at risk for routes that rely (or partially rely) on the defaultISM
+    // we are technically overestimating the total value at risk using this approach as we will account for balances that are not secured by the defaultISM
     validator_names: defaultMultisigConfigs[token.chainName].validators
       .map((v) => v.alias)
       .sort()


### PR DESCRIPTION
### Description
- Add validator_names, number_of_validators, validator_threshold labels to warp balance monitor metric
- The intention is to supplement the Value at Risk dashboard with this validator set information
- It may also be feasible to create alerts that consider the value at risk, validator set info and thresholds to warn us if the validators set is not secure enough

### Backward compatibility
- This will create new time series for the `hyperlane_warp_route_token_balance` metric as we are adding new labels which will mean that All warp route diffs, the warp routes and xERC20 related dashboards will switch to using a different time series. Whilst not ideal as the graphs will look weird, the downside is not significant 
