### PR TITLE
feat(warp): add PredicateRouterWrapper for compliance-gated transfers

### DIFF
--- a/solidity/contracts/token/extensions/PredicateRouterWrapper.sol
+++ b/solidity/contracts/token/extensions/PredicateRouterWrapper.sol
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+// ============ Internal Imports ============
+import {AbstractPostDispatchHook} from "../../hooks/libs/AbstractPostDispatchHook.sol";
+import {IPostDispatchHook} from "../../interfaces/hooks/IPostDispatchHook.sol";
+import {TokenRouter} from "../libs/TokenRouter.sol";
+
+// ============ Predicate Imports ============
+import {Attestation} from "@predicate/interfaces/IPredicateRegistry.sol";
+import {PredicateClient} from "@predicate/mixins/PredicateClient.sol";
+
+// ============ External Imports ============
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title PredicateRouterWrapper
+ * @author Abacus Works
+ * @notice Wraps an existing TokenRouter with Predicate attestation validation.
+ *         Acts as BOTH a user entry point AND a post-dispatch hook.
+ * @dev Security model:
+ *      1. User calls transferRemoteWithAttestation() on this wrapper
+ *      2. Wrapper validates attestation via PredicateClient, sets pendingAttestation = true
+ *      3. Wrapper calls warpRoute.transferRemote()
+ *      4. WarpRoute dispatches message, mailbox calls this contract's postDispatch()
+ *      5. postDispatch() verifies pendingAttestation == true, then clears it
+ *
+ *      If someone bypasses wrapper and calls warpRoute directly, postDispatch()
+ *      will revert because pendingAttestation will be false.
+ *
+ * Usage:
+ *      1. Deploy PredicateRouterWrapper pointing to existing warp route
+ *      2. Set PredicateRouterWrapper as the hook on the warp route: warpRoute.setHook(predicateWrapper)
+ *      3. Optionally aggregate with default hook for IGP using StaticAggregationHook
+ *      4. Users call predicateWrapper.transferRemoteWithAttestation() instead of warpRoute.transferRemote()
+ *
+ * @custom:oz-version 4.9.x (uses Ownable without constructor argument)
+ */
+contract PredicateRouterWrapper is AbstractPostDispatchHook, PredicateClient, Ownable {
+    using SafeERC20 for IERC20;
+
+    // ============ Constants ============
+
+    /// @notice Hook type identifier (UNUSED as this is a custom hook)
+    uint8 public constant override hookType =
+        uint8(IPostDispatchHook.HookTypes.UNUSED);
+
+    // ============ Immutables ============
+
+    /// @notice The underlying TokenRouter (warp route) being wrapped
+    TokenRouter public immutable warpRoute;
+
+    /// @notice The ERC20 token managed by the warp route
+    IERC20 public immutable token;
+
+    // ============ Storage ============
+
+    /// @notice Flag set during transferRemoteWithAttestation, checked in postDispatch
+    /// @dev This is the key bypass prevention mechanism
+    bool public pendingAttestation;
+
+    // ============ Errors ============
+
+    /// @notice Thrown when a transfer bypasses the wrapper (pendingAttestation is false)
+    error PredicateRouterWrapper__UnauthorizedTransfer();
+
+    /// @notice Thrown when attestation validation fails
+    error PredicateRouterWrapper__AttestationInvalid();
+
+    /// @notice Thrown when registry address is zero
+    error PredicateRouterWrapper__InvalidRegistry();
+
+    /// @notice Thrown when policy ID is empty
+    error PredicateRouterWrapper__InvalidPolicy();
+
+    // ============ Events ============
+
+    /// @notice Emitted when a transfer is authorized via attestation
+    event TransferAuthorized(
+        address indexed sender,
+        uint32 indexed destination,
+        bytes32 indexed recipient,
+        uint256 amount,
+        string uuid
+    );
+
+    // ============ Constructor ============
+
+    /**
+     * @notice Initializes the PredicateRouterWrapper
+     * @dev Deployer becomes owner. Use transferOwnership() to change owner after deployment.
+     * @param _warpRoute The underlying TokenRouter to wrap
+     * @param _token The ERC20 token address (use warpRoute.token() for collateral routes)
+     * @param _registry The Predicate registry address
+     * @param _policyID The policy ID for attestation validation
+     */
+    constructor(
+        address _warpRoute,
+        address _token,
+        address _registry,
+        string memory _policyID
+    ) {
+        if (_registry == address(0))
+            revert PredicateRouterWrapper__InvalidRegistry();
+        if (bytes(_policyID).length == 0)
+            revert PredicateRouterWrapper__InvalidPolicy();
+
+        warpRoute = TokenRouter(_warpRoute);
+        token = IERC20(_token);
+
+        // Initialize PredicateClient (handles registry, policy storage and registration)
+        _initPredicateClient(_registry, _policyID);
+
+        // Infinite approval to warp route - wrapper never holds tokens
+        token.forceApprove(_warpRoute, type(uint256).max);
+    }
+
+    // ============ External Functions ============
+
+    /**
+     * @notice Transfer tokens with Predicate attestation validation
+     * @dev This is the main entry point for compliance-gated transfers.
+     *      The attestation must be signed by a registered attester for this contract's policy.
+     * @param _attestation The Predicate attestation proving compliance
+     * @param _destination The destination chain domain
+     * @param _recipient The recipient address on destination (as bytes32)
+     * @param _amount The amount of tokens to transfer
+     * @return messageId The Hyperlane message ID
+     */
+    function transferRemoteWithAttestation(
+        Attestation calldata _attestation,
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _amount
+    ) external payable returns (bytes32 messageId) {
+        // 1. Build encoded signature for Predicate validation (full PredicateClient pattern)
+        bytes memory encodedSigAndArgs = abi.encodeWithSignature(
+            "transferRemote(uint32,bytes32,uint256)",
+            _destination,
+            _recipient,
+            _amount
+        );
+
+        // 2. Validate with Predicate (reverts if invalid)
+        bool isValid = _authorizeTransaction(
+            _attestation,
+            encodedSigAndArgs,
+            msg.sender,
+            msg.value
+        );
+        if (!isValid) revert PredicateRouterWrapper__AttestationInvalid();
+
+        emit TransferAuthorized(
+            msg.sender,
+            _destination,
+            _recipient,
+            _amount,
+            _attestation.uuid
+        );
+
+        // 3. Set flag BEFORE calling warpRoute (checked in postDispatch)
+        pendingAttestation = true;
+
+        // 4. Pull tokens from user (warp route already has infinite approval from constructor)
+        token.safeTransferFrom(msg.sender, address(this), _amount);
+
+        // 5. Call warp route - this will trigger postDispatch via mailbox
+        messageId = warpRoute.transferRemote{value: msg.value}(
+            _destination,
+            _recipient,
+            _amount
+        );
+
+        // Note: pendingAttestation is cleared in _postDispatch()
+        // If we reach here, the transfer succeeded
+        return messageId;
+    }
+
+    // ============ Hook Implementation ============
+
+    /**
+     * @notice Called by mailbox after dispatch - verifies transfer came from wrapper
+     * @dev Reverts if pendingAttestation is false, meaning someone bypassed the wrapper
+     */
+    function _postDispatch(bytes calldata, bytes calldata) internal override {
+        // Check that this transfer originated from transferRemoteWithAttestation
+        if (!pendingAttestation) {
+            revert PredicateRouterWrapper__UnauthorizedTransfer();
+        }
+
+        // Clear the flag
+        pendingAttestation = false;
+    }
+
+    /**
+     * @notice Quote returns 0 - this hook has no fee
+     * @dev The actual gas fees are paid through the warp route's IGP hook
+     */
+    function _quoteDispatch(
+        bytes calldata,
+        bytes calldata
+    ) internal pure override returns (uint256) {
+        return 0;
+    }
+
+    // ============ IPredicateClient Implementation ============
+
+    /**
+     * @notice Updates the policy ID
+     * @dev Implements IPredicateClient.setPolicyID
+     * @param _policyID The new policy ID
+     */
+    function setPolicyID(string memory _policyID) external onlyOwner {
+        if (bytes(_policyID).length == 0)
+            revert PredicateRouterWrapper__InvalidPolicy();
+
+        _setPolicyID(_policyID);
+    }
+
+    /**
+     * @notice Updates the Predicate registry address
+     * @dev Implements IPredicateClient.setRegistry
+     * @param _registry The new registry address
+     */
+    function setRegistry(address _registry) external onlyOwner {
+        if (_registry == address(0))
+            revert PredicateRouterWrapper__InvalidRegistry();
+
+        _setRegistry(_registry);
+    }
+
+    // ============ Receive ============
+
+    /// @notice Allow receiving ETH for refunds
+    receive() external payable {}
+}

--- a/solidity/foundry.toml
+++ b/solidity/foundry.toml
@@ -42,6 +42,7 @@ forge-std = "1.9.2"
 "@arbitrum-nitro-contracts" = { version = "1.2.1", git = "https://github.com/OffchainLabs/nitro-contracts.git", tag = "v1.2.1" }
 "@chainlink-contracts-ccip" = { version = "1.5.0", git = "https://github.com/smartcontractkit/ccip.git", tag = "contracts-ccip/v1.5.0" }
 "@eth-optimism-contracts" = { version = "0.6.0", git = "https://github.com/ethereum-optimism/optimism.git", tag = "@eth-optimism/contracts@0.6.0" }
+"@predicate-contracts" = { version = "2.2.2", git = "https://github.com/predicatelabs/predicate-contracts.git", tag = "v2.2.2" }
 
 [soldeer]
 remappings_generate = false  # We'll manage remappings manually to preserve import paths

--- a/solidity/remappings.txt
+++ b/solidity/remappings.txt
@@ -3,5 +3,6 @@
 @arbitrum/nitro-contracts/src/=dependencies/@arbitrum-nitro-contracts-1.2.1/src/
 @chainlink/contracts-ccip/src/v0.8/=dependencies/@chainlink-contracts-ccip-1.5.0/contracts/src/v0.8/
 @eth-optimism/contracts/=dependencies/@eth-optimism-contracts-0.6.0/packages/contracts/contracts/
+@predicate/=dependencies/@predicate-contracts-2.2.2/src/
 forge-std/=dependencies/forge-std-1.9.2/src/
 ds-test/=dependencies/forge-std-1.9.2/lib/ds-test/src/

--- a/solidity/soldeer.lock
+++ b/solidity/soldeer.lock
@@ -29,6 +29,12 @@ git = "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable.git"
 rev = "3d4c0d5741b131c231e558d7a6213392ab3672a5"
 
 [[dependencies]]
+name = "@predicate-contracts"
+version = "2.2.2"
+git = "https://github.com/predicatelabs/predicate-contracts.git"
+rev = "v2.2.2"
+
+[[dependencies]]
 name = "forge-std"
 version = "1.9.2"
 url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_9_2_06-08-2024_17:31:25_forge-std-1.9.2.zip"

--- a/solidity/test/token/PredicateRouterWrapper.t.sol
+++ b/solidity/test/token/PredicateRouterWrapper.t.sol
@@ -1,0 +1,798 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.13;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+import "forge-std/Test.sol";
+
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+import {MockMailbox} from "../../contracts/mock/MockMailbox.sol";
+import {ERC20Test} from "../../contracts/test/ERC20Test.sol";
+import {TestPostDispatchHook} from "../../contracts/test/TestPostDispatchHook.sol";
+import {HypERC20Collateral} from "../../contracts/token/HypERC20Collateral.sol";
+import {HypERC20} from "../../contracts/token/HypERC20.sol";
+import {PredicateRouterWrapper} from "../../contracts/token/extensions/PredicateRouterWrapper.sol";
+import {IPredicateRegistry, Statement, Attestation} from "@predicate/interfaces/IPredicateRegistry.sol";
+import {Quote} from "../../contracts/interfaces/ITokenBridge.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+/**
+ * @title MockPredicateRegistry
+ * @notice A mock implementation of the PredicateRegistry for testing
+ */
+contract MockPredicateRegistry is IPredicateRegistry {
+    mapping(address => string) public policies;
+    mapping(string => bool) public usedUUIDs;
+
+    bool public shouldValidate = true;
+    bool public shouldRevert = false;
+    string public revertMessage = "MockPredicateRegistry: validation failed";
+
+    // Registered attesters for signature verification
+    mapping(address => bool) public registeredAttesters;
+
+    event PolicySet(address indexed client, string policy);
+    event StatementValidated(
+        address indexed msgSender,
+        address indexed target,
+        address indexed attester
+    );
+
+    function setShouldValidate(bool _shouldValidate) external {
+        shouldValidate = _shouldValidate;
+    }
+
+    function setShouldRevert(
+        bool _shouldRevert,
+        string memory _message
+    ) external {
+        shouldRevert = _shouldRevert;
+        revertMessage = _message;
+    }
+
+    function registerAttester(address _attester) external {
+        registeredAttesters[_attester] = true;
+    }
+
+    function deregisterAttester(address _attester) external {
+        registeredAttesters[_attester] = false;
+    }
+
+    function setPolicyID(string memory policyID) external override {
+        policies[msg.sender] = policyID;
+        emit PolicySet(msg.sender, policyID);
+    }
+
+    function getPolicyID(
+        address client
+    ) external view override returns (string memory) {
+        return policies[client];
+    }
+
+    function validateAttestation(
+        Statement memory _statement,
+        Attestation memory _attestation
+    ) external override returns (bool) {
+        if (shouldRevert) {
+            revert(revertMessage);
+        }
+
+        // Check if UUID has been used (replay protection)
+        require(
+            !usedUUIDs[_statement.uuid],
+            "MockPredicateRegistry: UUID already used"
+        );
+
+        // Mark UUID as used
+        usedUUIDs[_statement.uuid] = true;
+
+        emit StatementValidated(
+            _statement.msgSender,
+            _statement.target,
+            _attestation.attester
+        );
+
+        return shouldValidate;
+    }
+
+    function markUUIDAsUsed(string memory uuid) external {
+        usedUUIDs[uuid] = true;
+    }
+}
+
+contract PredicateRouterWrapperTest is Test {
+    using TypeCasts for address;
+
+    // Constants
+    uint32 internal constant ORIGIN = 11;
+    uint32 internal constant DESTINATION = 12;
+    uint8 internal constant DECIMALS = 18;
+    uint256 internal constant SCALE = 1;
+    uint256 internal constant TOTAL_SUPPLY = 1_000_000e18;
+    uint256 internal constant TRANSFER_AMT = 100e18;
+    string internal constant NAME = "TestToken";
+    string internal constant SYMBOL = "TEST";
+    string internal constant POLICY_ID = "test-policy-123";
+    address internal constant PROXY_ADMIN = address(0x37);
+
+    // Addresses
+    address internal constant ALICE = address(0x1);
+    address internal constant BOB = address(0x2);
+    address internal constant ATTESTER = address(0x3);
+
+    // Contracts
+    ERC20Test internal primaryToken;
+    HypERC20Collateral internal collateralRouter;
+    HypERC20 internal remoteToken;
+    PredicateRouterWrapper internal predicateWrapper;
+    MockPredicateRegistry internal registry;
+    MockMailbox internal localMailbox;
+    MockMailbox internal remoteMailbox;
+    TestPostDispatchHook internal noopHook;
+
+    // Events (from PredicateClient)
+    event PredicateRegistryUpdated(
+        address indexed oldRegistry,
+        address indexed newRegistry
+    );
+    event PredicatePolicyIDUpdated(string oldPolicyID, string newPolicyID);
+    event TransferAuthorized(
+        address indexed sender,
+        uint32 indexed destination,
+        bytes32 indexed recipient,
+        uint256 amount,
+        string uuid
+    );
+    event SentTransferRemote(
+        uint32 indexed destination,
+        bytes32 indexed recipient,
+        uint256 amount
+    );
+
+    function setUp() public virtual {
+        // Setup mailboxes
+        localMailbox = new MockMailbox(ORIGIN);
+        remoteMailbox = new MockMailbox(DESTINATION);
+        localMailbox.addRemoteMailbox(DESTINATION, remoteMailbox);
+        remoteMailbox.addRemoteMailbox(ORIGIN, localMailbox);
+
+        // Setup hooks
+        noopHook = new TestPostDispatchHook();
+        localMailbox.setDefaultHook(address(noopHook));
+        localMailbox.setRequiredHook(address(noopHook));
+        remoteMailbox.setDefaultHook(address(noopHook));
+        remoteMailbox.setRequiredHook(address(noopHook));
+
+        // Deploy token
+        primaryToken = new ERC20Test(NAME, SYMBOL, TOTAL_SUPPLY, DECIMALS);
+
+        // Deploy collateral router
+        collateralRouter = new HypERC20Collateral(
+            address(primaryToken),
+            SCALE,
+            address(localMailbox)
+        );
+        collateralRouter.initialize(
+            address(noopHook),
+            address(0), // ISM
+            address(this) // owner
+        );
+
+        // Deploy remote synthetic token
+        HypERC20 implementation = new HypERC20(
+            DECIMALS,
+            SCALE,
+            address(remoteMailbox)
+        );
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(implementation),
+            PROXY_ADMIN,
+            abi.encodeWithSelector(
+                HypERC20.initialize.selector,
+                TOTAL_SUPPLY,
+                NAME,
+                SYMBOL,
+                address(noopHook),
+                address(0),
+                address(this)
+            )
+        );
+        remoteToken = HypERC20(address(proxy));
+
+        // Enroll routers
+        collateralRouter.enrollRemoteRouter(
+            DESTINATION,
+            address(remoteToken).addressToBytes32()
+        );
+        remoteToken.enrollRemoteRouter(
+            ORIGIN,
+            address(collateralRouter).addressToBytes32()
+        );
+
+        // Deploy mock predicate registry
+        registry = new MockPredicateRegistry();
+        registry.registerAttester(ATTESTER);
+
+        // Deploy predicate wrapper (deployer becomes owner)
+        predicateWrapper = new PredicateRouterWrapper(
+            address(collateralRouter),
+            address(primaryToken),
+            address(registry),
+            POLICY_ID
+        );
+
+        // Set predicate wrapper as hook on the warp route
+        // This is the key configuration - the wrapper acts as both entry point AND hook
+        collateralRouter.setHook(address(predicateWrapper));
+
+        // Fund accounts
+        primaryToken.transfer(address(collateralRouter), 500_000e18);
+        primaryToken.transfer(ALICE, 100_000e18);
+        vm.deal(ALICE, 10 ether);
+    }
+
+    // ============ Helper Functions ============
+
+    function _createAttestation(
+        string memory uuid,
+        uint256 expiration
+    ) internal pure returns (Attestation memory) {
+        return
+            Attestation({
+                uuid: uuid,
+                expiration: expiration,
+                attester: ATTESTER,
+                signature: hex"" // Mock doesn't verify signatures
+            });
+    }
+
+    function _approveAndTransfer(
+        address sender,
+        uint256 amount,
+        Attestation memory attestation
+    ) internal returns (bytes32) {
+        vm.startPrank(sender);
+        primaryToken.approve(address(predicateWrapper), amount);
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+        bytes32 messageId = predicateWrapper.transferRemoteWithAttestation{
+            value: requiredValue
+        }(attestation, DESTINATION, BOB.addressToBytes32(), amount);
+        vm.stopPrank();
+        return messageId;
+    }
+
+    // ============ Constructor Tests ============
+
+    function test_constructor_setsWarpRoute() public view {
+        assertEq(
+            address(predicateWrapper.warpRoute()),
+            address(collateralRouter)
+        );
+    }
+
+    function test_constructor_setsToken() public view {
+        assertEq(address(predicateWrapper.token()), address(primaryToken));
+    }
+
+    function test_constructor_setsRegistry() public view {
+        assertEq(predicateWrapper.getRegistry(), address(registry));
+    }
+
+    function test_constructor_setsPolicyID() public view {
+        assertEq(predicateWrapper.getPolicyID(), POLICY_ID);
+    }
+
+    function test_constructor_registersPolicyWithRegistry() public view {
+        assertEq(registry.getPolicyID(address(predicateWrapper)), POLICY_ID);
+    }
+
+    function test_constructor_setsOwner() public view {
+        assertEq(predicateWrapper.owner(), address(this));
+    }
+
+    function test_constructor_revert_ifZeroRegistry() public {
+        vm.expectRevert(
+            PredicateRouterWrapper
+                .PredicateRouterWrapper__InvalidRegistry
+                .selector
+        );
+        new PredicateRouterWrapper(
+            address(collateralRouter),
+            address(primaryToken),
+            address(0),
+            POLICY_ID
+        );
+    }
+
+    function test_constructor_revert_ifEmptyPolicy() public {
+        vm.expectRevert(
+            PredicateRouterWrapper
+                .PredicateRouterWrapper__InvalidPolicy
+                .selector
+        );
+        new PredicateRouterWrapper(
+            address(collateralRouter),
+            address(primaryToken),
+            address(registry),
+            ""
+        );
+    }
+
+    // ============ Transfer Tests ============
+
+    function test_transferRemoteWithAttestation_success() public {
+        Attestation memory attestation = _createAttestation(
+            "test-uuid-1",
+            block.timestamp + 1 hours
+        );
+
+        uint256 aliceBalanceBefore = primaryToken.balanceOf(ALICE);
+        uint256 routerBalanceBefore = primaryToken.balanceOf(
+            address(collateralRouter)
+        );
+
+        bytes32 messageId = _approveAndTransfer(
+            ALICE,
+            TRANSFER_AMT,
+            attestation
+        );
+
+        assertTrue(messageId != bytes32(0));
+        assertEq(
+            primaryToken.balanceOf(ALICE),
+            aliceBalanceBefore - TRANSFER_AMT
+        );
+        assertEq(
+            primaryToken.balanceOf(address(collateralRouter)),
+            routerBalanceBefore + TRANSFER_AMT
+        );
+    }
+
+    function test_transferRemoteWithAttestation_emitsEvents() public {
+        Attestation memory attestation = _createAttestation(
+            "test-uuid-events",
+            block.timestamp + 1 hours
+        );
+
+        vm.startPrank(ALICE);
+        primaryToken.approve(address(predicateWrapper), TRANSFER_AMT);
+
+        vm.expectEmit(true, true, true, true);
+        emit TransferAuthorized(
+            ALICE,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT,
+            "test-uuid-events"
+        );
+
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+        predicateWrapper.transferRemoteWithAttestation{value: requiredValue}(
+            attestation,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+        vm.stopPrank();
+    }
+
+    function test_transferRemoteWithAttestation_processesOnRemote() public {
+        Attestation memory attestation = _createAttestation(
+            "test-uuid-2",
+            block.timestamp + 1 hours
+        );
+
+        _approveAndTransfer(ALICE, TRANSFER_AMT, attestation);
+
+        // Process the message on remote
+        remoteMailbox.processNextInboundMessage();
+
+        assertEq(remoteToken.balanceOf(BOB), TRANSFER_AMT);
+    }
+
+    function test_transferRemoteWithAttestation_clearsPendingFlag() public {
+        Attestation memory attestation = _createAttestation(
+            "test-uuid-flag",
+            block.timestamp + 1 hours
+        );
+
+        // Before transfer, flag should be false
+        assertFalse(predicateWrapper.pendingAttestation());
+
+        _approveAndTransfer(ALICE, TRANSFER_AMT, attestation);
+
+        // After transfer, flag should be cleared (false)
+        assertFalse(predicateWrapper.pendingAttestation());
+    }
+
+    function test_transferRemoteWithAttestation_revert_ifValidationFails()
+        public
+    {
+        Attestation memory attestation = _createAttestation(
+            "test-uuid-3",
+            block.timestamp + 1 hours
+        );
+
+        registry.setShouldValidate(false);
+
+        vm.prank(ALICE);
+        primaryToken.approve(address(predicateWrapper), TRANSFER_AMT);
+
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+
+        vm.prank(ALICE);
+        vm.expectRevert(
+            PredicateRouterWrapper
+                .PredicateRouterWrapper__AttestationInvalid
+                .selector
+        );
+        predicateWrapper.transferRemoteWithAttestation{value: requiredValue}(
+            attestation,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+    }
+
+    function test_transferRemoteWithAttestation_revert_ifRegistryReverts()
+        public
+    {
+        Attestation memory attestation = _createAttestation(
+            "test-uuid-4",
+            block.timestamp + 1 hours
+        );
+
+        registry.setShouldRevert(true, "Attestation expired");
+
+        vm.prank(ALICE);
+        primaryToken.approve(address(predicateWrapper), TRANSFER_AMT);
+
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+
+        vm.prank(ALICE);
+        vm.expectRevert("Attestation expired");
+        predicateWrapper.transferRemoteWithAttestation{value: requiredValue}(
+            attestation,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+    }
+
+    function test_transferRemoteWithAttestation_revert_ifReplayAttack() public {
+        Attestation memory attestation = _createAttestation(
+            "replay-uuid",
+            block.timestamp + 1 hours
+        );
+
+        // First transfer succeeds
+        _approveAndTransfer(ALICE, TRANSFER_AMT, attestation);
+
+        // Second transfer with same UUID fails
+        vm.prank(ALICE);
+        primaryToken.approve(address(predicateWrapper), TRANSFER_AMT);
+
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+
+        vm.prank(ALICE);
+        vm.expectRevert("MockPredicateRegistry: UUID already used");
+        predicateWrapper.transferRemoteWithAttestation{value: requiredValue}(
+            attestation,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+    }
+
+    function test_transferRemoteWithAttestation_revert_ifInsufficientAllowance()
+        public
+    {
+        Attestation memory attestation = _createAttestation(
+            "test-uuid-5",
+            block.timestamp + 1 hours
+        );
+
+        // Don't approve tokens
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+
+        vm.prank(ALICE);
+        vm.expectRevert();
+        predicateWrapper.transferRemoteWithAttestation{value: requiredValue}(
+            attestation,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+    }
+
+    function test_transferRemoteWithAttestation_revert_ifInsufficientBalance()
+        public
+    {
+        Attestation memory attestation = _createAttestation(
+            "test-uuid-6",
+            block.timestamp + 1 hours
+        );
+
+        uint256 tooMuch = primaryToken.balanceOf(ALICE) + 1;
+
+        vm.prank(ALICE);
+        primaryToken.approve(address(predicateWrapper), tooMuch);
+
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+
+        vm.prank(ALICE);
+        vm.expectRevert();
+        predicateWrapper.transferRemoteWithAttestation{value: requiredValue}(
+            attestation,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            tooMuch
+        );
+    }
+
+    // ============ Bypass Prevention Tests (Critical Security) ============
+
+    function test_bypassPrevention_directTransferRemoteReverts() public {
+        // Fund Alice with tokens and give her allowance on the router directly
+        vm.prank(ALICE);
+        primaryToken.approve(address(collateralRouter), TRANSFER_AMT);
+
+        // Alice tries to bypass the wrapper by calling collateralRouter.transferRemote() directly
+        // This should fail because the hook (predicateWrapper) will check pendingAttestation
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+
+        vm.prank(ALICE);
+        vm.expectRevert(
+            PredicateRouterWrapper
+                .PredicateRouterWrapper__UnauthorizedTransfer
+                .selector
+        );
+        collateralRouter.transferRemote{value: requiredValue}(
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+    }
+
+    function test_bypassPrevention_pendingFlagNotSetExternally() public {
+        // The pendingAttestation flag is only set by transferRemoteWithAttestation
+        // There's no way for external actors to set it
+        assertFalse(predicateWrapper.pendingAttestation());
+
+        // Even if someone could somehow set the flag, they can't call the protected function
+        // because only the wrapper itself can set it during transferRemoteWithAttestation
+    }
+
+    // ============ Admin Function Tests ============
+
+    function test_setPolicyID_success() public {
+        string memory newPolicy = "new-policy-456";
+
+        vm.expectEmit(true, true, true, true);
+        emit PredicatePolicyIDUpdated(POLICY_ID, newPolicy);
+
+        predicateWrapper.setPolicyID(newPolicy);
+
+        assertEq(predicateWrapper.getPolicyID(), newPolicy);
+        assertEq(registry.getPolicyID(address(predicateWrapper)), newPolicy);
+    }
+
+    function test_setPolicyID_noop_ifSamePolicy() public {
+        // No event should be emitted
+        vm.recordLogs();
+        predicateWrapper.setPolicyID(POLICY_ID);
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        // Only expect PolicySet from registry, not PredicatePolicyIDUpdated
+        bool foundPolicyUpdatedEvent = false;
+        for (uint i = 0; i < entries.length; i++) {
+            if (
+                entries[i].topics[0] ==
+                keccak256("PredicatePolicyIDUpdated(string,string)")
+            ) {
+                foundPolicyUpdatedEvent = true;
+            }
+        }
+        assertFalse(foundPolicyUpdatedEvent);
+    }
+
+    function test_setPolicyID_revert_ifNotOwner() public {
+        vm.prank(ALICE);
+        vm.expectRevert("Ownable: caller is not the owner");
+        predicateWrapper.setPolicyID("unauthorized-policy");
+    }
+
+    function test_setPolicyID_revert_ifEmptyPolicy() public {
+        vm.expectRevert(
+            PredicateRouterWrapper
+                .PredicateRouterWrapper__InvalidPolicy
+                .selector
+        );
+        predicateWrapper.setPolicyID("");
+    }
+
+    function test_setRegistry_success() public {
+        MockPredicateRegistry newRegistry = new MockPredicateRegistry();
+
+        vm.expectEmit(true, true, true, true);
+        emit PredicateRegistryUpdated(address(registry), address(newRegistry));
+
+        predicateWrapper.setRegistry(address(newRegistry));
+
+        assertEq(predicateWrapper.getRegistry(), address(newRegistry));
+        // Policy should be re-registered with new registry
+        assertEq(newRegistry.getPolicyID(address(predicateWrapper)), POLICY_ID);
+    }
+
+    function test_setRegistry_noop_ifSameRegistry() public {
+        vm.recordLogs();
+        predicateWrapper.setRegistry(address(registry));
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        bool foundRegistryUpdatedEvent = false;
+        for (uint i = 0; i < entries.length; i++) {
+            if (
+                entries[i].topics[0] ==
+                keccak256("PredicateRegistryUpdated(address,address)")
+            ) {
+                foundRegistryUpdatedEvent = true;
+            }
+        }
+        assertFalse(foundRegistryUpdatedEvent);
+    }
+
+    function test_setRegistry_revert_ifNotOwner() public {
+        MockPredicateRegistry newRegistry = new MockPredicateRegistry();
+
+        vm.prank(ALICE);
+        vm.expectRevert("Ownable: caller is not the owner");
+        predicateWrapper.setRegistry(address(newRegistry));
+    }
+
+    function test_setRegistry_revert_ifZeroAddress() public {
+        vm.expectRevert(
+            PredicateRouterWrapper
+                .PredicateRouterWrapper__InvalidRegistry
+                .selector
+        );
+        predicateWrapper.setRegistry(address(0));
+    }
+
+    // ============ Hook Interface Tests ============
+
+    function test_hookType_returnsUnused() public view {
+        assertEq(predicateWrapper.hookType(), 0); // UNUSED = 0
+    }
+
+    function test_quoteDispatch_returnsZero() public view {
+        uint256 quote = predicateWrapper.quoteDispatch("", "");
+        assertEq(quote, 0);
+    }
+
+    function test_supportsMetadata_returnsTrue() public view {
+        assertTrue(predicateWrapper.supportsMetadata(""));
+    }
+
+    // ============ Fuzz Tests ============
+
+    function testFuzz_transferRemoteWithAttestation_variableAmounts(
+        uint256 amount
+    ) public {
+        amount = bound(amount, 1, primaryToken.balanceOf(ALICE));
+
+        Attestation memory attestation = _createAttestation(
+            string(abi.encodePacked("fuzz-uuid-", vm.toString(amount))),
+            block.timestamp + 1 hours
+        );
+
+        uint256 aliceBalanceBefore = primaryToken.balanceOf(ALICE);
+
+        _approveAndTransfer(ALICE, amount, attestation);
+
+        assertEq(primaryToken.balanceOf(ALICE), aliceBalanceBefore - amount);
+    }
+}
+
+/**
+ * @title PredicateRouterWrapperIntegrationTest
+ * @notice Integration tests demonstrating the full flow with mocked registry
+ */
+contract PredicateRouterWrapperIntegrationTest is PredicateRouterWrapperTest {
+    using TypeCasts for address;
+
+    function test_integration_fullTransferFlow() public {
+        // This test demonstrates the complete flow:
+        // 1. User gets attestation
+        // 2. User calls wrapper
+        // 3. Wrapper validates, sets flag, transfers tokens, calls warp route
+        // 4. Warp route dispatches, mailbox calls hook
+        // 5. Hook verifies flag, clears it
+        // 6. Message arrives on destination
+        // 7. Recipient receives tokens
+
+        Attestation memory attestation = _createAttestation(
+            "integration-uuid",
+            block.timestamp + 1 hours
+        );
+
+        uint256 aliceBalanceBefore = primaryToken.balanceOf(ALICE);
+        uint256 bobBalanceBefore = remoteToken.balanceOf(BOB);
+
+        // Step 1-5: Transfer via wrapper
+        bytes32 messageId = _approveAndTransfer(
+            ALICE,
+            TRANSFER_AMT,
+            attestation
+        );
+        assertTrue(messageId != bytes32(0));
+
+        // Verify intermediate state
+        assertEq(
+            primaryToken.balanceOf(ALICE),
+            aliceBalanceBefore - TRANSFER_AMT
+        );
+        assertFalse(predicateWrapper.pendingAttestation()); // Flag cleared
+
+        // Step 6-7: Process on destination
+        remoteMailbox.processNextInboundMessage();
+
+        // Verify final state
+        assertEq(remoteToken.balanceOf(BOB), bobBalanceBefore + TRANSFER_AMT);
+    }
+
+    function test_integration_multipleSequentialTransfers() public {
+        // Multiple transfers should work sequentially
+        for (uint i = 0; i < 3; i++) {
+            Attestation memory attestation = _createAttestation(
+                string(abi.encodePacked("sequential-", vm.toString(i))),
+                block.timestamp + 1 hours
+            );
+
+            _approveAndTransfer(ALICE, 10e18, attestation);
+        }
+
+        // Process all messages
+        for (uint i = 0; i < 3; i++) {
+            remoteMailbox.processNextInboundMessage();
+        }
+
+        assertEq(remoteToken.balanceOf(BOB), 30e18);
+    }
+
+    function test_integration_bypassAttemptAfterLegitTransfer() public {
+        // First, do a legitimate transfer
+        Attestation memory attestation = _createAttestation(
+            "legit-transfer",
+            block.timestamp + 1 hours
+        );
+        _approveAndTransfer(ALICE, TRANSFER_AMT, attestation);
+
+        // Now try to bypass
+        vm.prank(ALICE);
+        primaryToken.approve(address(collateralRouter), TRANSFER_AMT);
+
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+
+        vm.prank(ALICE);
+        vm.expectRevert(
+            PredicateRouterWrapper
+                .PredicateRouterWrapper__UnauthorizedTransfer
+                .selector
+        );
+        collateralRouter.transferRemote{value: requiredValue}(
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+    }
+}

--- a/solidity/test/token/PredicateRouterWrapperFork.t.sol
+++ b/solidity/test/token/PredicateRouterWrapperFork.t.sol
@@ -1,0 +1,732 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.13;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+import "forge-std/Test.sol";
+
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+import {MockMailbox} from "../../contracts/mock/MockMailbox.sol";
+import {ERC20Test} from "../../contracts/test/ERC20Test.sol";
+import {TestPostDispatchHook} from "../../contracts/test/TestPostDispatchHook.sol";
+import {HypERC20Collateral} from "../../contracts/token/HypERC20Collateral.sol";
+import {HypERC20} from "../../contracts/token/HypERC20.sol";
+import {PredicateRouterWrapper} from "../../contracts/token/extensions/PredicateRouterWrapper.sol";
+import {IPredicateRegistry, Statement, Attestation} from "@predicate/interfaces/IPredicateRegistry.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+/// @notice Minimal interface for PredicateRegistry admin functions not in IPredicateRegistry
+interface IPredicateRegistryAdmin {
+    function owner() external view returns (address);
+    function registerAttester(address attester) external;
+}
+
+/**
+ * @title PredicateRouterWrapperForkTest
+ * @notice Fork tests using the real Predicate Registry on Base with real cryptographic validation
+ * @dev Registers a test attester on the real registry and uses real ECDSA signatures
+ *      to validate attestations - no mocking of validateAttestation
+ * @dev Cancun EVM version required to avoid `NotActivated` errors on Base fork
+ * forge-config: default.evm_version = "cancun"
+ */
+contract PredicateRouterWrapperForkTest is Test {
+    using TypeCasts for address;
+
+    // ============ Constants ============
+
+    /// @notice Real Predicate Registry address (deployed on Base and Mainnet)
+    address internal constant PREDICATE_REGISTRY =
+        0xe15a8Ca5BD8464283818088c1760d8f23B6a216E;
+
+    uint32 internal constant ORIGIN = 8453; // Base chain ID
+    uint32 internal constant DESTINATION = 1; // Mainnet
+    uint8 internal constant DECIMALS = 18;
+    uint256 internal constant SCALE = 1;
+    uint256 internal constant TOTAL_SUPPLY = 1_000_000e18;
+    uint256 internal constant TRANSFER_AMT = 100e18;
+    string internal constant NAME = "TestToken";
+    string internal constant SYMBOL = "TEST";
+    string internal constant POLICY_ID = "x-predicate-test-policy";
+    address internal constant PROXY_ADMIN = address(0x37);
+
+    // Test addresses (using addresses > 0xFF to avoid precompile conflicts)
+    address internal constant ALICE = address(0xA11CE);
+    address internal constant BOB = address(0xB0B);
+
+    // ============ State ============
+
+    uint256 internal baseFork;
+
+    ERC20Test internal primaryToken;
+    HypERC20Collateral internal collateralRouter;
+    HypERC20 internal remoteToken;
+    PredicateRouterWrapper internal predicateWrapper;
+    MockMailbox internal localMailbox;
+    MockMailbox internal remoteMailbox;
+    TestPostDispatchHook internal noopHook;
+
+    // Attester keypair for signing real attestations
+    uint256 internal attesterPrivateKey;
+    address internal attester;
+
+    // ============ Events ============
+
+    event TransferAuthorized(
+        address indexed sender,
+        uint32 indexed destination,
+        bytes32 indexed recipient,
+        uint256 amount,
+        string uuid
+    );
+
+    // ============ Setup ============
+
+    function setUp() public {
+        // Create fork from Base - use env var or fallback to public RPC
+        string memory baseRpcUrl = vm.envOr(
+            "RPC_URL_BASE",
+            string("https://mainnet.base.org")
+        );
+        baseFork = vm.createFork(baseRpcUrl);
+        vm.selectFork(baseFork);
+
+        // Verify the registry exists on this fork
+        uint256 codeSize;
+        assembly {
+            codeSize := extcodesize(PREDICATE_REGISTRY)
+        }
+        require(codeSize > 0, "Predicate Registry not found on Base fork");
+
+        // Setup mailboxes (these are mocked, not forked)
+        localMailbox = new MockMailbox(ORIGIN);
+        remoteMailbox = new MockMailbox(DESTINATION);
+        localMailbox.addRemoteMailbox(DESTINATION, remoteMailbox);
+        remoteMailbox.addRemoteMailbox(ORIGIN, localMailbox);
+
+        // Setup hooks
+        noopHook = new TestPostDispatchHook();
+        localMailbox.setDefaultHook(address(noopHook));
+        localMailbox.setRequiredHook(address(noopHook));
+        remoteMailbox.setDefaultHook(address(noopHook));
+        remoteMailbox.setRequiredHook(address(noopHook));
+
+        // Deploy token
+        primaryToken = new ERC20Test(NAME, SYMBOL, TOTAL_SUPPLY, DECIMALS);
+
+        // Deploy collateral router
+        collateralRouter = new HypERC20Collateral(
+            address(primaryToken),
+            SCALE,
+            address(localMailbox)
+        );
+        collateralRouter.initialize(
+            address(noopHook),
+            address(0), // ISM
+            address(this) // owner
+        );
+
+        // Deploy remote synthetic token
+        HypERC20 implementation = new HypERC20(
+            DECIMALS,
+            SCALE,
+            address(remoteMailbox)
+        );
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(implementation),
+            PROXY_ADMIN,
+            abi.encodeWithSelector(
+                HypERC20.initialize.selector,
+                TOTAL_SUPPLY,
+                NAME,
+                SYMBOL,
+                address(noopHook),
+                address(0),
+                address(this)
+            )
+        );
+        remoteToken = HypERC20(address(proxy));
+
+        // Enroll routers
+        collateralRouter.enrollRemoteRouter(
+            DESTINATION,
+            address(remoteToken).addressToBytes32()
+        );
+        remoteToken.enrollRemoteRouter(
+            ORIGIN,
+            address(collateralRouter).addressToBytes32()
+        );
+
+        // Deploy predicate wrapper with REAL registry address
+        // Note: No need to mock setPolicyID - the real registry allows any client to set their policy
+        predicateWrapper = new PredicateRouterWrapper(
+            address(collateralRouter),
+            address(primaryToken),
+            PREDICATE_REGISTRY,
+            POLICY_ID
+        );
+
+        // Set predicate wrapper as hook on the warp route
+        collateralRouter.setHook(address(predicateWrapper));
+
+        // Fund accounts
+        primaryToken.transfer(address(collateralRouter), 500_000e18);
+        primaryToken.transfer(ALICE, 100_000e18);
+        vm.deal(ALICE, 10 ether);
+
+        // Create attester keypair for signing real attestations
+        (attester, attesterPrivateKey) = makeAddrAndKey("fork-test-attester");
+
+        // Register attester on the real registry by pranking as owner
+        address registryOwner = IPredicateRegistryAdmin(PREDICATE_REGISTRY)
+            .owner();
+        vm.prank(registryOwner);
+        IPredicateRegistryAdmin(PREDICATE_REGISTRY).registerAttester(attester);
+    }
+
+    // ============ Helper Functions ============
+
+    /// @notice Generate a unique UUID for each test to avoid replay protection conflicts
+    function _generateUUID(
+        string memory salt
+    ) internal view returns (string memory) {
+        return
+            vm.toString(
+                uint256(
+                    keccak256(abi.encode(block.timestamp, block.number, salt))
+                )
+            );
+    }
+
+    /// @notice Create a signed attestation using the registered attester's private key
+    /// @dev Computes the hash using the same logic as PredicateRegistry.hashStatementWithExpiry
+    function _createSignedAttestation(
+        string memory uuid,
+        uint256 expiration,
+        address sender,
+        uint32 destination,
+        bytes32 recipient,
+        uint256 amount
+    ) internal view returns (Attestation memory) {
+        bytes memory encodedSigAndArgs = abi.encodeWithSignature(
+            "transferRemote(uint32,bytes32,uint256)",
+            destination,
+            recipient,
+            amount
+        );
+
+        // Compute hash using same logic as PredicateRegistry.hashStatementWithExpiry
+        // When target == msg.sender (the wrapper calling validateAttestation), this matches hashStatementSafe
+        bytes32 digest = keccak256(
+            abi.encode(
+                block.chainid,
+                uuid,
+                sender,
+                address(predicateWrapper), // target - must match msg.sender at validation time
+                uint256(0), // msgValue
+                encodedSigAndArgs,
+                POLICY_ID,
+                expiration
+            )
+        );
+
+        // Sign with attester's private key
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attesterPrivateKey, digest);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        return
+            Attestation({
+                uuid: uuid,
+                expiration: expiration,
+                attester: attester,
+                signature: signature
+            });
+    }
+
+    function _approveAndTransfer(
+        address sender,
+        uint256 amount,
+        Attestation memory attestation
+    ) internal returns (bytes32) {
+        vm.startPrank(sender);
+        primaryToken.approve(address(predicateWrapper), amount);
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+        bytes32 messageId = predicateWrapper.transferRemoteWithAttestation{
+            value: requiredValue
+        }(attestation, DESTINATION, BOB.addressToBytes32(), amount);
+        vm.stopPrank();
+        return messageId;
+    }
+
+    // ============ Fork Verification Tests ============
+
+    function test_fork_registryExists() public view {
+        uint256 codeSize;
+        assembly {
+            codeSize := extcodesize(PREDICATE_REGISTRY)
+        }
+        assertGt(codeSize, 0, "Registry should have code");
+    }
+
+    function test_fork_canCallRegistryOwner() public view {
+        // Test direct staticcall to registry's owner() function
+        address owner = IPredicateRegistryAdmin(PREDICATE_REGISTRY).owner();
+        assertEq(
+            owner,
+            0x62ca17e47cC2EFF4a81FC0E173cAfCb1B840635F,
+            "Owner should match expected"
+        );
+    }
+
+    function test_fork_wrapperUsesRealRegistry() public view {
+        assertEq(
+            predicateWrapper.getRegistry(),
+            PREDICATE_REGISTRY,
+            "Wrapper should use real registry"
+        );
+    }
+
+    function test_fork_policyRegistered() public view {
+        assertEq(
+            predicateWrapper.getPolicyID(),
+            POLICY_ID,
+            "Policy should be set"
+        );
+    }
+
+    // ============ Transfer Tests with Real Cryptographic Validation ============
+
+    function test_fork_transfer_success() public {
+        string memory uuid = _generateUUID("success");
+        uint256 expiration = block.timestamp + 1 hours;
+
+        Attestation memory attestation = _createSignedAttestation(
+            uuid,
+            expiration,
+            ALICE,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+
+        uint256 aliceBalanceBefore = primaryToken.balanceOf(ALICE);
+        uint256 routerBalanceBefore = primaryToken.balanceOf(
+            address(collateralRouter)
+        );
+
+        bytes32 messageId = _approveAndTransfer(
+            ALICE,
+            TRANSFER_AMT,
+            attestation
+        );
+
+        assertTrue(messageId != bytes32(0), "Message ID should be non-zero");
+        assertEq(
+            primaryToken.balanceOf(ALICE),
+            aliceBalanceBefore - TRANSFER_AMT,
+            "Alice balance should decrease"
+        );
+        assertEq(
+            primaryToken.balanceOf(address(collateralRouter)),
+            routerBalanceBefore + TRANSFER_AMT,
+            "Router balance should increase"
+        );
+    }
+
+    function test_fork_transfer_emitsEvent() public {
+        string memory uuid = _generateUUID("events");
+        uint256 expiration = block.timestamp + 1 hours;
+
+        Attestation memory attestation = _createSignedAttestation(
+            uuid,
+            expiration,
+            ALICE,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+
+        vm.startPrank(ALICE);
+        primaryToken.approve(address(predicateWrapper), TRANSFER_AMT);
+
+        vm.expectEmit(true, true, true, true);
+        emit TransferAuthorized(
+            ALICE,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT,
+            uuid
+        );
+
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+        predicateWrapper.transferRemoteWithAttestation{value: requiredValue}(
+            attestation,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+        vm.stopPrank();
+    }
+
+    function test_fork_transfer_processesOnRemote() public {
+        string memory uuid = _generateUUID("remote");
+        uint256 expiration = block.timestamp + 1 hours;
+
+        Attestation memory attestation = _createSignedAttestation(
+            uuid,
+            expiration,
+            ALICE,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+
+        _approveAndTransfer(ALICE, TRANSFER_AMT, attestation);
+
+        // Process the message on remote
+        remoteMailbox.processNextInboundMessage();
+
+        assertEq(
+            remoteToken.balanceOf(BOB),
+            TRANSFER_AMT,
+            "Bob should receive tokens on remote"
+        );
+    }
+
+    function test_fork_transfer_clearsPendingFlag() public {
+        string memory uuid = _generateUUID("flag");
+        uint256 expiration = block.timestamp + 1 hours;
+
+        Attestation memory attestation = _createSignedAttestation(
+            uuid,
+            expiration,
+            ALICE,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+
+        assertFalse(
+            predicateWrapper.pendingAttestation(),
+            "Flag should be false before"
+        );
+
+        _approveAndTransfer(ALICE, TRANSFER_AMT, attestation);
+
+        assertFalse(
+            predicateWrapper.pendingAttestation(),
+            "Flag should be cleared after"
+        );
+    }
+
+    // ============ Validation Failure Tests ============
+
+    function test_fork_transferReverts_whenAttesterNotRegistered() public {
+        string memory uuid = _generateUUID("unregistered-attester");
+        uint256 expiration = block.timestamp + 1 hours;
+
+        // Create a different attester keypair that is NOT registered
+        (
+            address unregisteredAttester,
+            uint256 unregisteredKey
+        ) = makeAddrAndKey("unregistered-attester");
+
+        // Sign with the unregistered attester
+        bytes memory encodedSigAndArgs = abi.encodeWithSignature(
+            "transferRemote(uint32,bytes32,uint256)",
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+        bytes32 digest = keccak256(
+            abi.encode(
+                block.chainid,
+                uuid,
+                ALICE,
+                address(predicateWrapper),
+                uint256(0),
+                encodedSigAndArgs,
+                POLICY_ID,
+                expiration
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(unregisteredKey, digest);
+
+        Attestation memory attestation = Attestation({
+            uuid: uuid,
+            expiration: expiration,
+            attester: unregisteredAttester,
+            signature: abi.encodePacked(r, s, v)
+        });
+
+        vm.prank(ALICE);
+        primaryToken.approve(address(predicateWrapper), TRANSFER_AMT);
+
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+
+        vm.prank(ALICE);
+        vm.expectRevert(
+            "Predicate.validateAttestation: Attester is not a registered attester"
+        );
+        predicateWrapper.transferRemoteWithAttestation{value: requiredValue}(
+            attestation,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+    }
+
+    function test_fork_transferReverts_whenExpired() public {
+        string memory uuid = _generateUUID("expired");
+        uint256 expiration = block.timestamp - 1; // Already expired
+
+        Attestation memory attestation = _createSignedAttestation(
+            uuid,
+            expiration,
+            ALICE,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+
+        vm.prank(ALICE);
+        primaryToken.approve(address(predicateWrapper), TRANSFER_AMT);
+
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+
+        vm.prank(ALICE);
+        vm.expectRevert(
+            "Predicate.validateAttestation: attestation expired"
+        );
+        predicateWrapper.transferRemoteWithAttestation{value: requiredValue}(
+            attestation,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+    }
+
+    // ============ Bypass Prevention Tests on Fork ============
+
+    function test_fork_bypassPrevention_directTransferReverts() public {
+        // Fund Alice with tokens and give her allowance on the router directly
+        vm.prank(ALICE);
+        primaryToken.approve(address(collateralRouter), TRANSFER_AMT);
+
+        // Alice tries to bypass the wrapper by calling collateralRouter.transferRemote() directly
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+
+        vm.prank(ALICE);
+        vm.expectRevert(
+            PredicateRouterWrapper
+                .PredicateRouterWrapper__UnauthorizedTransfer
+                .selector
+        );
+        collateralRouter.transferRemote{value: requiredValue}(
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+    }
+
+    function test_fork_bypassAttemptAfterLegitTransfer() public {
+        // First, do a legitimate transfer with real attestation
+        string memory uuid = _generateUUID("legit-transfer");
+        uint256 expiration = block.timestamp + 1 hours;
+
+        Attestation memory attestation = _createSignedAttestation(
+            uuid,
+            expiration,
+            ALICE,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+
+        _approveAndTransfer(ALICE, TRANSFER_AMT, attestation);
+
+        // Now try to bypass
+        vm.prank(ALICE);
+        primaryToken.approve(address(collateralRouter), TRANSFER_AMT);
+
+        uint256 requiredValue = noopHook.quoteDispatch("", "");
+
+        vm.prank(ALICE);
+        vm.expectRevert(
+            PredicateRouterWrapper
+                .PredicateRouterWrapper__UnauthorizedTransfer
+                .selector
+        );
+        collateralRouter.transferRemote{value: requiredValue}(
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+    }
+
+    // ============ Multiple Sequential Transfers ============
+
+    function test_fork_multipleSequentialTransfers() public {
+        uint256 transferAmount = 10e18;
+
+        for (uint256 i = 0; i < 3; i++) {
+            string memory uuid = _generateUUID(
+                string(abi.encodePacked("sequential-", vm.toString(i)))
+            );
+            uint256 expiration = block.timestamp + 1 hours;
+
+            Attestation memory attestation = _createSignedAttestation(
+                uuid,
+                expiration,
+                ALICE,
+                DESTINATION,
+                BOB.addressToBytes32(),
+                transferAmount
+            );
+
+            _approveAndTransfer(ALICE, transferAmount, attestation);
+        }
+
+        // Process all messages
+        for (uint256 i = 0; i < 3; i++) {
+            remoteMailbox.processNextInboundMessage();
+        }
+
+        assertEq(
+            remoteToken.balanceOf(BOB),
+            30e18,
+            "Bob should receive all tokens"
+        );
+    }
+
+    // ============ Admin Functions on Fork ============
+
+    function test_fork_setPolicyID_updatesRegistry() public {
+        string memory newPolicy = "x-new-fork-policy";
+
+        // No mock needed - the real registry allows any client to set their policy
+        predicateWrapper.setPolicyID(newPolicy);
+
+        assertEq(
+            predicateWrapper.getPolicyID(),
+            newPolicy,
+            "Policy should be updated"
+        );
+    }
+
+    function test_fork_setRegistry_canChangeRegistry() public {
+        address newRegistry = address(0xBEEF);
+
+        // Mock setPolicyID on new registry
+        vm.mockCall(
+            newRegistry,
+            abi.encodeWithSelector(
+                IPredicateRegistry.setPolicyID.selector,
+                POLICY_ID
+            ),
+            abi.encode()
+        );
+
+        predicateWrapper.setRegistry(newRegistry);
+
+        assertEq(
+            predicateWrapper.getRegistry(),
+            newRegistry,
+            "Registry should be updated"
+        );
+    }
+}
+
+/**
+ * @title PredicateRouterWrapperForkIntegrationTest
+ * @notice Integration tests demonstrating full flow on Base fork with real cryptographic validation
+ * @dev Cancun EVM version required to avoid `NotActivated` errors on Base fork
+ * forge-config: default.evm_version = "cancun"
+ */
+contract PredicateRouterWrapperForkIntegrationTest is
+    PredicateRouterWrapperForkTest
+{
+    using TypeCasts for address;
+    function test_fork_integration_fullTransferFlow() public {
+        // This test demonstrates the complete flow on a real fork:
+        // 1. User gets attestation signed by registered attester
+        // 2. User calls wrapper
+        // 3. Wrapper validates via real registry with real ECDSA verification
+        // 4. Wrapper transfers tokens, calls warp route
+        // 5. Hook verifies flag, clears it
+        // 6. Message arrives on destination
+
+        string memory uuid = _generateUUID("integration-full-flow");
+        uint256 expiration = block.timestamp + 1 hours;
+
+        Attestation memory attestation = _createSignedAttestation(
+            uuid,
+            expiration,
+            ALICE,
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT
+        );
+
+        uint256 aliceBalanceBefore = primaryToken.balanceOf(ALICE);
+        uint256 bobBalanceBefore = remoteToken.balanceOf(BOB);
+
+        // Step 1-5: Transfer via wrapper with real attestation validation
+        bytes32 messageId = _approveAndTransfer(
+            ALICE,
+            TRANSFER_AMT,
+            attestation
+        );
+        assertTrue(messageId != bytes32(0));
+
+        // Verify intermediate state
+        assertEq(
+            primaryToken.balanceOf(ALICE),
+            aliceBalanceBefore - TRANSFER_AMT
+        );
+        assertFalse(predicateWrapper.pendingAttestation()); // Flag cleared
+
+        // Step 6: Process on destination
+        remoteMailbox.processNextInboundMessage();
+
+        // Verify final state
+        assertEq(remoteToken.balanceOf(BOB), bobBalanceBefore + TRANSFER_AMT);
+    }
+
+    function test_fork_integration_realRegistryInterface() public view {
+        // Verify we're interacting with the real registry's interface
+        // by checking it implements the expected functions
+
+        // Check the registry has the expected interface by checking code exists
+        uint256 codeSize;
+        assembly {
+            codeSize := extcodesize(PREDICATE_REGISTRY)
+        }
+        assertGt(codeSize, 0, "Registry should have code");
+
+        // The wrapper should point to the real registry
+        assertEq(
+            predicateWrapper.getRegistry(),
+            PREDICATE_REGISTRY,
+            "Should use real registry address"
+        );
+    }
+
+    function test_fork_integration_attesterIsRegistered() public view {
+        // Verify our test attester was successfully registered on the real registry
+        (bool success, bytes memory data) = PREDICATE_REGISTRY.staticcall(
+            abi.encodeWithSignature("isAttesterRegistered(address)", attester)
+        );
+        assertTrue(success, "Call should succeed");
+        assertTrue(abi.decode(data, (bool)), "Attester should be registered");
+    }
+}


### PR DESCRIPTION
## Summary
- Add PredicateRouterWrapper contract that enforces Predicate attestation validation before warp route transfers
- Wrapper acts as both entry point and post-dispatch hook to prevent bypass
- Includes comprehensive unit tests (65) and fork tests (33) with real cryptographic validation

## Test Plan
- `forge test --match-contract PredicateRouterWrapper` - 98 tests passing (65 unit + 33 fork)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new cross-chain token transfer wrapper contract with integrated Predicate attestation validation capabilities.

* **Dependencies**
  * Added Predicate Contracts (v2.2.2) library for attestation registry and policy management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->