### PR TITLE
fix: typo in variable name in `configUtils.test.ts`

### DIFF
--- a/typescript/sdk/src/token/configUtils.test.ts
+++ b/typescript/sdk/src/token/configUtils.test.ts
@@ -184,9 +184,9 @@ describe('configUtils', () => {
 
     for (const { msg, input, expected } of testCases) {
       it(msg, () => {
-        const tranformedObj = transformConfigToCheck(input);
+        const transformedObj = transformConfigToCheck(input);
 
-        expect(tranformedObj).to.eql(expected);
+        expect(transformedObj).to.eql(expected);
       });
     }
   });


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the variable name from tranformedObj to transformedObj within the test cases in `typescript/sdk/src/token/configUtils.test.ts`. This change improves code readability and consistency, ensuring the variable name accurately reflects its purpose. No functional changes were made to the test logic.
