### PR TITLE
fix: Add provider host to logging

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
@@ -146,8 +146,8 @@ where
             // future which visits all providers as they fulfill their requests
             let mut unordered = self.populate_unordered_future(method, &params);
 
-            while let Some(resp) = unordered.next().await {
-                let value = match categorize_client_response(method, resp) {
+            while let Some((provider_host, resp)) = unordered.next().await {
+                let value = match categorize_client_response(provider_host.as_str(), method, resp) {
                     IsOk(v) => serde_json::from_value(v)?,
                     RetryableErr(e) | RateLimitErr(e) => {
                         retryable_errors.push(e.into());
@@ -202,7 +202,7 @@ where
             for (idx, priority) in priorities_snapshot.iter().enumerate() {
                 let provider = &self.inner.providers[priority.index];
                 let fut = Self::provider_request(provider, method, &params);
-                let resp = fut.await;
+                let (provider_host, resp) = fut.await;
                 self.handle_stalled_provider(priority, provider).await;
                 if resp.is_err() {
                     self.handle_failed_provider(priority).await;
@@ -210,11 +210,12 @@ where
                 tracing::debug!(
                     fallback_count = idx,
                     provider_index = priority.index,
+                    provider_host = provider_host.as_str(),
                     method,
                     "fallback_request"
                 );
 
-                match categorize_client_response(method, resp) {
+                match categorize_client_response(provider_host.as_str(), method, resp) {
                     IsOk(v) => return Ok(serde_json::from_value(v)?),
                     RetryableErr(e) | RateLimitErr(e) => errors.push(e.into()),
                     NonRetryableErr(e) => return Err(e.into()),
@@ -229,18 +230,22 @@ where
         provider: &'a C,
         method: &'a str,
         params: &'a Value,
-    ) -> Result<Value, HttpClientError> {
-        match params {
+    ) -> (String, Result<Value, HttpClientError>) {
+        let provider_host = provider.node_host().to_owned();
+        let result = match params {
             Value::Null => provider.request(method, ()).await,
             _ => provider.request(method, params).await,
-        }
+        };
+
+        (provider_host, result)
     }
 
     fn populate_unordered_future<'a>(
         &'a self,
         method: &'a str,
         params: &'a Value,
-    ) -> FuturesUnordered<impl Future<Output = Result<Value, HttpClientError>> + Sized + 'a> {
+    ) -> FuturesUnordered<impl Future<Output = (String, Result<Value, HttpClientError>)> + Sized + 'a>
+    {
         let unordered = FuturesUnordered::new();
         self.inner
             .providers

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/tests.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/tests.rs
@@ -74,7 +74,7 @@ impl JsonRpcClient for EthereumProviderMock {
 
 impl PrometheusConfigExt for EthereumProviderMock {
     fn node_host(&self) -> &str {
-        todo!()
+        "test_provider_host"
     }
 
     fn chain_name(&self) -> &str {

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/retrying.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/retrying.rs
@@ -189,7 +189,8 @@ impl JsonRpcClient for RetryingProvider<PrometheusJsonRpcClient<Http>> {
             )
             .entered();
 
-            match categorize_client_response(method, res) {
+            let provider_host = self.inner.node_host();
+            match categorize_client_response(provider_host, method, res) {
                 IsOk(res) => Accept(res),
                 RetryableErr(e) => Retry(e),
                 RateLimitErr(e) => RateLimitedRetry(e),


### PR DESCRIPTION
### Description

Add provider host to logging so that we can see what provider returned an error on multicast.

### Backward compatibility

Yes

### Testing

Manual