### PR TITLE
feat: scrape SOON

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -374,7 +374,8 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     moonbeam: true,
     morph: true,
     nero: true,
-    neutron: true,
+    // Jan 14th - temporarily disabled while Neutron chain is down and RPCs give issues, causing scraper startup problems
+    neutron: false,
     oortmainnet: true,
     optimism: true,
     orderly: true,
@@ -397,7 +398,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     solanamainnet: true,
     soneium: true,
     sonic: true,
-    soon: false,
+    soon: true,
     stride: true,
     // subtensor: true,
     superseed: true,
@@ -672,7 +673,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '53fafa6-20250110-125541',
+      tag: 'd365e55-20250114-011047',
     },
     resources: scraperResources,
   },


### PR DESCRIPTION
### Description

- Scrapes SOON
- Temporarily disabling Neutron due to a chain stall and RPC issues there that cause the scraper to panic upon startup

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
