### PR TITLE
fix: add repository to starknet package.json

### DIFF
--- a/starknet/package.json
+++ b/starknet/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "homepage": "https://www.hyperlane.xyz",
   "license": "Apache-2.0",
+  "repository": "https://github.com/hyperlane-xyz/hyperlane-monorepo",
   "scripts": {
     "fetch-contracts": "./scripts/fetch-contracts-release.sh",
     "generate-artifacts": "tsx ./scripts/generate-artifacts.ts",


### PR DESCRIPTION
### Description

fix: add repository to starknet package.json
- fixes https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/15112270943/job/42478647721#step:5:759
- matches cosmos-sdk/cosmos-types/sdk/utils packages

```
error an error occurred while publishing @hyperlane-xyz/starknet-core: E422 422 Unprocessable Entity - PUT https://registry.npmjs.org/@hyperlane-xyz%2fstarknet-core - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/hyperlane-xyz/hyperlane-monorepo" from provenance 
```

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
