### PR TITLE
chore: scale down to only 1 AW validator per chain

### DIFF
--- a/typescript/infra/config/environments/mainnet3/aw-validators/hyperlane.json
+++ b/typescript/infra/config/environments/mainnet3/aw-validators/hyperlane.json
@@ -18,11 +18,7 @@
     "validators": ["0x0531251bbadc1f9f19ccce3ca6b3f79f08eae1be"]
   },
   "arbitrum": {
-    "validators": [
-      "0x4d966438fe9e2b1e7124c87bbb90cb4f0f6c59a1",
-      "0x6333e110b8a261cab28acb43030bcde59f26978a",
-      "0x3369e12edd52570806f126eb50be269ba5e65843"
-    ]
+    "validators": ["0x4d966438fe9e2b1e7124c87bbb90cb4f0f6c59a1"]
   },
   "arbitrumnova": {
     "validators": ["0xd2a5e9123308d187383c87053811a2c21bd8af1f"]
@@ -40,21 +36,13 @@
     "validators": ["0x37105aec3ff37c7bb0abdb0b1d75112e1e69fa86"]
   },
   "avalanche": {
-    "validators": [
-      "0x3fb8263859843bffb02950c492d492cae169f4cf",
-      "0xe58c63ad669b946e7c8211299f22679deecc9c83",
-      "0x6c754f1e9cd8287088b46a7c807303d55d728b49"
-    ]
+    "validators": ["0x3fb8263859843bffb02950c492d492cae169f4cf"]
   },
   "b3": {
     "validators": ["0xd77b516730a836fc41934e7d5864e72c165b934e"]
   },
   "base": {
-    "validators": [
-      "0xb9453d675e0fa3c178a17b4ce1ad5b1a279b3af9",
-      "0x4512985a574cb127b2af2d4bb676876ce804e3f8",
-      "0xb144bb2f599a5af095bc30367856f27ea8a8adc7"
-    ]
+    "validators": ["0xb9453d675e0fa3c178a17b4ce1ad5b1a279b3af9"]
   },
   "berachain": {
     "validators": ["0x0190915c55d9c7555e6d2cb838f04d18b5e2260e"]
@@ -75,11 +63,7 @@
     "validators": ["0xc944176bc4d4e5c7b0598884478a27a2b1904664"]
   },
   "bsc": {
-    "validators": [
-      "0x570af9b7b36568c8877eebba6c6727aa9dab7268",
-      "0x7bf928d5d262365d31d64eaa24755d48c3cae313",
-      "0x03047213365800f065356b4a2fe97c3c3a52296a"
-    ]
+    "validators": ["0x570af9b7b36568c8877eebba6c6727aa9dab7268"]
   },
   "bsquared": {
     "validators": ["0xcadc90933c9fbe843358a4e70e46ad2db78e28aa"]
@@ -88,11 +72,7 @@
     "validators": ["0x6dbc192c06907784fb0af0c0c2d8809ea50ba675"]
   },
   "celo": {
-    "validators": [
-      "0x63478422679303c3e4fc611b771fa4a707ef7f4a",
-      "0x2f4e808744df049d8acc050628f7bdd8265807f9",
-      "0x7bf30afcb6a7d92146d5a910ea4c154fba38d25e"
-    ]
+    "validators": ["0x63478422679303c3e4fc611b771fa4a707ef7f4a"]
   },
   "cheesechain": {
     "validators": ["0x478fb53c6860ae8fc35235ba0d38d49b13128226"]
@@ -122,11 +102,7 @@
     "validators": ["0x28c5b322da06f184ebf68693c5d19df4d4af13e5"]
   },
   "ethereum": {
-    "validators": [
-      "0x03c842db86a6a3e524d4a6615390c1ea8e2b9541",
-      "0x4346776b10f5e0d9995d884b7a1dbaee4e24c016",
-      "0x749d6e7ad949e522c92181dc77f7bbc1c5d71506"
-    ]
+    "validators": ["0x03c842db86a6a3e524d4a6615390c1ea8e2b9541"]
   },
   "everclear": {
     "validators": ["0xeff20ae3d5ab90abb11e882cfce4b92ea6c74837"]
@@ -159,11 +135,7 @@
     "validators": ["0x691dc4e763514df883155df0952f847b539454c0"]
   },
   "gnosis": {
-    "validators": [
-      "0xd4df66a859585678f2ea8357161d896be19cc1ca",
-      "0x06a833508579f8b59d756b3a1e72451fc70840c3",
-      "0xb93a72cee19402553c9dd7fed2461aebd04e2454"
-    ]
+    "validators": ["0xd4df66a859585678f2ea8357161d896be19cc1ca"]
   },
   "gravity": {
     "validators": ["0x23d549bf757a02a6f6068e9363196ecd958c974e"]
@@ -184,11 +156,7 @@
     "validators": ["0xbdda85b19a5efbe09e52a32db1a072f043dd66da"]
   },
   "inevm": {
-    "validators": [
-      "0xf9e35ee88e4448a3673b4676a4e153e3584a08eb",
-      "0xae3e6bb6b3ece1c425aa6f47adc8cb0453c1f9a2",
-      "0xd98c9522cd9d3e3e00bee05ff76c34b91b266ec3"
-    ]
+    "validators": ["0xf9e35ee88e4448a3673b4676a4e153e3584a08eb"]
   },
   "injective": {
     "validators": ["0xbfb8911b72cfb138c7ce517c57d9c691535dc517"]
@@ -221,11 +189,7 @@
     "validators": ["0xb69731640ffd4338a2c9358a935b0274c6463f85"]
   },
   "mantapacific": {
-    "validators": [
-      "0x8e668c97ad76d0e28375275c41ece4972ab8a5bc",
-      "0x80afdde2a81f3fb056fd088a97f0af3722dbc4f3",
-      "0x5dda0c4cf18de3b3ab637f8df82b24921082b54c"
-    ]
+    "validators": ["0x8e668c97ad76d0e28375275c41ece4972ab8a5bc"]
   },
   "mantle": {
     "validators": ["0xf930636c5a1a8bf9302405f72e3af3c96ebe4a52"]
@@ -261,21 +225,13 @@
     "validators": ["0xad5aa33f0d67f6fa258abbe75458ea4908f1dc9f"]
   },
   "moonbeam": {
-    "validators": [
-      "0x2225e2f4e9221049456da93b71d2de41f3b6b2a8",
-      "0x4fe067bb455358e295bfcfb92519a6f9de94b98e",
-      "0xcc4a78aa162482bea43313cd836ba7b560b44fc4"
-    ]
+    "validators": ["0x2225e2f4e9221049456da93b71d2de41f3b6b2a8"]
   },
   "morph": {
     "validators": ["0x4884535f393151ec419add872100d352f71af380"]
   },
   "neutron": {
-    "validators": [
-      "0xa9b8c1f4998f781f958c63cfcd1708d02f004ff0",
-      "0x60e890b34cb44ce3fa52f38684f613f31b47a1a6",
-      "0x7885fae56dbcf5176657f54adbbd881dc6714132"
-    ]
+    "validators": ["0xa9b8c1f4998f781f958c63cfcd1708d02f004ff0"]
   },
   "nibiru": {
     "validators": ["0xba9779d84a8efba1c6bc66326d875c3611a24b24"]
@@ -293,11 +249,7 @@
     "validators": ["0x1bdf52749ef2411ab9c28742dea92f209e96c9c4"]
   },
   "optimism": {
-    "validators": [
-      "0x20349eadc6c72e94ce38268b96692b1a5c20de4f",
-      "0x04d040cee072272789e2d1f29aef73b3ad098db5",
-      "0x779a17e035018396724a6dec8a59bda1b5adf738"
-    ]
+    "validators": ["0x20349eadc6c72e94ce38268b96692b1a5c20de4f"]
   },
   "orderly": {
     "validators": ["0xec3dc91f9fa2ad35edf5842aa764d5573b778bb6"]
@@ -312,18 +264,10 @@
     "validators": ["0x63c9b5ea28710d956a51f0f746ee8df81215663f"]
   },
   "polygon": {
-    "validators": [
-      "0x12ecb319c7f4e8ac5eb5226662aeb8528c5cefac",
-      "0x8dd8f8d34b5ecaa5f66de24b01acd7b8461c3916",
-      "0xdbf3666de031bea43ec35822e8c33b9a9c610322"
-    ]
+    "validators": ["0x12ecb319c7f4e8ac5eb5226662aeb8528c5cefac"]
   },
   "polygonzkevm": {
-    "validators": [
-      "0x86f2a44592bb98da766e880cfd70d3bbb295e61a",
-      "0xc84076030bdabaabb9e61161d833dd84b700afda",
-      "0x6a1da2e0b7ae26aaece1377c0a4dbe25b85fa3ca"
-    ]
+    "validators": ["0x86f2a44592bb98da766e880cfd70d3bbb295e61a"]
   },
   "polynomialfi": {
     "validators": ["0x23d348c2d365040e56f3fee07e6897122915f513"]
@@ -353,11 +297,7 @@
     "validators": ["0xa3e11929317e4a871c3d47445ea7bb8c4976fd8a"]
   },
   "scroll": {
-    "validators": [
-      "0xad557170a9f2f21c35e03de07cb30dcbcc3dff63",
-      "0xb37fe43a9f47b7024c2d5ae22526cc66b5261533",
-      "0x7210fa0a6be39a75cb14d682ebfb37e2b53ecbe5"
-    ]
+    "validators": ["0xad557170a9f2f21c35e03de07cb30dcbcc3dff63"]
   },
   "sei": {
     "validators": ["0x9920d2dbf6c85ffc228fdc2e810bf895732c6aa5"]

--- a/typescript/infra/config/environments/mainnet3/validators.ts
+++ b/typescript/infra/config/environments/mainnet3/validators.ts
@@ -29,11 +29,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('celo'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0x63478422679303c3e4fc611b771fa4a707ef7f4a',
-            '0x2f4e808744df049d8acc050628f7bdd8265807f9',
-            '0x7bf30afcb6a7d92146d5a910ea4c154fba38d25e',
-          ],
+          [Contexts.Hyperlane]: ['0x63478422679303c3e4fc611b771fa4a707ef7f4a'],
           [Contexts.ReleaseCandidate]: [
             '0xb51768c1388e976486a43dbbbbf9ce04cf45e990',
             '0x6325de37b33e20089c091950518a471e29c52883',
@@ -49,11 +45,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('ethereum'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0x03c842db86a6a3e524d4a6615390c1ea8e2b9541',
-            '0x4346776b10f5e0d9995d884b7a1dbaee4e24c016',
-            '0x749d6e7ad949e522c92181dc77f7bbc1c5d71506',
-          ],
+          [Contexts.Hyperlane]: ['0x03c842db86a6a3e524d4a6615390c1ea8e2b9541'],
           [Contexts.ReleaseCandidate]: [
             '0x0580884289890805802012b9872afa5ae41a5fa6',
             '0xa5465cb5095a2e6093587e644d6121d6ed55c632',
@@ -69,11 +61,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('avalanche'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0x3fb8263859843bffb02950c492d492cae169f4cf',
-            '0xe58c63ad669b946e7c8211299f22679deecc9c83',
-            '0x6c754f1e9cd8287088b46a7c807303d55d728b49',
-          ],
+          [Contexts.Hyperlane]: ['0x3fb8263859843bffb02950c492d492cae169f4cf'],
           [Contexts.ReleaseCandidate]: [
             '0x2c7cf6d1796e37676ba95f056ff21bf536c6c2d3',
             '0xcd250d48d16e2ce4b939d44b5215f9e978975152',
@@ -131,11 +119,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('polygon'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0x12ecb319c7f4e8ac5eb5226662aeb8528c5cefac',
-            '0x8dd8f8d34b5ecaa5f66de24b01acd7b8461c3916',
-            '0xdbf3666de031bea43ec35822e8c33b9a9c610322',
-          ],
+          [Contexts.Hyperlane]: ['0x12ecb319c7f4e8ac5eb5226662aeb8528c5cefac'],
           [Contexts.ReleaseCandidate]: [
             '0xf0a990959f833ccde624c8bcd4c7669286a57a0f',
             '0x456b636bdde99d69176261d7a4fba42c16f57f56',
@@ -151,11 +135,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('bsc'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0x570af9b7b36568c8877eebba6c6727aa9dab7268',
-            '0x7bf928d5d262365d31d64eaa24755d48c3cae313',
-            '0x03047213365800f065356b4a2fe97c3c3a52296a',
-          ],
+          [Contexts.Hyperlane]: ['0x570af9b7b36568c8877eebba6c6727aa9dab7268'],
           [Contexts.ReleaseCandidate]: [
             '0x911dfcc19dd5b723e84be452f6af52adef020bc8',
             '0xee2d4fd5fe2170e51c6279552297117feaeb19e1',
@@ -171,11 +151,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('arbitrum'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0x4d966438fe9e2b1e7124c87bbb90cb4f0f6c59a1',
-            '0x6333e110b8a261cab28acb43030bcde59f26978a',
-            '0x3369e12edd52570806f126eb50be269ba5e65843',
-          ],
+          [Contexts.Hyperlane]: ['0x4d966438fe9e2b1e7124c87bbb90cb4f0f6c59a1'],
           [Contexts.ReleaseCandidate]: [
             '0xb4c18167c163391facb345bb069d12d0430a6a89',
             '0x2f6dc057ae079997f76205903b85c8302164a78c',
@@ -191,11 +167,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('optimism'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0x20349eadc6c72e94ce38268b96692b1a5c20de4f',
-            '0x04d040cee072272789e2d1f29aef73b3ad098db5',
-            '0x779a17e035018396724a6dec8a59bda1b5adf738',
-          ],
+          [Contexts.Hyperlane]: ['0x20349eadc6c72e94ce38268b96692b1a5c20de4f'],
           [Contexts.ReleaseCandidate]: [
             '0x7e4391786e0b5b0cbaada12d32c931e46e44f104',
             '0x138ca73e805afa14e85d80f6e35c46e6f235429e',
@@ -223,11 +195,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('moonbeam'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0x2225e2f4e9221049456da93b71d2de41f3b6b2a8',
-            '0x4fe067bb455358e295bfcfb92519a6f9de94b98e',
-            '0xcc4a78aa162482bea43313cd836ba7b560b44fc4',
-          ],
+          [Contexts.Hyperlane]: ['0x2225e2f4e9221049456da93b71d2de41f3b6b2a8'],
           [Contexts.ReleaseCandidate]: [
             '0x75e3cd4e909089ae6c9f3a42b1468b33eec84161',
             '0xc28418d0858a82a46a11e07db75f8bf4eed43881',
@@ -243,11 +211,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('gnosis'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0xd4df66a859585678f2ea8357161d896be19cc1ca',
-            '0x06a833508579f8b59d756b3a1e72451fc70840c3',
-            '0xb93a72cee19402553c9dd7fed2461aebd04e2454',
-          ],
+          [Contexts.Hyperlane]: ['0xd4df66a859585678f2ea8357161d896be19cc1ca'],
           [Contexts.ReleaseCandidate]: [
             '0xd5122daa0c3dfc94a825ae928f3ea138cdb6a2e1',
             '0x2d1f367e942585f8a1c25c742397dc8be9a61dee',
@@ -263,11 +227,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('base'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0xb9453d675e0fa3c178a17b4ce1ad5b1a279b3af9',
-            '0x4512985a574cb127b2af2d4bb676876ce804e3f8',
-            '0xb144bb2f599a5af095bc30367856f27ea8a8adc7',
-          ],
+          [Contexts.Hyperlane]: ['0xb9453d675e0fa3c178a17b4ce1ad5b1a279b3af9'],
           [Contexts.ReleaseCandidate]: [
             '0xa8363570749080c7faa1de714e0782ff444af4cc',
             '0x3b55d9febe02a9038ef8c867fa8bbfdd8d70f9b8',
@@ -309,11 +269,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('inevm'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0xf9e35ee88e4448a3673b4676a4e153e3584a08eb',
-            '0xae3e6bb6b3ece1c425aa6f47adc8cb0453c1f9a2',
-            '0xd98c9522cd9d3e3e00bee05ff76c34b91b266ec3',
-          ],
+          [Contexts.Hyperlane]: ['0xf9e35ee88e4448a3673b4676a4e153e3584a08eb'],
           [Contexts.ReleaseCandidate]: [
             '0x52a0376903294c796c091c785a66c62943d99aa8',
             '0xc2ea1799664f753bedb9872d617e3ebc60b2e0ab',
@@ -383,11 +339,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('scroll'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0xad557170a9f2f21c35e03de07cb30dcbcc3dff63',
-            '0xb37fe43a9f47b7024c2d5ae22526cc66b5261533',
-            '0x7210fa0a6be39a75cb14d682ebfb37e2b53ecbe5',
-          ],
+          [Contexts.Hyperlane]: ['0xad557170a9f2f21c35e03de07cb30dcbcc3dff63'],
           [Contexts.ReleaseCandidate]: [
             '0x11387d89856219cf685f22781bf4e85e00468d54',
             '0x64b98b96ccae6e660ecf373b5dd61bcc34fd19ee',
@@ -439,11 +391,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('polygonzkevm'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0x86f2a44592bb98da766e880cfd70d3bbb295e61a',
-            '0xc84076030bdabaabb9e61161d833dd84b700afda',
-            '0x6a1da2e0b7ae26aaece1377c0a4dbe25b85fa3ca',
-          ],
+          [Contexts.Hyperlane]: ['0x86f2a44592bb98da766e880cfd70d3bbb295e61a'],
           [Contexts.ReleaseCandidate]: [
             '0x75cffb90391d7ecf58a84e9e70c67e7b306211c0',
             '0x82c10acb56f3d7ed6738b61668111a6b5250283e',
@@ -469,11 +417,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('neutron'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0xa9b8c1f4998f781f958c63cfcd1708d02f004ff0',
-            '0x60e890b34cb44ce3fa52f38684f613f31b47a1a6',
-            '0x7885fae56dbcf5176657f54adbbd881dc6714132',
-          ],
+          [Contexts.Hyperlane]: ['0xa9b8c1f4998f781f958c63cfcd1708d02f004ff0'],
           [Contexts.ReleaseCandidate]: [
             '0x307a8fe091b8273c7ce3d277b161b4a2167279b1',
             '0xb825c1bd020cb068f477b320f591b32e26814b5b',
@@ -489,11 +433,7 @@ export const validatorChainConfig = (
       reorgPeriod: getReorgPeriod('mantapacific'),
       validators: validatorsConfig(
         {
-          [Contexts.Hyperlane]: [
-            '0x8e668c97ad76d0e28375275c41ece4972ab8a5bc',
-            '0x80afdde2a81f3fb056fd088a97f0af3722dbc4f3',
-            '0x5dda0c4cf18de3b3ab637f8df82b24921082b54c',
-          ],
+          [Contexts.Hyperlane]: ['0x8e668c97ad76d0e28375275c41ece4972ab8a5bc'],
           [Contexts.ReleaseCandidate]: [
             '0x84fcb05e6e5961df2dfd9f36e8f2b3e87ede7d76',
             '0x45f3e2655a08feda821ee7b495cf2595401e1569',


### PR DESCRIPTION
### Description

chore: scale down legacy AW validators

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

https://linear.app/hyperlane-xyz/issue/ENG-2106/scale-down-to-1-aw-validator-on-all-chains

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
