### PR TITLE
fix: Use per destination fees for Everclear bridge

### DIFF
--- a/solidity/contracts/token/bridge/EverclearEthBridge.sol
+++ b/solidity/contracts/token/bridge/EverclearEthBridge.sol
@@ -74,7 +74,7 @@ contract EverclearEthBridge is EverclearTokenBridge {
         quotes[0] = Quote({
             token: address(0),
             amount: _amount +
-                feeParams.fee +
+                feeParams[_destination].fee +
                 _quoteGasPayment(_destination, _recipient, _amount)
         });
     }
@@ -124,7 +124,7 @@ contract EverclearEthBridge is EverclearTokenBridge {
     ) internal virtual override returns (uint256 dispatchValue) {
         uint256 fee = _feeAmount(_destination, _recipient, _amount);
 
-        uint256 totalAmount = _amount + fee + feeParams.fee;
+        uint256 totalAmount = _amount + fee + feeParams[_destination].fee;
         _transferFromSender(totalAmount);
         dispatchValue = msg.value - totalAmount;
         if (fee > 0) {

--- a/solidity/contracts/token/bridge/EverclearTokenBridge.sol
+++ b/solidity/contracts/token/bridge/EverclearTokenBridge.sol
@@ -11,7 +11,6 @@ import {PackageVersioned} from "../../PackageVersioned.sol";
 import {IWETH} from "../interfaces/IWETH.sol";
 import {TokenMessage} from "../libs/TokenMessage.sol";
 import {TypeCasts} from "../../libs/TypeCasts.sol";
-import {FungibleTokenRouter} from "../libs/FungibleTokenRouter.sol";
 
 /**
  * @notice Information about an output asset for a destination domain
@@ -34,9 +33,19 @@ contract EverclearTokenBridge is HypERC20Collateral {
     using TypeCasts for bytes32;
     using SafeERC20 for IERC20;
 
+    /// @notice Parameters for creating an Everclear intent
+    /// @dev This is used to avoid stack too deep errors
+    struct IntentParams {
+        bytes32 receiver;
+        address inputAsset;
+        bytes32 outputAsset;
+        uint256 amount;
+        IEverclearAdapter.FeeParams feeParams;
+    }
+
     /// @notice The output asset for a given destination domain
     /// @dev Everclear needs to know the output asset address to create intents for cross-chain transfers
-    mapping(uint32 destination => bytes32 outputAssets) public outputAssets;
+    mapping(uint32 destination => bytes32 outputAsset) public outputAssets;
 
     /// @notice Whether an intent has been settled
     /// @dev This is used to prevent funds from being sent to a recipient that has already received them
@@ -44,7 +53,8 @@ contract EverclearTokenBridge is HypERC20Collateral {
 
     /// @notice Fee parameters for the bridge operations
     /// @dev The signatures are produced by Everclear and stored here for re-use. We use the same fee for all transfers to all destinations
-    IEverclearAdapter.FeeParams public feeParams;
+    mapping(uint32 destination => IEverclearAdapter.FeeParams feeParams)
+        public feeParams;
 
     /// @notice The Everclear adapter contract interface
     /// @dev Immutable reference to the Everclear adapter used for creating intents
@@ -58,7 +68,7 @@ contract EverclearTokenBridge is HypERC20Collateral {
      * @param fee The new fee amount
      * @param deadline The new deadline timestamp for fee validity
      */
-    event FeeParamsUpdated(uint256 fee, uint256 deadline);
+    event FeeParamsUpdated(uint32 destination, uint256 fee, uint256 deadline);
 
     /**
      * @notice Emitted when an output asset is configured for a destination
@@ -103,16 +113,17 @@ contract EverclearTokenBridge is HypERC20Collateral {
      * @param _sig The signature for fee validation from Everclear
      */
     function setFeeParams(
+        uint32 _destination,
         uint256 _fee,
         uint256 _deadline,
         bytes calldata _sig
     ) external onlyOwner {
-        feeParams = IEverclearAdapter.FeeParams({
+        feeParams[_destination] = IEverclearAdapter.FeeParams({
             fee: _fee,
             deadline: _deadline,
             sig: _sig
         });
-        emit FeeParamsUpdated(_fee, _deadline);
+        emit FeeParamsUpdated(_destination, _fee, _deadline);
     }
 
     /**
@@ -179,7 +190,7 @@ contract EverclearTokenBridge is HypERC20Collateral {
         });
         quotes[1] = Quote({
             token: address(wrappedToken),
-            amount: _amount + feeParams.fee
+            amount: _amount + feeParams[_destination].fee
         });
     }
 
@@ -200,22 +211,35 @@ contract EverclearTokenBridge is HypERC20Collateral {
             outputAssets[_destination] != bytes32(0),
             "ETB: Output asset not set"
         );
+        require(
+            feeParams[_destination].sig.length > 0,
+            "ETB: Fee params not set"
+        );
 
         // Create everclear intent
         uint32[] memory destinations = new uint32[](1);
         destinations[0] = _destination;
 
         // Create intent
+        // Packing the intent params in a struct to avoid stack too deep errors
+        IntentParams memory intentParams = IntentParams({
+            feeParams: feeParams[_destination],
+            receiver: _getReceiver(_destination, _recipient),
+            inputAsset: address(wrappedToken),
+            outputAsset: outputAssets[_destination],
+            amount: _amount
+        });
+
         (, IEverclear.Intent memory intent) = everclearAdapter.newIntent({
             _destinations: destinations,
-            _receiver: _getReceiver(_destination, _recipient),
-            _inputAsset: address(wrappedToken),
-            _outputAsset: outputAssets[_destination], // We load this from storage again to avoid stack too deep
-            _amount: _amount,
+            _receiver: intentParams.receiver,
+            _inputAsset: intentParams.inputAsset,
+            _outputAsset: intentParams.outputAsset,
+            _amount: intentParams.amount,
             _maxFee: 0,
             _ttl: 0,
             _data: "",
-            _feeParams: feeParams
+            _feeParams: intentParams.feeParams
         });
 
         return intent;
@@ -253,7 +277,7 @@ contract EverclearTokenBridge is HypERC20Collateral {
             super._chargeSender(
                 _destination,
                 _recipient,
-                _amount + feeParams.fee
+                _amount + feeParams[_destination].fee
             );
     }
 

--- a/solidity/foundry.toml
+++ b/solidity/foundry.toml
@@ -8,7 +8,6 @@ cache_path = 'forge-cache'
 allow_paths = ["../node_modules"]
 solc_version = '0.8.22'
 evm_version= 'paris'
-# optimizer = true
 optimizer_runs = 999_999
 fs_permissions = [
     { access = "read", path = "./script/avs/"},

--- a/solidity/script/EverclearTokenBridge.s.sol
+++ b/solidity/script/EverclearTokenBridge.s.sol
@@ -38,6 +38,7 @@ contract EverclearTokenBridgeScript is Script {
 
         // Set the fee params for the bridge.
         bridge.setFeeParams(
+            10, // destination domain
             1000000000000,
             1751851366,
             hex"4edddfdeabc459e3e9df4bc6807698e26443a663b3905c9b5d0f1054b4831b4616e89ff702f57e13d650331f11986ebe925ce497621b7f488c4672189b49b8e11c"
@@ -50,7 +51,7 @@ contract EverclearTokenBridgeScript is Script {
         EverclearTokenBridge bridge = _getBridge();
 
         // Convert some eth to weth
-        (uint256 fee, , ) = bridge.feeParams();
+        (uint256 fee, , ) = bridge.feeParams(10); // destination domain 10 (Optimism)
         uint256 amount = 0.0001 ether;
         uint256 totalAmount = amount + fee + 1;
         IWETH weth = IWETH(0x82aF49447D8a07e3bd95BD0d56f35241523fBab1);


### PR DESCRIPTION
### Description

Fees are determined by `(asset, origin, destination)`, not `(asset, origin)`.


### Related issues
Fixes https://linear.app/hyperlane-xyz/issue/ENG-2255/handle-multiple-fees-in-evercleartokenbridge

### Backward compatibility

No

### Testing

Forge