### PR TITLE
feat: reduce ccip read dos vector

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
@@ -1,8 +1,7 @@
-#![allow(clippy::blocks_in_conditions)]
+#![allow(clippy::blocks_in_conditions)] // TODO: `rustc` 1.80.1 clippy issue
 
 use std::time::Duration;
 
-// TODO: `rustc` 1.80.1 clippy issue
 use async_trait::async_trait;
 use cache_types::SerializedOffchainLookup;
 use derive_more::Deref;


### PR DESCRIPTION
### Description

 - add a 30s timeout on CCIP read requests
 - add a regex to prevent localhost, or local IP address requests

### Related issues

- https://linear.app/hyperlane-xyz/issue/ENG-1614/relayer-ccip-read-dos-vector-potential-security-concerns

### Backward compatibility

Yes

### Testing

Add unit test to ensure regex is correct
