### PR TITLE
fix(sdk): cosmos transfer recipient

### DIFF
--- a/.changeset/tall-starfishes-build.md
+++ b/.changeset/tall-starfishes-build.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fix `CosmosModuleTokenAdapter` recipient conversion for populateTransferRemoteTx

--- a/typescript/sdk/src/token/adapters/CosmosModuleTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/CosmosModuleTokenAdapter.ts
@@ -255,13 +255,22 @@ export class CosmNativeHypCollateralAdapter
       );
     }
 
+    const destinationMetadata = this.multiProvider.getChainMetadata(
+      params.destination,
+    );
+    const destinationProtocol = destinationMetadata.protocol;
+
     const msg: MsgRemoteTransferEncodeObject = {
       typeUrl: '/hyperlane.warp.v1.MsgRemoteTransfer',
       value: {
         sender: params.fromAccountOwner,
         recipient: addressToBytes32(
-          convertToProtocolAddress(params.recipient, ProtocolType.Ethereum),
-          ProtocolType.Ethereum,
+          convertToProtocolAddress(
+            params.recipient,
+            destinationMetadata.protocol,
+            destinationMetadata.bech32Prefix,
+          ),
+          destinationProtocol,
         ),
         amount: params.weiAmountOrId.toString(),
         token_id: this.tokenId,


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
Fix `CosmosModuleTokenAdapter` recipient conversion for populateTransferRemoteTx by taking into account protocol 
### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
UI test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects recipient address encoding for cross-chain transfers by using the destination chain’s protocol, ensuring transfers to Cosmos and other non-EVM chains are encoded and processed correctly.

* **Chores**
  * Prepares a patch release of @hyperlane-xyz/sdk documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->