### PR TITLE
chore: set infra decimals in config getters to satisfy updated checker

### DIFF
--- a/.changeset/cool-rivers-tease.md
+++ b/.changeset/cool-rivers-tease.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/infra": patch
+---
+
+set token decimals in more warp config getters to satisfy warp checker rules

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getBscMilkywayMILKWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getBscMilkywayMILKWarpConfig.ts
@@ -25,6 +25,7 @@ export const getBscMilkywayMILKWarpConfig = async (
       ...routerConfig.milkyway,
       owner: safeOwners.milkyway,
       type: TokenType.native,
+      decimals: 6,
       foreignDeployment:
         '0x726f757465725f61707000000000000000000000000000010000000000000000',
     },

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionETHWarpConfig.ts
@@ -28,6 +28,7 @@ export const getEthereumVictionETHWarpConfig = async (
     ...routerConfig.ethereum,
     ...abacusWorksEnvOwnerConfig.ethereum,
     type: TokenType.native,
+    decimals: 18,
     gas: 65_000,
     interchainSecurityModule: ethers.constants.AddressZero,
     hook: '0xb87ac8ea4533ae017604e44470f7c1e550ac6f10',


### PR DESCRIPTION
## Description

This PR updates some more decimals for in config getters to avoid config-checker violations

## Backward compatibility

Yes, as we are setting actual decimals

### Testing

Run `check-config.ts`
