### PR TITLE
feat: timelock submitter [ENG-1855]

### DIFF
--- a/.changeset/friendly-elephants-shout.md
+++ b/.changeset/friendly-elephants-shout.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": major
+---
+
+Add support for submitting transactions using Timelock contracts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -301,6 +301,7 @@ jobs:
           # Other commands
           - relay
           # Warp Commands
+          - warp-apply-submitters
           - warp-apply
           - warp-bridge-1
           - warp-bridge-2

--- a/typescript/cli/examples/submit/strategy/json-rpc-timelock-strategy.yaml
+++ b/typescript/cli/examples/submit/strategy/json-rpc-timelock-strategy.yaml
@@ -1,0 +1,9 @@
+anvil3:
+  submitter:
+    type: timelockController
+    chain: anvil3
+    # Address of the timelock contract
+    timelockAddress: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+    # Configuration for how to propose this trasnaction on chain
+    proposerSubmitter:
+      type: jsonRpc

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -86,6 +86,7 @@ export const WARP_DEPLOY_CONFIG_CHAIN_2 = `${TEMP_PATH}/warp-route-deployment-2.
 export const WARP_DEPLOY_CONFIG_CHAIN_3 = `${TEMP_PATH}/warp-route-deployment-3.yaml`;
 
 export const JSON_RPC_ICA_STRATEGY_CONFIG_PATH = `${EXAMPLES_PATH}/submit/strategy/json-rpc-ica-strategy.yaml`;
+export const JSON_RPC_TIMELOCK_STRATEGY_CONFIG_PATH = `${EXAMPLES_PATH}/submit/strategy/json-rpc-timelock-strategy.yaml`;
 export function getCombinedWarpRoutePath(
   tokenSymbol: string,
   chains: string[],

--- a/typescript/cli/src/tests/warp/warp-extend-basic.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-extend-basic.e2e-test.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
 import { Signer, Wallet, ethers } from 'ethers';
 
-import { InterchainAccountRouter__factory } from '@hyperlane-xyz/core';
 import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
   ChainMetadata,
-  DerivedCoreConfig,
   HypTokenRouterConfig,
   TokenType,
   WarpRouteDeployConfig,
@@ -13,7 +11,6 @@ import {
 import { Address, Domain } from '@hyperlane-xyz/utils';
 
 import { readYamlOrJson, writeYamlOrJson } from '../../utils/files.js';
-import { hyperlaneCoreApply, readCoreConfig } from '../commands/core.js';
 import {
   ANVIL_KEY,
   CHAIN_2_METADATA_PATH,
@@ -21,20 +18,15 @@ import {
   CHAIN_NAME_2,
   CHAIN_NAME_3,
   CORE_CONFIG_PATH,
-  CORE_READ_CONFIG_PATH_2,
-  CORE_READ_CONFIG_PATH_3,
   DEFAULT_E2E_TEST_TIMEOUT,
   E2E_TEST_BURN_ADDRESS,
   EXAMPLES_PATH,
-  JSON_RPC_ICA_STRATEGY_CONFIG_PATH,
-  REGISTRY_PATH,
   TEMP_PATH,
   WARP_CONFIG_PATH_2,
   WARP_CONFIG_PATH_EXAMPLE,
   WARP_CORE_CONFIG_PATH_2,
   WARP_DEPLOY_2_ID,
   WARP_DEPLOY_CONFIG_CHAIN_2,
-  WARP_DEPLOY_CONFIG_CHAIN_3,
   deployOrUseExistingCore,
   extendWarpConfig,
   getCombinedWarpRoutePath,
@@ -328,116 +320,5 @@ describe('hyperlane warp apply basic extension tests', async function () {
       updatedWarpDeployConfig_3[CHAIN_NAME_3].destinationGas!;
     expect(Object.keys(destinationGas_3)).to.include(chain2Id);
     expect(destinationGas_3[chain2Id]).to.equal('7777');
-  });
-
-  it('should relay the ICA transaction to update the warp on the destination chain', async () => {
-    // Add the remote ica on chain anvil3
-    const [coreConfigChain2, coreConfigChain3]: DerivedCoreConfig[] =
-      await Promise.all([
-        readCoreConfig(CHAIN_NAME_2, CORE_READ_CONFIG_PATH_2),
-        readCoreConfig(CHAIN_NAME_3, CORE_READ_CONFIG_PATH_3),
-      ]);
-
-    const coreConfigChain2IcaConfig = coreConfigChain2.interchainAccountRouter!;
-    const coreConfigChain3IcaConfig = coreConfigChain3.interchainAccountRouter!;
-    coreConfigChain2IcaConfig.remoteRouters = {
-      [chain3DomainId]: {
-        address: coreConfigChain3IcaConfig.address,
-      },
-    };
-
-    writeYamlOrJson(CORE_READ_CONFIG_PATH_2, coreConfigChain2);
-    await hyperlaneCoreApply(CHAIN_NAME_2, CORE_READ_CONFIG_PATH_2);
-
-    // Read existing config into a file
-    const warpDeployConfig = await readWarpConfig(
-      CHAIN_NAME_2,
-      WARP_CORE_CONFIG_PATH_2,
-      WARP_DEPLOY_CONFIG_CHAIN_2,
-    );
-
-    // Extend the warp route to add a token on chain 3
-    const extendedConfig: HypTokenRouterConfig = {
-      decimals: 18,
-      mailbox: chain3Addresses!.mailbox,
-      name: 'Ether',
-      owner: initialOwnerAddress,
-      symbol: 'ETH',
-      type: TokenType.native,
-    };
-    warpDeployConfig[CHAIN_NAME_3] = extendedConfig;
-    writeYamlOrJson(WARP_DEPLOY_CONFIG_CHAIN_2, warpDeployConfig);
-    await hyperlaneWarpApply(
-      WARP_DEPLOY_CONFIG_CHAIN_2,
-      WARP_CORE_CONFIG_PATH_2,
-    );
-
-    const COMBINED_WARP_CORE_CONFIG_PATH = `${REGISTRY_PATH}/deployments/warp_routes/ETH/anvil2-anvil3-config.yaml`;
-    const [updatedWarpDeployConfig_2, updatedWarpDeployConfig_3] =
-      await Promise.all([
-        readWarpConfig(
-          CHAIN_NAME_2,
-          COMBINED_WARP_CORE_CONFIG_PATH,
-          WARP_DEPLOY_CONFIG_CHAIN_2,
-        ),
-        readWarpConfig(
-          CHAIN_NAME_3,
-          COMBINED_WARP_CORE_CONFIG_PATH,
-          WARP_DEPLOY_CONFIG_CHAIN_3,
-        ),
-      ]);
-
-    // Get the ICA router addresses and the associated ICA account address on chain3
-    const [core2Config, core3Config]: DerivedCoreConfig[] = await Promise.all([
-      readCoreConfig(CHAIN_NAME_2, CORE_READ_CONFIG_PATH_2),
-      readCoreConfig(CHAIN_NAME_3, CORE_READ_CONFIG_PATH_3),
-    ]);
-
-    const chain2IcaRouter = InterchainAccountRouter__factory.connect(
-      core2Config.interchainAccountRouter!.address,
-      signer,
-    );
-    const remoteIcaAccountAddress = await chain2IcaRouter.callStatic[
-      'getRemoteInterchainAccount(address,address,address)'
-    ](
-      initialOwnerAddress,
-      core3Config.interchainAccountRouter!.address,
-      ethers.constants.AddressZero,
-    );
-
-    // Transfer ownership of the warp token on chain3 to the ICA account
-    warpDeployConfig[CHAIN_NAME_2] = updatedWarpDeployConfig_2[CHAIN_NAME_2];
-    warpDeployConfig[CHAIN_NAME_3] = updatedWarpDeployConfig_3[CHAIN_NAME_3];
-    warpDeployConfig[CHAIN_NAME_3].owner = remoteIcaAccountAddress;
-    writeYamlOrJson(WARP_DEPLOY_CONFIG_CHAIN_2, warpDeployConfig);
-    await hyperlaneWarpApply(
-      WARP_DEPLOY_CONFIG_CHAIN_2,
-      COMBINED_WARP_CORE_CONFIG_PATH,
-    );
-
-    // Update the remote gas for chain2 on chain3 and run warp apply with an ICA strategy
-    const expectedChain2Gas = '46000';
-    warpDeployConfig[CHAIN_NAME_3].destinationGas = {
-      [chain2DomainId]: expectedChain2Gas,
-    };
-    writeYamlOrJson(WARP_DEPLOY_CONFIG_CHAIN_2, warpDeployConfig);
-
-    await hyperlaneWarpApply(
-      WARP_DEPLOY_CONFIG_CHAIN_2,
-      COMBINED_WARP_CORE_CONFIG_PATH,
-      JSON_RPC_ICA_STRATEGY_CONFIG_PATH,
-      undefined,
-      true,
-    );
-
-    const updatedWarpDeployConfig_3_2 = await readWarpConfig(
-      CHAIN_NAME_3,
-      COMBINED_WARP_CORE_CONFIG_PATH,
-      WARP_DEPLOY_CONFIG_CHAIN_2,
-    );
-
-    expect(
-      updatedWarpDeployConfig_3_2[CHAIN_NAME_3].destinationGas![chain2DomainId],
-    ).to.equal(expectedChain2Gas);
   });
 });

--- a/typescript/cli/src/tests/warp/warp-submitters.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-submitters.e2e-test.ts
@@ -1,0 +1,319 @@
+import { expect } from 'chai';
+import { Signer, Wallet, ethers } from 'ethers';
+
+import {
+  InterchainAccountRouter__factory,
+  TimelockController,
+  TimelockController__factory,
+} from '@hyperlane-xyz/core';
+import {
+  ChainAddresses,
+  createWarpRouteConfigId,
+} from '@hyperlane-xyz/registry';
+import {
+  CallData,
+  ChainMetadata,
+  ChainSubmissionStrategySchema,
+  DerivedCoreConfig,
+  SubmissionStrategy,
+  TokenType,
+  TxSubmitterType,
+  WarpRouteDeployConfig,
+} from '@hyperlane-xyz/sdk';
+import { Address, Domain, assert } from '@hyperlane-xyz/utils';
+
+import { readYamlOrJson, writeYamlOrJson } from '../../utils/files.js';
+import { hyperlaneCoreApply, readCoreConfig } from '../commands/core.js';
+import {
+  ANVIL_KEY,
+  CHAIN_2_METADATA_PATH,
+  CHAIN_3_METADATA_PATH,
+  CHAIN_NAME_2,
+  CHAIN_NAME_3,
+  CORE_CONFIG_PATH,
+  CORE_READ_CONFIG_PATH_2,
+  CORE_READ_CONFIG_PATH_3,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  JSON_RPC_TIMELOCK_STRATEGY_CONFIG_PATH,
+  TEMP_PATH,
+  WARP_CONFIG_PATH_2,
+  WARP_CONFIG_PATH_EXAMPLE,
+  deployOrUseExistingCore,
+  getCombinedWarpRoutePath,
+} from '../commands/helpers.js';
+import {
+  hyperlaneWarpApplyRaw,
+  hyperlaneWarpDeploy,
+  readWarpConfig,
+} from '../commands/warp.js';
+
+describe('hyperlane warp apply with submitters', async function () {
+  this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
+
+  let chain2Signer: Signer;
+  let chain3Signer: Signer;
+  let ownerAddress: Address;
+  let chain3Addresses: ChainAddresses = {};
+  let chain2Addresses: ChainAddresses = {};
+  let initialOwnerAddress: Address;
+  let chain2DomainId: Domain;
+  let chain3DomainId: Domain;
+  let warpConfig: WarpRouteDeployConfig;
+  let timelockInstance: TimelockController;
+  let chain3IcaAddress: Address;
+  let WARP_DEPLOY_CONFIG_PATH: string;
+  let WARP_CORE_CONFIG_PATH: string;
+  let WARP_ROUTE_ID: string;
+  const FORMATTED_TIMELOCK_SUBMITTER_STRATEGY_PATH = `${TEMP_PATH}/timelock-simple-strategy.yaml`;
+
+  before(async function () {
+    const chain2Metadata: ChainMetadata = readYamlOrJson(CHAIN_2_METADATA_PATH);
+    const chain3Metadata: ChainMetadata = readYamlOrJson(CHAIN_3_METADATA_PATH);
+
+    const chain2Provider = new ethers.providers.JsonRpcProvider(
+      chain2Metadata.rpcUrls[0].http,
+    );
+    const chain3Provider = new ethers.providers.JsonRpcProvider(
+      chain3Metadata.rpcUrls[0].http,
+    );
+    chain2DomainId = chain2Metadata.domainId;
+    chain3DomainId = chain3Metadata.domainId;
+    const wallet = new Wallet(ANVIL_KEY);
+    chain2Signer = wallet.connect(chain2Provider);
+
+    chain3Signer = wallet.connect(chain3Provider);
+    initialOwnerAddress = await chain2Signer.getAddress();
+
+    [chain2Addresses, chain3Addresses] = await Promise.all([
+      deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY),
+      deployOrUseExistingCore(CHAIN_NAME_3, CORE_CONFIG_PATH, ANVIL_KEY),
+    ]);
+
+    // Create a new warp config using the example
+    const warpConfig: WarpRouteDeployConfig = readYamlOrJson(
+      WARP_CONFIG_PATH_EXAMPLE,
+    );
+
+    const anvil2Config = { anvil2: { ...warpConfig.anvil1 } };
+    writeYamlOrJson(WARP_CONFIG_PATH_2, anvil2Config);
+
+    WARP_ROUTE_ID = createWarpRouteConfigId('ETH', CHAIN_NAME_3);
+    WARP_CORE_CONFIG_PATH = getCombinedWarpRoutePath('ETH', [CHAIN_NAME_3]);
+    WARP_DEPLOY_CONFIG_PATH = WARP_CORE_CONFIG_PATH.replace(
+      '-config.yaml',
+      '-deploy.yaml',
+    );
+
+    const chain2IcaRouter = InterchainAccountRouter__factory.connect(
+      chain2Addresses.interchainAccountRouter,
+      chain2Signer,
+    );
+
+    chain3IcaAddress = await chain2IcaRouter.callStatic[
+      'getRemoteInterchainAccount(address,address,address)'
+    ](
+      initialOwnerAddress,
+      chain3Addresses.interchainAccountRouter,
+      ethers.constants.AddressZero,
+    );
+
+    // Deploy the timelock and set both the owner address and the ICA
+    // as proposers and executors to avoid having to deploy a new timelock
+    timelockInstance = await new TimelockController__factory()
+      .connect(chain3Signer)
+      .deploy(
+        0,
+        [initialOwnerAddress, chain3IcaAddress],
+        [initialOwnerAddress, chain3IcaAddress],
+        ethers.constants.AddressZero,
+      );
+
+    // Configure ICA connections by enrolling the ICAs with each other
+    const [coreConfigChain2, coreConfigChain3]: DerivedCoreConfig[] =
+      await Promise.all([
+        readCoreConfig(CHAIN_NAME_2, CORE_READ_CONFIG_PATH_2),
+        readCoreConfig(CHAIN_NAME_3, CORE_READ_CONFIG_PATH_3),
+      ]);
+
+    const coreConfigChain2IcaConfig = coreConfigChain2.interchainAccountRouter!;
+    const coreConfigChain3IcaConfig = coreConfigChain3.interchainAccountRouter!;
+    coreConfigChain2IcaConfig.remoteRouters = {
+      [chain3DomainId]: {
+        address: coreConfigChain3IcaConfig.address,
+      },
+    };
+
+    writeYamlOrJson(CORE_READ_CONFIG_PATH_2, coreConfigChain2);
+    await hyperlaneCoreApply(CHAIN_NAME_2, CORE_READ_CONFIG_PATH_2);
+  });
+
+  beforeEach(async function () {
+    ownerAddress = new Wallet(ANVIL_KEY).address;
+    warpConfig = {
+      [CHAIN_NAME_2]: {
+        type: TokenType.native,
+        mailbox: chain2Addresses.mailbox,
+        owner: ownerAddress,
+      },
+      [CHAIN_NAME_3]: {
+        type: TokenType.synthetic,
+        mailbox: chain3Addresses.mailbox,
+        owner: ownerAddress,
+      },
+    };
+
+    formatTimelockStrategyFile();
+  });
+
+  function formatTimelockStrategyFile(
+    proposerSubmitter?: SubmissionStrategy['submitter'],
+  ) {
+    // Update the submitter config to use the deployed timelock address
+    const timelockSubmitterConfig = ChainSubmissionStrategySchema.parse(
+      readYamlOrJson(JSON_RPC_TIMELOCK_STRATEGY_CONFIG_PATH),
+    );
+
+    const chain3SubmissionStrategy = timelockSubmitterConfig[CHAIN_NAME_3];
+    assert(
+      chain3SubmissionStrategy.submitter.type ===
+        TxSubmitterType.TIMELOCK_CONTROLLER,
+      `expected submitter config to be of type ${TxSubmitterType.TIMELOCK_CONTROLLER}`,
+    );
+
+    chain3SubmissionStrategy.submitter.timelockAddress =
+      timelockInstance.address;
+    if (proposerSubmitter) {
+      chain3SubmissionStrategy.submitter.proposerSubmitter = proposerSubmitter;
+    }
+
+    timelockSubmitterConfig[CHAIN_NAME_3] = chain3SubmissionStrategy;
+
+    writeYamlOrJson(
+      FORMATTED_TIMELOCK_SUBMITTER_STRATEGY_PATH,
+      timelockSubmitterConfig,
+    );
+  }
+
+  async function deployAndExportWarpRoute(): Promise<WarpRouteDeployConfig> {
+    // currently warp deploy is not writing the deploy config to the registry
+    // should remove this once the deploy config is written to the registry
+    writeYamlOrJson(WARP_DEPLOY_CONFIG_PATH, warpConfig);
+    await hyperlaneWarpDeploy(WARP_DEPLOY_CONFIG_PATH, WARP_ROUTE_ID);
+
+    return warpConfig;
+  }
+
+  function getTimelockExecuteTxFile(logs: string): CallData {
+    const maybeGeneratedTxFilePath = logs.match(
+      /\.\/generated\/transactions\/anvil3-timelockController-\d+-receipts\.json/,
+    );
+    assert(maybeGeneratedTxFilePath, 'expected the tx file output');
+
+    const [generatedTxFilePath] = maybeGeneratedTxFilePath;
+    const txFile: CallData[] = readYamlOrJson(generatedTxFilePath);
+    const executeTransaction = txFile.pop();
+    assert(
+      executeTransaction,
+      'expected the timelock execute tx to be at the end of the receipts array',
+    );
+
+    return executeTransaction;
+  }
+
+  describe(TxSubmitterType.TIMELOCK_CONTROLLER, () => {
+    it('should be able to propose transactions to a timelock contract and execute them', async () => {
+      warpConfig[CHAIN_NAME_3].owner = timelockInstance.address;
+      await deployAndExportWarpRoute();
+
+      const expectedUpdatedGasValue = '900';
+      warpConfig[CHAIN_NAME_3].destinationGas = {
+        [chain2DomainId]: expectedUpdatedGasValue,
+      };
+      writeYamlOrJson(WARP_DEPLOY_CONFIG_PATH, warpConfig);
+
+      const res = await hyperlaneWarpApplyRaw({
+        strategyUrl: FORMATTED_TIMELOCK_SUBMITTER_STRATEGY_PATH,
+        warpRouteId: WARP_ROUTE_ID,
+      });
+
+      // get the timelock output file from the logs
+      const maybeGeneratedTxFilePath = res
+        .text()
+        .match(
+          /\.\/generated\/transactions\/anvil3-timelockController-\d+-receipts\.json/,
+        );
+      assert(maybeGeneratedTxFilePath, 'expected the tx file output');
+
+      const [generatedTxFilePath] = maybeGeneratedTxFilePath;
+      const txFile: CallData[] = readYamlOrJson(generatedTxFilePath);
+      const executeTransaction = txFile.pop();
+      assert(
+        executeTransaction,
+        'expected the timelock execute tx to be at the end of the receipts array',
+      );
+
+      const tx = await chain3Signer.sendTransaction(executeTransaction);
+      await tx.wait();
+
+      const updatedWarpDeployConfig_3_2 = await readWarpConfig(
+        CHAIN_NAME_3,
+        WARP_CORE_CONFIG_PATH,
+        WARP_DEPLOY_CONFIG_PATH,
+      );
+
+      expect(
+        updatedWarpDeployConfig_3_2[CHAIN_NAME_3].destinationGas![
+          chain2DomainId
+        ],
+      ).to.equal(expectedUpdatedGasValue);
+    });
+
+    it('should be able to propose transactions to a timelock contract using an ICA', async () => {
+      warpConfig[CHAIN_NAME_3].owner = timelockInstance.address;
+      await deployAndExportWarpRoute();
+
+      // Set the timelock to use the ICA to propose txs
+      formatTimelockStrategyFile({
+        type: TxSubmitterType.INTERCHAIN_ACCOUNT,
+        chain: CHAIN_NAME_2,
+        destinationChain: CHAIN_NAME_3,
+        owner: ownerAddress,
+        internalSubmitter: {
+          type: TxSubmitterType.JSON_RPC,
+          chain: CHAIN_NAME_2,
+        },
+      });
+
+      const expectedUpdatedGasValue = '900';
+      warpConfig[CHAIN_NAME_3].destinationGas = {
+        [chain2DomainId]: expectedUpdatedGasValue,
+      };
+      writeYamlOrJson(WARP_DEPLOY_CONFIG_PATH, warpConfig);
+
+      const res = await hyperlaneWarpApplyRaw({
+        strategyUrl: FORMATTED_TIMELOCK_SUBMITTER_STRATEGY_PATH,
+        warpRouteId: WARP_ROUTE_ID,
+        relay: true,
+      });
+
+      // get the timelock output file from the logs
+      const executeTransaction = getTimelockExecuteTxFile(res.text());
+      console.log(executeTransaction);
+
+      const tx = await chain3Signer.sendTransaction(executeTransaction);
+      await tx.wait();
+
+      const updatedWarpDeployConfig_3_2 = await readWarpConfig(
+        CHAIN_NAME_3,
+        WARP_CORE_CONFIG_PATH,
+        WARP_DEPLOY_CONFIG_PATH,
+      );
+
+      expect(
+        updatedWarpDeployConfig_3_2[CHAIN_NAME_3].destinationGas![
+          chain2DomainId
+        ],
+      ).to.equal(expectedUpdatedGasValue);
+    });
+  });
+});

--- a/typescript/cli/src/utils/relay.ts
+++ b/typescript/cli/src/utils/relay.ts
@@ -66,10 +66,7 @@ export function canSelfRelay(
     };
   }
 
-  const canRelay =
-    selfRelay &&
-    config.submitter.type === TxSubmitterType.INTERCHAIN_ACCOUNT &&
-    config.submitter.internalSubmitter.type === TxSubmitterType.JSON_RPC;
+  const canRelay = selfRelay && canSelfRelayFromConfig(config.submitter);
 
   if (!canRelay) {
     return { relay: false };
@@ -79,6 +76,21 @@ export function canSelfRelay(
     relay: canRelay,
     txReceipt,
   };
+}
+
+/**
+ * Recursively traverse the submitter config to check if it allows transaction self relaying
+ */
+function canSelfRelayFromConfig(
+  config: SubmissionStrategy['submitter'],
+): boolean {
+  if (config.type === TxSubmitterType.INTERCHAIN_ACCOUNT) {
+    return config.internalSubmitter.type === TxSubmitterType.JSON_RPC;
+  } else if (config.type === TxSubmitterType.TIMELOCK_CONTROLLER) {
+    return canSelfRelayFromConfig(config.proposerSubmitter);
+  }
+
+  return false;
 }
 
 export type RunSelfRelayOptions = {

--- a/typescript/sdk/src/providers/transactions/submitter/IcaTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/IcaTxSubmitter.ts
@@ -14,8 +14,8 @@ import { CallData } from '../types.js';
 
 import { TxSubmitterInterface } from './TxSubmitterInterface.js';
 import { TxSubmitterType } from './TxSubmitterTypes.js';
+import { EvmIcaTxSubmitterProps } from './ethersV5/types.js';
 import { getSubmitter } from './submitterBuilderGetter.js';
-import { EvmIcaTxSubmitterProps } from './types.js';
 
 type EvmIcaTxSubmitterConstructorConfig = Omit<
   EvmIcaTxSubmitterProps,

--- a/typescript/sdk/src/providers/transactions/submitter/TxSubmitterTypes.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/TxSubmitterTypes.ts
@@ -4,4 +4,5 @@ export enum TxSubmitterType {
   GNOSIS_SAFE = 'gnosisSafe',
   GNOSIS_TX_BUILDER = 'gnosisSafeTxBuilder',
   INTERCHAIN_ACCOUNT = 'interchainAccount',
+  TIMELOCK_CONTROLLER = 'timelockController',
 }

--- a/typescript/sdk/src/providers/transactions/submitter/builder/types.test.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/builder/types.test.ts
@@ -76,6 +76,20 @@ describe('ChainSubmissionStrategySchema', () => {
         },
       },
     },
+    {
+      submitter: {
+        type: TxSubmitterType.TIMELOCK_CONTROLLER,
+        chain: CHAIN_MOCK,
+        timelockAddress: OWNER_ADDRESS_MOCK,
+        proposerSubmitter: {
+          type: TxSubmitterType.GNOSIS_TX_BUILDER,
+          safeAddress: ADDRESS_MOCK,
+          chain: CHAIN_MOCK,
+          // Should not fail as it has a default value
+          version: undefined as any,
+        },
+      },
+    },
   ];
 
   for (const testCase of testCases) {

--- a/typescript/sdk/src/providers/transactions/submitter/builder/types.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/builder/types.ts
@@ -118,7 +118,8 @@ const formatTimelockSubmitter = (
       ...strategy.submitter,
       proposerSubmitter: {
         ...proposerSubmitter,
-        chain: chainName,
+        // Override the chain if it hasn't been set
+        chain: proposerSubmitter.chain ?? chainName,
       },
     },
   };

--- a/typescript/sdk/src/providers/transactions/submitter/builder/types.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/builder/types.ts
@@ -64,7 +64,10 @@ const formatIcaSubmitter = (
   chainName: ChainName,
   strategy: SubmissionStrategy,
 ): SubmissionStrategy => {
-  assert(strategy.submitter.type === TxSubmitterType.INTERCHAIN_ACCOUNT, '');
+  assert(
+    strategy.submitter.type === TxSubmitterType.INTERCHAIN_ACCOUNT,
+    `[ChainSubmissionStrategy] Expected ${TxSubmitterType.INTERCHAIN_ACCOUNT} strategy but got ${strategy.submitter.type}`,
+  );
 
   // Setting the default internal submitter config for interchain accounts here
   // instead of using zod's default() modifier because we require the chain property to be set
@@ -106,7 +109,10 @@ const formatTimelockSubmitter = (
   chainName: ChainName,
   strategy: SubmissionStrategy,
 ): SubmissionStrategy => {
-  assert(strategy.submitter.type === TxSubmitterType.TIMELOCK_CONTROLLER, '');
+  assert(
+    strategy.submitter.type === TxSubmitterType.TIMELOCK_CONTROLLER,
+    `[ChainSubmissionStrategy] Expected ${TxSubmitterType.TIMELOCK_CONTROLLER} strategy but got ${strategy.submitter.type}`,
+  );
 
   const {
     proposerSubmitter = { type: TxSubmitterType.JSON_RPC, chain: chainName },

--- a/typescript/sdk/src/providers/transactions/submitter/builder/types.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/builder/types.ts
@@ -5,7 +5,8 @@ import { eqAddress, objMap } from '@hyperlane-xyz/utils';
 import { ZChainName } from '../../../../metadata/customZodTypes.js';
 import { ChainMap } from '../../../../types.js';
 import { TxSubmitterType } from '../TxSubmitterTypes.js';
-import { EvmIcaTxSubmitterProps, SubmitterMetadataSchema } from '../types.js';
+import { EvmIcaTxSubmitterProps } from '../ethersV5/types.js';
+import { SubmitterMetadataSchema } from '../types.js';
 
 export const SubmissionStrategySchema = z
   .object({

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5TimelockSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5TimelockSubmitter.ts
@@ -1,0 +1,159 @@
+import {
+  TimelockController,
+  TimelockController__factory,
+} from '@hyperlane-xyz/core';
+import { IRegistry } from '@hyperlane-xyz/registry';
+import { ProtocolType, assert } from '@hyperlane-xyz/utils';
+
+import { MultiProvider } from '../../../MultiProvider.js';
+import {
+  AnnotatedEV5Transaction,
+  ProtocolTypedReceipt,
+} from '../../../ProviderType.js';
+import { CallData } from '../../types.js';
+import { TxSubmitterInterface } from '../TxSubmitterInterface.js';
+import { TxSubmitterType } from '../TxSubmitterTypes.js';
+import { getSubmitter } from '../submitterBuilderGetter.js';
+
+import { EvmTimelockControllerSubmitterProps } from './types.js';
+
+type EvmTimelockControllerSubmitterConstructorConfig = Required<
+  Pick<
+    EvmTimelockControllerSubmitterProps,
+    'chain' | 'predecessor' | 'delay' | 'salt'
+  >
+>;
+
+const ZERO_32_BYTES =
+  '0x0000000000000000000000000000000000000000000000000000000000000000';
+
+export class EV5TimelockSubmitter
+  implements TxSubmitterInterface<ProtocolType.Ethereum>
+{
+  public readonly txSubmitterType: TxSubmitterType =
+    TxSubmitterType.TIMELOCK_CONTROLLER;
+
+  protected constructor(
+    protected readonly config: EvmTimelockControllerSubmitterConstructorConfig,
+    protected readonly multiProvider: MultiProvider,
+    protected readonly proposerSubmitter: TxSubmitterInterface<ProtocolType.Ethereum>,
+    protected readonly timelockInstance: TimelockController,
+  ) {}
+
+  static async fromConfig(
+    config: EvmTimelockControllerSubmitterProps,
+    multiProvider: MultiProvider,
+    registry: Readonly<IRegistry>,
+  ): Promise<EV5TimelockSubmitter> {
+    const provider = multiProvider.getProvider(config.chain);
+    const timelockInstance = TimelockController__factory.connect(
+      config.timelockAddress,
+      provider,
+    );
+
+    const minDelay = await timelockInstance.getMinDelay();
+
+    const delay = config.delay ?? minDelay.toBigInt();
+
+    assert(delay >= minDelay.toBigInt(), '');
+
+    const internalSubmitter = await getSubmitter<ProtocolType.Ethereum>(
+      multiProvider,
+      config.proposerSubmitter,
+      registry,
+    );
+
+    return new EV5TimelockSubmitter(
+      {
+        chain: config.chain,
+        delay,
+        predecessor: config.predecessor ?? ZERO_32_BYTES,
+        salt: config.salt ?? ZERO_32_BYTES,
+      },
+      multiProvider,
+      internalSubmitter,
+      timelockInstance,
+    );
+  }
+
+  async submit(
+    ...txs: AnnotatedEV5Transaction[]
+  ): Promise<
+    | void
+    | ProtocolTypedReceipt<ProtocolType.Ethereum>['receipt']
+    | ProtocolTypedReceipt<ProtocolType.Ethereum>['receipt'][]
+  > {
+    if (txs.length === 0) {
+      return [];
+    }
+
+    const transactionChains = new Set(txs.map((tx) => tx.chainId));
+    if (transactionChains.size !== 1) {
+      throw new Error(
+        'TimelockController transactions should have all the same destination chain',
+      );
+    }
+
+    // If no domain id is set on the transactions
+    // assume they are to be sent on the current configured chain
+    const [domainId] = transactionChains.values();
+    const destinationChain = this.multiProvider.getDomainId(
+      domainId ?? this.config.chain,
+    );
+
+    const calldata: CallData[] = txs.map((transaction): CallData => {
+      assert(transaction.data, '');
+      assert(transaction.to, '');
+
+      return {
+        to: transaction.to,
+        data: transaction.data,
+        value: transaction.value?.toString(),
+      };
+    });
+
+    const [to, data, value] = calldata.reduce(
+      ([targets, data, values], item) => {
+        targets.push(item.to);
+        data.push(item.data);
+        values.push(item.value ?? '0');
+
+        return [targets, data, values];
+      },
+      [[], [], []] as [string[], string[], string[]],
+    );
+
+    const [proposeCallData, executeCallData] = await Promise.all([
+      this.timelockInstance.populateTransaction.scheduleBatch(
+        to,
+        value,
+        data,
+        this.config.predecessor,
+        this.config.salt,
+        this.config.delay,
+      ),
+      this.timelockInstance.populateTransaction.executeBatch(
+        to,
+        value,
+        data,
+        this.config.predecessor,
+        this.config.salt,
+      ),
+    ]);
+
+    const proposeFormattedCallData = await this.proposerSubmitter.submit({
+      chainId: destinationChain,
+      ...proposeCallData,
+    });
+
+    if (!proposeFormattedCallData) {
+      return [];
+    }
+
+    if (Array.isArray(proposeFormattedCallData)) {
+      return [...proposeFormattedCallData, executeCallData as any];
+    }
+
+    return [proposeFormattedCallData, executeCallData as any];
+  }
+}

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/types.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/types.ts
@@ -73,6 +73,30 @@ export const EvmIcaTxSubmitterPropsSchema: z.ZodSchema<EvmIcaTxSubmitterProps> =
     }),
   );
 
+export type EvmTimelockControllerSubmitterProps = {
+  type: TxSubmitterType.TIMELOCK_CONTROLLER;
+  chain: ChainName;
+  timelockAddress: Address;
+  salt?: string;
+  delay?: bigint;
+  predecessor?: string;
+  proposerSubmitter: EvmSubmitterMetadata;
+};
+
+// @ts-expect-error same as the ICA
+export const EvmTimelockControllerSubmitterPropsSchema: z.ZodSchema<EvmTimelockControllerSubmitterProps> =
+  z.lazy(() =>
+    z.object({
+      type: z.literal(TxSubmitterType.TIMELOCK_CONTROLLER),
+      chain: ZChainName,
+      timelockAddress: ZHash,
+      salt: z.string().optional(),
+      delay: z.bigint().optional(),
+      predecessor: z.string().optional(),
+      proposerSubmitter: EvmSubmitterMetadataSchema,
+    }),
+  );
+
 export const EvmSubmitterMetadataSchema = z.union([
   z.object({
     type: z.literal(TxSubmitterType.JSON_RPC),
@@ -91,6 +115,7 @@ export const EvmSubmitterMetadataSchema = z.union([
     ...EV5GnosisSafeTxBuilderPropsSchema.shape,
   }),
   EvmIcaTxSubmitterPropsSchema,
+  EvmTimelockControllerSubmitterPropsSchema,
 ]);
 
 export type EvmSubmitterMetadata = z.infer<typeof EvmSubmitterMetadataSchema>;

--- a/typescript/sdk/src/providers/transactions/submitter/submitterBuilderGetter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/submitterBuilderGetter.ts
@@ -12,6 +12,7 @@ import { EV5GnosisSafeTxBuilder } from './ethersV5/EV5GnosisSafeTxBuilder.js';
 import { EV5GnosisSafeTxSubmitter } from './ethersV5/EV5GnosisSafeTxSubmitter.js';
 import { EV5ImpersonatedAccountTxSubmitter } from './ethersV5/EV5ImpersonatedAccountTxSubmitter.js';
 import { EV5JsonRpcTxSubmitter } from './ethersV5/EV5JsonRpcTxSubmitter.js';
+import { EV5TimelockSubmitter } from './ethersV5/EV5TimelockSubmitter.js';
 import { SubmitterMetadata } from './types.js';
 
 export type SubmitterBuilderSettings = {
@@ -58,6 +59,12 @@ export async function getSubmitter<TProtocol extends ProtocolType>(
       });
     case TxSubmitterType.INTERCHAIN_ACCOUNT:
       return EvmIcaTxSubmitter.fromConfig(
+        submitterMetadata,
+        multiProvider,
+        registry,
+      );
+    case TxSubmitterType.TIMELOCK_CONTROLLER:
+      return EV5TimelockSubmitter.fromConfig(
         submitterMetadata,
         multiProvider,
         registry,

--- a/typescript/sdk/src/providers/transactions/submitter/types.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/types.ts
@@ -1,28 +1,6 @@
 import { z } from 'zod';
 
-import { ZChainName, ZHash } from '../../../metadata/customZodTypes.js';
-
-import { TxSubmitterType } from './TxSubmitterTypes.js';
 import { EvmSubmitterMetadataSchema } from './ethersV5/types.js';
 
-export const EvmIcaTxSubmitterPropsSchema = z.object({
-  type: z.literal(TxSubmitterType.INTERCHAIN_ACCOUNT),
-  chain: ZChainName,
-  owner: ZHash,
-  destinationChain: ZChainName,
-  originInterchainAccountRouter: ZHash.optional(),
-  destinationInterchainAccountRouter: ZHash.optional(),
-  interchainSecurityModule: ZHash.optional(),
-  internalSubmitter: EvmSubmitterMetadataSchema,
-});
-
-export type EvmIcaTxSubmitterProps = z.infer<
-  typeof EvmIcaTxSubmitterPropsSchema
->;
-
-export const SubmitterMetadataSchema = z.union([
-  EvmSubmitterMetadataSchema,
-  EvmIcaTxSubmitterPropsSchema,
-]);
-
-export type SubmitterMetadata = z.infer<typeof SubmitterMetadataSchema>;
+export const SubmitterMetadataSchema = EvmSubmitterMetadataSchema;
+export type SubmitterMetadata = z.infer<typeof EvmSubmitterMetadataSchema>;


### PR DESCRIPTION
### Description

This PR implements the Timelock submitter strategy to allow  users to propose and execute transactions using timelock contracts

### Drive-by changes

- Moves the ica submitter types in the same file as the other evm submitter configs
- Moves the warp apply ica tests to the new test file

### Related issues

- Fixes:
- [ENG-1855](https://linear.app/hyperlane-xyz/issue/ENG-1855/sdk-cli-implement-timelock-submitter)
- [ENG-1822](https://linear.app/hyperlane-xyz/issue/ENG-1822/create-timelocksubmitter)

### Backward compatibility

- YES

### Testing

- Manual
- e2e
