### PR TITLE
fix: update spl-token-cli dependency

### DIFF
--- a/rust/sealevel/client/src/warp_route.rs
+++ b/rust/sealevel/client/src/warp_route.rs
@@ -670,7 +670,7 @@ pub fn install_spl_token_cli() {
             "--branch",
             "dan/create-token-for-mint",
             "--rev",
-            "c1278a3f1",
+            "ae4c8ac46",
         ])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())


### PR DESCRIPTION
### Description

Fix E2E tests. New version of dependency was picked up and it broke E2E Ethereum and Sealevel tests.

### Backward compatibility

Yes

### Testing

E2E Ethereum and Sealevel tests