### PR TITLE
chore(infra): format when writing json to file

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "packageManager": "yarn@4.5.1",
   "private": true,
   "scripts": {
-    "agent-configs": "yarn --cwd typescript/infra/ update-agent-config:mainnet3 && yarn --cwd typescript/infra/ update-agent-config:testnet4 && yarn prettier",
+    "agent-configs": "yarn --cwd typescript/infra/ update-agent-config:mainnet3 && yarn --cwd typescript/infra/ update-agent-config:testnet4",
     "build": "turbo run build",
     "clean": "turbo run clean",
     "prettier": "turbo run prettier",

--- a/typescript/infra/scripts/agents/update-agent-config.ts
+++ b/typescript/infra/scripts/agents/update-agent-config.ts
@@ -37,7 +37,7 @@ import {
   filterRemoteDomainMetadata,
   isEthereumProtocolChain,
   readJSONAtPath,
-  writeJsonAtPath,
+  writeAndFormatJsonAtPath,
 } from '../../src/utils/utils.js';
 import {
   Modules,
@@ -209,9 +209,12 @@ export async function writeAgentConfig(
       }
       delete chainConfig.transactionOverrides;
     }
-    writeJsonAtPath(filepath, objMerge(currentAgentConfig, agentConfig));
+    writeAndFormatJsonAtPath(
+      filepath,
+      objMerge(currentAgentConfig, agentConfig),
+    );
   } else {
-    writeJsonAtPath(filepath, agentConfig);
+    writeAndFormatJsonAtPath(filepath, agentConfig);
   }
 }
 

--- a/typescript/infra/scripts/funding/calculate-relayer-daily-burn.ts
+++ b/typescript/infra/scripts/funding/calculate-relayer-daily-burn.ts
@@ -27,7 +27,7 @@ import {
   portForwardPrometheusServer,
 } from '../../src/infrastructure/monitoring/prometheus.js';
 import { fetchLatestGCPSecret } from '../../src/utils/gcloud.js';
-import { writeJsonAtPath } from '../../src/utils/utils.js';
+import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
 import { withSkipReview } from '../agent-utils.js';
 
 const tokenPrices: ChainMap<string> = rawTokenPrices;
@@ -329,7 +329,7 @@ async function getSealevelDomainIds(): Promise<ChainMap<string>> {
 function writeBurnDataToFile(burnData: ChainMap<number>) {
   try {
     rootLogger.info('Writing daily burn data to file..');
-    writeJsonAtPath(DAILY_BURN_PATH, burnData);
+    writeAndFormatJsonAtPath(DAILY_BURN_PATH, burnData);
     rootLogger.info('Daily burn data written to file.');
   } catch (err) {
     rootLogger.error('Error writing daily burn data to file:', err);

--- a/typescript/infra/scripts/funding/read-alert-thresholds.ts
+++ b/typescript/infra/scripts/funding/read-alert-thresholds.ts
@@ -6,7 +6,7 @@ import { THRESHOLD_CONFIG_PATH } from '../../src/config/funding/balances.js';
 import { alertConfigMapping } from '../../src/config/funding/grafanaAlerts.js';
 import { getBalanceAlertThresholds } from '../../src/funding/alerts.js';
 import { sortThresholds } from '../../src/funding/balances.js';
-import { writeJsonAtPath } from '../../src/utils/utils.js';
+import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
 import { withAlertTypeRequired, withWrite } from '../agent-utils.js';
 
 // this scripts reads the thresholds in the grafana alert, prints and then overwrites the thresholds in the file
@@ -25,7 +25,7 @@ async function main() {
   if (write) {
     rootLogger.info('Writing alert thresholds to file..');
     try {
-      writeJsonAtPath(
+      writeAndFormatJsonAtPath(
         `${THRESHOLD_CONFIG_PATH}/${alertConfigMapping[alertType].configFileName}`,
         sortedThresholds,
       );

--- a/typescript/infra/scripts/funding/update-balance-thresholds.ts
+++ b/typescript/infra/scripts/funding/update-balance-thresholds.ts
@@ -21,7 +21,7 @@ import {
   sortThresholdTypes,
   sortThresholds,
 } from '../../src/funding/balances.js';
-import { writeJsonAtPath } from '../../src/utils/utils.js';
+import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
 import { withSkipReview } from '../agent-utils.js';
 
 enum UserReview {
@@ -354,7 +354,7 @@ function writeConfigsToFile(newConfigs: ThresholdsData) {
       rootLogger.info(
         `Writing updated thresholds for ${thresholdType} => ${fileName}`,
       );
-      writeJsonAtPath(configPath, newConfigs[thresholdType]);
+      writeAndFormatJsonAtPath(configPath, newConfigs[thresholdType]);
     } catch (error) {
       rootLogger.error(`Failed to write config for ${thresholdType}:`, error);
     }

--- a/typescript/infra/scripts/gas/print-all-gas-oracles.ts
+++ b/typescript/infra/scripts/gas/print-all-gas-oracles.ts
@@ -1,12 +1,8 @@
-import {
-  ChainMap,
-  ChainName,
-  ProtocolAgnositicGasOracleConfig,
-} from '@hyperlane-xyz/sdk';
-import { objFilter, objMap, stringifyObject } from '@hyperlane-xyz/utils';
+import { ChainMap, ProtocolAgnositicGasOracleConfig } from '@hyperlane-xyz/sdk';
+import { stringifyObject } from '@hyperlane-xyz/utils';
 
-import { getChains, getWarpAddresses } from '../../config/registry.js';
-import { writeJsonAtPath } from '../../src/utils/utils.js';
+import { getChains } from '../../config/registry.js';
+import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
 import { getArgs, withOutputFile } from '../agent-utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
 
@@ -95,7 +91,7 @@ async function main() {
 
   if (outFile) {
     console.log(`Writing config to ${outFile}`);
-    writeJsonAtPath(outFile, gasOracles);
+    writeAndFormatJsonAtPath(outFile, gasOracles);
   }
 }
 

--- a/typescript/infra/scripts/print-gas-prices.ts
+++ b/typescript/infra/scripts/print-gas-prices.ts
@@ -22,7 +22,7 @@ import {
   getSafeNumericValue,
   updatePriceIfNeeded,
 } from '../src/config/gas-oracle.js';
-import { writeJsonAtPath } from '../src/utils/utils.js';
+import { writeAndFormatJsonAtPath } from '../src/utils/utils.js';
 
 import { getArgs, withWrite } from './agent-utils.js';
 
@@ -97,7 +97,7 @@ async function main() {
   if (write) {
     const outFile = gasPricesFilePath(environment);
     console.log(`Writing gas prices to ${outFile}`);
-    writeJsonAtPath(outFile, prices);
+    writeAndFormatJsonAtPath(outFile, prices);
   } else {
     console.log(JSON.stringify(prices, null, 2));
   }

--- a/typescript/infra/scripts/print-token-prices.ts
+++ b/typescript/infra/scripts/print-token-prices.ts
@@ -16,7 +16,7 @@ import {
   getSafeNumericValue,
   shouldUpdatePrice,
 } from '../src/config/gas-oracle.js';
-import { writeJsonAtPath } from '../src/utils/utils.js';
+import { writeAndFormatJsonAtPath } from '../src/utils/utils.js';
 
 import { getArgs, withWrite } from './agent-utils.js';
 
@@ -106,7 +106,7 @@ async function main() {
   if (write) {
     const outFile = tokenPricesFilePath(environment);
     console.log(`Writing token prices to ${outFile}`);
-    writeJsonAtPath(outFile, prices);
+    writeAndFormatJsonAtPath(outFile, prices);
   } else {
     console.log(JSON.stringify(prices, null, 2));
   }

--- a/typescript/infra/scripts/safes/combine-txs.ts
+++ b/typescript/infra/scripts/safes/combine-txs.ts
@@ -7,7 +7,10 @@ import yargs from 'yargs';
 
 import { rootLogger } from '@hyperlane-xyz/utils';
 
-import { readJSONAtPath, writeJsonAtPath } from '../../src/utils/utils.js';
+import {
+  readJSONAtPath,
+  writeAndFormatJsonAtPath,
+} from '../../src/utils/utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
 
 type TxFile = {
@@ -77,7 +80,7 @@ async function writeCombinedTransactions(
     // NOTE: hacky use of chainid instead of domainid or chain name here
     const chainName = multiProvider.getChainName(chainId);
     const outputFilePath = path.join(outputDir, `${chainId}-${chainName}.json`);
-    writeJsonAtPath(outputFilePath, outputData);
+    writeAndFormatJsonAtPath(outputFilePath, outputData);
     rootLogger.info(`Combined transactions written to ${outputFilePath}`);
   }
 }

--- a/typescript/infra/scripts/sealevel-helpers/print-gas-oracles.ts
+++ b/typescript/infra/scripts/sealevel-helpers/print-gas-oracles.ts
@@ -13,7 +13,7 @@ import {
 import { WarpRouteIds } from '../../config/environments/mainnet3/warp/warpIds.js';
 import { getChain, getWarpAddresses } from '../../config/registry.js';
 import { DeployEnvironment } from '../../src/config/environment.js';
-import { writeJsonAtPath } from '../../src/utils/utils.js';
+import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
 import { getArgs, withOutputFile } from '../agent-utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
 
@@ -79,7 +79,7 @@ async function main() {
 
   if (outFile) {
     console.log(`Writing config to ${outFile}`);
-    writeJsonAtPath(outFile, gasOracles);
+    writeAndFormatJsonAtPath(outFile, gasOracles);
   }
 }
 

--- a/typescript/infra/src/agents/key-utils.ts
+++ b/typescript/infra/src/agents/key-utils.ts
@@ -27,7 +27,7 @@ import {
   getInfraPath,
   isEthereumProtocolChain,
   readJSON,
-  writeJsonAtPath,
+  writeAndFormatJsonAtPath,
 } from '../utils/utils.js';
 
 import { AgentAwsKey } from './aws/key.js';
@@ -623,7 +623,7 @@ export async function persistRoleAddressesToLocalArtifacts(
   // Resolve the relative path
   const filePath = join(getInfraPath(), `config/${role}.json`);
 
-  writeJsonAtPath(filePath, addresses);
+  writeAndFormatJsonAtPath(filePath, addresses);
 }
 
 // maintaining the multisigIsm schema sans threshold
@@ -633,7 +633,7 @@ export async function persistValidatorAddressesToLocalArtifacts(
   fetchedValidatorAddresses: ChainMap<{ validators: Address[] }>,
 ) {
   // Write the updated object back to the file
-  writeJsonAtPath(
+  writeAndFormatJsonAtPath(
     getAWValidatorsPath(environment, context),
     fetchedValidatorAddresses,
   );

--- a/typescript/infra/src/deployment/deploy.ts
+++ b/typescript/infra/src/deployment/deploy.ts
@@ -22,7 +22,7 @@ import {
   writeAddresses,
 } from '../../scripts/agent-utils.js';
 import { DeployEnvironment } from '../config/environment.js';
-import { readJSONAtPath, writeJsonAtPath } from '../utils/utils.js';
+import { readJSONAtPath, writeAndFormatJsonAtPath } from '../utils/utils.js';
 
 enum DeployStatus {
   EMPTY = '🫥',
@@ -271,6 +271,9 @@ async function postDeploy<Config extends object>(
     );
 
     // write back deduplicated verification inputs
-    writeJsonAtPath(cache.verification, deduplicatedVerificationInputs);
+    writeAndFormatJsonAtPath(
+      cache.verification,
+      deduplicatedVerificationInputs,
+    );
   }
 }

--- a/typescript/infra/src/utils/utils.ts
+++ b/typescript/infra/src/utils/utils.ts
@@ -168,6 +168,39 @@ export function writeJsonAtPath(filepath: string, obj: any) {
   writeToFile(filepath, content);
 }
 
+export async function writeAndFormatJsonAtPath(filepath: string, obj: any) {
+  writeJsonAtPath(filepath, obj);
+  await formatFileWithPrettier(filepath);
+}
+
+/**
+ * Gets the monorepo root directory
+ */
+function getMonorepoRoot(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), '../../../../');
+}
+
+/**
+ * Formats a file using prettier
+ * @param filepath - The path to the file to format
+ */
+export async function formatFileWithPrettier(filepath: string): Promise<void> {
+  try {
+    const monorepoRoot = getMonorepoRoot();
+    await execCmd(`npx prettier --write "${filepath}"`, {
+      cwd: monorepoRoot,
+      stdio: 'pipe',
+    });
+  } catch (error) {
+    // Silently fail if prettier is not available or fails
+    // This ensures the deployment process continues even if formatting fails
+    console.warn(
+      `Warning: Failed to format file with prettier: ${filepath}`,
+      error instanceof Error ? error.message : error,
+    );
+  }
+}
+
 export function writeYamlAtPath(filepath: string, obj: any) {
   const content = stringifyObject(obj, 'yaml', 2);
   writeToFile(filepath, content);


### PR DESCRIPTION
### Description

chore(infra): format when writing json to file
- introduce formatFileWithPrettier helper
- introduce writeAndFormatJsonAtPath wrapper to writeJsonAtPath+formatFileWithPrettier
- replace existing infra uses of writeJsonAtPath with writeAndFormatJsonAtPath

this means we no longer need to manually pretty/open+save files after doing:
- deploy-agents / create-keys / anything that persists addresses to file
- update-agent-config
- relayer burn / alert threshold scripts
- print-all-gas-oracles (starknet) / print-gas-oracles (sealevel)
- print-gas-prices / print-token-prices 

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
