### PR TITLE
fix: env-test-matrix testnet4

### DIFF
--- a/typescript/infra/scripts/check/check-utils.ts
+++ b/typescript/infra/scripts/check/check-utils.ts
@@ -128,9 +128,11 @@ export async function getGovernor(
       !!chainAddresses[chain]?.interchainAccountRouter,
   );
 
-  const ica = ICA_ENABLED_MODULES.includes(module)
-    ? InterchainAccount.fromAddressesMap(icaChainAddresses, multiProvider)
-    : undefined;
+  const ica =
+    ICA_ENABLED_MODULES.includes(module) &&
+    Object.keys(icaChainAddresses).length > 0
+      ? InterchainAccount.fromAddressesMap(icaChainAddresses, multiProvider)
+      : undefined;
 
   if (module === Modules.CORE) {
     chainsToSkip.forEach((chain) => delete envConfig.core[chain]);

--- a/typescript/infra/scripts/check/check-utils.ts
+++ b/typescript/infra/scripts/check/check-utils.ts
@@ -166,6 +166,10 @@ export async function getGovernor(
       return acc;
     }, {});
 
+    if (!ica) {
+      throw new Error('ICA app not initialized');
+    }
+
     const icaChecker = new HyperlaneICAChecker(multiProvider, ica, icaConfig);
     governor = new ProxiedRouterGovernor(icaChecker);
   } else if (module === Modules.HAAS) {
@@ -188,6 +192,10 @@ export async function getGovernor(
       return acc;
     }, {});
 
+    if (!ica) {
+      throw new Error('ICA app not initialized');
+    }
+
     const icaChecker = new HyperlaneICAChecker(multiProvider, ica, icaConfig);
     chainsToSkip.forEach((chain) => delete envConfig.core[chain]);
     const coreChecker = new HyperlaneCoreChecker(
@@ -197,6 +205,9 @@ export async function getGovernor(
       ismFactory,
       chainAddresses,
     );
+    if (!ica) {
+      throw new Error('ICA app not initialized');
+    }
     governor = new HyperlaneHaasGovernor(ica, icaChecker, coreChecker);
   } else if (module === Modules.INTERCHAIN_QUERY_SYSTEM) {
     const iqs = InterchainQuery.fromAddressesMap(chainAddresses, multiProvider);


### PR DESCRIPTION
### Description

fix: env-test-matrix testnet4

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional Interchain Accounts support; modules initialize only when configured, improving flexibility.
- Bug Fixes
  - Added clear runtime guards when Interchain Accounts aren’t initialized, preventing crashes and improving error messaging.
- Refactor
  - Simplified core governance initialization by removing the explicit Interchain Accounts parameter and adjusting related initializations for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->