### PR TITLE
refactor(metrics): remove remote label from hyperlane_last_known_message_nonce

### DIFF
--- a/rust/main/agents/relayer/src/metrics/message_submission.rs
+++ b/rust/main/agents/relayer/src/metrics/message_submission.rs
@@ -40,11 +40,9 @@ impl MessageSubmissionMetrics {
         Self {
             origin: origin.to_string(),
             destination: destination.to_string(),
-            last_known_nonce: metrics.last_known_message_nonce().with_label_values(&[
-                "message_processed",
-                origin,
-                destination,
-            ]),
+            last_known_nonce: metrics
+                .last_known_message_nonce()
+                .with_label_values(&["message_processed", origin]),
             messages_processed: metrics
                 .messages_processed_count()
                 .with_label_values(&[origin, destination]),

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -38,17 +38,13 @@ impl ApplicationOperationVerifier for DummyApplicationOperationVerifier {
     }
 }
 
-pub fn dummy_message_loader_metrics(domain_id: u32) -> MessageDbLoaderMetrics {
+pub fn dummy_message_loader_metrics() -> MessageDbLoaderMetrics {
     MessageDbLoaderMetrics {
-        max_last_known_message_nonce_gauge: IntGauge::new(
-            "dummy_max_last_known_message_nonce_gauge",
+        last_known_message_nonce_gauge: IntGauge::new(
+            "dummy_last_known_message_nonce_gauge",
             "help string",
         )
         .unwrap(),
-        last_known_message_nonce_gauges: HashMap::from([(
-            domain_id,
-            IntGauge::new("dummy_last_known_message_nonce_gauge", "help string").unwrap(),
-        )]),
     }
 }
 
@@ -88,7 +84,7 @@ fn dummy_message_loader(
             Default::default(),
             Default::default(),
             Default::default(),
-            dummy_message_loader_metrics(origin_domain.id()),
+            dummy_message_loader_metrics(),
             HashMap::from([(destination_domain.id(), send_channel)]),
             HashMap::from([(destination_domain.id(), message_context)]),
             vec![].into(),
@@ -276,7 +272,7 @@ async fn test_forward_backward_iterator() {
     mock_db
         .expect_retrieve_processed_by_nonce()
         .returning(|_| Ok(Some(false)));
-    let dummy_metrics = dummy_message_loader_metrics(0);
+    let dummy_metrics = dummy_message_loader_metrics();
     let db = Arc::new(mock_db);
 
     let mut forward_backward_iterator = ForwardBackwardIterator::new(db.clone());

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -829,11 +829,7 @@ impl Relayer {
         send_channels: HashMap<u32, UnboundedSender<QueueOperation>>,
         task_monitor: TaskMonitor,
     ) -> eyre::Result<JoinHandle<()>> {
-        let metrics = MessageDbLoaderMetrics::new(
-            &self.core.metrics,
-            &origin.domain,
-            self.destinations.keys(),
-        );
+        let metrics = MessageDbLoaderMetrics::new(&self.core.metrics, &origin.domain);
         let destination_ctxs: HashMap<_, _> = self
             .destinations
             .keys()

--- a/rust/main/hyperlane-base/src/contract_sync/metrics.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/metrics.rs
@@ -23,9 +23,6 @@ pub struct ContractSyncMetrics {
     /// - `chain`: Chain the indexer is collecting data from.
     pub stored_events: IntCounterVec,
 
-    /// See `last_known_message_nonce` in CoreMetrics.
-    pub message_nonce: IntGaugeVec,
-
     /// Contract sync liveness metric
     pub liveness_metrics: IntGaugeVec,
 
@@ -60,13 +57,11 @@ impl ContractSyncMetrics {
             )
             .expect("failed to register liveness metric");
 
-        let message_nonce = metrics.last_known_message_nonce();
         let cursor_metrics = Arc::new(CursorMetrics::new(metrics));
 
         ContractSyncMetrics {
             indexed_height,
             stored_events,
-            message_nonce,
             liveness_metrics,
             cursor_metrics,
         }

--- a/rust/main/hyperlane-base/src/metrics/core.rs
+++ b/rust/main/hyperlane-base/src/metrics/core.rs
@@ -135,7 +135,7 @@ impl CoreMetrics {
                 "Last known message nonce",
                 const_labels_ref
             ),
-            &["phase", "origin", "remote"],
+            &["phase", "origin"],
             registry
         )?;
 
@@ -477,22 +477,15 @@ impl CoreMetrics {
     /// stage, such as being fully processed, even if the reported nonce is
     /// higher than that message's nonce.
     ///
-    /// Some phases are not able to report the remote chain, but origin chain is
-    /// always reported.
-    ///
     /// Labels:
     /// - `phase`: The phase the nonce is being tracked at, see below.
-    /// - `origin`: Origin chain the message comes from. Can be "any"
-    /// - `remote`: Remote chain for the message. This will skip values because
-    ///   the nonces are contiguous by origin not remote. Can be "any"
+    /// - `origin`: Origin chain the message comes from.
     ///
     /// The following phases are implemented:
-    /// - `dispatch`: Highest nonce which has been indexed on the mailbox
-    ///   contract syncer and stored in the relayer DB.
-    /// - `processor_loop`: Highest nonce which the MessageProcessor loop has
+    /// - `db_loader_loop`: Highest nonce, which the db loader loop has
     ///   gotten to but not attempted to send it.
-    /// - `message_processed`: When a nonce was processed as part of the
-    ///   MessageProcessor loop.
+    /// - `message_processed`: When nonce was processed as part of the
+    ///   message submission flow.
     pub fn last_known_message_nonce(&self) -> IntGaugeVec {
         self.last_known_message_nonce.clone()
     }


### PR DESCRIPTION
## Summary
- Removed `remote` label from `hyperlane_last_known_message_nonce` metric to reduce cardinality
- Simplified `MessageDbLoaderMetrics` to single gauge per origin (removed per-destination tracking)
- Removed unused `message_nonce` field from `ContractSyncMetrics` (was never accessed)
- Updated docstring to reflect actual phases (`db_loader_loop`, `message_processed`)

## Test plan
- [x] `cargo check` passes
- [x] `cargo test --package relayer db_loader` passes

## Breaking changes
Grafana dashboards and alerts using the `remote` label on this metric will need updates:
- "Relayers v2 & v3" dashboard panels and template variables
- mainnet2/testnet4 "relayer message leaf index is behind validator" alerts

Note: mainnet3 alerts already use `hyperlane_cursor_max_sequence` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified metrics collection by consolidating per-destination message nonce tracking into a single shared gauge.
  * Updated metrics labels to reduce dimensionality and streamline data collection in the relay agent.
  * Removed redundant message nonce metrics from the contract sync module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->