### PR TITLE
fix(infra): add token price overrides to prevent CoinGecko overwrites

### DIFF
--- a/typescript/infra/config/environments/mainnet3/chains.ts
+++ b/typescript/infra/config/environments/mainnet3/chains.ts
@@ -47,6 +47,11 @@ export const agentSpecificChainMetadataOverrides: ChainMap<
   },
 };
 
+// Chains without CoinGecko listings - these won't be overwritten by print-token-prices.ts
+export const tokenPriceOverrides: ChainMap<string> = {
+  incentiv: '0.002',
+};
+
 export const chainMetadataOverrides: ChainMap<Partial<ChainMetadata>> = {
   kyve: {
     gasPrice: {

--- a/typescript/infra/config/environments/testnet4/chains.ts
+++ b/typescript/infra/config/environments/testnet4/chains.ts
@@ -12,6 +12,9 @@ export const ethereumChainNames = supportedChainNames.filter(
   isEthereumProtocolChain,
 );
 
+// Chains without CoinGecko listings - these won't be overwritten by print-token-prices.ts
+export const tokenPriceOverrides: ChainMap<string> = {};
+
 export const chainMetadataOverrides: ChainMap<Partial<ChainMetadata>> = {
   bsctestnet: {
     transactionOverrides: {


### PR DESCRIPTION
## Summary

- Added `tokenPriceOverrides` config in `chains.ts` for mainnet3/testnet4 environments
- Modified `print-token-prices.ts` to apply overrides before CoinGecko/default fallback
- Added Incentiv with `0.002` USD price override

## Problem

Chains without CoinGecko listings (like Incentiv) were having their manually-set token prices in `tokenPrices.json` overwritten with default $1.00 values when `print-token-prices.ts --write` was run. This caused:

1. Incorrect IGP exchange rates (e.g., 4,782,385 instead of ~9,564)
2. Inflated bridging fees (e.g., ~$4.80 instead of ~$0.22 for ETH→Incentiv)

## Solution

Token prices in `tokenPriceOverrides` now take precedence over CoinGecko fetched prices and default fallbacks, preventing accidental overwrites of manually-managed prices.

## Testing

```bash
pnpm tsx scripts/print-token-prices.ts -e mainnet3 | grep incentiv
# Output: Using override price for incentiv: 0.002
#         "incentiv": "0.002",
```

## Follow-up Required

After merging, need to:
1. Run `pnpm tsx scripts/print-token-prices.ts -e mainnet3 --write` to update tokenPrices.json
2. Run IGP update script to push corrected exchange rate on-chain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced token price override support for blockchain networks without CoinGecko listings
  * Enhanced token pricing system to prioritize manual overrides over computed prices
  * Added override configurations across environments to ensure consistent and accurate pricing data

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Introduced `tokenPriceOverrides` config that takes precedence over CoinGecko API responses and default fallbacks when running the `print-token-prices.ts` script. This prevents manually-configured token prices (like incentiv's 0.002 USD) from being overwritten by the default $1.00 fallback when chains lack CoinGecko listings.

The implementation adds the override check at line 107-114 in `print-token-prices.ts:107:114`, immediately after fetching CoinGecko prices but before any fallback logic. This ensures override prices bypass both the CoinGecko data and the `shouldUpdatePrice` threshold check, preserving manually-set values for chains without public token listings.

<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with no risk
- Implementation is clean, well-scoped, and solves the stated problem without introducing side effects. The override logic correctly takes precedence before fallback paths, and the approach follows existing patterns in the codebase.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| typescript/infra/scripts/print-token-prices.ts | Added early return for override prices before CoinGecko fetch, preventing manual prices from being overwritten by defaults |
| typescript/infra/config/environments/mainnet3/chains.ts | Added `tokenPriceOverrides` map with incentiv set to 0.002 USD for chains without CoinGecko listings |
| typescript/infra/config/environments/testnet4/chains.ts | Added empty `tokenPriceOverrides` map structure for consistency with mainnet3 configuration |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Script as print-token-prices.ts
    participant Config as chains.ts (mainnet3/testnet4)
    participant CoinGecko as CoinGecko API
    participant File as tokenPrices.json
    
    Script->>Config: Import tokenPriceOverrides
    Script->>CoinGecko: Fetch prices for all chain tokens
    CoinGecko-->>Script: Return price data (or missing)
    
    loop For each chain
        alt Has tokenPriceOverride
            Script->>Script: Use override price (0.002 for incentiv)
            Note over Script: Skip CoinGecko & shouldUpdatePrice logic
        else No override
            Script->>Script: Check CoinGecko response
            alt CoinGecko has price
                Script->>Script: Compare with previous price
                Script->>Script: Apply shouldUpdatePrice threshold check
            else CoinGecko missing
                Script->>Script: Use default fallback ($1 mainnet3, $10 testnet4)
            end
        end
    end
    
    alt --write flag set
        Script->>File: Write updated prices to tokenPrices.json
    else No write flag
        Script->>Script: Print prices to console
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->