### PR TITLE
chore: Upgrade Relayer in testnet to latest image

### DIFF
--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -257,7 +257,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '45739bd-20250401-014114',
+      tag: 'fe1f33b-20250408-120728',
     },
     blacklist: [...releaseCandidateHelloworldMatchingList, ...relayBlacklist],
     gasPaymentEnforcement,
@@ -299,7 +299,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '8c3e983-20250310-144838',
+      tag: 'fe1f33b-20250408-120728',
     },
     whitelist: [...releaseCandidateHelloworldMatchingList],
     blacklist: relayBlacklist,


### PR DESCRIPTION
### Description

Upgrade Relayer in testnet to fe1f33b-20250408-120728

### Related issues

- Contributes into https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5748

### Backward compatibility

Yes

### Testing

Manual