### PR TITLE
feat(cli): add --skip-validation flag to warp send command

### DIFF
--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -264,6 +264,7 @@ const send: CommandModuleWithWriteContext<
       amount: string;
       recipient?: string;
       chains?: string;
+      skipValidation?: boolean;
     }
 > = {
   command: 'send',
@@ -286,6 +287,11 @@ const send: CommandModuleWithWriteContext<
       demandOption: false,
       conflicts: ['origin', 'destination'],
     },
+    'skip-validation': {
+      type: 'boolean',
+      description: 'Skip transfer validation (e.g., collateral checks)',
+      default: false,
+    },
   },
   handler: async ({
     context,
@@ -300,6 +306,7 @@ const send: CommandModuleWithWriteContext<
     recipient,
     roundTrip,
     chains: chainsAsString,
+    skipValidation,
   }) => {
     const warpCoreConfig = await getWarpCoreConfigOrExit({
       symbol,
@@ -351,6 +358,7 @@ const send: CommandModuleWithWriteContext<
       timeoutSec: timeout,
       skipWaitForDelivery: quick,
       selfRelay: relay,
+      skipValidation,
     });
     logGreen(
       `✅ Successfully sent messages for chains: ${chains.join(' ➡️ ')}`,


### PR DESCRIPTION
## Summary
- Adds `--skip-validation` flag to `hyperlane warp send` command
- When enabled, bypasses transfer validation checks (e.g., collateral checks)
- Useful for testing scenarios and cases where validation should be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--skip-validation` flag to the warp send command, enabling users to bypass validation checks during transfers. The flag is optional and defaults to validation enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->