### PR TITLE
chore: allow GitHub proxy to fetch custom registry

### DIFF
--- a/typescript/github-proxy/src/index.ts
+++ b/typescript/github-proxy/src/index.ts
@@ -1,13 +1,15 @@
 import { DISALLOWED_URL_MSG } from './errors.js';
 
-const GITHUB_API_ALLOWLIST = [
-  '/repos/hyperlane-xyz/hyperlane-registry/git/trees/main',
+export const GITHUB_API_ALLOWLIST = [
+  /^\/repos\/hyperlane-xyz\/hyperlane-registry\/.*/,
 ];
 const GITPUB_API_HOST = 'https://api.github.com';
 export default {
   async fetch(request, env, _ctx): Promise<Response> {
     const apiUrlPath = new URL(request.url).pathname;
-    const isAllowed = GITHUB_API_ALLOWLIST.includes(apiUrlPath);
+    const isAllowed = GITHUB_API_ALLOWLIST.some((pattern) =>
+      pattern.test(apiUrlPath),
+    );
     if (!isAllowed) {
       return new Response(DISALLOWED_URL_MSG, { status: 401 });
     }

--- a/typescript/github-proxy/src/index.ts
+++ b/typescript/github-proxy/src/index.ts
@@ -1,9 +1,9 @@
 import { DISALLOWED_URL_MSG } from './errors.js';
 
 const GITHUB_API_ALLOWLIST = [
-  /^\/repos\/hyperlane-xyz\/hyperlane-registry\/.*/,
+  /^\/repos\/hyperlane-xyz\/hyperlane-registry\/git\/trees\/.*/,
 ];
-const GITPUB_API_HOST = 'https://api.github.com';
+const GITHUB_API_HOST = 'https://api.github.com';
 export default {
   async fetch(request, env, _ctx): Promise<Response> {
     const apiUrlPath = new URL(request.url).pathname;
@@ -14,7 +14,7 @@ export default {
       return new Response(DISALLOWED_URL_MSG, { status: 401 });
     }
 
-    const apiUrl = new URL(`${GITPUB_API_HOST}${apiUrlPath}?recursive=true`);
+    const apiUrl = new URL(`${GITHUB_API_HOST}${apiUrlPath}?recursive=true`);
     return fetch(apiUrl, {
       method: 'GET',
       headers: {

--- a/typescript/github-proxy/src/index.ts
+++ b/typescript/github-proxy/src/index.ts
@@ -1,6 +1,6 @@
 import { DISALLOWED_URL_MSG } from './errors.js';
 
-export const GITHUB_API_ALLOWLIST = [
+const GITHUB_API_ALLOWLIST = [
   /^\/repos\/hyperlane-xyz\/hyperlane-registry\/.*/,
 ];
 const GITPUB_API_HOST = 'https://api.github.com';

--- a/typescript/github-proxy/test/index.spec.ts
+++ b/typescript/github-proxy/test/index.spec.ts
@@ -1,10 +1,20 @@
 import { faker } from '@faker-js/faker';
-import { SELF } from 'cloudflare:test';
-import { describe, expect, it } from 'vitest';
+import { SELF, fetchMock } from 'cloudflare:test';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { DISALLOWED_URL_MSG } from '../src/errors.js';
 
-describe('Hello World worker', () => {
+describe('Github proxy worker', () => {
+  beforeEach(() => {
+    // Enable outbound request mocking...
+    fetchMock.activate();
+    // ...and throw errors if an outbound request isn't mocked
+    fetchMock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    fetchMock.deactivate();
+  });
   it('returns empty response if pathname provided is not a valid api url', async () => {
     const results = await SELF.fetch('https://example.com/favicon.ico');
 
@@ -30,5 +40,21 @@ describe('Hello World worker', () => {
       expect(results.status).toBe(401);
       expect(await results.text()).toBe(DISALLOWED_URL_MSG);
     }
+  });
+
+  it('allows "/repos/hyperlane-xyz/hyperlane-registry/git/trees/*"', async () => {
+    const branchName = faker.git.branch();
+    fetchMock
+      .get('https://api.github.com')
+      .intercept({
+        path: `/repos/hyperlane-xyz/hyperlane-registry/git/trees/${branchName}?recursive=true`,
+      })
+      .reply(200, 'Ok');
+    const results = await SELF.fetch(
+      `https://example.com/repos/hyperlane-xyz/hyperlane-registry/git/trees/${branchName}`,
+    );
+
+    expect(results.status).toBe(200);
+    expect(await results.text()).toBe('Ok');
   });
 });


### PR DESCRIPTION
### Context
The Github proxy is a proxy server that runs on Cloudflare Workers. It's used to proxy api requests using our api key as defined in this, admittedly rough, [design doc](https://www.notion.so/hyperlanexyz/Github-rate-limiting-proxy-409d5f0764a64ac1956a740b63131168). 

The proxy's url is `http://proxy.hyperlane.xyz`. It is currently used in the GithubRegistry where we [fallback](https://github.com/hyperlane-xyz/hyperlane-registry/blob/9e4e4a3c8c2dab5043c0530d2079e68551573261/src/registry/GithubRegistry.ts#L230-L239) to it when we are rate limited by Github. To reduce usage of this proxy, we only allow requests with the path of `/repos/hyperlane-xyz/hyperlane-registry/git/trees/main`. 

However, we are now using this proxy for commits other than `main` e.g. `yarn tsx ... --registry https://github.com/hyperlane-xyz/hyperlane-registry/tree/xaroz/usdc/coti-ethereum` which causes  a 401, as expected.

### Description
This PR relaxes the proxy url restriction from only being able to access the `main` branch to any commits.

### Backward compatibility
Yes

### Testing
Manual
