### PR TITLE
feat: add grpc/rpc separation in rpc metrics

### DIFF
--- a/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/cosmos/provider.rs
@@ -25,7 +25,9 @@ use hyperlane_core::{
     HyperlaneDomain, HyperlaneProvider, HyperlaneProviderError, TxnInfo, TxnReceiptInfo, H256,
     H512, U256,
 };
-use hyperlane_metric::prometheus_metric::{NodeInfo, PrometheusClientMetrics, PrometheusConfig};
+use hyperlane_metric::prometheus_metric::{
+    ClientConnectionType, NodeInfo, PrometheusClientMetrics, PrometheusConfig,
+};
 use hyperlane_metric::utils::url_to_host_info;
 
 use crate::grpc::{WasmGrpcProvider, WasmProvider};
@@ -75,7 +77,8 @@ impl CosmosProvider {
             .get_rpc_urls()
             .iter()
             .map(|url| {
-                let metrics_config = PrometheusConfig::from_url(url, chain.clone());
+                let metrics_config =
+                    PrometheusConfig::from_url(url, ClientConnectionType::Rpc, chain.clone());
                 CosmosRpcClient::new(url, metrics.clone(), metrics_config)
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/rust/main/chains/hyperlane-cosmos/src/providers/grpc.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/grpc.rs
@@ -27,7 +27,9 @@ use cosmrs::{
     Any, Coin,
 };
 use derive_new::new;
-use hyperlane_metric::prometheus_metric::{ChainInfo, PrometheusClientMetrics, PrometheusConfig};
+use hyperlane_metric::prometheus_metric::{
+    ChainInfo, ClientConnectionType, PrometheusClientMetrics, PrometheusConfig,
+};
 use ibc_proto::cosmos::{
     auth::v1beta1::QueryAccountResponse, bank::v1beta1::QueryBalanceResponse,
     base::tendermint::v1beta1::GetLatestBlockResponse,
@@ -312,7 +314,8 @@ impl WasmGrpcProvider {
             .get_grpc_urls()
             .into_iter()
             .map(|url| {
-                let metrics_config = PrometheusConfig::from_url(&url, chain.clone());
+                let metrics_config =
+                    PrometheusConfig::from_url(&url, ClientConnectionType::Grpc, chain.clone());
                 Endpoint::new(url.to_string())
                     .map(|e| {
                         let metrics_channel =

--- a/rust/main/chains/hyperlane-cosmos/src/providers/rpc/provider.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/rpc/provider.rs
@@ -5,7 +5,9 @@ use cosmrs::cosmwasm::MsgExecuteContract;
 use cosmrs::rpc::client::Client;
 use futures::StreamExt;
 use hyperlane_core::rpc_clients::{BlockNumberGetter, FallbackProvider};
-use hyperlane_metric::prometheus_metric::{ChainInfo, PrometheusClientMetrics, PrometheusConfig};
+use hyperlane_metric::prometheus_metric::{
+    ChainInfo, ClientConnectionType, PrometheusClientMetrics, PrometheusConfig,
+};
 use sha256::digest;
 use tendermint::abci::{Event, EventAttribute};
 use tendermint::hash::Algorithm;
@@ -101,7 +103,8 @@ impl CosmosWasmRpcProvider {
             .get_rpc_urls()
             .iter()
             .map(|url| {
-                let metrics_config = PrometheusConfig::from_url(url, chain.clone());
+                let metrics_config =
+                    PrometheusConfig::from_url(url, ClientConnectionType::Rpc, chain.clone());
                 CosmosRpcClient::new(url, metrics.clone(), metrics_config)
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -26,7 +26,8 @@ use hyperlane_core::{
     ChainCommunicationError, ChainResult, ContractLocator, HyperlaneDomain, KnownHyperlaneDomain,
 };
 use hyperlane_metric::prometheus_metric::{
-    NodeInfo, PrometheusClientMetrics, PrometheusClientMetricsBuilder, PrometheusConfig,
+    ClientConnectionType, NodeInfo, PrometheusClientMetrics, PrometheusClientMetricsBuilder,
+    PrometheusConfig,
 };
 use tracing::instrument;
 
@@ -156,6 +157,7 @@ pub trait BuildableWithProvider {
                 .clone()
                 .unwrap_or_else(|| PrometheusClientMetricsBuilder::default().build().unwrap()),
             PrometheusConfig {
+                connection_type: ClientConnectionType::Rpc,
                 node: Some(NodeInfo {
                     host: url_to_host_info(&url),
                 }),

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client_builder.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client_builder.rs
@@ -1,4 +1,6 @@
-use hyperlane_metric::prometheus_metric::{ChainInfo, PrometheusClientMetrics, PrometheusConfig};
+use hyperlane_metric::prometheus_metric::{
+    ChainInfo, ClientConnectionType, PrometheusClientMetrics, PrometheusConfig,
+};
 use solana_client::{nonblocking::rpc_client::RpcClient, rpc_client::RpcClientConfig};
 use solana_sdk::commitment_config::CommitmentConfig;
 use url::Url;
@@ -29,7 +31,8 @@ impl SealevelRpcClientBuilder {
         metrics: PrometheusClientMetrics,
         chain: Option<ChainInfo>,
     ) -> Self {
-        let metrics_config = PrometheusConfig::from_url(&self.rpc_url, chain);
+        let metrics_config =
+            PrometheusConfig::from_url(&self.rpc_url, ClientConnectionType::Rpc, chain);
         self.prometheus_config = Some((metrics, metrics_config));
         self
     }

--- a/rust/main/hyperlane-metric/src/prometheus_metric.rs
+++ b/rust/main/hyperlane-metric/src/prometheus_metric.rs
@@ -11,13 +11,14 @@ use url::Url;
 use crate::utils::url_to_host_info;
 
 /// Expected label names for the metric.
-pub const REQUEST_COUNT_LABELS: &[&str] = &["provider_node", "chain", "method", "status"];
+pub const REQUEST_COUNT_LABELS: &[&str] =
+    &["provider_node", "connection", "chain", "method", "status"];
 /// Help string for the metric.
 pub const REQUEST_COUNT_HELP: &str = "Total number of requests made to this client";
 
 /// Expected label names for the metric.
 pub const REQUEST_DURATION_SECONDS_LABELS: &[&str] =
-    &["provider_node", "chain", "method", "status"];
+    &["provider_node", "connection", "chain", "method", "status"];
 /// Help string for the metric.
 pub const REQUEST_DURATION_SECONDS_HELP: &str = "Total number of seconds spent making requests";
 

--- a/rust/main/utils/run-locally/src/cosmos/termination_invariants.rs
+++ b/rust/main/utils/run-locally/src/cosmos/termination_invariants.rs
@@ -119,6 +119,14 @@ pub fn termination_invariants_met(
         return Ok(false);
     }
 
+    if !provider_metrics_invariant_met(
+        &relayer_metrics_port.to_string(),
+        messages_expected,
+        &hashmap! {"connection" => "grpc", "status" => "success"},
+    )? {
+        return Ok(false);
+    }
+
     log!("Termination invariants have been meet");
     Ok(true)
 }

--- a/rust/main/utils/run-locally/src/cosmos/termination_invariants.rs
+++ b/rust/main/utils/run-locally/src/cosmos/termination_invariants.rs
@@ -114,7 +114,7 @@ pub fn termination_invariants_met(
     if !provider_metrics_invariant_met(
         &relayer_metrics_port.to_string(),
         messages_expected,
-        &hashmap! {"status" => "success"},
+        &hashmap! {"connection" => "rpc", "status" => "success"},
     )? {
         return Ok(false);
     }

--- a/rust/main/utils/run-locally/src/sealevel/termination_invariants.rs
+++ b/rust/main/utils/run-locally/src/sealevel/termination_invariants.rs
@@ -66,7 +66,7 @@ pub fn termination_invariants_met(
     if !provider_metrics_invariant_met(
         RELAYER_METRICS_PORT,
         total_messages_expected,
-        &hashmap! {"chain" => "sealeveltest1", "status" => "success"},
+        &hashmap! {"chain" => "sealeveltest1", "connection" => "rpc", "status" => "success"},
     )? {
         return Ok(false);
     }


### PR DESCRIPTION
### Description

 - add a `connection` label to client metrics
   - so we can filter based on `rpc/grpc` connection types

### Related issues

https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5661

### Backward compatibility

Yes

### Testing

Updated E2E to filter by connection
