### PR TITLE
chore: update rebalancer image

### DIFF
--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -76,7 +76,7 @@ export class RebalancerHelmManager extends HelmManager {
     return {
       image: {
         repository: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-        tag: '5931d91-20251113-090707',
+        tag: '009603c-20251211-202114',
       },
       withMetrics: this.withMetrics,
       fullnameOverride: this.helmReleaseName,


### PR DESCRIPTION
### Description

- Updates rebalancer image to work with newer commits of the registry (that have the aleo protocol type)
- Some context https://hyperlaneworkspace.slack.com/archives/C08GHFABJQ6/p1765484891132339

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
