### PR TITLE
fix: StarknetAdapter `balance_of`

### DIFF
--- a/.changeset/honest-pumpkins-sort.md
+++ b/.changeset/honest-pumpkins-sort.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fix Starknet Adapter: balance_of

--- a/typescript/sdk/src/token/adapters/StarknetTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/StarknetTokenAdapter.ts
@@ -55,7 +55,7 @@ export class StarknetTokenAdapter
   }
 
   async getBalance(address: Address): Promise<bigint> {
-    return this.contract.balanceOf(address);
+    return this.contract.balance_of(address);
   }
 
   async getMetadata(_isNft?: boolean): Promise<TokenMetadata> {


### PR DESCRIPTION
### Description

fix: StarknetAdapter `balance_of`

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with balance retrieval for Starknet tokens, ensuring accurate balance display by correcting the method used to fetch balances.

* **Chores**
  * Updated documentation to reflect the latest patch and its changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->