### PR TITLE
feat: Add validator checkpoint inconsistency debugging skill

### DIFF
--- a/.claude/skills/alert-validator-checkpoints-inconsistent/SKILL.md
+++ b/.claude/skills/alert-validator-checkpoints-inconsistent/SKILL.md
@@ -64,7 +64,7 @@ The metric shows the latest highest signed index by a validator as it's observed
 - It's possible for a different origin chain validator set to be enrolled on different destination chains. This is usually not intentional and may reflect in-progress validator set rotations, but it could also indicate an issue. Keep this in mind if you ignore the destination chain by using `max by (origin, validator, app_context)`
 - It's possible that some validators are healthy and are just a couple seconds behind the rest of the pack, so the metric might show them as a tiny bit behind the rest. In this case, they aren't stalled, it's just that the relayer attempted to deliver a message shortly before the validator signed the checkpoint.
 
-**NEVER** ignore negative values from these metric. A `-1` value here means that the validator signatures are not accessible by the relayer. Consider this as serious as if the validator were completely down. Note that the root cause of this is one of the following:
+**NEVER** ignore negative values from these metrics. A `-1` value here means that the validator signatures are not accessible by the relayer. Consider this as serious as if the validator were completely down. Note that the root cause of this is one of the following:
 
 - The validator isn't configured correctly
 - The validator isn't running at all


### PR DESCRIPTION
## Summary

Adds the **validator checkpoint inconsistency skill** (`.claude/skills/alert-validator-checkpoints-inconsistent/`) for debugging validator stalls and checkpoint gaps with Claude Code.

### What it does

- Queries Prometheus metrics from the relayer's perspective to see ALL validators (including external)
- Identifies stalled validators vs healthy ones
- Maps validator addresses to human-friendly aliases from `multisigIsm.ts`
- Assesses quorum status and severity

### Usage

This skill is triggered when:
- Alert mentions "checkpoint inconsistency", "validator inconsistent", or "validators behind"
- User asks to debug validator set on a chain

**Note:** Requires local Grafana MCP server configured with read-only permissions. Makes live requests to Grafana/Prometheus.

## Test plan

- [x] Skill file passes lint/prettier

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive debugging guide for validator checkpoint inconsistencies: a multi-step workflow to identify and confirm stalled validators, Prometheus query patterns and metric interpretation (including handling negative values), mapping validators to human-friendly identities, cross-chain enrollment edge-case guidance, and user-facing result tables with priority assessments (HIGH/MEDIUM/LOW) for operational alerts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->