### PR TITLE
feat(lander): evm gas limit metric

### DIFF
--- a/rust/main/lander/src/dispatcher/metrics.rs
+++ b/rust/main/lander/src/dispatcher/metrics.rs
@@ -52,6 +52,8 @@ pub struct DispatcherMetrics {
     finalized_nonce: IntGaugeVec,
     /// Upper nonce, namely the nonce which can be used next for each destination
     upper_nonce: IntGaugeVec,
+    /// Gas limit set for the transaction, if applicable
+    pub gas_limit: IntGaugeVec,
 }
 
 impl DispatcherMetrics {
@@ -152,6 +154,14 @@ impl DispatcherMetrics {
             &["destination",],
             registry.clone()
         )?;
+        let gas_limit = register_int_gauge_vec_with_registry!(
+            opts!(
+                namespaced("gas_limit"),
+                "The gas limit set for the transaction, if applicable",
+            ),
+            &["destination",],
+            registry.clone()
+        )?;
         let finalized_nonce = register_int_gauge_vec_with_registry!(
             opts!(
                 namespaced("finalized_nonce"),
@@ -184,6 +194,7 @@ impl DispatcherMetrics {
             priority_fee,
             finalized_nonce,
             upper_nonce,
+            gas_limit,
         })
     }
 
@@ -256,6 +267,12 @@ impl DispatcherMetrics {
             .set(priority_fee as i64);
     }
 
+    pub fn update_gas_limit_metric(&self, gas_limit: u64, domain: &str) {
+        self.gas_limit
+            .with_label_values(&[domain])
+            .set(gas_limit as i64);
+    }
+
     pub fn get_finalized_nonce(&self, destination: &str, signer: &str) -> IntGauge {
         self.finalized_nonce
             .with_label_values(&[destination, signer])
@@ -268,12 +285,19 @@ impl DispatcherMetrics {
             .clone()
     }
 
-    pub fn set_vm_specific_metrics(&self, vm_metrics: &VmSpecificMetricsSource, domain: &str) {
+    pub fn set_post_inclusion_metrics(
+        &self,
+        vm_metrics: &PostInclusionMetricsSource,
+        domain: &str,
+    ) {
         if let Some(gas_price) = vm_metrics.gas_price {
             self.update_gas_price_metric(gas_price, domain);
         }
         if let Some(priority_fee) = vm_metrics.priority_fee {
             self.update_priority_fee_metric(priority_fee, domain);
+        }
+        if let Some(gas_limit) = vm_metrics.gas_limit {
+            self.update_gas_limit_metric(gas_limit, domain);
         }
     }
 
@@ -293,10 +317,12 @@ impl DispatcherMetrics {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-pub struct VmSpecificMetricsSource {
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PostInclusionMetricsSource {
     // max fee per gas for EIP-1559 chains, or gas price for others
     pub gas_price: Option<u64>,
     // priority fee per gas for EIP-1559 chains, or None for others
     pub priority_fee: Option<u64>,
+    // gas limit set for the transaction, if applicable
+    pub gas_limit: Option<u64>,
 }


### PR DESCRIPTION
### Description

Tracks the evm gas limit as a Lander metric.

I originally set out to track the `gas_usage` as well, but that is much trickier for reasons explained in https://linear.app/hyperlane-xyz/issue/ENG-1802/add-metrics-for-gas-usage-and-actual-gas-price

### Drive-by changes

Renames `VmSpecificMetricsSource` to `PostInclusionMetricsSource`, since in the future we may want to set metrics at other stages in the tx lifecycle

### Related issues

- Fixes https://linear.app/hyperlane-xyz/issue/ENG-1795/add-evm-gas-limit-metric

### Backward compatibility

yes

### Testing

unit tests to make sure we do extract the limit from the Transaction struct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tracking and reporting of gas limit metrics for Ethereum transactions.
- **Refactor**
  - Updated metric extraction and reporting logic to use a new metrics source structure that includes the gas limit.
  - Renamed and updated methods and structures related to post-inclusion metrics for improved clarity and extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->