### PR TITLE
chore: deploy relayer, stricter gas enforcement to starknet chains, ignore bad Neutron recipient msg

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -618,9 +618,6 @@ const gasPaymentEnforcement: GasPaymentEnforcement[] = [
       { destinationDomain: getDomainId('zeronetwork') },
       // Temporary workaround during testing of MilkyWay.
       { originDomain: getDomainId('milkyway') },
-      // Temporary workaround for incorrect gas limits estimated when sending to Starknet chains
-      { destinationDomain: getDomainId('starknet') },
-      { destinationDomain: getDomainId('paradex') },
       // Being more generous with some Velo message module messages, which occasionally underpay
       ...veloMessageModuleMatchingList,
     ],
@@ -820,7 +817,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'd8afb82-20250627-165046',
+      tag: '0e82fc3-20250630-122836',
     },
     blacklist,
     gasPaymentEnforcement: gasPaymentEnforcement,
@@ -866,7 +863,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: 'd8afb82-20250627-165046',
+      tag: '0e82fc3-20250630-122836',
     },
     blacklist,
     // We're temporarily (ab)using the RC relayer as a way to increase
@@ -910,7 +907,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '5f60dee-20250623-071346',
+      tag: '0e82fc3-20250630-122836',
     },
     blacklist,
     gasPaymentEnforcement,

--- a/typescript/infra/config/environments/mainnet3/customBlacklist.ts
+++ b/typescript/infra/config/environments/mainnet3/customBlacklist.ts
@@ -89,6 +89,7 @@ export const blacklistedMessageIds = [
   // Messages to a recipient that Neutron doesn't seem to allow
   '0x70be30b4f21cfe4dbb05c0c22601c6b4c9cf4a2a73727331dbbb6404d7566e1f',
   '0xc376df3e8d82de669b48b58e0521db5cf6c23a21fb2230487c30536f7b6503f7',
+  '0xe33edaf574065ad280dd961a50c2df21089dd5b0650ab840e3f1d61f473b4c93',
 
   // messages using the ICA call commitments with the wrong server address
   '0x69d5cfae80e3708a5cf57f2ee1590aa8806aef85fa5fb662de8cec51b7409167',


### PR DESCRIPTION
### Description

- Now that we should be paying correct gas amounts to starknet chains, we enforce some stricter gas payment enforcement when sending to a starknet chain
- Ignores a message with a bad Neutron recipient (https://hyperlaneworkspace.slack.com/archives/C08HE2R697U/p1751291878494549?thread_ts=1750562486.790529&cid=C08HE2R697U) that seems unable to receive tokens
- Updates the image to include galactica

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
