### PR TITLE
fix: corect synthetic token types

### DIFF
--- a/.changeset/calm-humans-do.md
+++ b/.changeset/calm-humans-do.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+fix: correct exported TypeScript types for synthetic tokens

--- a/typescript/sdk/src/token/deploy.hardhat-test.ts
+++ b/typescript/sdk/src/token/deploy.hardhat-test.ts
@@ -28,7 +28,7 @@ import { HypERC20Checker } from './checker.js';
 import { TokenType } from './config.js';
 import { HypERC20Deployer } from './deploy.js';
 import {
-  HypTokenRouterConfig,
+  SyntheticTokenConfig,
   WarpRouteDeployConfigMailboxRequired,
 } from './types.js';
 
@@ -72,16 +72,16 @@ describe('TokenDeployer', async () => {
     const ismFactory = new HyperlaneIsmFactory(factories, multiProvider);
     coreApp = await new TestCoreDeployer(multiProvider, ismFactory).deployApp();
     const routerConfigMap = coreApp.getRouterConfig(signer.address);
-    config = objMap(
-      routerConfigMap,
-      (chain, c): HypTokenRouterConfig => ({
-        type: TokenType.synthetic,
-        name: chain,
-        symbol: `u${chain}`,
-        decimals: 18,
-        ...c,
-      }),
-    );
+    const token: SyntheticTokenConfig = {
+      type: TokenType.synthetic,
+      name: chain,
+      symbol: `u${chain}`,
+      decimals: 18,
+    };
+    config = objMap(routerConfigMap, (chain, c) => ({
+      ...token,
+      ...c,
+    }));
   });
 
   beforeEach(async () => {

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -98,7 +98,7 @@ export const SyntheticTokenConfigSchema = TokenMetadataSchema.partial().extend({
   type: z.enum([TokenType.synthetic, TokenType.syntheticUri]),
   initialSupply: z.string().or(z.number()).optional(),
 });
-export type SyntheticTokenConfig = z.infer<typeof CollateralTokenConfigSchema>;
+export type SyntheticTokenConfig = z.infer<typeof SyntheticTokenConfigSchema>;
 export const isSyntheticTokenConfig = isCompliant(SyntheticTokenConfigSchema);
 
 export const SyntheticRebaseTokenConfigSchema =

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -107,7 +107,7 @@ export const SyntheticRebaseTokenConfigSchema =
     collateralChainName: z.string(),
   });
 export type SyntheticRebaseTokenConfig = z.infer<
-  typeof CollateralTokenConfigSchema
+  typeof SyntheticRebaseTokenConfigSchema
 >;
 export const isSyntheticRebaseTokenConfig = isCompliant(
   SyntheticRebaseTokenConfigSchema,


### PR DESCRIPTION
### Description

This PR fixes a couple mistakes in token config type definitions. Some of the synthetic token types didn't match to config schemas correctly.

### Backward compatibility

Incompatibilities should be caught by static typing but we can't be sure it doesn't cause breakage in any dependent code.

### Testing

The existing test suite wasn't extended to expose the bugs.