### PR TITLE
feat: add CLI Checker to validate owner correctness

### DIFF
--- a/typescript/sdk/src/contracts/contracts.hardhat-test.ts
+++ b/typescript/sdk/src/contracts/contracts.hardhat-test.ts
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import { Contract, Signer, ethers } from 'ethers';
+import hre from 'hardhat';
+
+import { ERC20Test__factory } from '@hyperlane-xyz/core';
+
+import { TestChainName } from '../consts/testChains.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+
+import { isAddressActive } from './contracts.js';
+
+describe('Contracts', () => {
+  let signer: Signer;
+  let contract: Contract;
+  let multiProvider: MultiProvider;
+  before(async () => {
+    [signer] = await hre.ethers.getSigners();
+
+    multiProvider = MultiProvider.createTestMultiProvider({ signer });
+    const factory = new ERC20Test__factory(signer);
+    contract = await factory.deploy(
+      'fake',
+      'FAKE',
+      '100000000000000000000',
+      18,
+    );
+    await contract.deployed();
+  });
+  describe('isAddressActive', async () => {
+    it('should return false for AddressZero', async () => {
+      const isActive = await isAddressActive(
+        multiProvider.getProvider(TestChainName.test1),
+        ethers.constants.AddressZero,
+      );
+
+      expect(isActive).to.be.false;
+    });
+
+    it('should return true for EOA address with some transactions', async () => {
+      const active = await isAddressActive(
+        multiProvider.getProvider(TestChainName.test1),
+        await signer.getAddress(),
+      );
+
+      expect(active).to.be.true;
+    });
+
+    it('should return true for contracts address with a non-zero nonce', async () => {
+      const active = await isAddressActive(
+        multiProvider.getProvider(TestChainName.test1),
+        contract.address,
+      );
+
+      expect(active).to.be.true;
+    });
+  });
+});

--- a/typescript/sdk/src/contracts/contracts.ts
+++ b/typescript/sdk/src/contracts/contracts.ts
@@ -14,6 +14,7 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
+import { EthersLikeProvider } from '../deploy/proxy.js';
 import { ChainMetadataManager } from '../metadata/ChainMetadataManager.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
@@ -304,4 +305,16 @@ export function transferOwnershipTransactions(
       ),
     },
   ];
+}
+
+export async function isAddressActive(
+  provider: EthersLikeProvider,
+  address: Address,
+): Promise<boolean> {
+  const [code, txnCount] = await Promise.all([
+    provider.getCode(address),
+    provider.getTransactionCount(address),
+  ]);
+
+  return code !== '0x' || txnCount > 0;
 }

--- a/typescript/sdk/src/deploy/proxy.ts
+++ b/typescript/sdk/src/deploy/proxy.ts
@@ -8,7 +8,7 @@ import { transferOwnershipTransactions } from '../contracts/contracts.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
 import { DeployedOwnableConfig } from '../types.js';
 
-type EthersLikeProvider = ethers.providers.Provider | ZKSyncProvider;
+export type EthersLikeProvider = ethers.providers.Provider | ZKSyncProvider;
 
 export type UpgradeConfig = {
   timelock: {

--- a/typescript/sdk/src/deploy/verify/ContractVerifier.ts
+++ b/typescript/sdk/src/deploy/verify/ContractVerifier.ts
@@ -296,12 +296,6 @@ export class ContractVerifier extends BaseContractVerifier {
     verificationLogger: Logger = this.logger,
   ): Promise<ContractVerificationStatus> {
     try {
-      const metadata = this.multiProvider.tryGetChainMetadata(chain);
-      const rpcUrl = metadata?.rpcUrls[0].http ?? '';
-      if (rpcUrl.includes('localhost') || rpcUrl.includes('127.0.0.1')) {
-        verificationLogger.debug('Skipping verification for local endpoints');
-        return ContractVerificationStatus.Skipped;
-      }
       verificationLogger.trace(
         `Fetching contract ABI for ${chain} address ${address}`,
       );

--- a/typescript/sdk/src/metadata/ChainMetadataManager.ts
+++ b/typescript/sdk/src/metadata/ChainMetadataManager.ts
@@ -469,4 +469,10 @@ export class ChainMetadataManager<MetaExt = {}> {
 
     return { intersection, result };
   }
+
+  isLocalRpc(chain: ChainName) {
+    const metadata = this.tryGetChainMetadata(chain);
+    const rpcUrl = metadata?.rpcUrls[0].http;
+    return rpcUrl?.includes('localhost') || rpcUrl?.includes('127.0.0.1');
+  }
 }

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -501,4 +501,33 @@ describe('ERC20WarpRouterReader', async () => {
       derivedConfig.remoteRouters![otherChainMetadata.domainId!].address,
     ).to.be.equal(addressToBytes32(warpRoute[otherChain].collateral.address));
   });
+
+  it('should return the ownerStatus virtual config', async () => {
+    const otherChain = TestChainName.test3;
+    const config: WarpRouteDeployConfigMailboxRequired = {
+      [chain]: {
+        type: TokenType.collateral,
+        token: token.address,
+        hook: await mailbox.defaultHook(),
+        ...baseConfig,
+      },
+      [otherChain]: {
+        type: TokenType.collateral,
+        token: token.address,
+        hook: await mailbox.defaultHook(),
+        ...baseConfig,
+      },
+    };
+    // Deploy with config
+    const warpRoute = await deployer.deploy(config);
+
+    // Derive config and check if remote router matches
+    const derivedConfig =
+      await evmERC20WarpRouteReader.deriveWarpRouteVirtualConfig(
+        chain,
+        warpRoute[chain].collateral.address,
+      );
+    console.log('derivedConfig', derivedConfig);
+    // TODO
+  });
 });

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -575,44 +575,6 @@ describe('ERC20WarpRouterReader', async () => {
     isLocalRpcStub.restore();
   });
 
-  it('should return the ownerStatus virtual config', async () => {
-    const otherChain = TestChainName.test3;
-    const config: WarpRouteDeployConfigMailboxRequired = {
-      [chain]: {
-        type: TokenType.collateral,
-        token: token.address,
-        hook: await mailbox.defaultHook(),
-        ...baseConfig,
-      },
-      [otherChain]: {
-        type: TokenType.collateral,
-        token: token.address,
-        hook: await mailbox.defaultHook(),
-        ...baseConfig,
-      },
-    };
-    // Deploy with config
-    const warpRoute = await deployer.deploy(config);
-
-    // Stub isLocalRpc to bypass local rpc check
-    const isLocalRpcStub = sinon
-      .stub(multiProvider, 'isLocalRpc')
-      .returns(false);
-
-    // Derive config and check if the owner is active
-    const derivedConfig =
-      await evmERC20WarpRouteReader.deriveWarpRouteVirtualConfig(
-        chain,
-        warpRoute[chain].collateral.address,
-      );
-    expect(derivedConfig.ownerStatus).to.deep.equal({
-      [signer.address]: OwnerStatus.Active,
-    });
-
-    // Restore stub
-    isLocalRpcStub.restore();
-  });
-
   it('should return the ownerStatus virtual config for the proxy, implementation, and proxy admin, if they are different', async () => {
     const provider = multiProvider.getProvider(chain);
     const otherChain = TestChainName.test3;

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -34,6 +34,7 @@ import {
   DerivedWarpRouteDeployConfig,
   HypTokenRouterConfig,
   HypTokenRouterVirtualConfig,
+  OwnerStatus,
   WarpRouteDeployConfig,
   WarpRouteDeployConfigMailboxRequired,
   isMovableCollateralTokenConfig,
@@ -193,7 +194,9 @@ export async function expandWarpDeployConfig(params: {
       const isEVMChain =
         multiProvider.getProtocol(chain) === ProtocolType.Ethereum;
 
-      // Expand EVM warpDeployConfig virtual to the control states
+      // Expand EVM warpDeployConfig virtual to the control states (states that we expect)
+      // For contractVerificationStatus, all values should be 'verified'
+      // For ownerStatus, all values should be 'active or 'gnosisSafe'
       if (
         expandedOnChainWarpConfig?.[chain]?.contractVerificationStatus &&
         multiProvider.getProtocol(chain) === ProtocolType.Ethereum
@@ -207,6 +210,29 @@ export async function expandWarpDeployConfig(params: {
               return ContractVerificationStatus.Skipped;
 
             return ContractVerificationStatus.Verified;
+          },
+        );
+      }
+
+      if (
+        expandedOnChainWarpConfig?.[chain]?.ownerStatus &&
+        multiProvider.getProtocol(chain) === ProtocolType.Ethereum
+      ) {
+        // For 'active' or 'gnosis-safe', we set their actual state as the control because they are both acceptable.
+        // For other cases, we expect 'active'
+        chainConfig.ownerStatus = objMap(
+          expandedOnChainWarpConfig[chain].ownerStatus ?? {},
+          (_, status) => {
+            // Skipped for local e2e testing
+            if (status === OwnerStatus.Skipped) return OwnerStatus.Skipped;
+
+            if (
+              status === OwnerStatus.Active ||
+              status === OwnerStatus.GnosisSafe
+            )
+              return status;
+
+            return OwnerStatus.Active;
           },
         );
       }

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -203,6 +203,12 @@ export enum ContractVerificationStatus {
   Error = 'error',
   Skipped = 'skipped',
 }
+export enum OwnerStatus {
+  Active = 'active',
+  Inactive = 'inactive',
+  Safe = 'safe',
+  Error = 'error',
+}
 export const HypTokenRouterVirtualConfigSchema = z.object({
   contractVerificationStatus: z.record(
     z.enum([
@@ -210,6 +216,14 @@ export const HypTokenRouterVirtualConfigSchema = z.object({
       ContractVerificationStatus.Unverified,
       ContractVerificationStatus.Error,
       ContractVerificationStatus.Skipped,
+    ]),
+  ),
+  ownerStatus: z.record(
+    z.enum([
+      OwnerStatus.Active,
+      OwnerStatus.Inactive,
+      OwnerStatus.Safe,
+      OwnerStatus.Error,
     ]),
   ),
 });

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -203,27 +203,30 @@ export enum ContractVerificationStatus {
   Error = 'error',
   Skipped = 'skipped',
 }
+
 export enum OwnerStatus {
-  Active = 'active',
+  Active = 'active', // Active address with nonce > 0 and/or contract code
   Inactive = 'inactive',
-  Safe = 'safe',
+  GnosisSafe = 'gnosis-safe',
   Error = 'error',
+  Skipped = 'skipped',
 }
 export const HypTokenRouterVirtualConfigSchema = z.object({
   contractVerificationStatus: z.record(
     z.enum([
-      ContractVerificationStatus.Verified,
-      ContractVerificationStatus.Unverified,
       ContractVerificationStatus.Error,
       ContractVerificationStatus.Skipped,
+      ContractVerificationStatus.Verified,
+      ContractVerificationStatus.Unverified,
     ]),
   ),
   ownerStatus: z.record(
     z.enum([
+      OwnerStatus.Error,
+      OwnerStatus.Skipped,
       OwnerStatus.Active,
       OwnerStatus.Inactive,
-      OwnerStatus.Safe,
-      OwnerStatus.Error,
+      OwnerStatus.GnosisSafe,
     ]),
   ),
 });

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -207,7 +207,7 @@ export enum ContractVerificationStatus {
 export enum OwnerStatus {
   Active = 'active', // Active address with nonce > 0 and/or contract code
   Inactive = 'inactive',
-  GnosisSafe = 'gnosis-safe',
+  GnosisSafe = 'gnosisSafe',
   Error = 'error',
   Skipped = 'skipped',
 }


### PR DESCRIPTION
### Description
This PR adds the ability to check if the warp route owner is `active and/or `gnosisSafe` through `warp check`

### Drive-by changes
- small cleanup of contract verification logic

### Backward compatibility
New feature but should be backwards compatible with existing warp routes

### Testing
Manual
