### PR TITLE
fix: protocol fee type & read routing ism

### DIFF
--- a/typescript/sdk/src/core/StarknetCoreModule.ts
+++ b/typescript/sdk/src/core/StarknetCoreModule.ts
@@ -128,8 +128,6 @@ export class StarknetCoreModule {
       protocolFee,
     );
 
-    console.log('updateCoreDeploy');
-
     // 5. Update the configuration with custom ISM and hooks if specified
     const { defaultIsm, defaultHook: merkleTreeHook } =
       await this.updateCoreDeploy(config, mailboxContract.address);
@@ -205,8 +203,6 @@ export class StarknetCoreModule {
 
     const owner = await this.readOwner(mailbox);
     const mailboxContract = getStarknetMailboxContract(mailbox, this.signer);
-
-    console.log('expectedConfig.defaultIsm', expectedConfig.defaultIsm);
 
     // Update ISM if specified in config
     if (expectedConfig.defaultIsm) {

--- a/typescript/sdk/src/core/StarknetCoreModule.ts
+++ b/typescript/sdk/src/core/StarknetCoreModule.ts
@@ -1,5 +1,4 @@
-import { BigNumber } from 'ethers';
-import { Account, MultiType } from 'starknet';
+import { Account, MultiType, cairo } from 'starknet';
 
 import {
   ChainId,
@@ -111,8 +110,8 @@ export class StarknetCoreModule {
     const protocolFee = await this.deployer.deployContract(
       StarknetContractName.PROTOCOL_FEE,
       [
-        BigNumber.from(config.requiredHook.maxProtocolFee),
-        BigNumber.from(config.requiredHook.protocolFee),
+        cairo.uint256(config.requiredHook.maxProtocolFee),
+        cairo.uint256(config.requiredHook.protocolFee),
         config.requiredHook.beneficiary,
         config.owner,
         PROTOCOL_TO_DEFAULT_NATIVE_TOKEN[ProtocolType.Starknet]!
@@ -128,6 +127,8 @@ export class StarknetCoreModule {
       defaultHook,
       protocolFee,
     );
+
+    console.log('updateCoreDeploy');
 
     // 5. Update the configuration with custom ISM and hooks if specified
     const { defaultIsm, defaultHook: merkleTreeHook } =
@@ -204,6 +205,8 @@ export class StarknetCoreModule {
 
     const owner = await this.readOwner(mailbox);
     const mailboxContract = getStarknetMailboxContract(mailbox, this.signer);
+
+    console.log('expectedConfig.defaultIsm', expectedConfig.defaultIsm);
 
     // Update ISM if specified in config
     if (expectedConfig.defaultIsm) {

--- a/typescript/sdk/src/ism/StarknetIsmReader.ts
+++ b/typescript/sdk/src/ism/StarknetIsmReader.ts
@@ -206,11 +206,19 @@ export class StarknetIsmReader {
 
     for (const domain of domains) {
       try {
+        const chainName = this.multiProvider.tryGetChainName(domain);
+        if (!chainName) {
+          this.logger.warn(
+            `Unknown domain ID ${domain}, skipping domain configuration`,
+          );
+          continue;
+        }
+
         const module = await ism.module(domain);
         const moduleConfig = await this.deriveIsmConfig(
           num.toHex64(module.toString()),
         );
-        domainConfigs[domain.toString()] = moduleConfig;
+        domainConfigs[chainName] = moduleConfig;
       } catch (error) {
         this.logger.error(
           `Failed to derive config for domain ${domain}`,


### PR DESCRIPTION
### Description

This PR fixes starknets core deploy by using the correct uint256 type for protocol fee values and fixing the routing ism read

### Drive-by changes

-

### Related issues

-

### Backward compatibility

Yes

### Testing

Manual Tests
