### PR TITLE
chore: move viction warp routes to default ISMs

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionETHWarpConfig.ts
@@ -1,10 +1,10 @@
+import { ethers } from 'ethers';
+
 import {
   ChainMap,
   HypTokenRouterConfig,
   OwnableConfig,
   TokenType,
-  buildAggregationIsmConfigs,
-  defaultMultisigConfigs,
 } from '@hyperlane-xyz/sdk';
 
 import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';
@@ -13,12 +13,6 @@ export const getEthereumVictionETHWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
   abacusWorksEnvOwnerConfig: ChainMap<OwnableConfig>,
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
-  const ismConfig = buildAggregationIsmConfigs(
-    'ethereum',
-    ['viction'],
-    defaultMultisigConfigs,
-  ).viction;
-
   const viction: HypTokenRouterConfig = {
     ...routerConfig.viction,
     ...abacusWorksEnvOwnerConfig.viction,
@@ -28,6 +22,7 @@ export const getEthereumVictionETHWarpConfig = async (
     decimals: 18,
     totalSupply: 0,
     gas: 50_000,
+    interchainSecurityModule: ethers.constants.AddressZero,
   };
 
   const ethereum: HypTokenRouterConfig = {
@@ -35,7 +30,7 @@ export const getEthereumVictionETHWarpConfig = async (
     ...abacusWorksEnvOwnerConfig.ethereum,
     type: TokenType.native,
     gas: 65_000,
-    interchainSecurityModule: ismConfig,
+    interchainSecurityModule: ethers.constants.AddressZero,
   };
 
   return {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDCWarpConfig.ts
@@ -1,10 +1,10 @@
+import { ethers } from 'ethers';
+
 import {
   ChainMap,
   HypTokenRouterConfig,
   OwnableConfig,
   TokenType,
-  buildAggregationIsmConfigs,
-  defaultMultisigConfigs,
 } from '@hyperlane-xyz/sdk';
 
 import {
@@ -16,13 +16,6 @@ export const getEthereumVictionUSDCWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
   abacusWorksEnvOwnerConfig: ChainMap<OwnableConfig>,
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
-  // commit that the config was copied from https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3067/commits/7ed5b460034ea5e140c6ff86bcd6baf6ebb824c4#diff-fab5dd1a27c76e4310699c57ccf92ab6274ef0acf17e079b17270cedf4057775R109
-  const ismConfig = buildAggregationIsmConfigs(
-    'ethereum',
-    ['viction'],
-    defaultMultisigConfigs,
-  ).viction;
-
   const viction: HypTokenRouterConfig = {
     ...routerConfig.viction,
     ...abacusWorksEnvOwnerConfig.viction,
@@ -32,6 +25,7 @@ export const getEthereumVictionUSDCWarpConfig = async (
     decimals: 6,
     totalSupply: 0,
     gas: 75_000,
+    interchainSecurityModule: ethers.constants.AddressZero,
   };
 
   const ethereum: HypTokenRouterConfig = {
@@ -40,7 +34,7 @@ export const getEthereumVictionUSDCWarpConfig = async (
     type: TokenType.collateral,
     token: tokens.ethereum.USDC,
     gas: 65_000,
-    interchainSecurityModule: ismConfig,
+    interchainSecurityModule: ethers.constants.AddressZero,
   };
 
   return {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDTWarpConfig.ts
@@ -1,10 +1,10 @@
+import { ethers } from 'ethers';
+
 import {
   ChainMap,
   HypTokenRouterConfig,
   OwnableConfig,
   TokenType,
-  buildAggregationIsmConfigs,
-  defaultMultisigConfigs,
 } from '@hyperlane-xyz/sdk';
 
 import {
@@ -16,12 +16,6 @@ export const getEthereumVictionUSDTWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
   abacusWorksEnvOwnerConfig: ChainMap<OwnableConfig>,
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
-  const ismConfig = buildAggregationIsmConfigs(
-    'ethereum',
-    ['viction'],
-    defaultMultisigConfigs,
-  ).viction;
-
   const viction: HypTokenRouterConfig = {
     ...routerConfig.viction,
     ...abacusWorksEnvOwnerConfig.viction,
@@ -31,6 +25,7 @@ export const getEthereumVictionUSDTWarpConfig = async (
     decimals: 6,
     totalSupply: 0,
     gas: 75_000,
+    interchainSecurityModule: ethers.constants.AddressZero,
   };
 
   const ethereum: HypTokenRouterConfig = {
@@ -39,7 +34,7 @@ export const getEthereumVictionUSDTWarpConfig = async (
     type: TokenType.collateral,
     token: tokens.ethereum.USDT,
     gas: 65_000,
-    interchainSecurityModule: ismConfig,
+    interchainSecurityModule: ethers.constants.AddressZero,
   };
 
   return {


### PR DESCRIPTION
### Description

- after the recent viction validator set change, just move this over to the default ISM so we always get the latest and greatest
- fixes our warp checker violations
- kinda stylistic, but just explicitly specifying the zero address as the ISM address on the viction side too

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
