### PR TITLE
fix: Change Settings.chains to use HyperlaneDomain as key instead of String

### DIFF
--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -524,7 +524,7 @@ impl BaseAgent for Relayer {
                 .core
                 .settings
                 .chains
-                .get(dest_domain.name())
+                .get(dest_domain)
                 .and_then(|chain| {
                     chain
                         .connection
@@ -536,7 +536,7 @@ impl BaseAgent for Relayer {
                 self.core
                     .settings
                     .chains
-                    .get(dest_domain.name())
+                    .get(dest_domain)
                     .and_then(|chain| {
                         chain
                             .connection
@@ -778,7 +778,7 @@ impl Relayer {
             .get(&origin)
             .cloned()
             .ok_or_else(|| eyre::eyre!("No message sync found"))?;
-        let index_settings = self.as_ref().settings.chains[origin.name()].index_settings();
+        let index_settings = self.as_ref().settings.chains[&origin].index_settings();
         let chain_metrics = self.chain_metrics.clone();
 
         let name = Self::contract_sync_task_name("message::", origin.name());
@@ -830,7 +830,7 @@ impl Relayer {
             .as_ref()
             .settings
             .chains
-            .get(origin.name())
+            .get(&origin)
             .map(|settings| settings.index_settings())
             .ok_or_else(|| eyre::eyre!("Error finding chain index settings"))?;
         let contract_sync = interchain_gas_payment_syncs
@@ -897,7 +897,7 @@ impl Relayer {
             .as_ref()
             .settings
             .chains
-            .get(origin.name())
+            .get(&origin)
             .map(|settings| settings.index_settings())
             .ok_or_else(|| eyre::eyre!("Error finding chain index settings"))?;
         let contract_sync = self
@@ -1115,7 +1115,7 @@ impl Relayer {
             .filter(|chain| {
                 settings
                     .chains
-                    .get(&chain.to_string())
+                    .get(chain)
                     .map(|chain| chain.submitter == SubmitterType::Lander)
                     .unwrap_or(false)
             })
@@ -1123,7 +1123,7 @@ impl Relayer {
                 (
                     chain.clone(),
                     DispatcherSettings {
-                        chain_conf: settings.chains[&chain.to_string()].clone(),
+                        chain_conf: settings.chains[chain].clone(),
                         raw_chain_conf: Default::default(),
                         domain: chain.clone(),
                         db: DatabaseOrPath::Database(db.clone()),
@@ -1173,7 +1173,7 @@ impl Relayer {
             .filter(|chain| {
                 settings
                     .chains
-                    .get(&chain.to_string())
+                    .get(chain)
                     .map(|chain| chain.submitter == SubmitterType::Lander)
                     .unwrap_or(false)
             })
@@ -1181,7 +1181,7 @@ impl Relayer {
                 (
                     chain.clone(),
                     DispatcherSettings {
-                        chain_conf: settings.chains[&chain.to_string()].clone(),
+                        chain_conf: settings.chains[chain].clone(),
                         raw_chain_conf: Default::default(),
                         domain: chain.clone(),
                         db: DatabaseOrPath::Database(db.clone()),

--- a/rust/main/agents/relayer/src/relayer/tests.rs
+++ b/rust/main/agents/relayer/src/relayer/tests.rs
@@ -101,9 +101,20 @@ fn generate_test_relayer_settings(
     destination_chains: &[HyperlaneDomain],
     metrics_port: u16,
 ) -> RelayerSettings {
+    let chains = chains
+        .into_iter()
+        .map(|(_, conf)| (conf.domain.clone(), conf))
+        .collect::<HashMap<_, _>>();
+
+    let domains = chains
+        .keys()
+        .map(|domain| (domain.name().to_string(), domain.clone()))
+        .collect();
+
     RelayerSettings {
         base: Settings {
-            chains: chains.into_iter().collect(),
+            domains,
+            chains,
             metrics_port,
             tracing: TracingConfig::default(),
         },

--- a/rust/main/agents/relayer/src/test_utils/dummy_data.rs
+++ b/rust/main/agents/relayer/src/test_utils/dummy_data.rs
@@ -1,5 +1,3 @@
-use std::{sync::Arc, time::Duration};
-
 use hyperlane_base::{
     cache::{LocalCache, MeteredCache, OptionalCache},
     db::HyperlaneRocksDB,
@@ -9,6 +7,8 @@ use hyperlane_base::{
 use hyperlane_core::{HyperlaneDomain, H256};
 use hyperlane_test::mocks::{MockMailboxContract, MockValidatorAnnounceContract};
 use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge, Opts, Registry};
+use std::collections::HashMap;
+use std::{sync::Arc, time::Duration};
 use tokio::sync::RwLock;
 
 use crate::{
@@ -53,12 +53,19 @@ pub fn dummy_metadata_builder(
     cache: OptionalCache<MeteredCache<LocalCache>>,
 ) -> BaseMetadataBuilder {
     let mut settings = Settings::default();
+    let domains = HashMap::from([
+        (origin_domain.name().to_string(), origin_domain.clone()),
+        (
+            destination_domain.name().to_string(),
+            destination_domain.clone(),
+        ),
+    ]);
+    settings.domains = domains;
+    settings
+        .chains
+        .insert(origin_domain.clone(), dummy_chain_conf(origin_domain));
     settings.chains.insert(
-        origin_domain.name().to_owned(),
-        dummy_chain_conf(origin_domain),
-    );
-    settings.chains.insert(
-        destination_domain.name().to_owned(),
+        destination_domain.clone(),
         dummy_chain_conf(destination_domain),
     );
     let destination_chain_conf = settings.chain_setup(destination_domain).unwrap();

--- a/rust/main/agents/relayer/src/test_utils/dummy_data.rs
+++ b/rust/main/agents/relayer/src/test_utils/dummy_data.rs
@@ -1,3 +1,9 @@
+use std::collections::HashMap;
+use std::{sync::Arc, time::Duration};
+
+use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge, Opts, Registry};
+use tokio::sync::RwLock;
+
 use hyperlane_base::{
     cache::{LocalCache, MeteredCache, OptionalCache},
     db::HyperlaneRocksDB,
@@ -6,10 +12,6 @@ use hyperlane_base::{
 };
 use hyperlane_core::{HyperlaneDomain, H256};
 use hyperlane_test::mocks::{MockMailboxContract, MockValidatorAnnounceContract};
-use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge, Opts, Registry};
-use std::collections::HashMap;
-use std::{sync::Arc, time::Duration};
-use tokio::sync::RwLock;
 
 use crate::{
     merkle_tree::builder::MerkleTreeBuilder,

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -465,9 +465,20 @@ mod test {
             },
         )];
 
+        let chains = chains
+            .into_iter()
+            .map(|(_, conf)| (conf.domain.clone(), conf))
+            .collect::<HashMap<_, _>>();
+
+        let domains = chains
+            .keys()
+            .map(|domain| (domain.name().to_string(), domain.clone()))
+            .collect();
+
         ScraperSettings {
             base: Settings {
-                chains: chains.into_iter().collect(),
+                domains,
+                chains,
                 metrics_port: 5000,
                 tracing: TracingConfig::default(),
             },

--- a/rust/main/agents/validator/src/reorg_reporter.rs
+++ b/rust/main/agents/validator/src/reorg_reporter.rs
@@ -101,7 +101,7 @@ impl LatestCheckpointReorgReporter {
 
         let chain_conf = settings
             .chains
-            .get(origin.name())
+            .get(origin)
             .expect("Chain configuration is not found")
             .clone();
 
@@ -149,13 +149,11 @@ impl LatestCheckpointReorgReporter {
                 let mut updated_settings = settings.clone();
                 let mut chain_conf = settings
                     .chains
-                    .get(origin.name())
+                    .get(origin)
                     .expect("Chain configuration is not found")
                     .clone();
                 chain_conf.connection = conn;
-                updated_settings
-                    .chains
-                    .insert(origin.name().to_string(), chain_conf);
+                updated_settings.chains.insert(origin.clone(), chain_conf);
                 (url, updated_settings)
             })
             .collect::<Vec<_>>()

--- a/rust/main/agents/validator/src/settings.rs
+++ b/rust/main/agents/validator/src/settings.rs
@@ -173,7 +173,7 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
         let mut base: Settings = base;
         // If the origin chain is an EVM chain, then we can use the validator as the signer if needed.
         if origin_chain.domain_protocol() == HyperlaneDomainProtocol::Ethereum {
-            if let Some(origin) = base.chains.get_mut(origin_chain.name()) {
+            if let Some(origin) = base.chains.get_mut(&origin_chain) {
                 origin.signer.get_or_insert_with(|| validator.clone());
             }
         }

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -298,8 +298,7 @@ impl BaseAgent for Validator {
 
 impl Validator {
     async fn run_merkle_tree_hook_sync(&self) -> JoinHandle<()> {
-        let index_settings =
-            self.as_ref().settings.chains[self.origin_chain.name()].index_settings();
+        let index_settings = self.as_ref().settings.chains[&self.origin_chain].index_settings();
         let contract_sync = self.merkle_tree_hook_sync.clone();
         let cursor = contract_sync
             .cursor(index_settings)
@@ -448,7 +447,7 @@ impl Validator {
                     "Validator has not announced signature storage location"
                 );
 
-                if let Some(chain_signer) = self.core.settings.chains[self.origin_chain.name()]
+                if let Some(chain_signer) = self.core.settings.chains[&self.origin_chain]
                     .chain_signer()
                     .await?
                 {

--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -103,22 +103,25 @@ impl FromRawConf<RawAgentConf, Option<&HashSet<&str>>> for Settings {
 
         let default_rpc_consensus_type = agent_name_to_default_rpc_consensus_type(agent_name);
 
-        let chains: HashMap<String, ChainConf> = raw_chains
+        let chains: HashMap<HyperlaneDomain, ChainConf> = raw_chains
             .into_iter()
             .filter_map(|(name, chain)| {
                 parse_chain(chain, &name, default_rpc_consensus_type.as_str())
                     .take_config_err(&mut err)
                     .map(|v| (name, v))
             })
-            .map(|(name, mut chain)| {
+            .map(|(_, mut chain)| {
                 if let Some(default_signer) = &default_signer {
                     chain.signer.get_or_insert_with(|| default_signer.clone());
                 }
-                (name, chain)
+                (chain.domain.clone(), chain)
             })
             .collect();
 
+        let domains = chains.keys().map(|k| (k.to_string(), k.clone())).collect();
+
         err.into_result(Self {
+            domains,
             chains,
             metrics_port,
             tracing: TracingConfig { fmt, level },


### PR DESCRIPTION
### Description

The keys in `Settings.chains` are string representing `HyperlaneDomain` while the value of type `ChainConf` contains a field of type `HyperlaneDomain`. It means that the map `Settings.chains` cannot contains invalid domains and we can use type `HyperlaneDomain` for the keys.

It removes the need to constantly converting domain into a string when we need to lookup `ChainConf` and makes it more safe since we cannot lookup with an arbitrary string.

Additional map from string to domain was added to support the lookup needed for validator settings.

### Related issues

- Contributes into https://linear.app/hyperlane-xyz/issue/ENG-1929/refactor-relayer-start-up-for-destination

### Backward compatibility

Yes

### Testing

Current unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new mapping of chain names to domain objects for improved domain lookups in settings.

* **Refactor**
  * Updated internal data structures to use domain objects as keys instead of chain name strings for chain configurations.
  * Adjusted test utilities and helper functions to align with the new domain-based mapping approach.
  * Streamlined domain and chain configuration access patterns across relayer, validator, and scraper modules.

* **Bug Fixes**
  * Improved consistency and reliability when accessing chain configurations and domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->