### PR TITLE
fix: cosmos native warp deploy

### DIFF
--- a/typescript/sdk/src/token/cosmosnativeDeploy.ts
+++ b/typescript/sdk/src/token/cosmosnativeDeploy.ts
@@ -5,6 +5,7 @@ import {
   Address,
   ProtocolType,
   assert,
+  eqAddress,
   objFilter,
   objMap,
   rootLogger,
@@ -74,6 +75,28 @@ export class CosmosNativeDeployer {
             `Token type ${config.type} not supported on chain ${chain}`,
           );
         }
+      }
+
+      if (config.interchainSecurityModule) {
+        this.logger.info(`Set ISM for token`);
+
+        await this.signersMap[chain].setToken({
+          token_id: result[chain],
+          new_owner: '',
+          ism_id: config.interchainSecurityModule,
+          renounce_ownership: false,
+        });
+      }
+
+      if (!eqAddress(this.signersMap[chain].account.address, config.owner)) {
+        this.logger.info(`Set new owner for token`);
+
+        await this.signersMap[chain].setToken({
+          token_id: result[chain],
+          new_owner: config.owner,
+          ism_id: config.interchainSecurityModule,
+          renounce_ownership: false,
+        });
       }
 
       this.logger.info(`Successfully deployed contracts on ${chain}`);


### PR DESCRIPTION
### Description

This PR fixes an issue where the Token ISM and Owner is not properly set after initially deploying a token to cosmos native

### Drive-by changes

-

### Related issues

-

### Backward compatibility

-

### Testing

Manual Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tokens deployed on Cosmos-native chains now automatically apply the configured interchain security module, reducing manual configuration.
  - Post-deployment ownership is automatically aligned with the configured owner when different, ensuring proper control without extra steps.
  - Deployment logs are clearer, indicating when the security module and ownership are set, improving visibility during rollout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->