### PR TITLE
feat: tokio task metrics

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -4598,6 +4598,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-metrics",
  "tracing",
  "tracing-error",
  "tracing-futures",
@@ -9966,12 +9967,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-metrics"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eace09241d62c98b7eeb1107d4c5c64ca3bd7da92e8c218c153ab3a78f9be112"
+checksum = "cb2bb07a8451c4c6fa8b3497ad198510d8b8dffa5df5cfb97a64102a58b113c8"
 dependencies = [
  "futures-util",
  "pin-project-lite",
+ "tokio",
  "tokio-stream",
 ]
 

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -141,7 +141,7 @@ thiserror = "1.0"
 time = "0.3"
 tiny-keccak = "2.0.2"
 tokio = { version = "1.42.0", features = ["parking_lot", "tracing"] }
-tokio-metrics = { version = "0.3.1", default-features = false }
+tokio-metrics = { version = "0.4.0" }
 tokio-test = "0.4"
 toml_edit = "0.19.14"
 tonic = "0.12.3"

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -11,10 +11,10 @@ use futures_util::future::try_join_all;
 use hyperlane_base::{
     broadcast::BroadcastMpscSender,
     db::{HyperlaneRocksDB, DB},
-    metrics::{AgentMetrics, MetricsUpdater},
+    metrics::{AgentMetrics, ChainSpecificMetricsUpdater},
     settings::{ChainConf, IndexSettings},
     AgentMetadata, BaseAgent, ChainMetrics, ContractSyncMetrics, ContractSyncer, CoreMetrics,
-    HyperlaneAgentCore, SyncOptions,
+    HyperlaneAgentCore, RuntimeMetrics, SyncOptions,
 };
 use hyperlane_core::{
     rpc_clients::call_and_retry_n_times, ChainCommunicationError, ContractSyncCursor,
@@ -89,6 +89,7 @@ pub struct Relayer {
     // or move them in `core_metrics`, like the validator metrics
     agent_metrics: AgentMetrics,
     chain_metrics: ChainMetrics,
+    runtime_metrics: RuntimeMetrics,
     /// Tokio console server
     pub tokio_console_server: Option<console_subscriber::Server>,
 }
@@ -123,6 +124,7 @@ impl BaseAgent for Relayer {
         core_metrics: Arc<CoreMetrics>,
         agent_metrics: AgentMetrics,
         chain_metrics: ChainMetrics,
+        runtime_metrics: RuntimeMetrics,
         tokio_console_server: console_subscriber::Server,
     ) -> Result<Self>
     where
@@ -302,6 +304,7 @@ impl BaseAgent for Relayer {
             core_metrics,
             agent_metrics,
             chain_metrics,
+            runtime_metrics,
             tokio_console_server: Some(tokio_console_server),
         })
     }
@@ -349,7 +352,7 @@ impl BaseAgent for Relayer {
                 task_monitor.clone(),
             ));
 
-            let metrics_updater = MetricsUpdater::new(
+            let metrics_updater = ChainSpecificMetricsUpdater::new(
                 dest_conf,
                 self.core_metrics.clone(),
                 self.agent_metrics.clone(),
@@ -412,6 +415,8 @@ impl BaseAgent for Relayer {
             ));
             tasks.push(self.run_merkle_tree_processor(origin, task_monitor.clone()));
         }
+
+        tasks.push(self.runtime_metrics.spawn());
 
         if let Err(err) = try_join_all(tasks).await {
             tracing::error!(

--- a/rust/main/hyperlane-base/Cargo.toml
+++ b/rust/main/hyperlane-base/Cargo.toml
@@ -35,6 +35,7 @@ static_assertions.workspace = true
 tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "parking_lot"] }
+tokio-metrics.workspace = true
 tracing-error.workspace = true
 tracing-futures.workspace = true
 tracing-subscriber = { workspace = true, features = ["json", "ansi"] }

--- a/rust/main/hyperlane-base/src/agent.rs
+++ b/rust/main/hyperlane-base/src/agent.rs
@@ -8,7 +8,7 @@ use hyperlane_core::config::*;
 use tracing::info;
 
 use crate::{
-    metrics::{AgentMetrics, CoreMetrics},
+    metrics::{AgentMetrics, CoreMetrics, RuntimeMetrics},
     settings::Settings,
     ChainMetrics,
 };
@@ -46,6 +46,7 @@ pub trait BaseAgent: Send + Sync + Debug {
         metrics: Arc<CoreMetrics>,
         agent_metrics: AgentMetrics,
         chain_metrics: ChainMetrics,
+        tokio_runtime_monitor: RuntimeMetrics,
         tokio_console_server: console_subscriber::Server,
     ) -> Result<Self>
     where
@@ -89,15 +90,18 @@ pub async fn agent_main<A: BaseAgent>() -> Result<()> {
     let core_settings: &Settings = settings.as_ref();
 
     let metrics = settings.as_ref().metrics(A::AGENT_NAME)?;
+    let task_monitor = tokio_metrics::TaskMonitor::new();
     let tokio_server = core_settings.tracing.start_tracing(&metrics)?;
     let agent_metrics = AgentMetrics::new(&metrics)?;
     let chain_metrics = ChainMetrics::new(&metrics)?;
+    let runtime_metrics = RuntimeMetrics::new(&metrics, task_monitor)?;
     let agent = A::from_settings(
         agent_metadata,
         settings,
         metrics.clone(),
         agent_metrics,
         chain_metrics,
+        runtime_metrics,
         tokio_server,
     )
     .await?;

--- a/rust/main/hyperlane-base/src/metrics/agent_metrics.rs
+++ b/rust/main/hyperlane-base/src/metrics/agent_metrics.rs
@@ -149,14 +149,14 @@ pub struct AgentMetricsConf {
 }
 
 /// Utility struct to update various metrics using a standalone tokio task
-pub struct MetricsUpdater {
+pub struct ChainSpecificMetricsUpdater {
     agent_metrics: AgentMetrics,
     chain_metrics: ChainMetrics,
     conf: AgentMetricsConf,
     provider: Box<dyn HyperlaneProvider>,
 }
 
-impl MetricsUpdater {
+impl ChainSpecificMetricsUpdater {
     /// Creates a new instance of the `MetricsUpdater`
     pub async fn new(
         chain_conf: &ChainConf,
@@ -180,29 +180,29 @@ impl MetricsUpdater {
         let Some(wallet_addr) = self.conf.address.clone() else {
             return;
         };
-        let wallet_name = self.conf.name.clone();
+        let agent_name = self.conf.name.clone();
         let Some(wallet_balance_metric) = self.agent_metrics.wallet_balance.clone() else {
             return;
         };
         let chain = self.conf.domain.name();
 
         match self.provider.get_balance(wallet_addr.clone()).await {
-            Ok(balance) => {
-                let balance = u256_as_scaled_f64(balance, self.conf.domain.domain_protocol());
-                trace!("Wallet {wallet_name} ({wallet_addr}) on chain {chain} balance is {balance} of the native currency");
-                wallet_balance_metric
-                .with(&hashmap! {
-                    "chain" => chain,
-                    "wallet_address" => wallet_addr.as_str(),
-                    "wallet_name" => wallet_name.as_str(),
-                    "token_address" => "none",
-                    // Note: Whatever this `chain`'s native currency is
-                    "token_symbol" => "Native",
-                    "token_name" => "Native"
-                }).set(balance)
-            },
-            Err(e) => warn!("Metric update failed for wallet {wallet_name} ({wallet_addr}) on chain {chain} balance for native currency; {e}")
-        }
+                Ok(balance) => {
+                    let balance = u256_as_scaled_f64(balance, self.conf.domain.domain_protocol());
+                    trace!("Wallet {agent_name} ({wallet_addr}) on chain {chain} balance is {balance} of the native currency");
+                    wallet_balance_metric
+                    .with(&hashmap! {
+                        "chain" => chain,
+                        "wallet_address" => wallet_addr.as_str(),
+                        "wallet_name" => agent_name.as_str(),
+                        "token_address" => "none",
+                        // Note: Whatever this `chain`'s native currency is
+                        "token_symbol" => "Native",
+                        "token_name" => "Native"
+                    }).set(balance)
+                },
+                Err(e) => warn!("Metric update failed for wallet {agent_name} ({wallet_addr}) on chain {chain} balance for native currency; {e}")
+            }
     }
 
     async fn update_block_details(&self) {

--- a/rust/main/hyperlane-base/src/metrics/agent_metrics.rs
+++ b/rust/main/hyperlane-base/src/metrics/agent_metrics.rs
@@ -187,22 +187,22 @@ impl ChainSpecificMetricsUpdater {
         let chain = self.conf.domain.name();
 
         match self.provider.get_balance(wallet_addr.clone()).await {
-                Ok(balance) => {
-                    let balance = u256_as_scaled_f64(balance, self.conf.domain.domain_protocol());
-                    trace!("Wallet {agent_name} ({wallet_addr}) on chain {chain} balance is {balance} of the native currency");
-                    wallet_balance_metric
-                    .with(&hashmap! {
-                        "chain" => chain,
-                        "wallet_address" => wallet_addr.as_str(),
-                        "wallet_name" => agent_name.as_str(),
-                        "token_address" => "none",
-                        // Note: Whatever this `chain`'s native currency is
-                        "token_symbol" => "Native",
-                        "token_name" => "Native"
-                    }).set(balance)
-                },
-                Err(e) => warn!("Metric update failed for wallet {agent_name} ({wallet_addr}) on chain {chain} balance for native currency; {e}")
-            }
+            Ok(balance) => {
+                let balance = u256_as_scaled_f64(balance, self.conf.domain.domain_protocol());
+                trace!("Wallet {agent_name} ({wallet_addr}) on chain {chain} balance is {balance} of the native currency");
+                wallet_balance_metric
+                .with(&hashmap! {
+                    "chain" => chain,
+                    "wallet_address" => wallet_addr.as_str(),
+                    "wallet_name" => agent_name.as_str(),
+                    "token_address" => "none",
+                    // Note: Whatever this `chain`'s native currency is
+                    "token_symbol" => "Native",
+                    "token_name" => "Native"
+                }).set(balance)
+            },
+            Err(e) => warn!("Metric update failed for wallet {agent_name} ({wallet_addr}) on chain {chain} balance for native currency; {e}")
+        }
     }
 
     async fn update_block_details(&self) {

--- a/rust/main/hyperlane-base/src/metrics/core.rs
+++ b/rust/main/hyperlane-base/src/metrics/core.rs
@@ -12,7 +12,6 @@ use prometheus::{
     Encoder, GaugeVec, HistogramVec, IntCounterVec, IntGaugeVec, Registry,
 };
 use tokio::sync::RwLock;
-use tokio_metrics::RuntimeMetrics;
 
 use ethers_prometheus::{json_rpc_client::JsonRpcClientMetrics, middleware::MiddlewareMetrics};
 

--- a/rust/main/hyperlane-base/src/metrics/core.rs
+++ b/rust/main/hyperlane-base/src/metrics/core.rs
@@ -12,6 +12,7 @@ use prometheus::{
     Encoder, GaugeVec, HistogramVec, IntCounterVec, IntGaugeVec, Registry,
 };
 use tokio::sync::RwLock;
+use tokio_metrics::RuntimeMetrics;
 
 use ethers_prometheus::{json_rpc_client::JsonRpcClientMetrics, middleware::MiddlewareMetrics};
 

--- a/rust/main/hyperlane-base/src/metrics/mod.rs
+++ b/rust/main/hyperlane-base/src/metrics/mod.rs
@@ -10,5 +10,7 @@ mod core;
 mod agent_metrics;
 mod json_rpc_client;
 mod provider;
+mod runtime_metrics;
 
 pub use self::agent_metrics::*;
+pub use self::runtime_metrics::*;

--- a/rust/main/hyperlane-base/src/metrics/runtime_metrics.rs
+++ b/rust/main/hyperlane-base/src/metrics/runtime_metrics.rs
@@ -9,9 +9,7 @@ use tracing::{info_span, instrument::Instrumented, Instrument};
 
 use super::CoreMetrics;
 
-/// Expected label names for the `gas_price` metric.
-/// Help string for the metric.
-pub const RUNTIME_DROPPED_TASKS_HELP: &str = "The number of tasks dropped";
+const RUNTIME_DROPPED_TASKS_HELP: &str = "The number of tasks dropped";
 
 /// Metrics for the runtime
 pub struct RuntimeMetrics {

--- a/rust/main/hyperlane-base/src/metrics/runtime_metrics.rs
+++ b/rust/main/hyperlane-base/src/metrics/runtime_metrics.rs
@@ -1,0 +1,66 @@
+use std::{fmt::Debug, time::Duration};
+
+use eyre::Result;
+use hyperlane_core::metrics::agent::METRICS_SCRAPE_INTERVAL;
+use prometheus::IntGauge;
+use tokio::{task::JoinHandle, time::MissedTickBehavior};
+use tokio_metrics::{TaskMetrics, TaskMonitor};
+use tracing::{info_span, instrument::Instrumented, Instrument};
+
+use super::CoreMetrics;
+
+/// Expected label names for the `gas_price` metric.
+/// Help string for the metric.
+pub const RUNTIME_DROPPED_TASKS_HELP: &str = "The number of tasks dropped";
+
+/// Metrics for the runtime
+pub struct RuntimeMetrics {
+    producer: TaskMonitor,
+    dropped_tasks: IntGauge,
+}
+
+// Need this to be included in the agents structs
+impl Debug for RuntimeMetrics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RuntimeMetrics").finish()
+    }
+}
+
+impl RuntimeMetrics {
+    pub(crate) fn new(metrics: &CoreMetrics, task_monitor: TaskMonitor) -> Result<RuntimeMetrics> {
+        let dropped_tasks = metrics
+            .new_int_gauge("tokio_dropped_tasks", RUNTIME_DROPPED_TASKS_HELP, &[])?
+            .with_label_values(&[]);
+        let chain_metrics = Self {
+            producer: task_monitor,
+            dropped_tasks,
+        };
+        Ok(chain_metrics)
+    }
+
+    fn update(&mut self, metrics: TaskMetrics) {
+        self.dropped_tasks.add(metrics.dropped_count as i64);
+    }
+
+    /// Periodically updates the metrics
+    pub async fn start_updating_on_interval(mut self, period: Duration) {
+        let mut interval = tokio::time::interval(period);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let mut metric_intervals = self.producer.intervals();
+        loop {
+            if let Some(metrics) = metric_intervals.next() {
+                self.update(metrics);
+            }
+            interval.tick().await;
+        }
+    }
+
+    /// Spawns a tokio task to update the metrics
+    pub fn spawn(self) -> Instrumented<JoinHandle<()>> {
+        tokio::spawn(async move {
+            self.start_updating_on_interval(METRICS_SCRAPE_INTERVAL)
+                .await;
+        })
+        .instrument(info_span!("RuntimeMetricsUpdater"))
+    }
+}

--- a/rust/main/utils/run-locally/src/invariants/termination_invariants.rs
+++ b/rust/main/utils/run-locally/src/invariants/termination_invariants.rs
@@ -20,7 +20,6 @@ pub fn termination_invariants_met(
     config: &Config,
     starting_relayer_balance: f64,
 ) -> eyre::Result<bool> {
-    return Ok(false);
     let eth_messages_expected = (config.kathy_messages / 2) as u32 * 2;
 
     // this is total messages expected to be delivered

--- a/rust/main/utils/run-locally/src/invariants/termination_invariants.rs
+++ b/rust/main/utils/run-locally/src/invariants/termination_invariants.rs
@@ -213,6 +213,14 @@ pub fn relayer_termination_invariants_met(
         total_messages_expected + non_matching_igp_message_count + double_insertion_message_count,
     );
 
+    let dropped_tasks = fetch_metric(
+        RELAYER_METRICS_PORT,
+        "hyperlane_tokio_dropped_tasks",
+        &hashmap! {"agent" => "relayer"},
+    )?;
+
+    assert_eq!(dropped_tasks.first().unwrap(), 0);
+
     if !relayer_balance_check(starting_relayer_balance)? {
         return Ok(false);
     }

--- a/rust/main/utils/run-locally/src/invariants/termination_invariants.rs
+++ b/rust/main/utils/run-locally/src/invariants/termination_invariants.rs
@@ -20,6 +20,7 @@ pub fn termination_invariants_met(
     config: &Config,
     starting_relayer_balance: f64,
 ) -> eyre::Result<bool> {
+    return Ok(false);
     let eth_messages_expected = (config.kathy_messages / 2) as u32 * 2;
 
     // this is total messages expected to be delivered


### PR DESCRIPTION
### Description

We recently had a critical bug on RC where the submitter task crashed due to a panic (https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5487). We've had similar issues in the past, where one tokio task getting dropped wasn't detected by alerts and was only discovered later.

This PR integrates tokio-metrics with our Prometheus setup and exposes one of the metrics available: `dropped_tasks`, which tracked in prometheus as the cumulative count of all tasks ever dropped. In e2e this metric is zero after invariants pass - in prod I think we'll alert if this ever becomes nonzero.

Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5466

### Drive-by changes

No

### Backward compatibility

Yes

### Testing

Checked in e2e that the new metric exists, otherwise relying on correctness from tokio-metrics
