### PR TITLE
build: Add postinstall script to install Soldeer dependencies

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -68,6 +68,7 @@
   ],
   "license": "Apache-2.0",
   "scripts": {
+    "postinstall": "command -v forge >/dev/null 2>&1 && forge soldeer install || echo 'Forge not installed, skipping soldeer install'",
     "build": "yarn version:update && yarn hardhat-esm compile && tsc && ./exportBuildArtifact.sh",
     "build:zk": "yarn hardhat-zk compile && tsc && ts-node generate-artifact-exports.mjs && ZKSYNC=true ./exportBuildArtifact.sh",
     "prepublishOnly": "yarn build && yarn build:zk",


### PR DESCRIPTION
### Description

Automatically run `forge soldeer install` after yarn install when forge is available. This ensures Solidity dependencies are installed in both local development and CI environments without requiring manual steps.

### Testing
CI
