### PR TITLE
feat(lander): more robust SVM `tx_ready_for_resubmission`

### DIFF
--- a/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_submit.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_submit.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::adapter::AdaptsChain;
 
 use super::super::TransactionFactory;
@@ -14,4 +16,42 @@ async fn test_submit() {
 
     // then
     assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_ready_for_resubmission() {
+    // given
+    let adapter = adapter();
+    let mut transaction = TransactionFactory::build(&payload(), precursor());
+
+    let expected_resubmission_time = adapter.time_before_resubmission();
+
+    let now = chrono::Utc::now();
+    let recent_but_too_soon_for_resubmission =
+        now - expected_resubmission_time + Duration::from_millis(1);
+    let recent_but_ready_for_resubmission = now - expected_resubmission_time;
+
+    // when
+    transaction.last_submission_attempt = Some(recent_but_too_soon_for_resubmission);
+    let is_ready = adapter.tx_ready_for_resubmission(&transaction).await;
+    assert_eq!(is_ready, false);
+
+    transaction.last_submission_attempt = Some(recent_but_ready_for_resubmission);
+    let is_ready = adapter.tx_ready_for_resubmission(&transaction).await;
+    assert_eq!(is_ready, true);
+}
+
+#[tokio::test]
+async fn test_time_before_resubmission() {
+    let mut adapter = adapter();
+    // the block time of SOON SVM is 50ms
+    adapter.estimated_block_time = Duration::from_millis(50);
+
+    let expected_time_before_resubmission =
+        adapter.estimated_block_time.mul_f32(3.0) + Duration::from_millis(500);
+
+    assert_eq!(
+        adapter.time_before_resubmission(),
+        expected_time_before_resubmission
+    );
 }


### PR DESCRIPTION
### Description

The tx resubmission interval should depend on:
- how often block are produced. It doesn't make sense to send more often than that, and we should resubmit about as often as new blocks are produced
- the tx processing latency in the lander, which is currently ~300ms

Previously, the SVM adapter waited 15s before resubmitting, which is too long.

This PR calculates the `time_before_resubmission` to be `3 * estimated_block_time + 500ms`. The `500ms` buffer is mainly to handle SOON SVM well, which has a block time of 50ms - lower than the lander processing time. The 500ms buffer can be lowered if needed, later.

### Related issues

- Fixes https://linear.app/hyperlane-xyz/issue/ENG-1905/improve-svm-implementation-of-tx-ready-for-resubmission

### Backward compatibility

Yes

### Testing

Unit Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction resubmission timing for greater accuracy and responsiveness.

* **Tests**
  * Added new tests to verify transaction resubmission behavior and timing calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->