### PR TITLE
fix: Denylist StarkNet<>StarkNet messages

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -800,6 +800,11 @@ const blacklist: MatchingList = [
       '0x867c1fd9341DEC12e4B779C35D7b7C475316b334',
     ],
   },
+  // StarkNet<>StarkNet messages
+  {
+    originDomain: getDomainId('starknet'),
+    destinationDomain: getDomainId('starknet'),
+  },
 ];
 
 const ismCacheConfigs: Array<IsmCacheConfig> = [


### PR DESCRIPTION
### Description

We see StarkNet<>StarkNet messages pending, but we don't support delivery from origin chain to the same chain at the moment.

### Backward compatibility

Yes

### Testing

Manual in RC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Enforced blocking of StarkNet-to-StarkNet messages on mainnet3 by adding a blacklist rule. Attempts to send messages within StarkNet are now rejected.
- Chores
  - Updated mainnet3 environment configuration to include the new StarkNet-to-StarkNet blacklist entry, ensuring consistent handling of intra-StarkNet messages across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->