### PR TITLE
fix: yaml resource exhaustion

### DIFF
--- a/.changeset/shaggy-dolphins-wink.md
+++ b/.changeset/shaggy-dolphins-wink.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/cli": patch
+---
+
+Fix yaml resource exhaustion

--- a/typescript/cli/src/utils/files.ts
+++ b/typescript/cli/src/utils/files.ts
@@ -4,15 +4,23 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import {
+  DocumentOptions,
   LineCounter,
+  ParseOptions,
+  SchemaOptions,
+  ToJSOptions,
   parse,
-  parse as yamlParse,
   stringify as yamlStringify,
 } from 'yaml';
 
 import { objMerge } from '@hyperlane-xyz/utils';
 
 import { log } from '../logger.js';
+
+const yamlParse = (
+  content: string,
+  options?: ParseOptions & DocumentOptions & SchemaOptions & ToJSOptions,
+) => parse(content, { maxAliasCount: -1, ...options });
 
 export const MAX_READ_LINE_OUTPUT = 250;
 
@@ -250,7 +258,7 @@ export function logYamlIfUnderMaxLines(
 ): void {
   const asYamlString = yamlStringify(obj, null, margin);
   const lineCounter = new LineCounter();
-  parse(asYamlString, { lineCounter });
+  yamlParse(asYamlString, { lineCounter });
 
   log(lineCounter.lineStarts.length < maxLines ? asYamlString : '');
 }

--- a/typescript/cli/src/utils/files.ts
+++ b/typescript/cli/src/utils/files.ts
@@ -20,7 +20,9 @@ import { log } from '../logger.js';
 const yamlParse = (
   content: string,
   options?: ParseOptions & DocumentOptions & SchemaOptions & ToJSOptions,
-) => parse(content, { maxAliasCount: -1, ...options });
+) =>
+  // See stackoverflow.com/questions/63075256/why-does-the-npm-yaml-library-have-a-max-alias-number
+  parse(content, { maxAliasCount: -1, ...options });
 
 export const MAX_READ_LINE_OUTPUT = 250;
 


### PR DESCRIPTION
### Description

Fixes 
```
ReferenceError: Excessive alias count indicates a resource exhaustion attack
```

See https://stackoverflow.com/questions/63075256/why-does-the-npm-yaml-library-have-a-max-alias-number

### Backward compatibility

Yes

### Testing

Manual