### PR TITLE
fix: make starknet signer key optional

### DIFF
--- a/rust/main/chains/hyperlane-starknet/src/ism/aggregation_ism.rs
+++ b/rust/main/chains/hyperlane-starknet/src/ism/aggregation_ism.rs
@@ -34,11 +34,9 @@ impl StarknetAggregationIsm {
     pub async fn new(
         conn: &ConnectionConf,
         locator: &ContractLocator<'_>,
-        signer: Signer,
+        signer: Option<Signer>,
     ) -> ChainResult<Self> {
-        let account =
-            build_single_owner_account(&conn.url, signer.local_wallet(), &signer.address, false)
-                .await?;
+        let account = build_single_owner_account(&conn.url, signer).await?;
 
         let ism_address: FieldElement = HyH256(locator.address)
             .try_into()

--- a/rust/main/chains/hyperlane-starknet/src/ism/interchain_security_module.rs
+++ b/rust/main/chains/hyperlane-starknet/src/ism/interchain_security_module.rs
@@ -35,11 +35,9 @@ impl StarknetInterchainSecurityModule {
     pub async fn new(
         conn: &ConnectionConf,
         locator: &ContractLocator<'_>,
-        signer: Signer,
+        signer: Option<Signer>,
     ) -> ChainResult<Self> {
-        let account =
-            build_single_owner_account(&conn.url, signer.local_wallet(), &signer.address, false)
-                .await?;
+        let account = build_single_owner_account(&conn.url, signer).await?;
 
         let ism_address: FieldElement = HyH256(locator.address)
             .try_into()

--- a/rust/main/chains/hyperlane-starknet/src/ism/multisig_ism.rs
+++ b/rust/main/chains/hyperlane-starknet/src/ism/multisig_ism.rs
@@ -32,11 +32,9 @@ impl StarknetMultisigIsm {
     pub async fn new(
         conn: &ConnectionConf,
         locator: &ContractLocator<'_>,
-        signer: Signer,
+        signer: Option<Signer>,
     ) -> ChainResult<Self> {
-        let account =
-            build_single_owner_account(&conn.url, signer.local_wallet(), &signer.address, false)
-                .await?;
+        let account = build_single_owner_account(&conn.url, signer).await?;
 
         let ism_address: FieldElement = HyH256(locator.address)
             .try_into()

--- a/rust/main/chains/hyperlane-starknet/src/ism/routing_ism.rs
+++ b/rust/main/chains/hyperlane-starknet/src/ism/routing_ism.rs
@@ -32,11 +32,9 @@ impl StarknetRoutingIsm {
     pub async fn new(
         conn: &ConnectionConf,
         locator: &ContractLocator<'_>,
-        signer: Signer,
+        signer: Option<Signer>,
     ) -> ChainResult<Self> {
-        let account =
-            build_single_owner_account(&conn.url, signer.local_wallet(), &signer.address, false)
-                .await?;
+        let account = build_single_owner_account(&conn.url, signer).await?;
 
         let ism_address: FieldElement = HyH256(locator.address)
             .try_into()

--- a/rust/main/chains/hyperlane-starknet/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-starknet/src/mailbox.rs
@@ -43,15 +43,9 @@ impl StarknetMailbox {
     pub async fn new(
         conn: &ConnectionConf,
         locator: &ContractLocator<'_>,
-        signer: Signer,
+        signer: Option<Signer>,
     ) -> ChainResult<Self> {
-        let account = build_single_owner_account(
-            &conn.url,
-            signer.local_wallet(),
-            &signer.address,
-            signer.is_legacy,
-        )
-        .await?;
+        let account = build_single_owner_account(&conn.url, signer).await?;
 
         let mailbox_address: FieldElement = HyH256(locator.address)
             .try_into()

--- a/rust/main/chains/hyperlane-starknet/src/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-starknet/src/merkle_tree_hook.rs
@@ -47,11 +47,9 @@ impl StarknetMerkleTreeHook {
     pub async fn new(
         conn: &ConnectionConf,
         locator: &ContractLocator<'_>,
-        signer: Signer,
+        signer: Option<Signer>,
     ) -> ChainResult<Self> {
-        let account =
-            build_single_owner_account(&conn.url, signer.local_wallet(), &signer.address, false)
-                .await?;
+        let account = build_single_owner_account(&conn.url, signer).await?;
 
         let hook_address: FieldElement = HyH256(locator.address)
             .try_into()

--- a/rust/main/chains/hyperlane-starknet/src/signers.rs
+++ b/rust/main/chains/hyperlane-starknet/src/signers.rs
@@ -67,3 +67,15 @@ impl Signer {
         ))
     }
 }
+
+impl Default for Signer {
+    fn default() -> Self {
+        // default signer is just all zeros
+        Self {
+            signing_key: SigningKey::from_secret_scalar(FieldElement::ZERO),
+            address: Default::default(),
+            is_legacy: Default::default(),
+            address_h256: Default::default(),
+        }
+    }
+}

--- a/rust/main/chains/hyperlane-starknet/src/utils.rs
+++ b/rust/main/chains/hyperlane-starknet/src/utils.rs
@@ -24,6 +24,7 @@ use crate::contracts::{
     validator_announce,
 };
 use crate::types::{tx_receipt_to_outcome, HyH256};
+use crate::Signer;
 use crate::{
     contracts::{interchain_security_module::ModuleType as StarknetModuleType, mailbox::Message},
     HyperlaneStarknetError,
@@ -71,27 +72,29 @@ pub async fn get_transaction_receipt(
 /// * `is_legacy` - Whether the account is legacy (Cairo 0) or not.
 pub async fn build_single_owner_account(
     rpc_url: &Url,
-    signer: LocalWallet,
-    account_address: &FieldElement,
-    is_legacy: bool,
+    signer: Option<Signer>,
 ) -> ChainResult<SingleOwnerAccount<AnyProvider, LocalWallet>> {
     let rpc_client =
         AnyProvider::JsonRpcHttp(JsonRpcClient::new(HttpTransport::new(rpc_url.clone())));
-
-    let execution_encoding = if is_legacy {
-        starknet::accounts::ExecutionEncoding::Legacy
-    } else {
-        starknet::accounts::ExecutionEncoding::New
-    };
 
     let chain_id = rpc_client.chain_id().await.map_err(|_| {
         ChainCommunicationError::from_other_str("Failed to get chain id from rpc client")
     })?;
 
+    // fallback to the default signer, as the starknet SDK requires the SignleOwnerAccount
+    // and therefore a signer to perform state queries
+    let signer = signer.unwrap_or_else(Signer::default);
+
+    let execution_encoding = if signer.is_legacy {
+        starknet::accounts::ExecutionEncoding::Legacy
+    } else {
+        starknet::accounts::ExecutionEncoding::New
+    };
+
     Ok(SingleOwnerAccount::new(
         rpc_client,
-        signer,
-        *account_address,
+        signer.local_wallet(),
+        signer.address,
         chain_id,
         execution_encoding,
     ))

--- a/rust/main/chains/hyperlane-starknet/src/utils.rs
+++ b/rust/main/chains/hyperlane-starknet/src/utils.rs
@@ -83,7 +83,7 @@ pub async fn build_single_owner_account(
 
     // fallback to the default signer, as the starknet SDK requires the SignleOwnerAccount
     // and therefore a signer to perform state queries
-    let signer = signer.unwrap_or_else(Signer::default);
+    let signer = signer.unwrap_or_default();
 
     let execution_encoding = if signer.is_legacy {
         starknet::accounts::ExecutionEncoding::Legacy

--- a/rust/main/chains/hyperlane-starknet/src/validator_announce.rs
+++ b/rust/main/chains/hyperlane-starknet/src/validator_announce.rs
@@ -48,15 +48,9 @@ impl StarknetValidatorAnnounce {
     pub async fn new(
         conn: &ConnectionConf,
         locator: &ContractLocator<'_>,
-        signer: Signer,
+        signer: Option<Signer>,
     ) -> ChainResult<Self> {
-        let account = build_single_owner_account(
-            &conn.url,
-            signer.local_wallet(),
-            &signer.address,
-            signer.is_legacy,
-        )
-        .await?;
+        let account = build_single_owner_account(&conn.url, signer).await?;
 
         let va_address: FieldElement = HyH256(locator.address)
             .try_into()

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -1116,10 +1116,8 @@ impl ChainConf {
         self.signer().await
     }
 
-    async fn starknet_signer(&self) -> Result<h_starknet::Signer> {
-        self.signer()
-            .await?
-            .ok_or_else(|| eyre!("Starknet requires a signer to construct contract instances"))
+    async fn starknet_signer(&self) -> Result<Option<h_starknet::Signer>> {
+        self.signer().await
     }
 
     async fn cosmos_native_signer(&self) -> Result<Option<h_cosmos_native::Signer>> {


### PR DESCRIPTION
### Description
Make signer optional for starknet protocol chains
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a default signer that is automatically used when no signer is provided.

- **Refactor**
  - Updated various components to accept an optional signer instead of requiring one.
  - Simplified account creation and initialization by handling the absence of a signer gracefully.

- **Bug Fixes**
  - Improved handling of cases where signer information is missing, reducing errors and improving robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->