### PR TITLE
feat: emit event on protocol fee payment

### DIFF
--- a/.changeset/rude-apricots-try.md
+++ b/.changeset/rude-apricots-try.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": minor
+---
+
+feat: emit event on protocol fee payment

--- a/solidity/contracts/hooks/ProtocolFee.sol
+++ b/solidity/contracts/hooks/ProtocolFee.sol
@@ -34,6 +34,7 @@ contract ProtocolFee is AbstractPostDispatchHook, Ownable {
 
     event ProtocolFeeSet(uint256 protocolFee);
     event BeneficiarySet(address beneficiary);
+    event ProtocolFeePaid(address indexed sender, uint256 fee);
 
     // ============ Constants ============
 
@@ -102,6 +103,8 @@ contract ProtocolFee is AbstractPostDispatchHook, Ownable {
             msg.value >= protocolFee,
             "ProtocolFee: insufficient protocol fee"
         );
+
+        emit ProtocolFeePaid(message.senderAddress(), protocolFee);
 
         _refund(metadata, message, msg.value - protocolFee);
     }

--- a/solidity/test/hooks/ProtocolFee.t.sol
+++ b/solidity/test/hooks/ProtocolFee.t.sol
@@ -183,7 +183,7 @@ contract ProtocolFeeTest is Test {
 
         fees.setProtocolFee(feeRequired);
 
-        vm.expectEmit(true, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit ProtocolFee.ProtocolFeePaid(alice, feeRequired);
         fees.postDispatch{value: feeSent}("", testMessage);
     }


### PR DESCRIPTION
### Description

emit ProtocolFeePaid event in postDispatch and add test coverage (ENG-1779

### Related issues

- Fixes ENG-1779

### Backward compatibility

Yes

### Testing

Unit Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an event that is emitted whenever a protocol fee is paid, allowing for easier tracking of fee payments.

* **Tests**
  * Introduced new tests to ensure the protocol fee payment event is emitted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->