### PR TITLE
feat(sdk,widgets): add EIP-7702 batch transaction support

### DIFF
--- a/.changeset/eip7702-batch-support.md
+++ b/.changeset/eip7702-batch-support.md
@@ -1,0 +1,6 @@
+---
+"@hyperlane-xyz/sdk": minor
+"@hyperlane-xyz/widgets": minor
+---
+
+EIP-7702 batch transaction support added for gasless approvals on Pectra-enabled chains. This enables 100% token coverage for single-transaction approve+transfer flows on Ethereum mainnet, Sepolia, and Holesky. Includes SDK types for Multicall3 batch calls, WarpCore helpers for building batch transactions, and widget hooks for EIP-7702 detection and execution.

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -713,11 +713,11 @@ export {
 } from './token/permit.js';
 export {
   Call3Value,
+  checkEIP7702Support,
   EIP7702BatchTransferParams,
-  EIP7702SupportedChain,
-  EIP7702_SUPPORTED_CHAINS,
+  EIP7702_DETECTION_REQUEST,
+  EIP7702_MAGIC_PREFIX,
   ERC20_APPROVE_ABI,
-  isEIP7702SupportedChain,
   MULTICALL3_ADDRESS,
   MULTICALL3_AGGREGATE3VALUE_ABI,
   Multicall3Result,

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -711,6 +711,17 @@ export {
   PermitSignature,
   PopulatePermitTxParams,
 } from './token/permit.js';
+export {
+  Call3Value,
+  EIP7702BatchTransferParams,
+  EIP7702SupportedChain,
+  EIP7702_SUPPORTED_CHAINS,
+  ERC20_APPROVE_ABI,
+  isEIP7702SupportedChain,
+  MULTICALL3_ADDRESS,
+  MULTICALL3_AGGREGATE3VALUE_ABI,
+  Multicall3Result,
+} from './token/eip7702.js';
 export { Token, getCollateralTokenAdapter } from './token/Token.js';
 export { TokenAmount } from './token/TokenAmount.js';
 export {

--- a/typescript/sdk/src/token/eip7702.ts
+++ b/typescript/sdk/src/token/eip7702.ts
@@ -1,0 +1,121 @@
+import type { Address } from '@hyperlane-xyz/utils';
+
+/**
+ * Standard Multicall3 address deployed on most EVM chains.
+ * This is the same contract used by the Hyperlane Lander agent for transaction batching.
+ * @see https://www.multicall3.com/
+ */
+export const MULTICALL3_ADDRESS: Address =
+  '0xcA11bde05977b3631167028862bE2a173976CA11';
+
+/**
+ * Call structure for Multicall3.aggregate3Value
+ * Represents a single call in a batch with value transfer support
+ */
+export interface Call3Value {
+  /** Target contract address */
+  target: Address;
+  /** Whether the call is allowed to fail without reverting the batch */
+  allowFailure: boolean;
+  /** ETH value to send with the call */
+  value: bigint;
+  /** Encoded function call data */
+  callData: string;
+}
+
+/**
+ * Result structure from Multicall3.aggregate3Value
+ */
+export interface Multicall3Result {
+  /** Whether the call succeeded */
+  success: boolean;
+  /** Return data from the call */
+  returnData: string;
+}
+
+/**
+ * Minimal ABI for Multicall3.aggregate3Value function
+ * This function allows batching multiple calls with different ETH values
+ */
+export const MULTICALL3_AGGREGATE3VALUE_ABI = [
+  {
+    name: 'aggregate3Value',
+    type: 'function',
+    stateMutability: 'payable',
+    inputs: [
+      {
+        name: 'calls',
+        type: 'tuple[]',
+        components: [
+          { name: 'target', type: 'address' },
+          { name: 'allowFailure', type: 'bool' },
+          { name: 'value', type: 'uint256' },
+          { name: 'callData', type: 'bytes' },
+        ],
+      },
+    ],
+    outputs: [
+      {
+        name: 'returnData',
+        type: 'tuple[]',
+        components: [
+          { name: 'success', type: 'bool' },
+          { name: 'returnData', type: 'bytes' },
+        ],
+      },
+    ],
+  },
+] as const;
+
+/**
+ * Minimal ABI for ERC20.approve function
+ */
+export const ERC20_APPROVE_ABI = [
+  {
+    name: 'approve',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'spender', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    outputs: [{ type: 'bool' }],
+  },
+] as const;
+
+/**
+ * Chains known to support EIP-7702 (Pectra upgrade).
+ * This list will expand as more chains adopt Pectra.
+ */
+export const EIP7702_SUPPORTED_CHAINS = [
+  'ethereum',
+  'sepolia',
+  'holesky',
+] as const;
+
+export type EIP7702SupportedChain = (typeof EIP7702_SUPPORTED_CHAINS)[number];
+
+/**
+ * Check if a chain name is known to support EIP-7702
+ * @param chainName - The chain name to check
+ * @returns true if the chain supports EIP-7702
+ */
+export function isEIP7702SupportedChain(chainName: string): boolean {
+  return EIP7702_SUPPORTED_CHAINS.includes(chainName as EIP7702SupportedChain);
+}
+
+/**
+ * Parameters for building EIP-7702 batch transfer calls
+ */
+export interface EIP7702BatchTransferParams {
+  /** Address of the ERC20 token to approve */
+  tokenAddress: Address;
+  /** Address of the warp route (spender) */
+  warpRouteAddress: Address;
+  /** Exact amount to approve (not uint256.max) */
+  approvalAmount: bigint;
+  /** Encoded transferRemote call data */
+  transferRemoteCallData: string;
+  /** ETH value for interchain gas payment */
+  interchainFeeValue: bigint;
+}

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -44,7 +44,7 @@ import {
   Call3Value,
   ERC20_APPROVE_ABI,
   MULTICALL3_ADDRESS,
-  isEIP7702SupportedChain,
+  checkEIP7702Support,
 } from '../token/eip7702.js';
 import type { PermitSignature } from '../token/permit.js';
 import { ChainName, ChainNameOrId } from '../types.js';
@@ -1191,10 +1191,12 @@ export class WarpCore {
   }
 
   /**
-   * Check if a chain supports EIP-7702 batch transactions (Pectra upgrade)
+   * Check if a chain supports EIP-7702 batch transactions (Pectra upgrade).
+   * Uses dynamic detection via RPC probe.
    */
-  supportsEIP7702Batch(chainName: ChainName): boolean {
-    return isEIP7702SupportedChain(chainName);
+  async supportsEIP7702Batch(chainName: ChainName): Promise<boolean> {
+    const rpcUrl = this.multiProvider.getRpcUrl(chainName);
+    return checkEIP7702Support(rpcUrl);
   }
 
   /**

--- a/typescript/sdk/src/warp/types.ts
+++ b/typescript/sdk/src/warp/types.ts
@@ -52,6 +52,7 @@ export enum WarpTxCategory {
   Permit = 'permit',
   Revoke = 'revoke',
   Transfer = 'transfer',
+  Batch = 'batch',
 }
 
 export type WarpTypedTransaction = TypedTransaction & {

--- a/typescript/widgets/src/walletIntegrations/ethereum.ts
+++ b/typescript/widgets/src/walletIntegrations/ethereum.ts
@@ -8,14 +8,17 @@ import {
   watchAsset,
 } from '@wagmi/core';
 import { useCallback, useMemo } from 'react';
-import { Hex, Chain as ViemChain } from 'viem';
+import { Hex, Chain as ViemChain, encodeFunctionData } from 'viem';
 import { useAccount, useConfig, useDisconnect } from 'wagmi';
 
 import {
+  Call3Value,
   ChainName,
   EvmHypXERC20LockboxAdapter,
   IToken,
   LOCKBOX_STANDARDS,
+  MULTICALL3_ADDRESS,
+  MULTICALL3_AGGREGATE3VALUE_ABI,
   MultiProtocolProvider,
   PERMIT_TYPES,
   PermitData,
@@ -24,6 +27,7 @@ import {
   TypedTransactionReceipt,
   WarpTypedTransaction,
   chainMetadataToViemChain,
+  isEIP7702SupportedChain,
 } from '@hyperlane-xyz/sdk';
 import { ProtocolType, assert, sleep } from '@hyperlane-xyz/utils';
 
@@ -276,6 +280,124 @@ export function useSignPermit(): {
   );
 
   return { signPermit };
+}
+
+export function useSupportsEIP7702(chainName?: ChainName): {
+  chainSupportsEIP7702: boolean;
+  walletSupportsEIP7702: boolean;
+} {
+  const config = useConfig();
+
+  const chainSupportsEIP7702 = useMemo(() => {
+    if (!chainName) return false;
+    return isEIP7702SupportedChain(chainName);
+  }, [chainName]);
+
+  const walletSupportsEIP7702 = useMemo(() => {
+    try {
+      const connector = (config as any).state?.current;
+      if (!connector) return false;
+
+      return typeof (connector as any).signAuthorization === 'function';
+    } catch {
+      return false;
+    }
+  }, [config]);
+
+  return { chainSupportsEIP7702, walletSupportsEIP7702 };
+}
+
+export function useEIP7702BatchTransfer(multiProvider: MultiProtocolProvider): {
+  executeBatchTransfer: (params: {
+    chainName: ChainName;
+    calls: Call3Value[];
+    batchContractAddress?: string;
+    activeChainName?: ChainName;
+  }) => Promise<{ hash: Hex; confirm: () => Promise<TypedTransactionReceipt> }>;
+} {
+  const config = useConfig();
+  const { switchNetwork } = useEthereumSwitchNetwork(multiProvider);
+
+  const executeBatchTransfer = useCallback(
+    async ({
+      chainName,
+      calls,
+      batchContractAddress = MULTICALL3_ADDRESS,
+      activeChainName,
+    }: {
+      chainName: ChainName;
+      calls: Call3Value[];
+      batchContractAddress?: string;
+      activeChainName?: ChainName;
+    }) => {
+      if (activeChainName && activeChainName !== chainName) {
+        await switchNetwork(chainName);
+      }
+
+      const chainId = multiProvider.getChainMetadata(chainName)
+        .chainId as number;
+      const account = getAccount(config);
+
+      assert(
+        account?.chain?.id === chainId,
+        `Wallet not on chain ${chainName} (ChainMismatchError)`,
+      );
+
+      assert(account.address, 'No account address available');
+
+      const walletClient = await (config as any).getClient?.({ chainId });
+
+      assert(
+        typeof (walletClient as any)?.signAuthorization === 'function',
+        'Wallet does not support EIP-7702 authorization signing',
+      );
+
+      const authorization = await (walletClient as any).signAuthorization({
+        contractAddress: batchContractAddress as Hex,
+      });
+
+      const totalValue = calls.reduce((sum, call) => sum + call.value, 0n);
+
+      const callData = encodeFunctionData({
+        abi: MULTICALL3_AGGREGATE3VALUE_ABI,
+        functionName: 'aggregate3Value',
+        args: [
+          calls.map((c) => ({
+            target: c.target as Hex,
+            allowFailure: c.allowFailure,
+            value: c.value,
+            callData: c.callData as Hex,
+          })),
+        ],
+      });
+
+      logger.debug(`Sending EIP-7702 batch tx on chain ${chainName}`);
+      const hash = await sendTransaction(config, {
+        chainId,
+        to: account.address,
+        value: totalValue,
+        data: callData,
+
+        authorizationList: [authorization] as any,
+      });
+
+      const confirm = (): Promise<TypedTransactionReceipt> => {
+        return waitForTransactionReceipt(config, {
+          chainId,
+          hash,
+          confirmations: 1,
+        }).then((r) => ({
+          type: ProviderType.Viem,
+          receipt: { ...r, contractAddress: r.contractAddress || null },
+        }));
+      };
+
+      return { hash, confirm };
+    },
+    [config, switchNetwork, multiProvider],
+  );
+
+  return { executeBatchTransfer };
 }
 
 // Metadata formatted for use in Wagmi config


### PR DESCRIPTION
## Summary

Adds EIP-7702 batch transaction support for gasless approvals on Pectra-enabled chains, building on top of the ERC-2612 permit support in #7790.

**Key benefit**: 100% token coverage for single-transaction approve+transfer flows on supported chains.

## Changes

### SDK (`@hyperlane-xyz/sdk`)

- **New file: `src/token/eip7702.ts`**
  - `MULTICALL3_ADDRESS` - Standard Multicall3 contract (`0xcA11...CA11`)
  - `Call3Value` interface for Multicall3 batch calls
  - `MULTICALL3_AGGREGATE3VALUE_ABI` for encoding batch transactions
  - `EIP7702_SUPPORTED_CHAINS` - Hardcoded list: `['ethereum', 'sepolia', 'holesky']`
  - `isEIP7702SupportedChain()` helper function

- **WarpCore additions:**
  - `supportsEIP7702Batch(chainName)` - Check if chain supports EIP-7702
  - `getBatchContractAddress(chainName)` - Get batch contract (supports registry override)
  - `buildEIP7702BatchCalls(params)` - Build Call3Value[] for approve + transferRemote

- **New enum value:** `WarpTxCategory.Batch`

### Widgets (`@hyperlane-xyz/widgets`)

- **New hooks:**
  - `useSupportsEIP7702(chainName)` - Returns `{ chainSupportsEIP7702, walletSupportsEIP7702 }`
  - `useEIP7702BatchTransfer(multiProvider)` - Execute EIP-7702 batch transactions

## Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Batch Contract | Multicall3 | Already used by Lander agent, deployed everywhere |
| Approval Amount | Exact | Per product requirements |
| Chain Detection | Hardcoded list | Simple, can expand as L2s adopt Pectra |
| Fallback | UI responsibility | Hooks return detection flags; UI shows warning on fallback |

## Detection Flow

```
Chain supports EIP-7702?
├── YES → Wallet supports EIP-7702?
│         ├── YES → Use EIP-7702 batch tx
│         └── NO  → Fallback (permit or standard)
└── NO  → Fallback (permit or standard)
```

## Testing

- [ ] Manual testing on Sepolia with EIP-7702 compatible wallet
- [ ] Verify fallback behavior when EIP-7702 unavailable

## Related

- Builds on: #7790 (ERC-2612 permit support)
- Research: https://gist.github.com/paulbalaji/e321fdc4f153ef546b7c7d559fafbce2