### PR TITLE
feat: allow to override `initialize` function in `HypERC721` and `HypNative`

### DIFF
--- a/solidity/contracts/token/HypERC721.sol
+++ b/solidity/contracts/token/HypERC721.sol
@@ -30,7 +30,7 @@ contract HypERC721 is ERC721EnumerableUpgradeable, TokenRouter {
         address _hook,
         address _interchainSecurityModule,
         address _owner
-    ) external initializer {
+    ) external virtual initializer {
         _MailboxClient_initialize(_hook, _interchainSecurityModule, _owner);
         __ERC721_init(_name, _symbol);
         for (uint256 i = 0; i < _mintAmount; i++) {

--- a/solidity/contracts/token/HypNative.sol
+++ b/solidity/contracts/token/HypNative.sol
@@ -34,7 +34,7 @@ contract HypNative is FungibleTokenRouter {
         address _hook,
         address _interchainSecurityModule,
         address _owner
-    ) public initializer {
+    ) public virtual initializer {
         _MailboxClient_initialize(_hook, _interchainSecurityModule, _owner);
     }
 


### PR DESCRIPTION
### Description

I noticed that some differences in the behaviour of the `initialize(...)` functions of the Hyp token contracts. For some contracts, the function can be overriden while for others it is not possible.

- ✅ defined as `virtual` on [HypERC20](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/fbb1441ea428585215b6356404cbb47f30b0ef56/solidity/contracts/token/HypERC20.sol#L38)
- ✅ defined as `virtual` on [HypERC20Collateral](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/a857df7771644c3a9678cb12a492dbcb075e222e/solidity/contracts/token/HypERC20Collateral.sol#L53)
- 🚫 not defined as `virtual` on [HypERC721](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/fbb1441ea428585215b6356404cbb47f30b0ef56/solidity/contracts/token/HypERC721.sol#L33)
- ✅ defined as `virtual` on [HypERC721Collateral](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/a857df7771644c3a9678cb12a492dbcb075e222e/solidity/contracts/token/HypERC721Collateral.sol#L34)
- 🚫 not defined as `virtual` on [HypNative](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/fbb1441ea428585215b6356404cbb47f30b0ef56/solidity/contracts/token/HypNative.sol#L37)

For consistency, I would suggest marking all of these as `virtual`

