### PR TITLE
fix: warp route id lookup source

### DIFF
--- a/.changeset/giant-animals-boil.md
+++ b/.changeset/giant-animals-boil.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Fixed warp route ID lookup to use deployment configs instead of warp routes when prompting users for selection on warp deployment

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -388,6 +388,7 @@ export async function getWarpRouteDeployConfig({
       warpRouteId: providedWarpRouteId,
       context,
       symbol,
+      promptByDeploymentConfigs: true,
     });
 
     warpDeployConfig = await readWarpRouteDeployConfig({

--- a/typescript/cli/src/utils/warp.ts
+++ b/typescript/cli/src/utils/warp.ts
@@ -57,16 +57,20 @@ export async function useProvidedWarpRouteIdOrPrompt({
   context,
   warpRouteId,
   symbol,
+  promptByDeploymentConfigs,
 }: {
   context: CommandContext;
   warpRouteId?: string;
   symbol?: string;
+  promptByDeploymentConfigs?: boolean;
 }): Promise<string> {
   if (warpRouteId) return warpRouteId;
   assert(!context.skipConfirmation, 'Warp route ID is required');
 
   const { ids: routeIds } = filterWarpRoutesIds(
-    (await context.registry.listRegistryContent()).deployments.warpRoutes,
+    (await context.registry.listRegistryContent()).deployments[
+      promptByDeploymentConfigs ? 'warpDeployConfig' : 'warpRoutes'
+    ],
     symbol ? { symbol } : undefined,
   );
 


### PR DESCRIPTION
### Description

Fixed warp route ID lookup to use deployment configs instead of warp routes when prompting users for selection on warp deployment.

### Drive-by changes

None

### Related issues

N/A

### Backward compatibility

Yes - This change only affects the user selection prompt behavior and doesn't impact infrastructure compatibility.

### Testing

Manual testing of the warp route ID selection workflow