### PR TITLE
fix: `CosmosNative` address parsing

### DIFF
--- a/.changeset/silly-lobsters-explain.md
+++ b/.changeset/silly-lobsters-explain.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/utils": major
+---
+
+Fix CosmosNative address parsing

--- a/typescript/utils/src/addresses.ts
+++ b/typescript/utils/src/addresses.ts
@@ -404,6 +404,10 @@ export function bytesToAddressCosmos(
   return toBech32(prefix, bytes);
 }
 
+export function bytesToAddressCosmosNative(bytes: Uint8Array): Address {
+  return ensure0x(Buffer.from(bytes).toString('hex'));
+}
+
 export function bytesToAddressStarknet(bytes: Uint8Array): Address {
   const hexString = encode.buf2hex(bytes);
   return addAddressPadding(hexString);
@@ -425,7 +429,7 @@ export function bytesToProtocolAddress(
   } else if (toProtocol === ProtocolType.Cosmos) {
     return bytesToAddressCosmos(bytes, prefix!);
   } else if (toProtocol === ProtocolType.CosmosNative) {
-    return bytesToAddressCosmos(bytes, prefix!);
+    return bytesToAddressCosmosNative(bytes);
   } else if (toProtocol === ProtocolType.Starknet) {
     return bytesToAddressStarknet(bytes);
   } else {


### PR DESCRIPTION
### Description

This PR fixes the Cosmos Native address parsing.

### Drive-by changes

N/A

### Related issues

https://github.com/hyperlane-xyz/hyperlane-explorer/pull/219#issuecomment-2916778230

### Backward compatibility

Yes

### Testing

N/A
