### PR TITLE
fix(sdk): pass from address correctly in HypNative checker

### DIFF
--- a/.changeset/fix-hypnative-checker-ci.md
+++ b/.changeset/fix-hypnative-checker-ci.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed HypNative token checker failing in CI environments by passing `from` address as the third parameter to `estimateGas` instead of inside the transaction object.

--- a/typescript/sdk/src/token/checker.ts
+++ b/typescript/sdk/src/token/checker.ts
@@ -146,11 +146,14 @@ export class HypERC20Checker extends ProxiedRouterChecker<
     // Check if configured token type matches actual token type
     if (isNativeTokenConfig(expectedConfig)) {
       try {
-        await this.multiProvider.estimateGas(chain, {
-          to: hypToken.address,
-          from: NON_ZERO_SENDER_ADDRESS,
-          value: BigNumber.from(1),
-        });
+        await this.multiProvider.estimateGas(
+          chain,
+          {
+            to: hypToken.address,
+            value: BigNumber.from(1),
+          },
+          NON_ZERO_SENDER_ADDRESS,
+        );
       } catch {
         const violation: TokenMismatchViolation = {
           type: 'deployed token not payable',


### PR DESCRIPTION
## Summary
- Fixed HypNative token checker failing in CI environments (e.g., hyperlane-registry CI)
- The `from` address was being passed inside the transaction object instead of as the third parameter to `estimateGas`

## Root Cause

The checker code was passing `from` inside the tx object:
```typescript
// Before (buggy)
await this.multiProvider.estimateGas(chain, {
  to: hypToken.address,
  from: NON_ZERO_SENDER_ADDRESS,  // Gets ignored!
  value: BigNumber.from(1),
});
```

But `MultiProvider.prepareTx` overwrites `tx.from` with the signer address:
```typescript
const txFrom = from ?? (await this.getSignerAddress(chain));  // ignores tx.from!
return { ...tx, from: txFrom, ...overrides };  // overwrites tx.from
```

**Why this causes "token not payable" in CI:**
1. CI runs with `CI=true` → `getMultiProviderForRole` returns MultiProvider without signers
2. Checker calls `estimateGas(chain, {from: NON_ZERO_SENDER_ADDRESS, ...})`
3. `prepareTx` ignores `tx.from` and calls `getSignerAddress(chain)`
4. `getSignerAddress` throws "No chain signer set for X"
5. The catch block interprets this as "token not payable" and adds a violation

**Why it works locally:**
- Locally, signers are configured
- `getSignerAddress` returns the signer's address (ignoring `NON_ZERO_SENDER_ADDRESS`)
- Gas estimation succeeds because the signer address works fine
- No violation (but technically using wrong address)

## Fix
Pass `from` as the third parameter (like `EvmWarpRouteReader` already does correctly):
```typescript
// After (fixed)
await this.multiProvider.estimateGas(
  chain,
  { to: hypToken.address, value: BigNumber.from(1) },
  NON_ZERO_SENDER_ADDRESS,
);
```

## Verified
```bash
# Before fix (CI=true)
$ CI=true pnpm tsx typescript/infra/scripts/check/check-deploy.ts -e mainnet3 -m warp --warpRouteId ETH/ethereum-hyperevm --forceRegistryConfig
# Result: "deployed token not payable" violation

# After fix (CI=true)  
$ CI=true pnpm tsx typescript/infra/scripts/check/check-deploy.ts -e mainnet3 -m warp --warpRouteId ETH/ethereum-hyperevm --forceRegistryConfig
# Result: "warp checker found no violations"
```

## Test plan
- [x] Verified fix locally with `CI=true` on ETH/ethereum-hyperevm HypNative route
- [ ] Verify HypNative warp routes pass check-deploy in hyperlane-registry CI after Docker image rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)