### PR TITLE
fix(cosmos-sdk): add sleep after node startup to fix e2e flake

### DIFF
--- a/typescript/cosmos-sdk/src/testing/node.ts
+++ b/typescript/cosmos-sdk/src/testing/node.ts
@@ -1,8 +1,16 @@
-import { GenericContainer, Wait } from 'testcontainers';
+import {
+  GenericContainer,
+  type StartedTestContainer,
+  Wait,
+} from 'testcontainers';
 
 import { type TestChainMetadata } from '@hyperlane-xyz/provider-sdk/chain';
+import { sleep } from '@hyperlane-xyz/utils';
 
-export async function runCosmosNode({ rpcPort, restPort }: TestChainMetadata) {
+export async function runCosmosNode({
+  rpcPort,
+  restPort,
+}: TestChainMetadata): Promise<StartedTestContainer> {
   const container = await new GenericContainer(
     'gcr.io/abacus-labs-dev/hyperlane-cosmos-simapp:v1.0.1',
   )
@@ -20,6 +28,11 @@ export async function runCosmosNode({ rpcPort, restPort }: TestChainMetadata) {
     )
     .withWaitStrategy(Wait.forLogMessage(/received complete proposal block/))
     .start();
+
+  // Wait for the block to be committed and RPC to be fully ready.
+  // The log message only indicates a proposal was received, not that
+  // the block was committed and sync info is available.
+  await sleep(2000);
 
   return container;
 }


### PR DESCRIPTION
## Summary

- Fixes flaky cosmos-sdk e2e test caused by race condition during node startup
- The test waits for `received complete proposal block` log, but this only means a proposal was received - not committed
- When cosmjs connects immediately, RPC status returns empty `latest_block_hash` causing `must provide a non-empty value` error
- Added 2s sleep after container start, matching pattern used in aleo-sdk tests

## Test plan

- [ ] Verify cosmos-sdk e2e tests pass consistently in CI
- [ ] Run `pnpm -C typescript/cosmos-sdk test:e2e` locally multiple times

🤖 Generated with [Claude Code](https://claude.ai/code)