### PR TITLE
chore: Fix typos in comments

### DIFF
--- a/rust/main/hyperlane-core/src/accumulator/incremental.rs
+++ b/rust/main/hyperlane-core/src/accumulator/incremental.rs
@@ -82,7 +82,7 @@ impl IncrementalMerkle {
         merkle_root_from_branch(item, &branch, 32, index)
     }
 
-    /// Verify a incremental merkle proof of inclusion
+    /// Verify an incremental merkle proof of inclusion
     pub fn verify(&self, proof: &Proof) -> bool {
         let computed = IncrementalMerkle::branch_root(proof.leaf, proof.path, proof.index);
         computed == self.root()

--- a/solidity/contracts/client/MailboxClient.sol
+++ b/solidity/contracts/client/MailboxClient.sol
@@ -58,7 +58,7 @@ abstract contract MailboxClient is OwnableUpgradeable, PackageVersioned {
     }
 
     /**
-     * @notice Only accept messages from an Hyperlane Mailbox contract
+     * @notice Only accept messages from a Hyperlane Mailbox contract
      */
     modifier onlyMailbox() {
         require(

--- a/solidity/contracts/client/Router.sol
+++ b/solidity/contracts/client/Router.sol
@@ -145,7 +145,7 @@ abstract contract Router is MailboxClient, IMessageRecipient {
     }
 
     /**
-     * @notice Assert that the given domain has a Application Router registered and return its address
+     * @notice Assert that the given domain has an Application Router registered and return its address
      * @param _domain The domain of the chain for which to get the Application Router
      * @return _router The address of the remote Application Router on _domain
      */

--- a/solidity/contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol
+++ b/solidity/contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol
@@ -27,7 +27,7 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 
 /**
  * @title AbstractMessageIdAuthorizedIsm
- * @notice Uses external verification options to verify interchain messages which need a authorized caller
+ * @notice Uses external verification options to verify interchain messages which need an authorized caller
  */
 abstract contract AbstractMessageIdAuthorizedIsm is
     IInterchainSecurityModule,

--- a/typescript/cli/src/avs/stakeRegistry.ts
+++ b/typescript/cli/src/avs/stakeRegistry.ts
@@ -136,7 +136,7 @@ async function getOperatorSignature(
 
   // random salt is ok, because we register the operator right after
   const salt = utils.hexZeroPad(utils.randomBytes(32), 32);
-  // give a expiry timestamp 1 hour from now
+  // give an expiry timestamp 1 hour from now
   const expiry = utils.hexZeroPad(
     utils.hexlify(Math.floor(Date.now() / 1000) + 60 * 60),
     32,

--- a/typescript/infra/scripts/helloworld/utils.ts
+++ b/typescript/infra/scripts/helloworld/utils.ts
@@ -127,7 +127,7 @@ export async function getHelloWorldMultiProtocolApp(
   );
 
   // TODO we need a MultiProtocolIgp
-  // Using an standard IGP for just evm chains for now
+  // Using a standard IGP for just evm chains for now
   // Unfortunately this requires hacking surgically around certain addresses
   const filteredAddresses = filterChainMapToProtocol(
     envAddresses,

--- a/typescript/utils/src/ids.ts
+++ b/typescript/utils/src/ids.ts
@@ -20,7 +20,7 @@ export function canonizeId(data: BytesLike): Uint8Array {
 }
 
 /**
- * Converts an Hyperlane ID of 20 or 32 bytes to the corresponding EVM Address.
+ * Converts a Hyperlane ID of 20 or 32 bytes to the corresponding EVM Address.
  *
  * For 32-byte IDs this enforces the EVM convention of using the LAST 20 bytes.
  *


### PR DESCRIPTION
This pull request addresses minor grammatical inconsistencies and corrects typos across multiple files in the repository. Specifically, it replaces incorrect usage of "a" with "an" where appropriate and corrects other minor typographical errors. These changes improve code readability and maintain grammatical accuracy.

### Changes
- **incremental.rs**: Updated "a incremental" to "an incremental".
- **MailboxClient.sol**: Updated "an Hyperlane" to "a Hyperlane".
- **Router.sol**: Updated "a Application Router" to "an Application Router".
- **AbstractMessageIdAuthorizedIsm.sol**: Updated "a authorized" to "an authorized".
- **stakeRegistry.ts**: Updated "a expiry" to "an expiry".
- **utils.ts**: Updated "an standard" to "a standard".
- **ids.ts**: Updated "an Hyperlane ID" to "a Hyperlane ID".

### Drive-by Changes
- No additional changes outside the scope of typo corrections.

### Related Issues
- None.

### Backward Compatibility
- These changes are backward compatible and do not affect functionality.

### Testing
- All changes have been manually reviewed for grammatical correctness.
- Verified correctness of usage within the context of each file.