### PR TITLE
fix: disable cosmos signers for now

### DIFF
--- a/.changeset/crazy-walls-bathe.md
+++ b/.changeset/crazy-walls-bathe.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+disable cosmos native signers and only allow evm signers for now again

--- a/typescript/cli/src/context/strategies/signer/MultiProtocolSignerManager.ts
+++ b/typescript/cli/src/context/strategies/signer/MultiProtocolSignerManager.ts
@@ -76,7 +76,12 @@ export class MultiProtocolSignerManager {
    * @dev Configures signers for EVM chains in MultiProvider
    */
   async getMultiProvider(): Promise<MultiProvider> {
-    for (const chain of this.compatibleChains) {
+    const evmChains = this.chains.filter(
+      (chain) =>
+        this.multiProvider.getProtocol(chain) === ProtocolType.Ethereum,
+    );
+
+    for (const chain of evmChains) {
       const signer = await this.initSigner(chain);
       this.multiProvider.setSigner(chain, signer as Signer);
     }

--- a/typescript/cli/src/context/strategies/signer/MultiProtocolSignerManager.ts
+++ b/typescript/cli/src/context/strategies/signer/MultiProtocolSignerManager.ts
@@ -50,11 +50,11 @@ export class MultiProtocolSignerManager {
     this.initializeStrategies();
   }
 
+  // TODO: readd Cosmos Native
   protected get compatibleChains(): ChainName[] {
     return this.chains.filter(
       (chain) =>
-        this.multiProvider.getProtocol(chain) === ProtocolType.Ethereum ||
-        this.multiProvider.getProtocol(chain) === ProtocolType.CosmosNative,
+        this.multiProvider.getProtocol(chain) === ProtocolType.Ethereum,
     );
   }
 

--- a/typescript/cli/src/context/strategies/signer/MultiProtocolSignerManager.ts
+++ b/typescript/cli/src/context/strategies/signer/MultiProtocolSignerManager.ts
@@ -50,7 +50,7 @@ export class MultiProtocolSignerManager {
     this.initializeStrategies();
   }
 
-  // TODO: readd Cosmos Native
+  // TODO: re-add Cosmos Native
   protected get compatibleChains(): ChainName[] {
     return this.chains.filter(
       (chain) =>


### PR DESCRIPTION
### Description

This PR only inits Ethereum signers and temporary reverts the changes made in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/6124. This is necessary, since Cosmos Signers are being initialized with an Eth private key in some circumstances which throw an error. The cosmos signers should therefore be disabled until a solution has been found to manage multi-vm signer intializations.

### Drive-by changes

-

### Related issues

-

### Backward compatibility

Yes

### Testing

Manual Tests
