### PR TITLE
fix: lander test timing flakes

### DIFF
--- a/rust/main/lander/src/tests/ethereum/inclusion_stage.rs
+++ b/rust/main/lander/src/tests/ethereum/inclusion_stage.rs
@@ -50,7 +50,7 @@ async fn test_inclusion_happy_path() {
 #[tokio::test]
 #[traced_test]
 async fn test_inclusion_gas_spike() {
-    let block_time = Duration::from_millis(20);
+    let block_time = Duration::from_millis(100);
     let mut mock_evm_provider = MockEvmProvider::new();
     mock_finalized_block_number(&mut mock_evm_provider);
     mock_estimate_gas_limit(&mut mock_evm_provider);
@@ -94,8 +94,8 @@ async fn test_inclusion_gas_spike() {
     // assert each expected price by mocking the `send` method of the provider
     let mut send_call_counter = 0;
     let elapsed = Instant::now();
-    let base_processing_delay = Duration::from_millis(200);
-    let inclusion_stage_processing_delay = Duration::from_millis(40);
+    let base_processing_delay = Duration::from_millis(500);
+    let inclusion_stage_processing_delay = Duration::from_millis(50);
     let block_time_clone = block_time.clone();
     mock_evm_provider.expect_send().returning(move |tx, _| {
         send_call_counter += 1;
@@ -122,7 +122,7 @@ async fn test_inclusion_gas_spike() {
 #[tokio::test]
 #[traced_test]
 async fn test_inclusion_gas_underpriced() {
-    let block_time = Duration::from_millis(20);
+    let block_time = Duration::from_millis(100);
     let mut mock_evm_provider = MockEvmProvider::new();
     mock_finalized_block_number(&mut mock_evm_provider);
     mock_estimate_gas_limit(&mut mock_evm_provider);
@@ -141,9 +141,9 @@ async fn test_inclusion_gas_underpriced() {
     // assert each expected price by mocking the `send` method of the provider
     let mut send_call_counter = 0;
     let elapsed = Instant::now();
-    let base_processing_delay = Duration::from_millis(200);
+    let base_processing_delay = Duration::from_millis(500);
     // assume 1 second more than usual because that's the retry delay when an error occurs
-    let inclusion_stage_processing_delay = Duration::from_millis(1040);
+    let inclusion_stage_processing_delay = Duration::from_millis(1100);
     let block_time_clone = block_time.clone();
     mock_evm_provider.expect_send().returning(move |tx, _| {
         send_call_counter += 1;
@@ -175,7 +175,7 @@ async fn test_inclusion_gas_underpriced() {
 #[tokio::test]
 #[traced_test]
 async fn test_tx_which_fails_simulation_after_submission_is_delivered() {
-    let block_time = Duration::from_millis(20);
+    let block_time = Duration::from_millis(100);
     let mut mock_evm_provider = MockEvmProvider::new();
     mock_finalized_block_number(&mut mock_evm_provider);
     mock_get_block(&mut mock_evm_provider);

--- a/rust/main/lander/src/tests/ethereum/inclusion_stage.rs
+++ b/rust/main/lander/src/tests/ethereum/inclusion_stage.rs
@@ -41,7 +41,7 @@ use crate::{
 #[tokio::test]
 #[traced_test]
 async fn test_inclusion_happy_path() {
-    let block_time = Duration::from_millis(10);
+    let block_time = Duration::from_millis(20);
     let mock_evm_provider = mocked_evm_provider();
 
     run_and_expect_successful_inclusion(mock_evm_provider, block_time).await;
@@ -50,7 +50,7 @@ async fn test_inclusion_happy_path() {
 #[tokio::test]
 #[traced_test]
 async fn test_inclusion_gas_spike() {
-    let block_time = Duration::from_millis(10);
+    let block_time = Duration::from_millis(20);
     let mut mock_evm_provider = MockEvmProvider::new();
     mock_finalized_block_number(&mut mock_evm_provider);
     mock_estimate_gas_limit(&mut mock_evm_provider);
@@ -122,7 +122,7 @@ async fn test_inclusion_gas_spike() {
 #[tokio::test]
 #[traced_test]
 async fn test_inclusion_gas_underpriced() {
-    let block_time = Duration::from_millis(10);
+    let block_time = Duration::from_millis(20);
     let mut mock_evm_provider = MockEvmProvider::new();
     mock_finalized_block_number(&mut mock_evm_provider);
     mock_estimate_gas_limit(&mut mock_evm_provider);
@@ -175,7 +175,7 @@ async fn test_inclusion_gas_underpriced() {
 #[tokio::test]
 #[traced_test]
 async fn test_tx_which_fails_simulation_after_submission_is_delivered() {
-    let block_time = Duration::from_millis(10);
+    let block_time = Duration::from_millis(20);
     let mut mock_evm_provider = MockEvmProvider::new();
     mock_finalized_block_number(&mut mock_evm_provider);
     mock_get_block(&mut mock_evm_provider);

--- a/rust/main/lander/src/tests/ethereum/inclusion_stage.rs
+++ b/rust/main/lander/src/tests/ethereum/inclusion_stage.rs
@@ -41,7 +41,7 @@ use crate::{
 #[tokio::test]
 #[traced_test]
 async fn test_inclusion_happy_path() {
-    let block_time = Duration::from_millis(10);
+    let block_time = Duration::from_millis(100);
     let mock_evm_provider = mocked_evm_provider();
 
     run_and_expect_successful_inclusion(mock_evm_provider, block_time).await;

--- a/rust/main/lander/src/tests/ethereum/inclusion_stage.rs
+++ b/rust/main/lander/src/tests/ethereum/inclusion_stage.rs
@@ -41,7 +41,7 @@ use crate::{
 #[tokio::test]
 #[traced_test]
 async fn test_inclusion_happy_path() {
-    let block_time = Duration::from_millis(100);
+    let block_time = Duration::from_millis(10);
     let mock_evm_provider = mocked_evm_provider();
 
     run_and_expect_successful_inclusion(mock_evm_provider, block_time).await;
@@ -50,7 +50,7 @@ async fn test_inclusion_happy_path() {
 #[tokio::test]
 #[traced_test]
 async fn test_inclusion_gas_spike() {
-    let block_time = Duration::from_millis(100);
+    let block_time = Duration::from_millis(10);
     let mut mock_evm_provider = MockEvmProvider::new();
     mock_finalized_block_number(&mut mock_evm_provider);
     mock_estimate_gas_limit(&mut mock_evm_provider);
@@ -95,7 +95,7 @@ async fn test_inclusion_gas_spike() {
     let mut send_call_counter = 0;
     let elapsed = Instant::now();
     let base_processing_delay = Duration::from_millis(500);
-    let inclusion_stage_processing_delay = Duration::from_millis(50);
+    let inclusion_stage_processing_delay = Duration::from_millis(100);
     let block_time_clone = block_time.clone();
     mock_evm_provider.expect_send().returning(move |tx, _| {
         send_call_counter += 1;
@@ -122,7 +122,7 @@ async fn test_inclusion_gas_spike() {
 #[tokio::test]
 #[traced_test]
 async fn test_inclusion_gas_underpriced() {
-    let block_time = Duration::from_millis(100);
+    let block_time = Duration::from_millis(10);
     let mut mock_evm_provider = MockEvmProvider::new();
     mock_finalized_block_number(&mut mock_evm_provider);
     mock_estimate_gas_limit(&mut mock_evm_provider);
@@ -175,7 +175,7 @@ async fn test_inclusion_gas_underpriced() {
 #[tokio::test]
 #[traced_test]
 async fn test_tx_which_fails_simulation_after_submission_is_delivered() {
-    let block_time = Duration::from_millis(100);
+    let block_time = Duration::from_millis(10);
     let mut mock_evm_provider = MockEvmProvider::new();
     mock_finalized_block_number(&mut mock_evm_provider);
     mock_get_block(&mut mock_evm_provider);


### PR DESCRIPTION
### Description

Increases the expected time it takes to process messages in Lander unit tests, to fix flakes such as https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/15781190728/job/44486989785#step:7:2446

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Increased timing durations in Ethereum inclusion stage tests to improve reliability of timing-related assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->