### PR TITLE
chore: add VSXERC20 tokens to getHypAdapter

### DIFF
--- a/typescript/sdk/src/token/Token.ts
+++ b/typescript/sdk/src/token/Token.ts
@@ -214,11 +214,17 @@ export class Token implements IToken {
       return new EvmHypSyntheticAdapter(chainName, multiProvider, {
         token: addressOrDenom,
       });
-    } else if (standard === TokenStandard.EvmHypXERC20) {
+    } else if (
+      standard === TokenStandard.EvmHypXERC20 ||
+      standard === TokenStandard.EvmHypVSXERC20
+    ) {
       return new EvmHypXERC20Adapter(chainName, multiProvider, {
         token: addressOrDenom,
       });
-    } else if (standard === TokenStandard.EvmHypXERC20Lockbox) {
+    } else if (
+      standard === TokenStandard.EvmHypXERC20Lockbox ||
+      standard === TokenStandard.EvmHypVSXERC20Lockbox
+    ) {
       return new EvmHypXERC20LockboxAdapter(chainName, multiProvider, {
         token: addressOrDenom,
       });


### PR DESCRIPTION
### Description

Fix broken test by adding `EvmHypVSXERC20` and `EvmHypVSXERC20Lockbox` token standards to getHypAdapter
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
UI test
