### PR TITLE
feat(ci): add @claude security manual trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -76,7 +76,7 @@ jobs:
           track_progress: true
           claude_args: |
             --model claude-opus-4-5
-            --max-turns 10
+            --max-turns 30
 
   # Security-focused review: auto on PR or manual via @claude security
   security-review:
@@ -209,7 +209,7 @@ jobs:
           track_progress: true
           claude_args: |
             --model claude-opus-4-5
-            --max-turns 15
+            --max-turns 25
 
   # Interactive @claude mentions in comments
   interactive:
@@ -245,4 +245,4 @@ jobs:
           track_progress: true
           claude_args: |
             --model claude-sonnet-4-5
-            --max-turns 15
+            --max-turns 20


### PR DESCRIPTION
## Summary

- Added `@claude security` comment trigger for on-demand security reviews
- Triggers both `security-review-manual` (claude-code-security-review) and `tob-security-skills-manual` (ToB skills for Solidity) jobs
- Updated `interactive` job to exclude `@claude security` pattern

## Triggers

| Trigger | What runs |
|---------|-----------|
| `@claude review` | General code review |
| `@claude security` | Security scan + ToB skills (if Solidity changes) |
| `@claude` (other) | Interactive assistant |
| PR open/sync | Auto security scan + ToB skills |

## Testing

Comment `@claude security` on any PR to trigger manual security review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Issue-comment triggers expanded: workflows now respond to security-related command mentions for on-demand reviews and contract-analysis requests.
  * Added on-demand manual review jobs accessible via issue comments with extended analysis options.

* **Changes**
  * Interaction limits increased: code assistant and review agents now allow longer multi-turn conversations (higher max-turns).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->