### PR TITLE
fix: native denom padding on paradex

### DIFF
--- a/rust/main/config/testnet_config.json
+++ b/rust/main/config/testnet_config.json
@@ -2149,7 +2149,7 @@
         "decimals": 18,
         "name": "EtherDUMMY_TOKEN",
         "symbol": "DT",
-        "denom": "0x49D36570D4E46F48E99674BD3FCC84644DDD6B96F7C741B1562B82F9E004DC7"
+        "denom": "0x049D36570D4E46F48E99674BD3FCC84644DDD6B96F7C741B1562B82F9E004DC7"
       },
       "protocol": "starknet",
       "rpcUrls": [

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -408,7 +408,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '0100511-20250609-175448',
+      tag: 'd2e35d5-20250612-130215',
     },
     blacklist: [...releaseCandidateHelloworldMatchingList, ...relayBlacklist],
     gasPaymentEnforcement,
@@ -423,7 +423,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'cedc8e1-20250603-094703',
+      tag: 'd2e35d5-20250612-130215',
     },
     chains: validatorChainConfig(Contexts.Hyperlane),
     resources: validatorResources,
@@ -432,7 +432,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '0100511-20250609-175448',
+      tag: 'd2e35d5-20250612-130215',
     },
     resources: scraperResources,
   },
@@ -447,7 +447,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '0100511-20250609-175448',
+      tag: 'd2e35d5-20250612-130215',
     },
     blacklist: relayBlacklist,
     gasPaymentEnforcement,
@@ -462,7 +462,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'cedc8e1-20250603-094703',
+      tag: 'd2e35d5-20250612-130215',
     },
     chains: validatorChainConfig(Contexts.ReleaseCandidate),
     resources: validatorResources,
@@ -485,7 +485,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '0100511-20250609-175448',
+      tag: 'd2e35d5-20250612-130215',
     },
     blacklist: relayBlacklist,
     gasPaymentEnforcement,
@@ -500,7 +500,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '385b307-20250418-150728',
+      tag: 'd2e35d5-20250612-130215',
     },
     chains: validatorChainConfig(Contexts.ReleaseCandidate),
     resources: validatorResources,


### PR DESCRIPTION
### Description
Deploys the latest image to paradex & starknet
<!--
What's included in this PR?
-->

### Drive-by changes
Add correct padding to paradex nativetoken denom
<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
