### PR TITLE
fix: use bash for npm scripts to fix Windows CI

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Use bash for running npm scripts to ensure cross-platform compatibility
+# This fixes Windows CI failures where scripts use Unix shell syntax
+script-shell=bash


### PR DESCRIPTION
## Summary

- Fixes release workflow failures on Windows runners by adding `script-shell=bash` to `.npmrc`

The release workflow `cli-install-cross-platform-release-test` job fails on Windows because pnpm uses `cmd.exe` by default to run npm scripts. Scripts like:

```
NODE_OPTIONS='--experimental-loader ts-node/esm/transpile-only' hardhat ...
```

use Unix shell syntax (`VAR='value' command`) that doesn't work on Windows `cmd.exe`, resulting in:

```
'NODE_OPTIONS' is not recognized as an internal or external command
```

This PR adds a root `.npmrc` with `script-shell=bash` which forces pnpm to use bash (available via Git for Windows on Windows runners) for all scripts.

Related failure: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/20241331242/job/58109990526

## Test plan

- [ ] Verify the release workflow passes on Windows runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm configuration to ensure consistent script execution across all platforms, improving compatibility with Windows environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->