### PR TITLE
fix: correct instructions in Rust readme for building docker image

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -119,11 +119,10 @@ cargo test --release --package run-locally --bin run-locally --features cosmos -
 ### Building Agent Docker Images
 
 There exists a docker build for the agent binaries. These docker images are used for deploying the agents in a
-production environment.
+production environment. You should run this at the top level of the repo.
 
 ```bash
-cd rust
-./build.sh <image_tag>
+./rust/build.sh <image_tag>
 ```
 
 ### Deploy Procedure

--- a/rust/build.sh
+++ b/rust/build.sh
@@ -19,4 +19,4 @@ if [[ -z $TAG ]]; then
   fi
 fi
 
-DOCKER_BUILDKIT=1 docker build $PLATFORM -t gcr.io/abacus-labs-dev/hyperlane-agent:$TAG .
+DOCKER_BUILDKIT=1 docker build -f rust/Dockerfile $PLATFORM -t gcr.io/abacus-labs-dev/hyperlane-agent:$TAG .


### PR DESCRIPTION
### Description

Fix incorrect instructions in Rust readme for building the docker image. The build does not work as the readme dictates. Being in the rust folder gives a `ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref y1ezs2da6re8bcvxgo9psu1xk::hydxdsbeaxqx3rvjjzako1134: "/rust/main/config": not found` error. Being at the top level causes a successful build.

Also have to edit the build script to target the correct directory dockerfile.