### PR TITLE
chore: default to only amd64 docker builds

### DIFF
--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -13,6 +13,12 @@ on:
       - 'docker-entrypoint.sh'
       - '.dockerignore'
       - '.github/workflows/monorepo-docker.yml'
+  workflow_dispatch:
+    inputs:
+      include_arm64:
+        description: 'Include arm64 in the build'
+        required: false
+        default: 'false'
 
 concurrency:
   group: build-push-monorepo-${{ github.ref }}
@@ -81,6 +87,15 @@ jobs:
           REGISTRY_VERSION=$(cat .registryrc)
           echo "REGISTRY_VERSION=$REGISTRY_VERSION" >> $GITHUB_ENV
 
+      - name: Determine platforms
+        id: determine-platforms
+        run: |
+          echo "PLATFORMS=linux/amd64" >> $GITHUB_ENV
+          if [ "${{ github.event.inputs.include_arm64 }}" == "true" ]; then
+            echo "PLATFORMS=${PLATFORMS},linux/arm64" >> $GITHUB_ENV
+          fi
+          echo "platforms=${PLATFORMS}" >> $GITHUB_OUTPUT
+
       - name: Build and push
         uses: depot/build-push-action@v1
         with:
@@ -92,4 +107,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             REGISTRY_COMMIT=${{ env.REGISTRY_VERSION }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ steps.determine-platforms.outputs.platforms }}

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -90,11 +90,11 @@ jobs:
       - name: Determine platforms
         id: determine-platforms
         run: |
-          echo "PLATFORMS=linux/amd64" >> $GITHUB_ENV
           if [ "${{ github.event.inputs.include_arm64 }}" == "true" ]; then
-            echo "PLATFORMS=${PLATFORMS},linux/arm64" >> $GITHUB_ENV
+            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+          else
+            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
           fi
-          echo "platforms=${PLATFORMS}" >> $GITHUB_OUTPUT
 
       - name: Build and push
         uses: depot/build-push-action@v1

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -8,6 +8,12 @@ on:
     paths:
       - 'rust/**'
       - '.github/workflows/rust-docker.yml'
+  workflow_dispatch:
+    inputs:
+      include_arm64:
+        description: 'Include arm64 in the build'
+        required: false
+        default: 'false'
 concurrency:
   group: build-push-agents-${{ github.ref }}
   cancel-in-progress: true
@@ -64,6 +70,14 @@ jobs:
           registry: gcr.io
           username: _json_key
           password: ${{ secrets.GCLOUD_SERVICE_KEY }}
+      - name: Determine platforms
+        id: determine-platforms
+        run: |
+          echo "PLATFORMS=linux/amd64" >> $GITHUB_ENV
+          if [ "${{ github.event.inputs.include_arm64 }}" == "true" ]; then
+            echo "PLATFORMS=${PLATFORMS},linux/arm64" >> $GITHUB_ENV
+          fi
+          echo "platforms=${PLATFORMS}" >> $GITHUB_OUTPUT
       - name: Build and push
         uses: depot/build-push-action@v1
         with:
@@ -73,4 +87,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ steps.determine-platforms.outputs.platforms }}

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -73,11 +73,11 @@ jobs:
       - name: Determine platforms
         id: determine-platforms
         run: |
-          echo "PLATFORMS=linux/amd64" >> $GITHUB_ENV
           if [ "${{ github.event.inputs.include_arm64 }}" == "true" ]; then
-            echo "PLATFORMS=${PLATFORMS},linux/arm64" >> $GITHUB_ENV
+            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+          else
+            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
           fi
-          echo "platforms=${PLATFORMS}" >> $GITHUB_OUTPUT
       - name: Build and push
         uses: depot/build-push-action@v1
         with:

--- a/README.md
+++ b/README.md
@@ -119,3 +119,23 @@ See [`rust/README.md`](rust/README.md)
 We use [changesets](https://github.com/changesets/changesets) to release to NPM. You can use the `release` script in `package.json` to publish.
 
 For an alpha or beta version, follow the directions [here](https://github.com/changesets/changesets/blob/main/docs/prereleases.md).
+
+### Manually Triggering Docker Builds in CI
+
+To manually trigger Agent or Monorepo Docker builds in CI, you can use the workflows provided in the repository. Here are the steps to do so:
+
+1. **Navigate to the workflow:**
+
+   - For agents, go to the [Rust Docker Workflow](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/workflows/rust-docker.yml).
+   - For the monorepo, go to the [Monorepo Docker Workflow](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/workflows/monorepo-docker.yml).
+
+2. **Trigger the workflow:**
+
+   - On the workflow page, click on the "Run workflow" button.
+   - You may need to select a branch and decide whether to trigger builds for the `arm64` platform.
+
+3. **Wait for the build to complete:**
+   - Once triggered, monitor the progress of the build by opening the new workflow run.
+     - You may have to refresh the page for it to appear.
+   - Check the logs for any errors or issues during the build process.
+   - Wait for the `build-and-push-to-gcr` step to complete successfully before using the new image.


### PR DESCRIPTION
### Description

chore: default to only amd64 docker builds
- default agent/monorepo images are only for amd64
- this saves time, cost of each image build
- if required for local runs, devs can manually trigger the workflow and say they want an arm64 build
- allowing manual runs also means that you don't need to have a PR open just to trigger image builds anymore

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
