### PR TITLE
fix: export CONTRACTS_PACKAGE_VERSION from core package

### DIFF
--- a/solidity/bytecodeversion.sh
+++ b/solidity/bytecodeversion.sh
@@ -14,3 +14,19 @@ EOF
 
 # overwrite the original file with the temp file
 cat $TEMPFILE > $FILEPATH
+
+# Update core-utils/index.ts as well
+FILEPATH2="core-utils/index.ts"
+TEMPFILE2=$(mktemp)
+
+# writes all but the last 2 lines to the temp file
+head -n $(($(wc -l < $FILEPATH2) - 2)) $FILEPATH2 > $TEMPFILE2
+
+# writes generated last 2 lines to the temp file
+cat <<EOF >> $TEMPFILE2
+// GENERATED CODE - DO NOT EDIT
+export const CONTRACTS_PACKAGE_VERSION = '$npm_package_version';
+EOF
+
+# overwrite the original file with the temp file
+cat $TEMPFILE2 > $FILEPATH2

--- a/solidity/core-utils/index.ts
+++ b/solidity/core-utils/index.ts
@@ -1,2 +1,4 @@
 export * from './typechain/index.js';
 export * from './zksync/index.js';
+// GENERATED CODE - DO NOT EDIT
+export const CONTRACTS_PACKAGE_VERSION = '8.0.2';

--- a/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 import { UINT_256_MAX } from 'starknet';
 
 import {
+  CONTRACTS_PACKAGE_VERSION,
   ERC20Test,
   ERC20Test__factory,
   ERC4626Test,
@@ -62,7 +63,6 @@ import {
   isMovableCollateralTokenType,
 } from './config.js';
 import {
-  CONTRACTS_VERSION,
   HypTokenRouterConfig,
   HypTokenRouterConfigSchema,
   derivedHookAddress,
@@ -1162,7 +1162,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       await sendTxs(
         await evmERC20WarpModule.update({
           ...config,
-          contractVersion: CONTRACTS_VERSION,
+          contractVersion: CONTRACTS_PACKAGE_VERSION,
         }),
       );
 
@@ -1170,7 +1170,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       const updatedConfig = await evmERC20WarpModule.read();
 
       // Assert
-      expect(updatedConfig.contractVersion).to.eq(CONTRACTS_VERSION);
+      expect(updatedConfig.contractVersion).to.eq(CONTRACTS_PACKAGE_VERSION);
       const newImpl = await proxyImplementation(
         multiProvider.getProvider(chain),
         deployedTokenRoute,
@@ -1211,17 +1211,17 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       await expect(
         evmERC20WarpModule.update({
           ...config,
-          contractVersion: CONTRACTS_VERSION,
+          contractVersion: CONTRACTS_PACKAGE_VERSION,
         }),
       ).to.be.rejectedWith(
-        `Expected contract version ${CONTRACTS_VERSION} is lower than actual contract version ${reallyHighVersion}`,
+        `Expected contract version ${CONTRACTS_PACKAGE_VERSION} is lower than actual contract version ${reallyHighVersion}`,
       );
 
       versionStub.restore();
       const updatedConfig = await evmERC20WarpModule.read();
 
       // Assert
-      expect(updatedConfig.contractVersion).to.eq(CONTRACTS_VERSION);
+      expect(updatedConfig.contractVersion).to.eq(CONTRACTS_PACKAGE_VERSION);
     });
   });
 });

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -1,9 +1,9 @@
 import { compareVersions } from 'compare-versions';
 import { z } from 'zod';
 
+import { CONTRACTS_PACKAGE_VERSION } from '@hyperlane-xyz/core';
 import { objMap } from '@hyperlane-xyz/utils';
 
-import packageJson from '../../package.json' with { type: 'json' };
 import { HookConfig, HookType } from '../hook/types.js';
 import {
   IsmConfig,
@@ -21,19 +21,16 @@ import { isCompliant } from '../utils/schemas.js';
 
 import { TokenType } from './config.js';
 
-export const CONTRACTS_VERSION =
-  packageJson.dependencies['@hyperlane-xyz/core'];
-
 export const WarpRouteDeployConfigSchemaErrors = {
   ONLY_SYNTHETIC_REBASE: `Config with ${TokenType.collateralVaultRebase} must be deployed with ${TokenType.syntheticRebase}`,
   NO_SYNTHETIC_ONLY: `Config must include Native or Collateral OR all synthetics must define token metadata`,
 };
 
 export const contractVersionMatchesDependency = (version: string) => {
-  return compareVersions(version, CONTRACTS_VERSION) === 0;
+  return compareVersions(version, CONTRACTS_PACKAGE_VERSION) === 0;
 };
 
-export const VERSION_ERROR_MESSAGE = `Contract version must match the @hyperlane-xyz/core dependency version (${CONTRACTS_VERSION})`;
+export const VERSION_ERROR_MESSAGE = `Contract version must match the @hyperlane-xyz/core dependency version (${CONTRACTS_PACKAGE_VERSION})`;
 
 export const TokenMetadataSchema = z.object({
   name: z.string(),


### PR DESCRIPTION
### Description

fix: export CONTRACTS_PACKAGE_VERSION from core package

means we no longer need to directly import the package.json in the SDK

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
