### PR TITLE
feat(infra): configure testnet4-neutron-relayer for kessel runner

### DIFF
--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -244,6 +244,10 @@ const defaultIsmCacheConfig: IsmCacheConfig = {
 
 const relayBlacklist: BaseRelayerConfig['blacklist'] = [
   {
+    // Ignore kessel runner test recipients
+    recipientAddress: '0x492b3653A38e229482Bab2f7De4A094B18017246',
+  },
+  {
     // In an effort to reduce some giant retry queues that resulted
     // from spam txs to the old TestRecipient before we were charging for
     // gas, we blacklist the old TestRecipient address.
@@ -337,7 +341,42 @@ const releaseCandidate: RootAgentConfig = {
   },
 };
 
+export const kesselRunnerNetworks = [
+  'basesepolia',
+  'arbitrumsepolia',
+  'sepolia',
+  'bsctestnet',
+  'optimismsepolia',
+];
+const neutron: RootAgentConfig = {
+  ...contextBase,
+  context: Contexts.Neutron,
+  contextChainNames: {
+    validator: [],
+    relayer: kesselRunnerNetworks,
+    scraper: [],
+  },
+  rolesWithKeys: [Role.Relayer],
+  relayer: {
+    rpcConsensusType: RpcConsensusType.Fallback,
+    docker: {
+      repo,
+      tag: 'f5d2e7a-20250410-174010',
+    },
+    whitelist: [
+      {
+        recipientAddress: '0x492b3653A38e229482Bab2f7De4A094B18017246',
+      },
+    ],
+    gasPaymentEnforcement,
+    defaultIsmCacheConfig,
+    allowContractCallCaching: true,
+    resources: relayerResources,
+  },
+};
+
 export const agents = {
   [Contexts.Hyperlane]: hyperlane,
   [Contexts.ReleaseCandidate]: releaseCandidate,
+  [Contexts.Neutron]: neutron,
 };

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -362,7 +362,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'f5d2e7a-20250410-174010',
+      tag: 'ef039ae-20250411-104801',
     },
     whitelist: [
       {

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -244,7 +244,8 @@ const defaultIsmCacheConfig: IsmCacheConfig = {
 
 const relayBlacklist: BaseRelayerConfig['blacklist'] = [
   {
-    // Ignore kessel runner test recipients
+    // Ignore kessel runner test recipients.
+    // All 5 test recipients have the same address.
     recipientAddress: '0x492b3653A38e229482Bab2f7De4A094B18017246',
   },
   {

--- a/typescript/infra/config/relayer.json
+++ b/typescript/infra/config/relayer.json
@@ -11,7 +11,7 @@
   },
   "testnet4": {
     "hyperlane": "0x16626cd24fd1f228a031e48b77602ae25f8930db",
-    "neutron": "",
+    "neutron": "0xf2c72c0befa494d62949a1699a99e2c605a0b636",
     "rc": "0x7fe8c60ead4ab10be736f4de2b3090db5a851f16"
   }
 }


### PR DESCRIPTION
### Description

feat(infra): configure testnet4-neutron-relayer for kessel runner
- kessel runner in progress
- we want to have the 3rd relayer focused purely on this, and blacklist the new testrecipients from the existing relayers to not affect regular testnet activity

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
