### PR TITLE
feat(agents): cosmosnative routing ism

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -5294,9 +5294,9 @@ dependencies = [
 
 [[package]]
 name = "hyperlane-cosmos-rs"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06b918a633cdc806490bd12dcac47b8c84ed01e171c2e5f1b8f24e934ef25e9"
+checksum = "dc98aea32657307552b9e58d53d2af8de83cda7f99ce8ea1daa8884221feba46"
 dependencies = [
  "cosmrs",
  "prost 0.13.4",

--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -5294,9 +5294,9 @@ dependencies = [
 
 [[package]]
 name = "hyperlane-cosmos-rs"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0354da8627e2110442d445e55df8cff1d73c67e6e62e2af401fb53122e92b65e"
+checksum = "b06b918a633cdc806490bd12dcac47b8c84ed01e171c2e5f1b8f24e934ef25e9"
 dependencies = [
  "cosmrs",
  "prost 0.13.4",

--- a/rust/main/chains/hyperlane-cosmos-native/Cargo.toml
+++ b/rust/main/chains/hyperlane-cosmos-native/Cargo.toml
@@ -43,7 +43,7 @@ pin-project.workspace = true
 tracing = { workspace = true }
 tracing-futures = { workspace = true }
 url = { workspace = true }
-hyperlane-cosmos-rs = "0.1.2"
+hyperlane-cosmos-rs = "0.1.3"
 
 hyperlane-metric = { path = "../../hyperlane-metric" }
 hyperlane-core = { path = "../../hyperlane-core", features = ["async"] }

--- a/rust/main/chains/hyperlane-cosmos-native/Cargo.toml
+++ b/rust/main/chains/hyperlane-cosmos-native/Cargo.toml
@@ -43,7 +43,7 @@ pin-project.workspace = true
 tracing = { workspace = true }
 tracing-futures = { workspace = true }
 url = { workspace = true }
-hyperlane-cosmos-rs = "0.1.3"
+hyperlane-cosmos-rs = "0.1.4"
 
 hyperlane-metric = { path = "../../hyperlane-metric" }
 hyperlane-core = { path = "../../hyperlane-core", features = ["async"] }

--- a/rust/main/chains/hyperlane-cosmos-native/src/indexers/delivery.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/indexers/delivery.rs
@@ -1,6 +1,6 @@
 use std::ops::RangeInclusive;
 
-use hyperlane_cosmos_rs::{hyperlane::core::v1::Process, prost::Name};
+use hyperlane_cosmos_rs::{hyperlane::core::v1::EventProcess, prost::Name};
 use tendermint::abci::EventAttribute;
 use tonic::async_trait;
 use tracing::instrument;
@@ -33,7 +33,7 @@ impl CosmosNativeDeliveryIndexer {
 
 impl CosmosEventIndexer<H256> for CosmosNativeDeliveryIndexer {
     fn target_type() -> String {
-        Process::full_name()
+        EventProcess::full_name()
     }
 
     fn provider(&self) -> &RpcProvider {

--- a/rust/main/chains/hyperlane-cosmos-native/src/indexers/dispatch.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/indexers/dispatch.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 use std::ops::RangeInclusive;
 
 use hex::ToHex;
-use hyperlane_cosmos_rs::hyperlane::core::v1::Dispatch;
+use hyperlane_cosmos_rs::hyperlane::core::v1::EventDispatch;
 use hyperlane_cosmos_rs::prost::Name;
 use tendermint::abci::EventAttribute;
 use tonic::async_trait;
@@ -36,7 +36,7 @@ impl CosmosNativeDispatchIndexer {
 
 impl CosmosEventIndexer<HyperlaneMessage> for CosmosNativeDispatchIndexer {
     fn target_type() -> String {
-        Dispatch::full_name()
+        EventDispatch::full_name()
     }
 
     fn provider(&self) -> &RpcProvider {

--- a/rust/main/chains/hyperlane-cosmos-native/src/indexers/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/indexers/interchain_gas.rs
@@ -1,6 +1,6 @@
 use std::ops::RangeInclusive;
 
-use hyperlane_cosmos_rs::{hyperlane::core::post_dispatch::v1::GasPayment, prost::Name};
+use hyperlane_cosmos_rs::{hyperlane::core::post_dispatch::v1::EventGasPayment, prost::Name};
 use tendermint::abci::EventAttribute;
 use tonic::async_trait;
 use tracing::instrument;
@@ -69,7 +69,7 @@ impl CosmosNativeInterchainGas {
 
 impl CosmosEventIndexer<InterchainGasPayment> for CosmosNativeInterchainGas {
     fn target_type() -> String {
-        GasPayment::full_name()
+        EventGasPayment::full_name()
     }
 
     fn provider(&self) -> &RpcProvider {

--- a/rust/main/chains/hyperlane-cosmos-native/src/indexers/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/indexers/merkle_tree_hook.rs
@@ -3,7 +3,7 @@ use std::ops::RangeInclusive;
 use hex::ToHex;
 use hyperlane_cosmos_rs::{
     hyperlane::core::post_dispatch::v1::{
-        InsertedIntoTree, TreeResponse, WrappedMerkleTreeHookResponse,
+        EventInsertedIntoTree, TreeResponse, WrappedMerkleTreeHookResponse,
     },
     prost::Name,
 };
@@ -131,7 +131,7 @@ impl MerkleTreeHook for CosmosNativeMerkleTreeHook {
 
 impl CosmosEventIndexer<MerkleTreeInsertion> for CosmosNativeMerkleTreeHook {
     fn target_type() -> String {
-        InsertedIntoTree::full_name()
+        EventInsertedIntoTree::full_name()
     }
 
     fn provider(&self) -> &RpcProvider {

--- a/rust/main/chains/hyperlane-cosmos-native/src/providers/rpc.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/providers/rpc.rs
@@ -37,7 +37,7 @@ use crate::{ConnectionConf, CosmosAmount, HyperlaneCosmosError, Signer};
 
 use super::cosmos::CosmosFallbackProvider;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct CosmosHttpClient {
     client: HttpClient,
     metrics: PrometheusClientMetrics,
@@ -107,6 +107,24 @@ impl CosmosHttpClient {
             .map_err(ChainCommunicationError::from_other)?;
 
         Ok(Self::new(client, metrics, metrics_config))
+    }
+}
+
+impl Drop for CosmosHttpClient {
+    fn drop(&mut self) {
+        // decrement provider metric count
+        let chain_name = PrometheusConfig::chain_name(&self.metrics_config.chain);
+        self.metrics.decrement_provider_instance(chain_name);
+    }
+}
+
+impl Clone for CosmosHttpClient {
+    fn clone(&self) -> Self {
+        Self::new(
+            self.client.clone(),
+            self.metrics.clone(),
+            self.metrics_config.clone(),
+        )
     }
 }
 

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -885,8 +885,11 @@ impl ChainConf {
                 let ism = Box::new(h_cosmos::CosmosRoutingIsm::new(provider, locator.clone())?);
                 Ok(ism as Box<dyn RoutingIsm>)
             }
-            ChainConnectionConf::CosmosNative(_) => {
-                Err(eyre!("Cosmos Native does not support routing ISM yet")).context(ctx)
+            ChainConnectionConf::CosmosNative(conf) => {
+                let provider = build_cosmos_native_provider(self, conf, metrics, &locator, None)?;
+                let ism: Box<hyperlane_cosmos_native::CosmosNativeIsm> =
+                    Box::new(h_cosmos_native::CosmosNativeIsm::new(provider, locator)?);
+                Ok(ism as Box<dyn RoutingIsm>)
             }
         }
         .context(ctx)

--- a/rust/main/utils/run-locally/src/cosmosnative/cli.rs
+++ b/rust/main/utils/run-locally/src/cosmosnative/cli.rs
@@ -178,6 +178,22 @@ impl SimApp {
             "1",
         ]);
 
+        // create routing ism and configure it to use the merkle tree ism just created
+        // cmd is following: create-routing
+        // expected ism address: 0x726f757465725f69736d00000000000000000000000000010000000000000001
+        self.tx(vec!["hyperlane", "ism", "create-routing"]);
+
+        // configure the routing ism to use the merkle tree ism
+        // cmd is following: set-routing-ism-domain [routing-ism-id] [domain] [ism-id]
+        self.tx(vec![
+            "hyperlane",
+            "ism",
+            "set-routing-ism-domain",
+            "0x726f757465725f69736d00000000000000000000000000010000000000000001",
+            destination_domain,
+            "0x726f757465725f69736d00000000000000000000000000040000000000000000",
+        ]);
+
         // create mailbox
         // cmd is following: default-ism local-domain
         // expected mailbox address: 0x68797065726c616e650000000000000000000000000000000000000000000000
@@ -185,7 +201,7 @@ impl SimApp {
             "hyperlane",
             "mailbox",
             "create",
-            "0x726f757465725f69736d00000000000000000000000000040000000000000000",
+            "0x726f757465725f69736d00000000000000000000000000010000000000000001",
             local_domain,
         ]);
 

--- a/rust/main/utils/run-locally/src/cosmosnative/cli.rs
+++ b/rust/main/utils/run-locally/src/cosmosnative/cli.rs
@@ -297,10 +297,8 @@ impl SimApp {
         ]);
 
         Contracts {
-            mailbox: MAILBOX_ADDRESS
-                .to_owned(),
-            merkle_tree_hook: MERKLE_TREE_HOOK_ADDRESS
-                .to_owned(),
+            mailbox: MAILBOX_ADDRESS.to_owned(),
+            merkle_tree_hook: MERKLE_TREE_HOOK_ADDRESS.to_owned(),
             igp: IGP_ADDRESS.to_owned(),
             tokens: vec![
                 COLLATERAL_TOKEN_ADDRESS.to_owned(),

--- a/rust/main/utils/run-locally/src/cosmosnative/cli.rs
+++ b/rust/main/utils/run-locally/src/cosmosnative/cli.rs
@@ -12,6 +12,18 @@ use super::{
 };
 
 const GENESIS_FUND: u128 = 1000000000000;
+const IGP_ADDRESS: &str = "0x726f757465725f706f73745f6469737061746368000000040000000000000000";
+const MERKLE_ISM_ADDRESS: &str =
+    "0x726f757465725f69736d00000000000000000000000000040000000000000000";
+const ROUTING_ISM_ADDRESS: &str =
+    "0x726f757465725f69736d00000000000000000000000000010000000000000001";
+const MAILBOX_ADDRESS: &str = "0x68797065726c616e650000000000000000000000000000000000000000000000";
+const MERKLE_TREE_HOOK_ADDRESS: &str =
+    "0x726f757465725f706f73745f6469737061746368000000030000000000000001";
+const COLLATERAL_TOKEN_ADDRESS: &str =
+    "0x726f757465725f61707000000000000000000000000000010000000000000000";
+const SYNTHETIC_TOKEN_ADDRESS: &str =
+    "0x726f757465725f61707000000000000000000000000000020000000000000001";
 
 #[derive(Debug)]
 pub struct SimApp {
@@ -151,9 +163,6 @@ impl SimApp {
         // TODO: test against the tx result to see if everything was created correctly
         self.tx(vec!["hyperlane", "hooks", "igp", "create", DENOM]);
 
-        const IGP_ADDRESS: &str =
-            "0x726f757465725f706f73745f6469737061746368000000040000000000000000";
-
         // set the interchain gas config -> this determines the interchain gaspayments
         // cmd is following: igp-address remote-domain exchange-rate gas-price and gas-overhead
         // this config requires a payment of at least 0.200001uhyp
@@ -181,15 +190,10 @@ impl SimApp {
             "1",
         ]);
 
-        const MERKLE_ISM_ADDRESS: &str =
-            "0x726f757465725f69736d00000000000000000000000000040000000000000000";
-
         // create routing ism and configure it to use the merkle tree ism just created
         // cmd is following: create-routing
         // expected ism address: 0x726f757465725f69736d00000000000000000000000000010000000000000001
         self.tx(vec!["hyperlane", "ism", "create-routing"]);
-        const ROUTING_ISM_ADDRESS: &str =
-            "0x726f757465725f69736d00000000000000000000000000010000000000000001";
 
         // configure the routing ism to use the merkle tree ism
         // cmd is following: set-routing-ism-domain [routing-ism-id] [domain] [ism-id]
@@ -213,9 +217,6 @@ impl SimApp {
             local_domain,
         ]);
 
-        const MAILBOX_ADDRESS: &str =
-            "0x68797065726c616e650000000000000000000000000000000000000000000000";
-
         // create merkle_tree_hook
         // cmd is following: mailbox-address
         // expected merkle_tree_hook address: 0x726f757465725f706f73745f6469737061746368000000030000000000000001
@@ -226,9 +227,6 @@ impl SimApp {
             "create",
             MAILBOX_ADDRESS,
         ]);
-
-        const MERKLE_TREE_HOOK_ADDRESS: &str =
-            "0x726f757465725f706f73745f6469737061746368000000030000000000000001";
 
         // set mailbox to use the hooks
         // cmd is following: mailbox-id --required-hook [id] --default-hook [id]
@@ -260,11 +258,6 @@ impl SimApp {
             MAILBOX_ADDRESS,
             DENOM,
         ]);
-
-        const COLLATERAL_TOKEN_ADDRESS: &str =
-            "0x726f757465725f61707000000000000000000000000000010000000000000000";
-        const SYNTHETIC_TOKEN_ADDRESS: &str =
-            "0x726f757465725f61707000000000000000000000000000020000000000000001";
 
         // enroll the remote domain to this token
         // cmd is following: token-id receiver-domain receiver-contract gas

--- a/rust/main/utils/run-locally/src/cosmosnative/mod.rs
+++ b/rust/main/utils/run-locally/src/cosmosnative/mod.rs
@@ -196,7 +196,7 @@ fn install_sim_app() -> PathBuf {
     let release_name = format!("{BINARY_NAME}_{target}");
     log!("Downloading Sim App {}", release_name);
     let uri = format!(
-        "https://github.com/bcp-innovations/hyperlane-cosmos/releases/download/v1.0.0-beta0/{}",
+        "https://github.com/bcp-innovations/hyperlane-cosmos/releases/download/v1.0.0/{}",
         release_name
     );
 


### PR DESCRIPTION
### Description

Added new routing ism to the agents.

<!--
What's included in this PR?
-->

### Drive-by changes
Decrease provider count for `cosmosnative` by implementing the Drop trait.
<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

[Linear Issue](https://linear.app/hyperlane-xyz/issue/BACK-127/cosmosnative-relayer-routing-ism-support)

<!--
- Fixes #[issue number here]
-->

### Backward compatibility
Full backwards compatibility.
<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing
Added new `RoutingIsm` to the E2E `cosmosnative` tests.
<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
