### PR TITLE
fix: remove misleading rust architecture readme comment

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -175,10 +175,6 @@ are merged. Auto-redeploys will be implemented at some future date.
 
 ### Architecture
 
-The on-chain portions of Hyperlane are written in Solidity. The rust portions are
-exclusively off-chain. Later, there may be on-chain rust for Near/Solana/
-Polkadot.
-
 Hyperlane will be managed by a number of small off-chain programs ("agents"). Each
 of these will have a specific role. We want these roles to be simple, and
 easily described. Each of these agents will connect to a home chain and any


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
