### PR TITLE
chore(infra): normalise before checking warp config equality

### DIFF
--- a/typescript/infra/test/warp-configs.test.ts
+++ b/typescript/infra/test/warp-configs.test.ts
@@ -7,6 +7,7 @@ import {
   HypTokenRouterConfig,
   MultiProvider,
   WarpRouteDeployConfig,
+  normalizeConfig,
 } from '@hyperlane-xyz/sdk';
 import { assert, rootLogger } from '@hyperlane-xyz/utils';
 
@@ -80,7 +81,9 @@ describe('Warp Configs', async function () {
       expect(warpConfig).to.have.keys(Object.keys(expectedConfig));
       for (const key in warpConfig) {
         if (warpConfig[key]) {
-          expect(warpConfig[key]).to.deep.equal(expectedConfig[key]);
+          expect(normalizeConfig(warpConfig[key])).to.deep.equal(
+            normalizeConfig(expectedConfig[key]),
+          );
         }
       }
     });


### PR DESCRIPTION
### Description

chore(infra): normalise before checking warp config equality
- so that we don't flag up mismatch in ordering between infra/registry

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

tested with https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/6358
- https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/15539520388/job/43747085969?pr=6358