### PR TITLE
fix(ci): preserve release PR title in publish-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          title: 'chore: release npm packages'
           version: pnpm version:prepare
           publish: pnpm release
           setupGitUser: false


### PR DESCRIPTION
## Summary
- Added `title: 'chore: release npm packages'` to publish-release job's changesets action

## Problem
The release PR title was reverting from "chore: release npm packages" back to "Version Packages" (see #7785).

**Root cause:** Both `prepare-release` and `publish-release` jobs run `changesets/action` with `version: pnpm version:prepare`. The `version:prepare` script includes `turbo run version:update` which regenerates `typescript/cli/src/version.ts` unconditionally.

When `publish-release` runs:
1. Checks out `main` (with old version in version.ts)
2. Runs version:prepare which regenerates version.ts
3. Changesets action detects dirty file and commits "Version Packages"
4. Updates PR without `title` parameter → reverts to default "Version Packages"

## Fix
Add `title` parameter to `publish-release` job so it preserves the correct PR title.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow configuration to generate clearer and more consistent changelog entries during package releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->