### PR TITLE
fix: Reduce chunk size to avoid RPC errors

### DIFF
--- a/rust/main/config/testnet_config.json
+++ b/rust/main/config/testnet_config.json
@@ -1278,7 +1278,7 @@
       "timelockController": "0x0000000000000000000000000000000000000000",
       "validatorAnnounce": "0x086E902d2f99BcCEAa28B31747eC6Dc5fd43B1bE",
       "index": {
-        "chunk": 50,
+        "chunk": 41,
         "from": 7032169
       }
     },


### PR DESCRIPTION
### Description

Reduce chunk size to avoid RPC errors

### Backward compatibility

Yes

### Testing

Manual