### PR TITLE
fix: Use withWarpRouteId for deploy-warp-monitor

### DIFF
--- a/typescript/infra/scripts/warp-routes/deploy-warp-monitor.ts
+++ b/typescript/infra/scripts/warp-routes/deploy-warp-monitor.ts
@@ -18,7 +18,7 @@ import {
   getAgentConfig,
   getArgs,
   getWarpRouteIdsInteractive,
-  withKnownWarpRouteId,
+  withWarpRouteId,
 } from '../agent-utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
 
@@ -42,8 +42,7 @@ async function validateRegistryCommit(commit: string) {
 
 async function main() {
   configureRootLogger(LogFormat.Pretty, LogLevel.Info);
-  const { environment, warpRouteId } = await withKnownWarpRouteId(getArgs())
-    .argv;
+  const { environment, warpRouteId } = await withWarpRouteId(getArgs()).argv;
   const envConfig = getEnvironmentConfig(environment);
   const multiProtocolProvider = await envConfig.getMultiProtocolProvider();
 

--- a/typescript/infra/scripts/warp-routes/monitor/monitor-warp-route-balances.ts
+++ b/typescript/infra/scripts/warp-routes/monitor/monitor-warp-route-balances.ts
@@ -33,7 +33,7 @@ import { startMetricsServer } from '../../../src/utils/metrics.js';
 import {
   getArgs,
   getWarpRouteIdInteractive,
-  withKnownWarpRouteId,
+  withWarpRouteId,
 } from '../../agent-utils.js';
 import { getEnvironmentConfig } from '../../core-utils.js';
 
@@ -57,7 +57,7 @@ async function main() {
     checkFrequency,
     environment,
     warpRouteId: warpRouteIdArg,
-  } = await withKnownWarpRouteId(getArgs())
+  } = await withWarpRouteId(getArgs())
     .describe('checkFrequency', 'frequency to check balances in ms')
     .demandOption('checkFrequency')
     .alias('v', 'checkFrequency') // v as in Greek letter nu

--- a/typescript/infra/src/warp/helm.ts
+++ b/typescript/infra/src/warp/helm.ts
@@ -73,7 +73,7 @@ export class WarpRouteMonitorHelmManager extends HelmManager {
     return {
       image: {
         repository: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-        tag: '1c4185a-20250312-165755',
+        tag: '89b6227-20250313-153031',
       },
       warpRouteId: this.warpRouteId,
       fullnameOverride: this.helmReleaseName,


### PR DESCRIPTION
### Description
This PR updates deploy-warp-monitor to use withWarpRouteId, which does not require a warpId in warpRouteIds enum

### Backward compatibility
Yes

### Testing
Manual
