### PR TITLE
feat: `write-instructions`

### DIFF
--- a/rust/sealevel/client/src/context.rs
+++ b/rust/sealevel/client/src/context.rs
@@ -1,3 +1,8 @@
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
 use solana_client::{
     rpc_client::RpcClient,
     rpc_config::{RpcSendTransactionConfig, RpcTransactionConfig},
@@ -11,6 +16,7 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use solana_transaction_status::{EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding};
+use std::error::Error;
 use std::{cell::RefCell, io::Read};
 
 pub(crate) struct PayerKeypair {
@@ -31,6 +37,18 @@ pub(crate) struct Context {
 pub(crate) struct InstructionWithDescription {
     pub instruction: Instruction,
     pub description: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct InstructionEntry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    chain_name: Option<String>,
+    description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message_base58: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transaction_base58: Option<String>,
+    instructions: String,
 }
 
 impl<T> From<(T, Option<String>)> for InstructionWithDescription
@@ -186,10 +204,82 @@ impl<'ctx, 'rpc> TxnBuilder<'ctx, 'rpc> {
         );
     }
 
+    pub(crate) fn write_transaction_to_json(
+        &self,
+        payer: &Pubkey,
+        path: PathBuf,
+        chain_name: Option<String>,
+    ) -> Result<(), Box<dyn Error>> {
+        let final_path = if path.exists() && path.is_dir() {
+            path.join("instructions.json")
+        } else if path.extension().map_or(false, |ext| ext == "json") {
+            path.to_path_buf()
+        } else if path.exists() && path.is_file() {
+            return Err("Provided file does not have a .json extension.".into());
+        } else if path.extension().is_none() {
+            path.with_extension("json")
+        } else {
+            return Err("Invalid path provided.".into());
+        };
+        println!("Writing instructions to: {}", final_path.to_str().unwrap());
+
+        let message = Message::new(&self.instructions(), Some(payer));
+        let txn = Transaction::new_unsigned(message.clone());
+
+        let message_bytes = bincode::serialize(&message)?;
+        let transaction_bytes = bincode::serialize(&txn)?;
+
+        let message_base58 = bs58::encode(&message_bytes).into_string();
+        let transaction_base58 = bs58::encode(&transaction_bytes).into_string();
+
+        let new_entries: Vec<InstructionEntry> = self.instructions_with_descriptions
+            .iter()
+            .enumerate()
+            .map(|(_, InstructionWithDescription { description, .. })| {
+                let solana = matches!(chain_name.as_deref(), Some("solanamainnet"));
+
+                InstructionEntry {
+                    chain_name: chain_name.clone(),
+                    description: description
+                        .as_deref()
+                        .unwrap_or("No description provided")
+                        .to_string(),
+                    message_base58: if solana { None } else { Some(message_base58.clone()) },
+                    transaction_base58: if solana { Some(transaction_base58.clone()) } else { None },
+                    instructions: if solana {
+                        "https://hyperlanexyz.notion.site/Solana-Using-Squads-2016d35200d6802480acfce20350db8d".to_string()
+                    } else {
+                        "https://hyperlanexyz.notion.site/Alt-SVMs-Using-Squads-2016d35200d680d280d1eaa7565b3711".to_string()
+                    }
+                }
+            })
+            .collect();
+
+        // Read existing entries if file exists
+        let mut existing_entries: Vec<InstructionEntry> = if final_path.exists() {
+            let mut file = File::open(final_path.to_str().unwrap())?;
+            let mut contents = String::new();
+            file.read_to_string(&mut contents)?;
+            serde_json::from_str(&contents).unwrap_or_default()
+        } else {
+            vec![]
+        };
+
+        // Append new entries
+        existing_entries.extend(new_entries);
+
+        // Write back to file
+        let json_str = serde_json::to_string_pretty(&existing_entries)?;
+        let mut file = File::create(final_path.to_str().unwrap())?;
+        file.write_all(json_str.as_bytes())?;
+
+        Ok(())
+    }
+
     pub(crate) fn send_with_payer(self) -> Option<EncodedConfirmedTransactionWithStatusMeta> {
         let payer_signer = self.ctx.payer_signer();
         let payer_pubkey = self.ctx.payer_pubkey;
-        self.send(&[payer_signer.as_deref()], &payer_pubkey)
+        self.send(&[payer_signer.as_deref()], &payer_pubkey, None, None)
     }
 
     /// Sends the transaction with a signer for the given pubkey.
@@ -199,15 +289,19 @@ impl<'ctx, 'rpc> TxnBuilder<'ctx, 'rpc> {
     pub(crate) fn send_with_pubkey_signer(
         self,
         pubkey: &Pubkey,
+        instructions_path: Option<PathBuf>,
+        chain_name: Option<String>,
     ) -> Option<EncodedConfirmedTransactionWithStatusMeta> {
         let signer = self.ctx.signer_for_pubkey(pubkey);
-        self.send(&[signer.as_deref()], pubkey)
+        self.send(&[signer.as_deref()], pubkey, instructions_path, chain_name)
     }
 
     pub(crate) fn send(
         self,
         maybe_signers: &[Option<&dyn Signer>],
         payer: &Pubkey,
+        instructions_path: Option<PathBuf>,
+        chain_name: Option<String>,
     ) -> Option<EncodedConfirmedTransactionWithStatusMeta> {
         // If the payer can't sign, it's presumed that the payer is intended
         // to be a Squads multisig, which must be submitted via a separate
@@ -217,10 +311,16 @@ impl<'ctx, 'rpc> TxnBuilder<'ctx, 'rpc> {
         if maybe_signers.iter().any(|s| s.is_none()) {
             println!("Transaction to be submitted via Squads multisig:");
 
-            self.pretty_print_transaction(payer);
+            if let Some(p) = instructions_path {
+                self.write_transaction_to_json(payer, p, chain_name)
+                    .expect("Failed to write transaction to JSON");
+            } else {
+                println!("To write the transaction to an instructions file, a path needs to be provided. Continuing to print the transactions.");
 
-            wait_for_user_confirmation();
+                self.pretty_print_transaction(payer);
 
+                wait_for_user_confirmation()
+            }
             return None;
         }
 

--- a/rust/sealevel/client/src/helloworld.rs
+++ b/rust/sealevel/client/src/helloworld.rs
@@ -214,5 +214,6 @@ fn deploy_helloworld(ctx: &mut Context, deploy: HelloWorldDeploy) {
         deploy.env_args.environments_dir,
         &deploy.env_args.environment,
         deploy.built_so_dir,
+        Option::from(deploy.instructions_file),
     )
 }

--- a/rust/sealevel/client/src/helloworld.rs
+++ b/rust/sealevel/client/src/helloworld.rs
@@ -214,6 +214,6 @@ fn deploy_helloworld(ctx: &mut Context, deploy: HelloWorldDeploy) {
         deploy.env_args.environments_dir,
         &deploy.env_args.environment,
         deploy.built_so_dir,
-        Option::from(deploy.instructions_file),
+        deploy.write_instructions,
     )
 }

--- a/rust/sealevel/client/src/igp.rs
+++ b/rust/sealevel/client/src/igp.rs
@@ -239,6 +239,8 @@ pub(crate) fn process_igp_cmd(mut ctx: Context, cmd: IgpCmd) {
                     Some(&unique_gas_payment_keypair),
                 ],
                 &ctx.payer_pubkey,
+                None,
+                None,
             );
 
             println!(

--- a/rust/sealevel/client/src/main.rs
+++ b/rust/sealevel/client/src/main.rs
@@ -158,6 +158,8 @@ pub(crate) struct WarpRouteDeploy {
     registry: PathBuf,
     #[arg(long)]
     ata_payer_funding_amount: Option<u64>,
+    #[arg(long)]
+    instructions_path: Option<PathBuf>,
 }
 
 #[derive(Args)]
@@ -711,6 +713,8 @@ pub(crate) struct HelloWorldDeploy {
     registry: PathBuf,
     #[arg(long)]
     context: String,
+    #[arg(long)]
+    instructions_file: PathBuf,
 }
 
 #[derive(Args)]
@@ -1241,6 +1245,8 @@ fn process_token_cmd(mut ctx: Context, cmd: TokenCmd) {
                     Some(&unique_message_account_keypair),
                 ],
                 &ctx.payer_pubkey,
+                None,
+                None,
             );
             // Print the output so it can be used in e2e tests
             println!("{:?}", tx_result);

--- a/rust/sealevel/client/src/main.rs
+++ b/rust/sealevel/client/src/main.rs
@@ -159,7 +159,7 @@ pub(crate) struct WarpRouteDeploy {
     #[arg(long)]
     ata_payer_funding_amount: Option<u64>,
     #[arg(long)]
-    instructions_path: Option<PathBuf>,
+    write_instructions: bool,
 }
 
 #[derive(Args)]
@@ -714,7 +714,7 @@ pub(crate) struct HelloWorldDeploy {
     #[arg(long)]
     context: String,
     #[arg(long)]
-    instructions_file: PathBuf,
+    write_instructions: bool,
 }
 
 #[derive(Args)]

--- a/rust/sealevel/client/src/router.rs
+++ b/rust/sealevel/client/src/router.rs
@@ -289,7 +289,7 @@ pub(crate) fn deploy_routers<
     environments_dir_path: PathBuf,
     environment: &str,
     built_so_dir_path: PathBuf,
-    instructions_path: Option<PathBuf>,
+    write_instructions: bool,
 ) {
     // Load the app configs from the app config file.
     let app_config_file = File::open(app_config_file_path).unwrap();
@@ -306,6 +306,12 @@ pub(crate) fn deploy_routers<
     let keys_dir = create_new_directory(&deploy_dir, "keys");
 
     let existing_program_ids = read_router_program_ids(&deploy_dir);
+
+    let instructions_path = if write_instructions {
+        Some(deploy_dir.join("instructions.yaml"))
+    } else {
+        None
+    };
 
     // Builds a HashMap of all the foreign deployments from the app config.
     // These domains with foreign deployments will not have any txs / deployments

--- a/rust/sealevel/client/src/warp_route.rs
+++ b/rust/sealevel/client/src/warp_route.rs
@@ -158,7 +158,7 @@ pub(crate) fn process_warp_route_cmd(mut ctx: Context, cmd: WarpRouteCmd) {
                 deploy.env_args.environments_dir,
                 &deploy.env_args.environment,
                 deploy.built_so_dir,
-                deploy.instructions_path,
+                deploy.write_instructions,
             );
         }
         WarpRouteSubCmd::DestinationGas(args) => {


### PR DESCRIPTION
### Description

This PR introduces `--write-instructions` flag to warp deploys to write the instructions that need to be submitted via Squads multisig to a file in order to share it.

### Drive-by changes

N/A

### Related issues

N/A

### Backward compatibility

Yes. If `--write-instructions` is not set, the CLI behaviour remains the same and just prints the transactions. 

### Testing

Manual
