### PR TITLE
feat: bridge route-based overrides

### DIFF
--- a/typescript/cli/src/rebalancer/config/Config.test.ts
+++ b/typescript/cli/src/rebalancer/config/Config.test.ts
@@ -179,6 +179,7 @@ describe('Config', () => {
         chain1: {
           minAmount: 1000,
           bridge: ethers.constants.AddressZero,
+          bridgeTolerance: 1,
           override: {
             chain2: {
               bridge: '0x1234567890123456789012345678901234567890',
@@ -188,10 +189,12 @@ describe('Config', () => {
         chain2: {
           minAmount: 2000,
           bridge: ethers.constants.AddressZero,
+          bridgeTolerance: 1,
         },
         chain3: {
           minAmount: 3000,
           bridge: ethers.constants.AddressZero,
+          bridgeTolerance: 1,
         },
       };
 
@@ -220,6 +223,7 @@ describe('Config', () => {
         chain1: {
           minAmount: 1000,
           bridge: ethers.constants.AddressZero,
+          bridgeTolerance: 1,
           override: {
             chain2: {
               bridge: '0x1234567890123456789012345678901234567890',
@@ -232,6 +236,7 @@ describe('Config', () => {
         chain2: {
           minAmount: 2000,
           bridge: ethers.constants.AddressZero,
+          bridgeTolerance: 1,
         },
       };
 
@@ -251,6 +256,7 @@ describe('Config', () => {
         chain1: {
           minAmount: 1000,
           bridge: ethers.constants.AddressZero,
+          bridgeTolerance: 1,
           override: {
             chain1: {
               bridgeMinAcceptedAmount: 1000,
@@ -260,6 +266,7 @@ describe('Config', () => {
         chain2: {
           minAmount: 2000,
           bridge: ethers.constants.AddressZero,
+          bridgeTolerance: 1,
         },
       };
 
@@ -274,6 +281,7 @@ describe('Config', () => {
       data.chain1 = {
         bridge: ethers.constants.AddressZero,
         bridgeMinAcceptedAmount: 3000,
+        bridgeTolerance: 1,
         weight: 100,
         tolerance: 0,
         override: {
@@ -289,6 +297,7 @@ describe('Config', () => {
       data.chain2 = {
         bridge: ethers.constants.AddressZero,
         bridgeMinAcceptedAmount: 5000,
+        bridgeTolerance: 1,
         weight: 100,
         tolerance: 0,
       };
@@ -296,6 +305,7 @@ describe('Config', () => {
       data.chain3 = {
         bridge: ethers.constants.AddressZero,
         bridgeMinAcceptedAmount: 6000,
+        bridgeTolerance: 1,
         weight: 100,
         tolerance: 0,
       };

--- a/typescript/cli/src/rebalancer/config/Config.test.ts
+++ b/typescript/cli/src/rebalancer/config/Config.test.ts
@@ -242,6 +242,34 @@ describe('Config', () => {
       );
     });
 
+    it('should throw when an override references itself', () => {
+      data = {
+        warpRouteId: 'warpRouteId',
+        checkFrequency: 1000,
+        coingeckoApiKey: COINGECKO_API_KEY,
+        rebalanceStrategy: 'minAmount',
+        chain1: {
+          minAmount: 1000,
+          bridge: ethers.constants.AddressZero,
+          override: {
+            chain1: {
+              bridgeMinAcceptedAmount: 1000,
+            },
+          },
+        },
+        chain2: {
+          minAmount: 2000,
+          bridge: ethers.constants.AddressZero,
+        },
+      };
+
+      writeYamlOrJson(REBALANCER_CONFIG_PATH, data);
+
+      expect(() => Config.load(REBALANCER_CONFIG_PATH, ANVIL_KEY, {})).to.throw(
+        "Chain 'chain1' has an override for 'chain1', but 'chain1' is self-referencing",
+      );
+    });
+
     it('should allow multiple chain overrides', () => {
       data.chain1 = {
         bridge: ethers.constants.AddressZero,

--- a/typescript/cli/src/rebalancer/config/Config.test.ts
+++ b/typescript/cli/src/rebalancer/config/Config.test.ts
@@ -211,6 +211,37 @@ describe('Config', () => {
       );
     });
 
+    it('should throw when an override references a non-existent chain', () => {
+      data = {
+        warpRouteId: 'warpRouteId',
+        checkFrequency: 1000,
+        coingeckoApiKey: COINGECKO_API_KEY,
+        rebalanceStrategy: 'minAmount',
+        chain1: {
+          minAmount: 1000,
+          bridge: ethers.constants.AddressZero,
+          override: {
+            chain2: {
+              bridge: '0x1234567890123456789012345678901234567890',
+            },
+            chain3: {
+              bridgeMinAcceptedAmount: 1000,
+            },
+          },
+        },
+        chain2: {
+          minAmount: 2000,
+          bridge: ethers.constants.AddressZero,
+        },
+      };
+
+      writeYamlOrJson(REBALANCER_CONFIG_PATH, data);
+
+      expect(() => Config.load(REBALANCER_CONFIG_PATH, ANVIL_KEY, {})).to.throw(
+        "Chain 'chain1' has an override for 'chain3', but 'chain3' is not defined in the config",
+      );
+    });
+
     it('should allow multiple chain overrides', () => {
       data.chain1 = {
         bridge: ethers.constants.AddressZero,
@@ -225,6 +256,20 @@ describe('Config', () => {
             bridge: '0x1234567890123456789012345678901234567890',
           },
         },
+      };
+
+      data.chain2 = {
+        bridge: ethers.constants.AddressZero,
+        bridgeMinAcceptedAmount: 5000,
+        weight: 100,
+        tolerance: 0,
+      };
+
+      data.chain3 = {
+        bridge: ethers.constants.AddressZero,
+        bridgeMinAcceptedAmount: 6000,
+        weight: 100,
+        tolerance: 0,
       };
 
       writeYamlOrJson(REBALANCER_CONFIG_PATH, data);

--- a/typescript/cli/src/rebalancer/config/Config.ts
+++ b/typescript/cli/src/rebalancer/config/Config.ts
@@ -86,6 +86,7 @@ const ConfigSchema = BaseConfigSchema.catchall(ChainConfigSchema).superRefine(
     // Check each chain's overrides
     for (const chainName of chainNames) {
       const chain = config[chainName] as ChainConfig;
+
       if (chain.override) {
         for (const overrideChainName of Object.keys(chain.override)) {
           // Each override key must reference a valid chain
@@ -93,6 +94,15 @@ const ConfigSchema = BaseConfigSchema.catchall(ChainConfigSchema).superRefine(
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               message: `Chain '${chainName}' has an override for '${overrideChainName}', but '${overrideChainName}' is not defined in the config`,
+              path: [chainName, 'override', overrideChainName],
+            });
+          }
+
+          // Override shouldn't be self-referencing
+          if (chainName === overrideChainName) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `Chain '${chainName}' has an override for '${chainName}', but '${chainName}' is self-referencing`,
               path: [chainName, 'override', overrideChainName],
             });
           }

--- a/typescript/cli/src/rebalancer/config/Config.ts
+++ b/typescript/cli/src/rebalancer/config/Config.ts
@@ -49,10 +49,22 @@ const MinAmountChainConfigSchema = BaseChainConfigSchema.extend({
     .optional(),
 });
 
-// Union of possible chain configs
-const ChainConfigSchema = z.union([
-  WeightedChainConfigSchema,
-  MinAmountChainConfigSchema,
+const OverrideValueSchema = BaseChainConfigSchema.partial().passthrough();
+
+const BaseChainConfigSchemaWithOverride = BaseChainConfigSchema.extend({
+  override: z.record(z.string(), OverrideValueSchema).optional(),
+});
+
+const WeightedChainConfigSchemaWithOverride =
+  BaseChainConfigSchemaWithOverride.merge(WeightedChainConfigSchema);
+
+const MinAmountChainConfigSchemaWithOverride =
+  BaseChainConfigSchemaWithOverride.merge(MinAmountChainConfigSchema);
+
+// Union of possible chain configs with override
+export const ChainConfigSchema = z.union([
+  WeightedChainConfigSchemaWithOverride,
+  MinAmountChainConfigSchemaWithOverride,
 ]);
 
 const BaseConfigSchema = z.object({

--- a/typescript/cli/src/rebalancer/config/Config.ts
+++ b/typescript/cli/src/rebalancer/config/Config.ts
@@ -79,8 +79,10 @@ const BaseConfigSchema = z.object({
 const ConfigSchema = BaseConfigSchema.catchall(ChainConfigSchema).superRefine(
   (config, ctx) => {
     // Get all chain names from the config
-    const chainNames = Object.keys(config).filter(
-      (key) => !Object.keys(BaseConfigSchema.shape).includes(key),
+    const chainNames = new Set(
+      Object.keys(config).filter(
+        (key) => !Object.keys(BaseConfigSchema.shape).includes(key),
+      ),
     );
 
     // Check each chain's overrides
@@ -90,7 +92,7 @@ const ConfigSchema = BaseConfigSchema.catchall(ChainConfigSchema).superRefine(
       if (chain.override) {
         for (const overrideChainName of Object.keys(chain.override)) {
           // Each override key must reference a valid chain
-          if (!chainNames.includes(overrideChainName)) {
+          if (!chainNames.has(overrideChainName)) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               message: `Chain '${chainName}' has an override for '${overrideChainName}', but '${overrideChainName}' is not defined in the config`,

--- a/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
+++ b/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
@@ -96,8 +96,8 @@ export class RebalancerContextFactory {
     const executor = new Executor(
       objMap(this.config.chains, (_, v) => ({
         bridge: v.bridge,
-        minAcceptedAmount: v.bridgeMinAcceptedAmount ?? 0n,
-        isWarp: v.bridgeIsWarp ?? false,
+        bridgeMinAcceptedAmount: v.bridgeMinAcceptedAmount ?? 0n,
+        bridgeIsWarp: v.bridgeIsWarp ?? false,
       })),
       this.config.rebalancerKey,
       this.warpCore,

--- a/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
+++ b/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
@@ -98,6 +98,7 @@ export class RebalancerContextFactory {
         bridge: v.bridge,
         bridgeMinAcceptedAmount: v.bridgeMinAcceptedAmount ?? 0n,
         bridgeIsWarp: v.bridgeIsWarp ?? false,
+        override: v.override,
       })),
       this.config.rebalancerKey,
       this.warpCore,

--- a/typescript/cli/src/rebalancer/utils/bridgeConfig.test.ts
+++ b/typescript/cli/src/rebalancer/utils/bridgeConfig.test.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+
+import { ChainMap } from '@hyperlane-xyz/sdk';
+
+import { type BridgeConfig, getBridgeConfig } from './bridgeConfig.js';
+
+describe('bridgeConfig', () => {
+  it('should return the base bridge config when no overrides exist', () => {
+    const bridges: ChainMap<BridgeConfig> = {
+      chain1: {
+        bridge: '0x1234567890123456789012345678901234567890',
+        bridgeMinAcceptedAmount: 1000n,
+        bridgeIsWarp: true,
+      },
+      chain2: {
+        bridge: '0x0987654321098765432109876543210987654321',
+        bridgeMinAcceptedAmount: 2000n,
+        bridgeIsWarp: true,
+      },
+    };
+
+    const result = getBridgeConfig(bridges, 'chain1', 'chain2');
+
+    expect(result).to.deep.equal({
+      bridge: '0x1234567890123456789012345678901234567890',
+      bridgeMinAcceptedAmount: 1000n,
+      bridgeIsWarp: true,
+    });
+  });
+
+  it('should merge base config with overrides when they exist', () => {
+    const bridges: ChainMap<BridgeConfig> = {
+      chain1: {
+        bridge: '0x1234567890123456789012345678901234567890',
+        bridgeMinAcceptedAmount: 1000n,
+        bridgeIsWarp: true,
+        overrides: {
+          chain2: {
+            bridgeMinAcceptedAmount: 5000n,
+          },
+        },
+      },
+      chain2: {
+        bridge: '0x0987654321098765432109876543210987654321',
+        bridgeMinAcceptedAmount: 2000n,
+        bridgeIsWarp: true,
+      },
+    };
+
+    const result = getBridgeConfig(bridges, 'chain1', 'chain2');
+
+    expect(result).to.deep.equal({
+      bridge: '0x1234567890123456789012345678901234567890',
+      bridgeMinAcceptedAmount: 5000n,
+      bridgeIsWarp: true,
+    });
+  });
+
+  it('should handle overrides that change the bridge address', () => {
+    const bridges: ChainMap<BridgeConfig> = {
+      chain1: {
+        bridge: '0x1234567890123456789012345678901234567890',
+        bridgeMinAcceptedAmount: 1000n,
+        bridgeIsWarp: true,
+        overrides: {
+          chain2: {
+            bridge: '0xABCDEF0123456789ABCDEF0123456789ABCDEF01',
+          },
+        },
+      },
+      chain2: {
+        bridge: '0x0987654321098765432109876543210987654321',
+        bridgeMinAcceptedAmount: 2000n,
+        bridgeIsWarp: true,
+      },
+    };
+
+    const result = getBridgeConfig(bridges, 'chain1', 'chain2');
+
+    expect(result).to.deep.equal({
+      bridge: '0xABCDEF0123456789ABCDEF0123456789ABCDEF01',
+      bridgeMinAcceptedAmount: 1000n,
+      bridgeIsWarp: true,
+    });
+  });
+});

--- a/typescript/cli/src/rebalancer/utils/bridgeConfig.ts
+++ b/typescript/cli/src/rebalancer/utils/bridgeConfig.ts
@@ -1,0 +1,30 @@
+import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
+
+export type BridgeConfig = {
+  bridge: string;
+  bridgeMinAcceptedAmount: bigint;
+  bridgeIsWarp: boolean;
+  overrides?: ChainMap<Partial<BridgeConfig>>;
+};
+
+/**
+ * Gets the bridge configuration for a specific chain pair, applying any overrides
+ * @param bridges The map of bridge configurations by chain
+ * @param fromChain The source chain
+ * @param toChain The destination chain
+ * @returns The bridge configuration with any overrides applied
+ */
+export function getBridgeConfig(
+  bridges: ChainMap<BridgeConfig>,
+  fromChain: ChainName,
+  toChain: ChainName,
+): BridgeConfig {
+  const fromConfig = bridges[fromChain];
+  const routeSpecificOverrides = fromConfig.overrides?.[toChain];
+
+  // Create a new object with the properties from bridgeConfig, excluding the overrides property
+  const { overrides: _, ...baseConfig } = fromConfig;
+
+  // Return a new object with the base config and any overrides
+  return { ...baseConfig, ...routeSpecificOverrides };
+}


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

Adds an `override` key to the chain config where bridge-specific props can be overriden based on the chain.

So, given the following scenario:
```ts
chain1: {
  bridge: '0x123',
  overrides: {
	chain2: {
      bridge: '0x222', 
    }
  }
}
````

When trying to bridge from `chain1` to `chain2`, brdige `0x222` will be used, while in the other cases will be `0x123`

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

Closes https://github.com/BootNodeDev/hyperlane-monorepo/issues/61

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

Yes

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->

Manual/Unit Tests