### PR TITLE
chore: upgrade rebalancer image

### DIFF
--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -75,7 +75,7 @@ export class RebalancerHelmManager extends HelmManager {
     return {
       image: {
         repository: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-        tag: '5abccc4-20250915-165639',
+        tag: 'edada36-20250925-105801',
       },
       withMetrics: this.withMetrics,
       fullnameOverride: this.helmReleaseName,


### PR DESCRIPTION
### Description

This PR upgrades the monorepo image used by the rebalancer to include the USDC/matchain rebalancer configuration.

### Related issues

Fixes ENG-2087

### Backward compatibility

Yes