### PR TITLE
chore: Pin registries for offchain lookup server values.yaml

### DIFF
--- a/typescript/infra/helm/offchain-lookup-server/values-mainnet.yaml
+++ b/typescript/infra/helm/offchain-lookup-server/values-mainnet.yaml
@@ -28,6 +28,6 @@ env:
   - name: SERVER_PORT
     value: '3000'
   - name: REGISTRY_URI
-    value: 'https://github.com/hyperlane-xyz/hyperlane-registry'
+    value: 'https://github.com/hyperlane-xyz/hyperlane-registry/tree/820e3940782c196d78496e82382b838cee109635'
   - name: SERVER_BASE_URL
     value: 'https://offchain-lookup.services.hyperlane.xyz'

--- a/typescript/infra/helm/offchain-lookup-server/values-testnet.yaml
+++ b/typescript/infra/helm/offchain-lookup-server/values-testnet.yaml
@@ -28,6 +28,6 @@ env:
   - name: SERVER_PORT
     value: '3000'
   - name: REGISTRY_URI
-    value: 'https://github.com/hyperlane-xyz/hyperlane-registry'
+    value: 'https://github.com/hyperlane-xyz/hyperlane-registry/tree/820e3940782c196d78496e82382b838cee109635'
   - name: SERVER_BASE_URL
     value: 'https://testnet-offchain-lookup.services.hyperlane.xyz'


### PR DESCRIPTION
### Description

Pin the registries since the radix protocol type addition broke the server

Also added some runbook instructions as to how to deploy the offchain lookup servers at https://www.notion.so/hyperlanexyz/Runbook-83c755f2652943289cf98cd1309487a8?source=copy_link#2636d35200d68018b196f5dc4945da64


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated configuration to pin the registry source to a specific commit for both mainnet and testnet offchain lookup services. This improves deployment consistency, traceability, and rollback safety by removing ambiguity from external references. Ensures subsequent releases reference an immutable, auditable source, reducing drift across environments and time. No user-facing behavior changes; existing environments continue to operate as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->