### PR TITLE
fix(warpConfig): Fix LUMIA/bsc-ethereum-lumia warp config

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumBscLumiaLUMIAWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumBscLumiaLUMIAWarpConfig.ts
@@ -38,7 +38,7 @@ export const getEthereumBscLUMIAWarpConfig = async (
     mailbox: '0x3a867fCfFeC2B790970eeBDC9023E75B0a172aa7',
     proxyAdmin: {
       owner: owner,
-      address: '0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D',
+      address: '0xBC53dACd8c0ac0d2bAC461479EAaf5519eCC8853',
     },
   };
 

--- a/typescript/sdk/src/deploy/HyperlaneAppChecker.ts
+++ b/typescript/sdk/src/deploy/HyperlaneAppChecker.ts
@@ -137,7 +137,7 @@ export abstract class HyperlaneAppChecker<
             const actualProxyAdminOwner =
               await actualProxyAdminContract.owner();
             const expectedOwner = this.getOwner(
-              actualProxyAdminOwner,
+              owner,
               'proxyAdmin',
               ownableOverrides,
             );


### PR DESCRIPTION
### Description
- Fix LUMIA/bsc-ethereum-lumia warp config, proxyAdmin address was incorrectly set to the AW proxyAdmin in Lumia
- Recent bug fix in checker has surfaced this issue

### Drive-by changes

- Fix bug with ownership check when proxyAdmin is not set in config

### Testing

Manual
