### PR TITLE
feat: recurse in safe timelock parser

### DIFF
--- a/typescript/infra/config/environments/mainnet3/owners.ts
+++ b/typescript/infra/config/environments/mainnet3/owners.ts
@@ -8,6 +8,7 @@ import { supportedChainNames } from './supportedChainNames.js';
 
 export const timelocks: ChainMap<Address | undefined> = {
   arbitrum: '0xAC98b0cD1B64EA4fe133C6D2EDaf842cE5cF4b01',
+  ethereum: '0x59cf937Ea9FA9D7398223E3aA33d92F7f5f986A2', // symbiotic network timelock
 };
 
 export function localAccountRouters(): ChainMap<Address> {

--- a/typescript/infra/src/tx/govern-transaction-reader.ts
+++ b/typescript/infra/src/tx/govern-transaction-reader.ts
@@ -202,8 +202,16 @@ export class GovernTransactionReader {
         'schedule(address,uint256,bytes,bytes32,bytes32,uint256)'
       ].name
     ) {
-      const [target, value, data, eta, executor, delay] = decoded.args;
-      insight = `Schedule ${target} to be executed at ${eta} with ${value} ${data}. Executor: ${executor}, Delay: ${delay}`;
+      const [target, value, data, _predecessor, _salt, delay] = decoded.args;
+      const inner = await this.read(chain, {
+        to: target,
+        data,
+        value,
+      });
+
+      const eta = new Date(Date.now() + delay.toNumber() * 1000);
+
+      insight = `Schedule for ${eta}: ${JSON.stringify(inner)}`;
     }
 
     if (


### PR DESCRIPTION
### Description

Parse inner transactions on timelocks

### Testing

Manual

```sh
$ yarn tsx scripts/safes/parse-txs.ts --chains ethereum
```

```yaml
ethereum-0xc096af73952e18fe1201b457a95b598d680d7f185747b28153da2c175532ca8f:
  chain: ethereum
  to: Timelock Controller (ethereum 0x59cf937Ea9FA9D7398223E3aA33d92F7f5f986A2)
  insight: 'Schedule for Sun Jan 26 2025 18:05:17 GMT-0500 (Eastern Standard
    Time): {"chain":"ethereum","to":"Timelock Controller (ethereum
    0x59cf937Ea9FA9D7398223E3aA33d92F7f5f986A2)","args":{"newDelay":{"type":"BigNumber","hex":"0x00"}}}'
```
