### PR TITLE
fix: constrain max mint limit for super XERC20 (#5492)

### DIFF
--- a/.changeset/bright-cars-wait.md
+++ b/.changeset/bright-cars-wait.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Update XERC20 collateral warp route adapter for Super XERC20 variant.

--- a/typescript/sdk/src/consts/testChains.ts
+++ b/typescript/sdk/src/consts/testChains.ts
@@ -74,6 +74,30 @@ export const test4: ChainMetadata = {
   name: 'test4',
 };
 
+export const testXERC20: ChainMetadata = {
+  ...test1,
+  chainId: 9913374,
+  domainId: 9913374,
+  displayName: 'Test XERC20',
+  name: 'testxerc20',
+};
+
+export const testVSXERC20: ChainMetadata = {
+  ...test1,
+  chainId: 9913375,
+  domainId: 9913375,
+  displayName: 'Test VSXERC20',
+  name: 'testvsxerc20',
+};
+
+export const testXERC20Lockbox: ChainMetadata = {
+  ...test1,
+  chainId: 9913376,
+  domainId: 9913376,
+  displayName: 'Test XERC20Lockbox',
+  name: 'testxerc20lockbox',
+};
+
 export const testChainMetadata: ChainMap<ChainMetadata> = {
   test1,
   test2,
@@ -123,6 +147,9 @@ export const multiProtocolTestChainMetadata: ChainMap<ChainMetadata> = {
   ...testChainMetadata,
   testcosmos: testCosmosChain,
   testsealevel: testSealevelChain,
+  testxerc20: testXERC20,
+  testvsxerc20: testVSXERC20,
+  testxerc20lockbox: testXERC20Lockbox,
 };
 
 export const multiProtocolTestChains: Array<ChainName> = Object.keys(

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -206,10 +206,9 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
   }
 
   async fetchXERC20Config(
-    type: TokenType.XERC20 | TokenType.XERC20Lockbox,
     xERC20Address: Address,
     warpRouteAddress: Address,
-  ): Promise<XERC20TokenMetadata | {}> {
+  ): Promise<XERC20TokenMetadata> {
     // fetch the limits if possible
     const rateLimitsABI = [
       'function rateLimitPerSecond(address) external view returns (uint128)',
@@ -290,11 +289,7 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
         await this.fetchERC20Metadata(token);
 
       if (type === TokenType.XERC20 || type === TokenType.XERC20Lockbox) {
-        xERC20Metadata = await this.fetchXERC20Config(
-          type,
-          token,
-          warpRouteAddress,
-        );
+        xERC20Metadata = await this.fetchXERC20Config(token, warpRouteAddress);
       }
 
       return {

--- a/typescript/sdk/src/token/Token.test.ts
+++ b/typescript/sdk/src/token/Token.test.ts
@@ -107,6 +107,22 @@ const STANDARD_TO_TOKEN: Record<TokenStandard, TokenArgs | null> = {
     symbol: 'USDC',
     name: 'USDC',
   },
+  [TokenStandard.EvmHypVSXERC20]: {
+    chainName: TestChainName.test2,
+    standard: TokenStandard.EvmHypVSXERC20,
+    addressOrDenom: '0x8358D8291e3bEDb04804975eEa0fe9fe0fAfB147',
+    decimals: 6,
+    symbol: 'USDC',
+    name: 'USDC',
+  },
+  [TokenStandard.EvmHypVSXERC20Lockbox]: {
+    chainName: TestChainName.test2,
+    standard: TokenStandard.EvmHypVSXERC20Lockbox,
+    addressOrDenom: '0x8358D8291e3bEDb04804975eEa0fe9fe0fAfB147',
+    decimals: 6,
+    symbol: 'USDC',
+    name: 'USDC',
+  },
 
   // Sealevel
   [TokenStandard.SealevelSpl]: {

--- a/typescript/sdk/src/token/Token.ts
+++ b/typescript/sdk/src/token/Token.ts
@@ -214,11 +214,17 @@ export class Token implements IToken {
       return new EvmHypSyntheticAdapter(chainName, multiProvider, {
         token: addressOrDenom,
       });
-    } else if (standard === TokenStandard.EvmHypXERC20) {
+    } else if (
+      standard === TokenStandard.EvmHypXERC20 ||
+      standard === TokenStandard.EvmHypVSXERC20
+    ) {
       return new EvmHypXERC20Adapter(chainName, multiProvider, {
         token: addressOrDenom,
       });
-    } else if (standard === TokenStandard.EvmHypXERC20Lockbox) {
+    } else if (
+      standard === TokenStandard.EvmHypXERC20Lockbox ||
+      standard === TokenStandard.EvmHypVSXERC20Lockbox
+    ) {
       return new EvmHypXERC20LockboxAdapter(chainName, multiProvider, {
         token: addressOrDenom,
       });

--- a/typescript/sdk/src/token/TokenStandard.ts
+++ b/typescript/sdk/src/token/TokenStandard.ts
@@ -21,6 +21,8 @@ export enum TokenStandard {
   EvmHypSyntheticRebase = 'EvmHypSyntheticRebase',
   EvmHypXERC20 = 'EvmHypXERC20',
   EvmHypXERC20Lockbox = 'EvmHypXERC20Lockbox',
+  EvmHypVSXERC20 = 'EvmHypVSXERC20',
+  EvmHypVSXERC20Lockbox = 'EvmHypVSXERC20Lockbox',
 
   // Sealevel (Solana)
   SealevelSpl = 'SealevelSpl',
@@ -65,6 +67,8 @@ export const TOKEN_STANDARD_TO_PROTOCOL: Record<TokenStandard, ProtocolType> = {
   EvmHypSyntheticRebase: ProtocolType.Ethereum,
   EvmHypXERC20: ProtocolType.Ethereum,
   EvmHypXERC20Lockbox: ProtocolType.Ethereum,
+  EvmHypVSXERC20: ProtocolType.Ethereum,
+  EvmHypVSXERC20Lockbox: ProtocolType.Ethereum,
 
   // Sealevel (Solana)
   SealevelSpl: ProtocolType.Sealevel,
@@ -116,14 +120,23 @@ export const TOKEN_COLLATERALIZED_STANDARDS = [
   TokenStandard.SealevelHypNative,
   TokenStandard.CwHypCollateral,
   TokenStandard.CwHypNative,
+  TokenStandard.EvmHypXERC20Lockbox,
+  TokenStandard.EvmHypVSXERC20Lockbox,
 ];
 
 export const XERC20_STANDARDS = [
   TokenStandard.EvmHypXERC20,
   TokenStandard.EvmHypXERC20Lockbox,
+  TokenStandard.EvmHypVSXERC20,
+  TokenStandard.EvmHypVSXERC20Lockbox,
 ];
 
-export const MINT_LIMITED_STANDARDS = [...XERC20_STANDARDS];
+export const MINT_LIMITED_STANDARDS = [
+  TokenStandard.EvmHypXERC20,
+  TokenStandard.EvmHypXERC20Lockbox,
+  TokenStandard.EvmHypVSXERC20,
+  TokenStandard.EvmHypVSXERC20Lockbox,
+];
 
 export const TOKEN_HYP_STANDARDS = [
   TokenStandard.EvmHypNative,
@@ -135,6 +148,8 @@ export const TOKEN_HYP_STANDARDS = [
   TokenStandard.EvmHypSyntheticRebase,
   TokenStandard.EvmHypXERC20,
   TokenStandard.EvmHypXERC20Lockbox,
+  TokenStandard.EvmHypVSXERC20,
+  TokenStandard.EvmHypVSXERC20Lockbox,
   TokenStandard.SealevelHypNative,
   TokenStandard.SealevelHypCollateral,
   TokenStandard.SealevelHypSynthetic,

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -8,6 +8,9 @@ import {
   test2,
   testCosmosChain,
   testSealevelChain,
+  testVSXERC20,
+  testXERC20,
+  testXERC20Lockbox,
 } from '../consts/testChains.js';
 import { MultiProtocolProvider } from '../providers/MultiProtocolProvider.js';
 import { ProviderType } from '../providers/ProviderType.js';
@@ -22,8 +25,10 @@ import { WarpTxCategory } from './types.js';
 const MOCK_LOCAL_QUOTE = { gasUnits: 2_000n, gasPrice: 100, fee: 200_000n };
 const MOCK_INTERCHAIN_QUOTE = { amount: 20_000n };
 const TRANSFER_AMOUNT = BigInt('1000000000000000000'); // 1 units @ 18 decimals
+const MEDIUM_TRANSFER_AMOUNT = BigInt('15000000000000000000'); // 15 units @ 18 deicmals
 const BIG_TRANSFER_AMOUNT = BigInt('100000000000000000000'); // 100 units @ 18 decimals
 const MOCK_BALANCE = BigInt('10000000000000000000'); // 10 units @ 18 decimals
+const MEDIUM_MOCK_BALANCE = BigInt('50000000000000000000'); // 50 units at @ 18 decimals
 const MOCK_ADDRESS = '0x0000000000000000000000000000000000000001';
 
 describe('WarpCore', () => {
@@ -31,6 +36,9 @@ describe('WarpCore', () => {
   let warpCore: WarpCore;
   let evmHypNative: Token;
   let evmHypSynthetic: Token;
+  let evmHypXERC20: Token;
+  let evmHypVSXERC20: Token;
+  let evmHypXERC20Lockbox: Token;
   let sealevelHypSynthetic: Token;
   let cwHypCollateral: Token;
   let cw20: Token;
@@ -57,6 +65,9 @@ describe('WarpCore', () => {
     [
       evmHypNative,
       evmHypSynthetic,
+      evmHypXERC20,
+      evmHypVSXERC20,
+      evmHypXERC20Lockbox,
       sealevelHypSynthetic,
       cwHypCollateral,
       cw20,
@@ -180,6 +191,10 @@ describe('WarpCore', () => {
     await testCollateral(evmHypNative, testCosmosChain.name, false);
     await testCollateral(evmHypNative, testSealevelChain.name, true);
     await testCollateral(cwHypCollateral, test1.name, false);
+    await testCollateral(evmHypXERC20, testVSXERC20.name, true);
+    await testCollateral(evmHypVSXERC20, testXERC20.name, true);
+    await testCollateral(evmHypXERC20Lockbox, testXERC20.name, true);
+    await testCollateral(evmHypNative, testXERC20Lockbox.name, false);
 
     stubs.forEach((s) => s.restore());
   });
@@ -195,6 +210,9 @@ describe('WarpCore', () => {
         isApproveRequired: () => Promise.resolve(false),
         populateTransferRemoteTx: () => Promise.resolve({}),
         getMinimumTransferAmount: () => Promise.resolve(minimumTransferAmount),
+        getBalance: () => Promise.resolve(MOCK_BALANCE),
+        getMintLimit: () => Promise.resolve(MEDIUM_MOCK_BALANCE),
+        getMintMaxLimit: () => Promise.resolve(MEDIUM_MOCK_BALANCE),
       } as any),
     );
 
@@ -245,6 +263,46 @@ describe('WarpCore', () => {
       sender: MOCK_ADDRESS,
     });
     expect(Object.keys(insufficientBalance || {})[0]).to.equal('amount');
+
+    const validXERC20TokenResult = await warpCore.validateTransfer({
+      originTokenAmount: evmHypNative.amount(TRANSFER_AMOUNT),
+      destination: testXERC20.name,
+      recipient: MOCK_ADDRESS,
+      sender: MOCK_ADDRESS,
+    });
+    expect(validXERC20TokenResult).to.be.null;
+
+    const invalidRateLimit = await warpCore.validateTransfer({
+      originTokenAmount: evmHypNative.amount(BIG_TRANSFER_AMOUNT),
+      destination: testXERC20.name,
+      recipient: MOCK_ADDRESS,
+      sender: MOCK_ADDRESS,
+    });
+    expect(Object.values(invalidRateLimit || {})[0]).to.equal(
+      'Rate limit exceeded on destination',
+    );
+
+    const invalidXERC20LockboxTokenRateLimit = await warpCore.validateTransfer({
+      originTokenAmount: evmHypXERC20.amount(BIG_TRANSFER_AMOUNT),
+      destination: testXERC20Lockbox.name,
+      recipient: MOCK_ADDRESS,
+      sender: MOCK_ADDRESS,
+    });
+    expect(Object.values(invalidXERC20LockboxTokenRateLimit || {})[0]).to.equal(
+      'Rate limit exceeded on destination',
+    );
+
+    const invalidCollateralXERC20LockboxToken = await warpCore.validateTransfer(
+      {
+        originTokenAmount: evmHypXERC20.amount(MEDIUM_TRANSFER_AMOUNT),
+        destination: testXERC20Lockbox.name,
+        recipient: MOCK_ADDRESS,
+        sender: MOCK_ADDRESS,
+      },
+    );
+    expect(
+      Object.values(invalidCollateralXERC20LockboxToken || {})[0],
+    ).to.equal('Insufficient collateral on destination');
 
     balanceStubs.forEach((s) => s.restore());
     quoteStubs.forEach((s) => s.restore());

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -476,31 +476,17 @@ export class WarpCore {
       originToken.getConnectionForChain(destinationName)?.token;
     assert(destinationToken, `No connection found for ${destinationName}`);
 
-    if (
-      !TOKEN_COLLATERALIZED_STANDARDS.includes(destinationToken.standard) &&
-      !MINT_LIMITED_STANDARDS.includes(destinationToken.standard)
-    ) {
+    if (!TOKEN_COLLATERALIZED_STANDARDS.includes(destinationToken.standard)) {
       this.logger.debug(
         `${destinationToken.symbol} is not collateralized, skipping`,
       );
       return true;
     }
 
-    let destinationBalance: bigint;
-
     const adapter = destinationToken.getAdapter(this.multiProvider);
-    if (
-      destinationToken.standard === TokenStandard.EvmHypXERC20 ||
-      destinationToken.standard === TokenStandard.EvmHypXERC20Lockbox
-    ) {
-      destinationBalance = await (
-        adapter as IHypXERC20Adapter<unknown>
-      ).getMintLimit();
-    } else {
-      destinationBalance = await adapter.getBalance(
-        destinationToken.addressOrDenom,
-      );
-    }
+    const destinationBalance: bigint = await adapter.getBalance(
+      destinationToken.addressOrDenom,
+    );
 
     const destinationBalanceInOriginDecimals = convertDecimalsToIntegerString(
       destinationToken.decimals,
@@ -573,6 +559,12 @@ export class WarpCore {
       recipient,
     );
     if (amountError) return amountError;
+
+    const destinationRateLimitError = await this.validateDestinationRateLimit(
+      originTokenAmount,
+      destination,
+    );
+    if (destinationRateLimitError) return destinationRateLimitError;
 
     const destinationCollateralError = await this.validateDestinationCollateral(
       originTokenAmount,
@@ -773,8 +765,73 @@ export class WarpCore {
       originTokenAmount,
       destination,
     });
-    if (!valid) return { amount: 'Insufficient collateral on destination' };
 
+    if (!valid) {
+      return { amount: 'Insufficient collateral on destination' };
+    }
+    return null;
+  }
+
+  /**
+   * Ensure the sender has sufficient balances for minting
+   */
+  protected async validateDestinationRateLimit(
+    originTokenAmount: TokenAmount,
+    destination: ChainNameOrId,
+  ): Promise<Record<string, string> | null> {
+    const { token: originToken, amount } = originTokenAmount;
+    const destinationName = this.multiProvider.getChainName(destination);
+    const destinationToken =
+      originToken.getConnectionForChain(destinationName)?.token;
+    assert(destinationToken, `No connection found for ${destinationName}`);
+
+    if (!MINT_LIMITED_STANDARDS.includes(destinationToken.standard)) {
+      this.logger.debug(
+        `${destinationToken.symbol} does not have rate limit constraint, skipping`,
+      );
+      return null;
+    }
+
+    let destinationMintLimit: bigint = 0n;
+    if (
+      destinationToken.standard === TokenStandard.EvmHypVSXERC20 ||
+      destinationToken.standard === TokenStandard.EvmHypVSXERC20Lockbox ||
+      destinationToken.standard === TokenStandard.EvmHypXERC20 ||
+      destinationToken.standard === TokenStandard.EvmHypXERC20Lockbox
+    ) {
+      const adapter = destinationToken.getAdapter(
+        this.multiProvider,
+      ) as IHypXERC20Adapter<unknown>;
+      destinationMintLimit = await adapter.getMintLimit();
+
+      if (
+        destinationToken.standard === TokenStandard.EvmHypVSXERC20 ||
+        destinationToken.standard === TokenStandard.EvmHypVSXERC20Lockbox
+      ) {
+        const bufferCap = await adapter.getMintMaxLimit();
+        const max = bufferCap / 2n;
+        if (destinationMintLimit > max) {
+          this.logger.debug(
+            `Mint limit ${destinationMintLimit} exceeds max ${max}, using max`,
+          );
+          destinationMintLimit = max;
+        }
+      }
+    }
+
+    const destinationMintLimitInOriginDecimals = convertDecimalsToIntegerString(
+      destinationToken.decimals,
+      originToken.decimals,
+      destinationMintLimit.toString(),
+    );
+
+    const isSufficient = BigInt(destinationMintLimitInOriginDecimals) >= amount;
+    this.logger.debug(
+      `${originTokenAmount.token.symbol} to ${destination} has ${
+        isSufficient ? 'sufficient' : 'INSUFFICIENT'
+      } rate limits`,
+    );
+    if (!isSufficient) return { amount: 'Rate limit exceeded on destination' };
     return null;
   }
 

--- a/typescript/sdk/src/warp/test-warp-core-config.yaml
+++ b/typescript/sdk/src/warp/test-warp-core-config.yaml
@@ -17,6 +17,15 @@ tokens:
       - {
           token: sealevel|testsealevel|s0LaBcEeFgHiJkLmNoPqRsTuVwXyZ456789012345678,
         }
+      - {
+          token: ethereum|testxerc20|0x9876543210987654321098765432109876543211,
+        }
+      - {
+          token: ethereum|testvsxerc20|0x9876543210987654321098765432109876543212,
+        }
+      - {
+          token: ethereum|testxerc20lockbox|0x9876543210987654321098765432109876543218,
+        }
   # test2 HypSynthetic token
   - chainName: test2
     standard: EvmHypSynthetic
@@ -29,6 +38,44 @@ tokens:
       - {
           token: cosmos|testcosmos|testcosmos1abcdefghijklmnopqrstuvwxyz1234567890ab,
         }
+  # testxerc20 EvmHypXERC20 token
+  - chainName: testxerc20
+    standard: EvmHypXERC20
+    decimals: 18
+    symbol: ETH
+    name: Ether
+    addressOrDenom: '0x9876543210987654321098765432109876543211'
+    connections:
+      - {
+          token: ethereum|testvsxerc20|0x9876543210987654321098765432109876543212,
+        }
+      - { token: ethereum|test1|0x1234567890123456789012345678901234567890 }
+      - {
+          token: ethereum|testxerc20lockbox|0x9876543210987654321098765432109876543218,
+        }
+  # testvsxerc20 EvmHypVSXERC20
+  - chainName: testvsxerc20
+    standard: EvmHypVSXERC20
+    decimals: 18
+    symbol: ETH
+    name: Ether
+    addressOrDenom: '0x9876543210987654321098765432109876543212'
+    connections:
+      - {
+          token: ethereum|testxerc20|0x9876543210987654321098765432109876543211,
+        }
+      - { token: ethereum|test1|0x1234567890123456789012345678901234567890 }
+  - chainName: testxerc20lockbox
+    standard: EvmHypXERC20Lockbox
+    decimals: 18
+    symbol: ETH
+    name: Ether
+    addressOrDenom: '0x9876543210987654321098765432109876543218'
+    connections:
+      - {
+          token: ethereum|testxerc20|0x9876543210987654321098765432109876543211,
+        }
+      - { token: ethereum|test1|0x1234567890123456789012345678901234567890 }
   # testsealevel HypSynthetic
   - chainName: testsealevel
     standard: SealevelHypSynthetic


### PR DESCRIPTION
### Description

Copying https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5492 to merge into `main`.

- Updates XERC20 collateral warp route adapter for [Super XERC20
variant](https://github.com/hyperlane-xyz/superchain-xerc20).
- Introduces a new token standard to represent this. 
- Adds logic for comparing to buffer cap limits. If the mint limit is
decreasing, latency of message delivery can cause the transfer to appear
mintable at dispatch time but not at process time. Thus we cap the mint
limit at the buffer midpoint (where it will stop decreasing).

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

Yes

### Testing

TODO

---------

Co-authored-by: Xaroz <jasonguo2013jg@gmail.com>
Co-authored-by: Jason Guo <33064781+Xaroz@users.noreply.github.com>### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
