### PR TITLE
feat: use GCP logging config for rebalancer logs

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,5 +24,13 @@ if [ -n "$REGISTRY_COMMIT" ]; then
   cd "$OLDPWD"
 fi
 
+# If INSTALL_GCP_LOGGER_CLI is true, install the package
+if [ "$INSTALL_GCP_LOGGER_CLI" = "true" ]; then
+  echo "INSTALL_GCP_LOGGER_CLI is set, installing @google-cloud/pino-logging-gcp-config for CLI..."
+  # We install in the CLI directory context for yarn workspaces
+  yarn workspace @hyperlane-xyz/cli add @google-cloud/pino-logging-gcp-config
+  echo "Installation complete."
+fi
+
 # Execute the main container command
 exec "$@"

--- a/typescript/cli/src/rebalancer/core/Rebalancer.ts
+++ b/typescript/cli/src/rebalancer/core/Rebalancer.ts
@@ -1,4 +1,5 @@
 import { PopulatedTransaction } from 'ethers';
+import { Logger } from 'pino';
 
 import {
   type ChainMap,
@@ -20,29 +21,29 @@ import { Metrics } from '../metrics/Metrics.js';
 import {
   type BridgeConfigWithOverride,
   getBridgeConfig,
-  rebalancerLogger,
 } from '../utils/index.js';
 
 export class Rebalancer implements IRebalancer {
+  private readonly logger: Logger;
   constructor(
     private readonly bridges: ChainMap<BridgeConfigWithOverride>,
     private readonly warpCore: WarpCore,
     private readonly chainMetadata: ChainMap<ChainMetadata>,
     private readonly tokensByChainName: ChainMap<Token>,
     private readonly multiProvider: MultiProvider,
+    logger: Logger,
     private readonly metrics?: Metrics,
-  ) {}
+  ) {
+    this.logger = logger.child({ class: Rebalancer.name });
+  }
 
   async rebalance(routes: RebalancingRoute[]): Promise<void> {
     if (routes.length === 0) {
-      rebalancerLogger.info('No routes to execute, exiting');
+      this.logger.info('No routes to execute, exiting');
       return;
     }
 
-    rebalancerLogger.info(
-      { numberOfRoutes: routes.length },
-      'Rebalance initiated',
-    );
+    this.logger.info({ numberOfRoutes: routes.length }, 'Rebalance initiated');
 
     const { preparedTransactions, preparationFailures } =
       await this.prepareTransactions(routes);
@@ -68,7 +69,7 @@ export class Rebalancer implements IRebalancer {
       gasEstimationFailures > 0 ||
       transactionFailures > 0
     ) {
-      rebalancerLogger.error(
+      this.logger.error(
         {
           preparationFailures,
           gasEstimationFailures,
@@ -88,7 +89,7 @@ export class Rebalancer implements IRebalancer {
       }
     }
 
-    rebalancerLogger.info('✅ Rebalance successful');
+    this.logger.info('✅ Rebalance successful');
     return;
   }
 
@@ -96,7 +97,7 @@ export class Rebalancer implements IRebalancer {
     preparedTransactions: PreparedTransaction[];
     preparationFailures: number;
   }> {
-    rebalancerLogger.info(
+    this.logger.info(
       { numRoutes: routes.length },
       'Preparing all rebalance transactions.',
     );
@@ -120,7 +121,7 @@ export class Rebalancer implements IRebalancer {
   ): Promise<PreparedTransaction | null> {
     const { origin, destination, amount } = route;
 
-    rebalancerLogger.info(
+    this.logger.info(
       {
         origin,
         destination,
@@ -149,6 +150,7 @@ export class Rebalancer implements IRebalancer {
       this.bridges,
       origin,
       destination,
+      this.logger,
     );
 
     // 2. Get quotes
@@ -162,7 +164,7 @@ export class Rebalancer implements IRebalancer {
         bridgeIsWarp,
       );
     } catch (error) {
-      rebalancerLogger.error(
+      this.logger.error(
         {
           origin,
           destination,
@@ -185,7 +187,7 @@ export class Rebalancer implements IRebalancer {
         quotes,
       );
     } catch (error) {
-      rebalancerLogger.error(
+      this.logger.error(
         {
           origin,
           destination,
@@ -208,7 +210,7 @@ export class Rebalancer implements IRebalancer {
     const destinationDomain = this.chainMetadata[destination];
 
     if (!originToken) {
-      rebalancerLogger.error(
+      this.logger.error(
         { origin, destination, amount },
         'Route validation failed: origin token not found.',
       );
@@ -220,7 +222,7 @@ export class Rebalancer implements IRebalancer {
       originTokenAmount.getDecimalFormattedAmount();
 
     if (!destinationToken) {
-      rebalancerLogger.error(
+      this.logger.error(
         { origin, destination, amount: decimalFormattedAmount },
         'Route validation failed: destination token not found.',
       );
@@ -228,7 +230,7 @@ export class Rebalancer implements IRebalancer {
     }
 
     if (!destinationDomain) {
-      rebalancerLogger.error(
+      this.logger.error(
         { origin, destination, amount: decimalFormattedAmount },
         'Route validation failed: destination domain metadata not found.',
       );
@@ -239,7 +241,7 @@ export class Rebalancer implements IRebalancer {
       this.warpCore.multiProvider,
     );
     if (!(originHypAdapter instanceof EvmHypCollateralAdapter)) {
-      rebalancerLogger.error(
+      this.logger.error(
         {
           origin,
           destination,
@@ -254,7 +256,7 @@ export class Rebalancer implements IRebalancer {
     const signer = this.multiProvider.getSigner(origin);
     const signerAddress = await signer.getAddress();
     if (!(await originHypAdapter.isRebalancer(signerAddress))) {
-      rebalancerLogger.error(
+      this.logger.error(
         {
           origin,
           destination,
@@ -272,7 +274,7 @@ export class Rebalancer implements IRebalancer {
       destinationDomain.domainId,
     );
     if (!eqAddress(allowedDestination, destinationToken.addressOrDenom)) {
-      rebalancerLogger.error(
+      this.logger.error(
         {
           origin,
           destination,
@@ -287,14 +289,19 @@ export class Rebalancer implements IRebalancer {
       return false;
     }
 
-    const { bridge } = getBridgeConfig(this.bridges, origin, destination);
+    const { bridge } = getBridgeConfig(
+      this.bridges,
+      origin,
+      destination,
+      this.logger,
+    );
     if (
       !(await originHypAdapter.isBridgeAllowed(
         destinationDomain.domainId,
         bridge,
       ))
     ) {
-      rebalancerLogger.error(
+      this.logger.error(
         {
           origin,
           destination,
@@ -318,7 +325,7 @@ export class Rebalancer implements IRebalancer {
     transactionFailures: number;
     successfulTransactions: PreparedTransaction[];
   }> {
-    rebalancerLogger.info(
+    this.logger.info(
       { numTransactions: transactions.length },
       'Estimating gas for all prepared transactions.',
     );
@@ -343,7 +350,7 @@ export class Rebalancer implements IRebalancer {
       } else {
         gasEstimationFailures++;
         const failedTransaction = transactions[i];
-        rebalancerLogger.error(
+        this.logger.error(
           {
             origin: failedTransaction.route.origin,
             destination: failedTransaction.route.destination,
@@ -358,7 +365,7 @@ export class Rebalancer implements IRebalancer {
     });
 
     if (validTransactions.length === 0) {
-      rebalancerLogger.info('No transactions to execute after gas estimation.');
+      this.logger.info('No transactions to execute after gas estimation.');
       return {
         gasEstimationFailures,
         transactionFailures: 0,
@@ -367,7 +374,7 @@ export class Rebalancer implements IRebalancer {
     }
 
     // 2. Send transactions
-    rebalancerLogger.info(
+    this.logger.info(
       { numTransactions: validTransactions.length },
       'Sending valid transactions.',
     );
@@ -379,7 +386,7 @@ export class Rebalancer implements IRebalancer {
         const decimalFormattedAmount =
           transaction.originTokenAmount.getDecimalFormattedAmount();
         const tokenName = transaction.originTokenAmount.token.name;
-        rebalancerLogger.info(
+        this.logger.info(
           {
             origin,
             destination,
@@ -392,7 +399,7 @@ export class Rebalancer implements IRebalancer {
           origin,
           transaction.populatedTx,
         );
-        rebalancerLogger.info(
+        this.logger.info(
           {
             origin,
             destination,
@@ -405,7 +412,7 @@ export class Rebalancer implements IRebalancer {
         successfulTransactions.push(transaction);
       } catch (error) {
         transactionFailures++;
-        rebalancerLogger.error(
+        this.logger.error(
           {
             origin: transaction.route.origin,
             destination: transaction.route.destination,
@@ -440,12 +447,13 @@ export class Rebalancer implements IRebalancer {
         this.bridges,
         origin,
         destination,
+        this.logger,
       );
       const minAccepted = BigInt(
         toWei(bridgeMinAcceptedAmount, originToken.decimals),
       );
       if (minAccepted > amount) {
-        rebalancerLogger.info(
+        this.logger.info(
           {
             origin,
             destination,

--- a/typescript/cli/src/rebalancer/core/WithSemaphore.test.ts
+++ b/typescript/cli/src/rebalancer/core/WithSemaphore.test.ts
@@ -1,6 +1,7 @@
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { ethers } from 'ethers';
+import { pino } from 'pino';
 import Sinon from 'sinon';
 
 import { RebalancerStrategyOptions } from '@hyperlane-xyz/sdk';
@@ -12,6 +13,8 @@ import { RebalancingRoute } from '../interfaces/IStrategy.js';
 import { WithSemaphore } from './WithSemaphore.js';
 
 chai.use(chaiAsPromised);
+
+const testLogger = pino({ level: 'silent' });
 
 class MockRebalancer implements IRebalancer {
   rebalance(_routes: RebalancingRoute[]): Promise<void> {
@@ -55,7 +58,7 @@ describe('WithSemaphore', () => {
 
     const rebalancer = new MockRebalancer();
     const rebalanceSpy = Sinon.spy(rebalancer, 'rebalance');
-    const withSemaphore = new WithSemaphore(config, rebalancer);
+    const withSemaphore = new WithSemaphore(config, rebalancer, testLogger);
     await withSemaphore.rebalance(routes);
 
     expect(rebalanceSpy.calledOnce).to.be.true;
@@ -67,7 +70,7 @@ describe('WithSemaphore', () => {
 
     const rebalancer = new MockRebalancer();
     const rebalanceSpy = Sinon.spy(rebalancer, 'rebalance');
-    const withSemaphore = new WithSemaphore(config, rebalancer);
+    const withSemaphore = new WithSemaphore(config, rebalancer, testLogger);
     await withSemaphore.rebalance([]);
 
     expect(rebalanceSpy.calledOnce).to.be.false;
@@ -84,7 +87,7 @@ describe('WithSemaphore', () => {
 
     const rebalancer = new MockRebalancer();
     const rebalanceSpy = Sinon.spy(rebalancer, 'rebalance');
-    const withSemaphore = new WithSemaphore(config, rebalancer);
+    const withSemaphore = new WithSemaphore(config, rebalancer, testLogger);
     await withSemaphore.rebalance(routes);
 
     expect(rebalanceSpy.calledOnce).to.be.true;
@@ -111,7 +114,7 @@ describe('WithSemaphore', () => {
     ];
 
     const rebalancer = new MockRebalancer();
-    const withSemaphore = new WithSemaphore(config, rebalancer);
+    const withSemaphore = new WithSemaphore(config, rebalancer, testLogger);
 
     await expect(withSemaphore.rebalance(routes)).to.be.rejectedWith(
       `Chain ${routes[0].origin} not found in config`,
@@ -129,7 +132,7 @@ describe('WithSemaphore', () => {
 
     const rebalancer = new MockRebalancer();
     const rebalanceSpy = Sinon.spy(rebalancer, 'rebalance');
-    const withSemaphore = new WithSemaphore(config, rebalancer);
+    const withSemaphore = new WithSemaphore(config, rebalancer, testLogger);
 
     const rebalancePromise1 = withSemaphore.rebalance(routes);
     const rebalancePromise2 = withSemaphore.rebalance(routes);

--- a/typescript/cli/src/rebalancer/metrics/PriceGetter.ts
+++ b/typescript/cli/src/rebalancer/metrics/PriceGetter.ts
@@ -1,3 +1,5 @@
+import { Logger } from 'pino';
+
 import {
   ChainMap,
   ChainMetadata,
@@ -5,31 +7,36 @@ import {
   Token,
 } from '@hyperlane-xyz/sdk';
 
-import { monitorLogger } from '../utils/index.js';
-
 export class PriceGetter extends CoinGeckoTokenPriceGetter {
+  private readonly logger: Logger;
+
   private constructor({
     chainMetadata,
+    logger,
     apiKey,
     expirySeconds,
     sleepMsBetweenRequests,
   }: {
     chainMetadata: ChainMap<ChainMetadata>;
+    logger: Logger;
     apiKey?: string;
     expirySeconds?: number;
     sleepMsBetweenRequests?: number;
   }) {
     super({ chainMetadata, apiKey, expirySeconds, sleepMsBetweenRequests });
+    this.logger = logger;
   }
 
   public static create(
     chainMetadata: ChainMap<ChainMetadata>,
+    logger: Logger,
     coingeckoApiKey?: string,
     expirySeconds?: number,
     sleepMsBetweenRequests?: number,
   ) {
     return new PriceGetter({
       chainMetadata,
+      logger,
       apiKey: coingeckoApiKey,
       expirySeconds,
       sleepMsBetweenRequests,
@@ -45,7 +52,7 @@ export class PriceGetter extends CoinGeckoTokenPriceGetter {
     const coinGeckoId = token.coinGeckoId;
 
     if (!coinGeckoId) {
-      monitorLogger.warn(
+      this.logger.warn(
         {
           tokenSymbol: token.symbol,
           chain: token.chainName,

--- a/typescript/cli/src/rebalancer/metrics/scripts/metrics.ts
+++ b/typescript/cli/src/rebalancer/metrics/scripts/metrics.ts
@@ -1,9 +1,9 @@
+import { Logger } from 'pino';
 import { Counter, Gauge, Registry } from 'prom-client';
 
 import { ChainName, Token, TokenStandard, WarpCore } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 
-import { monitorLogger } from '../../utils/index.js';
 import {
   NativeWalletBalance,
   WarpRouteBalance,
@@ -128,6 +128,7 @@ export function updateTokenBalanceMetrics(
   token: Token,
   balanceInfo: WarpRouteBalance,
   warpRouteId: string,
+  logger: Logger,
 ) {
   const allChains = warpCore.getTokenChains().sort();
   const relatedChains = allChains.filter(
@@ -154,7 +155,7 @@ export function updateTokenBalanceMetrics(
   };
 
   warpRouteTokenBalance.labels(metrics).set(balanceInfo.balance);
-  monitorLogger.info(
+  logger.info(
     {
       labels: metrics,
       balance: balanceInfo.balance,
@@ -165,7 +166,7 @@ export function updateTokenBalanceMetrics(
   if (balanceInfo.valueUSD) {
     // TODO: consider deprecating this metric in favor of the value at risk metric
     warpRouteCollateralValue.labels(metrics).set(balanceInfo.valueUSD);
-    monitorLogger.info(
+    logger.info(
       {
         labels: metrics,
         valueUSD: balanceInfo.valueUSD,
@@ -184,7 +185,7 @@ export function updateTokenBalanceMetrics(
       };
 
       warpRouteValueAtRisk.labels(labels).set(balanceInfo.valueUSD);
-      monitorLogger.info(
+      logger.info(
         {
           labels,
           valueUSD: balanceInfo.valueUSD,
@@ -204,6 +205,7 @@ export function updateManagedLockboxBalanceMetrics(
   lockBoxAddress: string,
   balanceInfo: WarpRouteBalance,
   warpRouteId: string,
+  logger: Logger,
 ) {
   const metrics: WarpRouteMetricLabels = {
     chain_name: chainName,
@@ -220,7 +222,7 @@ export function updateManagedLockboxBalanceMetrics(
   };
 
   warpRouteTokenBalance.labels(metrics).set(balanceInfo.balance);
-  monitorLogger.info(
+  logger.info(
     {
       labels: metrics,
       balance: balanceInfo.balance,
@@ -230,7 +232,7 @@ export function updateManagedLockboxBalanceMetrics(
 
   if (balanceInfo.valueUSD) {
     warpRouteCollateralValue.labels(metrics).set(balanceInfo.valueUSD);
-    monitorLogger.info(
+    logger.info(
       {
         labels: metrics,
         valueUSD: balanceInfo.valueUSD,
@@ -240,7 +242,10 @@ export function updateManagedLockboxBalanceMetrics(
   }
 }
 
-export function updateNativeWalletBalanceMetrics(balance: NativeWalletBalance) {
+export function updateNativeWalletBalanceMetrics(
+  balance: NativeWalletBalance,
+  logger: Logger,
+) {
   walletBalanceGauge
     .labels({
       chain: balance.chain,
@@ -250,7 +255,7 @@ export function updateNativeWalletBalanceMetrics(balance: NativeWalletBalance) {
       token_name: 'Native',
     })
     .set(balance.balance);
-  monitorLogger.info(
+  logger.info(
     {
       balanceInfo: balance,
     },
@@ -264,6 +269,7 @@ export function updateXERC20LimitsMetrics(
   bridgeAddress: Address,
   bridgeLabel: string,
   xERC20Address: Address,
+  logger: Logger,
 ) {
   const labels = {
     chain_name: token.chainName,
@@ -282,7 +288,7 @@ export function updateXERC20LimitsMetrics(
       .set(limit);
   }
 
-  monitorLogger.info(
+  logger.info(
     {
       ...labels,
       limits,

--- a/typescript/cli/src/rebalancer/strategy/MinAmountStrategy.test.ts
+++ b/typescript/cli/src/rebalancer/strategy/MinAmountStrategy.test.ts
@@ -1,5 +1,6 @@
 import { AddressZero } from '@ethersproject/constants';
 import { expect } from 'chai';
+import { pino } from 'pino';
 
 import {
   type ChainMap,
@@ -12,6 +13,8 @@ import {
 import type { RawBalances } from '../interfaces/IStrategy.js';
 
 import { MinAmountStrategy } from './MinAmountStrategy.js';
+
+const testLogger = pino({ level: 'silent' });
 
 describe('MinAmountStrategy', () => {
   let chain1: ChainName;
@@ -54,6 +57,7 @@ describe('MinAmountStrategy', () => {
             },
             tokensByChainName,
             totalCollateral,
+            testLogger,
           ),
       ).to.throw('At least two chains must be configured');
     });
@@ -82,6 +86,7 @@ describe('MinAmountStrategy', () => {
         },
         tokensByChainName,
         totalCollateral,
+        testLogger,
       );
     });
 
@@ -109,6 +114,7 @@ describe('MinAmountStrategy', () => {
         },
         tokensByChainName,
         totalCollateral,
+        testLogger,
       );
     });
 
@@ -138,6 +144,7 @@ describe('MinAmountStrategy', () => {
             },
             tokensByChainName,
             totalCollateral,
+            testLogger,
           ),
       ).to.throw('Minimum amount (-10) cannot be negative for chain chain2');
     });
@@ -168,6 +175,7 @@ describe('MinAmountStrategy', () => {
             },
             tokensByChainName,
             totalCollateral,
+            testLogger,
           ),
       ).to.throw(
         'Target (80) must be greater than or equal to min (100) for chain chain1',
@@ -200,6 +208,7 @@ describe('MinAmountStrategy', () => {
             },
             tokensByChainName,
             totalCollateral,
+            testLogger,
           ),
       ).to.throw(
         'Target (0.4) must be greater than or equal to min (0.5) for chain chain1',
@@ -231,6 +240,7 @@ describe('MinAmountStrategy', () => {
           },
           tokensByChainName,
           totalCollateral,
+          testLogger,
         ).getRebalancingRoutes({
           [chain1]: 100n,
           [chain2]: 200n,
@@ -264,6 +274,7 @@ describe('MinAmountStrategy', () => {
           },
           tokensByChainName,
           totalCollateral,
+          testLogger,
         ).getRebalancingRoutes({
           [chain1]: 100n,
           [chain3]: 300n,
@@ -296,6 +307,7 @@ describe('MinAmountStrategy', () => {
           },
           tokensByChainName,
           totalCollateral,
+          testLogger,
         ).getRebalancingRoutes({
           [chain1]: 100n,
           [chain2]: -2n,
@@ -329,6 +341,7 @@ describe('MinAmountStrategy', () => {
         },
         tokensByChainName,
         totalCollateral,
+        testLogger,
       );
 
       const rawBalances: RawBalances = {
@@ -365,6 +378,7 @@ describe('MinAmountStrategy', () => {
         },
         tokensByChainName,
         totalCollateral,
+        testLogger,
       );
 
       const rawBalances = {
@@ -416,6 +430,7 @@ describe('MinAmountStrategy', () => {
         },
         tokensByChainName,
         totalCollateral,
+        testLogger,
       );
 
       const rawBalances = {
@@ -466,6 +481,7 @@ describe('MinAmountStrategy', () => {
             },
             tokensByChainName,
             totalCollateral,
+            testLogger,
           ),
       ).to.throw(
         `Consider reducing the targets as the sum (340) is greater than sum of collaterals (300)`,
@@ -505,6 +521,7 @@ describe('MinAmountStrategy', () => {
         },
         tokensByChainName,
         totalCollateral,
+        testLogger,
       );
 
       const rawBalances = {
@@ -549,6 +566,7 @@ describe('MinAmountStrategy', () => {
         },
         tokensByChainName,
         totalCollateral,
+        testLogger,
       );
 
       const rawBalances = {
@@ -585,6 +603,7 @@ describe('MinAmountStrategy', () => {
         },
         tokensByChainName,
         totalCollateral,
+        testLogger,
       );
 
       const rawBalances: RawBalances = {

--- a/typescript/cli/src/rebalancer/strategy/MinAmountStrategy.ts
+++ b/typescript/cli/src/rebalancer/strategy/MinAmountStrategy.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from 'bignumber.js';
+import { Logger } from 'pino';
 
 import {
   type ChainMap,
@@ -19,15 +20,19 @@ import { BaseStrategy, type Delta } from './BaseStrategy.js';
  */
 export class MinAmountStrategy extends BaseStrategy {
   private readonly config: MinAmountStrategyConfig = {};
+  protected readonly logger: Logger;
 
   constructor(
     config: MinAmountStrategyConfig,
     private readonly tokensByChainName: ChainMap<Token>,
     initialTotalCollateral: bigint,
+    logger: Logger,
     metrics?: Metrics,
   ) {
     const chains = Object.keys(config);
-    super(chains, metrics);
+    const log = logger.child({ class: MinAmountStrategy.name });
+    super(chains, log, metrics);
+    this.logger = log;
 
     const minAmountType = config[chains[0]].minAmount.type;
     this.validateAmounts(initialTotalCollateral, minAmountType, config);
@@ -56,6 +61,7 @@ export class MinAmountStrategy extends BaseStrategy {
     }
 
     this.config = config;
+    this.logger.info('MinAmountStrategy created');
   }
 
   /**

--- a/typescript/cli/src/rebalancer/strategy/StrategyFactory.test.ts
+++ b/typescript/cli/src/rebalancer/strategy/StrategyFactory.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { ethers } from 'ethers';
+import { pino } from 'pino';
 
 import {
   type ChainMap,
@@ -15,6 +16,8 @@ import {
 import { MinAmountStrategy } from './MinAmountStrategy.js';
 import { StrategyFactory } from './StrategyFactory.js';
 import { WeightedStrategy } from './WeightedStrategy.js';
+
+const testLogger = pino({ level: 'silent' });
 
 describe('StrategyFactory', () => {
   const chain1 = 'chain1';
@@ -62,6 +65,7 @@ describe('StrategyFactory', () => {
         strategyConfig,
         tokensByChainName,
         totalCollateral,
+        testLogger,
       );
       expect(strategy).to.be.instanceOf(WeightedStrategy);
     });
@@ -97,6 +101,7 @@ describe('StrategyFactory', () => {
         strategyConfig,
         tokensByChainName,
         totalCollateral,
+        testLogger,
       );
       expect(strategy).to.be.instanceOf(MinAmountStrategy);
     });

--- a/typescript/cli/src/rebalancer/strategy/StrategyFactory.ts
+++ b/typescript/cli/src/rebalancer/strategy/StrategyFactory.ts
@@ -1,3 +1,5 @@
+import { Logger } from 'pino';
+
 import {
   ChainMap,
   RebalancerStrategyOptions,
@@ -16,6 +18,7 @@ export class StrategyFactory {
    * @param strategyConfig A discriminated union of strategy-specific configurations.
    * @param tokensByChainName - A map of chain->token to ease the lookup of token by chain
    * @param initialTotalCollateral - The initial total collateral of the rebalancer
+   * @param logger - The logger to use for the strategy
    * @param metrics - The metrics to use for the strategy
    * @returns A concrete strategy implementation
    */
@@ -23,16 +26,18 @@ export class StrategyFactory {
     strategyConfig: StrategyConfig,
     tokensByChainName: ChainMap<Token>,
     initialTotalCollateral: bigint,
+    logger: Logger,
     metrics?: Metrics,
   ): IStrategy {
     switch (strategyConfig.rebalanceStrategy) {
       case RebalancerStrategyOptions.Weighted:
-        return new WeightedStrategy(strategyConfig.chains, metrics);
+        return new WeightedStrategy(strategyConfig.chains, logger, metrics);
       case RebalancerStrategyOptions.MinAmount:
         return new MinAmountStrategy(
           strategyConfig.chains,
           tokensByChainName,
           initialTotalCollateral,
+          logger,
           metrics,
         );
       default: {

--- a/typescript/cli/src/rebalancer/strategy/WeightedStrategy.test.ts
+++ b/typescript/cli/src/rebalancer/strategy/WeightedStrategy.test.ts
@@ -1,11 +1,14 @@
 import { expect } from 'chai';
 import { ethers } from 'ethers';
+import { pino } from 'pino';
 
 import type { ChainName } from '@hyperlane-xyz/sdk';
 
 import type { RawBalances } from '../interfaces/IStrategy.js';
 
 import { WeightedStrategy } from './WeightedStrategy.js';
+
+const testLogger = pino({ level: 'silent' });
 
 describe('WeightedStrategy', () => {
   let chain1: ChainName;
@@ -22,81 +25,96 @@ describe('WeightedStrategy', () => {
     it('should throw an error when less than two chains are configured', () => {
       expect(
         () =>
-          new WeightedStrategy({
-            [chain1]: {
-              weighted: { weight: 100n, tolerance: 0n },
-              bridge: ethers.constants.AddressZero,
-              bridgeLockTime: 1,
+          new WeightedStrategy(
+            {
+              [chain1]: {
+                weighted: { weight: 100n, tolerance: 0n },
+                bridge: ethers.constants.AddressZero,
+                bridgeLockTime: 1,
+              },
             },
-          }),
+            testLogger,
+          ),
       ).to.throw('At least two chains must be configured');
     });
 
     it('should throw an error when weight is less than or equal to 0', () => {
       expect(
         () =>
-          new WeightedStrategy({
-            [chain1]: {
-              weighted: { weight: 100n, tolerance: 0n },
-              bridge: ethers.constants.AddressZero,
-              bridgeLockTime: 1,
+          new WeightedStrategy(
+            {
+              [chain1]: {
+                weighted: { weight: 100n, tolerance: 0n },
+                bridge: ethers.constants.AddressZero,
+                bridgeLockTime: 1,
+              },
+              [chain2]: {
+                weighted: { weight: 0n, tolerance: 0n },
+                bridge: ethers.constants.AddressZero,
+                bridgeLockTime: 1,
+              },
             },
-            [chain2]: {
-              weighted: { weight: 0n, tolerance: 0n },
-              bridge: ethers.constants.AddressZero,
-              bridgeLockTime: 1,
-            },
-          }),
+            testLogger,
+          ),
       ).to.throw('Weight (0) must be greater than 0 for chain2');
 
       expect(
         () =>
-          new WeightedStrategy({
-            [chain1]: {
-              weighted: { weight: 100n, tolerance: 0n },
-              bridge: ethers.constants.AddressZero,
-              bridgeLockTime: 1,
+          new WeightedStrategy(
+            {
+              [chain1]: {
+                weighted: { weight: 100n, tolerance: 0n },
+                bridge: ethers.constants.AddressZero,
+                bridgeLockTime: 1,
+              },
+              [chain2]: {
+                weighted: { weight: -1n, tolerance: 0n },
+                bridge: ethers.constants.AddressZero,
+                bridgeLockTime: 1,
+              },
             },
-            [chain2]: {
-              weighted: { weight: -1n, tolerance: 0n },
-              bridge: ethers.constants.AddressZero,
-              bridgeLockTime: 1,
-            },
-          }),
+            testLogger,
+          ),
       ).to.throw('Weight (-1) must be greater than 0 for chain2');
     });
 
     it('should throw an error when tolerance is less than 0 or greater than 100', () => {
       expect(
         () =>
-          new WeightedStrategy({
-            [chain1]: {
-              weighted: { weight: 100n, tolerance: 0n },
-              bridge: ethers.constants.AddressZero,
-              bridgeLockTime: 1,
+          new WeightedStrategy(
+            {
+              [chain1]: {
+                weighted: { weight: 100n, tolerance: 0n },
+                bridge: ethers.constants.AddressZero,
+                bridgeLockTime: 1,
+              },
+              [chain2]: {
+                weighted: { weight: 100n, tolerance: -1n },
+                bridge: ethers.constants.AddressZero,
+                bridgeLockTime: 1,
+              },
             },
-            [chain2]: {
-              weighted: { weight: 100n, tolerance: -1n },
-              bridge: ethers.constants.AddressZero,
-              bridgeLockTime: 1,
-            },
-          }),
+            testLogger,
+          ),
       ).to.throw('Tolerance (-1) must be between 0 and 100 for chain2');
 
       expect(
         () =>
-          new WeightedStrategy({
-            [chain1]: {
-              weighted: { weight: 100n, tolerance: 100n },
-              bridge: ethers.constants.AddressZero,
-              bridgeLockTime: 1,
+          new WeightedStrategy(
+            {
+              [chain1]: {
+                weighted: { weight: 100n, tolerance: 100n },
+                bridge: ethers.constants.AddressZero,
+                bridgeLockTime: 1,
+              },
+              [chain2]: {
+                weighted: { weight: 100n, tolerance: 101n },
+                bridge: ethers.constants.AddressZero,
+                bridgeLockTime: 1,
+              },
             },
-            [chain2]: {
-              weighted: { weight: 100n, tolerance: 101n },
-              bridge: ethers.constants.AddressZero,
-              bridgeLockTime: 1,
-            },
-          }),
+            testLogger,
+          ),
       ).to.throw('Tolerance (101) must be between 0 and 100 for chain2');
     });
   });
@@ -104,18 +122,21 @@ describe('WeightedStrategy', () => {
   describe('getRebalancingRoutes', () => {
     it('should throw an error when raw balances chains length does not match configured chains length', () => {
       expect(() =>
-        new WeightedStrategy({
-          [chain1]: {
-            weighted: { weight: 100n, tolerance: 0n },
-            bridge: ethers.constants.AddressZero,
-            bridgeLockTime: 1,
+        new WeightedStrategy(
+          {
+            [chain1]: {
+              weighted: { weight: 100n, tolerance: 0n },
+              bridge: ethers.constants.AddressZero,
+              bridgeLockTime: 1,
+            },
+            [chain2]: {
+              weighted: { weight: 100n, tolerance: 0n },
+              bridge: ethers.constants.AddressZero,
+              bridgeLockTime: 1,
+            },
           },
-          [chain2]: {
-            weighted: { weight: 100n, tolerance: 0n },
-            bridge: ethers.constants.AddressZero,
-            bridgeLockTime: 1,
-          },
-        }).getRebalancingRoutes({
+          testLogger,
+        ).getRebalancingRoutes({
           [chain1]: ethers.utils.parseEther('100').toBigInt(),
           [chain2]: ethers.utils.parseEther('200').toBigInt(),
           [chain3]: ethers.utils.parseEther('300').toBigInt(),
@@ -125,18 +146,21 @@ describe('WeightedStrategy', () => {
 
     it('should throw an error when a raw balance is missing', () => {
       expect(() =>
-        new WeightedStrategy({
-          [chain1]: {
-            weighted: { weight: 100n, tolerance: 0n },
-            bridge: ethers.constants.AddressZero,
-            bridgeLockTime: 1,
+        new WeightedStrategy(
+          {
+            [chain1]: {
+              weighted: { weight: 100n, tolerance: 0n },
+              bridge: ethers.constants.AddressZero,
+              bridgeLockTime: 1,
+            },
+            [chain2]: {
+              weighted: { weight: 100n, tolerance: 0n },
+              bridge: ethers.constants.AddressZero,
+              bridgeLockTime: 1,
+            },
           },
-          [chain2]: {
-            weighted: { weight: 100n, tolerance: 0n },
-            bridge: ethers.constants.AddressZero,
-            bridgeLockTime: 1,
-          },
-        }).getRebalancingRoutes({
+          testLogger,
+        ).getRebalancingRoutes({
           [chain1]: ethers.utils.parseEther('100').toBigInt(),
           [chain3]: ethers.utils.parseEther('300').toBigInt(),
         } as RawBalances),
@@ -145,7 +169,30 @@ describe('WeightedStrategy', () => {
 
     it('should throw an error when a raw balance is negative', () => {
       expect(() =>
-        new WeightedStrategy({
+        new WeightedStrategy(
+          {
+            [chain1]: {
+              weighted: { weight: 100n, tolerance: 0n },
+              bridge: ethers.constants.AddressZero,
+              bridgeLockTime: 1,
+            },
+            [chain2]: {
+              weighted: { weight: 100n, tolerance: 0n },
+              bridge: ethers.constants.AddressZero,
+              bridgeLockTime: 1,
+            },
+          },
+          testLogger,
+        ).getRebalancingRoutes({
+          [chain1]: ethers.utils.parseEther('100').toBigInt(),
+          [chain2]: ethers.utils.parseEther('-200').toBigInt(),
+        }),
+      ).to.throw('Raw balance for chain chain2 is negative');
+    });
+
+    it('should return an empty array when all chains are balanced', () => {
+      const strategy = new WeightedStrategy(
+        {
           [chain1]: {
             weighted: { weight: 100n, tolerance: 0n },
             bridge: ethers.constants.AddressZero,
@@ -156,26 +203,9 @@ describe('WeightedStrategy', () => {
             bridge: ethers.constants.AddressZero,
             bridgeLockTime: 1,
           },
-        }).getRebalancingRoutes({
-          [chain1]: ethers.utils.parseEther('100').toBigInt(),
-          [chain2]: ethers.utils.parseEther('-200').toBigInt(),
-        }),
-      ).to.throw('Raw balance for chain chain2 is negative');
-    });
-
-    it('should return an empty array when all chains are balanced', () => {
-      const strategy = new WeightedStrategy({
-        [chain1]: {
-          weighted: { weight: 100n, tolerance: 0n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
         },
-        [chain2]: {
-          weighted: { weight: 100n, tolerance: 0n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
-        },
-      });
+        testLogger,
+      );
 
       const rawBalances = {
         [chain1]: ethers.utils.parseEther('100').toBigInt(),
@@ -188,18 +218,21 @@ describe('WeightedStrategy', () => {
     });
 
     it('should return a single route when a chain is unbalanced', () => {
-      const strategy = new WeightedStrategy({
-        [chain1]: {
-          weighted: { weight: 100n, tolerance: 0n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
+      const strategy = new WeightedStrategy(
+        {
+          [chain1]: {
+            weighted: { weight: 100n, tolerance: 0n },
+            bridge: ethers.constants.AddressZero,
+            bridgeLockTime: 1,
+          },
+          [chain2]: {
+            weighted: { weight: 100n, tolerance: 0n },
+            bridge: ethers.constants.AddressZero,
+            bridgeLockTime: 1,
+          },
         },
-        [chain2]: {
-          weighted: { weight: 100n, tolerance: 0n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
-        },
-      });
+        testLogger,
+      );
 
       const rawBalances = {
         [chain1]: ethers.utils.parseEther('100').toBigInt(),
@@ -218,18 +251,21 @@ describe('WeightedStrategy', () => {
     });
 
     it('should return an empty array when a chain is unbalanced but has tolerance', () => {
-      const strategy = new WeightedStrategy({
-        [chain1]: {
-          weighted: { weight: 100n, tolerance: 1n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
+      const strategy = new WeightedStrategy(
+        {
+          [chain1]: {
+            weighted: { weight: 100n, tolerance: 1n },
+            bridge: ethers.constants.AddressZero,
+            bridgeLockTime: 1,
+          },
+          [chain2]: {
+            weighted: { weight: 100n, tolerance: 1n },
+            bridge: ethers.constants.AddressZero,
+            bridgeLockTime: 1,
+          },
         },
-        [chain2]: {
-          weighted: { weight: 100n, tolerance: 1n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
-        },
-      });
+        testLogger,
+      );
 
       const rawBalances = {
         [chain1]: ethers.utils.parseEther('100').toBigInt(),
@@ -242,23 +278,26 @@ describe('WeightedStrategy', () => {
     });
 
     it('should return a single route when two chains are unbalanced and can be solved with a single transfer', () => {
-      const strategy = new WeightedStrategy({
-        [chain1]: {
-          weighted: { weight: 100n, tolerance: 0n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
+      const strategy = new WeightedStrategy(
+        {
+          [chain1]: {
+            weighted: { weight: 100n, tolerance: 0n },
+            bridge: ethers.constants.AddressZero,
+            bridgeLockTime: 1,
+          },
+          [chain2]: {
+            weighted: { weight: 100n, tolerance: 0n },
+            bridge: ethers.constants.AddressZero,
+            bridgeLockTime: 1,
+          },
+          [chain3]: {
+            weighted: { weight: 100n, tolerance: 0n },
+            bridge: ethers.constants.AddressZero,
+            bridgeLockTime: 1,
+          },
         },
-        [chain2]: {
-          weighted: { weight: 100n, tolerance: 0n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
-        },
-        [chain3]: {
-          weighted: { weight: 100n, tolerance: 0n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
-        },
-      });
+        testLogger,
+      );
 
       const rawBalances = {
         [chain1]: ethers.utils.parseEther('100').toBigInt(),
@@ -277,23 +316,26 @@ describe('WeightedStrategy', () => {
       ]);
     });
     it('should return two routes when two chains are unbalanced and cannot be solved with a single transfer', () => {
-      const strategy = new WeightedStrategy({
-        [chain1]: {
-          weighted: { weight: 100n, tolerance: 0n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
+      const strategy = new WeightedStrategy(
+        {
+          [chain1]: {
+            weighted: { weight: 100n, tolerance: 0n },
+            bridge: ethers.constants.AddressZero,
+            bridgeLockTime: 1,
+          },
+          [chain2]: {
+            weighted: { weight: 100n, tolerance: 0n },
+            bridge: ethers.constants.AddressZero,
+            bridgeLockTime: 1,
+          },
+          [chain3]: {
+            weighted: { weight: 100n, tolerance: 0n },
+            bridge: ethers.constants.AddressZero,
+            bridgeLockTime: 1,
+          },
         },
-        [chain2]: {
-          weighted: { weight: 100n, tolerance: 0n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
-        },
-        [chain3]: {
-          weighted: { weight: 100n, tolerance: 0n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
-        },
-      });
+        testLogger,
+      );
 
       const rawBalances = {
         [chain1]: ethers.utils.parseEther('100').toBigInt(),
@@ -318,23 +360,26 @@ describe('WeightedStrategy', () => {
     });
 
     it('should return routes to balance different weighted chains', () => {
-      const strategy = new WeightedStrategy({
-        [chain1]: {
-          weighted: { weight: 50n, tolerance: 0n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
+      const strategy = new WeightedStrategy(
+        {
+          [chain1]: {
+            weighted: { weight: 50n, tolerance: 0n },
+            bridge: ethers.constants.AddressZero,
+            bridgeLockTime: 1,
+          },
+          [chain2]: {
+            weighted: { weight: 25n, tolerance: 0n },
+            bridge: ethers.constants.AddressZero,
+            bridgeLockTime: 1,
+          },
+          [chain3]: {
+            weighted: { weight: 25n, tolerance: 0n },
+            bridge: ethers.constants.AddressZero,
+            bridgeLockTime: 1,
+          },
         },
-        [chain2]: {
-          weighted: { weight: 25n, tolerance: 0n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
-        },
-        [chain3]: {
-          weighted: { weight: 25n, tolerance: 0n },
-          bridge: ethers.constants.AddressZero,
-          bridgeLockTime: 1,
-        },
-      });
+        testLogger,
+      );
 
       const rawBalances = {
         [chain1]: ethers.utils.parseEther('100').toBigInt(),

--- a/typescript/cli/src/rebalancer/strategy/WeightedStrategy.ts
+++ b/typescript/cli/src/rebalancer/strategy/WeightedStrategy.ts
@@ -1,3 +1,5 @@
+import { Logger } from 'pino';
+
 import type { WeightedStrategyConfig } from '@hyperlane-xyz/sdk';
 
 import type { RawBalances } from '../interfaces/IStrategy.js';
@@ -12,10 +14,17 @@ import { BaseStrategy, type Delta } from './BaseStrategy.js';
 export class WeightedStrategy extends BaseStrategy {
   private readonly config: WeightedStrategyConfig;
   private readonly totalWeight: bigint;
+  protected readonly logger: Logger;
 
-  constructor(config: WeightedStrategyConfig, metrics?: Metrics) {
+  constructor(
+    config: WeightedStrategyConfig,
+    logger: Logger,
+    metrics?: Metrics,
+  ) {
     const chains = Object.keys(config);
-    super(chains, metrics);
+    const log = logger.child({ class: WeightedStrategy.name });
+    super(chains, log, metrics);
+    this.logger = log;
 
     let totalWeight = 0n;
 
@@ -39,6 +48,7 @@ export class WeightedStrategy extends BaseStrategy {
 
     this.config = config;
     this.totalWeight = totalWeight;
+    this.logger.info('WeightedStrategy created');
   }
 
   /**

--- a/typescript/cli/src/rebalancer/utils/balanceUtils.test.ts
+++ b/typescript/cli/src/rebalancer/utils/balanceUtils.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { pino } from 'pino';
 import sinon from 'sinon';
 
 import { ChainName, Token, TokenStandard } from '@hyperlane-xyz/sdk';
@@ -6,6 +7,8 @@ import { ChainName, Token, TokenStandard } from '@hyperlane-xyz/sdk';
 import { MonitorEvent } from '../interfaces/IMonitor.js';
 
 import { getRawBalances } from './balanceUtils.js';
+
+const testLogger = pino({ level: 'silent' });
 
 describe('getRawBalances', () => {
   let chains: ChainName[];
@@ -36,7 +39,7 @@ describe('getRawBalances', () => {
   });
 
   it('should return the bridged supply for the token (EvmHypCollateral)', () => {
-    expect(getRawBalances(chains, event)).to.deep.equal({
+    expect(getRawBalances(chains, event, testLogger)).to.deep.equal({
       mainnet: tokenBridgedSupply,
     });
   });
@@ -44,7 +47,7 @@ describe('getRawBalances', () => {
   it('should return the bridged supply for the token (EvmHypNative)', () => {
     token.standard = TokenStandard.EvmHypNative;
 
-    expect(getRawBalances(chains, event)).to.deep.equal({
+    expect(getRawBalances(chains, event, testLogger)).to.deep.equal({
       mainnet: tokenBridgedSupply,
     });
   });
@@ -52,19 +55,19 @@ describe('getRawBalances', () => {
   it('should ignore non supported token standards', () => {
     token.standard = TokenStandard.EvmHypOwnerCollateral;
 
-    expect(getRawBalances(chains, event)).to.deep.equal({});
+    expect(getRawBalances(chains, event, testLogger)).to.deep.equal({});
   });
 
   it('should ignore tokens that are not in the chains list', () => {
     chains = [];
 
-    expect(getRawBalances(chains, event)).to.deep.equal({});
+    expect(getRawBalances(chains, event, testLogger)).to.deep.equal({});
   });
 
   it('should throw if the bridged supply is undefined', () => {
     delete event.tokensInfo[0].bridgedSupply;
 
-    expect(() => getRawBalances(chains, event)).to.throw(
+    expect(() => getRawBalances(chains, event, testLogger)).to.throw(
       'bridgedSupply should not be undefined for collateralized token 0xAddress',
     );
   });

--- a/typescript/cli/src/rebalancer/utils/balanceUtils.ts
+++ b/typescript/cli/src/rebalancer/utils/balanceUtils.ts
@@ -1,9 +1,10 @@
+import { Logger } from 'pino';
+
 import { ChainName, Token } from '@hyperlane-xyz/sdk';
 
 import { MonitorEvent } from '../interfaces/IMonitor.js';
 import { RawBalances } from '../interfaces/IStrategy.js';
 
-import { rebalancerLogger } from './loggerUtils.js';
 import { isCollateralizedTokenEligibleForRebalancing } from './tokenUtils.js';
 
 /**
@@ -15,6 +16,7 @@ import { isCollateralizedTokenEligibleForRebalancing } from './tokenUtils.js';
 export function getRawBalances(
   chains: ChainName[],
   event: MonitorEvent,
+  logger: Logger,
 ): RawBalances {
   const balances: RawBalances = {};
   const chainSet = new Set(chains);
@@ -24,7 +26,7 @@ export function getRawBalances(
 
     // Ignore tokens that are not in the provided chains list
     if (!chainSet.has(token.chainName)) {
-      rebalancerLogger.info(
+      logger.info(
         {
           context: getRawBalances.name,
           chain: token.chainName,
@@ -38,7 +40,7 @@ export function getRawBalances(
 
     // Ignore tokens that are not collateralized or are otherwise ineligible
     if (!isCollateralizedTokenEligibleForRebalancing(token)) {
-      rebalancerLogger.info(
+      logger.info(
         {
           context: getRawBalances.name,
           chain: token.chainName,

--- a/typescript/cli/src/rebalancer/utils/bridgeUtils.test.ts
+++ b/typescript/cli/src/rebalancer/utils/bridgeUtils.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { pino } from 'pino';
 
 import { ChainMap } from '@hyperlane-xyz/sdk';
 
@@ -6,6 +7,8 @@ import {
   type BridgeConfigWithOverride,
   getBridgeConfig,
 } from './bridgeUtils.js';
+
+const testLogger = pino({ level: 'silent' });
 
 describe('bridgeConfig', () => {
   it('should return the base bridge config when no overrides exist', () => {
@@ -22,7 +25,7 @@ describe('bridgeConfig', () => {
       },
     };
 
-    const result = getBridgeConfig(bridges, 'chain1', 'chain2');
+    const result = getBridgeConfig(bridges, 'chain1', 'chain2', testLogger);
 
     expect(result).to.deep.equal({
       bridge: '0x1234567890123456789012345678901234567890',
@@ -50,7 +53,7 @@ describe('bridgeConfig', () => {
       },
     };
 
-    const result = getBridgeConfig(bridges, 'chain1', 'chain2');
+    const result = getBridgeConfig(bridges, 'chain1', 'chain2', testLogger);
 
     expect(result).to.deep.equal({
       bridge: '0x1234567890123456789012345678901234567890',
@@ -78,7 +81,7 @@ describe('bridgeConfig', () => {
       },
     };
 
-    const result = getBridgeConfig(bridges, 'chain1', 'chain2');
+    const result = getBridgeConfig(bridges, 'chain1', 'chain2', testLogger);
 
     expect(result).to.deep.equal({
       bridge: '0xABCDEF0123456789ABCDEF0123456789ABCDEF01',

--- a/typescript/cli/src/rebalancer/utils/bridgeUtils.ts
+++ b/typescript/cli/src/rebalancer/utils/bridgeUtils.ts
@@ -1,6 +1,6 @@
-import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
+import { Logger } from 'pino';
 
-import { rebalancerLogger } from './loggerUtils.js';
+import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
 
 export type BridgeConfigWithOverride = BridgeConfig & {
   override?: ChainMap<Partial<BridgeConfig>>;
@@ -23,11 +23,12 @@ export function getBridgeConfig(
   bridges: ChainMap<BridgeConfigWithOverride>,
   fromChain: ChainName,
   toChain: ChainName,
+  logger: Logger,
 ): BridgeConfig {
   const fromConfig = bridges[fromChain];
 
   if (!fromConfig) {
-    rebalancerLogger.error({ fromChain }, 'Bridge config not found');
+    logger.error({ fromChain }, 'Bridge config not found');
     throw new Error(`Bridge config not found for chain ${fromChain}`);
   }
 

--- a/typescript/cli/src/rebalancer/utils/generalUtils.ts
+++ b/typescript/cli/src/rebalancer/utils/generalUtils.ts
@@ -1,12 +1,13 @@
-import { monitorLogger } from './loggerUtils.js';
+import { Logger } from 'pino';
 
-export async function tryFn(fn: () => Promise<void>, context: string) {
+export async function tryFn(
+  fn: () => Promise<void>,
+  context: string,
+  logger: Logger,
+) {
   try {
     await fn();
   } catch (error) {
-    monitorLogger.error(
-      { context, err: error as Error },
-      `Error in ${context}`,
-    );
+    logger.error({ context, err: error as Error }, `Error in ${context}`);
   }
 }

--- a/typescript/cli/src/rebalancer/utils/index.ts
+++ b/typescript/cli/src/rebalancer/utils/index.ts
@@ -1,5 +1,4 @@
 export * from './balanceUtils.js';
 export * from './bridgeUtils.js';
 export * from './generalUtils.js';
-export * from './loggerUtils.js';
 export * from './tokenUtils.js';

--- a/typescript/cli/src/rebalancer/utils/loggerUtils.ts
+++ b/typescript/cli/src/rebalancer/utils/loggerUtils.ts
@@ -1,9 +1,0 @@
-import { rootLogger } from '@hyperlane-xyz/utils';
-
-export const monitorLogger = rootLogger.child({ module: 'rebalancer-monitor' });
-export const rebalancerLogger = rootLogger.child({
-  module: 'rebalancer',
-});
-export const strategyLogger = rootLogger.child({
-  module: 'rebalancer-strategy',
-});

--- a/typescript/infra/helm/rebalancer/templates/_helpers.tpl
+++ b/typescript/infra/helm/rebalancer/templates/_helpers.tpl
@@ -70,7 +70,7 @@ The rebalancer container
   image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
   imagePullPolicy: IfNotPresent
   env:
-  - name: INSTALL_GCP_LOGGER
+  - name: INSTALL_GCP_LOGGER_CLI
     value: "true"
   - name: LOG_FORMAT
     value: json

--- a/typescript/infra/helm/rebalancer/templates/_helpers.tpl
+++ b/typescript/infra/helm/rebalancer/templates/_helpers.tpl
@@ -70,6 +70,8 @@ The rebalancer container
   image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
   imagePullPolicy: IfNotPresent
   env:
+  - name: INSTALL_GCP_LOGGER
+    value: "true"
   - name: LOG_FORMAT
     value: json
   - name: REGISTRY_COMMIT

--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -62,7 +62,7 @@ export class RebalancerHelmManager extends HelmManager {
     return {
       image: {
         repository: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-        tag: '722a6d0-20250703-160604',
+        tag: 'ef09844-20250707-104152',
       },
       withMetrics: this.withMetrics,
       fullnameOverride: this.helmReleaseName,


### PR DESCRIPTION
### Description

- Use GCP logging config for rebalancer logs
- Install "@google-cloud/pino-logging-gcp-config" dependency in the docker-entrypoint.sh script if `INSTALL_GCP_LOGGER_CLI` env var is set. This allows us to install this optionally in k8s environments
- Instantiate top level logger which is then injected to classes and methods

### Testing

Manual/Unit Tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for structured logging using an injected logger across all rebalancer components.
  * Introduced an environment variable to enable optional installation of a GCP logging package.

* **Refactor**
  * Replaced all global logger instances with explicit logger parameters in constructors and function signatures for improved logging consistency and flexibility.

* **Chores**
  * Updated tests to accommodate new logger dependencies.
  * Removed obsolete logger utility exports and related code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->