### PR TITLE
chore: transfer ownership of apxETH

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumApxETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumApxETHWarpConfig.ts
@@ -15,8 +15,9 @@ import {
 import { DEPLOYER } from '../../owners.js';
 import { SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT } from '../consts.js';
 
-const ethereumOwner = DEPLOYER;
-const eclipseOwner = '9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf';
+// Redacted / Dinero team
+const ethereumOwner = '0xA52Fd396891E7A74b641a2Cb1A6999Fcf56B077e';
+const eclipseOwner = 'BwYL3jLky8oHLeQp1S48cVRfZPmcXtg1V33UPmnZK3Jk';
 
 export async function getEclipseEthereumApxEthWarpConfig(
   routerConfig: ChainMap<RouterConfigWithoutOwner>,


### PR DESCRIPTION
### Description

Closes out ownership transfer of apxETH to the Dinero team

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
