### PR TITLE
feat: add timeout to AwsSigner

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -3706,7 +3706,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-21#f0440ebedff16b68ef2d7d6faab9e18e1f364e0f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-30#02d03c5f62cc5b34d44e34b0e2bc80c2bca83d6c"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -3720,7 +3720,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-21#f0440ebedff16b68ef2d7d6faab9e18e1f364e0f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-30#02d03c5f62cc5b34d44e34b0e2bc80c2bca83d6c"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-21#f0440ebedff16b68ef2d7d6faab9e18e1f364e0f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-30#02d03c5f62cc5b34d44e34b0e2bc80c2bca83d6c"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -3749,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-21#f0440ebedff16b68ef2d7d6faab9e18e1f364e0f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-30#02d03c5f62cc5b34d44e34b0e2bc80c2bca83d6c"
 dependencies = [
  "Inflector",
  "cfg-if",
@@ -3773,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-21#f0440ebedff16b68ef2d7d6faab9e18e1f364e0f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-30#02d03c5f62cc5b34d44e34b0e2bc80c2bca83d6c"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -3787,7 +3787,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-21#f0440ebedff16b68ef2d7d6faab9e18e1f364e0f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-30#02d03c5f62cc5b34d44e34b0e2bc80c2bca83d6c"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -3817,7 +3817,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-21#f0440ebedff16b68ef2d7d6faab9e18e1f364e0f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-30#02d03c5f62cc5b34d44e34b0e2bc80c2bca83d6c"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.15",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-21#f0440ebedff16b68ef2d7d6faab9e18e1f364e0f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-30#02d03c5f62cc5b34d44e34b0e2bc80c2bca83d6c"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-21#f0440ebedff16b68ef2d7d6faab9e18e1f364e0f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-30#02d03c5f62cc5b34d44e34b0e2bc80c2bca83d6c"
 dependencies = [
  "async-trait",
  "auto_impl 1.2.0",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-21#f0440ebedff16b68ef2d7d6faab9e18e1f364e0f"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2025-05-30#02d03c5f62cc5b34d44e34b0e2bc80c2bca83d6c"
 dependencies = [
  "async-trait",
  "coins-bip32 0.7.0",
@@ -3935,6 +3935,7 @@ dependencies = [
  "sha2 0.10.8",
  "spki 0.6.0",
  "thiserror 1.0.63",
+ "tokio",
  "tracing",
 ]
 

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -226,27 +226,27 @@ overflow-checks = true
 [workspace.dependencies.ethers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2025-05-21"
+tag = "2025-05-30"
 
 [workspace.dependencies.ethers-contract]
 features = ["legacy"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2025-05-21"
+tag = "2025-05-30"
 
 [workspace.dependencies.ethers-core]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2025-05-21"
+tag = "2025-05-30"
 
 [workspace.dependencies.ethers-providers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2025-05-21"
+tag = "2025-05-30"
 
 [workspace.dependencies.ethers-signers]
 features = ["aws"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2025-05-21"
+tag = "2025-05-30"
 
 [patch.crates-io.curve25519-dalek]
 branch = "v3.2.2-relax-zeroize"

--- a/rust/main/hyperlane-base/src/settings/signers.rs
+++ b/rust/main/hyperlane-base/src/settings/signers.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
 use ethers::prelude::{AwsSigner, LocalWallet};
 use ethers::utils::hex::ToHex;
@@ -10,6 +12,8 @@ use hyperlane_core::{AccountAddressType, H256};
 
 use super::aws_credentials::AwsChainCredentialsProvider;
 use crate::types::utils;
+
+const AWS_SIGNER_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Signer types
 #[derive(Default, Debug, Clone)]
@@ -92,7 +96,7 @@ impl BuildableWithSignerConf for hyperlane_ethereum::Signers {
                     region.clone(),
                 );
 
-                let signer = AwsSigner::new(client, id, 0).await?;
+                let signer = AwsSigner::new(client, id, 0, Some(AWS_SIGNER_TIMEOUT)).await?;
                 hyperlane_ethereum::Signers::Aws(signer)
             }
             SignerConf::CosmosKey { .. } => {


### PR DESCRIPTION
### Description

- Updates ethers-rs to https://github.com/hyperlane-xyz/ethers-rs/releases/tag/2025-05-30, which includes setting a timeout on the AwsSigner
- 30s was chosen because we've seemingly only experienced this once, so it's very infrequent, and high enough to not hit false positives on a timeout

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
