### PR TITLE
feat(submitter): measure tx submissions

### DIFF
--- a/rust/main/submitter/src/payload_dispatcher/metrics.rs
+++ b/rust/main/submitter/src/payload_dispatcher/metrics.rs
@@ -32,7 +32,7 @@ pub struct DispatcherMetrics {
     pub dropped_payloads: IntCounterVec,
     pub dropped_transactions: IntCounterVec,
 
-    pub transaction_resubmissions: IntCounterVec,
+    pub transaction_submissions: IntCounterVec,
 
     pub finalized_transactions: IntCounterVec,
 
@@ -93,9 +93,9 @@ impl DispatcherMetrics {
             &["destination", "reason",],
             registry.clone()
         )?;
-        let transaction_resubmissions = register_int_counter_vec_with_registry!(
+        let transaction_submissions = register_int_counter_vec_with_registry!(
             opts!(
-                namespaced("transaction_resubmissions"),
+                namespaced("transaction_submissions"),
                 "The number of times transactions were resubmitted",
             ),
             &["destination",],
@@ -133,7 +133,7 @@ impl DispatcherMetrics {
             finality_stage_pool_length,
             dropped_payloads,
             dropped_transactions,
-            transaction_resubmissions,
+            transaction_submissions,
             finalized_transactions,
             call_retries,
             in_flight_transaction_time,
@@ -179,8 +179,8 @@ impl DispatcherMetrics {
             .inc();
     }
 
-    pub fn update_transaction_resubmissions_metric(&self, domain: &str) {
-        self.transaction_resubmissions
+    pub fn update_transaction_submissions_metric(&self, domain: &str) {
+        self.transaction_submissions
             .with_label_values(&[domain])
             .inc();
     }

--- a/rust/main/submitter/src/payload_dispatcher/metrics.rs
+++ b/rust/main/submitter/src/payload_dispatcher/metrics.rs
@@ -32,6 +32,8 @@ pub struct DispatcherMetrics {
     pub dropped_payloads: IntCounterVec,
     pub dropped_transactions: IntCounterVec,
 
+    pub transaction_resubmissions: IntCounterVec,
+
     pub finalized_transactions: IntCounterVec,
 
     // includes a label for the error causing the retry, and a label for the type of call
@@ -91,6 +93,14 @@ impl DispatcherMetrics {
             &["destination", "reason",],
             registry.clone()
         )?;
+        let transaction_resubmissions = register_int_counter_vec_with_registry!(
+            opts!(
+                namespaced("transaction_resubmissions"),
+                "The number of times transactions were resubmitted",
+            ),
+            &["destination",],
+            registry.clone()
+        )?;
         let finalized_transactions = register_int_counter_vec_with_registry!(
             opts!(
                 namespaced("finalized_transactions"),
@@ -123,6 +133,7 @@ impl DispatcherMetrics {
             finality_stage_pool_length,
             dropped_payloads,
             dropped_transactions,
+            transaction_resubmissions,
             finalized_transactions,
             call_retries,
             in_flight_transaction_time,
@@ -165,6 +176,12 @@ impl DispatcherMetrics {
     pub fn update_dropped_transactions_metric(&self, reason: &str, domain: &str) {
         self.dropped_transactions
             .with_label_values(&[domain, reason])
+            .inc();
+    }
+
+    pub fn update_transaction_resubmissions_metric(&self, domain: &str) {
+        self.transaction_resubmissions
+            .with_label_values(&[domain])
             .inc();
     }
 

--- a/rust/main/submitter/src/payload_dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/submitter/src/payload_dispatcher/stages/inclusion_stage.rs
@@ -219,7 +219,7 @@ impl InclusionStage {
         tx.submission_attempts += 1;
         state
             .metrics
-            .update_transaction_resubmissions_metric(&state.domain);
+            .update_transaction_submissions_metric(&state.domain);
         // update tx status in db
         update_tx_status(state, &mut tx, TransactionStatus::Mempool).await?;
 

--- a/rust/main/submitter/src/payload_dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/submitter/src/payload_dispatcher/stages/inclusion_stage.rs
@@ -217,6 +217,9 @@ impl InclusionStage {
 
         // update tx submission attempts
         tx.submission_attempts += 1;
+        state
+            .metrics
+            .update_transaction_resubmissions_metric(&state.domain);
         // update tx status in db
         update_tx_status(state, &mut tx, TransactionStatus::Mempool).await?;
 

--- a/rust/main/submitter/src/payload_dispatcher/tests.rs
+++ b/rust/main/submitter/src/payload_dispatcher/tests.rs
@@ -101,7 +101,7 @@ async fn test_entrypoint_send_is_finalized_by_dispatcher() {
         dropped_transaction_reason: "".to_string(),
         // in `mock_adapter_methods`, the tx_status method is mocked to return `PendingInclusion` for the first 2 calls,
         // which causes the tx to be resubmitted each time
-        transaction_resubmissions: 2,
+        transaction_submissions: 2,
     };
     assert_metrics(metrics, metrics_assertion);
 }
@@ -159,7 +159,7 @@ async fn test_entrypoint_send_is_dropped_by_dispatcher() {
         dropped_transactions: 1,
         dropped_payload_reason: "DroppedInTransaction(FailedSimulation)".to_string(),
         dropped_transaction_reason: "FailedSimulation".to_string(),
-        transaction_resubmissions: 0,
+        transaction_submissions: 0,
     };
     assert_metrics(metrics, metrics_assertion);
 }
@@ -202,7 +202,7 @@ async fn test_entrypoint_payload_fails_simulation() {
         dropped_transactions: 0,
         dropped_payload_reason: "FailedSimulation".to_string(),
         dropped_transaction_reason: "".to_string(),
-        transaction_resubmissions: 0,
+        transaction_submissions: 0,
     };
     assert_metrics(metrics, metrics_assertion);
 }
@@ -305,7 +305,7 @@ struct MetricsAssertion {
     dropped_transactions: u64,
     dropped_payload_reason: String,
     dropped_transaction_reason: String,
-    transaction_resubmissions: u64,
+    transaction_submissions: u64,
 }
 
 fn assert_metrics(metrics: DispatcherMetrics, assertion: MetricsAssertion) {
@@ -365,13 +365,13 @@ fn assert_metrics(metrics: DispatcherMetrics, assertion: MetricsAssertion) {
         "Dropped transactions metric is incorrect for domain {}",
         assertion.domain
     );
-    let transaction_resubmissions = metrics
-        .transaction_resubmissions
+    let transaction_submissions = metrics
+        .transaction_submissions
         .with_label_values(&[&assertion.domain])
         .get();
     assert_eq!(
-        transaction_resubmissions, assertion.transaction_resubmissions,
-        "Transaction resubmissions metric is incorrect for domain {}",
+        transaction_submissions, assertion.transaction_submissions,
+        "Transaction submissions metric is incorrect for domain {}",
         assertion.domain
     );
 }


### PR DESCRIPTION
### Description

Adds a metric that is incremented each time a transaction is submitted

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

Unit tests and a new sealevel E2E invariant
