### PR TITLE
feat: enroll berachain

### DIFF
--- a/.changeset/new-phones-train.md
+++ b/.changeset/new-phones-train.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Fix default multichain strategy resolving.

--- a/.changeset/stale-seas-travel.md
+++ b/.changeset/stale-seas-travel.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Add new validators for unichain and berachain.

--- a/typescript/cli/src/context/strategies/chain/MultiChainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/MultiChainResolver.ts
@@ -134,10 +134,6 @@ export class MultiChainResolver implements ChainResolver {
       chains.push(argv.origin);
     }
 
-    if (argv.destination) {
-      chains.push(argv.destination);
-    }
-
     if (argv.chain) {
       chains.push(argv.chain);
     }
@@ -149,9 +145,13 @@ export class MultiChainResolver implements ChainResolver {
       return Array.from(new Set([...chains, ...additionalChains]));
     }
 
-    return chains.length > 0
-      ? chains
-      : Array.from(this.getEvmChains(multiProvider));
+    // If no destination is specified, return all EVM chains
+    if (!argv.destination) {
+      return Array.from(this.getEvmChains(multiProvider));
+    }
+
+    chains.push(argv.destination);
+    return chains;
   }
 
   private async getWarpRouteConfigChains(

--- a/typescript/cli/src/context/strategies/chain/MultiChainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/MultiChainResolver.ts
@@ -128,14 +128,14 @@ export class MultiChainResolver implements ChainResolver {
     argv: Record<string, any>,
   ): Promise<ChainName[]> {
     const { multiProvider } = argv.context;
-    const chains = [];
+    const chains = new Set<ChainName>();
 
     if (argv.origin) {
-      chains.push(argv.origin);
+      chains.add(argv.origin);
     }
 
     if (argv.chain) {
-      chains.push(argv.chain);
+      chains.add(argv.chain);
     }
 
     if (argv.chains) {
@@ -150,8 +150,8 @@ export class MultiChainResolver implements ChainResolver {
       return Array.from(this.getEvmChains(multiProvider));
     }
 
-    chains.push(argv.destination);
-    return chains;
+    chains.add(argv.destination);
+    return Array.from(chains);
   }
 
   private async getWarpRouteConfigChains(

--- a/typescript/cli/src/context/strategies/chain/MultiChainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/MultiChainResolver.ts
@@ -142,18 +142,16 @@ export class MultiChainResolver implements ChainResolver {
       chains.push(argv.chain);
     }
 
-    if (!argv.chains && chains.length === 0) {
-      return Array.from(this.getEvmChains(multiProvider));
+    if (argv.chains) {
+      const additionalChains = argv.chains
+        .split(',')
+        .map((item: string) => item.trim());
+      return Array.from(new Set([...chains, ...additionalChains]));
     }
 
-    return Array.from(
-      new Set([
-        ...chains,
-        ...(argv.chains
-          ? argv.chains.split(',').map((item: string) => item.trim())
-          : []),
-      ]),
-    );
+    return chains.length > 0
+      ? chains
+      : Array.from(this.getEvmChains(multiProvider));
   }
 
   private async getWarpRouteConfigChains(

--- a/typescript/infra/config/environments/mainnet3/chains.ts
+++ b/typescript/infra/config/environments/mainnet3/chains.ts
@@ -91,6 +91,11 @@ export const chainMetadataOverrides: ChainMap<Partial<ChainMetadata>> = {
   //     gasPrice: 600 * 10 ** 9, // 600 gwei
   //   },
   // },
+  // matchain: {
+  //   blocks: {
+  //     confirmations: 5,
+  //   },
+  // },
 };
 
 export const getRegistry = async (

--- a/typescript/infra/config/environments/mainnet3/owners.ts
+++ b/typescript/infra/config/environments/mainnet3/owners.ts
@@ -62,7 +62,7 @@ export const safes: ChainMap<Address> = {
   zircuit: '0x9e2fe7723b018d02cDE4f5cC1A9bC9C65b922Fc8',
   swell: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
 
-  // Q5, 2025 batch
+  // Q5, 2024 batch
   berachain: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
 
   // zksync chains
@@ -219,7 +219,7 @@ export const icas: Partial<
   unitzero: '0x66af72e46b3e8DFc19992A2A88C05d9EEFE01ffB',
   trumpchain: '0x56895bFa7f7dFA5743b2A0994B5B0f88b88350F9',
 
-  // Q5, 2025 batch
+  // Q5, 2024 batch
   // ----------------------------------------------------------
   // berachain: '0x56895bFa7f7dFA5743b2A0994B5B0f88b88350F9',
 } as const;

--- a/typescript/infra/config/environments/mainnet3/owners.ts
+++ b/typescript/infra/config/environments/mainnet3/owners.ts
@@ -61,6 +61,7 @@ export const safes: ChainMap<Address> = {
   endurance: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
   zircuit: '0x9e2fe7723b018d02cDE4f5cC1A9bC9C65b922Fc8',
   swell: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
+  berachain: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
 
   // zksync chains
   zeronetwork: '0xCB21F61A3c8139F18e635d45aD1e62A4A61d2c3D',
@@ -215,6 +216,10 @@ export const icas: Partial<
   matchain: '0x66af72e46b3e8DFc19992A2A88C05d9EEFE01ffB',
   unitzero: '0x66af72e46b3e8DFc19992A2A88C05d9EEFE01ffB',
   trumpchain: '0x56895bFa7f7dFA5743b2A0994B5B0f88b88350F9',
+
+  // Q5, 2025 batch
+  // ----------------------------------------------------------
+  // berachain: '0x56895bFa7f7dFA5743b2A0994B5B0f88b88350F9',
 } as const;
 
 export const DEPLOYER = '0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba';

--- a/typescript/infra/config/environments/mainnet3/owners.ts
+++ b/typescript/infra/config/environments/mainnet3/owners.ts
@@ -61,7 +61,9 @@ export const safes: ChainMap<Address> = {
   endurance: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
   zircuit: '0x9e2fe7723b018d02cDE4f5cC1A9bC9C65b922Fc8',
   swell: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
-  berachain: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
+
+  // Q5, 2025 batch
+  // berachain: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
 
   // zksync chains
   zeronetwork: '0xCB21F61A3c8139F18e635d45aD1e62A4A61d2c3D',

--- a/typescript/infra/config/environments/mainnet3/owners.ts
+++ b/typescript/infra/config/environments/mainnet3/owners.ts
@@ -63,7 +63,7 @@ export const safes: ChainMap<Address> = {
   swell: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
 
   // Q5, 2025 batch
-  // berachain: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
+  berachain: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
 
   // zksync chains
   zeronetwork: '0xCB21F61A3c8139F18e635d45aD1e62A4A61d2c3D',

--- a/typescript/infra/scripts/safes/parse-txs.ts
+++ b/typescript/infra/scripts/safes/parse-txs.ts
@@ -63,7 +63,7 @@ async function main() {
   ]);
 
   const chainResultEntries = await Promise.all(
-    pendingTxs.map(async ({ chain, fullTxHash }) => {
+    pendingTxs.map(async ({ chain, nonce, fullTxHash }) => {
       rootLogger.info(`Reading tx ${fullTxHash} on ${chain}`);
       const safeTx = await getSafeTx(chain, multiProvider, fullTxHash);
       const tx: AnnotatedEV5Transaction = {
@@ -75,7 +75,7 @@ async function main() {
       try {
         const results = await reader.read(chain, tx);
         rootLogger.info(`Finished reading tx ${fullTxHash} on ${chain}`);
-        return [`${chain}-${fullTxHash}`, results];
+        return [`${chain}-${nonce}-${fullTxHash}`, results];
       } catch (err) {
         rootLogger.error('Error reading transaction', err, chain, tx);
         process.exit(1);

--- a/typescript/infra/src/tx/govern-transaction-reader.ts
+++ b/typescript/infra/src/tx/govern-transaction-reader.ts
@@ -183,10 +183,10 @@ export class GovernTransactionReader {
     tx: AnnotatedEV5Transaction,
   ): Promise<GovernTransaction> {
     const { symbol } = await this.multiProvider.getNativeToken(chain);
-    const valueInEth = ethers.utils.formatEther(tx.value ?? BigNumber.from(0));
+    const numTokens = ethers.utils.formatEther(tx.value ?? BigNumber.from(0));
     return {
       chain,
-      insight: `Send ${valueInEth} ${symbol} to ${tx.to}`,
+      insight: `Send ${numTokens} ${symbol} to ${tx.to}`,
       tx,
     };
   }

--- a/typescript/infra/src/tx/govern-transaction-reader.ts
+++ b/typescript/infra/src/tx/govern-transaction-reader.ts
@@ -154,6 +154,11 @@ export class GovernTransactionReader {
       return this.readOwnableTransaction(chain, tx);
     }
 
+    // If it's a native token transfer (no data, only value)
+    if (this.isNativeTokenTransfer(tx)) {
+      return this.readNativeTokenTransfer(chain, tx);
+    }
+
     const insight = '⚠️ Unknown transaction type';
     // If we get here, it's an unknown transaction
     this.errors.push({
@@ -165,6 +170,23 @@ export class GovernTransactionReader {
     return {
       chain,
       insight,
+      tx,
+    };
+  }
+
+  private isNativeTokenTransfer(tx: AnnotatedEV5Transaction): boolean {
+    return !tx.data && !!tx.value && !!tx.to;
+  }
+
+  private async readNativeTokenTransfer(
+    chain: ChainName,
+    tx: AnnotatedEV5Transaction,
+  ): Promise<GovernTransaction> {
+    const { symbol } = await this.multiProvider.getNativeToken(chain);
+    const valueInEth = ethers.utils.formatEther(tx.value ?? BigNumber.from(0));
+    return {
+      chain,
+      insight: `Send ${valueInEth} ${symbol} to ${tx.to}`,
       tx,
     };
   }

--- a/typescript/sdk/src/consts/multisigIsm.ts
+++ b/typescript/sdk/src/consts/multisigIsm.ts
@@ -317,12 +317,22 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   berachain: {
-    threshold: 1,
+    threshold: 3,
     validators: [
       {
         address: '0x0190915c55d9c7555e6d2cb838f04d18b5e2260e',
         alias: AW_VALIDATOR_ALIAS,
       },
+      {
+        address: '0xa7341aa60faad0ce728aa9aeb67bb880f55e4392',
+        alias: 'Luganodes',
+      },
+      {
+        address: '0xae09cb3febc4cad59ef5a56c1df741df4eb1f4b6',
+        alias: 'Renzo',
+      },
+      DEFAULT_MERKLY_VALIDATOR,
+      DEFAULT_MITOSIS_VALIDATOR,
     ],
   },
 
@@ -2072,11 +2082,19 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   unichain: {
-    threshold: 2,
+    threshold: 3,
     validators: [
       {
         address: '0x9773a382342ebf604a2e5de0a1f462fb499e28b1',
         alias: AW_VALIDATOR_ALIAS,
+      },
+      {
+        address: '0xa9d517776fe8beba7d67c21cac1e805bd609c08e',
+        alias: 'Luganodes',
+      },
+      {
+        address: '0xfe318024ca6197f2157905209149067a11e6982c',
+        alias: 'Renzo',
       },
       DEFAULT_MERKLY_VALIDATOR,
       DEFAULT_MITOSIS_VALIDATOR,

--- a/typescript/sdk/src/utils/gnosisSafe.js
+++ b/typescript/sdk/src/utils/gnosisSafe.js
@@ -51,6 +51,11 @@ const chainOverrides = {
     multiSend: '0x0dFcccB95225ffB03c6FBB2559B530C2B7C8A912',
     multiSendCallOnly: '0xf220D3b4DFb23C4ade8C88E526C1353AbAcbC38F',
   },
+  // berachain
+  80094: {
+    multiSend: '0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761',
+    multiSendCallOnly: '0x40A2aCCbd92BCA938b02010E17A5b8929b49130D',
+  },
 };
 
 export async function getSafe(chain, multiProvider, safeAddress) {


### PR DESCRIPTION
### Description

feat: enroll berachain

### Drive-by changes

- add renzo/luganodes validators to default unichain set
- add bera multisend address overrides in SDK
- support reading native token transfers in the GovernTransactionReader
- add deploy-only tx override for matchain
- fix default strategy resolution in `MultiChainResolver`
	- encountered issue when attempting `hyperlane status`

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
