### PR TITLE
feat: check tag exists before deploying agents

### DIFF
--- a/typescript/infra/scripts/funding/deploy-key-funder.ts
+++ b/typescript/infra/scripts/funding/deploy-key-funder.ts
@@ -1,5 +1,8 @@
+import chalk from 'chalk';
+
 import { Contexts } from '../../config/contexts.js';
 import { KeyFunderHelmManager } from '../../src/funding/key-funder.js';
+import { checkMonorepoImageExists } from '../../src/utils/gcloud.js';
 import { HelmCommand } from '../../src/utils/helm.js';
 import { assertCorrectKubeContext } from '../agent-utils.js';
 import { getConfigsBasedOnArgs } from '../core-utils.js';
@@ -12,6 +15,22 @@ async function main() {
     );
 
   await assertCorrectKubeContext(envConfig);
+
+  if (envConfig.keyFunderConfig?.docker.tag) {
+    const exists = await checkMonorepoImageExists(
+      envConfig.keyFunderConfig.docker.tag,
+    );
+    if (!exists) {
+      console.log(
+        chalk.red(
+          `Attempted to deploy key funder with image tag ${chalk.bold(
+            envConfig.keyFunderConfig.docker.tag,
+          )}, but it has not been published to GCR.`,
+        ),
+      );
+      process.exit(1);
+    }
+  }
 
   const manager = KeyFunderHelmManager.forEnvironment(environment);
   await manager.runHelmCommand(HelmCommand.InstallOrUpgrade);

--- a/typescript/infra/src/utils/gcloud.ts
+++ b/typescript/infra/src/utils/gcloud.ts
@@ -369,3 +369,31 @@ function iamConditionsEqual(
   }
   return a && b && a.title === b.title && a.expression === b.expression;
 }
+
+async function checkDockerTagExists({
+  repo = 'abacus-labs-dev',
+  image,
+  tag,
+}: {
+  repo?: string;
+  image: string;
+  tag: string;
+}): Promise<boolean> {
+  const url = `https://gcr.io/v2/${repo}/${image}/manifests/${tag}`;
+  const res = await fetch(url, { method: 'HEAD' });
+  return res.status === 200;
+}
+
+export async function checkAgentImageExists(tag: string) {
+  return checkDockerTagExists({
+    image: 'hyperlane-agent',
+    tag,
+  });
+}
+
+export async function checkMonorepoImageExists(tag: string) {
+  return checkDockerTagExists({
+    image: 'hyperlane-monorepo',
+    tag,
+  });
+}

--- a/typescript/infra/src/utils/helm.ts
+++ b/typescript/infra/src/utils/helm.ts
@@ -1,6 +1,5 @@
 import { execSync } from 'child_process';
 
-import { DockerConfig } from '../config/agent/agent.js';
 import {
   HelmChartConfig,
   HelmChartRepositoryConfig,


### PR DESCRIPTION
### Description

feat: check tag exists before deploying agents
- helpers for checking an agent/monorepo image exist
- integrate with agents/keyfunder deploy scripts

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

![image](https://github.com/user-attachments/assets/06b73684-2dd2-42d2-a508-e6fd66559d11)
![image](https://github.com/user-attachments/assets/cdbf957c-de8b-4257-9c92-daefb99f4fdf)
