### PR TITLE
chore: remove Neutron from mantapacific

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getMantapacificTiaWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getMantapacificTiaWarpConfig.ts
@@ -11,20 +11,6 @@ export const getMantapacificTiaWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
   abacusWorksEnvOwnerConfig: ChainMap<OwnableConfig>,
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
-  const neutronRouter =
-    '0xc5fc6899019cb4a7649981d89eb7b1a0929d0a85b2d41802f3315129ad4b581a';
-  const neutronOwner =
-    'neutron1fqf5mprg3f5hytvzp3t7spmsum6rjrw80mq8zgkc0h6rxga0dtzqws3uu7';
-
-  // @ts-ignore - foreignDeployment configs don't conform to the HypTokenRouterConfig
-  const neutron: HypTokenRouterConfig = {
-    foreignDeployment: neutronRouter,
-    owner: neutronOwner,
-    type: TokenType.native,
-    decimals: 6,
-    gas: 0,
-  };
-
   const celestia: HypTokenRouterConfig = {
     ...routerConfig.celestia,
     ...abacusWorksEnvOwnerConfig.celestia,
@@ -48,15 +34,11 @@ export const getMantapacificTiaWarpConfig = async (
         address:
           '0x726f757465725f61707000000000000000000000000000010000000000000007',
       },
-      neutron: {
-        address: neutronRouter,
-      },
     },
   };
 
   return {
     mantapacific,
-    neutron,
     celestia,
   };
 };


### PR DESCRIPTION
### Description
This PR remove neutron from mantapacific

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Removed neutron from mantapacific's `remoteRouters` config but the cleanup's only halfway done.

- Neutron removed from mantapacific's remote router list (line 47-52)
- Added unused import for `getGnosisSafeBuilderStrategyConfigGenerator` (line 9)
- Neutron config still defined (lines 15-27) but orphaned
- Neutron still returned in the chain map (line 57) even though it's not connected to mantapacific anymore

The import on line 9 looks like it was added by accident since it's not used anywhere in the file.

<details><summary><h3>Confidence Score: 2/5</h3></summary>


- Incomplete removal leaves dead code and unused config
- The change only partially removes neutron - it's taken out of remoteRouters but the config definition and return value remain, creating dead code that'll confuse anyone looking at this later
- typescript/infra/config/environments/mainnet3/warp/configGetters/getMantapacificTiaWarpConfig.ts needs complete neutron removal
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| typescript/infra/config/environments/mainnet3/warp/configGetters/getMantapacificTiaWarpConfig.ts | Removed neutron from remoteRouters but still defines and returns neutron config |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant getMantapacificTiaWarpConfig
    participant RouterConfig
    participant ReturnedConfig

    Caller->>getMantapacificTiaWarpConfig: Call with routerConfig & ownerConfig
    getMantapacificTiaWarpConfig->>getMantapacificTiaWarpConfig: Define neutron config (unused)
    getMantapacificTiaWarpConfig->>RouterConfig: Extract celestia config
    RouterConfig-->>getMantapacificTiaWarpConfig: celestia data
    getMantapacificTiaWarpConfig->>RouterConfig: Extract mantapacific config
    RouterConfig-->>getMantapacificTiaWarpConfig: mantapacific data
    getMantapacificTiaWarpConfig->>getMantapacificTiaWarpConfig: Set mantapacific remoteRouters (only celestia)
    getMantapacificTiaWarpConfig->>ReturnedConfig: Return mantapacific, neutron, celestia
    Note over ReturnedConfig: neutron still returned but not used in remoteRouters
    ReturnedConfig-->>Caller: ChainMap with 3 chains
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->