### PR TITLE
fix: handle Sei retryable error

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -2991,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-10#3ce1ce74f2d014a2f9df213084a700106e567740"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-02-03#a6cd47a09f4ba16f7ac12242d598b6ac6a328694"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -3005,7 +3005,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-10#3ce1ce74f2d014a2f9df213084a700106e567740"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-02-03#a6cd47a09f4ba16f7ac12242d598b6ac6a328694"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -3016,7 +3016,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-10#3ce1ce74f2d014a2f9df213084a700106e567740"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-02-03#a6cd47a09f4ba16f7ac12242d598b6ac6a328694"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -3034,7 +3034,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-10#3ce1ce74f2d014a2f9df213084a700106e567740"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-02-03#a6cd47a09f4ba16f7ac12242d598b6ac6a328694"
 dependencies = [
  "Inflector",
  "cfg-if",
@@ -3058,7 +3058,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-10#3ce1ce74f2d014a2f9df213084a700106e567740"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-02-03#a6cd47a09f4ba16f7ac12242d598b6ac6a328694"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -3072,7 +3072,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-10#3ce1ce74f2d014a2f9df213084a700106e567740"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-02-03#a6cd47a09f4ba16f7ac12242d598b6ac6a328694"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -3102,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-10#3ce1ce74f2d014a2f9df213084a700106e567740"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-02-03#a6cd47a09f4ba16f7ac12242d598b6ac6a328694"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.15",
@@ -3118,7 +3118,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-10#3ce1ce74f2d014a2f9df213084a700106e567740"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-02-03#a6cd47a09f4ba16f7ac12242d598b6ac6a328694"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -3167,7 +3167,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-10#3ce1ce74f2d014a2f9df213084a700106e567740"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-02-03#a6cd47a09f4ba16f7ac12242d598b6ac6a328694"
 dependencies = [
  "async-trait",
  "auto_impl 1.2.0",
@@ -3203,7 +3203,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-01-10#3ce1ce74f2d014a2f9df213084a700106e567740"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-02-03#a6cd47a09f4ba16f7ac12242d598b6ac6a328694"
 dependencies = [
  "async-trait",
  "coins-bip32 0.7.0",

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -200,27 +200,27 @@ overflow-checks = true
 [workspace.dependencies.ethers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2025-01-10"
+tag = "2025-02-03"
 
 [workspace.dependencies.ethers-contract]
 features = ["legacy"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2025-01-10"
+tag = "2025-02-03"
 
 [workspace.dependencies.ethers-core]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2025-01-10"
+tag = "2025-02-03"
 
 [workspace.dependencies.ethers-providers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2025-01-10"
+tag = "2025-02-03"
 
 [workspace.dependencies.ethers-signers]
 features = ["aws"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2025-01-10"
+tag = "2025-02-03"
 
 [patch.crates-io.curve25519-dalek]
 branch = "v3.2.2-relax-zeroize"


### PR DESCRIPTION
Uses gas escalation fix for Sei from https://github.com/hyperlane-xyz/ethers-rs/pull/32:

> There was a gas spike on Sei overnight in which the escalator wasn't effective at all, because the error message (insufficient fee) is non-standard and txs were just dropped. This meant submissions were stuck until the gas price estimation RPC returned accurate enough values.

> Logs here: https://cloudlogging.app.goo.gl/wCsz7oEuFL6RdaAY7