### PR TITLE
fix(ci): enable codecov carryforward for stable coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -839,6 +839,8 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: solidity
+          fail_ci_if_error: true
 
   coverage:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,15 @@ coverage:
         target: auto # strictly increasing coverage
         threshold: 3% # buffer for coverage drop
 
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: solidity
+      paths:
+        - solidity/contracts/**
+      carryforward: true
+
 comment:
   layout: 'header, diff, flags, components' # show component info in the PR comment
 


### PR DESCRIPTION
  ## Summary
  - Enable Codecov carryforward flag to maintain accurate coverage data when PRs don't include Solidity changes
  - Add `solidity` flag to coverage uploads for better tracking
  - Add `fail_ci_if_error: true` to surface upload failures immediately instead of silently failing

  ## Context
  The coverage badge is showing 0% because:
  1. Coverage only runs when Solidity files change
  2. Upload failures were silent when `yarn coverage` was failing.

  With carryforward enabled, Codecov reuses previous coverage data when no coverage job runs, keeping the badge
  accurate. Failed uploads now fail CI so issues are caught immediately.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code coverage tracking and validation configuration to ensure stricter quality assurance checks during continuous integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->