### PR TITLE
feat(infra): add --forceRegistryConfig flag to check-deploy

### DIFF
--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -285,6 +285,7 @@ export async function getWarpConfig(
   envConfig: EnvironmentConfig,
   warpRouteId: string,
   registryUris = [DEFAULT_REGISTRY_URI],
+  forceRegistryConfig = false,
 ): Promise<ChainMap<HypTokenRouterConfig>> {
   const routerConfig = await getRouterConfigsForAllVms(
     envConfig,
@@ -309,7 +310,7 @@ export async function getWarpConfig(
   });
 
   const warpConfigGetter = warpConfigGetterMap[warpRouteId];
-  if (warpConfigGetter) {
+  if (warpConfigGetter && !forceRegistryConfig) {
     return warpConfigGetter(
       routerConfigWithoutOwner,
       abacusWorksEnvOwnerConfig,

--- a/typescript/infra/scripts/check/check-deploy.ts
+++ b/typescript/infra/scripts/check/check-deploy.ts
@@ -15,6 +15,7 @@ async function main() {
     govern,
     warpRouteId,
     registry,
+    forceRegistryConfig,
   } = await getCheckDeployArgs().argv;
 
   const governor = await getGovernor(
@@ -28,6 +29,7 @@ async function main() {
     govern,
     undefined,
     registry,
+    forceRegistryConfig,
   );
 
   if (fork) {

--- a/typescript/infra/scripts/check/check-utils.ts
+++ b/typescript/infra/scripts/check/check-utils.ts
@@ -65,7 +65,13 @@ export function getCheckWarpDeployArgs() {
 }
 
 export function getCheckDeployArgs() {
-  return withRegistryUris(withWarpRouteId(withModule(getCheckBaseArgs())));
+  return withRegistryUris(withWarpRouteId(withModule(getCheckBaseArgs())))
+    .describe(
+      'forceRegistryConfig',
+      'Force using registry YAML config instead of config getter',
+    )
+    .boolean('forceRegistryConfig')
+    .default('forceRegistryConfig', false);
 }
 
 const ICA_ENABLED_MODULES = [
@@ -85,6 +91,7 @@ export async function getGovernor(
   govern?: boolean,
   multiProvider: MultiProvider | undefined = undefined,
   registryUris?: string[],
+  forceRegistryConfig?: boolean,
 ) {
   const envConfig = getEnvironmentConfig(environment);
   // If the multiProvider is not passed in, get it from the environment
@@ -247,6 +254,7 @@ export async function getGovernor(
       envConfig,
       warpRouteId,
       registryUris,
+      forceRegistryConfig,
     ).catch((error) => {
       console.log(
         `Fetching warp route deploy config failed for ${warpRouteId}. Exiting with error: ${error}`,


### PR DESCRIPTION
## Summary
- Adds `--forceRegistryConfig` flag to `check-deploy.ts` that bypasses config getters and reads directly from registry YAML
- Useful for validating registry changes against on-chain state independent of what config getters define

## Context
This addresses the issue where warp route config getters can define chains that aren't yet enrolled on-chain. When registry CI runs `check-deploy.ts`, it should validate that the **registry YAML** matches on-chain state, not what the config getter says.

The recent USDC/paradex + hyperevm issue occurred because:
1. Config getter in monorepo had hyperevm in `deploymentChains`
2. Registry YAML was updated to include hyperevm
3. On-chain enrollment wasn't complete
4. CI checked config getter vs on-chain (which would fail), but the registry YAML vs on-chain check wasn't happening

With this flag, registry CI can run:
```bash
check-deploy.ts -m warp --warpRouteId USDC/paradex --forceRegistryConfig
```

This ensures registry YAML is validated against on-chain state directly.

## Testing
- TypeScript compiles without new errors
- Flag is wired through: `getCheckDeployArgs()` → `getGovernor()` → `getWarpConfig()`