### PR TITLE
fix: Bring back domain span so that we can filter by it in agents

### DIFF
--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -230,6 +230,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[instrument(fields(domain=domain.name()), skip(indexer, store, cursor, broadcast_sender, stored_logs_metric, indexed_height_metric, liveness_metric))]
     async fn cursor_indexer_task(
         domain: HyperlaneDomain,
         indexer: I,
@@ -240,7 +241,6 @@ where
         indexed_height_metric: GenericGauge<AtomicI64>,
         liveness_metric: GenericGauge<AtomicI64>,
     ) {
-        tracing::info_span!("cursor_indexer_task", domain = domain.name());
         loop {
             Self::update_liveness_metric(&liveness_metric);
             indexed_height_metric.set(cursor.latest_queried_block() as i64);


### PR DESCRIPTION
### Description

We have lost domain span in scraper with recent change to reduce logging. This commit brings domain back.

### Backward compatibility

Yes

### Testing

Manual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved structured logging and tracing for background tasks, enhancing observability without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->