### PR TITLE
chore: add monad safe address

### DIFF
--- a/typescript/infra/config/environments/mainnet3/governance/safe/aw.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/safe/aw.ts
@@ -62,6 +62,7 @@ export const awSafes: ChainMap<Address> = {
   // ----------------------------------------------------------
   viction: '0x18165B1cb2969B79D2a0f67AECe0bf7bb44a7CaD',
 
-  // Feb 4, 2026
+  // Feb 4, 2026 - FPWR ProxyAdmin on Safes
+  // ----------------------------------------------------------
   monad: '0x930f79e486B869EC7B5BF4e83121aDfcca198f42',
 };


### PR DESCRIPTION
## Summary
https://app.safe.global/settings/setup?safe=monad:0x930f79e486B869EC7B5BF4e83121aDfcca198f42
- Added Monad safe address to AW governance config

## Testing
Config change only, no testing needed

## Related issues
N/A

## Backward compatibility
Yes