### PR TITLE
fix: Add initializer for MovableCollateralRouter

### DIFF
--- a/solidity/contracts/token/HypERC20Collateral.sol
+++ b/solidity/contracts/token/HypERC20Collateral.sol
@@ -100,24 +100,4 @@ contract HypERC20Collateral is FungibleTokenRouter, MovableCollateralRouter {
             bridge: bridge
         });
     }
-
-    function _msgData()
-        internal
-        view
-        virtual
-        override(Context, ContextUpgradeable)
-        returns (bytes calldata)
-    {
-        return ContextUpgradeable._msgData();
-    }
-
-    function _msgSender()
-        internal
-        view
-        virtual
-        override(Context, ContextUpgradeable)
-        returns (address)
-    {
-        return ContextUpgradeable._msgSender();
-    }
 }

--- a/solidity/contracts/token/HypERC20Collateral.sol
+++ b/solidity/contracts/token/HypERC20Collateral.sol
@@ -52,8 +52,9 @@ contract HypERC20Collateral is FungibleTokenRouter, MovableCollateralRouter {
         address _hook,
         address _interchainSecurityModule,
         address _owner
-    ) public virtual initializer {
+    ) public virtual reinitializer(2) {
         _MailboxClient_initialize(_hook, _interchainSecurityModule, _owner);
+        _MovableCollateralRouter_initialize(_owner);
     }
 
     function balanceOf(

--- a/solidity/contracts/token/extensions/FastHypERC20Collateral.sol
+++ b/solidity/contracts/token/extensions/FastHypERC20Collateral.sol
@@ -59,24 +59,4 @@ contract FastHypERC20Collateral is FastTokenRouter, HypERC20Collateral {
     ) internal override {
         wrappedToken.safeTransferFrom(_sender, address(this), _amount);
     }
-
-    function _msgData()
-        internal
-        view
-        virtual
-        override(HypERC20Collateral, ContextUpgradeable)
-        returns (bytes calldata)
-    {
-        return ContextUpgradeable._msgData();
-    }
-
-    function _msgSender()
-        internal
-        view
-        virtual
-        override(HypERC20Collateral, ContextUpgradeable)
-        returns (address)
-    {
-        return ContextUpgradeable._msgSender();
-    }
 }

--- a/solidity/contracts/token/libs/MovableCollateralRouter.sol
+++ b/solidity/contracts/token/libs/MovableCollateralRouter.sol
@@ -13,8 +13,8 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 abstract contract MovableCollateralRouter is AccessControl {
     using SafeERC20 for IERC20;
 
-    constructor() {
-        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    function _MovableCollateralRouter_initialize(address admin) internal {
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
     }
 
     bytes32 public constant REBALANCER_ROLE = keccak256("REBALANCER_ROLE");

--- a/solidity/contracts/token/libs/MovableCollateralRouter.sol
+++ b/solidity/contracts/token/libs/MovableCollateralRouter.sol
@@ -4,13 +4,13 @@ pragma solidity >=0.8.0;
 import {FungibleTokenRouter} from "./FungibleTokenRouter.sol";
 import {ValueTransferBridge} from "./ValueTransferBridge.sol";
 
-import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-abstract contract MovableCollateralRouter is AccessControl {
+abstract contract MovableCollateralRouter is AccessControlUpgradeable {
     using SafeERC20 for IERC20;
 
     function _MovableCollateralRouter_initialize(address admin) internal {

--- a/solidity/test/token/HypERC20MovableCollateral.t.sol
+++ b/solidity/test/token/HypERC20MovableCollateral.t.sol
@@ -25,6 +25,8 @@ contract HypERC20MovableCollateralRouterTest is Test {
             1e18,
             address(new MockMailbox(uint32(1)))
         );
+        // Initialize the router -> we are the admin
+        router.initialize(address(0), address(0), address(this));
 
         vtb = new MockValueTransferBridge(token);
     }

--- a/solidity/test/token/MovableCollateralRouter.t.sol
+++ b/solidity/test/token/MovableCollateralRouter.t.sol
@@ -7,7 +7,11 @@ import {MovableCollateralRouter, ValueTransferBridge} from "contracts/token/libs
 import "forge-std/Test.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
-contract MockMovableCollateralRouter is MovableCollateralRouter {}
+contract MockMovableCollateralRouter is MovableCollateralRouter {
+    constructor() {
+        _MovableCollateralRouter_initialize(msg.sender);
+    }
+}
 
 contract MockValueTransferBridge is ValueTransferBridge {
     ERC20Test token;


### PR DESCRIPTION
### Description
Since HypERC20Collateral is an upgradeable contract, we can't use constructors to set storage. Here we add an initializer function to `MovableCollateralRouter` and call it in the initializer of `HypERC20Collateral`. 

We've also changed the initializer function on `HypERC20Collateral` to have a modifier of `reinitializer(2)` meaning that it can be called two times. This allows us to call `initialize` again on all existing instances of `HypERC20Collateral`.

### Drive-by changes


### Related issues



### Backward compatibility

Yes

### Testing

Unit
