### PR TITLE
fix: Remove absolute imports

### DIFF
--- a/.changeset/large-flies-rescue.md
+++ b/.changeset/large-flies-rescue.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": patch
+---
+
+Remove absolute imports. Fixes compilation for users who import from files under `solidity/contracts`.

--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -15,6 +15,7 @@ docs
 flattened/
 buildArtifact.json
 fixtures/
+broadcast/
 # ZKSync
 artifacts-zk
 cache-zk

--- a/solidity/contracts/AttributeCheckpointFraud.sol
+++ b/solidity/contracts/AttributeCheckpointFraud.sol
@@ -5,7 +5,7 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
-import {PackageVersioned} from "contracts/PackageVersioned.sol";
+import {PackageVersioned} from "@home/PackageVersioned.sol";
 import {TREE_DEPTH} from "./libs/Merkle.sol";
 import {CheckpointLib, Checkpoint} from "./libs/CheckpointLib.sol";
 import {CheckpointFraudProofs} from "./CheckpointFraudProofs.sol";

--- a/solidity/contracts/AttributeCheckpointFraud.sol
+++ b/solidity/contracts/AttributeCheckpointFraud.sol
@@ -5,7 +5,7 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
-import {PackageVersioned} from "@home/PackageVersioned.sol";
+import {PackageVersioned} from "./PackageVersioned.sol";
 import {TREE_DEPTH} from "./libs/Merkle.sol";
 import {CheckpointLib, Checkpoint} from "./libs/CheckpointLib.sol";
 import {CheckpointFraudProofs} from "./CheckpointFraudProofs.sol";

--- a/solidity/contracts/avs/HyperlaneServiceManager.sol
+++ b/solidity/contracts/avs/HyperlaneServiceManager.sol
@@ -19,7 +19,7 @@ import {IAVSDirectory} from "../interfaces/avs/vendored/IAVSDirectory.sol";
 import {IRemoteChallenger} from "../interfaces/avs/IRemoteChallenger.sol";
 import {ISlasher} from "../interfaces/avs/vendored/ISlasher.sol";
 import {ECDSAServiceManagerBase} from "./ECDSAServiceManagerBase.sol";
-import {PackageVersioned} from "contracts/PackageVersioned.sol";
+import {PackageVersioned} from "@home/PackageVersioned.sol";
 
 contract HyperlaneServiceManager is ECDSAServiceManagerBase, PackageVersioned {
     // ============ Libraries ============

--- a/solidity/contracts/avs/HyperlaneServiceManager.sol
+++ b/solidity/contracts/avs/HyperlaneServiceManager.sol
@@ -19,7 +19,7 @@ import {IAVSDirectory} from "../interfaces/avs/vendored/IAVSDirectory.sol";
 import {IRemoteChallenger} from "../interfaces/avs/IRemoteChallenger.sol";
 import {ISlasher} from "../interfaces/avs/vendored/ISlasher.sol";
 import {ECDSAServiceManagerBase} from "./ECDSAServiceManagerBase.sol";
-import {PackageVersioned} from "@home/PackageVersioned.sol";
+import {PackageVersioned} from "../PackageVersioned.sol";
 
 contract HyperlaneServiceManager is ECDSAServiceManagerBase, PackageVersioned {
     // ============ Libraries ============

--- a/solidity/contracts/hooks/warp-route/RateLimitedHook.sol
+++ b/solidity/contracts/hooks/warp-route/RateLimitedHook.sol
@@ -14,11 +14,11 @@ pragma solidity >=0.8.0;
 @@@@@@@@@       @@@@@@@@*/
 
 // ============ Internal Imports ============
-import {MailboxClient} from "contracts/client/MailboxClient.sol";
-import {IPostDispatchHook} from "contracts/interfaces/hooks/IPostDispatchHook.sol";
-import {Message} from "contracts/libs/Message.sol";
-import {TokenMessage} from "contracts/token/libs/TokenMessage.sol";
-import {RateLimited} from "contracts/libs/RateLimited.sol";
+import {MailboxClient} from "@home/client/MailboxClient.sol";
+import {IPostDispatchHook} from "@home/interfaces/hooks/IPostDispatchHook.sol";
+import {Message} from "@home/libs/Message.sol";
+import {TokenMessage} from "@home/token/libs/TokenMessage.sol";
+import {RateLimited} from "@home/libs/RateLimited.sol";
 import {AbstractPostDispatchHook} from "../libs/AbstractPostDispatchHook.sol";
 
 /*

--- a/solidity/contracts/hooks/warp-route/RateLimitedHook.sol
+++ b/solidity/contracts/hooks/warp-route/RateLimitedHook.sol
@@ -14,12 +14,12 @@ pragma solidity >=0.8.0;
 @@@@@@@@@       @@@@@@@@*/
 
 // ============ Internal Imports ============
-import {MailboxClient} from "@home/client/MailboxClient.sol";
-import {IPostDispatchHook} from "@home/interfaces/hooks/IPostDispatchHook.sol";
-import {Message} from "@home/libs/Message.sol";
-import {TokenMessage} from "@home/token/libs/TokenMessage.sol";
-import {RateLimited} from "@home/libs/RateLimited.sol";
-import {AbstractPostDispatchHook} from "../libs/AbstractPostDispatchHook.sol";
+import {MailboxClient} from "../../client/MailboxClient.sol";
+import {IPostDispatchHook} from "../../interfaces/hooks/IPostDispatchHook.sol";
+import {Message} from "../../libs/Message.sol";
+import {TokenMessage} from "../../token/libs/TokenMessage.sol";
+import {RateLimited} from "../../libs/RateLimited.sol";
+import {AbstractPostDispatchHook} from "../../hooks/libs/AbstractPostDispatchHook.sol";
 
 /*
  * @title RateLimitedHook

--- a/solidity/contracts/isms/NoopIsm.sol
+++ b/solidity/contracts/isms/NoopIsm.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 import {IInterchainSecurityModule} from "../interfaces/IInterchainSecurityModule.sol";
-import {PackageVersioned} from "contracts/PackageVersioned.sol";
+import {PackageVersioned} from "@home/PackageVersioned.sol";
 
 contract NoopIsm is IInterchainSecurityModule, PackageVersioned {
     uint8 public constant override moduleType = uint8(Types.NULL);

--- a/solidity/contracts/isms/NoopIsm.sol
+++ b/solidity/contracts/isms/NoopIsm.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 import {IInterchainSecurityModule} from "../interfaces/IInterchainSecurityModule.sol";
-import {PackageVersioned} from "@home/PackageVersioned.sol";
+import {PackageVersioned} from "../PackageVersioned.sol";
 
 contract NoopIsm is IInterchainSecurityModule, PackageVersioned {
     uint8 public constant override moduleType = uint8(Types.NULL);

--- a/solidity/contracts/isms/PausableIsm.sol
+++ b/solidity/contracts/isms/PausableIsm.sol
@@ -7,7 +7,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 // ============ Internal Imports ============
 import {IInterchainSecurityModule} from "../interfaces/IInterchainSecurityModule.sol";
-import {PackageVersioned} from "contracts/PackageVersioned.sol";
+import {PackageVersioned} from "@home/PackageVersioned.sol";
 
 contract PausableIsm is
     IInterchainSecurityModule,

--- a/solidity/contracts/isms/PausableIsm.sol
+++ b/solidity/contracts/isms/PausableIsm.sol
@@ -7,7 +7,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 // ============ Internal Imports ============
 import {IInterchainSecurityModule} from "../interfaces/IInterchainSecurityModule.sol";
-import {PackageVersioned} from "@home/PackageVersioned.sol";
+import {PackageVersioned} from "../PackageVersioned.sol";
 
 contract PausableIsm is
     IInterchainSecurityModule,

--- a/solidity/contracts/isms/TrustedRelayerIsm.sol
+++ b/solidity/contracts/isms/TrustedRelayerIsm.sol
@@ -6,7 +6,7 @@ import {IInterchainSecurityModule} from "../interfaces/IInterchainSecurityModule
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {Message} from "../libs/Message.sol";
 import {Mailbox} from "../Mailbox.sol";
-import {PackageVersioned} from "contracts/PackageVersioned.sol";
+import {PackageVersioned} from "@home/PackageVersioned.sol";
 
 contract TrustedRelayerIsm is IInterchainSecurityModule, PackageVersioned {
     using Message for bytes;

--- a/solidity/contracts/isms/TrustedRelayerIsm.sol
+++ b/solidity/contracts/isms/TrustedRelayerIsm.sol
@@ -6,7 +6,7 @@ import {IInterchainSecurityModule} from "../interfaces/IInterchainSecurityModule
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {Message} from "../libs/Message.sol";
 import {Mailbox} from "../Mailbox.sol";
-import {PackageVersioned} from "@home/PackageVersioned.sol";
+import {PackageVersioned} from "../PackageVersioned.sol";
 
 contract TrustedRelayerIsm is IInterchainSecurityModule, PackageVersioned {
     using Message for bytes;

--- a/solidity/contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol
+++ b/solidity/contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol
@@ -18,7 +18,7 @@ pragma solidity >=0.8.0;
 import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
 import {LibBit} from "../../libs/LibBit.sol";
 import {Message} from "../../libs/Message.sol";
-import {PackageVersioned} from "contracts/PackageVersioned.sol";
+import {PackageVersioned} from "@home/PackageVersioned.sol";
 
 // ============ External Imports ============
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/solidity/contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol
+++ b/solidity/contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol
@@ -18,7 +18,7 @@ pragma solidity >=0.8.0;
 import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
 import {LibBit} from "../../libs/LibBit.sol";
 import {Message} from "../../libs/Message.sol";
-import {PackageVersioned} from "@home/PackageVersioned.sol";
+import {PackageVersioned} from "../../PackageVersioned.sol";
 
 // ============ External Imports ============
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/solidity/contracts/isms/warp-route/RateLimitedIsm.sol
+++ b/solidity/contracts/isms/warp-route/RateLimitedIsm.sol
@@ -3,10 +3,10 @@ pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============
 import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
-import {MailboxClient} from "contracts/client/MailboxClient.sol";
-import {RateLimited} from "contracts/libs/RateLimited.sol";
-import {Message} from "contracts/libs/Message.sol";
-import {TokenMessage} from "contracts/token/libs/TokenMessage.sol";
+import {MailboxClient} from "@home/client/MailboxClient.sol";
+import {RateLimited} from "@home/libs/RateLimited.sol";
+import {Message} from "@home/libs/Message.sol";
+import {TokenMessage} from "@home/token/libs/TokenMessage.sol";
 
 contract RateLimitedIsm is
     MailboxClient,

--- a/solidity/contracts/isms/warp-route/RateLimitedIsm.sol
+++ b/solidity/contracts/isms/warp-route/RateLimitedIsm.sol
@@ -3,10 +3,10 @@ pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============
 import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
-import {MailboxClient} from "@home/client/MailboxClient.sol";
-import {RateLimited} from "@home/libs/RateLimited.sol";
-import {Message} from "@home/libs/Message.sol";
-import {TokenMessage} from "@home/token/libs/TokenMessage.sol";
+import {MailboxClient} from "../../client/MailboxClient.sol";
+import {RateLimited} from "../../libs/RateLimited.sol";
+import {Message} from "../../libs/Message.sol";
+import {TokenMessage} from "../../token/libs/TokenMessage.sol";
 
 contract RateLimitedIsm is
     MailboxClient,

--- a/solidity/contracts/token/HypNative.sol
+++ b/solidity/contracts/token/HypNative.sol
@@ -4,8 +4,8 @@ pragma solidity >=0.8.0;
 import {TokenRouter} from "./libs/TokenRouter.sol";
 import {FungibleTokenRouter} from "./libs/FungibleTokenRouter.sol";
 import {MovableCollateralRouter} from "./libs/MovableCollateralRouter.sol";
-import {ITokenBridge} from "contracts/interfaces/ITokenBridge.sol";
-import {Quote} from "contracts/interfaces/ITokenBridge.sol";
+import {ITokenBridge} from "@home/interfaces/ITokenBridge.sol";
+import {Quote} from "@home/interfaces/ITokenBridge.sol";
 
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 

--- a/solidity/contracts/token/HypNative.sol
+++ b/solidity/contracts/token/HypNative.sol
@@ -4,8 +4,8 @@ pragma solidity >=0.8.0;
 import {TokenRouter} from "./libs/TokenRouter.sol";
 import {FungibleTokenRouter} from "./libs/FungibleTokenRouter.sol";
 import {MovableCollateralRouter} from "./libs/MovableCollateralRouter.sol";
-import {ITokenBridge} from "@home/interfaces/ITokenBridge.sol";
-import {Quote} from "@home/interfaces/ITokenBridge.sol";
+import {ITokenBridge} from "../interfaces/ITokenBridge.sol";
+import {Quote} from "../interfaces/ITokenBridge.sol";
 
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 

--- a/solidity/contracts/token/extensions/HypERC4626.sol
+++ b/solidity/contracts/token/extensions/HypERC4626.sol
@@ -18,7 +18,7 @@ import {HypERC20} from "../HypERC20.sol";
 import {Message} from "../../libs/Message.sol";
 import {TokenMessage} from "../libs/TokenMessage.sol";
 import {TokenRouter} from "../libs/TokenRouter.sol";
-import {Router} from "contracts/client/Router.sol";
+import {Router} from "@home/client/Router.sol";
 import {FungibleTokenRouter} from "../libs/FungibleTokenRouter.sol";
 
 // ============ External Imports ============

--- a/solidity/contracts/token/extensions/HypERC4626.sol
+++ b/solidity/contracts/token/extensions/HypERC4626.sol
@@ -18,7 +18,7 @@ import {HypERC20} from "../HypERC20.sol";
 import {Message} from "../../libs/Message.sol";
 import {TokenMessage} from "../libs/TokenMessage.sol";
 import {TokenRouter} from "../libs/TokenRouter.sol";
-import {Router} from "@home/client/Router.sol";
+import {Router} from "../../client/Router.sol";
 import {FungibleTokenRouter} from "../libs/FungibleTokenRouter.sol";
 
 // ============ External Imports ============

--- a/solidity/contracts/token/libs/MovableCollateralRouter.sol
+++ b/solidity/contracts/token/libs/MovableCollateralRouter.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.0;
 
-import {Router} from "contracts/client/Router.sol";
+import {Router} from "@home/client/Router.sol";
 import {FungibleTokenRouter} from "./FungibleTokenRouter.sol";
-import {ITokenBridge} from "contracts/interfaces/ITokenBridge.sol";
+import {ITokenBridge} from "@home/interfaces/ITokenBridge.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/solidity/contracts/token/libs/MovableCollateralRouter.sol
+++ b/solidity/contracts/token/libs/MovableCollateralRouter.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.0;
 
-import {Router} from "@home/client/Router.sol";
+import {Router} from "../../client/Router.sol";
 import {FungibleTokenRouter} from "./FungibleTokenRouter.sol";
-import {ITokenBridge} from "@home/interfaces/ITokenBridge.sol";
+import {ITokenBridge} from "../../interfaces/ITokenBridge.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/solidity/contracts/token/libs/TokenRouter.sol
+++ b/solidity/contracts/token/libs/TokenRouter.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============
-import {TypeCasts} from "contracts/libs/TypeCasts.sol";
+import {TypeCasts} from "@home/libs/TypeCasts.sol";
 import {GasRouter} from "../../client/GasRouter.sol";
 import {TokenMessage} from "./TokenMessage.sol";
 import {Quote, ITokenBridge} from "../../interfaces/ITokenBridge.sol";

--- a/solidity/contracts/token/libs/TokenRouter.sol
+++ b/solidity/contracts/token/libs/TokenRouter.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============
-import {TypeCasts} from "@home/libs/TypeCasts.sol";
+import {TypeCasts} from "../../libs/TypeCasts.sol";
 import {GasRouter} from "../../client/GasRouter.sol";
 import {TokenMessage} from "./TokenMessage.sol";
 import {Quote, ITokenBridge} from "../../interfaces/ITokenBridge.sol";

--- a/solidity/remappings.txt
+++ b/solidity/remappings.txt
@@ -6,3 +6,4 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
 fx-portal/=lib/fx-portal/
+@home=./contracts

--- a/solidity/remappings.txt
+++ b/solidity/remappings.txt
@@ -6,4 +6,3 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
 fx-portal/=lib/fx-portal/
-@home=./contracts

--- a/solidity/script/xerc20/ApproveLockbox.s.sol
+++ b/solidity/script/xerc20/ApproveLockbox.s.sol
@@ -4,16 +4,16 @@ pragma solidity >=0.8.0;
 import "forge-std/Script.sol";
 
 import {AnvilRPC} from "test/AnvilRPC.sol";
-import {TypeCasts} from "contracts/libs/TypeCasts.sol";
+import {TypeCasts} from "@home/libs/TypeCasts.sol";
 
 import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
-import {ProxyAdmin} from "contracts/upgrade/ProxyAdmin.sol";
+import {ProxyAdmin} from "@home/upgrade/ProxyAdmin.sol";
 
-import {HypXERC20Lockbox} from "contracts/token/extensions/HypXERC20Lockbox.sol";
-import {IXERC20Lockbox} from "contracts/token/interfaces/IXERC20Lockbox.sol";
-import {IXERC20} from "contracts/token/interfaces/IXERC20.sol";
-import {IERC20} from "contracts/token/interfaces/IXERC20.sol";
+import {HypXERC20Lockbox} from "@home/token/extensions/HypXERC20Lockbox.sol";
+import {IXERC20Lockbox} from "@home/token/interfaces/IXERC20Lockbox.sol";
+import {IXERC20} from "@home/token/interfaces/IXERC20.sol";
+import {IERC20} from "@home/token/interfaces/IXERC20.sol";
 
 // source .env.<CHAIN>
 // forge script ApproveLockbox.s.sol --broadcast --rpc-url localhost:XXXX

--- a/solidity/script/xerc20/ApproveLockbox.s.sol
+++ b/solidity/script/xerc20/ApproveLockbox.s.sol
@@ -4,16 +4,15 @@ pragma solidity >=0.8.0;
 import "forge-std/Script.sol";
 
 import {AnvilRPC} from "test/AnvilRPC.sol";
-import {TypeCasts} from "@home/libs/TypeCasts.sol";
+import {TypeCasts} from "contracts/libs/TypeCasts.sol";
 
 import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
-import {ProxyAdmin} from "@home/upgrade/ProxyAdmin.sol";
+import {ProxyAdmin} from "contracts/upgrade/ProxyAdmin.sol";
 
-import {HypXERC20Lockbox} from "@home/token/extensions/HypXERC20Lockbox.sol";
-import {IXERC20Lockbox} from "@home/token/interfaces/IXERC20Lockbox.sol";
-import {IXERC20} from "@home/token/interfaces/IXERC20.sol";
-import {IERC20} from "@home/token/interfaces/IXERC20.sol";
+import {HypXERC20Lockbox} from "contracts/token/extensions/HypXERC20Lockbox.sol";
+import {IXERC20Lockbox} from "contracts/token/interfaces/IXERC20Lockbox.sol";
+import {IXERC20, IERC20} from "contracts/token/interfaces/IXERC20.sol";
 
 // source .env.<CHAIN>
 // forge script ApproveLockbox.s.sol --broadcast --rpc-url localhost:XXXX

--- a/solidity/script/xerc20/GrantLimits.s.sol
+++ b/solidity/script/xerc20/GrantLimits.s.sol
@@ -5,9 +5,9 @@ import "forge-std/Script.sol";
 
 import {AnvilRPC} from "test/AnvilRPC.sol";
 
-import {IXERC20Lockbox} from "contracts/token/interfaces/IXERC20Lockbox.sol";
-import {IXERC20} from "contracts/token/interfaces/IXERC20.sol";
-import {IERC20} from "contracts/token/interfaces/IXERC20.sol";
+import {IXERC20Lockbox} from "@home/token/interfaces/IXERC20Lockbox.sol";
+import {IXERC20} from "@home/token/interfaces/IXERC20.sol";
+import {IERC20} from "@home/token/interfaces/IXERC20.sol";
 
 // source .env.<CHAIN>
 // anvil --fork-url $RPC_URL --port XXXX

--- a/solidity/script/xerc20/GrantLimits.s.sol
+++ b/solidity/script/xerc20/GrantLimits.s.sol
@@ -3,11 +3,11 @@ pragma solidity >=0.8.0;
 
 import "forge-std/Script.sol";
 
-import {AnvilRPC} from "test/AnvilRPC.sol";
+import {AnvilRPC} from "../../test/AnvilRPC.sol";
 
-import {IXERC20Lockbox} from "@home/token/interfaces/IXERC20Lockbox.sol";
-import {IXERC20} from "@home/token/interfaces/IXERC20.sol";
-import {IERC20} from "@home/token/interfaces/IXERC20.sol";
+import {IXERC20Lockbox} from "contracts/token/interfaces/IXERC20Lockbox.sol";
+import {IXERC20} from "contracts/token/interfaces/IXERC20.sol";
+import {IERC20} from "contracts/token/interfaces/IXERC20.sol";
 
 // source .env.<CHAIN>
 // anvil --fork-url $RPC_URL --port XXXX


### PR DESCRIPTION
### Description

All absolute imports are removed. Absolute imports let us easily see the full path to a file, but prevent compilation when this repo is installed as a dependency. See https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/6560/files. 

### Issues
Fixes #6559



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated import paths throughout the Solidity project to use consistent relative paths.
  * Updated the ignore list to exclude the broadcast directory from version control.
  * Simplified import statements in select script files for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->