### PR TITLE
feat: Add support for update limits with wonderland XERC20

### DIFF
--- a/solidity/contracts/token/interfaces/IXERC20WL.sol
+++ b/solidity/contracts/token/interfaces/IXERC20WL.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.4 <0.9.0;
+
+interface IXERC20WL {
+    /**
+     * @notice Emits when a lockbox is set
+     *
+     * @param _lockbox The address of the lockbox
+     */
+    event LockboxSet(address _lockbox);
+
+    /**
+     * @notice Emits when a limit is set
+     *
+     * @param _mintingLimit The updated minting limit we are setting to the bridge
+     * @param _burningLimit The updated burning limit we are setting to the bridge
+     * @param _bridge The address of the bridge we are setting the limit too
+     */
+    event BridgeLimitsSet(
+        uint256 _mintingLimit,
+        uint256 _burningLimit,
+        address indexed _bridge
+    );
+
+    /**
+     * @notice Reverts when a user with too low of a limit tries to call mint/burn
+     */
+    error IXERC20_NotHighEnoughLimits();
+
+    /**
+     * @notice Reverts when caller is not the factory
+     */
+    error IXERC20_NotFactory();
+
+    /**
+     * @notice Reverts when limits are too high
+     */
+    error IXERC20_LimitsTooHigh();
+
+    /**
+     * @notice Contains the full minting and burning data for a particular bridge
+     *
+     * @param minterParams The minting parameters for the bridge
+     * @param burnerParams The burning parameters for the bridge
+     */
+    struct Bridge {
+        BridgeParameters minterParams;
+        BridgeParameters burnerParams;
+    }
+
+    /**
+     * @notice Contains the mint or burn parameters for a bridge
+     *
+     * @param timestamp The timestamp of the last mint/burn
+     * @param ratePerSecond The rate per second of the bridge
+     * @param maxLimit The max limit of the bridge
+     * @param currentLimit The current limit of the bridge
+     */
+    struct BridgeParameters {
+        uint256 timestamp;
+        uint256 ratePerSecond;
+        uint256 maxLimit;
+        uint256 currentLimit;
+    }
+
+    /**
+     * @notice Sets the lockbox address
+     *
+     * @param _lockbox The address of the lockbox
+     */
+    function setLockbox(address _lockbox) external;
+
+    /**
+     * @notice Updates the limits of any bridge
+     * @dev Can only be called by the owner
+     * @param _mintingLimit The updated minting limit we are setting to the bridge
+     * @param _burningLimit The updated burning limit we are setting to the bridge
+     * @param _bridge The address of the bridge we are setting the limits too
+     */
+    function setLimits(
+        address _bridge,
+        uint256 _mintingLimit,
+        uint256 _burningLimit
+    ) external;
+
+    /**
+     * @notice Returns the max limit of a minter
+     *
+     * @param _minter The minter we are viewing the limits of
+     *  @return _limit The limit the minter has
+     */
+    function mintingMaxLimitOf(
+        address _minter
+    ) external view returns (uint256 _limit);
+
+    /**
+     * @notice Returns the max limit of a bridge
+     *
+     * @param _bridge the bridge we are viewing the limits of
+     * @return _limit The limit the bridge has
+     */
+    function burningMaxLimitOf(
+        address _bridge
+    ) external view returns (uint256 _limit);
+
+    /**
+     * @notice Returns the current limit of a minter
+     *
+     * @param _minter The minter we are viewing the limits of
+     * @return _limit The limit the minter has
+     */
+    function mintingCurrentLimitOf(
+        address _minter
+    ) external view returns (uint256 _limit);
+
+    /**
+     * @notice Returns the current limit of a bridge
+     *
+     * @param _bridge the bridge we are viewing the limits of
+     * @return _limit The limit the bridge has
+     */
+    function burningCurrentLimitOf(
+        address _bridge
+    ) external view returns (uint256 _limit);
+
+    /**
+     * @notice Mints tokens for a user
+     * @dev Can only be called by a minter
+     * @param _user The address of the user who needs tokens minted
+     * @param _amount The amount of tokens being minted
+     */
+    function mint(address _user, uint256 _amount) external;
+
+    /**
+     * @notice Burns tokens for a user
+     * @dev Can only be called by a minter
+     * @param _user The address of the user who needs tokens burned
+     * @param _amount The amount of tokens being burned
+     */
+    function burn(address _user, uint256 _amount) external;
+}

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getoUSDTTokenWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getoUSDTTokenWarpConfig.ts
@@ -10,6 +10,7 @@ import {
   TokenType,
   XERC20LimitConfig,
   XERC20TokenExtraBridgesLimits,
+  XERC20Type,
 } from '@hyperlane-xyz/sdk';
 import { Address, assert } from '@hyperlane-xyz/utils';
 
@@ -239,6 +240,7 @@ const productionXERC20TokenAddress =
   '0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189';
 
 const zeroLimits: XERC20LimitConfig = {
+  type: XERC20Type.Velo,
   bufferCap: '0',
   rateLimitPerSecond: '0',
 };
@@ -255,6 +257,7 @@ const productionCCIPTokenPoolAddresses: ChainMap<Address> = {
 };
 
 const productionCCIPTokenPoolLimits: XERC20LimitConfig = {
+  type: XERC20Type.Velo,
   bufferCap: upperBufferCap,
   rateLimitPerSecond: productionDefaultRateLimitPerSecond,
 };
@@ -264,6 +267,7 @@ const productionExtraBridges: ChainMap<XERC20TokenExtraBridgesLimits[]> = {
     {
       lockbox: productionEthereumXERC20LockboxAddress,
       limits: {
+        type: XERC20Type.Velo,
         bufferCap: productionBufferCapByChain.ethereum,
         rateLimitPerSecond: productionRateLimitByChain.ethereum,
       },
@@ -460,6 +464,7 @@ const stagingExtraBridges: ChainMap<XERC20TokenExtraBridgesLimits[]> = {
     {
       lockbox: stagingEthereumXERC20LockboxAddress,
       limits: {
+        type: XERC20Type.Velo,
         bufferCap: stagingBufferCapByChain.ethereum,
         rateLimitPerSecond: stagingRateLimitByChain.ethereum,
       },
@@ -584,6 +589,7 @@ function generateoUSDTTokenConfig(
         token: xERC20AddressesByChain[chain],
         xERC20: {
           warpRouteLimits: {
+            type: XERC20Type.Velo,
             rateLimitPerSecond: rateLimitPerSecondPerChain[chain],
             bufferCap: bufferCapPerChain[chain],
           },

--- a/typescript/infra/scripts/xerc20/xerc20wl-add-bridge.ts
+++ b/typescript/infra/scripts/xerc20/xerc20wl-add-bridge.ts
@@ -8,7 +8,7 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import {
-  addWLBridgeToChain,
+  addBridgeToChainWL,
   deriveWLBridgesConfig,
   getAndValidateBridgesToUpdate,
   getWarpConfigsAndArtifacts,
@@ -49,7 +49,7 @@ async function main() {
 
   for (const bridgeConfig of bridgesToUpdate) {
     try {
-      await addWLBridgeToChain({
+      await addBridgeToChainWL({
         chain: bridgeConfig.chain,
         bridgeConfig,
         multiProtocolProvider,

--- a/typescript/infra/scripts/xerc20/xerc20wl-add-bridge.ts
+++ b/typescript/infra/scripts/xerc20/xerc20wl-add-bridge.ts
@@ -1,0 +1,83 @@
+import chalk from 'chalk';
+
+import {
+  LogFormat,
+  LogLevel,
+  configureRootLogger,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
+
+import {
+  addWLBridgeToChain,
+  deriveWLBridgesConfig,
+  getAndValidateBridgesToUpdate,
+  getWarpConfigsAndArtifacts,
+} from '../../src/xerc20/utils.js';
+import {
+  getArgs,
+  withChains,
+  withDryRun,
+  withWarpRouteIdRequired,
+} from '../agent-utils.js';
+import { getEnvironmentConfig } from '../core-utils.js';
+
+// Designed to work with Wonderland variant of xERC20: https://github.com/hyperlane-xyz/xERC20
+async function main() {
+  configureRootLogger(LogFormat.Pretty, LogLevel.Info);
+  const { environment, warpRouteId, chains, dryRun } = await withChains(
+    withWarpRouteIdRequired(withDryRun(getArgs())),
+  ).argv;
+
+  const { warpDeployConfig, warpCoreConfig } =
+    getWarpConfigsAndArtifacts(warpRouteId);
+
+  const envConfig = getEnvironmentConfig(environment);
+  const multiProtocolProvider = await envConfig.getMultiProtocolProvider();
+  const envMultiProvider = await envConfig.getMultiProvider();
+
+  const bridgesConfig = await deriveWLBridgesConfig(
+    warpDeployConfig,
+    warpCoreConfig,
+    envMultiProvider,
+  );
+
+  // if chains are provided, validate that they are in the warp config
+  // throw an error if they are not
+  const bridgesToUpdate = getAndValidateBridgesToUpdate(chains, bridgesConfig);
+
+  const erroredChains: string[] = [];
+
+  for (const bridgeConfig of bridgesToUpdate) {
+    try {
+      await addWLBridgeToChain({
+        chain: bridgeConfig.chain,
+        bridgeConfig,
+        multiProtocolProvider,
+        envMultiProvider,
+        dryRun,
+      });
+    } catch (e) {
+      rootLogger.error(
+        chalk.red(
+          `Error occurred while adding bridge to chain ${bridgeConfig.chain}: ${e}`,
+        ),
+      );
+      erroredChains.push(bridgeConfig.chain);
+    }
+  }
+
+  if (erroredChains.length > 0) {
+    rootLogger.error(
+      chalk.red(
+        `Errors occurred on the following chains: ${erroredChains.join(', ')}`,
+      ),
+    );
+  }
+}
+
+main()
+  .then()
+  .catch((e) => {
+    rootLogger.error(e);
+    process.exit(1);
+  });

--- a/typescript/infra/src/xerc20/utils.ts
+++ b/typescript/infra/src/xerc20/utils.ts
@@ -161,7 +161,7 @@ export async function addBridgeToChain({
   }
 }
 
-export async function addWLBridgeToChain({
+export async function addBridgeToChainWL({
   chain,
   bridgeConfig,
   multiProtocolProvider,

--- a/typescript/infra/src/xerc20/utils.ts
+++ b/typescript/infra/src/xerc20/utils.ts
@@ -852,10 +852,10 @@ function humanReadableLimit(limit: bigint, decimals: number): string {
     .toString();
 }
 
-export function getAndValidateBridgesToUpdate(
+export function getAndValidateBridgesToUpdate<T extends BridgeConfigBase>(
   chains: string[] | undefined,
-  bridgesConfig: BridgeConfigVS[],
-): BridgeConfigVS[] {
+  bridgesConfig: T[],
+): T[] {
   // if no chains are provided, return all configs
   if (!chains || chains.length === 0) {
     return bridgesConfig;

--- a/typescript/infra/src/xerc20/utils.ts
+++ b/typescript/infra/src/xerc20/utils.ts
@@ -646,13 +646,11 @@ export async function deriveBridgesConfig(
       throw new Error(`Missing "decimals" for chain: ${chainName}`);
     }
 
-    assert(
-      xERC20 && xERC20.warpRouteLimits.type === XERC20Type.Velo,
-      `Only supports ${XERC20Type.Velo}`,
-    );
+    if (!xERC20 || xERC20.warpRouteLimits.type !== XERC20Type.Velo) {
+      continue;
+    }
 
     if (
-      !xERC20 ||
       !xERC20.warpRouteLimits.bufferCap ||
       !xERC20.warpRouteLimits.rateLimitPerSecond
     ) {

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -597,6 +597,7 @@ export {
   EvmNativeTokenAdapter,
   EvmTokenAdapter,
   EvmXERC20VSAdapter,
+  EvmXERC20WLAdapter,
 } from './token/adapters/EvmTokenAdapter.js';
 export {
   IHypTokenAdapter,

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -712,6 +712,7 @@ export {
   WarpRouteDeployConfigSchema,
   WarpRouteDeployConfigSchemaErrors,
   XERC20LimitConfig,
+  XERC20Type,
   XERC20TokenExtraBridgesLimits,
   XERC20TokenMetadata,
 } from './token/types.js';

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -64,6 +64,7 @@ import {
   OwnerStatus,
   TokenMetadata,
   XERC20TokenMetadata,
+  XERC20Type,
   isMovableCollateralTokenConfig,
 } from './types.js';
 import { getExtraLockBoxConfigs } from './xerc20.js';
@@ -451,9 +452,11 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
         logger: this.logger,
       });
 
+      // TODO: fix this such that it fetches from WL's values too
       return {
         xERC20: {
           warpRouteLimits: {
+            type: XERC20Type.Velo,
             rateLimitPerSecond: (
               await xERC20.rateLimitPerSecond(warpRouteAddress)
             ).toString(),

--- a/typescript/sdk/src/token/adapters/ITokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/ITokenAdapter.ts
@@ -30,6 +30,11 @@ export interface RateLimitMidPoint {
   midPoint: bigint;
 }
 
+export interface RateLimitXERC20WL {
+  mint: bigint;
+  burn: bigint;
+}
+
 export interface ITokenAdapter<Tx> {
   getBalance(address: Address): Promise<bigint>;
   getTotalSupply(): Promise<bigint | undefined>;
@@ -114,6 +119,10 @@ export interface IXERC20VSAdapter<Tx> extends ITokenAdapter<Tx> {
     rateLimitPerSecond: bigint,
     bridge: Address,
   ): Promise<Tx>;
+}
+
+export interface IXERC20WLAdapter<Tx> extends ITokenAdapter<Tx> {
+  getRateLimits(bridge: Address): Promise<RateLimitXERC20WL>;
 }
 
 export interface IHypCollateralFiatAdapter<Tx> extends IHypTokenAdapter<Tx> {

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -115,22 +115,39 @@ export const CollateralTokenConfigSchema = TokenMetadataSchema.partial().extend(
 export type CollateralTokenConfig = z.infer<typeof CollateralTokenConfigSchema>;
 export const isCollateralTokenConfig = isCompliant(CollateralTokenConfigSchema);
 
+export const XERC20Type = {
+  Velo: 'velo',
+  Wonderland: 'wonderland',
+} as const;
+
 const xERC20LimitConfigSchema = z.object({
+  type: z.literal(XERC20Type.Velo),
   bufferCap: z.string().optional(),
   rateLimitPerSecond: z.string().optional(),
 });
 export type XERC20LimitConfig = z.infer<typeof xERC20LimitConfigSchema>;
 
+const xERC20LimitWLConfigSchema = z.object({
+  type: z.literal(XERC20Type.Wonderland),
+  mint: z.string().optional(),
+  burn: z.string().optional(),
+});
+export type XERC20LimitWLConfig = z.infer<typeof xERC20LimitWLConfigSchema>;
+
+const xERC20Limits = z.discriminatedUnion('type', [
+  xERC20LimitConfigSchema,
+  xERC20LimitWLConfigSchema,
+]);
 const xERC20ExtraBridgesLimitConfigsSchema = z.object({
   lockbox: z.string(),
-  limits: xERC20LimitConfigSchema,
+  limits: xERC20Limits,
 });
 
 const xERC20TokenMetadataSchema = z.object({
   xERC20: z
     .object({
       extraBridges: z.array(xERC20ExtraBridgesLimitConfigsSchema).optional(),
-      warpRouteLimits: xERC20LimitConfigSchema,
+      warpRouteLimits: xERC20Limits,
     })
     .optional(),
 });

--- a/typescript/sdk/src/token/xerc20.ts
+++ b/typescript/sdk/src/token/xerc20.ts
@@ -14,7 +14,7 @@ import { GetEventLogsResponse } from '../rpc/evm/types.js';
 import { viemLogFromGetEventLogsResponse } from '../rpc/evm/utils.js';
 import { ChainNameOrId } from '../types.js';
 
-import { XERC20TokenExtraBridgesLimits } from './types.js';
+import { XERC20TokenExtraBridgesLimits, XERC20Type } from './types.js';
 
 const minimalXERC20VSABI = [
   {
@@ -191,6 +191,7 @@ async function getLockboxesFromLogs(
     .map((log) => ({
       lockbox: log.args.bridge,
       limits: {
+        type: XERC20Type.Velo,
         bufferCap: log.args.bufferCap.toString(),
         rateLimitPerSecond: log.args.rateLimitPerSecond.toString(),
       },


### PR DESCRIPTION
### Description
This PR adds support for updating the limits on wonderland variant of XERC20 by:
- Add xerc20wl-add-bridge.ts
- Add WL XERC20 adapater
- Add WL XERC20 contract Interface

### Drive-by changes
- Add `XERC20Type` discriminator to allow narrowing of `xERC20LimitConfigSchema` and `xERC20LimitWLConfigSchema` 
- Update `oUSDT` to include XERC20Type
- 

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
