### PR TITLE
refactor: move @hyperlane-xyz/utils to devDependencies in core

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,9 +362,6 @@ importers:
 
   solidity:
     dependencies:
-      '@hyperlane-xyz/utils':
-        specifier: workspace:*
-        version: link:../typescript/utils
       '@types/sinon-chai':
         specifier: '*'
         version: 3.2.12
@@ -378,6 +375,9 @@ importers:
       '@hyperlane-xyz/tsconfig':
         specifier: workspace:^
         version: link:../typescript/tsconfig
+      '@hyperlane-xyz/utils':
+        specifier: workspace:*
+        version: link:../typescript/utils
       '@matterlabs/hardhat-zksync-solc':
         specifier: 1.2.5
         version: 1.2.5(hardhat@2.27.0(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.8.3))(typescript@5.8.3)(utf-8-validate@5.0.10))

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -2,11 +2,9 @@
   "name": "@hyperlane-xyz/core",
   "description": "Core solidity contracts for Hyperlane",
   "version": "10.1.5",
-  "dependencies": {
-    "@hyperlane-xyz/utils": "workspace:*"
-  },
   "devDependencies": {
     "@ethersproject/abi": "*",
+    "@hyperlane-xyz/utils": "workspace:*",
     "@ethersproject/providers": "*",
     "@hyperlane-xyz/tsconfig": "workspace:^",
     "@matterlabs/hardhat-zksync-solc": "1.2.5",


### PR DESCRIPTION
## Summary

- Moves `@hyperlane-xyz/utils` from `dependencies` to `devDependencies` in `@hyperlane-xyz/core`
- Utils is only used in test files (`addressToBytes32`, `messageId`, `parseMessage`), not in published contracts or build artifacts

## Context

Previously, changes to `@hyperlane-xyz/utils` implied transitive patch bumps to `@hyperlane-xyz/core`, which could affect onchain bytecode versioning even when no contracts changed. This change breaks that dependency chain.

With the new Solidity changeset validation CI (#7801), explicit changesets are now required for `@hyperlane-xyz/core` when contracts change, making this transitive bump unnecessary.