### PR TITLE
fix: Add simulation back in parallel with refreshing cache

### DIFF
--- a/rust/main/agents/relayer/src/msg/op_batch.rs
+++ b/rust/main/agents/relayer/src/msg/op_batch.rs
@@ -1,10 +1,11 @@
 use std::{sync::Arc, time::Duration};
 
 use derive_new::new;
+use futures_util::future::join_all;
 use hyperlane_core::{
     rpc_clients::DEFAULT_MAX_RPC_RETRIES, total_estimated_cost, BatchResult,
     ChainCommunicationError, ChainResult, ConfirmReason, HyperlaneDomain, Mailbox,
-    PendingOperation, PendingOperationStatus, QueueOperation, TxOutcome,
+    PendingOperation, PendingOperationStatus, QueueOperation, ReprepareReason, TxOutcome,
 };
 use itertools::{Either, Itertools};
 use tokio::time::sleep;
@@ -44,10 +45,14 @@ impl OperationBatch {
         };
 
         if !excluded_ops.is_empty() {
-            warn!(excluded_ops=?excluded_ops, "Either operations reverted in the batch or the txid wasn't included. Falling back to serial submission.");
-            OperationBatch::new(excluded_ops, self.domain)
-                .submit_serially(prepare_queue, confirm_queue, metrics)
-                .await;
+            warn!(excluded_ops=?excluded_ops, "Either operations reverted in the batch or the txid wasn't included. Sending them back to prepare queue.");
+            let reprepare = excluded_ops.into_iter().map(|mut op| {
+                let reason = ReprepareReason::ErrorSubmitting;
+                op.on_reprepare(None, reason.clone());
+                prepare_queue.push(op, Some(PendingOperationStatus::Retry(reason)))
+            });
+
+            join_all(reprepare).await;
         }
     }
 
@@ -142,7 +147,7 @@ impl OperationBatch {
         }
     }
 
-    async fn submit_serially(
+    async fn _submit_serially(
         self,
         prepare_queue: &mut OpQueue,
         confirm_queue: &mut OpQueue,


### PR DESCRIPTION
### Description

Add simulation back in parallel with refreshing cache so that we can see which calls to Mailbox.process failed in the batch.

### Backward compatibility

Yes

### Testing

Unit test with real RPC calls