### PR TITLE
chore: Add exports to CLI

### DIFF
--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -66,6 +66,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": "./dist/src/index.js"
+  },
   "engines": {
     "node": ">=16"
   },

--- a/typescript/cli/src/context/context.ts
+++ b/typescript/cli/src/context/context.ts
@@ -188,7 +188,7 @@ export async function getDryRunContext(
  * and an override one (such as a local directory)
  * @returns a new MergedRegistry
  */
-function getRegistry(
+export function getRegistry(
   primaryRegistryUri: string,
   overrideRegistryUri: string,
   enableProxy: boolean,

--- a/typescript/cli/src/index.ts
+++ b/typescript/cli/src/index.ts
@@ -1,0 +1,1 @@
+export { getRegistry } from './context/context.js';


### PR DESCRIPTION
### Description
This PR adds export to CLI

### Drive-by changes
- Export `getRegistry()` to be used by infra

### Backward compatibility

Yes

### Testing
Manual
