### PR TITLE
fix: use args instead of command in helm charts to preserve ENTRYPOINT

### DIFF
--- a/typescript/infra/helm/check-warp-deploy/templates/cron-job.yaml
+++ b/typescript/infra/helm/check-warp-deploy/templates/cron-job.yaml
@@ -18,7 +18,10 @@ spec:
           - name: check-warp-deploy
             image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
             imagePullPolicy: Always
-            command:
+            # Use `args` instead of `command` to preserve the Docker ENTRYPOINT.
+            # The entrypoint script (docker-entrypoint.sh) handles REGISTRY_COMMIT checkout.
+            # Using `command` would bypass the entrypoint and break registry version pinning.
+            args:
             - pnpm
             - exec
             - tsx

--- a/typescript/infra/helm/warp-routes/templates/_helpers.tpl
+++ b/typescript/infra/helm/warp-routes/templates/_helpers.tpl
@@ -72,7 +72,10 @@ The warp-routes container
     value: json
   - name: REGISTRY_COMMIT
     value: {{ .Values.hyperlane.registryCommit }}
-  command:
+  # Use `args` instead of `command` to preserve the Docker ENTRYPOINT.
+  # The entrypoint script (docker-entrypoint.sh) handles REGISTRY_COMMIT checkout.
+  # Using `command` would bypass the entrypoint and break registry version pinning.
+  args:
   - pnpm
   - exec
   - tsx


### PR DESCRIPTION
## Summary
- Change `command:` to `args:` in helm templates so that the Docker ENTRYPOINT (`docker-entrypoint.sh`) runs before the main script
- Add comments explaining why `args:` must be used instead of `command:`

## Problem
The warp-route monitor (and check-warp-deploy) were running with stale registry versions even when `REGISTRY_COMMIT` env var was set correctly.

**Root cause**: Using `command:` in K8s pod specs overrides the Docker ENTRYPOINT entirely. The `docker-entrypoint.sh` script that handles `REGISTRY_COMMIT` checkout at runtime was never executing.

## Solution
Change `command:` to `args:` because:
- `command` in K8s = Docker ENTRYPOINT (overrides)
- `args` in K8s = Docker CMD (passed to ENTRYPOINT)

With `args:`, the flow is:
1. Container starts → `docker-entrypoint.sh` runs (ENTRYPOINT)
2. Entrypoint checks `REGISTRY_COMMIT` and does `git checkout`
3. Entrypoint `exec "$@"` runs the actual script (args)

## Affected charts
- `warp-routes`
- `check-warp-deploy`

## Test plan
- [ ] Deploy warp-route monitor and verify REGISTRY_COMMIT checkout messages appear in startup logs
- [ ] Verify the registry in the pod matches the REGISTRY_COMMIT env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)