### PR TITLE
fix: Continue to update metrics as moving backward through already indexed sequences

### DIFF
--- a/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs
@@ -161,6 +161,10 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> BackwardSequenceAware
 
                 self.current_indexing_snapshot = self.last_indexed_snapshot.previous_target();
 
+                // Update metrics during fast-forward (actually backward in this case) so that
+                // the metrics do not stuck on the last indexed sequence.
+                self.update_metrics().await;
+
                 debug!(
                     last_indexed_snapshot=?self.last_indexed_snapshot,
                     current_indexing_snapshot=?self.current_indexing_snapshot,


### PR DESCRIPTION
### Description

Currently, backward cursor metrics get stuck in the middle of allowed range if there is nothing else left to reindex. The metric becomes misleading suggesting that backward cursor does not make progress. Actually, backward cursor has finished indexing and hanging on sequence 0.

### Backward compatibility

Yes

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
