### PR TITLE
refactor: improve radix state queries

### DIFF
--- a/rust/main/chains/hyperlane-radix/src/indexer/delivery.rs
+++ b/rust/main/chains/hyperlane-radix/src/indexer/delivery.rs
@@ -3,8 +3,7 @@ use std::ops::RangeInclusive;
 use async_trait::async_trait;
 
 use hyperlane_core::{
-    ChainResult, ContractLocator, Indexed, Indexer, LogMeta, ReorgPeriod, SequenceAwareIndexer,
-    H256, H512,
+    ChainResult, ContractLocator, Indexed, Indexer, LogMeta, SequenceAwareIndexer, H256, H512,
 };
 
 use crate::{encode_component_address, parse_process_id_event, ConnectionConf, RadixProvider};

--- a/rust/main/chains/hyperlane-radix/src/indexer/delivery.rs
+++ b/rust/main/chains/hyperlane-radix/src/indexer/delivery.rs
@@ -77,13 +77,9 @@ impl Indexer<H256> for RadixDeliveryIndexer {
 #[async_trait]
 impl SequenceAwareIndexer<H256> for RadixDeliveryIndexer {
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        let state_version = self
+        let (sequence, state_version): (u32, u64) = self
             .provider
-            .get_state_version(Some(&ReorgPeriod::None))
-            .await?;
-        let sequence: u32 = self
-            .provider
-            .call_method(&self.address, "processed", Some(state_version), Vec::new())
+            .call_method(&self.address, "processed", None, Vec::new())
             .await?;
         Ok((Some(sequence), state_version.try_into()?))
     }

--- a/rust/main/chains/hyperlane-radix/src/indexer/dispatch.rs
+++ b/rust/main/chains/hyperlane-radix/src/indexer/dispatch.rs
@@ -77,13 +77,9 @@ impl Indexer<HyperlaneMessage> for RadixDispatchIndexer {
 #[async_trait]
 impl SequenceAwareIndexer<HyperlaneMessage> for RadixDispatchIndexer {
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        let state_version = self
+        let (sequence, state_version): (u32, u64) = self
             .provider
-            .get_state_version(Some(&ReorgPeriod::None))
-            .await?;
-        let sequence: u32 = self
-            .provider
-            .call_method(&self.address, "nonce", Some(state_version), Vec::new())
+            .call_method(&self.address, "nonce", None, Vec::new())
             .await?;
         Ok((Some(sequence), state_version.try_into()?)) // TODO: check u32 bounds
     }

--- a/rust/main/chains/hyperlane-radix/src/indexer/dispatch.rs
+++ b/rust/main/chains/hyperlane-radix/src/indexer/dispatch.rs
@@ -81,6 +81,6 @@ impl SequenceAwareIndexer<HyperlaneMessage> for RadixDispatchIndexer {
             .provider
             .call_method(&self.address, "nonce", None, Vec::new())
             .await?;
-        Ok((Some(sequence), state_version.try_into()?)) // TODO: check u32 bounds
+        Ok((Some(sequence), state_version.try_into()?))
     }
 }

--- a/rust/main/chains/hyperlane-radix/src/indexer/dispatch.rs
+++ b/rust/main/chains/hyperlane-radix/src/indexer/dispatch.rs
@@ -3,7 +3,7 @@ use std::ops::RangeInclusive;
 use async_trait::async_trait;
 
 use hyperlane_core::{
-    ChainResult, ContractLocator, HyperlaneMessage, Indexed, Indexer, LogMeta, ReorgPeriod,
+    ChainResult, ContractLocator, HyperlaneMessage, Indexed, Indexer, LogMeta,
     SequenceAwareIndexer, H512,
 };
 

--- a/rust/main/chains/hyperlane-radix/src/indexer/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-radix/src/indexer/interchain_gas.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use hyperlane_core::{
     ChainResult, ContractLocator, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
     HyperlaneProvider, Indexed, Indexer, InterchainGasPaymaster, InterchainGasPayment, LogMeta,
-    ReorgPeriod, SequenceAwareIndexer, H256, H512,
+    SequenceAwareIndexer, H256, H512,
 };
 
 use crate::{encode_component_address, parse_gas_payment_event, ConnectionConf, RadixProvider};

--- a/rust/main/chains/hyperlane-radix/src/indexer/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-radix/src/indexer/interchain_gas.rs
@@ -103,13 +103,9 @@ impl Indexer<InterchainGasPayment> for RadixInterchainGasIndexer {
 #[async_trait]
 impl SequenceAwareIndexer<InterchainGasPayment> for RadixInterchainGasIndexer {
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        let state_version = self
+        let (sequence, state_version): (u32, u64) = self
             .provider
-            .get_state_version(Some(&ReorgPeriod::None))
-            .await?;
-        let sequence: u32 = self
-            .provider
-            .call_method(&self.address, "sequence", Some(state_version), Vec::new())
+            .call_method(&self.address, "sequence", None, Vec::new())
             .await?;
         Ok((Some(sequence), state_version.try_into()?))
     }

--- a/rust/main/chains/hyperlane-radix/src/ism.rs
+++ b/rust/main/chains/hyperlane-radix/src/ism.rs
@@ -56,9 +56,9 @@ impl InterchainSecurityModule for RadixIsm {
     /// Returns the module type of the ISM compliant with the corresponding
     /// metadata offchain fetching and onchain formatting standard.
     async fn module_type(&self) -> ChainResult<ModuleType> {
-        let types: IsmTypes = self
+        let (types, _) = self
             .provider
-            .call_method(&self.encoded_address, "module_type", None, Vec::new())
+            .call_method::<IsmTypes>(&self.encoded_address, "module_type", None, Vec::new())
             .await?;
 
         let result = match types {
@@ -96,12 +96,7 @@ impl MultisigIsm for RadixIsm {
 
         let (validators, threshold): (Vec<EthAddress>, usize) = self
             .provider
-            .call_method_with_arg(
-                &self.encoded_address,
-                "validators_and_threshold",
-                None,
-                &message,
-            )
+            .call_method_with_arg(&self.encoded_address, "validators_and_threshold", &message)
             .await?;
 
         Ok((
@@ -121,7 +116,7 @@ impl RoutingIsm for RadixIsm {
         let message = message.to_vec();
         let route: ComponentAddress = self
             .provider
-            .call_method_with_arg(&self.encoded_address, "route", None, &message)
+            .call_method_with_arg(&self.encoded_address, "route", &message)
             .await?;
 
         Ok(address_to_h256(route))

--- a/rust/main/chains/hyperlane-radix/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-radix/src/mailbox.rs
@@ -125,24 +125,31 @@ impl Mailbox for RadixMailbox {
     /// - `reorg_period` is how far behind the current block to query, if not specified
     ///   it will query at the latest block.
     async fn count(&self, _reorg_period: &ReorgPeriod) -> ChainResult<u32> {
-        self.provider
-            .call_method(&self.encoded_address, "count", None, Vec::new())
-            .await
+        Ok(self
+            .provider
+            .call_method::<u32>(&self.encoded_address, "count", None, Vec::new())
+            .await?
+            .0)
     }
 
     /// Fetch the status of a message
     async fn delivered(&self, id: H256) -> ChainResult<bool> {
         let id: Bytes32 = id.into();
         self.provider
-            .call_method_with_arg(&self.encoded_address, "delivered", None, &id)
+            .call_method_with_arg(&self.encoded_address, "delivered", &id)
             .await
     }
 
     /// Fetch the current default interchain security module value
     async fn default_ism(&self) -> ChainResult<H256> {
-        let default_ism: Option<ComponentAddress> = self
+        let (default_ism, _) = self
             .provider
-            .call_method(&self.encoded_address, "default_ism", None, Vec::new())
+            .call_method::<Option<ComponentAddress>>(
+                &self.encoded_address,
+                "default_ism",
+                None,
+                Vec::new(),
+            )
             .await?;
         match default_ism {
             Some(ism) => Ok(address_to_h256(ism)),
@@ -156,7 +163,7 @@ impl Mailbox for RadixMailbox {
 
         let default_ism: Option<ComponentAddress> = self
             .provider
-            .call_method_with_arg(&self.encoded_address, "recipient_ism", None, &recipient)
+            .call_method_with_arg(&self.encoded_address, "recipient_ism", &recipient)
             .await?;
         match default_ism {
             Some(ism) => Ok(address_to_h256(ism)),

--- a/rust/main/chains/hyperlane-radix/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-radix/src/mailbox.rs
@@ -161,13 +161,13 @@ impl Mailbox for RadixMailbox {
     async fn recipient_ism(&self, recipient: H256) -> ChainResult<H256> {
         let recipient = address_from_h256(recipient);
 
-        let default_ism: Option<ComponentAddress> = self
+        let recipient_ism: Option<ComponentAddress> = self
             .provider
             .call_method_with_arg(&self.encoded_address, "recipient_ism", &recipient)
             .await?;
-        match default_ism {
+        match recipient_ism {
             Some(ism) => Ok(address_to_h256(ism)),
-            None => Err(HyperlaneRadixError::Other("no default ism present".to_owned()).into()),
+            None => Err(HyperlaneRadixError::Other("no recipient ism present".to_owned()).into()),
         }
     }
 

--- a/rust/main/chains/hyperlane-radix/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-radix/src/mailbox.rs
@@ -124,10 +124,15 @@ impl Mailbox for RadixMailbox {
     ///
     /// - `reorg_period` is how far behind the current block to query, if not specified
     ///   it will query at the latest block.
-    async fn count(&self, _reorg_period: &ReorgPeriod) -> ChainResult<u32> {
+    async fn count(&self, reorg_period: &ReorgPeriod) -> ChainResult<u32> {
         Ok(self
             .provider
-            .call_method::<u32>(&self.encoded_address, "count", None, Vec::new())
+            .call_method::<u32>(
+                &self.encoded_address,
+                "count",
+                Some(reorg_period),
+                Vec::new(),
+            )
             .await?
             .0)
     }

--- a/rust/main/chains/hyperlane-radix/src/provider/radix.rs
+++ b/rust/main/chains/hyperlane-radix/src/provider/radix.rs
@@ -218,8 +218,7 @@ impl RadixProvider {
             .await
     }
 
-    /// Calls a method on a component
-    /// if specified will use the passed state_version
+    /// Calls a method with arguments on a component
     pub async fn call_method_with_arg<T: ScryptoSbor, A: ManifestEncode + ?Sized>(
         &self,
         component: &str,

--- a/rust/main/chains/hyperlane-radix/src/validator_announce.rs
+++ b/rust/main/chains/hyperlane-radix/src/validator_announce.rs
@@ -67,7 +67,6 @@ impl ValidatorAnnounce for RadixValidatorAnnounce {
             .call_method_with_arg(
                 &self.encoded_address,
                 "get_announced_storage_locations",
-                None,
                 &eth_addresses,
             )
             .await?;


### PR DESCRIPTION
### Description
Don't query at specific state versions if the reorg_period is configured to be zero.
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Consolidated multiple RPC interactions into single state-aware calls across indexing, mailbox, ISM, merkle, and validator flows, reducing awaits and simplifying response handling while preserving external behavior.

- Documentation
  - Updated provider docs to describe state/version-aware call semantics and typed return shapes.

- Chores
  - Added internal, state-aware provider helpers and streamlined argument passing; public-facing APIs remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->