### PR TITLE
fix: lint for msg.value in internal functions

### DIFF
--- a/solhint-plugin/index.js
+++ b/solhint-plugin/index.js
@@ -21,4 +21,28 @@ class NoVirtualOverrideAllowed {
   }
 }
 
-module.exports = [NoVirtualOverrideAllowed];
+class NoMsgValueInternal {
+  constructor(reporter, config) {
+    this.ruleId = 'no-msg-value-internal';
+
+    this.reporter = reporter;
+    this.config = config;
+  }
+
+  FunctionDefinition(ctx) {
+    if (ctx.visibility === 'internal') {
+      const hasMsgValue = ctx.body.statements.some((statement) =>
+        JSON.stringify(statement).includes('msg.value'),
+      );
+      if (hasMsgValue) {
+        this.reporter.error(
+          ctx,
+          this.ruleId,
+          'Functions cannot have msg.value if they are internal (only public/external payable)',
+        );
+      }
+    }
+  }
+}
+
+module.exports = [NoVirtualOverrideAllowed, NoMsgValueInternal];

--- a/solidity/.solhint.json
+++ b/solidity/.solhint.json
@@ -13,7 +13,8 @@
     "prettier/prettier": "error",
     "gas-custom-errors": "off",
     "named-parameters-mapping": "error",
-    "hyperlane/no-virtual-override": "error"
+    "hyperlane/no-virtual-override": "error",
+    "hyperlane/no-msg-value-internal": "error"
   },
   "plugins": ["prettier", "hyperlane"]
 }

--- a/solidity/contracts/token/libs/TokenCollateral.sol
+++ b/solidity/contracts/token/libs/TokenCollateral.sol
@@ -13,6 +13,7 @@ import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
  * @title Handles deposits and withdrawals of native token collateral.
  */
 library NativeCollateral {
+    // solhint-disable-next-line hyperlane/no-msg-value-internal
     function _transferFromSender(uint256 _amount) internal {
         require(msg.value >= _amount, "Native: amount exceeds msg.value");
     }


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
