### PR TITLE
fix: re-add registry commit to docker entry

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,7 +13,7 @@ if [ -n "$REGISTRY_COMMIT" ]; then
   echo "Updating Hyperlane registry to: $REGISTRY_COMMIT"
   OLDPWD=$(pwd)
   cd "$REGISTRY_URI"
-  git fetch origin
+  git fetch origin "$REGISTRY_COMMIT"
   git checkout "$REGISTRY_COMMIT"
 
   # Only reset if it's a branch


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
Re-add registry commit to `git fetch origin` in docker-entrypoint.sh
### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
