### PR TITLE
fix: Make Solana testnet chunk same as for mainnet

### DIFF
--- a/rust/main/config/testnet_config.json
+++ b/rust/main/config/testnet_config.json
@@ -951,7 +951,8 @@
       "domainId": 1399811150,
       "index": {
         "from": 1,
-        "mode": "sequence"
+        "mode": "sequence",
+        "chunk": 20
       },
       "interchainGasPaymaster": "9SQVtTNsbipdMzumhzi6X8GwojiSMwBfqAhS7FgyTcqy",
       "isTestnet": true,


### PR DESCRIPTION
### Description

Make Solana testnet chunk same as for mainnet

### Backward compatibility

Yes

### Testing

Manual