### PR TITLE
feat: Routing ISM caching

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/routing.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/routing.rs
@@ -1,13 +1,14 @@
 use async_trait::async_trait;
 use derive_more::Deref;
 use derive_new::new;
+use hyperlane_base::cache::FunctionCallCache;
 use tracing::instrument;
 
-use hyperlane_core::{HyperlaneMessage, H256};
+use hyperlane_core::{HyperlaneMessage, KnownHyperlaneDomain, ModuleType, H256};
 
 use super::{
-    base::MessageMetadataBuildParams, MessageMetadataBuilder, Metadata, MetadataBuildError,
-    MetadataBuilder,
+    base::MessageMetadataBuildParams, IsmCachePolicy, MessageMetadataBuilder, Metadata,
+    MetadataBuildError, MetadataBuilder,
 };
 
 #[derive(Clone, Debug, new, Deref)]
@@ -30,10 +31,57 @@ impl MetadataBuilder for RoutingIsmMetadataBuilder {
             .build_routing_ism(ism_address)
             .await
             .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?;
-        let module = ism
-            .route(message)
+
+        let message_domain = KnownHyperlaneDomain::try_from(message.origin)
+            .map(|domain| domain.as_str().to_string())
+            // if its an unknown domain, use the raw u32 as a string
+            .unwrap_or_else(|_| message.origin.to_string());
+        let fn_key = "route";
+
+        // Depending on the cache policy, make use of the message ID
+        let params_cache_key = match self
+            .base_builder()
+            .ism_cache_policy_classifier()
+            .get_cache_policy(self.root_ism, ism.domain(), ModuleType::Routing)
             .await
-            .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?;
+        {
+            // To have the cache key be more succinct, we use the message id
+            IsmCachePolicy::IsmSpecific => (ism.address(), H256::zero()),
+            IsmCachePolicy::MessageSpecific => (ism.address(), message.id()),
+        };
+
+        let cache_result: Option<H256> = self
+            .base_builder()
+            .cache()
+            .get_cached_call_result(message_domain.as_str(), fn_key, &params_cache_key)
+            .await
+            .map_err(|err| {
+                tracing::warn!(error = %err, "Error when caching call result for {:?}", fn_key);
+            })
+            .ok()
+            .flatten();
+
+        let module = match cache_result {
+            Some(result) => result,
+            None => {
+                let module = ism
+                    .route(message)
+                    .await
+                    .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?;
+
+                // store result in cache
+                self.base_builder()
+                    .cache()
+                    .cache_call_result(message_domain.as_str(), fn_key, &params_cache_key, &module)
+                    .await
+                    .map_err(|err| {
+                        tracing::warn!(error = %err, "Error when caching call result for {:?}", fn_key);
+                    })
+                    .ok();
+                module
+            }
+        };
+
         self.base.build(module, message, params).await
     }
 }

--- a/rust/main/hyperlane-base/src/types/s3_storage.rs
+++ b/rust/main/hyperlane-base/src/types/s3_storage.rs
@@ -128,7 +128,7 @@ impl S3Storage {
     }
 
     /// A default ConfigLoader with timeout, region, and behavior version.
-    /// Unless overriden, credentials will be loaded from the env.
+    /// Unless overridden, credentials will be loaded from the env.
     fn default_aws_sdk_config_loader(&self) -> aws_config::ConfigLoader {
         ConfigLoader::default()
             .timeout_config(


### PR DESCRIPTION
### Description

adds caching via `message.origin` for routing ISM

### Related issues

 - fixes https://linear.app/hyperlane-xyz/issue/ENG-1283/routing-ism-caching-for-the-default-ism-hyper-warp-route

### Backward compatibility

Yes

### Testing

None