### PR TITLE
feat: Configurable indexing direction per chain

### DIFF
--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -785,7 +785,8 @@
       "index": {
         "from": 1,
         "mode": "sequence",
-        "chunk": 100
+        "chunk": 100,
+        "direction": "forward"
       },
       "interchainGasPaymaster": "ABb3i11z7wKoGCfeRQNQbVYWjAm7jG7HzZnDLV4RKRbK",
       "mailbox": "EitxJuv2iBjsg2d7jVy2LDC1e2zBrx4GB5Y9h2Ko3A9Y",

--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -785,8 +785,7 @@
       "index": {
         "from": 1,
         "mode": "sequence",
-        "chunk": 100,
-        "direction": "forward"
+        "chunk": 100
       },
       "interchainGasPaymaster": "ABb3i11z7wKoGCfeRQNQbVYWjAm7jG7HzZnDLV4RKRbK",
       "mailbox": "EitxJuv2iBjsg2d7jVy2LDC1e2zBrx4GB5Y9h2Ko3A9Y",

--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -308,6 +308,7 @@ where
             from: watermark.unwrap_or(index_settings.from),
             chunk_size: index_settings.chunk_size,
             mode: index_settings.mode,
+            direction: index_settings.direction,
         };
         Ok(Box::new(
             RateLimitedContractSyncCursor::new(
@@ -356,6 +357,7 @@ where
                 Arc::new(self.store.clone()),
                 index_settings.chunk_size,
                 index_settings.mode,
+                index_settings.direction,
             )
             .await?,
         ))

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -8,8 +8,8 @@ use eyre::{eyre, Context, Result};
 use ethers_prometheus::middleware::{ChainInfo, ContractInfo, PrometheusMiddlewareConf};
 use hyperlane_core::{
     config::OperationBatchConfig, AggregationIsm, CcipReadIsm, ContractLocator, HyperlaneAbi,
-    HyperlaneDomain, HyperlaneDomainProtocol, HyperlaneMessage, HyperlaneProvider, IndexMode,
-    InterchainGasPaymaster, InterchainGasPayment, InterchainSecurityModule, Mailbox,
+    HyperlaneDomain, HyperlaneDomainProtocol, HyperlaneMessage, HyperlaneProvider, IndexDirection,
+    IndexMode, InterchainGasPaymaster, InterchainGasPayment, InterchainSecurityModule, Mailbox,
     MerkleTreeHook, MerkleTreeInsertion, MultisigIsm, ReorgPeriod, RoutingIsm,
     SequenceAwareIndexer, ValidatorAnnounce, H256,
 };
@@ -183,6 +183,8 @@ pub struct IndexSettings {
     pub chunk_size: u32,
     /// The indexing mode.
     pub mode: IndexMode,
+    /// The indexing direction.
+    pub direction: IndexDirection,
 }
 
 impl ChainConf {

--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -19,7 +19,7 @@ use url::Url;
 use h_cosmos::RawCosmosAmount;
 use hyperlane_core::{
     cfg_unwrap_all, config::*, HyperlaneDomain, HyperlaneDomainProtocol,
-    HyperlaneDomainTechnicalStack, IndexMode, ReorgPeriod,
+    HyperlaneDomainTechnicalStack, IndexDirection, IndexMode, ReorgPeriod,
 };
 
 use crate::settings::{
@@ -170,6 +170,12 @@ fn parse_chain(
                 })
                 .unwrap_or_default()
         });
+    let direction = chain
+        .chain(&mut err)
+        .get_opt_key("index")
+        .get_opt_key("direction")
+        .parse_value("Invalid index direction")
+        .unwrap_or(IndexDirection::Both);
 
     let mailbox = chain
         .chain(&mut err)
@@ -234,6 +240,7 @@ fn parse_chain(
             from,
             chunk_size,
             mode,
+            direction,
         },
     })
 }

--- a/rust/main/hyperlane-core/src/traits/indexer.rs
+++ b/rust/main/hyperlane-core/src/traits/indexer.rs
@@ -24,6 +24,37 @@ pub enum IndexMode {
     Sequence,
 }
 
+/// Indexing direction.
+#[derive(Copy, Debug, Default, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub enum IndexDirection {
+    /// Both directions: backward and forward
+    #[default]
+    Both,
+    /// Backward direction
+    Backward,
+    /// Forward direction
+    Forward,
+}
+
+impl IndexDirection {
+    /// Returns true if direction allows forward.
+    pub fn can_backward(&self) -> bool {
+        match self {
+            IndexDirection::Both | IndexDirection::Backward => true,
+            IndexDirection::Forward => false,
+        }
+    }
+
+    /// Returns true if direction allows backward.
+    pub fn can_forward(&self) -> bool {
+        match self {
+            IndexDirection::Both | IndexDirection::Forward => true,
+            IndexDirection::Backward => false,
+        }
+    }
+}
+
 /// Interface for an indexer.
 #[async_trait]
 #[auto_impl(&, Box, Arc,)]


### PR DESCRIPTION
### Description

Configurable indexing direction per chain. We can configure the direction we would like to index a chain: 
* Both - sequence-aware indexing will start from the tip and will index back into the past as well as new blocks.
* Backward - sequence-aware indexing will start from the tip and will index back into the past only.
* Forward - sequence-aware indexing will start from the tip and will indexing only new blocks.

Default is Both.

### Related issues

- Contributes into - https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4271

### Backward compatibility

Yes

### Testing

E2E Ethereum and Sealevel tests (for no regression)