### PR TITLE
feat: Add MovableCollateralRouter

### DIFF
--- a/.changeset/ten-lies-chew.md
+++ b/.changeset/ten-lies-chew.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/core': minor
+---
+
+Add MovableCollateralRouter, a router whose collateral can be removed to a remote chain

--- a/solidity/contracts/token/libs/MovableCollateralRouter.sol
+++ b/solidity/contracts/token/libs/MovableCollateralRouter.sol
@@ -36,12 +36,12 @@ abstract contract MovableCollateralRouter is AccessControl {
 
     function rebalance(
         uint32 domain,
-        bytes32 recipient,
         uint256 amount,
         ValueTransferBridge bridge
     ) external payable onlyRole(REBALANCER_ROLE) {
         address rebalancer = _msgSender();
-        if (allowedDestinations[domain] != recipient) {
+        bytes32 recipient = allowedDestinations[domain];
+        if (recipient == bytes32(0)) {
             revert BadDestination({rebalancer: rebalancer, domain: domain});
         }
 

--- a/solidity/contracts/token/libs/MovableCollateralRouter.sol
+++ b/solidity/contracts/token/libs/MovableCollateralRouter.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0;
+
+import {FungibleTokenRouter} from "./FungibleTokenRouter.sol";
+import {ValueTransferBridge} from "./ValueTransferBridge.sol";
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
+
+abstract contract MovableCollateralRouter is AccessControl {
+    constructor() {
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    }
+
+    bytes32 public constant REBALANCER_ROLE = keccak256("REBALANCER_ROLE");
+
+    mapping(uint32 destinationDomain => bytes32 recipient)
+        public allowedDestinations;
+    mapping(uint32 destinationDomain => mapping(ValueTransferBridge bridge => bool isValidBridge))
+        public allowedBridges;
+
+    event CollateralMoved(
+        uint32 indexed domain,
+        bytes32 recipient,
+        uint256 amount,
+        address indexed rebalancer
+    );
+
+    error BadDestination(address rebalancer, uint32 domain);
+    error BadBridge(address rebalancer, ValueTransferBridge bridge);
+
+    function moveCollateral(
+        uint32 domain,
+        bytes32 recipient,
+        uint256 amount,
+        ValueTransferBridge bridge
+    ) external onlyRole(REBALANCER_ROLE) {
+        address rebalancer = _msgSender();
+        if (allowedDestinations[domain] != recipient) {
+            revert BadDestination({rebalancer: rebalancer, domain: domain});
+        }
+
+        if (!(allowedBridges[domain][bridge])) {
+            revert BadBridge({rebalancer: rebalancer, bridge: bridge});
+        }
+
+        _moveCollateral(domain, recipient, amount, bridge);
+        emit CollateralMoved({
+            domain: domain,
+            recipient: recipient,
+            amount: amount,
+            rebalancer: rebalancer
+        });
+    }
+
+    function _moveCollateral(
+        uint32 domain,
+        bytes32 recipient,
+        uint256 amount,
+        ValueTransferBridge bridge
+    ) internal virtual {
+        bridge.transferRemote({
+            destinationDomain: domain,
+            recipient: recipient,
+            amountOut: amount
+        });
+    }
+
+    function addRecipient(
+        uint32 domain,
+        bytes32 recipient
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        allowedDestinations[domain] = recipient;
+    }
+
+    function addBridge(
+        ValueTransferBridge bridge,
+        uint32 destinationDomain
+    ) external onlyRole((DEFAULT_ADMIN_ROLE)) {
+        allowedBridges[destinationDomain][bridge] = true;
+    }
+}

--- a/solidity/contracts/token/libs/ValueTransferBridge.sol
+++ b/solidity/contracts/token/libs/ValueTransferBridge.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+struct Quote {
+    address token;
+    uint256 amount;
+}
+
+abstract contract ValueTransferBridge {
+    function quoteTransferRemote(
+        uint32 destinationDomain,
+        bytes32 recipient,
+        uint amountOut
+    ) public view virtual returns (Quote[] memory) {}
+
+    function transferRemote(
+        uint32 destinationDomain,
+        bytes32 recipient,
+        uint256 amountOut
+    ) external payable virtual returns (bytes32 transferId) {}
+}

--- a/solidity/coverage.sh
+++ b/solidity/coverage.sh
@@ -8,4 +8,5 @@ forge coverage \
     --report lcov \
     --report summary \
     --no-match-coverage "(test|mock|node_modules|script|Fast)" \
+    --no-match-test "Fork" \
     --ir-minimum # https://github.com/foundry-rs/foundry/issues/3357

--- a/solidity/test/token/MovableCollateralRouter.t.sol
+++ b/solidity/test/token/MovableCollateralRouter.t.sol
@@ -59,12 +59,7 @@ contract MovableCollateralRouterTest is Test {
         token.approve(address(vtb), 1e18);
 
         // Execute
-        router.rebalance(
-            destinationDomain,
-            bytes32(uint256(uint160(alice))),
-            1e18,
-            vtb
-        );
+        router.rebalance(destinationDomain, 1e18, vtb);
         // Assert
         assertEq(token.balanceOf(address(router)), 0);
         assertEq(token.balanceOf(address(vtb)), 1e18);
@@ -79,12 +74,7 @@ contract MovableCollateralRouterTest is Test {
         );
         vm.expectRevert(revertBytes);
         // Execute
-        router.rebalance(
-            destinationDomain,
-            bytes32(uint256(uint160(alice))),
-            1e18,
-            vtb
-        );
+        router.rebalance(destinationDomain, 1e18, vtb);
     }
 
     function testBadRecipient() public {
@@ -101,12 +91,7 @@ contract MovableCollateralRouterTest is Test {
             )
         );
         // Execute
-        router.rebalance(
-            destinationDomain,
-            bytes32(uint256(uint160(alice))),
-            1e18,
-            vtb
-        );
+        router.rebalance(destinationDomain, 1e18, vtb);
     }
 
     function testBadBridge() public {
@@ -129,12 +114,7 @@ contract MovableCollateralRouterTest is Test {
             )
         );
         // Execute
-        router.rebalance(
-            destinationDomain,
-            bytes32(uint256(uint160(alice))),
-            1e18,
-            vtb
-        );
+        router.rebalance(destinationDomain, 1e18, vtb);
     }
 
     function testApproveTokenForBridge() public {

--- a/solidity/test/token/MovableCollateralRouter.t.sol
+++ b/solidity/test/token/MovableCollateralRouter.t.sol
@@ -59,7 +59,7 @@ contract MovableCollateralRouterTest is Test {
         token.approve(address(vtb), 1e18);
 
         // Execute
-        router.moveCollateral(
+        router.rebalance(
             destinationDomain,
             bytes32(uint256(uint160(alice))),
             1e18,
@@ -79,7 +79,7 @@ contract MovableCollateralRouterTest is Test {
         );
         vm.expectRevert(revertBytes);
         // Execute
-        router.moveCollateral(
+        router.rebalance(
             destinationDomain,
             bytes32(uint256(uint160(alice))),
             1e18,
@@ -101,7 +101,7 @@ contract MovableCollateralRouterTest is Test {
             )
         );
         // Execute
-        router.moveCollateral(
+        router.rebalance(
             destinationDomain,
             bytes32(uint256(uint160(alice))),
             1e18,
@@ -129,11 +129,42 @@ contract MovableCollateralRouterTest is Test {
             )
         );
         // Execute
-        router.moveCollateral(
+        router.rebalance(
             destinationDomain,
             bytes32(uint256(uint160(alice))),
             1e18,
             vtb
         );
+    }
+
+    function testApproveTokenForBridge() public {
+        // Configuration
+        // Grant admin role to test contract
+        router.grantRole(router.DEFAULT_ADMIN_ROLE(), address(this));
+
+        // Execute
+        router.approveTokenForBridge(token, vtb);
+
+        // Assert
+        assertEq(
+            token.allowance(address(router), address(vtb)),
+            type(uint256).max
+        );
+    }
+
+    function testApproveTokenForBridge_NotAdmin() public {
+        address notAdmin = address(1);
+        // We don't grant admin role
+        bytes memory revertBytes = abi.encodePacked(
+            "AccessControl: account ",
+            Strings.toHexString(notAdmin),
+            " is missing role ",
+            Strings.toHexString(uint(router.DEFAULT_ADMIN_ROLE()), 32)
+        );
+        vm.expectRevert(revertBytes);
+
+        // Execute
+        vm.prank(notAdmin);
+        router.approveTokenForBridge(token, vtb);
     }
 }

--- a/solidity/test/token/MovableCollateralRouter.t.sol
+++ b/solidity/test/token/MovableCollateralRouter.t.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.13;
+
+import {ERC20Test} from "../../contracts/test/ERC20Test.sol";
+import {MovableCollateralRouter, ValueTransferBridge} from "contracts/token/libs/MovableCollateralRouter.sol";
+
+import "forge-std/Test.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+contract MockMovableCollateralRouter is MovableCollateralRouter {}
+
+contract MockValueTransferBridge is ValueTransferBridge {
+    ERC20Test token;
+
+    constructor(ERC20Test _token) {
+        token = _token;
+    }
+
+    function transferRemote(
+        uint32 destinationDomain,
+        bytes32 recipient,
+        uint256 amountOut
+    ) external payable override returns (bytes32 transferId) {
+        token.transferFrom(msg.sender, address(this), amountOut);
+        return keccak256("fake message");
+    }
+}
+
+contract MovableCollateralRouterTest is Test {
+    MovableCollateralRouter internal router;
+    MockValueTransferBridge internal vtb;
+    ERC20Test internal token;
+    uint32 internal constant destinationDomain = 2;
+    address internal constant alice = address(1);
+
+    function setUp() public {
+        router = new MockMovableCollateralRouter();
+        token = new ERC20Test("Foo Token", "FT", 1_000_000e18, 18);
+        vtb = new MockValueTransferBridge(token);
+    }
+
+    function testMovingCollateral() public {
+        // Configuration
+        // Grant permissions
+        router.grantRole(router.REBALANCER_ROLE(), address(this));
+
+        // Add the destination domain
+        router.addRecipient(
+            destinationDomain,
+            bytes32(uint256(uint160(alice)))
+        );
+
+        // Add the given bridge
+        router.addBridge(vtb, destinationDomain);
+
+        // Setup
+        token.mintTo(address(router), 1e18);
+        vm.prank(address(router));
+        token.approve(address(vtb), 1e18);
+
+        // Execute
+        router.moveCollateral(
+            destinationDomain,
+            bytes32(uint256(uint160(alice))),
+            1e18,
+            vtb
+        );
+        // Assert
+        assertEq(token.balanceOf(address(router)), 0);
+        assertEq(token.balanceOf(address(vtb)), 1e18);
+    }
+
+    function testBadRebalancer() public {
+        bytes memory revertBytes = abi.encodePacked(
+            "AccessControl: account ",
+            Strings.toHexString(address(this)),
+            " is missing role ",
+            Strings.toHexString(uint(router.REBALANCER_ROLE()), 32)
+        );
+        vm.expectRevert(revertBytes);
+        // Execute
+        router.moveCollateral(
+            destinationDomain,
+            bytes32(uint256(uint160(alice))),
+            1e18,
+            vtb
+        );
+    }
+
+    function testBadRecipient() public {
+        // Configuration
+        // Grant permissions
+        router.grantRole(router.REBALANCER_ROLE(), address(this));
+
+        // We didn't add the recipient
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                MovableCollateralRouter.BadDestination.selector,
+                address(this),
+                destinationDomain
+            )
+        );
+        // Execute
+        router.moveCollateral(
+            destinationDomain,
+            bytes32(uint256(uint160(alice))),
+            1e18,
+            vtb
+        );
+    }
+
+    function testBadBridge() public {
+        // Configuration
+        // Grant permissions
+        router.grantRole(router.REBALANCER_ROLE(), address(this));
+
+        // Add the destination domain
+        router.addRecipient(
+            destinationDomain,
+            bytes32(uint256(uint160(alice)))
+        );
+
+        // We didn't add the bridge
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                MovableCollateralRouter.BadBridge.selector,
+                address(this),
+                vtb
+            )
+        );
+        // Execute
+        router.moveCollateral(
+            destinationDomain,
+            bytes32(uint256(uint160(alice))),
+            1e18,
+            vtb
+        );
+    }
+}


### PR DESCRIPTION
### Description
Add abstract contract that allows a router's collateral to be moved.

### Drive-by changes

N/A

### Related issues

N/A

### Backward compatibility

Yes
### Testing

Unit
