### PR TITLE
feat: skip typescript tests for rust-only PRs

### DIFF
--- a/.github/actions/check-job-status/action.yml
+++ b/.github/actions/check-job-status/action.yml
@@ -1,0 +1,21 @@
+name: 'Check Job Status'
+description: 'Check the result of a job and print a message'
+inputs:
+  job_name:
+    description: 'The name of the job'
+    required: true
+  result:
+    description: 'The result of the job'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Check job status
+      shell: bash
+      run: |
+        if [[ "${{ inputs.result }}" == "skipped" ]]; then
+          echo "${{ inputs.job_name }} was skipped!"
+        elif [[ "${{ inputs.result }}" != "success" ]]; then
+          echo "${{ inputs.job_name }} failed"
+          exit 1
+        fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,6 @@ jobs:
       # Check if changes are ONLY rust
       - name: Check if changes are ONLY rust
         id: check-rust-only
-        if: github.event_name == 'push'
         run: |
           # Check for Rust changes
           if git diff ${{ needs.set-base-sha.outputs.base_sha }}..${{ needs.set-base-sha.outputs.current_sha }} --name-only | grep -qE '^rust/'; then
@@ -164,13 +163,11 @@ jobs:
       # If the push event is to main, fallback to rust_only as false.
       - name: Check if push event to main
         id: check-push-main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/main" ]; then
-            echo "only_rust=false" >> $GITHUB_OUTPUT
-            echo "Push event to main detected. Setting only_rust to false."
-          else
-            echo "Not a push event to main. Keeping only_rust as ${{ steps.check-rust-only.outputs.only_rust }}."
-          fi
+          echo "only_rust=false" >> $GITHUB_OUTPUT
+          echo "Push event to main detected. Setting only_rust to false."
+
 
   yarn-test-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,6 +224,8 @@ jobs:
 
   cli-install-test-run:
     runs-on: ubuntu-latest
+    needs: [rust-only]
+    if: needs.rust-only.outputs.only_rust == 'false'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
           # Check for Rust changes
           if git diff origin/$PR_BASE...HEAD --name-only | grep -qE '^rust/'; then
             # Check if there are only Rust changes
-            if ! git diff origin/$PR_BASE...HEAD --name-only | grep -qvE '^(rust/|\.github/)'; then
+            if ! git diff origin/$PR_BASE...HEAD --name-only | grep -qvE '^rust/'; then
               echo "only_rust=true" >> $GITHUB_OUTPUT
               echo "Only Rust changes detected."
             else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,8 +141,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [rust-only]
     timeout-minutes: 10
-    env:
-      PR_BASE: ${{ github.base_ref }}
     if: needs.rust-only.outputs.only_rust == 'false'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,27 +104,46 @@ jobs:
         run: |
           rm -f changed_files.txt
 
+  set-base-sha:
+    runs-on: ubuntu-latest
+    outputs:
+      base_sha: ${{ steps.determine-base-sha.outputs.base_sha }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Determine BASE_SHA
+        id: determine-base-sha
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "base_sha=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" == "merge_group" ]; then
+            echo "base_sha=${{ github.event.merge_group.base_sha }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" == "push" ]; then
+            echo "base_sha=$${{ github.event.push.before }}" >> $GITHUB_OUTPUT
+          else
+            echo "base_sha=$(git rev-parse HEAD^)" >> $GITHUB_OUTPUT
+          fi
+
   rust-only:
+    needs: [set-base-sha]
     outputs:
       only_rust: ${{ steps.check-rust-only.outputs.only_rust }}
     runs-on: ubuntu-latest
-    env:
-      PR_BASE: ${{ github.base_ref || 'HEAD^' }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Fetch PR base or parent commit
-        run: git fetch origin $PR_BASE
-
       - name: Check for Rust changes
         id: check-rust-only
         run: |
           # Check for Rust changes
-          if git diff origin/$PR_BASE...HEAD --name-only | grep -qE '^rust/'; then
+          if git diff ${{ needs.set-base-sha.outputs.base_sha }}..${{ github.sha }} --name-only | grep -qE '^rust/'; then
             # Check if there are only Rust changes
-            if ! git diff origin/$PR_BASE...HEAD --name-only | grep -qvE '^rust/'; then
+            if ! git diff ${{ needs.set-base-sha.outputs.base_sha }}..${{ github.sha }} --name-only | grep -qvE '^rust/'; then
               echo "only_rust=true" >> $GITHUB_OUTPUT
               echo "Only Rust changes detected."
             else
@@ -174,7 +193,7 @@ jobs:
 
   infra-test:
     runs-on: ubuntu-latest
-    needs: [yarn-install]
+    needs: [yarn-install, set-base-sha]
     env:
       GRAFANA_SERVICE_ACCOUNT_TOKEN: ${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN }}
       PR_BASE: ${{ github.base_ref }}
@@ -192,10 +211,10 @@ jobs:
 
       - name: Check for balance/config changes
         run: |
-          if git diff origin/$PR_BASE...HEAD --name-only | grep -qE '^typescript/infra/config/environments/mainnet3/balances|^.registryrc$'; then
+          if git diff ${{ needs.set-base-sha.outputs.base_sha }}..${{ github.sha }} --name-only | grep -qE '^typescript/infra/config/environments/mainnet3/balances|^.registryrc$'; then
             echo "BALANCE_CHANGES=true" >> $GITHUB_ENV
           fi
-          if git diff origin/$PR_BASE...HEAD --name-only | grep -qE '^typescript/infra/|^.registryrc$'; then
+          if git diff ${{ needs.set-base-sha.outputs.base_sha }}..${{ github.sha }} --name-only | grep -qE '^typescript/infra/|^.registryrc$'; then
             echo "WARP_CONFIG_CHANGES=true" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,13 +171,10 @@ jobs:
     if: always()
     steps:
       - name: Check yarn-test status
-        run: |
-          if [[ "${{ needs.yarn-test-run.result }}" == "skipped" ]]; then
-            echo "Yarn Test was skipped!"
-          elif [[ "${{ needs.yarn-test-run.result }}" != "success" ]]; then
-            echo "Yarn Test failed"
-            exit 1
-          fi
+        uses: ./.github/actions/check-job-status
+        with:
+          job_name: 'Yarn Test'
+          result: ${{ needs.yarn-test-run.result }}
 
   infra-test:
     runs-on: ubuntu-latest
@@ -293,13 +290,10 @@ jobs:
     if: always()
     steps:
       - name: Check cli-e2e matrix status
-        run: |
-          if [[ "${{ needs.cli-e2e-matrix.result }}" == "skipped" ]]; then
-            echo "CLI E2E Matrix was skipped!"
-          elif [[ "${{ needs.cli-e2e-matrix.result }}" != "success" ]]; then
-            echo "CLI E2E tests failed"
-            exit 1
-          fi
+        uses: ./.github/actions/check-job-status
+        with:
+          job_name: 'CLI E2E'
+          result: ${{ needs.cli-e2e-matrix.result }}
 
   cosmos-sdk-e2e:
     runs-on: ubuntu-latest
@@ -576,14 +570,10 @@ jobs:
     if: always()
     steps:
       - name: Check env-test matrix status
-        if: ${{ needs.env-test-matrix.result != 'success' }}
-        run: |
-          if [[ "${{ needs.env-test-matrix.result }}" == "skipped" ]]; then
-            echo "Env Test Matrix was skipped!"
-          elif [[ "${{ needs.env-test-matrix.result }}" != "success" ]]; then
-            echo "Env Test Matrix failed"
-            exit 1
-          fi
+        uses: ./.github/actions/check-job-status
+        with:
+          job_name: 'Env Test'
+          result: ${{ needs.env-test-matrix.result }}
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,24 +165,19 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
-  yarn-test-fallback:
-    runs-on: ubuntu-latest
-    needs: [yarn-test-run]
-    if: needs.yarn-test-run.result == 'skipped'
-    steps:
-      - name: Fallback for Yarn Test
-        run: echo "Yarn Test was skipped, running fallback."
-
   yarn-test:
     runs-on: ubuntu-latest
-    needs: [yarn-test-run, yarn-test-fallback]
+    needs: [yarn-test-run]
     if: always()
     steps:
       - name: Check yarn-test status
-        if: ${{ needs.yarn-test-run.result != 'success' }}
         run: |
-          echo "Yarn Test failed"
-          exit 1
+          if [[ "${{ needs.yarn-test-run.result }}" == "skipped" ]]; then
+            echo "Yarn Test was skipped!"
+          elif [[ "${{ needs.yarn-test-run.result }}" != "success" ]]; then
+            echo "Yarn Test failed"
+            exit 1
+          fi
 
   infra-test:
     runs-on: ubuntu-latest
@@ -292,24 +287,19 @@ jobs:
         env:
           CLI_E2E_TEST: ${{ matrix.test }}
 
-  cli-e2e-fallback:
-    runs-on: ubuntu-latest
-    needs: [cli-e2e-matrix]
-    if: needs.cli-e2e-matrix.result == 'skipped'
-    steps:
-      - name: Fallback for CLI E2E
-        run: echo "CLI E2E Matrix was skipped, running fallback."
-
   cli-e2e:
     runs-on: ubuntu-latest
-    needs: [cli-e2e-matrix, cli-e2e-fallback]
+    needs: [cli-e2e-matrix]
     if: always()
     steps:
       - name: Check cli-e2e matrix status
-        if: ${{ needs.cli-e2e-matrix.result != 'success' }}
         run: |
-          echo "CLI E2E tests failed"
-          exit 1
+          if [[ "${{ needs.cli-e2e-matrix.result }}" == "skipped" ]]; then
+            echo "CLI E2E Matrix was skipped!"
+          elif [[ "${{ needs.cli-e2e-matrix.result }}" != "success" ]]; then
+            echo "CLI E2E tests failed"
+            exit 1
+          fi
 
   cosmos-sdk-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       base_sha: ${{ steps.determine-base-sha.outputs.base_sha }}
+      current_sha: ${{ steps.determine-base-sha.outputs.current_sha }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -119,12 +120,16 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             echo "base_sha=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
+            echo "current_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" == "merge_group" ]; then
             echo "base_sha=${{ github.event.merge_group.base_sha }}" >> $GITHUB_OUTPUT
+            echo "current_sha=${{ github.event.merge_group.head_sha }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" == "push" ]; then
             echo "base_sha=$${{ github.event.push.before }}" >> $GITHUB_OUTPUT
+            echo "current_sha=${{ github.event.push.after }}" >> $GITHUB_OUTPUT
           else
             echo "base_sha=$(git rev-parse HEAD^)" >> $GITHUB_OUTPUT
+            echo "current_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           fi
 
   rust-only:
@@ -136,17 +141,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Fetch PR base
-        run: git fetch origin ${{ needs.set-base-sha.outputs.base_sha }}
+          fetch-depth: 0
 
       - name: Check for Rust changes
         id: check-rust-only
         run: |
           # Check for Rust changes
-          if git diff ${{ needs.set-base-sha.outputs.base_sha }}..${{ github.sha }} --name-only | grep -qE '^rust/'; then
+          if git diff ${{ needs.set-base-sha.outputs.base_sha }}..${{ needs.set-base-sha.outputs.current_sha }} --name-only | grep -qE '^rust/'; then
             # Check if there are only Rust changes
-            if ! git diff ${{ needs.set-base-sha.outputs.base_sha }}..${{ github.sha }} --name-only | grep -qvE '^rust/'; then
+            if ! git diff ${{ needs.set-base-sha.outputs.base_sha }}..${{ needs.set-base-sha.outputs.current_sha }} --name-only | grep -qvE '^rust/'; then
               echo "only_rust=true" >> $GITHUB_OUTPUT
               echo "Only Rust changes detected."
             else
@@ -208,15 +211,12 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Fetch base
-        run: git fetch origin ${{ needs.set-base-sha.outputs.base_sha }}
-
       - name: Check for balance/config changes
         run: |
-          if git diff ${{ needs.set-base-sha.outputs.base_sha }}..${{ github.sha }} --name-only | grep -qE '^typescript/infra/config/environments/mainnet3/balances|^.registryrc$'; then
+          if git diff ${{ needs.set-base-sha.outputs.base_sha }}..${{ needs.set-base-sha.outputs.current_sha }} --name-only | grep -qE '^typescript/infra/config/environments/mainnet3/balances|^.registryrc$'; then
             echo "BALANCE_CHANGES=true" >> $GITHUB_ENV
           fi
-          if git diff ${{ needs.set-base-sha.outputs.base_sha }}..${{ github.sha }} --name-only | grep -qE '^typescript/infra/|^.registryrc$'; then
+          if git diff ${{ needs.set-base-sha.outputs.base_sha }}..${{ needs.set-base-sha.outputs.current_sha }} --name-only | grep -qE '^typescript/infra/|^.registryrc$'; then
             echo "WARP_CONFIG_CHANGES=true" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,12 +105,11 @@ jobs:
           rm -f changed_files.txt
 
   rust-only:
-    if: github.event_name == 'pull_request'
     outputs:
       only_rust: ${{ steps.check-rust-only.outputs.only_rust }}
     runs-on: ubuntu-latest
     env:
-      PR_BASE: ${{ github.base_ref }}
+      PR_BASE: ${{ github.base_ref || 'HEAD^' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -118,7 +117,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Fetch PR base
+      - name: Fetch PR base or parent commit
         run: git fetch origin $PR_BASE
 
       - name: Check for Rust changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,12 +104,11 @@ jobs:
         run: |
           rm -f changed_files.txt
 
-  yarn-test:
+  rust-only:
+    if: github.event_name == 'pull_request'
+    outputs:
+      only_rust: ${{ steps.check-rust-only.outputs.only_rust }}
     runs-on: ubuntu-latest
-    needs: [yarn-install]
-    timeout-minutes: 10
-    env:
-      PR_BASE: ${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -117,16 +116,38 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Fetch PR base
+        run: git fetch origin $PR_BASE
+
       - name: Check for Rust changes
+        id: check-rust-only
         run: |
           # Check for Rust changes
-          if git diff $PR_BASE...HEAD --name-only | grep -qE '^rust/'; then
+          if git diff origin/$PR_BASE...HEAD --name-only | grep -qE '^rust/'; then
             # Check if there are only Rust changes
-            if ! git diff $PR_BASE...HEAD --name-only | grep -qvE '^rust/'; then
-              echo "Only Rust changes detected. Exiting."
-              exit 0
+            if ! git diff origin/$PR_BASE...HEAD --name-only | grep -qvE '^rust/'; then
+              echo "only_rust=true" >> $GITHUB_OUTPUT
+              echo "Only Rust changes detected."
+            else
+              echo "only_rust=false" >> $GITHUB_OUTPUT
             fi
+          else
+            echo "only_rust=false" >> $GITHUB_OUTPUT
           fi
+
+  yarn-test-run:
+    runs-on: ubuntu-latest
+    needs: [rust-only]
+    timeout-minutes: 10
+    env:
+      PR_BASE: ${{ github.base_ref }}
+    if: needs.rust-only.outputs.only_rust == 'false'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          submodules: recursive
+          fetch-depth: 0
 
       - name: foundry-install
         uses: foundry-rs/foundry-toolchain@v1
@@ -141,6 +162,25 @@ jobs:
 
       - name: Unit Tests
         run: yarn test:ci
+
+  yarn-test-fallback:
+    runs-on: ubuntu-latest
+    needs: [yarn-test-run]
+    if: needs.yarn-test-run.result == 'skipped'
+    steps:
+      - name: Fallback for Yarn Test
+        run: echo "Yarn Test was skipped, running fallback."
+
+  yarn-test:
+    runs-on: ubuntu-latest
+    needs: [yarn-test-run, yarn-test-fallback]
+    if: always()
+    steps:
+      - name: Check yarn-test status
+        if: ${{ needs.yarn-test-run.result != 'success' }}
+        run: |
+          echo "Yarn Test failed"
+          exit 1
 
   infra-test:
     runs-on: ubuntu-latest
@@ -163,15 +203,18 @@ jobs:
       - name: Checkout registry
         uses: ./.github/actions/checkout-registry
 
+      - name: Fetch PR base
+        run: git fetch origin $PR_BASE
+
       - name: Balance Tests
         run: |
-          if git diff $PR_BASE...HEAD --name-only | grep -qE '^typescript/infra/config/environments/mainnet3/balances|^.registryrc$'; then
+          if git diff origin/$PR_BASE...HEAD --name-only | grep -qE '^typescript/infra/config/environments/mainnet3/balances|^.registryrc$'; then
             yarn --cwd typescript/infra test:balance
           fi
 
       - name: Warp Config Tests
         run: |
-          if git diff $PR_BASE...HEAD --name-only | grep -qE '^typescript/infra/|^.registryrc$'; then
+          if git diff origin/$PR_BASE...HEAD --name-only | grep -qE '^typescript/infra/|^.registryrc$'; then
             yarn --cwd typescript/infra test:warp
           fi
 
@@ -193,6 +236,8 @@ jobs:
 
   cli-e2e-matrix:
     runs-on: ubuntu-latest
+    needs: [rust-only]
+    if: needs.rust-only.outputs.only_rust == 'false'
     strategy:
       fail-fast: false
       matrix:
@@ -245,9 +290,17 @@ jobs:
         env:
           CLI_E2E_TEST: ${{ matrix.test }}
 
+  cli-e2e-fallback:
+    runs-on: ubuntu-latest
+    needs: [cli-e2e-matrix]
+    if: needs.cli-e2e-matrix.result == 'skipped'
+    steps:
+      - name: Fallback for CLI E2E
+        run: echo "CLI E2E Matrix was skipped, running fallback."
+
   cli-e2e:
     runs-on: ubuntu-latest
-    needs: cli-e2e-matrix
+    needs: [cli-e2e-matrix, cli-e2e-fallback]
     if: always()
     steps:
       - name: Check cli-e2e matrix status

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,6 +168,8 @@ jobs:
           if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/main" ]; then
             echo "only_rust=false" >> $GITHUB_OUTPUT
             echo "Push event to main detected. Setting only_rust to false."
+          else
+            echo "Not a push event to main. Keeping only_rust as ${{ steps.check-rust-only.outputs.only_rust }}."
           fi
 
   yarn-test-run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,8 @@ jobs:
     outputs:
       only_rust: ${{ steps.check-rust-only.outputs.only_rust }}
     runs-on: ubuntu-latest
+    env:
+      PR_BASE: ${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -522,8 +522,10 @@ jobs:
           echo "E2E tests failed"
           exit 1
 
-  env-test:
+  env-test-matrix:
     runs-on: ubuntu-latest
+    needs: [rust-only]
+    if: needs.rust-only.outputs.only_rust == 'false'
     env:
       MAINNET3_ARBITRUM_RPC_URLS: ${{ secrets.MAINNET3_ARBITRUM_RPC_URLS }}
       MAINNET3_OPTIMISM_RPC_URLS: ${{ secrets.MAINNET3_OPTIMISM_RPC_URLS }}
@@ -567,6 +569,21 @@ jobs:
           command: cd typescript/infra && ./fork.sh ${{ matrix.environment }} ${{ matrix.module }} ${{ matrix.chain }}
           on_retry_command: |
             echo "Test failed, waiting before retry..."
+
+  env-test:
+    runs-on: ubuntu-latest
+    needs: env-test-matrix
+    if: always()
+    steps:
+      - name: Check env-test matrix status
+        if: ${{ needs.env-test-matrix.result != 'success' }}
+        run: |
+          if [[ "${{ needs.env-test-matrix.result }}" == "skipped" ]]; then
+            echo "Env Test Matrix was skipped!"
+          elif [[ "${{ needs.env-test-matrix.result }}" != "success" ]]; then
+            echo "Env Test Matrix failed"
+            exit 1
+          fi
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,6 @@ jobs:
           echo "only_rust=false" >> $GITHUB_OUTPUT
           echo "Push event to main detected. Setting only_rust to false."
 
-
   yarn-test-run:
     runs-on: ubuntu-latest
     needs: [rust-only]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,6 +170,7 @@ jobs:
     needs: [yarn-test-run]
     if: always()
     steps:
+      - uses: actions/checkout@v4
       - name: Check yarn-test status
         uses: ./.github/actions/check-job-status
         with:
@@ -289,6 +290,7 @@ jobs:
     needs: [cli-e2e-matrix]
     if: always()
     steps:
+      - uses: actions/checkout@v4
       - name: Check cli-e2e matrix status
         uses: ./.github/actions/check-job-status
         with:
@@ -569,6 +571,7 @@ jobs:
     needs: env-test-matrix
     if: always()
     steps:
+      - uses: actions/checkout@v4
       - name: Check env-test matrix status
         uses: ./.github/actions/check-job-status
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,7 +208,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Fetch PR base
+      - name: Fetch base
         run: git fetch origin ${{ needs.set-base-sha.outputs.base_sha }}
 
       - name: Check for balance/config changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,7 +199,6 @@ jobs:
     needs: [yarn-install, set-base-sha]
     env:
       GRAFANA_SERVICE_ACCOUNT_TOKEN: ${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN }}
-      PR_BASE: ${{ github.base_ref }}
       BALANCE_CHANGES: false
       WARP_CONFIG_CHANGES: false
     steps:
@@ -210,7 +209,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch PR base
-        run: git fetch origin $PR_BASE
+        run: git fetch origin ${{ needs.set-base-sha.outputs.base_sha }}
 
       - name: Check for balance/config changes
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,7 +222,7 @@ jobs:
         if: env.WARP_CONFIG_CHANGES == 'true'
         run: yarn --cwd typescript/infra test:warp
 
-  cli-install-test:
+  cli-install-test-run:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -237,6 +237,18 @@ jobs:
 
       - name: Test run the CLI
         run: hyperlane --version
+
+  cli-install-test:
+    runs-on: ubuntu-latest
+    needs: [cli-install-test-run]
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check cli-install-test status
+        uses: ./.github/actions/check-job-status
+        with:
+          job_name: 'CLI Install Test'
+          result: ${{ needs.cli-install-test-run.result }}
 
   cli-e2e-matrix:
     runs-on: ubuntu-latest
@@ -306,8 +318,10 @@ jobs:
           job_name: 'CLI E2E'
           result: ${{ needs.cli-e2e-matrix.result }}
 
-  cosmos-sdk-e2e:
+  cosmos-sdk-e2e-run:
     runs-on: ubuntu-latest
+    needs: [rust-only]
+    if: needs.rust-only.outputs.only_rust == 'false'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -322,6 +336,18 @@ jobs:
 
       - name: Cosmos SDK e2e tests
         run: yarn --cwd typescript/cosmos-sdk test:e2e
+
+  cosmos-sdk-e2e:
+    runs-on: ubuntu-latest
+    needs: [cosmos-sdk-e2e-run]
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check cosmos-sdk-e2e status
+        uses: ./.github/actions/check-job-status
+        with:
+          job_name: 'Cosmos SDK E2E'
+          result: ${{ needs.cosmos-sdk-e2e-run.result }}
 
   agent-configs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -615,8 +615,10 @@ jobs:
           job_name: 'Env Test'
           result: ${{ needs.env-test-matrix.result }}
 
-  coverage:
+  coverage-run:
     runs-on: ubuntu-latest
+    needs: [rust-only]
+    if: needs.rust-only.outputs.only_rust == 'false'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -640,3 +642,15 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: [coverage-run]
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check coverage status
+        uses: ./.github/actions/check-job-status
+        with:
+          job_name: 'Coverage'
+          result: ${{ needs.coverage-run.result }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,8 +143,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
-      - name: Check for Rust changes
+      # Check if changes are ONLY rust
+      - name: Check if changes are ONLY rust
         id: check-rust-only
+        if: github.event_name == 'push'
         run: |
           # Check for Rust changes
           if git diff ${{ needs.set-base-sha.outputs.base_sha }}..${{ needs.set-base-sha.outputs.current_sha }} --name-only | grep -qE '^rust/'; then
@@ -157,6 +159,15 @@ jobs:
             fi
           else
             echo "only_rust=false" >> $GITHUB_OUTPUT
+          fi
+
+      # If the push event is to main, fallback to rust_only as false.
+      - name: Check if push event to main
+        id: check-push-main
+        run: |
+          if [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/main" ]; then
+            echo "only_rust=false" >> $GITHUB_OUTPUT
+            echo "Push event to main detected. Setting only_rust to false."
           fi
 
   yarn-test-run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,6 +183,8 @@ jobs:
     env:
       GRAFANA_SERVICE_ACCOUNT_TOKEN: ${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN }}
       PR_BASE: ${{ github.base_ref }}
+      BALANCE_CHANGES: false
+      WARP_CONFIG_CHANGES: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -190,28 +192,35 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Fetch PR base
+        run: git fetch origin $PR_BASE
+
+      - name: Check for balance/config changes
+        run: |
+          if git diff origin/$PR_BASE...HEAD --name-only | grep -qE '^typescript/infra/config/environments/mainnet3/balances|^.registryrc$'; then
+            echo "BALANCE_CHANGES=true" >> $GITHUB_ENV
+          fi
+          if git diff origin/$PR_BASE...HEAD --name-only | grep -qE '^typescript/infra/|^.registryrc$'; then
+            echo "WARP_CONFIG_CHANGES=true" >> $GITHUB_ENV
+          fi
+
       - name: yarn-build
         uses: ./.github/actions/yarn-build-with-cache
+        if: env.BALANCE_CHANGES == 'true' || env.WARP_CONFIG_CHANGES == 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Checkout registry
+        if: env.BALANCE_CHANGES == 'true' || env.WARP_CONFIG_CHANGES == 'true'
         uses: ./.github/actions/checkout-registry
 
-      - name: Fetch PR base
-        run: git fetch origin $PR_BASE
-
       - name: Balance Tests
-        run: |
-          if git diff origin/$PR_BASE...HEAD --name-only | grep -qE '^typescript/infra/config/environments/mainnet3/balances|^.registryrc$'; then
-            yarn --cwd typescript/infra test:balance
-          fi
+        if: env.BALANCE_CHANGES == 'true'
+        run: yarn --cwd typescript/infra test:balance
 
       - name: Warp Config Tests
-        run: |
-          if git diff origin/$PR_BASE...HEAD --name-only | grep -qE '^typescript/infra/|^.registryrc$'; then
-            yarn --cwd typescript/infra test:warp
-          fi
+        if: env.WARP_CONFIG_CHANGES == 'true'
+        run: yarn --cwd typescript/infra test:warp
 
   cli-install-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,12 +108,25 @@ jobs:
     runs-on: ubuntu-latest
     needs: [yarn-install]
     timeout-minutes: 10
+    env:
+      PR_BASE: ${{ github.base_ref }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
           fetch-depth: 0
+
+      - name: Check for Rust changes
+        run: |
+          # Check for Rust changes
+          if git diff $PR_BASE...HEAD --name-only | grep -qE '^rust/'; then
+            # Check if there are only Rust changes
+            if ! git diff $PR_BASE...HEAD --name-only | grep -qvE '^rust/'; then
+              echo "Only Rust changes detected. Exiting."
+              exit 0
+            fi
+          fi
 
       - name: foundry-install
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,8 +114,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          submodules: recursive
-          fetch-depth: 0
 
       - name: Fetch PR base or parent commit
         run: git fetch origin $PR_BASE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
           # Check for Rust changes
           if git diff origin/$PR_BASE...HEAD --name-only | grep -qE '^rust/'; then
             # Check if there are only Rust changes
-            if ! git diff origin/$PR_BASE...HEAD --name-only | grep -qvE '^rust/'; then
+            if ! git diff origin/$PR_BASE...HEAD --name-only | grep -qvE '^(rust/|\.github/)'; then
               echo "only_rust=true" >> $GITHUB_OUTPUT
               echo "Only Rust changes detected."
             else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
+      - name: Fetch PR base
+        run: git fetch origin ${{ needs.set-base-sha.outputs.base_sha }}
+
       - name: Check for Rust changes
         id: check-rust-only
         run: |

--- a/rust/main/config/testnet_config.json
+++ b/rust/main/config/testnet_config.json
@@ -269,8 +269,7 @@
       "staticMessageIdWeightedMultisigIsmFactory": "0xaa80d23299861b7D7ab1bE665579029Ed9137BD1",
       "gasCurrencyCoinGeckoId": "binancecoin",
       "transactionOverrides": {
-        "gasPrice": 1000000000,
-        "diffTest": true
+        "gasPrice": 1000000000
       }
     },
     "connextsepolia": {

--- a/rust/main/config/testnet_config.json
+++ b/rust/main/config/testnet_config.json
@@ -269,7 +269,8 @@
       "staticMessageIdWeightedMultisigIsmFactory": "0xaa80d23299861b7D7ab1bE665579029Ed9137BD1",
       "gasCurrencyCoinGeckoId": "binancecoin",
       "transactionOverrides": {
-        "gasPrice": 1000000000
+        "gasPrice": 1000000000,
+        "diffTest": true
       }
     },
     "connextsepolia": {


### PR DESCRIPTION
### Description

feat: skip typescript tests for rust-only PRs
- detect if the PR has _only_ rust changes
- if only rust changes, skip:
	- yarn-test
	- cli-install-test
	- cli-e2e matrix
	- cosmos-sdk-e2e
	- coverage
	- env-test matrix

context:
https://hyperlaneworkspace.slack.com/archives/C08H0T2FL2V/p1746007815024329

A second order benefit is the reduction in `ubuntu-latest` usage, which will hopefully reduce the waiting times for these runners in general

### Drive-by changes

fix the current infra test diffing

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/14753714224?pr=6084

![image](https://github.com/user-attachments/assets/85c2fff3-1c8e-4d9c-adb8-8846937eb475)


![image](https://github.com/user-attachments/assets/c01f9c24-2ae7-4df0-a7dd-948bdb6e7ee4)

