### PR TITLE
feat(sealevel): log base58 transaction on simulation failure

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/provider.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/provider.rs
@@ -197,7 +197,14 @@ impl SealevelProviderForLander for SealevelProvider {
 
         // If there was an error in the simulation result, return an error.
         if simulation_result.err.is_some() {
-            tracing::error!(?simulation_result, "Got simulation result for transaction");
+            // Log base58-encoded transaction for debugging/replay
+            let tx_bytes = bincode::serialize(&simulation_tx).unwrap_or_default();
+            let tx_base58 = solana_sdk::bs58::encode(&tx_bytes).into_string();
+            tracing::error!(
+                ?simulation_result,
+                tx_base58,
+                "Simulation failed - transaction for replay"
+            );
             return Err(ChainCommunicationError::from_other_str(
                 format!("Error in simulation result: {:?}", simulation_result.err).as_str(),
             ));


### PR DESCRIPTION
## Summary
- Log base58-encoded transaction when Sealevel simulation fails in relayer
- Add `mailbox simulate` CLI command to replay failed transactions locally

## Debugging Workflow
1. Relayer simulation fails → logs include `tx_base58` field
2. Developer copies base58 transaction from logs
3. Run `./sealevel-client mailbox simulate --transaction <base58>` to replay locally and see detailed program logs

This helps debug recipient program issues (e.g., `UnsupportedProgramId`, `ConstraintMut` errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI "simulate" command to accept a base58-encoded transaction and display structured simulation results (success/failure, error details, program logs, and compute units).

* **Bug Fixes**
  * Improved error logging for transaction cost estimation to include a serialized transaction for replay and clearer diagnostic information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->