### PR TITLE
refactor: warp config loading

### DIFF
--- a/.changeset/little-houses-crash.md
+++ b/.changeset/little-houses-crash.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Refactored warp route configuration functions to use object parameters instead of positional parameters for improved clarity and flexibility.

--- a/.changeset/loose-numbers-tease.md
+++ b/.changeset/loose-numbers-tease.md
@@ -1,0 +1,8 @@
+---
+'@hyperlane-xyz/helloworld': minor
+'@hyperlane-xyz/widgets': minor
+'@hyperlane-xyz/infra': minor
+'@hyperlane-xyz/cli': minor
+---
+
+Upgraded @hyperlane-xyz/registry to v14.0.0 and updated warp route config API usage.

--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -8,7 +8,7 @@
     "@eslint/js": "^9.15.0",
     "@ethersproject/abi": "*",
     "@ethersproject/providers": "*",
-    "@hyperlane-xyz/registry": "11.1.0",
+    "@hyperlane-xyz/registry": "14.0.0",
     "@hyperlane-xyz/sdk": "12.5.0",
     "@hyperlane-xyz/utils": "12.5.0",
     "@inquirer/core": "9.0.10",

--- a/typescript/cli/src/commands/config.ts
+++ b/typescript/cli/src/commands/config.ts
@@ -98,7 +98,7 @@ const validateWarpCommand: CommandModuleWithContext<{ path: string }> = {
     path: inputFileCommandOption(),
   },
   handler: async ({ path, context }) => {
-    await readWarpRouteDeployConfig(path, context);
+    await readWarpRouteDeployConfig({ context, filePath: path });
     logGreen('Config is valid');
     process.exit(0);
   },

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -120,7 +120,10 @@ export const apply: CommandModuleWithWriteContext<{
 
     if (strategyUrl)
       ChainSubmissionStrategySchema.parse(readYamlOrJson(strategyUrl));
-    const warpDeployConfig = await readWarpRouteDeployConfig(config, context);
+    const warpDeployConfig = await readWarpRouteDeployConfig({
+      filePath: config,
+      context,
+    });
 
     await runWarpRouteApply({
       context,

--- a/typescript/cli/src/context/types.ts
+++ b/typescript/cli/src/context/types.ts
@@ -6,6 +6,8 @@ import type {
   ChainMap,
   ChainMetadata,
   MultiProvider,
+  WarpCoreConfig,
+  WarpRouteDeployConfigMailboxRequired,
 } from '@hyperlane-xyz/sdk';
 
 export interface ContextSettings {
@@ -35,6 +37,8 @@ export interface WriteCommandContext extends CommandContext {
   signer: ethers.Signer;
   isDryRun?: boolean;
   dryRunChain?: string;
+  warpDeployConfig?: WarpRouteDeployConfigMailboxRequired;
+  warpCoreConfig?: WarpCoreConfig;
 }
 
 export type CommandModuleWithContext<Args> = CommandModule<

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -120,10 +120,10 @@ export async function runWarpRouteDeploy({
       `Using warp route deployment config at ${warpRouteDeploymentConfigPath}`,
     );
   }
-  const warpRouteConfig = await readWarpRouteDeployConfig(
-    warpRouteDeploymentConfigPath,
+  const warpRouteConfig = await readWarpRouteDeployConfig({
+    filePath: warpRouteDeploymentConfigPath,
     context,
-  );
+  });
 
   const chains = Object.keys(warpRouteConfig);
 

--- a/typescript/helloworld/package.json
+++ b/typescript/helloworld/package.json
@@ -4,7 +4,7 @@
   "version": "12.5.0",
   "dependencies": {
     "@hyperlane-xyz/core": "7.1.4",
-    "@hyperlane-xyz/registry": "11.1.0",
+    "@hyperlane-xyz/registry": "14.0.0",
     "@hyperlane-xyz/sdk": "12.5.0",
     "@openzeppelin/contracts-upgradeable": "^4.9.3",
     "ethers": "^5.7.2"

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -14,7 +14,7 @@
     "@ethersproject/providers": "*",
     "@google-cloud/secret-manager": "^5.5.0",
     "@hyperlane-xyz/helloworld": "12.5.0",
-    "@hyperlane-xyz/registry": "11.1.0",
+    "@hyperlane-xyz/registry": "14.0.0",
     "@hyperlane-xyz/sdk": "12.5.0",
     "@hyperlane-xyz/utils": "12.5.0",
     "@inquirer/prompts": "3.3.2",

--- a/typescript/infra/scripts/warp-routes/export-warp-configs.ts
+++ b/typescript/infra/scripts/warp-routes/export-warp-configs.ts
@@ -31,12 +31,11 @@ async function main() {
       },
     );
 
-    const configFileName = `${warpRouteId}-deploy.yaml`;
-    registry.addWarpRouteConfig(registryConfig, configFileName);
+    registry.addWarpRouteConfig(registryConfig, { warpRouteId });
 
     // TODO: Use registry.getWarpRoutesPath() to dynamically generate path by removing "protected"
     console.log(
-      `Warp config successfully created at ${registry.getUri()}/deployments/warp_routes/${configFileName}`,
+      `Warp config successfully created at ${registry.getUri()}/deployments/warp_routes/${warpRouteId}-deploy.yaml`,
     );
   }
 }

--- a/typescript/widgets/package.json
+++ b/typescript/widgets/package.json
@@ -31,7 +31,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@eslint/js": "^9.15.0",
-    "@hyperlane-xyz/registry": "11.1.0",
+    "@hyperlane-xyz/registry": "14.0.0",
     "@storybook/addon-essentials": "^7.6.14",
     "@storybook/addon-interactions": "^7.6.14",
     "@storybook/addon-links": "^7.6.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7644,7 +7644,7 @@ __metadata:
     "@eslint/js": "npm:^9.15.0"
     "@ethersproject/abi": "npm:*"
     "@ethersproject/providers": "npm:*"
-    "@hyperlane-xyz/registry": "npm:11.1.0"
+    "@hyperlane-xyz/registry": "npm:14.0.0"
     "@hyperlane-xyz/sdk": "npm:12.5.0"
     "@hyperlane-xyz/utils": "npm:12.5.0"
     "@inquirer/core": "npm:9.0.10"
@@ -7795,7 +7795,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.15.0"
     "@hyperlane-xyz/core": "npm:7.1.4"
-    "@hyperlane-xyz/registry": "npm:11.1.0"
+    "@hyperlane-xyz/registry": "npm:14.0.0"
     "@hyperlane-xyz/sdk": "npm:12.5.0"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
     "@nomiclabs/hardhat-waffle": "npm:^2.0.6"
@@ -7846,7 +7846,7 @@ __metadata:
     "@ethersproject/providers": "npm:*"
     "@google-cloud/secret-manager": "npm:^5.5.0"
     "@hyperlane-xyz/helloworld": "npm:12.5.0"
-    "@hyperlane-xyz/registry": "npm:11.1.0"
+    "@hyperlane-xyz/registry": "npm:14.0.0"
     "@hyperlane-xyz/sdk": "npm:12.5.0"
     "@hyperlane-xyz/utils": "npm:12.5.0"
     "@inquirer/prompts": "npm:3.3.2"
@@ -7910,13 +7910,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/registry@npm:11.1.0":
-  version: 11.1.0
-  resolution: "@hyperlane-xyz/registry@npm:11.1.0"
+"@hyperlane-xyz/registry@npm:14.0.0":
+  version: 14.0.0
+  resolution: "@hyperlane-xyz/registry@npm:14.0.0"
   dependencies:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/4acb717a1f2d5b2c93237be6cd24406ae6f52eb86a4e5246eee919d5f95866ebdb7d4ce0fff2b193f6f4e29da2bcbe48e525ac958afaaa523e8260863069295d
+  checksum: 10/893c802f8f8206d5a314e8d729ae1f9bf7ae5e66c6034beb0a56e3dcfdb15a532e97f1b8c3ffe394970ccccf3d9129f340d4ad47c27102dafcfcc1c6321ea57b
   languageName: node
   linkType: hard
 
@@ -8020,7 +8020,7 @@ __metadata:
     "@eslint/js": "npm:^9.15.0"
     "@headlessui/react": "npm:^2.1.8"
     "@hyperlane-xyz/cosmos-sdk": "npm:12.5.0"
-    "@hyperlane-xyz/registry": "npm:11.1.0"
+    "@hyperlane-xyz/registry": "npm:14.0.0"
     "@hyperlane-xyz/sdk": "npm:12.5.0"
     "@hyperlane-xyz/utils": "npm:12.5.0"
     "@interchain-ui/react": "npm:^1.23.28"


### PR DESCRIPTION
### Description

This PR refactors the warp route configuration functions to use object parameters instead of positional parameters, improving API clarity and flexibility. The main changes include:

- Modified `readWarpRouteDeployConfig` to accept an object parameter with named properties
- Updated `readWarpCoreConfig` with similar parameter style changes
- Added utility functions for handling warp route configuration in various scenarios
- Enhanced context types with warp configuration properties

### Drive-by changes

- Added new `getWarpRouteDeployConfig` utility function
- Added `useProvidedWarpRouteIdOrPrompt` helper function
- Improved error messaging and assertions

Diff with last PR:
https://github.com/hyperlane-xyz/hyperlane-monorepo/compare/upgrade/registry-14.0.0...refactor/warp-config-loading

### Related issues

https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5244
https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5922

### Backward compatibility

Yes - Internal refactoring only, existing CLI commands work the same way

### Testing

Manual testing of CLI commands