### PR TITLE
fix: check OP withdrawal tx matches hyperlane messages

### DIFF
--- a/solidity/contracts/isms/hook/OPL2ToL1CcipReadIsm.sol
+++ b/solidity/contracts/isms/hook/OPL2ToL1CcipReadIsm.sol
@@ -40,6 +40,7 @@ interface OpL2toL1Service {
 abstract contract OPL2ToL1CcipReadIsm is AbstractCcipReadIsm {
     using Message for bytes;
     using TypeCasts for address;
+    using OPL2ToL1Withdrawal for IOptimismPortal.WithdrawalTransaction;
 
     // the OP Portal contract on L1
     IOptimismPortal public immutable opPortal;
@@ -77,14 +78,6 @@ abstract contract OPL2ToL1CcipReadIsm is AbstractCcipReadIsm {
         return true;
     }
 
-    function _proveMessageId(
-        bytes memory extraData
-    ) internal pure virtual returns (bytes32);
-
-    function _finalizeMessageId(
-        bytes memory extraData
-    ) internal pure virtual returns (bytes32);
-
     function _isProve(
         bytes calldata _message
     ) internal view virtual returns (bool);
@@ -109,11 +102,11 @@ abstract contract OPL2ToL1CcipReadIsm is AbstractCcipReadIsm {
             );
 
         require(
-            _proveMessageId(_tx.data) == messageId,
+            _tx.proveMessageId() == messageId,
             "OPL2ToL1CcipReadIsm: prove message id mismatch"
         );
 
-        bytes32 withdrawalHash = OPL2ToL1Withdrawal.hashWithdrawal(_tx);
+        bytes32 withdrawalHash = _tx.hashWithdrawal();
 
         // Proving only if the withdrawal wasn't
         // proven already by this contract
@@ -141,11 +134,11 @@ abstract contract OPL2ToL1CcipReadIsm is AbstractCcipReadIsm {
         );
 
         require(
-            _finalizeMessageId(_tx.data) == messageId,
+            _tx.finalizeMessageId() == messageId,
             "OPL2ToL1CcipReadIsm: finalize message id mismatch"
         );
 
-        bytes32 withdrawalHash = OPL2ToL1Withdrawal.hashWithdrawal(_tx);
+        bytes32 withdrawalHash = _tx.hashWithdrawal();
 
         if (!opPortal.finalizedWithdrawals(withdrawalHash)) {
             opPortal.finalizeWithdrawalTransaction(_tx);

--- a/solidity/contracts/libs/OPL2ToL1Withdrawal.sol
+++ b/solidity/contracts/libs/OPL2ToL1Withdrawal.sol
@@ -25,4 +25,28 @@ library OPL2ToL1Withdrawal {
                 )
             );
     }
+
+    function encodeData(
+        bytes32 _proveMessageId,
+        bytes32 _finalizeMessageId
+    ) internal pure returns (bytes memory) {
+        return abi.encode(_proveMessageId, _finalizeMessageId);
+    }
+
+    function proveMessageId(
+        IOptimismPortal.WithdrawalTransaction memory _tx
+    ) internal pure returns (bytes32) {
+        (bytes32 _proveMessageId, ) = abi.decode(_tx.data, (bytes32, bytes32));
+        return _proveMessageId;
+    }
+
+    function finalizeMessageId(
+        IOptimismPortal.WithdrawalTransaction memory _tx
+    ) internal pure returns (bytes32) {
+        (, bytes32 _finalizeMessageId) = abi.decode(
+            _tx.data,
+            (bytes32, bytes32)
+        );
+        return _finalizeMessageId;
+    }
 }

--- a/solidity/contracts/mock/MockOptimism.sol
+++ b/solidity/contracts/mock/MockOptimism.sol
@@ -67,12 +67,6 @@ contract MockOptimismPortal is IOptimismPortal {
     function finalizeWithdrawalTransaction(
         WithdrawalTransaction memory _tx
     ) external {
-        CallLib.Call memory call = CallLib.Call(
-            TypeCasts.addressToBytes32(_tx.target),
-            _tx.value,
-            _tx.data
-        );
-        CallLib.call(call);
         bytes32 withdrawalHash = OPL2ToL1Withdrawal.hashWithdrawal(_tx);
         _finalizedWithdrawals[withdrawalHash] = true;
     }

--- a/solidity/test/isms/OPL2ToL1CcipReadIsm.t.sol
+++ b/solidity/test/isms/OPL2ToL1CcipReadIsm.t.sol
@@ -126,7 +126,10 @@ contract OpL1V1NativeTokenBridgeTest is Test {
             messageBody
         );
 
-        bytes memory data = abi.encodePacked(proveMessageId, bytes32(0));
+        bytes memory data = OPL2ToL1Withdrawal.encodeData(
+            proveMessageId,
+            bytes32(0)
+        );
         IOptimismPortal.WithdrawalTransaction
             memory withdrawalTx = _getDummyWithdrawalTx(0, amount, data);
 
@@ -154,7 +157,10 @@ contract OpL1V1NativeTokenBridgeTest is Test {
             messageBody
         );
 
-        bytes memory data = abi.encodePacked(bytes32(0), finalizeMessageId);
+        bytes memory data = OPL2ToL1Withdrawal.encodeData(
+            bytes32(0),
+            finalizeMessageId
+        );
         IOptimismPortal.WithdrawalTransaction
             memory withdrawalTx = _getDummyWithdrawalTx(0, amount, data);
 
@@ -182,7 +188,10 @@ contract OpL1V1NativeTokenBridgeTest is Test {
             messageBody
         );
 
-        bytes memory data = abi.encodePacked(bytes32(0), bytes32(0));
+        bytes memory data = OPL2ToL1Withdrawal.encodeData(
+            bytes32(0),
+            bytes32(0)
+        );
         IOptimismPortal.WithdrawalTransaction
             memory withdrawalTx = _getDummyWithdrawalTx(0, 0, data);
 
@@ -206,7 +215,10 @@ contract OpL1V1NativeTokenBridgeTest is Test {
             messageBody
         );
 
-        bytes memory data = abi.encodePacked(bytes32(0), bytes32(0));
+        bytes memory data = OPL2ToL1Withdrawal.encodeData(
+            bytes32(0),
+            bytes32(0)
+        );
         IOptimismPortal.WithdrawalTransaction
             memory withdrawalTx = _getDummyWithdrawalTx(0, amount, data);
 

--- a/solidity/test/isms/OPL2ToL1CcipReadIsm.t.sol
+++ b/solidity/test/isms/OPL2ToL1CcipReadIsm.t.sol
@@ -118,16 +118,17 @@ contract OpL1V1NativeTokenBridgeTest is Test {
         bytes32 _recipient,
         uint256 amount
     ) public {
-        IOptimismPortal.WithdrawalTransaction
-            memory withdrawalTx = _getDummyWithdrawalTx(0, amount, bytes(""));
-
         // amount 0 indicates prove message
         bytes memory messageBody = TokenMessage.format(_recipient, 0);
-        mailboxOrigin.dispatch(
+        bytes32 proveMessageId = mailboxOrigin.dispatch(
             destination,
             address(ism).addressToBytes32(),
             messageBody
         );
+
+        bytes memory data = abi.encodePacked(proveMessageId, bytes32(0));
+        IOptimismPortal.WithdrawalTransaction
+            memory withdrawalTx = _getDummyWithdrawalTx(0, amount, data);
 
         bytes memory message = mailboxDestination.inboundMessages(0);
         bytes memory metadata = _getDummyVerifyMetadata(withdrawalTx);
@@ -146,15 +147,16 @@ contract OpL1V1NativeTokenBridgeTest is Test {
     ) public {
         vm.assume(amount > 0);
 
-        IOptimismPortal.WithdrawalTransaction
-            memory withdrawalTx = _getDummyWithdrawalTx(0, amount, bytes(""));
-
         bytes memory messageBody = TokenMessage.format(_recipient, amount);
-        mailboxOrigin.dispatch(
+        bytes32 finalizeMessageId = mailboxOrigin.dispatch(
             destination,
             address(tokenBridgeDestination).addressToBytes32(),
             messageBody
         );
+
+        bytes memory data = abi.encodePacked(bytes32(0), finalizeMessageId);
+        IOptimismPortal.WithdrawalTransaction
+            memory withdrawalTx = _getDummyWithdrawalTx(0, amount, data);
 
         vm.deal(address(portal), amount);
 
@@ -167,6 +169,54 @@ contract OpL1V1NativeTokenBridgeTest is Test {
             portal.finalizedWithdrawals(withdrawalTx.hashWithdrawal()),
             true
         );
+    }
+
+    function test_verify_revertsWhen_proveMessageIdMismatched(
+        bytes32 _recipient
+    ) public {
+        // amount 0 indicates prove message
+        bytes memory messageBody = TokenMessage.format(_recipient, 0);
+        mailboxOrigin.dispatch(
+            destination,
+            address(ism).addressToBytes32(),
+            messageBody
+        );
+
+        bytes memory data = abi.encodePacked(bytes32(0), bytes32(0));
+        IOptimismPortal.WithdrawalTransaction
+            memory withdrawalTx = _getDummyWithdrawalTx(0, 0, data);
+
+        bytes memory message = mailboxDestination.inboundMessages(0);
+        bytes memory metadata = _getDummyVerifyMetadata(withdrawalTx);
+
+        vm.expectRevert("OPL2ToL1CcipReadIsm: prove message id mismatch");
+        ism.verify(metadata, message);
+    }
+
+    function test_verify_revertsWhen_finalizeMessageIdMismatched(
+        bytes32 _recipient,
+        uint256 amount
+    ) public {
+        vm.assume(amount > 0);
+
+        bytes memory messageBody = TokenMessage.format(_recipient, amount);
+        mailboxOrigin.dispatch(
+            destination,
+            address(tokenBridgeDestination).addressToBytes32(),
+            messageBody
+        );
+
+        bytes memory data = abi.encodePacked(bytes32(0), bytes32(0));
+        IOptimismPortal.WithdrawalTransaction
+            memory withdrawalTx = _getDummyWithdrawalTx(0, amount, data);
+
+        vm.deal(address(portal), amount);
+
+        bytes memory message = mailboxDestination.inboundMessages(0);
+        bytes memory metadata = _getDummyVerifyMetadata(withdrawalTx);
+
+        vm.expectRevert("OPL2ToL1CcipReadIsm: finalize message id mismatch");
+        ism.verify(metadata, message);
     }
 
     function test_interchainSecurityModule_givenIsmIsCorrect() public {


### PR DESCRIPTION
### Description

- Enforces that the prove message is processed IFF the corresponding withdrawal is proven
- Enforces that the finalize message is processed IFF the corresponding withdrawal is finalized

Note that it is still possible for the withdrawal to be proven and finalized by another actor. In this case the messages will verify this status and then be marked as delivered.

### Backward compatibility

Yes

### Testing

Unit Tests
