### PR TITLE
chore: turn off preserveSymlinks

### DIFF
--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -1,6 +1,5 @@
 import { ProxyAdmin__factory } from '@hyperlane-xyz/core';
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
-import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
   Address,
   objMap,
@@ -27,6 +26,8 @@ import { extractIsmAndHookFactoryAddresses } from '../utils/ism.js';
 import { HyperlaneProxyFactoryDeployer } from './HyperlaneProxyFactoryDeployer.js';
 import { ContractVerifier } from './verify/ContractVerifier.js';
 import { ExplorerLicenseType } from './verify/types.js';
+
+type ChainAddresses = Record<string, string>;
 
 export async function executeWarpDeploy(
   multiProvider: MultiProvider,

--- a/typescript/sdk/src/gas/token-prices.test.ts
+++ b/typescript/sdk/src/gas/token-prices.test.ts
@@ -1,13 +1,14 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { ethereum, solanamainnet } from '@hyperlane-xyz/registry';
-
 import { TestChainName, testChainMetadata } from '../consts/testChains.js';
 
 import { CoinGeckoTokenPriceGetter } from './token-prices.js';
 
 const MOCK_FETCH_CALLS = true;
+
+const ethereum: { name?: string } = {};
+const solanamainnet: { name?: string } = {};
 
 describe('TokenPriceGetter', () => {
   let tokenPriceGetter: CoinGeckoTokenPriceGetter;
@@ -45,8 +46,8 @@ describe('TokenPriceGetter', () => {
       // stubbed results
       expect(
         await tokenPriceGetter.getTokenPriceByIds([
-          ethereum.name,
-          solanamainnet.name,
+          ethereum.name || 'ethereum',
+          solanamainnet.name || 'solanamainnet',
         ]),
       ).to.eql([priceA, priceB]);
     });
@@ -59,9 +60,9 @@ describe('TokenPriceGetter', () => {
         await tokenPriceGetter.getTokenPrice(TestChainName.test1),
       ).to.equal(1);
       // stubbed result for non-testnet
-      expect(await tokenPriceGetter.getTokenPrice(ethereum.name)).to.equal(
-        priceA,
-      );
+      expect(
+        await tokenPriceGetter.getTokenPrice(ethereum.name || 'ethereum'),
+      ).to.equal(priceA);
     });
   });
 
@@ -75,8 +76,8 @@ describe('TokenPriceGetter', () => {
       // stubbed result for non-testnet
       expect(
         await tokenPriceGetter.getTokenExchangeRate(
-          ethereum.name,
-          solanamainnet.name,
+          ethereum.name || 'ethereum',
+          solanamainnet.name || 'solanamainnet',
         ),
       ).to.equal(priceA / priceB);
     });

--- a/typescript/sdk/src/gas/token-prices.test.ts
+++ b/typescript/sdk/src/gas/token-prices.test.ts
@@ -46,8 +46,8 @@ describe('TokenPriceGetter', () => {
       // stubbed results
       expect(
         await tokenPriceGetter.getTokenPriceByIds([
-          ethereum.name || 'ethereum',
-          solanamainnet.name || 'solanamainnet',
+          'ethereum',
+          'solanamainnet',
         ]),
       ).to.eql([priceA, priceB]);
     });
@@ -60,9 +60,7 @@ describe('TokenPriceGetter', () => {
         await tokenPriceGetter.getTokenPrice(TestChainName.test1),
       ).to.equal(1);
       // stubbed result for non-testnet
-      expect(
-        await tokenPriceGetter.getTokenPrice(ethereum.name || 'ethereum'),
-      ).to.equal(priceA);
+      expect(await tokenPriceGetter.getTokenPrice('ethereum')).to.equal(priceA);
     });
   });
 
@@ -76,8 +74,8 @@ describe('TokenPriceGetter', () => {
       // stubbed result for non-testnet
       expect(
         await tokenPriceGetter.getTokenExchangeRate(
-          ethereum.name || 'ethereum',
-          solanamainnet.name || 'solanamainnet',
+          'ethereum',
+          'solanamainnet',
         ),
       ).to.equal(priceA / priceB);
     });

--- a/typescript/sdk/src/utils/ism.ts
+++ b/typescript/sdk/src/utils/ism.ts
@@ -1,7 +1,8 @@
-import { ChainAddresses } from '@hyperlane-xyz/registry';
 import { WithAddress, pick } from '@hyperlane-xyz/utils';
 
 import { multisigIsmVerifyCosts } from '../consts/multisigIsmVerifyCosts.js';
+
+type ChainAddresses = Record<string, string>;
 
 /**
  * Extracts the ISM and Hook factory addresses from chain-specific registry addresses
@@ -11,7 +12,7 @@ import { multisigIsmVerifyCosts } from '../consts/multisigIsmVerifyCosts.js';
 export function extractIsmAndHookFactoryAddresses(
   registryAddresses: ChainAddresses,
 ) {
-  return pick(registryAddresses, [
+  return pick(registryAddresses as Record<string, string>, [
     'domainRoutingIsmFactory',
     'staticMerkleRootMultisigIsmFactory',
     'staticMessageIdMultisigIsmFactory',

--- a/typescript/sdk/tsconfig.json
+++ b/typescript/sdk/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "@hyperlane-xyz/tsconfig/tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist/",
-    "rootDir": "./src/"
+    "outDir": "dist",
+    "rootDir": "src"
   },
-  "include": ["./src/**/*.ts", "./src/*.d.ts"]
+  "include": ["src/**/*"],
 }

--- a/typescript/tsconfig/tsconfig.json
+++ b/typescript/tsconfig/tsconfig.json
@@ -23,7 +23,7 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
-    "preserveSymlinks": true,
+    "preserveSymlinks": false,
     "preserveWatchOutput": true,
     "pretty": false,
     "resolveJsonModule": true,


### PR DESCRIPTION
### Description

This PR turns off the `preserveSymlinks` setting in tsconfig.json globally, with the benefit of fixing code navigation in VSCode. With this set to false (default and recommended), VSCode correctly navigates to the source code across package boundaries inside the monorepo, instead of landing in node_modules.

### Drive-by changes

Removing this setting uncovered a circular dependency between the SDK and the Registry, which led to compilation errors. To fix the circular dependency, imports from `@hyperlane-xyz/registry` were removed with small code fixes.

### Related issues

Fixes ENG-1668

### Backward compatibility

Yes, as the circular dependency wasn't declared in `package.json`, and wasn't imported anywhere else.

### Testing

The unit-tests are passing.
