### PR TITLE
fix: release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Set Changesets
-        run: echo "changesets=$(yarn changeset status --json)" >> $GITHUB_OUTPUT
-
   # The release PR removes individual changesets to prepare for a release.
   # This means that once the release PR is merged, there are no changesets left.
   # When there are no changesets left, we can run the cli-install-cross-platform-release-test


### PR DESCRIPTION
### Description

remove the "set changesets" step that was failing. The step that fails is completely extraneous and from an old attempt at the flow - might bring back in future but not necessary atm

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
