### PR TITLE
chore: deploy sealevel provider metrics

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -697,7 +697,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'bd0b886-20250218-210634',
+      tag: 'c94eb46-20250219-132827',
     },
     blacklist,
     gasPaymentEnforcement: gasPaymentEnforcement,
@@ -732,7 +732,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '328011a-20250218-173927',
+      tag: 'c94eb46-20250219-132827',
     },
     blacklist,
     // We're temporarily (ab)using the RC relayer as a way to increase


### PR DESCRIPTION
### Description

deploys the changes from https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5434 to the hyperlane context. They've been tested on RC with a bunch of providers to make sure we capture both successful and failed calls.

See the dashboard here: https://abacusworks.grafana.net/goto/R7gtDxcHg?orgId=1
