### PR TITLE
fix: filter out failed calls and estimate only successful calls

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
@@ -620,7 +620,7 @@ where
                 self.provider.clone(),
                 &self.conn.transaction_overrides,
                 &self.domain,
-                true,
+                false,
                 self.cache.clone(),
             )
         });

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/multicall.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/multicall.rs
@@ -2,11 +2,13 @@ use std::sync::Arc;
 
 use ethers::{abi::Detokenize, providers::Middleware};
 use ethers_contract::{builders::ContractCall, Multicall, MulticallResult, MulticallVersion};
+use itertools::{Either, Itertools};
+use tokio::sync::Mutex;
+use tracing::warn;
+
 use hyperlane_core::{
     utils::hex_or_base58_to_h256, ChainResult, HyperlaneDomain, HyperlaneProvider, U256,
 };
-use tokio::sync::Mutex;
-use tracing::warn;
 
 use crate::{ConnectionConf, EthereumProvider};
 
@@ -60,17 +62,49 @@ pub async fn build_multicall<M: Middleware + 'static>(
     Ok(multicall)
 }
 
-pub async fn batch<M, D>(
+pub fn batch<M, D>(
     multicall: &mut Multicall<M>,
     calls: Vec<ContractCall<M, D>>,
-) -> ChainResult<ContractCall<M, Vec<MulticallResult>>>
+) -> ContractCall<M, Vec<MulticallResult>>
 where
-    M: Middleware + 'static,
+    M: Middleware,
     D: Detokenize,
 {
     // clear any calls that were in the multicall beforehand
     multicall.clear_calls();
 
+    calls.into_iter().for_each(|call| {
+        multicall.add_call(call, ALLOW_BATCH_FAILURES);
+    });
+
+    multicall.as_aggregate_3_value()
+}
+
+pub fn filter_failed<M, D>(
+    calls: Vec<ContractCall<M, D>>,
+    results: Vec<MulticallResult>,
+) -> (Vec<ContractCall<M, D>>, Vec<usize>) {
+    calls
+        .into_iter()
+        .zip(results)
+        .enumerate()
+        .partition_map(|(index, (call, result))| {
+            if result.success {
+                Either::Left(call)
+            } else {
+                Either::Right(index)
+            }
+        })
+}
+
+pub async fn estimate<M, D>(
+    batch: ContractCall<M, D>,
+    calls: Vec<ContractCall<M, ()>>,
+) -> ChainResult<ContractCall<M, D>>
+where
+    M: Middleware + 'static,
+    D: Detokenize,
+{
     let mut individual_estimates_sum = Some(U256::zero());
     let overhead_per_call: U256 = MULTICALL_OVERHEAD_PER_CALL.into();
 
@@ -85,15 +119,13 @@ where
                 None
             }
         };
-        multicall.add_call(call, ALLOW_BATCH_FAILURES);
     });
 
-    let mut batch_call = multicall.as_aggregate_3_value();
-    let mut gas_limit: U256 = batch_call.estimate_gas().await?.into();
+    let mut gas_limit: U256 = batch.estimate_gas().await?.into();
     // Use the max of the sum of individual estimates and the estimate for the entire batch
     if let Some(gas_sum) = individual_estimates_sum {
         gas_limit = gas_limit.max(gas_sum)
     }
-    batch_call = batch_call.gas(gas_limit);
-    Ok(batch_call)
+
+    Ok(batch.gas(gas_limit))
 }

--- a/rust/main/chains/hyperlane-ethereum/src/tx.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/tx.rs
@@ -18,8 +18,8 @@ use ethers_core::{
         EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE,
     },
 };
-use tokio::join;
 use tokio::sync::Mutex;
+use tokio::try_join;
 use tracing::{debug, error, info, instrument, warn};
 
 use hyperlane_core::{
@@ -326,17 +326,19 @@ where
     M: Middleware + 'static,
 {
     let latest_block = latest_block(provider.clone());
-    let fee_history = provider.fee_history(
-        EIP1559_FEE_ESTIMATION_PAST_BLOCKS,
-        BlockNumber::Latest,
-        &[EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE],
-    );
 
-    let (latest_block, fee_history) = join!(latest_block, fee_history);
-    let (latest_block, fee_history) = (
-        latest_block?,
-        fee_history.map_err(ChainCommunicationError::from_other)?,
-    );
+    let fee_history = async {
+        provider
+            .fee_history(
+                EIP1559_FEE_ESTIMATION_PAST_BLOCKS,
+                BlockNumber::Latest,
+                &[EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE],
+            )
+            .await
+            .map_err(ChainCommunicationError::from_other)
+    };
+
+    let (latest_block, fee_history) = try_join!(latest_block, fee_history)?;
 
     let base_fee_per_gas = latest_block
         .base_fee_per_gas


### PR DESCRIPTION
### Description

We filter out failed calls from the batch so that the batch is smaller and we don't waist resources.

### Backward compatibility

Yes

### Testing

Unit tests
