### PR TITLE
fix(rebalancer-sim): Address PR #7903 review comments

### DIFF
--- a/typescript/rebalancer-sim/eslint.config.mjs
+++ b/typescript/rebalancer-sim/eslint.config.mjs
@@ -3,9 +3,7 @@ import MonorepoDefaults from '../../eslint.config.mjs';
 export default [
   ...MonorepoDefaults,
   {
-    files: ['./src/**/*.ts'],
-  },
-  {
+    files: ['./src/**/*.ts', './test/**/*.ts'],
     rules: {
       // Disable restricted imports for Node.js built-ins since simulation harness is Node.js-only
       'no-restricted-imports': ['off'],

--- a/typescript/rebalancer-sim/src/bridges/BridgeMockController.ts
+++ b/typescript/rebalancer-sim/src/bridges/BridgeMockController.ts
@@ -375,10 +375,12 @@ export class BridgeMockController extends EventEmitter {
         );
         // Mark all pending as failed and clear
         for (const transfer of this.pendingTransfers.values()) {
-          this.emit('transfer_failed', {
+          const event: BridgeEvent = {
+            type: 'transfer_failed',
             transfer,
-            error: 'Timeout waiting for delivery',
-          });
+            timestamp: Date.now(),
+          };
+          this.emit('transfer_failed', event);
         }
         this.pendingTransfers.clear();
         break;

--- a/typescript/rebalancer-sim/src/deployment/SimulationDeployment.ts
+++ b/typescript/rebalancer-sim/src/deployment/SimulationDeployment.ts
@@ -297,7 +297,7 @@ export async function processAllPendingMessages(
     domain: string;
     tx: Promise<ethers.ContractTransaction>;
   }> = [];
-  let currentNonce = await signer.getTransactionCount();
+  let currentNonce = await signer.getTransactionCount('pending');
 
   // Fire all transactions without waiting
   for (const domain of Object.values(domains)) {

--- a/typescript/rebalancer-sim/src/kpi/KPICollector.ts
+++ b/typescript/rebalancer-sim/src/kpi/KPICollector.ts
@@ -49,7 +49,12 @@ export class KPICollector {
     if (this.snapshotInterval) return;
 
     this.snapshotInterval = setInterval(async () => {
-      await this.takeSnapshot();
+      try {
+        await this.takeSnapshot();
+      } catch (error) {
+        // Ignore snapshot errors to prevent interval from breaking
+        console.warn('Snapshot collection failed:', error);
+      }
     }, this.snapshotFrequencyMs);
   }
 

--- a/typescript/rebalancer-sim/src/mailbox/MessageTracker.ts
+++ b/typescript/rebalancer-sim/src/mailbox/MessageTracker.ts
@@ -115,7 +115,7 @@ export class MessageTracker extends EventEmitter {
   }
 
   /**
-   * Get all pending messages (including not yet ready, excluding inflight)
+   * Get all pending messages (including not yet ready and inflight)
    */
   getPendingMessages(): TrackedMessage[] {
     return Array.from(this.messages.values()).filter(
@@ -205,7 +205,8 @@ export class MessageTracker extends EventEmitter {
     }
 
     if (processable.length === 0) {
-      return { delivered: 0, failed: ready.length };
+      // No messages processable yet - not a failure, they will retry
+      return { delivered: 0, failed: 0 };
     }
 
     // Fire all processable transactions in parallel

--- a/typescript/rebalancer-sim/src/rebalancer/RealRebalancerRunner.ts
+++ b/typescript/rebalancer-sim/src/rebalancer/RealRebalancerRunner.ts
@@ -20,6 +20,10 @@ const logger = pino({ level: 'silent' });
 // Track the current instance for cleanup
 let currentInstance: RealRebalancerRunner | null = null;
 
+function setCurrentInstance(instance: RealRebalancerRunner | null): void {
+  currentInstance = instance;
+}
+
 /**
  * Global cleanup function - call between test runs to ensure clean state
  */
@@ -123,10 +127,6 @@ export class RealRebalancerRunner
     // Cleanup any previously running instance
     await cleanupRealRebalancer();
 
-    this.running = true;
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    currentInstance = this;
-
     // Create registry
     const registry = new SimulationRegistry(this.config.deployment);
 
@@ -220,6 +220,10 @@ export class RealRebalancerRunner
         logger,
       },
     );
+
+    // Mark as running after service creation to avoid inconsistent state
+    this.running = true;
+    setCurrentInstance(this);
 
     // Start service in the background (don't await - it runs forever in daemon mode)
     this.service.start().catch((error) => {

--- a/typescript/rebalancer-sim/test/integration/full-simulation.test.ts
+++ b/typescript/rebalancer-sim/test/integration/full-simulation.test.ts
@@ -7,8 +7,8 @@
  *
  * Configuration:
  * - Set REBALANCERS env var to specify which rebalancers to test
- *   e.g., REBALANCERS=hyperlane,real pnpm test
- * - Default: runs HyperlaneRunner only
+ *   e.g., REBALANCERS=hyperlane pnpm test (for single rebalancer)
+ * - Default: runs both HyperlaneRunner and RealRebalancerService
  *
  * Each scenario JSON includes:
  * - description: What the scenario tests
@@ -60,13 +60,19 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const RESULTS_DIR = path.join(__dirname, '..', '..', 'results');
 
 // Configure which rebalancers to test via environment variable
-// e.g., REBALANCERS=hyperlane,real for comparison
-// Default: run HyperlaneRunner only (stable), opt-in to RealRebalancerService
+// e.g., REBALANCERS=hyperlane for single rebalancer
+// Default: run both HyperlaneRunner and RealRebalancerService for comparison
 type RebalancerType = 'hyperlane' | 'real';
 const REBALANCER_ENV = process.env.REBALANCERS || 'hyperlane,real';
 const ENABLED_REBALANCERS: RebalancerType[] = REBALANCER_ENV.split(',')
   .map((r) => r.trim().toLowerCase())
   .filter((r): r is RebalancerType => r === 'hyperlane' || r === 'real');
+
+if (ENABLED_REBALANCERS.length === 0) {
+  throw new Error(
+    `No valid rebalancers in REBALANCERS="${REBALANCER_ENV}". Use "hyperlane", "real", or both.`,
+  );
+}
 
 function createRebalancer(type: RebalancerType): IRebalancerRunner {
   switch (type) {


### PR DESCRIPTION
## Summary

- Fixed over-rebalancing bug in HyperlaneRunner by tracking remaining amounts
- Added guard against overlapping mailbox processing ticks
- Fixed incorrect transfer ID in failure recording
- Moved running state assignment after service creation in RealRebalancerRunner
- Added 'pending' parameter to getTransactionCount for correct nonce handling
- Added guard for empty REBALANCERS env var
- Fixed ESLint config scoping, KPICollector error handling, MessageTracker docstring and return value
- Fixed BridgeMockController timeout event to match BridgeEvent interface
- Updated test comments to match actual default behavior

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [ ] Run simulation tests to verify fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)