### PR TITLE
feat: Allow fetching aws signer keys with container provider

### DIFF
--- a/rust/main/hyperlane-base/src/settings/aws_credentials.rs
+++ b/rust/main/hyperlane-base/src/settings/aws_credentials.rs
@@ -21,7 +21,7 @@ use rusoto_sts::WebIdentityProvider;
 /// The IRSA approach follows security best practices and allows for key rotation.
 pub(crate) struct AwsChainCredentialsProvider {
     environment_provider: EnvironmentProvider,
-    container_provider: ContainerProvider,
+    container_provider: AutoRefreshingProvider<ContainerProvider>,
     web_identity_provider: AutoRefreshingProvider<WebIdentityProvider>,
 }
 


### PR DESCRIPTION
### Description

Adds support for `ContainerProvider` AWS Credentials which provides AWS credentials from a ECS task’s IAM role.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

Running the validator agent in ECS with a task role containing sufficient permissions, before this would fail due to a missing env var error when creating the AWS signer (because no access key or web id credentials were provided). After adding this the AWS resources are reachable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced AWS credential resolution: added support for container-based credentials (ECS/Fargate) and reordered the provider chain to prefer environment, then container, then web identity—improving credential discovery for containerized deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added support for AWS `ContainerProvider` credentials, enabling Hyperlane agents to authenticate using ECS task IAM roles when running in ECS/Fargate environments.

**Changes:**
- Added `ContainerProvider` as the second credential source in the fallback chain (between environment variables and web identity)
- Updated documentation to reflect the new credential order and explain ECS task role usage
- Improved code clarity with explicit comments for each credential source attempt

The credential chain now follows AWS best practices: Environment → ECS Container → Kubernetes IRSA. This eliminates the need for explicit AWS access keys when running validators/relayers in ECS with task roles.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>


- Safe to merge - straightforward credential provider addition with no logic errors
- The change follows AWS credential chain best practices by adding `ContainerProvider` between environment variables and web identity provider. The implementation is minimal, well-documented, and matches the existing pattern. No breaking changes or security concerns - just extends credential source support for ECS deployments
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| rust/main/hyperlane-base/src/settings/aws_credentials.rs | Added `ContainerProvider` for ECS task IAM role credentials with proper fallback chain |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent as Hyperlane Agent
    participant Provider as AwsChainCredentialsProvider
    participant EnvProv as EnvironmentProvider
    participant ContProv as ContainerProvider
    participant WebIdProv as WebIdentityProvider
    participant ECS as ECS Task Metadata
    participant STS as AWS STS

    Agent->>Provider: credentials()
    
    Provider->>EnvProv: credentials()
    alt Environment vars present
        EnvProv-->>Provider: Ok(creds)
        Provider-->>Agent: Ok(creds)
    else No environment vars
        EnvProv-->>Provider: Err
        
        Provider->>ContProv: credentials()
        alt ECS task role configured
            ContProv->>ECS: GET task metadata endpoint
            ECS-->>ContProv: credentials from IAM role
            ContProv-->>Provider: Ok(creds)
            Provider-->>Agent: Ok(creds)
        else Not in ECS or no task role
            ContProv-->>Provider: Err
            
            Provider->>WebIdProv: credentials()
            alt IRSA configured (K8s)
                WebIdProv->>STS: AssumeRoleWithWebIdentity
                STS-->>WebIdProv: temp credentials
                WebIdProv-->>Provider: Ok(creds)
                Provider-->>Agent: Ok(creds)
            else No IRSA
                WebIdProv-->>Provider: Err
                Provider-->>Agent: Err
            end
        end
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->