### PR TITLE
feat: get lockbox wrapped token

### DIFF
--- a/.changeset/smart-emus-change.md
+++ b/.changeset/smart-emus-change.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": minor
+---
+
+Make `getWrappedTokenAddress` public, add LOCKBOX_STANDARDS

--- a/.changeset/twelve-pets-tease.md
+++ b/.changeset/twelve-pets-tease.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": minor
+---
+
+Include lockbox check for `useEthereumWatchAsset`

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -663,6 +663,7 @@ export {
 export { TokenMetadataMap } from './token/TokenMetadataMap.js';
 export {
   EVM_TOKEN_TYPE_TO_STANDARD,
+  LOCKBOX_STANDARDS,
   MINT_LIMITED_STANDARDS,
   PROTOCOL_TO_NATIVE_STANDARD,
   TOKEN_COLLATERALIZED_STANDARDS,

--- a/typescript/sdk/src/token/TokenStandard.ts
+++ b/typescript/sdk/src/token/TokenStandard.ts
@@ -146,6 +146,11 @@ export const XERC20_STANDARDS = [
   TokenStandard.EvmHypVSXERC20Lockbox,
 ];
 
+export const LOCKBOX_STANDARDS = [
+  TokenStandard.EvmHypXERC20Lockbox,
+  TokenStandard.EvmHypVSXERC20Lockbox,
+];
+
 export const MINT_LIMITED_STANDARDS = [
   TokenStandard.EvmHypXERC20,
   TokenStandard.EvmHypXERC20Lockbox,

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -304,7 +304,7 @@ export class EvmHypCollateralAdapter
     );
   }
 
-  protected async getWrappedTokenAddress(): Promise<Address> {
+  async getWrappedTokenAddress(): Promise<Address> {
     if (!this.wrappedTokenAddress) {
       this.wrappedTokenAddress = await this.collateralContract.wrappedToken();
     }

--- a/typescript/sdk/src/token/adapters/ITokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/ITokenAdapter.ts
@@ -61,6 +61,7 @@ export interface IMovableCollateralRouterAdapter<Tx> extends ITokenAdapter<Tx> {
     amount: Numberish,
     isWarp: boolean,
   ): Promise<InterchainGasQuote[]>;
+  getWrappedTokenAddress(): Promise<Address>;
 
   populateRebalanceTx(
     domain: Domain,

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -24,6 +24,7 @@ import { Token } from '../token/Token.js';
 import { TokenAmount } from '../token/TokenAmount.js';
 import { parseTokenConnectionId } from '../token/TokenConnection.js';
 import {
+  LOCKBOX_STANDARDS,
   MINT_LIMITED_STANDARDS,
   TOKEN_COLLATERALIZED_STANDARDS,
   TOKEN_STANDARD_TO_PROVIDER_TYPE,
@@ -535,10 +536,7 @@ export class WarpCore {
   }
 
   async getTokenCollateral(token: IToken): Promise<bigint> {
-    if (
-      token.standard === TokenStandard.EvmHypXERC20Lockbox ||
-      token.standard === TokenStandard.EvmHypVSXERC20Lockbox
-    ) {
+    if (LOCKBOX_STANDARDS.includes(token.standard)) {
       const adapter = token.getAdapter(
         this.multiProvider,
       ) as EvmHypXERC20LockboxAdapter;

--- a/typescript/widgets/src/walletIntegrations/ethereum.ts
+++ b/typescript/widgets/src/walletIntegrations/ethereum.ts
@@ -12,7 +12,9 @@ import { useAccount, useConfig, useDisconnect } from 'wagmi';
 
 import {
   ChainName,
+  EvmHypXERC20LockboxAdapter,
   IToken,
+  LOCKBOX_STANDARDS,
   MultiProtocolProvider,
   ProviderType,
   TypedTransactionReceipt,
@@ -122,16 +124,26 @@ export function useEthereumWatchAsset(
       if (activeChainName && activeChainName !== chainName)
         await switchNetwork(chainName);
 
+      let tokenAddress = '';
+      if (LOCKBOX_STANDARDS.includes(token.standard)) {
+        const adapter = token.getAdapter(
+          multiProvider,
+        ) as EvmHypXERC20LockboxAdapter;
+        tokenAddress = await adapter.getWrappedTokenAddress();
+      } else {
+        tokenAddress = token.collateralAddressOrDenom || token.addressOrDenom;
+      }
+
       return watchAsset(config, {
         type: 'ERC20',
         options: {
-          address: token.collateralAddressOrDenom || token.addressOrDenom,
+          address: tokenAddress,
           decimals: token.decimals,
           symbol: token.symbol,
         },
       });
     },
-    [config, switchNetwork],
+    [config, switchNetwork, multiProvider],
   );
 
   return { addAsset: onAddAsset };


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

This PR updates `useEthereumWatchAsset` with the correct token for lockbox standard tokens

- Make `getWrappedTokenAddress` function as public
- Add new `LOCKBOX_STANDARDS` array for simplified checks
- Update `useEthereumWatchAsset` to include lockbox wrapped token address

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
Manual and UI