### PR TITLE
feat: update grpc secrets to work with cosmosnative as well

### DIFF
--- a/rust/main/helm/hyperlane-agent/templates/external-secret.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/external-secret.yaml
@@ -27,7 +27,7 @@ spec:
    */}}
         {{- range .Values.hyperlane.chains }}
         HYP_CHAINS_{{ .name | upper }}_CUSTOMRPCURLS: {{ printf "'{{ .%s_rpcs | mustFromJson | join \",\" }}'" .name }}
-        {{- if eq .protocol "cosmos" }}
+        {{- if or (eq .protocol "cosmos") (eq .protocol "cosmosnative") }}
         HYP_CHAINS_{{ .name | upper }}_CUSTOMGRPCURLS: {{ printf "'{{ .%s_grpcs | mustFromJson | join \",\" }}'" .name }}
         {{- end }}
         {{- if eq .protocol "sealevel" }}
@@ -48,7 +48,7 @@ spec:
   - secretKey: {{ printf "%s_rpcs" .name }}
     remoteRef:
       key: {{ printf "%s-rpc-endpoints-%s" $.Values.hyperlane.runEnv .name }}
-  {{- if eq .protocol "cosmos" }}
+  {{- if or (eq .protocol "cosmos") (eq .protocol "cosmosnative") }}
   - secretKey: {{ printf "%s_grpcs" .name }}
     remoteRef:
       key: {{ printf "%s-grpc-endpoints-%s" $.Values.hyperlane.runEnv .name }}


### PR DESCRIPTION
### Description

Fix, we want to fetch grpc secrets for cosmosnative chains as well

### Backward compatibility

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended external secret configuration to support an additional protocol type for GRPC URL and secret key population, enabling broader protocol support in agent deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->