### PR TITLE
chore: add logs to the rebalancer flow

### DIFF
--- a/typescript/cli/.mocharc.json
+++ b/typescript/cli/.mocharc.json
@@ -4,5 +4,6 @@
   "node-option": [
     "experimental-specifier-resolution=node",
     "loader=ts-node/esm"
-  ]
+  ],
+  "require": ["src/tests/test-setup.ts"]
 }

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -26,12 +26,12 @@ import {
   logBlue,
   logCommandHeader,
   logGreen,
+  warnYellow,
 } from '../logger.js';
 import { runWarpRouteRead } from '../read/warp.js';
 import {
   BaseConfig,
   Config,
-  IStrategy,
   RebalancerContextFactory,
 } from '../rebalancer/index.js';
 // TODO: This import should come from the IMonitor interface
@@ -490,6 +490,7 @@ export const rebalancer: CommandModuleWithWriteContext<{
         coingeckoApiKey,
         rebalanceStrategy: rebalanceStrategy as BaseConfig['rebalanceStrategy'],
       });
+      logGreen('✅ Loaded rebalancer config');
 
       // Instantiate the factory used to create the different rebalancer components
       const contextFactory = await RebalancerContextFactory.create(
@@ -501,17 +502,29 @@ export const rebalancer: CommandModuleWithWriteContext<{
       const monitor = contextFactory.createMonitor();
 
       // Instantiates the strategy that will compute how rebalance routes should be performed
-      const strategy: IStrategy = contextFactory.createStrategy();
+      const strategy = contextFactory.createStrategy();
 
       // Instantiates the executor in charge of executing the rebalancing transactions
       const executor = !config.monitorOnly
         ? contextFactory.createExecutor()
         : undefined;
 
+      if (config.monitorOnly) {
+        warnYellow(
+          'Running in monitorOnly mode: no transactions will be executed.',
+        );
+      }
+
       // Instantiates the metrics that will publish stats from the monitored data
       const metrics = withMetrics
         ? await contextFactory.createMetrics()
         : undefined;
+
+      if (withMetrics) {
+        warnYellow(
+          'Metrics collection has been enabled and will be gathered during execution',
+        );
+      }
 
       const monitorToStrategy =
         contextFactory.createMonitorToStrategyTransformer();
@@ -533,13 +546,9 @@ export const rebalancer: CommandModuleWithWriteContext<{
 
           const rebalancingRoutes = strategy.getRebalancingRoutes(rawBalances);
 
-          if (executor) {
-            executor.rebalance(rebalancingRoutes).catch((e) => {
-              errorRed('Error while rebalancing:', (e as Error).message);
-            });
-          } else {
-            log('monitorOnly mode enabled, skipping rebalancing');
-          }
+          executor?.rebalance(rebalancingRoutes).catch((e) => {
+            errorRed('Error while rebalancing:', (e as Error).message);
+          });
         })
         // Observe monitor errors and exit
         .on('error', (e) => {

--- a/typescript/cli/src/rebalancer/executor/Executor.ts
+++ b/typescript/cli/src/rebalancer/executor/Executor.ts
@@ -10,7 +10,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { Address, stringifyObject } from '@hyperlane-xyz/utils';
 
-import { errorRed, log, logDebug } from '../../logger.js';
+import { errorRed, log } from '../../logger.js';
 import { IExecutor } from '../interfaces/IExecutor.js';
 import { RebalancingRoute } from '../interfaces/IStrategy.js';
 
@@ -133,7 +133,7 @@ export class Executor implements IExecutor {
       transactions.map(async ({ signer, populatedTx }, i) => {
         try {
           await signer.estimateGas(populatedTx);
-          logDebug(`Gas estimation succeeded for route ${i}`);
+          log(`Gas estimation succeeded for route ${i}`);
         } catch (error) {
           log(`❌ Could not estimate gas for route`, routes[i]);
           throw error;
@@ -145,15 +145,15 @@ export class Executor implements IExecutor {
       throw new Error('❌ Could not estimate gas for some routes');
     }
 
-    logDebug('Sending transactions');
+    log('Sending transactions');
     const results = await Promise.allSettled(
       transactions.map(async ({ signer, populatedTx }, i) => {
-        logDebug(`Sending transaction for route ${i}`);
+        log(`Sending transaction for route ${i}`);
         try {
           const tx = await signer.sendTransaction(populatedTx);
           log(`Transaction sent: ${tx.hash}`);
           const receipt = await tx.wait();
-          logDebug(`Transaction confirmed: ${tx.hash}`);
+          log(`Transaction confirmed: ${tx.hash}`);
           return receipt;
         } catch (error) {
           errorRed(`Transaction failed for route ${i}: ${error}`);

--- a/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
+++ b/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
@@ -7,6 +7,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { objMap, objMerge } from '@hyperlane-xyz/utils';
 
+import { logDebug } from '../../logger.js';
 import { Config } from '../config/Config.js';
 import { Executor } from '../executor/Executor.js';
 import { IExecutor } from '../interfaces/IExecutor.js';
@@ -39,6 +40,7 @@ export class RebalancerContextFactory {
     registry: IRegistry,
     config: Config,
   ): Promise<RebalancerContextFactory> {
+    logDebug('Creating RebalancerContextFactory');
     const metadata = await registry.getMetadata();
     const addresses = await registry.getAddresses();
 
@@ -53,11 +55,12 @@ export class RebalancerContextFactory {
       );
     }
     const warpCore = WarpCore.FromConfig(provider, warpCoreConfig);
-
+    logDebug('RebalancerContextFactory created successfully');
     return new RebalancerContextFactory(registry, config, metadata, warpCore);
   }
 
   public async createMetrics(coingeckoApiKey?: string): Promise<Metrics> {
+    logDebug('Creating Metrics');
     const tokenPriceGetter = PriceGetter.create(this.metadata, coingeckoApiKey);
     const collateralTokenSymbol = Metrics.getWarpRouteCollateralTokenSymbol(
       this.warpCore,
@@ -75,10 +78,12 @@ export class RebalancerContextFactory {
   }
 
   public createMonitor(): Monitor {
+    logDebug('Creating Monitor');
     return new Monitor(this.config.checkFrequency, this.warpCore);
   }
 
   public createStrategy(): IStrategy {
+    logDebug('Creating Strategy');
     return StrategyFactory.createStrategy(
       this.config.rebalanceStrategy,
       this.config.chains,
@@ -86,6 +91,7 @@ export class RebalancerContextFactory {
   }
 
   public createExecutor(): IExecutor {
+    logDebug('Creating Executor');
     return new Executor(
       objMap(this.config.chains, (_, v) => ({
         bridge: v.bridge,

--- a/typescript/cli/src/rebalancer/monitor/Monitor.ts
+++ b/typescript/cli/src/rebalancer/monitor/Monitor.ts
@@ -1,10 +1,9 @@
-import { logger } from 'ethers';
 import EventEmitter from 'events';
 
 import type { Token, WarpCore } from '@hyperlane-xyz/sdk';
 import { sleep } from '@hyperlane-xyz/utils';
 
-import { log, logDebug } from '../../logger.js';
+import { log, logDebug, warnYellow } from '../../logger.js';
 import { WrappedError } from '../../utils/errors.js';
 import type { IMonitor, MonitorEvent } from '../interfaces/IMonitor.js';
 
@@ -52,7 +51,7 @@ export class Monitor implements IMonitor {
 
     try {
       this.isMonitorRunning = true;
-      logDebug('Monitor started');
+      logDebug(`Monitor started, polling every ${this.checkFrequency} ms...`);
       this.emitter.emit('start');
 
       while (this.isMonitorRunning) {
@@ -103,9 +102,8 @@ export class Monitor implements IMonitor {
     token: Token,
   ): Promise<bigint | undefined> {
     if (!token.isHypToken()) {
-      logger.warn(
-        'Cannot get bridged balance for a non-Hyperlane token',
-        token,
+      warnYellow(
+        `Cannot get bridged balance for a non-Hyperlane token: ${token.chainName}`,
       );
       return;
     }
@@ -114,7 +112,7 @@ export class Monitor implements IMonitor {
     const bridgedSupply = await adapter.getBridgedSupply();
 
     if (bridgedSupply === undefined) {
-      logger.warn('Bridged supply not found for token', token);
+      warnYellow(`Bridged supply not found for token: ${token.chainName}`);
     }
 
     return bridgedSupply;

--- a/typescript/cli/src/rebalancer/monitor/Monitor.ts
+++ b/typescript/cli/src/rebalancer/monitor/Monitor.ts
@@ -1,11 +1,12 @@
 import { logger } from 'ethers';
 import EventEmitter from 'events';
 
-import { Token, WarpCore } from '@hyperlane-xyz/sdk';
+import type { Token, WarpCore } from '@hyperlane-xyz/sdk';
 import { sleep } from '@hyperlane-xyz/utils';
 
+import { log, logDebug } from '../../logger.js';
 import { WrappedError } from '../../utils/errors.js';
-import { IMonitor, MonitorEvent } from '../interfaces/IMonitor.js';
+import type { IMonitor, MonitorEvent } from '../interfaces/IMonitor.js';
 
 export class MonitorStartError extends WrappedError {
   name = 'MonitorStartError';
@@ -51,15 +52,18 @@ export class Monitor implements IMonitor {
 
     try {
       this.isMonitorRunning = true;
+      logDebug('Monitor started');
       this.emitter.emit('start');
 
       while (this.isMonitorRunning) {
         try {
+          logDebug('Polling cycle started');
           const event: MonitorEvent = {
             tokensInfo: [],
           };
 
           for (const token of this.warpCore.tokens) {
+            logDebug(`Checking token: ${token.chainName}`);
             const bridgedSupply = await this.getTokenBridgedSupply(token);
 
             event.tokensInfo.push({
@@ -70,6 +74,7 @@ export class Monitor implements IMonitor {
 
           // Emit the event warp routes info
           this.emitter.emit('tokeninfo', event);
+          logDebug('Polling cycle completed');
         } catch (e) {
           this.emitter.emit(
             'error',
@@ -117,6 +122,7 @@ export class Monitor implements IMonitor {
 
   stop() {
     this.isMonitorRunning = false;
+    log('Monitor stopped');
     this.emitter.removeAllListeners();
   }
 }

--- a/typescript/cli/src/rebalancer/strategy/BaseStrategy.ts
+++ b/typescript/cli/src/rebalancer/strategy/BaseStrategy.ts
@@ -1,5 +1,6 @@
 import type { ChainName } from '@hyperlane-xyz/sdk';
 
+import { logDebug, logGray } from '../../logger.js';
 import type {
   IStrategy,
   RawBalances,
@@ -26,10 +27,15 @@ export abstract class BaseStrategy implements IStrategy {
    * Main method to get rebalancing routes
    */
   getRebalancingRoutes(rawBalances: RawBalances): RebalancingRoute[] {
+    logDebug(`[${this.constructor.name}] Input rawBalances:`, rawBalances);
+    logGray(`Calculating rebalancing routes using ${this.constructor.name}...`);
     this.validateRawBalances(rawBalances);
 
     // Get balances categorized by surplus and deficit
     const { surpluses, deficits } = this.getCategorizedBalances(rawBalances);
+
+    logDebug(`[${this.constructor.name}] Surpluses:`, surpluses);
+    logDebug(`[${this.constructor.name}] Deficits:`, deficits);
 
     // Sort from largest to smallest amounts as to always transfer largest amounts
     // first and decrease the amount of routes required
@@ -69,6 +75,10 @@ export abstract class BaseStrategy implements IStrategy {
       }
     }
 
+    logDebug(`[${this.constructor.name}] Generated routes:`, routes);
+    logGray(
+      `Found ${routes.length} rebalancing route(s) using ${this.constructor.name}.`,
+    );
     return routes;
   }
 

--- a/typescript/cli/src/tests/test-setup.ts
+++ b/typescript/cli/src/tests/test-setup.ts
@@ -1,0 +1,5 @@
+import { LogFormat, LogLevel, configureRootLogger } from '@hyperlane-xyz/utils';
+
+// mute logging in tests
+process.env.NODE_ENV === 'test' &&
+  configureRootLogger(LogFormat.JSON, LogLevel.Off);

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -364,7 +364,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     });
 
     await startRebalancerAndExpectLog(
-      `monitorOnly mode enabled, skipping rebalancing`,
+      `Running in monitorOnly mode: no transactions will be executed.`,
     );
   });
 


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
Add logs in different parts of the rebalancing flow
Also prevents from logging in the middle of the `test:ci` tests if the user sets `NODE_ENV=test`

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->
Closes https://github.com/BootNodeDev/hyperlane-monorepo/issues/51

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
