### PR TITLE
fix: Update warp init to allow user to specify proxyAdmin 

### DIFF
--- a/.changeset/sweet-ears-sort.md
+++ b/.changeset/sweet-ears-sort.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Update `hyperlane warp init` to not output proxyAdmin by default.

--- a/.changeset/thick-suns-confess.md
+++ b/.changeset/thick-suns-confess.md
@@ -1,5 +1,0 @@
----
-'@hyperlane-xyz/cli': minor
----
-
-Update `hyperlane warp init` to not output proxyAdmin

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -3,6 +3,7 @@ import { stringify as yamlStringify } from 'yaml';
 
 import {
   ChainMap,
+  DeployedOwnableConfig,
   IsmConfig,
   IsmType,
   MailboxClientConfig,
@@ -28,7 +29,10 @@ import {
   readYamlOrJson,
   writeYamlOrJson,
 } from '../utils/files.js';
-import { detectAndConfirmOrPrompt } from '../utils/input.js';
+import {
+  detectAndConfirmOrPrompt,
+  setProxyAdminConfig,
+} from '../utils/input.js';
 
 import { createAdvancedIsmConfig } from './ism.js';
 
@@ -148,6 +152,12 @@ export async function createWarpRouteDeployConfig({
         message: `Could not retrieve mailbox address from the registry for chain "${chain}". Please enter a valid mailbox address:`,
       }));
 
+    const proxyAdmin: DeployedOwnableConfig = await setProxyAdminConfig(
+      context,
+      chain,
+      owner,
+    );
+
     /**
      * The logic from the cli is as follows:
      *  --yes flag is provided: set ism to undefined (default ISM config)
@@ -189,6 +199,7 @@ export async function createWarpRouteDeployConfig({
           mailbox,
           type,
           owner,
+          proxyAdmin,
           isNft,
           interchainSecurityModule,
           token: await input({
@@ -202,6 +213,7 @@ export async function createWarpRouteDeployConfig({
           type,
           owner,
           isNft,
+          proxyAdmin,
           collateralChainName: '', // This will be derived correctly by zod.parse() below
           interchainSecurityModule,
         };
@@ -215,6 +227,7 @@ export async function createWarpRouteDeployConfig({
           mailbox,
           type,
           owner,
+          proxyAdmin,
           isNft,
           interchainSecurityModule,
           token: await input({
@@ -229,6 +242,7 @@ export async function createWarpRouteDeployConfig({
           mailbox,
           type,
           owner,
+          proxyAdmin,
           isNft,
           interchainSecurityModule,
           token: await input({
@@ -241,6 +255,7 @@ export async function createWarpRouteDeployConfig({
           mailbox,
           type,
           owner,
+          proxyAdmin,
           isNft,
           interchainSecurityModule,
         };

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -152,11 +152,8 @@ export async function createWarpRouteDeployConfig({
         message: `Could not retrieve mailbox address from the registry for chain "${chain}". Please enter a valid mailbox address:`,
       }));
 
-    const proxyAdmin: DeployedOwnableConfig = await setProxyAdminConfig(
-      context,
-      chain,
-      owner,
-    );
+    const proxyAdmin: DeployedOwnableConfig | undefined =
+      await setProxyAdminConfig(context, chain);
 
     /**
      * The logic from the cli is as follows:

--- a/typescript/cli/src/utils/input.ts
+++ b/typescript/cli/src/utils/input.ts
@@ -20,7 +20,7 @@ import chalk from 'chalk';
 
 import { ProxyAdmin__factory } from '@hyperlane-xyz/core';
 import { ChainName, DeployedOwnableConfig } from '@hyperlane-xyz/sdk';
-import { Address, isAddress, rootLogger } from '@hyperlane-xyz/utils';
+import { isAddress, rootLogger } from '@hyperlane-xyz/utils';
 
 import { CommandContext } from '../context/types.js';
 import { logGray } from '../logger.js';
@@ -84,11 +84,8 @@ export async function inputWithInfo({
 export async function setProxyAdminConfig(
   context: CommandContext,
   chain: ChainName,
-  warpRouteOwner: Address,
-): Promise<DeployedOwnableConfig> {
-  const defaultAdminConfig: DeployedOwnableConfig = {
-    owner: warpRouteOwner,
-  };
+): Promise<DeployedOwnableConfig | undefined> {
+  let defaultAdminConfig: DeployedOwnableConfig | undefined;
 
   // default to deploying a new ProxyAdmin with `warpRouteOwner` as the owner
   // if the user supplied the --yes flag


### PR DESCRIPTION
### Description
This PR updates warp init to allow user to specify proxyAdmin. It sets it to undefined by default.


### Backward compatibility

Yes

### Testing
Manual/Unit Tests

