### PR TITLE
feat(balances): update balance thresholds and alert templates to include starknet

### DIFF
--- a/typescript/infra/config/environments/mainnet3/balances/desiredRelayerBalanceOverrides.json
+++ b/typescript/infra/config/environments/mainnet3/balances/desiredRelayerBalanceOverrides.json
@@ -13,6 +13,7 @@
   "paradex": 0,
   "plume": 0.05,
   "reactive": 0.1,
+  "starknet": 200,
   "solaxy": 0.05,
   "sophon": 50,
   "tac": 5,

--- a/typescript/infra/config/environments/mainnet3/balances/desiredRelayerBalances.json
+++ b/typescript/infra/config/environments/mainnet3/balances/desiredRelayerBalances.json
@@ -117,7 +117,7 @@
   "sonicsvm": 1.54,
   "soon": 0.0156,
   "sophon": 50,
-  "starknet": 216,
+  "starknet": 200,
   "story": 13.4,
   "stride": 124,
   "subtensor": 2.13,

--- a/typescript/infra/config/environments/mainnet3/balances/highUrgencyRelayerBalance.json
+++ b/typescript/infra/config/environments/mainnet3/balances/highUrgencyRelayerBalance.json
@@ -114,7 +114,7 @@
   "sonicsvm": 0.5,
   "soon": 0.0039,
   "sophon": 12.5,
-  "starknet": 54,
+  "starknet": 50,
   "story": 3.34,
   "stride": 31,
   "subtensor": 0.532,

--- a/typescript/infra/config/environments/mainnet3/balances/lowUrgencyEngKeyFunderBalance.json
+++ b/typescript/infra/config/environments/mainnet3/balances/lowUrgencyEngKeyFunderBalance.json
@@ -114,7 +114,7 @@
   "sonicsvm": 1.16,
   "soon": 0.0117,
   "sophon": 37.5,
-  "starknet": 162,
+  "starknet": 150,
   "story": 10,
   "stride": 93,
   "subtensor": 1.6,

--- a/typescript/infra/config/environments/mainnet3/balances/lowUrgencyKeyFunderBalance.json
+++ b/typescript/infra/config/environments/mainnet3/balances/lowUrgencyKeyFunderBalance.json
@@ -114,7 +114,7 @@
   "sonicsvm": 2.32,
   "soon": 0.0234,
   "sophon": 75,
-  "starknet": 324,
+  "starknet": 300,
   "story": 20,
   "stride": 186,
   "subtensor": 3.19,

--- a/typescript/infra/src/config/funding/alert-query-templates.ts
+++ b/typescript/infra/src/config/funding/alert-query-templates.ts
@@ -30,6 +30,9 @@ export const LOW_URGENCY_KEY_FUNDER_FOOTER = `    # Mainnets that don't use key-
     # Any ATA payer on SonicSVM
     last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", chain=~"sonicsvm"}[1d]) - 0.1 or
     
+    # Starknet 
+    last_over_time(hyperlane_wallet_balance{wallet_name="relayer", hyperlane_context="hyperlane", chain=~"starknet"}[1d]) - 250 or
+
     # Neutron context
     last_over_time(hyperlane_wallet_balance{wallet_name="relayer", chain="mantapacific", hyperlane_context="neutron"}[1d]) - 0.3 or
     last_over_time(hyperlane_wallet_balance{wallet_name="relayer", chain="arbitrum", hyperlane_context="neutron"}[1d]) - 0.3 or
@@ -66,6 +69,9 @@ export const LOW_URGENCY_ENG_KEY_FUNDER_FOOTER = `    # Mainnets that don't use 
     last_over_time(hyperlane_wallet_balance{wallet_name="relayer", hyperlane_context="hyperlane", chain=~"sonicsvm"}[1d]) - 2 or
     # Any ATA payer on SonicSVM
     last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", chain=~"sonicsvm"}[1d]) - 0.05 or
+
+    # Starknet 
+    last_over_time(hyperlane_wallet_balance{wallet_name="relayer", hyperlane_context="hyperlane", chain=~"starknet"}[1d]) - 150 or
     
     # Neutron context
     last_over_time(hyperlane_wallet_balance{wallet_name="relayer", chain="mantapacific", hyperlane_context="neutron"}[1d]) - 0.15 or


### PR DESCRIPTION
### Description

- Include starknet in alert templates
- Add an override for starknet so that we can set the high urgency alert threshold to 50 STRK 

### Testing

Manual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring and alerting for Starknet relayer balances in low urgency funding alerts.

* **Chores**
  * Updated Starknet relayer balance thresholds for mainnet3, including desired, high urgency, and low urgency settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->