### PR TITLE
feat: add block confirmations to altvm tx submitters

### DIFF
--- a/.changeset/grumpy-ads-camp.md
+++ b/.changeset/grumpy-ads-camp.md
@@ -1,0 +1,8 @@
+---
+'@hyperlane-xyz/provider-sdk': patch
+'@hyperlane-xyz/cosmos-sdk': patch
+'@hyperlane-xyz/radix-sdk': patch
+'@hyperlane-xyz/aleo-sdk': patch
+---
+
+feat: add block confirmations to altvm tx submitters

--- a/typescript/provider-sdk/src/altvm.ts
+++ b/typescript/provider-sdk/src/altvm.ts
@@ -620,9 +620,12 @@ export interface ISigner<T, R> extends IProvider<T> {
 
   transactionToPrintableJson(transaction: T): Promise<object>;
 
-  sendAndConfirmTransaction(transaction: T): Promise<R>;
+  sendAndConfirmTransaction(transaction: T, confirmations?: number): Promise<R>;
 
-  sendAndConfirmBatchTransactions(transactions: T[]): Promise<R>;
+  sendAndConfirmBatchTransactions(
+    transactions: T[],
+    confirmations?: number,
+  ): Promise<R>;
 
   // ### TX CORE ###
 


### PR DESCRIPTION
### Description

This PR adds block confirmations to altvms `sendAndConfirmTransaction`

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Block confirmations support: Transaction submission methods now accept an optional parameter to specify the number of block confirmations to wait for, providing greater control over transaction finality across supported blockchains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->