### PR TITLE
fix(ICA): Remove ica from commitment 

### DIFF
--- a/solidity/contracts/isms/ccip-read/CommitmentReadIsm.sol
+++ b/solidity/contracts/isms/ccip-read/CommitmentReadIsm.sol
@@ -72,12 +72,7 @@ contract CommitmentReadIsm is AbstractCcipReadIsm, Ownable {
             "Commitment ISM: Revealed Hash Invalid"
         );
 
-        // Revert if this is not the ica's currently active commitment
-        require(
-            ica.commitment() == msgCommitment,
-            "Commitment ISM: Invalid Commitment"
-        );
-
+        // The ica will check if the commitment is currently active, reverting if not.
         ica.revealAndExecute(calls, salt);
 
         return true;

--- a/solidity/contracts/isms/ccip-read/CommitmentReadIsm.sol
+++ b/solidity/contracts/isms/ccip-read/CommitmentReadIsm.sol
@@ -54,7 +54,7 @@ contract CommitmentReadIsm is AbstractCcipReadIsm, Ownable {
 
     /**
      * @notice Verifies the commitment by comparing the calldata hash to the commitment
-     * @param _metadata The encoded (salt, calls) whose hash is the commitment
+     * @param _metadata The encoded (ica, salt, calls)
      * @param _message The reveal hyperlane message
      * @return true If the hash of the metadata matches the commitment.
      */
@@ -62,10 +62,12 @@ contract CommitmentReadIsm is AbstractCcipReadIsm, Ownable {
         bytes calldata _metadata,
         bytes calldata _message
     ) external returns (bool) {
-        (CallLib.Call[] memory calls, bytes32 salt, OwnableMulticall ica) = abi
-            .decode(_metadata, (CallLib.Call[], bytes32, OwnableMulticall));
+        // Fetch encoded calls and salt
+        (OwnableMulticall ica, bytes32 salt, CallLib.Call[] memory calls) = abi
+            .decode(_metadata, (OwnableMulticall, bytes32, CallLib.Call[]));
 
-        bytes32 revealedHash = keccak256(_metadata);
+        // This is hash(salt, calls). The ica address is excluded
+        bytes32 revealedHash = keccak256(abi.encode(salt, calls));
         bytes32 msgCommitment = _message.body().commitment();
         require(
             revealedHash == msgCommitment,

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -319,12 +319,7 @@ contract InterchainAccountRouter is Router, AbstractRoutingIsm {
             ica.multicall{value: msg.value}(calls);
         } else {
             // This is definitely a message of type COMMITMENT
-            require(
-                ica.commitment() == bytes32(0),
-                "ICA Router: Previous commitment pending execution"
-            );
-            bytes32 _commitment = _message.commitment();
-            ica.setCommitment(_commitment);
+            ica.setCommitment(_message.commitment());
         }
     }
 

--- a/solidity/contracts/middleware/libs/OwnableMulticall.sol
+++ b/solidity/contracts/middleware/libs/OwnableMulticall.sol
@@ -47,7 +47,9 @@ contract OwnableMulticall {
         bytes32 salt
     ) external payable returns (bytes32 executedCommitment) {
         // Check if metadata matches stored commitment (checks)
-        bytes32 revealedHash = keccak256(abi.encode(salt, calls));
+        bytes32 revealedHash = keccak256(
+            abi.encodePacked(salt, abi.encode(calls))
+        );
         require(commitment == revealedHash, "ICA: Invalid Reveal");
 
         // Delete the commitment (effects)

--- a/solidity/contracts/middleware/libs/OwnableMulticall.sol
+++ b/solidity/contracts/middleware/libs/OwnableMulticall.sol
@@ -42,11 +42,9 @@ contract OwnableMulticall {
         CallLib.Call[] calldata calls,
         bytes32 salt
     ) external payable returns (bytes32 executedCommitment) {
-        // If there is no active commitment, do nothing.
-        if (commitment == bytes32(0)) return bytes32(0);
-
+        // Check if metadata matches stored commitment (checks)
         bytes32 revealedHash = keccak256(abi.encode(calls, salt, this));
-        require(commitment == revealedHash, "Invalid Reveal");
+        require(commitment == revealedHash, "ICA: Invalid Reveal");
 
         // Delete the commitment (effects)
         executedCommitment = commitment;

--- a/solidity/contracts/middleware/libs/OwnableMulticall.sol
+++ b/solidity/contracts/middleware/libs/OwnableMulticall.sol
@@ -33,6 +33,10 @@ contract OwnableMulticall {
     /// @notice Sets the commitment value that will be executed next
     /// @param _commitment The new commitment value to be set
     function setCommitment(bytes32 _commitment) external onlyOwner {
+        require(
+            commitment == bytes32(0),
+            "ICA: Previous commitment pending execution"
+        );
         commitment = _commitment;
     }
 

--- a/solidity/contracts/middleware/libs/OwnableMulticall.sol
+++ b/solidity/contracts/middleware/libs/OwnableMulticall.sol
@@ -47,7 +47,7 @@ contract OwnableMulticall {
         bytes32 salt
     ) external payable returns (bytes32 executedCommitment) {
         // Check if metadata matches stored commitment (checks)
-        bytes32 revealedHash = keccak256(abi.encode(calls, salt, this));
+        bytes32 revealedHash = keccak256(abi.encode(salt, calls));
         require(commitment == revealedHash, "ICA: Invalid Reveal");
 
         // Delete the commitment (effects)

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -884,7 +884,7 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
     ) public {
         // Arrange
         CallLib.Call[] memory calls = getCalls(data, value);
-        bytes32 commitment = keccak256(abi.encode(calls, salt, ica));
+        bytes32 commitment = keccak256(abi.encode(salt, calls));
         deal(address(ica), value); // Ensure ICA has enough balance to execute calls
 
         // Act
@@ -922,7 +922,7 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
     ) public {
         // Arrange
         CallLib.Call[] memory calls = getCalls(data, value);
-        bytes32 commitment = keccak256(abi.encode(calls, salt, ica));
+        bytes32 commitment = keccak256(abi.encode(salt, calls));
         deal(address(ica), value); // Ensure ICA has enough balance to execute calls
 
         // Act
@@ -946,7 +946,7 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
             address(destinationIcaRouter.mailbox())
         );
         bytes memory message = _mailbox.inboundMessages(1);
-        bytes memory metadata = abi.encode(calls, salt, ica);
+        bytes memory metadata = abi.encode(ica, salt, calls);
         _mailbox.addInboundMetadata(1, metadata); // Metadata can fetched by other callers
         environment.processNextPendingMessage();
 
@@ -980,7 +980,7 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
     ) public {
         // Arrange
         CallLib.Call[] memory calls = getCalls(data, value);
-        bytes32 commitment = keccak256(abi.encode(calls, salt, ica));
+        bytes32 commitment = keccak256(abi.encode(salt, calls));
         deal(address(ica), value); // Ensure ICA has enough balance to execute calls
         // Act
         originIcaRouter.callRemoteCommitReveal(
@@ -1006,7 +1006,7 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
             address(destinationIcaRouter.mailbox())
         );
         bytes memory message = _mailbox.inboundMessages(1);
-        bytes memory metadata = abi.encode(calls, salt, ica);
+        bytes memory metadata = abi.encode(ica, salt, calls);
         CommitmentReadIsm _ism = destinationIcaRouter.CCIP_READ_ISM();
         vm.expectRevert("ICA: Invalid Reveal");
         _ism.process(metadata, message);

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -911,8 +911,8 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
         assertEq(ica.commitment(), bytes32(0));
 
         // Cannot reveal twice
-        executedCommitment = ica.revealAndExecute(calls, salt);
-        assertEq(executedCommitment, bytes32(0));
+        vm.expectRevert("ICA: Invalid Reveal");
+        ica.revealAndExecute(calls, salt);
     }
 
     function testFuzz_readIsm_verify(
@@ -969,7 +969,7 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
         bytes memory metadata = _mailbox.inboundMetadata(1);
 
         CommitmentReadIsm _ism = destinationIcaRouter.CCIP_READ_ISM();
-        vm.expectRevert("Commitment ISM: Invalid Commitment");
+        vm.expectRevert("ICA: Invalid Reveal");
         _ism.verify(metadata, message);
     }
 
@@ -1008,7 +1008,7 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
         bytes memory message = _mailbox.inboundMessages(1);
         bytes memory metadata = abi.encode(calls, salt, ica);
         CommitmentReadIsm _ism = destinationIcaRouter.CCIP_READ_ISM();
-        vm.expectRevert("Commitment ISM: Invalid Commitment");
+        vm.expectRevert("ICA: Invalid Reveal");
         _ism.process(metadata, message);
     }
 

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -1088,4 +1088,20 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
             originIcaRouter.owner()
         );
     }
+
+    function testFuzz_revert_commitTwice(bytes32 commitment) public {
+        // We need to deploy the ica here, since it's usually lazy deployed in `handle`, but handle is never called.
+        ica = destinationIcaRouter.getDeployedInterchainAccount(
+            origin,
+            address(this),
+            address(originIcaRouter),
+            address(environment.isms(destination))
+        );
+
+        vm.startPrank(address(destinationIcaRouter));
+        ica.setCommitment(commitment);
+
+        vm.expectRevert("ICA: Previous commitment pending execution");
+        ica.setCommitment(commitment);
+    }
 }


### PR DESCRIPTION
### Description

The commitment is simply `hash(salt, calls)`. 

### Drive by
- Remove redundant checks on revealed data
- Move check on existing commitment into ICA.