### PR TITLE
fix: Make scraper to start on dedicated node

### DIFF
--- a/rust/main/helm/hyperlane-agent/templates/scraper-statefulset.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/scraper-statefulset.yaml
@@ -71,8 +71,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        - key: "dedicated"
+          operator: "Equal"
+          value: "scraper"
+          effect: "NoSchedule"
 {{- end }}


### PR DESCRIPTION
### Description

Make scraper to start on dedicated node. It helps to avoid timeouts on Eclipse RPC with archival node of Luganodes

### Related issues

- Fixes https://github.com/hyperlane-xyz/issues/issues/1431

### Backward compatibility

Yes

### Testing

In testnet context
