### PR TITLE
fix: enforce CCTP message matches hyperlane message

### DIFF
--- a/solidity/contracts/libs/CctpMessage.sol
+++ b/solidity/contracts/libs/CctpMessage.sol
@@ -19,13 +19,40 @@ import {TypedMemView} from "./TypedMemView.sol";
 
 // @dev CCTP Message version 1
 // @dev copied from https://github.com/circlefin/evm-cctp-contracts/blob/release-2025-03-11T143015/src/messages/Message.sol
+
+/**
+ * @title Message Library
+ * @notice Library for formatted messages used by Relayer and Receiver.
+ *
+ * @dev The message body is dynamically-sized to support custom message body
+ * formats. Other fields must be fixed-size to avoid hash collisions.
+ * Each other input value has an explicit type to guarantee fixed-size.
+ * Padding: uintNN fields are left-padded, and bytesNN fields are right-padded.
+ *
+ * Field                 Bytes      Type       Index
+ * version               4          uint32     0
+ * sourceDomain          4          uint32     4
+ * destinationDomain     4          uint32     8
+ * nonce                 8          uint64     12
+ * sender                32         bytes32    20
+ * recipient             32         bytes32    52
+ * destinationCaller     32         bytes32    84
+ * messageBody           dynamic    bytes      116
+ *
+ **/
 library CctpMessage {
     using TypedMemView for bytes;
     using TypedMemView for bytes29;
 
     // Indices of each field in message
+    uint8 private constant VERSION_INDEX = 0;
     uint8 private constant SOURCE_DOMAIN_INDEX = 4;
+    uint8 private constant DESTINATION_DOMAIN_INDEX = 8;
     uint8 private constant NONCE_INDEX = 12;
+    uint8 private constant SENDER_INDEX = 20;
+    uint8 private constant RECIPIENT_INDEX = 52;
+    uint8 private constant DESTINATION_CALLER_INDEX = 84;
+    uint8 private constant MESSAGE_BODY_INDEX = 116;
 
     /**
      * @notice Returns formatted (packed) message with provided fields
@@ -62,11 +89,197 @@ library CctpMessage {
             );
     }
 
+    // @notice Returns _message's version field
+    function _version(bytes29 _message) internal pure returns (uint32) {
+        return uint32(_message.indexUint(VERSION_INDEX, 4));
+    }
+
+    // @notice Returns _message's sourceDomain field
     function _sourceDomain(bytes29 _message) internal pure returns (uint32) {
         return uint32(_message.indexUint(SOURCE_DOMAIN_INDEX, 4));
     }
 
+    // @notice Returns _message's destinationDomain field
+    function _destinationDomain(
+        bytes29 _message
+    ) internal pure returns (uint32) {
+        return uint32(_message.indexUint(DESTINATION_DOMAIN_INDEX, 4));
+    }
+
+    // @notice Returns _message's nonce field
     function _nonce(bytes29 _message) internal pure returns (uint64) {
         return uint64(_message.indexUint(NONCE_INDEX, 8));
+    }
+
+    // @notice Returns _message's sender field
+    function _sender(bytes29 _message) internal pure returns (bytes32) {
+        return _message.index(SENDER_INDEX, 32);
+    }
+
+    // @notice Returns _message's recipient field
+    function _recipient(bytes29 _message) internal pure returns (bytes32) {
+        return _message.index(RECIPIENT_INDEX, 32);
+    }
+
+    // @notice Returns _message's destinationCaller field
+    function _destinationCaller(
+        bytes29 _message
+    ) internal pure returns (bytes32) {
+        return _message.index(DESTINATION_CALLER_INDEX, 32);
+    }
+
+    // @notice Returns _message's messageBody field
+    function _messageBody(bytes29 _message) internal pure returns (bytes29) {
+        return
+            _message.slice(
+                MESSAGE_BODY_INDEX,
+                _message.len() - MESSAGE_BODY_INDEX,
+                0
+            );
+    }
+
+    /**
+     * @notice converts address to bytes32 (alignment preserving cast.)
+     * @param addr the address to convert to bytes32
+     */
+    function addressToBytes32(address addr) external pure returns (bytes32) {
+        return bytes32(uint256(uint160(addr)));
+    }
+
+    /**
+     * @notice converts bytes32 to address (alignment preserving cast.)
+     * @dev Warning: it is possible to have different input values _buf map to the same address.
+     * For use cases where this is not acceptable, validate that the first 12 bytes of _buf are zero-padding.
+     * @param _buf the bytes32 to convert to address
+     */
+    function bytes32ToAddress(bytes32 _buf) public pure returns (address) {
+        return address(uint160(uint256(_buf)));
+    }
+
+    /**
+     * @notice Reverts if message is malformed or incorrect length
+     * @param _message The message as bytes29
+     */
+    function _validateMessageFormat(bytes29 _message) internal pure {
+        require(_message.isValid(), "Malformed message");
+        require(
+            _message.len() >= MESSAGE_BODY_INDEX,
+            "Invalid message: too short"
+        );
+    }
+}
+
+// @dev copied from https://raw.githubusercontent.com/circlefin/evm-cctp-contracts/refs/tags/release-2025-03-11T143015/src/messages/BurnMessage.sol
+
+/**
+ * @title BurnMessage Library
+ * @notice Library for formatted BurnMessages used by TokenMessenger.
+ * @dev BurnMessage format:
+ * Field                 Bytes      Type       Index
+ * version               4          uint32     0
+ * burnToken             32         bytes32    4
+ * mintRecipient         32         bytes32    36
+ * amount                32         uint256    68
+ * messageSender         32         bytes32    100
+ **/
+library BurnMessage {
+    using TypedMemView for bytes;
+    using TypedMemView for bytes29;
+
+    uint8 private constant VERSION_INDEX = 0;
+    uint8 private constant VERSION_LEN = 4;
+    uint8 private constant BURN_TOKEN_INDEX = 4;
+    uint8 private constant BURN_TOKEN_LEN = 32;
+    uint8 private constant MINT_RECIPIENT_INDEX = 36;
+    uint8 private constant MINT_RECIPIENT_LEN = 32;
+    uint8 private constant AMOUNT_INDEX = 68;
+    uint8 private constant AMOUNT_LEN = 32;
+    uint8 private constant MSG_SENDER_INDEX = 100;
+    uint8 private constant MSG_SENDER_LEN = 32;
+    // 4 byte version + 32 bytes burnToken + 32 bytes mintRecipient + 32 bytes amount + 32 bytes messageSender
+    uint8 private constant BURN_MESSAGE_LEN = 132;
+
+    /**
+     * @notice Formats Burn message
+     * @param _version The message body version
+     * @param _burnToken The burn token address on source domain as bytes32
+     * @param _mintRecipient The mint recipient address as bytes32
+     * @param _amount The burn amount
+     * @param _messageSender The message sender
+     * @return Burn formatted message.
+     */
+    function _formatMessage(
+        uint32 _version,
+        bytes32 _burnToken,
+        bytes32 _mintRecipient,
+        uint256 _amount,
+        bytes32 _messageSender
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                _version,
+                _burnToken,
+                _mintRecipient,
+                _amount,
+                _messageSender
+            );
+    }
+
+    /**
+     * @notice Retrieves the burnToken from a DepositForBurn BurnMessage
+     * @param _message The message
+     * @return sourceToken address as bytes32
+     */
+    function _getMessageSender(
+        bytes29 _message
+    ) internal pure returns (bytes32) {
+        return _message.index(MSG_SENDER_INDEX, MSG_SENDER_LEN);
+    }
+
+    /**
+     * @notice Retrieves the burnToken from a DepositForBurn BurnMessage
+     * @param _message The message
+     * @return sourceToken address as bytes32
+     */
+    function _getBurnToken(bytes29 _message) internal pure returns (bytes32) {
+        return _message.index(BURN_TOKEN_INDEX, BURN_TOKEN_LEN);
+    }
+
+    /**
+     * @notice Retrieves the mintRecipient from a BurnMessage
+     * @param _message The message
+     * @return mintRecipient
+     */
+    function _getMintRecipient(
+        bytes29 _message
+    ) internal pure returns (bytes32) {
+        return _message.index(MINT_RECIPIENT_INDEX, MINT_RECIPIENT_LEN);
+    }
+
+    /**
+     * @notice Retrieves the amount from a BurnMessage
+     * @param _message The message
+     * @return amount
+     */
+    function _getAmount(bytes29 _message) internal pure returns (uint256) {
+        return _message.indexUint(AMOUNT_INDEX, AMOUNT_LEN);
+    }
+
+    /**
+     * @notice Retrieves the version from a Burn message
+     * @param _message The message
+     * @return version
+     */
+    function _getVersion(bytes29 _message) internal pure returns (uint32) {
+        return uint32(_message.indexUint(VERSION_INDEX, VERSION_LEN));
+    }
+
+    /**
+     * @notice Reverts if burn message is malformed or invalid length
+     * @param _message The burn message as bytes29
+     */
+    function _validateBurnMessageFormat(bytes29 _message) internal pure {
+        require(_message.isValid(), "Malformed message");
+        require(_message.len() == BURN_MESSAGE_LEN, "Invalid message length");
     }
 }

--- a/solidity/contracts/token/TokenBridgeCctp.sol
+++ b/solidity/contracts/token/TokenBridgeCctp.sol
@@ -210,10 +210,8 @@ contract TokenBridgeCctp is HypERC20Collateral, AbstractCcipReadIsm {
             outboundAmount,
             abi.encodePacked(nonce)
         );
-        require(
-            _tokenMessage.length == CCTP_TOKEN_BRIDGE_MESSAGE_LEN,
-            "Invalid message body length"
-        );
+        // sanity check: should only happen if the implementation changes
+        assert(_tokenMessage.length == CCTP_TOKEN_BRIDGE_MESSAGE_LEN);
 
         messageId = _Router_dispatch(
             _destination,

--- a/solidity/contracts/token/TokenBridgeCctp.sol
+++ b/solidity/contracts/token/TokenBridgeCctp.sol
@@ -140,13 +140,16 @@ contract TokenBridgeCctp is HypERC20Collateral, AbstractCcipReadIsm {
             (bytes, bytes)
         );
 
+        bytes calldata tokenMessage = _hyperlaneMessage.body();
+        require(
+            tokenMessage.length == CCTP_TOKEN_BRIDGE_MESSAGE_LEN,
+            "Invalid message body length"
+        );
+
         bytes29 originalMsg = TypedMemView.ref(cctpMessage, 0);
 
         bytes32 sourceSender = originalMsg._sender();
         require(sourceSender == _hyperlaneMessage.sender(), "Invalid sender");
-
-        bytes calldata tokenMessage = _hyperlaneMessage.body();
-        assert(tokenMessage.length == CCTP_TOKEN_BRIDGE_MESSAGE_LEN);
 
         uint64 sourceNonce = originalMsg._nonce();
         require(
@@ -208,7 +211,10 @@ contract TokenBridgeCctp is HypERC20Collateral, AbstractCcipReadIsm {
             outboundAmount,
             abi.encodePacked(nonce)
         );
-        assert(_tokenMessage.length == CCTP_TOKEN_BRIDGE_MESSAGE_LEN);
+        require(
+            _tokenMessage.length == CCTP_TOKEN_BRIDGE_MESSAGE_LEN,
+            "Invalid message body length"
+        );
 
         messageId = _Router_dispatch(
             _destination,

--- a/solidity/contracts/token/TokenBridgeCctp.sol
+++ b/solidity/contracts/token/TokenBridgeCctp.sol
@@ -151,14 +151,7 @@ contract TokenBridgeCctp is HypERC20Collateral, AbstractCcipReadIsm {
         bytes32 sourceSender = originalMsg._sender();
         require(sourceSender == _hyperlaneMessage.sender(), "Invalid sender");
 
-        uint64 sourceNonce = originalMsg._nonce();
-        require(
-            sourceNonce == uint64(bytes8(TokenMessage.metadata(tokenMessage))),
-            "Invalid nonce"
-        );
-
         bytes29 burnMessage = originalMsg._messageBody();
-
         require(
             TokenMessage.amount(tokenMessage) == burnMessage._getAmount(),
             "Invalid amount"
@@ -174,6 +167,12 @@ contract TokenBridgeCctp is HypERC20Collateral, AbstractCcipReadIsm {
             sourceDomain ==
                 hyperlaneDomainToCircleDomain(_hyperlaneMessage.origin()),
             "Invalid source domain"
+        );
+
+        uint64 sourceNonce = originalMsg._nonce();
+        require(
+            sourceNonce == uint64(bytes8(TokenMessage.metadata(tokenMessage))),
+            "Invalid nonce"
         );
 
         // Receive only if the nonce hasn't been used before

--- a/solidity/contracts/token/libs/TokenMessage.sol
+++ b/solidity/contracts/token/libs/TokenMessage.sol
@@ -2,6 +2,10 @@
 pragma solidity >=0.8.0;
 
 library TokenMessage {
+    uint8 internal constant RECIPIENT_OFFSET = 0;
+    uint8 internal constant AMOUNT_OFFSET = 32;
+    uint8 internal constant METADATA_OFFSET = 64;
+
     function format(
         bytes32 _recipient,
         uint256 _amount,
@@ -18,11 +22,11 @@ library TokenMessage {
     }
 
     function recipient(bytes calldata message) internal pure returns (bytes32) {
-        return bytes32(message[0:32]);
+        return bytes32(message[RECIPIENT_OFFSET:RECIPIENT_OFFSET + 32]);
     }
 
     function amount(bytes calldata message) internal pure returns (uint256) {
-        return uint256(bytes32(message[32:64]));
+        return uint256(bytes32(message[AMOUNT_OFFSET:AMOUNT_OFFSET + 32]));
     }
 
     // alias for ERC721
@@ -33,6 +37,6 @@ library TokenMessage {
     function metadata(
         bytes calldata message
     ) internal pure returns (bytes calldata) {
-        return message[64:];
+        return message[METADATA_OFFSET:];
     }
 }

--- a/solidity/test/token/TokenBridgeCctp.t.sol
+++ b/solidity/test/token/TokenBridgeCctp.t.sol
@@ -19,7 +19,7 @@ import {ITokenMessenger} from "../../contracts/interfaces/cctp/ITokenMessenger.s
 import {ITokenMessengerV2} from "../../contracts/interfaces/cctp/ITokenMessengerV2.sol";
 import {TokenRouter} from "../../contracts/token/libs/TokenRouter.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {CctpMessage} from "../../contracts/libs/CctpMessage.sol";
+import {CctpMessage, BurnMessage} from "../../contracts/libs/CctpMessage.sol";
 import {Message} from "../../contracts/libs/Message.sol";
 import {CctpService} from "../../contracts/token/TokenBridgeCctp.sol";
 
@@ -141,18 +141,43 @@ contract TokenBridgeCctpTest is Test {
     function _encodeCctpMessage(
         uint64 nonce,
         uint32 sourceDomain,
-        bytes memory body
+        bytes32 recipient,
+        uint256 amount
     ) internal view returns (bytes memory) {
+        return
+            _encodeCctpMessage(
+                nonce,
+                sourceDomain,
+                recipient,
+                amount,
+                address(tbOrigin)
+            );
+    }
+
+    function _encodeCctpMessage(
+        uint64 nonce,
+        uint32 sourceDomain,
+        bytes32 recipient,
+        uint256 amount,
+        address sender
+    ) internal view returns (bytes memory) {
+        bytes memory burnMessage = BurnMessage._formatMessage(
+            version,
+            address(tokenOrigin).addressToBytes32(),
+            recipient,
+            amount,
+            sender.addressToBytes32()
+        );
         return
             CctpMessage._formatMessage(
                 version,
                 sourceDomain,
                 cctpDestination,
                 nonce,
-                address(tbOrigin).addressToBytes32(),
+                sender.addressToBytes32(),
                 address(tbDestination).addressToBytes32(),
                 bytes32(0),
-                body
+                burnMessage
             );
     }
 
@@ -214,9 +239,10 @@ contract TokenBridgeCctpTest is Test {
     }
 
     function test_verify() public {
+        bytes32 recipient = user.addressToBytes32();
         Quote[] memory quote = tbOrigin.quoteTransferRemote(
             destination,
-            user.addressToBytes32(),
+            recipient,
             amount
         );
 
@@ -226,7 +252,7 @@ contract TokenBridgeCctpTest is Test {
         uint64 cctpNonce = tokenMessengerOrigin.nextNonce();
         tbOrigin.transferRemote{value: quote[0].amount}(
             destination,
-            user.addressToBytes32(),
+            recipient,
             amount
         );
 
@@ -238,7 +264,8 @@ contract TokenBridgeCctpTest is Test {
         bytes memory cctpMessage = _encodeCctpMessage(
             cctpNonce,
             cctpOrigin,
-            ""
+            recipient,
+            amount
         );
         bytes memory attestation = bytes("");
         bytes memory metadata = abi.encode(cctpMessage, attestation);
@@ -254,9 +281,11 @@ contract TokenBridgeCctpTest is Test {
     }
 
     function test_verify_revertsWhen_invalidNonce() public {
+        bytes32 recipient = user.addressToBytes32();
+
         Quote[] memory quote = tbOrigin.quoteTransferRemote(
             destination,
-            user.addressToBytes32(),
+            recipient,
             amount
         );
 
@@ -267,12 +296,17 @@ contract TokenBridgeCctpTest is Test {
         uint64 badNonce = tokenMessengerOrigin.nextNonce() + 1;
         tbOrigin.transferRemote{value: quote[0].amount}(
             destination,
-            user.addressToBytes32(),
+            recipient,
             amount
         );
         bytes memory message = mailboxDestination.inboundMessages(0);
 
-        bytes memory cctpMessage = _encodeCctpMessage(badNonce, cctpOrigin, "");
+        bytes memory cctpMessage = _encodeCctpMessage(
+            badNonce,
+            cctpOrigin,
+            recipient,
+            amount
+        );
         bytes memory attestation = bytes("");
         bytes memory metadata = abi.encode(cctpMessage, attestation);
 
@@ -281,9 +315,11 @@ contract TokenBridgeCctpTest is Test {
     }
 
     function test_verify_revertsWhen_invalidSourceDomain() public {
+        bytes32 recipient = user.addressToBytes32();
+
         Quote[] memory quote = tbOrigin.quoteTransferRemote(
             destination,
-            user.addressToBytes32(),
+            recipient,
             amount
         );
 
@@ -293,7 +329,7 @@ contract TokenBridgeCctpTest is Test {
         uint64 cctpNonce = tokenMessengerOrigin.nextNonce();
         tbOrigin.transferRemote{value: quote[0].amount}(
             destination,
-            user.addressToBytes32(),
+            recipient,
             amount
         );
         bytes memory message = mailboxDestination.inboundMessages(0);
@@ -303,13 +339,151 @@ contract TokenBridgeCctpTest is Test {
         bytes memory cctpMessage = _encodeCctpMessage(
             cctpNonce,
             badSourceDomain,
-            ""
+            recipient,
+            amount
         );
         bytes memory attestation = bytes("");
         bytes memory metadata = abi.encode(cctpMessage, attestation);
 
         vm.expectRevert(bytes("Invalid source domain"));
         tbDestination.verify(metadata, message);
+    }
+
+    function test_verify_revertsWhen_invalidAmount() public {
+        bytes32 recipient = user.addressToBytes32();
+        Quote[] memory quote = tbOrigin.quoteTransferRemote(
+            destination,
+            recipient,
+            amount
+        );
+
+        vm.startPrank(user);
+        tokenOrigin.approve(address(tbOrigin), quote[1].amount);
+
+        uint64 cctpNonce = tokenMessengerOrigin.nextNonce();
+        tbOrigin.transferRemote{value: quote[0].amount}(
+            destination,
+            recipient,
+            amount
+        );
+        bytes memory message = mailboxDestination.inboundMessages(0);
+
+        // invalid amount := amount + 1
+        uint256 badAmount = amount + 1;
+        bytes memory cctpMessage = _encodeCctpMessage(
+            cctpNonce,
+            cctpOrigin,
+            recipient,
+            badAmount
+        );
+        bytes memory attestation = bytes("");
+        bytes memory metadata = abi.encode(cctpMessage, attestation);
+
+        vm.expectRevert(bytes("Invalid amount"));
+        tbDestination.verify(metadata, message);
+    }
+
+    function test_verify_revertsWhen_invalidRecipient() public {
+        bytes32 recipient = user.addressToBytes32();
+        Quote[] memory quote = tbOrigin.quoteTransferRemote(
+            destination,
+            recipient,
+            amount
+        );
+
+        vm.startPrank(user);
+        tokenOrigin.approve(address(tbOrigin), quote[1].amount);
+
+        uint64 cctpNonce = tokenMessengerOrigin.nextNonce();
+        tbOrigin.transferRemote{value: quote[0].amount}(
+            destination,
+            recipient,
+            amount
+        );
+        bytes memory message = mailboxDestination.inboundMessages(0);
+
+        // invalid recipient := evil
+        bytes32 badRecipient = evil.addressToBytes32();
+        bytes memory cctpMessage = _encodeCctpMessage(
+            cctpNonce,
+            cctpOrigin,
+            badRecipient,
+            amount
+        );
+        bytes memory attestation = bytes("");
+        bytes memory metadata = abi.encode(cctpMessage, attestation);
+
+        vm.expectRevert(bytes("Invalid recipient"));
+        tbDestination.verify(metadata, message);
+    }
+
+    function test_verify_revertsWhen_invalidSender() public {
+        bytes32 recipient = user.addressToBytes32();
+        Quote[] memory quote = tbOrigin.quoteTransferRemote(
+            destination,
+            recipient,
+            amount
+        );
+
+        vm.startPrank(user);
+        tokenOrigin.approve(address(tbOrigin), quote[1].amount);
+
+        uint64 cctpNonce = tokenMessengerOrigin.nextNonce();
+        tbOrigin.transferRemote{value: quote[0].amount}(
+            destination,
+            recipient,
+            amount
+        );
+        bytes memory message = mailboxDestination.inboundMessages(0);
+
+        // invalid sender := evil
+        bytes memory cctpMessage = _encodeCctpMessage(
+            cctpNonce,
+            cctpOrigin,
+            recipient,
+            amount,
+            evil
+        );
+        bytes memory attestation = bytes("");
+        bytes memory metadata = abi.encode(cctpMessage, attestation);
+
+        vm.expectRevert(bytes("Invalid sender"));
+        tbDestination.verify(metadata, message);
+    }
+
+    function test_verify_revertsWhen_invalidLength() public {
+        bytes32 recipient = user.addressToBytes32();
+        Quote[] memory quote = tbOrigin.quoteTransferRemote(
+            destination,
+            recipient,
+            amount
+        );
+
+        vm.startPrank(user);
+        tokenOrigin.approve(address(tbOrigin), quote[1].amount);
+
+        uint64 cctpNonce = tokenMessengerOrigin.nextNonce();
+        tbOrigin.transferRemote{value: quote[0].amount}(
+            destination,
+            recipient,
+            amount
+        );
+        bytes memory message = mailboxDestination.inboundMessages(0);
+
+        bytes memory cctpMessage = _encodeCctpMessage(
+            cctpNonce,
+            cctpOrigin,
+            recipient,
+            amount
+        );
+        bytes memory attestation = bytes("");
+        bytes memory metadata = abi.encode(cctpMessage, attestation);
+
+        // a message with invalid length.
+        bytes memory badMessage = bytes.concat(message, bytes1(uint8(60)));
+
+        vm.expectRevert();
+        tbDestination.verify(metadata, badMessage);
     }
 
     function test_revertsWhen_versionIsNotSupported() public virtual {


### PR DESCRIPTION
### Description

> In #6386 PR, the patch still allows a 1:N mapping between CCTP messages and Hyperlane messages. For example, verify() does not check whether the length of _hyperlaneMessage.body().metadata() is exactly 8 bytes. If it is longer than 8 bytes, it will automatically be truncated to bytes8, discarding the trailing bytes. This allows malformed metadata values to pass through verify() as if they were valid. Additionally, other parts of _hyperlaneMessage.body() such as amount, recipient, and even _hyperlaneMessage.sender() can be manipulated.

Fixes this issue by checking all fields match.

### Backward compatibility

Requires new CCTP deploy

### Testing

Unit Tests
