### PR TITLE
feat(sdk): add single tx set route to `StarknetDeployer.deployIsm`

### DIFF
--- a/typescript/sdk/src/core/StarknetCoreModule.ts
+++ b/typescript/sdk/src/core/StarknetCoreModule.ts
@@ -3,7 +3,6 @@ import { Account, MultiType, cairo } from 'starknet';
 import {
   ChainId,
   Domain,
-  ProtocolType,
   assert,
   eqAddress,
   rootLogger,
@@ -20,7 +19,7 @@ import {
   AnnotatedStarknetTransaction,
   StarknetJsTransaction,
 } from '../providers/ProviderType.js';
-import { PROTOCOL_TO_DEFAULT_NATIVE_TOKEN } from '../token/nativeTokenMetadata.js';
+import { starknetNativeTokenMetadataOverrides } from '../token/nativeTokenMetadata.js';
 import { ChainName, ChainNameOrId } from '../types.js';
 import {
   StarknetContractName,
@@ -108,7 +107,7 @@ export class StarknetCoreModule {
         cairo.uint256(config.defaultHook.protocolFee),
         config.defaultHook.beneficiary,
         config.owner,
-        PROTOCOL_TO_DEFAULT_NATIVE_TOKEN[ProtocolType.Starknet]!
+        starknetNativeTokenMetadataOverrides(this.chainName)!
           .denom as MultiType,
       ],
     );

--- a/typescript/sdk/src/token/nativeTokenMetadata.ts
+++ b/typescript/sdk/src/token/nativeTokenMetadata.ts
@@ -1,6 +1,7 @@
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
 import { NativeToken } from '../metadata/chainMetadataTypes.js';
+import { ChainName } from '../types.js';
 
 export const PROTOCOL_TO_DEFAULT_NATIVE_TOKEN: Record<
   ProtocolType,
@@ -34,4 +35,22 @@ export const PROTOCOL_TO_DEFAULT_NATIVE_TOKEN: Record<
     name: 'Starknet Token',
     symbol: 'STRK',
   },
+};
+
+const starknetChainSpecificOverrides: Record<ChainName, NativeToken> = {
+  paradex: {
+    decimals: 6,
+    denom: '0x07348407ebad690fec0cc8597e87dc16ef7b269a655ff72587dafff83d462be2',
+    name: 'USDC',
+    symbol: 'USDC',
+  },
+};
+
+export const starknetNativeTokenMetadataOverrides = (
+  chainName: ChainName,
+): NativeToken => {
+  if (starknetChainSpecificOverrides[chainName]) {
+    return starknetChainSpecificOverrides[chainName];
+  }
+  return PROTOCOL_TO_DEFAULT_NATIVE_TOKEN[ProtocolType.Starknet];
 };

--- a/typescript/sdk/src/token/nativeTokenMetadata.ts
+++ b/typescript/sdk/src/token/nativeTokenMetadata.ts
@@ -49,8 +49,5 @@ const starknetChainSpecificOverrides: Record<ChainName, NativeToken> = {
 export const starknetNativeTokenMetadataOverrides = (
   chainName: ChainName,
 ): NativeToken => {
-  if (starknetChainSpecificOverrides[chainName]) {
-    return starknetChainSpecificOverrides[chainName];
-  }
-  return PROTOCOL_TO_DEFAULT_NATIVE_TOKEN[ProtocolType.Starknet];
+  return starknetChainSpecificOverrides[chainName] ?? PROTOCOL_TO_DEFAULT_NATIVE_TOKEN[ProtocolType.Starknet];
 };


### PR DESCRIPTION
### Description

- now setting the routes in the domain_routing_ism in one transaction
- add a mapping as a overrides for different starknet chains as paradex and starknet doesn't support the same token as protocol fee

### Drive-by changes

none

### Related issues

none

### Backward compatibility

yes

### Testing

manual
