### PR TITLE
chore(cli): only prompt for API key for etherscan explorer type

### DIFF
--- a/.changeset/shy-ideas-win.md
+++ b/.changeset/shy-ideas-win.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Only prompt for API key for etherscan explorer type.

--- a/typescript/cli/src/context/context.ts
+++ b/typescript/cli/src/context/context.ts
@@ -7,6 +7,7 @@ import {
   ChainMap,
   ChainMetadata,
   ChainName,
+  ExplorerFamily,
   MultiProtocolProvider,
   MultiProvider,
 } from '@hyperlane-xyz/sdk';
@@ -231,8 +232,12 @@ export async function requestAndSaveApiKeys(
   const apiKeys: ChainMap<string> = {};
 
   for (const chain of chains) {
-    if (chainMetadata[chain]?.blockExplorers?.[0]?.apiKey) {
-      apiKeys[chain] = chainMetadata[chain]!.blockExplorers![0]!.apiKey!;
+    const blockExplorer = chainMetadata[chain]?.blockExplorers?.[0];
+    if (blockExplorer?.family !== ExplorerFamily.Etherscan) {
+      continue;
+    }
+    if (blockExplorer?.apiKey) {
+      apiKeys[chain] = blockExplorer.apiKey;
       continue;
     }
     const wantApiKey = await confirm({


### PR DESCRIPTION
### Description

chore(cli): only prompt for API key for etherscan explorer type

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

before:
![image](https://github.com/user-attachments/assets/32e1e53c-6bc7-4f85-907d-8a1959b11063)

after:
![image](https://github.com/user-attachments/assets/90a4c20b-ab68-4824-844d-fc5730bc78b5)
