### PR TITLE
fix: starknet include address in key for helm config

### DIFF
--- a/typescript/infra/src/config/agent/agent.ts
+++ b/typescript/infra/src/config/agent/agent.ts
@@ -126,6 +126,7 @@ export type CosmosKeyConfig = {
 export type StarknetKeyConfig = {
   type: AgentSignerKeyType.Starknet;
   legacy: boolean;
+  address: string;
 };
 export type KeyConfig =
   | AwsKeyConfig
@@ -246,9 +247,17 @@ export function defaultChainSignerKeyConfig(chainName: ChainName): KeyConfig {
     // Use starknet key for starknet & paradexsepolia
     case ProtocolType.Starknet: {
       if (chainName === 'paradexsepolia') {
-        return { type: AgentSignerKeyType.Starknet, legacy: true };
+        return {
+          type: AgentSignerKeyType.Starknet,
+          legacy: true,
+          address: 'QQDw4tyQzGKUGBgzsrni49GZ1FMc1XST2vhAfJoFKAd',
+        };
       }
-      return { type: AgentSignerKeyType.Starknet, legacy: false };
+      return {
+        type: AgentSignerKeyType.Starknet,
+        legacy: false,
+        address: 'VEqLwdBPk4kFMXCzKB7Cfd5NhNiHT9ZLKwU2bB8hrbV',
+      };
     }
     // For Ethereum and Sealevel use a hex key
     case ProtocolType.Ethereum:


### PR DESCRIPTION
### Description
Fixes the Starknet key address in the helm config. Otherwise the env will get set but the value will be empty resulting in a crash-loop on deployment.
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
