### PR TITLE
feat: use safe arithmetic for gas estimation

### DIFF
--- a/rust/main/lander/src/adapter/chains/ethereum/adapter/gas_price/escalator.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter/gas_price/escalator.rs
@@ -102,5 +102,35 @@ fn get_escalated_price_from_old_and_new(old_gas_price: &U256, new_gas_price: &U2
 fn apply_escalation_multiplier(gas_price: &U256) -> U256 {
     let numerator = U256::from(ESCALATION_MULTIPLIER_NUMERATOR);
     let denominator = U256::from(ESCALATION_MULTIPLIER_DENOMINATOR);
-    gas_price * numerator / denominator
+    gas_price.saturating_mul(numerator).div_mod(denominator).0
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperlane_core::U256;
+
+    use crate::adapter::chains::ethereum::adapter::gas_price::GasPrice;
+
+    use super::*;
+
+    #[test]
+    fn test_gas_price_does_not_overflow() {
+        let old_gas_price = GasPrice::Eip1559 {
+            max_fee: U256::MAX,
+            max_priority_fee: U256::MAX,
+        };
+        let estimated_gas_price = GasPrice::Eip1559 {
+            max_fee: U256::MAX,
+            max_priority_fee: U256::MAX,
+        };
+
+        // should not overflow and panic
+        let res = escalate_gas_price_if_needed(&old_gas_price, &estimated_gas_price);
+        let expected = GasPrice::Eip1559 {
+            max_fee: U256::MAX,
+            max_priority_fee: U256::MAX,
+        };
+
+        assert_eq!(res, expected);
+    }
 }

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter/gas_price/price.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter/gas_price/price.rs
@@ -4,7 +4,7 @@ use hyperlane_core::U256;
 
 use crate::adapter::EthereumTxPrecursor;
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum GasPrice {
     None,
     NonEip1559 {


### PR DESCRIPTION
### Description

- prevent overflow when calculating gas estimation

### Related issues

- fixes https://linear.app/hyperlane-xyz/issue/ENG-2031/lander-fix-arithmetic-overflow-at-price-escalation

### Testing

- Unit test