### PR TITLE
fix: Configure proper index chunk for moonbeam to fix issues with their RPC

### DIFF
--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -2051,6 +2051,7 @@
       "gasCurrencyCoinGeckoId": "moonbeam",
       "gnosisSafeTransactionServiceUrl": "https://transaction.multisig.moonbeam.network",
       "index": {
+        "chunk": 1024,
         "from": 4719713
       },
       "interchainAccountIsm": "0x79b3730CE3685f65802aF1771319992bA960EB9D",


### PR DESCRIPTION
### Description

Moonbeam RPC endpoints report that they cannot service so wide block range. Maximum block range is 1024. So, we fix our default configuration to support it.

### Backward compatibility

Yes

### Testing

Manual