### PR TITLE
feat: if tx is not in mempool stage, we don't need to escalate gas

### DIFF
--- a/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
@@ -135,6 +135,12 @@ impl EthereumAdapter {
 
         let old_gas_price = old_tx_precursor.extract_gas_price();
 
+        // if transaction is not in mempool stage anymore, we don't need
+        // to escalate gas
+        if tx.status != TransactionStatus::Mempool {
+            return Ok(old_gas_price);
+        }
+
         // first, estimate the gas price
         let estimated_gas_price = gas_price::estimate_gas_price(
             &self.provider,


### PR DESCRIPTION
### Description

- EVM, only escalate gas if tx is in `Mempool` stage

### Drive-by changes

### Related issues

 - fixes https://linear.app/hyperlane-xyz/issue/ENG-2423/lander-escalate-only-if-there-tx-to-replace