### PR TITLE
feat: update Solana / Solanatestnet IGPs to send to some new chains

### DIFF
--- a/rust/sealevel/environments/mainnet3/chain-config.json
+++ b/rust/sealevel/environments/mainnet3/chain-config.json
@@ -1849,7 +1849,7 @@
     "displayName": "Fraxtal",
     "domainId": 252,
     "gasCurrencyCoinGeckoId": "frax-ether",
-    "gnosisSafeTransactionServiceUrl": "https://transaction-frax.safe.optimism.io",
+    "gnosisSafeTransactionServiceUrl": "https://safe.mainnet.frax.com/txs",
     "name": "fraxtal",
     "nativeToken": {
       "decimals": 18,
@@ -2169,6 +2169,7 @@
     "displayName": "HyperEVM",
     "domainId": 999,
     "gasCurrencyCoinGeckoId": "hyperliquid",
+    "gnosisSafeTransactionServiceUrl": "https://prod.hyperliquid.keypersafe.xyz",
     "name": "hyperevm",
     "nativeToken": {
       "decimals": 18,
@@ -2268,6 +2269,37 @@
       }
     ],
     "technicalStack": "arbitrumnitro"
+  },
+  "infinityvm": {
+    "blocks": {
+      "confirmations": 1,
+      "estimateBlockTime": 1,
+      "reorgPeriod": 1
+    },
+    "chainId": 1032009,
+    "deployer": {
+      "name": "Abacus Works",
+      "url": "https://www.hyperlane.xyz"
+    },
+    "displayName": "Infinity VM",
+    "domainId": 1032009,
+    "gasCurrencyCoinGeckoId": "infinityvm",
+    "index": {
+      "from": 157889
+    },
+    "name": "infinityvm",
+    "nativeToken": {
+      "decimals": 18,
+      "name": "INF",
+      "symbol": "INF"
+    },
+    "protocol": "ethereum",
+    "rpcUrls": [
+      {
+        "http": "https://mainnet-endpoint.infinityvm.xyz"
+      }
+    ],
+    "technicalStack": "other"
   },
   "ink": {
     "blockExplorers": [
@@ -2514,6 +2546,7 @@
     "displayName": "Lisk",
     "domainId": 1135,
     "gasCurrencyCoinGeckoId": "ethereum",
+    "gnosisSafeTransactionServiceUrl": "https://transaction-lisk.safe.optimism.io",
     "name": "lisk",
     "nativeToken": {
       "decimals": 18,
@@ -3352,6 +3385,45 @@
       "gasPrice": "0.025"
     }
   },
+  "plume": {
+    "blockExplorers": [
+      {
+        "apiUrl": "https://phoenix-explorer.plumenetwork.xyz/api",
+        "family": "blockscout",
+        "name": "Plume Explorer",
+        "url": "https://phoenix-explorer.plumenetwork.xyz"
+      }
+    ],
+    "blocks": {
+      "confirmations": 1,
+      "estimateBlockTime": 2,
+      "reorgPeriod": 0
+    },
+    "chainId": 98866,
+    "deployer": {
+      "name": "Abacus Works",
+      "url": "https://www.hyperlane.xyz"
+    },
+    "displayName": "Plume",
+    "domainId": 98866,
+    "gasCurrencyCoinGeckoId": "plume",
+    "index": {
+      "from": 9588
+    },
+    "name": "plume",
+    "nativeToken": {
+      "decimals": 18,
+      "name": "Plume",
+      "symbol": "PLUME"
+    },
+    "protocol": "ethereum",
+    "rpcUrls": [
+      {
+        "http": "https://phoenix-rpc.plumenetwork.xyz"
+      }
+    ],
+    "technicalStack": "arbitrumnitro"
+  },
   "polygon": {
     "blockExplorers": [
       {
@@ -4052,6 +4124,7 @@
     "displayName": "Soneium",
     "domainId": 1868,
     "gasCurrencyCoinGeckoId": "ethereum",
+    "gnosisSafeTransactionServiceUrl": "https://trx-soneium-stg.safe.protofire.io",
     "name": "soneium",
     "nativeToken": {
       "decimals": 18,
@@ -4342,9 +4415,6 @@
     "protocol": "ethereum",
     "rpcUrls": [
       {
-        "http": "https://archive.chain.opentensor.ai"
-      },
-      {
         "http": "https://bittensor-finney.api.onfinality.io/public"
       }
     ],
@@ -4372,6 +4442,7 @@
     "displayName": "Superseed",
     "domainId": 5330,
     "gasCurrencyCoinGeckoId": "ethereum",
+    "gnosisSafeTransactionServiceUrl": "https://trx-superseed.safe.protofire.io",
     "name": "superseed",
     "nativeToken": {
       "decimals": 18,
@@ -4712,6 +4783,7 @@
     "displayName": "Unichain",
     "domainId": 130,
     "gasCurrencyCoinGeckoId": "ethereum",
+    "gnosisSafeTransactionServiceUrl": "https://safe-transaction-unichain.safe.global",
     "name": "unichain",
     "nativeToken": {
       "decimals": 18,
@@ -4859,6 +4931,7 @@
     "displayName": "World Chain",
     "domainId": 480,
     "gasCurrencyCoinGeckoId": "ethereum",
+    "gnosisSafeTransactionServiceUrl": "https://safe-transaction-worldchain.safe.global",
     "name": "worldchain",
     "nativeToken": {
       "decimals": 18,

--- a/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
+++ b/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
@@ -8,6 +8,30 @@
       },
       "overhead": 166887
     },
+    "everclear": {
+      "oracleConfig": {
+        "tokenExchangeRate": "239372224587870308412",
+        "gasPrice": "234340482",
+        "tokenDecimals": 18
+      },
+      "overhead": 166887
+    },
+    "infinityvm": {
+      "oracleConfig": {
+        "tokenExchangeRate": "0",
+        "gasPrice": "0",
+        "tokenDecimals": 18
+      },
+      "overhead": 166887
+    },
+    "sophon": {
+      "oracleConfig": {
+        "tokenExchangeRate": "91246426181641219",
+        "gasPrice": "2261877890384",
+        "tokenDecimals": 18
+      },
+      "overhead": 333774
+    },
     "artela": {
       "oracleConfig": {
         "tokenExchangeRate": "1026217531480017",

--- a/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
+++ b/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
@@ -18,7 +18,7 @@
     },
     "infinityvm": {
       "oracleConfig": {
-        "tokenExchangeRate": "0",
+        "tokenExchangeRate": "91246426181641219",
         "gasPrice": "0",
         "tokenDecimals": 18
       },

--- a/rust/sealevel/environments/testnet4/chain-config.json
+++ b/rust/sealevel/environments/testnet4/chain-config.json
@@ -227,48 +227,6 @@
       }
     ]
   },
-  "berabartio": {
-    "blockExplorers": [
-      {
-        "apiUrl": "https://api.routescan.io/v2/network/testnet/evm/80084/etherscan/api/",
-        "family": "routescan",
-        "name": "Bartio Testnet Explorer",
-        "url": "https://bartio.beratrail.io/"
-      }
-    ],
-    "blocks": {
-      "confirmations": 1,
-      "estimateBlockTime": 3,
-      "reorgPeriod": 1
-    },
-    "chainId": 80084,
-    "deployer": {
-      "name": "Abacus Works",
-      "url": "https://www.hyperlane.xyz"
-    },
-    "displayName": "Berachain bArtio",
-    "domainId": 80084,
-    "gasCurrencyCoinGeckoId": "berachain",
-    "isTestnet": true,
-    "name": "berabartio",
-    "nativeToken": {
-      "decimals": 18,
-      "name": "BERA",
-      "symbol": "BERA"
-    },
-    "protocol": "ethereum",
-    "rpcUrls": [
-      {
-        "http": "https://bartio.rpc.berachain.com/"
-      },
-      {
-        "http": "https://bartio.drpc.org"
-      },
-      {
-        "http": "https://bera-testnet.nodeinfra.com"
-      }
-    ]
-  },
   "bsctestnet": {
     "blockExplorers": [
       {
@@ -346,6 +304,84 @@
         "http": "https://rpc-campnetwork.xyz"
       }
     ]
+  },
+  "carrchaintestnet": {
+    "blockExplorers": [
+      {
+        "apiUrl": "https://testnet.carrscan.io/api/v1",
+        "family": "etherscan",
+        "name": "CarrScan Testnet",
+        "url": "https://testnet.carrscan.io"
+      }
+    ],
+    "blocks": {
+      "confirmations": 1,
+      "estimateBlockTime": 1,
+      "reorgPeriod": 0
+    },
+    "chainId": 76672,
+    "deployer": {
+      "name": "Abacus Works",
+      "url": "https://www.hyperlane.xyz"
+    },
+    "displayName": "CarrChain Testnet",
+    "domainId": 76672,
+    "index": {
+      "from": 117
+    },
+    "isTestnet": true,
+    "name": "carrchaintestnet",
+    "nativeToken": {
+      "decimals": 18,
+      "name": "CARR",
+      "symbol": "CARR"
+    },
+    "protocol": "ethereum",
+    "rpcUrls": [
+      {
+        "http": "https://rpc-testnet.carrchain.io"
+      }
+    ],
+    "technicalStack": "arbitrumnitro"
+  },
+  "chronicleyellowstone": {
+    "blockExplorers": [
+      {
+        "apiUrl": "https://yellowstone-explorer.litprotocol.com/api",
+        "family": "blockscout",
+        "name": "Yellowstone Explorer",
+        "url": "https://yellowstone-explorer.litprotocol.com"
+      }
+    ],
+    "blocks": {
+      "confirmations": 1,
+      "estimateBlockTime": 1,
+      "reorgPeriod": 0
+    },
+    "chainId": 175188,
+    "deployer": {
+      "name": "Abacus Works",
+      "url": "https://www.hyperlane.xyz"
+    },
+    "displayName": "Chronicle Yellowstone",
+    "domainId": 175188,
+    "index": {
+      "from": 2339059
+    },
+    "isTestnet": true,
+    "name": "chronicleyellowstone",
+    "nativeToken": {
+      "decimals": 18,
+      "name": "Test LPX",
+      "symbol": "tstLPX"
+    },
+    "protocol": "ethereum",
+    "rpcUrls": [
+      {
+        "http": "https://yellowstone-rpc.litprotocol.com"
+      }
+    ],
+    "technicalStack": "arbitrumnitro"
   },
   "citreatestnet": {
     "blockExplorers": [
@@ -487,6 +523,44 @@
       }
     ]
   },
+  "flametestnet": {
+    "blockExplorers": [
+      {
+        "apiUrl": "https://explorer.flame.dawn-1.astria.org/api",
+        "family": "blockscout",
+        "name": "Astria Flame Explorer",
+        "url": "https://explorer.flame.dawn-1.astria.org"
+      }
+    ],
+    "blocks": {
+      "confirmations": 1,
+      "estimateBlockTime": 2,
+      "reorgPeriod": 1
+    },
+    "chainId": 16604737732183,
+    "deployer": {
+      "name": "Abacus Works",
+      "url": "https://www.hyperlane.xyz"
+    },
+    "displayName": "Flame Dawn-1 Testnet",
+    "displayNameShort": "Flame Testnet",
+    "domainId": 1660473773,
+    "gasCurrencyCoinGeckoId": "celestia",
+    "isTestnet": true,
+    "name": "flametestnet",
+    "nativeToken": {
+      "decimals": 18,
+      "name": "Celestia",
+      "symbol": "TIA"
+    },
+    "protocol": "ethereum",
+    "rpcUrls": [
+      {
+        "http": "https://rpc.flame.dawn-1.astria.org"
+      }
+    ],
+    "technicalStack": "other"
+  },
   "formtestnet": {
     "blockExplorers": [
       {
@@ -598,6 +672,73 @@
       }
     ]
   },
+  "hyperliquidevmtestnet": {
+    "blockExplorers": [
+      {
+        "apiUrl": "https://explorer.hyperlend.finance/api",
+        "family": "blockscout",
+        "name": "Hyperliquid EVM Testnet Explorer",
+        "url": "https://explorer.hyperlend.finance"
+      }
+    ],
+    "blocks": {
+      "confirmations": 1,
+      "estimateBlockTime": 2,
+      "reorgPeriod": 1
+    },
+    "chainId": 998,
+    "deployer": {
+      "name": "Abacus Works",
+      "url": "https://www.hyperlane.xyz"
+    },
+    "displayName": "Hyperliquid EVM Testnet",
+    "domainId": 998,
+    "gasCurrencyCoinGeckoId": "hyperliquid",
+    "isTestnet": true,
+    "name": "hyperliquidevmtestnet",
+    "nativeToken": {
+      "decimals": 18,
+      "name": "Hyperliquid",
+      "symbol": "HYPE"
+    },
+    "protocol": "ethereum",
+    "rpcUrls": [
+      {
+        "http": "https://api.hyperliquid-testnet.xyz/evm"
+      }
+    ]
+  },
+  "infinityvmmonza": {
+    "blocks": {
+      "confirmations": 1,
+      "estimateBlockTime": 1,
+      "reorgPeriod": 1
+    },
+    "chainId": 96025,
+    "deployer": {
+      "name": "Abacus Works",
+      "url": "https://www.hyperlane.xyz"
+    },
+    "displayName": "Infinity VM Monza Testnet",
+    "domainId": 96025,
+    "index": {
+      "from": 338182
+    },
+    "isTestnet": true,
+    "name": "infinityvmmonza",
+    "nativeToken": {
+      "decimals": 18,
+      "name": "INF",
+      "symbol": "INF"
+    },
+    "protocol": "ethereum",
+    "rpcUrls": [
+      {
+        "http": "https://rpc.monza.infinityvm.xyz"
+      }
+    ],
+    "technicalStack": "other"
+  },
   "inksepolia": {
     "blockExplorers": [
       {
@@ -633,6 +774,42 @@
       }
     ],
     "technicalStack": "opstack"
+  },
+  "monadtestnet": {
+    "blockExplorers": [
+      {
+        "apiUrl": "https://explorer.monad-testnet.category.xyz/api",
+        "family": "blockscout",
+        "name": "Monad Testnet Explorer",
+        "url": "https://explorer.monad-testnet.category.xyz"
+      }
+    ],
+    "blocks": {
+      "confirmations": 1,
+      "estimateBlockTime": 1,
+      "reorgPeriod": 1
+    },
+    "chainId": 10143,
+    "deployer": {
+      "name": "Abacus Works",
+      "url": "https://www.hyperlane.xyz"
+    },
+    "displayName": "Monad Testnet",
+    "domainId": 10143,
+    "isTestnet": true,
+    "name": "monadtestnet",
+    "nativeToken": {
+      "decimals": 18,
+      "name": "MON",
+      "symbol": "MON"
+    },
+    "protocol": "ethereum",
+    "rpcUrls": [
+      {
+        "http": "https://testnet-rpc.monad.xyz"
+      }
+    ],
+    "technicalStack": "other"
   },
   "odysseytestnet": {
     "blockExplorers": [
@@ -861,7 +1038,7 @@
       "url": "https://www.hyperlane.xyz"
     },
     "displayName": "Solana Testnet",
-    "displayNameShort": "Sol Testnet",
+    "displayNameShort": "Solana Testnet",
     "domainId": 1399811150,
     "gasCurrencyCoinGeckoId": "solana",
     "isTestnet": true,
@@ -877,6 +1054,42 @@
         "http": "https://api.testnet.solana.com"
       }
     ]
+  },
+  "somniatestnet": {
+    "blockExplorers": [
+      {
+        "apiUrl": "https://shannon-explorer.somnia.network/api",
+        "family": "blockscout",
+        "name": "https://shannon-explorer.somnia.network",
+        "url": "https://shannon-explorer.somnia.network"
+      }
+    ],
+    "blocks": {
+      "confirmations": 1,
+      "estimateBlockTime": 1,
+      "reorgPeriod": 1
+    },
+    "chainId": 50312,
+    "deployer": {
+      "name": "Abacus Works",
+      "url": "https://www.hyperlane.xyz"
+    },
+    "displayName": "Somnia Testnet",
+    "domainId": 50312,
+    "isTestnet": true,
+    "name": "somniatestnet",
+    "nativeToken": {
+      "decimals": 18,
+      "name": "STT",
+      "symbol": "STT"
+    },
+    "protocol": "ethereum",
+    "rpcUrls": [
+      {
+        "http": "https://vsf-rpc.somnia.network"
+      }
+    ],
+    "technicalStack": "other"
   },
   "soneiumtestnet": {
     "blockExplorers": [
@@ -911,6 +1124,45 @@
     "rpcUrls": [
       {
         "http": "https://rpc.minato.soneium.org"
+      }
+    ]
+  },
+  "sonicblaze": {
+    "blockExplorers": [
+      {
+        "apiUrl": "https://api-testnet.sonicscan.org/api",
+        "family": "etherscan",
+        "name": "Sonic Blaze Testnet Explorer",
+        "url": "https://testnet.sonicscan.org"
+      }
+    ],
+    "blocks": {
+      "confirmations": 1,
+      "estimateBlockTime": 1,
+      "reorgPeriod": 1
+    },
+    "chainId": 57054,
+    "deployer": {
+      "name": "Abacus Works",
+      "url": "https://www.hyperlane.xyz"
+    },
+    "displayName": "Sonic Blaze Testnet",
+    "displayNameShort": "Sonic Blaze",
+    "domainId": 57054,
+    "isTestnet": true,
+    "name": "sonicblaze",
+    "nativeToken": {
+      "decimals": 18,
+      "name": "Sonic",
+      "symbol": "S"
+    },
+    "protocol": "ethereum",
+    "rpcUrls": [
+      {
+        "http": "https://rpc.blaze.soniclabs.com"
+      },
+      {
+        "http": "https://rpc.ankr.com/sonic_blaze_testnet"
       }
     ]
   },
@@ -985,6 +1237,35 @@
         "http": "https://rpc.toliman.suave.flashbots.net"
       }
     ]
+  },
+  "subtensortestnet": {
+    "blocks": {
+      "confirmations": 1,
+      "estimateBlockTime": 12,
+      "reorgPeriod": 1
+    },
+    "chainId": 945,
+    "deployer": {
+      "name": "Abacus Works",
+      "url": "https://www.hyperlane.xyz"
+    },
+    "displayName": "Subtensor Testnet",
+    "domainId": 945,
+    "gasCurrencyCoinGeckoId": "bittensor",
+    "isTestnet": true,
+    "name": "subtensortestnet",
+    "nativeToken": {
+      "decimals": 18,
+      "name": "Bittensor",
+      "symbol": "TAO"
+    },
+    "protocol": "ethereum",
+    "rpcUrls": [
+      {
+        "http": "https://test.finney.opentensor.ai"
+      }
+    ],
+    "technicalStack": "other"
   },
   "superpositiontestnet": {
     "blockExplorers": [
@@ -1097,5 +1378,41 @@
         "http": "https://sepolia.unichain.org"
       }
     ]
+  },
+  "weavevmtestnet": {
+    "blockExplorers": [
+      {
+        "apiUrl": "https://explorer.wvm.dev/api",
+        "family": "blockscout",
+        "name": "WeaveVM Testnet Explorer",
+        "url": "https://explorer.wvm.dev"
+      }
+    ],
+    "blocks": {
+      "confirmations": 1,
+      "estimateBlockTime": 2,
+      "reorgPeriod": 1
+    },
+    "chainId": 9496,
+    "deployer": {
+      "name": "Abacus Works",
+      "url": "https://www.hyperlane.xyz"
+    },
+    "displayName": "Weave VM Testnet",
+    "domainId": 9496,
+    "isTestnet": true,
+    "name": "weavevmtestnet",
+    "nativeToken": {
+      "decimals": 18,
+      "name": "tWVM",
+      "symbol": "tWVM"
+    },
+    "protocol": "ethereum",
+    "rpcUrls": [
+      {
+        "http": "https://testnet-rpc.wvm.dev"
+      }
+    ],
+    "technicalStack": "other"
   }
 }

--- a/rust/sealevel/environments/testnet4/gas-oracle-configs.json
+++ b/rust/sealevel/environments/testnet4/gas-oracle-configs.json
@@ -7,6 +7,30 @@
         "tokenDecimals": 9
       },
       "overhead": 600000
+    },
+    "connextsepolia": {
+      "oracleConfig": {
+        "tokenExchangeRate": "15000000000000000000",
+        "gasPrice": "100000000",
+        "tokenDecimals": 18
+      },
+      "overhead": 151966
+    },
+    "infinityvmmonza": {
+      "oracleConfig": {
+        "tokenExchangeRate": "15000000000000000000",
+        "gasPrice": "1000000007",
+        "tokenDecimals": 18
+      },
+      "overhead": 151966
+    },
+    "basesepolia": {
+      "oracleConfig": {
+        "tokenExchangeRate": "15000000000000000000",
+        "gasPrice": "1000378",
+        "tokenDecimals": 18
+      },
+      "overhead": 151966
     }
   },
   "sonicsvmtestnet": {

--- a/rust/sealevel/environments/testnet4/gas-oracle-configs.json
+++ b/rust/sealevel/environments/testnet4/gas-oracle-configs.json
@@ -19,7 +19,7 @@
     "infinityvmmonza": {
       "oracleConfig": {
         "tokenExchangeRate": "15000000000000000000",
-        "gasPrice": "1000000007",
+        "gasPrice": "0",
         "tokenDecimals": 18
       },
       "overhead": 151966

--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -36,14 +36,19 @@ export function getOverheadWithOverrides(local: ChainName, remote: ChainName) {
   return overhead;
 }
 
-function getOracleConfigWithOverrides(chain: ChainName) {
-  const oracleConfig = storageGasOracleConfig[chain];
-  if (chain === 'infinityvm') {
-    // For InfinityVM, override all remote chain gas configs to use 0 gas
+function getOracleConfigWithOverrides(origin: ChainName) {
+  const oracleConfig = storageGasOracleConfig[origin];
+  if (origin === 'infinityvm') {
+    // For InfinityVM origin, override all remote chain gas configs to use 0 gas
     for (const remoteConfig of Object.values(oracleConfig)) {
       remoteConfig.gasPrice = '0';
     }
   }
+  // Solana -> InfinityVM, similarly don't charge gas
+  if (origin === 'solanamainnet') {
+    oracleConfig['infinityvm'].gasPrice = '0';
+  }
+
   return oracleConfig;
 }
 

--- a/typescript/infra/config/environments/testnet4/igp.ts
+++ b/typescript/infra/config/environments/testnet4/igp.ts
@@ -15,13 +15,17 @@ import rawTokenPrices from './tokenPrices.json';
 
 const tokenPrices: ChainMap<string> = rawTokenPrices;
 
-function getOracleConfigWithOverrides(chain: ChainName) {
-  const oracleConfig = storageGasOracleConfig[chain];
-  if (chain === 'infinityvmmonza') {
+function getOracleConfigWithOverrides(origin: ChainName) {
+  const oracleConfig = storageGasOracleConfig[origin];
+  if (origin === 'infinityvmmonza') {
     // For InfinityVM Monza, override all remote chain gas configs to use 0 gas
     for (const remoteConfig of Object.values(oracleConfig)) {
       remoteConfig.gasPrice = '0';
     }
+  }
+  // Solana Testnet -> InfinityVM Monza, similarly don't charge gas
+  if (origin === 'solanatestnet') {
+    oracleConfig['infinityvmmonza'].gasPrice = '0';
   }
   return oracleConfig;
 }

--- a/typescript/infra/scripts/sealevel-helpers/print-gas-oracles.ts
+++ b/typescript/infra/scripts/sealevel-helpers/print-gas-oracles.ts
@@ -100,6 +100,9 @@ function getChainConnections(
     connectedChains = [
       // For the Rivalz team building out their own warp route
       ['solanamainnet', 'rivalz'],
+      ['solanamainnet', 'everclear'],
+      ['solanamainnet', 'infinityvm'],
+      ['solanamainnet', 'sophon'],
       // All warp routes
       ...Object.values(WarpRouteIds).map(getWarpChains),
     ];
@@ -108,6 +111,9 @@ function getChainConnections(
       // As testnet warp routes are not tracked well, hardcode the connected chains.
       // For SOL/solanatestnet-sonicsvmtestnet
       ['solanatestnet', 'sonicsvmtestnet'],
+      ['solanatestnet', 'connextsepolia'],
+      ['solanatestnet', 'infinityvmmonza'],
+      ['solanatestnet', 'basesepolia'],
     ];
   } else {
     throw new Error(`Unknown environment: ${environment}`);


### PR DESCRIPTION
### Description

- Updates chain configs
- Mainnets: everclear, infinity, sophon (as https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5630 is not merged yet to track the warp route in question there)
- Testnets: connextsepolia, infinityvmmonza, basesepolia
- Also made sure Solana(testnet) -> infinityvm is free

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
