### PR TITLE
fix: isolate upgrade and symbiotic timelocks

### DIFF
--- a/typescript/infra/config/environments/mainnet3/owners.ts
+++ b/typescript/infra/config/environments/mainnet3/owners.ts
@@ -6,8 +6,12 @@ import { getMainnetAddresses } from '../../registry.js';
 import { ethereumChainNames } from './chains.js';
 import { supportedChainNames } from './supportedChainNames.js';
 
-export const timelocks: ChainMap<Address | undefined> = {
+export const upgradeTimelocks: ChainMap<Address | undefined> = {
   arbitrum: '0xAC98b0cD1B64EA4fe133C6D2EDaf842cE5cF4b01',
+};
+
+export const timelocks: ChainMap<Address> = {
+  ...upgradeTimelocks,
   ethereum: '0x59cf937Ea9FA9D7398223E3aA33d92F7f5f986A2', // symbiotic network timelock
 };
 
@@ -211,7 +215,7 @@ export const ethereumChainOwners: ChainMap<OwnableConfig> = Object.fromEntries(
       {
         owner,
         ownerOverrides: {
-          proxyAdmin: timelocks[local] ?? owner,
+          proxyAdmin: upgradeTimelocks[local] ?? owner,
           validatorAnnounce: DEPLOYER, // unused
           testRecipient: DEPLOYER,
           fallbackRoutingHook: DEPLOYER,


### PR DESCRIPTION
### Description

Checkers would expect proxyAdmin/upgrades to be gated by ethereum timelock added in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5278

### Backward compatibility

Yes

### Testing

Manual/cron
