### PR TITLE
chore(ci): move agent release workflow to depot runners

### DIFF
--- a/.github/workflows/agent-release-artifacts.yml
+++ b/.github/workflows/agent-release-artifacts.yml
@@ -33,19 +33,19 @@ jobs:
       matrix:
         include:
           - TARGET: x86_64-unknown-linux-gnu
-            OS: larger-runner
+            OS: depot-ubuntu-24.04-8
           - TARGET: x86_64-apple-darwin
-            OS: macos-latest
+            OS: depot-macos-latest
           - TARGET: aarch64-apple-darwin
-            OS: macos-latest
+            OS: depot-macos-latest
           - TARGET: x86_64-pc-windows-msvc
-            OS: windows-latest
+            OS: depot-windows-2022-4
     runs-on: ${{ matrix.OS }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
       - name: ubuntu setup
-        if: ${{ matrix.OS == 'larger-runner' }}
+        if: ${{ matrix.OS == 'depot-ubuntu-24.04-8' }}
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq crossbuild-essential-arm64 crossbuild-essential-armhf
@@ -57,6 +57,12 @@ jobs:
           [target.aarch64-unknown-linux-musl]
           linker = "aarch64-linux-gnu-gcc"
           EOF
+      - name: windows setup
+        if: ${{ matrix.OS == 'depot-windows-2022-4' }}
+        run: |
+          choco install llvm -y
+          $llvmPath = 'C:\Program Files\LLVM\bin'
+          echo "LIBCLANG_PATH=$llvmPath" >> $env:GITHUB_ENV
       - name: setup rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -68,7 +74,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.TARGET }} --bin relayer --bin scraper --bin validator
         working-directory: ./rust/main
       - name: make executable
-        if: ${{ matrix.OS == 'larger-runner' || matrix.OS == 'macos-latest' }}
+        if: ${{ matrix.OS == 'depot-ubuntu-24.04-8' || matrix.OS == 'depot-macos-latest' }}
         run: chmod ug+x,-w relayer scraper validator
         working-directory: rust/main/target/${{ matrix.TARGET }}/release
       - name: upload binaries


### PR DESCRIPTION
### Description

chore(ci): move agent release workflow to depot runners
- now takes ~half the time
- remove usage of legacy `larger-runner`
- use the runners from depot for faster agent release builds
- install clang as part of windows setup

| [Before](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/12952725397/job/36130719722)         | [After](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/14379128923)          |
|----------------|----------------|
| ![Before](https://github.com/user-attachments/assets/bb5504de-70b7-4e61-b59c-2604899cb88e) | ![After](https://github.com/user-attachments/assets/af41ee35-e5c3-4988-982b-8a1d1a5700f2) |

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
