### PR TITLE
chore: ignore ink in the oUSDT app context

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -25,6 +25,7 @@ import {
   MetricAppContext,
   chainMapMatchingList,
   consistentSenderRecipientMatchingList,
+  matchingList,
   routerMatchingList,
   senderMatchingList,
   warpRouteMatchingList,
@@ -32,7 +33,7 @@ import {
 import { BaseScraperConfig } from '../../../src/config/agent/scraper.js';
 import { ALL_KEY_ROLES, Role } from '../../../src/roles.js';
 import { Contexts, mustBeValidContext } from '../../contexts.js';
-import { getDomainId } from '../../registry.js';
+import { getDomainId, getWarpAddresses } from '../../registry.js';
 
 import { environment, ethereumChainNames } from './chains.js';
 import { blacklistedMessageIds } from './customBlacklist.js';
@@ -674,9 +675,23 @@ const vanguardMatchingList = [
 // - misc important applications not defined in the registry, e.g. merkly
 const metricAppContextsGetter = (): MetricAppContext[] => {
   const warpContexts = Object.values(WarpRouteIds).map((warpRouteId) => {
+    let warpMatchingList = undefined;
+
+    // oUSDT has Ink as a remote router but Ink doesn't have any limits set yet.
+    // Some people have been sending to Ink outside the UI, so to reduce alert noise
+    // we remove Ink from the matching list.
+    // TODO: once Ink has limits set, we should remove this.
+    if (warpRouteId === WarpRouteIds.oUSDT) {
+      const ousdtAddresses = getWarpAddresses(warpRouteId);
+      delete ousdtAddresses['ink'];
+      warpMatchingList = matchingList(ousdtAddresses);
+    } else {
+      warpMatchingList = warpRouteMatchingList(warpRouteId);
+    }
+
     return {
       name: warpRouteId,
-      matchingList: warpRouteMatchingList(warpRouteId),
+      matchingList: warpMatchingList,
     };
   });
 

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -677,13 +677,14 @@ const metricAppContextsGetter = (): MetricAppContext[] => {
   const warpContexts = Object.values(WarpRouteIds).map((warpRouteId) => {
     let warpMatchingList = undefined;
 
-    // oUSDT has Ink as a remote router but Ink doesn't have any limits set yet.
-    // Some people have been sending to Ink outside the UI, so to reduce alert noise
-    // we remove Ink from the matching list.
-    // TODO: once Ink has limits set, we should remove this.
+    // oUSDT has some remote routers but that don't have any limits set yet.
+    // Some people have been sending to e.g. Ink outside the UI, so to reduce alert noise
+    // we remove these from the matching list.
+    // TODO: once Ink or Worldchain have limits set, we should remove this.
     if (warpRouteId === WarpRouteIds.oUSDT) {
       const ousdtAddresses = getWarpAddresses(warpRouteId);
       delete ousdtAddresses['ink'];
+      delete ousdtAddresses['worldchain'];
       warpMatchingList = matchingList(ousdtAddresses);
     } else {
       warpMatchingList = warpRouteMatchingList(warpRouteId);

--- a/typescript/infra/config/environments/mainnet3/customBlacklist.ts
+++ b/typescript/infra/config/environments/mainnet3/customBlacklist.ts
@@ -54,6 +54,7 @@ export const blacklistedMessageIds = [
 
   // oUSDT dest with zero'd out limits
   '0x2ebe41a3c35efaba191765da61b4445d5a01764603bc4635d3d3f62ce65df7d8',
+  '0xc049929e777bc5c4515694f57818bb8cf561b5daeea0d48496e9b07062e701e4',
 
   // oUSDT messages sent to the zero address [2025-05-25]
   '0x8149ccd407507fc2b066450ba125fc487461d9d8d99261b624496fdd8e30c129',


### PR DESCRIPTION
### Description

- Ink is enrolled as a remote router on the oUSDT routers, but doesn't have any limits. Sometimes people send messages directly to Ink programmatically, and this causes alert noise. We temporarily remove Ink from the app context to not get high urgency alerted on oUSDT prep queues to Ink

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
