### PR TITLE
fix: Add index to cursor table

### DIFF
--- a/rust/main/agents/scraper/migration/src/m20230309_000003_create_table_cursor.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000003_create_table_cursor.rs
@@ -35,7 +35,20 @@ impl MigrationTrait for Migration {
                     )
                     .to_owned(),
             )
-            .await
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Cursor::Table)
+                    .name("cursor_domain_idx")
+                    .col(Cursor::Domain)
+                    .index_type(IndexType::BTree)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {


### PR DESCRIPTION
### Description

Add index to cursor table so than Scraper starts quickly

### Backward compatibility

Yes

### Testing

Manual