### PR TITLE
chore: Fix missing quote in warning log

### DIFF
--- a/typescript/infra/scripts/funding/calculate-relayer-daily-burn.ts
+++ b/typescript/infra/scripts/funding/calculate-relayer-daily-burn.ts
@@ -199,7 +199,7 @@ async function getSealevelBurnProm(
       burn[chain] = formatBalanceThreshold(parseFloat(series.value[1]));
     } else if (series.histogram) {
       rootLogger.warn(
-        `Unexpected histogram data found for "${chain} in Prometheus, skipping.`,
+        `Unexpected histogram data found for "${chain}" in Prometheus, skipping.`,
       );
     }
   }


### PR DESCRIPTION
### Description

Fixed a missing closing quote after `${chain}` in the log message.

