### PR TITLE
refactor(signer): use handleTx instead of ethers directly

### DIFF
--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -518,11 +518,8 @@ export const rebalancer: CommandModuleWithWriteContext<{
     amount,
   }) => {
     try {
-      const { registry, key: rebalancerKey } = context;
-
       // Load rebalancer config from disk
       const rebalancerConfig = Config.load(config, {
-        rebalancerKey,
         checkFrequency,
         withMetrics,
         monitorOnly,
@@ -531,8 +528,8 @@ export const rebalancer: CommandModuleWithWriteContext<{
 
       // Instantiate the factory used to create the different rebalancer components
       const contextFactory = await RebalancerContextFactory.create(
-        registry,
         rebalancerConfig,
+        context,
       );
 
       if (manual) {

--- a/typescript/cli/src/rebalancer/config/Config.test.ts
+++ b/typescript/cli/src/rebalancer/config/Config.test.ts
@@ -2,9 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'ethers';
 import { rmSync } from 'fs';
 
-import {
-  REBALANCER_CONFIG_PATH,
-} from '../../tests/commands/helpers.js';
+import { REBALANCER_CONFIG_PATH } from '../../tests/commands/helpers.js';
 import { ENV } from '../../utils/env.js';
 import { writeYamlOrJson } from '../../utils/files.js';
 import { StrategyOptions } from '../interfaces/IStrategy.js';
@@ -43,7 +41,6 @@ describe('Config', () => {
     writeYamlOrJson(REBALANCER_CONFIG_PATH, data);
 
     extraArgs = {
-      rebalancerKey: ANVIL_KEY,
       checkFrequency: 1000,
       monitorOnly: false,
       withMetrics: false,
@@ -142,7 +139,7 @@ describe('Config', () => {
         target: 0.3,
         type: MinAmountType.Relative,
       },
-    );
+    });
   });
 
   it('should load absolute params without modifications', () => {
@@ -170,7 +167,7 @@ describe('Config', () => {
         target: 140000,
         type: MinAmountType.Absolute,
       },
-    );
+    });
   });
 
   describe('override functionality', () => {

--- a/typescript/cli/src/rebalancer/config/Config.test.ts
+++ b/typescript/cli/src/rebalancer/config/Config.test.ts
@@ -3,7 +3,6 @@ import { ethers } from 'ethers';
 import { rmSync } from 'fs';
 
 import {
-  ANVIL_KEY,
   REBALANCER_CONFIG_PATH,
 } from '../../tests/commands/helpers.js';
 import { ENV } from '../../utils/env.js';
@@ -71,7 +70,6 @@ describe('Config', () => {
     expect(Config.load(REBALANCER_CONFIG_PATH, extraArgs)).to.deep.equal({
       warpRouteId: 'warpRouteId',
       checkFrequency: extraArgs.checkFrequency,
-      rebalancerKey: ANVIL_KEY,
       monitorOnly: extraArgs.monitorOnly,
       withMetrics: extraArgs.withMetrics,
       coingeckoApiKey: ENV.COINGECKO_API_KEY,
@@ -144,7 +142,7 @@ describe('Config', () => {
         target: 0.3,
         type: MinAmountType.Relative,
       },
-    });
+    );
   });
 
   it('should load absolute params without modifications', () => {
@@ -172,7 +170,7 @@ describe('Config', () => {
         target: 140000,
         type: MinAmountType.Absolute,
       },
-    });
+    );
   });
 
   describe('override functionality', () => {

--- a/typescript/cli/src/rebalancer/config/Config.ts
+++ b/typescript/cli/src/rebalancer/config/Config.ts
@@ -145,7 +145,6 @@ export type ConfigFileInput = BaseConfigInput &
 
 export class Config {
   constructor(
-    public readonly rebalancerKey: string,
     public readonly warpRouteId: string,
     public readonly checkFrequency: number,
     public readonly monitorOnly: boolean,
@@ -162,7 +161,6 @@ export class Config {
   static load(
     configFilePath: string,
     extraArgs: {
-      rebalancerKey: string;
       checkFrequency: number;
       monitorOnly: boolean;
       withMetrics: boolean;
@@ -182,7 +180,6 @@ export class Config {
     }
 
     return new Config(
-      extraArgs.rebalancerKey,
       warpRouteId,
       extraArgs.checkFrequency,
       extraArgs.monitorOnly,

--- a/typescript/cli/src/rebalancer/executor/Executor.ts
+++ b/typescript/cli/src/rebalancer/executor/Executor.ts
@@ -214,11 +214,6 @@ export class Executor implements IExecutor {
           } for ${originTokenAmount.getDecimalFormattedAmount()} ${originTokenAmount.token.name}`,
         );
         try {
-          log(
-            `About to send transaction for route from ${route.origin} to ${
-              route.destination
-            } for ${originTokenAmount.getDecimalFormattedAmount()} ${originTokenAmount.token.name}`,
-          );
           const receipt = await this.multiProvider.sendTransaction(
             route.origin,
             populatedTx,

--- a/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
+++ b/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
@@ -123,7 +123,7 @@ export class RebalancerContextFactory {
       this.warpCore,
       this.metadata,
       this.tokensByChainName,
-      this.context,
+      this.context.multiProvider,
     );
 
     return new WithSemaphore(this.config, executor);


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

This PR changes the Executor to use `handleTx` instead of ethers' `wait` directly.
Also,
 - removed `rebalancerKey` from Config and related components
 - removed `registry` and extracted it from context

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->
Fixes https://github.com/BootNodeDev/hyperlane-monorepo/issues/65

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
Unit/e2e