### PR TITLE
feat: Pass the whole message through commitment read ism

### DIFF
--- a/solidity/contracts/isms/ccip-read/CommitmentReadIsm.sol
+++ b/solidity/contracts/isms/ccip-read/CommitmentReadIsm.sol
@@ -14,8 +14,8 @@ import {OwnableMulticall} from "../../middleware/libs/OwnableMulticall.sol";
 import {MailboxClient} from "../../client/MailboxClient.sol";
 
 interface CommitmentReadIsmService {
-    function getCallsFromCommitment(
-        bytes32 _commitment
+    function getCallsFromRevealMessage(
+        bytes memory _message
     )
         external
         view
@@ -38,8 +38,8 @@ contract CommitmentReadIsm is AbstractCcipReadIsm {
     ) internal pure override returns (bytes memory) {
         return
             abi.encodeCall(
-                CommitmentReadIsmService.getCallsFromCommitment,
-                (_message.body().commitment())
+                CommitmentReadIsmService.getCallsFromRevealMessage,
+                (_message)
             );
     }
 


### PR DESCRIPTION
### Description

We need to pass through the whole message, so that we can determine the message ID for the reveal message that we can associated with the calls that were posted, otherwise it is not possible to determine which ICA needs to be passed in the metadata
