### PR TITLE
fix: metadata building error message

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base.rs
@@ -22,7 +22,7 @@ use crate::settings::matching_list::MatchingList;
 
 #[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub enum MetadataBuildError {
-    #[error("Some external error causing the build to fail")]
+    #[error("An external error causes the build to fail ({0})")]
     FailedToBuild(String),
     /// While building metadata, encountered something that should
     /// prohibit all metadata for the message from being built.


### PR DESCRIPTION
### Description

the actual error message is not being printed

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
