### PR TITLE
fix(solidity): remove constructor checks from interface checker

### DIFF
--- a/solidity/interface.sh
+++ b/solidity/interface.sh
@@ -64,9 +64,7 @@ if [ "$1" = "test-interface" ]; then
             error)
                 jq -r '.[] | select(.type == "error") | "error " + .name + "(" + ([.inputs[].type] | join(",")) + ")"' "$file" 2>/dev/null | sort
                 ;;
-            constructor)
-                jq -r '.[] | select(.type == "constructor") | "constructor(" + ([.inputs[].type] | join(",")) + ")"' "$file" 2>/dev/null
-                ;;
+
             fallback)
                 jq -r '.[] | select(.type == "fallback" or .type == "receive") | .type' "$file" 2>/dev/null | sort
                 ;;
@@ -87,7 +85,7 @@ if [ "$1" = "test-interface" ]; then
         fi
 
         # Check for removals and additions across all ABI types
-        for abi_type in function event error constructor fallback; do
+        for abi_type in function event error fallback; do
             base_items=$(extract_signatures "$base_file" "$abi_type")
             head_items=$(extract_signatures "$head_file" "$abi_type")
             find_removed "$base_items" "$head_items" "$contract_name"

--- a/solidity/test/interface.test.ts
+++ b/solidity/test/interface.test.ts
@@ -8,7 +8,6 @@
  * - Function return type changes
  * - Event removals
  * - Error removals
- * - Constructor changes
  * - Receive/fallback removals
  */
 import { execSync } from 'child_process';
@@ -38,15 +37,6 @@ contract InterfaceTestContract {`,
   },
 
   state: `mapping(address => uint256) public balances;`,
-
-  constructors: {
-    default: `constructor(uint256 initialSupply) {
-        balances[msg.sender] = initialSupply;
-    }`,
-    modified: `constructor(uint256 initialSupply, address recipient) {
-        balances[recipient] = initialSupply;
-    }`,
-  },
 
   functions: {
     transfer: `function transfer(address to, uint256 amount) external returns (bool) {
@@ -86,7 +76,6 @@ contract InterfaceTestContract {`,
 interface ContractConfig {
   events: string[];
   errors: string[];
-  constructor: string;
   functions: string[];
   receive: boolean;
   fallback: boolean;
@@ -110,12 +99,6 @@ function buildContract(config: ContractConfig): string {
   // State
   parts.push('    // State');
   parts.push(`    ${CONTRACT_PARTS.state}`);
-
-  // Constructor
-  if (config.constructor) {
-    parts.push('    // Constructor');
-    parts.push(`    ${config.constructor}`);
-  }
 
   // Functions
   if (config.functions) {
@@ -145,7 +128,6 @@ const BASE_CONFIG: ContractConfig = {
     CONTRACT_PARTS.errors.insufficientBalance,
     CONTRACT_PARTS.errors.unauthorized,
   ],
-  constructor: CONTRACT_PARTS.constructors.default,
   functions: [
     CONTRACT_PARTS.functions.transfer,
     CONTRACT_PARTS.functions.approve,
@@ -220,15 +202,6 @@ const CONTRACT_VARIANTS: Record<
     }),
     shouldFail: true,
     expectedMatch: 'Unauthorized',
-  },
-
-  constructor_changed: {
-    contract: buildContract({
-      ...BASE_CONFIG,
-      constructor: CONTRACT_PARTS.constructors.modified,
-    }),
-    shouldFail: true,
-    expectedMatch: 'constructor',
   },
 
   receive_removed: {


### PR DESCRIPTION
## Summary

- Removed constructor signature comparison from the interface checker script
- Removed associated test case and fixtures from the interface test file

Constructors are implementation details and don't affect the contract's public interface for external callers. Changes to constructor signatures should not be flagged as breaking changes.

## Changes

- `solidity/interface.sh`: Removed `constructor` from ABI types loop and removed the constructor case from `extract_signatures` function
- `solidity/test/interface.test.ts`: Removed constructor fixtures, interface property, build function handling, base config, test case, and documentation reference

## Testing

All 8 interface checker tests pass.