### PR TITLE
fix: only use proving urls for aleo mainnet

### DIFF
--- a/rust/main/helm/hyperlane-agent/templates/external-secret.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/external-secret.yaml
@@ -30,7 +30,7 @@ spec:
         {{- if or (eq .protocol "cosmos") (eq .protocol "cosmosnative") }}
         HYP_CHAINS_{{ .name | upper }}_CUSTOMGRPCURLS: {{ printf "'{{ .%s_grpcs | mustFromJson | join \",\" }}'" .name }}
         {{- end }}
-        {{- if eq .protocol "aleo" }}
+        {{- if and (eq .protocol "aleo") (eq .name "aleo") }}
         HYP_CHAINS_{{ .name | upper }}_CUSTOMPROVINGSERVICEURLS: {{ printf "'{{ .%s_proving_urls | default \"[]\" | mustFromJson | join \",\" }}'" .name }}
         {{- end }}
         {{- if eq .protocol "sealevel" }}
@@ -56,7 +56,7 @@ spec:
     remoteRef:
       key: {{ printf "%s-grpc-endpoints-%s" $.Values.hyperlane.runEnv .name }}
   {{- end }}
-  {{- if eq .protocol "aleo" }}
+  {{- if and (eq .protocol "aleo") (eq .name "aleo") }}
   - secretKey: {{ printf "%s_proving_urls" .name }}
     remoteRef:
       key: {{ printf "%s-proving-endpoints-%s" $.Values.hyperlane.runEnv .name }}


### PR DESCRIPTION
### Description

We only have proving urls set for Aleo mainnet, so we should only generate secrets with this for mainnet aleo

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed the Helm template to only generate proving URL configuration for mainnet Aleo (`name: "aleo"`), not for testnet (`name: "aleotestnet"`). The change adds a name check alongside the protocol check, preventing attempts to fetch proving endpoints that only exist for mainnet.

<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with no risk
- The change is a simple, focused condition tightening that correctly addresses the issue described. It adds a name check to ensure proving URLs are only configured for mainnet aleo where they actually exist, preventing configuration errors for aleotestnet
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| rust/main/helm/hyperlane-agent/templates/external-secret.yaml | Narrows proving URL condition to only mainnet `aleo`, preventing incorrect config generation for `aleotestnet` |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Helm as Helm Chart
    participant ES as ExternalSecret
    participant SM as Secret Manager
    participant Agent as Hyperlane Agent
    
    Note over Helm: Process chains config
    
    alt Chain protocol == "aleo" AND name == "aleo"
        Helm->>ES: Generate proving URL env vars<br/>for mainnet aleo only
        ES->>SM: Fetch proving endpoints<br/>(optional: true)
        SM-->>ES: Return proving URLs
        ES->>Agent: Set HYP_CHAINS_ALEO_CUSTOMPROVINGSERVICEURLS
    else Chain protocol == "aleo" AND name != "aleo"
        Note over Helm,Agent: Skip proving URL config<br/>for aleotestnet
    end
    
    Note over Agent: Agent uses proving URLs<br/>only for mainnet operations
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined configuration logic for Aleo chain service URL provisioning. Service URLs are now generated only when both protocol and chain name match "aleo", reducing unnecessary configuration entries and streamlining deployment settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->