### PR TITLE
feat(rework): cli warp check should assert that contracts are verified

### DIFF
--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -410,7 +410,7 @@ export const check: CommandModuleWithContext<{
       multiProvider: context.multiProvider,
       warpDeployConfig,
       deployedRoutersAddresses,
-      virtualConfig: expandedOnChainWarpConfig,
+      expandedOnChainWarpConfig,
     });
     expandedWarpDeployConfig = objFilter(
       expandedWarpDeployConfig,

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -623,7 +623,6 @@ async function updateExistingWarpRoute(
     multiProvider,
     warpDeployConfig,
     deployedRoutersAddresses,
-    includeVirtual: false,
   });
 
   await promiseObjAll(

--- a/typescript/sdk/src/deploy/verify/ContractVerifier.ts
+++ b/typescript/sdk/src/deploy/verify/ContractVerifier.ts
@@ -365,7 +365,9 @@ export class ContractVerifier {
         ? ContractVerificationStatus.Verified
         : ContractVerificationStatus.Unverified;
     } catch (e) {
-      this.logger.info(`Error fetching contract verification status: ${e}`);
+      this.logger.info(
+        `Error fetching contract verification status for ${address} on chain ${chain}: ${e}`,
+      );
       return ContractVerificationStatus.Error;
     }
   }

--- a/typescript/sdk/src/deploy/verify/ContractVerifier.ts
+++ b/typescript/sdk/src/deploy/verify/ContractVerifier.ts
@@ -340,6 +340,12 @@ export class ContractVerifier {
     address: Address,
     verificationLogger: Logger,
   ): Promise<{ isVerified: false } | { isVerified: true; name: string }> {
+    const metadata = this.multiProvider.tryGetChainMetadata(chain);
+    const rpcUrl = metadata?.rpcUrls[0].http ?? '';
+    if (rpcUrl.includes('localhost') || rpcUrl.includes('127.0.0.1')) {
+      verificationLogger.debug('Skipping verification for local endpoints');
+      return { isVerified: false };
+    }
     verificationLogger.trace(
       `Fetching contract ABI for ${chain} address ${address}`,
     );

--- a/typescript/sdk/src/deploy/verify/types.ts
+++ b/typescript/sdk/src/deploy/verify/types.ts
@@ -67,6 +67,12 @@ export const EXPLORER_GET_ACTIONS = [
   ExplorerApiActions.GETSOURCECODE,
 ];
 
+export enum VerifyContractTypes {
+  Proxy = 'proxy',
+  ProxyAdmin = 'proxyAdmin',
+  Implementation = 'implementation',
+}
+
 export enum ExplorerApiErrors {
   ALREADY_VERIFIED = 'Contract source code already verified',
   ALREADY_VERIFIED_ALT = 'Already Verified',

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -565,7 +565,7 @@ export { HypERC20Checker } from './token/checker.js';
 export { TokenType } from './token/config.js';
 export {
   expandWarpDeployConfig,
-  expandOnChainWarpDeployConfig,
+  expandVirtualWarpDeployConfig,
   getRouterAddressesFromWarpCoreConfig,
   splitWarpCoreAndExtendedConfigs,
   transformConfigToCheck,

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -25,6 +25,7 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
+import { VerifyContractTypes } from '../deploy/verify/types.js';
 import { EvmHookReader } from '../hook/EvmHookReader.js';
 import { EvmIsmReader } from '../ism/EvmIsmReader.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
@@ -146,13 +147,13 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
     };
 
     const contractType = (await isProxy(this.provider, address))
-      ? 'Proxy'
-      : 'Implementation';
+      ? VerifyContractTypes.Proxy
+      : VerifyContractTypes.Implementation;
 
     virtualConfig.contractVerificationStatus[contractType] =
       await this.contractVerifier.getContractVerificationStatus(chain, address);
 
-    if (contractType === 'Proxy') {
+    if (contractType === VerifyContractTypes.Proxy) {
       virtualConfig.contractVerificationStatus.Implementation =
         await this.contractVerifier.getContractVerificationStatus(
           chain,

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -147,7 +147,7 @@ export async function expandWarpDeployConfig(params: {
 
     // Expand EVM warpDeployConfig virtual to the control states
     if (
-      expandedOnChainWarpConfig?.[chain].contractVerificationStatus &&
+      expandedOnChainWarpConfig?.[chain]?.contractVerificationStatus &&
       multiProvider.getProtocol(chain) === ProtocolType.Ethereum
     ) {
       // For most cases, we set to Verified

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -180,15 +180,13 @@ export async function expandVirtualWarpDeployConfig(params: {
   onChainWarpConfig: WarpRouteDeployConfigMailboxRequired;
   deployedRoutersAddresses: ChainMap<Address>;
 }): Promise<WarpRouteDeployConfigMailboxRequired> {
+  const { multiProvider, deployedRoutersAddresses } = params;
   return promiseObjAll(
     objMap(params.onChainWarpConfig, async (chain, config) => {
-      const warpReader = new EvmERC20WarpRouteReader(
-        params.multiProvider,
-        chain,
-      );
+      const warpReader = new EvmERC20WarpRouteReader(multiProvider, chain);
       const warpVirtualConfig = await warpReader.deriveWarpRouteVirtualConfig(
         chain,
-        params.deployedRoutersAddresses[chain],
+        deployedRoutersAddresses[chain],
       );
       return {
         ...warpVirtualConfig,

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -21,6 +21,7 @@ import { EvmERC20WarpRouteReader } from './EvmERC20WarpRouteReader.js';
 import { gasOverhead } from './config.js';
 import { HypERC20Deployer } from './deploy.js';
 import {
+  ContractVerificationStatus,
   HypTokenRouterConfig,
   HypTokenRouterVirtualConfig,
   WarpRouteDeployConfig,
@@ -144,13 +145,19 @@ export async function expandWarpDeployConfig(params: {
       ...config,
     };
 
-    // Virtual Config Expansion
+    // Expand warpDeployConfig virtual to the control states
     if (expandedOnChainWarpConfig?.[chain].contractVerificationStatus) {
-      // Copy & set all virtual config values to compare
-      // chainConfig.contractVerificationStatus = objMap(
-      //   expandedOnChainWarpConfig[chain].contractVerificationStatus,
-      //   () => ContractVerificationStatus.Verified,
-      // );
+      // For most cases, we set to Verified
+      chainConfig.contractVerificationStatus = objMap(
+        expandedOnChainWarpConfig[chain].contractVerificationStatus ?? {},
+        (_, status) => {
+          // Skipped for local e2e testing
+          if (status === ContractVerificationStatus.Skipped)
+            return ContractVerificationStatus.Skipped;
+
+          return ContractVerificationStatus.Verified;
+        },
+      );
     }
 
     // Properly set the remote routers addresses to their 32 bytes representation

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -146,16 +146,16 @@ export async function expandWarpDeployConfig(params: {
     };
 
     // Expand EVM warpDeployConfig virtual to the control states
-    if (expandedOnChainWarpConfig?.[chain].contractVerificationStatus) {
+    if (
+      expandedOnChainWarpConfig?.[chain].contractVerificationStatus &&
+      multiProvider.getProtocol(chain) === ProtocolType.Ethereum
+    ) {
       // For most cases, we set to Verified
       chainConfig.contractVerificationStatus = objMap(
         expandedOnChainWarpConfig[chain].contractVerificationStatus ?? {},
         (_, status) => {
           // Skipped for local e2e testing
-          if (
-            status === ContractVerificationStatus.Skipped ||
-            !(multiProvider.getProtocol(chain) == ProtocolType.Ethereum)
-          )
+          if (status === ContractVerificationStatus.Skipped)
             return ContractVerificationStatus.Skipped;
 
           return ContractVerificationStatus.Verified;

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -146,16 +146,16 @@ export async function expandWarpDeployConfig(params: {
     };
 
     // Expand EVM warpDeployConfig virtual to the control states
-    if (
-      expandedOnChainWarpConfig?.[chain].contractVerificationStatus &&
-      multiProvider.getProtocol(chain) === ProtocolType.Ethereum
-    ) {
+    if (expandedOnChainWarpConfig?.[chain].contractVerificationStatus) {
       // For most cases, we set to Verified
       chainConfig.contractVerificationStatus = objMap(
         expandedOnChainWarpConfig[chain].contractVerificationStatus ?? {},
         (_, status) => {
           // Skipped for local e2e testing
-          if (status === ContractVerificationStatus.Skipped)
+          if (
+            status === ContractVerificationStatus.Skipped ||
+            !(multiProvider.getProtocol(chain) == ProtocolType.Ethereum)
+          )
             return ContractVerificationStatus.Skipped;
 
           return ContractVerificationStatus.Verified;

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -19,7 +19,6 @@ import { WarpCoreConfig } from '../warp/types.js';
 
 import { EvmERC20WarpRouteReader } from './EvmERC20WarpRouteReader.js';
 import { gasOverhead } from './config.js';
-import { hypERC20contracts } from './contracts.js';
 import { HypERC20Deployer } from './deploy.js';
 import {
   HypTokenRouterConfig,
@@ -87,23 +86,20 @@ export function getRouterAddressesFromWarpCoreConfig(
  * @param multiProvider
  * @param warpDeployConfig - The warp deployment config
  * @param deployedRoutersAddresses - Addresses of deployed routers for each chain
- * @param includeVirtual - Optional flag to expand virtual config details
+ * @param virtualConfig - Optional virtual config to include in the warpDeployConfig
  * @returns A promise resolving to an expanded Warp deploy config with derived and virtual metadata
  */
 export async function expandWarpDeployConfig(params: {
   multiProvider: MultiProvider;
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
   deployedRoutersAddresses: ChainMap<Address>;
-  includeVirtual: boolean;
-}): Promise<
-  WarpRouteDeployConfigMailboxRequired &
-    Record<string, Partial<HypTokenRouterVirtualConfig>>
-> {
+  expandedOnChainWarpConfig?: WarpRouteDeployConfigMailboxRequired;
+}): Promise<WarpRouteDeployConfigMailboxRequired> {
   const {
     multiProvider,
     warpDeployConfig,
     deployedRoutersAddresses,
-    includeVirtual,
+    expandedOnChainWarpConfig,
   } = params;
 
   const derivedTokenMetadata = await HypERC20Deployer.deriveTokenMetadata(
@@ -149,16 +145,12 @@ export async function expandWarpDeployConfig(params: {
     };
 
     // Virtual Config Expansion
-    if (includeVirtual) {
-      chainConfig.contractVerificationStatus = {
-        [hypERC20contracts[config.type]]: true,
-      };
-
-      if (isDeployedAsProxyByChain[chain]) {
-        chainConfig.contractVerificationStatus.TransparentUpgradeableProxy =
-          true;
-        chainConfig.contractVerificationStatus.ProxyAdmin = true;
-      }
+    if (expandedOnChainWarpConfig?.[chain].contractVerificationStatus) {
+      // Copy & set all virtual config values to compare
+      // chainConfig.contractVerificationStatus = objMap(
+      //   expandedOnChainWarpConfig[chain].contractVerificationStatus,
+      //   () => ContractVerificationStatus.Verified,
+      // );
     }
 
     // Properly set the remote routers addresses to their 32 bytes representation
@@ -176,19 +168,20 @@ export async function expandWarpDeployConfig(params: {
   });
 }
 
-export async function expandOnChainWarpDeployConfig(params: {
+export async function expandVirtualWarpDeployConfig(params: {
   multiProvider: MultiProvider;
-  warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
+  onChainWarpConfig: WarpRouteDeployConfigMailboxRequired;
   deployedRoutersAddresses: ChainMap<Address>;
-}) {
-  const { multiProvider, warpDeployConfig, deployedRoutersAddresses } = params;
-
+}): Promise<WarpRouteDeployConfigMailboxRequired> {
   return promiseObjAll(
-    objMap(warpDeployConfig, async (chain, config) => {
-      const warpReader = new EvmERC20WarpRouteReader(multiProvider, chain);
+    objMap(params.onChainWarpConfig, async (chain, config) => {
+      const warpReader = new EvmERC20WarpRouteReader(
+        params.multiProvider,
+        chain,
+      );
       const warpVirtualConfig = await warpReader.deriveWarpRouteVirtualConfig(
         chain,
-        deployedRoutersAddresses[chain],
+        params.deployedRoutersAddresses[chain],
       );
       return {
         ...warpVirtualConfig,

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -180,9 +180,9 @@ export async function expandVirtualWarpDeployConfig(params: {
   onChainWarpConfig: WarpRouteDeployConfigMailboxRequired;
   deployedRoutersAddresses: ChainMap<Address>;
 }): Promise<WarpRouteDeployConfigMailboxRequired> {
-  const { multiProvider, deployedRoutersAddresses } = params;
+  const { multiProvider, onChainWarpConfig, deployedRoutersAddresses } = params;
   return promiseObjAll(
-    objMap(params.onChainWarpConfig, async (chain, config) => {
+    objMap(onChainWarpConfig, async (chain, config) => {
       const warpReader = new EvmERC20WarpRouteReader(multiProvider, chain);
       const warpVirtualConfig = await warpReader.deriveWarpRouteVirtualConfig(
         chain,

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -145,8 +145,11 @@ export async function expandWarpDeployConfig(params: {
       ...config,
     };
 
-    // Expand warpDeployConfig virtual to the control states
-    if (expandedOnChainWarpConfig?.[chain].contractVerificationStatus) {
+    // Expand EVM warpDeployConfig virtual to the control states
+    if (
+      expandedOnChainWarpConfig?.[chain].contractVerificationStatus &&
+      multiProvider.getProtocol(chain) === ProtocolType.Ethereum
+    ) {
       // For most cases, we set to Verified
       chainConfig.contractVerificationStatus = objMap(
         expandedOnChainWarpConfig[chain].contractVerificationStatus ?? {},

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -128,7 +128,6 @@ export const HypTokenRouterVirtualConfigSchema = z.object({
       ContractVerificationStatus.Skipped,
     ]),
   ),
-  // .optional(),
 });
 export type HypTokenRouterVirtualConfig = z.infer<
   typeof HypTokenRouterVirtualConfigSchema

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -117,17 +117,18 @@ export enum ContractVerificationStatus {
   Verified = 'verified',
   Unverified = 'unverified',
   Error = 'error',
+  Skipped = 'skipped',
 }
 export const HypTokenRouterVirtualConfigSchema = z.object({
-  contractVerificationStatus: z
-    .record(
-      z.enum([
-        ContractVerificationStatus.Verified,
-        ContractVerificationStatus.Unverified,
-        ContractVerificationStatus.Error,
-      ]),
-    )
-    .optional(),
+  contractVerificationStatus: z.record(
+    z.enum([
+      ContractVerificationStatus.Verified,
+      ContractVerificationStatus.Unverified,
+      ContractVerificationStatus.Error,
+      ContractVerificationStatus.Skipped,
+    ]),
+  ),
+  // .optional(),
 });
 export type HypTokenRouterVirtualConfig = z.infer<
   typeof HypTokenRouterVirtualConfigSchema

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -113,6 +113,26 @@ export const isSyntheticRebaseTokenConfig = isCompliant(
   SyntheticRebaseTokenConfigSchema,
 );
 
+export enum ContractVerificationStatus {
+  Verified = 'verified',
+  Unverified = 'unverified',
+  Error = 'error',
+}
+export const HypTokenRouterVirtualConfigSchema = z.object({
+  contractVerificationStatus: z
+    .record(
+      z.enum([
+        ContractVerificationStatus.Verified,
+        ContractVerificationStatus.Unverified,
+        ContractVerificationStatus.Error,
+      ]),
+    )
+    .optional(),
+});
+export type HypTokenRouterVirtualConfig = z.infer<
+  typeof HypTokenRouterVirtualConfigSchema
+>;
+
 /**
  * @remarks
  * The discriminatedUnion is basically a switch statement for zod schemas
@@ -129,7 +149,8 @@ export type HypTokenConfig = z.infer<typeof HypTokenConfigSchema>;
 
 export const HypTokenRouterConfigSchema = HypTokenConfigSchema.and(
   GasRouterConfigSchema,
-);
+).and(HypTokenRouterVirtualConfigSchema.partial());
+
 export type HypTokenRouterConfig = z.infer<typeof HypTokenRouterConfigSchema>;
 
 export type DerivedTokenRouterConfig = z.infer<typeof HypTokenConfigSchema> &
@@ -154,7 +175,7 @@ export const HypTokenRouterConfigMailboxOptionalSchema =
     GasRouterConfigSchema.extend({
       mailbox: z.string().optional(),
     }),
-  );
+  ).and(HypTokenRouterVirtualConfigSchema.partial());
 
 export type HypTokenRouterConfigMailboxOptional = z.infer<
   typeof HypTokenRouterConfigMailboxOptionalSchema
@@ -374,10 +395,3 @@ function extractCCIPIsmMap(
       break;
   }
 }
-
-export const HypTokenRouterVirtualConfigSchema = z.object({
-  contractVerificationStatus: z.record(z.boolean()),
-});
-export type HypTokenRouterVirtualConfig = z.infer<
-  typeof HypTokenRouterVirtualConfigSchema
->;


### PR DESCRIPTION
### Description
- Reworked ContractVerifer.getContractVerificationStatus() to output a status instead of boolean. This allows more granular statuses for statuses such as `Skipped`.
- Update derive contract status to no longer include the actual token contract name and to instead just say `Implementation`. This reduces code complexity and can be featured in later, if needed.
- Add `HypTokenRouterVirtualConfigSchema` to `HypTokenRouterConfigMailboxOptionalSchema`

### Testing
Manual
