### PR TITLE
fix: resolve import cycle warnings using type-only imports

### DIFF
--- a/typescript/infra/config/environments/test/index.ts
+++ b/typescript/infra/config/environments/test/index.ts
@@ -2,7 +2,7 @@ import { JsonRpcProvider } from '@ethersproject/providers';
 
 import { MultiProvider } from '@hyperlane-xyz/sdk';
 
-import { EnvironmentConfig } from '../../../src/config/environment.js';
+import type { EnvironmentConfig } from '../../../src/config/environment.js';
 
 import { agents } from './agent.js';
 import { testChainNames } from './chains.js';

--- a/typescript/infra/src/agents/agent.ts
+++ b/typescript/infra/src/agents/agent.ts
@@ -1,7 +1,7 @@
 import { ChainName } from '@hyperlane-xyz/sdk';
 
 import { Contexts } from '../../config/contexts.js';
-import { DeployEnvironment } from '../config/environment.js';
+import type { DeployEnvironment } from '../config/environment.js';
 import { Role } from '../roles.js';
 import { assertRole } from '../utils/utils.js';
 

--- a/typescript/infra/src/agents/aws/user.ts
+++ b/typescript/infra/src/agents/aws/user.ts
@@ -10,8 +10,8 @@ import {
 import { ChainName } from '@hyperlane-xyz/sdk';
 
 import { Contexts } from '../../../config/contexts.js';
-import { AgentContextConfig } from '../../config/agent/agent.js';
-import { DeployEnvironment } from '../../config/environment.js';
+import type { AgentContextConfig } from '../../config/agent/agent.js';
+import type { DeployEnvironment } from '../../config/environment.js';
 import { Role } from '../../roles.js';
 import {
   fetchGCPSecret,

--- a/typescript/infra/src/agents/aws/validator-user.ts
+++ b/typescript/infra/src/agents/aws/validator-user.ts
@@ -11,8 +11,8 @@ import {
 import { ChainName } from '@hyperlane-xyz/sdk';
 
 import { Contexts } from '../../../config/contexts.js';
-import { AgentContextConfig } from '../../config/agent/agent.js';
-import { DeployEnvironment } from '../../config/environment.js';
+import type { AgentContextConfig } from '../../config/agent/agent.js';
+import type { DeployEnvironment } from '../../config/environment.js';
 import { Role } from '../../roles.js';
 
 import { AgentAwsKey } from './key.js';

--- a/typescript/infra/src/agents/key-utils.ts
+++ b/typescript/infra/src/agents/key-utils.ts
@@ -16,8 +16,11 @@ import { Contexts } from '../../config/contexts.js';
 import { getChain } from '../../config/registry.js';
 import localRelayerAddresses from '../../config/relayer.json' with { type: 'json' };
 import { getAWValidatorsPath } from '../../scripts/agent-utils.js';
-import { AgentContextConfig, RootAgentConfig } from '../config/agent/agent.js';
-import { DeployEnvironment } from '../config/environment.js';
+import type {
+  AgentContextConfig,
+  RootAgentConfig,
+} from '../config/agent/agent.js';
+import type { DeployEnvironment } from '../config/environment.js';
 import { Role } from '../roles.js';
 import { fetchGCPSecret, setGCPSecretUsingClient } from '../utils/gcloud.js';
 import {

--- a/typescript/infra/src/agents/keys.ts
+++ b/typescript/infra/src/agents/keys.ts
@@ -5,7 +5,7 @@ import { ChainName } from '@hyperlane-xyz/sdk';
 import { HexString, ProtocolType } from '@hyperlane-xyz/utils';
 
 import { Contexts } from '../../config/contexts.js';
-import { DeployEnvironment } from '../config/environment.js';
+import type { DeployEnvironment } from '../config/environment.js';
 import { Role } from '../roles.js';
 import { assertChain, assertContext, assertRole } from '../utils/utils.js';
 

--- a/typescript/infra/src/config/agent/agent.ts
+++ b/typescript/infra/src/config/agent/agent.ts
@@ -12,16 +12,16 @@ import { ProtocolType, objMap } from '@hyperlane-xyz/utils';
 import { Contexts } from '../../../config/contexts.js';
 import { getChain } from '../../../config/registry.js';
 import { AgentChainNames, AgentRole, Role } from '../../roles.js';
-import { DeployEnvironment } from '../environment.js';
-import { HelmImageValues } from '../infrastructure.js';
+import type { DeployEnvironment } from '../environment.js';
+import type { HelmImageValues } from '../infrastructure.js';
 
-import {
+import type {
   BaseRelayerConfig,
   HelmRelayerChainValues,
   HelmRelayerValues,
 } from './relayer.js';
-import { BaseScraperConfig, HelmScraperValues } from './scraper.js';
-import {
+import type { BaseScraperConfig, HelmScraperValues } from './scraper.js';
+import type {
   HelmValidatorValues,
   ValidatorBaseChainConfigMap,
 } from './validator.js';

--- a/typescript/infra/src/config/agent/scraper.ts
+++ b/typescript/infra/src/config/agent/scraper.ts
@@ -5,7 +5,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 
 import { Role } from '../../roles.js';
-import { HelmStatefulSetValues } from '../infrastructure.js';
+import type { HelmStatefulSetValues } from '../infrastructure.js';
 
 import { AgentConfigHelper, RootAgentConfig } from './agent.js';
 

--- a/typescript/infra/src/config/infrastructure.ts
+++ b/typescript/infra/src/config/infrastructure.ts
@@ -1,4 +1,4 @@
-import { KubernetesResources } from './agent/agent.js';
+import type { KubernetesResources } from './agent/agent.js';
 
 export interface HelmImageValues {
   repository: string;

--- a/typescript/provider-sdk/src/protocol.ts
+++ b/typescript/provider-sdk/src/protocol.ts
@@ -1,7 +1,7 @@
 import { assert } from '@hyperlane-xyz/utils';
 
 import { IProvider, ISigner } from './altvm.js';
-import { ChainMetadataForAltVM } from './chain.js';
+import type { ChainMetadataForAltVM } from './chain.js';
 import { IRawHookArtifactManager } from './hook.js';
 import { IRawIsmArtifactManager } from './ism.js';
 import { MinimumRequiredGasByAction } from './mingas.js';

--- a/typescript/sdk/src/block-explorer/etherscan.ts
+++ b/typescript/sdk/src/block-explorer/etherscan.ts
@@ -6,7 +6,7 @@ import {
   strip0x,
 } from '@hyperlane-xyz/utils';
 
-import { SolidityStandardJsonInput } from '../deploy/verify/types.js';
+import type { SolidityStandardJsonInput } from '../deploy/verify/types.js';
 import { GetEventLogsResponse } from '../rpc/evm/types.js';
 
 export enum EtherscanLikeExplorerApiModule {

--- a/typescript/sdk/src/block-explorer/utils.ts
+++ b/typescript/sdk/src/block-explorer/utils.ts
@@ -1,7 +1,5 @@
-import {
-  BlockExplorer,
-  ExplorerFamily,
-} from '../metadata/chainMetadataTypes.js';
+import type { BlockExplorer } from '../metadata/chainMetadataTypes.js';
+import { ExplorerFamily } from '../metadata/chainMetadataTypes.js';
 
 export function isEvmBlockExplorerAndNotEtherscan(
   blockExplorer: BlockExplorer,

--- a/typescript/sdk/src/consts/testChains.ts
+++ b/typescript/sdk/src/consts/testChains.ts
@@ -1,11 +1,11 @@
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
 import {
-  ChainMetadata,
   ChainTechnicalStack,
   ExplorerFamily,
 } from '../metadata/chainMetadataTypes.js';
-import { ChainMap, ChainName } from '../types.js';
+import type { ChainMetadata } from '../metadata/chainMetadataTypes.js';
+import type { ChainMap, ChainName } from '../types.js';
 
 export enum TestChainName {
   test1 = 'test1',

--- a/typescript/sdk/src/contracts/contracts.ts
+++ b/typescript/sdk/src/contracts/contracts.ts
@@ -16,7 +16,7 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
-import { EthersLikeProvider } from '../deploy/proxy.js';
+import type { EthersLikeProvider } from '../deploy/proxy.js';
 import { ChainMetadataManager } from '../metadata/ChainMetadataManager.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';

--- a/typescript/sdk/src/core/EvmIcaModule.ts
+++ b/typescript/sdk/src/core/EvmIcaModule.ts
@@ -15,8 +15,10 @@ import { serializeContracts } from '../contracts/contracts.js';
 import { HyperlaneAddresses } from '../contracts/types.js';
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
 import { EvmIcaRouterReader } from '../ica/EvmIcaReader.js';
-import { DerivedIcaRouterConfig } from '../ica/types.js';
-import { InterchainAccountConfig } from '../index.js';
+import type {
+  DerivedIcaRouterConfig,
+  IcaRouterConfig as InterchainAccountConfig,
+} from '../ica/types.js';
 import { InterchainAccountDeployer } from '../middleware/account/InterchainAccountDeployer.js';
 import { InterchainAccountFactories } from '../middleware/account/contracts.js';
 import { MultiProvider } from '../providers/MultiProvider.js';

--- a/typescript/sdk/src/deploy/verify/types.ts
+++ b/typescript/sdk/src/deploy/verify/types.ts
@@ -1,4 +1,4 @@
-import { ExplorerLicenseType } from '../../block-explorer/etherscan.js';
+import type { ExplorerLicenseType } from '../../block-explorer/etherscan.js';
 
 export type ContractVerificationInput = {
   name: string;

--- a/typescript/sdk/src/fee/EvmTokenFeeDeployer.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeDeployer.ts
@@ -1,11 +1,12 @@
 import { BaseFee, RoutingFee } from '@hyperlane-xyz/core';
 import { eqAddress } from '@hyperlane-xyz/utils';
 
+import type { HyperlaneContracts } from '../contracts/types.js';
 import {
   DeployerOptions,
   HyperlaneDeployer,
 } from '../deploy/HyperlaneDeployer.js';
-import { HyperlaneContracts, MultiProvider } from '../index.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainName } from '../types.js';
 
 import { EvmTokenFeeReader } from './EvmTokenFeeReader.js';

--- a/typescript/sdk/src/metadata/chainMetadataTypes.ts
+++ b/typescript/sdk/src/metadata/chainMetadataTypes.ts
@@ -6,7 +6,7 @@ import { SafeParseReturnType, z } from 'zod';
 
 import { ProtocolType, objMerge } from '@hyperlane-xyz/utils';
 
-import { ChainMap } from '../types.js';
+import type { ChainMap } from '../types.js';
 
 import { ZChainName, ZNzUint, ZUint } from './customZodTypes.js';
 

--- a/typescript/sdk/src/middleware/account/InterchainAccountChecker.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccountChecker.ts
@@ -1,4 +1,4 @@
-import { InterchainAccountConfig } from '../../index.js';
+import type { IcaRouterConfig as InterchainAccountConfig } from '../../ica/types.js';
 import { HyperlaneRouterChecker } from '../../router/HyperlaneRouterChecker.js';
 
 import { InterchainAccount } from './InterchainAccount.js';

--- a/typescript/sdk/src/rpc/evm/EvmEventLogsReader.ts
+++ b/typescript/sdk/src/rpc/evm/EvmEventLogsReader.ts
@@ -8,12 +8,10 @@ import {
   getLogsFromEtherscanLikeExplorerAPI,
 } from '../../block-explorer/etherscan.js';
 import { assertIsContractAddress } from '../../contracts/contracts.js';
-import {
-  ChainMetadataManager,
-  ChainNameOrId,
-  MultiProvider,
-} from '../../index.js';
+import type { ChainMetadataManager } from '../../metadata/ChainMetadataManager.js';
 import { ZBytes32String, ZHash, ZUint } from '../../metadata/customZodTypes.js';
+import { MultiProvider } from '../../providers/MultiProvider.js';
+import type { ChainNameOrId } from '../../types.js';
 
 import { GetEventLogsResponse } from './types.js';
 import { getContractCreationBlockFromRpc, getLogsFromRpc } from './utils.js';

--- a/typescript/sdk/src/signers/evm/ethersv5.ts
+++ b/typescript/sdk/src/signers/evm/ethersv5.ts
@@ -3,7 +3,7 @@ import { Wallet as ZkSyncWallet } from 'zksync-ethers';
 
 import { Address, ProtocolType, assert } from '@hyperlane-xyz/utils';
 
-import { ChainTechnicalStack } from '../../index.js';
+import { ChainTechnicalStack } from '../../metadata/chainMetadataTypes.js';
 import { MultiProtocolProvider } from '../../providers/MultiProtocolProvider.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
 import { EthersV5Transaction } from '../../providers/ProviderType.js';

--- a/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.ts
+++ b/typescript/sdk/src/timelock/evm/EvmTimelockDeployer.ts
@@ -8,9 +8,9 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
+import type { HyperlaneContracts } from '../../contracts/types.js';
 import { HyperlaneDeployer } from '../../deploy/HyperlaneDeployer.js';
 import { ContractVerifier } from '../../deploy/verify/ContractVerifier.js';
-import { HyperlaneContracts } from '../../index.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
 import { TimelockConfig } from '../types.js';
 

--- a/typescript/sdk/src/types.ts
+++ b/typescript/sdk/src/types.ts
@@ -5,7 +5,7 @@ import type { AltVM, ProtocolType } from '@hyperlane-xyz/provider-sdk';
 import type { Address, Domain } from '@hyperlane-xyz/utils';
 
 import { ZHash } from './metadata/customZodTypes.js';
-import { MultiProvider } from './providers/MultiProvider.js';
+import type { MultiProvider } from './providers/MultiProvider.js';
 import {
   ProtocolReceipt,
   ProtocolTransaction,


### PR DESCRIPTION
## Summary

Third PR in the oxlint migration series. Fixes import cycle warnings by converting regular imports to `import type` where values are only used in type positions.

**Warning reduction:** 60 → 18 (42 fixed, 70% reduction)

## Changes

Across 23 files in sdk, provider-sdk, and infra packages:
- Use `import type` for types/interfaces only used in annotations
- Replace barrel imports (from `index.js`) with direct module imports  
- Split imports where some values are runtime and others are types

## Remaining Cycles (18 warnings)

These require architectural refactoring (runtime dependencies):
- SDK submitter factory pattern cycle
- SDK token deploy/configUtils bidirectional calls
- Relayer metadata decode/aggregation cycle
- Infra governance type enum cycle
- CLI warp/context cycles

## PR Series

1. **PR #7966** (`pbio/migrate-to-oxlint`) - Initial oxlint setup
2. **PR #7970** (`pbio/oxlint-fixes-2`) - Fixed 108 general warnings
3. **PR #7975** (`pbio/oxlint-jest-fixes`) - Fixed 67 jest warnings
4. **This PR** - Fixed 42 import cycle warnings