### PR TITLE
fix: don't change signature order in metadata

### DIFF
--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   check-env:
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     # assign output from step to job output
     outputs:
       gcloud-service-key: ${{ steps.gcloud-service-key.outputs.defined }}
@@ -27,7 +27,7 @@ jobs:
         run: echo "defined=true" >> $GITHUB_OUTPUT
 
   build-and-push-to-gcr:
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write

--- a/rust/main/chains/hyperlane-cosmos-native/src/ism.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/ism.rs
@@ -115,15 +115,11 @@ impl MultisigIsm for CosmosNativeIsm {
             t if t == MerkleRootMultisigIsm::type_url() => {
                 let ism = MerkleRootMultisigIsm::decode(ism.value.as_slice())
                     .map_err(HyperlaneCosmosError::from)?;
-                let mut validators = ism
+                let validators = ism
                     .validators
                     .iter()
                     .map(|v| H160::from_str(v).map(H256::from))
                     .collect::<Result<Vec<_>, _>>()?;
-                // on cosmos native, the ISM expects the checkpoints in the metadata to be sorted
-                // in ascending order of the validator address. So we sort the validators here,
-                // which will determine the order of the checkpoints in the metadata.
-                validators.sort();
                 Ok((validators, ism.threshold as u8))
             }
             _ => Err(ChainCommunicationError::from_other_str(&format!(

--- a/rust/main/hyperlane-base/src/types/multisig.rs
+++ b/rust/main/hyperlane-base/src/types/multisig.rs
@@ -150,7 +150,7 @@ impl MultisigCheckpointSyncer {
 
             for index in (minimum_index..=start_index).rev() {
                 if let Ok(Some(checkpoint)) =
-                    self.fetch_checkpoint(&validators, threshold, index).await
+                    self.fetch_checkpoint(validators, threshold, index).await
                 {
                     return Ok(Some(checkpoint));
                 }

--- a/rust/main/hyperlane-base/src/types/multisig.rs
+++ b/rust/main/hyperlane-base/src/types/multisig.rs
@@ -138,12 +138,6 @@ impl MultisigCheckpointSyncer {
         // the highest index for which we (supposedly) have (n+1) signed checkpoints
         latest_indices.sort_by(|a, b| b.1.cmp(&a.1));
 
-        // create a slice with the sorted validators
-        let validators = latest_indices
-            .iter()
-            .map(|(address, _)| H256::from(*address))
-            .collect::<Vec<_>>();
-
         if let Some(&(_, highest_quorum_index)) = latest_indices.get(threshold - 1) {
             // The highest viable checkpoint index is the minimum of the highest index
             // we (supposedly) have a quorum for, and the maximum index for which we can


### PR DESCRIPTION
### Description
Keep the ordering of metadata signatures the same for MerkleRootMultiSig
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
