### PR TITLE
feat: add chunk limit to mitosis

### DIFF
--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -9080,6 +9080,7 @@
       "testRecipient": "0x72246331d057741008751AB3976a8297Ce7267Bc",
       "validatorAnnounce": "0xdf4aA3905e0391C7763e33CB6A08fFa97221D49B",
       "index": {
+        "chunk": 1000,
         "from": 127654
       }
     }


### PR DESCRIPTION
### Description

- limits chunk size to 1000
- rpc is erroring because we've exceeded their block range query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced a new “chunk” parameter in the Taiko chain indexing configuration, enabling chunk-based processing alongside the existing “from” value.
* Chores
  * Updated mainnet configuration to include the “chunk” field for the Taiko chain index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->