### PR TITLE
feat: Decode internal calls in forge tests

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -83,7 +83,7 @@
     "prettier": "prettier --write ./contracts ./test",
     "test": "yarn version:exhaustive && yarn hardhat-esm test && yarn test:forge",
     "test:hardhat": "yarn hardhat-esm test",
-    "test:forge": "yarn fixtures && forge test -vvv",
+    "test:forge": "yarn fixtures && forge test -vvv --decode-internal",
     "test:ci": "yarn version:changed && yarn test:hardhat && yarn test:forge --no-match-test testFork",
     "gas": "forge snapshot",
     "gas-ci": "yarn gas --check --tolerance 2 || (echo 'Manually update gas snapshot' && exit 1)",


### PR DESCRIPTION
### Description

By default we decode internal calls in our foundry tests. This is great for debugging! See these [Foundry v1.0 release notes](https://www.paradigm.xyz/2025/02/announcing-foundry-v1-0) for more.