### PR TITLE
fix(solidity): integrate soldeer with yarn build

### DIFF
--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -14,6 +14,9 @@ on:
       - '.dockerignore'
       - '.github/workflows/monorepo-docker.yml'
       - 'typescript/ccip-server/**'
+      # Dependency changes that could affect the Docker build
+      - 'yarn.lock'
+      - '**/package.json'
   workflow_dispatch:
     inputs:
       include_arm64:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
-FROM node:20-alpine
+FROM node:20-slim
 
 WORKDIR /hyperlane-monorepo
 
-RUN apk add --update --no-cache git g++ make py3-pip jq bash curl && \
-    yarn set version 4.5.1
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git g++ make python3 python3-pip jq bash curl ca-certificates unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && yarn set version 4.5.1
+
+# Install Foundry for solidity builds (early for layer caching)
+RUN curl -L https://foundry.paradigm.xyz | bash
+RUN /root/.foundry/bin/foundryup
+ENV PATH="/root/.foundry/bin:${PATH}"
 
 # Copy package.json and friends
 COPY package.json yarn.lock .yarnrc.yml ./

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -68,6 +68,7 @@
   ],
   "license": "Apache-2.0",
   "scripts": {
+    "deps:soldeer": "forge soldeer install",
     "build": "yarn version:update && yarn hardhat-esm compile && tsc && ./exportBuildArtifact.sh",
     "build:zk": "yarn hardhat-zk compile && tsc && ts-node generate-artifact-exports.mjs && ZKSYNC=true ./exportBuildArtifact.sh",
     "prepublishOnly": "yarn build && yarn build:zk",

--- a/solidity/turbo.json
+++ b/solidity/turbo.json
@@ -1,7 +1,12 @@
 {
   "extends": ["//"],
   "tasks": {
+    "deps:soldeer": {
+      "inputs": ["foundry.toml", "soldeer.lock"],
+      "outputs": ["dependencies/**"]
+    },
     "build": {
+      "dependsOn": ["deps:soldeer"],
       "outputs": [
         "artifacts/**",
         "cache/**",


### PR DESCRIPTION
## Summary

Fixes `yarn build` + Docker builds being broken after #7480 (Soldeer migration) by integrating `forge soldeer install` into the turbo build pipeline.

- fix: add `deps:soldeer` for the `forge soldeer install`
- fix: add `deps:soldeer` as a dependency for solidity `build` step in turbo.json
- driveby: trigger monorepo builds if changes made to `yarn.lock` and `**/package.json`
- fix: Dockerfile now works after soldeer migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated dependency-install step into the build so required tooling is installed before builds.
  * Build now runs this dependency step as a prerequisite, ensuring consistent build outputs.
  * CI workflow updated to trigger when dependency-related files change, ensuring dependency updates run in CI.
  * CI workflows now provision environment variables for turbo integration.
  * Container image updated to a Debian-slim base and expanded to include Foundry tooling and additional system packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->