### PR TITLE
feat(utils): ignore dynamic import in webpack builds

### DIFF
--- a/.changeset/modern-snakes-flash.md
+++ b/.changeset/modern-snakes-flash.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/utils": patch
+---
+
+Ignore dynamic import in webpack builds

--- a/typescript/utils/src/logging.ts
+++ b/typescript/utils/src/logging.ts
@@ -121,7 +121,7 @@ export async function tryInitializeGcpLogger(options?: {
 
   try {
     const { createGcpLoggingPinoConfig } = await import(
-      '@google-cloud/pino-logging-gcp-config'
+      /* webpackIgnore: true */ '@google-cloud/pino-logging-gcp-config'
     );
     const serviceContext = options
       ? {


### PR DESCRIPTION
### Description

- Ignore dynamic import in webpack builds
- This resulted in a warning in the warp-ui repo 
- 

### Testing

Manual


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dynamic import handling to ensure certain modules are ignored during webpack builds, preventing bundling issues.

* **Chores**
  * Added documentation for a patch update related to dynamic import handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->