### PR TITLE
fix: use bot user ID for proper avatar attribution in commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,16 @@ jobs:
           app-id: ${{ secrets.HYPER_GONK_APP_ID }}
           private-key: ${{ secrets.HYPER_GONK_PRIVATE_KEY }}
 
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api /users/${{ steps.generate-token.outputs.app-slug }}[bot] --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
       - name: Configure Git for Hyper Gonk
         run: |
           git config user.name "${{ steps.generate-token.outputs.app-slug }}[bot]"
-          git config user.email "${{ secrets.HYPER_GONK_APP_ID }}+${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git config user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Create Release PR
         id: changesets

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -183,8 +183,10 @@ jobs:
           BUMP_TYPE: ${{ steps.next_version.outputs.bump_type }}
           CHANGELOG: ${{ steps.changelog.outputs.changelog }}
         run: |
+          # Get bot user ID for proper avatar attribution
+          BOT_USER_ID=$(gh api /users/${{ steps.generate-token.outputs.app-slug }}[bot] --jq .id)
           git config user.name "${{ steps.generate-token.outputs.app-slug }}[bot]"
-          git config user.email "${{ secrets.HYPER_GONK_APP_ID }}+${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git config user.email "${BOT_USER_ID}+${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
           BRANCH_NAME="release-agents-v${NEW_VERSION}"
 


### PR DESCRIPTION
## Summary
- Fixes hyper-gonk[bot] commits showing default robot avatar instead of the GitHub App's custom logo
- Updates release workflows that use the Hyper Gonk bot to fetch the bot user ID via API before configuring git

## Problem
GitHub requires the **bot user ID** (not app ID) in the commit email to properly display the GitHub App's avatar.

**Before:** `{APP_ID}+{app-slug}[bot]@users.noreply.github.com`
**After:** `{BOT_USER_ID}+{app-slug}[bot]@users.noreply.github.com`

## Test plan
- [ ] Merge this PR and verify the next automated commit from hyper-gonk[bot] shows the correct avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions workflows for release automation by enhancing bot user identification configuration across multiple release processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->