### PR TITLE
feat: Ignore from rebalancing tokens that are not defined in the config

### DIFF
--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -622,7 +622,7 @@ export const rebalancer: CommandModuleWithWriteContext<{
             }
           }
 
-          const rawBalances = getRawBalances(event);
+          const rawBalances = getRawBalances(rebalancerConfig, event);
 
           const rebalancingRoutes = strategy.getRebalancingRoutes(rawBalances);
 

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -622,7 +622,10 @@ export const rebalancer: CommandModuleWithWriteContext<{
             }
           }
 
-          const rawBalances = getRawBalances(rebalancerConfig, event);
+          const rawBalances = getRawBalances(
+            Object.keys(rebalancerConfig.chains),
+            event,
+          );
 
           const rebalancingRoutes = strategy.getRebalancingRoutes(rawBalances);
 

--- a/typescript/cli/src/rebalancer/utils/getRawBalances.test.ts
+++ b/typescript/cli/src/rebalancer/utils/getRawBalances.test.ts
@@ -1,25 +1,20 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { Token, TokenStandard } from '@hyperlane-xyz/sdk';
+import { ChainName, Token, TokenStandard } from '@hyperlane-xyz/sdk';
 
-import { Config } from '../config/Config.js';
 import { MonitorEvent } from '../interfaces/IMonitor.js';
 
 import { getRawBalances } from './getRawBalances.js';
 
 describe('getRawBalances', () => {
-  let config: Config;
+  let chains: ChainName[];
   let token: Token;
   let tokenBridgedSupply: bigint;
   let event: MonitorEvent;
 
   beforeEach(() => {
-    config = {
-      chains: {
-        mainnet: {},
-      },
-    } as unknown as Config;
+    chains = ['mainnet'];
 
     token = {
       chainName: 'mainnet',
@@ -41,7 +36,7 @@ describe('getRawBalances', () => {
   });
 
   it('should return the bridged supply for the token (EvmHypCollateral)', () => {
-    expect(getRawBalances(config, event)).to.deep.equal({
+    expect(getRawBalances(chains, event)).to.deep.equal({
       mainnet: tokenBridgedSupply,
     });
   });
@@ -49,7 +44,7 @@ describe('getRawBalances', () => {
   it('should return the bridged supply for the token (EvmHypNative)', () => {
     token.standard = TokenStandard.EvmHypNative;
 
-    expect(getRawBalances(config, event)).to.deep.equal({
+    expect(getRawBalances(chains, event)).to.deep.equal({
       mainnet: tokenBridgedSupply,
     });
   });
@@ -57,19 +52,19 @@ describe('getRawBalances', () => {
   it('should ignore non supported token standards', () => {
     token.standard = TokenStandard.EvmHypOwnerCollateral;
 
-    expect(getRawBalances(config, event)).to.deep.equal({});
+    expect(getRawBalances(chains, event)).to.deep.equal({});
   });
 
-  it('should ignore tokens that are not in the config', () => {
-    delete config.chains.mainnet;
+  it('should ignore tokens that are not in the chains list', () => {
+    chains = [];
 
-    expect(getRawBalances(config, event)).to.deep.equal({});
+    expect(getRawBalances(chains, event)).to.deep.equal({});
   });
 
   it('should throw if the bridged supply is undefined', () => {
     delete event.tokensInfo[0].bridgedSupply;
 
-    expect(() => getRawBalances(config, event)).to.throw(
+    expect(() => getRawBalances(chains, event)).to.throw(
       'bridgedSupply should not be undefined for collateralized token 0xAddress',
     );
   });

--- a/typescript/cli/src/rebalancer/utils/getRawBalances.test.ts
+++ b/typescript/cli/src/rebalancer/utils/getRawBalances.test.ts
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { Token, TokenStandard } from '@hyperlane-xyz/sdk';
+
+import { Config } from '../config/Config.js';
+import { MonitorEvent } from '../interfaces/IMonitor.js';
+
+import { getRawBalances } from './getRawBalances.js';
+
+describe('getRawBalances', () => {
+  let config: Config;
+  let token: Token;
+  let tokenBridgedSupply: bigint;
+  let event: MonitorEvent;
+
+  beforeEach(() => {
+    config = {
+      chains: {
+        mainnet: {},
+      },
+    } as unknown as Config;
+
+    token = {
+      chainName: 'mainnet',
+      addressOrDenom: '0xAddress',
+      isCollateralized: sinon.stub().returns(true),
+      standard: TokenStandard.EvmHypCollateral,
+    } as unknown as Token;
+
+    tokenBridgedSupply = 100n;
+
+    event = {
+      tokensInfo: [
+        {
+          token,
+          bridgedSupply: tokenBridgedSupply,
+        },
+      ],
+    };
+  });
+
+  it('should return the bridged supply for the token (EvmHypCollateral)', () => {
+    expect(getRawBalances(config, event)).to.deep.equal({
+      mainnet: tokenBridgedSupply,
+    });
+  });
+
+  it('should return the bridged supply for the token (EvmHypNative)', () => {
+    token.standard = TokenStandard.EvmHypNative;
+
+    expect(getRawBalances(config, event)).to.deep.equal({
+      mainnet: tokenBridgedSupply,
+    });
+  });
+
+  it('should ignore non supported token standards', () => {
+    token.standard = TokenStandard.EvmHypOwnerCollateral;
+
+    expect(getRawBalances(config, event)).to.deep.equal({});
+  });
+
+  it('should ignore tokens that are not in the config', () => {
+    delete config.chains.mainnet;
+
+    expect(getRawBalances(config, event)).to.deep.equal({});
+  });
+
+  it('should throw if the bridged supply is undefined', () => {
+    delete event.tokensInfo[0].bridgedSupply;
+
+    expect(() => getRawBalances(config, event)).to.throw(
+      'bridgedSupply should not be undefined for collateralized token 0xAddress',
+    );
+  });
+});

--- a/typescript/cli/src/rebalancer/utils/getRawBalances.ts
+++ b/typescript/cli/src/rebalancer/utils/getRawBalances.ts
@@ -1,19 +1,40 @@
+import { logDebug } from '../../logger.js';
+import { Config } from '../config/Config.js';
 import { MonitorEvent } from '../interfaces/IMonitor.js';
 import { RawBalances } from '../interfaces/IStrategy.js';
 
 import { isCollateralizedTokenEligibleForRebalancing } from './isCollateralizedTokenEligibleForRebalancing.js';
 
-export function getRawBalances(event: MonitorEvent): RawBalances {
+export function getRawBalances(
+  config: Config,
+  event: MonitorEvent,
+): RawBalances {
   return event.tokensInfo.reduce((acc, tokenInfo) => {
-    if (isCollateralizedTokenEligibleForRebalancing(tokenInfo.token)) {
-      if (tokenInfo.bridgedSupply === undefined) {
-        throw new Error(
-          `bridgedSupply should not be undefined for collateralized token ${tokenInfo.token.addressOrDenom}`,
-        );
-      }
+    const { token, bridgedSupply } = tokenInfo;
 
-      acc[tokenInfo.token.chainName] = tokenInfo.bridgedSupply;
+    // Ignore tokens that are not in the rebalancer config
+    if (!config.chains[token.chainName]) {
+      logDebug(
+        `[${getRawBalances.name}] Skipping token on chain ${token.chainName} that is not in config`,
+      );
+      return acc;
     }
+
+    // Ignore tokens that are not collateralized
+    if (!isCollateralizedTokenEligibleForRebalancing(token)) {
+      logDebug(
+        `[${getRawBalances.name}] Skipping token on chain ${token.chainName} that is not collateralized`,
+      );
+      return acc;
+    }
+
+    if (bridgedSupply === undefined) {
+      throw new Error(
+        `bridgedSupply should not be undefined for collateralized token ${token.addressOrDenom}`,
+      );
+    }
+
+    acc[token.chainName] = bridgedSupply;
 
     return acc;
   }, {} as RawBalances);

--- a/typescript/cli/src/rebalancer/utils/getRawBalances.ts
+++ b/typescript/cli/src/rebalancer/utils/getRawBalances.ts
@@ -1,21 +1,29 @@
+import { ChainName } from '@hyperlane-xyz/sdk';
+
 import { logDebug } from '../../logger.js';
-import { Config } from '../config/Config.js';
 import { MonitorEvent } from '../interfaces/IMonitor.js';
 import { RawBalances } from '../interfaces/IStrategy.js';
 
 import { isCollateralizedTokenEligibleForRebalancing } from './isCollateralizedTokenEligibleForRebalancing.js';
 
+/**
+ * Returns the raw balances required by the strategies from the monitor event
+ * @param chains - The chains that should be included in the raw balances (e.g. the chains in the rebalancer config)
+ * @param event - The monitor event to extract the raw balances from
+ */
 export function getRawBalances(
-  config: Config,
+  chains: ChainName[],
   event: MonitorEvent,
 ): RawBalances {
   return event.tokensInfo.reduce((acc, tokenInfo) => {
     const { token, bridgedSupply } = tokenInfo;
 
-    // Ignore tokens that are not in the rebalancer config
-    if (!config.chains[token.chainName]) {
+    const chainSet = new Set(chains);
+
+    // Ignore tokens that are not in the provided chains list
+    if (!chainSet.has(token.chainName)) {
       logDebug(
-        `[${getRawBalances.name}] Skipping token on chain ${token.chainName} that is not in config`,
+        `[${getRawBalances.name}] Skipping token on chain ${token.chainName} that is not in chains list`,
       );
       return acc;
     }

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -186,6 +186,7 @@ export function hyperlaneWarpRebalancer(
         --checkFrequency ${checkFrequency} \
         --config ${config} \
         --key ${ANVIL_KEY} \
+        --verbosity debug \
         ${monitorOnly ? ['--monitorOnly'] : ['']} \
         ${origin ? ['--origin', origin] : ['']} \
         ${destination ? ['--destination', destination] : ['']} \

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -513,7 +513,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     });
 
     await startRebalancerAndExpectLog(
-      `[getRawBalances] Skipping token on chain anvil4 that is not in config`,
+      `[getRawBalances] Skipping token on chain anvil4 that is not in chains list`,
     );
   });
 

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -491,6 +491,66 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     );
   });
 
+  it('should skip chains that are not in the config', async () => {
+    writeYamlOrJson(REBALANCER_CONFIG_PATH, {
+      rebalanceStrategy: StrategyOptions.Weighted,
+      [CHAIN_NAME_2]: {
+        weighted: {
+          weight: '75',
+          tolerance: '0',
+        },
+        bridge: ethers.constants.AddressZero,
+        bridgeLockTime: 1,
+      },
+      [CHAIN_NAME_3]: {
+        weighted: {
+          weight: '25',
+          tolerance: '0',
+        },
+        bridge: ethers.constants.AddressZero,
+        bridgeLockTime: 1,
+      },
+    });
+
+    await startRebalancerAndExpectLog(
+      `[getRawBalances] Skipping token on chain anvil4 that is not in config`,
+    );
+  });
+
+  it('should skip chains that are not supported collaterals', async () => {
+    writeYamlOrJson(REBALANCER_CONFIG_PATH, {
+      rebalanceStrategy: StrategyOptions.Weighted,
+      [CHAIN_NAME_2]: {
+        weighted: {
+          weight: '75',
+          tolerance: '0',
+        },
+        bridge: ethers.constants.AddressZero,
+        bridgeLockTime: 1,
+      },
+      [CHAIN_NAME_3]: {
+        weighted: {
+          weight: '25',
+          tolerance: '0',
+        },
+        bridge: ethers.constants.AddressZero,
+        bridgeLockTime: 1,
+      },
+      [CHAIN_NAME_4]: {
+        weighted: {
+          weight: '25',
+          tolerance: '0',
+        },
+        bridge: ethers.constants.AddressZero,
+        bridgeLockTime: 1,
+      },
+    });
+
+    await startRebalancerAndExpectLog(
+      `[getRawBalances] Skipping token on chain anvil4 that is not collateralized`,
+    );
+  });
+
   it('should throw if key does not belong to the assigned rebalancer', async () => {
     writeYamlOrJson(REBALANCER_CONFIG_PATH, {
       rebalanceStrategy: StrategyOptions.Weighted,


### PR DESCRIPTION
Closes https://github.com/BootNodeDev/hyperlane-monorepo/issues/72

This allows the user to rebalance partially between some of the collaterals of a warp route. For example, if there is no working bridge on a certain chain that supports rebalancing.