### PR TITLE
feat: Support xERC20 limit checking

### DIFF
--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -6,6 +6,7 @@ import {
   HypERC4626Collateral__factory,
   HypERC4626OwnerCollateral__factory,
   HypERC4626__factory,
+  HypXERC20Lockbox__factory,
   ProxyAdmin__factory,
   TokenRouter__factory,
 } from '@hyperlane-xyz/core';
@@ -223,7 +224,9 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
     if (
       type === TokenType.collateral ||
       type === TokenType.collateralVault ||
-      type === TokenType.collateralVaultRebase
+      type === TokenType.collateralVaultRebase ||
+      type === TokenType.XERC20 ||
+      type === TokenType.XERC20Lockbox
     ) {
       let xerc20Token: Address | undefined;
       let lockbox: Address | undefined;

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -1,4 +1,4 @@
-import { BigNumber, constants } from 'ethers';
+import { BigNumber, Contract, constants } from 'ethers';
 
 import {
   HypERC20Collateral__factory,
@@ -36,6 +36,7 @@ import {
   HypTokenConfig,
   HypTokenRouterConfig,
   TokenMetadata,
+  XERC20LimitConfig,
 } from './types.js';
 
 export class EvmERC20WarpRouteReader extends HyperlaneReader {
@@ -185,40 +186,92 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
     };
   }
 
+  async fetchXERC20Config(
+    type: TokenType.XERC20 | TokenType.XERC20Lockbox,
+    xERC20Address: Address,
+    warpRouteAddress: Address,
+  ): Promise<XERC20LimitConfig | {}> {
+    // fetch the limits if possible
+    const rateLimitsABI = [
+      'function rateLimitPerSecond(address) external view returns (uint128)',
+      'function bufferCap(address) external view returns (uint112)',
+    ];
+    const xERC20 = new Contract(xERC20Address, rateLimitsABI, this.provider);
+    try {
+      return {
+        rateLimitPerSecond: (
+          await xERC20.rateLimitPerSecond(warpRouteAddress)
+        ).toString(),
+        bufferCap: (await xERC20.bufferCap(warpRouteAddress)).toString(),
+      };
+    } catch (_error) {
+      return {};
+    }
+  }
+
   /**
    * Fetches the metadata for a token address.
    *
-   * @param tokenAddress - The address of the token.
+   * @param warpRouteAddress - The address of the token.
    * @returns A partial ERC20 metadata object containing the token name, symbol, total supply, and decimals.
    * Throws if unsupported token type
    */
   async fetchTokenConfig(
     type: TokenType,
-    tokenAddress: Address,
+    warpRouteAddress: Address,
   ): Promise<HypTokenConfig> {
     if (
       type === TokenType.collateral ||
       type === TokenType.collateralVault ||
       type === TokenType.collateralVaultRebase
     ) {
-      const erc20 = HypERC20Collateral__factory.connect(
-        tokenAddress,
-        this.provider,
-      );
-      const token = await erc20.wrappedToken();
+      let xerc20Token: Address | undefined;
+      let lockbox: Address | undefined;
+      let token: Address;
+      let limits: XERC20LimitConfig | {} = {};
+
+      if (type === TokenType.XERC20Lockbox) {
+        // XERC20Lockbox is a special case of collateral, we will fetch it from the xerc20 contract
+        const hypXERC20Lockbox = HypXERC20Lockbox__factory.connect(
+          warpRouteAddress,
+          this.provider,
+        );
+        xerc20Token = await hypXERC20Lockbox.xERC20();
+        token = xerc20Token;
+        lockbox = await hypXERC20Lockbox.lockbox();
+      } else {
+        const erc20 = HypERC20Collateral__factory.connect(
+          warpRouteAddress,
+          this.provider,
+        );
+        token = await erc20.wrappedToken();
+      }
+
       const { name, symbol, decimals, totalSupply } =
         await this.fetchERC20Metadata(token);
 
-      return { type, name, symbol, decimals, totalSupply, token };
+      if (type === TokenType.XERC20 || type === TokenType.XERC20Lockbox) {
+        limits = await this.fetchXERC20Config(type, token, warpRouteAddress);
+      }
+
+      return {
+        ...limits,
+        type,
+        name,
+        symbol,
+        decimals,
+        totalSupply,
+        token: lockbox || token,
+      };
     } else if (
       type === TokenType.synthetic ||
       type === TokenType.syntheticRebase
     ) {
-      const baseMetadata = await this.fetchERC20Metadata(tokenAddress);
+      const baseMetadata = await this.fetchERC20Metadata(warpRouteAddress);
 
       if (type === TokenType.syntheticRebase) {
         const hypERC4626 = HypERC4626__factory.connect(
-          tokenAddress,
+          warpRouteAddress,
           this.provider,
         );
         const collateralChainName = this.multiProvider.getChainName(

--- a/typescript/sdk/src/token/checker.ts
+++ b/typescript/sdk/src/token/checker.ts
@@ -23,6 +23,7 @@ import {
   isCollateralTokenConfig,
   isNativeTokenConfig,
   isSyntheticTokenConfig,
+  isXERC20TokenConfig,
 } from './types.js';
 
 export class HypERC20Checker extends ProxiedRouterChecker<
@@ -176,7 +177,10 @@ export class HypERC20Checker extends ProxiedRouterChecker<
     const expectedConfig = this.configMap[chain];
     let collateralToken: ERC20 | undefined = undefined;
 
-    if (isCollateralTokenConfig(expectedConfig)) {
+    if (
+      isCollateralTokenConfig(expectedConfig) ||
+      isXERC20TokenConfig(expectedConfig)
+    ) {
       const provider = this.multiProvider.getProvider(chain);
 
       if (expectedConfig.type === TokenType.XERC20Lockbox) {

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -36,6 +36,7 @@ import {
   isSyntheticRebaseTokenConfig,
   isSyntheticTokenConfig,
   isTokenMetadata,
+  isXERC20TokenConfig,
 } from './types.js';
 
 abstract class TokenDeployer<
@@ -61,7 +62,7 @@ abstract class TokenDeployer<
     _: ChainName,
     config: HypTokenRouterConfig,
   ): Promise<any> {
-    if (isCollateralTokenConfig(config)) {
+    if (isCollateralTokenConfig(config) || isXERC20TokenConfig(config)) {
       return [config.token, config.mailbox];
     } else if (isNativeTokenConfig(config)) {
       return config.scale ? [config.scale, config.mailbox] : [config.mailbox];
@@ -89,7 +90,11 @@ abstract class TokenDeployer<
       // TransferOwnership will happen later in RouterDeployer
       signer,
     ];
-    if (isCollateralTokenConfig(config) || isNativeTokenConfig(config)) {
+    if (
+      isCollateralTokenConfig(config) ||
+      isXERC20TokenConfig(config) ||
+      isNativeTokenConfig(config)
+    ) {
       return defaultArgs;
     } else if (isSyntheticTokenConfig(config)) {
       return [config.totalSupply, config.name, config.symbol, ...defaultArgs];
@@ -122,7 +127,7 @@ abstract class TokenDeployer<
         }
       }
 
-      if (isCollateralTokenConfig(config)) {
+      if (isCollateralTokenConfig(config) || isXERC20TokenConfig(config)) {
         const provider = multiProvider.getProvider(chain);
 
         if (config.isNft) {


### PR DESCRIPTION
### Description

This PR supports checking the bufferCap and rateLimitPerSecond configuration of the warp route directly in the warp deploy config. 

### Backward compatibility

Yes

### Testing

Manually tested, since the velo xerc20 contracts are not yet referenced in the monorepo
