### PR TITLE
chore: Upgrade Scraper to 84918d2-20250224-172508

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -717,7 +717,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '328011a-20250218-173927',
+      tag: '84918d2-20250224-172508',
     },
     resources: scraperResources,
   },


### PR DESCRIPTION
### Description

Deploy fix for chuck size for Lumia and Lumia Prism chains.

### Backward compatibility

Yes