### PR TITLE
feat: allow rpc header for starknet chains

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -6387,6 +6387,7 @@ dependencies = [
  "hyperlane-metric",
  "hyperlane-operation-verifier",
  "hyperlane-warp-route",
+ "reqwest-utils",
  "serde",
  "serde_json",
  "starknet 0.15.1",

--- a/rust/main/chains/hyperlane-starknet/Cargo.toml
+++ b/rust/main/chains/hyperlane-starknet/Cargo.toml
@@ -29,6 +29,7 @@ hyperlane-core = { path = "../../hyperlane-core", features = ["async"] }
 hyperlane-operation-verifier = { path = "../../applications/hyperlane-operation-verifier" }
 hyperlane-warp-route = { path = "../../applications/hyperlane-warp-route" }
 hyperlane-metric = { path = "../../hyperlane-metric" }
+reqwest-utils = { path = "../../utils/reqwest-utils" }
 
 [build-dependencies]
 abigen = { path = "../../utils/abigen", features = ["starknet"] }

--- a/rust/main/chains/hyperlane-starknet/src/provider/client.rs
+++ b/rust/main/chains/hyperlane-starknet/src/provider/client.rs
@@ -36,21 +36,21 @@ impl StarknetProvider {
         conf: &ConnectionConf,
         metrics: PrometheusClientMetrics,
         chain: Option<ChainInfo>,
-    ) -> Self {
+    ) -> ChainResult<Self> {
         let provider = JsonRpcClient::new(FallbackHttpTransport::new(
             conf.urls.clone(),
             metrics,
             chain,
-        ));
+        )?);
 
         // Fee token address is used to check balances
         let fee_token_address = Felt::from_bytes_be(conf.native_token_address.as_fixed_bytes());
 
-        Self {
+        Ok(Self {
             domain,
             rpc_client: provider,
             fee_token_address,
-        }
+        })
     }
 
     /// Get the RPC client.

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -1483,12 +1483,12 @@ fn build_starknet_provider(
 ) -> ChainResult<StarknetProvider> {
     let middleware_metrics = chain_conf.metrics_conf();
     let metrics = metrics.client_metrics();
-    Ok(StarknetProvider::new(
+    StarknetProvider::new(
         locator.domain.clone(),
         connection_conf,
         metrics.clone(),
         middleware_metrics.chain.clone(),
-    ))
+    )
 }
 
 #[cfg(feature = "aleo")]


### PR DESCRIPTION
### Description
There is an upcoming change in paradex that will result in us having to pass Http Header in RPC requests. This PR addresses that issue and allows us to pass headers similar to the existing Radix & Ethereum integration.
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new utility dependency to support enhanced request handling.

* **Bug Fixes**
  * Improved error handling for Starknet provider initialization, ensuring initialization failures are properly detected and reported to callers instead of silently proceeding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->