### PR TITLE
feat(sdk,widgets): add ERC-2612 permit support for gasless approvals

### DIFF
--- a/.changeset/erc2612-permit-support.md
+++ b/.changeset/erc2612-permit-support.md
@@ -1,0 +1,6 @@
+---
+"@hyperlane-xyz/sdk": minor
+"@hyperlane-xyz/widgets": minor
+---
+
+Added ERC-2612 permit support for gasless token approvals. The SDK now includes permit types, adapter methods for checking permit support and signing permit data, and WarpCore integration that accepts permit signatures as an alternative to traditional approval transactions. The widgets package exports a new `useSignPermit` hook for signing EIP-712 typed permit messages with wagmi.

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -702,6 +702,15 @@ export { HypERC20Deployer, HypERC721Deployer } from './token/deploy.js';
 export { EvmERC20WarpModule } from './token/EvmERC20WarpModule.js';
 export { EvmERC20WarpRouteReader } from './token/EvmERC20WarpRouteReader.js';
 export { IToken, TokenArgs, TokenConfigSchema } from './token/IToken.js';
+export {
+  GetPermitDataParams,
+  PERMIT_TYPES,
+  PermitData,
+  PermitDomain,
+  PermitMessage,
+  PermitSignature,
+  PopulatePermitTxParams,
+} from './token/permit.js';
 export { Token, getCollateralTokenAdapter } from './token/Token.js';
 export { TokenAmount } from './token/TokenAmount.js';
 export {

--- a/typescript/sdk/src/token/adapters/ITokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/ITokenAdapter.ts
@@ -1,5 +1,10 @@
 import { Address, Domain, Numberish } from '@hyperlane-xyz/utils';
 
+import type {
+  GetPermitDataParams,
+  PermitData,
+  PopulatePermitTxParams,
+} from '../permit.js';
 import { TokenMetadata } from '../types.js';
 
 export interface TransferParams {
@@ -61,6 +66,12 @@ export interface ITokenAdapter<Tx> {
   isRevokeApprovalRequired(owner: Address, spender: Address): Promise<boolean>;
   populateApproveTx(params: TransferParams): Promise<Tx>;
   populateTransferTx(params: TransferParams): Promise<Tx>;
+
+  // ERC-2612 permit support (optional - only implemented by EVM adapters)
+  supportsPermit?(): Promise<boolean>;
+  getPermitNonce?(owner: Address): Promise<bigint>;
+  getPermitData?(params: GetPermitDataParams): Promise<PermitData>;
+  populatePermitTx?(params: PopulatePermitTxParams): Promise<Tx>;
 }
 
 export interface IMovableCollateralRouterAdapter<Tx> extends ITokenAdapter<Tx> {

--- a/typescript/sdk/src/token/permit.ts
+++ b/typescript/sdk/src/token/permit.ts
@@ -1,0 +1,54 @@
+import type { Address, Numberish } from '@hyperlane-xyz/utils';
+
+export const PERMIT_TYPES = {
+  Permit: [
+    { name: 'owner', type: 'address' },
+    { name: 'spender', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'deadline', type: 'uint256' },
+  ],
+} as const;
+
+export interface PermitDomain {
+  name: string;
+  version: string;
+  chainId: number;
+  verifyingContract: Address;
+}
+
+export interface PermitMessage {
+  owner: Address;
+  spender: Address;
+  value: string;
+  nonce: bigint;
+  deadline: number;
+}
+
+export interface PermitData {
+  domain: PermitDomain;
+  message: PermitMessage;
+  types: typeof PERMIT_TYPES;
+}
+
+export interface PermitSignature {
+  v: number;
+  r: string;
+  s: string;
+  deadline: number;
+}
+
+export interface GetPermitDataParams {
+  owner: Address;
+  spender: Address;
+  amount: Numberish;
+  deadline: number;
+}
+
+export interface PopulatePermitTxParams {
+  owner: Address;
+  spender: Address;
+  amount: Numberish;
+  deadline: number;
+  signature: PermitSignature;
+}

--- a/typescript/sdk/src/warp/types.ts
+++ b/typescript/sdk/src/warp/types.ts
@@ -49,6 +49,7 @@ export type RouteBlacklist = Array<{
 // Transaction types for warp core remote transfers
 export enum WarpTxCategory {
   Approval = 'approval',
+  Permit = 'permit',
   Revoke = 'revoke',
   Transfer = 'transfer',
 }

--- a/typescript/widgets/src/index.ts
+++ b/typescript/widgets/src/index.ts
@@ -117,6 +117,7 @@ export {
   useEthereumWalletDetails,
   useEthereumSwitchNetwork,
   useEthereumWatchAsset,
+  useSignPermit,
 } from './walletIntegrations/ethereum.js';
 export {
   getAccountAddressAndPubKey,

--- a/typescript/widgets/src/walletIntegrations/ethereum.ts
+++ b/typescript/widgets/src/walletIntegrations/ethereum.ts
@@ -17,6 +17,7 @@ import {
   IToken,
   LOCKBOX_STANDARDS,
   MultiProtocolProvider,
+  PERMIT_TYPES,
   PermitData,
   PermitSignature,
   ProviderType,
@@ -249,15 +250,7 @@ export function useSignPermit(): {
           chainId: permitData.domain.chainId,
           verifyingContract: permitData.domain.verifyingContract as Hex,
         },
-        types: {
-          Permit: [
-            { name: 'owner', type: 'address' },
-            { name: 'spender', type: 'address' },
-            { name: 'value', type: 'uint256' },
-            { name: 'nonce', type: 'uint256' },
-            { name: 'deadline', type: 'uint256' },
-          ],
-        },
+        types: PERMIT_TYPES,
         primaryType: 'Permit',
         message: {
           owner: permitData.message.owner as Hex,


### PR DESCRIPTION
## Summary

- Added ERC-2612 permit support to enable gasless token approvals for warp route transfers
- Users can now sign a permit message instead of submitting a separate approval transaction
- Falls back to traditional approval flow when permit is not supported or no signature provided

## Token Coverage

We analyzed **132 collateral tokens** across Hyperlane warp routes:

| Status | Count | Percentage |
|--------|-------|------------|
| ✅ Supports Permit | 57 | **43%** |
| ❌ No Permit | 75 | 57% |

**Key tokens WITH permit**: USDC (most chains), USDT (L2s), WSTETH, CBBTC, weETHs, OP, EURC

**Key tokens WITHOUT permit**: WETH, USDT (ethereum mainnet), stHYPER, most LRTs

See full analysis: https://gist.github.com/paulbalaji/00acf5bb8b379cbc77fddb21e51ea052

## Changes

### SDK (`@hyperlane-xyz/sdk`)

**New file: `src/token/permit.ts`**
- `PermitData`, `PermitSignature`, `PermitDomain`, `PermitMessage` types
- `PERMIT_TYPES` constant for EIP-712 typed data
- `GetPermitDataParams`, `PopulatePermitTxParams` interfaces

**Modified: `src/token/adapters/ITokenAdapter.ts`**
- Added optional permit methods to `ITokenAdapter` interface:
  - `supportsPermit?()` - check if token supports ERC-2612
  - `getPermitNonce?()` - get nonce for permit signing
  - `getPermitData?()` - build EIP-712 permit data
  - `populatePermitTx?()` - create permit transaction

**Modified: `src/token/adapters/EvmTokenAdapter.ts`**
- Implemented permit methods in `EvmTokenAdapter` class
- Added `ERC2612_PERMIT_ABI` constant

**Modified: `src/warp/types.ts`**
- Added `WarpTxCategory.Permit = 'permit'`

**Modified: `src/warp/WarpCore.ts`**
- Added `permitSignature?: PermitSignature` parameter to `getTransferRemoteTxs()`
- If permit signature provided, creates permit tx instead of approval tx
- Falls back to traditional approval flow when no permit signature

### Widgets (`@hyperlane-xyz/widgets`)

**Modified: `src/walletIntegrations/ethereum.ts`**
- Added `useSignPermit()` hook that uses wagmi's `signTypedData`
- Signs EIP-712 permit message and returns `PermitSignature` (v, r, s, deadline)

## Architecture Flow

```
Current: Approve Tx (gas) → Transfer Tx (gas)
New:     Sign Permit (no gas) → Permit+Transfer Tx (gas only)
```

## Testing

- Lint: ✅ No new errors
- Prettier: ✅ All files formatted
- TypeScript: ✅ No type errors in changed files

## Related

- Research & token analysis: https://gist.github.com/paulbalaji/00acf5bb8b379cbc77fddb21e51ea052
- Warp UI PR: https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/pull/895