### PR TITLE
feat: add print-warp-routers script

### DIFF
--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -330,9 +330,11 @@ export function withSkipReview<T>(args: Argv<T>) {
 
 // Interactively gets a single warp route ID
 export async function getWarpRouteIdInteractive() {
-  const choices = Object.values(WarpRouteIds).map((id) => ({
-    value: id,
-  }));
+  const choices = Object.values(WarpRouteIds)
+    .sort()
+    .map((id) => ({
+      value: id,
+    }));
   return select({
     message: 'Select Warp Route ID',
     choices,

--- a/typescript/infra/scripts/print-warp-routers.ts
+++ b/typescript/infra/scripts/print-warp-routers.ts
@@ -1,0 +1,26 @@
+import { strip0x } from '@hyperlane-xyz/utils';
+
+import { getWarpCoreConfig } from '../config/registry.js';
+
+import { getWarpRouteIdInteractive } from './agent-utils.js';
+
+// This is a quality of life script meant to be used with https://abacus-works.metabaseapp.com/dashboard/793-warp-route-details?routers_comma_separated=4F0654395d621De4d1101c0F98C1Dba73ca0a61f%2CbBa1938ff861c77eA1687225B9C33554379Ef327%2Ca0bD9e96556E27e6FfF0cC0F77496390d9844E1e%2C69158d1A7325Ca547aF66C3bA599F8111f7AB519%2C910FF91a92c9141b8352Ad3e50cF13ef9F3169A1%2C324d0b921C03b1e42eeFD198086A64beC3d736c2%2C7bD2676c85cca9Fa2203ebA324fb8792fbd520b8%2C2dC335bDF489f8e978477Ae53924324697e0f7BB%2C5beADE696E12aBE2839FEfB41c7EE6DA1f074C55%2C4A8149B1b9e0122941A69D01D23EaE6bD1441b4f%2CAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3
+// which allows you to input a comma separated list of warp route router address
+// and view the unprocessed messages relating to them.
+
+async function main() {
+  const warpRouteId = await getWarpRouteIdInteractive();
+
+  const warpConfig = getWarpCoreConfig(warpRouteId);
+  const addresses = warpConfig.tokens
+    .filter((t) => !!t.addressOrDenom)
+    // The metabase query expects addresses without the 0x prefix
+    .map((t) => strip0x(t.addressOrDenom!));
+
+  console.log(addresses.join(','));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
### Description

Motivating use case: when we see a warp route imbalance, sometimes it's hard to tell exactly why.

Intended to be used with [this metabase dashboard](https://abacus-works.metabaseapp.com/dashboard/793-warp-route-details?routers_comma_separated=4F0654395d621De4d1101c0F98C1Dba73ca0a61f%2CbBa1938ff861c77eA1687225B9C33554379Ef327%2Ca0bD9e96556E27e6FfF0cC0F77496390d9844E1e%2C69158d1A7325Ca547aF66C3bA599F8111f7AB519%2C910FF91a92c9141b8352Ad3e50cF13ef9F3169A1%2C324d0b921C03b1e42eeFD198086A64beC3d736c2%2C7bD2676c85cca9Fa2203ebA324fb8792fbd520b8%2C2dC335bDF489f8e978477Ae53924324697e0f7BB%2C5beADE696E12aBE2839FEfB41c7EE6DA1f074C55%2C4A8149B1b9e0122941A69D01D23EaE6bD1441b4f%2CAf6bEdBA6ab73f0a5941d429807C8B9c24Ea95F3), which will surface using the scraper DB any messages that are not processed. Future work here could be to add / subtract all in and outflows as well

Unfortunately the scraper DB seems to skip some messages so this isn't perfect, but still better than the status quo imo

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
