### PR TITLE
fix(cli): support multi-chain warp routes in extendWarpConfig test helper

### DIFF
--- a/.changeset/fix-extend-warp-config-multichain.md
+++ b/.changeset/fix-extend-warp-config-multichain.md
@@ -1,0 +1,12 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+Fix extendWarpConfig test helper to support multi-chain warp routes
+
+The extendWarpConfig helper now reads ALL existing chains from the warp core config instead of just a single chain. This fixes an issue where extending a multi-chain warp route (e.g., 2 chains → 3 chains) would lose configuration for existing chains that weren't explicitly passed to the function.
+
+Changes:
+- Updated extendWarpConfig to iterate over all tokens in warpCorePath
+- Removed the `chain` parameter (no longer needed)
+- Added test for multi-chain extension scenario

--- a/typescript/cli/src/tests/ethereum/warp/warp-extend-basic.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-extend-basic.e2e-test.ts
@@ -78,7 +78,6 @@ describe('hyperlane warp apply basic extension tests', async function () {
     };
 
     await extendWarpConfig({
-      chain: CHAIN_NAME_2,
       chainToExtend: CHAIN_NAME_3,
       extendedConfig: config,
       warpCorePath: WARP_CORE_CONFIG_PATH_2,
@@ -136,7 +135,6 @@ describe('hyperlane warp apply basic extension tests', async function () {
     };
 
     await extendWarpConfig({
-      chain: CHAIN_NAME_2,
       chainToExtend: CHAIN_NAME_3,
       extendedConfig: config,
       warpCorePath: WARP_CORE_CONFIG_PATH_2,
@@ -326,7 +324,6 @@ describe('hyperlane warp apply basic extension tests', async function () {
     };
 
     await extendWarpConfig({
-      chain: CHAIN_NAME_2,
       chainToExtend: CHAIN_NAME_3,
       extendedConfig: config,
       warpCorePath: WARP_CORE_CONFIG_PATH_2,

--- a/typescript/cli/src/tests/ethereum/warp/warp-extend-config.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-extend-config.e2e-test.ts
@@ -70,7 +70,6 @@ describe('hyperlane warp apply config extension tests', async function () {
     };
 
     await extendWarpConfig({
-      chain: CHAIN_NAME_2,
       chainToExtend: CHAIN_NAME_3,
       extendedConfig: config,
       warpCorePath: WARP_CORE_CONFIG_PATH_2,
@@ -130,7 +129,6 @@ describe('hyperlane warp apply config extension tests', async function () {
     };
 
     await extendWarpConfig({
-      chain: CHAIN_NAME_2,
       chainToExtend: CHAIN_NAME_3,
       extendedConfig: config,
       warpCorePath: WARP_CORE_CONFIG_PATH_2,

--- a/typescript/cli/src/tests/ethereum/warp/warp-extend-multichain.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-extend-multichain.e2e-test.ts
@@ -1,0 +1,201 @@
+import { expect } from 'chai';
+import { Wallet } from 'ethers';
+
+import { type ChainAddresses } from '@hyperlane-xyz/registry';
+import {
+  type HypTokenRouterConfig,
+  TokenType,
+  type WarpCoreConfig,
+  type WarpRouteDeployConfig,
+} from '@hyperlane-xyz/sdk';
+
+import { readYamlOrJson, writeYamlOrJson } from '../../../utils/files.js';
+import { deployOrUseExistingCore } from '../commands/core.js';
+import { getDomainId } from '../commands/helpers.js';
+import {
+  extendWarpConfig,
+  hyperlaneWarpDeploy,
+  readWarpConfig,
+} from '../commands/warp.js';
+import {
+  ANVIL_KEY,
+  CHAIN_NAME_2,
+  CHAIN_NAME_3,
+  CHAIN_NAME_4,
+  CORE_CONFIG_PATH,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  TEMP_PATH,
+  WARP_CONFIG_PATH_EXAMPLE,
+  getCombinedWarpRoutePath,
+} from '../consts.js';
+
+/**
+ * Tests for extending multi-chain warp routes.
+ *
+ * These tests verify that when extending a warp route that already spans
+ * multiple chains (e.g., chain2 + chain3), all existing chains are preserved
+ * in the deploy config, not just one.
+ *
+ * Bug context: The extendWarpConfig helper previously only read config for
+ * a single chain, causing other existing chains to be missing from the
+ * deploy config when extending multi-chain routes.
+ */
+describe('hyperlane warp apply multi-chain extension tests', async function () {
+  this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
+
+  let chain2Addresses: ChainAddresses = {};
+  let chain3Addresses: ChainAddresses = {};
+  let chain4Addresses: ChainAddresses = {};
+
+  const WARP_CONFIG_PATH_MULTICHAIN = `${TEMP_PATH}/warp-route-deployment-multichain.yaml`;
+  const WARP_DEPLOY_MULTICHAIN_ID = 'ETH/anvil2-anvil3';
+
+  before(async function () {
+    // Deploy core contracts to all three chains
+    [chain2Addresses, chain3Addresses, chain4Addresses] = await Promise.all([
+      deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY),
+      deployOrUseExistingCore(CHAIN_NAME_3, CORE_CONFIG_PATH, ANVIL_KEY),
+      deployOrUseExistingCore(CHAIN_NAME_4, CORE_CONFIG_PATH, ANVIL_KEY),
+    ]);
+  });
+
+  beforeEach(async function () {
+    // Create a warp config spanning TWO chains (chain2 + chain3)
+    const warpConfigExample: WarpRouteDeployConfig = readYamlOrJson(
+      WARP_CONFIG_PATH_EXAMPLE,
+    );
+
+    const multiChainConfig: WarpRouteDeployConfig = {
+      [CHAIN_NAME_2]: {
+        ...warpConfigExample.anvil1,
+        mailbox: chain2Addresses.mailbox,
+        owner: new Wallet(ANVIL_KEY).address,
+      },
+      [CHAIN_NAME_3]: {
+        type: TokenType.synthetic,
+        mailbox: chain3Addresses.mailbox,
+        owner: new Wallet(ANVIL_KEY).address,
+      },
+    };
+
+    writeYamlOrJson(WARP_CONFIG_PATH_MULTICHAIN, multiChainConfig);
+
+    // Deploy the initial 2-chain warp route
+    await hyperlaneWarpDeploy(
+      WARP_CONFIG_PATH_MULTICHAIN,
+      WARP_DEPLOY_MULTICHAIN_ID,
+    );
+  });
+
+  it('should extend a multi-chain warp route (2 chains -> 3 chains) and preserve all existing chains', async () => {
+    // Get the warp core config path for the 2-chain route
+    const WARP_CORE_CONFIG_PATH_2_CHAINS = getCombinedWarpRoutePath('ETH', [
+      CHAIN_NAME_2,
+      CHAIN_NAME_3,
+    ]);
+
+    const warpDeployPath = `${TEMP_PATH}/warp-route-deployment-multichain-extend.yaml`;
+
+    // Verify initial state: 2 chains exist
+    const initialWarpCoreConfig: WarpCoreConfig = readYamlOrJson(
+      WARP_CORE_CONFIG_PATH_2_CHAINS,
+    );
+    expect(initialWarpCoreConfig.tokens).to.have.lengthOf(2);
+    expect(
+      initialWarpCoreConfig.tokens.map((t) => t.chainName).sort(),
+    ).to.deep.equal([CHAIN_NAME_2, CHAIN_NAME_3].sort());
+
+    // Create config for the new chain (chain4)
+    const chain4Config: HypTokenRouterConfig = {
+      decimals: 18,
+      mailbox: chain4Addresses.mailbox,
+      name: 'Ether',
+      owner: new Wallet(ANVIL_KEY).address,
+      symbol: 'ETH',
+      type: TokenType.synthetic,
+    };
+
+    // Extend the 2-chain route to 3 chains
+    await extendWarpConfig({
+      chainToExtend: CHAIN_NAME_4,
+      extendedConfig: chain4Config,
+      warpCorePath: WARP_CORE_CONFIG_PATH_2_CHAINS,
+      warpDeployPath,
+    });
+
+    // Get the new warp core config path for the 3-chain route
+    const WARP_CORE_CONFIG_PATH_3_CHAINS = getCombinedWarpRoutePath('ETH', [
+      CHAIN_NAME_2,
+      CHAIN_NAME_3,
+      CHAIN_NAME_4,
+    ]);
+
+    // Verify the resulting config has all 3 chains
+    const resultWarpCoreConfig: WarpCoreConfig = readYamlOrJson(
+      WARP_CORE_CONFIG_PATH_3_CHAINS,
+    );
+    expect(resultWarpCoreConfig.tokens).to.have.lengthOf(3);
+    expect(
+      resultWarpCoreConfig.tokens.map((t) => t.chainName).sort(),
+    ).to.deep.equal([CHAIN_NAME_2, CHAIN_NAME_3, CHAIN_NAME_4].sort());
+
+    // Get domain IDs for verification
+    const chain2Id = await getDomainId(CHAIN_NAME_2, ANVIL_KEY);
+    const chain3Id = await getDomainId(CHAIN_NAME_3, ANVIL_KEY);
+    const chain4Id = await getDomainId(CHAIN_NAME_4, ANVIL_KEY);
+
+    // Verify chain2 has routers enrolled for chain3 AND chain4
+    const chain2Config = await readWarpConfig(
+      CHAIN_NAME_2,
+      WARP_CORE_CONFIG_PATH_3_CHAINS,
+      warpDeployPath,
+    );
+    const chain2RemoteRouters = Object.keys(
+      chain2Config[CHAIN_NAME_2].remoteRouters!,
+    );
+    expect(chain2RemoteRouters).to.include(
+      chain3Id,
+      'chain2 should have chain3 enrolled',
+    );
+    expect(chain2RemoteRouters).to.include(
+      chain4Id,
+      'chain2 should have chain4 enrolled',
+    );
+
+    // Verify chain3 has routers enrolled for chain2 AND chain4
+    const chain3Config = await readWarpConfig(
+      CHAIN_NAME_3,
+      WARP_CORE_CONFIG_PATH_3_CHAINS,
+      warpDeployPath,
+    );
+    const chain3RemoteRouters = Object.keys(
+      chain3Config[CHAIN_NAME_3].remoteRouters!,
+    );
+    expect(chain3RemoteRouters).to.include(
+      chain2Id,
+      'chain3 should have chain2 enrolled',
+    );
+    expect(chain3RemoteRouters).to.include(
+      chain4Id,
+      'chain3 should have chain4 enrolled',
+    );
+
+    // Verify chain4 has routers enrolled for chain2 AND chain3
+    const chain4ConfigResult = await readWarpConfig(
+      CHAIN_NAME_4,
+      WARP_CORE_CONFIG_PATH_3_CHAINS,
+      warpDeployPath,
+    );
+    const chain4RemoteRouters = Object.keys(
+      chain4ConfigResult[CHAIN_NAME_4].remoteRouters!,
+    );
+    expect(chain4RemoteRouters).to.include(
+      chain2Id,
+      'chain4 should have chain2 enrolled',
+    );
+    expect(chain4RemoteRouters).to.include(
+      chain3Id,
+      'chain4 should have chain3 enrolled',
+    );
+  });
+});

--- a/typescript/cli/src/tests/ethereum/warp/warp-extend-recovery.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-extend-recovery.e2e-test.ts
@@ -67,7 +67,6 @@ describe('hyperlane warp apply recovery extension tests', async function () {
 
     // Initial setup with chain3 using extendWarpConfig
     await extendWarpConfig({
-      chain: CHAIN_NAME_2,
       chainToExtend: CHAIN_NAME_3,
       extendedConfig: {
         decimals: 18,
@@ -117,7 +116,6 @@ describe('hyperlane warp apply recovery extension tests', async function () {
 
     // Re-extend to fix the configuration
     await extendWarpConfig({
-      chain: CHAIN_NAME_2,
       chainToExtend: CHAIN_NAME_3,
       extendedConfig: {
         decimals: 18,
@@ -180,7 +178,6 @@ describe('hyperlane warp apply recovery extension tests', async function () {
 
     // Complete the extension
     await extendWarpConfig({
-      chain: CHAIN_NAME_2,
       chainToExtend: CHAIN_NAME_3,
       extendedConfig: configToExtend,
       warpCorePath: combinedWarpCorePath,
@@ -254,7 +251,6 @@ describe('hyperlane warp apply recovery extension tests', async function () {
 
     // Complete the extension
     await extendWarpConfig({
-      chain: CHAIN_NAME_2,
       chainToExtend: CHAIN_NAME_3,
       extendedConfig: configToExtend,
       warpCorePath: WARP_CORE_CONFIG_PATH_2,
@@ -323,7 +319,6 @@ describe('hyperlane warp apply recovery extension tests', async function () {
 
     // Complete the extension with custom gas value
     await extendWarpConfig({
-      chain: CHAIN_NAME_2,
       chainToExtend: CHAIN_NAME_3,
       extendedConfig: configToExtend,
       warpCorePath: combinedWarpCorePath,


### PR DESCRIPTION
## Summary

Fixes the `extendWarpConfig` test helper to properly support extending multi-chain warp routes.

### Problem

The `extendWarpConfig` helper function assumed the warp route being extended only had a single chain. When extending a multi-chain route (e.g., 2 chains → 3 chains), only one existing chain's config was read, causing other existing chains to be missing from the deploy config.

**Before (bug):**
```
{chain2, chain3} → readWarpConfig(chain2) → {chain2} → add chain4 → {chain2, chain4}
// chain3 is lost!
```

**After (fixed):**
```
{chain2, chain3} → read ALL chains from warpCorePath → {chain2, chain3} → add chain4 → {chain2, chain3, chain4}
```

### Changes

- Updated `extendWarpConfig` to read all chains from `warpCoreConfig.tokens` instead of a single chain
- Deprecated the `chain` parameter (no longer needed since all chains are read from `warpCorePath`)
- Added new E2E test `warp-extend-multichain.e2e-test.ts` that verifies extending a 2-chain route to 3 chains
- Updated all existing callers to remove the deprecated `chain` parameter

### Testing

- ✅ New multi-chain extension test passes
- ✅ Existing `warp-extend-basic` tests pass (5 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Warp route extension now preserves and merges all existing chains/tokens when adding a new chain.

* **Tests**
  * Added an end-to-end test validating multi-chain Warp route extension.
  * Updated existing tests to reflect removal of the explicit source-chain argument and new multi-chain behavior.

* **Chores**
  * Removed the explicit source-chain parameter from the public extension API; extension now discovers and merges chains from core config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->