### PR TITLE
fix(metric): correct host detection and comment in url_to_host_info

### DIFF
--- a/rust/main/hyperlane-metric/src/utils.rs
+++ b/rust/main/hyperlane-metric/src/utils.rs
@@ -4,9 +4,9 @@ use url::Url;
 
 /// converts url into a host:port string
 pub fn url_to_host_info(url: &Url) -> Option<String> {
-    // check if url has scheme, if not, then add a dummy one
-    // to satisfy Url's parsing schema
-    match url.domain() {
+    // if the URL lacks a host/authority (e.g. parsed as an opaque URL like
+    // "grpc.example.com:234"), prepend a dummy scheme and reparse to extract host:port
+    match url.host_str() {
         None => {
             let with_dummy_scheme = format!("https://{url}");
             let url = Url::parse(&with_dummy_scheme).ok()?;
@@ -21,7 +21,7 @@ fn schemed_url_to_host_info(url: &Url) -> Option<String> {
         let mut s = String::new();
         s.push_str(host);
         if let Some(port) = url.port_or_known_default() {
-            write!(&mut s, ":{port}").unwrap();
+            let _ = write!(&mut s, ":{port}");
         }
         Some(s)
     } else {


### PR DESCRIPTION
 Replaced the misleading domain()-based check with host_str()-based detection to properly handle URLs that have a scheme but no registrable domain (e.g., localhost, IP, IPv6) and opaque URLs like grpc.example.com:234. Updated the comment to reflect the actual intent (absence of host/authority, not scheme). Also removed an unnecessary unwrap when writing to a String. This prevents losing node host info in metrics for localhost/IP cases and keeps behavior intact for opaque inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in URL and host parsing to prevent potential crashes during malformed URL processing
  * Enhanced robustness of utility functions responsible for host information extraction

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->