### PR TITLE
fix: Prevent key-funder from IGP claiming on berachain berabartio testnet

### DIFF
--- a/typescript/infra/config/environments/testnet4/funding.ts
+++ b/typescript/infra/config/environments/testnet4/funding.ts
@@ -92,6 +92,8 @@ export const keyFunderConfig: KeyFunderConfig<
   igpClaimThresholdPerChain: {
     alfajores: '1',
     arbitrumsepolia: '0.05',
+    // never claim on celo berabartio testnet
+    berabartio: '1000.0',
     basesepolia: '0.05',
     bsctestnet: '1',
     connextsepolia: '0.1',

--- a/typescript/infra/config/environments/testnet4/funding.ts
+++ b/typescript/infra/config/environments/testnet4/funding.ts
@@ -92,7 +92,7 @@ export const keyFunderConfig: KeyFunderConfig<
   igpClaimThresholdPerChain: {
     alfajores: '1',
     arbitrumsepolia: '0.05',
-    // never claim on celo berabartio testnet
+    // never claim on berachain berabartio testnet
     berabartio: '1000.0',
     basesepolia: '0.05',
     bsctestnet: '1',


### PR DESCRIPTION
### Description

Key funder cannot place a claiming transaction on Berachain Berabartio testnet. We are disabling Berabartio testnet at this time.

### Backward compatibility

Yes

### Testing

Manual run of key-funder