### PR TITLE
fix: emit Remote Transfer events first to fix incorrect order of emissions in logs of explorer transactions

### DIFF
--- a/solidity/contracts/token/libs/TokenRouter.sol
+++ b/solidity/contracts/token/libs/TokenRouter.sol
@@ -20,24 +20,24 @@ abstract contract TokenRouter is GasRouter {
      * @dev Emitted on `transferRemote` when a transfer message is dispatched.
      * @param destination The identifier of the destination chain.
      * @param recipient The address of the recipient on the destination chain.
-     * @param amount The amount of tokens sent in to the remote recipient.
+     * @param amountOrId The amount of tokens (or the token identifier for NFTs) sent in to the remote recipient.
      */
     event SentTransferRemote(
         uint32 indexed destination,
         bytes32 indexed recipient,
-        uint256 amount
+        uint256 amountOrId
     );
 
     /**
      * @dev Emitted on `_handle` when a transfer message is processed.
      * @param origin The identifier of the origin chain.
      * @param recipient The address of the recipient on the destination chain.
-     * @param amount The amount of tokens received from the remote sender.
+     * @param amountOrId The amount of tokens (or the token identifier for NFTs) received from the remote sender.
      */
     event ReceivedTransferRemote(
         uint32 indexed origin,
         bytes32 indexed recipient,
-        uint256 amount
+        uint256 amountOrId
     );
 
     constructor(address _mailbox) GasRouter(_mailbox) {}
@@ -46,9 +46,9 @@ abstract contract TokenRouter is GasRouter {
      * @notice Transfers `_amountOrId` token to `_recipient` on `_destination` domain.
      * @dev Delegates transfer logic to `_transferFromSender` implementation.
      * @dev Emits `SentTransferRemote` event on the origin chain.
-     * @param _destination The identifier of the destination chain.
+     * @param _destination The identifier of the destination chain. (_e.g: chain ID_)
      * @param _recipient The address of the recipient on the destination chain.
-     * @param _amountOrId The amount or identifier of tokens to be sent to the remote recipient.
+     * @param _amountOrId The amount of tokens or tokenId identifier to be sent to the remote recipient.
      * @return messageId The identifier of the dispatched message.
      */
     function transferRemote(
@@ -65,9 +65,9 @@ abstract contract TokenRouter is GasRouter {
      * @dev Delegates transfer logic to `_transferFromSender` implementation.
      * @dev The metadata is the token metadata, and is DIFFERENT than the hook metadata.
      * @dev Emits `SentTransferRemote` event on the origin chain.
-     * @param _destination The identifier of the destination chain.
+     * @param _destination The identifier of the destination chain. (_e.g: chain ID_)
      * @param _recipient The address of the recipient on the destination chain.
-     * @param _amountOrId The amount or identifier of tokens to be sent to the remote recipient.
+     * @param _amountOrId The amount of tokens or tokenId identifier to be sent to the remote recipient.
      * @param _hookMetadata The metadata passed into the hook
      * @param _hook The post dispatch hook to be called by the Mailbox
      * @return messageId The identifier of the dispatched message.
@@ -201,14 +201,14 @@ abstract contract TokenRouter is GasRouter {
         bytes calldata _message
     ) internal virtual override {
         bytes32 recipient = _message.recipient();
-        uint256 amount = _message.amount();
+        uint256 amountOrId = _message.amount();
         bytes calldata metadata = _message.metadata();
 
-        emit ReceivedTransferRemote(_origin, recipient, amount);
+        emit ReceivedTransferRemote(_origin, recipient, amountOrId);
 
         _transferTo(
             recipient.bytes32ToAddress(),
-            _inboundAmount(amount),
+            _inboundAmount(amountOrId),
             metadata
         );
     }

--- a/solidity/contracts/token/libs/TokenRouter.sol
+++ b/solidity/contracts/token/libs/TokenRouter.sol
@@ -115,9 +115,11 @@ abstract contract TokenRouter is GasRouter {
         bytes memory _hookMetadata,
         address _hook
     ) internal virtual returns (bytes32 messageId) {
+        uint256 outboundAmount = _outboundAmount(_amountOrId);
+        emit SentTransferRemote(_destination, _recipient, outboundAmount);
+
         bytes memory _tokenMetadata = _transferFromSender(_amountOrId);
 
-        uint256 outboundAmount = _outboundAmount(_amountOrId);
         bytes memory _tokenMessage = TokenMessage.format(
             _recipient,
             outboundAmount,
@@ -131,8 +133,6 @@ abstract contract TokenRouter is GasRouter {
             _hookMetadata,
             _hook
         );
-
-        emit SentTransferRemote(_destination, _recipient, outboundAmount);
     }
 
     /**
@@ -203,12 +203,14 @@ abstract contract TokenRouter is GasRouter {
         bytes32 recipient = _message.recipient();
         uint256 amount = _message.amount();
         bytes calldata metadata = _message.metadata();
+
+        emit ReceivedTransferRemote(_origin, recipient, amount);
+
         _transferTo(
             recipient.bytes32ToAddress(),
             _inboundAmount(amount),
             metadata
         );
-        emit ReceivedTransferRemote(_origin, recipient, amount);
     }
 
     /**


### PR DESCRIPTION
### Description

The goal of this PR is to fix the order in which events are emitted when performing a remote transfer transaction.

Currently, the events [`SentTransferRemote`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/f297a0994a1446141b5c1664331c21a58dffb299/solidity/contracts/token/libs/TokenRouter.sol#L19-L29) and [`ReceivedTransferRemote`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/f297a0994a1446141b5c1664331c21a58dffb299/solidity/contracts/token/libs/TokenRouter.sol#L31-L41) are emitted out of order since they are emitted at the end of the functions:
- before the logic of the ERC20/721 `_mint` or `_burn` function runs (which itself emits an event)
- before the `mailbox.dispatch(...)` function is called by the token wrapper `HypERC20/721` or `HypERC20Collateral/721Collateral`.

If we read and follow the code of the function logic, we can derive the following flow:
1. (a) the `HypERC20`/`HypERC721` token contract receives a request to perform a remote transfer of `amount` to `destination` (= read chain ID)
2. (b) the `HypERC20` / `HypERC20Collateral` (or ERC721 equivalent) token contract performs the token transfer (by locking it in the collateral via `safeTransferFrom`, or burning it for the synthetic one)
3. (c) the `HypERC20` / `HypERC20Collateral` token contract (or ERC721 equivalent) calls the Mailbox to dispatch the message.

![photo_2025-03-12_17-47-12](https://github.com/user-attachments/assets/d9af0da1-ecc0-41b2-ae7e-8cfc5626960f)
![image](https://github.com/user-attachments/assets/1bbab73a-1ba8-4cbf-8d64-e0bfecc4c6da)
![image](https://github.com/user-attachments/assets/5893f8ee-e300-4bd8-9605-7e1f52daf60b)


If we look at the logs of this [remote transfer transaction as an example](https://gnosisscan.io/tx/0x697aa6b0ae1780fa424107cbdcb60dc03e4168badc0d07eec44676c1882ad918#eventlog), we can see how the events are emitted out of orders:
1. First the `Transfer` event is emitted (action (b) above)
2. Second the `Dispatch` and `DispatchId` events are emitted (action (c) above)
3. Finally, the `SentTransferRemote` event is emitted at the end (bottom of the 2nd screenshot below)

> NB: I have skipped 3rd + 4th event in the logs below, since they are related to a custom hook / ISM setup in the warp route I am building.

![image](https://github.com/user-attachments/assets/c9a95752-4db9-4115-9751-f2a9eb7aba8c)

![image](https://github.com/user-attachments/assets/f37d56ce-f474-466d-bf7d-a4d6cef5c597)

Therefore, we can see that: 
- the event `SentTransferRemote` (inherited by the `HypERC20` token contract from `TokenRouter`) is emitted completely at the end. It is the last event emitted.
- the events `Dispatch` and `DispatchId` are emitted before `SentTransferRemote`. This seems not logical, as reading the logs, it is equivalent to reading _"the message has be"_.

Wouldn't it make more sense to have the `SentTransferRemote` event emitted first before calling the Mailbox?

Let's consider a scenario where you have some complex interaction flows, like some custom Hyperlane hook or ISM being called and re-trigger a transaction on the `HypERC20` token. If that's the case, **the second `SentTransferRemote` event (from the re-entrant call) would be emitted first, while the first one (from the original transaction) would be emitted second**, leading to out of order events.
In addition, since events write to the blockchain inside the logs, we can consider that this violates the _“checks effects interactions”_ pattern.

> **Note:** I also took the opportunity to improve some variable names and Natspec comments I noticed in the `TokenRouter` contract. 