### PR TITLE
fix(sdk): fix read commands on zksync chains

### DIFF
--- a/.changeset/violet-fireants-yell.md
+++ b/.changeset/violet-fireants-yell.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Updated NON_ZERO_SENDER_ADDRESS to 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 to fix reading on zksync chains

--- a/typescript/sdk/src/token/config.ts
+++ b/typescript/sdk/src/token/config.ts
@@ -29,4 +29,4 @@ export const gasOverhead = (tokenType: TokenType): number => {
 };
 
 export const NON_ZERO_SENDER_ADDRESS =
-  '0x0000000000000000000000000000000000000001';
+  '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';


### PR DESCRIPTION
### Description

This PR fixes reading on chain data on zksync chains by changing the NON_ZERO_SENDER_ADDRESS constant from `0x1` to anvil's `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266` because only smart accounts can perform read operations on the rpc and 0x1 is a precompile

Before fix:

![image](https://github.com/user-attachments/assets/ef044830-f6d7-4a1f-9c1b-c4887880596e)

After fix:

![image](https://github.com/user-attachments/assets/7c987d81-7aee-4ffe-b7a4-d43bc84bdeaa)


### Drive-by changes

- No

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

- Yes

### Testing

- Manual
