### PR TITLE
feat: Fetch warpRouteIds  from Registry

### DIFF
--- a/typescript/infra/src/warp/helm.ts
+++ b/typescript/infra/src/warp/helm.ts
@@ -1,7 +1,6 @@
 import { confirm } from '@inquirer/prompts';
 import path from 'path';
 
-import { getRegistry } from '@hyperlane-xyz/registry/fs';
 import {
   ChainMap,
   IToken,
@@ -14,6 +13,7 @@ import { difference, rootLogger } from '@hyperlane-xyz/utils';
 
 import {
   DEFAULT_REGISTRY_URI,
+  getRegistry,
   getWarpCoreConfig,
 } from '../../config/registry.js';
 import { DeployEnvironment } from '../../src/config/environment.js';
@@ -128,10 +128,7 @@ export class WarpRouteMonitorHelmManager extends HelmManager {
   // Any warp monitor helm releases found that do not relate to known warp route ids
   // will be prompted for uninstallation.
   static async uninstallUnknownWarpMonitorReleases(namespace: string) {
-    const localRegistry = getRegistry({
-      registryUris: [DEFAULT_REGISTRY_URI],
-      enableProxy: false,
-    });
+    const localRegistry = getRegistry();
     const allExpectedHelmReleaseNames = Object.values(
       Object.keys(await localRegistry.getWarpRoutes()),
     ).map(WarpRouteMonitorHelmManager.getHelmReleaseName);
@@ -167,13 +164,8 @@ export class WarpRouteMonitorHelmManager extends HelmManager {
       return;
     }
 
-    const localRegistry = getRegistry({
-      registryUris: [DEFAULT_REGISTRY_URI],
-      enableProxy: false,
-    });
-    const chainAddresses = await localRegistry.getChainAddresses(
-      token.chainName,
-    );
+    const localRegistry = getRegistry();
+    const chainAddresses = localRegistry.getChainAddresses(token.chainName);
     warpCore.multiProvider.metadata[token.chainName] = {
       ...warpCore.multiProvider.metadata[token.chainName],
       // Hack to get the Mailbox address into the metadata, which WarpCore requires for Sealevel chains.

--- a/typescript/infra/src/warp/helm.ts
+++ b/typescript/infra/src/warp/helm.ts
@@ -129,9 +129,10 @@ export class WarpRouteMonitorHelmManager extends HelmManager {
   // will be prompted for uninstallation.
   static async uninstallUnknownWarpMonitorReleases(namespace: string) {
     const localRegistry = getRegistry();
-    const allExpectedHelmReleaseNames = Object.values(
-      Object.keys(await localRegistry.getWarpRoutes()),
-    ).map(WarpRouteMonitorHelmManager.getHelmReleaseName);
+    const warpRouteIds = Object.keys(localRegistry.getWarpRoutes());
+    const allExpectedHelmReleaseNames = warpRouteIds.map(
+      WarpRouteMonitorHelmManager.getHelmReleaseName,
+    );
     const helmReleases =
       await WarpRouteMonitorHelmManager.getWarpMonitorHelmReleases(namespace);
 


### PR DESCRIPTION
### Description
This PR updates deploy-warp-monitor to fetch warpRouteIds from the monitor instead of the Getter mapping.


### Backward compatibility

Yes

### Testing
Manual


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of registry access for more dynamic and efficient operations. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->