### PR TITLE
 Fix typo in README files

### DIFF
--- a/rust/sealevel/programs/mailbox-test/README.md
+++ b/rust/sealevel/programs/mailbox-test/README.md
@@ -1,7 +1,7 @@
 # mailbox-test
 
 These are functional tests that ordinarily would live in `programs/mailbox/tests`, however
-due to some funky dependency resolution, the building the SBF .so files included some dev dependencies
+due to some funky dependency resolution, building the SBF .so files included some dev dependencies
 that would result in errors when trying to deploy the programs.
 
 As a (slightly hacky) fix, these tests are pulled into an entirely separate crate.

--- a/typescript/helloworld/src/multiProtocolApp/README.md
+++ b/typescript/helloworld/src/multiProtocolApp/README.md
@@ -1,5 +1,5 @@
 # HelloMultiProtocol
 
-This folder contains an alternative version of the HelloWorld app that intended for use across multiple protocol types (e.g. Ethereum, Sealevel, etc.)
+This folder contains an alternative version of the HelloWorld app that is intended for use across multiple protocol types (e.g. Ethereum, Sealevel, etc.)
 
 The simpler version in [../app](../app/) is recommended for applications that will only use evm-compatible chains.


### PR DESCRIPTION
## Changes Made

### 1. File: rust/sealevel/programs/mailbox-test/README.md
- Old: "due to some funky dependency resolution, the building the SBF .so files included some dev dependencies"
- New: "due to some funky dependency resolution, building the SBF .so files included some dev dependencies"
- Removed redundant "the" before "building"

### 2. File: typescript/helloworld/src/multiProtocolApp/README.md
- Old: "This folder contains an alternative version of the HelloWorld app that intended for use across multiple protocol types"
- New: "This folder contains an alternative version of the HelloWorld app that is intended for use across multiple protocol types"
- Added missing "is" for proper grammar
