### PR TITLE
fix(lander): Don't drop transaction if we got nonce too low error

### DIFF
--- a/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
@@ -539,6 +539,7 @@ impl AdaptsChain for EthereumAdapter {
 
     async fn submit(&self, tx: &mut Transaction) -> Result<(), LanderError> {
         use super::transaction::Precursor;
+        use LanderError::TxAlreadyExists;
 
         let tx_for_nonce = tx.clone();
         let tx_for_gas_price = tx.clone();
@@ -559,9 +560,7 @@ impl AdaptsChain for EthereumAdapter {
             Ok(hash) => hash,
             Err(e) => {
                 return if e.to_string().contains(NONCE_TOO_LOW_ERROR) {
-                    Err(LanderError::UnclearTxSubmissionError(
-                        NONCE_TOO_LOW_ERROR.to_string(),
-                    ))
+                    Err(TxAlreadyExists)
                 } else {
                     Err(e.into())
                 }

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
@@ -48,6 +48,8 @@ mod gas_limit_estimator;
 mod gas_price;
 mod tx_status_checker;
 
+const NONCE_TOO_LOW_ERROR: &str = "nonce too low";
+
 pub struct EthereumAdapter {
     pub estimated_block_time: Duration,
     pub domain: HyperlaneDomain,
@@ -556,9 +558,9 @@ impl AdaptsChain for EthereumAdapter {
         let hash = match send_result {
             Ok(hash) => hash,
             Err(e) => {
-                return if e.to_string().contains("nonce too low") {
-                    Err(LanderError::TxReSubmissionWarning(
-                        "nonce too low".to_string(),
+                return if e.to_string().contains(NONCE_TOO_LOW_ERROR) {
+                    Err(LanderError::UnclearTxSubmissionError(
+                        NONCE_TOO_LOW_ERROR.to_string(),
                     ))
                 } else {
                     Err(e.into())

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -271,7 +271,7 @@ impl InclusionStage {
 
                     match submit_result {
                         Ok(()) => Ok(tx_guard.clone()),
-                        Err(err) if matches!(err, LanderError::UnclearTxSubmissionError(_)) => {
+                        Err(err) if matches!(err, LanderError::TxAlreadyExists) => {
                             warn!(?tx, ?err, "Transaction resubmission failed, will check the status of transaction before dropping it");
                             Ok(tx_guard.clone())
                         }

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -267,8 +267,16 @@ impl InclusionStage {
                 let tx_shared_clone = tx_shared.clone();
                 async move {
                     let mut tx_guard = tx_shared_clone.lock().await;
-                    state.adapter.submit(&mut tx_guard).await?;
-                    Ok(tx_guard.clone())
+                    let submit_result = state.adapter.submit(&mut tx_guard).await;
+
+                    match submit_result {
+                        Ok(()) => Ok(tx_guard.clone()),
+                        Err(err) if matches!(err, LanderError::TxReSubmissionWarning(_)) => {
+                            warn!(?tx, ?err, "Transaction resubmission failed, will check the status of transaction before dropping it");
+                            Ok(tx.clone())
+                        }
+                        Err(err) => Err(err),
+                    }
                 }
             },
             "Submitting transaction",

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -271,7 +271,7 @@ impl InclusionStage {
 
                     match submit_result {
                         Ok(()) => Ok(tx_guard.clone()),
-                        Err(err) if matches!(err, LanderError::TxReSubmissionWarning(_)) => {
+                        Err(err) if matches!(err, LanderError::UnclearTxSubmissionError(_)) => {
                             warn!(?tx, ?err, "Transaction resubmission failed, will check the status of transaction before dropping it");
                             Ok(tx_guard.clone())
                         }

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -273,7 +273,7 @@ impl InclusionStage {
                         Ok(()) => Ok(tx_guard.clone()),
                         Err(err) if matches!(err, LanderError::TxReSubmissionWarning(_)) => {
                             warn!(?tx, ?err, "Transaction resubmission failed, will check the status of transaction before dropping it");
-                            Ok(tx.clone())
+                            Ok(tx_guard.clone())
                         }
                         Err(err) => Err(err),
                     }

--- a/rust/main/lander/src/error.rs
+++ b/rust/main/lander/src/error.rs
@@ -8,11 +8,8 @@ pub enum LanderError {
     NetworkError(String),
     #[error("Transaction error: {0}")]
     TxSubmissionError(String),
-    // This error is used to indicate that submission of a transaction failed,
-    // but we should check the status of the transaction before dropping it so that
-    // we don't drop a transaction that was successfully submitted.
-    #[error("Unclear transaction submission error: {0}")]
-    UnclearTxSubmissionError(String),
+    /// This error means that a transaction was already submitted
+    /// For EVM, it may mean that nonce got clashed on the chain.
     #[error("This transaction has already been broadcast")]
     TxAlreadyExists,
     #[error("The transaction reverted")]
@@ -48,7 +45,6 @@ impl LanderError {
         match self {
             NetworkError(_) => "NetworkError".to_string(),
             TxSubmissionError(_) => "TxSubmissionError".to_string(),
-            UnclearTxSubmissionError(_) => "TxReSubmissionWarning".to_string(),
             TxAlreadyExists => "TxAlreadyExists".to_string(),
             TxReverted => "TxReverted".to_string(),
             ChannelSendFailure(_) => "ChannelSendFailure".to_string(),
@@ -111,8 +107,7 @@ impl IsRetryable for LanderError {
             SimulationFailed(reasons) => reasons
                 .iter()
                 .all(|r| r.contains(SIMULATED_DELIVERY_FAILURE_ERROR)),
-            UnclearTxSubmissionError(_)
-            | ChannelSendFailure(_)
+            ChannelSendFailure(_)
             | NonRetryableError(_)
             | TxReverted
             | EstimationFailed

--- a/rust/main/lander/src/error.rs
+++ b/rust/main/lander/src/error.rs
@@ -8,11 +8,11 @@ pub enum LanderError {
     NetworkError(String),
     #[error("Transaction error: {0}")]
     TxSubmissionError(String),
-    // This error is used to indicate that resubmission of a transaction failed,
+    // This error is used to indicate that submission of a transaction failed,
     // but we should check the status of the transaction before dropping it so that
     // we don't drop a transaction that was successfully submitted.
-    #[error("Transaction resubmission warning: {0}")]
-    TxReSubmissionWarning(String),
+    #[error("Unclear transaction submission error: {0}")]
+    UnclearTxSubmissionError(String),
     #[error("This transaction has already been broadcast")]
     TxAlreadyExists,
     #[error("The transaction reverted")]
@@ -48,7 +48,7 @@ impl LanderError {
         match self {
             NetworkError(_) => "NetworkError".to_string(),
             TxSubmissionError(_) => "TxSubmissionError".to_string(),
-            TxReSubmissionWarning(_) => "TxReSubmissionWarning".to_string(),
+            UnclearTxSubmissionError(_) => "TxReSubmissionWarning".to_string(),
             TxAlreadyExists => "TxAlreadyExists".to_string(),
             TxReverted => "TxReverted".to_string(),
             ChannelSendFailure(_) => "ChannelSendFailure".to_string(),
@@ -111,7 +111,7 @@ impl IsRetryable for LanderError {
             SimulationFailed(reasons) => reasons
                 .iter()
                 .all(|r| r.contains(SIMULATED_DELIVERY_FAILURE_ERROR)),
-            TxReSubmissionWarning(_)
+            UnclearTxSubmissionError(_)
             | ChannelSendFailure(_)
             | NonRetryableError(_)
             | TxReverted

--- a/rust/main/lander/src/error.rs
+++ b/rust/main/lander/src/error.rs
@@ -8,6 +8,11 @@ pub enum LanderError {
     NetworkError(String),
     #[error("Transaction error: {0}")]
     TxSubmissionError(String),
+    // This error is used to indicate that resubmission of a transaction failed,
+    // but we should check the status of the transaction before dropping it so that
+    // we don't drop a transaction that was successfully submitted.
+    #[error("Transaction resubmission warning: {0}")]
+    TxReSubmissionWarning(String),
     #[error("This transaction has already been broadcast")]
     TxAlreadyExists,
     #[error("The transaction reverted")]
@@ -38,21 +43,24 @@ pub enum LanderError {
 
 impl LanderError {
     pub fn to_metrics_label(&self) -> String {
+        use LanderError::*;
+
         match self {
-            LanderError::NetworkError(_) => "NetworkError".to_string(),
-            LanderError::TxSubmissionError(_) => "TxSubmissionError".to_string(),
-            LanderError::TxAlreadyExists => "TxAlreadyExists".to_string(),
-            LanderError::TxReverted => "TxReverted".to_string(),
-            LanderError::ChannelSendFailure(_) => "ChannelSendFailure".to_string(),
-            LanderError::ChannelClosed => "ChannelClosed".to_string(),
-            LanderError::EyreError(_) => "EyreError".to_string(),
-            LanderError::PayloadNotFound => "PayloadNotFound".to_string(),
-            LanderError::SimulationFailed(_) => "SimulationFailed".to_string(),
-            LanderError::EstimationFailed => "EstimationFailed".to_string(),
-            LanderError::NonRetryableError(_) => "NonRetryableError".to_string(),
-            LanderError::DbError(_) => "DbError".to_string(),
-            LanderError::ChainCommunicationError(_) => "ChainCommunicationError".to_string(),
-            LanderError::TxHashNotFound(_) => "TxHashNotFound".to_string(),
+            NetworkError(_) => "NetworkError".to_string(),
+            TxSubmissionError(_) => "TxSubmissionError".to_string(),
+            TxReSubmissionWarning(_) => "TxReSubmissionWarning".to_string(),
+            TxAlreadyExists => "TxAlreadyExists".to_string(),
+            TxReverted => "TxReverted".to_string(),
+            ChannelSendFailure(_) => "ChannelSendFailure".to_string(),
+            ChannelClosed => "ChannelClosed".to_string(),
+            EyreError(_) => "EyreError".to_string(),
+            PayloadNotFound => "PayloadNotFound".to_string(),
+            SimulationFailed(_) => "SimulationFailed".to_string(),
+            EstimationFailed => "EstimationFailed".to_string(),
+            NonRetryableError(_) => "NonRetryableError".to_string(),
+            DbError(_) => "DbError".to_string(),
+            ChainCommunicationError(_) => "ChainCommunicationError".to_string(),
+            TxHashNotFound(_) => "TxHashNotFound".to_string(),
         }
     }
 }
@@ -75,13 +83,15 @@ const SIMULATED_DELIVERY_FAILURE_ERROR: &str = "block hash ends in 0";
 
 impl IsRetryable for LanderError {
     fn is_retryable(&self) -> bool {
+        use LanderError::*;
+
         match self {
-            LanderError::TxSubmissionError(_) => true,
-            LanderError::NetworkError(_) => {
+            TxSubmissionError(_) => true,
+            NetworkError(_) => {
                 // TODO: add logic to classify based on the error message
                 false
             }
-            LanderError::ChainCommunicationError(err) => {
+            ChainCommunicationError(err) => {
                 if err.to_string().contains(SIMULATED_DELIVERY_FAILURE_ERROR) {
                     return true;
                 }
@@ -94,22 +104,23 @@ impl IsRetryable for LanderError {
                 // TODO: add logic to classify based on the error message
                 false
             }
-            LanderError::EyreError(_) => {
+            EyreError(_) => {
                 // TODO: add logic to classify based on the error message
                 false
             }
-            LanderError::ChannelSendFailure(_) => false,
-            LanderError::NonRetryableError(_) => false,
-            LanderError::TxReverted => false,
-            LanderError::SimulationFailed(reasons) => reasons
+            SimulationFailed(reasons) => reasons
                 .iter()
                 .all(|r| r.contains(SIMULATED_DELIVERY_FAILURE_ERROR)),
-            LanderError::EstimationFailed => false,
-            LanderError::ChannelClosed => false,
-            LanderError::PayloadNotFound => false,
-            LanderError::TxAlreadyExists => false,
-            LanderError::DbError(_) => false,
-            LanderError::TxHashNotFound(_) => false,
+            TxReSubmissionWarning(_)
+            | ChannelSendFailure(_)
+            | NonRetryableError(_)
+            | TxReverted
+            | EstimationFailed
+            | ChannelClosed
+            | PayloadNotFound
+            | TxAlreadyExists
+            | DbError(_)
+            | TxHashNotFound(_) => false,
         }
     }
 }

--- a/rust/main/lander/src/tests/ethereum/tests_inclusion_stage.rs
+++ b/rust/main/lander/src/tests/ethereum/tests_inclusion_stage.rs
@@ -729,6 +729,102 @@ async fn test_inclusion_estimate_gas_limit_error_drops_tx_and_payload() {
     );
 }
 
+#[tokio::test]
+#[traced_test]
+async fn test_inclusion_stage_nonce_too_low_error_does_not_drop_tx() {
+    let block_time = Duration::from_millis(20);
+    let hash = H256::random();
+
+    let mut mock_evm_provider = MockEvmProvider::new();
+    mock_finalized_block_number(&mut mock_evm_provider);
+    mock_estimate_gas_limit(&mut mock_evm_provider);
+    mock_get_block(&mut mock_evm_provider);
+    mock_get_next_nonce_on_finalized_block(&mut mock_evm_provider);
+    mock_default_fee_history(&mut mock_evm_provider);
+
+    // Simulate provider returning "nonce too low" error on send
+    let mut send_call_counter = 0;
+    mock_evm_provider.expect_send().returning(move |_, _| {
+        send_call_counter += 1;
+        if send_call_counter == 1 {
+            Err(ChainCommunicationError::CustomError(
+                "nonce too low".to_string(),
+            ))
+        } else {
+            Ok(hash)
+        }
+    });
+
+    // Simulate receipt: always returns None (not included yet)
+    mock_evm_provider
+        .expect_get_transaction_receipt()
+        .returning(move |_| Ok(None));
+
+    let signer = H160::random();
+    let dispatcher_state =
+        mock_dispatcher_state_with_provider(mock_evm_provider, signer, block_time);
+    let (finality_stage_sender, mut finality_stage_receiver) = mpsc::channel(100);
+    let inclusion_stage_pool = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+
+    let created_txs = mock_evm_txs(
+        1,
+        &dispatcher_state.payload_db,
+        &dispatcher_state.tx_db,
+        TransactionStatus::PendingInclusion,
+        signer,
+        ExpectedTxType::Eip1559,
+    )
+    .await;
+    let created_tx = created_txs[0].clone();
+    let mock_domain = TEST_DOMAIN.into();
+    inclusion_stage_pool
+        .lock()
+        .await
+        .insert(created_tx.uuid.clone(), created_tx.clone());
+
+    // Run the inclusion stage step, which should NOT drop the tx due to "nonce too low" error
+    let result = InclusionStage::process_txs_step(
+        &inclusion_stage_pool,
+        &finality_stage_sender,
+        &dispatcher_state,
+        mock_domain,
+    )
+    .await;
+
+    // The result should be Ok, and the tx should still be in the pool
+    assert!(
+        result.is_ok(),
+        "Inclusion stage should not error on nonce too low"
+    );
+    let pool = inclusion_stage_pool.lock().await;
+    assert!(
+        pool.contains_key(&created_tx.uuid),
+        "Transaction should not be dropped from the pool on nonce too low error"
+    );
+
+    // The transaction should not be marked as Dropped in the DB
+    let retrieved_tx = dispatcher_state
+        .tx_db
+        .retrieve_transaction_by_uuid(&created_tx.uuid)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        !matches!(retrieved_tx.status, TransactionStatus::Dropped(_)),
+        "Transaction should not be dropped in DB on nonce too low error"
+    );
+
+    // No transaction should be sent to the finality stage
+    let maybe_tx = tokio::time::timeout(Duration::from_millis(100), finality_stage_receiver.recv())
+        .await
+        .ok()
+        .flatten();
+    assert!(
+        maybe_tx.is_none(),
+        "No transaction should be sent to finality stage"
+    );
+}
+
 async fn run_and_expect_successful_inclusion(
     initial_tx_type: ExpectedTxType,
     mut expected_tx_states: Vec<ExpectedTxState>,


### PR DESCRIPTION
### Description

Identify nonce low error and covert it into specific LanderError::UnclearTxSubmissionError. This error indicate that we should not drop transaction straight away. We should check the status of the transaction first. If it was the first submission, we won't have transaction hash recorded and the transaction will be resubmitted. If it was the consequent re-submission, transaction will contain hashes of native transaction from previous submission and we check the status of those native transactions.

### Related issues

- Fixes https://linear.app/hyperlane-xyz/issue/ENG-1798/dont-drop-transactions-when-nonce-too-low-is-reported

### Backward compatibility

Yes

### Testing

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added specific handling and warning for "nonce too low" errors during Ethereum transaction submission, improving error messaging and process resilience.

* **Bug Fixes**
  * Enhanced transaction resubmission logic to log and continue when a transaction already exists, preventing unnecessary failures.

* **Tests**
  * Added tests verifying that transactions with "nonce too low" errors are retained and not dropped during processing.

* **Refactor**
  * Improved error categorization and logging for transaction submission errors, providing clearer status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->