### PR TITLE
chore: add cosmos native core cli commands

### DIFF
--- a/.changeset/ninety-keys-brush.md
+++ b/.changeset/ninety-keys-brush.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+add cosmos native core cli commands

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -13,6 +13,7 @@ import {
   createCoreDeployConfig,
   readCoreDeployConfigs,
 } from '../config/core.js';
+import { MultiProtocolSignerManager } from '../context/strategies/signer/MultiProtocolSignerManager.js';
 import {
   CommandModuleWithContext,
   CommandModuleWithWriteContext,
@@ -104,6 +105,7 @@ export const deploy: CommandModuleWithWriteContext<{
   config: string;
   dryRun: string;
   fromAddress: string;
+  multiProtocolSigner?: MultiProtocolSignerManager;
 }> = {
   command: 'deploy',
   describe: 'Deploy Hyperlane contracts',
@@ -117,7 +119,13 @@ export const deploy: CommandModuleWithWriteContext<{
     'dry-run': dryRunCommandOption,
     'from-address': fromAddressCommandOption,
   },
-  handler: async ({ context, chain, config: configFilePath, dryRun }) => {
+  handler: async ({
+    context,
+    chain,
+    config: configFilePath,
+    dryRun,
+    multiProtocolSigner,
+  }) => {
     logCommandHeader(`Hyperlane Core deployment${dryRun ? ' dry-run' : ''}`);
 
     try {
@@ -125,6 +133,7 @@ export const deploy: CommandModuleWithWriteContext<{
         context,
         chain,
         config: readYamlOrJson(configFilePath),
+        multiProtocolSigner,
       });
     } catch (error: any) {
       evaluateIfDryRunFailure(error, dryRun);

--- a/typescript/cli/src/config/hooks.ts
+++ b/typescript/cli/src/config/hooks.ts
@@ -309,7 +309,7 @@ async function getIgpTokenPrices(
       chainMetadata: filteredMetadata,
     });
     const results = await tokenPriceGetter.getAllTokenPrices();
-    fetchedPrices = objMap(results, (v) => v.toString());
+    fetchedPrices = objMap(results, (v) => results[v].toString());
   }
 
   logBlue(

--- a/typescript/cli/src/context/strategies/chain/MultiChainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/MultiChainResolver.ts
@@ -148,7 +148,10 @@ export class MultiChainResolver implements ChainResolver {
 
     // If no destination is specified, return all EVM chains
     if (!argv.destination) {
-      return Array.from(this.getEvmChains(multiProvider));
+      return [
+        ...this.getEvmChains(multiProvider),
+        ...this.getCosmosNativeChains(multiProvider),
+      ];
     }
 
     chains.add(argv.destination);
@@ -195,6 +198,14 @@ export class MultiChainResolver implements ChainResolver {
 
     return chains.filter(
       (chain) => multiProvider.getProtocol(chain) === ProtocolType.Ethereum,
+    );
+  }
+
+  private getCosmosNativeChains(multiProvider: MultiProvider): ChainName[] {
+    const chains = multiProvider.getKnownChainNames();
+
+    return chains.filter(
+      (chain) => multiProvider.getProtocol(chain) === ProtocolType.CosmosNative,
     );
   }
 

--- a/typescript/cli/src/deploy/core.ts
+++ b/typescript/cli/src/deploy/core.ts
@@ -1,18 +1,22 @@
 import { stringify as yamlStringify } from 'yaml';
 
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
+import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
   ChainMap,
   ChainName,
   ContractVerifier,
   CoreConfig,
+  CosmosNativeCoreModule,
   DeployedCoreAddresses,
   EvmCoreModule,
   ExplorerLicenseType,
 } from '@hyperlane-xyz/sdk';
+import { ProtocolType, assert } from '@hyperlane-xyz/utils';
 
 import { MINIMUM_CORE_DEPLOY_GAS } from '../consts.js';
 import { requestAndSaveApiKeys } from '../context/context.js';
+import { MultiProtocolSignerManager } from '../context/strategies/signer/MultiProtocolSignerManager.js';
 import { WriteCommandContext } from '../context/types.js';
 import { log, logBlue, logGray, logGreen } from '../logger.js';
 import { runSingleChainSelectionStep } from '../utils/chains.js';
@@ -29,6 +33,7 @@ interface DeployParams {
   context: WriteCommandContext;
   chain: ChainName;
   config: CoreConfig;
+  multiProtocolSigner?: MultiProtocolSignerManager;
 }
 
 interface ApplyParams extends DeployParams {
@@ -41,7 +46,6 @@ interface ApplyParams extends DeployParams {
 export async function runCoreDeploy(params: DeployParams) {
   const { context, config } = params;
   let chain = params.chain;
-
   const {
     isDryRun,
     chainMetadata,
@@ -49,6 +53,7 @@ export async function runCoreDeploy(params: DeployParams) {
     registry,
     skipConfirmation,
     multiProvider,
+    multiProtocolSigner,
   } = context;
 
   // Select a dry-run chain if it's not supplied
@@ -65,42 +70,75 @@ export async function runCoreDeploy(params: DeployParams) {
   if (!skipConfirmation)
     apiKeys = await requestAndSaveApiKeys([chain], chainMetadata, registry);
 
-  const signer = multiProvider.getSigner(chain);
-
   const deploymentParams: DeployParams = {
-    context: { ...context, signer },
+    context: { ...context },
     chain,
     config,
   };
 
-  await runDeployPlanStep(deploymentParams);
-  await runPreflightChecksForChains({
-    ...deploymentParams,
-    chains: [chain],
-    minGas: MINIMUM_CORE_DEPLOY_GAS,
-  });
+  let deployedAddresses: ChainAddresses;
+  switch (multiProvider.getProtocol(chain)) {
+    case ProtocolType.Ethereum:
+      {
+        const signer = multiProvider.getSigner(chain);
+        await runDeployPlanStep(deploymentParams);
 
-  const userAddress = await signer.getAddress();
+        await runPreflightChecksForChains({
+          ...deploymentParams,
+          chains: [chain],
+          minGas: MINIMUM_CORE_DEPLOY_GAS,
+        });
 
-  const initialBalances = await prepareDeploy(context, userAddress, [chain]);
+        const userAddress = await signer.getAddress();
 
-  const contractVerifier = new ContractVerifier(
-    multiProvider,
-    apiKeys,
-    coreBuildArtifact,
-    ExplorerLicenseType.MIT,
-  );
+        const initialBalances = await prepareDeploy(context, userAddress, [
+          chain,
+        ]);
 
-  logBlue('🚀 All systems ready, captain! Beginning deployment...');
-  const evmCoreModule = await EvmCoreModule.create({
-    chain,
-    config,
-    multiProvider,
-    contractVerifier,
-  });
+        const contractVerifier = new ContractVerifier(
+          multiProvider,
+          apiKeys,
+          coreBuildArtifact,
+          ExplorerLicenseType.MIT,
+        );
 
-  await completeDeploy(context, 'core', initialBalances, userAddress, [chain]);
-  const deployedAddresses = evmCoreModule.serialize();
+        logBlue('🚀 All systems ready, captain! Beginning deployment...');
+        const evmCoreModule = await EvmCoreModule.create({
+          chain,
+          config,
+          multiProvider,
+          contractVerifier,
+        });
+
+        await completeDeploy(context, 'core', initialBalances, userAddress, [
+          chain,
+        ]);
+        deployedAddresses = evmCoreModule.serialize();
+      }
+      break;
+
+    case ProtocolType.CosmosNative:
+      {
+        const signer =
+          multiProtocolSigner?.getCosmosNativeSigner(chain) ?? null;
+        assert(signer, 'Cosmos Native signer failed!');
+
+        logBlue('🚀 All systems ready, captain! Beginning deployment...');
+
+        const cosmosNativeCoreModule = await CosmosNativeCoreModule.create({
+          chain,
+          config,
+          multiProvider,
+          signer,
+        });
+
+        deployedAddresses = cosmosNativeCoreModule.serialize();
+      }
+      break;
+
+    default:
+      throw new Error('Chain protocol is not supported yet!');
+  }
 
   if (!isDryRun) {
     await registry.updateChain({
@@ -115,29 +153,72 @@ export async function runCoreDeploy(params: DeployParams) {
 
 export async function runCoreApply(params: ApplyParams) {
   const { context, chain, deployedCoreAddresses, config } = params;
-  const { multiProvider } = context;
-  const evmCoreModule = new EvmCoreModule(multiProvider, {
-    chain,
-    config,
-    addresses: deployedCoreAddresses,
-  });
+  const { multiProvider, multiProtocolSigner } = context;
 
-  const transactions = await evmCoreModule.update(config);
+  switch (multiProvider.getProtocol(chain)) {
+    case ProtocolType.Ethereum: {
+      const evmCoreModule = new EvmCoreModule(multiProvider, {
+        chain,
+        config,
+        addresses: deployedCoreAddresses,
+      });
 
-  if (transactions.length) {
-    logGray('Updating deployed core contracts');
-    for (const transaction of transactions) {
-      await multiProvider.sendTransaction(
-        // Using the provided chain id because there might be remote chain transactions included in the batch
-        transaction.chainId ?? chain,
-        transaction,
-      );
+      const transactions = await evmCoreModule.update(config);
+
+      if (transactions.length) {
+        logGray('Updating deployed core contracts');
+        for (const transaction of transactions) {
+          await multiProvider.sendTransaction(
+            // Using the provided chain id because there might be remote chain transactions included in the batch
+            transaction.chainId ?? chain,
+            transaction,
+          );
+        }
+
+        logGreen(`Core config updated on ${chain}.`);
+      } else {
+        logGreen(
+          `Core config on ${chain} is the same as target. No updates needed.`,
+        );
+      }
+      break;
     }
+    case ProtocolType.CosmosNative: {
+      const signer = multiProtocolSigner?.getCosmosNativeSigner(chain) ?? null;
+      assert(signer, 'Cosmos Native signer failed!');
 
-    logGreen(`Core config updated on ${chain}.`);
-  } else {
-    logGreen(
-      `Core config on ${chain} is the same as target. No updates needed.`,
-    );
+      const cosmosNativeCoreModule = new CosmosNativeCoreModule(
+        multiProvider,
+        signer,
+        {
+          chain,
+          config,
+          addresses: deployedCoreAddresses,
+        },
+      );
+
+      const transactions = await cosmosNativeCoreModule.update(config);
+
+      if (transactions.length) {
+        logGray('Updating deployed core contracts');
+        const response = await signer.signAndBroadcast(
+          signer.account.address,
+          transactions,
+          2,
+        );
+
+        assert(
+          response.code === 0,
+          `Transaction failed with status code ${response.code}`,
+        );
+
+        logGreen(`Core config updated on ${chain}.`);
+      } else {
+        logGreen(
+          `Core config on ${chain} is the same as target. No updates needed.`,
+        );
+      }
+      break;
+    }
   }
 }

--- a/typescript/cli/src/read/core.ts
+++ b/typescript/cli/src/read/core.ts
@@ -1,5 +1,10 @@
-import { ChainName, CoreConfig, EvmCoreReader } from '@hyperlane-xyz/sdk';
-import { Address, assert } from '@hyperlane-xyz/utils';
+import {
+  ChainName,
+  CoreConfig,
+  CosmosNativeCoreReader,
+  EvmCoreReader,
+} from '@hyperlane-xyz/sdk';
+import { Address, ProtocolType, assert } from '@hyperlane-xyz/utils';
 
 import { CommandContext } from '../context/types.js';
 import { errorRed } from '../logger.js';
@@ -23,17 +28,46 @@ export async function executeCoreRead({
     );
   }
 
-  const evmCoreReader = new EvmCoreReader(context.multiProvider, chain);
-  try {
-    return evmCoreReader.deriveCoreConfig({
-      mailbox,
-      interchainAccountRouter: addresses?.interchainAccountRouter,
-    });
-  } catch (e: any) {
-    errorRed(
-      `❌ Failed to read core config for mailbox ${mailbox} on ${chain}:`,
-      e,
-    );
-    process.exit(1);
+  const protocolType = context.multiProvider.getProtocol(chain);
+
+  switch (protocolType) {
+    case ProtocolType.Ethereum: {
+      const evmCoreReader = new EvmCoreReader(context.multiProvider, chain);
+      try {
+        return evmCoreReader.deriveCoreConfig({
+          mailbox,
+          interchainAccountRouter: addresses?.interchainAccountRouter,
+        });
+      } catch (e: any) {
+        errorRed(
+          `❌ Failed to read core config for mailbox ${mailbox} on ${chain}:`,
+          e,
+        );
+        process.exit(1);
+      }
+      break;
+    }
+    case ProtocolType.CosmosNative: {
+      const cosmosProvider =
+        await context.multiProtocolProvider!.getCosmJsNativeProvider(chain);
+      const cosmosCoreReader = new CosmosNativeCoreReader(
+        context.multiProvider,
+        cosmosProvider,
+      );
+      try {
+        return cosmosCoreReader.deriveCoreConfig(mailbox);
+      } catch (e: any) {
+        errorRed(
+          `❌ Failed to read core config for mailbox ${mailbox} on ${chain}:`,
+          e,
+        );
+        process.exit(1);
+      }
+      break;
+    }
+    default: {
+      errorRed(`❌ Core Read not supported for protocol type ${protocolType}:`);
+      process.exit(1);
+    }
   }
 }


### PR DESCRIPTION
### Description

This PR finally adds support for Cosmos Native Core Init, Read, Deploy & Apply.

Note that this is the fifth and last PR of https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/6050 which is being split up in order to make it easier to review

### Drive-by changes

-

### Related issues

-

### Backward compatibility

Yes

### Testing

Manual Tests
