### PR TITLE
chore: new relayer image with less logging, ignore some neutron dest msgs

### DIFF
--- a/rust/main/config/testnet_config.json
+++ b/rust/main/config/testnet_config.json
@@ -272,7 +272,10 @@
       "validatorAnnounce": "0xf09701B0a93210113D175461b6135a96773B5465",
       "staticMerkleRootWeightedMultisigIsmFactory": "0xCa152b249791Adf7A09C6c1bdbAb05e4A594966e",
       "staticMessageIdWeightedMultisigIsmFactory": "0xaa80d23299861b7D7ab1bE665579029Ed9137BD1",
-      "gasCurrencyCoinGeckoId": "binancecoin"
+      "gasCurrencyCoinGeckoId": "binancecoin",
+      "transactionOverrides": {
+        "gasPrice": 1000000000
+      }
     },
     "connextsepolia": {
       "aggregationHook": "0x331eb40963dc11F5BB271308c42d97ac6e41F124",

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -902,7 +902,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '8b18655-20250606-081749',
+      tag: '420c950-20250612-172436',
     },
     blacklist,
     gasPaymentEnforcement,

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -824,7 +824,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '420c950-20250612-172436',
+      tag: '8185c87-20250618-151232',
     },
     blacklist,
     gasPaymentEnforcement: gasPaymentEnforcement,
@@ -864,7 +864,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '28d04ae-20250616-150106',
+      tag: '8185c87-20250618-151232',
     },
     blacklist,
     // We're temporarily (ab)using the RC relayer as a way to increase
@@ -902,7 +902,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '420c950-20250612-172436',
+      tag: '8185c87-20250618-151232',
     },
     blacklist,
     gasPaymentEnforcement,

--- a/typescript/infra/config/environments/mainnet3/customBlacklist.ts
+++ b/typescript/infra/config/environments/mainnet3/customBlacklist.ts
@@ -85,4 +85,8 @@ export const blacklistedMessageIds = [
   '0xd48b8599f52e75d43916a7d1ec9512c98c5025394bc4983bf7c6309744758b9e',
   '0x4f984fb0312da11f55b931a809563072bd8a46d44da0e42dfce40a9ccf1b97f2',
   '0x50b8a9b21a4a2c980db8232d819cab72fe04707e39fc1b78ef5e583a44c412cf',
+
+  // Messages to a recipient that Neutron doesn't seem to allow
+  '0x70be30b4f21cfe4dbb05c0c22601c6b4c9cf4a2a73727331dbbb6404d7566e1f',
+  '0xc376df3e8d82de669b48b58e0521db5cf6c23a21fb2230487c30536f7b6503f7',
 ];


### PR DESCRIPTION
### Description

- Deploys #6494 
- Ignore a couple messages destined to a seemingly blocked recipient https://hyperlaneworkspace.slack.com/archives/C08GHFABJQ6/p1750251725429679?thread_ts=1750203987.690569&cid=C08GHFABJQ6

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
