### PR TITLE
fix: deprecate form

### DIFF
--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -36,6 +36,11 @@ async function main() {
     'INJ/inevm-injective',
     'USDC/ethereum-inevm',
     'USDT/ethereum-inevm',
+    'WBTC/ethereum-form',
+    'WSTETH/ethereum-form',
+    'USDT/ethereum-form',
+    'USDC/ethereum-form',
+    'TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain',
   ];
 
   const registries = [DEFAULT_REGISTRY_URI];


### PR DESCRIPTION
### Description

Form has been deprecated, removing it from check-warp-deploy.ts

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal warp-deploy configuration to skip additional routes during checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->