### PR TITLE
chore: Add/clarify log in ISM and Hook deployer

### DIFF
--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -631,6 +631,8 @@ export class EvmHookModule extends HyperlaneModule<
       );
     }
 
+    this.logger.debug(`Deploying hook of type ${config.type}`);
+
     switch (config.type) {
       case HookType.MERKLE_TREE:
         return this.deployer.deployContract(this.chain, HookType.MERKLE_TREE, [

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
@@ -131,7 +131,7 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
     const logger = this.logger.child({ destination, ismType });
 
     logger.debug(
-      `Deploying ${ismType} to ${destination} ${
+      `Deploying ISM of type ${ismType} to ${destination} ${
         origin ? `(for verifying ${origin})` : ''
       }`,
     );


### PR DESCRIPTION
### Description

Since there's currently no other good way to track deployment progress, the Deploy App watches SDK log messages for its progress indicator. This adds a few logs to help it.

### Backward compatibility

Yes
