### PR TITLE
chore: update token decimals in warp config getters

### DIFF
--- a/.changeset/plenty-bulldogs-dream.md
+++ b/.changeset/plenty-bulldogs-dream.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/infra": patch
+---
+
+set token decimals in warp config getters to satisfy stricter warp checker rules

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumNeutronTiaWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumNeutronTiaWarpConfig.ts
@@ -21,6 +21,7 @@ export const getArbitrumNeutronTiaWarpConfig = async (
     token:
       'ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7',
     foreignDeployment: neutronRouter,
+    decimals: 6,
     gas: 600000,
   };
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseSolanaTRUMPWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseSolanaTRUMPWarpConfig.ts
@@ -30,6 +30,7 @@ export const getTRUMPWarpConfig = async (
       foreignDeployment: '21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS',
       decimals: 6,
       gas: 64000,
+      scale: 1_000_000_000_000,
     },
     base: {
       ...routerConfig.base,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseSolanaTRUMPWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseSolanaTRUMPWarpConfig.ts
@@ -28,6 +28,7 @@ export const getTRUMPWarpConfig = async (
       token: '6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN',
       owner: DEPLOYER,
       foreignDeployment: '21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS',
+      decimals: 18,
       gas: 64000,
     },
     base: {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseSolanaTRUMPWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseSolanaTRUMPWarpConfig.ts
@@ -28,7 +28,7 @@ export const getTRUMPWarpConfig = async (
       token: '6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN',
       owner: DEPLOYER,
       foreignDeployment: '21tAY4poz2VXvghqdSQpn9j7gYravQmGpuQi8pHPx9DS',
-      decimals: 18,
+      decimals: 6,
       gas: 64000,
     },
     base: {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getBsquaredUBTCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getBsquaredUBTCWarpConfig.ts
@@ -27,6 +27,9 @@ export const getBsquaredUBTCWarpConfig = async (
     mailbox: routerConfig.boba.mailbox,
     owner: safeOwners.boba,
     type: TokenType.synthetic,
+    decimals: 18,
+    name: 'uBTC',
+    symbol: 'uBTC',
   };
 
   const bsquared: HypTokenRouterConfig = {
@@ -34,6 +37,7 @@ export const getBsquaredUBTCWarpConfig = async (
     owner: safeOwners.bsquared,
     type: TokenType.collateral,
     token: tokens.bsquared.uBTC,
+    decimals: 18,
   };
 
   const nibiru: HypTokenRouterConfig = {
@@ -49,12 +53,18 @@ export const getBsquaredUBTCWarpConfig = async (
     mailbox: routerConfig.soneium.mailbox,
     owner: safeOwners.soneium,
     type: TokenType.synthetic,
+    decimals: 18,
+    name: 'uBTC',
+    symbol: 'uBTC',
   };
 
   const swell: HypTokenRouterConfig = {
     mailbox: routerConfig.swell.mailbox,
     owner: safeOwners.swell,
     type: TokenType.synthetic,
+    decimals: 18,
+    name: 'uBTC',
+    symbol: 'uBTC',
   };
 
   return {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDCWarpConfig.ts
@@ -32,6 +32,7 @@ export const getEthereumVictionUSDCWarpConfig = async (
     ...abacusWorksEnvOwnerConfig.ethereum,
     type: TokenType.collateral,
     token: tokens.ethereum.USDC,
+    decimals: 6,
     gas: 65_000,
     interchainSecurityModule: ethers.constants.AddressZero,
     hook: '0xb87ac8ea4533ae017604e44470f7c1e550ac6f10',

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDTWarpConfig.ts
@@ -32,6 +32,7 @@ export const getEthereumVictionUSDTWarpConfig = async (
     ...abacusWorksEnvOwnerConfig.ethereum,
     type: TokenType.collateral,
     token: tokens.ethereum.USDT,
+    decimals: 6,
     gas: 65_000,
     interchainSecurityModule: ethers.constants.AddressZero,
     hook: '0xb87ac8ea4533ae017604e44470f7c1e550ac6f10',

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getMantapacificNeutronTiaWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getMantapacificNeutronTiaWarpConfig.ts
@@ -19,6 +19,7 @@ export const getMantapacificNeutronTiaWarpConfig = async (
     foreignDeployment: neutronRouter,
     owner: abacusWorksEnvOwnerConfig.neutron.owner,
     type: TokenType.native,
+    decimals: 6,
     gas: 0,
   };
 


### PR DESCRIPTION
## Description

This PR updates the token decimals in warp config getters so that they are specified explicitly. Our recently updated decimals check requries all decimals to be set in configuration.

### Backward compatibility

Yes, as we specify the actual decimals for existing tokens.

### Testing

Manual `check-deploy.ts` runs for the warp routes affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Set explicit token decimals to ensure accurate amounts and consistent cross-chain behavior: Neutron TIA (Arbitrum, Mantapacific), USDC (Ethereum ↔ Viction), USDT (Ethereum ↔ Viction), TRUMP (Base ↔ Solana).
  - Added uBTC token metadata (decimals, name, symbol) across Boba, Bsquared, Nibiru, Soneium, and Swell for consistent display and calculations.

- Chores
  - Added a patch-level changeset entry for the infra package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->