### PR TITLE
fix: move zksync-ethers to regular cli deps

### DIFF
--- a/.changeset/tender-jokes-wonder.md
+++ b/.changeset/tender-jokes-wonder.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Fix cli package dependencies.

--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -22,6 +22,7 @@
     "tsx": "^4.19.1",
     "yaml": "2.4.5",
     "yargs": "^17.7.2",
+    "zksync-ethers": "^5.10.0",
     "zod": "^3.21.2",
     "zod-validation-error": "^3.3.0",
     "zx": "^8.1.4"
@@ -44,8 +45,7 @@
     "eslint-plugin-import": "^2.31.0",
     "mocha": "^10.2.0",
     "prettier": "^2.8.8",
-    "typescript": "5.3.3",
-    "zksync-ethers": "^5.10.0"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "hyperlane": "node ./dist/cli.js",


### PR DESCRIPTION
### Description

fix: move zksync-ethers to regular cli deps

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
