### PR TITLE
feat: stop RPC retries for permanent errors

### DIFF
--- a/.changeset/twelve-humans-type.md
+++ b/.changeset/twelve-humans-type.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Optimized SmartProvider to stop retrying on CALL_EXCEPTION errors as they are permanent failures


### PR DESCRIPTION
## Description

Optimizes SmartProvider error handling by stopping provider iteration and retries for CALL_EXCEPTION errors, which are permanent failures that indicate contract execution issues rather than transient network problems.

Introduces a new retry mechanism with `stopRetry` flag support that prevents wasted retries on permanent failures. When a CALL_EXCEPTION is encountered, the provider immediately stops trying additional providers and marks the error as non-retryable.

## Related Issues

TBD

## Backward Compatibility

Yes - this change only optimizes behavior for CALL_EXCEPTION errors while preserving existing retry and fallback logic for all other error types.