### PR TITLE
chore: Update mainnet3 relayer image to latest main

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -862,7 +862,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '02db74b-20251013-232420',
+      tag: 'c3b860b-20251021-080248',
     },
     blacklist,
     gasPaymentEnforcement: gasPaymentEnforcement,


### PR DESCRIPTION
## Summary
- Updated mainnet3 relayer Docker image tag from `02db74b-20251013-232420` to `c3b860b-20251021-080248`

## Details
This update brings the mainnet3 relayer to the latest main branch image, which includes:
- Fix for tracking status of all transactions (commit c3b860b)
- Latest improvements and bug fixes from main branch

## Test plan
- [ ] Verify image exists in GCR: `c3b860b-20251021-080248`
- [ ] Deploy agents using `deploy-agents.ts` script
- [ ] Monitor relayer logs for proper startup and operation
- [ ] Verify message processing continues normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)