### PR TITLE
fix(infra): rename fuse to fusemainnet in merkly-erc20-addresses.json

### DIFF
--- a/typescript/infra/config/environments/mainnet3/misc-artifacts/merkly-erc20-addresses.json
+++ b/typescript/infra/config/environments/mainnet3/misc-artifacts/merkly-erc20-addresses.json
@@ -8,7 +8,7 @@
   "avalanche": {
     "router": "0x904550e0D182cd4aEe0D305891c666a212EC8F01"
   },
-  "fuse": {
+  "fusemainnet": {
     "router": "0xCd8EAE908E27b9046ca7845DA22f6d3cdf367588"
   },
   "kaia": {


### PR DESCRIPTION
## Summary

- Fixes the `agent-configs` CI test that was broken by PR #7711

## Root Cause

PR #7711 changed the import for `merklyErc20Addresses` from `merkly-eth-addresses.json` to `merkly-erc20-addresses.json`. However, the latter file contained `"fuse"` as a chain name when the registry expects `"fusemainnet"`.

This caused the agent-configs CI test to fail with:
```
Failed to update agent config Error: Chain not found: fuse
    at getDomainId (typescript/infra/config/registry.ts:90:17)
    at matchingList (typescript/infra/src/config/agent/relayer.ts:374:28)
```

## Test plan

- [x] Verify `pnpm tsx ./scripts/agents/update-agent-config.ts -e mainnet3` completes successfully
- [ ] CI `agent-configs` test should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network configuration identifier for Fuse mainnet token addresses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->