### PR TITLE
fix(cosmos): add MessageIdMultisigIsm support in validators_and_threshold

### DIFF
--- a/rust/main/chains/hyperlane-cosmos/src/native/ism.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/native/ism.rs
@@ -127,6 +127,16 @@ impl MultisigIsm for CosmosNativeIsm {
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok((validators, ism.threshold as u8))
             }
+            t if t == MessageIdMultisigIsm::type_url() => {
+                let ism = MessageIdMultisigIsm::decode(ism.value.as_slice())
+                    .map_err(HyperlaneCosmosError::from)?;
+                let validators = ism
+                    .validators
+                    .iter()
+                    .map(|v| H160::from_str(v).map(H256::from))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok((validators, ism.threshold as u8))
+            }
             _ => Err(ChainCommunicationError::from_other_str(&format!(
                 "ISM {:?} not a multi sig ism",
                 self.address


### PR DESCRIPTION
## Summary

The `CosmosNativeIsm::validators_and_threshold()` function only handled `MerkleRootMultisigIsm` but not `MessageIdMultisigIsm`, even though `module_type()` correctly recognizes both ISM types.

This caused the relayer to fail with `ISM not a multi sig ism` error when processing messages on Cosmos chains configured with `MessageIdMultisigIsm`.

### Problem

When using a routing ISM on a Cosmos native chain that routes to a `MessageIdMultisigIsm`, the relayer fails to build metadata because `validators_and_threshold()` doesn't recognize `MessageIdMultisigIsm`:

```
ERROR: ISM 0x... not a multi sig ism
```

### Root cause

In `rust/main/chains/hyperlane-cosmos/src/native/ism.rs`:
- `module_type()` correctly handles both `MerkleRootMultisigIsm` and `MessageIdMultisigIsm`
- `validators_and_threshold()` only handles `MerkleRootMultisigIsm`

### Fix
- Add handling for `MessageIdMultisigIsm` in `validators_and_threshold()` to match the existing `MerkleRootMultisigIsm` case

## Test plan
- [ ] Build relayer with this change
- [ ] Test against a Cosmos chain with `MessageIdMultisigIsm` configured
- [ ] Verify messages are processed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Cosmos chain support to handle MessageIdMultisigIsm in addition to existing multisig validation types, enhancing interchain security module flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->