### PR TITLE
chore: re-enroll ALEO/aleo Solana leg

### DIFF
--- a/rust/sealevel/environments/mainnet3/warp-routes/ALEO-aleo/token-config.json
+++ b/rust/sealevel/environments/mainnet3/warp-routes/ALEO-aleo/token-config.json
@@ -31,7 +31,7 @@
     "type": "synthetic",
     "decimals": 6,
     "name": "Aleo",
-    "owner": "FUEyWicwhuRwAn5thRj6XrVwogWUeoCUX38iV2xW61Za",
+    "owner": "ABJnd4eWexNte9GYy21ud5hvSwFKWedveP6GCFxXKkCw",
     "symbol": "ALEO",
     "uri": "https://raw.githubusercontent.com/hyperlane-xyz/hyperlane-registry/ea47535339bc8d1ebc4435aa7ee66ea53ba2f669/deployments/warp_routes/ALEO/metadata.json",
     "interchainGasPaymaster": "AkeHBbE5JkwVppujCQQ6WuxsVsJtruBAjUo6fDCFp6fF",


### PR DESCRIPTION
### Description
Due to an issue during the initial deployment, the Solana leg of the Aleo synthetic route was not deployed correctly. This is now fixed by re-enrolling a newly created Solana leg. 
