### PR TITLE
fix: use Hyper Gonk identity for git commits in release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,12 +62,18 @@ jobs:
           app-id: ${{ secrets.HYPER_GONK_APP_ID }}
           private-key: ${{ secrets.HYPER_GONK_PRIVATE_KEY }}
 
+      - name: Configure Git for Hyper Gonk
+        run: |
+          git config user.name "${{ steps.generate-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ secrets.HYPER_GONK_APP_ID }}+${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
       - name: Create Release PR
         id: changesets
         uses: changesets/action@v1
         with:
           version: yarn version:prepare
           title: 'chore: release npm packages'
+          setupGitUser: false
         env:
           NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -183,8 +183,8 @@ jobs:
           BUMP_TYPE: ${{ steps.next_version.outputs.bump_type }}
           CHANGELOG: ${{ steps.changelog.outputs.changelog }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "${{ steps.generate-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ secrets.HYPER_GONK_APP_ID }}+${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
           BRANCH_NAME="release-agents-v${NEW_VERSION}"
 


### PR DESCRIPTION
## Summary

The previous fix (PR #7472) used Hyper Gonk token for authentication but still used `github-actions[bot]` for git commit identity. This caused force pushes to the release branch to still show as github-actions bot in the UI.

## Changes

### `rust-release.yml`
Uses the `app-slug` output from `create-github-app-token` to properly configure git user name and email as the Hyper Gonk bot.

### `release.yml` (npm releases)
- Added `setupGitUser: false` to the changesets action (which defaults to using `github-actions[bot]`)
- Added explicit git config step before changesets action to use Hyper Gonk identity

The git identity format:
- `user.name`: `\${{ steps.generate-token.outputs.app-slug }}[bot]`
- `user.email`: `\${{ secrets.HYPER_GONK_APP_ID }}+\${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com`

## Related

- Original PR: #7472
- Registry PR: hyperlane-xyz/hyperlane-registry#1258 (same fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Git configuration in release workflows with enhanced commit attribution handling
  * Updated automated release process to use dynamic bot identification for better commit traceability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->