### PR TITLE
chore: catch switchChainAsync for starknet

### DIFF
--- a/.changeset/tasty-spoons-live.md
+++ b/.changeset/tasty-spoons-live.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/widgets": minor
+---
+
+Catch onSwitchNetwork for starknet

--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -8278,7 +8278,7 @@
       ],
       "blocks": {
         "confirmations": 1,
-        "estimateBlockTime": 1,
+        "estimateBlockTime": 2,
         "reorgPeriod": 5
       },
       "chainId": 999,

--- a/typescript/widgets/src/walletIntegrations/starknet.ts
+++ b/typescript/widgets/src/walletIntegrations/starknet.ts
@@ -19,7 +19,7 @@ import {
   WarpTypedTransaction,
   chainMetadataToStarknetChain,
 } from '@hyperlane-xyz/sdk';
-import { ProtocolType, assert } from '@hyperlane-xyz/utils';
+import { ProtocolType, assert, sleep } from '@hyperlane-xyz/utils';
 
 import { widgetLogger } from '../logger.js';
 
@@ -117,6 +117,8 @@ export function useStarknetTransactionFns(
         await switchChainAsync({
           chainId: chainId.toString(),
         });
+        // Some wallets seem to require a brief pause after switch
+        await sleep(2000);
       } catch {
         logger.warn('Failed to switch chain');
       }

--- a/typescript/widgets/src/walletIntegrations/starknet.ts
+++ b/typescript/widgets/src/walletIntegrations/starknet.ts
@@ -113,9 +113,13 @@ export function useStarknetTransactionFns(
   const onSwitchNetwork = useCallback(
     async (chainName: ChainName) => {
       const chainId = multiProvider.getChainMetadata(chainName).chainId;
-      await switchChainAsync({
-        chainId: chainId.toString(),
-      });
+      try {
+        await switchChainAsync({
+          chainId: chainId.toString(),
+        });
+      } catch {
+        logger.warn('Failed to switch chain');
+      }
     },
     [multiProvider, switchChainAsync],
   );


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
Some wallets connector like Braavos do not have switch chain logic implemented, which is why this would throw if called instead it will catch this and proceed to attempt to sign.

Also introduced a slight delay when switching network same as ethereum 

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
Manual testing