### PR TITLE
Simplify Superswaps matchingList

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -558,20 +558,20 @@ const veloMessageModuleMatchingList = consistentSenderRecipientMatchingList(
 );
 
 // ICA v2 deploys that superswaps make use of
-const superswapIcaV2MatchingList = chainMapMatchingList({
-  base: '0x44647Cd983E80558793780f9a0c7C2aa9F384D07',
-  bob: '0xA6f0A37DFDe9C2c8F46F010989C47d9edB3a9FA8',
-  celo: '0x1eA7aC243c398671194B7e2C51d76d1a1D312953',
-  fraxtal: '0xD59a200cCEc5b3b1bF544dD7439De452D718f594',
-  ink: '0x55Ba00F1Bac2a47e0A73584d7c900087642F9aE3',
-  lisk: '0xE59592a179c4f436d5d2e4caA6e2750beA4E3166',
-  metal: '0x0b2d429acccAA411b867d57703F88Ed208eC35E4',
-  mode: '0x860ec58b115930EcbC53EDb8585C1B16AFFF3c50',
-  optimism: '0x3E343D07D024E657ECF1f8Ae8bb7a12f08652E75',
-  soneium: '0xc08C1451979e9958458dA3387E92c9Feb1571f9C',
-  superseed: '0x3CA0e8AEfC14F962B13B40c6c4b9CEE3e4927Ae3',
-  swell: '0x95Fb6Ca1BBF441386b119ad097edcAca3b1C35B7',
-  unichain: '0x43320f6B410322Bf5ca326a0DeAaa6a2FC5A021B',
+const superswapIcaV2MatchingList = senderMatchingList({
+  base: { sender: '0x44647Cd983E80558793780f9a0c7C2aa9F384D07' },
+  bob: { sender: '0xA6f0A37DFDe9C2c8F46F010989C47d9edB3a9FA8' },
+  celo: { sender: '0x1eA7aC243c398671194B7e2C51d76d1a1D312953' },
+  fraxtal: { sender: '0xD59a200cCEc5b3b1bF544dD7439De452D718f594' },
+  ink: { sender: '0x55Ba00F1Bac2a47e0A73584d7c900087642F9aE3' },
+  lisk: { sender: '0xE59592a179c4f436d5d2e4caA6e2750beA4E3166' },
+  metal: { sender: '0x0b2d429acccAA411b867d57703F88Ed208eC35E4' },
+  mode: { sender: '0x860ec58b115930EcbC53EDb8585C1B16AFFF3c50' },
+  optimism: { sender: '0x3E343D07D024E657ECF1f8Ae8bb7a12f08652E75' },
+  soneium: { sender: '0xc08C1451979e9958458dA3387E92c9Feb1571f9C' },
+  superseed: { sender: '0x3CA0e8AEfC14F962B13B40c6c4b9CEE3e4927Ae3' },
+  swell: { sender: '0x95Fb6Ca1BBF441386b119ad097edcAca3b1C35B7' },
+  unichain: { sender: '0x43320f6B410322Bf5ca326a0DeAaa6a2FC5A021B' },
 });
 
 const gasPaymentEnforcement: GasPaymentEnforcement[] = [


### PR DESCRIPTION
### Description

Simplify the Superswaps matching list so that it fits into the configmap size limit

### Drive-by changes

Add the print-latest-Checkpoint script to only give a specific validators information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added --validator (-v) option to the latest-checkpoints CLI to target a specific validator address.
  - When using the flag, outputs and errors are scoped to the chosen validator for clearer results; existing behavior is unchanged when not specified.
- Refactor
  - Updated internal sender-matching configuration to a structured format for consistency. No user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->