### PR TITLE
fix(checker): Add MissingRouterViolation when config misses enrolled routers

### DIFF
--- a/.changeset/wicked-bags-enjoy.md
+++ b/.changeset/wicked-bags-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Add MissingRouterViolation when config misses enrolled routers

--- a/typescript/infra/src/govern/HyperlaneICAChecker.ts
+++ b/typescript/infra/src/govern/HyperlaneICAChecker.ts
@@ -43,7 +43,7 @@ export class HyperlaneICAChecker extends InterchainAccountChecker {
 
       const violation: RouterViolation = {
         chain,
-        type: RouterViolationType.EnrolledRouter,
+        type: RouterViolationType.MisconfiguredEnrolledRouter,
         contract: router,
         actual: currentRouters,
         expected: expectedRouters,

--- a/typescript/infra/src/govern/ProxiedRouterGovernor.ts
+++ b/typescript/infra/src/govern/ProxiedRouterGovernor.ts
@@ -24,7 +24,7 @@ export class ProxiedRouterGovernor<
     switch (violation.type) {
       case ConnectionClientViolationType.InterchainSecurityModule:
         return this.handleIsmViolation(violation as ConnectionClientViolation);
-      case RouterViolationType.EnrolledRouter:
+      case RouterViolationType.MisconfiguredEnrolledRouter:
         return this.handleEnrolledRouterViolation(violation as RouterViolation);
       case ViolationType.Owner:
         return this.handleOwnerViolation(violation as OwnerViolation);

--- a/typescript/sdk/src/router/types.ts
+++ b/typescript/sdk/src/router/types.ts
@@ -48,16 +48,23 @@ export interface ClientViolation extends CheckerViolation {
 }
 
 export enum RouterViolationType {
-  EnrolledRouter = 'EnrolledRouter',
+  MisconfiguredEnrolledRouter = 'MisconfiguredEnrolledRouter',
+  MissingRouter = 'MissingRouter',
 }
 
 export interface RouterViolation extends CheckerViolation {
-  type: RouterViolationType.EnrolledRouter;
+  type: RouterViolationType.MisconfiguredEnrolledRouter;
   contract: Router;
   routerDiff: ChainMap<{
     actual: AddressBytes32;
     expected: AddressBytes32;
   }>;
+  description?: string;
+}
+
+export interface MissingRouterViolation extends CheckerViolation {
+  type: RouterViolationType.MissingRouter;
+  contract: Router;
   description?: string;
 }
 


### PR DESCRIPTION
### Description

- In response to an error thrown when there are actual enrolled routers that are not present in the config, this was encountered running the warp checker against a route not managed by AW. 

Here is the violation output
![image](https://github.com/user-attachments/assets/67d6b428-c669-4e27-9278-bf3404129473)

### Testing

Manual