### PR TITLE
feat(sdk): add isDelivered method to ICoreAdapter interface

### DIFF
--- a/typescript/sdk/src/core/adapters/AleoCoreAdapter.ts
+++ b/typescript/sdk/src/core/adapters/AleoCoreAdapter.ts
@@ -57,4 +57,15 @@ export class AleoCoreAdapter extends BaseAleoAdapter implements ICoreAdapter {
 
     return true;
   }
+
+  async isDelivered(
+    messageId: HexString,
+    _blockTag?: string | number,
+  ): Promise<boolean> {
+    const provider = this.multiProvider.getAleoProvider(this.chainName);
+    return provider.isMessageDelivered({
+      mailboxAddress: this.addresses.mailbox,
+      messageId: messageId,
+    });
+  }
 }

--- a/typescript/sdk/src/core/adapters/CosmNativeCoreAdapter.ts
+++ b/typescript/sdk/src/core/adapters/CosmNativeCoreAdapter.ts
@@ -90,4 +90,17 @@ export class CosmNativeCoreAdapter
 
     return true;
   }
+
+  async isDelivered(
+    messageId: HexString,
+    _blockTag?: string | number,
+  ): Promise<boolean> {
+    const provider = await this.multiProvider.getCosmJsNativeProvider(
+      this.chainName,
+    );
+    return provider.isMessageDelivered({
+      mailboxAddress: this.addresses.mailbox,
+      messageId: messageId,
+    });
+  }
 }

--- a/typescript/sdk/src/core/adapters/CosmWasmCoreAdapter.ts
+++ b/typescript/sdk/src/core/adapters/CosmWasmCoreAdapter.ts
@@ -210,4 +210,11 @@ export class CosmWasmCoreAdapter
   ): Promise<boolean> {
     throw new Error('Method not implemented.');
   }
+
+  async isDelivered(
+    messageId: HexString,
+    _blockTag?: string | number,
+  ): Promise<boolean> {
+    return this.delivered(messageId);
+  }
 }

--- a/typescript/sdk/src/core/adapters/EvmCoreAdapter.ts
+++ b/typescript/sdk/src/core/adapters/EvmCoreAdapter.ts
@@ -68,4 +68,12 @@ export class EvmCoreAdapter extends BaseEvmAdapter implements ICoreAdapter {
       maxAttempts,
     );
   }
+
+  async isDelivered(
+    messageId: HexString,
+    blockTag?: string | number,
+  ): Promise<boolean> {
+    const mailbox = this.core.getContracts(this.chainName).mailbox;
+    return mailbox.delivered(messageId, { blockTag });
+  }
 }

--- a/typescript/sdk/src/core/adapters/RadixCoreAdapter.ts
+++ b/typescript/sdk/src/core/adapters/RadixCoreAdapter.ts
@@ -93,4 +93,15 @@ export class RadixCoreAdapter extends BaseRadixAdapter implements ICoreAdapter {
 
     return true;
   }
+
+  async isDelivered(
+    messageId: HexString,
+    _blockTag?: string | number,
+  ): Promise<boolean> {
+    const provider = this.multiProvider.getRadixProvider(this.chainName);
+    return provider.isMessageDelivered({
+      mailboxAddress: this.addresses.mailbox,
+      messageId: messageId,
+    });
+  }
 }

--- a/typescript/sdk/src/core/adapters/SealevelCoreAdapter.ts
+++ b/typescript/sdk/src/core/adapters/SealevelCoreAdapter.ts
@@ -91,6 +91,20 @@ export class SealevelCoreAdapter
     return true;
   }
 
+  async isDelivered(
+    messageId: HexString,
+    _blockTag?: string | number,
+  ): Promise<boolean> {
+    const pda = SealevelCoreAdapter.deriveMailboxMessageProcessedPda(
+      this.addresses.mailbox,
+      messageId,
+    );
+    const connection = this.multiProvider.getSolanaWeb3Provider(this.chainName);
+    // If the PDA exists, then the message has been processed
+    const accountInfo = await connection.getAccountInfo(pda);
+    return (accountInfo?.data?.length ?? 0) > 0;
+  }
+
   static parseMessageDispatchLogs(
     logs: string[],
   ): Array<{ destination: string; messageId: string }> {

--- a/typescript/sdk/src/core/adapters/StarknetCoreAdapter.ts
+++ b/typescript/sdk/src/core/adapters/StarknetCoreAdapter.ts
@@ -124,4 +124,16 @@ export class StarknetCoreAdapter
 
     return true;
   }
+
+  async isDelivered(
+    messageId: HexString,
+    _blockTag?: string | number,
+  ): Promise<boolean> {
+    const mailboxContract = getStarknetMailboxContract(
+      this.addresses.mailbox,
+      this.getProvider(),
+    );
+    const result = await mailboxContract.call('delivered', [messageId]);
+    return Boolean(result);
+  }
 }

--- a/typescript/sdk/src/core/adapters/types.ts
+++ b/typescript/sdk/src/core/adapters/types.ts
@@ -14,4 +14,14 @@ export interface ICoreAdapter extends BaseAppAdapter {
     delayMs?: number,
     maxAttempts?: number,
   ): Promise<boolean>;
+  /**
+   * Check if a message has been delivered on this chain.
+   * @param messageId - The message ID to check
+   * @param blockTag - Optional block tag for finality checks (EVM only)
+   * @returns true if the message has been delivered, false otherwise
+   */
+  isDelivered(
+    messageId: HexString,
+    blockTag?: string | number,
+  ): Promise<boolean>;
 }


### PR DESCRIPTION
## Summary

This PR adds the `isDelivered()` method to the `ICoreAdapter` interface, enabling unified message delivery status checks across all supported VM types.

### Changes

**Interface (`types.ts`)**
- Added `isDelivered(messageId: HexString, blockTag?: string | number): Promise<boolean>` to `ICoreAdapter`

**Adapter Implementations**

| Adapter | Implementation |
|---------|----------------|
| `EvmCoreAdapter` | Queries `mailbox.delivered()` with optional `blockTag` for finality-aware checks |
| `StarknetCoreAdapter` | Queries mailbox contract `delivered()` call |
| `SealevelCoreAdapter` | Checks if message processed PDA exists |
| `CosmWasmCoreAdapter` | Delegates to existing `delivered()` method |
| `CosmNativeCoreAdapter` | Queries `provider.isMessageDelivered()` |
| `RadixCoreAdapter` | Queries `provider.isMessageDelivered()` |
| `AleoCoreAdapter` | Queries `provider.isMessageDelivered()` |

### Why blockTag?

The optional `blockTag` parameter enables finality-aware delivery checks on EVM chains. This is important for:
- Querying delivery status at specific block heights
- Using finality tags like `"finalized"` or `"safe"` to avoid reorg issues
- Supporting use cases like the rebalancer that need confirmed delivery status

Non-EVM adapters accept but ignore the `blockTag` parameter for now.

## Test plan

- [x] SDK builds successfully (`pnpm -C typescript/sdk build`)
- [ ] Verify downstream consumers (rebalancer) work with new interface

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message delivery status checking across all supported blockchains (Aleo, Cosmos, EVM, Radix, Solana, Starknet). Users can now verify message delivery with optional finality checks on EVM-compatible networks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->