### PR TITLE
docs: add guidance to avoid force push in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,6 +522,7 @@ Available MCP servers:
 8. **Use `assert()` liberally** - For preconditions, invariants, and unexpected states
 9. **Check error patterns first** - Review existing error handling before adding new try/catch
 10. **Question fallbacks** - Undefined values often signal bugs; don't mask with defaults
+11. **Never force push** - Don't use `git push --force`; use `git pull --rebase` to sync with remote and preserve git history
 
 ## Verify Before Acting
 


### PR DESCRIPTION
## Summary
- Added tip #11 to CLAUDE.md: avoid `git push --force`, use `git pull --rebase` instead to preserve remote git history