### PR TITLE
fix: relay message from tx containing multiple dispatches

### DIFF
--- a/.changeset/yellow-swans-join.md
+++ b/.changeset/yellow-swans-join.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Fix a bug where it would try to relay the incorrect message from a transaction that dispatches multiple messages.

--- a/typescript/cli/src/status/message.ts
+++ b/typescript/cli/src/status/message.ts
@@ -94,7 +94,11 @@ export async function checkMessageStatus({
     const merkleAddress = chainAddresses[origin].merkleTreeHook;
     stubMerkleTreeConfig(relayer, origin, hookAddress, merkleAddress);
 
-    deliveredTx = await relayer.relayMessage(dispatchedReceipt);
+    deliveredTx = await relayer.relayMessage(
+      dispatchedReceipt,
+      undefined,
+      message,
+    );
   }
 
   logGreen(


### PR DESCRIPTION
### Description

fix: relay message from tx containing multiple dispatches

without this change, it would automatically just assume you wanted to relay the 1st message (event index 0) from the transaction

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
