### PR TITLE
fix: cctp v2 burn amount

### DIFF
--- a/.changeset/angry-pandas-swim.md
+++ b/.changeset/angry-pandas-swim.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": patch
+---
+
+Fix CCTP v2 transferRemote amount

--- a/solidity/contracts/token/TokenBridgeCctpBase.sol
+++ b/solidity/contracts/token/TokenBridgeCctpBase.sol
@@ -38,6 +38,8 @@ abstract contract TokenBridgeCctpBase is
     using TypeCasts for bytes32;
     using SafeERC20 for IERC20;
 
+    uint256 private constant _SCALE = 1;
+
     IERC20 public immutable wrappedToken;
 
     // @notice CCTP message transmitter contract
@@ -64,11 +66,10 @@ abstract contract TokenBridgeCctpBase is
 
     constructor(
         address _erc20,
-        uint256 _scale,
         address _mailbox,
         IMessageTransmitter _messageTransmitter,
         ITokenMessenger _tokenMessenger
-    ) FungibleTokenRouter(_scale, _mailbox) {
+    ) FungibleTokenRouter(_SCALE, _mailbox) {
         require(
             _messageTransmitter.version() == _getCCTPVersion(),
             "Invalid messageTransmitter CCTP version"

--- a/solidity/contracts/token/TokenBridgeCctpV1.sol
+++ b/solidity/contracts/token/TokenBridgeCctpV1.sol
@@ -26,14 +26,12 @@ contract TokenBridgeCctpV1 is TokenBridgeCctpBase, IMessageHandler {
 
     constructor(
         address _erc20,
-        uint256 _scale,
         address _mailbox,
         IMessageTransmitter _messageTransmitter,
         ITokenMessengerV1 _tokenMessenger
     )
         TokenBridgeCctpBase(
             _erc20,
-            _scale,
             _mailbox,
             _messageTransmitter,
             _tokenMessenger

--- a/solidity/contracts/token/TokenBridgeCctpV2.sol
+++ b/solidity/contracts/token/TokenBridgeCctpV2.sol
@@ -179,7 +179,7 @@ contract TokenBridgeCctpV2 is TokenBridgeCctpBase, IMessageHandlerV2 {
         uint32 circleDomain = hyperlaneDomainToCircleDomain(destination);
 
         ITokenMessengerV2(address(tokenMessenger)).depositForBurn(
-            amount,
+            amount + fastFee,
             circleDomain,
             recipient,
             address(wrappedToken),

--- a/solidity/contracts/token/TokenBridgeCctpV2.sol
+++ b/solidity/contracts/token/TokenBridgeCctpV2.sol
@@ -29,7 +29,6 @@ contract TokenBridgeCctpV2 is TokenBridgeCctpBase, IMessageHandlerV2 {
 
     constructor(
         address _erc20,
-        uint256 _scale,
         address _mailbox,
         IMessageTransmitterV2 _messageTransmitter,
         ITokenMessengerV2 _tokenMessenger,
@@ -38,7 +37,6 @@ contract TokenBridgeCctpV2 is TokenBridgeCctpBase, IMessageHandlerV2 {
     )
         TokenBridgeCctpBase(
             _erc20,
-            _scale,
             _mailbox,
             _messageTransmitter,
             _tokenMessenger
@@ -174,13 +172,15 @@ contract TokenBridgeCctpV2 is TokenBridgeCctpBase, IMessageHandlerV2 {
         override
         returns (uint256 dispatchValue, bytes memory message)
     {
-        uint256 fastFee = _feeAmount(destination, recipient, amount);
-        _transferFromSender(amount + fastFee);
+        uint256 burnAmount = amount +
+            _feeAmount(destination, recipient, amount);
+
+        _transferFromSender(burnAmount);
 
         uint32 circleDomain = hyperlaneDomainToCircleDomain(destination);
 
         ITokenMessengerV2(address(tokenMessenger)).depositForBurn(
-            amount + fastFee,
+            burnAmount,
             circleDomain,
             recipient,
             address(wrappedToken),
@@ -190,7 +190,7 @@ contract TokenBridgeCctpV2 is TokenBridgeCctpBase, IMessageHandlerV2 {
         );
 
         dispatchValue = msg.value;
-        message = TokenMessage.format(recipient, amount + fastFee);
+        message = TokenMessage.format(recipient, burnAmount);
         _validateTokenMessageLength(message);
     }
 }

--- a/solidity/contracts/token/TokenBridgeCctpV2.sol
+++ b/solidity/contracts/token/TokenBridgeCctpV2.sol
@@ -190,7 +190,7 @@ contract TokenBridgeCctpV2 is TokenBridgeCctpBase, IMessageHandlerV2 {
         );
 
         dispatchValue = msg.value;
-        message = TokenMessage.format(recipient, _outboundAmount(amount));
+        message = TokenMessage.format(recipient, amount + fastFee);
         _validateTokenMessageLength(message);
     }
 }

--- a/solidity/contracts/token/TokenBridgeCctpV2.sol
+++ b/solidity/contracts/token/TokenBridgeCctpV2.sol
@@ -58,9 +58,8 @@ contract TokenBridgeCctpV2 is TokenBridgeCctpBase, IMessageHandlerV2 {
 
     function _getCircleNonce(
         bytes29 cctpMessage
-    ) internal pure override returns (bytes32 nonce) {
-        nonce = cctpMessage._getNonce();
-        require(nonce != bytes32(0), "Invalid nonce");
+    ) internal pure override returns (bytes32) {
+        return cctpMessage._getNonce();
     }
 
     function _getCircleSource(

--- a/solidity/contracts/token/TokenBridgeCctpV2.sol
+++ b/solidity/contracts/token/TokenBridgeCctpV2.sol
@@ -60,8 +60,9 @@ contract TokenBridgeCctpV2 is TokenBridgeCctpBase, IMessageHandlerV2 {
 
     function _getCircleNonce(
         bytes29 cctpMessage
-    ) internal pure override returns (bytes32) {
-        return cctpMessage._getNonce();
+    ) internal pure override returns (bytes32 nonce) {
+        nonce = cctpMessage._getNonce();
+        require(nonce != bytes32(0), "Invalid nonce");
     }
 
     function _getCircleSource(

--- a/solidity/test/token/TokenBridgeCctp.t.sol
+++ b/solidity/test/token/TokenBridgeCctp.t.sol
@@ -40,7 +40,6 @@ contract TokenBridgeCctpV1Test is Test {
     uint32 internal constant CCTP_VERSION_1 = 0;
     uint32 internal constant CCTP_VERSION_2 = 1;
 
-    uint256 internal constant scale = 1;
     uint32 internal constant origin = 1;
     uint32 internal constant destination = 2;
     uint32 internal constant cctpOrigin = 0;
@@ -110,7 +109,6 @@ contract TokenBridgeCctpV1Test is Test {
 
         TokenBridgeCctpV1 originImplementation = new TokenBridgeCctpV1(
             address(tokenOrigin),
-            scale,
             address(mailboxOrigin),
             messageTransmitterOrigin,
             tokenMessengerOrigin
@@ -131,7 +129,6 @@ contract TokenBridgeCctpV1Test is Test {
 
         TokenBridgeCctpV1 destinationImplementation = new TokenBridgeCctpV1(
             address(tokenDestination),
-            scale,
             address(mailboxDestination),
             messageTransmitterDestination,
             tokenMessengerDestination
@@ -338,7 +335,6 @@ contract TokenBridgeCctpV1Test is Test {
     function _upgrade(TokenBridgeCctpBase bridge) internal virtual {
         TokenBridgeCctpV1 newImplementation = new TokenBridgeCctpV1(
             address(bridge.wrappedToken()),
-            bridge.scale(),
             address(bridge.mailbox()),
             bridge.messageTransmitter(),
             ITokenMessengerV1(address(bridge.tokenMessenger()))
@@ -508,7 +504,6 @@ contract TokenBridgeCctpV1Test is Test {
         vm.expectRevert(bytes("Invalid TokenMessenger CCTP version"));
         TokenBridgeCctpV1 v1 = new TokenBridgeCctpV1(
             address(tokenOrigin),
-            scale,
             address(mailboxOrigin),
             messageTransmitterOrigin,
             tokenMessengerOrigin
@@ -518,7 +513,6 @@ contract TokenBridgeCctpV1Test is Test {
         vm.expectRevert(bytes("Invalid messageTransmitter CCTP version"));
         v1 = new TokenBridgeCctpV1(
             address(tokenOrigin),
-            scale,
             address(mailboxOrigin),
             messageTransmitterOrigin,
             tokenMessengerOrigin
@@ -856,7 +850,6 @@ contract TokenBridgeCctpV2Test is TokenBridgeCctpV1Test {
 
         TokenBridgeCctpV2 originImplementation = new TokenBridgeCctpV2(
             address(tokenOrigin),
-            scale,
             address(mailboxOrigin),
             messageTransmitterOrigin,
             tokenMessengerOrigin,
@@ -879,7 +872,6 @@ contract TokenBridgeCctpV2Test is TokenBridgeCctpV1Test {
 
         TokenBridgeCctpV2 destinationImplementation = new TokenBridgeCctpV2(
             address(tokenDestination),
-            scale,
             address(mailboxDestination),
             messageTransmitterDestination,
             tokenMessengerDestination,
@@ -972,7 +964,6 @@ contract TokenBridgeCctpV2Test is TokenBridgeCctpV1Test {
 
         TokenBridgeCctpV2 implementation = new TokenBridgeCctpV2(
             usdc,
-            1,
             0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D,
             messageTransmitter,
             tokenMessenger,
@@ -1257,7 +1248,6 @@ contract TokenBridgeCctpV2Test is TokenBridgeCctpV1Test {
         vm.expectRevert(bytes("Invalid TokenMessenger CCTP version"));
         TokenBridgeCctpV2 v2 = new TokenBridgeCctpV2(
             address(tokenOrigin),
-            scale,
             address(mailboxOrigin),
             messageTransmitterOrigin,
             tokenMessengerOrigin,
@@ -1269,7 +1259,6 @@ contract TokenBridgeCctpV2Test is TokenBridgeCctpV1Test {
         vm.expectRevert(bytes("Invalid messageTransmitter CCTP version"));
         v2 = new TokenBridgeCctpV2(
             address(tokenOrigin),
-            scale,
             address(mailboxOrigin),
             messageTransmitterOrigin,
             tokenMessengerOrigin,

--- a/solidity/test/token/TokenBridgeCctp.t.sol
+++ b/solidity/test/token/TokenBridgeCctp.t.sol
@@ -1125,15 +1125,16 @@ contract TokenBridgeCctpV2Test is TokenBridgeCctpV1Test {
             amount
         );
 
+        uint256 tokenQuote = quote[1].amount;
         vm.startPrank(user);
-        tokenOrigin.approve(address(tbOrigin), quote[1].amount);
+        tokenOrigin.approve(address(tbOrigin), tokenQuote);
 
         vm.expectCall(
             address(tokenMessengerOrigin),
             abi.encodeCall(
                 ITokenMessengerV2.depositForBurn,
                 (
-                    amount,
+                    tokenQuote,
                     cctpDestination,
                     user.addressToBytes32(),
                     address(tokenOrigin),

--- a/solidity/test/token/TokenBridgeCctp.t.sol
+++ b/solidity/test/token/TokenBridgeCctp.t.sol
@@ -917,7 +917,7 @@ contract TokenBridgeCctpV2Test is TokenBridgeCctpV1Test {
             version,
             address(tokenOrigin).addressToBytes32(),
             recipient,
-            amount,
+            amount + (amount * maxFee) / 10_000,
             sender.addressToBytes32(),
             maxFee,
             bytes("")

--- a/solidity/test/token/TokenBridgeCctp.t.sol
+++ b/solidity/test/token/TokenBridgeCctp.t.sol
@@ -1068,6 +1068,13 @@ contract TokenBridgeCctpV2Test is TokenBridgeCctpV1Test {
         );
     }
 
+    event MintAndWithdraw(
+        address indexed mintRecipient,
+        uint256 amount,
+        address indexed mintToken,
+        uint256 feeCollected
+    );
+
     function testFork_verify_tokenMessage() public {
         vm.createSelectFork(vm.rpcUrl("base"), 32_739_842);
 
@@ -1081,6 +1088,8 @@ contract TokenBridgeCctpV2Test is TokenBridgeCctpV1Test {
         ism.enrollRemoteRouter(origin, hook);
 
         // https://optimistic.etherscan.io/tx/0x4a8c5aef605bd1a79d7e4ab7b1852d246a05859a168db2b4791563877f2f3325
+        uint256 amount = 2;
+        uint256 fee = 1;
         bytes
             memory cctpMessage = hex"0000000100000002000000069abb52aa4e37d2ee3e521f9bc92e97581a68dadcd826fd2abaa5150de95db90e00000000000000000000000028b5a0e9c621a5badaa536219b3a228c8168cf5d00000000000000000000000028b5a0e9c621a5badaa536219b3a228c8168cf5d000000000000000000000000a7eccdb9be08178f896c26b7bbd8c3d4e844d9ba000003e8000003e8000000010000000000000000000000000b2c639c533813f4aa9d7837caf62653d097ff85000000000000000000000000a7eccdb9be08178f896c26b7bbd8c3d4e844d9ba0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000a7eccdb9be08178f896c26b7bbd8c3d4e844d9ba000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000001f825d8";
 
@@ -1097,9 +1106,11 @@ contract TokenBridgeCctpV2Test is TokenBridgeCctpV1Test {
             hook,
             ism.localDomain(),
             address(ism).addressToBytes32(),
-            abi.encode(hook, uint256(2))
+            abi.encode(hook, amount)
         );
 
+        vm.expectEmit(true, true, true, true, address(ism.tokenMessenger()));
+        emit MintAndWithdraw(deployer, amount - fee, usdc, fee);
         ism.verify(metadata, message);
     }
 

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -152,7 +152,6 @@ abstract class TokenDeployer<
         case 'V1':
           return [
             config.token,
-            scale,
             config.mailbox,
             config.messageTransmitter,
             config.tokenMessenger,
@@ -160,7 +159,6 @@ abstract class TokenDeployer<
         case 'V2':
           return [
             config.token,
-            scale,
             config.mailbox,
             config.messageTransmitter,
             config.tokenMessenger,


### PR DESCRIPTION
### Description

We want the semantic of our `transferRemote(destination, recipient, amount)` API to mean that the `recipient` on the `destination` chain receives `amount`.

Before this change, the fast CCTP v2 fee is charged to the sender but not forwarded to the `TokenMessengerV2.depositForBurn(amount)` call. 

Excerpt from the [CCTP fee docs](https://developers.circle.com/cctp/cctp-finality-and-fees#fees):

>  the Fast Transfer fee (which varies by chain) is charged onchain at minting.

This means that the `recipient` would receive `amount - amount * feeBps / 10_000`. 

This change forwards the fee amount to `TokenMessengerV2.depositForBurn(amount + fastFee)`, resulting in the recipient receiving `amount` on the destination.

### Drive-By Changes

Remove scale configuration on CCTP

### Backward compatibility

Yes

### Testing

Unit Tests and Fork Tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted deposit calculations to include both the original amount and an additional fee when processing token burns.

* **Tests**
  * Improved test coverage by explicitly verifying the token used and ensuring the correct event is emitted during remote transfers.
  * Introduced new test to verify token message handling on a forked chain.

* **Chores**
  * Removed obsolete scaling parameter from constructors and replaced with a constant scale value.
  * Updated tests and contracts to reflect removal of scaling parameter for cleaner initialization.
  * Updated deployment configurations to omit the removed scaling parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->