### PR TITLE
feat: parse warp route txs from safes

### DIFF
--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -14,7 +14,7 @@
     "@ethersproject/providers": "*",
     "@google-cloud/secret-manager": "^5.5.0",
     "@hyperlane-xyz/helloworld": "7.3.0",
-    "@hyperlane-xyz/registry": "6.1.0",
+    "@hyperlane-xyz/registry": "6.3.0",
     "@hyperlane-xyz/sdk": "7.3.0",
     "@hyperlane-xyz/utils": "7.3.0",
     "@inquirer/prompts": "3.3.2",

--- a/typescript/infra/scripts/safes/parse-txs.ts
+++ b/typescript/infra/scripts/safes/parse-txs.ts
@@ -17,11 +17,15 @@ async function main() {
   const multiProvider = await config.getMultiProvider();
   const { chainAddresses } = await getHyperlaneCore(environment, multiProvider);
 
+  const registry = await config.getRegistry();
+  const warpRoutes = await registry.getWarpRoutes();
+
   const reader = new GovernTransactionReader(
     environment,
     multiProvider,
     chainAddresses,
     config.core,
+    warpRoutes,
   );
 
   const chainResultEntries = await Promise.all(

--- a/typescript/infra/src/tx/govern-transaction-reader.ts
+++ b/typescript/infra/src/tx/govern-transaction-reader.ts
@@ -4,9 +4,11 @@ import {
   MetaTransactionData,
   OperationType,
 } from '@safe-global/safe-core-sdk-types';
+import assert from 'assert';
 import chalk from 'chalk';
 import { BigNumber, ethers } from 'ethers';
 
+import { TokenRouter__factory } from '@hyperlane-xyz/core';
 import {
   AnnotatedEV5Transaction,
   ChainMap,
@@ -16,6 +18,7 @@ import {
   EvmIsmReader,
   InterchainAccount,
   MultiProvider,
+  WarpCoreConfig,
   coreFactories,
   interchainAccountFactories,
   normalizeConfig,
@@ -83,12 +86,28 @@ export class GovernTransactionReader {
     module: 'GovernTransactionReader',
   });
 
+  readonly warpRouteIndex: ChainMap<
+    Record<string, WarpCoreConfig['tokens'][number]>
+  > = {};
+
   constructor(
     readonly environment: DeployEnvironment,
     readonly multiProvider: MultiProvider,
     readonly chainAddresses: ChainMap<Record<string, string>>,
     readonly coreConfig: ChainMap<CoreConfig>,
-  ) {}
+    warpRoutes: Record<string, WarpCoreConfig>,
+  ) {
+    // Populate maps with warp route addresses and additional token details
+    for (const warpRoute of Object.values(warpRoutes)) {
+      for (const token of Object.values(warpRoute.tokens)) {
+        const address = token.addressOrDenom?.toLowerCase() ?? '';
+        if (!this.warpRouteIndex[token.chainName]) {
+          this.warpRouteIndex[token.chainName] = {};
+        }
+        this.warpRouteIndex[token.chainName][address] = token;
+      }
+    }
+  }
 
   async read(
     chain: ChainName,
@@ -104,8 +123,14 @@ export class GovernTransactionReader {
       return this.readMailboxTransaction(chain, tx);
     }
 
+    // If it's a Multisend
     if (await this.isMultisendTransaction(chain, tx)) {
       return this.readMultisendTransaction(chain, tx);
+    }
+
+    // If it's a Warp Module transaction
+    if (this.isWarpModuleTransaction(chain, tx)) {
+      return this.readWarpModuleTransaction(chain, tx);
     }
 
     const insight = '⚠️ Unknown transaction type';
@@ -120,6 +145,138 @@ export class GovernTransactionReader {
       chain,
       insight,
       tx,
+    };
+  }
+
+  private isWarpModuleTransaction(
+    chain: ChainName,
+    tx: AnnotatedEV5Transaction,
+  ): boolean {
+    return (
+      tx.to !== undefined &&
+      this.warpRouteIndex[chain][tx.to.toLowerCase()] !== undefined
+    );
+  }
+
+  private async readWarpModuleTransaction(
+    chain: ChainName,
+    tx: AnnotatedEV5Transaction,
+  ): Promise<GovernTransaction> {
+    if (!tx.data) {
+      throw new Error('No data in Warp Module transaction');
+    }
+
+    const { symbol } = await this.multiProvider.getNativeToken(chain);
+    const tokenRouterInterface = TokenRouter__factory.createInterface();
+
+    const decoded = tokenRouterInterface.parseTransaction({
+      data: tx.data,
+      value: tx.value,
+    });
+
+    const args = formatFunctionFragmentArgs(
+      decoded.args,
+      decoded.functionFragment,
+    );
+
+    let insight = '';
+
+    if (
+      decoded.functionFragment.name ===
+      tokenRouterInterface.functions['setHook(address)'].name
+    ) {
+      const [hookAddress] = decoded.args;
+      insight = `Set hook to ${hookAddress}`;
+    }
+
+    if (
+      decoded.functionFragment.name ===
+      tokenRouterInterface.functions['setInterchainSecurityModule(address)']
+        .name
+    ) {
+      const [ismAddress] = decoded.args;
+      insight = `Set ISM to ${ismAddress}`;
+    }
+
+    // if (
+    //   decoded.functionFragment.name ===
+    //   tokenRouterInterface.functions['setDestinationGas(uint32,uint256)'].name
+    // ) {
+    //   const [domain, gas] = decoded.args;
+    //   const chainName = this.multiProvider.getChainName(domain);
+    //   insight = `Set destination gas for domain ${domain} (${chainName}) to ${gas}`;
+    // }
+
+    if (
+      decoded.functionFragment.name ===
+      tokenRouterInterface.functions['setDestinationGas((uint32,uint256)[])']
+        .name
+    ) {
+      const [gasConfigs] = decoded.args;
+      const insights = gasConfigs.map(
+        (config: { domain: number; gas: BigNumber }) => {
+          const chainName = this.multiProvider.getChainName(config.domain);
+          return `domain ${
+            config.domain
+          } (${chainName}) to ${config.gas.toString()}`;
+        },
+      );
+      insight = `Set destination gas for ${insights.join(', ')}`;
+    }
+
+    if (
+      decoded.functionFragment.name ===
+      tokenRouterInterface.functions['enrollRemoteRouter(uint32,bytes32)'].name
+    ) {
+      const [domain, router] = decoded.args;
+      const chainName = this.multiProvider.getChainName(domain);
+      insight = `Enroll remote router for domain ${domain} (${chainName}) to ${router}`;
+    }
+
+    if (
+      decoded.functionFragment.name ===
+      tokenRouterInterface.functions['enrollRemoteRouters(uint32[],bytes32[])']
+        .name
+    ) {
+      const [domains, routers] = decoded.args;
+      const insights = domains.map((domain: number, index: number) => {
+        const chainName = this.multiProvider.getChainName(domain);
+        return `domain ${domain} (${chainName}) to ${routers[index]}`;
+      });
+      insight = `Enroll remote routers for ${insights.join(', ')}`;
+    }
+
+    if (
+      decoded.functionFragment.name ===
+      tokenRouterInterface.functions['unenrollRemoteRouter(uint32)'].name
+    ) {
+      const [domain] = decoded.args;
+      const chainName = this.multiProvider.getChainName(domain);
+      insight = `Unenroll remote router for domain ${domain} (${chainName})`;
+    }
+
+    if (
+      decoded.functionFragment.name ===
+      tokenRouterInterface.functions['unenrollRemoteRouters(uint32[])'].name
+    ) {
+      const [domains] = decoded.args;
+      const insights = domains.map((domain: number) => {
+        const chainName = this.multiProvider.getChainName(domain);
+        return `domain ${domain} (${chainName})`;
+      });
+      insight = `Unenroll remote routers for ${insights.join(', ')}`;
+    }
+
+    assert(tx.to, 'Warp Module transaction must have a to address');
+    const token = this.warpRouteIndex[chain][tx.to.toLowerCase()];
+
+    return {
+      chain,
+      to: `${token.symbol} (${token.name}, ${token.standard})`,
+      insight,
+      value: `${ethers.utils.formatEther(decoded.value)} ${symbol}`,
+      signature: decoded.signature,
+      args,
     };
   }
 
@@ -205,6 +362,24 @@ export class GovernTransactionReader {
         chainName: remoteChainName,
         router: routerToBeEnrolled,
         insight,
+      };
+    });
+  }
+
+  private async formatRouterUnenrollments(
+    routerName: string,
+    args: Record<string, any>,
+  ): Promise<GovernTransaction> {
+    const { _domains: domains } = args;
+    return domains.map((domain: number) => {
+      const remoteChainName = this.multiProvider.getChainName(domain);
+      const expectedRouter = this.chainAddresses[remoteChainName][routerName];
+
+      return {
+        domain: domain,
+        chainName: remoteChainName,
+        router: expectedRouter,
+        insight: '✅ unenrolling router',
       };
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7520,7 +7520,7 @@ __metadata:
     "@ethersproject/providers": "npm:*"
     "@google-cloud/secret-manager": "npm:^5.5.0"
     "@hyperlane-xyz/helloworld": "npm:7.3.0"
-    "@hyperlane-xyz/registry": "npm:6.1.0"
+    "@hyperlane-xyz/registry": "npm:6.3.0"
     "@hyperlane-xyz/sdk": "npm:7.3.0"
     "@hyperlane-xyz/utils": "npm:7.3.0"
     "@inquirer/prompts": "npm:3.3.2"
@@ -7589,6 +7589,16 @@ __metadata:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
   checksum: 10/a0e1ecc02d83604793ddda0a3e00a9ffcaa38b1cddf9883b47cf8f1919b4474abd6cc2ee84846e6a35e1bc7539299b9bec92bfdf06be72beecff6aa44b73d382
+  languageName: node
+  linkType: hard
+
+"@hyperlane-xyz/registry@npm:6.3.0":
+  version: 6.3.0
+  resolution: "@hyperlane-xyz/registry@npm:6.3.0"
+  dependencies:
+    yaml: "npm:2.4.5"
+    zod: "npm:^3.21.2"
+  checksum: 10/7a1b7226593edf8e12c7e3d425b7889679d46abae1e8c5a389a0b472e2e0a08b292ba89f60572eff9e844c7b5f7322e4420a8888fabef9967c206d5b39f391a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

- extend `GovernTransactionReader` to parse warp route txs

### Drive-by changes

- use latest reg version in infra

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
