### PR TITLE
chore: upgrade to rust 1.85.0

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM rust:1.80.1 as builder
+FROM rust:1.85.0 as builder
 WORKDIR /usr/src
 
 # 1a: Prepare for static linking

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
@@ -215,7 +215,7 @@ where
         &'a self,
         method: &'a str,
         params: &'a Value,
-    ) -> FuturesUnordered<impl Future<Output = Result<Value, HttpClientError>> + Sized + '_> {
+    ) -> FuturesUnordered<impl Future<Output = Result<Value, HttpClientError>> + Sized + 'a> {
         let unordered = FuturesUnordered::new();
         self.inner
             .providers

--- a/rust/main/hyperlane-core/src/accumulator/merkle.rs
+++ b/rust/main/hyperlane-core/src/accumulator/merkle.rs
@@ -198,7 +198,7 @@ impl MerkleTree {
             Zero(_) => {
                 *self = MerkleTree::create(&[elem], depth);
             }
-            Node(ref mut hash, ref mut left, ref mut right) => {
+            Node(hash, left, right) => {
                 let left: &mut MerkleTree = &mut *left;
                 let right: &mut MerkleTree = &mut *right;
                 match (&*left, &*right) {

--- a/rust/main/hyperlane-core/src/lib.rs
+++ b/rust/main/hyperlane-core/src/lib.rs
@@ -4,7 +4,6 @@
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
 #![allow(unknown_lints)] // TODO: `rustc` 1.80.1 clippy issue
-#![forbid(where_clauses_object_safety)]
 extern crate core;
 
 pub use chain::*;

--- a/rust/main/hyperlane-core/src/types/primitive_types.rs
+++ b/rust/main/hyperlane-core/src/types/primitive_types.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::assign_op_pattern)]
 #![allow(clippy::reversed_empty_ranges)]
+#![allow(unexpected_cfgs)]
 
 use std::{
     ops::{Div, Mul},

--- a/rust/main/hyperlane-test/src/lib.rs
+++ b/rust/main/hyperlane-test/src/lib.rs
@@ -3,7 +3,6 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(test, warn(missing_docs))]
 #![allow(unknown_lints)] // TODO: `rustc` 1.80.1 clippy issue
-#![forbid(where_clauses_object_safety)]
 
 /// Mock contracts
 pub mod mocks;

--- a/rust/main/rust-toolchain
+++ b/rust/main/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.80.1"
+channel = "1.85.0"
 profile = "default"

--- a/rust/main/utils/abigen/src/lib.rs
+++ b/rust/main/utils/abigen/src/lib.rs
@@ -131,7 +131,7 @@ pub fn generate_bindings(
 #[cfg(feature = "fmt")]
 fn fmt_file(path: &Path) {
     if let Err(err) = std::process::Command::new(rustfmt_path())
-        .args(["--edition", "2024"])
+        .args(["--edition", "2021"])
         .arg(path)
         .output()
     {

--- a/rust/main/utils/abigen/src/lib.rs
+++ b/rust/main/utils/abigen/src/lib.rs
@@ -5,6 +5,7 @@ use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
+use std::path::PathBuf;
 
 use inflector::Inflector;
 
@@ -130,7 +131,7 @@ pub fn generate_bindings(
 #[cfg(feature = "fmt")]
 fn fmt_file(path: &Path) {
     if let Err(err) = std::process::Command::new(rustfmt_path())
-        .args(["--edition", "2021"])
+        .args(["--edition", "2024"])
         .arg(path)
         .output()
     {
@@ -140,26 +141,11 @@ fn fmt_file(path: &Path) {
 
 /// Get the rustfmt binary path.
 #[cfg(feature = "fmt")]
-fn rustfmt_path() -> &'static Path {
-    use std::path::PathBuf;
-
-    // lazy static var
-    static mut PATH: Option<PathBuf> = None;
-
-    if let Some(path) = unsafe { PATH.as_ref() } {
-        return path;
-    }
-
+fn rustfmt_path() -> PathBuf {
     if let Ok(path) = std::env::var("RUSTFMT") {
-        unsafe {
-            PATH = Some(PathBuf::from(path));
-            PATH.as_ref().unwrap()
-        }
+        PathBuf::from(path)
     } else {
         // assume it is in PATH
-        unsafe {
-            PATH = Some(which::which("rustmft").unwrap_or_else(|_| "rustfmt".into()));
-            PATH.as_ref().unwrap()
-        }
+        which::which("rustmft").unwrap_or_else(|_| "rustfmt".into())
     }
 }


### PR DESCRIPTION
### Description

So we can start using async closures instead of closures that return boxed futures.

Unfortunately we can't upgrade to the Rust 2024 edition yet due to the sealevel workspace.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
