### PR TITLE
refactor(rebalancer-sim): Use testcontainers for anvil setup

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2115,6 +2115,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.5.3
+      testcontainers:
+        specifier: 'catalog:'
+        version: 11.7.0
       tsx:
         specifier: 'catalog:'
         version: 4.19.1
@@ -15998,6 +16001,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}

--- a/typescript/rebalancer-sim/package.json
+++ b/typescript/rebalancer-sim/package.json
@@ -42,6 +42,7 @@
     "eslint": "catalog:",
     "mocha": "catalog:",
     "prettier": "catalog:",
+    "testcontainers": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:"
   },

--- a/typescript/rebalancer-sim/test/utils/anvil.ts
+++ b/typescript/rebalancer-sim/test/utils/anvil.ts
@@ -1,112 +1,54 @@
-import { ChildProcess, spawn } from 'child_process';
-import { ethers } from 'ethers';
+import {
+  GenericContainer,
+  Wait,
+  type StartedTestContainer,
+} from 'testcontainers';
+
+import { retryAsync } from '@hyperlane-xyz/utils';
+
+const DEFAULT_ANVIL_PORT = 8545;
+const DEFAULT_CHAIN_ID = 31337;
 
 /**
- * Check if Anvil is available in PATH
+ * Start an Anvil container using testcontainers.
+ * Uses the same pattern as CLI e2e tests for consistency.
  */
-export async function isAnvilAvailable(): Promise<boolean> {
-  return new Promise((resolve) => {
-    const check = spawn('which', ['anvil']);
-    check.on('close', (code) => resolve(code === 0));
-    check.on('error', () => resolve(false));
-  });
-}
-
-/**
- * Check if a port is already in use (e.g., Anvil already running)
- */
-export async function isPortInUse(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const provider = new ethers.providers.JsonRpcProvider(
-      `http://localhost:${port}`,
-    );
-    provider
-      .getBlockNumber()
-      .then(() => resolve(true))
-      .catch(() => resolve(false));
-  });
-}
-
-/**
- * Start Anvil process and wait for it to be ready
- */
-export async function startAnvil(port: number): Promise<ChildProcess> {
-  // Check if Anvil is already running on this port
-  if (await isPortInUse(port)) {
-    throw new Error(
-      `Port ${port} already in use. Kill existing Anvil or use different port.`,
-    );
-  }
-
-  return new Promise((resolve, reject) => {
-    const anvil = spawn('anvil', ['--port', port.toString()], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-
-    let started = false;
-    const timeout = setTimeout(() => {
-      if (!started) {
-        anvil.kill();
-        reject(new Error('Anvil startup timeout'));
-      }
-    }, 10000);
-
-    anvil.stdout?.on('data', (data: Buffer) => {
-      const output = data.toString();
-      if (output.includes('Listening on')) {
-        started = true;
-        clearTimeout(timeout);
-        setTimeout(() => resolve(anvil), 500);
-      }
-    });
-
-    anvil.stderr?.on('data', (data: Buffer) => {
-      console.error('Anvil stderr:', data.toString());
-    });
-
-    anvil.on('error', (err) => {
-      clearTimeout(timeout);
-      reject(err);
-    });
-
-    anvil.on('exit', (code) => {
-      if (!started) {
-        clearTimeout(timeout);
-        reject(new Error(`Anvil exited with code ${code}`));
-      }
-    });
-  });
-}
-
-/**
- * Stop an anvil process and wait for cleanup
- */
-export async function stopAnvil(process: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!process || process.killed) {
-      resolve();
-      return;
-    }
-
-    process.on('exit', () => {
-      resolve();
-    });
-
-    process.kill('SIGTERM');
-
-    // Force kill after timeout
-    setTimeout(() => {
-      if (!process.killed) {
-        process.kill('SIGKILL');
-      }
-      resolve();
-    }, 2000);
-  });
+export async function startAnvilContainer(
+  port: number = DEFAULT_ANVIL_PORT,
+  chainId: number = DEFAULT_CHAIN_ID,
+): Promise<StartedTestContainer> {
+  return retryAsync(
+    () =>
+      new GenericContainer('ghcr.io/foundry-rs/foundry:latest')
+        .withEntrypoint([
+          'anvil',
+          '--host',
+          '0.0.0.0',
+          '-p',
+          port.toString(),
+          '--chain-id',
+          chainId.toString(),
+        ])
+        .withExposedPorts({
+          container: port,
+          host: port,
+        })
+        .withWaitStrategy(Wait.forLogMessage(/Listening on/))
+        .start(),
+    3, // maxRetries
+    5000, // baseRetryMs
+  );
 }
 
 /**
  * Setup function for Mocha tests that require Anvil.
- * Starts a fresh Anvil for EACH TEST to ensure complete isolation.
+ * Starts a fresh Anvil container for EACH TEST to ensure complete isolation.
+ *
+ * Uses testcontainers for:
+ * - No local anvil installation required
+ * - Automatic container cleanup (even on crashes)
+ * - Retry logic for CI reliability
+ * - Consistent behavior across local/CI environments
  *
  * Usage:
  * ```typescript
@@ -114,62 +56,40 @@ export async function stopAnvil(process: ChildProcess): Promise<void> {
  *   const anvil = setupAnvilTestSuite(this, 8545);
  *
  *   it('test case', async () => {
- *     const rpc = anvil.rpc; // http://localhost:8545
+ *     const rpc = anvil.rpc; // http://127.0.0.1:8545
  *   });
  * });
  * ```
  */
 export function setupAnvilTestSuite(
   suite: Mocha.Suite,
-  port: number,
-): { rpc: string; process: ChildProcess | null } {
-  const state: { rpc: string; process: ChildProcess | null } = {
-    rpc: `http://localhost:${port}`,
-    process: null,
+  port: number = DEFAULT_ANVIL_PORT,
+  chainId: number = DEFAULT_CHAIN_ID,
+): { rpc: string } {
+  const state: { rpc: string; container: StartedTestContainer | null } = {
+    rpc: `http://127.0.0.1:${port}`,
+    container: null,
   };
 
   suite.timeout(180000); // 3 minutes per test
 
-  // Check anvil availability once at suite start
-  suite.beforeAll(async function () {
-    const available = await isAnvilAvailable();
-    if (!available) {
-      console.log('Anvil not found in PATH. Skipping tests.');
-      console.log(
-        'Install with: curl -L https://foundry.paradigm.xyz | bash && foundryup',
-      );
-      this.skip();
-      return;
-    }
-  });
-
-  // Start fresh anvil before EACH test
+  // Start fresh anvil container before EACH test
   suite.beforeEach(async function () {
-    // Kill any existing anvil on this port
-    if (state.process) {
-      await stopAnvil(state.process);
-      state.process = null;
+    // Stop any existing container
+    if (state.container) {
+      await state.container.stop();
+      state.container = null;
     }
 
-    // Wait for port to be free
-    await new Promise((resolve) => setTimeout(resolve, 500));
-
-    try {
-      state.process = await startAnvil(port);
-    } catch (err) {
-      console.log(`Failed to start Anvil: ${err}`);
-      this.skip();
-    }
+    state.container = await startAnvilContainer(port, chainId);
   });
 
-  // Stop anvil after EACH test for clean slate
+  // Stop container after EACH test for clean slate
   suite.afterEach(async function () {
-    if (state.process) {
-      await stopAnvil(state.process);
-      state.process = null;
+    if (state.container) {
+      await state.container.stop();
+      state.container = null;
     }
-    // Wait for cleanup
-    await new Promise((resolve) => setTimeout(resolve, 300));
   });
 
   return state;


### PR DESCRIPTION
## Summary

Replaced spawn-based anvil process management with testcontainers, consistent with CLI e2e tests pattern.

- No local anvil installation required (uses Docker image)
- Automatic container cleanup even on test crashes  
- Retry logic for CI reliability
- Consistent with how CLI e2e tests handle anvil

Addresses [PR #7903 review comment](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/7903#discussion_r2754749898) from @xeno097.

Relates to [ENG-3234](https://linear.app/hyperlane-xyz/issue/ENG-3234/consider-using-testcontainers-for-rebalancer-simulation-setup).

## Design Decision: Single Container

The rebalancer-sim intentionally uses a **single anvil container with multiple virtual domains** (domain IDs 1000, 2000, 3000) rather than multiple separate containers like CLI e2e tests. This is to:

1. **Keep provider/signer coordination simple** - All domains share one RPC endpoint, avoiding multi-provider orchestration complexity
2. **Faster test execution** - No multi-container startup/coordination overhead
3. **Simpler state management** - Single blockchain state to reason about
4. **Sufficient for rebalancer testing** - Tests verify rebalancer logic, not actual cross-chain message passing

The CLI e2e tests need multiple containers because they test real cross-chain scenarios. The rebalancer simulation tests the rebalancer's decision-making against synthetic scenarios on a shared state.

## Changes

- `typescript/rebalancer-sim/package.json` - Added `testcontainers` dependency
- `typescript/rebalancer-sim/test/utils/anvil.ts` - Rewrote to use testcontainers (177 → 85 lines)

## CI Workflow Note

The CI workflow change (`.github/workflows/rebalancer-sim-test.yml`) to remove the Foundry setup step couldn't be pushed due to token scope limitations. The change is:

```diff
-      - name: Setup Foundry
-        uses: ./.github/actions/setup-foundry
+      # Note: Foundry/anvil not needed - tests use testcontainers (Docker image)
```

This can be added manually or the tests will still work (Foundry setup is just unnecessary overhead now).

## Testing

All tests pass locally:
- `harness-setup` ✅
- `inflight-guard` ✅  
- `full-simulation (extreme-drain)` ✅