### PR TITLE
chore(submitter): default to considering errors non-retryable

### DIFF
--- a/rust/main/submitter/src/error.rs
+++ b/rust/main/submitter/src/error.rs
@@ -60,11 +60,21 @@ pub trait IsRetryable {
 impl IsRetryable for SubmitterError {
     fn is_retryable(&self) -> bool {
         match self {
-            SubmitterError::NetworkError(_) => true,
             SubmitterError::TxSubmissionError(_) => true,
-            SubmitterError::ChannelSendFailure(_) => true,
-            SubmitterError::ChainCommunicationError(_) => true,
-            SubmitterError::EyreError(_) => true,
+            SubmitterError::NetworkError(_) => {
+                // TODO: add logic to classify based on the error message
+                false
+            }
+            // tx submission errors are not retryable so gas gets escalated
+            SubmitterError::ChainCommunicationError(_) => {
+                // TODO: add logic to classify based on the error message
+                false
+            }
+            SubmitterError::EyreError(_) => {
+                // TODO: add logic to classify based on the error message
+                false
+            }
+            SubmitterError::ChannelSendFailure(_) => false,
             SubmitterError::NonRetryableError(_) => false,
             SubmitterError::TxReverted => false,
             SubmitterError::SimulationFailed => false,


### PR DESCRIPTION
### Description

- lean on higher level retries from the MessageProcessor to avoid getting the submitter blocked on errors that are actually non-retryable
- we can look for increases in the `dropped_transactions` metric to find errors that we can classify as retryable

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/6101

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
