### PR TITLE
fix(sdk, cli): fix cli sdk trying to derive configs from 0 address [eng-1551]

### DIFF
--- a/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
@@ -1,19 +1,21 @@
 import { expect } from 'chai';
-import { Wallet } from 'ethers';
+import { Signer, Wallet, ethers } from 'ethers';
 import { zeroAddress } from 'viem';
 
-import { ERC20Test } from '@hyperlane-xyz/core';
+import { ERC20Test, HypERC20Collateral__factory } from '@hyperlane-xyz/core';
 import {
   ChainAddresses,
   createWarpRouteConfigId,
 } from '@hyperlane-xyz/registry';
 import {
+  ChainMetadata,
   HookConfig,
   HookType,
   IsmConfig,
   IsmType,
   MUTABLE_HOOK_TYPE,
   MUTABLE_ISM_TYPE,
+  TokenStandard,
   TokenType,
   WarpCoreConfig,
   WarpRouteDeployConfig,
@@ -30,7 +32,9 @@ import {
 
 import { readYamlOrJson, writeYamlOrJson } from '../../utils/files.js';
 import {
+  ANVIL_DEPLOYER_ADDRESS,
   ANVIL_KEY,
+  CHAIN_2_METADATA_PATH,
   CHAIN_NAME_2,
   CHAIN_NAME_3,
   CORE_CONFIG_PATH,
@@ -49,6 +53,7 @@ import {
 describe('hyperlane warp check e2e tests', async function () {
   this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
 
+  let signer: Signer;
   let chain2Addresses: ChainAddresses = {};
   let chain3Addresses: ChainAddresses = {};
   let token: ERC20Test;
@@ -62,6 +67,14 @@ describe('hyperlane warp check e2e tests', async function () {
       deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY),
       deployOrUseExistingCore(CHAIN_NAME_3, CORE_CONFIG_PATH, ANVIL_KEY),
     ]);
+
+    const chainMetadata: ChainMetadata = readYamlOrJson(CHAIN_2_METADATA_PATH);
+
+    const provider = new ethers.providers.JsonRpcProvider(
+      chainMetadata.rpcUrls[0].http,
+    );
+
+    signer = new Wallet(ANVIL_KEY).connect(provider);
 
     token = await deployToken(ANVIL_KEY, CHAIN_NAME_2);
     tokenSymbol = await token.symbol();
@@ -154,6 +167,74 @@ describe('hyperlane warp check e2e tests', async function () {
           CHAIN_NAME_2,
           CHAIN_NAME_3,
         ]),
+      })
+        .stdio('pipe')
+        .nothrow();
+
+      expect(output.exitCode).to.equal(0);
+      expect(output.text()).to.include('No violations found');
+    });
+
+    it(`should successfully check warp routes that are not deployed as proxies`, async () => {
+      // Deploy the token and the hyp adapter
+      const symbol = 'NTAP';
+      const tokenName = 'NOTAPROXY';
+      const tokenDecimals = 10;
+      const collateral = await deployToken(
+        ANVIL_KEY,
+        CHAIN_NAME_2,
+        tokenDecimals,
+        symbol,
+      );
+
+      const contract = new HypERC20Collateral__factory(signer);
+      const tx = await contract.deploy(
+        collateral.address,
+        1,
+        chain2Addresses.mailbox,
+      );
+
+      const deployedContract = await tx.deployed();
+      const tx2 = await deployedContract.initialize(
+        zeroAddress,
+        zeroAddress,
+        ANVIL_DEPLOYER_ADDRESS,
+      );
+
+      await tx2.wait();
+
+      // Manually add config files to the registry
+      const routePath = getCombinedWarpRoutePath(symbol, [CHAIN_NAME_2]);
+      const warpDeployConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.collateral,
+          token: collateral.address,
+          owner: ANVIL_DEPLOYER_ADDRESS,
+        },
+      };
+      writeYamlOrJson(
+        routePath.replace('-config.yaml', '-deploy.yaml'),
+        warpDeployConfig,
+      );
+
+      const warpCoreConfig: WarpCoreConfig = {
+        tokens: [
+          {
+            addressOrDenom: deployedContract.address,
+            chainName: CHAIN_NAME_2,
+            decimals: tokenDecimals,
+            collateralAddressOrDenom: token.address,
+            name: tokenName,
+            standard: TokenStandard.EvmHypCollateral,
+            symbol,
+          },
+        ],
+      };
+      writeYamlOrJson(routePath, warpCoreConfig);
+
+      // Finally run warp check
+      const output = await hyperlaneWarpCheckRaw({
+        warpRouteId: createWarpRouteConfigId(symbol, [CHAIN_NAME_2]),
       })
         .stdio('pipe')
         .nothrow();


### PR DESCRIPTION
### Description

This PR fixes a bug in the warp reader that assumed that all warp routes are deployed as proxies when it doesn't seem to be the case, which resulted in the on-chain config derivation failing because the `.owner` field was called on the 0 address when deriving the proxy admin config 

### Drive-by changes

- None

### Related issues

- [ENG-1551](https://linear.app/hyperlane-xyz/issue/ENG-1551/fix-warp-checker-reader-trying-to-derive-info-from-the-0-address)

### Backward compatibility

- YES

### Testing

- Manual
- unit
- e2e
