### PR TITLE
fix: only relay specified message ID

### DIFF
--- a/.changeset/ten-poems-tan.md
+++ b/.changeset/ten-poems-tan.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/cli": patch
+---
+
+Only relay specified message ID


### PR DESCRIPTION
### Description

Small fixes to status command for filtering on specified message ID.

### Backward compatibility

Yes

### Testing

Manual

```
Checking status of message 0x96ecd0e3bce5939ad0a16a82cd071bba109b95d0cb73f63fe873ed2fa519480c on superseed
Message 0x96ecd0e3bce5939ad0a16a82cd071bba109b95d0cb73f63fe873ed2fa519480c was delivered in https://explorer.superseed.xyz//tx/0x50a0ed288a1a4e87c6996355fbab4fff18312cb76dd730dfeb76daad2226da03
```