### PR TITLE
fix(sdk): backwards-compatibility ISM derivation with legacy ICAs

### DIFF
--- a/.changeset/many-buckets-sit.md
+++ b/.changeset/many-buckets-sit.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Enable backwards-compatibility ISM derivation with legacy ICAs.


### PR DESCRIPTION
### Description

fix(sdk): backwards-compatibility ISM derivation with legacy ICAs

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
