### PR TITLE
fix: use `previewWithdraw(assetsDeposited)` for excess shares

### DIFF
--- a/solidity/contracts/token/extensions/HypERC4626OwnerCollateral.sol
+++ b/solidity/contracts/token/extensions/HypERC4626OwnerCollateral.sol
@@ -67,7 +67,7 @@ contract HypERC4626OwnerCollateral is HypERC4626Collateral {
      */
     function sweep() external onlyOwner {
         uint256 excessShares = vault.maxRedeem(address(this)) -
-            vault.convertToShares(assetDeposited);
+            vault.previewWithdraw(assetDeposited);
         uint256 assetsRedeemed = vault.redeem(
             excessShares,
             owner(),


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
