### PR TITLE
feat(relayer): config to ignore reported reorgs

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/base_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base_builder.rs
@@ -7,6 +7,7 @@ use derive_new::new;
 use eyre::Context;
 use futures::{stream, StreamExt};
 use hyperlane_ethereum::Signers;
+use prometheus::IntGauge;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
@@ -44,6 +45,7 @@ pub struct BaseMetadataBuilder {
     app_context_classifier: IsmAwareAppContextClassifier,
     ism_cache_policy_classifier: IsmCachePolicyClassifier,
     signer: Option<Signers>,
+    ignore_reorg_reports: bool,
 }
 
 impl Debug for BaseMetadataBuilder {
@@ -221,25 +223,9 @@ impl BuildsBaseMetadata for BaseMetadataBuilder {
                             continue;
                         }
 
-                        match config.build_and_validate(None).await {
-                            Ok(checkpoint_syncer) => {
-                                // found the syncer for this validator
-                                return Ok(Some((*validator, checkpoint_syncer)));
-                            }
-                            Err(CheckpointSyncerBuildError::ReorgEvent(reorg_event)) => {
-                                // If a reorg event has been posted to a checkpoint syncer,
-                                // we refuse to build
-                                // This will result in a short circuit and return an error for the entire build process of all syncers 
-                                return Err(CheckpointSyncerBuildError::ReorgEvent(reorg_event));
-                            }
-                            Err(err) => {
-                                debug!(
-                                    error=%err,
-                                    ?config,
-                                    ?validator,
-                                    "Error when loading checkpoint syncer; will attempt to use the next config"
-                                );
-                            }
+                        if let Some(syncer) = self.build_and_validate(&config, validator, None).await? {
+                            // found the syncer for this validator
+                            return Ok(Some((*validator, syncer)));
                         }
                     }
                     warn!(
@@ -258,7 +244,7 @@ impl BuildsBaseMetadata for BaseMetadataBuilder {
             .collect::<Vec<_>>()
             .await
             .into_iter()
-            .collect::<Result<Vec<_>, _>>()? // Collect results into a single vector and return if any of them returns an error
+            .collect::<Result<Vec<_>, CheckpointSyncerBuildError>>()? // Collect results into a single vector and return if any of them returns an error
             .into_iter()
             .flatten() // Flatten Option<_>
             .collect::<Vec<_>>();
@@ -286,5 +272,40 @@ impl BaseMetadataBuilder {
     ) -> eyre::Result<Vec<Vec<String>>> {
         fetch_storage_locations_helper(validators, &self.cache, &*self.origin_validator_announce)
             .await
+    }
+
+    async fn build_and_validate(
+        &self,
+        config: &CheckpointSyncerConf,
+        validator: &H256,
+        latest_index_gauge: Option<IntGauge>,
+    ) -> Result<Option<Box<dyn CheckpointSyncer>>, CheckpointSyncerBuildError> {
+        match config.build_and_validate(latest_index_gauge).await {
+            Ok(checkpoint_syncer) => {
+                return Ok(Some(checkpoint_syncer));
+            }
+            Err(CheckpointSyncerBuildError::ReorgEvent(reorg_event)) => {
+                if self.ignore_reorg_reports {
+                    warn!(
+                        ?reorg_event,
+                        "Ignoring reorg event for checkpoint syncer build"
+                    );
+                    return Ok(None);
+                }
+                // If a reorg event has been posted to a checkpoint syncer,
+                // we refuse to build
+                // This will result in a short circuit and return an error for the entire build process of all syncers
+                return Err(CheckpointSyncerBuildError::ReorgEvent(reorg_event));
+            }
+            Err(err) => {
+                debug!(
+                    error=%err,
+                    ?config,
+                    ?validator,
+                    "Error when loading checkpoint syncer; will attempt to use the next config"
+                );
+            }
+        }
+        Ok(None)
     }
 }

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -375,6 +375,7 @@ impl BaseAgent for Relayer {
             for (origin, validator_announce) in validator_announces.iter() {
                 let db = dbs.get(origin).unwrap().clone();
                 let default_ism_getter = DefaultIsmCache::new(dest_mailbox.clone());
+                let origin_chain_setup = core.settings.chain_setup(origin).unwrap().clone();
                 // Extract optional Ethereum signer for CCIP-read authentication
                 let metadata_builder = BaseMetadataBuilder::new(
                     origin.clone(),
@@ -394,6 +395,7 @@ impl BaseAgent for Relayer {
                         settings.ism_cache_configs.clone(),
                     ),
                     ccip_signers.get(destination).cloned().flatten(),
+                    origin_chain_setup.ignore_reorg_reports,
                 );
 
                 msg_ctxs.insert(
@@ -1180,6 +1182,7 @@ mod test {
                     chunk_size: 1,
                     mode: IndexMode::Block,
                 },
+                ignore_reorg_reports: false,
             },
         )];
 

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -87,6 +87,8 @@ pub struct ChainConf {
     pub metrics_conf: PrometheusMiddlewareConf,
     /// Settings for event indexing
     pub index: IndexSettings,
+    /// Whether to ignore reorg reports
+    pub ignore_reorg_reports: bool,
 }
 
 /// A sequence-aware indexer for messages

--- a/rust/main/hyperlane-base/src/settings/checkpoint_syncer.rs
+++ b/rust/main/hyperlane-base/src/settings/checkpoint_syncer.rs
@@ -123,11 +123,6 @@ impl FromStr for CheckpointSyncerConf {
 
 impl CheckpointSyncerConf {
     /// Turn conf info a Checkpoint Syncer
-    ///
-    /// # Panics
-    ///
-    /// Panics if a reorg event has been posted to the checkpoint store,
-    /// to prevent any operation processing until the reorg is resolved.
     pub async fn build_and_validate(
         &self,
         latest_index_gauge: Option<IntGauge>,

--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -238,6 +238,12 @@ fn parse_chain(
         .parse_u32()
         .end();
 
+    let ignore_reorg_reports = chain
+        .chain(&mut err)
+        .get_opt_key("ignoreReorgReports")
+        .parse_bool()
+        .unwrap_or(false);
+
     cfg_unwrap_all!(&chain.cwp, err: [domain]);
     let connection = build_connection_conf(
         domain.domain_protocol(),
@@ -273,6 +279,7 @@ fn parse_chain(
             chunk_size,
             mode,
         },
+        ignore_reorg_reports,
     })
 }
 


### PR DESCRIPTION
### Description

There are cases when validators have an unreliable RPC setup and end up reporting a reorg when no other validator in the set did. We want to halt processing as a failsafe but also have the option to disable the failsafe to speed up recovery - hence the config added in this PR, which applies to a chain when it is the origin of a message.

