### PR TITLE
chore: make denom optional in altvm interface

### DIFF
--- a/typescript/cosmos-sdk/src/clients/provider.ts
+++ b/typescript/cosmos-sdk/src/clients/provider.ts
@@ -113,11 +113,15 @@ export class CosmosNativeProvider implements AltVM.IProvider<EncodeObject> {
   }
 
   async getBalance(req: AltVM.ReqGetBalance): Promise<bigint> {
+    assert(req.denom, `denom required by ${CosmosNativeProvider.name}`);
+
     const coin = await this.query.bank.balance(req.address, req.denom);
     return BigInt(coin.amount);
   }
 
   async getTotalSupply(req: AltVM.ReqGetTotalSupply): Promise<bigint> {
+    assert(req.denom, `denom required by ${CosmosNativeProvider.name}`);
+
     const coin = await this.query.bank.supplyOf(req.denom);
     return BigInt(coin.amount);
   }
@@ -755,6 +759,8 @@ export class CosmosNativeProvider implements AltVM.IProvider<EncodeObject> {
   async getTransferTransaction(
     req: AltVM.ReqTransfer,
   ): Promise<MsgSendEncodeObject> {
+    assert(req.denom, `denom required by ${CosmosNativeProvider.name}`);
+
     return {
       typeUrl: '/cosmos.bank.v1beta1.MsgSend',
       value: {

--- a/typescript/cosmos-sdk/src/clients/signer.ts
+++ b/typescript/cosmos-sdk/src/clients/signer.ts
@@ -385,6 +385,8 @@ export class CosmosNativeSigner
   async createInterchainGasPaymasterHook(
     req: Omit<AltVM.ReqCreateInterchainGasPaymasterHook, 'signer'>,
   ): Promise<AltVM.ResCreateInterchainGasPaymasterHook> {
+    assert(req.denom, `denom required by ${CosmosNativeSigner.name}`);
+
     const msg = await this.getCreateInterchainGasPaymasterHookTransaction({
       ...req,
       signer: this.account.address,
@@ -520,6 +522,8 @@ export class CosmosNativeSigner
   async transfer(
     req: Omit<AltVM.ReqTransfer, 'signer'>,
   ): Promise<AltVM.ResTransfer> {
+    assert(req.denom, `denom required by ${CosmosNativeSigner.name}`);
+
     const msg = await this.getTransferTransaction({
       ...req,
       signer: this.account.address,

--- a/typescript/radix-sdk/src/clients/provider.ts
+++ b/typescript/radix-sdk/src/clients/provider.ts
@@ -132,6 +132,8 @@ export class RadixProvider implements AltVM.IProvider<RadixSDKTransaction> {
   }
 
   async getBalance(req: AltVM.ReqGetBalance): Promise<bigint> {
+    assert(req.denom, `denom required by ${RadixProvider.name}`);
+
     return this.base.getBalance({
       address: req.address,
       resource: req.denom,
@@ -139,6 +141,8 @@ export class RadixProvider implements AltVM.IProvider<RadixSDKTransaction> {
   }
 
   async getTotalSupply(req: AltVM.ReqGetTotalSupply): Promise<bigint> {
+    assert(req.denom, `denom required by ${RadixProvider.name}`);
+
     return this.base.getTotalSupply({
       resource: req.denom,
     });
@@ -479,6 +483,8 @@ export class RadixProvider implements AltVM.IProvider<RadixSDKTransaction> {
   async getCreateInterchainGasPaymasterHookTransaction(
     req: AltVM.ReqCreateInterchainGasPaymasterHook,
   ): Promise<RadixSDKTransaction> {
+    assert(req.denom, `denom required by ${RadixProvider.name}`);
+
     return {
       networkId: this.networkId,
       manifest: await this.populate.core.createIgp({
@@ -613,6 +619,8 @@ export class RadixProvider implements AltVM.IProvider<RadixSDKTransaction> {
   async getTransferTransaction(
     req: AltVM.ReqTransfer,
   ): Promise<RadixSDKTransaction> {
+    assert(req.denom, `denom required by ${RadixProvider.name}`);
+
     return {
       networkId: this.networkId,
       manifest: await this.base.transfer({

--- a/typescript/radix-sdk/src/clients/signer.ts
+++ b/typescript/radix-sdk/src/clients/signer.ts
@@ -301,6 +301,8 @@ export class RadixSigner
   async createInterchainGasPaymasterHook(
     req: Omit<AltVM.ReqCreateInterchainGasPaymasterHook, 'signer'>,
   ): Promise<AltVM.ResCreateInterchainGasPaymasterHook> {
+    assert(req.denom, `denom required by ${RadixProvider.name}`);
+
     return {
       hookAddress: await this.tx.core.createIgp({
         denom: req.denom,
@@ -427,6 +429,8 @@ export class RadixSigner
   async transfer(
     req: Omit<AltVM.ReqTransfer, 'signer'>,
   ): Promise<AltVM.ResTransfer> {
+    assert(req.denom, `denom required by ${RadixProvider.name}`);
+
     const manifest = await this.base.transfer({
       from_address: this.account.address,
       to_address: req.recipient,

--- a/typescript/utils/src/altvm.ts
+++ b/typescript/utils/src/altvm.ts
@@ -2,9 +2,9 @@ import { MinimumRequiredGasByAction } from './mingas.js';
 import { ProtocolType } from './types.js';
 
 // ### QUERY BASE ###
-export type ReqGetBalance = { address: string; denom: string };
+export type ReqGetBalance = { address: string; denom?: string };
 
-export type ReqGetTotalSupply = { denom: string };
+export type ReqGetTotalSupply = { denom?: string };
 
 export type ReqEstimateTransactionFee<T> = {
   transaction: T;
@@ -296,7 +296,7 @@ export type ResCreateMerkleTreeHook = {
 
 export type ReqCreateInterchainGasPaymasterHook = {
   signer: string;
-  denom: string;
+  denom?: string;
 };
 export type ResCreateInterchainGasPaymasterHook = {
   hookAddress: string;
@@ -407,7 +407,7 @@ export type ResUnenrollRemoteRouter = {
 export type ReqTransfer = {
   signer: string;
   recipient: string;
-  denom: string;
+  denom?: string;
   amount: string;
 };
 export type ResTransfer = {


### PR DESCRIPTION
### Description

This PR adds missing methods to the altvm interface

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

e2e tests
