### PR TITLE
fix: Find reorg script: use the last announced storage location

### DIFF
--- a/typescript/infra/scripts/validators/find-reorg.ts
+++ b/typescript/infra/scripts/validators/find-reorg.ts
@@ -39,7 +39,7 @@ async function main() {
   const storageLocations = await validatorAnnounce.getAnnouncedStorageLocations(
     [validator],
   );
-  const storageLocation = storageLocations[0][0];
+  const storageLocation = storageLocations[0][storageLocations[0].length - 1];
   const validatorInstance =
     await getValidatorFromStorageLocation(storageLocation);
   const latestCheckpointIndex =


### PR DESCRIPTION
### Description

If validator has announced several storage locations, we should check the last one for reorg flag

### Backward compatibility

Yes

### Testing

Manual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the selection of storage location for validator announcements, ensuring the correct storage location is used when retrieving validator instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->