### PR TITLE
chore(ci): catch-all e2e job for matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -305,6 +305,17 @@ jobs:
           E2E_CI_TIMEOUT_SEC: '600'
           RUST_BACKTRACE: 'full'
 
+  e2e:
+    runs-on: ubuntu-latest
+    needs: e2e-matrix
+    if: always()
+    steps:
+      - name: Check e2e matrix status
+        if: ${{ needs.e2e-matrix.result != 'success' }}
+        run: |
+          echo "E2E tests failed"
+          exit 1
+
   env-test:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
### Description

chore(ci): catch-all e2e job for matrix
- adds `e2e` job at the end of the `e2e-matrix` as the catch-all job to wait for
	- just like we do for `cli-e2e-matrix` with the `cli-e2e` step
- this means any future additions to the matrix don't require a change to the github branch protection settings


### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
