### PR TITLE
fix: Add indices to Scraper database so that queries are quicker

### DIFF
--- a/rust/main/agents/scraper/migration/src/m20230309_000003_create_table_cursor.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000003_create_table_cursor.rs
@@ -36,7 +36,6 @@ impl MigrationTrait for Migration {
                     .to_owned(),
             )
             .await?;
-
         manager
             .create_index(
                 Index::create()
@@ -47,7 +46,17 @@ impl MigrationTrait for Migration {
                     .to_owned(),
             )
             .await?;
-
+        manager
+            .create_index(
+                Index::create()
+                    .table(Cursor::Table)
+                    .name("cursor_domain_height_idx")
+                    .col(Cursor::Domain)
+                    .col(Cursor::Height)
+                    .index_type(IndexType::BTree)
+                    .to_owned(),
+            )
+            .await?;
         Ok(())
     }
 

--- a/rust/main/agents/scraper/migration/src/m20230309_000004_create_table_delivered_message.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000004_create_table_delivered_message.rs
@@ -68,6 +68,7 @@ impl MigrationTrait for Migration {
                     .name("delivered_message_domain_destination_mailbox_idx")
                     .col(DeliveredMessage::Domain)
                     .col(DeliveredMessage::DestinationMailbox)
+                    .index_type(IndexType::BTree)
                     .to_owned(),
             )
             .await?;
@@ -79,6 +80,7 @@ impl MigrationTrait for Migration {
                     .col(DeliveredMessage::Domain)
                     .col(DeliveredMessage::DestinationMailbox)
                     .col(DeliveredMessage::Sequence)
+                    .index_type(IndexType::BTree)
                     .to_owned(),
             )
             .await?;

--- a/rust/main/agents/scraper/migration/src/m20230309_000004_create_table_delivered_message.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000004_create_table_delivered_message.rs
@@ -65,6 +65,27 @@ impl MigrationTrait for Migration {
             .create_index(
                 Index::create()
                     .table(DeliveredMessage::Table)
+                    .name("delivered_message_domain_destination_mailbox_idx")
+                    .col(DeliveredMessage::Domain)
+                    .col(DeliveredMessage::DestinationMailbox)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .table(DeliveredMessage::Table)
+                    .name("delivered_message_domain_destination_mailbox_sequence_idx")
+                    .col(DeliveredMessage::Domain)
+                    .col(DeliveredMessage::DestinationMailbox)
+                    .col(DeliveredMessage::Sequence)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .table(DeliveredMessage::Table)
                     .name("delivered_message_tx_idx")
                     .col(DeliveredMessage::DestinationTxId)
                     .to_owned(),

--- a/rust/main/agents/scraper/migration/src/m20230309_000004_create_table_gas_payment.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000004_create_table_gas_payment.rs
@@ -86,7 +86,28 @@ impl MigrationTrait for Migration {
                     .to_owned(),
             )
             .await?;
-
+        manager
+            .create_index(
+                Index::create()
+                    .table(GasPayment::Table)
+                    .name("gas_payment_domain_id_idx")
+                    .col(GasPayment::Domain)
+                    .col(GasPayment::Id)
+                    .index_type(IndexType::BTree)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .table(GasPayment::Table)
+                    .name("gas_payment_origin_id_idx")
+                    .col(GasPayment::Origin)
+                    .col(GasPayment::Id)
+                    .index_type(IndexType::BTree)
+                    .to_owned(),
+            )
+            .await?;
         manager
             .create_index(
                 Index::create()
@@ -99,7 +120,6 @@ impl MigrationTrait for Migration {
                     .to_owned(),
             )
             .await?;
-
         manager
             .get_connection()
             .execute_unprepared(&format!(
@@ -124,7 +144,6 @@ impl MigrationTrait for Migration {
                 tgp_gas_amount = TotalGasPayment::TotalGasAmount.to_string(),
             ))
             .await?;
-
         Ok(())
     }
 


### PR DESCRIPTION
### Description

Add indices to Scraper database so that queries are quicker.

Scraper with SeaORM version 1.1.1 (currently reverted) reported that some queries are running slow. These indices will improve it.

### Related issues

- https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4793

### Backward compatibility

Yes

### Testing

Tested queries with indices on a separate database where full production database backup was restored