### PR TITLE
fix: Only rebalance EvmHypCollateralAdapter tokens

### DIFF
--- a/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
+++ b/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
@@ -15,6 +15,7 @@ import { Metrics } from '../metrics/Metrics.js';
 import { PriceGetter } from '../metrics/PriceGetter.js';
 import { Monitor } from '../monitor/Monitor.js';
 import { Strategy } from '../strategy/Strategy.js';
+import { MonitorToStrategyTransformer } from '../transformers/MonitorToStrategyTransformer.js';
 
 export class RebalancerContextFactory {
   /**
@@ -93,5 +94,9 @@ export class RebalancerContextFactory {
       this.warpCore,
       this.metadata,
     );
+  }
+
+  public createMonitorToStrategyTransformer(): MonitorToStrategyTransformer {
+    return new MonitorToStrategyTransformer(this.warpCore);
   }
 }

--- a/typescript/cli/src/rebalancer/interfaces/IStrategy.ts
+++ b/typescript/cli/src/rebalancer/interfaces/IStrategy.ts
@@ -1,6 +1,6 @@
-import { ChainName } from '@hyperlane-xyz/sdk';
+import { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
 
-export type RawBalances = Record<ChainName, bigint>;
+export type RawBalances = ChainMap<bigint>;
 
 export type RebalancingRoute = {
   fromChain: ChainName;

--- a/typescript/cli/src/rebalancer/interfaces/ITransformer.ts
+++ b/typescript/cli/src/rebalancer/interfaces/ITransformer.ts
@@ -1,0 +1,3 @@
+export interface ITransformer<T, R> {
+  transform(from: T): R;
+}

--- a/typescript/cli/src/rebalancer/transformers/MonitorToStrategyTransformer.ts
+++ b/typescript/cli/src/rebalancer/transformers/MonitorToStrategyTransformer.ts
@@ -1,0 +1,30 @@
+import { EvmHypCollateralAdapter, WarpCore } from '@hyperlane-xyz/sdk';
+
+import { MonitorEvent } from '../interfaces/IMonitor.js';
+import { RawBalances } from '../interfaces/IStrategy.js';
+import { ITransformer } from '../interfaces/ITransformer.js';
+
+export class MonitorToStrategyTransformer
+  implements ITransformer<MonitorEvent, RawBalances>
+{
+  constructor(private readonly warpCore: WarpCore) {}
+
+  transform(event: MonitorEvent): RawBalances {
+    return event.tokensInfo.reduce((acc, tokenInfo) => {
+      const provider = this.warpCore.multiProvider;
+      const adapter = tokenInfo.token.getHypAdapter(provider);
+
+      if (adapter instanceof EvmHypCollateralAdapter) {
+        if (tokenInfo.bridgedSupply === undefined) {
+          throw new Error(
+            `bridgedSupply should not be undefined for collateralized token ${tokenInfo.token.addressOrDenom}`,
+          );
+        }
+
+        acc[tokenInfo.token.chainName] = tokenInfo.bridgedSupply;
+      }
+
+      return acc;
+    }, {} as RawBalances);
+  }
+}


### PR DESCRIPTION
Previous implementation was allowing tokens that could not be rebalanced