### PR TITLE
feat: simplify warp configs

### DIFF
--- a/typescript/infra/scripts/warp-routes/simplify-warp-configs.ts
+++ b/typescript/infra/scripts/warp-routes/simplify-warp-configs.ts
@@ -10,7 +10,19 @@ async function main() {
     console.log(`Generating Warp config for ${warpRouteId}`, warpConfig);
 
     for (const chain of Object.keys(warpConfig)) {
-      const { ownerOverrides, owner, proxyAdmin } = warpConfig[chain];
+      const { ownerOverrides, owner, proxyAdmin, interchainSecurityModule } =
+        warpConfig[chain];
+      if (
+        interchainSecurityModule ===
+        '0x0000000000000000000000000000000000000000'
+      ) {
+        delete warpConfig[chain].interchainSecurityModule;
+        console.log(
+          `Removed 'interchainSecurityModule' for ${warpRouteId} on ${chain}:`,
+          warpConfig[chain],
+        );
+      }
+
       if (proxyAdmin && proxyAdmin.owner === owner) {
         delete warpConfig[chain].proxyAdmin;
         console.log(
@@ -32,7 +44,7 @@ async function main() {
       }
     }
 
-    registry.updateWarpRouteConfig(warpConfig, { warpRouteId });
+    registry.addWarpRouteConfig(warpConfig, { warpRouteId });
   }
   console.log('Successfully simplified warp configs');
 }


### PR DESCRIPTION
### Description

This PR adds a `simplify-warp-configs` script that removes
- `0x0000000000000000000000000000000000000000` as ISM
- `proxyAdmin` owner if it equals `owner`
- `ownerOverrides` owner if it equals `owner`

The plan is to add it as a registry workflow to prevent inefficient configs.

### Drive-by changes

N/A

### Related issues

https://github.com/hyperlane-xyz/hyperlane-registry/pull/511#discussion_r1924612890

### Backward compatibility

Yes

### Testing

This script was successfully used here: https://github.com/hyperlane-xyz/hyperlane-registry/commit/78b12779846194c0d4732eed59ac148cf5b68fc2