### PR TITLE
refactor: move registry functions to @hyperlane-xyz/registry

### DIFF
--- a/.changeset/rude-wasps-do.md
+++ b/.changeset/rude-wasps-do.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/infra': minor
+'@hyperlane-xyz/cli': minor
+---
+
+Move getRegistry function from the CLI to `@hyperlane-xyz/registry` package.

--- a/typescript/cli/src/index.ts
+++ b/typescript/cli/src/index.ts
@@ -1,1 +1,0 @@
-export { getRegistry } from './context/context.js';

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -1,4 +1,4 @@
-import { getRegistry } from '@hyperlane-xyz/cli';
+import { getRegistry } from '@hyperlane-xyz/registry';
 import {
   ChainMap,
   ChainSubmissionStrategy,

--- a/typescript/infra/test/warp-configs.test.ts
+++ b/typescript/infra/test/warp-configs.test.ts
@@ -1,10 +1,9 @@
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
-import { getRegistry } from '@hyperlane-xyz/cli';
-import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
+import { DEFAULT_GITHUB_REGISTRY, getRegistry } from '@hyperlane-xyz/registry';
 import { MultiProvider } from '@hyperlane-xyz/sdk';
-import { diffObjMerge } from '@hyperlane-xyz/utils';
+import { diffObjMerge, rootLogger } from '@hyperlane-xyz/utils';
 
 import { getWarpConfig, warpConfigGetterMap } from '../config/warp.js';
 import {
@@ -29,6 +28,7 @@ describe('Warp Configs', async function () {
     configsFromGithub = await getRegistry(
       [DEFAULT_GITHUB_REGISTRY],
       true,
+      rootLogger,
     ).getWarpDeployConfigs();
   });
 

--- a/typescript/infra/test/warpIds.test.ts
+++ b/typescript/infra/test/warpIds.test.ts
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 
-import { getRegistry } from '@hyperlane-xyz/cli';
-import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
+import { DEFAULT_GITHUB_REGISTRY, getRegistry } from '@hyperlane-xyz/registry';
+import { rootLogger } from '@hyperlane-xyz/utils';
 
 import { WarpRouteIds } from '../config/environments/mainnet3/warp/warpIds.js';
 
 describe('Warp IDs', () => {
   it('Has all warp IDs in the registry', () => {
-    const registry = getRegistry([DEFAULT_GITHUB_REGISTRY], true);
+    const registry = getRegistry([DEFAULT_GITHUB_REGISTRY], true, rootLogger);
     for (const warpId of Object.values(WarpRouteIds)) {
       // That's a long sentence!
       expect(


### PR DESCRIPTION
### Description

This PR moves the registry-related functionality from the CLI package to the dedicated `@hyperlane-xyz/registry` package. The main changes include:

- Relocating `getRegistry()` function and its dependencies from CLI to registry package
- Updating imports across the codebase to use the new location
- Adding logger parameter to `getRegistry()` function for better logging control

### Drive-by changes

None

### Related issues

N/A

### Backward compatibility

Yes - This is a pure refactor with no functional changes

### Testing

Unit Tests - Existing tests were updated to use the new import paths