### PR TITLE
fix: WarpCore collateral check for XERC20 lockboxes

### DIFF
--- a/.changeset/ten-doors-perform.md
+++ b/.changeset/ten-doors-perform.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Fix WarpCore collateral check for lockboxes

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -161,6 +161,7 @@ describe('WarpCore', () => {
     const stubs = warpCore.tokens.map((t) =>
       sinon.stub(t, 'getHypAdapter').returns({
         getBalance: () => Promise.resolve(MOCK_BALANCE),
+        getBridgedSupply: () => Promise.resolve(MOCK_BALANCE),
       } as any),
     );
 
@@ -211,6 +212,7 @@ describe('WarpCore', () => {
         populateTransferRemoteTx: () => Promise.resolve({}),
         getMinimumTransferAmount: () => Promise.resolve(minimumTransferAmount),
         getBalance: () => Promise.resolve(MOCK_BALANCE),
+        getBridgedSupply: () => Promise.resolve(MOCK_BALANCE),
         getMintLimit: () => Promise.resolve(MEDIUM_MOCK_BALANCE),
         getMintMaxLimit: () => Promise.resolve(MEDIUM_MOCK_BALANCE),
       } as any),

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -27,7 +27,10 @@ import {
   TOKEN_STANDARD_TO_PROVIDER_TYPE,
   TokenStandard,
 } from '../token/TokenStandard.js';
-import { EVM_TRANSFER_REMOTE_GAS_ESTIMATE } from '../token/adapters/EvmTokenAdapter.js';
+import {
+  EVM_TRANSFER_REMOTE_GAS_ESTIMATE,
+  EvmHypXERC20LockboxAdapter,
+} from '../token/adapters/EvmTokenAdapter.js';
 import { IHypXERC20Adapter } from '../token/adapters/ITokenAdapter.js';
 import { ChainName, ChainNameOrId } from '../types.js';
 
@@ -483,10 +486,22 @@ export class WarpCore {
       return true;
     }
 
-    const adapter = destinationToken.getAdapter(this.multiProvider);
-    const destinationBalance: bigint = await adapter.getBalance(
-      destinationToken.addressOrDenom,
-    );
+    let destinationBalance: bigint = 0n;
+
+    if (
+      destinationToken.standard === TokenStandard.EvmHypXERC20Lockbox ||
+      destinationToken.standard === TokenStandard.EvmHypVSXERC20Lockbox
+    ) {
+      const adapter = destinationToken.getAdapter(
+        this.multiProvider,
+      ) as EvmHypXERC20LockboxAdapter;
+      destinationBalance = await adapter.getBridgedSupply();
+    } else {
+      const adapter = destinationToken.getAdapter(this.multiProvider);
+      destinationBalance = await adapter.getBalance(
+        destinationToken.addressOrDenom,
+      );
+    }
 
     const destinationBalanceInOriginDecimals = convertDecimalsToIntegerString(
       destinationToken.decimals,


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

Fixed an issue where `isDestinationCollateralSufficient` would check for the wrong address for lockboxes, it will now instead use [getBridgedSupply](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/cd1d0334411a40950b59efee8b42e341a219cad4/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts#L409) to get collateral balance

Normally the collateral would be held by the destination's `addressOrDenom` but that is not the case for the XERC20 Lockboxes, as you can see [here](https://github.com/hyperlane-xyz/hyperlane-registry/blob/main/deployments/warp_routes/REZ/base-ethereum-config.yaml), this particular route if you dive deeper into the contract you can see that `addressOrDenom` hold no [funds](https://etherscan.io/address/0xc32848c38dd5a5098cd53d33e425c1013a4e06a8) but it is instead held by the lockbox [address](https://etherscan.io/address/0xd8b543feac4eecef5a46a926e10d6f4a72de6fe0) (which in the warp route case is denoted by the `collateralAddressOrDenom`)

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes
### Testing

<!--
What kind of testing have these changes undergone?
None/Manual/Unit Tests
-->
Unit test
Local UI