### PR TITLE
test(cli): core commands e2e tests

### DIFF
--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -35,7 +35,6 @@ import {
   fromAddressCommandOption,
   inputFileCommandOption,
   outputFileCommandOption,
-  skipConfirmationOption,
 } from './options.js';
 
 /**
@@ -117,7 +116,6 @@ export const deploy: CommandModuleWithWriteContext<{
     ),
     'dry-run': dryRunCommandOption,
     'from-address': fromAddressCommandOption,
-    'skip-confirmation': skipConfirmationOption,
   },
   handler: async ({ context, chain, config: configFilePath, dryRun }) => {
     logCommandHeader(`Hyperlane Core deployment${dryRun ? ' dry-run' : ''}`);

--- a/typescript/cli/src/tests/commands/core.ts
+++ b/typescript/cli/src/tests/commands/core.ts
@@ -14,7 +14,16 @@ export function hyperlaneCoreDeployRaw(
   coreInputPath: string,
   privateKey?: string,
   skip?: boolean,
+  hyp_key?: string,
 ): ProcessPromise {
+  if (hyp_key) {
+    return $`HYP_KEY=${hyp_key} yarn workspace @hyperlane-xyz/cli run hyperlane core deploy \
+        --registry ${REGISTRY_PATH} \
+        --config ${coreInputPath} \
+        --verbosity debug \
+        ${skip ? '--yes' : ''}`;
+  }
+
   if (privateKey) {
     return $`yarn workspace @hyperlane-xyz/cli run hyperlane core deploy \
         --registry ${REGISTRY_PATH} \

--- a/typescript/cli/src/tests/commands/core.ts
+++ b/typescript/cli/src/tests/commands/core.ts
@@ -1,6 +1,7 @@
-import { $ } from 'zx';
+import { $, ProcessPromise } from 'zx';
 
 import { DerivedCoreConfig } from '@hyperlane-xyz/sdk';
+import { Address } from '@hyperlane-xyz/utils';
 
 import { readYamlOrJson } from '../../utils/files.js';
 
@@ -30,6 +31,23 @@ export async function hyperlaneCoreRead(chain: string, coreOutputPath: string) {
         --registry ${REGISTRY_PATH} \
         --config ${coreOutputPath} \
         --chain ${chain} \
+        --verbosity debug \
+        --yes`;
+}
+
+/**
+ * Reads a Hyperlane core deployment on the specified chain using the provided config.
+ */
+export function hyperlaneCoreCheck(
+  chain: string,
+  coreOutputPath: string,
+  mailbox?: Address,
+): ProcessPromise {
+  return $`yarn workspace @hyperlane-xyz/cli run hyperlane core check \
+        --registry ${REGISTRY_PATH} \
+        --config ${coreOutputPath} \
+        --chain ${chain} \
+        --mailbox ${mailbox} \
         --verbosity debug \
         --yes`;
 }

--- a/typescript/cli/src/tests/commands/core.ts
+++ b/typescript/cli/src/tests/commands/core.ts
@@ -53,6 +53,29 @@ export function hyperlaneCoreCheck(
 }
 
 /**
+ * Creates a Hyperlane core deployment config
+ */
+export function hyperlaneCoreInit(
+  coreOutputPath: string,
+  privateKey?: string,
+): ProcessPromise {
+  if (privateKey) {
+    return $`yarn workspace @hyperlane-xyz/cli run hyperlane core init \
+        --registry ${REGISTRY_PATH} \
+        --config ${coreOutputPath} \
+        --verbosity debug \
+        --key ${privateKey} \
+        --yes`;
+  }
+
+  return $`yarn workspace @hyperlane-xyz/cli run hyperlane core init \
+        --registry ${REGISTRY_PATH} \
+        --config ${coreOutputPath} \
+        --verbosity debug \
+        --yes`;
+}
+
+/**
  * Updates a Hyperlane core deployment on the specified chain using the provided config.
  */
 export async function hyperlaneCoreApply(

--- a/typescript/cli/src/tests/commands/core.ts
+++ b/typescript/cli/src/tests/commands/core.ts
@@ -93,13 +93,31 @@ export function hyperlaneCoreInit(
   privateKey?: string,
   hyp_key?: string,
 ): ProcessPromise {
-  return $`${
-    hyp_key ? `HYP_KEY=${hyp_key}` : ''
-  } yarn workspace @hyperlane-xyz/cli run hyperlane core init \
+  if (hyp_key) {
+    return $`${
+      hyp_key ? `HYP_KEY=${hyp_key}` : ''
+    } yarn workspace @hyperlane-xyz/cli run hyperlane core init \
         --registry ${REGISTRY_PATH} \
         --config ${coreOutputPath} \
         --verbosity debug \
-        ${privateKey ? `--key ${privateKey}` : ''} \
+        --yes`;
+  }
+
+  if (privateKey) {
+    return $`${
+      hyp_key ? 'HYP_KEY=${hyp_key}' : ''
+    } yarn workspace @hyperlane-xyz/cli run hyperlane core init \
+        --registry ${REGISTRY_PATH} \
+        --config ${coreOutputPath} \
+        --verbosity debug \
+        --key ${privateKey} \
+        --yes`;
+  }
+
+  return $`yarn workspace @hyperlane-xyz/cli run hyperlane core init \
+        --registry ${REGISTRY_PATH} \
+        --config ${coreOutputPath} \
+        --verbosity debug \
         --yes`;
 }
 

--- a/typescript/cli/src/tests/commands/core.ts
+++ b/typescript/cli/src/tests/commands/core.ts
@@ -10,6 +10,30 @@ import { ANVIL_KEY, REGISTRY_PATH } from './helpers.js';
 /**
  * Deploys the Hyperlane core contracts to the specified chain using the provided config.
  */
+export function hyperlaneCoreDeployRaw(
+  coreInputPath: string,
+  privateKey?: string,
+  skip?: boolean,
+): ProcessPromise {
+  if (privateKey) {
+    return $`yarn workspace @hyperlane-xyz/cli run hyperlane core deploy \
+        --registry ${REGISTRY_PATH} \
+        --config ${coreInputPath} \
+        --key ${privateKey} \
+        --verbosity debug \
+        ${skip ? '--yes' : ''}`;
+  }
+
+  return $`yarn workspace @hyperlane-xyz/cli run hyperlane core deploy \
+        --registry ${REGISTRY_PATH} \
+        --config ${coreInputPath} \
+        --verbosity debug \
+        ${skip ? '--yes' : ''}`;
+}
+
+/**
+ * Deploys the Hyperlane core contracts to the specified chain using the provided config.
+ */
 export async function hyperlaneCoreDeploy(
   chain: string,
   coreInputPath: string,

--- a/typescript/cli/src/tests/commands/core.ts
+++ b/typescript/cli/src/tests/commands/core.ts
@@ -91,20 +91,15 @@ export function hyperlaneCoreCheck(
 export function hyperlaneCoreInit(
   coreOutputPath: string,
   privateKey?: string,
+  hyp_key?: string,
 ): ProcessPromise {
-  if (privateKey) {
-    return $`yarn workspace @hyperlane-xyz/cli run hyperlane core init \
+  return $`${
+    hyp_key ? `HYP_KEY=${hyp_key}` : ''
+  } yarn workspace @hyperlane-xyz/cli run hyperlane core init \
         --registry ${REGISTRY_PATH} \
         --config ${coreOutputPath} \
         --verbosity debug \
-        --key ${privateKey} \
-        --yes`;
-  }
-
-  return $`yarn workspace @hyperlane-xyz/cli run hyperlane core init \
-        --registry ${REGISTRY_PATH} \
-        --config ${coreOutputPath} \
-        --verbosity debug \
+        ${privateKey ? `--key ${privateKey}` : ''} \
         --yes`;
 }
 

--- a/typescript/cli/src/tests/commands/core.ts
+++ b/typescript/cli/src/tests/commands/core.ts
@@ -69,7 +69,7 @@ export async function hyperlaneCoreRead(chain: string, coreOutputPath: string) {
 }
 
 /**
- * Reads a Hyperlane core deployment on the specified chain using the provided config.
+ * Verifies that a Hyperlane core deployment matches the provided config on the specified chain.
  */
 export function hyperlaneCoreCheck(
   chain: string,

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -96,7 +96,7 @@ export const SELECT_ANVIL_3_AFTER_ANVIL_2_FROM_MULTICHAIN_PICKER = `${KeyBoardKe
 
 export const SELECT_MAINNET_CHAIN_TYPE_STEP: TestPromptAction = {
   check: (currentOutput: string) =>
-    currentOutput.includes('Creating a new warp route deployment config...'),
+    currentOutput.includes('Select network type'),
   // Select mainnet chains
   input: KeyBoardKeys.ENTER,
 };

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -66,6 +66,11 @@ export type TestPromptAction = {
   input: string;
 };
 
+/**
+ * Takes a {@link ProcessPromise} and a list of inputs that will be supplied
+ * in the provided order when the check in the {@link TestPromptAction} matches the output
+ * of the {@link ProcessPromise}.
+ */
 export async function handlePrompts(
   processPromise: Readonly<ProcessPromise>,
   actions: TestPromptAction[],
@@ -75,7 +80,6 @@ export async function handlePrompts(
     const currentLine: string = out.toString();
 
     const currentAction = actions[expectedStep];
-
     if (currentAction && currentAction.check(currentLine)) {
       // Select mainnet chains
       await asyncStreamInputWrite(processPromise.stdin, currentAction.input);
@@ -120,6 +124,25 @@ export const CONFIRM_DETECTED_OWNER_STEP: Readonly<TestPromptAction> = {
     currentOutput.includes('Detected owner address as'),
   input: KeyBoardKeys.ENTER,
 };
+
+export const SETUP_CHAIN_SIGNERS_MANUALLY_STEPS: ReadonlyArray<TestPromptAction> =
+  [
+    {
+      check: (currentOutput) =>
+        currentOutput.includes('Please enter the private key for chain'),
+      input: `${ANVIL_KEY}${KeyBoardKeys.ENTER}`,
+    },
+    {
+      check: (currentOutput) =>
+        currentOutput.includes('Please enter the private key for chain'),
+      input: `${ANVIL_KEY}${KeyBoardKeys.ENTER}`,
+    },
+    {
+      check: (currentOutput) =>
+        currentOutput.includes('Please enter the private key for chain'),
+      input: `${ANVIL_KEY}${KeyBoardKeys.ENTER}`,
+    },
+  ];
 
 /**
  * Retrieves the deployed Warp address from the Warp core config.

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -34,6 +34,7 @@ export const CHAIN_NAME_3 = 'anvil3';
 
 export const EXAMPLES_PATH = './examples';
 export const CORE_CONFIG_PATH = `${EXAMPLES_PATH}/core-config.yaml`;
+export const CORE_CONFIG_PATH_2 = `${TEMP_PATH}/${CHAIN_NAME_2}/core-config.yaml`;
 export const CORE_READ_CONFIG_PATH_2 = `${TEMP_PATH}/${CHAIN_NAME_2}/core-config-read.yaml`;
 export const CHAIN_2_METADATA_PATH = `${REGISTRY_PATH}/chains/${CHAIN_NAME_2}/metadata.yaml`;
 export const CHAIN_3_METADATA_PATH = `${REGISTRY_PATH}/chains/${CHAIN_NAME_3}/metadata.yaml`;

--- a/typescript/cli/src/tests/core/core-apply.e2e-test.ts
+++ b/typescript/cli/src/tests/core/core-apply.e2e-test.ts
@@ -11,13 +11,12 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { Address, Domain, addressToBytes32 } from '@hyperlane-xyz/utils';
 
-import { readYamlOrJson, writeYamlOrJson } from '../utils/files.js';
-
+import { readYamlOrJson, writeYamlOrJson } from '../../utils/files.js';
 import {
   hyperlaneCoreApply,
   hyperlaneCoreDeploy,
   readCoreConfig,
-} from './commands/core.js';
+} from '../commands/core.js';
 import {
   ANVIL_KEY,
   CHAIN_2_METADATA_PATH,
@@ -28,7 +27,7 @@ import {
   CORE_READ_CONFIG_PATH_2,
   DEFAULT_E2E_TEST_TIMEOUT,
   TEMP_PATH,
-} from './commands/helpers.js';
+} from '../commands/helpers.js';
 
 const CORE_READ_CHAIN_2_CONFIG_PATH = `${TEMP_PATH}/${CHAIN_NAME_2}/core-config-read.yaml`;
 const CORE_READ_CHAIN_3_CONFIG_PATH = `${TEMP_PATH}/${CHAIN_NAME_3}/core-config-read.yaml`;

--- a/typescript/cli/src/tests/core/core-check.e2e-test.ts
+++ b/typescript/cli/src/tests/core/core-check.e2e-test.ts
@@ -1,0 +1,93 @@
+import { expect } from 'chai';
+import { $ } from 'zx';
+
+import { randomAddress } from '@hyperlane-xyz/sdk';
+
+import { writeYamlOrJson } from '../../utils/files.js';
+import {
+  hyperlaneCoreCheck,
+  hyperlaneCoreDeploy,
+  readCoreConfig,
+} from '../commands/core.js';
+import {
+  ANVIL_KEY,
+  CHAIN_NAME_2,
+  CORE_CONFIG_PATH,
+  CORE_READ_CONFIG_PATH_2,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  REGISTRY_PATH,
+  deployOrUseExistingCore,
+} from '../commands/helpers.js';
+
+describe('hyperlane core check e2e tests', async function () {
+  this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
+
+  before(async () => {
+    await deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY);
+  });
+
+  it('should throw an error if the --chain param is not provided', async () => {
+    const wrongCommand =
+      $`yarn workspace @hyperlane-xyz/cli run hyperlane core check \
+              --registry ${REGISTRY_PATH} \
+              --config ${CORE_CONFIG_PATH} \
+              --verbosity debug \
+              --yes`.nothrow();
+
+    const output = await wrongCommand;
+
+    expect(output.exitCode).to.equal(1);
+    expect(output.text().includes('Missing required argument: chain')).to.be
+      .true;
+  });
+
+  it('should successfully run the core check command', async () => {
+    await readCoreConfig(CHAIN_NAME_2, CORE_READ_CONFIG_PATH_2);
+
+    const output = await hyperlaneCoreCheck(
+      CHAIN_NAME_2,
+      CORE_READ_CONFIG_PATH_2,
+    );
+
+    expect(output.exitCode).to.equal(0);
+    expect(output.text().includes('No violations found')).to.be.true;
+  });
+
+  it('should find differences between the local and onchain config', async () => {
+    const coreConfig = await readCoreConfig(
+      CHAIN_NAME_2,
+      CORE_READ_CONFIG_PATH_2,
+    );
+    coreConfig.owner = randomAddress();
+    writeYamlOrJson(CORE_READ_CONFIG_PATH_2, coreConfig);
+    const expectedDiffText = `EXPECTED: "${coreConfig.owner}"\n`;
+    const expectedActualText = `ACTUAL: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"\n`;
+
+    const output = await hyperlaneCoreCheck(
+      CHAIN_NAME_2,
+      CORE_READ_CONFIG_PATH_2,
+    ).nothrow();
+
+    expect(output.exitCode).to.equal(1);
+    expect(output.text().includes(expectedDiffText)).to.be.true;
+    expect(output.text().includes(expectedActualText)).to.be.true;
+  });
+
+  it('should successfully check the config when provided with a custom mailbox', async () => {
+    await hyperlaneCoreDeploy(CHAIN_NAME_2, CORE_CONFIG_PATH);
+    const coreConfig = await readCoreConfig(
+      CHAIN_NAME_2,
+      CORE_READ_CONFIG_PATH_2,
+    );
+    expect(coreConfig.interchainAccountRouter?.mailbox).not.to.be.undefined;
+
+    const output = await hyperlaneCoreCheck(
+      CHAIN_NAME_2,
+      CORE_READ_CONFIG_PATH_2,
+      coreConfig.interchainAccountRouter!.mailbox,
+    );
+
+    expect(output.exitCode).to.equal(0);
+    expect(output.text().includes('No violations found')).to.be.true;
+  });
+});

--- a/typescript/cli/src/tests/core/core-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/core/core-deploy.e2e-test.ts
@@ -9,9 +9,8 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 
-import { readYamlOrJson, writeYamlOrJson } from '../utils/files.js';
-
-import { hyperlaneCoreDeploy, readCoreConfig } from './commands/core.js';
+import { readYamlOrJson, writeYamlOrJson } from '../../utils/files.js';
+import { hyperlaneCoreDeploy, readCoreConfig } from '../commands/core.js';
 import {
   ANVIL_KEY,
   CHAIN_2_METADATA_PATH,
@@ -19,7 +18,7 @@ import {
   CORE_CONFIG_PATH,
   CORE_READ_CONFIG_PATH_2,
   DEFAULT_E2E_TEST_TIMEOUT,
-} from './commands/helpers.js';
+} from '../commands/helpers.js';
 
 describe('hyperlane core deploy e2e tests', async function () {
   this.timeout(DEFAULT_E2E_TEST_TIMEOUT);

--- a/typescript/cli/src/tests/core/core-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/core/core-deploy.e2e-test.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_E2E_TEST_TIMEOUT,
   KeyBoardKeys,
   SELECT_MAINNET_CHAIN_TYPE_STEP,
+  SETUP_CHAIN_SIGNERS_MANUALLY_STEPS,
   TestPromptAction,
   handlePrompts,
 } from '../commands/helpers.js';
@@ -51,21 +52,7 @@ describe('hyperlane core deploy e2e tests', async function () {
   describe('hyperlane core deploy', () => {
     it('should create a core deployment with the signer as the mailbox owner', async () => {
       const steps: TestPromptAction[] = [
-        {
-          check: (currentOutput) =>
-            currentOutput.includes('Please enter the private key for chain'),
-          input: `${ANVIL_KEY}${KeyBoardKeys.ENTER}`,
-        },
-        {
-          check: (currentOutput) =>
-            currentOutput.includes('Please enter the private key for chain'),
-          input: `${ANVIL_KEY}${KeyBoardKeys.ENTER}`,
-        },
-        {
-          check: (currentOutput) =>
-            currentOutput.includes('Please enter the private key for chain'),
-          input: `${ANVIL_KEY}${KeyBoardKeys.ENTER}`,
-        },
+        ...SETUP_CHAIN_SIGNERS_MANUALLY_STEPS,
         SELECT_MAINNET_CHAIN_TYPE_STEP,
         {
           check: (currentOutput: string) =>
@@ -113,23 +100,7 @@ describe('hyperlane core deploy e2e tests', async function () {
 
   describe('hyperlane core deploy --yes', () => {
     it('should fail if the --chain flag is not provided but the --yes flag is', async () => {
-      const steps: TestPromptAction[] = [
-        {
-          check: (currentOutput) =>
-            currentOutput.includes('Please enter the private key for chain'),
-          input: `${ANVIL_KEY}${KeyBoardKeys.ENTER}`,
-        },
-        {
-          check: (currentOutput) =>
-            currentOutput.includes('Please enter the private key for chain'),
-          input: `${ANVIL_KEY}${KeyBoardKeys.ENTER}`,
-        },
-        {
-          check: (currentOutput) =>
-            currentOutput.includes('Please enter the private key for chain'),
-          input: `${ANVIL_KEY}${KeyBoardKeys.ENTER}`,
-        },
-      ];
+      const steps: TestPromptAction[] = [...SETUP_CHAIN_SIGNERS_MANUALLY_STEPS];
 
       const output = hyperlaneCoreDeployRaw(CORE_CONFIG_PATH, undefined, true)
         .nothrow()

--- a/typescript/cli/src/tests/core/core-init.e2e-test.ts
+++ b/typescript/cli/src/tests/core/core-init.e2e-test.ts
@@ -1,0 +1,219 @@
+import { expect } from 'chai';
+import { Wallet } from 'ethers';
+
+import { CoreConfig, HookType, randomAddress } from '@hyperlane-xyz/sdk';
+import { normalizeAddress } from '@hyperlane-xyz/utils';
+
+import { readYamlOrJson } from '../../utils/files.js';
+import { hyperlaneCoreInit } from '../commands/core.js';
+import {
+  ANVIL_KEY,
+  CORE_CONFIG_PATH_2,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  KeyBoardKeys,
+  asyncStreamInputWrite,
+} from '../commands/helpers.js';
+
+describe('hyperlane core init e2e tests', async function () {
+  this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
+
+  before(async () => {
+    // await deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY);
+  });
+
+  describe('hyperlane core init', () => {
+    it('should successfully generate the core contract deployment config', async () => {
+      const output = hyperlaneCoreInit(CORE_CONFIG_PATH_2).stdio('pipe');
+
+      const owner = normalizeAddress(randomAddress());
+      const feeHookOwner = normalizeAddress(randomAddress());
+
+      let expectedStep = 0;
+      for await (const out of output.stdout) {
+        const currentLine: string = out.toString();
+
+        if (
+          expectedStep === 0 &&
+          currentLine.includes('Enter the desired owner address:')
+        ) {
+          await asyncStreamInputWrite(
+            output.stdin,
+            `${owner}${KeyBoardKeys.ENTER}`,
+          );
+          expectedStep++;
+        } else if (
+          expectedStep === 1 &&
+          currentLine.includes(
+            'For trusted relayer ISM, enter relayer address:',
+          )
+        ) {
+          await asyncStreamInputWrite(
+            output.stdin,
+            `${owner}${KeyBoardKeys.ENTER}`,
+          );
+          expectedStep++;
+        } else if (
+          expectedStep === 2 &&
+          currentLine.includes('For Protocol Fee Hook, enter owner address:')
+        ) {
+          await asyncStreamInputWrite(
+            output.stdin,
+            `${feeHookOwner}${KeyBoardKeys.ENTER}`,
+          );
+          expectedStep++;
+        } else if (
+          expectedStep === 3 &&
+          currentLine.match(/Use this same address \((.*?)\) for/)
+        ) {
+          await asyncStreamInputWrite(output.stdin, KeyBoardKeys.ENTER);
+          expectedStep++;
+        }
+      }
+
+      const finalOutput = await output;
+
+      expect(finalOutput.exitCode).to.equal(0);
+
+      const deploymentCoreConfig: CoreConfig =
+        readYamlOrJson(CORE_CONFIG_PATH_2);
+      expect(deploymentCoreConfig.owner).to.equal(owner);
+      expect(deploymentCoreConfig.proxyAdmin?.owner).to.equal(owner);
+
+      const defaultHookConfig = deploymentCoreConfig.defaultHook as Exclude<
+        CoreConfig['defaultHook'],
+        string
+      >;
+      expect(defaultHookConfig.type).to.equal(HookType.MERKLE_TREE);
+
+      const requiredHookConfig = deploymentCoreConfig.requiredHook as Exclude<
+        CoreConfig['requiredHook'],
+        string
+      >;
+      expect(requiredHookConfig.type).to.equal(HookType.PROTOCOL_FEE);
+      expect(normalizeAddress((requiredHookConfig as any).owner)).to.equal(
+        feeHookOwner,
+      );
+      expect(
+        normalizeAddress((requiredHookConfig as any).beneficiary),
+      ).to.equal(feeHookOwner);
+    });
+  });
+
+  describe('hyperlane core init --key ...', () => {
+    it('should successfully generate the core contract deployment config when confirming owner prompts', async () => {
+      const output = hyperlaneCoreInit(CORE_CONFIG_PATH_2, ANVIL_KEY).stdio(
+        'pipe',
+      );
+
+      const owner = new Wallet(ANVIL_KEY).address;
+      let expectedStep = 0;
+      for await (const out of output.stdout) {
+        const currentLine: string = out.toString();
+
+        if (
+          expectedStep === 0 &&
+          currentLine.includes('Detected owner address as')
+        ) {
+          await asyncStreamInputWrite(output.stdin, `${KeyBoardKeys.ENTER}`);
+          expectedStep++;
+        } else if (
+          expectedStep === 1 &&
+          currentLine.match(/Use this same address \((.*?)\) for/)
+        ) {
+          await asyncStreamInputWrite(output.stdin, KeyBoardKeys.ENTER);
+          expectedStep++;
+        }
+      }
+
+      const finalOutput = await output;
+
+      expect(finalOutput.exitCode).to.equal(0);
+
+      const deploymentCoreConfig: CoreConfig =
+        readYamlOrJson(CORE_CONFIG_PATH_2);
+      expect(deploymentCoreConfig.owner).to.equal(owner);
+      expect(deploymentCoreConfig.proxyAdmin?.owner).to.equal(owner);
+
+      const defaultHookConfig = deploymentCoreConfig.defaultHook as Exclude<
+        CoreConfig['defaultHook'],
+        string
+      >;
+      expect(defaultHookConfig.type).to.equal(HookType.MERKLE_TREE);
+
+      const requiredHookConfig = deploymentCoreConfig.requiredHook as Exclude<
+        CoreConfig['requiredHook'],
+        string
+      >;
+      expect(requiredHookConfig.type).to.equal(HookType.PROTOCOL_FEE);
+      expect(normalizeAddress((requiredHookConfig as any).owner)).to.equal(
+        owner,
+      );
+      expect(
+        normalizeAddress((requiredHookConfig as any).beneficiary),
+      ).to.equal(owner);
+    });
+
+    it('should successfully generate the core contract deployment config when not confirming owner prompts', async () => {
+      const output = hyperlaneCoreInit(CORE_CONFIG_PATH_2, ANVIL_KEY).stdio(
+        'pipe',
+      );
+
+      const owner = new Wallet(ANVIL_KEY).address;
+      const feeHookOwner = normalizeAddress(randomAddress());
+      let expectedStep = 0;
+      for await (const out of output.stdout) {
+        const currentLine: string = out.toString();
+
+        if (
+          expectedStep === 0 &&
+          currentLine.includes('Detected owner address as')
+        ) {
+          await asyncStreamInputWrite(output.stdin, `${KeyBoardKeys.ENTER}`);
+          expectedStep++;
+        } else if (
+          expectedStep === 1 &&
+          currentLine.match(/Use this same address \((.*?)\) for/)
+        ) {
+          await asyncStreamInputWrite(output.stdin, `no${KeyBoardKeys.ENTER}`);
+          expectedStep++;
+        } else if (
+          expectedStep === 2 &&
+          currentLine.includes('Enter beneficiary address for')
+        ) {
+          await asyncStreamInputWrite(
+            output.stdin,
+            `${feeHookOwner}${KeyBoardKeys.ENTER}`,
+          );
+          expectedStep++;
+        }
+      }
+
+      const finalOutput = await output;
+
+      expect(finalOutput.exitCode).to.equal(0);
+
+      const deploymentCoreConfig: CoreConfig =
+        readYamlOrJson(CORE_CONFIG_PATH_2);
+      expect(deploymentCoreConfig.owner).to.equal(owner);
+      expect(deploymentCoreConfig.proxyAdmin?.owner).to.equal(owner);
+
+      const defaultHookConfig = deploymentCoreConfig.defaultHook as Exclude<
+        CoreConfig['defaultHook'],
+        string
+      >;
+      expect(defaultHookConfig.type).to.equal(HookType.MERKLE_TREE);
+
+      const requiredHookConfig = deploymentCoreConfig.requiredHook as Exclude<
+        CoreConfig['requiredHook'],
+        string
+      >;
+      expect(requiredHookConfig.type).to.equal(HookType.PROTOCOL_FEE);
+      expect(normalizeAddress((requiredHookConfig as any).owner)).to.equal(
+        owner,
+      );
+      expect(
+        normalizeAddress((requiredHookConfig as any).beneficiary),
+      ).to.equal(feeHookOwner);
+    });
+  });
+});

--- a/typescript/cli/src/tests/core/core-init.e2e-test.ts
+++ b/typescript/cli/src/tests/core/core-init.e2e-test.ts
@@ -19,10 +19,6 @@ import {
 describe('hyperlane core init e2e tests', async function () {
   this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
 
-  before(async () => {
-    // await deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY);
-  });
-
   describe('hyperlane core init', () => {
     it('should successfully generate the core contract deployment config', async () => {
       const output = hyperlaneCoreInit(CORE_CONFIG_PATH_2).stdio('pipe');
@@ -78,6 +74,102 @@ describe('hyperlane core init e2e tests', async function () {
       expect(requiredHookConfig.type).to.equal(HookType.PROTOCOL_FEE);
       expect(normalizeAddress((requiredHookConfig as any).owner)).to.equal(
         feeHookOwner,
+      );
+      expect(
+        normalizeAddress((requiredHookConfig as any).beneficiary),
+      ).to.equal(feeHookOwner);
+    });
+  });
+
+  describe('HYP_KEY=... hyperlane core init', () => {
+    it('should successfully generate the core contract deployment config when confirming owner prompts', async () => {
+      const owner = new Wallet(ANVIL_KEY).address;
+      const steps: TestPromptAction[] = [
+        CONFIRM_DETECTED_OWNER_STEP,
+        {
+          check: (currentOutput) =>
+            !!currentOutput.match(/Use this same address \((.*?)\) for/),
+          input: KeyBoardKeys.ENTER,
+        },
+      ];
+
+      const output = hyperlaneCoreInit(
+        CORE_CONFIG_PATH_2,
+        undefined,
+        ANVIL_KEY,
+      ).stdio('pipe');
+
+      const finalOutput = await handlePrompts(output, steps);
+
+      expect(finalOutput.exitCode).to.equal(0);
+
+      const deploymentCoreConfig: CoreConfig =
+        readYamlOrJson(CORE_CONFIG_PATH_2);
+      expect(deploymentCoreConfig.owner).to.equal(owner);
+      expect(deploymentCoreConfig.proxyAdmin?.owner).to.equal(owner);
+
+      const defaultHookConfig = deploymentCoreConfig.defaultHook as Exclude<
+        CoreConfig['defaultHook'],
+        string
+      >;
+      expect(defaultHookConfig.type).to.equal(HookType.MERKLE_TREE);
+
+      const requiredHookConfig = deploymentCoreConfig.requiredHook as Exclude<
+        CoreConfig['requiredHook'],
+        string
+      >;
+      expect(requiredHookConfig.type).to.equal(HookType.PROTOCOL_FEE);
+      expect(normalizeAddress((requiredHookConfig as any).owner)).to.equal(
+        owner,
+      );
+      expect(
+        normalizeAddress((requiredHookConfig as any).beneficiary),
+      ).to.equal(owner);
+    });
+
+    it('should successfully generate the core contract deployment config when not confirming owner prompts', async () => {
+      const owner = new Wallet(ANVIL_KEY).address;
+      const feeHookOwner = normalizeAddress(randomAddress());
+      const steps: TestPromptAction[] = [
+        CONFIRM_DETECTED_OWNER_STEP,
+        {
+          check: (currentOutput) =>
+            !!currentOutput.match(/Use this same address \((.*?)\) for/),
+          input: `no${KeyBoardKeys.ENTER}`,
+        },
+        {
+          check: (currentOutput) =>
+            currentOutput.includes('Enter beneficiary address for'),
+          input: `${feeHookOwner}${KeyBoardKeys.ENTER}`,
+        },
+      ];
+
+      const output = hyperlaneCoreInit(CORE_CONFIG_PATH_2, ANVIL_KEY).stdio(
+        'pipe',
+      );
+
+      const finalOutput = await handlePrompts(output, steps);
+
+      expect(finalOutput.exitCode).to.equal(0);
+
+      const deploymentCoreConfig: CoreConfig =
+        readYamlOrJson(CORE_CONFIG_PATH_2);
+      expect(deploymentCoreConfig.owner).to.equal(owner);
+      expect(deploymentCoreConfig.proxyAdmin?.owner).to.equal(owner);
+
+      const defaultHookConfig = deploymentCoreConfig.defaultHook as Exclude<
+        CoreConfig['defaultHook'],
+        string
+      >;
+      expect(defaultHookConfig.type).to.equal(HookType.MERKLE_TREE);
+
+      const requiredHookConfig = deploymentCoreConfig.requiredHook as Exclude<
+        CoreConfig['requiredHook'],
+        string
+      >;
+      expect(requiredHookConfig.type).to.equal(HookType.PROTOCOL_FEE);
+      expect(normalizeAddress((requiredHookConfig as any).owner)).to.equal(
+        owner,
       );
       expect(
         normalizeAddress((requiredHookConfig as any).beneficiary),

--- a/typescript/cli/src/tests/core/core-read.e2e-test.ts
+++ b/typescript/cli/src/tests/core/core-read.e2e-test.ts
@@ -8,9 +8,8 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 
-import { readYamlOrJson } from '../utils/files.js';
-
-import { hyperlaneCoreDeploy, readCoreConfig } from './commands/core.js';
+import { readYamlOrJson } from '../../utils/files.js';
+import { hyperlaneCoreDeploy, readCoreConfig } from '../commands/core.js';
 import {
   ANVIL_KEY,
   CHAIN_2_METADATA_PATH,
@@ -18,7 +17,7 @@ import {
   CORE_CONFIG_PATH,
   CORE_READ_CONFIG_PATH_2,
   DEFAULT_E2E_TEST_TIMEOUT,
-} from './commands/helpers.js';
+} from '../commands/helpers.js';
 
 describe('hyperlane core read e2e tests', async function () {
   this.timeout(DEFAULT_E2E_TEST_TIMEOUT);

--- a/typescript/cli/src/tests/warp-init.e2e-test.ts
+++ b/typescript/cli/src/tests/warp-init.e2e-test.ts
@@ -16,14 +16,18 @@ import {
   ANVIL_KEY,
   CHAIN_NAME_2,
   CHAIN_NAME_3,
+  CONFIRM_DETECTED_OWNER_STEP,
   CORE_CONFIG_PATH,
   DEFAULT_E2E_TEST_TIMEOUT,
   KeyBoardKeys,
+  SELECT_ANVIL_2_AND_ANVIL_3_STEPS,
+  SELECT_ANVIL_2_FROM_MULTICHAIN_PICKER,
+  SELECT_MAINNET_CHAIN_TYPE_STEP,
+  TestPromptAction,
   WARP_CONFIG_PATH_2,
-  asyncStreamInputWrite,
   deployOrUseExistingCore,
   deployToken,
-  selectAnvil2AndAnvil3,
+  handlePrompts,
 } from './commands/helpers.js';
 import { hyperlaneWarpInit } from './commands/warp.js';
 
@@ -67,37 +71,26 @@ describe('hyperlane warp init e2e tests', async function () {
     }
 
     it('it should generate a warp deploy config with a single chain', async function () {
+      const steps: TestPromptAction[] = [
+        SELECT_MAINNET_CHAIN_TYPE_STEP,
+        {
+          check: (currentOutput: string) =>
+            currentOutput.includes('--Mainnet Chains--'),
+          // Scroll down through the mainnet chains list and select anvil2
+          input: `${SELECT_ANVIL_2_FROM_MULTICHAIN_PICKER}${KeyBoardKeys.ENTER}`,
+        },
+        CONFIRM_DETECTED_OWNER_STEP,
+        {
+          check: (currentOutput: string) =>
+            !!currentOutput.match(/Select .+?'s token type/),
+          // Scroll up through the token type list and select native
+          input: `${KeyBoardKeys.ARROW_UP.repeat(2)}${KeyBoardKeys.ENTER}`,
+        },
+      ];
+
       const output = hyperlaneWarpInit(WARP_CONFIG_PATH_2).stdio('pipe');
 
-      for await (const out of output.stdout) {
-        const currentLine: string = out.toString();
-
-        if (
-          currentLine.includes('Creating a new warp route deployment config...')
-        ) {
-          // Select mainnet chains
-          await asyncStreamInputWrite(output.stdin, KeyBoardKeys.ENTER);
-        } else if (currentLine.includes('--Mainnet Chains--')) {
-          // Scroll down through the mainnet chains list and select anvil2
-          await asyncStreamInputWrite(
-            output.stdin,
-            `${KeyBoardKeys.ARROW_DOWN.repeat(3)}${KeyBoardKeys.TAB}${
-              KeyBoardKeys.ENTER
-            }`,
-          );
-        } else if (currentLine.includes('token type')) {
-          // Scroll up through the token type list and select native
-          await asyncStreamInputWrite(
-            output.stdin,
-            `${KeyBoardKeys.ARROW_UP.repeat(2)}${KeyBoardKeys.ENTER}`,
-          );
-        } else if (currentLine.includes('Detected owner address as')) {
-          // Confirm owner prompts
-          await asyncStreamInputWrite(output.stdin, KeyBoardKeys.ENTER);
-        }
-      }
-
-      await output;
+      await handlePrompts(output, steps);
 
       const warpConfig: WarpRouteDeployConfig =
         readYamlOrJson(WARP_CONFIG_PATH_2);
@@ -106,31 +99,26 @@ describe('hyperlane warp init e2e tests', async function () {
     });
 
     it('it should generate a warp deploy config with a 2 chains warp route (native->native)', async function () {
+      const steps: TestPromptAction[] = [
+        SELECT_MAINNET_CHAIN_TYPE_STEP,
+        ...SELECT_ANVIL_2_AND_ANVIL_3_STEPS,
+        CONFIRM_DETECTED_OWNER_STEP,
+        {
+          check: (currentOutput: string) =>
+            !!currentOutput.match(/Select .+?'s token type/),
+          input: `${KeyBoardKeys.ARROW_UP.repeat(2)}${KeyBoardKeys.ENTER}`,
+        },
+        CONFIRM_DETECTED_OWNER_STEP,
+        {
+          check: (currentOutput: string) =>
+            !!currentOutput.match(/Select .+?'s token type/),
+          input: `${KeyBoardKeys.ARROW_UP.repeat(2)}${KeyBoardKeys.ENTER}`,
+        },
+      ];
+
       const output = hyperlaneWarpInit(WARP_CONFIG_PATH_2).stdio('pipe');
 
-      for await (const out of output.stdout) {
-        const currentLine: string = out.toString();
-
-        if (
-          currentLine.includes('Creating a new warp route deployment config...')
-        ) {
-          // Select mainnet chains
-          await asyncStreamInputWrite(output.stdin, KeyBoardKeys.ENTER);
-        } else if (currentLine.includes('--Mainnet Chains--')) {
-          await selectAnvil2AndAnvil3(output);
-        } else if (currentLine.match(/Select .+?'s token type/)) {
-          // Scroll up through the token type list and select native
-          await asyncStreamInputWrite(
-            output.stdin,
-            `${KeyBoardKeys.ARROW_UP.repeat(2)}${KeyBoardKeys.ENTER}`,
-          );
-        } else if (currentLine.includes('Detected owner address as')) {
-          // Confirm owner prompts
-          await asyncStreamInputWrite(output.stdin, KeyBoardKeys.ENTER);
-        }
-      }
-
-      await output;
+      await handlePrompts(output, steps);
 
       const warpConfig: WarpRouteDeployConfig =
         readYamlOrJson(WARP_CONFIG_PATH_2);
@@ -142,46 +130,35 @@ describe('hyperlane warp init e2e tests', async function () {
 
     it('it should generate a warp deploy config with a 2 chains warp route (collateral->synthetic)', async function () {
       const erc20Token = await deployToken(ANVIL_KEY, CHAIN_NAME_2, 6);
+      const steps: TestPromptAction[] = [
+        SELECT_MAINNET_CHAIN_TYPE_STEP,
+        ...SELECT_ANVIL_2_AND_ANVIL_3_STEPS,
+        // First chain token config
+        CONFIRM_DETECTED_OWNER_STEP,
+        {
+          check: (currentOutput: string) =>
+            !!currentOutput.match(/Select .+?'s token type/),
+          // Scroll down through the token type list and select collateral
+          input: `${KeyBoardKeys.ARROW_DOWN.repeat(4)}${KeyBoardKeys.ENTER}`,
+        },
+        {
+          check: (currentOutput: string) =>
+            currentOutput.includes('Enter the existing token address on chain'),
+          input: `${erc20Token.address}${KeyBoardKeys.ENTER}`,
+        },
+        // Other chain token config
+        CONFIRM_DETECTED_OWNER_STEP,
+        {
+          check: (currentOutput: string) =>
+            !!currentOutput.match(/Select .+?'s token type/),
+          // Select the synthetic token type
+          input: `${KeyBoardKeys.ENTER}`,
+        },
+      ];
 
       const output = hyperlaneWarpInit(WARP_CONFIG_PATH_2).stdio('pipe');
 
-      let tokenStep = 0;
-      for await (const out of output.stdout) {
-        const currentLine: string = out.toString();
-
-        if (
-          currentLine.includes('Creating a new warp route deployment config...')
-        ) {
-          // Select mainnet chains
-          await asyncStreamInputWrite(output.stdin, KeyBoardKeys.ENTER);
-        } else if (currentLine.includes('--Mainnet Chains--')) {
-          await selectAnvil2AndAnvil3(output);
-        } else if (
-          currentLine.includes('Enter the existing token address on chain')
-        ) {
-          await asyncStreamInputWrite(
-            output.stdin,
-            `${erc20Token.address}${KeyBoardKeys.ENTER}`,
-          );
-        } else if (currentLine.match(/Select .+?'s token type/)) {
-          if (tokenStep === 0) {
-            // Scroll down through the token type list and select collateral
-            await asyncStreamInputWrite(
-              output.stdin,
-              `${KeyBoardKeys.ARROW_DOWN.repeat(4)}${KeyBoardKeys.ENTER}`,
-            );
-          } else if (tokenStep === 1) {
-            // Select the synthetic token type
-            await asyncStreamInputWrite(output.stdin, KeyBoardKeys.ENTER);
-          }
-          tokenStep++;
-        } else if (currentLine.includes('Detected owner address as')) {
-          // Confirm owner prompts
-          await asyncStreamInputWrite(output.stdin, KeyBoardKeys.ENTER);
-        }
-      }
-
-      await output;
+      await handlePrompts(output, steps);
 
       const warpConfig: WarpRouteDeployConfig =
         readYamlOrJson(WARP_CONFIG_PATH_2);


### PR DESCRIPTION
### Description

Adds more E2E tests to the core commands in the CLI 

### Drive-by changes

- Removes the unused `--skip-confirmation` from the `core deploy` command
- Updates the `warp init` tests to use the `handlePrompts` function 
- Moves the core e2e tests into the `test/core` folder

### Related issues

- #5080 

### Backward compatibility

- YES
### Testing

- Manual
- E2E
