### PR TITLE
fix: add cosmos-types to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY typescript/infra/package.json ./typescript/infra/
 COPY typescript/ccip-server/package.json ./typescript/ccip-server/
 COPY typescript/widgets/package.json ./typescript/widgets/
 COPY typescript/github-proxy/package.json ./typescript/github-proxy/
+COPY typescript/cosmos-types/package.json ./typescript/cosmos-types/
 COPY solidity/package.json ./solidity/
 
 RUN yarn install && yarn cache clean


### PR DESCRIPTION
### Description

fix: add cosmos-types to Dockerfile
- to fix this issue https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/14201525450/job/39791444792#step:8:293

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
