### PR TITLE
chore(infra): misc fixes for safe operations

### DIFF
--- a/typescript/infra/src/xerc20/utils.ts
+++ b/typescript/infra/src/xerc20/utils.ts
@@ -17,7 +17,7 @@ import {
   WarpRouteDeployConfig,
   isXERC20TokenConfig,
 } from '@hyperlane-xyz/sdk';
-import { Address, CallData, rootLogger } from '@hyperlane-xyz/utils';
+import { Address, CallData, eqAddress, rootLogger } from '@hyperlane-xyz/utils';
 
 import { getRegistry } from '../../config/registry.js';
 import {
@@ -26,6 +26,7 @@ import {
   SafeMultiSend,
   SignerMultiSend,
 } from '../govern/multisend.js';
+import { Owner, determineGovernanceType } from '../governance.js';
 import { getSafeAndService } from '../utils/safe.js';
 import { getInfraPath } from '../utils/utils.js';
 
@@ -334,28 +335,17 @@ async function prepareRateLimitTx(
 
 async function checkOwnerIsSafe(
   chain: string,
-  multiProvider: MultiProvider,
   owner: Address,
   bridgeAddress: Address,
 ): Promise<boolean> {
-  try {
-    await getSafeAndService(chain, multiProvider, owner);
+  const { ownerType } = await determineGovernanceType(chain, owner);
+  if (ownerType === Owner.SAFE) {
     rootLogger.debug(
       chalk.gray(`[${chain}][${bridgeAddress}] Safe found: ${owner}`),
     );
     return true;
-  } catch (error) {
-    const level =
-      error instanceof Error &&
-      error.message.includes('must provide tx service url')
-        ? 'warn'
-        : 'info';
-    const color = level === 'warn' ? chalk.yellow : chalk.gray;
-    rootLogger[level](
-      color(`[${chain}][${bridgeAddress}] Safe not found: ${owner}. ${error}`),
-    );
-    return false;
   }
+  return false;
 }
 
 async function checkSafeProposer(
@@ -467,12 +457,7 @@ async function sendTransactions(
   // (a) the actual owner is a safe
   // (b) the signer (deployer) has the ability to propose transactions on the safe
   // otherwise fallback to a signer transaction, this fallback will allow for us to handle scenario 1 even though the expected owner is a safe
-  const isOwnerSafe = await checkOwnerIsSafe(
-    chain,
-    multiProvider,
-    actualOwner,
-    bridgeAddress,
-  );
+  const isOwnerSafe = await checkOwnerIsSafe(chain, actualOwner, bridgeAddress);
 
   let sender: MultiSend | undefined;
   let safeAddress: Address | undefined;
@@ -500,7 +485,7 @@ async function sendTransactions(
     }
   }
 
-  if (signerAddress !== actualOwner) {
+  if (!eqAddress(signerAddress, actualOwner)) {
     rootLogger.warn(
       chalk.red(
         `[${chain}][${bridgeAddress}] Signer is not the owner of the xERC20 so cannot successful submit a Signer transaction.`,


### PR DESCRIPTION
### Description

chore(infra): misc fixes for safe operations
- used when doing https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/6358
- correctly add xerc20 lockboxes to the tx parser's xerc20 deployments cache
- use entirely offline utilities for determining if an address is a safe (quicker, cleaner code, not prone to hitting rate limits)

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

- adding bridges to new prod ousdt xerc20s
- parsing eth safe tx
```
yarn tsx scripts/safes/parse-txs.ts -e mainnet3 --governanceType abacusWorks -c ethereum
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
Fetching pending transactions for safe 0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6 on ethereum
┌─────────┬────────────┬───────┬───────────────────┬──────────────────────────────────────────────────────────────────────┬───────┬───────────┬────────┬───────────────┐
│ (index) │ chain      │ nonce │ submissionDate    │ fullTxHash                                                           │ confs │ threshold │ status │ balance       │
├─────────┼────────────┼───────┼───────────────────┼──────────────────────────────────────────────────────────────────────┼───────┼───────────┼────────┼───────────────┤
│ 0       │ 'ethereum' │ 55    │ 'Fri May 30 2025' │ '0xe06c7fbd4ebc952984637825182f2e73dde1f5a5ded2b71a69de8219aa481090' │ 1     │ 4         │ '🔵'   │ '0.20000 ETH' │
└─────────┴────────────┴───────┴───────────────────┴──────────────────────────────────────────────────────────────────────┴───────┴───────────┴────────┴───────────────┘
Reading tx 0xe06c7fbd4ebc952984637825182f2e73dde1f5a5ded2b71a69de8219aa481090 on ethereum
Finished reading tx 0xe06c7fbd4ebc952984637825182f2e73dde1f5a5ded2b71a69de8219aa481090 on ethereum
✅✅✅✅✅ No fatal errors ✅✅✅✅✅
Results written to safe-tx-results-1748613693179.yaml
```
```
ethereum-55-0xe06c7fbd4ebc952984637825182f2e73dde1f5a5ded2b71a69de8219aa481090:
  chain: ethereum
  insight: Add new bridge 0xCe19f75BCE7Fb74c9e2328766Ebe50465df24CA3 with buffer
    cap 20000000000000 and rate limit 5000000000
  signature: addBridge((uint112,uint128,address))
  to: oUSDT (OpenUSDT, EvmHypVSXERC20, 0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189)
```