### PR TITLE
fix: persist key addresses in GCP

### DIFF
--- a/typescript/infra/src/agents/key-utils.ts
+++ b/typescript/infra/src/agents/key-utils.ts
@@ -390,7 +390,10 @@ async function persistAddressesInGcp(
       return;
     }
   } catch (e) {
-    // If the secret doesn't exist, just ignore the error.
+    // If the secret doesn't exist, we'll create it below.
+    debugLog(
+      `No existing secret found for ${context} context in ${environment} environment`,
+    );
   }
 
   debugLog(

--- a/typescript/infra/test/warp-configs.test.ts
+++ b/typescript/infra/test/warp-configs.test.ts
@@ -24,8 +24,8 @@ const DEFAULT_TIMEOUT = 100000;
 const warpIdsToSkip = [
   'EZETH/arbitrum-base-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-zircuit',
   'EZETHSTAGE/arbitrum-base-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-zircuit',
-  'USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain-staging',
-  'USDT/base-celo-fraxtal-ink-lisk-mode-optimism-soneium-superseed-unichain-worldchain',
+  'USDT/base-bitlayer-celo-ethereum-fraxtal-ink-linea-lisk-mantle-metal-metis-mode-optimism-ronin-soneium-sonic-superseed-unichain-worldchain',
+  'USDTSTAGING/base-bitlayer-celo-ethereum-fraxtal-ink-linea-lisk-mantle-metal-metis-mode-optimism-ronin-soneium-sonic-superseed-unichain-worldchain',
 ];
 
 async function getConfigsForBranch(branch: string) {


### PR DESCRIPTION
### Description

- Starts persisting key addresses in GCP again, fixing key funder infra
- Regression introduced in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/3159/files#diff-604c29d425429647a37bc7b46d72cfddb8f5ba0c40d81609234c36bb2a203b35L372 ages ago, just never realized because we didn't add new keys

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
