### PR TITLE
feat(cli): consolidate warpRouteId aliases

### DIFF
--- a/.github/prompts/code-review.md
+++ b/.github/prompts/code-review.md
@@ -60,13 +60,6 @@ Review this pull request. Focus on:
 - **Unused imports** - Remove imports that aren't used
 - **`||` for defaults** - `value || fallback` treats `0`/`''` as falsy; use `??` instead
 
-## Common TypeScript Anti-Patterns
-
-- **`forEach` with assignment** - `arr.forEach(x => (obj[x] = val))` returns value; use `for-of` with block body
-- **`array.sort()` mutates** - Use `[...array].sort()` to avoid mutating input
-- **Double-cast `as unknown as X`** - Hides type mismatches; use single cast or fix types
-- **Stale test `describe()` strings** - Keep in sync with actual CLI flags/behavior
-
 ## Solidity Patterns
 
 - **Events for state changes** - All storage mutations should emit events


### PR DESCRIPTION
## Summary

Consolidates and streamlines CLI warp route reference methods with improved aliases and smart resolution.

Accompanying docs PR: https://github.com/hyperlane-xyz/v4-docs/pull/63

## Changes

### New Aliases
- `--id` added as alias for `--warp-route-id` (alongside existing `-w`)
- Usage: `-w`, `--id`, or `--warp-route-id` all work interchangeably

### Symbol-Only Resolution
Symbol-only input (e.g., `-w ETH`) now intelligently resolves:
- **Single match**: Auto-selects the route
- **Multiple matches (interactive)**: Prompts user to select from list
- **Multiple matches (CI/--yes)**: Errors with list of matching routes

```bash
# These are equivalent when USDC has only one route
hyperlane warp check -w USDC
hyperlane warp check -w USDC/arbitrum-ethereum

# Symbol with multiple routes - prompts for selection
hyperlane warp check -w ETH
# > Multiple routes found for "ETH". Select one:
# > ETH/ethereum-arbitrum
# > ETH/ethereum-optimism
```

### Origin/Destination Chain Filtering
When `--origin` and/or `--destination` are specified with a symbol-only warp route ID, the CLI filters routes to those spanning the specified chains:

```bash
# Auto-resolves to ETH/ethereum-arbitrum (only route with both chains)
hyperlane warp send -w ETH --origin ethereum --destination arbitrum

# Auto-resolves to ETH/ethereum-optimism
hyperlane warp send -w ETH --origin ethereum --destination optimism
```

This enables automatic route selection without requiring the full route ID when origin/destination uniquely identify the route.

### Resolved ID Preservation (Bug Fix)
Fixed a bug where the resolved warp route ID was dropped during deploy/apply:
- `getWarpRouteDeployConfig` now returns `{ config, resolvedWarpRouteId }`
- Resolved ID is stored in context (`WarpDeployCommandContext.resolvedWarpRouteId`)
- Deploy and apply commands use the resolved ID for registry writes

This ensures that symbol-only input (`-w ETH`) correctly writes to the resolved route ID (`ETH/ethereum-arbitrum`) in the registry.

### Explicit Chain Filter Errors
When `--chains` filtering yields no matches, now throws an explicit error:
```
No warp route found for symbol "ETH" spanning chains: polygon.
Try without --chains to see all available routes for this symbol.
```

### SDK Utilities
New SDK utilities for filtering warp routes by chains:
- `getChainsFromWarpCoreConfig(config)` - Extract chain names from config
- `warpCoreConfigMatchesChains(config, chains)` - Check if config spans all chains
- `filterWarpCoreConfigMapByChains(configMap, chains)` - Filter routes by chains

### Breaking Changes (from earlier commits)
- Removed `--config` / `-wd` (warp deploy config path)
- Removed `--warp` / `-wc` (warp core config path)
- All warp commands now use registry-based IDs

## Testing

- ✅ CLI unit tests: 52 passing (includes symbol resolution, chain filtering, and getWarpCoreConfigOrExit tests)
- ✅ SDK tests: 416 passing
- ✅ Build, lint, prettier all pass

## Related

- Design Doc: https://www.notion.so/hyperlanexyz/2fc6d35200d68118b569c48c63d36b71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consolidated warp route referencing through unified `--warp-route-id` flag (aliases: `-w`, `--id`) replacing multiple file path options.
  * Added support for symbol-only warp route references (e.g., `-w ETH`) with automatic resolution via chains.
  * New SDK utilities for filtering warp routes by chains: `getChainsFromWarpCoreConfig`, `warpCoreConfigMatchesChains`, and `filterWarpCoreConfigMapByChains`.

* **Bug Fixes**
  * Simplified warp command options, removing redundant configuration parameters for cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking CLI flag removals and new warp-route resolution logic affect many commands; mistakes could cause selecting the wrong route or failing non-interactive workflows, though changes are largely input/selection plumbing with added tests.
> 
> **Overview**
> **CLI warp route selection is now standardized on a single registry-based flag.** All warp-related commands (and `relayer`) drop file-path/symbol selection (`--config/-wd`, `--warp/-wc`, `--symbol`) in favor of `--warp-route-id` with aliases `-w` and `--id`, and `warp read` now writes via `--out`.
> 
> **Symbol-only IDs are supported and smarter.** Passing `-w ETH` resolves to a unique route when possible, otherwise prompts interactively or errors in `--yes`/CI; `warp send` additionally passes `--origin/--destination/--chains` into resolution to auto-pick a route that spans those chains.
> 
> **Deploy/apply preserve the resolved route ID.** Chain resolution stores `resolvedWarpRouteId` in context and uses it for subsequent deploy/apply operations so registry reads/writes target the selected route consistently.
> 
> **SDK adds chain-filtering helpers.** Introduces and exports `getChainsFromWarpCoreConfig`, `warpCoreConfigMatchesChains`, and `filterWarpCoreConfigMapByChains`, with tests, to support CLI chain-based route disambiguation.
> 
> E2E/unit tests were updated broadly to use the new flag/aliases and registry-based deploy config expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38c73af4f29a41c4e12d98ed54f97b3fe88fbcad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->