### PR TITLE
chore: Upgrade Scraper to d82d24c-20250225-211517

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -717,7 +717,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '84918d2-20250224-172508',
+      tag: 'd82d24c-20250225-211517',
     },
     resources: scraperResources,
   },


### PR DESCRIPTION
### Description

Upgrade Scraper with the fix for search for relevant Sealevel transaction

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

- Deploys https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5558

### Backward compatibility

Yes

### Testing

CI E2E tests
