### PR TITLE
chore(infra): update mitosis getter with new owners

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getMitosisMITOWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getMitosisMITOWarpConfig.ts
@@ -10,15 +10,21 @@ import {
 
 import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';
 
+// TODO: update with new owners once they are updated
 const mitosisOwner = '0x8f51e8e0Ce90CC1B6E60a3E434c7E63DeaD13612';
+const mitosisTimelockOwner = '0x1248163200964459971c7cC9631909132AD28C27';
+const bscTimelockOwner = '0x1248163214D9A0D6F02932A245370D3fD9613A82';
 
 export const getMitosisMITOWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
   const mitosis: HypTokenRouterConfig = {
     ...routerConfig.mitosis,
-    owner: mitosisOwner,
+    owner: mitosisTimelockOwner,
     type: TokenType.native,
+    ownerOverrides: {
+      proxyAdmin: mitosisOwner,
+    },
     hook: {
       type: HookType.AGGREGATION,
       hooks: [
@@ -27,7 +33,7 @@ export const getMitosisMITOWarpConfig = async (
         },
         {
           type: HookType.PAUSABLE,
-          owner: mitosisOwner,
+          owner: mitosisTimelockOwner,
           paused: false,
         },
       ],
@@ -52,7 +58,10 @@ export const getMitosisMITOWarpConfig = async (
 
   const bsc: HypTokenRouterConfig = {
     ...routerConfig.bsc,
-    owner: mitosisOwner,
+    owner: bscTimelockOwner,
+    ownerOverrides: {
+      proxyAdmin: mitosisOwner,
+    },
     type: TokenType.synthetic,
     symbol: 'MITO',
     hook: {
@@ -63,7 +72,7 @@ export const getMitosisMITOWarpConfig = async (
         },
         {
           type: HookType.PAUSABLE,
-          owner: mitosisOwner,
+          owner: bscTimelockOwner,
           paused: false,
         },
       ],


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
Update mitosis getter with new timelock owners
### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
