### PR TITLE
fix: make env-test script more robust

### DIFF
--- a/typescript/infra/fork.sh
+++ b/typescript/infra/fork.sh
@@ -11,7 +11,7 @@ if [ -z "$ENVIRONMENT" ] || [ -z "$MODULE" ] || [ -z "$CHAIN" ]; then
 fi
 
 # kill all child processes on exit
-trap 'jobs -p | xargs -r kill' EXIT
+trap 'jobs -p | xargs -r kill 2>/dev/null || true' EXIT
 
 # exit 1 on any subsequent failures
 set -e


### PR DESCRIPTION
### Description

This PR prevents the exit trap handler in `fork.sh` from failing, which causes the whole test to fail sometimes.

### Backward compatibility

Yes

### Testing

env-test matrix jobs in CI