### PR TITLE
fix: E2E rust testing doesnt need gcp credentials

### DIFF
--- a/typescript/infra/scripts/deploy.ts
+++ b/typescript/infra/scripts/deploy.ts
@@ -106,11 +106,19 @@ async function main() {
     multiProvider.setSharedSigner(signer);
   }
 
+  // Only fetch explorer API keys (which reside in GCP) when we explicitly need
+  // to talk to public block explorers. Local/e2e deployments should not incur
+  // this dependency so they always skip the lookup.
+  const shouldFetchExplorerApiKeys =
+    !inCIMode() && envConfig.environment !== 'test';
+  const explorerApiKeys = shouldFetchExplorerApiKeys
+    ? await fetchExplorerApiKeys()
+    : {};
+
   // if none provided, instantiate a default verifier with the default core contract build artifact
-  // fetch explorer API keys from GCP
   const contractVerifier = new ContractVerifier(
     multiProvider,
-    inCIMode() ? {} : await fetchExplorerApiKeys(),
+    explorerApiKeys,
     buildArtifactPath
       ? extractBuildArtifact(buildArtifactPath)
       : coreBuildArtifact,


### PR DESCRIPTION
### Description

Stops Rust E2E runs from requiring GCP creds by updating typescript/infra/scripts/deploy.ts to skip fetching block-explorer secrets whenever we’re deploying against the local test environment. Local runs now instantiate ContractVerifier with empty API keys, so the deploy-ism/deploy-core steps no longer try to talk to GCP

### Drive-by changes
None
### Related issues


- Fixes #4261


### Backward compatibility

Yes. Production/testnet environments still fetch explorer API keys as before; only the local test environment changes behavior.
### Testing

None



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment configuration to adjust explorer API key handling across different environments. API keys are now conditionally managed based on deployment context, improving deployment efficiency for non-production environments while maintaining full functionality for production deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->