### PR TITLE
feat: add eslint custom rules

### DIFF
--- a/.changeset/nervous-rabbits-explain.md
+++ b/.changeset/nervous-rabbits-explain.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/utils': minor
+---
+
+implement custom ESLint rule for restricted imports from exports

--- a/typescript/utils/package.json
+++ b/typescript/utils/package.json
@@ -49,7 +49,10 @@
     "test:ci": "yarn test"
   },
   "type": "module",
-  "exports": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./eslint-rules": "./dist/eslint-rules/index.js"
+  },
   "types": "./dist/index.d.ts",
   "files": [
     "/dist"

--- a/typescript/utils/src/eslint-rules/index.ts
+++ b/typescript/utils/src/eslint-rules/index.ts
@@ -1,0 +1,8 @@
+import noRestrictedImportsFromExports from './no-restricted-imports-from-exports.js';
+
+export const importRestrictionsPlugin = {
+  name: '@hyperlane/import-restrictions',
+  rules: {
+    'no-restricted-imports-from-exports': noRestrictedImportsFromExports,
+  },
+};

--- a/typescript/utils/src/eslint-rules/no-restricted-imports-from-exports.test.ts
+++ b/typescript/utils/src/eslint-rules/no-restricted-imports-from-exports.test.ts
@@ -1,0 +1,343 @@
+import { expect } from 'chai';
+import { Rule } from 'eslint';
+import fs from 'fs';
+import path from 'path';
+import sinon from 'sinon';
+
+import rule from './no-restricted-imports-from-exports.js';
+
+interface ImportVerificationOptions {
+  sourceFile: string;
+  importPath: string;
+  expectedError?: string | undefined;
+  shouldPass?: boolean;
+  options?: Record<string, unknown>;
+}
+
+interface PathMappings {
+  [key: string]: string;
+}
+
+interface ExportedFileContents {
+  [key: string]: string;
+}
+
+describe('no-restricted-imports-from-exports rule', () => {
+  // Mock file contents to simulate index exports
+  const exportedFileContents: ExportedFileContents = {
+    './src/index.ts':
+      "export { componentA } from './components/componentA';\nexport { componentB } from './components/componentB';",
+    './src/index-fs.ts': "export { fileUtil } from './utils/fileUtil';",
+  };
+
+  // Path mapping for test fixtures
+  const pathMappings: PathMappings = {
+    './src/index.ts': './src/index.ts',
+    './src/index-fs.ts': './src/index-fs.ts',
+
+    'components/componentA': './src/components/componentA',
+    'components/componentB': './src/components/componentB',
+    'components/nested/componentA': './src/components/nested/componentA',
+
+    'utils/fileUtil': './src/utils/fileUtil',
+    'utils/otherUtil': './src/utils/otherUtil',
+  };
+
+  function setupStubs(): void {
+    // Stub fs.readFileSync to return mock file contents
+    sinon
+      .stub(fs, 'readFileSync')
+      .callsFake((filePath: fs.PathOrFileDescriptor) =>
+        typeof filePath === 'string'
+          ? exportedFileContents[filePath] || ''
+          : '',
+      );
+
+    // Stub path.resolve to simplify path resolution in tests
+    sinon
+      .stub(path, 'resolve')
+      .callsFake(function (...args: unknown[]): string {
+        const lastArg = args[args.length - 1];
+
+        if (typeof lastArg !== 'string') {
+          return String(lastArg);
+        }
+
+        for (const [pattern, mapping] of Object.entries(pathMappings)) {
+          if (lastArg.includes(pattern)) {
+            return mapping;
+          }
+        }
+
+        return lastArg;
+      });
+
+    sinon
+      .stub(path, 'dirname')
+      .callsFake((filePath: string) =>
+        filePath.substring(0, filePath.lastIndexOf('/') || 0),
+      );
+  }
+
+  // Helper function to test import validations in different scenarios
+  function verifyImport({
+    sourceFile,
+    importPath,
+    expectedError,
+    shouldPass = false,
+    options = {},
+  }: ImportVerificationOptions): void {
+    const errors: Array<{ messageId: string }> = [];
+    const context = {
+      getFilename: () => sourceFile,
+      cwd: () => '.',
+      report: (err: { messageId: string }) => errors.push(err),
+      options: [options],
+    } as unknown as Rule.RuleContext;
+
+    const ruleInstance = rule.create(context);
+    if (ruleInstance?.ImportDeclaration) {
+      ruleInstance.ImportDeclaration({
+        type: 'ImportDeclaration',
+        source: {
+          type: 'Literal',
+          value: importPath,
+          raw: `'${importPath}'`,
+        },
+        specifiers: [],
+        parent: {} as Rule.Node,
+      });
+    }
+
+    if (expectedError || !shouldPass) {
+      expect(errors.length).to.equal(
+        1,
+        `Import from ${sourceFile} to ${importPath} should report an error`,
+      );
+      if (expectedError) {
+        expect(errors[0].messageId).to.equal(
+          expectedError,
+          `Import should report error type ${expectedError}`,
+        );
+      }
+    } else {
+      expect(errors.length).to.equal(
+        0,
+        `Import from ${sourceFile} to ${importPath} should not report any errors`,
+      );
+    }
+  }
+
+  beforeEach(() => {
+    setupStubs();
+  });
+
+  afterEach(() => {
+    // Restore all stubs
+    sinon.restore();
+  });
+
+  describe('Non-exported files - Files not included in index exports', () => {
+    it('should allow importing node modules in non-exported files', () => {
+      verifyImport({
+        sourceFile: './src/other.ts',
+        importPath: 'fs',
+        shouldPass: true,
+      });
+    });
+
+    it('should allow importing any modules in non-exported files without restrictions', () => {
+      const sourceFile = './src/other.ts';
+
+      verifyImport({
+        sourceFile,
+        importPath: './components/other',
+        shouldPass: true,
+      });
+
+      verifyImport({
+        sourceFile,
+        importPath: './utils/fileUtil',
+        shouldPass: true,
+      });
+
+      verifyImport({
+        sourceFile,
+        importPath: 'path',
+        shouldPass: true,
+      });
+    });
+  });
+
+  describe('Exported files - Files that are exported through index.ts', () => {
+    const exportedComponentFile = './src/components/componentA.ts';
+
+    it('should allow importing regular modules from exported files', () => {
+      verifyImport({
+        sourceFile: exportedComponentFile,
+        importPath: './components/other',
+        shouldPass: true,
+      });
+    });
+
+    it('should disallow importing node modules from exported files to prevent side effects', () => {
+      verifyImport({
+        sourceFile: exportedComponentFile,
+        importPath: 'fs',
+        expectedError: 'restrictedNodeImport',
+      });
+
+      verifyImport({
+        sourceFile: exportedComponentFile,
+        importPath: 'path',
+        expectedError: 'restrictedNodeImport',
+      });
+
+      verifyImport({
+        sourceFile: exportedComponentFile,
+        importPath: 'crypto',
+        expectedError: 'restrictedNodeImport',
+      });
+    });
+
+    it('should disallow importing from fs-indexed modules in exported components', () => {
+      verifyImport({
+        sourceFile: exportedComponentFile,
+        importPath: './utils/fileUtil',
+        expectedError: 'restrictedFsImport',
+      });
+    });
+
+    it('should handle relative imports correctly and detect restricted fs imports', () => {
+      verifyImport({
+        sourceFile: exportedComponentFile,
+        importPath: '../utils/fileUtil',
+        expectedError: 'restrictedFsImport',
+      });
+    });
+
+    it('should allow importing scoped packages even from exported components', () => {
+      verifyImport({
+        sourceFile: exportedComponentFile,
+        importPath: '@scoped/fs-module',
+        shouldPass: true,
+      });
+    });
+
+    it('should allow files exported from index-fs.ts to import node modules directly', () => {
+      const fileUtilPath = './src/utils/fileUtil.ts';
+
+      verifyImport({
+        sourceFile: fileUtilPath,
+        importPath: 'fs',
+        shouldPass: true,
+      });
+
+      verifyImport({
+        sourceFile: fileUtilPath,
+        importPath: 'crypto',
+        shouldPass: true,
+      });
+    });
+  });
+
+  describe('Edge cases', () => {
+    const exportedComponentFile = './src/components/componentA.ts';
+
+    it('should handle subpaths of node modules correctly and restrict them in exported files', () => {
+      verifyImport({
+        sourceFile: exportedComponentFile,
+        importPath: 'fs/promises',
+        expectedError: 'restrictedNodeImport',
+      });
+
+      verifyImport({
+        sourceFile: exportedComponentFile,
+        importPath: 'path/posix',
+        expectedError: 'restrictedNodeImport',
+      });
+    });
+
+    it('should allow similarly named packages that are not actual node modules', () => {
+      verifyImport({
+        sourceFile: exportedComponentFile,
+        importPath: 'fstest',
+        shouldPass: true,
+      });
+
+      verifyImport({
+        sourceFile: exportedComponentFile,
+        importPath: 'fs-test',
+        shouldPass: true,
+      });
+
+      verifyImport({
+        sourceFile: exportedComponentFile,
+        importPath: 'path-extra',
+        shouldPass: true,
+      });
+    });
+
+    it('should handle non-existent files gracefully without throwing errors', () => {
+      verifyImport({
+        sourceFile: exportedComponentFile,
+        importPath: './non-existent-file',
+        shouldPass: true,
+      });
+    });
+  });
+
+  describe('Custom entry points', () => {
+    const customExportedFileContents: ExportedFileContents = {
+      './src/main.ts':
+        "export { customComponent } from './components/customComponent';",
+      './src/restricted.ts':
+        "export { restrictedUtil } from './utils/restrictedUtil';",
+    };
+
+    beforeEach(() => {
+      // Add custom file contents to the existing exportedFileContents
+      Object.assign(exportedFileContents, customExportedFileContents);
+
+      // Add custom path mappings
+      Object.assign(pathMappings, {
+        './src/main.ts': './src/main.ts',
+        './src/restricted.ts': './src/restricted.ts',
+        'components/customComponent': './src/components/customComponent',
+        'utils/restrictedUtil': './src/utils/restrictedUtil',
+      });
+    });
+
+    it('should respect custom main and restricted entry points', () => {
+      const options = {
+        mainEntry: './src/main.ts',
+        restrictedEntry: './src/restricted.ts',
+      };
+
+      // Test with custom entry points
+      verifyImport({
+        sourceFile: './src/components/customComponent.ts',
+        importPath: './utils/restrictedUtil',
+        expectedError: 'restrictedFsImport',
+        options,
+      });
+
+      // Should still work for node modules
+      verifyImport({
+        sourceFile: './src/components/customComponent.ts',
+        importPath: 'fs',
+        expectedError: 'restrictedNodeImport',
+        options,
+      });
+    });
+
+    it('should fall back to defaults when no options provided', () => {
+      // Test with default entry points
+      verifyImport({
+        sourceFile: './src/components/componentA.ts',
+        importPath: './utils/fileUtil',
+        expectedError: 'restrictedFsImport',
+      });
+    });
+  });
+});

--- a/typescript/utils/src/eslint-rules/no-restricted-imports-from-exports.ts
+++ b/typescript/utils/src/eslint-rules/no-restricted-imports-from-exports.ts
@@ -1,0 +1,191 @@
+import { Rule } from 'eslint';
+import fs from 'fs';
+import path from 'path';
+
+const NODE_BUILTIN_MODULES = [
+  'fs',
+  'path',
+  'child_process',
+  'os',
+  'process',
+  'http',
+  'https',
+  'net',
+  'dgram',
+  'dns',
+  'crypto',
+  'tls',
+  'cluster',
+  'stream',
+  'vm',
+  'readline',
+] as const;
+
+type NodeBuiltinModule = (typeof NODE_BUILTIN_MODULES)[number];
+
+interface RuleOptions {
+  mainEntry?: string;
+  restrictedEntry?: string;
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow client-restricted imports in files exported from specified entry points',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    messages: {
+      restrictedFsImport:
+        'Files exported from {{ mainEntry }} should not import "{{ moduleName }}" which is exported from {{ restrictedEntry }}',
+      restrictedNodeImport:
+        'Files exported from {{ mainEntry }} should not import Node.js built-in module "{{ moduleName }}"',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          mainEntry: {
+            type: 'string',
+            default: './src/index.ts',
+          },
+          restrictedEntry: {
+            type: 'string',
+            default: './src/index-fs.ts',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context: Rule.RuleContext): Rule.RuleListener {
+    const options = (context.options[0] || {}) as RuleOptions;
+    const mainEntry = options.mainEntry || './src/index.ts';
+    const restrictedEntry = options.restrictedEntry || './src/index-fs.ts';
+
+    const resolvePathFromCwd = (relativePath: string): string =>
+      path.resolve(context.cwd, relativePath);
+
+    const extractNamedExports = (content: string): string[] => {
+      const exportBlocks = content.match(/export\s+\{[^}]+\}/g) || [];
+      const namedExports =
+        exportBlocks.join(' ').match(/[a-zA-Z0-9_]+(?=\s*[,}])/g) || [];
+      return namedExports.map((name) => name.trim());
+    };
+
+    const extractReExports = (content: string, basePath: string): string[] => {
+      const reExportMatches =
+        content.match(/export\s+(?:[\s\S]*?)\s+from\s+['"](.+)['"]/g) || [];
+
+      const reExportPaths = reExportMatches
+        .map((match) => {
+          const pathMatch = match.match(/from\s+['"](.+)['"]/);
+          return pathMatch ? pathMatch[1] : null;
+        })
+        .filter(
+          (path): path is string =>
+            path !== null && (path.startsWith('./') || path.startsWith('../')),
+        );
+
+      return reExportPaths.map((exportPath) => {
+        const resolvedPath = exportPath.endsWith('.js')
+          ? exportPath.replace(/\.js$/, '.ts')
+          : exportPath;
+
+        return path.resolve(path.dirname(basePath), resolvedPath);
+      });
+    };
+
+    const extractExportsFromFile = (filePath: string): string[] => {
+      try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        return [
+          ...extractNamedExports(content),
+          ...extractReExports(content, filePath),
+        ];
+      } catch (error) {
+        return [];
+      }
+    };
+
+    const isPathPartOfExport = (
+      filePath: string,
+      exportPath: string,
+    ): boolean =>
+      typeof exportPath === 'string' &&
+      exportPath.includes('/') &&
+      filePath.includes(exportPath.replace(/\.ts$/, ''));
+
+    const indexTsPath = resolvePathFromCwd(mainEntry);
+    const indexFsPath = resolvePathFromCwd(restrictedEntry);
+
+    const indexExports = extractExportsFromFile(indexTsPath);
+    const fsIndexExports = extractExportsFromFile(indexFsPath);
+
+    const isFileExportedFromIndex = (filePath: string): boolean =>
+      indexExports.some((exportPath) =>
+        isPathPartOfExport(filePath, exportPath),
+      );
+
+    const isExportedFromFsIndex = (importPath: string): boolean =>
+      fsIndexExports.some((fsExport) =>
+        isPathPartOfExport(importPath, fsExport),
+      );
+
+    const isNodeBuiltinModuleOrSubpath = (importSource: string): boolean => {
+      if (NODE_BUILTIN_MODULES.includes(importSource as NodeBuiltinModule)) {
+        return true;
+      }
+
+      const parts = importSource.split('/');
+      return (
+        NODE_BUILTIN_MODULES.includes(parts[0] as NodeBuiltinModule) &&
+        parts.length > 1
+      );
+    };
+
+    return {
+      ImportDeclaration(node: Rule.Node): void {
+        const currentFilePath = context.getFilename();
+
+        if (!isFileExportedFromIndex(currentFilePath)) return;
+
+        const importSource = (node as any).source.value;
+
+        if (isNodeBuiltinModuleOrSubpath(importSource)) {
+          context.report({
+            node,
+            messageId: 'restrictedNodeImport',
+            data: {
+              moduleName: importSource,
+              mainEntry,
+            },
+          });
+        }
+
+        if (typeof importSource === 'string' && importSource.startsWith('.')) {
+          const resolvedImportPath = path.resolve(
+            path.dirname(currentFilePath),
+            importSource,
+          );
+
+          if (isExportedFromFsIndex(resolvedImportPath)) {
+            context.report({
+              node,
+              messageId: 'restrictedFsImport',
+              data: {
+                moduleName: importSource,
+                mainEntry,
+                restrictedEntry,
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/typescript/utils/tsconfig.json
+++ b/typescript/utils/tsconfig.json
@@ -4,6 +4,6 @@
     "outDir": "./dist/",
     "rootDir": "./src"
   },
-  "exclude": ["./node_modules/", "./dist/", "./tmp.ts"],
-  "include": ["./src/*.ts"]
+  "exclude": ["./node_modules/", "./dist/", "./tmp.ts", "./src/**/*.test.ts"],
+  "include": ["./src/*.ts", "./src/eslint-rules/*.ts"]
 }


### PR DESCRIPTION
# Description
Added a custom ESLint rule to enforce import restrictions in exported files, particularly focusing on preventing Node.js built-in modules and filesystem-related imports in client-facing code. This helps maintain a clear separation between client and server-side code.

Key changes:
- Added new ESLint rule `no-restricted-imports-from-exports` to enforce import restrictions
- Updated package exports to include ESLint rules
- Modified TypeScript configuration to include ESLint rule files
- Added comprehensive test suite for the new rule

# Drive-by changes
- Added new directory structure for ESLint rules under `src/eslint-rules/`
- Updated `package.json` exports to expose ESLint rules
- Modified `tsconfig.json` to include ESLint rule files and exclude test files
- Added extensive test coverage with various scenarios and edge cases

# Related issues
resolves https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5770
requirement for https://github.com/hyperlane-xyz/hyperlane-registry/issues/686

# Backward compatibility
This change is backward compatible as it:
- Only adds new exports without modifying existing functionality
- Maintains existing package structure and exports
- Adds new ESLint rules as an optional feature that can be enabled by consumers

# Testing
- Added comprehensive test suite covering:
  - Non-exported files behavior
  - Exported files restrictions
  - Node.js built-in module restrictions
  - Filesystem-related import restrictions
  - Edge cases and custom entry points
- Tested locally with `yarn link` in the registry repo
- Verified build process includes ESLint rule files
- Added unit tests for various import scenarios
- Tested with custom entry points and path mappings