### PR TITLE
Hyperlane gas estimation

### DIFF
--- a/typescript/sdk/src/middleware/account/InterchainAccount.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.ts
@@ -27,6 +27,7 @@ import {
   HyperlaneContracts,
   HyperlaneContractsMap,
 } from '../../contracts/types.js';
+import { HyperlaneCore } from '../../core/HyperlaneCore.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
 import { CallData as SdkCallData } from '../../providers/transactions/types.js';
 import { RouterApp } from '../../router/RouterApps.js';
@@ -230,11 +231,14 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
     );
 
     try {
-      const gasEstimate = await destinationRouter.estimateGas.handle(
-        originDomain,
-        addressToBytes32(localRouterAddress),
-        messageBody,
-        { from: await destinationRouter.mailbox() },
+      const gasEstimate = await HyperlaneCore.estimateHandleGas(
+        destinationRouter,
+        {
+          origin: originDomain,
+          sender: addressToBytes32(localRouterAddress),
+          body: messageBody,
+          from: await destinationRouter.mailbox(),
+        },
       );
       return addBufferToGasLimit(gasEstimate);
     } catch (error) {


### PR DESCRIPTION
### Description

Extracted `estimateGas.handle` logic into a new static helper `HyperlaneCore.estimateHandleGas`. This helper is now used by both `HyperlaneCore.estimateHandle` and `InterchainAccount.estimateHandleGas` to centralize gas estimation for `handle` calls.

### Drive-by changes

- Introduced `HandleGasEstimatable` type for better typing of the recipient in the new helper.

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

Yes

### Testing

None

---
<a href="https://cursor.com/background-agent?bcId=bc-dd1f17f5-48c2-433a-9328-d1361f3fa27a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dd1f17f5-48c2-433a-9328-d1361f3fa27a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

