### PR TITLE
feat: add optional public field for RpcUrlSchema

### DIFF
--- a/.changeset/wise-parrots-judge.md
+++ b/.changeset/wise-parrots-judge.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Add new `public` field to RpcUrlSchema

--- a/typescript/sdk/src/metadata/chainMetadataTypes.ts
+++ b/typescript/sdk/src/metadata/chainMetadataTypes.ts
@@ -95,6 +95,10 @@ export const RpcUrlSchema = z.object({
     .describe(
       'Default retry settings to be used by a provider such as MultiProvider.',
     ),
+  public: z
+    .boolean()
+    .optional()
+    .describe('Flag if the RPC is publicly available.'),
 });
 
 export type RpcUrl = z.infer<typeof RpcUrlSchema>;


### PR DESCRIPTION
### Description

Adds a new optional `public` field for the RpcUrlSchema. This allows the Validators to report more comprehensive stats. 

> [!IMPORTANT]  
> This field should not be set to true in the registry yet.

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
