### PR TITLE
fix: check-warp-deploy only fetches secrets for relevant chains

### DIFF
--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -1,6 +1,9 @@
 import chalk from 'chalk';
 import { Gauge, Registry } from 'prom-client';
 
+import { ChainName } from '@hyperlane-xyz/sdk';
+
+import { getWarpAddresses } from '../../config/registry.js';
 import { warpConfigGetterMap } from '../../config/warp.js';
 import { submitMetrics } from '../../src/utils/metrics.js';
 import { Modules, getWarpRouteIdsInteractive } from '../agent-utils.js';
@@ -24,10 +27,6 @@ async function main() {
     interactive,
   } = await getCheckWarpDeployArgs().argv;
 
-  const envConfig = getEnvironmentConfig(environment);
-  // Get the multiprovider once to avoid recreating it for each warp route
-  const multiProvider = await envConfig.getMultiProvider();
-
   const metricsRegister = new Registry();
   const checkerViolationsGauge = new Gauge(
     getCheckerViolationsGaugeObj(metricsRegister),
@@ -40,6 +39,31 @@ async function main() {
   if (interactive) {
     warpIdsToCheck = await getWarpRouteIdsInteractive();
   }
+
+  // Determine which chains have warp configs
+  const chainsWithWarpConfigs = warpIdsToCheck.reduce((chains, warpRouteId) => {
+    const warpAddresses = getWarpAddresses(warpRouteId);
+    Object.keys(warpAddresses).forEach((chain) => chains.add(chain));
+    return chains;
+  }, new Set<ChainName>());
+
+  console.log(
+    `Found warp configs for chains: ${Array.from(chainsWithWarpConfigs).join(
+      ', ',
+    )}`,
+  );
+
+  // Get the multiprovider once to avoid recreating it for each warp route
+  // We specify the chains to avoid creating a multiprovider for all chains.
+  // This ensures that we don't fail to fetch secrets for new chains in the cron job.
+  const envConfig = getEnvironmentConfig(environment);
+  // Use default values for context, role, and useSecrets
+  const multiProvider = await envConfig.getMultiProvider(
+    undefined,
+    undefined,
+    undefined,
+    Array.from(chainsWithWarpConfigs),
+  );
 
   // TODO: consider retrying this if check throws an error
   for (const warpRouteId of warpIdsToCheck) {


### PR DESCRIPTION
### Description

> There's an annoying issue where if a new chain has been added to mainnet3 in main, then the warp deploy checker cronjob in k8s (which uses the latest image off main) will try to get secret endpoints for that new chain. It'll fail if we haven't done a deploy of the warp deploy checker because the GCP secrets aren't populated into k8s via external secrets, and the deploy checker doesn't have credentials to get secrets directly from GCP secrets

Attempting to remedy this problem by deriving which subset of chains we care about (i.e. have warp config getters for) and only instantiating the multiprovider with these select chains.

[Relevant Thread](https://discord.com/channels/935678348330434570/1242873947293356042/1326854438518001696)

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

ran locally

```
yarn tsx scripts/check/check-warp-deploy.ts -e mainnet3
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
Found warp configs for chains: ethereum, ancient8, arbitrum, zircuit, inevm, neutron, optimism, base, blast, bsc, mode, linea, fraxtal, taiko, sei, swell, injective, flowmainnet, viction, lumia, mantapacific, eclipsemainnet, solanamainnet, zeronetwork, mantle, polygon, scroll, lisk, gnosis, zoramainnet, stride, appchain, boba, bsquared

Checking warp route USDC/ancient8-ethereum...
warp checker found no violations

Checking warp route AMPHRETH/arbitrum-ethereum-zircuit...
warp checker found no violations

Checking warp route USDC/ethereum-inevm...
warp checker found no violations

Checking warp route USDT/ethereum-inevm...
warp checker found no violations

Checking warp route ECLIP/arbitrum-neutron...
warp checker found no violations

Checking warp route TIA/arbitrum-neutron...
warp checker found no violations

Checking warp route EZETH/arbitrum-base-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-zircuit...
warp checker found no violations

Checking warp route INJ/inevm-injective...
warp checker found no violations

Checking warp route CBBTC/ethereum-flowmainnet...
warp checker found no violations

Checking warp route FASTUSD/ethereum-sei...
warp checker found no violations

Checking warp route pumpBTCsei/ethereum-sei...
┌─────────┬────────────┬────────┬──────────────┬─────────┬─────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┐
│ (index) │ chain      │ remote │ name         │ type    │ subType │ actual                                       │ expected                                     │
├─────────┼────────────┼────────┼──────────────┼─────────┼─────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┤
│ 0       │ 'sei'      │        │ 'proxyAdmin' │ 'Owner' │         │ '0xCed197FBc360C26C19889745Cf73511b71D03d5D' │ '0x14A359aE2446eaC89495b3F28b7a29cE2A17f392' │
│ 1       │ 'ethereum' │        │ 'proxyAdmin' │ 'Owner' │         │ '0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6' │ '0x77A0545Dc1Dc6bAee8d9c1d436c6688a75Ae5777' │
└─────────┴────────────┴────────┴──────────────┴─────────┴─────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┘

Checking warp route ETH/ethereum-viction...
warp checker found no violations

Checking warp route USDC/ethereum-viction...
warp checker found no violations

Checking warp route USDT/ethereum-viction...
warp checker found no violations

Checking warp route PZETH/ethereum-swell-zircuit...
warp checker found no violations

Checking warp route LUMIA/bsc-ethereum-lumia...
warp checker found no violations

Checking warp route TIA/mantapacific-neutron...
warp checker found no violations

Checking warp route APXETH/eclipsemainnet-ethereum...
warp checker found no violations

Checking warp route USDT/eclipsemainnet-ethereum-solanamainnet...
warp checker found no violations

Checking warp route WBTC/eclipsemainnet-ethereum...
warp checker found no violations

Checking warp route weETHs/eclipsemainnet-ethereum...
warp checker found no violations

Checking warp route CBBTC/base-zeronetwork...
warp checker found no violations

Checking warp route USDT/arbitrum-ethereum-mantle-mode-polygon-scroll-zeronetwork...
warp checker found no violations

Checking warp route USDC/arbitrum-base-ethereum-lisk-optimism-polygon-zeronetwork...
warp checker found no violations

Checking warp route ETH/arbitrum-base-blast-bsc-ethereum-gnosis-lisk-mantle-mode-optimism-polygon-scroll-zeronetwork-zoramainnet...
warp checker found no violations

Checking warp route TIA/eclipsemainnet-stride...
warp checker found no violations

Checking warp route stTIA/eclipsemainnet-stride...
warp checker found no violations

Checking warp route USDC/appchain-base...
warp checker found no violations

Checking warp route UBTC/boba-bsquared-swell...
warp checker found no violations

Checking warp route Re7LRT/ethereum-zircuit...
warp checker found no violations
```
