### PR TITLE
Fix: Remove trailing comma in rust-analyzer linkedProjects configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "rust-analyzer.linkedProjects": [
         "./rust/main/Cargo.toml",
-        "./rust/sealevel/Cargo.toml",
-    ],
+        "./rust/sealevel/Cargo.toml"
+    ]
 }


### PR DESCRIPTION
This commit fixes a JSON syntax issue in the rust-analyzer configuration file. The trailing comma after the last item in the "rust-analyzer.linkedProjects" list has been removed to ensure the file adheres to the JSON standard. Without this fix, tools processing the JSON file could encounter errors.

### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
