### PR TITLE
refactor: extract ISM and Hook factory addresses into reusable utilit…

### DIFF
--- a/.changeset/gold-points-turn.md
+++ b/.changeset/gold-points-turn.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+Extracted ISM and Hook factory addresses into a reusable utility function to reduce repetition and improve maintainability.

--- a/typescript/sdk/src/core/EvmCoreModule.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.ts
@@ -44,6 +44,7 @@ import { IsmConfig } from '../ism/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
 import { ChainName, ChainNameOrId } from '../types.js';
+import { extractIsmAndHookFactoryAddresses } from '../utils/ism.js';
 
 import {
   HyperlaneModule,
@@ -199,29 +200,14 @@ export class EvmCoreModule extends HyperlaneModule<
     deployedIsm: Address;
     ismUpdateTxs: AnnotatedEV5Transaction[];
   }> {
-    const {
-      mailbox,
-      domainRoutingIsmFactory,
-      staticAggregationIsmFactory,
-      staticAggregationHookFactory,
-      staticMessageIdMultisigIsmFactory,
-      staticMerkleRootMultisigIsmFactory,
-      staticMerkleRootWeightedMultisigIsmFactory,
-      staticMessageIdWeightedMultisigIsmFactory,
-    } = this.serialize();
+    const { mailbox } = this.serialize();
 
     const ismModule = new EvmIsmModule(this.multiProvider, {
       chain: this.args.chain,
       config: expectDefaultIsmConfig,
       addresses: {
         mailbox,
-        domainRoutingIsmFactory,
-        staticAggregationIsmFactory,
-        staticAggregationHookFactory,
-        staticMessageIdMultisigIsmFactory,
-        staticMerkleRootMultisigIsmFactory,
-        staticMerkleRootWeightedMultisigIsmFactory,
-        staticMessageIdWeightedMultisigIsmFactory,
+        ...extractIsmAndHookFactoryAddresses(this.serialize()),
         deployedIsm: actualDefaultIsmConfig.address,
       },
     });

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -625,7 +625,11 @@ export {
   // @ts-ignore
 } from './utils/gnosisSafe.js';
 export { HyperlaneReader } from './utils/HyperlaneReader.js';
-export { multisigIsmVerificationCost, normalizeConfig } from './utils/ism.js';
+export {
+  multisigIsmVerificationCost,
+  normalizeConfig,
+  extractIsmAndHookFactoryAddresses,
+} from './utils/ism.js';
 export { MultiGeneric } from './utils/MultiGeneric.js';
 export { isCompliant, validateZodResult } from './utils/schemas.js';
 export {

--- a/typescript/sdk/src/token/EvmERC20WarpModule.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.ts
@@ -38,6 +38,7 @@ import { DerivedIsmConfig } from '../ism/EvmIsmReader.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
 import { ChainName, ChainNameOrId } from '../types.js';
+import { extractIsmAndHookFactoryAddresses } from '../utils/ism.js';
 
 import { EvmERC20WarpRouteReader } from './EvmERC20WarpRouteReader.js';
 import { HypERC20Deployer } from './deploy.js';
@@ -465,16 +466,6 @@ export class EvmERC20WarpModule extends HyperlaneModule<
       `No hook deployed for warp route, deploying new hook on ${this.args.chain} chain`,
     );
 
-    const {
-      staticMerkleRootMultisigIsmFactory,
-      staticMessageIdMultisigIsmFactory,
-      staticAggregationIsmFactory,
-      staticAggregationHookFactory,
-      domainRoutingIsmFactory,
-      staticMerkleRootWeightedMultisigIsmFactory,
-      staticMessageIdWeightedMultisigIsmFactory,
-    } = this.args.addresses;
-
     assert(expectedConfig.hook, 'Hook is undefined');
     assert(
       expectedConfig.proxyAdmin?.address,
@@ -484,15 +475,9 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     const hookModule = await EvmHookModule.create({
       chain: this.args.chain,
       config: expectedConfig.hook,
-      proxyFactoryFactories: {
-        staticMerkleRootMultisigIsmFactory,
-        staticMessageIdMultisigIsmFactory,
-        staticAggregationIsmFactory,
-        staticAggregationHookFactory,
-        domainRoutingIsmFactory,
-        staticMerkleRootWeightedMultisigIsmFactory,
-        staticMessageIdWeightedMultisigIsmFactory,
-      },
+      proxyFactoryFactories: extractIsmAndHookFactoryAddresses(
+        this.args.addresses,
+      ),
       coreAddresses: {
         mailbox: expectedConfig.mailbox,
         proxyAdmin: expectedConfig.proxyAdmin?.address, // Assume that a proxyAdmin is always deployed with a WarpRoute
@@ -511,16 +496,6 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     deployedHook: Address;
     updateTransactions: AnnotatedEV5Transaction[];
   }> {
-    const {
-      staticMerkleRootMultisigIsmFactory,
-      staticMessageIdMultisigIsmFactory,
-      staticAggregationIsmFactory,
-      staticAggregationHookFactory,
-      domainRoutingIsmFactory,
-      staticMerkleRootWeightedMultisigIsmFactory,
-      staticMessageIdWeightedMultisigIsmFactory,
-    } = this.args.addresses;
-
     assert(actualConfig.proxyAdmin?.address, 'ProxyAdmin address is undefined');
     assert(actualConfig.hook, 'Hook is undefined');
 
@@ -530,13 +505,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
         chain: this.args.chain,
         config: actualConfig.hook,
         addresses: {
-          staticMerkleRootMultisigIsmFactory,
-          staticMessageIdMultisigIsmFactory,
-          staticAggregationIsmFactory,
-          staticAggregationHookFactory,
-          domainRoutingIsmFactory,
-          staticMerkleRootWeightedMultisigIsmFactory,
-          staticMessageIdWeightedMultisigIsmFactory,
+          ...extractIsmAndHookFactoryAddresses(this.args.addresses),
           mailbox: actualConfig.mailbox,
           proxyAdmin: actualConfig.proxyAdmin?.address,
           deployedHook: (actualConfig.hook as DerivedHookConfig).address,

--- a/typescript/sdk/src/utils/ism.ts
+++ b/typescript/sdk/src/utils/ism.ts
@@ -1,5 +1,5 @@
 import { ChainAddresses } from '@hyperlane-xyz/registry';
-import { WithAddress } from '@hyperlane-xyz/utils';
+import { WithAddress, pick } from '@hyperlane-xyz/utils';
 
 import { multisigIsmVerifyCosts } from '../consts/multisigIsmVerifyCosts.js';
 
@@ -11,25 +11,15 @@ import { multisigIsmVerifyCosts } from '../consts/multisigIsmVerifyCosts.js';
 export function extractIsmAndHookFactoryAddresses(
   registryAddresses: ChainAddresses,
 ) {
-  const {
-    domainRoutingIsmFactory,
-    staticMerkleRootMultisigIsmFactory,
-    staticMessageIdMultisigIsmFactory,
-    staticAggregationIsmFactory,
-    staticAggregationHookFactory,
-    staticMerkleRootWeightedMultisigIsmFactory,
-    staticMessageIdWeightedMultisigIsmFactory,
-  } = registryAddresses;
-
-  return {
-    domainRoutingIsmFactory,
-    staticMerkleRootMultisigIsmFactory,
-    staticMessageIdMultisigIsmFactory,
-    staticAggregationIsmFactory,
-    staticAggregationHookFactory,
-    staticMerkleRootWeightedMultisigIsmFactory,
-    staticMessageIdWeightedMultisigIsmFactory,
-  };
+  return pick(registryAddresses, [
+    'domainRoutingIsmFactory',
+    'staticMerkleRootMultisigIsmFactory',
+    'staticMessageIdMultisigIsmFactory',
+    'staticAggregationIsmFactory',
+    'staticAggregationHookFactory',
+    'staticMerkleRootWeightedMultisigIsmFactory',
+    'staticMessageIdWeightedMultisigIsmFactory',
+  ]);
 }
 
 export function multisigIsmVerificationCost(m: number, n: number): number {

--- a/typescript/sdk/src/utils/ism.ts
+++ b/typescript/sdk/src/utils/ism.ts
@@ -1,6 +1,36 @@
+import { ChainAddresses } from '@hyperlane-xyz/registry';
 import { WithAddress } from '@hyperlane-xyz/utils';
 
 import { multisigIsmVerifyCosts } from '../consts/multisigIsmVerifyCosts.js';
+
+/**
+ * Extracts the ISM and Hook factory addresses from chain-specific registry addresses
+ * @param registryAddresses The registry addresses for a specific chain
+ * @returns The extracted ISM and Hook factory addresses
+ */
+export function extractIsmAndHookFactoryAddresses(
+  registryAddresses: ChainAddresses,
+) {
+  const {
+    domainRoutingIsmFactory,
+    staticMerkleRootMultisigIsmFactory,
+    staticMessageIdMultisigIsmFactory,
+    staticAggregationIsmFactory,
+    staticAggregationHookFactory,
+    staticMerkleRootWeightedMultisigIsmFactory,
+    staticMessageIdWeightedMultisigIsmFactory,
+  } = registryAddresses;
+
+  return {
+    domainRoutingIsmFactory,
+    staticMerkleRootMultisigIsmFactory,
+    staticMessageIdMultisigIsmFactory,
+    staticAggregationIsmFactory,
+    staticAggregationHookFactory,
+    staticMerkleRootWeightedMultisigIsmFactory,
+    staticMessageIdWeightedMultisigIsmFactory,
+  };
+}
 
 export function multisigIsmVerificationCost(m: number, n: number): number {
   if (


### PR DESCRIPTION
### Description

Created a utility function `extractIsmAndHookFactoryAddresses` to reduce code duplication when extracting ISM and Hook factory addresses from chain-specific registry addresses. Implemented the function in multiple modules to improve code maintainability.

### Related issues

https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5543

### Backward compatibility

Yes - This is a pure refactoring change with no changes to external behavior or API.

### Testing

Manual - Verified that all existing functionality continues to work with the refactored code.