### PR TITLE
feat: radix lander, add support for delivered_calldata and reverted_payloads

### DIFF
--- a/rust/main/chains/hyperlane-radix/src/lib.rs
+++ b/rust/main/chains/hyperlane-radix/src/lib.rs
@@ -24,7 +24,7 @@ pub use {
     config::ConnectionConf,
     error::HyperlaneRadixError,
     ism::RadixIsm,
-    mailbox::RadixMailbox,
+    mailbox::{DeliveredCalldata, RadixMailbox},
     provider::{RadixProvider, RadixProviderForLander},
     signer::RadixSigner,
     validator_announce::RadixValidatorAnnounce,

--- a/rust/main/chains/hyperlane-radix/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-radix/src/mailbox.rs
@@ -5,13 +5,17 @@ use core_api_client::models::{FeeSummary, TransactionStatus};
 use radix_common::manifest_args;
 use radix_common::prelude::ManifestArgs;
 use regex::Regex;
-use scrypto::{address::AddressBech32Decoder, network::NetworkDefinition, types::ComponentAddress};
+use scrypto::{
+    address::AddressBech32Decoder, network::NetworkDefinition, prelude::manifest_encode,
+    types::ComponentAddress,
+};
 
 use hyperlane_core::{
     ChainCommunicationError, ChainResult, ContractLocator, Encode, FixedPointNumber,
     HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneMessage, HyperlaneProvider,
     Mailbox, ReorgPeriod, TxCostEstimate, TxOutcome, H256, U256,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::{
     address_from_h256, address_to_h256, encode_component_address, Bytes32, ConnectionConf,
@@ -238,7 +242,26 @@ impl Mailbox for RadixMailbox {
         todo!() // we dont need this for now
     }
 
-    fn delivered_calldata(&self, _message_id: H256) -> ChainResult<Option<Vec<u8>>> {
-        todo!()
+    /// Data required to make a TransactionCallPreviewRequest to
+    /// check if a message was delivered or not on-chain.
+    fn delivered_calldata(&self, message_id: H256) -> ChainResult<Option<Vec<u8>>> {
+        let id: Bytes32 = message_id.into();
+        let encoded_arguments = manifest_encode(&id).map_err(HyperlaneRadixError::from)?;
+
+        let calldata = DeliveredCalldata {
+            component_address: self.encoded_address.clone(),
+            method_name: "delivered".into(),
+            encoded_arguments,
+        };
+        let json_val = serde_json::to_vec(&calldata)
+            .map_err(|err| ChainCommunicationError::JsonParseError(err))?;
+        Ok(Some(json_val))
     }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DeliveredCalldata {
+    pub component_address: String,
+    pub method_name: String,
+    pub encoded_arguments: Vec<u8>,
 }

--- a/rust/main/chains/hyperlane-radix/src/provider/lander.rs
+++ b/rust/main/chains/hyperlane-radix/src/provider/lander.rs
@@ -1,18 +1,31 @@
 use gateway_api_client::models::TransactionStatusResponse;
 use hyperlane_core::{ChainResult, H512};
 
-use crate::RadixProvider;
+use crate::{DeliveredCalldata, RadixProvider};
 
 /// Trait used by lander
 #[async_trait::async_trait]
 pub trait RadixProviderForLander: Send + Sync {
     /// Get the status of a radix transaction
     async fn get_tx_hash_status(&self, hash: H512) -> ChainResult<TransactionStatusResponse>;
+    /// Check preview call
+    async fn check_preview(&self, params: &DeliveredCalldata) -> ChainResult<bool>;
 }
 
 #[async_trait::async_trait]
 impl RadixProviderForLander for RadixProvider {
     async fn get_tx_hash_status(&self, hash: H512) -> ChainResult<TransactionStatusResponse> {
         self.get_tx_status(hash).await
+    }
+    async fn check_preview(&self, params: &DeliveredCalldata) -> ChainResult<bool> {
+        let resp = self
+            .call_method::<bool>(
+                &params.component_address,
+                &params.method_name,
+                None,
+                vec![params.encoded_arguments.clone()],
+            )
+            .await?;
+        Ok(resp.0)
     }
 }

--- a/rust/main/lander/src/adapter/chains/radix.rs
+++ b/rust/main/lander/src/adapter/chains/radix.rs
@@ -1,1 +1,2 @@
 pub mod adapter;
+pub mod precursor;

--- a/rust/main/lander/src/adapter/chains/radix/precursor.rs
+++ b/rust/main/lander/src/adapter/chains/radix/precursor.rs
@@ -1,0 +1,2 @@
+#[derive(Clone, Debug)]
+pub struct RadixTxPrecursor {}


### PR DESCRIPTION
### Description

- implement RadixMailbox::delivered_calladata
- implement AdaptsChain::reverted_payloads for RadixAdapter

### Related issues

- fixes https://linear.app/hyperlane-xyz/issue/ENG-2245/radix-lander-implement-mailboxdelivered-calldata-and-reverted-payloads
