### PR TITLE
chore: pause Flow relayer operations

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -247,7 +247,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     everclear: true,
     fantom: true,
     flare: true,
-    flowmainnet: true,
+    flowmainnet: false,
     fluence: true,
     forma: true,
     fraxtal: true,

--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -254,10 +254,18 @@ export class RelayerConfigHelper extends AgentConfigHelper<RelayerConfig> {
       '0x97a05beCc2e7891D07F382457Cd5d57FD242e4e8',
     ];
 
+    const flowAddresses = [
+      '0x9D9247F5C3F3B78F7EE2C480B9CDaB91393Bf4D6',
+      '0x2e7C4b71397f10c93dC0C2ba6f8f179A47F994e1',
+      '0x00000000000000000000000235aE95896583818d',
+    ];
+
     const uniqueAddresses = new Set(
-      [...sanctionedEthereumAdresses, ...radiantExploiter].map((address) =>
-        address.toLowerCase(),
-      ),
+      [
+        ...sanctionedEthereumAdresses,
+        ...radiantExploiter,
+        ...flowAddresses,
+      ].map((address) => address.toLowerCase()),
     );
 
     return Array.from(uniqueAddresses);


### PR DESCRIPTION
### Description

- As requested due to the incident they are undergoing

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Paused Flow relayer operations by disabling the `flowmainnet` chain in the relayer config and blacklisting specific Flow addresses.

- Changed `flowmainnet` from `true` to `false` in the relayer role configuration (validator and scraper remain active)
- Added three Flow addresses to the sanctioned address blacklist: `0x9D9247F5C3F3B78F7EE2C480B9CDaB91393Bf4D6`, `0x2e7C4b71397f10c93dC0C2ba6f8f179A47F994e1`, and `0x00000000000000000000000235aE95896583818d`
- This prevents the relayer from processing transactions to/from Flow while validators and scrapers continue operating normally

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge - it's a simple configuration change to pause operations
- The changes are straightforward configuration updates to disable Flow relayer operations as requested due to an incident. The modifications only affect relayer behavior while keeping validators and scrapers active, which is the right approach for maintaining chain monitoring without processing transactions
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| typescript/infra/config/environments/mainnet3/agent.ts | Disabled `flowmainnet` relayer by setting it to `false` in the relayer configuration |
| typescript/infra/src/config/agent/relayer.ts | Added three Flow addresses to the sanctioned addresses blacklist to prevent relaying |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Config as Agent Config
    participant Relayer as Relayer Agent
    participant Flow as Flow Mainnet
    participant Validator as Validator Agent
    participant Scraper as Scraper Agent

    Note over Config,Scraper: Before: All agents active on Flow
    
    Config->>Relayer: flowmainnet: true
    Relayer->>Flow: Process transactions
    Validator->>Flow: Validate messages
    Scraper->>Flow: Index events
    
    Note over Config,Scraper: After: Relayer paused due to incident
    
    Config->>Config: Set flowmainnet: false (relayer)
    Config->>Config: Add Flow addresses to blacklist
    Config->>Relayer: flowmainnet: false
    Config->>Relayer: Blacklist Flow addresses
    Relayer-xFlow: No transaction processing
    Validator->>Flow: Continue validation
    Scraper->>Flow: Continue indexing
    
    Note over Relayer,Flow: Relayer operations paused<br/>Validators and scrapers continue
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->