### PR TITLE
feat(fee): Add update token fee to warp apply

### DIFF
--- a/.changeset/seven-hornets-run.md
+++ b/.changeset/seven-hornets-run.md
@@ -1,0 +1,6 @@
+---
+"@hyperlane-xyz/cli": minor
+"@hyperlane-xyz/sdk": minor
+---
+
+Add TokenFee updates to the FeeModule and WarpModule. This enables updating immutable fees (re-deploy), routing sub-fees, and ownership

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
@@ -958,7 +958,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
         bps: 1,
       },
     ]) {
-      it(`should deploy a ${tokenFee.type} tokenFee`, async () => {
+      it(`should deploy ${tokenFee.type} tokenFee`, async () => {
         const warpConfig = WarpRouteDeployConfigSchema.parse({
           [CHAIN_NAME_2]: {
             type: TokenType.collateral,

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
@@ -949,7 +949,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
         bps: 1,
       },
     ]) {
-      it.only(`should deploy a ${tokenFee.type} tokenFee`, async () => {
+      it(`should deploy a ${tokenFee.type} tokenFee`, async () => {
         const warpConfig = WarpRouteDeployConfigSchema.parse({
           [CHAIN_NAME_2]: {
             type: TokenType.collateral,

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
@@ -30,7 +30,7 @@ import {
   normalizeConfig,
   randomAddress,
 } from '@hyperlane-xyz/sdk';
-import { Address, normalizeAddressEvm } from '@hyperlane-xyz/utils';
+import { Address, normalizeAddressEvm, objMap } from '@hyperlane-xyz/utils';
 
 import { readYamlOrJson, writeYamlOrJson } from '../../../utils/files.js';
 import {
@@ -82,13 +82,8 @@ function extractInputOnlyFields(config: any): any {
       return {
         type: config.type,
         ...(config.feeContracts && {
-          feeContracts: Object.fromEntries(
-            Object.entries(config.feeContracts).map(
-              ([chain, subConfig]: [string, any]) => [
-                chain,
-                extractInputOnlyFields(subConfig),
-              ],
-            ),
+          feeContracts: objMap(config.feeContracts, (_, subConfig) =>
+            extractInputOnlyFields(subConfig),
           ),
         }),
       };
@@ -954,7 +949,7 @@ describe('hyperlane warp deploy e2e tests', async function () {
         bps: 1,
       },
     ]) {
-      it(`should deploy a ${tokenFee.type} tokenFee`, async () => {
+      it.only(`should deploy a ${tokenFee.type} tokenFee`, async () => {
         const warpConfig = WarpRouteDeployConfigSchema.parse({
           [CHAIN_NAME_2]: {
             type: TokenType.collateral,

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
@@ -3,7 +3,6 @@ import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { Wallet } from 'ethers';
 import fs from 'fs';
-import _ from 'lodash';
 import path from 'path';
 
 import {
@@ -32,7 +31,12 @@ import {
   normalizeConfig,
   randomAddress,
 } from '@hyperlane-xyz/sdk';
-import { Address, normalizeAddressEvm, objMap } from '@hyperlane-xyz/utils';
+import {
+  Address,
+  normalizeAddressEvm,
+  objMap,
+  pick,
+} from '@hyperlane-xyz/utils';
 
 import { readYamlOrJson, writeYamlOrJson } from '../../../utils/files.js';
 import {
@@ -94,7 +98,7 @@ function extractInputOnlyFields(config: TokenFeeConfigInput): any {
       };
     case TokenFeeType.ProgressiveFee:
     case TokenFeeType.RegressiveFee:
-      return _.pick(config, ['type']);
+      return pick(config, ['type']);
     default:
       return config;
   }

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
@@ -98,7 +98,7 @@ function extractInputOnlyFields(config: TokenFeeConfigInput): any {
       };
     case TokenFeeType.ProgressiveFee:
     case TokenFeeType.RegressiveFee:
-      return pick(config, ['type']);
+      return pick(config, ['type', 'maxFee', 'halfAmount']);
     default:
       return config;
   }

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy.e2e-test.ts
@@ -22,10 +22,12 @@ import {
   HookType,
   IsmConfig,
   IsmType,
+  TokenFeeConfigInput,
   TokenFeeType,
   TokenType,
   WarpCoreConfig,
   WarpRouteDeployConfig,
+  WarpRouteDeployConfigMailboxRequired,
   WarpRouteDeployConfigSchema,
   normalizeConfig,
   randomAddress,
@@ -72,12 +74,15 @@ const WARP_CORE_CONFIG_PATH_2_3 = GET_WARP_DEPLOY_CORE_CONFIG_OUTPUT_PATH(
   'VAULT',
 );
 
-function extractInputOnlyFields(config: any): any {
+function extractInputOnlyFields(config: TokenFeeConfigInput): any {
   if (!config) return config;
 
   switch (config.type) {
     case TokenFeeType.LinearFee:
-      return _.pick(config, ['type', 'bps']);
+      return {
+        type: config.type,
+        bps: config.bps.toString(), // Convert to string for consistent comparison
+      };
     case TokenFeeType.RoutingFee:
       return {
         type: config.type,
@@ -972,16 +977,17 @@ describe('hyperlane warp deploy e2e tests', async function () {
             await tokenChain2.symbol(),
           );
 
-        const collateralConfig: any = (
+        const collateralConfig: WarpRouteDeployConfigMailboxRequired =
           await readWarpConfig(
             CHAIN_NAME_2,
             COMBINED_WARP_CORE_CONFIG_PATH,
             WARP_DEPLOY_OUTPUT_PATH,
-          )
-        )[CHAIN_NAME_2];
+          );
 
-        expect(extractInputOnlyFields(collateralConfig.tokenFee)).to.deep.equal(
-          extractInputOnlyFields(tokenFee),
+        expect(
+          extractInputOnlyFields(collateralConfig[CHAIN_NAME_2].tokenFee!),
+        ).to.deep.equal(
+          extractInputOnlyFields(warpConfig[CHAIN_NAME_2].tokenFee!),
         );
       });
     }

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -409,7 +409,11 @@ export async function enrollCrossChainRouters(
           })(),
         };
 
-        const transactions = await evmWarpModule.update(expectedConfig);
+        const transactions = await evmWarpModule.update(expectedConfig, {
+          routingDestinations: allRemoteChains.map((c) =>
+            multiProvider.getDomainId(c),
+          ),
+        });
 
         if (transactions.length) {
           protocolTransactions[ProtocolType.Ethereum] = {

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -7,6 +7,7 @@ import { ERC20Test, ERC20Test__factory } from '@hyperlane-xyz/core';
 
 import { TestChainName } from '../consts/testChains.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
+import { randomAddress } from '../test/testUtils.js';
 import { normalizeConfig } from '../utils/ism.js';
 
 import { EvmTokenFeeModule } from './EvmTokenFeeModule.js';
@@ -195,6 +196,24 @@ describe('EvmTokenFeeModule', () => {
       await expectTxsAndUpdate(module, updatedConfig, 1, {
         routingDestinations: [multiProvider.getDomainId(test4Chain)],
       });
+    });
+
+    it('should transfer ownership if they are different', async () => {
+      const module = await EvmTokenFeeModule.create({
+        multiProvider,
+        chain: test4Chain,
+        config,
+      });
+      let txs = await module.update({ ...config, owner: config.owner });
+      expect(txs).to.have.lengthOf(0);
+
+      const newOwner = randomAddress();
+      txs = await module.update({ ...config, owner: newOwner });
+      expect(txs).to.have.lengthOf(1);
+      const onchainConfig = (await module.read()) as LinearFeeConfig;
+      expect(normalizeConfig(onchainConfig).owner).to.equal(
+        normalizeConfig(newOwner),
+      );
     });
   });
 });

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -15,7 +15,6 @@ import { EvmTokenFeeModule } from './EvmTokenFeeModule.js';
 import { BPS, HALF_AMOUNT, MAX_FEE } from './EvmTokenFeeReader.hardhat-test.js';
 import { TokenFeeReaderParams } from './EvmTokenFeeReader.js';
 import {
-  LinearFeeConfig,
   RoutingFeeConfig,
   TokenFeeConfig,
   TokenFeeConfigInput,
@@ -79,7 +78,11 @@ describe('EvmTokenFeeModule', () => {
       chain: test4Chain,
       config,
     });
-    const onchainConfig = (await module.read()) as LinearFeeConfig;
+    const onchainConfig = await module.read();
+    assert(
+      onchainConfig.type === TokenFeeType.LinearFee,
+      `Must be ${TokenFeeType.LinearFee}`,
+    );
     assert(
       onchainConfig.type === TokenFeeType.LinearFee,
       `Must be ${TokenFeeType.LinearFee}`,
@@ -169,7 +172,11 @@ describe('EvmTokenFeeModule', () => {
       });
       const updatedConfig = { ...config, bps: BPS + 1n };
       await module.update(updatedConfig);
-      const onchainConfig = (await module.read()) as LinearFeeConfig;
+      const onchainConfig = await module.read();
+      assert(
+        onchainConfig.type === TokenFeeType.LinearFee,
+        `Must be ${TokenFeeType.LinearFee}`,
+      );
       expect(onchainConfig.bps).to.eql(updatedConfig.bps);
     });
 
@@ -215,7 +222,11 @@ describe('EvmTokenFeeModule', () => {
       const newOwner = randomAddress();
       txs = await module.update({ ...config, owner: newOwner });
       expect(txs).to.have.lengthOf(1);
-      const onchainConfig = (await module.read()) as LinearFeeConfig;
+      const onchainConfig = await module.read();
+      assert(
+        onchainConfig.type === TokenFeeType.LinearFee,
+        `Must be ${TokenFeeType.LinearFee}`,
+      );
       expect(normalizeConfig(onchainConfig).owner).to.equal(
         normalizeConfig(newOwner),
       );

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -9,11 +9,9 @@ import { TestChainName } from '../consts/testChains.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { normalizeConfig } from '../utils/ism.js';
 
-import {
-  EvmTokenFeeModule,
-  OptionalModuleParams,
-} from './EvmTokenFeeModule.js';
+import { EvmTokenFeeModule } from './EvmTokenFeeModule.js';
 import { BPS, HALF_AMOUNT, MAX_FEE } from './EvmTokenFeeReader.hardhat-test.js';
+import { ReaderParams } from './EvmTokenFeeReader.js';
 import {
   LinearFeeConfig,
   RoutingFeeConfig,
@@ -51,7 +49,7 @@ describe('EvmTokenFeeModule', () => {
     feeModule: EvmTokenFeeModule,
     config: TokenFeeConfig,
     n: number,
-    params?: OptionalModuleParams,
+    params?: Partial<ReaderParams>,
   ) {
     const txs = await feeModule.update(config, params);
     expect(txs.length).to.equal(n);

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -13,7 +13,7 @@ import { normalizeConfig } from '../utils/ism.js';
 
 import { EvmTokenFeeModule } from './EvmTokenFeeModule.js';
 import { BPS, HALF_AMOUNT, MAX_FEE } from './EvmTokenFeeReader.hardhat-test.js';
-import { ReaderParams } from './EvmTokenFeeReader.js';
+import { TokenFeeReaderParams } from './EvmTokenFeeReader.js';
 import {
   LinearFeeConfig,
   RoutingFeeConfig,
@@ -51,7 +51,7 @@ describe('EvmTokenFeeModule', () => {
     feeModule: EvmTokenFeeModule,
     config: TokenFeeConfig,
     n: number,
-    params?: Partial<ReaderParams>,
+    params?: Partial<TokenFeeReaderParams>,
   ) {
     const txs = await feeModule.update(config, params);
     expect(txs.length).to.equal(n);

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -24,7 +24,7 @@ import {
 } from './types.js';
 
 describe('EvmTokenFeeModule', () => {
-  const chain = TestChainName.test4;
+  const test4Chain = TestChainName.test4;
   let multiProvider: MultiProvider;
   let signer: SignerWithAddress;
   let token: ERC20Test;
@@ -57,7 +57,7 @@ describe('EvmTokenFeeModule', () => {
     expect(txs.length).to.equal(n);
 
     for (const tx of txs) {
-      await multiProvider.sendTransaction(chain, tx);
+      await multiProvider.sendTransaction(test4Chain, tx);
     }
   }
 
@@ -76,7 +76,7 @@ describe('EvmTokenFeeModule', () => {
   it('should create a new token fee with bps', async () => {
     const module = await EvmTokenFeeModule.create({
       multiProvider,
-      chain: chain,
+      chain: test4Chain,
       config,
     });
     const onchainConfig = (await module.read()) as LinearFeeConfig;
@@ -86,7 +86,7 @@ describe('EvmTokenFeeModule', () => {
   it('should deploy and read the routing fee config', async () => {
     const routingFeeConfig: RoutingFeeConfig = {
       feeContracts: {
-        [chain]: config,
+        [test4Chain]: config,
       },
       owner: signer.address,
       token: token.address,
@@ -96,10 +96,10 @@ describe('EvmTokenFeeModule', () => {
     };
     const module = await EvmTokenFeeModule.create({
       multiProvider,
-      chain: chain,
+      chain: test4Chain,
       config: routingFeeConfig,
     });
-    const routingDestination = multiProvider.getDomainId(chain);
+    const routingDestination = multiProvider.getDomainId(test4Chain);
     const onchainConfig = await module.read({
       routingDestinations: [routingDestination],
     });
@@ -112,7 +112,7 @@ describe('EvmTokenFeeModule', () => {
     it('should not update if the linear configs are the same', async () => {
       const module = await EvmTokenFeeModule.create({
         multiProvider,
-        chain: chain,
+        chain: test4Chain,
         config,
       });
 
@@ -126,15 +126,15 @@ describe('EvmTokenFeeModule', () => {
         owner: signer.address,
         token: token.address,
         feeContracts: {
-          [chain]: config,
+          [test4Chain]: config,
         },
       });
       const module = await EvmTokenFeeModule.create({
         multiProvider,
-        chain: chain,
+        chain: test4Chain,
         config: routingConfig,
       });
-      const chainId = multiProvider.getDomainId(chain);
+      const chainId = multiProvider.getDomainId(test4Chain);
       const txs = await module.update(routingConfig, {
         routingDestinations: [chainId],
       });
@@ -144,7 +144,7 @@ describe('EvmTokenFeeModule', () => {
     it('should not update if providing a bps that is the same as the result of calculating with maxFee and halfAmount', async () => {
       const module = await EvmTokenFeeModule.create({
         multiProvider,
-        chain: chain,
+        chain: test4Chain,
         config,
       });
       const updatedConfig: TokenFeeConfigInput = {
@@ -160,7 +160,7 @@ describe('EvmTokenFeeModule', () => {
     it(`should redeploy immutable fees if updating token for ${TokenFeeType.LinearFee}`, async () => {
       const module = await EvmTokenFeeModule.create({
         multiProvider,
-        chain: chain,
+        chain: test4Chain,
         config,
       });
       const updatedConfig = { ...config, bps: BPS + 1n };
@@ -171,7 +171,7 @@ describe('EvmTokenFeeModule', () => {
 
     it(`should redeploy immutable fees if updating token for ${TokenFeeType.RoutingFee}`, async () => {
       const feeContracts = {
-        [chain]: config,
+        [test4Chain]: config,
       };
       const routingFeeConfig: TokenFeeConfig = {
         type: TokenFeeType.RoutingFee,
@@ -181,21 +181,21 @@ describe('EvmTokenFeeModule', () => {
       };
       const module = await EvmTokenFeeModule.create({
         multiProvider,
-        chain: chain,
+        chain: test4Chain,
         config: routingFeeConfig,
       });
       const updatedConfig = {
         ...routingFeeConfig,
         feeContracts: {
-          [chain]: {
-            ...feeContracts[chain],
+          [test4Chain]: {
+            ...feeContracts[test4Chain],
             bps: BPS + 1n,
           },
         },
       };
 
       await expectTxsAndUpdate(module, updatedConfig, 1, {
-        routingDestinations: [multiProvider.getDomainId(chain)],
+        routingDestinations: [multiProvider.getDomainId(test4Chain)],
       });
     });
   });

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -147,8 +147,7 @@ describe('EvmTokenFeeModule', () => {
       expect(onchainConfig.bps).to.eql(updatedConfig.bps);
     });
 
-    it.only(`should redeploy immutable fees if updating token for ${TokenFeeType.RoutingFee}`, async () => {
-      // multiProvider = await impersonateAccount(signer.address);
+    it(`should redeploy immutable fees if updating token for ${TokenFeeType.RoutingFee}`, async () => {
       const feeContracts = {
         [chain]: config,
       };
@@ -173,23 +172,9 @@ describe('EvmTokenFeeModule', () => {
         },
       };
 
-      const routingFeeAddress = (await module.read()).address;
       await expectTxsAndUpdate(module, updatedConfig, 1, {
         routingDestinations: [multiProvider.getDomainId(chain)],
       });
-
-      const onchainConfig = await module.read({
-        address: routingFeeAddress,
-        routingDestinations: [multiProvider.getDomainId(chain)],
-      });
-
-      expect(normalizeConfig(onchainConfig)).to.eql(
-        normalizeConfig({
-          ...updatedConfig,
-          maxFee: constants.MaxUint256.toBigInt(), // Set onchain by default
-          halfAmount: constants.MaxUint256.toBigInt(),
-        }),
-      );
     });
   });
 });

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -4,6 +4,7 @@ import { constants } from 'ethers';
 import hre from 'hardhat';
 
 import { ERC20Test, ERC20Test__factory } from '@hyperlane-xyz/core';
+import { assert } from '@hyperlane-xyz/utils';
 
 import { TestChainName } from '../consts/testChains.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
@@ -79,6 +80,10 @@ describe('EvmTokenFeeModule', () => {
       config,
     });
     const onchainConfig = (await module.read()) as LinearFeeConfig;
+    assert(
+      onchainConfig.type === TokenFeeType.LinearFee,
+      `Must be ${TokenFeeType.LinearFee}`,
+    );
     expect(onchainConfig.bps).to.equal(BPS);
   });
 

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -232,7 +232,7 @@ describe('EvmTokenFeeModule', () => {
       );
     });
 
-    it.only('should transfer ownership for each routing sub fee', async () => {
+    it('should transfer ownership for each routing sub fee', async () => {
       const feeContracts = {
         [test4Chain]: config,
       };

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -171,7 +171,7 @@ describe('EvmTokenFeeModule', () => {
         config,
       });
       const updatedConfig = { ...config, bps: BPS + 1n };
-      await module.update(updatedConfig);
+      await expectTxsAndUpdate(module, updatedConfig, 0);
       const onchainConfig = await module.read();
       assert(
         onchainConfig.type === TokenFeeType.LinearFee,
@@ -216,12 +216,9 @@ describe('EvmTokenFeeModule', () => {
         chain: test4Chain,
         config,
       });
-      let txs = await module.update({ ...config, owner: config.owner });
-      expect(txs).to.have.lengthOf(0);
-
+      await expectTxsAndUpdate(module, { ...config, owner: config.owner }, 0);
       const newOwner = randomAddress();
-      txs = await module.update({ ...config, owner: newOwner });
-      expect(txs).to.have.lengthOf(1);
+      await expectTxsAndUpdate(module, { ...config, owner: newOwner }, 1);
       const onchainConfig = await module.read();
       assert(
         onchainConfig.type === TokenFeeType.LinearFee,

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -27,6 +27,7 @@ import {
   DerivedRoutingFeeConfig,
   DerivedTokenFeeConfig,
   EvmTokenFeeReader,
+  ReaderParams,
 } from './EvmTokenFeeReader.js';
 import { EvmTokenFeeFactories } from './contracts.js';
 import {
@@ -40,11 +41,6 @@ import {
 type TokenFeeModuleAddresses = {
   deployedFee: Address;
 };
-
-export type OptionalModuleParams = Partial<{
-  address: Address;
-  routingDestinations: number[]; // Required for RoutingFee
-}>;
 
 export class EvmTokenFeeModule extends HyperlaneModule<
   ProtocolType.Ethereum,
@@ -184,7 +180,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     return deployer.deploy({ [params.chainName]: params.config });
   }
 
-  async read(params?: OptionalModuleParams): Promise<DerivedTokenFeeConfig> {
+  async read(params?: Partial<ReaderParams>): Promise<DerivedTokenFeeConfig> {
     const address = params?.address ?? this.args.addresses.deployedFee;
     const routingDestinations = params?.routingDestinations ?? [];
 
@@ -196,7 +192,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
 
   async update(
     targetConfig: TokenFeeConfigInput,
-    params?: OptionalModuleParams,
+    params?: Partial<ReaderParams>,
   ): Promise<AnnotatedEV5Transaction[]> {
     let updateTransactions: AnnotatedEV5Transaction[] = [];
 

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -221,11 +221,15 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     }
 
     // Redeploy immutable fee types, if owner is the same, but the rest of the config is different
+    const nonOwnerDiffers = !deepEquals(
+      _.omit(normalizedActualConfig, ['owner']),
+      _.omit(normalizedTargetConfig, ['owner']),
+    );
     if (
-      eqAddress(normalizedActualConfig.owner, normalizedTargetConfig.owner) &&
       ImmutableTokenFeeType.includes(
         normalizedTargetConfig.type as (typeof ImmutableTokenFeeType)[number],
-      )
+      ) &&
+      nonOwnerDiffers
     ) {
       this.logger.info(
         `Immutable fee type ${normalizedTargetConfig.type}, redeploying`,
@@ -238,6 +242,8 @@ export class EvmTokenFeeModule extends HyperlaneModule<
       });
       this.args.addresses.deployedFee =
         contracts[this.chainName][normalizedTargetConfig.type].address;
+
+      return [];
     }
 
     // if the type is a mutable (for now, only routing fee), then update

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -182,12 +182,6 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     return deployer.deploy({ [params.chainName]: params.config });
   }
 
-  // Public accessor for the deployed fee contract address
-  // TODO: Remove this an use serialize() instead
-  getDeployedFeeAddress(): Address {
-    return this.args.addresses.deployedFee;
-  }
-
   async read(params?: OptionalModuleParams): Promise<DerivedTokenFeeConfig> {
     const address = params?.address ?? this.args.addresses.deployedFee;
     const routingDestinations = params?.routingDestinations ?? [];

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -269,7 +269,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
             addresses: {
               deployedFee: constants.AddressZero,
             },
-            chain: chainName,
+            chain: this.chainName,
             config,
           },
           this.contractVerifier,

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -186,7 +186,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     params?: Partial<TokenFeeReaderParams>,
   ): Promise<DerivedTokenFeeConfig> {
     const address = params?.address ?? this.args.addresses.deployedFee;
-    const routingDestinations = params?.routingDestinations ?? [];
+    const routingDestinations = params?.routingDestinations;
 
     return this.reader.deriveTokenFeeConfig({
       address: address,

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -238,8 +238,6 @@ export class EvmTokenFeeModule extends HyperlaneModule<
       });
       this.args.addresses.deployedFee =
         contracts[this.chainName][normalizedTargetConfig.type].address;
-
-      return [];
     }
 
     // if the type is a mutable (for now, only routing fee), then update

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -238,12 +238,9 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     }
 
     // if the type is a mutable type, then update
-    switch (targetConfig.type) {
-      case TokenFeeType.RoutingFee:
-        updateTransactions = await this.updateRoutingFee(
-          _.merge(actualConfig, targetConfig) as DerivedRoutingFeeConfig, // Creates a config with address and new changes
-        );
-    }
+    updateTransactions = await this.updateRoutingFee(
+      _.merge(actualConfig, targetConfig) as DerivedRoutingFeeConfig, // Creates a config with address and new changes
+    );
 
     return updateTransactions;
   }

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -157,6 +157,8 @@ export class EvmTokenFeeModule extends HyperlaneModule<
         type: TokenFeeType.RoutingFee,
         token: config.token,
         owner: config.owner,
+        maxFee: constants.MaxUint256.toBigInt(),
+        halfAmount: constants.MaxUint256.toBigInt(),
         feeContracts,
       };
     } else {
@@ -254,7 +256,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     await promiseObjAll(
       objMap(targetConfig.feeContracts, async (chainName, config) => {
         const address = config.address;
-        await this.update(config, address);
+        await this.update(config, { address });
 
         // fetches the latest deployedFee
         updateTxs.push({

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -244,8 +244,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
   }
 
   private async updateRoutingFee(targetConfig: DerivedRoutingFeeConfig) {
-    // For each routing fee, call this.update
-    const updateTxs: AnnotatedEV5Transaction[] = [];
+    const updateTransactions: AnnotatedEV5Transaction[] = [];
 
     if (!targetConfig.feeContracts) return [];
     const currentRoutingAddress = this.args.addresses.deployedFee;
@@ -255,7 +254,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
         await this.update(config, { address });
 
         // fetches the latest deployedFee
-        updateTxs.push({
+        updateTransactions.push({
           annotation: 'Updating routing fee...',
           chainId: this.chainId,
           to: currentRoutingAddress,
@@ -270,6 +269,6 @@ export class EvmTokenFeeModule extends HyperlaneModule<
       }),
     );
 
-    return updateTxs;
+    return updateTransactions;
   }
 }

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -1,5 +1,4 @@
 import { constants } from 'ethers';
-import _ from 'lodash';
 
 import { RoutingFee__factory } from '@hyperlane-xyz/core';
 import {
@@ -8,6 +7,8 @@ import {
   deepEquals,
   eqAddress,
   objMap,
+  objMerge,
+  objOmit,
   promiseObjAll,
   rootLogger,
 } from '@hyperlane-xyz/utils';
@@ -222,8 +223,8 @@ export class EvmTokenFeeModule extends HyperlaneModule<
 
     // Redeploy immutable fee types, if owner is the same, but the rest of the config is different
     const nonOwnerDiffers = !deepEquals(
-      _.omit(normalizedActualConfig, ['owner']),
-      _.omit(normalizedTargetConfig, ['owner']),
+      objOmit(normalizedActualConfig, ['owner']),
+      objOmit(normalizedTargetConfig, ['owner']),
     );
     if (
       ImmutableTokenFeeType.includes(
@@ -249,7 +250,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     // if the type is a mutable (for now, only routing fee), then update
     updateTransactions = [
       ...(await this.updateRoutingFee(
-        _.merge(
+        objMerge(
           actualConfig,
           normalizedTargetConfig,
         ) as DerivedRoutingFeeConfig,

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -236,9 +236,11 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     }
 
     // if the type is a mutable type, then update
-    updateTransactions = await this.updateRoutingFee(
-      _.merge(actualConfig, targetConfig) as DerivedRoutingFeeConfig, // Creates a config with address and new changes
-    );
+    updateTransactions = [
+      ...(await this.updateRoutingFee(
+        _.merge(actualConfig, targetConfig) as DerivedRoutingFeeConfig, // Creates a config with address and new changes
+      )),
+    ];
 
     return updateTransactions;
   }

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -28,7 +28,7 @@ import {
   DerivedRoutingFeeConfig,
   DerivedTokenFeeConfig,
   EvmTokenFeeReader,
-  ReaderParams,
+  TokenFeeReaderParams,
 } from './EvmTokenFeeReader.js';
 import { EvmTokenFeeFactories } from './contracts.js';
 import {
@@ -181,7 +181,9 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     return deployer.deploy({ [params.chainName]: params.config });
   }
 
-  async read(params?: Partial<ReaderParams>): Promise<DerivedTokenFeeConfig> {
+  async read(
+    params?: Partial<TokenFeeReaderParams>,
+  ): Promise<DerivedTokenFeeConfig> {
     const address = params?.address ?? this.args.addresses.deployedFee;
     const routingDestinations = params?.routingDestinations ?? [];
 
@@ -193,7 +195,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
 
   async update(
     targetConfig: TokenFeeConfigInput,
-    params?: Partial<ReaderParams>,
+    params?: Partial<TokenFeeReaderParams>,
   ): Promise<AnnotatedEV5Transaction[]> {
     let updateTransactions: AnnotatedEV5Transaction[] = [];
 

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -223,8 +223,8 @@ export class EvmTokenFeeModule extends HyperlaneModule<
 
     // Redeploy immutable fee types, if owner is the same, but the rest of the config is different
     const nonOwnerDiffers = !deepEquals(
-      objOmit(normalizedActualConfig, ['owner']),
-      objOmit(normalizedTargetConfig, ['owner']),
+      objOmit(normalizedActualConfig, { owner: true }),
+      objOmit(normalizedTargetConfig, { owner: true }),
     );
     if (
       ImmutableTokenFeeType.includes(
@@ -253,6 +253,8 @@ export class EvmTokenFeeModule extends HyperlaneModule<
         objMerge(
           actualConfig,
           normalizedTargetConfig,
+          10,
+          true,
         ) as DerivedRoutingFeeConfig,
       )),
       ...this.createOwnershipUpdateTxs(

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
@@ -56,7 +56,9 @@ describe('EvmTokenFeeReader', () => {
       const reader = new EvmTokenFeeReader(multiProvider, TestChainName.test2);
       const tokenFee =
         deployedContracts[TestChainName.test2][TokenFeeType.LinearFee];
-      const onchainConfig = await reader.deriveTokenFeeConfig(tokenFee.address);
+      const onchainConfig = await reader.deriveTokenFeeConfig({
+        address: tokenFee.address,
+      });
       expect(normalizeConfig(onchainConfig)).to.deep.equal(
         normalizeConfig({
           ...config,
@@ -155,10 +157,12 @@ describe('EvmTokenFeeReader', () => {
         multiProvider.getDomainId(TestChainName.test2),
         multiProvider.getDomainId(TestChainName.test3),
       ];
-      const routingFee = await reader.deriveTokenFeeConfig(
-        deployedContracts[TestChainName.test2][TokenFeeType.RoutingFee].address,
-        destinations,
-      );
+      const routingFee = await reader.deriveTokenFeeConfig({
+        address:
+          deployedContracts[TestChainName.test2][TokenFeeType.RoutingFee]
+            .address,
+        routingDestinations: destinations,
+      });
       expect(normalizeConfig(routingFee)).to.deep.equal(
         normalizeConfig(routingFeeConfig),
       );

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.ts
@@ -133,8 +133,8 @@ export class EvmTokenFeeReader extends HyperlaneReader {
         feeContracts[chainName] = await this.deriveTokenFeeConfig({
           address: subFeeAddress,
 
-          // sub routing fees may have different routingDestinations
-          // However, we don't expect sub routing fees
+          // Currently, it's not possible to configure nested routing fees domains,
+          // but we should not expect that to exist
         });
       }),
     );

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.ts
@@ -27,6 +27,11 @@ export type DerivedRoutingFeeConfig = WithAddress<RoutingFeeConfig> & {
   feeContracts: Record<ChainName, DerivedTokenFeeConfig>;
 };
 
+export type ReaderParams = {
+  address: Address;
+  routingDestinations?: number[]; // Required for RoutingFee.feeContracts() interface
+};
+
 const MAX_BPS = 10_000n; // 100% in bps
 export class EvmTokenFeeReader extends HyperlaneReader {
   constructor(
@@ -36,10 +41,9 @@ export class EvmTokenFeeReader extends HyperlaneReader {
     super(multiProvider, chain);
   }
 
-  async deriveTokenFeeConfig(params: {
-    address: Address;
-    routingDestinations?: number[];
-  }): Promise<DerivedTokenFeeConfig> {
+  async deriveTokenFeeConfig(
+    params: ReaderParams,
+  ): Promise<DerivedTokenFeeConfig> {
     const { address, routingDestinations } = params;
     const tokenFee = BaseFee__factory.connect(address, this.provider);
 

--- a/typescript/sdk/src/fee/types.ts
+++ b/typescript/sdk/src/fee/types.ts
@@ -21,6 +21,12 @@ export enum TokenFeeType {
   RoutingFee = 'RoutingFee',
 }
 
+export const ImmutableTokenFeeType = [
+  TokenFeeType.LinearFee,
+  TokenFeeType.RegressiveFee,
+  TokenFeeType.ProgressiveFee,
+] as const;
+
 // Mapping between the on-chain token fee type (uint) and the token fee type (string)
 export const onChainTypeToTokenFeeTypeMap: Record<
   OnchainTokenFeeType,

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -812,6 +812,8 @@ export { getTimelockExecutableTransactionFromBatch } from './timelock/evm/utils.
 
 export {
   TokenFeeType,
+  TokenFeeConfig,
   TokenFeeConfigSchema,
+  TokenFeeConfigInputSchema,
   TokenFeeConfigInput,
 } from './fee/types.js';

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -1,4 +1,10 @@
 export {
+  DerivedRoutingFeeConfig,
+  DerivedTokenFeeConfig,
+  EvmTokenFeeReader,
+} from './fee/EvmTokenFeeReader.js';
+
+export {
   isAddressActive,
   isContractAddress,
   assertIsContractAddress,

--- a/typescript/sdk/src/router/types.ts
+++ b/typescript/sdk/src/router/types.ts
@@ -31,7 +31,7 @@ export type DerivedMailboxClientConfig = MailboxClientConfig & {
 };
 
 export type RouterConfig = z.infer<typeof RouterConfigSchema>;
-export type DerivedRouterConfig = RouterConfig & {
+export type DerivedRouterConfig = Omit<RouterConfig, 'tokenFee'> & {
   tokenFee?: DerivedTokenFeeConfig;
 } & DerivedMailboxClientConfig;
 

--- a/typescript/sdk/src/router/types.ts
+++ b/typescript/sdk/src/router/types.ts
@@ -11,6 +11,7 @@ import { Address, AddressBytes32, isNumeric } from '@hyperlane-xyz/utils';
 import { HyperlaneFactories } from '../contracts/types.js';
 import { UpgradeConfig } from '../deploy/proxy.js';
 import { CheckerViolation } from '../deploy/types.js';
+import { DerivedTokenFeeConfig } from '../fee/EvmTokenFeeReader.js';
 import { TokenFeeConfigInputSchema } from '../fee/types.js';
 import { DerivedHookConfig, HookConfigSchema } from '../hook/types.js';
 import { DerivedIsmConfig, IsmConfigSchema } from '../ism/types.js';
@@ -30,7 +31,9 @@ export type DerivedMailboxClientConfig = MailboxClientConfig & {
 };
 
 export type RouterConfig = z.infer<typeof RouterConfigSchema>;
-export type DerivedRouterConfig = RouterConfig & DerivedMailboxClientConfig;
+export type DerivedRouterConfig = RouterConfig & {
+  tokenFee?: DerivedTokenFeeConfig;
+} & DerivedMailboxClientConfig;
 
 export type GasRouterConfig = z.infer<typeof GasRouterConfigSchema>;
 

--- a/typescript/sdk/src/token/EvmERC20WarpModule.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpModule.ts
@@ -46,7 +46,6 @@ import {
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
 import { ExplorerLicenseType } from '../deploy/verify/types.js';
 import { EvmTokenFeeModule } from '../fee/EvmTokenFeeModule.js';
-import { DerivedTokenFeeConfig } from '../fee/EvmTokenFeeReader.js';
 import { getEvmHookUpdateTransactions } from '../hook/updates.js';
 import { EvmIsmModule } from '../ism/EvmIsmModule.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
@@ -718,9 +717,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     }
 
     // Get the current token fee configuration from the actual config
-    const currentTokenFee = actualConfig.tokenFee as
-      | DerivedTokenFeeConfig
-      | undefined;
+    const currentTokenFee = actualConfig.tokenFee;
 
     // If there's no current token fee but we expect one, we need to deploy
     if (!currentTokenFee) {

--- a/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmERC20WarpRouteReader.ts
@@ -270,7 +270,10 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
       return undefined;
     }
 
-    return this.evmTokenFeeReader.deriveTokenFeeConfig(tokenFee, destinations);
+    return this.evmTokenFeeReader.deriveTokenFeeConfig({
+      address: tokenFee,
+      routingDestinations: destinations,
+    });
   }
 
   async getContractVerificationStatus(chain: ChainName, address: Address) {

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -662,7 +662,8 @@ export class HypERC20Deployer extends TokenDeployer<HypERC20Factories> {
         });
 
         const router = this.router(deployedContractsMap[chain]);
-        const tx = await router.setFeeRecipient(module.getDeployedFeeAddress());
+        const { deployedFee } = module.serialize();
+        const tx = await router.setFeeRecipient(deployedFee);
         await this.multiProvider.handleTx(chain, tx);
       }),
     );

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -650,7 +650,7 @@ export class HypERC20Deployer extends TokenDeployer<HypERC20Factories> {
         }
 
         this.logger.debug(`Deploying token fee on ${chain}...`);
-        const processedTokenFee = await EvmTokenFeeModule.processConfig({
+        const processedTokenFee = await EvmTokenFeeModule.expandConfig({
           config: tokenFeeInput,
           multiProvider: this.multiProvider,
           chainName: chain,

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -313,12 +313,10 @@ function preprocessWarpRouteDeployConfig(
     HypTokenRouterConfigMailboxOptional
   >;
   objMap(mutatedConfig, (_, config) => {
-    if (isCollateralTokenConfig(config)) {
-      populateTokenFeeOwners({
-        tokenConfig: config,
-        feeConfig: config.tokenFee,
-      });
-    }
+    populateTokenFeeOwners({
+      tokenConfig: config,
+      feeConfig: config.tokenFee,
+    });
   });
   return mutatedConfig;
 }

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -312,8 +312,8 @@ function preprocessWarpRouteDeployConfig(
     HypTokenRouterConfigMailboxOptional
   >;
   objMap(mutatedConfig, (_, config) => {
-    // Default token fee owner and token to the router owner and token, if not specified
     if (isCollateralTokenConfig(config) && config.tokenFee) {
+      // Default token fee owner and token to the router owner and token, if not specified
       config.tokenFee = {
         ...config.tokenFee,
         owner: config.tokenFee.owner ?? config.owner,

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -272,9 +272,12 @@ export const HypTokenConfigSchema = z.discriminatedUnion('type', [
 ]);
 export type HypTokenConfig = z.infer<typeof HypTokenConfigSchema>;
 
-export const HypTokenRouterConfigSchema = HypTokenConfigSchema.and(
-  GasRouterConfigSchema,
-).and(HypTokenRouterVirtualConfigSchema.partial());
+export const HypTokenRouterConfigSchema = z.preprocess(
+  preprocessWarpRouteDeployConfig,
+  HypTokenConfigSchema.and(GasRouterConfigSchema).and(
+    HypTokenRouterVirtualConfigSchema.partial(),
+  ),
+);
 
 export type HypTokenRouterConfig = z.infer<typeof HypTokenRouterConfigSchema>;
 
@@ -294,39 +297,40 @@ export function derivedIsmAddress(config: DerivedTokenRouterConfig) {
     : config.interchainSecurityModule.address;
 }
 
-export const HypTokenRouterConfigMailboxOptionalSchema =
+export const HypTokenRouterConfigMailboxOptionalBaseSchema =
   HypTokenConfigSchema.and(
     GasRouterConfigSchema.extend({
       mailbox: z.string().optional(),
     }),
   ).and(HypTokenRouterVirtualConfigSchema.partial());
 
+export type HypTokenRouterConfigMailboxOptionalBase = z.infer<
+  typeof HypTokenRouterConfigMailboxOptionalBaseSchema
+>;
+
+export const HypTokenRouterConfigMailboxOptionalSchema = z.preprocess(
+  preprocessWarpRouteDeployConfig,
+  HypTokenRouterConfigMailboxOptionalBaseSchema,
+);
+
 export type HypTokenRouterConfigMailboxOptional = z.infer<
   typeof HypTokenRouterConfigMailboxOptionalSchema
 >;
 
-function preprocessWarpRouteDeployConfig(
-  value: unknown,
-): Record<string, HypTokenRouterConfigMailboxOptional> {
-  const mutatedConfig = value as Record<
-    string,
-    HypTokenRouterConfigMailboxOptional
-  >;
-  objMap(mutatedConfig, (_, config) => {
-    populateTokenFeeOwners({
-      tokenConfig: config,
-      feeConfig: config.tokenFee,
-    });
+function preprocessWarpRouteDeployConfig(value: unknown) {
+  const mutatedConfig = value as HypTokenRouterConfigMailboxOptionalBase;
+  return populateTokenFeeOwners({
+    tokenConfig: mutatedConfig,
+    feeConfig: mutatedConfig.tokenFee,
   });
-  return mutatedConfig;
 }
 
 function populateTokenFeeOwners(params: {
-  tokenConfig: HypTokenRouterConfigMailboxOptional;
+  tokenConfig: HypTokenRouterConfigMailboxOptionalBase;
   feeConfig?: TokenFeeConfigInput;
 }) {
   const { tokenConfig, feeConfig } = params;
-  if (!feeConfig) return;
+  if (!feeConfig) return tokenConfig;
 
   if (isCollateralTokenConfig(tokenConfig)) {
     // Default fee.token to the router token, if not specified
@@ -344,10 +348,7 @@ function populateTokenFeeOwners(params: {
 }
 
 export const WarpRouteDeployConfigSchema = z
-  .preprocess(
-    preprocessWarpRouteDeployConfig,
-    z.record(HypTokenRouterConfigMailboxOptionalSchema),
-  )
+  .record(HypTokenRouterConfigMailboxOptionalSchema)
   .refine((configMap) => {
     const entries = Object.entries(configMap);
     return (


### PR DESCRIPTION
### Description
This PR implements the update functionality to allow existing warp routes to deploy or update their fees.

- Deploys a new fee if it is immutable (non-routing fees)
- Updating routing sub fees
- Update owners

### Backward compatibility
Yes

### Testing
Manual/Unit Tests



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Manage token fees on Warp routes: add/update Linear/Regressive/Progressive and Routing fees (immutable redeploys), cross-chain routing sub-fees, per-sub-fee and overall ownership transfers, ability to add a token fee where none existed, and Warp updates now include routing destinations.

- **Refactor**
  - Recursive preprocessing and consolidated expand/read/update flows; reader/update APIs moved to parameter-object shapes.

- **Chores**
  - CLI and SDK bumped to minor versions; SDK public exports extended.

- **Tests**
  - Expanded e2e and unit tests covering deploy, read, update, routing, and ownership.

- **Documentation**
  - Added changeset entry documenting release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->