### PR TITLE
fix: request latest block and fee history in parallel and filter out failed calls and estimate only successful calls

### DIFF
--- a/rust/main/agents/relayer/src/msg/op_batch.rs
+++ b/rust/main/agents/relayer/src/msg/op_batch.rs
@@ -1,10 +1,11 @@
 use std::{sync::Arc, time::Duration};
 
 use derive_new::new;
+use futures_util::future::join_all;
 use hyperlane_core::{
     rpc_clients::DEFAULT_MAX_RPC_RETRIES, total_estimated_cost, BatchResult,
     ChainCommunicationError, ChainResult, ConfirmReason, HyperlaneDomain, Mailbox,
-    PendingOperation, PendingOperationStatus, QueueOperation, TxOutcome,
+    PendingOperation, PendingOperationStatus, QueueOperation, ReprepareReason, TxOutcome,
 };
 use itertools::{Either, Itertools};
 use tokio::time::sleep;
@@ -44,10 +45,14 @@ impl OperationBatch {
         };
 
         if !excluded_ops.is_empty() {
-            warn!(excluded_ops=?excluded_ops, "Either operations reverted in the batch or the txid wasn't included. Falling back to serial submission.");
-            OperationBatch::new(excluded_ops, self.domain)
-                .submit_serially(prepare_queue, confirm_queue, metrics)
-                .await;
+            warn!(excluded_ops=?excluded_ops, "Either operations reverted in the batch or the txid wasn't included. Sending them back to prepare queue.");
+            let reprepare = excluded_ops.into_iter().map(|mut op| {
+                let reason = ReprepareReason::ErrorSubmitting;
+                op.on_reprepare(None, reason.clone());
+                prepare_queue.push(op, Some(PendingOperationStatus::Retry(reason)))
+            });
+
+            join_all(reprepare).await;
         }
     }
 
@@ -142,7 +147,7 @@ impl OperationBatch {
         }
     }
 
-    async fn submit_serially(
+    async fn _submit_serially(
         self,
         prepare_queue: &mut OpQueue,
         confirm_queue: &mut OpQueue,

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
@@ -776,14 +776,28 @@ mod test {
             EthersU256::from(ethers::utils::parse_units("15", "gwei").unwrap()).into();
         mock_provider.push(gas_price).unwrap();
 
-        // RPC 4: eth_estimateGas to the ArbitrumNodeInterface's estimateRetryableTicket function by process_estimate_costs
+        // RPC 6: eth_estimateGas to the ArbitrumNodeInterface's estimateRetryableTicket function by process_estimate_costs
         let l2_gas_limit = U256::from(200000); // 200k gas
         mock_provider.push(l2_gas_limit).unwrap();
+
+        let fee_history = FeeHistory {
+            oldest_block: ethers::types::U256::zero(),
+            base_fee_per_gas: vec![],
+            gas_used_ratio: vec![],
+            reward: vec![vec![]],
+        };
+
+        // RPC 5: eth_feeHistory from the estimate_eip1559_fees_default
+        mock_provider.push(fee_history).unwrap();
 
         let latest_block: Block<Transaction> = Block {
             gas_limit: ethers::types::U256::MAX,
             ..Block::<Transaction>::default()
         };
+
+        // RPC 4: eth_getBlockByNumber from the estimate_eip1559_fees_default
+        mock_provider.push(latest_block.clone()).unwrap();
+
         // RPC 3: eth_getBlockByNumber from the fill_tx_gas_params call in process_contract_call
         // to get the latest block gas limit and for eip 1559 fee estimation
         mock_provider.push(latest_block).unwrap();

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
@@ -438,9 +438,7 @@ where
 
     async fn refresh_block_and_fee_cache(&self, tx: &TypedTransaction) -> ChainResult<()> {
         let (eip1559_fee, latest_block) =
-            estimate_eip1559_fees(self.provider.clone(), None, &self.domain, tx)
-                .await
-                .map_err(ChainCommunicationError::from_other)?;
+            estimate_eip1559_fees(self.provider.clone(), None, &self.domain, tx).await?;
         let mut cache = self.cache.lock().await;
         cache.latest_block = Some(latest_block);
         cache.eip1559_fee = Some(eip1559_fee);

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/multicall.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/multicall.rs
@@ -2,11 +2,13 @@ use std::sync::Arc;
 
 use ethers::{abi::Detokenize, providers::Middleware};
 use ethers_contract::{builders::ContractCall, Multicall, MulticallResult, MulticallVersion};
+use itertools::{Either, Itertools};
+use tokio::sync::Mutex;
+use tracing::warn;
+
 use hyperlane_core::{
     utils::hex_or_base58_to_h256, ChainResult, HyperlaneDomain, HyperlaneProvider, U256,
 };
-use tokio::sync::Mutex;
-use tracing::warn;
 
 use crate::{ConnectionConf, EthereumProvider};
 
@@ -60,17 +62,49 @@ pub async fn build_multicall<M: Middleware + 'static>(
     Ok(multicall)
 }
 
-pub async fn batch<M, D>(
+pub fn batch<M, D>(
     multicall: &mut Multicall<M>,
     calls: Vec<ContractCall<M, D>>,
-) -> ChainResult<ContractCall<M, Vec<MulticallResult>>>
+) -> ContractCall<M, Vec<MulticallResult>>
 where
-    M: Middleware + 'static,
+    M: Middleware,
     D: Detokenize,
 {
     // clear any calls that were in the multicall beforehand
     multicall.clear_calls();
 
+    calls.into_iter().for_each(|call| {
+        multicall.add_call(call, ALLOW_BATCH_FAILURES);
+    });
+
+    multicall.as_aggregate_3_value()
+}
+
+pub fn filter_failed<M, D>(
+    calls: Vec<ContractCall<M, D>>,
+    results: Vec<MulticallResult>,
+) -> (Vec<ContractCall<M, D>>, Vec<usize>) {
+    calls
+        .into_iter()
+        .zip(results)
+        .enumerate()
+        .partition_map(|(index, (call, result))| {
+            if result.success {
+                Either::Left(call)
+            } else {
+                Either::Right(index)
+            }
+        })
+}
+
+pub async fn estimate<M, D>(
+    batch: ContractCall<M, D>,
+    calls: Vec<ContractCall<M, ()>>,
+) -> ChainResult<ContractCall<M, D>>
+where
+    M: Middleware + 'static,
+    D: Detokenize,
+{
     let mut individual_estimates_sum = Some(U256::zero());
     let overhead_per_call: U256 = MULTICALL_OVERHEAD_PER_CALL.into();
 
@@ -85,15 +119,13 @@ where
                 None
             }
         };
-        multicall.add_call(call, ALLOW_BATCH_FAILURES);
     });
 
-    let mut batch_call = multicall.as_aggregate_3_value();
-    let mut gas_limit: U256 = batch_call.estimate_gas().await?.into();
+    let mut gas_limit: U256 = batch.estimate_gas().await?.into();
     // Use the max of the sum of individual estimates and the estimate for the entire batch
     if let Some(gas_sum) = individual_estimates_sum {
         gas_limit = gas_limit.max(gas_sum)
     }
-    batch_call = batch_call.gas(gas_limit);
-    Ok(batch_call)
+
+    Ok(batch.gas(gas_limit))
 }

--- a/rust/main/chains/hyperlane-ethereum/src/tx.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/tx.rs
@@ -18,11 +18,13 @@ use ethers_core::{
         EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE,
     },
 };
+use tokio::join;
+use tokio::sync::Mutex;
+use tracing::{debug, error, info, instrument, warn};
+
 use hyperlane_core::{
     ChainCommunicationError, ChainResult, HyperlaneDomain, ReorgPeriod, H256, U256,
 };
-use tokio::sync::Mutex;
-use tracing::{debug, error, info, instrument, warn};
 
 use crate::{EthereumMailboxCache, EthereumReorgPeriod, Middleware, TransactionOverrides};
 
@@ -163,10 +165,10 @@ where
     }
 
     let eip1559_fee_result = match cached_eip1559_fee {
-        Some(fee) => Ok(fee),
-        None => estimate_eip1559_fees(provider.clone(), None, &latest_block, domain, &tx.tx).await,
+        Some(fee) => Ok((fee, latest_block)),
+        None => estimate_eip1559_fees(provider.clone(), None, domain, &tx.tx).await,
     };
-    let (base_fee, max_fee, max_priority_fee) = match eip1559_fee_result {
+    let ((base_fee, max_fee, max_priority_fee), _) = match eip1559_fee_result {
         Ok(result) => result,
         Err(err) => {
             warn!(?err, "Failed to estimate EIP-1559 fees");
@@ -223,32 +225,44 @@ pub type Eip1559Fee = (
     EthersU256, // max priority fee
 );
 
+async fn latest_block<M>(provider: Arc<M>) -> ChainResult<Block<TxHash>>
+where
+    M: Middleware + 'static,
+{
+    let latest_block = provider
+        .get_block(BlockNumber::Latest)
+        .await
+        .map_err(ChainCommunicationError::from_other)?
+        .ok_or_else(|| ProviderError::CustomError("Latest block not found".into()))?;
+    Ok(latest_block)
+}
+
 /// Use this to estimate EIP 1559 fees with some chain-specific logic.
 pub(crate) async fn estimate_eip1559_fees<M>(
     provider: Arc<M>,
     estimator: Option<FeeEstimator>,
-    latest_block: &Block<TxHash>,
     domain: &HyperlaneDomain,
     tx: &TypedTransaction,
-) -> ChainResult<Eip1559Fee>
+) -> ChainResult<(Eip1559Fee, Block<TxHash>)>
 where
     M: Middleware + 'static,
 {
     if domain.is_zksync_stack() {
-        estimate_eip1559_fees_zksync(provider, latest_block, tx).await
+        estimate_eip1559_fees_zksync(provider, tx).await
     } else {
-        estimate_eip1559_fees_default(provider, estimator, latest_block).await
+        estimate_eip1559_fees_default(provider, estimator).await
     }
 }
 
 async fn estimate_eip1559_fees_zksync<M>(
     provider: Arc<M>,
-    latest_block: &Block<TxHash>,
     tx: &TypedTransaction,
-) -> ChainResult<Eip1559Fee>
+) -> ChainResult<(Eip1559Fee, Block<TxHash>)>
 where
     M: Middleware + 'static,
 {
+    let latest_block = latest_block(provider.clone()).await?;
+
     let base_fee_per_gas = latest_block
         .base_fee_per_gas
         .ok_or_else(|| ProviderError::CustomError("EIP-1559 not activated".into()))?;
@@ -257,7 +271,10 @@ where
     let max_fee_per_gas = response.max_fee_per_gas;
     let max_priority_fee_per_gas = response.max_priority_fee_per_gas;
 
-    Ok((base_fee_per_gas, max_fee_per_gas, max_priority_fee_per_gas))
+    Ok((
+        (base_fee_per_gas, max_fee_per_gas, max_priority_fee_per_gas),
+        latest_block,
+    ))
 }
 
 async fn zksync_estimate_fee<M>(
@@ -304,23 +321,26 @@ struct ZksyncEstimateFeeResponse {
 async fn estimate_eip1559_fees_default<M>(
     provider: Arc<M>,
     estimator: Option<FeeEstimator>,
-    latest_block: &Block<TxHash>,
-) -> ChainResult<(EthersU256, EthersU256, EthersU256)>
+) -> ChainResult<((EthersU256, EthersU256, EthersU256), Block<TxHash>)>
 where
     M: Middleware + 'static,
 {
+    let latest_block = latest_block(provider.clone());
+    let fee_history = provider.fee_history(
+        EIP1559_FEE_ESTIMATION_PAST_BLOCKS,
+        BlockNumber::Latest,
+        &[EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE],
+    );
+
+    let (latest_block, fee_history) = join!(latest_block, fee_history);
+    let (latest_block, fee_history) = (
+        latest_block?,
+        fee_history.map_err(ChainCommunicationError::from_other)?,
+    );
+
     let base_fee_per_gas = latest_block
         .base_fee_per_gas
         .ok_or_else(|| ProviderError::CustomError("EIP-1559 not activated".into()))?;
-
-    let fee_history = provider
-        .fee_history(
-            EIP1559_FEE_ESTIMATION_PAST_BLOCKS,
-            BlockNumber::Latest,
-            &[EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE],
-        )
-        .await
-        .map_err(ChainCommunicationError::from_other)?;
 
     // use the provided fee estimator function, or fallback to the default implementation.
     let (max_fee_per_gas, max_priority_fee_per_gas) = if let Some(es) = estimator {
@@ -329,7 +349,10 @@ where
         eip1559_default_estimator(base_fee_per_gas, fee_history.reward)
     };
 
-    Ok((base_fee_per_gas, max_fee_per_gas, max_priority_fee_per_gas))
+    Ok((
+        (base_fee_per_gas, max_fee_per_gas, max_priority_fee_per_gas),
+        latest_block,
+    ))
 }
 
 pub(crate) async fn call_with_reorg_period<M, T>(


### PR DESCRIPTION
### Description

Request latest block and fee history in parallel so that the latency to update cache with block number and fees is reduced. 

We filter out failed calls from the batch so that the batch is smaller and we don't waist resources.

### Backward compatibility

Yes

### Testing

Unit test with real RPC calls