### PR TITLE
feat(ci): migrate to depot

### DIFF
--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -34,6 +34,9 @@ jobs:
 
   build-and-push-to-gcr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     # uses check-env to determine if secrets.GCLOUD_SERVICE_KEY is defined
     needs: [check-env]
@@ -62,8 +65,8 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=raw,value=${{ steps.taggen.outputs.TAG_SHA }}-${{ steps.taggen.outputs.TAG_DATE }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
       - name: Login to GCR
         uses: docker/login-action@v3
         with:
@@ -78,8 +81,9 @@ jobs:
           echo "REGISTRY_VERSION=$REGISTRY_VERSION" >> $GITHUB_ENV
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: depot/build-push-action@v1
         with:
+          project: jmrf3hq6zz
           context: ./
           file: ./Dockerfile
           push: true

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -27,7 +27,10 @@ jobs:
         run: echo "defined=true" >> $GITHUB_OUTPUT
 
   build-and-push-to-gcr:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     # uses check-env to determine if secrets.GCLOUD_SERVICE_KEY is defined
     needs: [check-env]
@@ -54,8 +57,8 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=raw,value=${{ steps.taggen.outputs.TAG_SHA }}-${{ steps.taggen.outputs.TAG_DATE }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
       - name: Login to GCR
         uses: docker/login-action@v3
         with:
@@ -63,8 +66,9 @@ jobs:
           username: _json_key
           password: ${{ secrets.GCLOUD_SERVICE_KEY }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: depot/build-push-action@v1
         with:
+          project: jmrf3hq6zz
           context: .
           file: ./rust/Dockerfile
           push: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   submitter-coverage:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,7 +58,7 @@ jobs:
         run: |
           cargo install cargo-llvm-cov@0.5.39 --locked
           rustup component add llvm-tools-preview
-      
+
       - name: Generate coverage for submitter package
         run: cargo llvm-cov --package submitter --json --output-path coverage.json
         working-directory: ./rust/main
@@ -72,7 +72,7 @@ jobs:
             exit 1
           fi
         working-directory: ./rust/main
-      
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-rs:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@v4
         with:
@@ -112,7 +112,7 @@ jobs:
         working-directory: ./rust/sealevel
 
   lint-rs:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,7 @@ jobs:
           fi
 
   e2e-matrix:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-24.04-8
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main' || github.base_ref == 'cli-2.0') || github.event_name == 'merge_group'
     needs: [yarn-install]
     strategy:


### PR DESCRIPTION
### Description

feat(ci): migrate to depot
- move rust+monorepo docker builds to depot
- move big test runners from `buildjet-8vcpu-ubuntu-2204` to same-sized `depot-ubuntu-24.04-8`

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

ci