### PR TITLE
Implement HyperToken

### DIFF
--- a/solidity/contracts/token/HypERC20.sol
+++ b/solidity/contracts/token/HypERC20.sol
@@ -5,13 +5,14 @@ import {TokenRouter} from "./libs/TokenRouter.sol";
 import {FungibleTokenRouter} from "./libs/FungibleTokenRouter.sol";
 
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import {ERC20PermitUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
 
 /**
  * @title Hyperlane ERC20 Token Router that extends ERC20 with remote transfer functionality.
  * @author Abacus Works
  * @dev Supply on each chain is not constant but the aggregate supply across all chains is.
  */
-contract HypERC20 is ERC20Upgradeable, FungibleTokenRouter {
+contract HypERC20 is ERC20PermitUpgradeable, FungibleTokenRouter {
     uint8 private immutable _decimals;
 
     constructor(

--- a/solidity/contracts/token/extensions/HyperToken.sol
+++ b/solidity/contracts/token/extensions/HyperToken.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0;
+
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import {ERC20BurnableUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+
+import {HypERC20} from "../HypERC20.sol";
+
+/// @title HyperToken - The Hyperlane protocol's token contract.
+/// @notice This contract extends HypERC20 with access controlled local minting and burning.
+/// @dev Uses OpenZeppelin upgradeable contracts and Hyperlane's TokenRouter for bridging.
+/// @custom:security-contact security@hyperlane.xyz
+contract HyperToken is
+    HypERC20,
+    AccessControlUpgradeable,
+    ERC20BurnableUpgradeable
+{
+    /// @notice Role identifier for addresses allowed to mint tokens.
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+
+    /// @notice Role identifier for addresses allowed to burn tokens.
+    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
+
+    /// @notice Constructor for HyperToken contract.
+    /// @dev Calls the TokenRouter constructor and disables initializers.
+    /// @param __decimals The number of decimals for the token.
+    /// @param _scale The scale factor for the token.
+    /// @param _mailbox The address of the mailbox contract.
+    constructor(
+        uint8 __decimals,
+        uint256 _scale,
+        address _mailbox
+    ) HypERC20(__decimals, _scale, _mailbox) {
+        _disableInitializers();
+    }
+
+    /// @notice Initializes the HyperToken contract with initial configuration.
+    /// @dev This function can only be called once due to the initializer modifier.
+    /// @param _initialSupply The initial total supply of tokens to mint to the owner.
+    /// @param _name The name of the token.
+    /// @param _symbol The symbol of the token.
+    /// @param _hook The address of the hook contract for mailbox functionality.
+    /// @param _interchainSecurityModule The address of the interchain security module.
+    /// @param _owner The address of the contract owner.
+    function initialize(
+        uint256 _initialSupply,
+        string memory _name,
+        string memory _symbol,
+        address _hook,
+        address _interchainSecurityModule,
+        address _owner
+    ) public override initializer {
+        __ERC20_init(_name, _symbol);
+        __ERC20Burnable_init();
+        __ERC20Permit_init(_name);
+        _mint(_owner, _initialSupply);
+
+        __AccessControl_init();
+        _grantRole(DEFAULT_ADMIN_ROLE, _owner);
+
+        _MailboxClient_initialize(_hook, _interchainSecurityModule, _owner);
+    }
+
+    /// @notice Mints new tokens to a specified address.
+    /// @dev Only addresses with MINTER_ROLE can call this function.
+    /// @param _to The address that will receive the minted tokens.
+    /// @param _amount The amount of tokens to mint.
+    function mint(address _to, uint256 _amount) public virtual {
+        _checkRole(MINTER_ROLE);
+        _mint(_to, _amount);
+    }
+
+    /// @notice Burns tokens from a specified address.
+    /// @dev Only addresses with BURNER_ROLE can call this function.
+    /// @param _from The address from which tokens will be burned.
+    /// @param _amount The amount of tokens to burn.
+    function burn(address _from, uint256 _amount) public virtual {
+        _checkRole(BURNER_ROLE);
+        _burn(_from, _amount);
+    }
+
+    // /// @inheritdoc ERC20Upgradeable
+    function decimals()
+        public
+        view
+        virtual
+        override(ERC20Upgradeable, HypERC20)
+        returns (uint8)
+    {
+        return HypERC20.decimals();
+    }
+
+    // /// @inheritdoc ERC20Upgradeable
+    function balanceOf(
+        address _account
+    )
+        public
+        view
+        virtual
+        override(ERC20Upgradeable, HypERC20)
+        returns (uint256)
+    {
+        return ERC20Upgradeable.balanceOf(_account);
+    }
+}

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -7,6 +7,7 @@ import {
   HypERC4626OwnerCollateral__factory,
   HypERC4626__factory,
   HypXERC20Lockbox__factory,
+  HyperToken__factory,
   IXERC20__factory,
   ProxyAdmin__factory,
   TokenRouter__factory,
@@ -42,6 +43,7 @@ import {
 } from './types.js';
 import { getExtraLockBoxConfigs } from './xerc20.js';
 
+const OWNER_DOES_NOT_HAVE_ADMIN_ROLE = 'OWNER_DOES_NOT_HAVE_ADMIN_ROLE';
 export class EvmERC20WarpRouteReader extends HyperlaneReader {
   protected readonly logger = rootLogger.child({
     module: 'EvmERC20WarpRouteReader',
@@ -78,9 +80,33 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
     const remoteRouters = await this.fetchRemoteRouters(warpRouteAddress);
     const proxyAdmin = await this.fetchProxyAdminConfig(warpRouteAddress);
     const destinationGas = await this.fetchDestinationGas(warpRouteAddress);
+    let owner = mailboxClientConfig.owner;
+    // If the token is a hyper token, also check that the owner has the admin role
+    if (type === TokenType.hyperToken) {
+      try {
+        const hyperToken = HyperToken__factory.connect(
+          warpRouteAddress,
+          this.provider,
+        );
+        const hasAdminRole = await hyperToken.hasRole(
+          await hyperToken.DEFAULT_ADMIN_ROLE(),
+          proxyAdmin.owner,
+        );
+        if (!hasAdminRole) {
+          owner = OWNER_DOES_NOT_HAVE_ADMIN_ROLE;
+        }
+      } catch (e) {
+        this.logger.error(
+          `Error checking admin role for hyper token at ${warpRouteAddress}`,
+          e,
+        );
+        owner = OWNER_DOES_NOT_HAVE_ADMIN_ROLE;
+      }
+    }
 
     return {
       ...mailboxClientConfig,
+      owner,
       ...tokenConfig,
       remoteRouters,
       proxyAdmin,
@@ -117,6 +143,10 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
       [TokenType.syntheticRebase]: {
         factory: HypERC4626__factory,
         method: 'collateralDomain',
+      },
+      [TokenType.hyperToken]: {
+        factory: HyperToken__factory,
+        method: 'DEFAULT_ADMIN_ROLE',
       },
       [TokenType.synthetic]: {
         factory: HypERC20__factory,
@@ -302,7 +332,8 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
       };
     } else if (
       type === TokenType.synthetic ||
-      type === TokenType.syntheticRebase
+      type === TokenType.syntheticRebase ||
+      type === TokenType.hyperToken
     ) {
       const baseMetadata = await this.fetchERC20Metadata(warpRouteAddress);
 

--- a/typescript/sdk/src/token/Token.test.ts
+++ b/typescript/sdk/src/token/Token.test.ts
@@ -83,6 +83,14 @@ const STANDARD_TO_TOKEN: Record<TokenStandard, TokenArgs | null> = {
     symbol: 'USDC',
     name: 'USDC',
   },
+  [TokenStandard.EvmHyperToken]: {
+    chainName: TestChainName.test2,
+    standard: TokenStandard.EvmHyperToken,
+    addressOrDenom: '0x8358D8291e3bEDb04804975eEa0fe9fe0fAfB147',
+    decimals: 18,
+    symbol: 'HYPER',
+    name: 'HYPER',
+  },
   [TokenStandard.EvmHypSyntheticRebase]: {
     chainName: TestChainName.test2,
     standard: TokenStandard.EvmHypSyntheticRebase,

--- a/typescript/sdk/src/token/Token.ts
+++ b/typescript/sdk/src/token/Token.ts
@@ -202,7 +202,8 @@ export class Token implements IToken {
       });
     } else if (
       standard === TokenStandard.EvmHypSynthetic ||
-      standard === TokenStandard.EvmHypSyntheticRebase
+      standard === TokenStandard.EvmHypSyntheticRebase ||
+      standard === TokenStandard.EvmHyperToken
     ) {
       return new EvmHypSyntheticAdapter(chainName, multiProvider, {
         token: addressOrDenom,

--- a/typescript/sdk/src/token/TokenStandard.ts
+++ b/typescript/sdk/src/token/TokenStandard.ts
@@ -21,6 +21,7 @@ export enum TokenStandard {
   EvmHypSyntheticRebase = 'EvmHypSyntheticRebase',
   EvmHypXERC20 = 'EvmHypXERC20',
   EvmHypXERC20Lockbox = 'EvmHypXERC20Lockbox',
+  EvmHyperToken = 'EvmHyperToken',
   EvmHypVSXERC20 = 'EvmHypVSXERC20',
   EvmHypVSXERC20Lockbox = 'EvmHypVSXERC20Lockbox',
 
@@ -67,6 +68,7 @@ export const TOKEN_STANDARD_TO_PROTOCOL: Record<TokenStandard, ProtocolType> = {
   EvmHypSyntheticRebase: ProtocolType.Ethereum,
   EvmHypXERC20: ProtocolType.Ethereum,
   EvmHypXERC20Lockbox: ProtocolType.Ethereum,
+  EvmHyperToken: ProtocolType.Ethereum,
   EvmHypVSXERC20: ProtocolType.Ethereum,
   EvmHypVSXERC20Lockbox: ProtocolType.Ethereum,
 
@@ -148,6 +150,7 @@ export const TOKEN_HYP_STANDARDS = [
   TokenStandard.EvmHypSyntheticRebase,
   TokenStandard.EvmHypXERC20,
   TokenStandard.EvmHypXERC20Lockbox,
+  TokenStandard.EvmHyperToken,
   TokenStandard.EvmHypVSXERC20,
   TokenStandard.EvmHypVSXERC20Lockbox,
   TokenStandard.SealevelHypNative,
@@ -190,6 +193,7 @@ export const TOKEN_TYPE_TO_STANDARD: Record<TokenType, TokenStandard> = {
   [TokenType.syntheticRebase]: TokenStandard.EvmHypSyntheticRebase,
   [TokenType.syntheticUri]: TokenStandard.EvmHypSynthetic,
   [TokenType.nativeScaled]: TokenStandard.EvmHypNative,
+  [TokenType.hyperToken]: TokenStandard.EvmHyperToken,
 };
 
 // Starknet supported token types

--- a/typescript/sdk/src/token/config.ts
+++ b/typescript/sdk/src/token/config.ts
@@ -12,11 +12,13 @@ export enum TokenType {
   native = 'native',
   // backwards compatible alias to native
   nativeScaled = 'nativeScaled',
+  hyperToken = 'hyperToken',
 }
 
 export const gasOverhead = (tokenType: TokenType): number => {
   switch (tokenType) {
     case TokenType.synthetic:
+    case TokenType.hyperToken:
       return 64_000;
     case TokenType.native:
       return 44_000;

--- a/typescript/sdk/src/token/contracts.ts
+++ b/typescript/sdk/src/token/contracts.ts
@@ -12,6 +12,7 @@ import {
   HypNative__factory,
   HypXERC20Lockbox__factory,
   HypXERC20__factory,
+  HyperToken__factory,
 } from '@hyperlane-xyz/core';
 
 import { TokenType } from './config.js';
@@ -28,6 +29,7 @@ export const hypERC20contracts = {
   [TokenType.native]: 'HypNative',
   // uses same contract as native
   [TokenType.nativeScaled]: 'HypNative',
+  [TokenType.hyperToken]: 'HyperToken',
 };
 export type HypERC20contracts = typeof hypERC20contracts;
 
@@ -42,6 +44,7 @@ export const hypERC20factories = {
   [TokenType.XERC20Lockbox]: new HypXERC20Lockbox__factory(),
   [TokenType.native]: new HypNative__factory(),
   [TokenType.nativeScaled]: new HypNative__factory(),
+  [TokenType.hyperToken]: new HyperToken__factory(),
 };
 export type HypERC20Factories = typeof hypERC20factories;
 

--- a/typescript/sdk/src/token/types.test.ts
+++ b/typescript/sdk/src/token/types.test.ts
@@ -18,7 +18,11 @@ const COLLATERAL_TYPES = [
   TokenType.collateralVault,
 ];
 
-const NON_COLLATERAL_TYPES = [TokenType.synthetic, TokenType.syntheticUri];
+const NON_COLLATERAL_TYPES = [
+  TokenType.synthetic,
+  TokenType.syntheticUri,
+  TokenType.hyperToken,
+];
 
 describe('WarpRouteDeployConfigSchema refine', () => {
   let config: WarpRouteDeployConfig;

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -95,7 +95,11 @@ export const isCollateralRebaseTokenConfig = isCompliant(
 );
 
 export const SyntheticTokenConfigSchema = TokenMetadataSchema.partial().extend({
-  type: z.enum([TokenType.synthetic, TokenType.syntheticUri]),
+  type: z.enum([
+    TokenType.synthetic,
+    TokenType.syntheticUri,
+    TokenType.hyperToken,
+  ]),
   initialSupply: z.string().or(z.number()).optional(),
 });
 export type SyntheticTokenConfig = z.infer<typeof SyntheticTokenConfigSchema>;


### PR DESCRIPTION
### Description

Implements `HyperToken` which extends `HypERC20` with `AccessControl` `mint` and `burn`.

### Drive-by changes

- Adds Permit to HypERC20

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

Yes

### Testing

Unit Tests
