### PR TITLE
fix(cli): artifacts symbol for warp deploy and update registry packages

### DIFF
--- a/.changeset/proud-waves-camp.md
+++ b/.changeset/proud-waves-camp.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Fix issue where warp deploy artifacts did not include correct symbols.

--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@aws-sdk/client-kms": "^3.577.0",
     "@aws-sdk/client-s3": "^3.577.0",
-    "@hyperlane-xyz/registry": "6.6.0",
+    "@hyperlane-xyz/registry": "6.18.0",
     "@hyperlane-xyz/sdk": "8.2.0",
     "@hyperlane-xyz/utils": "8.2.0",
     "@inquirer/core": "9.0.10",

--- a/typescript/helloworld/package.json
+++ b/typescript/helloworld/package.json
@@ -4,7 +4,7 @@
   "version": "8.2.0",
   "dependencies": {
     "@hyperlane-xyz/core": "5.9.2",
-    "@hyperlane-xyz/registry": "6.6.0",
+    "@hyperlane-xyz/registry": "6.18.0",
     "@hyperlane-xyz/sdk": "8.2.0",
     "@openzeppelin/contracts-upgradeable": "^4.9.3",
     "ethers": "^5.7.2"

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -14,7 +14,7 @@
     "@ethersproject/providers": "*",
     "@google-cloud/secret-manager": "^5.5.0",
     "@hyperlane-xyz/helloworld": "8.2.0",
-    "@hyperlane-xyz/registry": "6.6.0",
+    "@hyperlane-xyz/registry": "6.18.0",
     "@hyperlane-xyz/sdk": "8.2.0",
     "@hyperlane-xyz/utils": "8.2.0",
     "@inquirer/prompts": "3.3.2",

--- a/typescript/widgets/package.json
+++ b/typescript/widgets/package.json
@@ -27,7 +27,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@eslint/js": "^9.15.0",
-    "@hyperlane-xyz/registry": "6.6.0",
+    "@hyperlane-xyz/registry": "6.18.0",
     "@storybook/addon-essentials": "^7.6.14",
     "@storybook/addon-interactions": "^7.6.14",
     "@storybook/addon-links": "^7.6.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7320,7 +7320,7 @@ __metadata:
     "@eslint/js": "npm:^9.15.0"
     "@ethersproject/abi": "npm:*"
     "@ethersproject/providers": "npm:*"
-    "@hyperlane-xyz/registry": "npm:6.6.0"
+    "@hyperlane-xyz/registry": "npm:6.18.0"
     "@hyperlane-xyz/sdk": "npm:8.2.0"
     "@hyperlane-xyz/utils": "npm:8.2.0"
     "@inquirer/core": "npm:9.0.10"
@@ -7424,7 +7424,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.15.0"
     "@hyperlane-xyz/core": "npm:5.9.2"
-    "@hyperlane-xyz/registry": "npm:6.6.0"
+    "@hyperlane-xyz/registry": "npm:6.18.0"
     "@hyperlane-xyz/sdk": "npm:8.2.0"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
     "@nomiclabs/hardhat-waffle": "npm:^2.0.6"
@@ -7475,7 +7475,7 @@ __metadata:
     "@ethersproject/providers": "npm:*"
     "@google-cloud/secret-manager": "npm:^5.5.0"
     "@hyperlane-xyz/helloworld": "npm:8.2.0"
-    "@hyperlane-xyz/registry": "npm:6.6.0"
+    "@hyperlane-xyz/registry": "npm:6.18.0"
     "@hyperlane-xyz/sdk": "npm:8.2.0"
     "@hyperlane-xyz/utils": "npm:8.2.0"
     "@inquirer/prompts": "npm:3.3.2"
@@ -7537,13 +7537,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/registry@npm:6.6.0":
-  version: 6.6.0
-  resolution: "@hyperlane-xyz/registry@npm:6.6.0"
+"@hyperlane-xyz/registry@npm:6.18.0":
+  version: 6.18.0
+  resolution: "@hyperlane-xyz/registry@npm:6.18.0"
   dependencies:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/4e8c955054a3872439f8a52ba208db848da1e46cdf920d4c0cf42080a147c4185d6fed2b00dec0320dfebeb7287578c8a95d3f2f81c2ba713a83a426a1793525
+  checksum: 10/0090afeffa60cf1891b1c7178d5f91d80db96a85595ba9a4ad7160cdc830737efc54022e11d416da4f4d9f7c032fde6f7aef678ae99e4a1f6142cdc06c50ccbc
   languageName: node
   linkType: hard
 
@@ -7642,7 +7642,7 @@ __metadata:
     "@emotion/styled": "npm:^11.13.0"
     "@eslint/js": "npm:^9.15.0"
     "@headlessui/react": "npm:^2.1.8"
-    "@hyperlane-xyz/registry": "npm:6.6.0"
+    "@hyperlane-xyz/registry": "npm:6.18.0"
     "@hyperlane-xyz/sdk": "npm:8.2.0"
     "@hyperlane-xyz/utils": "npm:8.2.0"
     "@interchain-ui/react": "npm:^1.23.28"


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
Fixes #5164 

Fixed an issue where symbols were not taken into account when creating artifacts through warp deploy.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

Update registry packages

### Related issues

<!--
- Fixes #[issue number here]
-->
Related issue: [registry fix](https://github.com/hyperlane-xyz/hyperlane-registry/pull/499)


### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
CLI
Manual