### PR TITLE
fix: add sanity range check for starknet indexer

### DIFF
--- a/rust/main/chains/hyperlane-starknet/src/indexer.rs
+++ b/rust/main/chains/hyperlane-starknet/src/indexer.rs
@@ -262,6 +262,17 @@ async fn fetch_logs_in_range<T>(
 where
     T: std::fmt::Debug,
 {
+    // sanity check the range, because the provider doesn't return an error if the range is invalid
+    // and only returns an empty list
+    let current_block = get_block_height_u32(provider, &ReorgPeriod::None).await?;
+    if !range.contains(&current_block) {
+        return Err(HyperlaneStarknetError::Other(format!(
+            "range {:?} is not valid for current block {}",
+            range, current_block
+        ))
+        .into());
+    }
+
     let key = get_selector_from_name(key)
         .map_err(|_| HyperlaneStarknetError::from_other("get selector cannot fail"))?;
 

--- a/rust/main/chains/hyperlane-starknet/src/indexer.rs
+++ b/rust/main/chains/hyperlane-starknet/src/indexer.rs
@@ -265,7 +265,7 @@ where
     // sanity check the range, because the provider doesn't return an error if the range is invalid
     // and only returns an empty list
     let current_block = get_block_height_u32(provider, &ReorgPeriod::None).await?;
-    if !range.contains(&current_block) {
+    if *range.start() >= current_block || *range.end() > current_block {
         return Err(HyperlaneStarknetError::Other(format!(
             "range {:?} is not valid for current block {}",
             range, current_block

--- a/rust/main/chains/hyperlane-starknet/src/indexer.rs
+++ b/rust/main/chains/hyperlane-starknet/src/indexer.rs
@@ -265,7 +265,7 @@ where
     // sanity check the range, because the provider doesn't return an error if the range is invalid
     // and only returns an empty list
     let current_block = get_block_height_u32(provider, &ReorgPeriod::None).await?;
-    if *range.start() >= current_block || *range.end() > current_block {
+    if *range.start() > current_block || *range.end() > current_block {
         return Err(HyperlaneStarknetError::Other(format!(
             "range {:?} is not valid for current block {}",
             range, current_block


### PR DESCRIPTION
### Description
This PR adds an extra sanity check for the starknet indexer methods. It first checks whether or not the current block height is included in the given index range.

The method we use to retrieve Starknet events doesn't check for a valid block range and will simply return an empty array for unkown / future block ranges. Sometimes it happens, that we hit a node that hasn't actually mined the latest block yet and therefore only returns an empty array instead of the actual events that might be in the range. 

This mainly impacts scraper deliveries and IGP indexing, as `merkle_tree_hook` & `dispatch` are sequence aware.
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues
[Linear Issue](https://linear.app/hyperlane-xyz/issue/ENG-1702/scraper-missing-events)
<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing
Local testing & E2E
<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for block range queries to ensure requested ranges do not exceed the current blockchain height, preventing silent failures and providing clearer error messages for out-of-range requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->