### PR TITLE
feat: rearrange release workflow

### DIFF
--- a/.github/actions/install-cli/action.yml
+++ b/.github/actions/install-cli/action.yml
@@ -5,6 +5,10 @@ inputs:
   ref:
     description: "The Git ref to checkout"
     required: true
+  cache-provider:
+    description: "Choose cache provider: buildjet or github"
+    required: false
+    default: "buildjet"
 
 runs:
   using: "composite"
@@ -13,6 +17,7 @@ runs:
       uses: ./.github/actions/yarn-build-with-cache
       with:
         ref: ${{ inputs.ref }}
+        cache-provider: ${{ inputs.cache-provider }}
 
     - name: Pack the CLI
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         uses: ./.github/actions/install-cli
         with:
           ref: ${{ github.sha }}
+          cache-provider: github
 
       - name: Test run the CLI
         run: hyperlane --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,32 +10,11 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  cli-install-cross-platform-release-test:
-    strategy:
-      matrix:
-        os: [depot-ubuntu-latest, depot-macos-latest, depot-windows-2022]
-        node-version: [18, 19, 20, 21, 22, 23]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: install-hyperlane-cli
-        id: install-hyperlane-cli
-        uses: ./.github/actions/install-cli
-        with:
-          ref: ${{ github.sha }}
-          cache-provider: github
-
-      - name: Test run the CLI
-        run: hyperlane --version
-
-  release:
-    needs:
-      - cli-install-cross-platform-release-test
+  # This job prepares the release by creating or updating a release PR.
+  # Notice the omission of the `publish` flag in the changesets action.
+  prepare-release:
+    outputs:
+      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     permissions:
       id-token: write
       contents: write
@@ -58,7 +37,76 @@ jobs:
       - name: Install Dependencies
         run: yarn install --immutable
 
-      - name: Create Release PR or Publish to NPM
+      - name: Create Release PR
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: yarn version:prepare
+        env:
+          NPM_CONFIG_PROVENANCE: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Set Changesets
+        run: echo "changesets=$(yarn changeset status --json)" >> $GITHUB_OUTPUT
+
+  # The release PR removes individual changesets to prepare for a release.
+  # This means that once the release PR is merged, there are no changesets left.
+  # When there are no changesets left, we can run the cli-install-cross-platform-release-test
+  # workflow to verify that the CLI installs correctly on all platforms.
+  # In all other cases, we already have a barebones `cli-install` test on the default CI platform
+  # which will catch most issues before any offending PR is merged.
+  cli-install-cross-platform-release-test:
+    needs: prepare-release
+    if: needs.prepare-release.outputs.hasChangesets == 'false'
+    strategy:
+      matrix:
+        os: [depot-ubuntu-latest, depot-macos-latest, depot-windows-2022]
+        node-version: [18, 19, 20, 21, 22, 23]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: install-hyperlane-cli
+        id: install-hyperlane-cli
+        uses: ./.github/actions/install-cli
+        with:
+          ref: ${{ github.sha }}
+          cache-provider: github
+
+      - name: Test run the CLI
+        run: hyperlane --version
+
+  # This job publishes the release to NPM.
+  publish-release:
+    needs: cli-install-cross-platform-release-test
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          # check out full history
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup Node.js 18.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+
+      - name: Install Dependencies
+        run: yarn install --immutable
+
+      - name: Publish Release to NPM
         id: changesets
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
### Description

feat: rearrange release workflow
- before this change, we'd spend 10-20mins in CI waiting for the cli matrix to run before updating the release PR.
- instead what is more beneficial is only running the full CLI test matrix when we detect that we may want to publish a release.

### Drive-by changes

- passthrough `github` cache-provider to the install/build action so that we use the correct cache on depot runners. currently we are using the wrong cache.

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
