### PR TITLE
fix: validator count fetching upon startup is retried

### DIFF
--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -264,8 +264,8 @@ impl BaseAgent for Validator {
                     }
                     break;
                 }
-                Err(e) => {
-                    error!(?e, "Error getting merkle tree hook count");
+                Err(err) => {
+                    error!(?err, "Error getting merkle tree hook count");
                     sleep(self.interval).await;
                 }
             }

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -264,9 +264,9 @@ impl BaseAgent for Validator {
                     }
                     break;
                 }
-                _ => {
-                    // Future that immediately resolves
-                    return;
+                Err(e) => {
+                    error!(?e, "Error getting merkle tree hook count");
+                    sleep(self.interval).await;
                 }
             }
         }


### PR DESCRIPTION
### Description

- Observed with Starknet, this is a fix for what we theorize the issue is

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
