### PR TITLE
feat(rebalancer): add MessageTracker infrastructure (PR 1/5)

### DIFF
--- a/typescript/rebalancer/src/config/RebalancerConfig.test.ts
+++ b/typescript/rebalancer/src/config/RebalancerConfig.test.ts
@@ -60,27 +60,27 @@ describe('RebalancerConfig', () => {
   });
 
   it('should load config from file', () => {
-    expect(RebalancerConfig.load(TEST_CONFIG_PATH)).to.deep.equal({
-      warpRouteId: 'warpRouteId',
-      strategyConfig: {
-        rebalanceStrategy: RebalancerStrategyOptions.Weighted,
-        chains: {
-          chain1: {
-            weighted: {
-              weight: 100n,
-              tolerance: 0n,
-            },
-            bridge: ethers.constants.AddressZero,
-            bridgeLockTime: 1_000,
+    const config = RebalancerConfig.load(TEST_CONFIG_PATH);
+    expect(config.warpRouteId).to.equal('warpRouteId');
+    expect(config.explorerUrl).to.be.undefined;
+    expect(config.strategyConfig).to.deep.equal({
+      rebalanceStrategy: RebalancerStrategyOptions.Weighted,
+      chains: {
+        chain1: {
+          weighted: {
+            weight: 100n,
+            tolerance: 0n,
           },
-          chain2: {
-            weighted: {
-              weight: 100n,
-              tolerance: 0n,
-            },
-            bridge: ethers.constants.AddressZero,
-            bridgeLockTime: 1_000,
+          bridge: ethers.constants.AddressZero,
+          bridgeLockTime: 1_000,
+        },
+        chain2: {
+          weighted: {
+            weight: 100n,
+            tolerance: 0n,
           },
+          bridge: ethers.constants.AddressZero,
+          bridgeLockTime: 1_000,
         },
       },
     });

--- a/typescript/rebalancer/src/config/RebalancerConfig.ts
+++ b/typescript/rebalancer/src/config/RebalancerConfig.ts
@@ -12,6 +12,8 @@ export class RebalancerConfig {
   constructor(
     public readonly warpRouteId: string,
     public readonly strategyConfig: StrategyConfig,
+    /** Optional explorer URL for message tracking (defaults to Hyperlane Explorer) */
+    public readonly explorerUrl?: string,
   ) {}
 
   /**

--- a/typescript/rebalancer/src/consts.ts
+++ b/typescript/rebalancer/src/consts.ts
@@ -1,0 +1,4 @@
+/**
+ * Default Hyperlane Explorer GraphQL API URL
+ */
+export const DEFAULT_EXPLORER_URL = 'https://explorer.hyperlane.xyz/graphql';

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -11,6 +11,7 @@ import {
 import { objMap } from '@hyperlane-xyz/utils';
 
 import { RebalancerConfig } from '../config/RebalancerConfig.js';
+import { DEFAULT_EXPLORER_URL } from '../consts.js';
 import { Rebalancer } from '../core/Rebalancer.js';
 import { WithSemaphore } from '../core/WithSemaphore.js';
 import type { IRebalancer } from '../interfaces/IRebalancer.js';
@@ -19,6 +20,7 @@ import { Metrics } from '../metrics/Metrics.js';
 import { PriceGetter } from '../metrics/PriceGetter.js';
 import { Monitor } from '../monitor/Monitor.js';
 import { StrategyFactory } from '../strategy/StrategyFactory.js';
+import { MessageTracker } from '../tracker/MessageTracker.js';
 import { isCollateralizedTokenEligibleForRebalancing } from '../utils/index.js';
 
 export class RebalancerContextFactory {
@@ -185,6 +187,25 @@ export class RebalancerContextFactory {
     );
 
     return withSemaphore;
+  }
+
+  public createMessageTracker(
+    explorerUrl: string = DEFAULT_EXPLORER_URL,
+  ): MessageTracker {
+    this.logger.debug(
+      {
+        warpRouteId: this.config.warpRouteId,
+        explorerUrl,
+      },
+      'Creating MessageTracker',
+    );
+    return new MessageTracker(
+      {
+        warpRouteId: this.config.warpRouteId,
+        explorerUrl,
+      },
+      this.logger,
+    );
   }
 
   private async getInitialTotalCollateral(): Promise<bigint> {

--- a/typescript/rebalancer/src/index.ts
+++ b/typescript/rebalancer/src/index.ts
@@ -28,6 +28,13 @@ export { WeightedStrategy } from './strategy/WeightedStrategy.js';
 export { MinAmountStrategy } from './strategy/MinAmountStrategy.js';
 export { StrategyFactory } from './strategy/StrategyFactory.js';
 
+// Tracker
+export {
+  MessageTracker,
+  type MessageTrackerConfig,
+  type InflightMessage,
+} from './tracker/index.js';
+
 // Monitor
 export { Monitor } from './monitor/Monitor.js';
 
@@ -44,6 +51,7 @@ export type {
   IStrategy,
   RebalancingRoute,
   RawBalances,
+  InflightContext,
 } from './interfaces/IStrategy.js';
 export type { IMonitor } from './interfaces/IMonitor.js';
 export {

--- a/typescript/rebalancer/src/interfaces/IStrategy.ts
+++ b/typescript/rebalancer/src/interfaces/IStrategy.ts
@@ -6,8 +6,28 @@ export type RebalancingRoute = {
   origin: ChainName;
   destination: ChainName;
   amount: bigint;
+  /** Optional bridge address for this route */
+  bridge?: string;
+};
+
+/**
+ * Context containing inflight messages for strategy decision making
+ */
+export type InflightContext = {
+  /** Pending user warp transfers that need collateral at destination */
+  pendingTransfers: RebalancingRoute[];
+  /** Pending rebalances (initiated by rebalancer or manually) */
+  pendingRebalances: RebalancingRoute[];
 };
 
 export interface IStrategy {
-  getRebalancingRoutes(rawBalances: RawBalances): RebalancingRoute[];
+  /**
+   * Get rebalancing routes based on current balances
+   * @param rawBalances Current on-chain balances
+   * @param inflightContext Optional context about inflight messages
+   */
+  getRebalancingRoutes(
+    rawBalances: RawBalances,
+    inflightContext?: InflightContext,
+  ): RebalancingRoute[];
 }

--- a/typescript/rebalancer/src/strategy/BaseStrategy.ts
+++ b/typescript/rebalancer/src/strategy/BaseStrategy.ts
@@ -4,6 +4,7 @@ import type { ChainName } from '@hyperlane-xyz/sdk';
 
 import type {
   IStrategy,
+  InflightContext,
   RawBalances,
   RebalancingRoute,
 } from '../interfaces/IStrategy.js';
@@ -31,12 +32,21 @@ export abstract class BaseStrategy implements IStrategy {
 
   /**
    * Main method to get rebalancing routes
+   * @param rawBalances Current on-chain balances
+   * @param _inflightContext Optional context about inflight messages (reserved for future use)
    */
-  getRebalancingRoutes(rawBalances: RawBalances): RebalancingRoute[] {
+  getRebalancingRoutes(
+    rawBalances: RawBalances,
+    _inflightContext?: InflightContext,
+  ): RebalancingRoute[] {
     this.logger.info(
       {
         context: this.constructor.name,
         rawBalances,
+        hasPendingTransfers:
+          (_inflightContext?.pendingTransfers.length ?? 0) > 0,
+        hasPendingRebalances:
+          (_inflightContext?.pendingRebalances.length ?? 0) > 0,
       },
       'Input rawBalances',
     );

--- a/typescript/rebalancer/src/tracker/MessageTracker.ts
+++ b/typescript/rebalancer/src/tracker/MessageTracker.ts
@@ -1,0 +1,80 @@
+import type { Logger } from 'pino';
+
+import type {
+  InflightContext,
+  RebalancingRoute,
+} from '../interfaces/IStrategy.js';
+
+/**
+ * Represents an inflight message (either a user transfer or a rebalance)
+ */
+export type InflightMessage = {
+  id: string;
+  origin: string;
+  destination: string;
+  amount: bigint;
+  sender: string;
+  recipient: string;
+  isRebalance: boolean;
+  timestamp: number;
+};
+
+export type MessageTrackerConfig = {
+  /** Warp route ID for filtering messages */
+  warpRouteId: string;
+  /** Explorer GraphQL API URL */
+  explorerUrl: string;
+};
+
+/**
+ * MessageTracker tracks inflight Hyperlane messages for rebalancing decisions.
+ *
+ * Currently returns empty context - full implementation will be added in a follow-up PR.
+ */
+export class MessageTracker {
+  private readonly logger: Logger;
+  private readonly config: MessageTrackerConfig;
+
+  constructor(config: MessageTrackerConfig, logger: Logger) {
+    this.config = config;
+    this.logger = logger.child({ component: 'MessageTracker' });
+  }
+
+  /**
+   * Get the current inflight context for strategy decision making
+   */
+  async getInflightContext(): Promise<InflightContext> {
+    this.logger.debug(
+      { warpRouteId: this.config.warpRouteId },
+      'Fetching inflight context',
+    );
+
+    // TODO: Implement actual message fetching from Explorer API
+    // For now, return empty context (no behavior change)
+    const pendingTransfers: RebalancingRoute[] = [];
+    const pendingRebalances: RebalancingRoute[] = [];
+
+    this.logger.debug(
+      {
+        pendingTransfersCount: pendingTransfers.length,
+        pendingRebalancesCount: pendingRebalances.length,
+      },
+      'Inflight context fetched',
+    );
+
+    return {
+      pendingTransfers,
+      pendingRebalances,
+    };
+  }
+
+  /**
+   * Record a rebalance that was just initiated by the rebalancer
+   * This allows the tracker to include it in the inflight context before
+   * it appears in the Explorer API
+   */
+  recordInitiatedRebalance(_route: RebalancingRoute, _messageId: string): void {
+    // TODO: Implement caching of initiated rebalances
+    this.logger.debug('recordInitiatedRebalance not yet implemented');
+  }
+}

--- a/typescript/rebalancer/src/tracker/index.ts
+++ b/typescript/rebalancer/src/tracker/index.ts
@@ -1,0 +1,5 @@
+export {
+  MessageTracker,
+  type MessageTrackerConfig,
+  type InflightMessage,
+} from './MessageTracker.js';


### PR DESCRIPTION
## Summary
This PR's content was merged into PR 1 (inflight-strategies). This branch is now aligned with PR 1.

Original content:
- Add `InflightContext` type and update `IStrategy.getRebalancingRoutes` to accept optional inflight context
- Add `MessageTracker` class (stub that returns empty context for now)
- Wire `MessageTracker` into `RebalancerService` with default Explorer URL
- Add `createMessageTracker` to `RebalancerContextFactory`
- Add optional `explorerUrl` to `RebalancerConfig`

## Test plan
- [x] Full monorepo build passes (`pnpm build`)
- [x] All 58 existing tests pass
- [x] Lint/prettier pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)