### PR TITLE
fix: Use only domain in spans so that it is easier to search

### DIFF
--- a/rust/main/agents/relayer/src/msg/op_batch.rs
+++ b/rust/main/agents/relayer/src/msg/op_batch.rs
@@ -26,7 +26,7 @@ pub(crate) struct OperationBatch {
 }
 
 impl OperationBatch {
-    #[instrument(skip_all, fields(domain=%self.domain, batch_size=self.operations.len()))]
+    #[instrument(skip_all, fields(domain=%self.domain.name(), batch_size=self.operations.len()))]
     pub async fn submit(
         self,
         prepare_queue: &mut OpQueue,

--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -394,6 +394,7 @@ where
     T: Indexable + Debug + Send + Sync + Clone + Eq + Hash + 'static,
 {
     /// Returns a new cursor to be used for syncing events from the indexer based on time
+    #[instrument(skip_all, fields(domain=%self.domain.name(), index_settings = ?index_settings))]
     async fn cursor(
         &self,
         index_settings: IndexSettings,


### PR DESCRIPTION
### Description

Use only domain in spans so that it is easier to search using usual field matching

### Backward compatibility

Yes

### Testing

None