### PR TITLE
fix: Start indexing of Solaxy from sequence 1 as other Sealevel chains

### DIFF
--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -9686,7 +9686,11 @@
       "interchainSecurityModule": "BMyTd7BBTw6ewENKkvzQsmPXPBHsTDW4oLHSYkv78spP",
       "mailbox": "6VdnmP8MfYkPNMwyU2ZY9S3ickYyewF58LPC38y9FAVU",
       "merkleTreeHook": "6VdnmP8MfYkPNMwyU2ZY9S3ickYyewF58LPC38y9FAVU",
-      "validatorAnnounce": "28S9ToSehVxdE7rTGEAA3vAX3AchHJh1MXcq9AeM1rL8"
+      "validatorAnnounce": "28S9ToSehVxdE7rTGEAA3vAX3AchHJh1MXcq9AeM1rL8",
+      "index": {
+        "from": 1,
+        "mode": "sequence"
+      }
     },
     "tac": {
       "blockExplorers": [


### PR DESCRIPTION
### Description

Start indexing of Solaxy from sequence 1 as other Sealevel chains

### Backward compatibility

Yes

### Testing

Manual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the "solaxy" chain configuration to include an "index" setting with new properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->