### PR TITLE
fix: minimize `warp apply` transaction submission

### DIFF
--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -348,6 +348,8 @@ export async function runWarpRouteApply(
     );
 
   const { multiProvider } = context;
+  // temporarily configure deployer as owner so that warp update after extension
+  // can leverage JSON RPC submitter on new chains
   const intermediateOwnerConfig = await promiseObjAll(
     objMap(params.warpDeployConfig, async (chain, config) => ({
       ...config,

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -806,8 +806,9 @@ async function submitWarpApplyTransactions(
               });
             const transactionReceipts = await submitter.submit(...transactions);
             if (transactionReceipts) {
-              const receiptPath = `${params.receiptsDir}/${chain}-${submitter.txSubmitterType
-                }-${Date.now()}-receipts.json`;
+              const receiptPath = `${params.receiptsDir}/${chain}-${
+                submitter.txSubmitterType
+              }-${Date.now()}-receipts.json`;
               writeYamlOrJson(receiptPath, transactionReceipts);
               logGreen(
                 `Transactions receipts successfully written to ${receiptPath}`,
@@ -847,11 +848,11 @@ async function getWarpApplySubmitter({
     strategyUrl && !isExtendedChain
       ? readChainSubmissionStrategy(strategyUrl)[chain]
       : {
-        submitter: {
-          chain,
-          type: TxSubmitterType.JSON_RPC,
-        },
-      };
+          submitter: {
+            chain,
+            type: TxSubmitterType.JSON_RPC,
+          },
+        };
 
   return getSubmitterBuilder<ProtocolType>({
     submissionStrategy,

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -385,9 +385,9 @@ abstract class TokenDeployer<
   ): Promise<void> {
     await promiseObjAll(
       objMap(configMap, async (chain, config) => {
-        const router = this.router(deployedContractsMap[chain]).address;
+        const router = this.router(deployedContractsMap[chain]);
         const movableToken = MovableCollateralRouter__factory.connect(
-          router,
+          router.address,
           this.multiProvider.getSigner(chain),
         );
 
@@ -403,13 +403,18 @@ abstract class TokenDeployer<
         ).flatMap(([domain, allowedBridgesToAdd]) => {
           return allowedBridgesToAdd.map((bridgeToAdd) => {
             return {
-              domain,
+              domain: Number(domain),
               bridge: bridgeToAdd.bridge,
             };
           });
         });
 
-        for (const bridgeConfig of bridgesToAllow) {
+        // Filter out domains that are not enrolled to avoid errors
+        const routerDomains = await router.domains();
+        const bridgesToAllowOnRouter = bridgesToAllow.filter(({ domain }) =>
+          routerDomains.includes(domain),
+        );
+        for (const bridgeConfig of bridgesToAllowOnRouter) {
           await this.multiProvider.handleTx(
             chain,
             movableToken.addBridge(bridgeConfig.domain, bridgeConfig.bridge),


### PR DESCRIPTION
### Description

Configures signer as owner for intermediate warp extension. Uses JSON_RPC submitter for warp apply on these extended chains. 

Delays adding bridge from extension deploy to warp update so that routers are definitely enrolled.

### Drive-by changes

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of ownership information and submission strategies for extended Warp route deployments, ensuring proper assignment and transaction processing for both core and extended chains.

- **Bug Fixes**
  - Added a check to prevent adding bridges for unenrolled domains during token deployment, reducing potential errors and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->