### PR TITLE
feat: Enable Solana and Eclipse in Scraper

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -276,8 +276,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     degenchain: true,
     dogechain: true,
     duckchain: true,
-    // Cannot scrape Sealevel chains
-    eclipsemainnet: false,
+    eclipsemainnet: true,
     endurance: true,
     ethereum: true,
     everclear: true,
@@ -328,8 +327,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     sei: true,
     shibarium: true,
     snaxchain: true,
-    // Cannot scrape Sealevel chains
-    solanamainnet: false,
+    solanamainnet: true,
     stride: true,
     superseed: true,
     superpositionmainnet: true,

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -121,7 +121,6 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     citreatestnet: true,
     connextsepolia: false,
     ecotestnet: true,
-    // Cannot scrape non-EVM chains
     eclipsetestnet: false,
     formtestnet: true,
     fuji: true,
@@ -135,7 +134,6 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     polygonamoy: true,
     scrollsepolia: true,
     sepolia: true,
-    // Cannot scrape non-EVM chains
     solanatestnet: false,
     soneiumtestnet: true,
     sonictestnet: true,


### PR DESCRIPTION
### Description

Enable Solana and Eclipse in Scraper.

We don't relay messages in Solana and Eclipse testnets, so, we don't enable these testnets in Scraper.

### Related issues

- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4274

### Backward compatibility

Yes

### Testing

E2E Ethereum and Sealevel test