### PR TITLE
chore: Disable the Merlin chain in Relayers while it is down for upgrade

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -290,7 +290,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     mantapacific: true,
     mantle: true,
     matchain: true,
-    merlin: true,
+    merlin: false,
     metal: true,
     metis: true,
     milkyway: true,


### PR DESCRIPTION
### Description

Disable the Merlin chain in Relayers while it is down for upgrade

### Backward compatibility

Yes

### Testing

None