### PR TITLE
chore: Re-enable Merlin chain

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -290,7 +290,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     mantapacific: true,
     mantle: true,
     matchain: true,
-    merlin: false,
+    merlin: true,
     metal: true,
     metis: true,
     milkyway: true,


### PR DESCRIPTION
### Description

Re-enable Merlin chain since it is producing blocks now after the upgrade.

### Backward compatibility

Yes

### Testing

None