### PR TITLE
fix: Starknet tx receipt type

### DIFF
--- a/.changeset/great-cougars-repeat.md
+++ b/.changeset/great-cougars-repeat.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Fix Starknet tx receipt type

--- a/typescript/sdk/src/providers/ProviderType.ts
+++ b/typescript/sdk/src/providers/ProviderType.ts
@@ -19,8 +19,7 @@ import {
   Contract as StarknetContract,
   Invocation as StarknetInvocation,
   Provider as StarknetProvider,
-  ReceiptTx as StarknetReceiptTx,
-  TransactionReceipt as StarknetTxReceipt,
+  GetTransactionReceiptResponse as StarknetTxReceipt,
 } from 'starknet';
 import type {
   GetContractReturnType,
@@ -300,9 +299,9 @@ export interface CosmJsWasmTransactionReceipt
 }
 
 export interface StarknetJsTransactionReceipt
-  extends TypedTransactionReceiptBase<StarknetTxReceipt | StarknetReceiptTx> {
+  extends TypedTransactionReceiptBase<StarknetTxReceipt> {
   type: ProviderType.Starknet;
-  receipt: StarknetTxReceipt | StarknetReceiptTx;
+  receipt: StarknetTxReceipt;
 }
 
 export type TypedTransactionReceipt =


### PR DESCRIPTION
### Description

This PR updates the Starknet transaction receipt typing in the SDK to use GetTransactionReceiptResponse instead of the previous union type (TransactionReceipt | ReceiptTx).

### Drive-by changes

None

### Related issues

None

### Backward compatibility

Yes

### Testing

None
