### PR TITLE
chore: Upgrade Scraper Testnet to latest

### DIFF
--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -416,7 +416,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '28e19ad-20250523-012551',
+      tag: '4bfa2da-20250526-135043',
     },
     resources: scraperResources,
   },


### PR DESCRIPTION
### Description

Upgrade Scraper Testnet to latest so that it does not report errors on Solana Testnet

### Backward compatibility

Yes

### Testing

Manual, Unit