### PR TITLE
fix: token isFungibleWith now checks for isHypNative

### DIFF
--- a/.changeset/four-olives-allow.md
+++ b/.changeset/four-olives-allow.md
@@ -1,0 +1,6 @@
+---
+"@hyperlane-xyz/sdk": patch
+"@hyperlane-xyz/widgets": patch
+---
+
+now token.isFungibleWith() will also check for isHypNative() tokens

--- a/typescript/sdk/src/token/Token.test.ts
+++ b/typescript/sdk/src/token/Token.test.ts
@@ -279,4 +279,128 @@ describe('Token', () => {
       sandbox.restore();
     });
   }
+
+  describe('isFungibleWith', () => {
+    const evmNativeToken = Token.FromChainMetadataNativeToken(test1);
+
+    const evmHypNativeToken = new Token({
+      chainName: TestChainName.test1,
+      standard: TokenStandard.EvmHypNative,
+      addressOrDenom: '0x26f32245fCF5Ad53159E875d5Cae62aEcf19c2d4',
+      decimals: 18,
+      symbol: 'ETH',
+      name: 'Ether',
+    });
+
+    const evmHypCollateralNativeToken2 = new Token({
+      chainName: TestChainName.test1,
+      standard: TokenStandard.EvmHypNative,
+      addressOrDenom: '0x41b5234A896FbC4b3e2F7237592D054716762131',
+      decimals: 18,
+      symbol: 'ETH',
+      name: 'Ether',
+    });
+
+    const evmHypCollateralToken = new Token({
+      chainName: TestChainName.test1,
+      standard: TokenStandard.EvmHypCollateral,
+      addressOrDenom: '0x31b5234A896FbC4b3e2F7237592D054716762131',
+      collateralAddressOrDenom: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      decimals: 6,
+      symbol: 'USDC',
+      name: 'USD Coin',
+    });
+
+    const evmHypSyntheticToken = new Token({
+      chainName: TestChainName.test1,
+      standard: TokenStandard.EvmHypSynthetic,
+      addressOrDenom: '0x8358D8291e3bEDb04804975eEa0fe9fe0fAfB147',
+      decimals: 6,
+      symbol: 'USDC',
+      name: 'USD Coin',
+    });
+
+    const cosmosIbcToken = new Token({
+      chainName: testCosmosChain.name,
+      standard: TokenStandard.CosmosIbc,
+      addressOrDenom:
+        'ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7',
+      decimals: 6,
+      symbol: 'TIA',
+      name: 'TIA',
+    });
+
+    const cosmosNativeToken = new Token({
+      chainName: testCosmosChain.name,
+      standard: TokenStandard.CosmosNative,
+      addressOrDenom:
+        'ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7',
+      decimals: 6,
+      symbol: 'TIA',
+      name: 'TIA',
+    });
+
+    it('returns false for undefined token', () => {
+      expect(evmHypCollateralToken.isFungibleWith(undefined)).to.be.false;
+    });
+
+    it('returns false for tokens on different chains', () => {
+      const differentChainToken = new Token({
+        chainName: TestChainName.test2,
+        standard: TokenStandard.ERC20,
+        addressOrDenom: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        decimals: 6,
+        symbol: 'USDC',
+        name: 'USD Coin',
+      });
+      expect(evmHypCollateralToken.isFungibleWith(differentChainToken)).to.be
+        .false;
+    });
+
+    it('returns true for identical tokens', () => {
+      expect(evmHypCollateralToken.isFungibleWith(evmHypCollateralToken)).to.be
+        .true;
+    });
+
+    it('returns false for collateralized token and non-matching token', () => {
+      expect(evmHypCollateralToken.isFungibleWith(evmHypSyntheticToken)).to.be
+        .false;
+    });
+
+    it('returns false for non-IBC tokens with different standards', () => {
+      expect(evmHypCollateralToken.isFungibleWith(cosmosNativeToken)).to.be
+        .false;
+    });
+
+    it('returns false for HypNative token and different token standards', () => {
+      expect(evmHypNativeToken.isFungibleWith(evmHypCollateralToken)).to.be
+        .false;
+    });
+
+    it('returns true for collateralized token without collateral address and native token', () => {
+      expect(evmHypCollateralNativeToken2.isFungibleWith(evmNativeToken)).to.be
+        .true;
+    });
+
+    it('returns true for collateralized token without collateral address and HypNative token', () => {
+      expect(evmHypCollateralNativeToken2.isFungibleWith(evmHypNativeToken)).to
+        .be.true;
+    });
+
+    it('returns true for IBC token and matching native token', () => {
+      expect(cosmosIbcToken.isFungibleWith(cosmosNativeToken)).to.be.true;
+    });
+
+    it('returns false for IBC token and non-matching native token', () => {
+      const nonMatchingNativeToken = new Token({
+        chainName: testCosmosChain.name,
+        standard: TokenStandard.CosmosNative,
+        addressOrDenom: 'different_denom',
+        decimals: 6,
+        symbol: 'OTHER',
+        name: 'Other Token',
+      });
+      expect(cosmosIbcToken.isFungibleWith(nonMatchingNativeToken)).to.be.false;
+    });
+  });
 });

--- a/typescript/sdk/src/token/Token.test.ts
+++ b/typescript/sdk/src/token/Token.test.ts
@@ -292,7 +292,7 @@ describe('Token', () => {
       name: 'Ether',
     });
 
-    const evmHypCollateralNativeToken2 = new Token({
+    const evmHypNativeToken2 = new Token({
       chainName: TestChainName.test1,
       standard: TokenStandard.EvmHypNative,
       addressOrDenom: '0x41b5234A896FbC4b3e2F7237592D054716762131',
@@ -378,13 +378,11 @@ describe('Token', () => {
     });
 
     it('returns true for collateralized token without collateral address and native token', () => {
-      expect(evmHypCollateralNativeToken2.isFungibleWith(evmNativeToken)).to.be
-        .true;
+      expect(evmHypNativeToken2.isFungibleWith(evmNativeToken)).to.be.true;
     });
 
     it('returns true for collateralized token without collateral address and HypNative token', () => {
-      expect(evmHypCollateralNativeToken2.isFungibleWith(evmHypNativeToken)).to
-        .be.true;
+      expect(evmHypNativeToken2.isFungibleWith(evmHypNativeToken)).to.be.true;
     });
 
     it('returns true for IBC token and matching native token', () => {

--- a/typescript/sdk/src/token/Token.ts
+++ b/typescript/sdk/src/token/Token.ts
@@ -493,7 +493,10 @@ export class Token implements IToken {
         return true;
       }
 
-      if (!this.collateralAddressOrDenom && token.isNative()) {
+      if (
+        !this.collateralAddressOrDenom &&
+        (token.isNative() || token.isHypNative())
+      ) {
         return true;
       }
     }


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
fix `Token` class `isFungibleWith()` not accounting for `HypNative` tokens as natives 

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->
Yes
### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fungibility checks now treat HypNative tokens like native tokens, reducing incorrect “non-fungible” results and improving token matching across chains.

* **Tests**
  * Added comprehensive tests validating fungibility across EVM/Cosmos token types and multiple scenarios.

* **Chores**
  * Published patch releases for @hyperlane-xyz/sdk and @hyperlane-xyz/widgets with a backward-compatible behavioral update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->