### PR TITLE
chore: add pre flight check to avoid warp monitor and rebalancer being deployed for the same route

### DIFF
--- a/typescript/infra/scripts/warp-routes/monitor/status.ts
+++ b/typescript/infra/scripts/warp-routes/monitor/status.ts
@@ -7,7 +7,7 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
-import { HelmManager } from '../../../src/utils/helm.js';
+import { HelmManager, getHelmReleaseName } from '../../../src/utils/helm.js';
 import { WarpRouteMonitorHelmManager } from '../../../src/warp/helm.js';
 import {
   assertCorrectKubeContext,
@@ -30,9 +30,7 @@ async function main() {
   await assertCorrectKubeContext(config);
 
   try {
-    const podWarpRouteId = `${WarpRouteMonitorHelmManager.getHelmReleaseName(
-      warpRouteId,
-    )}-0`;
+    const podWarpRouteId = `${getHelmReleaseName(warpRouteId, WarpRouteMonitorHelmManager.helmReleasePrefix)}-0`;
 
     rootLogger.info(chalk.grey.italic(`Fetching pod status...`));
     const pod = HelmManager.runK8sCommand(

--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -9,7 +9,8 @@ import { isObjEmpty } from '@hyperlane-xyz/utils';
 
 import { getWarpCoreConfig } from '../../config/registry.js';
 import { DeployEnvironment } from '../config/environment.js';
-import { HelmManager } from '../utils/helm.js';
+import { WARP_ROUTE_MONITOR_HELM_RELEASE_PREFIX } from '../utils/consts.js';
+import { HelmManager, getHelmReleaseName } from '../utils/helm.js';
 import { getInfraPath, readYaml } from '../utils/utils.js';
 
 export class RebalancerHelmManager extends HelmManager {
@@ -32,6 +33,18 @@ export class RebalancerHelmManager extends HelmManager {
   }
 
   async runPreflightChecks(localConfigPath: string) {
+    const monitorReleaseName = getHelmReleaseName(
+      this.warpRouteId,
+      WARP_ROUTE_MONITOR_HELM_RELEASE_PREFIX,
+    );
+    if (
+      await HelmManager.doesHelmReleaseExist(monitorReleaseName, this.namespace)
+    ) {
+      throw new Error(
+        `Warp route monitor for ${this.warpRouteId} already exists. Only one of rebalancer or monitor is allowed.`,
+      );
+    }
+
     const warpCoreConfig = getWarpCoreConfig(this.warpRouteId);
     if (!warpCoreConfig) {
       throw new Error(
@@ -76,24 +89,10 @@ export class RebalancerHelmManager extends HelmManager {
   }
 
   get helmReleaseName() {
-    return RebalancerHelmManager.getHelmReleaseName(this.warpRouteId);
-  }
-
-  static getHelmReleaseName(warpRouteId: string): string {
-    let name = `${RebalancerHelmManager.helmReleasePrefix}-${warpRouteId
-      .toLowerCase()
-      .replaceAll('/', '-')}`;
-
-    // 52 because the max label length is 63, and there is an auto appended 11 char
-    // suffix, e.g. `controller-revision-hash=hyperlane-warp-route-tia-mantapacific-neutron-566dc75599`
-    const maxChars = 52;
-
-    // Max out length, and it can't end with a dash.
-    if (name.length > maxChars) {
-      name = name.slice(0, maxChars);
-      name = name.replace(/-+$/, '');
-    }
-    return name;
+    return getHelmReleaseName(
+      this.warpRouteId,
+      RebalancerHelmManager.helmReleasePrefix,
+    );
   }
 
   // TODO: allow for a rebalancer to be uninstalled

--- a/typescript/infra/src/utils/consts.ts
+++ b/typescript/infra/src/utils/consts.ts
@@ -1,0 +1,2 @@
+export const REBALANCER_HELM_RELEASE_PREFIX = 'hyperlane-rebalancer';
+export const WARP_ROUTE_MONITOR_HELM_RELEASE_PREFIX = 'hyperlane-warp-route';

--- a/typescript/infra/src/warp/helm.ts
+++ b/typescript/infra/src/warp/helm.ts
@@ -17,7 +17,12 @@ import {
   getWarpCoreConfig,
 } from '../../config/registry.js';
 import { DeployEnvironment } from '../../src/config/environment.js';
-import { HelmManager, removeHelmRelease } from '../../src/utils/helm.js';
+import { REBALANCER_HELM_RELEASE_PREFIX } from '../../src/utils/consts.js';
+import {
+  HelmManager,
+  getHelmReleaseName,
+  removeHelmRelease,
+} from '../../src/utils/helm.js';
 import { execCmdAndParseJson, getInfraPath } from '../../src/utils/utils.js';
 
 // TODO: once we have automated tooling for ATA payer balances and a
@@ -34,7 +39,7 @@ const ataPayerAlertThreshold: ChainMap<number> = {
 const minAtaPayerBalanceFactor: number = 1.15;
 
 export class WarpRouteMonitorHelmManager extends HelmManager {
-  static helmReleasePrefix: string = 'hyperlane-warp-route-';
+  static helmReleasePrefix: string = 'hyperlane-warp-route';
 
   readonly helmChartPath: string = path.join(
     getInfraPath(),
@@ -51,6 +56,21 @@ export class WarpRouteMonitorHelmManager extends HelmManager {
   }
 
   async runPreflightChecks(multiProtocolProvider: MultiProtocolProvider) {
+    const rebalancerReleaseName = getHelmReleaseName(
+      this.warpRouteId,
+      REBALANCER_HELM_RELEASE_PREFIX,
+    );
+    if (
+      await HelmManager.doesHelmReleaseExist(
+        rebalancerReleaseName,
+        this.namespace,
+      )
+    ) {
+      throw new Error(
+        `Rebalancer for warp route ${this.warpRouteId} already exists. Only one of rebalancer or monitor is allowed.`,
+      );
+    }
+
     const warpCoreConfig = getWarpCoreConfig(this.warpRouteId);
     if (!warpCoreConfig) {
       throw new Error(
@@ -93,24 +113,10 @@ export class WarpRouteMonitorHelmManager extends HelmManager {
   }
 
   get helmReleaseName() {
-    return WarpRouteMonitorHelmManager.getHelmReleaseName(this.warpRouteId);
-  }
-
-  static getHelmReleaseName(warpRouteId: string): string {
-    let name = `${WarpRouteMonitorHelmManager.helmReleasePrefix}${warpRouteId
-      .toLowerCase()
-      .replaceAll('/', '-')}`;
-
-    // 52 because the max label length is 63, and there is an auto appended 11 char
-    // suffix, e.g. `controller-revision-hash=hyperlane-warp-route-tia-mantapacific-neutron-566dc75599`
-    const maxChars = 52;
-
-    // Max out length, and it can't end with a dash.
-    if (name.length > maxChars) {
-      name = name.slice(0, maxChars);
-      name = name.replace(/-+$/, '');
-    }
-    return name;
+    return getHelmReleaseName(
+      this.warpRouteId,
+      WarpRouteMonitorHelmManager.helmReleasePrefix,
+    );
   }
 
   // Gets all Warp Monitor Helm Releases in the given namespace.
@@ -130,8 +136,11 @@ export class WarpRouteMonitorHelmManager extends HelmManager {
   static async uninstallUnknownWarpMonitorReleases(namespace: string) {
     const localRegistry = getRegistry();
     const warpRouteIds = Object.keys(localRegistry.getWarpRoutes());
-    const allExpectedHelmReleaseNames = warpRouteIds.map(
-      WarpRouteMonitorHelmManager.getHelmReleaseName,
+    const allExpectedHelmReleaseNames = warpRouteIds.map((warpRouteId) =>
+      getHelmReleaseName(
+        warpRouteId,
+        WarpRouteMonitorHelmManager.helmReleasePrefix,
+      ),
     );
     const helmReleases =
       await WarpRouteMonitorHelmManager.getWarpMonitorHelmReleases(namespace);


### PR DESCRIPTION
### Description

- add pre flight check to avoid warp monitor and rebalancer being deployed for the same route, as they both expose balance metrics

### Drive-by changes

- small refactor with the helm manager to make it more reusable 


### Testing

Manual
