### PR TITLE
fix: print displayName instead of chain name in cli log

### DIFF
--- a/.changeset/green-schools-attack.md
+++ b/.changeset/green-schools-attack.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Print displayName instead of chain name in signer validity logs.

--- a/typescript/cli/src/deploy/utils.ts
+++ b/typescript/cli/src/deploy/utils.ts
@@ -51,7 +51,7 @@ export async function runPreflightChecksForChains({
       throw new Error('Only Ethereum chains are supported for now');
     const signer = multiProvider.getSigner(chain);
     assertSigner(signer);
-    logGreen(`✅ ${chain} signer is valid`);
+    logGreen(`✅ ${metadata.displayName ?? chain} signer is valid`);
   }
   logGreen('✅ Chains are valid');
 


### PR DESCRIPTION
### Description

fix: print displayName instead of chain name in cli log

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
