### PR TITLE
feat(fees): Deploy and set Fees in Deployer

### DIFF
--- a/.changeset/little-boxes-wink.md
+++ b/.changeset/little-boxes-wink.md
@@ -1,0 +1,6 @@
+---
+"@hyperlane-xyz/cli": minor
+"@hyperlane-xyz/sdk": minor
+---
+
+Add the Fee deploy logic into token deployer to allow warp routes to deploy with a token fee. Update Fee schemas to separate between input and output

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
@@ -878,5 +878,83 @@ describe('hyperlane warp deploy e2e tests', async function () {
         }),
       );
     });
+
+    it('should deploy a token fee with top-level owner when fee owner is unspecified', async () => {
+      const tokenFee: TokenFeeConfigInput = {
+        type: TokenFeeType.LinearFee,
+        token: tokenChain2.address,
+        bps: 1n,
+      };
+
+      const warpConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.collateral,
+          token: tokenChain2.address,
+          owner: ownerAddress,
+          tokenFee,
+        },
+        [CHAIN_NAME_3]: {
+          type: TokenType.synthetic,
+          owner: ownerAddress,
+        },
+      };
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpConfig);
+      await hyperlaneWarpDeploy(WARP_DEPLOY_OUTPUT_PATH);
+
+      const COMBINED_WARP_CORE_CONFIG_PATH =
+        GET_WARP_DEPLOY_CORE_CONFIG_OUTPUT_PATH(
+          WARP_DEPLOY_OUTPUT_PATH,
+          await tokenChain2.symbol(),
+        );
+
+      const collateralConfig = (
+        await readWarpConfig(
+          CHAIN_NAME_2,
+          COMBINED_WARP_CORE_CONFIG_PATH,
+          WARP_DEPLOY_OUTPUT_PATH,
+        )
+      )[CHAIN_NAME_2];
+      expect(collateralConfig.tokenFee?.owner).to.equal(ownerAddress);
+    });
+
+    it.only('should deploy a token fee with top-level token when fee token is unspecified', async () => {
+      const tokenFee: TokenFeeConfigInput = {
+        type: TokenFeeType.LinearFee,
+        owner: ownerAddress,
+        bps: 1n,
+      };
+
+      const warpConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.collateral,
+          token: tokenChain2.address,
+          owner: ownerAddress,
+          tokenFee,
+        },
+        [CHAIN_NAME_3]: {
+          type: TokenType.synthetic,
+          owner: ownerAddress,
+        },
+      };
+
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpConfig);
+      await hyperlaneWarpDeploy(WARP_DEPLOY_OUTPUT_PATH);
+
+      const COMBINED_WARP_CORE_CONFIG_PATH =
+        GET_WARP_DEPLOY_CORE_CONFIG_OUTPUT_PATH(
+          WARP_DEPLOY_OUTPUT_PATH,
+          await tokenChain2.symbol(),
+        );
+
+      const collateralConfig = (
+        await readWarpConfig(
+          CHAIN_NAME_2,
+          COMBINED_WARP_CORE_CONFIG_PATH,
+          WARP_DEPLOY_OUTPUT_PATH,
+        )
+      )[CHAIN_NAME_2];
+
+      expect(collateralConfig.tokenFee?.token).to.equal(tokenChain2.address);
+    });
   });
 });

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
@@ -832,7 +832,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
       }
     });
 
-    it('should deploy with a token fee config', async () => {
+    it.only('should deploy with a token fee config', async () => {
       const tokenFee: TokenFeeConfigInput = {
         type: TokenFeeType.LinearFee,
         token: tokenChain2.address,

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
@@ -832,7 +832,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
       }
     });
 
-    it.only('should deploy with a token fee config', async () => {
+    it('should deploy with a token fee config', async () => {
       const tokenFee: TokenFeeConfigInput = {
         type: TokenFeeType.LinearFee,
         token: tokenChain2.address,

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
@@ -21,7 +21,7 @@ import {
   HookType,
   IsmConfig,
   IsmType,
-  TokenFeeConfigSchema,
+  TokenFeeConfigInput,
   TokenFeeType,
   TokenType,
   WarpCoreConfig,
@@ -833,12 +833,12 @@ describe('hyperlane warp deploy e2e tests', async function () {
     });
 
     it('should deploy with a token fee config', async () => {
-      const tokenFee = TokenFeeConfigSchema.parse({
+      const tokenFee: TokenFeeConfigInput = {
         type: TokenFeeType.LinearFee,
         token: tokenChain2.address,
         owner: ownerAddress,
-        bps: 1,
-      });
+        bps: 1n,
+      };
 
       const warpConfig: WarpRouteDeployConfig = {
         [CHAIN_NAME_2]: {

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
@@ -917,7 +917,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
       expect(collateralConfig.tokenFee?.owner).to.equal(ownerAddress);
     });
 
-    it.only('should deploy a token fee with top-level token when fee token is unspecified', async () => {
+    it('should deploy a token fee with top-level token when fee token is unspecified', async () => {
       const tokenFee: TokenFeeConfigInput = {
         type: TokenFeeType.LinearFee,
         owner: ownerAddress,

--- a/typescript/sdk/src/fee/EvmTokenFeeDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeDeployer.hardhat-test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import hre from 'hardhat';
 
 import { ERC20Test, ERC20Test__factory } from '@hyperlane-xyz/core';
-import { addressToBytes32 } from '@hyperlane-xyz/utils';
+import { addressToBytes32, randomInt } from '@hyperlane-xyz/utils';
 
 import { TestChainName } from '../consts/testChains.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
@@ -36,7 +36,7 @@ describe('EvmTokenFeeDeployer', () => {
     title: string;
     config: DistributiveOmit<
       LinearFeeConfig | ProgressiveFeeConfig | RegressiveFeeConfig,
-      'owner' | 'token'
+      'owner' | 'token' // Omit owner and token because they are created after the beforeEach
     >;
   };
 
@@ -142,14 +142,15 @@ describe('EvmTokenFeeDeployer', () => {
 
     await routingFeeContract.setFeeContract(1, linearFeeContract.address);
 
+    const amount = randomInt(1, 10000000000000);
     const quote = await routingFeeContract.quoteTransferRemote(
       1,
       addressToBytes32(signer.address),
-      100000000000000,
+      amount,
     );
 
     expect(quote.length).to.equal(1);
-    expect(quote[0].amount).to.be.equal(10000000000000);
+    expect(quote[0].amount).to.be.equal((BigInt(amount) * BPS) / 10_000n);
     expect(quote[0].token).to.equal(token.address);
 
     // If no fee contract is set, the quote should be zero

--- a/typescript/sdk/src/fee/EvmTokenFeeDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeDeployer.hardhat-test.ts
@@ -9,6 +9,7 @@ import { TestChainName } from '../consts/testChains.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 
 import { EvmTokenFeeDeployer } from './EvmTokenFeeDeployer.js';
+import { BPS, HALF_AMOUNT, MAX_FEE } from './EvmTokenFeeReader.hardhat-test.js';
 import { EvmTokenFeeReader } from './EvmTokenFeeReader.js';
 import {
   LinearFeeConfig,
@@ -18,10 +19,6 @@ import {
   TokenFeeConfigSchema,
   TokenFeeType,
 } from './types.js';
-
-const MAX_FEE = 1157920892373161954235709850086879078532699846656405640394n;
-const HALF_AMOUNT = 5789604461865809771178549250434395392663499233282028201970n;
-const BPS = EvmTokenFeeReader.convertToBps(MAX_FEE, HALF_AMOUNT); // 0.1 or 1000bps
 
 type DistributiveOmit<T, K extends keyof T> = T extends any
   ? Omit<T, K>

--- a/typescript/sdk/src/fee/EvmTokenFeeDeployer.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeDeployer.ts
@@ -24,7 +24,7 @@ type RoutingFeeDeploymentResult = {
 };
 
 export class EvmTokenFeeDeployer extends HyperlaneDeployer<
-  TokenFeeConfigInput,
+  TokenFeeConfig,
   EvmTokenFeeFactories
 > {
   protected readonly tokenFeeReader: EvmTokenFeeReader;
@@ -43,11 +43,11 @@ export class EvmTokenFeeDeployer extends HyperlaneDeployer<
     const deployedContract: any = {}; // This is a partial HyperlaneContracts<EvmTokenFeeFactories>
     const parsedConfig = TokenFeeConfigSchema.parse(config);
 
-    switch (config.type) {
+    switch (parsedConfig.type) {
       case TokenFeeType.LinearFee:
       case TokenFeeType.ProgressiveFee:
       case TokenFeeType.RegressiveFee:
-        deployedContract[config.type] = await this.deployFee(
+        deployedContract[parsedConfig.type] = await this.deployFee(
           chain,
           parsedConfig,
         );
@@ -74,7 +74,7 @@ export class EvmTokenFeeDeployer extends HyperlaneDeployer<
 
   private async deployFee(
     chain: ChainName,
-    config: TokenFeeConfig,
+    config: Exclude<TokenFeeConfig, { type: TokenFeeType.RoutingFee }>,
   ): Promise<
     ReturnType<EvmTokenFeeFactories[TokenFeeConfig['type']]['deploy']>
   > {

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -9,32 +9,30 @@ import { MultiProvider } from '../providers/MultiProvider.js';
 import { normalizeConfig } from '../utils/ism.js';
 
 import { EvmTokenFeeModule } from './EvmTokenFeeModule.js';
-import {
-  LinearFeeConfig,
-  LinearFeeConfigSchema,
-  TokenFeeType,
-} from './types.js';
+import { EvmTokenFeeReader } from './EvmTokenFeeReader.js';
+import { TokenFeeConfigInput, TokenFeeType } from './types.js';
 
-const MAX_FEE = 100000000000000000000n;
-const HALF_AMOUNT = 50000000000000000000n;
+const MAX_FEE = 1157920892373161954235709850086879078532699846656405640394n;
+const HALF_AMOUNT = 578960446186580977117854925043439539266349923328202820197n;
+const BPS = EvmTokenFeeReader.convertToBps(MAX_FEE, HALF_AMOUNT);
 describe('EvmTokenFeeModule', () => {
   let multiProvider: MultiProvider;
   let signer: SignerWithAddress;
   let token: ERC20Test;
-  let config: LinearFeeConfig;
+  let config: TokenFeeConfigInput;
   before(async () => {
     [signer] = await hre.ethers.getSigners();
     multiProvider = MultiProvider.createTestMultiProvider({ signer });
     const factory = new ERC20Test__factory(signer);
     token = await factory.deploy('fake', 'FAKE', '100000000000000000000', 18);
     await token.deployed();
-    config = LinearFeeConfigSchema.parse({
+
+    config = {
       type: TokenFeeType.LinearFee,
       owner: signer.address,
       token: token.address,
-      maxFee: MAX_FEE,
-      halfAmount: HALF_AMOUNT,
-    });
+      bps: BPS,
+    };
   });
   it('should create a new token fee', async () => {
     const module = await EvmTokenFeeModule.create({
@@ -44,7 +42,7 @@ describe('EvmTokenFeeModule', () => {
     });
     const onchainConfig = await module.read();
     expect(normalizeConfig(onchainConfig)).to.deep.equal(
-      normalizeConfig({ ...config, bps: 10000n }),
+      normalizeConfig({ ...config, maxFee: MAX_FEE, halfAmount: HALF_AMOUNT }),
     );
   });
 
@@ -52,16 +50,13 @@ describe('EvmTokenFeeModule', () => {
     const module = await EvmTokenFeeModule.create({
       multiProvider,
       chain: TestChainName.test2,
-      config: {
-        ...config,
-        bps: 10000n,
-      },
+      config,
     });
     const onchainConfig = await module.read();
     assert(
       onchainConfig.type === TokenFeeType.LinearFee,
       `Must be ${TokenFeeType.LinearFee}`,
     );
-    expect(onchainConfig.bps).to.equal(10000n);
+    expect(onchainConfig.bps).to.equal(BPS);
   });
 });

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -9,12 +9,9 @@ import { MultiProvider } from '../providers/MultiProvider.js';
 import { normalizeConfig } from '../utils/ism.js';
 
 import { EvmTokenFeeModule } from './EvmTokenFeeModule.js';
-import { EvmTokenFeeReader } from './EvmTokenFeeReader.js';
+import { BPS, HALF_AMOUNT, MAX_FEE } from './EvmTokenFeeReader.hardhat-test.js';
 import { TokenFeeConfigInput, TokenFeeType } from './types.js';
 
-const MAX_FEE = 1157920892373161954235709850086879078532699846656405640394n;
-const HALF_AMOUNT = 578960446186580977117854925043439539266349923328202820197n;
-const BPS = EvmTokenFeeReader.convertToBps(MAX_FEE, HALF_AMOUNT);
 describe('EvmTokenFeeModule', () => {
   let multiProvider: MultiProvider;
   let signer: SignerWithAddress;

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -10,7 +10,7 @@ import { normalizeConfig } from '../utils/ism.js';
 
 import { EvmTokenFeeModule } from './EvmTokenFeeModule.js';
 import { EvmTokenFeeReader } from './EvmTokenFeeReader.js';
-import { TokenFeeConfigInput, TokenFeeType } from './types.js';
+import { TokenFeeConfig, TokenFeeType } from './types.js';
 
 const MAX_FEE = 1157920892373161954235709850086879078532699846656405640394n;
 const HALF_AMOUNT = 578960446186580977117854925043439539266349923328202820197n;
@@ -19,7 +19,7 @@ describe('EvmTokenFeeModule', () => {
   let multiProvider: MultiProvider;
   let signer: SignerWithAddress;
   let token: ERC20Test;
-  let config: TokenFeeConfigInput;
+  let config: TokenFeeConfig;
   before(async () => {
     [signer] = await hre.ethers.getSigners();
     multiProvider = MultiProvider.createTestMultiProvider({ signer });
@@ -31,6 +31,8 @@ describe('EvmTokenFeeModule', () => {
       type: TokenFeeType.LinearFee,
       owner: signer.address,
       token: token.address,
+      maxFee: MAX_FEE,
+      halfAmount: HALF_AMOUNT,
       bps: BPS,
     };
   });

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -9,9 +9,12 @@ import { MultiProvider } from '../providers/MultiProvider.js';
 import { normalizeConfig } from '../utils/ism.js';
 
 import { EvmTokenFeeModule } from './EvmTokenFeeModule.js';
-import { BPS, HALF_AMOUNT, MAX_FEE } from './EvmTokenFeeReader.hardhat-test.js';
+import { EvmTokenFeeReader } from './EvmTokenFeeReader.js';
 import { TokenFeeConfigInput, TokenFeeType } from './types.js';
 
+const MAX_FEE = 1157920892373161954235709850086879078532699846656405640394n;
+const HALF_AMOUNT = 578960446186580977117854925043439539266349923328202820197n;
+const BPS = EvmTokenFeeReader.convertToBps(MAX_FEE, HALF_AMOUNT);
 describe('EvmTokenFeeModule', () => {
   let multiProvider: MultiProvider;
   let signer: SignerWithAddress;

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -23,6 +23,7 @@ import {
   DerivedTokenFeeConfig,
   EvmTokenFeeReader,
 } from './EvmTokenFeeReader.js';
+import { EvmTokenFeeFactories } from './contracts.js';
 import {
   TokenFeeConfig,
   TokenFeeConfigInput,

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -19,10 +19,7 @@ import { ProtocolTypedTransaction } from '../providers/ProviderType.js';
 import { ChainNameOrId } from '../types.js';
 
 import { EvmTokenFeeDeployer } from './EvmTokenFeeDeployer.js';
-import {
-  DerivedTokenFeeConfig,
-  EvmTokenFeeReader,
-} from './EvmTokenFeeReader.js';
+import { EvmTokenFeeReader } from './EvmTokenFeeReader.js';
 import { EvmTokenFeeFactories } from './contracts.js';
 import {
   TokenFeeConfig,
@@ -145,7 +142,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     return this.args.addresses.deployedFee;
   }
 
-  async read(): Promise<DerivedTokenFeeConfig> {
+  async read(): Promise<TokenFeeConfig> {
     return this.reader.deriveTokenFeeConfig(this.args.addresses.deployedFee);
   }
 

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -76,6 +76,11 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     return module;
   }
 
+  // Public accessor for the deployed fee contract address
+  getDeployedFeeAddress(): Address {
+    return this.args.addresses.deployedFee;
+  }
+
   async read(): Promise<DerivedTokenFeeConfig> {
     return this.reader.deriveTokenFeeConfig(this.args.addresses.deployedFee);
   }

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -62,7 +62,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
   }: {
     multiProvider: MultiProvider;
     chain: ChainNameOrId;
-    config: TokenFeeConfigInput;
+    config: TokenFeeConfig;
     contractVerifier?: ContractVerifier;
   }): Promise<EvmTokenFeeModule> {
     const chainName = multiProvider.getChainName(chain);
@@ -78,7 +78,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
       contractVerifier,
     );
 
-    const finalizedConfig = await module.processConfig({
+    const finalizedConfig = await EvmTokenFeeModule.processConfig({
       config,
       multiProvider,
       chainName,
@@ -97,7 +97,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
 
   // Processes the Input config to the Final config
   // For LinearFee, it converts the bps to maxFee and halfAmount
-  private async processConfig(params: {
+  public static async processConfig(params: {
     config: TokenFeeConfigInput;
     multiProvider: MultiProvider;
     chainName: string;

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -4,6 +4,7 @@ import {
   Address,
   Annotated,
   ProtocolType,
+  assert,
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
@@ -104,6 +105,10 @@ export class EvmTokenFeeModule extends HyperlaneModule<
   }): Promise<TokenFeeConfig> {
     const intermediaryConfig: Partial<TokenFeeConfig> = { ...params.config };
     if (params.config.type === TokenFeeType.LinearFee) {
+      assert(
+        params.config.token,
+        'Token address is required to process config',
+      );
       const reader = new EvmTokenFeeReader(
         params.multiProvider,
         params.chainName,

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -85,10 +85,10 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     });
 
     const contracts = await module.deploy({
-      config: finalizedConfig,
       multiProvider,
       chainName,
       contractVerifier,
+      config: finalizedConfig,
     });
     module.args.addresses.deployedFee = contracts[chain][config.type].address;
 

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
@@ -15,9 +15,11 @@ import { EvmTokenFeeReader } from './EvmTokenFeeReader.js';
 import { EvmTokenFeeFactories } from './contracts.js';
 import { TokenFeeConfig, TokenFeeConfigSchema, TokenFeeType } from './types.js';
 
-const MAX_FEE = 1157920892373161954235709850086879078532699846656405640394n;
-const HALF_AMOUNT = 5789604461865809771178549250434395392663499233282028201970n;
-const BPS = EvmTokenFeeReader.convertToBps(MAX_FEE, HALF_AMOUNT); // 0.1 or 1000bps
+export const MAX_FEE =
+  1157920892373161954235709850086879078532699846656405640394n;
+export const HALF_AMOUNT =
+  5789604461865809771178549250434395392663499233282028201970n;
+export const BPS = EvmTokenFeeReader.convertToBps(MAX_FEE, HALF_AMOUNT); // 0.1 or 1000bps
 
 describe('EvmTokenFeeReader', () => {
   let multiProvider: MultiProvider;

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
@@ -15,11 +15,9 @@ import { EvmTokenFeeReader } from './EvmTokenFeeReader.js';
 import { EvmTokenFeeFactories } from './contracts.js';
 import { TokenFeeConfig, TokenFeeConfigSchema, TokenFeeType } from './types.js';
 
-export const MAX_FEE =
-  1157920892373161954235709850086879078532699846656405640394n;
-export const HALF_AMOUNT =
-  5789604461865809771178549250434395392663499233282028201970n;
-export const BPS = EvmTokenFeeReader.convertToBps(MAX_FEE, HALF_AMOUNT); // 0.1 or 1000bps
+const MAX_FEE = 1157920892373161954235709850086879078532699846656405640394n;
+const HALF_AMOUNT = 5789604461865809771178549250434395392663499233282028201970n;
+const BPS = EvmTokenFeeReader.convertToBps(MAX_FEE, HALF_AMOUNT); // 0.1 or 1000bps
 
 describe('EvmTokenFeeReader', () => {
   let multiProvider: MultiProvider;

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
@@ -14,9 +14,11 @@ import { EvmTokenFeeDeployer } from './EvmTokenFeeDeployer.js';
 import { EvmTokenFeeReader } from './EvmTokenFeeReader.js';
 import { TokenFeeConfig, TokenFeeConfigSchema, TokenFeeType } from './types.js';
 
-const MAX_FEE = 1157920892373161954235709850086879078532699846656405640394n;
-const HALF_AMOUNT = 5789604461865809771178549250434395392663499233282028201970n;
-const BPS = EvmTokenFeeReader.convertToBps(MAX_FEE, HALF_AMOUNT);
+export const MAX_FEE =
+  1157920892373161954235709850086879078532699846656405640394n;
+export const HALF_AMOUNT =
+  5789604461865809771178549250434395392663499233282028201970n;
+export const BPS = EvmTokenFeeReader.convertToBps(MAX_FEE, HALF_AMOUNT);
 
 describe('EvmTokenFeeReader', () => {
   let multiProvider: MultiProvider;

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
@@ -1,5 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers.js';
 import { expect } from 'chai';
+import { BigNumber, constants, utils } from 'ethers';
 import hre from 'hardhat';
 
 import { ERC20Test, ERC20Test__factory, LinearFee } from '@hyperlane-xyz/core';

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
@@ -1,6 +1,5 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers.js';
 import { expect } from 'chai';
-import { BigNumber, constants, utils } from 'ethers';
 import hre from 'hardhat';
 
 import { ERC20Test, ERC20Test__factory, LinearFee } from '@hyperlane-xyz/core';

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
@@ -1,61 +1,59 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers.js';
 import { expect } from 'chai';
+import { constants } from 'ethers';
 import hre from 'hardhat';
 
-import { ERC20Test, ERC20Test__factory, LinearFee } from '@hyperlane-xyz/core';
+import { ERC20Test, ERC20Test__factory } from '@hyperlane-xyz/core';
 
 import { TestChainName } from '../consts/testChains.js';
-import { HyperlaneContractsMap } from '../contracts/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { randomInt } from '../test/testUtils.js';
 import { normalizeConfig } from '../utils/ism.js';
 
 import { EvmTokenFeeDeployer } from './EvmTokenFeeDeployer.js';
 import { EvmTokenFeeReader } from './EvmTokenFeeReader.js';
-import { EvmTokenFeeFactories } from './contracts.js';
 import { TokenFeeConfig, TokenFeeConfigSchema, TokenFeeType } from './types.js';
 
 const MAX_FEE = 1157920892373161954235709850086879078532699846656405640394n;
 const HALF_AMOUNT = 5789604461865809771178549250434395392663499233282028201970n;
-const BPS = EvmTokenFeeReader.convertToBps(MAX_FEE, HALF_AMOUNT); // 0.1 or 1000bps
+const BPS = EvmTokenFeeReader.convertToBps(MAX_FEE, HALF_AMOUNT);
 
 describe('EvmTokenFeeReader', () => {
   let multiProvider: MultiProvider;
   let signer: SignerWithAddress;
-  let reader: EvmTokenFeeReader;
-  let tokenFee: LinearFee;
-  let deployer: EvmTokenFeeDeployer;
-  let deployedContracts: HyperlaneContractsMap<EvmTokenFeeFactories>;
   let token: ERC20Test;
 
-  let config: TokenFeeConfig;
   const TOKEN_TOTAL_SUPPLY = '100000000000000000000';
-  beforeEach(async () => {
+
+  before(async () => {
     [signer] = await hre.ethers.getSigners();
     multiProvider = MultiProvider.createTestMultiProvider({ signer });
-    deployer = new EvmTokenFeeDeployer(multiProvider, TestChainName.test2);
+
     const factory = new ERC20Test__factory(signer);
     token = await factory.deploy('fake', 'FAKE', TOKEN_TOTAL_SUPPLY, 18);
     await token.deployed();
-
-    config = TokenFeeConfigSchema.parse({
-      type: TokenFeeType.LinearFee,
-      maxFee: MAX_FEE,
-      halfAmount: HALF_AMOUNT,
-      bps: BPS,
-      token: token.address,
-      owner: signer.address,
-    });
-
-    deployedContracts = await deployer.deploy({
-      [TestChainName.test2]: config,
-    });
   });
 
-  describe('LinearFee', async () => {
+  describe('LinearFee', () => {
     it('should read the token fee config', async () => {
-      reader = new EvmTokenFeeReader(multiProvider, TestChainName.test2);
-      tokenFee = deployedContracts[TestChainName.test2][TokenFeeType.LinearFee];
+      const config = TokenFeeConfigSchema.parse({
+        type: TokenFeeType.LinearFee,
+        maxFee: MAX_FEE,
+        halfAmount: HALF_AMOUNT,
+        bps: BPS,
+        token: token.address,
+        owner: signer.address,
+      });
+      const deployer = new EvmTokenFeeDeployer(
+        multiProvider,
+        TestChainName.test2,
+      );
+      const deployedContracts = await deployer.deploy({
+        [TestChainName.test2]: config,
+      });
+      const reader = new EvmTokenFeeReader(multiProvider, TestChainName.test2);
+      const tokenFee =
+        deployedContracts[TestChainName.test2][TokenFeeType.LinearFee];
       const onchainConfig = await reader.deriveTokenFeeConfig(tokenFee.address);
       expect(normalizeConfig(onchainConfig)).to.deep.equal(
         normalizeConfig({
@@ -69,7 +67,7 @@ describe('EvmTokenFeeReader', () => {
 
     it('should convert maxFee and halfAmount to bps', async () => {
       const maxFee = BigInt(randomInt(2, 100_000_000));
-      const halfAmount = maxFee / 2n;
+      const halfAmount = maxFee * 5n;
 
       const config = {
         type: TokenFeeType.LinearFee,
@@ -80,10 +78,14 @@ describe('EvmTokenFeeReader', () => {
         bps: EvmTokenFeeReader.convertToBps(maxFee, halfAmount),
       };
       const parsedConfig = TokenFeeConfigSchema.parse(config);
-      deployedContracts = await deployer.deploy({
+      const deployer = new EvmTokenFeeDeployer(
+        multiProvider,
+        TestChainName.test2,
+      );
+      await deployer.deploy({
         [TestChainName.test3]: parsedConfig,
       });
-      tokenFee = deployedContracts[TestChainName.test3][TokenFeeType.LinearFee];
+
       const convertedBps = EvmTokenFeeReader.convertToBps(maxFee, halfAmount);
       expect(convertedBps).to.equal(BPS);
     });
@@ -110,14 +112,14 @@ describe('EvmTokenFeeReader', () => {
     });
   });
 
-  describe('RoutingFee', async () => {
+  describe('RoutingFee', () => {
     it('should be able to derive a routing fee config and its sub fees', async () => {
       const routingFeeConfig: TokenFeeConfig = {
         type: TokenFeeType.RoutingFee,
         owner: signer.address,
         token: token.address,
-        maxFee: MAX_FEE,
-        halfAmount: HALF_AMOUNT,
+        maxFee: constants.MaxUint256.toBigInt(),
+        halfAmount: constants.MaxUint256.toBigInt(),
         feeContracts: {
           [TestChainName.test2]: {
             owner: signer.address,

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.ts
@@ -19,7 +19,9 @@ import {
   onChainTypeToTokenFeeTypeMap,
 } from './types.js';
 
-export type DerivedTokenFeeConfig = WithAddress<TokenFeeConfig>;
+type DerivedTokenFeeConfig = WithAddress<TokenFeeConfig>;
+
+const MAX_BPS = 10_000n; // 100% in bps
 export class EvmTokenFeeReader extends HyperlaneReader {
   constructor(
     protected readonly multiProvider: MultiProvider,
@@ -147,8 +149,7 @@ export class EvmTokenFeeReader extends HyperlaneReader {
     const totalSupplyBn = await token.totalSupply();
     const maxFee = BigInt(constants.MaxUint256.div(totalSupplyBn).toString());
 
-    // 5_000 because halfAmount is maxFee / 2. The total is 10_000, which is 100% in bps
-    const halfAmount = (maxFee * 5_000n) / bps;
+    const halfAmount = ((maxFee / 2n) * MAX_BPS) / bps;
     return {
       maxFee,
       halfAmount,
@@ -156,8 +157,7 @@ export class EvmTokenFeeReader extends HyperlaneReader {
   }
 
   static convertToBps(maxFee: bigint, halfAmount: bigint): bigint {
-    const PRECISION = 10_000n; // 100% in bps
-    const bps = (maxFee * PRECISION) / (halfAmount * 2n);
+    const bps = (maxFee * MAX_BPS) / (halfAmount * 2n);
 
     return bps;
   }

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.ts
@@ -20,7 +20,7 @@ import {
   onChainTypeToTokenFeeTypeMap,
 } from './types.js';
 
-type DerivedTokenFeeConfig = WithAddress<TokenFeeConfig>;
+export type DerivedTokenFeeConfig = WithAddress<TokenFeeConfig>;
 
 const MAX_BPS = 10_000n; // 100% in bps
 export class EvmTokenFeeReader extends HyperlaneReader {

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.ts
@@ -13,6 +13,7 @@ import { ChainName, ChainNameOrId } from '../types.js';
 import { HyperlaneReader } from '../utils/HyperlaneReader.js';
 
 import {
+  FeeParameters,
   OnchainTokenFeeType,
   TokenFeeConfig,
   TokenFeeType,
@@ -77,7 +78,7 @@ export class EvmTokenFeeReader extends HyperlaneReader {
     ]);
     const maxFeeBn = BigInt(maxFee.toString());
     const halfAmountBn = BigInt(halfAmount.toString());
-    const bps = await EvmTokenFeeReader.convertToBps(maxFeeBn, halfAmountBn);
+    const bps = EvmTokenFeeReader.convertToBps(maxFeeBn, halfAmountBn);
 
     return {
       type: TokenFeeType.LinearFee,
@@ -143,7 +144,7 @@ export class EvmTokenFeeReader extends HyperlaneReader {
   async convertFromBps(
     bps: bigint,
     tokenAddress: Address,
-  ): Promise<{ maxFee: bigint; halfAmount: bigint }> {
+  ): Promise<FeeParameters> {
     // Assume maxFee is uint256.max / token.totalSupply
     const token = ERC20__factory.connect(tokenAddress, this.provider);
     const totalSupplyBn = await token.totalSupply();

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.ts
@@ -13,7 +13,6 @@ import { ChainName, ChainNameOrId } from '../types.js';
 import { HyperlaneReader } from '../utils/HyperlaneReader.js';
 
 import {
-  BaseTokenFeeConfig,
   OnchainTokenFeeType,
   TokenFeeConfig,
   TokenFeeType,
@@ -76,7 +75,7 @@ export class EvmTokenFeeReader extends HyperlaneReader {
     ]);
     const maxFeeBn = BigInt(maxFee.toString());
     const halfAmountBn = BigInt(halfAmount.toString());
-    const bps = await this.convertToBps(maxFeeBn, halfAmountBn);
+    const bps = await EvmTokenFeeReader.convertToBps(maxFeeBn, halfAmountBn);
 
     return {
       type: TokenFeeType.LinearFee,
@@ -142,7 +141,7 @@ export class EvmTokenFeeReader extends HyperlaneReader {
   async convertFromBps(
     bps: bigint,
     tokenAddress: Address,
-  ): Promise<Pick<BaseTokenFeeConfig, 'maxFee' | 'halfAmount'>> {
+  ): Promise<{ maxFee: bigint; halfAmount: bigint }> {
     // Assume maxFee is uint256.max / token.totalSupply
     const token = ERC20__factory.connect(tokenAddress, this.provider);
     const totalSupplyBn = await token.totalSupply();
@@ -154,7 +153,7 @@ export class EvmTokenFeeReader extends HyperlaneReader {
     };
   }
 
-  async convertToBps(maxFee: bigint, halfAmount: bigint): Promise<bigint> {
+  static convertToBps(maxFee: bigint, halfAmount: bigint): bigint {
     const PRECISION = 10_000n;
     const bps = (maxFee * PRECISION) / (halfAmount * 2n);
 

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.ts
@@ -6,7 +6,7 @@ import {
   LinearFee__factory,
   RoutingFee__factory,
 } from '@hyperlane-xyz/core';
-import { Address, WithAddress, assert, eqAddress } from '@hyperlane-xyz/utils';
+import { Address, WithAddress, assert } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainName, ChainNameOrId } from '../types.js';
@@ -20,7 +20,7 @@ import {
   onChainTypeToTokenFeeTypeMap,
 } from './types.js';
 
-export type DerivedTokenFeeConfig = WithAddress<TokenFeeConfig>;
+type DerivedTokenFeeConfig = WithAddress<TokenFeeConfig>;
 
 const MAX_BPS = 10_000n; // 100% in bps
 export class EvmTokenFeeReader extends HyperlaneReader {
@@ -60,7 +60,9 @@ export class EvmTokenFeeReader extends HyperlaneReader {
         );
         break;
       default:
-        throw new Error(`Unsupported token fee type: ${onchainFeeType}`);
+        throw new Error(
+          `Unsupported token fee type: ${await tokenFee.feeType()}`,
+        );
     }
 
     return derivedConfig;
@@ -122,9 +124,6 @@ export class EvmTokenFeeReader extends HyperlaneReader {
     await Promise.all(
       destinations.map(async (destination) => {
         const subFeeAddress = await routingFee.feeContracts(destination);
-        if (eqAddress(subFeeAddress, constants.AddressZero)) {
-          return;
-        }
         const chainName = this.multiProvider.getChainName(destination);
         feeContracts[chainName] =
           await this.deriveTokenFeeConfig(subFeeAddress);

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.ts
@@ -146,6 +146,8 @@ export class EvmTokenFeeReader extends HyperlaneReader {
     const token = ERC20__factory.connect(tokenAddress, this.provider);
     const totalSupplyBn = await token.totalSupply();
     const maxFee = BigInt(constants.MaxUint256.div(totalSupplyBn).toString());
+
+    // 5_000 because halfAmount is maxFee / 2. The total is 10_000, which is 100% in bps
     const halfAmount = (maxFee * 5_000n) / bps;
     return {
       maxFee,
@@ -154,7 +156,7 @@ export class EvmTokenFeeReader extends HyperlaneReader {
   }
 
   static convertToBps(maxFee: bigint, halfAmount: bigint): bigint {
-    const PRECISION = 10_000n;
+    const PRECISION = 10_000n; // 100% in bps
     const bps = (maxFee * PRECISION) / (halfAmount * 2n);
 
     return bps;

--- a/typescript/sdk/src/fee/types.ts
+++ b/typescript/sdk/src/fee/types.ts
@@ -1,4 +1,3 @@
-import { ethers } from 'ethers';
 import { z } from 'zod';
 
 import {
@@ -36,35 +35,40 @@ export const onChainTypeToTokenFeeTypeMap: Record<
 export const BaseFeeConfigSchema = z.object({
   token: ZHash,
   owner: ZHash,
-  maxFee: ZBigNumberish,
-  halfAmount: ZBigNumberish,
 });
 export type BaseTokenFeeConfig = z.infer<typeof BaseFeeConfigSchema>;
 
 export const LinearFeeConfigSchema = z.object({
   type: z.literal(TokenFeeType.LinearFee),
   ...BaseFeeConfigSchema.shape,
+  maxFee: ZBigNumberish,
+  halfAmount: ZBigNumberish,
   bps: ZBigNumberish,
 });
 export type LinearFeeConfig = z.infer<typeof LinearFeeConfigSchema>;
 
 export const LinearFeeInputConfigSchema = z.object({
-  ...LinearFeeConfigSchema.shape,
-  maxFee: ZBigNumberish.optional(),
-  halfAmount: ZBigNumberish.optional(),
-  bps: ZBigNumberish.optional(),
+  type: LinearFeeConfigSchema.shape.type,
+  token: BaseFeeConfigSchema.shape.token,
+  owner: BaseFeeConfigSchema.shape.owner,
+  bps: ZBigNumberish,
 });
+
 export type LinearFeeInputConfig = z.infer<typeof LinearFeeInputConfigSchema>;
 
 const ProgressiveFeeConfigSchema = z.object({
   type: z.literal(TokenFeeType.ProgressiveFee),
   ...BaseFeeConfigSchema.shape,
+  maxFee: ZBigNumberish,
+  halfAmount: ZBigNumberish,
 });
 export type ProgressiveFeeConfig = z.infer<typeof ProgressiveFeeConfigSchema>;
 
 const RegressiveFeeConfigSchema = z.object({
   type: z.literal(TokenFeeType.RegressiveFee),
   ...BaseFeeConfigSchema.shape,
+  maxFee: ZBigNumberish,
+  halfAmount: ZBigNumberish,
 });
 export type RegressiveFeeConfig = z.infer<typeof RegressiveFeeConfigSchema>;
 
@@ -77,6 +81,8 @@ export const RoutingFeeConfigSchema = z.object({
     )
     .optional(), // Destination -> Fee
   ...BaseFeeConfigSchema.shape,
+  maxFee: ZBigNumberish.optional(),
+  halfAmount: ZBigNumberish.optional(),
 });
 export type RoutingFeeConfig = z.infer<typeof RoutingFeeConfigSchema>;
 

--- a/typescript/sdk/src/fee/types.ts
+++ b/typescript/sdk/src/fee/types.ts
@@ -57,7 +57,7 @@ export const LinearFeeConfigSchema = StandardFeeConfigBaseSchema.extend({
 });
 export type LinearFeeConfig = z.infer<typeof LinearFeeConfigSchema>;
 
-// Linear Fee Input - only requires bps
+// Linear Fee Input - only requires bps & type
 export const LinearFeeInputConfigSchema = BaseFeeConfigSchema.extend({
   type: z.literal(TokenFeeType.LinearFee),
   bps: ZBigNumberish,

--- a/typescript/sdk/src/fee/types.ts
+++ b/typescript/sdk/src/fee/types.ts
@@ -69,10 +69,29 @@ export const ProgressiveFeeConfigSchema = StandardFeeConfigBaseSchema.extend({
 });
 export type ProgressiveFeeConfig = z.infer<typeof ProgressiveFeeConfigSchema>;
 
+export const ProgressiveFeeInputConfigSchema =
+  ProgressiveFeeConfigSchema.partial({
+    owner: true,
+    token: true,
+  });
+export type ProgressiveFeeInputConfig = z.infer<
+  typeof ProgressiveFeeInputConfigSchema
+>;
+
 export const RegressiveFeeConfigSchema = StandardFeeConfigBaseSchema.extend({
   type: z.literal(TokenFeeType.RegressiveFee),
 });
 export type RegressiveFeeConfig = z.infer<typeof RegressiveFeeConfigSchema>;
+
+export const RegressiveFeeInputConfigSchema = RegressiveFeeConfigSchema.partial(
+  {
+    owner: true,
+    token: true,
+  },
+);
+export type RegressiveFeeInputConfig = z.infer<
+  typeof RegressiveFeeInputConfigSchema
+>;
 
 export const RoutingFeeConfigSchema = BaseFeeConfigSchema.extend({
   type: z.literal(TokenFeeType.RoutingFee),
@@ -87,6 +106,12 @@ export const RoutingFeeConfigSchema = BaseFeeConfigSchema.extend({
 });
 export type RoutingFeeConfig = z.infer<typeof RoutingFeeConfigSchema>;
 
+export const RoutingFeeInputConfigSchema = RoutingFeeConfigSchema.partial({
+  owner: true,
+  token: true,
+});
+export type RoutingFeeInputConfig = z.infer<typeof RoutingFeeInputConfigSchema>;
+
 // ====== UNION SCHEMAS ======
 
 export const TokenFeeConfigSchema = z.discriminatedUnion('type', [
@@ -99,8 +124,8 @@ export type TokenFeeConfig = z.infer<typeof TokenFeeConfigSchema>;
 
 export const TokenFeeConfigInputSchema = z.discriminatedUnion('type', [
   LinearFeeInputConfigSchema,
-  ProgressiveFeeConfigSchema,
-  RegressiveFeeConfigSchema,
-  RoutingFeeConfigSchema,
+  ProgressiveFeeInputConfigSchema,
+  RegressiveFeeInputConfigSchema,
+  RoutingFeeInputConfigSchema,
 ]);
 export type TokenFeeConfigInput = z.infer<typeof TokenFeeConfigInputSchema>;

--- a/typescript/sdk/src/fee/types.ts
+++ b/typescript/sdk/src/fee/types.ts
@@ -58,7 +58,7 @@ export const LinearFeeConfigSchema = StandardFeeConfigBaseSchema.extend({
 export type LinearFeeConfig = z.infer<typeof LinearFeeConfigSchema>;
 
 // Linear Fee Input - only requires bps & type
-export const LinearFeeInputConfigSchema = BaseFeeConfigSchema.extend({
+export const LinearFeeInputConfigSchema = BaseFeeConfigSchema.partial().extend({
   type: z.literal(TokenFeeType.LinearFee),
   bps: ZBigNumberish,
 });

--- a/typescript/sdk/src/fee/types.ts
+++ b/typescript/sdk/src/fee/types.ts
@@ -1,3 +1,4 @@
+import { ethers } from 'ethers';
 import { z } from 'zod';
 
 import {

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -809,3 +809,9 @@ export {
 } from './timelock/evm/constants.js';
 export { EvmEventLogsReader } from './rpc/evm/EvmEventLogsReader.js';
 export { getTimelockExecutableTransactionFromBatch } from './timelock/evm/utils.js';
+
+export {
+  TokenFeeType,
+  TokenFeeConfigSchema,
+  TokenFeeConfigInput,
+} from './fee/types.js';

--- a/typescript/sdk/src/router/EvmRouterReader.ts
+++ b/typescript/sdk/src/router/EvmRouterReader.ts
@@ -1,15 +1,9 @@
 import { constants } from 'ethers';
 
-import {
-  FungibleTokenRouter__factory,
-  MailboxClient__factory,
-  Router__factory,
-} from '@hyperlane-xyz/core';
+import { MailboxClient__factory, Router__factory } from '@hyperlane-xyz/core';
 import { Address, eqAddress, rootLogger } from '@hyperlane-xyz/utils';
 
 import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
-import { EvmTokenFeeReader } from '../fee/EvmTokenFeeReader.js';
-import { TokenFeeConfig } from '../fee/types.js';
 import { EvmHookReader } from '../hook/EvmHookReader.js';
 import { EvmIsmReader } from '../ism/EvmIsmReader.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
@@ -27,7 +21,6 @@ export class EvmRouterReader extends HyperlaneReader {
   protected readonly logger = rootLogger.child({ module: 'EvmRouterReader' });
   protected evmHookReader: EvmHookReader;
   protected evmIsmReader: EvmIsmReader;
-  protected evmTokenFeeReader: EvmTokenFeeReader;
 
   constructor(
     multiProvider: MultiProvider,
@@ -37,7 +30,6 @@ export class EvmRouterReader extends HyperlaneReader {
     super(multiProvider, chain);
     this.evmHookReader = new EvmHookReader(multiProvider, chain, concurrency);
     this.evmIsmReader = new EvmIsmReader(multiProvider, chain, concurrency);
-    this.evmTokenFeeReader = new EvmTokenFeeReader(multiProvider, chain);
   }
 
   public async readRouterConfig(
@@ -45,23 +37,12 @@ export class EvmRouterReader extends HyperlaneReader {
   ): Promise<DerivedRouterConfig> {
     const mailboxClientConfig = await this.fetchMailboxClientConfig(address);
     const remoteRouters = await this.fetchRemoteRouters(address);
-    const tokenFee = await this.fetchTokenFee(address);
     // proxyAdmin and foreignDeployment are not directly readable from a generic router
     // and depend on deployment context or specific router implementations.
     return {
       ...mailboxClientConfig,
-      tokenFee,
       remoteRouters,
     };
-  }
-
-  public async fetchTokenFee(address: Address): Promise<TokenFeeConfig> {
-    const fungibleTokenRouter = FungibleTokenRouter__factory.connect(
-      address,
-      this.provider,
-    );
-    const tokenFee = await fungibleTokenRouter.feeRecipient();
-    return this.evmTokenFeeReader.deriveTokenFeeConfig(tokenFee);
   }
 
   async fetchMailboxClientConfig(

--- a/typescript/sdk/src/router/HyperlaneRouterDeployer.ts
+++ b/typescript/sdk/src/router/HyperlaneRouterDeployer.ts
@@ -156,6 +156,7 @@ export abstract class HyperlaneRouterDeployer<
     return deployedContractsMap;
   }
 
+  // TODO: Consider moving this somewhere else (see notes)
   async configureTokenFees(
     deployedContractsMap: HyperlaneContractsMap<Factories>,
     configMap: ChainMap<Config>,

--- a/typescript/sdk/src/router/HyperlaneRouterDeployer.ts
+++ b/typescript/sdk/src/router/HyperlaneRouterDeployer.ts
@@ -15,7 +15,6 @@ import {
   HyperlaneFactories,
 } from '../contracts/types.js';
 import { HyperlaneDeployer } from '../deploy/HyperlaneDeployer.js';
-import { EvmTokenFeeModule } from '../fee/EvmTokenFeeModule.js';
 import { RouterConfig } from '../router/types.js';
 import { ChainMap } from '../types.js';
 
@@ -161,24 +160,15 @@ export abstract class HyperlaneRouterDeployer<
     deployedContractsMap: HyperlaneContractsMap<Factories>,
     configMap: ChainMap<Config>,
   ): Promise<void> {
+    // Intentionally a no-op in the base deployer.
+    // Token-fee configuration is router-specific (e.g., fungible token routers)
+    // and should be implemented by subclasses that know their router interface.
     for (const chain of Object.keys(deployedContractsMap)) {
       const config = configMap[chain];
-      const tokenFee = config.tokenFee;
-      if (!tokenFee) {
-        continue;
-      }
-      this.logger.debug(`Deploying token fee on ${chain}...`);
-      const module = await EvmTokenFeeModule.create({
-        multiProvider: this.multiProvider,
-        chain,
-        config: tokenFee,
-      });
-      console.log('deployed fee', await module.read());
-      // TODO: set token fee on router
-      // const contracts = deployedContractsMap[chain];
-      // const router = this.router(contracts);
-      // const setTokenFeeTx = await router.setFeeRecipient(module);
-      // await this.multiProvider.handleTx(chain, setTokenFeeTx);
+      if (!config.tokenFee) continue;
+      this.logger.debug(
+        `Token fee config detected on ${chain}, no-op in base deployer. Must be handled by subclass if applicable`,
+      );
     }
   }
 }

--- a/typescript/sdk/src/router/HyperlaneRouterDeployer.ts
+++ b/typescript/sdk/src/router/HyperlaneRouterDeployer.ts
@@ -148,16 +148,15 @@ export abstract class HyperlaneRouterDeployer<
       configMap,
       foreignDeployments,
     );
+    await this.deployAndConfigureTokenFees(deployedContractsMap, configMap);
     await this.configureClients(deployedContractsMap, configMap);
-    await this.configureTokenFees(deployedContractsMap, configMap);
     await this.transferOwnership(deployedContractsMap, configMap);
     this.logger.debug(`Finished deploying router contracts for all chains.`);
 
     return deployedContractsMap;
   }
 
-  // TODO: Consider moving this somewhere else (see notes)
-  async configureTokenFees(
+  async deployAndConfigureTokenFees(
     deployedContractsMap: HyperlaneContractsMap<Factories>,
     configMap: ChainMap<Config>,
   ): Promise<void> {

--- a/typescript/sdk/src/router/types.ts
+++ b/typescript/sdk/src/router/types.ts
@@ -11,7 +11,7 @@ import { Address, AddressBytes32, isNumeric } from '@hyperlane-xyz/utils';
 import { HyperlaneFactories } from '../contracts/types.js';
 import { UpgradeConfig } from '../deploy/proxy.js';
 import { CheckerViolation } from '../deploy/types.js';
-import { TokenFeeConfigSchema } from '../fee/types.js';
+import { TokenFeeConfigInputSchema } from '../fee/types.js';
 import { DerivedHookConfig, HookConfigSchema } from '../hook/types.js';
 import { DerivedIsmConfig, IsmConfigSchema } from '../ism/types.js';
 import { ZHash } from '../metadata/customZodTypes.js';
@@ -134,7 +134,7 @@ export const RouterConfigSchema = MailboxClientConfigSchema.merge(
   z.object({
     remoteRouters: RemoteRoutersSchema.optional(),
     proxyAdmin: DeployedOwnableSchema.optional(),
-    tokenFee: TokenFeeConfigSchema.optional(),
+    tokenFee: TokenFeeConfigInputSchema.optional(),
   }),
 );
 

--- a/typescript/sdk/src/router/types.ts
+++ b/typescript/sdk/src/router/types.ts
@@ -11,6 +11,7 @@ import { Address, AddressBytes32, isNumeric } from '@hyperlane-xyz/utils';
 import { HyperlaneFactories } from '../contracts/types.js';
 import { UpgradeConfig } from '../deploy/proxy.js';
 import { CheckerViolation } from '../deploy/types.js';
+import { TokenFeeConfigSchema } from '../fee/types.js';
 import { DerivedHookConfig, HookConfigSchema } from '../hook/types.js';
 import { DerivedIsmConfig, IsmConfigSchema } from '../ism/types.js';
 import { ZHash } from '../metadata/customZodTypes.js';
@@ -133,6 +134,7 @@ export const RouterConfigSchema = MailboxClientConfigSchema.merge(
   z.object({
     remoteRouters: RemoteRoutersSchema.optional(),
     proxyAdmin: DeployedOwnableSchema.optional(),
+    tokenFee: TokenFeeConfigSchema.optional(),
   }),
 );
 

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -40,11 +40,7 @@ import { TestCoreDeployer } from '../core/TestCoreDeployer.js';
 import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDeployer.js';
 import { ProxyFactoryFactories } from '../deploy/contracts.js';
 import { VerifyContractTypes } from '../deploy/verify/types.js';
-import {
-  BPS,
-  HALF_AMOUNT,
-  MAX_FEE,
-} from '../fee/EvmTokenFeeReader.hardhat-test.js';
+import { BPS } from '../fee/EvmTokenFeeReader.hardhat-test.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainMap } from '../types.js';
@@ -692,8 +688,6 @@ describe('ERC20WarpRouterReader', async () => {
           type: TokenFeeType.LinearFee,
           owner: mailbox.address,
           token: token.address,
-          maxFee: MAX_FEE,
-          halfAmount: HALF_AMOUNT,
           bps: BPS,
         },
       },

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -26,6 +26,7 @@ import {
   HyperlaneContractsMap,
   RouterConfig,
   TestChainName,
+  TokenFeeType,
   WarpRouteDeployConfigMailboxRequired,
   proxyAdmin,
   proxyImplementation,
@@ -672,5 +673,30 @@ describe('ERC20WarpRouterReader', async () => {
     // Restore stub
     connectStub.restore();
     isLocalRpcStub.restore();
+  });
+
+  it.only('should derive token fee config correctly', async () => {
+    const config: WarpRouteDeployConfigMailboxRequired = {
+      [chain]: {
+        type: TokenType.collateral,
+        token: token.address,
+        hook: await mailbox.defaultHook(),
+        ...baseConfig,
+      },
+    };
+    // Deploy with config
+    const warpRoute = await deployer.deploy(config);
+    // Derive config and check if each value matches
+    const derivedConfig = await evmERC20WarpRouteReader.deriveWarpRouteConfig(
+      warpRoute[chain].collateral.address,
+    );
+
+    expect(derivedConfig.tokenFee).to.deep.equal({
+      [chain]: {
+        type: TokenFeeType.LinearFee,
+        token: token.address,
+        owner: mailbox.address,
+      },
+    });
   });
 });

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -28,6 +28,7 @@ import {
   TestChainName,
   TokenFeeType,
   WarpRouteDeployConfigMailboxRequired,
+  normalizeConfig,
   proxyAdmin,
   proxyImplementation,
   test3,
@@ -675,13 +676,22 @@ describe('ERC20WarpRouterReader', async () => {
     isLocalRpcStub.restore();
   });
 
-  it.only('should derive token fee config correctly', async () => {
+  it('should derive token fee config correctly', async () => {
     const config: WarpRouteDeployConfigMailboxRequired = {
       [chain]: {
+        ...baseConfig,
         type: TokenType.collateral,
         token: token.address,
         hook: await mailbox.defaultHook(),
-        ...baseConfig,
+        tokenFee: {
+          type: TokenFeeType.LinearFee,
+          owner: mailbox.address,
+          token: token.address,
+          maxFee: 1157920892373161954235709850086879078532699846656405640394n,
+          halfAmount:
+            5789604461865809771178549250434395392663499233282028201970n,
+          bps: 1000n,
+        },
       },
     };
     // Deploy with config
@@ -691,12 +701,8 @@ describe('ERC20WarpRouterReader', async () => {
       warpRoute[chain].collateral.address,
     );
 
-    expect(derivedConfig.tokenFee).to.deep.equal({
-      [chain]: {
-        type: TokenFeeType.LinearFee,
-        token: token.address,
-        owner: mailbox.address,
-      },
-    });
+    expect(normalizeConfig(derivedConfig.tokenFee)).to.deep.equal(
+      normalizeConfig(config[chain].tokenFee),
+    );
   });
 });

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -40,7 +40,11 @@ import { TestCoreDeployer } from '../core/TestCoreDeployer.js';
 import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDeployer.js';
 import { ProxyFactoryFactories } from '../deploy/contracts.js';
 import { VerifyContractTypes } from '../deploy/verify/types.js';
-import { BPS } from '../fee/EvmTokenFeeReader.hardhat-test.js';
+import {
+  BPS,
+  HALF_AMOUNT,
+  MAX_FEE,
+} from '../fee/EvmTokenFeeReader.hardhat-test.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainMap } from '../types.js';
@@ -700,7 +704,11 @@ describe('ERC20WarpRouterReader', async () => {
     );
 
     expect(normalizeConfig(derivedConfig.tokenFee)).to.deep.equal(
-      normalizeConfig(config[chain].tokenFee),
+      normalizeConfig({
+        ...config[chain].tokenFee,
+        maxFee: MAX_FEE,
+        halfAmount: HALF_AMOUNT,
+      }),
     );
   });
 });

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -40,6 +40,11 @@ import { TestCoreDeployer } from '../core/TestCoreDeployer.js';
 import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDeployer.js';
 import { ProxyFactoryFactories } from '../deploy/contracts.js';
 import { VerifyContractTypes } from '../deploy/verify/types.js';
+import {
+  BPS,
+  HALF_AMOUNT,
+  MAX_FEE,
+} from '../fee/EvmTokenFeeReader.hardhat-test.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainMap } from '../types.js';
@@ -687,10 +692,9 @@ describe('ERC20WarpRouterReader', async () => {
           type: TokenFeeType.LinearFee,
           owner: mailbox.address,
           token: token.address,
-          maxFee: 1157920892373161954235709850086879078532699846656405640394n,
-          halfAmount:
-            5789604461865809771178549250434395392663499233282028201970n,
-          bps: 1000n,
+          maxFee: MAX_FEE,
+          halfAmount: HALF_AMOUNT,
+          bps: BPS,
         },
       },
     };

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.hardhat-test.ts
@@ -40,11 +40,6 @@ import { TestCoreDeployer } from '../core/TestCoreDeployer.js';
 import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDeployer.js';
 import { ProxyFactoryFactories } from '../deploy/contracts.js';
 import { VerifyContractTypes } from '../deploy/verify/types.js';
-import {
-  BPS,
-  HALF_AMOUNT,
-  MAX_FEE,
-} from '../fee/EvmTokenFeeReader.hardhat-test.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainMap } from '../types.js';
@@ -692,9 +687,10 @@ describe('ERC20WarpRouterReader', async () => {
           type: TokenFeeType.LinearFee,
           owner: mailbox.address,
           token: token.address,
-          maxFee: MAX_FEE,
-          halfAmount: HALF_AMOUNT,
-          bps: BPS,
+          maxFee: 1157920892373161954235709850086879078532699846656405640394n,
+          halfAmount:
+            5789604461865809771178549250434395392663499233282028201970n,
+          bps: 1000n,
         },
       },
     };

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -214,18 +214,11 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
           error,
         );
       }
-      const hasTokenFeeInterface =
-        compareVersions(
-          tokenConfig.contractVersion!,
-          TOKEN_FEE_CONTRACT_VERSION,
-        ) >= 0;
 
-      const tokenFee = hasTokenFeeInterface
-        ? await this.fetchTokenFee(
-            warpRouteAddress,
-            await movableToken.domains(),
-          )
-        : undefined;
+      const tokenFee = await this.fetchTokenFee(
+        warpRouteAddress,
+        await movableToken.domains(),
+      );
 
       return {
         ...routerConfig,
@@ -255,8 +248,13 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
       this.provider,
     );
     const tokenFee = await fungibleTokenRouter.feeRecipient();
+    const hasTokenFeeInterface =
+      compareVersions(
+        await fungibleTokenRouter.PACKAGE_VERSION(),
+        TOKEN_FEE_CONTRACT_VERSION,
+      ) >= 0;
 
-    return eqAddress(tokenFee, constants.AddressZero)
+    return eqAddress(tokenFee, constants.AddressZero) || !hasTokenFeeInterface
       ? undefined
       : this.evmTokenFeeReader.deriveTokenFeeConfig(tokenFee, destinations);
   }

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -1,7 +1,8 @@
 import { compareVersions } from 'compare-versions';
-import { Contract } from 'ethers';
+import { Contract, constants } from 'ethers';
 
 import {
+  FungibleTokenRouter__factory,
   HypERC20Collateral__factory,
   HypERC20__factory,
   HypERC4626Collateral__factory,
@@ -44,6 +45,8 @@ import {
   ExplorerLicenseType,
   VerifyContractTypes,
 } from '../deploy/verify/types.js';
+import { EvmTokenFeeReader } from '../fee/EvmTokenFeeReader.js';
+import { TokenFeeConfig } from '../fee/types.js';
 import { EvmHookReader } from '../hook/EvmHookReader.js';
 import { EvmIsmReader } from '../ism/EvmIsmReader.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
@@ -73,6 +76,7 @@ import {
 import { getExtraLockBoxConfigs } from './xerc20.js';
 
 const REBALANCING_CONTRACT_VERSION = '8.0.0';
+const TOKEN_FEE_CONTRACT_VERSION = '10.0.0-beta.0';
 
 export class EvmERC20WarpRouteReader extends EvmRouterReader {
   protected readonly logger = rootLogger.child({
@@ -87,6 +91,8 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
   >;
   evmHookReader: EvmHookReader;
   evmIsmReader: EvmIsmReader;
+  evmTokenFeeReader: EvmTokenFeeReader;
+
   contractVerifier: ContractVerifier;
 
   constructor(
@@ -98,6 +104,7 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
     super(multiProvider, chain);
     this.evmHookReader = new EvmHookReader(multiProvider, chain, concurrency);
     this.evmIsmReader = new EvmIsmReader(multiProvider, chain, concurrency);
+    this.evmTokenFeeReader = new EvmTokenFeeReader(multiProvider, chain);
 
     this.deriveTokenConfigMap = {
       [TokenType.XERC20]: this.deriveHypXERC20TokenConfig.bind(this),
@@ -207,6 +214,19 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
           error,
         );
       }
+      const hasTokenFeeInterface =
+        compareVersions(
+          tokenConfig.contractVersion!,
+          TOKEN_FEE_CONTRACT_VERSION,
+        ) >= 0;
+
+      const tokenFee = hasTokenFeeInterface
+        ? await this.fetchTokenFee(
+            warpRouteAddress,
+            await movableToken.domains(),
+          )
+        : undefined;
+
       return {
         ...routerConfig,
         ...tokenConfig,
@@ -214,6 +234,7 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
         allowedRebalancingBridges,
         proxyAdmin,
         destinationGas,
+        tokenFee,
       } as DerivedTokenRouterConfig;
     }
 
@@ -224,6 +245,22 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
       destinationGas,
     };
   }
+
+  public async fetchTokenFee(
+    routerAddress: Address,
+    destinations?: number[],
+  ): Promise<TokenFeeConfig | undefined> {
+    const fungibleTokenRouter = FungibleTokenRouter__factory.connect(
+      routerAddress,
+      this.provider,
+    );
+    const tokenFee = await fungibleTokenRouter.feeRecipient();
+
+    return eqAddress(tokenFee, constants.AddressZero)
+      ? undefined
+      : this.evmTokenFeeReader.deriveTokenFeeConfig(tokenFee, destinations);
+  }
+
   async getContractVerificationStatus(chain: ChainName, address: Address) {
     const contractVerificationStatus: Record<
       string,

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -651,20 +651,6 @@ export class HypERC20Deployer extends TokenDeployer<HypERC20Factories> {
           return;
         }
 
-        if (!tokenFeeInput.owner) {
-          this.logger.debug(
-            `Token fee owner not specified, using router owner ${config.owner}`,
-          );
-          tokenFeeInput.owner = config.owner;
-        }
-
-        if (isCollateralTokenConfig(config) && !tokenFeeInput.token) {
-          this.logger.debug(
-            `Token fee token not specified for ${config.type}, using router token ${config.token}`,
-          );
-          tokenFeeInput.token = config.token;
-        }
-
         this.logger.debug(`Deploying token fee on ${chain}...`);
         const processedTokenFee = await EvmTokenFeeModule.processConfig({
           config: tokenFeeInput,

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -651,6 +651,20 @@ export class HypERC20Deployer extends TokenDeployer<HypERC20Factories> {
           return;
         }
 
+        if (!tokenFeeInput.owner) {
+          this.logger.debug(
+            `Token fee owner not specified, using router owner ${config.owner}`,
+          );
+          tokenFeeInput.owner = config.owner;
+        }
+
+        if (isCollateralTokenConfig(config) && !tokenFeeInput.token) {
+          this.logger.debug(
+            `Token fee token not specified for ${config.type}, using router token ${config.token}`,
+          );
+          tokenFeeInput.token = config.token;
+        }
+
         this.logger.debug(`Deploying token fee on ${chain}...`);
         const processedTokenFee = await EvmTokenFeeModule.processConfig({
           config: tokenFeeInput,

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -599,6 +599,7 @@ export class HypERC20Deployer extends TokenDeployer<HypERC20Factories> {
         }
 
         this.logger.debug(`Deploying token fee on ${chain}...`);
+        // tokenFee.token = config.tokenFee?.token ?? tokenFee.token;
         const module = await EvmTokenFeeModule.create({
           multiProvider: this.multiProvider,
           chain,

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -643,8 +643,8 @@ export class HypERC20Deployer extends TokenDeployer<HypERC20Factories> {
     await Promise.all(
       Object.keys(deployedContractsMap).map(async (chain) => {
         const config = configMap[chain];
-        const tokenFee = config?.tokenFee;
-        if (!tokenFee) return;
+        const tokenFeeInput = config?.tokenFee;
+        if (!tokenFeeInput) return;
 
         if (this.multiProvider.getProtocol(chain) !== ProtocolType.Ethereum) {
           this.logger.debug(`Skipping token fee on non-EVM chain ${chain}`);
@@ -652,11 +652,15 @@ export class HypERC20Deployer extends TokenDeployer<HypERC20Factories> {
         }
 
         this.logger.debug(`Deploying token fee on ${chain}...`);
-        // tokenFee.token = config.tokenFee?.token ?? tokenFee.token;
+        const processedTokenFee = await EvmTokenFeeModule.processConfig({
+          config: tokenFeeInput,
+          multiProvider: this.multiProvider,
+          chainName: chain,
+        });
         const module = await EvmTokenFeeModule.create({
           multiProvider: this.multiProvider,
           chain,
-          config: tokenFee,
+          config: processedTokenFee,
         });
 
         const router = this.router(deployedContractsMap[chain]);

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -325,126 +325,126 @@ function preprocessWarpRouteDeployConfig(
   return mutatedConfig;
 }
 
-export const WarpRouteDeployConfigSchema = z.preprocess(
-  preprocessWarpRouteDeployConfig,
-  z
-    .record(HypTokenRouterConfigMailboxOptionalSchema)
-    .refine((configMap) => {
-      const entries = Object.entries(configMap);
-      return (
-        entries.some(
-          ([_, config]) =>
-            isCollateralTokenConfig(config) ||
-            isCollateralRebaseTokenConfig(config) ||
-            isCctpTokenConfig(config) ||
-            isXERC20TokenConfig(config) ||
-            isNativeTokenConfig(config),
-        ) || entries.every(([_, config]) => isTokenMetadata(config))
-      );
-    }, WarpRouteDeployConfigSchemaErrors.NO_SYNTHETIC_ONLY)
-    // Verify synthetic rebase tokens config
-    .transform((warpRouteDeployConfig, ctx) => {
-      const collateralRebaseEntry = Object.entries(warpRouteDeployConfig).find(
-        ([_, config]) => isCollateralRebaseTokenConfig(config),
-      );
+export const WarpRouteDeployConfigSchema = z
+  .preprocess(
+    preprocessWarpRouteDeployConfig,
+    z.record(HypTokenRouterConfigMailboxOptionalSchema),
+  )
+  .refine((configMap) => {
+    const entries = Object.entries(configMap);
+    return (
+      entries.some(
+        ([_, config]) =>
+          isCollateralTokenConfig(config) ||
+          isCollateralRebaseTokenConfig(config) ||
+          isCctpTokenConfig(config) ||
+          isXERC20TokenConfig(config) ||
+          isNativeTokenConfig(config),
+      ) || entries.every(([_, config]) => isTokenMetadata(config))
+    );
+  }, WarpRouteDeployConfigSchemaErrors.NO_SYNTHETIC_ONLY)
+  // Verify synthetic rebase tokens config
+  .transform((warpRouteDeployConfig, ctx) => {
+    const collateralRebaseEntry = Object.entries(warpRouteDeployConfig).find(
+      ([_, config]) => isCollateralRebaseTokenConfig(config),
+    );
 
-      const syntheticRebaseEntry = Object.entries(warpRouteDeployConfig).find(
-        ([_, config]) => isSyntheticRebaseTokenConfig(config),
-      );
+    const syntheticRebaseEntry = Object.entries(warpRouteDeployConfig).find(
+      ([_, config]) => isSyntheticRebaseTokenConfig(config),
+    );
 
-      // Require both collateral rebase and synthetic rebase to be present in the config
-      if (!collateralRebaseEntry && !syntheticRebaseEntry) {
-        //  Pass through for other token types
-        return warpRouteDeployConfig;
-      }
+    // Require both collateral rebase and synthetic rebase to be present in the config
+    if (!collateralRebaseEntry && !syntheticRebaseEntry) {
+      //  Pass through for other token types
+      return warpRouteDeployConfig;
+    }
 
-      if (
-        collateralRebaseEntry &&
-        isCollateralRebasePairedCorrectly(warpRouteDeployConfig)
-      ) {
-        const collateralChainName = collateralRebaseEntry[0];
-        return objMap(warpRouteDeployConfig, (_, config) => {
-          if (config.type === TokenType.syntheticRebase)
-            config.collateralChainName = collateralChainName;
-          return config;
-        }) as Record<string, HypTokenRouterConfig>;
-      }
+    if (
+      collateralRebaseEntry &&
+      isCollateralRebasePairedCorrectly(warpRouteDeployConfig)
+    ) {
+      const collateralChainName = collateralRebaseEntry[0];
+      return objMap(warpRouteDeployConfig, (_, config) => {
+        if (config.type === TokenType.syntheticRebase)
+          config.collateralChainName = collateralChainName;
+        return config;
+      }) as Record<string, HypTokenRouterConfig>;
+    }
 
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: WarpRouteDeployConfigSchemaErrors.ONLY_SYNTHETIC_REBASE,
+    });
+
+    return z.NEVER; // Causes schema validation to throw with above issue
+  })
+  // Verify that CCIP hooks are paired with CCIP ISMs
+  .transform((warpRouteDeployConfig, ctx) => {
+    const { ccipHookMap, ccipIsmMap } = getCCIPConfigMaps(
+      warpRouteDeployConfig,
+    );
+
+    // Check hooks have corresponding ISMs
+    const hookConfigHasMissingIsms = Object.entries(ccipHookMap).some(
+      ([originChain, destinationChains]) =>
+        Array.from(destinationChains).some((chain) => {
+          if (!ccipIsmMap[originChain]?.has(chain)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: [chain, 'interchainSecurityModule', '...'],
+              message: `Required CCIP ISM not found in config for CCIP Hook with origin chain ${originChain} and destination chain ${chain}`,
+            });
+            return true;
+          }
+          return false;
+        }),
+    );
+
+    // Check ISMs have corresponding hooks
+    const ismConfigHasMissingHooks = Object.entries(ccipIsmMap).some(
+      ([originChain, destinationChains]) =>
+        Array.from(destinationChains).some((chain) => {
+          if (!ccipHookMap[originChain]?.has(chain)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: [originChain, 'hook', '...'],
+              message: `Required CCIP Hook not found in config for CCIP ISM with origin chain ${originChain} and destination chain ${chain}`,
+            });
+            return true;
+          }
+          return false;
+        }),
+    );
+
+    return hookConfigHasMissingIsms || ismConfigHasMissingHooks
+      ? z.NEVER
+      : warpRouteDeployConfig;
+  })
+  // Verify that xERC20 are only with xERC20s
+  .transform((warpRouteDeployConfig, ctx) => {
+    const isXERC20Route = Object.values(warpRouteDeployConfig).some(
+      isXERC20TokenConfig,
+    );
+
+    if (!isXERC20Route) {
+      return warpRouteDeployConfig;
+    }
+
+    const isAllXERC20s = Object.values(warpRouteDeployConfig).every(
+      isXERC20TokenConfig,
+    );
+
+    if (!isAllXERC20s) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: WarpRouteDeployConfigSchemaErrors.ONLY_SYNTHETIC_REBASE,
+        message: `All chains must be xERC20 warp route tokens`,
       });
 
-      return z.NEVER; // Causes schema validation to throw with above issue
-    })
-    // Verify that CCIP hooks are paired with CCIP ISMs
-    .transform((warpRouteDeployConfig, ctx) => {
-      const { ccipHookMap, ccipIsmMap } = getCCIPConfigMaps(
-        warpRouteDeployConfig,
-      );
+      return z.NEVER;
+    }
 
-      // Check hooks have corresponding ISMs
-      const hookConfigHasMissingIsms = Object.entries(ccipHookMap).some(
-        ([originChain, destinationChains]) =>
-          Array.from(destinationChains).some((chain) => {
-            if (!ccipIsmMap[originChain]?.has(chain)) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: [chain, 'interchainSecurityModule', '...'],
-                message: `Required CCIP ISM not found in config for CCIP Hook with origin chain ${originChain} and destination chain ${chain}`,
-              });
-              return true;
-            }
-            return false;
-          }),
-      );
-
-      // Check ISMs have corresponding hooks
-      const ismConfigHasMissingHooks = Object.entries(ccipIsmMap).some(
-        ([originChain, destinationChains]) =>
-          Array.from(destinationChains).some((chain) => {
-            if (!ccipHookMap[originChain]?.has(chain)) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: [originChain, 'hook', '...'],
-                message: `Required CCIP Hook not found in config for CCIP ISM with origin chain ${originChain} and destination chain ${chain}`,
-              });
-              return true;
-            }
-            return false;
-          }),
-      );
-
-      return hookConfigHasMissingIsms || ismConfigHasMissingHooks
-        ? z.NEVER
-        : warpRouteDeployConfig;
-    })
-    // Verify that xERC20 are only with xERC20s
-    .transform((warpRouteDeployConfig, ctx) => {
-      const isXERC20Route = Object.values(warpRouteDeployConfig).some(
-        isXERC20TokenConfig,
-      );
-
-      if (!isXERC20Route) {
-        return warpRouteDeployConfig;
-      }
-
-      const isAllXERC20s = Object.values(warpRouteDeployConfig).every(
-        isXERC20TokenConfig,
-      );
-
-      if (!isAllXERC20s) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `All chains must be xERC20 warp route tokens`,
-        });
-
-        return z.NEVER;
-      }
-
-      return warpRouteDeployConfig;
-    }),
-);
+    return warpRouteDeployConfig;
+  });
 
 export type WarpRouteDeployConfig = z.infer<typeof WarpRouteDeployConfigSchema>;
 


### PR DESCRIPTION
### Description
This PR adds the Fee deploy logic into token deployer. There are also changes the the Modules to support this deployment with some additional changes to the schema as mentioned in the **Drive-by changes**.

### Drive-by changes
This PR also refactors the schema such that a linear fee can be configured using `bps`.

### Related issues
- Fixes ENG-2070

### Backward compatibility
Yes, these additions should not impact existing warp deployments

### Testing
Unit Tests

