### PR TITLE
feat: Set relayer to use premium storage class

### DIFF
--- a/rust/main/helm/hyperlane-agent/templates/relayer-statefulset.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/relayer-statefulset.yaml
@@ -64,7 +64,7 @@ spec:
         resources:
           {{- toYaml .Values.hyperlane.relayer.resources | nindent 10 }}
         volumeMounts:
-        - name: state
+        - name: {{ .Values.hyperlane.relayer.storage.name | default "state" }}
           mountPath: {{ .Values.hyperlane.dbPath }}
         - name: relayer-configmap
           mountPath: /relayer-configmap
@@ -89,9 +89,9 @@ spec:
       {{- end }}
   volumeClaimTemplates:
   - metadata:
-      name: state
+      name: {{ .Values.hyperlane.relayer.storage.name | default "state" }}
     spec:
-      storageClassName: {{ .Values.storage.storageClass }}
+      storageClassName: {{ .Values.hyperlane.relayer.storage.storageClass | default .Values.storage.storageClass }}
       accessModes: [ {{ .Values.storage.accessModes }} ]
       {{- if .Values.hyperlane.relayer.storage.snapshot.enabled }}
       dataSource:

--- a/rust/main/helm/hyperlane-agent/values.yaml
+++ b/rust/main/helm/hyperlane-agent/values.yaml
@@ -106,6 +106,8 @@ hyperlane:
       prometheus.io/scrape: 'true'
     podLabels: {}
     storage:
+      name: 'state-premium'
+      storageClass: 'premium-immediate-rwo'
       size: 10Gi
       snapshot:
         enabled: false

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -725,7 +725,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'cc3af7d-20250304-172021',
+      tag: 'f5174e6-20250310-182921',
     },
     blacklist,
     gasPaymentEnforcement: gasPaymentEnforcement,


### PR DESCRIPTION
### Description

Set relayer to use premium storage class

This change allows Relayer to use premium storage class which using SSDs instead of HDD. It will allow relayer to start quicker.

### Related issues

- Fixes https://github.com/hyperlane-xyz/issues/issues/1433

### Backward compatibility

Yes

### Testing

Manual testing in test environment