### PR TITLE
apply instrumentation

### DIFF
--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -153,19 +153,21 @@ impl BaseAgent for Validator {
             .settings
             .server(self.core_metrics.clone())
             .expect("Failed to create server");
-        let server_task = tokio::spawn(async move {
-            server.run_with_custom_routes(custom_routes);
-        })
-        .instrument(info_span!("Validator server"));
+        let server_task = tokio::spawn(
+            async move {
+                server.run_with_custom_routes(custom_routes);
+            }
+            .instrument(info_span!("Validator server")),
+        );
         tasks.push(server_task);
 
         if let Some(signer_instance) = self.signer_instance.take() {
-            tasks.push(
-                tokio::spawn(async move {
+            tasks.push(tokio::spawn(
+                async move {
                     signer_instance.run().await;
-                })
+                }
                 .instrument(info_span!("SingletonSigner")),
-            );
+            ));
         }
 
         let metrics_updater = ChainSpecificMetricsUpdater::new(
@@ -177,12 +179,12 @@ impl BaseAgent for Validator {
         )
         .await
         .unwrap();
-        tasks.push(
-            tokio::spawn(async move {
+        tasks.push(tokio::spawn(
+            async move {
                 metrics_updater.spawn().await.unwrap();
-            })
+            }
             .instrument(info_span!("MetricsUpdater")),
-        );
+        ));
 
         // report agent metadata
         self.metadata()
@@ -223,7 +225,7 @@ impl BaseAgent for Validator {
 }
 
 impl Validator {
-    async fn run_merkle_tree_hook_sync(&self) -> Instrumented<JoinHandle<()>> {
+    async fn run_merkle_tree_hook_sync(&self) -> JoinHandle<()> {
         let index_settings =
             self.as_ref().settings.chains[self.origin_chain.name()].index_settings();
         let contract_sync = self.merkle_tree_hook_sync.clone();
@@ -237,15 +239,17 @@ impl Validator {
                 )
             });
         let origin = self.origin_chain.name().to_string();
-        tokio::spawn(async move {
-            let label = "merkle_tree_hook";
-            contract_sync.clone().sync(label, cursor.into()).await;
-            info!(chain = origin, label, "contract sync task exit");
-        })
-        .instrument(info_span!("MerkleTreeHookSyncer"))
+        tokio::spawn(
+            async move {
+                let label = "merkle_tree_hook";
+                contract_sync.clone().sync(label, cursor.into()).await;
+                info!(chain = origin, label, "contract sync task exit");
+            }
+            .instrument(info_span!("MerkleTreeHookSyncer")),
+        )
     }
 
-    async fn run_checkpoint_submitters(&self) -> Vec<Instrumented<JoinHandle<()>>> {
+    async fn run_checkpoint_submitters(&self) -> Vec<JoinHandle<()>> {
         let submitter = ValidatorSubmitter::new(
             self.interval,
             self.reorg_period.clone(),
@@ -270,19 +274,19 @@ impl Validator {
         let backfill_submitter = submitter.clone();
 
         let mut tasks = vec![];
-        tasks.push(
-            tokio::spawn(async move {
+        tasks.push(tokio::spawn(
+            async move {
                 backfill_submitter
                     .backfill_checkpoint_submitter(backfill_target)
                     .await
-            })
+            }
             .instrument(info_span!("BackfillCheckpointSubmitter")),
-        );
+        ));
 
-        tasks.push(
-            tokio::spawn(async move { submitter.checkpoint_submitter(tip_tree).await })
+        tasks.push(tokio::spawn(
+            async move { submitter.checkpoint_submitter(tip_tree).await }
                 .instrument(info_span!("TipCheckpointSubmitter")),
-        );
+        ));
 
         tasks
     }

--- a/rust/main/hyperlane-base/src/metrics/runtime_metrics.rs
+++ b/rust/main/hyperlane-base/src/metrics/runtime_metrics.rs
@@ -54,11 +54,12 @@ impl RuntimeMetrics {
     }
 
     /// Spawns a tokio task to update the metrics
-    pub fn spawn(self) -> Instrumented<JoinHandle<()>> {
+    pub fn spawn(self) -> JoinHandle<()> {
         tokio::spawn(async move {
             self.start_updating_on_interval(METRICS_SCRAPE_INTERVAL)
                 .await;
-        })
-        .instrument(info_span!("RuntimeMetricsUpdater"))
+        }
+        .instrument(info_span!("RuntimeMetricsUpdater")))
     }
 }
+


### PR DESCRIPTION
### Description

This change contains a small fix to log output

Instrumenting a `JoinHandle` will not correctly instrument the task. Instead, we should instrument the task itself, which will correctly display metrics. 

### Drive-by changes

N/A

### Related issues

N/A

### Backward compatibility

N/A

### Testing

Here's logging output for the MerkleTreeSyncer. Log format is set to `compact` in both. You'll note that in the before example, the [instrumentation span](https://github.com/Tessellated-io/hyperlane-monorepo/blob/9fc5e661cdf860242303c8d2a202b2f5db626972/rust/main/agents/validator/src/validator.rs#L245) is not logged to the console, while in the latter it does. 

Before this change:
```
  2025-03-01T04:48:32.076177Z  INFO hyperlane_base::contract_sync::cursors::sequence_aware::backward: return: Ok(Some(21921811..=21923810))
    at hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs:100
    in hyperlane_base::contract_sync::cursors::sequence_aware::backward::get_next_range with self: BackwardSequenceAwareSyncCursor { chunk_size: 1999, last_indexed_snapshot: LastIndexedSnapshot { sequence: Some(59947), at_block: 21923816 }, current_indexing_snapshot: Some(TargetSnapshot { sequence: 59946, at_block: 21923810 }), index_mode: Block, domain: HyperlaneDomain(ethereum (1)) }
    in hyperlane_base::contract_sync::fetch_logs_with_cursor with cursor: ForwardBackwardSequenceAwareSyncCursor { forward: ForwardSequenceAwareSyncCursor { chunk_size: 1999, last_indexed_snapshot: LastIndexedSnapshot { sequence: Some(61117), at_block: 21949711 }, current_indexing_snapshot: TargetSnapshot { sequence: 61118, at_block: 21949712 }, target_snapshot: None, index_mode: Block, domain: HyperlaneDomain(ethereum (1)) }, backward: BackwardSequenceAwareSyncCursor { chunk_size: 1999, last_indexed_snapshot: LastIndexedSnapshot { sequence: Some(59947), at_block: 21923816 }, current_indexing_snapshot: Some(TargetSnapshot { sequence: 59946, at_block: 21923810 }), index_mode: Block, domain: HyperlaneDomain(ethereum (1)) }, last_direction: Backward }, domain: "ethereum"
    in hyperlane_base::contract_sync::ContractSync with label: "merkle_tree_hook", domain: "ethereum"

```

After:
```
  2025-03-01T04:47:15.793466Z  INFO hyperlane_base::contract_sync::cursors::sequence_aware::backward: return: Ok(Some(21941709..=21943708))
    at hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs:100
    in hyperlane_base::contract_sync::cursors::sequence_aware::backward::get_next_range with self: BackwardSequenceAwareSyncCursor { chunk_size: 1999, last_indexed_snapshot: LastIndexedSnapshot { sequence: Some(60846), at_block: 21943780 }, current_indexing_snapshot: Some(TargetSnapshot { sequence: 60845, at_block: 21943708 }), index_mode: Block, domain: HyperlaneDomain(ethereum (1)) }
    in hyperlane_base::contract_sync::fetch_logs_with_cursor with cursor: ForwardBackwardSequenceAwareSyncCursor { forward: ForwardSequenceAwareSyncCursor { chunk_size: 1999, last_indexed_snapshot: LastIndexedSnapshot { sequence: Some(61117), at_block: 21949705 }, current_indexing_snapshot: TargetSnapshot { sequence: 61118, at_block: 21949706 }, target_snapshot: None, index_mode: Block, domain: HyperlaneDomain(ethereum (1)) }, backward: BackwardSequenceAwareSyncCursor { chunk_size: 1999, last_indexed_snapshot: LastIndexedSnapshot { sequence: Some(60846), at_block: 21943780 }, current_indexing_snapshot: Some(TargetSnapshot { sequence: 60845, at_block: 21943708 }), index_mode: Block, domain: HyperlaneDomain(ethereum (1)) }, last_direction: Backward }, domain: "ethereum"
    in hyperlane_base::contract_sync::ContractSync with label: "merkle_tree_hook", domain: "ethereum"
    in validator::validator::MerkleTreeHookSyncer
```

