### PR TITLE
feat: add regex to matching list

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
@@ -280,6 +280,7 @@ mod test {
                     Filter::Wildcard,
                     Filter::Wildcard,
                     Filter::Wildcard,
+                    None,
                 )])),
                 "abcd".to_string(),
             )],

--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -299,6 +299,10 @@ pub mod test {
             &self.recipient_address
         }
 
+        fn body(&self) -> &[u8] {
+            &[]
+        }
+
         fn get_metric(&self) -> Option<Arc<IntGauge>> {
             None
         }
@@ -663,6 +667,7 @@ pub mod test {
                     Filter::Wildcard,
                     Filter::Wildcard,
                     Filter::Wildcard,
+                    None,
                 )])),
                 transmitter: transmitter.clone(),
             })
@@ -719,6 +724,7 @@ pub mod test {
                     Filter::Wildcard,
                     Filter::Enumerated(vec![KnownHyperlaneDomain::Optimism as u32]),
                     Filter::Wildcard,
+                    None,
                 )])),
                 transmitter: transmitter.clone(),
             })
@@ -776,6 +782,7 @@ pub mod test {
                         Filter::Wildcard,
                         Filter::Wildcard,
                         Filter::Wildcard,
+                        None,
                     ),
                     ListElement::new(
                         Filter::Wildcard,
@@ -783,6 +790,7 @@ pub mod test {
                         Filter::Wildcard,
                         Filter::Enumerated(vec![KnownHyperlaneDomain::Arbitrum as u32]),
                         Filter::Wildcard,
+                        None,
                     ),
                 ])),
                 transmitter: transmitter.clone(),
@@ -840,6 +848,7 @@ pub mod test {
                     Filter::Wildcard,
                     Filter::Wildcard,
                     Filter::Wildcard,
+                    None,
                 ),
                 ListElement::new(
                     Filter::Wildcard,
@@ -847,6 +856,7 @@ pub mod test {
                     Filter::Wildcard,
                     Filter::Enumerated(vec![KnownHyperlaneDomain::Arbitrum as u32]),
                     Filter::Wildcard,
+                    None,
                 ),
             ])),
             transmitter: transmitter.clone(),

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -204,6 +204,10 @@ impl PendingOperation for PendingMessage {
         &self.message.recipient
     }
 
+    fn body(&self) -> &[u8] {
+        &self.message.body
+    }
+
     fn retrieve_status_from_db(&self) -> Option<PendingOperationStatus> {
         match self.ctx.origin_db.retrieve_status_by_message_id(&self.id()) {
             Ok(status) => status,

--- a/rust/main/agents/relayer/src/settings/matching_list.rs
+++ b/rust/main/agents/relayer/src/settings/matching_list.rs
@@ -9,9 +9,11 @@ use std::{
 };
 
 use derive_new::new;
+use ethers::utils::hex;
 use hyperlane_core::{
     config::StrOrInt, utils::hex_or_base58_to_h256, HyperlaneMessage, QueueOperation, H256,
 };
+use regex::Regex;
 use serde::{
     de::{Error, SeqAccess, Visitor},
     Deserialize, Deserializer,
@@ -27,6 +29,52 @@ use serde::{
 /// - list of values in decimal or hex format
 #[derive(Debug, Default, Clone)]
 pub struct MatchingList(pub Option<Vec<ListElement>>);
+
+impl MatchingList {
+    pub fn with_message_id(message_id: H256) -> Self {
+        Self(Some(vec![ListElement {
+            message_id: Filter::Enumerated(vec![message_id]),
+            origin_domain: Default::default(),
+            sender_address: Default::default(),
+            destination_domain: Default::default(),
+            recipient_address: Default::default(),
+            regex: Default::default(),
+        }]))
+    }
+
+    pub fn with_destination_domain(destination_domain: u32) -> Self {
+        Self(Some(vec![ListElement {
+            message_id: Default::default(),
+            origin_domain: Default::default(),
+            sender_address: Default::default(),
+            destination_domain: Filter::Enumerated(vec![destination_domain]),
+            recipient_address: Default::default(),
+            regex: Default::default(),
+        }]))
+    }
+
+    /// Check if a message matches any of the rules.
+    /// - `default`: What to return if the matching list is empty.
+    pub fn msg_matches(&self, msg: &HyperlaneMessage, default: bool) -> bool {
+        self.matches(msg.into(), default)
+    }
+
+    /// Check if queue operation matches any of the rules.
+    /// If the matching list is empty, we assume the queue operation does not match.
+    pub fn op_matches(&self, op: &QueueOperation) -> bool {
+        self.matches(op.into(), false)
+    }
+
+    /// Check if a message matches any of the rules.
+    /// - `default`: What to return if the matching list is empty.
+    fn matches(&self, info: MatchInfo, default: bool) -> bool {
+        if let Some(rules) = &self.0 {
+            matches_any_rule(rules.iter(), info)
+        } else {
+            default
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Filter<T> {
@@ -196,6 +244,26 @@ impl<'de> Visitor<'de> for FilterVisitor<H256> {
     }
 }
 
+impl<'de> Visitor<'de> for FilterVisitor<RegexWrapper> {
+    type Value = RegexWrapper;
+
+    fn expecting(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "Expecting either a wildcard \"*\", hex/base58 address string, or list of hex/base58 address strings"
+        )
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Regex::new(v)
+            .map(|regex| RegexWrapper(regex))
+            .map_err(|err| E::custom(err.to_string()))
+    }
+}
+
 impl<'de> Deserialize<'de> for MatchingList {
     fn deserialize<D>(d: D) -> Result<Self, D::Error>
     where
@@ -223,6 +291,18 @@ impl<'de> Deserialize<'de> for Filter<H256> {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct RegexWrapper(pub Regex);
+
+impl<'de> Deserialize<'de> for RegexWrapper {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        d.deserialize_any(FilterVisitor::<RegexWrapper>(Default::default()))
+    }
+}
+
 #[derive(Debug, Deserialize, Clone, new)]
 #[serde(tag = "type")]
 pub struct ListElement {
@@ -236,6 +316,8 @@ pub struct ListElement {
     destination_domain: Filter<u32>,
     #[serde(default, rename = "recipientaddress")]
     recipient_address: Filter<H256>,
+    #[serde(default, rename = "regex")]
+    regex: Option<RegexWrapper>,
 }
 
 impl Display for ListElement {
@@ -252,13 +334,14 @@ impl Display for ListElement {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 struct MatchInfo<'a> {
     src_msg_id: H256,
     src_domain: u32,
     src_addr: &'a H256,
     dst_domain: u32,
     dst_addr: &'a H256,
+    body: String,
 }
 
 impl<'a> From<&'a HyperlaneMessage> for MatchInfo<'a> {
@@ -269,6 +352,7 @@ impl<'a> From<&'a HyperlaneMessage> for MatchInfo<'a> {
             src_addr: &msg.sender,
             dst_domain: msg.destination,
             dst_addr: &msg.recipient,
+            body: hex::encode(&msg.body),
         }
     }
 }
@@ -281,50 +365,7 @@ impl<'a> From<&'a QueueOperation> for MatchInfo<'a> {
             src_addr: op.sender_address(),
             dst_domain: op.destination_domain().id(),
             dst_addr: op.recipient_address(),
-        }
-    }
-}
-
-impl MatchingList {
-    pub fn with_message_id(message_id: H256) -> Self {
-        Self(Some(vec![ListElement {
-            message_id: Filter::Enumerated(vec![message_id]),
-            origin_domain: Default::default(),
-            sender_address: Default::default(),
-            destination_domain: Default::default(),
-            recipient_address: Default::default(),
-        }]))
-    }
-
-    pub fn with_destination_domain(destination_domain: u32) -> Self {
-        Self(Some(vec![ListElement {
-            message_id: Default::default(),
-            origin_domain: Default::default(),
-            sender_address: Default::default(),
-            destination_domain: Filter::Enumerated(vec![destination_domain]),
-            recipient_address: Default::default(),
-        }]))
-    }
-
-    /// Check if a message matches any of the rules.
-    /// - `default`: What to return if the matching list is empty.
-    pub fn msg_matches(&self, msg: &HyperlaneMessage, default: bool) -> bool {
-        self.matches(msg.into(), default)
-    }
-
-    /// Check if queue operation matches any of the rules.
-    /// If the matching list is empty, we assume the queue operation does not match.
-    pub fn op_matches(&self, op: &QueueOperation) -> bool {
-        self.matches(op.into(), false)
-    }
-
-    /// Check if a message matches any of the rules.
-    /// - `default`: What to return if the matching list is empty.
-    fn matches(&self, info: MatchInfo, default: bool) -> bool {
-        if let Some(rules) = &self.0 {
-            matches_any_rule(rules.iter(), info)
-        } else {
-            default
+            body: hex::encode(op.body()),
         }
     }
 }
@@ -336,6 +377,11 @@ fn matches_any_rule<'a>(mut rules: impl Iterator<Item = &'a ListElement>, info: 
             && rule.sender_address.matches(info.src_addr)
             && rule.destination_domain.matches(&info.dst_domain)
             && rule.recipient_address.matches(info.dst_addr)
+            && rule
+                .regex
+                .as_ref()
+                .map(|regex| regex.0.is_match(&info.body))
+                .unwrap_or(true)
     })
 }
 
@@ -393,7 +439,8 @@ mod test {
                 src_domain: 0,
                 src_addr: &H256::default(),
                 dst_domain: 0,
-                dst_addr: &H256::default()
+                dst_addr: &H256::default(),
+                body: "".into(),
             },
             false
         ));
@@ -407,7 +454,8 @@ mod test {
                     .unwrap()
                     .into(),
                 dst_domain: 5456,
-                dst_addr: &H256::default()
+                dst_addr: &H256::default(),
+                body: "".into(),
             },
             false
         ))
@@ -449,7 +497,8 @@ mod test {
                 dst_addr: &"9d4454B023096f34B160D6B654540c56A1F81688"
                     .parse::<H160>()
                     .unwrap()
-                    .into()
+                    .into(),
+                body: "".into(),
             },
             false
         ));
@@ -463,7 +512,8 @@ mod test {
                     .unwrap()
                     .into(),
                 dst_domain: 5456,
-                dst_addr: &H256::default()
+                dst_addr: &H256::default(),
+                body: "".into(),
             },
             false
         ));
@@ -497,9 +547,10 @@ mod test {
             src_addr: &H256::default(),
             dst_domain: 0,
             dst_addr: &H256::default(),
+            body: "".into(),
         };
         // whitelist use
-        assert!(MatchingList(None).matches(info, true));
+        assert!(MatchingList(None).matches(info.clone(), true));
         // blacklist use
         assert!(!MatchingList(None).matches(info, false));
     }
@@ -524,5 +575,42 @@ mod test {
         let value_parser =
             hyperlane_base::settings::parser::ValueParser::new(Default::default(), &val);
         crate::settings::parse_matching_list(value_parser).unwrap();
+    }
+
+    #[test]
+    fn test_matching_list_regex() {
+        let list: MatchingList = serde_json::from_str(r#"[{"regex": "abcd"}]"#).unwrap();
+        assert!(list.matches(
+            MatchInfo {
+                src_msg_id: H256::default(),
+                src_domain: 34,
+                src_addr: &"0x9d4454B023096f34B160D6B654540c56A1F81688"
+                    .parse::<H160>()
+                    .unwrap()
+                    .into(),
+                dst_domain: 5456,
+                dst_addr: &"9d4454B023096f34B160D6B654540c56A1F81688"
+                    .parse::<H160>()
+                    .unwrap()
+                    .into(),
+                body: "abcd".into(),
+            },
+            false
+        ));
+
+        assert!(!list.matches(
+            MatchInfo {
+                src_msg_id: H256::default(),
+                src_domain: 34,
+                src_addr: &"0x9d4454B023096f34B160D6B654540c56A1F81688"
+                    .parse::<H160>()
+                    .unwrap()
+                    .into(),
+                dst_domain: 5456,
+                dst_addr: &H256::default(),
+                body: "defg".into(),
+            },
+            false
+        ));
     }
 }

--- a/rust/main/hyperlane-core/src/traits/pending_operation.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation.rs
@@ -72,6 +72,9 @@ pub trait PendingOperation: Send + Sync + Debug + TryBatchAs<HyperlaneMessage> {
     /// The recipient address of this operation.
     fn recipient_address(&self) -> &H256;
 
+    /// The recipient address of this operation.
+    fn body(&self) -> &[u8];
+
     /// Label to use for metrics granularity.
     fn app_context(&self) -> Option<String>;
 

--- a/rust/main/hyperlane-core/src/traits/pending_operation/tests.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation/tests.rs
@@ -37,6 +37,9 @@ impl PendingOperation for MockQueueOperation {
     fn recipient_address(&self) -> &H256 {
         unimplemented!()
     }
+    fn body(&self) -> &[u8] {
+        unimplemented!()
+    }
     fn app_context(&self) -> Option<String> {
         None
     }


### PR DESCRIPTION
### Description

 - add a regex field for the body to matching list

### Related issues

- fixes [https://linear.app/hyperlane-xyz/issue/ENG-1828/add-a-body-regex-filter-to-matchinglists]

### Backward compatibility

Yes

### Testing

- unittests
