### PR TITLE
feat: make `decimals()` virtual

### DIFF
--- a/solidity/contracts/token/HypERC20.sol
+++ b/solidity/contracts/token/HypERC20.sol
@@ -37,7 +37,7 @@ contract HypERC20 is ERC20Upgradeable, TokenRouter {
         _MailboxClient_initialize(_hook, _interchainSecurityModule, _owner);
     }
 
-    function decimals() public view override returns (uint8) {
+    function decimals() public view virtual override returns (uint8) {
         return _decimals;
     }
 


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
This PR makes the `decimals()` function virtual to allow for further overriding in derived contracts.
### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->
None.

### Related issues

<!--
- Fixes #[issue number here]
-->
N/A.

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

Yes
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
N/A
