### PR TITLE
chore: retryable errors should still be logged as warnings

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/mod.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/mod.rs
@@ -1,5 +1,5 @@
 use ethers::providers::HttpClientError;
-use tracing::{info, trace, warn};
+use tracing::{error, info, trace, warn};
 
 pub use self::{fallback::*, provider::*, retrying::*, trait_builder::*};
 

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/mod.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/mod.rs
@@ -86,12 +86,12 @@ fn categorize_client_response<R>(
                 // We don't want to retry errors that are probably not going to work if we keep
                 // retrying them or that indicate an error in higher-order logic and not
                 // transient provider (connection or other) errors.
-                warn!(error=%e, "Non-retryable JsonRpcError in http provider");
+                error!(error=%e, "Non-retryable JsonRpcError in http provider");
                 NonRetryableErr(JsonRpcError(e))
             } else {
                 // the assumption is this is not a "provider error" but rather an invalid
                 // request, e.g. nonce too low, not enough gas, ...
-                info!(error=%e, "Retryable JsonRpcError in http provider");
+                warn!(error=%e, "Retryable JsonRpcError in http provider");
                 RetryableErr(JsonRpcError(e))
             }
         }


### PR DESCRIPTION
### Description

Retryable errors often indicate that something abnormal is happening (such as we falling back to other providers, which may be causing issues). It's much easier to notice this if the logs are emitted are `warn` level. Non-retryable errors should be logged at `error` level to highlight the relative severity to retryable ones
