### PR TITLE
feat: include insertion_block_number for listing merkle tree insertions

### DIFF
--- a/rust/main/agents/relayer/src/server/merkle_tree_insertions/list_merkle_tree_insertions.rs
+++ b/rust/main/agents/relayer/src/server/merkle_tree_insertions/list_merkle_tree_insertions.rs
@@ -141,6 +141,18 @@ mod tests {
             .expect("DB Error")
     }
 
+    fn insert_merkle_tree_insertion_block_number(
+        dbs: &HashMap<u32, HyperlaneRocksDB>,
+        domain: &HyperlaneDomain,
+        leaf_index: u32,
+        block_number: u64,
+    ) {
+        dbs.get(&domain.id())
+            .expect("DB not found")
+            .store_merkle_tree_insertion_block_number_by_leaf_index(&leaf_index, &block_number)
+            .expect("DB Error")
+    }
+
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_list_merkle_tree_insertions_db_not_found() {
@@ -195,6 +207,9 @@ mod tests {
         for insertion in insertions.iter() {
             insert_merkle_tree_insertion(&dbs, &domains[0], insertion.index(), insertion);
         }
+        for insertion in insertions.iter().take(2) {
+            insert_merkle_tree_insertion_block_number(&dbs, &domains[0], insertion.index(), 100);
+        }
 
         let leaf_index_start = 100;
         let leaf_index_end = 102;
@@ -213,14 +228,17 @@ mod tests {
 
         let expected_list = [
             TreeInsertion {
+                insertion_block_number: Some(100),
                 leaf_index: 100,
                 message_id: format!("{:?}", H256::from_low_u64_be(100)),
             },
             TreeInsertion {
+                insertion_block_number: Some(100),
                 leaf_index: 101,
                 message_id: format!("{:?}", H256::from_low_u64_be(101)),
             },
             TreeInsertion {
+                insertion_block_number: None,
                 leaf_index: 102,
                 message_id: format!("{:?}", H256::from_low_u64_be(102)),
             },

--- a/rust/main/agents/validator/src/server/merkle_tree_insertions/list_merkle_tree_insertions.rs
+++ b/rust/main/agents/validator/src/server/merkle_tree_insertions/list_merkle_tree_insertions.rs
@@ -131,6 +131,15 @@ mod tests {
             .expect("DB Error")
     }
 
+    fn insert_merkle_tree_insertion_block_number(
+        db: &HyperlaneRocksDB,
+        leaf_index: u32,
+        block_number: u64,
+    ) {
+        db.store_merkle_tree_insertion_block_number_by_leaf_index(&leaf_index, &block_number)
+            .expect("DB Error")
+    }
+
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_list_merkle_tree_insertions_empty_db() {
@@ -163,6 +172,9 @@ mod tests {
         for insertion in insertions.iter() {
             insert_merkle_tree_insertion(&db, insertion.index(), insertion);
         }
+        for insertion in insertions.iter().take(2) {
+            insert_merkle_tree_insertion_block_number(&db, insertion.index(), 100);
+        }
 
         let leaf_index_start = 100;
         let leaf_index_end = 102;
@@ -175,14 +187,17 @@ mod tests {
 
         let expected_list = [
             TreeInsertion {
+                insertion_block_number: Some(100),
                 leaf_index: 100,
                 message_id: format!("{:?}", H256::from_low_u64_be(100)),
             },
             TreeInsertion {
+                insertion_block_number: Some(100),
                 leaf_index: 101,
                 message_id: format!("{:?}", H256::from_low_u64_be(101)),
             },
             TreeInsertion {
+                insertion_block_number: None,
                 leaf_index: 102,
                 message_id: format!("{:?}", H256::from_low_u64_be(102)),
             },

--- a/rust/main/hyperlane-core/src/types/message.rs
+++ b/rust/main/hyperlane-core/src/types/message.rs
@@ -88,11 +88,11 @@ impl From<RawHyperlaneMessage> for HyperlaneMessage {
 impl From<&RawHyperlaneMessage> for HyperlaneMessage {
     fn from(m: &RawHyperlaneMessage) -> Self {
         let version = m[0];
-        let nonce: [u8; 4] = m[1..5].try_into().unwrap();
-        let origin: [u8; 4] = m[5..9].try_into().unwrap();
-        let sender: [u8; 32] = m[9..41].try_into().unwrap();
-        let destination: [u8; 4] = m[41..45].try_into().unwrap();
-        let recipient: [u8; 32] = m[45..77].try_into().unwrap();
+        let nonce: [u8; 4] = m[1..5].try_into().expect("Failed to parse nonce");
+        let origin: [u8; 4] = m[5..9].try_into().expect("Failed to parse origin");
+        let sender: [u8; 32] = m[9..41].try_into().expect("Failed to parse sender");
+        let destination: [u8; 4] = m[41..45].try_into().expect("Failed to parse destination");
+        let recipient: [u8; 32] = m[45..77].try_into().expect("Failed to parse recipient");
         let body = m[77..].into();
         Self {
             version,
@@ -164,5 +164,21 @@ impl HyperlaneMessage {
     /// Convert the message to a message id
     pub fn id(&self) -> H256 {
         H256::from_slice(Keccak256::new().chain(self.to_vec()).finalize().as_slice())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HyperlaneMessage;
+
+    #[ignore]
+    #[test]
+    fn test_decode_from_raw_body() {
+        let raw = "0x03000010f90000044d00000000000000000000000046b4edaa761ef8d2934e9f7aaf32b5bf2c9c9f670000a4ec000000000000000000000000ad8676147360dbc010504ab69c7f1b187710952700000000000000000000000037a022b833fe3876ef2a9a6c61ae444295f1b7f80000000000000000000000000000000000000000000000008ac7230489e80000";
+
+        let raw_bytes = hex::decode(&raw[2..]).unwrap();
+        let msg = HyperlaneMessage::try_from(raw_bytes).unwrap();
+
+        eprintln!("{}\n{}\n{:?}", msg, msg.version, msg.body);
     }
 }


### PR DESCRIPTION
### Description
 - Add a new field `insertion_block_number` when listing merkle tree insertions
 - This helps with manual insertions

### Related issues

https://linear.app/hyperlane-xyz/issue/ENG-1607/scope-a-path-for-fixing-relayer-dbs-that-have-indexed-reorged-events
