### PR TITLE
fix(rebalancer): apply RPC overrides for all warp route chains

### DIFF
--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -68,8 +68,13 @@ export class RebalancerHelmManager extends HelmManager {
       throw new Error('No chains configured');
     }
 
-    // Store the chains for helm values (used for private RPC secrets)
-    this.rebalancerChains = Object.keys(chains);
+    // Store chains for helm values (used for private RPC secrets)
+    // Include BOTH strategy chains AND all warp route chains (for monitoring)
+    const strategyChains = Object.keys(chains);
+    const warpRouteChains = warpCoreConfig.tokens.map((t) => t.chainName);
+    this.rebalancerChains = [
+      ...new Set([...strategyChains, ...warpRouteChains]),
+    ];
 
     // Store the config file content for helm values
     this.rebalancerConfigContent = fs.readFileSync(

--- a/typescript/rebalancer/src/service.ts
+++ b/typescript/rebalancer/src/service.ts
@@ -106,10 +106,7 @@ async function main(): Promise<void> {
     );
 
     // Apply RPC URL overrides from environment variables
-    const configuredChains = Object.keys(
-      rebalancerConfig.strategyConfig.chains,
-    );
-    applyRpcOverrides(chainMetadata, configuredChains);
+    applyRpcOverrides(chainMetadata);
 
     // Create MultiProvider with signer
     const multiProvider = new MultiProvider(chainMetadata);
@@ -152,17 +149,18 @@ async function main(): Promise<void> {
 
 /**
  * Applies RPC URL overrides from environment variables.
- * For each configured chain, checks for RPC_URL_<CHAIN> env var
- * (e.g., RPC_URL_ETHEREUM, RPC_URL_ARBITRUM) and overrides the registry URL.
+ * Checks ALL chains in metadata for RPC_URL_<CHAIN> env vars
+ * (e.g., RPC_URL_ETHEREUM, RPC_URL_PARADEX) and overrides the registry URL.
+ * This ensures warp route chains not in the rebalancing strategy still get
+ * private RPCs for monitoring.
  */
 function applyRpcOverrides(
   chainMetadata: Record<string, Partial<ChainMetadata>>,
-  configuredChains: string[],
 ): void {
-  for (const chain of configuredChains) {
+  for (const chain of Object.keys(chainMetadata)) {
     const envVarName = `RPC_URL_${chain.toUpperCase().replace(/-/g, '_')}`;
     const rpcUrl = process.env[envVarName];
-    if (rpcUrl && chainMetadata[chain]) {
+    if (rpcUrl) {
       rootLogger.debug(
         { chain, envVarName },
         'Using RPC from environment variable',


### PR DESCRIPTION
## Summary
- Fix RPC URL overrides to apply to ALL warp route chains, not just chains in the rebalancing strategy config
- This ensures warp route chains that are only monitored (not rebalanced) can still get private RPCs from GCP Secret Manager

## Changes
- **helm.ts**: Include all warp route chains (not just strategy chains) when generating the chains list for RPC secret injection
- **service.ts**: Apply RPC overrides for ALL chains in metadata that have a matching `RPC_URL_<CHAIN>` env var

## Test plan
- [ ] Deploy rebalancer and verify all warp route chains have RPC env vars injected
- [ ] Verify token checks succeed for all chains in the warp route

🤖 Generated with [Claude Code](https://claude.ai/code)