### PR TITLE
fix(test): e2e increate timeout

### DIFF
--- a/rust/main/utils/run-locally/src/cosmosnative/cli.rs
+++ b/rust/main/utils/run-locally/src/cosmosnative/cli.rs
@@ -82,7 +82,7 @@ impl SimApp {
             .arg("rpc.pprof_laddr", &self.pprof_addr) // default is localhost:6060
             .arg("log_level", "panic")
             .spawn("SIMAPP", None);
-        sleep(Duration::from_secs(2));
+        sleep(Duration::from_secs(5));
         node
     }
 


### PR DESCRIPTION
### Description
Increase chain spin up time for cosmos native E2E tests
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
