### PR TITLE
feat(sdk): add 2x buffer to ICA quote for gas price fluctuations

### DIFF
--- a/.changeset/ica-quote-buffer.md
+++ b/.changeset/ica-quote-buffer.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Added 2x buffer multiplier to ICA getCallRemote quote to handle gas price fluctuations between Safe tx creation and execution. Configurable via quoteBuffer parameter.

--- a/typescript/sdk/src/middleware/account/types.ts
+++ b/typescript/sdk/src/middleware/account/types.ts
@@ -23,6 +23,9 @@ export const GetCallRemoteSettingsSchema = z.object({
   innerCalls: z.array(CallDataSchema),
   config: AccountConfigSchema,
   hookMetadata: BigNumberSchema.optional(),
+  // Multiplier for gas quote to handle price fluctuations. Defaults to 2.
+  // Excess is refunded by the hook.
+  quoteBuffer: z.number().optional(),
 });
 /* For InterchainAccount::getCallRemote() */
 


### PR DESCRIPTION
## Summary
- Added configurable `quoteBuffer` parameter (default 2x) to `getCallRemote`
- Prevents "StaticAggregationHook: insufficient value" errors when IGP quotes increase between Safe tx creation and execution
- Excess value is refunded by the hook, so this is safe

## Context
Safe transactions using ICA can fail when gas prices or token exchange rates change between:
1. Tx creation time (when quote is fetched)
2. Tx execution time (when hook enforces quote)

The hook calls `quoteDispatch()` at execution time, not creation time, so stale values fail.

## Test plan
- [ ] Verify existing ICA tests pass
- [ ] Manual test with Safe tx on mainnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)