### PR TITLE
feat: optimize `InterchainAccountRouter.handle` proxy deployment

### DIFF
--- a/.changeset/short-suns-shop.md
+++ b/.changeset/short-suns-shop.md
@@ -5,4 +5,10 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-Remove accountOwners from InterchainAccountRouter
+Remove `accountOwners` from `InterchainAccountRouter`
+
+This reverse mapping was intended to index from a given proxy account what the corresponding derivation inputs were.
+
+However, this implied 2 cold SSTORE instructions per account creation.
+
+Instead, the `InterchainAccountCreated` event can be used which now has an `indexed` account key to filter by.

--- a/.changeset/short-suns-shop.md
+++ b/.changeset/short-suns-shop.md
@@ -1,0 +1,8 @@
+---
+'@hyperlane-xyz/core': major
+'@hyperlane-xyz/helloworld': patch
+'@hyperlane-xyz/infra': patch
+'@hyperlane-xyz/sdk': patch
+---
+
+Remove accountOwners from InterchainAccountRouter

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -74,16 +74,18 @@ contract InterchainAccountRouter is Router {
 
     /**
      * @notice Emitted when an interchain account contract is deployed
+     * @param account The address of the proxy account that was created
      * @param origin The domain of the chain where the message was sent from
      * @param owner The address of the account that sent the message
      * @param ism The address of the local ISM
-     * @param account The address of the proxy account that was created
+     * @param salt The salt used to derive the interchain account
      */
     event InterchainAccountCreated(
-        uint32 indexed origin,
-        bytes32 indexed owner,
+        address indexed account,
+        uint32 origin,
+        bytes32 owner,
         address ism,
-        address account
+        bytes32 salt
     );
 
     // ============ Constructor ============
@@ -432,7 +434,13 @@ contract InterchainAccountRouter is Router {
         if (!Address.isContract(_account)) {
             bytes memory _bytecode = MinimalProxy.bytecode(implementation);
             _account = payable(Create2.deploy(0, _deploySalt, _bytecode));
-            emit InterchainAccountCreated(_origin, _owner, _ism, _account);
+            emit InterchainAccountCreated(
+                _account,
+                _origin,
+                _owner,
+                _ism,
+                _userSalt
+            );
         }
         return OwnableMulticall(_account);
     }

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -76,6 +76,7 @@ contract InterchainAccountRouter is Router {
      * @notice Emitted when an interchain account contract is deployed
      * @param account The address of the proxy account that was created
      * @param origin The domain of the chain where the message was sent from
+     * @param router The router on the origin domain
      * @param owner The address of the account that sent the message
      * @param ism The address of the local ISM
      * @param salt The salt used to derive the interchain account
@@ -83,6 +84,7 @@ contract InterchainAccountRouter is Router {
     event InterchainAccountCreated(
         address indexed account,
         uint32 origin,
+        bytes32 router,
         bytes32 owner,
         address ism,
         bytes32 salt
@@ -437,6 +439,7 @@ contract InterchainAccountRouter is Router {
             emit InterchainAccountCreated(
                 _account,
                 _origin,
+                _router,
                 _owner,
                 _ism,
                 _userSalt

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -37,11 +37,6 @@ contract InterchainAccountRouter is Router {
     using TypeCasts for address;
     using TypeCasts for bytes32;
 
-    struct AccountOwner {
-        uint32 origin;
-        bytes32 owner; // remote owner
-    }
-
     // ============ Constants ============
 
     address internal implementation;
@@ -49,8 +44,6 @@ contract InterchainAccountRouter is Router {
 
     // ============ Public Storage ============
     mapping(uint32 => bytes32) public isms;
-    // reverse lookup from the ICA account to the remote owner
-    mapping(address => AccountOwner) public accountOwners;
 
     // ============ Upgrade Gap ============
 
@@ -458,7 +451,6 @@ contract InterchainAccountRouter is Router {
         if (!Address.isContract(_account)) {
             bytes memory _bytecode = MinimalProxy.bytecode(implementation);
             _account = payable(Create2.deploy(0, _deploySalt, _bytecode));
-            accountOwners[_account] = AccountOwner(_origin, _owner);
             emit InterchainAccountCreated(_origin, _owner, _ism, _account);
         }
         return OwnableMulticall(_account);

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -87,27 +87,15 @@ contract InterchainAccountRouter is Router {
     );
 
     // ============ Constructor ============
-
-    constructor(address _mailbox) Router(_mailbox) {}
-
-    // ============ Initializers ============
-
-    /**
-     * @notice Initializes the contract with HyperlaneConnectionClient contracts
-     * @param _customHook used by the Router to set the hook to override with
-     * @param _interchainSecurityModule The address of the local ISM contract
-     * @param _owner The address with owner privileges
-     */
-    function initialize(
-        address _customHook,
+    constructor(
+        address _mailbox,
+        address _hook,
         address _interchainSecurityModule,
         address _owner
-    ) external initializer {
-        _MailboxClient_initialize(
-            _customHook,
-            _interchainSecurityModule,
-            _owner
-        );
+    ) Router(_mailbox) {
+        setHook(_hook);
+        setInterchainSecurityModule(_interchainSecurityModule);
+        _transferOwnership(_owner);
 
         bytes memory bytecode = _implementationBytecode(address(this));
         implementation = Create2.deploy(0, bytes32(0), bytecode);
@@ -149,12 +137,6 @@ contract InterchainAccountRouter is Router {
         for (uint256 i = 0; i < _destinations.length; i++) {
             _enrollRemoteRouterAndIsm(_destinations[i], _routers[i], _isms[i]);
         }
-    }
-
-    function setHook(
-        address _hook
-    ) public override onlyContractOrNull(_hook) onlyOwner {
-        hook = IPostDispatchHook(_hook);
     }
 
     // ============ External Functions ============

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -70,28 +70,19 @@ contract InterchainAccountRouterTestBase is Test {
 
     Callable internal target;
 
-    function deployProxiedIcaRouter(
+    function deployIcaRouter(
         MockMailbox _mailbox,
         IPostDispatchHook _customHook,
         IInterchainSecurityModule _ism,
         address _owner
     ) public returns (InterchainAccountRouter) {
-        InterchainAccountRouter implementation = new InterchainAccountRouter(
-            address(_mailbox)
-        );
-
-        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
-            address(implementation),
-            address(1), // no proxy owner necessary for testing
-            abi.encodeWithSelector(
-                InterchainAccountRouter.initialize.selector,
+        return
+            new InterchainAccountRouter(
+                address(_mailbox),
                 address(_customHook),
                 address(_ism),
                 _owner
-            )
-        );
-
-        return InterchainAccountRouter(address(proxy));
+            );
     }
 
     function setUp() public virtual {
@@ -108,14 +99,14 @@ contract InterchainAccountRouterTestBase is Test {
         );
 
         address owner = address(this);
-        originIcaRouter = deployProxiedIcaRouter(
+        originIcaRouter = deployIcaRouter(
             environment.mailboxes(origin),
             environment.igps(origin),
             icaIsm,
             owner
         );
 
-        destinationIcaRouter = deployProxiedIcaRouter(
+        destinationIcaRouter = deployIcaRouter(
             environment.mailboxes(destination),
             environment.igps(destination),
             icaIsm,
@@ -381,7 +372,7 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
     function test_quoteDispatch_differentHook() public {
         // arrange
         TestPostDispatchHook testHook = new TestPostDispatchHook();
-        originIcaRouter = deployProxiedIcaRouter(
+        originIcaRouter = deployIcaRouter(
             environment.mailboxes(origin),
             testHook,
             icaIsm,
@@ -454,7 +445,7 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
     ) public {
         // arrange
         TestPostDispatchHook testHook = new TestPostDispatchHook();
-        originIcaRouter = deployProxiedIcaRouter(
+        originIcaRouter = deployIcaRouter(
             environment.mailboxes(origin),
             testHook,
             icaIsm,
@@ -631,7 +622,7 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
     ) public {
         TestPostDispatchHook testHook = new TestPostDispatchHook();
 
-        originIcaRouter = deployProxiedIcaRouter(
+        originIcaRouter = deployIcaRouter(
             environment.mailboxes(origin),
             testHook,
             icaIsm,
@@ -842,7 +833,7 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
         TestPostDispatchHook testHook = new TestPostDispatchHook();
         TestPostDispatchHook customHook = new TestPostDispatchHook();
 
-        originIcaRouter = deployProxiedIcaRouter(
+        originIcaRouter = deployIcaRouter(
             environment.mailboxes(origin),
             testHook,
             icaIsm,

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -347,24 +347,6 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
         assertEq(address(igp).balance, expectedGasPayment);
     }
 
-    function testFuzz_getDeployedInterchainAccount_checkAccountOwners(
-        address owner
-    ) public {
-        // act
-        ica = destinationIcaRouter.getDeployedInterchainAccount(
-            origin,
-            owner,
-            address(originIcaRouter),
-            address(environment.isms(destination))
-        );
-
-        (uint32 domain, bytes32 ownerBytes) = destinationIcaRouter
-            .accountOwners(address(ica));
-        // assert
-        assertEq(domain, origin);
-        assertEq(ownerBytes, owner.addressToBytes32());
-    }
-
     function test_quoteGasPayment() public {
         // arrange
         originIcaRouter.enrollRemoteRouterAndIsm(

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -48,6 +48,7 @@ contract InterchainAccountRouterTestBase is Test {
     event InterchainAccountCreated(
         address indexed account,
         uint32 origin,
+        bytes32 router,
         bytes32 owner,
         address ism,
         bytes32 salt
@@ -318,6 +319,7 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
         emit InterchainAccountCreated(
             address(ica),
             origin,
+            address(originIcaRouter).addressToBytes32(),
             address(this).addressToBytes32(),
             TypeCasts.bytes32ToAddress(ismOverride),
             bytes32(0)

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -46,10 +46,11 @@ contract InterchainAccountRouterTestBase is Test {
     using TypeCasts for address;
 
     event InterchainAccountCreated(
-        uint32 indexed origin,
-        bytes32 indexed owner,
+        address indexed account,
+        uint32 origin,
+        bytes32 owner,
         address ism,
-        address account
+        bytes32 salt
     );
 
     MockHyperlaneEnvironment internal environment;
@@ -315,10 +316,11 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
 
         vm.expectEmit(true, true, false, true, address(destinationIcaRouter));
         emit InterchainAccountCreated(
+            address(ica),
             origin,
             address(this).addressToBytes32(),
             TypeCasts.bytes32ToAddress(ismOverride),
-            address(ica)
+            bytes32(0)
         );
 
         vm.deal(address(this), value);

--- a/typescript/infra/config/environments/mainnet3/owners.ts
+++ b/typescript/infra/config/environments/mainnet3/owners.ts
@@ -1,7 +1,5 @@
-import { AddressesMap, ChainMap, OwnableConfig } from '@hyperlane-xyz/sdk';
-import { Address, objFilter, objMap } from '@hyperlane-xyz/utils';
-
-import { getMainnetAddresses } from '../../registry.js';
+import { ChainMap, OwnableConfig } from '@hyperlane-xyz/sdk';
+import { Address } from '@hyperlane-xyz/utils';
 
 import { ethereumChainNames } from './chains.js';
 import { supportedChainNames } from './supportedChainNames.js';
@@ -14,19 +12,6 @@ export const timelocks: ChainMap<Address> = {
   ...upgradeTimelocks,
   ethereum: '0x59cf937Ea9FA9D7398223E3aA33d92F7f5f986A2', // symbiotic network timelock
 };
-
-export function localAccountRouters(): ChainMap<Address> {
-  const coreAddresses: ChainMap<AddressesMap> = getMainnetAddresses();
-  const filteredAddresses = objFilter(
-    coreAddresses,
-    (_, addressMap): addressMap is AddressesMap =>
-      addressMap.interchainAccountRouter !== undefined,
-  );
-  return objMap(
-    filteredAddresses,
-    (_, addressMap) => addressMap.interchainAccountRouter,
-  );
-}
 
 export const safes: ChainMap<Address> = {
   mantapacific: '0x03ed2D65f2742193CeD99D48EbF1F1D6F12345B6', // does not have a UI

--- a/typescript/infra/src/govern/HyperlaneAppGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneAppGovernor.ts
@@ -366,7 +366,16 @@ export abstract class HyperlaneAppGovernor<
       };
     }
 
-    if (account.address !== icas[chain as keyof typeof icas]) {
+    let accountConfig = this.interchainAccount.knownAccounts[account.address];
+    if (account.address === icas[chain as keyof typeof icas]) {
+      const origin = 'ethereum';
+      accountConfig = {
+        origin,
+        owner: safes[origin],
+      };
+    }
+
+    if (!accountConfig) {
       console.info(
         chalk.gray(
           `Account ${account.address} is not a known ICA. Defaulting to manual submission.`,
@@ -379,11 +388,8 @@ export abstract class HyperlaneAppGovernor<
       };
     }
 
-    const origin = 'ethereum';
-    const accountConfig = {
-      origin,
-      owner: safes[origin],
-    };
+    // WARNING: origin is a reserved word in TypeScript
+    const origin = accountConfig.origin;
 
     console.info(
       chalk.gray(

--- a/typescript/infra/src/govern/HyperlaneAppGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneAppGovernor.ts
@@ -440,7 +440,7 @@ export abstract class HyperlaneAppGovernor<
         // Require the submitter to be the owner of the ICA on the origin chain.
         return (
           chain === origin &&
-          eqAddress(bytes32ToAddress(accountConfig.owner), submitterAddress)
+          eqAddress(bytes32ToAddress(accountConfig!.owner), submitterAddress)
         );
       },
       true, // Flag this as an ICA call

--- a/typescript/infra/src/govern/HyperlaneICAChecker.ts
+++ b/typescript/infra/src/govern/HyperlaneICAChecker.ts
@@ -57,7 +57,10 @@ export class HyperlaneICAChecker extends InterchainAccountChecker {
   async checkChain(chain: ChainName): Promise<void> {
     await this.checkMailboxClient(chain);
     await this.checkEthRouterEnrollment(chain);
-    await this.checkProxiedContracts(chain);
-    await this.checkOwnership(chain);
+    await super.checkOwnership(
+      chain,
+      this.configMap[chain].owner,
+      this.configMap[chain].ownerOverrides,
+    );
   }
 }

--- a/typescript/sdk/src/core/EvmCoreModule.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.ts
@@ -1,5 +1,3 @@
-import { ethers } from 'ethers';
-
 import {
   Mailbox,
   Mailbox__factory,
@@ -83,10 +81,6 @@ export class EvmCoreModule extends HyperlaneModule<
         addresses: {
           interchainAccountIsm: args.addresses.interchainAccountIsm,
           interchainAccountRouter: args.addresses.interchainAccountRouter,
-          // TODO: fix this even though is not used at the moment internally
-          proxyAdmin: ethers.constants.AddressZero,
-          timelockController:
-            args.addresses.timelockController ?? ethers.constants.AddressZero,
         },
         config: args.config.interchainAccountRouter,
       });

--- a/typescript/sdk/src/core/EvmIcaModule.ts
+++ b/typescript/sdk/src/core/EvmIcaModule.ts
@@ -13,7 +13,6 @@ import {
 
 import { serializeContracts } from '../contracts/contracts.js';
 import { HyperlaneAddresses } from '../contracts/types.js';
-import { proxyAdminUpdateTxs } from '../deploy/proxy.js';
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
 import { EvmIcaRouterReader } from '../ica/EvmIcaReader.js';
 import { DerivedIcaRouterConfig } from '../ica/types.js';
@@ -73,12 +72,6 @@ export class EvmIcaModule extends HyperlaneModule<
         actualConfig.remoteIcaRouters,
         expectedConfig.remoteIcaRouters,
       )),
-      ...proxyAdminUpdateTxs(
-        this.chainId,
-        this.args.addresses.interchainAccountIsm,
-        actualConfig,
-        expectedConfig,
-      ),
     ];
 
     return transactions;

--- a/typescript/sdk/src/ica/EvmIcaReader.hardhat-test.ts
+++ b/typescript/sdk/src/ica/EvmIcaReader.hardhat-test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import hre from 'hardhat';
 
-import { Address, isAddressEvm } from '@hyperlane-xyz/utils';
+import { Address } from '@hyperlane-xyz/utils';
 
 import { TestChainName } from '../consts/testChains.js';
 import { EvmCoreModule } from '../core/EvmCoreModule.js';
@@ -46,10 +46,6 @@ describe(EvmIcaRouterReader.name, async () => {
 
       expect(res.address).to.equal(interchainAccountRouterAddress);
       expect(res.owner).to.equal(signerAddress);
-      // Proxy admin checks
-      expect(res.proxyAdmin.address).to.exist;
-      expect(isAddressEvm(res.proxyAdmin.address)).to.be.true;
-      expect(res.proxyAdmin.owner).to.equal(signerAddress);
       // Remote ICA Routers
       expect(res.remoteIcaRouters).to.exist;
     });

--- a/typescript/sdk/src/ica/EvmIcaReader.ts
+++ b/typescript/sdk/src/ica/EvmIcaReader.ts
@@ -3,11 +3,8 @@ import { providers } from 'ethers';
 import {
   InterchainAccountRouter,
   InterchainAccountRouter__factory,
-  Ownable__factory,
 } from '@hyperlane-xyz/core';
 import { Address, Domain, isZeroishAddress } from '@hyperlane-xyz/utils';
-
-import { proxyAdmin } from '../deploy/proxy.js';
 
 import {
   DerivedIcaRouterConfig,
@@ -23,14 +20,8 @@ export class EvmIcaRouterReader {
       this.provider,
     );
     const owner = await icaRouterInstance.owner();
-    const proxyAddress = await proxyAdmin(this.provider, address);
 
-    const proxyAdminInstance = Ownable__factory.connect(
-      proxyAddress,
-      this.provider,
-    );
-    const [proxyAdminOwner, knownDomains, mailboxAddress] = await Promise.all([
-      proxyAdminInstance.owner(),
+    const [knownDomains, mailboxAddress] = await Promise.all([
       icaRouterInstance.domains(),
       icaRouterInstance.mailbox(),
     ]);
@@ -44,10 +35,6 @@ export class EvmIcaRouterReader {
       owner,
       address,
       mailbox: mailboxAddress,
-      proxyAdmin: {
-        address: proxyAddress,
-        owner: proxyAdminOwner,
-      },
       remoteIcaRouters: remoteRouters,
     };
 

--- a/typescript/sdk/src/ica/types.ts
+++ b/typescript/sdk/src/ica/types.ts
@@ -18,10 +18,6 @@ export const RemoteIcaRouterConfigSchema = z.record(
 export const IcaRouterConfigSchema = z.object({
   owner: ZHash,
   mailbox: ZHash,
-  proxyAdmin: z.object({
-    address: ZHash.optional(),
-    owner: ZHash,
-  }),
   remoteIcaRouters: RemoteIcaRouterConfigSchema.optional(),
 });
 

--- a/typescript/sdk/src/ica/types.ts
+++ b/typescript/sdk/src/ica/types.ts
@@ -32,7 +32,6 @@ export const DerivedIcaRouterConfigSchema = DerivedOwnableSchema.merge(
     .object({
       owner: ZHash,
       mailbox: ZHash,
-      proxyAdmin: DerivedOwnableSchema,
       remoteIcaRouters: RemoteIcaRouterConfigSchema,
     })
     .strict(),

--- a/typescript/sdk/src/middleware/account/InterchainAccount.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.ts
@@ -26,11 +26,14 @@ import {
 import { AccountConfig, GetCallRemoteSettings } from './types.js';
 
 export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
+  knownAccounts: Record<Address, AccountConfig | undefined>;
+
   constructor(
     contractsMap: HyperlaneContractsMap<InterchainAccountFactories>,
     multiProvider: MultiProvider,
   ) {
     super(contractsMap, multiProvider);
+    this.knownAccounts = {};
   }
 
   override async remoteChains(chainName: string): Promise<ChainName[]> {
@@ -161,6 +164,9 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
         `Interchain account recovered at ${destinationAccount}`,
       );
     }
+
+    this.knownAccounts[destinationAccount] = config;
+
     return destinationAccount;
   }
 

--- a/typescript/sdk/src/middleware/account/InterchainAccount.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.ts
@@ -199,21 +199,6 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
     return callEncoded;
   }
 
-  async getAccountConfig(
-    chain: ChainName,
-    account: Address,
-  ): Promise<AccountConfig> {
-    const accountOwner = await this.router(
-      this.contractsMap[chain],
-    ).accountOwners(account);
-    const originChain = this.multiProvider.getChainName(accountOwner.origin);
-    return {
-      origin: originChain,
-      owner: accountOwner.owner,
-      localRouter: this.router(this.contractsMap[chain]).address,
-    };
-  }
-
   // general helper for different overloaded callRemote functions
   // can override the gasLimit by StandardHookMetadata.overrideGasLimit for optional hookMetadata here
   async callRemote({

--- a/typescript/sdk/src/middleware/account/InterchainAccountChecker.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccountChecker.ts
@@ -1,14 +1,14 @@
 import { objMap } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../../providers/MultiProvider.js';
-import { ProxiedRouterChecker } from '../../router/ProxiedRouterChecker.js';
+import { HyperlaneRouterChecker } from '../../router/HyperlaneRouterChecker.js';
 import { ChainMap } from '../../types.js';
 
 import { InterchainAccount } from './InterchainAccount.js';
 import { InterchainAccountConfig } from './InterchainAccountDeployer.js';
 import { InterchainAccountFactories } from './contracts.js';
 
-export class InterchainAccountChecker extends ProxiedRouterChecker<
+export class InterchainAccountChecker extends HyperlaneRouterChecker<
   InterchainAccountFactories,
   InterchainAccount,
   InterchainAccountConfig

--- a/typescript/sdk/src/middleware/account/InterchainAccountDeployer.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccountDeployer.ts
@@ -1,13 +1,12 @@
 import { ethers } from 'ethers';
 
 import { Router } from '@hyperlane-xyz/core';
-import { assert } from '@hyperlane-xyz/utils';
 
 import { HyperlaneContracts } from '../../contracts/types.js';
 import { ContractVerifier } from '../../deploy/verify/ContractVerifier.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
-import { ProxiedRouterDeployer } from '../../router/ProxiedRouterDeployer.js';
-import { ProxiedRouterConfig, RouterConfig } from '../../router/types.js';
+import { HyperlaneRouterDeployer } from '../../router/HyperlaneRouterDeployer.js';
+import { RouterConfig } from '../../router/types.js';
 import { ChainName } from '../../types.js';
 
 import {
@@ -15,9 +14,9 @@ import {
   interchainAccountFactories,
 } from './contracts.js';
 
-export type InterchainAccountConfig = ProxiedRouterConfig;
+export type InterchainAccountConfig = RouterConfig;
 
-export class InterchainAccountDeployer extends ProxiedRouterDeployer<
+export class InterchainAccountDeployer extends HyperlaneRouterDeployer<
   InterchainAccountConfig,
   InterchainAccountFactories
 > {
@@ -31,39 +30,9 @@ export class InterchainAccountDeployer extends ProxiedRouterDeployer<
       concurrentDeploy,
     });
   }
-  routerContractName(): string {
-    return 'interchainAccountRouter';
-  }
-
-  routerContractKey<K extends keyof InterchainAccountFactories>(): K {
-    return 'interchainAccountRouter' as K;
-  }
 
   router(contracts: HyperlaneContracts<InterchainAccountFactories>): Router {
     return contracts.interchainAccountRouter;
-  }
-
-  async constructorArgs<K extends keyof InterchainAccountFactories>(
-    _: string,
-    config: RouterConfig,
-  ): Promise<Parameters<InterchainAccountFactories[K]['deploy']>> {
-    return [config.mailbox] as any;
-  }
-
-  async initializeArgs(chain: string, config: RouterConfig): Promise<any> {
-    const owner = await this.multiProvider.getSignerAddress(chain);
-    if (config.interchainSecurityModule) {
-      assert(
-        typeof config.interchainSecurityModule === 'string',
-        'ISM objects not supported in ICA deployer',
-      );
-    }
-
-    return [
-      config.hook ?? ethers.constants.AddressZero,
-      config.interchainSecurityModule!,
-      owner,
-    ];
   }
 
   async deployContracts(
@@ -79,14 +48,21 @@ export class InterchainAccountDeployer extends ProxiedRouterDeployer<
       'interchainAccountIsm',
       [config.mailbox],
     );
-    const modifiedConfig = {
-      ...config,
-      interchainSecurityModule: interchainAccountIsm.address,
-    };
-    const contracts = await super.deployContracts(chain, modifiedConfig);
+
+    const owner = await this.multiProvider.getSignerAddress(chain);
+    const interchainAccountRouter = await this.deployContract(
+      chain,
+      'interchainAccountRouter',
+      [
+        config.mailbox,
+        ethers.constants.AddressZero,
+        interchainAccountIsm.address,
+        owner,
+      ],
+    );
 
     return {
-      ...contracts,
+      interchainAccountRouter,
       interchainAccountIsm,
     };
   }

--- a/typescript/sdk/src/middleware/account/contracts.ts
+++ b/typescript/sdk/src/middleware/account/contracts.ts
@@ -3,12 +3,9 @@ import {
   InterchainAccountRouter__factory,
 } from '@hyperlane-xyz/core';
 
-import { proxiedFactories } from '../../router/types.js';
-
 export const interchainAccountFactories = {
   interchainAccountRouter: new InterchainAccountRouter__factory(),
   interchainAccountIsm: new InterchainAccountIsm__factory(),
-  ...proxiedFactories,
 };
 
 export type InterchainAccountFactories = typeof interchainAccountFactories;


### PR DESCRIPTION
### Description

- Remove account owners reverse mapping
- Update` InterchainAccountCreated` event for reverse mapping purpose
- Use CREATE2 for constructor implementation deploy
- Do not proxy ICA routers

### Backward compatibility

No

### Testing

Unit Tests
