### PR TITLE
feat(lander): run inclusion stage only when new block produced

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/provider.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/provider.rs
@@ -17,6 +17,7 @@ use solana_transaction_status::{
     UiTransactionStatusMeta,
 };
 use solana_transaction_status::{TransactionStatus, UiReturnDataEncoding};
+
 use tracing::warn;
 
 use hyperlane_core::{
@@ -96,6 +97,9 @@ pub trait SealevelProviderForLander: Send + Sync {
         signature: Signature,
         commitment: CommitmentConfig,
     ) -> ChainResult<bool>;
+
+    /// Gets the finalized block height.
+    async fn block_slot_finalized(&self) -> ChainResult<u32>;
 }
 
 /// A wrapper around a Sealevel provider to get generic blockchain information.
@@ -309,6 +313,10 @@ impl SealevelProviderForLander for SealevelProvider {
         self.rpc_client()
             .confirm_transaction_with_commitment(signature, commitment)
             .await
+    }
+
+    async fn block_slot_finalized(&self) -> ChainResult<u32> {
+        self.rpc_client.get_slot().await
     }
 }
 

--- a/rust/main/lander/src/adapter/chains/cosmos.rs
+++ b/rust/main/lander/src/adapter/chains/cosmos.rs
@@ -65,6 +65,10 @@ impl AdaptsChain for CosmosAdapter {
         todo!()
     }
 
+    async fn new_block_finalized(&self) -> std::result::Result<bool, LanderError> {
+        todo!()
+    }
+
     fn estimated_block_time(&self) -> &std::time::Duration {
         todo!()
     }

--- a/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_common.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_common.rs
@@ -130,6 +130,10 @@ impl SealevelProviderForLander for MockProvider {
     ) -> ChainResult<bool> {
         Ok(true)
     }
+
+    async fn block_slot_finalized(&self) -> ChainResult<u32> {
+        Ok(43)
+    }
 }
 
 pub fn estimate() -> SealevelTxCostEstimate {

--- a/rust/main/lander/src/adapter/core.rs
+++ b/rust/main/lander/src/adapter/core.rs
@@ -93,6 +93,9 @@ pub trait AdaptsChain: Send + Sync {
         Ok(Vec::new())
     }
 
+    /// Returns if a new block was finalized since the last call.
+    async fn new_block_finalized(&self) -> Result<bool, LanderError>;
+
     /// Returns the estimated block time of the chain. Used for polling pending transactions. Called in the Inclusion and Finality Stages of the PayloadDispatcher
     fn estimated_block_time(&self) -> &Duration;
 

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -19,9 +19,6 @@ use crate::{
 
 use super::{utils::call_until_success_or_nonretryable_error, DispatcherState};
 
-#[cfg(test)]
-pub mod tests;
-
 pub type InclusionStagePool = Arc<Mutex<HashMap<TransactionUuid, Transaction>>>;
 
 pub const STAGE_NAME: &str = "InclusionStage";
@@ -87,7 +84,7 @@ impl InclusionStage {
                 .metrics
                 .update_liveness_metric(format!("{}::receive_txs", STAGE_NAME).as_str(), &domain);
             if let Some(tx) = building_stage_receiver.recv().await {
-                // the lock is held until the metric is updated, to prevent race conditions
+                // the lock is held until the metric is updated to prevent race conditions
                 let mut pool_lock = pool.lock().await;
                 let pool_len = pool_lock.len();
                 pool_lock.insert(tx.uuid.clone(), tx.clone());
@@ -340,3 +337,6 @@ impl InclusionStage {
         Ok(())
     }
 }
+
+#[cfg(test)]
+pub mod tests;

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
@@ -25,6 +25,10 @@ async fn test_processing_included_txs() {
         .return_const(Duration::from_millis(10));
 
     mock_adapter
+        .expect_new_block_finalized()
+        .returning(|| Ok(true));
+
+    mock_adapter
         .expect_tx_status()
         .returning(|_| Ok(TransactionStatus::Included));
 
@@ -50,6 +54,10 @@ async fn test_unincluded_txs_reach_mempool() {
     mock_adapter
         .expect_estimated_block_time()
         .return_const(Duration::from_millis(10));
+
+    mock_adapter
+        .expect_new_block_finalized()
+        .returning(|| Ok(true));
 
     mock_adapter
         .expect_tx_ready_for_resubmission()
@@ -93,6 +101,10 @@ async fn test_failed_simulation() {
         .return_const(Duration::from_millis(10));
 
     mock_adapter
+        .expect_new_block_finalized()
+        .returning(|| Ok(true));
+
+    mock_adapter
         .expect_tx_ready_for_resubmission()
         .returning(|_| true);
 
@@ -128,6 +140,10 @@ async fn test_failed_estimation() {
     mock_adapter
         .expect_estimated_block_time()
         .return_const(Duration::from_millis(10));
+
+    mock_adapter
+        .expect_new_block_finalized()
+        .returning(|| Ok(true));
 
     mock_adapter
         .expect_tx_status()
@@ -192,6 +208,9 @@ async fn test_transaction_status_dropped() {
         .expect_estimated_block_time()
         .return_const(Duration::from_millis(10));
     mock_adapter
+        .expect_new_block_finalized()
+        .returning(|| Ok(true));
+    mock_adapter
         .expect_tx_status()
         .returning(|_| Ok(TransactionStatus::Dropped(TxDropReason::FailedSimulation)));
 
@@ -243,6 +262,9 @@ async fn test_failed_submission_after_simulation_and_estimation() {
         .expect_estimated_block_time()
         .return_const(Duration::from_millis(10));
     mock_adapter
+        .expect_new_block_finalized()
+        .returning(|| Ok(true));
+    mock_adapter
         .expect_tx_status()
         .returning(|_| Ok(TransactionStatus::PendingInclusion));
     mock_adapter
@@ -277,6 +299,9 @@ async fn test_transaction_included_immediately() {
         .expect_estimated_block_time()
         .return_const(Duration::from_millis(10));
     mock_adapter
+        .expect_new_block_finalized()
+        .returning(|| Ok(true));
+    mock_adapter
         .expect_tx_status()
         .returning(|_| Ok(TransactionStatus::Included));
 
@@ -300,6 +325,9 @@ async fn test_transaction_pending_then_included() {
     mock_adapter
         .expect_estimated_block_time()
         .return_const(Duration::from_millis(10));
+    mock_adapter
+        .expect_new_block_finalized()
+        .returning(|| Ok(true));
     let mut call_count = 0;
     mock_adapter.expect_tx_status().returning(move |_| {
         call_count += 1;

--- a/rust/main/lander/src/dispatcher/tests.rs
+++ b/rust/main/lander/src/dispatcher/tests.rs
@@ -376,6 +376,8 @@ fn mock_adapter_methods(mut adapter: MockAdapter, payload: FullPayload) -> MockA
         .expect_estimated_block_time()
         .return_const(Duration::from_millis(100));
 
+    adapter.expect_new_block_finalized().returning(|| Ok(true));
+
     let tx = dummy_tx(vec![payload.clone()], TransactionStatus::PendingInclusion);
     let tx_building_result = TxBuildingResult::new(vec![payload.details.clone()], Some(tx));
     let txs = vec![tx_building_result];

--- a/rust/main/lander/src/tests/ethereum/tests_inclusion_stage.rs
+++ b/rust/main/lander/src/tests/ethereum/tests_inclusion_stage.rs
@@ -959,6 +959,7 @@ fn mock_ethereum_adapter(
         batch_contract_address,
         payload_db,
         signer,
+        current_block_number: Default::default(),
     }
 }
 

--- a/rust/main/lander/src/tests/test_utils.rs
+++ b/rust/main/lander/src/tests/test_utils.rs
@@ -30,6 +30,7 @@ mockall::mock! {
         async fn tx_status(&self, tx: &Transaction) -> Result<TransactionStatus, LanderError>;
         async fn tx_ready_for_resubmission(&self, _tx: &Transaction) -> bool;
         async fn reverted_payloads(&self, tx: &Transaction) -> Result<Vec<PayloadDetails>, LanderError>;
+        async fn new_block_finalized(&self) -> Result<bool, LanderError>;
         fn estimated_block_time(&self) -> &std::time::Duration;
         fn max_batch_size(&self) -> u32;
         fn update_vm_specific_metrics(&self, _tx: &Transaction, _metrics: &DispatcherMetrics);


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
