### PR TITLE
feat(infra): group ICA calls into one message

### DIFF
--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -698,7 +698,7 @@ export function writeAddresses(
   addressesMap: ChainMap<Record<string, Address>>,
   targetNetworks?: ChainName[],
 ) {
-  if (targetNetworks) {
+  if (targetNetworks && targetNetworks.length > 0) {
     addressesMap = objFilter(addressesMap, (chain, _): _ is ChainAddresses => {
       return targetNetworks.includes(chain as ChainName);
     });

--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -696,7 +696,14 @@ export function writeAddresses(
   environment: DeployEnvironment,
   module: Modules,
   addressesMap: ChainMap<Record<string, Address>>,
+  targetNetworks?: ChainName[],
 ) {
+  if (targetNetworks) {
+    addressesMap = objFilter(addressesMap, (chain, _): _ is ChainAddresses => {
+      return targetNetworks.includes(chain as ChainName);
+    });
+  }
+
   addressesMap = filterRemoteDomainMetadata(addressesMap);
 
   if (isRegistryModule(environment, module)) {

--- a/typescript/infra/src/deployment/deploy.ts
+++ b/typescript/infra/src/deployment/deploy.ts
@@ -82,7 +82,9 @@ export async function deployWithArtifacts<Config extends object>({
   // Run post-deploy steps
   const handleExit = async () => {
     console.info(chalk.gray.italic('Running post-deploy steps'));
-    await runWithTimeout(5000, () => postDeploy(deployer, cache))
+    await runWithTimeout(5000, () =>
+      postDeploy(deployer, cache, targetNetworks),
+    )
       .then(() => console.info('Post-deploy completed'))
       .catch((error) => {
         console.error(
@@ -232,6 +234,7 @@ async function baseDeploy<
 async function postDeploy<Config extends object>(
   deployer: HyperlaneDeployer<Config, any>,
   cache: DeployCache,
+  targetNetworks: ChainName[],
 ) {
   if (cache.write) {
     const deployedAddresses = serializeContractsMap(deployer.deployedContracts);
@@ -239,7 +242,7 @@ async function postDeploy<Config extends object>(
     const addresses = objMerge(deployedAddresses, cachedAddresses);
 
     // cache addresses of deployed contracts
-    writeAddresses(cache.environment, cache.module, addresses);
+    writeAddresses(cache.environment, cache.module, addresses, targetNetworks);
 
     let savedVerification = {};
     try {

--- a/typescript/infra/src/govern/HyperlaneHaasGovernor.test.ts
+++ b/typescript/infra/src/govern/HyperlaneHaasGovernor.test.ts
@@ -1,0 +1,400 @@
+import { expect } from 'chai';
+import { BigNumber } from 'ethers';
+import sinon from 'sinon';
+
+import {
+  HyperlaneCoreChecker,
+  InterchainAccount,
+  TestChainName,
+} from '@hyperlane-xyz/sdk';
+import { Address } from '@hyperlane-xyz/utils';
+
+import { AnnotatedCallData } from './HyperlaneAppGovernor.js';
+import { HyperlaneHaasGovernor } from './HyperlaneHaasGovernor.js';
+import { HyperlaneICAChecker } from './HyperlaneICAChecker.js';
+
+describe('HyperlaneHaasGovernor', () => {
+  describe('batchIcaCalls', () => {
+    let governor: HyperlaneHaasGovernor;
+    let mockIca: InterchainAccount;
+    let mockIcaChecker: HyperlaneICAChecker;
+    let mockCoreChecker: HyperlaneCoreChecker;
+    let mockGetCallRemote: sinon.SinonStub;
+    let sandbox: sinon.SinonSandbox;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+
+      // Create mock InterchainAccount
+      mockIca = {
+        getCallRemote: sandbox.stub(),
+      } as any;
+
+      // Create mock checkers with proper structure
+      mockIcaChecker = {
+        app: {
+          contractsMap: {
+            [TestChainName.test1]: {},
+            [TestChainName.test2]: {},
+            [TestChainName.test3]: {},
+          },
+        },
+        violations: [],
+      } as any;
+
+      mockCoreChecker = {
+        app: {
+          contractsMap: {
+            [TestChainName.test1]: {},
+            [TestChainName.test2]: {},
+            [TestChainName.test3]: {},
+          },
+        },
+        violations: [],
+      } as any;
+
+      // Create governor instance
+      governor = new HyperlaneHaasGovernor(
+        mockIca,
+        mockIcaChecker,
+        mockCoreChecker,
+      );
+
+      // Set up the interchainAccount property
+      (governor as any).interchainAccount = mockIca;
+      mockGetCallRemote = mockIca.getCallRemote as sinon.SinonStub;
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should throw error when interchainAccount is not available', async () => {
+      (governor as any).interchainAccount = undefined;
+
+      try {
+        await governor.batchIcaCalls();
+        expect.fail('Expected an error to be thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.equal(
+          'InterchainAccount is not available',
+        );
+      }
+    });
+
+    it('should handle empty calls array', async () => {
+      (governor as any).calls = {
+        [TestChainName.test1]: [],
+      };
+
+      await governor.batchIcaCalls();
+
+      expect(mockGetCallRemote.called).to.be.false;
+    });
+
+    it('should preserve non-ICA calls (calls without callRemoteArgs)', async () => {
+      const nonIcaCall: AnnotatedCallData = {
+        to: '0x1234567890123456789012345678901234567890' as Address,
+        data: '0xabcd',
+        value: BigNumber.from(0),
+        description: 'Non-ICA call',
+      };
+
+      (governor as any).calls = {
+        [TestChainName.test1]: [nonIcaCall],
+      };
+
+      await governor.batchIcaCalls();
+
+      expect(mockGetCallRemote.called).to.be.false;
+      expect((governor as any).calls[TestChainName.test1]).to.deep.equal([
+        nonIcaCall,
+      ]);
+    });
+
+    it('should actually test the grouping logic by verifying different callRemoteArgs create separate groups', async () => {
+      // Create calls with different callRemoteArgs that should NOT be grouped together
+      const callRemoteArgs1 = {
+        chain: TestChainName.test1,
+        destination: TestChainName.test2,
+        config: {
+          origin: TestChainName.test1,
+          owner: '0x1111111111111111111111111111111111111111' as Address,
+        },
+        innerCalls: [],
+        hookMetadata: undefined,
+      };
+
+      const callRemoteArgs2 = {
+        chain: TestChainName.test1,
+        destination: TestChainName.test3, // Different destination
+        config: {
+          origin: TestChainName.test1,
+          owner: '0x2222222222222222222222222222222222222222' as Address, // Different owner
+        },
+        innerCalls: [],
+        hookMetadata: undefined,
+      };
+
+      const call1: AnnotatedCallData = {
+        to: '0x1111111111111111111111111111111111111111' as Address,
+        data: '0x1111',
+        value: BigNumber.from(100),
+        description: 'First ICA call',
+        callRemoteArgs: callRemoteArgs1,
+      };
+
+      const call2: AnnotatedCallData = {
+        to: '0x2222222222222222222222222222222222222222' as Address,
+        data: '0x2222',
+        value: BigNumber.from(200),
+        description: 'Second ICA call',
+        callRemoteArgs: callRemoteArgs2,
+      };
+
+      (governor as any).calls = {
+        [TestChainName.test1]: [call1, call2],
+      };
+
+      // Mock the getCallRemote response
+      const mockCallRemoteResponse1 = {
+        to: '0x9999999999999999999999999999999999999999',
+        data: '0xcombined1',
+        value: BigNumber.from(100),
+      };
+      const mockCallRemoteResponse2 = {
+        to: '0x8888888888888888888888888888888888888888',
+        data: '0xcombined2',
+        value: BigNumber.from(200),
+      };
+      mockGetCallRemote.onFirstCall().resolves(mockCallRemoteResponse1);
+      mockGetCallRemote.onSecondCall().resolves(mockCallRemoteResponse2);
+
+      await governor.batchIcaCalls();
+
+      // Verify getCallRemote was called twice (once for each group)
+      expect(mockGetCallRemote.calledTwice).to.be.true;
+
+      // Verify the calls were replaced with two separate combined calls
+      expect((governor as any).calls[TestChainName.test1]).to.have.length(2);
+      const combinedCall1 = (governor as any).calls[TestChainName.test1][0];
+      const combinedCall2 = (governor as any).calls[TestChainName.test1][1];
+
+      expect(combinedCall1.description).to.equal('Combined 1 ICA calls');
+      expect(combinedCall2.description).to.equal('Combined 1 ICA calls');
+    });
+
+    it('should actually test the grouping logic by verifying identical callRemoteArgs create one group', async () => {
+      // Create calls with identical callRemoteArgs that SHOULD be grouped together
+      const callRemoteArgs = {
+        chain: TestChainName.test1,
+        destination: TestChainName.test2,
+        config: {
+          origin: TestChainName.test1,
+          owner: '0x1234567890123456789012345678901234567890' as Address,
+        },
+        innerCalls: [],
+        hookMetadata: undefined,
+      };
+
+      const call1: AnnotatedCallData = {
+        to: '0x1111111111111111111111111111111111111111' as Address,
+        data: '0x1111',
+        value: BigNumber.from(100),
+        description: 'First ICA call',
+        callRemoteArgs,
+      };
+
+      const call2: AnnotatedCallData = {
+        to: '0x2222222222222222222222222222222222222222' as Address,
+        data: '0x2222',
+        value: BigNumber.from(200),
+        description: 'Second ICA call',
+        callRemoteArgs, // Same callRemoteArgs as call1
+      };
+
+      const call3: AnnotatedCallData = {
+        to: '0x3333333333333333333333333333333333333333' as Address,
+        data: '0x3333',
+        value: BigNumber.from(300),
+        description: 'Third ICA call',
+        callRemoteArgs, // Same callRemoteArgs as call1 and call2
+      };
+
+      (governor as any).calls = {
+        [TestChainName.test1]: [call1, call2, call3],
+      };
+
+      // Mock the getCallRemote response
+      const mockCallRemoteResponse = {
+        to: '0x9999999999999999999999999999999999999999',
+        data: '0xcombined',
+        value: BigNumber.from(600),
+      };
+      mockGetCallRemote.resolves(mockCallRemoteResponse);
+
+      await governor.batchIcaCalls();
+
+      // Verify getCallRemote was called only once (for the single group)
+      expect(mockGetCallRemote.calledOnce).to.be.true;
+
+      // Verify the calls were replaced with a single combined call
+      expect((governor as any).calls[TestChainName.test1]).to.have.length(1);
+      const combinedCall = (governor as any).calls[TestChainName.test1][0];
+      expect(combinedCall.description).to.equal('Combined 3 ICA calls');
+      expect(combinedCall.expandedDescription).to.equal(
+        'Combined calls: First ICA call, Second ICA call, Third ICA call',
+      );
+
+      // Verify the innerCalls were properly combined
+      const mockFirstCallArgs = mockGetCallRemote.firstCall.args[0];
+      expect(mockFirstCallArgs.innerCalls).to.have.length(3);
+      expect(mockFirstCallArgs.innerCalls[0]).to.deep.equal({
+        to: call1.to,
+        data: call1.data,
+        value: '100',
+      });
+      expect(mockFirstCallArgs.innerCalls[1]).to.deep.equal({
+        to: call2.to,
+        data: call2.data,
+        value: '200',
+      });
+      expect(mockFirstCallArgs.innerCalls[2]).to.deep.equal({
+        to: call3.to,
+        data: call3.data,
+        value: '300',
+      });
+    });
+
+    it('should test the value conversion logic with different value types', async () => {
+      const callRemoteArgs = {
+        chain: TestChainName.test1,
+        destination: TestChainName.test2,
+        config: {
+          origin: TestChainName.test1,
+          owner: '0x1234567890123456789012345678901234567890' as Address,
+        },
+        innerCalls: [],
+        hookMetadata: undefined,
+      };
+
+      const call1: AnnotatedCallData = {
+        to: '0x1111111111111111111111111111111111111111' as Address,
+        data: '0x1111',
+        value: undefined, // Undefined value
+        description: 'ICA call with undefined value',
+        callRemoteArgs,
+      };
+
+      const call2: AnnotatedCallData = {
+        to: '0x2222222222222222222222222222222222222222' as Address,
+        data: '0x2222',
+        value: BigNumber.from(0), // Zero value
+        description: 'ICA call with zero value',
+        callRemoteArgs,
+      };
+
+      const call3: AnnotatedCallData = {
+        to: '0x3333333333333333333333333333333333333333' as Address,
+        data: '0x3333',
+        value: BigNumber.from(12345), // Non-zero value
+        description: 'ICA call with non-zero value',
+        callRemoteArgs,
+      };
+
+      (governor as any).calls = {
+        [TestChainName.test1]: [call1, call2, call3],
+      };
+
+      // Mock the getCallRemote response
+      const mockCallRemoteResponse = {
+        to: '0x9999999999999999999999999999999999999999',
+        data: '0xcombined',
+        value: BigNumber.from(12345),
+      };
+      mockGetCallRemote.resolves(mockCallRemoteResponse);
+
+      await governor.batchIcaCalls();
+
+      // Verify getCallRemote was called with correct value conversions
+      expect(mockGetCallRemote.calledOnce).to.be.true;
+      const mockFirstCallArgs = mockGetCallRemote.firstCall.args[0];
+      expect(mockFirstCallArgs.innerCalls[0].value).to.equal('0'); // undefined -> '0'
+      expect(mockFirstCallArgs.innerCalls[1].value).to.equal('0'); // BigNumber(0) -> '0'
+      expect(mockFirstCallArgs.innerCalls[2].value).to.equal('12345'); // BigNumber(12345) -> '12345'
+    });
+
+    it('should test the actual transformation of the calls structure', async () => {
+      const callRemoteArgs = {
+        chain: TestChainName.test1,
+        destination: TestChainName.test2,
+        config: {
+          origin: TestChainName.test1,
+          owner: '0x1234567890123456789012345678901234567890' as Address,
+        },
+        innerCalls: [],
+        hookMetadata: undefined,
+      };
+
+      const icaCall: AnnotatedCallData = {
+        to: '0x1111111111111111111111111111111111111111' as Address,
+        data: '0x1111',
+        value: BigNumber.from(100),
+        description: 'ICA call',
+        callRemoteArgs,
+        submissionType: 'MANUAL' as any,
+        governanceType: 'MULTISIG' as any,
+      };
+
+      const nonIcaCall: AnnotatedCallData = {
+        to: '0x2222222222222222222222222222222222222222' as Address,
+        data: '0x2222',
+        value: BigNumber.from(200),
+        description: 'Non-ICA call',
+      };
+
+      (governor as any).calls = {
+        [TestChainName.test1]: [icaCall, nonIcaCall],
+      };
+
+      // Mock the getCallRemote response
+      const mockCallRemoteResponse = {
+        to: '0x9999999999999999999999999999999999999999',
+        data: '0xcombined',
+        value: BigNumber.from(100),
+      };
+      mockGetCallRemote.resolves(mockCallRemoteResponse);
+
+      await governor.batchIcaCalls();
+
+      // Verify getCallRemote was called once (for the ICA call)
+      expect(mockGetCallRemote.calledOnce).to.be.true;
+
+      // Verify the final calls array contains both the combined ICA call and the non-ICA call
+      expect((governor as any).calls[TestChainName.test1]).to.have.length(2);
+      const finalCalls = (governor as any).calls[TestChainName.test1];
+
+      // One should be the combined ICA call
+      const combinedCall = finalCalls.find(
+        (call: AnnotatedCallData) =>
+          call.description === 'Combined 1 ICA calls',
+      );
+      expect(combinedCall).to.exist;
+      expect(combinedCall?.to).to.equal(mockCallRemoteResponse.to);
+      expect(combinedCall?.data).to.equal(mockCallRemoteResponse.data);
+      expect(combinedCall?.value).to.equal(mockCallRemoteResponse.value);
+      expect(combinedCall?.submissionType).to.equal('MANUAL');
+      expect(combinedCall?.governanceType).to.equal('MULTISIG');
+
+      // One should be the non-ICA call (preserved exactly as it was)
+      const preservedNonIcaCall = finalCalls.find(
+        (call: AnnotatedCallData) => call.description === 'Non-ICA call',
+      );
+      expect(preservedNonIcaCall).to.exist;
+      expect(preservedNonIcaCall?.to).to.equal(nonIcaCall.to);
+      expect(preservedNonIcaCall?.data).to.equal(nonIcaCall.data);
+      expect(preservedNonIcaCall?.value).to.equal(nonIcaCall.value);
+    });
+  });
+});

--- a/typescript/infra/src/govern/HyperlaneHaasGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneHaasGovernor.ts
@@ -168,12 +168,12 @@ export class HyperlaneHaasGovernor extends HyperlaneAppGovernor<
         if (!call.callRemoteArgs) continue;
 
         // Create a key based on all callRemoteArgs properties except innerCalls
-        const key = JSON.stringify({
-          chain: call.callRemoteArgs.chain,
-          destination: call.callRemoteArgs.destination,
-          config: call.callRemoteArgs.config,
-          hookMetadata: call.callRemoteArgs.hookMetadata,
-        });
+        const key = [
+          call.callRemoteArgs.chain,
+          call.callRemoteArgs.destination,
+          JSON.stringify(call.callRemoteArgs.config),
+          JSON.stringify(call.callRemoteArgs.hookMetadata),
+        ].join('|');
 
         if (!callGroups.has(key)) {
           callGroups.set(key, []);
@@ -201,8 +201,6 @@ export class HyperlaneHaasGovernor extends HyperlaneAppGovernor<
         // Create the combined callRemoteArgs
         const combinedCallRemoteArgs = {
           ...baseCallRemoteArgs,
-          chain,
-          destination: baseCallRemoteArgs.destination,
           innerCalls: combinedInnerCalls,
         };
 

--- a/typescript/infra/src/govern/HyperlaneHaasGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneHaasGovernor.ts
@@ -145,6 +145,9 @@ export class HyperlaneHaasGovernor extends HyperlaneAppGovernor<
     // 2. For each call, infer how it should be submitted on-chain.
     await this.inferCallSubmissionTypes();
 
+    // 2.5. Combine ICA calls that have the same callRemoteArgs
+    await this.batchIcaCalls();
+
     // 3. Prompt the user to confirm that the count, description,
     // and submission methods look correct before submitting.
     const chains = chain ? [chain] : Object.keys(this.calls);

--- a/typescript/infra/src/govern/HyperlaneHaasGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneHaasGovernor.ts
@@ -152,4 +152,89 @@ export class HyperlaneHaasGovernor extends HyperlaneAppGovernor<
       await this.sendCalls(chain, confirm);
     }
   }
+
+  async batchIcaCalls() {
+    if (!this.interchainAccount) {
+      throw new Error('InterchainAccount is not available');
+    }
+
+    for (const [chain, calls] of Object.entries(this.calls)) {
+      if (calls.length === 0) continue;
+
+      // Group calls by their callRemoteArgs (excluding innerCalls)
+      const callGroups = new Map<string, AnnotatedCallData[]>();
+
+      for (const call of calls) {
+        if (!call.callRemoteArgs) continue;
+
+        // Create a key based on all callRemoteArgs properties except innerCalls
+        const key = JSON.stringify({
+          chain: call.callRemoteArgs.chain,
+          destination: call.callRemoteArgs.destination,
+          config: call.callRemoteArgs.config,
+          hookMetadata: call.callRemoteArgs.hookMetadata,
+        });
+
+        if (!callGroups.has(key)) {
+          callGroups.set(key, []);
+        }
+        callGroups.get(key)!.push(call);
+      }
+
+      // Create new combined calls to replace the original ones
+      const newCalls: AnnotatedCallData[] = [];
+
+      // Process each group of calls
+      for (const [_, groupedCalls] of callGroups) {
+        if (groupedCalls.length === 0) continue;
+
+        // Use the first call's callRemoteArgs as the base
+        const baseCallRemoteArgs = groupedCalls[0].callRemoteArgs!;
+
+        // Combine all innerCalls from the grouped calls
+        const combinedInnerCalls = groupedCalls.map((call) => ({
+          to: call.to,
+          data: call.data,
+          value: call.value?.toString() || '0',
+        }));
+
+        // Create the combined callRemoteArgs
+        const combinedCallRemoteArgs = {
+          ...baseCallRemoteArgs,
+          chain,
+          destination: baseCallRemoteArgs.destination,
+          innerCalls: combinedInnerCalls,
+        };
+
+        // Get the callRemote transaction
+        const callRemote = await this.interchainAccount.getCallRemote(
+          combinedCallRemoteArgs,
+        );
+
+        // Create a new combined call that represents all the grouped calls
+        const combinedCall: AnnotatedCallData = {
+          to: callRemote.to!,
+          data: callRemote.data!,
+          value: callRemote.value,
+          description: `Combined ${groupedCalls.length} ICA calls`,
+          expandedDescription: `Combined calls: ${groupedCalls.map((c) => c.description).join(', ')}`,
+          callRemoteArgs: combinedCallRemoteArgs,
+          submissionType: groupedCalls[0].submissionType,
+          governanceType: groupedCalls[0].governanceType,
+        };
+
+        newCalls.push(combinedCall);
+        console.log(
+          `Combined ${groupedCalls.length} calls into single ICA transaction for chain ${chain}`,
+        );
+      }
+
+      // Add any calls that don't have callRemoteArgs (non-ICA calls)
+      const nonIcaCalls = calls.filter((call) => !call.callRemoteArgs);
+      newCalls.push(...nonIcaCalls);
+
+      // Update this.calls with the new combined calls
+      this.calls[chain] = newCalls;
+    }
+  }
 }


### PR DESCRIPTION
### Description

feat(infra): group ICA calls into one message

don't worry! most of the diff is just the new tests

### Drive-by changes

driveby: infra deployer/write-back fix
- only write-back the selected chains if provided

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

tests!
```
NODE_OPTIONS='--experimental-loader ts-node/esm/transpile-only --no-warnings=ExperimentalWarning' yarn --cwd typescript/infra hardhat --config hardhat.config.cts test src/govern/HyperlaneHaasGovernor.test.ts
```

real test will be the next multisig round

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batching of interchain account (ICA) calls, allowing multiple ICA calls to be grouped and sent as a single combined transaction for improved efficiency.
  * Enhanced deployment process to support filtering target networks when writing address data.

* **Bug Fixes**
  * Improved handling and logging of interchain account call metadata for more accurate transaction summaries.

* **Tests**
  * Introduced a comprehensive test suite to verify correct grouping, batching, and value handling of ICA calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->