### PR TITLE
feat: update ISMs to enroll celestia

### DIFF
--- a/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
+++ b/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
@@ -2,71 +2,71 @@
   "solanamainnet": {
     "abstract": {
       "oracleConfig": {
-        "tokenExchangeRate": "251984749943933617403",
-        "gasPrice": "154604207",
+        "tokenExchangeRate": "302449361171704580866",
+        "gasPrice": "89491282",
         "tokenDecimals": 18
       },
       "overhead": 333774
     },
     "apechain": {
       "oracleConfig": {
-        "tokenExchangeRate": "63400650370038125",
-        "gasPrice": "1087286206132",
+        "tokenExchangeRate": "51692115923963851",
+        "gasPrice": "926512141953",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "arbitrum": {
       "oracleConfig": {
-        "tokenExchangeRate": "251984749943933617403",
-        "gasPrice": "683917002",
+        "tokenExchangeRate": "302449361171704580866",
+        "gasPrice": "395879195",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "artela": {
       "oracleConfig": {
-        "tokenExchangeRate": "132904238618524",
-        "gasPrice": "518679113049071",
+        "tokenExchangeRate": "14396229354939",
+        "gasPrice": "3326799807503963",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "avalanche": {
       "oracleConfig": {
-        "tokenExchangeRate": "1892801076474545862",
-        "gasPrice": "36419385780",
+        "tokenExchangeRate": "2098005609224057338",
+        "gasPrice": "22828048141",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "base": {
       "oracleConfig": {
-        "tokenExchangeRate": "251984749943933617403",
-        "gasPrice": "273566764",
+        "tokenExchangeRate": "302449361171704580866",
+        "gasPrice": "158351709",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "bsc": {
       "oracleConfig": {
-        "tokenExchangeRate": "69372056514913657770",
-        "gasPrice": "993694812",
+        "tokenExchangeRate": "66772358990339669679",
+        "gasPrice": "717263458",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "eclipsemainnet": {
       "oracleConfig": {
-        "tokenExchangeRate": "25198474994393361",
-        "gasPrice": "2283",
+        "tokenExchangeRate": "30244936117170458",
+        "gasPrice": "1321",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
     "ethereum": {
       "oracleConfig": {
-        "tokenExchangeRate": "251984749943933617403",
+        "tokenExchangeRate": "302449361171704580866",
         "gasPrice": "4000000000",
         "tokenDecimals": 18
       },
@@ -74,39 +74,39 @@
     },
     "everclear": {
       "oracleConfig": {
-        "tokenExchangeRate": "251984749943933617403",
-        "gasPrice": "273566764",
+        "tokenExchangeRate": "302449361171704580866",
+        "gasPrice": "158351709",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "flowmainnet": {
       "oracleConfig": {
-        "tokenExchangeRate": "34437429917021753",
-        "gasPrice": "2001736272807",
+        "tokenExchangeRate": "33101589280149579",
+        "gasPrice": "1446860229020",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "form": {
       "oracleConfig": {
-        "tokenExchangeRate": "251984749943933617403",
-        "gasPrice": "273566764",
+        "tokenExchangeRate": "302449361171704580866",
+        "gasPrice": "158351709",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "hyperevm": {
       "oracleConfig": {
-        "tokenExchangeRate": "3932496075353218210",
-        "gasPrice": "17529490504",
+        "tokenExchangeRate": "3448114677469616703",
+        "gasPrice": "13889727439",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "infinityvmmainnet": {
       "oracleConfig": {
-        "tokenExchangeRate": "112132765193989683",
+        "tokenExchangeRate": "77905889685260205",
         "gasPrice": "0",
         "tokenDecimals": 18
       },
@@ -114,87 +114,95 @@
     },
     "ink": {
       "oracleConfig": {
-        "tokenExchangeRate": "251984749943933617403",
-        "gasPrice": "273566764",
+        "tokenExchangeRate": "302449361171704580866",
+        "gasPrice": "158351709",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "mint": {
       "oracleConfig": {
-        "tokenExchangeRate": "251984749943933617403",
-        "gasPrice": "273566764",
+        "tokenExchangeRate": "302449361171704580866",
+        "gasPrice": "158351709",
+        "tokenDecimals": 18
+      },
+      "overhead": 166887
+    },
+    "mode": {
+      "oracleConfig": {
+        "tokenExchangeRate": "302449361171704580866",
+        "gasPrice": "158351709",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "optimism": {
       "oracleConfig": {
-        "tokenExchangeRate": "251984749943933617403",
-        "gasPrice": "273566764",
+        "tokenExchangeRate": "302449361171704580866",
+        "gasPrice": "158351709",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "paradex": {
       "oracleConfig": {
-        "tokenExchangeRate": "112132765193989683",
-        "gasPrice": "987653967",
+        "tokenExchangeRate": "77905889685260205",
+        "gasPrice": "987654135",
         "tokenDecimals": 18
       },
       "overhead": 130000000
     },
-    "rivalz": {
+    "polygon": {
       "oracleConfig": {
-        "tokenExchangeRate": "251984749943933617403",
-        "gasPrice": "273566764",
+        "tokenExchangeRate": "18826503583670925",
+        "gasPrice": "2543933494286",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "solaxy": {
       "oracleConfig": {
-        "tokenExchangeRate": "11213276519398",
-        "gasPrice": "5128204",
-        "tokenDecimals": 9
+        "tokenExchangeRate": "6565518853",
+        "gasPrice": "6085083",
+        "tokenDecimals": 6
       },
       "overhead": 600000
     },
     "sonicsvm": {
       "oracleConfig": {
         "tokenExchangeRate": "1500000000000000",
-        "gasPrice": "38336",
+        "gasPrice": "26635",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
     "soon": {
       "oracleConfig": {
-        "tokenExchangeRate": "25198474994393361",
-        "gasPrice": "2283",
+        "tokenExchangeRate": "30244936117170458",
+        "gasPrice": "1321",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
     "sophon": {
       "oracleConfig": {
-        "tokenExchangeRate": "3969376541825521",
-        "gasPrice": "9814614939295",
+        "tokenExchangeRate": "3108915550015581",
+        "gasPrice": "8706116463066",
         "tokenDecimals": 18
       },
       "overhead": 333774
     },
     "starknet": {
       "oracleConfig": {
-        "tokenExchangeRate": "251984749943933617403",
-        "gasPrice": "439505",
+        "tokenExchangeRate": "302449361171704580866",
+        "gasPrice": "254404",
         "tokenDecimals": 18
       },
       "overhead": 130000000
     },
     "subtensor": {
       "oracleConfig": {
-        "tokenExchangeRate": "34505494505494505494",
+        "tokenExchangeRate": "33488625740105952009",
         "gasPrice": "10000000000",
         "tokenDecimals": 18
       },
@@ -202,24 +210,32 @@
     },
     "superseed": {
       "oracleConfig": {
-        "tokenExchangeRate": "251984749943933617403",
-        "gasPrice": "273566764",
+        "tokenExchangeRate": "302449361171704580866",
+        "gasPrice": "158351709",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "svmbnb": {
       "oracleConfig": {
-        "tokenExchangeRate": "6937205651491365",
-        "gasPrice": "8290",
+        "tokenExchangeRate": "6677235899033966",
+        "gasPrice": "5984",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
+    "unichain": {
+      "oracleConfig": {
+        "tokenExchangeRate": "302449361171704580866",
+        "gasPrice": "158351709",
+        "tokenDecimals": 18
+      },
+      "overhead": 166887
+    },
     "worldchain": {
       "oracleConfig": {
-        "tokenExchangeRate": "251984749943933617403",
-        "gasPrice": "273566764",
+        "tokenExchangeRate": "302449361171704580866",
+        "gasPrice": "158351709",
         "tokenDecimals": 18
       },
       "overhead": 166887
@@ -237,23 +253,23 @@
     "katana": {
       "oracleConfig": {
         "tokenExchangeRate": "15000000000000000000",
-        "gasPrice": "274104531",
+        "gasPrice": "158662109",
         "tokenDecimals": 18
       },
       "overhead": 166460
     },
     "solanamainnet": {
       "oracleConfig": {
-        "tokenExchangeRate": "89291117835528",
-        "gasPrice": "92007",
+        "tokenExchangeRate": "74392618694362",
+        "gasPrice": "63923",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
     "sonicsvm": {
       "oracleConfig": {
-        "tokenExchangeRate": "89291117835528",
-        "gasPrice": "38336",
+        "tokenExchangeRate": "74392618694362",
+        "gasPrice": "26635",
         "tokenDecimals": 9
       },
       "overhead": 600000
@@ -261,15 +277,15 @@
     "soon": {
       "oracleConfig": {
         "tokenExchangeRate": "1500000000000000",
-        "gasPrice": "2283",
+        "gasPrice": "1321",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
     "stride": {
       "oracleConfig": {
-        "tokenExchangeRate": "189347632609",
-        "gasPrice": "7232",
+        "tokenExchangeRate": "69073009396",
+        "gasPrice": "11475",
         "tokenDecimals": 6
       },
       "overhead": 600000
@@ -278,8 +294,8 @@
   "soon": {
     "bsc": {
       "oracleConfig": {
-        "tokenExchangeRate": "4129538981844072623",
-        "gasPrice": "1027568011",
+        "tokenExchangeRate": "3311580427794263105",
+        "gasPrice": "741709509",
         "tokenDecimals": 18
       },
       "overhead": 159736
@@ -287,23 +303,23 @@
     "eclipsemainnet": {
       "oracleConfig": {
         "tokenExchangeRate": "1500000000000000",
-        "gasPrice": "2283",
+        "gasPrice": "1321",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
     "solanamainnet": {
       "oracleConfig": {
-        "tokenExchangeRate": "89291117835528",
-        "gasPrice": "92007",
+        "tokenExchangeRate": "74392618694362",
+        "gasPrice": "63923",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
     "svmbnb": {
       "oracleConfig": {
-        "tokenExchangeRate": "412953898184407",
-        "gasPrice": "8290",
+        "tokenExchangeRate": "331158042779426",
+        "gasPrice": "5984",
         "tokenDecimals": 9
       },
       "overhead": 600000
@@ -312,8 +328,8 @@
   "sonicsvm": {
     "eclipsemainnet": {
       "oracleConfig": {
-        "tokenExchangeRate": "25198474994393361",
-        "gasPrice": "2283",
+        "tokenExchangeRate": "30244936117170458",
+        "gasPrice": "1321",
         "tokenDecimals": 9
       },
       "overhead": 600000
@@ -321,7 +337,7 @@
     "solanamainnet": {
       "oracleConfig": {
         "tokenExchangeRate": "1500000000000000",
-        "gasPrice": "92007",
+        "gasPrice": "63923",
         "tokenDecimals": 9
       },
       "overhead": 600000
@@ -331,23 +347,23 @@
     "bsc": {
       "oracleConfig": {
         "tokenExchangeRate": "15000000000000000000",
-        "gasPrice": "1027574348",
+        "gasPrice": "741716571",
         "tokenDecimals": 18
       },
       "overhead": 159736
     },
     "solanamainnet": {
       "oracleConfig": {
-        "tokenExchangeRate": "324338085539714",
-        "gasPrice": "92007",
+        "tokenExchangeRate": "336965779556405",
+        "gasPrice": "63923",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
     "soon": {
       "oracleConfig": {
-        "tokenExchangeRate": "5448550092134613",
-        "gasPrice": "2283",
+        "tokenExchangeRate": "6794338984237361",
+        "gasPrice": "1321",
         "tokenDecimals": 9
       },
       "overhead": 600000
@@ -356,16 +372,16 @@
   "solaxy": {
     "ethereum": {
       "oracleConfig": {
-        "tokenExchangeRate": "33708000000000000000000",
+        "tokenExchangeRate": "69099495698605754968851972",
         "gasPrice": "4000000000",
         "tokenDecimals": 18
       },
-      "overhead": 151966
+      "overhead": 159337
     },
     "solanamainnet": {
       "oracleConfig": {
-        "tokenExchangeRate": "200655000000000000",
-        "gasPrice": "92007",
+        "tokenExchangeRate": "342699495698605754968",
+        "gasPrice": "63923",
         "tokenDecimals": 9
       },
       "overhead": 600000

--- a/rust/sealevel/environments/mainnet3/multisig-ism-message-id/eclipsemainnet/hyperlane/multisig-config.json
+++ b/rust/sealevel/environments/mainnet3/multisig-ism-message-id/eclipsemainnet/hyperlane/multisig-config.json
@@ -220,6 +220,18 @@
       "0x4f977a59fdc2d9e39f6d780a84d5b4add1495a36"
     ]
   },
+  "celestia": {
+    "type": "messageIdMultisigIsm",
+    "threshold": 4,
+    "validators": [
+      "0x6dbc192c06907784fb0af0c0c2d8809ea50ba675",
+      "0x761980c3debdc8ddb69a2713cf5126d4db900f0f",
+      "0x885a8c1ef7f7eea8955c8f116fc1fbe1113c4a78",
+      "0xa6c998f0db2b56d7a63faf30a9b677c8b9b6faab",
+      "0x21e93a81920b73c0e98aed8e6b058dae409e4909",
+      "0x7b8606d61bc990165d1e5977037ddcf7f2de74d6"
+    ]
+  },
   "celo": {
     "type": "messageIdMultisigIsm",
     "threshold": 4,

--- a/rust/sealevel/environments/mainnet3/multisig-ism-message-id/solanamainnet/hyperlane/multisig-config.json
+++ b/rust/sealevel/environments/mainnet3/multisig-ism-message-id/solanamainnet/hyperlane/multisig-config.json
@@ -221,6 +221,18 @@
       "0x4f977a59fdc2d9e39f6d780a84d5b4add1495a36"
     ]
   },
+  "celestia": {
+    "type": "messageIdMultisigIsm",
+    "threshold": 4,
+    "validators": [
+      "0x6dbc192c06907784fb0af0c0c2d8809ea50ba675",
+      "0x761980c3debdc8ddb69a2713cf5126d4db900f0f",
+      "0x885a8c1ef7f7eea8955c8f116fc1fbe1113c4a78",
+      "0xa6c998f0db2b56d7a63faf30a9b677c8b9b6faab",
+      "0x21e93a81920b73c0e98aed8e6b058dae409e4909",
+      "0x7b8606d61bc990165d1e5977037ddcf7f2de74d6"
+    ]
+  },
   "celo": {
     "type": "messageIdMultisigIsm",
     "threshold": 4,

--- a/typescript/infra/config/environments/mainnet3/governance/signers/regular.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/signers/regular.ts
@@ -4,8 +4,8 @@ export const regularSigners: Address[] = [
   '0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba', // 1
   '0xc3E966E79eF1aA4751221F55fB8A36589C24C0cA', // 2
   '0x2f43Ac3cD6A22E4Ba20d3d18d116b1f9420eD84B', // 3
-  '0xfae231524539698f1d136d7b21e3b4144cdbf2a3', // 4
-  '0x2C073004A6e4f37377F848193d6433260Ebe9b99', // 5
+  '0x3247FC16763c340EeFc1e60eda172ef9Db7c96B6', // 4
+  '0x97a1b7D1B6D52CACf4B6754f144fd6E404790346', // 5
   '0x9f500df92175b2ac36f8d443382b219d211d354a', // 6
   '0x82950a6356316272dF1928C72F5F0A44D9673c88', // 7
   '0x861FC61a961F8AFDf115B8DE274101B9ECea2F26', // 8
@@ -14,3 +14,18 @@ export const regularSigners: Address[] = [
 ];
 
 export const regularThreshold = 6;
+
+export const regularSvmSigners: Address[] = [
+  '9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf', // 1
+  '3c5oFeqTRDXUkTcaxCMS2jsHWAkvUi4treoMBCP1aUPo', // 2
+  '4ocDADfUkH6qSMBGV977rPJEvmFxiG1MSmBbKwMUX9Ya', // 3
+  'FwHF7jDNvuwCuYhBCZZPY1VBoBVSHPsVBqu7UCp7dnA3', // 4
+  '8V5Uu7xMQhaUcD6pzNReVzrSe89KMCXoGk7ErbkXik2b', // 5
+  'A4voX3UC3TGLsKyEsDGWAvrjT3mpnA67Fx9cccdoPKqm', // 6
+  'Cstnx15y98NCnjXddxEcgpJrW44TFYq9QSXYcdmfW4HR', // 7
+  'DqGAc8YvHUPnpA5cuausLhkCp1cUvEQFYjpWVHJTPiNM', // 8
+  'EpaKfP4sd2xhEQvnYS3EgCXj7rkg7jTCasTByFj8kuLg', // 9
+  'AkG81cTMBD2Kh1gmDF66mAeRosDQjvATJyDWN48BSh85', // 10
+];
+
+export const regularSvmThreshold = 6;

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getLumiaUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getLumiaUSDCWarpConfig.ts
@@ -49,8 +49,6 @@ const submitterConfig = objMap(
   },
 );
 
-console.log(JSON.stringify(submitterConfig, null, 2));
-
 export const getLumiaUSDCWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
 ): Promise<ChainMap<HypTokenRouterConfig>> => {


### PR DESCRIPTION
### Description

feat: update ISMs to enroll celestia
- update solana/eclipse multisig configs
- update svm igp config
- update regular safe signers
- note down svm squads signers

### Drive-by changes

- remove extraneous console.log

### Related issues

https://github.com/hyperlane-xyz/hyperlane-registry/pull/1083
https://hyperlaneworkspace.slack.com/archives/C08GHFNNL30/p1752528856100859

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new chains "mode" and "unichain" under Solana Mainnet.
  * Introduced a new multisig configuration entry for the "celestia" network in both Eclipsed Mainnet and Solana Mainnet environments.

* **Updates**
  * Updated gas oracle parameters (exchange rates, gas prices, and some decimals) across multiple environments and chains.
  * Renamed or replaced the "rivalz" chain with "polygon" under Solana Mainnet.
  * Adjusted overhead values for certain chains.
  * Updated signer addresses and added a new set of SVM signers with a defined threshold.

* **Chores**
  * Removed a debugging log statement from the Lumia USDC Warp configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->