### PR TITLE
fix(ci): remove duplicate title key in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,6 @@ jobs:
         with:
           title: 'chore: release npm packages'
           version: yarn version:prepare
-          title: 'chore: release npm packages'
           setupGitUser: false
         env:
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
Remove duplicate `title:` key in the changesets action config.

## Problem
The release workflow was incorrectly triggering on feature branches and merge queue branches. The duplicate `title:` key was invalid YAML, likely causing parsing issues that made GitHub Actions ignore the `branches: [main]` filter.

## Test plan
- [ ] Verify workflow no longer triggers on pushes to feature branches
- [ ] Verify workflow still triggers correctly on pushes to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to execute exclusively on the main branch for controlled deployments.
  * Improved release pull request handling with automatic draft conversion.
  * Enhanced version verification process before publishing releases.
  * Removed a duplicated title entry in the release PR creation to tidy the workflow configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->