### PR TITLE
fix: don't derive testnet domains in IGP config derivation on mainnet

### DIFF
--- a/.changeset/purple-geese-study.md
+++ b/.changeset/purple-geese-study.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": minor
+---
+
+Don't derive testnet domains in IGP config derivation on mainnet


### PR DESCRIPTION
### Description

Right now, because IGP's domains are not an enumerable set, we have to query all known domains on it. That is becoming very expensive. This change at least avoids querying for testnet domains when looking at a mainnet IGP and vice versa.
