### PR TITLE
chore: export HypTokenRouterConfigMailboxOptional types

### DIFF
--- a/.changeset/three-schools-happen.md
+++ b/.changeset/three-schools-happen.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Export HypTokenRouterConfigMailboxOptionalSchema and HypTokenRouterConfigMailboxOptional

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -610,6 +610,8 @@ export {
   HypTokenConfigSchema,
   HypTokenRouterConfig,
   HypTokenRouterConfigSchema,
+  HypTokenRouterConfigMailboxOptional,
+  HypTokenRouterConfigMailboxOptionalSchema,
   isCollateralRebaseTokenConfig,
   isCollateralTokenConfig,
   isXERC20TokenConfig,

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -149,11 +149,12 @@ export function derivedIsmAddress(config: DerivedTokenRouterConfig) {
     : config.interchainSecurityModule.address;
 }
 
-const HypTokenRouterConfigMailboxOptionalSchema = HypTokenConfigSchema.and(
-  GasRouterConfigSchema.extend({
-    mailbox: z.string().optional(),
-  }),
-);
+export const HypTokenRouterConfigMailboxOptionalSchema =
+  HypTokenConfigSchema.and(
+    GasRouterConfigSchema.extend({
+      mailbox: z.string().optional(),
+    }),
+  );
 
 export type HypTokenRouterConfigMailboxOptional = z.infer<
   typeof HypTokenRouterConfigMailboxOptionalSchema


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
Export HypTokenRouterConfigMailboxOptionalSchema and HypTokenRouterConfigMailboxOptional
### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
