### PR TITLE
chore(infra): update SVM gas oracle configs

### DIFF
--- a/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
+++ b/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
@@ -2,95 +2,95 @@
   "solanamainnet": {
     "abstract": {
       "oracleConfig": {
-        "tokenExchangeRate": "347026904130352406214",
-        "gasPrice": "113810340",
+        "tokenExchangeRate": "349095867032722415967",
+        "gasPrice": "110768502",
         "tokenDecimals": 18
       },
       "overhead": 333774
     },
     "apechain": {
       "oracleConfig": {
-        "tokenExchangeRate": "40228419856006062",
-        "gasPrice": "1737216389910",
+        "tokenExchangeRate": "23762039029457594",
+        "gasPrice": "2879514755447",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "arbitrum": {
       "oracleConfig": {
-        "tokenExchangeRate": "347026904130352406214",
-        "gasPrice": "201383436",
+        "tokenExchangeRate": "349095867032722415967",
+        "gasPrice": "196001009",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "artela": {
       "oracleConfig": {
-        "tokenExchangeRate": "21006820765441",
-        "gasPrice": "3326798999923175",
+        "tokenExchangeRate": "20567262743934",
+        "gasPrice": "3326798653603196",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "avalanche": {
       "oracleConfig": {
-        "tokenExchangeRate": "1674497915877226222",
-        "gasPrice": "41735179036",
+        "tokenExchangeRate": "1569340357646360466",
+        "gasPrice": "43599937816",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "base": {
       "oracleConfig": {
-        "tokenExchangeRate": "347026904130352406214",
-        "gasPrice": "201383436",
+        "tokenExchangeRate": "349095867032722415967",
+        "gasPrice": "196001009",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "bsc": {
       "oracleConfig": {
-        "tokenExchangeRate": "106544903372489579386",
-        "gasPrice": "655925043",
+        "tokenExchangeRate": "98863990502337315426",
+        "gasPrice": "692093670",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "carrchain": {
       "oracleConfig": {
-        "tokenExchangeRate": "79785903751421",
-        "gasPrice": "875912498676057",
+        "tokenExchangeRate": "57167396304815",
+        "gasPrice": "1196890997798684",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "celestia": {
       "oracleConfig": {
-        "tokenExchangeRate": "8966225843122",
-        "gasPrice": "2601",
+        "tokenExchangeRate": "6261456555613",
+        "gasPrice": "3647",
         "tokenDecimals": 6
       },
       "overhead": 600000
     },
     "eclipsemainnet": {
       "oracleConfig": {
-        "tokenExchangeRate": "34702690413035240",
-        "gasPrice": "1680",
+        "tokenExchangeRate": "34909586703272241",
+        "gasPrice": "1636",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
     "electroneum": {
       "oracleConfig": {
-        "tokenExchangeRate": "228816218264494",
-        "gasPrice": "305421839606021",
+        "tokenExchangeRate": "132900868145729",
+        "gasPrice": "514843454068300",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "ethereum": {
       "oracleConfig": {
-        "tokenExchangeRate": "347026904130352406214",
+        "tokenExchangeRate": "349095867032722415967",
         "gasPrice": "2500000000",
         "tokenDecimals": 18
       },
@@ -98,128 +98,104 @@
     },
     "everclear": {
       "oracleConfig": {
-        "tokenExchangeRate": "347026904130352406214",
-        "gasPrice": "201383436",
-        "tokenDecimals": 18
-      },
-      "overhead": 166887
-    },
-    "flowmainnet": {
-      "oracleConfig": {
-        "tokenExchangeRate": "28812277377794619",
-        "gasPrice": "2425544825829",
-        "tokenDecimals": 18
-      },
-      "overhead": 166887
-    },
-    "form": {
-      "oracleConfig": {
-        "tokenExchangeRate": "347026904130352406214",
-        "gasPrice": "201383436",
+        "tokenExchangeRate": "349095867032722415967",
+        "gasPrice": "196001009",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "galactica": {
       "oracleConfig": {
-        "tokenExchangeRate": "3210468359226980",
-        "gasPrice": "21767998464518",
+        "tokenExchangeRate": "4113159827854863",
+        "gasPrice": "16635177058147",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "hyperevm": {
       "oracleConfig": {
-        "tokenExchangeRate": "4378931413414172034",
-        "gasPrice": "15959480457",
+        "tokenExchangeRate": "2859315871484751799",
+        "gasPrice": "23929899697",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "incentiv": {
       "oracleConfig": {
-        "tokenExchangeRate": "113679424024251610",
-        "gasPrice": "614759187196",
+        "tokenExchangeRate": "333902203754544",
+        "gasPrice": "204919707733111",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "ink": {
       "oracleConfig": {
-        "tokenExchangeRate": "347026904130352406214",
-        "gasPrice": "201383436",
+        "tokenExchangeRate": "349095867032722415967",
+        "gasPrice": "196001009",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "litchain": {
       "oracleConfig": {
-        "tokenExchangeRate": "4365813944676013",
-        "gasPrice": "16007432107651",
-        "tokenDecimals": 18
-      },
-      "overhead": 166887
-    },
-    "mint": {
-      "oracleConfig": {
-        "tokenExchangeRate": "347026904130352406214",
-        "gasPrice": "201383436",
+        "tokenExchangeRate": "2237178155375825",
+        "gasPrice": "30584574518756",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "mode": {
       "oracleConfig": {
-        "tokenExchangeRate": "347026904130352406214",
-        "gasPrice": "201383436",
+        "tokenExchangeRate": "349095867032722415967",
+        "gasPrice": "196001009",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "optimism": {
       "oracleConfig": {
-        "tokenExchangeRate": "347026904130352406214",
-        "gasPrice": "201383436",
+        "tokenExchangeRate": "349095867032722415967",
+        "gasPrice": "196001009",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "paradex": {
       "oracleConfig": {
-        "tokenExchangeRate": "113679424024251610",
-        "gasPrice": "987653896",
+        "tokenExchangeRate": "111300734584848260",
+        "gasPrice": "987653793",
         "tokenDecimals": 18
       },
       "overhead": 130000000
     },
     "polygon": {
       "oracleConfig": {
-        "tokenExchangeRate": "16561841606669192",
-        "gasPrice": "4219667834880",
+        "tokenExchangeRate": "13390925280106848",
+        "gasPrice": "5109664983829",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "pulsechain": {
       "oracleConfig": {
-        "tokenExchangeRate": "2408866995074",
-        "gasPrice": "29011759660017106",
+        "tokenExchangeRate": "1647250871855",
+        "gasPrice": "41537778594568421",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "radix": {
       "oracleConfig": {
-        "tokenExchangeRate": "282187571049640",
-        "gasPrice": "1755339420081",
+        "tokenExchangeRate": "168566075536098",
+        "gasPrice": "2877033589918",
         "tokenDecimals": 18
       },
       "overhead": 600000
     },
     "solaxy": {
       "oracleConfig": {
-        "tokenExchangeRate": "2265517241",
-        "gasPrice": "25732375",
+        "tokenExchangeRate": "1962565852",
+        "gasPrice": "29082995",
         "tokenDecimals": 6
       },
       "overhead": 600000
@@ -227,38 +203,38 @@
     "sonicsvm": {
       "oracleConfig": {
         "tokenExchangeRate": "1500000000000000",
-        "gasPrice": "38865",
+        "gasPrice": "38052",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
     "soon": {
       "oracleConfig": {
-        "tokenExchangeRate": "34702690413035240",
-        "gasPrice": "1680",
+        "tokenExchangeRate": "34909586703272241",
+        "gasPrice": "1636",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
     "sophon": {
       "oracleConfig": {
-        "tokenExchangeRate": "2048812428950360",
-        "gasPrice": "19277142822057",
+        "tokenExchangeRate": "1518385768346071",
+        "gasPrice": "25467062935997",
         "tokenDecimals": 18
       },
       "overhead": 333774
     },
     "starknet": {
       "oracleConfig": {
-        "tokenExchangeRate": "347026904130352406214",
-        "gasPrice": "323537",
+        "tokenExchangeRate": "349095867032722415967",
+        "gasPrice": "314890",
         "tokenDecimals": 18
       },
       "overhead": 130000000
     },
     "subtensor": {
       "oracleConfig": {
-        "tokenExchangeRate": "35956801818870784388",
+        "tokenExchangeRate": "29406767084662758774",
         "gasPrice": "10000000000",
         "tokenDecimals": 18
       },
@@ -266,32 +242,24 @@
     },
     "superseed": {
       "oracleConfig": {
-        "tokenExchangeRate": "347026904130352406214",
-        "gasPrice": "201383436",
+        "tokenExchangeRate": "349095867032722415967",
+        "gasPrice": "196001009",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
-    "svmbnb": {
-      "oracleConfig": {
-        "tokenExchangeRate": "10654490337248957",
-        "gasPrice": "5472",
-        "tokenDecimals": 9
-      },
-      "overhead": 600000
-    },
     "unichain": {
       "oracleConfig": {
-        "tokenExchangeRate": "347026904130352406214",
-        "gasPrice": "201383436",
+        "tokenExchangeRate": "349095867032722415967",
+        "gasPrice": "196001009",
         "tokenDecimals": 18
       },
       "overhead": 166887
     },
     "worldchain": {
       "oracleConfig": {
-        "tokenExchangeRate": "347026904130352406214",
-        "gasPrice": "201383436",
+        "tokenExchangeRate": "349095867032722415967",
+        "gasPrice": "196001009",
         "tokenDecimals": 18
       },
       "overhead": 166887
@@ -301,7 +269,7 @@
     "arbitrum": {
       "oracleConfig": {
         "tokenExchangeRate": "15000000000000000000",
-        "gasPrice": "201780160",
+        "gasPrice": "196387324",
         "tokenDecimals": 18
       },
       "overhead": 166460
@@ -309,15 +277,15 @@
     "base": {
       "oracleConfig": {
         "tokenExchangeRate": "15000000000000000000",
-        "gasPrice": "201780160",
+        "gasPrice": "196387324",
         "tokenDecimals": 18
       },
       "overhead": 166460
     },
     "celestia": {
       "oracleConfig": {
-        "tokenExchangeRate": "387558964581",
-        "gasPrice": "2601",
+        "tokenExchangeRate": "269043140305",
+        "gasPrice": "3647",
         "tokenDecimals": 6
       },
       "overhead": 600000
@@ -333,23 +301,39 @@
     "katana": {
       "oracleConfig": {
         "tokenExchangeRate": "15000000000000000000",
-        "gasPrice": "201780160",
+        "gasPrice": "196387324",
+        "tokenDecimals": 18
+      },
+      "overhead": 166460
+    },
+    "optimism": {
+      "oracleConfig": {
+        "tokenExchangeRate": "15000000000000000000",
+        "gasPrice": "196387324",
+        "tokenDecimals": 18
+      },
+      "overhead": 166460
+    },
+    "polygon": {
+      "oracleConfig": {
+        "tokenExchangeRate": "575383148786390",
+        "gasPrice": "5119736049984",
         "tokenDecimals": 18
       },
       "overhead": 166460
     },
     "solanamainnet": {
       "oracleConfig": {
-        "tokenExchangeRate": "64836471559416",
-        "gasPrice": "93276",
+        "tokenExchangeRate": "64452209621522",
+        "gasPrice": "91324",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
     "sonicsvm": {
       "oracleConfig": {
-        "tokenExchangeRate": "64836471559416",
-        "gasPrice": "38865",
+        "tokenExchangeRate": "64452209621522",
+        "gasPrice": "38052",
         "tokenDecimals": 9
       },
       "overhead": 600000
@@ -357,25 +341,33 @@
     "soon": {
       "oracleConfig": {
         "tokenExchangeRate": "1500000000000000",
-        "gasPrice": "1680",
+        "gasPrice": "1635",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
     "stride": {
       "oracleConfig": {
-        "tokenExchangeRate": "33079621840",
-        "gasPrice": "30471",
+        "tokenExchangeRate": "15315254853",
+        "gasPrice": "64054",
         "tokenDecimals": 6
       },
       "overhead": 600000
+    },
+    "unichain": {
+      "oracleConfig": {
+        "tokenExchangeRate": "15000000000000000000",
+        "gasPrice": "196387324",
+        "tokenDecimals": 18
+      },
+      "overhead": 166460
     }
   },
   "soon": {
     "bsc": {
       "oracleConfig": {
-        "tokenExchangeRate": "4605330398207476709",
-        "gasPrice": "678287167",
+        "tokenExchangeRate": "4248001759917870499",
+        "gasPrice": "715689582",
         "tokenDecimals": 18
       },
       "overhead": 159736
@@ -383,23 +375,15 @@
     "eclipsemainnet": {
       "oracleConfig": {
         "tokenExchangeRate": "1500000000000000",
-        "gasPrice": "1680",
+        "gasPrice": "1635",
         "tokenDecimals": 9
       },
       "overhead": 600000
     },
     "solanamainnet": {
       "oracleConfig": {
-        "tokenExchangeRate": "64836471559416",
-        "gasPrice": "93276",
-        "tokenDecimals": 9
-      },
-      "overhead": 600000
-    },
-    "svmbnb": {
-      "oracleConfig": {
-        "tokenExchangeRate": "460533039820747",
-        "gasPrice": "5472",
+        "tokenExchangeRate": "64452209621522",
+        "gasPrice": "91324",
         "tokenDecimals": 9
       },
       "overhead": 600000
@@ -408,8 +392,8 @@
   "sonicsvm": {
     "eclipsemainnet": {
       "oracleConfig": {
-        "tokenExchangeRate": "34702690413035240",
-        "gasPrice": "1680",
+        "tokenExchangeRate": "34909586703272241",
+        "gasPrice": "1636",
         "tokenDecimals": 9
       },
       "overhead": 600000
@@ -417,7 +401,7 @@
     "solanamainnet": {
       "oracleConfig": {
         "tokenExchangeRate": "1500000000000000",
-        "gasPrice": "93276",
+        "gasPrice": "91324",
         "tokenDecimals": 9
       },
       "overhead": 600000

--- a/typescript/infra/scripts/sealevel-helpers/print-gas-oracles.ts
+++ b/typescript/infra/scripts/sealevel-helpers/print-gas-oracles.ts
@@ -125,6 +125,9 @@ function getChainConnections(
       ['eclipsemainnet', 'sonicsvm'],
       ['eclipsemainnet', 'soon'],
       ['eclipsemainnet', 'katana'],
+      ['eclipsemainnet', 'unichain'],
+      ['eclipsemainnet', 'optimism'],
+      ['eclipsemainnet', 'polygon'],
       // for solaxy routes
       ['solaxy', 'solanamainnet'],
       ['solaxy', 'ethereum'],


### PR DESCRIPTION
## Summary
- Updated token exchange rates and gas prices for SVM chains
- Removed deprecated chains (flowmainnet, form, mint, svmbnb) from gas oracle configs
- Added eclipse connections for optimism, polygon, unichain

## Test plan
- [ ] Verify gas oracle configs are valid JSON
- [ ] Confirm deprecated chains are correctly removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Routine gas oracle config update that refreshes token exchange rates and gas prices across SVM chains, removes four deprecated chains (`flowmainnet`, `form`, `mint`, `svmbnb`) from Solana routes, and adds three new eclipse connections (`optimism`, `polygon`, `unichain`).

- Updated exchange rates and gas prices for 30+ chain routes from `solanamainnet`
- Added eclipse connections for `optimism`, `polygon`, and `unichain` in the helper script
- Removed gas oracle configs for `flowmainnet`, `form`, `mint`, and `svmbnb` 

Worth noting: `flowmainnet` still appears in governance configs and there's a TRUMP warp route referencing both `flowmainnet` and `form`. If these chains are being fully deprecated, those configs might need cleanup too.

<details><summary><h3>Confidence Score: 4/5</h3></summary>


- This PR is safe to merge - it's a routine gas oracle config update with properly formatted JSON
- Score reflects straightforward config updates with valid JSON structure. Small concern about potential config inconsistencies with removed chains still referenced elsewhere, but this doesn't affect functionality
- No files require special attention - both changes are routine maintenance updates
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| rust/sealevel/environments/mainnet3/gas-oracle-configs.json | Updated gas prices and token exchange rates for SVM chains; removed deprecated chains (flowmainnet, form, mint, svmbnb) |
| typescript/infra/scripts/sealevel-helpers/print-gas-oracles.ts | Added eclipse connections for optimism, polygon, and unichain chains |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Script as print-gas-oracles.ts
    participant Config as gas-oracle-configs.json
    participant Oracle as Gas Oracle System
    
    Dev->>Script: Run gas oracle update script
    Note over Script: Fetches latest gas prices<br/>and token exchange rates
    Script->>Config: Generate updated configs
    Note over Config: solanamainnet routes:<br/>- Updated rates for 30+ chains<br/>- Removed: flowmainnet, form, mint, svmbnb
    Note over Config: eclipsemainnet routes:<br/>- Added: optimism, polygon, unichain<br/>- Updated existing routes
    Note over Config: soon, sonicsvm, solaxy routes:<br/>- Updated gas prices
    Dev->>Config: Commit updated configs
    Config->>Oracle: Deploy to SVM chains
    Oracle->>Oracle: Calculate cross-chain gas costs<br/>using new rates
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->