### PR TITLE
feat: async checkpoint syncer builder

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/base_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base_builder.rs
@@ -226,6 +226,7 @@ impl BuildsBaseMetadata for BaseMetadataBuilder {
                             Err(CheckpointSyncerBuildError::ReorgEvent(reorg_event)) => {
                                 // If a reorg event has been posted to a checkpoint syncer,
                                 // we refuse to build
+                                // This will result in a short circuit and return an error for the entire build process of all syncers 
                                 return Err(CheckpointSyncerBuildError::ReorgEvent(reorg_event));
                             }
                             Err(err) => {
@@ -254,7 +255,7 @@ impl BuildsBaseMetadata for BaseMetadataBuilder {
             .collect::<Vec<_>>()
             .await
             .into_iter()
-            .collect::<Result<Vec<_>, _>>()? // Collect results into a single vector
+            .collect::<Result<Vec<_>, _>>()? // Collect results into a single vector and return if any of them returns an error
             .into_iter()
             .flatten() // Flatten Option<_>
             .collect::<Vec<_>>();

--- a/rust/main/agents/relayer/src/msg/metadata/base_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base_builder.rs
@@ -180,63 +180,87 @@ impl BuildsBaseMetadata for BaseMetadataBuilder {
 
         // Only use the most recently announced location for now.
         let mut checkpoint_syncers: HashMap<H160, Arc<dyn CheckpointSyncer>> = HashMap::new();
-        for (&validator, validator_storage_locations) in validators.iter().zip(storage_locations) {
-            debug!(hyp_message=?message, ?validator, ?validator_storage_locations, "Validator and its storage locations for message");
-            for storage_location in validator_storage_locations.iter().rev() {
-                let Ok(config) = CheckpointSyncerConf::from_str(storage_location) else {
-                    debug!(
-                        ?validator,
-                        ?storage_location,
-                        "Could not parse checkpoint syncer config for validator"
-                    );
-                    continue;
-                };
 
-                // If this is a LocalStorage based checkpoint syncer and it's not
-                // allowed, ignore it
-                if !self.allow_local_checkpoint_syncers
-                    && matches!(config, CheckpointSyncerConf::LocalStorage { .. })
-                {
-                    debug!(
-                        ?config,
-                        "Ignoring disallowed LocalStorage based checkpoint syncer"
-                    );
-                    continue;
-                }
-
-                match config.build_and_validate(None).await {
-                    Ok(checkpoint_syncer) => {
-                        // found the syncer for this validator
-                        checkpoint_syncers.insert(validator.into(), checkpoint_syncer.into());
-                        break;
-                    }
-                    Err(CheckpointSyncerBuildError::ReorgEvent(reorg_event)) => {
-                        // If a reorg event has been posted to a checkpoint syncer,
-                        // we refuse to build
-                        return Err(CheckpointSyncerBuildError::ReorgEvent(reorg_event));
-                    }
-                    Err(err) => {
-                        debug!(
-                            error=%err,
-                            ?config,
-                            ?validator,
-                            "Error when loading checkpoint syncer; will attempt to use the next config"
-                        );
-                    }
-                }
-            }
-            if checkpoint_syncers.get(&validator.into()).is_none() {
+        // TODO: it might make sense to make this in chunks, as we might not want to execute all the requests at the same time (worst case 50 validators)
+        let result = validators
+            .iter()
+            .zip(storage_locations)
+            .filter_map(|(validator, validator_storage_locations)| {
+                debug!(hyp_message=?message, ?validator, ?validator_storage_locations, "Validator and its storage locations for message");
                 if validator_storage_locations.is_empty() {
+                    // If the validator has not announced any storage locations, we skip it
+                    // and log a warning.
                     warn!(?validator, "Validator has not announced any storage locations; see https://docs.hyperlane.xyz/docs/operators/validators/announcing-your-validator");
-                } else {
+                    return None;
+                }
+
+                let future = async move {
+                    // Reverse the order of storage locations to prefer the most recently announced
+                    for storage_location in validator_storage_locations.iter().rev() {
+                        let Ok(config) = CheckpointSyncerConf::from_str(storage_location) else {
+                            debug!(
+                                ?validator,
+                                ?storage_location,
+                                "Could not parse checkpoint syncer config for validator"
+                            );
+                            continue;
+                        };
+
+                        // If this is a LocalStorage based checkpoint syncer and it's not
+                        // allowed, ignore it
+                        if !self.allow_local_checkpoint_syncers
+                            && matches!(config, CheckpointSyncerConf::LocalStorage { .. })
+                        {
+                            debug!(
+                                ?config,
+                                "Ignoring disallowed LocalStorage based checkpoint syncer"
+                            );
+                            continue;
+                        }
+
+                        match config.build_and_validate(None).await {
+                            Ok(checkpoint_syncer) => {
+                                // found the syncer for this validator
+                                return Ok(Some((*validator, checkpoint_syncer)));
+                            }
+                            Err(CheckpointSyncerBuildError::ReorgEvent(reorg_event)) => {
+                                // If a reorg event has been posted to a checkpoint syncer,
+                                // we refuse to build
+                                return Err(CheckpointSyncerBuildError::ReorgEvent(reorg_event));
+                            }
+                            Err(err) => {
+                                debug!(
+                                    error=%err,
+                                    ?config,
+                                    ?validator,
+                                    "Error when loading checkpoint syncer; will attempt to use the next config"
+                                );
+                            }
+                        }
+                    }
                     warn!(
                         ?validator,
                         ?validator_storage_locations,
                         "No valid checkpoint syncer configs for validator"
                     );
-                }
-            }
+                    Ok(None)
+                };
+                Some(future)
+            })
+            .collect::<Vec<_>>();
+
+        let checkpoint_syncers_results = futures::future::join_all(result)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+
+        for (validator, checkpoint_syncer) in checkpoint_syncers_results {
+            checkpoint_syncers.insert(validator.into(), checkpoint_syncer.into());
         }
+
         Ok(MultisigCheckpointSyncer::new(
             checkpoint_syncers,
             self.metrics.clone(),

--- a/rust/main/hyperlane-base/src/types/s3_storage.rs
+++ b/rust/main/hyperlane-base/src/types/s3_storage.rs
@@ -128,7 +128,7 @@ impl S3Storage {
     }
 
     /// A default ConfigLoader with timeout, region, and behavior version.
-    /// Unless overriden, credentials will be loaded from the env.
+    /// Unless overridden, credentials will be loaded from the env.
     fn default_aws_sdk_config_loader(&self) -> aws_config::ConfigLoader {
         ConfigLoader::default()
             .timeout_config(


### PR DESCRIPTION
### Description
Build the `checkpoint_syncer` in parallel for each validator in the `BaseMetadataBuilder`
- limits the number of concurrent requests to 10
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues
[Linear](https://linear.app/hyperlane-xyz/issue/BACK-148/make-basemetadatabuilderbuild-checkpoint-syncer-more-concurrent)
<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing
Ran E2E tests
<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
