### PR TITLE
chore: make aleo proving service optional

### DIFF
--- a/rust/main/helm/hyperlane-agent/templates/external-secret.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/external-secret.yaml
@@ -31,7 +31,7 @@ spec:
         HYP_CHAINS_{{ .name | upper }}_CUSTOMGRPCURLS: {{ printf "'{{ .%s_grpcs | mustFromJson | join \",\" }}'" .name }}
         {{- end }}
         {{- if eq .protocol "aleo" }}
-        HYP_CHAINS_{{ .name | upper }}_CUSTOMPROVINGSERVICEURLS: {{ printf "'{{ .%s_proving_urls | mustFromJson | join \",\" }}'" .name }}
+        HYP_CHAINS_{{ .name | upper }}_CUSTOMPROVINGSERVICEURLS: {{ printf "'{{ .%s_proving_urls | default \"[]\" | mustFromJson | join \",\" }}'" .name }}
         {{- end }}
         {{- if eq .protocol "sealevel" }}
         {{- if eq ((.priorityFeeOracle).type) "helius" }}
@@ -60,6 +60,7 @@ spec:
   - secretKey: {{ printf "%s_proving_urls" .name }}
     remoteRef:
       key: {{ printf "%s-proving-endpoints-%s" $.Values.hyperlane.runEnv .name }}
+      optional: true
   {{- end }}
   {{- if and (eq .protocol "sealevel") (or (eq ((.priorityFeeOracle).type) "helius") (eq ((.transactionSubmitter).url) "helius")) }}
   - secretKey: {{ printf "%s_helius" .name }}


### PR DESCRIPTION
### Description
This PR makes it not necessary to have the proving service secret set in GCP for all contexts.
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
