### PR TITLE
chore: Upgrade Scraper to latest mainstream image

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -760,7 +760,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'a76dd09-20250325-111203',
+      tag: 'c03278b-20250326-170423',
     },
     resources: scraperResources,
   },

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -283,7 +283,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'af7146e-20250314-172005',
+      tag: 'c03278b-20250326-170423',
     },
     resources: scraperResources,
   },


### PR DESCRIPTION
### Description

Upgrade scraper to latest mainstream image c03278b-20250326-170423. It includes configurable timeout for Sealevel RPC client as well as Sealevel fallback provider

### Backward compatibility

Yes

### Testing

Testnet environment