### PR TITLE
feat: Support xerc20 token config derivation in warp check

### DIFF
--- a/.changeset/fuzzy-pillows-notice.md
+++ b/.changeset/fuzzy-pillows-notice.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+Add XERC20 derivation in SDK/CLI Warp Reading

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -1,7 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers.js';
 import { expect } from 'chai';
 import hre from 'hardhat';
-import { zeroAddress } from 'viem';
 
 import {
   ERC20Test,

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -169,7 +169,6 @@ describe('ERC20WarpRouterReader', async () => {
 
   it('should derive xerc20 config correctly', async () => {
     // Create token
-    // @ts-ignore
     const xerc20Token = await new XERC20Test__factory(signer).deploy(
       TOKEN_NAME,
       TOKEN_NAME,

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -1,6 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers.js';
 import { expect } from 'chai';
 import hre from 'hardhat';
+import { zeroAddress } from 'viem';
 
 import {
   ERC20Test,
@@ -9,6 +10,7 @@ import {
   ERC4626Test__factory,
   Mailbox,
   Mailbox__factory,
+  XERC20LockboxTest__factory,
   XERC20Test__factory,
 } from '@hyperlane-xyz/core';
 import {
@@ -214,6 +216,57 @@ describe('ERC20WarpRouterReader', async () => {
       expect(derivedConfig.name).to.equal(TOKEN_NAME);
       expect(derivedConfig.symbol).to.equal(TOKEN_NAME);
       expect(derivedConfig.decimals).to.equal(TOKEN_DECIMALS);
+      expect(derivedConfig.token).to.equal(xerc20Token.address);
+    }
+  });
+
+  it('should derive xerc20lockbox config correctly', async () => {
+    // Create token
+    const xerc20Lockbox = await new XERC20LockboxTest__factory(signer).deploy(
+      TOKEN_NAME,
+      TOKEN_NAME,
+      TOKEN_SUPPLY,
+      TOKEN_DECIMALS,
+    );
+    // Create config
+    const config: WarpRouteDeployConfig = {
+      [chain]: {
+        type: TokenType.XERC20Lockbox,
+        token: xerc20Lockbox.address,
+        hook: await mailbox.defaultHook(),
+        interchainSecurityModule: await mailbox.defaultIsm(),
+        ...baseConfig,
+      },
+    };
+    // Deploy with config
+    const warpRoute = await deployer.deploy(config);
+    // Derive config and check if each value matches
+    const derivedConfig = await evmERC20WarpRouteReader.deriveWarpRouteConfig(
+      warpRoute[chain].xERC20Lockbox.address,
+    );
+    for (const [key, value] of Object.entries(derivedConfig)) {
+      const deployedValue = (config[chain] as any)[key];
+      if (deployedValue && typeof value === 'string')
+        expect(deployedValue).to.equal(value);
+    }
+
+    // Check hook because they're potentially objects
+    expect(derivedConfig.hook).to.deep.equal(
+      await evmERC20WarpRouteReader.evmHookReader.deriveHookConfig(
+        config[chain].hook as string,
+      ),
+    );
+    // Check ism
+    expect(
+      (derivedConfig.interchainSecurityModule as DerivedIsmConfig).address,
+    ).to.be.equal(await mailbox.defaultIsm());
+
+    // Check if token values matches
+    if (derivedConfig.type === TokenType.XERC20) {
+      expect(derivedConfig.name).to.equal(TOKEN_NAME);
+      expect(derivedConfig.symbol).to.equal(TOKEN_NAME);
+      expect(derivedConfig.decimals).to.equal(TOKEN_DECIMALS);
+      expect(derivedConfig.token).to.equal(xerc20Lockbox.address);
     }
   });
 
@@ -361,7 +414,7 @@ describe('ERC20WarpRouterReader', async () => {
     expect(derivedConfig.token).to.equal(token.address);
   });
 
-  it('should return undefined if ism is not set onchain', async () => {
+  it('should return 0x0 if ism is not set onchain', async () => {
     // Create config
     const config: WarpRouteDeployConfig = {
       [chain]: {
@@ -379,7 +432,7 @@ describe('ERC20WarpRouterReader', async () => {
       warpRoute[chain].collateral.address,
     );
 
-    expect(derivedConfig.interchainSecurityModule).to.be.undefined;
+    expect(derivedConfig.interchainSecurityModule).to.be.equal(zeroAddress);
   });
 
   it('should return the remote routers', async () => {

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -414,7 +414,7 @@ describe('ERC20WarpRouterReader', async () => {
     expect(derivedConfig.token).to.equal(token.address);
   });
 
-  it('should return 0x0 if ism is not set onchain', async () => {
+  it('should return undefined if ism is not set onchain', async () => {
     // Create config
     const config: WarpRouteDeployConfig = {
       [chain]: {
@@ -432,7 +432,7 @@ describe('ERC20WarpRouterReader', async () => {
       warpRoute[chain].collateral.address,
     );
 
-    expect(derivedConfig.interchainSecurityModule).to.be.equal(zeroAddress);
+    expect(derivedConfig.interchainSecurityModule).to.be.undefined;
   });
 
   it('should return the remote routers', async () => {

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -103,6 +103,10 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
         factory: HypERC4626OwnerCollateral__factory,
         method: 'vault',
       },
+      [TokenType.XERC20Lockbox]: {
+        factory: HypXERC20Lockbox__factory,
+        method: 'lockbox',
+      },
       [TokenType.collateral]: {
         factory: HypERC20Collateral__factory,
         method: 'wrappedToken',
@@ -128,19 +132,7 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
       try {
         const warpRoute = factory.connect(warpRouteAddress, this.provider);
         await warpRoute[method]();
-
-        // If its a collateral, it could be an xerc20 token
         if (tokenType === TokenType.collateral) {
-          // Try if its HypXERC20Lockbox
-          const hypXERC20Lockbox = HypXERC20Lockbox__factory.connect(
-            warpRouteAddress,
-            this.provider,
-          );
-          try {
-            await hypXERC20Lockbox.lockbox();
-            return TokenType.XERC20Lockbox;
-            // eslint-disable-next-line no-empty
-          } catch {}
           const wrappedToken = await warpRoute.wrappedToken();
           const xerc20 = IXERC20__factory.connect(wrappedToken, this.provider);
           try {

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -1,4 +1,4 @@
-import { BigNumber, constants } from 'ethers';
+import { BigNumber, Contract, constants } from 'ethers';
 
 import {
   HypERC20Collateral__factory,
@@ -38,6 +38,7 @@ import {
   HypTokenConfig,
   HypTokenRouterConfig,
   TokenMetadata,
+  XERC20LimitConfig,
 } from './types.js';
 
 export class EvmERC20WarpRouteReader extends HyperlaneReader {
@@ -200,16 +201,39 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
     };
   }
 
+  async fetchXERC20Config(
+    type: TokenType.XERC20 | TokenType.XERC20Lockbox,
+    xERC20Address: Address,
+    warpRouteAddress: Address,
+  ): Promise<XERC20LimitConfig | {}> {
+    // fetch the limits if possible
+    const rateLimitsABI = [
+      'function rateLimitPerSecond(address) external view returns (uint128)',
+      'function bufferCap(address) external view returns (uint112)',
+    ];
+    const xERC20 = new Contract(xERC20Address, rateLimitsABI, this.provider);
+    try {
+      return {
+        rateLimitPerSecond: (
+          await xERC20.rateLimitPerSecond(warpRouteAddress)
+        ).toString(),
+        bufferCap: (await xERC20.bufferCap(warpRouteAddress)).toString(),
+      };
+    } catch (_error) {
+      return {};
+    }
+  }
+
   /**
    * Fetches the metadata for a token address.
    *
-   * @param tokenAddress - The address of the token.
+   * @param warpRouteAddress - The address of the token.
    * @returns A partial ERC20 metadata object containing the token name, symbol, total supply, and decimals.
    * Throws if unsupported token type
    */
   async fetchTokenConfig(
     type: TokenType,
-    tokenAddress: Address,
+    warpRouteAddress: Address,
   ): Promise<HypTokenConfig> {
     if (
       type === TokenType.collateral ||
@@ -218,24 +242,53 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
       type === TokenType.XERC20 ||
       type === TokenType.XERC20Lockbox
     ) {
-      const erc20 = HypERC20Collateral__factory.connect(
-        tokenAddress,
-        this.provider,
-      );
-      const token = await erc20.wrappedToken();
+      let xerc20Token: Address | undefined;
+      let lockbox: Address | undefined;
+      let token: Address;
+      let limits: XERC20LimitConfig | {} = {};
+
+      if (type === TokenType.XERC20Lockbox) {
+        // XERC20Lockbox is a special case of collateral, we will fetch it from the xerc20 contract
+        const hypXERC20Lockbox = HypXERC20Lockbox__factory.connect(
+          warpRouteAddress,
+          this.provider,
+        );
+        xerc20Token = await hypXERC20Lockbox.xERC20();
+        token = xerc20Token;
+        lockbox = await hypXERC20Lockbox.lockbox();
+      } else {
+        const erc20 = HypERC20Collateral__factory.connect(
+          warpRouteAddress,
+          this.provider,
+        );
+        token = await erc20.wrappedToken();
+      }
+
       const { name, symbol, decimals, totalSupply } =
         await this.fetchERC20Metadata(token);
 
-      return { type, name, symbol, decimals, totalSupply, token };
+      if (type === TokenType.XERC20 || type === TokenType.XERC20Lockbox) {
+        limits = await this.fetchXERC20Config(type, token, warpRouteAddress);
+      }
+
+      return {
+        ...limits,
+        type,
+        name,
+        symbol,
+        decimals,
+        totalSupply,
+        token: lockbox || token,
+      };
     } else if (
       type === TokenType.synthetic ||
       type === TokenType.syntheticRebase
     ) {
-      const baseMetadata = await this.fetchERC20Metadata(tokenAddress);
+      const baseMetadata = await this.fetchERC20Metadata(warpRouteAddress);
 
       if (type === TokenType.syntheticRebase) {
         const hypERC4626 = HypERC4626__factory.connect(
-          tokenAddress,
+          warpRouteAddress,
           this.provider,
         );
         const collateralChainName = this.multiProvider.getChainName(

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -139,13 +139,15 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
           try {
             await hypXERC20Lockbox.lockbox();
             return TokenType.XERC20Lockbox;
-          } catch (error) {}
+            // eslint-disable-next-line no-empty
+          } catch {}
           const wrappedToken = await warpRoute.wrappedToken();
           const xerc20 = IXERC20__factory.connect(wrappedToken, this.provider);
           try {
             await xerc20['mintingCurrentLimitOf(address)'](warpRouteAddress);
             return TokenType.XERC20;
-          } catch (error) {}
+            // eslint-disable-next-line no-empty
+          } catch {}
         }
         return tokenType as TokenType;
       } catch {

--- a/typescript/sdk/src/token/checker.ts
+++ b/typescript/sdk/src/token/checker.ts
@@ -23,6 +23,7 @@ import {
   isCollateralTokenConfig,
   isNativeTokenConfig,
   isSyntheticTokenConfig,
+  isXERC20TokenConfig,
 } from './types.js';
 
 export class HypERC20Checker extends ProxiedRouterChecker<
@@ -176,7 +177,10 @@ export class HypERC20Checker extends ProxiedRouterChecker<
     const expectedConfig = this.configMap[chain];
     let collateralToken: ERC20 | undefined = undefined;
 
-    if (isCollateralTokenConfig(expectedConfig)) {
+    if (
+      isCollateralTokenConfig(expectedConfig) ||
+      isXERC20TokenConfig(expectedConfig)
+    ) {
       const provider = this.multiProvider.getProvider(chain);
 
       if (expectedConfig.type === TokenType.XERC20Lockbox) {

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -36,6 +36,7 @@ import {
   isSyntheticRebaseTokenConfig,
   isSyntheticTokenConfig,
   isTokenMetadata,
+  isXERC20TokenConfig,
 } from './types.js';
 
 abstract class TokenDeployer<
@@ -61,7 +62,7 @@ abstract class TokenDeployer<
     _: ChainName,
     config: HypTokenRouterConfig,
   ): Promise<any> {
-    if (isCollateralTokenConfig(config)) {
+    if (isCollateralTokenConfig(config) || isXERC20TokenConfig(config)) {
       return [config.token, config.mailbox];
     } else if (isNativeTokenConfig(config)) {
       return config.scale ? [config.scale, config.mailbox] : [config.mailbox];
@@ -89,7 +90,11 @@ abstract class TokenDeployer<
       // TransferOwnership will happen later in RouterDeployer
       signer,
     ];
-    if (isCollateralTokenConfig(config) || isNativeTokenConfig(config)) {
+    if (
+      isCollateralTokenConfig(config) ||
+      isXERC20TokenConfig(config) ||
+      isNativeTokenConfig(config)
+    ) {
       return defaultArgs;
     } else if (isSyntheticTokenConfig(config)) {
       return [config.totalSupply, config.name, config.symbol, ...defaultArgs];
@@ -122,7 +127,7 @@ abstract class TokenDeployer<
         }
       }
 
-      if (isCollateralTokenConfig(config)) {
+      if (isCollateralTokenConfig(config) || isXERC20TokenConfig(config)) {
         const provider = multiProvider.getProvider(chain);
 
         if (config.isNft) {

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -31,15 +31,8 @@ export const NativeTokenConfigSchema = TokenMetadataSchema.partial().extend({
 export type NativeTokenConfig = z.infer<typeof NativeTokenConfigSchema>;
 export const isNativeTokenConfig = isCompliant(NativeTokenConfigSchema);
 
-const sharedCollateralTokenConfig = {
-  // For xerc20lockbox and collateral vault, we use the token as the lockbox/vault respectively
-  token: z
-    .string()
-    .describe('Existing token address to extend with Warp Route functionality'),
-};
-
-export const CollateralTokenConfigSchema = TokenMetadataSchema.partial()
-  .extend({
+export const CollateralTokenConfigSchema = TokenMetadataSchema.partial().extend(
+  {
     type: z.enum([
       TokenType.collateral,
       TokenType.collateralVault,
@@ -48,8 +41,13 @@ export const CollateralTokenConfigSchema = TokenMetadataSchema.partial()
       TokenType.fastCollateral,
       TokenType.collateralUri,
     ]),
-  })
-  .extend(sharedCollateralTokenConfig);
+    token: z
+      .string()
+      .describe(
+        'Existing token address to extend with Warp Route functionality',
+      ),
+  },
+);
 
 export type CollateralTokenConfig = z.infer<typeof CollateralTokenConfigSchema>;
 export const isCollateralTokenConfig = isCompliant(CollateralTokenConfigSchema);
@@ -69,12 +67,12 @@ const xERC20TokenMetadataSchema = z.object({
 });
 export type XERC20TokenMetadata = z.infer<typeof xERC20TokenMetadataSchema>;
 
-export const XERC20TokenConfigSchema = TokenMetadataSchema.partial()
-  .extend({
+export const XERC20TokenConfigSchema = CollateralTokenConfigSchema.merge(
+  z.object({
     type: z.enum([TokenType.XERC20, TokenType.XERC20Lockbox]),
-  })
-  .merge(xERC20TokenMetadataSchema)
-  .extend(sharedCollateralTokenConfig);
+  }),
+).merge(xERC20TokenMetadataSchema);
+
 export type XERC20LimitsTokenConfig = z.infer<typeof XERC20TokenConfigSchema>;
 export const isXERC20TokenConfig = isCompliant(XERC20TokenConfigSchema);
 

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -60,11 +60,20 @@ const xERC20LimitConfigSchema = z.object({
 });
 export type XERC20LimitConfig = z.infer<typeof xERC20LimitConfigSchema>;
 
+const xERC20TokenMetadataSchema = z.object({
+  xERC20: z
+    .object({
+      limits: xERC20LimitConfigSchema,
+    })
+    .optional(),
+});
+export type XERC20TokenMetadata = z.infer<typeof xERC20TokenMetadataSchema>;
+
 export const XERC20TokenConfigSchema = TokenMetadataSchema.partial()
   .extend({
     type: z.enum([TokenType.XERC20, TokenType.XERC20Lockbox]),
   })
-  .merge(xERC20LimitConfigSchema)
+  .merge(xERC20TokenMetadataSchema)
   .extend(sharedCollateralTokenConfig);
 export type XERC20LimitsTokenConfig = z.infer<typeof XERC20TokenConfigSchema>;
 export const isXERC20TokenConfig = isCompliant(XERC20TokenConfigSchema);


### PR DESCRIPTION
### Description

Allow `HypXERC20` and `HypXERC20Lockbox` to be derived in the warp reader, similar to https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5478, just for CLI

### Backward compatibility

Yes

### Testing

Manual/Unit Tests

