### PR TITLE
chore: mainnet vanguards

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -23,6 +23,7 @@ import {
 } from '../../../src/config/agent/agent.js';
 import {
   MetricAppContext,
+  chainMapMatchingList,
   consistentSenderRecipientMatchingList,
   routerMatchingList,
   senderMatchingList,
@@ -591,6 +592,43 @@ const gasPaymentEnforcement: GasPaymentEnforcement[] = [
   },
 ];
 
+// HYPER - https://github.com/hyperlane-xyz/hyperlane-registry-private/blob/6f9ef6ca2805480312b75894cf030acde37c5527/deployments/warp_routes/HYPER/arbitrum-base-bsc-ethereum-optimism-config.yaml
+const hyperMatchingList = chainMapMatchingList({
+  arbitrum: '0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4',
+  base: '0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4',
+  bsc: '0xC9d23ED2ADB0f551369946BD377f8644cE1ca5c4',
+  ethereum: '0x93A2Db22B7c736B341C32Ff666307F4a9ED910F5',
+  optimism: '0x9923DB8d7FBAcC2E69E87fAd19b886C81cd74979',
+});
+
+// stHYPER - https://github.com/hyperlane-xyz/hyperlane-registry-private/blob/6f9ef6ca2805480312b75894cf030acde37c5527/deployments/warp_routes/stHYPER/bsc-ethereum-config.yaml#L1
+const stHyperMatchingList = chainMapMatchingList({
+  bsc: '0x6E9804a08092D8ba4E69DaCF422Df12459F2599E',
+  ethereum: '0x9F6E6d150977dabc82d5D4EaaBDB1F1Ab0D25F92',
+});
+
+// Staging HYPER - https://github.com/hyperlane-xyz/hyperlane-registry-private/blob/38b91443b960a7887653445ef094c730bf708717/deployments/warp_routes/HYPER/arbitrum-base-bsc-ethereum-optimism-config.yaml
+const stagingHyperMatchingList = chainMapMatchingList({
+  arbitrum: '0xF80dcED2488Add147E60561F8137338F7f3976e1',
+  base: '0x830B15a1986C75EaF8e048442a13715693CBD8bD',
+  bsc: '0x9537c772c6092DB4B93cFBA93659bB5a8c0E133D',
+  ethereum: '0xC10c27afcb915439C27cAe54F5F46Da48cd71190',
+  optimism: '0x31cD131F5F6e1Cc0d6743F695Fc023B70D0aeAd8',
+});
+
+// Staging stHYPER - https://github.com/hyperlane-xyz/hyperlane-registry-private/blob/38b91443b960a7887653445ef094c730bf708717/deployments/warp_routes/stHYPER/bsc-ethereum-config.yaml
+const stagingStHyperMatchingList = chainMapMatchingList({
+  bsc: '0xf0c8c5fc69fCC3fA49C319Fdf422D8279756afE2',
+  ethereum: '0x0C919509663cb273E156B706f065b9F7e6331891',
+});
+
+const vanguardMatchingList = [
+  ...hyperMatchingList,
+  ...stHyperMatchingList,
+  ...stagingHyperMatchingList,
+  ...stagingStHyperMatchingList,
+];
+
 // Gets metric app contexts, including:
 // - helloworld
 // - all warp routes defined in WarpRouteIds, using addresses from the registry
@@ -653,6 +691,23 @@ const metricAppContextsGetter = (): MetricAppContext[] => {
       // Messages between HubGateway (Everclear hub) <> EverclearSpoke (all other spoke chains)
       name: 'everclear_gateway',
       matchingList: senderMatchingList(everclearSenderAddresses),
+    },
+    // Manually specified for now until things are public
+    {
+      name: 'HYPER/arbitrum-base-bsc-ethereum-optimism',
+      matchingList: hyperMatchingList,
+    },
+    {
+      name: 'stHYPER/bsc-ethereum',
+      matchingList: stHyperMatchingList,
+    },
+    {
+      name: 'HYPER-STAGING/arbitrum-base-bsc-ethereum-optimism',
+      matchingList: stagingHyperMatchingList,
+    },
+    {
+      name: 'stHYPER-STAGING/bsc-ethereum',
+      matchingList: stagingStHyperMatchingList,
     },
   ];
 };
@@ -748,12 +803,12 @@ const ismCacheConfigs: Array<IsmCacheConfig> = [
     selector: {
       type: IsmCacheSelectorType.DefaultIsm,
     },
-    // Default ISM Routing ISMs change configs based off message content,
-    // so they are not specified here.
     moduleTypes: [
       ModuleType.AGGREGATION,
       ModuleType.MERKLE_ROOT_MULTISIG,
       ModuleType.MESSAGE_ID_MULTISIG,
+      // The relayer will cache these per-origin to accommodate DomainRoutingIsms
+      ModuleType.ROUTING,
     ],
     // SVM is explicitly not cached as the default ISM is a multisig ISM
     // that routes internally.
@@ -771,9 +826,9 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'da3978b-20250414-155929',
+      tag: 'c0bc208-20250415-142808',
     },
-    blacklist,
+    blacklist: [...blacklist, ...vanguardMatchingList],
     gasPaymentEnforcement: gasPaymentEnforcement,
     metricAppContextsGetter,
     ismCacheConfigs,
@@ -811,9 +866,9 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'da3978b-20250414-155929',
+      tag: 'c0bc208-20250415-142808',
     },
-    blacklist,
+    blacklist: [...blacklist, ...vanguardMatchingList],
     // We're temporarily (ab)using the RC relayer as a way to increase
     // message throughput.
     // whitelist: releaseCandidateHelloworldMatchingList,
@@ -849,9 +904,9 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'cecb0d8-20250411-150743',
+      tag: 'c0bc208-20250415-142808',
     },
-    blacklist,
+    blacklist: [...blacklist, ...vanguardMatchingList],
     gasPaymentEnforcement,
     metricAppContextsGetter,
     ismCacheConfigs,
@@ -875,33 +930,55 @@ const getVanguardRootAgentConfig = (index: number): RootAgentConfig => ({
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '385b307-20250418-150728',
+      // includes gasPriceCap overrides + per-chain maxSubmitQueueLength
+      tag: '9d20c65-20250418-220918',
     },
-    whitelist: [
+    whitelist: vanguardMatchingList,
+    // Not specifying a blacklist for optimization purposes -- all the message IDs
+    // in there are not vanguard-specific.
+    gasPaymentEnforcement: [
       {
-        originDomain: getDomainId('base'),
-        senderAddress: '0x000000000000000000000000000000000000dead',
-        destinationDomain: getDomainId('arbitrum'),
-        recipientAddress: '0x000000000000000000000000000000000000dead',
+        type: GasPaymentEnforcementPolicyType.None,
+        matchingList: vanguardMatchingList,
       },
     ],
-    blacklist,
-    gasPaymentEnforcement,
     metricAppContextsGetter,
     ismCacheConfigs,
     cache: {
       enabled: true,
+      // Cache for 10 minutes
+      defaultExpirationSeconds: 10 * 60,
     },
-    resources: relayerResources,
+    resources: {
+      requests: {
+        // Big enough to claim a c3-standard-44 each
+        cpu: '35000m',
+        memory: '100Gi',
+      },
+    },
     dbBootstrap: true,
+    mixing: {
+      enabled: true,
+      // Arbitrary salt to ensure different agents have different sorting behavior for pending messages
+      salt: 69690 + index,
+    },
     batch: {
       defaultBatchSize: 32,
       batchSizeOverrides: {
         // Slightly lower to ideally fit within 5M
-        ethereum: 23,
+        ethereum: 26,
       },
       bypassBatchSimulation: true,
+      maxSubmitQueueLength: {
+        arbitrum: 350,
+        base: 350,
+        bsc: 350,
+        optimism: 350,
+        ethereum: 75,
+      },
     },
+    txIdIndexingEnabled: false,
+    igpIndexingEnabled: false,
   },
 });
 

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -965,8 +965,7 @@ const getVanguardRootAgentConfig = (index: number): RootAgentConfig => ({
     batch: {
       defaultBatchSize: 32,
       batchSizeOverrides: {
-        // Slightly lower to ideally fit within 5M
-        ethereum: 26,
+        ethereum: 15,
       },
       bypassBatchSimulation: true,
       maxSubmitQueueLength: {

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -826,7 +826,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'c0bc208-20250415-142808',
+      tag: '8117739-20250420-201559',
     },
     blacklist: [...blacklist, ...vanguardMatchingList],
     gasPaymentEnforcement: gasPaymentEnforcement,
@@ -866,7 +866,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'c0bc208-20250415-142808',
+      tag: '8117739-20250420-201559',
     },
     blacklist: [...blacklist, ...vanguardMatchingList],
     // We're temporarily (ab)using the RC relayer as a way to increase
@@ -904,7 +904,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'c0bc208-20250415-142808',
+      tag: '8117739-20250420-201559',
     },
     blacklist: [...blacklist, ...vanguardMatchingList],
     gasPaymentEnforcement,
@@ -931,7 +931,7 @@ const getVanguardRootAgentConfig = (index: number): RootAgentConfig => ({
     docker: {
       repo,
       // includes gasPriceCap overrides + per-chain maxSubmitQueueLength
-      tag: '9d20c65-20250418-220918',
+      tag: '8117739-20250420-201559',
     },
     whitelist: vanguardMatchingList,
     // Not specifying a blacklist for optimization purposes -- all the message IDs

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -965,7 +965,8 @@ const getVanguardRootAgentConfig = (index: number): RootAgentConfig => ({
     batch: {
       defaultBatchSize: 32,
       batchSizeOverrides: {
-        ethereum: 15,
+        // Slightly lower to ideally fit within 5M
+        ethereum: 26,
       },
       bypassBatchSimulation: true,
       maxSubmitQueueLength: {

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -826,7 +826,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '8117739-20250420-201559',
+      tag: '8b985a4-20250421-152948',
     },
     blacklist: [...blacklist, ...vanguardMatchingList],
     gasPaymentEnforcement: gasPaymentEnforcement,
@@ -866,7 +866,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '8117739-20250420-201559',
+      tag: '8b985a4-20250421-152948',
     },
     blacklist: [...blacklist, ...vanguardMatchingList],
     // We're temporarily (ab)using the RC relayer as a way to increase
@@ -904,7 +904,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '8117739-20250420-201559',
+      tag: '8b985a4-20250421-152948',
     },
     blacklist: [...blacklist, ...vanguardMatchingList],
     gasPaymentEnforcement,

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -251,6 +251,15 @@ export class RelayerHelmManager extends OmniscientAgentHelmManager {
       effect: 'NoSchedule',
     });
 
+    if (this.context.includes('vanguard')) {
+      values.tolerations.push({
+        key: 'context-family',
+        operator: 'Equal',
+        value: 'vanguard',
+        effect: 'NoSchedule',
+      });
+    }
+
     return values;
   }
 

--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -18,6 +18,7 @@ import {
   ProtocolType,
   addressToBytes32,
   isValidAddressEvm,
+  objMap,
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
@@ -322,6 +323,16 @@ export function consistentSenderRecipientMatchingList(
       recipientAddress: addressToBytes32(address),
     },
   ];
+}
+
+export function chainMapMatchingList(
+  chainMap: ChainMap<Address>,
+): MatchingList {
+  // Convert to a router matching list
+  const routers = objMap(chainMap, (chain, address) => ({
+    router: address,
+  }));
+  return routerMatchingList(routers);
 }
 
 // Create a matching list for the given contract addresses


### PR DESCRIPTION
### Description

Deployed all the relayers
Deploys all 6 vanguard relayers to c3-standard-44 machines
Updated the other relayers to an image that's after the move to the faster s3 querying, but not anything else - just being conservative to not impact things there

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
