### PR TITLE
feat: add revealMessageId migration

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", "cache/**", "types/**"]
+      "outputs": ["dist/**", "cache/**", "types/**", "src/generated/**"]
     },
     "test:ci": {
       "dependsOn": ["build", "^test:ci"]

--- a/typescript/ccip-server/prisma/migrations/20250606125803_update_commitment_pk/migration.sql
+++ b/typescript/ccip-server/prisma/migrations/20250606125803_update_commitment_pk/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - The primary key for the `Commitment` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- AlterTable
+ALTER TABLE "Commitment" DROP CONSTRAINT "Commitment_pkey",
+ADD CONSTRAINT "Commitment_pkey" PRIMARY KEY ("revealMessageId");


### PR DESCRIPTION
### Description

This migration should have been added as part of https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/6255/commits/ca714da5cd848961aead4134d5da82ce00ff3bd8#diff-6786590fa8ab71b31bbbf88a66d8d10d0af3c93096d687275d6817b85ba5a14b

It removes the unnecessary composite primary key

### Backward compatibility

No

### Testing

Tested locally and on the production deployment it is already live

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the primary key constraint on the "Commitment" table in the database. No changes to user-facing features.
  - Improved build configuration to include additional generated files in the output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->