### PR TITLE
chore: split cli e2e tests in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -291,9 +291,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        protocol:
-          - ethereum
-          - cosmosnative
         test:
           # Core Commands
           - core-apply

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -284,7 +284,7 @@ jobs:
           job_name: 'CLI Install Test'
           result: ${{ needs.cli-install-test-run.result }}
 
-  cli-e2e-matrix:
+  cli-evm-e2e-matrix:
     runs-on: depot-ubuntu-latest
     needs: [rust-only]
     if: needs.rust-only.outputs.only_rust == 'false'
@@ -304,19 +304,22 @@ jobs:
           # Other commands
           - relay
           # Warp Commands
+          - warp-apply-1
+          - warp-apply-2
           - warp-apply-submitters
-          - warp-apply
           - warp-bridge-1
           - warp-bridge-2
-          - warp-check
+          - warp-check-1
+          - warp-check-2
+          - warp-check-3
           - warp-deploy
           - warp-extend-basic
           - warp-extend-config
           - warp-extend-recovery
           - warp-init
           - warp-read
-          - warp-send
           - warp-rebalancer
+          - warp-send
     steps:
       - uses: actions/checkout@v4
         with:
@@ -337,22 +340,68 @@ jobs:
       - name: Checkout registry
         uses: ./.github/actions/checkout-registry
 
-      - name: CLI ${{ matrix.protocol }} e2e tests (${{ matrix.test }})
-        run: yarn --cwd typescript/cli test:${{ matrix.protocol }}:e2e
+      - name: CLI ethereum e2e tests (${{ matrix.test }})
+        run: yarn --cwd typescript/cli test:ethereum:e2e
+        env:
+          CLI_E2E_TEST: ${{ matrix.test }}
+
+  cli-cosmos-e2e-matrix:
+    runs-on: depot-ubuntu-latest
+    needs: [rust-only]
+    if: needs.rust-only.outputs.only_rust == 'false'
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          # Core Commands
+          - core-apply
+          - core-check
+          - core-deploy
+          - core-read
+          # Warp Commands
+          - warp-deploy
+          - warp-read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: foundry-install
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: install-hyperlane-cli
+        id: install-hyperlane-cli
+        uses: ./.github/actions/install-cli
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          cache-provider: github
+
+      - name: Checkout registry
+        uses: ./.github/actions/checkout-registry
+
+      - name: CLI cosmosnative e2e tests (${{ matrix.test }})
+        run: yarn --cwd typescript/cli test:cosmosnative:e2e
         env:
           CLI_E2E_TEST: ${{ matrix.test }}
 
   cli-e2e:
     runs-on: ubuntu-latest
-    needs: [cli-e2e-matrix]
+    needs: [cli-evm-e2e-matrix, cli-cosmos-e2e-matrix]
     if: always()
     steps:
       - uses: actions/checkout@v4
-      - name: Check cli-e2e matrix status
+      - name: Check CLI EVM E2E status
         uses: ./.github/actions/check-job-status
         with:
-          job_name: 'CLI E2E'
-          result: ${{ needs.cli-e2e-matrix.result }}
+          job_name: 'CLI EVM E2E'
+          result: ${{ needs.cli-evm-e2e-matrix.result }}
+      - name: Check CLI CosmosNative E2E status
+        uses: ./.github/actions/check-job-status
+        with:
+          job_name: 'CLI CosmosNative E2E'
+          result: ${{ needs.cli-cosmos-e2e-matrix.result }}
 
   cosmos-sdk-e2e-run:
     runs-on: depot-ubuntu-latest

--- a/typescript/cli/src/tests/ethereum/warp/warp-apply-1.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-apply-1.e2e-test.ts
@@ -1,0 +1,209 @@
+import { expect } from 'chai';
+
+import {
+  HookType,
+  WarpRouteDeployConfig,
+  normalizeConfig,
+  randomAddress,
+} from '@hyperlane-xyz/sdk';
+
+import { readYamlOrJson, writeYamlOrJson } from '../../../utils/files.js';
+import { deployOrUseExistingCore } from '../commands/core.js';
+import {
+  hyperlaneWarpApply,
+  hyperlaneWarpDeploy,
+  readWarpConfig,
+  updateOwner,
+} from '../commands/warp.js';
+import {
+  ANVIL_DEPLOYER_ADDRESS,
+  ANVIL_KEY,
+  CHAIN_NAME_2,
+  CORE_CONFIG_PATH,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  E2E_TEST_BURN_ADDRESS,
+  TEMP_PATH,
+  WARP_CONFIG_PATH_2,
+  WARP_CONFIG_PATH_EXAMPLE,
+  WARP_CORE_CONFIG_PATH_2,
+  WARP_DEPLOY_2_ID,
+} from '../consts.js';
+
+describe('hyperlane warp apply owner update tests', async function () {
+  this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
+
+  before(async function () {
+    await deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY);
+
+    // Create a new warp config using the example
+    const warpConfig: WarpRouteDeployConfig = readYamlOrJson(
+      WARP_CONFIG_PATH_EXAMPLE,
+    );
+    const anvil2Config = { anvil2: { ...warpConfig.anvil1 } };
+    writeYamlOrJson(WARP_CONFIG_PATH_2, anvil2Config);
+  });
+
+  beforeEach(async function () {
+    await hyperlaneWarpDeploy(WARP_CONFIG_PATH_2, WARP_DEPLOY_2_ID);
+  });
+
+  it('should burn owner address', async function () {
+    const warpConfigPath = `${TEMP_PATH}/warp-route-deployment-2.yaml`;
+    await updateOwner(
+      E2E_TEST_BURN_ADDRESS,
+      CHAIN_NAME_2,
+      warpConfigPath,
+      WARP_CORE_CONFIG_PATH_2,
+    );
+    const updatedWarpDeployConfig = await readWarpConfig(
+      CHAIN_NAME_2,
+      WARP_CORE_CONFIG_PATH_2,
+      warpConfigPath,
+    );
+    expect(updatedWarpDeployConfig.anvil2.owner).to.equal(
+      E2E_TEST_BURN_ADDRESS,
+    );
+  });
+
+  it('should not update the same owner', async () => {
+    const warpConfigPath = `${TEMP_PATH}/warp-route-deployment-2.yaml`;
+    await updateOwner(
+      E2E_TEST_BURN_ADDRESS,
+      CHAIN_NAME_2,
+      warpConfigPath,
+      WARP_CORE_CONFIG_PATH_2,
+    );
+    const { stdout } = await updateOwner(
+      E2E_TEST_BURN_ADDRESS,
+      CHAIN_NAME_2,
+      warpConfigPath,
+      WARP_CORE_CONFIG_PATH_2,
+    );
+    expect(stdout).to.include(
+      'Warp config is the same as target. No updates needed.',
+    );
+  });
+
+  it('should update the owner of both the warp token and the proxy admin', async () => {
+    const warpConfigPath = `${TEMP_PATH}/warp-route-deploy-config-2.yaml`;
+
+    const warpConfig: WarpRouteDeployConfig = readYamlOrJson(
+      WARP_CONFIG_PATH_EXAMPLE,
+    );
+
+    // Set to undefined if it was defined in the config
+    warpConfig.anvil1.proxyAdmin = undefined;
+    warpConfig.anvil1.owner = E2E_TEST_BURN_ADDRESS;
+    const anvil2Config = { anvil2: { ...warpConfig.anvil1 } };
+    writeYamlOrJson(warpConfigPath, anvil2Config);
+
+    await hyperlaneWarpApply(
+      warpConfigPath,
+      WARP_CORE_CONFIG_PATH_2,
+      undefined,
+      WARP_DEPLOY_2_ID,
+    );
+
+    const updatedWarpDeployConfig1 = await readWarpConfig(
+      CHAIN_NAME_2,
+      WARP_CORE_CONFIG_PATH_2,
+      warpConfigPath,
+    );
+
+    expect(updatedWarpDeployConfig1.anvil2.owner).to.eq(E2E_TEST_BURN_ADDRESS);
+    expect(updatedWarpDeployConfig1.anvil2.proxyAdmin?.owner).to.eq(
+      E2E_TEST_BURN_ADDRESS,
+    );
+  });
+
+  it('should update only the owner of the warp token if the proxy admin config is specified', async () => {
+    const warpConfigPath = `${TEMP_PATH}/warp-route-deploy-config-2.yaml`;
+
+    const warpConfig: WarpRouteDeployConfig = readYamlOrJson(
+      WARP_CONFIG_PATH_EXAMPLE,
+    );
+
+    // Explicitly set it to the deployer address if it was not defined
+    warpConfig.anvil1.proxyAdmin = { owner: ANVIL_DEPLOYER_ADDRESS };
+    warpConfig.anvil1.owner = E2E_TEST_BURN_ADDRESS;
+    const anvil2Config = { anvil2: { ...warpConfig.anvil1 } };
+    writeYamlOrJson(warpConfigPath, anvil2Config);
+
+    await hyperlaneWarpApply(warpConfigPath, WARP_CORE_CONFIG_PATH_2);
+
+    const updatedWarpDeployConfig1 = await readWarpConfig(
+      CHAIN_NAME_2,
+      WARP_CORE_CONFIG_PATH_2,
+      warpConfigPath,
+    );
+
+    expect(updatedWarpDeployConfig1.anvil2.owner).to.eq(E2E_TEST_BURN_ADDRESS);
+    expect(updatedWarpDeployConfig1.anvil2.proxyAdmin?.owner).to.eq(
+      ANVIL_DEPLOYER_ADDRESS,
+    );
+  });
+
+  it('should update only the owner of the proxy admin if the proxy admin config is specified', async () => {
+    const warpConfigPath = `${TEMP_PATH}/warp-route-deploy-config-2.yaml`;
+
+    const warpConfig: WarpRouteDeployConfig = readYamlOrJson(
+      WARP_CONFIG_PATH_EXAMPLE,
+    );
+
+    warpConfig.anvil1.proxyAdmin = { owner: E2E_TEST_BURN_ADDRESS };
+    const anvil2Config = { anvil2: { ...warpConfig.anvil1 } };
+    writeYamlOrJson(warpConfigPath, anvil2Config);
+
+    await hyperlaneWarpApply(warpConfigPath, WARP_CORE_CONFIG_PATH_2);
+
+    const updatedWarpDeployConfig1 = await readWarpConfig(
+      CHAIN_NAME_2,
+      WARP_CORE_CONFIG_PATH_2,
+      warpConfigPath,
+    );
+
+    expect(updatedWarpDeployConfig1.anvil2.owner).to.eq(ANVIL_DEPLOYER_ADDRESS);
+    expect(updatedWarpDeployConfig1.anvil2.proxyAdmin?.owner).to.eq(
+      E2E_TEST_BURN_ADDRESS,
+    );
+  });
+
+  it('should update hook configuration', async () => {
+    const warpDeployPath = `${TEMP_PATH}/warp-route-deployment-2.yaml`;
+
+    // First read the existing config
+    const warpDeployConfig = await readWarpConfig(
+      CHAIN_NAME_2,
+      WARP_CORE_CONFIG_PATH_2,
+      warpDeployPath,
+    );
+
+    // Update with a new hook config
+    const owner = randomAddress();
+    warpDeployConfig[CHAIN_NAME_2].hook = {
+      type: HookType.PROTOCOL_FEE,
+      beneficiary: owner,
+      maxProtocolFee: '1000000',
+      protocolFee: '100000',
+      owner,
+    };
+
+    // Write the updated config
+    await writeYamlOrJson(warpDeployPath, warpDeployConfig);
+
+    // Apply the changes
+    await hyperlaneWarpApply(warpDeployPath, WARP_CORE_CONFIG_PATH_2);
+
+    // Read back the config to verify changes
+    const updatedConfig = await readWarpConfig(
+      CHAIN_NAME_2,
+      WARP_CORE_CONFIG_PATH_2,
+      warpDeployPath,
+    );
+
+    // Verify the hook was updated with all properties
+    expect(normalizeConfig(updatedConfig[CHAIN_NAME_2].hook)).to.deep.equal(
+      normalizeConfig(warpDeployConfig[CHAIN_NAME_2].hook),
+    );
+  });
+});

--- a/typescript/cli/src/tests/ethereum/warp/warp-check-1.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-check-1.e2e-test.ts
@@ -1,0 +1,173 @@
+import { expect } from 'chai';
+import { Wallet } from 'ethers';
+
+import { ERC20Test } from '@hyperlane-xyz/core';
+import {
+  ChainAddresses,
+  createWarpRouteConfigId,
+} from '@hyperlane-xyz/registry';
+import {
+  HookConfig,
+  IsmConfig,
+  IsmType,
+  MUTABLE_HOOK_TYPE,
+  MUTABLE_ISM_TYPE,
+  TokenType,
+  WarpRouteDeployConfig,
+  randomAddress,
+  randomHookConfig,
+  randomIsmConfig,
+} from '@hyperlane-xyz/sdk';
+import { Address, assert, deepCopy } from '@hyperlane-xyz/utils';
+
+import { writeYamlOrJson } from '../../../utils/files.js';
+import { deployOrUseExistingCore } from '../commands/core.js';
+import { deployToken } from '../commands/helpers.js';
+import {
+  hyperlaneWarpCheckRaw,
+  hyperlaneWarpDeploy,
+} from '../commands/warp.js';
+import {
+  ANVIL_KEY,
+  CHAIN_NAME_2,
+  CHAIN_NAME_3,
+  CORE_CONFIG_PATH,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  WARP_DEPLOY_OUTPUT_PATH,
+  getCombinedWarpRoutePath,
+} from '../consts.js';
+
+describe('hyperlane warp check e2e tests', async function () {
+  this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
+
+  let chain2Addresses: ChainAddresses = {};
+  let chain3Addresses: ChainAddresses = {};
+  let token: ERC20Test;
+  let tokenSymbol: string;
+  let ownerAddress: Address;
+  let combinedWarpCoreConfigPath: string;
+  let warpConfig: WarpRouteDeployConfig;
+
+  before(async function () {
+    [chain2Addresses, chain3Addresses] = await Promise.all([
+      deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY),
+      deployOrUseExistingCore(CHAIN_NAME_3, CORE_CONFIG_PATH, ANVIL_KEY),
+    ]);
+
+    token = await deployToken(ANVIL_KEY, CHAIN_NAME_2);
+    tokenSymbol = await token.symbol();
+
+    combinedWarpCoreConfigPath = getCombinedWarpRoutePath(tokenSymbol, [
+      CHAIN_NAME_3,
+    ]);
+  });
+
+  async function deployAndExportWarpRoute(): Promise<WarpRouteDeployConfig> {
+    writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpConfig);
+    // currently warp deploy is not writing the deploy config to the registry
+    // should remove this once the deploy config is written to the registry
+    writeYamlOrJson(
+      combinedWarpCoreConfigPath.replace('-config.yaml', '-deploy.yaml'),
+      warpConfig,
+    );
+
+    const currentWarpId = createWarpRouteConfigId(
+      await token.symbol(),
+      CHAIN_NAME_3,
+    );
+
+    await hyperlaneWarpDeploy(WARP_DEPLOY_OUTPUT_PATH, currentWarpId);
+
+    return warpConfig;
+  }
+
+  // Reset config before each test to avoid test changes intertwining
+  beforeEach(async function () {
+    ownerAddress = new Wallet(ANVIL_KEY).address;
+    warpConfig = {
+      [CHAIN_NAME_2]: {
+        type: TokenType.collateral,
+        token: token.address,
+        mailbox: chain2Addresses.mailbox,
+        owner: ownerAddress,
+      },
+      [CHAIN_NAME_3]: {
+        type: TokenType.synthetic,
+        mailbox: chain3Addresses.mailbox,
+        owner: ownerAddress,
+      },
+    };
+  });
+
+  for (const hookType of MUTABLE_HOOK_TYPE) {
+    it(`should find owner differences between the local config and the on chain config for hook of type ${hookType}`, async function () {
+      warpConfig[CHAIN_NAME_3].hook = randomHookConfig(0, 2, hookType);
+      await deployAndExportWarpRoute();
+
+      const mutatedWarpConfig = deepCopy(warpConfig);
+
+      const hookConfig: Extract<
+        HookConfig,
+        { type: (typeof MUTABLE_HOOK_TYPE)[number]; owner: string }
+      > = mutatedWarpConfig[CHAIN_NAME_3].hook!;
+      const actualOwner = hookConfig.owner;
+      const wrongOwner = randomAddress();
+      assert(actualOwner !== wrongOwner, 'Random owner matches actualOwner');
+      hookConfig.owner = wrongOwner;
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, mutatedWarpConfig);
+
+      const expectedDiffText = `EXPECTED: "${wrongOwner.toLowerCase()}"\n`;
+      const expectedActualText = `ACTUAL: "${actualOwner.toLowerCase()}"\n`;
+
+      const output = await hyperlaneWarpCheckRaw({
+        warpDeployPath: WARP_DEPLOY_OUTPUT_PATH,
+        warpCoreConfigPath: combinedWarpCoreConfigPath,
+      }).nothrow();
+      expect(output.exitCode).to.equal(1);
+      expect(output.text().includes(expectedDiffText)).to.be.true;
+      expect(output.text().includes(expectedActualText)).to.be.true;
+    });
+  }
+
+  // Removing the offchain lookup ism because it is a family of different isms
+  for (const ismType of MUTABLE_ISM_TYPE.filter(
+    (ismType) => ismType !== IsmType.OFFCHAIN_LOOKUP,
+  )) {
+    it(`should find owner differences between the local config and the on chain config for ism of type ${ismType}`, async function () {
+      // Create a Pausable because randomIsmConfig() cannot generate it (reason: NULL type Isms)
+      warpConfig[CHAIN_NAME_3].interchainSecurityModule =
+        ismType === IsmType.PAUSABLE
+          ? {
+              type: IsmType.PAUSABLE,
+              owner: randomAddress(),
+              paused: true,
+            }
+          : randomIsmConfig(0, 2, ismType);
+      await deployAndExportWarpRoute();
+
+      const mutatedWarpConfig = deepCopy(warpConfig);
+
+      const ismConfig: Extract<
+        IsmConfig,
+        { type: (typeof MUTABLE_ISM_TYPE)[number]; owner: string }
+      > = mutatedWarpConfig[CHAIN_NAME_3].interchainSecurityModule;
+      const actualOwner = ismConfig.owner;
+      const wrongOwner = randomAddress();
+      assert(actualOwner !== wrongOwner, 'Random owner matches actualOwner');
+      ismConfig.owner = wrongOwner;
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, mutatedWarpConfig);
+
+      const expectedDiffText = `EXPECTED: "${wrongOwner.toLowerCase()}"\n`;
+      const expectedActualText = `ACTUAL: "${actualOwner.toLowerCase()}"\n`;
+
+      const output = await hyperlaneWarpCheckRaw({
+        warpDeployPath: WARP_DEPLOY_OUTPUT_PATH,
+        warpCoreConfigPath: combinedWarpCoreConfigPath,
+      }).nothrow();
+
+      expect(output.exitCode).to.equal(1);
+      expect(output.text().includes(expectedDiffText)).to.be.true;
+      expect(output.text().includes(expectedActualText)).to.be.true;
+    });
+  }
+});

--- a/typescript/cli/src/tests/ethereum/warp/warp-check-2.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-check-2.e2e-test.ts
@@ -1,0 +1,329 @@
+import { expect } from 'chai';
+import { Signer, Wallet, ethers } from 'ethers';
+import { zeroAddress } from 'viem';
+
+import { ERC20Test, HypERC20Collateral__factory } from '@hyperlane-xyz/core';
+import {
+  ChainAddresses,
+  createWarpRouteConfigId,
+} from '@hyperlane-xyz/registry';
+import {
+  ChainMetadata,
+  TokenStandard,
+  TokenType,
+  WarpCoreConfig,
+  WarpRouteDeployConfig,
+  randomAddress,
+} from '@hyperlane-xyz/sdk';
+import { Address, assert } from '@hyperlane-xyz/utils';
+
+import { readYamlOrJson, writeYamlOrJson } from '../../../utils/files.js';
+import { deployOrUseExistingCore } from '../commands/core.js';
+import { deployToken } from '../commands/helpers.js';
+import {
+  hyperlaneWarpCheckRaw,
+  hyperlaneWarpDeploy,
+} from '../commands/warp.js';
+import {
+  ANVIL_DEPLOYER_ADDRESS,
+  ANVIL_KEY,
+  CHAIN_2_METADATA_PATH,
+  CHAIN_3_METADATA_PATH,
+  CHAIN_NAME_2,
+  CHAIN_NAME_3,
+  CORE_CONFIG_PATH,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  WARP_DEPLOY_OUTPUT_PATH,
+  getCombinedWarpRoutePath,
+} from '../consts.js';
+
+describe('hyperlane warp check e2e tests', async function () {
+  this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
+
+  let signer: Signer;
+  let chain2Addresses: ChainAddresses = {};
+  let chain3Addresses: ChainAddresses = {};
+  let chain3DomainId: number;
+  let token: ERC20Test;
+  let tokenSymbol: string;
+  let ownerAddress: Address;
+  let combinedWarpCoreConfigPath: string;
+  let warpConfig: WarpRouteDeployConfig;
+
+  before(async function () {
+    [chain2Addresses, chain3Addresses] = await Promise.all([
+      deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY),
+      deployOrUseExistingCore(CHAIN_NAME_3, CORE_CONFIG_PATH, ANVIL_KEY),
+    ]);
+
+    const chainMetadata: ChainMetadata = readYamlOrJson(CHAIN_2_METADATA_PATH);
+    chain3DomainId = (readYamlOrJson(CHAIN_3_METADATA_PATH) as ChainMetadata)
+      .domainId;
+
+    const provider = new ethers.providers.JsonRpcProvider(
+      chainMetadata.rpcUrls[0].http,
+    );
+
+    signer = new Wallet(ANVIL_KEY).connect(provider);
+
+    token = await deployToken(ANVIL_KEY, CHAIN_NAME_2);
+    tokenSymbol = await token.symbol();
+
+    combinedWarpCoreConfigPath = getCombinedWarpRoutePath(tokenSymbol, [
+      CHAIN_NAME_3,
+    ]);
+  });
+
+  async function deployAndExportWarpRoute(): Promise<WarpRouteDeployConfig> {
+    writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpConfig);
+    // currently warp deploy is not writing the deploy config to the registry
+    // should remove this once the deploy config is written to the registry
+    writeYamlOrJson(
+      combinedWarpCoreConfigPath.replace('-config.yaml', '-deploy.yaml'),
+      warpConfig,
+    );
+
+    const currentWarpId = createWarpRouteConfigId(
+      await token.symbol(),
+      CHAIN_NAME_3,
+    );
+
+    await hyperlaneWarpDeploy(WARP_DEPLOY_OUTPUT_PATH, currentWarpId);
+
+    return warpConfig;
+  }
+
+  // Reset config before each test to avoid test changes intertwining
+  beforeEach(async function () {
+    ownerAddress = new Wallet(ANVIL_KEY).address;
+    warpConfig = {
+      [CHAIN_NAME_2]: {
+        type: TokenType.collateral,
+        token: token.address,
+        mailbox: chain2Addresses.mailbox,
+        owner: ownerAddress,
+      },
+      [CHAIN_NAME_3]: {
+        type: TokenType.synthetic,
+        mailbox: chain3Addresses.mailbox,
+        owner: ownerAddress,
+      },
+    };
+  });
+
+  describe('hyperlane warp check --config ... and hyperlane warp check --warp ...', () => {
+    const expectedError =
+      'Both --config/-wd and --warp/-wc must be provided together when using individual file paths';
+    it(`should require both warp core & warp deploy config paths to be provided together`, async function () {
+      await deployAndExportWarpRoute();
+
+      const output1 = await hyperlaneWarpCheckRaw({
+        warpDeployPath: WARP_DEPLOY_OUTPUT_PATH,
+      })
+        .stdio('pipe')
+        .nothrow();
+
+      const output2 = await hyperlaneWarpCheckRaw({
+        warpCoreConfigPath: combinedWarpCoreConfigPath,
+      })
+        .stdio('pipe')
+        .nothrow();
+
+      expect(output1.exitCode).to.equal(1);
+      expect(output1.text()).to.include(expectedError);
+      expect(output2.exitCode).to.equal(1);
+      expect(output2.text()).to.include(expectedError);
+    });
+  });
+
+  describe('hyperlane warp check --symbol ...', () => {
+    it(`should not find any differences between the on chain config and the local one`, async function () {
+      await deployAndExportWarpRoute();
+
+      // only one route exists for this token so no need to interact with prompts
+      const output = await hyperlaneWarpCheckRaw({
+        symbol: tokenSymbol,
+      })
+        .stdio('pipe')
+        .nothrow();
+
+      expect(output.exitCode).to.equal(0);
+      expect(output.text()).to.include('No violations found');
+    });
+  });
+
+  describe('hyperlane warp check --warpRouteId ...', () => {
+    it(`should not find any differences between the on chain config and the local one`, async function () {
+      await deployAndExportWarpRoute();
+
+      const output = await hyperlaneWarpCheckRaw({
+        warpRouteId: createWarpRouteConfigId(tokenSymbol, CHAIN_NAME_3),
+      })
+        .stdio('pipe')
+        .nothrow();
+
+      expect(output.exitCode).to.equal(0);
+      expect(output.text()).to.include('No violations found');
+    });
+
+    it(`should successfully check warp routes that are not deployed as proxies`, async () => {
+      // Deploy the token and the hyp adapter
+      const symbol = 'NTAP';
+      const tokenName = 'NOTAPROXY';
+      const tokenDecimals = 10;
+      const collateral = await deployToken(
+        ANVIL_KEY,
+        CHAIN_NAME_2,
+        tokenDecimals,
+        symbol,
+      );
+
+      const contract = new HypERC20Collateral__factory(signer);
+      const tx = await contract.deploy(
+        collateral.address,
+        1,
+        chain2Addresses.mailbox,
+      );
+
+      const deployedContract = await tx.deployed();
+      const tx2 = await deployedContract.initialize(
+        zeroAddress,
+        zeroAddress,
+        ANVIL_DEPLOYER_ADDRESS,
+      );
+
+      await tx2.wait();
+
+      // Manually add config files to the registry
+      const routePath = getCombinedWarpRoutePath(symbol, [CHAIN_NAME_2]);
+      const warpDeployConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.collateral,
+          token: collateral.address,
+          owner: ANVIL_DEPLOYER_ADDRESS,
+        },
+      };
+      writeYamlOrJson(
+        routePath.replace('-config.yaml', '-deploy.yaml'),
+        warpDeployConfig,
+      );
+
+      const warpCoreConfig: WarpCoreConfig = {
+        tokens: [
+          {
+            addressOrDenom: deployedContract.address,
+            chainName: CHAIN_NAME_2,
+            decimals: tokenDecimals,
+            collateralAddressOrDenom: token.address,
+            name: tokenName,
+            standard: TokenStandard.EvmHypCollateral,
+            symbol,
+          },
+        ],
+      };
+      writeYamlOrJson(routePath, warpCoreConfig);
+
+      // Finally run warp check
+      const output = await hyperlaneWarpCheckRaw({
+        warpRouteId: createWarpRouteConfigId(symbol, CHAIN_NAME_2),
+      })
+        .stdio('pipe')
+        .nothrow();
+
+      expect(output.exitCode).to.equal(0);
+      expect(output.text()).to.include('No violations found');
+    });
+  });
+
+  it('should successfully check allowedRebalancers', async () => {
+    assert(
+      warpConfig[CHAIN_NAME_2].type === TokenType.collateral,
+      'Expected config to be for a collateral token',
+    );
+    warpConfig[CHAIN_NAME_2].allowedRebalancers = [randomAddress()];
+    await deployAndExportWarpRoute();
+
+    const output = await hyperlaneWarpCheckRaw({
+      warpDeployPath: WARP_DEPLOY_OUTPUT_PATH,
+      warpCoreConfigPath: combinedWarpCoreConfigPath,
+    })
+      .stdio('pipe')
+      .nothrow();
+
+    expect(output.exitCode).to.equal(0);
+    expect(output.text()).to.include('No violations found');
+  });
+
+  it('should report a violation if no rebalancers are in the config but are set on chain', async () => {
+    assert(
+      warpConfig[CHAIN_NAME_2].type === TokenType.collateral,
+      'Expected config to be for a collateral token',
+    );
+    warpConfig[CHAIN_NAME_2].allowedRebalancers = [randomAddress()];
+    await deployAndExportWarpRoute();
+
+    warpConfig[CHAIN_NAME_2].allowedRebalancers = undefined;
+    const wrongDeployConfigPath = combinedWarpCoreConfigPath.replace(
+      '-config.yaml',
+      '-deploy.yaml',
+    );
+    writeYamlOrJson(wrongDeployConfigPath, warpConfig);
+
+    const output = await hyperlaneWarpCheckRaw({
+      warpDeployPath: wrongDeployConfigPath,
+      warpCoreConfigPath: combinedWarpCoreConfigPath,
+    })
+      .stdio('pipe')
+      .nothrow();
+
+    expect(output.exitCode).to.equal(1);
+  });
+
+  it('should successfully check the allowed rebalancing bridges', async () => {
+    assert(
+      warpConfig[CHAIN_NAME_2].type === TokenType.collateral,
+      'Expected config to be for a collateral token',
+    );
+    warpConfig[CHAIN_NAME_2].allowedRebalancingBridges = {
+      [chain3DomainId]: [{ bridge: randomAddress() }],
+    };
+    await deployAndExportWarpRoute();
+
+    const output = await hyperlaneWarpCheckRaw({
+      warpDeployPath: WARP_DEPLOY_OUTPUT_PATH,
+      warpCoreConfigPath: combinedWarpCoreConfigPath,
+    })
+      .stdio('pipe')
+      .nothrow();
+
+    expect(output.exitCode).to.equal(0);
+    expect(output.text()).to.include('No violations found');
+  });
+
+  it('should report a violation if no allowed bridges are in the config but are set on chain', async () => {
+    assert(
+      warpConfig[CHAIN_NAME_2].type === TokenType.collateral,
+      'Expected config to be for a collateral token',
+    );
+    warpConfig[CHAIN_NAME_2].allowedRebalancingBridges = {
+      [chain3DomainId]: [{ bridge: randomAddress() }],
+    };
+    await deployAndExportWarpRoute();
+
+    warpConfig[CHAIN_NAME_2].allowedRebalancingBridges = undefined;
+    const wrongDeployConfigPath = combinedWarpCoreConfigPath.replace(
+      '-config.yaml',
+      '-deploy.yaml',
+    );
+    writeYamlOrJson(wrongDeployConfigPath, warpConfig);
+
+    const output = await hyperlaneWarpCheckRaw({
+      warpDeployPath: wrongDeployConfigPath,
+      warpCoreConfigPath: combinedWarpCoreConfigPath,
+    })
+      .stdio('pipe')
+      .nothrow();
+
+    expect(output.exitCode).to.equal(1);
+  });
+});


### PR DESCRIPTION
### Description

chore: split cli e2e tests in ci
- warp-apply split into 2
- warp-check split into 3
- cli e2e matrix split into 2 matrices (cosm, eth) so we don't extraneously create cli e2e jobs on cosmos 

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
