### PR TITLE
chore: spin down vanguard0

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -848,7 +848,7 @@ const hyperlane: RootAgentConfig = {
       repo,
       tag: 'f05ebc4-20250502-225226',
     },
-    blacklist: [...blacklist, ...vanguardMatchingList],
+    blacklist,
     gasPaymentEnforcement: gasPaymentEnforcement,
     metricAppContextsGetter,
     ismCacheConfigs,
@@ -888,7 +888,7 @@ const releaseCandidate: RootAgentConfig = {
       repo,
       tag: 'f05ebc4-20250502-225226',
     },
-    blacklist: [...blacklist, ...vanguardMatchingList],
+    blacklist,
     // We're temporarily (ab)using the RC relayer as a way to increase
     // message throughput.
     // whitelist: releaseCandidateHelloworldMatchingList,
@@ -926,7 +926,7 @@ const neutron: RootAgentConfig = {
       repo,
       tag: 'f05ebc4-20250502-225226',
     },
-    blacklist: [...blacklist, ...vanguardMatchingList],
+    blacklist,
     gasPaymentEnforcement,
     metricAppContextsGetter,
     ismCacheConfigs,

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -846,7 +846,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '3a04631-20250428-170554',
+      tag: 'f05ebc4-20250502-225226',
     },
     blacklist: [...blacklist, ...vanguardMatchingList],
     gasPaymentEnforcement: gasPaymentEnforcement,
@@ -886,7 +886,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '673c6d2-20250502-141150',
+      tag: 'f05ebc4-20250502-225226',
     },
     blacklist: [...blacklist, ...vanguardMatchingList],
     // We're temporarily (ab)using the RC relayer as a way to increase
@@ -924,7 +924,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '3a04631-20250428-170554',
+      tag: 'f05ebc4-20250502-225226',
     },
     blacklist: [...blacklist, ...vanguardMatchingList],
     gasPaymentEnforcement,

--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -33,7 +33,7 @@ export const keyFunderConfig: KeyFunderConfig<
     [Contexts.Hyperlane]: [Role.Relayer, Role.Kathy],
     [Contexts.ReleaseCandidate]: [Role.Relayer, Role.Kathy],
   },
-  chainsToSkip: [],
+  chainsToSkip: ['ontology'],
   // desired balance config, must be set for each chain
   desiredBalancePerChain: desiredRelayerBalancePerChain,
   // if not set, keyfunder defaults to 0

--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -32,7 +32,6 @@ export const keyFunderConfig: KeyFunderConfig<
   contextsAndRolesToFund: {
     [Contexts.Hyperlane]: [Role.Relayer, Role.Kathy],
     [Contexts.ReleaseCandidate]: [Role.Relayer, Role.Kathy],
-    [Contexts.Vanguard0]: [Role.Relayer],
   },
   chainsToSkip: [],
   // desired balance config, must be set for each chain


### PR DESCRIPTION
### Description

chore: spin down vanguard0
- update hyperlane image tag to latest `main` build
- remove vanguard blacklisting
- remove vanguard from keyfunder config

### Drive-by changes

- add `ontology` to keyfunder `chainsToSkip`, as we have not received funding for deploying on that chain yet

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
