### PR TITLE
feat: graceful and alertable relayer reorg detection

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -137,9 +137,7 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
             .iter()
             .find_map(|result| match result {
                 Ok(sub_module_and_meta) => match &sub_module_and_meta.metadata {
-                    Metadata::MetadataBuildingRefused(reason) => {
-                        Some(Metadata::MetadataBuildingRefused(reason.clone()))
-                    }
+                    Metadata::Refused(reason) => Some(Metadata::Refused(reason.clone())),
                     _ => None,
                 },
                 Err(_) => None,

--- a/rust/main/agents/relayer/src/msg/metadata/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base.rs
@@ -54,8 +54,9 @@ pub enum Metadata {
     /// Unable to fetch metadata, but no error occurred
     CouldNotFetch,
     /// While building metadata, encountered something that should
-    /// prohibit all metadata for the message from being built
-    MetadataBuildingRefused(String),
+    /// prohibit all metadata for the message from being built.
+    /// Provides the reason for the refusal.
+    Refused(String),
 }
 
 #[derive(Debug)]

--- a/rust/main/agents/relayer/src/msg/metadata/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base.rs
@@ -50,7 +50,7 @@ pub enum MetadataBuilderError {
 #[derive(Clone, Debug)]
 pub enum Metadata {
     /// Able to fetch metadata
-    Ok(Vec<u8>),
+    Found(Vec<u8>),
     /// Unable to fetch metadata, but no error occurred
     CouldNotFetch,
     /// While building metadata, encountered something that should

--- a/rust/main/agents/relayer/src/msg/metadata/ccip_read.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/ccip_read.rs
@@ -81,7 +81,7 @@ impl MetadataBuilder for CcipReadIsmMetadataBuilder {
                 Ok(result) => {
                     // remove leading 0x which hex_decode doesn't like
                     let metadata = hex_decode(&result.data[2..])?;
-                    return Ok(Metadata::Ok(metadata));
+                    return Ok(Metadata::Found(metadata));
                 }
                 Err(_err) => {
                     // try the next URL

--- a/rust/main/agents/relayer/src/msg/metadata/ccip_read.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/ccip_read.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::{info, instrument};
 
-use super::{base::MessageMetadataBuilder, MetadataBuilder};
+use super::{base::MessageMetadataBuilder, Metadata, MetadataBuilder};
 
 #[derive(Serialize, Deserialize)]
 struct OffchainResponse {
@@ -28,11 +28,7 @@ pub struct CcipReadIsmMetadataBuilder {
 #[async_trait]
 impl MetadataBuilder for CcipReadIsmMetadataBuilder {
     #[instrument(err, skip(self, message))]
-    async fn build(
-        &self,
-        ism_address: H256,
-        message: &HyperlaneMessage,
-    ) -> eyre::Result<Option<Vec<u8>>> {
+    async fn build(&self, ism_address: H256, message: &HyperlaneMessage) -> eyre::Result<Metadata> {
         const CTX: &str = "When fetching CcipRead metadata";
         let ism = self.build_ccip_read_ism(ism_address).await.context(CTX)?;
 
@@ -42,15 +38,15 @@ impl MetadataBuilder for CcipReadIsmMetadataBuilder {
         let info: OffchainLookup = match response {
             Ok(_) => {
                 info!("incorrectly configured getOffchainVerifyInfo, expected revert");
-                return Ok(None);
+                return Ok(Metadata::CouldNotFetch);
             }
             Err(raw_error) => {
                 let matching_regex = Regex::new(r"0x[[:xdigit:]]+")?;
                 if let Some(matching) = &matching_regex.captures(&raw_error.to_string()) {
                     OffchainLookup::decode(hex_decode(&matching[0][2..])?)?
                 } else {
-                    info!("unable to parse custom error out of revert");
-                    return Ok(None);
+                    info!(?raw_error, "unable to parse custom error out of revert");
+                    return Ok(Metadata::CouldNotFetch);
                 }
             }
         };
@@ -85,7 +81,7 @@ impl MetadataBuilder for CcipReadIsmMetadataBuilder {
                 Ok(result) => {
                     // remove leading 0x which hex_decode doesn't like
                     let metadata = hex_decode(&result.data[2..])?;
-                    return Ok(Some(metadata));
+                    return Ok(Metadata::Ok(metadata));
                 }
                 Err(_err) => {
                     // try the next URL
@@ -94,6 +90,6 @@ impl MetadataBuilder for CcipReadIsmMetadataBuilder {
         }
 
         // No metadata endpoints or endpoints down
-        Ok(None)
+        Ok(Metadata::CouldNotFetch)
     }
 }

--- a/rust/main/agents/relayer/src/msg/metadata/mod.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/mod.rs
@@ -6,9 +6,9 @@ mod null_metadata;
 mod routing;
 
 use aggregation::AggregationIsmMetadataBuilder;
-pub(crate) use base::MetadataBuilder;
 pub(crate) use base::{
-    AppContextClassifier, BaseMetadataBuilder, IsmAwareAppContextClassifier, MessageMetadataBuilder,
+    AppContextClassifier, BaseMetadataBuilder, IsmAwareAppContextClassifier,
+    MessageMetadataBuilder, Metadata, MetadataBuilder,
 };
 use ccip_read::CcipReadIsmMetadataBuilder;
 use null_metadata::NullMetadataBuilder;

--- a/rust/main/agents/relayer/src/msg/metadata/multisig/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/multisig/base.rs
@@ -137,7 +137,7 @@ impl<T: MultisigIsmMetadataBuilder> MetadataBuilder for T {
             .context(CTX)?
         {
             debug!(hyp_message=?message, ?metadata.checkpoint, "Found checkpoint with quorum");
-            Ok(Metadata::Ok(self.format_metadata(metadata)?))
+            Ok(Metadata::Found(self.format_metadata(metadata)?))
         } else {
             info!(
                 hyp_message=?message, ?validators, threshold, ism=%multisig_ism.address(),

--- a/rust/main/agents/relayer/src/msg/metadata/multisig/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/multisig/base.rs
@@ -121,7 +121,7 @@ impl<T: MultisigIsmMetadataBuilder> MetadataBuilder for T {
         {
             Ok(syncer) => syncer,
             Err(CheckpointSyncerBuildError::ReorgEvent(reorg_event)) => {
-                return Ok(Metadata::MetadataBuildingRefused(format!(
+                return Ok(Metadata::Refused(format!(
                     "A reorg event occurred {:?}",
                     reorg_event
                 )));

--- a/rust/main/agents/relayer/src/msg/metadata/multisig/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/multisig/base.rs
@@ -6,6 +6,7 @@ use derive_new::new;
 use ethers::abi::Token;
 
 use eyre::{Context, Result};
+use hyperlane_base::settings::CheckpointSyncerBuildError;
 use hyperlane_base::MultisigCheckpointSyncer;
 use hyperlane_core::accumulator::merkle::Proof;
 use hyperlane_core::{HyperlaneMessage, MultisigSignedCheckpoint, H256};
@@ -14,7 +15,7 @@ use tracing::{debug, info};
 
 use crate::msg::metadata::base::MessageMetadataBuilder;
 
-use crate::msg::metadata::MetadataBuilder;
+use crate::msg::metadata::{Metadata, MetadataBuilder};
 
 #[derive(new, AsRef, Deref)]
 pub struct MultisigMetadata {
@@ -93,11 +94,7 @@ pub trait MultisigIsmMetadataBuilder: AsRef<MessageMetadataBuilder> + Send + Syn
 
 #[async_trait]
 impl<T: MultisigIsmMetadataBuilder> MetadataBuilder for T {
-    async fn build(
-        &self,
-        ism_address: H256,
-        message: &HyperlaneMessage,
-    ) -> Result<Option<Vec<u8>>> {
+    async fn build(&self, ism_address: H256, message: &HyperlaneMessage) -> Result<Metadata> {
         const CTX: &str = "When fetching MultisigIsm metadata";
         let multisig_ism = self
             .as_ref()
@@ -112,16 +109,27 @@ impl<T: MultisigIsmMetadataBuilder> MetadataBuilder for T {
 
         if validators.is_empty() {
             info!("Could not fetch metadata: No validator set found for ISM");
-            return Ok(None);
+            return Ok(Metadata::CouldNotFetch);
         }
 
         info!(hyp_message=?message, ?validators, threshold, "List of validators and threshold for message");
 
-        let checkpoint_syncer = self
+        let checkpoint_syncer = match self
             .as_ref()
             .build_checkpoint_syncer(message, &validators, self.as_ref().app_context.clone())
             .await
-            .context(CTX)?;
+        {
+            Ok(syncer) => syncer,
+            Err(CheckpointSyncerBuildError::ReorgEvent(reorg_event)) => {
+                return Ok(Metadata::MetadataBuildingRefused(format!(
+                    "A reorg event occurred {:?}",
+                    reorg_event
+                )));
+            }
+            Err(e) => {
+                return Err(e).context(CTX);
+            }
+        };
 
         if let Some(metadata) = self
             .fetch_metadata(&validators, threshold, message, &checkpoint_syncer)
@@ -129,13 +137,13 @@ impl<T: MultisigIsmMetadataBuilder> MetadataBuilder for T {
             .context(CTX)?
         {
             debug!(hyp_message=?message, ?metadata.checkpoint, "Found checkpoint with quorum");
-            Ok(Some(self.format_metadata(metadata)?))
+            Ok(Metadata::Ok(self.format_metadata(metadata)?))
         } else {
             info!(
                 hyp_message=?message, ?validators, threshold, ism=%multisig_ism.address(),
                 "Could not fetch metadata: Unable to reach quorum"
             );
-            Ok(None)
+            Ok(Metadata::CouldNotFetch)
         }
     }
 }

--- a/rust/main/agents/relayer/src/msg/metadata/null_metadata.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/null_metadata.rs
@@ -1,4 +1,4 @@
-use super::MetadataBuilder;
+use super::{Metadata, MetadataBuilder};
 use async_trait::async_trait;
 use derive_new::new;
 use tracing::instrument;
@@ -16,7 +16,7 @@ impl MetadataBuilder for NullMetadataBuilder {
         &self,
         _ism_address: H256,
         _message: &HyperlaneMessage,
-    ) -> eyre::Result<Option<Vec<u8>>> {
-        Ok(Some(vec![]))
+    ) -> eyre::Result<Metadata> {
+        Ok(Metadata::Ok(vec![]))
     }
 }

--- a/rust/main/agents/relayer/src/msg/metadata/null_metadata.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/null_metadata.rs
@@ -17,6 +17,6 @@ impl MetadataBuilder for NullMetadataBuilder {
         _ism_address: H256,
         _message: &HyperlaneMessage,
     ) -> eyre::Result<Metadata> {
-        Ok(Metadata::Ok(vec![]))
+        Ok(Metadata::Found(vec![]))
     }
 }

--- a/rust/main/agents/relayer/src/msg/metadata/routing.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/routing.rs
@@ -5,7 +5,7 @@ use eyre::Context;
 use hyperlane_core::{HyperlaneMessage, H256};
 use tracing::instrument;
 
-use super::{MessageMetadataBuilder, MetadataBuilder};
+use super::{MessageMetadataBuilder, Metadata, MetadataBuilder};
 
 #[derive(Clone, Debug, new, Deref)]
 pub struct RoutingIsmMetadataBuilder {
@@ -16,11 +16,7 @@ pub struct RoutingIsmMetadataBuilder {
 impl MetadataBuilder for RoutingIsmMetadataBuilder {
     #[instrument(err, skip(self, message), ret)]
     #[allow(clippy::blocks_in_conditions)] // TODO: `rustc` 1.80.1 clippy issue
-    async fn build(
-        &self,
-        ism_address: H256,
-        message: &HyperlaneMessage,
-    ) -> eyre::Result<Option<Vec<u8>>> {
+    async fn build(&self, ism_address: H256, message: &HyperlaneMessage) -> eyre::Result<Metadata> {
         const CTX: &str = "When fetching RoutingIsm metadata";
         let ism = self.build_routing_ism(ism_address).await.context(CTX)?;
         let module = ism.route(message).await.context(CTX)?;

--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -376,12 +376,12 @@ pub mod test {
 
     fn initialize_queue(broadcaster: &sync::broadcast::Sender<MessageRetryRequest>) -> OpQueue {
         let (metrics, queue_metrics_label) = dummy_metrics_and_label();
-        let op_queue = OpQueue::new(
+
+        OpQueue::new(
             metrics.clone(),
             queue_metrics_label.clone(),
             Arc::new(Mutex::new(broadcaster.subscribe())),
-        );
-        op_queue
+        )
     }
 
     fn generate_test_messages(

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -283,7 +283,7 @@ impl PendingOperation for PendingMessage {
                 return self.on_reprepare::<String>(None, ReprepareReason::CouldNotFetchMetadata);
             }
             // If the metadata building is refused, we still allow it to be retried later.
-            Metadata::MetadataBuildingRefused(reason) => {
+            Metadata::Refused(reason) => {
                 warn!(?reason, "Metadata building refused");
                 return self.on_reprepare::<String>(None, ReprepareReason::MessageMetadataRefused);
             }

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -275,7 +275,7 @@ impl PendingOperation for PendingMessage {
         };
 
         let metadata_bytes = match metadata {
-            Metadata::Ok(metadata_bytes) => {
+            Metadata::Found(metadata_bytes) => {
                 self.metadata = Some(metadata_bytes.clone());
                 metadata_bytes
             }

--- a/rust/main/agents/relayer/src/server/message_retry.rs
+++ b/rust/main/agents/relayer/src/server/message_retry.rs
@@ -146,7 +146,7 @@ mod tests {
         if let Ok(req) = retry_request_receiver.recv().await {
             for (op, (evaluated, matched)) in pending_operations.iter().zip(metrics) {
                 // Check that the list received by the server matches the pending operation
-                assert!(req.pattern.op_matches(&op));
+                assert!(req.pattern.op_matches(op));
                 let resp = MessageRetryQueueResponse { evaluated, matched };
                 req.transmitter.send(resp).await.unwrap();
             }

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -77,10 +77,13 @@ impl BaseAgent for Validator {
         let (signer_instance, signer) = SingletonSigner::new(settings.validator.build().await?);
 
         let core = settings.build_hyperlane_core(metrics.clone());
+        // Be extra sure to panic checkpoint syncer fails, which indicates
+        // a fatal startup error.
         let checkpoint_syncer = settings
             .checkpoint_syncer
             .build_and_validate(None)
-            .await?
+            .await
+            .expect("Failed to build checkpoint syncer")
             .into();
 
         let mailbox = settings

--- a/rust/main/hyperlane-base/src/settings/checkpoint_syncer.rs
+++ b/rust/main/hyperlane-base/src/settings/checkpoint_syncer.rs
@@ -232,11 +232,10 @@ mod test {
         }
 
         // Initialize a new checkpoint syncer and expect it to panic due to the reorg event.
-        // `AssertUnwindSafe` is required for ignoring some type checks so the panic can be caught.
         let result = checkpoint_syncer_conf.build_and_validate(None).await;
         match result {
             Err(CheckpointSyncerBuildError::ReorgEvent(e)) => {
-                assert_eq!(e, dummy_reorg_event);
+                assert_eq!(e, dummy_reorg_event, "Reported reorg event doesn't match");
             }
             _ => panic!("Expected a reorg event error"),
         }

--- a/rust/main/hyperlane-base/src/settings/checkpoint_syncer.rs
+++ b/rust/main/hyperlane-base/src/settings/checkpoint_syncer.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use core::str::FromStr;
 use eyre::{eyre, Context, Report, Result};
+use hyperlane_core::{ChainCommunicationError, ReorgEvent};
 use prometheus::IntGauge;
 use rusoto_core::Region;
 use std::{env, path::PathBuf};
@@ -39,6 +40,20 @@ pub enum CheckpointSyncerConf {
         /// `gcloud auth application-default login`
         user_secrets: Option<String>,
     },
+}
+
+/// Checkpoint Syncer errors
+#[derive(Debug, thiserror::Error)]
+pub enum CheckpointSyncerBuildError {
+    /// A reorg event has been detected in the checkpoint syncer when building it
+    #[error("A reorg event has been detected: {0:?}")]
+    ReorgEvent(ReorgEvent),
+    /// Error communicating with the chain
+    #[error(transparent)]
+    ChainError(#[from] ChainCommunicationError),
+    /// Other errors
+    #[error(transparent)]
+    Other(#[from] Report),
 }
 
 impl FromStr for CheckpointSyncerConf {
@@ -110,15 +125,12 @@ impl CheckpointSyncerConf {
     pub async fn build_and_validate(
         &self,
         latest_index_gauge: Option<IntGauge>,
-    ) -> Result<Box<dyn CheckpointSyncer>, Report> {
+    ) -> Result<Box<dyn CheckpointSyncer>, CheckpointSyncerBuildError> {
         let syncer: Box<dyn CheckpointSyncer> = self.build(latest_index_gauge).await?;
 
         match syncer.reorg_status().await {
             Ok(Some(reorg_event)) => {
-                panic!(
-                    "A reorg event has been detected: {:#?}. Please resolve the reorg to continue.",
-                    reorg_event
-                );
+                return Err(CheckpointSyncerBuildError::ReorgEvent(reorg_event));
             }
             Err(err) => {
                 error!(
@@ -177,10 +189,7 @@ impl CheckpointSyncerConf {
 
 #[cfg(test)]
 mod test {
-    use std::panic::AssertUnwindSafe;
-
-    use futures_util::FutureExt;
-    use hyperlane_core::{ReorgEvent, ReorgPeriod, H256};
+    use hyperlane_core::{ReorgPeriod, H256};
 
     #[tokio::test]
     async fn test_build_and_validate() {
@@ -191,6 +200,23 @@ mod test {
         let checkpoint_path = format!("file://{}", temp_checkpoint_dir.path().to_str().unwrap());
         let checkpoint_syncer_conf = CheckpointSyncerConf::from_str(&checkpoint_path).unwrap();
 
+        let dummy_local_merkle_root =
+            H256::from_str("0x8da44bc8198e9874db215ec2000037c58e16918c94743d70c838ecb10e243c64")
+                .unwrap();
+        let dummy_canonical_merkle_root =
+            H256::from_str("0xb437b888332ef12f7260c7f679aad3c96b91ab81c2dc7242f8b290f0b6bba92b")
+                .unwrap();
+        let dummy_checkpoint_index = 56;
+        let unix_timestamp = 1620000000;
+        let reorg_period = ReorgPeriod::from_blocks(5);
+        let dummy_reorg_event = ReorgEvent {
+            local_merkle_root: dummy_local_merkle_root,
+            canonical_merkle_root: dummy_canonical_merkle_root,
+            checkpoint_index: dummy_checkpoint_index,
+            unix_timestamp,
+            reorg_period,
+        };
+
         // create a checkpoint syncer and write a reorg event
         // then `drop` it, to simulate a restart
         {
@@ -199,24 +225,6 @@ mod test {
                 .await
                 .unwrap();
 
-            let dummy_local_merkle_root = H256::from_str(
-                "0x8da44bc8198e9874db215ec2000037c58e16918c94743d70c838ecb10e243c64",
-            )
-            .unwrap();
-            let dummy_canonical_merkle_root = H256::from_str(
-                "0xb437b888332ef12f7260c7f679aad3c96b91ab81c2dc7242f8b290f0b6bba92b",
-            )
-            .unwrap();
-            let dummy_checkpoint_index = 56;
-            let unix_timestamp = 1620000000;
-            let reorg_period = ReorgPeriod::from_blocks(5);
-            let dummy_reorg_event = ReorgEvent {
-                local_merkle_root: dummy_local_merkle_root,
-                canonical_merkle_root: dummy_canonical_merkle_root,
-                checkpoint_index: dummy_checkpoint_index,
-                unix_timestamp,
-                reorg_period,
-            };
             checkpoint_syncer
                 .write_reorg_status(&dummy_reorg_event)
                 .await
@@ -225,28 +233,12 @@ mod test {
 
         // Initialize a new checkpoint syncer and expect it to panic due to the reorg event.
         // `AssertUnwindSafe` is required for ignoring some type checks so the panic can be caught.
-        let startup_result = AssertUnwindSafe(checkpoint_syncer_conf.build_and_validate(None))
-            .catch_unwind()
-            .await
-            .unwrap_err();
-        if let Some(err) = startup_result.downcast_ref::<String>() {
-            assert_eq!(
-                *err,
-                r#"A reorg event has been detected: ReorgEvent {
-    local_merkle_root: 0x8da44bc8198e9874db215ec2000037c58e16918c94743d70c838ecb10e243c64,
-    canonical_merkle_root: 0xb437b888332ef12f7260c7f679aad3c96b91ab81c2dc7242f8b290f0b6bba92b,
-    checkpoint_index: 56,
-    unix_timestamp: 1620000000,
-    reorg_period: Blocks(
-        5,
-    ),
-}. Please resolve the reorg to continue."#
-            );
-        } else {
-            panic!(
-                "Caught panic has a different type than the expected one (`String`): {:?}",
-                startup_result
-            );
+        let result = checkpoint_syncer_conf.build_and_validate(None).await;
+        match result {
+            Err(CheckpointSyncerBuildError::ReorgEvent(e)) => {
+                assert_eq!(e, dummy_reorg_event);
+            }
+            _ => panic!("Expected a reorg event error"),
         }
     }
 }

--- a/rust/main/hyperlane-core/src/traits/pending_operation.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation.rs
@@ -250,6 +250,9 @@ pub enum ReprepareReason {
     #[strum(to_string = "Delivery transaction reverted or reorged")]
     /// Delivery transaction reverted or reorged
     RevertedOrReorged,
+    /// The metadata building was refused for the message.
+    #[strum(to_string = "Message metadata refused")]
+    MessageMetadataRefused,
 }
 
 #[derive(Display, Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/rust/main/hyperlane-core/src/types/reorg.rs
+++ b/rust/main/hyperlane-core/src/types/reorg.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::{ReorgPeriod, H256};
 
 /// Details about a detected chain reorg, from an agent's perspective
-#[derive(Debug, Clone, Serialize, Deserialize, new)]
+#[derive(Debug, Clone, Serialize, Deserialize, new, PartialEq)]
 pub struct ReorgEvent {
     /// the merkle root built from this agent's indexed events
     pub local_merkle_root: H256,

--- a/rust/main/hyperlane-core/src/types/reorg.rs
+++ b/rust/main/hyperlane-core/src/types/reorg.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::{ReorgPeriod, H256};
 
 /// Details about a detected chain reorg, from an agent's perspective
-#[derive(Debug, Clone, Serialize, Deserialize, new, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, new, PartialEq, Default)]
 pub struct ReorgEvent {
     /// the merkle root built from this agent's indexed events
     pub local_merkle_root: H256,

--- a/rust/main/utils/run-locally/src/main.rs
+++ b/rust/main/utils/run-locally/src/main.rs
@@ -30,7 +30,7 @@ use std::{
 };
 
 use ethers_contract::MULTICALL_ADDRESS;
-use hyperlane_core::{PendingOperationStatus, ReorgEvent, ReorgPeriod, ReprepareReason, H256};
+use hyperlane_core::{PendingOperationStatus, ReorgEvent, ReprepareReason};
 use logging::log;
 pub use metrics::fetch_metric;
 use once_cell::sync::Lazy;
@@ -583,10 +583,10 @@ fn stop_validator(state: &mut State, validator_index: usize) {
     let (child, _) = state
         .agents
         .get_mut(&name)
-        .expect(&format!("Validator {} not found", name));
+        .unwrap_or_else(|| panic!("Validator {} not found", name));
     child
         .kill()
-        .expect(&format!("Failed to stop validator {}", name));
+        .unwrap_or_else(|_| panic!("Failed to stop validator {}", name));
     // Remove the validator from the state
     state.agents.remove(&name);
 }

--- a/rust/main/utils/run-locally/src/main.rs
+++ b/rust/main/utils/run-locally/src/main.rs
@@ -591,7 +591,7 @@ fn stop_validator(state: &mut State, validator_index: usize) {
     state.agents.remove(&name);
 }
 
-fn set_validator_reorg_flag(checkpoints_dirs: &Vec<DynPath>, validator_index: usize) {
+fn set_validator_reorg_flag(checkpoints_dirs: &[DynPath], validator_index: usize) {
     let reorg_event = ReorgEvent::default();
 
     let checkpoint_path = (*checkpoints_dirs[validator_index]).as_ref();
@@ -599,7 +599,7 @@ fn set_validator_reorg_flag(checkpoints_dirs: &Vec<DynPath>, validator_index: us
     let mut reorg_flag_file =
         File::create(reorg_flag_path).expect("Failed to create reorg flag file");
     // Write to file
-    reorg_flag_file
+    let _ = reorg_flag_file
         .write(serde_json::to_string(&reorg_event).unwrap().as_bytes())
         .expect("Failed to write to reorg flag file");
 }

--- a/rust/main/utils/run-locally/src/main.rs
+++ b/rust/main/utils/run-locally/src/main.rs
@@ -18,6 +18,7 @@
 use std::{
     collections::HashMap,
     fs::{self, File},
+    io::Write,
     path::Path,
     process::{Child, ExitCode},
     sync::{
@@ -29,6 +30,7 @@ use std::{
 };
 
 use ethers_contract::MULTICALL_ADDRESS;
+use hyperlane_core::{PendingOperationStatus, ReorgEvent, ReorgPeriod, ReprepareReason, H256};
 use logging::log;
 pub use metrics::fetch_metric;
 use once_cell::sync::Lazy;
@@ -460,6 +462,21 @@ fn main() -> ExitCode {
         return report_test_result(test_passed);
     }
 
+    // Kill validator 1 and simulate a reorg, which we'll later use
+    // to ensure the relayer handles reorgs correctly.
+    stop_validator(&mut state, 1);
+    set_validator_reorg_flag(&checkpoints_dirs, 1);
+
+    // Send a single message from validator 1's origin chain to test the relayer's reorg handling.
+    Program::new("yarn")
+        .working_dir(INFRA_PATH)
+        .cmd("kathy")
+        .arg("messages", "1")
+        .arg("timeout", "1000")
+        .arg("single-origin", "test1")
+        .run()
+        .join();
+
     // Here we want to restart the relayer and validate
     // its restart behaviour.
     restart_relayer(&config, &mut state, &rocks_db_dir);
@@ -472,7 +489,7 @@ fn main() -> ExitCode {
     test_passed = wait_for_condition(
         &config,
         loop_start,
-        relayer_restart_invariants_met,
+        || Ok(relayer_restart_invariants_met()? && relayer_reorg_handling_invariants_met()?),
         || !SHUTDOWN.load(Ordering::Relaxed),
         || long_running_processes_exited_check(&mut state),
     );
@@ -560,6 +577,34 @@ fn create_relayer(config: &Config, rocks_db_dir: &TempDir) -> Program {
 }
 
 /// Kills relayer in State and respawns the relayer again
+fn stop_validator(state: &mut State, validator_index: usize) {
+    let name = format!("VL{}", validator_index + 1);
+    log!("Stopping validator {}...", name);
+    let (child, _) = state
+        .agents
+        .get_mut(&name)
+        .expect(&format!("Validator {} not found", name));
+    child
+        .kill()
+        .expect(&format!("Failed to stop validator {}", name));
+    // Remove the validator from the state
+    state.agents.remove(&name);
+}
+
+fn set_validator_reorg_flag(checkpoints_dirs: &Vec<DynPath>, validator_index: usize) {
+    let reorg_event = ReorgEvent::default();
+
+    let checkpoint_path = (*checkpoints_dirs[validator_index]).as_ref();
+    let reorg_flag_path = checkpoint_path.join("reorg_flag.json");
+    let mut reorg_flag_file =
+        File::create(reorg_flag_path).expect("Failed to create reorg flag file");
+    // Write to file
+    reorg_flag_file
+        .write(serde_json::to_string(&reorg_event).unwrap().as_bytes())
+        .expect("Failed to write to reorg flag file");
+}
+
+/// Kills relayer in State and respawns the relayer again
 fn restart_relayer(config: &Config, state: &mut State, rocks_db_dir: &TempDir) {
     log!("Stopping relayer...");
     let (child, _) = state.agents.get_mut("RLY").expect("No relayer agent found");
@@ -569,6 +614,25 @@ fn restart_relayer(config: &Config, state: &mut State, rocks_db_dir: &TempDir) {
     let relayer_env = create_relayer(config, rocks_db_dir);
     state.push_agent(relayer_env.spawn("RLY", Some(&AGENT_LOGGING_DIR)));
     log!("Restarted relayer...");
+}
+
+fn relayer_reorg_handling_invariants_met() -> eyre::Result<bool> {
+    let lengths = fetch_metric(
+        RELAYER_METRICS_PORT,
+        "hyperlane_submitter_queue_length",
+        &HashMap::from([(
+            "operation_status",
+            PendingOperationStatus::Retry(ReprepareReason::MessageMetadataRefused)
+                .to_string()
+                .as_str(),
+        )]),
+    )?;
+    if lengths.iter().sum::<u32>() == 0 {
+        log!("Relayer still doesn't have any MessageMetadataRefused messages in the queue.",);
+        return Ok(false);
+    };
+
+    Ok(true)
 }
 
 /// Check relayer restart behaviour is correct.
@@ -585,7 +649,7 @@ fn relayer_restart_invariants_met() -> eyre::Result<bool> {
 
     let no_metadata_message_count = *matched_logs
         .get(&line_filters)
-        .expect("Failed to get matched message count");
+        .ok_or_else(|| eyre::eyre!("No logs matched line filters"))?;
     // These messages are never inserted into the merkle tree.
     // So these messages will never be deliverable and will always
     // be in a CouldNotFetchMetadata state.

--- a/rust/main/utils/run-locally/src/main.rs
+++ b/rust/main/utils/run-locally/src/main.rs
@@ -628,7 +628,7 @@ fn relayer_reorg_handling_invariants_met() -> eyre::Result<bool> {
         )]),
     )?;
     if lengths.iter().sum::<u32>() == 0 {
-        log!("Relayer still doesn't have any MessageMetadataRefused messages in the queue.",);
+        log!("Relayer still doesn't have any MessageMetadataRefused messages in the queue.");
         return Ok(false);
     };
 


### PR DESCRIPTION
### Description

- Only panics in the validator if there is a reorg detected
- Mostly solves https://github.com/hyperlane-xyz/issues/issues/1394 (does not have super clear alert conditions for a reorg occurring, this should come later)
- Whereas before we would use `Result<Option<Vec<u8>>` as a return type for metadata building, where the Result indicates some error occurred (e.g. an RPC issue or something), Ok(Some(_)) meant that metadata building was successful, and Ok(None) meant that no error occurred but simply that fetching metadata wasn't successful -- we now have a new `Metadata` enum:
```
#[derive(Clone, Debug)]
pub enum Metadata {
    /// Able to fetch metadata
    Ok(Vec<u8>),
    /// Unable to fetch metadata, but no error occurred
    CouldNotFetch,
    /// While building metadata, encountered something that should
    /// prohibit all metadata for the message from being built.
    /// Provides the reason for the refusal.
    Refused(String),
}
```
- When we are building metadata and encounter a reorg flag in a validator that's used by the message, we handle this and return `Metadata::MetadataBuildingRefused`. The aggregation ISM will propagate this to make sure that we have end behavior of flatly refusing to build metadata for a message even if a nested metadata builder encounters this. If this happens, a new reprepare reason `MessageMetadataRefused` is introduced that's used.
- e2e test is added to confirm this behavior

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

e2e, some unit