### PR TITLE
code-Update Dockerfile

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -42,8 +42,8 @@ RUN \
 FROM ubuntu:22.04
 RUN apt-get update && \
     apt-get install -y \
-        openssl \
         ca-certificates \
+        openssl \
         tini && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
# Fix: Sorted package names alphanumerically in Dockerfile

## Changes
- Rearranged package names in the `RUN apt-get install` command to maintain alphabetical order.

  - **Before**:
    ```dockerfile
    RUN apt-get update && \
        apt-get install -y \
            openssl \
            ca-certificates \
            tini && \
    ```

  - **After**:
    ```dockerfile
    RUN apt-get update && \
        apt-get install -y \
            ca-certificates \
            openssl \
            tini && \
    ```

## Purpose
- Improved readability and maintainability of the Dockerfile by sorting package names alphabetically.
- Resolved SonarQube warning regarding unsorted package names.
