### PR TITLE
fix(rebalancer-sim): Cleanup simulation engine issues from PR review

### DIFF
--- a/typescript/rebalancer-sim/src/RebalancerSimulationHarness.ts
+++ b/typescript/rebalancer-sim/src/RebalancerSimulationHarness.ts
@@ -1,5 +1,3 @@
-import { ethers } from 'ethers';
-
 import { rootLogger } from '@hyperlane-xyz/utils';
 
 import { deployMultiDomainSimulation } from './SimulationDeployment.js';
@@ -172,11 +170,6 @@ export class RebalancerSimulationHarness {
     }
 
     const results: SimulationResult[] = [];
-    const provider = new ethers.providers.JsonRpcProvider(this.config.anvilRpc);
-    // Set fast polling interval for tx.wait() - ethers defaults to 4000ms
-    provider.pollingInterval = 100;
-    // Disable automatic polling to reduce RPC contention
-    provider.polling = false;
 
     for (const rebalancer of rebalancers) {
       // Recreate engine with fresh provider to avoid cached RPC state

--- a/typescript/rebalancer-sim/src/types.ts
+++ b/typescript/rebalancer-sim/src/types.ts
@@ -37,8 +37,6 @@ export interface BridgeRouteConfig {
   failureRate: number;
   /** Jitter in milliseconds (± variance) */
   deliveryJitter: number;
-  /** Optional native fee for bridge */
-  nativeFee?: bigint;
   /** Optional token fee as basis points (e.g., 10 = 0.1%) */
   tokenFeeBps?: number;
 }
@@ -462,7 +460,7 @@ export interface ScenarioFile {
   /** Ordered list of transfer events */
   transfers: SerializedTransferEvent[];
 
-  /** Default initial collateral balance per chain in wei (as string for JSON) */
+  /** Default initial collateral balance in wei, applied to all chains (as string for JSON) */
   defaultInitialCollateral: string;
 
   /** Default timing configuration */

--- a/typescript/rebalancer-sim/test/utils/simulation-helpers.ts
+++ b/typescript/rebalancer-sim/test/utils/simulation-helpers.ts
@@ -18,6 +18,7 @@ import {
   loadScenarioFile,
 } from '../../src/index.js';
 import type {
+  ChainStrategyConfig,
   IRebalancerRunner,
   ScenarioFile,
   SimulationResult,
@@ -147,11 +148,17 @@ export async function runScenarioWithRebalancers(
           );
         }
       }
+      // Cleanup provider after applying imbalance
+      provider.removeAllListeners();
+      provider.polling = false;
     }
 
-    const strategyConfig = {
+    const strategyConfig: {
+      type: 'weighted' | 'minAmount';
+      chains: Record<string, ChainStrategyConfig>;
+    } = {
       type: file.defaultStrategyConfig.type,
-      chains: {} as Record<string, any>,
+      chains: {},
     };
     for (const [chainName, chainConfig] of Object.entries(
       file.defaultStrategyConfig.chains,


### PR DESCRIPTION
## Summary
- Remove unused provider in `RebalancerSimulationHarness.compareRebalancers()`
- Fix `buildWarpConfig()` return type from `any` to `WarpCoreConfig`
- Remove unused `_deliveryDelay` parameters from internal methods
- Fix error handling: use `unknown` type with proper narrowing
- Remove unused `nativeFee` field from `BridgeRouteConfig`
- Fix misleading comment for `defaultInitialCollateral`
- Add provider cleanup after imbalance loop in test helpers
- Replace `Record<string, any>` with `ChainStrategyConfig` in test helpers

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Tests pass (`pnpm test`)
- [x] Lint passes on src

🤖 Generated with [Claude Code](https://claude.ai/code)