### PR TITLE
feat: Add names to tokio tasks in Relayer

### DIFF
--- a/rust/main/agents/relayer/src/merkle_tree/processor.rs
+++ b/rust/main/agents/relayer/src/merkle_tree/processor.rs
@@ -42,6 +42,12 @@ impl Debug for MerkleTreeProcessor {
 
 #[async_trait]
 impl ProcessorExt for MerkleTreeProcessor {
+    fn name(&self) -> String {
+        let mut name = "processor::merkle_tree::".to_string();
+        name.push_str(self.domain().name());
+        name
+    }
+
     /// The domain this processor is getting merkle tree hook insertions from.
     fn domain(&self) -> &HyperlaneDomain {
         self.db.domain()

--- a/rust/main/agents/relayer/src/msg/op_submitter.rs
+++ b/rust/main/agents/relayer/src/msg/op_submitter.rs
@@ -95,7 +95,7 @@ pub struct SerialSubmitter {
     /// Domain this submitter delivers to.
     domain: HyperlaneDomain,
     /// Receiver for new messages to submit.
-    rx: mpsc::UnboundedReceiver<QueueOperation>,
+    rx: Option<mpsc::UnboundedReceiver<QueueOperation>>,
     /// Metrics for serial submitter.
     metrics: SerialSubmitterMetrics,
     /// Max batch size for submitting messages
@@ -134,7 +134,8 @@ impl SerialSubmitter {
 
         Self {
             domain,
-            rx,
+            // Using Options so that method which needs it can take from struct
+            rx: Some(rx),
             metrics,
             max_batch_size,
             task_monitor,
@@ -151,70 +152,107 @@ impl SerialSubmitter {
     pub fn spawn(self) -> Instrumented<JoinHandle<()>> {
         let span = info_span!("SerialSubmitter", destination=%self.domain);
         let task_monitor = self.task_monitor.clone();
-        tokio::spawn(TaskMonitor::instrument(&task_monitor, async move {
-            self.run().await
-        }))
-        .instrument(span)
+        let name = Self::task_name("", &self.domain);
+        tokio::task::Builder::new()
+            .name(&name)
+            .spawn(TaskMonitor::instrument(&task_monitor, async move {
+                self.run().await
+            }))
+            .expect("spawning tokio task from Builder is infalliable")
+            .instrument(span)
     }
 
-    async fn run(self) {
-        let Self {
-            domain,
-            metrics,
-            rx: rx_prepare,
-            max_batch_size,
-            task_monitor,
-            prepare_queue,
-            submit_queue,
-            confirm_queue,
-        } = self;
+    async fn run(mut self) {
+        let rx_prepare = self.rx.take().expect("rx should be initialised");
 
         let tasks = [
-            tokio::spawn(TaskMonitor::instrument(
-                &task_monitor,
-                receive_task(domain.clone(), rx_prepare, prepare_queue.clone()),
-            )),
-            tokio::spawn(TaskMonitor::instrument(
-                &task_monitor,
-                prepare_task(
-                    domain.clone(),
-                    prepare_queue.clone(),
-                    submit_queue.clone(),
-                    confirm_queue.clone(),
-                    max_batch_size,
-                    metrics.clone(),
-                ),
-            )),
-            tokio::spawn(TaskMonitor::instrument(
-                &task_monitor,
-                submit_task(
-                    domain.clone(),
-                    prepare_queue.clone(),
-                    submit_queue,
-                    confirm_queue.clone(),
-                    max_batch_size,
-                    metrics.clone(),
-                ),
-            )),
-            tokio::spawn(TaskMonitor::instrument(
-                &task_monitor,
-                confirm_task(
-                    domain.clone(),
-                    prepare_queue,
-                    confirm_queue,
-                    max_batch_size,
-                    metrics,
-                ),
-            )),
+            self.create_receive_task(rx_prepare),
+            self.create_prepare_task(),
+            self.create_submit_task(),
+            self.create_confirm_task(),
         ];
 
         if let Err(err) = try_join_all(tasks).await {
             tracing::error!(
                 error=?err,
-                ?domain,
+                domain=?self.domain,
                 "SerialSubmitter task panicked for domain"
             );
         }
+    }
+
+    fn create_receive_task(
+        &self,
+        rx_prepare: mpsc::UnboundedReceiver<QueueOperation>,
+    ) -> JoinHandle<()> {
+        let name = Self::task_name("receive::", &self.domain);
+        tokio::task::Builder::new()
+            .name(&name)
+            .spawn(TaskMonitor::instrument(
+                &self.task_monitor,
+                receive_task(self.domain.clone(), rx_prepare, self.prepare_queue.clone()),
+            ))
+            .expect("spawning tokio task from Builder is infalliable")
+    }
+
+    fn create_prepare_task(&self) -> JoinHandle<()> {
+        let name = Self::task_name("prepare::", &self.domain);
+        tokio::task::Builder::new()
+            .name(&name)
+            .spawn(TaskMonitor::instrument(
+                &self.task_monitor,
+                prepare_task(
+                    self.domain.clone(),
+                    self.prepare_queue.clone(),
+                    self.submit_queue.clone(),
+                    self.confirm_queue.clone(),
+                    self.max_batch_size,
+                    self.metrics.clone(),
+                ),
+            ))
+            .expect("spawning tokio task from Builder is infalliable")
+    }
+
+    fn create_submit_task(&self) -> JoinHandle<()> {
+        let name = Self::task_name("submit::", &self.domain);
+        tokio::task::Builder::new()
+            .name(&name)
+            .spawn(TaskMonitor::instrument(
+                &self.task_monitor,
+                submit_task(
+                    self.domain.clone(),
+                    self.prepare_queue.clone(),
+                    self.submit_queue.clone(),
+                    self.confirm_queue.clone(),
+                    self.max_batch_size,
+                    self.metrics.clone(),
+                ),
+            ))
+            .expect("spawning tokio task from Builder is infalliable")
+    }
+
+    fn create_confirm_task(&self) -> JoinHandle<()> {
+        let name = Self::task_name("confirm::", &self.domain);
+        tokio::task::Builder::new()
+            .name(&name)
+            .spawn(TaskMonitor::instrument(
+                &self.task_monitor,
+                confirm_task(
+                    self.domain.clone(),
+                    self.prepare_queue.clone(),
+                    self.confirm_queue.clone(),
+                    self.max_batch_size,
+                    self.metrics.clone(),
+                ),
+            ))
+            .expect("spawning tokio task from Builder is infalliable")
+    }
+
+    fn task_name(prefix: &str, domain: &HyperlaneDomain) -> String {
+        let mut name = "op_submitter::".to_owned();
+        name.push_str(prefix);
+        name.push_str(&domain.name());
+        name
     }
 }
 

--- a/rust/main/agents/relayer/src/msg/processor.rs
+++ b/rust/main/agents/relayer/src/msg/processor.rs
@@ -239,6 +239,13 @@ impl Debug for MessageProcessor {
 
 #[async_trait]
 impl ProcessorExt for MessageProcessor {
+    /// The name of this processor
+    fn name(&self) -> String {
+        let mut name = "processor::message::".to_string();
+        name.push_str(self.domain().name());
+        name
+    }
+
     /// The domain this processor is getting messages from.
     fn domain(&self) -> &HyperlaneDomain {
         self.nonce_iterator.high_nonce_iter.db.domain()

--- a/rust/main/agents/relayer/src/processor.rs
+++ b/rust/main/agents/relayer/src/processor.rs
@@ -10,6 +10,9 @@ use tracing::{instrument, warn};
 
 #[async_trait]
 pub trait ProcessorExt: Send + Debug {
+    /// The name of this processor
+    fn name(&self) -> String;
+
     /// The domain this processor is getting messages from.
     fn domain(&self) -> &HyperlaneDomain;
 
@@ -27,9 +30,13 @@ pub struct Processor {
 impl Processor {
     pub fn spawn(self) -> JoinHandle<()> {
         let task_monitor = self.task_monitor.clone();
-        tokio::spawn(TaskMonitor::instrument(&task_monitor, async move {
-            self.main_loop().await
-        }))
+        let name = self.ticker.name();
+        let instrumented =
+            TaskMonitor::instrument(&task_monitor, async move { self.main_loop().await });
+        tokio::task::Builder::new()
+            .name(&name)
+            .spawn(instrumented)
+            .expect("spawning tokio task from Builder is infalliable")
     }
 
     #[instrument(ret, skip(self), level = "info", fields(domain=%self.ticker.domain()))]

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -324,13 +324,15 @@ impl BaseAgent for Relayer {
 
         let task_monitor = tokio_metrics::TaskMonitor::new();
         if let Some(tokio_console_server) = self.tokio_console_server.take() {
-            let console_server =
-                tokio::spawn(TaskMonitor::instrument(&task_monitor.clone(), async move {
+            let console_server = tokio::task::Builder::new()
+                .name("tokio_console_server")
+                .spawn(TaskMonitor::instrument(&task_monitor.clone(), async move {
                     info!("Starting tokio console server");
                     if let Err(e) = tokio_console_server.serve().await {
                         error!(error=?e, "Tokio console server failed to start");
                     }
-                }));
+                }))
+                .expect("spawning tokio task from Builder is infalliable");
             tasks.push(console_server.instrument(info_span!("Tokio console server")));
         }
         let sender = BroadcastSender::new(ENDPOINT_MESSAGES_QUEUE_SIZE);
@@ -391,7 +393,7 @@ impl BaseAgent for Relayer {
                 .await,
             );
             tasks.push(
-                self.run_merkle_tree_hook_syncs(
+                self.run_merkle_tree_hook_sync(
                     origin,
                     BroadcastMpscSender::map_get_receiver(maybe_broadcaster.as_ref()).await,
                     task_monitor.clone(),
@@ -483,12 +485,16 @@ impl Relayer {
             }
         };
         let origin_name = origin.name().to_string();
-        tokio::spawn(TaskMonitor::instrument(&task_monitor, async move {
-            let label = "dispatched_messages";
-            contract_sync.clone().sync(label, cursor.into()).await;
-            info!(chain = origin_name, label, "contract sync task exit");
-        }))
-        .instrument(info_span!("MessageSync"))
+        let name = Self::contract_sync_task_name("message::", &origin_name);
+        tokio::task::Builder::new()
+            .name(&name)
+            .spawn(TaskMonitor::instrument(&task_monitor, async move {
+                let label = "dispatched_messages";
+                contract_sync.clone().sync(label, cursor.into()).await;
+                info!(chain = origin_name, label, "contract sync task exit");
+            }))
+            .expect("spawning tokio task from Builder is infalliable")
+            .instrument(info_span!("MessageSync"))
     }
 
     async fn run_interchain_gas_payment_sync(
@@ -514,18 +520,22 @@ impl Relayer {
             }
         };
         let origin_name = origin.name().to_string();
-        tokio::spawn(TaskMonitor::instrument(&task_monitor, async move {
-            let label = "gas_payments";
-            contract_sync
-                .clone()
-                .sync(label, SyncOptions::new(Some(cursor), tx_id_receiver))
-                .await;
-            info!(chain = origin_name, label, "contract sync task exit");
-        }))
-        .instrument(info_span!("IgpSync"))
+        let name = Self::contract_sync_task_name("gas_payment::", &origin_name);
+        tokio::task::Builder::new()
+            .name(&name)
+            .spawn(TaskMonitor::instrument(&task_monitor, async move {
+                let label = "gas_payments";
+                contract_sync
+                    .clone()
+                    .sync(label, SyncOptions::new(Some(cursor), tx_id_receiver))
+                    .await;
+                info!(chain = origin_name, label, "contract sync task exit");
+            }))
+            .expect("spawning tokio task from Builder is infalliable")
+            .instrument(info_span!("IgpSync"))
     }
 
-    async fn run_merkle_tree_hook_syncs(
+    async fn run_merkle_tree_hook_sync(
         &self,
         origin: &HyperlaneDomain,
         tx_id_receiver: Option<MpscReceiver<H512>>,
@@ -544,15 +554,26 @@ impl Relayer {
             }
         };
         let origin_name = origin.name().to_string();
-        tokio::spawn(TaskMonitor::instrument(&task_monitor, async move {
-            let label = "merkle_tree_hook";
-            contract_sync
-                .clone()
-                .sync(label, SyncOptions::new(Some(cursor), tx_id_receiver))
-                .await;
-            info!(chain = origin_name, label, "contract sync task exit");
-        }))
-        .instrument(info_span!("MerkleTreeHookSync"))
+        let name = Self::contract_sync_task_name("merkle_tree::", &origin_name);
+        tokio::task::Builder::new()
+            .name(&name)
+            .spawn(TaskMonitor::instrument(&task_monitor, async move {
+                let label = "merkle_tree_hook";
+                contract_sync
+                    .clone()
+                    .sync(label, SyncOptions::new(Some(cursor), tx_id_receiver))
+                    .await;
+                info!(chain = origin_name, label, "contract sync task exit");
+            }))
+            .expect("spawning tokio task from Builder is infalliable")
+            .instrument(info_span!("MerkleTreeHookSync"))
+    }
+
+    fn contract_sync_task_name(prefix: &str, domain: &str) -> String {
+        let mut name = "contract::sync::".to_string();
+        name.push_str(prefix);
+        name.push_str(domain);
+        name
     }
 
     fn run_message_processor(
@@ -626,16 +647,21 @@ impl Relayer {
     ) -> Instrumented<JoinHandle<()>> {
         let span = info_span!("SerialSubmitter", destination=%destination);
         let destination = destination.clone();
-        tokio::spawn(TaskMonitor::instrument(&task_monitor, async move {
-            // Propagate task panics
-            serial_submitter.spawn().await.unwrap_or_else(|err| {
-                panic!(
-                    "destination submitter panicked for destination {}: {:?}",
-                    destination, err
-                )
-            });
-        }))
-        .instrument(span)
+        let mut name = "submitter::destination::".to_string();
+        name.push_str(&destination.name());
+        tokio::task::Builder::new()
+            .name(&name)
+            .spawn(TaskMonitor::instrument(&task_monitor, async move {
+                // Propagate task panics
+                serial_submitter.spawn().await.unwrap_or_else(|err| {
+                    panic!(
+                        "destination submitter panicked for destination {}: {:?}",
+                        destination, err
+                    )
+                });
+            }))
+            .expect("spawning tokio task from Builder is infalliable")
+            .instrument(span)
     }
 
     /// Helper function to build and return a hashmap of mailboxes.

--- a/rust/main/hyperlane-base/src/metrics/agent_metrics.rs
+++ b/rust/main/hyperlane-base/src/metrics/agent_metrics.rs
@@ -253,10 +253,15 @@ impl ChainSpecificMetricsUpdater {
 
     /// Spawns a tokio task to update the metrics
     pub fn spawn(self) -> Instrumented<JoinHandle<()>> {
-        tokio::spawn(async move {
-            self.start_updating_on_interval(METRICS_SCRAPE_INTERVAL)
-                .await;
-        })
-        .instrument(info_span!("MetricsUpdater"))
+        let mut name = "metrics::agent::".to_string();
+        name.push_str(&self.conf.domain.name());
+        tokio::task::Builder::new()
+            .name(&name)
+            .spawn(async move {
+                self.start_updating_on_interval(METRICS_SCRAPE_INTERVAL)
+                    .await;
+            })
+            .expect("spawning tokio task from Builder is infalliable")
+            .instrument(info_span!("MetricsUpdater"))
     }
 }

--- a/rust/main/hyperlane-base/src/metrics/runtime_metrics.rs
+++ b/rust/main/hyperlane-base/src/metrics/runtime_metrics.rs
@@ -55,10 +55,13 @@ impl RuntimeMetrics {
 
     /// Spawns a tokio task to update the metrics
     pub fn spawn(self) -> Instrumented<JoinHandle<()>> {
-        tokio::spawn(async move {
-            self.start_updating_on_interval(METRICS_SCRAPE_INTERVAL)
-                .await;
-        })
-        .instrument(info_span!("RuntimeMetricsUpdater"))
+        tokio::task::Builder::new()
+            .name("metrics::runtime")
+            .spawn(async move {
+                self.start_updating_on_interval(METRICS_SCRAPE_INTERVAL)
+                    .await;
+            })
+            .expect("spawning tokio task from Builder is infalliable")
+            .instrument(info_span!("RuntimeMetricsUpdater"))
     }
 }

--- a/rust/main/hyperlane-base/src/server/base_server.rs
+++ b/rust/main/hyperlane-base/src/server/base_server.rs
@@ -41,13 +41,16 @@ impl Server {
             app = app.nest(route, router);
         }
 
-        tokio::spawn(async move {
-            let addr = SocketAddr::from(([0, 0, 0, 0], port));
-            axum::Server::bind(&addr)
-                .serve(app.into_make_service())
-                .await
-                .expect("Failed to start server");
-        })
+        tokio::task::Builder::new()
+            .name("agent::server")
+            .spawn(async move {
+                let addr = SocketAddr::from(([0, 0, 0, 0], port));
+                axum::Server::bind(&addr)
+                    .serve(app.into_make_service())
+                    .await
+                    .expect("Failed to start server");
+            })
+            .expect("spawning tokio task from Builder is infalliable")
     }
 
     /// Gather available metrics into an encoded (plaintext, OpenMetrics format)

--- a/rust/main/hyperlane-base/src/settings/trace/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/trace/mod.rs
@@ -76,6 +76,9 @@ impl TracingConfig {
                 .with_target("tendermint", Level::Info)
                 .with_target("tokio", Level::Debug)
                 .with_target("tokio_util", Level::Debug)
+                // Enable Trace level for Tokio if you want to use tokio-console
+                // .with_target("tokio", Level::Trace)
+                // .with_target("tokio_util", Level::Trace)
                 .with_target("ethers_providers", Level::Debug);
         }
 


### PR DESCRIPTION
### Description

Add names to tokio tasks in Relayer so that each task is recognisable in tokio-console

### Drive-by changes

- Minor method rename `run_merkle_tree_hook_syncs` to `run_merkle_tree_hook_sync`.

### Related issues

- Contributes into https://github.com/hyperlane-xyz/issues/issues/1420

### Backward compatibility

Yes

### Testing

Locally