### PR TITLE
feat(core): use safeApprove in HypXERC20Lockbox.approveLockbox()

### DIFF
--- a/.changeset/early-cooks-wink.md
+++ b/.changeset/early-cooks-wink.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/core': patch
+---
+
+Use SafeERC20.safeApprove instead of IERC20.approve in HypXERC20Lockbox.approveLockbox()

--- a/solidity/contracts/token/extensions/HypXERC20Lockbox.sol
+++ b/solidity/contracts/token/extensions/HypXERC20Lockbox.sol
@@ -4,12 +4,15 @@ pragma solidity >=0.8.0;
 import {IXERC20Lockbox} from "../interfaces/IXERC20Lockbox.sol";
 import {IXERC20, IERC20} from "../interfaces/IXERC20.sol";
 import {HypERC20Collateral} from "../HypERC20Collateral.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 contract HypXERC20Lockbox is HypERC20Collateral {
     uint256 constant MAX_INT = 2 ** 256 - 1;
 
     IXERC20Lockbox public immutable lockbox;
     IXERC20 public immutable xERC20;
+
+    using SafeERC20 for IERC20;
 
     constructor(
         address _lockbox,
@@ -33,14 +36,8 @@ contract HypXERC20Lockbox is HypERC20Collateral {
      * @dev This function is idempotent and need not be access controlled
      */
     function approveLockbox() public {
-        require(
-            IERC20(wrappedToken).approve(address(lockbox), MAX_INT),
-            "erc20 lockbox approve failed"
-        );
-        require(
-            xERC20.approve(address(lockbox), MAX_INT),
-            "xerc20 lockbox approve failed"
-        );
+        IERC20(wrappedToken).safeApprove(address(lockbox), MAX_INT);
+        IERC20(xERC20).safeApprove(address(lockbox), MAX_INT);
     }
 
     /**


### PR DESCRIPTION
### Description

Use SafeERC20.safeApprove instead of IERC20.approve to approve expenditure of the wrapped token in HypXERC20Lockbox.approveLockbox(). Useful for cases such as USDT on ethereum whose `approve()` method is non-standard to regular ERC20.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

ousdt staging route