### PR TITLE
docs: clarify SVM signer treatment comment

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/utils.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/utils.rs
@@ -47,11 +47,13 @@ pub fn sanitize_dynamic_accounts(
         }
     });
 
-    // On SVM, if an instruction specifies the same account twice, if one of them is a signer
-    // then the SVM ends up treating the other as a signer as well, even if the other AccountMeta
-    // didn't ask for it!
+    // On SVM, if a transaction's top level instruction specifies the same account twice, if one of
+    // them is a signer then the SVM ends up treating the other as a signer as well, even if the other
+    // AccountMeta didn't ask for it!
     // This means that if one of the dynamic account metas includes the payer, the
     // CPI made into the program will end up providing the payer account as a signer.
+    // Note this limitation is only for top level instructions, and an inner CPI is allowed to have
+    // an account specified twice with one being a signer and the other not.
     if account_metas.iter().any(|meta| meta.pubkey == *payer) {
         return Err(ChainCommunicationError::from_other_str(
             "Dynamic account metas contain payer account",


### PR DESCRIPTION
### Description

Clarifying a comment from https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5545

Context from auditors:
```
@tkporter may be we can correct this [comment](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/5545/files#diff-6aac2407212511b84f349708b48e31fed21236db8dc4d46888e52eba51b0a61fR50-R54), it is little inaccurate.
    // On SVM, if an instruction specifies the same account twice, if one of them is a signer
    // then the SVM ends up treating the other as a signer as well, even if the other AccountMeta
    // didn't ask for it!
    // This means that if one of the dynamic account metas includes the payer, the
    // CPI made into the program will end up providing the payer account as a signer.

There are two cases:
Mailbox program is called directly in a transaction: One of transaction's ix's program-id is the mailbox. This is the case if relayer calls the mailbox in a transaction
Program is executed by CPI: One of transaction ix's program id is some X and X calls mailbox.

The issue happens in the first case. If payer signs the transaction, all instances of payer in the ix to mailbox will be signers even if some of them are marked as non-signers while constructing the transaction.
In the second case, I do not think this happens. If accounts are passed in CPI, one instance of payer can be signer and other a non-signer.

The comment could be corrected to say "if payer signs the transaction the program called in the Txn ix's will see all payer accounts as signers". That program can choose if it wants to pass those accounts as signers or not to the other programs through CPI.

simply:
Txn ix -> mailbox, all instance become signers
Txn ix -> XYZ -> mailbox, XYZ can choose which instances of payer account can be signer in CPI to mailbox
```

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
