### PR TITLE
feat: filter chains to check depending on Operator chain

### DIFF
--- a/typescript/cli/src/avs/check.ts
+++ b/typescript/cli/src/avs/check.ts
@@ -12,7 +12,12 @@ import {
   MultiProvider,
   isValidValidatorStorageLocation,
 } from '@hyperlane-xyz/sdk';
-import { Address, ProtocolType, isObjEmpty } from '@hyperlane-xyz/utils';
+import {
+  Address,
+  OperatorChain,
+  ProtocolType,
+  isObjEmpty,
+} from '@hyperlane-xyz/utils';
 
 import { CommandContext } from '../context/types.js';
 import {
@@ -86,7 +91,7 @@ export const checkValidatorAvsSetup = async (
   );
 
   if (!isObjEmpty(avsOperatorRecord)) {
-    await setValidatorInfo(context, avsOperatorRecord, topLevelErrors);
+    await setValidatorInfo(chain, context, avsOperatorRecord, topLevelErrors);
   }
 
   logOutput(avsOperatorRecord, topLevelErrors);
@@ -231,6 +236,7 @@ const setOperatorName = async (
 };
 
 const setValidatorInfo = async (
+  operatorChain: string,
   context: CommandContext,
   avsOperatorRecord: Record<Address, ValidatorInfo>,
   topLevelErrors: string[],
@@ -246,6 +252,15 @@ const setValidatorInfo = async (
   for (const chain of chains) {
     // skip if chain is not an Ethereum chain
     if (chainMetadata[chain].protocol !== ProtocolType.Ethereum) continue;
+
+    // skip if chain network type does not match the operator chain
+    if (
+      (operatorChain === OperatorChain.Ethereum &&
+        chainMetadata[chain].isTestnet) ||
+      (operatorChain === OperatorChain.Holesky &&
+        !chainMetadata[chain].isTestnet)
+    )
+      continue;
 
     const chainAddresses = addresses[chain];
 

--- a/typescript/utils/src/index.ts
+++ b/typescript/utils/src/index.ts
@@ -161,6 +161,8 @@ export {
   MerkleProof,
   MessageStatus,
   Numberish,
+  OperatorChain,
+  OperatorChainValue,
   ParsedLegacyMultisigIsmMetadata,
   ParsedMessage,
   ProtocolSmallestUnit,

--- a/typescript/utils/src/types.ts
+++ b/typescript/utils/src/types.ts
@@ -1,6 +1,13 @@
 import type { SignatureLike } from '@ethersproject/bytes';
 import type { BigNumber, ethers } from 'ethers';
 
+export enum OperatorChain {
+  Ethereum = 'ethereum',
+  Holesky = 'holesky',
+}
+// A type that also allows for literal values of the enum
+export type OperatorChainValue = `${OperatorChain}`;
+
 export enum ProtocolType {
   Ethereum = 'ethereum',
   Sealevel = 'sealevel',


### PR DESCRIPTION
### Description

The current CLI command `hyperlane avs check` makes a loop on all chains and ignores the operator chain (ethereum / holesky)

This PR filters chains to check depending on the operator chain  (ethereum / holesky)

### Drive-by changes

* None

### Related issues

* None

### Backward compatibility

* Yes

### Testing

* Manual using locally compiled `yarn hyperlane avs check` command