### PR TITLE
feat: extend USDC/eclipsemainnet-ethereum-solanamainnet to arbitrum, base and enable rebalancing

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumSolanaUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumSolanaUSDCWarpConfig.ts
@@ -1,37 +1,107 @@
-import { ethers } from 'ethers';
+import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
 
-import {
-  ChainMap,
-  HypTokenRouterConfig,
-  RouterConfig,
-  TokenType,
-} from '@hyperlane-xyz/sdk';
-
-import { tokens } from '../../../../../src/config/warp.js';
+import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';
+import { awSafes } from '../../governance/safe/aw.js';
+import { chainOwners } from '../../owners.js';
+import { usdcTokenAddresses } from '../cctp.js';
 import { SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT } from '../consts.js';
 
+import { getUSDCRebalancingBridgesConfigFor } from './utils.js';
+
+const deploymentChains = [
+  'ethereum',
+  'arbitrum',
+  'base',
+  'eclipsemainnet',
+  'solanamainnet',
+] as const;
+
+type DeploymentChain = (typeof deploymentChains)[number];
+
+const rebalanceableCollateralChains = [
+  'ethereum',
+  'arbitrum',
+  'base',
+] as const satisfies DeploymentChain[];
+
+const ownersByChain: Record<DeploymentChain, string> = {
+  ethereum: awSafes.ethereum,
+  arbitrum: awSafes.arbitrum,
+  base: awSafes.base,
+  eclipsemainnet: chainOwners.eclipsemainnet.owner,
+  solanamainnet: chainOwners.solanamainnet.owner,
+};
+
+const CONTRACT_VERSION = '8.1.1';
+
 export const getEclipseEthereumSolanaUSDCWarpConfig = async (
-  routerConfig: ChainMap<RouterConfig>,
+  routerConfig: ChainMap<RouterConfigWithoutOwner>,
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
-  const eclipsemainnet: HypTokenRouterConfig = {
-    ...routerConfig.eclipsemainnet,
-    type: TokenType.synthetic,
-    foreignDeployment: 'D6k6T3G74ij6atCtBiWBs5TbFa1hFVcrFUSGZHuV7q3Z',
-    gas: SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT,
-  };
+  const rebalancingConfigByChain = getUSDCRebalancingBridgesConfigFor(
+    rebalanceableCollateralChains,
+  );
 
-  const ethereum: HypTokenRouterConfig = {
-    ...routerConfig.ethereum,
-    type: TokenType.collateral,
-    interchainSecurityModule: ethers.constants.AddressZero,
-    token: tokens.ethereum.USDC,
-  };
+  const configs: Array<[DeploymentChain, HypTokenRouterConfig]> = [];
 
-  // Intentionally don't enroll Solana to avoid transferring
-  // directly between Solana and Ethereum
+  // Handle rebalanceable collateral chains (EVM chains with rebalancing)
+  for (const currentChain of rebalanceableCollateralChains) {
+    const owner = ownersByChain[currentChain];
+    const usdcTokenAddress =
+      usdcTokenAddresses[currentChain as keyof typeof usdcTokenAddresses];
 
-  return {
-    eclipsemainnet,
-    ethereum,
-  };
+    assert(
+      usdcTokenAddress,
+      `USDC token address not found for chain ${currentChain}`,
+    );
+
+    const currentRebalancingConfig = rebalancingConfigByChain[currentChain];
+    assert(
+      currentRebalancingConfig,
+      `Rebalancing config not found for chain ${currentChain}`,
+    );
+
+    const { allowedRebalancers, allowedRebalancingBridges } =
+      currentRebalancingConfig;
+
+    configs.push([
+      currentChain,
+      {
+        type: TokenType.collateral,
+        token: usdcTokenAddress,
+        mailbox: routerConfig[currentChain].mailbox,
+        owner,
+        allowedRebalancers,
+        allowedRebalancingBridges,
+        contractVersion: CONTRACT_VERSION,
+      },
+    ]);
+  }
+
+  // Handle synthetic chain (Eclipse)
+  configs.push([
+    'eclipsemainnet',
+    {
+      type: TokenType.synthetic,
+      mailbox: routerConfig.eclipsemainnet.mailbox,
+      foreignDeployment: 'EqRSt9aUDMKYKhzd1DGMderr3KNp29VZH3x5P7LFTC8m',
+      owner: ownersByChain.eclipsemainnet,
+      gas: SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT,
+    },
+  ]);
+
+  // Handle non-rebalanceable collateral chain (Solana)
+  configs.push([
+    'solanamainnet',
+    {
+      type: TokenType.collateral,
+      token: usdcTokenAddresses.solanamainnet,
+      mailbox: routerConfig.solanamainnet.mailbox,
+      foreignDeployment: '3EpVCPUgyjq2MfGeCttyey6bs5zya5wjYZ2BE6yDg6bm',
+      owner: ownersByChain.solanamainnet,
+      gas: SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT,
+    },
+  ]);
+
+  return Object.fromEntries(configs);
 };

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -46,6 +46,7 @@ import {
   getCCTPWarpConfig as getMainnetCCTPWarpConfig,
 } from './environments/mainnet3/warp/configGetters/getCCTPConfig.js';
 import { getEclipseEthereumESWarpConfig } from './environments/mainnet3/warp/configGetters/getEclipseEthereumESWarpConfig.js';
+import { getEclipseEthereumSolanaUSDCWarpConfig } from './environments/mainnet3/warp/configGetters/getEclipseEthereumSolanaUSDCWarpConfig.js';
 import { getEclipseEthereumSolanaUSDTWarpConfig } from './environments/mainnet3/warp/configGetters/getEclipseEthereumSolanaUSDTWarpConfig.js';
 import { getEclipseEthereumWBTCWarpConfig } from './environments/mainnet3/warp/configGetters/getEclipseEthereumWBTCWarpConfig.js';
 import { getEclipseStrideTiaWarpConfig } from './environments/mainnet3/warp/configGetters/getEclipseStrideSTTIAWarpConfig.js';
@@ -130,6 +131,8 @@ export const warpConfigGetterMap: Record<string, WarpConfigGetter> = {
   [WarpRouteIds.BerachainEthereumSwellUnichainZircuitPZETHSTAGE]:
     getRenzoPZETHStagingWarpConfig,
   [WarpRouteIds.MantapacificNeutronTIA]: getMantapacificNeutronTiaWarpConfig,
+  [WarpRouteIds.EclipseEthereumSolanaUSDC]:
+    getEclipseEthereumSolanaUSDCWarpConfig,
   [WarpRouteIds.EclipseEthereumSolanaUSDT]:
     getEclipseEthereumSolanaUSDTWarpConfig,
   [WarpRouteIds.EclipseEthereumWBTC]: getEclipseEthereumWBTCWarpConfig,


### PR DESCRIPTION
### Description

- extend USDC/eclipsemainnet-ethereum-solanamainnet to arbitrum, base and enable rebalancing

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
