### PR TITLE
Andrey/eng-1018-optional-mailbox-field

### DIFF
--- a/typescript/cli/src/read/warp.ts
+++ b/typescript/cli/src/read/warp.ts
@@ -8,8 +8,8 @@ import {
 import {
   ChainMap,
   ChainName,
+  DerivedTokenRouterConfig,
   EvmERC20WarpRouteReader,
-  HypTokenRouterConfig,
   TokenStandard,
 } from '@hyperlane-xyz/sdk';
 import { isAddressEvm, objMap, promiseObjAll } from '@hyperlane-xyz/utils';
@@ -30,7 +30,7 @@ export async function runWarpRouteRead({
   warp?: string;
   address?: string;
   symbol?: string;
-}): Promise<Record<ChainName, HypTokenRouterConfig>> {
+}): Promise<Record<ChainName, DerivedTokenRouterConfig>> {
   const { multiProvider } = context;
 
   let addresses: ChainMap<string>;

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -15,7 +15,7 @@ import {
   createWarpRouteConfigId,
 } from '@hyperlane-xyz/registry';
 import {
-  HypTokenRouterConfig,
+  DerivedTokenRouterConfig,
   TokenType,
   WarpCoreConfig,
   WarpCoreConfigSchema,
@@ -218,7 +218,7 @@ export async function updateOwner(
 export async function extendWarpConfig(params: {
   chain: string;
   chainToExtend: string;
-  extendedConfig: HypTokenRouterConfig;
+  extendedConfig: DerivedTokenRouterConfig;
   warpCorePath: string;
   warpDeployPath: string;
   strategyUrl?: string;
@@ -258,7 +258,7 @@ export async function setupIncompleteWarpRouteExtension(
   chain2DomainId: string;
   chain3DomainId: string;
   warpConfigPath: string;
-  configToExtend: HypTokenRouterConfig;
+  configToExtend: DerivedTokenRouterConfig;
   context: CommandContext;
   combinedWarpCorePath: string;
 }> {
@@ -267,7 +267,7 @@ export async function setupIncompleteWarpRouteExtension(
   const chain2DomainId = await getDomainId(CHAIN_NAME_2, ANVIL_KEY);
   const chain3DomainId = await getDomainId(CHAIN_NAME_3, ANVIL_KEY);
 
-  const configToExtend: HypTokenRouterConfig = {
+  const configToExtend: DerivedTokenRouterConfig = {
     decimals: 18,
     mailbox: chain2Addresses!.mailbox,
     name: 'Ether',

--- a/typescript/cli/src/tests/warp/warp-apply.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-apply.e2e-test.ts
@@ -3,8 +3,8 @@ import { Wallet } from 'ethers';
 
 import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
+  DerivedTokenRouterConfig,
   HookType,
-  HypTokenRouterConfig,
   TokenType,
   WarpRouteDeployConfig,
   normalizeConfig,
@@ -142,7 +142,7 @@ describe('hyperlane warp apply owner update tests', async function () {
     await readWarpConfig(CHAIN_NAME_2, WARP_CORE_CONFIG_PATH_2, warpConfigPath);
 
     // Extend with new config
-    const config: HypTokenRouterConfig = {
+    const config: DerivedTokenRouterConfig = {
       decimals: 18,
       mailbox: chain2Addresses!.mailbox,
       name: 'Ether',

--- a/typescript/cli/src/tests/warp/warp-extend-basic.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-extend-basic.e2e-test.ts
@@ -3,7 +3,7 @@ import { Wallet } from 'ethers';
 
 import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
-  HypTokenRouterConfig,
+  DerivedTokenRouterConfig,
   TokenType,
   WarpRouteDeployConfig,
 } from '@hyperlane-xyz/sdk';
@@ -63,7 +63,7 @@ describe('hyperlane warp apply basic extension tests', async function () {
     await readWarpConfig(CHAIN_NAME_2, WARP_CORE_CONFIG_PATH_2, warpConfigPath);
 
     // Extend with new config
-    const config: HypTokenRouterConfig = {
+    const config: DerivedTokenRouterConfig = {
       decimals: 18,
       mailbox: chain2Addresses!.mailbox,
       name: 'Ether',
@@ -118,7 +118,7 @@ describe('hyperlane warp apply basic extension tests', async function () {
     await readWarpConfig(CHAIN_NAME_2, WARP_CORE_CONFIG_PATH_2, warpConfigPath);
 
     // Extend with new config
-    const config: HypTokenRouterConfig = {
+    const config: DerivedTokenRouterConfig = {
       decimals: 18,
       mailbox: chain2Addresses!.mailbox,
       name: 'Ether',
@@ -180,7 +180,7 @@ describe('hyperlane warp apply basic extension tests', async function () {
 
     // Extend with new config
     const randomOwner = new Wallet(ANVIL_KEY).address;
-    const extendedConfig: HypTokenRouterConfig = {
+    const extendedConfig: DerivedTokenRouterConfig = {
       decimals: 18,
       mailbox: chain2Addresses!.mailbox,
       name: 'Ether',
@@ -245,7 +245,7 @@ describe('hyperlane warp apply basic extension tests', async function () {
 
     // Extend with new config
     const GAS = 694200;
-    const extendedConfig: HypTokenRouterConfig = {
+    const extendedConfig: DerivedTokenRouterConfig = {
       decimals: 18,
       mailbox: chain2Addresses!.mailbox,
       name: 'Ether',

--- a/typescript/cli/src/tests/warp/warp-extend-config.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-extend-config.e2e-test.ts
@@ -3,7 +3,7 @@ import { Wallet } from 'ethers';
 
 import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
-  HypTokenRouterConfig,
+  DerivedTokenRouterConfig,
   TokenType,
   WarpRouteDeployConfig,
   normalizeConfig,
@@ -60,7 +60,7 @@ describe('hyperlane warp apply config extension tests', async function () {
     const warpDeployPath = `${TEMP_PATH}/warp-route-deployment-2.yaml`;
 
     // Extend with new config
-    const config: HypTokenRouterConfig = {
+    const config: DerivedTokenRouterConfig = {
       decimals: 18,
       mailbox: chain2Addresses!.mailbox,
       name: 'Ether',
@@ -115,7 +115,7 @@ describe('hyperlane warp apply config extension tests', async function () {
     const warpDeployPath = `${TEMP_PATH}/warp-route-deployment-2.yaml`;
 
     // Extend with new config
-    const config: HypTokenRouterConfig = {
+    const config: DerivedTokenRouterConfig = {
       decimals: 18,
       mailbox: chain2Addresses!.mailbox,
       name: 'Ether',
@@ -181,7 +181,7 @@ describe('hyperlane warp apply config extension tests', async function () {
     );
 
     // Extend with new config for chain 3
-    const extendedConfig: HypTokenRouterConfig = {
+    const extendedConfig: DerivedTokenRouterConfig = {
       decimals: 18,
       mailbox: chain2Addresses!.mailbox,
       name: 'Ether',

--- a/typescript/helloworld/src/deploy/config.ts
+++ b/typescript/helloworld/src/deploy/config.ts
@@ -1,7 +1,9 @@
 import { chainMetadata } from '@hyperlane-xyz/registry';
 import { RouterConfig } from '@hyperlane-xyz/sdk';
 
-export type HelloWorldConfig = RouterConfig;
+import { MailboxAddress } from '../../../sdk/src/router/types.js';
+
+export type HelloWorldConfig = RouterConfig & MailboxAddress;
 
 // SET DESIRED NETWORKS HERE OR USE THE DEFAULT SET FROM THE REGISTRY
 export const prodConfigs = {

--- a/typescript/infra/test/govern.hardhat-test.ts
+++ b/typescript/infra/test/govern.hardhat-test.ts
@@ -31,6 +31,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { Address, CallData, eqAddress } from '@hyperlane-xyz/utils';
 
+import { MailboxAddress } from '../../sdk/src/router/types.js';
 import {
   AnnotatedCallData,
   HyperlaneAppGovernor,
@@ -97,7 +98,7 @@ describe('ICA governance', async () => {
   let coreApp: TestCoreApp;
   // let local: InterchainAccountRouter;
   let remote: InterchainAccountRouter;
-  let routerConfig: ChainMap<RouterConfig>;
+  let routerConfig: ChainMap<RouterConfig & MailboxAddress>;
   let contracts: HyperlaneContractsMap<InterchainAccountFactories>;
   let icaApp: InterchainAccount;
   let recipient: TestRecipient;

--- a/typescript/sdk/src/core/EvmIcaModule.ts
+++ b/typescript/sdk/src/core/EvmIcaModule.ts
@@ -21,7 +21,7 @@ import { InterchainAccountDeployer } from '../middleware/account/InterchainAccou
 import { InterchainAccountFactories } from '../middleware/account/contracts.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
-import { ProxiedRouterConfig } from '../router/types.js';
+import { MailboxAddress, ProxiedRouterConfig } from '../router/types.js';
 import { ChainNameOrId } from '../types.js';
 
 import {
@@ -30,6 +30,7 @@ import {
 } from './AbstractHyperlaneModule.js';
 
 export type InterchainAccountConfig = ProxiedRouterConfig &
+  MailboxAddress &
   Partial<Pick<DerivedIcaRouterConfig, 'remoteIcaRouters'>>;
 
 export class EvmIcaModule extends HyperlaneModule<

--- a/typescript/sdk/src/core/HyperlaneCore.ts
+++ b/typescript/sdk/src/core/HyperlaneCore.ts
@@ -36,7 +36,7 @@ import { DerivedHookConfig } from '../hook/types.js';
 import { EvmIsmReader } from '../ism/EvmIsmReader.js';
 import { DerivedIsmConfig } from '../ism/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
-import { RouterConfig } from '../router/types.js';
+import { MailboxAddress, RouterConfig } from '../router/types.js';
 import { ChainMap, ChainName, OwnableConfig } from '../types.js';
 import { findMatchingLogEvents } from '../utils/logUtils.js';
 
@@ -63,7 +63,7 @@ export class HyperlaneCore extends HyperlaneApp<CoreFactories> {
 
   getRouterConfig = (
     owners: Address | ChainMap<OwnableConfig>,
-  ): ChainMap<RouterConfig> => {
+  ): ChainMap<RouterConfig & MailboxAddress> => {
     // filter for EVM chains
     const evmContractsMap = objFilter(
       this.contractsMap,
@@ -72,15 +72,12 @@ export class HyperlaneCore extends HyperlaneApp<CoreFactories> {
     );
 
     // get config
-    const config = objMap(
-      evmContractsMap,
-      (chain, contracts): RouterConfig => ({
-        mailbox: contracts.mailbox.address,
-        owner: typeof owners === 'string' ? owners : owners[chain].owner,
-        ownerOverrides:
-          typeof owners === 'string' ? undefined : owners[chain].ownerOverrides,
-      }),
-    );
+    const config = objMap(evmContractsMap, (chain, contracts) => ({
+      mailbox: contracts.mailbox.address,
+      owner: typeof owners === 'string' ? owners : owners[chain].owner,
+      ownerOverrides:
+        typeof owners === 'string' ? undefined : owners[chain].ownerOverrides,
+    }));
 
     return config;
   };

--- a/typescript/sdk/src/core/HyperlaneRelayer.ts
+++ b/typescript/sdk/src/core/HyperlaneRelayer.ts
@@ -84,6 +84,10 @@ export function messageMatchesWhitelist(
   return true;
 }
 
+interface DerivedRelayerCache extends RelayerCache {
+  hook: Record<string, Record<string, DerivedHookConfig>>;
+}
+
 export class HyperlaneRelayer {
   protected multiProvider: MultiProvider;
   protected metadataBuilder: BaseMetadataBuilder;
@@ -93,7 +97,7 @@ export class HyperlaneRelayer {
   protected readonly whitelist: ChainMap<Set<Address>> | undefined;
 
   public backlog: RelayerCache['backlog'];
-  public cache: RelayerCache | undefined;
+  public cache: DerivedRelayerCache | undefined;
 
   protected stopRelayingHandler: ((chains?: ChainName[]) => void) | undefined;
 
@@ -139,7 +143,7 @@ export class HyperlaneRelayer {
   ): Promise<DerivedHookConfig> {
     let config: DerivedHookConfig | undefined;
     if (this.cache?.hook[chain]?.[hook]) {
-      config = this.cache.hook[chain][hook] as DerivedHookConfig | undefined;
+      config = this.cache.hook[chain][hook];
     } else {
       const evmHookReader = new EvmHookReader(
         this.multiProvider,

--- a/typescript/sdk/src/deploy/HyperlaneDeployer.ts
+++ b/typescript/sdk/src/deploy/HyperlaneDeployer.ts
@@ -34,7 +34,6 @@ import { IsmConfig } from '../ism/types.js';
 import { moduleMatchesConfig } from '../ism/utils.js';
 import { InterchainAccount } from '../middleware/account/InterchainAccount.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
-import { MailboxClientConfig } from '../router/types.js';
 import { ChainMap, ChainName, OwnableConfig } from '../types.js';
 
 import {
@@ -63,6 +62,11 @@ export interface DeployerOptions {
   icaApp?: InterchainAccount;
   contractVerifier?: ContractVerifier;
   concurrentDeploy?: boolean;
+}
+
+interface ClientConfig {
+  hook?: HookConfig;
+  interchainSecurityModule?: IsmConfig;
 }
 
 export abstract class HyperlaneDeployer<
@@ -339,7 +343,7 @@ export abstract class HyperlaneDeployer<
   protected async configureClient(
     local: ChainName,
     client: MailboxClient,
-    config: MailboxClientConfig,
+    config: ClientConfig,
   ): Promise<void> {
     this.logger.debug(
       `Initializing mailbox client (if not already) on ${local}...`,

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -217,7 +217,9 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
     return config;
   }
 
-  async deriveIdAuthIsmConfig(address: Address): Promise<DerivedHookConfig> {
+  async deriveIdAuthIsmConfig(
+    address: Address,
+  ): Promise<WithAddress<CCIPHookConfig | OpStackHookConfig>> {
     // First check if it's a CCIP hook
     try {
       const ccipHook = CCIPHook__factory.connect(address, this.provider);

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { Address, WithAddress } from '@hyperlane-xyz/utils';
+import { WithAddress } from '@hyperlane-xyz/utils';
 
 import { ProtocolAgnositicGasOracleConfigSchema } from '../gas/oracle/types.js';
 import { ZHash } from '../metadata/customZodTypes.js';
@@ -79,7 +79,7 @@ export type AmountRoutingHookConfig = {
 
 export type HookConfig = z.infer<typeof HookConfigSchema>;
 
-export type DerivedHookConfig = WithAddress<Exclude<HookConfig, Address>>;
+export type DerivedHookConfig = WithAddress<HookConfig>;
 
 // Hook types that can be updated in-place
 export const MUTABLE_HOOK_TYPE = [

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -598,6 +598,7 @@ export {
   CollateralRebaseTokenConfigSchema,
   CollateralTokenConfig,
   CollateralTokenConfigSchema,
+  DerivedTokenRouterConfig,
   HypTokenConfig,
   HypTokenConfigSchema,
   HypTokenRouterConfig,

--- a/typescript/sdk/src/ism/types.ts
+++ b/typescript/sdk/src/ism/types.ts
@@ -175,7 +175,7 @@ export type AggregationIsmConfig = {
 
 export type IsmConfig = z.infer<typeof IsmConfigSchema>;
 
-export type DerivedIsmConfig = WithAddress<Exclude<IsmConfig, Address>>;
+export type DerivedIsmConfig = WithAddress<IsmConfig>;
 
 export type DeployedIsmType = {
   [IsmType.CUSTOM]: IInterchainSecurityModule;

--- a/typescript/sdk/src/middleware/account/InterchainAccountDeployer.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccountDeployer.ts
@@ -7,7 +7,11 @@ import { HyperlaneContracts } from '../../contracts/types.js';
 import { ContractVerifier } from '../../deploy/verify/ContractVerifier.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
 import { ProxiedRouterDeployer } from '../../router/ProxiedRouterDeployer.js';
-import { ProxiedRouterConfig, RouterConfig } from '../../router/types.js';
+import {
+  MailboxAddress,
+  ProxiedRouterConfig,
+  RouterConfig,
+} from '../../router/types.js';
 import { ChainName } from '../../types.js';
 
 import {
@@ -15,7 +19,7 @@ import {
   interchainAccountFactories,
 } from './contracts.js';
 
-export type InterchainAccountConfig = ProxiedRouterConfig;
+export type InterchainAccountConfig = ProxiedRouterConfig & MailboxAddress;
 
 export class InterchainAccountDeployer extends ProxiedRouterDeployer<
   InterchainAccountConfig,

--- a/typescript/sdk/src/middleware/account/accounts.hardhat-test.ts
+++ b/typescript/sdk/src/middleware/account/accounts.hardhat-test.ts
@@ -15,7 +15,7 @@ import { TestCoreDeployer } from '../../core/TestCoreDeployer.js';
 import { HyperlaneProxyFactoryDeployer } from '../../deploy/HyperlaneProxyFactoryDeployer.js';
 import { HyperlaneIsmFactory } from '../../ism/HyperlaneIsmFactory.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
-import { RouterConfig } from '../../router/types.js';
+import { MailboxAddress, RouterConfig } from '../../router/types.js';
 import { ChainMap } from '../../types.js';
 
 import { InterchainAccount } from './InterchainAccount.js';
@@ -35,7 +35,7 @@ describe('InterchainAccounts', async () => {
   let multiProvider: MultiProvider;
   let coreApp: TestCoreApp;
   let app: InterchainAccount;
-  let config: ChainMap<RouterConfig>;
+  let config: ChainMap<RouterConfig & MailboxAddress>;
 
   before(async () => {
     [signer] = await hre.ethers.getSigners();

--- a/typescript/sdk/src/middleware/query/InterchainQueryDeployer.ts
+++ b/typescript/sdk/src/middleware/query/InterchainQueryDeployer.ts
@@ -6,14 +6,14 @@ import { HyperlaneContracts } from '../../contracts/types.js';
 import { ContractVerifier } from '../../deploy/verify/ContractVerifier.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
 import { ProxiedRouterDeployer } from '../../router/ProxiedRouterDeployer.js';
-import { RouterConfig } from '../../router/types.js';
+import { MailboxAddress, RouterConfig } from '../../router/types.js';
 
 import {
   InterchainQueryFactories,
   interchainQueryFactories,
 } from './contracts.js';
 
-export type InterchainQueryConfig = RouterConfig;
+export type InterchainQueryConfig = RouterConfig & MailboxAddress;
 
 export class InterchainQueryDeployer extends ProxiedRouterDeployer<
   InterchainQueryConfig,

--- a/typescript/sdk/src/middleware/query/queries.hardhat-test.ts
+++ b/typescript/sdk/src/middleware/query/queries.hardhat-test.ts
@@ -16,7 +16,7 @@ import { TestCoreDeployer } from '../../core/TestCoreDeployer.js';
 import { HyperlaneProxyFactoryDeployer } from '../../deploy/HyperlaneProxyFactoryDeployer.js';
 import { HyperlaneIsmFactory } from '../../ism/HyperlaneIsmFactory.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
-import { RouterConfig } from '../../router/types.js';
+import { MailboxAddress, RouterConfig } from '../../router/types.js';
 import { ChainMap } from '../../types.js';
 
 import { InterchainQuery } from './InterchainQuery.js';
@@ -37,7 +37,7 @@ describe.skip('InterchainQueryRouter', async () => {
   let remote: InterchainQueryRouter;
   let multiProvider: MultiProvider;
   let coreApp: TestCoreApp;
-  let config: ChainMap<RouterConfig>;
+  let config: ChainMap<RouterConfig & MailboxAddress>;
   let testQuery: TestQuery;
 
   before(async () => {

--- a/typescript/sdk/src/router/HyperlaneRouterChecker.ts
+++ b/typescript/sdk/src/router/HyperlaneRouterChecker.ts
@@ -58,7 +58,10 @@ export class HyperlaneRouterChecker<
     const config = this.configMap[chain];
 
     const mailboxAddr = await router.mailbox();
-    if (!eqAddress(mailboxAddr, config.mailbox)) {
+    // TODO for this check to make sense, we need to fetch the mailbox address from the registry
+    if (
+      !eqAddress(mailboxAddr, config.mailbox || ethers.constants.AddressZero)
+    ) {
       this.addViolation({
         chain,
         type: ClientViolationType.Mailbox,

--- a/typescript/sdk/src/router/types.ts
+++ b/typescript/sdk/src/router/types.ts
@@ -20,18 +20,24 @@ export type RouterAddress = {
   router: Address;
 };
 
-export type MailboxClientConfig = z.infer<typeof MailboxClientConfigSchema>;
-
-export type DerivedMailboxClientFields = {
-  hook: string | DerivedHookConfig;
-  interchainSecurityModule: string | DerivedIsmConfig;
+export type MailboxAddress = {
+  mailbox: Address;
 };
 
-export type DerivedMailboxClientConfig = Omit<
-  MailboxClientConfig,
-  keyof DerivedMailboxClientFields
-> &
-  DerivedMailboxClientFields;
+export interface MailboxClientConfig
+  extends z.infer<typeof MailboxClientConfigSchema> {
+  mailbox: Address;
+}
+
+export type DerivedMailboxClientFields = {
+  hook?: DerivedHookConfig;
+  interchainSecurityModule?: DerivedIsmConfig;
+};
+
+export interface DerivedMailboxClientConfig extends MailboxClientConfig {
+  hook?: DerivedHookConfig;
+  interchainSecurityModule?: DerivedIsmConfig;
+}
 
 export type RouterConfig = z.infer<typeof RouterConfigSchema>;
 export type GasRouterConfig = z.infer<typeof GasRouterConfigSchema>;
@@ -84,7 +90,7 @@ export type RemoteRouters = z.infer<typeof RemoteRoutersSchema>;
 export type DestinationGas = z.infer<typeof DestinationGasSchema>;
 
 export const MailboxClientConfigSchema = OwnableSchema.extend({
-  mailbox: ZHash,
+  mailbox: ZHash.optional(),
   hook: HookConfigSchema.optional(),
   interchainSecurityModule: IsmConfigSchema.optional(),
 });

--- a/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
@@ -36,7 +36,7 @@ import { ProxyFactoryFactories } from '../deploy/contracts.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
-import { RemoteRouters } from '../router/types.js';
+import { MailboxAddress, RemoteRouters } from '../router/types.js';
 import { randomAddress } from '../test/testUtils.js';
 import { ChainMap } from '../types.js';
 import { normalizeConfig } from '../utils/ism.js';
@@ -70,8 +70,8 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
   let signer: SignerWithAddress;
   let multiProvider: MultiProvider;
   let coreApp: TestCoreApp;
-  let routerConfigMap: ChainMap<RouterConfig>;
-  let baseConfig: RouterConfig;
+  let routerConfigMap: ChainMap<RouterConfig & MailboxAddress>;
+  let baseConfig: (typeof routerConfigMap)[typeof chain];
 
   async function validateCoreValues(deployedToken: GasRouter) {
     expect(await deployedToken.mailbox()).to.equal(mailbox.address);

--- a/typescript/sdk/src/token/EvmERC20WarpModule.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.ts
@@ -425,7 +425,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
         config: expectedConfig.interchainSecurityModule,
         addresses: {
           ...this.args.addresses,
-          mailbox: expectedConfig.mailbox,
+          mailbox: actualConfig.mailbox,
           deployedIsm: derivedIsmAddress(actualConfig),
         },
       },
@@ -457,13 +457,16 @@ export class EvmERC20WarpModule extends HyperlaneModule<
   }> {
     assert(expectedConfig.hook, 'No hook config');
     if (!actualConfig.hook || actualConfig.hook === zeroAddress) {
-      return this.deployNewHook(expectedConfig);
+      return this.deployNewHook(expectedConfig, actualConfig.mailbox);
     }
 
     return this.updateExistingHook(expectedConfig, actualConfig);
   }
 
-  async deployNewHook(expectedConfig: HypTokenRouterConfig): Promise<{
+  async deployNewHook(
+    expectedConfig: HypTokenRouterConfig,
+    mailboxAddress: Address,
+  ): Promise<{
     deployedHook: Address;
     updateTransactions: AnnotatedEV5Transaction[];
   }> {
@@ -484,7 +487,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
         this.args.addresses,
       ),
       coreAddresses: {
-        mailbox: expectedConfig.mailbox,
+        mailbox: mailboxAddress,
         proxyAdmin: expectedConfig.proxyAdmin?.address, // Assume that a proxyAdmin is always deployed with a WarpRoute
       },
       contractVerifier: this.contractVerifier,

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -1,7 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers.js';
 import { expect } from 'chai';
 import hre from 'hardhat';
-import { zeroAddress } from 'viem';
 
 import {
   ERC20Test,
@@ -28,6 +27,7 @@ import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDe
 import { ProxyFactoryFactories } from '../deploy/contracts.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
+import { MailboxAddress } from '../router/types.js';
 import { ChainMap } from '../types.js';
 
 import { EvmERC20WarpRouteReader } from './EvmERC20WarpRouteReader.js';
@@ -49,8 +49,8 @@ describe('ERC20WarpRouterReader', async () => {
   let deployer: HypERC20Deployer;
   let multiProvider: MultiProvider;
   let coreApp: TestCoreApp;
-  let routerConfigMap: ChainMap<RouterConfig>;
-  let baseConfig: RouterConfig;
+  let routerConfigMap: ChainMap<RouterConfig & MailboxAddress>;
+  let baseConfig: (typeof routerConfigMap)[typeof chain];
   let mailbox: Mailbox;
   let evmERC20WarpRouteReader: EvmERC20WarpRouteReader;
   let vault: ERC4626;
@@ -430,7 +430,7 @@ describe('ERC20WarpRouterReader', async () => {
       warpRoute[chain].collateral.address,
     );
 
-    expect(derivedConfig.interchainSecurityModule).to.be.equal(zeroAddress);
+    expect(derivedConfig.interchainSecurityModule).to.be.undefined;
   });
 
   it('should return the remote routers', async () => {

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -192,10 +192,10 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
     ]);
 
     const derivedIsm = eqAddress(ism, constants.AddressZero)
-      ? constants.AddressZero
+      ? undefined
       : await this.evmIsmReader.deriveIsmConfig(ism);
     const derivedHook = eqAddress(hook, constants.AddressZero)
-      ? constants.AddressZero
+      ? undefined
       : await this.evmHookReader.deriveHookConfig(hook);
 
     return {

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -1,3 +1,4 @@
+import { constants } from 'ethers';
 import { z } from 'zod';
 
 import { objMap } from '@hyperlane-xyz/utils';
@@ -7,6 +8,7 @@ import { IsmConfig, IsmType } from '../ism/types.js';
 import {
   DerivedMailboxClientFields,
   GasRouterConfigSchema,
+  MailboxAddress,
 } from '../router/types.js';
 import { ChainMap, ChainName } from '../types.js';
 import { isCompliant } from '../utils/schemas.js';
@@ -132,21 +134,16 @@ export const HypTokenRouterConfigSchema = HypTokenConfigSchema.and(
 );
 export type HypTokenRouterConfig = z.infer<typeof HypTokenRouterConfigSchema>;
 
-export type DerivedTokenRouterConfig = z.infer<typeof HypTokenConfigSchema> &
-  Omit<
-    z.infer<typeof GasRouterConfigSchema>,
-    keyof DerivedMailboxClientFields
-  > &
+export type DerivedTokenRouterConfig = HypTokenRouterConfig &
+  MailboxAddress &
   DerivedMailboxClientFields;
 
 export function derivedHookAddress(config: DerivedTokenRouterConfig) {
-  return typeof config.hook === 'string' ? config.hook : config.hook.address;
+  return config.hook?.address || constants.AddressZero;
 }
 
 export function derivedIsmAddress(config: DerivedTokenRouterConfig) {
-  return typeof config.interchainSecurityModule === 'string'
-    ? config.interchainSecurityModule
-    : config.interchainSecurityModule.address;
+  return config.interchainSecurityModule?.address || constants.AddressZero;
 }
 
 const HypTokenRouterConfigMailboxOptionalSchema = HypTokenConfigSchema.and(

--- a/typescript/utils/src/types.ts
+++ b/typescript/utils/src/types.ts
@@ -30,9 +30,11 @@ export type TokenCaip19Id = `${string}:${string}/${string}:${string}`; // e.g. e
 export type HexString = string;
 export type Numberish = number | string | bigint;
 
-export type WithAddress<T> = T & {
-  address: Address;
-};
+export type WithAddress<T> = T extends object
+  ? T & {
+      address: Address;
+    }
+  : never;
 
 export type MerkleProof = {
   branch: ethers.utils.BytesLike[];


### PR DESCRIPTION
### Description

This is an attempt to make the mailbox address optional in the configuration schema, and then apply chain-derivied types with non-optional mailbox, hook, and ISM fields to most parts of the code.

### Related issues

Fixes ENG 1018

### Backward compatibility

This is a draft as I'm not fully certain this doesn't break anything.

### Testing

The test suite hasn't been extended.