### PR TITLE
feat(ci): corepack/yarn caching

### DIFF
--- a/.github/actions/yarn-build-with-cache/action.yml
+++ b/.github/actions/yarn-build-with-cache/action.yml
@@ -8,7 +8,7 @@ inputs:
   cache-provider:
     description: 'Choose cache provider: buildjet or github'
     required: false
-    default: 'buildjet'
+    default: 'github'
 
 runs:
   using: 'composite'
@@ -22,27 +22,49 @@ runs:
       shell: bash
       run: echo "cache-provider=${{ inputs.cache-provider }}" >> $GITHUB_ENV
 
-    - name: Cache
+    - name: Enable corepack
+      run: |
+        corepack enable
+
+    - name: Cache Corepack Yarn installation
       if: env.cache-provider == 'buildjet'
       uses: buildjet/cache@v4
-      id: buildjet-cache
+      with:
+        path: ~/.cache/node/corepack
+        key: corepack-yarn-${{ runner.os }}-${{ hashFiles('**/.yarnrc.yml', '**/package.json') }}
+        restore-keys: |
+          corepack-yarn-${{ runner.os }}-
+
+    - name: Cache Corepack Yarn installation
+      if: env.cache-provider == 'actions'
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/node/corepack
+        key: corepack-yarn-${{ runner.os }}-${{ hashFiles('**/.yarnrc.yml', '**/package.json') }}
+        restore-keys: |
+          corepack-yarn-${{ runner.os }}-
+
+    - name: Cache yarn packages
+      if: env.cache-provider == 'buildjet'
+      uses: buildjet/cache@v4
       with:
         path: |
-          **/node_modules
-          .yarn
-        key: ${{ runner.os }}-yarn-4.5.1-cache-${{ hashFiles('./yarn.lock') }}
+          .yarn/cache
+          .yarn/releases
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn
 
-    - name: Cache
+    - name: Cache yarn packages
       if: env.cache-provider == 'github'
       uses: actions/cache@v4
-      id: github-cache
       with:
         path: |
-          **/node_modules
-          .yarn
-        key: ${{ runner.os }}-yarn-4.5.1-cache-${{ hashFiles('./yarn.lock') }}
+          .yarn/cache
+          .yarn/releases
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
-          ${{ runner.os }}-yarn-4.5.1-cache-
+          ${{ runner.os }}-yarn
 
     # Typically, the cache will be hit, but if there's a network error when
     # restoring the cache, let's run the install step ourselves.
@@ -50,13 +72,7 @@ runs:
       if: steps.buildjet-cache.outputs.cache-hit != 'true' && steps.github-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        yarn install
-        CHANGES=$(git status -s --ignore-submodules)
-        if [[ ! -z $CHANGES ]]; then
-          echo "Changes found: $CHANGES"
-          git diff
-          exit 1
-        fi
+        yarn install --immutable
 
     - name: Build
       shell: bash

--- a/.github/actions/yarn-build-with-cache/action.yml
+++ b/.github/actions/yarn-build-with-cache/action.yml
@@ -23,6 +23,7 @@ runs:
       run: echo "cache-provider=${{ inputs.cache-provider }}" >> $GITHUB_ENV
 
     - name: Enable corepack
+      shell: bash
       run: |
         corepack enable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,6 @@ jobs:
         uses: ./.github/actions/install-cli
         with:
           ref: ${{ github.sha }}
-          cache-provider: github
 
       - name: Test run the CLI
         run: hyperlane --version

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -23,18 +23,30 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
 
-      - name: yarn-cache
-        uses: buildjet/cache@v4
+      - name: Enable corepack
+        run: |
+          corepack enable
+
+      - name: Cache Corepack Yarn installation
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/node/corepack
+          key: corepack-yarn-${{ runner.os }}-${{ hashFiles('**/.yarnrc.yml', '**/package.json') }}
+          restore-keys: |
+            corepack-yarn-${{ runner.os }}-
+
+      - name: Cache yarn packages
+        uses: actions/cache@v4
         with:
           path: |
-            **/node_modules
-            .yarn
-          key: ${{ runner.os }}-yarn-4.5.1-cache-${{ hashFiles('./yarn.lock') }}
+            .yarn/cache
+            .yarn/releases
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-4.5.1.-cache-
+            ${{ runner.os }}-yarn
 
       - name: yarn-install
-        run: yarn install
+        run: yarn install --immutable
 
       - name: foundry-install
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/storage-analysis.yml
+++ b/.github/workflows/storage-analysis.yml
@@ -23,18 +23,30 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: yarn-cache
-        uses: buildjet/cache@v4
+      - name: Enable corepack
+        run: |
+          corepack enable
+
+      - name: Cache Corepack Yarn installation
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/node/corepack
+          key: corepack-yarn-${{ runner.os }}-${{ hashFiles('**/.yarnrc.yml', '**/package.json') }}
+          restore-keys: |
+            corepack-yarn-${{ runner.os }}-
+
+      - name: Cache yarn packages
+        uses: actions/cache@v4
         with:
           path: |
-            **/node_modules
-            .yarn
-          key: ${{ runner.os }}-yarn-4.5.1-cache-${{ hashFiles('./yarn.lock') }}
+            .yarn/cache
+            .yarn/releases
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-4.5.1-cache-
+            ${{ runner.os }}-yarn
 
       - name: yarn-install
-        run: yarn install
+        run: yarn install --immutable
 
       - name: foundry-install
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ env:
   TURBO_TOKEN: ${{ secrets.DEPOT_TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.DEPOT_ORG_ID }}
   YARN_ENABLE_GLOBAL_CACHE: false
-  YARN_ENABLE_SCRIPTS: false
   YARN_NODE_LINKER: pnp
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ env:
   TURBO_API: https://cache.depot.dev
   TURBO_TOKEN: ${{ secrets.DEPOT_TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.DEPOT_ORG_ID }}
+  YARN_ENABLE_GLOBAL_CACHE: false
+  YARN_ENABLE_SCRIPTS: false
+  YARN_NODE_LINKER: pnp
 
 jobs:
   yarn-install:
@@ -39,25 +42,31 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: yarn-cache
-        uses: buildjet/cache@v4
+      - name: Enable corepack
+        run: |
+          corepack enable
+
+      - name: Cache Corepack Yarn installation
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/node/corepack
+          key: corepack-yarn-${{ runner.os }}-${{ hashFiles('**/.yarnrc.yml', '**/package.json') }}
+          restore-keys: |
+            corepack-yarn-${{ runner.os }}-
+
+      - name: Cache yarn packages
+        uses: actions/cache@v4
         with:
           path: |
-            **/node_modules
-            .yarn
-          key: ${{ runner.os }}-yarn-4.5.1-cache-${{ hashFiles('./yarn.lock') }}
+            .yarn/cache
+            .yarn/releases
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-4.5.1-cache-
+            ${{ runner.os }}-yarn
 
       - name: yarn-install
         run: |
-          yarn install
-          CHANGES=$(git status -s --ignore-submodules)
-          if [[ ! -z $CHANGES ]]; then
-            echo "Changes found: $CHANGES"
-            git diff
-            exit 1
-          fi
+          yarn install --immutable
 
       # Check for mismatched dep versions across the monorepo
       - name: syncpack
@@ -79,7 +88,6 @@ jobs:
         uses: ./.github/actions/yarn-build-with-cache
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          cache-provider: github
 
       - name: lint
         run: yarn lint
@@ -192,7 +200,6 @@ jobs:
         uses: ./.github/actions/yarn-build-with-cache
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          cache-provider: github
       - name: Checkout registry
         uses: ./.github/actions/checkout-registry
 
@@ -239,7 +246,6 @@ jobs:
         if: env.BALANCE_CHANGES == 'true' || env.WARP_CONFIG_CHANGES == 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          cache-provider: github
 
       - name: Checkout registry
         if: env.BALANCE_CHANGES == 'true' || env.WARP_CONFIG_CHANGES == 'true'
@@ -325,7 +331,6 @@ jobs:
         uses: ./.github/actions/install-cli
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          cache-provider: github
 
       - name: Checkout registry
         uses: ./.github/actions/checkout-registry
@@ -362,7 +367,6 @@ jobs:
         uses: ./.github/actions/yarn-build-with-cache
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          cache-provider: github
 
       - name: Cosmos SDK e2e tests
         run: yarn --cwd typescript/cosmos-sdk test:e2e
@@ -395,7 +399,6 @@ jobs:
         uses: ./.github/actions/yarn-build-with-cache
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          cache-provider: github
 
       - name: Checkout registry
         uses: ./.github/actions/checkout-registry
@@ -518,7 +521,6 @@ jobs:
         uses: ./.github/actions/yarn-build-with-cache
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          cache-provider: github
 
       - name: Install system dependencies
         if: steps.check-conditions.outputs.skip-e2e != 'true'
@@ -625,7 +627,6 @@ jobs:
         uses: ./.github/actions/yarn-build-with-cache
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          cache-provider: github
 
       - name: Checkout registry
         uses: ./.github/actions/checkout-registry
@@ -666,6 +667,7 @@ jobs:
         uses: ./.github/actions/yarn-build-with-cache
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          cache-provider: buildjet
       - name: foundry-install
         uses: foundry-rs/foundry-toolchain@v1
 

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -46,6 +46,7 @@
     "@types/sinon-chai": "^3.2.12",
     "@types/yargs": "^17.0.24",
     "chai": "^4.5.0",
+    "chalk": "^5.3.0",
     "ethereum-waffle": "^4.0.10",
     "ethers": "^5.8.0",
     "hardhat": "^2.22.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8278,6 +8278,7 @@ __metadata:
     asn1.js: "npm:^5.4.1"
     aws-kms-ethers-signer: "npm:^0.1.3"
     chai: "npm:^4.5.0"
+    chalk: "npm:^5.3.0"
     deep-object-diff: "npm:^1.1.9"
     dotenv: "npm:^10.0.0"
     ethereum-waffle: "npm:^4.0.10"


### PR DESCRIPTION
### Description

feat(ci): corepack/yarn caching
- update `yarn-build-with-cache` to use corepack
- change `yarn-build-with-cache` default to `github`
- change `yarn install` invocations in CI to `yarn install --immutable`

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
