### PR TITLE
feat: fix message status not being stored correctly

### DIFF
--- a/rust/main/agents/relayer/src/msg/op_batch.rs
+++ b/rust/main/agents/relayer/src/msg/op_batch.rs
@@ -169,13 +169,12 @@ mod tests {
             },
             op_queue::test::MockPendingOperation,
             pending_message::{MessageContext, PendingMessage},
-            processor::test::{
-                dummy_cache_metrics, dummy_submission_metrics, DummyApplicationOperationVerifier,
-            },
+            processor::test::{dummy_cache_metrics, DummyApplicationOperationVerifier},
         },
         settings::{
             matching_list::MatchingList, GasPaymentEnforcementConf, GasPaymentEnforcementPolicy,
         },
+        test_utils::dummy_data::dummy_submission_metrics,
     };
     use ethers::utils::hex;
     use hyperlane_base::{

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -1046,36 +1046,17 @@ impl PendingMessage {
 mod test {
     use std::{
         fmt::Debug,
-        str::FromStr,
         sync::Arc,
         time::{Duration, Instant},
     };
 
     use chrono::TimeDelta;
-    use hyperlane_base::{
-        cache::OptionalCache,
-        db::*,
-        settings::{ChainConf, ChainConnectionConf, CoreContractAddresses},
-        CoreMetrics,
-    };
-    use hyperlane_core::{config::OpSubmissionConfig, identifiers::UniqueIdentifier, *};
-    use hyperlane_test::mocks::MockValidatorAnnounceContract;
-    use tokio::sync::RwLock;
+    use hyperlane_base::{cache::OptionalCache, db::*};
+    use hyperlane_core::{identifiers::UniqueIdentifier, *};
 
-    use crate::{
-        merkle_tree::builder::MerkleTreeBuilder,
-        msg::{
-            gas_payment::GasPaymentEnforcer,
-            metadata::{
-                BaseMetadataBuilder, DefaultIsmCache, IsmAwareAppContextClassifier,
-                IsmCachePolicyClassifier,
-            },
-            pending_message::{MessageContext, DEFAULT_MAX_MESSAGE_RETRIES},
-            processor::test::{dummy_submission_metrics, DummyApplicationOperationVerifier},
-        },
-    };
+    use crate::test_utils::dummy_data::{dummy_message_context, dummy_metadata_builder};
 
-    use super::PendingMessage;
+    use super::{PendingMessage, DEFAULT_MAX_MESSAGE_RETRIES};
 
     mockall::mock! {
         pub Db {
@@ -1360,47 +1341,13 @@ mod test {
     #[tokio::test]
     async fn check_stored_status() {
         let origin_domain = HyperlaneDomain::Known(hyperlane_core::KnownHyperlaneDomain::Arbitrum);
+        let destination_domain =
+            HyperlaneDomain::Known(hyperlane_core::KnownHyperlaneDomain::Arbitrum);
         let cache = OptionalCache::new(None);
 
         let temp_dir = tempfile::tempdir().unwrap();
         let db = DB::from_path(temp_dir.path()).unwrap();
         let base_db = HyperlaneRocksDB::new(&origin_domain, db);
-
-        let arb_chain_conf = ChainConf {
-            domain: origin_domain.clone(),
-            signer: None,
-            submitter: SubmitterType::Classic,
-            estimated_block_time: Duration::from_secs(1),
-            reorg_period: ReorgPeriod::from_blocks(10),
-            addresses: CoreContractAddresses {
-                mailbox: H160::from_str("0x979Ca5202784112f4738403dBec5D0F3B9daabB9")
-                    .unwrap()
-                    .into(),
-                validator_announce: H160::from_str("0x1df063280C4166AF9a725e3828b4dAC6c7113B08")
-                    .unwrap()
-                    .into(),
-                ..Default::default()
-            },
-            connection: ChainConnectionConf::Ethereum(hyperlane_ethereum::ConnectionConf {
-                rpc_connection: hyperlane_ethereum::RpcConnectionConf::HttpFallback {
-                    urls: vec![
-                        "https://arbitrum.drpc.org".parse().unwrap(),
-                        "https://endpoints.omniatech.io/v1/arbitrum/one/public"
-                            .parse()
-                            .unwrap(),
-                    ],
-                },
-                transaction_overrides: Default::default(),
-                op_submission_config: OpSubmissionConfig {
-                    batch_contract_address: None,
-                    max_batch_size: 32,
-                    bypass_batch_simulation: false,
-                    ..Default::default()
-                },
-            }),
-            metrics_conf: Default::default(),
-            index: Default::default(),
-        };
 
         let message = HyperlaneMessage {
             nonce: 0,
@@ -1409,52 +1356,18 @@ mod test {
             ..Default::default()
         };
 
-        let core_metrics = CoreMetrics::new("test", 9090, Default::default()).unwrap();
-        let arb_mailbox: Arc<dyn Mailbox> = arb_chain_conf
-            .build_mailbox(&core_metrics)
-            .await
-            .unwrap()
-            .into();
-
-        let base_va = Arc::new(MockValidatorAnnounceContract::default());
-        let default_ism_getter = DefaultIsmCache::new(arb_mailbox.clone());
-        let core_metrics = Arc::new(core_metrics);
-        let base_metadata_builder = BaseMetadataBuilder::new(
-            origin_domain.clone(),
-            arb_chain_conf.clone(),
-            Arc::new(RwLock::new(MerkleTreeBuilder::new())),
-            base_va,
-            false,
-            core_metrics.clone(),
-            cache.clone(),
-            base_db.clone(),
-            IsmAwareAppContextClassifier::new(default_ism_getter.clone(), vec![]),
-            IsmCachePolicyClassifier::new(default_ism_getter, Default::default()),
-        );
-        let message_context = Arc::new(MessageContext {
-            destination_mailbox: arb_mailbox,
-            origin_db: Arc::new(base_db.clone()),
-            cache,
-            metadata_builder: Arc::new(base_metadata_builder),
-            origin_gas_payment_enforcer: Arc::new(GasPaymentEnforcer::new([], base_db.clone())),
-            transaction_gas_limit: Default::default(),
-            metrics: dummy_submission_metrics(),
-            application_operation_verifier: Some(Arc::new(DummyApplicationOperationVerifier {})),
-        });
-        let metadata =
-        "0x000000100000001000000010000001680000000000000000000000100000015800000000000000000000000019dc38aeae620380430c200a6e990d5af5480117dbd3d5e656de9dcf604fcc90b52a3b97d9f3573b4a0733e824f1358e515698cf00139eaa5452e030aa937f6b14162a44ec3327f6832bbf16e4b0d6df452524af1c1a04e875b4ce7ac0da92aa08838a89f2a126eef23f6b6a08b6cdbe9e9e804b321088b91b034f9466eed2da1dcc36cb220b887b15f3e111a179142c27e4a0b6d6b7a291e22577d6296d82b7c3f29e8989ec1161d853aba0982b2db28b9a9917226c2c27111c41c99e6a84e7717740f901528062385e659b4330e7227593a334be532d27bcf24f3f13bf4fc1a860e96f8d6937984ea83ef61c8ea30d48cc903f6ff725406a4d1ce73f46064b3403ea4c720b770f4389d7259b275f085c6a98cef9a04880a249b42c382ba34a63031debbfb5b9b232ffd9ee45ff63a7249e83c7e9720f9e978a431b".as_bytes().to_vec();
+        let base_metadata_builder =
+            dummy_metadata_builder(&origin_domain, &destination_domain, &base_db, cache.clone());
+        let message_context =
+            dummy_message_context(Arc::new(base_metadata_builder), &base_db, cache);
 
         let mut pending_message = PendingMessage::new(
             message.clone(),
-            message_context.clone(),
+            Arc::new(message_context),
             PendingOperationStatus::FirstPrepareAttempt,
             Some(format!("test-{}", 0)),
             2,
         );
-        pending_message.submission_data = Some(Box::new(MessageSubmissionData {
-            metadata: metadata.clone(),
-            gas_limit: U256::from(615293),
-        }));
 
         let expected_status = PendingOperationStatus::ReadyToSubmit;
         pending_message.set_status(expected_status.clone());

--- a/rust/main/agents/relayer/src/msg/processor.rs
+++ b/rust/main/agents/relayer/src/msg/processor.rs
@@ -407,12 +407,9 @@ impl MessageProcessorMetrics {
 pub mod test {
     use std::time::Instant;
 
-    use prometheus::{CounterVec, IntCounter, IntCounterVec, Opts, Registry};
+    use prometheus::IntCounterVec;
     use tokio::{
-        sync::{
-            mpsc::{self, UnboundedReceiver},
-            RwLock,
-        },
+        sync::mpsc::{self, UnboundedReceiver},
         time::sleep,
     };
     use tokio_metrics::TaskMonitor;
@@ -423,7 +420,6 @@ pub mod test {
             test_utils, DbResult, HyperlaneRocksDB, InterchainGasExpenditureData,
             InterchainGasPaymentData,
         },
-        settings::{ChainConf, ChainConnectionConf, Settings},
     };
     use hyperlane_core::{
         identifiers::UniqueIdentifier, test_utils::dummy_domain, GasPaymentKey,
@@ -433,20 +429,11 @@ pub mod test {
     use hyperlane_operation_verifier::{
         ApplicationOperationVerifier, ApplicationOperationVerifierReport,
     };
-    use hyperlane_test::mocks::{MockMailboxContract, MockValidatorAnnounceContract};
     use tracing::info_span;
 
     use crate::{
-        merkle_tree::builder::MerkleTreeBuilder,
-        metrics::message_submission::MessageSubmissionMetrics,
-        msg::{
-            gas_payment::GasPaymentEnforcer,
-            metadata::{
-                BaseMetadataBuilder, DefaultIsmCache, IsmAwareAppContextClassifier,
-                IsmCachePolicyClassifier,
-            },
-        },
         processor::Processor,
+        test_utils::dummy_data::{dummy_message_context, dummy_metadata_builder},
     };
 
     use super::*;
@@ -493,79 +480,6 @@ pub mod test {
         }
     }
 
-    pub fn dummy_submission_metrics() -> MessageSubmissionMetrics {
-        MessageSubmissionMetrics {
-            origin: "".to_string(),
-            destination: "".to_string(),
-            last_known_nonce: IntGauge::new("last_known_nonce_gauge", "help string").unwrap(),
-            messages_processed: IntCounter::new("message_processed_gauge", "help string").unwrap(),
-            metadata_build_count: IntCounterVec::new(
-                Opts::new("metadata_build_count", "help string"),
-                &["app_context", "origin", "remote", "status"],
-            )
-            .unwrap(),
-            metadata_build_duration: CounterVec::new(
-                Opts::new("metadata_build_duration", "help string"),
-                &["app_context", "origin", "remote", "status"],
-            )
-            .unwrap(),
-        }
-    }
-
-    fn dummy_chain_conf(domain: &HyperlaneDomain) -> ChainConf {
-        ChainConf {
-            domain: domain.clone(),
-            signer: Default::default(),
-            submitter: Default::default(),
-            estimated_block_time: Duration::from_secs_f64(1.1),
-            reorg_period: Default::default(),
-            addresses: Default::default(),
-            connection: ChainConnectionConf::Ethereum(hyperlane_ethereum::ConnectionConf {
-                rpc_connection: hyperlane_ethereum::RpcConnectionConf::Http {
-                    url: "http://example.com".parse().unwrap(),
-                },
-                transaction_overrides: Default::default(),
-                op_submission_config: Default::default(),
-            }),
-            metrics_conf: Default::default(),
-            index: Default::default(),
-        }
-    }
-
-    fn dummy_metadata_builder(
-        origin_domain: &HyperlaneDomain,
-        destination_domain: &HyperlaneDomain,
-        db: &HyperlaneRocksDB,
-        cache: OptionalCache<MeteredCache<LocalCache>>,
-    ) -> BaseMetadataBuilder {
-        let mut settings = Settings::default();
-        settings.chains.insert(
-            origin_domain.name().to_owned(),
-            dummy_chain_conf(origin_domain),
-        );
-        settings.chains.insert(
-            destination_domain.name().to_owned(),
-            dummy_chain_conf(destination_domain),
-        );
-        let destination_chain_conf = settings.chain_setup(destination_domain).unwrap();
-        let core_metrics = CoreMetrics::new("dummy_relayer", 37582, Registry::new()).unwrap();
-        let default_ism_getter = DefaultIsmCache::new(Arc::new(
-            MockMailboxContract::new_with_default_ism(H256::zero()),
-        ));
-        BaseMetadataBuilder::new(
-            origin_domain.clone(),
-            destination_chain_conf.clone(),
-            Arc::new(RwLock::new(MerkleTreeBuilder::new())),
-            Arc::new(MockValidatorAnnounceContract::default()),
-            false,
-            Arc::new(core_metrics),
-            cache,
-            db.clone(),
-            IsmAwareAppContextClassifier::new(default_ism_getter.clone(), vec![]),
-            IsmCachePolicyClassifier::new(default_ism_getter, Default::default()),
-        )
-    }
-
     fn dummy_message_processor(
         origin_domain: &HyperlaneDomain,
         destination_domain: &HyperlaneDomain,
@@ -574,16 +488,11 @@ pub mod test {
     ) -> (MessageProcessor, UnboundedReceiver<QueueOperation>) {
         let base_metadata_builder =
             dummy_metadata_builder(origin_domain, destination_domain, db, cache.clone());
-        let message_context = Arc::new(MessageContext {
-            destination_mailbox: Arc::new(MockMailboxContract::new_with_default_ism(H256::zero())),
-            origin_db: Arc::new(db.clone()),
+        let message_context = Arc::new(dummy_message_context(
+            Arc::new(base_metadata_builder),
+            db,
             cache,
-            metadata_builder: Arc::new(base_metadata_builder),
-            origin_gas_payment_enforcer: Arc::new(GasPaymentEnforcer::new([], db.clone())),
-            transaction_gas_limit: Default::default(),
-            metrics: dummy_submission_metrics(),
-            application_operation_verifier: Some(Arc::new(DummyApplicationOperationVerifier {})),
-        });
+        ));
 
         let (send_channel, receive_channel) = mpsc::unbounded_channel::<QueueOperation>();
         (

--- a/rust/main/agents/relayer/src/test_utils/dummy_data.rs
+++ b/rust/main/agents/relayer/src/test_utils/dummy_data.rs
@@ -1,0 +1,116 @@
+use std::{sync::Arc, time::Duration};
+
+use hyperlane_base::{
+    cache::{LocalCache, MeteredCache, OptionalCache},
+    db::HyperlaneRocksDB,
+    settings::{ChainConf, ChainConnectionConf, Settings},
+    CoreMetrics,
+};
+use hyperlane_core::{HyperlaneDomain, H256};
+use hyperlane_test::mocks::{MockMailboxContract, MockValidatorAnnounceContract};
+use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge, Opts, Registry};
+use tokio::sync::RwLock;
+
+use crate::{
+    merkle_tree::builder::MerkleTreeBuilder,
+    metrics::message_submission::MessageSubmissionMetrics,
+    msg::{
+        gas_payment::GasPaymentEnforcer,
+        metadata::{
+            BaseMetadataBuilder, DefaultIsmCache, IsmAwareAppContextClassifier,
+            IsmCachePolicyClassifier,
+        },
+        pending_message::MessageContext,
+        processor::test::DummyApplicationOperationVerifier,
+    },
+};
+
+pub fn dummy_chain_conf(domain: &HyperlaneDomain) -> ChainConf {
+    ChainConf {
+        domain: domain.clone(),
+        signer: Default::default(),
+        submitter: Default::default(),
+        estimated_block_time: Duration::from_secs_f64(1.1),
+        reorg_period: Default::default(),
+        addresses: Default::default(),
+        connection: ChainConnectionConf::Ethereum(hyperlane_ethereum::ConnectionConf {
+            rpc_connection: hyperlane_ethereum::RpcConnectionConf::Http {
+                url: "http://example.com".parse().unwrap(),
+            },
+            transaction_overrides: Default::default(),
+            op_submission_config: Default::default(),
+        }),
+        metrics_conf: Default::default(),
+        index: Default::default(),
+    }
+}
+
+pub fn dummy_metadata_builder(
+    origin_domain: &HyperlaneDomain,
+    destination_domain: &HyperlaneDomain,
+    db: &HyperlaneRocksDB,
+    cache: OptionalCache<MeteredCache<LocalCache>>,
+) -> BaseMetadataBuilder {
+    let mut settings = Settings::default();
+    settings.chains.insert(
+        origin_domain.name().to_owned(),
+        dummy_chain_conf(origin_domain),
+    );
+    settings.chains.insert(
+        destination_domain.name().to_owned(),
+        dummy_chain_conf(destination_domain),
+    );
+    let destination_chain_conf = settings.chain_setup(destination_domain).unwrap();
+    let core_metrics = CoreMetrics::new("dummy_relayer", 37582, Registry::new()).unwrap();
+    let default_ism_getter = DefaultIsmCache::new(Arc::new(
+        MockMailboxContract::new_with_default_ism(H256::zero()),
+    ));
+    BaseMetadataBuilder::new(
+        origin_domain.clone(),
+        destination_chain_conf.clone(),
+        Arc::new(RwLock::new(MerkleTreeBuilder::new())),
+        Arc::new(MockValidatorAnnounceContract::default()),
+        false,
+        Arc::new(core_metrics),
+        cache,
+        db.clone(),
+        IsmAwareAppContextClassifier::new(default_ism_getter.clone(), vec![]),
+        IsmCachePolicyClassifier::new(default_ism_getter, Default::default()),
+    )
+}
+
+pub fn dummy_submission_metrics() -> MessageSubmissionMetrics {
+    MessageSubmissionMetrics {
+        origin: "".to_string(),
+        destination: "".to_string(),
+        last_known_nonce: IntGauge::new("last_known_nonce_gauge", "help string").unwrap(),
+        messages_processed: IntCounter::new("message_processed_gauge", "help string").unwrap(),
+        metadata_build_count: IntCounterVec::new(
+            Opts::new("metadata_build_count", "help string"),
+            &["app_context", "origin", "remote", "status"],
+        )
+        .unwrap(),
+        metadata_build_duration: CounterVec::new(
+            Opts::new("metadata_build_duration", "help string"),
+            &["app_context", "origin", "remote", "status"],
+        )
+        .unwrap(),
+    }
+}
+
+pub fn dummy_message_context(
+    base_metadata_builder: Arc<BaseMetadataBuilder>,
+    db: &HyperlaneRocksDB,
+    cache: OptionalCache<MeteredCache<LocalCache>>,
+) -> MessageContext {
+    MessageContext {
+        destination_mailbox: Arc::new(MockMailboxContract::new_with_default_ism(H256::zero())),
+        origin_db: Arc::new(db.clone()),
+        cache,
+        metadata_builder: base_metadata_builder,
+        origin_gas_payment_enforcer: Arc::new(GasPaymentEnforcer::new([], db.clone())),
+        transaction_gas_limit: Default::default(),
+        metrics: dummy_submission_metrics(),
+        application_operation_verifier: Some(Arc::new(DummyApplicationOperationVerifier {})),
+    }
+}

--- a/rust/main/agents/relayer/src/test_utils/mod.rs
+++ b/rust/main/agents/relayer/src/test_utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod dummy_data;
 pub mod mock_aggregation_ism;
 pub mod mock_base_builder;
 pub mod mock_ism;


### PR DESCRIPTION
### Description

Fix message status not being stored correctly.
Turns out, instead of storing the new message status, we store the old message status,
but set it to the new message status in memory.

### Related issues

 - fixes: https://linear.app/hyperlane-xyz/issue/ENG-1024/bug-relayer-messages-are-loaded-with-the-wrong-operation-status-from

### Drive-bys

 - move some dummy test code to be public so other tests can also use them

### Backward compatibility

Yes

### Testing

 - added a test with a temp dir rocksdb to make sure `PendingMessage.set_status()` works as expected