### PR TITLE
fix: Add timeout to some Cosmos gRPC requests

### DIFF
--- a/rust/main/chains/hyperlane-cosmos-native/src/providers/grpc.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/providers/grpc.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use hyperlane_cosmos_rs::cosmos::base::tendermint::v1beta1::service_client::ServiceClient;
 use hyperlane_cosmos_rs::cosmos::base::tendermint::v1beta1::GetLatestBlockRequest;
 use hyperlane_cosmos_rs::hyperlane::core::interchain_security::v1::{
@@ -25,6 +27,8 @@ use hyperlane_metric::prometheus_metric::{
 use crate::prometheus::metrics_channel::MetricsChannel;
 use crate::{ConnectionConf, HyperlaneCosmosError};
 
+const REQUEST_TIMEOUT: u64 = 30;
+
 /// Grpc Provider
 #[derive(Clone, Debug)]
 pub struct GrpcProvider {
@@ -40,7 +44,8 @@ struct CosmosGrpcClient {
 impl BlockNumberGetter for CosmosGrpcClient {
     async fn get_block_number(&self) -> Result<u64, ChainCommunicationError> {
         let mut client = ServiceClient::new(self.channel.clone());
-        let request = tonic::Request::new(GetLatestBlockRequest {});
+        let mut request = tonic::Request::new(GetLatestBlockRequest {});
+        request.set_timeout(Duration::from_secs(REQUEST_TIMEOUT));
         let response = client
             .get_latest_block(request)
             .await

--- a/rust/main/chains/hyperlane-cosmos-native/src/providers/grpc.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/providers/grpc.rs
@@ -94,6 +94,7 @@ impl GrpcProvider {
         height: Option<u32>,
     ) -> tonic::Request<T> {
         let mut request = request.into_request();
+        request.set_timeout(Duration::from_secs(REQUEST_TIMEOUT));
         if let Some(height) = height {
             request
                 .metadata_mut()

--- a/rust/main/chains/hyperlane-cosmos-native/src/providers/grpc.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/providers/grpc.rs
@@ -79,7 +79,7 @@ impl GrpcProvider {
                     .map(|e| e.timeout(Duration::from_secs(REQUEST_TIMEOUT)))
                     .map(|e| e.connect_timeout(Duration::from_secs(REQUEST_TIMEOUT)))
                     .map(|e| MetricsChannel::new(e.connect_lazy(), metrics.clone(), metrics_config))
-                    .map(|m| CosmosGrpcClient::new(m))
+                    .map(CosmosGrpcClient::new)
                     .map_err(Into::<HyperlaneCosmosError>::into)
             })
             .collect::<Result<Vec<CosmosGrpcClient>, _>>()

--- a/rust/main/chains/hyperlane-cosmos/src/providers/grpc.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/grpc.rs
@@ -1,4 +1,6 @@
-use std::{fmt::Debug, future::Future, time::Instant};
+use std::fmt::Debug;
+use std::future::Future;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use cosmrs::{
@@ -61,6 +63,8 @@ const GAS_ESTIMATE_MULTIPLIER: f64 = 1.25;
 /// The number of blocks in the future in which a transaction will
 /// be valid for.
 const TIMEOUT_BLOCKS: u64 = 1000;
+/// gRPC request timeout
+const REQUEST_TIMEOUT: u64 = 30;
 
 #[derive(Debug, Clone, new)]
 struct CosmosChannel {
@@ -73,7 +77,8 @@ struct CosmosChannel {
 impl CosmosChannel {
     async fn latest_block_height(&self) -> ChainResult<GetLatestBlockResponse> {
         let mut client = ServiceClient::new(self.channel.clone());
-        let request = tonic::Request::new(GetLatestBlockRequest {});
+        let mut request = tonic::Request::new(GetLatestBlockRequest {});
+        request.set_timeout(Duration::from_secs(REQUEST_TIMEOUT));
         let response = client
             .get_latest_block(request)
             .await
@@ -86,7 +91,8 @@ impl CosmosChannel {
         let tx_bytes = payload.to_vec();
         let mut client = TxServiceClient::new(self.channel.clone());
         #[allow(deprecated)]
-        let sim_req = tonic::Request::new(SimulateRequest { tx: None, tx_bytes });
+        let mut sim_req = tonic::Request::new(SimulateRequest { tx: None, tx_bytes });
+        sim_req.set_timeout(Duration::from_secs(REQUEST_TIMEOUT));
         let response = client
             .simulate(sim_req)
             .await
@@ -100,7 +106,8 @@ impl CosmosChannel {
     async fn account_query(&self, account: String) -> ChainResult<QueryAccountResponse> {
         let address = account.clone();
         let mut client = QueryAccountClient::new(self.channel.clone());
-        let request = tonic::Request::new(QueryAccountRequest { address });
+        let mut request = tonic::Request::new(QueryAccountRequest { address });
+        request.set_timeout(Duration::from_secs(REQUEST_TIMEOUT));
         let response = client
             .account(request)
             .await
@@ -114,9 +121,10 @@ impl CosmosChannel {
         account: String,
     ) -> ChainResult<injective_std::types::cosmos::auth::v1beta1::QueryAccountResponse> {
         let address = account.clone();
-        let request = tonic::Request::new(
+        let mut request = tonic::Request::new(
             injective_std::types::cosmos::auth::v1beta1::QueryAccountRequest { address },
         );
+        request.set_timeout(Duration::from_secs(REQUEST_TIMEOUT));
 
         // Borrowed from the logic of `QueryAccountClient` in `cosmrs`, but using injective types.
         let mut grpc_client = tonic::client::Grpc::new(self.channel.clone());
@@ -152,7 +160,8 @@ impl CosmosChannel {
         let denom = denom.clone();
 
         let mut client = QueryBalanceClient::new(self.channel.clone());
-        let balance_request = tonic::Request::new(QueryBalanceRequest { address, denom });
+        let mut balance_request = tonic::Request::new(QueryBalanceRequest { address, denom });
+        balance_request.set_timeout(Duration::from_secs(REQUEST_TIMEOUT));
         let response = client
             .balance(balance_request)
             .await
@@ -173,6 +182,7 @@ impl CosmosChannel {
             address: to,
             query_data: payload.clone(),
         });
+        request.set_timeout(Duration::from_secs(REQUEST_TIMEOUT));
         if let Some(block_height) = block_height {
             request
                 .metadata_mut()
@@ -189,7 +199,8 @@ impl CosmosChannel {
         let to = contract_address.clone();
         let mut client = WasmQueryClient::new(self.channel.clone());
 
-        let request = tonic::Request::new(QueryContractInfoRequest { address: to });
+        let mut request = tonic::Request::new(QueryContractInfoRequest { address: to });
+        request.set_timeout(Duration::from_secs(REQUEST_TIMEOUT));
 
         let response = client
             .contract_info(request)
@@ -228,7 +239,8 @@ impl CosmosChannel {
 impl BlockNumberGetter for CosmosChannel {
     async fn get_block_number(&self) -> ChainResult<u64> {
         let mut client = ServiceClient::new(self.channel.clone());
-        let request = tonic::Request::new(GetLatestBlockRequest {});
+        let mut request = tonic::Request::new(GetLatestBlockRequest {});
+        request.set_timeout(Duration::from_secs(REQUEST_TIMEOUT));
 
         let response = client
             .get_latest_block(request)

--- a/rust/main/chains/hyperlane-cosmos/src/providers/grpc.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/grpc.rs
@@ -329,11 +329,10 @@ impl WasmGrpcProvider {
                 let metrics_config =
                     PrometheusConfig::from_url(&url, ClientConnectionType::Grpc, chain.clone());
                 Endpoint::new(url.to_string())
-                    .map(|e| {
-                        let metrics_channel =
-                            MetricsChannel::new(e.connect_lazy(), metrics.clone(), metrics_config);
-                        CosmosChannel::new(metrics_channel, url)
-                    })
+                    .map(|e| e.timeout(Duration::from_secs(REQUEST_TIMEOUT)))
+                    .map(|e| e.connect_timeout(Duration::from_secs(REQUEST_TIMEOUT)))
+                    .map(|e| MetricsChannel::new(e.connect_lazy(), metrics.clone(), metrics_config))
+                    .map(|m| CosmosChannel::new(m, url))
                     .map_err(Into::<HyperlaneCosmosError>::into)
             })
             .collect();


### PR DESCRIPTION
### Description

Add timeout to Cosmos gRPC requests which we fully control. Some requests are done via a wrapper methods (with BroadcastTxRequest, for example) which do not expose raw Request, so we cannot set timeout on them.

### Related issues

Relayer was hanging indefinitely on request for misbehaving gRPC endpoint. This change is not a remedy, but hopefully we'll get a timeout next time and will be able to switch to a different endpoint.

### Backward compatibility

Yes

### Testing

None
