### PR TITLE
feat: update timelock deployer

### DIFF
--- a/.changeset/smooth-rice-reply.md
+++ b/.changeset/smooth-rice-reply.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": minor
+---
+
+Updated the timelock deployer class to allow configuration of cancellers on contract deployment

--- a/typescript/infra/src/utils/timelock.ts
+++ b/typescript/infra/src/utils/timelock.ts
@@ -82,7 +82,9 @@ export async function timelockConfigMatches({
     // Ensure the cancellers have the CANCELLER_ROLE
     // by default proposers are also cancellers
     const expectedCancellers =
-      expectedConfig.cancellers ?? expectedConfig.proposers;
+      expectedConfig.cancellers && expectedConfig.cancellers.length !== 0
+        ? expectedConfig.cancellers
+        : expectedConfig.proposers;
     const cancellerRoles = await Promise.all(
       expectedCancellers.map(async (canceller) => {
         return timelock.hasRole(CANCELLER_ROLE, canceller);

--- a/typescript/infra/src/utils/timelock.ts
+++ b/typescript/infra/src/utils/timelock.ts
@@ -46,9 +46,10 @@ export async function timelockConfigMatches({
     }
 
     // Ensure the executors have the EXECUTOR_ROLE
-    const expectedExecutors = expectedConfig.executors ?? [
-      ethers.constants.AddressZero,
-    ];
+    const expectedExecutors =
+      expectedConfig.executors && expectedConfig.executors.length !== 0
+        ? expectedConfig.executors
+        : [ethers.constants.AddressZero];
     const executorRoles = await Promise.all(
       expectedExecutors.map(async (executor) => {
         return timelock.hasRole(EXECUTOR_ROLE, executor);
@@ -117,7 +118,7 @@ export function getTimelockConfigs({
     timelockConfigs[chain] = {
       minimumDelay: DEFAULT_TIMELOCK_DELAY_SECONDS,
       proposers: [owner],
-      executors: [DEPLOYER],
+      cancellers: [DEPLOYER],
     };
   });
 

--- a/typescript/infra/src/utils/timelock.ts
+++ b/typescript/infra/src/utils/timelock.ts
@@ -1,5 +1,3 @@
-import { ethers } from 'ethers';
-
 import { TimelockController__factory } from '@hyperlane-xyz/core';
 import {
   CANCELLER_ROLE,
@@ -46,9 +44,7 @@ export async function timelockConfigMatches({
     }
 
     // Ensure the executors have the EXECUTOR_ROLE
-    const expectedExecutors = expectedConfig.executors ?? [
-      ethers.constants.AddressZero,
-    ];
+    const expectedExecutors = expectedConfig.executors ?? [];
     const executorRoles = await Promise.all(
       expectedExecutors.map(async (executor) => {
         return timelock.hasRole(EXECUTOR_ROLE, executor);

--- a/typescript/infra/src/utils/timelock.ts
+++ b/typescript/infra/src/utils/timelock.ts
@@ -92,7 +92,7 @@ export async function timelockConfigMatches({
     );
     if (cancellerMissing.length > 0) {
       issues.push(
-        `Canceller missing role for ${chain} at ${address}: ${executorsMissing.join(', ')}`,
+        `Canceller missing role for ${chain} at ${address}: ${cancellerMissing.join(', ')}`,
       );
     }
   }

--- a/typescript/infra/src/utils/timelock.ts
+++ b/typescript/infra/src/utils/timelock.ts
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers';
+
 import { TimelockController__factory } from '@hyperlane-xyz/core';
 import {
   CANCELLER_ROLE,
@@ -44,7 +46,9 @@ export async function timelockConfigMatches({
     }
 
     // Ensure the executors have the EXECUTOR_ROLE
-    const expectedExecutors = expectedConfig.executors ?? [];
+    const expectedExecutors = expectedConfig.executors ?? [
+      ethers.constants.AddressZero,
+    ];
     const executorRoles = await Promise.all(
       expectedExecutors.map(async (executor) => {
         return timelock.hasRole(EXECUTOR_ROLE, executor);

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -91,7 +91,7 @@
     "test": "yarn test:unit && yarn test:hardhat && yarn test:foundry",
     "test:ci": "yarn test",
     "test:unit": "mocha --config .mocharc.json './src/**/*.test.ts' --exit",
-    "test:hardhat": "NODE_OPTIONS='--experimental-loader ts-node/esm/transpile-only --no-warnings=ExperimentalWarning' hardhat --config hardhat.config.cts test $(find ./src -name \"EvmTimelockDeployer.hardhat-test.ts\")",
+    "test:hardhat": "NODE_OPTIONS='--experimental-loader ts-node/esm/transpile-only --no-warnings=ExperimentalWarning' hardhat --config hardhat.config.cts test $(find ./src -name \"*.hardhat-test.ts\")",
     "test:foundry": "./scripts/foundry-test.sh"
   },
   "peerDependencies": {

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -91,7 +91,7 @@
     "test": "yarn test:unit && yarn test:hardhat && yarn test:foundry",
     "test:ci": "yarn test",
     "test:unit": "mocha --config .mocharc.json './src/**/*.test.ts' --exit",
-    "test:hardhat": "NODE_OPTIONS='--experimental-loader ts-node/esm/transpile-only --no-warnings=ExperimentalWarning' hardhat --config hardhat.config.cts test $(find ./src -name \"*.hardhat-test.ts\")",
+    "test:hardhat": "NODE_OPTIONS='--experimental-loader ts-node/esm/transpile-only --no-warnings=ExperimentalWarning' hardhat --config hardhat.config.cts test $(find ./src -name \"EvmTimelockDeployer.hardhat-test.ts\")",
     "test:foundry": "./scripts/foundry-test.sh"
   },
   "peerDependencies": {

--- a/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.hardhat-test.ts
@@ -3,10 +3,7 @@ import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import hre from 'hardhat';
 
-import {
-  TimelockController,
-  TimelockController__factory,
-} from '@hyperlane-xyz/core';
+import { TimelockController__factory } from '@hyperlane-xyz/core';
 import { assert } from '@hyperlane-xyz/utils';
 
 import { TestChainName } from '../../consts/testChains.js';

--- a/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.hardhat-test.ts
@@ -1,4 +1,3 @@
-import { JsonRpcProvider } from '@ethersproject/providers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers.js';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -8,7 +7,7 @@ import {
   TimelockController,
   TimelockController__factory,
 } from '@hyperlane-xyz/core';
-import { assert, randomInt } from '@hyperlane-xyz/utils';
+import { assert } from '@hyperlane-xyz/utils';
 
 import { TestChainName } from '../../consts/testChains.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';

--- a/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.hardhat-test.ts
@@ -190,6 +190,10 @@ describe('EvmTimelockDeployer', async () => {
       multiProvider.getProvider(TestChainName.test4),
     );
 
+    expect(
+      await timelock.hasRole(EXECUTOR_ROLE, hre.ethers.constants.AddressZero),
+    ).to.be.true;
+
     const _0_BYTES_32 =
       '0x0000000000000000000000000000000000000000000000000000000000000000';
     const updatedDelay = 100;

--- a/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.hardhat-test.ts
@@ -15,7 +15,12 @@ import { randomAddress } from '../../test/testUtils.js';
 import { TimelockConfig } from '../types.js';
 
 import { EvmTimelockDeployer } from './EvmTimelockDeployer.js';
-import { CANCELLER_ROLE, EXECUTOR_ROLE, PROPOSER_ROLE } from './constants.js';
+import {
+  CANCELLER_ROLE,
+  EMPTY_BYTES_32,
+  EXECUTOR_ROLE,
+  PROPOSER_ROLE,
+} from './constants.js';
 
 chai.use(chaiAsPromised);
 
@@ -23,179 +28,156 @@ describe('EvmTimelockDeployer', async () => {
   let multiProvider: MultiProvider;
   let deployer: EvmTimelockDeployer;
   let signer: SignerWithAddress;
+  const signerAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+  const otherSignerAddress = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
   let otherSigner: SignerWithAddress;
-  let config: TimelockConfig;
+
+  type TestCase = {
+    title: string;
+    config: TimelockConfig;
+  };
 
   beforeEach(async () => {
     [signer, otherSigner] = await hre.ethers.getSigners();
     multiProvider = MultiProvider.createTestMultiProvider({ signer });
     deployer = new EvmTimelockDeployer(multiProvider);
-    config = {
+
+    assert(
+      signer.address === signerAddress,
+      'Expected signer.address to be equal signerAddress',
+    );
+    assert(
+      otherSigner.address === otherSignerAddress,
+      'Expected otherSigner.address address to be equal otherSignerAddress',
+    );
+  });
+
+  describe('basic config', async () => {
+    const testCases: TestCase[] = [
+      {
+        title: 'should deploy TimelockController with correct parameters',
+        config: {
+          minimumDelay: 3600,
+          proposers: [signerAddress],
+          executors: [signerAddress],
+          admin: signerAddress,
+        },
+      },
+      {
+        title:
+          'should deploy TimelockController with multiple proposers and executors',
+        config: {
+          minimumDelay: 7200,
+          proposers: [signerAddress, randomAddress()],
+          executors: [signerAddress, randomAddress()],
+          admin: signerAddress,
+        },
+      },
+      {
+        title: 'should deploy with minimum delay of 0',
+        config: {
+          minimumDelay: 0,
+          proposers: [signerAddress],
+          executors: [signerAddress],
+          admin: signerAddress,
+        },
+      },
+    ];
+
+    for (const { title, config } of testCases) {
+      it(title, async () => {
+        const { TimelockController } = await deployer.deployContracts(
+          TestChainName.test2,
+          config,
+        );
+        const timelockAddress = TimelockController.address;
+
+        const timelock = TimelockController__factory.connect(
+          timelockAddress as string,
+          multiProvider.getProvider(TestChainName.test2),
+        );
+
+        expect(await timelock.getMinDelay()).to.equal(config.minimumDelay);
+
+        for (const proposer of config.proposers) {
+          expect(await timelock.hasRole(PROPOSER_ROLE, proposer)).to.be.true;
+        }
+
+        // proposers are also cancellers by default
+        for (const proposer of config.proposers) {
+          expect(await timelock.hasRole(CANCELLER_ROLE, proposer)).to.be.true;
+        }
+
+        assert(config.executors, 'Expected executors to be defined');
+        for (const executor of config.executors) {
+          expect(await timelock.hasRole(EXECUTOR_ROLE, executor)).to.be.true;
+        }
+      });
+    }
+  });
+
+  describe('multichain deployments', () => {
+    const config: TimelockConfig = {
       minimumDelay: 3600,
-      proposers: [signer.address],
-      executors: [signer.address],
-      admin: signer.address,
-    };
-  });
-
-  it('should deploy TimelockController with correct parameters', async () => {
-    await deployer.deploy({ [TestChainName.test1]: config });
-    const { TimelockController } =
-      deployer.deployedContracts[TestChainName.test1];
-    const timelockAddress = TimelockController.address;
-    const timelockAdminRoleHash =
-      await TimelockController.TIMELOCK_ADMIN_ROLE();
-
-    expect(timelockAddress).to.exist;
-
-    const timelock = TimelockController__factory.connect(
-      timelockAddress,
-      multiProvider.getProvider(TestChainName.test1),
-    );
-
-    expect(await timelock.getMinDelay()).to.equal(config.minimumDelay);
-    expect(await timelock.hasRole(PROPOSER_ROLE, config.proposers[0])).to.be
-      .true;
-    assert(config.executors, 'Expected executors to be defined');
-    expect(await timelock.hasRole(EXECUTOR_ROLE, config.executors[0])).to.be
-      .true;
-    expect(await timelock.hasRole(timelockAdminRoleHash, config.admin!)).to.be
-      .true;
-  });
-
-  it('should deploy TimelockController with multiple proposers and executors', async () => {
-    const multiConfig: TimelockConfig = {
-      minimumDelay: 7200, // 2 hours
-      proposers: [signer.address, randomAddress()],
-      executors: [signer.address, randomAddress()],
-      admin: signer.address,
+      proposers: [signerAddress],
+      executors: [signerAddress],
+      admin: signerAddress,
     };
 
-    const { TimelockController } = await deployer.deployContracts(
-      TestChainName.test2,
-      multiConfig,
-    );
-    const timelockAddress = TimelockController.address;
+    it('should not redeploy if contract already exists', async () => {
+      const chainName = TestChainName.test1;
 
-    const timelock = TimelockController__factory.connect(
-      timelockAddress as string,
-      multiProvider.getProvider(TestChainName.test2),
-    );
+      // Deploy first time
+      await deployer.deployContracts(chainName, config);
+      const firstAddress = deployer.deployedContracts[chainName];
 
-    expect(await timelock.getMinDelay()).to.equal(multiConfig.minimumDelay);
+      // Deploy again with same config
+      await deployer.deployContracts(chainName, config);
+      const secondAddress = deployer.deployedContracts[chainName];
 
-    for (const proposer of multiConfig.proposers) {
-      expect(await timelock.hasRole(PROPOSER_ROLE, proposer)).to.be.true;
-    }
+      expect(firstAddress).to.equal(secondAddress);
+    });
 
-    // proposers are also cancellers by default
-    for (const proposer of multiConfig.proposers) {
-      expect(await timelock.hasRole(CANCELLER_ROLE, proposer)).to.be.true;
-    }
+    it('should deploy different contracts for different chains', async () => {
+      const {
+        TimelockController: { address: address1 },
+      } = await deployer.deployContracts(TestChainName.test1, config);
+      const {
+        TimelockController: { address: address2 },
+      } = await deployer.deployContracts(TestChainName.test2, config);
 
-    assert(multiConfig.executors, 'Expected executors to be defined');
-    for (const executor of multiConfig.executors) {
-      expect(await timelock.hasRole(EXECUTOR_ROLE, executor)).to.be.true;
-    }
+      expect(address1).to.not.equal(address2);
+      expect(address1).to.exist;
+      expect(address2).to.exist;
+    });
   });
 
-  it('should deploy TimelockController with the timelock as the only admin when an admin address is not provided', async () => {
-    const noAdminConfig: TimelockConfig = {
-      minimumDelay: 1800,
-      proposers: [signer.address],
-      executors: [signer.address],
-    };
-
-    const { TimelockController } = await deployer.deployContracts(
-      TestChainName.test3,
-      noAdminConfig,
-    );
-    const timelockAddress = TimelockController.address;
-    const timelockAdminRoleHash =
-      await TimelockController.TIMELOCK_ADMIN_ROLE();
-
-    const timelock = TimelockController__factory.connect(
-      timelockAddress,
-      multiProvider.getProvider(TestChainName.test3),
-    );
-
-    expect(await timelock.hasRole(timelockAdminRoleHash, timelockAddress)).to.be
-      .true;
-  });
-
-  it('should not redeploy if contract already exists', async () => {
-    const chainName = TestChainName.test1;
-
-    // Deploy first time
-    await deployer.deployContracts(chainName, config);
-    const firstAddress = deployer.deployedContracts[chainName];
-
-    // Deploy again with same config
-    await deployer.deployContracts(chainName, config);
-    const secondAddress = deployer.deployedContracts[chainName];
-
-    expect(firstAddress).to.equal(secondAddress);
-  });
-
-  it('should deploy different contracts for different chains', async () => {
-    const {
-      TimelockController: { address: address1 },
-    } = await deployer.deployContracts(TestChainName.test1, config);
-    const {
-      TimelockController: { address: address2 },
-    } = await deployer.deployContracts(TestChainName.test2, config);
-
-    expect(address1).to.not.equal(address2);
-    expect(address1).to.exist;
-    expect(address2).to.exist;
-  });
-
-  it('should deploy with minimum delay of 0', async () => {
-    const zeroDelayConfig: TimelockConfig = {
+  it('should allow anyone to execute a transaction if no one is set in the input config', async () => {
+    const openExecutorRoleConfig: TimelockConfig = {
       minimumDelay: 0,
-      proposers: [signer.address],
-      executors: [signer.address],
-      admin: signer.address,
+      proposers: [signerAddress],
+      admin: signerAddress,
     };
 
     const { TimelockController } = await deployer.deployContracts(
       TestChainName.test4,
-      zeroDelayConfig,
+      openExecutorRoleConfig,
     );
     const timelockAddress = TimelockController.address;
-
     const timelock = TimelockController__factory.connect(
       timelockAddress,
-      multiProvider.getProvider(TestChainName.test4),
+      signer,
     );
 
-    expect(await timelock.getMinDelay()).to.equal(0);
-  });
-
-  it('should set anyone as a executor if no one is set in the input config', async () => {
-    const zeroDelayConfig: TimelockConfig = {
-      minimumDelay: 0,
-      proposers: [signer.address],
-      admin: signer.address,
-    };
-
-    const { TimelockController } = await deployer.deployContracts(
-      TestChainName.test4,
-      zeroDelayConfig,
-    );
-    const timelockAddress = TimelockController.address;
-
-    const timelock = TimelockController__factory.connect(
-      timelockAddress,
-      multiProvider.getProvider(TestChainName.test4),
-    );
-
+    // If the 0 address has the executor role anyone can execute
     expect(
       await timelock.hasRole(EXECUTOR_ROLE, hre.ethers.constants.AddressZero),
     ).to.be.true;
 
-    const _0_BYTES_32 =
-      '0x0000000000000000000000000000000000000000000000000000000000000000';
+    // Test that someone who does not have the executor role can execute proposed transactions
+    expect(await timelock.hasRole(EXECUTOR_ROLE, otherSignerAddress)).to.be
+      .false;
+
     const updatedDelay = 100;
     const testTxData =
       TimelockController__factory.createInterface().encodeFunctionData(
@@ -203,155 +185,189 @@ describe('EvmTimelockDeployer', async () => {
         [updatedDelay],
       );
 
-    const signerTimelock = TimelockController__factory.connect(
-      timelockAddress,
-      signer,
-    );
-    const tx = await signerTimelock.schedule(
+    const scheduleTx = await timelock.schedule(
       timelockAddress,
       0,
       testTxData,
-      _0_BYTES_32,
-      _0_BYTES_32,
+      EMPTY_BYTES_32,
+      EMPTY_BYTES_32,
       0,
     );
-    await tx.wait();
+    await scheduleTx.wait();
 
-    const randomSignerTimelockInstance = TimelockController__factory.connect(
+    const otherSignerTimelockInstance = TimelockController__factory.connect(
       timelockAddress,
       otherSigner,
     );
-    const executeTx = await randomSignerTimelockInstance.execute(
+    const executeTx = await otherSignerTimelockInstance.execute(
       timelockAddress,
       0,
       testTxData,
-      _0_BYTES_32,
-      _0_BYTES_32,
+      EMPTY_BYTES_32,
+      EMPTY_BYTES_32,
     );
     await executeTx.wait();
 
     expect(await timelock.getMinDelay()).to.equal(updatedDelay);
   });
 
-  async function assertCancellerConfig(
-    expectedConfig: TimelockConfig,
-    timelockInstance: TimelockController,
-  ) {
-    // proposer should be a proposer but not a canceller if not in canceller config
-    assert(expectedConfig.proposers, 'Expected proposers to be defined');
-    for (const proposer of expectedConfig.proposers) {
-      expect(await timelockInstance.hasRole(PROPOSER_ROLE, proposer)).to.be
-        .true;
+  describe('canceller config', () => {
+    async function assertCancellerConfig(
+      expectedConfig: TimelockConfig,
+      timelockInstance: TimelockController,
+    ) {
+      // proposer should be a proposer but not a canceller if not in canceller config
+      assert(expectedConfig.proposers, 'Expected proposers to be defined');
+      for (const proposer of expectedConfig.proposers) {
+        expect(await timelockInstance.hasRole(PROPOSER_ROLE, proposer)).to.be
+          .true;
 
-      if (!expectedConfig.cancellers?.includes(proposer)) {
-        expect(await timelockInstance.hasRole(CANCELLER_ROLE, proposer)).to.be
-          .false;
+        if (!expectedConfig.cancellers?.includes(proposer)) {
+          expect(await timelockInstance.hasRole(CANCELLER_ROLE, proposer)).to.be
+            .false;
+        }
       }
-    }
 
-    // cancellers should be a canceller but not a proposer if not in the proposer config
-    assert(expectedConfig.cancellers, 'Expected cancellers to be defined');
-    for (const canceller of expectedConfig.cancellers) {
-      expect(await timelockInstance.hasRole(CANCELLER_ROLE, canceller)).to.be
-        .true;
-      if (!expectedConfig.proposers?.includes(canceller)) {
-        expect(await timelockInstance.hasRole(PROPOSER_ROLE, canceller)).to.be
-          .false;
+      // cancellers should be a canceller but not a proposer if not in the proposer config
+      assert(expectedConfig.cancellers, 'Expected cancellers to be defined');
+      for (const canceller of expectedConfig.cancellers) {
+        expect(await timelockInstance.hasRole(CANCELLER_ROLE, canceller)).to.be
+          .true;
+        if (!expectedConfig.proposers?.includes(canceller)) {
+          expect(await timelockInstance.hasRole(PROPOSER_ROLE, canceller)).to.be
+            .false;
+        }
       }
-    }
 
-    // signer should not be the timelock admin after deployment
-    const timelockAdminRoleHash = await timelockInstance.TIMELOCK_ADMIN_ROLE();
-    expect(
-      await timelockInstance.hasRole(timelockAdminRoleHash, signer.address),
-    ).to.be.false;
+      // signer should not be the timelock admin after deployment
+      const timelockAdminRoleHash =
+        await timelockInstance.TIMELOCK_ADMIN_ROLE();
+      expect(
+        await timelockInstance.hasRole(timelockAdminRoleHash, signerAddress),
+      ).to.be.false;
 
-    // Timelock should still be the admin of itself
-    expect(
-      await timelockInstance.hasRole(
-        timelockAdminRoleHash,
-        timelockInstance.address,
-      ),
-    ).to.be.true;
-
-    // if an admin was set it should be the admin after the changes
-    if (expectedConfig.admin) {
+      // Timelock should still be the admin of itself
       expect(
         await timelockInstance.hasRole(
           timelockAdminRoleHash,
-          expectedConfig.admin,
+          timelockInstance.address,
         ),
       ).to.be.true;
+
+      // if an admin was set it should be the admin after the changes
+      if (expectedConfig.admin) {
+        expect(
+          await timelockInstance.hasRole(
+            timelockAdminRoleHash,
+            expectedConfig.admin,
+          ),
+        ).to.be.true;
+      }
     }
-  }
 
-  it('should deploy with the correct canceller config', async () => {
-    const proposer = randomAddress();
-    const cancellerConfig: TimelockConfig = {
-      minimumDelay: 30,
-      proposers: [proposer],
-      executors: [signer.address],
-      cancellers: [randomAddress(), randomAddress()],
-    };
+    it('should deploy with the correct canceller config', async () => {
+      const proposer = randomAddress();
+      const cancellerConfig: TimelockConfig = {
+        minimumDelay: 30,
+        proposers: [proposer],
+        executors: [signerAddress],
+        cancellers: [randomAddress(), randomAddress()],
+      };
 
-    const { TimelockController } = await deployer.deployContracts(
-      TestChainName.test4,
-      cancellerConfig,
-    );
-    const timelockAddress = TimelockController.address;
+      const { TimelockController } = await deployer.deployContracts(
+        TestChainName.test4,
+        cancellerConfig,
+      );
+      const timelockAddress = TimelockController.address;
 
-    const timelock = TimelockController__factory.connect(
-      timelockAddress,
-      multiProvider.getProvider(TestChainName.test4),
-    );
+      const timelock = TimelockController__factory.connect(
+        timelockAddress,
+        multiProvider.getProvider(TestChainName.test4),
+      );
 
-    await assertCancellerConfig(cancellerConfig, timelock);
+      await assertCancellerConfig(cancellerConfig, timelock);
+    });
+
+    it('should not remove a proposer that it is also a canceller', async () => {
+      const proposer = randomAddress();
+      const cancellerConfig: TimelockConfig = {
+        minimumDelay: 30,
+        proposers: [proposer],
+        executors: [signerAddress],
+        cancellers: [proposer, randomAddress()],
+      };
+
+      const { TimelockController } = await deployer.deployContracts(
+        TestChainName.test4,
+        cancellerConfig,
+      );
+      const timelockAddress = TimelockController.address;
+
+      const timelock = TimelockController__factory.connect(
+        timelockAddress,
+        multiProvider.getProvider(TestChainName.test4),
+      );
+
+      await assertCancellerConfig(cancellerConfig, timelock);
+    });
   });
 
-  it('should not remove a proposer that it is also a canceller', async () => {
+  describe('admin config', () => {
     const proposer = randomAddress();
-    const cancellerConfig: TimelockConfig = {
-      minimumDelay: 30,
-      proposers: [proposer],
-      executors: [signer.address],
-      cancellers: [proposer, randomAddress()],
-    };
+    const customAdmin = randomAddress();
+    const testCases: TestCase[] = [
+      {
+        title:
+          'should deploy TimelockController with the timelock as the only admin when an admin address is not provided',
+        config: {
+          minimumDelay: 1800,
+          proposers: [signerAddress],
+          executors: [signerAddress],
+        },
+      },
+      {
+        title:
+          'should not revoke the admin role from the deployer if it is the expected admin',
+        config: {
+          minimumDelay: 30,
+          proposers: [randomAddress()],
+          executors: [signerAddress],
+          cancellers: [randomAddress()],
+          admin: signerAddress,
+        },
+      },
+      {
+        title:
+          'should set the expected admin from the config after applying the changes',
+        config: {
+          minimumDelay: 30,
+          proposers: [proposer],
+          executors: [signerAddress],
+          cancellers: [proposer, randomAddress()],
+          admin: customAdmin,
+        },
+      },
+    ];
 
-    const { TimelockController } = await deployer.deployContracts(
-      TestChainName.test4,
-      cancellerConfig,
-    );
-    const timelockAddress = TimelockController.address;
+    for (const { title, config } of testCases) {
+      it(title, async () => {
+        const { TimelockController } = await deployer.deployContracts(
+          TestChainName.test3,
+          config,
+        );
 
-    const timelock = TimelockController__factory.connect(
-      timelockAddress,
-      multiProvider.getProvider(TestChainName.test4),
-    );
+        const timelockAdminRoleHash =
+          await TimelockController.TIMELOCK_ADMIN_ROLE();
 
-    await assertCancellerConfig(cancellerConfig, timelock);
-  });
-
-  it('should set the expected admin from the config after applying the canceller changes', async () => {
-    const proposer = randomAddress();
-    const cancellerConfig: TimelockConfig = {
-      minimumDelay: 30,
-      proposers: [proposer],
-      executors: [signer.address],
-      cancellers: [proposer, randomAddress()],
-      admin: randomAddress(),
-    };
-
-    const { TimelockController } = await deployer.deployContracts(
-      TestChainName.test4,
-      cancellerConfig,
-    );
-    const timelockAddress = TimelockController.address;
-
-    const timelock = TimelockController__factory.connect(
-      timelockAddress,
-      multiProvider.getProvider(TestChainName.test4),
-    );
-
-    await assertCancellerConfig(cancellerConfig, timelock);
+        // if an admin was set in the config we expect the timelock to be the admin
+        const expectedAdmin = config.admin ?? TimelockController.address;
+        expect(
+          await TimelockController.hasRole(
+            timelockAdminRoleHash,
+            expectedAdmin,
+          ),
+        ).to.be.true;
+      });
+    }
   });
 });

--- a/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.hardhat-test.ts
@@ -1,9 +1,14 @@
+import { JsonRpcProvider } from '@ethersproject/providers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers.js';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import hre from 'hardhat';
 
-import { TimelockController__factory } from '@hyperlane-xyz/core';
+import {
+  TimelockController,
+  TimelockController__factory,
+} from '@hyperlane-xyz/core';
+import { assert, randomInt } from '@hyperlane-xyz/utils';
 
 import { TestChainName } from '../../consts/testChains.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
@@ -19,10 +24,11 @@ describe('EvmTimelockDeployer', async () => {
   let multiProvider: MultiProvider;
   let deployer: EvmTimelockDeployer;
   let signer: SignerWithAddress;
+  let otherSigner: SignerWithAddress;
   let config: TimelockConfig;
 
-  before(async () => {
-    [signer] = await hre.ethers.getSigners();
+  beforeEach(async () => {
+    [signer, otherSigner] = await hre.ethers.getSigners();
     multiProvider = MultiProvider.createTestMultiProvider({ signer });
     deployer = new EvmTimelockDeployer(multiProvider);
     config = {
@@ -51,6 +57,7 @@ describe('EvmTimelockDeployer', async () => {
     expect(await timelock.getMinDelay()).to.equal(config.minimumDelay);
     expect(await timelock.hasRole(PROPOSER_ROLE, config.proposers[0])).to.be
       .true;
+    assert(config.executors, 'Expected executors to be defined');
     expect(await timelock.hasRole(EXECUTOR_ROLE, config.executors[0])).to.be
       .true;
     expect(await timelock.hasRole(timelockAdminRoleHash, config.admin!)).to.be
@@ -87,6 +94,7 @@ describe('EvmTimelockDeployer', async () => {
       expect(await timelock.hasRole(CANCELLER_ROLE, proposer)).to.be.true;
     }
 
+    assert(multiConfig.executors, 'Expected executors to be defined');
     for (const executor of multiConfig.executors) {
       expect(await timelock.hasRole(EXECUTOR_ROLE, executor)).to.be.true;
     }
@@ -163,5 +171,184 @@ describe('EvmTimelockDeployer', async () => {
     );
 
     expect(await timelock.getMinDelay()).to.equal(0);
+  });
+
+  it('should set anyone as a executor if no one is set in the input config', async () => {
+    const zeroDelayConfig: TimelockConfig = {
+      minimumDelay: 0,
+      proposers: [signer.address],
+      admin: signer.address,
+    };
+
+    const { TimelockController } = await deployer.deployContracts(
+      TestChainName.test4,
+      zeroDelayConfig,
+    );
+    const timelockAddress = TimelockController.address;
+
+    const timelock = TimelockController__factory.connect(
+      timelockAddress,
+      multiProvider.getProvider(TestChainName.test4),
+    );
+
+    const _0_BYTES_32 =
+      '0x0000000000000000000000000000000000000000000000000000000000000000';
+    const updatedDelay = 100;
+    const testTxData =
+      TimelockController__factory.createInterface().encodeFunctionData(
+        'updateDelay',
+        [updatedDelay],
+      );
+
+    const signerTimelock = TimelockController__factory.connect(
+      timelockAddress,
+      signer,
+    );
+    const tx = await signerTimelock.schedule(
+      timelockAddress,
+      0,
+      testTxData,
+      _0_BYTES_32,
+      _0_BYTES_32,
+      0,
+    );
+    await tx.wait();
+
+    const randomSignerTimelockInstance = TimelockController__factory.connect(
+      timelockAddress,
+      otherSigner,
+    );
+    const executeTx = await randomSignerTimelockInstance.execute(
+      timelockAddress,
+      0,
+      testTxData,
+      _0_BYTES_32,
+      _0_BYTES_32,
+    );
+    await executeTx.wait();
+
+    expect(await timelock.getMinDelay()).to.equal(updatedDelay);
+  });
+
+  async function assertCancellerConfig(
+    expectedConfig: TimelockConfig,
+    timelockInstance: TimelockController,
+  ) {
+    // proposer should be a proposer but not a canceller if not in canceller config
+    assert(expectedConfig.proposers, 'Expected proposers to be defined');
+    for (const proposer of expectedConfig.proposers) {
+      expect(await timelockInstance.hasRole(PROPOSER_ROLE, proposer)).to.be
+        .true;
+
+      if (!expectedConfig.cancellers?.includes(proposer)) {
+        expect(await timelockInstance.hasRole(CANCELLER_ROLE, proposer)).to.be
+          .false;
+      }
+    }
+
+    // cancellers should be a canceller but not a proposer if not in the proposer config
+    assert(expectedConfig.cancellers, 'Expected cancellers to be defined');
+    for (const canceller of expectedConfig.cancellers) {
+      expect(await timelockInstance.hasRole(CANCELLER_ROLE, canceller)).to.be
+        .true;
+      if (!expectedConfig.proposers?.includes(canceller)) {
+        expect(await timelockInstance.hasRole(PROPOSER_ROLE, canceller)).to.be
+          .false;
+      }
+    }
+
+    // signer should not be the timelock admin after deployment
+    const timelockAdminRoleHash = await timelockInstance.TIMELOCK_ADMIN_ROLE();
+    expect(
+      await timelockInstance.hasRole(timelockAdminRoleHash, signer.address),
+    ).to.be.false;
+
+    // Timelock should still be the admin of itself
+    expect(
+      await timelockInstance.hasRole(
+        timelockAdminRoleHash,
+        timelockInstance.address,
+      ),
+    ).to.be.true;
+
+    // if an admin was set it should be the admin after the changes
+    if (expectedConfig.admin) {
+      expect(
+        await timelockInstance.hasRole(
+          timelockAdminRoleHash,
+          expectedConfig.admin,
+        ),
+      ).to.be.true;
+    }
+  }
+
+  it('should deploy with the correct canceller config', async () => {
+    const proposer = randomAddress();
+    const cancellerConfig: TimelockConfig = {
+      minimumDelay: 30,
+      proposers: [proposer],
+      executors: [signer.address],
+      cancellers: [randomAddress(), randomAddress()],
+    };
+
+    const { TimelockController } = await deployer.deployContracts(
+      TestChainName.test4,
+      cancellerConfig,
+    );
+    const timelockAddress = TimelockController.address;
+
+    const timelock = TimelockController__factory.connect(
+      timelockAddress,
+      multiProvider.getProvider(TestChainName.test4),
+    );
+
+    await assertCancellerConfig(cancellerConfig, timelock);
+  });
+
+  it('should not remove a proposer that it is also a canceller', async () => {
+    const proposer = randomAddress();
+    const cancellerConfig: TimelockConfig = {
+      minimumDelay: 30,
+      proposers: [proposer],
+      executors: [signer.address],
+      cancellers: [proposer, randomAddress()],
+    };
+
+    const { TimelockController } = await deployer.deployContracts(
+      TestChainName.test4,
+      cancellerConfig,
+    );
+    const timelockAddress = TimelockController.address;
+
+    const timelock = TimelockController__factory.connect(
+      timelockAddress,
+      multiProvider.getProvider(TestChainName.test4),
+    );
+
+    await assertCancellerConfig(cancellerConfig, timelock);
+  });
+
+  it('should set the expected admin from the config after applying the canceller changes', async () => {
+    const proposer = randomAddress();
+    const cancellerConfig: TimelockConfig = {
+      minimumDelay: 30,
+      proposers: [proposer],
+      executors: [signer.address],
+      cancellers: [proposer, randomAddress()],
+      admin: randomAddress(),
+    };
+
+    const { TimelockController } = await deployer.deployContracts(
+      TestChainName.test4,
+      cancellerConfig,
+    );
+    const timelockAddress = TimelockController.address;
+
+    const timelock = TimelockController__factory.connect(
+      timelockAddress,
+      multiProvider.getProvider(TestChainName.test4),
+    );
+
+    await assertCancellerConfig(cancellerConfig, timelock);
   });
 });

--- a/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.ts
+++ b/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.ts
@@ -2,6 +2,8 @@ import { ethers } from 'ethers';
 import { Logger } from 'pino';
 
 import { rootLogger } from '@hyperlane-xyz/utils';
+import { isZeroishAddress } from '@hyperlane-xyz/utils';
+import { eqAddress } from '@hyperlane-xyz/utils';
 
 import { HyperlaneDeployer } from '../../deploy/HyperlaneDeployer.js';
 import { ContractVerifier } from '../../deploy/verify/ContractVerifier.js';
@@ -33,11 +35,7 @@ export class EvmTimelockDeployer extends HyperlaneDeployer<
     chain: string,
     config: TimelockConfig,
   ): Promise<HyperlaneContracts<EvmTimelockFactories>> {
-    const currentDeployer = this.multiProvider.getSigner(chain);
-    const deployerAddress = await currentDeployer.getAddress();
-
-    const admin = config.cancellers ? deployerAddress : config.admin;
-    const expectedFinalAdmin = config.admin ?? ethers.constants.AddressZero;
+    const deployerAddress = await this.multiProvider.getSignerAddress(chain);
     const deployedContract = await this.deployContract(
       chain,
       'TimelockController',
@@ -45,45 +43,42 @@ export class EvmTimelockDeployer extends HyperlaneDeployer<
         config.minimumDelay,
         config.proposers,
         config.executors ?? [ethers.constants.AddressZero],
-        admin ?? ethers.constants.AddressZero,
+        deployerAddress,
       ],
     );
 
-    if (!config.cancellers) {
-      return {
-        TimelockController: deployedContract,
-      };
-    }
-
-    // Remove all the proposers that should not be cancellers
-    const cancellers = new Set(config.cancellers ?? []);
-    const cancellersToRemove = config.proposers.filter(
-      (address) => !cancellers.has(address),
-    );
-
-    this.logger.info(`Revoking CANCELLER_ROLE to ${cancellersToRemove}`);
-    for (const proposer of cancellersToRemove) {
-      await this.multiProvider.handleTx(
-        chain,
-        deployedContract.revokeRole(CANCELLER_ROLE, proposer),
+    if (config.cancellers && config.cancellers.length !== 0) {
+      // Remove all the proposers that should not be cancellers
+      const cancellers = new Set(config.cancellers ?? []);
+      const cancellersToRemove = config.proposers.filter(
+        (address) => !cancellers.has(address),
       );
+
+      this.logger.info(`Revoking CANCELLER_ROLE from ${cancellersToRemove}`);
+      for (const proposer of cancellersToRemove) {
+        await this.multiProvider.handleTx(
+          chain,
+          deployedContract.revokeRole(CANCELLER_ROLE, proposer),
+        );
+      }
+
+      // Give canceller role only to the addresses in the cancellers config
+      this.logger.info(`Setting CANCELLER_ROLE to ${config.cancellers}`);
+      for (const canceller of config.cancellers) {
+        await this.multiProvider.handleTx(
+          chain,
+          deployedContract.grantRole(CANCELLER_ROLE, canceller),
+        );
+      }
     }
 
-    // Give canceller role only to the addresses in the cancellers config
-    this.logger.info(`Setting CANCELLER_ROLE to ${config.cancellers}`);
-    for (const canceller of config.cancellers) {
-      await this.multiProvider.handleTx(
-        chain,
-        deployedContract.grantRole(CANCELLER_ROLE, canceller),
-      );
-    }
-
+    const expectedFinalAdmin = config.admin ?? ethers.constants.AddressZero;
     const adminRole = await deployedContract.TIMELOCK_ADMIN_ROLE();
     const isAdminSetCorrectly = await deployedContract.hasRole(
       adminRole,
       expectedFinalAdmin,
     );
-    if (!isAdminSetCorrectly) {
+    if (!isAdminSetCorrectly && !isZeroishAddress(expectedFinalAdmin)) {
       this.logger.info(
         `Granting admin role to the expected admin ${expectedFinalAdmin}`,
       );
@@ -93,13 +88,15 @@ export class EvmTimelockDeployer extends HyperlaneDeployer<
       );
     }
 
-    this.logger.info(
-      `Revoking temporary admin role from deployer ${deployerAddress}`,
-    );
-    await this.multiProvider.handleTx(
-      chain,
-      deployedContract.revokeRole(adminRole, deployerAddress),
-    );
+    if (!eqAddress(expectedFinalAdmin, deployerAddress)) {
+      this.logger.info(
+        `Revoking temporary admin role from deployer ${deployerAddress}`,
+      );
+      await this.multiProvider.handleTx(
+        chain,
+        deployedContract.revokeRole(adminRole, deployerAddress),
+      );
+    }
 
     return {
       TimelockController: deployedContract,

--- a/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.ts
+++ b/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.ts
@@ -9,6 +9,7 @@ import { HyperlaneContracts } from '../../index.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
 import { TimelockConfig } from '../types.js';
 
+import { CANCELLER_ROLE } from './constants.js';
 import { EvmTimelockFactories, evmTimelockFactories } from './contracts.js';
 
 export class EvmTimelockDeployer extends HyperlaneDeployer<
@@ -32,15 +33,72 @@ export class EvmTimelockDeployer extends HyperlaneDeployer<
     chain: string,
     config: TimelockConfig,
   ): Promise<HyperlaneContracts<EvmTimelockFactories>> {
+    const currentDeployer = this.multiProvider.getSigner(chain);
+    const deployerAddress = await currentDeployer.getAddress();
+
+    const admin = config.cancellers ? deployerAddress : config.admin;
+    const expectedFinalAdmin = config.admin ?? ethers.constants.AddressZero;
     const deployedContract = await this.deployContract(
       chain,
       'TimelockController',
       [
         config.minimumDelay,
         config.proposers,
-        config.executors,
-        config.admin ?? ethers.constants.AddressZero,
+        config.executors ?? [ethers.constants.AddressZero],
+        admin ?? ethers.constants.AddressZero,
       ],
+    );
+
+    if (!config.cancellers) {
+      return {
+        TimelockController: deployedContract,
+      };
+    }
+
+    // Remove all the proposers that should not be cancellers
+    const cancellers = new Set(config.cancellers ?? []);
+    const cancellersToRemove = config.proposers.filter(
+      (address) => !cancellers.has(address),
+    );
+
+    this.logger.info(`Revoking CANCELLER_ROLE to ${cancellersToRemove}`);
+    for (const proposer of cancellersToRemove) {
+      await this.multiProvider.handleTx(
+        chain,
+        deployedContract.revokeRole(CANCELLER_ROLE, proposer),
+      );
+    }
+
+    // Give canceller role only to the addresses in the cancellers config
+    this.logger.info(`Setting CANCELLER_ROLE to ${config.cancellers}`);
+    for (const canceller of config.cancellers) {
+      await this.multiProvider.handleTx(
+        chain,
+        deployedContract.grantRole(CANCELLER_ROLE, canceller),
+      );
+    }
+
+    const adminRole = await deployedContract.TIMELOCK_ADMIN_ROLE();
+    const isAdminSetCorrectly = await deployedContract.hasRole(
+      adminRole,
+      expectedFinalAdmin,
+    );
+    if (!isAdminSetCorrectly) {
+      this.logger.info(
+        `Granting admin role to the expected admin ${expectedFinalAdmin}`,
+      );
+      await this.multiProvider.handleTx(
+        chain,
+        deployedContract.grantRole(adminRole, expectedFinalAdmin),
+      );
+    }
+
+    this.logger.info(
+      `Revoking temporary admin role from deployer ${deployerAddress}`,
+    );
+    await this.multiProvider.handleTx(
+      chain,
+      deployedContract.revokeRole(adminRole, deployerAddress),
     );
 
     return {

--- a/typescript/sdk/src/timelock/evm/constants.ts
+++ b/typescript/sdk/src/timelock/evm/constants.ts
@@ -1,5 +1,8 @@
 import { keccak256 } from 'ethers/lib/utils.js';
 
+export const EMPTY_BYTES_32 =
+  '0x0000000000000000000000000000000000000000000000000000000000000000';
+
 export const PROPOSER_ROLE: string = keccak256(Buffer.from('PROPOSER_ROLE'));
 export const EXECUTOR_ROLE: string = keccak256(Buffer.from('EXECUTOR_ROLE'));
 export const CANCELLER_ROLE: string = keccak256(Buffer.from('CANCELLER_ROLE'));

--- a/typescript/sdk/src/timelock/types.ts
+++ b/typescript/sdk/src/timelock/types.ts
@@ -5,7 +5,8 @@ import { ZChainName, ZHash, ZNzUint } from '../metadata/customZodTypes.js';
 export const TimelockConfigSchema = z.object({
   minimumDelay: ZNzUint,
   proposers: z.array(ZHash).min(1),
-  executors: z.array(ZHash).min(1),
+  executors: z.array(ZHash).min(1).optional(),
+  cancellers: z.array(ZHash).min(1).optional(),
   admin: ZHash.optional(),
 });
 


### PR DESCRIPTION
### Description

allows to set cancellers when deploying timelocks

### Drive-by changes

- no

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

-yes

### Testing

unit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying cancellers in timelock configurations, allowing explicit assignment of who can cancel scheduled transactions.
  * Executors are now optional in timelock configurations; if not provided, anyone can execute scheduled transactions.
* **Bug Fixes**
  * Improved validation and error reporting for missing and unexpected canceller roles in timelock configurations.
* **Tests**
  * Enhanced test coverage for role assignments, executor/canceller configurations, multi-chain deployments, and transaction execution permissions in timelock deployments.
* **Chores**
  * Introduced a new constant representing a 32-byte zero-filled value for internal use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->