### PR TITLE
feat: clear auth token when request is unauthorzied

### DIFF
--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -200,6 +200,7 @@ impl HttpClient for JWTBaseHttpClient {
             .await
             .map_err(HyperlaneAleoError::from)?;
 
+        // Two instances of the relayer might compete for the same JWT, if so clear the token early and request a new one
         if response.status() == reqwest::StatusCode::UNAUTHORIZED {
             self.clear_auth_token().await;
         }
@@ -229,6 +230,7 @@ impl HttpClient for JWTBaseHttpClient {
             .await
             .map_err(HyperlaneAleoError::from)?;
 
+        // Two instances of the relayer might compete for the same JWT, if so clear the token early and request a new one
         if response.status() == reqwest::StatusCode::UNAUTHORIZED {
             self.clear_auth_token().await;
         }


### PR DESCRIPTION
### Description
The past proving JWT becomes invalid when we request a new token. There might be the case where we request a new JWT for the same secret, for example when the RC context is also running and the current implementation is not aware of that. 

This PR realizes when our JWT is outdated and requests a new one directly.
<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication resilience: cached auth tokens are now cleared automatically when API responses indicate unauthorized access, forcing a fresh token retrieval on the next request. This prevents repeated failures from stale credentials and improves reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->