### PR TITLE
feat: registry 13.16.0

### DIFF
--- a/.changeset/shy-terms-hang.md
+++ b/.changeset/shy-terms-hang.md
@@ -1,0 +1,8 @@
+---
+'@hyperlane-xyz/helloworld': minor
+'@hyperlane-xyz/widgets': minor
+'@hyperlane-xyz/infra': minor
+'@hyperlane-xyz/cli': minor
+---
+
+Upgraded @hyperlane-xyz/registry to 13.16.0 and updated warp route config API usage

--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -8,7 +8,7 @@
     "@eslint/js": "^9.15.0",
     "@ethersproject/abi": "*",
     "@ethersproject/providers": "*",
-    "@hyperlane-xyz/registry": "11.1.0",
+    "@hyperlane-xyz/registry": "13.16.0",
     "@hyperlane-xyz/sdk": "12.5.0",
     "@hyperlane-xyz/utils": "12.5.0",
     "@inquirer/core": "9.0.10",

--- a/typescript/helloworld/package.json
+++ b/typescript/helloworld/package.json
@@ -4,7 +4,7 @@
   "version": "12.5.0",
   "dependencies": {
     "@hyperlane-xyz/core": "7.1.4",
-    "@hyperlane-xyz/registry": "11.1.0",
+    "@hyperlane-xyz/registry": "13.16.0",
     "@hyperlane-xyz/sdk": "12.5.0",
     "@openzeppelin/contracts-upgradeable": "^4.9.3",
     "ethers": "^5.7.2"

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -14,7 +14,7 @@
     "@ethersproject/providers": "*",
     "@google-cloud/secret-manager": "^5.5.0",
     "@hyperlane-xyz/helloworld": "12.5.0",
-    "@hyperlane-xyz/registry": "11.1.0",
+    "@hyperlane-xyz/registry": "13.16.0",
     "@hyperlane-xyz/sdk": "12.5.0",
     "@hyperlane-xyz/utils": "12.5.0",
     "@inquirer/prompts": "3.3.2",

--- a/typescript/infra/scripts/warp-routes/export-warp-configs.ts
+++ b/typescript/infra/scripts/warp-routes/export-warp-configs.ts
@@ -31,12 +31,11 @@ async function main() {
       },
     );
 
-    const configFileName = `${warpRouteId}-deploy.yaml`;
-    registry.addWarpRouteConfig(registryConfig, configFileName);
+    registry.addWarpRouteConfig(registryConfig, { warpRouteId });
 
     // TODO: Use registry.getWarpRoutesPath() to dynamically generate path by removing "protected"
     console.log(
-      `Warp config successfully created at ${registry.getUri()}/deployments/warp_routes/${configFileName}`,
+      `Warp config successfully created at ${registry.getUri()}/deployments/warp_routes/${warpRouteId}-deploy.yaml`,
     );
   }
 }

--- a/typescript/widgets/package.json
+++ b/typescript/widgets/package.json
@@ -31,7 +31,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@eslint/js": "^9.15.0",
-    "@hyperlane-xyz/registry": "11.1.0",
+    "@hyperlane-xyz/registry": "13.16.0",
     "@storybook/addon-essentials": "^7.6.14",
     "@storybook/addon-interactions": "^7.6.14",
     "@storybook/addon-links": "^7.6.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7644,7 +7644,7 @@ __metadata:
     "@eslint/js": "npm:^9.15.0"
     "@ethersproject/abi": "npm:*"
     "@ethersproject/providers": "npm:*"
-    "@hyperlane-xyz/registry": "npm:11.1.0"
+    "@hyperlane-xyz/registry": "npm:13.16.0"
     "@hyperlane-xyz/sdk": "npm:12.5.0"
     "@hyperlane-xyz/utils": "npm:12.5.0"
     "@inquirer/core": "npm:9.0.10"
@@ -7795,7 +7795,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.15.0"
     "@hyperlane-xyz/core": "npm:7.1.4"
-    "@hyperlane-xyz/registry": "npm:11.1.0"
+    "@hyperlane-xyz/registry": "npm:13.16.0"
     "@hyperlane-xyz/sdk": "npm:12.5.0"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
     "@nomiclabs/hardhat-waffle": "npm:^2.0.6"
@@ -7846,7 +7846,7 @@ __metadata:
     "@ethersproject/providers": "npm:*"
     "@google-cloud/secret-manager": "npm:^5.5.0"
     "@hyperlane-xyz/helloworld": "npm:12.5.0"
-    "@hyperlane-xyz/registry": "npm:11.1.0"
+    "@hyperlane-xyz/registry": "npm:13.16.0"
     "@hyperlane-xyz/sdk": "npm:12.5.0"
     "@hyperlane-xyz/utils": "npm:12.5.0"
     "@inquirer/prompts": "npm:3.3.2"
@@ -7910,13 +7910,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/registry@npm:11.1.0":
-  version: 11.1.0
-  resolution: "@hyperlane-xyz/registry@npm:11.1.0"
+"@hyperlane-xyz/registry@npm:13.16.0":
+  version: 13.16.0
+  resolution: "@hyperlane-xyz/registry@npm:13.16.0"
   dependencies:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/4acb717a1f2d5b2c93237be6cd24406ae6f52eb86a4e5246eee919d5f95866ebdb7d4ce0fff2b193f6f4e29da2bcbe48e525ac958afaaa523e8260863069295d
+  checksum: 10/cdedcc383679cfd122a887a8185acf9834b7cf48682881b460248ddfca01181d4d826a595f61f9dff26844e26856a43451e991206a985a64cee4c80a57d32f67
   languageName: node
   linkType: hard
 
@@ -8020,7 +8020,7 @@ __metadata:
     "@eslint/js": "npm:^9.15.0"
     "@headlessui/react": "npm:^2.1.8"
     "@hyperlane-xyz/cosmos-sdk": "npm:12.5.0"
-    "@hyperlane-xyz/registry": "npm:11.1.0"
+    "@hyperlane-xyz/registry": "npm:13.16.0"
     "@hyperlane-xyz/sdk": "npm:12.5.0"
     "@hyperlane-xyz/utils": "npm:12.5.0"
     "@interchain-ui/react": "npm:^1.23.28"


### PR DESCRIPTION
### Description

Upgrade `@hyperlane-xyz/registry` from 11.1.0 to 13.16.0 across all packages and update code to use the new API.

### Drive-by changes

Update warp route config generation to use the new API format.

### Related issues

N/A

### Backward compatibility

Yes - API changes in registry package are handled in this PR.

### Testing

Manual