### PR TITLE
refactor: Add database and chain conf into destination chain init

### DIFF
--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -305,8 +305,9 @@ impl BaseAgent for Relayer {
         let mut msg_ctxs = HashMap::new();
         let mut destination_chains = HashMap::new();
         for (destination_domain, destination) in destinations.iter() {
-            let destination_mailbox = destination.mailbox.clone();
             let application_operation_verifier = destination.application_operation_verifier.clone();
+            let destination_mailbox = destination.mailbox.clone();
+            let default_ism_getter = DefaultIsmCache::new(destination_mailbox.clone());
             let ccip_signer = destination.ccip_signer.clone();
 
             let destination_chain_setup = match core.settings.chain_setup(destination_domain) {
@@ -333,7 +334,6 @@ impl BaseAgent for Relayer {
                         continue;
                     }
                 };
-                let default_ism_getter = DefaultIsmCache::new(destination_mailbox.clone());
                 let origin_chain_setup = match core.settings.chain_setup(origin) {
                     Ok(chain_setup) => chain_setup.clone(),
                     Err(err) => {

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -80,7 +80,6 @@ struct ContextKey {
 #[derive(AsRef)]
 pub struct Relayer {
     origin_chains: HashSet<HyperlaneDomain>,
-    destination_chains: HashMap<HyperlaneDomain, ChainConf>,
     #[as_ref]
     core: HyperlaneAgentCore,
     message_syncs: HashMap<HyperlaneDomain, Arc<dyn ContractSyncer<HyperlaneMessage>>>,
@@ -120,7 +119,7 @@ impl Debug for Relayer {
             f,
             "Relayer {{ origin_chains: {:?}, destination_chains: {:?}, message_whitelist: {:?}, message_blacklist: {:?}, address_blacklist: {:?}, transaction_gas_limit: {:?}, skip_transaction_gas_limit_for: {:?}, allow_local_checkpoint_syncers: {:?} }}",
             self.origin_chains,
-            self.destination_chains,
+            self.destinations.values(),
             self.message_whitelist,
             self.message_blacklist,
             self.address_blacklist,
@@ -303,21 +302,13 @@ impl BaseAgent for Relayer {
 
         start_entity_init = Instant::now();
         let mut msg_ctxs = HashMap::new();
-        let mut destination_chains = HashMap::new();
         for (destination_domain, destination) in destinations.iter() {
             let application_operation_verifier = destination.application_operation_verifier.clone();
+            let destination_chain_setup = destination.chain_conf.clone();
             let destination_mailbox = destination.mailbox.clone();
             let default_ism_getter = DefaultIsmCache::new(destination_mailbox.clone());
             let ccip_signer = destination.ccip_signer.clone();
 
-            let destination_chain_setup = match core.settings.chain_setup(destination_domain) {
-                Ok(setup) => setup.clone(),
-                Err(err) => {
-                    error!(?destination_domain, ?err, "Destination chain setup failed");
-                    continue;
-                }
-            };
-            destination_chains.insert(destination_domain.clone(), destination_chain_setup.clone());
             let transaction_gas_limit: Option<U256> =
                 if skip_transaction_gas_limit_for.contains(&destination_domain.id()) {
                     None
@@ -408,7 +399,6 @@ impl BaseAgent for Relayer {
             dbs,
             _cache: cache,
             origin_chains: settings.origin_chains,
-            destination_chains,
             msg_ctxs,
             core,
             message_syncs,
@@ -460,10 +450,11 @@ impl BaseAgent for Relayer {
 
         let sender = BroadcastSender::new(ENDPOINT_MESSAGES_QUEUE_SIZE);
         // send channels by destination chain
-        let mut send_channels = HashMap::with_capacity(self.destination_chains.len());
-        let mut prep_queues = HashMap::with_capacity(self.destination_chains.len());
+        let mut send_channels = HashMap::with_capacity(self.destinations.len());
+        let mut prep_queues = HashMap::with_capacity(self.destinations.len());
         start_entity_init = Instant::now();
-        for (dest_domain, dest_conf) in &self.destination_chains {
+        for (dest_domain, destination) in &self.destinations {
+            let dest_conf = &destination.chain_conf;
             let (send_channel, receive_channel) = mpsc::unbounded_channel::<QueueOperation>();
             send_channels.insert(dest_domain.id(), send_channel);
 
@@ -668,7 +659,7 @@ impl BaseAgent for Relayer {
             .iter()
             .map(|(key, ctx)| (key.origin.clone(), ctx.origin_gas_payment_enforcer.clone()))
             .collect();
-        let relayer_router = relayer_server::Server::new(self.destination_chains.len())
+        let relayer_router = relayer_server::Server::new(self.destinations.len())
             .with_op_retry(sender.clone())
             .with_message_queue(prep_queues)
             .with_dbs(dbs)
@@ -928,9 +919,9 @@ impl Relayer {
         task_monitor: TaskMonitor,
     ) -> eyre::Result<JoinHandle<()>> {
         let metrics =
-            MessageDbLoaderMetrics::new(&self.core.metrics, origin, self.destination_chains.keys());
+            MessageDbLoaderMetrics::new(&self.core.metrics, origin, self.destinations.keys());
         let destination_ctxs: HashMap<_, _> = self
-            .destination_chains
+            .destinations
             .keys()
             .filter_map(|destination| {
                 let key = ContextKey {

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -651,8 +651,11 @@ impl BaseAgent for Relayer {
         start_entity_init = Instant::now();
 
         // create a db mapping for server handlers
-        let dbs: HashMap<u32, HyperlaneRocksDB> =
-            self.dbs.iter().map(|(k, v)| (k.id(), v.clone())).collect();
+        let dbs: HashMap<u32, HyperlaneRocksDB> = self
+            .destinations
+            .iter()
+            .map(|(k, v)| (k.id(), v.database.clone()))
+            .collect();
 
         let gas_enforcers: HashMap<_, _> = self
             .msg_ctxs

--- a/rust/main/agents/relayer/src/relayer/destination.rs
+++ b/rust/main/agents/relayer/src/relayer/destination.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 
 use tracing::warn;
 
+use hyperlane_base::db::HyperlaneRocksDB;
 use hyperlane_base::{db::DB, settings::ChainConf, CoreMetrics};
 use hyperlane_core::{HyperlaneDomain, HyperlaneDomainProtocol, Mailbox, SubmitterType};
 use hyperlane_ethereum::Signers;
@@ -16,6 +17,7 @@ pub struct Destination {
     pub domain: HyperlaneDomain,
     pub application_operation_verifier: Arc<dyn ApplicationOperationVerifier>,
     pub chain_conf: ChainConf,
+    pub database: HyperlaneRocksDB,
     pub dispatcher_entrypoint: Option<DispatcherEntrypoint>,
     pub dispatcher: Option<Dispatcher>,
     pub mailbox: Arc<dyn Mailbox>,
@@ -75,6 +77,8 @@ impl Factory for DestinationFactory {
 
         let ccip_signer = self.init_ccip_signer(&domain, &chain_conf).await;
 
+        let database = HyperlaneRocksDB::new(&domain, self.db.clone());
+
         let (dispatcher_entrypoint, dispatcher) = self
             .init_dispatcher_and_entrypoint(&domain, chain_conf.clone(), dispatcher_metrics)
             .await?;
@@ -85,6 +89,7 @@ impl Factory for DestinationFactory {
             domain,
             application_operation_verifier,
             chain_conf,
+            database,
             dispatcher_entrypoint,
             dispatcher,
             mailbox,

--- a/rust/main/agents/relayer/src/relayer/destination.rs
+++ b/rust/main/agents/relayer/src/relayer/destination.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -14,10 +15,17 @@ use lander::{
 pub struct Destination {
     pub domain: HyperlaneDomain,
     pub application_operation_verifier: Arc<dyn ApplicationOperationVerifier>,
+    pub chain_conf: ChainConf,
     pub dispatcher_entrypoint: Option<DispatcherEntrypoint>,
     pub dispatcher: Option<Dispatcher>,
     pub mailbox: Arc<dyn Mailbox>,
     pub ccip_signer: Option<Signers>,
+}
+
+impl Debug for Destination {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Destination {{ domain: {} }}", self.domain.name())
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -76,6 +84,7 @@ impl Factory for DestinationFactory {
         let destination = Destination {
             domain,
             application_operation_verifier,
+            chain_conf,
             dispatcher_entrypoint,
             dispatcher,
             mailbox,


### PR DESCRIPTION
### Description

Add database and chain conf into destination chain init

### Related issues

- Contributes into https://linear.app/hyperlane-xyz/issue/ENG-1929/refactor-relayer-start-up-for-destination
 
### Backward compatibility

Yes

### Testing

None