### PR TITLE
chore(svm client: parse domains directly as u32

### DIFF
--- a/rust/sealevel/client/src/multisig_ism.rs
+++ b/rust/sealevel/client/src/multisig_ism.rs
@@ -54,11 +54,7 @@ pub(crate) fn process_multisig_ism_message_id_cmd(mut ctx: Context, cmd: Multisi
             let chain_dir = create_new_directory(&ism_dir, &deploy.chain);
             let context_dir = create_new_directory(&chain_dir, &deploy.context);
             let key_dir = create_new_directory(&context_dir, "keys");
-            let local_domain = deploy
-                .chain
-                .parse::<KnownHyperlaneDomain>()
-                .map(|v| v as u32)
-                .expect("Invalid chain name");
+            let local_domain = deploy.chain.parse::<u32>().expect("Invalid chain name");
 
             let ism_program_id = deploy_multisig_ism_message_id(
                 &mut ctx,


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
