### PR TITLE
chore: add multi vm branch to ci allow list

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   # Triggers the workflow on pushes to main branch
   push:
-    branches: [main, 'audit-*']
+    branches: [main, 'audit-*', 'feat/multi-vm']
   # Triggers on pull requests
   pull_request:
     branches:


### PR DESCRIPTION
### Description

Enables PRs pointing to the multi vm feature branch to run the ci to ensure nothing breaks during the refactor

### Drive-by changes

- 

### Related issues

- 

### Backward compatibility

- yes

### Testing

- None