### PR TITLE
fix(sdk): respect expectedRemoteChains when checking enrollments

### DIFF
--- a/.changeset/giant-snakes-pull.md
+++ b/.changeset/giant-snakes-pull.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Respect the expectedRemoteChains arg when checking enrolled routers in HyperlaneRouterChecker.

--- a/typescript/sdk/src/router/HyperlaneRouterChecker.ts
+++ b/typescript/sdk/src/router/HyperlaneRouterChecker.ts
@@ -150,6 +150,13 @@ export class HyperlaneRouterChecker<
     const router = this.app.router(this.app.getContracts(chain));
     const actualRemoteChains = await this.app.remoteChains(chain);
 
+    // If expectedRemoteChains is provided, only check those specific chains
+    // Otherwise, check all currently enrolled chains
+    const chainsToCheck =
+      expectedRemoteChains.length > 0
+        ? expectedRemoteChains.filter((c) => actualRemoteChains.includes(c))
+        : actualRemoteChains;
+
     const currentRouters: ChainMap<string> = {};
     const expectedRouters: ChainMap<string> = {};
 
@@ -163,7 +170,7 @@ export class HyperlaneRouterChecker<
     const missingRouterDomains: ChainName[] = [];
 
     await Promise.all(
-      actualRemoteChains.map(async (remoteChain) => {
+      chainsToCheck.map(async (remoteChain) => {
         let remoteRouterAddress: string;
         try {
           remoteRouterAddress = this.app.routerAddress(remoteChain);
@@ -188,7 +195,7 @@ export class HyperlaneRouterChecker<
       }),
     );
 
-    const expectedRouterChains = actualRemoteChains.filter(
+    const expectedRouterChains = chainsToCheck.filter(
       (chain) => !missingRouterDomains.includes(chain),
     );
 


### PR DESCRIPTION
### Description

fix(sdk): respect expectedRemoteChains when checking enrollments

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the enrollment verification process to correctly respect specified remote chains during router checks. If a list of expected remote chains is provided, only those chains are checked; otherwise, all enrolled chains are checked as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->