### PR TITLE
feat(relayer): add gas payment enforcement to TypeScript relayer

### DIFF
--- a/typescript/relayer/src/core/HyperlaneRelayer.test.ts
+++ b/typescript/relayer/src/core/HyperlaneRelayer.test.ts
@@ -1,0 +1,571 @@
+import { expect } from 'chai';
+import { BigNumber, ethers, providers } from 'ethers';
+
+import { InterchainGasPaymaster__factory } from '@hyperlane-xyz/core';
+import {
+  DispatchedMessage,
+  GasPaymentEnforcementPolicyType,
+  GasPolicyStatus,
+  HookType,
+  HyperlaneCore,
+} from '@hyperlane-xyz/sdk';
+import { Address, WithAddress } from '@hyperlane-xyz/utils';
+
+import { HyperlaneRelayer } from './HyperlaneRelayer.js';
+
+// Mock HyperlaneCore with minimal implementation
+function createMockCore(): HyperlaneCore {
+  return {
+    multiProvider: {
+      getChainName: () => 'test',
+    },
+    logger: {
+      child: () => ({
+        info: () => {},
+        debug: () => {},
+        warn: () => {},
+        error: () => {},
+        trace: () => {},
+      }),
+    },
+  } as unknown as HyperlaneCore;
+}
+
+// Create a mock message
+function createMockMessage(
+  overrides: Partial<DispatchedMessage> = {},
+): DispatchedMessage {
+  return {
+    id: '0x1111111111111111111111111111111111111111111111111111111111111111',
+    parsed: {
+      version: 0,
+      nonce: 0,
+      origin: 1,
+      sender:
+        '0x0000000000000000000000001234567890123456789012345678901234567890',
+      destination: 2,
+      recipient:
+        '0x0000000000000000000000000987654321098765432109876543210987654321',
+      body: '0x',
+      ...overrides.parsed,
+    },
+    message: '0x',
+    ...overrides,
+  } as DispatchedMessage;
+}
+
+// Create mock hook config with IGP
+function createMockHookWithIgp(
+  igpAddress: Address,
+): WithAddress<{ type: HookType }> {
+  return {
+    type: HookType.INTERCHAIN_GAS_PAYMASTER,
+    address: igpAddress,
+  } as WithAddress<{ type: HookType }>;
+}
+
+// Create a properly encoded GasPayment event log
+function createGasPaymentLog(
+  igpAddress: Address,
+  messageId: string,
+  destinationDomain: number,
+  gasAmount: bigint,
+  payment: bigint,
+): providers.Log {
+  const iface = InterchainGasPaymaster__factory.createInterface();
+
+  // Encode the event
+  const eventFragment = iface.getEvent('GasPayment');
+  const topics = iface.encodeFilterTopics(eventFragment, [
+    messageId,
+    destinationDomain,
+  ]);
+
+  // Encode non-indexed parameters (gasAmount, payment)
+  const data = ethers.utils.defaultAbiCoder.encode(
+    ['uint256', 'uint256'],
+    [BigNumber.from(gasAmount.toString()), BigNumber.from(payment.toString())],
+  );
+
+  return {
+    address: igpAddress,
+    topics: topics as string[],
+    data,
+    blockNumber: 1,
+    blockHash: '0x',
+    transactionHash: '0x',
+    transactionIndex: 0,
+    logIndex: 0,
+    removed: false,
+  };
+}
+
+// Create mock dispatch tx with gas payment logs
+function createMockDispatchTx(
+  logs: providers.Log[],
+): providers.TransactionReceipt {
+  return {
+    logs,
+    to: '0x',
+    from: '0x',
+    contractAddress: '0x',
+    transactionIndex: 0,
+    gasUsed: BigNumber.from(0),
+    logsBloom: '0x',
+    blockHash: '0x',
+    transactionHash: '0x',
+    blockNumber: 1,
+    confirmations: 1,
+    cumulativeGasUsed: BigNumber.from(0),
+    effectiveGasPrice: BigNumber.from(0),
+    byzantium: true,
+    type: 0,
+    status: 1,
+  };
+}
+
+describe('HyperlaneRelayer', () => {
+  describe('checkGasPayment with OnChainFeeQuoting', () => {
+    const igpAddress = '0x1234567890123456789012345678901234567890';
+    const messageId =
+      '0x1111111111111111111111111111111111111111111111111111111111111111';
+    const destination = 2;
+
+    function createRelayer(gasPaymentEnforcement: any[]): HyperlaneRelayer {
+      return new HyperlaneRelayer({
+        core: createMockCore(),
+        gasPaymentEnforcement,
+      });
+    }
+
+    describe('when gas estimate is available', () => {
+      it('should return PolicyMet when gasAmount meets required fraction (1/2)', async () => {
+        const gasEstimate = '100000';
+        const gasAmount = BigInt(50000); // exactly 50%
+        const payment = BigInt(1000000000000000);
+
+        const relayer = createRelayer([
+          {
+            type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+            gasFraction: { numerator: 1, denominator: 2 },
+          },
+        ]);
+
+        const message = createMockMessage({ id: messageId });
+        const hook = createMockHookWithIgp(igpAddress);
+        const log = createGasPaymentLog(
+          igpAddress,
+          messageId,
+          destination,
+          gasAmount,
+          payment,
+        );
+        const dispatchTx = createMockDispatchTx([log]);
+
+        const result = await relayer.checkGasPayment(
+          message,
+          dispatchTx,
+          hook,
+          gasEstimate,
+        );
+
+        expect(result).to.equal(GasPolicyStatus.PolicyMet);
+      });
+
+      it('should return PolicyMet when gasAmount exceeds required fraction', async () => {
+        const gasEstimate = '100000';
+        const gasAmount = BigInt(75000); // 75% > 50%
+        const payment = BigInt(1000000000000000);
+
+        const relayer = createRelayer([
+          {
+            type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+            gasFraction: { numerator: 1, denominator: 2 },
+          },
+        ]);
+
+        const message = createMockMessage({ id: messageId });
+        const hook = createMockHookWithIgp(igpAddress);
+        const log = createGasPaymentLog(
+          igpAddress,
+          messageId,
+          destination,
+          gasAmount,
+          payment,
+        );
+        const dispatchTx = createMockDispatchTx([log]);
+
+        const result = await relayer.checkGasPayment(
+          message,
+          dispatchTx,
+          hook,
+          gasEstimate,
+        );
+
+        expect(result).to.equal(GasPolicyStatus.PolicyMet);
+      });
+
+      it('should return PolicyNotMet when gasAmount is below required fraction', async () => {
+        const gasEstimate = '100000';
+        const gasAmount = BigInt(49999); // just under 50%
+        const payment = BigInt(1000000000000000);
+
+        const relayer = createRelayer([
+          {
+            type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+            gasFraction: { numerator: 1, denominator: 2 },
+          },
+        ]);
+
+        const message = createMockMessage({ id: messageId });
+        const hook = createMockHookWithIgp(igpAddress);
+        const log = createGasPaymentLog(
+          igpAddress,
+          messageId,
+          destination,
+          gasAmount,
+          payment,
+        );
+        const dispatchTx = createMockDispatchTx([log]);
+
+        const result = await relayer.checkGasPayment(
+          message,
+          dispatchTx,
+          hook,
+          gasEstimate,
+        );
+
+        expect(result).to.equal(GasPolicyStatus.PolicyNotMet);
+      });
+
+      it('should respect custom gasFraction (3/4 = 75%)', async () => {
+        const gasEstimate = '100000';
+        const gasAmount = BigInt(74999); // just under 75%
+        const payment = BigInt(1000000000000000);
+
+        const relayer = createRelayer([
+          {
+            type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+            gasFraction: { numerator: 3, denominator: 4 },
+          },
+        ]);
+
+        const message = createMockMessage({ id: messageId });
+        const hook = createMockHookWithIgp(igpAddress);
+        const log = createGasPaymentLog(
+          igpAddress,
+          messageId,
+          destination,
+          gasAmount,
+          payment,
+        );
+        const dispatchTx = createMockDispatchTx([log]);
+
+        const result = await relayer.checkGasPayment(
+          message,
+          dispatchTx,
+          hook,
+          gasEstimate,
+        );
+
+        expect(result).to.equal(GasPolicyStatus.PolicyNotMet);
+      });
+
+      it('should handle 1/1 gasFraction (100% required)', async () => {
+        const gasEstimate = '100000';
+        const gasAmount = BigInt(100000); // exactly 100%
+        const payment = BigInt(1000000000000000);
+
+        const relayer = createRelayer([
+          {
+            type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+            gasFraction: { numerator: 1, denominator: 1 },
+          },
+        ]);
+
+        const message = createMockMessage({ id: messageId });
+        const hook = createMockHookWithIgp(igpAddress);
+        const log = createGasPaymentLog(
+          igpAddress,
+          messageId,
+          destination,
+          gasAmount,
+          payment,
+        );
+        const dispatchTx = createMockDispatchTx([log]);
+
+        const result = await relayer.checkGasPayment(
+          message,
+          dispatchTx,
+          hook,
+          gasEstimate,
+        );
+
+        expect(result).to.equal(GasPolicyStatus.PolicyMet);
+      });
+    });
+
+    describe('when gas estimate is unavailable (ZkSync)', () => {
+      it('should return PolicyNotMet when gasEstimate is "0"', async () => {
+        const gasEstimate = '0';
+        const gasAmount = BigInt(100000);
+        const payment = BigInt(1000000000000000);
+
+        const relayer = createRelayer([
+          {
+            type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+            gasFraction: { numerator: 1, denominator: 2 },
+          },
+        ]);
+
+        const message = createMockMessage({ id: messageId });
+        const hook = createMockHookWithIgp(igpAddress);
+        const log = createGasPaymentLog(
+          igpAddress,
+          messageId,
+          destination,
+          gasAmount,
+          payment,
+        );
+        const dispatchTx = createMockDispatchTx([log]);
+
+        const result = await relayer.checkGasPayment(
+          message,
+          dispatchTx,
+          hook,
+          gasEstimate,
+        );
+
+        expect(result).to.equal(GasPolicyStatus.PolicyNotMet);
+      });
+    });
+
+    describe('when no payment is found', () => {
+      it('should return NoPaymentFound when no matching payment exists', async () => {
+        const gasEstimate = '100000';
+        const differentMessageId =
+          '0x2222222222222222222222222222222222222222222222222222222222222222';
+
+        const relayer = createRelayer([
+          {
+            type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+            gasFraction: { numerator: 1, denominator: 2 },
+          },
+        ]);
+
+        const message = createMockMessage({ id: messageId });
+        const hook = createMockHookWithIgp(igpAddress);
+        // Create log with payment for different message
+        const log = createGasPaymentLog(
+          igpAddress,
+          differentMessageId,
+          destination,
+          BigInt(100000),
+          BigInt(1000000000000000),
+        );
+        const dispatchTx = createMockDispatchTx([log]);
+
+        const result = await relayer.checkGasPayment(
+          message,
+          dispatchTx,
+          hook,
+          gasEstimate,
+        );
+
+        expect(result).to.equal(GasPolicyStatus.NoPaymentFound);
+      });
+
+      it('should return NoPaymentFound when destination does not match', async () => {
+        const gasEstimate = '100000';
+        const wrongDestination = 999;
+
+        const relayer = createRelayer([
+          {
+            type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+            gasFraction: { numerator: 1, denominator: 2 },
+          },
+        ]);
+
+        const message = createMockMessage({ id: messageId });
+        const hook = createMockHookWithIgp(igpAddress);
+        const log = createGasPaymentLog(
+          igpAddress,
+          messageId,
+          wrongDestination,
+          BigInt(100000),
+          BigInt(1000000000000000),
+        );
+        const dispatchTx = createMockDispatchTx([log]);
+
+        const result = await relayer.checkGasPayment(
+          message,
+          dispatchTx,
+          hook,
+          gasEstimate,
+        );
+
+        expect(result).to.equal(GasPolicyStatus.NoPaymentFound);
+      });
+    });
+
+    describe('policy matching', () => {
+      it('should return PolicyMet when no policy matches', async () => {
+        const gasEstimate = '100000';
+
+        const relayer = createRelayer([
+          {
+            type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+            gasFraction: { numerator: 1, denominator: 2 },
+            matchingList: [{ originDomain: 999 }], // Won't match origin=1
+          },
+        ]);
+
+        const message = createMockMessage({ id: messageId });
+        const hook = createMockHookWithIgp(igpAddress);
+        const dispatchTx = createMockDispatchTx([]);
+
+        const result = await relayer.checkGasPayment(
+          message,
+          dispatchTx,
+          hook,
+          gasEstimate,
+        );
+
+        expect(result).to.equal(GasPolicyStatus.PolicyMet);
+      });
+
+      it('should use first matching policy', async () => {
+        const gasEstimate = '100000';
+        const gasAmount = BigInt(30000); // 30%
+
+        const relayer = createRelayer([
+          {
+            // First policy: requires 50% but only for origin=999
+            type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+            gasFraction: { numerator: 1, denominator: 2 },
+            matchingList: [{ originDomain: 999 }],
+          },
+          {
+            // Second policy: requires only 25%, matches all
+            type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+            gasFraction: { numerator: 1, denominator: 4 },
+          },
+        ]);
+
+        const message = createMockMessage({ id: messageId }); // origin=1
+        const hook = createMockHookWithIgp(igpAddress);
+        const log = createGasPaymentLog(
+          igpAddress,
+          messageId,
+          destination,
+          gasAmount,
+          BigInt(1000000000000000),
+        );
+        const dispatchTx = createMockDispatchTx([log]);
+
+        const result = await relayer.checkGasPayment(
+          message,
+          dispatchTx,
+          hook,
+          gasEstimate,
+        );
+
+        // Second policy matches, 30% > 25% required
+        expect(result).to.equal(GasPolicyStatus.PolicyMet);
+      });
+    });
+
+    describe('None policy', () => {
+      it('should return PolicyMet for None policy regardless of payment', async () => {
+        const gasEstimate = '100000';
+
+        const relayer = createRelayer([
+          {
+            type: GasPaymentEnforcementPolicyType.None,
+          },
+        ]);
+
+        const message = createMockMessage({ id: messageId });
+        const hook = createMockHookWithIgp(igpAddress);
+        const dispatchTx = createMockDispatchTx([]); // No payment
+
+        const result = await relayer.checkGasPayment(
+          message,
+          dispatchTx,
+          hook,
+          gasEstimate,
+        );
+
+        expect(result).to.equal(GasPolicyStatus.PolicyMet);
+      });
+    });
+
+    describe('Minimum policy', () => {
+      it('should return PolicyMet when payment meets minimum', async () => {
+        const gasEstimate = '100000';
+        const minPayment = BigInt(1000000000000000); // 0.001 ETH
+        const actualPayment = BigInt(1000000000000000);
+
+        const relayer = createRelayer([
+          {
+            type: GasPaymentEnforcementPolicyType.Minimum,
+            payment: minPayment.toString(),
+          },
+        ]);
+
+        const message = createMockMessage({ id: messageId });
+        const hook = createMockHookWithIgp(igpAddress);
+        const log = createGasPaymentLog(
+          igpAddress,
+          messageId,
+          destination,
+          BigInt(100000),
+          actualPayment,
+        );
+        const dispatchTx = createMockDispatchTx([log]);
+
+        const result = await relayer.checkGasPayment(
+          message,
+          dispatchTx,
+          hook,
+          gasEstimate,
+        );
+
+        expect(result).to.equal(GasPolicyStatus.PolicyMet);
+      });
+
+      it('should return PolicyNotMet when payment is below minimum', async () => {
+        const gasEstimate = '100000';
+        const minPayment = BigInt(1000000000000000);
+        const actualPayment = BigInt(999999999999999); // just under
+
+        const relayer = createRelayer([
+          {
+            type: GasPaymentEnforcementPolicyType.Minimum,
+            payment: minPayment.toString(),
+          },
+        ]);
+
+        const message = createMockMessage({ id: messageId });
+        const hook = createMockHookWithIgp(igpAddress);
+        const log = createGasPaymentLog(
+          igpAddress,
+          messageId,
+          destination,
+          BigInt(100000),
+          actualPayment,
+        );
+        const dispatchTx = createMockDispatchTx([log]);
+
+        const result = await relayer.checkGasPayment(
+          message,
+          dispatchTx,
+          hook,
+          gasEstimate,
+        );
+
+        expect(result).to.equal(GasPolicyStatus.PolicyNotMet);
+      });
+    });
+  });
+});

--- a/typescript/relayer/src/core/events.ts
+++ b/typescript/relayer/src/core/events.ts
@@ -30,7 +30,7 @@ export type RelayerEvent =
       originChain: string;
       destinationChain: string;
       messageId: string;
-      reason: 'whitelist' | 'already_delivered';
+      reason: 'whitelist' | 'already_delivered' | 'gas_payment';
       dispatchTx?: providers.TransactionReceipt;
     }
   | {

--- a/typescript/relayer/src/index.ts
+++ b/typescript/relayer/src/index.ts
@@ -1,6 +1,9 @@
 export { RelayerCacheSchema } from './core/cache.js';
 export { RelayerEvent, RelayerObserver } from './core/events.js';
-export { HyperlaneRelayer } from './core/HyperlaneRelayer.js';
+export {
+  GasPaymentEnforcementError,
+  HyperlaneRelayer,
+} from './core/HyperlaneRelayer.js';
 export { messageMatchesWhitelist } from './core/whitelist.js';
 export type { RelayerCache } from './core/cache.js';
 

--- a/typescript/sdk/src/gas/GasPaymentParser.test.ts
+++ b/typescript/sdk/src/gas/GasPaymentParser.test.ts
@@ -1,0 +1,173 @@
+import { expect } from 'chai';
+
+import {
+  aggregateGasPayments,
+  getGasPaymentForMessage,
+} from './GasPaymentParser.js';
+import type { InterchainGasPayment } from './types.js';
+
+// Note: parseGasPaymentsFromReceipt requires actual contract ABI parsing,
+// which is better tested in hardhat integration tests. Here we test the
+// pure utility functions.
+
+describe('GasPaymentParser', () => {
+  describe('getGasPaymentForMessage', () => {
+    const payments: InterchainGasPayment[] = [
+      {
+        messageId:
+          '0x1111111111111111111111111111111111111111111111111111111111111111',
+        destination: 1,
+        gasAmount: BigInt(100000),
+        payment: BigInt(1000000000000000),
+      },
+      {
+        messageId:
+          '0x2222222222222222222222222222222222222222222222222222222222222222',
+        destination: 2,
+        gasAmount: BigInt(200000),
+        payment: BigInt(2000000000000000),
+      },
+      {
+        messageId:
+          '0x1111111111111111111111111111111111111111111111111111111111111111',
+        destination: 1,
+        gasAmount: BigInt(50000),
+        payment: BigInt(500000000000000),
+      },
+    ];
+
+    it('should return payment matching messageId and destination', () => {
+      const result = getGasPaymentForMessage(
+        payments,
+        '0x2222222222222222222222222222222222222222222222222222222222222222',
+        2,
+      );
+      expect(result).to.not.be.undefined;
+      expect(result!.gasAmount).to.equal(BigInt(200000));
+      expect(result!.payment).to.equal(BigInt(2000000000000000));
+    });
+
+    it('should return undefined when no match found', () => {
+      const result = getGasPaymentForMessage(
+        payments,
+        '0x3333333333333333333333333333333333333333333333333333333333333333',
+        1,
+      );
+      expect(result).to.be.undefined;
+    });
+
+    it('should return undefined when destination does not match', () => {
+      const result = getGasPaymentForMessage(
+        payments,
+        '0x1111111111111111111111111111111111111111111111111111111111111111',
+        99, // Wrong destination
+      );
+      expect(result).to.be.undefined;
+    });
+
+    it('should aggregate multiple payments for same message', () => {
+      const result = getGasPaymentForMessage(
+        payments,
+        '0x1111111111111111111111111111111111111111111111111111111111111111',
+        1,
+      );
+      expect(result).to.not.be.undefined;
+      // Should aggregate: 100000 + 50000 = 150000
+      expect(result!.gasAmount).to.equal(BigInt(150000));
+      // Should aggregate: 1000000000000000 + 500000000000000 = 1500000000000000
+      expect(result!.payment).to.equal(BigInt(1500000000000000));
+    });
+
+    it('should match messageId case-insensitively', () => {
+      const result = getGasPaymentForMessage(
+        payments,
+        '0x2222222222222222222222222222222222222222222222222222222222222222'.toUpperCase(),
+        2,
+      );
+      expect(result).to.not.be.undefined;
+      expect(result!.gasAmount).to.equal(BigInt(200000));
+    });
+
+    it('should return undefined for empty payments array', () => {
+      const result = getGasPaymentForMessage(
+        [],
+        '0x1111111111111111111111111111111111111111111111111111111111111111',
+        1,
+      );
+      expect(result).to.be.undefined;
+    });
+  });
+
+  describe('aggregateGasPayments', () => {
+    it('should sum gasAmount and payment for multiple payments', () => {
+      const payments: InterchainGasPayment[] = [
+        {
+          messageId: '0x1111',
+          destination: 1,
+          gasAmount: BigInt(100),
+          payment: BigInt(1000),
+        },
+        {
+          messageId: '0x1111',
+          destination: 1,
+          gasAmount: BigInt(200),
+          payment: BigInt(2000),
+        },
+        {
+          messageId: '0x1111',
+          destination: 1,
+          gasAmount: BigInt(300),
+          payment: BigInt(3000),
+        },
+      ];
+
+      const result = aggregateGasPayments(payments);
+      expect(result.messageId).to.equal('0x1111');
+      expect(result.destination).to.equal(1);
+      expect(result.gasAmount).to.equal(BigInt(600));
+      expect(result.payment).to.equal(BigInt(6000));
+    });
+
+    it('should return the same payment for single element array', () => {
+      const payments: InterchainGasPayment[] = [
+        {
+          messageId: '0x1111',
+          destination: 1,
+          gasAmount: BigInt(100),
+          payment: BigInt(1000),
+        },
+      ];
+
+      const result = aggregateGasPayments(payments);
+      expect(result).to.deep.equal(payments[0]);
+    });
+
+    it('should throw for empty array', () => {
+      expect(() => aggregateGasPayments([])).to.throw(
+        'Cannot aggregate empty payments array',
+      );
+    });
+
+    it('should handle large BigInt values', () => {
+      const largeValue = BigInt('1000000000000000000000'); // 1000 ETH in wei
+      const payments: InterchainGasPayment[] = [
+        {
+          messageId: '0x1111',
+          destination: 1,
+          gasAmount: largeValue,
+          payment: largeValue,
+        },
+        {
+          messageId: '0x1111',
+          destination: 1,
+          gasAmount: largeValue,
+          payment: largeValue,
+        },
+      ];
+
+      const result = aggregateGasPayments(payments);
+      expect(result.gasAmount).to.equal(largeValue * BigInt(2));
+      expect(result.payment).to.equal(largeValue * BigInt(2));
+    });
+  });
+});

--- a/typescript/sdk/src/gas/GasPaymentParser.ts
+++ b/typescript/sdk/src/gas/GasPaymentParser.ts
@@ -1,0 +1,105 @@
+import type { TransactionReceipt } from '@ethersproject/providers';
+
+import { InterchainGasPaymaster__factory } from '@hyperlane-xyz/core';
+import { eqAddressEvm } from '@hyperlane-xyz/utils';
+
+import type { InterchainGasPayment } from './types.js';
+
+const IGP_INTERFACE = InterchainGasPaymaster__factory.createInterface();
+const GAS_PAYMENT_TOPIC = IGP_INTERFACE.getEventTopic('GasPayment');
+
+/**
+ * Parse GasPayment events from a transaction receipt.
+ *
+ * @param receipt The transaction receipt to parse
+ * @param igpAddress Optional IGP address to filter events by. If provided,
+ *                   only events from this address will be returned.
+ * @returns Array of parsed InterchainGasPayment objects
+ */
+export function parseGasPaymentsFromReceipt(
+  receipt: TransactionReceipt,
+  igpAddress?: string,
+): InterchainGasPayment[] {
+  return receipt.logs
+    .filter((log) => {
+      // Must be a GasPayment event
+      if (log.topics[0] !== GAS_PAYMENT_TOPIC) {
+        return false;
+      }
+      // If igpAddress is provided, filter by contract address
+      if (igpAddress && !eqAddressEvm(log.address, igpAddress)) {
+        return false;
+      }
+      return true;
+    })
+    .map((log) => {
+      const parsed = IGP_INTERFACE.parseLog(log);
+      return {
+        messageId: parsed.args.messageId as string,
+        destination: parsed.args.destinationDomain as number,
+        gasAmount: BigInt(parsed.args.gasAmount.toString()),
+        payment: BigInt(parsed.args.payment.toString()),
+      };
+    });
+}
+
+/**
+ * Get the gas payment for a specific message from a list of payments.
+ * If multiple payments exist for the same message, they are aggregated.
+ *
+ * @param payments Array of gas payments to search
+ * @param messageId The message ID to find payment for
+ * @param destination The destination domain
+ * @returns The aggregated payment, or undefined if no payment found
+ */
+export function getGasPaymentForMessage(
+  payments: InterchainGasPayment[],
+  messageId: string,
+  destination: number,
+): InterchainGasPayment | undefined {
+  const matching = payments.filter(
+    (p) =>
+      p.messageId.toLowerCase() === messageId.toLowerCase() &&
+      p.destination === destination,
+  );
+
+  if (matching.length === 0) {
+    return undefined;
+  }
+
+  return aggregateGasPayments(matching);
+}
+
+/**
+ * Aggregate multiple gas payments into a single payment.
+ * Sums the gasAmount and payment fields.
+ *
+ * @param payments Array of payments to aggregate (must be non-empty)
+ * @returns Aggregated payment with summed amounts
+ */
+export function aggregateGasPayments(
+  payments: InterchainGasPayment[],
+): InterchainGasPayment {
+  if (payments.length === 0) {
+    throw new Error('Cannot aggregate empty payments array');
+  }
+
+  if (payments.length === 1) {
+    return payments[0];
+  }
+
+  return payments.reduce(
+    (acc, p) => ({
+      messageId: acc.messageId,
+      destination: acc.destination,
+      gasAmount: acc.gasAmount + p.gasAmount,
+      payment: acc.payment + p.payment,
+    }),
+    {
+      messageId: payments[0].messageId,
+      destination: payments[0].destination,
+      gasAmount: BigInt(0),
+      payment: BigInt(0),
+    },
+  );
+}

--- a/typescript/sdk/src/gas/types.ts
+++ b/typescript/sdk/src/gas/types.ts
@@ -41,3 +41,30 @@ export interface IgpOverheadViolation extends IgpViolation {
   actual: ChainMap<BigNumber>;
   expected: ChainMap<BigNumber>;
 }
+
+/**
+ * Represents a gas payment made for an interchain message.
+ * This is parsed from GasPayment events emitted by the InterchainGasPaymaster.
+ */
+export interface InterchainGasPayment {
+  /** The ID of the message this payment is for (bytes32 hex) */
+  messageId: string;
+  /** The destination domain ID */
+  destination: number;
+  /** Amount of destination gas paid for */
+  gasAmount: bigint;
+  /** Amount of native tokens paid */
+  payment: bigint;
+}
+
+/**
+ * Status of gas payment policy evaluation.
+ */
+export enum GasPolicyStatus {
+  /** Gas payment meets the policy requirements */
+  PolicyMet = 'PolicyMet',
+  /** Gas payment does not meet the policy requirements */
+  PolicyNotMet = 'PolicyNotMet',
+  /** No gas payment was found for the message */
+  NoPaymentFound = 'NoPaymentFound',
+}

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -175,13 +175,20 @@ export {
 } from './gas/oracle/types.js';
 export { CoinGeckoTokenPriceGetter } from './gas/token-prices.js';
 export {
+  GasPolicyStatus,
   IgpBeneficiaryViolation,
   IgpConfig,
   IgpGasOraclesViolation,
   IgpOverheadViolation,
   IgpViolation,
   IgpViolationType,
+  InterchainGasPayment,
 } from './gas/types.js';
+export {
+  aggregateGasPayments,
+  getGasPaymentForMessage,
+  parseGasPaymentsFromReceipt,
+} from './gas/GasPaymentParser.js';
 export { EvmHookReader } from './hook/EvmHookReader.js';
 export { HyperlaneHookDeployer } from './hook/HyperlaneHookDeployer.js';
 export {
@@ -303,6 +310,7 @@ export {
   AgentSignerNode,
   buildAgentConfig,
   GasPaymentEnforcement,
+  GasPaymentEnforcementInput,
   GasPaymentEnforcementPolicyType,
   IsmCacheConfig,
   IsmCachePolicy,
@@ -347,6 +355,10 @@ export {
   HyperlaneDeploymentArtifactsSchema,
 } from './metadata/deploymentArtifacts.js';
 export { MatchingList } from './metadata/matchingList.js';
+export {
+  messageMatchesMatchingList,
+  MatchingListMessage,
+} from './metadata/matchingListUtils.js';
 export {
   WarpRouteConfig,
   WarpRouteConfigSchema,

--- a/typescript/sdk/src/metadata/agentConfig.test.ts
+++ b/typescript/sdk/src/metadata/agentConfig.test.ts
@@ -3,7 +3,11 @@ import { expect } from 'chai';
 import { TestChainName } from '../consts/testChains.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 
-import { buildAgentConfig } from './agentConfig.js';
+import {
+  GasPaymentEnforcementPolicyType,
+  GasPaymentEnforcementSchema,
+  buildAgentConfig,
+} from './agentConfig.js';
 
 describe('Agent config', () => {
   const args: Parameters<typeof buildAgentConfig> = [
@@ -32,5 +36,250 @@ describe('Agent config', () => {
     expect(result.chains[TestChainName.test1].merkleTreeHook).to.equal(
       '0xmerkle',
     );
+  });
+});
+
+describe('GasPaymentEnforcement schema', () => {
+  describe('OnChainFeeQuoting gasFraction', () => {
+    it('should use default gasFraction of 1/2 when not specified', () => {
+      const input = {
+        type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+      };
+
+      const result = GasPaymentEnforcementSchema.parse(input) as any;
+
+      expect(result.type).to.equal(
+        GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+      );
+      expect(result.gasFraction).to.deep.equal({
+        numerator: 1,
+        denominator: 2,
+      });
+    });
+
+    it('should parse gasFraction string "1/2" to object', () => {
+      const input = {
+        type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+        gasFraction: '1/2',
+      };
+
+      const result = GasPaymentEnforcementSchema.parse(input) as any;
+
+      expect(result.gasFraction).to.deep.equal({
+        numerator: 1,
+        denominator: 2,
+      });
+    });
+
+    it('should parse gasFraction string "3/4" to object', () => {
+      const input = {
+        type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+        gasFraction: '3/4',
+      };
+
+      const result = GasPaymentEnforcementSchema.parse(input) as any;
+
+      expect(result.gasFraction).to.deep.equal({
+        numerator: 3,
+        denominator: 4,
+      });
+    });
+
+    it('should parse gasFraction string "1/1" (100% required)', () => {
+      const input = {
+        type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+        gasFraction: '1/1',
+      };
+
+      const result = GasPaymentEnforcementSchema.parse(input) as any;
+
+      expect(result.gasFraction).to.deep.equal({
+        numerator: 1,
+        denominator: 1,
+      });
+    });
+
+    it('should parse gasFraction with spaces "1 / 2"', () => {
+      const input = {
+        type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+        gasFraction: '1 / 2',
+      };
+
+      const result = GasPaymentEnforcementSchema.parse(input) as any;
+
+      expect(result.gasFraction).to.deep.equal({
+        numerator: 1,
+        denominator: 2,
+      });
+    });
+
+    it('should reject invalid gasFraction format', () => {
+      const input = {
+        type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+        gasFraction: 'invalid',
+      };
+
+      expect(() => GasPaymentEnforcementSchema.parse(input)).to.throw();
+    });
+
+    it('should reject gasFraction with zero denominator', () => {
+      const input = {
+        type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+        gasFraction: '1/0',
+      };
+
+      expect(() => GasPaymentEnforcementSchema.parse(input)).to.throw();
+    });
+  });
+
+  describe('None policy', () => {
+    it('should parse None policy', () => {
+      const input = {
+        type: GasPaymentEnforcementPolicyType.None,
+      };
+
+      const result = GasPaymentEnforcementSchema.parse(input);
+
+      expect(result.type).to.equal(GasPaymentEnforcementPolicyType.None);
+    });
+
+    it('should parse policy with undefined type as None', () => {
+      const input = {};
+
+      const result = GasPaymentEnforcementSchema.parse(input);
+
+      expect(result.type).to.be.undefined;
+    });
+  });
+
+  describe('Minimum policy', () => {
+    it('should parse Minimum policy with payment', () => {
+      const input = {
+        type: GasPaymentEnforcementPolicyType.Minimum,
+        payment: '1000000000000000',
+      };
+
+      const result = GasPaymentEnforcementSchema.parse(input) as any;
+
+      expect(result.type).to.equal(GasPaymentEnforcementPolicyType.Minimum);
+      expect(result.payment).to.equal('1000000000000000');
+    });
+  });
+
+  describe('with matchingList', () => {
+    it('should parse policy with matchingList', () => {
+      const input = {
+        type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
+        matchingList: [
+          {
+            originDomain: 1,
+            destinationDomain: 2,
+          },
+        ],
+      };
+
+      const result = GasPaymentEnforcementSchema.parse(input);
+
+      expect(result.matchingList).to.have.length(1);
+      expect(result.matchingList![0].originDomain).to.equal(1);
+    });
+  });
+});
+
+describe('OnChainFeeQuoting calculation', () => {
+  // Test the calculation logic: gasAmount >= gasEstimate * numerator / denominator
+  function meetsOnChainFeeQuoting(
+    gasAmount: bigint,
+    gasEstimate: bigint,
+    numerator: number,
+    denominator: number,
+  ): boolean {
+    const requiredGas = (gasEstimate * BigInt(numerator)) / BigInt(denominator);
+    return gasAmount >= requiredGas;
+  }
+
+  describe('with 1/2 fraction (50% required)', () => {
+    const numerator = 1;
+    const denominator = 2;
+
+    it('should pass when gasAmount equals 50% of estimate', () => {
+      const gasEstimate = BigInt(100000);
+      const gasAmount = BigInt(50000); // exactly 50%
+      expect(
+        meetsOnChainFeeQuoting(gasAmount, gasEstimate, numerator, denominator),
+      ).to.be.true;
+    });
+
+    it('should pass when gasAmount exceeds 50% of estimate', () => {
+      const gasEstimate = BigInt(100000);
+      const gasAmount = BigInt(75000); // 75%
+      expect(
+        meetsOnChainFeeQuoting(gasAmount, gasEstimate, numerator, denominator),
+      ).to.be.true;
+    });
+
+    it('should fail when gasAmount is below 50% of estimate', () => {
+      const gasEstimate = BigInt(100000);
+      const gasAmount = BigInt(49999); // just under 50%
+      expect(
+        meetsOnChainFeeQuoting(gasAmount, gasEstimate, numerator, denominator),
+      ).to.be.false;
+    });
+  });
+
+  describe('with 3/4 fraction (75% required)', () => {
+    const numerator = 3;
+    const denominator = 4;
+
+    it('should pass when gasAmount equals 75% of estimate', () => {
+      const gasEstimate = BigInt(100000);
+      const gasAmount = BigInt(75000);
+      expect(
+        meetsOnChainFeeQuoting(gasAmount, gasEstimate, numerator, denominator),
+      ).to.be.true;
+    });
+
+    it('should fail when gasAmount is below 75% of estimate', () => {
+      const gasEstimate = BigInt(100000);
+      const gasAmount = BigInt(74999);
+      expect(
+        meetsOnChainFeeQuoting(gasAmount, gasEstimate, numerator, denominator),
+      ).to.be.false;
+    });
+  });
+
+  describe('with 1/1 fraction (100% required)', () => {
+    const numerator = 1;
+    const denominator = 1;
+
+    it('should pass when gasAmount equals estimate', () => {
+      const gasEstimate = BigInt(100000);
+      const gasAmount = BigInt(100000);
+      expect(
+        meetsOnChainFeeQuoting(gasAmount, gasEstimate, numerator, denominator),
+      ).to.be.true;
+    });
+
+    it('should fail when gasAmount is below estimate', () => {
+      const gasEstimate = BigInt(100000);
+      const gasAmount = BigInt(99999);
+      expect(
+        meetsOnChainFeeQuoting(gasAmount, gasEstimate, numerator, denominator),
+      ).to.be.false;
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle zero gas estimate', () => {
+      const gasEstimate = BigInt(0);
+      const gasAmount = BigInt(0);
+      expect(meetsOnChainFeeQuoting(gasAmount, gasEstimate, 1, 2)).to.be.true;
+    });
+
+    it('should handle large values', () => {
+      const gasEstimate = BigInt('1000000000000000000'); // 1 ETH worth of gas
+      const gasAmount = BigInt('500000000000000000'); // 0.5 ETH
+      expect(meetsOnChainFeeQuoting(gasAmount, gasEstimate, 1, 2)).to.be.true;
+    });
   });
 });

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -333,7 +333,7 @@ const GasPaymentEnforcementBaseSchema = z.object({
     'An optional matching list, any message that matches will use this policy. By default all messages will match.',
   ),
 });
-const GasPaymentEnforcementSchema = z.union([
+export const GasPaymentEnforcementSchema = z.union([
   GasPaymentEnforcementBaseSchema.extend({
     type: z.literal(GasPaymentEnforcementPolicyType.None).optional(),
   }),
@@ -346,10 +346,21 @@ const GasPaymentEnforcementSchema = z.union([
     gasFraction: z
       .string()
       .regex(/^\d+ ?\/ ?[1-9]\d*$/)
-      .optional(),
+      .default('1/2')
+      .transform((val) => {
+        const match = val.match(/^(\d+) ?\/ ?([1-9]\d*)$/);
+        if (!match) return { numerator: 1, denominator: 2 };
+        return {
+          numerator: parseInt(match[1], 10),
+          denominator: parseInt(match[2], 10),
+        };
+      }),
   }),
 ]);
 export type GasPaymentEnforcement = z.infer<typeof GasPaymentEnforcementSchema>;
+export type GasPaymentEnforcementInput = z.input<
+  typeof GasPaymentEnforcementSchema
+>;
 
 const MetricAppContextSchema = z.object({
   name: z.string().min(1),

--- a/typescript/sdk/src/metadata/matchingListUtils.test.ts
+++ b/typescript/sdk/src/metadata/matchingListUtils.test.ts
@@ -1,0 +1,252 @@
+import { expect } from 'chai';
+
+import type { MatchingList } from './matchingList.js';
+import {
+  type MatchingListMessage,
+  messageMatchesMatchingList,
+} from './matchingListUtils.js';
+
+describe('matchingListUtils', () => {
+  describe('messageMatchesMatchingList', () => {
+    const testMessage: MatchingListMessage = {
+      id: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+      origin: 1,
+      destination: 2,
+      sender: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      recipient: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      body: '0xdeadbeef',
+    };
+
+    describe('empty/undefined list (wildcard)', () => {
+      it('should match all messages when list is undefined', () => {
+        expect(messageMatchesMatchingList(undefined, testMessage)).to.be.true;
+      });
+
+      it('should match all messages when list is empty', () => {
+        expect(messageMatchesMatchingList([], testMessage)).to.be.true;
+      });
+    });
+
+    describe('originDomain matching', () => {
+      it('should match exact originDomain', () => {
+        const list: MatchingList = [{ originDomain: 1 }];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+
+      it('should reject non-matching originDomain', () => {
+        const list: MatchingList = [{ originDomain: 99 }];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.false;
+      });
+
+      it('should match wildcard originDomain', () => {
+        const list: MatchingList = [{ originDomain: '*' }];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+
+      it('should match originDomain in array', () => {
+        const list: MatchingList = [{ originDomain: [1, 3, 5] }];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+
+      it('should reject originDomain not in array', () => {
+        const list: MatchingList = [{ originDomain: [3, 5, 7] }];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.false;
+      });
+    });
+
+    describe('destinationDomain matching', () => {
+      it('should match exact destinationDomain', () => {
+        const list: MatchingList = [{ destinationDomain: 2 }];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+
+      it('should reject non-matching destinationDomain', () => {
+        const list: MatchingList = [{ destinationDomain: 99 }];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.false;
+      });
+
+      it('should match wildcard destinationDomain', () => {
+        const list: MatchingList = [{ destinationDomain: '*' }];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+    });
+
+    describe('senderAddress matching', () => {
+      it('should match exact senderAddress (lowercase)', () => {
+        const list: MatchingList = [
+          { senderAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+        ];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+
+      it('should match senderAddress case-insensitively', () => {
+        const list: MatchingList = [
+          { senderAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+        ];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+
+      it('should reject non-matching senderAddress', () => {
+        const list: MatchingList = [
+          { senderAddress: '0xcccccccccccccccccccccccccccccccccccccccc' },
+        ];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.false;
+      });
+
+      it('should match wildcard senderAddress', () => {
+        const list: MatchingList = [{ senderAddress: '*' }];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+
+      it('should match senderAddress in array', () => {
+        const list: MatchingList = [
+          {
+            senderAddress: [
+              '0xcccccccccccccccccccccccccccccccccccccccc',
+              '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            ],
+          },
+        ];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+    });
+
+    describe('recipientAddress matching', () => {
+      it('should match exact recipientAddress', () => {
+        const list: MatchingList = [
+          { recipientAddress: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' },
+        ];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+
+      it('should reject non-matching recipientAddress', () => {
+        const list: MatchingList = [
+          { recipientAddress: '0xcccccccccccccccccccccccccccccccccccccccc' },
+        ];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.false;
+      });
+    });
+
+    describe('messageId matching', () => {
+      it('should match exact messageId', () => {
+        const list: MatchingList = [
+          {
+            messageId:
+              '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          },
+        ];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+
+      it('should reject non-matching messageId', () => {
+        const list: MatchingList = [
+          {
+            messageId:
+              '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+          },
+        ];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.false;
+      });
+
+      it('should match wildcard messageId', () => {
+        const list: MatchingList = [{ messageId: '*' }];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+    });
+
+    describe('bodyRegex matching', () => {
+      it('should match body with regex', () => {
+        const list: MatchingList = [{ bodyRegex: 'dead' }];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+
+      it('should match body with full regex pattern', () => {
+        const list: MatchingList = [{ bodyRegex: '^0x[a-f0-9]+$' }];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+
+      it('should reject non-matching bodyRegex', () => {
+        const list: MatchingList = [{ bodyRegex: 'notfound' }];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.false;
+      });
+
+      it('should handle invalid regex gracefully', () => {
+        const list: MatchingList = [{ bodyRegex: '[invalid(' }];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.false;
+      });
+    });
+
+    describe('multiple fields in element (AND logic)', () => {
+      it('should match when ALL fields match', () => {
+        const list: MatchingList = [
+          {
+            originDomain: 1,
+            destinationDomain: 2,
+            senderAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          },
+        ];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+
+      it('should reject when ANY field does not match', () => {
+        const list: MatchingList = [
+          {
+            originDomain: 1,
+            destinationDomain: 99, // Does not match
+            senderAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          },
+        ];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.false;
+      });
+    });
+
+    describe('multiple elements in list (OR logic)', () => {
+      it('should match when ANY element matches', () => {
+        const list: MatchingList = [
+          { originDomain: 99 }, // Does not match
+          { originDomain: 1 }, // Matches
+        ];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+
+      it('should reject when NO element matches', () => {
+        const list: MatchingList = [
+          { originDomain: 99 },
+          { destinationDomain: 99 },
+        ];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.false;
+      });
+
+      it('should match first element when multiple could match', () => {
+        const list: MatchingList = [
+          { originDomain: 1 }, // Matches
+          { destinationDomain: 2 }, // Also would match
+        ];
+        expect(messageMatchesMatchingList(list, testMessage)).to.be.true;
+      });
+    });
+
+    describe('undefined message fields', () => {
+      it('should not match when required field is undefined', () => {
+        const messageWithoutOrigin: MatchingListMessage = {
+          destination: 2,
+          sender: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        };
+        const list: MatchingList = [{ originDomain: 1 }];
+        expect(messageMatchesMatchingList(list, messageWithoutOrigin)).to.be
+          .false;
+      });
+
+      it('should match wildcard even when field is undefined', () => {
+        // Wildcard should still require the field to be present
+        const messageWithoutOrigin: MatchingListMessage = {
+          destination: 2,
+        };
+        const list: MatchingList = [{ originDomain: '*' }];
+        // Even with wildcard, undefined origin should not match
+        expect(messageMatchesMatchingList(list, messageWithoutOrigin)).to.be
+          .false;
+      });
+    });
+  });
+});

--- a/typescript/sdk/src/metadata/matchingListUtils.ts
+++ b/typescript/sdk/src/metadata/matchingListUtils.ts
@@ -1,0 +1,155 @@
+import { eqAddress } from '@hyperlane-xyz/utils';
+
+import type { MatchingList, MatchingListElement } from './matchingList.js';
+
+/**
+ * Message-like object for matching against a MatchingList.
+ * All fields are optional - only fields present in the matching list element
+ * will be checked.
+ */
+export interface MatchingListMessage {
+  id?: string;
+  origin?: number;
+  destination?: number;
+  sender?: string;
+  recipient?: string;
+  body?: string;
+}
+
+/**
+ * Check if a message matches a matching list.
+ *
+ * Matching logic:
+ * - Empty/undefined list = wildcard (matches all messages)
+ * - Element matches if ALL specified fields match (AND logic)
+ * - List matches if ANY element matches (OR logic)
+ *
+ * @param list The matching list to check against
+ * @param message The message to check
+ * @returns true if the message matches the list
+ */
+export function messageMatchesMatchingList(
+  list: MatchingList | undefined,
+  message: MatchingListMessage,
+): boolean {
+  // Empty/undefined list = wildcard (matches all)
+  if (!list || list.length === 0) {
+    return true;
+  }
+  // Match if ANY element matches (OR logic)
+  return list.some((element) => messageMatchesElement(element, message));
+}
+
+/**
+ * Check if a message matches a single matching list element.
+ * ALL specified fields in the element must match (AND logic).
+ */
+function messageMatchesElement(
+  element: MatchingListElement,
+  message: MatchingListMessage,
+): boolean {
+  if (
+    element.originDomain !== undefined &&
+    !matchesDomain(element.originDomain, message.origin)
+  ) {
+    return false;
+  }
+
+  if (
+    element.destinationDomain !== undefined &&
+    !matchesDomain(element.destinationDomain, message.destination)
+  ) {
+    return false;
+  }
+
+  if (
+    element.senderAddress !== undefined &&
+    !matchesAddress(element.senderAddress, message.sender)
+  ) {
+    return false;
+  }
+
+  if (
+    element.recipientAddress !== undefined &&
+    !matchesAddress(element.recipientAddress, message.recipient)
+  ) {
+    return false;
+  }
+
+  if (
+    element.messageId !== undefined &&
+    !matchesAddress(element.messageId, message.id)
+  ) {
+    return false;
+  }
+
+  if (
+    element.bodyRegex !== undefined &&
+    !matchesBodyRegex(element.bodyRegex, message.body)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Check if a domain value matches a domain pattern.
+ * @param pattern '*' (wildcard), single domain, or array of domains
+ * @param value The domain value to check
+ */
+function matchesDomain(
+  pattern: '*' | number | number[],
+  value: number | undefined,
+): boolean {
+  if (value === undefined) {
+    return false;
+  }
+  if (pattern === '*') {
+    return true;
+  }
+  if (Array.isArray(pattern)) {
+    return pattern.includes(value);
+  }
+  return pattern === value;
+}
+
+/**
+ * Check if an address/hash value matches an address pattern.
+ * Uses case-insensitive comparison for hex addresses.
+ * @param pattern '*' (wildcard), single address, or array of addresses
+ * @param value The address value to check (can be checksummed or lowercase)
+ */
+function matchesAddress(
+  pattern: string | string[],
+  value: string | undefined,
+): boolean {
+  if (value === undefined) {
+    return false;
+  }
+  if (pattern === '*') {
+    return true;
+  }
+  if (Array.isArray(pattern)) {
+    return pattern.some((p) => eqAddress(p, value));
+  }
+  return eqAddress(pattern, value);
+}
+
+/**
+ * Check if a message body matches a regex pattern.
+ * @param regex The regex pattern string
+ * @param body The message body to check
+ */
+function matchesBodyRegex(regex: string, body: string | undefined): boolean {
+  if (body === undefined) {
+    return false;
+  }
+  try {
+    const re = new RegExp(regex);
+    return re.test(body);
+  } catch {
+    // Invalid regex - treat as no match
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Adds gas payment enforcement to the TypeScript relayer, matching the Rust relayer's `GasPaymentEnforcement[]` configuration format. This allows the relayer to verify that messages have sufficient gas payments before relaying.

### Policy Types

| Policy | Behavior |
|--------|----------|
| `None` | Skip enforcement (allow all messages) |
| `Minimum` | Require `payment >= threshold` |
| `OnChainFeeQuoting` | Require `gasAmount >= gasEstimate * gasFraction` |

### SDK Additions

- **`GasPaymentParser`**: Parse `GasPayment` events from transaction receipts
- **`matchingListUtils`**: Evaluate messages against `MatchingList` configs (for policy routing)
- **`InterchainGasPayment`** type and **`GasPolicyStatus`** enum
- **`gasFraction`** Zod transform: parses `"1/2"` string → `{ numerator, denominator }` at parse time

### Relayer Changes

- **`checkGasPayment()`**: Public async method with optional `hook`/`gasEstimate` params
  - Derives hook config internally if not provided
  - Estimates gas internally if not provided (for `OnChainFeeQuoting`)
- **`GasPaymentEnforcementError`**: Thrown when policy check fails
- Emits `gas_payment` skip reason in observer events

### Usage

```typescript
const relayer = new HyperlaneRelayer({
  core,
  gasPaymentEnforcement: [
    {
      type: GasPaymentEnforcementPolicyType.OnChainFeeQuoting,
      gasFraction: { numerator: 1, denominator: 2 }, // require 50% of estimated gas
      matchingList: [{ originDomain: 1 }], // only for messages from domain 1
    },
    {
      type: GasPaymentEnforcementPolicyType.None, // fallback: allow all others
    },
  ],
});

// Or check gas payment directly
const status = await relayer.checkGasPayment(message, dispatchTx);
```

## Test Plan

- **31 tests** for matching list evaluation
- **10 tests** for gas payment parsing/aggregation  
- **20 tests** for schema parsing (gasFraction transform)
- **13 tests** for relayer `checkGasPayment()` integration

## Known Limitations

- **No negation support** in matching lists (Rust supports `!0x...` patterns)
- **No expenditure tracking** (Rust subtracts gas already spent on retries)

These can be added in follow-up PRs if needed.

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Prettier passes (`pnpm prettier`)
- [ ] Changeset added