### PR TITLE
CI: migrate workflows to checkout v6

### DIFF
--- a/.github/actions/checkout-registry/action.yml
+++ b/.github/actions/checkout-registry/action.yml
@@ -17,7 +17,7 @@ runs:
         fi
 
     - name: Checkout hyperlane-registry
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         repository: hyperlane-xyz/hyperlane-registry
         ref: ${{ env.REGISTRY_VERSION }}

--- a/.github/workflows/agent-release-artifacts.yml
+++ b/.github/workflows/agent-release-artifacts.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ matrix.OS }}
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: ubuntu setup
         if: ${{ matrix.OS == 'depot-ubuntu-24.04-8' }}
         run: |

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup python
         uses: actions/setup-python@v6

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -51,7 +51,7 @@ jobs:
     if: needs.check-env.outputs.gcloud-service-key == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: depot-ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # check out full history
           fetch-depth: 0
@@ -70,7 +70,7 @@ jobs:
     outputs:
       all_latest: ${{ steps.check.outputs.all_latest }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Retrieve package versions
         id: pkg
@@ -110,7 +110,7 @@ jobs:
         node-version: [18, 19, 20, 21, 22, 23]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # check out full history
           fetch-depth: 0

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -42,7 +42,7 @@ jobs:
     needs: [check-env]
     if: needs.check-env.outputs.gcloud-service-key == 'true'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Generate tag data

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -39,7 +39,7 @@ jobs:
       current_version: ${{ steps.check_version.outputs.current_version }}
       latest_version: ${{ steps.check_version.outputs.latest_version }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check if there are changes since last release
@@ -104,7 +104,7 @@ jobs:
       needs.check-release-status.outputs.has_changes == 'true' &&
       needs.check-release-status.outputs.should_release == 'false'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
@@ -257,7 +257,7 @@ jobs:
         github.event_name == 'push' &&
         needs.check-release-status.outputs.should_release == 'true')
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Determine version and create release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
   lander-coverage:
     runs-on: depot-ubuntu-24.04-8
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
@@ -68,7 +68,7 @@ jobs:
   test-rs:
     runs-on: depot-ubuntu-24.04-8
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
@@ -95,7 +95,7 @@ jobs:
   lint-rs:
     runs-on: depot-ubuntu-24.04-8
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/simapp-docker.yml
+++ b/.github/workflows/simapp-docker.yml
@@ -36,7 +36,7 @@ jobs:
     if: needs.check-env.outputs.gcloud-service-key == 'true'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive

--- a/.github/workflows/storage-analysis.yml
+++ b/.github/workflows/storage-analysis.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Checkout the PR branch
       - name: Checkout PR branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
   yarn-install:
     runs-on: depot-ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
@@ -60,7 +60,7 @@ jobs:
     runs-on: depot-ubuntu-24.04-8
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -109,7 +109,7 @@ jobs:
       current_sha: ${{ steps.determine-sha.outputs.current_sha }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -123,7 +123,7 @@ jobs:
       only_rust: ${{ steps.override-main.outputs.only_rust || steps.check-rust.outputs.only_changes }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
@@ -152,7 +152,7 @@ jobs:
     timeout-minutes: 10
     if: needs.rust-only.outputs.only_rust == 'false'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
@@ -176,7 +176,7 @@ jobs:
     needs: [yarn-test-run]
     if: always()
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Check yarn-test status
         uses: ./.github/actions/check-job-status
         with:
@@ -191,7 +191,7 @@ jobs:
       BALANCE_CHANGES: false
       WARP_CONFIG_CHANGES: false
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
@@ -239,7 +239,7 @@ jobs:
     needs: [rust-only]
     if: needs.rust-only.outputs.only_rust == 'false'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -257,7 +257,7 @@ jobs:
     needs: [cli-install-test-run]
     if: always()
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Check cli-install-test status
         uses: ./.github/actions/check-job-status
         with:
@@ -303,7 +303,7 @@ jobs:
           - warp-rebalancer
           - warp-send
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
@@ -343,7 +343,7 @@ jobs:
           - warp-deploy
           - warp-read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
@@ -381,7 +381,7 @@ jobs:
           - warp-apply-ownership-updates
           - warp-apply-route-extension
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
@@ -413,7 +413,7 @@ jobs:
           - warp-apply
           - warp-deploy
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
@@ -443,7 +443,7 @@ jobs:
       ]
     if: always()
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Check CLI EVM E2E status
         uses: ./.github/actions/check-job-status
         with:
@@ -471,7 +471,7 @@ jobs:
     if: needs.rust-only.outputs.only_rust == 'false'
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
@@ -489,7 +489,7 @@ jobs:
     needs: [cosmos-sdk-e2e-run]
     if: always()
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Check cosmos-sdk-e2e status
         uses: ./.github/actions/check-job-status
         with:
@@ -503,7 +503,7 @@ jobs:
       matrix:
         environment: [mainnet3, testnet4]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -534,7 +534,7 @@ jobs:
       matrix:
         e2e-type: [cosmwasm, cosmosnative, evm, sealevel, starknet, radix]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
@@ -738,7 +738,7 @@ jobs:
             module: core
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -768,7 +768,7 @@ jobs:
     needs: env-test-matrix
     if: always()
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Check env-test matrix status
         uses: ./.github/actions/check-job-status
         with:
@@ -781,7 +781,7 @@ jobs:
     outputs:
       has_solidity_changes: ${{ steps.check-solidity.outputs.has_changes }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -798,7 +798,7 @@ jobs:
     needs: [check-solidity-changes]
     if: needs.check-solidity-changes.outputs.has_solidity_changes == 'true'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 


### PR DESCRIPTION
Bumps `actions/checkout` from v5 to v6. Workflow-only change, no impact on functionality.

https://github.com/actions/checkout/releases/tag/v6.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD and automation workflow infrastructure across multiple pipelines to use a newer version of the checkout action. No functional impact to application behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->