### PR TITLE
fix: pausable owner

### DIFF
--- a/typescript/sdk/src/ism/StarknetIsmReader.ts
+++ b/typescript/sdk/src/ism/StarknetIsmReader.ts
@@ -176,7 +176,7 @@ export class StarknetIsmReader {
       return {
         address,
         paused,
-        owner,
+        owner: num.toHex64(owner.toString()),
         type: IsmType.PAUSABLE,
       };
     } catch {


### PR DESCRIPTION
### Description

This PR fixes the read method for the starknet pausable ISM

### Drive-by changes

-

### Related issues

-

### Backward compatibility

Yes

### Testing

Manual testing
