### PR TITLE
chore: Upgrade validators in hyperlane context to f6b682c-20250124-144126

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -681,7 +681,7 @@ const hyperlane: RootAgentConfig = {
   validators: {
     docker: {
       repo,
-      tag: '7eec2ac-20250123-193619',
+      tag: 'f6b682c-20250124-144126',
     },
     rpcConsensusType: RpcConsensusType.Quorum,
     chains: validatorChainConfig(Contexts.Hyperlane),


### PR DESCRIPTION
### Description

Upgrade validators in hyperlane context to f6b682c-20250124-144126

### Backward compatibility

Yes

### Testing

E2E tests in CI
