### PR TITLE
refactor(cli,infra): migrate to @hyperlane-xyz/utils/fs

### DIFF
--- a/.changeset/cli-migrate-to-utils-fs.md
+++ b/.changeset/cli-migrate-to-utils-fs.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/cli": patch
+---
+
+Migrate filesystem utilities to use `@hyperlane-xyz/utils/fs` submodule, reducing code duplication.

--- a/.changeset/infra-migrate-to-utils-fs.md
+++ b/.changeset/infra-migrate-to-utils-fs.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/infra": patch
+---
+
+Migrate filesystem utilities to use `@hyperlane-xyz/utils/fs` submodule, reducing code duplication.

--- a/typescript/cli/src/config/strategy.ts
+++ b/typescript/cli/src/config/strategy.ts
@@ -50,7 +50,8 @@ export async function createStrategyConfig({
     const strategyObj = await readYamlOrJson(outPath);
     strategy = ExtendedChainSubmissionStrategySchema.parse(strategyObj);
   } catch {
-    strategy = writeYamlOrJson(outPath, {}, 'yaml');
+    writeYamlOrJson(outPath, {}, 'yaml');
+    strategy = {};
   }
 
   const chain = await runSingleChainSelectionStep(context.chainMetadata);

--- a/typescript/cli/src/utils/files.ts
+++ b/typescript/cli/src/utils/files.ts
@@ -1,208 +1,69 @@
 import { input } from '@inquirer/prompts';
 import select from '@inquirer/select';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
-import {
-  DocumentOptions,
-  LineCounter,
-  ParseOptions,
-  SchemaOptions,
-  ToJSOptions,
-  parse,
-  stringify as yamlStringify,
-} from 'yaml';
+import { LineCounter, stringify as yamlStringify } from 'yaml';
 
-import { objMerge } from '@hyperlane-xyz/utils';
+import {
+  indentYamlOrJson,
+  // Re-export core fs utilities from utils/fs
+  isFile,
+  mergeJson,
+  mergeYaml,
+  mergeYamlOrJson,
+  readFileAtPath,
+  readJson,
+  readYaml,
+  readYamlOrJson,
+  removeEndingSlash,
+  resolveFileFormat,
+  resolvePath,
+  tryReadJson,
+  tryReadYaml,
+  writeFileAtPath,
+  writeJson,
+  writeYaml,
+  writeYamlOrJson,
+  yamlParse,
+} from '@hyperlane-xyz/utils/fs';
 
 import { log } from '../logger.js';
 
-const yamlParse = (
-  content: string,
-  options?: ParseOptions & DocumentOptions & SchemaOptions & ToJSOptions,
-) =>
-  // See stackoverflow.com/questions/63075256/why-does-the-npm-yaml-library-have-a-max-alias-number
-  parse(content, { maxAliasCount: -1, ...options });
+export type { FileFormat } from '@hyperlane-xyz/utils/fs';
+
+// Re-export all the core fs utilities
+export {
+  isFile,
+  readFileAtPath,
+  writeFileAtPath,
+  removeEndingSlash,
+  resolvePath,
+  readJson,
+  tryReadJson,
+  writeJson,
+  mergeJson,
+  readYaml,
+  tryReadYaml,
+  writeYaml,
+  mergeYaml,
+  readYamlOrJson,
+  writeYamlOrJson,
+  mergeYamlOrJson,
+  resolveFileFormat,
+  indentYamlOrJson,
+};
 
 export const MAX_READ_LINE_OUTPUT = 250;
-
-export type FileFormat = 'yaml' | 'json';
 
 export type ArtifactsFile = {
   filename: string;
   description: string;
 };
 
-export function removeEndingSlash(dirPath: string): string {
-  if (dirPath.endsWith('/')) {
-    return dirPath.slice(0, -1);
-  }
-  return dirPath;
-}
-
-export function resolvePath(filePath: string): string {
-  if (filePath.startsWith('~')) {
-    const homedir = os.homedir();
-    return path.join(homedir, filePath.slice(1));
-  }
-  return filePath;
-}
-
-export function isFile(filepath: string) {
-  if (!filepath) return false;
-  try {
-    return fs.existsSync(filepath) && fs.lstatSync(filepath).isFile();
-  } catch {
-    log(`Error checking for file: ${filepath}`);
-    return false;
-  }
-}
-
-export function readFileAtPath(filepath: string) {
-  if (!isFile(filepath)) {
-    throw Error(`File doesn't exist at ${filepath}`);
-  }
-  return fs.readFileSync(filepath, 'utf8');
-}
-
-export function writeFileAtPath(filepath: string, value: string) {
-  const dirname = path.dirname(filepath);
-  if (!isFile(dirname)) {
-    fs.mkdirSync(dirname, { recursive: true });
-  }
-  fs.writeFileSync(filepath, value);
-}
-
-export function readJson<T>(filepath: string): T {
-  return JSON.parse(readFileAtPath(filepath)) as T;
-}
-
-export function tryReadJson<T>(filepath: string): T | null {
-  try {
-    return readJson(filepath) as T;
-  } catch {
-    return null;
-  }
-}
-
-export function writeJson(filepath: string, obj: any) {
-  writeFileAtPath(filepath, JSON.stringify(obj, null, 2) + '\n');
-}
-
-export function mergeJson<T extends Record<string, any>>(
-  filepath: string,
-  obj: T,
-) {
-  if (isFile(filepath)) {
-    const previous = readJson<T>(filepath);
-    writeJson(filepath, objMerge(previous, obj));
-  } else {
-    writeJson(filepath, obj);
-  }
-}
-
-export function readYaml<T>(filepath: string): T {
-  return yamlParse(readFileAtPath(filepath)) as T;
-}
-
-export function tryReadYamlAtPath<T>(filepath: string): T | null {
-  try {
-    return readYaml(filepath);
-  } catch {
-    return null;
-  }
-}
-
-export function writeYaml(filepath: string, obj: any) {
-  writeFileAtPath(
-    filepath,
-    yamlStringify(obj, { indent: 2, sortMapEntries: true }) + '\n',
-  );
-}
-
-export function mergeYaml<T extends Record<string, any>>(
-  filepath: string,
-  obj: T,
-) {
-  if (isFile(filepath)) {
-    const previous = readYaml<T>(filepath);
-    writeYaml(filepath, objMerge(previous, obj));
-  } else {
-    writeYaml(filepath, obj);
-  }
-}
-
-export function readYamlOrJson<T>(filepath: string, format?: FileFormat): T {
-  return resolveYamlOrJsonFn(filepath, readJson, readYaml, format);
-}
-
-export function writeYamlOrJson(
-  filepath: string,
-  obj: Record<string, any>,
-  format?: FileFormat,
-) {
-  return resolveYamlOrJsonFn(
-    filepath,
-    (f: string) => writeJson(f, obj),
-    (f: string) => writeYaml(f, obj),
-    format,
-  );
-}
-
-export function mergeYamlOrJson(
-  filepath: string,
-  obj: Record<string, any>,
-  format: FileFormat = 'yaml',
-) {
-  return resolveYamlOrJsonFn(
-    filepath,
-    (f: string) => mergeJson(f, obj),
-    (f: string) => mergeYaml(f, obj),
-    format,
-  );
-}
-
-function resolveYamlOrJsonFn(
-  filepath: string,
-  jsonFn: any,
-  yamlFn: any,
-  format?: FileFormat,
-) {
-  const fileFormat = resolveFileFormat(filepath, format);
-  if (!fileFormat) {
-    throw new Error(`Invalid file format for ${filepath}`);
-  }
-
-  if (fileFormat === 'json') {
-    return jsonFn(filepath);
-  }
-
-  return yamlFn(filepath);
-}
-
-export function resolveFileFormat(
-  filepath?: string,
-  format?: FileFormat,
-): FileFormat | undefined {
-  // early out if filepath is undefined
-  if (!filepath) {
-    return format;
-  }
-
-  if (format === 'json' || filepath?.endsWith('.json')) {
-    return 'json';
-  }
-
-  if (
-    format === 'yaml' ||
-    filepath?.endsWith('.yaml') ||
-    filepath?.endsWith('.yml')
-  ) {
-    return 'yaml';
-  }
-
-  return undefined;
-}
+/**
+ * @deprecated Use tryReadYaml from @hyperlane-xyz/utils/fs instead
+ */
+export const tryReadYamlAtPath = tryReadYaml;
 
 export async function runFileSelectionStep(
   folderPath: string,
@@ -236,14 +97,6 @@ export async function runFileSelectionStep(
 
   if (filename) return filename;
   else throw new Error(`No filepath entered ${description}`);
-}
-
-export function indentYamlOrJson(str: string, indentLevel: number): string {
-  const indent = ' '.repeat(indentLevel);
-  return str
-    .split('\n')
-    .map((line) => indent + line)
-    .join('\n');
 }
 
 /**

--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -23,6 +23,7 @@ import {
   promiseObjAll,
   rootLogger,
 } from '@hyperlane-xyz/utils';
+import { mergeJson, readJson } from '@hyperlane-xyz/utils/fs';
 
 import { Contexts } from '../config/contexts.js';
 import { agents } from '../config/environments/agents.js';
@@ -54,8 +55,6 @@ import {
   assertRole,
   filterRemoteDomainMetadata,
   getInfraPath,
-  readJSONAtPath,
-  writeMergedJSONAtPath,
 } from '../src/utils/utils.js';
 
 const logger = rootLogger.child({ module: 'infra:scripts:agent-utils' });
@@ -680,11 +679,13 @@ export function getAddresses(
   module: Modules,
   chains?: ChainName[],
 ) {
-  let addresses;
+  let addresses: ChainMap<ChainAddresses>;
   if (isRegistryModule(environment, module)) {
     addresses = getChainAddresses();
   } else {
-    addresses = readJSONAtPath(getInfraLandfillPath(environment, module));
+    addresses = readJson<ChainMap<ChainAddresses>>(
+      getInfraLandfillPath(environment, module),
+    );
   }
 
   // Filter by chains if specified, otherwise use environment chains
@@ -719,10 +720,7 @@ export function writeAddresses(
       getRegistry().updateChain({ chainName, addresses });
     }
   } else {
-    writeMergedJSONAtPath(
-      getInfraLandfillPath(environment, module),
-      addressesMap,
-    );
+    mergeJson(getInfraLandfillPath(environment, module), addressesMap);
   }
 }
 

--- a/typescript/infra/scripts/agents/update-agent-config.ts
+++ b/typescript/infra/scripts/agents/update-agent-config.ts
@@ -24,6 +24,7 @@ import {
   promiseObjAll,
   rootLogger,
 } from '@hyperlane-xyz/utils';
+import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import { Contexts } from '../../config/contexts.js';
 import { agentSpecificChainMetadataOverrides } from '../../config/environments/mainnet3/chains.js';
@@ -42,7 +43,6 @@ import {
   chainIsProtocol,
   filterRemoteDomainMetadata,
   isEthereumProtocolChain,
-  readJSONAtPath,
   writeAndFormatJsonAtPath,
 } from '../../src/utils/utils.js';
 import {
@@ -235,7 +235,7 @@ export async function writeAgentConfig(
   const filepath = getAgentConfigJsonPath(envNameToAgentEnv[environment]);
   console.log(`Writing config to ${filepath}`);
   if (fs.existsSync(filepath)) {
-    const currentAgentConfig: AgentConfig = readJSONAtPath(filepath);
+    const currentAgentConfig: AgentConfig = readJson<AgentConfig>(filepath);
     // Remove transactionOverrides from each chain in the agent config
     // To ensure all overrides are configured in infra code or the registry, and not in JSON
     for (const chainConfig of Object.values(currentAgentConfig.chains)) {
@@ -272,7 +272,7 @@ export async function writeAgentAppContexts(
   );
   console.log(`Writing config to ${filepath}`);
   if (fs.existsSync(filepath)) {
-    const currentAgentConfigMap = readJSONAtPath(filepath);
+    const currentAgentConfigMap = readJson<RelayerAppContextConfig>(filepath);
     writeAndFormatJsonAtPath(
       filepath,
       objMerge(currentAgentConfigMap, agentConfigMap),

--- a/typescript/infra/scripts/deploy.ts
+++ b/typescript/infra/scripts/deploy.ts
@@ -26,6 +26,7 @@ import {
   TestRecipientDeployer,
 } from '@hyperlane-xyz/sdk';
 import { inCIMode, objFilter, objMap } from '@hyperlane-xyz/utils';
+import { writeYaml } from '@hyperlane-xyz/utils/fs';
 
 import { Contexts } from '../config/contexts.js';
 import { core as coreConfig } from '../config/environments/mainnet3/core.js';
@@ -42,7 +43,6 @@ import {
 import { DEPLOYERS } from '../src/governance.js';
 import { Role } from '../src/roles.js';
 import { impersonateAccount, useLocalProvider } from '../src/utils/fork.js';
-import { writeYamlAtPath } from '../src/utils/utils.js';
 
 import {
   Modules,
@@ -300,7 +300,7 @@ async function main() {
         deploymentPlansDir,
         `${chain}.yaml`,
       );
-      writeYamlAtPath(chainDeployPlanPath, config);
+      writeYaml(chainDeployPlanPath, config);
       console.log(
         `Deployment Plan for ${chain} written to ${chainDeployPlanPath}`,
       );

--- a/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-keys-from-deployer.ts
@@ -12,6 +12,7 @@ import {
   defaultMultisigConfigs,
 } from '@hyperlane-xyz/sdk';
 import { Address, objFilter, objMap, rootLogger } from '@hyperlane-xyz/utils';
+import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import { Contexts } from '../../config/contexts.js';
 import { getEnvAddresses } from '../../config/registry.js';
@@ -43,7 +44,6 @@ import {
   assertFundableRole,
   assertRole,
   isEthereumProtocolChain,
-  readJSONAtPath,
 } from '../../src/utils/utils.js';
 import { getAgentConfig, getArgs } from '../agent-utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
@@ -344,7 +344,8 @@ class ContextFunder {
   ) {
     logger.info({ filePath }, 'Reading identifiers and addresses from file');
     // A big array of KeyAsAddress, including keys that we may not care about.
-    const allIdsAndAddresses: KeyAsAddress[] = readJSONAtPath(filePath);
+    const allIdsAndAddresses: KeyAsAddress[] =
+      readJson<KeyAsAddress[]>(filePath);
     if (!allIdsAndAddresses.length) {
       throw Error(`Expected at least one key in file ${filePath}`);
     }

--- a/typescript/infra/scripts/funding/write-alert.ts
+++ b/typescript/infra/scripts/funding/write-alert.ts
@@ -4,6 +4,7 @@ import yargs from 'yargs';
 
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { rootLogger } from '@hyperlane-xyz/utils';
+import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import {
   BalanceThresholdType,
@@ -30,7 +31,6 @@ import {
   fetchPrometheusInstantExpression,
   portForwardPrometheusServer,
 } from '../../src/infrastructure/monitoring/prometheus.js';
-import { readJSONAtPath } from '../../src/utils/utils.js';
 import { withDryRun } from '../agent-utils.js';
 
 interface AlertUpdateInfo {
@@ -86,7 +86,7 @@ async function main() {
 
       // read the proposed thresholds from the config file
       let proposedThresholds: ChainMap<number> = {};
-      proposedThresholds = readJSONAtPath(
+      proposedThresholds = readJson(
         `${THRESHOLD_CONFIG_PATH}/${alertConfigMapping[alert].configFileName}`,
       );
 
@@ -172,7 +172,7 @@ async function validateBalanceThresholdConfigs() {
   const balanceThresholdTypes = Object.values(BalanceThresholdType);
   const balanceThresholdConfigs = balanceThresholdTypes.reduce(
     (acc, balanceThresholdType) => {
-      const thresholds = readJSONAtPath(
+      const thresholds = readJson(
         `${THRESHOLD_CONFIG_PATH}/${balanceThresholdConfigMapping[balanceThresholdType].configFileName}`,
       ) as ChainMap<string>;
 

--- a/typescript/infra/scripts/safes/combine-txs.ts
+++ b/typescript/infra/scripts/safes/combine-txs.ts
@@ -6,11 +6,9 @@ import * as path from 'path';
 import yargs from 'yargs';
 
 import { rootLogger } from '@hyperlane-xyz/utils';
+import { readJson } from '@hyperlane-xyz/utils/fs';
 
-import {
-  readJSONAtPath,
-  writeAndFormatJsonAtPath,
-} from '../../src/utils/utils.js';
+import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
 
 type TxFile = {
@@ -33,7 +31,7 @@ function readJSONFiles(directory: string): Record<string, TxFile[]> {
 
       // If the filename contains 'timelock', expect an array and only parse the first object
       if (file.includes('timelock')) {
-        const arr = readJSONAtPath(filePath);
+        const arr = readJson<TxFile[]>(filePath);
         if (!Array.isArray(arr) || arr.length === 0) {
           throw new Error(
             `Expected an array of objects in ${filePath} for TimelockController, but got: ${JSON.stringify(arr)}`,
@@ -41,7 +39,7 @@ function readJSONFiles(directory: string): Record<string, TxFile[]> {
         }
         txs = arr[0];
       } else {
-        txs = readJSONAtPath(filePath);
+        txs = readJson<TxFile>(filePath);
       }
 
       const chainId = txs.chainId;

--- a/typescript/infra/scripts/sealevel-helpers/update-multisig-ism-config.ts
+++ b/typescript/infra/scripts/sealevel-helpers/update-multisig-ism-config.ts
@@ -15,6 +15,7 @@ import {
   SvmMultiProtocolSignerAdapter,
 } from '@hyperlane-xyz/sdk';
 import { ProtocolType, rootLogger } from '@hyperlane-xyz/utils';
+import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import { Contexts } from '../../config/contexts.js';
 import { getChain } from '../../config/registry.js';
@@ -33,7 +34,7 @@ import {
 } from '../../src/utils/sealevel.js';
 import { submitProposalToSquads } from '../../src/utils/squads.js';
 import { getTurnkeySealevelDeployerSigner } from '../../src/utils/turnkey.js';
-import { chainIsProtocol, readJSONAtPath } from '../../src/utils/utils.js';
+import { chainIsProtocol } from '../../src/utils/utils.js';
 import { getArgs, withChains } from '../agent-utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
 
@@ -331,7 +332,7 @@ async function processChain(
 
   // Load configuration from file
   const configPath = multisigIsmConfigPath(environment, context, chain);
-  const config: SvmMultisigConfigMap = readJSONAtPath(configPath);
+  const config: SvmMultisigConfigMap = readJson(configPath);
 
   rootLogger.info(
     chalk.gray(

--- a/typescript/infra/scripts/timelocks/parse-txs.ts
+++ b/typescript/infra/scripts/timelocks/parse-txs.ts
@@ -19,7 +19,6 @@ import {
 import { processGovernorReaderResult } from '../../src/tx/utils.js';
 import { logTable } from '../../src/utils/log.js';
 import { getPendingTimelockTxs } from '../../src/utils/timelock.js';
-import { writeYamlAtPath } from '../../src/utils/utils.js';
 import { withChains } from '../agent-utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
 

--- a/typescript/infra/scripts/verify.ts
+++ b/typescript/infra/scripts/verify.ts
@@ -4,13 +4,13 @@ import {
   PostDeploymentContractVerifier,
   VerificationInput,
 } from '@hyperlane-xyz/sdk';
+import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import { assertEnvironment } from '../src/config/environment.js';
 import {
   extractBuildArtifact,
   fetchExplorerApiKeys,
 } from '../src/deployment/verify.js';
-import { readJSONAtPath } from '../src/utils/utils.js';
 
 import { getArgs, withBuildArtifactPath, withChain } from './agent-utils.js';
 import { getEnvironmentConfig } from './core-utils.js';
@@ -33,7 +33,7 @@ async function main() {
   const multiProvider = await config.getMultiProvider();
 
   // grab verification artifacts
-  const verification: ChainMap<VerificationInput> = readJSONAtPath(
+  const verification: ChainMap<VerificationInput> = readJson(
     verificationArtifactPath,
   );
 

--- a/typescript/infra/scripts/warp-routes/export-svm-config.ts
+++ b/typescript/infra/scripts/warp-routes/export-svm-config.ts
@@ -5,9 +5,9 @@ import { fileURLToPath } from 'url';
 
 import { HypTokenConfig, TokenStandard } from '@hyperlane-xyz/sdk';
 import { rootLogger } from '@hyperlane-xyz/utils';
+import { readFileAtPath } from '@hyperlane-xyz/utils/fs';
 
 import { getChain, getRegistry } from '../../config/registry.js';
-import { readFileAtPath } from '../../src/utils/utils.js';
 import { getArgs, withWarpRouteId } from '../agent-utils.js';
 
 async function main() {

--- a/typescript/infra/scripts/warp-routes/generate-strategy-config.ts
+++ b/typescript/infra/scripts/warp-routes/generate-strategy-config.ts
@@ -6,9 +6,9 @@ import {
   assert,
   configureRootLogger,
 } from '@hyperlane-xyz/utils';
+import { writeYaml } from '@hyperlane-xyz/utils/fs';
 
 import { strategyConfigGetterMap } from '../../config/warp.js';
-import { writeYamlAtPath } from '../../src/utils/utils.js';
 import {
   getArgs,
   withKnownWarpRouteId,
@@ -41,7 +41,7 @@ async function main() {
     }
     const configFileName = `${warpRouteId}-strategy.yaml`;
     const outputFilePath = `${outFile}/${configFileName}`;
-    writeYamlAtPath(outputFilePath, strategy);
+    writeYaml(outputFilePath, strategy);
     logger.info(`Strategy successfully created at`, outputFilePath);
   }
 }

--- a/typescript/infra/scripts/warp-routes/generate-warp-config.ts
+++ b/typescript/infra/scripts/warp-routes/generate-warp-config.ts
@@ -2,9 +2,9 @@ import { stringify as yamlStringify } from 'yaml';
 
 import { WarpRouteDeployConfigSchema } from '@hyperlane-xyz/sdk';
 import { rootLogger } from '@hyperlane-xyz/utils';
+import { writeYaml } from '@hyperlane-xyz/utils/fs';
 
 import { getWarpConfig } from '../../config/warp.js';
-import { writeYamlAtPath } from '../../src/utils/utils.js';
 import {
   getArgs,
   withKnownWarpRouteIdRequired,
@@ -35,7 +35,7 @@ async function main() {
 
   if (outFile) {
     rootLogger.info(`Writing config to ${outFile}`);
-    writeYamlAtPath(outFile, parsed.data);
+    writeYaml(outFile, parsed.data);
   }
 }
 

--- a/typescript/infra/scripts/warp-routes/ousdt/update-submitter-strategy.ts
+++ b/typescript/infra/scripts/warp-routes/ousdt/update-submitter-strategy.ts
@@ -8,11 +8,11 @@ import {
   WarpRouteDeployConfigSchema,
 } from '@hyperlane-xyz/sdk';
 import { rootLogger } from '@hyperlane-xyz/utils';
+import { writeYaml } from '@hyperlane-xyz/utils/fs';
 
 import { awSafes } from '../../../config/environments/mainnet3/governance/safe/aw.js';
 import { getWarpConfig } from '../../../config/warp.js';
 import { Owner, determineGovernanceType } from '../../../src/governance.js';
-import { writeYamlAtPath } from '../../../src/utils/utils.js';
 import { getEnvironmentConfig } from '../../core-utils.js';
 
 const warpRouteId = 'oUSDT/production';
@@ -109,7 +109,7 @@ async function main() {
   rootLogger.info('Generated strategy:');
   rootLogger.info(yamlStringify(chainSubmissionStrategy, null, 2));
   rootLogger.info(`Wrote strategy to ${strategyFilePath}`);
-  writeYamlAtPath(strategyFilePath, chainSubmissionStrategy);
+  writeYaml(strategyFilePath, chainSubmissionStrategy);
 }
 
 main().catch((err) => rootLogger.error('Error:', err));

--- a/typescript/infra/src/agents/key-utils.ts
+++ b/typescript/infra/src/agents/key-utils.ts
@@ -10,6 +10,7 @@ import {
   objMap,
   rootLogger,
 } from '@hyperlane-xyz/utils';
+import { readJsonFromDir } from '@hyperlane-xyz/utils/fs';
 
 import { Contexts } from '../../config/contexts.js';
 import { helloworld } from '../../config/environments/helloworld.js';
@@ -26,7 +27,6 @@ import {
   execCmd,
   getInfraPath,
   isEthereumProtocolChain,
-  readJSON,
   writeAndFormatJsonAtPath,
 } from '../utils/utils.js';
 
@@ -641,7 +641,7 @@ export async function persistValidatorAddressesToLocalArtifacts(
 
 export function fetchLocalKeyAddresses(role: Role): LocalRoleAddresses {
   try {
-    const addresses: LocalRoleAddresses = readJSON(
+    const addresses: LocalRoleAddresses = readJsonFromDir(
       CONFIG_DIRECTORY_PATH,
       `${role}.json`,
     );

--- a/typescript/infra/src/config/gas-oracle.ts
+++ b/typescript/infra/src/config/gas-oracle.ts
@@ -24,9 +24,10 @@ import {
   rootLogger,
   toWei,
 } from '@hyperlane-xyz/utils';
+import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import { getChain } from '../../config/registry.js';
-import { mustGetChainNativeToken, readJSONAtPath } from '../utils/utils.js';
+import { mustGetChainNativeToken } from '../utils/utils.js';
 
 // gas oracle configs for each chain, which includes
 // a map for each chain's remote chains
@@ -75,7 +76,7 @@ const GasOracleConfigFileSchema = z.record(
 export function loadAndValidateGasOracleConfig(
   configPath: string,
 ): ChainMap<ChainMap<GasOracleConfigWithOverhead>> {
-  const rawConfig = readJSONAtPath(configPath);
+  const rawConfig = readJson(configPath);
 
   try {
     const validated = GasOracleConfigFileSchema.parse(rawConfig);

--- a/typescript/infra/src/deployment/deploy.ts
+++ b/typescript/infra/src/deployment/deploy.ts
@@ -15,6 +15,7 @@ import {
   objMerge,
   runWithTimeout,
 } from '@hyperlane-xyz/utils';
+import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import {
   Modules,
@@ -22,7 +23,7 @@ import {
   writeAddresses,
 } from '../../scripts/agent-utils.js';
 import { DeployEnvironment } from '../config/environment.js';
-import { readJSONAtPath, writeAndFormatJsonAtPath } from '../utils/utils.js';
+import { writeAndFormatJsonAtPath } from '../utils/utils.js';
 
 enum DeployStatus {
   EMPTY = '🫥',
@@ -249,7 +250,7 @@ async function postDeploy<Config extends object>(
 
     let savedVerification = {};
     try {
-      savedVerification = readJSONAtPath(cache.verification);
+      savedVerification = readJson(cache.verification);
     } catch (e) {
       console.error(
         chalk.red('Failed to load cached verification inputs. Error: ', e),

--- a/typescript/infra/src/deployment/verify.ts
+++ b/typescript/infra/src/deployment/verify.ts
@@ -1,7 +1,7 @@
 import { BuildArtifact, ChainMap } from '@hyperlane-xyz/sdk';
+import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import { fetchGCPSecret } from '../utils/gcloud.js';
-import { readJSONAtPath } from '../utils/utils.js';
 
 // read build artifact from given path
 export function extractBuildArtifact(buildArtifactPath: string): BuildArtifact {
@@ -11,7 +11,7 @@ export function extractBuildArtifact(buildArtifactPath: string): BuildArtifact {
   }
 
   // return as BuildArtifact
-  return readJSONAtPath(buildArtifactPath) as BuildArtifact;
+  return readJson<BuildArtifact>(buildArtifactPath);
 }
 
 // fetch explorer API keys from GCP

--- a/typescript/infra/src/funding/balances.ts
+++ b/typescript/infra/src/funding/balances.ts
@@ -1,5 +1,6 @@
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { rootLogger } from '@hyperlane-xyz/utils';
+import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import {
   BalanceThresholdType,
@@ -7,7 +8,6 @@ import {
   ThresholdsData,
   balanceThresholdConfigMapping,
 } from '../config/funding/balances.js';
-import { readJSONAtPath } from '../utils/utils.js';
 
 export function validateThresholds(thresholdsData: ThresholdsData): void {
   const errors: string[] = [];
@@ -106,7 +106,7 @@ export function readAllThresholds(): ThresholdsData {
   for (const thresholdType of Object.values(BalanceThresholdType)) {
     const thresholdsFile = `${THRESHOLD_CONFIG_PATH}/${balanceThresholdConfigMapping[thresholdType].configFileName}`;
 
-    const chainMap = readJSONAtPath(thresholdsFile) as ChainMap<number>;
+    const chainMap = readJson<ChainMap<number>>(thresholdsFile);
 
     result[thresholdType] = chainMap;
   }

--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -6,12 +6,13 @@ import {
   RebalancerConfigSchema,
 } from '@hyperlane-xyz/sdk';
 import { isObjEmpty } from '@hyperlane-xyz/utils';
+import { readYaml } from '@hyperlane-xyz/utils/fs';
 
 import { getWarpCoreConfig } from '../../config/registry.js';
 import { DeployEnvironment } from '../config/environment.js';
 import { WARP_ROUTE_MONITOR_HELM_RELEASE_PREFIX } from '../utils/consts.js';
 import { HelmManager, getHelmReleaseName } from '../utils/helm.js';
-import { getInfraPath, readYaml } from '../utils/utils.js';
+import { getInfraPath } from '../utils/utils.js';
 
 export class RebalancerHelmManager extends HelmManager {
   static helmReleasePrefix: string = 'hyperlane-rebalancer';

--- a/typescript/infra/src/tx/utils.ts
+++ b/typescript/infra/src/tx/utils.ts
@@ -2,8 +2,7 @@ import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
 
 import { rootLogger, stringifyObject } from '@hyperlane-xyz/utils';
-
-import { writeYamlAtPath } from '../utils/utils.js';
+import { writeYaml } from '@hyperlane-xyz/utils/fs';
 
 import { GovernTransaction } from './govern-transaction-reader.js';
 
@@ -26,7 +25,7 @@ export function processGovernorReaderResult(
 
   const chainResults = Object.fromEntries(result);
   const resultsPath = `${outputFileName}-${Date.now()}.yaml`;
-  writeYamlAtPath(resultsPath, chainResults);
+  writeYaml(resultsPath, chainResults);
   rootLogger.info(`Results written to ${resultsPath}`);
 
   if (errors.length) {

--- a/typescript/infra/src/utils/sealevel.ts
+++ b/typescript/infra/src/utils/sealevel.ts
@@ -27,12 +27,13 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { SealevelMultisigIsmInstructionType as SdkMultisigIsmInstructionType } from '@hyperlane-xyz/sdk';
 import { rootLogger } from '@hyperlane-xyz/utils';
+import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import { Contexts } from '../../config/contexts.js';
 import { DeployEnvironment } from '../config/environment.js';
 
 import { getValidatorAlias } from './consts.js';
-import { getMonorepoRoot, readJSONAtPath } from './utils.js';
+import { getMonorepoRoot } from './utils.js';
 
 // ============================================================================
 // Solana Data Structure Sizes
@@ -383,7 +384,7 @@ export function loadCoreProgramIds(
   );
 
   try {
-    return readJSONAtPath(programIdsPath);
+    return readJson(programIdsPath);
   } catch (error) {
     throw new Error(`Failed to load program IDs from ${programIdsPath}.`);
   }

--- a/typescript/infra/test/agent-configs.test.ts
+++ b/typescript/infra/test/agent-configs.test.ts
@@ -1,5 +1,8 @@
 import { expect } from 'chai';
 
+import { AgentConfig } from '@hyperlane-xyz/sdk';
+import { readJson } from '@hyperlane-xyz/utils/fs';
+
 import { hyperlaneContextAgentChainConfig as mainnet3AgentChainConfig } from '../config/environments/mainnet3/agent.js';
 import { mainnet3SupportedChainNames } from '../config/environments/mainnet3/supportedChainNames.js';
 import { hyperlaneContextAgentChainConfig as testnet4AgentChainConfig } from '../config/environments/testnet4/agent.js';
@@ -10,21 +13,20 @@ import {
   ensureAgentChainConfigIncludesAllChainNames,
 } from '../src/config/agent/agent.js';
 import { AgentEnvironment } from '../src/config/environment.js';
-import { readJSONAtPath } from '../src/utils/utils.js';
 
 const environmentChainConfigs = {
   mainnet3: {
     agentChainConfig: mainnet3AgentChainConfig,
     // We read the agent config from the file system instead of importing
     // to get around the agent JSON configs living outside the typescript rootDir
-    agentJsonConfig: readJSONAtPath(
+    agentJsonConfig: readJson<AgentConfig>(
       getAgentConfigJsonPath(AgentEnvironment.Mainnet),
     ),
     supportedChainNames: mainnet3SupportedChainNames,
   },
   testnet4: {
     agentChainConfig: testnet4AgentChainConfig,
-    agentJsonConfig: readJSONAtPath(
+    agentJsonConfig: readJson<AgentConfig>(
       getAgentConfigJsonPath(AgentEnvironment.Testnet),
     ),
     supportedChainNames: testnet4SupportedChainNames,

--- a/typescript/infra/test/balance-alerts.test.ts
+++ b/typescript/infra/test/balance-alerts.test.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 
+import { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
 import { retryAsync } from '@hyperlane-xyz/utils';
+import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import { THRESHOLD_CONFIG_PATH } from '../src/config/funding/balances.js';
 import {
@@ -12,7 +14,6 @@ import {
   fetchGrafanaAlert,
   fetchGrafanaServiceAccountToken,
 } from '../src/infrastructure/monitoring/grafana.js';
-import { readJSONAtPath } from '../src/utils/utils.js';
 
 const DEFAULT_TIMEOUT = 30_000;
 
@@ -50,7 +51,7 @@ describe('Balance Alert Thresholds', async function () {
       );
 
       // Read proposed thresholds from config file
-      const proposedThresholds = readJSONAtPath(
+      const proposedThresholds = readJson<ChainMap<number>>(
         `${THRESHOLD_CONFIG_PATH}/${alertConfigMapping[alert].configFileName}`,
       );
 

--- a/typescript/infra/test/gitleaks.test.ts
+++ b/typescript/infra/test/gitleaks.test.ts
@@ -11,8 +11,7 @@ import {
 } from 'smol-toml';
 
 import { bufferToBase58, setEquality } from '@hyperlane-xyz/utils';
-
-import { readFileAtPath, writeToFile } from '../src/utils/utils.js';
+import { readFileAtPath, writeToFile } from '@hyperlane-xyz/utils/fs';
 
 describe('GitLeaks CLI Integration Tests', function () {
   let tempDir: string;


### PR DESCRIPTION
## Summary
- Migrate CLI and infra packages to use the new `@hyperlane-xyz/utils/fs` submodule
- Remove duplicated filesystem utility implementations
- Net deletion of ~180 lines of code

**Stacked on #7558**

## Test plan
- [x] Build passes
- [x] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Consolidated filesystem utilities across CLI and infra packages by migrating to a shared centralized utilities module, reducing code duplication and improving maintainability.
  * Updated internal file handling operations for JSON and YAML processing to use standardized utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->