### PR TITLE
feat: chunk message db insertions

### DIFF
--- a/rust/main/helm/hyperlane-agent/templates/relayer-statefulset.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/relayer-statefulset.yaml
@@ -11,7 +11,7 @@ spec:
     matchLabels:
       {{- include "agent-common.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: relayer
-  replicas: 1 
+  replicas: 1
   serviceName: {{ include "agent-common.fullname" . }}-relayer
   template:
     metadata:
@@ -119,7 +119,7 @@ spec:
           mountPath: {{ .Values.hyperlane.dbPath }}
         - name: relayer-configmap
           mountPath: /relayer-configmap
-        ports: 
+        ports:
         - name: metrics
           containerPort: {{ .Values.hyperlane.metrics.port }}
       volumes:

--- a/rust/main/helm/hyperlane-agent/templates/scraper-statefulset.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/scraper-statefulset.yaml
@@ -11,7 +11,7 @@ spec:
     matchLabels:
       {{- include "agent-common.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: scraper3
-  replicas: 1 
+  replicas: 1
   serviceName: {{ include "agent-common.fullname" . }}-scraper3
   template:
     metadata:
@@ -60,7 +60,7 @@ spec:
         {{- include "agent-common.config-env-vars" (dict "config" .Values.hyperlane.scraper.config) | nindent 8 }}
         resources:
           {{- toYaml .Values.hyperlane.scraper.resources | nindent 10 }}
-        ports: 
+        ports:
         - name: metrics
           containerPort: {{ .Values.hyperlane.metrics.port }}
       {{- with .Values.nodeSelector }}

--- a/rust/main/helm/hyperlane-agent/templates/validator-statefulset.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/validator-statefulset.yaml
@@ -75,7 +75,7 @@ spec:
           mountPath: /config-env-vars
         - name: secret-env-vars
           mountPath: /secret-env-vars
-        ports: 
+        ports:
         - name: metrics
           containerPort: {{ .Values.hyperlane.metrics.port }}
       volumes:


### PR DESCRIPTION
### Description

Instead of inserting all the messages we receive in a single db transaction, we chunk it into smaller sizes.
This prevents us from running into `Too many arguments` errors from Postgres for exceeding their `u16::MAX` parameter count.

### Related issues
- fixes https://linear.app/hyperlane-xyz/issue/ENG-1390/scraper-cannot-insert-too-many-records

### Backward compatibility

Yes

### Testing

Manual. From Jeff:

Tried it locally with a postgres instance with 100k messages and it failed without chunking 
```
running 1 test
RES: Err(Query Error: encountered unexpected or invalid data: PgConnection::run(): too many arguments for query: 1000000 (sqlx_postgres::connection::executor:215)

Caused by:
   0: encountered unexpected or invalid data: PgConnection::run(): too many arguments for query: 1000000 (sqlx_postgres::connection::executor:215)
   1: encountered unexpected or invalid data: PgConnection::run(): too many arguments for query: 1000000 (sqlx_postgres::connection::executor:215)

Location:
    agents/scraper/src/db/message.rs:320:9)
test db::message::tests::test_store_dispatched_messages_real_postgres ... ok
```

Tried it again with chunking + transaction and it didn't have any errors :+1:
So we can use the transaction if we want the action to be atomic, but the important part is the chunking.
