### PR TITLE
Xeno/everclear token bridge support eng 1918

### DIFF
--- a/solidity/contracts/mock/MockEverclearAdapter.sol
+++ b/solidity/contracts/mock/MockEverclearAdapter.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.22;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+import {IEverclearAdapter, IEverclear, IEverclearSpoke} from "../../contracts/interfaces/IEverclearAdapter.sol";
+
+/**
+ * @notice Mock implementation of IEverclearAdapter for testing
+ */
+contract MockEverclearAdapter is IEverclearAdapter {
+    uint256 public constant INTENT_FEE = 1000; // 0.001 ETH
+    bool public shouldRevert = false;
+    bytes32 public lastIntentId;
+    IEverclear.Intent public lastIntent;
+
+    // Track calls for verification
+    uint256 public newIntentCallCount;
+    uint32[] public lastDestinations;
+    bytes32 public lastReceiver;
+    address public lastInputAsset;
+    bytes32 public lastOutputAsset;
+    uint256 public lastAmount;
+    uint24 public lastMaxFee;
+    uint48 public lastTtl;
+    bytes public lastData;
+    FeeParams public lastFeeParams;
+
+    function setRevert(bool _shouldRevert) external {
+        shouldRevert = _shouldRevert;
+    }
+
+    function newIntent(
+        uint32[] memory _destinations,
+        bytes32 _receiver,
+        address _inputAsset,
+        bytes32 _outputAsset,
+        uint256 _amount,
+        uint24 _maxFee,
+        uint48 _ttl,
+        bytes calldata _data,
+        FeeParams calldata _feeParams
+    ) external payable override returns (bytes32, IEverclear.Intent memory) {
+        if (shouldRevert) {
+            revert("MockEverclearAdapter: reverted");
+        }
+
+        // Store call data for verification
+        newIntentCallCount++;
+        lastDestinations = _destinations;
+        lastReceiver = _receiver;
+        lastInputAsset = _inputAsset;
+        lastOutputAsset = _outputAsset;
+        lastAmount = _amount;
+        lastMaxFee = _maxFee;
+        lastTtl = _ttl;
+        lastData = _data;
+        lastFeeParams = _feeParams;
+
+        // Generate mock intent ID
+        lastIntentId = keccak256(
+            abi.encodePacked(block.timestamp, _receiver, _amount)
+        );
+
+        // Create mock intent
+        lastIntent = IEverclear.Intent({
+            initiator: bytes32(uint256(uint160(msg.sender))),
+            receiver: _receiver,
+            inputAsset: bytes32(uint256(uint160(_inputAsset))),
+            outputAsset: _outputAsset,
+            maxFee: _maxFee,
+            origin: uint32(block.chainid),
+            destinations: _destinations,
+            nonce: uint64(newIntentCallCount),
+            timestamp: uint48(block.timestamp),
+            ttl: _ttl,
+            amount: _amount,
+            data: _data
+        });
+
+        return (lastIntentId, lastIntent);
+    }
+
+    function feeSigner() external view returns (address) {
+        return address(0x222);
+    }
+
+    function owner() external view returns (address) {
+        return address(0x1);
+    }
+
+    function updateFeeSigner(address _feeSigner) external {
+        // Do nothing
+    }
+
+    function spoke() external view returns (IEverclearSpoke) {
+        return IEverclearSpoke(address(0x333));
+    }
+}

--- a/solidity/contracts/mock/MockWETH.sol
+++ b/solidity/contracts/mock/MockWETH.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.22;
+
+import {IWETH} from "../token/interfaces/IWETH.sol";
+
+contract MockWETH is IWETH {
+    function allowance(
+        address _owner,
+        address _spender
+    ) external view returns (uint256) {}
+
+    function approve(
+        address _spender,
+        uint256 _amount
+    ) external returns (bool) {
+        return true;
+    }
+
+    function balanceOf(address _account) external view returns (uint256) {
+        return 0;
+    }
+
+    function deposit() external payable {}
+
+    function totalSupply() external view returns (uint256) {
+        return address(this).balance;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        return true;
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    ) external returns (bool) {
+        return true;
+    }
+
+    function withdraw(uint256 amount) external {}
+}

--- a/solidity/test/token/EverclearTokenBridge.t.sol
+++ b/solidity/test/token/EverclearTokenBridge.t.sol
@@ -19,6 +19,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {MockMailbox} from "../../contracts/mock/MockMailbox.sol";
 import {ERC20Test} from "../../contracts/test/ERC20Test.sol";
+import {MockEverclearAdapter} from "../../contracts/mock/MockEverclearAdapter.sol";
 import {TestPostDispatchHook} from "../../contracts/test/TestPostDispatchHook.sol";
 import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
 import {MockHyperlaneEnvironment} from "../../contracts/mock/MockHyperlaneEnvironment.sol";
@@ -31,98 +32,6 @@ import {TokenMessage} from "../../contracts/token/libs/TokenMessage.sol";
 import {IWETH} from "contracts/token/interfaces/IWETH.sol";
 
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-/**
- * @notice Mock implementation of IEverclearAdapter for testing
- */
-contract MockEverclearAdapter is IEverclearAdapter {
-    uint256 public constant INTENT_FEE = 1000; // 0.001 ETH
-    bool public shouldRevert = false;
-    bytes32 public lastIntentId;
-    IEverclear.Intent public lastIntent;
-
-    // Track calls for verification
-    uint256 public newIntentCallCount;
-    uint32[] public lastDestinations;
-    bytes32 public lastReceiver;
-    address public lastInputAsset;
-    bytes32 public lastOutputAsset;
-    uint256 public lastAmount;
-    uint24 public lastMaxFee;
-    uint48 public lastTtl;
-    bytes public lastData;
-    FeeParams public lastFeeParams;
-
-    function setRevert(bool _shouldRevert) external {
-        shouldRevert = _shouldRevert;
-    }
-
-    function newIntent(
-        uint32[] memory _destinations,
-        bytes32 _receiver,
-        address _inputAsset,
-        bytes32 _outputAsset,
-        uint256 _amount,
-        uint24 _maxFee,
-        uint48 _ttl,
-        bytes calldata _data,
-        FeeParams calldata _feeParams
-    ) external payable override returns (bytes32, IEverclear.Intent memory) {
-        if (shouldRevert) {
-            revert("MockEverclearAdapter: reverted");
-        }
-
-        // Store call data for verification
-        newIntentCallCount++;
-        lastDestinations = _destinations;
-        lastReceiver = _receiver;
-        lastInputAsset = _inputAsset;
-        lastOutputAsset = _outputAsset;
-        lastAmount = _amount;
-        lastMaxFee = _maxFee;
-        lastTtl = _ttl;
-        lastData = _data;
-        lastFeeParams = _feeParams;
-
-        // Generate mock intent ID
-        lastIntentId = keccak256(
-            abi.encodePacked(block.timestamp, _receiver, _amount)
-        );
-
-        // Create mock intent
-        lastIntent = IEverclear.Intent({
-            initiator: bytes32(uint256(uint160(msg.sender))),
-            receiver: _receiver,
-            inputAsset: bytes32(uint256(uint160(_inputAsset))),
-            outputAsset: _outputAsset,
-            maxFee: _maxFee,
-            origin: uint32(block.chainid),
-            destinations: _destinations,
-            nonce: uint64(newIntentCallCount),
-            timestamp: uint48(block.timestamp),
-            ttl: _ttl,
-            amount: _amount,
-            data: _data
-        });
-
-        return (lastIntentId, lastIntent);
-    }
-
-    function feeSigner() external view returns (address) {
-        return address(0x222);
-    }
-
-    function owner() external view returns (address) {
-        return address(0x1);
-    }
-
-    function updateFeeSigner(address _feeSigner) external {
-        // Do nothing
-    }
-
-    function spoke() external view returns (IEverclearSpoke) {
-        return IEverclearSpoke(address(0x333));
-    }
-}
 
 contract EverclearTokenBridgeTest is Test {
     using TypeCasts for *;
@@ -715,6 +624,7 @@ contract MockEverclearTokenBridge is EverclearTokenBridge {
     ) EverclearTokenBridge(_weth, _scale, _mailbox, _everclearAdapter) {}
 
     bytes public lastIntent;
+
     function _createIntent(
         uint32 _destination,
         bytes32 _recipient,

--- a/typescript/cli/scripts/run-e2e-test.sh
+++ b/typescript/cli/scripts/run-e2e-test.sh
@@ -14,9 +14,9 @@ function cleanup() {
 cleanup
 
 echo "Starting anvil2, anvil3 and anvil4 chains for E2E tests"
-anvil --chain-id 31338 -p 8555 --state /tmp/anvil2/state --gas-price 1 > /dev/null &
-anvil --chain-id 31347 -p 8600 --state /tmp/anvil3/state --gas-price 1 > /dev/null &
-anvil --chain-id 31348 -p 8601 --state /tmp/anvil4/state --gas-price 1 > /dev/null &
+anvil --chain-id 31338 -p 8555 --state /tmp/anvil2/state --gas-price 1 --code-size-limit 10000000 > /dev/null &
+anvil --chain-id 31347 -p 8600 --state /tmp/anvil3/state --gas-price 1 --code-size-limit 10000000 > /dev/null &
+anvil --chain-id 31348 -p 8601 --state /tmp/anvil4/state --gas-price 1 --code-size-limit 10000000 > /dev/null &
 
 echo "Running E2E tests"
 if [ -n "${CLI_E2E_TEST}" ]; then

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -61,6 +61,10 @@ const TYPE_DESCRIPTIONS: Record<TokenType, string> = {
     'Extends an existing xERC20 Lockbox with Warp Route functionality',
   [TokenType.nativeOpL2]: 'An OP L2 native ETH token',
   [TokenType.nativeOpL1]: 'An OP L1 native ETH token',
+  [TokenType.collateralEverclear]:
+    'A collateral token that can be transferred via Everclear intents',
+  [TokenType.ethEverclear]:
+    'An ETH token that can be transferred via Everclear intents',
   // TODO: describe
   [TokenType.syntheticUri]: '',
   [TokenType.collateralUri]: '',

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -6,6 +6,8 @@ import {
   ERC20Test,
   ERC20Test__factory,
   ERC4626Test__factory,
+  MockEverclearAdapter,
+  MockEverclearAdapter__factory,
   XERC20LockboxTest,
   XERC20LockboxTest__factory,
   XERC20VSTest,
@@ -475,6 +477,25 @@ export async function deployToken(
   await token.deployed();
 
   return token;
+}
+
+export async function deployEverclearBridgeAdapter(
+  privateKey: string,
+  chain: string,
+): Promise<MockEverclearAdapter> {
+  const { multiProvider } = await getContext({
+    registryUris: [REGISTRY_PATH],
+    key: privateKey,
+  });
+
+  multiProvider.setSigner(chain, new ethers.Wallet(privateKey));
+
+  const adapter = await new MockEverclearAdapter__factory(
+    multiProvider.getSigner(chain),
+  ).deploy();
+  await adapter.deployed();
+
+  return adapter;
 }
 
 export async function deploy4626Vault(

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -8,7 +8,7 @@ import {
   WarpRouteDeployConfigMailboxRequired,
   WarpRouteDeployConfigSchema,
 } from '@hyperlane-xyz/sdk';
-import { Address } from '@hyperlane-xyz/utils';
+import { Address, randomInt } from '@hyperlane-xyz/utils';
 
 import { readYamlOrJson } from '../../utils/files.js';
 
@@ -274,6 +274,7 @@ type GetWarpTokenConfigByTokenTypeOptions = {
   token: Address;
   vault: Address;
   otherChain: ChainName;
+  everclearBridgeAdapter: Address;
 };
 
 function getWarpTokenConfigForType({
@@ -283,6 +284,7 @@ function getWarpTokenConfigForType({
   token,
   tokenType,
   vault,
+  everclearBridgeAdapter,
 }: GetWarpTokenConfigByTokenTypeOptions): HypTokenRouterConfig {
   let tokenConfig: HypTokenRouterConfig;
   switch (tokenType) {
@@ -340,6 +342,21 @@ function getWarpTokenConfigForType({
         collateralChainName: otherChain,
       };
       break;
+    case TokenType.collateralEverclear:
+      tokenConfig = {
+        type: TokenType.collateralEverclear,
+        mailbox,
+        owner,
+        token,
+        everclearBridgeAddress: everclearBridgeAdapter,
+        outputAssets: {},
+        everclearFeeParams: {
+          deadline: Date.now(),
+          fee: randomInt(10000000),
+          signature: '0x42',
+        },
+      };
+      break;
     default:
       throw new Error(
         `Unsupported token type "${tokenType}" for random config generation`,
@@ -355,6 +372,7 @@ type GetWarpTokenConfigOptions = {
   token: Address;
   vault: Address;
   chainName: ChainName;
+  everclearBridgeAdapter: Address;
 };
 
 export function generateWarpConfigs(
@@ -372,6 +390,9 @@ export function generateWarpConfigs(
     TokenType.collateralCctp,
     TokenType.nativeOpL1,
     TokenType.nativeOpL2,
+    // No adapter has been implemented yet
+    TokenType.ethEverclear,
+    TokenType.collateralEverclear,
   ]);
 
   const allowedWarpTokenTypes = Object.values(TokenType).filter(

--- a/typescript/cli/src/tests/warp/warp-bridge-utils.ts
+++ b/typescript/cli/src/tests/warp/warp-bridge-utils.ts
@@ -2,7 +2,11 @@ import { JsonRpcProvider } from '@ethersproject/providers';
 import { Wallet } from 'ethers';
 import { parseUnits } from 'ethers/lib/utils.js';
 
-import { ERC20Test, ERC4626Test } from '@hyperlane-xyz/core';
+import {
+  ERC20Test,
+  ERC4626Test,
+  MockEverclearAdapter,
+} from '@hyperlane-xyz/core';
 import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
   ChainMap,
@@ -24,6 +28,7 @@ import {
   REGISTRY_PATH,
   WARP_DEPLOY_OUTPUT_PATH,
   deploy4626Vault,
+  deployEverclearBridgeAdapter,
   deployOrUseExistingCore,
   deployToken,
   sendWarpRouteMessageRoundTrip,
@@ -46,6 +51,8 @@ export type WarpBridgeTestConfig = {
   vaultChain2: ERC4626Test;
   tokenChain3: ERC20Test;
   vaultChain3: ERC4626Test;
+  everclearBridgeAdapterChain2: MockEverclearAdapter;
+  everclearBridgeAdapterChain3: MockEverclearAdapter;
 };
 
 export async function runWarpBridgeTests(
@@ -136,6 +143,11 @@ export async function setupChains(): Promise<WarpBridgeTestConfig> {
     vaultChain2.symbol(),
   ]);
 
+  const everclearBridgeAdapterChain2 = await deployEverclearBridgeAdapter(
+    ANVIL_KEY,
+    CHAIN_NAME_2,
+  );
+
   const tokenChain3 = await deployToken(ANVIL_KEY, CHAIN_NAME_3);
   const vaultChain3 = await deploy4626Vault(
     ANVIL_KEY,
@@ -147,6 +159,11 @@ export async function setupChains(): Promise<WarpBridgeTestConfig> {
     tokenChain3.symbol(),
     vaultChain3.symbol(),
   ]);
+
+  const everclearBridgeAdapterChain3 = await deployEverclearBridgeAdapter(
+    ANVIL_KEY,
+    CHAIN_NAME_3,
+  );
 
   return {
     chain2Addresses,
@@ -162,6 +179,8 @@ export async function setupChains(): Promise<WarpBridgeTestConfig> {
     tokenChain3Symbol,
     vaultChain3,
     tokenVaultChain3Symbol,
+    everclearBridgeAdapterChain2,
+    everclearBridgeAdapterChain3,
   };
 }
 
@@ -177,6 +196,7 @@ export function generateTestCases(
       owner: config.ownerAddress,
       token: config.tokenChain2.address,
       vault: config.vaultChain2.address,
+      everclearBridgeAdapter: config.everclearBridgeAdapterChain2.address,
     },
     {
       chainName: CHAIN_NAME_3,
@@ -184,6 +204,7 @@ export function generateTestCases(
       owner: config.ownerAddress,
       token: config.tokenChain3.address,
       vault: config.vaultChain3.address,
+      everclearBridgeAdapter: config.everclearBridgeAdapterChain3.address,
     },
   );
 

--- a/typescript/sdk/hardhat.config.cts
+++ b/typescript/sdk/hardhat.config.cts
@@ -20,7 +20,12 @@ module.exports = {
     currency: 'USD',
   },
   mocha: {
-    bail: true,
+    bail: false,
     import: 'tsx',
+  },
+  networks: {
+    hardhat: {
+      allowUnlimitedContractSize: true,
+    },
   },
 };

--- a/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
@@ -42,6 +42,7 @@ import {
   deepCopy,
   eqAddress,
   normalizeAddressEvm,
+  objMap,
   randomInt,
 } from '@hyperlane-xyz/utils';
 
@@ -69,6 +70,7 @@ import {
   HypTokenRouterConfig,
   HypTokenRouterConfigSchema,
   derivedHookAddress,
+  isEverclearCollateralTokenConfig,
   isMovableCollateralTokenConfig,
 } from './types.js';
 
@@ -163,6 +165,11 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
   const movableCollateralTypes = Object.values(TokenType).filter(
     isMovableCollateralTokenType,
   ) as MovableTokenType[];
+
+  const everclearTokenBridgeTypes = [
+    TokenType.ethEverclear,
+    TokenType.collateralEverclear,
+  ] as EverclearTokenBridgeTokenType[];
 
   const assertAllowedRebalancers = async (
     evmERC20WarpModule: EvmERC20WarpModule,
@@ -405,11 +412,8 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
     });
   }
 
-  for (const tokenType of [
-    TokenType.ethEverclear,
-    TokenType.collateralEverclear,
-  ] as EverclearTokenBridgeTokenType[]) {
-    it.only(`should create ${tokenType} token`, async () => {
+  for (const tokenType of everclearTokenBridgeTypes) {
+    it(`should create ${tokenType} token`, async () => {
       const config: HypTokenRouterConfig =
         getEverclearTokenBridgeTokenConfig()[tokenType];
 
@@ -1188,6 +1192,192 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
 
           testCase++;
         }
+      });
+    }
+
+    for (const tokenType of everclearTokenBridgeTypes) {
+      it(`should add destination outputAssets if the token is of type ${tokenType}`, async () => {
+        const config = deepCopy(
+          getEverclearTokenBridgeTokenConfig()[tokenType],
+        );
+
+        const domainId = 31337;
+        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+          chain,
+          config: {
+            ...config,
+            remoteRouters: {
+              [domainId]: {
+                address: randomAddress(),
+              },
+            },
+          },
+          multiProvider,
+          proxyFactoryFactories: ismFactoryAddresses,
+        });
+
+        const remoteToken = randomAddress();
+        const txs = await evmERC20WarpModule.update({
+          ...config,
+
+          outputAssets: {
+            [domainId]: remoteToken,
+          },
+        });
+
+        expect(txs.length).to.equal(1);
+        await sendTxs(txs);
+
+        const currentConfig = await evmERC20WarpModule.read();
+
+        assert(
+          isEverclearCollateralTokenConfig(currentConfig),
+          `Expected token of type ${tokenType}`,
+        );
+        expect(currentConfig.outputAssets[domainId]).to.equal(
+          addressToBytes32(remoteToken),
+        );
+      });
+
+      it(`should overwrite a destination outputAssets if the token is of type ${tokenType} and a destination token already exists for the given destination`, async () => {
+        const config = deepCopy(
+          getEverclearTokenBridgeTokenConfig()[tokenType],
+        );
+
+        const domainId = 31337;
+        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+          chain,
+          config: {
+            ...config,
+            remoteRouters: {
+              [domainId]: {
+                address: randomAddress(),
+              },
+            },
+            outputAssets: {
+              [domainId]: randomAddress(),
+            },
+          },
+          multiProvider,
+          proxyFactoryFactories: ismFactoryAddresses,
+        });
+
+        const expectedRemoteOuputToken = randomAddress();
+        const txs = await evmERC20WarpModule.update({
+          ...config,
+          outputAssets: {
+            [domainId]: expectedRemoteOuputToken,
+          },
+        });
+
+        expect(txs.length).to.equal(1);
+        await sendTxs(txs);
+
+        const currentConfig = await evmERC20WarpModule.read();
+
+        assert(
+          isEverclearCollateralTokenConfig(currentConfig),
+          `Expected token of type ${tokenType}`,
+        );
+        expect(currentConfig.outputAssets[domainId]).to.equal(
+          addressToBytes32(expectedRemoteOuputToken),
+        );
+      });
+
+      it(`should remove destination outputAssets if the token is of type ${tokenType} and a config is set`, async () => {
+        const config = deepCopy(
+          getEverclearTokenBridgeTokenConfig()[tokenType],
+        );
+
+        const domainId = 31337;
+        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+          chain,
+          config: {
+            ...config,
+            remoteRouters: {
+              [domainId]: {
+                address: randomAddress(),
+              },
+            },
+            outputAssets: {
+              [domainId]: randomAddress(),
+            },
+          },
+          multiProvider,
+          proxyFactoryFactories: ismFactoryAddresses,
+        });
+
+        const txs = await evmERC20WarpModule.update({
+          ...config,
+          outputAssets: {},
+        });
+
+        expect(txs.length).to.equal(1);
+        await sendTxs(txs);
+
+        const currentConfig = await evmERC20WarpModule.read();
+
+        assert(
+          isEverclearCollateralTokenConfig(currentConfig),
+          `Expected token of type ${tokenType}`,
+        );
+        expect(currentConfig.outputAssets).to.deep.equal({});
+      });
+
+      it(`should remove 1 outputAsset and leave the others if the token is of type ${tokenType}`, async () => {
+        const config = deepCopy(
+          getEverclearTokenBridgeTokenConfig()[tokenType],
+        );
+
+        const domainId = 31337;
+        const numOfRouters = randomInt(10, 0);
+        const remoteRoutersToKeep = randomRemoteRouters(numOfRouters);
+        const initialRemoteRouters = {
+          [domainId]: {
+            address: randomAddress(),
+          },
+          ...remoteRoutersToKeep,
+        };
+
+        const outputAssetsToKeep = objMap(remoteRoutersToKeep, (_domainId, _) =>
+          randomAddress(),
+        );
+
+        const expectedOutputAssets = objMap(
+          outputAssetsToKeep,
+          (_domainId, address) => addressToBytes32(address),
+        );
+        const initialOutputAddresses = {
+          [domainId]: randomAddress(),
+          ...outputAssetsToKeep,
+        };
+        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+          chain,
+          config: {
+            ...config,
+            remoteRouters: initialRemoteRouters,
+            outputAssets: initialOutputAddresses,
+          },
+          multiProvider,
+          proxyFactoryFactories: ismFactoryAddresses,
+        });
+
+        const txs = await evmERC20WarpModule.update({
+          ...config,
+          remoteRouters: initialRemoteRouters,
+          outputAssets: outputAssetsToKeep,
+        });
+
+        expect(txs.length).to.equal(1);
+        await sendTxs(txs);
+
+        const currentConfig = await evmERC20WarpModule.read();
+
+        assert(
+          isEverclearCollateralTokenConfig(currentConfig),
+          `Expected token of type ${tokenType}`,
+        );
+        expect(currentConfig.outputAssets).to.deep.equal(expectedOutputAssets);
       });
     }
 

--- a/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
@@ -232,7 +232,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
     const everclearFeeParams = {
       deadline: Date.now(),
       fee: randomInt(1000),
-      signature: '',
+      signature: '0x',
     };
 
     return {
@@ -1378,6 +1378,79 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
           `Expected token of type ${tokenType}`,
         );
         expect(currentConfig.outputAssets).to.deep.equal(expectedOutputAssets);
+      });
+
+      it(`should update the fee params if the token is of type ${tokenType}`, async () => {
+        const config = deepCopy(
+          getEverclearTokenBridgeTokenConfig()[tokenType],
+        );
+
+        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+          chain,
+          config,
+          multiProvider,
+          proxyFactoryFactories: ismFactoryAddresses,
+        });
+
+        const expectedEverclearFeeParams = {
+          deadline: Date.now(),
+          fee: randomInt(100000000, 100),
+          signature: '0x42',
+        };
+        const txs = await evmERC20WarpModule.update({
+          ...config,
+          everclearFeeParams: expectedEverclearFeeParams,
+        });
+
+        expect(txs.length).to.equal(1);
+        await sendTxs(txs);
+
+        const currentConfig = await evmERC20WarpModule.read();
+
+        assert(
+          isEverclearCollateralTokenConfig(currentConfig),
+          `Expected token of type ${tokenType}`,
+        );
+        expect(currentConfig.everclearFeeParams).to.deep.equal(
+          expectedEverclearFeeParams,
+        );
+      });
+
+      it(`should not generate any update transactions for the fee params if the config did not change and the token is of type ${tokenType}`, async () => {
+        const config = deepCopy(
+          getEverclearTokenBridgeTokenConfig()[tokenType],
+        );
+
+        const expectedEverclearFeeParams = {
+          deadline: Date.now(),
+          fee: randomInt(100000000, 100),
+          signature: '0x42',
+        };
+
+        const formattedConfig = {
+          ...config,
+          everclearFeeParams: expectedEverclearFeeParams,
+        };
+
+        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+          chain,
+          config: formattedConfig,
+          multiProvider,
+          proxyFactoryFactories: ismFactoryAddresses,
+        });
+
+        const txs = await evmERC20WarpModule.update(formattedConfig);
+
+        expect(txs.length).to.equal(0);
+
+        const currentConfig = await evmERC20WarpModule.read();
+        assert(
+          isEverclearCollateralTokenConfig(currentConfig),
+          `Expected token of type ${tokenType}`,
+        );
+        expect(currentConfig.everclearFeeParams).to.deep.equal(
+          expectedEverclearFeeParams,
+        );
       });
     }
 

--- a/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.hardhat-test.ts
@@ -17,6 +17,8 @@ import {
   Mailbox,
   MailboxClient__factory,
   Mailbox__factory,
+  MockEverclearAdapter,
+  MockEverclearAdapter__factory,
   MovableCollateralRouter__factory,
 } from '@hyperlane-xyz/core';
 import {
@@ -57,6 +59,7 @@ import { normalizeConfig } from '../utils/ism.js';
 
 import { EvmERC20WarpModule } from './EvmERC20WarpModule.js';
 import {
+  EverclearTokenBridgeTokenType,
   MovableTokenType,
   TokenType,
   isMovableCollateralTokenType,
@@ -97,6 +100,8 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
   let vault: ERC4626Test;
   let token: ERC20Test;
   let feeToken: ERC20Test;
+  let everclearBridgeAdapterMockFactory: MockEverclearAdapter__factory;
+  let everclearBridgeAdapterMock: MockEverclearAdapter;
   let signer: SignerWithAddress;
   let multiProvider: MultiProvider;
   let coreApp: TestCoreApp;
@@ -147,6 +152,12 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
 
     mailbox = Mailbox__factory.connect(baseConfig.mailbox, signer);
     ismAddress = await mailbox.defaultIsm();
+
+    everclearBridgeAdapterMockFactory = new MockEverclearAdapter__factory(
+      signer,
+    );
+    everclearBridgeAdapterMock =
+      await everclearBridgeAdapterMockFactory.deploy();
   });
 
   const movableCollateralTypes = Object.values(TokenType).filter(
@@ -203,6 +214,36 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         ...baseConfig,
         type: TokenType.nativeScaled,
         allowedRebalancers,
+      },
+    };
+  };
+
+  const getEverclearTokenBridgeTokenConfig = (): Record<
+    EverclearTokenBridgeTokenType,
+    HypTokenRouterConfig
+  > => {
+    const everclearFeeParams = {
+      deadline: Date.now(),
+      fee: randomInt(1000),
+      signature: '',
+    };
+
+    return {
+      [TokenType.collateralEverclear]: {
+        type: TokenType.collateralEverclear,
+        token: token.address,
+        ...baseConfig,
+        everclearBridgeAddress: everclearBridgeAdapterMock.address,
+        everclearFeeParams,
+        outputAssets: {},
+      },
+      [TokenType.ethEverclear]: {
+        type: TokenType.ethEverclear,
+        wethAddress: token.address,
+        ...baseConfig,
+        everclearBridgeAddress: everclearBridgeAdapterMock.address,
+        everclearFeeParams,
+        outputAssets: {},
       },
     };
   };
@@ -361,6 +402,27 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       });
 
       await assertAllowedRebalancers(evmERC20WarpModule, expectedRebalancers);
+    });
+  }
+
+  for (const tokenType of [
+    TokenType.ethEverclear,
+    TokenType.collateralEverclear,
+  ] as EverclearTokenBridgeTokenType[]) {
+    it.only(`should create ${tokenType} token`, async () => {
+      const config: HypTokenRouterConfig =
+        getEverclearTokenBridgeTokenConfig()[tokenType];
+
+      // Deploy using WarpModule
+      const evmERC20WarpModule = EvmERC20WarpModule.create({
+        chain,
+        config,
+        multiProvider,
+        proxyFactoryFactories: ismFactoryAddresses,
+      });
+
+      // TODO: update this once there is reader support
+      await expect(evmERC20WarpModule).not.to.rejected;
     });
   }
 

--- a/typescript/sdk/src/token/EvmERC20WarpModule.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.ts
@@ -5,6 +5,7 @@ import { UINT_256_MAX } from 'starknet';
 import { zeroAddress } from 'viem';
 
 import {
+  EverclearTokenBridge__factory,
   GasRouter__factory,
   IERC20__factory,
   MailboxClient__factory,
@@ -18,6 +19,7 @@ import {
   Domain,
   EvmChainId,
   ProtocolType,
+  ZERO_ADDRESS_HEX_32,
   addressToBytes32,
   assert,
   deepEquals,
@@ -25,6 +27,8 @@ import {
   eqAddress,
   isObjEmpty,
   normalizeAddressEvm,
+  objDiff,
+  objKeys,
   objMap,
   promiseObjAll,
   rootLogger,
@@ -64,6 +68,7 @@ import {
   contractVersionMatchesDependency,
   derivedHookAddress,
   derivedIsmAddress,
+  isEverclearTokenBridgeConfig,
   isMovableCollateralTokenConfig,
 } from './types.js';
 
@@ -171,6 +176,8 @@ export class EvmERC20WarpModule extends HyperlaneModule<
         expectedConfig,
       )),
       ...this.createRemoveBridgesTxs(actualConfig, expectedConfig),
+      ...this.createAddRemoteOutputAddressTxs(actualConfig, expectedConfig),
+      ...this.createRemoveRemoteOutputAddressTxs(actualConfig, expectedConfig),
       ...this.createOwnershipUpdateTxs(actualConfig, expectedConfig),
       ...proxyAdminUpdateTxs(
         this.chainId,
@@ -550,6 +557,117 @@ export class EvmERC20WarpModule extends HyperlaneModule<
         });
       },
     );
+  }
+
+  createAddRemoteOutputAddressTxs(
+    actualConfig: DerivedTokenRouterConfig,
+    expectedConfig: HypTokenRouterConfig,
+  ): AnnotatedEV5Transaction[] {
+    if (
+      !isEverclearTokenBridgeConfig(expectedConfig) ||
+      !isEverclearTokenBridgeConfig(actualConfig)
+    ) {
+      return [];
+    }
+
+    const actualOutputAssets = resolveRouterMapConfig(
+      this.multiProvider,
+      actualConfig.outputAssets,
+    );
+    const expectedOutputAssets = resolveRouterMapConfig(
+      this.multiProvider,
+      expectedConfig.outputAssets,
+    );
+
+    const outputAssetsToAdd = objDiff(
+      expectedOutputAssets,
+      actualOutputAssets,
+      (address, address2) =>
+        !!address &&
+        !!address2 &&
+        addressToBytes32(address) !== addressToBytes32(address2),
+    );
+    if (isObjEmpty(outputAssetsToAdd)) {
+      return [];
+    }
+
+    const assets = Object.entries(outputAssetsToAdd).map(
+      ([domainId, outputAsset]): {
+        destination: number;
+        outputAsset: string;
+      } => ({
+        destination: parseInt(domainId),
+        outputAsset: addressToBytes32(outputAsset),
+      }),
+    );
+
+    return [
+      {
+        chainId: this.multiProvider.getEvmChainId(this.chainId),
+        to: this.args.addresses.deployedTokenRoute,
+        annotation: `Adding "${Object.keys(assets)}" output assets for token "${this.args.addresses.deployedTokenRoute}" on chain "${this.chainName}"`,
+        data: EverclearTokenBridge__factory.createInterface().encodeFunctionData(
+          'setOutputAssetsBatch((uint32,bytes32)[])',
+          [assets],
+        ),
+      },
+    ];
+  }
+
+  createRemoveRemoteOutputAddressTxs(
+    actualConfig: DerivedTokenRouterConfig,
+    expectedConfig: HypTokenRouterConfig,
+  ): AnnotatedEV5Transaction[] {
+    if (
+      !isEverclearTokenBridgeConfig(expectedConfig) ||
+      !isEverclearTokenBridgeConfig(actualConfig)
+    ) {
+      return [];
+    }
+
+    const actualOutputAssets = resolveRouterMapConfig(
+      this.multiProvider,
+      actualConfig.outputAssets,
+    );
+    const expectedOutputAssets = resolveRouterMapConfig(
+      this.multiProvider,
+      expectedConfig.outputAssets,
+    );
+
+    const outputAssetsToRemove = Array.from(
+      difference(
+        new Set(objKeys(actualOutputAssets)),
+        new Set(objKeys(expectedOutputAssets)),
+      ),
+    );
+
+    if (outputAssetsToRemove.length === 0) {
+      return [];
+    }
+
+    const assets = outputAssetsToRemove.map(
+      (
+        domainId,
+      ): {
+        destination: number;
+        outputAsset: string;
+      } => ({
+        destination: this.multiProvider.getDomainId(domainId),
+        outputAsset: ZERO_ADDRESS_HEX_32,
+      }),
+    );
+
+    return [
+      {
+        chainId: this.multiProvider.getEvmChainId(this.chainId),
+        to: this.args.addresses.deployedTokenRoute,
+        annotation: `Removing "${outputAssetsToRemove}" output assets from token "${this.args.addresses.deployedTokenRoute}" on chain "${this.chainName}"`,
+        data: EverclearTokenBridge__factory.createInterface().encodeFunctionData(
+          'setOutputAssetsBatch((uint32,bytes32)[])',
+          [assets],
+        ),
+      },
+    ];
   }
 
   /**
@@ -1013,6 +1131,18 @@ export class EvmERC20WarpModule extends HyperlaneModule<
       for (const tx of addBridgesTxs) {
         await multiProvider.sendTransaction(chain, tx);
       }
+    }
+
+    if (
+      isEverclearTokenBridgeConfig(config) &&
+      !isObjEmpty(config.outputAssets)
+    ) {
+      const addRemoteOutputTokens = warpModule.createAddRemoteOutputAddressTxs(
+        actualConfig,
+        config,
+      );
+
+      await multiProvider.sendTransaction(chain, addRemoteOutputTokens[0]);
     }
 
     return warpModule;

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -504,7 +504,7 @@ describe('ERC20WarpRouterReader', async () => {
     TokenType.ethEverclear,
     TokenType.collateralEverclear,
   ] as EverclearTokenBridgeTokenType[]) {
-    it.only(`should derive ${tokenType} token correctly`, async () => {
+    it(`should derive ${tokenType} token correctly`, async () => {
       // Create config
       const config: WarpRouteDeployConfigMailboxRequired = {
         [chain]: getEverclearTokenBridgeConfig()[tokenType],

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -30,6 +30,7 @@ import {
   assert,
   eqAddress,
   getLogLevel,
+  isZeroish,
   isZeroishAddress,
   objFilter,
   objMap,
@@ -732,7 +733,11 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
 
     return {
       everclearBridgeAddress,
-      outputAssets,
+      outputAssets: objFilter(
+        outputAssets,
+        (_domainId, assetAddress): assetAddress is string =>
+          !isZeroish(assetAddress),
+      ),
       everclearFeeParams: {
         deadline: deadline.toNumber(),
         fee: fee.toNumber(),

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -112,6 +112,9 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
       [TokenType.nativeScaled]: null,
       [TokenType.collateralUri]: null,
       [TokenType.syntheticUri]: null,
+      // TODO: add everclear token derivation
+      [TokenType.ethEverclear]: null,
+      [TokenType.collateralEverclear]: null,
     };
 
     this.contractVerifier =

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -1,6 +1,8 @@
 import { Contract } from 'ethers';
 
 import {
+  EverclearTokenBridge,
+  EverclearTokenBridge__factory,
   HypERC20Collateral__factory,
   HypERC20__factory,
   HypERC4626Collateral__factory,
@@ -10,6 +12,7 @@ import {
   HypXERC20__factory,
   IFiatToken__factory,
   IMessageTransmitter__factory,
+  IWETH__factory,
   IXERC20__factory,
   MovableCollateralRouter__factory,
   OpL1NativeTokenBridge__factory,
@@ -53,6 +56,8 @@ import {
   CctpTokenConfig,
   CollateralTokenConfig,
   DerivedTokenRouterConfig,
+  EverclearCollateralTokenConfig,
+  EverclearEthBridgeTokenConfig,
   HypTokenConfig,
   HypTokenConfigSchema,
   HypTokenRouterVirtualConfig,
@@ -112,9 +117,10 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
       [TokenType.nativeScaled]: null,
       [TokenType.collateralUri]: null,
       [TokenType.syntheticUri]: null,
-      // TODO: add everclear token derivation
-      [TokenType.ethEverclear]: null,
-      [TokenType.collateralEverclear]: null,
+      [TokenType.ethEverclear]:
+        this.deriveEverclearEthTokenBridgeConfig.bind(this),
+      [TokenType.collateralEverclear]:
+        this.deriveEverclearTokenbridgeConfig.bind(this),
     };
 
     this.contractVerifier =
@@ -320,7 +326,45 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
               error,
             );
           }
+
+          try {
+            const maybeEverclearTokenBridge =
+              EverclearTokenBridge__factory.connect(
+                warpRouteAddress,
+                this.provider,
+              );
+
+            await maybeEverclearTokenBridge.callStatic.feeParams();
+
+            let everclearTokenType = TokenType.collateralEverclear;
+            try {
+              // if simulating an ETH transfer works this should be the WETH contract
+              await this.provider.estimateGas({
+                from: NON_ZERO_SENDER_ADDRESS,
+                to: wrappedToken,
+                data: IWETH__factory.createInterface().encodeFunctionData(
+                  'deposit',
+                ),
+                value: 1,
+              });
+
+              everclearTokenType = TokenType.ethEverclear;
+            } catch (error) {
+              this.logger.debug(
+                `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.collateralEverclear}`,
+                error,
+              );
+            }
+
+            return everclearTokenType;
+          } catch (error) {
+            this.logger.debug(
+              `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.collateralEverclear}`,
+              error,
+            );
+          }
         }
+
         return tokenType as TokenType;
       } catch {
         continue;
@@ -662,6 +706,87 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
       ...erc20TokenMetadata,
       type: TokenType.syntheticRebase,
       collateralChainName,
+    };
+  }
+
+  private async deriveEverclearbridgeConfig(
+    everclearTokenbridgeInstance: EverclearTokenBridge,
+  ): Promise<
+    Pick<
+      EverclearEthBridgeTokenConfig,
+      'everclearBridgeAddress' | 'outputAssets' | 'everclearFeeParams'
+    >
+  > {
+    const [[deadline, fee, signature], everclearBridgeAddress, domains] =
+      await Promise.all([
+        everclearTokenbridgeInstance.feeParams(),
+        everclearTokenbridgeInstance.everclearAdapter(),
+        everclearTokenbridgeInstance.domains(),
+      ]);
+
+    const outputAssets = await promiseObjAll(
+      objMap(arrayToObject(domains.map(String)), async (domainId, _) =>
+        everclearTokenbridgeInstance.outputAssets(domainId),
+      ),
+    );
+
+    return {
+      everclearBridgeAddress,
+      outputAssets,
+      everclearFeeParams: {
+        deadline: deadline.toNumber(),
+        fee: fee.toNumber(),
+        signature,
+      },
+    };
+  }
+
+  private async deriveEverclearEthTokenBridgeConfig(
+    hypTokenAddress: Address,
+  ): Promise<EverclearEthBridgeTokenConfig> {
+    const everclearTokenbridgeInstance = EverclearTokenBridge__factory.connect(
+      hypTokenAddress,
+      this.provider,
+    );
+
+    const wethAddress = await everclearTokenbridgeInstance.wrappedToken();
+    const { everclearBridgeAddress, everclearFeeParams, outputAssets } =
+      await this.deriveEverclearbridgeConfig(everclearTokenbridgeInstance);
+
+    return {
+      type: TokenType.ethEverclear,
+      wethAddress,
+      everclearBridgeAddress,
+      everclearFeeParams,
+      outputAssets,
+    };
+  }
+
+  private async deriveEverclearTokenbridgeConfig(
+    hypTokenAddress: Address,
+  ): Promise<EverclearCollateralTokenConfig> {
+    const everclearTokenbridgeInstance = EverclearTokenBridge__factory.connect(
+      hypTokenAddress,
+      this.provider,
+    );
+
+    const collateralTokenAddress =
+      await everclearTokenbridgeInstance.wrappedToken();
+    const [
+      erc20TokenMetadata,
+      { everclearBridgeAddress, everclearFeeParams, outputAssets },
+    ] = await Promise.all([
+      this.fetchERC20Metadata(collateralTokenAddress),
+      this.deriveEverclearbridgeConfig(everclearTokenbridgeInstance),
+    ]);
+
+    return {
+      type: TokenType.collateralEverclear,
+      ...erc20TokenMetadata,
+      token: collateralTokenAddress,
+      everclearBridgeAddress,
+      everclearFeeParams,
+      outputAssets,
     };
   }
 

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -718,7 +718,7 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
       'everclearBridgeAddress' | 'outputAssets' | 'everclearFeeParams'
     >
   > {
-    const [[deadline, fee, signature], everclearBridgeAddress, domains] =
+    const [[fee, deadline, signature], everclearBridgeAddress, domains] =
       await Promise.all([
         everclearTokenbridgeInstance.feeParams(),
         everclearTokenbridgeInstance.everclearAdapter(),

--- a/typescript/sdk/src/token/Token.test.ts
+++ b/typescript/sdk/src/token/Token.test.ts
@@ -123,6 +123,8 @@ const STANDARD_TO_TOKEN: Record<TokenStandard, TokenArgs | null> = {
     symbol: 'USDC',
     name: 'USDC',
   },
+  [TokenStandard.EvmHypEverclearCollateral]: null,
+  [TokenStandard.EvmHypEverclearEth]: null,
 
   // Sealevel
   [TokenStandard.SealevelSpl]: {

--- a/typescript/sdk/src/token/TokenStandard.ts
+++ b/typescript/sdk/src/token/TokenStandard.ts
@@ -23,6 +23,8 @@ export enum TokenStandard {
   EvmHypXERC20Lockbox = 'EvmHypXERC20Lockbox',
   EvmHypVSXERC20 = 'EvmHypVSXERC20',
   EvmHypVSXERC20Lockbox = 'EvmHypVSXERC20Lockbox',
+  EvmHypEverclearCollateral = 'EvmHypEverclearCollateral',
+  EvmHypEverclearEth = 'EvmHypEverclearEth',
 
   // Sealevel (Solana)
   SealevelSpl = 'SealevelSpl',
@@ -73,6 +75,8 @@ export const TOKEN_STANDARD_TO_PROTOCOL: Record<TokenStandard, ProtocolType> = {
   EvmHypXERC20Lockbox: ProtocolType.Ethereum,
   EvmHypVSXERC20: ProtocolType.Ethereum,
   EvmHypVSXERC20Lockbox: ProtocolType.Ethereum,
+  [TokenStandard.EvmHypEverclearCollateral]: ProtocolType.Ethereum,
+  [TokenStandard.EvmHypEverclearEth]: ProtocolType.Ethereum,
 
   // Sealevel (Solana)
   SealevelSpl: ProtocolType.Sealevel,
@@ -210,6 +214,8 @@ export const TOKEN_TYPE_TO_STANDARD: Record<TokenType, TokenStandard> = {
   [TokenType.syntheticRebase]: TokenStandard.EvmHypSyntheticRebase,
   [TokenType.syntheticUri]: TokenStandard.EvmHypSynthetic,
   [TokenType.nativeScaled]: TokenStandard.EvmHypNative,
+  [TokenType.ethEverclear]: TokenStandard.EvmHypEverclearEth,
+  [TokenType.collateralEverclear]: TokenStandard.EvmHypEverclearCollateral,
 };
 
 // Starknet supported token types

--- a/typescript/sdk/src/token/config.ts
+++ b/typescript/sdk/src/token/config.ts
@@ -47,6 +47,10 @@ export type MovableTokenType = {
     : never;
 }[keyof typeof isMovableCollateralTokenTypeMap];
 
+export type EverclearTokenBridgeTokenType =
+  | TokenType.ethEverclear
+  | TokenType.collateralEverclear;
+
 export function isMovableCollateralTokenType(type: TokenType): boolean {
   return !!isMovableCollateralTokenTypeMap[type];
 }

--- a/typescript/sdk/src/token/config.ts
+++ b/typescript/sdk/src/token/config.ts
@@ -10,9 +10,11 @@ export enum TokenType {
   collateralFiat = 'collateralFiat',
   collateralUri = 'collateralUri',
   collateralCctp = 'collateralCctp',
+  collateralEverclear = 'collateralEverclear',
   native = 'native',
   nativeOpL2 = 'nativeOpL2',
   nativeOpL1 = 'nativeOpL1',
+  ethEverclear = 'ethEverclear',
   // backwards compatible alias to native
   nativeScaled = 'nativeScaled',
 }
@@ -35,6 +37,8 @@ const isMovableCollateralTokenTypeMap = {
   [TokenType.synthetic]: false,
   [TokenType.syntheticRebase]: false,
   [TokenType.syntheticUri]: false,
+  [TokenType.ethEverclear]: false,
+  [TokenType.collateralEverclear]: false,
 } as const;
 
 export type MovableTokenType = {

--- a/typescript/sdk/src/token/contracts.ts
+++ b/typescript/sdk/src/token/contracts.ts
@@ -1,4 +1,8 @@
+import { ContractFactory } from 'ethers';
+
 import {
+  EverclearEthBridge__factory,
+  EverclearTokenBridge__factory,
   HypERC20Collateral__factory,
   HypERC20__factory,
   HypERC721Collateral__factory,
@@ -37,8 +41,15 @@ export const hypERC20contracts = {
   [TokenType.nativeOpL1]: 'OpL1TokenBridgeNative',
   // uses same contract as native
   [TokenType.nativeScaled]: 'HypNative',
-} as const;
+  [TokenType.ethEverclear]: 'EverclearEthBridge',
+  [TokenType.collateralEverclear]: 'EverclearTokenBridge',
+} as const satisfies Record<TokenType, string>;
 export type HypERC20contracts = typeof hypERC20contracts;
+
+type HypERC20TokenType = Exclude<
+  TokenType,
+  TokenType.syntheticUri | TokenType.collateralUri
+>;
 
 export const hypERC20factories = {
   [TokenType.synthetic]: new HypERC20__factory(),
@@ -56,7 +67,10 @@ export const hypERC20factories = {
   // assume V1 for now
   [TokenType.nativeOpL1]: new OpL1V1NativeTokenBridge__factory(),
   [TokenType.nativeScaled]: new HypNative__factory(),
-} as const;
+
+  [TokenType.ethEverclear]: new EverclearEthBridge__factory(),
+  [TokenType.collateralEverclear]: new EverclearTokenBridge__factory(),
+} as const satisfies Record<HypERC20TokenType, ContractFactory>;
 export type HypERC20Factories = typeof hypERC20factories;
 
 // Helper function to get the appropriate CCTP factory based on version

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -271,7 +271,10 @@ abstract class TokenDeployer<
         continue;
       }
 
-      if (isNativeTokenConfig(config)) {
+      if (
+        isNativeTokenConfig(config) ||
+        isEverclearEthBridgeTokenConfig(config)
+      ) {
         const nativeToken = multiProvider.getChainMetadata(chain).nativeToken;
         if (nativeToken) {
           metadataMap.set(
@@ -287,7 +290,8 @@ abstract class TokenDeployer<
       if (
         isCollateralTokenConfig(config) ||
         isXERC20TokenConfig(config) ||
-        isCctpTokenConfig(config)
+        isCctpTokenConfig(config) ||
+        isEverclearCollateralTokenConfig(config)
       ) {
         const provider = multiProvider.getProvider(chain);
 

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -15,6 +15,7 @@ import {
 } from '@hyperlane-xyz/core';
 import {
   ProtocolType,
+  addressToBytes32,
   assert,
   objFilter,
   objKeys,
@@ -58,6 +59,7 @@ import {
   isCollateralTokenConfig,
   isEverclearCollateralTokenConfig,
   isEverclearEthBridgeTokenConfig,
+  isEverclearTokenBridgeConfig,
   isMovableCollateralTokenConfig,
   isNativeTokenConfig,
   isOpL1TokenConfig,
@@ -513,6 +515,73 @@ abstract class TokenDeployer<
     );
   }
 
+  protected async setEverclearFeeParams(
+    configMap: ChainMap<HypTokenConfig>,
+    deployedContractsMap: HyperlaneContractsMap<Factories>,
+  ): Promise<void> {
+    await promiseObjAll(
+      objMap(configMap, async (chain, config) => {
+        if (!isEverclearTokenBridgeConfig(config)) {
+          return;
+        }
+
+        const router = this.router(deployedContractsMap[chain]).address;
+        const everclearTokenBridge = EverclearTokenBridge__factory.connect(
+          router,
+          this.multiProvider.getSigner(chain),
+        );
+
+        await this.multiProvider.handleTx(
+          chain,
+          everclearTokenBridge.setFeeParams(
+            config.everclearFeeParams.fee,
+            config.everclearFeeParams.deadline,
+            config.everclearFeeParams.signature,
+          ),
+        );
+      }),
+    );
+  }
+
+  protected async setEverclearOutputAssets(
+    configMap: ChainMap<HypTokenConfig>,
+    deployedContractsMap: HyperlaneContractsMap<Factories>,
+  ): Promise<void> {
+    await promiseObjAll(
+      objMap(configMap, async (chain, config) => {
+        if (!isEverclearTokenBridgeConfig(config)) {
+          return;
+        }
+
+        const router = this.router(deployedContractsMap[chain]).address;
+        const everclearTokenBridge = EverclearTokenBridge__factory.connect(
+          router,
+          this.multiProvider.getSigner(chain),
+        );
+
+        const remoteOutputAddresses = resolveRouterMapConfig(
+          this.multiProvider,
+          config.outputAssets ?? {},
+        );
+
+        const assets = Object.entries(remoteOutputAddresses).map(
+          ([domainId, outputAsset]): {
+            destination: number;
+            outputAsset: string;
+          } => ({
+            destination: parseInt(domainId),
+            outputAsset: addressToBytes32(outputAsset),
+          }),
+        );
+
+        await this.multiProvider.handleTx(
+          chain,
+          everclearTokenBridge.setOutputAssetsBatch(assets),
+        );
+      }),
+    );
+  }
+
   async deploy(configMap: WarpRouteDeployConfigMailboxRequired) {
     let tokenMetadataMap: TokenMetadataMap;
     try {
@@ -545,6 +614,10 @@ abstract class TokenDeployer<
     await this.setAllowedBridges(configMap, deployedContractsMap);
 
     await this.setBridgesTokenApprovals(configMap, deployedContractsMap);
+
+    await this.setEverclearFeeParams(configMap, deployedContractsMap);
+
+    await this.setEverclearOutputAssets(configMap, deployedContractsMap);
 
     return deployedContractsMap;
   }

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -54,6 +54,16 @@ const MovableTokenRebalancingBridgeConfigSchema = z.object({
     .optional(),
 });
 
+const BaseEverclearTokenBridgeConfigSchema = z.object({
+  everclearBridgeAddress: ZHash,
+  outputAssets: z.record(RemoteRouterDomainOrChainNameSchema, ZHash),
+  everclearFeeParams: z.object({
+    fee: z.number().int(),
+    deadline: z.number().int(),
+    signature: z.string(),
+  }),
+});
+
 export const BaseMovableTokenConfigSchema = z.object({
   allowedRebalancingBridges: z
     .record(
@@ -200,6 +210,24 @@ export const isSyntheticRebaseTokenConfig = isCompliant(
   SyntheticRebaseTokenConfigSchema,
 );
 
+export const EverclearCollateralTokenConfigSchema = z.object({
+  type: z.literal(TokenType.collateralEverclear),
+  ...CollateralTokenConfigSchema.omit({ type: true }).shape,
+  ...BaseEverclearTokenBridgeConfigSchema.shape,
+});
+export const isEverclearCollateralTokenConfig = isCompliant(
+  EverclearCollateralTokenConfigSchema,
+);
+
+export const EverclearEthBridgeTokenConfigSchema = z.object({
+  type: z.literal(TokenType.ethEverclear),
+  ...NativeTokenConfigSchema.omit({ type: true }).shape,
+  ...BaseEverclearTokenBridgeConfigSchema.shape,
+});
+export const isEverclearEthBridgeTokenConfig = isCompliant(
+  EverclearEthBridgeTokenConfigSchema,
+);
+
 export enum ContractVerificationStatus {
   Verified = 'verified',
   Unverified = 'unverified',
@@ -234,6 +262,8 @@ export const HypTokenConfigSchema = z.discriminatedUnion('type', [
   SyntheticTokenConfigSchema,
   SyntheticRebaseTokenConfigSchema,
   CctpTokenConfigSchema,
+  EverclearCollateralTokenConfigSchema,
+  EverclearEthBridgeTokenConfigSchema,
 ]);
 export type HypTokenConfig = z.infer<typeof HypTokenConfigSchema>;
 

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -324,7 +324,8 @@ export const WarpRouteDeployConfigSchema = z
           isCollateralRebaseTokenConfig(config) ||
           isCctpTokenConfig(config) ||
           isXERC20TokenConfig(config) ||
-          isNativeTokenConfig(config),
+          isNativeTokenConfig(config) ||
+          isEverclearTokenBridgeConfig(config),
       ) || entries.every(([_, config]) => isTokenMetadata(config))
     );
   }, WarpRouteDeployConfigSchemaErrors.NO_SYNTHETIC_ONLY)

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -215,6 +215,10 @@ export const EverclearCollateralTokenConfigSchema = z.object({
   ...CollateralTokenConfigSchema.omit({ type: true }).shape,
   ...BaseEverclearTokenBridgeConfigSchema.shape,
 });
+
+export type EverclearCollateralTokenConfig = z.infer<
+  typeof EverclearCollateralTokenConfigSchema
+>;
 export const isEverclearCollateralTokenConfig = isCompliant(
   EverclearCollateralTokenConfigSchema,
 );
@@ -225,6 +229,10 @@ export const EverclearEthBridgeTokenConfigSchema = z.object({
   ...NativeTokenConfigSchema.omit({ type: true }).shape,
   ...BaseEverclearTokenBridgeConfigSchema.shape,
 });
+
+export type EverclearEthBridgeTokenConfig = z.infer<
+  typeof EverclearEthBridgeTokenConfigSchema
+>;
 export const isEverclearEthBridgeTokenConfig = isCompliant(
   EverclearEthBridgeTokenConfigSchema,
 );

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -64,6 +64,10 @@ const BaseEverclearTokenBridgeConfigSchema = z.object({
   }),
 });
 
+export const isEverclearTokenBridgeConfig = isCompliant(
+  BaseEverclearTokenBridgeConfigSchema,
+);
+
 export const BaseMovableTokenConfigSchema = z.object({
   allowedRebalancingBridges: z
     .record(

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -221,6 +221,7 @@ export const isEverclearCollateralTokenConfig = isCompliant(
 
 export const EverclearEthBridgeTokenConfigSchema = z.object({
   type: z.literal(TokenType.ethEverclear),
+  wethAddress: ZHash,
   ...NativeTokenConfigSchema.omit({ type: true }).shape,
   ...BaseEverclearTokenBridgeConfigSchema.shape,
 });

--- a/typescript/utils/src/index.ts
+++ b/typescript/utils/src/index.ts
@@ -140,6 +140,7 @@ export {
   transformObj,
   TransformObjectTransformer,
   sortArraysInObject,
+  objDiff,
 } from './objects.js';
 export { Result, failure, success } from './result.js';
 export {

--- a/typescript/utils/src/objects.ts
+++ b/typescript/utils/src/objects.ts
@@ -454,3 +454,32 @@ export function sortArraysInObject(
 
   return obj;
 }
+
+type JSPrimitiveTypes =
+  | string
+  | number
+  | bigint
+  | boolean
+  | undefined
+  | symbol
+  | null;
+
+/**
+ * Returns an object where only the keys from `a` that are not in `b` or are different, are kept
+ */
+export function objDiff<
+  TKey extends string | number,
+  TValue extends JSPrimitiveTypes,
+>(
+  a: Record<TKey, TValue>,
+  b: Record<TKey, TValue>,
+  compare: (a: TValue, b: TValue) => boolean = (a, b) => a !== b,
+): Record<TKey, TValue> {
+  const bKeys = new Set(objKeys(b));
+
+  return objFilter(
+    a,
+    (key, value): value is TValue =>
+      !bKeys.has(key as TKey) || compare(value, b[key as TKey]),
+  ) as Record<TKey, TValue>;
+}


### PR DESCRIPTION
### Description

This PR add support for deploying the new `EverclearEthBridge` and `EverclearTokenBridge` contracts

### Drive-by changes

- Updates the hardhat and anvil start config to skip the contract size limit (for now)
- Moves the `MockEverclearAdapter` from the `solidity/test/token/EverclearTokenBridge.t.sol` to its own file
- implements the `objDiff` function to filter out properties in an object when compared to one of the same type

### Related issues

- Fixes #[ENG-1918](https://linear.app/hyperlane-xyz/issue/ENG-1918/support-configuration-and-deployment-of-everclear-token-bridges)

### Backward compatibility

- YES

### Testing

- E2E
- unit
