### PR TITLE
fix: deprecate all remaining form routes

### DIFF
--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -41,6 +41,9 @@ async function main() {
     'USDT/ethereum-form',
     'USDC/ethereum-form',
     'TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain',
+    'AIXBT/base-form',
+    'FORM/ethereum-form',
+    'GAME/base-form',
   ];
 
   const registries = [DEFAULT_REGISTRY_URI];


### PR DESCRIPTION
### Description

Deprecate all remaining form routes so that the warp check successfully runs again

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment checks to skip three Warp routes: AIXBT/base-form, FORM/ethereum-form, and GAME/base-form.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->