### PR TITLE
feat(submitter): near complete Building Stage implementation

### DIFF
--- a/rust/main/hyperlane-base/src/db/error.rs
+++ b/rust/main/hyperlane-base/src/db/error.rs
@@ -25,6 +25,9 @@ pub enum DbError {
     /// Hyperlane Error
     #[error("{0}")]
     HyperlaneError(#[from] HyperlaneProtocolError),
+    /// Custom error
+    #[error("{0}")]
+    Other(String),
 }
 
 impl From<DbError> for ChainCommunicationError {

--- a/rust/main/submitter/src/payload/types.rs
+++ b/rust/main/submitter/src/payload/types.rs
@@ -24,6 +24,12 @@ pub struct PayloadDetails {
     success_criteria: Option<(Vec<u8>, Address)>,
 }
 
+impl PayloadDetails {
+    pub fn id(&self) -> &PayloadId {
+        &self.id
+    }
+}
+
 /// Full details about a payload. This is instantiated by the caller of PayloadDispatcher
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq, Eq, Default)]
 pub struct FullPayload {
@@ -59,6 +65,7 @@ pub enum PayloadStatus {
 pub enum DropReason {
     FailedSimulation,
     Reverted,
+    UnhandledError,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq, Eq)]

--- a/rust/main/submitter/src/payload_dispatcher/building_stage.rs
+++ b/rust/main/submitter/src/payload_dispatcher/building_stage.rs
@@ -26,12 +26,6 @@ struct BuildingStage {
     state: PayloadDispatcherState,
 }
 
-// - Event-driven by the Building queue
-// - Calls `simulate_payload(payload)` on ChainTxAdapter to drop bad payloads
-// - Builds txs from payloads via ChainTxAdapter, by calling `build_transactions(payloads)`
-// - Sends txs to the **Inclusion Stage** via its channel
-// - updates the Transaction store, the Payload store, the `payload_id` → `tx_uuid` mapping
-
 impl BuildingStage {
     pub async fn run(&self) {
         loop {
@@ -107,7 +101,6 @@ impl BuildingStage {
         if let Err(err) = self.state.tx_db.store_transaction_by_id(tx).await {
             error!(?err, "Error storing transaction in the database");
         }
-        // update the status of payloads in the payload store
         for payload_detail in tx.payload_details() {
             if let Err(err) = self
                 .state

--- a/rust/main/submitter/src/payload_dispatcher/entrypoint.rs
+++ b/rust/main/submitter/src/payload_dispatcher/entrypoint.rs
@@ -115,7 +115,7 @@ mod tests {
             unimplemented!()
         }
 
-        async fn store_transaction_by_id(&self, _tx: Transaction) -> DbResult<()> {
+        async fn store_transaction_by_id(&self, _tx: &Transaction) -> DbResult<()> {
             unimplemented!()
         }
     }

--- a/rust/main/submitter/src/transaction/db.rs
+++ b/rust/main/submitter/src/transaction/db.rs
@@ -18,7 +18,7 @@ pub trait TransactionDb: Send + Sync {
         -> DbResult<Option<Transaction>>;
 
     /// Store a transaction by its unique ID
-    async fn store_transaction_by_id(&self, tx: Transaction) -> DbResult<()>;
+    async fn store_transaction_by_id(&self, tx: &Transaction) -> DbResult<()>;
 }
 
 #[async_trait]
@@ -30,8 +30,8 @@ impl TransactionDb for HyperlaneRocksDB {
         self.retrieve_value_by_key(TRANSACTION_BY_ID_STORAGE_PREFIX, id)
     }
 
-    async fn store_transaction_by_id(&self, tx: Transaction) -> DbResult<()> {
-        self.store_value_by_key(TRANSACTION_BY_ID_STORAGE_PREFIX, tx.id(), &tx)
+    async fn store_transaction_by_id(&self, tx: &Transaction) -> DbResult<()> {
+        self.store_value_by_key(TRANSACTION_BY_ID_STORAGE_PREFIX, tx.id(), tx)
     }
 }
 


### PR DESCRIPTION
### Description

Implements most missing Building Stage steps described in the [design doc](https://www.notion.so/hyperlanexyz/Relayer-Submitter-Redesign-17b6d35200d68020b516c6c9bc455213?pvs=4#1a56d35200d680f08da4cd70dbf3f965).

Functionally it's only missing the update of the `payload_id`->`transaction_id` db mapping because store hasn't been created yet.

Non-functionally, I added a bunch of failures modes that will need better testing coverage.

### Drive-by changes

- Adds an `Other` enum variant to `DbError` to make it easier to propagate custom errors

### Related issues

- Makes progress on https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5766

### Backward compatibility

Yes

### Testing

Existing unit tests, though more should be added later
