### PR TITLE
feat: agent-specific rpc consensus defaults

### DIFF
--- a/rust/main/agents/relayer/src/settings/mod.rs
+++ b/rust/main/agents/relayer/src/settings/mod.rs
@@ -137,7 +137,7 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
             .parse_from_raw_config::<Settings, RawAgentConf, Option<&HashSet<&str>>>(
                 relay_chain_names.as_ref(),
                 "Parsing base config",
-                agent_name,
+                agent_name.to_string(),
             )
             .take_config_err(&mut err);
 

--- a/rust/main/agents/relayer/src/settings/mod.rs
+++ b/rust/main/agents/relayer/src/settings/mod.rs
@@ -120,6 +120,7 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
         raw: RawRelayerSettings,
         cwp: &ConfigPath,
         _filter: (),
+        agent_name: &str,
     ) -> ConfigResult<Self> {
         let mut err = ConfigParsingError::default();
 
@@ -136,6 +137,7 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
             .parse_from_raw_config::<Settings, RawAgentConf, Option<&HashSet<&str>>>(
                 relay_chain_names.as_ref(),
                 "Parsing base config",
+                agent_name,
             )
             .take_config_err(&mut err);
 

--- a/rust/main/agents/scraper/src/settings.rs
+++ b/rust/main/agents/scraper/src/settings.rs
@@ -43,6 +43,7 @@ impl FromRawConf<RawScraperSettings> for ScraperSettings {
         raw: RawScraperSettings,
         cwp: &ConfigPath,
         _filter: (),
+        agent_name: &str,
     ) -> ConfigResult<Self> {
         let mut err = ConfigParsingError::default();
 
@@ -59,6 +60,7 @@ impl FromRawConf<RawScraperSettings> for ScraperSettings {
             .parse_from_raw_config::<Settings, RawAgentConf, Option<&HashSet<&str>>>(
                 chains_names_to_scrape.as_ref(),
                 "Parsing base config",
+                agent_name.to_string(),
             )
             .take_config_err(&mut err);
 

--- a/rust/main/agents/validator/src/settings.rs
+++ b/rust/main/agents/validator/src/settings.rs
@@ -70,6 +70,7 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
         raw: RawValidatorSettings,
         cwp: &ConfigPath,
         _filter: (),
+        agent_name: &str,
     ) -> ConfigResult<Self> {
         let mut err = ConfigParsingError::default();
 
@@ -93,6 +94,7 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
             .parse_from_raw_config::<Settings, RawAgentConf, Option<&HashSet<&str>>>(
                 origin_chain_name_set.as_ref(),
                 "Expected valid base agent configuration",
+                agent_name,
             )
             .take_config_err(&mut err);
 
@@ -111,6 +113,7 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
             .parse_from_raw_config::<SignerConf, RawAgentSignerConf, NoFilter>(
                 (),
                 "Expected valid validator configuration",
+                agent_name,
             )
             .end();
 

--- a/rust/main/agents/validator/src/settings.rs
+++ b/rust/main/agents/validator/src/settings.rs
@@ -94,7 +94,7 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
             .parse_from_raw_config::<Settings, RawAgentConf, Option<&HashSet<&str>>>(
                 origin_chain_name_set.as_ref(),
                 "Expected valid base agent configuration",
-                agent_name,
+                agent_name.to_string(),
             )
             .take_config_err(&mut err);
 
@@ -113,7 +113,7 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
             .parse_from_raw_config::<SignerConf, RawAgentSignerConf, NoFilter>(
                 (),
                 "Expected valid validator configuration",
-                agent_name,
+                agent_name.to_string(),
             )
             .end();
 

--- a/rust/main/hyperlane-base/src/agent.rs
+++ b/rust/main/hyperlane-base/src/agent.rs
@@ -27,7 +27,7 @@ pub struct HyperlaneAgentCore {
 pub trait LoadableFromSettings: AsRef<Settings> + Sized {
     /// Create a new instance of these settings by reading the configs and env
     /// vars.
-    fn load() -> ConfigResult<Self>;
+    fn load(agent_name: &str) -> ConfigResult<Self>;
 }
 
 /// Metadata of an agent defined from configuration

--- a/rust/main/hyperlane-base/src/agent.rs
+++ b/rust/main/hyperlane-base/src/agent.rs
@@ -93,7 +93,7 @@ pub async fn agent_main<A: BaseAgent>() -> Result<()> {
         git_sha()
     );
 
-    let settings = A::Settings::load()?;
+    let settings = A::Settings::load(A::AGENT_NAME)?;
     let agent_metadata = A::Metadata::build_metadata(&settings);
     let core_settings: &Settings = settings.as_ref();
 

--- a/rust/main/hyperlane-base/src/settings/loader/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/loader/mod.rs
@@ -17,7 +17,7 @@ mod case_adapter;
 mod environment;
 
 /// Deserialize a settings object from the configs.
-pub fn load_settings<T, R>(agent: &str) -> ConfigResult<R>
+pub fn load_settings<T, R>(agent_name: &str) -> ConfigResult<R>
 where
     T: DeserializeOwned + Debug,
     R: FromRawConf<T>,
@@ -127,7 +127,7 @@ where
         })
         .into_config_result(|| root_path.clone())?;
 
-    let res = raw_config.parse_config(&root_path);
+    let res = raw_config.parse_config(&root_path, agent_name);
     if res.is_err() {
         eprintln!("Loaded config for debugging: {formatted_config}");
     }

--- a/rust/main/hyperlane-base/src/settings/loader/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/loader/mod.rs
@@ -17,7 +17,7 @@ mod case_adapter;
 mod environment;
 
 /// Deserialize a settings object from the configs.
-pub fn load_settings<T, R>() -> ConfigResult<R>
+pub fn load_settings<T, R>(agent: &str) -> ConfigResult<R>
 where
     T: DeserializeOwned + Debug,
     R: FromRawConf<T>,

--- a/rust/main/hyperlane-base/src/settings/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/mod.rs
@@ -100,8 +100,8 @@ pub mod parser;
 macro_rules! impl_loadable_from_settings {
     ($agent:ident, $settingsparser:ident -> $settingsobj:ident) => {
         impl hyperlane_base::LoadableFromSettings for $settingsobj {
-            fn load() -> hyperlane_core::config::ConfigResult<Self> {
-                hyperlane_base::settings::loader::load_settings::<$settingsparser, Self>()
+            fn load(agent: &str) -> hyperlane_core::config::ConfigResult<Self> {
+                hyperlane_base::settings::loader::load_settings::<$settingsparser, Self>(agent)
             }
         }
     };

--- a/rust/main/hyperlane-base/src/settings/parser/json_value_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/json_value_parser.rs
@@ -357,13 +357,18 @@ impl<'v, 'e> ParseChain<'e, ValueParser<'v>> {
         )
     }
 
-    pub fn parse_from_raw_config<O, T, F>(self, filter: F, ctx: &'static str) -> ParseChain<'e, O>
+    pub fn parse_from_raw_config<O, T, F>(
+        self,
+        filter: F,
+        ctx: &'static str,
+        agent_name: &'static str,
+    ) -> ParseChain<'e, O>
     where
         O: FromRawConf<T, F>,
         T: Debug + DeserializeOwned,
         F: Default,
     {
-        self.and_then(|v| v.parse_from_raw_config::<O, T, F>(filter, ctx))
+        self.and_then(|v| v.parse_from_raw_config::<O, T, F>(filter, ctx, agent_name))
     }
 }
 

--- a/rust/main/hyperlane-base/src/settings/parser/json_value_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/json_value_parser.rs
@@ -276,13 +276,20 @@ impl<'v> ValueParser<'v> {
     }
 
     /// Use FromRawConf to parse a value.
-    pub fn parse_from_raw_config<O, T, F>(&self, filter: F, ctx: &'static str) -> ConfigResult<O>
+    pub fn parse_from_raw_config<O, T, F>(
+        &self,
+        filter: F,
+        ctx: &'static str,
+        agent_name: &'static str,
+    ) -> ConfigResult<O>
     where
         O: FromRawConf<T, F>,
         T: Debug + DeserializeOwned,
         F: Default,
     {
-        O::from_config_filtered(self.parse_value::<T>(ctx)?, &self.cwp, filter)
+        O::from_config_filtered(self.parse_value::<T>(ctx)?, &self.cwp, filter, agent_name)
+            .context(ctx)
+            .into_config_result(|| self.cwp.clone())
     }
 }
 

--- a/rust/main/hyperlane-base/src/settings/parser/json_value_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/json_value_parser.rs
@@ -280,16 +280,21 @@ impl<'v> ValueParser<'v> {
         &self,
         filter: F,
         ctx: &'static str,
-        agent_name: &'static str,
+        agent_name: String,
     ) -> ConfigResult<O>
     where
         O: FromRawConf<T, F>,
         T: Debug + DeserializeOwned,
         F: Default,
     {
-        O::from_config_filtered(self.parse_value::<T>(ctx)?, &self.cwp, filter, agent_name)
-            .context(ctx)
-            .into_config_result(|| self.cwp.clone())
+        O::from_config_filtered(
+            self.parse_value::<T>(ctx)?,
+            &self.cwp,
+            filter,
+            agent_name.as_str(),
+        )
+        .context(ctx)
+        .into_config_result(|| self.cwp.clone())
     }
 }
 
@@ -361,7 +366,7 @@ impl<'v, 'e> ParseChain<'e, ValueParser<'v>> {
         self,
         filter: F,
         ctx: &'static str,
-        agent_name: &'static str,
+        agent_name: String,
     ) -> ParseChain<'e, O>
     where
         O: FromRawConf<T, F>,

--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -47,6 +47,7 @@ impl FromRawConf<RawAgentConf, Option<&HashSet<&str>>> for Settings {
         raw: RawAgentConf,
         cwp: &ConfigPath,
         filter: Option<&HashSet<&str>>,
+        agent_name: &str,
     ) -> Result<Self, ConfigParsingError> {
         let mut err = ConfigParsingError::default();
 

--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -23,9 +23,12 @@ use hyperlane_core::{
     HyperlaneDomainTechnicalStack, IndexMode, ReorgPeriod, SubmitterType,
 };
 
-use crate::settings::{
-    chains::IndexSettings, parser::connection_parser::build_connection_conf, trace::TracingConfig,
-    ChainConf, CoreContractAddresses, Settings, SignerConf,
+use crate::{
+    agent,
+    settings::{
+        chains::IndexSettings, parser::connection_parser::build_connection_conf,
+        trace::TracingConfig, ChainConf, CoreContractAddresses, Settings, SignerConf,
+    },
 };
 
 pub use super::envs::*;
@@ -404,8 +407,9 @@ impl FromRawConf<RawAgentSignerConf> for SignerConf {
         raw: RawAgentSignerConf,
         cwp: &ConfigPath,
         _filter: (),
+        agent_name: &str,
     ) -> ConfigResult<Self> {
-        parse_signer(ValueParser::new(cwp.clone(), &raw.0))
+        parse_signer(ValueParser::new(cwp.clone(), &raw.0, agent_name))
     }
 }
 

--- a/rust/main/hyperlane-core/src/config/mod.rs
+++ b/rust/main/hyperlane-core/src/config/mod.rs
@@ -47,8 +47,8 @@ where
     /// Construct `Self` from a raw config type.
     /// - `raw` is the raw config value
     /// - `cwp` is the current working path
-    fn from_config(raw: T, cwp: &ConfigPath) -> ConfigResult<Self> {
-        Self::from_config_filtered(raw, cwp, F::default())
+    fn from_config(raw: T, cwp: &ConfigPath, agent_name: &str) -> ConfigResult<Self> {
+        Self::from_config_filtered(raw, cwp, F::default(), agent_name)
     }
 
     /// Construct `Self` from a raw config type with a filter to limit what
@@ -56,7 +56,12 @@ where
     /// - `raw` is the raw config value
     /// - `cwp` is the current working path
     /// - `filter` can define what config paths are parsed
-    fn from_config_filtered(raw: T, cwp: &ConfigPath, filter: F) -> ConfigResult<Self>;
+    fn from_config_filtered(
+        raw: T,
+        cwp: &ConfigPath,
+        filter: F,
+        agent_name: &str,
+    ) -> ConfigResult<Self>;
 }
 
 /// A trait that allows for converting a raw config type into a "parsed" type.
@@ -66,11 +71,16 @@ pub trait IntoParsedConf<F: Default>: Debug + Sized {
         self,
         cwp: &ConfigPath,
         filter: F,
+        agent_name: &str,
     ) -> ConfigResult<O>;
 
     /// Parse the config.
-    fn parse_config<O: FromRawConf<Self, F>>(self, cwp: &ConfigPath) -> ConfigResult<O> {
-        self.parse_config_with_filter(cwp, F::default())
+    fn parse_config<O: FromRawConf<Self, F>>(
+        self,
+        cwp: &ConfigPath,
+        agent_name: &str,
+    ) -> ConfigResult<O> {
+        self.parse_config_with_filter(cwp, F::default(), agent_name)
     }
 }
 
@@ -83,8 +93,9 @@ where
         self,
         cwp: &ConfigPath,
         filter: F,
+        agent_name: &str,
     ) -> ConfigResult<O> {
-        O::from_config_filtered(self, cwp, filter)
+        O::from_config_filtered(self, cwp, filter, agent_name)
     }
 }
 


### PR DESCRIPTION
### Description

We recently discovered that validators use fallback provider as the default consensus type, which leaves them susceptible to reorgs regardless of how big their RPC set is.

This PR adds agent-specific rpc consensus default: fallback for the relayer and scraper, quorum for the validator. This default can still be overriden via the regular config.

### Drive-by changes

The `defaultRpcConsensusType` is removed from the agent config schema, since it applied to all chains and agents, which is much too generic at this point. It was always set to `fallback` in our infra TS code. It now still defaults to `fallback` in all cases but when the validator is run.

### Backward compatibility

The agent schema no longer contains `defaultRpcConsensusType`. See above. This won't break any builds with new agents that use old configs.

### Testing

Manual, by running a local validator and printing the `origin_chain_conf` to make sure it's using `HttpQuorum`
