### PR TITLE
feat: add initialDeploy config to enable inner hook recovery for aggregates

### DIFF
--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -54,6 +54,7 @@ import {
 import {
   ProtocolType,
   assert,
+  deepCopy,
   objMap,
   promiseObjAll,
   retryAsync,
@@ -458,7 +459,7 @@ async function updateExistingWarpRoute(
 
   const expandedWarpDeployConfig = await expandWarpDeployConfig({
     multiProvider,
-    warpDeployConfig,
+    warpDeployConfig: deepCopy(warpDeployConfig),
     deployedRoutersAddresses,
   });
 
@@ -480,7 +481,7 @@ async function updateExistingWarpRoute(
         const evmERC20WarpModule = new EvmERC20WarpModule(
           multiProvider,
           {
-            config: configWithMailbox,
+            config: warpDeployConfig[chain],
             chain,
             addresses: {
               deployedTokenRoute,

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -459,7 +459,7 @@ async function updateExistingWarpRoute(
 
   const expandedWarpDeployConfig = await expandWarpDeployConfig({
     multiProvider,
-    warpDeployConfig: deepCopy(warpDeployConfig),
+    warpDeployConfig: deepCopy(warpDeployConfig), // Need to be copied because expandWarpDeployConfig mutates
     deployedRoutersAddresses,
   });
 

--- a/typescript/sdk/src/core/AbstractHyperlaneModule.ts
+++ b/typescript/sdk/src/core/AbstractHyperlaneModule.ts
@@ -20,10 +20,12 @@ export abstract class HyperlaneModule<
   TAddressMap extends Record<string, any>,
 > {
   protected abstract readonly logger: Logger;
-
+  protected readonly initialConfig: TConfig;
   protected constructor(
     protected readonly args: HyperlaneModuleParams<TConfig, TAddressMap>,
-  ) {}
+  ) {
+    this.initialConfig = this.args.config;
+  }
 
   public serialize(): TAddressMap {
     return this.args.addresses;

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -174,7 +174,7 @@ export class EvmHookModule extends HyperlaneModule<
       this.shouldDeployNewHook(normalizedCurrentConfig, normalizedTargetConfig)
     ) {
       const contract = await this.deploy({
-        config: normalizedTargetConfig,
+        config: this.initialConfig,
       });
 
       this.args.addresses.deployedHook = contract.address;

--- a/typescript/sdk/src/token/EvmERC20WarpModule.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.ts
@@ -510,7 +510,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
       this.multiProvider,
       {
         chain: this.args.chain,
-        config: this.initialConfig.hook!,
+        config: this.initialConfig.hook || expectedConfig.hook,
         addresses: {
           ...extractIsmAndHookFactoryAddresses(this.args.addresses),
           mailbox: actualConfig.mailbox,

--- a/typescript/sdk/src/token/EvmERC20WarpModule.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.ts
@@ -510,7 +510,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
       this.multiProvider,
       {
         chain: this.args.chain,
-        config: actualConfig.hook,
+        config: this.initialConfig.hook!,
         addresses: {
           ...extractIsmAndHookFactoryAddresses(this.args.addresses),
           mailbox: actualConfig.mailbox,

--- a/typescript/sdk/src/token/EvmERC20WarpModule.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.ts
@@ -510,7 +510,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
       this.multiProvider,
       {
         chain: this.args.chain,
-        config: this.initialConfig.hook || expectedConfig.hook,
+        config: this.initialConfig.hook || actualConfig.hook,
         addresses: {
           ...extractIsmAndHookFactoryAddresses(this.args.addresses),
           mailbox: actualConfig.mailbox,


### PR DESCRIPTION
### Description
Problem: when we have an aggregate hook with some address ([example: EZETH uses a defaultHook address](https://github.com/hyperlane-xyz/hyperlane-registry/blob/main/deployments/warp_routes/EZETH/renzo-prod-deploy.yaml#L5)), we derive the expectedConfig before passing it into WarpModule. This is fine when looking for a diff (e.g. `warp check`) because we use this to compare the derived actualConfig. 

However, this is problematic when we add a new config to the aggregate triggering a redeployment. This ends up using the derived config and unintentionally deploys a new default hook. There is no way to signal to `warp apply` to "keep" a hook.

This PR introduces `initialConfig` which is intended to store the raw deploy config. This allows us to do something like this

```yaml
hook:
    hooks:
      - "0x6EFB7Fd2934db70dA2521Edc5AE5e5FcC59EaBB1" // defaultHook
      - "0x7937CB2886f01F38210506491A69B0D107Ea0ad9" // protocolHook
      - type: domainRouting // <----New hook added here
         .... 
    type: aggregationHook
```

which will deploy a new aggregateHook with domainRouting, but keep the 2 existing hooks.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
