### PR TITLE
ci: add Dockerfile validation and use yarn workspaces for package discovery

### DIFF
--- a/scripts/check-package-json.sh
+++ b/scripts/check-package-json.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-# This script validates that all publishable packages have the required fields
-# for npm's sigstore provenance verification and consistent metadata.
+# This script validates:
+# 1. All publishable packages have required fields for npm sigstore provenance
+# 2. Dockerfile has COPY statements for all workspace package.json files
 
 EXPECTED_REPO="https://github.com/hyperlane-xyz/hyperlane-monorepo"
 EXPECTED_LICENSE="Apache-2.0"
 ERRORS=0
 
-# Find all package.json files in workspaces (typescript/*, solidity, starknet, solhint-plugin)
-PACKAGE_FILES=$(find typescript solidity starknet solhint-plugin -maxdepth 2 -name "package.json" -type f 2>/dev/null)
+# Get all workspace package.json files using yarn workspaces
+# Skip the root workspace (location ".")
+PACKAGE_FILES=$(yarn workspaces list --json 2>/dev/null | jq -r 'select(.location != ".") | .location + "/package.json"')
+
+echo "Checking package.json fields..."
 
 for pkg in $PACKAGE_FILES; do
     # Skip if package is private (not published to npm)
@@ -57,14 +61,28 @@ for pkg in $PACKAGE_FILES; do
     fi
 done
 
+echo "Checking Dockerfile COPY statements..."
+
+for pkg in $PACKAGE_FILES; do
+    # Check if Dockerfile has a COPY statement for this package.json
+    if ! grep -q "COPY $pkg" Dockerfile; then
+        echo "ERROR: Dockerfile is missing COPY statement for $pkg"
+        echo "       Add: COPY $pkg ./$pkg"
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
 if [ $ERRORS -gt 0 ]; then
     echo ""
-    echo "Found $ERRORS error(s) in package.json fields."
-    echo "All publishable @hyperlane-xyz packages must have:"
+    echo "Found $ERRORS error(s)."
+    echo ""
+    echo "For package.json issues, all publishable @hyperlane-xyz packages must have:"
     echo "  \"repository\": \"$EXPECTED_REPO\""
     echo "  \"license\": \"$EXPECTED_LICENSE\""
+    echo ""
+    echo "For Dockerfile issues, add missing COPY statements before 'yarn install'."
     exit 1
 fi
 
-echo "All publishable packages have correct repository and license fields."
+echo "All checks passed."
 exit 0


### PR DESCRIPTION
## Summary
- Adds validation to check Dockerfile has COPY statements for all workspace packages
- Refactors `check-package-json.sh` to use `yarn workspaces list` instead of `find`

## Changes
1. **scripts/check-package-json.sh**: 
   - Now uses `yarn workspaces list --json` to discover packages instead of `find`
   - Adds Dockerfile COPY statement validation for all workspace packages

## Benefits
- CI will catch missing Dockerfile COPY statements before merge
- Package discovery is more reliable using yarn workspaces
- Prevents future Docker build failures like the one caused by #7481

## Test plan
- [x] `./scripts/check-package-json.sh` passes locally
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)