### PR TITLE
fix(starknet): add retry logic to fetch-contracts-release.sh

### DIFF
--- a/starknet/scripts/fetch-contracts-release.sh
+++ b/starknet/scripts/fetch-contracts-release.sh
@@ -37,12 +37,13 @@ curl_with_retry() {
     local attempt=1
 
     while [ $attempt -le $MAX_RETRIES ]; do
-        if curl "$@" "$url"; then
+        # --retry-connrefused handles low-level connection failures
+        if curl --retry-connrefused "$@" "$url"; then
             return 0
         fi
 
         if [ $attempt -lt $MAX_RETRIES ]; then
-            log_warning "Curl failed (attempt $attempt/$MAX_RETRIES), retrying in ${RETRY_DELAY}s..."
+            log_warning "Curl failed (attempt $attempt/$MAX_RETRIES), retrying in ${RETRY_DELAY}s..." >&2
             sleep $RETRY_DELAY
         fi
         ((attempt++))


### PR DESCRIPTION
## Summary
- Added retry logic (3 attempts, 5s delay) to all curl commands in `fetch-contracts-release.sh`
- Fixes transient CI flakes where GitHub API returns failures during Docker builds

## Context
CI builds were failing intermittently with errors like "Version v0.3.2 does not exist" even though the version exists. This happens when GitHub API is temporarily unavailable or rate-limited during Docker image builds.

Example failure: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/21528198346/job/62037207091

## Test plan
- [x] Tested script locally - downloads contracts successfully
- [x] Verified bash syntax is valid

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contract release download reliability with automatic retry mechanism for transient network failures
  * Enhanced error messaging with colored warnings to better communicate retry attempts and failures during network operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->