### PR TITLE
fix(ci): build before gitleaks in infra-test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,13 +245,11 @@ jobs:
 
       - name: yarn-build
         uses: ./.github/actions/yarn-build-with-cache
-        if: env.BALANCE_CHANGES == 'true' || env.WARP_CONFIG_CHANGES == 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           cache-provider: github
 
       - name: Checkout registry
-        if: env.BALANCE_CHANGES == 'true' || env.WARP_CONFIG_CHANGES == 'true'
         uses: ./.github/actions/checkout-registry
 
       - name: GitLeaks Tests


### PR DESCRIPTION
### Description

fix(ci): build before gitleaks in infra-test

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to always run the build and registry checkout steps, removing conditional gating tied to specific environment variables. This ensures consistent execution across all runs and reduces the risk of skipped builds due to unset or mismatched conditions.
  * No user-facing changes; application features and behavior remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->