### PR TITLE
feat: Increase max-depth tree

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base.rs
@@ -292,7 +292,7 @@ pub struct BaseMetadataBuilder {
     metrics: Arc<CoreMetrics>,
     db: HyperlaneRocksDB,
     app_context_classifier: IsmAwareAppContextClassifier,
-    #[new(value = "7")]
+    #[new(value = "13")]
     max_depth: u32,
 }
 


### PR DESCRIPTION
### Description

We now face ISM trees which are deeper than the configured default
