### PR TITLE
chore: bump escalator version

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -2901,7 +2901,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-03-3#edf703a6e515266245b88bb4f1daad24f7c6566c"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-10#d9f822ef9dd3d63b88cae74973540ef9e6773015"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -2915,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-03-3#edf703a6e515266245b88bb4f1daad24f7c6566c"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-10#d9f822ef9dd3d63b88cae74973540ef9e6773015"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -2926,7 +2926,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-03-3#edf703a6e515266245b88bb4f1daad24f7c6566c"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-10#d9f822ef9dd3d63b88cae74973540ef9e6773015"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-03-3#edf703a6e515266245b88bb4f1daad24f7c6566c"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-10#d9f822ef9dd3d63b88cae74973540ef9e6773015"
 dependencies = [
  "Inflector",
  "cfg-if",
@@ -2968,7 +2968,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-03-3#edf703a6e515266245b88bb4f1daad24f7c6566c"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-10#d9f822ef9dd3d63b88cae74973540ef9e6773015"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-03-3#edf703a6e515266245b88bb4f1daad24f7c6566c"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-10#d9f822ef9dd3d63b88cae74973540ef9e6773015"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -3012,7 +3012,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-03-3#edf703a6e515266245b88bb4f1daad24f7c6566c"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-10#d9f822ef9dd3d63b88cae74973540ef9e6773015"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.15",
@@ -3028,7 +3028,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-03-3#edf703a6e515266245b88bb4f1daad24f7c6566c"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-10#d9f822ef9dd3d63b88cae74973540ef9e6773015"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -3076,7 +3076,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-03-3#edf703a6e515266245b88bb4f1daad24f7c6566c"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-10#d9f822ef9dd3d63b88cae74973540ef9e6773015"
 dependencies = [
  "async-trait",
  "auto_impl 1.2.0",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-03-3#edf703a6e515266245b88bb4f1daad24f7c6566c"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-10#d9f822ef9dd3d63b88cae74973540ef9e6773015"
 dependencies = [
  "async-trait",
  "coins-bip32 0.7.0",

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -197,27 +197,27 @@ overflow-checks = true
 [workspace.dependencies.ethers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-12-03-3"
+tag = "2024-12-10"
 
 [workspace.dependencies.ethers-contract]
 features = ["legacy"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-12-03-3"
+tag = "2024-12-10"
 
 [workspace.dependencies.ethers-core]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-12-03-3"
+tag = "2024-12-10"
 
 [workspace.dependencies.ethers-providers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-12-03-3"
+tag = "2024-12-10"
 
 [workspace.dependencies.ethers-signers]
 features = ["aws"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-12-03-3"
+tag = "2024-12-10"
 
 [patch.crates-io.curve25519-dalek]
 branch = "v3.2.2-relax-zeroize"


### PR DESCRIPTION
### Description

the escalator doesn't log the hash of the new gas-escalated transaction, so it's hard to find the transaction that actually landed onchain (you have to look by nonce) - example [here](https://cloudlogging.app.goo.gl/cFXYHui4agpxU4AK9). This PR uses a newer version of the escalator, which does log the hash. 

ethers-rs fork PR: https://github.com/hyperlane-xyz/ethers-rs/pull/22
