### PR TITLE
refactor: rename `bridgeTolerance` to `bridgeLockTime`

### DIFF
--- a/typescript/cli/src/rebalancer/config/Config.test.ts
+++ b/typescript/cli/src/rebalancer/config/Config.test.ts
@@ -24,13 +24,13 @@ describe('Config', () => {
         weight: 100,
         tolerance: 0,
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       chain2: {
         weight: 100,
         tolerance: 0,
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
     };
 
@@ -63,13 +63,13 @@ describe('Config', () => {
           weight: 100n,
           tolerance: 0n,
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
         chain2: {
           weight: 100n,
           tolerance: 0n,
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
       },
     });
@@ -157,13 +157,13 @@ describe('Config', () => {
           weight: 100n,
           tolerance: 0n,
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
         chain2: {
           weight: 100n,
           tolerance: 0n,
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
       },
     });
@@ -179,7 +179,7 @@ describe('Config', () => {
         chain1: {
           minAmount: 1000,
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
           override: {
             chain2: {
               bridge: '0x1234567890123456789012345678901234567890',
@@ -189,12 +189,12 @@ describe('Config', () => {
         chain2: {
           minAmount: 2000,
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
         chain3: {
           minAmount: 3000,
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
       };
 
@@ -223,7 +223,7 @@ describe('Config', () => {
         chain1: {
           minAmount: 1000,
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
           override: {
             chain2: {
               bridge: '0x1234567890123456789012345678901234567890',
@@ -236,7 +236,7 @@ describe('Config', () => {
         chain2: {
           minAmount: 2000,
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
       };
 
@@ -256,7 +256,7 @@ describe('Config', () => {
         chain1: {
           minAmount: 1000,
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
           override: {
             chain1: {
               bridgeMinAcceptedAmount: 1000,
@@ -266,7 +266,7 @@ describe('Config', () => {
         chain2: {
           minAmount: 2000,
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
       };
 
@@ -281,7 +281,7 @@ describe('Config', () => {
       data.chain1 = {
         bridge: ethers.constants.AddressZero,
         bridgeMinAcceptedAmount: 3000,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
         weight: 100,
         tolerance: 0,
         override: {
@@ -297,7 +297,7 @@ describe('Config', () => {
       data.chain2 = {
         bridge: ethers.constants.AddressZero,
         bridgeMinAcceptedAmount: 5000,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
         weight: 100,
         tolerance: 0,
       };
@@ -305,7 +305,7 @@ describe('Config', () => {
       data.chain3 = {
         bridge: ethers.constants.AddressZero,
         bridgeMinAcceptedAmount: 6000,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
         weight: 100,
         tolerance: 0,
       };

--- a/typescript/cli/src/rebalancer/config/Config.ts
+++ b/typescript/cli/src/rebalancer/config/Config.ts
@@ -13,7 +13,7 @@ const BaseChainConfigSchema = z.object({
     .or(z.number())
     .transform((val) => BigInt(val))
     .optional(),
-  bridgeTolerance: z
+  bridgeLockTime: z
     .number()
     .positive()
     .describe('Expected time in milliseconds for bridge to process a transfer'),

--- a/typescript/cli/src/rebalancer/executor/WithSemaphore.test.ts
+++ b/typescript/cli/src/rebalancer/executor/WithSemaphore.test.ts
@@ -21,7 +21,7 @@ describe('WithSemaphore', () => {
     const config = {
       chains: {
         chain1: {
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
       },
     } as any as Config;
@@ -45,7 +45,7 @@ describe('WithSemaphore', () => {
     const config = {
       chains: {
         chain1: {
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
       },
     } as any as Config;
@@ -62,7 +62,7 @@ describe('WithSemaphore', () => {
     const config = {
       chains: {
         chain1: {
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
       },
     } as any as Config;
@@ -102,7 +102,7 @@ describe('WithSemaphore', () => {
     const withSemaphore = new WithSemaphore(config, executor);
 
     await expect(withSemaphore.rebalance(routes)).to.be.rejectedWith(
-      "Cannot read properties of undefined (reading 'bridgeTolerance')",
+      "Cannot read properties of undefined (reading 'bridgeLockTime')",
     );
   });
 
@@ -110,7 +110,7 @@ describe('WithSemaphore', () => {
     const config = {
       chains: {
         chain1: {
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
       },
     } as any as Config;

--- a/typescript/cli/src/rebalancer/executor/WithSemaphore.ts
+++ b/typescript/cli/src/rebalancer/executor/WithSemaphore.ts
@@ -46,7 +46,7 @@ export class WithSemaphore implements IExecutor {
     }
 
     // The wait period will be determined by the bridge with the highest wait tolerance
-    const highestTolerance = this.getHighestTolerance(routes);
+    const highestTolerance = this.getHighestLockTime(routes);
 
     try {
       // Execute rebalance
@@ -64,7 +64,7 @@ export class WithSemaphore implements IExecutor {
     );
   }
 
-  private getHighestTolerance(routes: RebalancingRoute[]) {
+  private getHighestLockTime(routes: RebalancingRoute[]) {
     return routes.reduce((highest, route) => {
       // TODO: consider overrides to calculate this value;
       //  Currently it's assuming that the root `bridgeLockTime` value is the highest in the chain config.

--- a/typescript/cli/src/rebalancer/executor/WithSemaphore.ts
+++ b/typescript/cli/src/rebalancer/executor/WithSemaphore.ts
@@ -1,7 +1,7 @@
 import { log } from '../../logger.js';
 import { Config } from '../config/Config.js';
-import { IExecutor } from '../interfaces/IExecutor.js';
-import { RebalancingRoute } from '../interfaces/IStrategy.js';
+import type { IExecutor } from '../interfaces/IExecutor.js';
+import type { RebalancingRoute } from '../interfaces/IStrategy.js';
 
 /**
  * Prevents frequent rebalancing operations while bridges complete.
@@ -28,7 +28,7 @@ export class WithSemaphore implements IExecutor {
       return;
     }
 
-    // No routes means the system is balanced so we reset the timer to allow new rebalancing
+    // No routes mean the system is balanced so we reset the timer to allow new rebalancing
     if (!routes.length) {
       log(
         `No routes to execute. Assuming rebalance is complete. Resetting semaphore timer.`,
@@ -66,10 +66,11 @@ export class WithSemaphore implements IExecutor {
 
   private getHighestTolerance(routes: RebalancingRoute[]) {
     return routes.reduce((highest, route) => {
-      const bridgeTolerance =
-        this.config.chains[route.fromChain].bridgeTolerance;
+      // TODO: consider overrides to calculate this value;
+      //  Currently it's assuming that the root `bridgeLockTime` value is the highest in the chain config.
+      const bridgeLockTime = this.config.chains[route.fromChain].bridgeLockTime;
 
-      return Math.max(highest, bridgeTolerance);
+      return Math.max(highest, bridgeLockTime);
     }, 0);
   }
 }

--- a/typescript/cli/src/rebalancer/strategy/StrategyFactory.test.ts
+++ b/typescript/cli/src/rebalancer/strategy/StrategyFactory.test.ts
@@ -20,13 +20,13 @@ describe('StrategyFactory', () => {
           weight: 100n,
           tolerance: 0n,
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
         chain2: {
           weight: 100n,
           tolerance: 0n,
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
       };
 
@@ -39,12 +39,12 @@ describe('StrategyFactory', () => {
         chain1: {
           minAmount: ethers.utils.parseEther('100').toBigInt(),
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
         chain2: {
           minAmount: ethers.utils.parseEther('100').toBigInt(),
           bridge: ethers.constants.AddressZero,
-          bridgeTolerance: 1,
+          bridgeLockTime: 1,
         },
       };
 

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -178,13 +178,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: '100',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       [CHAIN_NAME_3]: {
         weight: '100',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
     });
 
@@ -334,13 +334,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: 'weight',
         tolerance: 0,
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       [CHAIN_NAME_3]: {
         weight: 100,
         tolerance: 0,
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
     });
 
@@ -354,13 +354,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: 100,
         tolerance: 0,
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       [CHAIN_NAME_3]: {
         weight: 100,
         tolerance: 'tolerance',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
     });
 
@@ -374,13 +374,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: 100,
         tolerance: 0,
         bridge: 'bridge',
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       [CHAIN_NAME_3]: {
         weight: 100,
         tolerance: 0,
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
     });
 
@@ -403,13 +403,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: '75',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       [CHAIN_NAME_3]: {
         weight: '25',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
     });
 
@@ -425,13 +425,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: '75',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       [CHAIN_NAME_3]: {
         weight: '25',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
     });
 
@@ -447,13 +447,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: '75',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       [CHAIN_NAME_3]: {
         weight: '25',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
     });
 
@@ -486,13 +486,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: '75',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       [CHAIN_NAME_3]: {
         weight: '25',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
     });
 
@@ -529,13 +529,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: '75',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       [CHAIN_NAME_3]: {
         weight: '25',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
     });
 
@@ -610,13 +610,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: '75',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       [CHAIN_NAME_3]: {
         weight: '25',
         tolerance: '0',
         bridge: bridgeContract.address,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
     });
 
@@ -662,13 +662,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: '75',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       [CHAIN_NAME_3]: {
         weight: '25',
         tolerance: '0',
         bridge: bridgeContract.address,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
         bridgeMinAcceptedAmount: '5000000000000000001',
       },
     });
@@ -741,13 +741,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: '75',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       [CHAIN_NAME_3]: {
         weight: '25',
         tolerance: '0',
         bridge: bridgeContract.address,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
     });
 
@@ -865,13 +865,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: '75',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 10000,
+        bridgeLockTime: 10000,
       },
       [CHAIN_NAME_3]: {
         weight: '25',
         tolerance: '0',
         bridge: bridgeContract.address,
-        bridgeTolerance: 10000,
+        bridgeLockTime: 10000,
       },
     });
 
@@ -892,13 +892,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: '75',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       [CHAIN_NAME_3]: {
         weight: '25',
         tolerance: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
     });
 
@@ -948,13 +948,13 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         minAmount: '-100',
         buffer: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
       [CHAIN_NAME_3]: {
         minAmount: '100',
         buffer: '0',
         bridge: ethers.constants.AddressZero,
-        bridgeTolerance: 1,
+        bridgeLockTime: 1,
       },
     });
 
@@ -1049,14 +1049,14 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         weight: '25',
         tolerance: '0',
         bridge: otherWarpCoreConfig.tokens[0].addressOrDenom!,
-        bridgeTolerance: 60000,
+        bridgeLockTime: 60000,
         bridgeIsWarp: true,
       },
       [CHAIN_NAME_3]: {
         weight: '75',
         tolerance: '0',
         bridge: otherWarpCoreConfig.tokens[1].addressOrDenom!,
-        bridgeTolerance: 60000,
+        bridgeLockTime: 60000,
         bridgeIsWarp: true,
       },
     });


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

A semantic change. That is not backwards compatible.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

No

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
