### PR TITLE
refactor: artifact type utilities

### DIFF
--- a/typescript/provider-sdk/src/artifact.ts
+++ b/typescript/provider-sdk/src/artifact.ts
@@ -163,11 +163,15 @@ export type RawArtifact<C, D> = {
  * Helper type to transform nested objects containing Artifacts.
  * Handles objects where all properties are Artifacts (required or optional).
  */
-type NestedOnChain<T> = T extends { [L: string]: Artifact<infer CC, infer DD> }
-  ? { [L in keyof T]: ArtifactOnChain<CC, DD> }
-  : T extends { [L: string]: Artifact<infer CC, infer DD> | undefined }
-    ? { [L in keyof T]: ArtifactOnChain<CC, DD> | undefined }
-    : T;
+type NestedOnChain<T> = T extends { [L: string]: any }
+  ? {
+      [L in keyof T]: T[L] extends Artifact<infer CC, infer DD>
+        ? ArtifactOnChain<CC, DD>
+        : T[L] extends Artifact<infer CC, infer DD> | undefined
+          ? ArtifactOnChain<CC, DD> | undefined
+          : T[L];
+    }
+  : T;
 
 /**
  * Utility type to convert a config type to its on-chain representation.

--- a/typescript/provider-sdk/src/artifact.types.test.ts
+++ b/typescript/provider-sdk/src/artifact.types.test.ts
@@ -176,7 +176,7 @@ export type _Test7 = AssertTrue<
 >;
 
 // ============================================================================
-// Mixed nested object (limitation - not transformed)
+// Mixed nested object (artifact properties transformed recursively)
 // ============================================================================
 
 interface MixedNestedConfig {
@@ -189,16 +189,71 @@ interface MixedNestedConfig {
 
 type MixedNestedResult = ConfigOnChain<MixedNestedConfig>;
 
-// Expected: the mixed object is NOT transformed (falls through to C[K])
+// Expected: the mixed object IS transformed recursively
 type ExpectedMixedNested = {
   mixed: {
-    art: Artifact<TestConfig, TestDeployed>;
+    art: ArtifactOnChain<TestConfig, TestDeployed>;
     bar: string;
   };
   name: string;
 };
 
 export type _Test8 = AssertTrue<Equals<MixedNestedResult, ExpectedMixedNested>>;
+
+// ============================================================================
+// Optional mixed nested object
+// ============================================================================
+
+interface OptionalMixedNestedConfig {
+  mixed?: {
+    art: Artifact<TestConfig, TestDeployed>;
+    bar: string;
+  };
+  name: string;
+}
+
+type OptionalMixedNestedResult = ConfigOnChain<OptionalMixedNestedConfig>;
+
+// Expected: the optional mixed object IS transformed recursively
+type ExpectedOptionalMixedNested = {
+  mixed?: {
+    art: ArtifactOnChain<TestConfig, TestDeployed>;
+    bar: string;
+  };
+  name: string;
+};
+
+export type _Test9 = AssertTrue<
+  Equals<OptionalMixedNestedResult, ExpectedOptionalMixedNested>
+>;
+
+// ============================================================================
+// Mixed nested object with optional Artifact property inside
+// ============================================================================
+
+interface MixedNestedOptionalArtifactConfig {
+  mixed: {
+    art?: Artifact<TestConfig, TestDeployed>;
+    bar: string;
+  };
+  name: string;
+}
+
+type MixedNestedOptionalArtifactResult =
+  ConfigOnChain<MixedNestedOptionalArtifactConfig>;
+
+// Expected: the optional Artifact inside the nested object is transformed
+type ExpectedMixedNestedOptionalArtifact = {
+  mixed: {
+    art?: ArtifactOnChain<TestConfig, TestDeployed>;
+    bar: string;
+  };
+  name: string;
+};
+
+export type _Test10 = AssertTrue<
+  Equals<MixedNestedOptionalArtifactResult, ExpectedMixedNestedOptionalArtifact>
+>;
 
 // ============================================================================
 // Primitives unchanged
@@ -222,7 +277,7 @@ type ExpectedPrimitives = {
   optional?: number;
 };
 
-export type _Test9 = AssertTrue<Equals<PrimitivesResult, ExpectedPrimitives>>;
+export type _Test11 = AssertTrue<Equals<PrimitivesResult, ExpectedPrimitives>>;
 
 // ============================================================================
 // Test that required Artifact does NOT become optional
@@ -240,6 +295,6 @@ type _CorrectRequired = {
 };
 
 // This should now pass with the fixed implementation
-export type _Test10 = AssertTrue<
+export type _Test12 = AssertTrue<
   Equals<_StrictRequiredResult, _CorrectRequired>
 >;


### PR DESCRIPTION
### Description

Test the type utilities for `Artifact<>` transforms. Support optional properties but not arrays of optional artifacts (seems unnecessary).