### PR TITLE
fix(infra): add aleo-sdk to service Dockerfiles and update post-bundle scripts

### DIFF
--- a/typescript/ccip-server/Dockerfile
+++ b/typescript/ccip-server/Dockerfile
@@ -35,6 +35,7 @@ COPY typescript/utils/package.json ./typescript/utils/
 COPY typescript/cosmos-sdk/package.json ./typescript/cosmos-sdk/
 COPY typescript/cosmos-types/package.json ./typescript/cosmos-types/
 COPY typescript/radix-sdk/package.json ./typescript/radix-sdk/
+COPY typescript/aleo-sdk/package.json ./typescript/aleo-sdk/
 COPY typescript/tsconfig/package.json ./typescript/tsconfig/
 COPY typescript/eslint-config/package.json ./typescript/eslint-config/
 COPY solidity/package.json ./solidity/
@@ -62,6 +63,7 @@ COPY typescript/utils ./typescript/utils
 COPY typescript/cosmos-sdk ./typescript/cosmos-sdk
 COPY typescript/cosmos-types ./typescript/cosmos-types
 COPY typescript/radix-sdk ./typescript/radix-sdk
+COPY typescript/aleo-sdk ./typescript/aleo-sdk
 COPY typescript/tsconfig ./typescript/tsconfig
 COPY typescript/eslint-config ./typescript/eslint-config
 COPY solidity ./solidity

--- a/typescript/rebalancer/Dockerfile
+++ b/typescript/rebalancer/Dockerfile
@@ -35,6 +35,7 @@ COPY typescript/utils/package.json ./typescript/utils/
 COPY typescript/cosmos-sdk/package.json ./typescript/cosmos-sdk/
 COPY typescript/cosmos-types/package.json ./typescript/cosmos-types/
 COPY typescript/radix-sdk/package.json ./typescript/radix-sdk/
+COPY typescript/aleo-sdk/package.json ./typescript/aleo-sdk/
 COPY typescript/tsconfig/package.json ./typescript/tsconfig/
 COPY typescript/eslint-config/package.json ./typescript/eslint-config/
 COPY solidity/package.json ./solidity/
@@ -53,6 +54,7 @@ COPY typescript/utils ./typescript/utils
 COPY typescript/cosmos-sdk ./typescript/cosmos-sdk
 COPY typescript/cosmos-types ./typescript/cosmos-types
 COPY typescript/radix-sdk ./typescript/radix-sdk
+COPY typescript/aleo-sdk ./typescript/aleo-sdk
 COPY typescript/tsconfig ./typescript/tsconfig
 COPY typescript/eslint-config ./typescript/eslint-config
 COPY solidity ./solidity

--- a/typescript/rebalancer/scripts/ncc.post-bundle.mjs
+++ b/typescript/rebalancer/scripts/ncc.post-bundle.mjs
@@ -6,33 +6,55 @@ import { readFile, writeFile } from 'fs/promises';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const outputFile = path.join(__dirname, '..', 'bundle', 'index.js');
+const OUTPUT_FILE = path.join(__dirname, '..', 'bundle', 'index.js');
+const SHEBANG = '#!/usr/bin/env node';
 
-const shebang = '#!/usr/bin/env node';
-const dirnameDef = `import { fileURLToPath } from 'url';
+const DIRNAME_SHIM = `
+import { fileURLToPath, pathToFileURL } from 'url';
 import path from 'path';
+
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);`;
+const __dirname = path.dirname(__filename);
+`.trim();
 
-async function prepend() {
+/**
+ * Apply Node.js compatibility patches to the bundled service output.
+ */
+async function patchServiceExecutable() {
   try {
-    const content = await readFile(outputFile, 'utf8');
+    let content = await readFile(OUTPUT_FILE, 'utf8');
 
-    // Assume the 'service.ts' file entry point already has the shebang
-    if (!content.startsWith(shebang)) {
-      throw new Error('Missing shebang from service entry point');
+    // Skip if already patched
+    if (content.includes(DIRNAME_SHIM)) {
+      return;
     }
 
-    if (!content.includes(dirnameDef)) {
-      const [, executable] = content.split(shebang);
-      const newContent = `${shebang}\n${dirnameDef}\n${executable}`;
-      await writeFile(outputFile, newContent, 'utf8');
-      console.log('Adding missing __dirname definition to service executable');
-    }
-  } catch (err) {
-    console.error('Error processing output file:', err);
+    // Remove any existing shebang *and* leading whitespace
+    content = content.replace(/^#!.*\n/, '');
+
+    // Patch WASM init to use file:// URLs
+    content = content.replace(
+      /await __wbg_init\(\{ module_or_path: (module\$\d+) \}\)/g,
+      'await __wbg_init({ module_or_path: pathToFileURL($1).href })',
+    );
+
+    // Patch Worker creation to accept file:// URLs
+    content = content.replace(
+      'const worker = new Worker(url,',
+      'const worker = new Worker(pathToFileURL(url),',
+    );
+
+    const patched = [SHEBANG, DIRNAME_SHIM, '', content].join('\n');
+
+    await writeFile(OUTPUT_FILE, patched, 'utf8');
+
+    console.log(
+      '✔ Service executable patched for Node.js + file:// compatibility',
+    );
+  } catch (error) {
+    console.error('✖ Failed to patch service executable:', error);
     process.exit(1);
   }
 }
 
-await prepend();
+await patchServiceExecutable();

--- a/typescript/warp-monitor/Dockerfile
+++ b/typescript/warp-monitor/Dockerfile
@@ -35,6 +35,7 @@ COPY typescript/utils/package.json ./typescript/utils/
 COPY typescript/cosmos-sdk/package.json ./typescript/cosmos-sdk/
 COPY typescript/cosmos-types/package.json ./typescript/cosmos-types/
 COPY typescript/radix-sdk/package.json ./typescript/radix-sdk/
+COPY typescript/aleo-sdk/package.json ./typescript/aleo-sdk/
 COPY typescript/tsconfig/package.json ./typescript/tsconfig/
 COPY typescript/eslint-config/package.json ./typescript/eslint-config/
 COPY solidity/package.json ./solidity/
@@ -53,6 +54,7 @@ COPY typescript/utils ./typescript/utils
 COPY typescript/cosmos-sdk ./typescript/cosmos-sdk
 COPY typescript/cosmos-types ./typescript/cosmos-types
 COPY typescript/radix-sdk ./typescript/radix-sdk
+COPY typescript/aleo-sdk ./typescript/aleo-sdk
 COPY typescript/tsconfig ./typescript/tsconfig
 COPY typescript/eslint-config ./typescript/eslint-config
 COPY solidity ./solidity

--- a/typescript/warp-monitor/scripts/ncc.post-bundle.mjs
+++ b/typescript/warp-monitor/scripts/ncc.post-bundle.mjs
@@ -6,33 +6,55 @@ import { readFile, writeFile } from 'fs/promises';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const outputFile = path.join(__dirname, '..', 'bundle', 'index.js');
+const OUTPUT_FILE = path.join(__dirname, '..', 'bundle', 'index.js');
+const SHEBANG = '#!/usr/bin/env node';
 
-const shebang = '#!/usr/bin/env node';
-const dirnameDef = `import { fileURLToPath } from 'url';
+const DIRNAME_SHIM = `
+import { fileURLToPath, pathToFileURL } from 'url';
 import path from 'path';
+
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);`;
+const __dirname = path.dirname(__filename);
+`.trim();
 
-async function prepend() {
+/**
+ * Apply Node.js compatibility patches to the bundled service output.
+ */
+async function patchServiceExecutable() {
   try {
-    const content = await readFile(outputFile, 'utf8');
+    let content = await readFile(OUTPUT_FILE, 'utf8');
 
-    // Assume the 'service.ts' file entry point already has the shebang
-    if (!content.startsWith(shebang)) {
-      throw new Error('Missing shebang from service entry point');
+    // Skip if already patched
+    if (content.includes(DIRNAME_SHIM)) {
+      return;
     }
 
-    if (!content.includes(dirnameDef)) {
-      const [, executable] = content.split(shebang);
-      const newContent = `${shebang}\n${dirnameDef}\n${executable}`;
-      await writeFile(outputFile, newContent, 'utf8');
-      console.log('Adding missing __dirname definition to service executable');
-    }
-  } catch (err) {
-    console.error('Error processing output file:', err);
+    // Remove any existing shebang *and* leading whitespace
+    content = content.replace(/^#!.*\n/, '');
+
+    // Patch WASM init to use file:// URLs
+    content = content.replace(
+      /await __wbg_init\(\{ module_or_path: (module\$\d+) \}\)/g,
+      'await __wbg_init({ module_or_path: pathToFileURL($1).href })',
+    );
+
+    // Patch Worker creation to accept file:// URLs
+    content = content.replace(
+      'const worker = new Worker(url,',
+      'const worker = new Worker(pathToFileURL(url),',
+    );
+
+    const patched = [SHEBANG, DIRNAME_SHIM, '', content].join('\n');
+
+    await writeFile(OUTPUT_FILE, patched, 'utf8');
+
+    console.log(
+      '✔ Service executable patched for Node.js + file:// compatibility',
+    );
+  } catch (error) {
+    console.error('✖ Failed to patch service executable:', error);
     process.exit(1);
   }
 }
 
-await prepend();
+await patchServiceExecutable();


### PR DESCRIPTION
## Summary
- Added `aleo-sdk` package.json and source copy to ccip-server, rebalancer, and warp-monitor Dockerfiles
- Updated rebalancer and warp-monitor `ncc.post-bundle.mjs` with WASM init patching from CLI (as discussed in #7522)

## Context
The `deploy-sdk` now depends on `@hyperlane-xyz/aleo-sdk` after #7522, which broke Docker builds for services that depend on deploy-sdk (ccip-server, rebalancer, warp-monitor).

The ncc post-bundle scripts were also updated to include WASM compatibility patches for Aleo and any future WASM-based packages, as discussed in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/7522#discussion_r2675328723.

## Changes
1. **Dockerfiles**: Added `aleo-sdk` to the COPY commands for:
   - `typescript/ccip-server/Dockerfile`
   - `typescript/rebalancer/Dockerfile`
   - `typescript/warp-monitor/Dockerfile`

2. **Post-bundle scripts**: Updated to match CLI's patching logic:
   - `typescript/rebalancer/scripts/ncc.post-bundle.mjs`
   - `typescript/warp-monitor/scripts/ncc.post-bundle.mjs`
   - Patches WASM init to use `file://` URLs
   - Patches Worker creation to accept `file://` URLs
   - Adds `pathToFileURL` import

## Testing
- [x] Local `pnpm -C typescript/deploy-sdk build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated aleo-sdk package into Docker builds across multiple services.

* **Bug Fixes**
  * Enhanced bundle patching to properly handle WASM module initialization and Worker URL handling with file:// URLs. Added detection to prevent redundant patching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->