### PR TITLE
chore: move rust caching to depot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,15 +69,6 @@ jobs:
           # check out full history
           fetch-depth: 0
 
-      - name: yarn-cache
-        uses: buildjet/cache@v4
-        with:
-          path: |
-            **/node_modules
-            .yarn
-          key: ${{ runner.os }}-yarn-4.5.1-cache-${{ hashFiles('./yarn.lock') }}
-          fail-on-cache-miss: true
-
       # Build required before linting or the intra-monorepo package cycle checking won't work
       - name: yarn-build
         uses: ./.github/actions/yarn-build-with-cache
@@ -274,7 +265,7 @@ jobs:
         with:
           prefix-key: 'v3-rust-e2e'
           shared-key: ${{ matrix.e2e-type }}
-          cache-provider: 'buildjet'
+          cache-provider: 'github'
           save-if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
           workspaces: |
             ./rust/main


### PR DESCRIPTION
### Description

depot claim:
> we transparently redirect anything bound for GitHub's Actions cache to our own for extra speed

this PR moves the swatinem backend to github, to test whether this redirects to depot on the depot runner

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
