### PR TITLE
chore(infra): skip warp check job for deprecated inevm routes

### DIFF
--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -33,6 +33,9 @@ async function main() {
   const routesToSkip: string[] = [
     WarpRouteIds.ArbitrumBaseBlastBscEthereumGnosisLiskMantleModeOptimismPolygonScrollZeroNetworkZoraMainnet,
     'EDGEN/bsc-edgenchain-ethereum',
+    'INJ/inevm-injective',
+    'USDC/ethereum-inevm',
+    'USDT/ethereum-inevm',
   ];
 
   const registries = [DEFAULT_REGISTRY_URI];


### PR DESCRIPTION
### Description

Adds inevm warp routes to the skip list for the warp check monitor as inevm has been deprecated and the job can't check the warp route config on inevm

### Drive-by changes



### Related issues

- 

### Backward compatibility

- Yes

### Testing

- Manual script run locally
