### PR TITLE
fix: aleo remote transfer units

### DIFF
--- a/typescript/aleo-sdk/src/clients/provider.ts
+++ b/typescript/aleo-sdk/src/clients/provider.ts
@@ -956,7 +956,7 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
   async getRemoteTransferTransaction(
     req: AltVM.ReqRemoteTransfer,
   ): Promise<AleoTransaction> {
-    const { mailboxAddress } = await this.getToken({
+    const { mailboxAddress, tokenType } = await this.getToken({
       tokenAddress: req.tokenAddress,
     });
 
@@ -1028,6 +1028,8 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
       required_hook:${mailbox.requiredHook ? fromAleoAddress(mailbox.requiredHook).address : ALEO_NULL_ADDRESS}
     }`;
 
+    const amount = `${req.amount}${tokenType === AltVM.TokenType.native ? 'u64' : 'u128'}`;
+
     if (req.customHookAddress) {
       const metadataBytes: number[] = fillArray(
         [...Buffer.from(strip0x(req.customHookMetadata || ''), 'hex')],
@@ -1051,7 +1053,7 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
           remoteRouterValue,
           `${req.destinationDomainId}u32`,
           recipient,
-          `${req.amount}u64`,
+          amount,
           arrayToPlaintext(creditAllowance),
           fromAleoAddress(req.customHookAddress).address,
           hookMetadata,
@@ -1070,7 +1072,7 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
         remoteRouterValue,
         `${req.destinationDomainId}u32`,
         recipient,
-        `${req.amount}u64`,
+        amount,
         arrayToPlaintext(creditAllowance),
       ],
     };


### PR DESCRIPTION
### Description

This PR fixes a bug where the aleo native denom requires u64 during a remote transfer and the collateral and synthetic a u128

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote transfer operations now correctly handle different token types when constructing transfer payloads, ensuring proper transaction formatting for both native and non-native transfers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->