### PR TITLE
fix: Do not lint after `forge build`

### DIFF
--- a/solidity/foundry.toml
+++ b/solidity/foundry.toml
@@ -29,3 +29,6 @@ base = "https://mainnet.base.org"
 [fuzz]
 runs = 50
 dictionary_weight = 80
+
+[lint]
+lint_on_build = false


### PR DESCRIPTION
### Description

`forge lint` runs after every `forge build` by default. Skip this linting step as the stable version of `forge` does not work with our monorepo setup (`forge` can't find `/node_modules` which is in the root).

This fixes some CI errors we've been seeing, e.g. in https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/19343043679/job/55336299771?pr=7377.

### Backward compatibility

Yes

### Testing

Before adding this config, the build fails
```shell
➜  solidity git:(fix-forge-ci) forge build
[⠒] Compiling...
No files changed, compilation skipped
Error: Lint failed

Context:
- solar run failed:

error: file ../Strings.sol not found
 --> ../node_modules/@openzeppelin/contracts/utils/cryptography/ECDSA.sol:6:8
  |
6 | import "../Strings.sol";
  |        ^^^^^^^^^^^^^^^^
```


After adding this config value to foundry.toml, building works.
```shell
➜  solidity git:(fix-forge-ci) ✗ forge clean && forge build
[⠒] Compiling...
[⠒] Compiling 407 files with Solc 0.8.22
[⠰] Solc 0.8.22 finished in 46.71s
Compiler run successful with warnings:
Warning (2519): This declaration shadows an existing declaration.
  --> contracts/mock/MockCircleMessageTransmitter.sol:53:13:
   |
...

➜  solidity git:(fix-forge-ci) ✗ 
```
This was tested with the following version of forge:
```shell
➜  solidity git:(fix-forge-ci) forge --version
forge Version: 1.4.4-stable
Commit SHA: 05794498bf47257b144e2e2789a1d5bf8566be0e
Build Timestamp: 2025-11-03T23:46:57.847015000Z (1762213617)
Build Profile: maxperf
```