### PR TITLE
fix: Add logs for diagnostics in Scraper

### DIFF
--- a/rust/main/agents/scraper/src/db/message.rs
+++ b/rust/main/agents/scraper/src/db/message.rs
@@ -277,6 +277,7 @@ impl ScraperDb {
         let latest_id_before = self
             .latest_dispatched_id(domain, origin_mailbox.clone())
             .await?;
+        debug!(?latest_id_before, "Got latest id before");
         // we have a race condition where a message may not have been scraped yet even
         let models = messages
             .map(|storable| message::ActiveModel {
@@ -298,7 +299,7 @@ impl ScraperDb {
             })
             .collect_vec();
 
-        trace!(?models, "Writing messages to database");
+        debug!(?models, "Writing messages to database");
 
         if models.is_empty() {
             debug!("Wrote zero new messages to database");

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use eyre::Result;
+use tracing::debug;
 
 use hyperlane_core::{
     unwrap_or_none_result, HyperlaneLogStore, HyperlaneMessage,
@@ -25,6 +26,8 @@ impl HyperlaneLogStore<HyperlaneMessage> for HyperlaneDbStore {
             .await?
             .map(|t| (t.hash, t))
             .collect();
+
+        debug!("Preparing storable");
         let storable = messages
             .iter()
             .filter_map(|(message, meta)| {
@@ -32,6 +35,7 @@ impl HyperlaneLogStore<HyperlaneMessage> for HyperlaneDbStore {
                     .map(|t| (message.inner().clone(), meta, t.id))
             })
             .map(|(msg, meta, txn_id)| StorableMessage { msg, meta, txn_id });
+        debug!(?storable, "Prepared storable");
         let stored = self
             .db
             .store_dispatched_messages(self.domain.id(), &self.mailbox_address, storable)

--- a/rust/main/agents/scraper/src/store/storage.rs
+++ b/rust/main/agents/scraper/src/store/storage.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, sync::Arc};
 use async_trait::async_trait;
 use eyre::Result;
 use itertools::Itertools;
-use tracing::{trace, warn};
+use tracing::{debug, trace, warn};
 
 use hyperlane_base::settings::IndexSettings;
 use hyperlane_core::{
@@ -84,7 +84,7 @@ impl HyperlaneDbStore {
             .await?
             .map(|block| (block.hash, block))
             .collect();
-        trace!(?blocks, "Ensured blocks");
+        debug!(?blocks, "Ensured blocks");
 
         // We ensure transactions only from blocks which are inserted into database
         let txn_hash_with_block_ids = block_id_by_txn_hash
@@ -92,6 +92,7 @@ impl HyperlaneDbStore {
             .filter_map(move |(txn, block)| blocks.get(&block.hash).map(|b| (txn, b.id)))
             .map(|(txn_hash, block_id)| TxnWithBlockId { txn_hash, block_id });
         let txns_with_ids = self.ensure_txns(txn_hash_with_block_ids).await?;
+        debug!(?txns_with_ids, "Ensured transactions");
 
         Ok(txns_with_ids.map(move |TxnWithId { hash, id: txn_id }| TxnWithId { hash, id: txn_id }))
     }


### PR DESCRIPTION
### Description

Add logs for diagnostics in Scraper to identify issue between ensuring blocks and transactions and storing dispatched messages into database.

### Backward compatibility

Yes

### Testing

None