### PR TITLE
chore: fix broken sealevel e2e build

### DIFF
--- a/rust/sealevel/client/src/warp_route.rs
+++ b/rust/sealevel/client/src/warp_route.rs
@@ -747,6 +747,8 @@ pub fn install_spl_token_cli() {
             "dan/create-token-for-mint",
             "--rev",
             "ae4c8ac46",
+            "--locked",
+            "--force",
         ])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())

--- a/rust/sealevel/client/src/warp_route.rs
+++ b/rust/sealevel/client/src/warp_route.rs
@@ -748,7 +748,6 @@ pub fn install_spl_token_cli() {
             "--rev",
             "ae4c8ac46",
             "--locked",
-            "--force",
         ])
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())


### PR DESCRIPTION
### Description

We have at least 2 PRs whose CIs are failing due to the sealevel e2e: https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5570 and https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5517

TIL that `cargo install`ing from a repo ignores the lockfile. This means that any patch bumps will be automatically applied. This wouldn't be a problem if crates upheld the promise that patches don't break the MSRV, but they do :) and this breaks our sealevel e2e because it is on `1.76.0` (a rust version that doesn't conform to the MSRV after applying the patch updates)

So the fix is to pass a `--locked` flag to `cargo install` to force it to use the lockfile. ~~I've also added the `--force` flag to invalidate any cache so we make sure the lockfile versions are always used.~~

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

E2E should pass now
