### PR TITLE
fix: radix docker e2e command

### DIFF
--- a/rust/main/utils/run-locally/src/radix/mod.rs
+++ b/rust/main/utils/run-locally/src/radix/mod.rs
@@ -109,7 +109,7 @@ fn start_localnet() {
         .arg("profile", "fullnode")
         .arg("profile", "network-gateway-image")
         .cmd("up")
-        .cmd("-d")
+        .raw_arg("--detach")
         .filter_logs(|_| false)
         .run()
         .join();


### PR DESCRIPTION
### Description

fixing the issue of
```
❯ cargo test --package run-locally --bin run-locally --features radix -- radix::test --nocapture

running 1 test
<E2E> Staring local net

thread 'radix::test::test_run' panicked at utils/run-locally/src/program.rs:115:9:
arg should not start with -
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test radix::test::test_run ... FAILED
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the way detached mode is enabled for local runs, using a more explicit flag to maintain consistent behavior across environments. No change to user workflow.
* **Chores**
  * Minor internal argument handling adjustment to improve compatibility with different Docker Compose versions. No user-facing changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->