### PR TITLE
fix: resolve jest-related oxlint warnings

### DIFF
--- a/oxlint.json
+++ b/oxlint.json
@@ -117,7 +117,27 @@
     "jest/no-focused-tests": "error",
     "jest/no-identical-title": "error",
     "jest/prefer-to-have-length": "warn",
-    "jest/valid-expect": "error"
+    "jest/valid-expect": "error",
+    "jest/expect-expect": [
+      "warn",
+      {
+        "assertFunctionNames": [
+          "expect",
+          "assert",
+          "verifyImport",
+          "runGitleaksSuccessTest",
+          "runGitleaksFailureTest",
+          "sinon.assert.*",
+          "**.expectEmpty",
+          "**.expectViolations",
+          "request.**.expect"
+        ]
+      }
+    ],
+    "jest/valid-title": "off",
+    "jest/valid-describe-callback": "warn",
+    "jest/no-conditional-expect": "warn",
+    "jest/no-export": "warn"
   },
   "globals": {
     "AudioWorkletGlobalScope": "readonly",

--- a/typescript/ccip-server/tests/services/ProofsService.test.ts
+++ b/typescript/ccip-server/tests/services/ProofsService.test.ts
@@ -40,6 +40,7 @@ describe('ProofsService', () => {
     jest.clearAllMocks();
   });
 
+  /* eslint-disable jest/no-conditional-expect -- testing error handling state */
   test('should set currentProofId, if proof is not ready', async () => {
     try {
       await proofsService.getProofs([TARGET_ADDR, STORAGE_KEY, MESSAGE_ID]);
@@ -74,4 +75,5 @@ describe('ProofsService', () => {
       expect(proofsService.pendingProof.get(pendingProofKey)).toBeUndefined();
     }
   });
+  /* eslint-enable jest/no-conditional-expect */
 });

--- a/typescript/helloworld/src/test/deploy.test.ts
+++ b/typescript/helloworld/src/test/deploy.test.ts
@@ -17,7 +17,7 @@ import { HelloWorldChecker } from '../deploy/check.js';
 import { HelloWorldConfig } from '../deploy/config.js';
 import { HelloWorldDeployer } from '../deploy/deploy.js';
 
-describe('deploy', async () => {
+describe('deploy', () => {
   let multiProvider: MultiProvider;
   let core: TestCoreApp;
   let config: ChainMap<HelloWorldConfig>;
@@ -39,10 +39,12 @@ describe('deploy', async () => {
     deployer = new HelloWorldDeployer(multiProvider);
   });
 
+  // eslint-disable-next-line jest/expect-expect -- testing deploy doesn't throw
   it('deploys', async () => {
     contracts = await deployer.deploy(config);
   });
 
+  // eslint-disable-next-line jest/expect-expect -- testing app construction doesn't throw
   it('builds app', async () => {
     contracts = await deployer.deploy(config);
     app = new HelloWorldApp(core, contracts, multiProvider);

--- a/typescript/helloworld/src/test/helloworld.test.ts
+++ b/typescript/helloworld/src/test/helloworld.test.ts
@@ -16,7 +16,7 @@ import { HelloWorldConfig } from '../deploy/config.js';
 import { HelloWorldDeployer } from '../deploy/deploy.js';
 import { HelloWorld } from '../types/index.js';
 
-describe('HelloWorld', async () => {
+describe('HelloWorld', () => {
   const localChain = TestChainName.test1;
   const remoteChain = TestChainName.test2;
   let localDomain: number;

--- a/typescript/infra/test/agent-configs.test.ts
+++ b/typescript/infra/test/agent-configs.test.ts
@@ -36,6 +36,7 @@ const environmentChainConfigs = {
 describe('Agent configs', () => {
   Object.entries(environmentChainConfigs).forEach(([environment, config]) => {
     describe(`Environment: ${environment}`, () => {
+      // eslint-disable-next-line jest/expect-expect -- ensureAgentChainConfigIncludesAllChainNames throws on failure
       it('AgentChainConfig specifies all chains for each role in the agent chain config', () => {
         // This will throw if there are any inconsistencies
         ensureAgentChainConfigIncludesAllChainNames(

--- a/typescript/infra/test/balance-alerts.test.ts
+++ b/typescript/infra/test/balance-alerts.test.ts
@@ -17,7 +17,7 @@ import {
 
 const DEFAULT_TIMEOUT = 30_000;
 
-describe('Balance Alert Thresholds', async function () {
+describe('Balance Alert Thresholds', function () {
   this.timeout(DEFAULT_TIMEOUT);
 
   it('should have matching thresholds between Grafana alerts and threshold config files', async function () {

--- a/typescript/infra/test/govern.hardhat-test.ts
+++ b/typescript/infra/test/govern.hardhat-test.ts
@@ -37,8 +37,10 @@ import {
   HyperlaneAppGovernor,
 } from '../src/govern/HyperlaneAppGovernor.js';
 
+// eslint-disable-next-line jest/no-export -- test fixture class
 export class TestApp extends HyperlaneApp<{}> {}
 
+// eslint-disable-next-line jest/no-export -- test fixture class
 export class TestChecker extends HyperlaneAppChecker<TestApp, OwnableConfig> {
   async checkChain(_: string): Promise<void> {
     this.addViolation({
@@ -50,6 +52,7 @@ export class TestChecker extends HyperlaneAppChecker<TestApp, OwnableConfig> {
   }
 }
 
+// eslint-disable-next-line jest/no-export -- test fixture class
 export class HyperlaneTestGovernor extends HyperlaneAppGovernor<
   TestApp,
   OwnableConfig

--- a/typescript/infra/test/warp-configs.test.ts
+++ b/typescript/infra/test/warp-configs.test.ts
@@ -34,7 +34,8 @@ async function getConfigsForBranch(branch: string) {
   }).getWarpDeployConfigs();
 }
 
-describe.skip('Warp Configs', async function () {
+// eslint-disable-next-line jest/no-disabled-tests -- intentionally skipped, needs stable warp ids
+describe.skip('Warp Configs', function () {
   this.timeout(DEFAULT_TIMEOUT);
   const ENV = 'mainnet3';
   const warpIdsToCheck = Object.keys(warpConfigGetterMap).filter(
@@ -86,6 +87,7 @@ describe.skip('Warp Configs', async function () {
     });
   }
 
+  // eslint-disable-next-line jest/expect-expect -- uses chai-as-promised .should.eventually assertion
   it('should throw if warpRouteId is not found in either Getter nor Registry', async () => {
     const invalidWarpIds = '1111bla-bla-bla111';
     await getWarpConfig(

--- a/typescript/keyfunder/src/metrics/Metrics.test.ts
+++ b/typescript/keyfunder/src/metrics/Metrics.test.ts
@@ -96,6 +96,7 @@ describe('KeyFunderMetrics', () => {
   });
 
   describe('push', () => {
+    // eslint-disable-next-line jest/expect-expect -- testing no-throw behavior
     it('should not throw when no push gateway configured', async () => {
       const metrics = new KeyFunderMetrics(undefined);
       await metrics.push();

--- a/typescript/rebalancer/src/strategy/MinAmountStrategy.test.ts
+++ b/typescript/rebalancer/src/strategy/MinAmountStrategy.test.ts
@@ -64,6 +64,7 @@ describe('MinAmountStrategy', () => {
       ).to.throw('At least two chains must be configured');
     });
 
+    // eslint-disable-next-line jest/expect-expect -- testing constructor doesn't throw
     it('should create a strategy with minAmount and target using absolute values', () => {
       new MinAmountStrategy(
         {
@@ -93,6 +94,7 @@ describe('MinAmountStrategy', () => {
       );
     });
 
+    // eslint-disable-next-line jest/expect-expect -- testing constructor doesn't throw
     it('should create a strategy with minAmount and target using relative values', () => {
       new MinAmountStrategy(
         {

--- a/typescript/relayer/src/metadata/multisig.test.ts
+++ b/typescript/relayer/src/metadata/multisig.test.ts
@@ -49,7 +49,8 @@ const fixtures: Fixture<MultisigMetadata>[] = files
     return { decoded, encoded: contents.encoded };
   });
 
-// FIXME: migrate to mocha rules: eslint-disable-next-line jest/no-disabled-tests
+// FIXME: migrate to mocha rules
+// eslint-disable-next-line jest/no-disabled-tests -- intentionally skipped pending migration
 describe.skip('MultisigMetadataBuilder', () => {
   fixtures.forEach((fixture, i) => {
     it(`should encode fixture ${i}`, () => {

--- a/typescript/sdk/src/core/HyperlaneCore.test.ts
+++ b/typescript/sdk/src/core/HyperlaneCore.test.ts
@@ -4,6 +4,7 @@ import { HyperlaneCore } from './HyperlaneCore.js';
 
 describe('HyperlaneCore', () => {
   describe('fromEnvironment', () => {
+    // eslint-disable-next-line jest/expect-expect -- testing factory doesn't throw
     it('creates an object for testnet', async () => {
       const multiProvider = MultiProvider.createTestMultiProvider();
       HyperlaneCore.fromAddressesMap({ test1: {} }, multiProvider);

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
@@ -15,8 +15,11 @@ import { EvmTokenFeeReader } from './EvmTokenFeeReader.js';
 import { TokenFeeConfig, TokenFeeConfigSchema, TokenFeeType } from './types.js';
 import { ASSUMED_MAX_AMOUNT_FOR_ZERO_SUPPLY, convertToBps } from './utils.js';
 
+// eslint-disable-next-line jest/no-export -- test fixtures shared across test files
 export const MAX_FEE = 115792089237316195423570985008687907853269n;
+// eslint-disable-next-line jest/no-export -- test fixtures shared across test files
 export const HALF_AMOUNT = 578960446186580977117854925043439539266340n;
+// eslint-disable-next-line jest/no-export -- test fixtures shared across test files
 export const BPS = convertToBps(MAX_FEE, HALF_AMOUNT);
 
 describe('EvmTokenFeeReader', () => {

--- a/typescript/warp-monitor/src/utils.test.ts
+++ b/typescript/warp-monitor/src/utils.test.ts
@@ -36,6 +36,7 @@ describe('Warp Monitor Utils', () => {
       expect(executed).to.be.true;
     });
 
+    // eslint-disable-next-line jest/expect-expect -- testing no-throw behavior
     it('should catch and log errors without throwing', async () => {
       const logger = getLogger();
       const errorFn = async () => {


### PR DESCRIPTION
## Summary

Follow-up to #7970 - resolves all remaining jest-related oxlint warnings.

**Warnings reduced: 127 → 60 (67 fixed)**

All remaining 60 warnings are import cycles (architectural debt, intentionally kept as warnings).

### Fixes included

| Category | Count | Fix |
|----------|-------|-----|
| `valid-title` | 22 | Disabled rule for test files (parameterized tests are valid) |
| `expect-expect` | 30 | Added `assertFunctionNames` config + disable comments for no-throw tests |
| `no-export` | 6 | Added disable comments (test fixtures shared between files) |
| `valid-describe-callback` | 4 | Removed unnecessary `async` from describe callbacks |
| `no-conditional-expect` | 3 | Added disable comments (testing error handling state) |
| `no-disabled-tests` | 2 | Added disable comments (intentionally skipped tests) |

### oxlint config changes

Updated `oxlint.json` with:
- `jest/expect-expect` with `assertFunctionNames` for custom assertion helpers
- `jest/valid-title` disabled (parameterized test patterns are valid)
- Explicit jest rule configuration for better control

### Test files modified

- `typescript/ccip-server/tests/services/ProofsService.test.ts`
- `typescript/helloworld/src/test/deploy.test.ts`
- `typescript/helloworld/src/test/helloworld.test.ts`
- `typescript/infra/test/agent-configs.test.ts`
- `typescript/infra/test/balance-alerts.test.ts`
- `typescript/infra/test/govern.hardhat-test.ts`
- `typescript/infra/test/warp-configs.test.ts`
- `typescript/keyfunder/src/metrics/Metrics.test.ts`
- `typescript/rebalancer/src/strategy/MinAmountStrategy.test.ts`
- `typescript/relayer/src/metadata/multisig.test.ts`
- `typescript/sdk/src/core/HyperlaneCore.test.ts`
- `typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts`
- `typescript/warp-monitor/src/utils.test.ts`