### PR TITLE
fix(solidity): rename fork test to match CI exclusion pattern

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,12 +160,6 @@ jobs:
       - name: foundry-install
         uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Set Foundry RPC URLs for fork tests
-        env:
-          MAINNET3_ARBITRUM_RPC_URLS: ${{ secrets.MAINNET3_ARBITRUM_RPC_URLS }}
-        run: |
-          echo "FOUNDRY_RPC_URL_ARBITRUM=${MAINNET3_ARBITRUM_RPC_URLS%%,*}" >> $GITHUB_ENV
-
       - name: yarn-build
         uses: ./.github/actions/yarn-build-with-cache
         with:

--- a/solidity/test/token/EverclearTokenBridge.t.sol
+++ b/solidity/test/token/EverclearTokenBridge.t.sol
@@ -723,7 +723,7 @@ contract BaseEverclearTokenBridgeForkTest is Test {
 contract EverclearTokenBridgeForkTest is BaseEverclearTokenBridgeForkTest {
     using TypeCasts for *;
 
-    function testFuzz_ForkTransferRemote(uint256 amount) public {
+    function testFork_FuzzTransferRemote(uint256 amount) public {
         // Fund Alice with WETH by wrapping ETH
         amount = bound(amount, 1, 100e6 ether);
         uint depositAmount = amount + FEE_AMOUNT;


### PR DESCRIPTION
## Summary

- Renames `testFuzz_ForkTransferRemote` to `testFork_FuzzTransferRemote` so it matches the CI exclusion pattern
- Reverts https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/7454 in favour of the general fix

## Context

The `test:ci` script in `solidity/package.json` uses `--no-match-test testFork` to skip fork tests during CI runs. However, `testFuzz_ForkTransferRemote` was escaping this filter because it starts with `testFuzz`, not `testFork`.

This caused CI failures when the test tried to fork from Arbitrum using the free-tier drpc.org RPC endpoint (configured in `foundry.toml`), which has rate limits that result in HTTP 408 timeouts.

## Test plan

- [ ] Verify the test is now excluded from `yarn --cwd solidity test:ci` runs
- [ ] Verify the test still runs with `yarn --cwd solidity test` (full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)