### PR TITLE
Fix typo Update CHANGELOG.md

### DIFF
--- a/typescript/sdk/CHANGELOG.md
+++ b/typescript/sdk/CHANGELOG.md
@@ -9,7 +9,7 @@
 - 170a0fc73: Add `createHookUpdateTxs()` to `WarpModule.update()` such that it 1) deploys a hook for a warp route _without_ an existing hook, or 2) update an existing hook.
 - 9a09afcc7: Deploy to appchain, treasure, zklink.
 - 24784af95: Introduce GcpValidator for retrieving announcements, checkpoints and metadata for a Validator posting to a GCP bucket. Uses GcpStorageWrapper for bucket operations.
-- 3e8dd70ac: Update validators for boba, duckchain, unichain, vana, bsquared, superseed. Update oort's own validator. Update blockpi's viction validator. Adad luganodes/dsrv to flame validator set.
+- 3e8dd70ac: Update validators for boba, duckchain, unichain, vana, bsquared, supersede. Update oort's own validator. Update blockpi's viction validator. Adad luganodes/dsrv to flame validator set.
 - aa1ea9a48: updates the warp deployment config schema to be closer to the ica routing schema
 - f0b98fdef: Updated the derivation logic to enable ICA ISM metadata building from on chain data to enable self relaying of ICA messages
 - ff9e8a72b: Added a getter to derive ATA payer accounts on Sealevel warp routes


### PR DESCRIPTION
### Description

This pull request fixes a typo in the `CHANGELOG.md` file. The word "superseed" has been corrected to "supersede" for consistency.

### Changes

- Fixed the typo "superseed" to "supersede" in the `CHANGELOG.md` file.

### Related Issues

- (Optional: reference any related issues if applicable)

### Checklist

- [ ] I have read the contributing guidelines.
- [ ] My code follows the style guidelines of this project.
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes and they work as expected (if applicable).
