### PR TITLE
fix(cli): remove unused DEFAULT_METRICS_SERVER variable

### DIFF
--- a/typescript/cli/src/tests/ethereum/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-rebalancer.e2e-test.ts
@@ -71,8 +71,6 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
   // For these tests we mostly care about the first run
   const CHECK_FREQUENCY = 60000;
 
-  const DEFAULT_METRICS_SERVER = 'http://localhost:9090/metrics';
-
   let tokenSymbol: string;
   let warpRouteId: string;
   let snapshots: { rpcUrl: string; snapshotId: string }[] = [];


### PR DESCRIPTION
## Summary
- Removed unused `DEFAULT_METRICS_SERVER` constant from warp-rebalancer e2e test file that was causing TypeScript build error (TS6133)

## Test plan
- [x] Build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)