### PR TITLE
fix: aleo recipient ism

### DIFF
--- a/rust/main/chains/hyperlane-aleo/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-aleo/src/mailbox.rs
@@ -178,10 +178,14 @@ impl<C: AleoClient> Mailbox for AleoMailbox<C> {
             .provider
             .get_mapping_value(&recipient.to_string(), "app_metadata", &true)
             .await?;
-        match metadata {
-            Some(metadata) => to_h256(metadata.ism),
-            None => self.default_ism().await,
+        if let Some(metadata) = metadata {
+            let address = to_h256(metadata.ism)?;
+            // Only return if the address is non-zero
+            if !address.is_zero() {
+                return Ok(address);
+            }
         }
+        self.default_ism().await
     }
 
     /// Process a message with a proof against the provided signed checkpoint


### PR DESCRIPTION
### Description
This PR fixes the logic to retrieve the recipient ISM in Aleo.
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced recipient security module selection with stricter validation of metadata-provided values. Zero or invalid values from metadata are now properly rejected in favor of the default security configuration. When metadata is missing or contains invalid data, the system consistently falls back to the default security module for reliable operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->