### PR TITLE
fix(infra): ensure all supported chains per env have owners

### DIFF
--- a/typescript/infra/config/environments/mainnet3/owners.ts
+++ b/typescript/infra/config/environments/mainnet3/owners.ts
@@ -243,4 +243,7 @@ export const chainOwners: ChainMap<OwnableConfig> = {
   osmosis: {
     owner: 'n/a - nothing owned here',
   },
+  soon: {
+    owner: 'n/a - nothing owned here',
+  },
 };

--- a/typescript/infra/config/environments/testnet4/owners.ts
+++ b/typescript/infra/config/environments/testnet4/owners.ts
@@ -13,4 +13,10 @@ export const owners: ChainMap<OwnableConfig> = {
     ]),
   ),
   // [chainMetadata.solanadevnet.name]: SEALEVEL_DEPLOYER_ADDRESS,
+  eclipsetestnet: {
+    owner: 'n/a - nothing owned here',
+  },
+  solanatestnet: {
+    owner: 'n/a - nothing owned here',
+  },
 };

--- a/typescript/infra/test/environment.test.ts
+++ b/typescript/infra/test/environment.test.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+
+import { environments } from '../config/environments/index.js';
+
+describe('Environment', () => {
+  for (const env of Object.values(environments)) {
+    it(`Has owners configured for ${env.environment}`, () => {
+      for (const chain of env.supportedChainNames) {
+        expect(
+          env.owners[chain],
+          `Missing owner for chain ${chain} in environment ${env.environment}`,
+        ).to.not.be.undefined;
+      }
+    });
+  }
+});


### PR DESCRIPTION
### Description

fix(infra): ensure all supported chains per env have owners
- add test
- add missing chains

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

yarn test - tried with + without fix and observed that it correctly fails without the additional chains being added