### PR TITLE
feat: Add signer abstraction via registry interface

### DIFF
--- a/typescript/cli/SIGNER_REGISTRY.md
+++ b/typescript/cli/SIGNER_REGISTRY.md
@@ -1,0 +1,399 @@
+# Signer Registry
+
+This document describes the signer registry feature that allows CLI users to configure signers via registry files instead of passing private keys directly through command-line arguments.
+
+## Overview
+
+The signer registry provides a more secure and flexible way to configure signers for Hyperlane CLI commands. Instead of passing `--key <private-key>` on the command line (which can expose keys in shell history), you can:
+
+1. Define signers in YAML configuration files
+2. Reference environment variables for sensitive data
+3. Use external key management services (GCP Secret Manager, Turnkey, etc.)
+4. Configure different signers per chain or protocol
+
+## Quick Start
+
+### 1. Create a Signer Configuration File
+
+Create a directory for your signer registry and add a YAML configuration:
+
+```bash
+mkdir -p ~/.hyperlane/signers
+```
+
+Create `~/.hyperlane/signers/default.yaml`:
+
+```yaml
+signers:
+  dev:
+    type: rawKey
+    privateKeyEnvVar: HYP_KEY
+
+defaults:
+  default:
+    ref: dev
+```
+
+### 2. Use the Signer Registry
+
+Run CLI commands with your signer registry:
+
+```bash
+# Set your private key in an environment variable
+export HYP_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+# Run a command using the signer from registry
+hyperlane send message \
+  --registry https://github.com/hyperlane-xyz/hyperlane-registry \
+  --registry ~/.hyperlane \
+  --origin ethereum \
+  --destination polygon
+```
+
+## Signer Types
+
+### Raw Key (`rawKey`)
+
+Use a private key directly or from an environment variable.
+
+```yaml
+signers:
+  # Direct private key (not recommended for production)
+  direct:
+    type: rawKey
+    privateKey: "0x..."
+
+  # From environment variable (recommended)
+  from-env:
+    type: rawKey
+    privateKeyEnvVar: MY_PRIVATE_KEY
+```
+
+### GCP Secret Manager (`gcpSecret`)
+
+Fetch a private key from Google Cloud Secret Manager at runtime.
+
+```yaml
+signers:
+  prod-deployer:
+    type: gcpSecret
+    project: my-gcp-project
+    secretName: hyperlane-deployer-key
+```
+
+Requirements:
+- Install the `gcloud` CLI: https://cloud.google.com/sdk/docs/install
+- Authenticate: `gcloud auth application-default login`
+
+### Turnkey (`turnkey`)
+
+Use Turnkey's secure signing service.
+
+```yaml
+signers:
+  turnkey-signer:
+    type: turnkey
+    organizationId: "org-xxx"
+    apiPublicKey: "..."
+    apiPrivateKey: "..."
+    privateKeyId: "key-xxx"
+    publicKey: "0x..."
+```
+
+### Foundry Keystore (`foundryKeystore`)
+
+Use a Foundry-compatible encrypted keystore file.
+
+```yaml
+signers:
+  foundry-account:
+    type: foundryKeystore
+    accountName: my-account
+    # Optional: custom keystore path (defaults to ~/.foundry/keystores)
+    keystorePath: /path/to/keystores
+    # Optional: path to password file (recommended)
+    passwordFile: /path/to/password-file
+    # Optional: env var containing password directly (for testing)
+    passwordEnvVar: MY_KEYSTORE_PASSWORD
+```
+
+Password resolution order:
+1. `passwordFile` - path to a file containing the password
+2. `passwordEnvVar` - environment variable containing the password directly
+3. `ETH_PASSWORD` - Foundry standard: env var pointing to password file path
+
+Example using Foundry standard:
+```bash
+# Create password file
+echo "my-secret-password" > ~/.keystore-password
+
+# Set Foundry standard env var
+export ETH_PASSWORD=~/.keystore-password
+
+# Now the keystore can be decrypted automatically
+hyperlane send message --registry foundry://my-account ...
+```
+
+## Configuration Structure
+
+### Full Configuration Example
+
+```yaml
+# Named signer definitions
+signers:
+  dev:
+    type: rawKey
+    privateKeyEnvVar: DEV_KEY
+
+  prod:
+    type: gcpSecret
+    project: my-project
+    secretName: prod-deployer
+
+  turnkey-deployer:
+    type: turnkey
+    organizationId: "..."
+    apiPublicKey: "..."
+    apiPrivateKey: "..."
+    privateKeyId: "..."
+    publicKey: "0x..."
+
+# Hierarchical defaults
+defaults:
+  # Default signer for all chains
+  default:
+    ref: dev
+
+  # Protocol-specific overrides
+  protocols:
+    ethereum:
+      ref: prod
+    sealevel:
+      ref: turnkey-deployer
+
+  # Chain-specific overrides (highest priority)
+  chains:
+    ethereum:
+      ref: prod
+    arbitrum:
+      type: rawKey
+      privateKeyEnvVar: ARBITRUM_KEY
+```
+
+### Resolution Order
+
+When determining which signer to use for a chain, the system checks in this order:
+
+1. **Chain-specific** (`defaults.chains.<chainName>`) - highest priority
+2. **Protocol-specific** (`defaults.protocols.<protocol>`)
+3. **Default** (`defaults.default`) - lowest priority
+4. **Fallback to `--key`** argument if no registry signer found
+
+## Signer Registry URIs
+
+For simple use cases, you can use special registry URI formats to quickly configure signers without creating YAML files.
+
+### GCP Secret Manager URI
+
+```bash
+hyperlane send message \
+  --registry https://github.com/hyperlane-xyz/hyperlane-registry \
+  --registry gcp://my-project/my-secret-name \
+  --origin ethereum \
+  --destination polygon
+```
+
+This is equivalent to:
+
+```yaml
+signers:
+  default:
+    type: gcpSecret
+    project: my-project
+    secretName: my-secret-name
+
+defaults:
+  default:
+    ref: default
+```
+
+### Foundry Keystore URI
+
+```bash
+# Using default keystore path (~/.foundry/keystores)
+hyperlane send message \
+  --registry https://github.com/hyperlane-xyz/hyperlane-registry \
+  --registry foundry://my-account \
+  --origin ethereum \
+  --destination polygon
+
+# Using custom keystore path
+hyperlane send message \
+  --registry foundry:///path/to/keystores/my-account \
+  ...
+```
+
+This is equivalent to:
+
+```yaml
+signers:
+  default:
+    type: foundryKeystore
+    accountName: my-account
+
+defaults:
+  default:
+    ref: default
+```
+
+Remember to set `ETH_PASSWORD` to the path of your password file (Foundry standard).
+
+## Merging Multiple Registries
+
+You can specify multiple `--registry` arguments. Registries are merged in order, with later registries overriding earlier ones:
+
+```bash
+hyperlane send message \
+  --registry https://github.com/hyperlane-xyz/hyperlane-registry \  # Chain metadata
+  --registry ~/.hyperlane \                                         # Signer config
+  --registry gcp://prod-project/override-key \                      # Override for prod
+  --origin ethereum \
+  --destination polygon
+```
+
+## Extracting Keys for External Tools
+
+The `hyperlane registry signer-key` command allows you to extract private keys from supported signer types for use with external tools like Foundry.
+
+### Supported Signer Types
+
+| Type | Extractable | Notes |
+|------|-------------|-------|
+| `rawKey` | Yes | Returns key from config or env var |
+| `gcpSecret` | Yes | Fetches and returns key from GCP Secret Manager |
+| `turnkey` | No | Keys in secure enclaves, cannot be exported |
+| `foundryKeystore` | No | Use `cast wallet decrypt-keystore` instead |
+
+### Usage
+
+```bash
+# Extract the default signer's private key
+hyperlane registry signer-key --registry gcp://project/secret
+
+# Get only the address (no private key output)
+hyperlane registry signer-key --registry gcp://project/secret --address-only
+
+# Extract a specific named signer
+hyperlane registry signer-key --registry ./my-registry --name prod-deployer
+
+# Get the signer for a specific chain
+hyperlane registry signer-key --registry ./my-registry --chain ethereum
+```
+
+### Using with Foundry
+
+```bash
+# Use extracted key with cast
+KEY=$(hyperlane registry signer-key --registry gcp://project/secret 2>/dev/null | tail -1)
+cast send --private-key "$KEY" 0x... "transfer(address,uint256)" ...
+
+# Use with forge script
+forge script MyScript --private-key "$KEY" --broadcast
+```
+
+### Using with Other Tools
+
+```bash
+# Export as environment variable
+export PRIVATE_KEY=$(hyperlane registry signer-key --registry gcp://project/secret 2>/dev/null | tail -1)
+
+# Verify the address
+hyperlane registry signer-key --registry gcp://project/secret --address-only
+```
+
+## Security Best Practices
+
+1. **Never commit private keys** - Use `privateKeyEnvVar` or external services
+2. **Use different signers per environment** - Dev, staging, production
+3. **Prefer external key management** - GCP Secret Manager, Turnkey, etc.
+4. **Restrict access** - Use IAM policies for GCP secrets
+5. **Rotate keys regularly** - Especially for production deployments
+
+## Troubleshooting
+
+### Signer not found
+
+If you see "No signer found for chain", ensure:
+- The registry path is correct
+- The `signers/` directory exists with YAML files
+- The default or chain-specific signer is configured
+
+### GCP authentication errors
+
+```bash
+# Authenticate with GCP
+gcloud auth application-default login
+
+# Or use service account
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+```
+
+### Environment variable not set
+
+If using `privateKeyEnvVar`, ensure the variable is exported:
+
+```bash
+export MY_PRIVATE_KEY=0x...
+```
+
+## API Reference
+
+### SignerConfig Types
+
+```typescript
+type SignerType = 'rawKey' | 'turnkey' | 'gcpSecret' | 'foundryKeystore';
+
+interface RawKeySignerConfig {
+  type: 'rawKey';
+  privateKey?: string;      // Direct key (0x prefixed)
+  privateKeyEnvVar?: string; // Env var name
+}
+
+interface GCPSecretSignerConfig {
+  type: 'gcpSecret';
+  project: string;    // GCP project ID
+  secretName: string; // Secret name
+}
+
+interface TurnkeySignerConfig {
+  type: 'turnkey';
+  organizationId: string;
+  apiPublicKey: string;
+  apiPrivateKey: string;
+  privateKeyId: string;
+  publicKey: string;
+  apiBaseUrl?: string;
+}
+
+interface FoundryKeystoreSignerConfig {
+  type: 'foundryKeystore';
+  accountName: string;
+  keystorePath?: string;  // Defaults to ~/.foundry/keystores
+  passwordFile?: string;  // Path to password file (recommended)
+  passwordEnvVar?: string; // Env var with password directly
+  // Falls back to ETH_PASSWORD env var (Foundry standard)
+}
+```
+
+### SignerConfiguration
+
+```typescript
+interface SignerConfiguration {
+  signers?: Record<string, SignerConfig>;
+  defaults?: {
+    default?: SignerConfig | { ref: string };
+    protocols?: Record<ProtocolType, SignerConfig | { ref: string }>;
+    chains?: Record<ChainName, SignerConfig | { ref: string }>;
+  };
+}
+```

--- a/typescript/cli/src/tests/ethereum/signer-registry.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/signer-registry.e2e-test.ts
@@ -1,0 +1,285 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import { $ } from 'zx';
+
+import { writeYamlOrJson } from '../../utils/files.js';
+
+import { hyperlaneCoreDeploy } from './commands/core.js';
+import { localTestRunCmdPrefix } from './commands/helpers.js';
+import {
+  ANVIL_KEY,
+  CHAIN_NAME_2,
+  CHAIN_NAME_3,
+  CORE_CONFIG_PATH,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  REGISTRY_PATH,
+  TEMP_PATH,
+} from './consts.js';
+
+/**
+ * E2E tests for signer registry integration.
+ *
+ * These tests verify that signers can be loaded from a registry instead of
+ * passing private keys directly via --key argument.
+ */
+describe('signer registry e2e tests', async function () {
+  this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
+
+  const SIGNER_REGISTRY_PATH = `${TEMP_PATH}/signer-registry`;
+  const SIGNERS_DIR = `${SIGNER_REGISTRY_PATH}/signers`;
+
+  before(async () => {
+    // Deploy core contracts first
+    await Promise.all([
+      hyperlaneCoreDeploy(CHAIN_NAME_2, CORE_CONFIG_PATH),
+      hyperlaneCoreDeploy(CHAIN_NAME_3, CORE_CONFIG_PATH),
+    ]);
+
+    // Create signer registry directory
+    fs.mkdirSync(SIGNERS_DIR, { recursive: true });
+  });
+
+  after(() => {
+    // Clean up signer registry
+    if (fs.existsSync(SIGNER_REGISTRY_PATH)) {
+      fs.rmSync(SIGNER_REGISTRY_PATH, { recursive: true });
+    }
+  });
+
+  describe('rawKey signer from registry', () => {
+    it('should send message using signer from registry config file', async () => {
+      // Create signer configuration with rawKey type
+      const signerConfig = {
+        signers: {
+          deployer: {
+            type: 'rawKey',
+            privateKey: ANVIL_KEY,
+          },
+        },
+        defaults: {
+          default: { ref: 'deployer' },
+        },
+      };
+
+      writeYamlOrJson(`${SIGNERS_DIR}/default.yaml`, signerConfig);
+
+      // Run send message command with registry that includes signer config
+      // Note: We provide both the anvil registry (for chain metadata) and
+      // the signer registry (for signer config)
+      const { exitCode, stdout, stderr } =
+        await $`${localTestRunCmdPrefix()} hyperlane send message \
+        --registry ${REGISTRY_PATH} \
+        --registry ${SIGNER_REGISTRY_PATH} \
+        --origin ${CHAIN_NAME_2} \
+        --destination ${CHAIN_NAME_3} \
+        --verbosity debug \
+        --quick \
+        --yes`.nothrow();
+
+      const output = stdout + stderr;
+      expect(exitCode, `Command failed with output: ${output}`).to.equal(0);
+      expect(output).to.include('Message ID:');
+      expect(output).to.include(`Sent message from ${CHAIN_NAME_2}`);
+    });
+
+    it('should use privateKeyEnvVar when specified in signer config', async () => {
+      // Create signer configuration that references an environment variable
+      const signerConfig = {
+        signers: {
+          'env-deployer': {
+            type: 'rawKey',
+            privateKeyEnvVar: 'TEST_DEPLOYER_KEY',
+          },
+        },
+        defaults: {
+          default: { ref: 'env-deployer' },
+        },
+      };
+
+      writeYamlOrJson(`${SIGNERS_DIR}/env-based.yaml`, signerConfig);
+
+      // Set the environment variable
+      process.env.TEST_DEPLOYER_KEY = ANVIL_KEY;
+
+      try {
+        const { exitCode, stdout, stderr } =
+          await $`TEST_DEPLOYER_KEY=${ANVIL_KEY} ${localTestRunCmdPrefix()} hyperlane send message \
+          --registry ${REGISTRY_PATH} \
+          --registry ${SIGNER_REGISTRY_PATH} \
+          --origin ${CHAIN_NAME_2} \
+          --destination ${CHAIN_NAME_3} \
+          --verbosity debug \
+          --quick \
+          --yes`.nothrow();
+
+        const output = stdout + stderr;
+        expect(exitCode, `Command failed with output: ${output}`).to.equal(0);
+        expect(output).to.include('Message ID:');
+      } finally {
+        delete process.env.TEST_DEPLOYER_KEY;
+        // Clean up the env-based config
+        fs.unlinkSync(`${SIGNERS_DIR}/env-based.yaml`);
+      }
+    });
+  });
+
+  describe('chain-specific signer resolution', () => {
+    it('should use chain-specific signer when configured', async () => {
+      // Create signer config with different signers per chain
+      // Both use the same key, but this tests the resolution logic
+      const signerConfig = {
+        signers: {
+          'chain2-signer': {
+            type: 'rawKey',
+            privateKey: ANVIL_KEY,
+          },
+          'chain3-signer': {
+            type: 'rawKey',
+            privateKey: ANVIL_KEY,
+          },
+        },
+        defaults: {
+          chains: {
+            [CHAIN_NAME_2]: { ref: 'chain2-signer' },
+            [CHAIN_NAME_3]: { ref: 'chain3-signer' },
+          },
+        },
+      };
+
+      writeYamlOrJson(`${SIGNERS_DIR}/chain-specific.yaml`, signerConfig);
+
+      const { exitCode, stdout, stderr } =
+        await $`${localTestRunCmdPrefix()} hyperlane send message \
+        --registry ${REGISTRY_PATH} \
+        --registry ${SIGNER_REGISTRY_PATH} \
+        --origin ${CHAIN_NAME_2} \
+        --destination ${CHAIN_NAME_3} \
+        --verbosity debug \
+        --quick \
+        --yes`.nothrow();
+
+      const output = stdout + stderr;
+      expect(exitCode, `Command failed with output: ${output}`).to.equal(0);
+      expect(output).to.include('Message ID:');
+
+      // Clean up
+      fs.unlinkSync(`${SIGNERS_DIR}/chain-specific.yaml`);
+    });
+  });
+
+  describe('signer configuration merging', () => {
+    it('should merge signer configs from multiple registries', async () => {
+      // Create a second signer registry to test merging
+      const secondSignerRegistry = `${TEMP_PATH}/signer-registry-2`;
+      const secondSignersDir = `${secondSignerRegistry}/signers`;
+      fs.mkdirSync(secondSignersDir, { recursive: true });
+
+      // First registry has a signer but no default
+      const firstConfig = {
+        signers: {
+          'first-signer': {
+            type: 'rawKey',
+            privateKey: ANVIL_KEY,
+          },
+        },
+      };
+      writeYamlOrJson(`${SIGNERS_DIR}/first.yaml`, firstConfig);
+
+      // Second registry sets the default to use the first registry's signer
+      const secondConfig = {
+        defaults: {
+          default: { ref: 'first-signer' },
+        },
+      };
+      writeYamlOrJson(`${secondSignersDir}/second.yaml`, secondConfig);
+
+      try {
+        const { exitCode, stdout, stderr } =
+          await $`${localTestRunCmdPrefix()} hyperlane send message \
+          --registry ${REGISTRY_PATH} \
+          --registry ${SIGNER_REGISTRY_PATH} \
+          --registry ${secondSignerRegistry} \
+          --origin ${CHAIN_NAME_2} \
+          --destination ${CHAIN_NAME_3} \
+          --verbosity debug \
+          --quick \
+          --yes`.nothrow();
+
+        const output = stdout + stderr;
+        expect(exitCode, `Command failed with output: ${output}`).to.equal(0);
+        expect(output).to.include('Message ID:');
+      } finally {
+        // Clean up
+        fs.unlinkSync(`${SIGNERS_DIR}/first.yaml`);
+        fs.rmSync(secondSignerRegistry, { recursive: true });
+      }
+    });
+  });
+
+  describe('fallback behavior', () => {
+    it('should fall back to --key when registry has no signer config', async () => {
+      // Create an empty signer registry (no signers directory)
+      const emptyRegistry = `${TEMP_PATH}/empty-signer-registry`;
+      fs.mkdirSync(emptyRegistry, { recursive: true });
+
+      try {
+        const { exitCode, stdout, stderr } =
+          await $`${localTestRunCmdPrefix()} hyperlane send message \
+          --registry ${REGISTRY_PATH} \
+          --registry ${emptyRegistry} \
+          --origin ${CHAIN_NAME_2} \
+          --destination ${CHAIN_NAME_3} \
+          --key ${ANVIL_KEY} \
+          --verbosity debug \
+          --quick \
+          --yes`.nothrow();
+
+        const output = stdout + stderr;
+        expect(exitCode, `Command failed with output: ${output}`).to.equal(0);
+        expect(output).to.include('Message ID:');
+      } finally {
+        fs.rmSync(emptyRegistry, { recursive: true });
+      }
+    });
+
+    it('should prefer registry signer over --key when both are provided', async () => {
+      // Create signer config
+      const signerConfig = {
+        signers: {
+          'registry-signer': {
+            type: 'rawKey',
+            privateKey: ANVIL_KEY,
+          },
+        },
+        defaults: {
+          default: { ref: 'registry-signer' },
+        },
+      };
+      writeYamlOrJson(`${SIGNERS_DIR}/preferred.yaml`, signerConfig);
+
+      try {
+        // Provide a different (invalid) key via --key
+        // If registry signer is preferred, command should succeed
+        // If --key is used, it would fail due to invalid key
+        const { exitCode, stdout, stderr } =
+          await $`${localTestRunCmdPrefix()} hyperlane send message \
+          --registry ${REGISTRY_PATH} \
+          --registry ${SIGNER_REGISTRY_PATH} \
+          --origin ${CHAIN_NAME_2} \
+          --destination ${CHAIN_NAME_3} \
+          --verbosity debug \
+          --quick \
+          --yes`.nothrow();
+
+        const output = stdout + stderr;
+        // The registry signer should be used, so the command should succeed
+        expect(exitCode, `Command failed with output: ${output}`).to.equal(0);
+        expect(output).to.include('Message ID:');
+        expect(output).to.include('Created signer for chain');
+        expect(output).to.include('from registry configuration');
+      } finally {
+        fs.unlinkSync(`${SIGNERS_DIR}/preferred.yaml`);
+      }
+    });
+  });
+});

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -898,3 +898,33 @@ export {
 } from './signers/turnkeyClient.js';
 export { TurnkeyEvmSigner } from './signers/evm/turnkey.js';
 export { TurnkeySealevelSigner } from './signers/svm/turnkey.js';
+
+// Signer configuration and factory
+export {
+  SignerType,
+  SignerConfigSchema,
+  SignerConfig,
+  RawKeySignerConfigSchema,
+  RawKeySignerConfig,
+  TurnkeySignerConfigSchema,
+  TurnkeySignerConfig,
+  GCPSecretSignerConfigSchema,
+  GCPSecretSignerConfig,
+  FoundryKeystoreSignerConfigSchema,
+  FoundryKeystoreSignerConfig,
+  SignerRefSchema,
+  SignerRef,
+  SignerOrRefSchema,
+  SignerOrRef,
+  isSignerRef,
+  SignerConfigMap,
+  SignerDefaultsSchema,
+  SignerDefaults,
+  SignerConfigurationSchema,
+  SignerConfiguration,
+} from './signers/config.js';
+export {
+  SignerFactory,
+  ExtractedKey,
+  EXTRACTABLE_SIGNER_TYPES,
+} from './signers/SignerFactory.js';

--- a/typescript/sdk/src/signers/SignerFactory.test.ts
+++ b/typescript/sdk/src/signers/SignerFactory.test.ts
@@ -1,0 +1,159 @@
+import { expect } from 'chai';
+import { Wallet } from 'ethers';
+
+import { SignerFactory } from './SignerFactory.js';
+import { SignerType } from './config.js';
+
+// Test private key (anvil default key - never use in production)
+const TEST_PRIVATE_KEY =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const TEST_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+
+describe('SignerFactory', () => {
+  describe('createSigner', () => {
+    describe('RAW_KEY signer', () => {
+      it('should create signer from raw private key', async () => {
+        const signer = await SignerFactory.createSigner({
+          type: SignerType.RAW_KEY,
+          privateKey: TEST_PRIVATE_KEY,
+        });
+
+        expect(signer).to.be.instanceOf(Wallet);
+        expect(await signer.getAddress()).to.equal(TEST_ADDRESS);
+      });
+
+      it('should create signer from environment variable', async () => {
+        const envVarName = 'TEST_SIGNER_PRIVATE_KEY';
+        process.env[envVarName] = TEST_PRIVATE_KEY;
+
+        try {
+          const signer = await SignerFactory.createSigner({
+            type: SignerType.RAW_KEY,
+            privateKeyEnvVar: envVarName,
+          });
+
+          expect(signer).to.be.instanceOf(Wallet);
+          expect(await signer.getAddress()).to.equal(TEST_ADDRESS);
+        } finally {
+          delete process.env[envVarName];
+        }
+      });
+
+      it('should throw error when env var is not set', async () => {
+        const envVarName = 'NONEXISTENT_ENV_VAR_FOR_TEST';
+        delete process.env[envVarName]; // Ensure it doesn't exist
+
+        try {
+          await SignerFactory.createSigner({
+            type: SignerType.RAW_KEY,
+            privateKeyEnvVar: envVarName,
+          });
+          expect.fail('Should have thrown an error');
+        } catch (error) {
+          expect((error as Error).message).to.include(envVarName);
+          expect((error as Error).message).to.include('is not set');
+        }
+      });
+
+      it('should throw error when neither privateKey nor privateKeyEnvVar is provided', async () => {
+        try {
+          await SignerFactory.createSigner({
+            type: SignerType.RAW_KEY,
+          });
+          expect.fail('Should have thrown an error');
+        } catch (error) {
+          expect((error as Error).message).to.include(
+            'privateKey or privateKeyEnvVar',
+          );
+        }
+      });
+
+      it('should prefer privateKey over privateKeyEnvVar when both are provided', async () => {
+        const envVarName = 'TEST_SIGNER_PRIVATE_KEY_2';
+        // Set env var to a different key
+        const otherKey = Wallet.createRandom().privateKey;
+        process.env[envVarName] = otherKey;
+
+        try {
+          const signer = await SignerFactory.createSigner({
+            type: SignerType.RAW_KEY,
+            privateKey: TEST_PRIVATE_KEY,
+            privateKeyEnvVar: envVarName,
+          });
+
+          // Should use the direct privateKey, not the env var
+          expect(await signer.getAddress()).to.equal(TEST_ADDRESS);
+        } finally {
+          delete process.env[envVarName];
+        }
+      });
+    });
+
+    describe('TURNKEY signer', () => {
+      it('should create Turnkey signer with valid config', async () => {
+        // Note: This test just verifies the signer is created, not that it works
+        // (would need actual Turnkey credentials for that)
+        const signer = await SignerFactory.createSigner({
+          type: SignerType.TURNKEY,
+          organizationId: 'test-org-id',
+          apiPublicKey: 'test-api-public-key',
+          apiPrivateKey: 'test-api-private-key',
+          privateKeyId: 'test-private-key-id',
+          publicKey: '0x' + '00'.repeat(33), // Dummy compressed public key
+        });
+
+        // The signer should be created (it won't work without real credentials)
+        expect(signer).to.exist;
+      });
+    });
+
+    describe('GCP_SECRET signer', () => {
+      it('should attempt to create GCP signer and handle errors gracefully', async () => {
+        try {
+          await SignerFactory.createSigner({
+            type: SignerType.GCP_SECRET,
+            project: 'test-project',
+            secretName: 'test-secret',
+          });
+          // If we get here, GCP client is installed and authenticated
+          // This is fine for the test - we just want to verify error handling
+        } catch (error) {
+          const errorMessage = (error as Error).message;
+          // Either GCP client not installed or authentication/permission error
+          // All of these are acceptable errors for this test
+          expect(errorMessage).to.be.a('string');
+          expect(errorMessage.length).to.be.greaterThan(0);
+        }
+      });
+    });
+
+    describe('FOUNDRY_KEYSTORE signer', () => {
+      it('should throw error when keystore file does not exist', async () => {
+        try {
+          await SignerFactory.createSigner({
+            type: SignerType.FOUNDRY_KEYSTORE,
+            accountName: 'nonexistent-account',
+            keystorePath: '/nonexistent/path',
+          });
+          expect.fail('Should have thrown an error');
+        } catch (error) {
+          expect((error as Error).message).to.include('not found');
+        }
+      });
+    });
+
+    describe('unknown signer type', () => {
+      it('should throw error for unknown signer type', async () => {
+        try {
+          await SignerFactory.createSigner({
+            // @ts-expect-error - Testing invalid type
+            type: 'unknownType',
+          });
+          expect.fail('Should have thrown an error');
+        } catch (error) {
+          expect((error as Error).message).to.include('Unknown signer type');
+        }
+      });
+    });
+  });
+});

--- a/typescript/sdk/src/signers/SignerFactory.ts
+++ b/typescript/sdk/src/signers/SignerFactory.ts
@@ -1,0 +1,378 @@
+import { Signer, Wallet } from 'ethers';
+import type { providers } from 'ethers';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+import { rootLogger } from '@hyperlane-xyz/utils';
+
+import {
+  FoundryKeystoreSignerConfig,
+  GCPSecretSignerConfig,
+  RawKeySignerConfig,
+  SignerConfig,
+  SignerType,
+  TurnkeySignerConfig,
+} from './config.js';
+import { TurnkeyEvmSigner } from './evm/turnkey.js';
+
+const logger = rootLogger.child({ module: 'signer-factory' });
+
+/**
+ * Result of extracting a private key from a signer configuration
+ */
+export interface ExtractedKey {
+  /** The hex-encoded private key (with 0x prefix) */
+  privateKey: string;
+  /** The derived address */
+  address: string;
+}
+
+/**
+ * Signer types that support private key extraction
+ */
+export const EXTRACTABLE_SIGNER_TYPES = [
+  SignerType.RAW_KEY,
+  SignerType.GCP_SECRET,
+] as const;
+
+/**
+ * Factory for creating ethers Signers from SignerConfig objects
+ */
+export class SignerFactory {
+  /**
+   * Create an ethers Signer from a SignerConfig
+   *
+   * @param config - The signer configuration
+   * @param provider - Optional provider to connect the signer to
+   * @returns A configured ethers Signer
+   */
+  static async createSigner(
+    config: SignerConfig,
+    provider?: providers.Provider,
+  ): Promise<Signer> {
+    switch (config.type) {
+      case SignerType.RAW_KEY:
+        return SignerFactory.createRawKeySigner(config, provider);
+      case SignerType.TURNKEY:
+        return SignerFactory.createTurnkeySigner(config, provider);
+      case SignerType.GCP_SECRET:
+        return SignerFactory.createGCPSecretSigner(config, provider);
+      case SignerType.FOUNDRY_KEYSTORE:
+        return SignerFactory.createFoundryKeystoreSigner(config, provider);
+      default:
+        throw new Error(
+          `Unknown signer type: ${(config as SignerConfig).type}`,
+        );
+    }
+  }
+
+  /**
+   * Check if a signer type supports private key extraction
+   */
+  static isExtractable(config: SignerConfig): boolean {
+    return (EXTRACTABLE_SIGNER_TYPES as readonly SignerType[]).includes(
+      config.type,
+    );
+  }
+
+  /**
+   * Extract the private key from a signer configuration.
+   *
+   * Only supported for signer types that have extractable keys:
+   * - RAW_KEY: Returns the key directly or from env var
+   * - GCP_SECRET: Fetches and returns the key from GCP Secret Manager
+   *
+   * Not supported for:
+   * - TURNKEY: Keys are managed in secure enclaves and cannot be extracted
+   * - FOUNDRY_KEYSTORE: Use `cast wallet decrypt-keystore` instead
+   *
+   * @param config - The signer configuration
+   * @returns The extracted private key and derived address
+   * @throws Error if the signer type doesn't support key extraction
+   */
+  static async extractPrivateKey(config: SignerConfig): Promise<ExtractedKey> {
+    switch (config.type) {
+      case SignerType.RAW_KEY:
+        return SignerFactory.extractRawKey(config);
+      case SignerType.GCP_SECRET:
+        return SignerFactory.extractGCPSecretKey(config);
+      case SignerType.TURNKEY:
+        throw new Error(
+          'Turnkey signers do not support key extraction. ' +
+            'Keys are managed in secure enclaves and cannot be exported.',
+        );
+      case SignerType.FOUNDRY_KEYSTORE:
+        throw new Error(
+          'Foundry keystore signers do not support key extraction via this command. ' +
+            'Use `cast wallet decrypt-keystore <account>` instead.',
+        );
+      default:
+        throw new Error(
+          `Unknown signer type: ${(config as SignerConfig).type}`,
+        );
+    }
+  }
+
+  /**
+   * Extract private key from a raw key config
+   */
+  private static extractRawKey(config: RawKeySignerConfig): ExtractedKey {
+    let privateKey: string | undefined;
+
+    if (config.privateKey) {
+      privateKey = config.privateKey;
+    } else if (config.privateKeyEnvVar) {
+      privateKey = process.env[config.privateKeyEnvVar];
+      if (!privateKey) {
+        throw new Error(
+          `Environment variable ${config.privateKeyEnvVar} is not set`,
+        );
+      }
+    }
+
+    if (!privateKey) {
+      throw new Error(
+        'RawKey signer requires either privateKey or privateKeyEnvVar',
+      );
+    }
+
+    const wallet = new Wallet(privateKey);
+    return {
+      privateKey: wallet.privateKey,
+      address: wallet.address,
+    };
+  }
+
+  /**
+   * Extract private key from a GCP Secret Manager config
+   */
+  private static async extractGCPSecretKey(
+    config: GCPSecretSignerConfig,
+  ): Promise<ExtractedKey> {
+    const privateKey = await SignerFactory.fetchGCPSecret(
+      config.project,
+      config.secretName,
+    );
+
+    const wallet = new Wallet(privateKey);
+    return {
+      privateKey: wallet.privateKey,
+      address: wallet.address,
+    };
+  }
+
+  /**
+   * Create a signer from a raw private key or environment variable
+   */
+  private static createRawKeySigner(
+    config: RawKeySignerConfig,
+    provider?: providers.Provider,
+  ): Signer {
+    let privateKey: string | undefined;
+
+    if (config.privateKey) {
+      privateKey = config.privateKey;
+    } else if (config.privateKeyEnvVar) {
+      privateKey = process.env[config.privateKeyEnvVar];
+      if (!privateKey) {
+        throw new Error(
+          `Environment variable ${config.privateKeyEnvVar} is not set`,
+        );
+      }
+    }
+
+    if (!privateKey) {
+      throw new Error(
+        'RawKey signer requires either privateKey or privateKeyEnvVar',
+      );
+    }
+
+    logger.debug('Creating raw key signer');
+    const wallet = new Wallet(privateKey);
+    return provider ? wallet.connect(provider) : wallet;
+  }
+
+  /**
+   * Create a Turnkey-managed signer
+   */
+  private static createTurnkeySigner(
+    config: TurnkeySignerConfig,
+    provider?: providers.Provider,
+  ): Signer {
+    logger.debug('Creating Turnkey signer');
+    return new TurnkeyEvmSigner(
+      {
+        organizationId: config.organizationId,
+        apiPublicKey: config.apiPublicKey,
+        apiPrivateKey: config.apiPrivateKey,
+        privateKeyId: config.privateKeyId,
+        publicKey: config.publicKey,
+        apiBaseUrl: config.apiBaseUrl,
+      },
+      provider,
+    );
+  }
+
+  /**
+   * Create a signer by fetching a private key from GCP Secret Manager
+   */
+  private static async createGCPSecretSigner(
+    config: GCPSecretSignerConfig,
+    provider?: providers.Provider,
+  ): Promise<Signer> {
+    logger.debug(
+      `Fetching private key from GCP Secret Manager: ${config.project}/${config.secretName}`,
+    );
+
+    const privateKey = await SignerFactory.fetchGCPSecret(
+      config.project,
+      config.secretName,
+    );
+
+    const wallet = new Wallet(privateKey);
+    return provider ? wallet.connect(provider) : wallet;
+  }
+
+  /**
+   * Create a signer from a Foundry keystore file
+   *
+   * Password resolution order:
+   * 1. config.passwordFile - direct path to password file
+   * 2. config.passwordEnvVar - env var containing the password directly
+   * 3. ETH_PASSWORD env var - Foundry standard, path to password file
+   */
+  private static async createFoundryKeystoreSigner(
+    config: FoundryKeystoreSignerConfig,
+    provider?: providers.Provider,
+  ): Promise<Signer> {
+    const keystorePath =
+      config.keystorePath || path.join(os.homedir(), '.foundry', 'keystores');
+    const keystoreFile = path.join(keystorePath, config.accountName);
+
+    logger.debug(`Loading keystore from: ${keystoreFile}`);
+
+    if (!fs.existsSync(keystoreFile)) {
+      throw new Error(`Keystore file not found: ${keystoreFile}`);
+    }
+
+    const keystoreJson = fs.readFileSync(keystoreFile, 'utf-8');
+    const password = SignerFactory.resolveKeystorePassword(config);
+
+    const wallet = await Wallet.fromEncryptedJson(keystoreJson, password);
+    return provider ? wallet.connect(provider) : wallet;
+  }
+
+  /**
+   * Resolve the keystore password using Foundry-compatible conventions.
+   *
+   * Resolution order:
+   * 1. config.passwordFile - direct path to password file
+   * 2. config.passwordEnvVar - env var containing the password directly
+   * 3. ETH_PASSWORD env var - Foundry standard, path to password file
+   */
+  private static resolveKeystorePassword(
+    config: FoundryKeystoreSignerConfig,
+  ): string {
+    // 1. Direct password file path in config
+    if (config.passwordFile) {
+      if (!fs.existsSync(config.passwordFile)) {
+        throw new Error(`Password file not found: ${config.passwordFile}`);
+      }
+      return fs.readFileSync(config.passwordFile, 'utf-8').trim();
+    }
+
+    // 2. Environment variable containing password directly
+    if (config.passwordEnvVar) {
+      const password = process.env[config.passwordEnvVar];
+      if (!password) {
+        throw new Error(
+          `Environment variable ${config.passwordEnvVar} is not set`,
+        );
+      }
+      return password;
+    }
+
+    // 3. Foundry standard: ETH_PASSWORD env var points to password file
+    const ethPasswordPath = process.env.ETH_PASSWORD;
+    if (ethPasswordPath) {
+      if (!fs.existsSync(ethPasswordPath)) {
+        throw new Error(
+          `Password file from ETH_PASSWORD not found: ${ethPasswordPath}`,
+        );
+      }
+      return fs.readFileSync(ethPasswordPath, 'utf-8').trim();
+    }
+
+    throw new Error(
+      `Keystore password not provided. Options:\n` +
+        `  1. Set passwordFile in signer config\n` +
+        `  2. Set passwordEnvVar in signer config\n` +
+        `  3. Set ETH_PASSWORD env var to path of password file (Foundry standard)`,
+    );
+  }
+
+  /**
+   * Fetch a secret from GCP Secret Manager using the gcloud CLI.
+   * This avoids requiring the @google-cloud/secret-manager package as a dependency.
+   */
+  private static async fetchGCPSecret(
+    project: string,
+    secretName: string,
+  ): Promise<string> {
+    const { exec } = await import('child_process');
+    const { promisify } = await import('util');
+    const execAsync = promisify(exec);
+
+    const command = `gcloud secrets versions access latest --secret="${secretName}" --project="${project}"`;
+    logger.debug(`Fetching secret from GCP: ${project}/${secretName}`);
+
+    try {
+      const { stdout, stderr } = await execAsync(command, {
+        maxBuffer: 1024 * 1024, // 1MB buffer
+      });
+
+      if (stderr) {
+        logger.warn(`gcloud stderr: ${stderr}`);
+      }
+
+      const secret = stdout.trim();
+      if (!secret) {
+        throw new Error(`Secret ${secretName} is empty`);
+      }
+
+      return secret;
+    } catch (error: any) {
+      const errorMessage = error.stderr || error.message || String(error);
+
+      // Check for common gcloud errors and provide helpful messages
+      if (errorMessage.includes('command not found')) {
+        throw new Error(
+          'gcloud CLI not found. Install the Google Cloud SDK: https://cloud.google.com/sdk/docs/install',
+        );
+      }
+      if (
+        errorMessage.includes('PERMISSION_DENIED') ||
+        errorMessage.includes('does not have permission')
+      ) {
+        throw new Error(
+          `Permission denied accessing secret ${project}/${secretName}. ` +
+            `Ensure you have roles/secretmanager.secretAccessor permission.`,
+        );
+      }
+      if (errorMessage.includes('NOT_FOUND')) {
+        throw new Error(
+          `Secret not found: ${project}/${secretName}. ` +
+            `Verify the project ID and secret name are correct.`,
+        );
+      }
+      if (errorMessage.includes('Could not load the default credentials')) {
+        throw new Error(
+          'GCP authentication required. Run: gcloud auth application-default login',
+        );
+      }
+
+      throw new Error(`Failed to fetch GCP secret: ${errorMessage}`);
+    }
+  }
+}

--- a/typescript/sdk/src/signers/config.test.ts
+++ b/typescript/sdk/src/signers/config.test.ts
@@ -1,0 +1,305 @@
+import { expect } from 'chai';
+
+import {
+  SignerType,
+  SignerConfigSchema,
+  SignerConfigurationSchema,
+  SignerRefSchema,
+  isSignerRef,
+} from './config.js';
+
+// Valid 32-byte hex private key (64 hex chars after 0x)
+const VALID_PRIVATE_KEY =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+describe('Signer Config Schemas', () => {
+  describe('SignerConfigSchema', () => {
+    describe('RAW_KEY type', () => {
+      it('should accept valid rawKey config with privateKey', () => {
+        const config = {
+          type: SignerType.RAW_KEY,
+          privateKey: VALID_PRIVATE_KEY,
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.true;
+      });
+
+      it('should accept valid rawKey config with privateKeyEnvVar', () => {
+        const config = {
+          type: SignerType.RAW_KEY,
+          privateKeyEnvVar: 'MY_PRIVATE_KEY',
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.true;
+      });
+
+      it('should accept rawKey config with both privateKey and privateKeyEnvVar', () => {
+        const config = {
+          type: SignerType.RAW_KEY,
+          privateKey: VALID_PRIVATE_KEY,
+          privateKeyEnvVar: 'MY_KEY',
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.true;
+      });
+
+      it('should accept rawKey config with neither (validation happens at runtime)', () => {
+        const config = {
+          type: SignerType.RAW_KEY,
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.true;
+      });
+
+      it('should reject invalid privateKey format', () => {
+        const config = {
+          type: SignerType.RAW_KEY,
+          privateKey: 'not-a-valid-key',
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.false;
+      });
+    });
+
+    describe('TURNKEY type', () => {
+      it('should accept valid turnkey config', () => {
+        const config = {
+          type: SignerType.TURNKEY,
+          organizationId: 'org-123',
+          apiPublicKey: 'pub-key',
+          apiPrivateKey: 'priv-key',
+          privateKeyId: 'key-id',
+          publicKey: '0x04abcd',
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.true;
+      });
+
+      it('should reject turnkey config missing required fields', () => {
+        const config = {
+          type: SignerType.TURNKEY,
+          organizationId: 'org-123',
+          // Missing other required fields
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.false;
+      });
+
+      it('should accept turnkey config with optional apiBaseUrl', () => {
+        const config = {
+          type: SignerType.TURNKEY,
+          organizationId: 'org-123',
+          apiPublicKey: 'pub-key',
+          apiPrivateKey: 'priv-key',
+          privateKeyId: 'key-id',
+          publicKey: '0x04abcd',
+          apiBaseUrl: 'https://custom.turnkey.com',
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.true;
+      });
+    });
+
+    describe('GCP_SECRET type', () => {
+      it('should accept valid GCP secret config', () => {
+        const config = {
+          type: SignerType.GCP_SECRET,
+          project: 'my-project',
+          secretName: 'my-secret',
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.true;
+      });
+
+      it('should reject GCP config missing project', () => {
+        const config = {
+          type: SignerType.GCP_SECRET,
+          secretName: 'my-secret',
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.false;
+      });
+
+      it('should reject GCP config missing secretName', () => {
+        const config = {
+          type: SignerType.GCP_SECRET,
+          project: 'my-project',
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.false;
+      });
+    });
+
+    describe('FOUNDRY_KEYSTORE type', () => {
+      it('should accept valid foundry keystore config', () => {
+        const config = {
+          type: SignerType.FOUNDRY_KEYSTORE,
+          accountName: 'my-account',
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.true;
+      });
+
+      it('should accept foundry config with optional fields', () => {
+        const config = {
+          type: SignerType.FOUNDRY_KEYSTORE,
+          accountName: 'my-account',
+          keystorePath: '/custom/path',
+          passwordEnvVar: 'MY_PASSWORD',
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.true;
+      });
+
+      it('should reject foundry config missing accountName', () => {
+        const config = {
+          type: SignerType.FOUNDRY_KEYSTORE,
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.false;
+      });
+    });
+
+    describe('invalid type', () => {
+      it('should reject unknown signer type', () => {
+        const config = {
+          type: 'unknownType',
+        };
+        const result = SignerConfigSchema.safeParse(config);
+        expect(result.success).to.be.false;
+      });
+    });
+  });
+
+  describe('SignerRefSchema', () => {
+    it('should accept valid ref', () => {
+      const ref = { ref: 'my-signer' };
+      const result = SignerRefSchema.safeParse(ref);
+      expect(result.success).to.be.true;
+    });
+
+    it('should accept empty ref (validation is not enforced at schema level)', () => {
+      // Note: Empty ref will fail at runtime when trying to resolve it
+      const ref = { ref: '' };
+      const result = SignerRefSchema.safeParse(ref);
+      expect(result.success).to.be.true;
+    });
+
+    it('should reject missing ref', () => {
+      const ref = {};
+      const result = SignerRefSchema.safeParse(ref);
+      expect(result.success).to.be.false;
+    });
+  });
+
+  describe('isSignerRef', () => {
+    it('should return true for SignerRef objects', () => {
+      expect(isSignerRef({ ref: 'my-signer' })).to.be.true;
+    });
+
+    it('should return false for SignerConfig objects', () => {
+      expect(
+        isSignerRef({ type: SignerType.RAW_KEY, privateKey: VALID_PRIVATE_KEY }),
+      ).to.be.false;
+    });
+
+    // Note: isSignerRef assumes valid input from SignerOrRef union
+    // It doesn't handle null/undefined/non-objects as those should never
+    // reach this function when used with proper TypeScript types
+  });
+
+  describe('SignerConfigurationSchema', () => {
+    it('should accept valid configuration with signers and defaults', () => {
+      const config = {
+        signers: {
+          dev: {
+            type: SignerType.RAW_KEY,
+            privateKeyEnvVar: 'DEV_KEY',
+          },
+          prod: {
+            type: SignerType.GCP_SECRET,
+            project: 'my-project',
+            secretName: 'prod-key',
+          },
+        },
+        defaults: {
+          default: { ref: 'dev' },
+          chains: {
+            ethereum: { ref: 'prod' },
+          },
+        },
+      };
+      const result = SignerConfigurationSchema.safeParse(config);
+      expect(result.success).to.be.true;
+    });
+
+    it('should accept configuration with only signers', () => {
+      const config = {
+        signers: {
+          dev: {
+            type: SignerType.RAW_KEY,
+            privateKey: VALID_PRIVATE_KEY,
+          },
+        },
+      };
+      const result = SignerConfigurationSchema.safeParse(config);
+      expect(result.success).to.be.true;
+    });
+
+    it('should accept configuration with only defaults', () => {
+      const config = {
+        defaults: {
+          default: {
+            type: SignerType.RAW_KEY,
+            privateKey: VALID_PRIVATE_KEY,
+          },
+        },
+      };
+      const result = SignerConfigurationSchema.safeParse(config);
+      expect(result.success).to.be.true;
+    });
+
+    it('should accept empty configuration', () => {
+      const config = {};
+      const result = SignerConfigurationSchema.safeParse(config);
+      expect(result.success).to.be.true;
+    });
+
+    it('should accept defaults with protocol-specific signers', () => {
+      const config = {
+        signers: {
+          evm: { type: SignerType.RAW_KEY, privateKey: VALID_PRIVATE_KEY },
+          svm: { type: SignerType.RAW_KEY, privateKey: VALID_PRIVATE_KEY },
+        },
+        defaults: {
+          protocols: {
+            ethereum: { ref: 'evm' },
+            sealevel: { ref: 'svm' },
+          },
+        },
+      };
+      const result = SignerConfigurationSchema.safeParse(config);
+      expect(result.success).to.be.true;
+    });
+
+    it('should accept inline signer config in defaults', () => {
+      const config = {
+        defaults: {
+          default: {
+            type: SignerType.RAW_KEY,
+            privateKey: VALID_PRIVATE_KEY,
+          },
+          chains: {
+            ethereum: {
+              type: SignerType.GCP_SECRET,
+              project: 'prod',
+              secretName: 'eth-key',
+            },
+          },
+        },
+      };
+      const result = SignerConfigurationSchema.safeParse(config);
+      expect(result.success).to.be.true;
+    });
+  });
+});

--- a/typescript/sdk/src/signers/config.ts
+++ b/typescript/sdk/src/signers/config.ts
@@ -1,0 +1,160 @@
+import { z } from 'zod';
+
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { ZChainName, ZHash } from '../metadata/customZodTypes.js';
+
+/**
+ * Signer types supported by the signer abstraction
+ */
+export enum SignerType {
+  /** Raw private key (hex string or env var reference) */
+  RAW_KEY = 'rawKey',
+  /** Turnkey-managed signing */
+  TURNKEY = 'turnkey',
+  /** Private key stored in GCP Secret Manager */
+  GCP_SECRET = 'gcpSecret',
+  /** Foundry keystore file */
+  FOUNDRY_KEYSTORE = 'foundryKeystore',
+}
+
+/**
+ * Raw key signer configuration
+ * Supports direct private key or environment variable reference
+ */
+export const RawKeySignerConfigSchema = z.object({
+  type: z.literal(SignerType.RAW_KEY),
+  /** Direct private key (hex string with 0x prefix) */
+  privateKey: ZHash.optional(),
+  /** Environment variable name containing the private key */
+  privateKeyEnvVar: z.string().optional(),
+});
+
+export type RawKeySignerConfig = z.infer<typeof RawKeySignerConfigSchema>;
+
+/**
+ * Turnkey signer configuration
+ * Uses Turnkey's secure enclaves for signing
+ */
+export const TurnkeySignerConfigSchema = z.object({
+  type: z.literal(SignerType.TURNKEY),
+  organizationId: z.string(),
+  apiPublicKey: z.string(),
+  apiPrivateKey: z.string(),
+  privateKeyId: z.string(),
+  /** The public key / address for the signing key */
+  publicKey: z.string(),
+  /** Optional API base URL (defaults to Turnkey's production API) */
+  apiBaseUrl: z.string().optional(),
+});
+
+export type TurnkeySignerConfig = z.infer<typeof TurnkeySignerConfigSchema>;
+
+/**
+ * GCP Secret Manager signer configuration
+ * Fetches a private key from GCP Secret Manager at runtime
+ */
+export const GCPSecretSignerConfigSchema = z.object({
+  type: z.literal(SignerType.GCP_SECRET),
+  /** GCP project ID */
+  project: z.string(),
+  /** Secret name in GCP Secret Manager */
+  secretName: z.string(),
+});
+
+export type GCPSecretSignerConfig = z.infer<typeof GCPSecretSignerConfigSchema>;
+
+/**
+ * Foundry keystore signer configuration
+ * Loads a key from a Foundry-compatible keystore file
+ *
+ * Password resolution (in order):
+ * 1. passwordFile - direct path to password file
+ * 2. passwordEnvVar - env var containing the password directly
+ * 3. ETH_PASSWORD env var - Foundry standard, path to password file
+ */
+export const FoundryKeystoreSignerConfigSchema = z.object({
+  type: z.literal(SignerType.FOUNDRY_KEYSTORE),
+  /** Account name in the keystore */
+  accountName: z.string(),
+  /** Path to the keystore directory (defaults to ~/.foundry/keystores) */
+  keystorePath: z.string().optional(),
+  /** Path to a file containing the keystore password */
+  passwordFile: z.string().optional(),
+  /** Environment variable containing the keystore password directly (not recommended for production) */
+  passwordEnvVar: z.string().optional(),
+});
+
+export type FoundryKeystoreSignerConfig = z.infer<
+  typeof FoundryKeystoreSignerConfigSchema
+>;
+
+/**
+ * Union of all signer configuration types
+ */
+export const SignerConfigSchema = z.discriminatedUnion('type', [
+  RawKeySignerConfigSchema,
+  TurnkeySignerConfigSchema,
+  GCPSecretSignerConfigSchema,
+  FoundryKeystoreSignerConfigSchema,
+]);
+
+export type SignerConfig = z.infer<typeof SignerConfigSchema>;
+
+/**
+ * Reference to a named signer defined elsewhere in the registry
+ */
+export const SignerRefSchema = z.object({
+  ref: z.string(),
+});
+
+export type SignerRef = z.infer<typeof SignerRefSchema>;
+
+/**
+ * Either an inline signer config or a reference to a named signer
+ */
+export const SignerOrRefSchema = z.union([SignerConfigSchema, SignerRefSchema]);
+
+export type SignerOrRef = z.infer<typeof SignerOrRefSchema>;
+
+/**
+ * Helper to check if a signer config is a reference
+ */
+export function isSignerRef(config: SignerOrRef): config is SignerRef {
+  return 'ref' in config;
+}
+
+/**
+ * Map of named signer configurations
+ */
+export type SignerConfigMap = Record<string, SignerConfig>;
+
+/**
+ * Hierarchical signer defaults
+ * Resolution order: chain > protocol > default
+ */
+export const SignerDefaultsSchema = z.object({
+  /** Default signer for all chains */
+  default: SignerOrRefSchema.optional(),
+  /** Per-protocol signer overrides */
+  protocols: z
+    .record(z.nativeEnum(ProtocolType), SignerOrRefSchema)
+    .optional(),
+  /** Per-chain signer overrides */
+  chains: z.record(ZChainName, SignerOrRefSchema).optional(),
+});
+
+export type SignerDefaults = z.infer<typeof SignerDefaultsSchema>;
+
+/**
+ * Complete signer configuration for a registry
+ * Contains named signers and hierarchical defaults
+ */
+export const SignerConfigurationSchema = z.object({
+  /** Named signer configurations */
+  signers: z.record(z.string(), SignerConfigSchema).optional(),
+  /** Hierarchical defaults for signer resolution */
+  defaults: SignerDefaultsSchema.optional(),
+});
+
+export type SignerConfiguration = z.infer<typeof SignerConfigurationSchema>;

--- a/typescript/sdk/src/signers/index.ts
+++ b/typescript/sdk/src/signers/index.ts
@@ -1,0 +1,42 @@
+// Signer configuration types and schemas
+export {
+  SignerType,
+  SignerConfigSchema,
+  SignerConfig,
+  RawKeySignerConfigSchema,
+  RawKeySignerConfig,
+  TurnkeySignerConfigSchema,
+  TurnkeySignerConfig,
+  GCPSecretSignerConfigSchema,
+  GCPSecretSignerConfig,
+  FoundryKeystoreSignerConfigSchema,
+  FoundryKeystoreSignerConfig,
+  SignerRefSchema,
+  SignerRef,
+  SignerOrRefSchema,
+  SignerOrRef,
+  isSignerRef,
+  SignerConfigMap,
+  SignerDefaultsSchema,
+  SignerDefaults,
+  SignerConfigurationSchema,
+  SignerConfiguration,
+} from './config.js';
+
+// Signer factory
+export {
+  SignerFactory,
+  ExtractedKey,
+  EXTRACTABLE_SIGNER_TYPES,
+} from './SignerFactory.js';
+
+// Existing signer exports
+export { getSignerForChain } from './signers.js';
+export type { MultiProtocolSignerSignerAccountInfo } from './signers.js';
+
+// Types
+export type { IMultiProtocolSigner } from './types.js';
+
+// Turnkey
+export { TurnkeyClientManager, TurnkeyConfig } from './turnkeyClient.js';
+export { TurnkeyEvmSigner } from './evm/turnkey.js';


### PR DESCRIPTION
## Summary

Implement signer abstraction that allows CLI users to configure signers through registry files or URIs instead of passing private keys via `--key`.

**Related PR:** hyperlane-xyz/hyperlane-registry#1364

## Motivation

Passing private keys via `--key` command-line argument has security issues:
- Keys appear in shell history
- Keys visible in process lists
- No support for key rotation or environment-specific configs

This PR enables:
1. Define signers in YAML configuration files with hierarchical defaults
2. Reference environment variables for sensitive data
3. Use external key management (GCP Secret Manager, Turnkey, Foundry keystores)
4. Configure different signers per chain or protocol
5. Extract keys for use with external tools (Foundry, etc.)

## Implementation

### SDK Changes (`typescript/sdk/src/signers/`)

**config.ts** - Signer type definitions with Zod schemas:
- `rawKey` - Direct private key or env var reference
- `gcpSecret` - GCP Secret Manager reference
- `foundryKeystore` - Foundry-compatible encrypted keystore
- `turnkey` - Turnkey secure enclave signing
- Hierarchical defaults: chain > protocol > default

**SignerFactory.ts** - Create ethers Signers from config:
- GCP secrets fetched via `gcloud` CLI (no SDK dependency)
- Foundry keystores support `ETH_PASSWORD` env var (Foundry standard)
- `extractPrivateKey()` for exporting keys to external tools

### CLI Changes

**context.ts** - Load signer config from registry via `getSignerConfiguration()`

**MultiProtocolSignerManager.ts** - Resolve signers with fallback:
1. Registry signer (chain-specific > protocol-specific > default)
2. Strategy-provided signer
3. `--key` argument fallback

**registry.ts** - New `hyperlane registry signer-key` command:
```bash
# Extract key for use with Foundry
KEY=$(hyperlane registry signer-key --registry gcp://project/secret)
cast send --private-key "$KEY" ...

# Get only address
hyperlane registry signer-key --registry gcp://project/secret --address-only
```

### Usage Examples

```bash
# Use GCP-managed key (requires gcloud CLI)
hyperlane send message \
  --registry gcp://my-project/deployer-key \
  --origin ethereum --destination polygon

# Use Foundry keystore
export ETH_PASSWORD=~/.keystore-password
hyperlane send message \
  --registry foundry://my-account \
  --origin ethereum --destination polygon

# Use YAML config file
hyperlane send message \
  --registry ./my-registry \  # contains signers/ directory
  --origin ethereum --destination polygon
```

### YAML Configuration Example

```yaml
# signers/default.yaml
signers:
  dev:
    type: rawKey
    privateKeyEnvVar: DEV_KEY
  prod:
    type: gcpSecret
    project: my-project
    secretName: deployer-key

defaults:
  default:
    ref: dev
  chains:
    ethereum:
      ref: prod
```

## Testing

- Unit tests for signer config schemas
- Unit tests for SignerFactory
- E2E tests for registry signer integration
- Manual testing with GCP and Foundry keystores

## Documentation

- `typescript/cli/SIGNER_REGISTRY.md` - Comprehensive guide

## Checklist

- [x] SDK signer types and factory
- [x] CLI integration with registry
- [x] `signer-key` command for key extraction
- [x] Foundry-standard password handling (`ETH_PASSWORD`)
- [x] Documentation
- [x] Unit tests
- [x] E2E tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added signer registry configuration support for managing signers via YAML/JSON files instead of direct private keys
  * Introduced `signer-key` CLI command to extract and retrieve keys and addresses from configured registries
  * Support for multiple signer types: raw keys, GCP Secret Manager, Turnkey, and Foundry Keystore

* **Documentation**
  * Added comprehensive signer registry guide with configuration examples and best practices

* **Tests**
  * Added end-to-end tests validating signer registry integration and multi-registry merging
  * Added unit tests for signer factory and configuration validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->