### PR TITLE
fix(rpc): ensure 4-round retries in FallbackProvider and Ethereum fallback

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
@@ -198,8 +198,8 @@ where
 
         let mut errors = vec![];
         // make sure we do at least 4 total retries.
-        while errors.len() <= 3 {
-            if !errors.is_empty() {
+        for attempt in 0..=3 {
+            if attempt > 0 {
                 sleep(Duration::from_millis(100)).await;
             }
             let priorities_snapshot = self.take_priorities_snapshot().await;


### PR DESCRIPTION
The previous fallback retry loop stopped after four accumulated errors across providers, which meant with four or more providers there would be no subsequent retry round. This change switches to a fixed four-round retry loop (for attempt in 0..=3) in both hyperlane-core and the Ethereum wrapper, preserving the existing 100ms backoff and error aggregation. This aligns fallback behavior with the multicast strategy and the existing comment semantics, prevents premature termination with many providers, and keeps API and prioritization logic unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified retry logic in fallback network request handling for improved code clarity while maintaining consistent retry behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->