### PR TITLE
fix(e2e): add retry logic to testcontainers for CI reliability

### DIFF
--- a/typescript/cli/src/tests/nodes.ts
+++ b/typescript/cli/src/tests/nodes.ts
@@ -1,26 +1,31 @@
 import { GenericContainer, Wait } from 'testcontainers';
 
 import { type TestChainMetadata } from '@hyperlane-xyz/provider-sdk/chain';
+import { retryAsync } from '@hyperlane-xyz/utils';
 
 export async function runEvmNode({ rpcPort, chainId }: TestChainMetadata) {
-  const container = await new GenericContainer(
-    'ghcr.io/foundry-rs/foundry:latest',
-  )
-    .withEntrypoint([
-      'anvil',
-      '--host',
-      '0.0.0.0',
-      '-p',
-      rpcPort.toString(),
-      '--chain-id',
-      chainId.toString(),
-    ])
-    .withExposedPorts({
-      container: rpcPort,
-      host: rpcPort,
-    })
-    .withWaitStrategy(Wait.forLogMessage(/Listening on/))
-    .start();
+  // Retry container start to handle transient Docker registry 503 errors in CI
+  const container = await retryAsync(
+    () =>
+      new GenericContainer('ghcr.io/foundry-rs/foundry:latest')
+        .withEntrypoint([
+          'anvil',
+          '--host',
+          '0.0.0.0',
+          '-p',
+          rpcPort.toString(),
+          '--chain-id',
+          chainId.toString(),
+        ])
+        .withExposedPorts({
+          container: rpcPort,
+          host: rpcPort,
+        })
+        .withWaitStrategy(Wait.forLogMessage(/Listening on/))
+        .start(),
+    3,
+    5000,
+  );
 
   return container;
 }

--- a/typescript/cosmos-sdk/src/testing/node.ts
+++ b/typescript/cosmos-sdk/src/testing/node.ts
@@ -5,29 +5,37 @@ import {
 } from 'testcontainers';
 
 import { type TestChainMetadata } from '@hyperlane-xyz/provider-sdk/chain';
-import { sleep } from '@hyperlane-xyz/utils';
+import { retryAsync, sleep } from '@hyperlane-xyz/utils';
 
 export async function runCosmosNode({
   rpcPort,
   restPort,
 }: TestChainMetadata): Promise<StartedTestContainer> {
-  const container = await new GenericContainer(
-    'gcr.io/abacus-labs-dev/hyperlane-cosmos-simapp:v1.0.1',
-  )
-    .withExposedPorts(
-      {
-        // default port on the container
-        container: 26657,
-        host: rpcPort,
-      },
-      {
-        // default port on the container
-        container: 1317,
-        host: restPort,
-      },
-    )
-    .withWaitStrategy(Wait.forLogMessage(/received complete proposal block/))
-    .start();
+  // Retry container start to handle transient Docker registry 503 errors in CI
+  const container = await retryAsync(
+    () =>
+      new GenericContainer(
+        'gcr.io/abacus-labs-dev/hyperlane-cosmos-simapp:v1.0.1',
+      )
+        .withExposedPorts(
+          {
+            // default port on the container
+            container: 26657,
+            host: rpcPort,
+          },
+          {
+            // default port on the container
+            container: 1317,
+            host: restPort,
+          },
+        )
+        .withWaitStrategy(
+          Wait.forLogMessage(/received complete proposal block/),
+        )
+        .start(),
+    3,
+    5000,
+  );
 
   // Wait for the block to be committed and RPC to be fully ready.
   // The log message only indicates a proposal was received, not that


### PR DESCRIPTION
## Summary
- Wrapped testcontainers `start()` and `up()` calls with `retryAsync(fn, 3, 5000)` to handle transient Docker registry 503 errors in CI
- Affects radix-sdk, cosmos-sdk, aleo-sdk, and cli e2e test node setup

## Test plan
- [ ] CI passes (this fix addresses the flaky Radix e2e failure from #7962)
- [ ] Manual verification that e2e tests still work locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)