### PR TITLE
fix: comment out oUSDT staging warp id to fix check warp deploy job

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
@@ -75,12 +75,13 @@ export enum WarpRouteIds {
   SolanaSonicsvmLrtsSOL = 'lrtsSOL/solanamainnet-sonicsvm',
   SolanaSonicsvmSonicSOL = 'sonicSOL/solanamainnet-sonicsvm',
   ArbitrumEthereumSolanaTreasureSMOL = 'SMOL/arbitrum-ethereum-solanamainnet-treasure',
-  SuperTokenStaging = 'USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain-staging',
+  // TODO: uncomment after merging the staging route to registry
+  // this has been commented out as it leads to check-warp-deploy cron job failing
+  // SuperTokenStaging = 'USDTSTAGING/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain',
   SuperUSDT = 'USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain',
   BaseSolanaCDX = 'CDX/base-solanamainnet',
   HyperevmSolanaSOL = 'SOL/hyperevm-solanamainnet',
   MintSolanaMINT = 'MINT/mint-solanamainnet',
   EthereumUnichainPumpBTC = 'pumpBTCuni/ethereum-unichain',
-  BaseCeloFraxtalInkLiskModeOptimismSoneiumSuperseedUnichainWorldchainUSDT = 'USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain',
   BaseEthereumLumiaprismETH = 'ETH/base-ethereum-lumiaprism',
 }

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -110,7 +110,9 @@ export const warpConfigGetterMap: Record<string, WarpConfigGetter> = {
   [WarpRouteIds.EthereumSuperseedUSDC]: getEthereumSuperseedUSDCWarpConfig,
   [WarpRouteIds.ArbitrumEthereumSolanaTreasureSMOL]:
     getArbitrumEthereumSolanaTreasureSMOLWarpConfig,
-  [WarpRouteIds.SuperTokenStaging]: getSuperTokenStagingWarpConfig,
+  // TODO: uncomment after merging the staging route to registry
+  // this has been commented out as it leads to check-warp-deploy cron job failing
+  // [WarpRouteIds.SuperTokenStaging]: getSuperTokenStagingWarpConfig,
   [WarpRouteIds.SuperUSDT]: getSuperTokenProductionWarpConfig,
   [WarpRouteIds.MintSolanaMINT]: getMintSolanaMintWarpConfig,
   [WarpRouteIds.BaseEthereumLumiaprismETH]:


### PR DESCRIPTION
### Description

- comment out the oUSDT staging route for now until we decide on a path forward to include it (see https://hyperlaneworkspace.slack.com/archives/C08H0T2FL2V/p1741724924053689) 
- the inclusion of this warpId is leading to the check-warp-deploy job failing as the staging config is not yet merged into registry

### Drive-by changes

- delete duplicated warp route ID for oUSDT 

### Testing

Manual