### PR TITLE
test(metrics): rebalancer metrics

### DIFF
--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -483,6 +483,16 @@ export const rebalancer: CommandModuleWithWriteContext<{
       await monitor
         // Observe balances events and process rebalancing routes
         .on('tokeninfo', (event) => {
+          if (metrics) {
+            for (const tokenInfo of event.tokensInfo) {
+              metrics.processToken(tokenInfo).catch((e) => {
+                errorRed(
+                  `Error building metrics for ${tokenInfo.token.addressOrDenom}: ${e.message}`,
+                );
+              });
+            }
+          }
+
           const rawBalances = event.tokensInfo.reduce((acc, tokenInfo) => {
             if (
               !tokenInfo.token.isCollateralized() ||
@@ -493,16 +503,6 @@ export const rebalancer: CommandModuleWithWriteContext<{
             acc[tokenInfo.token.chainName] = tokenInfo.bridgedSupply;
             return acc;
           }, {} as RawBalances);
-
-          if (metrics) {
-            for (const tokenInfo of event.tokensInfo) {
-              metrics.processToken(tokenInfo).catch((e) => {
-                errorRed(
-                  `Error building metrics for ${tokenInfo.token.addressOrDenom}: ${e.message}`,
-                );
-              });
-            }
-          }
 
           const rebalancingRoutes = strategy.getRebalancingRoutes(rawBalances);
 

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -160,7 +160,7 @@ export function hyperlaneWarpRebalancer(
   warpRouteId: string,
   checkFrequency: number,
   rebalancerConfigFile: string,
-  withMetrics: boolean,
+  withMetrics: boolean = false,
 ): ProcessPromise {
   return $`yarn workspace @hyperlane-xyz/cli run hyperlane warp rebalancer \
         --registry ${REGISTRY_PATH} \

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -715,8 +715,8 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     await sleep(3000);
 
     // Check that metrics endpoint is not responding
-    fetch(DEFAULT_METRICS_SERVER).should.eventually.throw();
-
-    await process.kill();
+    return fetch(DEFAULT_METRICS_SERVER).should.be.rejected.then(() =>
+      process.kill(),
+    );
   });
 });

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { Wallet, ethers } from 'ethers';
 import { rmSync } from 'fs';
 import { $ } from 'zx';
@@ -48,6 +49,10 @@ import {
   hyperlaneWarpRebalancer,
   hyperlaneWarpSendRelay,
 } from '../commands/warp.js';
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+chai.should();
 
 describe('hyperlane warp rebalancer e2e tests', async function () {
   this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
@@ -703,21 +708,14 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     await process.kill();
   });
 
-  it('should not find any metrics server when they are not enabled', async () => {
+  it('should not find any metrics server when metrics are not enabled', async () => {
     const process = startRebalancer({ withMetrics: false });
 
     // Give the server some time to start
     await sleep(3000);
 
-    let failed = false;
-    try {
-      await fetch(DEFAULT_METRICS_SERVER);
-    } catch (_) {
-      failed = true;
-    }
-
     // Check that metrics endpoint is not responding
-    expect(failed).to.be.true;
+    fetch(DEFAULT_METRICS_SERVER).should.eventually.throw();
 
     await process.kill();
   });


### PR DESCRIPTION
### Description

This PR adds tests for the Metrics module in the CLI warp rebalancer command.

Ensures that Metrics are correctly enabled by flag

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

Fixes https://github.com/BootNodeDev/hyperlane-monorepo/issues/45

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
- [x] e2e tests