### PR TITLE
fix: update monorepo docker tags post-pnpm migration

### DIFF
--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -36,7 +36,7 @@ export const keyFunderConfig: KeyFunderConfig<
 > = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-    tag: '62472e9-20251212-155803',
+    tag: '8da6852-20251215-172511',
   },
   // We're currently using the same deployer/key funder key as mainnet2.
   // To minimize nonce clobbering we offset the key funder cron

--- a/typescript/infra/config/environments/mainnet3/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet3/helloworld.ts
@@ -13,7 +13,7 @@ export const hyperlane: HelloWorldConfig = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: '7e520fb-20241215-234731',
+      tag: '8da6852-20251215-172511',
     },
     chainsToSkip: [],
     runEnv: environment,
@@ -33,7 +33,7 @@ export const releaseCandidate: HelloWorldConfig = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: '7e520fb-20241215-234731',
+      tag: '8da6852-20251215-172511',
     },
     chainsToSkip: [],
     runEnv: environment,

--- a/typescript/infra/config/environments/mainnet3/warp/checkWarpDeploy.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/checkWarpDeploy.ts
@@ -4,7 +4,7 @@ import { environment } from '../chains.js';
 export const checkWarpDeployConfig: CheckWarpDeployConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-    tag: 'main',
+    tag: '8da6852-20251215-172511',
   },
   namespace: environment,
   cronSchedule: '0 15 * * *', // set to 3pm utc every day

--- a/typescript/infra/config/environments/testnet4/funding.ts
+++ b/typescript/infra/config/environments/testnet4/funding.ts
@@ -10,7 +10,7 @@ export const keyFunderConfig: KeyFunderConfig<
 > = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-    tag: '032b3b0-20251105-200907',
+    tag: '8da6852-20251215-172511',
   },
   // We're currently using the same deployer key as testnet2.
   // To minimize nonce clobbering we offset the key funder cron

--- a/typescript/infra/config/environments/testnet4/helloworld.ts
+++ b/typescript/infra/config/environments/testnet4/helloworld.ts
@@ -13,7 +13,7 @@ export const hyperlaneHelloworld: HelloWorldConfig = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: '3e27f07-20250415-081849',
+      tag: '8da6852-20251215-172511',
     },
     chainsToSkip: [],
     runEnv: environment,
@@ -32,7 +32,7 @@ export const releaseCandidateHelloworld: HelloWorldConfig = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-      tag: '3e27f07-20250415-081849',
+      tag: '8da6852-20251215-172511',
     },
     chainsToSkip: [],
     runEnv: environment,

--- a/typescript/infra/helm/offchain-lookup-server/values-mainnet.yaml
+++ b/typescript/infra/helm/offchain-lookup-server/values-mainnet.yaml
@@ -6,7 +6,7 @@ image:
   # Modify this tag to deploy a new revision.
   # Images can be found here:
   # https://console.cloud.google.com/artifacts/docker/abacus-labs-dev/us/gcr.io/hyperlane-monorepo?inv=1&invt=AbxRMg&project=abacus-labs-dev
-  tag: 31d0189-20251110-105856
+  tag: 8da6852-20251215-172511
 
 # In Google Cloud Secret Manager, all secrets need to have a certain prefix in order to be accessible by
 # the Cluster Secret Store. For testnet this prefix is "hyperlane-testnet4"

--- a/typescript/infra/helm/offchain-lookup-server/values-testnet.yaml
+++ b/typescript/infra/helm/offchain-lookup-server/values-testnet.yaml
@@ -6,7 +6,7 @@ image:
   # Modify this tag to deploy a new revision.
   # Images can be found here:
   # https://console.cloud.google.com/artifacts/docker/abacus-labs-dev/us/gcr.io/hyperlane-monorepo?inv=1&invt=AbxRMg&project=abacus-labs-dev
-  tag: 31d0189-20251110-105856
+  tag: 8da6852-20251215-172511
 
 # In Google Cloud Secret Manager, all secrets need to have a certain prefix in order to be accessible by
 # the Cluster Secret Store. For testnet this prefix is "hyperlane-testnet4"

--- a/typescript/infra/helm/offchain-lookup-server/values.yaml
+++ b/typescript/infra/helm/offchain-lookup-server/values.yaml
@@ -6,7 +6,7 @@ image:
   # Modify this tag to deploy a new revision.
   # Images can be found here:
   # https://console.cloud.google.com/artifacts/docker/abacus-labs-dev/us/gcr.io/hyperlane-monorepo?inv=1&invt=AbxRMg&project=abacus-labs-dev
-  tag: 88afca1-20250702-173601
+  tag: 8da6852-20251215-172511
 
 secrets:
   name: 'offchain-lookup-server'

--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -76,7 +76,7 @@ export class RebalancerHelmManager extends HelmManager {
     return {
       image: {
         repository: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-        tag: '009603c-20251211-202114',
+        tag: '8da6852-20251215-172511',
       },
       withMetrics: this.withMetrics,
       fullnameOverride: this.helmReleaseName,

--- a/typescript/infra/src/warp/helm.ts
+++ b/typescript/infra/src/warp/helm.ts
@@ -96,7 +96,7 @@ export class WarpRouteMonitorHelmManager extends HelmManager {
     return {
       image: {
         repository: 'gcr.io/abacus-labs-dev/hyperlane-monorepo',
-        tag: 'dbcf390-20251118-224744',
+        tag: '8da6852-20251215-172511',
       },
       warpRouteId: this.warpRouteId,
       fullnameOverride: this.helmReleaseName,


### PR DESCRIPTION
### Description

fix: update monorepo docker tags post-pnpm migration

need to update all monorepo tags post-pnpm migration, since the helm charts will be invoking pnpm commands

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
