### PR TITLE
chore: Update remoteRouter names to domainIds in Getters 

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumBaseEthereumOptimismPolygonZeroNetworkUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumBaseEthereumOptimismPolygonZeroNetworkUSDCWarpConfig.ts
@@ -31,8 +31,8 @@ export const getArbitrumBaseEthereumLiskOptimismPolygonZeroNetworkUSDCWarpConfig
       token: tokens.arbitrum.USDC,
       interchainSecurityModule: ISM_CONFIG,
       remoteRouters: {
-        lisk: { address: '0x0FC41a92F526A8CD22060A4052e156502D6B9db0' },
-        zeronetwork: { address: '0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1' },
+        1135: { address: '0x0FC41a92F526A8CD22060A4052e156502D6B9db0' },
+        543210: { address: '0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1' },
       },
     };
 
@@ -47,8 +47,8 @@ export const getArbitrumBaseEthereumLiskOptimismPolygonZeroNetworkUSDCWarpConfig
       token: tokens.base.USDC,
       interchainSecurityModule: ISM_CONFIG,
       remoteRouters: {
-        lisk: { address: '0x0FC41a92F526A8CD22060A4052e156502D6B9db0' },
-        zeronetwork: { address: '0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1' },
+        1135: { address: '0x0FC41a92F526A8CD22060A4052e156502D6B9db0' },
+        543210: { address: '0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1' },
       },
     };
 
@@ -63,8 +63,8 @@ export const getArbitrumBaseEthereumLiskOptimismPolygonZeroNetworkUSDCWarpConfig
       token: tokens.optimism.USDC,
       interchainSecurityModule: ISM_CONFIG,
       remoteRouters: {
-        lisk: { address: '0x0FC41a92F526A8CD22060A4052e156502D6B9db0' },
-        zeronetwork: { address: '0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1' },
+        1135: { address: '0x0FC41a92F526A8CD22060A4052e156502D6B9db0' },
+        543210: { address: '0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1' },
       },
     };
 
@@ -79,8 +79,8 @@ export const getArbitrumBaseEthereumLiskOptimismPolygonZeroNetworkUSDCWarpConfig
       token: tokens.polygon.USDC,
       interchainSecurityModule: ISM_CONFIG,
       remoteRouters: {
-        lisk: { address: '0x0FC41a92F526A8CD22060A4052e156502D6B9db0' },
-        zeronetwork: { address: '0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1' },
+        1135: { address: '0x0FC41a92F526A8CD22060A4052e156502D6B9db0' },
+        543210: { address: '0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1' },
       },
     };
 
@@ -107,8 +107,8 @@ export const getArbitrumBaseEthereumLiskOptimismPolygonZeroNetworkUSDCWarpConfig
       token: tokens.ethereum.USDC,
       interchainSecurityModule: ISM_CONFIG,
       remoteRouters: {
-        lisk: { address: '0x0FC41a92F526A8CD22060A4052e156502D6B9db0' },
-        zeronetwork: { address: '0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1' },
+        1135: { address: '0x0FC41a92F526A8CD22060A4052e156502D6B9db0' },
+        543210: { address: '0xbb967d98313EDF91751651C0E66ef8A8B7BeD9e1' },
       },
     };
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumEthereumMantleModePolygonScrollZeroNetworkUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumEthereumMantleModePolygonScrollZeroNetworkUSDTWarpConfig.ts
@@ -32,7 +32,7 @@ export const getArbitrumEthereumMantleModePolygonScrollZeroNetworkUSDTWarpConfig
       token: tokens.arbitrum.USDT,
       interchainSecurityModule: ISM_CONFIG,
       remoteRouters: {
-        zeronetwork: { address: '0x36dcfe3A0C6e0b5425F298587159249d780AAfab' },
+        543210: { address: '0x36dcfe3A0C6e0b5425F298587159249d780AAfab' },
       },
     };
 
@@ -47,7 +47,7 @@ export const getArbitrumEthereumMantleModePolygonScrollZeroNetworkUSDTWarpConfig
       token: tokens.ethereum.USDT,
       interchainSecurityModule: ISM_CONFIG,
       remoteRouters: {
-        zeronetwork: { address: '0x36dcfe3A0C6e0b5425F298587159249d780AAfab' },
+        543210: { address: '0x36dcfe3A0C6e0b5425F298587159249d780AAfab' },
       },
     };
 
@@ -62,7 +62,7 @@ export const getArbitrumEthereumMantleModePolygonScrollZeroNetworkUSDTWarpConfig
       token: tokens.mantle.USDT,
       interchainSecurityModule: ISM_CONFIG,
       remoteRouters: {
-        zeronetwork: { address: '0x36dcfe3A0C6e0b5425F298587159249d780AAfab' },
+        543210: { address: '0x36dcfe3A0C6e0b5425F298587159249d780AAfab' },
       },
     };
 
@@ -77,7 +77,7 @@ export const getArbitrumEthereumMantleModePolygonScrollZeroNetworkUSDTWarpConfig
       token: tokens.mode.USDT,
       interchainSecurityModule: ISM_CONFIG,
       remoteRouters: {
-        zeronetwork: { address: '0x36dcfe3A0C6e0b5425F298587159249d780AAfab' },
+        543210: { address: '0x36dcfe3A0C6e0b5425F298587159249d780AAfab' },
       },
     };
 
@@ -92,7 +92,7 @@ export const getArbitrumEthereumMantleModePolygonScrollZeroNetworkUSDTWarpConfig
       token: tokens.polygon.USDT,
       interchainSecurityModule: ISM_CONFIG,
       remoteRouters: {
-        zeronetwork: { address: '0x36dcfe3A0C6e0b5425F298587159249d780AAfab' },
+        543210: { address: '0x36dcfe3A0C6e0b5425F298587159249d780AAfab' },
       },
     };
 
@@ -107,7 +107,7 @@ export const getArbitrumEthereumMantleModePolygonScrollZeroNetworkUSDTWarpConfig
       token: tokens.scroll.USDT,
       interchainSecurityModule: ISM_CONFIG,
       remoteRouters: {
-        zeronetwork: { address: '0x36dcfe3A0C6e0b5425F298587159249d780AAfab' },
+        543210: { address: '0x36dcfe3A0C6e0b5425F298587159249d780AAfab' },
       },
     };
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumEthereumSolanaTreasureSMOLWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumEthereumSolanaTreasureSMOLWarpConfig.ts
@@ -56,6 +56,10 @@ export async function getArbitrumEthereumSolanaTreasureSMOLWarpConfig(
       symbol,
       decimals: 18,
       owner: evmOwner,
+      remoteRouters: {
+        1: { address: '0x53cce6d10e43d1b3d11872ad22ec2acd8d2537b8' },
+        61166: { address: '0xb73e4f558F7d4436d77a18f56e4EE9d01764c641' },
+      },
     },
   };
   return tokenConfig;


### PR DESCRIPTION
### Description
This PR Update remoteRouter names to domainIds in Getters for zero USDC, USDT, and treasure Smol

### Related issues
- Resolves https://linear.app/hyperlane-xyz/issue/ENG-1278/update-configs-that-have-violations

### Backward compatibility
Yes

### Testing
check warp deploy script
