### PR TITLE
fix: Check if validators is enabled for a chain in set-rpc-urls.ts

### DIFF
--- a/typescript/infra/src/utils/rpcUrls.ts
+++ b/typescript/infra/src/utils/rpcUrls.ts
@@ -302,7 +302,10 @@ async function refreshDependentK8sResourcesInteractive(
     if (agentConfig.relayer) {
       pushContextHelmManager(context, new RelayerHelmManager(agentConfig));
     }
-    if (agentConfig.validators) {
+    if (
+      agentConfig.validators &&
+      agentConfig.contextChainNames.validator?.includes(chain)
+    ) {
       pushContextHelmManager(
         context,
         new ValidatorHelmManager(agentConfig, chain),


### PR DESCRIPTION
### Description

Check if validators is enabled for a chain in set-rpc-urls.ts

### Backward compatibility

Yes

### Testing

Manual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validator activation to ensure validators are only enabled on explicitly configured chains, improving chain-specific validator management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->