### PR TITLE
feat: don't default to 0 index when comparing checkpoint indexes

### DIFF
--- a/rust/main/hyperlane-base/src/traits/checkpoint_syncer.rs
+++ b/rust/main/hyperlane-base/src/traits/checkpoint_syncer.rs
@@ -14,9 +14,15 @@ pub trait CheckpointSyncer: Debug + Send + Sync {
     async fn write_latest_index(&self, index: u32) -> Result<()>;
     /// Update the latest index of this syncer if necessary
     async fn update_latest_index(&self, index: u32) -> Result<()> {
-        let curr = self.latest_index().await?.unwrap_or(0);
-        if index > curr {
-            self.write_latest_index(index).await?;
+        match self.latest_index().await? {
+            None => {
+                self.write_latest_index(index).await?;
+            }
+            Some(curr) => {
+                if index > curr {
+                    self.write_latest_index(index).await?;
+                }
+            }
         }
         Ok(())
     }

--- a/rust/main/hyperlane-base/src/types/gcs_storage.rs
+++ b/rust/main/hyperlane-base/src/types/gcs_storage.rs
@@ -206,16 +206,6 @@ impl CheckpointSyncer for GcsStorageClient {
         self.upload_and_log(LATEST_INDEX_KEY, data).await
     }
 
-    /// Update the latest index of this syncer if necessary
-    #[instrument(skip(self, index))]
-    async fn update_latest_index(&self, index: u32) -> Result<()> {
-        let curr = self.latest_index().await?.unwrap_or(0);
-        if index > curr {
-            self.write_latest_index(index).await?;
-        }
-        Ok(())
-    }
-
     /// Attempt to fetch the signed (checkpoint, messageId) tuple at this index
     #[instrument(skip(self, index))]
     async fn fetch_checkpoint(&self, index: u32) -> Result<Option<SignedCheckpointWithMessageId>> {


### PR DESCRIPTION
### Description

- instead of defaulting to 0 when comparing checkpoint indexes, we check if its None.
- if it's None, then we write checkpoint, if not, then we do checkpoint index comparison

### Drive-by changes

 - remove GcsStorageClient override of `update_latest_index()`

### Related issues

 - fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4260

### Backward compatibility

Yes/No

### Testing

None