### PR TITLE
fix: parse private keys as string instead of number

### DIFF
--- a/.changeset/afraid-mice-attend.md
+++ b/.changeset/afraid-mice-attend.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/cli": patch
+---
+
+fix: parse private keys as string instead of number

--- a/typescript/cli/cli.ts
+++ b/typescript/cli/cli.ts
@@ -79,6 +79,9 @@ try {
     .demandCommand()
     .strict()
     .help()
+    .parserConfiguration({
+      'parse-numbers': false,
+    })
     .showHelpOnFail(false).argv;
 } catch (error: any) {
   errorRed('Error: ' + error.message);


### PR DESCRIPTION
### Description

This PR fixes an issue where `yargs` parses the hex private key as decimal instead of string

### Drive-by changes

### Related issues

### Backward compatibility

### Testing




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where private keys were incorrectly parsed as numbers by treating numeric-looking inputs as strings in the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->