### PR TITLE
feat: accept unknown warp route IDs in generate-strategy-config

### DIFF
--- a/.changeset/honest-cycles-trade.md
+++ b/.changeset/honest-cycles-trade.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/infra": patch
+---
+
+generate-strategy-config script now accepts unknown warp route IDs


### PR DESCRIPTION
## Description

Allow the generate-strategy-config script to accept unknown warp route IDs and provide helpful error messages when no strategy configuration exists. Previously, the script would only accept known warp route IDs, but now it validates the ID after input and shows available routes when the requested one doesn't have a strategy.

## Drive-by Changes

Fixed typo in assert error message (was showing `${strategy}` instead of `${warpRouteId}`)

## Related Issues

To be filled in

## Backward Compatibility

Yes - this change expands functionality without breaking existing usage. All previously valid warp route IDs continue to work as before.