### PR TITLE
chore: optimize warp config tests

### DIFF
--- a/typescript/infra/test/warp-configs.test.ts
+++ b/typescript/infra/test/warp-configs.test.ts
@@ -26,7 +26,7 @@ describe('Warp Configs', async function () {
   const envConfig = getEnvironmentConfig(ENV);
 
   for (const warpRouteId of warpIdsToCheck) {
-    it(`should match Github Registry configs for ${warpRouteId}`, async () => {
+    it(`should match Github Registry configs for ${warpRouteId}`, async function () {
       const warpConfig = await getWarpConfig(
         multiProvider,
         envConfig,

--- a/typescript/infra/test/warp-configs.test.ts
+++ b/typescript/infra/test/warp-configs.test.ts
@@ -16,9 +16,11 @@ describe('Warp Configs', async function () {
   const ENV = 'mainnet3';
   const warpIdsToCheck = Object.keys(warpConfigGetterMap);
   let multiProvider: MultiProvider;
+  let configsFromGithub;
 
   before(async () => {
     multiProvider = (await getHyperlaneCore(ENV)).multiProvider;
+    configsFromGithub = await getGithubRegistry().getWarpDeployConfigs();
   });
 
   const envConfig = getEnvironmentConfig(ENV);
@@ -30,13 +32,9 @@ describe('Warp Configs', async function () {
         envConfig,
         warpRouteId,
       );
-      const githubRegistry = getGithubRegistry();
-      const configsFromGithub = await githubRegistry.getWarpDeployConfig(
-        warpRouteId,
-      );
       const { mergedObject, isInvalid } = diffObjMerge(
         warpConfig,
-        configsFromGithub!,
+        configsFromGithub![warpRouteId],
       );
 
       if (isInvalid) {

--- a/typescript/infra/test/warp-configs.test.ts
+++ b/typescript/infra/test/warp-configs.test.ts
@@ -18,7 +18,7 @@ describe('Warp Configs', async function () {
   let multiProvider: MultiProvider;
   let configsFromGithub;
 
-  before(async () => {
+  before(async function () {
     multiProvider = (await getHyperlaneCore(ENV)).multiProvider;
     configsFromGithub = await getGithubRegistry().getWarpDeployConfigs();
   });


### PR DESCRIPTION
### Description
This PR optimizes the warp config tests by moving the registry fetching into `before()` and reading it in memory.

### Backward compatibility
Yes

### Testing
Unit Tests

