### PR TITLE
docs: fix CLI changeset to clarify array syntax options

### DIFF
--- a/.changeset/witty-forks-promise.md
+++ b/.changeset/witty-forks-promise.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/cli': major
 ---
 
-CLI array input handling changed from CSV parsing to native yargs array syntax. Commands now use `--chains a --chains b` instead of `--chains a,b`. Affected options: `--chains`, `--validators`, `--destinations`. Fixed a bug in chain resolver where string spreading produced individual characters instead of chain names.
+CLI array input handling changed from CSV parsing to native yargs array syntax. Commands now use `--chains a b c` or `--chains a --chains b` instead of `--chains a,b`. Affected options: `--chains`, `--validators`, `--destinations`. Fixed a bug in chain resolver where string spreading produced individual characters instead of chain names.


### PR DESCRIPTION
## Summary
- Fixed changeset description to clarify that both `--chains a b c` and `--chains a --chains b` syntax work

The original changeset only mentioned `--chains a --chains b`, which was misleading.

## Test plan
- [x] Read the changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated examples to show multiple ways to specify array options (--chains, --validators, --destinations), including comma-separated values, multiple occurrences, and explicit lists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->