### PR TITLE
chore: Add .catch() for cases when there are no warp deploy config

### DIFF
--- a/typescript/infra/scripts/check/check-utils.ts
+++ b/typescript/infra/scripts/check/check-utils.ts
@@ -198,12 +198,19 @@ export async function getGovernor(
     if (!warpRouteId) {
       warpRouteId = await getWarpRouteIdInteractive();
     }
+
     const config = await getWarpConfig(
       multiProvider,
       envConfig,
       warpRouteId,
       registryUris,
-    );
+    ).catch(() => {
+      console.log(
+        `Warp route deploy config not found for ${warpRouteId}. Exiting.`,
+      );
+      process.exit(0);
+    });
+
     const warpAddresses = await getWarpAddressesFrom(warpRouteId, registryUris);
 
     const filteredAddresses = Object.keys(warpAddresses) // filter out changes not in config

--- a/typescript/infra/scripts/check/check-utils.ts
+++ b/typescript/infra/scripts/check/check-utils.ts
@@ -204,9 +204,9 @@ export async function getGovernor(
       envConfig,
       warpRouteId,
       registryUris,
-    ).catch(() => {
+    ).catch((error) => {
       console.log(
-        `Warp route deploy config not found for ${warpRouteId}. Exiting.`,
+        `Fetching warp route deploy config failed for ${warpRouteId}. Exiting with error: ${error}`,
       );
       process.exit(0);
     });


### PR DESCRIPTION
### Description
This PR addresses the issue of when there are no warp deploy config by exit(0)

### Backward compatibility

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
