### PR TITLE
fix(cli): fix signer init strategy

### DIFF
--- a/.changeset/hot-spies-share.md
+++ b/.changeset/hot-spies-share.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+fix signer strategy init for broken cli commands

--- a/typescript/cli/src/commands/signCommands.ts
+++ b/typescript/cli/src/commands/signCommands.ts
@@ -13,7 +13,8 @@ export const SIGN_COMMANDS = [
 export function isSignCommand(argv: any): boolean {
   //TODO: fix reading and checking warp without signer, and remove this
   const temporarySignCommandsCheck =
-    argv._[0] === 'warp' && (argv._[1] === 'read' || argv._[1] === 'check');
+    argv._[0] === 'warp' &&
+    (argv._[1] === 'read' || argv._[1] === 'check' || argv._[1] === 'verify');
   return (
     SIGN_COMMANDS.includes(argv._[0]) ||
     (argv._.length > 1 && SIGN_COMMANDS.includes(argv._[1])) ||

--- a/typescript/cli/src/context/strategies/chain/ChainResolverFactory.ts
+++ b/typescript/cli/src/context/strategies/chain/ChainResolverFactory.ts
@@ -1,7 +1,6 @@
 import { CommandType } from '../../../commands/signCommands.js';
 
 import { MultiChainResolver } from './MultiChainResolver.js';
-import { SingleChainResolver } from './SingleChainResolver.js';
 import { ChainResolver } from './types.js';
 
 /**
@@ -11,13 +10,16 @@ import { ChainResolver } from './types.js';
 export class ChainResolverFactory {
   private static strategyMap: Map<CommandType, () => ChainResolver> = new Map([
     [CommandType.WARP_DEPLOY, () => MultiChainResolver.forWarpRouteConfig()],
-    [CommandType.WARP_SEND, () => MultiChainResolver.forOriginDestination()],
+    // Using the forRelayer resolver because warp send allows the user to self relay the tx
+    [CommandType.WARP_SEND, () => MultiChainResolver.forRelayer()],
     [CommandType.WARP_APPLY, () => MultiChainResolver.forWarpRouteConfig()],
     [CommandType.WARP_READ, () => MultiChainResolver.forWarpCoreConfig()],
     [CommandType.WARP_CHECK, () => MultiChainResolver.forWarpCoreConfig()],
-    [CommandType.SEND_MESSAGE, () => MultiChainResolver.forOriginDestination()],
+    // Using the forRelayer resolver because send allows the user to self relay the tx
+    [CommandType.SEND_MESSAGE, () => MultiChainResolver.forRelayer()],
     [CommandType.AGENT_KURTOSIS, () => MultiChainResolver.forAgentKurtosis()],
-    [CommandType.STATUS, () => MultiChainResolver.forOriginDestination()],
+    // Using the forRelayer resolver because status allows the user to self relay the tx
+    [CommandType.STATUS, () => MultiChainResolver.forRelayer()],
     [CommandType.SUBMIT, () => MultiChainResolver.forStrategyConfig()],
     [CommandType.RELAYER, () => MultiChainResolver.forRelayer()],
     [CommandType.CORE_APPLY, () => MultiChainResolver.forCoreApply()],
@@ -30,7 +32,7 @@ export class ChainResolverFactory {
   static getStrategy(argv: Record<string, any>): ChainResolver {
     const commandKey = `${argv._[0]}:${argv._[1] || ''}`.trim() as CommandType;
     const createStrategy =
-      this.strategyMap.get(commandKey) || (() => new SingleChainResolver());
+      this.strategyMap.get(commandKey) || (() => MultiChainResolver.default());
     return createStrategy();
   }
 }

--- a/typescript/cli/src/context/strategies/chain/MultiChainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/MultiChainResolver.ts
@@ -31,7 +31,6 @@ enum ChainSelectionMode {
   WARP_CONFIG,
   WARP_READ,
   STRATEGY,
-  RELAYER,
   CORE_APPLY,
   DEFAULT,
 }
@@ -55,8 +54,6 @@ export class MultiChainResolver implements ChainResolver {
         return this.resolveAgentChains(argv);
       case ChainSelectionMode.STRATEGY:
         return this.resolveStrategyChains(argv);
-      case ChainSelectionMode.RELAYER:
-        return this.resolveRelayerChains(argv);
       case ChainSelectionMode.CORE_APPLY:
         return this.resolveCoreApplyChains(argv);
       case ChainSelectionMode.DEFAULT:
@@ -233,7 +230,7 @@ export class MultiChainResolver implements ChainResolver {
   }
 
   static forRelayer(): MultiChainResolver {
-    return new MultiChainResolver(ChainSelectionMode.RELAYER);
+    return new MultiChainResolver(ChainSelectionMode.DEFAULT);
   }
 
   static forStrategyConfig(): MultiChainResolver {

--- a/typescript/cli/src/context/strategies/signer/MultiProtocolSignerManager.ts
+++ b/typescript/cli/src/context/strategies/signer/MultiProtocolSignerManager.ts
@@ -118,12 +118,12 @@ export class MultiProtocolSignerManager {
     let privateKey: string;
 
     if (this.options.key) {
-      this.logger.info(
+      this.logger.debug(
         `Using private key passed via CLI --key flag for chain ${chain}`,
       );
       privateKey = this.options.key;
     } else if (ENV.HYP_KEY) {
-      this.logger.info(`Using private key from .env for chain ${chain}`);
+      this.logger.debug(`Using private key from .env for chain ${chain}`);
       privateKey = ENV.HYP_KEY;
     } else {
       privateKey = await this.extractPrivateKey(chain, signerStrategy);
@@ -145,7 +145,7 @@ export class MultiProtocolSignerManager {
       `No private key found for chain ${chain}`,
     );
 
-    this.logger.info(
+    this.logger.debug(
       `Extracting private key from strategy config/user prompt for chain ${chain}`,
     );
     return strategyConfig.privateKey;


### PR DESCRIPTION
### Description

Probably fixes an issue due to a recent pr merge that changes how signers are initialized based on the command to be executed

### Drive-by changes

- Updates the key info message log level from info to debug to avoid the following
![image](https://github.com/user-attachments/assets/3ad0d4f8-36b9-4e2f-8c28-199858f8ef0e)


### Related issues

### Backward compatibility

- Yes

### Testing

- Manual
