### PR TITLE
fix: enforce withdrawal tx sender matches message sender

### DIFF
--- a/solidity/contracts/isms/hook/OPL2ToL1CcipReadIsm.sol
+++ b/solidity/contracts/isms/hook/OPL2ToL1CcipReadIsm.sol
@@ -40,6 +40,7 @@ interface OpL2toL1Service {
 abstract contract OPL2ToL1CcipReadIsm is AbstractCcipReadIsm {
     using Message for bytes;
     using TypeCasts for address;
+    using TypeCasts for bytes32;
     using OPL2ToL1Withdrawal for IOptimismPortal.WithdrawalTransaction;
 
     // the OP Portal contract on L1
@@ -70,9 +71,9 @@ abstract contract OPL2ToL1CcipReadIsm is AbstractCcipReadIsm {
         bytes calldata _message
     ) external override returns (bool) {
         if (_isProve(_message)) {
-            _proveWithdrawal(_message.id(), _metadata);
+            _proveWithdrawal(_message, _metadata);
         } else {
-            _finalizeWithdrawal(_message.id(), _metadata);
+            _finalizeWithdrawal(_message, _metadata);
         }
 
         return true;
@@ -83,7 +84,7 @@ abstract contract OPL2ToL1CcipReadIsm is AbstractCcipReadIsm {
     ) internal view virtual returns (bool);
 
     function _proveWithdrawal(
-        bytes32 messageId,
+        bytes calldata _message,
         bytes calldata _metadata
     ) internal {
         (
@@ -102,7 +103,12 @@ abstract contract OPL2ToL1CcipReadIsm is AbstractCcipReadIsm {
             );
 
         require(
-            _tx.proveMessageId() == messageId,
+            _tx.sender == _message.sender().bytes32ToAddress(),
+            "OPL2ToL1CcipReadIsm: sender mismatch"
+        );
+
+        require(
+            _tx.proveMessageId() == _message.id(),
             "OPL2ToL1CcipReadIsm: prove message id mismatch"
         );
 
@@ -125,7 +131,7 @@ abstract contract OPL2ToL1CcipReadIsm is AbstractCcipReadIsm {
     ) internal view virtual returns (bool);
 
     function _finalizeWithdrawal(
-        bytes32 messageId,
+        bytes calldata _message,
         bytes calldata _metadata
     ) internal {
         IOptimismPortal.WithdrawalTransaction memory _tx = abi.decode(
@@ -134,7 +140,12 @@ abstract contract OPL2ToL1CcipReadIsm is AbstractCcipReadIsm {
         );
 
         require(
-            _tx.finalizeMessageId() == messageId,
+            _tx.sender == _message.sender().bytes32ToAddress(),
+            "OPL2ToL1CcipReadIsm: sender mismatch"
+        );
+
+        require(
+            _tx.finalizeMessageId() == _message.id(),
             "OPL2ToL1CcipReadIsm: finalize message id mismatch"
         );
 


### PR DESCRIPTION
### Description

> In PR #6471, the metadata of the OptimismPortal.WithdrawalTransaction was modified to include two Hyperlane message IDs (proveMessageId and finalizeMessageId). However, this patch allows an attacker to create a separate OP to L1 withdrawal transaction with the same pair of message IDs in the metadata, and execute OPL2ToL1CcipReadIsm.verify() using that forged metadata. In other words, it is possible to use the metadata of a different withdrawal transaction instead of the legitimate one. To address this issue, OPL2ToL1CcipReadIsm.verify() should verify that the _tx.sender() from IOptimismPortal.WithdrawalTransaction matches the sender() of the _message

Fixes this issue by enforcing message sender matches tx sender.

### Backward compatibility

No, requires new deployments

### Testing

Unit Tests
