### PR TITLE
fix: use SERVICE_VERSION env var for ccip-server version logging

### DIFF
--- a/.github/workflows/ccip-server-docker.yml
+++ b/.github/workflows/ccip-server-docker.yml
@@ -110,6 +110,7 @@ jobs:
           platforms: ${{ steps.determine-platforms.outputs.platforms }}
           build-args: |
             FOUNDRY_VERSION=${{ steps.foundry-version.outputs.FOUNDRY_VERSION }}
+            SERVICE_VERSION=${{ steps.taggen.outputs.TAG_SHA }}-${{ steps.taggen.outputs.TAG_DATE }}
 
       - name: Comment image tags on PR
         if: github.event_name == 'pull_request'

--- a/typescript/ccip-server/Dockerfile
+++ b/typescript/ccip-server/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Foundry (Linux binaries) - pinned version for reproducibility
 ARG FOUNDRY_VERSION
+ARG SERVICE_VERSION=dev
 ARG TARGETARCH
 SHELL ["/bin/bash", "-c"]
 RUN set -o pipefail && \
@@ -93,9 +94,11 @@ COPY --from=builder /app ./
 COPY --from=builder /hyperlane-monorepo/typescript/ccip-server/prisma ./prisma
 
 # Environment variables
+ARG SERVICE_VERSION=dev
 ENV NODE_ENV=production
 ENV LOG_LEVEL=info
 ENV SERVER_PORT=3000
+ENV SERVICE_VERSION=${SERVICE_VERSION}
 
 # Expose ports
 EXPOSE 3000

--- a/typescript/ccip-server/src/server.ts
+++ b/typescript/ccip-server/src/server.ts
@@ -4,8 +4,6 @@ import { pinoHttp } from 'pino-http';
 
 import { createServiceLogger } from '@hyperlane-xyz/utils';
 
-import packageJson from '../package.json' with { type: 'json' };
-
 import { getEnabledModules } from './config.js';
 import { ServiceFactory } from './services/BaseService.js';
 import { CCTPService } from './services/CCTPService.js';
@@ -25,10 +23,12 @@ export const moduleRegistry: Record<string, ServiceFactory> = {
 };
 
 async function startServer() {
+  const VERSION = process.env.SERVICE_VERSION || 'dev';
+
   // Initialize logger first thing in startup
   const logger = await createServiceLogger({
     service: 'ccip-server',
-    version: packageJson.version,
+    version: VERSION,
   });
 
   const app = express();


### PR DESCRIPTION
## Summary
- Use CI-generated Docker tag (SHA + date) as SERVICE_VERSION instead of package.json version
- Multiple Docker images can be built from the same npm package version, so the package version doesn't uniquely identify a build
- Same pattern as applied to rebalancer and warp-monitor

## Test plan
- [x] Verify Docker build succeeds with SERVICE_VERSION build arg
- [x] Verify logs show correct version in deployed container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Switched ccip-server version logging from `package.json` version to `SERVICE_VERSION` environment variable, which gets set during Docker builds using a unique SHA+date identifier.

- Workflow passes `SERVICE_VERSION` build arg with format `{7-char-sha}-{timestamp}` (e.g., `b9c592a-20250129-143022`)
- Dockerfile accepts `SERVICE_VERSION` as ARG (defaults to `dev`) and exposes it as ENV variable  
- Server code reads `process.env.SERVICE_VERSION` instead of importing from `package.json`
- Removed unused `package.json` import from `server.ts`

This matches the pattern the team applied to other services and ensures each Docker image has a unique version identifier even when multiple images are built from the same npm package version.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- Safe to merge - straightforward versioning change with proper fallback handling
- Clean implementation that properly threads the version through CI build args, Dockerfile ARG/ENV, and runtime code. The fallback to 'dev' is sensible, and removing the unused import keeps things tidy.
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ccip-server-docker.yml | Added `SERVICE_VERSION` build arg using SHA+date tag for Docker versioning |
| typescript/ccip-server/Dockerfile | Added `SERVICE_VERSION` ARG and ENV to pass build-time version through to runtime |
| typescript/ccip-server/src/server.ts | Replaced `package.json` version with `SERVICE_VERSION` env var for logging |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant Docker as Docker Build
    participant Container as Running Container
    participant Logger as Service Logger
    
    GHA->>GHA: Generate TAG_SHA (first 7 chars of commit)
    GHA->>GHA: Generate TAG_DATE (timestamp)
    GHA->>Docker: Build with SERVICE_VERSION arg<br/>(SHA-DATE format)
    Docker->>Docker: Set ARG SERVICE_VERSION=dev (default)
    Docker->>Docker: Build stage: install deps
    Docker->>Docker: Runner stage: accept SERVICE_VERSION arg
    Docker->>Docker: Set ENV SERVICE_VERSION=${SERVICE_VERSION}
    Docker->>Container: Start container with env var
    Container->>Container: Read process.env.SERVICE_VERSION
    Container->>Logger: createServiceLogger({version: VERSION})
    Logger->>Logger: Log with unique build identifier
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved service versioning to support dynamic version configuration during container builds, replacing static package-based version sourcing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->