### PR TITLE
feat(rebalancer): add CollateralDeficit and Composite strategies (PR 3/4)

### DIFF
--- a/typescript/rebalancer/src/index.ts
+++ b/typescript/rebalancer/src/index.ts
@@ -26,6 +26,9 @@ export { RebalancerConfig } from './config/RebalancerConfig.js';
 export { BaseStrategy } from './strategy/BaseStrategy.js';
 export { WeightedStrategy } from './strategy/WeightedStrategy.js';
 export { MinAmountStrategy } from './strategy/MinAmountStrategy.js';
+export { CollateralDeficitStrategy } from './strategy/CollateralDeficitStrategy.js';
+export type { CollateralDeficitStrategyConfig } from './strategy/CollateralDeficitStrategy.js';
+export { CompositeStrategy } from './strategy/CompositeStrategy.js';
 export { StrategyFactory } from './strategy/StrategyFactory.js';
 
 // Tracker

--- a/typescript/rebalancer/src/strategy/CollateralDeficitStrategy.test.ts
+++ b/typescript/rebalancer/src/strategy/CollateralDeficitStrategy.test.ts
@@ -1,0 +1,279 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import { pino } from 'pino';
+
+import { CollateralDeficitStrategy } from './CollateralDeficitStrategy.js';
+
+const testLogger = pino({ level: 'silent' });
+
+const chain1 = 'chain1';
+const chain2 = 'chain2';
+const chain3 = 'chain3';
+const bridge1 = '0x1111111111111111111111111111111111111111';
+const bridge2 = '0x2222222222222222222222222222222222222222';
+const bridge3 = '0x3333333333333333333333333333333333333333';
+
+describe('CollateralDeficitStrategy', () => {
+  describe('constructor', () => {
+    it('should throw an error when less than two chains are configured', () => {
+      expect(
+        () =>
+          new CollateralDeficitStrategy(
+            {
+              [chain1]: {
+                bridge: bridge1,
+                buffer: 0n,
+              },
+            },
+            testLogger,
+          ),
+      ).to.throw('At least two chains must be configured');
+    });
+
+    it('should create a strategy with valid configuration', () => {
+      const strategy = new CollateralDeficitStrategy(
+        {
+          [chain1]: {
+            bridge: bridge1,
+            buffer: ethers.utils.parseEther('100').toBigInt(),
+          },
+          [chain2]: {
+            bridge: bridge2,
+            buffer: ethers.utils.parseEther('50').toBigInt(),
+          },
+        },
+        testLogger,
+      );
+
+      expect(strategy).to.be.instanceOf(CollateralDeficitStrategy);
+    });
+  });
+
+  describe('getRebalancingRoutes', () => {
+    it('should return empty array when no chains have negative balances', () => {
+      const strategy = new CollateralDeficitStrategy(
+        {
+          [chain1]: { bridge: bridge1, buffer: 0n },
+          [chain2]: { bridge: bridge2, buffer: 0n },
+        },
+        testLogger,
+      );
+
+      const rawBalances = {
+        [chain1]: ethers.utils.parseEther('100').toBigInt(),
+        [chain2]: ethers.utils.parseEther('100').toBigInt(),
+      };
+
+      const routes = strategy.getRebalancingRoutes(rawBalances);
+      expect(routes).to.deep.equal([]);
+    });
+
+    it('should return empty array when all balances are zero', () => {
+      const strategy = new CollateralDeficitStrategy(
+        {
+          [chain1]: { bridge: bridge1, buffer: 0n },
+          [chain2]: { bridge: bridge2, buffer: 0n },
+        },
+        testLogger,
+      );
+
+      const rawBalances = {
+        [chain1]: 0n,
+        [chain2]: 0n,
+      };
+
+      const routes = strategy.getRebalancingRoutes(rawBalances);
+      expect(routes).to.deep.equal([]);
+    });
+
+    it('should return route when a chain has negative balance', () => {
+      const strategy = new CollateralDeficitStrategy(
+        {
+          [chain1]: { bridge: bridge1, buffer: 0n },
+          [chain2]: { bridge: bridge2, buffer: 0n },
+        },
+        testLogger,
+      );
+
+      // chain1 has negative balance (deficit), chain2 has surplus
+      const rawBalances = {
+        [chain1]: ethers.utils.parseEther('-50').toBigInt(),
+        [chain2]: ethers.utils.parseEther('100').toBigInt(),
+      };
+
+      const routes = strategy.getRebalancingRoutes(rawBalances);
+
+      expect(routes).to.have.lengthOf(1);
+      expect(routes[0]).to.deep.equal({
+        origin: chain2,
+        destination: chain1,
+        amount: ethers.utils.parseEther('50').toBigInt(),
+        bridge: bridge1, // Uses destination chain's bridge
+      });
+    });
+
+    it('should apply buffer to deficit calculation', () => {
+      const buffer = ethers.utils.parseEther('10').toBigInt();
+      const strategy = new CollateralDeficitStrategy(
+        {
+          [chain1]: { bridge: bridge1, buffer },
+          [chain2]: { bridge: bridge2, buffer: 0n },
+        },
+        testLogger,
+      );
+
+      // chain1 has -50 balance, with buffer of 10, deficit should be 60
+      const rawBalances = {
+        [chain1]: ethers.utils.parseEther('-50').toBigInt(),
+        [chain2]: ethers.utils.parseEther('100').toBigInt(),
+      };
+
+      const routes = strategy.getRebalancingRoutes(rawBalances);
+
+      expect(routes).to.have.lengthOf(1);
+      expect(routes[0].amount).to.equal(
+        ethers.utils.parseEther('60').toBigInt(),
+      );
+    });
+
+    it('should handle multiple chains with deficits', () => {
+      const strategy = new CollateralDeficitStrategy(
+        {
+          [chain1]: { bridge: bridge1, buffer: 0n },
+          [chain2]: { bridge: bridge2, buffer: 0n },
+          [chain3]: { bridge: bridge3, buffer: 0n },
+        },
+        testLogger,
+      );
+
+      // chain1 and chain2 have deficits, chain3 has surplus
+      const rawBalances = {
+        [chain1]: ethers.utils.parseEther('-30').toBigInt(),
+        [chain2]: ethers.utils.parseEther('-20').toBigInt(),
+        [chain3]: ethers.utils.parseEther('100').toBigInt(),
+      };
+
+      const routes = strategy.getRebalancingRoutes(rawBalances);
+
+      expect(routes).to.have.lengthOf(2);
+      // Routes should cover both deficits
+      const totalTransferred = routes.reduce((sum, r) => sum + r.amount, 0n);
+      expect(totalTransferred).to.equal(
+        ethers.utils.parseEther('50').toBigInt(),
+      );
+    });
+
+    it('should skip routes that already have pending rebalances to same destination', () => {
+      const strategy = new CollateralDeficitStrategy(
+        {
+          [chain1]: { bridge: bridge1, buffer: 0n },
+          [chain2]: { bridge: bridge2, buffer: 0n },
+        },
+        testLogger,
+      );
+
+      const rawBalances = {
+        [chain1]: ethers.utils.parseEther('-50').toBigInt(),
+        [chain2]: ethers.utils.parseEther('100').toBigInt(),
+      };
+
+      // Simulate pending rebalance to chain1 using same bridge
+      const inflightContext = {
+        pendingTransfers: [],
+        pendingRebalances: [
+          {
+            origin: chain2,
+            destination: chain1,
+            amount: ethers.utils.parseEther('50').toBigInt(),
+            bridge: bridge1, // Same bridge as chain1
+          },
+        ],
+      };
+
+      const routes = strategy.getRebalancingRoutes(
+        rawBalances,
+        inflightContext,
+      );
+
+      // Should not duplicate the route since there's already a pending rebalance
+      expect(routes).to.deep.equal([]);
+    });
+
+    it('should include route when pending rebalance uses different bridge', () => {
+      const strategy = new CollateralDeficitStrategy(
+        {
+          [chain1]: { bridge: bridge1, buffer: 0n },
+          [chain2]: { bridge: bridge2, buffer: 0n },
+        },
+        testLogger,
+      );
+
+      const rawBalances = {
+        [chain1]: ethers.utils.parseEther('-50').toBigInt(),
+        [chain2]: ethers.utils.parseEther('100').toBigInt(),
+      };
+
+      // Pending rebalance uses different bridge
+      const inflightContext = {
+        pendingTransfers: [],
+        pendingRebalances: [
+          {
+            origin: chain2,
+            destination: chain1,
+            amount: ethers.utils.parseEther('50').toBigInt(),
+            bridge: '0x9999999999999999999999999999999999999999', // Different bridge
+          },
+        ],
+      };
+
+      const routes = strategy.getRebalancingRoutes(
+        rawBalances,
+        inflightContext,
+      );
+
+      // Should include route since pending rebalance uses different bridge
+      expect(routes).to.have.lengthOf(1);
+    });
+
+    it('should reserve collateral for pending transfers on destination chain', () => {
+      const strategy = new CollateralDeficitStrategy(
+        {
+          [chain1]: { bridge: bridge1, buffer: 0n },
+          [chain2]: { bridge: bridge2, buffer: 0n },
+        },
+        testLogger,
+      );
+
+      // chain1 has -50 deficit, chain2 has 100 surplus
+      // Pending transfer TO chain1 means chain1 needs to reserve collateral for payout
+      const rawBalances = {
+        [chain1]: ethers.utils.parseEther('-50').toBigInt(),
+        [chain2]: ethers.utils.parseEther('100').toBigInt(),
+      };
+
+      const inflightContext = {
+        pendingTransfers: [
+          {
+            origin: chain2,
+            destination: chain1,
+            amount: ethers.utils.parseEther('80').toBigInt(),
+          },
+        ],
+        pendingRebalances: [],
+      };
+
+      const routes = strategy.getRebalancingRoutes(
+        rawBalances,
+        inflightContext,
+      );
+
+      // After reserving 80 on destination (chain1): chain1 = -50 - 80 = -130 (worse deficit)
+      // chain2 still has 100 surplus (origin balance already reduced on-chain when transfer initiated)
+      // Deficit = 130, surplus = 100, so scaled route = 100
+      expect(routes).to.have.lengthOf(1);
+      expect(routes[0].amount).to.equal(
+        ethers.utils.parseEther('100').toBigInt(),
+      );
+    });
+  });
+});

--- a/typescript/rebalancer/src/strategy/CollateralDeficitStrategy.ts
+++ b/typescript/rebalancer/src/strategy/CollateralDeficitStrategy.ts
@@ -1,0 +1,214 @@
+import { Logger } from 'pino';
+
+import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
+
+import type { RawBalances, RebalancingRoute } from '../interfaces/IStrategy.js';
+import { Metrics } from '../metrics/Metrics.js';
+
+import { BaseStrategy, type Delta } from './BaseStrategy.js';
+
+/**
+ * Configuration for a chain in the CollateralDeficit strategy
+ */
+export type CollateralDeficitChainConfig = {
+  /** Bridge address for just-in-time rebalances (e.g., CCTP V2 Fast) */
+  bridge: string;
+  /** Buffer amount to add to deficit for headroom (in wei) */
+  buffer: bigint;
+};
+
+export type CollateralDeficitStrategyConfig =
+  ChainMap<CollateralDeficitChainConfig>;
+
+/**
+ * Strategy implementation that detects and addresses collateral deficits.
+ *
+ * This strategy interprets negative balances (after collateral reservation)
+ * as deficits that need immediate attention via just-in-time rebalancing.
+ *
+ * Key behaviors:
+ * - Scans for negative balances indicating insufficient collateral
+ * - Adds a configurable buffer per chain for headroom
+ * - Checks pending rebalances using the same bridge to avoid duplicates
+ * - Uses fast bridges (e.g., CCTP V2 Fast) for quick delivery
+ */
+export class CollateralDeficitStrategy extends BaseStrategy {
+  private readonly config: CollateralDeficitStrategyConfig;
+  protected readonly logger: Logger;
+
+  constructor(
+    config: CollateralDeficitStrategyConfig,
+    logger: Logger,
+    metrics?: Metrics,
+  ) {
+    const chains = Object.keys(config);
+    const log = logger.child({ class: CollateralDeficitStrategy.name });
+    super(chains, log, metrics);
+    this.logger = log;
+    this.config = config;
+
+    // Validate config
+    for (const chain of chains) {
+      const chainConfig = config[chain];
+
+      if (!chainConfig.bridge) {
+        throw new Error(`Bridge address required for chain ${chain}`);
+      }
+
+      if (chainConfig.buffer < 0n) {
+        throw new Error(`Buffer cannot be negative for chain ${chain}`);
+      }
+    }
+
+    this.logger.info('CollateralDeficitStrategy created');
+  }
+
+  /**
+   * Override validation to allow negative balances.
+   * This strategy is designed to detect deficits (negative balances after
+   * collateral reservation), so negative values are expected and valid.
+   */
+  protected override validateRawBalances(
+    rawBalances: RawBalances,
+    _allowNegative = true,
+  ): void {
+    // Always allow negative balances for deficit detection
+    super.validateRawBalances(rawBalances, true);
+  }
+
+  /**
+   * Override to only fast-forward pending rebalances that use the same bridge
+   * as this strategy. This ensures we still detect deficits even if there are
+   * pending rebalances via slower bridges - we want to send fast bridge
+   * rebalances regardless.
+   */
+  protected override simulatePendingRebalances(
+    rawBalances: RawBalances,
+    pendingRebalances: RebalancingRoute[],
+  ): RawBalances {
+    // Filter to only same-bridge rebalances
+    const sameBridgeRebalances = pendingRebalances.filter((rebalance) => {
+      const chainConfig = this.config[rebalance.destination];
+      return chainConfig && rebalance.bridge === chainConfig.bridge;
+    });
+
+    return super.simulatePendingRebalances(rawBalances, sameBridgeRebalances);
+  }
+
+  /**
+   * Gets balances categorized by surplus and deficit.
+   *
+   * This strategy treats negative balances as deficits (after collateral
+   * reservation from BaseStrategy). The deficit amount is the absolute value
+   * of the negative balance plus the configured buffer.
+   *
+   * @param rawBalances Adjusted balances (may be negative after reservation)
+   * @param pendingRebalances Pending rebalances to check for conflicts
+   */
+  protected getCategorizedBalances(
+    rawBalances: RawBalances,
+    pendingRebalances: RebalancingRoute[],
+  ): {
+    surpluses: Delta[];
+    deficits: Delta[];
+  } {
+    const surpluses: Delta[] = [];
+    const deficits: Delta[] = [];
+
+    // Create a map of pending rebalances by destination using same bridge
+    const pendingByDest = this.getPendingByDestination(pendingRebalances);
+
+    for (const chain of this.chains) {
+      const balance = rawBalances[chain];
+      const chainConfig = this.config[chain];
+
+      if (balance < 0n) {
+        // Negative balance indicates a deficit
+        // Deficit amount = abs(negative balance) + buffer
+        const deficitAmount = -balance + chainConfig.buffer;
+
+        // Check if there's already a pending rebalance to this chain
+        // using the same bridge that would satisfy the deficit
+        const pendingAmount = pendingByDest.get(chain) ?? 0n;
+
+        if (pendingAmount >= deficitAmount) {
+          this.logger.debug(
+            {
+              chain,
+              deficitAmount: deficitAmount.toString(),
+              pendingAmount: pendingAmount.toString(),
+            },
+            'Deficit already covered by pending rebalance',
+          );
+          continue;
+        }
+
+        // Calculate remaining deficit after accounting for pending
+        const remainingDeficit = deficitAmount - pendingAmount;
+
+        if (remainingDeficit > 0n) {
+          deficits.push({ chain, amount: remainingDeficit });
+
+          this.logger.info(
+            {
+              chain,
+              balance: balance.toString(),
+              buffer: chainConfig.buffer.toString(),
+              deficitAmount: deficitAmount.toString(),
+              pendingAmount: pendingAmount.toString(),
+              remainingDeficit: remainingDeficit.toString(),
+            },
+            'Detected collateral deficit',
+          );
+        }
+      } else if (balance > 0n) {
+        // Positive balance can contribute to surplus
+        surpluses.push({ chain, amount: balance });
+      }
+    }
+
+    return { surpluses, deficits };
+  }
+
+  /**
+   * Get a map of pending rebalance amounts by destination,
+   * only counting rebalances using bridges configured for this strategy.
+   */
+  private getPendingByDestination(
+    pendingRebalances: RebalancingRoute[],
+  ): Map<ChainName, bigint> {
+    const pendingByDest = new Map<ChainName, bigint>();
+
+    for (const rebalance of pendingRebalances) {
+      const chainConfig = this.config[rebalance.destination];
+
+      // Only count rebalances using the same bridge as this strategy
+      if (chainConfig && rebalance.bridge === chainConfig.bridge) {
+        const current = pendingByDest.get(rebalance.destination) ?? 0n;
+        pendingByDest.set(rebalance.destination, current + rebalance.amount);
+      }
+    }
+
+    return pendingByDest;
+  }
+
+  /**
+   * Override to assign the bridge for each route based on destination chain.
+   */
+  getRebalancingRoutes(
+    rawBalances: RawBalances,
+    inflightContext?: {
+      pendingTransfers: RebalancingRoute[];
+      pendingRebalances: RebalancingRoute[];
+    },
+  ): RebalancingRoute[] {
+    // Get routes from base implementation
+    const routes = super.getRebalancingRoutes(rawBalances, inflightContext);
+
+    // Assign bridge based on destination chain config
+    return routes.map((route) => ({
+      ...route,
+      bridge: this.config[route.destination]?.bridge,
+    }));
+  }
+}

--- a/typescript/rebalancer/src/strategy/CompositeStrategy.test.ts
+++ b/typescript/rebalancer/src/strategy/CompositeStrategy.test.ts
@@ -1,0 +1,243 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import { pino } from 'pino';
+
+import type {
+  IStrategy,
+  RawBalances,
+  RebalancingRoute,
+} from '../interfaces/IStrategy.js';
+
+import { CompositeStrategy } from './CompositeStrategy.js';
+
+const testLogger = pino({ level: 'silent' });
+
+const chain1 = 'chain1';
+const chain2 = 'chain2';
+const chain3 = 'chain3';
+
+// Mock strategy for testing
+class MockStrategy implements IStrategy {
+  private routes: RebalancingRoute[];
+  public callCount = 0;
+  public lastInflightContext: any;
+
+  constructor(routes: RebalancingRoute[]) {
+    this.routes = routes;
+  }
+
+  getRebalancingRoutes(
+    _rawBalances: RawBalances,
+    inflightContext?: {
+      pendingTransfers: RebalancingRoute[];
+      pendingRebalances: RebalancingRoute[];
+    },
+  ): RebalancingRoute[] {
+    this.callCount++;
+    this.lastInflightContext = inflightContext;
+    return this.routes;
+  }
+}
+
+describe('CompositeStrategy', () => {
+  describe('constructor', () => {
+    it('should throw an error when no strategies are provided', () => {
+      expect(() => new CompositeStrategy([], testLogger)).to.throw(
+        'CompositeStrategy requires at least one sub-strategy',
+      );
+    });
+
+    it('should create a strategy with valid configuration', () => {
+      const mockStrategy = new MockStrategy([]);
+      const composite = new CompositeStrategy([mockStrategy], testLogger);
+      expect(composite).to.be.instanceOf(CompositeStrategy);
+    });
+  });
+
+  describe('getRebalancingRoutes', () => {
+    it('should execute single strategy and return its routes', () => {
+      const expectedRoutes: RebalancingRoute[] = [
+        {
+          origin: chain1,
+          destination: chain2,
+          amount: ethers.utils.parseEther('50').toBigInt(),
+        },
+      ];
+      const mockStrategy = new MockStrategy(expectedRoutes);
+      const composite = new CompositeStrategy([mockStrategy], testLogger);
+
+      const rawBalances = {
+        [chain1]: ethers.utils.parseEther('100').toBigInt(),
+        [chain2]: ethers.utils.parseEther('100').toBigInt(),
+      };
+
+      const routes = composite.getRebalancingRoutes(rawBalances);
+
+      expect(mockStrategy.callCount).to.equal(1);
+      expect(routes).to.deep.equal(expectedRoutes);
+    });
+
+    it('should execute multiple strategies in sequence', () => {
+      const routes1: RebalancingRoute[] = [
+        {
+          origin: chain1,
+          destination: chain2,
+          amount: ethers.utils.parseEther('30').toBigInt(),
+          bridge: '0x1111111111111111111111111111111111111111',
+        },
+      ];
+      const routes2: RebalancingRoute[] = [
+        {
+          origin: chain1,
+          destination: chain3,
+          amount: ethers.utils.parseEther('20').toBigInt(),
+        },
+      ];
+
+      const strategy1 = new MockStrategy(routes1);
+      const strategy2 = new MockStrategy(routes2);
+      const composite = new CompositeStrategy(
+        [strategy1, strategy2],
+        testLogger,
+      );
+
+      const rawBalances = {
+        [chain1]: ethers.utils.parseEther('100').toBigInt(),
+        [chain2]: ethers.utils.parseEther('50').toBigInt(),
+        [chain3]: ethers.utils.parseEther('50').toBigInt(),
+      };
+
+      const routes = composite.getRebalancingRoutes(rawBalances);
+
+      expect(strategy1.callCount).to.equal(1);
+      expect(strategy2.callCount).to.equal(1);
+      expect(routes).to.deep.equal([...routes1, ...routes2]);
+    });
+
+    it('should pass routes from first strategy as pendingRebalances to second strategy', () => {
+      const routes1: RebalancingRoute[] = [
+        {
+          origin: chain1,
+          destination: chain2,
+          amount: ethers.utils.parseEther('30').toBigInt(),
+          bridge: '0x1111111111111111111111111111111111111111',
+        },
+      ];
+      const routes2: RebalancingRoute[] = [];
+
+      const strategy1 = new MockStrategy(routes1);
+      const strategy2 = new MockStrategy(routes2);
+      const composite = new CompositeStrategy(
+        [strategy1, strategy2],
+        testLogger,
+      );
+
+      const rawBalances = {
+        [chain1]: ethers.utils.parseEther('100').toBigInt(),
+        [chain2]: ethers.utils.parseEther('50').toBigInt(),
+      };
+
+      composite.getRebalancingRoutes(rawBalances);
+
+      // First strategy should receive no pending rebalances
+      expect(
+        strategy1.lastInflightContext?.pendingRebalances || [],
+      ).to.deep.equal([]);
+
+      // Second strategy should receive routes from first strategy as pending rebalances
+      expect(strategy2.lastInflightContext?.pendingRebalances).to.deep.equal(
+        routes1,
+      );
+    });
+
+    it('should pass through inflight context to first strategy', () => {
+      const routes1: RebalancingRoute[] = [];
+      const strategy1 = new MockStrategy(routes1);
+      const composite = new CompositeStrategy([strategy1], testLogger);
+
+      const rawBalances = {
+        [chain1]: ethers.utils.parseEther('100').toBigInt(),
+        [chain2]: ethers.utils.parseEther('50').toBigInt(),
+      };
+
+      const inflightContext = {
+        pendingTransfers: [
+          {
+            origin: chain1,
+            destination: chain2,
+            amount: ethers.utils.parseEther('10').toBigInt(),
+          },
+        ],
+        pendingRebalances: [
+          {
+            origin: chain2,
+            destination: chain1,
+            amount: ethers.utils.parseEther('5').toBigInt(),
+          },
+        ],
+      };
+
+      composite.getRebalancingRoutes(rawBalances, inflightContext);
+
+      expect(strategy1.lastInflightContext).to.deep.equal(inflightContext);
+    });
+
+    it('should accumulate pending rebalances through multiple strategies', () => {
+      const routes1: RebalancingRoute[] = [
+        {
+          origin: chain1,
+          destination: chain2,
+          amount: ethers.utils.parseEther('30').toBigInt(),
+        },
+      ];
+      const routes2: RebalancingRoute[] = [
+        {
+          origin: chain2,
+          destination: chain3,
+          amount: ethers.utils.parseEther('20').toBigInt(),
+        },
+      ];
+      const routes3: RebalancingRoute[] = [];
+
+      const strategy1 = new MockStrategy(routes1);
+      const strategy2 = new MockStrategy(routes2);
+      const strategy3 = new MockStrategy(routes3);
+      const composite = new CompositeStrategy(
+        [strategy1, strategy2, strategy3],
+        testLogger,
+      );
+
+      const rawBalances = {
+        [chain1]: ethers.utils.parseEther('100').toBigInt(),
+        [chain2]: ethers.utils.parseEther('50').toBigInt(),
+        [chain3]: ethers.utils.parseEther('50').toBigInt(),
+      };
+
+      composite.getRebalancingRoutes(rawBalances);
+
+      // Strategy 3 should see routes from both strategy 1 and 2
+      expect(strategy3.lastInflightContext?.pendingRebalances).to.deep.equal([
+        ...routes1,
+        ...routes2,
+      ]);
+    });
+
+    it('should return empty array when all strategies return empty', () => {
+      const strategy1 = new MockStrategy([]);
+      const strategy2 = new MockStrategy([]);
+      const composite = new CompositeStrategy(
+        [strategy1, strategy2],
+        testLogger,
+      );
+
+      const rawBalances = {
+        [chain1]: ethers.utils.parseEther('100').toBigInt(),
+        [chain2]: ethers.utils.parseEther('100').toBigInt(),
+      };
+
+      const routes = composite.getRebalancingRoutes(rawBalances);
+
+      expect(routes).to.deep.equal([]);
+    });
+  });
+});

--- a/typescript/rebalancer/src/strategy/CompositeStrategy.ts
+++ b/typescript/rebalancer/src/strategy/CompositeStrategy.ts
@@ -1,0 +1,104 @@
+import type { Logger } from 'pino';
+
+import type {
+  IStrategy,
+  InflightContext,
+  RawBalances,
+  RebalancingRoute,
+} from '../interfaces/IStrategy.js';
+
+/**
+ * CompositeStrategy executes a sequence of strategies and combines their routes.
+ *
+ * This allows composing multiple strategies together, for example:
+ * - CollateralDeficitStrategy (fast bridge) → WeightedStrategy (standard bridge)
+ *
+ * Each strategy sees the pending rebalances from previous strategies in the chain,
+ * allowing later strategies to avoid proposing redundant routes.
+ *
+ * Key behaviors:
+ * - Strategies are executed in order
+ * - Routes from earlier strategies are added to pendingRebalances for later strategies
+ * - All routes are combined and returned as the final result
+ */
+export class CompositeStrategy implements IStrategy {
+  private readonly strategies: IStrategy[];
+  private readonly logger: Logger;
+
+  constructor(strategies: IStrategy[], logger: Logger) {
+    if (strategies.length === 0) {
+      throw new Error('CompositeStrategy requires at least one sub-strategy');
+    }
+
+    this.strategies = strategies;
+    this.logger = logger.child({ class: CompositeStrategy.name });
+    this.logger.info(
+      { strategyCount: strategies.length },
+      'CompositeStrategy created',
+    );
+  }
+
+  /**
+   * Get rebalancing routes by executing all strategies in sequence.
+   *
+   * Routes from earlier strategies are passed as pendingRebalances to
+   * later strategies, allowing them to make informed decisions.
+   */
+  getRebalancingRoutes(
+    rawBalances: RawBalances,
+    inflightContext?: InflightContext,
+  ): RebalancingRoute[] {
+    const allRoutes: RebalancingRoute[] = [];
+
+    // Start with the provided inflight context or empty
+    let currentContext: InflightContext = {
+      pendingTransfers: inflightContext?.pendingTransfers ?? [],
+      pendingRebalances: inflightContext?.pendingRebalances ?? [],
+    };
+
+    for (let i = 0; i < this.strategies.length; i++) {
+      const strategy = this.strategies[i];
+      const strategyName = strategy.constructor.name;
+
+      this.logger.debug(
+        {
+          strategyIndex: i,
+          strategyName,
+          pendingRebalancesCount: currentContext.pendingRebalances.length,
+        },
+        'Executing strategy in composition',
+      );
+
+      // Execute the strategy with current context
+      const routes = strategy.getRebalancingRoutes(rawBalances, currentContext);
+
+      this.logger.debug(
+        {
+          strategyIndex: i,
+          strategyName,
+          routesCount: routes.length,
+        },
+        'Strategy produced routes',
+      );
+
+      // Add routes to the result
+      allRoutes.push(...routes);
+
+      // Add these routes to pendingRebalances for the next strategy
+      currentContext = {
+        pendingTransfers: currentContext.pendingTransfers,
+        pendingRebalances: [...currentContext.pendingRebalances, ...routes],
+      };
+    }
+
+    this.logger.info(
+      {
+        totalRoutes: allRoutes.length,
+        strategiesExecuted: this.strategies.length,
+      },
+      'CompositeStrategy completed',
+    );
+
+    return allRoutes;
+  }
+}


### PR DESCRIPTION
## Summary
- **CollateralDeficitStrategy**: Detects negative balances (deficits) after collateral reservation and proposes just-in-time rebalances using fast bridges (e.g., CCTP V2 Fast)
- **CompositeStrategy**: Chains multiple strategies together, passing routes from earlier strategies as `pendingRebalances` to later strategies

## Key Features

### CollateralDeficitStrategy
- Interprets negative balances as deficits requiring immediate attention
- Adds configurable per-chain buffer for headroom
- Only considers pending rebalances using the same bridge (allows fast bridge routes even when slower bridges are pending)
- Overrides `validateRawBalances` to allow negative balances
- Overrides `simulatePendingRebalances` to filter by bridge type

### CompositeStrategy
- Executes strategies in sequence
- Routes from earlier strategies are added to `pendingRebalances` for later strategies
- Enables patterns like: `CollateralDeficitStrategy (fast) → WeightedStrategy (standard)`

## Test Plan
- [x] 9 tests for CollateralDeficitStrategy (deficit detection, buffer handling, pending rebalance filtering)
- [x] 7 tests for CompositeStrategy (sequencing, route accumulation, context passing)
- [x] All 76 tests pass

## PR Chain
This is PR 3 of 4:
- PR 1: Inflight-Aware Infrastructure (#7679) ← merged
- PR 2: MessageTracker Implementation (#7680) ← base
- **PR 3: CollateralDeficit + Composite Strategies** ← this PR
- PR 4: RebalanceTracker + Executor (coming next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds two new rebalancing strategies that work together to handle collateral deficits:

**CollateralDeficitStrategy** detects negative balances (after collateral reservation) and proposes just-in-time rebalances using fast bridges. The strategy interprets negative balances as deficits requiring immediate attention, adds configurable per-chain buffers, and only considers pending rebalances using the same bridge type (allowing fast bridge routes even when slower bridges are pending).

**CompositeStrategy** chains multiple strategies together, executing them in sequence and passing routes from earlier strategies as `pendingRebalances` to later strategies. This enables patterns like "CollateralDeficitStrategy (fast) → WeightedStrategy (standard)" where deficit coverage happens via fast bridges first, then regular rebalancing fills in the gaps.

Both strategies extend/implement existing interfaces cleanly:
- `CollateralDeficitStrategy` extends `BaseStrategy` and overrides `validateRawBalances` (to allow negative balances) and `simulatePendingRebalances` (to filter by bridge)
- `CompositeStrategy` implements `IStrategy` and manages context propagation between sub-strategies

The implementation is well-structured with comprehensive test coverage (16 new tests total) covering deficit detection, buffer handling, bridge filtering, strategy sequencing, and route accumulation.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase, properly extends base classes, includes comprehensive test coverage with 16 new tests, and integrates cleanly with the existing rebalancer infrastructure. The logic for deficit detection and strategy composition is straightforward and well-tested.
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| typescript/rebalancer/src/strategy/CollateralDeficitStrategy.ts | Adds strategy to detect and address collateral deficits using fast bridges. Overrides validateRawBalances to allow negative balances and simulatePendingRebalances to filter by bridge type. Logic is sound and well-tested. |
| typescript/rebalancer/src/strategy/CompositeStrategy.ts | Implements strategy composition by chaining multiple strategies sequentially. Routes from earlier strategies pass as pendingRebalances to later ones. Clean implementation with proper context propagation. |
| typescript/rebalancer/src/strategy/CollateralDeficitStrategy.test.ts | Comprehensive test coverage with 9 tests covering deficit detection, buffer handling, bridge filtering, and collateral reservation. All edge cases properly tested. |
| typescript/rebalancer/src/strategy/CompositeStrategy.test.ts | Solid test coverage with 7 tests verifying strategy sequencing, route accumulation, and context passing. Uses mock strategies effectively to isolate behavior. |
| typescript/rebalancer/src/index.ts | Exports new strategies and types for public API. Clean addition following existing export patterns. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant RS as RebalancerService
    participant CS as CompositeStrategy
    participant CDS as CollateralDeficitStrategy
    participant WS as WeightedStrategy
    participant MT as MessageTracker
    participant BS as BaseStrategy

    Note over RS,MT: Phase 1: Gather Context
    RS->>MT: getInflightContext()
    MT-->>RS: {pendingTransfers, pendingRebalances}

    Note over RS,CS: Phase 2: Execute Composite Strategy
    RS->>CS: getRebalancingRoutes(rawBalances, inflightContext)
    
    Note over CS,CDS: Execute First Strategy (Fast Bridge)
    CS->>CDS: getRebalancingRoutes(rawBalances, inflightContext)
    CDS->>BS: [BaseStrategy.getRebalancingRoutes]
    
    Note over BS: Reserve collateral for pendingTransfers
    BS->>BS: reserveCollateral(rawBalances, pendingTransfers)
    Note over BS: Simulate pending rebalances (filtered by bridge)
    BS->>CDS: simulatePendingRebalances(adjustedBalances, pendingRebalances)
    CDS->>CDS: Filter to same-bridge rebalances only
    CDS-->>BS: sameBridgeRebalances
    BS->>BS: Apply simulation
    
    Note over BS: Categorize balances
    BS->>CDS: getCategorizedBalances(simulatedBalances, pendingRebalances)
    CDS->>CDS: Detect negative balances as deficits
    CDS->>CDS: Add buffer to deficits
    CDS->>CDS: Check if deficit covered by pending
    CDS-->>BS: {surpluses, deficits}
    
    Note over BS: Generate routes
    BS->>BS: Match surpluses to deficits
    BS->>BS: Scale if insufficient surplus
    
    BS-->>CDS: routes
    CDS->>CDS: Assign fast bridge to routes
    CDS-->>CS: fastBridgeRoutes
    
    Note over CS: Add fast routes to context
    CS->>CS: currentContext.pendingRebalances.push(...fastBridgeRoutes)
    
    Note over CS,WS: Execute Second Strategy (Standard Bridge)
    CS->>WS: getRebalancingRoutes(rawBalances, updatedContext)
    WS->>BS: [BaseStrategy.getRebalancingRoutes]
    
    Note over BS: Now sees fast bridge routes as pending
    BS->>BS: reserveCollateral()
    BS->>BS: simulatePendingRebalances(includes fast routes)
    BS->>WS: getCategorizedBalances()
    WS->>WS: Calculate weighted targets
    WS-->>BS: {surpluses, deficits}
    BS->>BS: Generate routes
    BS-->>WS: routes
    WS-->>CS: standardBridgeRoutes
    
    Note over CS: Combine all routes
    CS->>CS: allRoutes = [...fastBridgeRoutes, ...standardBridgeRoutes]
    CS-->>RS: allRoutes
    
    Note over RS: Execute rebalancing routes
    RS->>RS: executeRoutes(allRoutes)
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->