### PR TITLE
fix(sdk): correct parameter type for validatorsAndThreshold in EvmIsmReader

### DIFF
--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -453,9 +453,7 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
           : IsmType.STORAGE_MESSAGE_ID_MULTISIG;
     }
 
-    const [validators, threshold] = await ism.validatorsAndThreshold(
-      ethers.constants.AddressZero,
-    );
+    const [validators, threshold] = await ism.validatorsAndThreshold('0x');
 
     return {
       address,


### PR DESCRIPTION
## Description

Fixes #7499

Changes parameter from `ethers.constants.AddressZero` to `'0x'` to fix hanging in `warp read`/`warp apply` commands.

## The Fix

```diff
- ethers.constants.AddressZero,
+ '0x',
```

## Testing

**Before:** `warp read` and `warp apply` hang when reading ISM configs  
**After:** Commands complete successfully in seconds

**Cast verification:**
```bash
# With address type - FAILS
cast call 0xf8B38A4e42934c4155de579eBe5448AeDDaFfC64 \
  "validatorsAndThreshold(address)(address[],uint8)" \
  "0x0000000000000000000000000000000000000000" \
  --rpc-url https://mainnet.base.org
# Error: execution reverted

# With bytes type - WORKS
cast call 0xf8B38A4e42934c4155de579eBe5448AeDDaFfC64 \
  "validatorsAndThreshold(bytes)(address[],uint8)" \
  "0x" \
  --rpc-url https://mainnet.base.org
# Returns validators ✅
```

Tested on Base mainnet with ISM `0xf8B38A4e42934c4155de579eBe5448AeDDaFfC64`.