### PR TITLE
fix(cli): increase Radix e2e setup timeout for CI reliability

### DIFF
--- a/typescript/cli/src/tests/radix/e2e-test.setup.ts
+++ b/typescript/cli/src/tests/radix/e2e-test.setup.ts
@@ -21,7 +21,9 @@ let orginalRadixTestMentadata:
   | undefined;
 
 before(async function () {
-  this.timeout(DEFAULT_E2E_TEST_TIMEOUT);
+  // Use 3x timeout for setup since Docker container startup can be slow in CI
+  // (image pulling, postgres init, fullnode sync, gateway sync)
+  this.timeout(3 * DEFAULT_E2E_TEST_TIMEOUT);
 
   // Clean up existing chain addresses
   Object.entries(TEST_CHAIN_NAMES_BY_PROTOCOL).forEach(

--- a/typescript/radix-sdk/src/tests/e2e-test.setup.ts
+++ b/typescript/radix-sdk/src/tests/e2e-test.setup.ts
@@ -19,7 +19,9 @@ let radixNodeInstance: StartedDockerComposeEnvironment;
 export let DEPLOYED_TEST_CHAIN_METADATA: TestChainMetadata;
 
 before(async function () {
-  this.timeout(DEFAULT_E2E_TEST_TIMEOUT);
+  // Use 3x timeout for setup since Docker container startup can be slow in CI
+  // (image pulling, postgres init, fullnode sync, gateway sync)
+  this.timeout(3 * DEFAULT_E2E_TEST_TIMEOUT);
 
   // Download Radix contracts
   const artifacts = await downloadRadixContracts();


### PR DESCRIPTION
## Summary

- Increased Radix e2e setup `before` hook timeout from 100s to 300s (3x)
- Fixes flaky timeout in CI where Docker container startup takes longer than expected

## Details

The Radix e2e tests use `testcontainers` to start Docker containers inside the mocha `before` hook. In CI environments, Docker startup can exceed 100 seconds due to:
- Image pulling (if not cached)
- PostgreSQL initialization
- Fullnode sync
- Gateway sync waiting for `HealthyAndSynced=1`
- Multiple package deployments

The test was timing out at 100s while actually completing in ~120s.

## Test plan

- [x] Verified TypeScript compiles
- [ ] CI should pass without timeout in the Radix e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)