### PR TITLE
fix: Add domain into log spans in Lander

### DIFF
--- a/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
+++ b/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
@@ -28,7 +28,7 @@ pub struct BuildingStage {
 }
 
 impl BuildingStage {
-    #[instrument(skip(self), name = "BuildingStage::run")]
+    #[instrument(skip(self), name = "BuildingStage::run", fields(domain=%self.domain))]
     pub async fn run(&self) {
         loop {
             // event-driven by the Building queue

--- a/rust/main/lander/src/dispatcher/stages/finality_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage.rs
@@ -82,6 +82,7 @@ impl FinalityStage {
         }
     }
 
+    #[instrument(skip_all, fields(domain))]
     async fn receive_txs(
         mut tx_receiver: mpsc::Receiver<Transaction>,
         pool: FinalityStagePool,
@@ -102,6 +103,7 @@ impl FinalityStage {
         }
     }
 
+    #[instrument(skip_all, fields(domain))]
     async fn process_txs(
         pool: FinalityStagePool,
         building_stage_queue: BuildingStageQueue,

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -81,6 +81,7 @@ impl InclusionStage {
         }
     }
 
+    #[instrument(skip_all, fields(domain))]
     pub async fn receive_txs(
         mut building_stage_receiver: mpsc::Receiver<Transaction>,
         pool: InclusionStagePool,
@@ -109,6 +110,7 @@ impl InclusionStage {
         }
     }
 
+    #[instrument(skip_all, fields(domain))]
     async fn process_txs(
         pool: InclusionStagePool,
         finality_stage_sender: mpsc::Sender<Transaction>,


### PR DESCRIPTION
### Description

We are not logging domain as part of logs in Lander. This fix adds it back.

### Backward compatibility

Yes

### Testing

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added per-domain tracing spans to Building, Inclusion, and Finality stages for clearer, structured logs.
  - Configured instrumentation to skip arguments while recording domain context, reducing noise and improving correlation during troubleshooting.
  - Improves observability in production and aids faster issue triage.
  - No functional changes; runtime behavior and interfaces remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->