### PR TITLE
feat(infra): misc chain deploy fixes

### DIFF
--- a/typescript/infra/.gitignore
+++ b/typescript/infra/.gitignore
@@ -4,6 +4,7 @@ dist/
 .env*
 cache/
 deployment-plan.yaml
+deployment-plans/
 test/outputs
 config/environments/test/core/
 config/environments/test/igp/

--- a/typescript/infra/.prettierignore
+++ b/typescript/infra/.prettierignore
@@ -1,3 +1,4 @@
 **/helm
 test/outputs/**
 deployment-plan.yaml
+deployment-plans/**

--- a/typescript/infra/src/govern/HyperlaneAppGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneAppGovernor.ts
@@ -191,13 +191,22 @@ export abstract class HyperlaneAppGovernor<
             ),
           );
           try {
-            await multiSend.sendTransactions(
-              callsForSubmissionType.map((call) => ({
-                to: call.to,
-                data: call.data,
-                value: call.value,
-              })),
-            );
+            // Process calls in batches up to max size of 100
+            const maxBatchSize = 100;
+            for (
+              let i = 0;
+              i < callsForSubmissionType.length;
+              i += maxBatchSize
+            ) {
+              const batch = callsForSubmissionType.slice(i, i + maxBatchSize);
+              await multiSend.sendTransactions(
+                batch.map((call) => ({
+                  to: call.to,
+                  data: call.data,
+                  value: call.value,
+                })),
+              );
+            }
           } catch (error) {
             rootLogger.error(
               chalk.red(`Error submitting calls on ${chain}: ${error}`),
@@ -544,21 +553,13 @@ export abstract class HyperlaneAppGovernor<
     // Need to check all governance types because the safe address is different for each type
     for (const governanceType of Object.values(GovernanceType)) {
       const safeAddress = getGovernanceSafes(governanceType)[chain];
-      if (typeof safeAddress === 'string') {
-        // Check if the safe can propose transactions
-        const canProposeSafe = await this.checkSafeProposalEligibility(
-          chain,
-          signerAddress,
-          safeAddress,
-        );
-        if (
-          canProposeSafe &&
-          (await checkTransactionSuccess(chain, safeAddress))
-        ) {
-          call.governanceType = governanceType;
-          // If the transaction will succeed with the safe, return the inferred call
-          return { type: SubmissionType.SAFE, chain, call };
-        }
+      if (
+        typeof safeAddress === 'string' &&
+        (await checkTransactionSuccess(chain, safeAddress))
+      ) {
+        call.governanceType = governanceType;
+        // If the transaction will succeed with the safe, return the inferred call
+        return { type: SubmissionType.SAFE, chain, call };
       }
     }
 
@@ -591,68 +592,6 @@ export abstract class HyperlaneAppGovernor<
         ),
       );
     }
-  }
-
-  private async checkSafeProposalEligibility(
-    chain: ChainName,
-    signerAddress: Address,
-    safeAddress: string,
-    retries = 10,
-  ): Promise<boolean> {
-    if (!this.canPropose[chain].has(safeAddress)) {
-      try {
-        const canPropose = await canProposeSafeTransactions(
-          signerAddress,
-          chain,
-          this.checker.multiProvider,
-          safeAddress,
-        );
-        this.canPropose[chain].set(safeAddress, canPropose);
-      } catch (error) {
-        const errorMessage = (error as Error).message.toLowerCase();
-
-        // Handle invalid MultiSend contract errors
-        if (
-          errorMessage.includes('invalid multisend contract address') ||
-          errorMessage.includes('invalid multisendcallonly contract address')
-        ) {
-          rootLogger.warn(chalk.yellow(`Invalid contract: ${errorMessage}.`));
-          return false;
-        }
-
-        // Handle service unavailable and rate limit errors
-        if (
-          errorMessage.includes('service unavailable') ||
-          errorMessage.includes('too many requests')
-        ) {
-          rootLogger.warn(
-            chalk.yellow(
-              `Safe service error for ${safeAddress} on ${chain}: ${errorMessage}. ${retries} retries left.`,
-            ),
-          );
-
-          if (retries > 0) {
-            await new Promise((resolve) => setTimeout(resolve, 1000));
-            return this.checkSafeProposalEligibility(
-              chain,
-              signerAddress,
-              safeAddress,
-              retries - 1,
-            );
-          }
-          return false;
-        }
-
-        // Handle all other errors
-        rootLogger.error(
-          chalk.red(
-            `Failed to determine if signer can propose safe transactions on ${chain}. Error: ${error}`,
-          ),
-        );
-        return false;
-      }
-    }
-    return this.canPropose[chain].get(safeAddress) || false;
   }
 
   handleOwnerViolation(violation: OwnerViolation) {


### PR DESCRIPTION
### Description

feat(infra): misc chain deploy fixes
- print per-chain deployment plan
	- when doing the ism updates, we end up with files that are so big that we error out just trying to write the file. to simplify things, and also make per-chain changes easier to review, i've made the deployment plans per-chain instead of per-deployment.
- max batch size of 100 for safe multisend txs
	- tooling and API downstream starts breaking if there are too many things bundled together in a single multisend tx. in most cases we will be below 100, but recent changes like the TGE owner transfer and the incoming ICA migration will require 400-500 individual actions all going through the eth safe. 
- remove `checkSafeProposalEligibility`
	- this was originally a nice-to-have, but actually greatly contributes to the API rate limiting that we encounter with the safe APIs. functionally there is no real difference because `checkTransactionSuccess` is the real meat of the check and that is still there.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

all these changes have been tested and used in several rounds of chain deploys, but just not upstreamed