### PR TITLE
feat(infra): check public validator rpc script

### DIFF
--- a/typescript/infra/scripts/check/check-validator-rpcs.ts
+++ b/typescript/infra/scripts/check/check-validator-rpcs.ts
@@ -24,6 +24,7 @@ async function main() {
     chains && chains.length > 0 ? chains : config.supportedChainNames
   ).filter((chain) => isEthereumProtocolChain(chain) && chain !== 'lumia');
 
+  // set useSecrets to `false` to compare with public RPCs instead of private ones
   const registry = await config.getRegistry(false);
   const metadata = await registry.getMetadata();
 
@@ -50,7 +51,7 @@ async function main() {
     chain: string;
     validator: string;
     status: CheckResult;
-    rpcs: number | string;
+    rpcs: string;
     private: string;
   }[] = [];
 
@@ -77,14 +78,14 @@ async function main() {
           const matchCount = publicRpcs.filter((rpc) =>
             metadata.rpcs?.some((x) => x == rpc),
           ).length;
-          const rpcs = metadata.rpcs?.length || 0;
+          const rpcCount = metadata.rpcs?.length;
 
           output.push({
             chain,
             validator: alias ?? validator,
             status: CheckResult.OK,
-            rpcs: rpcs || '?',
-            private: rpcs == 0 ? '?/?' : `${rpcs - matchCount}/${rpcs || `?`}`,
+            rpcs: `${rpcCount ?? '?'}`,
+            private: !rpcCount ? '?/?' : `${rpcCount - matchCount}/${rpcCount}`,
           });
         } catch {
           output.push({

--- a/typescript/infra/scripts/check/check-validator-rpcs.ts
+++ b/typescript/infra/scripts/check/check-validator-rpcs.ts
@@ -1,0 +1,107 @@
+import { ethers } from 'ethers';
+
+import {
+  defaultMultisigConfigs,
+  getValidatorFromStorageLocation,
+} from '@hyperlane-xyz/sdk';
+
+import { isEthereumProtocolChain } from '../../src/utils/utils.js';
+import { getArgs, withChains } from '../agent-utils.js';
+import { getEnvironmentConfig, getHyperlaneCore } from '../core-utils.js';
+
+enum CheckResult {
+  OK = '✅',
+  WARNING = '🚨',
+}
+
+async function main() {
+  const { environment, chains } = await withChains(getArgs()).argv;
+  const config = getEnvironmentConfig(environment);
+  const { core } = await getHyperlaneCore(environment);
+
+  // Ensure we skip lumia, as we don't have the addresses in registry.
+  const targetNetworks = (
+    chains && chains.length > 0 ? chains : config.supportedChainNames
+  ).filter((chain) => isEthereumProtocolChain(chain) && chain !== 'lumia');
+
+  const registry = await config.getRegistry(false);
+  const metadata = await registry.getMetadata();
+
+  const publicRpcs: string[] = [];
+
+  for (const chain of targetNetworks) {
+    const chainMetadata = metadata[chain];
+    if (!chainMetadata) {
+      throw new Error(`No metadata for ${chain}`);
+    }
+    publicRpcs.push(
+      ...chainMetadata.rpcUrls.map((rpc) =>
+        ethers.utils.solidityKeccak256(['string'], [rpc.http]),
+      ),
+    );
+    if (chainMetadata.grpcUrls)
+      publicRpcs.push(
+        ...chainMetadata.grpcUrls.map((rpc) =>
+          ethers.utils.solidityKeccak256(['string'], [rpc.http]),
+        ),
+      );
+  }
+  const output = [];
+
+  await Promise.all(
+    targetNetworks.map(async (chain) => {
+      const validatorAnnounce = core.getContracts(chain).validatorAnnounce;
+      // // TODO: check if the validator has announced itself
+      // const announcedValidators =
+      //   await validatorAnnounce.getAnnouncedValidators();
+
+      const defaultValidatorConfigs =
+        defaultMultisigConfigs[chain].validators || [];
+      const validators = defaultValidatorConfigs.map((v) => v.address);
+
+      const storageLocations =
+        await validatorAnnounce.getAnnouncedStorageLocations(validators);
+
+      for (let i = 0; i < defaultValidatorConfigs.length; i++) {
+        const { address: validator, alias } = defaultValidatorConfigs[i];
+        const location = storageLocations[i][storageLocations[i].length - 1];
+
+        try {
+          const validatorInstance = await getValidatorFromStorageLocation(
+            location,
+          );
+          const metadata = await validatorInstance.getMetadata();
+
+          const matchCount = publicRpcs.filter((rpc) =>
+            metadata.rpcs?.some((x) => x == rpc),
+          ).length;
+          const rpcs = metadata.rpcs?.length || 0;
+
+          output.push({
+            chain,
+            validator: alias ?? validator,
+            status: CheckResult.OK,
+            rpcs: rpcs || '?',
+            private: rpcs == 0 ? '?/?' : `${rpcs - matchCount}/${rpcs || `?`}`,
+          });
+        } catch {
+          output.push({
+            chain,
+            validator: alias ?? validator,
+            status: CheckResult.WARNING,
+            rpcs: '?',
+            private: '?/?',
+          });
+        }
+      }
+
+      return {
+        chain,
+      };
+    }),
+  );
+
+  console.table(output);
+}
+
+main().catch(console.error);

--- a/typescript/infra/scripts/check/check-validator-rpcs.ts
+++ b/typescript/infra/scripts/check/check-validator-rpcs.ts
@@ -46,15 +46,17 @@ async function main() {
         ),
       );
   }
-  const output = [];
+  const output: {
+    chain: string;
+    validator: string;
+    status: CheckResult;
+    rpcs: number | string;
+    private: string;
+  }[] = [];
 
   await Promise.all(
     targetNetworks.map(async (chain) => {
       const validatorAnnounce = core.getContracts(chain).validatorAnnounce;
-      // // TODO: check if the validator has announced itself
-      // const announcedValidators =
-      //   await validatorAnnounce.getAnnouncedValidators();
-
       const defaultValidatorConfigs =
         defaultMultisigConfigs[chain].validators || [];
       const validators = defaultValidatorConfigs.map((v) => v.address);

--- a/typescript/sdk/src/aws/s3.ts
+++ b/typescript/sdk/src/aws/s3.ts
@@ -36,6 +36,7 @@ export class S3Wrapper {
   constructor(readonly config: S3Config) {
     this.client = new S3Client({
       ...config,
+      // explicitly set empty credentials to allow usage without env vars
       credentials: {
         accessKeyId: '',
         secretAccessKey: '',

--- a/typescript/sdk/src/aws/s3.ts
+++ b/typescript/sdk/src/aws/s3.ts
@@ -34,7 +34,14 @@ export class S3Wrapper {
   }
 
   constructor(readonly config: S3Config) {
-    this.client = new S3Client(config);
+    this.client = new S3Client({
+      ...config,
+      credentials: {
+        accessKeyId: '',
+        secretAccessKey: '',
+      },
+      signer: { sign: async (req) => req },
+    });
     if (config.caching) {
       this.cache = {};
     }

--- a/typescript/utils/src/types.ts
+++ b/typescript/utils/src/types.ts
@@ -123,4 +123,6 @@ export type Annotated<T> = T & {
 
 export type ValidatorMetadata = {
   git_sha: string;
+  rpcs?: string[];
+  allows_public_rpcs?: boolean;
 };


### PR DESCRIPTION
### Description
Added infra script to check public RPCs on validator sets.
Uses the `metadata_latest.json` for each validator in a given set and matches the entries against the `hyperlane-registry`. We flag every matching RPC to the registry as public.
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility
Yes
<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing
Local testing
<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
