### PR TITLE
feat(release): Upgrade scraper to latest version

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -678,7 +678,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '95deca3-20250120-103609',
+      tag: '359ce5d-20250121-133827',
     },
     resources: scraperResources,
   },


### PR DESCRIPTION
### Description

Upgrade scraper to latest version.

Scraper won't crash if a single RPC is unstable. It will report a critical error.

### Backward compatibility

Yes

### Testing

Deployment