### PR TITLE
feat: configure some nonces from Stride as unprocessed

### DIFF
--- a/rust/main/agents/relayer/src/msg/processor.rs
+++ b/rust/main/agents/relayer/src/msg/processor.rs
@@ -185,9 +185,7 @@ impl DirectionalNonceIterator {
                                 nonce = message.nonce,
                                 "Setting Stride origin message as unprocessed"
                             );
-                            self.db
-                                .store_processed_by_nonce(&message.nonce, &false)
-                                .unwrap();
+                            self.db.store_processed_by_nonce(&message.nonce, &false)?;
                         }
                     }
                     _ => {


### PR DESCRIPTION
### Description

Suggested env vars:
```
STRIDE_RESET_DELIVERY_NONCE_LOW=187315
STRIDE_RESET_DELIVERY_NONCE_HIGH=193716
```

The low is from an hour before the Forma reorg https://explorer.hyperlane.xyz/message/0xe453ba0be37cc2a7d42ba2ea3ef6c76b27ab381eb7954ee33b297286203eaf14, and the high is the last message sent to Forma https://explorer.hyperlane.xyz/message/0x7e0750b1f7469455c62ff145db8c6909870d82e6a2bd9b8745b3185cda5b1fe7

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
