### PR TITLE
chore: raise job history limits

### DIFF
--- a/typescript/infra/helm/check-warp-deploy/values.yaml
+++ b/typescript/infra/helm/check-warp-deploy/values.yaml
@@ -7,7 +7,7 @@ hyperlane:
   registryCommit: '' # Registry commit to use
 cronjob:
   schedule: '0 15 * * *'
-  successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
 externalSecrets:
   clusterSecretStore:

--- a/typescript/infra/helm/key-funder/values.yaml
+++ b/typescript/infra/helm/key-funder/values.yaml
@@ -13,7 +13,7 @@ hyperlane:
       - relayer
 cronjob:
   schedule: '*/10 * * * *' # Every 10 minutes
-  successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 6
+  failedJobsHistoryLimit: 10
 externalSecrets:
   clusterSecretStore:


### PR DESCRIPTION
### Description

Increase Kubernetes job history limits for `check-warp-deploy` and `key-funder` cronjobs to provide better debugging visibility.

  - `check-warp-deploy`: 1→3 successful, 1→5 failed (runs daily at 3pm UTC)
  - `key-funder`: 1→6 successful, 1→10 failed (runs hourly)

Higher history limits no longer interfere with Grafana alert accuracy. Recent updates to use `kube_job_*` metrics enable alerts to query only the most recently created job's status, ignoring older jobs in history.

### Backward compatibility

Yes - only increases history retention.

### Testing

- [ ] Verify history limits are applied after helm deployment
- [ ] Confirm alerts continue to function correctly with increased history