### PR TITLE
fix: only derive rebalancing config when bytecode version matches

### DIFF
--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -149,7 +149,7 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
       compareVersions(
         tokenConfig.contractVersion!,
         REBALANCING_CONTRACT_VERSION,
-      ) > 0;
+      ) >= 0;
 
     let allowedRebalancers: Address[] | undefined;
     let allowedRebalancingBridges: MovableTokenConfig['allowedRebalancingBridges'];


### PR DESCRIPTION
### Description

Only derive rebalancing config in WarpModule.read when contractVersion implies the interface

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved support for rebalancing features, now only available for tokens with contract versions 8.0.0 and above.
- **Bug Fixes**
  - Ensured rebalancing-related options are shown only when supported by the token’s contract version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->