### PR TITLE
fix: Stop resubmitting a message if there is a payload in Lander which is not dropped

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@ solidity/ @yorhodes @ltyu @larryob
 starknet/ @yorhodes @troykessler
 
 ## Agents
-rust/ @ameten @kamiyaa
+rust/ @ameten @kamiyaa @yjamin
 
 ## SDK
 typescript/utils @yorhodes @ltyu @paulbalaji @xaroz @xeno097 @antigremlin

--- a/rust/main/agents/relayer/src/msg/message_processor.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor.rs
@@ -160,7 +160,10 @@ impl MessageProcessor {
 
         let entrypoint = self.payload_dispatcher_entrypoint.take().map(Arc::new);
 
-        let prepare_task = self.create_classic_prepare_task();
+        let prepare_task = match &entrypoint {
+            None => self.create_classic_prepare_task(),
+            Some(entrypoint) => self.create_lander_prepare_task(entrypoint.clone()),
+        };
 
         let submit_task = match &entrypoint {
             None => self.create_classic_submit_task(),


### PR DESCRIPTION
### Description

Currently, MessageProcessor will try to resubmit a message if it could not confirm its delivery after 10 mins. It will create a new payload and results into a new transaction created by Lander. Lander will attempt to land two independent transaction for a message, which is not correct.

We are storing a linkage between payloads and messages when we send a message to Lander. So, we will check if we have a payload which is not dropped and related to a message, MessageProcessor does not attempt to send the message again to Lander.

### Related issues

- Fixes https://linear.app/hyperlane-xyz/issue/ENG-2023/messageprocessor-track-linkage-between-message-and-payload

### Backward compatibility

Yes

### Testing

E2E tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message processing adapts automatically to deployment mode: preparation and submission now follow the same selection logic to support entrypoint-based or classic flows seamlessly.
* **Chores**
  * Added @yjamin to the Rust Agents codeowners to expand maintainership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->