### PR TITLE
feat: require Sealevel native transfers to cover the rent of the recipient

### DIFF
--- a/.changeset/clever-melons-sell.md
+++ b/.changeset/clever-melons-sell.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Require Sealevel native transfers to cover the rent of the recipient

--- a/typescript/infra/scripts/warp-routes/monitor/monitor-warp-route-balances.ts
+++ b/typescript/infra/scripts/warp-routes/monitor/monitor-warp-route-balances.ts
@@ -1,4 +1,3 @@
-import { PublicKey } from '@solana/web3.js';
 import { PopulatedTransaction } from 'ethers';
 
 import { createWarpRouteConfigId } from '@hyperlane-xyz/registry';
@@ -16,13 +15,7 @@ import {
   TokenStandard,
   WarpCore,
 } from '@hyperlane-xyz/sdk';
-import {
-  ProtocolType,
-  assert,
-  objMap,
-  objMerge,
-  sleep,
-} from '@hyperlane-xyz/utils';
+import { ProtocolType, objMap, objMerge, sleep } from '@hyperlane-xyz/utils';
 
 import { getWarpCoreConfig } from '../../../config/registry.js';
 import {
@@ -96,25 +89,6 @@ async function pollAndUpdateWarpRouteMetrics(
     chainMetadata,
     apiKey: await getCoinGeckoApiKey(),
   });
-
-  // console.log('token', token);
-  console.log('before');
-  const origin = warpCore.getTokensForChain('eclipsemainnet')[0];
-
-  assert(origin, 'origin token not found');
-
-  const valid = await warpCore.validateTransfer({
-    originTokenAmount: origin.amount(1n),
-    destination: 'solanamainnet',
-    sender: '9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf',
-    recipient: '9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWng',
-    // senderPubKey: new PublicKey('G5FM3UKwcBJ47PwLWLLY1RQpqNtTMgnqnd6nZGcJqaBp'),
-  });
-  console.log('valid', valid);
-
-  if (1 + 1 == 2) {
-    return;
-  }
 
   while (true) {
     await tryFn(async () => {

--- a/typescript/infra/scripts/warp-routes/monitor/monitor-warp-route-balances.ts
+++ b/typescript/infra/scripts/warp-routes/monitor/monitor-warp-route-balances.ts
@@ -1,3 +1,4 @@
+import { PublicKey } from '@solana/web3.js';
 import { PopulatedTransaction } from 'ethers';
 
 import { createWarpRouteConfigId } from '@hyperlane-xyz/registry';
@@ -15,7 +16,13 @@ import {
   TokenStandard,
   WarpCore,
 } from '@hyperlane-xyz/sdk';
-import { ProtocolType, objMap, objMerge, sleep } from '@hyperlane-xyz/utils';
+import {
+  ProtocolType,
+  assert,
+  objMap,
+  objMerge,
+  sleep,
+} from '@hyperlane-xyz/utils';
 
 import { getWarpCoreConfig } from '../../../config/registry.js';
 import {
@@ -89,6 +96,25 @@ async function pollAndUpdateWarpRouteMetrics(
     chainMetadata,
     apiKey: await getCoinGeckoApiKey(),
   });
+
+  // console.log('token', token);
+  console.log('before');
+  const origin = warpCore.getTokensForChain('eclipsemainnet')[0];
+
+  assert(origin, 'origin token not found');
+
+  const valid = await warpCore.validateTransfer({
+    originTokenAmount: origin.amount(1n),
+    destination: 'solanamainnet',
+    sender: '9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf',
+    recipient: '9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWng',
+    // senderPubKey: new PublicKey('G5FM3UKwcBJ47PwLWLLY1RQpqNtTMgnqnd6nZGcJqaBp'),
+  });
+  console.log('valid', valid);
+
+  if (1 + 1 == 2) {
+    return;
+  }
 
   while (true) {
     await tryFn(async () => {

--- a/typescript/sdk/src/token/adapters/CosmWasmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/CosmWasmTokenAdapter.ts
@@ -64,6 +64,10 @@ export class CwNativeTokenAdapter
     throw new Error('Metadata not available to native tokens');
   }
 
+  async getMinimumTransferAmount(_recipient: Address): Promise<bigint> {
+    return 0n;
+  }
+
   async isApproveRequired(): Promise<boolean> {
     return false;
   }
@@ -144,6 +148,10 @@ export class CwTokenAdapter
       ...resp,
       totalSupply: resp.total_supply,
     };
+  }
+
+  async getMinimumTransferAmount(_recipient: Address): Promise<bigint> {
+    return 0n;
   }
 
   async isApproveRequired(): Promise<boolean> {

--- a/typescript/sdk/src/token/adapters/CosmosTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/CosmosTokenAdapter.ts
@@ -46,6 +46,10 @@ export class CosmNativeTokenAdapter
     throw new Error('Metadata not available to native tokens');
   }
 
+  async getMinimumTransferAmount(_recipient: Address): Promise<bigint> {
+    return 0n;
+  }
+
   async isApproveRequired(): Promise<boolean> {
     return false;
   }

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -57,6 +57,10 @@ export class EvmNativeTokenAdapter
     throw new Error('Metadata not available to native tokens');
   }
 
+  async getMinimumTransferAmount(_recipient: Address): Promise<bigint> {
+    return 0n;
+  }
+
   async isApproveRequired(
     _owner: Address,
     _spender: Address,

--- a/typescript/sdk/src/token/adapters/ITokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/ITokenAdapter.ts
@@ -25,6 +25,7 @@ export interface ITokenAdapter<Tx> {
   getBalance(address: Address): Promise<bigint>;
   getTotalSupply(): Promise<bigint | undefined>;
   getMetadata(isNft?: boolean): Promise<TokenMetadata>;
+  getMinimumTransferAmount(recipient: Address): Promise<bigint>;
   isApproveRequired(
     owner: Address,
     spender: Address,

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -636,6 +636,10 @@ export class SealevelHypNativeAdapter extends SealevelHypTokenAdapter {
     return this.wrappedNative.getMetadata();
   }
 
+  override async getMinimumTransferAmount(recipient: Address): Promise<bigint> {
+    return this.wrappedNative.getMinimumTransferAmount(recipient);
+  }
+
   override async getMedianPriorityFee(): Promise<number | undefined> {
     // Native tokens don't have a collateral address, so we don't fetch
     // prioritization fee history

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -173,7 +173,7 @@ export class SealevelTokenAdapter
     return { decimals: 9, symbol: 'SPL', name: 'SPL Token', totalSupply: '' };
   }
 
-  async getMinimumTransferAmount(recipient: Address): Promise<bigint> {
+  async getMinimumTransferAmount(_recipient: Address): Promise<bigint> {
     return 0n;
   }
 

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -90,6 +90,24 @@ export class SealevelNativeTokenAdapter
     throw new Error('Metadata not available to native tokens');
   }
 
+  // Require a minimum transfer amount to cover rent for the recipient.
+  async getMinimumTransferAmount(recipient: Address): Promise<bigint> {
+    const recipientPubkey = new PublicKey(recipient);
+    const provider = this.getProvider();
+    const recipientAccount = await provider.getAccountInfo(recipientPubkey);
+    const recipientDataLength = recipientAccount?.data.length ?? 0;
+    const recipientLamports = recipientAccount?.lamports ?? 0;
+
+    const minRequiredLamports =
+      await provider.getMinimumBalanceForRentExemption(recipientDataLength);
+
+    if (recipientLamports < minRequiredLamports) {
+      return BigInt(minRequiredLamports - recipientLamports);
+    }
+
+    return 0n;
+  }
+
   async isApproveRequired(): Promise<boolean> {
     return false;
   }
@@ -153,6 +171,10 @@ export class SealevelTokenAdapter
   async getMetadata(_isNft?: boolean): Promise<TokenMetadata> {
     // TODO solana support
     return { decimals: 9, symbol: 'SPL', name: 'SPL Token', totalSupply: '' };
+  }
+
+  async getMinimumTransferAmount(recipient: Address): Promise<bigint> {
+    return 0n;
   }
 
   async isApproveRequired(): Promise<boolean> {

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -663,7 +663,7 @@ export class WarpCore {
 
     const destinationName = this.multiProvider.getChainName(destination);
     const destinationToken =
-      originTokenAmount.token.getConnectionForChain(destinationName)?.token;
+      originToken.getConnectionForChain(destinationName)?.token;
     assert(destinationToken, `No connection found for ${destinationName}`);
     const destinationAdapter = destinationToken.getAdapter(this.multiProvider);
 

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -667,27 +667,20 @@ export class WarpCore {
     assert(destinationToken, `No connection found for ${destinationName}`);
     const destinationAdapter = destinationToken.getAdapter(this.multiProvider);
 
-    // Convert the originTokenAmount to a destination amount
-    const destinationTokenAmount = destinationToken.amount(
-      convertDecimals(
-        originToken.decimals,
-        destinationToken.decimals,
-        originTokenAmount.amount.toString(),
-      ),
-    );
     // Get the min required destination amount
     const minDestinationTransferAmount =
       await destinationAdapter.getMinimumTransferAmount(recipient);
 
-    if (minDestinationTransferAmount > destinationTokenAmount.amount) {
-      // Surface the min required amount to the user as an origin amount
-      const minOriginTransferAmount = originToken.amount(
-        convertDecimals(
-          destinationToken.decimals,
-          originToken.decimals,
-          minDestinationTransferAmount.toString(),
-        ),
-      );
+    // Convert the minDestinationTransferAmount to an origin amount
+    const minOriginTransferAmount = destinationToken.amount(
+      convertDecimals(
+        originToken.decimals,
+        destinationToken.decimals,
+        minDestinationTransferAmount.toString(),
+      ),
+    );
+
+    if (minOriginTransferAmount.amount > originTokenAmount.amount) {
       return {
         amount: `Minimum transfer amount is ${minOriginTransferAmount.getDecimalFormattedAmount()} ${
           originToken.symbol


### PR DESCRIPTION
### Description

- Happened a few times where someone transferred SOL from Eclipse -> SOL on Solana, and the recipient did not yet exist (so had no SOL balance to cover its rent). The amount on these transfers would be insufficient to cover the rent of the recipient, so the transfer could never be delivered. See https://discord.com/channels/935678348330434570/1311371339889639486/1311381212828532858 for context on the first time this happened. There were then a few other instances the day after
- This introduces `ITokenAdapter.getMinimumTransferAmount`, where impls generally return a minimum of 0, but native Sealevel and native Sealevel warp routes have some logic that is aware of required rent exemption balances
- Atm, in WarpCore this only checks getMinimumTransferAmount on the destination side and not the origin -- my reasoning here is that:
  a. for the specific issue this is addressing, the destination side is the only one where issues can arise. On the origin, the account that escrows the SOL is always rent exempt
  b. checking on the origin for completeness could be done, but would require some extra logic to be aware of where tokens are escrowed on the origin side (i.e. the recipient should be the account that escrows the SOL), which felt unnecessary / confusing

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
