### PR TITLE
fix: throw error if radix error is likely

### DIFF
--- a/typescript/radix-sdk/src/utils/base.ts
+++ b/typescript/radix-sdk/src/utils/base.ts
@@ -260,6 +260,16 @@ export class RadixBase {
           await new Promise((resolve) => setTimeout(resolve, pollDelayMs));
           continue;
         }
+        case 'LikelyButNotCertainRejection': {
+          if (statusOutput.error_message) {
+            throw new Error(
+              `Transaction ${intentHashTransactionId} was not committed successfully - instead it resulted in: ${statusOutput.intent_status} with description: ${statusOutput.error_message}`,
+            );
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, pollDelayMs));
+          continue;
+        }
         case 'CommittedSuccess': {
           try {
             const committedDetails =


### PR DESCRIPTION
### Description

This PR properly addresses the case when a Radix transaction is likely going to fail. This was noticed when we try to submit transactions where the deployer key is not authorized for it. It will now print the radix error message in detail like this:

```
Error: Transaction txid_rdx1ct69v3gvljjqswyslfzxpa396hav5a75zd0r5cgr3td9z6dukjwqmxtgc6 was not committed successfully - instead it resulted in: LikelyButNotCertainRejection with description: ErrorBeforeLoanAndDeferredCostsRepaid(SystemModuleError(AuthError(Unauthorized(Unauthorized { failed_access_rules: RoleList([Tuple(RoleKey("_owner_"), [Protected(ProofRule(Require(NonFungible(NonFungibleGlobalId { resource_address: ResourceAddress("resource_rdx1nfxxxxxxxxxxed25sgxxxxxxxxx002236757237xxxxxxxxxed25sg"), local_id: [debe9af79f3367a894293a1822b692f862d2a0b13890bb64ab7e9c19a3] }))))])]), fn_identifier: FnIdentifier { blueprint_id: BlueprintId { package_address: PackageAddress("package_rdx1pkgxxxxxxxxxaccntxxxxxxxxxx000929625493xxxxxxxxxaccntx"), blueprint_name: "Account" }, ident: "lock_fee" } }))))
```

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

Manual Testing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction polling by correctly handling an intermediate “likely but not certain” rejection state, preventing misleading outcomes.
  * Provides clearer error messages when available, including relevant context to aid troubleshooting.
  * Continues polling appropriately when no detailed error is provided, reducing false negatives and improving stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->