### PR TITLE
fix(solidity): exclude Fork contracts from coverage

### DIFF
--- a/solidity/coverage.sh
+++ b/solidity/coverage.sh
@@ -8,4 +8,5 @@ forge coverage \
     --report summary \
     --no-match-coverage "(test|mock|node_modules|script|Fast|TypedMemView)" \
     --no-match-test "Fork" \
+    --no-match-contract "Fork" \
     --ir-minimum # https://github.com/foundry-rs/foundry/issues/3357


### PR DESCRIPTION

### Description
Add --no-match-contract "Fork" flag to coverage script to skip fork test contracts that require external RPC connections.


### Testing

Unit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI exclusion flag `--no-match-contract "Fork"` to the coverage command, enabling users to exclude contracts matching specific patterns from coverage analysis. Existing coverage and exclusion options remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->