### PR TITLE
feat: add integration test for no tx receipt getting dropped

### DIFF
--- a/rust/main/lander/src/tests/evm/tests_inclusion_stage.rs
+++ b/rust/main/lander/src/tests/evm/tests_inclusion_stage.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant, SystemTime};
 
 use chrono::{TimeZone, Utc};
-use core::panic;
 use ethers::types::transaction::eip2718::TypedTransaction;
 use ethers::types::{
     Address, Bloom, Eip1559TransactionRequest, TransactionReceipt, H160, U256 as EthersU256, U64,


### PR DESCRIPTION
### Description

 - add integration tests for when there are no transaction receipts received, tx is dropped after reaching gas limit cap

### Related issues

- fixes https://linear.app/hyperlane-xyz/issue/ENG-2480/lander-evm-no-tx-receipt-integration-test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added additional unit tests covering transaction behavior under rapid gas price escalation.
* **Chores**
  * Minor test-code cleanup and duplication consolidation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->