### PR TITLE
refactor: Refactor building mailboxes as part of destination chains

### DIFF
--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -144,9 +144,9 @@ impl BaseAgent for Validator {
             .expect("Failed to build checkpoint syncer")
             .into();
 
-        let mailbox = settings
-            .build_mailbox(&settings.origin_chain, &metrics)
-            .await?;
+        let origin_chain_conf = core.settings.chain_setup(&settings.origin_chain)?.clone();
+
+        let mailbox = origin_chain_conf.build_mailbox(&metrics).await?;
 
         let merkle_tree_hook = settings
             .build_merkle_tree_hook(&settings.origin_chain, &metrics)
@@ -155,8 +155,6 @@ impl BaseAgent for Validator {
         let validator_announce = settings
             .build_validator_announce(&settings.origin_chain, &metrics)
             .await?;
-
-        let origin_chain_conf = core.settings.chain_setup(&settings.origin_chain)?.clone();
 
         let contract_sync_metrics = Arc::new(ContractSyncMetrics::new(&metrics));
 

--- a/rust/main/hyperlane-base/src/settings/base.rs
+++ b/rust/main/hyperlane-base/src/settings/base.rs
@@ -6,7 +6,7 @@ use futures_util::future::join_all;
 use hyperlane_core::{
     HyperlaneDomain, HyperlaneLogStore, HyperlaneProvider,
     HyperlaneSequenceAwareIndexerStoreReader, HyperlaneWatermarkedLogStore, InterchainGasPaymaster,
-    Mailbox, MerkleTreeHook, MultisigIsm, SequenceAwareIndexer, ValidatorAnnounce, H256,
+    MerkleTreeHook, MultisigIsm, SequenceAwareIndexer, ValidatorAnnounce, H256,
 };
 use hyperlane_operation_verifier::ApplicationOperationVerifier;
 
@@ -153,7 +153,6 @@ pub type SequenceIndexer<T> = Arc<dyn SequenceAwareIndexer<T>>;
 impl Settings {
     build_chain_conf_fns!(build_application_operation_verifier, build_application_operation_verifiers -> dyn ApplicationOperationVerifier);
     build_chain_conf_fns!(build_interchain_gas_paymaster, build_interchain_gas_paymasters -> dyn InterchainGasPaymaster);
-    build_chain_conf_fns!(build_mailbox, build_mailboxes -> dyn Mailbox);
     build_chain_conf_fns!(build_merkle_tree_hook, build_merkle_tree_hooks -> dyn MerkleTreeHook);
     build_chain_conf_fns!(build_provider, build_providers -> dyn HyperlaneProvider);
     build_chain_conf_fns!(build_validator_announce, build_validator_announces -> dyn ValidatorAnnounce);


### PR DESCRIPTION
### Description

Refactor building mailboxes as part of destination chains

### Drive-by changes

- Remove some unnecessary qualification on logging.

### Related issues

- Contributes into https://linear.app/hyperlane-xyz/issue/ENG-1929/refactor-relayer-start-up-for-destination

### Backward compatibility

Yes

### Testing

Unit tests