### PR TITLE
feat: xerc20 safe tx submission improvements

### DIFF
--- a/typescript/infra/scripts/xerc20/xerc20vs-add-bridge.ts
+++ b/typescript/infra/scripts/xerc20/xerc20vs-add-bridge.ts
@@ -10,8 +10,8 @@ import {
 import {
   addBridgeToChain,
   deriveBridgesConfig,
+  getAndValidateBridgesToUpdate,
   getWarpConfigsAndArtifacts,
-  validateConfigChains,
 } from '../../src/xerc20/utils.js';
 import {
   getArgs,
@@ -42,11 +42,11 @@ async function main() {
 
   // if chains are provided, validate that they are in the warp config
   // throw an error if they are not
-  validateConfigChains(chains, bridgesConfig);
+  const bridgesToUpdate = getAndValidateBridgesToUpdate(chains, bridgesConfig);
 
   const erroredChains: string[] = [];
 
-  for (const [_, bridgeConfig] of Object.entries(bridgesConfig)) {
+  for (const bridgeConfig of bridgesToUpdate) {
     try {
       await addBridgeToChain({
         chain: bridgeConfig.chain,

--- a/typescript/infra/scripts/xerc20/xerc20vs-add-bridge.ts
+++ b/typescript/infra/scripts/xerc20/xerc20vs-add-bridge.ts
@@ -11,6 +11,7 @@ import {
   addBridgeToChain,
   deriveBridgesConfig,
   getWarpConfigsAndArtifacts,
+  validateConfigChains,
 } from '../../src/xerc20/utils.js';
 import {
   getArgs,
@@ -39,19 +40,9 @@ async function main() {
     envMultiProvider,
   );
 
-  const configChains = Object.keys(bridgesConfig);
-  if (chains) {
-    const missingChains = chains.filter(
-      (chain) => !configChains.includes(chain),
-    );
-    if (missingChains.length > 0) {
-      throw new Error(
-        `The following chains are not in the provided warp config: ${missingChains.join(
-          ', ',
-        )}`,
-      );
-    }
-  }
+  // if chains are provided, validate that they are in the warp config
+  // throw an error if they are not
+  validateConfigChains(chains, bridgesConfig);
 
   const erroredChains: string[] = [];
 

--- a/typescript/infra/scripts/xerc20/xerc20vs-add-bridge.ts
+++ b/typescript/infra/scripts/xerc20/xerc20vs-add-bridge.ts
@@ -14,6 +14,7 @@ import {
 } from '../../src/xerc20/utils.js';
 import {
   getArgs,
+  withChains,
   withDryRun,
   withWarpRouteIdRequired,
 } from '../agent-utils.js';
@@ -21,8 +22,8 @@ import { getEnvironmentConfig } from '../core-utils.js';
 
 async function main() {
   configureRootLogger(LogFormat.Pretty, LogLevel.Info);
-  const { environment, warpRouteId, dryRun } = await withWarpRouteIdRequired(
-    withDryRun(getArgs()),
+  const { environment, warpRouteId, chains, dryRun } = await withChains(
+    withWarpRouteIdRequired(withDryRun(getArgs())),
   ).argv;
 
   const { warpDeployConfig, warpCoreConfig } =
@@ -37,6 +38,20 @@ async function main() {
     warpCoreConfig,
     envMultiProvider,
   );
+
+  const configChains = Object.keys(bridgesConfig);
+  if (chains) {
+    const missingChains = chains.filter(
+      (chain) => !configChains.includes(chain),
+    );
+    if (missingChains.length > 0) {
+      throw new Error(
+        `The following chains are not in the provided warp config: ${missingChains.join(
+          ', ',
+        )}`,
+      );
+    }
+  }
 
   const erroredChains: string[] = [];
 

--- a/typescript/infra/scripts/xerc20/xerc20vs-set-limits.ts
+++ b/typescript/infra/scripts/xerc20/xerc20vs-set-limits.ts
@@ -14,6 +14,7 @@ import {
 } from '../../src/xerc20/utils.js';
 import {
   getArgs,
+  withChains,
   withDryRun,
   withWarpRouteIdRequired,
 } from '../agent-utils.js';
@@ -21,8 +22,8 @@ import { getEnvironmentConfig } from '../core-utils.js';
 
 async function main() {
   configureRootLogger(LogFormat.Pretty, LogLevel.Info);
-  const { environment, warpRouteId, dryRun } = await withWarpRouteIdRequired(
-    withDryRun(getArgs()),
+  const { environment, warpRouteId, chains, dryRun } = await withChains(
+    withWarpRouteIdRequired(withDryRun(getArgs())),
   ).argv;
 
   const { warpDeployConfig, warpCoreConfig } =
@@ -36,6 +37,20 @@ async function main() {
     warpCoreConfig,
     envMultiProvider,
   );
+
+  const configChains = Object.keys(bridgesConfig);
+  if (chains) {
+    const missingChains = chains.filter(
+      (chain) => !configChains.includes(chain),
+    );
+    if (missingChains.length > 0) {
+      throw new Error(
+        `The following chains are not in the provided warp config: ${missingChains.join(
+          ', ',
+        )}`,
+      );
+    }
+  }
 
   const erroredChains: string[] = [];
 

--- a/typescript/infra/scripts/xerc20/xerc20vs-set-limits.ts
+++ b/typescript/infra/scripts/xerc20/xerc20vs-set-limits.ts
@@ -11,6 +11,7 @@ import {
   deriveBridgesConfig,
   getWarpConfigsAndArtifacts,
   updateChainLimits,
+  validateConfigChains,
 } from '../../src/xerc20/utils.js';
 import {
   getArgs,
@@ -32,25 +33,16 @@ async function main() {
   const envConfig = getEnvironmentConfig(environment);
   const multiProtocolProvider = await envConfig.getMultiProtocolProvider();
   const envMultiProvider = await envConfig.getMultiProvider();
+
   const bridgesConfig = await deriveBridgesConfig(
     warpDeployConfig,
     warpCoreConfig,
     envMultiProvider,
   );
 
-  const configChains = Object.keys(bridgesConfig);
-  if (chains) {
-    const missingChains = chains.filter(
-      (chain) => !configChains.includes(chain),
-    );
-    if (missingChains.length > 0) {
-      throw new Error(
-        `The following chains are not in the provided warp config: ${missingChains.join(
-          ', ',
-        )}`,
-      );
-    }
-  }
+  // if chains are provided, validate that they are in the warp config
+  // throw an error if they are not
+  validateConfigChains(chains, bridgesConfig);
 
   const erroredChains: string[] = [];
 

--- a/typescript/infra/scripts/xerc20/xerc20vs-set-limits.ts
+++ b/typescript/infra/scripts/xerc20/xerc20vs-set-limits.ts
@@ -9,9 +9,9 @@ import {
 
 import {
   deriveBridgesConfig,
+  getAndValidateBridgesToUpdate,
   getWarpConfigsAndArtifacts,
   updateChainLimits,
-  validateConfigChains,
 } from '../../src/xerc20/utils.js';
 import {
   getArgs,
@@ -42,11 +42,11 @@ async function main() {
 
   // if chains are provided, validate that they are in the warp config
   // throw an error if they are not
-  validateConfigChains(chains, bridgesConfig);
+  const bridgesToUpdate = getAndValidateBridgesToUpdate(chains, bridgesConfig);
 
   const erroredChains: string[] = [];
 
-  for (const [_, bridgeConfig] of Object.entries(bridgesConfig)) {
+  for (const bridgeConfig of bridgesToUpdate) {
     try {
       await updateChainLimits({
         chain: bridgeConfig.chain,

--- a/typescript/infra/src/utils/safe.ts
+++ b/typescript/infra/src/utils/safe.ts
@@ -32,12 +32,12 @@ export async function getSafeAndService(
   multiProvider: MultiProvider,
   safeAddress: Address,
 ) {
+  const safeService: SafeApiKit.default = getSafeService(chain, multiProvider);
   const safeSdk: Safe.default = await retryAsync(
     () => getSafe(chain, multiProvider, safeAddress),
     5,
     1000,
   );
-  const safeService: SafeApiKit.default = getSafeService(chain, multiProvider);
   return { safeSdk, safeService };
 }
 

--- a/typescript/infra/src/xerc20/utils.ts
+++ b/typescript/infra/src/xerc20/utils.ts
@@ -8,6 +8,7 @@ import {
   Ownable__factory,
 } from '@hyperlane-xyz/core';
 import {
+  ChainMap,
   ChainName,
   EvmHypVSXERC20Adapter,
   EvmHypVSXERC20LockboxAdapter,
@@ -620,6 +621,27 @@ function getHypVSXERC20Adapter(
       chainName,
       multiProtocolProvider,
       addresses,
+    );
+  }
+}
+
+export function validateConfigChains(
+  chains: string[] | undefined,
+  bridgesConfig: ChainMap<BridgeConfig>,
+) {
+  if (!chains) {
+    return;
+  }
+
+  const configChains = Object.keys(bridgesConfig);
+  const nonConfigChains = chains.filter(
+    (chain) => !configChains.includes(chain),
+  );
+  if (nonConfigChains.length > 0) {
+    throw new Error(
+      `The following chains are not in the provided warp config: ${nonConfigChains.join(
+        ', ',
+      )}`,
     );
   }
 }

--- a/typescript/infra/src/xerc20/utils.ts
+++ b/typescript/infra/src/xerc20/utils.ts
@@ -201,7 +201,7 @@ export async function updateChainLimits({
   ) as PopulatedTransaction[];
   if (txsToSend.length === 0) {
     rootLogger.info(
-      chalk.yellow(`[${chain}][${bridgeAddress}] Nothing to update`),
+      chalk.blue(`[${chain}][${bridgeAddress}] Nothing to update`),
     );
     return;
   }
@@ -631,14 +631,17 @@ function getHypVSXERC20Adapter(
   }
 }
 
-export function validateConfigChains(
+export function getAndValidateBridgesToUpdate(
   chains: string[] | undefined,
   bridgesConfig: Record<string, BridgeConfig>,
-) {
+): BridgeConfig[] {
+  // if no chains are provided, return all configs
   if (!chains || chains.length === 0) {
-    return;
+    return Object.values(bridgesConfig);
   }
 
+  // check that all provided chains are in the warp config
+  // throw an error if any are not
   const configChains = Object.values(bridgesConfig).map(
     (config) => config.chain,
   );
@@ -652,4 +655,9 @@ export function validateConfigChains(
       )}`,
     );
   }
+
+  // return only the configs that are in the chains array
+  return Object.values(bridgesConfig).filter((config) =>
+    chains.includes(config.chain),
+  );
 }


### PR DESCRIPTION
### Description

feat: xerc20 safe tx submission improvements
- use getSafeAndService infra util where possible instead of SDK directly (to have retry logic)
- refactor sendTransaction logic to better leverage MultiSend
- add --chains filter

![image](https://github.com/user-attachments/assets/c3201fd5-b83c-420c-af51-6f3881ae68a4)


### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

manual