### PR TITLE
feat(sealevel): Support claim tx via SealevelIgpAdapter

### DIFF
--- a/.changeset/slimy-coins-tan.md
+++ b/.changeset/slimy-coins-tan.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Support populateClaimTx on SealevelIgpAdapter

--- a/typescript/sdk/src/consts/sealevel.ts
+++ b/typescript/sdk/src/consts/sealevel.ts
@@ -1,2 +1,11 @@
+import { ChainName } from '../types.js';
+
 export const SEALEVEL_SPL_NOOP_ADDRESS =
   'noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV';
+
+/**
+ * Priority fees in microlamports for Sealevel chains
+ */
+export const SEALEVEL_PRIORITY_FEES: Partial<Record<ChainName, number>> = {
+  solanamainnet: 200_000,
+};

--- a/typescript/sdk/src/gas/adapters/SealevelIgpAdapter.ts
+++ b/typescript/sdk/src/gas/adapters/SealevelIgpAdapter.ts
@@ -191,7 +191,7 @@ export class SealevelIgpAdapter extends SealevelIgpProgramAdapter {
   }
 
   /**
-   * Constructs a TransactionInstruction for the Claim instruction.
+   * Constructs a Transaction for .
    * @param {PublicKey} beneficiary - The IGP’s configured beneficiary.
    * @returns {Promise<TransactionInstruction>} The claim instruction.
    */

--- a/typescript/sdk/src/gas/adapters/SealevelIgpAdapter.ts
+++ b/typescript/sdk/src/gas/adapters/SealevelIgpAdapter.ts
@@ -1,7 +1,9 @@
 import {
+  AccountMeta,
   Message,
   PublicKey,
   SystemProgram,
+  Transaction,
   TransactionInstruction,
   VersionedTransaction,
 } from '@solana/web3.js';
@@ -19,6 +21,8 @@ import {
 
 import {
   SealeveIgpInstruction,
+  SealevelIgpData,
+  SealevelIgpDataSchema,
   SealevelIgpQuoteGasPaymentInstruction,
   SealevelIgpQuoteGasPaymentResponse,
   SealevelIgpQuoteGasPaymentResponseSchema,
@@ -157,6 +161,59 @@ export class SealevelIgpAdapter extends SealevelIgpProgramAdapter {
       programId: this.programId,
       igpAccount: this.igp,
     };
+  }
+
+  async getAccountInfo(): Promise<SealevelIgpData> {
+    const address = this.addresses.igp;
+    const connection = this.getProvider();
+
+    const accountInfo = await connection.getAccountInfo(new PublicKey(address));
+    assert(accountInfo, `No account info found for ${address}}`);
+
+    const accountData = deserializeUnchecked(
+      SealevelIgpDataSchema,
+      SealevelAccountDataWrapper,
+      accountInfo.data,
+    );
+    return accountData.data as SealevelIgpData;
+  }
+
+  // Should match https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs#L536-L581
+  getClaimInstructionKeyList(beneficiary: PublicKey): Array<AccountMeta> {
+    return [
+      // 0. [executable] The system program.
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      // 1. [writeable] The IGP account.
+      { pubkey: this.igp, isSigner: false, isWritable: true },
+      // 2. [writeable] The IGP beneficiary.
+      { pubkey: beneficiary, isSigner: false, isWritable: true },
+    ];
+  }
+
+  /**
+   * Constructs a TransactionInstruction for the Claim instruction.
+   * @param {PublicKey} beneficiary - The IGP’s configured beneficiary.
+   * @returns {Promise<TransactionInstruction>} The claim instruction.
+   */
+  async populateClaimTx(beneficiary: PublicKey): Promise<Transaction> {
+    const igpData = await this.getAccountInfo();
+
+    // check if the passed in beneficiary is same as stored beneficiary
+    if (!igpData.beneficiary_pub_key.equals(beneficiary)) {
+      throw new Error('Beneficiary account mismatch');
+    }
+
+    const keys = this.getClaimInstructionKeyList(beneficiary);
+
+    const data = Buffer.from([SealeveIgpInstruction.Claim]);
+
+    const claimIgpInstruction = new TransactionInstruction({
+      keys,
+      programId: this.programId,
+      data: data,
+    });
+
+    return new Transaction().add(claimIgpInstruction);
   }
 }
 

--- a/typescript/sdk/src/gas/adapters/serialization.ts
+++ b/typescript/sdk/src/gas/adapters/serialization.ts
@@ -92,6 +92,47 @@ export const SealevelOverheadIgpDataSchema = new Map<any, any>([
   ],
 ]);
 
+// Should match https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/rust/sealevel/programs/hyperlane-sealevel-igp/src/accounts.rs#L159
+export class SealevelIgpData {
+  /// The bump seed for this PDA.
+  bump_seed!: number;
+  // The salt used to derive the IGP PDA.
+  salt!: Uint8Array; // 32 bytes
+  /// The owner of the IGP.
+  owner?: Uint8Array | null;
+  owner_pub_key?: PublicKey;
+  /// The beneficiary of the IGP.
+  beneficiary!: Uint8Array; // 32 bytes
+  beneficiary_pub_key!: PublicKey;
+  gas_oracles!: Map<number, bigint>;
+
+  constructor(fields: any) {
+    Object.assign(this, fields);
+    this.owner_pub_key = this.owner ? new PublicKey(this.owner) : undefined;
+    this.beneficiary_pub_key = new PublicKey(this.beneficiary);
+  }
+}
+
+export const SealevelIgpDataSchema = new Map<any, any>([
+  [
+    SealevelAccountDataWrapper,
+    getSealevelAccountDataSchema(SealevelIgpData, [8]),
+  ],
+  [
+    SealevelIgpData,
+    {
+      kind: 'struct',
+      fields: [
+        ['bump_seed', 'u8'],
+        ['salt', [32]],
+        ['owner', { kind: 'option', type: [32] }],
+        ['beneficiary', [32]],
+        ['gas_oracles', { kind: 'map', key: 'u32', value: 'u64' }],
+      ],
+    },
+  ],
+]);
+
 /**
  * IGP instruction Borsh Schema
  */

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -120,7 +120,10 @@ export {
   VerificationInput,
 } from './deploy/verify/types.js';
 export * as verificationUtils from './deploy/verify/utils.js';
-export { SealevelOverheadIgpAdapter } from './gas/adapters/SealevelIgpAdapter.js';
+export {
+  SealevelOverheadIgpAdapter,
+  SealevelIgpAdapter,
+} from './gas/adapters/SealevelIgpAdapter.js';
 export {
   SealevelInterchainGasPaymasterConfig,
   SealevelInterchainGasPaymasterConfigSchema,


### PR DESCRIPTION
### Description

- add `populateClaimTx` implementation to the `SealevelIgpAdapter`
- support priority fee config for sealevel chains
- This is a step towards supporting sealevel chains on the key funder

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->

Manual
