### PR TITLE
Fix typo Update README.md

### DIFF
--- a/rust/sealevel/programs/mailbox-test/README.md
+++ b/rust/sealevel/programs/mailbox-test/README.md
@@ -4,4 +4,4 @@ These are functional tests that ordinarily would live in `programs/mailbox/tests
 due to some funky dependency resolution, the building the SBF .so files included some dev dependencies
 that would result in errors when trying to deploy the programs.
 
-As a (slightly hacky) fix, these tests are pulled into an entirely separate crate.
+As a (slightly hacky) fix, these tests are pulled into an entirely separate create.


### PR DESCRIPTION
### Title:
Fix Typo in `README.md`

### Description:
This pull request corrects a typo in the `README.md` file. The word "create" has been corrected to "crate" to align with the intended meaning.
