### PR TITLE
feat: Support commitments in ICA messages

### DIFF
--- a/solidity/contracts/isms/routing/InterchainAccountIsm.sol
+++ b/solidity/contracts/isms/routing/InterchainAccountIsm.sol
@@ -35,7 +35,7 @@ contract InterchainAccountIsm is AbstractRoutingIsm, PackageVersioned {
         bytes calldata _message
     ) public view virtual override returns (IInterchainSecurityModule) {
         bytes calldata _icaMsg = _message.body();
-        address _ism = _icaMsg.ism(_icaMsg.messageType()).bytes32ToAddress();
+        address _ism = _icaMsg.ism().bytes32ToAddress();
         if (_ism == address(0)) {
             return mailbox.defaultIsm();
         } else {

--- a/solidity/contracts/isms/routing/InterchainAccountIsm.sol
+++ b/solidity/contracts/isms/routing/InterchainAccountIsm.sol
@@ -14,6 +14,9 @@ import {TypeCasts} from "../../libs/TypeCasts.sol";
  */
 contract InterchainAccountIsm is AbstractRoutingIsm, PackageVersioned {
     using TypeCasts for bytes32;
+    using Message for bytes;
+    using InterchainAccountMessage for bytes;
+
     IMailbox private immutable mailbox;
 
     // ============ Constructor ============
@@ -31,9 +34,8 @@ contract InterchainAccountIsm is AbstractRoutingIsm, PackageVersioned {
     function route(
         bytes calldata _message
     ) public view virtual override returns (IInterchainSecurityModule) {
-        address _ism = InterchainAccountMessage
-            .ism(Message.body(_message))
-            .bytes32ToAddress();
+        bytes calldata _icaMsg = _message.body();
+        address _ism = _icaMsg.ism(_icaMsg.messageType()).bytes32ToAddress();
         if (_ism == address(0)) {
             return mailbox.defaultIsm();
         } else {

--- a/solidity/contracts/isms/routing/InterchainAccountIsm.sol
+++ b/solidity/contracts/isms/routing/InterchainAccountIsm.sol
@@ -7,11 +7,13 @@ import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityMod
 import {Message} from "../../libs/Message.sol";
 import {InterchainAccountMessage} from "../../middleware/libs/InterchainAccountMessage.sol";
 import {PackageVersioned} from "../../PackageVersioned.sol";
+import {TypeCasts} from "../../libs/TypeCasts.sol";
 
 /**
  * @title InterchainAccountIsm
  */
 contract InterchainAccountIsm is AbstractRoutingIsm, PackageVersioned {
+    using TypeCasts for bytes32;
     IMailbox private immutable mailbox;
 
     // ============ Constructor ============
@@ -29,7 +31,9 @@ contract InterchainAccountIsm is AbstractRoutingIsm, PackageVersioned {
     function route(
         bytes calldata _message
     ) public view virtual override returns (IInterchainSecurityModule) {
-        address _ism = InterchainAccountMessage.ism(Message.body(_message));
+        address _ism = InterchainAccountMessage
+            .ism(Message.body(_message))
+            .bytes32ToAddress();
         if (_ism == address(0)) {
             return mailbox.defaultIsm();
         } else {

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -321,7 +321,7 @@ contract InterchainAccountRouter is Router {
             CallLib.Call[] memory calls = _message.calls();
             ica.multicall{value: msg.value}(calls);
         } else {
-            // This is definitely of a message of type COMMITMENT
+            // This is definitely a message of type COMMITMENT
             verifiedCommitments[_commitment] = ica;
         }
     }

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -15,7 +15,7 @@ pragma solidity ^0.8.13;
 
 // ============ Internal Imports ============
 import {OwnableMulticall} from "./libs/OwnableMulticall.sol";
-import {InterchainAccountMessage} from "./libs/InterchainAccountMessage.sol";
+import {InterchainAccountMessage, InterchainAccountMessageReveal} from "./libs/InterchainAccountMessage.sol";
 import {CallLib} from "./libs/Call.sol";
 import {MinimalProxy} from "../libs/MinimalProxy.sol";
 import {TypeCasts} from "../libs/TypeCasts.sol";
@@ -286,21 +286,27 @@ contract InterchainAccountRouter is Router {
         InterchainAccountMessage.MessageType _messageType = _message
             .messageType();
 
-        // If the message is a reveal, we don't do any derivation of the ica address
-        // The commitment should be executed in the `verify` method of the CCIP read ISM that verified this message
-        // so here we just check that commitment -> ICA association has been cleared
+        bytes32 _commitment;
+        bytes32 _ism;
         if (_messageType == InterchainAccountMessage.MessageType.REVEAL) {
+            _commitment = InterchainAccountMessageReveal.commitment(_message);
+            _ism = InterchainAccountMessageReveal.ism(_message);
+
+            // If the message is a reveal, we don't do any derivation of the ica address
             // The commitment should be executed in the `verify` method of the CCIP read ISM that verified this message
+            // so here we just check that commitment -> ICA association has been cleared
             require(
-                verifiedCommitments[_message.commitment(_messageType)] ==
+                verifiedCommitments[_commitment] ==
                     OwnableMulticall(payable(address(0))),
                 "Commitment was not executed"
             );
             return;
+        } else {
+            _commitment = _message.commitment();
+            _ism = _message.ism();
         }
 
         bytes32 _owner = _message.owner();
-        bytes32 _ism = _message.ism(_messageType);
         bytes32 _salt = _message.salt();
 
         OwnableMulticall ica = getDeployedInterchainAccount(
@@ -315,8 +321,8 @@ contract InterchainAccountRouter is Router {
             CallLib.Call[] memory calls = _message.calls();
             ica.multicall{value: msg.value}(calls);
         } else {
-            bytes32 commitment = _message.commitment(_messageType);
-            verifiedCommitments[commitment] = ica;
+            // This is definitely of a message of type COMMITMENT
+            verifiedCommitments[_commitment] = ica;
         }
     }
 

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -292,7 +292,7 @@ contract InterchainAccountRouter is Router {
             require(
                 verifiedCommitments[_message.commitment()] !=
                     OwnableMulticall(payable(address(0))),
-                "Commitment ewas not executed"
+                "Commitment was not executed"
             );
             return;
         }

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -292,7 +292,7 @@ contract InterchainAccountRouter is Router {
         if (_messageType == InterchainAccountMessage.MessageType.REVEAL) {
             // The commitment should be executed in the `verify` method of the CCIP read ISM that verified this message
             require(
-                verifiedCommitments[_message.commitment()] ==
+                verifiedCommitments[_message.commitment(_messageType)] ==
                     OwnableMulticall(payable(address(0))),
                 "Commitment was not executed"
             );
@@ -300,7 +300,7 @@ contract InterchainAccountRouter is Router {
         }
 
         bytes32 _owner = _message.owner();
-        bytes32 _ism = _message.ism();
+        bytes32 _ism = _message.ism(_messageType);
         bytes32 _salt = _message.salt();
 
         OwnableMulticall ica = getDeployedInterchainAccount(
@@ -315,7 +315,7 @@ contract InterchainAccountRouter is Router {
             CallLib.Call[] memory calls = _message.calls();
             ica.multicall{value: msg.value}(calls);
         } else {
-            bytes32 commitment = _message.commitment();
+            bytes32 commitment = _message.commitment(_messageType);
             verifiedCommitments[commitment] = ica;
         }
     }

--- a/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
+++ b/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
@@ -172,8 +172,11 @@ library InterchainAccountMessage {
      * @param _message The interchain account message
      * @return The ISM encoded in the message
      */
-    function ism(bytes calldata _message) internal pure returns (bytes32) {
-        if (messageType(_message) == MessageType.REVEAL) {
+    function ism(
+        bytes calldata _message,
+        MessageType _type
+    ) internal pure returns (bytes32) {
+        if (_type == MessageType.REVEAL) {
             return bytes32(_message[1:33]);
         }
         return bytes32(_message[33:65]);
@@ -190,9 +193,10 @@ library InterchainAccountMessage {
     }
 
     function commitment(
-        bytes calldata _message
+        bytes calldata _message,
+        MessageType _type
     ) internal pure returns (bytes32) {
-        if (messageType(_message) == MessageType.REVEAL) {
+        if (_type == MessageType.REVEAL) {
             return bytes32(_message[33:65]);
         }
         return bytes32(_message[97:]);

--- a/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
+++ b/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
@@ -162,7 +162,6 @@ library InterchainAccountMessage {
     ) internal pure returns (MessageType) {
         return MessageType(uint8(_message[0]));
     }
-    }
 
     function owner(bytes calldata _message) internal pure returns (bytes32) {
         return bytes32(_message[1:33]);

--- a/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
+++ b/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
@@ -194,11 +194,6 @@ library InterchainAccountMessage {
 }
 
 library InterchainAccountMessageReveal {
-    enum MessageType {
-        CALLS,
-        COMMITMENT,
-        REVEAL
-    }
     function ism(bytes calldata _message) internal pure returns (bytes32) {
         return bytes32(_message[1:33]);
     }

--- a/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
+++ b/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
@@ -162,7 +162,7 @@ library InterchainAccountMessage {
     function messageType(
         bytes calldata _message
     ) internal pure returns (MessageType) {
-        return MessageType(uint8(uint256(bytes32(_message[0:1]))));
+        return MessageType(uint8(bytes1(_message[0:1])));
     }
 
     function owner(bytes calldata _message) internal pure returns (bytes32) {

--- a/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
+++ b/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
@@ -197,6 +197,7 @@ library InterchainAccountMessageReveal {
     function ism(bytes calldata _message) internal pure returns (bytes32) {
         return bytes32(_message[1:33]);
     }
+
     function commitment(
         bytes calldata _message
     ) internal pure returns (bytes32) {

--- a/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
+++ b/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
@@ -160,7 +160,8 @@ library InterchainAccountMessage {
     function messageType(
         bytes calldata _message
     ) internal pure returns (MessageType) {
-        return MessageType(uint8(bytes1(_message[0:1])));
+        return MessageType(uint8(_message[0]));
+    }
     }
 
     function owner(bytes calldata _message) internal pure returns (bytes32) {

--- a/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
+++ b/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
@@ -16,7 +16,8 @@ library InterchainAccountMessage {
 
     enum MessageType {
         CALLS,
-        COMMITMENT
+        COMMITMENT,
+        REVEAL
     }
 
     bytes32 internal constant EMPTY_SALT = bytes32(0);
@@ -149,14 +150,11 @@ library InterchainAccountMessage {
             );
     }
 
-    function decodeCommitment(
-        bytes calldata _message
-    ) internal pure returns (MessageType, bytes32, bytes32, bytes32, bytes32) {
-        return
-            abi.decode(
-                _message,
-                (MessageType, bytes32, bytes32, bytes32, bytes32)
-            );
+    function encodeReveal(
+        bytes32 _ism,
+        bytes32 _commitment
+    ) internal pure returns (bytes memory) {
+        return abi.encodePacked(MessageType.REVEAL, _ism, _commitment);
     }
 
     function messageType(
@@ -175,6 +173,9 @@ library InterchainAccountMessage {
      * @return The ISM encoded in the message
      */
     function ism(bytes calldata _message) internal pure returns (bytes32) {
+        if (messageType(_message) == MessageType.REVEAL) {
+            return bytes32(_message[1:33]);
+        }
         return bytes32(_message[33:65]);
     }
 
@@ -191,6 +192,9 @@ library InterchainAccountMessage {
     function commitment(
         bytes calldata _message
     ) internal pure returns (bytes32) {
+        if (messageType(_message) == MessageType.REVEAL) {
+            return bytes32(_message[33:65]);
+        }
         return bytes32(_message[97:]);
     }
 }

--- a/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
+++ b/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
@@ -172,13 +172,7 @@ library InterchainAccountMessage {
      * @param _message The interchain account message
      * @return The ISM encoded in the message
      */
-    function ism(
-        bytes calldata _message,
-        MessageType _type
-    ) internal pure returns (bytes32) {
-        if (_type == MessageType.REVEAL) {
-            return bytes32(_message[1:33]);
-        }
+    function ism(bytes calldata _message) internal pure returns (bytes32) {
         return bytes32(_message[33:65]);
     }
 
@@ -193,12 +187,24 @@ library InterchainAccountMessage {
     }
 
     function commitment(
-        bytes calldata _message,
-        MessageType _type
+        bytes calldata _message
     ) internal pure returns (bytes32) {
-        if (_type == MessageType.REVEAL) {
-            return bytes32(_message[33:65]);
-        }
         return bytes32(_message[97:]);
+    }
+}
+
+library InterchainAccountMessageReveal {
+    enum MessageType {
+        CALLS,
+        COMMITMENT,
+        REVEAL
+    }
+    function ism(bytes calldata _message) internal pure returns (bytes32) {
+        return bytes32(_message[1:33]);
+    }
+    function commitment(
+        bytes calldata _message
+    ) internal pure returns (bytes32) {
+        return bytes32(_message[33:65]);
     }
 }

--- a/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
+++ b/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
@@ -12,12 +12,19 @@ import {TypeCasts} from "../../libs/TypeCasts.sol";
  */
 library InterchainAccountMessage {
     using TypeCasts for bytes32;
+    using TypeCasts for address;
+
+    enum MessageType {
+        CALLS,
+        COMMITMENT
+    }
 
     bytes32 internal constant EMPTY_SALT = bytes32(0);
 
     /**
      * @notice Returns formatted (packed) InterchainAccountMessage
-     * @dev This function should only be used in memory message construction.
+     * @dev `Calls` are usually passed in calldata, but here we construct the `Call` array in memory.
+     * We can't reuse the `encode` function below because it expects a type of `CallLib.Call[] calldata`.
      * @param _owner The owner of the interchain account
      * @param _ism The address of the remote ISM
      * @param _to The address of the contract to call
@@ -34,13 +41,15 @@ library InterchainAccountMessage {
     ) internal pure returns (bytes memory) {
         CallLib.Call[] memory _calls = new CallLib.Call[](1);
         _calls[0] = CallLib.build(_to, _value, _data);
-        return
-            abi.encode(
-                TypeCasts.addressToBytes32(_owner),
-                _ism,
-                _calls,
-                EMPTY_SALT // Salts are expected when decoding.
-            );
+
+        bytes memory prefix = abi.encodePacked(
+            MessageType.CALLS,
+            _owner.addressToBytes32(),
+            _ism,
+            EMPTY_SALT
+        );
+        bytes memory suffix = abi.encode(_calls);
+        return bytes.concat(prefix, suffix);
     }
 
     /**
@@ -107,19 +116,57 @@ library InterchainAccountMessage {
         CallLib.Call[] calldata _calls,
         bytes32 _userSalt
     ) internal pure returns (bytes memory) {
-        return abi.encode(_owner, _ism, _calls, _userSalt);
+        bytes memory prefix = abi.encodePacked(
+            MessageType.CALLS,
+            _owner,
+            _ism,
+            _userSalt
+        );
+        bytes memory suffix = abi.encode(_calls);
+        return bytes.concat(prefix, suffix);
     }
 
     /**
-     * @notice Parses and returns the calls from the provided message
-     * @param _message The interchain account message
-     * @return The array of calls
+     * @notice Returns formatted (packed) InterchainAccountMessage
+     * @dev This function should only be used in memory message construction.
+     * @param _owner The owner of the interchain account
+     * @param _ism The address of the remote ISM
+     * @return Formatted message body
      */
-    function decode(
-        bytes calldata _message
-    ) internal pure returns (bytes32, bytes32, CallLib.Call[] memory, bytes32) {
+    function encodeCommitment(
+        bytes32 _owner,
+        bytes32 _ism,
+        bytes32 _commitment,
+        bytes32 _userSalt
+    ) internal pure returns (bytes memory) {
         return
-            abi.decode(_message, (bytes32, bytes32, CallLib.Call[], bytes32));
+            abi.encodePacked(
+                MessageType.COMMITMENT,
+                _owner,
+                _ism,
+                _userSalt,
+                _commitment
+            );
+    }
+
+    function decodeCommitment(
+        bytes calldata _message
+    ) internal pure returns (MessageType, bytes32, bytes32, bytes32, bytes32) {
+        return
+            abi.decode(
+                _message,
+                (MessageType, bytes32, bytes32, bytes32, bytes32)
+            );
+    }
+
+    function messageType(
+        bytes calldata _message
+    ) internal pure returns (MessageType) {
+        return MessageType(uint8(uint256(bytes32(_message[0:1]))));
+    }
+
+    function owner(bytes calldata _message) internal pure returns (bytes32) {
+        return bytes32(_message[1:33]);
     }
 
     /**
@@ -127,7 +174,23 @@ library InterchainAccountMessage {
      * @param _message The interchain account message
      * @return The ISM encoded in the message
      */
-    function ism(bytes calldata _message) internal pure returns (address) {
-        return address(bytes20(_message[44:64]));
+    function ism(bytes calldata _message) internal pure returns (bytes32) {
+        return bytes32(_message[33:65]);
+    }
+
+    function salt(bytes calldata _message) internal pure returns (bytes32) {
+        return bytes32(_message[65:97]);
+    }
+
+    function calls(
+        bytes calldata _message
+    ) internal pure returns (CallLib.Call[] memory) {
+        return abi.decode(_message[97:], (CallLib.Call[]));
+    }
+
+    function commitment(
+        bytes calldata _message
+    ) internal pure returns (bytes32) {
+        return bytes32(_message[97:]);
     }
 }

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -920,12 +920,18 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
             address(ica)
         );
 
-        // Process reveal message
-        environment.processNextPendingMessage();
+        // Manually process the reveal. In reality, the CCIP read ISM will call `revealAndExecute`
+        // but here we do it manually since we're not using the CCIP read ISM yet
         destinationIcaRouter.revealAndExecute(calls, salt);
+
+        // Commitment should be cleared
         assertEq(
             address(destinationIcaRouter.verifiedCommitments(commitment)),
             address(0)
         );
+
+        // Cannot reveal twice
+        vm.expectRevert("Invalid Reveal");
+        destinationIcaRouter.revealAndExecute(calls, salt);
     }
 }


### PR DESCRIPTION
### Description

You can now make shielded calls using ICAs. We use a [commit/reveal](https://en.wikipedia.org/wiki/Commitment_scheme) scheme where the first message is a commitment, and the second message is a reveal. The commitment message looks like 

```solidity
struct {
  address owner;
  address ism;
  bytes32 salt;
  bytes32 commitment;
}
```

The commitment is `hash(bytes32 salt, Call[] calls)`. 

The reveal message looks like 
```solidity
struct {
  address offChainLookupIsm;
  bytes32 commitment;
}
```

The offChainLookupIsm will contain the urls that a relayer must query to retrieve the calls/salt given the commitment. The relayer will pass the retrieved calls/salt to this ism as **metadata**, and the ism will verify if the salt/calls match the commitment. For more, see #6069 and the [CCIP spec](https://eips.ethereum.org/EIPS/eip-3668#specification).
### Drive-by changes


### Related issues
https://linear.app/hyperlane-xyz/issue/ENG-1425/ica-call-commitments-smart-contract-changes


### Backward compatibility

No.

### Testing
Unit. 