### PR TITLE
fix: Ignore reorg flag temporarily

### DIFF
--- a/rust/main/hyperlane-base/src/types/s3_storage.rs
+++ b/rust/main/hyperlane-base/src/types/s3_storage.rs
@@ -280,11 +280,8 @@ impl CheckpointSyncer for S3Storage {
     }
 
     async fn reorg_status(&self) -> Result<Option<ReorgEvent>> {
-        self.anonymously_read_from_bucket(S3Storage::reorg_flag_key())
-            .await?
-            .map(|data| serde_json::from_slice(&data))
-            .transpose()
-            .map_err(Into::into)
+        // Return None
+        return Ok(None);
     }
 }
 

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -849,7 +849,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'd3f8da9-20250509-160937',
+      tag: 'c4aee3c-20250514-024948',
     },
     blacklist,
     gasPaymentEnforcement: gasPaymentEnforcement,


### PR DESCRIPTION
### Description

@daniel-savu's previous PR at https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/6213 still seems to result in lack of delivery. I can't quite explain why, but somehow both multisig metadata builders get the error which makes the aggregation builder unable to build metadata. This PR disables reorg checking on the s3 checkpoint syncer completely so that the relayer effectively ignores the flag
