### PR TITLE
feat: Set Lander as the default submitter for Aleo

### DIFF
--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -294,6 +294,7 @@ fn parse_chain(
         Some(submitter_type) => submitter_type,
         None => match connection.protocol() {
             HyperlaneDomainProtocol::Ethereum
+            | HyperlaneDomainProtocol::Aleo
             | HyperlaneDomainProtocol::Radix
             | HyperlaneDomainProtocol::Sealevel => SubmitterType::Lander,
             _ => Default::default(),


### PR DESCRIPTION
### Description

Set Lander as the default submitter for Aleo

### Backward compatibility

Yes

### Testing

E2E tests and manual testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Aleo protocol chains now receive proper default submitter configuration, consistent with other supported protocols.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->