### PR TITLE
feat: update fork command to use chains in the deploy config

### DIFF
--- a/typescript/cli/src/commands/options.ts
+++ b/typescript/cli/src/commands/options.ts
@@ -277,11 +277,6 @@ export const forkCommandOptions: Record<string, Options> = {
     description:
       'The path to a configuration file that specifies how to build the forked chains',
   },
-  chains: {
-    type: 'string',
-    description:
-      'Comma-separated list of chain names to fork (e.g., "ethereum,arbitrum,base"). If provided, overrides chains from warp config.',
-  },
   kill: {
     type: 'boolean',
     default: false,


### PR DESCRIPTION
## Summary

Updates the fork command to automatically read chains from the warp deploy config.

## Motivation

This change supports the warp extension workflow where users:
1. Export their warp route changes to the deploy config (including the chains they are extending to)
2. Run the fork command to create local forks for those chains

By reading chains from the warp deploy config, the fork command automatically forks the chains defined in the user's deploy config - no manual chain specification needed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Streamlined the fork command to determine chains to fork solely from the deploy configuration.
  * Improved logging to clearly report which chains are being forked during execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->