### PR TITLE
feat: enhance block explorer utility tests with edge cases and multiple explorers

### DIFF
--- a/typescript/sdk/src/metadata/blockExplorer.test.ts
+++ b/typescript/sdk/src/metadata/blockExplorer.test.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
 
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
 import {
   test1,
   testCosmosChain,
@@ -8,6 +10,7 @@ import {
 
 import {
   getExplorerAddressUrl,
+  getExplorerApi,
   getExplorerApiUrl,
   getExplorerBaseUrl,
   getExplorerTxUrl,
@@ -49,6 +52,122 @@ describe('Block explorer utils', () => {
     it(`gets an address url for protocol ${chain.protocol}`, () => {
       expect(getExplorerAddressUrl(chain, '0x123')).to.equal(
         EXPECTED_RESULTS[i][3],
+      );
+    });
+  });
+
+  describe('Edge cases', () => {
+    const emptyChain = {
+      protocol: ProtocolType.Ethereum,
+      name: 'empty',
+      domainId: 1,
+      chainId: 1,
+      rpcUrls: [{ http: 'https://empty.test' }],
+    };
+
+    const chainWithoutApi = {
+      protocol: ProtocolType.Ethereum,
+      name: 'noapi',
+      chainId: 1,
+      domainId: 1,
+      rpcUrls: [{ http: 'https://noapi.test' }],
+      blockExplorers: [
+        {
+          name: 'test',
+          url: 'https://test.com',
+          apiUrl: '',
+        },
+      ],
+    };
+
+    it('handles chain without block explorers', () => {
+      expect(getExplorerBaseUrl(emptyChain)).to.be.null;
+      expect(getExplorerApi(emptyChain)).to.be.null;
+      expect(getExplorerTxUrl(emptyChain, '0x123')).to.be.null;
+      expect(getExplorerAddressUrl(emptyChain, '0x123')).to.be.null;
+    });
+
+    it('handles chain without api url', () => {
+      expect(getExplorerBaseUrl(chainWithoutApi)).to.equal('https://test.com/');
+      expect(getExplorerApi(chainWithoutApi)).to.be.null;
+    });
+  });
+
+  describe('Multiple block explorers', () => {
+    const multiExplorerChain = {
+      protocol: ProtocolType.Ethereum,
+      name: 'multi',
+      domainId: 1,
+      chainId: 1,
+      rpcUrls: [{ http: 'https://multi.test' }],
+      blockExplorers: [
+        {
+          name: 'first',
+          url: 'https://first.com',
+          apiUrl: 'https://api.first.com',
+          apiKey: 'key1',
+        },
+        {
+          name: 'second',
+          url: 'https://second.com',
+          apiUrl: 'https://api.second.com',
+          apiKey: 'key2',
+        },
+      ],
+    };
+
+    it('uses correct explorer by index', () => {
+      expect(getExplorerBaseUrl(multiExplorerChain, 1)).to.equal(
+        'https://second.com/',
+      );
+      expect(getExplorerApiUrl(multiExplorerChain, 1)).to.equal(
+        'https://api.second.com/?apikey=key2',
+      );
+    });
+  });
+
+  describe('Special chain names with different common paths', () => {
+    const nautilusChain = {
+      protocol: ProtocolType.Ethereum,
+      name: 'nautilus',
+      chainId: 1,
+      domainId: 1,
+      rpcUrls: [{ http: 'https://nautilus.test' }],
+      blockExplorers: [
+        {
+          name: 'nautilus',
+          url: 'https://nautilus.com',
+          apiUrl: 'https://api.nautilus.com',
+        },
+      ],
+    };
+
+    it('uses correct transaction path for special chains', () => {
+      expect(getExplorerTxUrl(nautilusChain, '0x123')).to.equal(
+        'https://nautilus.com/transaction/0x123',
+      );
+    });
+  });
+
+  describe('URL handling', () => {
+    const chainWithTrailingSlash = {
+      protocol: ProtocolType.Ethereum,
+      name: 'test',
+      domainId: 1,
+      chainId: 1,
+      rpcUrls: [{ http: 'https://test.chain' }],
+      blockExplorers: [
+        {
+          name: 'test',
+          url: 'https://test.com/',
+          apiUrl: 'https://api.test.com',
+        },
+      ],
+    };
+
+    it('handles trailing slashes correctly', () => {
+      expect(getExplorerTxUrl(chainWithTrailingSlash, '0x123')).to.equal(
+        'https://test.com/tx/0x123',
       );
     });
   });


### PR DESCRIPTION
### Description
- Added comprehensive tests for block explorer utilities, covering edge cases such as chains without block explorers and chains without API URLs.
- Implemented tests for handling multiple block explorers, ensuring correct explorer selection by index.
- Included tests for special chain names and proper URL handling, particularly with trailing slashes.
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing
All new tests have been implemented and verified for correctness.
<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
