### PR TITLE
feat(cli): optionally check ism and hook config if provided in input config

### DIFF
--- a/typescript/cli/src/check/warp.ts
+++ b/typescript/cli/src/check/warp.ts
@@ -21,13 +21,13 @@ export async function runWarpRouteCheck({
   // Go through each chain and only add to the output the chains that have mismatches
   const [violations, isInvalid] = Object.keys(warpRouteConfig).reduce(
     (acc, chain) => {
-      const formattedOnchainConfig = formatCheckerInput({
+      formatCheckerInput({
         warpRouteConfig: warpRouteConfig[chain],
         onChainWarpConfig: onChainWarpConfig[chain],
       });
 
       const { mergedObject, isInvalid } = diffObjMerge(
-        normalizeConfig(formattedOnchainConfig),
+        normalizeConfig(onChainWarpConfig[chain]),
         normalizeConfig(warpRouteConfig[chain]),
       );
 
@@ -55,7 +55,7 @@ function formatCheckerInput({
 }: {
   warpRouteConfig: Readonly<HypTokenRouterConfig>;
   onChainWarpConfig: HypTokenRouterConfig;
-}): HypTokenRouterConfig {
+}) {
   // If the hook config is not defined in the input file,
   // we need to remove it from the onChainWarpConfig if it was derived
   if (!warpRouteConfig.hook) {
@@ -64,7 +64,7 @@ function formatCheckerInput({
 
   // if the hook config is defined the input file, it means the user wants to check
   // the hook config, so we need to add the default hook address to the onChainWarpConfig
-  // in case the default hook is used by the token.
+  // in case the default hook is currently used by the token.
   if (warpRouteConfig.hook && !onChainWarpConfig.hook) {
     onChainWarpConfig.hook = constants.AddressZero;
   }
@@ -81,9 +81,7 @@ function formatCheckerInput({
   ) {
     // Same as with the hook, if the interchainSecurityModule is defined in the input file,
     // if the user defined it, we need to add the default address to the onChainWarpConfig
-    // in case the default interchainSecurityModule is used by the token.
+    // in case the default interchainSecurityModule is currently used by the token.
     onChainWarpConfig.interchainSecurityModule = constants.AddressZero;
   }
-
-  return onChainWarpConfig;
 }

--- a/typescript/cli/src/check/warp.ts
+++ b/typescript/cli/src/check/warp.ts
@@ -1,6 +1,11 @@
+import { constants } from 'ethers';
 import { stringify as yamlStringify } from 'yaml';
 
-import { WarpRouteDeployConfig, normalizeConfig } from '@hyperlane-xyz/sdk';
+import {
+  HypTokenRouterConfig,
+  WarpRouteDeployConfig,
+  normalizeConfig,
+} from '@hyperlane-xyz/sdk';
 import { ObjectDiff, diffObjMerge } from '@hyperlane-xyz/utils';
 
 import { log, logGreen } from '../logger.js';
@@ -10,14 +15,19 @@ export async function runWarpRouteCheck({
   warpRouteConfig,
   onChainWarpConfig,
 }: {
-  warpRouteConfig: WarpRouteDeployConfig;
+  warpRouteConfig: Readonly<WarpRouteDeployConfig>;
   onChainWarpConfig: WarpRouteDeployConfig;
 }): Promise<void> {
   // Go through each chain and only add to the output the chains that have mismatches
   const [violations, isInvalid] = Object.keys(warpRouteConfig).reduce(
     (acc, chain) => {
+      const formattedOnchainConfig = formatCheckerInput({
+        warpRouteConfig: warpRouteConfig[chain],
+        onChainWarpConfig: onChainWarpConfig[chain],
+      });
+
       const { mergedObject, isInvalid } = diffObjMerge(
-        normalizeConfig(onChainWarpConfig[chain]),
+        normalizeConfig(formattedOnchainConfig),
         normalizeConfig(warpRouteConfig[chain]),
       );
 
@@ -37,4 +47,43 @@ export async function runWarpRouteCheck({
   }
 
   logGreen(`No violations found`);
+}
+
+function formatCheckerInput({
+  warpRouteConfig,
+  onChainWarpConfig,
+}: {
+  warpRouteConfig: Readonly<HypTokenRouterConfig>;
+  onChainWarpConfig: HypTokenRouterConfig;
+}): HypTokenRouterConfig {
+  // If the hook config is not defined in the input file,
+  // we need to remove it from the onChainWarpConfig if it was derived
+  if (!warpRouteConfig.hook) {
+    onChainWarpConfig.hook = undefined;
+  }
+
+  // if the hook config is defined the input file, it means the user wants to check
+  // the hook config, so we need to add the default hook address to the onChainWarpConfig
+  // in case the default hook is used by the token.
+  if (warpRouteConfig.hook && !onChainWarpConfig.hook) {
+    onChainWarpConfig.hook = constants.AddressZero;
+  }
+
+  // If the ism config is not defined in the input file,
+  // we need to remove it from the onChainWarpConfig if it was derived
+  if (!warpRouteConfig.interchainSecurityModule) {
+    onChainWarpConfig.interchainSecurityModule = undefined;
+  }
+
+  if (
+    warpRouteConfig.interchainSecurityModule &&
+    !onChainWarpConfig.interchainSecurityModule
+  ) {
+    // Same as with the hook, if the interchainSecurityModule is defined in the input file,
+    // if the user defined it, we need to add the default address to the onChainWarpConfig
+    // in case the default interchainSecurityModule is used by the token.
+    onChainWarpConfig.interchainSecurityModule = constants.AddressZero;
+  }
+
+  return onChainWarpConfig;
 }

--- a/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
@@ -1,9 +1,13 @@
 import { expect } from 'chai';
-import { Wallet } from 'ethers';
+import { Wallet, constants } from 'ethers';
 
 import { ERC20Test } from '@hyperlane-xyz/core';
 import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
+  ChainName,
+  HookType,
+  HypTokenRouterConfig,
+  IsmType,
   TokenType,
   WarpRouteDeployConfig,
   randomAddress,
@@ -96,23 +100,7 @@ describe('hyperlane warp check e2e tests', async function () {
     return warpReadResult;
   }
 
-  describe('HYP_KEY=... hyperlane warp check --config ...', () => {
-    it(`should exit early if no symbol, chain or warp file have been provided`, async function () {
-      await deployAndExportWarpRoute(tokenSymbol, token.address);
-
-      const finalOutput = await hyperlaneWarpCheckRaw({
-        hypKey: ANVIL_KEY,
-        warpDeployPath: WARP_DEPLOY_OUTPUT_PATH,
-      })
-        .stdio('pipe')
-        .nothrow();
-
-      expect(finalOutput.exitCode).to.equal(1);
-      expect(finalOutput.text()).to.include(
-        'Please specify either a symbol, chain and address or warp file',
-      );
-    });
-  });
+  describe('HYP_KEY=... hyperlane warp check --config ...', () => {});
 
   describe('hyperlane warp check --key ... --config ...', () => {
     it(`should exit early if no symbol, chain or warp file have been provided`, async function () {
@@ -198,6 +186,180 @@ describe('hyperlane warp check e2e tests', async function () {
       expect(output.exitCode).to.equal(1);
       expect(output.text().includes(expectedDiffText)).to.be.true;
       expect(output.text().includes(expectedActualText)).to.be.true;
+    });
+  });
+
+  describe('Optional checks', () => {
+    async function deployAndExportSingleChainWarpRoute(
+      chainName: ChainName,
+      warpConfig: HypTokenRouterConfig,
+    ): Promise<WarpRouteDeployConfig> {
+      const deployConfig: WarpRouteDeployConfig = {
+        [chainName]: warpConfig,
+      };
+
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, deployConfig);
+      await hyperlaneWarpDeploy(WARP_DEPLOY_OUTPUT_PATH);
+
+      const WARP_CORE_CONFIG_PATH = getCombinedWarpRoutePath(tokenSymbol, [
+        chainName,
+      ]);
+
+      const derivedConfig = await readWarpConfig(
+        chainName,
+        WARP_CORE_CONFIG_PATH,
+        WARP_DEPLOY_OUTPUT_PATH,
+      );
+
+      return derivedConfig;
+    }
+
+    it(`should not check the hook config if it is not provided in the input file`, async function () {
+      const derivedConfig = await deployAndExportSingleChainWarpRoute(
+        CHAIN_NAME_2,
+        {
+          type: TokenType.collateral,
+          token: token.address,
+          mailbox: chain2Addresses.mailbox,
+          hook: {
+            type: HookType.MERKLE_TREE,
+          },
+          owner: ownerAddress,
+        },
+      );
+
+      derivedConfig[CHAIN_NAME_2].hook = undefined;
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, derivedConfig);
+
+      const steps: TestPromptAction[] = [
+        {
+          check: (currentOutput) =>
+            currentOutput.includes('Select from matching warp routes'),
+          input: `${KeyBoardKeys.ARROW_DOWN}${KeyBoardKeys.ENTER}`,
+        },
+      ];
+
+      const output = hyperlaneWarpCheck(WARP_DEPLOY_OUTPUT_PATH, tokenSymbol)
+        .stdio('pipe')
+        .nothrow();
+
+      const finalOutput = await handlePrompts(output, steps);
+
+      expect(finalOutput.exitCode).to.equal(0);
+      expect(finalOutput.text()).to.include('No violations found');
+    });
+
+    it(`should check the hook config if it is provided in the input file and find differences`, async function () {
+      const derivedConfig = await deployAndExportSingleChainWarpRoute(
+        CHAIN_NAME_2,
+        {
+          type: TokenType.collateral,
+          token: token.address,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+        },
+      );
+
+      derivedConfig[CHAIN_NAME_2].hook = {
+        type: HookType.MERKLE_TREE,
+      };
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, derivedConfig);
+
+      const expectedDiffText = `type: ${HookType.MERKLE_TREE}\n`;
+      const expectedActualText = `ACTUAL: "${constants.AddressZero}"\n`;
+
+      const steps: TestPromptAction[] = [
+        {
+          check: (currentOutput) =>
+            currentOutput.includes('Select from matching warp routes'),
+          input: `${KeyBoardKeys.ARROW_DOWN}${KeyBoardKeys.ENTER}`,
+        },
+      ];
+
+      const output = hyperlaneWarpCheck(WARP_DEPLOY_OUTPUT_PATH, tokenSymbol)
+        .stdio('pipe')
+        .nothrow();
+
+      const finalOutput = await handlePrompts(output, steps);
+
+      expect(finalOutput.exitCode).to.equal(1);
+      expect(finalOutput.text()).to.include(expectedDiffText);
+      expect(finalOutput.text()).to.include(expectedActualText);
+    });
+
+    it(`should not check the ism config if it is not provided in the input file`, async function () {
+      const derivedConfig = await deployAndExportSingleChainWarpRoute(
+        CHAIN_NAME_2,
+        {
+          type: TokenType.collateral,
+          token: token.address,
+          mailbox: chain2Addresses.mailbox,
+          interchainSecurityModule: {
+            type: IsmType.TRUSTED_RELAYER,
+            relayer: randomAddress(),
+          },
+          owner: ownerAddress,
+        },
+      );
+
+      derivedConfig[CHAIN_NAME_2].interchainSecurityModule = undefined;
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, derivedConfig);
+
+      const steps: TestPromptAction[] = [
+        {
+          check: (currentOutput) =>
+            currentOutput.includes('Select from matching warp routes'),
+          input: `${KeyBoardKeys.ARROW_DOWN}${KeyBoardKeys.ENTER}`,
+        },
+      ];
+
+      const output = hyperlaneWarpCheck(WARP_DEPLOY_OUTPUT_PATH, tokenSymbol)
+        .stdio('pipe')
+        .nothrow();
+
+      const finalOutput = await handlePrompts(output, steps);
+
+      expect(finalOutput.exitCode).to.equal(0);
+      expect(finalOutput.text()).to.include('No violations found');
+    });
+
+    it(`should check the ism config if it is provided in the input file adn find differences`, async function () {
+      const derivedConfig = await deployAndExportSingleChainWarpRoute(
+        CHAIN_NAME_2,
+        {
+          type: TokenType.collateral,
+          token: token.address,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+        },
+      );
+
+      derivedConfig[CHAIN_NAME_2].interchainSecurityModule = {
+        type: IsmType.TRUSTED_RELAYER,
+        relayer: randomAddress(),
+      };
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, derivedConfig);
+
+      const expectedDiffText = `type: ${IsmType.TRUSTED_RELAYER}\n`;
+      const expectedActualText = `ACTUAL: "${constants.AddressZero}"\n`;
+
+      const steps: TestPromptAction[] = [
+        {
+          check: (currentOutput) =>
+            currentOutput.includes('Select from matching warp routes'),
+          input: `${KeyBoardKeys.ARROW_DOWN}${KeyBoardKeys.ENTER}`,
+        },
+      ];
+
+      const output = hyperlaneWarpCheck(WARP_DEPLOY_OUTPUT_PATH, tokenSymbol)
+        .stdio('pipe')
+        .nothrow();
+
+      const finalOutput = await handlePrompts(output, steps);
+
+      expect(finalOutput.exitCode).to.equal(1);
+      expect(finalOutput.text()).to.include(expectedDiffText);
+      expect(finalOutput.text()).to.include(expectedActualText);
     });
   });
 });


### PR DESCRIPTION
### Description

This PR updates the `warp check` command to optionally check the ism and hook config if they are provided in the input file

### Drive-by changes

- NO

### Related issues

### Backward compatibility

- YES

### Testing

- E2E
