### PR TITLE
docs(changeset): Added minimal support for Starknet networks (for registry build)

### DIFF
--- a/.changeset/sour-mirrors-chew.md
+++ b/.changeset/sour-mirrors-chew.md
@@ -1,0 +1,9 @@
+---
+'@hyperlane-xyz/cli': major
+'@hyperlane-xyz/helloworld': major
+'@hyperlane-xyz/sdk': major
+'@hyperlane-xyz/utils': major
+'@hyperlane-xyz/widgets': major
+---
+
+Added minimal support for Starknet networks (for successful registry build)

--- a/.changeset/sour-mirrors-chew.md
+++ b/.changeset/sour-mirrors-chew.md
@@ -1,6 +1,4 @@
 ---
-'@hyperlane-xyz/cli': major
-'@hyperlane-xyz/helloworld': major
 '@hyperlane-xyz/sdk': major
 '@hyperlane-xyz/utils': major
 '@hyperlane-xyz/widgets': major


### PR DESCRIPTION
…cessful registry build)

### Description

Changeset for https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5650

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
