### PR TITLE
chore: separate mint limit check and add test

### DIFF
--- a/typescript/sdk/src/consts/testChains.ts
+++ b/typescript/sdk/src/consts/testChains.ts
@@ -74,6 +74,22 @@ export const test4: ChainMetadata = {
   name: 'test4',
 };
 
+export const testXERC20: ChainMetadata = {
+  ...test1,
+  chainId: 9913374,
+  domainId: 9913374,
+  displayName: 'Test XERC20',
+  name: 'testxerc20',
+};
+
+export const testVSXERC20: ChainMetadata = {
+  ...test1,
+  chainId: 9913375,
+  domainId: 9913375,
+  displayName: 'Test VSXERC20',
+  name: 'testvsxerc20',
+};
+
 export const testChainMetadata: ChainMap<ChainMetadata> = {
   test1,
   test2,
@@ -123,6 +139,8 @@ export const multiProtocolTestChainMetadata: ChainMap<ChainMetadata> = {
   ...testChainMetadata,
   testcosmos: testCosmosChain,
   testsealevel: testSealevelChain,
+  testxerc20: testXERC20,
+  testvsxerc20: testVSXERC20,
 };
 
 export const multiProtocolTestChains: Array<ChainName> = Object.keys(

--- a/typescript/sdk/src/consts/testChains.ts
+++ b/typescript/sdk/src/consts/testChains.ts
@@ -90,6 +90,14 @@ export const testVSXERC20: ChainMetadata = {
   name: 'testvsxerc20',
 };
 
+export const testXERC20Lockbox: ChainMetadata = {
+  ...test1,
+  chainId: 9913376,
+  domainId: 9913376,
+  displayName: 'Test XERC20Lockbox',
+  name: 'testxerc20lockbox',
+};
+
 export const testChainMetadata: ChainMap<ChainMetadata> = {
   test1,
   test2,
@@ -141,6 +149,7 @@ export const multiProtocolTestChainMetadata: ChainMap<ChainMetadata> = {
   testsealevel: testSealevelChain,
   testxerc20: testXERC20,
   testvsxerc20: testVSXERC20,
+  testxerc20lockbox: testXERC20Lockbox,
 };
 
 export const multiProtocolTestChains: Array<ChainName> = Object.keys(

--- a/typescript/sdk/src/token/TokenStandard.ts
+++ b/typescript/sdk/src/token/TokenStandard.ts
@@ -110,6 +110,8 @@ export const TOKEN_COLLATERALIZED_STANDARDS = [
   TokenStandard.SealevelHypNative,
   TokenStandard.CwHypCollateral,
   TokenStandard.CwHypNative,
+  TokenStandard.EvmHypXERC20Lockbox,
+  TokenStandard.EvmHypVSXERC20Lockbox,
 ];
 
 export const XERC20_STANDARDS = [
@@ -119,7 +121,12 @@ export const XERC20_STANDARDS = [
   TokenStandard.EvmHypVSXERC20Lockbox,
 ];
 
-export const MINT_LIMITED_STANDARDS = [...XERC20_STANDARDS];
+export const MINT_LIMITED_STANDARDS = [
+  TokenStandard.EvmHypXERC20,
+  TokenStandard.EvmHypXERC20Lockbox,
+  TokenStandard.EvmHypVSXERC20,
+  TokenStandard.EvmHypVSXERC20Lockbox,
+];
 
 export const TOKEN_HYP_STANDARDS = [
   TokenStandard.EvmHypNative,

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -24,8 +24,10 @@ import { WarpTxCategory } from './types.js';
 const MOCK_LOCAL_QUOTE = { gasUnits: 2_000n, gasPrice: 100, fee: 200_000n };
 const MOCK_INTERCHAIN_QUOTE = { amount: 20_000n };
 const TRANSFER_AMOUNT = BigInt('1000000000000000000'); // 1 units @ 18 decimals
+const MEDIUM_TRANSFER_AMOUNT = BigInt('15000000000000000000'); // 15 units @ 18 deicmals
 const BIG_TRANSFER_AMOUNT = BigInt('100000000000000000000'); // 100 units @ 18 decimals
 const MOCK_BALANCE = BigInt('10000000000000000000'); // 10 units @ 18 decimals
+const MEDIUM_MOCK_BALANCE = BigInt('50000000000000000000'); // 50 units at @ 18 decimals
 const MOCK_ADDRESS = '0x0000000000000000000000000000000000000001';
 
 describe('WarpCore', () => {
@@ -204,8 +206,8 @@ describe('WarpCore', () => {
         populateTransferRemoteTx: () => Promise.resolve({}),
         getMinimumTransferAmount: () => Promise.resolve(minimumTransferAmount),
         getBalance: () => Promise.resolve(MOCK_BALANCE),
-        getMintLimit: () => Promise.resolve(MOCK_BALANCE),
-        getMintMaxLimit: () => Promise.resolve(MOCK_BALANCE),
+        getMintLimit: () => Promise.resolve(MEDIUM_MOCK_BALANCE),
+        getMintMaxLimit: () => Promise.resolve(MEDIUM_MOCK_BALANCE),
       } as any),
     );
 
@@ -271,7 +273,6 @@ describe('WarpCore', () => {
       recipient: MOCK_ADDRESS,
       sender: MOCK_ADDRESS,
     });
-
     expect(Object.values(invalidRateLimit || {})[0]).to.equal(
       'Rate limit exceeded on destination',
     );
@@ -282,9 +283,18 @@ describe('WarpCore', () => {
       recipient: MOCK_ADDRESS,
       sender: MOCK_ADDRESS,
     });
-
     expect(Object.values(invalidVSXERC20TokenRateLimit || {})[0]).to.equal(
       'Rate limit exceeded on destination',
+    );
+
+    const invalidCollateralForVSXERC20Token = await warpCore.validateTransfer({
+      originTokenAmount: evmHypXERC20.amount(MEDIUM_TRANSFER_AMOUNT),
+      destination: testVSXERC20.name,
+      recipient: MOCK_ADDRESS,
+      sender: MOCK_ADDRESS,
+    });
+    expect(Object.values(invalidCollateralForVSXERC20Token || {})[0]).to.equal(
+      'Insufficient collateral on destination',
     );
 
     balanceStubs.forEach((s) => s.restore());

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -10,6 +10,7 @@ import {
   testSealevelChain,
   testVSXERC20,
   testXERC20,
+  testXERC20Lockbox,
 } from '../consts/testChains.js';
 import { MultiProtocolProvider } from '../providers/MultiProtocolProvider.js';
 import { ProviderType } from '../providers/ProviderType.js';
@@ -37,6 +38,7 @@ describe('WarpCore', () => {
   let evmHypSynthetic: Token;
   let evmHypXERC20: Token;
   let evmHypVSXERC20: Token;
+  let evmHypXERC20Lockbox: Token;
   let sealevelHypSynthetic: Token;
   let cwHypCollateral: Token;
   let cw20: Token;
@@ -65,6 +67,7 @@ describe('WarpCore', () => {
       evmHypSynthetic,
       evmHypXERC20,
       evmHypVSXERC20,
+      evmHypXERC20Lockbox,
       sealevelHypSynthetic,
       cwHypCollateral,
       cw20,
@@ -188,8 +191,10 @@ describe('WarpCore', () => {
     await testCollateral(evmHypNative, testCosmosChain.name, false);
     await testCollateral(evmHypNative, testSealevelChain.name, true);
     await testCollateral(cwHypCollateral, test1.name, false);
-    await testCollateral(evmHypXERC20, testVSXERC20.name, false);
-    await testCollateral(evmHypVSXERC20, testXERC20.name, false);
+    await testCollateral(evmHypXERC20, testVSXERC20.name, true);
+    await testCollateral(evmHypVSXERC20, testXERC20.name, true);
+    await testCollateral(evmHypXERC20Lockbox, testXERC20.name, true);
+    await testCollateral(evmHypNative, testXERC20Lockbox.name, false);
 
     stubs.forEach((s) => s.restore());
   });
@@ -277,25 +282,27 @@ describe('WarpCore', () => {
       'Rate limit exceeded on destination',
     );
 
-    const invalidVSXERC20TokenRateLimit = await warpCore.validateTransfer({
+    const invalidXERC20LockboxTokenRateLimit = await warpCore.validateTransfer({
       originTokenAmount: evmHypXERC20.amount(BIG_TRANSFER_AMOUNT),
-      destination: testVSXERC20.name,
+      destination: testXERC20Lockbox.name,
       recipient: MOCK_ADDRESS,
       sender: MOCK_ADDRESS,
     });
-    expect(Object.values(invalidVSXERC20TokenRateLimit || {})[0]).to.equal(
+    expect(Object.values(invalidXERC20LockboxTokenRateLimit || {})[0]).to.equal(
       'Rate limit exceeded on destination',
     );
 
-    const invalidCollateralForVSXERC20Token = await warpCore.validateTransfer({
-      originTokenAmount: evmHypXERC20.amount(MEDIUM_TRANSFER_AMOUNT),
-      destination: testVSXERC20.name,
-      recipient: MOCK_ADDRESS,
-      sender: MOCK_ADDRESS,
-    });
-    expect(Object.values(invalidCollateralForVSXERC20Token || {})[0]).to.equal(
-      'Insufficient collateral on destination',
+    const invalidCollateralXERC20LockboxToken = await warpCore.validateTransfer(
+      {
+        originTokenAmount: evmHypXERC20.amount(MEDIUM_TRANSFER_AMOUNT),
+        destination: testXERC20Lockbox.name,
+        recipient: MOCK_ADDRESS,
+        sender: MOCK_ADDRESS,
+      },
     );
+    expect(
+      Object.values(invalidCollateralXERC20LockboxToken || {})[0],
+    ).to.equal('Insufficient collateral on destination');
 
     balanceStubs.forEach((s) => s.restore());
     quoteStubs.forEach((s) => s.restore());

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -257,13 +257,13 @@ describe('WarpCore', () => {
     });
     expect(Object.keys(insufficientBalance || {})[0]).to.equal('amount');
 
-    const validXERC20Result = await warpCore.validateTransfer({
+    const validXERC20TokenResult = await warpCore.validateTransfer({
       originTokenAmount: evmHypNative.amount(TRANSFER_AMOUNT),
       destination: testXERC20.name,
       recipient: MOCK_ADDRESS,
       sender: MOCK_ADDRESS,
     });
-    expect(validXERC20Result).to.be.null;
+    expect(validXERC20TokenResult).to.be.null;
 
     const invalidRateLimit = await warpCore.validateTransfer({
       originTokenAmount: evmHypNative.amount(BIG_TRANSFER_AMOUNT),
@@ -273,6 +273,17 @@ describe('WarpCore', () => {
     });
 
     expect(Object.values(invalidRateLimit || {})[0]).to.equal(
+      'Rate limit exceeded on destination',
+    );
+
+    const invalidVSXERC20TokenRateLimit = await warpCore.validateTransfer({
+      originTokenAmount: evmHypXERC20.amount(BIG_TRANSFER_AMOUNT),
+      destination: testVSXERC20.name,
+      recipient: MOCK_ADDRESS,
+      sender: MOCK_ADDRESS,
+    });
+
+    expect(Object.values(invalidVSXERC20TokenRateLimit || {})[0]).to.equal(
       'Rate limit exceeded on destination',
     );
 

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -476,10 +476,7 @@ export class WarpCore {
       originToken.getConnectionForChain(destinationName)?.token;
     assert(destinationToken, `No connection found for ${destinationName}`);
 
-    if (
-      !TOKEN_COLLATERALIZED_STANDARDS.includes(destinationToken.standard) &&
-      !MINT_LIMITED_STANDARDS.includes(destinationToken.standard)
-    ) {
+    if (!TOKEN_COLLATERALIZED_STANDARDS.includes(destinationToken.standard)) {
       this.logger.debug(
         `${destinationToken.symbol} is not collateralized, skipping`,
       );

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -22,7 +22,6 @@ import { Token } from '../token/Token.js';
 import { TokenAmount } from '../token/TokenAmount.js';
 import { parseTokenConnectionId } from '../token/TokenConnection.js';
 import {
-  MINT_LIMITED_STANDARDS,
   TOKEN_COLLATERALIZED_STANDARDS,
   TOKEN_STANDARD_TO_PROVIDER_TYPE,
   TokenStandard,

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -795,11 +795,11 @@ export class WarpCore {
       return null;
     }
 
-    let destinationBalance: bigint;
+    let destinationMintLimit: bigint;
     const adapter = destinationToken.getAdapter(
       this.multiProvider,
     ) as IHypXERC20Adapter<unknown>;
-    destinationBalance = await adapter.getMintLimit();
+    destinationMintLimit = await adapter.getMintLimit();
 
     if (
       destinationToken.standard === TokenStandard.EvmHypVSXERC20 ||
@@ -807,21 +807,21 @@ export class WarpCore {
     ) {
       const bufferCap = await adapter.getMintMaxLimit();
       const max = bufferCap / 2n;
-      if (destinationBalance > max) {
+      if (destinationMintLimit > max) {
         this.logger.debug(
-          `Mint limit ${destinationBalance} exceeds max ${max}, using max`,
+          `Mint limit ${destinationMintLimit} exceeds max ${max}, using max`,
         );
-        destinationBalance = max;
+        destinationMintLimit = max;
       }
     }
 
-    const destinationBalanceInOriginDecimals = convertDecimalsToIntegerString(
+    const destinationMintLimitInOriginDecimals = convertDecimalsToIntegerString(
       destinationToken.decimals,
       originToken.decimals,
-      destinationBalance.toString(),
+      destinationMintLimit.toString(),
     );
 
-    const isSufficient = BigInt(destinationBalanceInOriginDecimals) >= amount;
+    const isSufficient = BigInt(destinationMintLimitInOriginDecimals) >= amount;
     this.logger.debug(
       `${originTokenAmount.token.symbol} to ${destination} has ${
         isSufficient ? 'sufficient' : 'INSUFFICIENT'

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -486,33 +486,10 @@ export class WarpCore {
       return true;
     }
 
-    let destinationBalance: bigint;
-
     const adapter = destinationToken.getAdapter(this.multiProvider);
-    if (MINT_LIMITED_STANDARDS.includes(destinationToken.standard)) {
-      const adapter = destinationToken.getAdapter(
-        this.multiProvider,
-      ) as IHypXERC20Adapter<unknown>;
-      destinationBalance = await adapter.getMintLimit();
-
-      if (
-        destinationToken.standard === TokenStandard.EvmHypVSXERC20 ||
-        destinationToken.standard === TokenStandard.EvmHypVSXERC20Lockbox
-      ) {
-        const bufferCap = await adapter.getMintMaxLimit();
-        const max = bufferCap / 2n;
-        if (destinationBalance > max) {
-          this.logger.debug(
-            `Mint limit ${destinationBalance} exceeds max ${max}, using max`,
-          );
-          destinationBalance = max;
-        }
-      }
-    } else {
-      destinationBalance = await adapter.getBalance(
-        destinationToken.addressOrDenom,
-      );
-    }
+    const destinationBalance: bigint = await adapter.getBalance(
+      destinationToken.addressOrDenom,
+    );
 
     const destinationBalanceInOriginDecimals = convertDecimalsToIntegerString(
       destinationToken.decimals,
@@ -585,6 +562,12 @@ export class WarpCore {
       recipient,
     );
     if (amountError) return amountError;
+
+    const destinationRateLimitError = await this.validateDestinationRateLimit(
+      originTokenAmount,
+      destination,
+    );
+    if (destinationRateLimitError) return destinationRateLimitError;
 
     const destinationCollateralError = await this.validateDestinationCollateral(
       originTokenAmount,
@@ -787,18 +770,64 @@ export class WarpCore {
     });
 
     if (!valid) {
-      const destinationName = this.multiProvider.getChainName(destination);
-      const destinationToken =
-        originTokenAmount.token.getConnectionForChain(destinationName)?.token;
-      if (
-        destinationToken &&
-        MINT_LIMITED_STANDARDS.includes(destinationToken.standard)
-      ) {
-        return { amount: 'Rate limit exceeded on destination' };
-      }
       return { amount: 'Insufficient collateral on destination' };
     }
+    return null;
+  }
 
+  /**
+   * Ensure the sender has sufficient balances for minting
+   */
+  protected async validateDestinationRateLimit(
+    originTokenAmount: TokenAmount,
+    destination: ChainNameOrId,
+  ): Promise<Record<string, string> | null> {
+    const { token: originToken, amount } = originTokenAmount;
+    const destinationName = this.multiProvider.getChainName(destination);
+    const destinationToken =
+      originToken.getConnectionForChain(destinationName)?.token;
+    assert(destinationToken, `No connection found for ${destinationName}`);
+
+    if (!MINT_LIMITED_STANDARDS.includes(destinationToken.standard)) {
+      this.logger.debug(
+        `${destinationToken.symbol} does not have rate limit constraint, skipping`,
+      );
+      return null;
+    }
+
+    let destinationBalance: bigint;
+    const adapter = destinationToken.getAdapter(
+      this.multiProvider,
+    ) as IHypXERC20Adapter<unknown>;
+    destinationBalance = await adapter.getMintLimit();
+
+    if (
+      destinationToken.standard === TokenStandard.EvmHypVSXERC20 ||
+      destinationToken.standard === TokenStandard.EvmHypVSXERC20Lockbox
+    ) {
+      const bufferCap = await adapter.getMintMaxLimit();
+      const max = bufferCap / 2n;
+      if (destinationBalance > max) {
+        this.logger.debug(
+          `Mint limit ${destinationBalance} exceeds max ${max}, using max`,
+        );
+        destinationBalance = max;
+      }
+    }
+
+    const destinationBalanceInOriginDecimals = convertDecimalsToIntegerString(
+      destinationToken.decimals,
+      originToken.decimals,
+      destinationBalance.toString(),
+    );
+
+    const isSufficient = BigInt(destinationBalanceInOriginDecimals) >= amount;
+    this.logger.debug(
+      `${originTokenAmount.token.symbol} to ${destination} has ${
+        isSufficient ? 'sufficient' : 'INSUFFICIENT'
+      } rate limits`,
+    );
+    if (!isSufficient) return { amount: 'Rate limit exceeded on destination' };
     return null;
   }
 

--- a/typescript/sdk/src/warp/test-warp-core-config.yaml
+++ b/typescript/sdk/src/warp/test-warp-core-config.yaml
@@ -17,6 +17,9 @@ tokens:
       - {
           token: sealevel|testsealevel|s0LaBcEeFgHiJkLmNoPqRsTuVwXyZ456789012345678,
         }
+      - {
+          token: ethereum|testxerc20|0x9876543210987654321098765432109876543211,
+        }
   # test2 HypSynthetic token
   - chainName: test2
     standard: EvmHypSynthetic
@@ -28,6 +31,28 @@ tokens:
       - { token: ethereum|test1|0x1234567890123456789012345678901234567890 }
       - {
           token: cosmos|testcosmos|testcosmos1abcdefghijklmnopqrstuvwxyz1234567890ab,
+        }
+  # test3 EvmHypXERC20 token
+  - chainName: testxerc20
+    standard: EvmHypXERC20
+    decimals: 18
+    symbol: ETH
+    name: Ether
+    addressOrDenom: '0x9876543210987654321098765432109876543211'
+    connections:
+      - {
+          token: ethereum|testvsxerc20|0x9876543210987654321098765432109876543212,
+        }
+  # test4 EvmHypVSXERC20
+  - chainName: testvsxerc20
+    standard: EvmHypVSXERC20
+    decimals: 18
+    symbol: ETH
+    name: Ether
+    addressOrDenom: '0x9876543210987654321098765432109876543212'
+    connections:
+      - {
+          token: ethereum|testxerc20|0x9876543210987654321098765432109876543211,
         }
   # testsealevel HypSynthetic
   - chainName: testsealevel

--- a/typescript/sdk/src/warp/test-warp-core-config.yaml
+++ b/typescript/sdk/src/warp/test-warp-core-config.yaml
@@ -20,6 +20,12 @@ tokens:
       - {
           token: ethereum|testxerc20|0x9876543210987654321098765432109876543211,
         }
+      - {
+          token: ethereum|testvsxerc20|0x9876543210987654321098765432109876543212,
+        }
+      - {
+          token: ethereum|testxerc20lockbox|0x9876543210987654321098765432109876543218,
+        }
   # test2 HypSynthetic token
   - chainName: test2
     standard: EvmHypSynthetic
@@ -32,7 +38,7 @@ tokens:
       - {
           token: cosmos|testcosmos|testcosmos1abcdefghijklmnopqrstuvwxyz1234567890ab,
         }
-  # test3 EvmHypXERC20 token
+  # testxerc20 EvmHypXERC20 token
   - chainName: testxerc20
     standard: EvmHypXERC20
     decimals: 18
@@ -43,7 +49,11 @@ tokens:
       - {
           token: ethereum|testvsxerc20|0x9876543210987654321098765432109876543212,
         }
-  # test4 EvmHypVSXERC20
+      - { token: ethereum|test1|0x1234567890123456789012345678901234567890 }
+      - {
+          token: ethereum|testxerc20lockbox|0x9876543210987654321098765432109876543218,
+        }
+  # testvsxerc20 EvmHypVSXERC20
   - chainName: testvsxerc20
     standard: EvmHypVSXERC20
     decimals: 18
@@ -54,6 +64,18 @@ tokens:
       - {
           token: ethereum|testxerc20|0x9876543210987654321098765432109876543211,
         }
+      - { token: ethereum|test1|0x1234567890123456789012345678901234567890 }
+  - chainName: testxerc20lockbox
+    standard: EvmHypXERC20Lockbox
+    decimals: 18
+    symbol: ETH
+    name: Ether
+    addressOrDenom: '0x9876543210987654321098765432109876543218'
+    connections:
+      - {
+          token: ethereum|testxerc20|0x9876543210987654321098765432109876543211,
+        }
+      - { token: ethereum|test1|0x1234567890123456789012345678901234567890 }
   # testsealevel HypSynthetic
   - chainName: testsealevel
     standard: SealevelHypSynthetic


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

- Separate mint limit checking from `isDestinationCollateralSufficient` into its own function: `validateDestinationRateLimit`
- Add new test for XERC20 tokens for checking `isDestinationCollateralSufficient` and `validateTransfer` 
- Add lockbox token standard to `TOKEN_COLLATERALIZED_STANDARDS` 
- Separated `MINT_LIMITED_STANDARDS` from `XERC20_STANDARDS` tokens
- Remove early return in `isDestinationCollateralSufficient` for `MINT_LIMITED_STANDARDS` tokens

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
Unit tests