### PR TITLE
chore(ci): update mold

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,9 +80,6 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Install mold linker
         uses: rui314/setup-mold@v1
-        with:
-          mold-version: 2.0.0
-          make-default: true
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - name: Run tests for main workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -625,9 +625,6 @@ jobs:
       - name: Install mold linker
         if: steps.check-conditions.outputs.skip-e2e != 'true'
         uses: rui314/setup-mold@v1
-        with:
-          mold-version: 2.0.0
-          make-default: true
 
       - name: yarn-build
         if: steps.check-conditions.outputs.skip-e2e != 'true'


### PR DESCRIPTION
### Description

chore(ci): update mold

removing overrides so that we use the default values in the action:
- we use the latest mold always (get all the patches)
- the default already sets make-default to true

<img width="1093" height="307" alt="image" src="https://github.com/user-attachments/assets/da9dfead-4493-4efd-8d58-b7d61c1db2cd" />

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
