### PR TITLE
chore: depot docker recommendations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,8 @@ FROM node:20-alpine
 
 WORKDIR /hyperlane-monorepo
 
-RUN apk add --update --no-cache git g++ make py3-pip jq bash curl
-
-RUN yarn set version 4.5.1
+RUN apk add --update --no-cache git g++ make py3-pip jq bash curl && \
+    yarn set version 4.5.1
 
 # Copy package.json and friends
 COPY package.json yarn.lock .yarnrc.yml ./

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -7,7 +7,9 @@
 # Base image containing all necessary build tools and dependencies
 FROM rust:1.81.0 AS base
 RUN apt-get update && \
-    apt-get install -y musl-tools clang && \
+    apt-get install -y --no-install-recommends musl-tools clang && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
     rustup target add x86_64-unknown-linux-musl && \
     cargo install --locked sccache
 
@@ -67,7 +69,8 @@ COPY --from=builder /release/* .
 # Install runtime dependencies
 # remove /var/lib/apt/lists/* to clean up the package lists
 RUN apt-get update && \
-    apt-get install -y openssl ca-certificates tini && \
+    apt-get install -y --no-install-recommends openssl ca-certificates tini && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     chmod 777 /app && \
     mkdir -p /usr/share/hyperlane && chmod 1000 /usr/share/hyperlane && \


### PR DESCRIPTION
### Description

chore: depot docker recommendations
- update dockerfiles based on the depot recommendations

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

- [x] ci
- [x] monorepo image on keyfunder
- [x] agent image on rc
