### PR TITLE
fix: update Checker checkChains() to convert remoteRouter domainId to name

### DIFF
--- a/typescript/sdk/src/token/checker.ts
+++ b/typescript/sdk/src/token/checker.ts
@@ -41,11 +41,14 @@ export class HypERC20Checker extends ProxiedRouterChecker<
     expectedChains = Object.keys(this.configMap);
     const thisChainConfig = this.configMap[chain];
     if (thisChainConfig?.remoteRouters) {
-      expectedChains = Object.keys(thisChainConfig.remoteRouters).map((chn) =>
-        this.multiProvider.getChainName(chn),
+      expectedChains = Object.keys(thisChainConfig.remoteRouters).map(
+        (remoteRouterChain) =>
+          this.multiProvider.getChainName(remoteRouterChain),
       );
     }
-    expectedChains = expectedChains.filter((chn) => chn !== chain).sort();
+    expectedChains = expectedChains
+      .filter((remoteRouterChain) => remoteRouterChain !== chain)
+      .sort();
 
     await super.checkChain(chain, expectedChains);
     await this.checkToken(chain);

--- a/typescript/sdk/src/token/checker.ts
+++ b/typescript/sdk/src/token/checker.ts
@@ -41,7 +41,9 @@ export class HypERC20Checker extends ProxiedRouterChecker<
     expectedChains = Object.keys(this.configMap);
     const thisChainConfig = this.configMap[chain];
     if (thisChainConfig?.remoteRouters) {
-      expectedChains = Object.keys(thisChainConfig.remoteRouters);
+      expectedChains = Object.keys(thisChainConfig.remoteRouters).map((chn) =>
+        this.multiProvider.getChainName(chn),
+      );
     }
     expectedChains = expectedChains.filter((chn) => chn !== chain).sort();
 


### PR DESCRIPTION
### Description
This PR adds `this.multiProvider.getChainName(chn)` to convert the each domainId in remoteRouters to a chain name to allow Checker comparison.

### Backward compatibility
Yes

### Testing
Manual
