### PR TITLE
feat: Improve usability of Token.FromChainMetadataNativeToken

### DIFF
--- a/.changeset/selfish-drinks-add.md
+++ b/.changeset/selfish-drinks-add.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Improve usability of Token.FromChainMetadataNativeToken

--- a/typescript/sdk/src/token/Token.ts
+++ b/typescript/sdk/src/token/Token.ts
@@ -59,6 +59,7 @@ import {
   SealevelNativeTokenAdapter,
   SealevelTokenAdapter,
 } from './adapters/SealevelTokenAdapter.js';
+import { PROTOCOL_TO_DEFAULT_NATIVE_TOKEN } from './nativeTokenMetadata.js';
 
 // Declaring the interface in addition to class allows
 // Typescript to infer the members vars from TokenArgs
@@ -72,12 +73,15 @@ export class Token implements IToken {
     this.protocol = TOKEN_STANDARD_TO_PROTOCOL[this.standard];
   }
 
+  /**
+   * Creates a Token for the native currency on the given chain.
+   * Will use the default native token for the given protocol if
+   * nothing specific is set in the ChainMetadata.
+   */
   static FromChainMetadataNativeToken(chainMetadata: ChainMetadata): Token {
-    const { protocol, name: chainName, nativeToken, logoURI } = chainMetadata;
-    assert(
-      nativeToken,
-      `ChainMetadata for ${chainMetadata.name} missing nativeToken`,
-    );
+    const { protocol, name: chainName, logoURI } = chainMetadata;
+    const nativeToken =
+      chainMetadata.nativeToken || PROTOCOL_TO_DEFAULT_NATIVE_TOKEN[protocol];
 
     return new Token({
       chainName,

--- a/typescript/sdk/src/token/nativeTokenMetadata.ts
+++ b/typescript/sdk/src/token/nativeTokenMetadata.ts
@@ -1,0 +1,25 @@
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { NativeToken } from '../metadata/chainMetadataTypes.js';
+
+export const PROTOCOL_TO_DEFAULT_NATIVE_TOKEN: Record<
+  ProtocolType,
+  NativeToken
+> = {
+  [ProtocolType.Ethereum]: {
+    decimals: 18,
+    name: 'Ether',
+    symbol: 'ETH',
+  },
+  [ProtocolType.Sealevel]: {
+    decimals: 9,
+    name: 'Solana',
+    symbol: 'SOL',
+  },
+  [ProtocolType.Cosmos]: {
+    decimals: 6,
+    denom: 'uatom',
+    name: 'Atom',
+    symbol: 'ATOM',
+  },
+};


### PR DESCRIPTION
### Description

Improve Token.FromChainMetadataNativeToken by having it fallback to default `nativeToken` metadata if it hasn't been set in the `chainMetadata`. This is useful because `nativeToken` is optional and it's relatively safe because pretty much only the `decimals` value is important in cases where this is used.
