### PR TITLE
fix(infra): include all chains in keyfunder config

### DIFF
--- a/typescript/infra/src/funding/key-funder.ts
+++ b/typescript/infra/src/funding/key-funder.ts
@@ -138,6 +138,9 @@ export class KeyFunderHelmManager extends HelmManager {
       // Add sweep config only for chains in CHAINS_TO_SWEEP with valid thresholds
       if (CHAINS_TO_SWEEP.has(chain)) {
         const sweepThreshold = this.config.lowUrgencyKeyFunderBalances?.[chain];
+        if (!sweepThreshold) {
+          throw new Error(`Sweep threshold is missing for chain ${chain}`);
+        }
         const thresholdNum = Number(sweepThreshold);
         if (!Number.isFinite(thresholdNum) || thresholdNum <= 0) {
           throw new Error(`Sweep threshold is invalid for chain ${chain}`);


### PR DESCRIPTION
## Summary
- Fixed bug where keyfunder skipped chains not in `CHAINS_TO_SWEEP`, even if they had balance configs
- Mainnet: chains like `incentiv` with balances but no sweep were being excluded
- Testnet: ALL chains were excluded (testnet chain names like `arbitrumsepolia` don't match mainnet names in `CHAINS_TO_SWEEP`)

## Changes
- Sweep config is now only added for chains in `CHAINS_TO_SWEEP`
- All chains with valid config (balances, igp, or sweep) are included in the keyfunder output

## Test plan
- [ ] Verify keyfunder configmap includes `incentiv` after deployment
- [ ] Verify testnet keyfunder still generates valid config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure sweep thresholds are finite and positive; invalid sweep configs now trigger an error to prevent improper assignments.

* **Improvements**
  * Sweep handling is consolidated into a single, validated flow and now only applies to eligible chains.
  * Non-sweep settings (balances and gas-related fields) continue to apply independently; sweep address and multiplier selection is clearer and more robust.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->