### PR TITLE
chore: Bump Registry to version 15.10.1

### DIFF
--- a/.changeset/tasty-turtles-clap.md
+++ b/.changeset/tasty-turtles-clap.md
@@ -1,0 +1,7 @@
+---
+'@hyperlane-xyz/helloworld': patch
+'@hyperlane-xyz/widgets': patch
+'@hyperlane-xyz/cli': patch
+---
+
+Bump Registry to version 15.10.1 to patch addWarpRouteConfig to no longer throw when a warpRouteId exists

--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -10,7 +10,7 @@
     "@ethersproject/abi": "*",
     "@ethersproject/providers": "*",
     "@hyperlane-xyz/cosmos-sdk": "13.1.1",
-    "@hyperlane-xyz/registry": "15.7.0",
+    "@hyperlane-xyz/registry": "15.10.1",
     "@hyperlane-xyz/sdk": "13.1.1",
     "@hyperlane-xyz/tsconfig": "workspace:^",
     "@hyperlane-xyz/utils": "13.1.1",

--- a/typescript/helloworld/package.json
+++ b/typescript/helloworld/package.json
@@ -4,7 +4,7 @@
   "version": "13.1.1",
   "dependencies": {
     "@hyperlane-xyz/core": "7.1.8",
-    "@hyperlane-xyz/registry": "15.7.0",
+    "@hyperlane-xyz/registry": "15.10.1",
     "@hyperlane-xyz/sdk": "13.1.1",
     "@openzeppelin/contracts-upgradeable": "^4.9.3",
     "ethers": "^5.7.2"

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -14,7 +14,7 @@
     "@ethersproject/providers": "*",
     "@google-cloud/secret-manager": "^5.5.0",
     "@hyperlane-xyz/helloworld": "13.1.1",
-    "@hyperlane-xyz/registry": "15.7.0",
+    "@hyperlane-xyz/registry": "15.10.1",
     "@hyperlane-xyz/sdk": "13.1.1",
     "@hyperlane-xyz/utils": "13.1.1",
     "@inquirer/prompts": "3.3.2",

--- a/typescript/widgets/package.json
+++ b/typescript/widgets/package.json
@@ -31,7 +31,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@eslint/js": "^9.15.0",
-    "@hyperlane-xyz/registry": "15.7.0",
+    "@hyperlane-xyz/registry": "15.10.1",
     "@hyperlane-xyz/tsconfig": "workspace:^",
     "@storybook/addon-essentials": "^7.6.14",
     "@storybook/addon-interactions": "^7.6.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7647,7 +7647,7 @@ __metadata:
     "@ethersproject/abi": "npm:*"
     "@ethersproject/providers": "npm:*"
     "@hyperlane-xyz/cosmos-sdk": "npm:13.1.1"
-    "@hyperlane-xyz/registry": "npm:15.7.0"
+    "@hyperlane-xyz/registry": "npm:15.10.1"
     "@hyperlane-xyz/sdk": "npm:13.1.1"
     "@hyperlane-xyz/tsconfig": "workspace:^"
     "@hyperlane-xyz/utils": "npm:13.1.1"
@@ -7803,7 +7803,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.15.0"
     "@hyperlane-xyz/core": "npm:7.1.8"
-    "@hyperlane-xyz/registry": "npm:15.7.0"
+    "@hyperlane-xyz/registry": "npm:15.10.1"
     "@hyperlane-xyz/sdk": "npm:13.1.1"
     "@nomiclabs/hardhat-ethers": "npm:^2.2.3"
     "@nomiclabs/hardhat-waffle": "npm:^2.0.6"
@@ -7854,7 +7854,7 @@ __metadata:
     "@ethersproject/providers": "npm:*"
     "@google-cloud/secret-manager": "npm:^5.5.0"
     "@hyperlane-xyz/helloworld": "npm:13.1.1"
-    "@hyperlane-xyz/registry": "npm:15.7.0"
+    "@hyperlane-xyz/registry": "npm:15.10.1"
     "@hyperlane-xyz/sdk": "npm:13.1.1"
     "@hyperlane-xyz/tsconfig": "workspace:^"
     "@hyperlane-xyz/utils": "npm:13.1.1"
@@ -7920,14 +7920,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/registry@npm:15.7.0":
-  version: 15.7.0
-  resolution: "@hyperlane-xyz/registry@npm:15.7.0"
+"@hyperlane-xyz/registry@npm:15.10.1":
+  version: 15.10.1
+  resolution: "@hyperlane-xyz/registry@npm:15.10.1"
   dependencies:
     jszip: "npm:^3.10.1"
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/9f1475deb9abe690f08eb2dd5f7cbce5aff7239c43d588f3e5be52f171ff9339932a3a45c741f423a4a4d8cbad5563212c3b10e456909a32704bf036af79d0a0
+  checksum: 10/cafd861d93bd02f79489f3a6b0d45d4cc6e40c46ed35dda2d903799259eafa648a1d7c0d600debee7fc2ed0a0692eb814bf6e5fb1b5bc74632dfebf0280f7840
   languageName: node
   linkType: hard
 
@@ -8061,7 +8061,7 @@ __metadata:
     "@eslint/js": "npm:^9.15.0"
     "@headlessui/react": "npm:^2.1.8"
     "@hyperlane-xyz/cosmos-sdk": "npm:13.1.1"
-    "@hyperlane-xyz/registry": "npm:15.7.0"
+    "@hyperlane-xyz/registry": "npm:15.10.1"
     "@hyperlane-xyz/sdk": "npm:13.1.1"
     "@hyperlane-xyz/tsconfig": "workspace:^"
     "@hyperlane-xyz/utils": "npm:13.1.1"


### PR DESCRIPTION
### Description
This pull request updates the `@hyperlane-xyz/registry` dependency across multiple packages to version `15.10.1` and includes a patch to remove the throw from `addWarpRouteConfig`

### Backward compatibility
Yes, the only impacting update is to removing throw from addWarpRouteConfig(). This function is directly called in  `export-warp-configs.ts` and `warp init`

### Testing
Manual
