### PR TITLE
chore: set batch gas limit multiplier back to 1x

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/contracts/multicall.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/multicall.rs
@@ -14,7 +14,7 @@ use crate::{ConnectionConf, EthereumProvider};
 
 use super::EthereumMailboxCache;
 
-const MULTICALL_GAS_LIMIT_MULTIPLIER_DENOMINATOR: u64 = 80;
+const MULTICALL_GAS_LIMIT_MULTIPLIER_DENOMINATOR: u64 = 100;
 const MULTICALL_GAS_LIMIT_MULTIPLIER_NUMERATOR: u64 = 100;
 const ALLOW_BATCH_FAILURES: bool = true;
 


### PR DESCRIPTION
### Description

To improve TGE day throughput, we scaled down batch gas limit estimate by 0.8x so we can fit more messages in a block, since hyperchains significantly overestimate gas. Also as part of those changes, we started allowing single-message batches, to simplify the submission flow and keep latency low.

One consequence this has had is a delivery [tx](https://explorer.metall2.com/tx/0x101b4ab2c4598b36471fff88ba5bf0bb98f0292ef5e7e73fcd0a9639632e77b1) that ran out of gas to `metal` chain, where the gas estimate was rather accurate. The tx was a single-message batch - there were supposed to be 2 messages in the batch, but one of them failed simulation: https://cloudlogging.app.goo.gl/J3D6Ga2vyyxTA9q77

We no longer to maximize messages sent per block for now, so I'm setting the batch gas limit back to 1x, to avoid such edge cases. With a multiplier of 1x, the gas limit would've been ~685k gas instead of ~537k, which would've been enough to account for `multicall`'s overhead. For reference, Nam's self-relay [tx](https://explorer.metall2.com/tx/0x101b4ab2c4598b36471fff88ba5bf0bb98f0292ef5e7e73fcd0a9639632e77b1) for this same message only used 438k gas.

To verify that the tx ran out of gas I used
```
cast run 0xdcee896a366b84ac0d3d2b3a51d48d184572c5c33fe70e0c2a5aa8a3a5cb3089 --rpc-url https://rpc.metall2.com/
```