### PR TITLE
feat: Remove createWarpRouteConfigId() from metrics.ts and monitor-warp-route-balances.ts

### DIFF
--- a/typescript/infra/scripts/warp-routes/monitor/metrics.ts
+++ b/typescript/infra/scripts/warp-routes/monitor/metrics.ts
@@ -1,6 +1,5 @@
 import { Gauge, Registry } from 'prom-client';
 
-import { createWarpRouteConfigId } from '@hyperlane-xyz/registry';
 import { ChainName, Token, TokenStandard, WarpCore } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 
@@ -95,7 +94,7 @@ export function updateTokenBalanceMetrics(
   warpCore: WarpCore,
   token: Token,
   balanceInfo: WarpRouteBalance,
-  collateralTokenSymbol: string,
+  warpRouteId: string,
 ) {
   const allChains = warpCore.getTokenChains().sort();
   const relatedChains = allChains.filter(
@@ -116,10 +115,7 @@ export function updateTokenBalanceMetrics(
     token_standard:
       // as we are reporting the total supply for clarity we report the standard as xERC20
       token.standard !== TokenStandard.EvmHypXERC20 ? token.standard : 'xERC20',
-    warp_route_id: createWarpRouteConfigId(
-      collateralTokenSymbol,
-      warpCore.getTokenChains(),
-    ),
+    warp_route_id: warpRouteId,
     // TODO: consider deprecating this label given that we have the value at risk metric
     related_chain_names: relatedChains.join(','),
   };
@@ -174,7 +170,7 @@ export function updateManagedLockboxBalanceMetrics(
   tokenAddress: string,
   lockBoxAddress: string,
   balanceInfo: WarpRouteBalance,
-  collateralTokenSymbol: string,
+  warpRouteId: string,
 ) {
   const metrics: WarpRouteMetrics = {
     chain_name: chainName,
@@ -182,10 +178,7 @@ export function updateManagedLockboxBalanceMetrics(
     token_name: tokenName,
     wallet_address: lockBoxAddress,
     token_standard: 'EvmManagedLockbox', // TODO: we should eventually a new TokenStandard for this
-    warp_route_id: createWarpRouteConfigId(
-      collateralTokenSymbol,
-      warpCore.getTokenChains(),
-    ),
+    warp_route_id: warpRouteId,
     related_chain_names: warpCore
       .getTokenChains()
       .filter((_chainName) => _chainName !== chainName)


### PR DESCRIPTION
### Description
Given that these scripts have the warpRouteId already at some point (used to fetch the warpCore), we pass it through each function instead of using createWarpRouteConfigId() with warpCore

### Backward compatibility
Yes - should not change any existing functionality
