### PR TITLE
fix: configure bash script shell for Windows CI only

### DIFF
--- a/.github/actions/install-cli/action.yml
+++ b/.github/actions/install-cli/action.yml
@@ -13,6 +13,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Configure script shell for Windows
+      if: runner.os == 'Windows'
+      shell: bash
+      run: echo "script-shell=bash" >> .npmrc
+
     - name: pnpm-build-with-cache
       if: inputs.no-cache == 'false'
       uses: ./.github/actions/pnpm-build-with-cache


### PR DESCRIPTION
## Summary

- Fixes release workflow failures on Windows runners by configuring `script-shell=bash` only in CI on Windows

The release workflow `cli-install-cross-platform-release-test` job fails on Windows because pnpm uses `cmd.exe` by default to run npm scripts. Scripts like:

```
NODE_OPTIONS='--experimental-loader ts-node/esm/transpile-only' hardhat ...
```

use Unix shell syntax (`VAR='value' command`) that doesn't work on Windows `cmd.exe`, resulting in:

```
'NODE_OPTIONS' is not recognized as an internal or external command
```

This PR adds a step to the `install-cli` action that appends `script-shell=bash` to `.npmrc` **only on Windows runners**, so it doesn't affect local development or other CI platforms.

Related failure: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/20241331242/job/58109990526

## Test plan

- [ ] Verify the release workflow passes on Windows runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)