### PR TITLE
feat(infra): Log diffs for MisconfiguredEnrolledRouter violations

### DIFF
--- a/typescript/infra/src/utils/violation.ts
+++ b/typescript/infra/src/utils/violation.ts
@@ -10,6 +10,7 @@ import {
   IsmConfigSchema,
   MailboxViolation,
   MailboxViolationType,
+  RouterViolationType,
 } from '@hyperlane-xyz/sdk';
 
 interface AnyObject {
@@ -286,6 +287,11 @@ export function logViolationDetails(violations: CheckerViolation[]): void {
         `${violation.chain} connection client violation ${violation.type} details:`,
       );
       logViolationDetail(violation);
+    }
+
+    if (violation.type === RouterViolationType.MisconfiguredEnrolledRouter) {
+      console.log(`${violation.chain} router violation details:`);
+      logDiff(violation.expected, violation.actual);
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR addresses an issue during Renzo extension. When running Infra Checker, it showed MisconfiguredEnrolledRouter with `[Object]` and no information on what the actual and expected are.

- Adds detailed diff logging for `MisconfiguredEnrolledRouter` violations in `logViolationDetails`

## Drive-by changes

None

## Related issues

None

## Backward compatibility

Yes

## Testing

Manual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for misconfigured router violations, now displaying detailed configuration comparisons to help identify mismatches between expected and actual settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->