### PR TITLE
feat: cosmosnative fixes

### DIFF
--- a/.changeset/twenty-eggs-rescue.md
+++ b/.changeset/twenty-eggs-rescue.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+Fixes to support CosmosNative and warp apply with foreign deployments.

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -652,6 +652,11 @@ async function updateExistingWarpRoute(
 
   await promiseObjAll(
     objMap(expandedWarpDeployConfig, async (chain, config) => {
+      if (multiProvider.getProtocol(chain) !== ProtocolType.Ethereum) {
+        logBlue(`Skipping non-EVM chain ${chain}`);
+        return;
+      }
+
       await retryAsync(async () => {
         const deployedTokenRoute = deployedRoutersAddresses[chain];
         assert(deployedTokenRoute, `Missing artifacts for ${chain}.`);

--- a/typescript/sdk/src/consts/igp.ts
+++ b/typescript/sdk/src/consts/igp.ts
@@ -35,6 +35,8 @@ export function getProtocolExchangeRateDecimals(
       return TOKEN_EXCHANGE_RATE_DECIMALS_SEALEVEL;
     case ProtocolType.Cosmos:
       return TOKEN_EXCHANGE_RATE_DECIMALS_COSMOS;
+    case ProtocolType.CosmosNative:
+      return TOKEN_EXCHANGE_RATE_DECIMALS_COSMOS;
     default:
       throw new Error(`Unsupported protocol type: ${protocolType}`);
   }

--- a/typescript/sdk/src/contracts/contracts.ts
+++ b/typescript/sdk/src/contracts/contracts.ts
@@ -188,6 +188,7 @@ export function attachContractsMapAndGetForeignDeployments<
           throw new Error('Ethereum chain should not have foreign deployments');
 
         case ProtocolType.Cosmos:
+        case ProtocolType.CosmosNative:
           return router;
 
         case ProtocolType.Sealevel:

--- a/typescript/sdk/src/gas/utils.ts
+++ b/typescript/sdk/src/gas/utils.ts
@@ -47,7 +47,8 @@ export async function getGasPrice(
         decimals: 9,
       };
     }
-    case ProtocolType.Cosmos: {
+    case ProtocolType.Cosmos:
+    case ProtocolType.CosmosNative: {
       const { amount } = await getCosmosChainGasPrice(chain, mpp);
       return {
         amount,

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -235,6 +235,7 @@ export const AgentChainMetadataSchema = ChainMetadataSchemaObject.merge(
         break;
 
       case ProtocolType.Cosmos:
+      case ProtocolType.CosmosNative:
         if (![AgentSignerKeyType.Cosmos].includes(signerType)) {
           return false;
         }
@@ -251,7 +252,10 @@ export const AgentChainMetadataSchema = ChainMetadataSchemaObject.merge(
     }
 
     // If the protocol type is Cosmos, require everything in AgentCosmosChainMetadataSchema
-    if (metadata.protocol === ProtocolType.Cosmos) {
+    if (
+      metadata.protocol === ProtocolType.Cosmos ||
+      metadata.protocol === ProtocolType.CosmosNative
+    ) {
       if (!AgentCosmosChainMetadataSchema.safeParse(metadata).success) {
         return false;
       }
@@ -548,7 +552,10 @@ export function buildAgentConfig(
   const chainConfigs: ChainMap<AgentChainMetadata> = {};
   for (const chain of [...chains].sort()) {
     const metadata = multiProvider.tryGetChainMetadata(chain);
-    if (metadata?.protocol === ProtocolType.Cosmos) {
+    if (
+      metadata?.protocol === ProtocolType.Cosmos ||
+      metadata?.protocol === ProtocolType.CosmosNative
+    ) {
       // Note: the gRPC URL format in the registry lacks a correct http:// or https:// prefix at the moment,
       // which is expected by the agents. For now, we intentionally skip this.
       delete metadata.grpcUrls;

--- a/typescript/sdk/src/metadata/chainMetadataTypes.ts
+++ b/typescript/sdk/src/metadata/chainMetadataTypes.ts
@@ -336,7 +336,8 @@ export const ChainMetadataSchema = ChainMetadataSchemaExtensible.refine(
     )
       return false;
     else if (
-      metadata.protocol === ProtocolType.Cosmos &&
+      (metadata.protocol === ProtocolType.Cosmos ||
+        metadata.protocol === ProtocolType.CosmosNative) &&
       typeof metadata.chainId !== 'string'
     )
       return false;
@@ -355,7 +356,8 @@ export const ChainMetadataSchema = ChainMetadataSchemaExtensible.refine(
   .refine(
     (metadata) => {
       if (
-        metadata.protocol === ProtocolType.Cosmos &&
+        (metadata.protocol === ProtocolType.Cosmos ||
+          metadata.protocol === ProtocolType.CosmosNative) &&
         (!metadata.bech32Prefix || !metadata.slip44)
       )
         return false;
@@ -369,7 +371,8 @@ export const ChainMetadataSchema = ChainMetadataSchemaExtensible.refine(
   .refine(
     (metadata) => {
       if (
-        metadata.protocol === ProtocolType.Cosmos &&
+        (metadata.protocol === ProtocolType.Cosmos ||
+          metadata.protocol === ProtocolType.CosmosNative) &&
         (!metadata.restUrls || !metadata.grpcUrls)
       )
         return false;
@@ -383,7 +386,8 @@ export const ChainMetadataSchema = ChainMetadataSchemaExtensible.refine(
   .refine(
     (metadata) => {
       if (
-        metadata.protocol === ProtocolType.Cosmos &&
+        (metadata.protocol === ProtocolType.Cosmos ||
+          metadata.protocol === ProtocolType.CosmosNative) &&
         metadata.nativeToken &&
         !metadata.nativeToken.denom
       )

--- a/typescript/sdk/src/metadata/customZodTypes.ts
+++ b/typescript/sdk/src/metadata/customZodTypes.ts
@@ -14,7 +14,7 @@ export const ZUWei = z.union([ZUint.safe(), z.string().regex(/^\d+$/)]);
 export const ZHash = z
   .string()
   .regex(
-    /^(0x([0-9a-fA-F]{32}|[0-9a-fA-F]{40}|[0-9a-fA-F]{64}|[0-9a-fA-F]{128}))|([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{32})$/,
+    /^(0x([0-9a-fA-F]{32}|[0-9a-fA-F]{40}|[0-9a-fA-F]{64}|[0-9a-fA-F]{128}))|([123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{32})|([a-z]{1,10}1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{38,58})$/,
   );
 /** Zod ChainName schema */
 export const ZChainName = z.string().regex(/^[a-z][a-z0-9]*$/);


### PR DESCRIPTION
### Description

feat: cosmosnative fixes
- correctly skip non-EVM chains when doing a warp apply
- adjust the `ZHash` zod regex to support cosmos addresses more explicitly
	- required because setting valid cosmos addresses such as `milk1326ley07fm6rpeqgxmxevnqevrsjfew2akzupg` or `neutron1fqf5mprg3f5hytvzp3t7spmsum6rjrw80mq8zgkc0h6rxga0dtzqws3uu7` as an owner in the warp deploy config would break the schema parsing

### Drive-by changes

- bring `CosmosNative` parity in more conditions where `Cosmos` protocol type exists
- don't fail balance thresholds test if an alert threshold is configured in grafana but undefined locally
	- this is common when doing new chain deploys, and we should not be breaking CI for everyone else just because 1 PR adds a new chain

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

manual cli warp apply of the MILK/bsc-milkyway route