### PR TITLE
fix: enforce repo and licenses are set in publishable packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,10 @@ jobs:
       - name: syncpack
         run: yarn syncpack list-mismatches
 
+      # Check publishable packages have required fields for npm provenance
+      - name: check-package-json
+        run: ./scripts/check-package-json.sh
+
   lint-prettier:
     runs-on: depot-ubuntu-24.04-8
     timeout-minutes: 5

--- a/scripts/check-package-json.sh
+++ b/scripts/check-package-json.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# This script validates that all publishable packages have the required fields
+# for npm's sigstore provenance verification and consistent metadata.
+
+EXPECTED_REPO="https://github.com/hyperlane-xyz/hyperlane-monorepo"
+EXPECTED_LICENSE="Apache-2.0"
+ERRORS=0
+
+# Find all package.json files in workspaces (typescript/*, solidity, starknet, solhint-plugin)
+PACKAGE_FILES=$(find typescript solidity starknet solhint-plugin -maxdepth 2 -name "package.json" -type f 2>/dev/null)
+
+for pkg in $PACKAGE_FILES; do
+    # Skip if package is private (not published to npm)
+    IS_PRIVATE=$(jq -r '.private // false' "$pkg")
+    if [ "$IS_PRIVATE" = "true" ]; then
+        continue
+    fi
+
+    # Check if package has @hyperlane-xyz scope (published packages)
+    NAME=$(jq -r '.name // ""' "$pkg")
+    if [[ ! "$NAME" =~ ^@hyperlane-xyz/ ]]; then
+        continue
+    fi
+
+    # Check repository field - must be a string with exact value
+    REPO_TYPE=$(jq -r '.repository | type' "$pkg")
+    REPO_VALUE=$(jq -r '.repository // ""' "$pkg")
+
+    if [ "$REPO_TYPE" != "string" ]; then
+        echo "ERROR: $pkg has repository as object, must be string format"
+        echo "       Required: \"repository\": \"$EXPECTED_REPO\""
+        ERRORS=$((ERRORS + 1))
+    elif [ -z "$REPO_VALUE" ] || [ "$REPO_VALUE" = "null" ]; then
+        echo "ERROR: $pkg is missing 'repository' field"
+        echo "       Required for npm sigstore provenance verification"
+        ERRORS=$((ERRORS + 1))
+    elif [ "$REPO_VALUE" != "$EXPECTED_REPO" ]; then
+        echo "ERROR: $pkg has incorrect 'repository' field"
+        echo "       Expected: $EXPECTED_REPO"
+        echo "       Got: $REPO_VALUE"
+        ERRORS=$((ERRORS + 1))
+    fi
+
+    # Check license field
+    LICENSE_VALUE=$(jq -r '.license // ""' "$pkg")
+
+    if [ -z "$LICENSE_VALUE" ] || [ "$LICENSE_VALUE" = "null" ]; then
+        echo "ERROR: $pkg is missing 'license' field"
+        echo "       Required: \"license\": \"$EXPECTED_LICENSE\""
+        ERRORS=$((ERRORS + 1))
+    elif [ "$LICENSE_VALUE" != "$EXPECTED_LICENSE" ]; then
+        echo "ERROR: $pkg has incorrect 'license' field"
+        echo "       Expected: $EXPECTED_LICENSE"
+        echo "       Got: $LICENSE_VALUE"
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+if [ $ERRORS -gt 0 ]; then
+    echo ""
+    echo "Found $ERRORS error(s) in package.json fields."
+    echo "All publishable @hyperlane-xyz packages must have:"
+    echo "  \"repository\": \"$EXPECTED_REPO\""
+    echo "  \"license\": \"$EXPECTED_LICENSE\""
+    exit 1
+fi
+
+echo "All publishable packages have correct repository and license fields."
+exit 0

--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -94,11 +94,8 @@
   "bin": {
     "hyperlane": "./cli-bundle/index.js"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/hyperlane-xyz/hyperlane-monorepo"
-  },
-  "license": "Apache 2.0",
+  "repository": "https://github.com/hyperlane-xyz/hyperlane-monorepo",
+  "license": "Apache-2.0",
   "homepage": "https://www.hyperlane.xyz",
   "keywords": [
     "Hyperlane",

--- a/typescript/deploy-sdk/package.json
+++ b/typescript/deploy-sdk/package.json
@@ -2,6 +2,8 @@
   "name": "@hyperlane-xyz/deploy-sdk",
   "version": "0.2.0",
   "description": "Deployer SDK for the Hyperlane Protocol",
+  "repository": "https://github.com/hyperlane-xyz/hyperlane-monorepo",
+  "license": "Apache-2.0",
   "type": "module",
   "files": [
     "dist"

--- a/typescript/helloworld/package.json
+++ b/typescript/helloworld/package.json
@@ -59,10 +59,7 @@
     "/dist",
     "/contracts"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/hyperlane-xyz/hyperlane-monorepo"
-  },
+  "repository": "https://github.com/hyperlane-xyz/hyperlane-monorepo",
   "scripts": {
     "build": "yarn hardhat-esm compile && tsc",
     "clean": "yarn hardhat-esm clean && rm -rf dist cache src/types",

--- a/typescript/provider-sdk/package.json
+++ b/typescript/provider-sdk/package.json
@@ -2,6 +2,8 @@
   "name": "@hyperlane-xyz/provider-sdk",
   "version": "0.2.0",
   "description": "Protocol Provider SDK for the Hyperlane Protocol",
+  "repository": "https://github.com/hyperlane-xyz/hyperlane-monorepo",
+  "license": "Apache-2.0",
   "type": "module",
   "files": [
     "dist"

--- a/typescript/widgets/package.json
+++ b/typescript/widgets/package.json
@@ -91,10 +91,7 @@
     "Typescript"
   ],
   "license": "Apache-2.0",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/hyperlane-xyz/hyperlane-monorepo"
-  },
+  "repository": "https://github.com/hyperlane-xyz/hyperlane-monorepo",
   "scripts": {
     "build": "yarn build:ts && yarn build:css",
     "build:ts": "tsc",


### PR DESCRIPTION
### Description

fix: enforce repo and licenses are set in publishable packages

- add urls to new packages
- ask claude to write a script to enforce package.jsons have the url
- extend script to also enforce consistent url usage + consistent license usage

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added npm package metadata validation to the CI pipeline to ensure publishable packages meet publishing requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->