### PR TITLE
feat(sdk): momentarily turn off bridges derivation in warp reader

### DIFF
--- a/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
@@ -18,7 +18,7 @@ import {
   randomHookConfig,
   randomIsmConfig,
 } from '@hyperlane-xyz/sdk';
-import { Address, assert, deepCopy, randomInt } from '@hyperlane-xyz/utils';
+import { Address, assert, deepCopy } from '@hyperlane-xyz/utils';
 
 import { readYamlOrJson, writeYamlOrJson } from '../../utils/files.js';
 import {
@@ -32,8 +32,6 @@ import {
   WARP_DEPLOY_OUTPUT_PATH,
   deployOrUseExistingCore,
   deployToken,
-  deployXERC20LockboxToken,
-  deployXERC20VSToken,
   getCombinedWarpRoutePath,
   handlePrompts,
 } from '../commands/helpers.js';
@@ -276,115 +274,116 @@ describe('hyperlane warp check e2e tests', async function () {
       expect(output.text()).to.includes(expectedActualText);
     });
 
-    describe('check extra lockboxes', () => {
-      async function deployXERC20WarpRoute(): Promise<
-        [string, WarpRouteDeployConfig]
-      > {
-        const xERC20TokenSymbol = 'XERC20TOKEN';
-        const xERC20Token = await deployXERC20VSToken(
-          ANVIL_KEY,
-          CHAIN_NAME_2,
-          undefined,
-          xERC20TokenSymbol,
-        );
+    // Re enable this once we figure out how to reliable derive bridges for xERC20 tokens
+    // describe('check extra lockboxes', () => {
+    //   async function deployXERC20WarpRoute(): Promise<
+    //     [string, WarpRouteDeployConfig]
+    //   > {
+    //     const xERC20TokenSymbol = 'XERC20TOKEN';
+    //     const xERC20Token = await deployXERC20VSToken(
+    //       ANVIL_KEY,
+    //       CHAIN_NAME_2,
+    //       undefined,
+    //       xERC20TokenSymbol,
+    //     );
 
-        const token = await deployToken(
-          ANVIL_KEY,
-          CHAIN_NAME_2,
-          undefined,
-          'XERC20Collateral',
-        );
-        const xERC20Lockbox = await deployXERC20LockboxToken(
-          ANVIL_KEY,
-          CHAIN_NAME_2,
-          token,
-        );
+    //     const token = await deployToken(
+    //       ANVIL_KEY,
+    //       CHAIN_NAME_2,
+    //       undefined,
+    //       'XERC20Collateral',
+    //     );
+    //     const xERC20Lockbox = await deployXERC20LockboxToken(
+    //       ANVIL_KEY,
+    //       CHAIN_NAME_2,
+    //       token,
+    //     );
 
-        const tx = await xERC20Token.addBridge({
-          bridge: xERC20Lockbox.address,
-          bufferCap: '1000',
-          rateLimitPerSecond: '1000',
-        });
+    //     const tx = await xERC20Token.addBridge({
+    //       bridge: xERC20Lockbox.address,
+    //       bufferCap: '1000',
+    //       rateLimitPerSecond: '1000',
+    //     });
 
-        await tx.wait();
+    //     await tx.wait();
 
-        const warpConfig: WarpRouteDeployConfig = {
-          [CHAIN_NAME_2]: {
-            type: TokenType.XERC20,
-            token: xERC20Token.address,
-            mailbox: chain2Addresses.mailbox,
-            owner: ownerAddress,
-            xERC20: {
-              warpRouteLimits: {
-                bufferCap: '0',
-                rateLimitPerSecond: '0',
-              },
-              extraBridges: [
-                {
-                  limits: {
-                    bufferCap: '1000',
-                    rateLimitPerSecond: '1000',
-                  },
-                  lockbox: xERC20Lockbox.address,
-                },
-              ],
-            },
-          },
-        };
+    //     const warpConfig: WarpRouteDeployConfig = {
+    //       [CHAIN_NAME_2]: {
+    //         type: TokenType.XERC20,
+    //         token: xERC20Token.address,
+    //         mailbox: chain2Addresses.mailbox,
+    //         owner: ownerAddress,
+    //         xERC20: {
+    //           warpRouteLimits: {
+    //             bufferCap: '0',
+    //             rateLimitPerSecond: '0',
+    //           },
+    //           extraBridges: [
+    //             {
+    //               limits: {
+    //                 bufferCap: '1000',
+    //                 rateLimitPerSecond: '1000',
+    //               },
+    //               lockbox: xERC20Lockbox.address,
+    //             },
+    //           ],
+    //         },
+    //       },
+    //     };
 
-        writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpConfig);
-        await hyperlaneWarpDeploy(WARP_DEPLOY_OUTPUT_PATH);
+    //     writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpConfig);
+    //     await hyperlaneWarpDeploy(WARP_DEPLOY_OUTPUT_PATH);
 
-        return [xERC20TokenSymbol, warpConfig];
-      }
+    //     return [xERC20TokenSymbol, warpConfig];
+    //   }
 
-      it(`should not find differences between the local limits and the on chain ones`, async function () {
-        const [xERC20TokenSymbol] = await deployXERC20WarpRoute();
+    //   it(`should not find differences between the local limits and the on chain ones`, async function () {
+    //     const [xERC20TokenSymbol] = await deployXERC20WarpRoute();
 
-        const output = await hyperlaneWarpCheck(
-          WARP_DEPLOY_OUTPUT_PATH,
-          xERC20TokenSymbol,
-        ).nothrow();
+    //     const output = await hyperlaneWarpCheck(
+    //       WARP_DEPLOY_OUTPUT_PATH,
+    //       xERC20TokenSymbol,
+    //     ).nothrow();
 
-        expect(output.exitCode).to.equal(0);
-      });
+    //     expect(output.exitCode).to.equal(0);
+    //   });
 
-      it(`should find differences between the local limits and the on chain ones`, async function () {
-        const [xERC20TokenSymbol, warpDeployConfig] =
-          await deployXERC20WarpRoute();
+    //   it(`should find differences between the local limits and the on chain ones`, async function () {
+    //     const [xERC20TokenSymbol, warpDeployConfig] =
+    //       await deployXERC20WarpRoute();
 
-        assert(
-          warpDeployConfig[CHAIN_NAME_2].type === TokenType.XERC20,
-          'Deploy config should be for an XERC20 token',
-        );
-        const currentExtraBridgesLimits =
-          warpDeployConfig[CHAIN_NAME_2].xERC20!.extraBridges![0];
-        const wrongBufferCap = randomInt(100).toString();
-        warpDeployConfig[CHAIN_NAME_2].xERC20!.extraBridges = [
-          {
-            ...currentExtraBridgesLimits,
-            limits: {
-              bufferCap: wrongBufferCap,
-              rateLimitPerSecond:
-                currentExtraBridgesLimits.limits.rateLimitPerSecond,
-            },
-          },
-        ];
+    //     assert(
+    //       warpDeployConfig[CHAIN_NAME_2].type === TokenType.XERC20,
+    //       'Deploy config should be for an XERC20 token',
+    //     );
+    //     const currentExtraBridgesLimits =
+    //       warpDeployConfig[CHAIN_NAME_2].xERC20!.extraBridges![0];
+    //     const wrongBufferCap = randomInt(100).toString();
+    //     warpDeployConfig[CHAIN_NAME_2].xERC20!.extraBridges = [
+    //       {
+    //         ...currentExtraBridgesLimits,
+    //         limits: {
+    //           bufferCap: wrongBufferCap,
+    //           rateLimitPerSecond:
+    //             currentExtraBridgesLimits.limits.rateLimitPerSecond,
+    //         },
+    //       },
+    //     ];
 
-        writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpDeployConfig);
-        const expectedDiffText = `EXPECTED: "${wrongBufferCap}"\n`;
-        const expectedActualText = `ACTUAL: "${currentExtraBridgesLimits.limits.rateLimitPerSecond}"\n`;
+    //     writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpDeployConfig);
+    //     const expectedDiffText = `EXPECTED: "${wrongBufferCap}"\n`;
+    //     const expectedActualText = `ACTUAL: "${currentExtraBridgesLimits.limits.rateLimitPerSecond}"\n`;
 
-        const output = await hyperlaneWarpCheck(
-          WARP_DEPLOY_OUTPUT_PATH,
-          xERC20TokenSymbol,
-        ).nothrow();
+    //     const output = await hyperlaneWarpCheck(
+    //       WARP_DEPLOY_OUTPUT_PATH,
+    //       xERC20TokenSymbol,
+    //     ).nothrow();
 
-        expect(output.exitCode).to.equal(1);
-        expect(output.text()).includes(expectedDiffText);
-        expect(output.text()).includes(expectedActualText);
-      });
-    });
+    //     expect(output.exitCode).to.equal(1);
+    //     expect(output.text()).includes(expectedDiffText);
+    //     expect(output.text()).includes(expectedActualText);
+    //   });
+    // });
   });
 
   for (const hookType of MUTABLE_HOOK_TYPE) {

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -40,7 +40,6 @@ import {
   TokenMetadata,
   XERC20TokenMetadata,
 } from './types.js';
-import { getExtraLockBoxConfigs } from './xerc20.js';
 
 export class EvmERC20WarpRouteReader extends HyperlaneReader {
   protected readonly logger = rootLogger.child({
@@ -218,13 +217,6 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
     const xERC20 = new Contract(xERC20Address, rateLimitsABI, this.provider);
 
     try {
-      const extraBridgesLimits = await getExtraLockBoxConfigs({
-        chain: this.chain,
-        multiProvider: this.multiProvider,
-        xERC20Address,
-        logger: this.logger,
-      });
-
       return {
         xERC20: {
           warpRouteLimits: {
@@ -233,8 +225,6 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
             ).toString(),
             bufferCap: (await xERC20.bufferCap(warpRouteAddress)).toString(),
           },
-          extraBridges:
-            extraBridgesLimits.length > 0 ? extraBridgesLimits : undefined,
         },
       };
     } catch (error) {


### PR DESCRIPTION
### Description

Momentarily removes the logic to retrieve xERC20 token bridges 

### Drive-by changes

- None

### Related issues



### Backward compatibility

- Yes

### Testing

- Manual
