### PR TITLE
refactor: remove mailbox from warp config

### DIFF
--- a/typescript/cli/src/tests/warp/warp-init.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-init.e2e-test.ts
@@ -1,12 +1,10 @@
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
 
-import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
-  ChainMap,
   ChainName,
   TokenType,
-  WarpRouteDeployConfig,
+  WarpRouteDeployConfigWithoutMailbox,
 } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 
@@ -16,7 +14,6 @@ import {
   CHAIN_NAME_2,
   CHAIN_NAME_3,
   CONFIRM_DETECTED_OWNER_STEP,
-  CORE_CONFIG_PATH,
   DEFAULT_E2E_TEST_TIMEOUT,
   KeyBoardKeys,
   SELECT_ANVIL_2_AND_ANVIL_3_STEPS,
@@ -24,7 +21,6 @@ import {
   SELECT_MAINNET_CHAIN_TYPE_STEP,
   TestPromptAction,
   WARP_CONFIG_PATH_2,
-  deployOrUseExistingCore,
   deployToken,
   handlePrompts,
 } from '../commands/helpers.js';
@@ -33,38 +29,21 @@ import { hyperlaneWarpInit } from '../commands/warp.js';
 describe('hyperlane warp init e2e tests', async function () {
   this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
 
-  let chain2Addresses: ChainAddresses = {};
-  let chain3Addresses: ChainAddresses = {};
   let initialOwnerAddress: Address;
-  let chainMapAddresses: ChainMap<ChainAddresses> = {};
 
   before(async function () {
-    [chain2Addresses, chain3Addresses] = await Promise.all([
-      deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY),
-      deployOrUseExistingCore(CHAIN_NAME_3, CORE_CONFIG_PATH, ANVIL_KEY),
-    ]);
-
-    chainMapAddresses = {
-      [CHAIN_NAME_2]: chain2Addresses,
-      [CHAIN_NAME_3]: chain3Addresses,
-    };
-
     const wallet = new Wallet(ANVIL_KEY);
     initialOwnerAddress = wallet.address;
   });
 
   describe('hyperlane warp init --yes', () => {
     function assertWarpConfig(
-      warpConfig: WarpRouteDeployConfig,
-      chainMapAddresses: ChainMap<ChainAddresses>,
+      warpConfig: WarpRouteDeployConfigWithoutMailbox,
       chainName: ChainName,
     ) {
       expect(warpConfig[chainName]).not.to.be.undefined;
 
       const chain2TokenConfig = warpConfig[chainName];
-      expect(chain2TokenConfig.mailbox).equal(
-        chainMapAddresses[chainName].mailbox,
-      );
       expect(chain2TokenConfig.owner).equal(initialOwnerAddress);
       expect(chain2TokenConfig.type).equal(TokenType.native);
     }
@@ -91,10 +70,10 @@ describe('hyperlane warp init e2e tests', async function () {
 
       await handlePrompts(output, steps);
 
-      const warpConfig: WarpRouteDeployConfig =
+      const warpConfig: WarpRouteDeployConfigWithoutMailbox =
         readYamlOrJson(WARP_CONFIG_PATH_2);
 
-      assertWarpConfig(warpConfig, chainMapAddresses, CHAIN_NAME_2);
+      assertWarpConfig(warpConfig, CHAIN_NAME_2);
     });
 
     it('it should generate a warp deploy config with a 2 chains warp route (native->native)', async function () {
@@ -119,11 +98,11 @@ describe('hyperlane warp init e2e tests', async function () {
 
       await handlePrompts(output, steps);
 
-      const warpConfig: WarpRouteDeployConfig =
+      const warpConfig: WarpRouteDeployConfigWithoutMailbox =
         readYamlOrJson(WARP_CONFIG_PATH_2);
 
       [CHAIN_NAME_2, CHAIN_NAME_3].map((chainName) =>
-        assertWarpConfig(warpConfig, chainMapAddresses, chainName),
+        assertWarpConfig(warpConfig, chainName),
       );
     });
 
@@ -159,13 +138,12 @@ describe('hyperlane warp init e2e tests', async function () {
 
       await handlePrompts(output, steps);
 
-      const warpConfig: WarpRouteDeployConfig =
+      const warpConfig: WarpRouteDeployConfigWithoutMailbox =
         readYamlOrJson(WARP_CONFIG_PATH_2);
 
       expect(warpConfig[CHAIN_NAME_2]).not.to.be.undefined;
 
       const chain2TokenConfig = warpConfig[CHAIN_NAME_2];
-      expect(chain2TokenConfig.mailbox).equal(chain2Addresses.mailbox);
       expect(chain2TokenConfig.owner).equal(initialOwnerAddress);
       expect(chain2TokenConfig.type).equal(TokenType.collateral);
       expect((chain2TokenConfig as any).token).equal(erc20Token.address);
@@ -173,7 +151,6 @@ describe('hyperlane warp init e2e tests', async function () {
       expect(warpConfig[CHAIN_NAME_3]).not.to.be.undefined;
 
       const chain3TokenConfig = warpConfig[CHAIN_NAME_3];
-      expect(chain3TokenConfig.mailbox).equal(chain3Addresses.mailbox);
       expect(chain3TokenConfig.owner).equal(initialOwnerAddress);
       expect(chain3TokenConfig.type).equal(TokenType.synthetic);
     });

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -587,6 +587,8 @@ export {
   WarpRouteDeployConfig,
   WarpRouteDeployConfigSchema,
   WarpRouteDeployConfigSchemaErrors,
+  WarpRouteDeployConfigWithoutMailbox,
+  WarpRouteDeployConfigSchemaWithoutMailbox,
 } from './token/types.js';
 export {
   ChainMap,


### PR DESCRIPTION
### Description
Refactors Warp Route configuration to make mailbox addresses optional during initial config creation. This change separates the mailbox configuration from the base token configuration, introducing new types `WarpRouteDeployConfigWithoutMailbox` and `HypTokenRouterConfigWithoutMailbox`. This improves the configuration workflow by allowing more flexible mailbox address handling.

### Drive-by changes
- Extracted common refinement and transformation logic into separate functions for better code organization
- Improved type safety in configuration validation functions
- Removed unused `isAddress` import

### Related issues
https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5237
https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5258

### Backward compatibility
Yes - This change maintains backward compatibility while providing more flexibility in configuration
