### PR TITLE
feat(rebalancer-sim): add blocked-user-transfer test scenario

### DIFF
--- a/.github/workflows/rebalancer-sim-test.yml
+++ b/.github/workflows/rebalancer-sim-test.yml
@@ -35,6 +35,7 @@ jobs:
           - full-simulation_whale-transfers
           - full-simulation_balanced-bidirectional
           - full-simulation_random-with-headroom
+          - full-simulation_blocked-user-transfer
           # Other test files
           - inflight-guard
           - harness-setup

--- a/typescript/rebalancer-sim/scenarios/blocked-user-transfer.json
+++ b/typescript/rebalancer-sim/scenarios/blocked-user-transfer.json
@@ -1,0 +1,62 @@
+{
+  "name": "blocked-user-transfer",
+  "description": "Tests scenario where user transfer is BLOCKED at destination due to insufficient collateral, and rebalancer doesn't act because weights appear within tolerance.",
+  "expectedBehavior": "With 50/50 weights and 50% tolerance, initial state is balanced (40/40). User transfer of 50 tokens to chain2 exceeds chain2 collateral (50 > 40), blocking delivery. After user locks tokens on chain1, state is 90/40 (69%/31%) which is within tolerance (25-75%). Rebalancer sees no need to act. Transfer stays stuck.",
+  "duration": 15000,
+  "chains": ["chain1", "chain2"],
+  "initialImbalance": {},
+  "transfers": [
+    {
+      "id": "blocked-transfer-1",
+      "timestamp": 500,
+      "origin": "chain1",
+      "destination": "chain2",
+      "amount": "50000000000000000000",
+      "user": "0x1111111111111111111111111111111111111111"
+    }
+  ],
+  "defaultInitialCollateral": "40000000000000000000",
+  "defaultTiming": {
+    "userTransferDeliveryDelay": 0,
+    "rebalancerPollingFrequency": 1000,
+    "userTransferInterval": 100
+  },
+  "defaultBridgeConfig": {
+    "chain1": {
+      "chain2": {
+        "deliveryDelay": 3000,
+        "failureRate": 0,
+        "deliveryJitter": 0
+      }
+    },
+    "chain2": {
+      "chain1": {
+        "deliveryDelay": 3000,
+        "failureRate": 0,
+        "deliveryJitter": 0
+      }
+    }
+  },
+  "defaultStrategyConfig": {
+    "type": "weighted",
+    "chains": {
+      "chain1": {
+        "weighted": {
+          "weight": "0.5",
+          "tolerance": "0.5"
+        },
+        "bridgeLockTime": 500
+      },
+      "chain2": {
+        "weighted": {
+          "weight": "0.5",
+          "tolerance": "0.5"
+        },
+        "bridgeLockTime": 500
+      }
+    }
+  },
+  "expectations": {
+    "_note": "Both rebalancers show 0% completion. Weights within tolerance (25-75%), so no rebalancing triggered. With mock Explorer: rebalancer should see blocked transfer and proactively add collateral to chain2."
+  }
+}

--- a/typescript/rebalancer-sim/test/integration/full-simulation.test.ts
+++ b/typescript/rebalancer-sim/test/integration/full-simulation.test.ts
@@ -213,6 +213,50 @@ describe('Rebalancer Simulation', function () {
   });
 
   // ============================================================================
+  // BLOCKED USER TRANSFER
+  // ============================================================================
+
+  /**
+   * Blocked User Transfer Test
+   *
+   * Tests the gap when user transfers are BLOCKED at destination due to
+   * insufficient collateral. With 50/50 weights and 50% tolerance, state
+   * appears within tolerance after user initiates transfer (69%/31% is
+   * within 25-75% range). But destination chain2 can't pay out (40 tokens
+   * < 50 needed), so transfer stays stuck.
+   *
+   * Neither rebalancer acts because weights are within tolerance.
+   * With future mock Explorer, rebalancer should see blocked transfer
+   * and proactively add collateral to chain2.
+   */
+  it('blocked-user-transfer: demonstrates blocked transfer without Explorer (report only)', async function () {
+    this.timeout(120000);
+
+    const { results } = await runScenarioWithRebalancers(
+      'blocked-user-transfer',
+      {
+        anvilRpc: anvil.rpc,
+      },
+    );
+
+    console.log('\n  BLOCKED USER TRANSFER REPORT:');
+    for (const result of results) {
+      console.log(
+        `    ${result.rebalancerName}: completion=${(result.kpis.completionRate * 100).toFixed(0)}%, rebalances=${result.kpis.totalRebalances}`,
+      );
+    }
+    console.log(
+      '    (Expected: 0% completion for both - weights within tolerance, no rebalancing)',
+    );
+    console.log(
+      '    (Transfer blocked: chain2 has 40 tokens but needs 50 to pay out)',
+    );
+    console.log(
+      '    (With Explorer mock: rebalancer should see blocked transfer and act)',
+    );
+  });
+
+  // ============================================================================
   // BASELINE (NO REBALANCER)
   // ============================================================================
 


### PR DESCRIPTION
## Summary
- Adds `blocked-user-transfer` scenario to rebalancer-sim that demonstrates a gap in rebalancer awareness
- User transfer is blocked at destination due to insufficient collateral (50 tokens needed, only 40 available)
- With 50/50 weights and 50% tolerance, state appears "within tolerance" so rebalancer doesn't act
- Transfer stays stuck with 0% completion rate

## Scenario Details
- **Initial state**: chain1=40, chain2=40 (balanced 50/50)
- **User transfer**: 50 tokens from chain1→chain2 at t=500ms
- **After lock**: chain1=90, chain2=40 (69%/31% - within 25-75% tolerance range)
- **Result**: Transfer blocked with "ERC20: transfer amount exceeds balance"

## Purpose
Establishes baseline for future Explorer mock that will enable rebalancer to detect and proactively unblock stuck transfers. With Explorer awareness, rebalancer should see the blocked transfer and move collateral to chain2.

## Test plan
- [x] `pnpm -C typescript/rebalancer-sim test --grep "blocked-user-transfer"` passes
- [x] Both rebalancers show 0% completion, 0 rebalances
- [x] CI matrix entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)