### PR TITLE
chore: update oUSDT prune script to replace ethereum symbol

### DIFF
--- a/typescript/infra/scripts/warp-routes/ousdt/prune-warp-config.ts
+++ b/typescript/infra/scripts/warp-routes/ousdt/prune-warp-config.ts
@@ -61,7 +61,7 @@ async function main() {
     if (collateralChains.includes(token.chainName)) {
       token.coinGeckoId = 'tether';
       token.name = 'USDT';
-      token.symbol = 'USD₮';
+      token.symbol = token.chainName === 'ethereum' ? 'USDT' : 'USD₮';
       token.standard = TokenStandard.EvmHypVSXERC20Lockbox;
       token.logoURI = isStaging
         ? undefined


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
Sets correct symbol for `ethereum` in oUSDT prune script
### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
