### PR TITLE
Fix: Remove trailing comma in rust-analyzer linkedProjects configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "rust-analyzer.linkedProjects": [
         "./rust/main/Cargo.toml",
-        "./rust/sealevel/Cargo.toml",
-    ],
+        "./rust/sealevel/Cargo.toml"
+    ]
 }


### PR DESCRIPTION
### Description
This PR fixes a JSON syntax issue in the rust-analyzer configuration file. The trailing comma after the last item in the `"rust-analyzer.linkedProjects"` list has been removed to comply with the JSON standard.

### Drive-by changes
None.

### Related issues
None.

### Backward compatibility
Yes, these changes are backward compatible as they only fix a JSON formatting issue and do not impact functionality.

### Testing
Manual validation was performed to ensure the JSON file is now valid and properly handled by tools.