### PR TITLE
fix: pin zksync deps from ccip package

### DIFF
--- a/.changeset/selfish-lizards-play.md
+++ b/.changeset/selfish-lizards-play.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/core': patch
+---
+
+pin zksync deps from ccip package

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -8,6 +8,8 @@
     "@eth-optimism/contracts": "^0.6.0",
     "@hyperlane-xyz/utils": "9.2.1",
     "@layerzerolabs/lz-evm-oapp-v2": "2.0.2",
+    "@matterlabs/hardhat-zksync-solc": "1.2.5",
+    "@matterlabs/hardhat-zksync-verify": "1.7.1",
     "@openzeppelin/contracts": "^4.9.3",
     "@openzeppelin/contracts-upgradeable": "^4.9.3",
     "fx-portal": "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7701,6 +7701,8 @@ __metadata:
     "@hyperlane-xyz/utils": "npm:9.2.1"
     "@layerzerolabs/lz-evm-oapp-v2": "npm:2.0.2"
     "@layerzerolabs/solidity-examples": "npm:^1.1.0"
+    "@matterlabs/hardhat-zksync-solc": "npm:1.2.5"
+    "@matterlabs/hardhat-zksync-verify": "npm:1.7.1"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
     "@nomiclabs/hardhat-waffle": "npm:^2.0.6"
     "@openzeppelin/contracts": "npm:^4.9.3"
@@ -9078,7 +9080,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@matterlabs/hardhat-zksync-solc@npm:^1.2.5":
+"@matterlabs/hardhat-zksync-solc@npm:1.2.5, @matterlabs/hardhat-zksync-solc@npm:^1.2.5":
   version: 1.2.5
   resolution: "@matterlabs/hardhat-zksync-solc@npm:1.2.5"
   dependencies:
@@ -9099,7 +9101,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@matterlabs/hardhat-zksync-verify@npm:^1.6.0":
+"@matterlabs/hardhat-zksync-verify@npm:1.7.1, @matterlabs/hardhat-zksync-verify@npm:^1.6.0":
   version: 1.7.1
   resolution: "@matterlabs/hardhat-zksync-verify@npm:1.7.1"
   dependencies:


### PR DESCRIPTION
### Description

New zksync dependencies 

    "@matterlabs/hardhat-zksync-solc": "1.3.0",
    "@matterlabs/hardhat-zksync-verify": "1.8.0",

introduce a zksync-telemetry package which tries to run husky

This pins them in the solidity package to prevent that
