### PR TITLE
fix: filter undefined factory addresses

### DIFF
--- a/.changeset/late-fishes-end.md
+++ b/.changeset/late-fishes-end.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Fix contract address filtering to remove undefined factory addresses from the addresses map

--- a/typescript/sdk/src/contracts/contracts.ts
+++ b/typescript/sdk/src/contracts/contracts.ts
@@ -58,9 +58,12 @@ export function filterAddressesMap<F extends HyperlaneFactories>(
   factories: F,
 ): HyperlaneAddressesMap<F> {
   const factoryKeys = Object.keys(factories);
-  // Filter out addresses that we do not have factories for
+  // Filter out addresses that we do not have factories for and remove undefined values
   const pickedAddressesMap = objMap(addressesMap, (_, addresses) =>
-    pick(addresses, factoryKeys),
+    objFilter(
+      pick(addresses, factoryKeys),
+      (_, value): value is Address => value !== undefined,
+    ),
   );
   // Filter out chains for which we do not have a complete set of addresses
   return objFilter(


### PR DESCRIPTION
### Description

When deploying Hyperlane contracts using `warp deploy`, the core addresses obtained using older version of `core deploy` may not include addresses of newer factories (`staticMessageIdWeightedMultisigIsmFactory` and `staticMessageIdWeightedMultisigIsmFactory`). These `undefined` addresses would cause warp deploy to fail, even though they aren't absolutely necessary for warping. 

This fix handles undefined factory addresses that are filtered out during `warp deploy`. This way, warp deploy can proceed the weighted factories, and users won't have to pay gas fees for core deployment once again to.

Attached LogX chain core deployment lacking weighted factory addresses & the resulting error message from `warp deploy`

![2025-01-30 16 30 55](https://github.com/user-attachments/assets/cbe86080-a944-487f-a8d7-beb5f746b007)

![2025-01-30 16 30 39](https://github.com/user-attachments/assets/b118fe99-4894-43bf-a17b-6561d3052d31)

### Drive-by changes

- Added `undefined` address filtering in the `filterAddressesMap` function

### Related issues

None

### Backward compatibility

Yes

### Testing

Manual