### PR TITLE
chore(keyfunder): omit from config if value is 0

### DIFF
--- a/typescript/infra/src/funding/key-funder.ts
+++ b/typescript/infra/src/funding/key-funder.ts
@@ -67,5 +67,18 @@ export function getKeyFunderConfig(
       `Environment ${coreConfig.environment} does not have a KeyFunderConfig config`,
     );
   }
+
+  const removeZeroEntries = (obj: Record<string, string>) => {
+    for (const key in obj) {
+      if (obj[key] === '0') {
+        delete obj[key];
+      }
+    }
+  };
+
+  removeZeroEntries(keyFunderConfig.desiredBalancePerChain);
+  removeZeroEntries(keyFunderConfig.desiredKathyBalancePerChain);
+  removeZeroEntries(keyFunderConfig.igpClaimThresholdPerChain);
+
   return keyFunderConfig;
 }


### PR DESCRIPTION
### Description

chore(keyfunder): omit from config if value is 0
- by sanitising the config before initialising the `KeyFunderHelmManager`, we can omit checking of chains entirely instead of even doing a `0` check.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
