### PR TITLE
chore: Update fork overrides to always use block.confirmation of 1

### DIFF
--- a/typescript/cli/src/fork/fork.ts
+++ b/typescript/cli/src/fork/fork.ts
@@ -59,6 +59,7 @@ export async function runForkCommand({
     readYamlOrJson,
   );
   const chainMetadataOverrides: ChainMap<{
+    blocks: ChainMetadata['blocks'];
     rpcUrls: ChainMetadata['rpcUrls'];
   }> = {};
   for (const chainName of filteredChainsToFork) {
@@ -69,7 +70,10 @@ export async function runForkCommand({
       kill,
       parsedForkConfig[chainName],
     );
-    chainMetadataOverrides[chainName] = { rpcUrls: [{ http: endpoint }] };
+    chainMetadataOverrides[chainName] = {
+      blocks: { confirmations: 1 },
+      rpcUrls: [{ http: endpoint }],
+    };
 
     port++;
   }


### PR DESCRIPTION
### Description
This Pr updates `warp fork` to always use a block confirmation of 1 to fix anvil auto-mine issues

### Backward compatibility
Yes

### Testing
Manual
