### PR TITLE
fix: Add response into log of fallback request

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
@@ -216,6 +216,7 @@ where
                     provider_index = priority.index,
                     provider_host = provider_host.as_str(),
                     method,
+                    ?resp,
                     "fallback_request"
                 );
 


### PR DESCRIPTION
### Description

Add response into log of fallback request so that we are very explicit of what RPC provider returns as response.

### Backward compatibility

Yes

### Testing

Manual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced debug logging for provider fallback requests to improve diagnostic visibility when multiple providers are attempted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->