### PR TITLE
chore: fix GITHUB_API_HOST constant

### DIFF
--- a/typescript/github-proxy/src/index.ts
+++ b/typescript/github-proxy/src/index.ts
@@ -3,7 +3,7 @@ import { DISALLOWED_URL_MSG } from './errors.js';
 const GITHUB_API_ALLOWLIST = [
   '/repos/hyperlane-xyz/hyperlane-registry/git/trees/main',
 ];
-const GITPUB_API_HOST = 'https://api.github.com';
+const GITHUB_API_HOST = 'https://api.github.com';
 export default {
   async fetch(request, env, _ctx): Promise<Response> {
     const apiUrlPath = new URL(request.url).pathname;


### PR DESCRIPTION
### Description
 
Noticed a typo in the `GITHUB_API_HOST` constant— it was mistakenly written as `GITPUB_API_HOST`.
This could have caused issues when constructing `apiUrl`.

Fixed it to ensure the correct GitHub API host is used.