### PR TITLE
chore: Update tag to reflect changes to deploy-warp-monitor

### DIFF
--- a/typescript/infra/src/warp/helm.ts
+++ b/typescript/infra/src/warp/helm.ts
@@ -73,7 +73,7 @@ export class WarpRouteMonitorHelmManager extends HelmManager {
     return {
       image: {
         repository: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-        tag: 'ceac574-20250312-143219',
+        tag: 'a09f20a-20250313-154105',
       },
       warpRouteId: this.warpRouteId,
       fullnameOverride: this.helmReleaseName,

--- a/typescript/infra/src/warp/helm.ts
+++ b/typescript/infra/src/warp/helm.ts
@@ -73,7 +73,7 @@ export class WarpRouteMonitorHelmManager extends HelmManager {
     return {
       image: {
         repository: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-        tag: 'a09f20a-20250313-154105',
+        tag: '4df3739-20250317-173420',
       },
       warpRouteId: this.warpRouteId,
       fullnameOverride: this.helmReleaseName,


### PR DESCRIPTION
### Description
This updates the image tag to reflect updates to deploy-warp-monitor in this [PR](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5666)

### Backward compatibility
Yes - because the update just removes the requirement that warpId is part of the warpRouteIds set

### Testing
Manual - Tested through redeploying gps monitor
