### PR TITLE
feat: SVM agents - use the transaction submission URL for polling tx status

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -490,12 +490,10 @@ impl Mailbox for SealevelMailbox {
 
         let send_instant = std::time::Instant::now();
 
+        let rpc = self.tx_submitter.rpc_client().unwrap_or_else(|| self.rpc());
+
         // Wait for the transaction to be confirmed.
-        self.tx_submitter
-            .rpc_client()
-            .unwrap_or_else(|| self.rpc())
-            .wait_for_transaction_confirmation(&tx)
-            .await?;
+        rpc.wait_for_transaction_confirmation(&tx).await?;
 
         // We expect time_to_confirm to fluctuate depending on the commitment level when submitting the
         // tx, but still use it as a proxy for tx latency to help debug.
@@ -503,8 +501,7 @@ impl Mailbox for SealevelMailbox {
 
         // TODO: not sure if this actually checks if the transaction was executed / reverted?
         // Confirm the transaction.
-        let executed = self
-            .rpc()
+        let executed = rpc
             .confirm_transaction_with_commitment(&signature, commitment)
             .await
             .map_err(|err| warn!("Failed to confirm inbox process transaction: {}", err))

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -493,7 +493,7 @@ impl Mailbox for SealevelMailbox {
         // Wait for the transaction to be confirmed.
         self.tx_submitter
             .rpc_client()
-            .unwrap_or(self.rpc())
+            .unwrap_or_else(|| self.rpc())
             .wait_for_transaction_confirmation(&tx)
             .await?;
 

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -491,7 +491,11 @@ impl Mailbox for SealevelMailbox {
         let send_instant = std::time::Instant::now();
 
         // Wait for the transaction to be confirmed.
-        self.rpc().wait_for_transaction_confirmation(&tx).await?;
+        self.tx_submitter
+            .rpc_client()
+            .unwrap_or(self.rpc())
+            .wait_for_transaction_confirmation(&tx)
+            .await?;
 
         // We expect time_to_confirm to fluctuate depending on the commitment level when submitting the
         // tx, but still use it as a proxy for tx latency to help debug.

--- a/rust/main/chains/hyperlane-sealevel/src/tx_submitter.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/tx_submitter.rs
@@ -24,6 +24,10 @@ pub trait TransactionSubmitter: Send + Sync {
         transaction: &Transaction,
         skip_preflight: bool,
     ) -> ChainResult<Signature>;
+
+    fn rpc_client(&self) -> Option<&SealevelRpcClient> {
+        None
+    }
 }
 
 /// A transaction submitter that uses the vanilla RPC to submit transactions.
@@ -59,6 +63,10 @@ impl TransactionSubmitter for RpcTransactionSubmitter {
         self.rpc_client
             .send_transaction(transaction, skip_preflight)
             .await
+    }
+
+    fn rpc_client(&self) -> Option<&SealevelRpcClient> {
+        Some(&self.rpc_client)
     }
 }
 

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -671,7 +671,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'f6b682c-20250124-144126',
+      tag: 'a54c98e-20250126-113529',
     },
     blacklist,
     gasPaymentEnforcement: gasPaymentEnforcement,


### PR DESCRIPTION
### Description

- context: https://discord.com/channels/935678348330434570/1333035743622336614
- uses the RPC URL used for tx submission (if it's possible) to poll tx status. We use a Helius tx submission URL on solana mainnet so this now uses Helius for polling the status as well

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
