### PR TITLE
feat: restrict WarpCore recipients to exclude remote router and collateral token

### DIFF
--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -558,14 +558,21 @@ export class WarpCore {
     sender: Address;
     senderPubKey?: HexString;
   }): Promise<Record<string, string> | null> {
+    const destinationName = this.multiProvider.getChainName(destination);
+    const { token: originToken } = originTokenAmount;
     const chainError = this.validateChains(
-      originTokenAmount.token.chainName,
+      originToken.chainName,
       destination,
     );
     if (chainError) return chainError;
 
     const recipientError = this.validateRecipient(recipient, destination);
     if (recipientError) return recipientError;
+
+    const destinationToken =
+    originToken.getConnectionForChain(destinationName)?.token;
+    assert(destinationToken, `No connection found for ${destinationName}`);
+    assert(recipient !== destinationToken?.addressOrDenom, "Recipient cannot be the destination token address.");
 
     const amountError = await this.validateAmount(
       originTokenAmount,


### PR DESCRIPTION
feat: restrict WarpCore recipients to exclude remote router and collateral token

### Description
**What's included in this PR?**
In validateTransfer, checks to ensure that the recipient is not the destination router or token address

### Drive-by changes
**Are there any minor or drive-by changes also included?**
No


### Related issues
- Fixes #4964


### Backward compatibility
**Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?**
No


### Testing
**What kind of testing have these changes undergone?**
None, for now.
