### PR TITLE
feat: Support ISM/Hook checking when using defaults

### DIFF
--- a/.changeset/lazy-otters-boil.md
+++ b/.changeset/lazy-otters-boil.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+Change semantics of ism/hook config from undefined to 0x0 for reading/checking purposes

--- a/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
@@ -1,9 +1,12 @@
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
+import { zeroAddress } from 'viem';
 
 import { ERC20Test } from '@hyperlane-xyz/core';
 import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
+  HookType,
+  IsmType,
   TokenType,
   WarpRouteDeployConfig,
   randomAddress,
@@ -38,6 +41,7 @@ describe('hyperlane warp check e2e tests', async function () {
   let token: ERC20Test;
   let tokenSymbol: string;
   let ownerAddress: Address;
+  let warpConfig: WarpRouteDeployConfig;
 
   before(async function () {
     [chain2Addresses, chain3Addresses] = await Promise.all([
@@ -48,15 +52,10 @@ describe('hyperlane warp check e2e tests', async function () {
     token = await deployToken(ANVIL_KEY, CHAIN_NAME_2);
     tokenSymbol = await token.symbol();
     ownerAddress = new Wallet(ANVIL_KEY).address;
-  });
-
-  async function deployAndExportWarpRoute(
-    collateralTokenAddress: Address,
-  ): Promise<WarpRouteDeployConfig> {
-    const warpConfig: WarpRouteDeployConfig = {
+    warpConfig = {
       [CHAIN_NAME_2]: {
         type: TokenType.collateral,
-        token: collateralTokenAddress,
+        token: token.address,
         mailbox: chain2Addresses.mailbox,
         owner: ownerAddress,
       },
@@ -66,7 +65,9 @@ describe('hyperlane warp check e2e tests', async function () {
         owner: ownerAddress,
       },
     };
+  });
 
+  async function deployAndExportWarpRoute(): Promise<WarpRouteDeployConfig> {
     writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpConfig);
     await hyperlaneWarpDeploy(WARP_DEPLOY_OUTPUT_PATH);
 
@@ -77,7 +78,7 @@ describe('hyperlane warp check e2e tests', async function () {
 
   describe('HYP_KEY=... hyperlane warp check --config ...', () => {
     it(`should exit early if no symbol, chain or warp file have been provided`, async function () {
-      await deployAndExportWarpRoute(token.address);
+      await deployAndExportWarpRoute();
 
       const finalOutput = await hyperlaneWarpCheckRaw({
         hypKey: ANVIL_KEY,
@@ -95,7 +96,7 @@ describe('hyperlane warp check e2e tests', async function () {
 
   describe('hyperlane warp check --key ... --config ...', () => {
     it(`should exit early if no symbol, chain or warp file have been provided`, async function () {
-      await deployAndExportWarpRoute(token.address);
+      await deployAndExportWarpRoute();
 
       const finalOutput = await hyperlaneWarpCheckRaw({
         privateKey: ANVIL_KEY,
@@ -113,7 +114,7 @@ describe('hyperlane warp check e2e tests', async function () {
 
   describe('hyperlane warp check --symbol ... --config ...', () => {
     it(`should not find any differences between the on chain config and the local one`, async function () {
-      await deployAndExportWarpRoute(token.address);
+      await deployAndExportWarpRoute();
 
       const steps: TestPromptAction[] = [
         {
@@ -142,9 +143,9 @@ describe('hyperlane warp check e2e tests', async function () {
     });
   });
 
-  describe('hyperlane warp check --symbol ... --config ... --key ...', () => {
+  describe.only('hyperlane warp check --symbol ... --config ... --key ...', () => {
     it(`should not find any differences between the on chain config and the local one`, async function () {
-      await deployAndExportWarpRoute(token.address);
+      await deployAndExportWarpRoute();
 
       const output = await hyperlaneWarpCheck(
         WARP_DEPLOY_OUTPUT_PATH,
@@ -155,8 +156,73 @@ describe('hyperlane warp check e2e tests', async function () {
       expect(output.text()).to.includes('No violations found');
     });
 
+    describe('when using a custom ISM', () => {
+      before(async function () {
+        warpConfig[CHAIN_NAME_3].interchainSecurityModule = {
+          type: IsmType.TRUSTED_RELAYER,
+          relayer: ownerAddress,
+        };
+      });
+      it(`should not find any differences between the on chain config and the local one`, async function () {
+        await deployAndExportWarpRoute();
+
+        const output = await hyperlaneWarpCheck(
+          WARP_DEPLOY_OUTPUT_PATH,
+          tokenSymbol,
+        );
+
+        expect(output.exitCode).to.equal(0);
+        expect(output.text()).to.includes('No violations found');
+      });
+    });
+
+    describe('when using a custom hook', () => {
+      before(async function () {
+        warpConfig[CHAIN_NAME_3].hook = {
+          type: HookType.PROTOCOL_FEE,
+          protocolFee: '1',
+          maxProtocolFee: '1',
+          owner: ownerAddress,
+          beneficiary: ownerAddress,
+        };
+      });
+      it(`should not find any differences between the on chain config and the local one`, async function () {
+        await deployAndExportWarpRoute();
+
+        const output = await hyperlaneWarpCheck(
+          WARP_DEPLOY_OUTPUT_PATH,
+          tokenSymbol,
+        );
+
+        expect(output.exitCode).to.equal(0);
+        expect(output.text()).to.includes('No violations found');
+      });
+    });
+
+    it(`should find differences between the local config and the on chain config in the ism`, async function () {
+      const warpDeployConfig = await deployAndExportWarpRoute();
+      warpDeployConfig[CHAIN_NAME_3].interchainSecurityModule = {
+        type: IsmType.TRUSTED_RELAYER,
+        relayer: ownerAddress,
+      };
+      const expectedDiffText = `EXPECTED:`;
+      const expectedActualText = `ACTUAL: "${zeroAddress.toLowerCase()}"\n`;
+
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpDeployConfig);
+      const output = await hyperlaneWarpCheck(
+        WARP_DEPLOY_OUTPUT_PATH,
+        tokenSymbol,
+      )
+        .stdio('pipe')
+        .nothrow();
+
+      expect(output.exitCode).to.equal(1);
+      expect(output.text().includes(expectedDiffText)).to.be.true;
+      expect(output.text().includes(expectedActualText)).to.be.true;
+    });
+
     it(`should find differences between the local config and the on chain config`, async function () {
-      const warpDeployConfig = await deployAndExportWarpRoute(token.address);
+      const warpDeployConfig = await deployAndExportWarpRoute();
 
       const wrongOwner = randomAddress();
       warpDeployConfig[CHAIN_NAME_3].owner = wrongOwner;

--- a/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
@@ -143,7 +143,7 @@ describe('hyperlane warp check e2e tests', async function () {
     });
   });
 
-  describe.only('hyperlane warp check --symbol ... --config ... --key ...', () => {
+  describe('hyperlane warp check --symbol ... --config ... --key ...', () => {
     it(`should not find any differences between the on chain config and the local one`, async function () {
       await deployAndExportWarpRoute();
 

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -29,17 +29,19 @@ import {
 } from './types.js';
 
 const hookTypes = Object.values(HookType);
+const hookTypesToFilter = [
+  HookType.OP_STACK,
+  HookType.ARB_L2_TO_L1,
+  HookType.CUSTOM,
+  HookType.CCIP,
+];
 const DEFAULT_TOKEN_DECIMALS = 18;
 
 function randomHookType(): HookType {
   // OP_STACK filtering is temporary until we have a way to deploy the required contracts
   // ARB_L2_TO_L1 filtered out until we have a way to deploy the required contracts (arbL2ToL1.hardhat-test.ts has the same test for checking deployment)
   const filteredHookTypes = hookTypes.filter(
-    (type) =>
-      type !== HookType.OP_STACK &&
-      type !== HookType.ARB_L2_TO_L1 &&
-      type !== HookType.CUSTOM &&
-      type !== HookType.CCIP,
+    (type) => !hookTypesToFilter.includes(type),
   );
   return filteredHookTypes[
     Math.floor(Math.random() * filteredHookTypes.length)
@@ -302,12 +304,7 @@ describe('EvmHookModule', async () => {
       randomAddress(),
       ...hookTypes
         // need to setup deploying/mocking IL1CrossDomainMessenger before this test can be enabled
-        .filter(
-          (hookType) =>
-            hookType !== HookType.OP_STACK &&
-            hookType !== HookType.ARB_L2_TO_L1 &&
-            hookType !== HookType.CUSTOM,
-        )
+        .filter((hookType) => !hookTypesToFilter.includes(hookType))
         // generate a random config for each hook type
         .map((hookType) => {
           return randomHookConfig(0, 1, hookType);

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -149,14 +149,14 @@ export class EvmHookModule extends HyperlaneModule<
     targetConfig: HookConfig,
   ): Promise<AnnotatedEV5Transaction[]> {
     // Nothing to do if its the default hook
-    if (this.args.config === zeroAddress) {
+    if (targetConfig === zeroAddress) {
       return Promise.resolve([]);
     }
 
     targetConfig = HookConfigSchema.parse(targetConfig);
 
     // Do not support updating to a custom Hook address
-    if (typeof targetConfig === 'string' && targetConfig !== zeroAddress) {
+    if (typeof targetConfig === 'string') {
       throw new Error(
         'Invalid targetConfig: Updating to a custom Hook address is not supported. Please provide a valid Hook configuration.',
       );

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -1,5 +1,6 @@
 import { getArbitrumNetwork } from '@arbitrum/sdk';
 import { BigNumber, ethers } from 'ethers';
+import { zeroAddress } from 'viem';
 
 import {
   AmountRoutingHook,
@@ -147,10 +148,15 @@ export class EvmHookModule extends HyperlaneModule<
   public async update(
     targetConfig: HookConfig,
   ): Promise<AnnotatedEV5Transaction[]> {
+    // Nothing to do if its the default hook
+    if (this.args.config === zeroAddress) {
+      return Promise.resolve([]);
+    }
+
     targetConfig = HookConfigSchema.parse(targetConfig);
 
     // Do not support updating to a custom Hook address
-    if (typeof targetConfig === 'string') {
+    if (typeof targetConfig === 'string' && targetConfig !== zeroAddress) {
       throw new Error(
         'Invalid targetConfig: Updating to a custom Hook address is not supported. Please provide a valid Hook configuration.',
       );

--- a/typescript/sdk/src/router/types.ts
+++ b/typescript/sdk/src/router/types.ts
@@ -1,4 +1,3 @@
-import { zeroAddress } from 'viem';
 import { z } from 'zod';
 
 import {
@@ -74,8 +73,8 @@ export type DestinationGas = z.infer<typeof DestinationGasSchema>;
 
 export const MailboxClientConfigSchema = OwnableSchema.extend({
   mailbox: ZHash,
-  hook: HookConfigSchema.optional().default(zeroAddress),
-  interchainSecurityModule: IsmConfigSchema.optional().default(zeroAddress),
+  hook: HookConfigSchema.optional(),
+  interchainSecurityModule: IsmConfigSchema.optional(),
 });
 
 export const ForeignDeploymentConfigSchema = z.object({

--- a/typescript/sdk/src/router/types.ts
+++ b/typescript/sdk/src/router/types.ts
@@ -1,3 +1,4 @@
+import { zeroAddress } from 'viem';
 import { z } from 'zod';
 
 import {
@@ -73,8 +74,8 @@ export type DestinationGas = z.infer<typeof DestinationGasSchema>;
 
 export const MailboxClientConfigSchema = OwnableSchema.extend({
   mailbox: ZHash,
-  hook: HookConfigSchema.optional(),
-  interchainSecurityModule: IsmConfigSchema.optional(),
+  hook: HookConfigSchema.optional().default(zeroAddress),
+  interchainSecurityModule: IsmConfigSchema.optional().default(zeroAddress),
 });
 
 export const ForeignDeploymentConfigSchema = z.object({

--- a/typescript/sdk/src/token/EvmERC20WarpModule.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.ts
@@ -1,4 +1,5 @@
 import { BigNumberish } from 'ethers';
+import { zeroAddress } from 'viem';
 
 import {
   GasRouter__factory,
@@ -296,7 +297,10 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     expectedConfig: HypTokenRouterConfig,
   ): Promise<AnnotatedEV5Transaction[]> {
     const updateTransactions: AnnotatedEV5Transaction[] = [];
-    if (!expectedConfig.interchainSecurityModule) {
+    if (
+      !expectedConfig.interchainSecurityModule ||
+      expectedConfig.interchainSecurityModule === zeroAddress
+    ) {
       return [];
     }
 
@@ -339,7 +343,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
   ): Promise<AnnotatedEV5Transaction[]> {
     const updateTransactions: AnnotatedEV5Transaction[] = [];
 
-    if (!expectedConfig.hook) {
+    if (!expectedConfig.hook || expectedConfig.hook === zeroAddress) {
       return [];
     }
 
@@ -448,8 +452,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     updateTransactions: AnnotatedEV5Transaction[];
   }> {
     assert(expectedConfig.hook, 'No hook config');
-
-    if (!actualConfig.hook) {
+    if (!actualConfig.hook || actualConfig.hook === zeroAddress) {
       return this.deployNewHook(expectedConfig);
     }
 

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -1,6 +1,7 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers.js';
 import { expect } from 'chai';
 import hre from 'hardhat';
+import { zeroAddress } from 'viem';
 
 import {
   ERC20Test,
@@ -412,7 +413,7 @@ describe('ERC20WarpRouterReader', async () => {
     expect(derivedConfig.token).to.equal(token.address);
   });
 
-  it('should return undefined if ism is not set onchain', async () => {
+  it('should return 0x0 if ism is not set onchain', async () => {
     // Create config
     const config: WarpRouteDeployConfig = {
       [chain]: {
@@ -430,7 +431,7 @@ describe('ERC20WarpRouterReader', async () => {
       warpRoute[chain].collateral.address,
     );
 
-    expect(derivedConfig.interchainSecurityModule).to.be.undefined;
+    expect(derivedConfig.interchainSecurityModule).to.be.equal(zeroAddress);
   });
 
   it('should return the remote routers', async () => {

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -187,10 +187,10 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
     ]);
 
     const derivedIsm = eqAddress(ism, constants.AddressZero)
-      ? undefined
+      ? constants.AddressZero
       : await this.evmIsmReader.deriveIsmConfig(ism);
     const derivedHook = eqAddress(hook, constants.AddressZero)
-      ? undefined
+      ? constants.AddressZero
       : await this.evmHookReader.deriveHookConfig(hook);
 
     return {

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -1,3 +1,5 @@
+import { zeroAddress } from 'viem';
+
 import { Address, objMap } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../providers/MultiProvider.js';
@@ -79,6 +81,8 @@ export async function expandWarpDeployConfig(
       ...derivedTokenMetadata,
       remoteRouters,
       destinationGas,
+      hook: zeroAddress,
+      interchainSecurityModule: zeroAddress,
       proxyAdmin: { owner: config.owner },
 
       // User-specified config takes precedence


### PR DESCRIPTION
### Description

This PR changes the canonical definition of using the default ism/hooks from `undefined` to `zeroAddress`. This ultimately makes cli checking work. Builds on top of https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5483 and should be based against it once CI tests are passing

### Backward compatibility

Mostly yes (because I don't think this behavior has been leveraged)

### Testing

Unit tests/e2e tests/ manual tests
