### PR TITLE
fix: Skip SMOL warp route since it fails the check

### DIFF
--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -32,6 +32,7 @@ async function main() {
 
   const routesToSkip: string[] = [
     WarpRouteIds.ArbitrumBaseBlastBscEthereumGnosisLiskMantleModeOptimismPolygonScrollZeroNetworkZoraMainnet,
+    WarpRouteIds.ArbitrumEthereumSolanaTreasureSMOL,
   ];
 
   const registries = [DEFAULT_REGISTRY_URI];


### PR DESCRIPTION
### Description

Skip SMOL warp route since it fails the check

### Backward compatibility

Yes

### Testing

Manual