### PR TITLE
fix(widgets): change 'Id' to 'ID' in metadata modal labels

### DIFF
--- a/.changeset/fix-id-label-casing.md
+++ b/.changeset/fix-id-label-casing.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/widgets': patch
+---
+
+Updated 'Chain Id' and 'Domain Id' labels to use uppercase 'ID' in the chain details metadata modal for consistency.

--- a/typescript/widgets/src/chains/ChainDetailsMenu.tsx
+++ b/typescript/widgets/src/chains/ChainDetailsMenu.tsx
@@ -300,11 +300,11 @@ function ChainInfo({ chainMetadata }: { chainMetadata: ChainMetadata }) {
       <SectionHeader>Chain Information</SectionHeader>
       <div className="htw-grid htw-grid-cols-2 htw-gap-1.5">
         <div>
-          <SectionHeader className="htw-text-xs">Chain Id</SectionHeader>
+          <SectionHeader className="htw-text-xs">Chain ID</SectionHeader>
           <span className="htw-text-sm">{chainId}</span>
         </div>
         <div>
-          <SectionHeader className="htw-text-xs">Domain Id</SectionHeader>
+          <SectionHeader className="htw-text-xs">Domain ID</SectionHeader>
           <span className="htw-text-sm">{domainId}</span>
         </div>
         <div>


### PR DESCRIPTION
### Description

Fixes an inconsistency in the chain details metadata modal by updating 'Chain Id' and 'Domain Id' labels to use uppercase 'ID' for 'Chain ID' and 'Domain ID'.

### Drive-by changes

- Added a changeset file (`.changeset/fix-id-label-casing.md`) to document the patch version bump for `@hyperlane-xyz/widgets`.

### Related issues

- Fixes #12

### Backward compatibility

Yes

### Testing

Manual

---
<a href="https://cursor.com/background-agent?bcId=bc-eb751a8c-4fd7-4804-972a-39df17c59396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb751a8c-4fd7-4804-972a-39df17c59396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the casing of labels in the chain details modal to use uppercase "ID" for consistency ("Chain ID" and "Domain ID").

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Straightforward text label fix in the chain details metadata modal. Changed 'Chain Id' and 'Domain Id' to use proper 'ID' capitalization for consistency.

- Updated two SectionHeader labels in `ChainInfo` component
- Added proper changeset documenting the patch version bump

<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe as a wee lamb - just a text label change with zero functional impact
- Pure UI text change affecting only display labels. No logic changes, no security implications, no breaking changes. The changeset follows proper style guide formatting.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .changeset/fix-id-label-casing.md | Adds changeset documenting the patch version bump for correcting 'Chain Id' and 'Domain Id' casing to 'Chain ID' and 'Domain ID'. Follows proper past-tense style guide. |
| typescript/widgets/src/chains/ChainDetailsMenu.tsx | Updates two UI labels from 'Chain Id' to 'Chain ID' and 'Domain Id' to 'Domain ID' for consistent capitalization. No functional changes, no issues found. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant CDM as ChainDetailsMenu
    participant CI as ChainInfo Component
    participant SH as SectionHeader

    U->>CDM: Opens chain details modal
    CDM->>CI: Renders chain info section
    CI->>SH: Renders "Chain ID" label
    CI->>SH: Renders "Domain ID" label
    SH-->>U: Displays updated labels
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->