### PR TITLE
fix: Remove reset of critical error

### DIFF
--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -135,6 +135,8 @@ impl BaseAgent for Relayer {
     where
         Self: Sized,
     {
+        Self::reset_critical_errors(&settings, &chain_metrics);
+
         let start = Instant::now();
         let mut start_entity_init = Instant::now();
 
@@ -840,6 +842,13 @@ impl Relayer {
                 }
             })
             .collect()
+    }
+
+    fn reset_critical_errors(settings: &RelayerSettings, chain_metrics: &ChainMetrics) {
+        settings
+            .origin_chains
+            .iter()
+            .for_each(|origin| chain_metrics.set_critical_error(origin.name(), false));
     }
 }
 

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -437,8 +437,6 @@ impl BaseAgent for Relayer {
 
         start_entity_init = Instant::now();
         for origin in &self.origin_chains {
-            self.chain_metrics.set_critical_error(origin.name(), false);
-
             let maybe_broadcaster = self
                 .message_syncs
                 .get(origin)


### PR DESCRIPTION
### Description

Remove reset of critical error

Prometheus may miss critical error since it can be reset to false before the metrics are scrapped another time.

### Related issues

- Contributes into https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5748

### Backward compatibility

Yes

### Testing

None
