### PR TITLE
fix(cli): generate Cosmos placeholder addresses dynamically for warp fee command

### DIFF
--- a/.changeset/warp-fee-cosmos-prefix.md
+++ b/.changeset/warp-fee-cosmos-prefix.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Fixed warp fee command failing for Cosmos chains with non-standard bech32 prefixes (e.g., osmo1, inj1) by generating placeholder addresses dynamically using the chain's bech32Prefix from metadata.


### PR DESCRIPTION
## Summary
- Fixed warp fee command failing for Cosmos chains with non-standard bech32 prefixes (e.g., `osmo1`, `inj1`, `neutron1`)
- `WarpCore.validateRecipient` checks that recipient prefix matches the destination chain's `bech32Prefix`, so hardcoded `cosmos1...` placeholders fail
- Now generates placeholder addresses dynamically using `bytesToAddressCosmos()` with the chain's `bech32Prefix` from metadata

## Example
```
$ hyperlane warp get-fees --warpRouteId TIA/celestia-ethereum

Hyperlane CLI
Hyperlane Warp Route Fees
_________________________

Fee Breakdown:
┌─────────┬────────────┬─────────────┬──────────────┬───────────┬──────────┐
│ (index) │ Origin     │ Destination │ Fee Amount   │ Fee Token │ USD Cost │
├─────────┼────────────┼─────────────┼──────────────┼───────────┼──────────┤
│ 0       │ 'celestia' │ 'ethereum'  │ '3.29402200' │ 'TIA'     │ '~$1.49' │
│ 1       │ 'ethereum' │ 'celestia'  │ '0.00012630' │ 'ETH'     │ '~$0.38' │
└─────────┴────────────┴─────────────┴──────────────┴───────────┴──────────┘

Total USD Cost Matrix (From → To):
┌─────────┬────────────┬──────────┬──────────┐
│ (index) │ From       │ celestia │ ethereum │
├─────────┼────────────┼──────────┼──────────┤
│ 0       │ 'celestia' │ '-'      │ '$1.49'  │
│ 1       │ 'ethereum' │ '$0.38'  │ '-'      │
└─────────┴────────────┴──────────┴──────────┘

Fees quoted for 1 token transfer.
USD prices from CoinGecko (approximate).
```

## Test plan
- [x] Build passes: `pnpm -C typescript/cli build`
- [x] Lint passes: `pnpm -C typescript/cli lint`
- [x] Unit tests pass: `pnpm -C typescript/cli test:ci`

🤖 Generated with [Claude Code](https://claude.ai/code)