### PR TITLE
chore: update gas oracles for the solana destination

### DIFF
--- a/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
+++ b/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
@@ -119,14 +119,6 @@
         "tokenDecimals": 9
       },
       "overhead": 600000
-    },
-    "treasure": {
-      "oracleConfig": {
-        "tokenExchangeRate": "21123257666268419",
-        "gasPrice": "1601935300783",
-        "tokenDecimals": 18
-      },
-      "overhead": 333774
     }
   },
   "eclipsemainnet": {
@@ -141,7 +133,7 @@
     "solanamainnet": {
       "oracleConfig": {
         "tokenExchangeRate": "115958288827584",
-        "gasPrice": "50977",
+        "gasPrice": "61172",
         "tokenDecimals": 9
       },
       "overhead": 600000
@@ -159,7 +151,7 @@
     "solanamainnet": {
       "oracleConfig": {
         "tokenExchangeRate": "115958288827584",
-        "gasPrice": "50977",
+        "gasPrice": "61172",
         "tokenDecimals": 9
       },
       "overhead": 600000
@@ -169,7 +161,7 @@
     "solanamainnet": {
       "oracleConfig": {
         "tokenExchangeRate": "1500000000000000",
-        "gasPrice": "50977",
+        "gasPrice": "61172",
         "tokenDecimals": 9
       },
       "overhead": 600000

--- a/typescript/infra/src/config/gas-oracle.ts
+++ b/typescript/infra/src/config/gas-oracle.ts
@@ -187,7 +187,7 @@ function getMinUsdCost(local: ChainName, remote: ChainName): number {
     // Nexus adjustment
     neutron: 0.5,
     // For Solana, special min cost
-    solanamainnet: 1,
+    solanamainnet: 1.2,
   };
   const override = remoteMinCostOverrides[remote];
   if (override !== undefined) {


### PR DESCRIPTION
### Description

Solana gas price more than 10xed since the igp quotes were updated. I've updated the gas oracles and merging in the config I got

Quicknode is reporting the medium fee to be 500k ([source](https://www.quicknode.com/gas-tracker/solana)), but in practice helius is quoting us 1M+. Our previous quote was $1, updating to $1.2 to cover some of the increased cost