### PR TITLE
chore: increase tonic message size

### DIFF
--- a/rust/main/chains/hyperlane-cosmos/src/providers/grpc.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/grpc.rs
@@ -2,7 +2,6 @@ use std::ops::Deref;
 use std::time::Duration;
 
 use derive_new::new;
-use ibc_proto::cosmos::base::tendermint::v1beta1::GetLatestValidatorSetRequest;
 use tonic::async_trait;
 use tonic::transport::{Channel, Endpoint};
 
@@ -13,7 +12,7 @@ use hyperlane_metric::prometheus_metric::{
 };
 
 use cosmrs::proto::cosmos::base::tendermint::v1beta1::service_client::ServiceClient;
-use cosmrs::proto::cosmos::base::tendermint::v1beta1::GetLatestBlockRequest;
+use cosmrs::proto::cosmos::base::tendermint::v1beta1::GetLatestValidatorSetRequest;
 use url::Url;
 
 use crate::{ConnectionConf, HyperlaneCosmosError, MetricsChannel};


### PR DESCRIPTION
### Description
This PR queries the get latest validator endpoint instead of the get latest block endpoint, this uses less memory and doesn't run into message size limits for the tonic service.
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
