### PR TITLE
fix: Increase claimed storage size for Relayers to 32Gi

### DIFF
--- a/rust/main/helm/hyperlane-agent/values.yaml
+++ b/rust/main/helm/hyperlane-agent/values.yaml
@@ -108,7 +108,7 @@ hyperlane:
     storage:
       name: 'state-premium'
       storageClass: 'premium-immediate-rwo'
-      size: 16Gi
+      size: 32Gi
       snapshot:
         enabled: false
         name: ''


### PR DESCRIPTION
### Description

Increase claimed storage size for Relayers to 32Gi

### Related issues

- Fixes https://linear.app/hyperlane-xyz/issue/ENG-2354/increase-volume-size-for-relayers

Yes

### Testing

Testnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased relayer storage allocation from 16Gi to 32Gi to provide more capacity for data and logs.
  * Aims to improve reliability during high-load periods and reduce risk of storage-related interruptions.
  * No functional changes to user-facing behavior; deployments will use the updated default storage size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->