### PR TITLE
fix(sdk, cli): fix audit branch failing tests

### DIFF
--- a/solidity/contracts/mock/MockValueTransferBridge.sol
+++ b/solidity/contracts/mock/MockValueTransferBridge.sol
@@ -4,6 +4,12 @@ pragma solidity ^0.8.13;
 import {ITokenBridge, Quote} from "../interfaces/ITokenBridge.sol";
 
 contract MockValueTransferBridge is ITokenBridge {
+    address public collateral;
+
+    constructor(address _collateral) {
+        collateral = _collateral;
+    }
+
     event SentTransferRemote(
         uint32 indexed origin,
         uint32 indexed destination,
@@ -17,7 +23,7 @@ contract MockValueTransferBridge is ITokenBridge {
         uint256 //_amountOut
     ) public view virtual override returns (Quote[] memory) {
         Quote[] memory quotes = new Quote[](1);
-        quotes[0] = Quote(address(0), 1);
+        quotes[0] = Quote(collateral, 1);
 
         return quotes;
     }

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -6,6 +6,8 @@ import {
   ERC20Test,
   ERC20Test__factory,
   ERC4626Test__factory,
+  FiatTokenTest,
+  FiatTokenTest__factory,
   XERC20LockboxTest,
   XERC20LockboxTest__factory,
   XERC20VSTest,
@@ -475,6 +477,28 @@ export async function deployToken(
   multiProvider.setSigner(chain, new ethers.Wallet(privateKey));
 
   const token = await new ERC20Test__factory(
+    multiProvider.getSigner(chain),
+  ).deploy(name, symbol.toLocaleUpperCase(), '100000000000000000000', decimals);
+  await token.deployed();
+
+  return token;
+}
+
+export async function deployFiatToken(
+  privateKey: string,
+  chain: string,
+  decimals = 18,
+  symbol = 'FIAT TOKEN',
+  name = 'fiat token',
+): Promise<FiatTokenTest> {
+  const { multiProvider } = await getContext({
+    registryUris: [REGISTRY_PATH],
+    key: privateKey,
+  });
+
+  multiProvider.setSigner(chain, new ethers.Wallet(privateKey));
+
+  const token = await new FiatTokenTest__factory(
     multiProvider.getSigner(chain),
   ).deploy(name, symbol.toLocaleUpperCase(), '100000000000000000000', decimals);
   await token.deployed();

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -279,6 +279,7 @@ type GetWarpTokenConfigByTokenTypeOptions = {
   token: Address;
   fiatToken: Address;
   xerc20: Address;
+  xerc20Lockbox: Address;
   vault: Address;
   otherChain: ChainName;
 };
@@ -292,6 +293,7 @@ function getWarpTokenConfigForType({
   vault,
   fiatToken,
   xerc20,
+  xerc20Lockbox,
 }: GetWarpTokenConfigByTokenTypeOptions): HypTokenRouterConfig {
   let tokenConfig: HypTokenRouterConfig;
   switch (tokenType) {
@@ -324,7 +326,7 @@ function getWarpTokenConfigForType({
         type: TokenType.XERC20Lockbox,
         mailbox,
         owner,
-        token: xerc20,
+        token: xerc20Lockbox,
       };
       break;
     case TokenType.collateralVault:
@@ -390,6 +392,7 @@ type GetWarpTokenConfigOptions = {
   chainName: ChainName;
   fiatToken: Address;
   xerc20: Address;
+  xerc20Lockbox: Address;
 };
 
 export function generateWarpConfigs(
@@ -397,7 +400,6 @@ export function generateWarpConfigs(
   chain2Config: GetWarpTokenConfigOptions,
 ): ReadonlyArray<WarpRouteDeployConfig> {
   const ignoreTokenTypes = new Set([
-    TokenType.XERC20Lockbox,
     TokenType.collateralUri,
     TokenType.syntheticUri,
     // TODO Fix: sender not mailbox or relaying simply fails

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -277,6 +277,8 @@ type GetWarpTokenConfigByTokenTypeOptions = {
   mailbox: Address;
   owner: Address;
   token: Address;
+  fiatToken: Address;
+  xerc20: Address;
   vault: Address;
   otherChain: ChainName;
 };
@@ -288,6 +290,8 @@ function getWarpTokenConfigForType({
   token,
   tokenType,
   vault,
+  fiatToken,
+  xerc20,
 }: GetWarpTokenConfigByTokenTypeOptions): HypTokenRouterConfig {
   let tokenConfig: HypTokenRouterConfig;
   switch (tokenType) {
@@ -297,6 +301,30 @@ function getWarpTokenConfigForType({
         mailbox,
         owner,
         token,
+      };
+      break;
+    case TokenType.collateralFiat:
+      tokenConfig = {
+        type: TokenType.collateralFiat,
+        mailbox,
+        owner,
+        token: fiatToken,
+      };
+      break;
+    case TokenType.XERC20:
+      tokenConfig = {
+        type: TokenType.XERC20,
+        mailbox,
+        owner,
+        token: xerc20,
+      };
+      break;
+    case TokenType.XERC20Lockbox:
+      tokenConfig = {
+        type: TokenType.XERC20Lockbox,
+        mailbox,
+        owner,
+        token: xerc20,
       };
       break;
     case TokenType.collateralVault:
@@ -360,6 +388,8 @@ type GetWarpTokenConfigOptions = {
   token: Address;
   vault: Address;
   chainName: ChainName;
+  fiatToken: Address;
+  xerc20: Address;
 };
 
 export function generateWarpConfigs(
@@ -367,9 +397,7 @@ export function generateWarpConfigs(
   chain2Config: GetWarpTokenConfigOptions,
 ): ReadonlyArray<WarpRouteDeployConfig> {
   const ignoreTokenTypes = new Set([
-    TokenType.XERC20,
     TokenType.XERC20Lockbox,
-    TokenType.collateralFiat,
     TokenType.collateralUri,
     TokenType.syntheticUri,
     // TODO Fix: sender not mailbox or relaying simply fails

--- a/typescript/cli/src/tests/warp/warp-bridge-utils.ts
+++ b/typescript/cli/src/tests/warp/warp-bridge-utils.ts
@@ -4,8 +4,10 @@ import { parseUnits } from 'ethers/lib/utils.js';
 
 import {
   ERC20Test,
+  ERC20Test__factory,
   ERC4626Test,
   FiatTokenTest,
+  XERC20LockboxTest,
   XERC20VSTest,
 } from '@hyperlane-xyz/core';
 import { ChainAddresses } from '@hyperlane-xyz/registry';
@@ -13,6 +15,7 @@ import {
   ChainMap,
   ChainMetadata,
   Token,
+  TokenType,
   WarpCoreConfig,
   WarpRouteDeployConfig,
 } from '@hyperlane-xyz/sdk';
@@ -32,6 +35,7 @@ import {
   deployFiatToken,
   deployOrUseExistingCore,
   deployToken,
+  deployXERC20LockboxToken,
   deployXERC20VSToken,
   getTokenAddressFromWarpConfig,
   sendWarpRouteMessageRoundTrip,
@@ -53,10 +57,12 @@ export type WarpBridgeTestConfig = {
   tokenChain2: ERC20Test;
   fiatToken2: FiatTokenTest;
   xERC202: XERC20VSTest;
+  xERC20Lockbox2: XERC20LockboxTest;
   vaultChain2: ERC4626Test;
   tokenChain3: ERC20Test;
   fiatToken3: FiatTokenTest;
   xERC203: XERC20VSTest;
+  xERC20Lockbox3: XERC20LockboxTest;
   vaultChain3: ERC4626Test;
 };
 
@@ -121,10 +127,12 @@ export async function runWarpBridgeTests(
       [CHAIN_NAME_2]: {
         wallet: config.walletChain2,
         collateral: config.tokenChain2,
+        xerc20Lockbox: config.xERC20Lockbox2,
       },
       [CHAIN_NAME_3]: {
         wallet: config.walletChain3,
         collateral: config.tokenChain3,
+        xerc20Lockbox: config.xERC20Lockbox3,
       },
     });
 
@@ -160,6 +168,11 @@ export async function setupChains(): Promise<WarpBridgeTestConfig> {
   const tokenChain2 = await deployToken(ANVIL_KEY, CHAIN_NAME_2);
   const fiatToken2 = await deployFiatToken(ANVIL_KEY, CHAIN_NAME_2);
   const xERC202 = await deployXERC20VSToken(ANVIL_KEY, CHAIN_NAME_2);
+  const xERC20Lockbox2 = await deployXERC20LockboxToken(
+    ANVIL_KEY,
+    CHAIN_NAME_2,
+    tokenChain2,
+  );
   const vaultChain2 = await deploy4626Vault(
     ANVIL_KEY,
     CHAIN_NAME_2,
@@ -174,6 +187,11 @@ export async function setupChains(): Promise<WarpBridgeTestConfig> {
   const tokenChain3 = await deployToken(ANVIL_KEY, CHAIN_NAME_3);
   const fiatToken3 = await deployFiatToken(ANVIL_KEY, CHAIN_NAME_3);
   const xERC203 = await deployXERC20VSToken(ANVIL_KEY, CHAIN_NAME_3);
+  const xERC20Lockbox3 = await deployXERC20LockboxToken(
+    ANVIL_KEY,
+    CHAIN_NAME_3,
+    tokenChain3,
+  );
   const vaultChain3 = await deploy4626Vault(
     ANVIL_KEY,
     CHAIN_NAME_3,
@@ -194,12 +212,14 @@ export async function setupChains(): Promise<WarpBridgeTestConfig> {
     tokenChain2,
     fiatToken2,
     xERC202,
+    xERC20Lockbox2,
     tokenChain2Symbol,
     vaultChain2,
     tokenVaultChain2Symbol,
     tokenChain3,
     fiatToken3,
     xERC203,
+    xERC20Lockbox3,
     tokenChain3Symbol,
     vaultChain3,
     tokenVaultChain3Symbol,
@@ -220,6 +240,7 @@ export function generateTestCases(
       vault: config.vaultChain2.address,
       fiatToken: config.fiatToken2.address,
       xerc20: config.xERC202.address,
+      xerc20Lockbox: config.xERC20Lockbox2.address,
     },
     {
       chainName: CHAIN_NAME_3,
@@ -229,6 +250,7 @@ export function generateTestCases(
       vault: config.vaultChain3.address,
       fiatToken: config.fiatToken3.address,
       xerc20: config.xERC203.address,
+      xerc20Lockbox: config.xERC20Lockbox3.address,
     },
   );
 
@@ -269,6 +291,7 @@ export async function collateralizeWarpTokens(
   walletAndCollateralByChain: ChainMap<{
     wallet: Wallet;
     collateral: ERC20Test;
+    xerc20Lockbox: XERC20LockboxTest;
   }>,
 ) {
   const config: ChainMap<Token> = (
@@ -300,6 +323,24 @@ export async function collateralizeWarpTokens(
             chainName
           ].collateral.transfer(
             config[chainName].addressOrDenom,
+            parseUnits('1', decimals),
+          );
+
+          await tx.wait();
+        }
+
+        if (warpDeployConfig[chainName].type === TokenType.XERC20Lockbox) {
+          const lockbox = walletAndCollateralByChain[chainName].xerc20Lockbox;
+
+          const lockboxCollateral = await lockbox.ERC20();
+          const collateralInstance = ERC20Test__factory.connect(
+            lockboxCollateral,
+            walletAndCollateralByChain[chainName].wallet,
+          );
+
+          const decimals = await collateralInstance.decimals();
+          const tx = await collateralInstance.transfer(
+            lockbox.address,
             parseUnits('1', decimals),
           );
 

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -18,6 +18,7 @@ import {
   TokenType,
   WarpCoreConfig,
   WarpRouteDeployConfig,
+  randomAddress,
 } from '@hyperlane-xyz/sdk';
 import {
   Address,
@@ -88,6 +89,8 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
 
   let tokenChain2: ERC20;
   let tokenChain3: ERC20;
+
+  const bridgeAddress = randomAddress();
 
   let warpRouteDeployConfig: WarpRouteDeployConfig;
 
@@ -196,7 +199,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
               weight: '100',
               tolerance: '0',
             },
-            bridge: ethers.constants.AddressZero,
+            bridge: bridgeAddress,
             bridgeLockTime: 1,
           },
           [CHAIN_NAME_3]: {
@@ -204,7 +207,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
               weight: '100',
               tolerance: '0',
             },
-            bridge: ethers.constants.AddressZero,
+            bridge: bridgeAddress,
             bridgeLockTime: 1,
           },
         },
@@ -350,6 +353,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         // Wait for the process to output the expected log.
         for await (let chunk of rebalancer.stdout) {
           chunk = typeof chunk === 'string' ? chunk : chunk.toString();
+          console.log(chunk);
           const lines = chunk.split('\n').filter(Boolean); // handle empty lines
 
           for (const line of lines) {
@@ -751,7 +755,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
               weight: '75',
               tolerance: '0',
             },
-            bridge: ethers.constants.AddressZero,
+            bridge: bridgeAddress,
             bridgeLockTime: 1,
           },
           [CHAIN_NAME_3]: {
@@ -759,7 +763,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
               weight: '25',
               tolerance: '0',
             },
-            bridge: ethers.constants.AddressZero,
+            bridge: bridgeAddress,
             bridgeLockTime: 1,
           },
         },
@@ -777,10 +781,12 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     );
 
     // Allow bridge
-    await chain3CollateralContract.addBridge(
+    const tx3 = await chain3CollateralContract.addBridge(
       chain2Metadata.domainId,
-      ethers.constants.AddressZero,
+      bridgeAddress,
     );
+
+    await tx3.wait();
 
     await startRebalancerAndExpectLog('Failed to get quotes for route.');
   });

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -351,7 +351,6 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         // Wait for the process to output the expected log.
         for await (let chunk of rebalancer.stdout) {
           chunk = typeof chunk === 'string' ? chunk : chunk.toString();
-          console.log(chunk);
           const lines = chunk.split('\n').filter(Boolean); // handle empty lines
 
           for (const line of lines) {

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -90,8 +90,6 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
   let tokenChain2: ERC20;
   let tokenChain3: ERC20;
 
-  const bridgeAddress = randomAddress();
-
   let warpRouteDeployConfig: WarpRouteDeployConfig;
 
   before(async () => {
@@ -199,7 +197,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
               weight: '100',
               tolerance: '0',
             },
-            bridge: bridgeAddress,
+            bridge: ethers.constants.AddressZero,
             bridgeLockTime: 1,
           },
           [CHAIN_NAME_3]: {
@@ -207,7 +205,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
               weight: '100',
               tolerance: '0',
             },
-            bridge: bridgeAddress,
+            bridge: ethers.constants.AddressZero,
             bridgeLockTime: 1,
           },
         },
@@ -745,6 +743,8 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
   });
 
   it('should throw if rebalance quotes cannot be obtained', async () => {
+    const noBridge = randomAddress();
+
     writeYamlOrJson(REBALANCER_CONFIG_PATH, {
       warpRouteId,
       strategy: {
@@ -755,7 +755,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
               weight: '75',
               tolerance: '0',
             },
-            bridge: bridgeAddress,
+            bridge: ethers.constants.AddressZero,
             bridgeLockTime: 1,
           },
           [CHAIN_NAME_3]: {
@@ -763,7 +763,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
               weight: '25',
               tolerance: '0',
             },
-            bridge: bridgeAddress,
+            bridge: noBridge,
             bridgeLockTime: 1,
           },
         },
@@ -783,7 +783,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     // Allow bridge
     const tx3 = await chain3CollateralContract.addBridge(
       chain2Metadata.domainId,
-      bridgeAddress,
+      noBridge,
     );
 
     await tx3.wait();
@@ -805,7 +805,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     // Deploy the bridge
     const bridgeContract = await new MockValueTransferBridge__factory(
       chain3Signer,
-    ).deploy();
+    ).deploy(tokenChain3.address);
 
     // Allow bridge
     await chain3CollateralContract.addBridge(
@@ -859,7 +859,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     // Deploy the bridge
     const bridgeContract = await new MockValueTransferBridge__factory(
       chain3Signer,
-    ).deploy();
+    ).deploy(tokenChain3.address);
 
     // Allow bridge
     await chain3CollateralContract.addBridge(
@@ -909,7 +909,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     // Deploy the bridge
     const bridgeContract = await new MockValueTransferBridge__factory(
       chain3Signer,
-    ).deploy();
+    ).deploy(tokenChain3.address);
 
     // Allow bridge
     await chain3CollateralContract.addBridge(
@@ -997,7 +997,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     // It will also allow us to mock some token movement
     const bridgeContract = await new MockValueTransferBridge__factory(
       originSigner,
-    ).deploy();
+    ).deploy(tokenChain3.address);
 
     // Allow bridge
     // This allow the bridge to be used to send the rebalance transaction
@@ -1122,7 +1122,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
 
     const bridgeContract = await new MockValueTransferBridge__factory(
       originSigner,
-    ).deploy();
+    ).deploy(tokenChain3.address);
 
     // --- Allow bridge ---
 
@@ -1451,7 +1451,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
       // It will also allow us to mock some token movement
       const bridgeContract = await new MockValueTransferBridge__factory(
         originSigner,
-      ).deploy();
+      ).deploy(tokenChain3.address);
 
       // Allow bridge
       // This allow the bridge to be used to send the rebalance transaction

--- a/typescript/sdk/src/token/Token.test.ts
+++ b/typescript/sdk/src/token/Token.test.ts
@@ -270,6 +270,11 @@ describe('Token', () => {
         balanceOf: async () => '100',
       };
 
+      // @ts-ignore
+      adapter.getWrappedTokenAdapter = () => ({
+        getBalance: async () => 100n,
+      });
+
       const balance = await adapter.getBalance(balanceCheckAddress);
       expect(typeof balance).to.eql('bigint');
       sandbox.restore();

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -315,8 +315,8 @@ export class EvmHypCollateralAdapter
   }
 
   override async getBalance(address: Address): Promise<bigint> {
-    const wrappedToken = await this.getWrappedTokenAdapter();
-    return wrappedToken.getBalance(address);
+    const wrappedTokenAdapter = await this.getWrappedTokenAdapter();
+    return wrappedTokenAdapter.getBalance(address);
   }
 
   override getBridgedSupply(): Promise<bigint | undefined> {

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -35,6 +35,7 @@ import {
   addressToByteHexString,
   addressToBytes32,
   bytes32ToAddress,
+  normalizeAddress,
   strip0x,
 } from '@hyperlane-xyz/utils';
 
@@ -385,7 +386,9 @@ export class EvmHypCollateralAdapter
   async isBridgeAllowed(domain: Domain, bridge: Address): Promise<boolean> {
     const allowedBridges = await this.collateralContract.allowedBridges(domain);
 
-    return allowedBridges.includes(bridge);
+    return allowedBridges
+      .map((bridgeAddress) => normalizeAddress(bridgeAddress))
+      .includes(normalizeAddress(bridge));
   }
 
   async getRebalanceQuotes(

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -313,6 +313,11 @@ export class EvmHypCollateralAdapter
     });
   }
 
+  override async getBalance(address: Address): Promise<bigint> {
+    const wrappedToken = await this.getWrappedTokenAdapter();
+    return wrappedToken.getBalance(address);
+  }
+
   override getBridgedSupply(): Promise<bigint | undefined> {
     return this.getBalance(this.addresses.token);
   }
@@ -756,6 +761,13 @@ export class EvmHypNativeAdapter
   extends EvmHypCollateralAdapter
   implements IHypTokenAdapter<PopulatedTransaction>
 {
+  override async getBalance(address: Address): Promise<bigint> {
+    const provider = this.getProvider();
+    const balance = await provider.getBalance(address);
+
+    return BigInt(balance.toString());
+  }
+
   override async isApproveRequired(): Promise<boolean> {
     return false;
   }

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -375,8 +375,32 @@ export const WarpRouteDeployConfigSchema = z
     return hookConfigHasMissingIsms || ismConfigHasMissingHooks
       ? z.NEVER
       : warpRouteDeployConfig;
-  });
+  })
+  // Verify that xERC20 are only with xERC20s
+  .transform((warpRouteDeployConfig, ctx) => {
+    const isXERC20Route = Object.values(warpRouteDeployConfig).some(
+      isXERC20TokenConfig,
+    );
 
+    if (!isXERC20Route) {
+      return warpRouteDeployConfig;
+    }
+
+    const isAllXERC20s = Object.values(warpRouteDeployConfig).every(
+      isXERC20TokenConfig,
+    );
+
+    if (!isAllXERC20s) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `All chains must be xERC20 warp route tokens`,
+      });
+
+      return z.NEVER;
+    }
+
+    return warpRouteDeployConfig;
+  });
 export type WarpRouteDeployConfig = z.infer<typeof WarpRouteDeployConfigSchema>;
 
 const _RequiredMailboxSchema = z.record(


### PR DESCRIPTION
### Description

This PR fixes the bugs related to the failing tests in the current audit branch, specifically:

- balance being reported incorrectly by the collateral token adapter due to contract breaking changes
- balance being reported incorrectly by the native token adapter due to contract breaking changes
- approving a bridge to spend tokens failing when the bridge already had max approval
- usage of safeApproval preventing tests from using the 0 address as a bridge to cause expected failures

### Drive-by changes

- updates `MockValueTransferBridge` to track the collateral token address
- overrides the evm collateral and native token adapters `getBalance` methods to return the expected account balance
- add support for testing deployment and bridging of fiat collateral and xerc20 tokens

### Related issues

-

### Backward compatibility

- YES

### Testing

- Manual
- e2e
- unit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Warp config and testing support for FiatToken and XERC20 (including Lockbox); warp generation now includes these token types.
  - Validation enforces that xERC20 routes are homogeneous across chains.
  - Adapters now use wrapped-token balances for collateral and fetch native balances via provider; address comparisons normalized.

- Bug Fixes
  - Deployment flow skips approvals when allowances already exist, avoiding reset-to-zero issues.

- Tests
  - Expanded warp bridge e2e tests and helpers; bridge/mock deployments updated to accept token-backed bridges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->