### PR TITLE
feat: EvmCollateralFiat minting limit

### DIFF
--- a/.changeset/brown-cougars-hammer.md
+++ b/.changeset/brown-cougars-hammer.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": minor
+---
+
+Add limit check for EvmCollateralFiat tokens

--- a/.changeset/sharp-pears-kiss.md
+++ b/.changeset/sharp-pears-kiss.md
@@ -1,5 +1,0 @@
----
-"@hyperlane-xyz/core": minor
----
-
-Update FiatToken to include `mintAllowance`

--- a/.changeset/sharp-pears-kiss.md
+++ b/.changeset/sharp-pears-kiss.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": minor
+---
+
+Update FiatToken to include `mintAllowance`

--- a/solidity/contracts/test/ERC20Test.sol
+++ b/solidity/contracts/test/ERC20Test.sol
@@ -56,6 +56,10 @@ contract FiatTokenTest is ERC20Test, IFiatToken {
         _mint(account, amount);
         return true;
     }
+
+    function minterAllowance(address _minter) public pure returns (uint256) {
+        return type(uint256).max;
+    }
 }
 
 contract XERC20Test is ERC20Test, Ownable, IXERC20 {

--- a/solidity/contracts/token/interfaces/IFiatToken.sol
+++ b/solidity/contracts/token/interfaces/IFiatToken.sol
@@ -21,4 +21,11 @@ interface IFiatToken is IERC20 {
      * @return True if the operation was successful.
      */
     function mint(address _to, uint256 _amount) external returns (bool);
+
+    /**
+     * @notice Gets the minter allowance for an account.
+     * @param _minter The address to check.
+     * @return The remaining minter allowance for the account.
+     */
+    function minterAllowance(address _minter) external view returns (uint256);
 }

--- a/typescript/sdk/src/consts/testChains.ts
+++ b/typescript/sdk/src/consts/testChains.ts
@@ -114,6 +114,14 @@ export const testScale2: ChainMetadata = {
   name: 'testscale2',
 };
 
+export const testCollateralFiat: ChainMetadata = {
+  ...test1,
+  chainId: 9913379,
+  domainId: 9913379,
+  displayName: 'Test Collateral Fiat',
+  name: 'testcollateralfiat',
+};
+
 export const testChainMetadata: ChainMap<ChainMetadata> = {
   test1,
   test2,
@@ -195,6 +203,7 @@ export const multiProtocolTestChainMetadata: ChainMap<ChainMetadata> = {
   starknetdevnet: testStarknetChain,
   testscale1: testScale1,
   testscale2: testScale2,
+  testcollateralfiat: testCollateralFiat,
 };
 
 export const multiProtocolTestChains: Array<ChainName> = Object.keys(

--- a/typescript/sdk/src/token/TokenStandard.ts
+++ b/typescript/sdk/src/token/TokenStandard.ts
@@ -151,6 +151,7 @@ export const MINT_LIMITED_STANDARDS = [
   TokenStandard.EvmHypXERC20Lockbox,
   TokenStandard.EvmHypVSXERC20,
   TokenStandard.EvmHypVSXERC20Lockbox,
+  TokenStandard.EvmHypCollateralFiat,
 ];
 
 export const TOKEN_HYP_STANDARDS = [

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -470,7 +470,6 @@ export class EvmHypCollateralFiatAdapter
       wrappedToken,
       this.getProvider(),
     );
-    console.log('fiatToken', fiatToken);
     const limit = await fiatToken.minterAllowance(this.addresses.token);
 
     return limit.toBigInt();

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -21,6 +21,7 @@ import {
   HypXERC20Lockbox,
   HypXERC20Lockbox__factory,
   HypXERC20__factory,
+  IFiatToken__factory,
   IXERC20,
   IXERC20VS,
   IXERC20VS__factory,
@@ -44,6 +45,7 @@ import { ChainName } from '../../types.js';
 import { TokenMetadata } from '../types.js';
 
 import {
+  IHypCollateralFiatAdapter,
   IHypTokenAdapter,
   IHypVSXERC20Adapter,
   IHypXERC20Adapter,
@@ -450,7 +452,7 @@ export class EvmHypCollateralAdapter
 
 export class EvmHypCollateralFiatAdapter
   extends EvmHypCollateralAdapter
-  implements IHypTokenAdapter<PopulatedTransaction>
+  implements IHypCollateralFiatAdapter<PopulatedTransaction>
 {
   /**
    * Note this may be inaccurate, as this returns the total supply
@@ -460,6 +462,18 @@ export class EvmHypCollateralFiatAdapter
   override async getBridgedSupply(): Promise<bigint> {
     const wrapped = await this.getWrappedTokenAdapter();
     return wrapped.getTotalSupply();
+  }
+
+  async getMintLimit(): Promise<bigint> {
+    const wrappedToken = await this.getWrappedTokenAddress();
+    const fiatToken = IFiatToken__factory.connect(
+      wrappedToken,
+      this.getProvider(),
+    );
+    console.log('fiatToken', fiatToken);
+    const limit = await fiatToken.minterAllowance(this.addresses.token);
+
+    return limit.toBigInt();
   }
 }
 

--- a/typescript/sdk/src/token/adapters/ITokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/ITokenAdapter.ts
@@ -117,5 +117,5 @@ export interface IXERC20VSAdapter<Tx> extends ITokenAdapter<Tx> {
 }
 
 export interface IHypCollateralFiatAdapter<Tx> extends IHypTokenAdapter<Tx> {
-  getMintLimit(): Promise<BigInt>;
+  getMintLimit(): Promise<bigint>;
 }

--- a/typescript/sdk/src/token/adapters/ITokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/ITokenAdapter.ts
@@ -115,3 +115,7 @@ export interface IXERC20VSAdapter<Tx> extends ITokenAdapter<Tx> {
     bridge: Address,
   ): Promise<Tx>;
 }
+
+export interface IHypCollateralFiatAdapter<Tx> extends IHypTokenAdapter<Tx> {
+  getMintLimit(): Promise<BigInt>;
+}

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -6,6 +6,7 @@ import { parse as yamlParse } from 'yaml';
 import {
   test1,
   test2,
+  testCollateralFiat,
   testCosmosChain,
   testScale1,
   testScale2,
@@ -43,6 +44,7 @@ describe('WarpCore', () => {
   let evmHypXERC20: Token;
   let evmHypVSXERC20: Token;
   let evmHypXERC20Lockbox: Token;
+  let evmHypCollateralFiat: Token;
   let sealevelHypSynthetic: Token;
   let cwHypCollateral: Token;
   let cw20: Token;
@@ -74,6 +76,7 @@ describe('WarpCore', () => {
       evmHypXERC20Lockbox,
       evmHypNativeScale1,
       evmHypNativeScale2,
+      evmHypCollateralFiat,
       sealevelHypSynthetic,
       cwHypCollateral,
       cw20,
@@ -337,6 +340,18 @@ describe('WarpCore', () => {
     expect(Object.values(invalidXERC20LockboxTokenRateLimit || {})[0]).to.equal(
       'Rate limit exceeded on destination',
     );
+
+    const invalidCollateralFiatTokenRateLimit = await warpCore.validateTransfer(
+      {
+        originTokenAmount: evmHypNative.amount(BIG_TRANSFER_AMOUNT),
+        destination: testCollateralFiat.name,
+        recipient: MOCK_ADDRESS,
+        sender: MOCK_ADDRESS,
+      },
+    );
+    expect(
+      Object.values(invalidCollateralFiatTokenRateLimit || {})[0],
+    ).to.equal('Rate limit exceeded on destination');
 
     const invalidCollateralXERC20LockboxToken = await warpCore.validateTransfer(
       {

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -344,7 +344,7 @@ describe('WarpCore', () => {
     const invalidCollateralFiatTokenRateLimit = await warpCore.validateTransfer(
       {
         originTokenAmount: evmHypNative.amount(BIG_TRANSFER_AMOUNT),
-        destination: testCollateralFiat.name,
+        destination: evmHypCollateralFiat.chainName,
         recipient: MOCK_ADDRESS,
         sender: MOCK_ADDRESS,
       },

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -6,7 +6,6 @@ import { parse as yamlParse } from 'yaml';
 import {
   test1,
   test2,
-  testCollateralFiat,
   testCosmosChain,
   testScale1,
   testScale2,

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -31,6 +31,7 @@ import {
 } from '../token/TokenStandard.js';
 import {
   EVM_TRANSFER_REMOTE_GAS_ESTIMATE,
+  EvmHypCollateralFiatAdapter,
   EvmHypXERC20LockboxAdapter,
 } from '../token/adapters/EvmTokenAdapter.js';
 import { IHypXERC20Adapter } from '../token/adapters/ITokenAdapter.js';
@@ -930,6 +931,13 @@ export class WarpCore {
           destinationMintLimit = max;
         }
       }
+    } else if (
+      destinationToken.standard === TokenStandard.EvmHypCollateralFiat
+    ) {
+      const adapter = destinationToken.getAdapter(
+        this.multiProvider,
+      ) as EvmHypCollateralFiatAdapter;
+      destinationMintLimit = await adapter.getMintLimit();
     }
 
     const destinationMintLimitInOriginDecimals = convertDecimalsToIntegerString(

--- a/typescript/sdk/src/warp/test-warp-core-config.yaml
+++ b/typescript/sdk/src/warp/test-warp-core-config.yaml
@@ -26,6 +26,9 @@ tokens:
       - {
           token: ethereum|testxerc20lockbox|0x9876543210987654321098765432109876543218,
         }
+      - {
+          token: ethereum|testcollateralfiat|0x4234567890123456789012345678901234567890,
+        }
   # test2 HypSynthetic token
   - chainName: test2
     standard: EvmHypSynthetic
@@ -100,6 +103,15 @@ tokens:
       - {
           token: ethereum|testscale1|0x2234567890123456789012345678901234567890,
         }
+  # testcollateralfiat token
+  - chainName: testcollateralfiat
+    standard: EvmHypCollateralFiat
+    decimals: 18
+    symbol: ETH
+    name: Ether
+    addressOrDenom: '0x4234567890123456789012345678901234567890'
+    connections:
+      - { token: ethereum|test1|0x1234567890123456789012345678901234567890 }
   # testsealevel HypSynthetic
   - chainName: testsealevel
     standard: SealevelHypSynthetic


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
This PR adds a way to include minting limit for `EvmCollateralFiat` tokens

- Update solidity interface for `IFiatToken` to include `mintingAllowance` function
- Update EvmCollateralFiat adapter to include getMintLimit() function
- Update WarpCore `validateDestinationRateLimit` to include collateral fiat tokens check
- Types, interfaces and test updates

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
Unit tests/ UI tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for the EvmHypCollateralFiat token standard, including mint limit checks and validation for transfers.
  * Added a new test chain and token configuration for "Test Collateral Fiat".
  * Enhanced the user interface to display rate limit errors when transferring to EvmHypCollateralFiat tokens.

* **Bug Fixes**
  * Improved validation to ensure accurate error reporting for rate-limited transfers involving the new token standard.

* **Tests**
  * Added tests to validate rate limit enforcement for EvmHypCollateralFiat tokens.

* **Chores**
  * Updated documentation and configuration files to include the new token and chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->