### PR TITLE
fix(infra): filter out testnets for check-warp-deploy

### DIFF
--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -56,18 +56,18 @@ async function main() {
 
   const warpConfigChains = new Set<ChainName>();
   const warpIdsToCheck = await Promise.all(
-    Object.keys(warpCoreConfigMap).map(async (warpRouteId) => {
+    Object.keys(warpCoreConfigMap).filter(async (warpRouteId) => {
       const warpRouteConfig = warpCoreConfigMap[warpRouteId];
       const isTestnet = await isTestnetRoute(warpRouteConfig);
       if (!routesToSkip.includes(warpRouteId) && !isTestnet) {
         Object.keys(warpRouteConfig).forEach((chain) =>
           warpConfigChains.add(chain),
         );
-        return warpRouteId;
+        return true;
       }
-      return null;
+      return false;
     }),
-  ).then((results) => results.filter((id) => id !== null));
+  );
 
   console.log(
     `Found warp configs for chains: ${Array.from(warpConfigChains).join(', ')}`,

--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -1,9 +1,8 @@
 import chalk from 'chalk';
 import { Gauge, Registry } from 'prom-client';
 
-import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
+import { getRegistry } from '@hyperlane-xyz/registry/fs';
 import { ChainName } from '@hyperlane-xyz/sdk';
-import { assert } from '@hyperlane-xyz/utils';
 
 import { WarpRouteIds } from '../../config/environments/mainnet3/warp/warpIds.js';
 import { DEFAULT_REGISTRY_URI } from '../../config/registry.js';
@@ -36,23 +35,39 @@ async function main() {
   ];
 
   const registries = [DEFAULT_REGISTRY_URI];
+  const registry = getRegistry({
+    registryUris: registries,
+    enableProxy: true,
+  });
+
   const warpCoreConfigMap =
     await getWarpConfigMapFromMergedRegistry(registries);
 
   console.log(chalk.yellow('Skipping the following warp routes:'));
   routesToSkip.forEach((route) => console.log(chalk.yellow(`- ${route}`)));
 
-  const warpIdsToCheck = Object.keys(warpCoreConfigMap).filter(
-    (warpRouteId) => !routesToSkip.includes(warpRouteId),
-  );
+  const isTestnetRoute = async (warpRouteConfig: any) => {
+    for (const chain of Object.keys(warpRouteConfig)) {
+      const chainMetadata = await registry.getChainMetadata(chain);
+      if (chainMetadata?.isTestnet) return true;
+    }
+    return false;
+  };
 
-  // Get all the chains from warpCoreConfigMap. Used to initialize the MultiProvider.
-  const warpConfigChains = warpIdsToCheck.reduce((chains, warpRouteId) => {
-    const warpConfigs = warpCoreConfigMap[warpRouteId];
-    assert(warpConfigs, `Config not found in registry for ${warpRouteId}`);
-    Object.keys(warpConfigs).forEach((chain) => chains.add(chain));
-    return chains;
-  }, new Set<ChainName>());
+  const warpConfigChains = new Set<ChainName>();
+  const warpIdsToCheck = await Promise.all(
+    Object.keys(warpCoreConfigMap).map(async (warpRouteId) => {
+      const warpRouteConfig = warpCoreConfigMap[warpRouteId];
+      const isTestnet = await isTestnetRoute(warpRouteConfig);
+      if (!routesToSkip.includes(warpRouteId) && !isTestnet) {
+        Object.keys(warpRouteConfig).forEach((chain) =>
+          warpConfigChains.add(chain),
+        );
+        return warpRouteId;
+      }
+      return null;
+    }),
+  ).then((results) => results.filter((id) => id !== null));
 
   console.log(
     `Found warp configs for chains: ${Array.from(warpConfigChains).join(', ')}`,
@@ -62,6 +77,7 @@ async function main() {
   // We specify the chains to avoid creating a multiprovider for all chains.
   // This ensures that we don't fail to fetch secrets for new chains in the cron job.
   const envConfig = getEnvironmentConfig(environment);
+
   // Use default values for context, role, and useSecrets
   const multiProvider = await envConfig.getMultiProvider(
     undefined,


### PR DESCRIPTION
### Description

fix(infra): filter out testnets for check-warp-deploy

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
