### PR TITLE
refactor: Add app operation verifier and ccip signers into destination chain init

### DIFF
--- a/rust/main/agents/relayer/src/msg/op_batch.rs
+++ b/rust/main/agents/relayer/src/msg/op_batch.rs
@@ -413,7 +413,7 @@ mod tests {
             ))),
             transaction_gas_limit: Default::default(),
             metrics: dummy_submission_metrics(),
-            application_operation_verifier: Some(Arc::new(DummyApplicationOperationVerifier {})),
+            application_operation_verifier: Arc::new(DummyApplicationOperationVerifier {}),
         });
 
         let attempts = 2;

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -80,7 +80,7 @@ pub struct MessageContext {
     pub transaction_gas_limit: Option<U256>,
     pub metrics: MessageSubmissionMetrics,
     /// Application operation verifier
-    pub application_operation_verifier: Option<Arc<dyn ApplicationOperationVerifier>>,
+    pub application_operation_verifier: Arc<dyn ApplicationOperationVerifier>,
 }
 
 /// A message that is pending processing and submission.
@@ -965,7 +965,6 @@ impl PendingMessage {
         match self
             .ctx
             .application_operation_verifier
-            .as_ref()?
             .verify(&self.app_context, &self.message)
             .await
         {

--- a/rust/main/agents/relayer/src/relayer/destination.rs
+++ b/rust/main/agents/relayer/src/relayer/destination.rs
@@ -87,6 +87,7 @@ impl DestinationFactory {
         domain: &HyperlaneDomain,
         chain_conf: &ChainConf,
     ) -> Result<Arc<dyn ApplicationOperationVerifier>, FactoryError> {
+        let start_entity_init = Instant::now();
         let verifier = chain_conf
             .build_application_operation_verifier(self.core_metrics.as_ref())
             .await
@@ -97,6 +98,11 @@ impl DestinationFactory {
                 )
             })?
             .into();
+        self.measure(
+            domain,
+            "applictaion_operation_verifier",
+            start_entity_init.elapsed(),
+        );
 
         Ok(verifier)
     }
@@ -148,11 +154,13 @@ impl DestinationFactory {
         domain: &HyperlaneDomain,
         chain_conf: &ChainConf,
     ) -> Result<Arc<dyn Mailbox>, FactoryError> {
+        let start_entity_init = Instant::now();
         let mailbox = chain_conf
             .build_mailbox(self.core_metrics.as_ref())
             .await
             .map_err(|e| FactoryError::MailboxCreationFailed(domain.to_string(), e.to_string()))?
             .into();
+        self.measure(domain, "mailbox", start_entity_init.elapsed());
 
         Ok(mailbox)
     }

--- a/rust/main/agents/relayer/src/test_utils/dummy_data.rs
+++ b/rust/main/agents/relayer/src/test_utils/dummy_data.rs
@@ -123,6 +123,6 @@ pub fn dummy_message_context(
         origin_gas_payment_enforcer: Arc::new(RwLock::new(GasPaymentEnforcer::new([], db.clone()))),
         transaction_gas_limit: Default::default(),
         metrics: dummy_submission_metrics(),
-        application_operation_verifier: Some(Arc::new(DummyApplicationOperationVerifier {})),
+        application_operation_verifier: Arc::new(DummyApplicationOperationVerifier {}),
     }
 }

--- a/rust/main/hyperlane-base/src/settings/base.rs
+++ b/rust/main/hyperlane-base/src/settings/base.rs
@@ -8,7 +8,6 @@ use hyperlane_core::{
     HyperlaneSequenceAwareIndexerStoreReader, HyperlaneWatermarkedLogStore, InterchainGasPaymaster,
     MerkleTreeHook, MultisigIsm, SequenceAwareIndexer, ValidatorAnnounce, H256,
 };
-use hyperlane_operation_verifier::ApplicationOperationVerifier;
 
 use crate::{
     cursors::{CursorType, Indexable},
@@ -151,7 +150,6 @@ macro_rules! build_chain_conf_fns {
 pub type SequenceIndexer<T> = Arc<dyn SequenceAwareIndexer<T>>;
 
 impl Settings {
-    build_chain_conf_fns!(build_application_operation_verifier, build_application_operation_verifiers -> dyn ApplicationOperationVerifier);
     build_chain_conf_fns!(build_interchain_gas_paymaster, build_interchain_gas_paymasters -> dyn InterchainGasPaymaster);
     build_chain_conf_fns!(build_merkle_tree_hook, build_merkle_tree_hooks -> dyn MerkleTreeHook);
     build_chain_conf_fns!(build_provider, build_providers -> dyn HyperlaneProvider);


### PR DESCRIPTION
### Description

Add app operation verifier and ccip signers into destination chain init

### Related issues

- Contributes into https://linear.app/hyperlane-xyz/issue/ENG-1929/refactor-relayer-start-up-for-destination

### Backward compatibility

Yes

### Testing

None