### PR TITLE
fix(lander): lower sleep periods to improve latency

### DIFF
--- a/rust/main/lander/src/dispatcher/db/loader.rs
+++ b/rust/main/lander/src/dispatcher/db/loader.rs
@@ -143,7 +143,7 @@ impl<T: LoadableFromDb + Debug> DbIterator<T> {
                 }
 
                 // sleep to wait for new items to be added
-                sleep(Duration::from_millis(100)).await;
+                sleep(Duration::from_millis(1)).await;
                 iteration_count += 1;
             } else {
                 debug!(?self, "Loaded item");

--- a/rust/main/lander/src/dispatcher/db/loader.rs
+++ b/rust/main/lander/src/dispatcher/db/loader.rs
@@ -143,7 +143,7 @@ impl<T: LoadableFromDb + Debug> DbIterator<T> {
                 }
 
                 // sleep to wait for new items to be added
-                sleep(Duration::from_millis(1)).await;
+                sleep(Duration::from_millis(10)).await;
                 iteration_count += 1;
             } else {
                 debug!(?self, "Loaded item");

--- a/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
+++ b/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
@@ -39,7 +39,7 @@ impl BuildingStage {
                 .await;
             if payloads.is_empty() {
                 // wait for more payloads to arrive
-                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
                 continue;
             }
 

--- a/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
+++ b/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
@@ -38,7 +38,7 @@ impl BuildingStage {
                 .await;
             if payloads.is_empty() {
                 // wait for more payloads to arrive
-                tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+                tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
                 continue;
             }
             // note: this will set the queue length metric to `length - payloads.len()`,

--- a/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
+++ b/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
@@ -31,7 +31,6 @@ impl BuildingStage {
     #[instrument(skip(self), name = "BuildingStage::run")]
     pub async fn run(&self) {
         loop {
-            self.update_metrics().await;
             // event-driven by the Building queue
             let payloads = self
                 .queue
@@ -42,6 +41,9 @@ impl BuildingStage {
                 tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
                 continue;
             }
+            // note: this will set the queue length metric to `length - payloads.len()`,
+            // so worst case this will be lower by `max_batch_size`
+            self.update_metrics().await;
 
             info!(?payloads, "Building transactions from payloads");
             let tx_building_results = self.state.adapter.build_transactions(&payloads).await;


### PR DESCRIPTION
### Description

Lowers the `sleep`s from the Lander's DbLoader and BuildingStage. This should shave off ~1.1s in the worst case and 550ms on average. I'm leaving the reduction of the sleep in the InclusionStage to Danil's PR here: https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/6666

### Backward compatibility

Yes

### Testing

Existing unit tests + e2e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced wait times in processing loops, resulting in faster responsiveness when waiting for new items or payloads.
  * Enhanced metric updates to better reflect queue processing status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->