### PR TITLE
Use implementation instead of admin slot for isProxy

### DIFF
--- a/typescript/sdk/src/deploy/proxy.ts
+++ b/typescript/sdk/src/deploy/proxy.ts
@@ -69,8 +69,8 @@ export async function isProxy(
   provider: ethers.providers.Provider,
   proxy: Address,
 ): Promise<boolean> {
-  const admin = await proxyAdmin(provider, proxy);
-  return !eqAddress(admin, ethers.constants.AddressZero);
+  const implementation = await proxyImplementation(provider, proxy);
+  return !eqAddress(implementation, ethers.constants.AddressZero);
 }
 
 export function proxyAdminUpdateTxs(


### PR DESCRIPTION
### Description

Admin slot is optional as per https://eips.ethereum.org/EIPS/eip-1967
This PR uses the implementation slot for determining whether the contract is a (1967) proxy.

### Backward compatibility

Yes

### Testing

None
