### PR TITLE
feat: explorer link in cli logs

### DIFF
--- a/.changeset/three-walls-count.md
+++ b/.changeset/three-walls-count.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Add explorer link to warp send and send message commands

--- a/typescript/cli/src/consts.ts
+++ b/typescript/cli/src/consts.ts
@@ -3,3 +3,4 @@ export const MINIMUM_WARP_DEPLOY_GAS = (3e7).toString();
 export const MINIMUM_TEST_SEND_GAS = (3e5).toString();
 export const MINIMUM_AVS_GAS = (3e6).toString();
 export const PROXY_DEPLOYED_URL = 'https://proxy.hyperlane.xyz';
+export const EXPLORER_URL = 'https://explorer.hyperlane.xyz';

--- a/typescript/cli/src/send/message.ts
+++ b/typescript/cli/src/send/message.ts
@@ -3,7 +3,7 @@ import { stringify as yamlStringify } from 'yaml';
 import { ChainName, HyperlaneCore, HyperlaneRelayer } from '@hyperlane-xyz/sdk';
 import { addressToBytes32, timeout } from '@hyperlane-xyz/utils';
 
-import { MINIMUM_TEST_SEND_GAS } from '../consts.js';
+import { EXPLORER_URL, MINIMUM_TEST_SEND_GAS } from '../consts.js';
 import { CommandContext, WriteCommandContext } from '../context/types.js';
 import { runPreflightChecksForChains } from '../deploy/utils.js';
 import { errorRed, log, logBlue, logGreen } from '../logger.js';
@@ -102,6 +102,7 @@ async function executeDelivery({
     );
     logBlue(`Sent message from ${origin} to ${recipient} on ${destination}.`);
     logBlue(`Message ID: ${message.id}`);
+    logBlue(`Explorer Link: ${EXPLORER_URL}/message/${message.id}`);
     log(`Message:\n${indentYamlOrJson(yamlStringify(message, null, 2), 4)}`);
 
     if (selfRelay) {

--- a/typescript/cli/src/send/transfer.ts
+++ b/typescript/cli/src/send/transfer.ts
@@ -14,7 +14,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { parseWarpRouteMessage, timeout } from '@hyperlane-xyz/utils';
 
-import { MINIMUM_TEST_SEND_GAS } from '../consts.js';
+import { EXPLORER_URL, MINIMUM_TEST_SEND_GAS } from '../consts.js';
 import { WriteCommandContext } from '../context/types.js';
 import { runPreflightChecksForChains } from '../deploy/utils.js';
 import { log, logBlue, logGreen, logRed } from '../logger.js';
@@ -167,6 +167,7 @@ async function executeDelivery({
     `Sent transfer from sender (${signerAddress}) on ${origin} to recipient (${recipient}) on ${destination}.`,
   );
   logBlue(`Message ID: ${message.id}`);
+  logBlue(`Explorer Link: ${EXPLORER_URL}/message/${message.id}`);
   log(`Message:\n${indentYamlOrJson(yamlStringify(message, null, 2), 4)}`);
   log(`Body:\n${indentYamlOrJson(yamlStringify(parsed, null, 2), 4)}`);
 


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
Add link to explorer message for hyperlane CLI `warp send` and `send message` commands

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->
No

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
CLI
send message command:
![Screenshot 2025-01-14 at 3 30 51 PM](https://github.com/user-attachments/assets/dac9a9ae-0b19-43a2-8d12-6c15551a1b50)

warp send command:
![Screenshot 2025-01-14 at 3 32 32 PM](https://github.com/user-attachments/assets/afb114fd-9397-40bd-a29a-3d6e07f5938d)
