### PR TITLE
refactor(sdk): rename evm warp module and reader

### DIFF
--- a/.changeset/rename-evm-warp-module.md
+++ b/.changeset/rename-evm-warp-module.md
@@ -1,0 +1,6 @@
+---
+"@hyperlane-xyz/sdk": major
+---
+
+Renamed EvmERC20WarpModule to EvmWarpModule.
+Renamed EvmERC20WarpRouteReader to EvmWarpRouteReader.

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -19,7 +19,7 @@ import {
   type ChainMap,
   type ChainName,
   ContractVerifier,
-  EvmERC20WarpModule,
+  EvmWarpModule,
   ExplorerLicenseType,
   HypERC20Deployer,
   IsmType,
@@ -724,7 +724,7 @@ async function updateExistingWarpRoute(
 
         switch (protocolType) {
           case ProtocolType.Ethereum: {
-            const evmERC20WarpModule = new EvmERC20WarpModule(
+            const evmERC20WarpModule = new EvmWarpModule(
               multiProvider,
               {
                 config: configWithMailbox,

--- a/typescript/cli/src/read/warp.ts
+++ b/typescript/cli/src/read/warp.ts
@@ -11,7 +11,7 @@ import {
   type ChainMap,
   type ChainName,
   type DerivedWarpRouteDeployConfig,
-  EvmERC20WarpRouteReader,
+  EvmWarpRouteReader,
   type HypTokenRouterConfig,
   type MultiProvider,
   TokenStandard,
@@ -126,7 +126,7 @@ async function deriveWarpRouteConfigs(
       const protocol = context.multiProvider.getProtocol(chain);
       switch (protocol) {
         case ProtocolType.Ethereum: {
-          return new EvmERC20WarpRouteReader(
+          return new EvmWarpRouteReader(
             multiProvider,
             chain,
           ).deriveWarpRouteConfig(address);

--- a/typescript/cli/src/verify/warp.ts
+++ b/typescript/cli/src/verify/warp.ts
@@ -3,7 +3,7 @@ import { type ContractFactory } from 'ethers';
 import { buildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
 import {
   type ChainMap,
-  EvmERC20WarpRouteReader,
+  EvmWarpRouteReader,
   ExplorerLicenseType,
   type MultiProvider,
   PostDeploymentContractVerifier,
@@ -124,7 +124,7 @@ async function getWarpRouteFactory(
     typeof TokenType.syntheticUri | typeof TokenType.collateralUri
   >;
 }> {
-  const warpRouteReader = new EvmERC20WarpRouteReader(multiProvider, chainName);
+  const warpRouteReader = new EvmWarpRouteReader(multiProvider, chainName);
   const tokenType = (await warpRouteReader.deriveTokenType(
     warpRouteAddress,
   )) as Exclude<

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -43,7 +43,7 @@ import { altVmChainLookup } from '../metadata/ChainMetadataManager.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { TypedAnnotatedTransaction } from '../providers/ProviderType.js';
 import { DestinationGas, RemoteRouters } from '../router/types.js';
-import { EvmERC20WarpModule } from '../token/EvmERC20WarpModule.js';
+import { EvmWarpModule } from '../token/EvmWarpModule.js';
 import { gasOverhead } from '../token/config.js';
 import { HypERC20Factories, hypERC20factories } from '../token/contracts.js';
 import { HypERC20Deployer, HypERC721Deployer } from '../token/deploy.js';
@@ -134,7 +134,7 @@ export async function executeWarpDeploy(
       case ProtocolType.Ethereum: {
         const deployer = warpDeployConfig.isNft
           ? new HypERC721Deployer(multiProvider)
-          : new HypERC20Deployer(multiProvider); // TODO: replace with EvmERC20WarpModule
+          : new HypERC20Deployer(multiProvider); // TODO: replace with EvmWarpModule
 
         const evmContracts = await deployer.deploy(protocolSpecificConfig);
         deployedContracts = {
@@ -449,7 +449,7 @@ export async function enrollCrossChainRouters(
             staticMessageIdWeightedMultisigIsmFactory,
           } = registryAddresses[currentChain];
 
-          const evmWarpModule = new EvmERC20WarpModule(multiProvider, {
+          const evmWarpModule = new EvmWarpModule(multiProvider, {
             chain: currentChain,
             config: resolvedConfigMap[currentChain],
             addresses: {

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -700,8 +700,8 @@ export {
   TokenFactories,
 } from './token/contracts.js';
 export { HypERC20Deployer, HypERC721Deployer } from './token/deploy.js';
-export { EvmERC20WarpModule } from './token/EvmERC20WarpModule.js';
-export { EvmERC20WarpRouteReader } from './token/EvmERC20WarpRouteReader.js';
+export { EvmWarpModule } from './token/EvmWarpModule.js';
+export { EvmWarpRouteReader } from './token/EvmWarpRouteReader.js';
 export { IToken, TokenArgs, TokenConfigSchema } from './token/IToken.js';
 export { Token, getCollateralTokenAdapter } from './token/Token.js';
 export { TokenAmount } from './token/TokenAmount.js';

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.foundry-test.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.foundry-test.ts
@@ -14,7 +14,8 @@ const PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const NETWORK = 31337;
 const URL = 'http://127.0.0.1:8545';
 
-describe('SmartProvider', async () => {
+describe('SmartProvider', function () {
+  this.timeout(10_000);
   let signer: Wallet;
   let smartProvider: HyperlaneSmartProvider;
   let contractAddress: string;

--- a/typescript/sdk/src/token/EvmWarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.hardhat-test.ts
@@ -61,7 +61,7 @@ import { randomAddress } from '../test/testUtils.js';
 import { ChainMap } from '../types.js';
 import { normalizeConfig } from '../utils/ism.js';
 
-import { EvmERC20WarpModule } from './EvmERC20WarpModule.js';
+import { EvmWarpModule } from './EvmWarpModule.js';
 import {
   EverclearTokenBridgeTokenType,
   MovableTokenType,
@@ -89,7 +89,7 @@ const randomRemoteRouters = (n: number) => {
   return routers;
 };
 
-describe('EvmERC20WarpHyperlaneModule', async () => {
+describe('EvmWarpModule', async () => {
   const TOKEN_NAME = 'fake';
   const TOKEN_SUPPLY = '100000000000000000000';
   const TOKEN_DECIMALS = 18;
@@ -175,7 +175,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
   ] as EverclearTokenBridgeTokenType[];
 
   const assertAllowedRebalancers = async (
-    evmERC20WarpModule: EvmERC20WarpModule,
+    evmERC20WarpModule: EvmWarpModule,
     expectedRebalancers: string[],
   ) => {
     const currentConfig = await evmERC20WarpModule.read();
@@ -267,7 +267,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
     };
 
     // Deploy using WarpModule
-    const evmERC20WarpModule = await EvmERC20WarpModule.create({
+    const evmERC20WarpModule = await EvmWarpModule.create({
       chain,
       config,
       multiProvider,
@@ -289,7 +289,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
     };
 
     // Deploy using WarpModule
-    const evmERC20WarpModule = await EvmERC20WarpModule.create({
+    const evmERC20WarpModule = await EvmWarpModule.create({
       chain,
       config,
       multiProvider,
@@ -325,7 +325,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
     };
 
     // Deploy using WarpModule
-    const evmERC20WarpModule = await EvmERC20WarpModule.create({
+    const evmERC20WarpModule = await EvmWarpModule.create({
       chain,
       config,
       multiProvider,
@@ -357,7 +357,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
     } as HypTokenRouterConfig;
 
     // Deploy using WarpModule
-    const evmERC20WarpModule = await EvmERC20WarpModule.create({
+    const evmERC20WarpModule = await EvmWarpModule.create({
       chain,
       config,
       multiProvider,
@@ -387,7 +387,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
     } as HypTokenRouterConfig;
 
     // Deploy using WarpModule
-    const evmERC20WarpModule = await EvmERC20WarpModule.create({
+    const evmERC20WarpModule = await EvmWarpModule.create({
       chain,
       config,
       multiProvider,
@@ -405,7 +405,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         getMovableTokenConfig(expectedRebalancers)[tokenType],
       );
 
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config,
         multiProvider,
@@ -421,7 +421,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       const config = getEverclearTokenBridgeTokenConfig()[tokenType];
 
       // Deploy using WarpModule
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config,
         multiProvider,
@@ -476,7 +476,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       };
 
       // Deploy using WarpModule
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config: updatedConfig,
         multiProvider,
@@ -501,7 +501,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
     });
   }
 
-  describe(EvmERC20WarpModule.prototype.update.name, async () => {
+  describe(EvmWarpModule.prototype.update.name, async () => {
     const owner = randomAddress();
     const ismConfigToUpdate: IsmConfig[] = [
       {
@@ -551,7 +551,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         } as HypTokenRouterConfig;
 
         // Deploy using WarpModule
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config,
           multiProvider,
@@ -580,7 +580,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       } as HypTokenRouterConfig;
 
       // Deploy using WarpModule
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config,
         multiProvider,
@@ -620,7 +620,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       } as HypTokenRouterConfig;
 
       // Deploy using WarpModule
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config,
         multiProvider,
@@ -647,7 +647,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       } as HypTokenRouterConfig;
 
       // Deploy using WarpModule
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config,
         multiProvider,
@@ -678,7 +678,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       } as HypTokenRouterConfig;
 
       // Deploy using WarpModule
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config,
         multiProvider,
@@ -727,7 +727,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         interchainSecurityModule: deployedIsm,
       } as HypTokenRouterConfig;
 
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config,
         multiProvider,
@@ -764,7 +764,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       } as HypTokenRouterConfig;
 
       // Deploy using WarpModule
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config: {
           ...config,
@@ -795,7 +795,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       } as HypTokenRouterConfig;
 
       // Deploy using WarpModule
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config: {
           ...config,
@@ -832,7 +832,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       } as HypTokenRouterConfig;
 
       // Deploy using WarpModule
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config: {
           ...config,
@@ -890,7 +890,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       } as HypTokenRouterConfig;
 
       const owner = signer.address.toLowerCase();
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config: {
           ...config,
@@ -929,7 +929,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       };
 
       const owner = signer.address.toLowerCase();
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config: {
           ...config,
@@ -977,7 +977,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       };
 
       // Deploy using WarpModule
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config: {
           ...config,
@@ -1005,7 +1005,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         const config = deepCopy(
           getMovableTokenConfig([initialRebalancer])[tokenType],
         );
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config,
           multiProvider,
@@ -1032,7 +1032,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         const config = deepCopy(
           getMovableTokenConfig(Array.from(rebalancers))[tokenType],
         );
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config,
           multiProvider,
@@ -1056,7 +1056,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
           getMovableTokenConfig([rebalancerToKeep.toLowerCase()])[tokenType],
         );
 
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config,
           multiProvider,
@@ -1084,7 +1084,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         };
 
         const allowedBridgeToAdd = normalizeAddressEvm(randomAddress());
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config,
           multiProvider,
@@ -1143,7 +1143,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
           },
         });
 
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config,
           multiProvider,
@@ -1194,7 +1194,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
           },
         });
 
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config,
           multiProvider,
@@ -1223,7 +1223,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         const remoteRouter = randomAddress();
 
         const config = deepCopy(getMovableTokenConfig()[tokenType]);
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config: {
             ...config,
@@ -1269,7 +1269,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       it(`should add destination outputAssets if the token is of type ${tokenType}`, async () => {
         const config = getEverclearTokenBridgeTokenConfig()[tokenType];
 
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config,
           multiProvider,
@@ -1301,7 +1301,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       it(`should overwrite a destination outputAssets if the token is of type ${tokenType} and a destination token already exists for the given destination`, async () => {
         const config = getEverclearTokenBridgeTokenConfig()[tokenType];
 
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config: {
             ...config,
@@ -1338,7 +1338,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       it(`should remove destination outputAssets if the token is of type ${tokenType} and a config is set`, async () => {
         const config = getEverclearTokenBridgeTokenConfig()[tokenType];
 
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config: {
             ...config,
@@ -1391,7 +1391,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
           [domainId]: randomAddress(),
           ...outputAssetsToKeep,
         };
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config: {
             ...config,
@@ -1423,7 +1423,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       it(`should update the fee params if the token is of type ${tokenType}`, async () => {
         const config = getEverclearTokenBridgeTokenConfig()[tokenType];
 
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config,
           multiProvider,
@@ -1461,7 +1461,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
 
         const expectedEverclearFeeParams = config.everclearFeeParams;
 
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config,
           multiProvider,
@@ -1485,7 +1485,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       it(`should remove everclear fee params if the token is of type ${tokenType}`, async () => {
         const config = getEverclearTokenBridgeTokenConfig()[tokenType];
 
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config,
           multiProvider,
@@ -1537,7 +1537,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
           ...feeParamsToKeep,
         };
 
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config: {
             ...config,
@@ -1603,7 +1603,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
           },
         };
 
-        const evmERC20WarpModule = await EvmERC20WarpModule.create({
+        const evmERC20WarpModule = await EvmWarpModule.create({
           chain,
           config: {
             ...config,
@@ -1654,7 +1654,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       };
 
       // Deploy using WarpModule
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config: {
           ...config,
@@ -1710,7 +1710,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       };
 
       // Deploy using WarpModule
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config: {
           ...config,
@@ -1749,7 +1749,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
       };
 
       // Deploy using WarpModule
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config,
         multiProvider,
@@ -1779,7 +1779,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         type: TokenType.native,
       };
 
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config,
         multiProvider,
@@ -1823,7 +1823,7 @@ describe('EvmERC20WarpHyperlaneModule', async () => {
         type: TokenType.native,
       };
 
-      const evmERC20WarpModule = await EvmERC20WarpModule.create({
+      const evmERC20WarpModule = await EvmWarpModule.create({
         chain,
         config,
         multiProvider,

--- a/typescript/sdk/src/token/EvmWarpModule.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.ts
@@ -61,7 +61,7 @@ import { RemoteRouters, resolveRouterMapConfig } from '../router/types.js';
 import { ChainName, ChainNameOrId } from '../types.js';
 import { extractIsmAndHookFactoryAddresses } from '../utils/ism.js';
 
-import { EvmERC20WarpRouteReader } from './EvmERC20WarpRouteReader.js';
+import { EvmWarpRouteReader } from './EvmWarpRouteReader.js';
 import { resolveTokenFeeAddress } from './configUtils.js';
 import { hypERC20contracts } from './contracts.js';
 import { HypERC20Deployer } from './deploy.js';
@@ -98,15 +98,15 @@ const getAllowedRebalancingBridgesByDomain = (
     },
   );
 };
-export class EvmERC20WarpModule extends HyperlaneModule<
+export class EvmWarpModule extends HyperlaneModule<
   ProtocolType.Ethereum,
   HypTokenRouterConfig,
   WarpRouteAddresses
 > {
   protected logger = rootLogger.child({
-    module: 'EvmERC20WarpModule',
+    module: 'EvmWarpModule',
   });
-  reader: EvmERC20WarpRouteReader;
+  reader: EvmWarpRouteReader;
   public readonly chainName: ChainName;
   public readonly chainId: EvmChainId;
   public readonly domainId: Domain;
@@ -118,7 +118,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     protected readonly contractVerifier?: ContractVerifier,
   ) {
     super(args);
-    this.reader = new EvmERC20WarpRouteReader(multiProvider, args.chain);
+    this.reader = new EvmWarpRouteReader(multiProvider, args.chain);
     this.chainName = this.multiProvider.getChainName(args.chain);
     this.chainId = multiProvider.getEvmChainId(args.chain);
     this.domainId = multiProvider.getDomainId(args.chain);
@@ -1128,7 +1128,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     const updateTransactions: AnnotatedEV5Transaction[] = [];
 
     // This should be impossible since we try catch the call to `PACKAGE_VERSION`
-    // in `EvmERC20WarpRouteReader.fetchPackageVersion`
+    // in `EvmWarpRouteReader.fetchPackageVersion`
     assert(
       actualConfig.contractVersion,
       'Actual contract version is undefined',
@@ -1217,7 +1217,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     ccipContractCache?: CCIPContractCache;
     contractVerifier?: ContractVerifier;
     proxyFactoryFactories: HyperlaneAddresses<ProxyFactoryFactories>;
-  }): Promise<EvmERC20WarpModule> {
+  }): Promise<EvmWarpModule> {
     const {
       chain,
       config,
@@ -1230,7 +1230,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
     const deployer = new HypERC20Deployer(multiProvider);
     const deployedContracts = await deployer.deployContracts(chainName, config);
 
-    const warpModule = new EvmERC20WarpModule(
+    const warpModule = new EvmWarpModule(
       multiProvider,
       {
         addresses: {
@@ -1250,7 +1250,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
         await warpModule.createEnrollRemoteRoutersUpdateTxs(
           actualConfig,
           config,
-        ); // @TODO Remove when EvmERC20WarpModule.create can be used
+        ); // @TODO Remove when EvmWarpModule.create can be used
       const onlyTxIndex = 0;
       await multiProvider.sendTransaction(chain, enrollRemoteTxs[onlyTxIndex]);
     }
@@ -1263,7 +1263,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
       const addRebalancerTxs = await warpModule.createAddRebalancersUpdateTxs(
         actualConfig,
         config,
-      ); // @TODO Remove when EvmERC20WarpModule.create can be used
+      ); // @TODO Remove when EvmWarpModule.create can be used
 
       for (const tx of addRebalancerTxs) {
         await multiProvider.sendTransaction(chain, tx);
@@ -1278,7 +1278,7 @@ export class EvmERC20WarpModule extends HyperlaneModule<
       const addBridgesTxs = await warpModule.createAddAllowedBridgesUpdateTxs(
         actualConfig,
         config,
-      ); // @TODO Remove when EvmERC20WarpModule.create can be used
+      ); // @TODO Remove when EvmWarpModule.create can be used
 
       for (const tx of addBridgesTxs) {
         await multiProvider.sendTransaction(chain, tx);

--- a/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
@@ -60,9 +60,9 @@ import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainMap } from '../types.js';
 
 import {
-  EvmERC20WarpRouteReader,
+  EvmWarpRouteReader,
   TOKEN_FEE_CONTRACT_VERSION,
-} from './EvmERC20WarpRouteReader.js';
+} from './EvmWarpRouteReader.js';
 import { EverclearTokenBridgeTokenType, TokenType } from './config.js';
 import { HypERC20Deployer } from './deploy.js';
 import {
@@ -73,7 +73,7 @@ import {
   derivedIsmAddress,
 } from './types.js';
 
-describe('ERC20WarpRouterReader', async () => {
+describe('EvmWarpRouteReader', async () => {
   const TOKEN_NAME = 'fake';
   const TOKEN_SUPPLY = '100000000000000000000';
   const TOKEN_DECIMALS = 18;
@@ -93,7 +93,7 @@ describe('ERC20WarpRouterReader', async () => {
   let routerConfigMap: ChainMap<RouterConfig>;
   let baseConfig: RouterConfig;
   let mailbox: Mailbox;
-  let evmERC20WarpRouteReader: EvmERC20WarpRouteReader;
+  let evmERC20WarpRouteReader: EvmWarpRouteReader;
   let vault: ERC4626;
   let collateralFiatToken: FiatTokenTest;
   let everclearBridgeAdapterMockFactory: MockEverclearAdapter__factory;
@@ -163,7 +163,7 @@ describe('ERC20WarpRouterReader', async () => {
       coreBuildArtifact,
       ExplorerLicenseType.MIT,
     );
-    evmERC20WarpRouteReader = new EvmERC20WarpRouteReader(
+    evmERC20WarpRouteReader = new EvmWarpRouteReader(
       multiProvider,
       chain,
       1,

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -83,9 +83,9 @@ import { getExtraLockBoxConfigs } from './xerc20.js';
 const REBALANCING_CONTRACT_VERSION = '8.0.0';
 export const TOKEN_FEE_CONTRACT_VERSION = '10.0.0';
 
-export class EvmERC20WarpRouteReader extends EvmRouterReader {
+export class EvmWarpRouteReader extends EvmRouterReader {
   protected readonly logger = rootLogger.child({
-    module: 'EvmERC20WarpRouteReader',
+    module: 'EvmWarpRouteReader',
   });
 
   // Using null instead of undefined to force
@@ -150,10 +150,10 @@ export class EvmERC20WarpRouteReader extends EvmRouterReader {
   }
 
   /**
-   * Derives the configuration for a Hyperlane ERC20 router contract at the given address.
+   * Derives the configuration for a Hyperlane warp route token router contract at the given address.
    *
-   * @param warpRouteAddress - The address of the Hyperlane ERC20 router contract.
-   * @returns The configuration for the Hyperlane ERC20 router.
+   * @param warpRouteAddress - The address of the Hyperlane warp route token router contract.
+   * @returns The configuration for the Hyperlane warp route token router.
    *
    */
   async deriveWarpRouteConfig(

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -32,7 +32,7 @@ import { DestinationGas, RemoteRouters } from '../router/types.js';
 import { ChainMap } from '../types.js';
 import { WarpCoreConfig } from '../warp/types.js';
 
-import { EvmERC20WarpRouteReader } from './EvmERC20WarpRouteReader.js';
+import { EvmWarpRouteReader } from './EvmWarpRouteReader.js';
 import { TokenMetadataMap } from './TokenMetadataMap.js';
 import { gasOverhead } from './config.js';
 import { HypERC20Deployer } from './deploy.js';
@@ -380,7 +380,7 @@ export async function expandVirtualWarpDeployConfig(params: {
   const { multiProvider, onChainWarpConfig, deployedRoutersAddresses } = params;
   return promiseObjAll(
     objMap(onChainWarpConfig, async (chain, config) => {
-      const warpReader = new EvmERC20WarpRouteReader(multiProvider, chain);
+      const warpReader = new EvmWarpRouteReader(multiProvider, chain);
       const warpVirtualConfig = await warpReader.deriveWarpRouteVirtualConfig(
         chain,
         deployedRoutersAddresses[chain],

--- a/typescript/sdk/src/token/deploy.hardhat-test.ts
+++ b/typescript/sdk/src/token/deploy.hardhat-test.ts
@@ -31,7 +31,7 @@ import { TokenFeeType } from '../fee/types.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 
-import { EvmERC20WarpRouteReader } from './EvmERC20WarpRouteReader.js';
+import { EvmWarpRouteReader } from './EvmWarpRouteReader.js';
 import { HypERC20App } from './app.js';
 import { HypERC20Checker } from './checker.js';
 import { TokenType } from './config.js';
@@ -229,14 +229,11 @@ describe('TokenDeployer', async () => {
     });
 
     describe('ERC20WarpRouterReader', async () => {
-      let reader: EvmERC20WarpRouteReader;
+      let reader: EvmWarpRouteReader;
       let routerAddress: Address;
 
       before(() => {
-        reader = new EvmERC20WarpRouteReader(
-          multiProvider,
-          TestChainName.test1,
-        );
+        reader = new EvmWarpRouteReader(multiProvider, TestChainName.test1);
       });
 
       beforeEach(async () => {


### PR DESCRIPTION
### Description
- Renamed EvmERC20WarpModule -> EvmWarpModule across SDK/CLI.
- Renamed EvmERC20WarpRouteReader -> EvmWarpRouteReader (file/class/tests).
- Increased SmartProvider foundry test timeout to avoid CI 2s timeouts.

### Backward compatibility
Breaking: EvmERC20WarpModule/EvmERC20WarpRouteReader removed.

### Testing
- pnpm lint (fails: metrics import/no-unresolved + TokenStandard error; helloworld solhint unused import)
- pnpm prettier

---
<a href="https://cursor.com/background-agent?bcId=bc-d32669df-9016-456c-b500-353dd48e02f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d32669df-9016-456c-b500-353dd48e02f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

