### PR TITLE
chore: bump abstract key funder desired balance

### DIFF
--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -26,7 +26,7 @@ export const keyFunderConfig: KeyFunderConfig<
   },
   // desired balance config, must be set for each chain
   desiredBalancePerChain: {
-    abstract: '0',
+    abstract: '0.05',
     // acala: '5',
     ancient8: '0.5',
     alephzeroevmmainnet: '100',


### PR DESCRIPTION
### Description

- was previously 0, now 0.05. Fees are very low on abstract (like `0.00000928` per tx), see https://abscan.org/address/0x74cae0ecc47b02ed9b9d32e000fd70b9417970c5

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
