### PR TITLE
feat(sdk): validate transfer amount and max transfer amount

### DIFF
--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -356,7 +356,7 @@ export class EvmHypCollateralAdapter
     );
   }
 
-  protected async getWrappedTokenAddress(): Promise<Address> {
+  async getWrappedTokenAddress(): Promise<Address> {
     if (!this.wrappedTokenAddress) {
       this.wrappedTokenAddress = await this.collateralContract.wrappedToken();
     }

--- a/typescript/sdk/src/token/adapters/ITokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/ITokenAdapter.ts
@@ -74,6 +74,7 @@ export interface IMovableCollateralRouterAdapter<Tx> extends ITokenAdapter<Tx> {
     amount: Numberish,
     isWarp: boolean,
   ): Promise<InterchainGasQuote[]>;
+  getWrappedTokenAddress(): Promise<Address>;
 
   populateRebalanceTx(
     domain: Domain,

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -105,7 +105,10 @@ describe('WarpCore', () => {
     const stubs = warpCore.tokens.map((t) =>
       sinon.stub(t, 'getHypAdapter').returns({
         quoteTransferRemoteGas: () =>
-          Promise.resolve({ igpQuote: MOCK_INTERCHAIN_QUOTE }),
+          Promise.resolve({
+            igpQuote: MOCK_INTERCHAIN_QUOTE,
+            tokenFeeQuote: MOCK_INTERCHAIN_QUOTE,
+          }),
         isApproveRequired: () => Promise.resolve(false),
         populateTransferRemoteTx: () => Promise.resolve({}),
         isRevokeApprovalRequired: () => Promise.resolve(false),
@@ -116,7 +119,10 @@ describe('WarpCore', () => {
       token: Token,
       destination: ChainName,
       standard: TokenStandard,
-      interchainQuote: InterchainGasQuote = { igpQuote: MOCK_INTERCHAIN_QUOTE },
+      interchainQuote: InterchainGasQuote = {
+        igpQuote: MOCK_INTERCHAIN_QUOTE,
+        tokenFeeQuote: MOCK_INTERCHAIN_QUOTE,
+      },
     ) => {
       const tokenAmount = new TokenAmount(0, token);
       const result = await warpCore.estimateTransferRemoteFees({
@@ -141,6 +147,10 @@ describe('WarpCore', () => {
         result.interchainQuote.amount,
         `token interchain amount check for ${token.chainName} to ${destination}`,
       ).to.equal(interchainQuote.igpQuote.amount);
+      expect(
+        result.tokenFeeQuote?.amount,
+        `token fee amount check for ${token.chainName} to ${destination}`,
+      ).to.equal(interchainQuote.tokenFeeQuote?.amount);
     };
 
     await testQuote(evmHypNative, test1.name, TokenStandard.EvmNative);

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -594,7 +594,17 @@ export class WarpCore {
       maxAmount = maxAmount.minus(interchainQuote.amount);
     }
     if (originToken.isFungibleWith(tokenFeeQuote?.token)) {
-      maxAmount = maxAmount.minus(tokenFeeQuote?.amount || 0n);
+      const { tokenFeeQuote: newFeeQuote } =
+        await this.getInterchainTransferFee({
+          originTokenAmount: maxAmount,
+          destination,
+          recipient,
+          sender,
+        });
+      // Because tokenFeeQuote is calculated based on the amount, we need to recalculate
+      // the tokenFeeQuote after subtracting the localQuote and IGP to get max transfer amount
+      // to be as close as possible
+      maxAmount = maxAmount.minus(newFeeQuote?.amount || 0n);
     }
 
     if (maxAmount.amount > 0) return maxAmount;

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -191,9 +191,9 @@ export class WarpCore {
     }
 
     let feeTokenAmount: TokenAmount | undefined;
-    if (feeAmount && feeAddressOrDenom) {
-      // zero address is native route
-      if (isZeroishAddress(feeAddressOrDenom)) {
+    if (feeAmount) {
+      // empty address or zero address is native route
+      if (!feeAddressOrDenom || isZeroishAddress(feeAddressOrDenom)) {
         const nativeToken = Token.FromChainMetadataNativeToken(
           this.multiProvider.getChainMetadata(originName),
         );


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
- Update `validateTokenBalances` to include token fee check
- Max transfer amount now takes into account fees


### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->
Restore getWrappedTokenAddress to public as it is used in widgets
### Related issues

<!--
- Fixes #[issue number here]
-->
Fixes [ENG-2121](https://linear.app/hyperlane-xyz/issue/ENG-2121/validations-should-take-into-account-fees)
### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
No
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
UI test