### PR TITLE
Standardize naming in utilities and fixed incorrect method

### DIFF
--- a/typescript/cli/src/utils/files.ts
+++ b/typescript/cli/src/utils/files.ts
@@ -235,7 +235,7 @@ export async function runFileSelectionStep(
   });
 
   if (filename) return filename;
-  else throw new Error(`No filepath entered ${description}`);
+  else throw new Error(`No filepath entered for ${description}`);
 }
 
 export function indentYamlOrJson(str: string, indentLevel: number): string {

--- a/typescript/infra/scripts/check/check-utils.ts
+++ b/typescript/infra/scripts/check/check-utils.ts
@@ -280,7 +280,7 @@ export async function getGovernor(
     governor = new ProxiedRouterGovernor(checker, ica);
   } else {
     throw Error(
-      `Checker or governor not implemented not implemented for ${module}`,
+      `Checker or governor not implemented for ${module}`,
     );
   }
 

--- a/typescript/sdk/src/gas/utils.ts
+++ b/typescript/sdk/src/gas/utils.ts
@@ -16,7 +16,7 @@ import { MultiProtocolProvider } from '../providers/MultiProtocolProvider.js';
 import { ChainMap, ChainName } from '../types.js';
 import { getCosmosRegistryChain } from '../utils/cosmos.js';
 
-import { ProtocolAgnositicGasOracleConfig } from './oracle/types.js';
+import { ProtocolAgnosticGasOracleConfig } from './oracle/types.js';
 
 export interface GasPriceConfig {
   amount: string;
@@ -171,9 +171,9 @@ export function getLocalStorageGasOracleConfig({
   gasPriceModifier?: (
     local: ChainName,
     remote: ChainName,
-    gasOracleConfig: ProtocolAgnositicGasOracleConfig,
+    gasOracleConfig: ProtocolAgnosticGasOracleConfig,
   ) => BigNumberJs.Value;
-}): ChainMap<ProtocolAgnositicGasOracleConfig> {
+}): ChainMap<ProtocolAgnosticGasOracleConfig> {
   const remotes = Object.keys(gasOracleParams).filter(
     (remote) => remote !== local,
   );
@@ -242,14 +242,14 @@ export function getLocalStorageGasOracleConfig({
       ...agg,
       [remote]: gasOracleConfig,
     };
-  }, {} as ChainMap<ProtocolAgnositicGasOracleConfig>);
+  }, {} as ChainMap<ProtocolAgnosticGasOracleConfig>);
 }
 
 function adjustForPrecisionLoss(
   gasPrice: BigNumberJs.Value,
   exchangeRate: BigNumber,
   remoteDecimals: number,
-): ProtocolAgnositicGasOracleConfig {
+): ProtocolAgnosticGasOracleConfig {
   let newGasPrice = new BigNumberJs(gasPrice);
   let newExchangeRate = exchangeRate;
 
@@ -263,7 +263,7 @@ function adjustForPrecisionLoss(
     // Check that there's no significant underflow when applying
     // this to the exchange rate:
     const adjustedExchangeRate = newExchangeRate.div(gasPriceScalingFactor);
-    const recoveredExchangeRate = adjustedExchangeRate.mul(
+    const recoveredExchangeRate = adjustedExchangeRate.times(
       gasPriceScalingFactor,
     );
     if (recoveredExchangeRate.mul(100).div(newExchangeRate).lt(99)) {


### PR DESCRIPTION
- Fixed incorrect method usage (`.mul()` → `.times()`) in `adjustForPrecisionLoss`
- Fixed  in `runFileSelectionStep` error message in `files.ts`
- Corrected a duplicate phrase in `check-utils.ts` error message
- Standardized the naming of `ProtocolAgnositicGasOracleConfig` to `ProtocolAgnosticGasOracleConfig` in `utils.ts`