### PR TITLE
fix(sdk): zksync fixes

### DIFF
--- a/.changeset/shy-doors-hunt.md
+++ b/.changeset/shy-doors-hunt.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fix zkSync ICA compatibility and add storage ISM support in metadata builder

--- a/typescript/sdk/src/ism/metadata/builder.ts
+++ b/typescript/sdk/src/ism/metadata/builder.ts
@@ -66,6 +66,8 @@ export class BaseMetadataBuilder implements MetadataBuilder {
 
       case IsmType.MERKLE_ROOT_MULTISIG:
       case IsmType.MESSAGE_ID_MULTISIG:
+      case IsmType.STORAGE_MERKLE_ROOT_MULTISIG:
+      case IsmType.STORAGE_MESSAGE_ID_MULTISIG:
         if (typeof hook === 'string') {
           throw new Error('Hook context must be an object (for multisig ISM)');
         }
@@ -95,6 +97,7 @@ export class BaseMetadataBuilder implements MetadataBuilder {
         );
 
       case IsmType.AGGREGATION:
+      case IsmType.STORAGE_AGGREGATION:
         return this.aggregationMetadataBuilder.build(
           { ...context, ism },
           maxDepth,

--- a/typescript/sdk/src/ism/metadata/decode.ts
+++ b/typescript/sdk/src/ism/metadata/decode.ts
@@ -18,9 +18,12 @@ export function decodeIsmMetadata(
 
     case IsmType.MERKLE_ROOT_MULTISIG:
     case IsmType.MESSAGE_ID_MULTISIG:
+    case IsmType.STORAGE_MERKLE_ROOT_MULTISIG:
+    case IsmType.STORAGE_MESSAGE_ID_MULTISIG:
       return MultisigMetadataBuilder.decode(metadata, ism.type);
 
     case IsmType.AGGREGATION:
+    case IsmType.STORAGE_AGGREGATION:
       return AggregationMetadataBuilder.decode(metadata, { ...context, ism });
 
     case IsmType.ROUTING:

--- a/typescript/sdk/src/ism/metadata/multisig.ts
+++ b/typescript/sdk/src/ism/metadata/multisig.ts
@@ -158,7 +158,8 @@ export class MultisigMetadataBuilder implements MetadataBuilder {
     >,
   ): Promise<string> {
     assert(
-      context.ism.type === IsmType.MESSAGE_ID_MULTISIG,
+      context.ism.type === IsmType.MESSAGE_ID_MULTISIG ||
+        context.ism.type === IsmType.STORAGE_MESSAGE_ID_MULTISIG,
       'Merkle proofs are not yet supported',
     );
 
@@ -331,10 +332,13 @@ export class MultisigMetadataBuilder implements MetadataBuilder {
     metadata: string,
     type:
       | typeof IsmType.MERKLE_ROOT_MULTISIG
-      | typeof IsmType.MESSAGE_ID_MULTISIG,
+      | typeof IsmType.MESSAGE_ID_MULTISIG
+      | typeof IsmType.STORAGE_MERKLE_ROOT_MULTISIG
+      | typeof IsmType.STORAGE_MESSAGE_ID_MULTISIG,
   ): MultisigMetadata {
     const prefix: any =
-      type === IsmType.MERKLE_ROOT_MULTISIG
+      type === IsmType.MERKLE_ROOT_MULTISIG ||
+      type === IsmType.STORAGE_MERKLE_ROOT_MULTISIG
         ? this.decodeProofPrefix(metadata)
         : this.decodeSimplePrefix(metadata);
 


### PR DESCRIPTION
## Summary

- Handle gas estimation failures gracefully in `estimateHandle()` instead of special-casing zkSync chains. Returns `'0'` when estimation fails, allowing the caller to handle gas estimation differently
- Add support for storage-based ISM types in metadata builder/decoder:
  - `STORAGE_MERKLE_ROOT_MULTISIG`
  - `STORAGE_MESSAGE_ID_MULTISIG`  
  - `STORAGE_AGGREGATION`

## Test plan

- [x] SDK tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed zkSync interchain account compatibility
  * Improved gas estimation error handling with graceful fallback

* **New Features**
  * Added support for storage-based ISM verification types in metadata processing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->