### PR TITLE
fix: repairs broken tests from foundry 1.0 release

### DIFF
--- a/solidity/test/isms/ExternalBridgeTest.sol
+++ b/solidity/test/isms/ExternalBridgeTest.sol
@@ -115,12 +115,13 @@ abstract contract ExternalBridgeTest is Test {
     function test_postDispatch_revertWhen_insufficientValue() public {
         bytes memory encodedHookData = _encodeHookData(messageId, 0);
         originMailbox.updateLatestDispatchedId(messageId);
-        _expectOriginExternalBridgeCall(encodedHookData);
 
         uint256 quote = hook.quoteDispatch(testMetadata, encodedMessage);
 
-        vm.expectRevert(); //arithmetic underflow
-        hook.postDispatch{value: quote - 1}(testMetadata, encodedMessage);
+        if (quote > 0) {
+            vm.expectRevert(); //arithmetic underflow
+            hook.postDispatch{value: quote - 1}(testMetadata, encodedMessage);
+        }
     }
 
     /* ============ ISM.preVerifyMessage ============ */

--- a/solidity/test/isms/MultisigIsm.t.sol
+++ b/solidity/test/isms/MultisigIsm.t.sol
@@ -172,7 +172,7 @@ abstract contract AbstractMultisigIsmTest is Test {
         assertTrue(ism.verify(metadata, message));
     }
 
-    function testFailVerify(
+    function test_RevertWhen_badMetadata(
         uint32 destination,
         bytes32 recipient,
         bytes calldata body,
@@ -187,7 +187,8 @@ abstract contract AbstractMultisigIsmTest is Test {
         // changing single byte in metadata should fail signature verification
         uint256 index = uint256(seed) % metadata.length;
         metadata[index] = ~metadata[index];
-        assertFalse(ism.verify(metadata, message));
+        vm.expectRevert();
+        ism.verify(metadata, message);
     }
 
     function test_verify_revertWhen_duplicateSignatures(


### PR DESCRIPTION
### Description

Migrates to 1.0 according to https://book.getfoundry.sh/guides/v1.0-migration#expect-revert-cheatcode-disabled-on-internal-calls-by-default
