### PR TITLE
fix: docker monorepo build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,3 +24,6 @@ typescript/cosmos-types @troykessler @yjamin
 
 ## CCIP Server
 typescript/ccip-server @Mo-Hussain @nambrot
+
+## Radix
+typescript/radix-sdk @troykessler @yjamin

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY typescript/github-proxy/package.json ./typescript/github-proxy/
 COPY typescript/helloworld/package.json ./typescript/helloworld/
 COPY typescript/http-registry-server/package.json ./typescript/http-registry-server/
 COPY typescript/infra/package.json ./typescript/infra/
+COPY typescript/radix-sdk/package.json ./typescript/radix-sdk/
 COPY typescript/sdk/package.json ./typescript/sdk/
 COPY typescript/tsconfig/package.json ./typescript/tsconfig/
 COPY typescript/utils/package.json ./typescript/utils/


### PR DESCRIPTION
### Description

fix: docker monorepo build

### Drive-by changes

- add radix-sdk pkg codeowners

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated repository ownership rules to include dedicated maintainers for the Radix area, clarifying review responsibilities and accelerating approvals.
  - Refined Docker build steps to ensure dependencies are installed during image creation, improving build determinism and preventing missing-dependency failures in CI and local builds.
  - No functional changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->