### PR TITLE
fix: Move access to database into a blocking task

### DIFF
--- a/rust/main/agents/relayer/src/merkle_tree/processor.rs
+++ b/rust/main/agents/relayer/src/merkle_tree/processor.rs
@@ -21,6 +21,8 @@ use crate::processor::ProcessorExt;
 
 use super::builder::MerkleTreeBuilder;
 
+const PREFIX: &str = "processor::merkle_tree";
+
 /// Finds unprocessed merkle tree insertions and adds them to the prover sync
 #[derive(new)]
 pub struct MerkleTreeProcessor {
@@ -44,7 +46,7 @@ impl Debug for MerkleTreeProcessor {
 #[async_trait]
 impl ProcessorExt for MerkleTreeProcessor {
     fn name(&self) -> String {
-        format!("processor::merkle_tree::{}", self.domain().name())
+        format!("{}::{}", PREFIX, self.domain().name())
     }
 
     /// The domain this processor is getting merkle tree hook insertions from.
@@ -55,7 +57,7 @@ impl ProcessorExt for MerkleTreeProcessor {
     /// One round of processing, extracted from infinite work loop for
     /// testing purposes.
     async fn tick(&mut self) -> Result<()> {
-        if let Some(insertion) = self.next_unprocessed_leaf()? {
+        if let Some(insertion) = self.next_unprocessed_leaf_task().await? {
             // Feed the message to the prover sync
 
             let begin = {
@@ -81,34 +83,57 @@ impl ProcessorExt for MerkleTreeProcessor {
 }
 
 impl MerkleTreeProcessor {
-    fn next_unprocessed_leaf(&mut self) -> Result<Option<MerkleTreeInsertion>> {
+    async fn next_unprocessed_leaf_task(&mut self) -> Result<Option<MerkleTreeInsertion>> {
+        let index = self.leaf_index;
+        let db = self.db.clone();
+        let metrics = self.metrics.clone();
+        let name = format!("{}::retrieval::{}::{}", PREFIX, self.domain(), index);
+        let insertion = tokio::task::Builder::new()
+            .name(&name)
+            .spawn_blocking(move || Self::next_unprocessed_leaf(&index, &db, &metrics))?
+            .await??;
+        Ok(insertion)
+    }
+
+    fn next_unprocessed_leaf(
+        leaf_index: &u32,
+        db: &HyperlaneRocksDB,
+        metrics: &MerkleTreeProcessorMetrics,
+    ) -> Result<Option<MerkleTreeInsertion>> {
         let begin = Instant::now();
-        let leaf = if let Some(insertion) = self
-            .db
-            .retrieve_merkle_tree_insertion_by_leaf_index(&self.leaf_index)?
-        {
-            // Update the metrics
-            // we assume that leaves are inserted in order so this will be monotonically increasing
-            self.metrics
-                .latest_tree_insertion_index_gauge
-                .set(insertion.index() as i64);
-
-            self.metrics
-                .merkle_tree_retrieve_insertion_total_elapsed_micros
-                .inc_by(begin.elapsed().as_micros() as u64);
-            self.metrics.merkle_tree_retrieve_insertions_count.inc();
-
+        let insertion = db.retrieve_merkle_tree_insertion_by_leaf_index(leaf_index)?;
+        let leaf = if let Some(insertion) = insertion {
+            Self::update_metrics(metrics, &insertion, &begin);
             Some(insertion)
         } else {
-            trace!(leaf_index=?self.leaf_index, "No merkle tree insertion found in DB for leaf index, waiting for it to be indexed");
+            trace!(
+                ?leaf_index,
+                "No merkle tree insertion found in DB for leaf index, waiting for it to be indexed"
+            );
             None
         };
 
         Ok(leaf)
     }
+
+    fn update_metrics(
+        metrics: &MerkleTreeProcessorMetrics,
+        insertion: &MerkleTreeInsertion,
+        begin: &Instant,
+    ) {
+        // Update the metrics
+        // we assume that leaves are inserted in order so this will be monotonically increasing
+        metrics
+            .latest_tree_insertion_index_gauge
+            .set(insertion.index() as i64);
+        metrics
+            .merkle_tree_retrieve_insertion_total_elapsed_micros
+            .inc_by(begin.elapsed().as_micros() as u64);
+        metrics.merkle_tree_retrieve_insertions_count.inc();
+    }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MerkleTreeProcessorMetrics {
     latest_tree_insertion_index_gauge: IntGauge,
     merkle_tree_retrieve_insertion_total_elapsed_micros: IntCounter,


### PR DESCRIPTION
### Description

Move access to database into a blocking task

The access to rocksdb is synchronous and we discovered that it take about 1 millisecond to make one retrieval of an insertion into a merkle tree from the database when we build internal merkle tree in relayer from scratch. As the result, the worker thread which executes the task, is blocked by access to the database and cannot be used to execute other scheduled tasks.

This change moves the access to the database into a separate thread in the blocking pool. It frees up the worker thread to execute other tasks.

### Related issues

- Contributes into https://github.com/hyperlane-xyz/issues/issues/1420

### Backward compatibility

Yes

### Testing

Manual run of relayer locally