### PR TITLE
fix(cli): successfully check status on chains without a block explorer

### DIFF
--- a/.changeset/tender-pandas-bake.md
+++ b/.changeset/tender-pandas-bake.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Do not error in hyperlane status if chain does not contain block explorer URL.

--- a/typescript/cli/src/status/message.ts
+++ b/typescript/cli/src/status/message.ts
@@ -73,11 +73,12 @@ export async function checkMessageStatus({
     if (delivered) {
       try {
         const processedReceipt = await core.getProcessedReceipt(message);
-        const url = context.multiProvider.getExplorerTxUrl(
+        const hash = processedReceipt.transactionHash;
+        const url = context.multiProvider.tryGetExplorerTxUrl(
           message.parsed.destination,
-          { hash: processedReceipt.transactionHash },
+          { hash },
         );
-        logGreen(`Message ${message.id} was delivered in ${url}`);
+        logGreen(`Message ${message.id} was delivered in ${url || hash}`);
       } catch (error) {
         logRed(`Failed to fetch processed receipt: ${error}`);
         logGreen(`Message ${message.id} was delivered`);


### PR DESCRIPTION
### Description

- use `tryGetExplorerTxUrl` instead of `getExplorerTxUrl` to support chains that do not have a block explorer configured e.g. local anvil builds

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

resolves https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5720

### Backward compatibility

yes

### Testing

manual