### PR TITLE
fix(scraper): Reorder message unique index to support origin-only queries

### DIFF
--- a/rust/main/agents/scraper/migration/src/m20230309_000005_create_table_message.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000005_create_table_message.rs
@@ -54,8 +54,8 @@ impl MigrationTrait for Migration {
                     .index(
                         Index::create()
                             .unique()
-                            .col(Message::OriginMailbox)
                             .col(Message::Origin)
+                            .col(Message::OriginMailbox)
                             .col(Message::Nonce),
                     )
                     .to_owned(),

--- a/rust/main/agents/scraper/src/db/message.rs
+++ b/rust/main/agents/scraper/src/db/message.rs
@@ -327,8 +327,8 @@ impl ScraperDb {
                         Insert::many(chunk.to_vec())
                             .on_conflict(
                                 OnConflict::columns([
-                                    message::Column::OriginMailbox,
                                     message::Column::Origin,
+                                    message::Column::OriginMailbox,
                                     message::Column::Nonce,
                                 ])
                                 .update_columns([


### PR DESCRIPTION
## Summary
- Changed index column order from `(origin_mailbox, origin, nonce)` to `(origin, origin_mailbox, nonce)`
- Updated OnConflict clause to match new index order

## Problem
The composite unique index started with `origin_mailbox`, making it unusable for `origin`-only queries in `message_view`. This forced a full table scan when filtering by `origin_domain_id`.

## Solution
Reordering to `(origin, origin_mailbox, nonce)` allows:
- `origin`-only filtering (message_view queries)
- `origin` + `origin_mailbox` filtering (partial prefix)
- Full `origin` + `origin_mailbox` + `nonce` lookups (all scraper queries)

## Results
Query cost reduced from ~1.9M to ~12K for origin-filtered queries (~150x improvement).

## Test plan
- [x] Verified compilation with `cargo check -p scraper`
- [x] Verified execution plan uses new index on test database
- [ ] Deploy to testnet scraper and verify query performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal database configurations to optimize message storage operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->