### PR TITLE
fix: use hyper-gonk bot for release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,14 +55,22 @@ jobs:
       - name: Install Dependencies
         run: yarn install --immutable
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.HYPER_GONK_APP_ID }}
+          private-key: ${{ secrets.HYPER_GONK_PRIVATE_KEY }}
+
       - name: Create Release PR
         id: changesets
         uses: changesets/action@v1
         with:
           version: yarn version:prepare
+          title: 'chore: release npm packages'
         env:
           NPM_CONFIG_PROVENANCE: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   check-latest-published:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -170,9 +170,15 @@ jobs:
           cd ../sealevel
           cargo update --workspace --offline 2>/dev/null || cargo update --workspace
           echo "Updated rust/sealevel/Cargo.lock"
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.HYPER_GONK_APP_ID }}
+          private-key: ${{ secrets.HYPER_GONK_PRIVATE_KEY }}
       - name: Create or update release PR
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           NEW_VERSION: ${{ steps.next_version.outputs.new_version }}
           BUMP_TYPE: ${{ steps.next_version.outputs.bump_type }}
           CHANGELOG: ${{ steps.changelog.outputs.changelog }}


### PR DESCRIPTION
## Summary

Use GitHub App token (Hyper Gonk) instead of `GITHUB_TOKEN` for creating release PRs. This fixes the issue where CI workflows wouldn't trigger on PRs created by the release workflows.

## Problem

GitHub's security model prevents workflows triggered by `GITHUB_TOKEN` from triggering other workflows. This means:
- When the NPM release workflow creates a "Version Packages" PR, CI doesn't run
- When the Rust release workflow creates a release PR, CI doesn't run

## Solution

Use a GitHub App token instead. The Hyper Gonk GitHub App has been configured with:
- **Contents**: Read & Write
- **Pull requests**: Read & Write

## Changes

- `.github/workflows/release.yml`: Use Hyper Gonk token for changesets action
- `.github/workflows/rust-release.yml`: Use Hyper Gonk token for PR creation

## Setup Required

The following secrets need to be added to the repository:
- `HYPER_GONK_APP_ID`: The App ID
- `HYPER_GONK_PRIVATE_KEY`: The private key

## Test plan
- [x] Verified CI triggers on release PRs (tested with Rust release workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release process authentication and token management to ensure secure and reliable package deployment workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->