### PR TITLE
fix: Make block gas limit exceeds a non-retriable error

### DIFF
--- a/rust/main/lander/src/error.rs
+++ b/rust/main/lander/src/error.rs
@@ -71,6 +71,9 @@ const EVM_GAS_UNDERPRICED_ERRORS: [&str; 4] = [
 
 const SVM_BLOCKHASH_NOT_FOUND_ERROR: &str = "Blockhash not found";
 
+// Add constant for block gas limit error
+const EVM_EXCEEDS_BLOCK_GAS_LIMIT_ERROR: &str = "exceeds block gas limit";
+
 // this error is returned randomly by the `TestTokenRecipient`,
 // to simulate delivery errors
 const SIMULATED_DELIVERY_FAILURE_ERROR: &str = "block hash ends in 0";
@@ -90,17 +93,21 @@ impl IsRetryable for LanderError {
                 false
             }
             ChainCommunicationError(err) => {
-                if err.to_string().contains(SIMULATED_DELIVERY_FAILURE_ERROR) {
+                let err_str = err.to_string();
+                // If error contains block gas limit, always non-retryable
+                if err_str.contains(EVM_EXCEEDS_BLOCK_GAS_LIMIT_ERROR) {
+                    return false;
+                }
+                if err_str.contains(SIMULATED_DELIVERY_FAILURE_ERROR) {
                     return true;
                 }
                 if EVM_GAS_UNDERPRICED_ERRORS
                     .iter()
-                    .any(|&e| err.to_string().contains(e))
+                    .any(|&e| err_str.contains(e))
                 {
                     return true;
                 }
-
-                if err.to_string().contains(SVM_BLOCKHASH_NOT_FOUND_ERROR) {
+                if err_str.contains(SVM_BLOCKHASH_NOT_FOUND_ERROR) {
                     return true;
                 }
                 // TODO: add logic to classify based on the error message
@@ -125,3 +132,6 @@ impl IsRetryable for LanderError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/rust/main/lander/src/error/tests.rs
+++ b/rust/main/lander/src/error/tests.rs
@@ -1,0 +1,33 @@
+use crate::error::{IsRetryable, LanderError};
+use hyperlane_core::ChainCommunicationError;
+
+fn make_chain_comm_err(msg: &str) -> LanderError {
+    LanderError::ChainCommunicationError(ChainCommunicationError::from(eyre::eyre!(msg.to_owned())))
+}
+
+#[test]
+fn test_exceeds_block_gas_limit_non_retryable() {
+    let err = make_chain_comm_err("exceeds block gas limit");
+    assert!(
+        !err.is_retryable(),
+        "Should not be retryable if exceeds block gas limit"
+    );
+}
+
+#[test]
+fn test_exceeds_block_gas_limit_with_retryable_string_non_retryable() {
+    let err = make_chain_comm_err("already known; exceeds block gas limit");
+    assert!(
+        !err.is_retryable(),
+        "Should not be retryable if exceeds block gas limit is present, even with retryable string"
+    );
+}
+
+#[test]
+fn test_retryable_string_only() {
+    let err = make_chain_comm_err("already known");
+    assert!(
+        err.is_retryable(),
+        "Should be retryable if only retryable string is present"
+    );
+}

--- a/rust/main/lander/src/error/tests.rs
+++ b/rust/main/lander/src/error/tests.rs
@@ -1,5 +1,6 @@
-use crate::error::{IsRetryable, LanderError};
 use hyperlane_core::ChainCommunicationError;
+
+use crate::error::{IsRetryable, LanderError};
 
 fn make_chain_comm_err(msg: &str) -> LanderError {
     LanderError::ChainCommunicationError(ChainCommunicationError::from(eyre::eyre!(msg.to_owned())))


### PR DESCRIPTION
### Description

Currently, if an error returned by RPC provider contains a string which is treated by Lander as retriable, it won't take into account other errors which can be not re-triable. We add logic so that if a transaction exceeds block gas limit, it won't be retried.

### Related issues

- Fixed https://linear.app/hyperlane-xyz/issue/ENG-2021/lander-more-precise-underpriced-error-classification

Yes

### Testing

Added unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry logic for network/chain errors to avoid retrying transactions that exceed the block gas limit.
  * Refined error classification for more accurate retry vs. fail decisions, reducing unnecessary retries and speeding up failure feedback.

* **Tests**
  * Added tests to verify non-retryable behavior for block gas limit errors and retryable behavior for known transient errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->