### PR TITLE
fix(submitter): svm adapter commitment levels

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
@@ -96,10 +96,14 @@ impl SealevelRpcClient {
         Ok(balance.into())
     }
 
-    /// get block
-    pub async fn get_block(&self, slot: u64) -> ChainResult<UiConfirmedBlock> {
+    /// get block with commitment
+    pub async fn get_block_with_commitment(
+        &self,
+        slot: u64,
+        commitment: CommitmentConfig,
+    ) -> ChainResult<UiConfirmedBlock> {
         let config = RpcBlockConfig {
-            commitment: Some(CommitmentConfig::finalized()),
+            commitment: Some(commitment),
             max_supported_transaction_version: Some(0),
             ..Default::default()
         };
@@ -199,13 +203,14 @@ impl SealevelRpcClient {
     }
 
     /// get transaction
-    pub async fn get_transaction(
+    pub async fn get_transaction_with_commitment(
         &self,
         signature: &Signature,
+        commitment: CommitmentConfig,
     ) -> ChainResult<EncodedConfirmedTransactionWithStatusMeta> {
         let config = RpcTransactionConfig {
             encoding: Some(UiTransactionEncoding::JsonParsed),
-            commitment: Some(CommitmentConfig::finalized()),
+            commitment: Some(commitment),
             max_supported_transaction_version: Some(0),
         };
         self.0

--- a/rust/main/submitter/src/chain_tx_adapter/chains/sealevel/adapter/tests/common.rs
+++ b/rust/main/submitter/src/chain_tx_adapter/chains/sealevel/adapter/tests/common.rs
@@ -37,8 +37,28 @@ mock! {
     #[async_trait]
     impl SubmitSealevelRpc for Client {
         async fn get_block(&self, slot: u64) -> ChainResult<UiConfirmedBlock>;
-        async fn get_transaction(&self, signature: Signature) -> ChainResult<EncodedConfirmedTransactionWithStatusMeta>;
-        async fn simulate_transaction(&self, transaction: &SealevelTransaction) -> ChainResult<RpcSimulateTransactionResult>;
+
+        async fn get_block_with_commitment(
+            &self,
+            slot: u64,
+            commitment: CommitmentConfig,
+        ) -> ChainResult<UiConfirmedBlock>;
+
+        async fn get_transaction(
+            &self,
+            signature: Signature,
+        ) -> ChainResult<EncodedConfirmedTransactionWithStatusMeta>;
+
+        async fn get_transaction_with_commitment(
+            &self,
+            signature: Signature,
+            commitment: CommitmentConfig,
+        ) -> ChainResult<EncodedConfirmedTransactionWithStatusMeta>;
+
+        async fn simulate_transaction(
+            &self,
+            transaction: &SealevelTransaction,
+        ) -> ChainResult<RpcSimulateTransactionResult>;
     }
 }
 
@@ -177,10 +197,12 @@ fn mock_client() -> MockClient {
     };
 
     let mut client = MockClient::new();
-    client.expect_get_block().returning(move |_| Ok(block()));
     client
-        .expect_get_transaction()
-        .returning(move |_| Ok(encoded_transaction()));
+        .expect_get_block_with_commitment()
+        .returning(move |_, _| Ok(block()));
+    client
+        .expect_get_transaction_with_commitment()
+        .returning(move |_, _| Ok(encoded_transaction()));
     client
         .expect_simulate_transaction()
         .returning(move |_| Ok(result.clone()));

--- a/rust/main/submitter/src/chain_tx_adapter/chains/sealevel/adapter/tests/config.rs
+++ b/rust/main/submitter/src/chain_tx_adapter/chains/sealevel/adapter/tests/config.rs
@@ -43,10 +43,8 @@ fn test_configuration_fields() {
     // when
     let estimated_block_time = adapter.estimated_block_time();
     let max_batch_size = adapter.max_batch_size();
-    let reorg_period = adapter.reorg_period.clone();
 
     // then
     assert_eq!(estimated_block_time, &expected_estimated_block_time);
     assert_eq!(max_batch_size, expected_max_batch_size);
-    assert_eq!(reorg_period, expected_reorg_period);
 }

--- a/rust/main/submitter/src/error.rs
+++ b/rust/main/submitter/src/error.rs
@@ -65,7 +65,6 @@ impl IsRetryable for SubmitterError {
                 // TODO: add logic to classify based on the error message
                 false
             }
-            // tx submission errors are not retryable so gas gets escalated
             SubmitterError::ChainCommunicationError(_) => {
                 // TODO: add logic to classify based on the error message
                 false


### PR DESCRIPTION
### Description

- All chain reads for confirming the status of a tx happened at the `finalized` [commitment](https://docs.anza.xyz/consensus/commitments) level, which explains why the Finality Pool is always empty in prod and why it takes 10-30s to get a tx included in Sealevel E2E
- This PR reads the tx hash at the `processed` status - if that fails, we return an error like before. Then, if the tx's slot can be read at `finalized` status, the tx is final. If the slot can be read at `confirmed` status, the tx is included. Otherwise the tx is pending inclusion, because the hash does exist.
- Removes the `reorgPeriod` from the SVM adapter, since I noticed we actually [set that to zero](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/f692b35be7bf9d7083877bfe259e18e8bf124ab6/rust/main/config/mainnet_config.json#L2870). We rely on using the right commitment levels in code (e.g. `finalized`) as opposed to setting an arbitrary number of blocks

### Related issues

Fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/6103

### Backward compatibility

Yes

### Testing

sealevel E2E