### PR TITLE
feat: Expand warp deploy config in warp check

### DIFF
--- a/.changeset/red-cows-warn.md
+++ b/.changeset/red-cows-warn.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+Expand warpDeployConfig for checking purposes

--- a/typescript/cli/src/check/warp.ts
+++ b/typescript/cli/src/check/warp.ts
@@ -6,6 +6,16 @@ import { ObjectDiff, diffObjMerge } from '@hyperlane-xyz/utils';
 import { log, logGreen } from '../logger.js';
 import { formatYamlViolationsOutput } from '../utils/output.js';
 
+const KEYS_TO_IGNORE = ['totalSupply'];
+
+function sanitizeConfig(obj: any): any {
+  // Remove keys from obj
+  const filteredObj = Object.fromEntries(
+    Object.entries(obj).filter(([key]) => !KEYS_TO_IGNORE.includes(key)),
+  );
+  return normalizeConfig(filteredObj);
+}
+
 export async function runWarpRouteCheck({
   warpRouteConfig,
   onChainWarpConfig,
@@ -17,8 +27,8 @@ export async function runWarpRouteCheck({
   const [violations, isInvalid] = Object.keys(warpRouteConfig).reduce(
     (acc, chain) => {
       const { mergedObject, isInvalid } = diffObjMerge(
-        normalizeConfig(onChainWarpConfig[chain]),
-        normalizeConfig(warpRouteConfig[chain]),
+        sanitizeConfig(onChainWarpConfig[chain]),
+        sanitizeConfig(warpRouteConfig[chain]),
       );
 
       if (isInvalid) {

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -1,7 +1,12 @@
 import { stringify as yamlStringify } from 'yaml';
 import { CommandModule } from 'yargs';
 
-import { ChainName, ChainSubmissionStrategySchema } from '@hyperlane-xyz/sdk';
+import {
+  ChainName,
+  ChainSubmissionStrategySchema,
+  expandWarpDeployConfig,
+  getRouterAddressesFromWarpCoreConfig,
+} from '@hyperlane-xyz/sdk';
 import { assert, objFilter } from '@hyperlane-xyz/utils';
 
 import { runWarpRouteCheck } from '../check/warp.js';
@@ -367,9 +372,21 @@ export const check: CommandModuleWithContext<{
       symbol,
     });
 
+    const warpCoreConfig = context.warpCoreConfig;
+
+    if (!warpCoreConfig) {
+      throw new Error('No warp core config found');
+    }
+
+    const expandedWarpDeployConfig = await expandWarpDeployConfig(
+      context.multiProvider,
+      warpRouteConfig,
+      getRouterAddressesFromWarpCoreConfig(warpCoreConfig),
+    );
+
     await runWarpRouteCheck({
       onChainWarpConfig,
-      warpRouteConfig,
+      warpRouteConfig: expandedWarpDeployConfig,
     });
 
     process.exit(0);

--- a/typescript/cli/src/read/warp.ts
+++ b/typescript/cli/src/read/warp.ts
@@ -9,6 +9,7 @@ import {
   ChainMap,
   ChainName,
   EvmERC20WarpRouteReader,
+  HypTokenRouterConfig,
   TokenStandard,
 } from '@hyperlane-xyz/sdk';
 import { isAddressEvm, objMap, promiseObjAll } from '@hyperlane-xyz/utils';
@@ -29,7 +30,7 @@ export async function runWarpRouteRead({
   warp?: string;
   address?: string;
   symbol?: string;
-}): Promise<Record<ChainName, any>> {
+}): Promise<Record<ChainName, HypTokenRouterConfig>> {
   const { multiProvider } = context;
 
   let addresses: ChainMap<string>;

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -530,6 +530,10 @@ export { HypERC20App } from './token/app.js';
 export { HypERC20Checker } from './token/checker.js';
 export { TokenType } from './token/config.js';
 export {
+  expandWarpDeployConfig,
+  getRouterAddressesFromWarpCoreConfig,
+} from './token/configUtils.js';
+export {
   hypERC20contracts,
   HypERC20Factories,
   hypERC20factories,

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -75,10 +75,13 @@ export async function expandWarpDeployConfig(
       );
 
     return {
+      // Default Expansion
       ...derivedTokenMetadata,
       remoteRouters,
       destinationGas,
       proxyAdmin: { owner: config.owner },
+
+      // User-specified config takes precedence
       ...config,
     };
   });

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -1,4 +1,4 @@
-import { Address, objMap, promiseObjAll } from '@hyperlane-xyz/utils';
+import { Address, objMap } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { DestinationGas, RemoteRouters } from '../router/types.js';

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -1,0 +1,95 @@
+import { Address, objMap, promiseObjAll } from '@hyperlane-xyz/utils';
+
+import { MultiProvider } from '../providers/MultiProvider.js';
+import { DestinationGas, RemoteRouters } from '../router/types.js';
+import { ChainMap } from '../types.js';
+import { WarpCoreConfig } from '../warp/types.js';
+
+import { gasOverhead } from './config.js';
+import { HypERC20Deployer } from './deploy.js';
+import { WarpRouteDeployConfig } from './types.js';
+
+/**
+ * Gets router address for a chain
+ */
+const getRemoteRouterAddress = (
+  deployedRoutersAddresses: ChainMap<Address>,
+  chain: string,
+): Address => deployedRoutersAddresses[chain];
+
+/**
+ * Gets gas configuration for a chain
+ */
+const getGasConfig = (
+  warpDeployConfig: WarpRouteDeployConfig,
+  chain: string,
+): string =>
+  warpDeployConfig[chain].gas?.toString() ||
+  gasOverhead(warpDeployConfig[chain].type).toString();
+
+export function getDefaultRemoteRouterAndDestinationGasConfig(
+  multiProvider: MultiProvider,
+  chain: string,
+  deployedRoutersAddresses: ChainMap<Address>,
+  warpDeployConfig: WarpRouteDeployConfig,
+): [RemoteRouters, DestinationGas] {
+  const remoteRouters: RemoteRouters = {};
+  const destinationGas: DestinationGas = {};
+
+  const otherChains = multiProvider
+    .getRemoteChains(chain)
+    .filter((c) => Object.keys(deployedRoutersAddresses).includes(c));
+
+  for (const otherChain of otherChains) {
+    const domainId = multiProvider.getDomainId(otherChain);
+
+    remoteRouters[domainId] = {
+      address: getRemoteRouterAddress(deployedRoutersAddresses, otherChain),
+    };
+
+    destinationGas[domainId] = getGasConfig(warpDeployConfig, otherChain);
+  }
+
+  return [remoteRouters, destinationGas];
+}
+
+export function getRouterAddressesFromWarpCoreConfig(
+  warpCoreConfig: WarpCoreConfig,
+): ChainMap<Address> {
+  return Object.fromEntries(
+    warpCoreConfig.tokens.map((token) => [
+      token.chainName,
+      token.addressOrDenom,
+    ]),
+  ) as ChainMap<Address>;
+}
+
+export async function expandWarpDeployConfig(
+  multiProvider: MultiProvider,
+  warpDeployConfig: WarpRouteDeployConfig,
+  deployedRoutersAddresses: ChainMap<Address>,
+): Promise<WarpRouteDeployConfig> {
+  const derivedTokenMetadata = await HypERC20Deployer.deriveTokenMetadata(
+    multiProvider,
+    warpDeployConfig,
+  );
+  return promiseObjAll(
+    objMap(warpDeployConfig, async (chain, config) => {
+      const [remoteRouters, destinationGas] =
+        getDefaultRemoteRouterAndDestinationGasConfig(
+          multiProvider,
+          chain,
+          deployedRoutersAddresses,
+          warpDeployConfig,
+        );
+
+      return {
+        ...derivedTokenMetadata,
+        remoteRouters,
+        destinationGas,
+        proxyAdmin: { owner: config.owner },
+        ...config,
+      };
+    }),
+  );
+}

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -10,14 +10,6 @@ import { HypERC20Deployer } from './deploy.js';
 import { WarpRouteDeployConfig } from './types.js';
 
 /**
- * Gets router address for a chain
- */
-const getRemoteRouterAddress = (
-  deployedRoutersAddresses: ChainMap<Address>,
-  chain: string,
-): Address => deployedRoutersAddresses[chain];
-
-/**
  * Gets gas configuration for a chain
  */
 const getGasConfig = (
@@ -44,7 +36,7 @@ export function getDefaultRemoteRouterAndDestinationGasConfig(
     const domainId = multiProvider.getDomainId(otherChain);
 
     remoteRouters[domainId] = {
-      address: getRemoteRouterAddress(deployedRoutersAddresses, otherChain),
+      address: deployedRoutersAddresses[otherChain],
     };
 
     destinationGas[domainId] = getGasConfig(warpDeployConfig, otherChain);
@@ -73,23 +65,21 @@ export async function expandWarpDeployConfig(
     multiProvider,
     warpDeployConfig,
   );
-  return promiseObjAll(
-    objMap(warpDeployConfig, async (chain, config) => {
-      const [remoteRouters, destinationGas] =
-        getDefaultRemoteRouterAndDestinationGasConfig(
-          multiProvider,
-          chain,
-          deployedRoutersAddresses,
-          warpDeployConfig,
-        );
+  return objMap(warpDeployConfig, (chain, config) => {
+    const [remoteRouters, destinationGas] =
+      getDefaultRemoteRouterAndDestinationGasConfig(
+        multiProvider,
+        chain,
+        deployedRoutersAddresses,
+        warpDeployConfig,
+      );
 
-      return {
-        ...derivedTokenMetadata,
-        remoteRouters,
-        destinationGas,
-        proxyAdmin: { owner: config.owner },
-        ...config,
-      };
-    }),
-  );
+    return {
+      ...derivedTokenMetadata,
+      remoteRouters,
+      destinationGas,
+      proxyAdmin: { owner: config.owner },
+      ...config,
+    };
+  });
 }


### PR DESCRIPTION
### Description

When using `WarpDeployConfig` we often assume certain defaults, however when we compare against `warp read` config, it includes all the "expanded" config. This PR adds "config expansion", so that checking actually can be done. As part of that, it removes the practice of `warp read` after deploy in the warp check e2e tests so that the actual comparison against the intended deploy config can happen (instead of the inferred config from warp read).

This is related to https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5358 and in fact lifts some of the convenience function into `configUtils.ts` fyi @mshojaei-txfusion 

### Drive-by changes

The warp-check e2e test setup changes as mentioned

### Backward compatibility

Yes

### Testing

Local e2e tests and manual