### PR TITLE
refactor(infra): use borsh schemas for squads tx parsing

### DIFF
--- a/typescript/infra/src/tx/squads-transaction-reader.ts
+++ b/typescript/infra/src/tx/squads-transaction-reader.ts
@@ -12,20 +12,20 @@ import fs from 'fs';
 
 import {
   ChainName,
-  MailboxInstructionName,
-  MailboxInstructionType,
-  MailboxSetDefaultIsmInstruction,
-  MailboxSetDefaultIsmInstructionSchema,
-  MailboxTransferOwnershipInstruction,
-  MailboxTransferOwnershipInstructionSchema,
   MultiProtocolProvider,
-  MultisigIsmInstructionName,
-  MultisigIsmInstructionType,
-  MultisigIsmSetValidatorsInstruction,
-  MultisigIsmSetValidatorsInstructionSchema,
-  MultisigIsmTransferOwnershipInstruction,
-  MultisigIsmTransferOwnershipInstructionSchema,
   SealevelInstructionWrapper,
+  SealevelMailboxInstructionName,
+  SealevelMailboxInstructionType,
+  SealevelMailboxSetDefaultIsmInstruction,
+  SealevelMailboxSetDefaultIsmInstructionSchema,
+  SealevelMailboxTransferOwnershipInstruction,
+  SealevelMailboxTransferOwnershipInstructionSchema,
+  SealevelMultisigIsmInstructionName,
+  SealevelMultisigIsmInstructionType,
+  SealevelMultisigIsmSetValidatorsInstruction,
+  SealevelMultisigIsmSetValidatorsInstructionSchema,
+  SealevelMultisigIsmTransferOwnershipInstruction,
+  SealevelMultisigIsmTransferOwnershipInstructionSchema,
   defaultMultisigConfigs,
 } from '@hyperlane-xyz/sdk';
 import { rootLogger } from '@hyperlane-xyz/utils';
@@ -167,17 +167,18 @@ export class SquadsTransactionReader {
         // - GET_OWNER (8): GetOwner
         // - CLAIM_PROTOCOL_FEES (10): ClaimProtocolFees
         // - SET_PROTOCOL_FEE_CONFIG (11): SetProtocolFeeConfig(ProtocolFee)
-        case MailboxInstructionType.INBOX_SET_DEFAULT_ISM: {
+        case SealevelMailboxInstructionType.INBOX_SET_DEFAULT_ISM: {
           const wrapper = deserializeUnchecked(
-            MailboxSetDefaultIsmInstructionSchema,
+            SealevelMailboxSetDefaultIsmInstructionSchema,
             SealevelInstructionWrapper,
             instructionData,
           );
-          const instruction = wrapper.data as MailboxSetDefaultIsmInstruction;
+          const instruction =
+            wrapper.data as SealevelMailboxSetDefaultIsmInstruction;
           const ismAddress = instruction.newIsmPubkey.toBase58();
 
           return {
-            instructionType: MailboxInstructionName[discriminator],
+            instructionType: SealevelMailboxInstructionName[discriminator],
             data: {
               newDefaultIsm: ismAddress,
             },
@@ -186,19 +187,19 @@ export class SquadsTransactionReader {
           };
         }
 
-        case MailboxInstructionType.TRANSFER_OWNERSHIP: {
+        case SealevelMailboxInstructionType.TRANSFER_OWNERSHIP: {
           const wrapper = deserializeUnchecked(
-            MailboxTransferOwnershipInstructionSchema,
+            SealevelMailboxTransferOwnershipInstructionSchema,
             SealevelInstructionWrapper,
             instructionData,
           );
           const instruction =
-            wrapper.data as MailboxTransferOwnershipInstruction;
+            wrapper.data as SealevelMailboxTransferOwnershipInstruction;
 
           if (instruction.newOwnerPubkey) {
             const newOwnerAddress = instruction.newOwnerPubkey.toBase58();
             return {
-              instructionType: MailboxInstructionName[discriminator],
+              instructionType: SealevelMailboxInstructionName[discriminator],
               data: {
                 newOwner: newOwnerAddress,
               },
@@ -208,7 +209,7 @@ export class SquadsTransactionReader {
           }
 
           return {
-            instructionType: MailboxInstructionName[discriminator],
+            instructionType: SealevelMailboxInstructionName[discriminator],
             data: { newOwner: null },
             insight: 'Renounce ownership',
             warnings: [WarningMessage.OWNERSHIP_RENUNCIATION],
@@ -278,14 +279,14 @@ export class SquadsTransactionReader {
         // Note: Parsing not implemented for the following MultisigIsm instructions:
         // - INIT (0): Initialize
         // - GET_OWNER (2): GetOwner
-        case MultisigIsmInstructionType.SET_VALIDATORS_AND_THRESHOLD: {
+        case SealevelMultisigIsmInstructionType.SET_VALIDATORS_AND_THRESHOLD: {
           const wrapper = deserializeUnchecked(
-            MultisigIsmSetValidatorsInstructionSchema,
+            SealevelMultisigIsmSetValidatorsInstructionSchema,
             SealevelInstructionWrapper,
             borshData,
           );
           const instruction =
-            wrapper.data as MultisigIsmSetValidatorsInstruction;
+            wrapper.data as SealevelMultisigIsmSetValidatorsInstruction;
 
           const remoteChain = this.mpp.tryGetChainName(instruction.domain);
           const chainInfo = remoteChain
@@ -296,7 +297,7 @@ export class SquadsTransactionReader {
           const insight = `Set ${validatorCount} validator${validatorCount > 1 ? 's' : ''} with threshold ${instruction.threshold} for ${chainInfo}`;
 
           return {
-            instructionType: MultisigIsmInstructionName[discriminator],
+            instructionType: SealevelMultisigIsmInstructionName[discriminator],
             data: {
               domain: instruction.domain,
               threshold: instruction.threshold,
@@ -308,19 +309,20 @@ export class SquadsTransactionReader {
           };
         }
 
-        case MultisigIsmInstructionType.TRANSFER_OWNERSHIP: {
+        case SealevelMultisigIsmInstructionType.TRANSFER_OWNERSHIP: {
           const wrapper = deserializeUnchecked(
-            MultisigIsmTransferOwnershipInstructionSchema,
+            SealevelMultisigIsmTransferOwnershipInstructionSchema,
             SealevelInstructionWrapper,
             borshData,
           );
           const instruction =
-            wrapper.data as MultisigIsmTransferOwnershipInstruction;
+            wrapper.data as SealevelMultisigIsmTransferOwnershipInstruction;
 
           if (instruction.newOwnerPubkey) {
             const newOwnerAddress = instruction.newOwnerPubkey.toBase58();
             return {
-              instructionType: MultisigIsmInstructionName[discriminator],
+              instructionType:
+                SealevelMultisigIsmInstructionName[discriminator],
               data: {
                 newOwner: newOwnerAddress,
               },
@@ -330,7 +332,7 @@ export class SquadsTransactionReader {
           }
 
           return {
-            instructionType: MultisigIsmInstructionName[discriminator],
+            instructionType: SealevelMultisigIsmInstructionName[discriminator],
             data: { newOwner: null },
             insight: 'Renounce ownership',
             warnings: [WarningMessage.OWNERSHIP_RENUNCIATION],
@@ -979,8 +981,8 @@ export class SquadsTransactionReader {
 
     // Add args for important instructions
     switch (inst.instructionType) {
-      case MultisigIsmInstructionName[
-        MultisigIsmInstructionType.SET_VALIDATORS_AND_THRESHOLD
+      case SealevelMultisigIsmInstructionName[
+        SealevelMultisigIsmInstructionType.SET_VALIDATORS_AND_THRESHOLD
       ]: {
         // Get remote chain for aliases
         const remoteChain = this.mpp.tryGetChainName(inst.data.domain);
@@ -1023,8 +1025,8 @@ export class SquadsTransactionReader {
         break;
       }
 
-      case MailboxInstructionName[
-        MailboxInstructionType.INBOX_SET_DEFAULT_ISM
+      case SealevelMailboxInstructionName[
+        SealevelMailboxInstructionType.INBOX_SET_DEFAULT_ISM
       ]: {
         tx.args = {
           module: inst.data.newDefaultIsm,
@@ -1032,9 +1034,11 @@ export class SquadsTransactionReader {
         break;
       }
 
-      case MailboxInstructionName[MailboxInstructionType.TRANSFER_OWNERSHIP]:
-      case MultisigIsmInstructionName[
-        MultisigIsmInstructionType.TRANSFER_OWNERSHIP
+      case SealevelMailboxInstructionName[
+        SealevelMailboxInstructionType.TRANSFER_OWNERSHIP
+      ]:
+      case SealevelMultisigIsmInstructionName[
+        SealevelMultisigIsmInstructionType.TRANSFER_OWNERSHIP
       ]: {
         tx.args = {
           newOwner: inst.data.newOwner || null,

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -218,20 +218,20 @@ export {
   multisigConfigToIsmConfig,
 } from './ism/multisig.js';
 export {
-  MultisigIsmInstructionName,
-  MultisigIsmInstructionType,
-  MultisigIsmSetValidatorsInstruction,
-  MultisigIsmSetValidatorsInstructionSchema,
-  MultisigIsmTransferOwnershipInstruction,
-  MultisigIsmTransferOwnershipInstructionSchema,
+  SealevelMultisigIsmInstructionName,
+  SealevelMultisigIsmInstructionType,
+  SealevelMultisigIsmSetValidatorsInstruction,
+  SealevelMultisigIsmSetValidatorsInstructionSchema,
+  SealevelMultisigIsmTransferOwnershipInstruction,
+  SealevelMultisigIsmTransferOwnershipInstructionSchema,
 } from './ism/serialization.js';
 export {
-  MailboxInstructionName,
-  MailboxInstructionType,
-  MailboxSetDefaultIsmInstruction,
-  MailboxSetDefaultIsmInstructionSchema,
-  MailboxTransferOwnershipInstruction,
-  MailboxTransferOwnershipInstructionSchema,
+  SealevelMailboxInstructionName,
+  SealevelMailboxInstructionType,
+  SealevelMailboxSetDefaultIsmInstruction,
+  SealevelMailboxSetDefaultIsmInstructionSchema,
+  SealevelMailboxTransferOwnershipInstruction,
+  SealevelMailboxTransferOwnershipInstructionSchema,
 } from './mailbox/serialization.js';
 export {
   AggregationIsmConfig,

--- a/typescript/sdk/src/ism/serialization.ts
+++ b/typescript/sdk/src/ism/serialization.ts
@@ -6,22 +6,22 @@ import { SealevelInstructionWrapper } from '../utils/sealevelSerialization.js';
  * MultisigIsm instruction types matching Rust enum
  * See: rust/sealevel/programs/ism/multisig-ism-message-id/src/instruction.rs
  */
-export enum MultisigIsmInstructionType {
+export enum SealevelMultisigIsmInstructionType {
   INIT = 0,
   SET_VALIDATORS_AND_THRESHOLD = 1,
   GET_OWNER = 2,
   TRANSFER_OWNERSHIP = 3,
 }
 
-export const MultisigIsmInstructionName: Record<
-  MultisigIsmInstructionType,
+export const SealevelMultisigIsmInstructionName: Record<
+  SealevelMultisigIsmInstructionType,
   string
 > = {
-  [MultisigIsmInstructionType.INIT]: 'Init',
-  [MultisigIsmInstructionType.SET_VALIDATORS_AND_THRESHOLD]:
+  [SealevelMultisigIsmInstructionType.INIT]: 'Init',
+  [SealevelMultisigIsmInstructionType.SET_VALIDATORS_AND_THRESHOLD]:
     'SetValidatorsAndThreshold',
-  [MultisigIsmInstructionType.GET_OWNER]: 'GetOwner',
-  [MultisigIsmInstructionType.TRANSFER_OWNERSHIP]: 'TransferOwnership',
+  [SealevelMultisigIsmInstructionType.GET_OWNER]: 'GetOwner',
+  [SealevelMultisigIsmInstructionType.TRANSFER_OWNERSHIP]: 'TransferOwnership',
 };
 
 /**
@@ -31,7 +31,7 @@ export const MultisigIsmInstructionName: Record<
  * Note: Instruction format AFTER 8-byte program discriminator:
  * [enum_discriminator: u8, domain: u32, validators: Vec<[u8; 20]>, threshold: u8]
  */
-export class MultisigIsmSetValidatorsInstruction {
+export class SealevelMultisigIsmSetValidatorsInstruction {
   domain!: number;
   validators!: Uint8Array[]; // Vec<[u8; 20]> - Ethereum addresses
   threshold!: number;
@@ -46,19 +46,22 @@ export class MultisigIsmSetValidatorsInstruction {
   }
 }
 
-export const MultisigIsmSetValidatorsInstructionSchema = new Map<any, any>([
+export const SealevelMultisigIsmSetValidatorsInstructionSchema = new Map<
+  any,
+  any
+>([
   [
     SealevelInstructionWrapper,
     {
       kind: 'struct',
       fields: [
         ['instruction', 'u8'], // Enum discriminator (1 byte, after 8-byte program discriminator)
-        ['data', MultisigIsmSetValidatorsInstruction],
+        ['data', SealevelMultisigIsmSetValidatorsInstruction],
       ],
     },
   ],
   [
-    MultisigIsmSetValidatorsInstruction,
+    SealevelMultisigIsmSetValidatorsInstruction,
     {
       kind: 'struct',
       fields: [
@@ -73,7 +76,7 @@ export const MultisigIsmSetValidatorsInstructionSchema = new Map<any, any>([
 /**
  * TransferOwnership instruction data
  */
-export class MultisigIsmTransferOwnershipInstruction {
+export class SealevelMultisigIsmTransferOwnershipInstruction {
   newOwner!: Uint8Array | null;
   newOwnerPubkey?: PublicKey;
 
@@ -85,19 +88,22 @@ export class MultisigIsmTransferOwnershipInstruction {
   }
 }
 
-export const MultisigIsmTransferOwnershipInstructionSchema = new Map<any, any>([
+export const SealevelMultisigIsmTransferOwnershipInstructionSchema = new Map<
+  any,
+  any
+>([
   [
     SealevelInstructionWrapper,
     {
       kind: 'struct',
       fields: [
         ['instruction', 'u8'],
-        ['data', MultisigIsmTransferOwnershipInstruction],
+        ['data', SealevelMultisigIsmTransferOwnershipInstruction],
       ],
     },
   ],
   [
-    MultisigIsmTransferOwnershipInstruction,
+    SealevelMultisigIsmTransferOwnershipInstruction,
     {
       kind: 'struct',
       fields: [

--- a/typescript/sdk/src/mailbox/serialization.ts
+++ b/typescript/sdk/src/mailbox/serialization.ts
@@ -6,7 +6,7 @@ import { SealevelInstructionWrapper } from '../utils/sealevelSerialization.js';
  * Mailbox instruction types matching Rust enum
  * See: rust/sealevel/programs/mailbox/src/instruction.rs
  */
-export enum MailboxInstructionType {
+export enum SealevelMailboxInstructionType {
   INIT = 0,
   INBOX_PROCESS = 1,
   INBOX_SET_DEFAULT_ISM = 2,
@@ -21,27 +21,32 @@ export enum MailboxInstructionType {
   SET_PROTOCOL_FEE_CONFIG = 11,
 }
 
-export const MailboxInstructionName: Record<MailboxInstructionType, string> = {
-  [MailboxInstructionType.INIT]: 'Init',
-  [MailboxInstructionType.INBOX_PROCESS]: 'InboxProcess',
-  [MailboxInstructionType.INBOX_SET_DEFAULT_ISM]: 'InboxSetDefaultIsm',
-  [MailboxInstructionType.INBOX_GET_RECIPIENT_ISM]: 'InboxGetRecipientIsm',
-  [MailboxInstructionType.OUTBOX_DISPATCH]: 'OutboxDispatch',
-  [MailboxInstructionType.OUTBOX_GET_COUNT]: 'OutboxGetCount',
-  [MailboxInstructionType.OUTBOX_GET_LATEST_CHECKPOINT]:
+export const SealevelMailboxInstructionName: Record<
+  SealevelMailboxInstructionType,
+  string
+> = {
+  [SealevelMailboxInstructionType.INIT]: 'Init',
+  [SealevelMailboxInstructionType.INBOX_PROCESS]: 'InboxProcess',
+  [SealevelMailboxInstructionType.INBOX_SET_DEFAULT_ISM]: 'InboxSetDefaultIsm',
+  [SealevelMailboxInstructionType.INBOX_GET_RECIPIENT_ISM]:
+    'InboxGetRecipientIsm',
+  [SealevelMailboxInstructionType.OUTBOX_DISPATCH]: 'OutboxDispatch',
+  [SealevelMailboxInstructionType.OUTBOX_GET_COUNT]: 'OutboxGetCount',
+  [SealevelMailboxInstructionType.OUTBOX_GET_LATEST_CHECKPOINT]:
     'OutboxGetLatestCheckpoint',
-  [MailboxInstructionType.OUTBOX_GET_ROOT]: 'OutboxGetRoot',
-  [MailboxInstructionType.GET_OWNER]: 'GetOwner',
-  [MailboxInstructionType.TRANSFER_OWNERSHIP]: 'TransferOwnership',
-  [MailboxInstructionType.CLAIM_PROTOCOL_FEES]: 'ClaimProtocolFees',
-  [MailboxInstructionType.SET_PROTOCOL_FEE_CONFIG]: 'SetProtocolFeeConfig',
+  [SealevelMailboxInstructionType.OUTBOX_GET_ROOT]: 'OutboxGetRoot',
+  [SealevelMailboxInstructionType.GET_OWNER]: 'GetOwner',
+  [SealevelMailboxInstructionType.TRANSFER_OWNERSHIP]: 'TransferOwnership',
+  [SealevelMailboxInstructionType.CLAIM_PROTOCOL_FEES]: 'ClaimProtocolFees',
+  [SealevelMailboxInstructionType.SET_PROTOCOL_FEE_CONFIG]:
+    'SetProtocolFeeConfig',
 };
 
 /**
  * SetDefaultIsm instruction data
  * Matches: rust/sealevel/programs/mailbox/src/instruction.rs
  */
-export class MailboxSetDefaultIsmInstruction {
+export class SealevelMailboxSetDefaultIsmInstruction {
   newIsm!: Uint8Array;
   newIsmPubkey!: PublicKey;
 
@@ -51,19 +56,19 @@ export class MailboxSetDefaultIsmInstruction {
   }
 }
 
-export const MailboxSetDefaultIsmInstructionSchema = new Map<any, any>([
+export const SealevelMailboxSetDefaultIsmInstructionSchema = new Map<any, any>([
   [
     SealevelInstructionWrapper,
     {
       kind: 'struct',
       fields: [
         ['instruction', 'u32'], // Borsh enum discriminator (4 bytes)
-        ['data', MailboxSetDefaultIsmInstruction],
+        ['data', SealevelMailboxSetDefaultIsmInstruction],
       ],
     },
   ],
   [
-    MailboxSetDefaultIsmInstruction,
+    SealevelMailboxSetDefaultIsmInstruction,
     {
       kind: 'struct',
       fields: [
@@ -77,7 +82,7 @@ export const MailboxSetDefaultIsmInstructionSchema = new Map<any, any>([
  * TransferOwnership instruction data
  * Matches: rust/sealevel/programs/mailbox/src/instruction.rs
  */
-export class MailboxTransferOwnershipInstruction {
+export class SealevelMailboxTransferOwnershipInstruction {
   newOwner!: Uint8Array | null;
   newOwnerPubkey?: PublicKey;
 
@@ -89,19 +94,22 @@ export class MailboxTransferOwnershipInstruction {
   }
 }
 
-export const MailboxTransferOwnershipInstructionSchema = new Map<any, any>([
+export const SealevelMailboxTransferOwnershipInstructionSchema = new Map<
+  any,
+  any
+>([
   [
     SealevelInstructionWrapper,
     {
       kind: 'struct',
       fields: [
         ['instruction', 'u32'],
-        ['data', MailboxTransferOwnershipInstruction],
+        ['data', SealevelMailboxTransferOwnershipInstruction],
       ],
     },
   ],
   [
-    MailboxTransferOwnershipInstruction,
+    SealevelMailboxTransferOwnershipInstruction,
     {
       kind: 'struct',
       fields: [


### PR DESCRIPTION
### Description

refactor(infra): use borsh schemas for squads tx parsing

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

https://linear.app/hyperlane-xyz/issue/ENG-2452/refactor-mailboxmultisig-parsing-to-use-borsch-schemas

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

parsing still works fine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed Sealevel Mailbox and Multisig-ISM instruction types in the SDK for richer transaction metadata.
  * New decoding surfaces ownership, default ISM, validator list and threshold details in transaction insights.

* **Improvements**
  * Switched to structured deserialization for more reliable parsing and clearer human-readable insights.
  * Consistent error handling and standardized warnings for unknown or failed instruction parses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->