### PR TITLE
chore: fetch latest branch in docker-entrypoint

### DIFF
--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -10,6 +10,7 @@ on:
       - 'typescript/infra/**'
       - '.registryrc'
       - 'Dockerfile'
+      - 'docker-entrypoint.sh'
       - '.dockerignore'
       - '.github/workflows/monorepo-docker.yml'
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,10 @@ set -e
 # Set default registry URI, same as Dockerfile
 REGISTRY_URI="/hyperlane-registry"
 
+echo "REGISTRY_COMMIT: $REGISTRY_COMMIT"
+echo "REGISTRY_URI: $REGISTRY_URI"
+echo "Current commit: $(git -C "$REGISTRY_URI" rev-parse HEAD)"
+
 # Only update registry if REGISTRY_COMMIT is set
 if [ -n "$REGISTRY_COMMIT" ]; then
   echo "Updating Hyperlane registry to: $REGISTRY_COMMIT"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,11 +6,17 @@ REGISTRY_URI="/hyperlane-registry"
 
 # Only update registry if REGISTRY_COMMIT is set
 if [ -n "$REGISTRY_COMMIT" ]; then
-  echo "Updating Hyperlane registry to commit: ${REGISTRY_COMMIT}"
+  echo "Updating Hyperlane registry to: $REGISTRY_COMMIT"
   OLDPWD=$(pwd)
   cd "$REGISTRY_URI"
-  git fetch origin "$REGISTRY_COMMIT"
+  git fetch origin
   git checkout "$REGISTRY_COMMIT"
+
+  # Only reset if it's a branch
+  if git show-ref --verify --quiet "refs/remotes/origin/$REGISTRY_COMMIT"; then
+    git reset --hard "origin/$REGISTRY_COMMIT"
+  fi
+
   cd "$OLDPWD"
 fi
 

--- a/typescript/infra/helm/check-warp-deploy/templates/cron-job.yaml
+++ b/typescript/infra/helm/check-warp-deploy/templates/cron-job.yaml
@@ -18,7 +18,7 @@ spec:
           - name: check-warp-deploy
             image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
             imagePullPolicy: Always
-            command:
+            args:
             - ./node_modules/.bin/tsx
             - ./typescript/infra/scripts/check/check-warp-deploy.ts
             - -e


### PR DESCRIPTION
### Description

chore: fetch latest branch in docker-entrypoint

### Drive-by changes

add docker-entrypoint as one of the conditions for running monorepo image builds

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

```
$ kubectl logs check-warp-deploy-pbio-zq7lk

REGISTRY_COMMIT: main
REGISTRY_URI: /hyperlane-registry
Current commit: 7a0a79942383dac2fca1fa5e5a0e57f5d8b2d3f2
Updating Hyperlane registry to: main
Previous HEAD position was 7a0a799 Update chain metadata and address files
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
HEAD is now at af29ded Update chain metadata and address files
```