### PR TITLE
feat: script to combine safe txs by chain id

### DIFF
--- a/typescript/infra/scripts/safes/combine-txs.ts
+++ b/typescript/infra/scripts/safes/combine-txs.ts
@@ -1,10 +1,13 @@
 // Import necessary modules
 import { SafeTransaction } from '@safe-global/safe-core-sdk-types';
+// eslint-disable-next-line
 import * as fs from 'fs';
 import * as path from 'path';
 import yargs from 'yargs';
 
-import { getRegistry } from '../../config/environments/mainnet3/chains.js';
+import { rootLogger } from '@hyperlane-xyz/utils';
+
+import { readJSONAtPath, writeJsonAtPath } from '../../src/utils/utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
 
 type TxFile = {
@@ -19,20 +22,17 @@ function readJSONFiles(directory: string): Record<string, TxFile[]> {
   const files = fs.readdirSync(directory);
   const transactionsByChainId: Record<string, TxFile[]> = {};
 
-  files.forEach((file) => {
+  for (const file of files) {
     if (path.extname(file) === '.json') {
       const filePath = path.join(directory, file);
-      const data = fs.readFileSync(filePath, 'utf8');
-      const jsonData = JSON.parse(data) as TxFile;
-
-      const chainId = jsonData.chainId;
+      const txs: TxFile = readJSONAtPath(filePath);
+      const chainId = txs.chainId;
       if (!transactionsByChainId[chainId]) {
         transactionsByChainId[chainId] = [];
       }
-
-      transactionsByChainId[chainId].push(jsonData);
+      transactionsByChainId[chainId].push(txs);
     }
-  });
+  }
 
   return transactionsByChainId;
 }
@@ -62,12 +62,8 @@ async function writeCombinedTransactions(
     // NOTE: hacky use of chainid instead of domainid or chain name here
     const chainName = multiProvider.getChainName(chainId);
     const outputFilePath = path.join(outputDir, `${chainId}-${chainName}.json`);
-    fs.writeFileSync(
-      outputFilePath,
-      JSON.stringify(outputData, null, 2),
-      'utf8',
-    );
-    console.log(`Combined transactions written to ${outputFilePath}`);
+    writeJsonAtPath(outputFilePath, outputData);
+    rootLogger.info(`Combined transactions written to ${outputFilePath}`);
   }
 }
 
@@ -81,16 +77,16 @@ async function main() {
   }).argv;
 
   if (!fs.existsSync(directory)) {
-    console.error(`Directory ${directory} does not exist`);
+    rootLogger.error(`Directory ${directory} does not exist`);
     process.exit(1);
   }
 
   const transactionsByChainId = readJSONFiles(directory);
-  writeCombinedTransactions(transactionsByChainId, directory);
+  await writeCombinedTransactions(transactionsByChainId, directory);
 }
 
 // Execute the main function and handle promise
 main().catch((error) => {
-  console.error('An error occurred:', error);
+  rootLogger.error('An error occurred:', error);
   process.exit(1);
 });

--- a/typescript/infra/scripts/safes/combine-txs.ts
+++ b/typescript/infra/scripts/safes/combine-txs.ts
@@ -1,0 +1,96 @@
+// Import necessary modules
+import { SafeTransaction } from '@safe-global/safe-core-sdk-types';
+import * as fs from 'fs';
+import * as path from 'path';
+import yargs from 'yargs';
+
+import { getRegistry } from '../../config/environments/mainnet3/chains.js';
+import { getEnvironmentConfig } from '../core-utils.js';
+
+type TxFile = {
+  version: string;
+  chainId: string;
+  meta: any;
+  transactions: SafeTransaction[];
+};
+
+// Function to read and parse JSON files
+function readJSONFiles(directory: string): Record<string, TxFile[]> {
+  const files = fs.readdirSync(directory);
+  const transactionsByChainId: Record<string, TxFile[]> = {};
+
+  files.forEach((file) => {
+    if (path.extname(file) === '.json') {
+      const filePath = path.join(directory, file);
+      const data = fs.readFileSync(filePath, 'utf8');
+      const jsonData = JSON.parse(data) as TxFile;
+
+      const chainId = jsonData.chainId;
+      if (!transactionsByChainId[chainId]) {
+        transactionsByChainId[chainId] = [];
+      }
+
+      transactionsByChainId[chainId].push(jsonData);
+    }
+  });
+
+  return transactionsByChainId;
+}
+
+// Function to write combined transactions to new JSON files
+async function writeCombinedTransactions(
+  transactionsByChainId: Record<string, TxFile[]>,
+  directory: string,
+) {
+  // Create the output directory
+  const outputDir = path.join(directory, `combined-txs-${Date.now()}`);
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const config = getEnvironmentConfig('mainnet3');
+  const multiProvider = await config.getMultiProvider();
+
+  for (const [chainId, transactions] of Object.entries(transactionsByChainId)) {
+    // Create the output data
+    const outputData = {
+      version: '1.0',
+      chainId: chainId,
+      meta: {},
+      transactions: transactions.flatMap((txFile) => txFile.transactions),
+    };
+
+    // Write the output file
+    // NOTE: hacky use of chainid instead of domainid or chain name here
+    const chainName = multiProvider.getChainName(chainId);
+    const outputFilePath = path.join(outputDir, `${chainId}-${chainName}.json`);
+    fs.writeFileSync(
+      outputFilePath,
+      JSON.stringify(outputData, null, 2),
+      'utf8',
+    );
+    console.log(`Combined transactions written to ${outputFilePath}`);
+  }
+}
+
+// Main function to execute the script
+async function main() {
+  const { directory } = await yargs(process.argv.slice(2)).option('directory', {
+    type: 'string',
+    describe: 'directory containing txs',
+    demandOption: true,
+    alias: 'd',
+  }).argv;
+
+  if (!fs.existsSync(directory)) {
+    console.error(`Directory ${directory} does not exist`);
+    process.exit(1);
+  }
+
+  const transactionsByChainId = readJSONFiles(directory);
+  writeCombinedTransactions(transactionsByChainId, directory);
+}
+
+// Execute the main function and handle promise
+main().catch((error) => {
+  console.error('An error occurred:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Description

feat: script to combine safe txs by chain id
- pass in a directory of safe txs in json form
- combines/groups transactions together by the chainid to submit to

before:
<img width="453" alt="image" src="https://github.com/user-attachments/assets/78eea59c-d0bc-4f9a-a97c-8d815add069c">

after:
<img width="333" alt="image" src="https://github.com/user-attachments/assets/c55b72fa-26dc-43ec-8b5d-ec6d8af26d2e">

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
