### PR TITLE
fix(infra): make safeHomeUrl optional in create-safe script

### DIFF
--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -144,13 +144,6 @@ export function withChainRequired<T>(args: Argv<T>) {
   return withChain(args).demandOption('chain');
 }
 
-export function withSafeHomeUrlRequired<T>(args: Argv<T>) {
-  return args
-    .string('safeHomeUrl')
-    .describe('safeHomeUrl', 'Custom safe home url')
-    .demandOption('safeHomeUrl');
-}
-
 export function withThreshold<T>(args: Argv<T>) {
   return args
     .describe('threshold', 'threshold for multisig')

--- a/typescript/infra/scripts/safes/create-safe.ts
+++ b/typescript/infra/scripts/safes/create-safe.ts
@@ -7,18 +7,18 @@ import { Contexts } from '../../config/contexts.js';
 import { getGovernanceSigners } from '../../config/environments/mainnet3/governance/utils.js';
 import { withGovernanceType } from '../../src/governance.js';
 import { Role } from '../../src/roles.js';
-import {
-  getArgs,
-  withChainRequired,
-  withSafeHomeUrlRequired,
-  withThreshold,
-} from '../agent-utils.js';
+import { getArgs, withChainRequired, withThreshold } from '../agent-utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
+
+const DEFAULT_SAFE_HOME_URL = 'https://app.safe.global';
 
 async function main() {
   const { chain, safeHomeUrl, threshold, governanceType } =
     await withGovernanceType(
-      withThreshold(withSafeHomeUrlRequired(withChainRequired(getArgs()))),
+      withThreshold(withChainRequired(getArgs()))
+        .string('safeHomeUrl')
+        .describe('safeHomeUrl', 'Safe web UI base URL')
+        .default('safeHomeUrl', DEFAULT_SAFE_HOME_URL),
     ).argv;
 
   const envConfig = getEnvironmentConfig('mainnet3');


### PR DESCRIPTION
## Summary
- Made `--safeHomeUrl` optional in create-safe script with default `https://app.safe.global`
- Removed unused `withSafeHomeUrlRequired` helper from agent-utils (single-use abstraction)

The parameter was only used to log a convenience URL after safe creation - not functionally required for deployment.