### PR TITLE
fix: Stop advancing cursor when not all logs were stored

### DIFF
--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -250,8 +250,21 @@ where
 
             accumulated_stored_logs_count += stored_logs_count as u64;
             if accumulated_stored_logs_count == deduped_logs_count {
+                info!(
+                    ?accumulated_stored_logs_count,
+                    ?stored_logs_count,
+                    ?deduped_logs_count,
+                    "Successfully stored all logs",
+                );
                 break;
             }
+
+            warn!(
+                ?accumulated_stored_logs_count,
+                ?stored_logs_count,
+                ?deduped_logs_count,
+                "Repeat storing logs since not all logs were stored yet",
+            );
         }
 
         logs


### PR DESCRIPTION
### Description

Stop advancing cursor when not all logs were stored.

### Backward compatibility

Yes

### Testing

E2E Ethereum and Sealevel test (for no regressions)