### PR TITLE
fix: add contract existence check in `constructor` of `HypERC721Collateral`

### DIFF
--- a/solidity/contracts/token/HypERC721Collateral.sol
+++ b/solidity/contracts/token/HypERC721Collateral.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0;
 // ============ Internal Imports ============
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {TokenRouter} from "./libs/TokenRouter.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
 /**
  * @title Hyperlane ERC721 Token Collateral that wraps an existing ERC721 with remote transfer functionality.
@@ -17,6 +18,10 @@ contract HypERC721Collateral is TokenRouter {
      * @param erc721 Address of the token to keep as collateral
      */
     constructor(address erc721, address _mailbox) TokenRouter(_mailbox) {
+        require(
+            Address.isContract(erc721),
+            "HypERC721Collateral: invalid token"
+        );
         wrappedToken = IERC721(erc721);
     }
 


### PR DESCRIPTION
The `HypERC721Collateral` contract's `constructor` does not validate that the provided ERC721 token address is a valid contract address.
This is inconsistent with the `HypERC20Collateral` contract which properly performs this check. In `HypERC20Collateral.sol`, the `constructor` validates the token address.

Without this validation, it's possible to deploy the `HypERC721Collateral` contract with an invalid or non-existent token address. If the `erc721` address parameter is not a contract, all token operations will fail, rendering the collateral
contract unusable and result in the deployment of non-functional collateral contracts.

https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/f5130bf170f2bbce1654dec977fec32d4932d87e/solidity/contracts/token/HypERC20Collateral.sol#L40-L51

https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/f5130bf170f2bbce1654dec977fec32d4932d87e/solidity/contracts/token/HypERC721Collateral.sol#L15-L21