### PR TITLE
fix: do not erase config when deriving token metadata

### DIFF
--- a/.changeset/kind-bags-knock.md
+++ b/.changeset/kind-bags-knock.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed a bug when deriving token metadata from chain was erasing existing fields from deployment config

--- a/typescript/sdk/src/token/TokenMetadataMap.ts
+++ b/typescript/sdk/src/token/TokenMetadataMap.ts
@@ -15,6 +15,13 @@ export class TokenMetadataMap {
     this.tokenMetadataMap.set(chain, metadata);
   }
 
+  update(chain: string, metadata: TokenMetadata): void {
+    this.tokenMetadataMap.set(
+      chain,
+      Object.assign(this.tokenMetadataMap.get(chain) ?? {}, metadata),
+    );
+  }
+
   getDecimals(chain: string): number | undefined {
     const config = this.tokenMetadataMap.get(chain);
     if (config) return config.decimals!;

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -228,7 +228,7 @@ abstract class TokenDeployer<
       if (isNativeTokenConfig(config)) {
         const nativeToken = multiProvider.getChainMetadata(chain).nativeToken;
         if (nativeToken) {
-          metadataMap.set(
+          metadataMap.update(
             chain,
             TokenMetadataSchema.parse({
               ...nativeToken,
@@ -254,7 +254,7 @@ abstract class TokenDeployer<
             erc721.name(),
             erc721.symbol(),
           ]);
-          metadataMap.set(
+          metadataMap.update(
             chain,
             TokenMetadataSchema.parse({
               name,
@@ -290,7 +290,7 @@ abstract class TokenDeployer<
           erc20.decimals(),
         ]);
 
-        metadataMap.set(
+        metadataMap.update(
           chain,
           TokenMetadataSchema.parse({
             name,


### PR DESCRIPTION
## Description

Fixes a bug where deriving token metadata would completely overwrite existing configuration instead of merging it. This change introduces a new `update()` method in `TokenMetadataMap` that preserves existing metadata while adding new derived fields.

The issue occurred when deriving metadata for native tokens, ERC-721 tokens, and ERC-20 tokens - any existing configuration would be lost and replaced entirely with the derived metadata. As the scale field was not being read from the token config, it would be overwritten making the scaling check fail.

## Related Issues

Fixes ENG-2129

## Backward Compatibility

Yes - this change is fully backward compatible. The new `update()` method only affects internal behavior by preserving existing configuration, and the public API remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where deriving token metadata from a chain could overwrite and erase existing deployment settings. Metadata is now merged, preserving preconfigured fields (e.g., name, symbol, decimals, scale) while updating with chain-provided details.
* **Chores**
  * Added a changeset entry documenting this patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->