### PR TITLE
fix(submitter): don't use ethers submission middleware

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
@@ -309,6 +309,10 @@ pub struct SubmitterProviderBuilder {}
 impl BuildableWithProvider for SubmitterProviderBuilder {
     type Output = Box<dyn EvmProviderForSubmitter>;
     const NEEDS_SIGNER: bool = true;
+    // the submitter does not use the ethers submission middleware.
+    // it uses its own logic for setting transaction parameters
+    // and landing them onchain
+    const USES_ETHERS_SUBMISSION_MIDDLEWARE: bool = false;
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
@@ -309,10 +309,13 @@ pub struct SubmitterProviderBuilder {}
 impl BuildableWithProvider for SubmitterProviderBuilder {
     type Output = Box<dyn EvmProviderForSubmitter>;
     const NEEDS_SIGNER: bool = true;
+
     // the submitter does not use the ethers submission middleware.
     // it uses its own logic for setting transaction parameters
     // and landing them onchain
-    const USES_ETHERS_SUBMISSION_MIDDLEWARE: bool = false;
+    fn uses_ethers_submission_middleware(&self) -> bool {
+        false
+    }
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -219,6 +219,9 @@ pub trait BuildableWithProvider {
                 .await);
         }
 
+        // The signing provider is used for sending txs, which may end up stuck in the mempool due to
+        // gas pricing issues. We first wrap the provider in a signer middleware, to sign any new txs sent by the gas escalator middleware.
+        // We keep nonce manager as the outermost middleware, so that resubmitting a tx with a higher gas price reuses its initial nonce.
         let gas_escalator_provider = wrap_with_gas_escalator(signing_provider);
         let gas_oracle_provider = wrap_with_gas_oracle(gas_escalator_provider, locator.domain)?;
         let nonce_manager_provider = wrap_with_nonce_manager(gas_oracle_provider, signer.address())

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -65,6 +65,11 @@ pub trait BuildableWithProvider {
     /// Whether this provider requires a signer
     const NEEDS_SIGNER: bool;
 
+    /// Whether this provider requires submission middleware such as gas oracle,
+    /// gas escalator, nonce manager. It defaults to true, since it's only Lander
+    /// that doesn't require it.
+    const USES_ETHERS_SUBMISSION_MIDDLEWARE: bool = true;
+
     /// Construct a new instance of the associated trait using a connection
     /// config. This is the first step and will wrap the provider with
     /// metrics and a signer as needed.
@@ -200,25 +205,29 @@ pub trait BuildableWithProvider {
     where
         M: Middleware + 'static,
     {
-        Ok(if let Some(signer) = signer {
-            // The signing provider is used for sending txs, which may end up stuck in the mempool due to
-            // gas pricing issues. We first wrap the provider in a signer middleware, to sign any new txs sent by the gas escalator middleware.
-            // We keep nonce manager as the outermost middleware, so that every new tx with a higher gas price reuses the same nonce.
-            let signing_provider = wrap_with_signer(provider, signer.clone())
-                .await
-                .map_err(ChainCommunicationError::from_other)?;
-            let gas_escalator_provider = wrap_with_gas_escalator(signing_provider);
-            let gas_oracle_provider = wrap_with_gas_oracle(gas_escalator_provider, locator.domain)?;
-            let nonce_manager_provider =
-                wrap_with_nonce_manager(gas_oracle_provider, signer.address())
-                    .await
-                    .map_err(ChainCommunicationError::from_other)?;
+        let Some(signer) = signer else {
+            return Ok(self.build_with_provider(provider, conn, locator).await);
+        };
+        let signing_provider = wrap_with_signer(provider, signer.clone())
+            .await
+            .map_err(ChainCommunicationError::from_other)?;
 
-            self.build_with_provider(nonce_manager_provider, conn, locator)
-        } else {
-            self.build_with_provider(provider, conn, locator)
+        if !Self::USES_ETHERS_SUBMISSION_MIDDLEWARE {
+            // don't wrap the signing provider in any middlewares
+            return Ok(self
+                .build_with_provider(signing_provider, conn, locator)
+                .await);
         }
-        .await)
+
+        let gas_escalator_provider = wrap_with_gas_escalator(signing_provider);
+        let gas_oracle_provider = wrap_with_gas_oracle(gas_escalator_provider, locator.domain)?;
+        let nonce_manager_provider = wrap_with_nonce_manager(gas_oracle_provider, signer.address())
+            .await
+            .map_err(ChainCommunicationError::from_other)?;
+
+        Ok(self
+            .build_with_provider(nonce_manager_provider, conn, locator)
+            .await)
     }
 
     /// Construct a new instance of the associated trait using a provider.

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -68,7 +68,9 @@ pub trait BuildableWithProvider {
     /// Whether this provider requires submission middleware such as gas oracle,
     /// gas escalator, nonce manager. It defaults to true, since it's only Lander
     /// that doesn't require it.
-    const USES_ETHERS_SUBMISSION_MIDDLEWARE: bool = true;
+    fn uses_ethers_submission_middleware(&self) -> bool {
+        true
+    }
 
     /// Construct a new instance of the associated trait using a connection
     /// config. This is the first step and will wrap the provider with
@@ -212,7 +214,7 @@ pub trait BuildableWithProvider {
             .await
             .map_err(ChainCommunicationError::from_other)?;
 
-        if !Self::USES_ETHERS_SUBMISSION_MIDDLEWARE {
+        if !self.uses_ethers_submission_middleware() {
             // don't wrap the signing provider in any middlewares
             return Ok(self
                 .build_with_provider(signing_provider, conn, locator)


### PR DESCRIPTION
### Description

**When reviewing, make double sure the changes in `build_with_signer` make sense, otherwise this can break prod**

Since the new submitter has its own logic for setting tx parameters, so ethers middleware like the gas escalator, nonce manager, etc isn't required. This PR makes the usage of middleware configurable, via an associated const in `BuildableWithProvider` that defaults to `true`. This const is only ever used if `NEEDS_SIGNER` is `true`

### Drive-by changes

Cleans up the provider-building logic in `build_with_signer`

### Related issues

- Fixes: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/6163

### Backward compatibility

**Yes - but make double sure the changes in `build_with_signer` make sense, otherwise this can break prod**

### Testing

EVM E2E
