### PR TITLE
feat: use core provider to get state_version

### DIFF
--- a/rust/main/chains/hyperlane-radix/src/indexer/delivery.rs
+++ b/rust/main/chains/hyperlane-radix/src/indexer/delivery.rs
@@ -51,12 +51,7 @@ impl Indexer<H256> for RadixDeliveryIndexer {
     }
 
     async fn get_finalized_block_number(&self) -> ChainResult<u32> {
-        Ok(self
-            .provider
-            .get_status(None)
-            .await?
-            .state_version
-            .try_into()?)
+        Ok(self.provider.get_state_version(None).await?.try_into()?)
     }
 
     async fn fetch_logs_by_tx_hash(
@@ -82,16 +77,14 @@ impl Indexer<H256> for RadixDeliveryIndexer {
 #[async_trait]
 impl SequenceAwareIndexer<H256> for RadixDeliveryIndexer {
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        let status = self.provider.get_status(Some(&ReorgPeriod::None)).await?;
+        let state_version = self
+            .provider
+            .get_state_version(Some(&ReorgPeriod::None))
+            .await?;
         let sequence: u32 = self
             .provider
-            .call_method(
-                &self.address,
-                "processed",
-                Some(status.state_version as u64),
-                Vec::new(),
-            )
+            .call_method(&self.address, "processed", Some(state_version), Vec::new())
             .await?;
-        Ok((Some(sequence), status.state_version.try_into()?))
+        Ok((Some(sequence), state_version.try_into()?))
     }
 }

--- a/rust/main/chains/hyperlane-radix/src/indexer/dispatch.rs
+++ b/rust/main/chains/hyperlane-radix/src/indexer/dispatch.rs
@@ -51,12 +51,7 @@ impl Indexer<HyperlaneMessage> for RadixDispatchIndexer {
     }
 
     async fn get_finalized_block_number(&self) -> ChainResult<u32> {
-        Ok(self
-            .provider
-            .get_status(None)
-            .await?
-            .state_version
-            .try_into()?)
+        Ok(self.provider.get_state_version(None).await?.try_into()?)
     }
 
     async fn fetch_logs_by_tx_hash(
@@ -82,16 +77,14 @@ impl Indexer<HyperlaneMessage> for RadixDispatchIndexer {
 #[async_trait]
 impl SequenceAwareIndexer<HyperlaneMessage> for RadixDispatchIndexer {
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        let status = self.provider.get_status(Some(&ReorgPeriod::None)).await?;
+        let state_version = self
+            .provider
+            .get_state_version(Some(&ReorgPeriod::None))
+            .await?;
         let sequence: u32 = self
             .provider
-            .call_method(
-                &self.address,
-                "nonce",
-                Some(status.state_version as u64),
-                Vec::new(),
-            )
+            .call_method(&self.address, "nonce", Some(state_version), Vec::new())
             .await?;
-        Ok((Some(sequence), status.state_version.try_into()?)) // TODO: check u32 bounds
+        Ok((Some(sequence), state_version.try_into()?)) // TODO: check u32 bounds
     }
 }

--- a/rust/main/chains/hyperlane-radix/src/indexer/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-radix/src/indexer/interchain_gas.rs
@@ -76,12 +76,7 @@ impl Indexer<InterchainGasPayment> for RadixInterchainGasIndexer {
     }
 
     async fn get_finalized_block_number(&self) -> ChainResult<u32> {
-        Ok(self
-            .provider
-            .get_status(None)
-            .await?
-            .state_version
-            .try_into()?)
+        Ok(self.provider.get_state_version(None).await?.try_into()?)
     }
 
     /// Fetch list of logs emitted in a transaction with the given hash.
@@ -108,16 +103,14 @@ impl Indexer<InterchainGasPayment> for RadixInterchainGasIndexer {
 #[async_trait]
 impl SequenceAwareIndexer<InterchainGasPayment> for RadixInterchainGasIndexer {
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        let status = self.provider.get_status(Some(&ReorgPeriod::None)).await?;
+        let state_version = self
+            .provider
+            .get_state_version(Some(&ReorgPeriod::None))
+            .await?;
         let sequence: u32 = self
             .provider
-            .call_method(
-                &self.address,
-                "sequence",
-                Some(status.state_version as u64),
-                Vec::new(),
-            )
+            .call_method(&self.address, "sequence", Some(state_version), Vec::new())
             .await?;
-        Ok((Some(sequence), status.state_version.try_into()?))
+        Ok((Some(sequence), state_version.try_into()?))
     }
 }

--- a/rust/main/chains/hyperlane-radix/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-radix/src/mailbox.rs
@@ -5,10 +5,7 @@ use core_api_client::models::{FeeSummary, TransactionStatus};
 use radix_common::manifest_args;
 use radix_common::prelude::ManifestArgs;
 use regex::Regex;
-use scrypto::{
-    address::AddressBech32Decoder, data::manifest::manifest_encode, network::NetworkDefinition,
-    types::ComponentAddress,
-};
+use scrypto::{address::AddressBech32Decoder, network::NetworkDefinition, types::ComponentAddress};
 
 use hyperlane_core::{
     ChainCommunicationError, ChainResult, ContractLocator, Encode, FixedPointNumber,
@@ -136,9 +133,8 @@ impl Mailbox for RadixMailbox {
     /// Fetch the status of a message
     async fn delivered(&self, id: H256) -> ChainResult<bool> {
         let id: Bytes32 = id.into();
-        let id = manifest_encode(&id).map_err(HyperlaneRadixError::from)?;
         self.provider
-            .call_method(&self.encoded_address, "delivered", None, vec![id])
+            .call_method_with_arg(&self.encoded_address, "delivered", None, &id)
             .await
     }
 

--- a/rust/main/chains/hyperlane-radix/src/provider/fallback.rs
+++ b/rust/main/chains/hyperlane-radix/src/provider/fallback.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
-use core_api_client::models::{TransactionCallPreviewRequest, TransactionCallPreviewResponse};
+use core_api_client::models::{
+    NetworkStatusResponse, TransactionCallPreviewRequest, TransactionCallPreviewResponse,
+};
 use derive_new::new;
 use gateway_api_client::models::{
     CommittedTransactionInfo, GatewayStatusResponse, StateEntityDetailsRequest,
@@ -104,6 +106,15 @@ impl RadixGatewayProvider for RadixFallbackProvider {
 
 #[async_trait]
 impl RadixCoreProvider for RadixFallbackProvider {
+    async fn core_status(&self) -> ChainResult<NetworkStatusResponse> {
+        self.core
+            .call(|client| {
+                let future = async move { client.core_status().await };
+                Box::pin(future)
+            })
+            .await
+    }
+
     async fn call_preview(
         &self,
         request: TransactionCallPreviewRequest,


### PR DESCRIPTION
### Description

I noticed a lot of warnings in the logs. We use 2 RPCs (Core & Gateway) for Radix chains and it  turns out that the Gateway usually reports a higher state_version (equal to block height) than the Core API. This results in errors, because we try to Query state from the higher, not available, state version. 

This PR now uses the Core API to query for the state version, which resolved all of the errors.

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added network status support in the Radix provider.
  - More accurate finalized block height and tip reporting across Radix indexers.

- Performance
  - Reduced overhead by passing binary arguments directly in Radix ISM and Mailbox calls.
  - Streamlined state-version lookups for faster, leaner queries.

- Bug Fixes
  - Improved stability and consistency of Radix reads during reorg scenarios.

- Refactor
  - Migrated indexing and provider logic to a state-version-based API for consistency across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->