### PR TITLE
chore: update testnet agent images

### DIFF
--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -356,7 +356,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '2fc3e17-20251117-225554',
+      tag: '97c93e2-20251124-141939',
     },
     blacklist: [...releaseCandidateHelloworldMatchingList, ...relayBlacklist],
     gasPaymentEnforcement,
@@ -377,7 +377,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '20c24dc-20251106-222459',
+      tag: '97c93e2-20251124-141939',
     },
     chains: validatorChainConfig(Contexts.Hyperlane),
     resources: validatorResources,
@@ -386,7 +386,7 @@ const hyperlane: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo,
-      tag: '20c24dc-20251106-222459',
+      tag: '97c93e2-20251124-141939',
     },
     resources: scraperResources,
   },


### PR DESCRIPTION
### Description

Deployed with:
- tonic GRPC to larger limit (8MB)
- agent images now use secrets grpc for cosmosnative

Commit: https://github.com/hyperlane-xyz/hyperlane-monorepo/commit/97c93e2142558bad6614b628de800f89bcd552f4