### PR TITLE
chore: set abstract chain reorg period to 1

### DIFF
--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -7781,7 +7781,7 @@
       "blocks": {
         "confirmations": 1,
         "estimateBlockTime": 1,
-        "reorgPeriod": 0
+        "reorgPeriod": 1
       },
       "chainId": 2741,
       "deployer": {


### PR DESCRIPTION
### Description

@paulbalaji reported that from time to time we get warnings on abstract. The failure happens in the `latest_sequence_count_and_tip` calls, where we query the last block number from the provider, and then we fail when trying to read storage at that block.

Logs here: https://cloudlogging.app.goo.gl/BGwu9Q8BXB237ikz9

I had a quick look at the finality of Abstract and they suggest reorgs **can** happen: https://docs.abs.xyz/infrastructure/nodes/components#reorg-detector

So I've set the reorg period to 1 to hopefully avoid those warnings and be slightly better protected against reorgs (source code [here](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/b8743744f133b0bec7022c48f99d446968222ee0/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs#L206)), and I also created an issue to review finality of all zksync stack chains: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5497
