### PR TITLE
fix: Revert in TokenBridgeCctp if parent initialize is called

### DIFF
--- a/solidity/contracts/token/TokenBridgeCctp.sol
+++ b/solidity/contracts/token/TokenBridgeCctp.sol
@@ -90,7 +90,7 @@ contract TokenBridgeCctp is HypERC20Collateral, AbstractCcipReadIsm {
         address _interchainSecurityModule,
         address _owner
     ) public override {
-        revert("Only one initialize() function is allowed");
+        revert("Only TokenBridgeCctp.initialize() may be called");
     }
 
     function interchainSecurityModule()

--- a/solidity/contracts/token/TokenBridgeCctp.sol
+++ b/solidity/contracts/token/TokenBridgeCctp.sol
@@ -85,6 +85,14 @@ contract TokenBridgeCctp is HypERC20Collateral, AbstractCcipReadIsm {
         wrappedToken.approve(address(tokenMessenger), type(uint256).max);
     }
 
+    function initialize(
+        address _hook,
+        address _interchainSecurityModule,
+        address _owner
+    ) public override {
+        revert("Only one initialize() function is allowed");
+    }
+
     function interchainSecurityModule()
         external
         view

--- a/solidity/test/token/TokenBridgeCctp.t.sol
+++ b/solidity/test/token/TokenBridgeCctp.t.sol
@@ -398,7 +398,7 @@ contract TokenBridgeCctpTest is Test {
     }
 
     function test_parent_initialize_reverts() public {
-        vm.expectRevert("Only one initialize() function is allowed");
+        vm.expectRevert("Only TokenBridgeCctp.initialize() may be called");
         tbOrigin.initialize(address(0), address(0), address(0));
     }
 }


### PR DESCRIPTION
### Description

For safety, we want to make sure that each contract only has one initializer. 