### PR TITLE
fix: Restore span for message metadata building

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
@@ -137,7 +137,7 @@ impl MessageMetadataBuilder {
 }
 
 /// Builds metadata for a message.
-#[instrument(err, skip(message_builder, message, params), fields(destination_domain=self.destination_domain().name()), ret)]
+#[instrument(err, skip(message_builder, ism_address, message, params), fields(destination_domain=message_builder.base_builder().destination_domain().name(), ism_address=ism_address.to_string()))]
 pub async fn build_message_metadata(
     message_builder: MessageMetadataBuilder,
     ism_address: H256,

--- a/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
@@ -137,6 +137,7 @@ impl MessageMetadataBuilder {
 }
 
 /// Builds metadata for a message.
+#[instrument(err, skip(message_builder, message, params), fields(destination_domain=self.destination_domain().name()), ret)]
 pub async fn build_message_metadata(
     message_builder: MessageMetadataBuilder,
     ism_address: H256,

--- a/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
@@ -137,7 +137,7 @@ impl MessageMetadataBuilder {
 }
 
 /// Builds metadata for a message.
-#[instrument(err, skip(message_builder, ism_address, message, params), fields(destination_domain=message_builder.base_builder().destination_domain().name(), ism_address=ism_address.to_string()))]
+#[instrument(err, skip(message_builder, message, params), fields(destination_domain=message_builder.base_builder().destination_domain().name()))]
 pub async fn build_message_metadata(
     message_builder: MessageMetadataBuilder,
     ism_address: H256,


### PR DESCRIPTION
### Description

Restore span for message metadata building.

Currently, the alert which is based on `build_ism_and_metadata` and metrics `hyperlane_span_duration_seconds` and `hyperlane_span_count` reports no data since span `build_ism_and_metadata` was removed some time ago.

This change adds span `build_message_metadata` which is equivalent of the removed span and we'll be able to point the alert to the new span.

### Backward compatibility

Yes

### Testing

None
