### PR TITLE
fix(sealevel): return an error regardless of how simulation fails

### DIFF
--- a/rust/main/submitter/src/chain_tx_adapter/chains/sealevel/adapter/tests/common.rs
+++ b/rust/main/submitter/src/chain_tx_adapter/chains/sealevel/adapter/tests/common.rs
@@ -89,11 +89,11 @@ impl SealevelProviderForSubmitter for MockProvider {
         _payer: &SealevelKeypair,
         _tx_submitter: &dyn TransactionSubmitter,
         _priority_fee_oracle: &dyn PriorityFeeOracle,
-    ) -> ChainResult<Option<SealevelTxCostEstimate>> {
-        Ok(Some(SealevelTxCostEstimate {
+    ) -> ChainResult<SealevelTxCostEstimate> {
+        Ok(SealevelTxCostEstimate {
             compute_units: GAS_LIMIT,
             compute_unit_price_micro_lamports: 0,
-        }))
+        })
     }
 
     async fn wait_for_transaction_confirmation(


### PR DESCRIPTION
### Description

this change had been made as part of the new submitter but introduced an alerting regression in the old submission logic

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
