### PR TITLE
fix(submitter): Fix transaction fields

### DIFF
--- a/rust/main/submitter/src/chain_tx_adapter/chains/ethereum/adapter/gas_price_estimator.rs
+++ b/rust/main/submitter/src/chain_tx_adapter/chains/ethereum/adapter/gas_price_estimator.rs
@@ -93,6 +93,15 @@ pub async fn estimate_gas_price(
     if let Some(value) = tx.value() {
         request = request.value(*value);
     }
+    if let Some(nonce) = tx.nonce() {
+        request = request.nonce(*nonce);
+    }
+    if let Some(gas_limit) = tx.gas() {
+        request = request.gas(*gas_limit);
+    }
+    if let Some(chain_id) = tx.chain_id() {
+        request = request.chain_id(chain_id);
+    }
     request = request.max_fee_per_gas(max_fee);
     request = request.max_priority_fee_per_gas(max_priority_fee);
 

--- a/rust/main/utils/run-locally/src/main.rs
+++ b/rust/main/utils/run-locally/src/main.rs
@@ -97,7 +97,7 @@ const FAILED_MESSAGE_COUNT: u32 = 1;
 const RELAYER_METRICS_PORT: &str = "9092";
 const SCRAPER_METRICS_PORT: &str = "9093";
 
-pub const SUBMITTER_TYPE: SubmitterType = SubmitterType::Lander;
+pub const SUBMITTER_TYPE: SubmitterType = SubmitterType::Classic;
 
 type DynPath = Box<dyn AsRef<Path>>;
 


### PR DESCRIPTION
### Description

Required fields on EVM transaction are overwritten when we estimate gas price in EVM adapter for Lander. It means that these fields are not set when transaction is submitted into a chain.

This change ensures that all the required fields are copied from old transaction to the new one during gas price estimations.

E2E tests do not pass with fields set, so, we use classical submitter for the time being.

### Backward compatibility

Yes

### Testing

E2E test