### PR TITLE
fix: set from address when performing eth_estimateGas calls

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/tx.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/tx.rs
@@ -131,6 +131,16 @@ where
     M: Middleware + 'static,
     D: Detokenize,
 {
+    // Set the from address to the signer's address when estimating gas.
+    // On some chains, if no `from` address is specified, the RPC assumes the zero address,
+    // which may not have funds, causing gas estimation to fail even though the relayer
+    // has sufficient funds. See: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4585
+    let tx = if let Some(signer) = provider.default_sender() {
+        tx.from(signer)
+    } else {
+        tx
+    };
+
     // either use the pre-estimated gas limit or estimate it
     let mut estimated_gas_limit: U256 = match tx.tx.gas() {
         Some(&estimate) => estimate.into(),


### PR DESCRIPTION
## Description

On some chains (e.g., Citrea testnet), when no `from` address is specified in `eth_estimateGas` calls, the RPC defaults to using the zero address. If the zero address has no funds, gas estimation fails even when the relayer has sufficient funds.

## Changes

This PR sets the `from` address to the signer's address in all locations where gas estimation is performed:

- ✅ `estimate_gas_limit` in [provider.rs](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs)
- ✅ `estimate_batch` in [provider.rs](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs)
- ✅ `fill_tx_gas_params` in [tx.rs](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/rust/main/chains/hyperlane-ethereum/src/tx.rs)
- ✅ Arbitrum-specific estimation in [mailbox.rs](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs)
- ✅ ISM verification in [interchain_security_module.rs](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/rust/main/chains/hyperlane-ethereum/src/ism/interchain_security_module.rs)

## Testing

The fix ensures that when a signer is configured, its address is used for gas estimation, preventing failures on chains that check balance at the `from` address during estimation.

Fixes #4585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gas estimation reliability by properly utilizing the signer's address when available, reducing gas estimation failures across various blockchain networks. Implemented fallback mechanisms for chains with specific requirements to ensure consistent transaction preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->