### PR TITLE
chore: add chunk size & from index for aleo indexing

### DIFF
--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -9396,7 +9396,9 @@
       "validatorAnnounce": "0xf3aa0d652226e21ae35cd9035c492ae41725edc9036edf0d6a48701b153b90a0",
       "technicalStack": "other",
       "availability": {
-        "reasons": ["deprecated"],
+        "reasons": [
+          "deprecated"
+        ],
         "status": "disabled"
       }
     },

--- a/rust/main/config/testnet_config.json
+++ b/rust/main/config/testnet_config.json
@@ -2389,6 +2389,9 @@
       "validatorAnnounceProgram": "test_hyp_validator_announce.aleo",
       "signer": {
         "key": "0x1a1484a05bee53f5858a3888cdb5a397e433aee4d725e0f6c8a92cba3bb2b011"
+      },
+      "index": {
+        "chunk": 50
       }
     }
   }


### PR DESCRIPTION
### Description
The default chunk size of 2000 is too high for aleo indexing and results in errors. I arrived at 50 by just testing some values and this seems to be the most consistent.
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
