### PR TITLE
fix(ci): mitigate flaky Hardhat compiler download

### DIFF
--- a/.github/actions/pnpm-build-with-cache/action.yml
+++ b/.github/actions/pnpm-build-with-cache/action.yml
@@ -11,6 +11,12 @@ runs:
       id: pnpm-cache
       uses: ./.github/actions/pnpm-cache
 
+    - name: Cache Hardhat compilers
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/hardhat-nodejs/compilers-v2
+        key: hardhat-compilers-${{ runner.os }}
+
     # Always run install - pnpm needs to create symlinks from the cached store
     # The cache makes this much faster by restoring the pnpm store
     - name: Install dependencies

--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -45,7 +45,7 @@ runs:
     - name: Cache (GitHub)
       id: github-cache
       if: env.cache_provider == 'github'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-store.outputs.store_path }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/actions/setup-foundry/action.yml
+++ b/.github/actions/setup-foundry/action.yml
@@ -14,6 +14,12 @@ runs:
       with:
         version: ${{ steps.foundry-version.outputs.version }}
 
+    - name: Cache Soldeer dependencies
+      uses: actions/cache@v5
+      with:
+        path: solidity/dependencies
+        key: soldeer-${{ hashFiles('solidity/soldeer.lock') }}
+
     - name: Install Soldeer dependencies
       shell: bash
       run: forge soldeer install

--- a/typescript/helloworld/hardhat.config.cts
+++ b/typescript/helloworld/hardhat.config.cts
@@ -9,7 +9,7 @@ import 'solidity-coverage';
  */
 module.exports = {
   solidity: {
-    version: '0.8.19',
+    version: '0.8.22',
   },
   gasReporter: {
     currency: 'USD',


### PR DESCRIPTION
## Summary
- Added Hardhat compiler caching to `pnpm-build-with-cache` action to avoid flaky downloads from GitHub releases
- Added Soldeer dependency caching to `setup-foundry` action to avoid flaky git clones
- Bumped helloworld solc version from 0.8.19 to 0.8.22 for consistency with SDK
- Updated `actions/cache` from v4 to v5

## Test plan
- [ ] CI passes without compiler/dependency download flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Solidity compiler to version 0.8.22
  * Enhanced build pipeline caching for Hardhat compilers and Soldeer dependencies to improve CI/CD performance
  * Updated GitHub Actions cache utility to the latest version

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->