### PR TITLE
chore: deploy relayers with updated blacklist

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -735,11 +735,6 @@ const blacklistedMessageIds = [
 
 // Blacklist matching list intended to be used by all contexts.
 const blacklist: MatchingList = [
-  {
-    // Eco, who's sending a lot of messages not intended to be processed by the relayer.
-    // A temporary measure to prevent some wasted effort on our relayer.
-    senderAddress: '0xd890d66a0e2530335D10b3dEb5C8Ec8eA1DaB954',
-  },
   ...blacklistedMessageIds.map((messageId) => ({
     messageId,
   })),
@@ -754,7 +749,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '28ca872-20250331-100202',
+      tag: '45739bd-20250401-014114',
     },
     blacklist,
     gasPaymentEnforcement: gasPaymentEnforcement,
@@ -790,7 +785,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '8ab7c80-20250326-191115',
+      tag: '45739bd-20250401-014114',
     },
     blacklist,
     // We're temporarily (ab)using the RC relayer as a way to increase
@@ -824,7 +819,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '7c4f0f2-20250326-180331',
+      tag: '45739bd-20250401-014114',
     },
     blacklist,
     gasPaymentEnforcement,

--- a/typescript/infra/config/environments/mainnet3/aw-validators/hyperlane.json
+++ b/typescript/infra/config/environments/mainnet3/aw-validators/hyperlane.json
@@ -36,9 +36,6 @@
   "astar": {
     "validators": ["0x4d1b2cade01ee3493f44304653d8e352c66ec3e7"]
   },
-  "astarzkevm": {
-    "validators": ["0x89ecdd6caf138934bf3a2fb7b323984d72fd66de"]
-  },
   "aurora": {
     "validators": ["0x37105aec3ff37c7bb0abdb0b1d75112e1e69fa86"]
   },


### PR DESCRIPTION
### Description

- Removes Eco from the blacklist
- This is safe following #5787 

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
