### PR TITLE
fix: Avoid holding lock on nonce manager with a remote call

### DIFF
--- a/rust/main/submitter/src/chain_tx_adapter/chains/ethereum/nonce/manager.rs
+++ b/rust/main/submitter/src/chain_tx_adapter/chains/ethereum/nonce/manager.rs
@@ -2,6 +2,10 @@
 // implementing the trait for the boxed type would require a lot of boilerplate code.
 #![allow(clippy::borrowed_box)]
 
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
 use hyperlane_ethereum::EvmProviderForSubmitter;
 
 use crate::transaction::Transaction;
@@ -10,13 +14,13 @@ use crate::SubmitterError;
 use super::super::transaction::Precursor;
 
 pub struct NonceManager {
-    pub tx_in_finality_count: usize,
+    pub tx_in_finality_count: Arc<Mutex<usize>>,
 }
 
 impl NonceManager {
     pub fn new() -> Self {
         Self {
-            tx_in_finality_count: 0,
+            tx_in_finality_count: Arc::new(Mutex::new(0usize)),
         }
     }
 
@@ -38,10 +42,18 @@ impl NonceManager {
                 "Transaction missing address".to_string(),
             ))?;
         let nonce = provider.get_next_nonce_on_finalized_block(address).await?;
-        let next_nonce = nonce + self.tx_in_finality_count;
+        let next_nonce = nonce + self.get_tx_in_finality_count().await as u64;
 
         precursor.tx.set_nonce(next_nonce);
 
         Ok(())
+    }
+
+    pub async fn set_tx_in_finality_count(&self, count: usize) {
+        *self.tx_in_finality_count.lock().await = count;
+    }
+
+    async fn get_tx_in_finality_count(&self) -> usize {
+        *self.tx_in_finality_count.lock().await
     }
 }


### PR DESCRIPTION
### Description

Avoid holding lock on nonce manager with a remote call.

Now we are using internal mutability to update the number of non finalized transactions in nonce manager

### Backward compatibility

Yes

### Testing

None