### PR TITLE
fix(ci): bigger lint-prettier runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         run: yarn syncpack list-mismatches
 
   lint-prettier:
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -84,8 +84,6 @@ jobs:
 
       - name: lint
         run: yarn lint
-        env:
-          NODE_OPTIONS: --max_old_space_size=8192
 
       - name: Get changed PR files
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
### Description

fix(ci): bigger lint-prettier runner

temporary fix til we figure out why we need so much memory

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
