### PR TITLE
chore: fix Release pipeline

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,14 +1,16 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# Check for potential secrets in staged files
-echo "🔍 Checking for potential secrets in staged files..."
-if git diff --cached --name-only | xargs gitleaks protect --staged --verbose --redact --config .gitleaks.toml; then
-    echo "✅ No secrets detected"
-else
-    echo "❌ Potential secrets detected in your changes!"
-    echo "Please remove any secrets, credentials, or sensitive information before committing."
-    exit 1
+# If not in GitHub Actions, check for potential secrets in staged files
+if [ "$GITHUB_ACTIONS" != "true" ]; then
+    echo "🔍 Checking for potential secrets in staged files..."
+    if git diff --cached --name-only | xargs gitleaks protect --staged --verbose --redact --config .gitleaks.toml; then
+        echo "✅ No secrets detected"
+    else
+        echo "❌ Potential secrets detected in your changes!"
+        echo "Please remove any secrets, credentials, or sensitive information before committing."
+        exit 1
+    fi
 fi
 
 yarn lint-staged


### PR DESCRIPTION
### Description

chore: fix Release pipeline
- added gitleaks to precommit, but this is not installed by default on github actions
- so skipping gitleaks checks in CI

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
