### PR TITLE
fix: Disable Eclipse in Scraper until we get archival RPC endpoint

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -276,6 +276,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     degenchain: true,
     dogechain: true,
     duckchain: true,
+    // Disabled until we get archival RPC for Eclipse
     eclipsemainnet: false,
     endurance: true,
     ethereum: true,

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -276,7 +276,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     degenchain: true,
     dogechain: true,
     duckchain: true,
-    eclipsemainnet: true,
+    eclipsemainnet: false,
     endurance: true,
     ethereum: true,
     everclear: true,


### PR DESCRIPTION
### Description

Disable Eclipse in Scraper until we get archival RPC endpoint

### Related issues

- Contributes into https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4274

### Backward compatibility

Yes

### Testing

No testing since it is a config change