### PR TITLE
fix: fix circular dependency import in sdk package relying on the registry

### DIFF
--- a/.changeset/rich-pianos-watch.md
+++ b/.changeset/rich-pianos-watch.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": minor
+---
+
+Remove a circular import dependency between the sdk and registry package by not importing the IRegistry interface in the sdk

--- a/.changeset/rich-pianos-watch.md
+++ b/.changeset/rich-pianos-watch.md
@@ -1,5 +1,5 @@
 ---
-"@hyperlane-xyz/sdk": minor
+"@hyperlane-xyz/sdk": major
 ---
 
 Remove a circular import dependency between the sdk and registry package by not importing the IRegistry interface in the sdk

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -940,7 +940,7 @@ export async function getSubmitterByStrategy<T extends ProtocolType>({
     submitter: await getSubmitterBuilder<T>({
       submissionStrategy: submissionStrategy as SubmissionStrategy, // TODO: fix this
       multiProvider,
-      registry,
+      coreAddressesByChain: await registry.getAddresses(),
       additionalSubmitterFactories: {
         file: (_multiProvider: MultiProvider, metadata: any) => {
           return new EV5FileSubmitter(metadata);

--- a/typescript/sdk/src/middleware/account/InterchainAccount.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.ts
@@ -5,7 +5,6 @@ import {
   InterchainAccountRouter,
   InterchainAccountRouter__factory,
 } from '@hyperlane-xyz/core';
-import { IRegistry } from '@hyperlane-xyz/registry';
 import {
   Address,
   CallData,
@@ -231,22 +230,20 @@ export async function buildInterchainAccountApp(
   multiProvider: MultiProvider,
   chain: ChainName,
   config: AccountConfig,
-  registry: Readonly<IRegistry>,
+  addressByChain: ChainMap<Record<string, string>>,
 ): Promise<InterchainAccount> {
   if (!config.localRouter) {
     throw new Error('localRouter is required for account deployment');
   }
 
   let remoteIcaAddresses: ChainMap<{ interchainAccountRouter: Address }>;
-  const localChainAddresses = await registry.getChainAddresses(chain);
+  const localChainAddresses = addressByChain[chain];
   // if the user specified a custom router address we need to retrieve the remote ica addresses
   // configured on the user provided router, otherwise we use the ones defined in the registry
   if (
     localChainAddresses?.interchainAccountRouter &&
     eqAddress(config.localRouter, localChainAddresses.interchainAccountRouter)
   ) {
-    const addressByChain = await registry.getAddresses();
-
     remoteIcaAddresses = objMap(addressByChain, (_, chainAddresses) => ({
       interchainAccountRouter: chainAddresses.interchainAccountRouter,
     }));
@@ -290,7 +287,7 @@ export async function deployInterchainAccount(
   multiProvider: MultiProvider,
   chain: ChainName,
   config: AccountConfig,
-  registry: IRegistry,
+  registry: ChainMap<Record<string, string>>,
 ): Promise<Address> {
   const interchainAccountApp: InterchainAccount =
     await buildInterchainAccountApp(multiProvider, chain, config, registry);

--- a/typescript/sdk/src/middleware/account/InterchainAccount.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.ts
@@ -230,21 +230,21 @@ export async function buildInterchainAccountApp(
   multiProvider: MultiProvider,
   chain: ChainName,
   config: AccountConfig,
-  addressByChain: ChainMap<Record<string, string>>,
+  coreAddressesByChain: ChainMap<Record<string, string>>,
 ): Promise<InterchainAccount> {
   if (!config.localRouter) {
     throw new Error('localRouter is required for account deployment');
   }
 
   let remoteIcaAddresses: ChainMap<{ interchainAccountRouter: Address }>;
-  const localChainAddresses = addressByChain[chain];
+  const localChainAddresses = coreAddressesByChain[chain];
   // if the user specified a custom router address we need to retrieve the remote ica addresses
   // configured on the user provided router, otherwise we use the ones defined in the registry
   if (
     localChainAddresses?.interchainAccountRouter &&
     eqAddress(config.localRouter, localChainAddresses.interchainAccountRouter)
   ) {
-    remoteIcaAddresses = objMap(addressByChain, (_, chainAddresses) => ({
+    remoteIcaAddresses = objMap(coreAddressesByChain, (_, chainAddresses) => ({
       interchainAccountRouter: chainAddresses.interchainAccountRouter,
     }));
   } else {
@@ -287,10 +287,15 @@ export async function deployInterchainAccount(
   multiProvider: MultiProvider,
   chain: ChainName,
   config: AccountConfig,
-  registry: ChainMap<Record<string, string>>,
+  coreAddressesByChain: ChainMap<Record<string, string>>,
 ): Promise<Address> {
   const interchainAccountApp: InterchainAccount =
-    await buildInterchainAccountApp(multiProvider, chain, config, registry);
+    await buildInterchainAccountApp(
+      multiProvider,
+      chain,
+      config,
+      coreAddressesByChain,
+    );
   return interchainAccountApp.deployAccount(chain, config);
 }
 

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5TimelockSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5TimelockSubmitter.ts
@@ -2,9 +2,9 @@ import {
   TimelockController,
   TimelockController__factory,
 } from '@hyperlane-xyz/core';
-import { IRegistry } from '@hyperlane-xyz/registry';
 import { ProtocolType, assert } from '@hyperlane-xyz/utils';
 
+import { ChainMap } from '../../../../types.js';
 import { MultiProvider } from '../../../MultiProvider.js';
 import {
   AnnotatedEV5Transaction,
@@ -43,7 +43,7 @@ export class EV5TimelockSubmitter
   static async fromConfig(
     config: EvmTimelockControllerSubmitterProps,
     multiProvider: MultiProvider,
-    registry: Readonly<IRegistry>,
+    coreAddressesByChain: ChainMap<Record<string, string>>,
   ): Promise<EV5TimelockSubmitter> {
     const provider = multiProvider.getProvider(config.chain);
     const timelockInstance = TimelockController__factory.connect(
@@ -61,7 +61,7 @@ export class EV5TimelockSubmitter
     const proposerSubmitter = await getSubmitter<ProtocolType.Ethereum>(
       multiProvider,
       config.proposerSubmitter,
-      registry,
+      coreAddressesByChain,
     );
 
     return new EV5TimelockSubmitter(

--- a/typescript/sdk/src/providers/transactions/submitter/submitterBuilderGetter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/submitterBuilderGetter.ts
@@ -1,6 +1,6 @@
-import { IRegistry } from '@hyperlane-xyz/registry';
 import { ProtocolType, assert } from '@hyperlane-xyz/utils';
 
+import { ChainMap } from '../../../types.js';
 import { MultiProvider } from '../../MultiProvider.js';
 
 import { EvmIcaTxSubmitter } from './IcaTxSubmitter.js';
@@ -18,20 +18,20 @@ import { SubmitterMetadata } from './types.js';
 export type SubmitterBuilderSettings = {
   submissionStrategy: SubmissionStrategy;
   multiProvider: MultiProvider;
-  registry: IRegistry;
+  coreAddressesByChain: ChainMap<Record<string, string>>;
   additionalSubmitterFactories?: Record<string, SubmitterFactory>;
 };
 
 export async function getSubmitterBuilder<TProtocol extends ProtocolType>({
   submissionStrategy,
   multiProvider,
-  registry,
+  coreAddressesByChain,
   additionalSubmitterFactories,
 }: SubmitterBuilderSettings): Promise<TxSubmitterBuilder<TProtocol>> {
   const submitter = await getSubmitter<TProtocol>(
     multiProvider,
     submissionStrategy.submitter,
-    registry,
+    coreAddressesByChain,
     additionalSubmitterFactories,
   );
 
@@ -41,7 +41,7 @@ export async function getSubmitterBuilder<TProtocol extends ProtocolType>({
 export type SubmitterFactory<TProtocol extends ProtocolType = any> = (
   multiProvider: MultiProvider,
   metadata: SubmitterMetadata,
-  registry: IRegistry,
+  coreAddressesByChain: ChainMap<Record<string, string>>,
 ) => Promise<TxSubmitterInterface<TProtocol>> | TxSubmitterInterface<TProtocol>;
 
 const defaultSubmitterFactories: Record<string, SubmitterFactory> = {
@@ -74,24 +74,36 @@ const defaultSubmitterFactories: Record<string, SubmitterFactory> = {
     );
     return EV5GnosisSafeTxBuilder.create(multiProvider, metadata);
   },
-  [TxSubmitterType.INTERCHAIN_ACCOUNT]: (multiProvider, metadata, registry) => {
+  [TxSubmitterType.INTERCHAIN_ACCOUNT]: (
+    multiProvider,
+    metadata,
+    coreAddressesByChain,
+  ) => {
     assert(
       metadata.type === TxSubmitterType.INTERCHAIN_ACCOUNT,
       `Invalid metadata type: ${metadata.type}, expected ${TxSubmitterType.INTERCHAIN_ACCOUNT}`,
     );
-    return EvmIcaTxSubmitter.fromConfig(metadata, multiProvider, registry);
+    return EvmIcaTxSubmitter.fromConfig(
+      metadata,
+      multiProvider,
+      coreAddressesByChain,
+    );
   },
   [TxSubmitterType.TIMELOCK_CONTROLLER]: (
     multiProvider,
     metadata,
-    registry,
+    coreAddressesByChain,
   ) => {
     assert(
       metadata.type === TxSubmitterType.TIMELOCK_CONTROLLER,
       `Invalid metadata type: ${metadata.type}, expected ${TxSubmitterType.TIMELOCK_CONTROLLER}`,
     );
 
-    return EV5TimelockSubmitter.fromConfig(metadata, multiProvider, registry);
+    return EV5TimelockSubmitter.fromConfig(
+      metadata,
+      multiProvider,
+      coreAddressesByChain,
+    );
   },
 };
 
@@ -103,7 +115,7 @@ const defaultSubmitterFactories: Record<string, SubmitterFactory> = {
  *
  * @param multiProvider - The MultiProvider instance
  * @param submitterMetadata - The metadata defining the type and configuration of the submitter.
- * @param registry - The IRegistry instance for looking up chain-specific details.
+ * @param coreAddressesByChain - The address of the core Hyperlane deployments by chain. Used for filling some default values for the submission strategies.
  * @param additionalSubmitterFactories optional extension to extend the default registry. Can override if specifying the the same key.
  * @returns A promise that resolves to an instance of a TxSubmitterInterface.
  * @throws If no submitter factory is registered for the type specified in the metadata.
@@ -111,7 +123,7 @@ const defaultSubmitterFactories: Record<string, SubmitterFactory> = {
 export async function getSubmitter<TProtocol extends ProtocolType>(
   multiProvider: MultiProvider,
   submitterMetadata: SubmitterMetadata,
-  registry: IRegistry,
+  coreAddressesByChain: ChainMap<Record<string, string>>,
   additionalSubmitterFactories: Record<string, SubmitterFactory> = {},
 ): Promise<TxSubmitterInterface<TProtocol>> {
   const mergedSubmitterRegistry = {
@@ -124,5 +136,5 @@ export async function getSubmitter<TProtocol extends ProtocolType>(
       `No submitter factory registered for type ${submitterMetadata.type}`,
     );
   }
-  return factory(multiProvider, submitterMetadata, registry);
+  return factory(multiProvider, submitterMetadata, coreAddressesByChain);
 }


### PR DESCRIPTION
### Description

Removes `@hyperlane-xyz/registry` imports from the `sdk` package

### Drive-by changes

- None

### Related issues



### Backward compatibility

- No, the `getSubmitter` function signature and related code interface has changes

### Testing

- Manual
- e2e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated various components to use a direct mapping of core addresses by chain instead of relying on a registry interface for chain-specific details.
  * Modified function and method signatures to accept the new address mapping structure.
  * Improved internal handling of chain addresses for account and transaction submitters.

* **Chores**
  * Added documentation for a major update to the SDK package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->