### PR TITLE
fix: hyperlane warp send out of order for --origin --destination 

### DIFF
--- a/.changeset/tall-starfishes-hunt.md
+++ b/.changeset/tall-starfishes-hunt.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Fix hyperlane warp send where --origin and --destination are out of order

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -2,7 +2,7 @@ import { stringify as yamlStringify } from 'yaml';
 import { CommandModule } from 'yargs';
 
 import { ChainName, ChainSubmissionStrategySchema } from '@hyperlane-xyz/sdk';
-import { objFilter } from '@hyperlane-xyz/utils';
+import { assert, objFilter } from '@hyperlane-xyz/utils';
 
 import { runWarpRouteCheck } from '../check/warp.js';
 import {
@@ -310,10 +310,9 @@ const send: CommandModuleWithWriteContext<
         );
 
       chains = [origin, destination].filter((c) => chains.includes(c));
-    }
 
-    if (chains.length < 2) {
-      throw Error(
+      assert(
+        chains.length === 2,
         `Origin (${origin}) or destination (${destination}) are not part of the warp route.`,
       );
     }

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -309,7 +309,13 @@ const send: CommandModuleWithWriteContext<
           'Select the destination chain:',
         );
 
-      chains = chains.filter((c) => c === origin || c === destination);
+      chains = [origin, destination].filter((c) => chains.includes(c));
+    }
+
+    if (chains.length < 2) {
+      throw Error(
+        `Origin (${origin}) or destination (${destination}) are not part of the warp route.`,
+      );
     }
 
     logBlue(`🚀 Sending a message for chains: ${chains.join(' ➡️ ')}`);

--- a/typescript/cli/src/tests/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/warp-deploy.e2e-test.ts
@@ -222,19 +222,6 @@ describe('hyperlane warp deploy e2e tests', async function () {
     writeYamlOrJson(WARP_CONFIG_PATH, warpConfig);
     await hyperlaneWarpDeploy(WARP_CONFIG_PATH);
 
-    // Check collateralRebase
-    const collateralRebaseConfig = (
-      await readWarpConfig(
-        CHAIN_NAME_2,
-        WARP_CORE_CONFIG_PATH_2_3,
-        WARP_CONFIG_PATH,
-      )
-    )[CHAIN_NAME_2];
-
-    expect(collateralRebaseConfig.type).to.equal(
-      TokenType.collateralVaultRebase,
-    );
-
     // Try to send a transaction with the origin destination
     const { stdout: chain2Tochain3Stdout } = await hyperlaneWarpSendRelay(
       CHAIN_NAME_2,

--- a/typescript/cli/src/tests/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/warp-deploy.e2e-test.ts
@@ -28,7 +28,11 @@ import {
   deployToken,
   sendWarpRouteMessageRoundTrip,
 } from './commands/helpers.js';
-import { hyperlaneWarpDeploy, readWarpConfig } from './commands/warp.js';
+import {
+  hyperlaneWarpDeploy,
+  hyperlaneWarpSendRelay,
+  readWarpConfig,
+} from './commands/warp.js';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -196,6 +200,64 @@ describe('hyperlane warp deploy e2e tests', async function () {
 
     expect(normalizeConfig(collateralRebaseConfig.hook)).to.deep.equal(
       normalizeConfig(hook),
+    );
+  });
+
+  it('should send a message from origin to destination in the correct order', async function () {
+    const warpConfig: WarpRouteDeployConfig = {
+      [CHAIN_NAME_2]: {
+        type: TokenType.collateralVaultRebase,
+        token: vault.address,
+        mailbox: chain2Addresses.mailbox,
+        owner: chain2Addresses.mailbox,
+      },
+      [CHAIN_NAME_3]: {
+        type: TokenType.syntheticRebase,
+        mailbox: chain3Addresses.mailbox,
+        owner: chain3Addresses.mailbox,
+        collateralChainName: CHAIN_NAME_2,
+      },
+    };
+
+    writeYamlOrJson(WARP_CONFIG_PATH, warpConfig);
+    await hyperlaneWarpDeploy(WARP_CONFIG_PATH);
+
+    // Check collateralRebase
+    const collateralRebaseConfig = (
+      await readWarpConfig(
+        CHAIN_NAME_2,
+        WARP_CORE_CONFIG_PATH_2_3,
+        WARP_CONFIG_PATH,
+      )
+    )[CHAIN_NAME_2];
+
+    expect(collateralRebaseConfig.type).to.equal(
+      TokenType.collateralVaultRebase,
+    );
+
+    // Try to send a transaction with the origin destination
+    const { stdout: chain2Tochain3Stdout } = await hyperlaneWarpSendRelay(
+      CHAIN_NAME_2,
+      CHAIN_NAME_3,
+      WARP_CORE_CONFIG_PATH_2_3,
+    );
+    expect(chain2Tochain3Stdout).to.include('anvil2 ➡️ anvil3');
+
+    // Send another message with swapped origin destination
+    const { stdout: chain3Tochain2Stdout } = await hyperlaneWarpSendRelay(
+      CHAIN_NAME_3,
+      CHAIN_NAME_2,
+      WARP_CORE_CONFIG_PATH_2_3,
+    );
+    expect(chain3Tochain2Stdout).to.include('anvil3 ➡️ anvil2');
+
+    // Should throw if invalid origin or destination
+    await hyperlaneWarpSendRelay(
+      'anvil1',
+      CHAIN_NAME_3,
+      WARP_CORE_CONFIG_PATH_2_3,
+    ).should.be.rejectedWith(
+      'Error: Origin (anvil1) or destination (anvil3) are not part of the warp route.',
     );
   });
 });


### PR DESCRIPTION
### Description
Fix ordering issue where --origin and --destination are sent out of order. For example, when --origin is zircuit, and --destination is ethereum, `warp send` will send from origin ethereum to destination zircuit. 

### Testing
Manual/Unit Tests

