### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@ solidity/ @yorhodes @ltyu @larryob
 starknet/ @yorhodes @troykessler
 
 ## Agents
-rust/ @ameten @kamiyaa @yjamin
+rust/ @ameten @yjamin
 
 ## SDK
 typescript/utils @yorhodes @ltyu @paulbalaji @xaroz @xeno097 @antigremlin


### PR DESCRIPTION
## Summary
- Removed @kamiyaa from Rust agents code ownership (former employee)

Note: @chrisbrumm was not found in CODEOWNERS - they may have already been removed or were never listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)