### PR TITLE
Fix spelling errors

### DIFF
--- a/rust/main/hyperlane-base/src/contract_sync/eta_calculator.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/eta_calculator.rs
@@ -31,7 +31,7 @@ impl SyncerEtaCalculator {
         self.last_time = now;
 
         // It was observed that this function can be called with a `last_block` that is greater
-        // than the `currenct_block`, which results in an underflow. Use saturating math to
+        // than the `current_block`, which results in an underflow. Use saturating math to
         // prevent this.
         let blocks_processed = current_block.saturating_sub(self.last_block) as f64;
         let tip_progression = current_tip.saturating_sub(self.last_tip) as f64;

--- a/rust/sealevel/programs/mailbox/src/processor.rs
+++ b/rust/sealevel/programs/mailbox/src/processor.rs
@@ -385,7 +385,7 @@ fn inbox_process(
         .map_err(|e| ProgramError::BorshIoError(e.to_string()))?;
 
     // Now call into the recipient program with the verified message!
-    let handle_intruction = Instruction::new_with_bytes(
+    let handle_instruction = Instruction::new_with_bytes(
         recipient_program_id,
         &MessageRecipientInstruction::Handle(HandleInstruction::new(
             message.origin,
@@ -396,7 +396,7 @@ fn inbox_process(
         recipient_account_metas,
     );
     invoke_signed(
-        &handle_intruction,
+        &handle_instruction,
         &recipient_infos,
         &[mailbox_process_authority_pda_seeds!(
             &recipient_program_id,

--- a/typescript/sdk/src/deploy/verify/ContractVerifier.ts
+++ b/typescript/sdk/src/deploy/verify/ContractVerifier.ts
@@ -366,7 +366,7 @@ export class ContractVerifier {
       contractname: `${sourceName}:${input.name}`,
       contractaddress: input.address,
       /* TYPO IS ENFORCED BY API */
-      constructorArguements: strip0x(input.constructorArguments ?? ''),
+      constructorArguments: strip0x(input.constructorArguments ?? ''),
       ...this.compilerOptions,
     };
   }

--- a/typescript/sdk/src/deploy/verify/types.ts
+++ b/typescript/sdk/src/deploy/verify/types.ts
@@ -89,7 +89,7 @@ export type FormOptions<Action extends ExplorerApiActions> =
         sourceCode: string;
         contractname: string;
         /* TYPO IS ENFORCED BY API */
-        constructorArguements?: string;
+        constructorArguments?: string;
       }
     : Action extends ExplorerApiActions.VERIFY_PROXY
     ? {

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -60,7 +60,7 @@ export {
   CoreFactories,
   coreFactories,
 } from './core/contracts.js';
-export { HyperlaneLifecyleEvent } from './core/events.js';
+export { HyperlaneLifecycleEvent } from './core/events.js';
 export { EvmCoreReader } from './core/EvmCoreReader.js';
 export { HyperlaneCore } from './core/HyperlaneCore.js';
 export { HyperlaneCoreChecker } from './core/HyperlaneCoreChecker.js';

--- a/typescript/widgets/src/stories/ChainLogo.stories.tsx
+++ b/typescript/widgets/src/stories/ChainLogo.stories.tsx
@@ -39,7 +39,7 @@ ChainWithBigSize.args = {
 };
 
 export const ChainWithBackgrounAndBig = Template.bind({});
-ChainWithBackgrounAndBig.args = {
+ChainWithBackgroundAndBig.args = {
   chainName: 'ethereum',
   size: 100,
   background: true,

--- a/typescript/widgets/src/stories/ChainLogo.stories.tsx
+++ b/typescript/widgets/src/stories/ChainLogo.stories.tsx
@@ -38,7 +38,7 @@ ChainWithBigSize.args = {
   registry,
 };
 
-export const ChainWithBackgrounAndBig = Template.bind({});
+export const ChainWithBackgroundAndBig = Template.bind({});
 ChainWithBackgroundAndBig.args = {
   chainName: 'ethereum',
   size: 100,


### PR DESCRIPTION
- Fixed `currenct` to `current`.
- Corrected `intruction` to `instruction`.
- Changed `Backgroun` to `Background`.
- Fixed `Lifecyle` to `Lifecycle`.
- Corrected `Arguements` to `Arguments`.
