### PR TITLE
fix(ci): skip gitleaks for external PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,7 +187,8 @@ jobs:
 
       - name: Install gitleaks
         id: gitleaks-install
-        if: github.event_name != 'merge_group'
+        # Skip for merge_group and external PRs (forks don't have access to GITLEAKS_LICENSE secret)
+        if: github.event_name != 'merge_group' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Skip gitleaks step for external PRs (forks) since they don't have access to `GITLEAKS_LICENSE` secret
- Gitleaks still runs for internal PRs and push events

## Test plan
- [ ] Verify CI passes on this PR
- [ ] External PRs should no longer fail on gitleaks step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions test workflow security by refining conditions for gitleaks installation to prevent secrets exposure in pull requests from external forks, while maintaining existing behavior for internal pull requests and other event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->