### PR TITLE
chore: add optional limit to token schema

### DIFF
--- a/typescript/sdk/src/token/IToken.ts
+++ b/typescript/sdk/src/token/IToken.ts
@@ -51,6 +51,12 @@ export const TokenConfigSchema = z.object({
     .string()
     .optional()
     .describe('The CoinGecko id of the token, used for price lookups'),
+  limits: z
+    .record(z.number())
+    .optional()
+    .describe(
+      'The limits set to the current token towards a destination chain',
+    ),
 });
 
 export type TokenArgs = Omit<


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

Simple setup for adding token limits from the current token to a specific destination chain, example:

```typescript
const token = {
  ...
  limits: {
    arbitrum: 10000000
  }
}
```

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
