### PR TITLE
feat: make `initialize` function public virtual

### DIFF
--- a/.changeset/fast-comics-wave.md
+++ b/.changeset/fast-comics-wave.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": patch
+---
+
+Make `initialize` function public virtual

--- a/solidity/contracts/token/HypERC20.sol
+++ b/solidity/contracts/token/HypERC20.sol
@@ -30,7 +30,7 @@ contract HypERC20 is ERC20Upgradeable, TokenRouter {
         address _hook,
         address _interchainSecurityModule,
         address _owner
-    ) external initializer {
+    ) public virtual initializer {
         // Initialize ERC20 metadata
         __ERC20_init(_name, _symbol);
         _mint(msg.sender, _totalSupply);


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
This PR makes the `initialize` function public and virtual to allow for further overriding in derived contracts.
### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->
None.

### Related issues

<!--
- Fixes #[issue number here]
-->
N/A.

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

Yes
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
N/A
