### PR TITLE
fix: more conservative polygon gas price estimates

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -2901,7 +2901,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-30#31653ac8c54ae3fe78b91bf5d92a1ab71604d07e"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-09#0afa80630b90fbc82ef42a0b3f26dd72e68285e4"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -2915,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-30#31653ac8c54ae3fe78b91bf5d92a1ab71604d07e"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-09#0afa80630b90fbc82ef42a0b3f26dd72e68285e4"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -2926,7 +2926,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-30#31653ac8c54ae3fe78b91bf5d92a1ab71604d07e"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-09#0afa80630b90fbc82ef42a0b3f26dd72e68285e4"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-30#31653ac8c54ae3fe78b91bf5d92a1ab71604d07e"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-09#0afa80630b90fbc82ef42a0b3f26dd72e68285e4"
 dependencies = [
  "Inflector",
  "cfg-if",
@@ -2968,7 +2968,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-30#31653ac8c54ae3fe78b91bf5d92a1ab71604d07e"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-09#0afa80630b90fbc82ef42a0b3f26dd72e68285e4"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-30#31653ac8c54ae3fe78b91bf5d92a1ab71604d07e"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-09#0afa80630b90fbc82ef42a0b3f26dd72e68285e4"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -3012,7 +3012,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-30#31653ac8c54ae3fe78b91bf5d92a1ab71604d07e"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-09#0afa80630b90fbc82ef42a0b3f26dd72e68285e4"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.15",
@@ -3028,7 +3028,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-30#31653ac8c54ae3fe78b91bf5d92a1ab71604d07e"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-09#0afa80630b90fbc82ef42a0b3f26dd72e68285e4"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-30#31653ac8c54ae3fe78b91bf5d92a1ab71604d07e"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-09#0afa80630b90fbc82ef42a0b3f26dd72e68285e4"
 dependencies = [
  "async-trait",
  "auto_impl 1.2.0",
@@ -3113,7 +3113,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2024-12-30#31653ac8c54ae3fe78b91bf5d92a1ab71604d07e"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-09#0afa80630b90fbc82ef42a0b3f26dd72e68285e4"
 dependencies = [
  "async-trait",
  "coins-bip32 0.7.0",

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -198,27 +198,27 @@ overflow-checks = true
 [workspace.dependencies.ethers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-12-30"
+tag = "2025-01-09"
 
 [workspace.dependencies.ethers-contract]
 features = ["legacy"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-12-30"
+tag = "2025-01-09"
 
 [workspace.dependencies.ethers-core]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-12-30"
+tag = "2025-01-09"
 
 [workspace.dependencies.ethers-providers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-12-30"
+tag = "2025-01-09"
 
 [workspace.dependencies.ethers-signers]
 features = ["aws"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2024-12-30"
+tag = "2025-01-09"
 
 [patch.crates-io.curve25519-dalek]
 branch = "v3.2.2-relax-zeroize"


### PR DESCRIPTION
applies fix from this ethers PR: https://github.com/hyperlane-xyz/ethers-rs/pull/30

> applies a multiplier of 1.5x to the base fee (or maxFee) and one of 1.1 to the priority fee, since the ones retrieved from the polygon api are too low
