### PR TITLE
fix: Report all operations as failed when we are failing a batch

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
@@ -366,6 +366,7 @@ where
         let batch = multicall::batch::<_, ()>(multicall, contract_calls.clone());
         let call_results = batch.call().await?;
 
+        let call_count = contract_calls.len();
         let (successful, failed) = multicall::filter_failed(contract_calls, call_results);
 
         if successful.is_empty() {
@@ -383,7 +384,7 @@ where
                 failed,
             ))
         } else {
-            Ok(BatchSimulation::failed(failed.len()))
+            Ok(BatchSimulation::failed(call_count))
         }
     }
 


### PR DESCRIPTION
### Description

When there is a single successful operation in a batch and decide to fail the batch as a whole, currently, we will reports only failed operations. We should include the successful operation into the failed list.

### Backward compatibility

Yes

### Testing

None