### PR TITLE
feat: update warp deploy to output to WarpCoreConfig to --warpRouteId

### DIFF
--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -141,7 +141,7 @@ export const deploy: CommandModuleWithWarpDeployContext<{
     },
     warpRouteId: warpRouteIdCommandOption,
   },
-  handler: async ({ context, dryRun }) => {
+  handler: async ({ context, dryRun, warpRouteId }) => {
     logCommandHeader(
       `Hyperlane Warp Route Deployment${dryRun ? ' Dry-Run' : ''}`,
     );
@@ -151,6 +151,7 @@ export const deploy: CommandModuleWithWarpDeployContext<{
         context,
         // Already fetched in the resolveWarpRouteConfigChains
         warpDeployConfig: context.warpDeployConfig,
+        warpRouteId,
       });
     } catch (error: any) {
       evaluateIfDryRunFailure(error, dryRun);

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -3,7 +3,10 @@ import { groupBy } from 'lodash-es';
 import { stringify as yamlStringify } from 'yaml';
 
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
-import { AddWarpRouteOptions, ChainAddresses } from '@hyperlane-xyz/registry';
+import {
+  AddWarpRouteConfigOptions,
+  ChainAddresses,
+} from '@hyperlane-xyz/registry';
 import {
   AggregationIsmConfig,
   AnnotatedEV5Transaction,
@@ -87,9 +90,11 @@ interface WarpApplyParams extends DeployParams {
 export async function runWarpRouteDeploy({
   context,
   warpDeployConfig,
+  warpRouteId,
 }: {
   context: WriteCommandContext;
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
+  warpRouteId?: string;
 }) {
   const { skipConfirmation, chainMetadata, registry } = context;
   const chains = Object.keys(warpDeployConfig);
@@ -125,7 +130,11 @@ export async function runWarpRouteDeploy({
     deployedContracts,
   );
 
-  await writeDeploymentArtifacts(warpCoreConfig, context, addWarpRouteOptions);
+  await writeDeploymentArtifacts(
+    warpCoreConfig,
+    context,
+    warpRouteId ? { warpRouteId } : addWarpRouteOptions,
+  );
 
   await completeDeploy(context, 'warp', initialBalances, null, ethereumChains!);
 }
@@ -174,7 +183,7 @@ async function executeDeploy(
 async function writeDeploymentArtifacts(
   warpCoreConfig: WarpCoreConfig,
   context: WriteCommandContext,
-  addWarpRouteOptions?: AddWarpRouteOptions,
+  addWarpRouteOptions?: AddWarpRouteConfigOptions,
 ) {
   if (!context.isDryRun) {
     log('Writing deployment artifacts...');
@@ -188,7 +197,7 @@ async function getWarpCoreConfig(
   contracts: HyperlaneContractsMap<TokenFactories>,
 ): Promise<{
   warpCoreConfig: WarpCoreConfig;
-  addWarpRouteOptions?: AddWarpRouteOptions;
+  addWarpRouteOptions: AddWarpRouteConfigOptions;
 }> {
   const warpCoreConfig: WarpCoreConfig = { tokens: [] };
 


### PR DESCRIPTION
### Description
This PR updates warp deploy to output to WarpCoreConfig to `--warpRouteId`

### Related issues
- https://github.com/hyperlane-xyz/hyperlane-registry/pull/877

### Backward compatibility
Yes - See registry above referenced PR

### Testing
Manual/Unit Tests

