### PR TITLE
fix(agents): Fix flaky CI tests in lander and relayer

### DIFF
--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -1203,14 +1203,16 @@ mod test {
             .sum();
 
         // Have a window that is acceptable for "around 2 weeks".
-        // Give or take 1 day.
+        // The backoff calculation adds random jitter of 0-6 hours for retries 50-65
+        // (16 retries), giving up to 96 hours of variance. Use ±5 days tolerance
+        // to account for this randomness.
         let max_backoff_duration = chrono::Duration::weeks(2)
-            .checked_add(&TimeDelta::days(1))
+            .checked_add(&TimeDelta::days(5))
             .expect("Failed to compute duration")
             .to_std()
             .expect("Failed to convert TimeDelta to Duration");
         let min_backoff_duration = chrono::Duration::weeks(2)
-            .checked_sub(&TimeDelta::days(1))
+            .checked_sub(&TimeDelta::days(5))
             .expect("Failed to compute duration")
             .to_std()
             .expect("Failed to convert TimeDelta to Duration");


### PR DESCRIPTION
## Summary

Fixes two flaky CI tests that were causing intermittent failures:
- https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/21491444475/job/61914760381#step:7:2628
- https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/21491234133/job/61913996990#step:7:3435

### Fix 1: `test_update_boundaries_waits_for_block_time` (lander)

**Root cause:** The test used `block_time = 1ms` which was too short for slow CI machines. By the time the second `update_boundaries()` call executed, 1ms had already passed, causing the test to fail with `left: Some(2), right: Some(100)`.

**Fix:** Increased `block_time` to 500ms to ensure the second call reliably skips the update.

### Fix 2: `check_default_max_message_retries` (relayer)

**Root cause:** The `calculate_msg_backoff` function adds random jitter for retries 50-65:

```rust
let random_val = rand::random::<u64>();
target.saturating_add(random_val.overflowing_rem(six_hours).0)
```

This adds 0-6 hours of random jitter per retry × 16 retries = up to **96 hours (4 days)** of variance.

The deterministic portion of the backoff sums to ~12 days. With unlucky RNG, the total could be as low as ~12 days. The test expected 13-15 days (±1 day tolerance), so it would fail when random jitter happened to be low.

**Fix:** Widened tolerance from ±1 day to ±5 days to cover the full variance range.

## Test plan

- [x] `cargo test --package lander test_update_boundaries_waits_for_block_time` passes
- [x] `cargo test --package relayer check_default_max_message_retries` passes

🤖 Generated with [Claude Code](https://claude.ai/code)