### PR TITLE
feat: Expand warp deploy config in warp check

### DIFF
--- a/typescript/cli/src/check/warp.ts
+++ b/typescript/cli/src/check/warp.ts
@@ -6,6 +6,16 @@ import { ObjectDiff, diffObjMerge } from '@hyperlane-xyz/utils';
 import { log, logGreen } from '../logger.js';
 import { formatYamlViolationsOutput } from '../utils/output.js';
 
+const KEYS_TO_IGNORE = ['totalSupply'];
+
+function sanitizeConfig(obj: any): any {
+  // Remove keys from obj
+  const filteredObj = Object.fromEntries(
+    Object.entries(obj).filter(([key]) => !KEYS_TO_IGNORE.includes(key)),
+  );
+  return normalizeConfig(filteredObj);
+}
+
 export async function runWarpRouteCheck({
   warpRouteConfig,
   onChainWarpConfig,
@@ -17,8 +27,8 @@ export async function runWarpRouteCheck({
   const [violations, isInvalid] = Object.keys(warpRouteConfig).reduce(
     (acc, chain) => {
       const { mergedObject, isInvalid } = diffObjMerge(
-        normalizeConfig(onChainWarpConfig[chain]),
-        normalizeConfig(warpRouteConfig[chain]),
+        sanitizeConfig(onChainWarpConfig[chain]),
+        sanitizeConfig(warpRouteConfig[chain]),
       );
 
       if (isInvalid) {

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -1,7 +1,12 @@
 import { stringify as yamlStringify } from 'yaml';
 import { CommandModule } from 'yargs';
 
-import { ChainName, ChainSubmissionStrategySchema } from '@hyperlane-xyz/sdk';
+import {
+  ChainName,
+  ChainSubmissionStrategySchema,
+  expandWarpDeployConfig,
+  getRouterAddressesFromWarpCoreConfig,
+} from '@hyperlane-xyz/sdk';
 import { assert, objFilter } from '@hyperlane-xyz/utils';
 
 import { runWarpRouteCheck } from '../check/warp.js';
@@ -367,9 +372,21 @@ export const check: CommandModuleWithContext<{
       symbol,
     });
 
+    const warpCoreConfig = context.warpCoreConfig;
+
+    if (!warpCoreConfig) {
+      throw new Error('No warp core config found');
+    }
+
+    const expandedWarpDeployConfig = await expandWarpDeployConfig(
+      context.multiProvider,
+      warpRouteConfig,
+      getRouterAddressesFromWarpCoreConfig(warpCoreConfig),
+    );
+
     await runWarpRouteCheck({
       onChainWarpConfig,
-      warpRouteConfig,
+      warpRouteConfig: expandedWarpDeployConfig,
     });
 
     process.exit(0);

--- a/typescript/cli/src/read/warp.ts
+++ b/typescript/cli/src/read/warp.ts
@@ -9,6 +9,7 @@ import {
   ChainMap,
   ChainName,
   EvmERC20WarpRouteReader,
+  HypTokenRouterConfig,
   TokenStandard,
 } from '@hyperlane-xyz/sdk';
 import { isAddressEvm, objMap, promiseObjAll } from '@hyperlane-xyz/utils';
@@ -29,7 +30,7 @@ export async function runWarpRouteRead({
   warp?: string;
   address?: string;
   symbol?: string;
-}): Promise<Record<ChainName, any>> {
+}): Promise<Record<ChainName, HypTokenRouterConfig>> {
   const { multiProvider } = context;
 
   let addresses: ChainMap<string>;

--- a/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
@@ -1,9 +1,12 @@
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
+import { zeroAddress } from 'viem';
 
 import { ERC20Test } from '@hyperlane-xyz/core';
 import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
+  HookType,
+  IsmType,
   TokenType,
   WarpRouteDeployConfig,
   randomAddress,
@@ -38,6 +41,7 @@ describe('hyperlane warp check e2e tests', async function () {
   let token: ERC20Test;
   let tokenSymbol: string;
   let ownerAddress: Address;
+  let warpConfig: WarpRouteDeployConfig;
 
   before(async function () {
     [chain2Addresses, chain3Addresses] = await Promise.all([
@@ -48,15 +52,10 @@ describe('hyperlane warp check e2e tests', async function () {
     token = await deployToken(ANVIL_KEY, CHAIN_NAME_2);
     tokenSymbol = await token.symbol();
     ownerAddress = new Wallet(ANVIL_KEY).address;
-  });
-
-  async function deployAndExportWarpRoute(
-    collateralTokenAddress: Address,
-  ): Promise<WarpRouteDeployConfig> {
-    const warpConfig: WarpRouteDeployConfig = {
+    warpConfig = {
       [CHAIN_NAME_2]: {
         type: TokenType.collateral,
-        token: collateralTokenAddress,
+        token: token.address,
         mailbox: chain2Addresses.mailbox,
         owner: ownerAddress,
       },
@@ -66,7 +65,9 @@ describe('hyperlane warp check e2e tests', async function () {
         owner: ownerAddress,
       },
     };
+  });
 
+  async function deployAndExportWarpRoute(): Promise<WarpRouteDeployConfig> {
     writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpConfig);
     await hyperlaneWarpDeploy(WARP_DEPLOY_OUTPUT_PATH);
 
@@ -77,7 +78,7 @@ describe('hyperlane warp check e2e tests', async function () {
 
   describe('HYP_KEY=... hyperlane warp check --config ...', () => {
     it(`should exit early if no symbol, chain or warp file have been provided`, async function () {
-      await deployAndExportWarpRoute(token.address);
+      await deployAndExportWarpRoute();
 
       const finalOutput = await hyperlaneWarpCheckRaw({
         hypKey: ANVIL_KEY,
@@ -95,7 +96,7 @@ describe('hyperlane warp check e2e tests', async function () {
 
   describe('hyperlane warp check --key ... --config ...', () => {
     it(`should exit early if no symbol, chain or warp file have been provided`, async function () {
-      await deployAndExportWarpRoute(token.address);
+      await deployAndExportWarpRoute();
 
       const finalOutput = await hyperlaneWarpCheckRaw({
         privateKey: ANVIL_KEY,
@@ -113,7 +114,7 @@ describe('hyperlane warp check e2e tests', async function () {
 
   describe('hyperlane warp check --symbol ... --config ...', () => {
     it(`should not find any differences between the on chain config and the local one`, async function () {
-      await deployAndExportWarpRoute(token.address);
+      await deployAndExportWarpRoute();
 
       const steps: TestPromptAction[] = [
         {
@@ -142,9 +143,9 @@ describe('hyperlane warp check e2e tests', async function () {
     });
   });
 
-  describe('hyperlane warp check --symbol ... --config ... --key ...', () => {
+  describe.only('hyperlane warp check --symbol ... --config ... --key ...', () => {
     it(`should not find any differences between the on chain config and the local one`, async function () {
-      await deployAndExportWarpRoute(token.address);
+      await deployAndExportWarpRoute();
 
       const output = await hyperlaneWarpCheck(
         WARP_DEPLOY_OUTPUT_PATH,
@@ -155,8 +156,73 @@ describe('hyperlane warp check e2e tests', async function () {
       expect(output.text()).to.includes('No violations found');
     });
 
+    describe('when using a custom ISM', () => {
+      before(async function () {
+        warpConfig[CHAIN_NAME_3].interchainSecurityModule = {
+          type: IsmType.TRUSTED_RELAYER,
+          relayer: ownerAddress,
+        };
+      });
+      it(`should not find any differences between the on chain config and the local one`, async function () {
+        await deployAndExportWarpRoute();
+
+        const output = await hyperlaneWarpCheck(
+          WARP_DEPLOY_OUTPUT_PATH,
+          tokenSymbol,
+        );
+
+        expect(output.exitCode).to.equal(0);
+        expect(output.text()).to.includes('No violations found');
+      });
+    });
+
+    describe('when using a custom hook', () => {
+      before(async function () {
+        warpConfig[CHAIN_NAME_3].hook = {
+          type: HookType.PROTOCOL_FEE,
+          protocolFee: '1',
+          maxProtocolFee: '1',
+          owner: ownerAddress,
+          beneficiary: ownerAddress,
+        };
+      });
+      it(`should not find any differences between the on chain config and the local one`, async function () {
+        await deployAndExportWarpRoute();
+
+        const output = await hyperlaneWarpCheck(
+          WARP_DEPLOY_OUTPUT_PATH,
+          tokenSymbol,
+        );
+
+        expect(output.exitCode).to.equal(0);
+        expect(output.text()).to.includes('No violations found');
+      });
+    });
+
+    it(`should find differences between the local config and the on chain config in the ism`, async function () {
+      const warpDeployConfig = await deployAndExportWarpRoute();
+      warpDeployConfig[CHAIN_NAME_3].interchainSecurityModule = {
+        type: IsmType.TRUSTED_RELAYER,
+        relayer: ownerAddress,
+      };
+      const expectedDiffText = `EXPECTED:`;
+      const expectedActualText = `ACTUAL: "${zeroAddress.toLowerCase()}"\n`;
+
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpDeployConfig);
+      const output = await hyperlaneWarpCheck(
+        WARP_DEPLOY_OUTPUT_PATH,
+        tokenSymbol,
+      )
+        .stdio('pipe')
+        .nothrow();
+
+      expect(output.exitCode).to.equal(1);
+      expect(output.text().includes(expectedDiffText)).to.be.true;
+      expect(output.text().includes(expectedActualText)).to.be.true;
+    });
+
     it(`should find differences between the local config and the on chain config`, async function () {
-      const warpDeployConfig = await deployAndExportWarpRoute(token.address);
+      const warpDeployConfig = await deployAndExportWarpRoute();
 
       const wrongOwner = randomAddress();
       warpDeployConfig[CHAIN_NAME_3].owner = wrongOwner;

--- a/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
@@ -143,7 +143,7 @@ describe('hyperlane warp check e2e tests', async function () {
     });
   });
 
-  describe.only('hyperlane warp check --symbol ... --config ... --key ...', () => {
+  describe('hyperlane warp check --symbol ... --config ... --key ...', () => {
     it(`should not find any differences between the on chain config and the local one`, async function () {
       await deployAndExportWarpRoute();
 

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -29,17 +29,19 @@ import {
 } from './types.js';
 
 const hookTypes = Object.values(HookType);
+const hookTypesToFilter = [
+  HookType.OP_STACK,
+  HookType.ARB_L2_TO_L1,
+  HookType.CUSTOM,
+  HookType.CCIP,
+];
 const DEFAULT_TOKEN_DECIMALS = 18;
 
 function randomHookType(): HookType {
   // OP_STACK filtering is temporary until we have a way to deploy the required contracts
   // ARB_L2_TO_L1 filtered out until we have a way to deploy the required contracts (arbL2ToL1.hardhat-test.ts has the same test for checking deployment)
   const filteredHookTypes = hookTypes.filter(
-    (type) =>
-      type !== HookType.OP_STACK &&
-      type !== HookType.ARB_L2_TO_L1 &&
-      type !== HookType.CUSTOM &&
-      type !== HookType.CCIP,
+    (type) => !hookTypesToFilter.includes(type),
   );
   return filteredHookTypes[
     Math.floor(Math.random() * filteredHookTypes.length)
@@ -302,12 +304,7 @@ describe('EvmHookModule', async () => {
       randomAddress(),
       ...hookTypes
         // need to setup deploying/mocking IL1CrossDomainMessenger before this test can be enabled
-        .filter(
-          (hookType) =>
-            hookType !== HookType.OP_STACK &&
-            hookType !== HookType.ARB_L2_TO_L1 &&
-            hookType !== HookType.CUSTOM,
-        )
+        .filter((hookType) => !hookTypesToFilter.includes(hookType))
         // generate a random config for each hook type
         .map((hookType) => {
           return randomHookConfig(0, 1, hookType);

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -1,5 +1,6 @@
 import { getArbitrumNetwork } from '@arbitrum/sdk';
 import { BigNumber, ethers } from 'ethers';
+import { zeroAddress } from 'viem';
 
 import {
   AmountRoutingHook,
@@ -147,10 +148,15 @@ export class EvmHookModule extends HyperlaneModule<
   public async update(
     targetConfig: HookConfig,
   ): Promise<AnnotatedEV5Transaction[]> {
+    // Nothing to do if its the default hook
+    if (this.args.config === zeroAddress) {
+      return Promise.resolve([]);
+    }
+
     targetConfig = HookConfigSchema.parse(targetConfig);
 
     // Do not support updating to a custom Hook address
-    if (typeof targetConfig === 'string') {
+    if (typeof targetConfig === 'string' && targetConfig !== zeroAddress) {
       throw new Error(
         'Invalid targetConfig: Updating to a custom Hook address is not supported. Please provide a valid Hook configuration.',
       );

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -530,6 +530,10 @@ export { HypERC20App } from './token/app.js';
 export { HypERC20Checker } from './token/checker.js';
 export { TokenType } from './token/config.js';
 export {
+  expandWarpDeployConfig,
+  getRouterAddressesFromWarpCoreConfig,
+} from './token/configUtils.js';
+export {
   hypERC20contracts,
   HypERC20Factories,
   hypERC20factories,

--- a/typescript/sdk/src/token/EvmERC20WarpModule.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.ts
@@ -1,4 +1,5 @@
 import { BigNumberish } from 'ethers';
+import { zeroAddress } from 'viem';
 
 import {
   GasRouter__factory,
@@ -296,7 +297,10 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     expectedConfig: HypTokenRouterConfig,
   ): Promise<AnnotatedEV5Transaction[]> {
     const updateTransactions: AnnotatedEV5Transaction[] = [];
-    if (!expectedConfig.interchainSecurityModule) {
+    if (
+      !expectedConfig.interchainSecurityModule ||
+      expectedConfig.interchainSecurityModule === zeroAddress
+    ) {
       return [];
     }
 
@@ -339,7 +343,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
   ): Promise<AnnotatedEV5Transaction[]> {
     const updateTransactions: AnnotatedEV5Transaction[] = [];
 
-    if (!expectedConfig.hook) {
+    if (!expectedConfig.hook || expectedConfig.hook === zeroAddress) {
       return [];
     }
 
@@ -448,8 +452,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     updateTransactions: AnnotatedEV5Transaction[];
   }> {
     assert(expectedConfig.hook, 'No hook config');
-
-    if (!actualConfig.hook) {
+    if (!actualConfig.hook || actualConfig.hook === zeroAddress) {
       return this.deployNewHook(expectedConfig);
     }
 

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -1,6 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers.js';
 import { expect } from 'chai';
 import hre from 'hardhat';
+import { zeroAddress } from 'viem';
 
 import {
   ERC20Test,
@@ -308,7 +309,7 @@ describe('ERC20WarpRouterReader', async () => {
     expect(derivedConfig.token).to.equal(token.address);
   });
 
-  it('should return undefined if ism is not set onchain', async () => {
+  it('should return 0x0 if ism is not set onchain', async () => {
     // Create config
     const config: WarpRouteDeployConfig = {
       [chain]: {
@@ -326,7 +327,7 @@ describe('ERC20WarpRouterReader', async () => {
       warpRoute[chain].collateral.address,
     );
 
-    expect(derivedConfig.interchainSecurityModule).to.be.undefined;
+    expect(derivedConfig.interchainSecurityModule).to.be.equal(zeroAddress);
   });
 
   it('should return the remote routers', async () => {

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -171,10 +171,10 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
     ]);
 
     const derivedIsm = eqAddress(ism, constants.AddressZero)
-      ? undefined
+      ? constants.AddressZero
       : await this.evmIsmReader.deriveIsmConfig(ism);
     const derivedHook = eqAddress(hook, constants.AddressZero)
-      ? undefined
+      ? constants.AddressZero
       : await this.evmHookReader.deriveHookConfig(hook);
 
     return {

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -1,3 +1,5 @@
+import { zeroAddress } from 'viem';
+
 import { Address, objMap, promiseObjAll } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../providers/MultiProvider.js';
@@ -87,6 +89,8 @@ export async function expandWarpDeployConfig(
         ...derivedTokenMetadata,
         remoteRouters,
         destinationGas,
+        hook: zeroAddress,
+        interchainSecurityModule: zeroAddress,
         proxyAdmin: { owner: config.owner },
         ...config,
       };

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -1,0 +1,95 @@
+import { Address, objMap, promiseObjAll } from '@hyperlane-xyz/utils';
+
+import { MultiProvider } from '../providers/MultiProvider.js';
+import { DestinationGas, RemoteRouters } from '../router/types.js';
+import { ChainMap } from '../types.js';
+import { WarpCoreConfig } from '../warp/types.js';
+
+import { gasOverhead } from './config.js';
+import { HypERC20Deployer } from './deploy.js';
+import { WarpRouteDeployConfig } from './types.js';
+
+/**
+ * Gets router address for a chain
+ */
+const getRemoteRouterAddress = (
+  deployedRoutersAddresses: ChainMap<Address>,
+  chain: string,
+): Address => deployedRoutersAddresses[chain];
+
+/**
+ * Gets gas configuration for a chain
+ */
+const getGasConfig = (
+  warpDeployConfig: WarpRouteDeployConfig,
+  chain: string,
+): string =>
+  warpDeployConfig[chain].gas?.toString() ||
+  gasOverhead(warpDeployConfig[chain].type).toString();
+
+export function getDefaultRemoteRouterAndDestinationGasConfig(
+  multiProvider: MultiProvider,
+  chain: string,
+  deployedRoutersAddresses: ChainMap<Address>,
+  warpDeployConfig: WarpRouteDeployConfig,
+): [RemoteRouters, DestinationGas] {
+  const remoteRouters: RemoteRouters = {};
+  const destinationGas: DestinationGas = {};
+
+  const otherChains = multiProvider
+    .getRemoteChains(chain)
+    .filter((c) => Object.keys(deployedRoutersAddresses).includes(c));
+
+  for (const otherChain of otherChains) {
+    const domainId = multiProvider.getDomainId(otherChain);
+
+    remoteRouters[domainId] = {
+      address: getRemoteRouterAddress(deployedRoutersAddresses, otherChain),
+    };
+
+    destinationGas[domainId] = getGasConfig(warpDeployConfig, otherChain);
+  }
+
+  return [remoteRouters, destinationGas];
+}
+
+export function getRouterAddressesFromWarpCoreConfig(
+  warpCoreConfig: WarpCoreConfig,
+): ChainMap<Address> {
+  return Object.fromEntries(
+    warpCoreConfig.tokens.map((token) => [
+      token.chainName,
+      token.addressOrDenom,
+    ]),
+  ) as ChainMap<Address>;
+}
+
+export async function expandWarpDeployConfig(
+  multiProvider: MultiProvider,
+  warpDeployConfig: WarpRouteDeployConfig,
+  deployedRoutersAddresses: ChainMap<Address>,
+): Promise<WarpRouteDeployConfig> {
+  const derivedTokenMetadata = await HypERC20Deployer.deriveTokenMetadata(
+    multiProvider,
+    warpDeployConfig,
+  );
+  return promiseObjAll(
+    objMap(warpDeployConfig, async (chain, config) => {
+      const [remoteRouters, destinationGas] =
+        getDefaultRemoteRouterAndDestinationGasConfig(
+          multiProvider,
+          chain,
+          deployedRoutersAddresses,
+          warpDeployConfig,
+        );
+
+      return {
+        ...derivedTokenMetadata,
+        remoteRouters,
+        destinationGas,
+        proxyAdmin: { owner: config.owner },
+        ...config,
+      };
+    }),
+  );
+}


### PR DESCRIPTION
### Description

When using `WarpDeployConfig` we often assume certain defaults, however when we compare against `warp read` config, it includes all the "expanded" config. This PR adds "config expansion", so that checking actually can be done. As part of that, it removes the practice of `warp read` after deploy in the warp check e2e tests so that the actual comparison against the intended deploy config can happen (instead of the inferred config from warp read).

This is related to https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5358 and in fact lifts some of the convenience function into `configUtils.ts` fyi @mshojaei-txfusion 

### Drive-by changes

The warp-check e2e test setup changes as mentioned

### Backward compatibility

Yes

### Testing

Local e2e tests and manual