### PR TITLE
fix: enable native LP deposits with payable overload

### DIFF
--- a/solidity/contracts/token/HypNative.sol
+++ b/solidity/contracts/token/HypNative.sol
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.0;
 
+// ============ Internal Imports ============
 import {LpCollateralRouter} from "./libs/LpCollateralRouter.sol";
 import {Quote, ITokenBridge} from "../interfaces/ITokenBridge.sol";
 import {NativeCollateral} from "./libs/TokenCollateral.sol";
 import {TokenRouter} from "./libs/TokenRouter.sol";
 
+// ============ External Imports ============
+import {ERC4626Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
 /**
@@ -37,9 +40,19 @@ contract HypNative is LpCollateralRouter {
     }
 
     /**
+     * Replacement for ERC4626Upgradeable.deposit that allows for native token deposits.
+     * @dev msg.value will be used as the amount to deposit.
+     * @param receiver The address to deposit the native token to.
+     * @return shares The number of shares minted.
+     */
+    function deposit(address receiver) public payable returns (uint256 shares) {
+        return ERC4626Upgradeable.deposit(msg.value, receiver);
+    }
+
+    /**
      * @inheritdoc TokenRouter
      */
-    function token() public view override returns (address) {
+    function token() public pure override returns (address) {
         return address(0);
     }
 

--- a/solidity/contracts/token/libs/LpCollateralRouter.sol
+++ b/solidity/contracts/token/libs/LpCollateralRouter.sol
@@ -92,7 +92,7 @@ abstract contract LpCollateralRouter is
     }
 
     // can be used to distribute rewards to LPs pro rata
-    function donate(uint256 amount) public {
+    function donate(uint256 amount) public payable {
         // checks
         _transferFromSender(amount);
 

--- a/solidity/test/token/HypNativeLp.t.sol
+++ b/solidity/test/token/HypNativeLp.t.sol
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import "forge-std/Test.sol";
+import {HypNative} from "../../contracts/token/HypNative.sol";
+import {MockMailbox} from "../../contracts/mock/MockMailbox.sol";
+
+contract HypNativeLpTest is Test {
+    event Donation(address sender, uint256 amount);
+    event Deposit(
+        address indexed sender,
+        address indexed owner,
+        uint256 assets,
+        uint256 shares
+    );
+    event Withdraw(
+        address indexed sender,
+        address indexed receiver,
+        address indexed owner,
+        uint256 assets,
+        uint256 shares
+    );
+
+    HypNative internal router;
+    address internal alice = address(0x1);
+    address internal bob = address(0x2);
+    uint256 internal constant DEPOSIT_AMOUNT = 100e18;
+    uint256 internal constant DONATE_AMOUNT = 50e18;
+
+    function setUp() public {
+        MockMailbox mailbox = new MockMailbox(1);
+        router = new HypNative(1, address(mailbox));
+        router.initialize(address(0), address(0), address(this));
+
+        vm.label(alice, "Alice");
+        vm.label(bob, "Bob");
+        vm.deal(alice, 1000e18);
+        vm.deal(bob, 1000e18);
+    }
+
+    function testDepositIncreasesBalances() public {
+        uint256 shares = router.previewDeposit(DEPOSIT_AMOUNT);
+        vm.prank(alice);
+        router.deposit{value: DEPOSIT_AMOUNT}(alice);
+        assertEq(router.balanceOf(alice), shares);
+        assertEq(router.totalAssets(), DEPOSIT_AMOUNT);
+    }
+
+    function testDepositEmitsEvent() public {
+        uint256 shares = router.previewDeposit(DEPOSIT_AMOUNT);
+        vm.expectEmit(true, true, true, true);
+        emit Deposit(alice, alice, DEPOSIT_AMOUNT, shares);
+        vm.prank(alice);
+        router.deposit{value: DEPOSIT_AMOUNT}(alice);
+    }
+
+    function testDepositWithZeroValue() public {
+        vm.prank(alice);
+        uint256 shares = router.deposit(alice);
+        assertEq(shares, 0);
+        assertEq(router.balanceOf(alice), 0);
+    }
+
+    function testDepositToReceiverCreditsCorrectAccount() public {
+        uint256 shares = router.previewDeposit(DEPOSIT_AMOUNT);
+        vm.prank(alice);
+        router.deposit{value: DEPOSIT_AMOUNT}(bob);
+        assertEq(router.balanceOf(bob), shares);
+        assertEq(router.balanceOf(alice), 0);
+    }
+
+    function testWithdrawDecreasesBalances() public {
+        uint256 shares = router.previewDeposit(DEPOSIT_AMOUNT);
+        vm.prank(alice);
+        router.deposit{value: DEPOSIT_AMOUNT}(alice);
+        vm.prank(alice);
+        router.withdraw(DEPOSIT_AMOUNT, bob, alice);
+        assertEq(router.balanceOf(alice), 0);
+        assertEq(router.totalAssets(), 0);
+        assertEq(bob.balance, 1000e18 + DEPOSIT_AMOUNT);
+    }
+
+    function testWithdrawEmitsEvent() public {
+        vm.prank(alice);
+        router.deposit{value: DEPOSIT_AMOUNT}(alice);
+        uint256 shares = router.balanceOf(alice);
+        vm.expectEmit(true, true, true, true);
+        emit Withdraw(alice, bob, alice, DEPOSIT_AMOUNT, shares);
+        vm.prank(alice);
+        router.withdraw(DEPOSIT_AMOUNT, bob, alice);
+    }
+
+    function testTotalSupplyTracksShares() public {
+        assertEq(router.totalSupply(), 0);
+        vm.prank(alice);
+        router.deposit{value: DEPOSIT_AMOUNT}(alice);
+        assertEq(router.totalSupply(), router.balanceOf(alice));
+    }
+
+    function testTotalAssetsTracksDepositsAndWithdrawals() public {
+        assertEq(router.totalAssets(), 0);
+        vm.prank(alice);
+        router.deposit{value: DEPOSIT_AMOUNT}(alice);
+        assertEq(router.totalAssets(), DEPOSIT_AMOUNT);
+        vm.prank(alice);
+        router.withdraw(DEPOSIT_AMOUNT, bob, alice);
+        assertEq(router.totalAssets(), 0);
+    }
+
+    function testDonateIncreasesTotalAssets() public {
+        assertEq(router.totalAssets(), 0);
+        vm.prank(alice);
+        router.donate{value: DONATE_AMOUNT}(DONATE_AMOUNT);
+        assertEq(router.totalAssets(), DONATE_AMOUNT);
+    }
+
+    function testDonateEmitsEvent() public {
+        vm.expectEmit(true, true, true, true);
+        emit Donation(alice, DONATE_AMOUNT);
+        vm.prank(alice);
+        router.donate{value: DONATE_AMOUNT}(DONATE_AMOUNT);
+    }
+
+    function testDonateIsNotWithdrawable() public {
+        vm.prank(alice);
+        router.donate{value: DONATE_AMOUNT}(DONATE_AMOUNT);
+        vm.prank(alice);
+        vm.expectRevert();
+        router.withdraw(DONATE_AMOUNT, bob, alice);
+    }
+
+    function testWithdrawMoreThanBalanceReverts() public {
+        vm.prank(alice);
+        router.deposit{value: DEPOSIT_AMOUNT}(alice);
+        vm.prank(alice);
+        vm.expectRevert();
+        router.withdraw(DEPOSIT_AMOUNT + 1, bob, alice);
+    }
+
+    function testDonateDistributesToAllHolders() public {
+        uint256 aliceDeposit = 100e18;
+        uint256 bobDeposit = 200e18;
+        uint256 donation = DONATE_AMOUNT;
+
+        // Alice deposits
+        vm.prank(alice);
+        router.deposit{value: aliceDeposit}(alice);
+
+        // Bob deposits
+        vm.prank(bob);
+        router.deposit{value: bobDeposit}(bob);
+
+        // Record balances before donation
+        uint256 aliceWithdrawBefore = router.maxWithdraw(alice);
+        uint256 bobWithdrawBefore = router.maxWithdraw(bob);
+
+        // Donate to the vault
+        vm.deal(address(this), donation);
+        router.donate{value: donation}(donation);
+
+        // After donation, both should be able to withdraw more
+        assertGt(router.maxWithdraw(alice), aliceWithdrawBefore);
+        assertGt(router.maxWithdraw(bob), bobWithdrawBefore);
+
+        // Alice should get 1/3 of donation, Bob should get 2/3
+        assertEq(router.maxWithdraw(alice), aliceDeposit + donation / 3);
+        assertEq(router.maxWithdraw(bob), bobDeposit + (donation * 2) / 3);
+    }
+
+    function testReceiveCallsDonate() public {
+        assertEq(router.totalAssets(), 0);
+        vm.expectEmit(true, true, true, true);
+        emit Donation(alice, DONATE_AMOUNT);
+        vm.prank(alice);
+        (bool success, ) = address(router).call{value: DONATE_AMOUNT}("");
+        assertTrue(success);
+        assertEq(router.totalAssets(), DONATE_AMOUNT);
+    }
+
+    function testMultipleDepositsAndWithdrawals() public {
+        // Alice deposits
+        vm.prank(alice);
+        uint256 aliceShares = router.deposit{value: DEPOSIT_AMOUNT}(alice);
+
+        // Bob deposits
+        vm.prank(bob);
+        uint256 bobShares = router.deposit{value: DEPOSIT_AMOUNT * 2}(bob);
+
+        assertEq(router.totalAssets(), DEPOSIT_AMOUNT * 3);
+        assertEq(router.totalSupply(), aliceShares + bobShares);
+
+        // Alice withdraws half
+        vm.prank(alice);
+        router.withdraw(DEPOSIT_AMOUNT / 2, alice, alice);
+
+        assertEq(router.totalAssets(), DEPOSIT_AMOUNT * 3 - DEPOSIT_AMOUNT / 2);
+        assertEq(alice.balance, 1000e18 - DEPOSIT_AMOUNT + DEPOSIT_AMOUNT / 2);
+
+        // Bob withdraws all
+        uint256 bobMaxWithdraw = router.maxWithdraw(bob);
+        vm.prank(bob);
+        router.withdraw(bobMaxWithdraw, bob, bob);
+
+        assertEq(bob.balance, 1000e18);
+    }
+
+    function testDepositAfterDonationGetsCorrectShares() public {
+        // Alice deposits initially
+        vm.prank(alice);
+        uint256 aliceShares = router.deposit{value: DEPOSIT_AMOUNT}(alice);
+
+        // Someone donates
+        vm.deal(address(this), DONATE_AMOUNT);
+        router.donate{value: DONATE_AMOUNT}(DONATE_AMOUNT);
+
+        // Bob deposits same amount
+        vm.prank(bob);
+        uint256 bobShares = router.deposit{value: DEPOSIT_AMOUNT}(bob);
+
+        // Bob should get fewer shares since totalAssets increased from donation
+        assertLt(bobShares, aliceShares);
+    }
+}


### PR DESCRIPTION
### Description

> HypNative and EverclearEthBridge inherit from LPCollateralRouter, but since deposit() does not have the payable modifier, msg.value is always zero when _transferFromSender() is executed within _deposit(), making valid deposits impossible. It is recommended to override the deposit() function and set the asset amount to msg.value. (As there is currently no refund logic, users may lose funds if they set amount lower than msg.value.)


### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

- Fixes https://linear.app/hyperlane-xyz/issue/ENG-2254/fix-lpcollateralrouter-on-native-extensions

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support depositing native tokens directly into the vault with a designated receiver.
  - Enable ETH donations to the liquidity router; direct transfers are now accepted and accounted for.
- Bug Fixes
  - Improved native asset handling by avoiding unnecessary state reads for token address resolution.
- Tests
  - Added comprehensive coverage for deposits, withdrawals, donations, direct-transfer donations, event emissions, and asset/share accounting across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->