### PR TITLE
chore: reduce release-e2e-matrix frequency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,28 +61,28 @@ jobs:
       - name: Retrieve package versions
         id: pkg
         run: |
-          versions=$(find . -name 'package.json' -exec jq -r 'select(.private != true) | .name + "@" + .version' {} \;)
-          echo "$versions" | tee versions.txt
+          find . -name 'package.json' -print0 | while IFS= read -r -d '' pkg; do
+            jq -r 'select(.private != true) | .name + "@" + .version' "$pkg"
+          done | tee versions.txt
 
       - name: Compare package versions
         id: check
         run: |
           all_latest=true
           while read -r pkg; do
-            name=$(echo "$pkg" | cut -d'@' -f1)
-            version=$(echo "$pkg" | cut -d'@' -f2)
-            echo "Checking if $name@$version is published..."
-            exists=$(npm view "$name@$version" version 2>/dev/null || echo "N/A")
+            echo "Checking if $pkg is published..."
+            exists=$(npm view "$pkg" version 2>/dev/null || echo "N/A")
             echo "npm returned: $exists"
             if [ "$exists" = "N/A" ]; then
-              echo "$name@$version is NOT published."
+              echo "$pkg is NOT published."
               all_latest=false
               break
             else
-              echo "$name@$version is published."
+              echo "$pkg is published."
             fi
           done < versions.txt
           echo "all_latest=$all_latest" >> $GITHUB_OUTPUT
+
   # If we detect that not all packages are published, we run the
   # cli-install-cross-platform-release-test workflow to verify that the CLI installs correctly on all platforms.
   # In all other cases, we already have a barebones `cli-install` test on the default CI platform

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
   # This job prepares the release by creating or updating a release PR.
   # Notice the omission of the `publish` flag in the changesets action.
   prepare-release:
-    outputs:
-      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     permissions:
       id-token: write
       contents: write
@@ -53,15 +51,52 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  # The release PR removes individual changesets to prepare for a release.
-  # This means that once the release PR is merged, there are no changesets left.
-  # When there are no changesets left, we can run the cli-install-cross-platform-release-test
-  # workflow to verify that the CLI installs correctly on all platforms.
+  check-latest-published:
+    runs-on: ubuntu-latest
+    outputs:
+      all_latest: ${{ steps.check.outputs.all_latest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Retrieve package versions
+        id: pkg
+        run: |
+          versions=$(find . -name 'package.json' -exec jq -r '.name + "@" + .version' {} \;)
+          echo "$versions" > versions.txt
+
+      - name: Fetch latest published versions from npm
+        id: npm
+        run: |
+          latest=""
+          while read -r pkg; do
+            name=$(echo "$pkg" | cut -d'@' -f1)
+            latest_version=$(npm view "$name" version 2>/dev/null || echo "N/A")
+            latest="$latest $name@$latest_version"
+          done < versions.txt
+          echo "$latest" > latest_versions.txt
+
+      - name: Compare package versions
+        id: check
+        run: |
+          all_latest=true
+          while read -r pkg; do
+            name=$(echo "$pkg" | cut -d'@' -f1)
+            version=$(echo "$pkg" | cut -d'@' -f2)
+            latest=$(grep -o "$name@[^ ]*" latest_versions.txt | cut -d'@' -f2)
+            if [ "$version" != "$latest" ]; then
+              all_latest=false
+              break
+            fi
+          done < versions.txt
+          echo "all_latest=$all_latest" >> $GITHUB_OUTPUT
+
+  # If we detect that not all packages are published, we run the
+  # cli-install-cross-platform-release-test workflow to verify that the CLI installs correctly on all platforms.
   # In all other cases, we already have a barebones `cli-install` test on the default CI platform
   # which will catch most issues before any offending PR is merged.
   cli-install-cross-platform-release-test:
-    needs: prepare-release
-    if: needs.prepare-release.outputs.hasChangesets == 'false'
+    needs: [check-latest-published]
+    if: needs.check-latest-published.outputs.all_latest == 'false'
     strategy:
       matrix:
         os: [depot-ubuntu-latest, depot-macos-latest, depot-windows-2022]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Retrieve package versions
         id: pkg
         run: |
-          versions=$(find . -name 'package.json' -exec jq -r '.name + "@" + .version' {} \;)
+          versions=$(find . -name 'package.json' -exec jq -r 'select(.private != true) | .name + "@" + .version' {} \;)
           echo "$versions" | tee versions.txt
 
       - name: Compare package versions
@@ -83,7 +83,6 @@ jobs:
             fi
           done < versions.txt
           echo "all_latest=$all_latest" >> $GITHUB_OUTPUT
-
   # If we detect that not all packages are published, we run the
   # cli-install-cross-platform-release-test workflow to verify that the CLI installs correctly on all platforms.
   # In all other cases, we already have a barebones `cli-install` test on the default CI platform

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,18 +62,7 @@ jobs:
         id: pkg
         run: |
           versions=$(find . -name 'package.json' -exec jq -r '.name + "@" + .version' {} \;)
-          echo "$versions" > versions.txt
-
-      - name: Fetch latest published versions from npm
-        id: npm
-        run: |
-          latest=""
-          while read -r pkg; do
-            name=$(echo "$pkg" | cut -d'@' -f1)
-            latest_version=$(npm view "$name" version 2>/dev/null || echo "N/A")
-            latest="$latest $name@$latest_version"
-          done < versions.txt
-          echo "$latest" > latest_versions.txt
+          echo "$versions" | tee versions.txt
 
       - name: Compare package versions
         id: check
@@ -82,10 +71,15 @@ jobs:
           while read -r pkg; do
             name=$(echo "$pkg" | cut -d'@' -f1)
             version=$(echo "$pkg" | cut -d'@' -f2)
-            latest=$(grep -o "$name@[^ ]*" latest_versions.txt | cut -d'@' -f2)
-            if [ "$version" != "$latest" ]; then
+            echo "Checking if $name@$version is published..."
+            exists=$(npm view "$name@$version" version 2>/dev/null || echo "N/A")
+            echo "npm returned: $exists"
+            if [ "$exists" = "N/A" ]; then
+              echo "$name@$version is NOT published."
               all_latest=false
               break
+            else
+              echo "$name@$version is published."
             fi
           done < versions.txt
           echo "all_latest=$all_latest" >> $GITHUB_OUTPUT

--- a/typescript/infra/src/agents/gcp.ts
+++ b/typescript/infra/src/agents/gcp.ts
@@ -124,7 +124,7 @@ export class AgentGCPKey extends CloudAgentKey {
         );
         // TODO support other prefixes?
         // https://cosmosdrops.io/en/tools/bech32-converter is useful for converting to other prefixes.
-        return pubkeyToAddress(encodedPubkey, 'neutron');
+        return pubkeyToAddress(encodedPubkey, 'milk');
       }
       default:
         this.logger.debug(`Unsupported protocol: ${protocol}`);

--- a/typescript/infra/src/agents/gcp.ts
+++ b/typescript/infra/src/agents/gcp.ts
@@ -124,7 +124,7 @@ export class AgentGCPKey extends CloudAgentKey {
         );
         // TODO support other prefixes?
         // https://cosmosdrops.io/en/tools/bech32-converter is useful for converting to other prefixes.
-        return pubkeyToAddress(encodedPubkey, 'milk');
+        return pubkeyToAddress(encodedPubkey, 'neutron');
       }
       default:
         this.logger.debug(`Unsupported protocol: ${protocol}`);


### PR DESCRIPTION
### Description

chore: reduce release-e2e-matrix frequency
- previously we would run the release cli test matrix if there were no changesets
- no changesets _implied_ that a release is to be done, but in cases where packages are published but no new publishable changes have landed yet - we're still churning through these tests for no good reason
- this PR changes the behaviour such that we always try and do prepare-release so that the Changesets PR is updated, but we also in parallel check if the _current_ package versions are published and only run the tests if we detect that there are packages that need to be published

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

tested here https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/15161126534
![image](https://github.com/user-attachments/assets/984e16d7-ae0e-4cb6-ad0f-2a5adbfc5fd9)
![image](https://github.com/user-attachments/assets/61f960fe-3ee1-4250-b737-0c515c23bb73)
