### PR TITLE
feat: alert if merkle root from validators differ from relayer internal root

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -153,7 +153,17 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
         // If any inner ISMs are refusing to build metadata, we propagate just the first refusal.
         for sub_module_res in sub_modules_and_metas.iter() {
             if let Err(MetadataBuildError::Refused(s)) = sub_module_res {
-                return Err(MetadataBuildError::Refused(s.to_string()));
+                return Err(MetadataBuildError::Refused(s.clone()));
+            }
+            if let Err(MetadataBuildError::MerkleRootMismatch {
+                root,
+                canonical_root,
+            }) = sub_module_res
+            {
+                return Err(MetadataBuildError::MerkleRootMismatch {
+                    root: *root,
+                    canonical_root: *canonical_root,
+                });
             }
         }
 

--- a/rust/main/agents/relayer/src/msg/metadata/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base.rs
@@ -35,6 +35,8 @@ pub enum MetadataBuildError {
     MaxIsmCountReached(u32),
     #[error("Aggregation threshold not met ({0})")]
     AggregationThresholdNotMet(u32),
+    #[error("Merkle root mismatch ({root}, {canonical_root})")]
+    MerkleRootMismatch { root: H256, canonical_root: H256 },
 }
 
 #[derive(Clone, Debug, new)]


### PR DESCRIPTION
### Description

 - add metrics to indicate merkle root mismatch

### Related issues

https://linear.app/hyperlane-xyz/issue/BACK-72/pre-tge-relayer-should-high-urgency-alert-if-a-known-app-context-has-a

### Backward compatibility

Yes/No

### Testing
None so far