### PR TITLE
ci: reduce Claude review comment noise

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -123,7 +123,7 @@ jobs:
           ref: ${{ steps.pr-sha.outputs.head_sha }}
           fetch-depth: 2
 
-      - name: Delete previous security review comments
+      - name: Collapse previous security review comments
         uses: actions/github-script@v7
         with:
           script: |
@@ -135,11 +135,13 @@ jobs:
             });
             for (const comment of comments) {
               if (comment.body.includes('Security Review') &&
-                  (comment.user.login.includes('github-actions') || comment.user.type === 'Bot')) {
-                await github.rest.issues.deleteComment({
+                  (comment.user.login.includes('github-actions') || comment.user.type === 'Bot') &&
+                  !comment.body.startsWith('<details>')) {
+                await github.rest.issues.updateComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  comment_id: comment.id
+                  comment_id: comment.id,
+                  body: `<details>\n<summary>Previous Security Review</summary>\n\n${comment.body}\n</details>`
                 });
               }
             }
@@ -212,7 +214,7 @@ jobs:
           ref: ${{ steps.pr-sha.outputs.head_sha }}
           fetch-depth: 0
 
-      - name: Delete previous ToB security comments
+      - name: Collapse previous ToB security comments
         if: steps.solidity-changes.outputs.solidity == 'true'
         uses: actions/github-script@v7
         with:
@@ -225,11 +227,13 @@ jobs:
             });
             for (const comment of comments) {
               if (comment.body.includes('Trail of Bits') &&
-                  (comment.user.login.includes('github-actions') || comment.user.type === 'Bot')) {
-                await github.rest.issues.deleteComment({
+                  (comment.user.login.includes('github-actions') || comment.user.type === 'Bot') &&
+                  !comment.body.startsWith('<details>')) {
+                await github.rest.issues.updateComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  comment_id: comment.id
+                  comment_id: comment.id,
+                  body: `<details>\n<summary>Previous Trail of Bits Review</summary>\n\n${comment.body}\n</details>`
                 });
               }
             }


### PR DESCRIPTION
## Summary

Reduces noise in Claude security review comments by collapsing old comments instead of deleting them.

### Changes

1. **Collapse instead of delete**: Previous security review comments are wrapped in `<details>` blocks rather than deleted
2. **Preserves history**: Old reviews remain accessible by expanding the collapsed section
3. **Skips already-collapsed**: Comments already wrapped in `<details>` are not re-wrapped

### Affected reviews
- Security Review (claude-code-security-review action)
- Trail of Bits Security Skills review

### Test plan
- [ ] Push a Solidity change to a PR
- [ ] Verify first security review posts normally
- [ ] Push another commit
- [ ] Verify old comment gets collapsed with `<details>` wrapper
- [ ] Verify new comment posts normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled sticky comments for automated review actions.
  * Added steps to collapse prior review comments into a summary block before reruns.
  * Reordered workflow steps so cleanup runs immediately before each review task to ensure fresh commentary.

Note: No user-facing changes; updates apply to internal review workflow only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->