### PR TITLE
feat: check for unenrolled routers on new chains

### DIFF
--- a/.changeset/blue-chefs-obey.md
+++ b/.changeset/blue-chefs-obey.md
@@ -1,0 +1,9 @@
+---
+'@hyperlane-xyz/infra': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+New check: HyperlaneRouterChecker now compares the list of domains
+the Router is enrolled with against the warp route expectations.
+It will raise a violation for missing remote domains.
+`check-deploy` and `check-warp-deploy` scripts use this new check.

--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -60,9 +60,9 @@ async function main() {
   }, new Set<ChainName>());
 
   console.log(
-    `Found warp configs for chains: ${Array.from(chainsWithWarpConfigs).join(
-      ', ',
-    )}`,
+    `Found warp configs for chains: ${Array.from(chainsWithWarpConfigs)
+      .sort()
+      .join(', ')}`,
   );
 
   // Get the multiprovider once to avoid recreating it for each warp route

--- a/typescript/sdk/src/router/HyperlaneRouterChecker.ts
+++ b/typescript/sdk/src/router/HyperlaneRouterChecker.ts
@@ -21,6 +21,7 @@ import { RouterApp } from './RouterApps.js';
 import {
   ClientViolation,
   ClientViolationType,
+  MissingEnrolledRouterViolation,
   MissingRouterViolation,
   RouterConfig,
   RouterViolation,
@@ -128,10 +129,17 @@ export class HyperlaneRouterChecker<
   async checkEnrolledRouters(chain: ChainName): Promise<void> {
     const router = this.app.router(this.app.getContracts(chain));
     const actualRemoteChains = await this.app.remoteChains(chain);
+    const expectedRemoteChains = this.app
+      .chains()
+      .filter((c) => c !== chain)
+      .sort();
 
     const currentRouters: ChainMap<string> = {};
     const expectedRouters: ChainMap<string> = {};
 
+    const missingRemoteChains = expectedRemoteChains
+      .filter((chn) => !actualRemoteChains.includes(chn))
+      .sort();
     const misconfiguredRouterDiff: ChainMap<{
       actual: AddressBytes32;
       expected: AddressBytes32;
@@ -167,6 +175,19 @@ export class HyperlaneRouterChecker<
     const expectedRouterChains = actualRemoteChains.filter(
       (chain) => !missingRouterDomains.includes(chain),
     );
+
+    if (missingRemoteChains.length > 0) {
+      const violation: MissingEnrolledRouterViolation = {
+        chain,
+        type: RouterViolationType.MissingEnrolledRouter,
+        contract: router,
+        actual: actualRemoteChains.join(),
+        expected: expectedRemoteChains.join(),
+        missingChains: missingRemoteChains,
+        description: `Routers for some domains are missing from the router`,
+      };
+      this.addViolation(violation);
+    }
 
     if (Object.keys(misconfiguredRouterDiff).length > 0) {
       const violation: RouterViolation = {

--- a/typescript/sdk/src/router/HyperlaneRouterChecker.ts
+++ b/typescript/sdk/src/router/HyperlaneRouterChecker.ts
@@ -181,7 +181,7 @@ export class HyperlaneRouterChecker<
         chain,
         type: RouterViolationType.MissingEnrolledRouter,
         contract: router,
-        actual: actualRemoteChains.join(),
+        actual: actualRemoteChains.join(', '),
         expected: expectedRemoteChains.join(),
         missingChains: missingRemoteChains,
         description: `Routers for some domains are missing from the router`,

--- a/typescript/sdk/src/router/types.ts
+++ b/typescript/sdk/src/router/types.ts
@@ -61,6 +61,7 @@ export interface ClientViolation extends CheckerViolation {
 
 export enum RouterViolationType {
   MisconfiguredEnrolledRouter = 'MisconfiguredEnrolledRouter',
+  MissingEnrolledRouter = 'MissingEnrolledRouter',
   MissingRouter = 'MissingRouter',
 }
 
@@ -71,6 +72,13 @@ export interface RouterViolation extends CheckerViolation {
     actual: AddressBytes32;
     expected: AddressBytes32;
   }>;
+  description?: string;
+}
+
+export interface MissingEnrolledRouterViolation extends CheckerViolation {
+  type: RouterViolationType.MissingEnrolledRouter;
+  contract: Router;
+  missingChains: string[];
   description?: string;
 }
 


### PR DESCRIPTION
### Description

- Update HyperlaneRouterChecker to verify if all remote chain Routers are enrolled in the Router on a specific chain.
- The checker will generate one violation per chain Router listing the expected and existing enrolled chains.

### Drive-by Changes

- check-warp-deploys.ts now prints the list of known chains sorted alphabetically

### Related issues

Fixes #5440
Fixes ENG-1061

### Backward compatibility

This change introduces a new warp deployment check without changing other existing checks.

### Testing

Manually running check-warp-deploy.ts after applying the upcoming LUMIA changes from #5842.