### PR TITLE
refactor: simplify ccip read ISM

### DIFF
--- a/.changeset/beige-falcons-brake.md
+++ b/.changeset/beige-falcons-brake.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": major
+---
+
+Refactor MailboxClient and AbstractCCIPReadIsm

--- a/solidity/contracts/client/MailboxClient.sol
+++ b/solidity/contracts/client/MailboxClient.sol
@@ -36,7 +36,7 @@ abstract contract MailboxClient is OwnableUpgradeable, PackageVersioned {
 
     IPostDispatchHook public hook;
 
-    IInterchainSecurityModule public interchainSecurityModule;
+    IInterchainSecurityModule internal _interchainSecurityModule;
 
     uint256[48] private __GAP; // gap for upgrade safety
 
@@ -74,6 +74,15 @@ abstract contract MailboxClient is OwnableUpgradeable, PackageVersioned {
         _transferOwnership(msg.sender);
     }
 
+    function interchainSecurityModule()
+        external
+        view
+        virtual
+        returns (IInterchainSecurityModule)
+    {
+        return _interchainSecurityModule;
+    }
+
     /**
      * @notice Sets the address of the application's custom hook.
      * @param _hook The address of the hook contract.
@@ -92,19 +101,19 @@ abstract contract MailboxClient is OwnableUpgradeable, PackageVersioned {
     function setInterchainSecurityModule(
         address _module
     ) public onlyContractOrNull(_module) onlyOwner {
-        interchainSecurityModule = IInterchainSecurityModule(_module);
+        _interchainSecurityModule = IInterchainSecurityModule(_module);
         emit IsmSet(_module);
     }
 
     // ======== Initializer =========
     function _MailboxClient_initialize(
         address _hook,
-        address _interchainSecurityModule,
+        address __interchainSecurityModule,
         address _owner
     ) internal onlyInitializing {
         __Ownable_init();
         setHook(_hook);
-        setInterchainSecurityModule(_interchainSecurityModule);
+        setInterchainSecurityModule(__interchainSecurityModule);
         _transferOwnership(_owner);
     }
 

--- a/solidity/contracts/isms/ccip-read/CommitmentReadIsm.sol
+++ b/solidity/contracts/isms/ccip-read/CommitmentReadIsm.sol
@@ -27,11 +27,8 @@ contract CommitmentReadIsm is AbstractCcipReadIsm {
     using Message for bytes;
     using TypeCasts for bytes32;
 
-    constructor(
-        address _mailbox,
-        address _owner,
-        string[] memory _urls
-    ) MailboxClient(_mailbox) {
+    constructor(address _owner, string[] memory _urls) {
+        _transferOwnership(msg.sender);
         setUrls(_urls);
         _transferOwnership(_owner);
     }

--- a/solidity/contracts/isms/ccip-read/CommitmentReadIsm.sol
+++ b/solidity/contracts/isms/ccip-read/CommitmentReadIsm.sol
@@ -11,45 +11,39 @@ import {CallLib} from "../../middleware/libs/Call.sol";
 import {Message} from "../../libs/Message.sol";
 import {TypeCasts} from "../../libs/TypeCasts.sol";
 import {OwnableMulticall} from "../../middleware/libs/OwnableMulticall.sol";
+import {MailboxClient} from "../../client/MailboxClient.sol";
 
-contract CommitmentReadIsm is AbstractCcipReadIsm, Ownable {
+interface CommitmentReadIsmService {
+    function getCallsFromCommitment(
+        bytes32 _commitment
+    )
+        external
+        view
+        returns (address ica, bytes32 salt, CallLib.Call[] memory _calls);
+}
+
+contract CommitmentReadIsm is AbstractCcipReadIsm {
     using InterchainAccountMessageReveal for bytes;
     using Message for bytes;
     using TypeCasts for bytes32;
 
-    string[] public urls;
-    Mailbox public immutable mailbox;
-
-    constructor(Mailbox _mailbox, address _owner) {
-        mailbox = _mailbox;
+    constructor(
+        address _mailbox,
+        address _owner,
+        string[] memory _urls
+    ) MailboxClient(_mailbox) {
+        setUrls(_urls);
         _transferOwnership(_owner);
     }
 
-    function setUrls(string[] memory _urls) external onlyOwner {
-        urls = _urls;
-    }
-
-    function getOffchainVerifyInfo(
+    function _offchainLookupCalldata(
         bytes calldata _message
-    ) external view override {
-        revert OffchainLookup({
-            sender: address(this),
-            urls: urls,
-            callData: abi.encodeWithSignature(
-                "getCallsFromCommitment(bytes32)",
-                _message.body().commitment()
-            ),
-            callbackFunction: this.process.selector,
-            extraData: _message
-        });
-    }
-
-    /// @dev called by the relayer when the off-chain data is ready
-    function process(
-        bytes calldata _metadata,
-        bytes calldata _message
-    ) external {
-        mailbox.process(_metadata, _message);
+    ) internal pure override returns (bytes memory) {
+        return
+            abi.encodeCall(
+                CommitmentReadIsmService.getCallsFromCommitment,
+                (_message.body().commitment())
+            );
     }
 
     /**

--- a/solidity/contracts/isms/ccip-read/TestCccipReadIsm.sol
+++ b/solidity/contracts/isms/ccip-read/TestCccipReadIsm.sol
@@ -1,14 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.8.0;
 
-error OffchainLookup(
-    address sender,
-    string[] urls,
-    bytes callData,
-    bytes4 callbackFunction,
-    bytes extraData
-);
-
 import "../../interfaces/isms/ICcipReadIsm.sol";
 import "../../interfaces/IInterchainSecurityModule.sol";
 import "../../interfaces/IMailbox.sol";
@@ -20,23 +12,20 @@ import "./AbstractCcipReadIsm.sol";
  * @notice A test CCIP-Read ISM that simply checks the passed metadata as a boolean.
  */
 contract TestCcipReadIsm is AbstractCcipReadIsm {
-    string[] public urls;
-
-    constructor(string[] memory _urls) {
-        urls = _urls;
+    constructor(string[] memory _urls) MailboxClient(address(0)) {
+        setUrls(_urls);
     }
 
-    function getOffchainVerifyInfo(
-        bytes calldata _message
-    ) external view override {
-        // Revert with OffchainLookup to instruct off-chain resolution
-        revert OffchainLookup(address(this), urls, _message, bytes4(0), "");
+    function _offchainLookupCalldata(
+        bytes calldata /*_message*/
+    ) internal pure override returns (bytes memory) {
+        return bytes("");
     }
 
     function verify(
         bytes calldata metadata,
         bytes calldata
-    ) external view override returns (bool) {
+    ) external pure override returns (bool) {
         bool ok = abi.decode(metadata, (bool));
         require(ok, "TestCcipReadIsm: invalid metadata");
         return true;

--- a/solidity/contracts/isms/ccip-read/TestCccipReadIsm.sol
+++ b/solidity/contracts/isms/ccip-read/TestCccipReadIsm.sol
@@ -12,7 +12,7 @@ import "./AbstractCcipReadIsm.sol";
  * @notice A test CCIP-Read ISM that simply checks the passed metadata as a boolean.
  */
 contract TestCcipReadIsm is AbstractCcipReadIsm {
-    constructor(string[] memory _urls) MailboxClient(address(0)) {
+    constructor(string[] memory _urls) {
         setUrls(_urls);
     }
 

--- a/solidity/contracts/isms/hook/OPL2ToL1CcipReadIsm.sol
+++ b/solidity/contracts/isms/hook/OPL2ToL1CcipReadIsm.sol
@@ -11,7 +11,6 @@ import {IMessageRecipient} from "../../interfaces/IMessageRecipient.sol";
 import {IOptimismPortal} from "../../interfaces/optimism/IOptimismPortal.sol";
 import {IOptimismPortal2} from "../../interfaces/optimism/IOptimismPortal2.sol";
 import {IInterchainSecurityModule, ISpecifiesInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
-import {MailboxClient} from "../../client/MailboxClient.sol";
 
 interface OpL2toL1Service {
     function getWithdrawalProof(
@@ -36,7 +35,11 @@ interface OpL2toL1Service {
  * ISM because OP Stack expects the prover and the finalizer to
  * be the same caller
  */
-contract OPL2ToL1CcipReadIsm is AbstractCcipReadIsm, IMessageRecipient {
+contract OPL2ToL1CcipReadIsm is
+    AbstractCcipReadIsm,
+    IMessageRecipient,
+    ISpecifiesInterchainSecurityModule
+{
     using Message for bytes;
     using TypeCasts for address;
 
@@ -59,10 +62,8 @@ contract OPL2ToL1CcipReadIsm is AbstractCcipReadIsm, IMessageRecipient {
     constructor(
         string[] memory _urls,
         address _opPortal,
-        uint32 _opPortalVersion,
-        address _mailbox
-    ) MailboxClient(_mailbox) {
-        require(_urls.length > 0, "URLs array is empty");
+        uint32 _opPortalVersion
+    ) {
         require(
             _opPortalVersion == OP_PORTAL_VERSION_1 ||
                 _opPortalVersion == OP_PORTAL_VERSION_2,
@@ -70,6 +71,7 @@ contract OPL2ToL1CcipReadIsm is AbstractCcipReadIsm, IMessageRecipient {
         );
         opPortalVersion = _opPortalVersion;
         opPortal = IOptimismPortal(_opPortal);
+        _transferOwnership(msg.sender);
         setUrls(_urls);
     }
 

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -116,11 +116,7 @@ contract InterchainAccountRouter is Router, AbstractRoutingIsm {
         implementation = Create2.deploy(0, bytes32(0), bytecode);
         bytecodeHash = _proxyBytecodeHash(implementation);
 
-        CCIP_READ_ISM = new CommitmentReadIsm(
-            _mailbox,
-            _owner,
-            _commitment_urls
-        );
+        CCIP_READ_ISM = new CommitmentReadIsm(_owner, _commitment_urls);
         COMMIT_TX_GAS_USAGE = _commit_tx_gas_usage;
     }
 

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -106,7 +106,8 @@ contract InterchainAccountRouter is Router, AbstractRoutingIsm {
         address _mailbox,
         address _hook,
         address _owner,
-        uint _commit_tx_gas_usage
+        uint _commit_tx_gas_usage,
+        string[] memory _commitment_urls
     ) Router(_mailbox) {
         setHook(_hook);
         _transferOwnership(_owner);
@@ -115,9 +116,21 @@ contract InterchainAccountRouter is Router, AbstractRoutingIsm {
         implementation = Create2.deploy(0, bytes32(0), bytecode);
         bytecodeHash = _proxyBytecodeHash(implementation);
 
-        CCIP_READ_ISM = new CommitmentReadIsm(Mailbox(_mailbox), _owner);
-        interchainSecurityModule = IInterchainSecurityModule(address(this));
+        CCIP_READ_ISM = new CommitmentReadIsm(
+            _mailbox,
+            _owner,
+            _commitment_urls
+        );
         COMMIT_TX_GAS_USAGE = _commit_tx_gas_usage;
+    }
+
+    function interchainSecurityModule()
+        external
+        view
+        override
+        returns (IInterchainSecurityModule)
+    {
+        return IInterchainSecurityModule(address(this));
     }
 
     /**

--- a/solidity/contracts/test/TestCcipReadIsm.sol
+++ b/solidity/contracts/test/TestCcipReadIsm.sol
@@ -20,8 +20,6 @@ contract TestCcipReadIsm is AbstractCcipReadIsm, IMessageRecipient {
         bytes message
     );
 
-    constructor(address _mailbox) MailboxClient(_mailbox) {}
-
     function _offchainLookupCalldata(
         bytes calldata /*_message*/
     ) internal pure override returns (bytes memory) {
@@ -46,14 +44,5 @@ contract TestCcipReadIsm is AbstractCcipReadIsm, IMessageRecipient {
         bytes calldata _messageBody
     ) external payable {
         emit ReceivedMessage(_origin, _sender, msg.value, _messageBody);
-    }
-
-    function interchainSecurityModule()
-        external
-        view
-        override
-        returns (IInterchainSecurityModule)
-    {
-        return IInterchainSecurityModule(address(this));
     }
 }

--- a/solidity/contracts/test/TestCcipReadIsm.sol
+++ b/solidity/contracts/test/TestCcipReadIsm.sol
@@ -8,14 +8,10 @@ import {ICcipReadIsm} from "../interfaces/isms/ICcipReadIsm.sol";
 import {IMessageRecipient} from "../interfaces/IMessageRecipient.sol";
 import {IOptimismPortal} from "../interfaces/optimism/IOptimismPortal.sol";
 import {IInterchainSecurityModule, ISpecifiesInterchainSecurityModule} from "../interfaces/IInterchainSecurityModule.sol";
+import {MailboxClient} from "../client/MailboxClient.sol";
 
-contract TestCcipReadIsm is
-    AbstractCcipReadIsm,
-    IMessageRecipient,
-    ISpecifiesInterchainSecurityModule
-{
+contract TestCcipReadIsm is AbstractCcipReadIsm, IMessageRecipient {
     uint8 public receivedMessages = 0;
-    IMailbox public mailbox;
 
     event ReceivedMessage(
         uint32 indexed origin,
@@ -24,34 +20,17 @@ contract TestCcipReadIsm is
         bytes message
     );
 
-    constructor(address _mailbox) {
-        mailbox = IMailbox(_mailbox);
-    }
+    constructor(address _mailbox) MailboxClient(_mailbox) {}
 
-    function getOffchainVerifyInfo(
-        bytes calldata _message
-    ) external view override {
-        string[] memory urls;
-        revert OffchainLookup(
-            address(this),
-            urls,
-            bytes(""),
-            TestCcipReadIsm.process.selector,
-            _message
-        );
-    }
-
-    /// @dev called by the relayer when the off-chain data is ready
-    function process(
-        bytes calldata _metadata,
-        bytes calldata _message
-    ) external {
-        mailbox.process(_metadata, _message);
+    function _offchainLookupCalldata(
+        bytes calldata /*_message*/
+    ) internal pure override returns (bytes memory) {
+        return bytes("");
     }
 
     function verify(
-        bytes calldata _metadata,
-        bytes calldata _message
+        bytes calldata /*_metadata*/,
+        bytes calldata /*_message*/
     ) external override returns (bool) {
         receivedMessages++;
 

--- a/solidity/contracts/token/TokenBridgeCctp.sol
+++ b/solidity/contracts/token/TokenBridgeCctp.sol
@@ -19,9 +19,6 @@ abstract contract TokenBridgeCctp is
     // @notice CCTP message transmitter contract
     IMessageTransmitter public immutable messageTransmitter;
 
-    // @notice CCIP-read URLs
-    string[] public urls;
-
     /// @notice Hyperlane domain => Circle domain.
     /// ATM, known Circle domains are Ethereum = 0, Avalanche = 1, Optimism = 2, Arbitrum = 3.
     /// Note this could result in ambiguity between the Circle domain being
@@ -37,11 +34,6 @@ abstract contract TokenBridgeCctp is
     event DomainAdded(uint32 indexed hyperlaneDomain, uint32 circleDomain);
 
     /**
-     * @notice Emitted when new CCIP-read urls are being set
-     */
-    event UrlsChanged(string[] newUrls);
-
-    /**
      * @notice Raised when the version in use by the TokenMessenger
      * is not recognized
      */
@@ -53,18 +45,7 @@ abstract contract TokenBridgeCctp is
         address _mailbox,
         IMessageTransmitter _messageTransmitter
     ) HypERC20Collateral(_erc20, _scale, _mailbox) {
-        interchainSecurityModule = IInterchainSecurityModule(address(this));
         messageTransmitter = _messageTransmitter;
-    }
-
-    /**
-     * @notice Set the CCIP-read URLs
-     * @param _urls URLs to be added
-     */
-    function setUrls(string[] memory _urls) external onlyOwner {
-        urls = _urls;
-
-        emit UrlsChanged(_urls);
     }
 
     /**
@@ -113,24 +94,10 @@ abstract contract TokenBridgeCctp is
         quotes[0] = Quote(address(0), quoteGasPayment(_destination));
     }
 
-    function getOffchainVerifyInfo(
+    function _offchainLookupCalldata(
         bytes calldata _message
-    ) external view override {
-        revert OffchainLookup(
-            address(this),
-            urls,
-            abi.encodeWithSignature("getCCTPAttestation(bytes)", _message),
-            this.process.selector,
-            _message
-        );
-    }
-
-    /// @dev called by the relayer when the off-chain data is ready
-    function process(
-        bytes calldata _metadata,
-        bytes calldata _message
-    ) external {
-        mailbox.process(_metadata, _message);
+    ) internal view virtual override returns (bytes memory) {
+        return abi.encodeWithSignature("getCCTPAttestation(bytes)", _message);
     }
 
     function verify(

--- a/solidity/contracts/token/TokenBridgeCctp.sol
+++ b/solidity/contracts/token/TokenBridgeCctp.sol
@@ -8,6 +8,15 @@ import {IMessageTransmitter} from "../interfaces/cctp/IMessageTransmitter.sol";
 import {IInterchainSecurityModule} from "../interfaces/IInterchainSecurityModule.sol";
 import {AbstractCcipReadIsm} from "../isms/ccip-read/AbstractCcipReadIsm.sol";
 
+interface CctpService {
+    function getCCTPAttestation(
+        bytes calldata _message
+    )
+        external
+        view
+        returns (bytes memory cctpMessage, bytes memory attestation);
+}
+
 abstract contract TokenBridgeCctp is
     ITokenBridge,
     HypERC20Collateral,
@@ -97,7 +106,7 @@ abstract contract TokenBridgeCctp is
     function _offchainLookupCalldata(
         bytes calldata _message
     ) internal view virtual override returns (bytes memory) {
-        return abi.encodeWithSignature("getCCTPAttestation(bytes)", _message);
+        return abi.encodeCall(CctpService.getCCTPAttestation, (_message));
     }
 
     function verify(

--- a/solidity/script/TokenBridgeScript.s.sol
+++ b/solidity/script/TokenBridgeScript.s.sol
@@ -121,8 +121,7 @@ contract TokenBridgeScript is Script {
         OPL2ToL1CcipReadIsm ism = new OPL2ToL1CcipReadIsm(
             urls,
             opPortal,
-            portalVersion,
-            mailboxDestination
+            portalVersion
         );
         console.log("OPL2ToL1CcipReadIsm @", address(ism));
 

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -1025,7 +1025,7 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
         bytes memory metadata = _get_metadata(ica, salt, calls);
         CommitmentReadIsm _ism = destinationIcaRouter.CCIP_READ_ISM();
         vm.expectRevert("ICA: Invalid Reveal");
-        _ism.process(metadata, message);
+        _ism.verify(metadata, message);
     }
 
     function testFuzz_callRemoteCommitReveal_simpleOverload(

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -81,7 +81,8 @@ contract InterchainAccountRouterTestBase is Test {
                 address(_mailbox),
                 address(_customHook),
                 _owner,
-                20_000
+                20_000,
+                new string[](0)
             );
     }
 

--- a/solidity/test/isms/CommitmentReadIsm.t.sol
+++ b/solidity/test/isms/CommitmentReadIsm.t.sol
@@ -31,7 +31,7 @@ contract CommitmentReadIsmTest is Test {
         environment = new MockHyperlaneEnvironment(origin, destination);
         mailboxOrigin = environment.mailboxes(origin);
         mailboxDestination = environment.mailboxes(destination);
-        ism = new CommitmentReadIsm(address(mailboxDestination), alice, urls);
+        ism = new CommitmentReadIsm(alice, urls);
     }
 
     function testUrls() public {

--- a/solidity/test/isms/CommitmentReadIsm.t.sol
+++ b/solidity/test/isms/CommitmentReadIsm.t.sol
@@ -31,12 +31,7 @@ contract CommitmentReadIsmTest is Test {
         environment = new MockHyperlaneEnvironment(origin, destination);
         mailboxOrigin = environment.mailboxes(origin);
         mailboxDestination = environment.mailboxes(destination);
-        ism = new CommitmentReadIsm(mailboxDestination, alice);
-
-        vm.prank(alice);
-        ism.setUrls(urls);
-        assertEq(urls.length, 1);
-        assertEq(urls[0], "https://ccip-server-gateway.io");
+        ism = new CommitmentReadIsm(address(mailboxDestination), alice, urls);
     }
 
     function testUrls() public {
@@ -45,7 +40,7 @@ contract CommitmentReadIsmTest is Test {
 
         vm.prank(alice);
         ism.setUrls(newUrls);
-        assertEq(ism.urls(0), "https:://foobar.io");
+        assertEq(ism.urls()[0], "https:://foobar.io");
 
         // Setting urls doesn't work if you aren't the owner
         vm.expectRevert("Ownable: caller is not the owner");

--- a/solidity/test/isms/OPL2ToL1CcipReadIsm.t.sol
+++ b/solidity/test/isms/OPL2ToL1CcipReadIsm.t.sol
@@ -52,12 +52,7 @@ contract OPL2ToL1CcipReadIsmTest is Test {
         tokenBridgeDestination = address(new LightTestRecipient());
         uint32 portalVersion = 1;
 
-        ism = new OPL2ToL1CcipReadIsm(
-            urls,
-            address(portal),
-            portalVersion,
-            address(mailboxDestination)
-        );
+        ism = new OPL2ToL1CcipReadIsm(urls, address(portal), portalVersion);
 
         mailboxDestination.setDefaultIsm(address(ism));
         mailboxDestination.addRemoteMailbox(origin, mailboxOrigin);
@@ -171,7 +166,7 @@ contract OPL2ToL1CcipReadIsmTest is Test {
             0,
             bytes("")
         );
-        ism.process(metadata, message);
+        mailboxDestination.process(metadata, message);
     }
 
     function testFuzz_constructor_revertWhen_creatingWithWrongPortalVersion(
@@ -181,11 +176,6 @@ contract OPL2ToL1CcipReadIsmTest is Test {
         vm.assume(portalVersion != 2);
 
         vm.expectRevert(bytes("Unsupported OP portal version"));
-        ism = new OPL2ToL1CcipReadIsm(
-            urls,
-            address(portal),
-            portalVersion,
-            address(mailboxDestination)
-        );
+        ism = new OPL2ToL1CcipReadIsm(urls, address(portal), portalVersion);
     }
 }

--- a/solidity/test/token/OPL2ToL1TokenBridgeNative.t.sol
+++ b/solidity/test/token/OPL2ToL1TokenBridgeNative.t.sol
@@ -98,7 +98,7 @@ contract OPL2ToL1TokenBridgeNativeTest is Test {
     }
 
     function deployIsm() public {
-        ism = new TestCcipReadIsm(address(environment.mailboxes(destination)));
+        ism = new TestCcipReadIsm();
     }
 
     function deployAll() public {

--- a/solidity/test/token/TokenBridgeCctp.t.sol
+++ b/solidity/test/token/TokenBridgeCctp.t.sol
@@ -186,7 +186,7 @@ contract TokenBridgeCctpV1Test is Test {
             user.addressToBytes32(),
             amount
         );
-        tbDestination.process(ccipReadData, message);
+        tbDestination.verify(ccipReadData, message);
 
         uint256 tokenBalance = tokenDestination.balanceOf(user);
         assertEq(tokenBalance, amount);
@@ -226,7 +226,7 @@ contract TokenBridgeCctpV1Test is Test {
                 address(tbDestination),
                 urls,
                 abi.encodeWithSignature("getCCTPAttestation(bytes)", message),
-                tbDestination.process.selector,
+                tbDestination.verify.selector,
                 message
             )
         );


### PR DESCRIPTION
### Description

- Enables overriding `MailboxClient.interchainSecurityModule` to avoid unnecessary SLOAD
- Pulls URL config into shared contract
- Shares event revert and mailbox process logic

### Backward compatibility

No

### Testing

Unit Tests
