### PR TITLE
feat(claude): add investigate and denylist stuck messages skills

### DIFF
--- a/.claude/skills/denylist-stuck-messages/SKILL.md
+++ b/.claude/skills/denylist-stuck-messages/SKILL.md
@@ -1,170 +1,94 @@
 ---
 name: denylist-stuck-messages
-description: Denylist stuck messages that are causing relayer queue alerts. Use when alerts mention "queue length > 0", when messages are stuck in the prepare queue, or when asked to blacklist/denylist specific messages for an app context.
+description: Add message IDs to the relayer denylist. Use after investigating stuck messages with /investigate-stuck-messages, or when you have specific message IDs to denylist.
 ---
 
 # Denylist Stuck Messages
 
-Add stuck messages to the relayer denylist to stop retrying undeliverable messages.
+Add message IDs to the relayer denylist configuration, create a PR, and deploy.
 
 ## When to Use
 
-1. **Alert-based triggers:**
+1. **After investigation:**
 
-   - Alert: "Known app context relayer queue length > 0 for 40m"
-   - Any alert mentioning stuck messages in prepare queue
-   - High retry counts for specific app contexts
+   - User ran `/investigate-stuck-messages` and wants to denylist the found messages
+   - User says "denylist these" or "add these to blacklist"
 
-2. **User request triggers:**
-   - "Denylist messages for [app_context]"
-   - "Blacklist stuck messages on [chain]"
-   - "Stop retrying messages for [warp_route]"
-   - Pasting a Grafana alert URL like `https://abacusworks.grafana.net/alerting/grafana/.../view`
+2. **Direct denylist request:**
+   - User provides specific message IDs to denylist
+   - User pastes message IDs from explorer or logs
 
 ## Input Parameters
 
-The skill accepts either:
-
-**Option 1: Grafana Alert URL (recommended)**
-
 ```
-/denylist-stuck-messages https://abacusworks.grafana.net/alerting/grafana/cdg1ro5hi4vswb/view?tab=instances
+/denylist-stuck-messages <message_ids> [app_context=NAME] [reason=REASON]
 ```
 
-The skill will fetch the alert, extract all firing instances, and get `app_context` and `remote` labels automatically.
+| Parameter     | Required | Default                  | Description                                    |
+| ------------- | -------- | ------------------------ | ---------------------------------------------- |
+| `message_ids` | Yes      | -                        | Space or newline separated message IDs (0x...) |
+| `app_context` | No       | Inferred or "Unknown"    | App context name for the comment               |
+| `reason`      | No       | "stuck in prepare queue" | Reason for denylisting (for comment)           |
+| `environment` | No       | `mainnet3`               | Deployment environment                         |
 
-**Option 2: Manual specification**
+**Examples:**
 
 ```
-/denylist-stuck-messages app_context=EZETH/renzo-prod remote=linea
+/denylist-stuck-messages 0xabc123 0xdef456 app_context=USDC/mainnet-cctp-v2-standard
 ```
 
-| Parameter     | Required | Default    | Description                                                           |
-| ------------- | -------- | ---------- | --------------------------------------------------------------------- |
-| `alert_url`   | No       | -          | Grafana alert URL (extracts app_context/remote from firing instances) |
-| `app_context` | No\*     | -          | The app context (e.g., `EZETH/renzo-prod`, `oUSDT/production`)        |
-| `remote`      | No\*     | -          | Destination chain name (e.g., `linea`, `ethereum`, `arbitrum`)        |
-| `environment` | No       | `mainnet3` | Deployment environment                                                |
-
-\*Either `alert_url` OR both `app_context` and `remote` must be provided.
-
-## Chain Name to Domain ID Mapping
-
-Look up domain IDs in `rust/main/app-contexts/mainnet_config.json`. The app context's `matchingList` contains `originDomain` and `destinationDomain` fields with the numeric IDs.
+```
+/denylist-stuck-messages
+0xabc123
+0xdef456
+0x789ghi
+```
 
 ## Workflow
 
-### Step 0: Parse Input and Extract Alert Instances
+### Step 1: Parse Message IDs
 
-**If Grafana alert URL provided:**
+Extract all message IDs from the input. Valid formats:
 
-1. Extract the alert UID from the URL (e.g., `cdg1ro5hi4vswb` from `.../alerting/grafana/cdg1ro5hi4vswb/view`)
+- Space-separated: `0xabc 0xdef 0x123`
+- Newline-separated
+- Comma-separated: `0xabc, 0xdef, 0x123`
 
-2. Use the Grafana MCP tool to get alert details:
+Validate each ID:
 
-   ```
-   mcp__grafana__get_alert_rule_by_uid(uid="cdg1ro5hi4vswb")
-   ```
+- Must start with `0x`
+- Must be 66 characters (0x + 64 hex chars)
 
-3. Use the Grafana MCP tool to get firing instances:
+### Step 2: Confirm with User
 
-   ```
-   mcp__grafana__list_alert_groups()
-   ```
-
-   Filter for alerts matching the rule UID and state "alerting" or "firing".
-
-4. Extract `app_context` and `remote` labels from each firing instance. These are in the alert labels:
-
-   - `app_context`: e.g., `EZETH/renzo-prod`
-   - `remote`: e.g., `linea`
-
-5. Collect all unique `(app_context, remote)` pairs from firing instances.
-
-**If manual app_context/remote provided:**
-
-Use the provided values directly. Multiple pairs can be comma-separated:
+Use `AskUserQuestion` to confirm:
 
 ```
-app_context=EZETH/renzo-prod,oUSDT/production remote=linea,celo
+Ready to denylist X messages for [APP_CONTEXT]:
+
+| Message ID |
+|------------|
+| 0xabc123... |
+| 0xdef456... |
+
+Proceed?
 ```
-
-### Step 1: Setup Port-Forward to Relayer
-
-First, check if port 9090 is already in use:
-
-```bash
-lsof -i :9090
-```
-
-If not in use, start port-forward in background:
-
-```bash
-kubectl port-forward omniscient-relayer-hyperlane-agent-relayer-0 9090 -n mainnet3 &
-```
-
-Wait a few seconds for the port-forward to establish.
-
-### Step 2: Query Relayer API for Stuck Messages
-
-For each `remote` chain, convert to domain ID and query:
-
-```bash
-curl -s 'http://localhost:9090/list_operations?destination_domain=<DOMAIN_ID>' | jq '.'
-```
-
-The response contains operations with:
-
-- `id`: Message ID (H256)
-- `operation.sender_address`: Sender address
-- `operation.recipient_address`: Recipient address
-- `operation.retry_count`: Number of retries (higher = more stuck)
-- `operation.origin_domain_id`: Origin chain domain
-- `operation.destination_domain_id`: Destination chain domain
-
-### Step 3: Filter Messages by App Context
-
-Look up the `app_context` in `rust/main/app-contexts/mainnet_config.json` to get the matching sender/recipient addresses:
-
-```bash
-jq '.metricAppContexts[] | select(.name == "<APP_CONTEXT>")' rust/main/app-contexts/mainnet_config.json
-```
-
-This returns the `matchingList` with `originDomain`, `senderAddress`, `destinationDomain`, `recipientAddress` for the app context.
-
-Filter the API results to only include messages where:
-
-- `sender_address` matches one of the `senderAddress` values (case-insensitive, both are 0x-prefixed H256)
-- `recipient_address` matches one of the `recipientAddress` values
-
-**Important**: Addresses in the config are padded to 32 bytes (H256 format). The API returns the same format.
-
-### Step 4: Present Messages for User Confirmation
-
-Use `AskUserQuestion` to confirm which messages to denylist:
-
-Present a summary table:
-
-```
-Found X messages for app_context=[APP_CONTEXT] to [REMOTE]:
-
-| Message ID | Retry Count | Origin | Destination |
-|------------|-------------|--------|-------------|
-| 0xabc...   | 45          | arbitrum | linea |
-| 0xdef...   | 52          | arbitrum | linea |
-```
-
-Ask: "Which messages should be added to the denylist?"
 
 Options:
 
-1. "All X messages" (Recommended) - Add all found messages
-2. "Let me specify" - User will provide specific message IDs
-3. "None - cancel" - Abort the operation
+1. "Yes, denylist all" (Recommended)
+2. "Let me modify the list"
+3. "Cancel"
 
-If user selects "Let me specify", ask for the specific message IDs.
+### Step 3: Get User's GitHub Handle
 
-### Step 5: Update Blacklist Configuration
+Ask for GitHub handle if not known:
+
+```
+What is your GitHub handle for the branch name?
+```
+
+### Step 4: Update Blacklist Configuration
 
 Edit `typescript/infra/config/environments/mainnet3/customBlacklist.ts`:
 
@@ -173,32 +97,35 @@ Edit `typescript/infra/config/environments/mainnet3/customBlacklist.ts`:
 3. Include a comment with:
    - App context name
    - Date (YYYY-MM-DD format)
-   - Brief reason (e.g., "stuck in prepare queue")
+   - Reason
 
 Example addition:
 
 ```typescript
-  // [APP_CONTEXT] stuck messages [YYYY-MM-DD]
+  // [APP_CONTEXT] [REASON] [YYYY-MM-DD]
   '0xabc123...',
   '0xdef456...',
 ```
 
-Add the new entries near the end of the array, before the closing bracket, grouped by app context.
+Add entries near the end of the array, before the closing bracket.
 
-### Step 6: Create Branch and Pull Request
+### Step 5: Create Branch and Pull Request
 
 ```bash
-# Create branch (use the user's GitHub handle)
+# Checkout main and pull latest
+git checkout main && git pull origin main
+
+# Create branch
 git checkout -b <github_handle>/denylist-<app_context>
 
 # Stage changes
 git add typescript/infra/config/environments/mainnet3/customBlacklist.ts
 
 # Commit
-git commit -m "denylist: add stuck messages for <APP_CONTEXT>
+git commit -m "chore: denylist <APP_CONTEXT> stuck messages
 
 Added X message IDs to denylist for <APP_CONTEXT> route.
-Messages were stuck in prepare queue with high retry counts.
+Reason: <REASON>
 
 Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
 
@@ -208,77 +135,94 @@ gh pr create --title "chore: denylist <APP_CONTEXT> stuck messages" --body "$(ca
 ## Summary
 - Added X message IDs to the relayer denylist
 - App context: `<APP_CONTEXT>`
-- Destination: `<REMOTE>`
-- Reason: Messages stuck in prepare queue with high retry counts
+- Reason: <REASON>
 
 ## Message IDs
 <list of message IDs>
 
 ## Test plan
 - [ ] Review message IDs are correct
-- [ ] Relayer already deployed with these changes
+- [ ] Deploy relayer with updated denylist
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )"
 ```
 
-### Step 7: Ask User to Confirm Deployment
+### Step 6: Output Slack Message
 
-After creating the PR, ask the user if they want to deploy the relayer now:
+Before asking about deployment, output the Slack message:
+
+```
+**Slack Message (copy/paste to #relayer-alerts):**
+
+:no_entry_sign: *Denylist PR created*
+
+App context: `<APP_CONTEXT>`
+Messages denylisted: X
+Reason: <REASON>
+
+PR: <PR_URL>
+```
+
+### Step 7: Ask About Deployment
 
 Use `AskUserQuestion`:
 
-- Question: "PR created. Deploy the relayer now with the updated denylist?"
-- Options:
-  1. "Yes, deploy now" (Recommended) - Run deployment immediately
-  2. "No, I'll deploy later" - Skip deployment, output command for later use
+```
+PR created. Deploy the relayer now with the updated denylist?
+```
 
-If user confirms deployment, run:
+Options:
+
+1. "Yes, deploy now" (Recommended)
+2. "No, I'll deploy later"
+
+If user confirms, run:
 
 ```bash
 pnpm --dir typescript/infra exec tsx ./scripts/agents/deploy-agents.ts -e mainnet3 --context hyperlane --role relayer
 ```
 
-If user skips deployment, output the command for them to run later.
+If user skips, output the command for later use.
 
-### Step 8: Output Slack Message
+### Step 8: Update Slack Message After Deploy
 
-After deployment, output Slack message for awareness:
-
-**Slack Message (copy/paste to #relayer-alerts or relevant channel):**
+If deployed, update the Slack message:
 
 ```
-🚫 *Denylist deployed*
+:no_entry_sign: *Denylist deployed*
 
 App context: `<APP_CONTEXT>`
-Destination: `<REMOTE>`
 Messages denylisted: X
+Reason: <REASON>
 
 PR: <PR_URL>
 ```
 
-## Handling Multiple App Contexts
+## Grouping by Destination
 
-If the alert has multiple firing instances (multiple app_context/remote pairs):
+If message IDs are for multiple destinations (from investigation output), group them in the blacklist file:
 
-1. Process each pair sequentially
-2. Collect all message IDs across all pairs
-3. Present a combined summary for user confirmation
-4. Create a single PR with all changes
-5. Group message IDs by app context in the blacklist file with separate comments
+```typescript
+  // [APP_CONTEXT] stuck messages [YYYY-MM-DD]
+  // dest: arbitrum
+  '0xabc123...',
+  '0xdef456...',
+  // dest: optimism
+  '0x789ghi...',
+  '0xjkl012...',
+```
 
 ## Error Handling
 
-- **No firing alert instances**: Inform user the alert may have resolved; no action needed
-- **Port-forward fails**: Ask user to check kubectl context and cluster access
-- **No messages found**: Inform user the queue may have cleared; no action needed
-- **API returns error**: Check if relayer pod is running with `kubectl get pods -n mainnet3`
-- **App context not found in config**: The app context may be new or custom; ask user to provide sender/recipient addresses manually
-- **Cannot parse alert URL**: Ask user to provide app_context and remote manually
+- **Invalid message ID format**: Show which IDs are invalid, ask user to fix
+- **Git conflicts**: Pull latest main and retry
+- **PR creation fails**: Check gh auth status
+- **Deployment fails**: Show error, suggest manual deployment
 
 ## Prerequisites
 
-- `kubectl` configured with access to mainnet cluster
 - `gh` CLI authenticated
 - Git configured with push access to the repo
+- For deployment: `kubectl` configured with mainnet cluster access

--- a/.claude/skills/investigate-stuck-messages/SKILL.md
+++ b/.claude/skills/investigate-stuck-messages/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: investigate-stuck-messages
+description: Investigate stuck messages in relayer queue. Use when alerts mention "queue length > 0", to diagnose why messages are stuck, or to get message IDs for denylisting.
+---
+
+# Investigate Stuck Messages
+
+Query the relayer API to investigate stuck messages, their retry counts, and error reasons.
+
+## When to Use
+
+1. **Alert-based triggers:**
+
+   - Alert: "Known app context relayer queue length > 0 for 40m"
+   - Any alert mentioning stuck messages in prepare queue
+   - High retry counts for specific app contexts
+
+2. **User request triggers:**
+   - "Why are messages stuck for [app_context]?"
+   - "Investigate stuck messages on [chain]"
+   - "What's causing the queue alert?"
+   - Pasting a Grafana alert URL
+
+## Input Parameters
+
+**Option 1: Grafana Alert URL (recommended)**
+
+```
+/investigate-stuck-messages https://abacusworks.grafana.net/alerting/grafana/cdg1ro5hi4vswb/view?tab=instances
+```
+
+**Option 2: Manual specification**
+
+```
+/investigate-stuck-messages app_context=EZETH/renzo-prod remote=linea
+```
+
+| Parameter     | Required | Default    | Description                                                           |
+| ------------- | -------- | ---------- | --------------------------------------------------------------------- |
+| `alert_url`   | No       | -          | Grafana alert URL (extracts app_context/remote from firing instances) |
+| `app_context` | No\*     | -          | The app context (e.g., `EZETH/renzo-prod`, `oUSDT/production`)        |
+| `remote`      | No\*     | -          | Destination chain name (e.g., `linea`, `ethereum`, `arbitrum`)        |
+| `environment` | No       | `mainnet3` | Deployment environment                                                |
+
+\*Either `alert_url` OR both `app_context` and `remote` must be provided.
+
+## Workflow
+
+### Step 1: Parse Input and Extract Alert Instances
+
+**If Grafana alert URL provided:**
+
+1. Extract the alert UID from the URL (e.g., `cdg1ro5hi4vswb` from `.../alerting/grafana/cdg1ro5hi4vswb/view`)
+
+2. Query Prometheus directly for firing instances using `mcp__grafana__query_prometheus`:
+
+   ```
+   sum by (app_context, remote)(
+       max_over_time(
+           hyperlane_submitter_queue_length{
+               queue_name="prepare_queue",
+               app_context!~"Unknown|merkly_eth|merkly_erc20|helloworld|velo_message_module",
+               hyperlane_context!~"rc|vanguard0|vanguard1|vanguard2|vanguard3|vanguard4|vanguard5",
+               operation_status!~"Retry\\(ApplicationReport\\(.*\\)\\)|FirstPrepareAttempt",
+               hyperlane_deployment="mainnet3",
+           }[2m]
+       )
+   ) > 0
+   ```
+
+3. Extract `app_context` and `remote` labels from each result.
+
+**If manual app_context/remote provided:**
+
+Use the provided values directly.
+
+### Step 2: Setup Port-Forward to Relayer
+
+Check if port 9090 is already in use:
+
+```bash
+lsof -i :9090
+```
+
+If not in use, start port-forward in background:
+
+```bash
+kubectl port-forward omniscient-relayer-hyperlane-agent-relayer-0 9090 -n mainnet3 &
+```
+
+Wait a few seconds for the port-forward to establish.
+
+### Step 3: Get Domain IDs for Chains
+
+Look up domain IDs from the registry:
+
+```bash
+cat node_modules/.pnpm/@hyperlane-xyz+registry@*/node_modules/@hyperlane-xyz/registry/dist/chains/<chain>/metadata.json | jq '.domainId'
+```
+
+Common domain IDs:
+
+- ethereum: 1
+- optimism: 10
+- arbitrum: 42161
+- polygon: 137
+- base: 8453
+- unichain: 130
+- avalanche: 43114
+
+### Step 4: Query Relayer API
+
+For each destination chain, query the relayer API:
+
+```bash
+curl -s 'http://localhost:9090/list_operations?destination_domain=<DOMAIN_ID>' > /tmp/<chain>.json
+```
+
+The response contains operations with:
+
+- `id`: Message ID (H256)
+- `operation.message.sender`: Sender address
+- `operation.message.recipient`: Recipient address
+- `operation.num_retries`: Number of retries (higher = more stuck)
+- `operation.status`: Error status (e.g., `{"Retry": "ErrorEstimatingGas"}`)
+- `operation.message.origin`: Origin domain ID
+- `operation.message.destination`: Destination domain ID
+- `operation.app_context`: App context name
+
+### Step 5: Filter Messages by App Context
+
+Look up the `app_context` in `rust/main/app-contexts/mainnet_config.json`:
+
+```bash
+jq '.metricAppContexts[] | select(.name == "<APP_CONTEXT>")' rust/main/app-contexts/mainnet_config.json
+```
+
+Filter API results to only include messages where:
+
+- `operation.message.recipient` matches one of the `recipientAddress` values for that destination domain
+
+**Important**: Addresses are padded to 32 bytes (H256 format).
+
+### Step 6: Query GCP Logs for Actual Errors
+
+**Calculate log freshness based on retry count:**
+
+The relayer uses exponential backoff (see `calculate_msg_backoff` in `rust/main/agents/relayer/src/msg/pending_message.rs`):
+
+| Retries | Backoff/retry | Cumulative Time | Freshness Flag    |
+| ------- | ------------- | --------------- | ----------------- |
+| 1-4     | 5s-1min       | ~2min           | `--freshness=1h`  |
+| 5-24    | 3min          | ~1h             | `--freshness=3h`  |
+| 25-39   | 5-26min       | ~5h             | `--freshness=12h` |
+| 40-49   | 30min-1h      | ~12h            | `--freshness=24h` |
+| 50-60   | 2-22h         | ~35h            | `--freshness=3d`  |
+| 60+     | 22h+          | 35h+            | `--freshness=7d`  |
+
+For each message ID, query GCP logs with calculated freshness:
+
+```bash
+gcloud logging read 'resource.type=k8s_container AND resource.labels.namespace_name=mainnet3 AND resource.labels.pod_name:omniscient-relayer AND jsonPayload.span.id:<MESSAGE_ID> AND jsonPayload.fields.error:*' --project=abacus-labs-dev --limit=1 --format='value(jsonPayload.fields.error)' --freshness=<CALCULATED_FRESHNESS>
+```
+
+Extract the human-readable error from the response using `sed` (macOS compatible):
+
+```bash
+echo "$raw_error" | sed -n 's/.*execution reverted: \([^"]*\)".*/\1/p' | head -1
+```
+
+Common error patterns:
+
+- `"execution reverted: Nonce already used"` → "Nonce already used"
+- `"execution reverted: panic: arithmetic underflow"` → "Arithmetic underflow"
+
+**Note**: Do not use `grep -P` as it's not available on macOS.
+
+### Step 7: Present Investigation Results
+
+Output a detailed summary table with **full message IDs** and **both error sources**:
+
+```
+## Investigation Results for [APP_CONTEXT]
+
+### Summary
+- Total stuck messages: X
+- Destinations affected: [list]
+- Reprepare reasons: ErrorEstimatingGas (N), CouldNotFetchMetadata (M)
+
+### Messages
+
+| Message ID | Retries | Reprepare Reason | Error | Origin |
+|------------|---------|------------------|-----------|--------|
+| `0xaa18ebc1c79345e6d24984a0b9a5ab66c968d128d46b2357b641e56e71b8d30c` | 47 | ErrorEstimatingGas | Nonce already used | optimism |
+| `0xd6aeef7c092a88aa23ad53227aeb834ae731d059b3ce749db8451e761f3f15ac` | 47 | ErrorEstimatingGas | Nonce already used | arbitrum |
+
+**Important**: Always show the full 66-character message ID (0x + 64 hex chars). Do not truncate.
+
+### Error Analysis
+[Explain based on the actual log errors found]
+
+### Next Steps
+To denylist these messages, run:
+/denylist-stuck-messages <message_ids> app_context=APP_CONTEXT
+```
+
+**Column definitions:**
+
+- **Reprepare Reason**: From `operation.status` in relayer API (e.g., ErrorEstimatingGas, CouldNotFetchMetadata)
+- **Error**: Actual revert reason from GCP logs (e.g., "Nonce already used", "Arithmetic underflow")
+
+### Step 8: Output Denylist Command
+
+At the end of the investigation results, output the full denylist command:
+
+```
+### Next Steps
+To denylist, run:
+/denylist-stuck-messages 0xaa18ebc1c79345e6d24984a0b9a5ab66c968d128d46b2357b641e56e71b8d30c 0xd6aeef7c092a88aa23ad53227aeb834ae731d059b3ce749db8451e761f3f15ac app_context=APP_CONTEXT
+```
+
+Always use full message IDs, never truncated.
+
+## Error Status Reference
+
+| Status                   | Meaning                                 | Action                                   |
+| ------------------------ | --------------------------------------- | ---------------------------------------- |
+| `ErrorEstimatingGas`     | Gas estimation failed (contract revert) | Usually denylist - contract won't accept |
+| `CouldNotFetchMetadata`  | Can't get ISM metadata                  | Check validators, may resolve itself     |
+| `ApplicationReport(...)` | App-specific error                      | Check the specific error message         |
+| `GasPaymentNotFound`     | No IGP payment                          | May need manual relay with gas           |
+
+## Error Handling
+
+- **Port-forward fails**: Check kubectl context: `kubectl config current-context`
+- **No messages found**: Queue may have cleared; alert may be stale
+- **API returns error**: Check relayer pod: `kubectl get pods -n mainnet3 | grep relayer`
+- **App context not found**: May be new/custom; ask user for sender/recipient addresses
+
+## Prerequisites
+
+- `kubectl` configured with access to mainnet cluster
+- Grafana MCP server connected (for alert URL parsing)


### PR DESCRIPTION
## Summary
- Added `investigate-stuck-messages` skill for diagnosing why messages are stuck in relayer queue
- Updated `denylist-stuck-messages` skill to take message IDs as input (separated from investigation)

The investigation skill:
- Queries relayer API for stuck messages with retry counts and reprepare reasons
- Fetches actual errors from GCP logs
- Calculates next retry time based on backoff schedule
- Outputs formatted table for easy analysis

The denylist skill:
- Takes message IDs as input (from investigation or alert)
- Updates customBlacklist.ts with provided message IDs
- Creates PR and optionally deploys relayer

## Test plan
- [x] Tested investigate skill against live alerts
- [x] Tested denylist skill with 4 CCTP messages to ethereum
- [x] Verified deployment works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added operational guides for investigating stuck messages in the relayer system and managing the denylist configuration, including step-by-step workflows, error handling procedures, and command examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->