### PR TITLE
fix: add polymer ism type enum

### DIFF
--- a/solidity/contracts/interfaces/IInterchainSecurityModule.sol
+++ b/solidity/contracts/interfaces/IInterchainSecurityModule.sol
@@ -14,7 +14,8 @@ interface IInterchainSecurityModule {
         ARB_L2_TO_L1,
         WEIGHTED_MERKLE_ROOT_MULTISIG,
         WEIGHTED_MESSAGE_ID_MULTISIG,
-        OP_L2_TO_L1
+        OP_L2_TO_L1,
+        POLYMER
     }
 
     /**


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

"Reserving" the ISM enum "slot" so that we don't have multiple different ISMs with the same type ~

### Drive-by changes

None

### Related issues

None

### Backward compatibility

Should be backwards compatible since we're only adding a new enum value.

### Testing



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Polymer” as a selectable interchain security module type, expanding available options for configuring interchain security.

* **Chores**
  * Updated type listings to include the new module option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->