### PR TITLE
feat: add treasure batch contract address

### DIFF
--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -6322,6 +6322,7 @@
       "validatorAnnounce": "0x1196055C61af3e3DA6f8458B07b255a72b64Bcf7"
     },
     "treasure": {
+      "batchContractAddress": "0x2e29fe39496a56856D8698bD43e1dF4D0CE6266a",
       "blockExplorers": [
         {
           "apiUrl": "https://rpc-explorer-verify.treasure.lol/contract_verification",


### PR DESCRIPTION
### Description

- Multicall3 is at a nonstandard address due to it being a zksync chain

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
