### PR TITLE
perf(docker): optimize agent image with stripped binaries

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -65,7 +65,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # Using debian-slim instead of Alpine because Rust binaries are linked against glibc
 FROM debian:bookworm-slim
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates tini && \
+    apt-get install -y --no-install-recommends ca-certificates tini libcurl4 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /app /usr/share/hyperlane /data && \


### PR DESCRIPTION
## Summary

Optimizes the Hyperlane agent Docker image by switching to Debian slim and stripping binaries.

### Changes

1. **Switch runtime base**: `ubuntu:22.04` → `debian:bookworm-slim`
2. **Strip binaries**: Remove debug symbols from release binaries
3. **Reorder Dockerfile**: Better layer caching

### Image Size Comparison

| Image | Size | Notes |
|-------|------|-------|
| `036e035-20251208-192517` | 667 MB | Baseline (Ubuntu 22.04, main) |
| `f6a3501-20251209-123355` | 580 MB | This PR (Debian slim + stripped) |
| **Savings** | **87 MB** | **13% reduction** |

### Image Breakdown

| Component | Before (Ubuntu) | After (Debian slim) | Savings |
|-----------|-----------------|---------------------|---------|
| Base image | ~88 MB | ~74 MB | 14 MB |
| Runtime deps | ~8 MB | ~8 MB | - |
| `relayer` | 163 MB | 132 MB | 31 MB (19%) |
| `validator` | 144 MB | 117 MB | 27 MB (19%) |
| `scraper` | 70 MB | 55 MB | 15 MB (21%) |
| Config/app-contexts | ~2 MB | ~2 MB | - |
| **Total** | **667 MB** | **580 MB** | **87 MB (13%)** |

## Test plan

- [x] CI build succeeds
- [x] `validator --help` works in resulting image
- [x] `relayer --help` works in resulting image
- [x] `scraper --help` works in resulting image
- [x] Compare final image size (87 MB / 13% savings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)