### PR TITLE
feat: Add getRegistryWithFallback to warp-configs test

### DIFF
--- a/typescript/infra/test/warp-configs.test.ts
+++ b/typescript/infra/test/warp-configs.test.ts
@@ -4,7 +4,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
 import { getRegistry } from '@hyperlane-xyz/registry/fs';
 import { HypTokenRouterConfig, MultiProvider } from '@hyperlane-xyz/sdk';
-import { diffObjMerge, rootLogger } from '@hyperlane-xyz/utils';
+import { rootLogger } from '@hyperlane-xyz/utils';
 
 import { getWarpConfig, warpConfigGetterMap } from '../config/warp.js';
 import {

--- a/typescript/infra/test/warp-configs.test.ts
+++ b/typescript/infra/test/warp-configs.test.ts
@@ -3,7 +3,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
 import { getRegistry } from '@hyperlane-xyz/registry/fs';
-import { MultiProvider } from '@hyperlane-xyz/sdk';
+import { HypTokenRouterConfig, MultiProvider } from '@hyperlane-xyz/sdk';
 import { diffObjMerge, rootLogger } from '@hyperlane-xyz/utils';
 
 import { getWarpConfig, warpConfigGetterMap } from '../config/warp.js';
@@ -24,19 +24,18 @@ const warpIdsToSkip = [
   'USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain',
 ];
 
-async function getRegistryWithFallback(warpRouteId: string) {
+async function getRegistryWithFallback() {
   const getConfigForBranch = async (branch: string) => {
-    const registry = getRegistry({
+    return getRegistry({
       registryUris: [DEFAULT_GITHUB_REGISTRY],
       enableProxy: true,
       logger: rootLogger,
       branch,
-    });
-    return registry.getWarpDeployConfig(warpRouteId);
+    }).getWarpDeployConfigs();
   };
 
   const mainConfig = await getConfigForBranch('main');
-  return mainConfig ?? getConfigForBranch('main~5');
+  return mainConfig ?? getConfigForBranch('main~10');
 }
 describe('Warp Configs', async function () {
   this.timeout(DEFAULT_TIMEOUT);
@@ -46,34 +45,38 @@ describe('Warp Configs', async function () {
   );
 
   let multiProvider: MultiProvider;
-
+  let configsFromGithub;
   before(async function () {
     multiProvider = (await getHyperlaneCore(ENV)).multiProvider;
+    configsFromGithub = await getRegistryWithFallback();
   });
 
   const envConfig = getEnvironmentConfig(ENV);
 
   for (const warpRouteId of warpIdsToCheck) {
     it(`should match Github Registry configs for ${warpRouteId}`, async function () {
-      const configsFromGithub = await getRegistryWithFallback(warpRouteId);
-      const warpConfig = await getWarpConfig(
-        multiProvider,
-        envConfig,
-        warpRouteId,
-      );
-      const { mergedObject, isInvalid } = diffObjMerge(
-        warpConfig,
-        configsFromGithub!, // If null the diff will result in !isInvalid
-      );
-
-      if (isInvalid) {
-        console.log('Differences', JSON.stringify(mergedObject, null, 2));
+      const warpConfig: Record<
+        string,
+        Partial<HypTokenRouterConfig>
+      > = await getWarpConfig(multiProvider, envConfig, warpRouteId);
+      for (const key in warpConfig) {
+        if (warpConfig[key].mailbox) {
+          delete warpConfig[key].mailbox;
+        }
+      }
+      const expectedConfig = configsFromGithub![warpRouteId];
+      for (const key in expectedConfig) {
+        if (expectedConfig[key].mailbox) {
+          delete expectedConfig[key].mailbox;
+        }
       }
 
-      expect(
-        isInvalid,
-        `Registry config does not match Getter for ${warpRouteId}`,
-      ).to.be.false;
+      expect(warpConfig).to.have.keys(Object.keys(expectedConfig));
+      for (const key in warpConfig) {
+        if (warpConfig[key]) {
+          expect(warpConfig[key]).to.deep.equal(expectedConfig[key]);
+        }
+      }
     });
   }
 

--- a/typescript/infra/test/warp-configs.test.ts
+++ b/typescript/infra/test/warp-configs.test.ts
@@ -3,8 +3,12 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
 import { getRegistry } from '@hyperlane-xyz/registry/fs';
-import { HypTokenRouterConfig, MultiProvider } from '@hyperlane-xyz/sdk';
-import { rootLogger } from '@hyperlane-xyz/utils';
+import {
+  HypTokenRouterConfig,
+  MultiProvider,
+  WarpRouteDeployConfig,
+} from '@hyperlane-xyz/sdk';
+import { assert, rootLogger } from '@hyperlane-xyz/utils';
 
 import { getWarpConfig, warpConfigGetterMap } from '../config/warp.js';
 import {
@@ -24,18 +28,13 @@ const warpIdsToSkip = [
   'USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain',
 ];
 
-async function getRegistryWithFallback() {
-  const getConfigForBranch = async (branch: string) => {
-    return getRegistry({
-      registryUris: [DEFAULT_GITHUB_REGISTRY],
-      enableProxy: true,
-      logger: rootLogger,
-      branch,
-    }).getWarpDeployConfigs();
-  };
-
-  const mainConfig = await getConfigForBranch('main');
-  return mainConfig ?? getConfigForBranch('main~10');
+async function getConfigsForBranch(branch: string) {
+  return getRegistry({
+    registryUris: [DEFAULT_GITHUB_REGISTRY],
+    enableProxy: true,
+    logger: rootLogger,
+    branch,
+  }).getWarpDeployConfigs();
 }
 describe('Warp Configs', async function () {
   this.timeout(DEFAULT_TIMEOUT);
@@ -45,10 +44,10 @@ describe('Warp Configs', async function () {
   );
 
   let multiProvider: MultiProvider;
-  let configsFromGithub;
+  let configsFromGithub: Record<string, WarpRouteDeployConfig>;
   before(async function () {
     multiProvider = (await getHyperlaneCore(ENV)).multiProvider;
-    configsFromGithub = await getRegistryWithFallback();
+    configsFromGithub = await getConfigsForBranch('main');
   });
 
   const envConfig = getEnvironmentConfig(ENV);
@@ -64,7 +63,11 @@ describe('Warp Configs', async function () {
           delete warpConfig[key].mailbox;
         }
       }
-      const expectedConfig = configsFromGithub![warpRouteId];
+      const expectedConfig =
+        configsFromGithub[warpRouteId] ??
+        (await getConfigsForBranch('main~10'))[warpRouteId];
+      assert(expectedConfig, `Deploy config not found for ${warpRouteId}`);
+
       for (const key in expectedConfig) {
         if (expectedConfig[key].mailbox) {
           delete expectedConfig[key].mailbox;

--- a/typescript/infra/test/warp-configs.test.ts
+++ b/typescript/infra/test/warp-configs.test.ts
@@ -65,6 +65,7 @@ describe('Warp Configs', async function () {
       }
 
       // Attempt to read the config from main, but fallback to main~10 to decrease test CI failures for old PRs
+      // TODO: remove this when we have stable warp ids
       const expectedConfig =
         configsFromGithub[warpRouteId] ??
         (await getConfigsForBranch('main~10'))[warpRouteId];

--- a/typescript/infra/test/warp-configs.test.ts
+++ b/typescript/infra/test/warp-configs.test.ts
@@ -63,6 +63,8 @@ describe('Warp Configs', async function () {
           delete warpConfig[key].mailbox;
         }
       }
+
+      // Attempt to read the config from main, but fallback to main~10 to decrease test CI failures for old PRs
       const expectedConfig =
         configsFromGithub[warpRouteId] ??
         (await getConfigsForBranch('main~10'))[warpRouteId];


### PR DESCRIPTION
### Description
This PR attempts to solve the issue of updated Registry configs causing unrelated PRs config test to fail. This solution attempts to fetch the config on the `main` branch, and then failling back to `main~10` before finally failing.

### Backward compatibility

Yes

### Testing
Manual/Unit Tests

