### PR TITLE
feat(infra): update USDC/eclipsemainnet rebalancer config

### DIFF
--- a/typescript/infra/config/environments/mainnet3/rebalancer/USDC/eclipsemainnet-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/USDC/eclipsemainnet-config.yaml
@@ -4,42 +4,48 @@ strategy:
   chains:
     ethereum:
       weighted:
-        weight: 33
+        weight: 29
         tolerance: 5
       bridgeLockTime: 1800
+      bridgeMinAcceptedAmount: 3500
       bridge: '0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23'
 
     base:
       weighted:
-        weight: 27
+        weight: 24
         tolerance: 5
       bridgeLockTime: 1800
+      bridgeMinAcceptedAmount: 3500
       bridge: '0x33e94B6D2ae697c16a750dB7c3d9443622C4405a'
 
     arbitrum:
       weighted:
-        weight: 20
+        weight: 17
         tolerance: 5
       bridgeLockTime: 1800
+      bridgeMinAcceptedAmount: 3500
       bridge: '0x4c19c653a8419A475d9B6735511cB81C15b8d9b2'
 
     optimism:
       weighted:
-        weight: 7
+        weight: 10
         tolerance: 5
       bridgeLockTime: 1800
+      bridgeMinAcceptedAmount: 3500
       bridge: '0x33e94B6D2ae697c16a750dB7c3d9443622C4405a'
 
     polygon:
       weighted:
-        weight: 7
+        weight: 10
         tolerance: 5
       bridgeLockTime: 1800
+      bridgeMinAcceptedAmount: 3500
       bridge: '0x33e94B6D2ae697c16a750dB7c3d9443622C4405a'
 
     unichain:
       weighted:
-        weight: 6
+        weight: 10
         tolerance: 5
       bridgeLockTime: 1800
+      bridgeMinAcceptedAmount: 3500
       bridge: '0x33e94B6D2ae697c16a750dB7c3d9443622C4405a'


### PR DESCRIPTION
## Summary
- Updated chain weights for eclipsemainnet USDC rebalancer (ethereum: 33→29, base: 27→24, arbitrum: 20→17, optimism: 7→10, polygon: 7→10, unichain: 6→10)
- Added `bridgeMinAcceptedAmount: 3500` to all chains

## Test plan
- [ ] Verify YAML syntax is valid
- [ ] Confirm weights sum to 100%
- [ ] Review bridgeMinAcceptedAmount values are appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated rebalancing configuration weights across multiple blockchain networks (Ethereum, Base, Arbitrum, Optimism, Polygon, and Unichain) to optimize distribution
  * Added minimum bridge amount threshold to strengthen cross-chain transfer safety and reliability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->