### PR TITLE
fix: failed_indexes for starknet batch submissions

### DIFF
--- a/rust/main/chains/hyperlane-starknet/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-starknet/src/mailbox.rs
@@ -12,7 +12,7 @@ use hyperlane_core::{
 };
 use hyperlane_core::{BatchItem, BatchResult, FixedPointNumber, QueueOperation, ReorgPeriod};
 use starknet::accounts::{Account, ExecutionV3, SingleOwnerAccount};
-use starknet::core::types::{ExecuteInvocation, Felt, TransactionTrace};
+use starknet::core::types::Felt;
 
 use starknet::signers::LocalWallet;
 use tracing::instrument;


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues
Resolves following issue: https://linear.app/hyperlane-xyz/issue/ENG-2308/paradex-inspect-tx-outcome-for-batch
<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Batch operation results now accurately report failed item indices: when a batch fully executes, failures are empty; when it doesn't, failed indices list the affected items.
  * Improves reliability and observability of multi-operation submissions, reducing misleading success reports and aiding downstream error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->