### PR TITLE
feat: deploy agents, faster external-secrets

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -803,7 +803,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'b431cda-20250529-133433',
+      tag: 'cedc8e1-20250603-094703',
     },
     blacklist,
     gasPaymentEnforcement: gasPaymentEnforcement,
@@ -817,7 +817,7 @@ const hyperlane: RootAgentConfig = {
   validators: {
     docker: {
       repo,
-      tag: '2903fe1-20250602-134907',
+      tag: 'cedc8e1-20250603-094703',
     },
     rpcConsensusType: RpcConsensusType.Quorum,
     chains: validatorChainConfig(Contexts.Hyperlane),
@@ -843,7 +843,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '2903fe1-20250602-134907',
+      tag: 'cedc8e1-20250603-094703',
     },
     blacklist,
     // We're temporarily (ab)using the RC relayer as a way to increase
@@ -860,7 +860,7 @@ const releaseCandidate: RootAgentConfig = {
   validators: {
     docker: {
       repo,
-      tag: '385b307-20250418-150728',
+      tag: 'cedc8e1-20250603-094703',
     },
     rpcConsensusType: RpcConsensusType.Quorum,
     chains: validatorChainConfig(Contexts.ReleaseCandidate),
@@ -881,7 +881,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'b431cda-20250529-133433',
+      tag: 'cedc8e1-20250603-094703',
     },
     blacklist,
     gasPaymentEnforcement,

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -405,7 +405,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'b23399a-20250603-075344',
+      tag: 'cedc8e1-20250603-094703',
     },
     blacklist: [...releaseCandidateHelloworldMatchingList, ...relayBlacklist],
     gasPaymentEnforcement,
@@ -420,7 +420,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '761d140-20250526-120715',
+      tag: 'cedc8e1-20250603-094703',
     },
     chains: validatorChainConfig(Contexts.Hyperlane),
     resources: validatorResources,
@@ -444,7 +444,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'b23399a-20250603-075344',
+      tag: 'cedc8e1-20250603-094703',
     },
     blacklist: relayBlacklist,
     gasPaymentEnforcement,
@@ -459,7 +459,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '385b307-20250418-150728',
+      tag: 'cedc8e1-20250603-094703',
     },
     chains: validatorChainConfig(Contexts.ReleaseCandidate),
     resources: validatorResources,

--- a/typescript/infra/scripts/agents/utils.ts
+++ b/typescript/infra/scripts/agents/utils.ts
@@ -1,4 +1,4 @@
-import { concurrentMap } from '@hyperlane-xyz/utils';
+import { concurrentMap, sleep } from '@hyperlane-xyz/utils';
 
 import {
   AgentHelmManager,

--- a/typescript/infra/scripts/agents/utils.ts
+++ b/typescript/infra/scripts/agents/utils.ts
@@ -1,4 +1,4 @@
-import { concurrentMap, sleep } from '@hyperlane-xyz/utils';
+import { concurrentMap } from '@hyperlane-xyz/utils';
 
 import {
   AgentHelmManager,

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -373,6 +373,12 @@ export class ValidatorHelmManager extends MultichainAgentHelmManager {
     const helmValues = await super.helmValues();
     const cfg = await this.config.buildConfig();
 
+    // Only care about the origin chain for the helm values. This
+    // prevents getting secret endpoints for all chains in the environment.
+    helmValues.hyperlane.chains = helmValues.hyperlane.chains.filter(
+      (chain) => chain.name === cfg.originChainName,
+    );
+
     helmValues.hyperlane.validator = {
       enabled: true,
       configs: cfg.validators.map((c) => ({

--- a/typescript/infra/src/infrastructure/external-secrets/external-secrets.ts
+++ b/typescript/infra/src/infrastructure/external-secrets/external-secrets.ts
@@ -117,10 +117,14 @@ async function ensureExternalSecretsRelease(infraConfig: InfrastructureConfig) {
   // CRD resources to be deleted!
   let installCrds = false;
   if (!(await isExternalSecretsReleaseInstalled(infraConfig))) {
-    await confirm({
+    const shouldProceed = await confirm({
       message:
         '⚠️ WARNING ⚠️\nThe external-secrets CRDs are not installed. This will install them, which may delete and recreate existing external-secrets CRDs. Do not do this unless this is a fresh cluster or you are sure you want to do this.\nContinue?',
     });
+
+    if (!shouldProceed) {
+      throw new Error('User cancelled external-secrets CRD installation');
+    }
     console.log(
       'Installing external-secrets release with CRDs, as it is not already installed.',
     );

--- a/typescript/infra/src/infrastructure/external-secrets/external-secrets.ts
+++ b/typescript/infra/src/infrastructure/external-secrets/external-secrets.ts
@@ -1,3 +1,5 @@
+import { confirm } from '@inquirer/prompts';
+
 import { sleep } from '@hyperlane-xyz/utils';
 
 import { InfrastructureConfig } from '../../config/infrastructure.js';
@@ -104,23 +106,30 @@ async function ensureExternalSecretsRelease(infraConfig: InfrastructureConfig) {
   // Prometheus's helm chart requires a repository to be added
   await addHelmRepoIfRequired(infraConfig.externalSecrets.helmChart);
 
-  // Only install the release if it doesn't already exist. We've observed
-  // some issues attempting an upgrade when the external-secrets release
-  // already exists. Doing so could result in the CRD being deleted and
-  // recreated, which would cause all existing external-secrets CRDs to be
-  // deleted!
-  if (!(await isExternalSecretsReleaseInstalled(infraConfig))) {
-    // The name passed in must be in the form `repo/chartName`
-    const chartName = getDeployableHelmChartName(
-      infraConfig.externalSecrets.helmChart,
-    );
+  // The name passed in must be in the form `repo/chartName`
+  const chartName = getDeployableHelmChartName(
+    infraConfig.externalSecrets.helmChart,
+  );
 
-    await execCmd(
-      `helm upgrade external-secrets ${chartName} --namespace ${infraConfig.externalSecrets.namespace} --create-namespace --version ${infraConfig.externalSecrets.helmChart.version} --install --set installCRDs=true `,
+  // Only install CRDs if the release doesn't already exist. We've observed
+  // issues installing the CRDs when they already exist - doing so could result
+  // in the CRD being deleted and recreated, which would cause all existing external-secrets
+  // CRD resources to be deleted!
+  let installCrds = false;
+  if (!(await isExternalSecretsReleaseInstalled(infraConfig))) {
+    await confirm({
+      message:
+        '⚠️ WARNING ⚠️\nThe external-secrets CRDs are not installed. This will install them, which may delete and recreate existing external-secrets CRDs. Do not do this unless this is a fresh cluster or you are sure you want to do this.\nContinue?',
+    });
+    console.log(
+      'Installing external-secrets release with CRDs, as it is not already installed.',
     );
-  } else {
-    console.log('External-secrets release already installed.');
+    installCrds = true;
   }
+
+  await execCmd(
+    `helm upgrade external-secrets ${chartName} --namespace ${infraConfig.externalSecrets.namespace} --create-namespace --version ${infraConfig.externalSecrets.helmChart.version} --install --set concurrent=10 ${installCrds ? '--set installCRDs=true' : ''}`,
+  );
 
   // Wait for the external-secrets-webhook deployment to have a ready replica.
   // The webhook deployment is required in order for subsequent deployments


### PR DESCRIPTION
### Description

- Updates all testnet4 relayer / validator agents (except for testnet4 neutron relayer)
- Adds concurrency of 10 to external-secrets, so it can update 10 secrets concurrently instead of the default of 1
- Removes unnecessary chains from validator external-secrets templates, cutting down on the work that external-secrets needs to do
- Makes it a bit safer to work with the external-secrets helm chart

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
