### PR TITLE
feat: bump overhead when sending to zkSync chains

### DIFF
--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -1,6 +1,7 @@
 import {
   ChainMap,
   ChainName,
+  ChainTechnicalStack,
   HookType,
   IgpConfig,
   getTokenExchangeRateFromValues,
@@ -14,6 +15,7 @@ import {
   getOverhead,
 } from '../../../src/config/gas-oracle.js';
 import { mustGetChainNativeToken } from '../../../src/utils/utils.js';
+import { getChain } from '../../registry.js';
 
 import { ethereumChainNames } from './chains.js';
 import gasPrices from './gasPrices.json';
@@ -25,8 +27,14 @@ const tokenPrices: ChainMap<string> = rawTokenPrices;
 
 export function getOverheadWithOverrides(local: ChainName, remote: ChainName) {
   let overhead = getOverhead(local, remote, ethereumChainNames);
+  // Moonbeam gas usage can be up to 4x higher than vanilla EVM
   if (remote === 'moonbeam') {
     overhead *= 4;
+  }
+  // ZkSync gas usage is different from the EVM and tends to give high
+  // estimates. We double the overhead to help account for this.
+  if (getChain(remote).technicalStack === ChainTechnicalStack.ZkSync) {
+    overhead *= 2;
   }
   return overhead;
 }


### PR DESCRIPTION
### Description

Context: https://discord.com/channels/935678348330434570/1319115367167033399/1319442102454849639

zkSync chains have non standard EVM gas metering, and their eth_estimateGas RPC returns abnormally high estimates compared to the actual usage. As a semi-temporary workaround, we bump the overhead to result in more gas paid for. The impact of this is actually not meaningful when it comes to cost borne by users - because the zkSync chains are cheap, our min fee logic means that applying this still results in a ~20c cost to users

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
