### PR TITLE
chore: skip eco messages in relayer

### DIFF
--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -1263,7 +1263,7 @@
       "domainId": 6909546,
       "gasCurrencyCoinGeckoId": "injective-protocol",
       "gasPrice": {
-        "amount": "700000000",
+        "amount": "160000000",
         "denom": "inj"
       },
       "grpcUrls": [

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -686,9 +686,16 @@ const blacklistedMessageIds = [
 ];
 
 // Blacklist matching list intended to be used by all contexts.
-const blacklist: MatchingList = blacklistedMessageIds.map((messageId) => ({
-  messageId,
-}));
+const blacklist: MatchingList = [
+  {
+    // Eco, who's sending a lot of messages not intended to be processed by the relayer.
+    // A temporary measure to prevent some wasted effort on our relayer.
+    senderAddress: '0xd890d66a0e2530335D10b3dEb5C8Ec8eA1DaB954',
+  },
+  ...blacklistedMessageIds.map((messageId) => ({
+    messageId,
+  })),
+];
 
 const hyperlane: RootAgentConfig = {
   ...contextBase,


### PR DESCRIPTION
### Description

- To prevent our relayers from wasting their time
- Context https://hyperlaneworkspace.slack.com/archives/C08GHFABJQ6/p1741864497342839

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
