### PR TITLE
feat(relayer): add Prometheus metrics support

### DIFF
--- a/.changeset/separate-relayer-package.md
+++ b/.changeset/separate-relayer-package.md
@@ -9,5 +9,6 @@ Extracted relayer into dedicated `@hyperlane-xyz/relayer` package
 
 - Moved `HyperlaneRelayer` class from SDK to new package
 - New package supports both manual CLI execution and continuous daemon mode for K8s deployments
+- Added Prometheus metrics support with `/metrics` endpoint (enabled by default on port 9090)
 - CLI and infra now import from new package
 - **Breaking**: `HyperlaneRelayer`, `RelayerCacheSchema`, and `messageMatchesWhitelist` are no longer exported from `@hyperlane-xyz/sdk`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1835,6 +1835,9 @@ importers:
       pino-pretty:
         specifier: 'catalog:'
         version: 13.1.2
+      prom-client:
+        specifier: 'catalog:'
+        version: 14.2.0
       yaml:
         specifier: 'catalog:'
         version: 2.4.5

--- a/typescript/relayer/README.md
+++ b/typescript/relayer/README.md
@@ -54,13 +54,15 @@ await service.start();
 
 ### Environment Variables
 
-| Variable              | Description                              | Required |
-| --------------------- | ---------------------------------------- | -------- |
-| `HYP_KEY`             | Private key for signing transactions     | Yes      |
-| `RELAYER_CONFIG_FILE` | Path to YAML config file                 | No       |
-| `RELAYER_CHAINS`      | Comma-separated chain list               | No       |
-| `RELAYER_CACHE_FILE`  | Path to cache file for persistence       | No       |
-| `LOG_LEVEL`           | Logging level (debug, info, warn, error) | No       |
+| Variable              | Description                              | Required | Default |
+| --------------------- | ---------------------------------------- | -------- | ------- |
+| `HYP_KEY`             | Private key for signing transactions     | Yes      | -       |
+| `RELAYER_CONFIG_FILE` | Path to YAML config file                 | No       | -       |
+| `RELAYER_CHAINS`      | Comma-separated chain list               | No       | -       |
+| `RELAYER_CACHE_FILE`  | Path to cache file for persistence       | No       | -       |
+| `LOG_LEVEL`           | Logging level (debug, info, warn, error) | No       | info    |
+| `PROMETHEUS_ENABLED`  | Enable Prometheus metrics server         | No       | true    |
+| `PROMETHEUS_PORT`     | Port for metrics endpoint                | No       | 9090    |
 
 ### YAML Configuration
 
@@ -78,6 +80,19 @@ retryTimeout: 1000
 cacheFile: ./relayer-cache.json
 ```
 
+## Prometheus Metrics
+
+The relayer exposes metrics at `http://localhost:9090/metrics` (configurable via `PROMETHEUS_PORT`).
+
+| Metric                                               | Type      | Description                                                          |
+| ---------------------------------------------------- | --------- | -------------------------------------------------------------------- |
+| `hyperlane_relayer_messages_total`                   | Counter   | Messages processed (labels: origin_chain, destination_chain, status) |
+| `hyperlane_relayer_retries_total`                    | Counter   | Retry attempts                                                       |
+| `hyperlane_relayer_backlog_size`                     | Gauge     | Current message backlog                                              |
+| `hyperlane_relayer_relay_duration_seconds`           | Histogram | Time to relay messages                                               |
+| `hyperlane_relayer_messages_skipped_total`           | Counter   | Messages filtered by whitelist                                       |
+| `hyperlane_relayer_messages_already_delivered_total` | Counter   | Messages already delivered                                           |
+
 ## Architecture
 
 ```
@@ -88,6 +103,9 @@ typescript/relayer/
 │   │   └── RelayerService.ts     # Service orchestrator
 │   ├── config/
 │   │   └── RelayerConfig.ts      # Config loading/validation
+│   ├── metrics/
+│   │   ├── relayerMetrics.ts     # Prometheus metric definitions
+│   │   └── metricsServer.ts      # HTTP server for /metrics
 │   ├── service.ts                # Daemon entry point
 │   └── index.ts                  # Public API
 ```

--- a/typescript/relayer/package.json
+++ b/typescript/relayer/package.json
@@ -31,6 +31,7 @@
     "ethers": "catalog:",
     "pino": "catalog:",
     "pino-pretty": "catalog:",
+    "prom-client": "catalog:",
     "yaml": "catalog:",
     "zod": "catalog:",
     "zod-validation-error": "catalog:"

--- a/typescript/relayer/src/index.ts
+++ b/typescript/relayer/src/index.ts
@@ -10,3 +10,15 @@ export type { RelayerServiceConfig } from './core/RelayerService.js';
 
 export { RelayerConfig, RelayerConfigSchema } from './config/RelayerConfig.js';
 export type { RelayerConfigInput } from './config/RelayerConfig.js';
+
+export {
+  RelayerMetrics,
+  relayerMetricsRegistry,
+  relayerMessagesTotal,
+  relayerRetriesTotal,
+  relayerBacklogSize,
+  relayerRelayDuration,
+  relayerMessagesSkipped,
+  relayerMessagesAlreadyDelivered,
+  startMetricsServer,
+} from './metrics/index.js';

--- a/typescript/relayer/src/metrics/index.ts
+++ b/typescript/relayer/src/metrics/index.ts
@@ -1,0 +1,12 @@
+export {
+  RelayerMetrics,
+  relayerMetricsRegistry,
+  relayerMessagesTotal,
+  relayerRetriesTotal,
+  relayerBacklogSize,
+  relayerRelayDuration,
+  relayerMessagesSkipped,
+  relayerMessagesAlreadyDelivered,
+} from './relayerMetrics.js';
+
+export { startMetricsServer } from './metricsServer.js';

--- a/typescript/relayer/src/metrics/metricsServer.ts
+++ b/typescript/relayer/src/metrics/metricsServer.ts
@@ -1,0 +1,40 @@
+import http from 'http';
+import { Registry } from 'prom-client';
+
+import { rootLogger } from '@hyperlane-xyz/utils';
+
+const logger = rootLogger.child({ module: 'metrics-server' });
+
+export function startMetricsServer(register: Registry): http.Server {
+  const port = parseInt(process.env['PROMETHEUS_PORT'] || '9090');
+
+  return http
+    .createServer((req, res) => {
+      if (req.url !== '/metrics') {
+        res.writeHead(404, 'Not Found');
+        res.end();
+        return;
+      }
+
+      if (req.method !== 'GET') {
+        res.writeHead(405, 'Method Not Allowed');
+        res.end();
+        return;
+      }
+
+      register
+        .metrics()
+        .then((metricsStr) => {
+          res.writeHead(200, { 'Content-Type': 'text/plain' });
+          res.end(metricsStr);
+        })
+        .catch((err) => {
+          logger.error({ err }, 'Failed to collect metrics');
+          res.writeHead(500, 'Internal Server Error');
+          res.end();
+        });
+    })
+    .listen(port, () => {
+      logger.info({ port }, 'Metrics server started');
+    });
+}

--- a/typescript/relayer/src/metrics/relayerMetrics.ts
+++ b/typescript/relayer/src/metrics/relayerMetrics.ts
@@ -1,0 +1,151 @@
+import { Counter, Gauge, Histogram, Registry } from 'prom-client';
+
+/**
+ * Prometheus metric registry for the relayer
+ */
+export const relayerMetricsRegistry = new Registry();
+
+/**
+ * Total number of messages processed by the relayer
+ */
+export const relayerMessagesTotal = new Counter({
+  name: 'hyperlane_relayer_messages_total',
+  help: 'Total number of messages processed by the relayer',
+  registers: [relayerMetricsRegistry],
+  labelNames: ['origin_chain', 'destination_chain', 'status'] as const,
+});
+
+/**
+ * Total number of retry attempts for failed messages
+ */
+export const relayerRetriesTotal = new Counter({
+  name: 'hyperlane_relayer_retries_total',
+  help: 'Total number of retry attempts for failed messages',
+  registers: [relayerMetricsRegistry],
+  labelNames: ['origin_chain', 'destination_chain'] as const,
+});
+
+/**
+ * Current size of the message backlog
+ */
+export const relayerBacklogSize = new Gauge({
+  name: 'hyperlane_relayer_backlog_size',
+  help: 'Current number of messages in the relay backlog',
+  registers: [relayerMetricsRegistry],
+});
+
+/**
+ * Time taken to relay a message (in seconds)
+ */
+export const relayerRelayDuration = new Histogram({
+  name: 'hyperlane_relayer_relay_duration_seconds',
+  help: 'Time taken to relay a message in seconds',
+  registers: [relayerMetricsRegistry],
+  labelNames: ['origin_chain', 'destination_chain'] as const,
+  buckets: [0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300],
+});
+
+/**
+ * Number of messages skipped due to whitelist filtering
+ */
+export const relayerMessagesSkipped = new Counter({
+  name: 'hyperlane_relayer_messages_skipped_total',
+  help: 'Total number of messages skipped due to whitelist filtering',
+  registers: [relayerMetricsRegistry],
+  labelNames: ['origin_chain', 'destination_chain'] as const,
+});
+
+/**
+ * Number of messages already delivered (no relay needed)
+ */
+export const relayerMessagesAlreadyDelivered = new Counter({
+  name: 'hyperlane_relayer_messages_already_delivered_total',
+  help: 'Total number of messages that were already delivered',
+  registers: [relayerMetricsRegistry],
+  labelNames: ['origin_chain', 'destination_chain'] as const,
+});
+
+/**
+ * Helper class for recording relayer metrics
+ */
+export class RelayerMetrics {
+  recordMessageSuccess(originChain: string, destinationChain: string): void {
+    relayerMessagesTotal
+      .labels({
+        origin_chain: originChain,
+        destination_chain: destinationChain,
+        status: 'success',
+      })
+      .inc();
+  }
+
+  recordMessageFailure(originChain: string, destinationChain: string): void {
+    relayerMessagesTotal
+      .labels({
+        origin_chain: originChain,
+        destination_chain: destinationChain,
+        status: 'failure',
+      })
+      .inc();
+  }
+
+  recordRetry(originChain: string, destinationChain: string): void {
+    relayerRetriesTotal
+      .labels({
+        origin_chain: originChain,
+        destination_chain: destinationChain,
+      })
+      .inc();
+  }
+
+  updateBacklogSize(size: number): void {
+    relayerBacklogSize.set(size);
+  }
+
+  recordRelayDuration(
+    originChain: string,
+    destinationChain: string,
+    durationSeconds: number,
+  ): void {
+    relayerRelayDuration
+      .labels({
+        origin_chain: originChain,
+        destination_chain: destinationChain,
+      })
+      .observe(durationSeconds);
+  }
+
+  recordMessageSkipped(originChain: string, destinationChain: string): void {
+    relayerMessagesSkipped
+      .labels({
+        origin_chain: originChain,
+        destination_chain: destinationChain,
+      })
+      .inc();
+  }
+
+  recordMessageAlreadyDelivered(
+    originChain: string,
+    destinationChain: string,
+  ): void {
+    relayerMessagesAlreadyDelivered
+      .labels({
+        origin_chain: originChain,
+        destination_chain: destinationChain,
+      })
+      .inc();
+  }
+
+  /**
+   * Start a timer for measuring relay duration
+   * Returns a function that should be called when the relay completes
+   */
+  startRelayTimer(originChain: string, destinationChain: string): () => number {
+    const startTime = Date.now();
+    return () => {
+      const durationSeconds = (Date.now() - startTime) / 1000;
+      this.recordRelayDuration(originChain, destinationChain, durationSeconds);
+      return durationSeconds;
+    };
+  }
+}

--- a/typescript/relayer/src/service.ts
+++ b/typescript/relayer/src/service.ts
@@ -42,12 +42,17 @@ async function main(): Promise<void> {
     version: VERSION,
   });
 
+  const enableMetrics = process.env.PROMETHEUS_ENABLED !== 'false';
+  const prometheusPort = process.env.PROMETHEUS_PORT || '9090';
+
   logger.info(
     {
       version: VERSION,
       configFile,
       chainsEnv,
       cacheFile,
+      enableMetrics,
+      prometheusPort: enableMetrics ? prometheusPort : undefined,
     },
     'Starting Hyperlane Relayer Service',
   );
@@ -88,6 +93,7 @@ async function main(): Promise<void> {
         mode: 'daemon',
         cacheFile,
         logger,
+        enableMetrics,
       },
       relayerConfig,
     );


### PR DESCRIPTION
## Summary
- Adds Prometheus metrics support to the TypeScript relayer package
- Exposes key operational metrics via HTTP `/metrics` endpoint for observability

## Metrics Added
| Metric | Type | Description |
|--------|------|-------------|
| `hyperlane_relayer_messages_total` | Counter | Messages processed (labels: origin_chain, destination_chain, status) |
| `hyperlane_relayer_retries_total` | Counter | Retry attempts |
| `hyperlane_relayer_backlog_size` | Gauge | Current message backlog |
| `hyperlane_relayer_relay_duration_seconds` | Histogram | Time to relay messages |
| `hyperlane_relayer_messages_skipped_total` | Counter | Messages filtered by whitelist |
| `hyperlane_relayer_messages_already_delivered_total` | Counter | Messages already delivered |

## Configuration
- `PROMETHEUS_ENABLED=true|false` (default: true in daemon mode)
- `PROMETHEUS_PORT=9090` (configurable)

## Stacked on
- #7671 (PR1: Package extraction)