### PR TITLE
feat(isms): add BlockHashIsm for receipt-proof based verification

### DIFF
--- a/solidity/contracts/interfaces/IBlockHashOracle.sol
+++ b/solidity/contracts/interfaces/IBlockHashOracle.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/**
+ * @title IBlockHashOracle
+ * @notice Interface for an oracle that provides block hashes from a specific origin chain
+ */
+interface IBlockHashOracle {
+    /**
+     * @notice Returns the origin domain ID this oracle serves
+     * @return The origin domain ID
+     */
+    function origin() external view returns (uint32);
+
+    /**
+     * @notice Returns the block hash for a given block height on the origin chain
+     * @param height The block number to query
+     * @return The block hash, or bytes32(0) if not available
+     */
+    function blockHash(uint256 height) external view returns (bytes32);
+}

--- a/solidity/contracts/isms/blockhash/BlockHashIsm.sol
+++ b/solidity/contracts/isms/blockhash/BlockHashIsm.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+// ============ Internal Imports ============
+import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
+import {IBlockHashOracle} from "../../interfaces/IBlockHashOracle.sol";
+import {Message} from "../../libs/Message.sol";
+import {RLPReader} from "../../libs/RLPReader.sol";
+import {MerklePatriciaTrie} from "../../libs/MerklePatriciaTrie.sol";
+import {BlockHashIsmMetadata} from "../libs/BlockHashIsmMetadata.sol";
+import {PackageVersioned} from "../../PackageVersioned.sol";
+
+/**
+ * @title BlockHashIsm
+ * @notice ISM that verifies messages using block hash oracle and receipt proofs
+ * @dev Verifies that a Dispatch event was emitted by the origin Mailbox
+ *      by proving inclusion in the receiptsRoot of a block whose hash
+ *      is attested to by the oracle.
+ */
+contract BlockHashIsm is IInterchainSecurityModule, PackageVersioned {
+    using Message for bytes;
+    using BlockHashIsmMetadata for bytes;
+    using RLPReader for bytes;
+
+    // ============ Constants ============
+
+    /// @notice Module type for the ISM
+    uint8 public constant moduleType =
+        uint8(IInterchainSecurityModule.Types.NULL);
+
+    /// @notice DispatchId event signature: keccak256("DispatchId(bytes32)")
+    bytes32 public constant DISPATCH_ID_TOPIC =
+        0x788dbc1b7152732178210e7f4d9d010ef016f9eafbe66786bd7169f56e0c353a;
+
+    // ============ Immutables ============
+
+    /// @notice The block hash oracle for the origin chain
+    IBlockHashOracle public immutable oracle;
+
+    /// @notice The Mailbox address on the origin chain
+    address public immutable originMailbox;
+
+    /// @notice The origin domain ID (cached from oracle)
+    uint32 public immutable origin;
+
+    // ============ Constructor ============
+
+    /**
+     * @param _oracle The block hash oracle for the origin chain
+     * @param _originMailbox The Mailbox address on the origin chain
+     */
+    constructor(IBlockHashOracle _oracle, address _originMailbox) {
+        require(address(_oracle) != address(0), "BlockHashIsm: zero oracle");
+        require(_originMailbox != address(0), "BlockHashIsm: zero mailbox");
+
+        oracle = _oracle;
+        originMailbox = _originMailbox;
+        origin = _oracle.origin();
+    }
+
+    // ============ External Functions ============
+
+    /**
+     * @notice Verifies that a message was dispatched on the origin chain
+     * @param _metadata Encoded proof data (see BlockHashIsmMetadata)
+     * @param _message Hyperlane formatted message
+     * @return True if verification succeeds
+     */
+    function verify(
+        bytes calldata _metadata,
+        bytes calldata _message
+    ) external view returns (bool) {
+        require(_message.origin() == origin, "BlockHashIsm: wrong origin");
+
+        bytes32 receiptsRoot = _verifyBlockHeader(_metadata);
+
+        (address emitter, bytes32 logMessageId) = _verifyReceiptProof(
+            _metadata,
+            receiptsRoot
+        );
+
+        require(emitter == originMailbox, "BlockHashIsm: wrong emitter");
+        require(
+            logMessageId == _message.id(),
+            "BlockHashIsm: message ID mismatch"
+        );
+
+        return true;
+    }
+
+    // ============ Internal Functions ============
+
+    /**
+     * @notice Verifies block header against oracle and extracts receiptsRoot
+     * @param _metadata The metadata containing block header
+     * @return receiptsRoot The receipts root from the verified header
+     */
+    function _verifyBlockHeader(
+        bytes calldata _metadata
+    ) internal view returns (bytes32 receiptsRoot) {
+        uint64 blockNum = _metadata.blockNumber();
+        bytes32 expectedBlockHash = oracle.blockHash(blockNum);
+        require(
+            expectedBlockHash != bytes32(0),
+            "BlockHashIsm: block not found"
+        );
+
+        bytes calldata header = _metadata.blockHeader();
+        require(
+            keccak256(header) == expectedBlockHash,
+            "BlockHashIsm: invalid block header"
+        );
+
+        receiptsRoot = header.extractReceiptsRoot();
+    }
+
+    /**
+     * @notice Verifies receipt proof and extracts DispatchId log
+     * @param _metadata The metadata containing proof
+     * @param _receiptsRoot The verified receipts root
+     * @return emitter The log emitter address
+     * @return messageId The message ID from the log
+     */
+    function _verifyReceiptProof(
+        bytes calldata _metadata,
+        bytes32 _receiptsRoot
+    ) internal pure returns (address emitter, bytes32 messageId) {
+        bytes memory txKey = BlockHashIsmMetadata.encodeTxIndexAsKey(
+            _metadata.txIndex()
+        );
+
+        bytes[] memory proof = _metadata.proofNodes();
+        bytes memory receiptRlp = MerklePatriciaTrie.verifyProof(
+            _receiptsRoot,
+            txKey,
+            proof
+        );
+
+        return _parseReceiptForDispatchId(receiptRlp, _metadata.logIndex());
+    }
+
+    /**
+     * @notice Parses a receipt to extract DispatchId log data
+     * @param _receiptRlp RLP encoded receipt
+     * @param _logIndex Index of the log to extract
+     * @return emitter The log emitter address
+     * @return messageId The message ID from the log
+     */
+    function _parseReceiptForDispatchId(
+        bytes memory _receiptRlp,
+        uint8 _logIndex
+    ) internal pure returns (address emitter, bytes32 messageId) {
+        bytes memory receiptData = _receiptRlp;
+
+        // Handle typed transaction receipts (EIP-2718)
+        if (_receiptRlp.length > 0) {
+            uint8 firstByte = uint8(_receiptRlp[0]);
+            if (firstByte == 0x01 || firstByte == 0x02) {
+                receiptData = _slice(_receiptRlp, 1, _receiptRlp.length - 1);
+            }
+        }
+
+        bytes[] memory receiptItems = RLPReader.decodeList(receiptData);
+        require(receiptItems.length >= 4, "BlockHashIsm: invalid receipt");
+
+        bytes[] memory logs = RLPReader.decodeList(receiptItems[3]);
+        require(_logIndex < logs.length, "BlockHashIsm: log index OOB");
+
+        bytes[] memory logItems = RLPReader.decodeList(logs[_logIndex]);
+        require(logItems.length >= 3, "BlockHashIsm: invalid log");
+
+        emitter = RLPReader.toAddress(logItems[0]);
+
+        bytes[] memory topics = RLPReader.decodeList(logItems[1]);
+        require(topics.length >= 2, "BlockHashIsm: missing topics");
+
+        bytes32 eventSig = bytes32(RLPReader.toBytes(topics[0]));
+        require(
+            eventSig == DISPATCH_ID_TOPIC,
+            "BlockHashIsm: wrong event signature"
+        );
+
+        messageId = bytes32(RLPReader.toBytes(topics[1]));
+    }
+
+    /**
+     * @notice Slices bytes from memory
+     */
+    function _slice(
+        bytes memory _data,
+        uint256 _start,
+        uint256 _length
+    ) internal pure returns (bytes memory result) {
+        result = new bytes(_length);
+        for (uint256 i = 0; i < _length; i++) {
+            result[i] = _data[_start + i];
+        }
+    }
+}

--- a/solidity/contracts/isms/libs/BlockHashIsmMetadata.sol
+++ b/solidity/contracts/isms/libs/BlockHashIsmMetadata.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/**
+ * @title BlockHashIsmMetadata
+ * @notice Library for parsing BlockHashIsm metadata
+ *
+ * Format of metadata:
+ * [   0:   8] Block number (uint64)
+ * [   8:  10] Block header length (uint16)
+ * [  10:  10+headerLen] RLP encoded block header
+ * [  ...:  ...+2] Transaction index in block (uint16)
+ * [  ...:  ...+1] Log index in receipt (uint8)
+ * [  ...:  end] MPT proof nodes (concatenated, each prefixed with uint16 length)
+ */
+library BlockHashIsmMetadata {
+    uint256 private constant BLOCK_NUMBER_OFFSET = 0;
+    uint256 private constant HEADER_LENGTH_OFFSET = 8;
+    uint256 private constant HEADER_OFFSET = 10;
+
+    /**
+     * @notice Returns the block number
+     * @param _metadata ABI encoded BlockHashIsm metadata
+     * @return Block number
+     */
+    function blockNumber(
+        bytes calldata _metadata
+    ) internal pure returns (uint64) {
+        return uint64(bytes8(_metadata[BLOCK_NUMBER_OFFSET:HEADER_LENGTH_OFFSET]));
+    }
+
+    /**
+     * @notice Returns the block header length
+     * @param _metadata ABI encoded BlockHashIsm metadata
+     * @return Header length in bytes
+     */
+    function headerLength(
+        bytes calldata _metadata
+    ) internal pure returns (uint16) {
+        return uint16(bytes2(_metadata[HEADER_LENGTH_OFFSET:HEADER_OFFSET]));
+    }
+
+    /**
+     * @notice Returns the RLP encoded block header
+     * @param _metadata ABI encoded BlockHashIsm metadata
+     * @return The block header bytes
+     */
+    function blockHeader(
+        bytes calldata _metadata
+    ) internal pure returns (bytes calldata) {
+        uint16 len = headerLength(_metadata);
+        return _metadata[HEADER_OFFSET:HEADER_OFFSET + len];
+    }
+
+    /**
+     * @notice Returns the transaction index
+     * @param _metadata ABI encoded BlockHashIsm metadata
+     * @return Transaction index in the block
+     */
+    function txIndex(
+        bytes calldata _metadata
+    ) internal pure returns (uint16) {
+        uint256 offset = HEADER_OFFSET + headerLength(_metadata);
+        return uint16(bytes2(_metadata[offset:offset + 2]));
+    }
+
+    /**
+     * @notice Returns the log index within the receipt
+     * @param _metadata ABI encoded BlockHashIsm metadata
+     * @return Log index
+     */
+    function logIndex(
+        bytes calldata _metadata
+    ) internal pure returns (uint8) {
+        uint256 offset = HEADER_OFFSET + headerLength(_metadata) + 2;
+        return uint8(_metadata[offset]);
+    }
+
+    /**
+     * @notice Returns the MPT proof nodes
+     * @param _metadata ABI encoded BlockHashIsm metadata
+     * @return proof Array of proof nodes
+     */
+    function proofNodes(
+        bytes calldata _metadata
+    ) internal pure returns (bytes[] memory proof) {
+        uint256 offset = HEADER_OFFSET + headerLength(_metadata) + 3;
+        bytes calldata proofData = _metadata[offset:];
+
+        // First pass: count nodes
+        uint256 count = 0;
+        uint256 pos = 0;
+        while (pos < proofData.length) {
+            uint16 nodeLen = uint16(bytes2(proofData[pos:pos + 2]));
+            pos += 2 + nodeLen;
+            count++;
+        }
+
+        // Second pass: extract nodes
+        proof = new bytes[](count);
+        pos = 0;
+        for (uint256 i = 0; i < count; i++) {
+            uint16 nodeLen = uint16(bytes2(proofData[pos:pos + 2]));
+            proof[i] = proofData[pos + 2:pos + 2 + nodeLen];
+            pos += 2 + nodeLen;
+        }
+    }
+
+    /**
+     * @notice Encodes the transaction index as RLP for MPT key
+     * @param _txIndex The transaction index
+     * @return RLP encoded key
+     */
+    function encodeTxIndexAsKey(
+        uint16 _txIndex
+    ) internal pure returns (bytes memory) {
+        if (_txIndex == 0) {
+            return hex"80"; // RLP encoding of empty string (0)
+        } else if (_txIndex < 128) {
+            return abi.encodePacked(uint8(_txIndex));
+        } else if (_txIndex < 256) {
+            return abi.encodePacked(uint8(0x81), uint8(_txIndex));
+        } else {
+            return abi.encodePacked(uint8(0x82), uint16(_txIndex));
+        }
+    }
+}

--- a/solidity/contracts/libs/MerklePatriciaTrie.sol
+++ b/solidity/contracts/libs/MerklePatriciaTrie.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+import {RLPReader} from "./RLPReader.sol";
+
+/**
+ * @title MerklePatriciaTrie
+ * @notice Verifies Merkle Patricia Trie proofs for Ethereum state/receipt verification
+ * @dev Implements verification against receiptsRoot for receipt proofs
+ */
+library MerklePatriciaTrie {
+    // Node types in MPT
+    uint8 private constant BRANCH_NODE_LENGTH = 17;
+    uint8 private constant LEAF_OR_EXTENSION_MIN_LENGTH = 2;
+
+    /**
+     * @notice Verifies an MPT proof and returns the value
+     * @param _root The expected root hash
+     * @param _key The key (RLP encoded transaction index for receipts)
+     * @param _proof Array of RLP encoded proof nodes
+     * @return value The verified value (RLP encoded receipt)
+     */
+    function verifyProof(
+        bytes32 _root,
+        bytes memory _key,
+        bytes[] memory _proof
+    ) internal pure returns (bytes memory value) {
+        require(_proof.length > 0, "MPT: empty proof");
+
+        bytes32 expectedHash = _root;
+        bytes memory keyNibbles = _toNibbles(_key);
+        uint256 keyIndex = 0;
+
+        for (uint256 i = 0; i < _proof.length; i++) {
+            bytes memory node = _proof[i];
+
+            // Verify node hash matches expected
+            require(
+                keccak256(node) == expectedHash,
+                "MPT: invalid proof node hash"
+            );
+
+            bytes[] memory nodeItems = RLPReader.decodeList(node);
+
+            if (nodeItems.length == BRANCH_NODE_LENGTH) {
+                if (keyIndex >= keyNibbles.length) {
+                    return RLPReader.toBytes(nodeItems[16]);
+                }
+
+                uint8 nibble = uint8(keyNibbles[keyIndex]);
+                require(nibble < 16, "MPT: invalid nibble");
+
+                bytes memory nextNode = nodeItems[nibble];
+                if (nextNode.length == 0) {
+                    revert("MPT: empty branch child");
+                }
+
+                if (nextNode.length < 32) {
+                    expectedHash = keccak256(nextNode);
+                } else {
+                    expectedHash = bytes32(RLPReader.toBytes(nextNode));
+                }
+                keyIndex++;
+            } else if (nodeItems.length >= LEAF_OR_EXTENSION_MIN_LENGTH) {
+                bytes memory encodedPath = RLPReader.toBytes(nodeItems[0]);
+                (uint8 prefix, bytes memory path) = _parsePath(encodedPath);
+
+                bool isLeaf = (prefix == 2 || prefix == 3);
+                uint256 pathLen = path.length;
+                require(
+                    keyIndex + pathLen <= keyNibbles.length,
+                    "MPT: key too short"
+                );
+
+                for (uint256 j = 0; j < pathLen; j++) {
+                    require(
+                        keyNibbles[keyIndex + j] == path[j],
+                        "MPT: path mismatch"
+                    );
+                }
+                keyIndex += pathLen;
+
+                if (isLeaf) {
+                    require(
+                        keyIndex == keyNibbles.length,
+                        "MPT: key not exhausted at leaf"
+                    );
+                    return RLPReader.toBytes(nodeItems[1]);
+                } else {
+                    bytes memory nextNode = nodeItems[1];
+                    if (nextNode.length < 32) {
+                        expectedHash = keccak256(nextNode);
+                    } else {
+                        expectedHash = bytes32(RLPReader.toBytes(nextNode));
+                    }
+                }
+            } else {
+                revert("MPT: invalid node length");
+            }
+        }
+
+        revert("MPT: proof incomplete");
+    }
+
+    /**
+     * @notice Converts bytes to nibbles (4-bit units)
+     * @param _data Input bytes
+     * @return nibbles Array of nibbles
+     */
+    function _toNibbles(
+        bytes memory _data
+    ) private pure returns (bytes memory nibbles) {
+        nibbles = new bytes(_data.length * 2);
+        for (uint256 i = 0; i < _data.length; i++) {
+            nibbles[i * 2] = bytes1(uint8(_data[i]) >> 4);
+            nibbles[i * 2 + 1] = bytes1(uint8(_data[i]) & 0x0f);
+        }
+    }
+
+    /**
+     * @notice Parses HP-encoded path from node
+     * @param _encodedPath The HP-encoded path
+     * @return prefix The prefix (0=ext-even, 1=ext-odd, 2=leaf-even, 3=leaf-odd)
+     * @return path The decoded nibble path
+     */
+    function _parsePath(
+        bytes memory _encodedPath
+    ) private pure returns (uint8 prefix, bytes memory path) {
+        require(_encodedPath.length > 0, "MPT: empty path");
+
+        uint8 firstByte = uint8(_encodedPath[0]);
+        prefix = firstByte >> 4;
+
+        bool isOdd = (prefix == 1 || prefix == 3);
+
+        if (isOdd) {
+            path = new bytes(_encodedPath.length * 2 - 1);
+            path[0] = bytes1(firstByte & 0x0f);
+            for (uint256 i = 1; i < _encodedPath.length; i++) {
+                path[i * 2 - 1] = bytes1(uint8(_encodedPath[i]) >> 4);
+                path[i * 2] = bytes1(uint8(_encodedPath[i]) & 0x0f);
+            }
+        } else {
+            path = new bytes((_encodedPath.length - 1) * 2);
+            for (uint256 i = 1; i < _encodedPath.length; i++) {
+                path[(i - 1) * 2] = bytes1(uint8(_encodedPath[i]) >> 4);
+                path[(i - 1) * 2 + 1] = bytes1(uint8(_encodedPath[i]) & 0x0f);
+            }
+        }
+    }
+}

--- a/solidity/contracts/libs/RLPReader.sol
+++ b/solidity/contracts/libs/RLPReader.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/**
+ * @title RLPReader
+ * @notice Minimal RLP decoding library for block headers and receipts
+ * @dev Based on https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
+ */
+library RLPReader {
+    /**
+     * @notice Decodes an RLP item and returns offset and length
+     * @param _data The RLP encoded data
+     * @param _offset Starting offset in data
+     * @return dataOffset Offset where actual data starts
+     * @return dataLen Length of the data
+     * @return consumed Total bytes consumed (header + data)
+     */
+    function decodeItemOffset(
+        bytes memory _data,
+        uint256 _offset
+    ) internal pure returns (uint256 dataOffset, uint256 dataLen, uint256 consumed) {
+        require(_offset < _data.length, "RLP: offset OOB");
+
+        uint8 prefix = uint8(_data[_offset]);
+
+        if (prefix <= 0x7f) {
+            return (_offset, 1, 1);
+        } else if (prefix <= 0xb7) {
+            uint256 strLen = prefix - 0x80;
+            return (_offset + 1, strLen, 1 + strLen);
+        } else if (prefix <= 0xbf) {
+            uint256 lenBytes = prefix - 0xb7;
+            uint256 strLen = _decodeLength(_data, _offset + 1, lenBytes);
+            return (_offset + 1 + lenBytes, strLen, 1 + lenBytes + strLen);
+        } else if (prefix <= 0xf7) {
+            uint256 listLen = prefix - 0xc0;
+            return (_offset + 1, listLen, 1 + listLen);
+        } else {
+            uint256 lenBytes = prefix - 0xf7;
+            uint256 listLen = _decodeLength(_data, _offset + 1, lenBytes);
+            return (_offset + 1 + lenBytes, listLen, 1 + lenBytes + listLen);
+        }
+    }
+
+    /**
+     * @notice Decodes a list and returns array of items
+     * @param _data RLP encoded list
+     * @return items Array of RLP items as bytes
+     */
+    function decodeList(
+        bytes memory _data
+    ) internal pure returns (bytes[] memory items) {
+        return decodeListAt(_data, 0);
+    }
+
+    /**
+     * @notice Decodes a list starting at offset
+     * @param _data RLP encoded data
+     * @param _offset Starting offset
+     * @return items Array of RLP items as bytes
+     */
+    function decodeListAt(
+        bytes memory _data,
+        uint256 _offset
+    ) internal pure returns (bytes[] memory items) {
+        (uint256 listDataOffset, uint256 listDataLen, ) = decodeItemOffset(_data, _offset);
+
+        // First pass: count items
+        uint256 count = 0;
+        uint256 pos = listDataOffset;
+        uint256 listEnd = listDataOffset + listDataLen;
+
+        while (pos < listEnd) {
+            (, , uint256 consumed) = decodeItemOffset(_data, pos);
+            pos += consumed;
+            count++;
+        }
+
+        // Second pass: extract items
+        items = new bytes[](count);
+        pos = listDataOffset;
+
+        for (uint256 i = 0; i < count; i++) {
+            (, , uint256 consumed) = decodeItemOffset(_data, pos);
+            items[i] = _slice(_data, pos, consumed);
+            pos += consumed;
+        }
+    }
+
+    /**
+     * @notice Extracts the receiptsRoot from an RLP encoded block header
+     * @dev receiptsRoot is at index 5 in the header list
+     * @param _header RLP encoded block header
+     * @return receiptsRoot The receipts root hash
+     */
+    function extractReceiptsRoot(
+        bytes calldata _header
+    ) internal pure returns (bytes32 receiptsRoot) {
+        bytes memory headerMem = _header;
+        bytes[] memory items = decodeList(headerMem);
+        require(items.length >= 6, "RLP: invalid header length");
+
+        bytes memory rootItem = items[5];
+        bytes memory rootData = toBytes(rootItem);
+        require(rootData.length == 32, "RLP: invalid receiptsRoot length");
+
+        assembly {
+            receiptsRoot := mload(add(rootData, 32))
+        }
+    }
+
+    /**
+     * @notice Decodes raw bytes from an RLP item
+     * @param _item RLP encoded item
+     * @return The decoded bytes
+     */
+    function toBytes(
+        bytes memory _item
+    ) internal pure returns (bytes memory) {
+        if (_item.length == 0) return "";
+
+        uint8 prefix = uint8(_item[0]);
+
+        if (prefix <= 0x7f) {
+            bytes memory result = new bytes(1);
+            result[0] = _item[0];
+            return result;
+        } else if (prefix <= 0xb7) {
+            uint256 strLen = prefix - 0x80;
+            return _slice(_item, 1, strLen);
+        } else if (prefix <= 0xbf) {
+            uint256 lenBytes = prefix - 0xb7;
+            uint256 strLen = _decodeLength(_item, 1, lenBytes);
+            return _slice(_item, 1 + lenBytes, strLen);
+        }
+
+        revert("RLP: not a string");
+    }
+
+    /**
+     * @notice Decodes an address from an RLP item
+     * @param _item RLP encoded item
+     * @return The decoded address
+     */
+    function toAddress(bytes memory _item) internal pure returns (address) {
+        bytes memory data = toBytes(_item);
+        require(data.length == 20, "RLP: invalid address length");
+
+        address result;
+        assembly {
+            result := mload(add(data, 20))
+        }
+        return result;
+    }
+
+    /**
+     * @notice Decodes length from big-endian bytes at offset
+     */
+    function _decodeLength(
+        bytes memory _data,
+        uint256 _offset,
+        uint256 _lenBytes
+    ) private pure returns (uint256 length) {
+        require(_offset + _lenBytes <= _data.length, "RLP: length OOB");
+        for (uint256 i = 0; i < _lenBytes; i++) {
+            length = (length << 8) | uint8(_data[_offset + i]);
+        }
+    }
+
+    /**
+     * @notice Slices bytes from memory
+     */
+    function _slice(
+        bytes memory _data,
+        uint256 _start,
+        uint256 _length
+    ) private pure returns (bytes memory result) {
+        require(_start + _length <= _data.length, "RLP: slice OOB");
+        result = new bytes(_length);
+        for (uint256 i = 0; i < _length; i++) {
+            result[i] = _data[_start + i];
+        }
+    }
+}

--- a/solidity/test/isms/BlockHashIsm.t.sol
+++ b/solidity/test/isms/BlockHashIsm.t.sol
@@ -1,0 +1,482 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import {BlockHashIsm} from "../../contracts/isms/blockhash/BlockHashIsm.sol";
+import {IBlockHashOracle} from "../../contracts/interfaces/IBlockHashOracle.sol";
+import {IInterchainSecurityModule} from "../../contracts/interfaces/IInterchainSecurityModule.sol";
+import {Message} from "../../contracts/libs/Message.sol";
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+import {RLPReader} from "../../contracts/libs/RLPReader.sol";
+import {MerklePatriciaTrie} from "../../contracts/libs/MerklePatriciaTrie.sol";
+import {BlockHashIsmMetadata} from "../../contracts/isms/libs/BlockHashIsmMetadata.sol";
+
+contract MockBlockHashOracle is IBlockHashOracle {
+    uint32 public immutable origin;
+    mapping(uint256 => bytes32) public blockHashes;
+
+    constructor(uint32 _origin) {
+        origin = _origin;
+    }
+
+    function setBlockHash(uint256 _height, bytes32 _hash) external {
+        blockHashes[_height] = _hash;
+    }
+
+    function blockHash(uint256 _height) external view returns (bytes32) {
+        return blockHashes[_height];
+    }
+}
+
+// Test harness to wrap calldata functions
+contract MetadataHarness {
+    function blockNumber(bytes calldata _metadata) external pure returns (uint64) {
+        return BlockHashIsmMetadata.blockNumber(_metadata);
+    }
+
+    function txIndex(bytes calldata _metadata) external pure returns (uint16) {
+        return BlockHashIsmMetadata.txIndex(_metadata);
+    }
+
+    function logIndex(bytes calldata _metadata) external pure returns (uint8) {
+        return BlockHashIsmMetadata.logIndex(_metadata);
+    }
+
+    function proofNodes(bytes calldata _metadata) external pure returns (bytes[] memory) {
+        return BlockHashIsmMetadata.proofNodes(_metadata);
+    }
+}
+
+contract RLPHarness {
+    function extractReceiptsRoot(bytes calldata _header) external pure returns (bytes32) {
+        return RLPReader.extractReceiptsRoot(_header);
+    }
+}
+
+// Wrapper to convert memory to calldata for Message.formatMessage
+contract MessageHarness {
+    function formatMessage(
+        uint8 _version,
+        uint32 _nonce,
+        uint32 _originDomain,
+        bytes32 _sender,
+        uint32 _destinationDomain,
+        bytes32 _recipient,
+        bytes calldata _messageBody
+    ) external pure returns (bytes memory) {
+        return Message.formatMessage(
+            _version,
+            _nonce,
+            _originDomain,
+            _sender,
+            _destinationDomain,
+            _recipient,
+            _messageBody
+        );
+    }
+}
+
+contract BlockHashIsmTest is Test {
+    using TypeCasts for address;
+    using Message for bytes;
+
+    BlockHashIsm public ism;
+    MockBlockHashOracle public oracle;
+    MetadataHarness public metadataHarness;
+    RLPHarness public rlpHarness;
+    MessageHarness public messageHarness;
+
+    uint32 constant ORIGIN_DOMAIN = 1;
+    uint32 constant DEST_DOMAIN = 2;
+    address constant ORIGIN_MAILBOX = address(0x1234567890123456789012345678901234567890);
+    address constant SENDER = address(0x5eeD5EED5eeD5EEd5eed5eEd5eEd5eed5EeD5EEd);
+    address constant RECIPIENT = address(0xBEeFbeefbEefbeEFbeEfbEEfBEeFbeEfBeEfBeef);
+
+    function setUp() public {
+        oracle = new MockBlockHashOracle(ORIGIN_DOMAIN);
+        ism = new BlockHashIsm(oracle, ORIGIN_MAILBOX);
+        metadataHarness = new MetadataHarness();
+        rlpHarness = new RLPHarness();
+        messageHarness = new MessageHarness();
+    }
+
+    // ============ Constructor Tests ============
+
+    function test_constructor_setsImmutables() public view {
+        assertEq(address(ism.oracle()), address(oracle));
+        assertEq(ism.originMailbox(), ORIGIN_MAILBOX);
+        assertEq(ism.origin(), ORIGIN_DOMAIN);
+    }
+
+    function test_constructor_revertsOnZeroOracle() public {
+        vm.expectRevert("BlockHashIsm: zero oracle");
+        new BlockHashIsm(IBlockHashOracle(address(0)), ORIGIN_MAILBOX);
+    }
+
+    function test_constructor_revertsOnZeroMailbox() public {
+        vm.expectRevert("BlockHashIsm: zero mailbox");
+        new BlockHashIsm(oracle, address(0));
+    }
+
+    function test_moduleType() public view {
+        assertEq(ism.moduleType(), uint8(IInterchainSecurityModule.Types.NULL));
+    }
+
+    // ============ Origin Check Tests ============
+
+    function test_verify_revertsOnWrongOrigin() public {
+        bytes memory message = _createMessage(DEST_DOMAIN); // Wrong origin
+        bytes memory metadata = _createEmptyMetadata();
+
+        vm.expectRevert("BlockHashIsm: wrong origin");
+        ism.verify(metadata, message);
+    }
+
+    // ============ Block Hash Tests ============
+
+    function test_verify_revertsOnBlockNotFound() public {
+        bytes memory message = _createMessage(ORIGIN_DOMAIN);
+        bytes memory metadata = _createMetadataWithBlockNumber(12345);
+
+        // Oracle returns 0 (block not found)
+        vm.expectRevert("BlockHashIsm: block not found");
+        ism.verify(metadata, message);
+    }
+
+    function test_verify_revertsOnInvalidBlockHeader() public {
+        bytes memory message = _createMessage(ORIGIN_DOMAIN);
+
+        // Set a block hash in oracle
+        uint64 blockNum = 12345;
+        bytes32 fakeBlockHash = keccak256("fake block");
+        oracle.setBlockHash(blockNum, fakeBlockHash);
+
+        // Create metadata with invalid header (won't hash to fakeBlockHash)
+        bytes memory metadata = _createMetadataWithHeader(blockNum, hex"c0"); // Empty RLP list
+
+        vm.expectRevert("BlockHashIsm: invalid block header");
+        ism.verify(metadata, message);
+    }
+
+    // ============ RLP Reader Unit Tests ============
+
+    function test_rlpReader_decodeShortString() public pure {
+        // "dog" = 0x83 'd' 'o' 'g'
+        bytes memory data = hex"83646f67";
+        bytes memory decoded = RLPReader.toBytes(data);
+        assertEq(decoded, bytes("dog"));
+    }
+
+    function test_rlpReader_decodeEmptyString() public pure {
+        bytes memory data = hex"80";
+        bytes memory decoded = RLPReader.toBytes(data);
+        assertEq(decoded.length, 0);
+    }
+
+    function test_rlpReader_decodeSingleByte() public pure {
+        bytes memory data = hex"61"; // 'a'
+        bytes memory decoded = RLPReader.toBytes(data);
+        assertEq(decoded, bytes("a"));
+    }
+
+    function test_rlpReader_decodeList() public pure {
+        // ["cat", "dog"] = 0xc8 0x83 'c' 'a' 't' 0x83 'd' 'o' 'g'
+        bytes memory data = hex"c88363617483646f67";
+        bytes[] memory items = RLPReader.decodeList(data);
+        assertEq(items.length, 2);
+    }
+
+    // ============ Metadata Encoding Tests ============
+
+    function test_metadata_blockNumber() public view {
+        bytes memory metadata = _createMetadataWithBlockNumber(0x123456789ABCDEF0);
+        assertEq(metadataHarness.blockNumber(metadata), 0x123456789ABCDEF0);
+    }
+
+    function test_metadata_txIndexEncoding() public pure {
+        // 0 encodes as 0x80
+        assertEq(BlockHashIsmMetadata.encodeTxIndexAsKey(0), hex"80");
+
+        // 1-127 encode as single byte
+        assertEq(BlockHashIsmMetadata.encodeTxIndexAsKey(1), hex"01");
+        assertEq(BlockHashIsmMetadata.encodeTxIndexAsKey(127), hex"7f");
+
+        // 128-255 encode as 0x81 + byte
+        assertEq(BlockHashIsmMetadata.encodeTxIndexAsKey(128), hex"8180");
+        assertEq(BlockHashIsmMetadata.encodeTxIndexAsKey(255), hex"81ff");
+
+        // 256+ encode as 0x82 + 2 bytes
+        assertEq(BlockHashIsmMetadata.encodeTxIndexAsKey(256), hex"820100");
+    }
+
+    // ============ DISPATCH_ID_TOPIC Tests ============
+
+    function test_dispatchIdTopic() public view {
+        bytes32 expected = keccak256("DispatchId(bytes32)");
+        assertEq(ism.DISPATCH_ID_TOPIC(), expected);
+    }
+
+    // ============ MPT Proof Tests ============
+
+    function test_mpt_singleLeafProof() public pure {
+        // Construct a simple trie with one leaf node
+        // Key: empty, Value: "test" (RLP encoded in the node)
+        bytes memory valueRlp = hex"8474657374"; // RLP of "test"
+
+        // Leaf node: [0x20 prefix (leaf, even, empty remaining path), value]
+        // HP encoding: 0x20 = leaf flag (0x2_) + even flag (_0) + no nibbles
+        bytes memory leafNode = _rlpEncodeList2(hex"20", valueRlp);
+
+        bytes32 root = keccak256(leafNode);
+        bytes[] memory proof = new bytes[](1);
+        proof[0] = leafNode;
+
+        // Empty key → nibbles is empty → should match leaf with empty path
+        // MPT returns the RLP-decoded value
+        bytes memory result = MerklePatriciaTrie.verifyProof(root, hex"", proof);
+        assertEq(result, bytes("test"));
+    }
+
+    function test_mpt_revertsOnEmptyProof() public {
+        bytes[] memory emptyProof = new bytes[](0);
+
+        vm.expectRevert("MPT: empty proof");
+        MerklePatriciaTrie.verifyProof(bytes32(0), hex"00", emptyProof);
+    }
+
+    function test_mpt_revertsOnHashMismatch() public {
+        bytes memory leafNode = hex"c28020"; // Simple leaf
+        bytes32 wrongRoot = keccak256("wrong");
+
+        bytes[] memory proof = new bytes[](1);
+        proof[0] = leafNode;
+
+        vm.expectRevert("MPT: invalid proof node hash");
+        MerklePatriciaTrie.verifyProof(wrongRoot, hex"80", proof);
+    }
+
+    // ============ Receipt Parsing Tests ============
+
+    function test_rlpReader_extractReceiptsRoot() public view {
+        // Minimal block header with 6 items, receiptsRoot at index 5
+        bytes32 expectedRoot = keccak256("receiptsRoot");
+        bytes memory rootRlp = abi.encodePacked(uint8(0xa0), expectedRoot); // 0xa0 = 32-byte string
+
+        // Build header: [item0, item1, item2, item3, item4, receiptsRoot]
+        bytes memory header = _buildMinimalHeader(rootRlp);
+
+        bytes32 extracted = rlpHarness.extractReceiptsRoot(header);
+        assertEq(extracted, expectedRoot);
+    }
+
+    function test_rlpReader_toAddress() public pure {
+        address expected = address(0x1234567890123456789012345678901234567890);
+        // RLP encode: 0x94 + 20 bytes (0x94 = 0x80 + 20)
+        bytes memory rlpAddr = abi.encodePacked(uint8(0x94), expected);
+
+        address decoded = RLPReader.toAddress(rlpAddr);
+        assertEq(decoded, expected);
+    }
+
+    function test_rlpReader_revertsOnInvalidAddressLength() public {
+        // 19 bytes instead of 20 (0x93 = 0x80 + 19, then 19 bytes of data)
+        bytes memory badAddr = hex"9312345678901234567890123456789012345678"; // 0x93 + 19 bytes
+
+        vm.expectRevert("RLP: invalid address length");
+        RLPReader.toAddress(badAddr);
+    }
+
+    // ============ Metadata Proof Parsing Tests ============
+
+    function test_metadata_proofNodes() public view {
+        bytes memory node1 = hex"aabbcc";
+        bytes memory node2 = hex"ddeeff0011";
+
+        bytes memory proofData = abi.encodePacked(
+            uint16(node1.length), node1,
+            uint16(node2.length), node2
+        );
+
+        bytes memory metadata = abi.encodePacked(
+            uint64(1),           // block number
+            uint16(1),           // header length
+            hex"c0",             // minimal header
+            uint16(0),           // tx index
+            uint8(0),            // log index
+            proofData            // proof nodes
+        );
+
+        bytes[] memory nodes = metadataHarness.proofNodes(metadata);
+        assertEq(nodes.length, 2);
+        assertEq(nodes[0], node1);
+        assertEq(nodes[1], node2);
+    }
+
+    function test_metadata_emptyProofNodes() public view {
+        bytes memory metadata = abi.encodePacked(
+            uint64(1),
+            uint16(1),
+            hex"c0",
+            uint16(0),
+            uint8(0)
+            // no proof nodes
+        );
+
+        bytes[] memory nodes = metadataHarness.proofNodes(metadata);
+        assertEq(nodes.length, 0);
+    }
+
+    // ============ Helper Functions ============
+
+    function _rlpEncodeList2(bytes memory a, bytes memory b) internal pure returns (bytes memory) {
+        uint256 totalLen = a.length + b.length;
+        if (totalLen < 56) {
+            return abi.encodePacked(uint8(0xc0 + totalLen), a, b);
+        }
+        revert("List too long for test helper");
+    }
+
+    function _buildMinimalHeader(bytes memory receiptsRoot) internal pure returns (bytes memory) {
+        // 6 empty items + receiptsRoot at index 5
+        bytes memory empty = hex"80"; // RLP empty string
+        bytes memory items = abi.encodePacked(
+            empty, empty, empty, empty, empty, receiptsRoot
+        );
+        uint256 len = items.length;
+        if (len < 56) {
+            return abi.encodePacked(uint8(0xc0 + len), items);
+        }
+        // Long list encoding
+        return abi.encodePacked(uint8(0xf7 + 1), uint8(len), items);
+    }
+
+    function _createMessage(uint32 _origin) internal view returns (bytes memory) {
+        return messageHarness.formatMessage(
+            uint8(3), // version
+            uint32(1), // nonce
+            _origin,
+            TypeCasts.addressToBytes32(SENDER),
+            DEST_DOMAIN,
+            TypeCasts.addressToBytes32(RECIPIENT),
+            hex"74657374206d65737361676520626f6479" // "test message body"
+        );
+    }
+
+    function _createEmptyMetadata() internal pure returns (bytes memory) {
+        return _createMetadataWithBlockNumber(0);
+    }
+
+    function _createMetadataWithBlockNumber(
+        uint64 _blockNum
+    ) internal pure returns (bytes memory) {
+        // Minimal metadata: blockNumber (8) + headerLen (2) + header (0) + txIndex (2) + logIndex (1)
+        return abi.encodePacked(
+            _blockNum,      // 8 bytes
+            uint16(0),      // header length
+            uint16(0),      // tx index
+            uint8(0)        // log index
+        );
+    }
+
+    function _createMetadataWithHeader(
+        uint64 _blockNum,
+        bytes memory _header
+    ) internal pure returns (bytes memory) {
+        return abi.encodePacked(
+            _blockNum,
+            uint16(_header.length),
+            _header,
+            uint16(0),      // tx index
+            uint8(0)        // log index
+        );
+    }
+}
+
+// ============ Fuzz Tests ============
+
+contract BlockHashIsmFuzzTest is Test {
+    using TypeCasts for address;
+    using Message for bytes;
+
+    MockBlockHashOracle public oracle;
+    BlockHashIsm public ism;
+    MetadataHarness public metadataHarness;
+
+    uint32 constant ORIGIN_DOMAIN = 1;
+    address constant ORIGIN_MAILBOX = address(0x1234567890123456789012345678901234567890);
+
+    function setUp() public {
+        oracle = new MockBlockHashOracle(ORIGIN_DOMAIN);
+        ism = new BlockHashIsm(oracle, ORIGIN_MAILBOX);
+        metadataHarness = new MetadataHarness();
+    }
+
+    function testFuzz_verify_alwaysRevertsOnWrongOrigin(
+        uint32 _wrongOrigin,
+        uint32 _nonce,
+        bytes32 _sender,
+        bytes32 _recipient,
+        bytes calldata _body
+    ) public {
+        vm.assume(_wrongOrigin != ORIGIN_DOMAIN);
+        vm.assume(_body.length < 1000); // Reasonable size
+
+        bytes memory message = Message.formatMessage(
+            uint8(3),
+            _nonce,
+            _wrongOrigin,
+            _sender,
+            uint32(2),
+            _recipient,
+            _body
+        );
+
+        bytes memory metadata = abi.encodePacked(
+            uint64(1),
+            uint16(0),
+            uint16(0),
+            uint8(0)
+        );
+
+        vm.expectRevert("BlockHashIsm: wrong origin");
+        ism.verify(metadata, message);
+    }
+
+    function testFuzz_metadata_blockNumber(uint64 _blockNum) public view {
+        bytes memory metadata = abi.encodePacked(
+            _blockNum,
+            uint16(0),
+            uint16(0),
+            uint8(0)
+        );
+
+        assertEq(metadataHarness.blockNumber(metadata), _blockNum);
+    }
+
+    function testFuzz_metadata_txIndex(uint16 _txIndex) public view {
+        bytes memory header = hex"c0"; // Empty RLP list
+        bytes memory metadata = abi.encodePacked(
+            uint64(1),
+            uint16(header.length),
+            header,
+            _txIndex,
+            uint8(0)
+        );
+
+        assertEq(metadataHarness.txIndex(metadata), _txIndex);
+    }
+
+    function testFuzz_metadata_logIndex(uint8 _logIndex) public view {
+        bytes memory header = hex"c0";
+        bytes memory metadata = abi.encodePacked(
+            uint64(1),
+            uint16(header.length),
+            header,
+            uint16(0),
+            _logIndex
+        );
+
+        assertEq(metadataHarness.logIndex(metadata), _logIndex);
+    }
+}


### PR DESCRIPTION
Implements an ISM that verifies Hyperlane messages by proving inclusion of DispatchId events in Ethereum block receipts. Uses a trusted block hash oracle to anchor verification.

New contracts:
- BlockHashIsm: Main ISM verifying receipt proofs against oracle
- IBlockHashOracle: Interface for block hash oracles
- BlockHashIsmMetadata: Packed metadata parsing library
- RLPReader: Minimal RLP decoding for headers and receipts
- MerklePatriciaTrie: MPT proof verification

### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced block hash oracle-based interchain security module enabling secure message verification through cryptographic block hash and Merkle proof validation.

* **Tests**
  * Added comprehensive test suite with unit tests, end-to-end verification scenarios, and fuzz tests for the security module and supporting cryptographic utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->