### PR TITLE
fix: Estimate gas before sending rebalance transactions

### DIFF
--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -488,7 +488,15 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
       chain2Metadata.domainId,
     );
 
-    await startRebalancerAndExpectLog('❌ Some rebalance transaction failed');
+    await startRebalancerAndExpectLog(`❌ Could not estimate gas for route {
+  fromChain: 'anvil3',
+  toChain: 'anvil2',
+  amount: 5000000000000000000n
+}`);
+
+    await startRebalancerAndExpectLog(
+      '❌ Could not estimate gas for some routes',
+    );
   });
 
   it('should successfully send rebalance transaction', async () => {


### PR DESCRIPTION
This allows verifying that all rebalance transactions can be executed before sending them, helping prevent incomplete rebalances caused by a failure in any transaction within the batch.