### PR TITLE
chore: Adds M0 as an app context

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -746,6 +746,12 @@ const metricAppContextsGetter = (): MetricAppContext[] => {
       name: 'superswap_ica_v2',
       matchingList: superswapIcaV2MatchingList,
     },
+    {
+      name: 'm0',
+      matchingList: consistentSenderRecipientMatchingList(
+        '0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE',
+      ),
+    },
   ];
 };
 


### PR DESCRIPTION
### Description

Adds M0 as an app context so that there is higher-urgency alerting upon non-processing of messages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new metric app context “m0” on mainnet3 to track activity for address 0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE.
  * Expands monitoring coverage and visibility for this address while leaving existing contexts unchanged.
  * Ensures consistent attribution of interactions for more accurate reporting.
  * No changes to user-facing settings or APIs; existing dashboards and workflows continue to operate as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->