### PR TITLE
fix: Improve domain logging

### DIFF
--- a/rust/main/agents/relayer/src/msg/op_submitter.rs
+++ b/rust/main/agents/relayer/src/msg/op_submitter.rs
@@ -190,7 +190,7 @@ impl SerialSubmitter {
         if let Err(err) = try_join_all(tasks).await {
             error!(
                 error=?err,
-                domain=?self.domain,
+                domain=?self.domain.name(),
                 "SerialSubmitter task panicked for domain"
             );
         }

--- a/rust/main/chains/hyperlane-cosmos/src/providers/grpc.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/grpc.rs
@@ -667,7 +667,7 @@ impl WasmProvider for WasmGrpcProvider {
                 Box::pin(future)
             })
             .await?;
-        debug!(tx_result=?tx_res, domain=?self.domain, ?payload, "Wasm transaction sent");
+        debug!(tx_result=?tx_res, domain=?self.domain.name(), ?payload, "Wasm transaction sent");
         Ok(tx_res)
     }
 

--- a/rust/main/chains/hyperlane-cosmos/src/providers/rpc/provider.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/rpc/provider.rs
@@ -261,7 +261,7 @@ impl WasmRpcProvider for CosmosWasmRpcProvider {
         Ok(latest_height.saturating_sub(self.reorg_period))
     }
 
-    #[instrument(err, skip(self, parser))]
+    #[instrument(err, fields(domain = self.domain.name()), skip(self, parser))]
     #[allow(clippy::blocks_in_conditions)] // TODO: `rustc` 1.80.1 clippy issue
     async fn get_logs_in_block<T>(
         &self,
@@ -275,7 +275,7 @@ impl WasmRpcProvider for CosmosWasmRpcProvider {
         // The two calls below could be made in parallel, but on cosmos rate limiting is a bigger problem
         // than indexing latency, so we do them sequentially.
         let block = self.get_block(block_number).await?;
-        debug!(?block_number, block_hash = ?block.block_id.hash, cursor_label, domain=?self.domain, "Getting logs in block with hash");
+        debug!(?block_number, block_hash = ?block.block_id.hash, cursor_label, domain=?self.domain.name(), "Getting logs in block with hash");
         let block_results = self
             .rpc_client
             .call(|provider| {
@@ -305,7 +305,7 @@ impl WasmRpcProvider for CosmosWasmRpcProvider {
         let block = self.get_block(block_number).await?;
         let block_hash = H256::from_slice(block.block_id.hash.as_bytes());
 
-        debug!(?block_number, block_hash = ?block.block_id.hash, cursor_label, domain=?self.domain, "Getting logs in transaction: block info");
+        debug!(?block_number, block_hash = ?block.block_id.hash, cursor_label, domain=?self.domain.name(), "Getting logs in transaction: block info");
 
         Ok(self.handle_tx(tx, block_hash, parser).collect())
     }

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
@@ -350,7 +350,7 @@ where
                 ChainCommunicationError::Other(HyperlaneCustomErrorWrapper::new(Box::new(e)))
             })?
         else {
-            tracing::trace!(domain=?self.domain, "Latest block not found");
+            tracing::trace!(domain=?self.domain.name(), "Latest block not found");
             return Ok(None);
         };
 


### PR DESCRIPTION
### Description

If we log domains in debug mode as a whole, we get not only name but the full struct. For example, "HyperlaneDomain(injective (6909546))". We switch to use domain name for logging in this change.

### Backward compatibility

Yes

### Testing

None