### PR TITLE
refactor: Optimize TokenType derivation with caching and parallelization

### DIFF
--- a/.changeset/rotten-emus-try.md
+++ b/.changeset/rotten-emus-try.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Optimize deriveTokenType method with caching and batch processing

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -49,6 +49,8 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
   evmHookReader: EvmHookReader;
   evmIsmReader: EvmIsmReader;
 
+  private static tokenTypeCache: Map<Address, TokenType> = new Map();
+
   constructor(
     protected readonly multiProvider: MultiProvider,
     protected readonly chain: ChainNameOrId,
@@ -94,79 +96,105 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
    * @returns The derived token type, which can be one of: collateralVault, collateral, native, or synthetic.
    */
   async deriveTokenType(warpRouteAddress: Address): Promise<TokenType> {
-    const contractTypes: Partial<
-      Record<TokenType, { factory: any; method: string }>
-    > = {
-      [TokenType.collateralVaultRebase]: {
-        factory: HypERC4626Collateral__factory,
-        method: 'NULL_RECIPIENT',
-      },
-      [TokenType.collateralVault]: {
-        factory: HypERC4626OwnerCollateral__factory,
-        method: 'vault',
-      },
-      [TokenType.XERC20Lockbox]: {
-        factory: HypXERC20Lockbox__factory,
-        method: 'lockbox',
-      },
-      [TokenType.collateral]: {
-        factory: HypERC20Collateral__factory,
-        method: 'wrappedToken',
-      },
-      [TokenType.syntheticRebase]: {
-        factory: HypERC4626__factory,
-        method: 'collateralDomain',
-      },
-      [TokenType.synthetic]: {
-        factory: HypERC20__factory,
-        method: 'decimals',
-      },
-    };
+    const cached = EvmERC20WarpRouteReader.tokenTypeCache.get(warpRouteAddress);
+    if (cached) return cached;
 
     // Temporarily turn off SmartProvider logging
     // Provider errors are expected because deriving will call methods that may not exist in the Bytecode
     this.setSmartProviderLogLevel('silent');
 
-    // First, try checking token specific methods
-    for (const [tokenType, { factory, method }] of Object.entries(
-      contractTypes,
-    )) {
-      try {
-        const warpRoute = factory.connect(warpRouteAddress, this.provider);
-        await warpRoute[method]();
-        if (tokenType === TokenType.collateral) {
-          const wrappedToken = await warpRoute.wrappedToken();
-          const xerc20 = IXERC20__factory.connect(wrappedToken, this.provider);
-          try {
-            await xerc20['mintingCurrentLimitOf(address)'](warpRouteAddress);
-            return TokenType.XERC20;
-            // eslint-disable-next-line no-empty
-          } catch {}
-        }
-        return tokenType as TokenType;
-      } catch {
-        continue;
-      } finally {
-        this.setSmartProviderLogLevel(getLogLevel()); // returns to original level defined by rootLogger
-      }
-    }
-
-    // Finally check native
-    // Using estimateGas to send 0 wei. Success implies that the Warp Route has a receive() function
     try {
-      await this.multiProvider.estimateGas(
-        this.chain,
-        {
-          to: warpRouteAddress,
-          value: BigNumber.from(0),
-        },
-        NON_ZERO_SENDER_ADDRESS, // Use non-zero address as signer is not provided for read commands
-      );
-      return TokenType.native;
-    } catch (e) {
-      throw Error(`Error accessing token specific method ${e}`);
+      const contracts: Partial<Record<TokenType, any>> = {
+        [TokenType.collateralVaultRebase]:
+          HypERC4626Collateral__factory.connect(
+            warpRouteAddress,
+            this.provider,
+          ),
+        [TokenType.collateralVault]: HypERC4626OwnerCollateral__factory.connect(
+          warpRouteAddress,
+          this.provider,
+        ),
+        [TokenType.XERC20Lockbox]: HypXERC20Lockbox__factory.connect(
+          warpRouteAddress,
+          this.provider,
+        ),
+        [TokenType.collateral]: HypERC20Collateral__factory.connect(
+          warpRouteAddress,
+          this.provider,
+        ),
+        [TokenType.syntheticRebase]: HypERC4626__factory.connect(
+          warpRouteAddress,
+          this.provider,
+        ),
+        [TokenType.synthetic]: HypERC20__factory.connect(
+          warpRouteAddress,
+          this.provider,
+        ),
+      };
+
+      // Batch all method calls together
+      const results = await Promise.allSettled([
+        contracts[TokenType.collateralVaultRebase]
+          .NULL_RECIPIENT()
+          .then(() => TokenType.collateralVaultRebase),
+        contracts[TokenType.collateralVault]
+          .vault()
+          .then(() => TokenType.collateralVault),
+        contracts[TokenType.XERC20Lockbox]
+          .lockbox()
+          .then(() => TokenType.XERC20Lockbox),
+        contracts[TokenType.collateral]
+          .wrappedToken()
+          .then(async (wrappedToken: Address) => {
+            try {
+              const xerc20 = IXERC20__factory.connect(
+                wrappedToken,
+                this.provider,
+              );
+              await xerc20['mintingCurrentLimitOf(address)'](warpRouteAddress);
+              return TokenType.XERC20;
+            } catch {
+              return TokenType.collateral;
+            }
+          }),
+        contracts[TokenType.syntheticRebase]
+          .collateralDomain()
+          .then(() => TokenType.syntheticRebase),
+        contracts[TokenType.synthetic]
+          .decimals()
+          .then(() => TokenType.synthetic),
+      ]);
+
+      // Find the first successful result and cache it
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          const tokenType = result.value;
+          EvmERC20WarpRouteReader.tokenTypeCache.set(
+            warpRouteAddress,
+            tokenType,
+          );
+          return tokenType;
+        }
+      }
+
+      // Check native last (only if all others fail)
+      try {
+        await this.multiProvider.estimateGas(
+          this.chain,
+          {
+            to: warpRouteAddress,
+            value: BigNumber.from(0),
+          },
+          NON_ZERO_SENDER_ADDRESS, // Use non-zero address as signer is not provided for read commands
+        );
+        const type = TokenType.native;
+        EvmERC20WarpRouteReader.tokenTypeCache.set(warpRouteAddress, type);
+        return type;
+      } catch (e) {
+        throw Error(`Unable to determine token type: ${e}`);
+      }
     } finally {
-      this.setSmartProviderLogLevel(getLogLevel()); // returns to original level defined by rootLogger
+      this.setSmartProviderLogLevel(getLogLevel());
     }
   }
 


### PR DESCRIPTION
### Description

This PR optimizes the `deriveTokenType` method in the `EvmERC20WarpRouteReader` class by implementing two key improvements:
1. Static Token Type Cache: Added a memory cache for derived `TokenType` to avoid redundant contract calls for previously queried warp route addresses
2. Parallel Contract Method Execution: Replaced `for loop` contract calls with `Promise.allSettled` for parallelization

This significantly improves performance for token type derivation is important for `warp` commands:

| Command                    | Before                                         | After                                        |
|---------------------------------------|-----------------------------------------------|----------------------------------------------|
| Warp Read  ETH/alfajores-sepolia      | 6:54 (m:ss)                          | 1:11 (m:ss)                         |
| Warp Deploy - enrollRemoteRoutes ETH/sepolia-starknetsepolia (native>synthetic) | 28:00 (m:ss) (derive token type called twice)  | 2:40 (m:ss) (derive token type called once due to caching) |


### Drive-by changes

1. Refactored code structure with cleaner organization
2. Improved code readability by removing nested try/catch blocks

### Related issues

None

### Backward compatibility

Yes

### Testing

Manual with performance timing measurements using `console.time`
