### PR TITLE
feat: xERC20 extra lockboxes derivation updated logic

### DIFF
--- a/.changeset/lovely-melons-ring.md
+++ b/.changeset/lovely-melons-ring.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Remove fallback logic to derive extra lockboxes from rpc

--- a/typescript/sdk/src/block-explorer/etherscan.ts
+++ b/typescript/sdk/src/block-explorer/etherscan.ts
@@ -37,9 +37,10 @@ function formatExplorerUrl<TModule extends string, TAction extends string>(
 async function handleEtherscanResponse<T>(response: Response): Promise<T> {
   const body = await response.json();
 
+  const explorerUrl = new URL(response.url);
   if (body.status === '0') {
     throw new Error(
-      `Error while performing request to Etherscan like API: ${body.message} ${body.result}`,
+      `Error while performing request to Etherscan like API at ${explorerUrl.host}: ${body.message} ${body.result}`,
     );
   }
 


### PR DESCRIPTION
### Description

Updates the extra lockboxes logic to only rely on block explorers apis and skip derviation otherwise

### Drive-by changes

- Removes rpc based logic to service lockboxes
- Removes e2e tests for reading on chain lockboxes 

### Related issues

### Backward compatibility



### Testing

- Manual
