### PR TITLE
chore: change extractPrivateKey info logs to debug logs

### DIFF
--- a/.changeset/odd-glasses-spend.md
+++ b/.changeset/odd-glasses-spend.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Change info logs to debug logs in MultiProtocolSignerManager.extractPrivateKey().

--- a/typescript/cli/src/context/strategies/signer/MultiProtocolSignerManager.ts
+++ b/typescript/cli/src/context/strategies/signer/MultiProtocolSignerManager.ts
@@ -133,14 +133,14 @@ export class MultiProtocolSignerManager {
    */
   private async extractPrivateKey(chain: ChainName): Promise<SignerConfig> {
     if (this.options.key) {
-      this.logger.info(
+      this.logger.debug(
         `Using private key passed via CLI --key flag for chain ${chain}`,
       );
       return { privateKey: this.options.key };
     }
 
     if (ENV.HYP_KEY) {
-      this.logger.info(`Using private key from .env for chain ${chain}`);
+      this.logger.debug(`Using private key from .env for chain ${chain}`);
       return { privateKey: ENV.HYP_KEY };
     }
 
@@ -150,7 +150,7 @@ export class MultiProtocolSignerManager {
       strategyConfig.privateKey,
       `No private key found for chain ${chain}`,
     );
-    this.logger.info(
+    this.logger.debug(
       `Extracting private key from strategy config/user prompt for chain ${chain}`,
     );
 


### PR DESCRIPTION
### Description

chore: reduce logging of extractPrivateKey

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
