### PR TITLE
fix: remove public fn from RateLimited library

### DIFF
--- a/solidity/contracts/hooks/warp-route/RateLimitedHook.sol
+++ b/solidity/contracts/hooks/warp-route/RateLimitedHook.sol
@@ -83,7 +83,7 @@ contract RateLimitedHook is
         require(_isLatestDispatched(_message.id()), "InvalidDispatchedMessage");
 
         uint256 newAmount = _message.body().amount();
-        validateAndConsumeFilledLevel(newAmount);
+        _validateAndConsumeFilledLevel(newAmount);
     }
 
     /// @inheritdoc AbstractPostDispatchHook

--- a/solidity/contracts/isms/warp-route/RateLimitedIsm.sol
+++ b/solidity/contracts/isms/warp-route/RateLimitedIsm.sol
@@ -61,7 +61,7 @@ contract RateLimitedIsm is
         require(_isDelivered(_message.id()), "InvalidDeliveredMessage");
 
         uint256 newAmount = _message.body().amount();
-        validateAndConsumeFilledLevel(newAmount);
+        _validateAndConsumeFilledLevel(newAmount);
 
         return true;
     }

--- a/solidity/contracts/libs/RateLimited.sol
+++ b/solidity/contracts/libs/RateLimited.sol
@@ -115,9 +115,9 @@ contract RateLimited is OwnableUpgradeable {
      * @param _consumedAmount The amount to consume the fill level
      * @return The new filled level
      */
-    function validateAndConsumeFilledLevel(
+    function _validateAndConsumeFilledLevel(
         uint256 _consumedAmount
-    ) public returns (uint256) {
+    ) internal returns (uint256) {
         uint256 adjustedFilledLevel = calculateCurrentLevel();
         require(_consumedAmount <= adjustedFilledLevel, "RateLimitExceeded");
 

--- a/solidity/test/lib/RateLimited.t.sol
+++ b/solidity/test/lib/RateLimited.t.sol
@@ -4,14 +4,24 @@ pragma solidity ^0.8.13;
 import {Test} from "forge-std/Test.sol";
 import {RateLimited} from "../../contracts/libs/RateLimited.sol";
 
+contract TestRateLimited is RateLimited {
+    constructor(uint256 _maxCapacity) RateLimited(_maxCapacity) {}
+
+    function validateAndConsumeFilledLevel(
+        uint256 _amount
+    ) public returns (uint256) {
+        return _validateAndConsumeFilledLevel(_amount);
+    }
+}
+
 contract RateLimitLibTest is Test {
-    RateLimited rateLimited;
+    TestRateLimited rateLimited;
     uint256 constant MAX_CAPACITY = 1 ether;
     uint256 constant ONE_PERCENT = 0.01 ether; // Used for assertApproxEqRel
     address HOOK = makeAddr("HOOK");
 
     function setUp() public {
-        rateLimited = new RateLimited(MAX_CAPACITY);
+        rateLimited = new TestRateLimited(MAX_CAPACITY);
     }
 
     function testConstructor_revertsWhen_lowCapacity() public {


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

- Fixes https://linear.app/hyperlane-xyz/issue/ENG-1387/rate-limit-ism

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
