### PR TITLE
feat: gas price improvements

### DIFF
--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -1084,6 +1084,7 @@ mod test {
                         gas_limit: None,
                         max_fee_per_gas: None,
                         max_priority_fee_per_gas: None,
+                        ..Default::default()
                     },
                     operation_batch: OperationBatchConfig {
                         batch_contract_address: None,

--- a/rust/main/chains/hyperlane-ethereum/src/config.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/config.rs
@@ -55,6 +55,13 @@ pub struct TransactionOverrides {
     pub max_fee_per_gas: Option<U256>,
     /// Max priority fee per gas to use for EIP-1559 transactions.
     pub max_priority_fee_per_gas: Option<U256>,
+
+    /// Min gas price to use for Legacy transactions, in wei.
+    pub min_gas_price: Option<U256>,
+    /// Min fee per gas to use for EIP-1559 transactions.
+    pub min_fee_per_gas: Option<U256>,
+    /// Min priority fee per gas to use for EIP-1559 transactions.
+    pub min_priority_fee_per_gas: Option<U256>,
 }
 
 /// Ethereum reorg period

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -284,9 +284,8 @@ fn wrap_with_gas_escalator<M>(provider: M) -> GasEscalatorMiddleware<M>
 where
     M: Middleware + 'static,
 {
-    // Increase the gas price by 12.5% every 90 seconds
-    // (These are the default values from ethers doc comments)
-    const COEFFICIENT: f64 = 1.125;
+    // Increase the gas price by 25% every 90 seconds
+    const COEFFICIENT: f64 = 1.25;
 
     // escalating creates a new tx hash, and the submitter tracks each tx hash for at most
     // `PENDING_TX_TIMEOUT_SECS`. So the escalator will send a new tx when the initial

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -292,7 +292,7 @@ where
     // tx hash stops being tracked.
     const EVERY_SECS: u64 = PENDING_TX_TIMEOUT_SECS;
     // a 50k gwei limit is chosen to account for `treasure` chain, where the highest gas price observed is 1.2k gwei
-    const MAX_GAS_PRICE: u128 = 50_000 * 10u128.pow(9);
+    const MAX_GAS_PRICE: u128 = 3_000 * 10u128.pow(9);
     let escalator = GeometricGasPrice::new(COEFFICIENT, EVERY_SECS, MAX_GAS_PRICE.into());
     // Check the status of sent txs every eth block or so. The alternative is to subscribe to new blocks and check then,
     // which adds unnecessary load on the provider.

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -68,6 +68,21 @@ pub fn build_ethereum_connection_conf(
                 .get_opt_key("maxPriorityFeePerGas")
                 .parse_u256()
                 .end(),
+            min_gas_price: value_parser
+                .chain(err)
+                .get_opt_key("minGasPrice")
+                .parse_u256()
+                .end(),
+            min_fee_per_gas: value_parser
+                .chain(err)
+                .get_opt_key("minFeePerGas")
+                .parse_u256()
+                .end(),
+            min_priority_fee_per_gas: value_parser
+                .chain(err)
+                .get_opt_key("minPriorityFeePerGas")
+                .parse_u256()
+                .end(),
         })
         .unwrap_or_default();
 


### PR DESCRIPTION
### Description

adds:
- hardcoded gas price multiplier on EVM of 10% (previously there was none). Lmk if you'd rather have this configurable
- min gas price: configs are added under the `transactionOverrides` config, for all legacy and eip1559 fields
- higher hardcoded EVM escalator multiplier: it's now 1.25 (from a previous 1.125)
- lower tx inclusion timeout: 90 seconds (from a previous 150s), to match how long it takes to escalate


### Testing

None
