### PR TITLE
fix: tracing unit test

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -10307,6 +10307,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "uuid 1.11.0",
 ]
 

--- a/rust/main/agents/relayer/src/msg/op_batch.rs
+++ b/rust/main/agents/relayer/src/msg/op_batch.rs
@@ -253,11 +253,9 @@ mod tests {
         ));
     }
 
+    #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_handle_batch_succeeds_eventually() {
-        let _ = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::DEBUG)
-            .try_init();
         let mut mock_mailbox = MockMailboxContract::new();
         let dummy_domain: HyperlaneDomain = KnownHyperlaneDomain::Alfajores.into();
 
@@ -311,13 +309,10 @@ mod tests {
         )
     }
 
+    #[tracing_test::traced_test]
     #[tokio::test]
     #[ignore]
     async fn benchmarking_with_real_rpcs() {
-        let _ = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::DEBUG)
-            .try_init();
-
         let arb_chain_conf = ChainConf {
             domain: HyperlaneDomain::Known(hyperlane_core::KnownHyperlaneDomain::Arbitrum),
             // TODO

--- a/rust/main/submitter/Cargo.toml
+++ b/rust/main/submitter/Cargo.toml
@@ -30,5 +30,6 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 
 [dev-dependencies]
 tracing-subscriber.workspace = true
+tracing-test.workspace = true
 mockall.workspace = true
 tempfile.workspace = true

--- a/rust/main/submitter/src/payload_dispatcher/tests.rs
+++ b/rust/main/submitter/src/payload_dispatcher/tests.rs
@@ -58,12 +58,9 @@ async fn test_entrypoint_send_is_detected_by_loader() {
     );
 }
 
+#[tracing_test::traced_test]
 #[tokio::test]
 async fn test_entrypoint_send_is_finalized_by_dispatcher() {
-    let _ = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
-        .try_init();
-
     let payload = FullPayload::random();
 
     let adapter = MockAdapter::new();
@@ -103,12 +100,9 @@ async fn test_entrypoint_send_is_finalized_by_dispatcher() {
     assert_metrics(metrics, metrics_assertion);
 }
 
+#[tracing_test::traced_test]
 #[tokio::test]
 async fn test_entrypoint_send_is_dropped_by_dispatcher() {
-    let _ = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
-        .try_init();
-
     let payload = FullPayload::random();
 
     let mut adapter = MockAdapter::new();
@@ -160,12 +154,9 @@ async fn test_entrypoint_send_is_dropped_by_dispatcher() {
     assert_metrics(metrics, metrics_assertion);
 }
 
+#[tracing_test::traced_test]
 #[tokio::test]
 async fn test_entrypoint_payload_fails_simulation() {
-    let _ = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
-        .try_init();
-
     let payload = FullPayload::random();
 
     let mut adapter = MockAdapter::new();


### PR DESCRIPTION
### Description

 - remove trace subscriber and use #[traced_test] decorator

if you want to see logs, use `-- --nocapture`

### Related issues

- https://linear.app/hyperlane-xyz/issue/BACK-179/cargo-test-fails-unless-run-on-a-single-thread

### Backward compatibility

Yes