### PR TITLE
fix: remove forma TIA route from blacklist

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -802,7 +802,6 @@ const blacklist: MatchingList = [
     recipientAddress: [
       '0x4ca56fbecfe8431996c6b4ec8da140d4201338e8',
       '0x0a5c7d4ee3d65b2581d5606f8081fc8d8be22319',
-      '0x832d26b6904ba7539248db4d58614251fd63dc05',
       '0x74a26075fa2eec77936a56b0f9645d32a79b28af',
       '0xfcee86f472d0c19fccdd3aedb89aa9cc0a1fb0d1',
     ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an outdated entry from the legacy recipient blacklist on mainnet, restoring the ability to complete transactions to that recipient. Payments, transfers, and routing to that destination will no longer be unexpectedly blocked. No changes to other recipients or user workflows. No UI updates required, and no downtime or user action needed. All other behavior and settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->