### PR TITLE
fix: ensure 4626 warp route variants use `FungibleTokenRouter` scaling

### DIFF
--- a/.changeset/rotten-goats-knock.md
+++ b/.changeset/rotten-goats-knock.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/core': patch
+---
+
+Fix yield route (`HypERC4626`/`HypERC4626Collateral`) decimal scaling by leveraging `FungibleTokenRouter`

--- a/solidity/contracts/token/HypERC20.sol
+++ b/solidity/contracts/token/HypERC20.sol
@@ -64,7 +64,7 @@ contract HypERC20 is ERC20Upgradeable, FungibleTokenRouter {
      */
     function _transferFromSender(
         uint256 _amount
-    ) internal override returns (bytes memory) {
+    ) internal virtual override returns (bytes memory) {
         _burn(msg.sender, _amount);
         return bytes(""); // no metadata
     }

--- a/solidity/contracts/token/extensions/4626.md
+++ b/solidity/contracts/token/extensions/4626.md
@@ -1,3 +1,11 @@
+# Yield Routes
+
+Yield routes are a mechanism to transfer yield-bearing assets across chains using the ERC4626 standard.
+
+`HypERC4626Collateral` is a contract that implements `ERC4626` deposits upon transfer and withdrawal upon transfer back.
+
+`HypERC4646` is a contract that implements a rebasing `ERC20`. Balances are virtualized as vault shares times the total assets over the total shares in the `ERC4626` vault (on the collateral chain).
+
 ## `HypERC4626Collateral.transferRemote`
 
 ```mermaid
@@ -13,8 +21,11 @@ sequenceDiagram
     WarpRoute->>ERC20: approve(ERC4626, amount)
     WarpRoute->>ERC4626: deposit(amount, WarpRoute)
     ERC4626-->>WarpRoute: shares
+    WarpRoute->>ERC4626: convertToAssets(PRECISION)
+    ERC4626-->>WarpRoute: exchangeRate
+    WarpRoute->>WarpRoute: nonce += 1
 
-    WarpRoute->>Mailbox: dispatch(dest, router[dest], {recipient, shares})
+    WarpRoute->>Mailbox: dispatch(dest, router[dest], {recipient, shares, exchangeRate, nonce})
 ```
 
 ## `HypERC4626.handle`
@@ -25,8 +36,16 @@ sequenceDiagram
     participant WarpRoute
     participant Mailbox
 
-    Mailbox->>WarpRoute: handle(orgn, sender, {recipient, shares})
-    WarpRoute-->>WarpRoute: mint(shares, recipient)
+    Mailbox->>WarpRoute: handle(origin, sender, {recipient, shares, exchangeRate, nonce})
+    alt nonce > latestNonce && origin = collateralChain
+        WarpRoute->>WarpRoute: latestNonce = nonce
+        WarpRoute->>WarpRoute: latestExchangeRate = exchangeRate
+    end
+
+    WarpRoute->>WarpRoute: mint(shares, recipient)
+    WarpRoute->>WarpRoute: balance[recipient] = shares
+    Recipient->>WarpRoute: balanceOf(recipient)
+    WarpRoute-->>WarpRoute: balance[recipient] * latestExchangeRate
     WarpRoute-->>Recipient: amount
 ```
 

--- a/solidity/contracts/token/extensions/4626.md
+++ b/solidity/contracts/token/extensions/4626.md
@@ -1,0 +1,61 @@
+## `HypERC4626Collateral.transferRemote`
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ERC20
+    participant ERC4626
+    participant WarpRoute
+    participant Mailbox
+
+    User->>WarpRoute: transferRemote(dest, recipient, amount)
+    WarpRoute->>ERC20: transferFrom(User, WarpRoute, amount)
+    WarpRoute->>ERC20: approve(ERC4626, amount)
+    WarpRoute->>ERC4626: deposit(amount, WarpRoute)
+    ERC4626-->>WarpRoute: shares
+
+    WarpRoute->>Mailbox: dispatch(dest, router[dest], {recipient, shares})
+```
+
+## `HypERC4626.handle`
+
+```mermaid
+sequenceDiagram
+    participant Recipient
+    participant WarpRoute
+    participant Mailbox
+
+    Mailbox->>WarpRoute: handle(orgn, sender, {recipient, shares})
+    WarpRoute-->>WarpRoute: mint(shares, recipient)
+    WarpRoute-->>Recipient: amount
+```
+
+## `HypERC4626.transferRemote`
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant WarpRoute
+    participant Mailbox
+
+    User->>WarpRoute: transferRemote(dest, recipient, amount)
+    WarpRoute-->>WarpRoute: burn(shares, User)
+    WarpRoute->>Mailbox: dispatch(dest, router[dest], {recipient, shares})
+```
+
+## `HypERC4626Collateral.handle`
+
+```mermaid
+sequenceDiagram
+    participant Recipient
+    participant ERC20
+    participant ERC4626
+    participant WarpRoute
+    participant Mailbox
+
+    Mailbox->>WarpRoute: handle(orgn, sender, {recipient, shares})
+    WarpRoute->>ERC4626: redeem(shares, recipient, WarpRoute)
+    ERC4626-->>WarpRoute: amount
+    WarpRoute->>ERC20: transfer(recipient, amount)
+    ERC20-->>Recipient: amount
+```

--- a/solidity/contracts/token/extensions/HypERC4626.sol
+++ b/solidity/contracts/token/extensions/HypERC4626.sol
@@ -110,6 +110,7 @@ contract HypERC4626 is HypERC20 {
     }
 
     // @inheritdoc ERC20Upgradeable
+    // @dev Amount specified by user is in assets, but the internal accounting is in shares
     function _transfer(
         address _from,
         address _to,

--- a/solidity/contracts/token/extensions/HypERC4626.sol
+++ b/solidity/contracts/token/extensions/HypERC4626.sol
@@ -137,6 +137,9 @@ contract HypERC4626 is HypERC20 {
             FungibleTokenRouter._outboundAmount(assetsToShares(_localAmount));
     }
 
+    // `_inboundAmount` implementation reused from `FungibleTokenRouter` unchanged because message
+    // accounting is in shares
+
     // ========== TokenRouter extensions ============
     /// @inheritdoc TokenRouter
     function _handle(

--- a/solidity/contracts/token/extensions/HypERC4626.sol
+++ b/solidity/contracts/token/extensions/HypERC4626.sol
@@ -60,31 +60,6 @@ contract HypERC4626 is HypERC20 {
 
     // ============ Public Functions ============
 
-    /// Override transfer to handle underlying amounts while using shares internally
-    /// @inheritdoc ERC20Upgradeable
-    /// @dev the Transfer event emitted from ERC20Upgradeable will be in terms of shares not assets, so it may be misleading
-    function transfer(
-        address to,
-        uint256 amount
-    ) public virtual override returns (bool) {
-        _transfer(_msgSender(), to, assetsToShares(amount));
-        return true;
-    }
-
-    /// Override transferFrom to handle underlying amounts while using shares internally
-    /// @inheritdoc ERC20Upgradeable
-    function transferFrom(
-        address sender,
-        address recipient,
-        uint256 amount
-    ) public virtual override returns (bool) {
-        address spender = _msgSender();
-        uint256 shares = assetsToShares(amount);
-        _spendAllowance(sender, spender, amount);
-        _transfer(sender, recipient, shares);
-        return true;
-    }
-
     /// Override totalSupply to return the total assets instead of shares. This reflects the actual circulating supply in terms of assets, accounting for rebasing
     /// @inheritdoc ERC20Upgradeable
     function totalSupply() public view virtual override returns (uint256) {
@@ -132,6 +107,15 @@ contract HypERC4626 is HypERC20 {
     ) internal view virtual override returns (uint256) {
         return
             FungibleTokenRouter._outboundAmount(assetsToShares(_localAmount));
+    }
+
+    // @inheritdoc ERC20Upgradeable
+    function _transfer(
+        address _from,
+        address _to,
+        uint256 _amount
+    ) internal virtual override {
+        super._transfer(_from, _to, assetsToShares(_amount));
     }
 
     // `_inboundAmount` implementation reused from `FungibleTokenRouter` unchanged because message

--- a/solidity/contracts/token/extensions/HypERC4626.sol
+++ b/solidity/contracts/token/extensions/HypERC4626.sol
@@ -30,9 +30,10 @@ import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/
  * @title Hyperlane ERC20 Rebasing Token
  * @author Abacus Works
  * @notice This contract implements a rebasing token that reflects yields from the origin chain
- * @dev Amounts in message and balance storage mapping are shares of the collateralizing ERC4626
- * @dev ERC20 internal accounting is in shares, but the public interface is in assets
-        This includes `balanceOf`, `totalSupply`, `transfer`, `transferFrom`, and `approve`.
+ * @dev Messages contain amounts as shares of ERC4626 and exchange rate of assets per share.
+ * @dev internal ERC20 balances storage mapping is in share units
+ * @dev internal ERC20 allowances storage mapping is in asset units
+ * @dev public ERC20 interface is in asset units
  */
 contract HypERC4626 is HypERC20 {
     using Math for uint256;
@@ -57,7 +58,32 @@ contract HypERC4626 is HypERC20 {
         _disableInitializers();
     }
 
-    // =========== ERC20 Public Interface ============
+    // ============ Public Functions ============
+
+    /// Override transfer to handle underlying amounts while using shares internally
+    /// @inheritdoc ERC20Upgradeable
+    /// @dev the Transfer event emitted from ERC20Upgradeable will be in terms of shares not assets, so it may be misleading
+    function transfer(
+        address to,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        _transfer(_msgSender(), to, assetsToShares(amount));
+        return true;
+    }
+
+    /// Override transferFrom to handle underlying amounts while using shares internally
+    /// @inheritdoc ERC20Upgradeable
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        address spender = _msgSender();
+        uint256 shares = assetsToShares(amount);
+        _spendAllowance(sender, spender, amount);
+        _transfer(sender, recipient, shares);
+        return true;
+    }
 
     /// Override totalSupply to return the total assets instead of shares. This reflects the actual circulating supply in terms of assets, accounting for rebasing
     /// @inheritdoc ERC20Upgradeable
@@ -75,12 +101,12 @@ contract HypERC4626 is HypERC20 {
 
     /// This function provides the total supply in terms of shares
     function totalShares() public view returns (uint256) {
-        return ERC20Upgradeable.totalSupply();
+        return super.totalSupply();
     }
 
     ///  This returns the balance of the account in terms of shares
     function shareBalanceOf(address account) public view returns (uint256) {
-        return ERC20Upgradeable.balanceOf(account);
+        return super.balanceOf(account);
     }
 
     function assetsToShares(uint256 _amount) public view returns (uint256) {
@@ -89,35 +115,6 @@ contract HypERC4626 is HypERC20 {
 
     function sharesToAssets(uint256 _shares) public view returns (uint256) {
         return _shares.mulDiv(exchangeRate, PRECISION);
-    }
-
-    // =========== ERC20 internal accounting ===========
-    function _transfer(
-        address from,
-        address to,
-        uint256 amount
-    ) internal virtual override {
-        ERC20Upgradeable._transfer(from, to, assetsToShares(amount));
-    }
-
-    function _spendAllowance(
-        address owner,
-        address spender,
-        uint256 amount
-    ) internal virtual override {
-        ERC20Upgradeable._spendAllowance(
-            owner,
-            spender,
-            assetsToShares(amount)
-        );
-    }
-
-    function _approve(
-        address owner,
-        address spender,
-        uint256 amount
-    ) internal virtual override {
-        ERC20Upgradeable._approve(owner, spender, assetsToShares(amount));
     }
 
     // @inheritdoc HypERC20
@@ -159,7 +156,6 @@ contract HypERC4626 is HypERC20 {
                 emit ExchangeRateUpdated(exchangeRate, rateUpdateNonce);
             }
         }
-
-        TokenRouter._handle(_origin, _sender, _message);
+        super._handle(_origin, _sender, _message);
     }
 }

--- a/solidity/contracts/token/extensions/HypERC4626Collateral.sol
+++ b/solidity/contracts/token/extensions/HypERC4626Collateral.sol
@@ -22,6 +22,8 @@ import {FungibleTokenRouter} from "../libs/FungibleTokenRouter.sol";
 // ============ External Imports ============
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 
+import "forge-std/console.sol";
+
 /**
  * @title Hyperlane ERC4626 Token Collateral with deposits collateral to a vault
  * @author Abacus Works
@@ -64,10 +66,9 @@ contract HypERC4626Collateral is HypERC20Collateral {
     function _outboundAmount(
         uint256 _localAmount
     ) internal view virtual override returns (uint256) {
-        return
-            FungibleTokenRouter._outboundAmount(
-                vault.convertToShares(_localAmount)
-            );
+        uint256 shares = vault.convertToShares(_localAmount);
+        console.log(shares);
+        return FungibleTokenRouter._outboundAmount(shares);
     }
 
     /**
@@ -81,7 +82,9 @@ contract HypERC4626Collateral is HypERC20Collateral {
         HypERC20Collateral._transferFromSender(_amount);
 
         wrappedToken.approve(address(vault), _amount);
-        vault.deposit(_amount, address(this));
+        // TODO: send this in the message rather than vault.convertToShares
+        uint256 shares = vault.deposit(_amount, address(this));
+        console.log(shares);
 
         uint256 _exchangeRate = vault.convertToAssets(PRECISION);
         rateUpdateNonce++;

--- a/solidity/contracts/token/libs/FungibleTokenRouter.sol
+++ b/solidity/contracts/token/libs/FungibleTokenRouter.sol
@@ -3,6 +3,10 @@ pragma solidity >=0.8.0;
 
 import {TokenRouter} from "./TokenRouter.sol";
 
+/**
+ * @title Hyperlane Fungible Token Router that extends TokenRouter with scaling logic for fungible tokens with different decimals.
+ * @author Abacus Works
+ */
 abstract contract FungibleTokenRouter is TokenRouter {
     uint256 public immutable scale;
 

--- a/solidity/contracts/token/libs/TokenRouter.sol
+++ b/solidity/contracts/token/libs/TokenRouter.sol
@@ -20,7 +20,7 @@ abstract contract TokenRouter is GasRouter {
      * @dev Emitted on `transferRemote` when a transfer message is dispatched.
      * @param destination The identifier of the destination chain.
      * @param recipient The address of the recipient on the destination chain.
-     * @param amount The amount of tokens burnt on the origin chain.
+     * @param amount The amount of tokens sent in to the remote recipient.
      */
     event SentTransferRemote(
         uint32 indexed destination,
@@ -32,7 +32,7 @@ abstract contract TokenRouter is GasRouter {
      * @dev Emitted on `_handle` when a transfer message is processed.
      * @param origin The identifier of the origin chain.
      * @param recipient The address of the recipient on the destination chain.
-     * @param amount The amount of tokens minted on the destination chain.
+     * @param amount The amount of tokens received from the remote sender.
      */
     event ReceivedTransferRemote(
         uint32 indexed origin,

--- a/solidity/test/token/HypERC4626Test.t.sol
+++ b/solidity/test/token/HypERC4626Test.t.sol
@@ -542,6 +542,28 @@ contract HypERC4626CollateralTest is HypTokenTest {
         ); // asserting that the exchange rate is set finally by the collateral variant
     }
 
+    function test_rebasingERC20() public {
+        _performRemoteTransferWithoutExpectation(0, transferAmount);
+        assertEq(remoteToken.balanceOf(BOB), transferAmount);
+
+        _accrueYield();
+        localRebasingToken.rebase(DESTINATION, bytes(""), address(0)); // yield is added
+        remoteMailbox.processNextInboundMessage();
+
+        uint256 balance = remoteToken.balanceOf(BOB);
+        assertNotEq(balance, transferAmount);
+
+        vm.prank(BOB);
+        remoteToken.approve(ALICE, balance);
+
+        vm.prank(ALICE);
+        remoteToken.transferFrom(BOB, CAROL, balance);
+
+        assertEq(remoteToken.allowance(BOB, ALICE), 0);
+        assertEq(remoteToken.balanceOf(BOB), 0);
+        assertEq(remoteToken.balanceOf(CAROL), balance);
+    }
+
     function test_cyclicTransfers() public {
         // ALICE: local -> remote(BOB)
         _performRemoteTransferWithoutExpectation(0, transferAmount);

--- a/solidity/test/token/HypERC4626Test.t.sol
+++ b/solidity/test/token/HypERC4626Test.t.sol
@@ -551,7 +551,12 @@ contract HypERC4626CollateralTest is HypTokenTest {
         remoteMailbox.processNextInboundMessage();
 
         uint256 balance = remoteToken.balanceOf(BOB);
-        assertNotEq(balance, transferAmount);
+        assertApproxEqRelDecimal(
+            balance,
+            transferAmount + _discountedYield(),
+            1e14,
+            0
+        );
 
         vm.prank(BOB);
         remoteToken.approve(ALICE, balance);


### PR DESCRIPTION
### Description

Inherits more behavior from `FungibleTokenRouter` and `HypERC20`/`HypERC20Collateral` in `HypERC4626` and `HypERC4626Collateral`.

Adjusts docstrings on `TokenRouter` for clarity.

Adds yield route lifecycle diagrams.

### Backward compatibility

No

### Testing

Existing warp route unit tests

New tests added for approvals
