### PR TITLE
chore: Remove DEFAULT_GITHUB_REGISTRY from check-warp-deploy

### DIFF
--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -35,10 +35,9 @@ async function main() {
     WarpRouteIds.ArbitrumBaseBlastBscEthereumGnosisLiskMantleModeOptimismPolygonScrollZeroNetworkZoraMainnet,
   ];
 
-  const registries = [DEFAULT_GITHUB_REGISTRY, DEFAULT_REGISTRY_URI];
-  const warpCoreConfigMap = await getWarpConfigMapFromMergedRegistry(
-    registries,
-  );
+  const registries = [DEFAULT_REGISTRY_URI];
+  const warpCoreConfigMap =
+    await getWarpConfigMapFromMergedRegistry(registries);
 
   console.log(chalk.yellow('Skipping the following warp routes:'));
   routesToSkip.forEach((route) => console.log(chalk.yellow(`- ${route}`)));


### PR DESCRIPTION
### Description
Removing `DEFAULT_GITHUB_REGISTRY` from check-warp-deploy because we will update the cronjob to clone main instead. This reduces github api rate limiting 

### Backward compatibility
Yes

### Testing
Manual - will test by running `kubectl create job --from=cronjob/check-warp-deploy check-warp-deploy-manual-2025-04-29`
