### PR TITLE
fix: set default ism address zero upon warp init

### DIFF
--- a/.changeset/moody-impalas-switch.md
+++ b/.changeset/moody-impalas-switch.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/cli': minor
 ---
 
-Update `hyperlane warp init` to output address(0) for ISM by default.
+Update `hyperlane warp init` to be undefined for ISM by default.

--- a/.changeset/moody-impalas-switch.md
+++ b/.changeset/moody-impalas-switch.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Update `hyperlane warp init` to output address(0) for ISM by default.

--- a/.changeset/thick-suns-confess.md
+++ b/.changeset/thick-suns-confess.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Update `hyperlane warp init` to not output proxyAdmin

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -1,4 +1,5 @@
 import { confirm, input, select } from '@inquirer/prompts';
+import { ethers } from 'ethers';
 import { stringify as yamlStringify } from 'yaml';
 
 import {
@@ -160,7 +161,7 @@ export async function createWarpRouteDeployConfig({
     if (advanced) {
       interchainSecurityModule = await createAdvancedIsmConfig(context);
     } else if (context.skipConfirmation) {
-      interchainSecurityModule = createDefaultWarpIsmConfig(owner);
+      interchainSecurityModule = ethers.constants.AddressZero;
     } else if (
       await confirm({
         message: 'Do you want to use a trusted ISM for warp route?',
@@ -168,7 +169,7 @@ export async function createWarpRouteDeployConfig({
     ) {
       interchainSecurityModule = createDefaultWarpIsmConfig(owner);
     } else {
-      interchainSecurityModule = createFallbackRoutingConfig(owner);
+      interchainSecurityModule = ethers.constants.AddressZero;
     }
 
     const type = await select({

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -1,5 +1,4 @@
 import { confirm, input, select } from '@inquirer/prompts';
-import { ethers } from 'ethers';
 import { stringify as yamlStringify } from 'yaml';
 
 import {

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -1,9 +1,9 @@
 import { confirm, input, select } from '@inquirer/prompts';
+import { ethers } from 'ethers';
 import { stringify as yamlStringify } from 'yaml';
 
 import {
   ChainMap,
-  DeployedOwnableConfig,
   IsmConfig,
   IsmType,
   MailboxClientConfig,
@@ -29,10 +29,7 @@ import {
   readYamlOrJson,
   writeYamlOrJson,
 } from '../utils/files.js';
-import {
-  detectAndConfirmOrPrompt,
-  setProxyAdminConfig,
-} from '../utils/input.js';
+import { detectAndConfirmOrPrompt } from '../utils/input.js';
 
 import { createAdvancedIsmConfig } from './ism.js';
 
@@ -152,12 +149,6 @@ export async function createWarpRouteDeployConfig({
         message: `Could not retrieve mailbox address from the registry for chain "${chain}". Please enter a valid mailbox address:`,
       }));
 
-    const proxyAdmin: DeployedOwnableConfig = await setProxyAdminConfig(
-      context,
-      chain,
-      owner,
-    );
-
     /**
      * The logic from the cli is as follows:
      *  --advanced flag is provided: the user will have to build their own configuration using the available ISM types
@@ -201,7 +192,6 @@ export async function createWarpRouteDeployConfig({
           mailbox,
           type,
           owner,
-          proxyAdmin,
           isNft,
           interchainSecurityModule,
           token: await input({
@@ -215,7 +205,6 @@ export async function createWarpRouteDeployConfig({
           type,
           owner,
           isNft,
-          proxyAdmin,
           collateralChainName: '', // This will be derived correctly by zod.parse() below
           interchainSecurityModule,
         };
@@ -229,7 +218,6 @@ export async function createWarpRouteDeployConfig({
           mailbox,
           type,
           owner,
-          proxyAdmin,
           isNft,
           interchainSecurityModule,
           token: await input({
@@ -244,7 +232,6 @@ export async function createWarpRouteDeployConfig({
           mailbox,
           type,
           owner,
-          proxyAdmin,
           isNft,
           interchainSecurityModule,
           token: await input({
@@ -257,7 +244,6 @@ export async function createWarpRouteDeployConfig({
           mailbox,
           type,
           owner,
-          proxyAdmin,
           isNft,
           interchainSecurityModule,
         };

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -152,10 +152,10 @@ export async function createWarpRouteDeployConfig({
     /**
      * The logic from the cli is as follows:
      *  --advanced flag is provided: the user will have to build their own configuration using the available ISM types
-     *  --yes flag is provided: the default ISM config will be used (Trusted ISM + Default fallback ISM)
+     *  --yes flag is provided: the address(0) will be used (default ISM config)
      *  -- no flag is provided: the user must choose if the default ISM config should be used:
      *    - yes: the default ISM config will be used (Trusted ISM + Default fallback ISM)
-     *    - no: the default fallback ISM will be used
+     *    - no: address(0) will be used (default ISM config)
      */
     let interchainSecurityModule: IsmConfig;
     if (advanced) {

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -1,5 +1,4 @@
 import { confirm, input, select } from '@inquirer/prompts';
-import { ethers } from 'ethers';
 import { stringify as yamlStringify } from 'yaml';
 
 import {
@@ -151,25 +150,23 @@ export async function createWarpRouteDeployConfig({
 
     /**
      * The logic from the cli is as follows:
+     *  --yes flag is provided: set ism to undefined (default ISM config)
      *  --advanced flag is provided: the user will have to build their own configuration using the available ISM types
-     *  --yes flag is provided: the address(0) will be used (default ISM config)
      *  -- no flag is provided: the user must choose if the default ISM config should be used:
      *    - yes: the default ISM config will be used (Trusted ISM + Default fallback ISM)
-     *    - no: address(0) will be used (default ISM config)
+     *    - no: keep ism as undefined (default ISM config)
      */
-    let interchainSecurityModule: IsmConfig;
-    if (advanced) {
+    let interchainSecurityModule: IsmConfig | undefined;
+    if (context.skipConfirmation) {
+      interchainSecurityModule = undefined;
+    } else if (advanced) {
       interchainSecurityModule = await createAdvancedIsmConfig(context);
-    } else if (context.skipConfirmation) {
-      interchainSecurityModule = ethers.constants.AddressZero;
     } else if (
       await confirm({
         message: 'Do you want to use a trusted ISM for warp route?',
       })
     ) {
       interchainSecurityModule = createDefaultWarpIsmConfig(owner);
-    } else {
-      interchainSecurityModule = ethers.constants.AddressZero;
     }
 
     const type = await select({

--- a/typescript/cli/src/tests/warp/warp-init.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-init.e2e-test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { Wallet } from 'ethers';
+import { Wallet, ethers } from 'ethers';
 
 import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
@@ -67,6 +67,9 @@ describe('hyperlane warp init e2e tests', async function () {
       );
       expect(chain2TokenConfig.owner).equal(initialOwnerAddress);
       expect(chain2TokenConfig.type).equal(TokenType.native);
+      expect(chain2TokenConfig.interchainSecurityModule).equal(
+        ethers.constants.AddressZero,
+      );
       expect(chain2TokenConfig.proxyAdmin).undefined;
     }
 

--- a/typescript/cli/src/tests/warp/warp-init.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-init.e2e-test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { Wallet, ethers } from 'ethers';
+import { Wallet } from 'ethers';
 
 import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
@@ -67,9 +67,7 @@ describe('hyperlane warp init e2e tests', async function () {
       );
       expect(chain2TokenConfig.owner).equal(initialOwnerAddress);
       expect(chain2TokenConfig.type).equal(TokenType.native);
-      expect(chain2TokenConfig.interchainSecurityModule).equal(
-        ethers.constants.AddressZero,
-      );
+      expect(chain2TokenConfig.interchainSecurityModule).undefined;
       expect(chain2TokenConfig.proxyAdmin).undefined;
     }
 

--- a/typescript/cli/src/tests/warp/warp-init.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-init.e2e-test.ts
@@ -67,6 +67,7 @@ describe('hyperlane warp init e2e tests', async function () {
       );
       expect(chain2TokenConfig.owner).equal(initialOwnerAddress);
       expect(chain2TokenConfig.type).equal(TokenType.native);
+      expect(chain2TokenConfig.proxyAdmin).undefined;
     }
 
     it('it should generate a warp deploy config with a single chain', async function () {


### PR DESCRIPTION
### Description

This PR changes warp init to output address(0) for ISM by default

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues
- Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5513
### Backward compatibility

Yes defaultIsm and address(0) are interchangable

### Testing

Manual/Unit Tests

