### PR TITLE
Adding custom service account name to validator and relayer statefulset

### DIFF
--- a/rust/main/helm/hyperlane-agent/templates/relayer-statefulset.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/relayer-statefulset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.hyperlane.relayer.enabled }}
-apiVersion: apps/v1
+BapiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "agent-common.fullname" . }}-relayer
@@ -86,6 +86,9 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hyperlane.relayer.attachServiceAccount }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}
   volumeClaimTemplates:
   - metadata:

--- a/rust/main/helm/hyperlane-agent/templates/validator-statefulset.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/validator-statefulset.yaml
@@ -97,6 +97,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.hyperlane.validator.attachServiceAccount }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: state

--- a/rust/main/helm/hyperlane-agent/values.yaml
+++ b/rust/main/helm/hyperlane-agent/values.yaml
@@ -82,6 +82,7 @@ hyperlane:
       prometheus.io/port: '9090'
       prometheus.io/scrape: 'true'
     podLabels: {}
+    attachServiceAccount: false
     storage:
       size: 10Gi
       snapshot:
@@ -105,6 +106,7 @@ hyperlane:
       prometheus.io/port: '9090'
       prometheus.io/scrape: 'true'
     podLabels: {}
+    attachServiceAccount: false
     storage:
       size: 10Gi
       snapshot:


### PR DESCRIPTION
### Description

<!--
This is to attach a custom service account name to the validator and relayor statefulset
-->

### Drive-by changes

<!--
We need to add service accounts to attach AWS IAM roles to use in AWS EKS for access permissions to S3
-->
### Testing

<!--
No testing
-->
