### PR TITLE
refactor: Add debug log with `std::fs::read` errors for checkpoint and reorg status

### DIFF
--- a/rust/main/hyperlane-base/src/types/local_storage.rs
+++ b/rust/main/hyperlane-base/src/types/local_storage.rs
@@ -85,7 +85,7 @@ impl CheckpointSyncer for LocalStorage {
             Err(error) => {
                 tracing::debug!(
                     ?error,
-                    path = ?checkpoint_file.display(),
+                    path = %checkpoint_file.display(),
                     "Failed to read checkpoint");
                 return Ok(None);
             }
@@ -144,7 +144,7 @@ impl CheckpointSyncer for LocalStorage {
             Err(error) => {
                 tracing::debug!(
                     ?error,
-                    path = ?reorg_flag.display(),
+                    path = %reorg_flag.display(),
                     "Failed to read reorg status");
                 return Ok(None);
             }


### PR DESCRIPTION
It makes it easier to debug configuration/setup issues.

It still maintains current approach of silently ignoring error, and debug level shouldn't be intrusive, as default is the info.

### Description

Debug logs with error information

### Drive-by changes

None


### Backward compatibility

Yes

### Testing

Manual


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Improved robustness of local storage reads for checkpoint and reorg status by explicitly handling read failures.
  - Added detailed debug logging that includes error details and file paths when reads fail to aid diagnostics.
  - On failures, operations now gracefully return no data, preserving existing user-facing behavior.
  - Enhances observability and troubleshooting without impacting normal usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->