### PR TITLE
feat: add rivalz to the solanamainnet IGP

### DIFF
--- a/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
+++ b/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
@@ -1,17 +1,9 @@
 {
   "solanamainnet": {
-    "trumpchain": {
-      "oracleConfig": {
-        "tokenExchangeRate": "4545000000000000000",
-        "gasPrice": "11271716004",
-        "tokenDecimals": 18
-      },
-      "overhead": 166887
-    },
-    "optimism": {
+    "rivalz": {
       "oracleConfig": {
         "tokenExchangeRate": "263105000000000000000",
-        "gasPrice": "486782274",
+        "gasPrice": "194712945",
         "tokenDecimals": 18
       },
       "overhead": 166887
@@ -68,6 +60,22 @@
       "oracleConfig": {
         "tokenExchangeRate": "263105000000000000000",
         "gasPrice": "194712945",
+        "tokenDecimals": 18
+      },
+      "overhead": 166887
+    },
+    "optimism": {
+      "oracleConfig": {
+        "tokenExchangeRate": "263105000000000000000",
+        "gasPrice": "486782274",
+        "tokenDecimals": 18
+      },
+      "overhead": 166887
+    },
+    "trumpchain": {
+      "oracleConfig": {
+        "tokenExchangeRate": "4545000000000000000",
+        "gasPrice": "11271716004",
         "tokenDecimals": 18
       },
       "overhead": 166887

--- a/typescript/infra/scripts/sealevel-helpers/print-gas-oracles.ts
+++ b/typescript/infra/scripts/sealevel-helpers/print-gas-oracles.ts
@@ -98,12 +98,8 @@ function getChainConnections(
   if (environment === 'mainnet3') {
     // All the mainnet3 warp route chains
     connectedChains = [
-      // Some branch juggling for the new TRUMP route temporarily
-      // requires these chains to be hardcoded:
-      // TRUMP/solanamainnet-trumpchain
-      ['solanamainnet', 'trumpchain'],
-      // For the massive TRUMP warp route, which is undergoing an extension atm
-      ['solanamainnet', 'optimism'],
+      // For the Rivalz team building out their own warp route
+      ['solanamainnet', 'rivalz'],
       // All warp routes
       ...Object.values(WarpRouteIds).map(getWarpChains),
     ];


### PR DESCRIPTION
### Description

- Rivalz deployed their own warp route and needs this to test
- The optimism & trumpchain change was already applied, but I think was lost somewhere in the branch juggle. As the warp route has been updated in the registry, we no longer need the explicit handling

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
