### PR TITLE
chore: trigger release PR testing automatically

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,7 @@
 name: rust
 
 on:
-  # Triggers the workflow on pushes to main branch
+  # Triggers the workflow on pushes to main and changeset branches
   push:
     branches: [main, changeset-release/main]
   # Triggers on pull requests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,7 @@ name: rust
 on:
   # Triggers the workflow on pushes to main branch
   push:
-    branches: [main]
+    branches: [main, changeset-release/main]
   # Triggers on pull requests
   pull_request:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   # Triggers the workflow on pushes to main branch
   push:
-    branches: [main]
+    branches: [main, changeset-release/main]
   # Triggers on pull requests
   pull_request:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: test
 
 on:
-  # Triggers the workflow on pushes to main branch
+  # Triggers the workflow on pushes to main and changeset branches
   push:
     branches: [main, changeset-release/main]
   # Triggers on pull requests


### PR DESCRIPTION
### Description

chore: trigger release PR testing automatically

Currently due to the nature of the changesets bot, it requires closing/reopening the release PR to trigger the tests for CI to run. Hoping that enabling this will cause CI to automatically run on the release PR branch

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
