### PR TITLE
chore(agents): update relayer hyperlane testnet to include latest starknet changes

### DIFF
--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -405,7 +405,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '28e19ad-20250523-012551',
+      tag: 'df49f07-20250528-094039',
     },
     blacklist: [...releaseCandidateHelloworldMatchingList, ...relayBlacklist],
     gasPaymentEnforcement,


### PR DESCRIPTION
### Description

- Updated relayer hyperlane image to `df49f07-20250528-094039`

Now, both rc and hyperlane have starknet enabled.

### Drive-by changes

None

### Related issues

None

### Backward compatibility

Yes

### Testing

No error messages live.
