### PR TITLE
feat: easy RPC configuration for agents for all chains

### DIFF
--- a/rust/main/agents/relayer/src/settings/mod.rs
+++ b/rust/main/agents/relayer/src/settings/mod.rs
@@ -129,7 +129,8 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
             .parse_from_raw_config::<Settings, RawAgentConf, Option<HashSet<String>>>(
                 relay_chain_names.clone(),
                 "Parsing base config",
-            ).await
+            )
+            .await
             .take_config_err(&mut err);
 
         let db = p

--- a/rust/main/agents/scraper/src/settings.rs
+++ b/rust/main/agents/scraper/src/settings.rs
@@ -61,7 +61,8 @@ impl FromRawConf<RawScraperSettings> for ScraperSettings {
             .parse_from_raw_config::<Settings, RawAgentConf, Option<HashSet<String>>>(
                 chains_names_to_scrape.clone(),
                 "Parsing base config",
-            ).await
+            )
+            .await
             .take_config_err(&mut err);
 
         let db = p

--- a/rust/main/agents/validator/src/settings.rs
+++ b/rust/main/agents/validator/src/settings.rs
@@ -74,7 +74,8 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
             .parse_from_raw_config::<Settings, RawAgentConf, Option<HashSet<String>>>(
                 origin_chain_name_set,
                 "Expected valid base agent configuration",
-            ).await
+            )
+            .await
             .take_config_err(&mut err);
 
         let origin_chain = if let (Some(base), Some(origin_chain_name)) = (&base, origin_chain_name)
@@ -92,7 +93,8 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
             .parse_from_raw_config::<SignerConf, RawAgentSignerConf, NoFilter>(
                 (),
                 "Expected valid validator configuration",
-            ).await
+            )
+            .await
             .end();
 
         let db = p

--- a/rust/main/hyperlane-base/src/agent.rs
+++ b/rust/main/hyperlane-base/src/agent.rs
@@ -23,10 +23,11 @@ pub struct HyperlaneAgentCore {
 }
 
 /// Settings of an agent defined from configuration
+#[async_trait]
 pub trait LoadableFromSettings: AsRef<Settings> + Sized {
     /// Create a new instance of these settings by reading the configs and env
     /// vars.
-    fn load() -> ConfigResult<Self>;
+    async fn load() -> ConfigResult<Self>;
 }
 
 /// A fundamental agent which does not make any assumptions about the tools
@@ -86,7 +87,7 @@ pub async fn agent_main<A: BaseAgent>() -> Result<()> {
 
     let agent_metadata = AgentMetadata::new(git_sha);
 
-    let settings = A::Settings::load()?;
+    let settings = A::Settings::load().await?;
     let core_settings: &Settings = settings.as_ref();
 
     let metrics = settings.as_ref().metrics(A::AGENT_NAME)?;

--- a/rust/main/hyperlane-base/src/settings/loader/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/loader/mod.rs
@@ -17,9 +17,9 @@ mod case_adapter;
 mod environment;
 
 /// Deserialize a settings object from the configs.
-pub fn load_settings<T, R>() -> ConfigResult<R>
+pub async fn load_settings<T, R>() -> ConfigResult<R>
 where
-    T: DeserializeOwned + Debug,
+    T: DeserializeOwned + Debug + Send + 'static,
     R: FromRawConf<T>,
 {
     let root_path = ConfigPath::default();
@@ -124,7 +124,7 @@ where
         })
         .into_config_result(|| root_path.clone())?;
 
-    let res = raw_config.parse_config(&root_path);
+    let res = raw_config.parse_config(&root_path).await;
     if res.is_err() {
         eprintln!("Loaded config for debugging: {formatted_config}");
     }

--- a/rust/main/hyperlane-base/src/settings/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/mod.rs
@@ -99,9 +99,10 @@ pub mod parser;
 #[macro_export]
 macro_rules! impl_loadable_from_settings {
     ($agent:ident, $settingsparser:ident -> $settingsobj:ident) => {
+        #[async_trait]
         impl hyperlane_base::LoadableFromSettings for $settingsobj {
-            fn load() -> hyperlane_core::config::ConfigResult<Self> {
-                hyperlane_base::settings::loader::load_settings::<$settingsparser, Self>()
+            async fn load() -> hyperlane_core::config::ConfigResult<Self> {
+                hyperlane_base::settings::loader::load_settings::<$settingsparser, Self>().await
             }
         }
     };

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -86,7 +86,7 @@ pub fn build_cosmos_connection_conf(
 ) -> Option<ChainConnectionConf> {
     let mut local_err = ConfigParsingError::default();
     let grpcs =
-        parse_base_and_override_urls(chain, "grpcUrls", "customGrpcUrls", "http", &mut local_err);
+        parse_base_and_override_urls(chain, "grpcUrls", "customGrpcUrls", "http", None, &mut local_err);
 
     let chain_id = chain
         .chain(&mut local_err)
@@ -168,7 +168,7 @@ pub fn build_cosmos_native_connection_conf(
 ) -> Option<ChainConnectionConf> {
     let mut local_err = ConfigParsingError::default();
     let grpcs =
-        parse_base_and_override_urls(chain, "grpcUrls", "customGrpcUrls", "http", &mut local_err);
+        parse_base_and_override_urls(chain, "grpcUrls", "customGrpcUrls", "http", None, &mut local_err);
 
     let chain_id = chain
         .chain(&mut local_err)

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -85,8 +85,14 @@ pub fn build_cosmos_connection_conf(
     operation_batch: OperationBatchConfig,
 ) -> Option<ChainConnectionConf> {
     let mut local_err = ConfigParsingError::default();
-    let grpcs =
-        parse_base_and_override_urls(chain, "grpcUrls", "customGrpcUrls", "http", None, &mut local_err);
+    let grpcs = parse_base_and_override_urls(
+        chain,
+        "grpcUrls",
+        "customGrpcUrls",
+        "http",
+        None,
+        &mut local_err,
+    );
 
     let chain_id = chain
         .chain(&mut local_err)
@@ -167,8 +173,14 @@ pub fn build_cosmos_native_connection_conf(
     operation_batch: OperationBatchConfig,
 ) -> Option<ChainConnectionConf> {
     let mut local_err = ConfigParsingError::default();
-    let grpcs =
-        parse_base_and_override_urls(chain, "grpcUrls", "customGrpcUrls", "http", None, &mut local_err);
+    let grpcs = parse_base_and_override_urls(
+        chain,
+        "grpcUrls",
+        "customGrpcUrls",
+        "http",
+        None,
+        &mut local_err,
+    );
 
     let chain_id = chain
         .chain(&mut local_err)

--- a/rust/main/hyperlane-base/src/settings/parser/json_value_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/json_value_parser.rs
@@ -276,7 +276,11 @@ impl<'v> ValueParser<'v> {
     }
 
     /// Use FromRawConf to parse a value.
-    pub async fn parse_from_raw_config<O, T, F>(&self, filter: F, ctx: &'static str) -> ConfigResult<O>
+    pub async fn parse_from_raw_config<O, T, F>(
+        &self,
+        filter: F,
+        ctx: &'static str,
+    ) -> ConfigResult<O>
     where
         O: FromRawConf<T, F>,
         T: Debug + DeserializeOwned + Send + 'static,
@@ -350,14 +354,21 @@ impl<'v, 'e> ParseChain<'e, ValueParser<'v>> {
         )
     }
 
-    pub async fn parse_from_raw_config<O, T, F>(self, filter: F, ctx: &'static str) -> ParseChain<'e, O>
+    pub async fn parse_from_raw_config<O, T, F>(
+        self,
+        filter: F,
+        ctx: &'static str,
+    ) -> ParseChain<'e, O>
     where
         O: FromRawConf<T, F>,
         T: Debug + DeserializeOwned + Send + 'static,
         F: Default + Send + 'static,
     {
         let parsed = match self.0 {
-            Some(v) => v.parse_from_raw_config::<O, T, F>(filter, ctx).await.take_config_err(self.1),
+            Some(v) => v
+                .parse_from_raw_config::<O, T, F>(filter, ctx)
+                .await
+                .take_config_err(self.1),
             None => None,
         };
 

--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -538,7 +538,9 @@ fn parse_base_and_override_urls(
     let overrides = parse_custom_urls(chain, override_key, err);
     let mut combined = overrides.unwrap_or(base);
     if let Some(rpc_urls) = rpc_urls {
-        combined.extend(rpc_urls.into_iter().cloned());
+        let mut new_combined = rpc_urls.clone();
+        new_combined.extend(combined.into_iter());
+        combined = new_combined;
     }
 
     if combined.is_empty() {

--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+use axum::async_trait;
 use convert_case::{Case, Casing};
 use ethers::providers::{Http, Middleware, Provider};
 use eyre::{eyre, Context};
@@ -43,11 +44,12 @@ const DEFAULT_CHUNK_SIZE: u32 = 1999;
 #[serde(transparent)]
 pub struct RawAgentConf(Value);
 
-impl FromRawConf<RawAgentConf, Option<&HashSet<&str>>> for Settings {
+#[async_trait]
+impl FromRawConf<RawAgentConf, Option<HashSet<String>>> for Settings {
     async fn from_config_filtered(
         raw: RawAgentConf,
         cwp: &ConfigPath,
-        filter: Option<&HashSet<&str>>,
+        filter: Option<HashSet<String>>,
     ) -> Result<Self, ConfigParsingError> {
         let mut err = ConfigParsingError::default();
 
@@ -383,6 +385,7 @@ fn parse_signer(signer: ValueParser) -> ConfigResult<SignerConf> {
 #[serde(transparent)]
 pub struct RawAgentSignerConf(Value);
 
+#[async_trait]
 impl FromRawConf<RawAgentSignerConf> for SignerConf {
     async fn from_config_filtered(
         raw: RawAgentSignerConf,

--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -159,7 +159,14 @@ fn parse_chain(
         .unwrap_or(ReorgPeriod::from_blocks(1));
 
     let chain_rpc_urls = rpc_urls.get(&chain_id.unwrap_or_default());
-    let rpcs = parse_base_and_override_urls(&chain, "rpcUrls", "customRpcUrls", "http", chain_rpc_urls, &mut err);
+    let rpcs = parse_base_and_override_urls(
+        &chain,
+        "rpcUrls",
+        "customRpcUrls",
+        "http",
+        chain_rpc_urls,
+        &mut err,
+    );
 
     let from = chain
         .chain(&mut err)
@@ -498,7 +505,8 @@ fn parse_urls(
                     .end()
             })
             .collect_vec()
-        }).unwrap_or_default()
+        })
+        .unwrap_or_default()
 }
 
 fn parse_custom_urls(


### PR DESCRIPTION
### Description

This PR introduces a new common configuration field `rpcUrls` which is a string argument expecting list of comma separated RPC URLs. Regardless of chains, any chain RPC URL can be provided in list and while configuration is loaded each RPC will be queried for its chain id so its utilized within related chain configuration.

This makes configuration very easy, especially for automated deployment environments.

### Drive-by changes

Configuration loading is now async

### Related issues

NA

### Backward compatibility

Changes are backward compatible. Common `rpcUrls` field is optional, when provided URL preferred over chain specific fields so that its easy to configure RPC URLs by default. If common (new) field is not provided RPC URL configuration works as usual.

### Testing

Manual, `rpcUrls` provided and tested
