### PR TITLE
fix: balance check skip confirmation

### DIFF
--- a/.changeset/five-bats-attend.md
+++ b/.changeset/five-bats-attend.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+fix: balance check skip confirmation

--- a/typescript/cli/src/deploy/utils.ts
+++ b/typescript/cli/src/deploy/utils.ts
@@ -41,7 +41,7 @@ export async function runPreflightChecksForChains({
   chainsToGasCheck?: ChainName[];
 }) {
   log('Running pre-flight checks for chains...');
-  const { multiProvider } = context;
+  const { multiProvider, skipConfirmation } = context;
 
   if (!chains?.length) throw new Error('Empty chain selection');
   for (const chain of chains) {
@@ -59,6 +59,7 @@ export async function runPreflightChecksForChains({
     multiProvider,
     chainsToGasCheck ?? chains,
     minGas,
+    skipConfirmation,
   );
 }
 

--- a/typescript/cli/src/utils/balances.ts
+++ b/typescript/cli/src/utils/balances.ts
@@ -1,15 +1,16 @@
-import { confirm } from '@inquirer/prompts';
 import { ethers } from 'ethers';
 
 import { ChainName, MultiProvider } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
-import { logGray, logGreen, logRed } from '../logger.js';
+import { autoConfirm } from '../config/prompts.js';
+import { logBlue, logGray, logGreen, logRed, warnYellow } from '../logger.js';
 
 export async function nativeBalancesAreSufficient(
   multiProvider: MultiProvider,
   chains: ChainName[],
   minGas: string,
+  skipConfirmation: boolean,
 ) {
   const sufficientBalances: boolean[] = [];
   for (const chain of chains) {
@@ -42,9 +43,10 @@ export async function nativeBalancesAreSufficient(
   if (allSufficient) {
     logGreen('✅ Balances are sufficient');
   } else {
-    const isResume = await confirm({
-      message: 'Deployment may fail due to insufficient balance(s). Continue?',
-    });
+    warnYellow(`Deployment may fail due to insufficient balance(s)`);
+    const isResume = await autoConfirm('Continue?', skipConfirmation, () =>
+      logBlue('Continuing deployment with insufficient balances'),
+    );
     if (!isResume) throw new Error('Canceled deployment due to low balance');
   }
 }


### PR DESCRIPTION
### Description

Balance checking will skip confirmation when CLI flag is defined. When balances are insufficient, CLI asks for confirmation to continue with deployment, if `skip-confirmations` is provided through CLI args this should be bypassed.

### Backward compatibility

No, compatible with backwards

### Testing

Manual
