### PR TITLE
fix: Use --quiet for soldeer installation

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -68,7 +68,7 @@
   ],
   "license": "Apache-2.0",
   "scripts": {
-    "deps:soldeer": "forge soldeer install",
+    "deps:soldeer": "forge soldeer install --quiet",
     "build": "yarn version:update && yarn hardhat-esm compile && tsc && ./exportBuildArtifact.sh",
     "build:zk": "yarn hardhat-zk compile && tsc && ts-node generate-artifact-exports.mjs && ZKSYNC=true ./exportBuildArtifact.sh",
     "prepublishOnly": "yarn build && yarn build:zk",


### PR DESCRIPTION
### Description

 Add --quiet flag to forge soldeer install command to suppress verbose output during dependency installation

### Drive-by changes

No

### Backward compatibility
Yes

### Testing
  - Run `yarn deps:soldeer` and verify output is silent
  - Run `yarn build` and verify soldeer step completes without excessive logging



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency installation script to reduce output verbosity during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->