### PR TITLE
feat: support HypNative router rebalancing

### DIFF
--- a/.changeset/modern-snails-drum.md
+++ b/.changeset/modern-snails-drum.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": minor
+---
+
+Add getBridgedSupply to EvmHypNativeAdapter to return the native token balance as collateral

--- a/.changeset/ninety-queens-clean.md
+++ b/.changeset/ninety-queens-clean.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/cli": minor
+---
+
+Dont check for token collateralAddressOrDenom to enable HypNative router collateral balance reads

--- a/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
+++ b/typescript/cli/src/rebalancer/factories/RebalancerContextFactory.ts
@@ -180,7 +180,6 @@ export class RebalancerContextFactory {
       this.warpCore.tokens.map(async (token) => {
         if (
           isCollateralizedTokenEligibleForRebalancing(token) &&
-          token.collateralAddressOrDenom &&
           chainNames.has(token.chainName)
         ) {
           const adapter = token.getHypAdapter(this.warpCore.multiProvider);

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -832,6 +832,11 @@ export class EvmHypNativeAdapter
       },
     );
   }
+
+  override async getBridgedSupply(): Promise<bigint | undefined> {
+    const balance = await this.getProvider().getBalance(this.addresses.token);
+    return BigInt(balance.toString());
+  }
 }
 
 export class EvmXERC20Adapter


### PR DESCRIPTION
### Description

- Support rebalancing of `HypNative` routers
- Don't check for token collateralAddressOrDenom being defined, this won't be defined for `HypNative` routers but we still want to check for is balance. `isCollateralizedTokenEligibleForRebalancing` will ensure that we don't include synthetic balances
- Add `getBridgedSupply` to `EvmHypNativeAdapter` to return the native token balance, this will be treated as effective collateral 

### Testing

Manual


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enables bridged supply reporting for native tokens by reading on-chain balances.
  - Rebalancer now considers eligible tokens without requiring a collateral address/denom, improving coverage for HypNative tokens.
  - CLI updated to allow collateral balance reads for HypNative routers without a collateral address/denom check.

- Chores
  - Prepared minor version bumps for SDK and CLI via changesets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->