### PR TITLE
chore: verify decimals & scale

### DIFF
--- a/typescript/cli/src/check/warp.ts
+++ b/typescript/cli/src/check/warp.ts
@@ -83,13 +83,6 @@ function verifyDecimalsAndScale(
     Record<string, Partial<HypTokenRouterVirtualConfig>>,
 ): boolean {
   let valid = true;
-  Object.entries(warpRouteConfig).forEach(([chain, config]) => {
-    if (config.decimals !== undefined && config.decimals === 0) {
-      logRed(`Decimals, if defined, must not be zero for ${chain}`);
-      valid = false;
-    }
-  });
-
   if (!verifyScale(warpRouteConfig)) {
     logRed(`Found invalid or missing scale for inconsistent decimals`);
     valid = false;

--- a/typescript/cli/src/check/warp.ts
+++ b/typescript/cli/src/check/warp.ts
@@ -6,6 +6,7 @@ import {
   WarpRouteDeployConfigMailboxRequired,
   derivedHookAddress,
   derivedIsmAddress,
+  scaleIsCorrect,
   transformConfigToCheck,
 } from '@hyperlane-xyz/sdk';
 import {
@@ -85,33 +86,8 @@ function verifyDecimalsAndScale(
     }
   });
 
-  if (!areDecimalsUniform(warpRouteConfig)) {
-    const maxDecimals = Math.max(
-      ...Object.values(warpRouteConfig).map((config) => config.decimals!),
-    );
-
-    for (const [chain, config] of Object.entries(warpRouteConfig)) {
-      if (config.decimals) {
-        const scale = 10 ** (maxDecimals - config.decimals);
-        if (!config.scale && scale !== 1) {
-          logRed(`Scale is required for ${chain}`);
-          process.exit(1);
-        } else if (config.scale && scale !== config.scale) {
-          logRed(`Scale is not correct for ${chain}`);
-          process.exit(1);
-        }
-      }
-    }
+  if (!scaleIsCorrect(warpRouteConfig)) {
+    logRed(`Found invalid or missing scale for inconsistent decimals`);
+    process.exit(1);
   }
-}
-
-function areDecimalsUniform(configMap: Record<string, any>): boolean {
-  const values = [...Object.values(configMap)];
-  const [first, ...rest] = values;
-  for (const d of rest) {
-    if (d.decimals !== first.decimals) {
-      return false;
-    }
-  }
-  return true;
 }

--- a/typescript/cli/src/check/warp.ts
+++ b/typescript/cli/src/check/warp.ts
@@ -6,8 +6,8 @@ import {
   WarpRouteDeployConfigMailboxRequired,
   derivedHookAddress,
   derivedIsmAddress,
-  scaleIsCorrect,
   transformConfigToCheck,
+  verifyScale,
 } from '@hyperlane-xyz/sdk';
 import {
   ObjectDiff,
@@ -86,7 +86,7 @@ function verifyDecimalsAndScale(
     }
   });
 
-  if (!scaleIsCorrect(warpRouteConfig)) {
+  if (!verifyScale(warpRouteConfig)) {
     logRed(`Found invalid or missing scale for inconsistent decimals`);
     process.exit(1);
   }

--- a/typescript/cli/src/check/warp.ts
+++ b/typescript/cli/src/check/warp.ts
@@ -26,31 +26,8 @@ export async function runWarpRouteCheck({
   onChainWarpConfig: DerivedWarpRouteDeployConfig &
     Record<string, Partial<HypTokenRouterVirtualConfig>>;
 }): Promise<void> {
-  Object.values(warpRouteConfig).forEach((config) => {
-    if (config.decimals === undefined && config.decimals !== 0) {
-      logRed('Decimals, if defined, must not be zero');
-      process.exit(1);
-    }
-  });
-
-  if (!areDecimalsUniform(warpRouteConfig)) {
-    const maxDecimals = Math.max(
-      ...Object.values(warpRouteConfig).map((config) => config.decimals!),
-    );
-
-    for (const [chain, config] of Object.entries(warpRouteConfig)) {
-      if (config.decimals) {
-        const scale = 10 ** (maxDecimals - config.decimals);
-        if (!config.scale && scale !== 1) {
-          logRed(`Scale is required for ${chain}`);
-          process.exit(1);
-        } else if (config.scale && scale !== config.scale) {
-          logRed(`Scale is not correct for ${chain}`);
-          process.exit(1);
-        }
-      }
-    }
-  }
+  // Check whether the decimals are consistent. If not, ensure that the scale is correct.
+  verifyDecimalsAndScale(warpRouteConfig);
 
   // Go through each chain and only add to the output the chains that have mismatches
   const [violations, isInvalid] = Object.keys(warpRouteConfig).reduce(
@@ -95,6 +72,37 @@ export async function runWarpRouteCheck({
   }
 
   logGreen(`No violations found`);
+}
+
+function verifyDecimalsAndScale(
+  warpRouteConfig: WarpRouteDeployConfigMailboxRequired &
+    Record<string, Partial<HypTokenRouterVirtualConfig>>,
+) {
+  Object.values(warpRouteConfig).forEach((config) => {
+    if (config.decimals === undefined && config.decimals !== 0) {
+      logRed('Decimals, if defined, must not be zero');
+      process.exit(1);
+    }
+  });
+
+  if (!areDecimalsUniform(warpRouteConfig)) {
+    const maxDecimals = Math.max(
+      ...Object.values(warpRouteConfig).map((config) => config.decimals!),
+    );
+
+    for (const [chain, config] of Object.entries(warpRouteConfig)) {
+      if (config.decimals) {
+        const scale = 10 ** (maxDecimals - config.decimals);
+        if (!config.scale && scale !== 1) {
+          logRed(`Scale is required for ${chain}`);
+          process.exit(1);
+        } else if (config.scale && scale !== config.scale) {
+          logRed(`Scale is not correct for ${chain}`);
+          process.exit(1);
+        }
+      }
+    }
+  }
 }
 
 function areDecimalsUniform(configMap: Record<string, any>): boolean {

--- a/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-check.e2e-test.ts
@@ -495,7 +495,7 @@ describe('hyperlane warp check e2e tests', async function () {
 
       expect(output.exitCode).to.equal(1);
       expect(output.text()).to.includes(
-        `Scale is required for ${CHAIN_NAME_2}`,
+        `Found invalid or missing scale for inconsistent decimals`,
       );
     });
 
@@ -529,7 +529,7 @@ describe('hyperlane warp check e2e tests', async function () {
 
       expect(output.exitCode).to.equal(1);
       expect(output.text()).to.includes(
-        `Scale is not correct for ${CHAIN_NAME_2}`,
+        `Found invalid or missing scale for inconsistent decimals`,
       );
     });
   });

--- a/typescript/cli/src/tests/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-deploy.e2e-test.ts
@@ -209,7 +209,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
         finalOutput
           .text()
           .includes(
-            `Failed to derive token metadata Error: Scale is not correct for ${CHAIN_NAME_3}`,
+            `Failed to derive token metadata Error: Found invalid or missing scale for inconsistent decimals`,
           ),
       ).to.be.true;
     });

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -728,3 +728,4 @@ export {
   getStarknetMailboxContract,
   getStarknetEtherContract,
 } from './utils/starknet.js';
+export { verifyScale } from './utils/decimals.js';

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -20,7 +20,7 @@ export const WarpRouteDeployConfigSchemaErrors = {
 export const TokenMetadataSchema = z.object({
   name: z.string(),
   symbol: z.string(),
-  decimals: z.number().optional(),
+  decimals: z.number().gt(0).optional(),
   scale: z.number().optional(),
   isNft: z.boolean().optional(),
 });

--- a/typescript/sdk/src/utils/decimals.ts
+++ b/typescript/sdk/src/utils/decimals.ts
@@ -1,0 +1,31 @@
+export function verifyScale(configMap: Record<string, any>): boolean {
+  if (!areDecimalsUniform(configMap)) {
+    const maxDecimals = Math.max(
+      ...Object.values(configMap).map((config) => config.decimals!),
+    );
+
+    for (const [_, config] of Object.entries(configMap)) {
+      if (config.decimals) {
+        const scale = 10 ** (maxDecimals - config.decimals);
+        if (
+          (!config.scale && scale !== 1) ||
+          (config.scale && scale !== config.scale)
+        ) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+function areDecimalsUniform(configMap: Record<string, any>): boolean {
+  const values = [...Object.values(configMap)];
+  const [first, ...rest] = values;
+  for (const d of rest) {
+    if (d.decimals !== first.decimals) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/typescript/sdk/src/utils/decimals.ts
+++ b/typescript/sdk/src/utils/decimals.ts
@@ -1,4 +1,16 @@
-export function verifyScale(configMap: Record<string, any>): boolean {
+import {
+  HypTokenRouterVirtualConfig,
+  WarpRouteDeployConfigMailboxRequired,
+} from '@hyperlane-xyz/sdk';
+
+import { TokenMetadata } from '../token/types.js';
+
+export function verifyScale(
+  configMap:
+    | Map<string, TokenMetadata>
+    | WarpRouteDeployConfigMailboxRequired
+    | Record<string, Partial<HypTokenRouterVirtualConfig>>,
+): boolean {
   if (!areDecimalsUniform(configMap)) {
     const maxDecimals = Math.max(
       ...Object.values(configMap).map((config) => config.decimals!),
@@ -6,10 +18,10 @@ export function verifyScale(configMap: Record<string, any>): boolean {
 
     for (const [_, config] of Object.entries(configMap)) {
       if (config.decimals) {
-        const scale = 10 ** (maxDecimals - config.decimals);
+        const calculatedScale = 10 ** (maxDecimals - config.decimals);
         if (
-          (!config.scale && scale !== 1) ||
-          (config.scale && scale !== config.scale)
+          (!config.scale && calculatedScale !== 1) ||
+          (config.scale && calculatedScale !== config.scale)
         ) {
           return false;
         }
@@ -19,7 +31,12 @@ export function verifyScale(configMap: Record<string, any>): boolean {
   return true;
 }
 
-function areDecimalsUniform(configMap: Record<string, any>): boolean {
+function areDecimalsUniform(
+  configMap:
+    | Map<string, TokenMetadata>
+    | WarpRouteDeployConfigMailboxRequired
+    | Record<string, Partial<HypTokenRouterVirtualConfig>>,
+): boolean {
   const values = [...Object.values(configMap)];
   const [first, ...rest] = values;
   for (const d of rest) {


### PR DESCRIPTION
### Description

This PR adds a check to `warp check` CLI verifying that decimals are consistent and have the correct scale if not.

### Related issues

#5173

### Backward compatibility

Yes

### Testing

Two E2E tests checking for missing and incorrect scale, when decimals are not consistent.
