### PR TITLE
chore(ci): set yarn unit test timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,7 @@ jobs:
   yarn-test:
     runs-on: ubuntu-latest
     needs: [yarn-install]
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Description

chore(ci): set yarn unit test timeout
- default is 6hours, so we reduce this to 10 mins
	- test time is usually 5-7mins
- avoid spinning unnecessarily like https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/14090330834/job/39465209656

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
