### PR TITLE
feat: update renzo config getters to use DefaultHook

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.ts
@@ -1,6 +1,5 @@
 import { parseEther } from 'ethers/lib/utils.js';
 
-import { Mailbox__factory } from '@hyperlane-xyz/core';
 import {
   ChainMap,
   ChainName,
@@ -91,15 +90,13 @@ const chainProtocolFee: Record<ChainName, string> = {
   zircuit: '400000000000000',
 };
 
-export function getRenzoHook(
-  defaultHook: Address,
-  chain: ChainName,
-  owner: Address,
-): HookConfig {
+export function getRenzoHook(chain: ChainName, owner: Address): HookConfig {
   return {
     type: HookType.AGGREGATION,
     hooks: [
-      defaultHook,
+      {
+        type: HookType.MAILBOX_DEFAULT,
+      },
       {
         type: HookType.PROTOCOL_FEE,
         owner: owner,
@@ -531,12 +528,6 @@ export function getRenzoWarpConfigGenerator(params: {
             const addresses = await registry.getChainAddresses(chain);
             assert(addresses, 'No addresses in Registry');
             const { mailbox } = addresses;
-
-            const mailboxContract = Mailbox__factory.connect(
-              mailbox,
-              multiProvider.getProvider(chain),
-            );
-            const defaultHook = await mailboxContract.defaultHook();
             const ret: HypTokenRouterConfig = {
               isNft: false,
               type:
@@ -568,7 +559,7 @@ export function getRenzoWarpConfigGenerator(params: {
                   },
                 ],
               },
-              hook: getRenzoHook(defaultHook, chain, safes[chain]),
+              hook: getRenzoHook(chain, safes[chain]),
             };
 
             if (chainOwnerOverrides?.[chain]) {


### PR DESCRIPTION
### Description

feat: update renzo config getters to use DefaultHook
- saves ton of time having to read the entire default hook tree on warp apply

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
