### PR TITLE
fix(infra): skip deprecated chains in check-warp-deploy

### DIFF
--- a/.changeset/yellow-sheep-attack.md
+++ b/.changeset/yellow-sheep-attack.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/infra': patch
+---
+
+The check-warp-deploy script now filters out deprecated chains when creating the MultiProvider to avoid attempting to fetch RPC secrets for chains that are no longer supported.

--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -100,12 +100,28 @@ async function main() {
   // This ensures that we don't fail to fetch secrets for new chains in the cron job.
   const envConfig = getEnvironmentConfig(environment);
 
+  // Filter to only supported chains to avoid fetching secrets for deprecated chains
+  const supportedWarpChains = Array.from(warpConfigChains).filter((chain) =>
+    envConfig.supportedChainNames.includes(chain),
+  );
+
+  const unsupportedChains = Array.from(warpConfigChains).filter(
+    (chain) => !envConfig.supportedChainNames.includes(chain),
+  );
+  if (unsupportedChains.length > 0) {
+    console.log(
+      chalk.yellow(
+        `Skipping unsupported chains: ${unsupportedChains.join(', ')}`,
+      ),
+    );
+  }
+
   // Use default values for context, role, and useSecrets
   const multiProvider = await envConfig.getMultiProvider(
     undefined,
     undefined,
     undefined,
-    Array.from(warpConfigChains),
+    supportedWarpChains,
   );
 
   // TODO: consider retrying this if check throws an error


### PR DESCRIPTION
## Description

Filters warp config chains against `supportedChainNames` before creating MultiProvider to prevent fetching RPC secrets for deprecated chains.

The check-warp-deploy cron job was failing with `PERMISSION_DENIED` errors when trying to fetch secrets for chains deprecated in December (mint, form, inevm, injective, neutron, osmosis) that still have warp route configs in the registry.

## Related Issues

N/A

## Backward Compatibility

Yes - only affects internal cron job behavior, no API changes.