### PR TITLE
feat: gas price cap and batch gas limit optimization

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/config.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/config.rs
@@ -72,6 +72,9 @@ pub struct TransactionOverrides {
     pub gas_price_multiplier_denominator: Option<U256>,
     /// Gas price multiplier numerator to use for transactions, eg 100
     pub gas_price_multiplier_numerator: Option<U256>,
+
+    /// Gas price cap, in wei.
+    pub gas_price_cap: Option<U256>,
 }
 
 /// Ethereum reorg period

--- a/rust/main/chains/hyperlane-ethereum/src/tx.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/tx.rs
@@ -202,7 +202,7 @@ where
         Err(err) => {
             warn!(?err, "Failed to estimate EIP-1559 fees");
             // Assume it's not an EIP 1559 chain
-            return Ok(apply_legacy_min_gas_price(tx, transaction_overrides).gas(gas_limit));
+            return Ok(apply_legacy_overrides(tx, transaction_overrides).gas(gas_limit));
         }
     };
 
@@ -212,7 +212,7 @@ where
     // fee lower than 3 gwei because of privileged transactions being included by block
     // producers that have a lower priority fee.
     if base_fee.is_zero() {
-        return Ok(apply_legacy_min_gas_price(tx, transaction_overrides).gas(gas_limit));
+        return Ok(apply_legacy_overrides(tx, transaction_overrides).gas(gas_limit));
     }
 
     // Apply overrides for EIP 1559 tx params if they exist.
@@ -240,7 +240,7 @@ where
     Ok(eip_1559_tx.gas(gas_limit))
 }
 
-fn apply_legacy_min_gas_price<M, D>(
+fn apply_legacy_overrides<M, D>(
     tx: ContractCall<M, D>,
     transaction_overrides: &TransactionOverrides,
 ) -> ContractCall<M, D>
@@ -248,23 +248,19 @@ where
     M: Middleware + 'static,
     D: Detokenize,
 {
-    let gas_price = max_between_options(
-        tx.tx.gas_price(),
-        transaction_overrides.min_gas_price.map(Into::into),
-    );
-    if let Some(gas_price) = gas_price {
-        return tx.gas_price(gas_price);
-    }
-    tx
-}
+    let mut gas_price = tx.tx.gas_price();
+    // if no gas price was set in the tx, leave the tx as is and return early
+    let Some(mut gas_price) = gas_price else {
+        return tx;
+    };
 
-fn max_between_options(a: Option<EthersU256>, b: Option<EthersU256>) -> Option<EthersU256> {
-    match (a, b) {
-        (Some(a), Some(b)) => Some(a.max(b)),
-        (Some(a), None) => Some(a),
-        (None, Some(b)) => Some(b),
-        (None, None) => None,
-    }
+    let min_price_override = transaction_overrides
+        .min_gas_price
+        .map(Into::into)
+        .unwrap_or(0.into());
+    gas_price = gas_price.max(min_price_override);
+    gas_price = apply_gas_price_cap(gas_price, transaction_overrides);
+    tx.gas_price(gas_price)
 }
 
 fn apply_1559_multipliers_and_overrides(
@@ -290,7 +286,25 @@ fn apply_1559_multipliers_and_overrides(
     if let Some(min_priority_fee) = transaction_overrides.min_priority_fee_per_gas {
         max_priority_fee = max_priority_fee.max(min_priority_fee.into());
     }
+    max_fee = apply_gas_price_cap(max_fee, transaction_overrides);
     (max_fee, max_priority_fee)
+}
+
+fn apply_gas_price_cap(
+    gas_price: EthersU256,
+    transaction_overrides: &TransactionOverrides,
+) -> EthersU256 {
+    if let Some(gas_price_cap) = transaction_overrides.gas_price_cap {
+        if gas_price > gas_price_cap.into() {
+            warn!(
+                ?gas_price,
+                ?gas_price_cap,
+                "Gas price for transaction is higher than the gas price cap. Capping it to the gas price cap."
+            );
+            return gas_price_cap.into();
+        }
+    }
+    gas_price
 }
 
 type FeeEstimator = fn(EthersU256, Vec<Vec<EthersU256>>) -> (EthersU256, EthersU256);

--- a/rust/main/chains/hyperlane-ethereum/src/tx.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/tx.rs
@@ -248,7 +248,7 @@ where
     M: Middleware + 'static,
     D: Detokenize,
 {
-    let mut gas_price = tx.tx.gas_price();
+    let gas_price = tx.tx.gas_price();
     // if no gas price was set in the tx, leave the tx as is and return early
     let Some(mut gas_price) = gas_price else {
         return tx;

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -106,6 +106,12 @@ pub fn build_ethereum_connection_conf(
                 .get_opt_key("gasPriceMultiplierNumerator")
                 .parse_u256()
                 .end(),
+
+            gas_price_cap: value_parser
+                .chain(err)
+                .get_opt_key("gasPriceCap")
+                .parse_u256()
+                .end(),
         })
         .unwrap_or_default();
 


### PR DESCRIPTION
### Description

- adds a gas price cap tx override
- scales down the batch gas limit to 80% of the estimate, since in practice we use no more than 65% of the estimate

### Testing

e2e
