### PR TITLE
feat: allow test action to run on multi vm feature branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -516,7 +516,7 @@ jobs:
 
   e2e-matrix:
     runs-on: depot-ubuntu-24.04-8
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main' || github.base_ref == 'cli-2.0' || github.base_ref == 'feat/multi-vm') || github.event_name == 'merge_group'
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main' || github.base_ref == 'feat/multi-vm') || github.event_name == 'merge_group'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Description

Adds the multi vm feature branch explicitly to the allow list for running test in ci when openinf a pr as the `*` selector does not work if the target branch name has a `/`

### Drive-by changes

- Removed cli-2.0 in test ci config

### Related issues

- 

### Backward compatibility

- yes

### Testing


