### PR TITLE
fix(infra): script to retrieve keys from secret manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yalc.lock
 .yalc
 
 **/keys
+!typescript/infra/scripts/keys
 **/warp-route-deployer-key.json
 **/key.json
 **/deployer-key.json

--- a/typescript/infra/src/agents/gcp.ts
+++ b/typescript/infra/src/agents/gcp.ts
@@ -187,16 +187,22 @@ export class AgentGCPKey extends CloudAgentKey {
     this.requireFetched();
 
     if (protocol === ProtocolType.Sealevel) {
-      // This assumes the key is stored as the base64 encoded
-      // string of the stringified version of the private key
-      // in array format (format used by the solana CLI).
-      // So we need to:
-      // - convert the base64 string to a buffer so we can get the stringified json string
-      // - get the the json array from its stringified representation
-      // - finally get the byte array from the parsed json array
-      return Uint8Array.from(
-        JSON.parse(String(Buffer.from(this.privateKey, 'base64'))),
-      );
+      if (this.role === Role.Deployer) {
+        // This assumes the key is stored as the base64 encoded
+        // string of the stringified version of the private key
+        // in array format (format used by the solana CLI).
+        // So we need to:
+        // - convert the base64 string to a buffer so we can get the stringified json string
+        // - get the the json array from its stringified representation
+        // - finally get the byte array from the parsed json array
+        return Uint8Array.from(
+          JSON.parse(String(Buffer.from(this.privateKey, 'base64'))),
+        );
+      }
+
+      // All other keys are stored as hex strings
+      return Keypair.fromSeed(Buffer.from(strip0x(this.privateKey), 'hex'))
+        .secretKey;
     } else if (protocol === ProtocolType.Starknet) {
       return ethers.utils.hexlify(ethers.utils.base58.decode(this.privateKey));
     } else {


### PR DESCRIPTION
### Description

Fixes pk parsing for svm chains in infra

### Drive-by changes

- 

### Related issues

- 

### Backward compatibility

- Yes

### Testing

- Manual


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed key handling for Sealevel roles: non-deployer roles now correctly load hex-encoded private keys, preventing signing/authentication failures. Deployer behavior remains unchanged.

* **Chores**
  * Updated ignore rules to track a specific keys directory under typescript/infra/scripts while keeping other keys paths ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->