### PR TITLE
fix: warp read crashing when warpRouteId is provided

### DIFF
--- a/.changeset/sharp-wombats-vanish.md
+++ b/.changeset/sharp-wombats-vanish.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/cli": minor
+---
+
+Fix warp read crashing when providing the `--warpRouteId` flag

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -225,6 +225,8 @@ export const read: CommandModuleWithContext<
     address,
     config: configFilePath,
     symbol,
+    warp,
+    warpRouteId,
   }) => {
     logCommandHeader('Hyperlane Warp Reader');
 
@@ -233,6 +235,8 @@ export const read: CommandModuleWithContext<
       chain,
       address,
       symbol,
+      warpCoreConfigPath: warp,
+      warpRouteId,
     });
 
     if (configFilePath) {

--- a/typescript/cli/src/read/warp.ts
+++ b/typescript/cli/src/read/warp.ts
@@ -17,7 +17,12 @@ import {
   TokenStandard,
   WarpCoreConfig,
 } from '@hyperlane-xyz/sdk';
-import { ProtocolType, objMap, promiseObjAll } from '@hyperlane-xyz/utils';
+import {
+  Address,
+  ProtocolType,
+  objMap,
+  promiseObjAll,
+} from '@hyperlane-xyz/utils';
 
 import { CommandContext } from '../context/types.js';
 import { logGray, logRed, logTable, warnYellow } from '../logger.js';
@@ -28,36 +33,38 @@ export async function runWarpRouteRead({
   chain,
   address,
   symbol,
+  warpRouteId,
+  warpCoreConfigPath,
 }: {
   context: CommandContext;
   chain?: ChainName;
   address?: string;
   symbol?: string;
+  warpRouteId?: string;
+  warpCoreConfigPath?: string;
 }): Promise<ChainMap<HypTokenRouterConfig>> {
-  const hasTokenSymbol = Boolean(symbol);
-  const hasChainAddress = Boolean(chain && address);
+  let addresses: ChainMap<Address>;
+  let warpCoreConfig: WarpCoreConfig | undefined;
+  if (symbol || warpCoreConfigPath || warpRouteId) {
+    warpCoreConfig = await getWarpCoreConfigOrExit({
+      context,
+      symbol,
+      warp: warpCoreConfigPath,
+      warpRouteId,
+    });
 
-  if (!hasTokenSymbol && !hasChainAddress) {
-    logRed(
-      'Invalid input parameters. Please provide either a token symbol or both chain name and token address',
+    addresses = Object.fromEntries(
+      warpCoreConfig.tokens.map((t) => [t.chainName, t.addressOrDenom!]),
     );
-    process.exit(1);
+  } else if (chain && address) {
+    addresses = {
+      [chain]: address,
+    };
+  } else {
+    throw new Error(
+      'Invalid input parameters. Please provide either a token symbol, a warp route id or both chain name and token address',
+    );
   }
-
-  const warpCoreConfig = hasTokenSymbol
-    ? await getWarpCoreConfigOrExit({
-        context,
-        symbol,
-      })
-    : undefined;
-
-  const addresses = warpCoreConfig
-    ? Object.fromEntries(
-        warpCoreConfig.tokens.map((t) => [t.chainName, t.addressOrDenom!]),
-      )
-    : {
-        [chain!]: address!,
-      };
 
   return deriveWarpRouteConfigs(context, addresses, warpCoreConfig);
 }

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -11,6 +11,8 @@ import { readYamlOrJson } from '../../utils/files.js';
 
 import { localTestRunCmdPrefix } from './helpers.js';
 
+$.verbose = true;
+
 export class HyperlaneE2EWarpTestCommands {
   protected cmdPrefix: string[];
 
@@ -67,10 +69,12 @@ export class HyperlaneE2EWarpTestCommands {
     warpAddress,
     symbol,
     outputPath,
+    warpRouteId,
   }: {
     chain?: string;
     symbol?: string;
     warpAddress?: string;
+    warpRouteId?: string;
     outputPath?: string;
   }): ProcessPromise {
     return $`${localTestRunCmdPrefix()} hyperlane warp read \
@@ -78,6 +82,7 @@ export class HyperlaneE2EWarpTestCommands {
             ${warpAddress ? ['--address', warpAddress] : []} \
             ${chain ? ['--chain', chain] : []} \
             ${symbol ? ['--symbol', symbol] : []} \
+            ${warpRouteId ? ['--warpRouteId', warpRouteId] : []} \
             --verbosity debug \
             ${outputPath || this.outputPath ? ['--config', outputPath || this.outputPath] : []}`;
   }

--- a/typescript/cli/src/utils/warp.ts
+++ b/typescript/cli/src/utils/warp.ts
@@ -31,19 +31,31 @@ export async function getWarpCoreConfigOrExit({
   context,
   symbol,
   warp,
+  warpRouteId,
 }: {
   context: CommandContext;
   symbol?: string;
   warp?: string;
+  warpRouteId?: string;
 }): Promise<WarpCoreConfig> {
   let warpCoreConfig: WarpCoreConfig;
   if (symbol) {
     warpCoreConfig = await selectRegistryWarpRoute(context.registry, symbol);
   } else if (warp) {
     warpCoreConfig = await readWarpCoreConfig({ filePath: warp });
+  } else if (warpRouteId) {
+    const maybeWarpRoute = await context.registry.getWarpRoute(warpRouteId);
+    assert(
+      maybeWarpRoute,
+      `No warp route found with the provided id "${warpRouteId}"`,
+    );
+
+    warpCoreConfig = maybeWarpRoute;
   } else {
-    logRed(`Please specify either a symbol or warp config`);
-    process.exit(0);
+    logRed(
+      `Invalid input parameters. Please provide either a token symbol, a warp route id or both chain name and token address`,
+    );
+    process.exit(1);
   }
 
   return warpCoreConfig;


### PR DESCRIPTION
### Description

This PR fixes a bug in warp read where providing the `warpRouteId` flag caused a cli crash

### Drive-by changes

- 

### Related issues

- 

### Backward compatibility

- Yes

### Testing

- Manual
- e2e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Warp read now supports --warp and --warpRouteId flags to read routes via a Warp Core config path or a specific route ID.
  * Enhanced validation and error messages for input options.

* **Bug Fixes**
  * Resolved crash when using --warpRouteId with warp read.

* **Tests**
  * Added e2e coverage for --warpRouteId, including success and error scenarios; updated expected error messaging.

* **Chores**
  * Version bump (minor) for @hyperlane-xyz/cli via changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->