### PR TITLE
feat: Add reporting of latest checkpoints on reorg at start up

### DIFF
--- a/rust/main/agents/validator/src/reorg_reporter.rs
+++ b/rust/main/agents/validator/src/reorg_reporter.rs
@@ -29,6 +29,7 @@ pub struct LatestCheckpointReorgReporter {
 #[async_trait]
 impl ReorgReporter for LatestCheckpointReorgReporter {
     async fn report_at_block(&self, height: u64) {
+        info!(?height, "Reporting latest checkpoint on reorg");
         let mut futures = vec![];
         for (url, merkle_tree_hook) in &self.merkle_tree_hooks {
             let future = async {
@@ -40,7 +41,7 @@ impl ReorgReporter for LatestCheckpointReorgReporter {
                 })
                 .await;
 
-                info!(url = ?url.clone(), ?latest_checkpoint, "Latest checkpoint on reorg");
+                info!(url = ?url.clone(), ?height, ?latest_checkpoint, "Report latest checkpoint on reorg");
             };
 
             futures.push(future);
@@ -50,6 +51,7 @@ impl ReorgReporter for LatestCheckpointReorgReporter {
     }
 
     async fn report_with_reorg_period(&self, reorg_period: &ReorgPeriod) {
+        info!(?reorg_period, "Reporting latest checkpoint on reorg");
         let mut futures = vec![];
         for (url, merkle_tree_hook) in &self.merkle_tree_hooks {
             let future = async {
@@ -60,7 +62,7 @@ impl ReorgReporter for LatestCheckpointReorgReporter {
                 })
                 .await;
 
-                info!(url = ?url.clone(), ?latest_checkpoint, "Latest checkpoint on reorg");
+                info!(url = ?url.clone(), ?reorg_period, ?latest_checkpoint, "Report latest checkpoint on reorg");
             };
 
             futures.push(future);


### PR DESCRIPTION
### Description

When validator starts up, it creates checkpoint syncer. The syncer checks if a reorg event was reported by the validator and, if it was, the syncer constructor will report an error. Validator was intentionaly crashed (with expect on Result) when it happens.

Now, we capture the error and we report the latest checkpoints as they are provided by each endpoint separately using reorg reporter. Once report is logged, we crash the validator.

### Backward compatibility

Yes

### Testing

None