### PR TITLE
feat(infra): enable kube_job metrics in Prometheus

### DIFF
--- a/typescript/infra/src/infrastructure/monitoring/prometheus.ts
+++ b/typescript/infra/src/infrastructure/monitoring/prometheus.ts
@@ -96,8 +96,6 @@ async function getPrometheusConfig(
               action: 'keep',
               regex: `(${[
                 'container.*',
-                'optics.*',
-                'Optics.*',
                 'prometheus.*',
                 'ethereum.*',
                 'hyperlane.*',


### PR DESCRIPTION
### Description

This PR adds two Kubernetes job metrics to be sent to Prometheus -- `kube_job_*`.
This should enable better job failure alerts in Grafana. 

### Drive-by changes

- Changed a very long regex to a code fragment to make it easier to edit and review changes
- Removed the Optics metrics

### Backward compatibility

Yes, as no metrics are being removed.

### Testing

- Deploying to testnet4 cluster first
- Testing some queries in Grafana once Prometheus is redeployed
- Will have to check how many time series this is adding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Monitoring & Infrastructure**
  * Updated Prometheus remote-write configuration: pattern matching for Kubernetes job metrics now includes job failure and job creation events, and the matching expression is constructed dynamically to better accommodate multiple patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->