### PR TITLE
fix(cosmos-native): sort sigs in ascending order by validator address

### DIFF
--- a/rust/main/chains/hyperlane-cosmos-native/src/ism.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/ism.rs
@@ -120,6 +120,9 @@ impl MultisigIsm for CosmosNativeIsm {
                     .iter()
                     .map(|v| H160::from_str(v).map(H256::from))
                     .collect::<Result<Vec<_>, _>>()?;
+                // on cosmos native, the ISM expects the checkpoints in the metadata to be sorted
+                // in ascending order of the validator address. So we sort the validators here,
+                // which will determine the order of the checkpoints in the metadata.
                 validators.sort();
                 Ok((validators, ism.threshold as u8))
             }

--- a/rust/main/chains/hyperlane-cosmos-native/src/ism.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/ism.rs
@@ -115,11 +115,12 @@ impl MultisigIsm for CosmosNativeIsm {
             t if t == MerkleRootMultisigIsm::type_url() => {
                 let ism = MerkleRootMultisigIsm::decode(ism.value.as_slice())
                     .map_err(HyperlaneCosmosError::from)?;
-                let validators = ism
+                let mut validators = ism
                     .validators
                     .iter()
                     .map(|v| H160::from_str(v).map(H256::from))
                     .collect::<Result<Vec<_>, _>>()?;
+                validators.sort();
                 Ok((validators, ism.threshold as u8))
             }
             _ => Err(ChainCommunicationError::from_other_str(&format!(


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
