### PR TITLE
chore: Upgrade Relayer Testnet to 8c3e983-20250310-144838

### DIFF
--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -252,7 +252,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '9c57bfe-20250307-120826',
+      tag: '8c3e983-20250310-144838',
     },
     blacklist: [...releaseCandidateHelloworldMatchingList, ...relayBlacklist],
     gasPaymentEnforcement,
@@ -298,7 +298,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '7c0c967-20241218-173053',
+      tag: '8c3e983-20250310-144838',
     },
     whitelist: [...releaseCandidateHelloworldMatchingList],
     blacklist: relayBlacklist,


### PR DESCRIPTION
### Description

Upgrade Relayer Testnet to 8c3e983-20250310-144838
* Add merkle tree processor metrics
* Move retrieval merkle tree into a blocking task

### Related issues

- Contributes into https://github.com/hyperlane-xyz/issues/issues/1420

### Backward compatibility

Yes

### Testing

Manually