### PR TITLE
feat(sdk): switch starknet hooks config

### DIFF
--- a/starknet/scripts/fetch-contracts-release.sh
+++ b/starknet/scripts/fetch-contracts-release.sh
@@ -8,7 +8,7 @@ IFS=$'\n\t'
 readonly REPO="hyperlane-xyz/hyperlane-starknet"
 readonly GITHUB_RELEASES_API="https://api.github.com/repos/${REPO}/releases"
 readonly TARGET_DIR="./release"
-readonly VERSION="v0.3.8"
+readonly VERSION="v0.3.9"
 
 # Color definitions
 declare -r COLOR_GREEN='\033[0;32m'

--- a/typescript/sdk/src/core/StarknetCoreModule.ts
+++ b/typescript/sdk/src/core/StarknetCoreModule.ts
@@ -100,13 +100,7 @@ export class StarknetCoreModule {
       [],
     );
 
-    // 2. Default Hook - A basic hook implementation for message processing
-    const requiredHook = await this.deployer.deployContract(
-      StarknetContractName.HOOK,
-      [],
-    );
-
-    // 3. Protocol Fee Hook - Handles fee collection for cross-chain messages
+    // 2. Protocol Fee as Default Hook - Handles fee collection for cross-chain messages
     const protocolFee = await this.deployer.deployContract(
       StarknetContractName.PROTOCOL_FEE,
       [
@@ -117,6 +111,12 @@ export class StarknetCoreModule {
         PROTOCOL_TO_DEFAULT_NATIVE_TOKEN[ProtocolType.Starknet]!
           .denom as MultiType,
       ],
+    );
+
+    // 3. Required Hook - A basic hook implementation for message processing
+    const requiredHook = await this.deployer.deployContract(
+      StarknetContractName.HOOK,
+      [],
     );
 
     // 4. Deploy Mailbox with initial configuration

--- a/typescript/sdk/src/token/nativeTokenMetadata.ts
+++ b/typescript/sdk/src/token/nativeTokenMetadata.ts
@@ -30,8 +30,8 @@ export const PROTOCOL_TO_DEFAULT_NATIVE_TOKEN: Record<
   },
   [ProtocolType.Starknet]: {
     decimals: 18,
-    denom: '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7',
-    name: 'Ether',
-    symbol: 'ETH',
+    denom: '0x04718f5a0Fc34cC1AF16A1cdee98fFB20C31f5cD61D6Ab07201858f4287c938D',
+    name: 'Starknet Token',
+    symbol: 'STRK',
   },
 };


### PR DESCRIPTION
### Description

- switched protocol fee to be default and merkle to be required for legal reasons. (we should avoid charging non-zero protocol fee payment as advised by the lawyers)
- changed native token from ETH to STRK bc ETH will not be supported after June

### Drive-by changes

- v0.3.8 -> v0.3.9 of starknet contracts (now on main :) )

### Related issues

None

### Backward compatibility

Yes

### Testing

Live deployment
