### PR TITLE
fix(release): process morph transactions as legacy

### DIFF
--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -933,6 +933,9 @@
         },
         {
           "http": "https://cloudflare-eth.com"
+        },
+        {
+          "http": "https://eth.drpc.org"
         }
       ],
       "staticAggregationHookFactory": "0x6D2555A8ba483CcF4409C39013F5e9a3285D3C9E",
@@ -3052,10 +3055,10 @@
       "aggregationHook": "0x8007d1e60991fB9BE1be26f70A7cE284fdE7da97",
       "blockExplorers": [
         {
-          "apiUrl": "https://worldchain-mainnet-explorer.alchemy.com/api",
-          "family": "blockscout",
-          "name": "World Chain explorer",
-          "url": "https://worldchain-mainnet-explorer.alchemy.com"
+          "apiUrl": "https://api.worldscan.org/api",
+          "family": "etherscan",
+          "name": "Worldscan",
+          "url": "https://worldscan.org"
         }
       ],
       "blocks": {
@@ -4721,6 +4724,9 @@
       "validatorAnnounce": "0x60B8d195f1b2EcaC26d54b95C69E6399cFD64b53",
       "index": {
         "from": 94151
+      },
+      "transactionOverrides": {
+        "gasPrice": 1000000
       }
     },
     "orderly": {
@@ -5946,10 +5952,10 @@
     "unichain": {
       "blockExplorers": [
         {
-          "apiUrl": "https://unichain.blockscout.com/api",
-          "family": "blockscout",
+          "apiUrl": "https://api.uniscan.xyz/api",
+          "family": "etherscan",
           "name": "Unichain Explorer",
-          "url": "https://unichain.blockscout.com"
+          "url": "https://uniscan.xyz"
         }
       ],
       "blocks": {

--- a/typescript/infra/config/environments/mainnet3/chains.ts
+++ b/typescript/infra/config/environments/mainnet3/chains.ts
@@ -45,6 +45,11 @@ export const chainMetadataOverrides: ChainMap<Partial<ChainMetadata>> = {
       maxPriorityFeePerGas: 50 * 10 ** 9, // 50 gwei
     },
   },
+  morph: {
+    transactionOverrides: {
+      gasPrice: 1 * 10 ** 6, // 0.001 gwei
+    },
+  },
   rootstockmainnet: {
     transactionOverrides: {
       gasPrice: 7 * 10 ** 7, // 0.07 gwei


### PR DESCRIPTION
### Description

- added transactionOverrides for morph based on the recent blocks on their explorer. They have had 0.2-05% full blocks for the past month.

### Drive-by changes

None

### Related issues

- fixes https://discord.com/channels/935678348330434570/1340007394368950372/1340007397183459348

### Backward compatibility

Yes

### Testing

None
