### PR TITLE
feat: support nested safe tx parsing

### DIFF
--- a/typescript/infra/config/environments/mainnet3/governance/safe/ousdt.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/safe/ousdt.ts
@@ -1,0 +1,16 @@
+import { ChainMap } from '@hyperlane-xyz/sdk';
+import { Address } from '@hyperlane-xyz/utils';
+
+export const ousdtSafes: ChainMap<Address> = {
+  celo: '0xf1b3fc934bB46c459253fb38555A400b94909800',
+  optimism: '0x8E3340E241880F80359AA95Ae20Dc498d3f62503',
+  base: '0x125d1b64dfd7898DD06ac3E060A432691b8Fa676',
+  unichain: '0xf306ad5bF95960188c67A30f5546D193760ca3D0',
+  ink: '0x1BBf2CE75A77b8A10dA7e73dC1F76456008010bD',
+  soneium: '0x31Bf112F33556A0F1dc76881cfA8A36Bc2134A57',
+  mode: '0xD4c01B4753575899AD81aAca0bb2DB7796E9F7C0',
+  fraxtal: '0x21C0CA5be5aC9BC6161Bf1cfE281A18Fe2190079',
+  superseed: '0x0731a8e0DC88Df79d9643BD6C1f26cfe6fa53382',
+  lisk: '0x6F0A0038FcDB2F1655219f1b92f7E9aD4b78Aa49',
+  worldchain: '0x998238aF5A2DDC7ae08Dbe4B60b82EF63A1538cd',
+};

--- a/typescript/infra/config/environments/mainnet3/governance/utils.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/utils.ts
@@ -7,6 +7,7 @@ import { awIcas } from './ica/aw.js';
 import { regularIcas } from './ica/regular.js';
 import { awSafes } from './safe/aw.js';
 import { irregularSafes } from './safe/irregular.js';
+import { ousdtSafes } from './safe/ousdt.js';
 import { regularSafes } from './safe/regular.js';
 import { awSigners, awThreshold } from './signers/aw.js';
 import { irregularSigners, irregularThreshold } from './signers/irregular.js';
@@ -20,6 +21,8 @@ export function getGovernanceSafes(governanceType: GovernanceType) {
       return awSafes;
     case GovernanceType.Irregular:
       return irregularSafes;
+    case GovernanceType.OUSDT:
+      return ousdtSafes;
     default:
       throw new Error(`Unknown governance type: ${governanceType}`);
   }
@@ -32,6 +35,8 @@ export function getGovernanceIcas(governanceType: GovernanceType) {
     case GovernanceType.AbacusWorks:
       return awIcas;
     case GovernanceType.Irregular:
+      return {};
+    case GovernanceType.OUSDT:
       return {};
     default:
       throw new Error(`Unknown governance type: ${governanceType}`);
@@ -58,11 +63,24 @@ export function getGovernanceSigners(governanceType: GovernanceType): {
         signers: irregularSigners,
         threshold: irregularThreshold,
       };
+    default:
+      throw new Error(
+        `Unsupported method for governance type: ${governanceType}`,
+      );
   }
 }
+
 export function getSafeChains(): Set<ChainName> {
   return new Set(
     ...Object.keys(getGovernanceSafes(GovernanceType.AbacusWorks)),
     ...Object.keys(getGovernanceSafes(GovernanceType.Regular)),
+    ...Object.keys(getGovernanceSafes(GovernanceType.Irregular)),
+    ...Object.keys(getGovernanceSafes(GovernanceType.OUSDT)),
   );
+}
+
+export function getAllSafesForChain(chain: ChainName): string[] {
+  return Object.values(GovernanceType)
+    .map((governanceType) => getGovernanceSafes(governanceType)[chain])
+    .filter((safe) => safe !== undefined);
 }

--- a/typescript/infra/scripts/safes/parse-txs.ts
+++ b/typescript/infra/scripts/safes/parse-txs.ts
@@ -99,7 +99,6 @@ async function main() {
     rootLogger.error('❌❌❌❌❌ Encountered fatal errors ❌❌❌❌❌');
     rootLogger.info(stringifyObject(reader.errors, 'yaml', 2));
     rootLogger.error('❌❌❌❌❌ Encountered fatal errors ❌❌❌❌❌');
-    process.exit(1);
   } else {
     rootLogger.info('✅✅✅✅✅ No fatal errors ✅✅✅✅✅');
   }
@@ -108,6 +107,10 @@ async function main() {
   const resultsPath = `safe-tx-results-${Date.now()}.yaml`;
   writeYamlAtPath(resultsPath, chainResults);
   rootLogger.info(`Results written to ${resultsPath}`);
+
+  if (reader.errors.length) {
+    process.exit(1);
+  }
 }
 
 main().catch((err) => {

--- a/typescript/infra/src/governance.ts
+++ b/typescript/infra/src/governance.ts
@@ -14,6 +14,7 @@ export enum GovernanceType {
   AbacusWorks = 'abacusWorks',
   Regular = 'regular',
   Irregular = 'irregular',
+  OUSDT = 'ousdt',
 }
 
 export enum Owner {


### PR DESCRIPTION
### Description

feat: support nested safe tx parsing
- add ousdt as governance type
- add function to get all safes for a given chain
- support parsing safes txs to other (known) safes 

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
