### PR TITLE
chore(ci): remove unnecessary cache-to and cache-from

### DIFF
--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -89,7 +89,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           build-args: |
             REGISTRY_COMMIT=${{ env.REGISTRY_VERSION }}


### PR DESCRIPTION
### Description

This PR removes the `cache-to` and `cache-from` from the `depot/build-push-action` inputs - caching is automatically handled by the Depot builder without needing to additionally save / load from GitHub. Removing these options will save that additional time on every build.

cc @paulbalaji 

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
