### PR TITLE
refactor(ccip-server): Use shared startMetricsServer from @hyperlane-xyz/metrics

### DIFF
--- a/.changeset/ccip-server-shared-metrics.md
+++ b/.changeset/ccip-server-shared-metrics.md
@@ -1,0 +1,6 @@
+---
+"@hyperlane-xyz/ccip-server": patch
+"@hyperlane-xyz/metrics": patch
+---
+
+Migrated ccip-server to use the shared `startMetricsServer` from `@hyperlane-xyz/metrics`. This eliminates the duplicate Express-based metrics server implementation and ensures consistent behavior across all services. The shared server now uses `register.contentType` for proper Prometheus content type headers.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,6 +611,9 @@ importers:
       '@hyperlane-xyz/core':
         specifier: workspace:*
         version: link:../../solidity
+      '@hyperlane-xyz/metrics':
+        specifier: workspace:*
+        version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
         version: 23.7.0

--- a/typescript/ccip-server/Dockerfile
+++ b/typescript/ccip-server/Dockerfile
@@ -29,6 +29,7 @@ COPY patches ./patches
 # Copy only the packages needed for ccip-server
 COPY typescript/ccip-server/package.json ./typescript/ccip-server/
 COPY typescript/deploy-sdk/package.json ./typescript/deploy-sdk/
+COPY typescript/metrics/package.json ./typescript/metrics/
 COPY typescript/sdk/package.json ./typescript/sdk/
 COPY typescript/provider-sdk/package.json ./typescript/provider-sdk/
 COPY typescript/utils/package.json ./typescript/utils/
@@ -57,6 +58,7 @@ RUN pnpm --filter @hyperlane-xyz/ccip-server prisma generate
 COPY turbo.json ./
 COPY typescript/ccip-server ./typescript/ccip-server
 COPY typescript/deploy-sdk ./typescript/deploy-sdk
+COPY typescript/metrics ./typescript/metrics
 COPY typescript/sdk ./typescript/sdk
 COPY typescript/provider-sdk ./typescript/provider-sdk
 COPY typescript/utils ./typescript/utils

--- a/typescript/ccip-server/package.json
+++ b/typescript/ccip-server/package.json
@@ -51,6 +51,7 @@
     "@ethersproject/providers": "*",
     "@google-cloud/pino-logging-gcp-config": "catalog:",
     "@hyperlane-xyz/core": "workspace:*",
+    "@hyperlane-xyz/metrics": "workspace:*",
     "@hyperlane-xyz/registry": "catalog:",
     "@hyperlane-xyz/sdk": "workspace:*",
     "@hyperlane-xyz/utils": "workspace:*",

--- a/typescript/ccip-server/src/server.ts
+++ b/typescript/ccip-server/src/server.ts
@@ -113,15 +113,15 @@ async function startServer() {
 
 // Start the server and handle startup logging
 startServer()
-  .then((logger) => logger.info('Server startup completed'))
+  .then((logger) => {
+    logger.info('Server startup completed');
+    startPrometheusServer(logger);
+    logger.info('Prometheus metrics server started');
+  })
   .catch((err) => {
     console.error('Server startup failed:', err); // Fallback to console if logger failed
     process.exit(1);
   });
-
-startPrometheusServer()
-  .then(() => console.log('Prometheus server started'))
-  .catch((err) => console.error('Prometheus server startup failed:', err));
 
 /*
  * TODO: if PRISMA throws an error the entire express application crashes.

--- a/typescript/ccip-server/src/utils/prometheus.ts
+++ b/typescript/ccip-server/src/utils/prometheus.ts
@@ -1,5 +1,8 @@
-import express from 'express';
+import type http from 'http';
+import type { Logger } from 'pino';
 import { Counter, Registry } from 'prom-client';
+
+import { startMetricsServer } from '@hyperlane-xyz/metrics';
 
 // Global register for offchain lookup metrics
 const register = new Registry();
@@ -56,16 +59,6 @@ export const PrometheusMetrics = {
   },
 };
 
-export async function startPrometheusServer() {
-  const app = express();
-
-  app.get('/metrics', async (req, res) => {
-    res.set('Content-Type', register.contentType);
-    res.end(await register.metrics());
-  });
-
-  const port = parseInt(process.env.PROMETHEUS_PORT ?? '9090');
-  app.listen(port, () =>
-    console.log(`Prometheus server started on port ${port}`),
-  );
+export function startPrometheusServer(logger?: Logger): http.Server {
+  return startMetricsServer(register, logger);
 }

--- a/typescript/metrics/src/server.ts
+++ b/typescript/metrics/src/server.ts
@@ -30,7 +30,9 @@ export function startMetricsServer(
       register
         .metrics()
         .then((metricsStr) => {
-          res.writeHead(200, { 'Content-Type': 'text/plain' }).end(metricsStr);
+          res
+            .writeHead(200, { 'Content-Type': register.contentType })
+            .end(metricsStr);
         })
         .catch((err) => {
           if (logger) {


### PR DESCRIPTION
## Summary
Migrates ccip-server to use the shared `startMetricsServer` from `@hyperlane-xyz/metrics`, eliminating the duplicate Express-based metrics server implementation.

**Depends on**: #7812

## Changes

### `typescript/ccip-server/src/utils/prometheus.ts`
- Replaced Express-based metrics server with the shared HTTP server from `@hyperlane-xyz/metrics`
- Simplified `startPrometheusServer()` to a one-liner wrapper
- Removed `express` import (no longer needed for metrics endpoint)

### `typescript/ccip-server/src/server.ts`
- Unified logging: Prometheus server now receives the same logger as the main server
- Metrics server starts after main server initialization (within the `.then()` chain)

### `typescript/metrics/src/server.ts`
- Improved to use `register.contentType` for proper Prometheus content type headers (was hardcoded `text/plain`)

### `typescript/ccip-server/Dockerfile`
- Added `typescript/metrics` package to build context

### `typescript/ccip-server/package.json`
- Added `@hyperlane-xyz/metrics` as dependency

## Behavior Changes
- **Content-Type header**: Now uses `register.contentType` (e.g., `text/plain; version=0.0.4; charset=utf-8`) instead of hardcoded `text/plain`
- **Non-GET requests**: Returns 405 (Method Not Allowed) instead of Express's default 404
- **Error handling**: Returns 500 with proper error logging on metrics collection failure

## Test Plan
- [x] `pnpm -C typescript/ccip-server build` passes
- [x] `pnpm -C typescript/ccip-server lint` passes
- [ ] Verify `/metrics` endpoint returns expected counters
- [ ] Verify Docker build works

🤖 Generated with [Claude Code](https://claude.ai/code)