### PR TITLE
feat: cosmos block events

### DIFF
--- a/rust/main/agents/scraper/src/store/storage.rs
+++ b/rust/main/agents/scraper/src/store/storage.rs
@@ -136,7 +136,7 @@ impl HyperlaneDbStore {
         let mut hashes_to_insert: Vec<&H512> = Vec::with_capacity(CHUNK_SIZE);
 
         for mut chunk in as_chunks::<(&H512, &mut (Option<i64>, i64))>(txns_to_fetch, CHUNK_SIZE) {
-            for (hash, (_, block_id)) in chunk.iter() {
+            for (hash, (_, block_id)) in chunk.iter().filter(|(hash, _)| !hash.is_zero()) {
                 let info = match self.provider.get_txn_by_hash(hash).await {
                     Ok(info) => info,
                     Err(e) => {

--- a/rust/main/chains/hyperlane-cosmos-native/src/indexers/indexer.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/indexers/indexer.rs
@@ -130,21 +130,18 @@ where
     async fn get_logs_in_block(&self, block_height: u32) -> ChainResult<Vec<(T, LogMeta)>> {
         let block = self.provider().get_block(block_height).await?;
         let block_results = self.provider().get_block_results(block_height).await?;
-        let result = self.handle_txs(block, block_results);
+        let result = self.handle_block(block, block_results);
         Ok(result)
     }
 
     /// Iterate through all txs, filter out failed txs, find target events
-    /// in successful txs, and parse them.
-    fn handle_txs(
+    /// in successful txs, and parse them. Also iterates through all events in the block and tries to parse them.
+    fn handle_block(
         &self,
         block: BlockResponse,
         block_results: BlockResultsResponse,
     ) -> Vec<(T, LogMeta)> {
-        let Some(tx_results) = block_results.txs_results else {
-            return vec![];
-        };
-
+        let tx_results = block_results.txs_results.unwrap_or_default();
         // Cosmos can also emit events in the block itself, those events do not originate from a tx, but rather from the block
         let mut block_events = block_results.finalize_block_events;
 

--- a/rust/main/chains/hyperlane-cosmos-native/src/indexers/indexer.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/indexers/indexer.rs
@@ -156,6 +156,8 @@ where
             block_events.extend(end_events);
         }
 
+        let block_hash = H256::from_slice(block.block_id.hash.as_bytes());
+
         let tx_hashes: Vec<Hash> = block
             .clone()
             .block
@@ -189,11 +191,14 @@ where
                     proof: None,
                 };
 
-                let block_hash = H256::from_slice(block.block_id.hash.as_bytes());
-
                 Some(self.handle_tx(tx_response, block_hash))
             })
             .flatten()
+            .chain(self.handle_block_events(
+                block_events,
+                block_hash,
+                block.block.header.height.into(),
+            ))
             .collect()
     }
 

--- a/rust/main/chains/hyperlane-cosmos-native/src/indexers/indexer.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/indexers/indexer.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::ops::RangeInclusive;
 
 use futures::future;
-use tendermint::abci::EventAttribute;
+use tendermint::abci::{Event, EventAttribute};
 use tendermint::hash::Algorithm;
 use tendermint::Hash;
 use tendermint_rpc::endpoint::tx;
@@ -72,6 +72,9 @@ where
         &self,
         tx_hash: H512,
     ) -> ChainResult<Vec<(Indexed<T>, LogMeta)>> {
+        if tx_hash.is_zero() {
+            return Ok(vec![]);
+        }
         let tx_response = self.provider().get_tx(&tx_hash).await?;
         let block_height = tx_response.height.value() as u32;
         let block = self.provider().get_block(block_height).await?;
@@ -142,6 +145,17 @@ where
             return vec![];
         };
 
+        // Cosmos can also emit events in the block itself, those events do not originate from a tx, but rather from the block
+        let mut block_events = block_results.finalize_block_events;
+
+        if let Some(begin_events) = block_results.begin_block_events {
+            block_events.extend(begin_events);
+        }
+
+        if let Some(end_events) = block_results.end_block_events {
+            block_events.extend(end_events);
+        }
+
         let tx_hashes: Vec<Hash> = block
             .clone()
             .block
@@ -183,6 +197,36 @@ where
             .collect()
     }
 
+    /// Iter through all events in the block, looking for any target events
+    fn handle_block_events(
+        &self,
+        events: Vec<Event>,
+        block_hash: H256,
+        block_height: u64,
+    ) -> impl Iterator<Item = (T, LogMeta)> {
+        events.into_iter().enumerate().filter_map(move |(log_idx, event)| {
+            if event.kind.as_str() != Self::target_type() {
+                return None;
+            }
+
+            self.parse(&event.attributes)
+                .map_err(|err| {
+                    trace!(?err, block_hash=?block_hash, log_idx, ?event, "Failed to parse block event attributes");
+                })
+                .ok()
+                .map(|parsed_event| {
+                    (parsed_event.event, LogMeta {
+                        address: parsed_event.contract_address,
+                        block_number: block_height,
+                        block_hash,
+                        transaction_id: H512::zero(),
+                        transaction_index: 0,
+                        log_index: U256::from(log_idx),
+                    })
+                })
+        })
+    }
+
     /// Iter through all events in the tx, looking for any target events
     /// made by the contract we are indexing.
     fn handle_tx(&self, tx: tx::Response, block_hash: H256) -> impl Iterator<Item = (T, LogMeta)> {
@@ -192,7 +236,6 @@ where
         let block_height = tx.height;
 
         tx_events.into_iter().enumerate().filter_map(move |(log_idx, event)| {
-
             if event.kind.as_str() != Self::target_type() {
                 return None;
             }
@@ -208,7 +251,7 @@ where
                         block_number: block_height.value(),
                         block_hash,
                         transaction_id: H256::from_slice(tx_hash.as_bytes()).into(),
-                        transaction_index: tx_index as u64,
+                        transaction_index: tx_index.into(),
                         log_index: U256::from(log_idx),
                     })
                 })

--- a/rust/main/chains/hyperlane-cosmos-native/src/providers/cosmos.rs
+++ b/rust/main/chains/hyperlane-cosmos-native/src/providers/cosmos.rs
@@ -393,6 +393,9 @@ impl HyperlaneProvider for CosmosNativeProvider {
     }
 
     async fn get_txn_by_hash(&self, hash: &H512) -> ChainResult<TxnInfo> {
+        if hash.is_zero() {
+            return Err(HyperlaneProviderError::CouldNotFindTransactionByHash(*hash).into());
+        }
         let response = self.rpc.get_tx(hash).await?;
         let tx = Tx::from_bytes(&response.tx)?;
 


### PR DESCRIPTION
### Description
Added block event indexing for cosmos. Block events are special in the sense that they do not have any TX Hash. This will result in the scraper not finding the given events, however, the relayer & validator do.
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing
Local E2E Testing
<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
