### PR TITLE
fix(ci): pass GitHub App token to checkout for workflow triggering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,22 @@ jobs:
       pull-requests: write
     runs-on: depot-ubuntu-latest
     steps:
+      # Generate token first so checkout configures git credentials with it
+      # This allows subsequent pushes to trigger workflows
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.HYPER_GONK_APP_ID }}
+          private-key: ${{ secrets.HYPER_GONK_PRIVATE_KEY }}
+
       - name: Checkout Repo
         uses: actions/checkout@v5
         with:
           # check out full history
           fetch-depth: 0
           submodules: recursive
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -54,13 +64,6 @@ jobs:
 
       - name: Install Dependencies
         run: yarn install --immutable
-
-      - name: Generate GitHub App Token
-        id: generate-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.HYPER_GONK_APP_ID }}
-          private-key: ${{ secrets.HYPER_GONK_PRIVATE_KEY }}
 
       - name: Get GitHub App User ID
         id: get-user-id
@@ -155,12 +158,22 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      # Generate token first so checkout configures git credentials with it
+      # This allows subsequent pushes to trigger workflows
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.HYPER_GONK_APP_ID }}
+          private-key: ${{ secrets.HYPER_GONK_PRIVATE_KEY }}
+
       - name: Checkout Repo
         uses: actions/checkout@v5
         with:
           # check out full history
           fetch-depth: 0
           submodules: recursive
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -170,13 +183,25 @@ jobs:
       - name: Install Dependencies
         run: yarn install --immutable
 
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api /users/${{ steps.generate-token.outputs.app-slug }}[bot] --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Configure Git for Hyper Gonk
+        run: |
+          git config user.name "${{ steps.generate-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
       - name: Publish Release to NPM
         id: changesets
         uses: changesets/action@v1
         with:
           version: yarn version:prepare
           publish: yarn release
+          setupGitUser: false
         env:
           NPM_CONFIG_PROVENANCE: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -104,9 +104,18 @@ jobs:
       needs.check-release-status.outputs.has_changes == 'true' &&
       needs.check-release-status.outputs.should_release == 'false'
     steps:
+      # Generate token first so checkout configures git credentials with it
+      # This allows subsequent pushes to trigger workflows
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.HYPER_GONK_APP_ID }}
+          private-key: ${{ secrets.HYPER_GONK_PRIVATE_KEY }}
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Determine next version from conventional commits
         id: next_version
@@ -170,12 +179,6 @@ jobs:
           cd ../sealevel
           cargo update --workspace --offline 2>/dev/null || cargo update --workspace
           echo "Updated rust/sealevel/Cargo.lock"
-      - name: Generate GitHub App Token
-        id: generate-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.HYPER_GONK_APP_ID }}
-          private-key: ${{ secrets.HYPER_GONK_PRIVATE_KEY }}
       - name: Create or update release PR
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Generate GitHub App token BEFORE checkout in release workflows
- Pass the token to `actions/checkout` for git credential configuration
- Add `setupGitUser: false` and git config to `publish-release` job
- This fixes two issues:
  1. CI not triggering on commits pushed by the workflow
  2. Commits being authored by github-actions[bot] instead of hyper-gonk[bot]

## Problem 1: CI Not Triggering
When the release workflow pushes commits (e.g., "Version Packages"), CI doesn't run on those commits. This is because:

1. `actions/checkout` configures git credentials at checkout time
2. By default, it uses `GITHUB_TOKEN` which **cannot** trigger other workflows (GitHub security feature)
3. GitHub App tokens **can** trigger workflows, but only if used for git authentication

## Problem 2: Wrong Commit Author
The `publish-release` job was creating "Version Packages" commits as `github-actions[bot]` because:

1. It didn't have `setupGitUser: false` set
2. changesets/action defaults to configuring git as github-actions[bot]
3. It then force-pushes to `changeset-release/main`, overwriting hyper-gonk's commits

## Solution
Generate the token **before** checkout and pass it via the `token` parameter, then configure git for both jobs:

```yaml
steps:
  - name: Generate GitHub App Token
    id: generate-token
    uses: actions/create-github-app-token@v2
    ...

  - uses: actions/checkout@v5
    with:
      token: ${{ steps.generate-token.outputs.token }}

  - name: Configure Git for Hyper Gonk
    run: |
      git config user.name "hyper-gonk[bot]"
      git config user.email "...[bot]@users.noreply.github.com"

  - name: Changesets Action
    uses: changesets/action@v1
    with:
      setupGitUser: false  # Use our git config, not default
    env:
      GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
```

## Changes
- `release.yml`: 
  - Move token generation before checkout in prepare-release
  - Add token generation, git config, and setupGitUser to publish-release
- `rust-release.yml`: Same fix for release-pr job

Note: `combine.yml` and `update-hyperlane-deps.yml` in hyperlane-registry already do this correctly.

## Test Plan
- [ ] Merge this PR
- [ ] Trigger a release (e.g., merge a changeset)
- [ ] Verify CI runs on the "Version Packages" commit pushed by hyper-gonk
- [ ] Verify commits are authored by hyper-gonk[bot], not github-actions[bot]

🤖 Generated with [Claude Code](https://claude.com/claude-code)