### PR TITLE
chore: move executeDeploy logic from CLI to SDK

### DIFF
--- a/.changeset/orange-women-show.md
+++ b/.changeset/orange-women-show.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+Move executeDeploy logic from CLI to SDK

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -2,7 +2,6 @@ import { confirm } from '@inquirer/prompts';
 import { groupBy } from 'lodash-es';
 import { stringify as yamlStringify } from 'yaml';
 
-import { ProxyAdmin__factory } from '@hyperlane-xyz/core';
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
 import { AddWarpRouteOptions, ChainAddresses } from '@hyperlane-xyz/registry';
 import {
@@ -15,18 +14,11 @@ import {
   ChainSubmissionStrategySchema,
   ContractVerifier,
   EvmERC20WarpModule,
-  EvmHookModule,
-  EvmIsmModule,
   ExplorerLicenseType,
-  HookConfig,
   HypERC20Deployer,
   HypERC20Factories,
-  HypERC721Deployer,
   HypERC721Factories,
-  HypTokenRouterConfig,
   HyperlaneContractsMap,
-  HyperlaneProxyFactoryDeployer,
-  IsmConfig,
   IsmType,
   MultiProvider,
   MultisigIsmConfig,
@@ -45,6 +37,7 @@ import {
   WarpRouteDeployConfigSchema,
   attachContractsMap,
   connectContractsMap,
+  executeWarpDeploy,
   expandWarpDeployConfig,
   extractIsmAndHookFactoryAddresses,
   getRouterAddressesFromWarpCoreConfig,
@@ -56,7 +49,6 @@ import {
   splitWarpCoreAndExtendedConfigs,
 } from '@hyperlane-xyz/sdk';
 import {
-  Address,
   ProtocolType,
   assert,
   objMap,
@@ -159,40 +151,21 @@ async function executeDeploy(
 
   const {
     warpDeployConfig,
-    context: { multiProvider, isDryRun, dryRunChain },
+    context: { multiProvider, isDryRun, dryRunChain, registry },
   } = params;
-
-  const deployer = warpDeployConfig.isNft
-    ? new HypERC721Deployer(multiProvider)
-    : new HypERC20Deployer(multiProvider); // TODO: replace with EvmERC20WarpModule
 
   const config: WarpRouteDeployConfigMailboxRequired =
     isDryRun && dryRunChain
       ? { [dryRunChain]: warpDeployConfig[dryRunChain] }
       : warpDeployConfig;
+  const registryAddresses = await registry.getAddresses();
 
-  const contractVerifier = new ContractVerifier(
+  const deployedContracts = await executeWarpDeploy(
     multiProvider,
-    apiKeys,
-    coreBuildArtifact,
-    ExplorerLicenseType.MIT,
-  );
-
-  const ismFactoryDeployer = new HyperlaneProxyFactoryDeployer(
-    multiProvider,
-    contractVerifier,
-  );
-
-  // For each chain in WarpRouteConfig, deploy each Ism Factory, if it's not in the registry
-  // Then return a modified config with the ism and/or hook address as a string
-  const modifiedConfig = await resolveWarpIsmAndHook(
     config,
-    params.context,
-    ismFactoryDeployer,
-    contractVerifier,
+    registryAddresses,
+    apiKeys,
   );
-
-  const deployedContracts = await deployer.deploy(modifiedConfig);
 
   logGreen('✅ Warp contract deployments complete');
   return deployedContracts;
@@ -208,158 +181,6 @@ async function writeDeploymentArtifacts(
     await context.registry.addWarpRoute(warpCoreConfig, addWarpRouteOptions);
   }
   log(indentYamlOrJson(yamlStringify(warpCoreConfig, null, 2), 4));
-}
-
-async function resolveWarpIsmAndHook(
-  warpConfig: WarpRouteDeployConfigMailboxRequired,
-  context: WriteCommandContext,
-  ismFactoryDeployer: HyperlaneProxyFactoryDeployer,
-  contractVerifier?: ContractVerifier,
-): Promise<WarpRouteDeployConfigMailboxRequired> {
-  return promiseObjAll(
-    objMap(warpConfig, async (chain, config) => {
-      const registryAddresses = await context.registry.getAddresses();
-      const ccipContractCache = new CCIPContractCache(registryAddresses);
-      const chainAddresses = registryAddresses[chain];
-
-      if (!chainAddresses) {
-        throw `Registry factory addresses not found for ${chain}.`;
-      }
-
-      config.interchainSecurityModule = await createWarpIsm({
-        ccipContractCache,
-        chain,
-        chainAddresses,
-        context,
-        contractVerifier,
-        ismFactoryDeployer,
-        warpConfig: config,
-      }); // TODO write test
-
-      config.hook = await createWarpHook({
-        ccipContractCache,
-        chain,
-        chainAddresses,
-        context,
-        contractVerifier,
-        ismFactoryDeployer,
-        warpConfig: config,
-      });
-      return config;
-    }),
-  );
-}
-
-/**
- * Deploys the Warp ISM for a given config
- *
- * @returns The deployed ism address
- */
-async function createWarpIsm({
-  ccipContractCache,
-  chain,
-  chainAddresses,
-  context,
-  contractVerifier,
-  warpConfig,
-}: {
-  ccipContractCache: CCIPContractCache;
-  chain: string;
-  chainAddresses: Record<string, string>;
-  context: WriteCommandContext;
-  contractVerifier?: ContractVerifier;
-  warpConfig: HypTokenRouterConfig;
-  ismFactoryDeployer: HyperlaneProxyFactoryDeployer;
-}): Promise<IsmConfig | undefined> {
-  const { interchainSecurityModule } = warpConfig;
-  if (
-    !interchainSecurityModule ||
-    typeof interchainSecurityModule === 'string'
-  ) {
-    logGray(
-      `Config Ism is ${
-        !interchainSecurityModule ? 'empty' : interchainSecurityModule
-      }, skipping deployment.`,
-    );
-    return interchainSecurityModule;
-  }
-
-  logBlue(`Loading registry factory addresses for ${chain}...`);
-
-  logGray(
-    `Creating ${interchainSecurityModule.type} ISM for token on ${chain} chain...`,
-  );
-
-  logGreen(
-    `Finished creating ${interchainSecurityModule.type} ISM for token on ${chain} chain.`,
-  );
-
-  const evmIsmModule = await EvmIsmModule.create({
-    chain,
-    mailbox: chainAddresses.mailbox,
-    multiProvider: context.multiProvider,
-    proxyFactoryFactories: extractIsmAndHookFactoryAddresses(chainAddresses),
-    config: interchainSecurityModule,
-    ccipContractCache,
-    contractVerifier,
-  });
-  const { deployedIsm } = evmIsmModule.serialize();
-  return deployedIsm;
-}
-
-async function createWarpHook({
-  ccipContractCache,
-  chain,
-  chainAddresses,
-  context,
-  contractVerifier,
-  warpConfig,
-}: {
-  ccipContractCache: CCIPContractCache;
-  chain: string;
-  chainAddresses: Record<string, string>;
-  context: WriteCommandContext;
-  contractVerifier?: ContractVerifier;
-  warpConfig: HypTokenRouterConfig;
-  ismFactoryDeployer: HyperlaneProxyFactoryDeployer;
-}): Promise<HookConfig | undefined> {
-  const { hook } = warpConfig;
-
-  if (!hook || typeof hook === 'string') {
-    logGray(`Config Hook is ${!hook ? 'empty' : hook}, skipping deployment.`);
-    return hook;
-  }
-
-  logBlue(`Loading registry factory addresses for ${chain}...`);
-
-  logGray(`Creating ${hook.type} Hook for token on ${chain} chain...`);
-
-  // If config.proxyadmin.address exists, then use that. otherwise deploy a new proxyAdmin
-  const proxyAdminAddress: Address =
-    warpConfig.proxyAdmin?.address ??
-    (
-      await context.multiProvider.handleDeploy(
-        chain,
-        new ProxyAdmin__factory(),
-        [],
-      )
-    ).address;
-
-  const evmHookModule = await EvmHookModule.create({
-    chain,
-    multiProvider: context.multiProvider,
-    coreAddresses: {
-      mailbox: chainAddresses.mailbox,
-      proxyAdmin: proxyAdminAddress,
-    },
-    config: hook,
-    ccipContractCache,
-    contractVerifier,
-    proxyFactoryFactories: extractIsmAndHookFactoryAddresses(chainAddresses),
-  });
-  logGreen(`Finished creating ${hook.type} Hook for token on ${chain} chain.`);
-  const { deployedHook } = evmHookModule.serialize();
-  return deployedHook;
 }
 
 async function getWarpCoreConfig(

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -1,7 +1,12 @@
 import { ProxyAdmin__factory } from '@hyperlane-xyz/core';
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
 import { ChainAddresses } from '@hyperlane-xyz/registry';
-import { Address, objMap, promiseObjAll } from '@hyperlane-xyz/utils';
+import {
+  Address,
+  objMap,
+  promiseObjAll,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
 
 import { CCIPContractCache } from '../ccip/utils.js';
 import { HyperlaneContractsMap } from '../contracts/types.js';
@@ -126,23 +131,21 @@ async function createWarpIsm({
     !interchainSecurityModule ||
     typeof interchainSecurityModule === 'string'
   ) {
-    // logGray(
-    //   `Config Ism is ${
-    //     !interchainSecurityModule ? 'empty' : interchainSecurityModule
-    //   }, skipping deployment.`,
-    // );
+    rootLogger.info(
+      `Config Ism is ${
+        !interchainSecurityModule ? 'empty' : interchainSecurityModule
+      }, skipping deployment.`,
+    );
     return interchainSecurityModule;
   }
 
-  // logBlue(`Loading registry factory addresses for ${chain}...`);
-
-  // logGray(
-  //   `Creating ${interchainSecurityModule.type} ISM for token on ${chain} chain...`,
-  // );
-
-  // logGreen(
-  //   `Finished creating ${interchainSecurityModule.type} ISM for token on ${chain} chain.`,
-  // );
+  rootLogger.info(`Loading registry factory addresses for ${chain}...`);
+  rootLogger.info(
+    `Creating ${interchainSecurityModule.type} ISM for token on ${chain} chain...`,
+  );
+  rootLogger.info(
+    `Finished creating ${interchainSecurityModule.type} ISM for token on ${chain} chain.`,
+  );
 
   const evmIsmModule = await EvmIsmModule.create({
     chain,
@@ -176,13 +179,14 @@ async function createWarpHook({
   const { hook } = warpConfig;
 
   if (!hook || typeof hook === 'string') {
-    // logGray(`Config Hook is ${!hook ? 'empty' : hook}, skipping deployment.`);
+    rootLogger.info(
+      `Config Hook is ${!hook ? 'empty' : hook}, skipping deployment.`,
+    );
     return hook;
   }
 
-  // logBlue(`Loading registry factory addresses for ${chain}...`);
-
-  // logGray(`Creating ${hook.type} Hook for token on ${chain} chain...`);
+  rootLogger.info(`Loading registry factory addresses for ${chain}...`);
+  rootLogger.info(`Creating ${hook.type} Hook for token on ${chain} chain...`);
 
   // If config.proxyadmin.address exists, then use that. otherwise deploy a new proxyAdmin
   const proxyAdminAddress: Address =
@@ -202,7 +206,10 @@ async function createWarpHook({
     contractVerifier,
     proxyFactoryFactories: extractIsmAndHookFactoryAddresses(chainAddresses),
   });
-  // logGreen(`Finished creating ${hook.type} Hook for token on ${chain} chain.`);
+  rootLogger.info(
+    `Finished creating ${hook.type} Hook for token on ${chain} chain.`,
+  );
+
   const { deployedHook } = evmHookModule.serialize();
   return deployedHook;
 }

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -1,0 +1,208 @@
+import { ProxyAdmin__factory } from '@hyperlane-xyz/core';
+import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
+import { ChainAddresses } from '@hyperlane-xyz/registry';
+import { Address, objMap, promiseObjAll } from '@hyperlane-xyz/utils';
+
+import { CCIPContractCache } from '../ccip/utils.js';
+import { HyperlaneContractsMap } from '../contracts/types.js';
+import { EvmHookModule } from '../hook/EvmHookModule.js';
+import { HookConfig } from '../hook/types.js';
+import { EvmIsmModule } from '../ism/EvmIsmModule.js';
+import { IsmConfig } from '../ism/types.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+import { HypERC20Factories, HypERC721Factories } from '../token/contracts.js';
+import { HypERC20Deployer, HypERC721Deployer } from '../token/deploy.js';
+import {
+  HypTokenRouterConfig,
+  WarpRouteDeployConfigMailboxRequired,
+} from '../token/types.js';
+import { ChainMap } from '../types.js';
+import { extractIsmAndHookFactoryAddresses } from '../utils/ism.js';
+
+import { HyperlaneProxyFactoryDeployer } from './HyperlaneProxyFactoryDeployer.js';
+import { ContractVerifier } from './verify/ContractVerifier.js';
+import { ExplorerLicenseType } from './verify/types.js';
+
+export async function executeWarpDeploy(
+  multiProvider: MultiProvider,
+  warpDeployConfig: WarpRouteDeployConfigMailboxRequired,
+  registryAddresses: ChainMap<ChainAddresses>,
+  apiKeys: ChainMap<string>,
+): Promise<HyperlaneContractsMap<HypERC20Factories | HypERC721Factories>> {
+  const deployer = warpDeployConfig.isNft
+    ? new HypERC721Deployer(multiProvider)
+    : new HypERC20Deployer(multiProvider); // TODO: replace with EvmERC20WarpModule
+
+  const contractVerifier = new ContractVerifier(
+    multiProvider,
+    apiKeys,
+    coreBuildArtifact,
+    ExplorerLicenseType.MIT,
+  );
+
+  const ismFactoryDeployer = new HyperlaneProxyFactoryDeployer(
+    multiProvider,
+    contractVerifier,
+  );
+
+  // For each chain in WarpRouteConfig, deploy each Ism Factory, if it's not in the registry
+  // Then return a modified config with the ism and/or hook address as a string
+  const modifiedConfig = await resolveWarpIsmAndHook(
+    warpDeployConfig,
+    multiProvider,
+    registryAddresses,
+    ismFactoryDeployer,
+    contractVerifier,
+  );
+
+  const deployedContracts = await deployer.deploy(modifiedConfig);
+
+  return deployedContracts;
+}
+
+async function resolveWarpIsmAndHook(
+  warpConfig: WarpRouteDeployConfigMailboxRequired,
+  multiProvider: MultiProvider,
+  registryAddresses: ChainMap<ChainAddresses>,
+  ismFactoryDeployer: HyperlaneProxyFactoryDeployer,
+  contractVerifier?: ContractVerifier,
+): Promise<WarpRouteDeployConfigMailboxRequired> {
+  return promiseObjAll(
+    objMap(warpConfig, async (chain, config) => {
+      const ccipContractCache = new CCIPContractCache(registryAddresses);
+      const chainAddresses = registryAddresses[chain];
+
+      if (!chainAddresses) {
+        throw `Registry factory addresses not found for ${chain}.`;
+      }
+
+      config.interchainSecurityModule = await createWarpIsm({
+        ccipContractCache,
+        chain,
+        chainAddresses,
+        multiProvider,
+        contractVerifier,
+        ismFactoryDeployer,
+        warpConfig: config,
+      }); // TODO write test
+
+      config.hook = await createWarpHook({
+        ccipContractCache,
+        chain,
+        chainAddresses,
+        multiProvider,
+        contractVerifier,
+        ismFactoryDeployer,
+        warpConfig: config,
+      });
+      return config;
+    }),
+  );
+}
+
+/**
+ * Deploys the Warp ISM for a given config
+ *
+ * @returns The deployed ism address
+ */
+async function createWarpIsm({
+  ccipContractCache,
+  chain,
+  chainAddresses,
+  multiProvider,
+  contractVerifier,
+  warpConfig,
+}: {
+  ccipContractCache: CCIPContractCache;
+  chain: string;
+  chainAddresses: Record<string, string>;
+  multiProvider: MultiProvider;
+  contractVerifier?: ContractVerifier;
+  warpConfig: HypTokenRouterConfig;
+  ismFactoryDeployer: HyperlaneProxyFactoryDeployer;
+}): Promise<IsmConfig | undefined> {
+  const { interchainSecurityModule } = warpConfig;
+  if (
+    !interchainSecurityModule ||
+    typeof interchainSecurityModule === 'string'
+  ) {
+    // logGray(
+    //   `Config Ism is ${
+    //     !interchainSecurityModule ? 'empty' : interchainSecurityModule
+    //   }, skipping deployment.`,
+    // );
+    return interchainSecurityModule;
+  }
+
+  // logBlue(`Loading registry factory addresses for ${chain}...`);
+
+  // logGray(
+  //   `Creating ${interchainSecurityModule.type} ISM for token on ${chain} chain...`,
+  // );
+
+  // logGreen(
+  //   `Finished creating ${interchainSecurityModule.type} ISM for token on ${chain} chain.`,
+  // );
+
+  const evmIsmModule = await EvmIsmModule.create({
+    chain,
+    mailbox: chainAddresses.mailbox,
+    multiProvider,
+    proxyFactoryFactories: extractIsmAndHookFactoryAddresses(chainAddresses),
+    config: interchainSecurityModule,
+    ccipContractCache,
+    contractVerifier,
+  });
+  const { deployedIsm } = evmIsmModule.serialize();
+  return deployedIsm;
+}
+
+async function createWarpHook({
+  ccipContractCache,
+  chain,
+  chainAddresses,
+  multiProvider,
+  contractVerifier,
+  warpConfig,
+}: {
+  ccipContractCache: CCIPContractCache;
+  chain: string;
+  chainAddresses: Record<string, string>;
+  multiProvider: MultiProvider;
+  contractVerifier?: ContractVerifier;
+  warpConfig: HypTokenRouterConfig;
+  ismFactoryDeployer: HyperlaneProxyFactoryDeployer;
+}): Promise<HookConfig | undefined> {
+  const { hook } = warpConfig;
+
+  if (!hook || typeof hook === 'string') {
+    // logGray(`Config Hook is ${!hook ? 'empty' : hook}, skipping deployment.`);
+    return hook;
+  }
+
+  // logBlue(`Loading registry factory addresses for ${chain}...`);
+
+  // logGray(`Creating ${hook.type} Hook for token on ${chain} chain...`);
+
+  // If config.proxyadmin.address exists, then use that. otherwise deploy a new proxyAdmin
+  const proxyAdminAddress: Address =
+    warpConfig.proxyAdmin?.address ??
+    (await multiProvider.handleDeploy(chain, new ProxyAdmin__factory(), []))
+      .address;
+
+  const evmHookModule = await EvmHookModule.create({
+    chain,
+    multiProvider,
+    coreAddresses: {
+      mailbox: chainAddresses.mailbox,
+      proxyAdmin: proxyAdminAddress,
+    },
+    config: hook,
+    ccipContractCache,
+    contractVerifier,
+    proxyFactoryFactories: extractIsmAndHookFactoryAddresses(chainAddresses),
+  });
+  // logGreen(`Finished creating ${hook.type} Hook for token on ${chain} chain.`);
+  const { deployedHook } = evmHookModule.serialize();
+  return deployedHook;
+}

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -120,6 +120,7 @@ export {
   VerificationInput,
 } from './deploy/verify/types.js';
 export * as verificationUtils from './deploy/verify/utils.js';
+export { executeWarpDeploy } from './deploy/warp.js';
 export {
   SealevelOverheadIgpAdapter,
   SealevelIgpAdapter,


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

- Move logic from `executeDeploy` that was in the `CLI` to the `SDK`, now this function is named `executeWarpDeploy`
- Instead of using the CLI context, the function will receive the parameters

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->
No
### Related issues

<!--
- Fixes #[issue number here]
-->
fix #6138 
### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
Manual local test