### PR TITLE
feat: add metrics for detecting if merkle root from validators different from relayer internal root

### DIFF
--- a/rust/main/agents/relayer/src/metrics/message_submission.rs
+++ b/rust/main/agents/relayer/src/metrics/message_submission.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use maplit::hashmap;
-use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge};
+use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 
 use hyperlane_base::CoreMetrics;
 use hyperlane_core::{HyperlaneDomain, HyperlaneMessage};
@@ -27,6 +27,9 @@ pub struct MessageSubmissionMetrics {
     pub metadata_build_count: IntCounterVec,
     /// Total number of seconds spent building different types of metadata.
     pub metadata_build_duration: CounterVec,
+
+    /// Indicator for merkle root mismatch
+    pub merkle_root_mismatch: IntGaugeVec,
 }
 
 impl MessageSubmissionMetrics {
@@ -50,6 +53,7 @@ impl MessageSubmissionMetrics {
                 .with_label_values(&[origin, destination]),
             metadata_build_count: metrics.metadata_build_count(),
             metadata_build_duration: metrics.metadata_build_duration(),
+            merkle_root_mismatch: metrics.merkle_root_mismatch(),
         }
     }
 

--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -339,7 +339,7 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
         // If any inner ISMs are refusing to build metadata, we propagate just the first refusal.
         for sub_module_res in sub_modules_and_metas.iter() {
             if let Err(MetadataBuildError::Refused(s)) = sub_module_res {
-                return Err(MetadataBuildError::Refused(s.to_string()));
+                return Err(MetadataBuildError::Refused(s.clone()));
             }
         }
 

--- a/rust/main/agents/relayer/src/msg/metadata/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base.rs
@@ -44,6 +44,8 @@ pub enum MetadataBuildError {
     AggregationThresholdNotMet(u32),
     #[error("Fast path error ({0})")]
     FastPathError(String),
+    #[error("Merkle root mismatch ({root}, {canonical_root})")]
+    MerkleRootMismatch { root: H256, canonical_root: H256 },
 }
 
 #[derive(Clone, Debug, new)]

--- a/rust/main/agents/relayer/src/msg/metadata/multisig/merkle_root_multisig.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/multisig/merkle_root_multisig.rs
@@ -4,12 +4,12 @@ use async_trait::async_trait;
 use derive_more::{AsRef, Deref};
 use derive_new::new;
 
-use eyre::{Context, Result};
+use eyre::Result;
 use hyperlane_base::MultisigCheckpointSyncer;
 use hyperlane_core::{unwrap_or_none_result, HyperlaneMessage, ModuleType, H256};
 use tracing::debug;
 
-use crate::msg::metadata::MessageMetadataBuilder;
+use crate::msg::metadata::{MessageMetadataBuilder, MetadataBuildError};
 
 use super::base::{MetadataToken, MultisigIsmMetadataBuilder, MultisigMetadata};
 
@@ -39,7 +39,7 @@ impl MultisigIsmMetadataBuilder for MerkleRootMultisigMetadataBuilder {
         threshold: u8,
         message: &HyperlaneMessage,
         checkpoint_syncer: &MultisigCheckpointSyncer,
-    ) -> Result<Option<MultisigMetadata>> {
+    ) -> Result<Option<MultisigMetadata>, MetadataBuildError> {
         const CTX: &str = "When fetching MerkleRootMultisig metadata";
         let highest_leaf_index = unwrap_or_none_result!(
             self.base_builder().highest_known_leaf_index().await,
@@ -49,7 +49,7 @@ impl MultisigIsmMetadataBuilder for MerkleRootMultisigMetadataBuilder {
             self.base_builder()
                 .get_merkle_leaf_id_by_message_id(message.id())
                 .await
-                .context(CTX)?,
+                .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?,
             debug!(
                 hyp_message=?message,
                 "No merkle leaf found for message id, must have not been enqueued in the tree"
@@ -66,7 +66,7 @@ impl MultisigIsmMetadataBuilder for MerkleRootMultisigMetadataBuilder {
                     self.base_builder().destination_domain(),
                 )
                 .await
-                .context(CTX)?,
+                .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?,
             debug!(
                 leaf_index,
                 highest_leaf_index, "Couldn't get checkpoint in range"
@@ -75,8 +75,7 @@ impl MultisigIsmMetadataBuilder for MerkleRootMultisigMetadataBuilder {
         let proof = self
             .base_builder()
             .get_proof(leaf_index, quorum_checkpoint.checkpoint.checkpoint)
-            .await
-            .context(CTX)?;
+            .await?;
         Ok(Some(MultisigMetadata::new(
             quorum_checkpoint,
             leaf_index,

--- a/rust/main/agents/relayer/src/msg/metadata/multisig/message_id_multisig.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/multisig/message_id_multisig.rs
@@ -4,13 +4,13 @@ use async_trait::async_trait;
 use derive_more::{AsRef, Deref};
 use derive_new::new;
 
-use eyre::{Context, Result};
+use eyre::Result;
 use hyperlane_base::MultisigCheckpointSyncer;
 use hyperlane_core::{unwrap_or_none_result, HyperlaneMessage, ModuleType, H256};
 use tracing::{debug, warn};
 
 use super::base::{MetadataToken, MultisigIsmMetadataBuilder, MultisigMetadata};
-use crate::msg::metadata::MessageMetadataBuilder;
+use crate::msg::metadata::{MessageMetadataBuilder, MetadataBuildError};
 
 #[derive(Debug, Clone, Deref, new, AsRef)]
 pub struct MessageIdMultisigMetadataBuilder(MessageMetadataBuilder);
@@ -36,14 +36,13 @@ impl MultisigIsmMetadataBuilder for MessageIdMultisigMetadataBuilder {
         threshold: u8,
         message: &HyperlaneMessage,
         checkpoint_syncer: &MultisigCheckpointSyncer,
-    ) -> Result<Option<MultisigMetadata>> {
+    ) -> Result<Option<MultisigMetadata>, MetadataBuildError> {
         let message_id = message.id();
-        const CTX: &str = "When fetching MessageIdMultisig metadata";
         let leaf_index = unwrap_or_none_result!(
             self.base_builder()
                 .get_merkle_leaf_id_by_message_id(message_id)
                 .await
-                .context(CTX)?,
+                .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?,
             debug!(
                 hyp_message=?message,
                 "No merkle leaf found for message id, must have not been enqueued in the tree"
@@ -63,7 +62,7 @@ impl MultisigIsmMetadataBuilder for MessageIdMultisigMetadataBuilder {
             checkpoint_syncer
                 .fetch_checkpoint(validators, threshold as usize, leaf_index)
                 .await
-                .context(CTX)?,
+                .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?,
             debug!("No quorum checkpoint found")
         );
 

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -1038,6 +1038,13 @@ impl PendingMessage {
                 warn!(count, "Max validator count reached");
                 self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
             }
+            MetadataBuildError::MerkleRootMismatch {
+                root,
+                canonical_root,
+            } => {
+                warn!(?root, ?canonical_root, "Nerkle root mismatch");
+                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
+            }
         });
         let build_metadata_end = Instant::now();
 


### PR DESCRIPTION
### Description

- add metrics to indicate merkle root mismatch
- update get_proof() to return MetadataBuildError on error

### Related issues

- fixes https://linear.app/hyperlane-xyz/issue/BACK-72/pre-tge-relayer-should-high-urgency-alert-if-a-known-app-context-has-a

### Backward compatibility

Yes
