### PR TITLE
feat: deploy JitoSOL and kySOL warp route monitors

### DIFF
--- a/typescript/infra/config/environments/mainnet3/gasPrices.json
+++ b/typescript/infra/config/environments/mainnet3/gasPrices.json
@@ -132,7 +132,7 @@
     "decimals": 9
   },
   "ethereum": {
-    "amount": "32.059172476",
+    "amount": "10.0",
     "decimals": 9
   },
   "everclear": {

--- a/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
@@ -14,6 +14,8 @@ export enum WarpRouteIds {
   EclipseEthereumWeETHs = 'weETHs/eclipsemainnet-ethereum',
   EclipseSolanaEzSOL = 'EZSOL/eclipsemainnet-solanamainnet',
   EclipseSolanaORCA = 'ORCA/eclipsemainnet-solanamainnet',
+  EclipseSolanaJitoSOL = 'jitoSOL/eclipsemainnet-solanamainnet',
+  EclipseSolanaKySOL = 'kySOL/eclipsemainnet-solanamainnet',
   EclipseSolanaSOL = 'SOL/eclipsemainnet-solanamainnet',
   EclipseSolanaWIF = 'WIF/eclipsemainnet-solanamainnet',
   EclipseStrideSTTIA = 'stTIA/eclipsemainnet-stride',

--- a/typescript/infra/src/warp/helm.ts
+++ b/typescript/infra/src/warp/helm.ts
@@ -28,7 +28,7 @@ export class WarpRouteMonitorHelmManager extends HelmManager {
     return {
       image: {
         repository: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-        tag: '3cacafd-20241220-092417',
+        tag: 'de11906-20241227-214834',
       },
       warpRouteId: this.warpRouteId,
       fullnameOverride: this.helmReleaseName,


### PR DESCRIPTION
### Description

- Deployed the JitoSOL and kySOL warp route monitors
- Ensured ATA payer balances are sufficient
- Also deployed the relayer with the new app contexts
- Drive-by to lower the ethereum gas price (applied onchain)

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
