### PR TITLE
chore: switch to using helius's high prio fee

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -458,7 +458,7 @@ const sealevelPriorityFeeOracleConfigGetter = (
   if (chain === 'solanamainnet') {
     return {
       type: AgentSealevelPriorityFeeOracleType.Helius,
-      feeLevel: AgentSealevelHeliusFeeLevel.Recommended,
+      feeLevel: AgentSealevelHeliusFeeLevel.High,
       // URL is auto populated by the external secrets in the helm chart
       url: '',
     };


### PR DESCRIPTION
The helius priority gas API started returning values that were too low at the `recommended` over the weekend. Their recommendation was to switch to the `high` one, which seems about as high as the `low` level reported by quicknode.

In the past, the `high` level reported significantly higher prio fees than needed to get inclusion so we avoided it, but maybe they recently tweaked their algorithm 