### PR TITLE
feat: add irregular safes for checking

### DIFF
--- a/typescript/infra/config/environments/mainnet3/governance/safe/irregular.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/safe/irregular.ts
@@ -1,0 +1,6 @@
+import { ChainMap } from '@hyperlane-xyz/sdk';
+import { Address } from '@hyperlane-xyz/utils';
+
+export const irregularSafes: ChainMap<Address> = {
+  ethereum: '0xec2EdC01a2Fbade68dBcc80947F43a5B408cC3A0',
+};

--- a/typescript/infra/config/environments/mainnet3/governance/signers/irregular.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/signers/irregular.ts
@@ -1,0 +1,13 @@
+import { Address } from '@hyperlane-xyz/utils';
+
+export const irregularSigners: Address[] = [
+  '0x9f500df92175b2ac36f8d443382b219d211d354a',
+  '0x82950a6356316272dF1928C72F5F0A44D9673c88',
+  '0x861FC61a961F8AFDf115B8DE274101B9ECea2F26',
+  '0x3b548E88BA3259A6f45DEeA91449cdda5cF164b3',
+  '0xD5c0D17cCb9071D27a4F7eD8255F59989b9aee0d',
+  '0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6',
+  '0x87fcEcb180E0275C22CEF213FF301816bB24E74B',
+];
+
+export const irregularThreshold = 5;

--- a/typescript/infra/config/environments/mainnet3/governance/utils.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/utils.ts
@@ -6,8 +6,10 @@ import { GovernanceType } from '../../../../src/governance.js';
 import { awIcas } from './ica/aw.js';
 import { regularIcas } from './ica/regular.js';
 import { awSafes } from './safe/aw.js';
+import { irregularSafes } from './safe/irregular.js';
 import { regularSafes } from './safe/regular.js';
 import { awSigners, awThreshold } from './signers/aw.js';
+import { irregularSigners, irregularThreshold } from './signers/irregular.js';
 import { regularSigners, regularThreshold } from './signers/regular.js';
 
 export function getGovernanceSafes(governanceType: GovernanceType) {
@@ -16,6 +18,8 @@ export function getGovernanceSafes(governanceType: GovernanceType) {
       return regularSafes;
     case GovernanceType.AbacusWorks:
       return awSafes;
+    case GovernanceType.Irregular:
+      return irregularSafes;
     default:
       throw new Error(`Unknown governance type: ${governanceType}`);
   }
@@ -27,6 +31,8 @@ export function getGovernanceIcas(governanceType: GovernanceType) {
       return regularIcas;
     case GovernanceType.AbacusWorks:
       return awIcas;
+    case GovernanceType.Irregular:
+      return {};
     default:
       throw new Error(`Unknown governance type: ${governanceType}`);
   }
@@ -46,6 +52,11 @@ export function getGovernanceSigners(governanceType: GovernanceType): {
       return {
         signers: awSigners,
         threshold: awThreshold,
+      };
+    case GovernanceType.Irregular:
+      return {
+        signers: irregularSigners,
+        threshold: irregularThreshold,
       };
   }
 }

--- a/typescript/infra/src/governance.ts
+++ b/typescript/infra/src/governance.ts
@@ -13,6 +13,7 @@ import { DeployEnvironment } from './config/environment.js';
 export enum GovernanceType {
   AbacusWorks = 'abacusWorks',
   Regular = 'regular',
+  Irregular = 'irregular',
 }
 
 export enum Owner {


### PR DESCRIPTION
### Description

- Add irregular GovernanceType and irregulare governance safe address and config for etheruem
- This is only needed for checking

`LOG_FORMAT=pretty LOG_LEVEL=debug yarn tsx ./scripts/safes/governance/check-safe-signers.ts --governanceType irregular`

### Testing

Manual
