### PR TITLE
feat(widgets): allow chains to be disabled in ChainSearchMenu

### DIFF
--- a/.changeset/witty-houses-wash.md
+++ b/.changeset/witty-houses-wash.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/widgets': minor
+---
+
+Allow chains to be disabled in ChainSearchMenu

--- a/typescript/widgets/src/chains/ChainSearchMenu.tsx
+++ b/typescript/widgets/src/chains/ChainSearchMenu.tsx
@@ -231,7 +231,7 @@ function chainSearch({
   filter,
   customListItemField,
 }: {
-  data: ChainMetadata[];
+  data: Array<ChainMetadata & { disabled: boolean }>;
   query: string;
   sort: SortState<ChainSortByOption>;
   filter: ChainFilterState;
@@ -262,6 +262,10 @@ function chainSearch({
       })
       // Sort options
       .sort((c1, c2) => {
+        // If one chain is disabled and the other is not, place the disabled chain at the bottom
+        if (c1.disabled && !c2.disabled) return 1;
+        if (!c1.disabled && c2.disabled) return -1;
+
         // Special case handling for if the chains are being sorted by the
         // custom field provided to ChainSearchMenu
         if (customListItemField && sort.sortBy === customListItemField.header) {

--- a/typescript/widgets/src/chains/ChainSearchMenu.tsx
+++ b/typescript/widgets/src/chains/ChainSearchMenu.tsx
@@ -368,7 +368,7 @@ function getDisabledChains(
 ) {
   if (showDisabledChains) return chainMetadata;
 
-  return objMap(chainMetadata, (key, chain) => {
+  return objMap(chainMetadata, (_, chain) => {
     if (
       !chain.availability ||
       chain.availability.status === ChainStatus.Enabled

--- a/typescript/widgets/src/chains/ChainSearchMenu.tsx
+++ b/typescript/widgets/src/chains/ChainSearchMenu.tsx
@@ -4,9 +4,10 @@ import {
   ChainMap,
   ChainMetadata,
   ChainName,
+  ChainStatus,
   mergeChainMetadataMap,
 } from '@hyperlane-xyz/sdk';
-import { ProtocolType } from '@hyperlane-xyz/utils';
+import { ProtocolType, objMap } from '@hyperlane-xyz/utils';
 
 import {
   SearchMenu,
@@ -88,7 +89,11 @@ export function ChainSearchMenu({
       chainMetadata,
       overrideChainMetadata,
     );
-    return { mergedMetadata, listData: Object.values(mergedMetadata) };
+    const disabledChainMetadata = getDisabledChains(mergedMetadata);
+    return {
+      mergedMetadata: disabledChainMetadata,
+      listData: Object.values(disabledChainMetadata),
+    };
   }, [chainMetadata, overrideChainMetadata]);
 
   const { ListComponent, searchFn, sortOptions, defaultSortState } =
@@ -332,4 +337,17 @@ function useCustomizedListItems(
   ) as SortState<ChainSortByOption> | undefined;
 
   return { ListComponent, searchFn, sortOptions, defaultSortState };
+}
+
+function getDisabledChains(chainMetadata: ChainMap<ChainMetadata>) {
+  return objMap(chainMetadata, (key, chain) => {
+    if (
+      !chain.availability ||
+      chain.availability.status === ChainStatus.Enabled
+    ) {
+      return chain;
+    }
+
+    return { ...chain, disabled: true };
+  });
 }

--- a/typescript/widgets/src/components/SearchMenu.tsx
+++ b/typescript/widgets/src/components/SearchMenu.tsx
@@ -106,6 +106,7 @@ export function SearchMenu<
       e.stopPropagation();
       if (results.length === 1) {
         const item = results[0];
+        if (item.disabled) return;
         isEditMode ? onClickEditItem(item) : onClickItem(item);
       }
     },

--- a/typescript/widgets/src/stories/ChainSearchMenu.stories.tsx
+++ b/typescript/widgets/src/stories/ChainSearchMenu.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
 import { chainMetadata } from '@hyperlane-xyz/registry';
+import { ChainDisabledReason, ChainStatus } from '@hyperlane-xyz/sdk';
 import { pick } from '@hyperlane-xyz/utils';
 
 import {
@@ -79,6 +80,29 @@ export const WithOverrideChain = {
     chainMetadata: pick(chainMetadata, ['alfajores']),
     overrideChainMetadata: {
       arbitrum: { ...chainMetadata['arbitrum'], displayName: 'Fake Arb' },
+    },
+    onChangeOverrideMetadata: () => {},
+    showAddChainButton: true,
+  },
+} satisfies Story;
+
+export const WithDisabledChains = {
+  args: {
+    chainMetadata: pick(chainMetadata, ['alfajores']),
+    overrideChainMetadata: {
+      arbitrum: {
+        ...chainMetadata['arbitrum'],
+        availability: {
+          status: ChainStatus.Disabled,
+          reasons: [ChainDisabledReason.Deprecated],
+        },
+      },
+      ethereum: {
+        ...chainMetadata['ethereum'],
+        availability: {
+          status: ChainStatus.Enabled,
+        },
+      },
     },
     onChangeOverrideMetadata: () => {},
     showAddChainButton: true,

--- a/typescript/widgets/src/stories/ChainSearchMenu.stories.tsx
+++ b/typescript/widgets/src/stories/ChainSearchMenu.stories.tsx
@@ -88,7 +88,7 @@ export const WithOverrideChain = {
 
 export const WithDisabledChains = {
   args: {
-    chainMetadata: pick(chainMetadata, ['alfajores']),
+    chainMetadata: pick(chainMetadata, ['alfajores', 'base']),
     overrideChainMetadata: {
       arbitrum: {
         ...chainMetadata['arbitrum'],
@@ -100,11 +100,21 @@ export const WithDisabledChains = {
       ethereum: {
         ...chainMetadata['ethereum'],
         availability: {
-          status: ChainStatus.Enabled,
+          status: ChainStatus.Disabled,
         },
       },
     },
     onChangeOverrideMetadata: () => {},
     showAddChainButton: true,
+    defaultSortField: 'custom',
+    customListItemField: {
+      header: 'Warp Routes',
+      data: {
+        alfajores: { display: '1 token', sortValue: 1 },
+        arbitrum: { display: '2 tokens', sortValue: 2 },
+        ethereum: { display: '1 token', sortValue: 1 },
+        base: { display: '2 tokens', sortValue: 2 },
+      },
+    },
   },
 } satisfies Story;

--- a/typescript/widgets/src/stories/ChainSearchMenu.stories.tsx
+++ b/typescript/widgets/src/stories/ChainSearchMenu.stories.tsx
@@ -107,6 +107,7 @@ export const WithDisabledChains = {
     onChangeOverrideMetadata: () => {},
     showAddChainButton: true,
     defaultSortField: 'custom',
+    showDisabledChains: false,
     customListItemField: {
       header: 'Warp Routes',
       data: {


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
Updates `<ChainSearchMenu />` to be able to disabled chains when the status of the chain is `disabled` 

- Add `showDisabledChains` boolean to props. When false it will make the chain items unable to be selected. Defaults to `true`
- Add disabled to the chain metadata because its required by `SearchMenu` component
- Now disabled items will be shown at the bottom
- New storybook for this use case

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
Manual and visual testing with storybook