### PR TITLE
feat: add --chains flag to warp apply

### DIFF
--- a/.changeset/odd-dingos-watch.md
+++ b/.changeset/odd-dingos-watch.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/cli": minor
+---
+
+add --chains command to warp apply to limit updates to chains

--- a/typescript/cli/src/commands/options.ts
+++ b/typescript/cli/src/commands/options.ts
@@ -193,13 +193,6 @@ export const symbolCommandOption: Options = {
   description: 'Token symbol (e.g. ETH, USDC)',
 };
 
-export const chainsCommandOption: Options = {
-  type: 'string',
-  alias: ['c'],
-  description:
-    'Only update this subset of chains with warp apply (comma separated list)',
-};
-
 export const validatorCommandOption: Options = {
   type: 'string',
   description: 'Comma separated list of validator addresses',

--- a/typescript/cli/src/commands/options.ts
+++ b/typescript/cli/src/commands/options.ts
@@ -193,6 +193,13 @@ export const symbolCommandOption: Options = {
   description: 'Token symbol (e.g. ETH, USDC)',
 };
 
+export const chainsCommandOption: Options = {
+  type: 'string',
+  alias: ['c'],
+  description:
+    'Only update this subset of chains with warp apply (comma separated list)',
+};
+
 export const validatorCommandOption: Options = {
   type: 'string',
   description: 'Comma separated list of validator addresses',

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -53,6 +53,7 @@ import {
   DEFAULT_WARP_ROUTE_DEPLOYMENT_CONFIG_PATH,
   addressCommandOption,
   chainCommandOption,
+  chainsCommandOption,
   dryRunCommandOption,
   forkCommandOptions,
   fromAddressCommandOption,
@@ -108,6 +109,10 @@ export const apply: CommandModuleWithWarpApplyContext<{
     },
     symbol: {
       ...symbolCommandOption,
+      demandOption: false,
+    },
+    chains: {
+      ...chainsCommandOption,
       demandOption: false,
     },
     strategy: { ...strategyCommandOption, demandOption: false },

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -53,7 +53,7 @@ import {
   DEFAULT_WARP_ROUTE_DEPLOYMENT_CONFIG_PATH,
   addressCommandOption,
   chainCommandOption,
-  chainsCommandOption,
+  chainTargetsCommandOption,
   dryRunCommandOption,
   forkCommandOptions,
   fromAddressCommandOption,
@@ -112,7 +112,7 @@ export const apply: CommandModuleWithWarpApplyContext<{
       demandOption: false,
     },
     chains: {
-      ...chainsCommandOption,
+      ...chainTargetsCommandOption,
       demandOption: false,
     },
     strategy: { ...strategyCommandOption, demandOption: false },

--- a/typescript/cli/src/context/strategies/chain/MultiChainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/MultiChainResolver.ts
@@ -92,6 +92,14 @@ export class MultiChainResolver implements ChainResolver {
     argv.context.warpDeployConfig = warpDeployConfig;
     argv.context.chains = Object.keys(warpDeployConfig);
 
+    if (argv.chains) {
+      const chains = argv.chains.split(',').map((item: string) => item.trim());
+
+      argv.context.chains = argv.context.chains.filter((chain: ChainName) =>
+        chains.includes(chain),
+      );
+    }
+
     assert(
       argv.context.chains.length !== 0,
       'No chains found in warp route deployment config',

--- a/typescript/cli/src/context/types.ts
+++ b/typescript/cli/src/context/types.ts
@@ -5,6 +5,7 @@ import type { IRegistry } from '@hyperlane-xyz/registry';
 import type {
   ChainMap,
   ChainMetadata,
+  ChainName,
   MultiProtocolProvider,
   MultiProvider,
   ProtocolMap,
@@ -44,6 +45,7 @@ export interface WriteCommandContext extends CommandContext {
   isDryRun?: boolean;
   dryRunChain?: string;
   apiKeys?: ChainMap<string>;
+  chains?: ChainName[];
 }
 
 export interface WarpDeployCommandContext extends WriteCommandContext {

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -435,7 +435,7 @@ export async function extendWarpRoute(
   const warpCoreConfigByChain = Object.fromEntries(
     warpCoreConfig.tokens.map((token) => [token.chainName, token]),
   );
-  const warpCoreChains = Object.keys(params.context.chains || []);
+  const warpCoreChains = params.context.chains || [];
 
   // Split between the existing and additional config
   const [existingConfigs, initialExtendedConfigs] =

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -337,7 +337,7 @@ export async function runWarpRouteApply(
   WarpRouteDeployConfigSchema.parse(warpDeployConfig);
   WarpCoreConfigSchema.parse(warpCoreConfig);
 
-  assert(chains, `no chains found for warp apply`);
+  assert(chains && chains.length, `no chains found for warp apply`);
 
   let apiKeys: ChainMap<string> = {};
   if (!skipConfirmation)


### PR DESCRIPTION
### Description

This PR adds a new flag `--chains` to warp apply to limit the chains which should be updated

### Drive-by changes

-

### Related issues

-

### Backward compatibility

-

### Testing

Manual Testing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new --chains option to the warp apply command, allowing users to target specific blockchain chains for updates.
- **Chores**
  - Improved chain selection logic to enable updates only on user-specified chains, enhancing control during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->