### PR TITLE
chore: Upgrade agent image to latest in Mainnet

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -848,7 +848,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '2fe58b3-20250718-114304',
+      tag: 'cb7d42b-20250801-092506',
     },
     blacklist,
     gasPaymentEnforcement: gasPaymentEnforcement,
@@ -894,7 +894,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '2fe58b3-20250718-114304',
+      tag: 'cb7d42b-20250801-092506',
     },
     blacklist,
     // We're temporarily (ab)using the RC relayer as a way to increase
@@ -938,7 +938,7 @@ const neutron: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '5291797-20250701-134531',
+      tag: 'cb7d42b-20250801-092506',
     },
     blacklist,
     gasPaymentEnforcement,

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -879,7 +879,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '5291797-20250701-134531',
+      tag: 'e22a72a-20250801-083007',
     },
     resources: scraperResources,
   },


### PR DESCRIPTION
### Description

Upgrade agent image to latest in Mainnet

### Backward compatibility

Yes

### Testing

None