### PR TITLE
feat: Collect operational metrics for rebalancer

### DIFF
--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -584,11 +584,11 @@ export const rebalancer: CommandModuleWithWriteContext<{
       // Instantiates the monitor that will observe the warp route
       monitor = contextFactory.createMonitor();
 
-      // Instantiates the strategy that will compute how rebalance routes should be performed
-      strategy = await contextFactory.createStrategy();
-
       // Instantiates the metrics that will publish stats from the monitored data
       metrics = withMetrics ? await contextFactory.createMetrics() : undefined;
+
+      // Instantiates the strategy that will compute how rebalance routes should be performed
+      strategy = await contextFactory.createStrategy(metrics);
 
       // Instantiates the rebalancer in charge of executing the rebalancing transactions
       rebalancer = !rebalancerConfig.monitorOnly

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -478,7 +478,7 @@ export const rebalancer: CommandModuleWithWriteContext<{
       type: 'boolean',
       description: 'Enable metrics (default: true)',
       demandOption: false,
-      default: true,
+      default: false,
     },
     monitorOnly: {
       type: 'boolean',

--- a/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
+++ b/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
@@ -44,7 +44,9 @@ export class RebalancerContextFactory {
     config: RebalancerConfig,
     context: WriteCommandContext,
   ): Promise<RebalancerContextFactory> {
-    logDebug('Creating RebalancerContextFactory');
+    logDebug('Creating RebalancerContextFactory', {
+      warpRouteId: config.warpRouteId,
+    });
     const { registry } = context;
     const metadata = await registry.getMetadata();
     const addresses = await registry.getAddresses();
@@ -64,7 +66,9 @@ export class RebalancerContextFactory {
       warpCore.tokens.map((t) => [t.chainName, t]),
     );
 
-    logDebug('RebalancerContextFactory created successfully');
+    logDebug('RebalancerContextFactory created successfully', {
+      warpRouteId: config.warpRouteId,
+    });
     return new RebalancerContextFactory(
       config,
       metadata,
@@ -79,7 +83,7 @@ export class RebalancerContextFactory {
   }
 
   public async createMetrics(coingeckoApiKey?: string): Promise<Metrics> {
-    logDebug('Creating Metrics');
+    logDebug('Creating Metrics', { warpRouteId: this.config.warpRouteId });
     const tokenPriceGetter = PriceGetter.create(this.metadata, coingeckoApiKey);
     const collateralTokenSymbol = Metrics.getWarpRouteCollateralTokenSymbol(
       this.warpCore,
@@ -97,12 +101,18 @@ export class RebalancerContextFactory {
   }
 
   public createMonitor(): Monitor {
-    logDebug('Creating Monitor');
+    logDebug('Creating Monitor', {
+      warpRouteId: this.config.warpRouteId,
+      checkFrequency: this.config.checkFrequency,
+    });
     return new Monitor(this.config.checkFrequency, this.warpCore);
   }
 
   public async createStrategy(): Promise<IStrategy> {
-    logDebug('Creating Strategy');
+    logDebug('Creating Strategy', {
+      warpRouteId: this.config.warpRouteId,
+      strategyType: this.config.rebalanceStrategy,
+    });
     return StrategyFactory.createStrategy(
       this.config.rebalanceStrategy,
       this.config.chains,
@@ -112,7 +122,7 @@ export class RebalancerContextFactory {
   }
 
   public createRebalancer(): IRebalancer {
-    logDebug('Creating Rebalancer');
+    logDebug('Creating Rebalancer', { warpRouteId: this.config.warpRouteId });
     const rebalancer = new Rebalancer(
       objMap(this.config.chains, (_, v) => ({
         bridge: v.bridge,

--- a/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
+++ b/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
@@ -8,7 +8,6 @@ import {
 import { objMap, objMerge } from '@hyperlane-xyz/utils';
 
 import type { WriteCommandContext } from '../../context/types.js';
-import { logDebug } from '../../logger.js';
 import { RebalancerConfig } from '../config/RebalancerConfig.js';
 import type { IRebalancer } from '../interfaces/IRebalancer.js';
 import type { IStrategy } from '../interfaces/IStrategy.js';
@@ -19,6 +18,7 @@ import { Rebalancer } from '../rebalancer/Rebalancer.js';
 import { WithSemaphore } from '../rebalancer/WithSemaphore.js';
 import { StrategyFactory } from '../strategy/StrategyFactory.js';
 import { isCollateralizedTokenEligibleForRebalancing } from '../utils/isCollateralizedTokenEligibleForRebalancing.js';
+import { rebalancerLogger } from '../utils/logger.js';
 
 export class RebalancerContextFactory {
   /**
@@ -44,9 +44,12 @@ export class RebalancerContextFactory {
     config: RebalancerConfig,
     context: WriteCommandContext,
   ): Promise<RebalancerContextFactory> {
-    logDebug('Creating RebalancerContextFactory', {
-      warpRouteId: config.warpRouteId,
-    });
+    rebalancerLogger.debug(
+      {
+        warpRouteId: config.warpRouteId,
+      },
+      'Creating RebalancerContextFactory',
+    );
     const { registry } = context;
     const metadata = await registry.getMetadata();
     const addresses = await registry.getAddresses();
@@ -66,9 +69,12 @@ export class RebalancerContextFactory {
       warpCore.tokens.map((t) => [t.chainName, t]),
     );
 
-    logDebug('RebalancerContextFactory created successfully', {
-      warpRouteId: config.warpRouteId,
-    });
+    rebalancerLogger.debug(
+      {
+        warpRouteId: config.warpRouteId,
+      },
+      'RebalancerContextFactory created successfully',
+    );
     return new RebalancerContextFactory(
       config,
       metadata,
@@ -83,7 +89,10 @@ export class RebalancerContextFactory {
   }
 
   public async createMetrics(coingeckoApiKey?: string): Promise<Metrics> {
-    logDebug('Creating Metrics', { warpRouteId: this.config.warpRouteId });
+    rebalancerLogger.debug(
+      { warpRouteId: this.config.warpRouteId },
+      'Creating Metrics',
+    );
     const tokenPriceGetter = PriceGetter.create(this.metadata, coingeckoApiKey);
     const collateralTokenSymbol = Metrics.getWarpRouteCollateralTokenSymbol(
       this.warpCore,
@@ -102,18 +111,24 @@ export class RebalancerContextFactory {
   }
 
   public createMonitor(): Monitor {
-    logDebug('Creating Monitor', {
-      warpRouteId: this.config.warpRouteId,
-      checkFrequency: this.config.checkFrequency,
-    });
+    rebalancerLogger.debug(
+      {
+        warpRouteId: this.config.warpRouteId,
+        checkFrequency: this.config.checkFrequency,
+      },
+      'Creating Monitor',
+    );
     return new Monitor(this.config.checkFrequency, this.warpCore);
   }
 
   public async createStrategy(): Promise<IStrategy> {
-    logDebug('Creating Strategy', {
-      warpRouteId: this.config.warpRouteId,
-      strategyType: this.config.rebalanceStrategy,
-    });
+    rebalancerLogger.debug(
+      {
+        warpRouteId: this.config.warpRouteId,
+        strategyType: this.config.rebalanceStrategy,
+      },
+      'Creating Strategy',
+    );
     return StrategyFactory.createStrategy(
       this.config.rebalanceStrategy,
       this.config.chains,
@@ -123,7 +138,10 @@ export class RebalancerContextFactory {
   }
 
   public createRebalancer(): IRebalancer {
-    logDebug('Creating Rebalancer', { warpRouteId: this.config.warpRouteId });
+    rebalancerLogger.debug(
+      { warpRouteId: this.config.warpRouteId },
+      'Creating Rebalancer',
+    );
     const rebalancer = new Rebalancer(
       objMap(this.config.chains, (_, v) => ({
         bridge: v.bridge,

--- a/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
+++ b/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
@@ -137,7 +137,7 @@ export class RebalancerContextFactory {
     );
   }
 
-  public createRebalancer(): IRebalancer {
+  public createRebalancer(metrics?: Metrics): IRebalancer {
     rebalancerLogger.debug(
       { warpRouteId: this.config.warpRouteId },
       'Creating Rebalancer',
@@ -153,6 +153,7 @@ export class RebalancerContextFactory {
       this.metadata,
       this.tokensByChainName,
       this.context.multiProvider,
+      metrics,
     );
 
     return new WithSemaphore(this.config, rebalancer);

--- a/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
+++ b/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
@@ -121,7 +121,7 @@ export class RebalancerContextFactory {
     return new Monitor(this.config.checkFrequency, this.warpCore);
   }
 
-  public async createStrategy(): Promise<IStrategy> {
+  public async createStrategy(metrics?: Metrics): Promise<IStrategy> {
     rebalancerLogger.debug(
       {
         warpRouteId: this.config.warpRouteId,
@@ -134,6 +134,7 @@ export class RebalancerContextFactory {
       this.config.chains,
       this.tokensByChainName,
       await this.getInitialTotalCollateral(),
+      metrics,
     );
   }
 

--- a/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
+++ b/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
@@ -97,6 +97,7 @@ export class RebalancerContextFactory {
       collateralTokenSymbol,
       warpDeployConfig,
       this.warpCore,
+      this.config.warpRouteId,
     );
   }
 

--- a/typescript/cli/src/rebalancer/metrics/Metrics.ts
+++ b/typescript/cli/src/rebalancer/metrics/Metrics.ts
@@ -119,9 +119,10 @@ export class Metrics implements IMetrics {
       );
 
       if (!this.warpDeployConfig) {
-        warnYellow(
-          `Can't read warp deploy config for token ${token.symbol} on chain ${token.chainName} skipping extra lockboxes`,
-        );
+        warnYellow("Can't read warp deploy config, skipping extra lockboxes", {
+          tokenSymbol: token.symbol,
+          chain: token.chainName,
+        });
         return;
       }
 
@@ -132,7 +133,12 @@ export class Metrics implements IMetrics {
         currentTokenDeployConfig.type !== TokenType.XERC20 &&
         currentTokenDeployConfig.type !== TokenType.XERC20Lockbox
       ) {
-        errorRed('Token is xERC20 but token deploy config is not');
+        errorRed('Token type mismatch in deploy config for xERC20 token', {
+          tokenSymbol: token.symbol,
+          chain: token.chainName,
+          expectedType: [TokenType.XERC20, TokenType.XERC20Lockbox],
+          actualType: currentTokenDeployConfig.type,
+        });
         return;
       }
 
@@ -192,7 +198,11 @@ export class Metrics implements IMetrics {
     bridgedSupply?: bigint,
   ): Promise<WarpRouteBalance | undefined> {
     if (!token.isHypToken()) {
-      warnYellow('Cannot get bridged balance for a non-Hyperlane token', token);
+      warnYellow('Cannot get bridged balance for a non-Hyperlane token', {
+        tokenChain: token.chainName,
+        tokenSymbol: token.symbol,
+        tokenAddress: token.addressOrDenom,
+      });
       return undefined;
     }
 
@@ -200,7 +210,11 @@ export class Metrics implements IMetrics {
     let tokenAddress = token.collateralAddressOrDenom ?? token.addressOrDenom;
 
     if (bridgedSupply === undefined) {
-      warnYellow('Bridged supply not found for token', token);
+      warnYellow('Bridged supply not found for token', {
+        tokenChain: token.chainName,
+        tokenSymbol: token.symbol,
+        tokenAddress: token.addressOrDenom,
+      });
       return undefined;
     }
 

--- a/typescript/cli/src/rebalancer/metrics/PriceGetter.ts
+++ b/typescript/cli/src/rebalancer/metrics/PriceGetter.ts
@@ -45,7 +45,11 @@ export class PriceGetter extends CoinGeckoTokenPriceGetter {
     const coinGeckoId = token.coinGeckoId;
 
     if (!coinGeckoId) {
-      warnYellow('CoinGecko ID missing for token', token.symbol);
+      warnYellow('CoinGecko ID missing for token', {
+        tokenSymbol: token.symbol,
+        chain: token.chainName,
+        tokenAddress: token.addressOrDenom,
+      });
       return undefined;
     }
 

--- a/typescript/cli/src/rebalancer/metrics/PriceGetter.ts
+++ b/typescript/cli/src/rebalancer/metrics/PriceGetter.ts
@@ -5,7 +5,7 @@ import {
   Token,
 } from '@hyperlane-xyz/sdk';
 
-import { warnYellow } from '../../logger.js';
+import { monitorLogger } from '../utils/logger.js';
 
 export class PriceGetter extends CoinGeckoTokenPriceGetter {
   private constructor({
@@ -45,11 +45,14 @@ export class PriceGetter extends CoinGeckoTokenPriceGetter {
     const coinGeckoId = token.coinGeckoId;
 
     if (!coinGeckoId) {
-      warnYellow('CoinGecko ID missing for token', {
-        tokenSymbol: token.symbol,
-        chain: token.chainName,
-        tokenAddress: token.addressOrDenom,
-      });
+      monitorLogger.warn(
+        {
+          tokenSymbol: token.symbol,
+          chain: token.chainName,
+          tokenAddress: token.addressOrDenom,
+        },
+        'CoinGecko ID missing for token',
+      );
       return undefined;
     }
 

--- a/typescript/cli/src/rebalancer/metrics/scripts/metrics.ts
+++ b/typescript/cli/src/rebalancer/metrics/scripts/metrics.ts
@@ -1,4 +1,4 @@
-import { Gauge, Registry } from 'prom-client';
+import { Counter, Gauge, Registry } from 'prom-client';
 
 import { createWarpRouteConfigId } from '@hyperlane-xyz/registry';
 import { ChainName, Token, TokenStandard, WarpCore } from '@hyperlane-xyz/sdk';
@@ -76,6 +76,41 @@ const warpRouteValueAtRisk = new Gauge({
   help: 'Value at risk on chain for a given Warp Route',
   registers: [metricsRegister],
   labelNames: warpRouteValueAtRiskLabels,
+});
+
+export const rebalancerExecutionTotal = new Counter({
+  name: 'hyperlane_rebalancer_execution_total',
+  help: 'Total number of rebalance execution attempts.',
+  registers: [metricsRegister],
+  labelNames: ['warp_route_id'],
+});
+
+export const rebalancerExecutionErrorsTotal = new Counter({
+  name: 'hyperlane_rebalancer_execution_errors_total',
+  help: 'Total number of errors during rebalance execution attempts.',
+  registers: [metricsRegister],
+  labelNames: ['warp_route_id'],
+});
+
+export const rebalancerPollingErrorsTotal = new Counter({
+  name: 'hyperlane_rebalancer_polling_errors_total',
+  help: 'Total number of errors during the monitor polling phase.',
+  registers: [metricsRegister],
+  labelNames: ['warp_route_id'],
+});
+
+export const rebalancerLastExecutionStatus = new Gauge({
+  name: 'hyperlane_rebalancer_last_execution_status',
+  help: 'Status of the last rebalance execution attempt (0 for success, 1 for failure).',
+  registers: [metricsRegister],
+  labelNames: ['warp_route_id'],
+});
+
+export const rebalancerConsecutiveExecutionFailures = new Gauge({
+  name: 'hyperlane_rebalancer_consecutive_execution_failures',
+  help: 'Number of consecutive failed rebalance execution attempts.',
+  registers: [metricsRegister],
+  labelNames: ['warp_route_id'],
 });
 
 const walletBalanceGauge = getWalletBalanceGauge(metricsRegister);

--- a/typescript/cli/src/rebalancer/metrics/scripts/metrics.ts
+++ b/typescript/cli/src/rebalancer/metrics/scripts/metrics.ts
@@ -4,7 +4,7 @@ import { createWarpRouteConfigId } from '@hyperlane-xyz/registry';
 import { ChainName, Token, TokenStandard, WarpCore } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 
-import { logger } from '../../utils/logger.js';
+import { monitorLogger } from '../../utils/logger.js';
 import {
   NativeWalletBalance,
   WarpRouteBalance,
@@ -163,7 +163,7 @@ export function updateTokenBalanceMetrics(
   };
 
   warpRouteTokenBalance.labels(metrics).set(balanceInfo.balance);
-  logger.info(
+  monitorLogger.info(
     {
       labels: metrics,
       balance: balanceInfo.balance,
@@ -174,7 +174,7 @@ export function updateTokenBalanceMetrics(
   if (balanceInfo.valueUSD) {
     // TODO: consider deprecating this metric in favor of the value at risk metric
     warpRouteCollateralValue.labels(metrics).set(balanceInfo.valueUSD);
-    logger.info(
+    monitorLogger.info(
       {
         labels: metrics,
         valueUSD: balanceInfo.valueUSD,
@@ -193,7 +193,7 @@ export function updateTokenBalanceMetrics(
       };
 
       warpRouteValueAtRisk.labels(labels).set(balanceInfo.valueUSD);
-      logger.info(
+      monitorLogger.info(
         {
           labels,
           valueUSD: balanceInfo.valueUSD,
@@ -232,7 +232,7 @@ export function updateManagedLockboxBalanceMetrics(
   };
 
   warpRouteTokenBalance.labels(metrics).set(balanceInfo.balance);
-  logger.info(
+  monitorLogger.info(
     {
       labels: metrics,
       balance: balanceInfo.balance,
@@ -242,7 +242,7 @@ export function updateManagedLockboxBalanceMetrics(
 
   if (balanceInfo.valueUSD) {
     warpRouteCollateralValue.labels(metrics).set(balanceInfo.valueUSD);
-    logger.info(
+    monitorLogger.info(
       {
         labels: metrics,
         valueUSD: balanceInfo.valueUSD,
@@ -262,9 +262,12 @@ export function updateNativeWalletBalanceMetrics(balance: NativeWalletBalance) {
       token_name: 'Native',
     })
     .set(balance.balance);
-  logger.info('Native wallet balance updated', {
-    balanceInfo: balance,
-  });
+  monitorLogger.info(
+    {
+      balanceInfo: balance,
+    },
+    'Native wallet balance updated',
+  );
 }
 
 export function updateXERC20LimitsMetrics(
@@ -291,7 +294,7 @@ export function updateXERC20LimitsMetrics(
       .set(limit);
   }
 
-  logger.info(
+  monitorLogger.info(
     {
       ...labels,
       limits,

--- a/typescript/cli/src/rebalancer/monitor/Monitor.ts
+++ b/typescript/cli/src/rebalancer/monitor/Monitor.ts
@@ -51,7 +51,7 @@ export class Monitor implements IMonitor {
 
     try {
       this.isMonitorRunning = true;
-      logDebug(`Monitor started, polling every ${this.checkFrequency} ms...`);
+      logDebug('Monitor started', { checkFrequency: this.checkFrequency });
       this.emitter.emit(MonitorEventType.Start);
 
       while (this.isMonitorRunning) {
@@ -62,7 +62,11 @@ export class Monitor implements IMonitor {
           };
 
           for (const token of this.warpCore.tokens) {
-            logDebug(`Checking token: ${token.chainName}`);
+            logDebug('Checking token', {
+              chain: token.chainName,
+              tokenSymbol: token.symbol,
+              tokenAddress: token.addressOrDenom,
+            });
             const bridgedSupply = await this.getTokenBridgedSupply(token);
 
             event.tokensInfo.push({
@@ -102,9 +106,11 @@ export class Monitor implements IMonitor {
     token: Token,
   ): Promise<bigint | undefined> {
     if (!token.isHypToken()) {
-      warnYellow(
-        `Cannot get bridged balance for a non-Hyperlane token: ${token.chainName}`,
-      );
+      warnYellow('Cannot get bridged balance for a non-Hyperlane token', {
+        chain: token.chainName,
+        tokenSymbol: token.symbol,
+        tokenAddress: token.addressOrDenom,
+      });
       return;
     }
 
@@ -112,7 +118,11 @@ export class Monitor implements IMonitor {
     const bridgedSupply = await adapter.getBridgedSupply();
 
     if (bridgedSupply === undefined) {
-      warnYellow(`Bridged supply not found for token: ${token.chainName}`);
+      warnYellow('Bridged supply not found for token', {
+        chain: token.chainName,
+        tokenSymbol: token.symbol,
+        tokenAddress: token.addressOrDenom,
+      });
     }
 
     return bridgedSupply;

--- a/typescript/cli/src/rebalancer/rebalancer/Rebalancer.ts
+++ b/typescript/cli/src/rebalancer/rebalancer/Rebalancer.ts
@@ -13,6 +13,7 @@ import { toWei } from '@hyperlane-xyz/utils';
 import { WrappedError } from '../../utils/errors.js';
 import type { IRebalancer } from '../interfaces/IRebalancer.js';
 import type { RebalancingRoute } from '../interfaces/IStrategy.js';
+import { Metrics } from '../metrics/Metrics.js';
 import { type BridgeConfig, getBridgeConfig } from '../utils/bridgeConfig.js';
 import { rebalancerLogger } from '../utils/logger.js';
 
@@ -23,6 +24,7 @@ export class Rebalancer implements IRebalancer {
     private readonly chainMetadata: ChainMap<ChainMetadata>,
     private readonly tokensByChainName: ChainMap<Token>,
     private readonly multiProvider: MultiProvider,
+    private readonly metrics: Metrics | undefined,
   ) {}
 
   async rebalance(routes: RebalancingRoute[]) {
@@ -35,6 +37,8 @@ export class Rebalancer implements IRebalancer {
       rebalancerLogger.info('No routes to execute');
       return;
     }
+
+    this.metrics?.recordRebalancerAttempt();
 
     const { warpCore, chainMetadata, tokensByChainName } = this;
 
@@ -172,7 +176,7 @@ export class Rebalancer implements IRebalancer {
           tokenName: originToken.name,
           bridge,
         },
-        'Getting rebalance quotes',
+        'Populating rebalance transaction',
       );
 
       const populatedTx = await originHypAdapter.populateRebalanceTx(

--- a/typescript/cli/src/rebalancer/strategy/BaseStrategy.ts
+++ b/typescript/cli/src/rebalancer/strategy/BaseStrategy.ts
@@ -27,15 +27,26 @@ export abstract class BaseStrategy implements IStrategy {
    * Main method to get rebalancing routes
    */
   getRebalancingRoutes(rawBalances: RawBalances): RebalancingRoute[] {
-    logDebug(`[${this.constructor.name}] Input rawBalances:`, rawBalances);
-    logGray(`Calculating rebalancing routes using ${this.constructor.name}...`);
+    logDebug('Input rawBalances', {
+      context: this.constructor.name,
+      rawBalances,
+    });
+    logGray('Calculating rebalancing routes', {
+      context: this.constructor.name,
+    });
     this.validateRawBalances(rawBalances);
 
     // Get balances categorized by surplus and deficit
     const { surpluses, deficits } = this.getCategorizedBalances(rawBalances);
 
-    logDebug(`[${this.constructor.name}] Surpluses:`, surpluses);
-    logDebug(`[${this.constructor.name}] Deficits:`, deficits);
+    logDebug('Surpluses calculated', {
+      context: this.constructor.name,
+      surpluses,
+    });
+    logDebug('Deficits calculated', {
+      context: this.constructor.name,
+      deficits,
+    });
 
     // Calculate sums of surpluses and deficits
     const totalSurplus = surpluses.reduce(
@@ -47,15 +58,23 @@ export abstract class BaseStrategy implements IStrategy {
       0n,
     );
 
-    logDebug(`[${this.constructor.name}] Total surplus: ${totalSurplus}`);
-    logDebug(`[${this.constructor.name}] Total deficit: ${totalDeficit}`);
+    logDebug('Total surplus calculated', {
+      context: this.constructor.name,
+      totalSurplus: totalSurplus.toString(),
+    });
+    logDebug('Total deficit calculated', {
+      context: this.constructor.name,
+      totalDeficit: totalDeficit.toString(),
+    });
 
     // If total surplus is less than total deficit, scale down deficits proportionally
     // TODO: consider how to handle sum of targets > sum of collateral balances i.e throw or raise an alert
     if (totalSurplus < totalDeficit) {
-      warnYellow(
-        `[${this.constructor.name}] Deficits are greater than surpluses. Scaling deficits...`,
-      );
+      warnYellow('Deficits are greater than surpluses. Scaling deficits', {
+        context: this.constructor.name,
+        totalSurplus: totalSurplus.toString(),
+        totalDeficit: totalDeficit.toString(),
+      });
 
       for (const deficit of deficits) {
         const newAmount = (deficit.amount * totalSurplus) / totalDeficit;
@@ -63,7 +82,10 @@ export abstract class BaseStrategy implements IStrategy {
         deficit.amount = newAmount;
       }
 
-      logDebug(`[${this.constructor.name}] Scaled deficits:`, deficits);
+      logDebug('Scaled deficits', {
+        context: this.constructor.name,
+        deficits,
+      });
     }
 
     // Sort from largest to smallest amounts as to always transfer largest amounts
@@ -104,10 +126,14 @@ export abstract class BaseStrategy implements IStrategy {
       }
     }
 
-    logDebug(`[${this.constructor.name}] Generated routes:`, routes);
-    logGray(
-      `Found ${routes.length} rebalancing route(s) using ${this.constructor.name}.`,
-    );
+    logDebug('Generated routes', {
+      context: this.constructor.name,
+      routes,
+    });
+    logGray(`Found rebalancing routes`, {
+      context: this.constructor.name,
+      numberOfRoutes: routes.length,
+    });
     return routes;
   }
 

--- a/typescript/cli/src/rebalancer/strategy/MinAmountStrategy.ts
+++ b/typescript/cli/src/rebalancer/strategy/MinAmountStrategy.ts
@@ -9,6 +9,7 @@ import {
 import { fromWei, toWei } from '@hyperlane-xyz/utils';
 
 import type { RawBalances } from '../interfaces/IStrategy.js';
+import { Metrics } from '../metrics/Metrics.js';
 
 import { BaseStrategy, type Delta } from './BaseStrategy.js';
 
@@ -27,9 +28,10 @@ export class MinAmountStrategy extends BaseStrategy {
     config: MinAmountStrategyConfig,
     private readonly tokensByChainName: ChainMap<Token>,
     initialTotalCollateral: bigint,
+    metrics?: Metrics,
   ) {
     const chains = Object.keys(config);
-    super(chains);
+    super(chains, metrics);
 
     const minAmountType = config[chains[0]].minAmount.type;
     this.validateAmounts(initialTotalCollateral, minAmountType, config);

--- a/typescript/cli/src/rebalancer/strategy/StrategyFactory.ts
+++ b/typescript/cli/src/rebalancer/strategy/StrategyFactory.ts
@@ -6,6 +6,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 
 import { type IStrategy } from '../interfaces/IStrategy.js';
+import { Metrics } from '../metrics/Metrics.js';
 
 import {
   MinAmountStrategy,
@@ -28,14 +29,16 @@ export class StrategyFactory {
     config: ChainMap<RebalancerChainConfig>,
     tokensByChainName: ChainMap<Token>,
     initialTotalCollateral: bigint,
+    metrics?: Metrics,
   ): IStrategy {
     if (rebalanceStrategy === RebalancerStrategyOptions.Weighted) {
-      return new WeightedStrategy(config as WeightedStrategyConfig);
+      return new WeightedStrategy(config as WeightedStrategyConfig, metrics);
     } else if (rebalanceStrategy === RebalancerStrategyOptions.MinAmount) {
       return new MinAmountStrategy(
         config as MinAmountStrategyConfig,
         tokensByChainName,
         initialTotalCollateral,
+        metrics,
       );
     } else {
       throw new Error(`Unsupported strategy type: ${rebalanceStrategy}`);

--- a/typescript/cli/src/rebalancer/strategy/WeightedStrategy.ts
+++ b/typescript/cli/src/rebalancer/strategy/WeightedStrategy.ts
@@ -1,6 +1,7 @@
 import type { ChainMap, RebalancerChainConfig } from '@hyperlane-xyz/sdk';
 
 import type { RawBalances } from '../interfaces/IStrategy.js';
+import { Metrics } from '../metrics/Metrics.js';
 
 import { BaseStrategy, type Delta } from './BaseStrategy.js';
 
@@ -16,9 +17,9 @@ export class WeightedStrategy extends BaseStrategy {
   private readonly config: WeightedStrategyConfig;
   private readonly totalWeight: bigint;
 
-  constructor(config: WeightedStrategyConfig) {
+  constructor(config: WeightedStrategyConfig, metrics?: Metrics) {
     const chains = Object.keys(config);
-    super(chains);
+    super(chains, metrics);
 
     let totalWeight = 0n;
 

--- a/typescript/cli/src/rebalancer/utils/getRawBalances.ts
+++ b/typescript/cli/src/rebalancer/utils/getRawBalances.ts
@@ -1,8 +1,8 @@
 import { ChainName } from '@hyperlane-xyz/sdk';
 
-import { logDebug } from '../../logger.js';
 import { MonitorEvent } from '../interfaces/IMonitor.js';
 import { RawBalances } from '../interfaces/IStrategy.js';
+import { rebalancerLogger } from '../utils/logger.js';
 
 import { isCollateralizedTokenEligibleForRebalancing } from './isCollateralizedTokenEligibleForRebalancing.js';
 
@@ -22,25 +22,28 @@ export function getRawBalances(
 
     // Ignore tokens that are not in the provided chains list
     if (!chainSet.has(token.chainName)) {
-      logDebug('Skipping token: not in configured chains list', {
-        context: getRawBalances.name,
-        chain: token.chainName,
-        tokenSymbol: token.symbol,
-        tokenAddress: token.addressOrDenom,
-      });
-      return acc;
-    }
-
-    // Ignore tokens that are not collateralized
-    if (!isCollateralizedTokenEligibleForRebalancing(token)) {
-      logDebug(
-        'Skipping token: not collateralized or ineligible for rebalancing',
+      rebalancerLogger.debug(
         {
           context: getRawBalances.name,
           chain: token.chainName,
           tokenSymbol: token.symbol,
           tokenAddress: token.addressOrDenom,
         },
+        'Skipping token: not in configured chains list',
+      );
+      return acc;
+    }
+
+    // Ignore tokens that are not collateralized
+    if (!isCollateralizedTokenEligibleForRebalancing(token)) {
+      rebalancerLogger.debug(
+        {
+          context: getRawBalances.name,
+          chain: token.chainName,
+          tokenSymbol: token.symbol,
+          tokenAddress: token.addressOrDenom,
+        },
+        'Skipping token: not collateralized or ineligible for rebalancing',
       );
       return acc;
     }

--- a/typescript/cli/src/rebalancer/utils/getRawBalances.ts
+++ b/typescript/cli/src/rebalancer/utils/getRawBalances.ts
@@ -22,16 +22,25 @@ export function getRawBalances(
 
     // Ignore tokens that are not in the provided chains list
     if (!chainSet.has(token.chainName)) {
-      logDebug(
-        `[${getRawBalances.name}] Skipping token on chain ${token.chainName} that is not in chains list`,
-      );
+      logDebug('Skipping token: not in configured chains list', {
+        context: getRawBalances.name,
+        chain: token.chainName,
+        tokenSymbol: token.symbol,
+        tokenAddress: token.addressOrDenom,
+      });
       return acc;
     }
 
     // Ignore tokens that are not collateralized
     if (!isCollateralizedTokenEligibleForRebalancing(token)) {
       logDebug(
-        `[${getRawBalances.name}] Skipping token on chain ${token.chainName} that is not collateralized`,
+        'Skipping token: not collateralized or ineligible for rebalancing',
+        {
+          context: getRawBalances.name,
+          chain: token.chainName,
+          tokenSymbol: token.symbol,
+          tokenAddress: token.addressOrDenom,
+        },
       );
       return acc;
     }

--- a/typescript/cli/src/rebalancer/utils/logger.ts
+++ b/typescript/cli/src/rebalancer/utils/logger.ts
@@ -1,4 +1,4 @@
 import { rootLogger } from '@hyperlane-xyz/utils';
 
 // TODO: this is to keep the same logging structure as in the monitor, but we may need change the module name
-export const logger = rootLogger.child({ module: 'warp-balance-monitor' });
+export const logger = rootLogger.child({ module: 'warp-rebalancer-monitor' });

--- a/typescript/cli/src/rebalancer/utils/logger.ts
+++ b/typescript/cli/src/rebalancer/utils/logger.ts
@@ -1,4 +1,3 @@
 import { rootLogger } from '@hyperlane-xyz/utils';
 
-// TODO: this is to keep the same logging structure as in the monitor, but we may need change the module name
 export const logger = rootLogger.child({ module: 'warp-rebalancer-monitor' });

--- a/typescript/cli/src/rebalancer/utils/logger.ts
+++ b/typescript/cli/src/rebalancer/utils/logger.ts
@@ -1,3 +1,9 @@
 import { rootLogger } from '@hyperlane-xyz/utils';
 
-export const logger = rootLogger.child({ module: 'warp-rebalancer-monitor' });
+export const monitorLogger = rootLogger.child({ module: 'rebalancer-monitor' });
+export const rebalancerLogger = rootLogger.child({
+  module: 'rebalancer',
+});
+export const strategyLogger = rootLogger.child({
+  module: 'rebalancer-strategy',
+});

--- a/typescript/cli/src/rebalancer/utils/tryFn.ts
+++ b/typescript/cli/src/rebalancer/utils/tryFn.ts
@@ -4,6 +4,6 @@ export async function tryFn(fn: () => Promise<void>, context: string) {
   try {
     await fn();
   } catch (error) {
-    logger.error(`Error in ${context}`, error);
+    logger.error({ context, err: error as Error }, `Error in ${context}`);
   }
 }

--- a/typescript/cli/src/rebalancer/utils/tryFn.ts
+++ b/typescript/cli/src/rebalancer/utils/tryFn.ts
@@ -1,9 +1,12 @@
-import { logger } from './logger.js';
+import { monitorLogger } from './logger.js';
 
 export async function tryFn(fn: () => Promise<void>, context: string) {
   try {
     await fn();
   } catch (error) {
-    logger.error({ context, err: error as Error }, `Error in ${context}`);
+    monitorLogger.error(
+      { context, err: error as Error },
+      `Error in ${context}`,
+    );
   }
 }

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -179,7 +179,7 @@ export function hyperlaneWarpRebalancer(
   destination?: string,
   amount?: string,
 ): ProcessPromise {
-  return $`yarn workspace @hyperlane-xyz/cli run hyperlane warp rebalancer \
+  return $`LOG_LEVEL=debug yarn workspace @hyperlane-xyz/cli run hyperlane warp rebalancer \
         --registry ${REGISTRY_PATH} \
         --checkFrequency ${checkFrequency} \
         --config ${config} \

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -1621,8 +1621,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
             `Manual rebalance strategy selected. Origin: ${CHAIN_NAME_2}, Destination: ${CHAIN_NAME_3}, Amount: ${manualRebalanceAmount}`,
             'Rebalance initiated with 1 route(s)',
             `Populating rebalance transaction: domain=${chain3Metadata.domainId}, amount=${manualRebalanceAmount} token, bridge=${otherWarpCoreConfig.tokens[0].addressOrDenom}`,
-            `Route result - Origin: ${CHAIN_NAME_2}, Destination: ${CHAIN_NAME_3}, Amount: ${manualRebalanceAmount} token`,
-            '✅ Rebalance successful',
+            `✅ Manual rebalance from ${CHAIN_NAME_2} to ${CHAIN_NAME_3} for amount ${manualRebalanceAmount} submitted successfully.`,
           ],
           {
             timeout: 30000,

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -382,7 +382,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     });
 
     await startRebalancerAndExpectLog(
-      `Rebalancer error: Error: Validation error: All chains must use the same minAmount type. at "minAmount.type"`,
+      `Rebalancer startup error: Error: Validation error: All chains must use the same minAmount type. at "minAmount.type`,
     );
   });
 
@@ -520,7 +520,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     });
 
     await startRebalancerAndExpectLog(
-      `[getRawBalances] Skipping token on chain anvil4 that is not in chains list`,
+      `Skipping token: not in configured chains list`,
     );
   });
 
@@ -555,7 +555,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     });
 
     await startRebalancerAndExpectLog(
-      `[getRawBalances] Skipping token on chain anvil4 that is not collateralized`,
+      `Skipping token: not collateralized or ineligible for rebalancing`,
     );
   });
 
@@ -676,11 +676,11 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     );
 
     await startRebalancerAndExpectLog(
-      `Bridge ${ethers.constants.AddressZero} for domain ${chain2Metadata.domainId} (${
+      `Error while rebalancing: Error: Bridge ${ethers.constants.AddressZero} for domain ${chain2Metadata.domainId} (${
         chain2Metadata.name
-      }) is not allowed. From ${warpCoreConfig.tokens[0].addressOrDenom} at ${
+      }) is not allowed. From ${warpCoreConfig.tokens[1].addressOrDenom} at ${
         chain3Metadata.name
-      }. To ${warpCoreConfig.tokens[1].addressOrDenom} at ${chain2Metadata.name}.`,
+      }. To ${warpCoreConfig.tokens[0].addressOrDenom} at ${chain2Metadata.name}.`,
     );
   });
 
@@ -795,7 +795,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     });
 
     await startRebalancerAndExpectLog(
-      `Rebalancer error: Error: Consider reducing the targets as the sum (23) is greater than sum of collaterals (20)`,
+      `Rebalancer startup error: Error: Consider reducing the targets as the sum (23) is greater than sum of collaterals (20)`,
     );
   });
 
@@ -1313,10 +1313,10 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
       await startRebalancerAndExpectLog(
         [
           'Rebalancer started successfully 🚀',
-          'Found 1 rebalancing route(s) using WeightedStrategy',
-          `Populating rebalance transaction: domain=${chain3Metadata.domainId}, amount=5 token, bridge=${otherWarpCoreConfig.tokens[0].addressOrDenom}`,
+          `{ context: 'WeightedStrategy', numberOfRoutes: 1 } Found rebalancing routes`,
+          `} Populating rebalance transaction`,
           '✅ Rebalance successful',
-          'Found 0 rebalancing route(s) using WeightedStrategy.',
+          `{ context: 'WeightedStrategy', numberOfRoutes: 0 } Found rebalancing routes`,
           'No routes to execute',
         ],
         { timeout: 30000, checkFrequency: 1000 },
@@ -1608,8 +1608,8 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
       try {
         await startRebalancerAndExpectLog(
           [
-            'Calculating rebalancing routes using WeightedStrategy...',
-            'Found 1 rebalancing route(s) using WeightedStrategy.',
+            `{ context: 'WeightedStrategy' } Calculating rebalancing routes`,
+            `{ context: 'WeightedStrategy', numberOfRoutes: 1 } Found rebalancing routes`,
           ],
           { monitorOnly: true },
         );
@@ -1619,8 +1619,8 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         await startRebalancerAndExpectLog(
           [
             `Manual rebalance strategy selected. Origin: ${CHAIN_NAME_2}, Destination: ${CHAIN_NAME_3}, Amount: ${manualRebalanceAmount}`,
-            'Rebalance initiated with 1 route(s)',
-            `Populating rebalance transaction: domain=${chain3Metadata.domainId}, amount=${manualRebalanceAmount} token, bridge=${otherWarpCoreConfig.tokens[0].addressOrDenom}`,
+            '{ numberOfRoutes: 1 } Rebalance initiated',
+            `} Populating rebalance transaction`,
             `✅ Manual rebalance from ${CHAIN_NAME_2} to ${CHAIN_NAME_3} for amount ${manualRebalanceAmount} submitted successfully.`,
           ],
           {
@@ -1634,8 +1634,8 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
 
         await startRebalancerAndExpectLog(
           [
-            'Calculating rebalancing routes using WeightedStrategy...',
-            'Found 0 rebalancing route(s) using WeightedStrategy.',
+            `{ context: 'WeightedStrategy' } Calculating rebalancing routes`,
+            `{ context: 'WeightedStrategy', numberOfRoutes: 0 } Found rebalancing routes`,
           ],
           { timeout: 90000, monitorOnly: true },
         );

--- a/typescript/infra/helm/rebalancer/templates/_helpers.tpl
+++ b/typescript/infra/helm/rebalancer/templates/_helpers.tpl
@@ -87,6 +87,8 @@ The rebalancer container
   - "rebalancer"
   - "--checkFrequency"
   - "60000"
+  - "--withMetrics"
+  - "true"
   - "--configFile"
   - "{{ .Values.hyperlane.rebalancerConfigFile }}"
   - "--registry"

--- a/typescript/infra/helm/rebalancer/templates/_helpers.tpl
+++ b/typescript/infra/helm/rebalancer/templates/_helpers.tpl
@@ -70,8 +70,8 @@ The rebalancer container
   image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
   imagePullPolicy: IfNotPresent
   env:
-  - name: LOG_LEVEL
-    value: pretty
+  - name: LOG_FORMAT
+    value: json
   - name: REGISTRY_COMMIT
     value: {{ .Values.hyperlane.registryCommit }}
   - name: HYP_KEY

--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -61,7 +61,7 @@ export class RebalancerHelmManager extends HelmManager {
     return {
       image: {
         repository: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-        tag: '4d92547-20250530-134110',
+        tag: 'a546be2-20250602-142949',
       },
       withMetrics: this.withMetrics,
       fullnameOverride: this.helmReleaseName,


### PR DESCRIPTION
### Description

- Expose metrics for ongoing rebalancing
- Use structured logging
- Split start up and on going execution into separate try catch blocks, throw on startup errors and do not throw on execution errors. 

### Drive-by changes

- Set `withMetrics` to default false

### Backward compatibility

Yes

### Testing

- Unit Tests
- e2e tests
