### PR TITLE
Add upgrades for old versions of HypERC20Collateral

### DIFF
--- a/typescript/sdk/src/token/EvmERC20WarpModule.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.ts
@@ -553,8 +553,11 @@ export class EvmERC20WarpModule extends HyperlaneModule<
   ): Promise<AnnotatedEV5Transaction[]> {
     const updateTransactions: AnnotatedEV5Transaction[] = [];
 
-    // Check if package version is below 7.1.5
-    if (actualConfig.packageVersion && actualConfig.packageVersion < '7.1.5') {
+    const actualVersion = actualConfig.packageVersion ?? '';
+    if (
+      expectedConfig.packageVersion &&
+      expectedConfig.packageVersion > actualVersion
+    ) {
       const provider = this.multiProvider.getProvider(this.domainId);
       const signer = this.multiProvider.getSigner(this.domainId);
       const proxyAddr = this.args.addresses.deployedTokenRoute;

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -10,6 +10,7 @@ import {
   HypXERC20__factory,
   IFiatToken__factory,
   IXERC20__factory,
+  PackageVersioned,
   ProxyAdmin__factory,
   TokenRouter__factory,
 } from '@hyperlane-xyz/core';
@@ -435,11 +436,15 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
     const erc20TokenMetadata = await this.fetchERC20Metadata(
       collateralTokenAddress,
     );
+    const packageVersion = await this.fetchPackageVersion(
+      hypCollateralTokenInstance,
+    );
 
     return {
       ...erc20TokenMetadata,
       type: TokenType.collateral,
       token: collateralTokenAddress,
+      packageVersion,
     };
   }
 
@@ -542,6 +547,10 @@ export class EvmERC20WarpRouteReader extends HyperlaneReader {
     ]);
 
     return { name, symbol, decimals, isNft: false };
+  }
+
+  async fetchPackageVersion(versionContract: PackageVersioned) {
+    return versionContract.PACKAGE_VERSION();
   }
 
   async fetchRemoteRouters(warpRouteAddress: Address): Promise<RemoteRouters> {

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -23,6 +23,7 @@ export const TokenMetadataSchema = z.object({
   decimals: z.number().optional(),
   scale: z.number().optional(),
   isNft: z.boolean().optional(),
+  packageVersion: z.string().optional(),
 });
 export type TokenMetadata = z.infer<typeof TokenMetadataSchema>;
 export const isTokenMetadata = isCompliant(TokenMetadataSchema);


### PR DESCRIPTION
### Description

 In `EvmERC20WarpModule.update()`, check if package version is below a certain number. If it is, deploy a new implementation and also attempt to upgrade with `upgradeToAndCall`.