### PR TITLE
Xeno/fallback to rpc when fetching timelock data fails using explorer api

### DIFF
--- a/.changeset/gentle-toes-admire.md
+++ b/.changeset/gentle-toes-admire.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": minor
+---
+
+Add fallback logic to the `EvmEventLogsReader` to use the rpc when the block explorer api request fails

--- a/typescript/infra/src/utils/timelock.ts
+++ b/typescript/infra/src/utils/timelock.ts
@@ -137,6 +137,17 @@ export async function timelockConfigMatches({
   return { matches: issues.length === 0, issues };
 }
 
+const rpcBlockRangesByChain: ChainMap<number> = {
+  // The rpc limits to a max of 1024 blocks
+  moonbeam: 1024,
+  // The rpc limits to a max of 5000 blocks
+  merlin: 5000,
+  // The rpc limits to a max of 1000 blocks
+  xlayer: 1000,
+  // The rpc limits to a max of 1000 blocks
+  dogechain: 5000,
+};
+
 export function getTimelockConfigs({
   chains,
   owners,
@@ -204,7 +215,7 @@ export async function getTimelockPendingTxs(
         chain,
         multiProvider,
         timelockAddress,
-        paginationBlockRange: 5_000,
+        paginationBlockRange: rpcBlockRangesByChain[chain] ?? 10_000,
       });
 
       let scheduledTxs: Awaited<


### PR DESCRIPTION
### Description

Updates the `EvmEventLogsReader` to fallback to use the RPC when block explorer APi requests fail. The only chains where the script for retrieving timelock txs are:
- `nero`
- `reactive`
- `nibiru`
- `evmos`
- `oortmainnet`

Note:
- merge #6799 first

### Drive-by changes

- No

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

- Yes

### Testing

- Manual
