### PR TITLE
chore: update cosmos package versions only when there are changes

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": true,
-  "fixed": [["@hyperlane-xyz/!(core)|*"]],
+  "fixed": [["@hyperlane-xyz/!(core|cosmos-types|cosmos-sdk)|*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
### Description

chore: update cosmos package versions only when there are changes

Noticed that the recent monorepo release bumped up the cosmos-types's first release version as 11.0.0 to be in line with other packages. This PR proposes to only bump up the package versions for the cosmos-sdk + cosmos-types modules when there are changes - similar to how the current solidity "core" package behaves.

See changesets docs for more info on the `fixed` option: https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#fixed-array-of-arrays-of-package-names

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
