### PR TITLE
feat(relayer): optimize matching list classification

### DIFF
--- a/rust/main/agents/relayer/src/settings/matching_list.rs
+++ b/rust/main/agents/relayer/src/settings/matching_list.rs
@@ -345,7 +345,7 @@ impl MatchingList {
     {
         let rules = match &self.0 {
             Some(rules) => rules,
-            None => return Some(HashSet::new()),
+            None => return None, // No configuration = wildcard (no domain restrictions)
         };
 
         let mut domains = HashSet::new();
@@ -599,8 +599,8 @@ mod test {
     #[test]
     fn matching_list_domain_methods() {
         let empty = MatchingList(None);
-        assert_eq!(empty.origin_domains(), Some(HashSet::new()));
-        assert_eq!(empty.destination_domains(), Some(HashSet::new()));
+        assert_eq!(empty.origin_domains(), None);
+        assert_eq!(empty.destination_domains(), None);
 
         let wildcard_origin: MatchingList =
             serde_json::from_str(r#"[{"origindomain":"*"}]"#).unwrap();

--- a/rust/main/agents/relayer/src/settings/matching_list.rs
+++ b/rust/main/agents/relayer/src/settings/matching_list.rs
@@ -297,11 +297,11 @@ impl Display for ListElement {
 #[derive(Clone, Debug)]
 pub(crate) struct MatchInfo<'a> {
     src_msg_id: H256,
-    src_domain: u32,
+    pub(crate) src_domain: u32,
     src_addr: &'a H256,
-    dst_domain: u32,
+    pub(crate) dst_domain: u32,
     dst_addr: &'a H256,
-    body: &'a [u8],
+    pub(crate) body: &'a [u8],
 }
 
 impl<'a> From<&'a HyperlaneMessage> for MatchInfo<'a> {
@@ -417,10 +417,6 @@ impl MatchingList {
         } else {
             default
         }
-    }
-
-    fn matches(&self, info: MatchInfo, default: bool) -> bool {
-        self.matches_info(&info, default, None)
     }
 }
 

--- a/rust/main/agents/relayer/src/settings/matching_list.rs
+++ b/rust/main/agents/relayer/src/settings/matching_list.rs
@@ -448,6 +448,8 @@ fn parse_addr<E: Error>(addr_str: &str) -> Result<H256, E> {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashSet;
+
     use hyperlane_core::{H160, H256};
 
     use super::{Filter::*, MatchingList};
@@ -592,6 +594,83 @@ mod test {
         assert!(MatchingList(None).matches(&info, true));
         // blacklist use
         assert!(!MatchingList(None).matches(&info, false));
+    }
+
+    #[test]
+    fn matching_list_domain_methods() {
+        let empty = MatchingList(None);
+        assert_eq!(empty.origin_domains(), Some(HashSet::new()));
+        assert_eq!(empty.destination_domains(), Some(HashSet::new()));
+
+        let wildcard_origin: MatchingList =
+            serde_json::from_str(r#"[{"origindomain":"*"}]"#).unwrap();
+        assert_eq!(wildcard_origin.origin_domains(), None);
+
+        let wildcard_destination: MatchingList =
+            serde_json::from_str(r#"[{"destinationdomain":"*"}]"#).unwrap();
+        assert_eq!(wildcard_destination.destination_domains(), None);
+
+        let enumerated_origin: MatchingList =
+            serde_json::from_str(r#"[{"origindomain":[1,2]},{"origindomain":[2,3]}]"#).unwrap();
+        let expected_origin: HashSet<u32> = [1u32, 2, 3].iter().copied().collect();
+        assert_eq!(enumerated_origin.origin_domains(), Some(expected_origin));
+
+        let enumerated_destination: MatchingList = serde_json::from_str(
+            r#"[{"destinationdomain":[10,11]},{"destinationdomain":[11,12]}]"#,
+        )
+        .unwrap();
+        let expected_destination: HashSet<u32> = [10u32, 11, 12].iter().copied().collect();
+        assert_eq!(
+            enumerated_destination.destination_domains(),
+            Some(expected_destination)
+        );
+
+        // Rule with no domain fields specified (defaults to Wildcard)
+        // Critical: many real configs only specify sender/recipient addresses
+        let no_domains_specified: MatchingList = serde_json::from_str(
+            r#"[{"senderaddress":"0x0000000000000000000000001234567890123456789012345678901234567890"}]"#,
+        )
+        .unwrap();
+        assert_eq!(no_domains_specified.origin_domains(), None);
+        assert_eq!(no_domains_specified.destination_domains(), None);
+
+        // Mixed: one rule enumerated, another wildcard → None
+        let mixed_origin: MatchingList =
+            serde_json::from_str(r#"[{"origindomain":[1,2]},{"origindomain":"*"}]"#).unwrap();
+        assert_eq!(mixed_origin.origin_domains(), None);
+
+        // Single scalar domain (common shorthand, not array)
+        let single_origin: MatchingList = serde_json::from_str(r#"[{"origindomain":42}]"#).unwrap();
+        let expected_single: HashSet<u32> = [42u32].iter().copied().collect();
+        assert_eq!(single_origin.origin_domains(), Some(expected_single));
+
+        // Cross-field independence: wildcard dest shouldn't affect origin_domains()
+        // Real pattern from mainnet_config.json (e.g., "aave" config)
+        let specific_origin_wildcard_dest: MatchingList =
+            serde_json::from_str(r#"[{"origindomain":1,"destinationdomain":"*"}]"#).unwrap();
+        let expected_specific: HashSet<u32> = [1u32].iter().copied().collect();
+        assert_eq!(
+            specific_origin_wildcard_dest.origin_domains(),
+            Some(expected_specific)
+        );
+        assert_eq!(specific_origin_wildcard_dest.destination_domains(), None);
+
+        // Multiple rules with same domain (deduplication via HashSet)
+        let duplicate_domains: MatchingList =
+            serde_json::from_str(r#"[{"origindomain":1},{"origindomain":1},{"origindomain":1}]"#)
+                .unwrap();
+        let expected_dedup: HashSet<u32> = [1u32].iter().copied().collect();
+        assert_eq!(duplicate_domains.origin_domains(), Some(expected_dedup));
+
+        // Bidirectional warp route pattern (from mainnet_config.json)
+        let bidirectional: MatchingList = serde_json::from_str(
+            r#"[{"origindomain":888888888,"destinationdomain":1},{"origindomain":1,"destinationdomain":888888888}]"#,
+        )
+        .unwrap();
+        let expected_origins: HashSet<u32> = [888888888u32, 1].iter().copied().collect();
+        let expected_dests: HashSet<u32> = [1u32, 888888888].iter().copied().collect();
+        assert_eq!(bidirectional.origin_domains(), Some(expected_origins));
+        assert_eq!(bidirectional.destination_domains(), Some(expected_dests));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Optimizes app context classification in the relayer by adding early domain rejection before full matching list evaluation.

### Changes

- Added `origin_domains()` and `destination_domains()` methods to `MatchingList` that return the set of domains a matching list could match (or `None` if wildcarded)
- `AppContextClassifier` pre-computes domain sets for each matching list at construction time
- During classification, messages are rejected early via O(1) HashSet lookups before iterating through rules

### Why

When classifying messages against many app matching lists, most messages don't match most lists. Early domain rejection avoids expensive rule iteration and regex matching for non-matching lists.

### Testing

Comprehensive unit tests for domain helper methods in `matching_list_domain_methods`:

| Test Case | Description |
|-----------|-------------|
| Empty list | `MatchingList(None)` returns `Some(empty set)` |
| Explicit wildcard | `{"origindomain":"*"}` returns `None` |
| Enumerated union | Multiple rules union domains across rules |
| Implicit wildcard | Rules without domain fields default to Wildcard → `None` |
| Mixed rules | Enumerated + wildcard in same list → `None` |
| Single scalar | `{"origindomain":42}` (not array) works |
| Cross-field independence | Wildcard dest doesn't affect `origin_domains()` |
| Deduplication | Same domain in multiple rules deduped via HashSet |
| Bidirectional warp | Real production pattern from mainnet_config.json |

```bash
cargo test -p relayer matching_list_domain_methods
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Message classification now performs per-entry origin/destination domain pre-filtering before full matching, and matching entries surface domain sets to enable faster checks—reducing redundant work while preserving external behavior.
  * Classifier construction was streamlined to internally wrap pairs into richer entries for improved matching efficiency.

* **Tests**
  * Updated and extended tests to cover domain filtering and wildcard/enumeration matching scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->