### PR TITLE
fix(lander): evm max fee per gas metric

### DIFF
--- a/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
@@ -25,6 +25,7 @@ use hyperlane_ethereum::{EthereumReorgPeriod, EvmProviderForLander, SubmitterPro
 
 use crate::{
     adapter::{core::TxBuildingResult, AdaptsChain, GasLimit},
+    dispatcher::VmSpecificMetricsSource,
     payload::{FullPayload, PayloadDetails},
     transaction::{Transaction, TransactionStatus, VmSpecificTxData},
     DispatcherMetrics, LanderError,
@@ -130,6 +131,32 @@ impl EthereumAdapter {
 
         info!(old=?old_tx_precursor, new=?tx.precursor(), "estimated gas price for transaction");
         Ok(())
+    }
+
+    fn extract_vm_specific_metrics(tx: &Transaction) -> VmSpecificMetricsSource {
+        let mut metrics_source = VmSpecificMetricsSource::default();
+        let VmSpecificTxData::Evm(precursor) = &tx.vm_specific_data else {
+            warn!(
+                ?tx,
+                "Transaction does not have EVM-specific data, skipping metrics update"
+            );
+            return metrics_source;
+        };
+
+        if let TypedTransaction::Eip1559(precursor) = &precursor.tx {
+            if let Some(max_prio_fee) = precursor.max_priority_fee_per_gas {
+                metrics_source.priority_fee = Some(max_prio_fee.as_u64());
+            }
+            if let Some(max_fee) = precursor.max_fee_per_gas {
+                metrics_source.gas_price = Some(max_fee.as_u64());
+            }
+        } else {
+            // for legacy transactions, we can only set the gas price
+            if let Some(gas_price) = precursor.tx.gas_price() {
+                metrics_source.gas_price = Some(gas_price.as_u64());
+            }
+        }
+        metrics_source
     }
 }
 
@@ -246,29 +273,8 @@ impl AdaptsChain for EthereumAdapter {
     }
 
     fn update_vm_specific_metrics(&self, tx: &Transaction, metrics: &DispatcherMetrics) {
-        let VmSpecificTxData::Evm(precursor) = &tx.vm_specific_data else {
-            warn!(
-                ?tx,
-                "Transaction does not have EVM-specific data, skipping metrics update"
-            );
-            return;
-        };
-        if let Some(gas_price) = precursor.tx.gas_price() {
-            let gas_price = gas_price.as_u64();
-            metrics.update_gas_price_metric(gas_price, self.domain.as_ref());
-        } else {
-            warn!(
-                ?tx,
-                "Transaction does not have gas price set, skipping gas price metric update"
-            );
-        }
-        // if a priority fee is set, update the priority fee metric
-        if let TypedTransaction::Eip1559(precursor) = &precursor.tx {
-            if let Some(max_prio_fee) = precursor.max_priority_fee_per_gas {
-                let max_prio_fee = max_prio_fee.as_u64();
-                metrics.update_priority_fee_metric(max_prio_fee, self.domain.as_ref());
-            }
-        }
+        let metrics_source = Self::extract_vm_specific_metrics(tx);
+        metrics.set_vm_specific_metrics(&metrics_source, self.domain.as_ref());
     }
 
     fn estimated_block_time(&self) -> &std::time::Duration {
@@ -277,5 +283,106 @@ impl AdaptsChain for EthereumAdapter {
 
     fn max_batch_size(&self) -> u32 {
         self.submission_config.max_batch_size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ethers::types::{
+        transaction::{eip2718::TypedTransaction, eip2930::AccessList},
+        Eip1559TransactionRequest, Eip2930TransactionRequest, TransactionRequest, H160, H256,
+    };
+
+    use crate::{
+        adapter::EthereumTxPrecursor,
+        tests::ethereum::inclusion_stage::{dummy_evm_tx, dummy_tx_precursor},
+        transaction::VmSpecificTxData,
+    };
+
+    #[test]
+    fn vm_specific_metrics_are_extracted_correctly_legacy() {
+        use super::EthereumAdapter;
+        use crate::transaction::Transaction;
+
+        let mut evm_tx = dummy_evm_tx(
+            vec![],
+            crate::TransactionStatus::PendingInclusion,
+            H160::random(),
+        );
+
+        if let VmSpecificTxData::Evm(ethereum_tx_precursor) = &mut evm_tx.vm_specific_data {
+            ethereum_tx_precursor.tx = TypedTransaction::Legacy(TransactionRequest {
+                from: Some(H160::random()),
+                to: Some(H160::random().into()),
+                nonce: Some(0.into()),
+                gas: Some(21000.into()),
+                gas_price: Some(1000000000.into()),
+                value: Some(1.into()),
+                ..Default::default()
+            });
+        }
+
+        let metrics_source = EthereumAdapter::extract_vm_specific_metrics(&evm_tx);
+        assert_eq!(metrics_source.gas_price.unwrap(), 1000000000);
+        assert_eq!(metrics_source.priority_fee, None);
+    }
+
+    #[test]
+    fn vm_specific_metrics_are_extracted_correctly_eip1559() {
+        use super::EthereumAdapter;
+        use crate::transaction::Transaction;
+
+        let mut evm_tx = dummy_evm_tx(
+            vec![],
+            crate::TransactionStatus::PendingInclusion,
+            H160::random(),
+        );
+
+        if let VmSpecificTxData::Evm(ethereum_tx_precursor) = &mut evm_tx.vm_specific_data {
+            ethereum_tx_precursor.tx = TypedTransaction::Eip1559(Eip1559TransactionRequest {
+                from: Some(H160::random()),
+                to: Some(H160::random().into()),
+                nonce: Some(0.into()),
+                max_fee_per_gas: Some(1000000000.into()),
+                max_priority_fee_per_gas: Some(22222.into()),
+                value: Some(1.into()),
+                ..Default::default()
+            });
+        }
+
+        let metrics_source = EthereumAdapter::extract_vm_specific_metrics(&evm_tx);
+        assert_eq!(metrics_source.gas_price.unwrap(), 1000000000);
+        assert_eq!(metrics_source.priority_fee.unwrap(), 22222);
+    }
+
+    #[test]
+    fn vm_specific_metrics_are_extracted_correctly_eip2930() {
+        use super::EthereumAdapter;
+        use crate::transaction::Transaction;
+
+        let mut evm_tx = dummy_evm_tx(
+            vec![],
+            crate::TransactionStatus::PendingInclusion,
+            H160::random(),
+        );
+
+        if let VmSpecificTxData::Evm(ethereum_tx_precursor) = &mut evm_tx.vm_specific_data {
+            ethereum_tx_precursor.tx = TypedTransaction::Eip2930(Eip2930TransactionRequest {
+                tx: TransactionRequest {
+                    from: Some(H160::random()),
+                    to: Some(H160::random().into()),
+                    nonce: Some(0.into()),
+                    gas: Some(21000.into()),
+                    gas_price: Some(1000000000.into()),
+                    value: Some(1.into()),
+                    ..Default::default()
+                },
+                access_list: AccessList::default(),
+            });
+        }
+
+        let metrics_source = EthereumAdapter::extract_vm_specific_metrics(&evm_tx);
+        assert_eq!(metrics_source.gas_price.unwrap(), 1000000000);
+        assert_eq!(metrics_source.priority_fee, None);
     }
 }

--- a/rust/main/lander/src/tests.rs
+++ b/rust/main/lander/src/tests.rs
@@ -1,3 +1,3 @@
-mod ethereum;
+pub mod ethereum;
 #[cfg(test)]
 pub mod test_utils;

--- a/rust/main/lander/src/tests/ethereum.rs
+++ b/rust/main/lander/src/tests/ethereum.rs
@@ -1,1 +1,1 @@
-mod inclusion_stage;
+pub mod inclusion_stage;

--- a/rust/main/lander/src/tests/ethereum/inclusion_stage.rs
+++ b/rust/main/lander/src/tests/ethereum/inclusion_stage.rs
@@ -329,7 +329,7 @@ pub(crate) async fn mock_evm_txs(
     txs
 }
 
-fn dummy_evm_tx(
+pub fn dummy_evm_tx(
     payloads: Vec<FullPayload>,
     status: TransactionStatus,
     signer: H160,
@@ -351,7 +351,7 @@ fn dummy_evm_tx(
     }
 }
 
-fn dummy_tx_precursor(signer: H160) -> EthereumTxPrecursor {
+pub fn dummy_tx_precursor(signer: H160) -> EthereumTxPrecursor {
     let function = Function {
         name: "baz".to_owned(),
         inputs: vec![


### PR DESCRIPTION
### Description

The max fee per gas wasn't showing up on eip1559 chains for some reason - this PR fixes it and adds unit tests to ensure we're able to extract gas price metrics from all evm tx types.

### Backward compatibility

yes

### Testing

unit tests
