### PR TITLE
feat: metadata building fast path

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -244,7 +244,10 @@ impl AggregationIsmMetadataBuilder {
             ));
         }
         let sub_module_metadata = SubModuleMetadata::new(message_id_multisig_ism_index, metadata);
-        let metadata = Metadata::new(Self::format_metadata(&mut [sub_module_metadata], 1));
+        let metadata = Metadata::new(Self::format_metadata(
+            &mut [sub_module_metadata],
+            ism_addresses.len(),
+        ));
         Ok(metadata)
     }
 }

--- a/rust/main/agents/relayer/src/msg/metadata/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base.rs
@@ -42,6 +42,8 @@ pub enum MetadataBuildError {
     MaxValidatorCountReached(u32),
     #[error("Aggregation threshold not met ({0})")]
     AggregationThresholdNotMet(u32),
+    #[error("Fast path error ({0})")]
+    FastPathError(String),
 }
 
 #[derive(Clone, Debug, new)]

--- a/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
@@ -61,7 +61,7 @@ impl MetadataBuilder for MessageMetadataBuilder {
         message: &HyperlaneMessage,
         params: MessageMetadataBuildParams,
     ) -> Result<Metadata, MetadataBuildError> {
-        build_message_metadata(self.clone(), ism_address, message, params)
+        build_message_metadata(self.clone(), ism_address, message, params, None)
             .await
             .map(|res| res.metadata)
     }
@@ -136,21 +136,31 @@ impl MessageMetadataBuilder {
     }
 }
 
+pub async fn ism_and_module_type(
+    message_builder: MessageMetadataBuilder,
+    ism_address: H256,
+) -> Result<(Box<dyn InterchainSecurityModule>, ModuleType), MetadataBuildError> {
+    let ism = message_builder
+        .base_builder()
+        .build_ism(ism_address)
+        .await
+        .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?;
+    let module_type = message_builder.call_module_type(&ism).await?;
+    Ok((ism, module_type))
+}
+
 /// Builds metadata for a message.
 pub async fn build_message_metadata(
     message_builder: MessageMetadataBuilder,
     ism_address: H256,
     message: &HyperlaneMessage,
     mut params: MessageMetadataBuildParams,
+    maybe_ism_and_module_type: Option<(Box<dyn InterchainSecurityModule>, ModuleType)>,
 ) -> Result<IsmWithMetadataAndType, MetadataBuildError> {
-    let ism: Box<dyn InterchainSecurityModule> = message_builder
-        .base_builder()
-        .build_ism(ism_address)
-        .await
-        .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?;
-
-    let module_type = message_builder.call_module_type(&ism).await?;
-
+    let (ism, module_type) = match maybe_ism_and_module_type {
+        Some((ism, module_type)) => (ism, module_type),
+        None => ism_and_module_type(message_builder.clone(), ism_address).await?,
+    };
     // check if max depth is reached
     if params.ism_depth >= message_builder.max_ism_depth {
         tracing::error!(
@@ -214,8 +224,10 @@ mod test {
 
     use crate::{
         msg::metadata::{
-            base::MetadataBuildError, message_builder::build_message_metadata, DefaultIsmCache,
-            IsmAwareAppContextClassifier, IsmCachePolicyClassifier, MessageMetadataBuildParams,
+            base::MetadataBuildError,
+            message_builder::{build_message_metadata, ism_and_module_type},
+            DefaultIsmCache, IsmAwareAppContextClassifier, IsmCachePolicyClassifier,
+            MessageMetadataBuildParams,
         },
         settings::matching_list::{Filter, ListElement, MatchingList},
         test_utils::{
@@ -460,9 +472,10 @@ mod test {
             builder
         };
         let params = MessageMetadataBuildParams::default();
-        let err = build_message_metadata(message_builder, ism_address, &message, params.clone())
-            .await
-            .expect_err("Metadata found when it should have failed");
+        let err =
+            build_message_metadata(message_builder, ism_address, &message, params.clone(), None)
+                .await
+                .expect_err("Metadata found when it should have failed");
         assert_eq!(err, MetadataBuildError::MaxIsmDepthExceeded(0));
         assert_eq!(*(params.ism_count.lock().await), 0);
 
@@ -488,9 +501,10 @@ mod test {
         };
 
         let params = MessageMetadataBuildParams::default();
-        let err = build_message_metadata(message_builder, ism_address, &message, params.clone())
-            .await
-            .expect_err("Metadata found when it should have failed");
+        let err =
+            build_message_metadata(message_builder, ism_address, &message, params.clone(), None)
+                .await
+                .expect_err("Metadata found when it should have failed");
         assert_eq!(err, MetadataBuildError::MaxIsmCountReached(0));
         assert_eq!(*(params.ism_count.lock().await), 0);
 
@@ -516,9 +530,10 @@ mod test {
         };
 
         let params = MessageMetadataBuildParams::default();
-        let err = build_message_metadata(message_builder, ism_address, &message, params.clone())
-            .await
-            .expect_err("Metadata found when it should have failed");
+        let err =
+            build_message_metadata(message_builder, ism_address, &message, params.clone(), None)
+                .await
+                .expect_err("Metadata found when it should have failed");
         assert_eq!(err, MetadataBuildError::AggregationThresholdNotMet(2));
         assert!(*(params.ism_count.lock().await) <= 4);
         assert!(logs_contain("Max ISM depth reached ism_depth=2"));
@@ -543,9 +558,10 @@ mod test {
         };
 
         let params = MessageMetadataBuildParams::default();
-        let err = build_message_metadata(message_builder, ism_address, &message, params.clone())
-            .await
-            .expect_err("Metadata found when it should have failed");
+        let err =
+            build_message_metadata(message_builder, ism_address, &message, params.clone(), None)
+                .await
+                .expect_err("Metadata found when it should have failed");
         assert_eq!(err, MetadataBuildError::AggregationThresholdNotMet(2));
         assert_eq!(*(params.ism_count.lock().await), 5);
         assert!(logs_contain("Max ISM count reached ism_count=5"));

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -987,7 +987,7 @@ impl PendingMessage {
             .build(ism_address, &self.message, params)
             .await
             .map_err(|err| match &err {
-                MetadataBuildError::FailedToBuild(_) => {
+                MetadataBuildError::FailedToBuild(_) | MetadataBuildError::FastPathError(_) => {
                     self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
                 }
                 MetadataBuildError::CouldNotFetch => {

--- a/rust/main/hyperlane-base/src/settings/trace/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/trace/mod.rs
@@ -76,8 +76,8 @@ impl TracingConfig {
                 .with_target("tendermint", Level::Info)
                 .with_target("tokio", Level::Debug)
                 .with_target("tokio_util", Level::Debug)
-                .with_target("aws_smithy", Level::Info)
-                .with_target("aws_sdk", Level::Info)
+                .with_target("aws_sdk_s3", Level::Info)
+                .with_target("aws_smithy_runtime_api", Level::Info)
                 // Enable Trace level for Tokio if you want to use tokio-console
                 // .with_target("tokio", Level::Trace)
                 // .with_target("tokio_util", Level::Trace)

--- a/typescript/infra/config/environments/test/aggregationIsm.ts
+++ b/typescript/infra/config/environments/test/aggregationIsm.ts
@@ -9,6 +9,6 @@ export const aggregationIsm = (validatorKey: string): AggregationIsmConfig => {
       merkleRootMultisig(validatorKey),
       messageIdMultisig(validatorKey),
     ],
-    threshold: 2,
+    threshold: 1,
   };
 };


### PR DESCRIPTION
### Description

In most aggregation ISM setups, the messageIdMultisigIsm is one of the submodules. This is the fastest one to build, and if the aggregation threshold is 1, there's no need to make network calls to build metadata for the other modules.

This PR adds this "fast path" to the aggregation ISM. If it fails, we fall back to the previous behavior where all submodules are built concurrently.

### Drive-by changes

Fixes the s3 sdk log silencing by matching against the log targets that show up in gcp logs

### Backward compatibility

Yes

### Testing
e2e with a 1/2 threshold, looking up the log `Built metadata using fast path` (28 occurrences), but it did fail 64 times
