### PR TITLE
chore: add BSC sanctioned address, dedupe addresses

### DIFF
--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -215,7 +215,7 @@ export class RelayerConfigHelper extends AgentConfigHelper<RelayerConfig> {
 
   async getSanctionedAddresses() {
     // All Ethereum-style addresses from https://github.com/0xB10C/ofac-sanctioned-digital-currency-addresses/tree/lists
-    const currencies = ['ARB', 'ETC', 'ETH', 'USDC', 'USDT', 'BSC'];
+    const currencies = ['ARB', 'BSC', 'ETC', 'ETH', 'USDC', 'USDT'];
 
     const schema = z.array(z.string());
 


### PR DESCRIPTION
### Description

- Added BSC sanctioned address from https://github.com/0xB10C/ofac-sanctioned-digital-currency-addresses/tree/lists
- Tested it by observing the logged addresses - along the way saw that we had some duped addresses, so deduped them

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
