### PR TITLE
feat: warp init with config hydration

### DIFF
--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -77,6 +77,7 @@ export const warpCommand: CommandModule = {
 
 export const apply: CommandModuleWithWarpApplyContext<{
   config?: string;
+  actualConfigPath?: string;
   warp?: string;
   symbol?: string;
   warpRouteId?: string;
@@ -87,6 +88,12 @@ export const apply: CommandModuleWithWarpApplyContext<{
   describe: 'Update Warp Route contracts',
   builder: {
     config: warpDeploymentConfigCommandOption,
+    actualConfigPath: {
+      type: 'string',
+      description:
+        'A path to a JSON or YAML file with a derived warp route deployment config (warp read).',
+      demandOption: false,
+    },
     warpRouteId: warpRouteIdCommandOption,
     warp: {
       ...warpCoreConfigCommandOption,
@@ -109,6 +116,7 @@ export const apply: CommandModuleWithWarpApplyContext<{
     strategy: strategyUrl,
     receiptsDir,
     warpRouteId,
+    actualConfigPath,
   }) => {
     logCommandHeader('Hyperlane Warp Apply');
 
@@ -120,6 +128,7 @@ export const apply: CommandModuleWithWarpApplyContext<{
       // Already fetched in the resolveWarpApplyChains
       warpDeployConfig: context.warpDeployConfig,
       warpCoreConfig: context.warpCoreConfig,
+      actualWarpDeployConfigPath: actualConfigPath,
       strategyUrl,
       receiptsDir,
       warpRouteId,

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -347,8 +347,8 @@ export async function runWarpRouteApply(
       params,
       apiKeys,
       warpDeployConfig,
-      warpCoreConfig: updatedWarpCoreConfig,
       actualWarpDeployConfig,
+      warpCoreConfig: updatedWarpCoreConfig,
     },
   );
 

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -16,6 +16,7 @@ import {
   ChainSubmissionStrategy,
   ChainSubmissionStrategySchema,
   ContractVerifier,
+  DerivedWarpRouteDeployConfig,
   EvmERC20WarpModule,
   ExplorerLicenseType,
   HypERC20Deployer,
@@ -62,7 +63,14 @@ import {
 import { MINIMUM_WARP_DEPLOY_GAS } from '../consts.js';
 import { requestAndSaveApiKeys } from '../context/context.js';
 import { WriteCommandContext } from '../context/types.js';
-import { log, logBlue, logGray, logGreen, logTable } from '../logger.js';
+import {
+  log,
+  logBlue,
+  logGray,
+  logGreen,
+  logTable,
+  warnYellow,
+} from '../logger.js';
 import { getSubmitterBuilder } from '../submit/submit.js';
 import {
   indentYamlOrJson,
@@ -84,6 +92,7 @@ interface DeployParams {
 
 interface WarpApplyParams extends DeployParams {
   warpCoreConfig: WarpCoreConfig;
+  actualWarpDeployConfigPath?: string;
   strategyUrl?: string;
   receiptsDir: string;
   warpRouteId?: string;
@@ -293,7 +302,12 @@ function fullyConnectTokens(warpCoreConfig: WarpCoreConfig): void {
 export async function runWarpRouteApply(
   params: WarpApplyParams,
 ): Promise<void> {
-  const { warpDeployConfig, warpCoreConfig, context } = params;
+  const {
+    warpDeployConfig,
+    actualWarpDeployConfigPath,
+    warpCoreConfig,
+    context,
+  } = params;
   const { chainMetadata, skipConfirmation } = context;
 
   WarpRouteDeployConfigSchema.parse(warpDeployConfig);
@@ -316,12 +330,26 @@ export async function runWarpRouteApply(
     warpCoreConfig,
   );
 
+  // Try to read the actualWarpDeployConfig path
+  let actualWarpDeployConfig: DerivedWarpRouteDeployConfig | undefined;
+  if (actualWarpDeployConfigPath) {
+    actualWarpDeployConfig = readYamlOrJson<DerivedWarpRouteDeployConfig>(
+      actualWarpDeployConfigPath,
+    );
+
+    // TODO: add DerivedWarpRouteDeployConfigSchema.parse() when available
+    WarpRouteDeployConfigSchema.parse(actualWarpDeployConfig);
+  }
+
   // Then create and submit update transactions
   const transactions: AnnotatedEV5Transaction[] = await updateExistingWarpRoute(
-    params,
-    apiKeys,
-    warpDeployConfig,
-    updatedWarpCoreConfig,
+    {
+      params,
+      apiKeys,
+      warpDeployConfig,
+      warpCoreConfig: updatedWarpCoreConfig,
+      actualWarpDeployConfig,
+    },
   );
 
   if (transactions.length == 0)
@@ -433,13 +461,21 @@ export async function extendWarpRoute(
 }
 
 // Updates Warp routes with new configurations.
-async function updateExistingWarpRoute(
-  params: WarpApplyParams,
-  apiKeys: ChainMap<string>,
-  warpDeployConfig: WarpRouteDeployConfigMailboxRequired,
-  warpCoreConfig: WarpCoreConfig,
-) {
+async function updateExistingWarpRoute(updateParams: {
+  params: WarpApplyParams;
+  apiKeys: ChainMap<string>;
+  warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
+  warpCoreConfig: WarpCoreConfig;
+  actualWarpDeployConfig?: DerivedWarpRouteDeployConfig;
+}) {
   logBlue('Updating deployed Warp Routes');
+  const {
+    params,
+    apiKeys,
+    warpDeployConfig,
+    warpCoreConfig,
+    actualWarpDeployConfig,
+  } = updateParams;
   const { multiProvider, registry } = params.context;
   const registryAddresses =
     (await registry.getAddresses()) as ChainMap<ChainAddresses>;
@@ -490,8 +526,12 @@ async function updateExistingWarpRoute(
           ccipContractCache,
           contractVerifier,
         );
+
+        const actualConfig = actualWarpDeployConfig?.[chain];
+        if (actualConfig) warnYellow(`Using cached config for chain ${chain}!`);
+
         transactions.push(
-          ...(await evmERC20WarpModule.update(configWithMailbox)),
+          ...(await evmERC20WarpModule.update(configWithMailbox, actualConfig)),
         );
       });
     }),

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -67,6 +67,7 @@ import {
   AmountRoutingHookConfig,
   ArbL2ToL1HookConfig,
   CCIPHookConfig,
+  DerivedHookConfig,
   DomainRoutingHookConfig,
   FallbackRoutingHookConfig,
   HookConfig,
@@ -149,6 +150,7 @@ export class EvmHookModule extends HyperlaneModule<
 
   public async update(
     targetConfig: HookConfig,
+    actualConfig?: DerivedHookConfig,
   ): Promise<AnnotatedEV5Transaction[]> {
     // Nothing to do if its the default hook
     if (targetConfig === zeroAddress) {
@@ -162,7 +164,9 @@ export class EvmHookModule extends HyperlaneModule<
     this.args.config = targetConfig;
 
     // We need to normalize the current and target configs to compare.
-    const normalizedCurrentConfig = normalizeConfig(await this.read());
+    const normalizedCurrentConfig = normalizeConfig(
+      actualConfig ?? (await this.read()),
+    );
     const normalizedTargetConfig = normalizeConfig(targetConfig);
 
     // If configs match, no updates needed

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -96,6 +96,7 @@ export class EvmIsmModule extends HyperlaneModule<
   // whoever calls update() needs to ensure that targetConfig has a valid owner
   public async update(
     targetConfig: IsmConfig,
+    actualConfig?: IsmConfig,
   ): Promise<AnnotatedEV5Transaction[]> {
     targetConfig = IsmConfigSchema.parse(targetConfig);
 
@@ -108,7 +109,7 @@ export class EvmIsmModule extends HyperlaneModule<
 
     // save current config for comparison
     // normalize the config to ensure it's in a consistent format for comparison
-    const currentConfig = normalizeConfig(await this.read());
+    const currentConfig = normalizeConfig(actualConfig ?? (await this.read()));
     // Update the config
     this.args.config = targetConfig;
     targetConfig = normalizeConfig(targetConfig);

--- a/typescript/sdk/src/token/EvmERC20WarpModule.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.ts
@@ -46,6 +46,7 @@ import {
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
 import { ExplorerLicenseType } from '../deploy/verify/types.js';
 import { EvmHookModule } from '../hook/EvmHookModule.js';
+import { DerivedHookConfig } from '../hook/types.js';
 import { EvmIsmModule } from '../ism/EvmIsmModule.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
@@ -140,9 +141,11 @@ export class EvmERC20WarpModule extends HyperlaneModule<
    */
   async update(
     expectedConfig: HypTokenRouterConfig,
+    actualWarpConfig?: DerivedTokenRouterConfig,
   ): Promise<AnnotatedEV5Transaction[]> {
     HypTokenRouterConfigSchema.parse(expectedConfig);
-    const actualConfig = await this.read();
+    const actualConfig = actualWarpConfig ?? (await this.read());
+
     const transactions = [];
 
     /**
@@ -755,6 +758,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     );
     const updateTransactions = await ismModule.update(
       expectedConfig.interchainSecurityModule,
+      actualConfig.interchainSecurityModule,
     );
     const { deployedIsm } = ismModule.serialize();
 
@@ -841,7 +845,10 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     this.logger.info(
       `Comparing target Hook config with ${this.args.chain} chain`,
     );
-    const updateTransactions = await hookModule.update(expectedConfig.hook!);
+    const updateTransactions = await hookModule.update(
+      expectedConfig.hook!,
+      actualConfig.hook as DerivedHookConfig,
+    );
     const { deployedHook } = hookModule.serialize();
 
     return { deployedHook, updateTransactions };

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -244,6 +244,9 @@ export type DerivedTokenRouterConfig = z.infer<typeof HypTokenConfigSchema> &
   z.infer<typeof GasRouterConfigSchema> &
   DerivedRouterConfig;
 
+export const DerivedWarpRouteDeployConfigSchema = z.record(
+  DerivedTokenRouterConfig,
+);
 export type DerivedWarpRouteDeployConfig = ChainMap<DerivedTokenRouterConfig>;
 
 export function derivedHookAddress(config: DerivedTokenRouterConfig) {


### PR DESCRIPTION
### Description
Currently, we oread the onchain config many times, which adds significant overhead to deployment time (EZETH takes ~45 mins, _if it doesnt fail_). Most of the time cost is from deriving the default hook/ism.

This PR attempts to remedy this by allowing `warp apply` to use a cached warp config via `--actualConfigPath`. The idea is to use `warp read` and then use the filepath in the parameter.

### Backward compatibility
Yes

### Testing
Manual
