### PR TITLE
fix(sdk): don't use esm specific syntax for json import

### DIFF
--- a/.changeset/young-crabs-tap.md
+++ b/.changeset/young-crabs-tap.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Don't use esm specific syntax for json imports in SDK.

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 
 import { objMap } from '@hyperlane-xyz/utils';
 
-import packageJson from '../../package.json' with { type: 'json' };
+// @ts-ignore
+import packageJson from '../../package.json';
 import { HookConfig, HookType } from '../hook/types.js';
 import {
   IsmConfig,


### PR DESCRIPTION
### Description

fix(sdk): don't use esm specific syntax for json import

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved compatibility for JSON imports in the SDK by updating import syntax. No changes to functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->