### PR TITLE
fix: Reduce index chunk to avoid errors

### DIFF
--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -3759,7 +3759,7 @@
       "testRecipient": "0xbB22547D1dc681fe925f568f637Ff67aC06c20fc",
       "validatorAnnounce": "0xb4fc9B5fD57499Ef6FfF3995728a55F7A618ef86",
       "index": {
-        "chunk": 30,
+        "chunk": 29,
         "from": 28949565
       },
       "interchainAccountIsm": "0xc2Da384799488B4e1E773d70a83346529145085B",


### PR DESCRIPTION
### Description

Reduce index chuck to avoid errors when requesting logs via eth_getLogs on Flare chain.

Error: "(code: -32000, message: requested too many blocks from 46033252 to 46033282, maximum is set to 30, data: None)"

### Backward compatibility

Yes

### Testing

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mainnet configuration for the Cyber chain by adjusting an index chunk parameter.
  * No changes to public APIs or user-facing features.
  * Rollout is transparent; existing workflows continue to function as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->