### PR TITLE
feat: Sealevel transaction submitter URLs comma separated, update helm

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
@@ -392,8 +392,7 @@ mod test {
         let params = MessageMetadataBuildParams::default();
         let err = build_message_metadata(message_builder, ism_address, &message, params.clone())
             .await
-            .err()
-            .expect("Metadata found when it should have failed");
+            .expect_err("Metadata found when it should have failed");
         assert_eq!(err, MetadataBuildError::MaxIsmDepthExceeded(0));
         assert_eq!(*(params.ism_count.lock().await), 0);
 
@@ -421,8 +420,7 @@ mod test {
         let params = MessageMetadataBuildParams::default();
         let err = build_message_metadata(message_builder, ism_address, &message, params.clone())
             .await
-            .err()
-            .expect("Metadata found when it should have failed");
+            .expect_err("Metadata found when it should have failed");
         assert_eq!(err, MetadataBuildError::MaxIsmCountReached(0));
         assert_eq!(*(params.ism_count.lock().await), 0);
 
@@ -450,8 +448,7 @@ mod test {
         let params = MessageMetadataBuildParams::default();
         let err = build_message_metadata(message_builder, ism_address, &message, params.clone())
             .await
-            .err()
-            .expect("Metadata found when it should have failed");
+            .expect_err("Metadata found when it should have failed");
         assert_eq!(err, MetadataBuildError::AggregationThresholdNotMet(2));
         assert!(*(params.ism_count.lock().await) <= 4);
         assert!(logs_contain("Max ISM depth reached ism_depth=2"));
@@ -478,8 +475,7 @@ mod test {
         let params = MessageMetadataBuildParams::default();
         let err = build_message_metadata(message_builder, ism_address, &message, params.clone())
             .await
-            .err()
-            .expect("Metadata found when it should have failed");
+            .expect_err("Metadata found when it should have failed");
         assert_eq!(err, MetadataBuildError::AggregationThresholdNotMet(2));
         assert_eq!(*(params.ism_count.lock().await), 5);
         assert!(logs_contain("Max ISM count reached ism_count=5"));

--- a/rust/main/agents/relayer/src/test_utils/mock_base_builder.rs
+++ b/rust/main/agents/relayer/src/test_utils/mock_base_builder.rs
@@ -28,6 +28,7 @@ pub struct MockBaseMetadataBuilderResponses {
     /// responses.
     /// In order to fix this in tests, the mock ISMs are built with specific addresses
     /// in place. And gets responses from this based on the address.
+    #[allow(clippy::type_complexity)]
     pub build_ism:
         Arc<Mutex<HashMap<H256, VecDeque<eyre::Result<Box<dyn InterchainSecurityModule>>>>>>,
     pub build_routing_ism: ResponseList<eyre::Result<Box<dyn RoutingIsm>>>,

--- a/rust/main/agents/relayer/src/test_utils/mock_ism.rs
+++ b/rust/main/agents/relayer/src/test_utils/mock_ism.rs
@@ -64,10 +64,7 @@ impl InterchainSecurityModule for MockInterchainSecurityModule {
             .lock()
             .unwrap()
             .pop_front()
-            .expect(&format!(
-                "No mock dry_run_verify response set {}",
-                self.address
-            ))
+            .unwrap_or_else(|| panic!("No mock dry_run_verify response set {}", self.address))
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/provider/recipient/tests.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/provider/recipient/tests.rs
@@ -33,7 +33,7 @@ fn test_identify_recipient_in_complex_transaction(
     let json = read_json(transaction_file);
     let transaction = transaction(&json);
     let mailbox_address = decode_h256(mailbox).unwrap();
-    let provider = RecipientProvider::new(&vec![mailbox_address]);
+    let provider = RecipientProvider::new(&[mailbox_address]);
 
     let warp_route_address = decode_h256(warp_route).unwrap();
 
@@ -51,7 +51,7 @@ fn test_identify_recipient_in_igp_transaction() {
     let transaction = transaction_with_igp();
     let igp_master = "DrFtxirPPsfdY4HQiNZj2A9o4Ux7JaL3gELANgAoihhp";
     let igp_master_address = decode_h256(igp_master).unwrap();
-    let provider = RecipientProvider::new(&vec![igp_master_address]);
+    let provider = RecipientProvider::new(&[igp_master_address]);
 
     let igp_address = decode_h256("GwHaw8ewMyzZn9vvrZEnTEAAYpLdkGYs195XWcLDCN4U").unwrap();
 
@@ -69,7 +69,7 @@ fn test_identify_recipient_in_alternative_igp_transaction() {
     let transaction = transaction_with_alternative_igp();
     let igp_master = "DrFtxirPPsfdY4HQiNZj2A9o4Ux7JaL3gELANgAoihhp";
     let igp_master_address = decode_h256(igp_master).unwrap();
-    let provider = RecipientProvider::new(&vec![igp_master_address]);
+    let provider = RecipientProvider::new(&[igp_master_address]);
 
     let igp_address = decode_h256("GwHaw8ewMyzZn9vvrZEnTEAAYpLdkGYs195XWcLDCN4U").unwrap();
 
@@ -87,7 +87,7 @@ fn test_failure_to_identify_recipient_transaction_with_native() {
     let transaction = transaction_with_native_programs_only();
     let igp_master = "DrFtxirPPsfdY4HQiNZj2A9o4Ux7JaL3gELANgAoihhp";
     let igp_master_address = decode_h256(igp_master).unwrap();
-    let provider = RecipientProvider::new(&vec![igp_master_address]);
+    let provider = RecipientProvider::new(&[igp_master_address]);
 
     // when
     let recipient = provider.recipient(&H512::zero(), &transaction);

--- a/rust/main/helm/hyperlane-agent/templates/external-secret.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/external-secret.yaml
@@ -35,7 +35,7 @@ spec:
         HYP_CHAINS_{{ .name | upper }}_PRIORITYFEEORACLE_URL: {{ printf "'{{ .%s_helius }}'" .name }}
         {{- end }}
         {{- if eq ((.transactionSubmitter).url) "helius" }}
-        HYP_CHAINS_{{ .name | upper }}_TRANSACTIONSUBMITTER_URL: {{ printf "'{{ .%s_helius }}'" .name }}
+        HYP_CHAINS_{{ .name | upper }}_TRANSACTIONSUBMITTER_URLS: {{ printf "'{{ .%s_helius }}'" .name }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -325,26 +325,18 @@ fn parse_transaction_submitter_config(
                     .chain(err)
                     .get_opt_key("transactionSubmitter")
                     .get_opt_key("urls")
-                    .into_array_iter()
-                    .map(|arr_iter| {
-                        arr_iter
-                            .filter_map(|v| v.parse_from_str("Invalid url").ok())
-                            .collect()
-                    })
+                    .parse_string()
+                    .map(|str| str.split(",").map(|s| s.to_owned()).collect())
                     .unwrap_or_default();
                 Some(h_sealevel::config::TransactionSubmitterConfig::Rpc { urls })
             }
             "jito" => {
-                let urls: Vec<_> = chain
+                let urls: Vec<String> = chain
                     .chain(err)
                     .get_opt_key("transactionSubmitter")
                     .get_opt_key("urls")
-                    .into_array_iter()
-                    .map(|arr_iter| {
-                        arr_iter
-                            .filter_map(|v| v.parse_from_str("Invalid url").ok())
-                            .collect()
-                    })
+                    .parse_string()
+                    .map(|str| str.split(",").map(|s| s.to_owned()).collect())
                     .unwrap_or_default();
                 Some(h_sealevel::config::TransactionSubmitterConfig::Jito { urls })
             }


### PR DESCRIPTION
### Description

- Makes transaction submitter URLs comma separated
- Updates helm to pass in URLs using the correct env var name. Does not try to actually have a fallback here or anything

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
