### PR TITLE
chore: remove sealevel priority fees

### DIFF
--- a/.changeset/loud-radios-remember.md
+++ b/.changeset/loud-radios-remember.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Remove priority fee for sealevel non-solana chains

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -555,10 +555,18 @@ export abstract class SealevelHypTokenAdapter
 
   /**
    * Fetches the median prioritization fee for transfers of the collateralAddress token.
-   * @returns The median prioritization fee in micro-lamports
+   * @returns The median prioritization fee in micro-lamports, defaults to `0` when chain is not solanamainnet
    */
   async getMedianPriorityFee(): Promise<number | undefined> {
     this.logger.debug('Fetching priority fee history for token transfer');
+
+    // Currently only transactions done in solana requires a priority
+    if (this.chainName !== 'solanamainnet') {
+      this.logger.debug(
+        `Chain ${this.chainName} does not need priority fee, defaulting to 0`,
+      );
+      return 0;
+    }
 
     const collateralAddress = this.addresses.token;
     const fees = await this.getProvider().getRecentPrioritizationFees({


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

Default to `0` for `Sealevel` chains that are not `solanamainnet`

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->
No

### Related issues

<!--
- Fixes #[issue number here]
-->
Fixes this [issue](https://github.com/hyperlane-xyz/issues/issues/1415)
### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
Tested in Warp UI:
Solana <> Eclipse https://explorer.eclipse.xyz/tx/2WNYksY9bTbXW8tWZVPRbf5JMQ2MbdiQ7j2j7mMpvq2XpmirNcYDPp3PYKharvidrbfSyy36sVXUgk7EamEQexRC
Solana <> Soon
https://explorer.soo.network/tx/3Sdia7mM3eowhthetDQhNG5FyfU43zNYQYSJNcX8yNXLwg3UjGy9YErXMpuySxHLfaDiFVXr4fCxtEyYYSzjQxMe


