### PR TITLE
feat: fix exposed private key in logs

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/interchain_security_module.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/interchain_security_module.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use num_traits::cast::FromPrimitive;
-use solana_sdk::{instruction::Instruction, pubkey::Pubkey, signature::Keypair};
+use solana_sdk::{instruction::Instruction, pubkey::Pubkey, signature::Keypair, signer::Signer};
 use tracing::warn;
 
 use hyperlane_core::{
@@ -13,7 +13,6 @@ use serializable_account_meta::SimulationReturnData;
 use crate::{ConnectionConf, SealevelProvider, SealevelRpcClient};
 
 /// A reference to an InterchainSecurityModule contract on some Sealevel chain
-#[derive(Debug)]
 pub struct SealevelInterchainSecurityModule {
     payer: Option<Keypair>,
     program_id: Pubkey,
@@ -93,5 +92,81 @@ impl InterchainSecurityModule for SealevelInterchainSecurityModule {
     ) -> ChainResult<Option<U256>> {
         // TODO: Implement this once we have aggregation ISM support in Sealevel
         Ok(Some(U256::zero()))
+    }
+}
+
+impl std::fmt::Debug for SealevelInterchainSecurityModule {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[allow(dead_code)]
+        #[derive(Debug)]
+        struct PublicKey {
+            base58_pubkey: String,
+        }
+
+        #[allow(dead_code)]
+        #[derive(Debug)]
+        struct SealevelInterchainSecurityModule<'a> {
+            payer: Option<PublicKey>,
+            program_id: &'a Pubkey,
+            provider: &'a SealevelProvider,
+        }
+
+        let payer = self.payer.as_ref().map(|s| PublicKey {
+            base58_pubkey: s.pubkey().to_string(),
+        });
+        let val = SealevelInterchainSecurityModule {
+            payer,
+            program_id: &self.program_id,
+            provider: &self.provider,
+        };
+        std::fmt::Debug::fmt(&val, f)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use hyperlane_core::{
+        config::OperationBatchConfig, HyperlaneDomain, KnownHyperlaneDomain, NativeToken,
+    };
+    use solana_sdk::{signature::Keypair, signer::Signer};
+    use url::Url;
+
+    use crate::{
+        ConnectionConf, PriorityFeeOracleConfig, SealevelProvider, TransactionSubmitterConfig,
+    };
+
+    use super::SealevelInterchainSecurityModule;
+
+    #[test]
+    fn test_no_exposed_secret_key() {
+        let priv_key = "2ckDxzDFpZGeWd7VbHzd6dMgxYpqVDPA8XzeXFuuUJ1K8CjtyTBenD1TSPPovahXEFw3kBihoyAKktyro22MP4bN";
+        let pub_key = "6oKnHXD2LRzQ4iNsgvkGSNNx68vj5GCYYpR2icy5JZhE";
+
+        let keypair = Keypair::from_base58_string(priv_key);
+
+        let program_id = keypair.pubkey();
+
+        let value = SealevelInterchainSecurityModule {
+            payer: Some(keypair),
+            program_id,
+            provider: SealevelProvider::new(
+                HyperlaneDomain::Known(KnownHyperlaneDomain::SolanaMainnet),
+                &ConnectionConf {
+                    url: Url::from_str("https://solscan.io").expect("Failed to parse URL"),
+                    operation_batch: OperationBatchConfig::default(),
+                    native_token: NativeToken::default(),
+                    priority_fee_oracle: PriorityFeeOracleConfig::Constant(0),
+                    transaction_submitter: TransactionSubmitterConfig::Rpc { url: None },
+                },
+            ),
+        };
+
+        let expected = format!(
+            r#"SealevelInterchainSecurityModule {{ payer: Some(PublicKey {{ base58_pubkey: "{pub_key}" }}), program_id: {pub_key}, provider: SealevelProvider {{ domain: HyperlaneDomain(solanamainnet (1399811149)), rpc_client: RpcClient {{ ... }}, native_token: NativeToken {{ decimals: 0, denom: "" }} }} }}"#
+        );
+        let actual = format!("{:?}", value);
+        assert_eq!(expected, actual);
     }
 }

--- a/rust/main/chains/hyperlane-sealevel/src/interchain_security_module.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/interchain_security_module.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use num_traits::cast::FromPrimitive;
-use solana_sdk::{instruction::Instruction, pubkey::Pubkey, signature::Keypair, signer::Signer};
+use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
 use tracing::warn;
 
 use hyperlane_core::{
@@ -10,18 +10,23 @@ use hyperlane_core::{
 use hyperlane_sealevel_interchain_security_module_interface::InterchainSecurityModuleInstruction;
 use serializable_account_meta::SimulationReturnData;
 
-use crate::{ConnectionConf, SealevelProvider, SealevelRpcClient};
+use crate::{ConnectionConf, SealevelKeypair, SealevelProvider, SealevelRpcClient};
 
 /// A reference to an InterchainSecurityModule contract on some Sealevel chain
+#[derive(Debug)]
 pub struct SealevelInterchainSecurityModule {
-    payer: Option<Keypair>,
+    payer: Option<SealevelKeypair>,
     program_id: Pubkey,
     provider: SealevelProvider,
 }
 
 impl SealevelInterchainSecurityModule {
     /// Create a new sealevel InterchainSecurityModule
-    pub fn new(conf: &ConnectionConf, locator: ContractLocator, payer: Option<Keypair>) -> Self {
+    pub fn new(
+        conf: &ConnectionConf,
+        locator: ContractLocator,
+        payer: Option<SealevelKeypair>,
+    ) -> Self {
         let provider = SealevelProvider::new(locator.domain.clone(), conf);
         let program_id = Pubkey::from(<[u8; 32]>::from(locator.address));
         Self {
@@ -92,81 +97,5 @@ impl InterchainSecurityModule for SealevelInterchainSecurityModule {
     ) -> ChainResult<Option<U256>> {
         // TODO: Implement this once we have aggregation ISM support in Sealevel
         Ok(Some(U256::zero()))
-    }
-}
-
-impl std::fmt::Debug for SealevelInterchainSecurityModule {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        #[allow(dead_code)]
-        #[derive(Debug)]
-        struct PublicKey {
-            base58_pubkey: String,
-        }
-
-        #[allow(dead_code)]
-        #[derive(Debug)]
-        struct SealevelInterchainSecurityModule<'a> {
-            payer: Option<PublicKey>,
-            program_id: &'a Pubkey,
-            provider: &'a SealevelProvider,
-        }
-
-        let payer = self.payer.as_ref().map(|s| PublicKey {
-            base58_pubkey: s.pubkey().to_string(),
-        });
-        let val = SealevelInterchainSecurityModule {
-            payer,
-            program_id: &self.program_id,
-            provider: &self.provider,
-        };
-        std::fmt::Debug::fmt(&val, f)
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use std::str::FromStr;
-
-    use hyperlane_core::{
-        config::OperationBatchConfig, HyperlaneDomain, KnownHyperlaneDomain, NativeToken,
-    };
-    use solana_sdk::{signature::Keypair, signer::Signer};
-    use url::Url;
-
-    use crate::{
-        ConnectionConf, PriorityFeeOracleConfig, SealevelProvider, TransactionSubmitterConfig,
-    };
-
-    use super::SealevelInterchainSecurityModule;
-
-    #[test]
-    fn test_no_exposed_secret_key() {
-        let priv_key = "2ckDxzDFpZGeWd7VbHzd6dMgxYpqVDPA8XzeXFuuUJ1K8CjtyTBenD1TSPPovahXEFw3kBihoyAKktyro22MP4bN";
-        let pub_key = "6oKnHXD2LRzQ4iNsgvkGSNNx68vj5GCYYpR2icy5JZhE";
-
-        let keypair = Keypair::from_base58_string(priv_key);
-
-        let program_id = keypair.pubkey();
-
-        let value = SealevelInterchainSecurityModule {
-            payer: Some(keypair),
-            program_id,
-            provider: SealevelProvider::new(
-                HyperlaneDomain::Known(KnownHyperlaneDomain::SolanaMainnet),
-                &ConnectionConf {
-                    url: Url::from_str("https://solscan.io").expect("Failed to parse URL"),
-                    operation_batch: OperationBatchConfig::default(),
-                    native_token: NativeToken::default(),
-                    priority_fee_oracle: PriorityFeeOracleConfig::Constant(0),
-                    transaction_submitter: TransactionSubmitterConfig::Rpc { url: None },
-                },
-            ),
-        };
-
-        let expected = format!(
-            r#"SealevelInterchainSecurityModule {{ payer: Some(PublicKey {{ base58_pubkey: "{pub_key}" }}), program_id: {pub_key}, provider: SealevelProvider {{ domain: HyperlaneDomain(solanamainnet (1399811149)), rpc_client: RpcClient {{ ... }}, native_token: NativeToken {{ decimals: 0, denom: "" }} }} }}"#
-        );
-        let actual = format!("{:?}", value);
-        assert_eq!(expected, actual);
     }
 }

--- a/rust/main/chains/hyperlane-sealevel/src/keypair.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/keypair.rs
@@ -1,0 +1,41 @@
+use solana_sdk::{signature::Keypair, signer::Signer};
+
+/// Wrapper around solana_sdk's Keypair.
+/// This implments a custom Debug so the private keys are
+/// not exposed.
+pub struct SealevelKeypair(pub Keypair);
+
+impl SealevelKeypair {
+    /// create new SealevelKeypair
+    pub fn new(keypair: Keypair) -> Self {
+        Self(keypair)
+    }
+    /// Return the underlying keypair
+    pub fn keypair(&self) -> &Keypair {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for SealevelKeypair {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.pubkey().to_string())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use solana_sdk::signature::Keypair;
+
+    use super::SealevelKeypair;
+
+    #[test]
+    fn test_no_exposed_secret_key() {
+        let priv_key = "2ckDxzDFpZGeWd7VbHzd6dMgxYpqVDPA8XzeXFuuUJ1K8CjtyTBenD1TSPPovahXEFw3kBihoyAKktyro22MP4bN";
+        let pub_key = "6oKnHXD2LRzQ4iNsgvkGSNNx68vj5GCYYpR2icy5JZhE";
+
+        let keypair = SealevelKeypair(Keypair::from_base58_string(priv_key));
+
+        let actual = format!("{:?}", keypair);
+        assert_eq!(pub_key, actual);
+    }
+}

--- a/rust/main/chains/hyperlane-sealevel/src/lib.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/lib.rs
@@ -7,6 +7,7 @@
 pub use crate::multisig_ism::*;
 pub use interchain_gas::*;
 pub use interchain_security_module::*;
+pub use keypair::*;
 pub use mailbox::*;
 pub use merkle_tree_hook::*;
 pub use provider::*;
@@ -19,6 +20,7 @@ mod account;
 mod error;
 mod interchain_gas;
 mod interchain_security_module;
+mod keypair;
 mod log_meta_composer;
 mod mailbox;
 mod merkle_tree_hook;

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -29,7 +29,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
-    signer::{keypair::Keypair, Signer as _},
+    signer::Signer as _,
 };
 use tracing::{debug, info, instrument, warn};
 
@@ -40,13 +40,16 @@ use hyperlane_core::{
     ReorgPeriod, SequenceAwareIndexer, TxCostEstimate, TxOutcome, H256, H512, U256,
 };
 
-use crate::log_meta_composer::{
-    is_message_delivery_instruction, is_message_dispatch_instruction, LogMetaComposer,
-};
 use crate::tx_submitter::TransactionSubmitter;
 use crate::{
     account::{search_accounts_by_discriminator, search_and_validate_account},
     priority_fee::PriorityFeeOracle,
+};
+use crate::{
+    log_meta_composer::{
+        is_message_delivery_instruction, is_message_dispatch_instruction, LogMetaComposer,
+    },
+    SealevelKeypair,
 };
 use crate::{ConnectionConf, SealevelProvider, SealevelRpcClient};
 
@@ -79,7 +82,7 @@ pub struct SealevelMailbox {
     inbox: (Pubkey, u8),
     pub(crate) outbox: (Pubkey, u8),
     pub(crate) provider: SealevelProvider,
-    payer: Option<Keypair>,
+    payer: Option<SealevelKeypair>,
     priority_fee_oracle: Box<dyn PriorityFeeOracle>,
     tx_submitter: Box<dyn TransactionSubmitter>,
 }
@@ -89,7 +92,7 @@ impl SealevelMailbox {
     pub fn new(
         conf: &ConnectionConf,
         locator: ContractLocator,
-        payer: Option<Keypair>,
+        payer: Option<SealevelKeypair>,
     ) -> ChainResult<Self> {
         let provider = SealevelProvider::new(locator.domain.clone(), conf);
         let program_id = Pubkey::from(<[u8; 32]>::from(locator.address));
@@ -334,7 +337,7 @@ impl SealevelMailbox {
 
         // Craft the accounts for the transaction.
         let mut accounts: Vec<AccountMeta> = vec![
-            AccountMeta::new_readonly(payer.pubkey(), true),
+            AccountMeta::new_readonly(payer.keypair().pubkey(), true),
             AccountMeta::new_readonly(Pubkey::from_str(SYSTEM_PROGRAM).unwrap(), false),
             AccountMeta::new(self.inbox.0, false),
             AccountMeta::new_readonly(process_authority_key, false),
@@ -379,7 +382,7 @@ impl SealevelMailbox {
         Ok(inbox)
     }
 
-    fn get_payer(&self) -> ChainResult<&Keypair> {
+    fn get_payer(&self) -> ChainResult<&SealevelKeypair> {
         self.payer
             .as_ref()
             .ok_or_else(|| ChainCommunicationError::SignerUnavailable)

--- a/rust/main/chains/hyperlane-sealevel/src/multisig_ism.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/multisig_ism.rs
@@ -8,10 +8,9 @@ use serializable_account_meta::SimulationReturnData;
 use solana_sdk::{
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
-    signature::Keypair,
 };
 
-use crate::{ConnectionConf, SealevelProvider, SealevelRpcClient};
+use crate::{ConnectionConf, SealevelKeypair, SealevelProvider, SealevelRpcClient};
 
 use multisig_ism::interface::{
     MultisigIsmInstruction, VALIDATORS_AND_THRESHOLD_ACCOUNT_METAS_PDA_SEEDS,
@@ -20,7 +19,7 @@ use multisig_ism::interface::{
 /// A reference to a MultisigIsm contract on some Sealevel chain
 #[derive(Debug)]
 pub struct SealevelMultisigIsm {
-    payer: Option<Keypair>,
+    payer: Option<SealevelKeypair>,
     program_id: Pubkey,
     domain: HyperlaneDomain,
     provider: SealevelProvider,
@@ -28,7 +27,11 @@ pub struct SealevelMultisigIsm {
 
 impl SealevelMultisigIsm {
     /// Create a new Sealevel MultisigIsm.
-    pub fn new(conf: &ConnectionConf, locator: ContractLocator, payer: Option<Keypair>) -> Self {
+    pub fn new(
+        conf: &ConnectionConf,
+        locator: ContractLocator,
+        payer: Option<SealevelKeypair>,
+    ) -> Self {
         let provider = SealevelProvider::new(locator.domain.clone(), conf);
         let program_id = Pubkey::from(<[u8; 32]>::from(locator.address));
 

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -240,9 +240,13 @@ impl ChainConf {
             }
             ChainConnectionConf::Sealevel(conf) => {
                 let keypair = self.sealevel_signer().await.context(ctx)?;
-                h_sealevel::SealevelMailbox::new(conf, locator, keypair)
-                    .map(|m| Box::new(m) as Box<dyn Mailbox>)
-                    .map_err(Into::into)
+                h_sealevel::SealevelMailbox::new(
+                    conf,
+                    locator,
+                    keypair.map(|k| h_sealevel::SealevelKeypair::new(k)),
+                )
+                .map(|m| Box::new(m) as Box<dyn Mailbox>)
+                .map_err(Into::into)
             }
             ChainConnectionConf::Cosmos(conf) => {
                 let signer = self.cosmos_signer().await.context(ctx)?;
@@ -568,7 +572,9 @@ impl ChainConf {
             ChainConnectionConf::Sealevel(conf) => {
                 let keypair = self.sealevel_signer().await.context(ctx)?;
                 let ism = Box::new(h_sealevel::SealevelInterchainSecurityModule::new(
-                    conf, locator, keypair,
+                    conf,
+                    locator,
+                    keypair.map(|k| h_sealevel::SealevelKeypair::new(k)),
                 ));
                 Ok(ism as Box<dyn InterchainSecurityModule>)
             }
@@ -601,7 +607,11 @@ impl ChainConf {
             ChainConnectionConf::Fuel(_) => todo!(),
             ChainConnectionConf::Sealevel(conf) => {
                 let keypair = self.sealevel_signer().await.context(ctx)?;
-                let ism = Box::new(h_sealevel::SealevelMultisigIsm::new(conf, locator, keypair));
+                let ism = Box::new(h_sealevel::SealevelMultisigIsm::new(
+                    conf,
+                    locator,
+                    keypair.map(|k| h_sealevel::SealevelKeypair::new(k)),
+                ));
                 Ok(ism as Box<dyn MultisigIsm>)
             }
             ChainConnectionConf::Cosmos(conf) => {


### PR DESCRIPTION
### Description

Initially I was thinking of just reimplementing Debug for `SealevelInterchainSecurityModule`, but I saw that keypair is used in many different places.
So I think this solution is a bit more permanent. Having a wrapper around Solana's Keypair with a custom Debug function.

### Drive-by changes

### Related issues

### Backward compatibility

yes

### Testing

Added unittest to test debug functionality