### PR TITLE
feat: Add optional parameter for existingProxyAdmins in getRenzoEZETHWarpConfigGenerator

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.ts
@@ -298,6 +298,7 @@ const existingProxyAdmins: ChainMap<{ address: string; owner: string }> = {
 export function getRenzoEZETHWarpConfigGenerator(
   ezEthSafes: Record<string, string>,
   xERC20: Record<(typeof chainsToDeploy)[number], string>,
+  existingProxyAdmins?: ChainMap<{ address: string; owner: string }>,
 ) {
   return async (): Promise<ChainMap<HypTokenRouterConfig>> => {
     const config = getEnvironmentConfig('mainnet3');
@@ -396,7 +397,7 @@ export function getRenzoEZETHWarpConfigGenerator(
                   ],
                 },
                 hook: getRenzoHook(defaultHook, chain, ezEthSafes[chain]),
-                proxyAdmin: existingProxyAdmins[chain],
+                proxyAdmin: existingProxyAdmins?.[chain] ?? undefined, // when 'undefined' yaml will not include the field
               },
             ];
 
@@ -413,6 +414,7 @@ export function getRenzoEZETHWarpConfigGenerator(
 export const getRenzoEZETHWarpConfig = getRenzoEZETHWarpConfigGenerator(
   ezEthSafes,
   xERC20,
+  existingProxyAdmins,
 );
 
 // Create a GnosisSafeBuilder Strategy for each safe address


### PR DESCRIPTION
### Description
This PR addresses an issue mentioned on [discord](https://discord.com/channels/935678348330434570/1321870185984163880/1337085307073597591) where the existing infra checker does not fully support proxyAdmin. The error is introduced because we reused renzo's proxyAdmin. 

This change allows specification of the proxyAdmin, such that if it's not provided, will deploy a new proxyAdmin

### Backward compatibility

Yes

### Testing
Tested by running `yarn tsx ./scripts/warp-routes/export-warp-configs.ts -e mainnet3` which resulted in:
- no diffs in production ezEth config
- removes the proxyAdmin object from EZETHSTAGE
