### PR TITLE
fix: do not donate on receive in `HypNative`

### DIFF
--- a/solidity/contracts/token/HypNative.sol
+++ b/solidity/contracts/token/HypNative.sol
@@ -73,7 +73,6 @@ contract HypNative is LpCollateralRouter {
         NativeCollateral._transferTo(_recipient, _amount);
     }
 
-    receive() external payable {
-        donate(msg.value);
-    }
+    // allow receiving native tokens for collateral rebalancing
+    receive() external payable {}
 }

--- a/solidity/test/token/HypNativeLp.t.sol
+++ b/solidity/test/token/HypNativeLp.t.sol
@@ -167,16 +167,6 @@ contract HypNativeLpTest is Test {
         assertEq(router.maxWithdraw(bob), bobDeposit + (donation * 2) / 3);
     }
 
-    function testReceiveCallsDonate() public {
-        assertEq(router.totalAssets(), 0);
-        vm.expectEmit(true, true, true, true);
-        emit Donation(alice, DONATE_AMOUNT);
-        vm.prank(alice);
-        (bool success, ) = address(router).call{value: DONATE_AMOUNT}("");
-        assertTrue(success);
-        assertEq(router.totalAssets(), DONATE_AMOUNT);
-    }
-
     function testMultipleDepositsAndWithdrawals() public {
         // Alice deposits
         vm.prank(alice);


### PR DESCRIPTION
### Description

> Recommend removing the donate() call in HypNative.receive(). When LP deposited via HypNative.deposit() is sent to another chain by the rebalancer and then returns, HypNative.receive() is invoked. Even though the LP is merely returning, donate() is executed and the share value can be incorrectly increased.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed automatic donation triggering when native tokens are received, enabling tokens to be accepted strictly for collateral rebalancing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->