### PR TITLE
feat: Retrieve gas payments by sequence for scraping Sealevel 

### DIFF
--- a/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
@@ -462,6 +462,22 @@ const DOMAINS: &[RawDomain] = &[
         is_test_net: true,
         is_deprecated: false,
     },
+    RawDomain {
+        name: "sealeveltest1",
+        token: "SOL",
+        domain: 13375,
+        chain_id: 13375,
+        is_test_net: true,
+        is_deprecated: false,
+    },
+    RawDomain {
+        name: "sealeveltest2",
+        token: "SOL",
+        domain: 13376,
+        chain_id: 13376,
+        is_test_net: true,
+        is_deprecated: false,
+    },
 ];
 
 #[derive(DeriveMigrationName)]

--- a/rust/main/agents/scraper/migration/src/m20230309_000004_create_table_gas_payment.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000004_create_table_gas_payment.rs
@@ -1,5 +1,3 @@
-use std::borrow::BorrowMut as _;
-
 use sea_orm::ConnectionTrait;
 use sea_orm_migration::prelude::*;
 
@@ -41,11 +39,15 @@ impl MigrationTrait for Migration {
                             .big_unsigned()
                             .not_null(),
                     )
-                    .col(ColumnDef::new(GasPayment::Origin).unsigned())
-                    .col(ColumnDef::new(GasPayment::Destination).unsigned())
+                    .col(ColumnDef::new(GasPayment::Origin).unsigned().not_null())
+                    .col(
+                        ColumnDef::new(GasPayment::Destination)
+                            .unsigned()
+                            .not_null(),
+                    )
                     .col(
                         ColumnDef::new_with_type(GasPayment::InterchainGasPaymaster, Address)
-                            .borrow_mut(),
+                            .not_null(),
                     )
                     .col(ColumnDef::new(GasPayment::Sequence).big_integer())
                     .foreign_key(
@@ -86,6 +88,19 @@ impl MigrationTrait for Migration {
                     .name("gas_payment_msg_id_idx")
                     .col(GasPayment::MsgId)
                     .index_type(IndexType::Hash)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(GasPayment::Table)
+                    .name("gas_payment_origin_interchain_gas_paymaster_sequence_idx")
+                    .col(GasPayment::Origin)
+                    .col(GasPayment::InterchainGasPaymaster)
+                    .col(GasPayment::Sequence)
+                    .index_type(IndexType::BTree)
                     .to_owned(),
             )
             .await?;

--- a/rust/main/agents/scraper/migration/src/m20230309_000004_create_table_gas_payment.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000004_create_table_gas_payment.rs
@@ -65,11 +65,6 @@ impl MigrationTrait for Migration {
                             .from_col(GasPayment::Origin)
                             .to(Domain::Table, Domain::Id),
                     )
-                    .foreign_key(
-                        ForeignKey::create()
-                            .from_col(GasPayment::Destination)
-                            .to(Domain::Table, Domain::Id),
-                    )
                     .index(
                         Index::create()
                             // don't need domain because TxId includes it

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -231,7 +231,7 @@ impl Scraper {
         let sync = self
             .as_ref()
             .settings
-            .watermark_contract_sync::<Delivery, _>(
+            .contract_sync::<Delivery, _>(
                 &domain,
                 &metrics.clone(),
                 &contract_sync_metrics.clone(),
@@ -264,11 +264,11 @@ impl Scraper {
         let sync = self
             .as_ref()
             .settings
-            .watermark_contract_sync::<InterchainGasPayment, _>(
+            .contract_sync::<InterchainGasPayment, _>(
                 &domain,
                 &metrics.clone(),
                 &contract_sync_metrics.clone(),
-                Arc::new(store.clone()),
+                Arc::new(store.clone()) as _,
                 true,
             )
             .await

--- a/rust/main/agents/scraper/src/conversions.rs
+++ b/rust/main/agents/scraper/src/conversions.rs
@@ -8,3 +8,31 @@ pub fn u256_to_decimal(v: U256) -> BigDecimal {
     v.to_little_endian(&mut buf);
     BigDecimal::from(BigInt::from_bytes_le(Sign::Plus, &buf as &[u8]))
 }
+
+pub fn decimal_to_u256(v: BigDecimal) -> U256 {
+    let (i, _) = v.into_bigint_and_exponent();
+    let (_, b) = i.to_bytes_le();
+    U256::from_little_endian(&b)
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperlane_core::U256;
+
+    use crate::conversions::{decimal_to_u256, u256_to_decimal};
+
+    #[test]
+    fn test() {
+        // given
+        let u = U256::from_dec_str(
+            "76418673493495739447102571088210420170780567439841463646292940247514478199569",
+        )
+        .unwrap();
+
+        // when
+        let r = decimal_to_u256(u256_to_decimal(u));
+
+        // then
+        assert_eq!(u, r);
+    }
+}

--- a/rust/main/agents/scraper/src/db/generated/gas_payment.rs
+++ b/rust/main/agents/scraper/src/db/generated/gas_payment.rs
@@ -21,9 +21,9 @@ pub struct Model {
     pub gas_amount: BigDecimal,
     pub tx_id: i64,
     pub log_index: i64,
-    pub origin: Option<i32>,
-    pub destination: Option<i32>,
-    pub interchain_gas_paymaster: Option<Vec<u8>>,
+    pub origin: i32,
+    pub destination: i32,
+    pub interchain_gas_paymaster: Vec<u8>,
     pub sequence: Option<i64>,
 }
 
@@ -75,12 +75,10 @@ impl ColumnTrait for Column {
             Self::GasAmount => ColumnType::Decimal(Some((78u32, 0u32))).def(),
             Self::TxId => ColumnType::BigInteger.def(),
             Self::LogIndex => ColumnType::BigInteger.def(),
-            Self::Origin => ColumnType::Integer.def().null(),
-            Self::Destination => ColumnType::Integer.def().null(),
+            Self::Origin => ColumnType::Integer.def(),
+            Self::Destination => ColumnType::Integer.def(),
             Self::InterchainGasPaymaster => {
-                ColumnType::Binary(sea_orm::sea_query::BlobSize::Blob(None))
-                    .def()
-                    .null()
+                ColumnType::Binary(sea_orm::sea_query::BlobSize::Blob(None)).def()
             }
             Self::Sequence => ColumnType::BigInteger.def().null(),
         }

--- a/rust/main/agents/scraper/src/db/generated/gas_payment.rs
+++ b/rust/main/agents/scraper/src/db/generated/gas_payment.rs
@@ -57,7 +57,6 @@ impl PrimaryKeyTrait for PrimaryKey {
 
 #[derive(Copy, Clone, Debug, EnumIter)]
 pub enum Relation {
-    Destination,
     Domain,
     Origin,
     Transaction,
@@ -88,10 +87,6 @@ impl ColumnTrait for Column {
 impl RelationTrait for Relation {
     fn def(&self) -> RelationDef {
         match self {
-            Self::Destination => Entity::belongs_to(super::domain::Entity)
-                .from(Column::Destination)
-                .to(super::domain::Column::Id)
-                .into(),
             Self::Domain => Entity::belongs_to(super::domain::Entity)
                 .from(Column::Domain)
                 .to(super::domain::Column::Id)

--- a/rust/main/config/test_sealevel_config.json
+++ b/rust/main/config/test_sealevel_config.json
@@ -15,7 +15,7 @@
       },
       "rpcUrls": [
         {
-          "http": "http://localhost:8899"
+          "http": "http://127.0.0.1:8899"
         }
       ],
       "index": {
@@ -38,7 +38,7 @@
       },
       "rpcUrls": [
         {
-          "http": "http://localhost:8899"
+          "http": "http://127.0.0.1:8899"
         }
       ],
       "index": {

--- a/rust/main/hyperlane-base/src/settings/base.rs
+++ b/rust/main/hyperlane-base/src/settings/base.rs
@@ -225,28 +225,10 @@ impl Settings {
         // TODO: parallelize these calls again
         let mut syncs = vec![];
         for domain in domains {
-            let sync = match T::indexing_cursor(domain.domain_protocol()) {
-                CursorType::SequenceAware => self
-                    .sequenced_contract_sync(
-                        domain,
-                        metrics,
-                        sync_metrics,
-                        stores.get(domain).unwrap().clone(),
-                        advanced_log_meta,
-                    )
-                    .await
-                    .map(|r| r as Arc<dyn ContractSyncer<T>>)?,
-                CursorType::RateLimited => self
-                    .watermark_contract_sync(
-                        domain,
-                        metrics,
-                        sync_metrics,
-                        stores.get(domain).unwrap().clone(),
-                        advanced_log_meta,
-                    )
-                    .await
-                    .map(|r| r as Arc<dyn ContractSyncer<T>>)?,
-            };
+            let store = stores.get(domain).unwrap().clone();
+            let sync = self
+                .contract_sync(domain, metrics, sync_metrics, store, advanced_log_meta)
+                .await?;
             syncs.push(sync);
         }
 
@@ -254,5 +236,37 @@ impl Settings {
             .into_iter()
             .map(|i| Ok((i.domain().clone(), i)))
             .collect()
+    }
+
+    /// Build single contract sync.
+    /// All contracts have to implement both sequenced and
+    /// watermark trait bounds
+    pub async fn contract_sync<T, S>(
+        &self,
+        domain: &HyperlaneDomain,
+        metrics: &CoreMetrics,
+        sync_metrics: &ContractSyncMetrics,
+        store: Arc<S>,
+        advanced_log_meta: bool,
+    ) -> Result<Arc<dyn ContractSyncer<T>>>
+    where
+        T: Indexable + Debug + Send + Sync + Clone + Eq + Hash + 'static,
+        SequenceIndexer<T>: TryFromWithMetrics<ChainConf>,
+        S: HyperlaneLogStore<T>
+            + HyperlaneSequenceAwareIndexerStoreReader<T>
+            + HyperlaneWatermarkedLogStore<T>
+            + 'static,
+    {
+        let sync = match T::indexing_cursor(domain.domain_protocol()) {
+            CursorType::SequenceAware => self
+                .sequenced_contract_sync(domain, metrics, sync_metrics, store, advanced_log_meta)
+                .await
+                .map(|r| r as Arc<dyn ContractSyncer<T>>)?,
+            CursorType::RateLimited => self
+                .watermark_contract_sync(domain, metrics, sync_metrics, store, advanced_log_meta)
+                .await
+                .map(|r| r as Arc<dyn ContractSyncer<T>>)?,
+        };
+        Ok(sync)
     }
 }

--- a/rust/main/utils/run-locally/src/config.rs
+++ b/rust/main/utils/run-locally/src/config.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::sync::Arc;
 
+#[derive(Debug)]
 pub struct Config {
     pub is_ci_env: bool,
     pub ci_mode: bool,

--- a/rust/main/utils/run-locally/src/invariants/termination_invariants.rs
+++ b/rust/main/utils/run-locally/src/invariants/termination_invariants.rs
@@ -163,11 +163,12 @@ pub fn termination_invariants_met(
     )?
     .iter()
     .sum::<u32>();
-    if dispatched_messages_scraped != eth_messages_expected + ZERO_MERKLE_INSERTION_KATHY_MESSAGES {
+    if dispatched_messages_scraped != total_messages_expected + ZERO_MERKLE_INSERTION_KATHY_MESSAGES
+    {
         log!(
             "Scraper has scraped {} dispatched messages, expected {}",
             dispatched_messages_scraped,
-            eth_messages_expected
+            total_messages_expected + ZERO_MERKLE_INSERTION_KATHY_MESSAGES,
         );
         return Ok(false);
     }
@@ -179,15 +180,11 @@ pub fn termination_invariants_met(
     )?
     .iter()
     .sum::<u32>();
-    // The relayer and scraper should have the same number of gas payments.
-    // TODO: Sealevel gas payments are not yet included in the event count.
-    // For now, treat as an exception in the invariants.
-    let expected_gas_payments = gas_payment_events_count - gas_payment_sealevel_events_count;
-    if gas_payments_scraped != expected_gas_payments {
+    if gas_payments_scraped != gas_payment_events_count {
         log!(
             "Scraper has scraped {} gas payments, expected {}",
             gas_payments_scraped,
-            expected_gas_payments
+            gas_payment_events_count
         );
         return Ok(false);
     }
@@ -199,11 +196,11 @@ pub fn termination_invariants_met(
     )?
     .iter()
     .sum::<u32>();
-    if delivered_messages_scraped != eth_messages_expected {
+    if delivered_messages_scraped != total_messages_expected {
         log!(
             "Scraper has scraped {} delivered messages, expected {}",
             delivered_messages_scraped,
-            eth_messages_expected
+            total_messages_expected
         );
         return Ok(false);
     }

--- a/rust/main/utils/run-locally/src/invariants/termination_invariants.rs
+++ b/rust/main/utils/run-locally/src/invariants/termination_invariants.rs
@@ -126,16 +126,6 @@ pub fn termination_invariants_met(
         "Verbose logs not expected at the log level set in e2e"
     );
 
-    let _gas_payment_sealevel_events_count = fetch_metric(
-        RELAYER_METRICS_PORT,
-        "hyperlane_contract_sync_stored_events",
-        &hashmap! {
-                "data_type" => "gas_payments",
-                "chain" => "sealeveltest",
-        },
-    )?
-    .iter()
-    .sum::<u32>();
     // TestSendReceiver randomly breaks gas payments up into
     // two. So we expect at least as many gas payments as messages.
     if gas_payment_events_count < total_messages_expected {

--- a/rust/main/utils/run-locally/src/invariants/termination_invariants.rs
+++ b/rust/main/utils/run-locally/src/invariants/termination_invariants.rs
@@ -126,7 +126,7 @@ pub fn termination_invariants_met(
         "Verbose logs not expected at the log level set in e2e"
     );
 
-    let gas_payment_sealevel_events_count = fetch_metric(
+    let _gas_payment_sealevel_events_count = fetch_metric(
         RELAYER_METRICS_PORT,
         "hyperlane_contract_sync_stored_events",
         &hashmap! {

--- a/rust/main/utils/run-locally/src/main.rs
+++ b/rust/main/utils/run-locally/src/main.rs
@@ -286,7 +286,10 @@ fn main() -> ExitCode {
         .hyp_env("CHAINS_TEST2_CUSTOMRPCURLS", "http://127.0.0.1:8545")
         .hyp_env("CHAINS_TEST3_RPCCONSENSUSTYPE", "quorum")
         .hyp_env("CHAINS_TEST3_CUSTOMRPCURLS", "http://127.0.0.1:8545")
-        .hyp_env("CHAINSTOSCRAPE", "test1,test2,test3")
+        .hyp_env(
+            "CHAINSTOSCRAPE",
+            "test1,test2,test3,sealeveltest1,sealeveltest2",
+        )
         .hyp_env("METRICSPORT", SCRAPER_METRICS_PORT)
         .hyp_env(
             "DB",

--- a/rust/main/utils/run-locally/src/main.rs
+++ b/rust/main/utils/run-locally/src/main.rs
@@ -288,15 +288,19 @@ fn main() -> ExitCode {
         .hyp_env("CHAINS_TEST2_CUSTOMRPCURLS", "http://127.0.0.1:8545")
         .hyp_env("CHAINS_TEST3_RPCCONSENSUSTYPE", "quorum")
         .hyp_env("CHAINS_TEST3_CUSTOMRPCURLS", "http://127.0.0.1:8545")
-        .hyp_env(
-            "CHAINSTOSCRAPE",
-            "test1,test2,test3,sealeveltest1,sealeveltest2",
-        )
         .hyp_env("METRICSPORT", SCRAPER_METRICS_PORT)
         .hyp_env(
             "DB",
             "postgresql://postgres:47221c18c610@localhost:5432/postgres",
         );
+    let scraper_env = if config.sealevel_enabled {
+        scraper_env.hyp_env(
+            "CHAINSTOSCRAPE",
+            "test1,test2,test3,sealeveltest1,sealeveltest2",
+        )
+    } else {
+        scraper_env.hyp_env("CHAINSTOSCRAPE", "test1,test2,test3")
+    };
 
     let mut state = State::default();
 

--- a/rust/main/utils/run-locally/src/main.rs
+++ b/rust/main/utils/run-locally/src/main.rs
@@ -153,6 +153,8 @@ fn main() -> ExitCode {
     .unwrap();
 
     let config = Config::load();
+    log!("Running with config: {:?}", config);
+
     let mut validator_origin_chains = ["test1", "test2", "test3"].to_vec();
     let mut validator_keys = ETH_VALIDATOR_KEYS.to_vec();
     let mut validator_count: usize = validator_keys.len();

--- a/rust/sealevel/environments/local-e2e/chain-config.json
+++ b/rust/sealevel/environments/local-e2e/chain-config.json
@@ -4,7 +4,7 @@
     "name": "sealeveltest1",
     "rpcUrls": [
       {
-        "http": "http://localhost:8899"
+        "http": "http://127.0.0.1:8899"
       }
     ]
   },
@@ -13,7 +13,7 @@
     "name": "sealeveltest2",
     "rpcUrls": [
       {
-        "http": "http://localhost:8899"
+        "http": "http://127.0.0.1:8899"
       }
     ]
   }


### PR DESCRIPTION
### Description

- Retrieve gas payment by origin, interchain_gas_paymaster and sequence
- Add Sealevel to Scraper in E2E Ethereum and Sealevel tests

### Related issues

- Contributes into https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4271

### Backward compatibility

Yes (after backfill of origin, destination, interchain_gas_paymaster)

### Testing

E2E Ethereum and Sealevel tests (including scraping Sealevel)
