### PR TITLE
fix(sdk): fix warp apply proxy onwership logic [eng-1399]

### DIFF
--- a/.changeset/wise-files-listen.md
+++ b/.changeset/wise-files-listen.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': patch
+'@hyperlane-xyz/sdk': patch
+---
+
+Fixed proxy admin ownership transfer logic when the config is not specified in the input file

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -40,6 +40,8 @@ export const TEMP_PATH = '/tmp'; // /temp gets removed at the end of all-test.sh
 
 export const ANVIL_KEY =
   '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+export const ANVIL_DEPLOYER_ADDRESS =
+  '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
 export const E2E_TEST_BURN_ADDRESS =
   '0x0000000000000000000000000000000000000001';
 

--- a/typescript/sdk/src/deploy/proxy.ts
+++ b/typescript/sdk/src/deploy/proxy.ts
@@ -85,43 +85,47 @@ export async function isProxy(
 export function proxyAdminUpdateTxs(
   chainId: ChainId,
   proxyAddress: Address,
-  actualConfig: Readonly<{ proxyAdmin?: DeployedOwnableConfig }>,
-  expectedConfig: Readonly<{ proxyAdmin?: DeployedOwnableConfig }>,
+  actualConfig: Readonly<{ owner: string; proxyAdmin?: DeployedOwnableConfig }>,
+  expectedConfig: Readonly<{
+    owner: string;
+    proxyAdmin?: DeployedOwnableConfig;
+  }>,
 ): AnnotatedEV5Transaction[] {
   const transactions: AnnotatedEV5Transaction[] = [];
 
-  // Return early because old config files did not have the
-  // proxyAdmin property
-  if (!expectedConfig.proxyAdmin?.address) {
-    return transactions;
-  }
-
-  const actualProxyAdmin = actualConfig.proxyAdmin!;
   const parsedChainId =
     typeof chainId === 'string' ? parseInt(chainId) : chainId;
 
   if (
-    actualProxyAdmin.address &&
-    actualProxyAdmin.address !== expectedConfig.proxyAdmin.address
+    actualConfig.proxyAdmin?.address &&
+    expectedConfig.proxyAdmin?.address &&
+    actualConfig.proxyAdmin.address !== expectedConfig.proxyAdmin.address
   ) {
     transactions.push({
       chainId: parsedChainId,
-      annotation: `Updating ProxyAdmin for proxy at "${proxyAddress}" from "${actualProxyAdmin.address}" to "${expectedConfig.proxyAdmin.address}"`,
-      to: actualProxyAdmin.address,
+      annotation: `Updating ProxyAdmin for proxy at "${proxyAddress}" from "${actualConfig.proxyAdmin.address}" to "${expectedConfig.proxyAdmin.address}"`,
+      to: actualConfig.proxyAdmin.address,
       data: ProxyAdmin__factory.createInterface().encodeFunctionData(
         'changeProxyAdmin(address,address)',
         [proxyAddress, expectedConfig.proxyAdmin.address],
       ),
     });
   } else {
+    const actualOwnershipConfig = actualConfig.proxyAdmin ?? {
+      owner: actualConfig.owner,
+    };
+    const expectedOwnershipConfig = expectedConfig.proxyAdmin ?? {
+      owner: expectedConfig.owner,
+    };
+
     transactions.push(
       // Internally the createTransferOwnershipTx method already checks if the
       // two owner values are the same and produces an empty tx batch if they are
       ...transferOwnershipTransactions(
         parsedChainId,
-        actualProxyAdmin.address!,
-        actualProxyAdmin,
-        expectedConfig.proxyAdmin,
+        actualOwnershipConfig.address!,
+        actualOwnershipConfig,
+        expectedOwnershipConfig,
       ),
     );
   }


### PR DESCRIPTION
### Description

Updates the proxy admin ownership management logic to default to the warp route owner if no proxy admin config is specified 

### Drive-by changes

- None

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

- YES

### Testing

- Manual
- e2e
