### PR TITLE
fix: don't use radix-engine-toolkit for remote transfer

### DIFF
--- a/typescript/radix-sdk/src/utils/base.ts
+++ b/typescript/radix-sdk/src/utils/base.ts
@@ -56,19 +56,22 @@ export class RadixBase {
   public async estimateTransactionFee({
     transactionManifest,
   }: {
-    transactionManifest: TransactionManifest;
+    transactionManifest: TransactionManifest | string;
   }): Promise<{ gasUnits: bigint; gasPrice: number; fee: bigint }> {
     const pk = new PrivateKey.Ed25519(new Uint8Array(utils.randomBytes(32)));
     const constructionMetadata =
       await this.gateway.transaction.innerClient.transactionConstruction();
 
-    const manifest = (
-      await RadixEngineToolkit.Instructions.convert(
-        transactionManifest.instructions,
-        this.networkId,
-        'String',
-      )
-    ).value as string;
+    const manifest =
+      typeof transactionManifest === 'string'
+        ? transactionManifest
+        : ((
+            await RadixEngineToolkit.Instructions.convert(
+              transactionManifest.instructions,
+              this.networkId,
+              'String',
+            )
+          ).value as string);
 
     const response =
       await this.gateway.transaction.innerClient.transactionPreview({

--- a/typescript/radix-sdk/src/warp/tx.ts
+++ b/typescript/radix-sdk/src/warp/tx.ts
@@ -133,38 +133,4 @@ export class RadixWarpTx {
 
     await this.signer.signAndBroadcast(transactionManifest);
   }
-
-  public async remoteTransfer({
-    token,
-    destination_domain,
-    recipient,
-    amount,
-    custom_hook_id,
-    gas_limit,
-    custom_hook_metadata,
-    max_fee,
-  }: {
-    token: string;
-    destination_domain: number;
-    recipient: string;
-    amount: string;
-    custom_hook_id: string;
-    gas_limit: string;
-    custom_hook_metadata: string;
-    max_fee: { denom: string; amount: string };
-  }) {
-    const transactionManifest = await this.populate.remoteTransfer({
-      from_address: this.account.address,
-      token,
-      destination_domain,
-      recipient,
-      amount,
-      custom_hook_id,
-      gas_limit,
-      custom_hook_metadata,
-      max_fee,
-    });
-
-    await this.signer.signAndBroadcast(transactionManifest);
-  }
 }

--- a/typescript/sdk/src/providers/ProviderType.ts
+++ b/typescript/sdk/src/providers/ProviderType.ts
@@ -275,7 +275,7 @@ export interface EthersV5Transaction
 
 export interface RadixSDKTransaction {
   networkId: number;
-  manifest: TransactionManifest;
+  manifest: TransactionManifest | string;
 }
 
 export type AnnotatedEV5Transaction = Annotated<EV5Transaction>;

--- a/typescript/widgets/src/walletIntegrations/radix.ts
+++ b/typescript/widgets/src/walletIntegrations/radix.ts
@@ -2,7 +2,6 @@ import {
   DataRequestBuilder,
   generateRolaChallenge,
 } from '@radixdlt/radix-dapp-toolkit';
-import { RadixEngineToolkit } from '@radixdlt/radix-engine-toolkit';
 import { useCallback, useMemo } from 'react';
 
 import {
@@ -164,14 +163,7 @@ export function useRadixTransactionFns(
       assert(gatewayApi, `gateway api is not defined`);
 
       const transaction = tx.transaction as never as RadixSDKTransaction;
-
-      const transactionManifest = (
-        await RadixEngineToolkit.Instructions.convert(
-          transaction.manifest.instructions,
-          transaction.networkId,
-          'String',
-        )
-      ).value as string;
+      const transactionManifest = transaction.manifest as string;
 
       const transactionResult = await rdt.walletApi.sendTransaction({
         transactionManifest,


### PR DESCRIPTION
### Description
We don't allow `WebAssembly.instantiate` in the `warp-ui/nexus` and `radix-engine-toolkit` uses this, as a result we were unable to sign transactions in production in `nexus`.

This PR removes the usage of `radix-engine-toolkit` for the remote transfer and instead builds the manifest directly as a string.
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
