### PR TITLE
feat: remove redundant tx status network call for finalized transactions

### DIFF
--- a/rust/main/lander/src/dispatcher/stages/finality_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage.rs
@@ -159,12 +159,17 @@ impl FinalityStage {
         state: &DispatcherState,
     ) -> Result<(), LanderError> {
         info!(?tx, "Processing finality stage transaction");
-        let tx_status = call_until_success_or_nonretryable_error(
-            || state.adapter.tx_status(&tx),
-            "Querying transaction status",
-            state,
-        )
-        .await?;
+        let tx_status = match &tx.status {
+            TransactionStatus::Finalized => tx.status.clone(),
+            _ => {
+                call_until_success_or_nonretryable_error(
+                    || state.adapter.tx_status(&tx),
+                    "Querying transaction status",
+                    state,
+                )
+                .await?
+            }
+        };
 
         match tx_status {
             TransactionStatus::Included => {


### PR DESCRIPTION
### Description

Skip fetching tx status if transaction already has finalized status.

### Related issues

- fixes https://linear.app/hyperlane-xyz/issue/ENG-2780/lander-skip-redundant-tx-status-call-in-finalitystage-for-already

### Backward compatibility

Yes

### Testing

- unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized transaction finality processing to skip redundant status queries when transactions are already finalized.

* **Tests**
  * Added test to verify finalized transactions bypass unnecessary status checks and remain properly handled in the transaction pool.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->