### PR TITLE
chore: rm Viction env-test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -301,7 +301,7 @@ jobs:
       fail-fast: false
       matrix:
         environment: [mainnet3]
-        chain: [ethereum, arbitrum, optimism, inevm, viction]
+        chain: [ethereum, arbitrum, optimism, inevm]
         module: [core, igp]
         include:
           - environment: testnet4


### PR DESCRIPTION
### Description

- Removing the consistently failing Viction env test, see https://discord.com/channels/935678348330434570/1319783601407262854/1319788686111674418 for context

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
