### PR TITLE
fix: Expose operation ID as separate field on logs

### DIFF
--- a/rust/main/agents/relayer/src/msg/op_submitter.rs
+++ b/rust/main/agents/relayer/src/msg/op_submitter.rs
@@ -804,7 +804,7 @@ async fn process_confirm_result(
 ) -> PendingOperationResult {
     match &operation_result {
         PendingOperationResult::Success => {
-            debug!(?op, "Operation confirmed");
+            debug!(id=?op.id(), ?op, "Operation confirmed");
             metrics.ops_confirmed.inc();
             op.decrement_metric_if_exists();
         }


### PR DESCRIPTION
### Description

Expose operation ID as separate field on logs so that it is easier to search and the field is indexed by log consolidation tools.

### Backward compatibility

Yes

### Testing

None