### PR TITLE
feat: Scales down deficits to distribute surpluses accordingly

### DIFF
--- a/typescript/cli/src/rebalancer/strategy/MinAmountStrategy.test.ts
+++ b/typescript/cli/src/rebalancer/strategy/MinAmountStrategy.test.ts
@@ -427,7 +427,7 @@ describe('MinAmountStrategy', () => {
       ]);
     });
 
-    it('should handle case where there is not enough surplus to meet all minimum requirements', () => {
+    it('should handle case where there is not enough surplus to meet all minimum requirements by scaling down deficits', () => {
       const strategy = new MinAmountStrategy(
         {
           [chain1]: {
@@ -469,10 +469,14 @@ describe('MinAmountStrategy', () => {
 
       const routes = strategy.getRebalancingRoutes(rawBalances);
 
-      // Should use all surplus but only partially address the deficits
-      expect(routes.length).to.equal(1);
+      // It scales down the deficits to prevent sending all surplus to a single chain
+      expect(routes.length).to.equal(2);
       expect(routes[0].origin).to.equal(chain3);
-      expect(routes[0].amount).to.equal(BigInt(50e18));
+      expect(routes[0].destination).to.equal(chain1);
+      expect(routes[0].amount).to.equal(BigInt(25e18));
+      expect(routes[1].origin).to.equal(chain3);
+      expect(routes[1].destination).to.equal(chain2);
+      expect(routes[1].amount).to.equal(BigInt(25e18));
     });
 
     it('should have no surplus or deficit when all at min', () => {


### PR DESCRIPTION
Closes https://github.com/BootNodeDev/hyperlane-monorepo/issues/62

For example, if deficits sum 10 but surpluses sum 9. Deficits are scaled down to distribute those 9 accordingly instead of 10.

If chain A and B have 6 and 4 as deficit while chain C has 9 surplus. Chain A and B are scaled down to 5.4 and 3.6