### PR TITLE
chore: remove inevm form ci tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -736,7 +736,7 @@ jobs:
       fail-fast: false
       matrix:
         environment: [mainnet3]
-        chain: [ethereum, arbitrum, optimism, inevm]
+        chain: [ethereum, arbitrum, optimism]
         module: [core, igp]
         include:
           - environment: testnet4


### PR DESCRIPTION
### Description

inevm is deprecated and the ci was failing because it was included in the test matrix

<img width="655" height="168" alt="image" src="https://github.com/user-attachments/assets/faf96e6c-b42b-40c0-8c87-3ffdc3105922" />


### Drive-by changes

### Related issues

-

### Backward compatibility

- yeah

### Testing

-
