### PR TITLE
fix(sdk): compare bps instead of maxFee/halfAmount in warp check fee configs

### DIFF
--- a/.changeset/fix-warp-check-fee-bps.md
+++ b/.changeset/fix-warp-check-fee-bps.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Fixed warp check to compare bps instead of maxFee/halfAmount for fee configs. Previously, warp check showed false violations because on-chain configs store derived maxFee/halfAmount values while deploy configs specify bps. The transform now handles each fee type appropriately: LinearFee and RoutingFee compare bps only, while ProgressiveFee and RegressiveFee preserve maxFee/halfAmount for direct comparison.

--- a/typescript/cli/src/tests/ethereum/warp/warp-check-fee.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-check-fee.e2e-test.ts
@@ -1,0 +1,188 @@
+import { expect } from 'chai';
+import { Wallet, ethers } from 'ethers';
+
+import { type ERC20Test } from '@hyperlane-xyz/core';
+import {
+  type ChainAddresses,
+  createWarpRouteConfigId,
+} from '@hyperlane-xyz/registry';
+import {
+  type ChainMetadata,
+  TokenFeeType,
+  TokenType,
+  type WarpRouteDeployConfig,
+  WarpRouteDeployConfigSchema,
+} from '@hyperlane-xyz/sdk';
+import { type Address } from '@hyperlane-xyz/utils';
+
+import { readYamlOrJson, writeYamlOrJson } from '../../../utils/files.js';
+import { deployOrUseExistingCore } from '../commands/core.js';
+import { deployToken } from '../commands/helpers.js';
+import {
+  hyperlaneWarpCheckRaw,
+  hyperlaneWarpDeploy,
+} from '../commands/warp.js';
+import {
+  ANVIL_KEY,
+  CHAIN_2_METADATA_PATH,
+  CHAIN_NAME_2,
+  CHAIN_NAME_3,
+  CORE_CONFIG_PATH,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  WARP_DEPLOY_OUTPUT_PATH,
+  getCombinedWarpRoutePath,
+} from '../consts.js';
+
+describe('hyperlane warp check fee e2e tests', async function () {
+  this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
+
+  let chain2Addresses: ChainAddresses = {};
+  let chain3Addresses: ChainAddresses = {};
+  let token: ERC20Test;
+  let tokenSymbol: string;
+  let ownerAddress: Address;
+  let combinedWarpCoreConfigPath: string;
+  let warpConfig: WarpRouteDeployConfig;
+
+  before(async function () {
+    [chain2Addresses, chain3Addresses] = await Promise.all([
+      deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY),
+      deployOrUseExistingCore(CHAIN_NAME_3, CORE_CONFIG_PATH, ANVIL_KEY),
+    ]);
+
+    const chainMetadata: ChainMetadata = readYamlOrJson(CHAIN_2_METADATA_PATH);
+
+    new ethers.providers.JsonRpcProvider(chainMetadata.rpcUrls[0].http);
+
+    token = await deployToken(ANVIL_KEY, CHAIN_NAME_2);
+    tokenSymbol = await token.symbol();
+
+    combinedWarpCoreConfigPath = getCombinedWarpRoutePath(tokenSymbol, [
+      CHAIN_NAME_3,
+    ]);
+  });
+
+  async function deployAndExportWarpRoute(): Promise<WarpRouteDeployConfig> {
+    writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpConfig);
+    writeYamlOrJson(
+      combinedWarpCoreConfigPath.replace('-config.yaml', '-deploy.yaml'),
+      warpConfig,
+    );
+
+    const currentWarpId = createWarpRouteConfigId(
+      await token.symbol(),
+      CHAIN_NAME_3,
+    );
+
+    await hyperlaneWarpDeploy(WARP_DEPLOY_OUTPUT_PATH, currentWarpId);
+
+    return warpConfig;
+  }
+
+  beforeEach(async function () {
+    ownerAddress = new Wallet(ANVIL_KEY).address;
+    warpConfig = {
+      [CHAIN_NAME_2]: {
+        type: TokenType.collateral,
+        token: token.address,
+        mailbox: chain2Addresses.mailbox,
+        owner: ownerAddress,
+      },
+      [CHAIN_NAME_3]: {
+        type: TokenType.synthetic,
+        mailbox: chain3Addresses.mailbox,
+        owner: ownerAddress,
+      },
+    };
+  });
+
+  describe('tokenFee bps comparison', () => {
+    it('should pass warp check when LinearFee bps matches (no maxFee/halfAmount violations)', async function () {
+      const bpsValue = 100n;
+
+      warpConfig = WarpRouteDeployConfigSchema.parse({
+        [CHAIN_NAME_2]: {
+          type: TokenType.collateral,
+          token: token.address,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+          tokenFee: {
+            type: TokenFeeType.LinearFee,
+            owner: ownerAddress,
+            bps: bpsValue,
+          },
+        },
+        [CHAIN_NAME_3]: {
+          type: TokenType.synthetic,
+          mailbox: chain3Addresses.mailbox,
+          owner: ownerAddress,
+        },
+      });
+
+      await deployAndExportWarpRoute();
+
+      const currentWarpId = createWarpRouteConfigId(
+        await token.symbol(),
+        CHAIN_NAME_3,
+      );
+
+      const output = await hyperlaneWarpCheckRaw({
+        warpRouteId: currentWarpId,
+      }).nothrow();
+
+      expect(output.text()).to.not.include('maxFee');
+      expect(output.text()).to.not.include('halfAmount');
+
+      if (output.exitCode !== 0) {
+        expect(output.text()).to.not.include('tokenFee');
+      }
+    });
+
+    it('should pass warp check when RoutingFee with nested LinearFee bps matches', async function () {
+      const bpsValue = 50n;
+
+      warpConfig = WarpRouteDeployConfigSchema.parse({
+        [CHAIN_NAME_2]: {
+          type: TokenType.collateral,
+          token: token.address,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+          tokenFee: {
+            type: TokenFeeType.RoutingFee,
+            owner: ownerAddress,
+            feeContracts: {
+              [CHAIN_NAME_3]: {
+                type: TokenFeeType.LinearFee,
+                owner: ownerAddress,
+                bps: bpsValue,
+              },
+            },
+          },
+        },
+        [CHAIN_NAME_3]: {
+          type: TokenType.synthetic,
+          mailbox: chain3Addresses.mailbox,
+          owner: ownerAddress,
+        },
+      });
+
+      await deployAndExportWarpRoute();
+
+      const currentWarpId = createWarpRouteConfigId(
+        await token.symbol(),
+        CHAIN_NAME_3,
+      );
+
+      const output = await hyperlaneWarpCheckRaw({
+        warpRouteId: currentWarpId,
+      }).nothrow();
+
+      expect(output.text()).to.not.include('maxFee');
+      expect(output.text()).to.not.include('halfAmount');
+
+      if (output.exitCode !== 0) {
+        expect(output.text()).to.not.include('feeContracts');
+      }
+    });
+  });
+});

--- a/typescript/sdk/src/token/configUtils.test.ts
+++ b/typescript/sdk/src/token/configUtils.test.ts
@@ -89,6 +89,112 @@ describe('configUtils', () => {
         },
       },
       {
+        msg: 'It should remove maxFee and halfAmount from tokenFee config',
+        input: {
+          type: TokenType.collateral,
+          tokenFee: {
+            type: TokenFeeType.LinearFee,
+            maxFee: 123456789n,
+            halfAmount: 987654321n,
+            bps: 100n,
+            owner: ADDRESS,
+            token: ADDRESS,
+          },
+        },
+        expected: {
+          type: TokenType.collateral,
+          tokenFee: {
+            type: TokenFeeType.LinearFee,
+            bps: 100n,
+            owner: ADDRESS.toLowerCase(),
+            token: ADDRESS.toLowerCase(),
+          },
+        },
+      },
+      {
+        msg: 'It should remove maxFee and halfAmount from nested feeContracts',
+        input: {
+          tokenFee: {
+            type: TokenFeeType.RoutingFee,
+            maxFee: 999n,
+            halfAmount: 888n,
+            owner: ADDRESS,
+            token: ADDRESS,
+            feeContracts: {
+              ethereum: {
+                type: TokenFeeType.LinearFee,
+                maxFee: 111n,
+                halfAmount: 222n,
+                bps: 50n,
+                owner: ADDRESS,
+                token: ADDRESS,
+              },
+            },
+          },
+        },
+        expected: {
+          tokenFee: {
+            type: TokenFeeType.RoutingFee,
+            owner: ADDRESS.toLowerCase(),
+            token: ADDRESS.toLowerCase(),
+            feeContracts: {
+              ethereum: {
+                type: TokenFeeType.LinearFee,
+                bps: 50n,
+                owner: ADDRESS.toLowerCase(),
+                token: ADDRESS.toLowerCase(),
+              },
+            },
+          },
+        },
+      },
+      {
+        msg: 'It should preserve maxFee and halfAmount for ProgressiveFee (no bps)',
+        input: {
+          type: TokenType.collateral,
+          tokenFee: {
+            type: TokenFeeType.ProgressiveFee,
+            maxFee: 123456789n,
+            halfAmount: 987654321n,
+            owner: ADDRESS,
+            token: ADDRESS,
+          },
+        },
+        expected: {
+          type: TokenType.collateral,
+          tokenFee: {
+            type: TokenFeeType.ProgressiveFee,
+            maxFee: 123456789n,
+            halfAmount: 987654321n,
+            owner: ADDRESS.toLowerCase(),
+            token: ADDRESS.toLowerCase(),
+          },
+        },
+      },
+      {
+        msg: 'It should preserve maxFee and halfAmount for RegressiveFee (no bps)',
+        input: {
+          type: TokenType.collateral,
+          tokenFee: {
+            type: TokenFeeType.RegressiveFee,
+            maxFee: 111222333n,
+            halfAmount: 444555666n,
+            owner: ADDRESS,
+            token: ADDRESS,
+          },
+        },
+        expected: {
+          type: TokenType.collateral,
+          tokenFee: {
+            type: TokenFeeType.RegressiveFee,
+            maxFee: 111222333n,
+            halfAmount: 444555666n,
+            owner: ADDRESS.toLowerCase(),
+            token: ADDRESS.toLowerCase(),
+          },
+        },
+      },
+      {
         msg: 'It should sort out of order modules and validator arrays',
         expected: {
           bsc: {


### PR DESCRIPTION
## Description

Fixed `warp check` to compare `bps` instead of `maxFee`/`halfAmount` for fee configs.

### Problem
`warp check` was showing false violations because:
- On-chain config stores derived `maxFee`/`halfAmount` values
- Deploy config specifies `bps` (user-friendly)
- These aren't directly comparable

```yaml
eni:
  contractVerificationStatus:
    proxy:
      EXPECTED: verified
      ACTUAL: error
  tokenFee:
    maxFee:
      ACTUAL: 115792089237316195423570985008687907853269984665640564039457584007913129639935
      EXPECTED: ""
    halfAmount:
      ACTUAL: 115792089237316195423570985008687907853269984665640564039457584007913129639935
      EXPECTED: ""
    feeContracts:
      ethereum:
        maxFee:
          ACTUAL: 115792089237316195423570985008687907853269
          EXPECTED: ""
        halfAmount:
          ACTUAL: 72370055773322622139731865630429942408292500
          EXPECTED: ""
        type: LinearFee
    type: RoutingFee
  type: synthetic
```

### Solution
Added type-aware fee config transform in `transformConfigToCheck` that handles each fee type appropriately:

| Fee Type | Behavior |
|----------|----------|
| **LinearFee** | Removes `maxFee`/`halfAmount`, compares `bps` only |
| **RoutingFee** | Removes `maxFee`/`halfAmount` at root (hardcoded max uint256), recursively processes nested `feeContracts` |
| **ProgressiveFee** | Preserves `maxFee`/`halfAmount` (they ARE the config values, no bps field) |
| **RegressiveFee** | Preserves `maxFee`/`halfAmount` (they ARE the config values, no bps field) |

After: 
```yaml
eni:
  contractVerificationStatus:
    proxy:
      EXPECTED: verified
      ACTUAL: error
  type: synthetic
```

## Drive-by changes

None

## Related issues

None

## Backward compatibility

Yes - this is a bug fix that reduces false positives in warp check output.

## Testing

- SDK unit tests: 414 passing
- New e2e tests for LinearFee and RoutingFee fee config comparison: 2 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved warp-check fee validation issues that were incorrectly reporting configuration violations. The tool now accurately compares all fee types during Warp route deployment verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->