### PR TITLE
chore: update relayer image

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -602,6 +602,10 @@ const blacklistedMessageIds = [
   // txs between unenrolled routers of
   // USDT/arbitrum-ethereum-mantle-mode-polygon-scroll-zeronetwork
   '0x10159bf1b5b2142b882cb060d1da9f9123d82974ca265ba432138221e52c2a27',
+
+  // test tx when route was first deployed, no merkle tree insertion
+  // USDC/ethereum-inevm
+  '0x998746dc822dc15332b8683fb8a29aec22ed3e2f2fb8245c40f56303c5cb6032',
 ];
 
 // Blacklist matching list intended to be used by all contexts.
@@ -618,7 +622,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '234704d-20241226-192528',
+      tag: 'f73dcc3-20241229-154524',
     },
     blacklist,
     gasPaymentEnforcement: gasPaymentEnforcement,


### PR DESCRIPTION
### Description

- update image in config to the current relayer image tag
- add USDC/ethereum-inevm test tx to blacklist https://explorer.hyperlane.xyz/message/0x998746dc822dc15332b8683fb8a29aec22ed3e2f2fb8245c40f56303c5cb6032 top

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
