### PR TITLE
feat: Support VSXERC20 token standard in warp monitor

### DIFF
--- a/typescript/infra/scripts/warp-routes/monitor/monitor-warp-route-balances.ts
+++ b/typescript/infra/scripts/warp-routes/monitor/monitor-warp-route-balances.ts
@@ -272,12 +272,16 @@ async function getTokenBridgedBalance(
   // Only record value for collateralized and xERC20 lockbox tokens.
   if (
     token.isCollateralized() ||
-    token.standard === TokenStandard.EvmHypXERC20Lockbox
+    token.standard === TokenStandard.EvmHypXERC20Lockbox ||
+    token.standard === TokenStandard.EvmHypVSXERC20Lockbox
   ) {
     tokenPrice = await tryGetTokenPrice(token, tokenPriceGetter);
   }
 
-  if (token.standard === TokenStandard.EvmHypXERC20Lockbox) {
+  if (
+    token.standard === TokenStandard.EvmHypXERC20Lockbox ||
+    token.standard === TokenStandard.EvmHypVSXERC20Lockbox
+  ) {
     tokenAddress = (await (adapter as EvmHypXERC20LockboxAdapter).getXERC20())
       .address;
   }
@@ -573,7 +577,8 @@ function getWarpRouteCollateralTokenSymbol(warpCore: WarpCore): string {
   const collateralTokens = warpCore.tokens.filter(
     (token) =>
       token.isCollateralized() ||
-      token.standard === TokenStandard.EvmHypXERC20Lockbox,
+      token.standard === TokenStandard.EvmHypXERC20Lockbox ||
+      token.standard === TokenStandard.EvmHypVSXERC20Lockbox,
   );
 
   if (collateralTokens.length === 0) {

--- a/typescript/infra/scripts/warp-routes/monitor/monitor-warp-route-balances.ts
+++ b/typescript/infra/scripts/warp-routes/monitor/monitor-warp-route-balances.ts
@@ -363,7 +363,10 @@ async function getXERC20Info(
     throw new Error(`Unsupported XERC20 protocol type ${token.protocol}`);
   }
 
-  if (token.standard === TokenStandard.EvmHypXERC20) {
+  if (
+    token.standard === TokenStandard.EvmHypXERC20 ||
+    token.standard === TokenStandard.EvmHypVSXERC20
+  ) {
     const adapter = token.getAdapter(
       warpCore.multiProvider,
     ) as EvmHypXERC20Adapter;
@@ -371,7 +374,10 @@ async function getXERC20Info(
       limits: await getXERC20Limit(token, adapter),
       xERC20Address: (await adapter.getXERC20()).address,
     };
-  } else if (token.standard === TokenStandard.EvmHypXERC20Lockbox) {
+  } else if (
+    token.standard === TokenStandard.EvmHypXERC20Lockbox ||
+    token.standard === TokenStandard.EvmHypVSXERC20Lockbox
+  ) {
     const adapter = token.getAdapter(
       warpCore.multiProvider,
     ) as EvmHypXERC20LockboxAdapter;


### PR DESCRIPTION
### Description

- When we extended the oUSDT route, we changed the token standards (`EvmHypXERC20Lockbox` => `EvmHypVSXERC20Lockbox`,  `EvmHypXERC20` => `EvmHypVSXERC20`).
- This was a change that is an accurate representation of the tokens.
- This PR introduces support for these token standards in the monitoring service 


### Backward compatibility

Yes

### Testing

Manual
