### PR TITLE
feat: migrate Docker workflows to Workload Identity Federation

### DIFF
--- a/.github/workflows/ccip-server-docker.yml
+++ b/.github/workflows/ccip-server-docker.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: recursive
+          fetch-depth: 0
 
       - name: Generate tag data
         id: taggen
@@ -121,7 +122,7 @@ jobs:
           fi
 
       - name: Comment image tags on PR
-        if: github.event_name == 'pull_request' && steps.check-changes.outputs.has_changes == 'true' && always()
+        if: github.event_name == 'pull_request' && steps.check-changes.outputs.has_changes == 'true'
         uses: ./.github/actions/docker-image-comment
         with:
           comment_tag: ccip-server-docker-image

--- a/.github/workflows/ccip-server-docker.yml
+++ b/.github/workflows/ccip-server-docker.yml
@@ -1,0 +1,133 @@
+name: Build and Push CCIP Server Image to GCR
+on:
+  push:
+    branches: [main]
+    tags:
+      - '**'
+    paths:
+      - 'typescript/ccip-server/**'
+      - 'typescript/sdk/**'
+      - 'typescript/utils/**'
+      - '.github/workflows/ccip-server-docker.yml'
+  pull_request:
+    paths:
+      - 'typescript/ccip-server/**'
+      - 'typescript/sdk/**'
+      - 'typescript/utils/**'
+      - '.github/workflows/ccip-server-docker.yml'
+  workflow_dispatch:
+    inputs:
+      include_arm64:
+        description: 'Include arm64 in the build'
+        required: false
+        default: 'false'
+
+concurrency:
+  group: build-push-ccip-server-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-env:
+    runs-on: ubuntu-latest
+    outputs:
+      gcloud-service-key: ${{ steps.gcloud-service-key.outputs.defined }}
+    steps:
+      - id: gcloud-service-key
+        env:
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
+        if: "${{ env.GCLOUD_SERVICE_KEY != '' }}"
+        run: echo "defined=true" >> $GITHUB_OUTPUT
+
+  build-and-push-to-gcr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    needs: [check-env]
+    if: needs.check-env.outputs.gcloud-service-key == 'true'
+
+    steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.HYPER_GONK_APP_ID }}
+          private-key: ${{ secrets.HYPER_GONK_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          submodules: recursive
+
+      - name: Generate tag data
+        id: taggen
+        run: |
+          echo "TAG_DATE=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
+          echo "TAG_SHA=$(echo '${{ github.event.pull_request.head.sha || github.sha }}' | cut -b 1-7)" >> $GITHUB_OUTPUT
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            gcr.io/abacus-labs-dev/hyperlane-offchain-lookup-server
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=${{ steps.taggen.outputs.TAG_SHA }}-${{ steps.taggen.outputs.TAG_DATE }}
+
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
+
+      - name: Login to GCR
+        uses: docker/login-action@v3
+        with:
+          registry: gcr.io
+          username: _json_key
+          password: ${{ secrets.GCLOUD_SERVICE_KEY }}
+
+      - name: Determine platforms
+        id: determine-platforms
+        run: |
+          if [ "${{ github.event.inputs.include_arm64 }}" == "true" ]; then
+            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+          else
+            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
+        id: build
+        uses: depot/build-push-action@v1
+        with:
+          project: 3cpjhx94qv
+          context: ./
+          file: ./typescript/ccip-server/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ steps.determine-platforms.outputs.platforms }}
+
+      - name: Check for ccip-server changes
+        id: check-changes
+        if: github.event_name == 'pull_request'
+        run: |
+          # Only comment if there are explicit changes to ccip-server package
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^typescript/ccip-server/'; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Comment image tags on PR
+        if: github.event_name == 'pull_request' && steps.check-changes.outputs.has_changes == 'true' && always()
+        uses: ./.github/actions/docker-image-comment
+        with:
+          comment_tag: ccip-server-docker-image
+          image_name: CCIP Server Docker Image
+          emoji: 🔗
+          image_tags: ${{ steps.meta.outputs.tags }}
+          pr_number: ${{ github.event.pull_request.number }}
+          github_token: ${{ steps.generate-token.outputs.token }}
+          job_status: ${{ job.status }}

--- a/.github/workflows/ccip-server-docker.yml
+++ b/.github/workflows/ccip-server-docker.yml
@@ -126,7 +126,7 @@ jobs:
         with:
           comment_tag: ccip-server-docker-image
           image_name: CCIP Server Docker Image
-          emoji: 🔗
+          emoji: 🔍
           image_tags: ${{ steps.meta.outputs.tags }}
           pr_number: ${{ github.event.pull_request.number }}
           github_token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/ccip-server-docker.yml
+++ b/.github/workflows/ccip-server-docker.yml
@@ -34,12 +34,14 @@ jobs:
   check-env:
     runs-on: ubuntu-latest
     outputs:
-      gcloud-service-key: ${{ steps.gcloud-service-key.outputs.defined }}
+      gcp-configured: ${{ steps.gcp-configured.outputs.defined }}
     steps:
-      - id: gcloud-service-key
+      - id: gcp-configured
+        # Check if Workload Identity Federation is configured
         env:
-          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
-        if: "${{ env.GCLOUD_SERVICE_KEY != '' }}"
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+        if: "${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' }}"
         run: echo "defined=true" >> $GITHUB_OUTPUT
 
   build-and-push-to-gcr:
@@ -50,7 +52,7 @@ jobs:
       pull-requests: write
 
     needs: [check-env]
-    if: needs.check-env.outputs.gcloud-service-key == 'true'
+    if: needs.check-env.outputs.gcp-configured == 'true'
 
     steps:
       - name: Generate GitHub App Token
@@ -86,12 +88,18 @@ jobs:
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
 
-      - name: Login to GCR
-        uses: docker/login-action@v3
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
         with:
-          registry: gcr.io
-          username: _json_key
-          password: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker gcr.io --quiet
 
       - name: Determine platforms
         id: determine-platforms

--- a/.github/workflows/ccip-server-docker.yml
+++ b/.github/workflows/ccip-server-docker.yml
@@ -7,12 +7,14 @@ on:
     paths:
       - 'typescript/ccip-server/**'
       - 'typescript/sdk/**'
+      - 'typescript/provider-sdk/**'
       - 'typescript/utils/**'
       - '.github/workflows/ccip-server-docker.yml'
   pull_request:
     paths:
       - 'typescript/ccip-server/**'
       - 'typescript/sdk/**'
+      - 'typescript/provider-sdk/**'
       - 'typescript/utils/**'
       - '.github/workflows/ccip-server-docker.yml'
   workflow_dispatch:

--- a/.github/workflows/ccip-server-docker.yml
+++ b/.github/workflows/ccip-server-docker.yml
@@ -113,8 +113,8 @@ jobs:
         id: check-changes
         if: github.event_name == 'pull_request'
         run: |
-          # Only comment if there are explicit changes to ccip-server package
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^typescript/ccip-server/'; then
+          # Only comment if there are explicit changes to ccip-server package or this workflow
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qE '^typescript/ccip-server/|^\.github/workflows/ccip-server-docker\.yml$'; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/ccip-server-docker.yml
+++ b/.github/workflows/ccip-server-docker.yml
@@ -6,6 +6,7 @@ on:
       - '**'
     paths:
       - 'typescript/ccip-server/**'
+      - 'typescript/deploy-sdk/**'
       - 'typescript/sdk/**'
       - 'typescript/provider-sdk/**'
       - 'typescript/utils/**'
@@ -13,6 +14,7 @@ on:
   pull_request:
     paths:
       - 'typescript/ccip-server/**'
+      - 'typescript/deploy-sdk/**'
       - 'typescript/sdk/**'
       - 'typescript/provider-sdk/**'
       - 'typescript/utils/**'

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -34,14 +34,14 @@ jobs:
     runs-on: ubuntu-latest
     # assign output from step to job output
     outputs:
-      gcloud-service-key: ${{ steps.gcloud-service-key.outputs.defined }}
+      gcp-configured: ${{ steps.gcp-configured.outputs.defined }}
     steps:
-      - id: gcloud-service-key
-        # assign GCLOUD_SERVICE_KEY to env for access in conditional
+      - id: gcp-configured
+        # Check if Workload Identity Federation is configured
         env:
-          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
-        if: "${{ env.GCLOUD_SERVICE_KEY != '' }}"
-        # runs if GCLOUD_SERVICE_KEY is defined, so we set the output to true
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+        if: "${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' }}"
         run: echo "defined=true" >> $GITHUB_OUTPUT
 
   build-and-push-to-gcr:
@@ -51,9 +51,8 @@ jobs:
       id-token: write
       pull-requests: write
 
-    # uses check-env to determine if secrets.GCLOUD_SERVICE_KEY is defined
     needs: [check-env]
-    if: needs.check-env.outputs.gcloud-service-key == 'true'
+    if: needs.check-env.outputs.gcp-configured == 'true'
 
     steps:
       - name: Generate GitHub App Token
@@ -87,12 +86,19 @@ jobs:
             type=raw,value=${{ steps.taggen.outputs.TAG_SHA }}-${{ steps.taggen.outputs.TAG_DATE }}
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
-      - name: Login to GCR
-        uses: docker/login-action@v3
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
         with:
-          registry: gcr.io
-          username: _json_key
-          password: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker gcr.io --quiet
 
       - name: Read .registryrc
         shell: bash

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -22,14 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     # assign output from step to job output
     outputs:
-      gcloud-service-key: ${{ steps.gcloud-service-key.outputs.defined }}
+      gcp-configured: ${{ steps.gcp-configured.outputs.defined }}
     steps:
-      - id: gcloud-service-key
-        # assign GCLOUD_SERVICE_KEY to env for access in conditional
+      - id: gcp-configured
+        # Check if Workload Identity Federation is configured
         env:
-          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
-        if: "${{ env.GCLOUD_SERVICE_KEY != '' }}"
-        # runs if GCLOUD_SERVICE_KEY is defined, so we set the output to true
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+        if: "${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' }}"
         run: echo "defined=true" >> $GITHUB_OUTPUT
 
   build-and-push-to-gcr:
@@ -39,9 +39,8 @@ jobs:
       id-token: write
       pull-requests: write
 
-    # uses check-env to determine if secrets.GCLOUD_SERVICE_KEY is defined
     needs: [check-env]
-    if: needs.check-env.outputs.gcloud-service-key == 'true'
+    if: needs.check-env.outputs.gcp-configured == 'true'
     steps:
       - name: Generate GitHub App Token
         id: generate-token
@@ -93,12 +92,20 @@ jobs:
             type=raw,value=${{ steps.taggen.outputs.TAG_SHA }}-${{ steps.taggen.outputs.TAG_DATE }}
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
-      - name: Login to GCR
-        uses: docker/login-action@v3
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
         with:
-          registry: gcr.io
-          username: _json_key
-          password: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker gcr.io --quiet
+
       - name: Determine platforms
         id: determine-platforms
         run: |

--- a/.github/workflows/simapp-docker.yml
+++ b/.github/workflows/simapp-docker.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     # assign output from step to job output
     outputs:
-      gcloud-service-key: ${{ steps.gcloud-service-key.outputs.defined }}
+      gcp-configured: ${{ steps.gcp-configured.outputs.defined }}
     steps:
-      - id: gcloud-service-key
-        # assign GCLOUD_SERVICE_KEY to env for access in conditional
+      - id: gcp-configured
+        # Check if Workload Identity Federation is configured
         env:
-          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
-        if: "${{ env.GCLOUD_SERVICE_KEY != '' }}"
-        # runs if GCLOUD_SERVICE_KEY is defined, so we set the output to true
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+        if: "${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '' }}"
         run: echo "defined=true" >> $GITHUB_OUTPUT
 
   build-and-push-to-gcr:
@@ -31,9 +31,8 @@ jobs:
       contents: read
       id-token: write
 
-    # uses check-env to determine if secrets.GCLOUD_SERVICE_KEY is defined
     needs: [check-env]
-    if: needs.check-env.outputs.gcloud-service-key == 'true'
+    if: needs.check-env.outputs.gcp-configured == 'true'
 
     steps:
       - uses: actions/checkout@v6
@@ -42,12 +41,20 @@ jobs:
           submodules: recursive
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
-      - name: Login to GCR
-        uses: docker/login-action@v3
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
         with:
-          registry: gcr.io
-          username: _json_key
-          password: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for GCR
+        run: gcloud auth configure-docker gcr.io --quiet
+
       - name: Build and push
         uses: depot/build-push-action@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ COPY solidity/package.json ./solidity/
 COPY solhint-plugin/package.json ./solhint-plugin/
 COPY starknet/package.json ./starknet/
 
+# Set dummy DATABASE_URL for ccip-server prisma generate during install
+ENV DATABASE_URL="postgresql://placeholder:placeholder@localhost:5432/placeholder"
+
 RUN pnpm install --frozen-lockfile && pnpm store prune
 
 # Copy everything else

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,10 @@
     "coverage": {
       "dependsOn": ["build"],
       "outputs": ["coverage/**", "fixtures/**"]
+    },
+    "bundle": {
+      "dependsOn": ["^build"],
+      "outputs": ["*-bundle/**"]
     }
   }
 }

--- a/typescript/ccip-server/Dockerfile
+++ b/typescript/ccip-server/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-slim AS builder
 WORKDIR /hyperlane-monorepo
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git g++ make python3 python3-pip jq bash curl ca-certificates unzip \
+    git g++ make python3 python3-pip bash curl ca-certificates unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Foundry for solidity builds (soldeer)

--- a/typescript/ccip-server/Dockerfile
+++ b/typescript/ccip-server/Dockerfile
@@ -39,6 +39,9 @@ COPY starknet/package.json ./starknet/
 # Copy prisma schema before install (needed for postinstall prisma generate)
 COPY typescript/ccip-server/prisma ./typescript/ccip-server/prisma
 
+# Set dummy DATABASE_URL for prisma generate during install (actual URL provided at runtime)
+ENV DATABASE_URL="postgresql://placeholder:placeholder@localhost:5432/placeholder"
+
 RUN pnpm install --frozen-lockfile
 
 # Run prisma generate after install (needed to generate Prisma client)

--- a/typescript/ccip-server/Dockerfile
+++ b/typescript/ccip-server/Dockerfile
@@ -31,6 +31,9 @@ COPY solidity/package.json ./solidity/
 COPY solhint-plugin/package.json ./solhint-plugin/
 COPY starknet/package.json ./starknet/
 
+# Copy prisma schema before yarn install (needed for postinstall prisma generate)
+COPY typescript/ccip-server/prisma ./typescript/ccip-server/prisma
+
 RUN yarn install && yarn cache clean
 
 # Copy source files

--- a/typescript/ccip-server/Dockerfile
+++ b/typescript/ccip-server/Dockerfile
@@ -70,6 +70,11 @@ RUN pnpm --filter @hyperlane-xyz/ccip-server deploy --legacy --prod /app
 # Copy generated Prisma client to dist (TypeScript doesn't copy non-TS files)
 RUN cp -r /app/src/generated /app/dist/generated
 
+# Copy the generated Prisma client (pnpm deploy may not include .prisma)
+RUN cp -r /hyperlane-monorepo/typescript/ccip-server/node_modules/.prisma /app/node_modules/.prisma 2>/dev/null || \
+    cp -r /hyperlane-monorepo/node_modules/.prisma /app/node_modules/.prisma 2>/dev/null || \
+    echo "Warning: Could not find .prisma directory"
+
 # Production stage - Debian slim for Prisma native binary compatibility
 FROM node:20-slim AS runner
 

--- a/typescript/ccip-server/Dockerfile
+++ b/typescript/ccip-server/Dockerfile
@@ -3,24 +3,29 @@ FROM node:20-slim AS builder
 WORKDIR /hyperlane-monorepo
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git g++ make python3 python3-pip jq bash curl ca-certificates unzip openssl \
-    && rm -rf /var/lib/apt/lists/* \
-    && yarn set version 4.5.1
+    git g++ make python3 python3-pip jq bash curl ca-certificates unzip \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Foundry for solidity builds (soldeer)
 RUN curl -L https://foundry.paradigm.xyz | bash
 RUN /root/.foundry/bin/foundryup
 ENV PATH="/root/.foundry/bin:${PATH}"
 
-# Copy package.json and yarn config
-COPY package.json yarn.lock .yarnrc.yml ./
-COPY .yarn/plugins ./.yarn/plugins
-COPY .yarn/releases ./.yarn/releases
-COPY .yarn/patches ./.yarn/patches
+# Copy package.json first for corepack to read packageManager field
+COPY package.json ./
+RUN corepack enable && corepack install
+
+# Copy pnpm config files
+COPY pnpm-lock.yaml pnpm-workspace.yaml ./
+
+# Copy patches directory (required for pnpm install)
+COPY patches ./patches
 
 # Copy only the packages needed for ccip-server
 COPY typescript/ccip-server/package.json ./typescript/ccip-server/
+COPY typescript/deploy-sdk/package.json ./typescript/deploy-sdk/
 COPY typescript/sdk/package.json ./typescript/sdk/
+COPY typescript/provider-sdk/package.json ./typescript/provider-sdk/
 COPY typescript/utils/package.json ./typescript/utils/
 COPY typescript/cosmos-sdk/package.json ./typescript/cosmos-sdk/
 COPY typescript/cosmos-types/package.json ./typescript/cosmos-types/
@@ -31,19 +36,20 @@ COPY solidity/package.json ./solidity/
 COPY solhint-plugin/package.json ./solhint-plugin/
 COPY starknet/package.json ./starknet/
 
-# Copy prisma schema before yarn install (needed for postinstall prisma generate)
+# Copy prisma schema before install (needed for postinstall prisma generate)
 COPY typescript/ccip-server/prisma ./typescript/ccip-server/prisma
 
-# Skip postinstall scripts during install (--mode=skip-build)
-RUN yarn install --mode=skip-build && yarn cache clean
+RUN pnpm install --frozen-lockfile
 
 # Run prisma generate after install (needed to generate Prisma client)
-RUN yarn --cwd typescript/ccip-server prisma generate
+RUN pnpm --filter @hyperlane-xyz/ccip-server prisma generate
 
 # Copy source files
 COPY turbo.json ./
 COPY typescript/ccip-server ./typescript/ccip-server
+COPY typescript/deploy-sdk ./typescript/deploy-sdk
 COPY typescript/sdk ./typescript/sdk
+COPY typescript/provider-sdk ./typescript/provider-sdk
 COPY typescript/utils ./typescript/utils
 COPY typescript/cosmos-sdk ./typescript/cosmos-sdk
 COPY typescript/cosmos-types ./typescript/cosmos-types
@@ -54,24 +60,29 @@ COPY solidity ./solidity
 COPY solhint-plugin ./solhint-plugin
 COPY starknet ./starknet
 
-# Build the ccip-server (generates prisma client and compiles TypeScript)
-RUN yarn turbo run build --filter=@hyperlane-xyz/ccip-server
+# Build the ccip-server
+RUN pnpm turbo run build --filter=@hyperlane-xyz/ccip-server
 
-# Production stage - minimal image with built code
+# Create standalone deployment with resolved dependencies (no symlinks)
+# --legacy flag required for pnpm v10+ without inject-workspace-packages
+RUN pnpm --filter @hyperlane-xyz/ccip-server deploy --legacy --prod /app
+
+# Copy generated Prisma client to dist (TypeScript doesn't copy non-TS files)
+RUN cp -r /app/src/generated /app/dist/generated
+
+# Production stage - Debian slim for Prisma native binary compatibility
 FROM node:20-slim AS runner
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates openssl \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy the built application
-COPY --from=builder /hyperlane-monorepo/typescript/ccip-server/dist ./dist
-COPY --from=builder /hyperlane-monorepo/typescript/ccip-server/src/generated ./src/generated
+# Copy the deployed standalone package
+COPY --from=builder /app ./
+
+# Copy prisma schema for migrations
 COPY --from=builder /hyperlane-monorepo/typescript/ccip-server/prisma ./prisma
-COPY --from=builder /hyperlane-monorepo/typescript/ccip-server/package.json ./
-COPY --from=builder /hyperlane-monorepo/typescript/ccip-server/node_modules ./node_modules
 
 # Environment variables
 ENV NODE_ENV=production

--- a/typescript/ccip-server/Dockerfile
+++ b/typescript/ccip-server/Dockerfile
@@ -34,7 +34,11 @@ COPY starknet/package.json ./starknet/
 # Copy prisma schema before yarn install (needed for postinstall prisma generate)
 COPY typescript/ccip-server/prisma ./typescript/ccip-server/prisma
 
-RUN yarn install && yarn cache clean
+# Skip postinstall scripts during install (--mode=skip-build)
+RUN yarn install --mode=skip-build && yarn cache clean
+
+# Run prisma generate after install (needed to generate Prisma client)
+RUN yarn --cwd typescript/ccip-server prisma generate
 
 # Copy source files
 COPY turbo.json ./

--- a/typescript/ccip-server/Dockerfile
+++ b/typescript/ccip-server/Dockerfile
@@ -1,0 +1,79 @@
+FROM node:20-slim AS builder
+
+WORKDIR /hyperlane-monorepo
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git g++ make python3 python3-pip jq bash curl ca-certificates unzip openssl \
+    && rm -rf /var/lib/apt/lists/* \
+    && yarn set version 4.5.1
+
+# Install Foundry for solidity builds (soldeer)
+RUN curl -L https://foundry.paradigm.xyz | bash
+RUN /root/.foundry/bin/foundryup
+ENV PATH="/root/.foundry/bin:${PATH}"
+
+# Copy package.json and yarn config
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY .yarn/plugins ./.yarn/plugins
+COPY .yarn/releases ./.yarn/releases
+COPY .yarn/patches ./.yarn/patches
+
+# Copy only the packages needed for ccip-server
+COPY typescript/ccip-server/package.json ./typescript/ccip-server/
+COPY typescript/sdk/package.json ./typescript/sdk/
+COPY typescript/utils/package.json ./typescript/utils/
+COPY typescript/cosmos-sdk/package.json ./typescript/cosmos-sdk/
+COPY typescript/cosmos-types/package.json ./typescript/cosmos-types/
+COPY typescript/radix-sdk/package.json ./typescript/radix-sdk/
+COPY typescript/tsconfig/package.json ./typescript/tsconfig/
+COPY typescript/eslint-config/package.json ./typescript/eslint-config/
+COPY solidity/package.json ./solidity/
+COPY solhint-plugin/package.json ./solhint-plugin/
+COPY starknet/package.json ./starknet/
+
+RUN yarn install && yarn cache clean
+
+# Copy source files
+COPY turbo.json ./
+COPY typescript/ccip-server ./typescript/ccip-server
+COPY typescript/sdk ./typescript/sdk
+COPY typescript/utils ./typescript/utils
+COPY typescript/cosmos-sdk ./typescript/cosmos-sdk
+COPY typescript/cosmos-types ./typescript/cosmos-types
+COPY typescript/radix-sdk ./typescript/radix-sdk
+COPY typescript/tsconfig ./typescript/tsconfig
+COPY typescript/eslint-config ./typescript/eslint-config
+COPY solidity ./solidity
+COPY solhint-plugin ./solhint-plugin
+COPY starknet ./starknet
+
+# Build the ccip-server (generates prisma client and compiles TypeScript)
+RUN yarn turbo run build --filter=@hyperlane-xyz/ccip-server
+
+# Production stage - minimal image with built code
+FROM node:20-slim AS runner
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates openssl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the built application
+COPY --from=builder /hyperlane-monorepo/typescript/ccip-server/dist ./dist
+COPY --from=builder /hyperlane-monorepo/typescript/ccip-server/src/generated ./src/generated
+COPY --from=builder /hyperlane-monorepo/typescript/ccip-server/prisma ./prisma
+COPY --from=builder /hyperlane-monorepo/typescript/ccip-server/package.json ./
+COPY --from=builder /hyperlane-monorepo/typescript/ccip-server/node_modules ./node_modules
+
+# Environment variables
+ENV NODE_ENV=production
+ENV LOG_LEVEL=info
+ENV SERVER_PORT=3000
+
+# Expose ports
+EXPOSE 3000
+EXPOSE 9090
+
+# Run the ccip-server
+CMD ["node", "dist/server.js"]

--- a/typescript/ccip-server/Dockerfile
+++ b/typescript/ccip-server/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-slim AS builder
 WORKDIR /hyperlane-monorepo
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git g++ make python3 python3-pip bash curl ca-certificates unzip \
+    git g++ make python3 python3-pip jq bash curl ca-certificates unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Foundry for solidity builds (soldeer)

--- a/typescript/ccip-server/package.json
+++ b/typescript/ccip-server/package.json
@@ -6,7 +6,8 @@
   "typedocMain": "src/index.ts",
   "private": true,
   "files": [
-    "src"
+    "src",
+    "dist"
   ],
   "engines": {
     "node": ">=16"

--- a/typescript/ccip-server/prisma/schema.prisma
+++ b/typescript/ccip-server/prisma/schema.prisma
@@ -6,10 +6,10 @@ generator client {
   output   = "../src/generated/prisma"
 }
 
-// With engineType = "client" in Prisma 7, connection is handled via driver adapter in code
-// The DATABASE_URL is passed to the pg Pool in db.ts, not here
+// DATABASE_URL is required for prisma generate but actual connection is handled in code
 datasource db {
   provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 model Commitment {

--- a/typescript/ccip-server/prisma/schema.prisma
+++ b/typescript/ccip-server/prisma/schema.prisma
@@ -6,9 +6,10 @@ generator client {
   output   = "../src/generated/prisma"
 }
 
+// With engineType = "client" in Prisma 7, connection is handled via driver adapter in code
+// The DATABASE_URL is passed to the pg Pool in db.ts, not here
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model Commitment {

--- a/typescript/infra/helm/offchain-lookup-server/templates/deployment.yaml
+++ b/typescript/infra/helm/offchain-lookup-server/templates/deployment.yaml
@@ -31,15 +31,6 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           imagePullPolicy: IfNotPresent
-          {{- if .Values.image.standalone }}
-          # Standalone image runs the server directly
-          command: ["node"]
-          args: ["dist/server.js"]
-          {{- else }}
-          # Monorepo image uses pnpm to start the server
-          command: ["pnpm"]
-          args: ["-C", "typescript/ccip-server", "run", "start"]
-          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.port }}

--- a/typescript/infra/helm/offchain-lookup-server/templates/deployment.yaml
+++ b/typescript/infra/helm/offchain-lookup-server/templates/deployment.yaml
@@ -1,7 +1,6 @@
 # Container Deployment
-# The offchain-lookup typescript server, started with pnpm.
-# It is used for the ccip-read ISM
-# And can expose multiple endpoints depending on its ENV.
+# The offchain-lookup typescript server (CCIP-read ISM)
+# Can expose multiple endpoints depending on its ENV.
 # The server code can be found in /typescript/ccip-server
 apiVersion: apps/v1
 kind: Deployment
@@ -32,8 +31,15 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           imagePullPolicy: IfNotPresent
+          {{- if .Values.image.standalone }}
+          # Standalone image runs the server directly
+          command: ["node"]
+          args: ["dist/server.js"]
+          {{- else }}
+          # Monorepo image uses pnpm to start the server
           command: ["pnpm"]
           args: ["-C", "typescript/ccip-server", "run", "start"]
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.port }}

--- a/typescript/infra/helm/offchain-lookup-server/values-mainnet.yaml
+++ b/typescript/infra/helm/offchain-lookup-server/values-mainnet.yaml
@@ -2,11 +2,11 @@ environment: mainnet
 
 # General deployment configuration
 image:
-  repository: gcr.io/abacus-labs-dev/hyperlane-monorepo
+  repository: gcr.io/abacus-labs-dev/hyperlane-offchain-lookup-server
   # Modify this tag to deploy a new revision.
   # Images can be found here:
-  # https://console.cloud.google.com/artifacts/docker/abacus-labs-dev/us/gcr.io/hyperlane-monorepo?inv=1&invt=AbxRMg&project=abacus-labs-dev
-  tag: 8da6852-20251215-172511
+  # https://console.cloud.google.com/artifacts/docker/abacus-labs-dev/us/gcr.io/hyperlane-offchain-lookup-server
+  tag: 57f9d1c-20251215-182854
 
 # In Google Cloud Secret Manager, all secrets need to have a certain prefix in order to be accessible by
 # the Cluster Secret Store. For testnet this prefix is "hyperlane-testnet4"

--- a/typescript/infra/helm/offchain-lookup-server/values-testnet.yaml
+++ b/typescript/infra/helm/offchain-lookup-server/values-testnet.yaml
@@ -2,11 +2,11 @@ environment: testnet
 
 # General deployment configuration
 image:
-  repository: gcr.io/abacus-labs-dev/hyperlane-monorepo
+  repository: gcr.io/abacus-labs-dev/hyperlane-offchain-lookup-server
   # Modify this tag to deploy a new revision.
   # Images can be found here:
-  # https://console.cloud.google.com/artifacts/docker/abacus-labs-dev/us/gcr.io/hyperlane-monorepo?inv=1&invt=AbxRMg&project=abacus-labs-dev
-  tag: 8da6852-20251215-172511
+  # https://console.cloud.google.com/artifacts/docker/abacus-labs-dev/us/gcr.io/hyperlane-offchain-lookup-server
+  tag: 57f9d1c-20251215-182854
 
 # In Google Cloud Secret Manager, all secrets need to have a certain prefix in order to be accessible by
 # the Cluster Secret Store. For testnet this prefix is "hyperlane-testnet4"

--- a/typescript/infra/helm/offchain-lookup-server/values.yaml
+++ b/typescript/infra/helm/offchain-lookup-server/values.yaml
@@ -2,11 +2,11 @@ environment: testnet
 
 # General deployment configuration
 image:
-  repository: gcr.io/abacus-labs-dev/hyperlane-monorepo
+  repository: gcr.io/abacus-labs-dev/hyperlane-offchain-lookup-server
   # Modify this tag to deploy a new revision.
   # Images can be found here:
-  # https://console.cloud.google.com/artifacts/docker/abacus-labs-dev/us/gcr.io/hyperlane-monorepo?inv=1&invt=AbxRMg&project=abacus-labs-dev
-  tag: 8da6852-20251215-172511
+  # https://console.cloud.google.com/artifacts/docker/abacus-labs-dev/us/gcr.io/hyperlane-offchain-lookup-server
+  tag: 57f9d1c-20251215-182854
 
 secrets:
   name: 'offchain-lookup-server'


### PR DESCRIPTION
## Summary

Replace stored `GCLOUD_SERVICE_KEY` with OIDC-based authentication using Google Cloud Workload Identity Federation. This eliminates long-lived service account keys in favor of short-lived tokens generated on-demand.

## Changes

- Update `monorepo-docker.yml` to use WIF
- Update `rust-docker.yml` to use WIF
- Update `simapp-docker.yml` to use WIF
- Update `ccip-server-docker.yml` to use WIF

## Benefits

- **No long-lived secrets** — Tokens are generated on-demand and expire quickly
- **Auditable** — All token requests are logged in GCP Cloud Audit Logs
- **Rotationless** — No key rotation maintenance required

## GitHub Repository Variables Required

After GCP setup is complete, add these repository **variables** (Settings → Secrets and variables → Actions → Variables):

| Variable | Value |
|----------|-------|
| `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/116541836866/locations/global/workloadIdentityPools/github-actions/providers/github` |
| `GCP_SERVICE_ACCOUNT` | `github-actions-gcr@abacus-labs-dev.iam.gserviceaccount.com` |

## GCP Setup Instructions

See [setup gist](https://gist.github.com/paulbalaji/008cfb935dfd2228935951465dbaae93) for complete GCP configuration instructions for the security engineer.

**Stacked on #7565**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR migrates Docker workflows from long-lived service account keys to OIDC-based Workload Identity Federation (WIF) for Google Cloud authentication. All four Docker workflows (`monorepo-docker.yml`, `rust-docker.yml`, `simapp-docker.yml`, and the new `ccip-server-docker.yml`) now use short-lived tokens generated on-demand via `google-github-actions/auth@v2`.

**Key changes:**
- Replaced `docker/login-action` with `google-github-actions/auth@v2` + `gcloud auth configure-docker`
- Changed environment check from `GCLOUD_SERVICE_KEY` secret to `GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_SERVICE_ACCOUNT` variables
- Added `id-token: write` permission to all workflows (required for OIDC token generation)
- Introduced `check-env` job to gracefully skip builds when WIF not configured

**Security improvements:**
- Eliminates risk of leaked long-lived credentials
- Tokens auto-expire (no rotation needed)
- All authentication events logged in GCP Cloud Audit Logs

**Dependencies:**
This PR depends on GCP infrastructure setup (workload identity pool + service account bindings) and requires repository variables `GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_SERVICE_ACCOUNT` to be configured before workflows will execute.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk - standard WIF migration pattern
- The implementation follows Google's recommended WIF authentication pattern correctly. All workflows consistently use the same auth approach with proper permissions. The `check-env` job provides graceful degradation if variables aren't configured. No breaking changes to existing functionality - workflows simply won't run until variables are set.
- No files require special attention - all changes follow established patterns
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ccip-server-docker.yml | New workflow correctly uses WIF authentication with proper permissions (`id-token: write`) and fallback behavior when WIF not configured |
| .github/workflows/monorepo-docker.yml | Replaced `docker/login-action` with `google-github-actions/auth@v2` for WIF, removed `GCLOUD_SERVICE_KEY` secret dependency |
| .github/workflows/rust-docker.yml | Migrated from service key to WIF authentication, follows same pattern as monorepo workflow |
| .github/workflows/simapp-docker.yml | Updated to use WIF authentication, removed service key dependency |
| typescript/ccip-server/Dockerfile | Multi-stage build with pnpm deploy creates standalone image; placeholder DATABASE_URL allows Prisma generation during build |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant OIDC as GitHub OIDC Provider
    participant WIF as GCP Workload Identity Pool
    participant SA as Service Account
    participant GCR as Google Container Registry
    participant Depot as Depot Build

    Note over GHA: Workflow Triggered (push/PR/tag)
    
    GHA->>GHA: check-env job validates<br/>GCP_WORKLOAD_IDENTITY_PROVIDER<br/>& GCP_SERVICE_ACCOUNT vars
    
    alt WIF not configured
        GHA->>GHA: Skip build-and-push job
    else WIF configured
        GHA->>GHA: Generate GitHub App token<br/>(for PR comments)
        GHA->>GHA: Checkout code with submodules
        
        Note over GHA,SA: WIF Authentication Flow
        GHA->>OIDC: Request OIDC token<br/>(id-token: write permission)
        OIDC-->>GHA: Return JWT token
        GHA->>WIF: Exchange JWT for GCP token<br/>(google-github-actions/auth@v2)
        WIF->>WIF: Validate token claims<br/>(repo, branch, environment)
        WIF->>SA: Impersonate service account
        SA-->>WIF: Generate short-lived credentials
        WIF-->>GHA: Return GCP access token
        
        GHA->>GHA: Setup gcloud SDK
        GHA->>GHA: Configure Docker auth<br/>(gcloud auth configure-docker)
        
        Note over GHA,Depot: Build & Push
        GHA->>Depot: depot/build-push-action<br/>(multi-platform build)
        Depot->>Depot: Build Docker image
        Depot->>GCR: Push image with tags<br/>(branch/PR/SHA-timestamp)
        GCR-->>Depot: Push complete
        Depot-->>GHA: Build complete
        
        alt Pull Request Event
            GHA->>GHA: Check for relevant changes
            alt Has Changes
                GHA->>GHA: Comment image tags on PR<br/>(via GitHub App token)
            end
        end
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->