### PR TITLE
feat: hyperlane warp send all chains

### DIFF
--- a/.changeset/lovely-snakes-cross.md
+++ b/.changeset/lovely-snakes-cross.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Update hyperlane warp send to send a round trip transfer to all chains in WarpCoreConfig, if --origin and/or --destination is not provided.

--- a/typescript/cli/src/commands/send.ts
+++ b/typescript/cli/src/commands/send.ts
@@ -50,6 +50,10 @@ export const messageSendOptions: { [k: string]: Options } = {
     type: 'string',
     description: 'Destination chain to send message to',
   },
+  'round-trip': {
+    type: 'boolean',
+    description: 'Send test transfers to all chains in WarpCoreConfig',
+  },
 };
 
 export interface MessageOptionsArgTypes {

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -287,7 +287,7 @@ const send: CommandModuleWithWriteContext<
 
     let chains: ChainName[] = warpCoreConfig.tokens.map((t) => t.chainName);
     if (roundTrip) {
-      // Appends the reverse of the array to roundtrip, excluding the 1st
+      // Appends the reverse of the array to roundtrip, excluding the 1st (e.g. [1,2,3] becomes [1,2,3,2,1])
       // We make a copy because .reverse() is mutating
       const reversed = [...chains].reverse().slice(1, chains.length + 1);
       chains.push(...chains, ...reversed);

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -287,10 +287,9 @@ const send: CommandModuleWithWriteContext<
 
     let chains: ChainName[] = warpCoreConfig.tokens.map((t) => t.chainName);
     if (roundTrip) {
-      // Appends the reverse of the array to roundtrip, excluding the 1st (e.g. [1,2,3] becomes [1,2,3,2,1])
-      // We make a copy because .reverse() is mutating
-      const reversed = [...chains].reverse().slice(1, chains.length + 1);
-      chains.push(...chains, ...reversed);
+      // Appends the reverse of the array, excluding the 1st (e.g. [1,2,3] becomes [1,2,3,2,1])
+      const reversed = [...chains].reverse().slice(1, chains.length + 1); // We make a copy because .reverse() is mutating
+      chains.push(...reversed);
     } else {
       // Assume we want to use use `--origin` and `--destination` params, prompt as needed.
       const chainMetadata = objFilter(

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -1,7 +1,7 @@
 import { stringify as yamlStringify } from 'yaml';
 import { CommandModule } from 'yargs';
 
-import { ChainSubmissionStrategySchema } from '@hyperlane-xyz/sdk';
+import { ChainName, ChainSubmissionStrategySchema } from '@hyperlane-xyz/sdk';
 
 import { runWarpRouteCheck } from '../check/warp.js';
 import {
@@ -14,7 +14,7 @@ import {
 } from '../context/types.js';
 import { evaluateIfDryRunFailure } from '../deploy/dry-run.js';
 import { runWarpRouteApply, runWarpRouteDeploy } from '../deploy/warp.js';
-import { log, logCommandHeader, logGreen } from '../logger.js';
+import { log, logBlue, logCommandHeader, logGreen } from '../logger.js';
 import { runWarpRouteRead } from '../read/warp.js';
 import { sendTestTransfer } from '../send/transfer.js';
 import {
@@ -282,17 +282,27 @@ const send: CommandModuleWithWriteContext<
       context,
     });
 
+    let chains: ChainName[];
+    if (origin && destination) {
+      chains = [origin, destination];
+    } else {
+      // Send to all chains in WarpCoreConfig
+      chains = warpCoreConfig.tokens.map((t) => t.chainName);
+      // Appends the reverse of the array to roundtrip
+      chains = [...chains, ...chains.reverse().slice(1, chains.length + 1)];
+    }
+    logBlue(`🚀 Sending a message for chains: ${chains.join(' ➡️ ')}`);
     await sendTestTransfer({
       context,
       warpCoreConfig,
-      origin,
-      destination,
+      chains,
       amount,
       recipient,
       timeoutSec: timeout,
       skipWaitForDelivery: quick,
       selfRelay: relay,
     });
+    logGreen(`✅ Sending a message for chains: ${chains.join(' ➡️ ')}`);
     process.exit(0);
   },
 };

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -302,7 +302,9 @@ const send: CommandModuleWithWriteContext<
       skipWaitForDelivery: quick,
       selfRelay: relay,
     });
-    logGreen(`✅ Sucessfully sent messages for chains: ${chains.join(' ➡️ ')}`);
+    logGreen(
+      `✅ Successfully sent messages for chains: ${chains.join(' ➡️ ')}`,
+    );
     process.exit(0);
   },
 };

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -302,7 +302,7 @@ const send: CommandModuleWithWriteContext<
       skipWaitForDelivery: quick,
       selfRelay: relay,
     });
-    logGreen(`✅ Sending a message for chains: ${chains.join(' ➡️ ')}`);
+    logGreen(`✅ Sucessfully sent messages for chains: ${chains.join(' ➡️ ')}`);
     process.exit(0);
   },
 };

--- a/typescript/cli/src/send/transfer.ts
+++ b/typescript/cli/src/send/transfer.ts
@@ -18,7 +18,6 @@ import { MINIMUM_TEST_SEND_GAS } from '../consts.js';
 import { WriteCommandContext } from '../context/types.js';
 import { runPreflightChecksForChains } from '../deploy/utils.js';
 import { log, logBlue, logGreen, logRed } from '../logger.js';
-import { runSingleChainSelectionStep } from '../utils/chains.js';
 import { indentYamlOrJson } from '../utils/files.js';
 import { stubMerkleTreeConfig } from '../utils/relay.js';
 import { runTokenSelectionStep } from '../utils/tokens.js';
@@ -30,8 +29,7 @@ export const WarpSendLogs = {
 export async function sendTestTransfer({
   context,
   warpCoreConfig,
-  origin,
-  destination,
+  chains,
   amount,
   recipient,
   timeoutSec,
@@ -40,51 +38,41 @@ export async function sendTestTransfer({
 }: {
   context: WriteCommandContext;
   warpCoreConfig: WarpCoreConfig;
-  origin?: ChainName; // resolved in signerMiddleware
-  destination?: ChainName; // resolved in signerMiddleware
+  chains: ChainName[];
   amount: string;
   recipient?: string;
   timeoutSec: number;
   skipWaitForDelivery: boolean;
   selfRelay?: boolean;
 }) {
-  const { chainMetadata } = context;
-
-  if (!origin) {
-    origin = await runSingleChainSelectionStep(
-      chainMetadata,
-      'Select the origin chain:',
-    );
-  }
-
-  if (!destination) {
-    destination = await runSingleChainSelectionStep(
-      chainMetadata,
-      'Select the destination chain:',
-    );
-  }
-
   await runPreflightChecksForChains({
     context,
-    chains: [origin, destination],
-    chainsToGasCheck: [origin],
+    chains,
     minGas: MINIMUM_TEST_SEND_GAS,
   });
 
-  await timeout(
-    executeDelivery({
-      context,
-      origin,
-      destination,
-      warpCoreConfig,
-      amount,
-      recipient,
-      skipWaitForDelivery,
-      selfRelay,
-    }),
-    timeoutSec * 1000,
-    'Timed out waiting for messages to be delivered',
-  );
+  for (let i = 0; i < chains.length; i++) {
+    const origin = chains[i];
+    const destination = chains[i + 1];
+
+    if (destination) {
+      logBlue(`Sending a message from ${origin} to ${destination}`);
+      await timeout(
+        executeDelivery({
+          context,
+          origin,
+          destination,
+          warpCoreConfig,
+          amount,
+          recipient,
+          skipWaitForDelivery,
+          selfRelay,
+        }),
+        timeoutSec * 1000,
+        'Timed out waiting for messages to be delivered',
+      );
+    }
+  }
 }
 
 async function executeDelivery({
@@ -199,5 +187,5 @@ async function executeDelivery({
 
   // Max wait 10 minutes
   await core.waitForMessageProcessed(transferTxReceipt, 10000, 60);
-  logGreen(`Transfer sent to destination chain!`);
+  logGreen(`Transfer sent to ${destination} chain!`);
 }


### PR DESCRIPTION
### Description
Update `hyperlane warp send` to send a round trip transfer to all chains in WarpCoreConfig, if `--origin` and/or `--destination` is not provided.

### Backward compatibility
Yes

### Testing
Manual
