### PR TITLE
fix: improve TokenRouter validation and error handling

### DIFF
--- a/solidity/contracts/hooks/igp/InterchainGasPaymaster.sol
+++ b/solidity/contracts/hooks/igp/InterchainGasPaymaster.sol
@@ -115,7 +115,7 @@ contract InterchainGasPaymaster is
      * @notice Transfers the entire native token balance to the beneficiary.
      * @dev The beneficiary must be able to receive native tokens.
      */
-    function claim() external {
+    function claim() external onlyOwner {
         // Transfer the entire balance to the beneficiary.
         (bool success, ) = beneficiary.call{value: address(this).balance}("");
         require(success, "IGP: claim failed");

--- a/solidity/contracts/token/libs/TokenRouter.sol
+++ b/solidity/contracts/token/libs/TokenRouter.sol
@@ -142,9 +142,6 @@ abstract contract TokenRouter is GasRouter, ITokenBridge {
         bytes32 _recipient,
         uint256 _amount
     ) public payable virtual returns (bytes32 messageId) {
-        // Prevent zero-amount transfers to avoid spam
-        require(_amount > 0, "TokenRouter: amount must be greater than 0");
-        
         // 1. Calculate the fee amounts, charge the sender and distribute to feeRecipient if necessary
         (, uint256 remainingNativeValue) = _calculateFeesAndCharge(
             _destination,
@@ -193,10 +190,6 @@ abstract contract TokenRouter is GasRouter, ITokenBridge {
             // transfer atomically so we don't need to keep track of collateral
             // and fee balances separately
             _transferFee(_feeRecipient, feeAmount);
-        }
-        // For native token transfers, ensure sufficient ETH was sent
-        if (token() == address(0)) {
-            require(_msgValue >= charge, "TokenRouter: insufficient ETH sent");
         }
         remainingNativeValue = token() != address(0)
             ? _msgValue

--- a/solidity/contracts/token/libs/TokenRouter.sol
+++ b/solidity/contracts/token/libs/TokenRouter.sol
@@ -142,6 +142,9 @@ abstract contract TokenRouter is GasRouter, ITokenBridge {
         bytes32 _recipient,
         uint256 _amount
     ) public payable virtual returns (bytes32 messageId) {
+        // Prevent zero-amount transfers to avoid spam
+        require(_amount > 0, "TokenRouter: amount must be greater than 0");
+        
         // 1. Calculate the fee amounts, charge the sender and distribute to feeRecipient if necessary
         (, uint256 remainingNativeValue) = _calculateFeesAndCharge(
             _destination,
@@ -190,6 +193,10 @@ abstract contract TokenRouter is GasRouter, ITokenBridge {
             // transfer atomically so we don't need to keep track of collateral
             // and fee balances separately
             _transferFee(_feeRecipient, feeAmount);
+        }
+        // For native token transfers, ensure sufficient ETH was sent
+        if (token() == address(0)) {
+            require(_msgValue >= charge, "TokenRouter: insufficient ETH sent");
         }
         remainingNativeValue = token() != address(0)
             ? _msgValue


### PR DESCRIPTION
## Summary
This PR addresses two low-severity security issues in the `TokenRouter.sol` and `InterchainGasPaymaster.sol` contract that improve user experience and prevent potential spam attacks.

## Issues Fixed

### 🐛 Bug #1: Unrestricted Withdrawal Trigger in InterchainGasPaymaster
**Severity**: Medium (Operational Griefing)

**Problem:**
The claim() function is external and lacks an onlyOwner modifier. It
transfers the entire ETH balance to the beneficiary.

**Impact:** :  Any user can force the contract to pay out. This disrupts the operator's ability
to batch withdrawals or manage accounting cycles. It prevents the contract from
accumulating funds as intended.


**Solution:**
Restrict access to onlyOwner or onlyBeneficiary:
```solidity
function claim() external onlyOwner {
  (bool success, ) = beneficiary.call{value: address(this).balance}("");
  require(success, "IGP: claim failed");
}

```

---

### 🐛 Bug #2: Zero-Amount Token Transfers (Spam Risk)
**Severity:** Low  
**Impact:** Potential relayer congestion and event spam

**Problem:**
The bridge allowed transferring 0 tokens, which could be exploited to spam the bridge with events and potentially clog relayers.

**Solution:**
Added validation at the start of `transferRemote` function:
```solidity
require(_amount > 0, \"TokenRouter: amount must be greater than 0\");
```

**Benefits:**
- Prevents spam attacks
- Saves gas for users attempting zero transfers
- Reduces relayer load
- Cleaner event logs

---

## Changes Made
- ✅ Added onlyOwner modifier to Restrict access to owner only
- ✅ Added zero-amount validation in `transferRemote()` function
- ✅ Added explicit ETH sufficiency check in `_calculateFeesAndCharge()` function
- ✅ Improved error messages for better debugging

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted claim function to owner access only
  * Added validation to prevent zero-amount transfers
  * Added payment sufficiency checks for native token transfers

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- gk-ai-analysis-start:eda64bc63a0f96ec02a2a4193ac4615bc4fa0620 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiUmVzdHJpY3RzIHRoZSBjbGFpbSBmdW5jdGlvbiBpbiBJbnRlcmNoYWluR2FzUGF5bWFzdGVyIHRvIG93bmVyIGFjY2VzcyBvbmx5IHRvIHByZXZlbnQgdW5hdXRob3JpemVkIHBheW91dHMuIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiQWNjZXNzIGNvbnRyb2wgYWRkZWQgdG8gY2xhaW0gZnVuY3Rpb24iLCJkZXNjcmlwdGlvbiI6IlRoZSBgY2xhaW0oKWAgZnVuY3Rpb24gbm93IHJlcXVpcmVzIGBvbmx5T3duZXJgIGFjY2VzcywgcHJldmVudGluZyB1bmF1dGhvcml6ZWQgdXNlcnMgZnJvbSB0cmlnZ2VyaW5nIHdpdGhkcmF3YWwgb2YgdGhlIGNvbnRyYWN0J3MgZW50aXJlIG5hdGl2ZSB0b2tlbiBiYWxhbmNlIHRvIHRoZSBiZW5lZmljaWFyeS4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoic29saWRpdHkvY29udHJhY3RzL2hvb2tzL2lncC9JbnRlcmNoYWluR2FzUGF5bWFzdGVyLnNvbCIsImxpbmVTdGFydCI6MTE4fV0sImlzc3VlcyI6W10sInN1Z2dlc3Rpb25zIjpbXSwic2VjdXJpdHkiOlt7InRpdGxlIjoiTWl0aWdhdGVkIG9wZXJhdGlvbmFsIGdyaWVmaW5nIHJpc2siLCJkZXNjcmlwdGlvbiI6IkJ5IHJlc3RyaWN0aW5nIHRoZSBgY2xhaW0oKWAgZnVuY3Rpb24gdG8gdGhlIG93bmVyLCB0aGUgY29udHJhY3QgcHJldmVudHMgYXJiaXRyYXJ5IHVzZXJzIGZyb20gZm9yY2luZyBwYXlvdXRzLCB3aGljaCBjb3VsZCBkaXNydXB0IHRoZSBvcGVyYXRvcidzIGFjY291bnRpbmcgb3Igd2l0aGRyYXdhbCBjeWNsZXMuIiwic2V2ZXJpdHkiOiJtZWRpdW0iLCJmaWxlUGF0aCI6InNvbGlkaXR5L2NvbnRyYWN0cy9ob29rcy9pZ3AvSW50ZXJjaGFpbkdhc1BheW1hc3Rlci5zb2wiLCJsaW5lU3RhcnQiOjExOH1dfQ== -->
<!-- gk-ai-analysis-end:eda64bc63a0f96ec02a2a4193ac4615bc4fa0620 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/hyperlane-xyz/hyperlane-monorepo/pull/7670?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->