### PR TITLE
chore: remove total supply from token metadata

### DIFF
--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@aws-sdk/client-kms": "^3.577.0",
     "@aws-sdk/client-s3": "^3.577.0",
-    "@hyperlane-xyz/registry": "10.1.0",
+    "@hyperlane-xyz/registry": "11.1.0",
     "@hyperlane-xyz/sdk": "9.1.0",
     "@hyperlane-xyz/utils": "9.1.0",
     "@inquirer/core": "9.0.10",

--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@aws-sdk/client-kms": "^3.577.0",
     "@aws-sdk/client-s3": "^3.577.0",
-    "@hyperlane-xyz/registry": "10.12.0",
+    "@hyperlane-xyz/registry": "11.1.0",
     "@hyperlane-xyz/sdk": "9.0.0",
     "@hyperlane-xyz/utils": "9.0.0",
     "@inquirer/core": "9.0.10",

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -273,7 +273,6 @@ export async function setupIncompleteWarpRouteExtension(
     name: 'Ether',
     owner: new Wallet(ANVIL_KEY).address,
     symbol: 'ETH',
-    totalSupply: 0,
     type: TokenType.native,
   };
 

--- a/typescript/cli/src/tests/warp/warp-apply-extend.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-apply-extend.e2e-test.ts
@@ -69,7 +69,6 @@ describe('hyperlane warp apply warp route extension tests', async function () {
       name: 'Ether',
       owner: new Wallet(ANVIL_KEY).address,
       symbol: 'ETH',
-      totalSupply: 0,
       type: TokenType.native,
     };
 
@@ -125,7 +124,6 @@ describe('hyperlane warp apply warp route extension tests', async function () {
       name: 'Ether',
       owner: new Wallet(ANVIL_KEY).address,
       symbol: 'ETH',
-      totalSupply: 0,
       type: TokenType.native,
     };
 
@@ -188,7 +186,6 @@ describe('hyperlane warp apply warp route extension tests', async function () {
       name: 'Ether',
       owner: randomOwner,
       symbol: 'ETH',
-      totalSupply: 0,
       type: TokenType.native,
     };
 
@@ -251,7 +248,6 @@ describe('hyperlane warp apply warp route extension tests', async function () {
       name: 'Ether',
       owner: new Wallet(ANVIL_KEY).address,
       symbol: 'ETH',
-      totalSupply: 0,
       type: TokenType.native,
       gas: GAS,
     };

--- a/typescript/cli/src/tests/warp/warp-apply-extend.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-apply-extend.e2e-test.ts
@@ -321,7 +321,6 @@ describe('hyperlane warp apply warp route extension tests', async function () {
         name: 'Ether',
         owner: new Wallet(ANVIL_KEY).address,
         symbol: 'ETH',
-        totalSupply: 0,
         type: TokenType.native,
       },
       warpCorePath: WARP_CORE_CONFIG_PATH_2,
@@ -372,7 +371,6 @@ describe('hyperlane warp apply warp route extension tests', async function () {
         name: 'Ether',
         owner: new Wallet(ANVIL_KEY).address,
         symbol: 'ETH',
-        totalSupply: 0,
         type: TokenType.native,
       },
       warpCorePath: WARP_CORE_CONFIG_PATH_2,
@@ -614,7 +612,6 @@ describe('hyperlane warp apply warp route extension tests', async function () {
       name: 'Ether',
       owner: new Wallet(ANVIL_KEY).address,
       symbol: 'ETH',
-      totalSupply: 0,
       type: TokenType.native,
     };
 
@@ -670,7 +667,6 @@ describe('hyperlane warp apply warp route extension tests', async function () {
       name: 'Ether',
       owner: new Wallet(ANVIL_KEY).address,
       symbol: 'ETH',
-      totalSupply: 0,
       type: TokenType.native,
     };
 
@@ -737,7 +733,6 @@ describe('hyperlane warp apply warp route extension tests', async function () {
       name: 'Ether',
       owner: new Wallet(ANVIL_KEY).address,
       symbol: 'ETH',
-      totalSupply: 0,
       type: TokenType.native,
     };
 

--- a/typescript/cli/src/tests/warp/warp-apply.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-apply.e2e-test.ts
@@ -148,7 +148,6 @@ describe('hyperlane warp apply owner update tests', async function () {
       name: 'Ether',
       owner: new Wallet(ANVIL_KEY).address,
       symbol: 'ETH',
-      totalSupply: 0,
       type: TokenType.native,
     };
 

--- a/typescript/helloworld/package.json
+++ b/typescript/helloworld/package.json
@@ -4,7 +4,7 @@
   "version": "9.0.0",
   "dependencies": {
     "@hyperlane-xyz/core": "6.0.0",
-    "@hyperlane-xyz/registry": "10.12.0",
+    "@hyperlane-xyz/registry": "11.1.0",
     "@hyperlane-xyz/sdk": "9.0.0",
     "@openzeppelin/contracts-upgradeable": "^4.9.3",
     "ethers": "^5.7.2"

--- a/typescript/helloworld/package.json
+++ b/typescript/helloworld/package.json
@@ -4,7 +4,7 @@
   "version": "9.1.0",
   "dependencies": {
     "@hyperlane-xyz/core": "6.0.1",
-    "@hyperlane-xyz/registry": "10.1.0",
+    "@hyperlane-xyz/registry": "11.1.0",
     "@hyperlane-xyz/sdk": "9.1.0",
     "@openzeppelin/contracts-upgradeable": "^4.9.3",
     "ethers": "^5.7.2"

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumNeutronTiaWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumNeutronTiaWarpConfig.ts
@@ -30,7 +30,6 @@ export const getArbitrumNeutronTiaWarpConfig = async (
     name: 'TIA',
     symbol: 'TIA.n',
     decimals: 6,
-    totalSupply: 0,
     gas: 600_000,
   };
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseSolanaTRUMPWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseSolanaTRUMPWarpConfig.ts
@@ -15,14 +15,12 @@ export const getTrumpchainTRUMPWarpConfig = async (
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
   const name = 'OFFICIAL TRUMP';
   const symbol = 'TRUMP';
-  const totalSupply = 0;
   const tokenConfig: ChainMap<HypTokenRouterConfig> = {
     solanamainnet: {
       ...routerConfig.solanamainnet,
       type: TokenType.collateral,
       name,
       symbol,
-      totalSupply,
       token: '6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN',
       owner: DEPLOYER,
       gas: SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT,
@@ -34,7 +32,6 @@ export const getTrumpchainTRUMPWarpConfig = async (
       name,
       symbol,
       decimals: 18,
-      totalSupply,
       owner: DEPLOYER,
       proxyAdmin: {
         owner: DEPLOYER,
@@ -51,11 +48,9 @@ export const getTRUMPWarpConfig = async (
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
   const name = 'OFFICIAL TRUMP';
   const symbol = 'TRUMP';
-  const totalSupply = 0;
   const syntheticToken = {
     name,
     symbol,
-    totalSupply,
     decimals: 18,
   };
   const tokenConfig: ChainMap<HypTokenRouterConfig> = {
@@ -64,7 +59,6 @@ export const getTRUMPWarpConfig = async (
       type: TokenType.collateral,
       name,
       symbol,
-      totalSupply,
       token: '6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN',
       owner: DEPLOYER,
       gas: SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionETHWarpConfig.ts
@@ -20,7 +20,6 @@ export const getEthereumVictionETHWarpConfig = async (
     name: 'ETH',
     symbol: 'ETH',
     decimals: 18,
-    totalSupply: 0,
     gas: 50_000,
     interchainSecurityModule: ethers.constants.AddressZero,
   };

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDCWarpConfig.ts
@@ -23,7 +23,6 @@ export const getEthereumVictionUSDCWarpConfig = async (
     name: 'USDC',
     symbol: 'USDC',
     decimals: 6,
-    totalSupply: 0,
     gas: 75_000,
     interchainSecurityModule: ethers.constants.AddressZero,
   };

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDTWarpConfig.ts
@@ -23,7 +23,6 @@ export const getEthereumVictionUSDTWarpConfig = async (
     name: 'USDT',
     symbol: 'USDT',
     decimals: 6,
-    totalSupply: 0,
     gas: 75_000,
     interchainSecurityModule: ethers.constants.AddressZero,
   };

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getMantapacificNeutronTiaWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getMantapacificNeutronTiaWarpConfig.ts
@@ -26,7 +26,6 @@ export const getMantapacificNeutronTiaWarpConfig = async (
     name: 'TIA',
     symbol: 'TIA',
     decimals: 6,
-    totalSupply: 0,
     gas: 600_000,
   };
 

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -14,7 +14,7 @@
     "@ethersproject/providers": "*",
     "@google-cloud/secret-manager": "^5.5.0",
     "@hyperlane-xyz/helloworld": "9.0.0",
-    "@hyperlane-xyz/registry": "10.12.0",
+    "@hyperlane-xyz/registry": "11.1.0",
     "@hyperlane-xyz/sdk": "9.0.0",
     "@hyperlane-xyz/utils": "9.0.0",
     "@inquirer/prompts": "3.3.2",

--- a/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
@@ -179,7 +179,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       name: TOKEN_NAME,
       symbol: TOKEN_NAME,
       decimals: TOKEN_DECIMALS,
-      totalSupply: TOKEN_SUPPLY,
+      initialSupply: TOKEN_SUPPLY,
     };
 
     // Deploy using WarpModule

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -110,7 +110,6 @@ describe('ERC20WarpRouterReader', async () => {
             name: TOKEN_NAME,
             symbol: TOKEN_NAME,
             decimals: TOKEN_DECIMALS,
-            totalSupply: TOKEN_SUPPLY,
             gas: GAS,
             ...baseConfig,
           },
@@ -311,7 +310,7 @@ describe('ERC20WarpRouterReader', async () => {
         name: TOKEN_NAME,
         symbol: TOKEN_NAME,
         decimals: TOKEN_DECIMALS,
-        totalSupply: TOKEN_SUPPLY,
+        initialSupply: TOKEN_SUPPLY,
         ...baseConfig,
       },
     };

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -285,8 +285,7 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
         token = await erc20.wrappedToken();
       }
 
-      const { name, symbol, decimals } =
-        await this.fetchERC20Metadata(token);
+      const { name, symbol, decimals } = await this.fetchERC20Metadata(token);
 
       if (type === TokenType.XERC20 || type === TokenType.XERC20Lockbox) {
         xERC20Metadata = await this.fetchXERC20Config(token, warpRouteAddress);

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -285,7 +285,7 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
         token = await erc20.wrappedToken();
       }
 
-      const { name, symbol, decimals, totalSupply } =
+      const { name, symbol, decimals } =
         await this.fetchERC20Metadata(token);
 
       if (type === TokenType.XERC20 || type === TokenType.XERC20Lockbox) {
@@ -298,7 +298,6 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
         name,
         symbol,
         decimals,
-        totalSupply,
         token: lockbox || token,
       };
     } else if (
@@ -328,7 +327,6 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
           name,
           symbol,
           decimals,
-          totalSupply: 0,
         };
       } else {
         throw new Error(
@@ -344,14 +342,13 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
 
   async fetchERC20Metadata(tokenAddress: Address): Promise<TokenMetadata> {
     const erc20 = HypERC20__factory.connect(tokenAddress, this.provider);
-    const [name, symbol, decimals, totalSupply] = await Promise.all([
+    const [name, symbol, decimals] = await Promise.all([
       erc20.name(),
       erc20.symbol(),
       erc20.decimals(),
-      erc20.totalSupply(),
     ]);
 
-    return { name, symbol, decimals, totalSupply: totalSupply.toString() };
+    return { name, symbol, decimals };
   }
 
   async fetchRemoteRouters(warpRouteAddress: Address): Promise<RemoteRouters> {

--- a/typescript/sdk/src/token/adapters/CosmWasmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/CosmWasmTokenAdapter.ts
@@ -141,13 +141,9 @@ export class CwTokenAdapter
   }
 
   async getMetadata(): Promise<CW20Metadata> {
-    const resp = await this.queryToken<TokenInfoResponse>({
+    return this.queryToken<TokenInfoResponse>({
       token_info: {},
     });
-    return {
-      ...resp,
-      totalSupply: resp.total_supply,
-    };
   }
 
   async getMinimumTransferAmount(_recipient: Address): Promise<bigint> {

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -120,13 +120,12 @@ export class EvmTokenAdapter<T extends ERC20 = ERC20>
   }
 
   override async getMetadata(isNft?: boolean): Promise<TokenMetadata> {
-    const [decimals, symbol, name, totalSupply] = await Promise.all([
+    const [decimals, symbol, name] = await Promise.all([
       isNft ? 0 : this.contract.decimals(),
       this.contract.symbol(),
       this.contract.name(),
-      this.getTotalSupply(),
     ]);
-    return { decimals, symbol, name, totalSupply: totalSupply.toString() };
+    return { decimals, symbol, name };
   }
 
   override async isApproveRequired(

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -177,7 +177,7 @@ export class SealevelTokenAdapter
 
   async getMetadata(_isNft?: boolean): Promise<TokenMetadata> {
     // TODO solana support
-    return { decimals: 9, symbol: 'SPL', name: 'SPL Token', totalSupply: '' };
+    return { decimals: 9, symbol: 'SPL', name: 'SPL Token' };
   }
 
   async getMinimumTransferAmount(_recipient: Address): Promise<bigint> {
@@ -280,7 +280,6 @@ export abstract class SealevelHypTokenAdapter
     // TODO full token metadata support
     return {
       decimals: tokenData.decimals,
-      totalSupply: '0',
       symbol: 'HYP',
       name: 'Unknown Hyp Token',
     };

--- a/typescript/sdk/src/token/configUtils.test.ts
+++ b/typescript/sdk/src/token/configUtils.test.ts
@@ -16,23 +16,8 @@ describe('configUtils', () => {
       input: any;
     }> = [
       {
-        msg: 'It should remove the totalSupply field from the config',
-        input: {
-          totalSupply: 1000,
-          hook: {
-            type: HookType.AMOUNT_ROUTING,
-          },
-        },
-        expected: {
-          hook: {
-            type: HookType.AMOUNT_ROUTING,
-          },
-        },
-      },
-      {
         msg: 'It should remove the address and ownerOverrides fields from the config',
         input: {
-          totalSupply: 1000,
           ownerOverrides: {
             owner: ADDRESS,
           },

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -125,9 +125,6 @@ const transformWarpDeployConfigToCheck: TransformObjectTransformer = (
   return obj;
 };
 
-type HypTokenRouterConfigKey = keyof HypTokenRouterConfig;
-const KEYS_TO_IGNORE: HypTokenRouterConfigKey[] = ['totalSupply'];
-
 /**
  * transforms the provided {@link HypTokenRouterConfig}, removing the address, totalSupply and ownerOverrides
  * field where they are not required for the config comparison
@@ -135,13 +132,7 @@ const KEYS_TO_IGNORE: HypTokenRouterConfigKey[] = ['totalSupply'];
 export function transformConfigToCheck(
   obj: HypTokenRouterConfig,
 ): HypTokenRouterConfig {
-  const filteredObj = Object.fromEntries(
-    Object.entries(obj).filter(
-      ([key]) => !KEYS_TO_IGNORE.includes(key as HypTokenRouterConfigKey),
-    ),
-  );
-
   return sortArraysInConfig(
-    transformObj(filteredObj, transformWarpDeployConfigToCheck),
+    transformObj(obj, transformWarpDeployConfigToCheck),
   );
 }

--- a/typescript/sdk/src/token/deploy.hardhat-test.ts
+++ b/typescript/sdk/src/token/deploy.hardhat-test.ts
@@ -44,6 +44,7 @@ describe('TokenDeployer', async () => {
   let xerc20: XERC20Test;
   let erc20: ERC20Test;
   let admin: ProxyAdmin;
+  const totalSupply = '100000';
 
   before(async () => {
     [signer] = await hre.ethers.getSigners();
@@ -62,14 +63,13 @@ describe('TokenDeployer', async () => {
         name: chain,
         symbol: `u${chain}`,
         decimals: 18,
-        totalSupply: '100000',
         ...c,
       }),
     );
   });
 
   beforeEach(async () => {
-    const { name, decimals, symbol, totalSupply } = config[chain];
+    const { name, decimals, symbol } = config[chain];
     const implementation = await new XERC20Test__factory(signer).deploy(
       name!,
       symbol!,

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -101,7 +101,12 @@ abstract class TokenDeployer<
     ) {
       return defaultArgs;
     } else if (isSyntheticTokenConfig(config)) {
-      return [config.initialSupply, config.name, config.symbol, ...defaultArgs];
+      return [
+        config.initialSupply ?? 0,
+        config.name,
+        config.symbol,
+        ...defaultArgs,
+      ];
     } else if (isSyntheticRebaseTokenConfig(config)) {
       return [0, config.name, config.symbol, ...defaultArgs];
     } else {

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -101,7 +101,7 @@ abstract class TokenDeployer<
     ) {
       return defaultArgs;
     } else if (isSyntheticTokenConfig(config)) {
-      return [config.totalSupply, config.name, config.symbol, ...defaultArgs];
+      return [config.initialSupply, config.name, config.symbol, ...defaultArgs];
     } else if (isSyntheticRebaseTokenConfig(config)) {
       return [0, config.name, config.symbol, ...defaultArgs];
     } else {
@@ -113,9 +113,6 @@ abstract class TokenDeployer<
     multiProvider: MultiProvider,
     configMap: WarpRouteDeployConfig,
   ): Promise<TokenMetadata | undefined> {
-    // this is used for synthetic token metadata and should always be 0
-    const DERIVED_TOKEN_SUPPLY = 0;
-
     for (const [chain, config] of Object.entries(configMap)) {
       if (isTokenMetadata(config)) {
         return TokenMetadataSchema.parse(config);
@@ -125,7 +122,6 @@ abstract class TokenDeployer<
         const nativeToken = multiProvider.getChainMetadata(chain).nativeToken;
         if (nativeToken) {
           return TokenMetadataSchema.parse({
-            totalSupply: DERIVED_TOKEN_SUPPLY,
             ...nativeToken,
           });
         }
@@ -146,7 +142,6 @@ abstract class TokenDeployer<
           return TokenMetadataSchema.parse({
             name,
             symbol,
-            totalSupply: DERIVED_TOKEN_SUPPLY,
           });
         }
 
@@ -180,7 +175,6 @@ abstract class TokenDeployer<
           name,
           symbol,
           decimals,
-          totalSupply: DERIVED_TOKEN_SUPPLY,
         });
       }
     }

--- a/typescript/sdk/src/token/types.test.ts
+++ b/typescript/sdk/src/token/types.test.ts
@@ -78,7 +78,6 @@ describe('WarpRouteDeployConfigSchema refine', () => {
   it('should succeed if non-collateral type, token is empty, metadata is defined', async () => {
     //@ts-ignore
     delete config.arbitrum.token;
-    config.arbitrum.totalSupply = '0';
     config.arbitrum.name = 'name';
 
     for (const type of NON_COLLATERAL_TYPES) {

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -84,9 +84,8 @@ export const XERC20TokenConfigSchema = CollateralTokenConfigSchema.merge(
 export type XERC20LimitsTokenConfig = z.infer<typeof XERC20TokenConfigSchema>;
 export const isXERC20TokenConfig = isCompliant(XERC20TokenConfigSchema);
 
-export const CollateralRebaseTokenConfigSchema = TokenMetadataSchema
-  .partial()
-  .extend({
+export const CollateralRebaseTokenConfigSchema =
+  TokenMetadataSchema.partial().extend({
     type: z.literal(TokenType.collateralVaultRebase),
   });
 export const isCollateralRebaseTokenConfig = isCompliant(

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -17,7 +17,6 @@ export const WarpRouteDeployConfigSchemaErrors = {
 export const TokenMetadataSchema = z.object({
   name: z.string(),
   symbol: z.string(),
-  totalSupply: z.string().or(z.number()),
   decimals: z.number().optional(),
   scale: z.number().optional(),
   isNft: z.boolean().optional(),
@@ -85,9 +84,7 @@ export const XERC20TokenConfigSchema = CollateralTokenConfigSchema.merge(
 export type XERC20LimitsTokenConfig = z.infer<typeof XERC20TokenConfigSchema>;
 export const isXERC20TokenConfig = isCompliant(XERC20TokenConfigSchema);
 
-export const CollateralRebaseTokenConfigSchema = TokenMetadataSchema.omit({
-  totalSupply: true,
-})
+export const CollateralRebaseTokenConfigSchema = TokenMetadataSchema
   .partial()
   .extend({
     type: z.literal(TokenType.collateralVaultRebase),
@@ -97,6 +94,7 @@ export const isCollateralRebaseTokenConfig = isCompliant(
 );
 
 export const SyntheticTokenConfigSchema = TokenMetadataSchema.partial().extend({
+  initialSupply: z.string().or(z.number()).optional(),
   type: z.enum([
     TokenType.synthetic,
     TokenType.syntheticUri,

--- a/typescript/sdk/src/types.ts
+++ b/typescript/sdk/src/types.ts
@@ -18,6 +18,7 @@ export const OwnableSchema = z.object({
   owner: ZHash,
   ownerOverrides: z.record(ZHash).optional(),
 });
+
 export type OwnableConfig = z.infer<typeof OwnableSchema>;
 
 export const DeployedOwnableSchema = OwnableSchema.extend({

--- a/typescript/widgets/package.json
+++ b/typescript/widgets/package.json
@@ -29,7 +29,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@eslint/js": "^9.15.0",
-    "@hyperlane-xyz/registry": "10.12.0",
+    "@hyperlane-xyz/registry": "11.1.0",
     "@storybook/addon-essentials": "^7.6.14",
     "@storybook/addon-interactions": "^7.6.14",
     "@storybook/addon-links": "^7.6.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7650,7 +7650,7 @@ __metadata:
     "@eslint/js": "npm:^9.15.0"
     "@ethersproject/abi": "npm:*"
     "@ethersproject/providers": "npm:*"
-    "@hyperlane-xyz/registry": "npm:10.1.0"
+    "@hyperlane-xyz/registry": "npm:11.1.0"
     "@hyperlane-xyz/sdk": "npm:9.1.0"
     "@hyperlane-xyz/utils": "npm:9.1.0"
     "@inquirer/core": "npm:9.0.10"
@@ -7756,7 +7756,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.15.0"
     "@hyperlane-xyz/core": "npm:6.0.1"
-    "@hyperlane-xyz/registry": "npm:10.1.0"
+    "@hyperlane-xyz/registry": "npm:11.1.0"
     "@hyperlane-xyz/sdk": "npm:9.1.0"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
     "@nomiclabs/hardhat-waffle": "npm:^2.0.6"
@@ -7869,16 +7869,6 @@ __metadata:
     tsx: "npm:^4.19.1"
   languageName: unknown
   linkType: soft
-
-"@hyperlane-xyz/registry@npm:10.1.0":
-  version: 10.1.0
-  resolution: "@hyperlane-xyz/registry@npm:10.1.0"
-  dependencies:
-    yaml: "npm:2.4.5"
-    zod: "npm:^3.21.2"
-  checksum: 10/2b7b3bcecc25f744a2ee7ee38899706441165092e39e174b83e1e73c4b7530f989da5d3215b0760408e0b990b8d0f1ecd205b06719243cb18f8dea64fb007b4a
-  languageName: node
-  linkType: hard
 
 "@hyperlane-xyz/registry@npm:11.1.0":
   version: 11.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -7650,7 +7650,7 @@ __metadata:
     "@eslint/js": "npm:^9.15.0"
     "@ethersproject/abi": "npm:*"
     "@ethersproject/providers": "npm:*"
-    "@hyperlane-xyz/registry": "npm:10.12.0"
+    "@hyperlane-xyz/registry": "npm:11.1.0"
     "@hyperlane-xyz/sdk": "npm:9.0.0"
     "@hyperlane-xyz/utils": "npm:9.0.0"
     "@inquirer/core": "npm:9.0.10"
@@ -7756,7 +7756,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.15.0"
     "@hyperlane-xyz/core": "npm:6.0.0"
-    "@hyperlane-xyz/registry": "npm:10.12.0"
+    "@hyperlane-xyz/registry": "npm:11.1.0"
     "@hyperlane-xyz/sdk": "npm:9.0.0"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
     "@nomiclabs/hardhat-waffle": "npm:^2.0.6"
@@ -7807,7 +7807,7 @@ __metadata:
     "@ethersproject/providers": "npm:*"
     "@google-cloud/secret-manager": "npm:^5.5.0"
     "@hyperlane-xyz/helloworld": "npm:9.0.0"
-    "@hyperlane-xyz/registry": "npm:10.12.0"
+    "@hyperlane-xyz/registry": "npm:11.1.0"
     "@hyperlane-xyz/sdk": "npm:9.0.0"
     "@hyperlane-xyz/utils": "npm:9.0.0"
     "@inquirer/prompts": "npm:3.3.2"
@@ -7870,13 +7870,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/registry@npm:10.12.0":
-  version: 10.12.0
-  resolution: "@hyperlane-xyz/registry@npm:10.12.0"
+"@hyperlane-xyz/registry@npm:11.1.0":
+  version: 11.1.0
+  resolution: "@hyperlane-xyz/registry@npm:11.1.0"
   dependencies:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/8d82aa7a5d7ddf858a5b1de12dcd1303c4f9867d472d014e6f7a50cbd769977d61a8477a5a2e305e5e25df05a9b5a21aecae4680209d7080a5f6616b2700de25
+  checksum: 10/4acb717a1f2d5b2c93237be6cd24406ae6f52eb86a4e5246eee919d5f95866ebdb7d4ce0fff2b193f6f4e29da2bcbe48e525ac958afaaa523e8260863069295d
   languageName: node
   linkType: hard
 
@@ -7976,7 +7976,7 @@ __metadata:
     "@emotion/styled": "npm:^11.13.0"
     "@eslint/js": "npm:^9.15.0"
     "@headlessui/react": "npm:^2.1.8"
-    "@hyperlane-xyz/registry": "npm:10.12.0"
+    "@hyperlane-xyz/registry": "npm:11.1.0"
     "@hyperlane-xyz/sdk": "npm:9.0.0"
     "@hyperlane-xyz/utils": "npm:9.0.0"
     "@interchain-ui/react": "npm:^1.23.28"


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
Remove `totalSupply` from `TokenMetadataSchema`. The field is not needed in most cases and could cause misconfiguration issues, on the synthetic token contract `totalSupply` was used, which mints tokens to the message sender.

Instead we now apply a `initialSupply` directly to the synthetic token without the need to use `totalSupply`

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

- Upgrade registry version
- Fix and remove tests that would depend on `totalSupply`

### Related issues

<!--
- Fixes #[issue number here]
-->
fixes #5687 
### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
Unit tests