### PR TITLE
fix: Submit failed operations from a batch in a serial manner

### DIFF
--- a/rust/main/agents/relayer/src/msg/op_batch.rs
+++ b/rust/main/agents/relayer/src/msg/op_batch.rs
@@ -4,11 +4,11 @@ use derive_new::new;
 use hyperlane_core::{
     rpc_clients::DEFAULT_MAX_RPC_RETRIES, total_estimated_cost, BatchResult,
     ChainCommunicationError, ChainResult, ConfirmReason, HyperlaneDomain, Mailbox,
-    PendingOperation, PendingOperationStatus, QueueOperation, ReprepareReason, TxOutcome,
+    PendingOperation, PendingOperationStatus, QueueOperation, TxOutcome,
 };
 use itertools::{Either, Itertools};
 use tokio::time::sleep;
-use tracing::{error, info, instrument, warn};
+use tracing::{info, instrument, warn};
 
 use super::{
     op_queue::OpQueue,
@@ -43,26 +43,11 @@ impl OperationBatch {
             }
         };
 
-        if let Some(first_item) = excluded_ops.first() {
-            let Some(mailbox) = first_item.try_get_mailbox() else {
-                error!(excluded_ops=?excluded_ops, "Excluded ops don't have mailbox while they should have");
-                return; // we expect that excluded ops have mailbox
-            };
-
-            if mailbox.supports_batching() {
-                warn!(excluded_ops=?excluded_ops, "Either operations reverted in the batch or the txid wasn't included. Sending them back to prepare queue.");
-                let reason = ReprepareReason::ErrorEstimatingGas;
-                let status = Some(PendingOperationStatus::Retry(reason.clone()));
-                for mut op in excluded_ops.into_iter() {
-                    op.on_reprepare(None, reason.clone());
-                    prepare_queue.push(op, status.clone()).await;
-                }
-            } else {
-                info!(excluded_ops=?excluded_ops, "Chain does not support batching. Submitting serially.");
-                OperationBatch::new(excluded_ops, self.domain)
-                    .submit_serially(prepare_queue, confirm_queue, metrics)
-                    .await;
-            }
+        if !excluded_ops.is_empty() {
+            warn!(excluded_ops=?excluded_ops, "Either operations reverted in the batch or the txid wasn't included. Submitting them serially.");
+            OperationBatch::new(excluded_ops, self.domain)
+                .submit_serially(prepare_queue, confirm_queue, metrics)
+                .await;
         }
     }
 

--- a/rust/main/agents/relayer/src/msg/op_batch.rs
+++ b/rust/main/agents/relayer/src/msg/op_batch.rs
@@ -44,7 +44,7 @@ impl OperationBatch {
         };
 
         if !excluded_ops.is_empty() {
-            warn!(excluded_ops=?excluded_ops, "Either operations reverted in the batch or the txid wasn't included. Submitting them serially.");
+            warn!(excluded_ops=?excluded_ops, "Either operations reverted in the batch or the txid wasn't included. Falling back to serial submission.");
             OperationBatch::new(excluded_ops, self.domain)
                 .submit_serially(prepare_queue, confirm_queue, metrics)
                 .await;

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
@@ -366,26 +366,19 @@ where
         let batch = multicall::batch::<_, ()>(multicall, contract_calls.clone());
         let call_results = batch.call().await?;
 
-        let call_count = contract_calls.len();
         let (successful, failed) = multicall::filter_failed(contract_calls, call_results);
 
         if successful.is_empty() {
             return Ok(BatchSimulation::failed(failed.len()));
         }
 
-        let successful_calls_len = successful.len();
         let successful_batch = multicall::batch::<_, ()>(multicall, successful.clone());
 
-        // only send a batch if there are at least two successful calls
-        if successful_calls_len >= 2 {
-            Ok(BatchSimulation::new(
-                Some(self.submittable_batch(successful_batch)),
-                successful,
-                failed,
-            ))
-        } else {
-            Ok(BatchSimulation::failed(call_count))
-        }
+        Ok(BatchSimulation::new(
+            Some(self.submittable_batch(successful_batch)),
+            successful,
+            failed,
+        ))
     }
 
     fn submittable_batch(


### PR DESCRIPTION
### Description

* Submit failed operations from a batch in a serial manner
* Allow batches to contains a single successful operation

### Backward compatibility

Yes

### Testing

None