### PR TITLE
feat: app-context specific ISM cache configs, reuse Ethereum HTTP reqwest clients

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -5332,6 +5332,7 @@ version = "0.1.0"
 dependencies = [
  "abigen",
  "async-trait",
+ "dashmap",
  "derive-new",
  "ethers",
  "ethers-contract",

--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -140,7 +140,12 @@ impl AggregationIsmMetadataBuilder {
         let params_cache_key = match self
             .base_builder()
             .ism_cache_policy_classifier()
-            .get_cache_policy(self.root_ism, ism.domain(), ModuleType::Aggregation)
+            .get_cache_policy(
+                self.root_ism,
+                ism.domain(),
+                ModuleType::Aggregation,
+                self.base.app_context.as_ref(),
+            )
             .await
         {
             // To have the cache key be more succinct, we use the message id

--- a/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
@@ -215,8 +215,7 @@ mod test {
     use crate::{
         msg::metadata::{
             base::MetadataBuildError, message_builder::build_message_metadata, DefaultIsmCache,
-            IsmAwareAppContextClassifier, IsmCacheConfig, IsmCachePolicyClassifier,
-            MessageMetadataBuildParams,
+            IsmAwareAppContextClassifier, IsmCachePolicyClassifier, MessageMetadataBuildParams,
         },
         settings::matching_list::{Filter, ListElement, MatchingList},
         test_utils::{
@@ -279,7 +278,7 @@ mod test {
         base_builder.responses.app_context_classifier = Some(app_context_classifier);
         base_builder.responses.ism_cache_policy_classifier = Some(IsmCachePolicyClassifier::new(
             default_ism_getter,
-            IsmCacheConfig::default(),
+            Default::default(),
         ));
         base_builder
     }

--- a/rust/main/agents/relayer/src/msg/metadata/multisig/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/multisig/base.rs
@@ -117,6 +117,7 @@ pub trait MultisigIsmMetadataBuilder: AsRef<MessageMetadataBuilder> + Send + Syn
                 self.as_ref().root_ism,
                 multisig_ism.domain(),
                 self.module_type(),
+                self.as_ref().app_context.as_ref(),
             )
             .await
         {

--- a/rust/main/agents/relayer/src/msg/metadata/routing.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/routing.rs
@@ -39,7 +39,12 @@ impl MetadataBuilder for RoutingIsmMetadataBuilder {
         let cache_policy = self
             .base_builder()
             .ism_cache_policy_classifier()
-            .get_cache_policy(self.root_ism, ism.domain(), ModuleType::Routing)
+            .get_cache_policy(
+                self.root_ism,
+                ism.domain(),
+                ModuleType::Routing,
+                self.base.app_context.as_ref(),
+            )
             .await;
 
         let cache_result: Option<H256> = match cache_policy {

--- a/rust/main/agents/relayer/src/msg/processor.rs
+++ b/rust/main/agents/relayer/src/msg/processor.rs
@@ -442,7 +442,7 @@ mod test {
         msg::{
             gas_payment::GasPaymentEnforcer,
             metadata::{
-                BaseMetadataBuilder, DefaultIsmCache, IsmAwareAppContextClassifier, IsmCacheConfig,
+                BaseMetadataBuilder, DefaultIsmCache, IsmAwareAppContextClassifier,
                 IsmCachePolicyClassifier,
             },
         },
@@ -562,7 +562,7 @@ mod test {
             cache,
             db.clone(),
             IsmAwareAppContextClassifier::new(default_ism_getter.clone(), vec![]),
-            IsmCachePolicyClassifier::new(default_ism_getter, IsmCacheConfig::default()),
+            IsmCachePolicyClassifier::new(default_ism_getter, Default::default()),
         )
     }
 

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -346,7 +346,7 @@ impl BaseAgent for Relayer {
                     ),
                     IsmCachePolicyClassifier::new(
                         default_ism_getter.clone(),
-                        settings.default_ism_cache_config.clone(),
+                        settings.ism_cache_configs.clone(),
                     ),
                 );
 
@@ -1132,7 +1132,7 @@ mod test {
             allow_local_checkpoint_syncers: true,
             metric_app_contexts: Vec::new(),
             allow_contract_call_caching: true,
-            default_ism_cache_config: Default::default(),
+            ism_cache_configs: Default::default(),
             max_retries: 1,
         }
     }

--- a/rust/main/agents/relayer/src/settings/mod.rs
+++ b/rust/main/agents/relayer/src/settings/mod.rs
@@ -477,7 +477,7 @@ mod test {
             {
                 "selector": {
                     "type": "appContext",
-                    "data": "foo"
+                    "context": "foo"
                 },
                 "moduletypes": [2],
                 "chains": ["foochain"],

--- a/rust/main/agents/relayer/src/settings/mod.rs
+++ b/rust/main/agents/relayer/src/settings/mod.rs
@@ -66,8 +66,8 @@ pub struct RelayerSettings {
     pub metric_app_contexts: Vec<(MatchingList, String)>,
     /// Whether to allow contract call caching at all.
     pub allow_contract_call_caching: bool,
-    /// The default ISM cache policy to use for all messages that use the default ISM.
-    pub default_ism_cache_config: IsmCacheConfig,
+    /// The ISM cache policies to use
+    pub ism_cache_configs: Vec<IsmCacheConfig>,
     /// Maximum number of retries per operation
     pub max_retries: u32,
 }
@@ -329,10 +329,10 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
             .parse_bool()
             .unwrap_or(true);
 
-        let default_ism_cache_config = p
+        let ism_cache_configs = p
             .chain(&mut err)
-            .get_opt_key("defaultIsmCacheConfig")
-            .and_then(parse_ism_cache_config)
+            .get_opt_key("ismCacheConfigs")
+            .and_then(parse_ism_cache_configs)
             .unwrap_or_default();
 
         let max_message_retries = p
@@ -355,7 +355,7 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
             allow_local_checkpoint_syncers,
             metric_app_contexts,
             allow_contract_call_caching,
-            default_ism_cache_config,
+            ism_cache_configs,
             max_retries: max_message_retries,
         })
     }
@@ -397,37 +397,16 @@ fn parse_matching_list(p: ValueParser) -> ConfigResult<MatchingList> {
     err.into_result(ml)
 }
 
-fn parse_json_object(p: ValueParser) -> Option<(ConfigPath, Value)> {
+fn parse_ism_cache_configs(p: ValueParser) -> ConfigResult<Vec<IsmCacheConfig>> {
     let mut err = ConfigParsingError::default();
 
-    match p {
-        ValueParser {
-            val: Value::String(array_str),
-            cwp,
-        } => serde_json::from_str::<Value>(array_str)
-            .context("Expected JSON string")
-            .take_err(&mut err, || cwp.clone())
-            .map(|v| (cwp, recase_json_value(v, Case::Flat))),
-        ValueParser {
-            val: value @ Value::Object(_),
-            cwp,
-        } => Some((cwp, value.clone())),
-        _ => Err(eyre!("Expected JSON object or stringified JSON"))
-            .take_err(&mut err, || p.cwp.clone()),
-    }
-}
-
-fn parse_ism_cache_config(p: ValueParser) -> ConfigResult<IsmCacheConfig> {
-    let mut err = ConfigParsingError::default();
-
-    let raw_object = parse_json_object(p.clone()).map(|(_, v)| v);
-    let Some(raw_object) = raw_object else {
-        return err.into_result(IsmCacheConfig::default());
+    let raw_list = parse_json_array(p.clone()).map(|(_, v)| v);
+    let Some(raw_list) = raw_list else {
+        return err.into_result(Default::default());
     };
-
-    let p = ValueParser::new(p.cwp.clone(), &raw_object);
+    let p = ValueParser::new(p.cwp.clone(), &raw_list);
     let ml = p
-        .parse_value::<IsmCacheConfig>("Expected ISM cache config")
+        .parse_value::<Vec<IsmCacheConfig>>("Expected ISM cache configs")
         .take_config_err(&mut err)
         .unwrap_or_default();
 
@@ -481,5 +460,35 @@ mod test {
         let res = parse_address_list(&input, &mut err, ConfigPath::default);
         assert_eq!(res, vec![valid_address1, valid_address2]);
         assert!(!err.is_ok());
+    }
+
+    #[test]
+    fn test_parse_ism_cache_configs() {
+        let raw = r#"
+        [
+            {
+                "selector": {
+                    "type": "defaultIsm"
+                },
+                "moduletypes": [2],
+                "chains": ["foochain"],
+                "cachepolicy": "ismSpecific"
+            },
+            {
+                "selector": {
+                    "type": "appContext",
+                    "data": "foo"
+                },
+                "moduletypes": [2],
+                "chains": ["foochain"],
+                "cachepolicy": "ismSpecific"
+            }
+        ]
+        "#;
+
+        let value = serde_json::from_str::<Value>(raw).unwrap();
+        let p = ValueParser::new(ConfigPath::default(), &value);
+        let configs = parse_ism_cache_configs(p).unwrap();
+        assert_eq!(configs.len(), 2);
     }
 }

--- a/rust/main/chains/hyperlane-ethereum/Cargo.toml
+++ b/rust/main/chains/hyperlane-ethereum/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 # Main block
 async-trait.workspace = true
+dashmap.workspace = true
 derive-new.workspace = true
 ethers-contract.workspace = true
 ethers-core.workspace = true

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -1,9 +1,10 @@
 use std::fmt::Debug;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use dashmap::DashMap;
 use ethers::middleware::gas_escalator::{Frequency, GasEscalatorMiddleware, GeometricGasPrice};
 use ethers::middleware::gas_oracle::{
     GasCategory, GasOracle, GasOracleMiddleware, Polygon, ProviderOracle,
@@ -296,6 +297,21 @@ where
 }
 
 fn build_http_provider(url: Url) -> ChainResult<Http> {
+    let client = get_reqwest_client(&url)?;
+    Ok(Http::new_with_client(url, client))
+}
+
+fn get_reqwest_client(url: &Url) -> ChainResult<Client> {
+    let client_cache = get_client_cache();
+    if let Some(client) = client_cache.get(&url) {
+        return Ok(client.clone());
+    }
+    let client = build_new_reqwest_client(url.clone())?;
+    client_cache.insert(url.clone(), client.clone());
+    Ok(client)
+}
+
+fn build_new_reqwest_client(url: Url) -> ChainResult<Client> {
     let mut queries_to_keep = vec![];
     let mut headers = reqwest::header::HeaderMap::new();
 
@@ -325,11 +341,17 @@ fn build_http_provider(url: Url) -> ChainResult<Http> {
         .clear()
         .extend_pairs(queries_to_keep);
 
-    let http_client = Client::builder()
+    let client = Client::builder()
         .timeout(HTTP_CLIENT_TIMEOUT)
         .default_headers(headers)
         .build()
         .map_err(EthereumProviderConnectionError::from)?;
 
-    Ok(Http::new_with_client(url, http_client))
+    Ok(client)
+}
+
+static CLIENT_CACHE: OnceLock<DashMap<Url, Client>> = OnceLock::new();
+
+fn get_client_cache() -> &'static DashMap<Url, Client> {
+    CLIENT_CACHE.get_or_init(DashMap::new)
 }

--- a/rust/main/hyperlane-base/src/cache/moka/dynamic_expiry.rs
+++ b/rust/main/hyperlane-base/src/cache/moka/dynamic_expiry.rs
@@ -12,7 +12,7 @@ static DEFAULT_EXPIRATION: OnceLock<Duration> = OnceLock::new();
 
 fn default_expiration() -> Duration {
     *DEFAULT_EXPIRATION.get_or_init(|| {
-        let secs = std::env::var("HYP_CACHEDEFAULTEXPIRATION")
+        let secs = std::env::var("HYP_CACHEDEFAULTEXPIRATIONSECONDS")
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(120); // default: 2 minutes

--- a/rust/main/hyperlane-base/src/cache/moka/dynamic_expiry.rs
+++ b/rust/main/hyperlane-base/src/cache/moka/dynamic_expiry.rs
@@ -1,11 +1,24 @@
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{
+    sync::OnceLock,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use chrono::{offset::LocalResult, TimeZone, Utc};
 use moka::Expiry;
 use serde::{Deserialize, Serialize};
 
 /// Default expiration time for cache entries.
-pub const DEFAULT_EXPIRATION: Duration = Duration::from_secs(60 * 10);
+static DEFAULT_EXPIRATION: OnceLock<Duration> = OnceLock::new();
+
+fn default_expiration() -> Duration {
+    *DEFAULT_EXPIRATION.get_or_init(|| {
+        let secs = std::env::var("HYP_CACHEDEFAULTEXPIRATION")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(120); // default: 2 minutes
+        Duration::from_secs(secs)
+    })
+}
 
 /// The type of expiration for a cache entry.
 ///
@@ -55,7 +68,7 @@ impl Expiration {
                     .or(Some(Duration::ZERO))
             }
             ExpirationType::Never => None,
-            ExpirationType::Default => Some(DEFAULT_EXPIRATION),
+            ExpirationType::Default => Some(default_expiration()),
         }
     }
 

--- a/rust/main/hyperlane-base/src/cache/moka/dynamic_expiry.rs
+++ b/rust/main/hyperlane-base/src/cache/moka/dynamic_expiry.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 /// Default expiration time for cache entries.
 static DEFAULT_EXPIRATION: OnceLock<Duration> = OnceLock::new();
 
-fn default_expiration() -> Duration {
+pub fn default_expiration() -> Duration {
     *DEFAULT_EXPIRATION.get_or_init(|| {
         let secs = std::env::var("HYP_CACHEDEFAULTEXPIRATIONSECONDS")
             .ok()

--- a/rust/main/hyperlane-base/src/cache/moka/dynamic_expiry.rs
+++ b/rust/main/hyperlane-base/src/cache/moka/dynamic_expiry.rs
@@ -5,7 +5,7 @@ use moka::Expiry;
 use serde::{Deserialize, Serialize};
 
 /// Default expiration time for cache entries.
-pub const DEFAULT_EXPIRATION: Duration = Duration::from_secs(60 * 2);
+pub const DEFAULT_EXPIRATION: Duration = Duration::from_secs(60 * 10);
 
 /// The type of expiration for a cache entry.
 ///

--- a/rust/main/hyperlane-base/src/cache/moka/mod.rs
+++ b/rust/main/hyperlane-base/src/cache/moka/mod.rs
@@ -116,7 +116,7 @@ mod test {
 
     use hyperlane_core::{H256, U256};
 
-    use crate::cache::moka::dynamic_expiry::DEFAULT_EXPIRATION;
+    use crate::cache::moka::dynamic_expiry::default_expiration;
 
     use super::*;
 
@@ -300,7 +300,7 @@ mod test {
                         // The second entry should have a TTL between 5 and 10 seconds
                         .is_some_and(|duration| duration.as_secs() > 5 && duration.as_secs() <= 10),
                     2 => ttl.is_some_and(|duration| {
-                        let default_secs = DEFAULT_EXPIRATION.as_secs();
+                        let default_secs = default_expiration().as_secs();
                         // The third entry should have a TTL of > 90% of the default
                         duration.as_secs() > ((default_secs * 9) / 10)
                             && duration.as_secs() <= default_secs

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -9,6 +9,7 @@ import {
   GasPaymentEnforcementPolicyType,
   IsmCacheConfig,
   IsmCachePolicy,
+  IsmCacheSelectorType,
   MatchingList,
   ModuleType,
   RpcConsensusType,
@@ -740,19 +741,24 @@ const blacklist: MatchingList = [
   })),
 ];
 
-const defaultIsmCacheConfig: IsmCacheConfig = {
-  // Default ISM Routing ISMs change configs based off message content,
-  // so they are not specified here.
-  moduleTypes: [
-    ModuleType.AGGREGATION,
-    ModuleType.MERKLE_ROOT_MULTISIG,
-    ModuleType.MESSAGE_ID_MULTISIG,
-  ],
-  // SVM is explicitly not cached as the default ISM is a multisig ISM
-  // that routes internally.
-  chains: ethereumChainNames,
-  cachePolicy: IsmCachePolicy.IsmSpecific,
-};
+const ismCacheConfigs: Array<IsmCacheConfig> = [
+  {
+    selector: {
+      type: IsmCacheSelectorType.DefaultIsm,
+    },
+    // Default ISM Routing ISMs change configs based off message content,
+    // so they are not specified here.
+    moduleTypes: [
+      ModuleType.AGGREGATION,
+      ModuleType.MERKLE_ROOT_MULTISIG,
+      ModuleType.MESSAGE_ID_MULTISIG,
+    ],
+    // SVM is explicitly not cached as the default ISM is a multisig ISM
+    // that routes internally.
+    chains: ethereumChainNames,
+    cachePolicy: IsmCachePolicy.IsmSpecific,
+  },
+];
 
 const hyperlane: RootAgentConfig = {
   ...contextBase,
@@ -768,7 +774,7 @@ const hyperlane: RootAgentConfig = {
     blacklist,
     gasPaymentEnforcement: gasPaymentEnforcement,
     metricAppContextsGetter,
-    defaultIsmCacheConfig,
+    ismCacheConfigs,
     allowContractCallCaching: true,
     resources: relayerResources,
   },
@@ -809,7 +815,7 @@ const releaseCandidate: RootAgentConfig = {
     // whitelist: releaseCandidateHelloworldMatchingList,
     gasPaymentEnforcement,
     metricAppContextsGetter,
-    defaultIsmCacheConfig,
+    ismCacheConfigs,
     allowContractCallCaching: true,
     resources: relayerResources,
   },
@@ -842,7 +848,7 @@ const neutron: RootAgentConfig = {
     blacklist,
     gasPaymentEnforcement,
     metricAppContextsGetter,
-    defaultIsmCacheConfig,
+    ismCacheConfigs,
     allowContractCallCaching: true,
     resources: relayerResources,
   },

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -286,11 +286,9 @@ const ismCacheConfigs: Array<IsmCacheConfig> = [
 ];
 
 const relayBlacklist: BaseRelayerConfig['blacklist'] = [
-  {
-    // Ignore kessel runner test recipients.
-    // All 5 test recipients have the same address.
-    recipientAddress: '0x492b3653A38e229482Bab2f7De4A094B18017246',
-  },
+  // Ignore kessel runner test recipients.
+  // All 5 test recipients have the same address.
+  ...kesselMatchingList,
   {
     // In an effort to reduce some giant retry queues that resulted
     // from spam txs to the old TestRecipient before we were charging for

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -400,7 +400,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '4894e63-20250416-110808',
+      tag: '8e87bb6-20250416-174849',
     },
     whitelist: kesselMatchingList,
     gasPaymentEnforcement,

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -399,14 +399,19 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '7bc0b10-20250415-210606',
+      tag: '98f5172-20250416-095534',
     },
     whitelist: kesselMatchingList,
     gasPaymentEnforcement,
     metricAppContextsGetter,
     ismCacheConfigs,
     allowContractCallCaching: true,
-    resources: relayerResources,
+    resources: {
+      requests: {
+        cpu: '20000m',
+        memory: '32Gi',
+      },
+    },
   },
 };
 

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -3,6 +3,7 @@ import {
   GasPaymentEnforcementPolicyType,
   IsmCacheConfig,
   IsmCachePolicy,
+  IsmCacheSelectorType,
   ModuleType,
   RpcConsensusType,
 } from '@hyperlane-xyz/sdk';
@@ -14,6 +15,7 @@ import {
 } from '../../../src/config/agent/agent.js';
 import {
   BaseRelayerConfig,
+  MetricAppContext,
   routerMatchingList,
 } from '../../../src/config/agent/relayer.js';
 import { ALL_KEY_ROLES, Role } from '../../../src/roles.js';
@@ -228,19 +230,58 @@ const scraperResources = {
   },
 };
 
-const defaultIsmCacheConfig: IsmCacheConfig = {
-  // Default ISM Routing ISMs change configs based off message content,
-  // so they are not specified here.
-  moduleTypes: [
-    ModuleType.AGGREGATION,
-    ModuleType.MERKLE_ROOT_MULTISIG,
-    ModuleType.MESSAGE_ID_MULTISIG,
-  ],
-  // SVM is explicitly not cached as the default ISM is a multisig ISM
-  // that routes internally.
-  chains: ethereumChainNames,
-  cachePolicy: IsmCachePolicy.IsmSpecific,
-};
+const kesselMatchingList = [
+  {
+    recipientAddress: '0x492b3653A38e229482Bab2f7De4A094B18017246',
+  },
+];
+
+const metricAppContextsGetter = (): MetricAppContext[] => [
+  {
+    name: 'helloworld',
+    matchingList: routerMatchingList(helloWorld[Contexts.Hyperlane].addresses),
+  },
+  {
+    name: 'kessel',
+    matchingList: kesselMatchingList,
+  },
+];
+
+const ismCacheConfigs: Array<IsmCacheConfig> = [
+  {
+    selector: {
+      type: IsmCacheSelectorType.DefaultIsm,
+    },
+    // Default ISM Routing ISMs change configs based off message content,
+    // so they are not specified here.
+    moduleTypes: [
+      ModuleType.AGGREGATION,
+      ModuleType.MERKLE_ROOT_MULTISIG,
+      ModuleType.MESSAGE_ID_MULTISIG,
+    ],
+    // SVM is explicitly not cached as the default ISM is a multisig ISM
+    // that routes internally.
+    chains: ethereumChainNames,
+    cachePolicy: IsmCachePolicy.IsmSpecific,
+  },
+  {
+    selector: {
+      type: IsmCacheSelectorType.AppContext,
+      data: 'kessel',
+    },
+    // Default ISM Routing ISMs change configs based off message content,
+    // so they are not specified here.
+    moduleTypes: [
+      ModuleType.AGGREGATION,
+      ModuleType.MERKLE_ROOT_MULTISIG,
+      ModuleType.MESSAGE_ID_MULTISIG,
+    ],
+    // SVM is explicitly not cached as the default ISM is a multisig ISM
+    // that routes internally.
+    chains: ethereumChainNames,
+    cachePolicy: IsmCachePolicy.IsmSpecific,
+  },
+];
 
 const relayBlacklist: BaseRelayerConfig['blacklist'] = [
   {
@@ -283,15 +324,8 @@ const hyperlane: RootAgentConfig = {
     },
     blacklist: [...releaseCandidateHelloworldMatchingList, ...relayBlacklist],
     gasPaymentEnforcement,
-    metricAppContextsGetter: () => [
-      {
-        name: 'helloworld',
-        matchingList: routerMatchingList(
-          helloWorld[Contexts.Hyperlane].addresses,
-        ),
-      },
-    ],
-    defaultIsmCacheConfig,
+    metricAppContextsGetter,
+    ismCacheConfigs,
     allowContractCallCaching: true,
     resources: relayerResources,
   },
@@ -327,7 +361,8 @@ const releaseCandidate: RootAgentConfig = {
     },
     blacklist: relayBlacklist,
     gasPaymentEnforcement,
-    defaultIsmCacheConfig,
+    metricAppContextsGetter,
+    ismCacheConfigs,
     allowContractCallCaching: true,
     resources: relayerResources,
   },
@@ -364,13 +399,10 @@ const neutron: RootAgentConfig = {
       repo,
       tag: 'ef039ae-20250411-104801',
     },
-    whitelist: [
-      {
-        recipientAddress: '0x492b3653A38e229482Bab2f7De4A094B18017246',
-      },
-    ],
+    whitelist: kesselMatchingList,
     gasPaymentEnforcement,
-    defaultIsmCacheConfig,
+    metricAppContextsGetter,
+    ismCacheConfigs,
     allowContractCallCaching: true,
     resources: relayerResources,
   },

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -400,7 +400,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'a4f29f0-20250416-103851',
+      tag: '4894e63-20250416-110808',
     },
     whitelist: kesselMatchingList,
     gasPaymentEnforcement,

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -236,13 +236,15 @@ const kesselMatchingList = [
   },
 ];
 
+const kesselAppContext = 'kessel';
+
 const metricAppContextsGetter = (): MetricAppContext[] => [
   {
     name: 'helloworld',
     matchingList: routerMatchingList(helloWorld[Contexts.Hyperlane].addresses),
   },
   {
-    name: 'kessel',
+    name: kesselAppContext,
     matchingList: kesselMatchingList,
   },
 ];
@@ -267,7 +269,7 @@ const ismCacheConfigs: Array<IsmCacheConfig> = [
   {
     selector: {
       type: IsmCacheSelectorType.AppContext,
-      data: 'kessel',
+      data: kesselAppContext,
     },
     // Default ISM Routing ISMs change configs based off message content,
     // so they are not specified here.

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -230,6 +230,8 @@ const scraperResources = {
   },
 };
 
+// Kessel is a load test, these are contracts involved in the load
+// test that we want to have certain relayers focus on or ignore.
 const kesselMatchingList = [
   {
     recipientAddress: '0x492b3653A38e229482Bab2f7De4A094B18017246',
@@ -269,7 +271,7 @@ const ismCacheConfigs: Array<IsmCacheConfig> = [
   {
     selector: {
       type: IsmCacheSelectorType.AppContext,
-      data: kesselAppContext,
+      context: kesselAppContext,
     },
     // Default ISM Routing ISMs change configs based off message content,
     // so they are not specified here.

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -399,7 +399,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'ef039ae-20250411-104801',
+      tag: '7bc0b10-20250415-210606',
     },
     whitelist: kesselMatchingList,
     gasPaymentEnforcement,

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -279,6 +279,7 @@ const ismCacheConfigs: Array<IsmCacheConfig> = [
       ModuleType.AGGREGATION,
       ModuleType.MERKLE_ROOT_MULTISIG,
       ModuleType.MESSAGE_ID_MULTISIG,
+      ModuleType.ROUTING,
     ],
     // SVM is explicitly not cached as the default ISM is a multisig ISM
     // that routes internally.
@@ -399,7 +400,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '98f5172-20250416-095534',
+      tag: 'a4f29f0-20250416-103851',
     },
     whitelist: kesselMatchingList,
     gasPaymentEnforcement,

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -185,7 +185,7 @@ export class RelayerHelmManager extends OmniscientAgentHelmManager {
       addressBlacklist: config.addressBlacklist,
       metricAppContexts: config.metricAppContexts,
       gasPaymentEnforcement: config.gasPaymentEnforcement,
-      defaultIsmCacheConfig: config.defaultIsmCacheConfig,
+      ismCacheConfigs: config.ismCacheConfigs,
     };
     const envConfig = objOmitKeys<RelayerConfig>(
       config,

--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -54,7 +54,7 @@ export interface BaseRelayerConfig {
   transactionGasLimit?: BigNumberish;
   skipTransactionGasLimitFor?: string[];
   metricAppContextsGetter?: () => MetricAppContext[];
-  defaultIsmCacheConfig?: IsmCacheConfig;
+  ismCacheConfigs?: Array<IsmCacheConfig>;
   allowContractCallCaching?: boolean;
 }
 
@@ -67,7 +67,7 @@ export type RelayerConfigMapConfig = Pick<
   | 'addressBlacklist'
   | 'gasPaymentEnforcement'
   | 'metricAppContexts'
-  | 'defaultIsmCacheConfig'
+  | 'ismCacheConfigs'
 >;
 // The rest of the config is intended to be set as env vars.
 export type RelayerEnvConfig = Omit<
@@ -137,8 +137,8 @@ export class RelayerConfigHelper extends AgentConfigHelper<RelayerConfig> {
         baseConfig.metricAppContextsGetter(),
       );
     }
-    if (baseConfig.defaultIsmCacheConfig) {
-      relayerConfig.defaultIsmCacheConfig = baseConfig.defaultIsmCacheConfig;
+    if (baseConfig.ismCacheConfigs) {
+      relayerConfig.ismCacheConfigs = baseConfig.ismCacheConfigs;
     }
     relayerConfig.allowContractCallCaching =
       baseConfig.allowContractCallCaching;

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -242,6 +242,7 @@ export {
   GasPaymentEnforcementPolicyType,
   IsmCacheConfig,
   IsmCachePolicy,
+  IsmCacheSelectorType,
   RelayerConfig,
   RpcConsensusType,
   ScraperConfig,

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -366,7 +366,7 @@ const IsmCacheSelector = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal(IsmCacheSelectorType.AppContext),
-    data: z.string(),
+    context: z.string(),
   }),
 ]);
 

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -355,7 +355,25 @@ export enum IsmCachePolicy {
   IsmSpecific = 'ismSpecific',
 }
 
+export enum IsmCacheSelectorType {
+  DefaultIsm = 'defaultIsm',
+  AppContext = 'appContext',
+}
+
+const IsmCacheSelector = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal(IsmCacheSelectorType.DefaultIsm),
+  }),
+  z.object({
+    type: z.literal(IsmCacheSelectorType.AppContext),
+    data: z.string(),
+  }),
+]);
+
 const IsmCacheConfigSchema = z.object({
+  selector: IsmCacheSelector.describe(
+    'The selector to use for the ISM cache policy',
+  ),
   moduleTypes: z
     .array(z.nativeEnum(ModuleType))
     .describe('The ISM module types to use the cache policy for.'),
@@ -420,11 +438,11 @@ export const RelayerAgentConfigSchema = AgentConfigSchema.extend({
     .describe(
       'A list of app contexts and their matching lists to use for metrics. A message will be classified as the first matching app context.',
     ),
-  defaultIsmCacheConfig: z
-    .union([IsmCacheConfigSchema, z.string().min(1)])
+  ismCacheConfigs: z
+    .union([z.array(IsmCacheConfigSchema), z.string().min(1)])
     .optional()
     .describe(
-      'The default ISM cache config to use for all chains. If not specified, default caching will be used.',
+      'The ISM cache configs to be used. If not specified, default caching will be used.',
     ),
   allowContractCallCaching: z
     .boolean()


### PR DESCRIPTION
### Description

- Moves away from the default ISM cache config to a vec of ISM cache configs with a selector that can match either default ISM use or a specific app context
- Motivating use case here is the testnet4 load testing doesn't actually use the default ISM. This will also allow us to cache other routes like ezETH etc that don't use the default ISM directly
- Reuses Ethereum HTTP reqwest clients instead of creating a bunch of new ones

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
