### PR TITLE
fix: suppress help on CLI failures

### DIFF
--- a/.changeset/long-llamas-fly.md
+++ b/.changeset/long-llamas-fly.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/cli": patch
+---
+
+Suppress help on CLI failures

--- a/typescript/cli/cli.ts
+++ b/typescript/cli/cli.ts
@@ -32,9 +32,6 @@ import { configureLogger, errorRed } from './src/logger.js';
 import { checkVersion } from './src/utils/version-check.js';
 import { VERSION } from './src/version.js';
 
-// From yargs code:
-const MISSING_PARAMS_ERROR = 'Not enough non-option arguments';
-
 console.log(chalk.blue('Hyperlane'), chalk.magentaBright('CLI'));
 
 await checkVersion();
@@ -73,14 +70,7 @@ try {
     .demandCommand()
     .strict()
     .help()
-    .fail((msg, err, yargs) => {
-      if (msg && !msg.includes(MISSING_PARAMS_ERROR)) errorRed('Error: ' + msg);
-      console.log('');
-      yargs.showHelp();
-      console.log('');
-      if (err) errorRed(err.toString());
-      process.exit(1);
-    }).argv;
+    .showHelpOnFail(false).argv;
 } catch (error: any) {
   errorRed('Error: ' + error.message);
 }


### PR DESCRIPTION
### Description

No longer outputs help dialog on any error
