### PR TITLE
fix: use non-AW proxy admin for pumpBTC deploy

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumSeiPumpBTCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumSeiPumpBTCWarpConfig.ts
@@ -13,6 +13,7 @@ import {
   tokens,
 } from '../../../../../src/config/warp.js';
 
+// pumpBTC team
 const ethereumOwner = '0x77A0545Dc1Dc6bAee8d9c1d436c6688a75Ae5777';
 const seiOwner = '0x14A359aE2446eaC89495b3F28b7a29cE2A17f392';
 
@@ -23,6 +24,11 @@ export const getEthereumSeiPumpBTCWarpConfig = async (
   const ethereum: HypTokenRouterConfig = {
     ...routerConfig.ethereum,
     ...getOwnerConfigForAddress(ethereumOwner),
+    proxyAdmin: {
+      // Address explicitly specified as move away from the AW proxy admin
+      address: '0x64d4ba42f033927ca3babbbebaa11ac8caed9472',
+      owner: ethereumOwner,
+    },
     type: TokenType.collateral,
     token: tokens.ethereum.pumpBTCsei,
     interchainSecurityModule: ethers.constants.AddressZero,
@@ -31,6 +37,11 @@ export const getEthereumSeiPumpBTCWarpConfig = async (
   const sei: HypTokenRouterConfig = {
     ...routerConfig.sei,
     ...getOwnerConfigForAddress(seiOwner),
+    proxyAdmin: {
+      // Address explicitly specified as move away from the AW proxy admin
+      address: '0x932a0a357CbE9a06c0FCec8C56335DA162c5D071',
+      owner: seiOwner,
+    },
     type: TokenType.synthetic,
     interchainSecurityModule: ethers.constants.AddressZero,
   };


### PR DESCRIPTION
### Description

Moves away from the AW proxy admin for the pumpBTC deploy. I deployed new proxy admins that have already had ownership transferred to the pumpBTC team addresses that I deployed using the CLI (using a dummy warp route):
- https://etherscan.io/address/0x64d4ba42f033927ca3babbbebaa11ac8caed9472#code
- https://seitrace.com/address/0x932a0a357cbe9a06c0fcec8c56335da162c5d071?chain=pacific-1

Checker output atm:
```
$ yarn tsx ./scripts/check/check-deploy.ts -e mainnet3  -m warp --warpRouteId pumpBTCsei/ethereum-sei
┌─────────┬────────────┬────────┬──────────────┬──────────────┬─────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┐
│ (index) │   chain    │ remote │     name     │     type     │ subType │                    actual                    │                   expected                   │
├─────────┼────────────┼────────┼──────────────┼──────────────┼─────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┤
│    0    │ 'ethereum' │        │ 'collateral' │ 'ProxyAdmin' │         │ '0x75EE15Ee1B4A75Fa3e2fDF5DF3253c25599cc659' │ '0x64d4ba42f033927ca3babbbebaa11ac8caed9472' │
│    1    │   'sei'    │        │ 'synthetic'  │ 'ProxyAdmin' │         │ '0x0761b0827849abbf7b0cC09CE14e1C93D87f5004' │ '0x932a0a357CbE9a06c0FCec8C56335DA162c5D071' │
└─────────┴────────────┴────────┴──────────────┴──────────────┴─────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┘
Error: Checking warp deploy yielded 2 violations
    at main (/Users/trevor/abacus-monorepo/typescript/infra/scripts/check/check-deploy.ts:48:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

Haven't yet ran with `--govern`. This will result in some multisig txs.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
