### PR TITLE
fix: add missing tsconfig dep after revert

### DIFF
--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -12,6 +12,7 @@
     "@hyperlane-xyz/cosmos-sdk": "13.1.1",
     "@hyperlane-xyz/registry": "15.7.0",
     "@hyperlane-xyz/sdk": "13.1.1",
+    "@hyperlane-xyz/tsconfig": "workspace:^",
     "@hyperlane-xyz/utils": "13.1.1",
     "@inquirer/core": "9.0.10",
     "@inquirer/figures": "1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7649,6 +7649,7 @@ __metadata:
     "@hyperlane-xyz/cosmos-sdk": "npm:13.1.1"
     "@hyperlane-xyz/registry": "npm:15.7.0"
     "@hyperlane-xyz/sdk": "npm:13.1.1"
+    "@hyperlane-xyz/tsconfig": "workspace:^"
     "@hyperlane-xyz/utils": "npm:13.1.1"
     "@inquirer/core": "npm:9.0.10"
     "@inquirer/figures": "npm:1.0.5"


### PR DESCRIPTION
### Description

We bring back the missing tsconfig dependency that was lost in an urgent revert.

### Related issues

Part of ENG-1668

### Backward compatibility

Yes

### Testing

The CLI build works.
