### PR TITLE
chore: add whole RPC array to chainMetadataToViemChain

### DIFF
--- a/.changeset/dirty-gifts-grin.md
+++ b/.changeset/dirty-gifts-grin.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Include entire RPC array for chainMetadataToViemChain

--- a/typescript/sdk/src/metadata/chainMetadataConversion.ts
+++ b/typescript/sdk/src/metadata/chainMetadataConversion.ts
@@ -12,14 +12,15 @@ import {
 import { PROTOCOL_TO_DEFAULT_NATIVE_TOKEN } from '../token/nativeTokenMetadata.js';
 
 export function chainMetadataToViemChain(metadata: ChainMetadata): Chain {
+  const rpcUrls = metadata.rpcUrls.map((rpcUrl) => rpcUrl.http);
   return defineChain({
     id: getChainIdNumber(metadata),
     name: metadata.displayName || metadata.name,
     network: metadata.name,
     nativeCurrency: metadata.nativeToken || test1.nativeToken!,
     rpcUrls: {
-      public: { http: [metadata.rpcUrls[0].http] },
-      default: { http: [metadata.rpcUrls[0].http] },
+      public: { http: [...rpcUrls] },
+      default: { http: [...rpcUrls] },
     },
     blockExplorers: metadata.blockExplorers?.length
       ? {

--- a/typescript/sdk/src/metadata/chainMetadataConversion.ts
+++ b/typescript/sdk/src/metadata/chainMetadataConversion.ts
@@ -19,8 +19,8 @@ export function chainMetadataToViemChain(metadata: ChainMetadata): Chain {
     network: metadata.name,
     nativeCurrency: metadata.nativeToken || test1.nativeToken!,
     rpcUrls: {
-      public: { http: [...rpcUrls] },
-      default: { http: [...rpcUrls] },
+      public: { http: rpcUrls },
+      default: { http: rpcUrls },
     },
     blockExplorers: metadata.blockExplorers?.length
       ? {


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
Include array of RPC urls to `chainMetadataToViemChain` function

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->
No
### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
Storybook
Manual