### PR TITLE
chore: update slither-action to v0.4.2

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -43,7 +43,7 @@ jobs:
         run: cd solidity && forge build --build-info
 
       - name: Static analysis
-        uses: crytic/slither-action@v0.4.1
+        uses: crytic/slither-action@v0.4.2
         id: slither
         with:
           target: 'solidity/'


### PR DESCRIPTION
## Summary
- Updated `crytic/slither-action` from v0.4.1 to v0.4.2 for Python 3.10 support required by recent Slither releases
- The action defaults to latest Slither from PyPI, enabling automatic access to new detectors (like the reentrancy detector in 0.11.5)

## Test plan
- [ ] CI static-analysis workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)