### PR TITLE
test(lander): restarting doesn't interfere with tx resubmission

### DIFF
--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -35,7 +35,7 @@ pub const STAGE_NAME: &str = "InclusionStage";
 
 pub struct InclusionStage {
     pub(crate) pool: InclusionStagePool,
-    tx_receiver: mpsc::Receiver<Transaction>,
+    pub(crate) tx_receiver: mpsc::Receiver<Transaction>,
     finality_stage_sender: mpsc::Sender<Transaction>,
     state: DispatcherState,
     domain: String,
@@ -83,7 +83,7 @@ impl InclusionStage {
         }
     }
 
-    async fn receive_txs(
+    pub(crate) async fn receive_txs(
         mut building_stage_receiver: mpsc::Receiver<Transaction>,
         pool: InclusionStagePool,
         state: DispatcherState,
@@ -109,7 +109,7 @@ impl InclusionStage {
         }
     }
 
-    async fn process_txs(
+    pub(crate) async fn process_txs(
         pool: InclusionStagePool,
         finality_stage_sender: mpsc::Sender<Transaction>,
         state: DispatcherState,

--- a/rust/main/lander/src/tests/ethereum/inclusion_stage.rs
+++ b/rust/main/lander/src/tests/ethereum/inclusion_stage.rs
@@ -55,6 +55,7 @@ async fn test_inclusion_gas_spike() {
     mock_finalized_block_number(&mut mock_evm_provider);
     mock_estimate_gas_limit(&mut mock_evm_provider);
     mock_get_block(&mut mock_evm_provider);
+    mock_get_next_nonce_on_finalized_block(&mut mock_evm_provider);
 
     let mut fee_history_call_counter = 0;
     mock_evm_provider
@@ -128,6 +129,7 @@ async fn test_inclusion_gas_underpriced() {
     mock_estimate_gas_limit(&mut mock_evm_provider);
     mock_default_fee_history(&mut mock_evm_provider);
     mock_get_block(&mut mock_evm_provider);
+    mock_get_next_nonce_on_finalized_block(&mut mock_evm_provider);
 
     // after the tx is sent and gets a tx hash, immediately report it as included
     mock_evm_provider
@@ -180,6 +182,7 @@ async fn test_tx_which_fails_simulation_after_submission_is_delivered() {
     mock_finalized_block_number(&mut mock_evm_provider);
     mock_get_block(&mut mock_evm_provider);
     mock_default_fee_history(&mut mock_evm_provider);
+    mock_get_next_nonce_on_finalized_block(&mut mock_evm_provider);
     let mut estimate_gas_call_counter = 0;
     mock_evm_provider
         .expect_estimate_gas_limit()
@@ -218,13 +221,9 @@ async fn test_tx_which_fails_simulation_after_submission_is_delivered() {
 }
 
 async fn run_and_expect_successful_inclusion(
-    mut mock_evm_provider: MockEvmProvider,
+    mock_evm_provider: MockEvmProvider,
     block_time: Duration,
 ) {
-    mock_evm_provider
-        .expect_get_next_nonce_on_finalized_block()
-        .returning(|_, _| Ok(U256::from(0)));
-
     let signer = H160::random();
     let dispatcher_state =
         mock_dispatcher_state_with_provider(mock_evm_provider, signer, block_time);
@@ -483,6 +482,12 @@ fn mock_estimate_gas_limit(mock_evm_provider: &mut MockEvmProvider) {
     mock_evm_provider
         .expect_estimate_gas_limit()
         .returning(|_, _| Ok(21000.into())); // Mocked gas limit
+}
+
+fn mock_get_next_nonce_on_finalized_block(mock_evm_provider: &mut MockEvmProvider) {
+    mock_evm_provider
+        .expect_get_next_nonce_on_finalized_block()
+        .returning(|_, _| Ok(U256::zero())); // Mocked nonce
 }
 
 fn mock_get_block(mock_evm_provider: &mut MockEvmProvider) {

--- a/rust/main/lander/src/tests/ethereum/inclusion_stage.rs
+++ b/rust/main/lander/src/tests/ethereum/inclusion_stage.rs
@@ -269,16 +269,10 @@ fn mocked_evm_provider() -> MockEvmProvider {
     let mut mock_evm_provider = MockEvmProvider::new();
     mock_finalized_block_number(&mut mock_evm_provider);
     mock_estimate_gas_limit(&mut mock_evm_provider);
-    mock_evm_provider.expect_get_block().returning(|_| {
-        Ok(Some(Default::default())) // Mocked block retrieval
-    });
-
-    mock_evm_provider.expect_send().returning(|_, _| {
-        Ok(H256::random()) // Mocked transaction hash
-    });
-    mock_evm_provider
-        .expect_fee_history()
-        .returning(|_, _, _| Ok(mock_fee_history(0, 0)));
+    mock_get_block(&mut mock_evm_provider);
+    mock_send(&mut mock_evm_provider);
+    mock_default_fee_history(&mut mock_evm_provider);
+    mock_get_next_nonce_on_finalized_block(&mut mock_evm_provider);
 
     mock_evm_provider
         .expect_get_transaction_receipt()
@@ -289,10 +283,6 @@ fn mocked_evm_provider() -> MockEvmProvider {
                 ..Default::default()
             }))
         });
-    mock_evm_provider
-        .expect_get_next_nonce_on_finalized_block()
-        .returning(|_, _| Ok(U256::one()));
-
     mock_evm_provider
 }
 
@@ -494,6 +484,12 @@ fn mock_get_block(mock_evm_provider: &mut MockEvmProvider) {
     mock_evm_provider
         .expect_get_block()
         .returning(|_| Ok(Some(mock_block(42, 100)))); // Mocked block retrieval
+}
+
+fn mock_send(mock_evm_provider: &mut MockEvmProvider) {
+    mock_evm_provider
+        .expect_send()
+        .returning(|_, _| Ok(H256::random())); // Mocked send method
 }
 
 fn assert_gas_prices_and_timings(

--- a/rust/main/lander/src/tests/test_utils.rs
+++ b/rust/main/lander/src/tests/test_utils.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
@@ -40,7 +41,13 @@ mockall::mock! {
 
 pub(crate) fn tmp_dbs() -> (Arc<dyn PayloadDb>, Arc<dyn TransactionDb>, Arc<dyn NonceDb>) {
     let temp_dir = tempfile::tempdir().unwrap();
-    let db = DB::from_path(temp_dir.path()).unwrap();
+    tmp_dbs_at_path(&temp_dir.path())
+}
+
+pub(crate) fn tmp_dbs_at_path(
+    path: &Path,
+) -> (Arc<dyn PayloadDb>, Arc<dyn TransactionDb>, Arc<dyn NonceDb>) {
+    let db = DB::from_path(&path).unwrap();
     let domain = KnownHyperlaneDomain::Arbitrum.into();
     let rocksdb = Arc::new(HyperlaneRocksDB::new(&domain, db));
 


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
