### PR TITLE
chore: loosen validator consistency check on non-hyperlane contexts

### DIFF
--- a/typescript/infra/config/environments/mainnet3/aw-validators/rc.json
+++ b/typescript/infra/config/environments/mainnet3/aw-validators/rc.json
@@ -90,6 +90,9 @@
       "0x2111141b7f985d305f392c502ad52dd74ef9c569"
     ]
   },
+  "hyperevm": {
+    "validators": ["0x95b460edc770f53981c9aa82aa2a297af619cabf"]
+  },
   "inevm": {
     "validators": [
       "0x52a0376903294c796c091c785a66c62943d99aa8",

--- a/typescript/infra/config/environments/mainnet3/validators.ts
+++ b/typescript/infra/config/environments/mainnet3/validators.ts
@@ -1632,6 +1632,9 @@ export const validatorChainConfig = (
       validators: validatorsConfig(
         {
           [Contexts.Hyperlane]: ['0x01be14a9eceeca36c9c1d46c056ca8c87f77c26f'],
+          [Contexts.ReleaseCandidate]: [
+            '0x95b460edc770f53981c9aa82aa2a297af619cabf',
+          ],
         },
         'hyperevm',
       ),


### PR DESCRIPTION
### Description

chore: loosen validator consistency check on non-hyperlane contexts

previously when trying to do create keys in the RC context we'd get a validator inconsistency warning. This is due to the fact we check that all chains have a validator configured in a context.

However! We only want to enforce this on `hyperlane`, as RC/Neutron context validators are not mandatory and only spun up for testing.

### Drive-by changes

- make it pretty
- add hyperevm rc validator address

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

before:
![image](https://github.com/user-attachments/assets/a84079ee-6e7b-42e8-ae9e-fcaef869365a)

after:
![image](https://github.com/user-attachments/assets/77e6dd3d-7623-4afa-9ef0-51099e65c830)
