### PR TITLE
feat(warp): Add pumpBTC/ethereum-unichain warp route

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
@@ -75,4 +75,5 @@ export enum WarpRouteIds {
   ArbitrumEthereumSolanaTreasureSMOL = 'SMOL/arbitrum-ethereum-solanamainnet-treasure',
   BaseSolanaCDX = 'CDX/base-solanamainnet',
   HyperevmSolanaSOL = 'SOL/hyperevm-solanamainnet',
+  EthereumUnichainPumpBTC = 'pumpBTCuni/ethereum-unichain',
 }

--- a/typescript/infra/src/warp/helm.ts
+++ b/typescript/infra/src/warp/helm.ts
@@ -29,7 +29,7 @@ export class WarpRouteMonitorHelmManager extends HelmManager {
     return {
       image: {
         repository: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-        tag: '4da3333-20250219-171102',
+        tag: 'd00126c-20250224-205507',
       },
       warpRouteId: this.warpRouteId,
       fullnameOverride: this.helmReleaseName,


### PR DESCRIPTION
### Description
- Add pumpBTC/ethereum-unichain warp route
- Accompanying registry PR https://github.com/hyperlane-xyz/hyperlane-registry/pull/616 
- dashboard: https://abacusworks.grafana.net/d/ddz6ma94rnzswc/warp-routes?orgId=1&var-warp_route_id=pumpBTC.uni%2Fethereum-unichain&from=now-30m&to=now&timezone=browser

### Testing

Manual

- outbound transfer https://explorer.hyperlane.xyz/message/0xd08c3ce12f0258d4f363e7af416734f2afb9e93e84bb39705d511f90d793b0a3
- inbound transfer https://explorer.hyperlane.xyz/message/0x6ec6c36716fa5d5b8e7e89dd98e10a9405ca14f742e9c655e52ced8042c7e5fb