### PR TITLE
feat: warp deploy should output to config file name [ENG-1732]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,6 +304,7 @@ jobs:
           - warp-bridge-1
           - warp-bridge-2
           - warp-check
+          - warp-deploy
           - warp-extend-basic
           - warp-extend-config
           - warp-extend-recovery

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -147,7 +147,7 @@ export const deploy: CommandModuleWithWarpDeployContext<{
     },
     warpRouteId: warpRouteIdCommandOption,
   },
-  handler: async ({ context, dryRun, warpRouteId }) => {
+  handler: async ({ context, dryRun, warpRouteId, config }) => {
     logCommandHeader(
       `Hyperlane Warp Route Deployment${dryRun ? ' Dry-Run' : ''}`,
     );
@@ -158,6 +158,7 @@ export const deploy: CommandModuleWithWarpDeployContext<{
         // Already fetched in the resolveWarpRouteConfigChains
         warpDeployConfig: context.warpDeployConfig,
         warpRouteId,
+        warpDeployConfigFileName: config,
       });
     } catch (error: any) {
       evaluateIfDryRunFailure(error, dryRun);

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -65,7 +65,14 @@ import {
 import { MINIMUM_WARP_DEPLOY_GAS } from '../consts.js';
 import { requestAndSaveApiKeys } from '../context/context.js';
 import { WriteCommandContext } from '../context/types.js';
-import { log, logBlue, logGray, logGreen, logTable } from '../logger.js';
+import {
+  log,
+  logBlue,
+  logGray,
+  logGreen,
+  logTable,
+  warnYellow,
+} from '../logger.js';
 import { getSubmitterBuilder } from '../submit/submit.js';
 import {
   indentYamlOrJson,
@@ -146,11 +153,10 @@ export async function runWarpRouteDeploy({
   let warpRouteIdOptions: AddWarpRouteConfigOptions;
   if (warpRouteId) {
     warpRouteIdOptions = { warpRouteId };
-  } else if (
-    warpDeployConfigFileName &&
-    !('warpRouteId' in addWarpRouteOptions)
-  ) {
-    const fileName = path.parse(warpDeployConfigFileName).name;
+  } else if (warpDeployConfigFileName && 'symbol' in addWarpRouteOptions) {
+    const fileName = path
+      .parse(warpDeployConfigFileName)
+      .name.replace(/-deploy$/, '');
     const maybeId = createWarpRouteConfigId(
       addWarpRouteOptions.symbol,
       fileName,
@@ -164,6 +170,9 @@ export async function runWarpRouteDeploy({
       });
     } catch {
       isIdOk = false;
+      warnYellow(
+        `Generated id "${maybeId}" from input config file would be invalid, falling back to default options`,
+      );
     }
 
     warpRouteIdOptions = isIdOk

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -1,4 +1,5 @@
 import { Wallet, ethers } from 'ethers';
+import path from 'path';
 import { $, ProcessOutput, ProcessPromise } from 'zx';
 
 import {
@@ -61,6 +62,15 @@ export const WARP_CONFIG_PATH_EXAMPLE = `${EXAMPLES_PATH}/warp-route-deployment.
 export const WARP_CONFIG_PATH_2 = `${TEMP_PATH}/${CHAIN_NAME_2}/warp-route-deployment-anvil2.yaml`;
 export const WARP_DEPLOY_OUTPUT_PATH = `${TEMP_PATH}/warp-route-deployment.yaml`;
 export const WARP_CORE_CONFIG_PATH_2 = `${REGISTRY_PATH}/deployments/warp_routes/ETH/anvil2-config.yaml`;
+
+export const GET_WARP_DEPLOY_CORE_CONFIG_OUTPUT_PATH = (
+  originalDeployConfigPath: string,
+  symbol: string,
+): string => {
+  const fileName = path.parse(originalDeployConfigPath).name;
+
+  return `${REGISTRY_PATH}/deployments/warp_routes/${symbol}/${fileName}-config.yaml`;
+};
 
 export function getCombinedWarpRoutePath(
   tokenSymbol: string,

--- a/typescript/cli/src/tests/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-deploy.e2e-test.ts
@@ -135,7 +135,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
       );
     });
 
-    it.only(`should exit early when the provided scale is incorrect`, async function () {
+    it(`should exit early when the provided scale is incorrect`, async function () {
       const tokenFiat = await deployToken(
         ANVIL_KEY,
         CHAIN_NAME_2,

--- a/typescript/cli/src/tests/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-deploy.e2e-test.ts
@@ -27,6 +27,7 @@ import {
   CHAIN_NAME_3,
   CORE_CONFIG_PATH,
   DEFAULT_E2E_TEST_TIMEOUT,
+  GET_WARP_DEPLOY_CORE_CONFIG_OUTPUT_PATH,
   KeyBoardKeys,
   REGISTRY_PATH,
   TestPromptAction,
@@ -34,7 +35,6 @@ import {
   deploy4626Vault,
   deployOrUseExistingCore,
   deployToken,
-  getCombinedWarpRoutePath,
   handlePrompts,
 } from '../commands/helpers.js';
 import {
@@ -48,10 +48,10 @@ chai.use(chaiAsPromised);
 const expect = chai.expect;
 chai.should();
 
-const WARP_CORE_CONFIG_PATH_2_3 = getCombinedWarpRoutePath('VAULT', [
-  CHAIN_NAME_2,
-  CHAIN_NAME_3,
-]);
+const WARP_CORE_CONFIG_PATH_2_3 = GET_WARP_DEPLOY_CORE_CONFIG_OUTPUT_PATH(
+  WARP_DEPLOY_OUTPUT_PATH,
+  'VAULT',
+);
 
 describe('hyperlane warp deploy e2e tests', async function () {
   this.timeout(DEFAULT_E2E_TEST_TIMEOUT);
@@ -122,7 +122,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
       ];
 
       const output = hyperlaneWarpDeployRaw({
-        warpCorePath: nonExistingFilePath,
+        warpDeployPath: nonExistingFilePath,
       })
         .stdio('pipe')
         .nothrow();
@@ -130,17 +130,12 @@ describe('hyperlane warp deploy e2e tests', async function () {
       const finalOutput = await handlePrompts(output, steps);
 
       expect(finalOutput.exitCode).to.equal(1);
-      expect(
-        finalOutput
-          .text()
-          .includes(`No "Warp route deployment config" found in`) ||
-          finalOutput
-            .text()
-            .includes(`Invalid file format for ${nonExistingFilePath}`),
-      ).to.be.true;
+      expect(finalOutput.text()).to.include(
+        `Warp route deployment config file not found at ${nonExistingFilePath}`,
+      );
     });
 
-    it(`should exit early when the provided scale is incorrect`, async function () {
+    it.only(`should exit early when the provided scale is incorrect`, async function () {
       const tokenFiat = await deployToken(
         ANVIL_KEY,
         CHAIN_NAME_2,
@@ -197,7 +192,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
 
       // Deploy
       const output = hyperlaneWarpDeployRaw({
-        warpCorePath: WARP_DEPLOY_OUTPUT_PATH,
+        warpDeployPath: WARP_DEPLOY_OUTPUT_PATH,
       })
         .stdio('pipe')
         .nothrow();
@@ -207,13 +202,9 @@ describe('hyperlane warp deploy e2e tests', async function () {
       // Assertions
       expect(finalOutput.exitCode).to.equal(1);
 
-      expect(
-        finalOutput
-          .text()
-          .includes(
-            `Failed to derive token metadata Error: Found invalid or missing scale for inconsistent decimals`,
-          ),
-      ).to.be.true;
+      expect(finalOutput.text()).includes(
+        `Failed to derive token metadata Error: Found invalid or missing scale for inconsistent decimals`,
+      );
     });
 
     it(`should successfully deploy a ${TokenType.collateral} -> ${TokenType.synthetic} warp route`, async function () {
@@ -223,10 +214,11 @@ describe('hyperlane warp deploy e2e tests', async function () {
         token.symbol(),
         token.decimals(),
       ]);
-      const COMBINED_WARP_CORE_CONFIG_PATH = getCombinedWarpRoutePath(
-        expectedTokenSymbol,
-        [CHAIN_NAME_2, CHAIN_NAME_3],
-      );
+      const COMBINED_WARP_CORE_CONFIG_PATH =
+        GET_WARP_DEPLOY_CORE_CONFIG_OUTPUT_PATH(
+          WARP_DEPLOY_OUTPUT_PATH,
+          expectedTokenSymbol,
+        );
 
       const warpConfig: WarpRouteDeployConfig = {
         [CHAIN_NAME_2]: {
@@ -264,7 +256,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
 
       // Deploy
       const output = hyperlaneWarpDeployRaw({
-        warpCorePath: WARP_DEPLOY_OUTPUT_PATH,
+        warpDeployPath: WARP_DEPLOY_OUTPUT_PATH,
       })
         .stdio('pipe')
         .nothrow();
@@ -369,10 +361,11 @@ describe('hyperlane warp deploy e2e tests', async function () {
         tokenFiat.symbol(),
       ]);
 
-      const COMBINED_WARP_CORE_CONFIG_PATH = getCombinedWarpRoutePath(
-        expectedTokenSymbol,
-        [CHAIN_NAME_2, CHAIN_NAME_3],
-      );
+      const COMBINED_WARP_CORE_CONFIG_PATH =
+        GET_WARP_DEPLOY_CORE_CONFIG_OUTPUT_PATH(
+          WARP_DEPLOY_OUTPUT_PATH,
+          expectedTokenSymbol,
+        );
 
       const warpConfig: WarpRouteDeployConfig = {
         [CHAIN_NAME_2]: {
@@ -411,7 +404,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
 
       // Deploy
       const output = hyperlaneWarpDeployRaw({
-        warpCorePath: WARP_DEPLOY_OUTPUT_PATH,
+        warpDeployPath: WARP_DEPLOY_OUTPUT_PATH,
       })
         .stdio('pipe')
         .nothrow();
@@ -482,7 +475,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
       ];
 
       const output = hyperlaneWarpDeployRaw({
-        warpCorePath: nonExistingFilePath,
+        warpDeployPath: nonExistingFilePath,
         skipConfirmationPrompts: true,
       })
         .stdio('pipe')
@@ -492,7 +485,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
 
       expect(finalOutput.exitCode).to.equal(1);
       expect(finalOutput.text()).to.include(
-        `Warp route deployment config is required`,
+        `Warp route deployment config file not found at ${nonExistingFilePath}`,
       );
     });
 
@@ -504,10 +497,11 @@ describe('hyperlane warp deploy e2e tests', async function () {
         token.decimals(),
       ]);
       console.log(expectedTokenDecimals);
-      const COMBINED_WARP_CORE_CONFIG_PATH = getCombinedWarpRoutePath(
-        expectedTokenSymbol,
-        [CHAIN_NAME_2, CHAIN_NAME_3],
-      );
+      const COMBINED_WARP_CORE_CONFIG_PATH =
+        GET_WARP_DEPLOY_CORE_CONFIG_OUTPUT_PATH(
+          WARP_DEPLOY_OUTPUT_PATH,
+          expectedTokenSymbol,
+        );
 
       const warpConfig: WarpRouteDeployConfig = {
         [CHAIN_NAME_2]: {
@@ -540,7 +534,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
 
       // Deploy
       const output = hyperlaneWarpDeployRaw({
-        warpCorePath: WARP_DEPLOY_OUTPUT_PATH,
+        warpDeployPath: WARP_DEPLOY_OUTPUT_PATH,
         skipConfirmationPrompts: true,
       })
         .stdio('pipe')

--- a/typescript/sdk/src/utils/decimals.test.ts
+++ b/typescript/sdk/src/utils/decimals.test.ts
@@ -1,0 +1,164 @@
+import { assert } from 'chai';
+
+import { randomAddress } from '../test/testUtils.js';
+import { TokenType } from '../token/config.js';
+import {
+  TokenMetadata,
+  WarpRouteDeployConfigMailboxRequired,
+} from '../token/types.js';
+
+import { verifyScale } from './decimals.js';
+
+describe(verifyScale.name, () => {
+  const TOKEN_NAME = 'TOKEN';
+
+  it('should return true when all decimals are uniform', () => {
+    const configMap: Map<string, TokenMetadata> = new Map([
+      ['chain1', { name: TOKEN_NAME, symbol: TOKEN_NAME, decimals: 18 }],
+      ['chain2', { name: TOKEN_NAME, symbol: TOKEN_NAME, decimals: 18 }],
+    ]);
+    assert.isTrue(verifyScale(configMap));
+  });
+
+  it('should return true when all decimals are uniform and scale is not provided', () => {
+    const configMap: Map<string, TokenMetadata> = new Map([
+      ['chain1', { name: TOKEN_NAME, symbol: TOKEN_NAME, decimals: 6 }],
+      ['chain2', { name: TOKEN_NAME, symbol: TOKEN_NAME, decimals: 6 }],
+    ]);
+    assert.isTrue(verifyScale(configMap));
+  });
+
+  it('should return true when decimals are non-uniform but scales are correctly calculated/provided', () => {
+    const configMap: Map<string, TokenMetadata> = new Map([
+      ['chain1', { name: TOKEN_NAME, symbol: TOKEN_NAME, decimals: 18 }],
+      [
+        'chain2',
+        {
+          name: TOKEN_NAME,
+          symbol: TOKEN_NAME,
+          decimals: 6,
+          //scale: 1_000_000_000_000
+          scale: 1_000_000_000_000,
+        },
+      ], // 10^(18-6) = 10^12
+    ]);
+    assert.isTrue(verifyScale(configMap));
+  });
+
+  it('should return false when decimals are non-uniform and an incorrect scale is provided', () => {
+    const configMap: Map<string, TokenMetadata> = new Map([
+      ['chain1', { name: TOKEN_NAME, symbol: TOKEN_NAME, decimals: 18 }],
+      [
+        'chain2',
+        { name: TOKEN_NAME, symbol: TOKEN_NAME, decimals: 6, scale: 100 },
+      ],
+    ]);
+    assert.isFalse(verifyScale(configMap));
+  });
+
+  it('should return false when decimals are non-uniform and scale is missing', () => {
+    const configMap: Map<string, TokenMetadata> = new Map([
+      ['chain1', { name: TOKEN_NAME, symbol: TOKEN_NAME, decimals: 18 }],
+      ['chain2', { name: TOKEN_NAME, symbol: TOKEN_NAME, decimals: 6 }],
+    ]);
+
+    assert.isFalse(verifyScale(configMap));
+  });
+
+  it('should throw an error if decimals are not defined for a token config', () => {
+    const configMap: Map<string, TokenMetadata> = new Map([
+      ['chain1', { name: TOKEN_NAME, symbol: TOKEN_NAME, decimals: 18 }],
+      ['chain2', { name: TOKEN_NAME, symbol: TOKEN_NAME }],
+    ]);
+
+    assert.throws(
+      () => verifyScale(configMap),
+      'Decimals must be defined for token config on chain chain2',
+    );
+  });
+
+  it('should handle WarpRouteDeployConfigMailboxRequired input type', () => {
+    const config: WarpRouteDeployConfigMailboxRequired = {
+      chain1: {
+        type: TokenType.collateral,
+        token: randomAddress(),
+        owner: randomAddress(),
+        decimals: 18,
+        mailbox: randomAddress(),
+      },
+      chain2: {
+        type: TokenType.collateral,
+        token: randomAddress(),
+        owner: randomAddress(),
+        decimals: 6,
+        scale: 1_000_000_000_000,
+        mailbox: randomAddress(),
+      },
+    };
+    assert.isTrue(verifyScale(config));
+  });
+
+  it('should handle WarpRouteDeployConfigMailboxRequired with uniform decimals', () => {
+    const config: WarpRouteDeployConfigMailboxRequired = {
+      chain1: {
+        type: TokenType.collateral,
+        token: randomAddress(),
+        owner: randomAddress(),
+        decimals: 18,
+        mailbox: randomAddress(),
+      },
+      chain2: {
+        type: TokenType.collateral,
+        token: randomAddress(),
+        owner: randomAddress(),
+        decimals: 18,
+        mailbox: randomAddress(),
+      },
+    };
+    assert.isTrue(verifyScale(config));
+  });
+
+  it('should return false for WarpRouteDeployConfigMailboxRequired with incorrect scale', () => {
+    const config: WarpRouteDeployConfigMailboxRequired = {
+      chain1: {
+        type: TokenType.collateral,
+        token: randomAddress(),
+        owner: randomAddress(),
+        decimals: 18,
+        mailbox: randomAddress(),
+      },
+      chain2: {
+        type: TokenType.collateral,
+        token: randomAddress(),
+        owner: randomAddress(),
+        decimals: 6,
+        scale: 1000,
+        mailbox: randomAddress(),
+      },
+    };
+    assert.isFalse(verifyScale(config));
+  });
+
+  it('should throw an error for WarpRouteDeployConfigMailboxRequired with missing decimals', () => {
+    const config: WarpRouteDeployConfigMailboxRequired = {
+      chain1: {
+        type: TokenType.collateral,
+        token: randomAddress(),
+        owner: randomAddress(),
+        decimals: 18,
+        mailbox: randomAddress(),
+      },
+      chain2: {
+        type: TokenType.collateral,
+        token: randomAddress(),
+        owner: randomAddress(),
+        decimals: undefined,
+        mailbox: randomAddress(),
+      },
+    };
+    assert.throws(
+      () => verifyScale(config),
+      'Decimals must be defined for token config on chain chain2',
+    );
+  });
+});


### PR DESCRIPTION
### Description

This PR adds the required logic in the CLI to output the warp core config to the same folder as the optionally provided warp deploy config (otherwise fallback to write to the registry folder related to the provided warp id)

### Drive-by changes

- Added the `warp-deploy` tests into the ci checks because it seems they were missing
- Fixed bug in decimals config checks that failed to report inconsistencies when working with maps

### Related issues

- Fixes #[ENG-1732](https://linear.app/hyperlane-xyz/issue/ENG-1732/warp-deploy-should-output-artifacts-to-config)

### Backward compatibility

- YES

### Testing

- E2E
- Unit

