### PR TITLE
feat: allow multiple override registries

### DIFF
--- a/.changeset/weak-hats-juggle.md
+++ b/.changeset/weak-hats-juggle.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+feat: allow multiple override registries

--- a/typescript/cli/src/commands/options.ts
+++ b/typescript/cli/src/commands/options.ts
@@ -33,9 +33,11 @@ export const registryUriCommandOption: Options = {
 };
 
 export const overrideRegistryUriCommandOption: Options = {
-  type: 'string',
-  description: 'Path to a local registry to override the default registry',
-  default: `${os.homedir()}/.hyperlane`,
+  type: 'array',
+  string: true,
+  description:
+    'List of Github or local path registries to override the default registry, later registry takes priority over previous',
+  default: [`${os.homedir()}/.hyperlane`],
 };
 
 export const skipConfirmationOption: Options = {

--- a/typescript/cli/src/context/context.ts
+++ b/typescript/cli/src/context/context.ts
@@ -38,7 +38,7 @@ export async function contextMiddleware(argv: Record<string, any>) {
   const requiresKey = isSignCommand(argv);
   const settings: ContextSettings = {
     registryUri: argv.registry,
-    registryOverrideUri: argv.overrides,
+    registryOverrideUris: argv.overrides,
     key: argv.key,
     fromAddress: argv.fromAddress,
     requiresKey,
@@ -100,14 +100,18 @@ export async function signerMiddleware(argv: Record<string, any>) {
  */
 export async function getContext({
   registryUri,
-  registryOverrideUri,
+  registryOverrideUris,
   key,
   requiresKey,
   skipConfirmation,
   disableProxy = false,
   strategyPath,
 }: ContextSettings): Promise<CommandContext> {
-  const registry = getRegistry(registryUri, registryOverrideUri, !disableProxy);
+  const registry = getRegistry(
+    registryUri,
+    registryOverrideUris,
+    !disableProxy,
+  );
 
   //Just for backward compatibility
   let signerAddress: string | undefined = undefined;
@@ -138,7 +142,7 @@ export async function getContext({
 export async function getDryRunContext(
   {
     registryUri,
-    registryOverrideUri,
+    registryOverrideUris,
     key,
     fromAddress,
     skipConfirmation,
@@ -146,7 +150,11 @@ export async function getDryRunContext(
   }: ContextSettings,
   chain?: ChainName,
 ): Promise<CommandContext> {
-  const registry = getRegistry(registryUri, registryOverrideUri, !disableProxy);
+  const registry = getRegistry(
+    registryUri,
+    registryOverrideUris,
+    !disableProxy,
+  );
   const chainMetadata = await registry.getMetadata();
 
   if (!chain) {
@@ -190,11 +198,11 @@ export async function getDryRunContext(
  */
 function getRegistry(
   primaryRegistryUri: string,
-  overrideRegistryUri: string,
+  overrideRegistryUris: string[],
   enableProxy: boolean,
 ): IRegistry {
   const logger = rootLogger.child({ module: 'MergedRegistry' });
-  const registries = [primaryRegistryUri, overrideRegistryUri]
+  const registries = [primaryRegistryUri, ...overrideRegistryUris]
     .map((uri) => uri.trim())
     .filter((uri) => !!uri)
     .map((uri, index) => {

--- a/typescript/cli/src/context/types.ts
+++ b/typescript/cli/src/context/types.ts
@@ -11,7 +11,7 @@ import type {
 
 export interface ContextSettings {
   registryUri: string;
-  registryOverrideUri: string;
+  registryOverrideUris: string[];
   key?: string;
   fromAddress?: string;
   requiresKey?: boolean;

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -228,7 +228,7 @@ export async function deployOrUseExistingCore(
 ) {
   const { registry } = await getContext({
     registryUri: REGISTRY_PATH,
-    registryOverrideUri: '',
+    registryOverrideUris: [],
     key,
   });
   const addresses = (await registry.getChainAddresses(chain)) as ChainAddresses;
@@ -247,7 +247,7 @@ export async function getDomainId(
 ): Promise<string> {
   const { registry } = await getContext({
     registryUri: REGISTRY_PATH,
-    registryOverrideUri: '',
+    registryOverrideUris: [],
     key,
   });
   const chainMetadata = await registry.getChainMetadata(chainName);
@@ -261,7 +261,7 @@ export async function deployToken(
 ) {
   const { multiProvider } = await getContext({
     registryUri: REGISTRY_PATH,
-    registryOverrideUri: '',
+    registryOverrideUris: [],
     key: privateKey,
   });
 
@@ -283,7 +283,7 @@ export async function deploy4626Vault(
 ) {
   const { multiProvider } = await getContext({
     registryUri: REGISTRY_PATH,
-    registryOverrideUri: '',
+    registryOverrideUris: [],
     key: privateKey,
   });
 


### PR DESCRIPTION
### Description

Extend `overrides` CLI argument to allow multiple registries to be defined, later override takes priority over previous

```
hyperlane registry list --overrides <path1> --overrides <githubLink>
```

This will allow such configuration option for users;

* Utilize Hyperlane Canonical Github registry for public chain info
* Utilize private Github repository registry for private chain info
* Utilize local registry for private RPC info

works better with https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5223 feature

### Drive-by changes

No

### Related issues

Nothing

### Backward compatibility

Yes

when single argument or none is provided works as usual but allows multiple registries to be defined

### Testing

Manual
