### PR TITLE
fix: Release Scraper with revert of new SeaORM

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -566,7 +566,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '05e90bc-20241216-180035',
+      tag: 'd84d8da-20241217-172447',
     },
     resources: scraperResources,
   },

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -113,7 +113,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     alephzeroevmtestnet: true,
     alfajores: true,
     arbitrumsepolia: true,
-    arcadiatestnet2: true,
+    arcadiatestnet2: false,
     basesepolia: true,
     berabartio: true,
     bsctestnet: true,

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -250,7 +250,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '4b280cd-20241206-130519',
+      tag: 'd84d8da-20241217-172447',
     },
     resources: scraperResources,
   },


### PR DESCRIPTION
### Description

Release Scraper with revert of new SeaORM.

We shall add indexes for searching interchain gas payments and delivered messages by sequence and bring back new version of SeaORM.

### Drive-by change

Disabled arcadiatestnet2 while their RPC is down to allow Scraper to start

### Backward compatibility

Yes

### Testing

E2E tests on code change