### PR TITLE
feat: allow headers to be passed in as RPC query params

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -310,8 +310,8 @@ fn build_http_provider(url: Url) -> ChainResult<Http> {
     // A hack to pass custom headers to the provider without
     // requiring a bunch of changes to our configuration surface area.
     // Any `custom_rpc_header` query parameter is expected to have the value
-    // format: `header_name:header_value`, and will be added to the headers
-    // of the HTTP client and removed from the URL params.
+    // format: `header_name:header_value`, will be added to the headers
+    // of the HTTP client, and removed from the URL params.
     let mut updated_url = url.clone();
     for (key, value) in url.query_pairs() {
         if key != "custom_rpc_header" {

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -307,9 +307,14 @@ fn build_http_provider(url: Url) -> ChainResult<Http> {
     let mut queries_to_keep = vec![];
     let mut headers = reqwest::header::HeaderMap::new();
 
+    // A hack to pass custom headers to the provider without
+    // requiring a bunch of changes to our configuration surface area.
+    // Any `custom_rpc_header` query parameter is expected to have the value
+    // format: `header_name:header_value`, and will be added to the headers
+    // of the HTTP client and removed from the URL params.
     let mut updated_url = url.clone();
     for (key, value) in url.query_pairs() {
-        if !key.starts_with("custom_rpc_header") {
+        if key != "custom_rpc_header" {
             queries_to_keep.push((key.clone(), value.clone()));
             continue;
         }


### PR DESCRIPTION
### Description

- A bit hacky, but we need to satisfy the quick goal of adding headers to Http RPCs
- Doesn't do anything for ws
- Any `custom_rpc_header` query parameter is expected to have the value format: `header_name:header_value`, will be added to the headers, and removed from the URL params.
- Allows you to for example do:
```
HYP_CHAINS_MYCHAIN_CUSTOMRPCURLS=https://foo.bar.com?custom_rpc_header=Authorization%3A%20Bearer%20MySecret
```

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
