### PR TITLE
fix(solidity): replace safeApprove with forceApprove

### DIFF
--- a/solidity/contracts/token/extensions/HypERC4626Collateral.sol
+++ b/solidity/contracts/token/extensions/HypERC4626Collateral.sol
@@ -68,7 +68,7 @@ contract HypERC4626Collateral is TokenRouter {
         address _interchainSecurityModule,
         address _owner
     ) public initializer {
-        wrappedToken.safeApprove(address(vault), type(uint256).max);
+        wrappedToken.forceApprove(address(vault), type(uint256).max);
         _MailboxClient_initialize(_hook, _interchainSecurityModule, _owner);
     }
 

--- a/solidity/contracts/token/extensions/HypXERC20Lockbox.sol
+++ b/solidity/contracts/token/extensions/HypXERC20Lockbox.sol
@@ -38,8 +38,8 @@ contract HypXERC20Lockbox is TokenRouter {
      * @dev This function is idempotent and need not be access controlled
      */
     function approveLockbox() public {
-        wrappedToken.safeApprove(address(lockbox), MAX_INT);
-        IERC20(xERC20).safeApprove(address(lockbox), MAX_INT);
+        wrappedToken.forceApprove(address(lockbox), MAX_INT);
+        IERC20(xERC20).forceApprove(address(lockbox), MAX_INT);
     }
 
     /**

--- a/solidity/contracts/token/libs/MovableCollateralRouter.sol
+++ b/solidity/contracts/token/libs/MovableCollateralRouter.sol
@@ -106,7 +106,7 @@ abstract contract MovableCollateralRouter is TokenRouter {
         IERC20 token,
         ITokenBridge bridge
     ) external onlyOwner {
-        token.safeApprove(address(bridge), type(uint256).max);
+        token.forceApprove(address(bridge), type(uint256).max);
     }
 
     function addRebalancer(address rebalancer) external onlyOwner {


### PR DESCRIPTION

### Description

In all cases where safeApprove is used, we want to unconditionally set the approval to the specified value regardless of any prior approval. forceApprove achieves this by resetting to 0 first if needed.


### Backward compatibility

Yes

### Testing

Unit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated token approval mechanisms across collateral, lockbox, and bridge integrations to enhance compatibility with non-standard ERC20 token implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->