### PR TITLE
feat(infra): streamline pending timelock txs output

### DIFF
--- a/typescript/infra/scripts/timelocks/get-pending-txs.ts
+++ b/typescript/infra/scripts/timelocks/get-pending-txs.ts
@@ -55,14 +55,26 @@ async function main() {
     process.exit(0);
   }
 
-  logTable(pendingTxs, [
-    'chain',
-    'id',
-    'predecessorId',
-    'salt',
-    'status',
-    'canSignerExecute',
-  ]);
+  // Sort by chain name, then by earliestExecution (as BigNumber, so use .toNumber())
+  // Then convert earliestExecution to a readable date string
+  logTable(
+    pendingTxs
+      .sort((a, b) => {
+        const chainCmp = a.chain.localeCompare(b.chain);
+        if (chainCmp !== 0) return chainCmp;
+        // Compare earliestExecution as numbers (BigNumber -> number)
+        const aExec = a.earliestExecution.toNumber();
+        const bExec = b.earliestExecution.toNumber();
+        return aExec - bExec;
+      })
+      .map((tx) => ({
+        ...tx,
+        earliestExecution: new Date(
+          tx.earliestExecution.toNumber() * 1000,
+        ).toLocaleString(),
+      })),
+    ['chain', 'id', 'earliestExecution', 'status'],
+  );
 
   const executableTxs = pendingTxs.filter(
     (tx) =>


### PR DESCRIPTION
### Description

feat(infra): streamline pending timelock txs output
- trim down columns shown
- include earliest possible execution time to the timelock tx info
- sort by chain name then by earliest execution time

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<img width="924" height="454" alt="image" src="https://github.com/user-attachments/assets/1576e165-b1da-43b1-a9c4-5208529dce6a" />
