### PR TITLE
refactor(sdk): Use solidity version 0.8.22 in hardhat

### DIFF
--- a/typescript/sdk/hardhat.config.cts
+++ b/typescript/sdk/hardhat.config.cts
@@ -8,7 +8,7 @@ import 'solidity-coverage';
  */
 module.exports = {
   solidity: {
-    version: '0.8.19',
+    version: '0.8.22',
     settings: {
       optimizer: {
         enabled: true,


### PR DESCRIPTION
Bump the sdk's solc version. 

Perhaps a shared configuration could be used across the `typescript/` and `solidity/` directories? There's already a `rootHardhatConfig` in `solidity/`.