### PR TITLE
fix: evm commands should not load altvm chains

### DIFF
--- a/typescript/cli/src/context/strategies/chain/MultiChainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/MultiChainResolver.ts
@@ -156,7 +156,7 @@ export class MultiChainResolver implements ChainResolver {
   private async resolveRelayerChains(
     argv: Record<string, any>,
   ): Promise<ChainName[]> {
-    const { multiProvider, supportedProtocols } = argv.context;
+    const { multiProvider } = argv.context;
     const chains = new Set<ChainName>();
 
     if (argv.origin) {
@@ -174,12 +174,13 @@ export class MultiChainResolver implements ChainResolver {
       return Array.from(new Set([...chains, ...additionalChains]));
     }
 
-    // If no destination is specified, return all EVM and AltVM chains
+    // If no destination is specified, return all EVM chains only
     if (!argv.destination) {
       const chains = multiProvider.getKnownChainNames();
 
-      return chains.filter((chain: string) =>
-        supportedProtocols.includes(multiProvider.getProtocol(chain)),
+      return chains.filter(
+        (chain: string) =>
+          ProtocolType.Ethereum === multiProvider.getProtocol(chain),
       );
     }
 


### PR DESCRIPTION
### Description

This PR ensures that evm only commands like `hyperlane status, relayer, submit ...` only loads EVM chains and does not require AltVM keys

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

Manual Testing with `hyperlane status` command


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Default chain resolution now returns only EVM chains when no destination is specified, improving accuracy and preventing unintended inclusion of non-EVM chains.

* **Refactor**
  * Simplified CLI context usage in chain resolution to reduce unnecessary configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->