### PR TITLE
chore: Update mainnet3 relayer image to latest main

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -862,7 +862,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '02db74b-20251013-232420',
+      tag: '7d6a86b-20251021-100620',
     },
     blacklist,
     gasPaymentEnforcement: gasPaymentEnforcement,


### PR DESCRIPTION
## Summary
- Updated mainnet3 relayer Docker image tag from `02db74b-20251013-232420` to `7d6a86b-20251021-100620`

## Details
This update brings the mainnet3 relayer to the latest main branch image, which includes:
- Latest fixes and improvements from main branch (commit 7d6a86b)
- Updated to the most recent stable build

## Test plan
- [ ] Verify image exists in GCR: `7d6a86b-20251021-100620`
- [ ] Deploy agents using `deploy-agents.ts` script
- [ ] Monitor relayer logs for proper startup and operation
- [ ] Verify message processing continues normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)