### PR TITLE
fix: foundry error messages after foundry@1.1.0 upgrade

### DIFF
--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.foundry-test.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.foundry-test.ts
@@ -157,7 +157,7 @@ describe('SmartProvider', async () => {
       await token.transfer(constants.AddressZero, 1000000);
     } catch (e: any) {
       expect(e.error.message).to.equal(
-        'execution reverted: revert: ERC20: transfer to the zero address',
+        'execution reverted: ERC20: transfer to the zero address',
       );
     }
   });
@@ -174,7 +174,7 @@ describe('SmartProvider', async () => {
       await token.transfer(signer.address, 1000000);
     } catch (e: any) {
       expect(e.error.message).to.equal(
-        'execution reverted: revert: ERC20: transfer amount exceeds balance',
+        'execution reverted: ERC20: transfer amount exceeds balance',
       );
     }
   });


### PR DESCRIPTION
### Description

We change the ERC20 errors messages coming back from foundry tests. The difference is caused by foundry@1.1.0 release.

### Backward compatibility

No, as this only works with foundry@1.1.0.