### PR TITLE
feat(sdk): add Predicate wrapper SDK integration for compliance-gated warp routes

### DIFF
--- a/.changeset/predicate-wrapper-sdk.md
+++ b/.changeset/predicate-wrapper-sdk.md
@@ -1,0 +1,23 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Add Predicate integration for compliance-gated warp route transfers
+
+- Add `PredicateWrapperConfigSchema` for configuring predicate wrapper deployment
+- Add `PredicateApiClient` for fetching attestations from Predicate API
+- Add `PredicateWrapperDeployer` for deploying and configuring PredicateRouterWrapper contracts
+- Integrate predicate wrapper deployment into warp route deployment flow
+- Support aggregation hooks with predicate wrapper (wrapper executes first)
+- Always aggregate predicate wrapper with mailbox default hook to ensure gas quoting works correctly
+- Detect PredicateRouterWrapper recursively inside nested aggregation hooks
+
+Example configuration:
+```yaml
+ethereum:
+  type: collateral
+  token: '0x...'
+  predicateWrapper:
+    predicateRegistry: '0xe15a8Ca5BD8464283818088c1760d8f23B6a216E'
+    policyId: 'x-your-policy-id'
+```

--- a/solidity/contracts/interfaces/hooks/IPostDispatchHook.sol
+++ b/solidity/contracts/interfaces/hooks/IPostDispatchHook.sol
@@ -30,7 +30,8 @@ interface IPostDispatchHook {
         OP_L2_TO_L1,
         MAILBOX_DEFAULT_HOOK,
         AMOUNT_ROUTING,
-        CCTP
+        CCTP,
+        PREDICATE_ROUTER_WRAPPER
     }
 
     /**

--- a/solidity/contracts/mock/MockPredicateRegistry.sol
+++ b/solidity/contracts/mock/MockPredicateRegistry.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import {IPredicateRegistry, Statement, Attestation} from "@predicate/interfaces/IPredicateRegistry.sol";
+
+contract MockPredicateRegistry is IPredicateRegistry {
+    mapping(address => string) public policies;
+    mapping(string => bool) public usedUUIDs;
+
+    bool public shouldValidate = true;
+    bool public shouldRevert = false;
+    string public revertMessage = "MockPredicateRegistry: validation failed";
+
+    mapping(address => bool) public registeredAttesters;
+
+    event PolicySet(address indexed client, string policy);
+    event StatementValidated(
+        address indexed msgSender,
+        address indexed target,
+        address indexed attester
+    );
+
+    function setShouldValidate(bool _shouldValidate) external {
+        shouldValidate = _shouldValidate;
+    }
+
+    function setShouldRevert(
+        bool _shouldRevert,
+        string memory _message
+    ) external {
+        shouldRevert = _shouldRevert;
+        revertMessage = _message;
+    }
+
+    function registerAttester(address _attester) external {
+        registeredAttesters[_attester] = true;
+    }
+
+    function deregisterAttester(address _attester) external {
+        registeredAttesters[_attester] = false;
+    }
+
+    function setPolicyID(string memory policyID) external override {
+        policies[msg.sender] = policyID;
+        emit PolicySet(msg.sender, policyID);
+    }
+
+    function getPolicyID(
+        address client
+    ) external view override returns (string memory) {
+        return policies[client];
+    }
+
+    function validateAttestation(
+        Statement memory _statement,
+        Attestation memory _attestation
+    ) external override returns (bool) {
+        if (shouldRevert) {
+            revert(revertMessage);
+        }
+
+        require(
+            !usedUUIDs[_statement.uuid],
+            "MockPredicateRegistry: UUID already used"
+        );
+
+        usedUUIDs[_statement.uuid] = true;
+
+        emit StatementValidated(
+            _statement.msgSender,
+            _statement.target,
+            _attestation.attester
+        );
+
+        return shouldValidate;
+    }
+
+    function markUUIDAsUsed(string memory uuid) external {
+        usedUUIDs[uuid] = true;
+    }
+}

--- a/solidity/contracts/token/extensions/PredicateRouterWrapper.sol
+++ b/solidity/contracts/token/extensions/PredicateRouterWrapper.sol
@@ -50,14 +50,18 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
  *
  * @custom:oz-version 4.9.x (uses Ownable without constructor argument)
  */
-contract PredicateRouterWrapper is AbstractPostDispatchHook, PredicateClient, Ownable {
+contract PredicateRouterWrapper is
+    AbstractPostDispatchHook,
+    PredicateClient,
+    Ownable
+{
     using SafeERC20 for IERC20;
 
     // ============ Constants ============
 
-    /// @notice Hook type identifier (UNUSED as this is a custom hook)
+    /// @notice Hook type identifier for Predicate router wrapper
     uint8 public constant override hookType =
-        uint8(IPostDispatchHook.HookTypes.UNUSED);
+        uint8(IPostDispatchHook.HookTypes.PREDICATE_ROUTER_WRAPPER);
 
     // ============ Immutables ============
 

--- a/solidity/test/token/PredicateRouterWrapper.t.sol
+++ b/solidity/test/token/PredicateRouterWrapper.t.sol
@@ -17,98 +17,15 @@ import "forge-std/Test.sol";
 
 import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
 import {MockMailbox} from "../../contracts/mock/MockMailbox.sol";
+import {MockPredicateRegistry} from "../../contracts/mock/MockPredicateRegistry.sol";
 import {ERC20Test} from "../../contracts/test/ERC20Test.sol";
 import {TestPostDispatchHook} from "../../contracts/test/TestPostDispatchHook.sol";
 import {HypERC20Collateral} from "../../contracts/token/HypERC20Collateral.sol";
 import {HypERC20} from "../../contracts/token/HypERC20.sol";
 import {PredicateRouterWrapper} from "../../contracts/token/extensions/PredicateRouterWrapper.sol";
-import {IPredicateRegistry, Statement, Attestation} from "@predicate/interfaces/IPredicateRegistry.sol";
+import {Statement, Attestation} from "@predicate/interfaces/IPredicateRegistry.sol";
 import {Quote} from "../../contracts/interfaces/ITokenBridge.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-
-/**
- * @title MockPredicateRegistry
- * @notice A mock implementation of the PredicateRegistry for testing
- */
-contract MockPredicateRegistry is IPredicateRegistry {
-    mapping(address => string) public policies;
-    mapping(string => bool) public usedUUIDs;
-
-    bool public shouldValidate = true;
-    bool public shouldRevert = false;
-    string public revertMessage = "MockPredicateRegistry: validation failed";
-
-    // Registered attesters for signature verification
-    mapping(address => bool) public registeredAttesters;
-
-    event PolicySet(address indexed client, string policy);
-    event StatementValidated(
-        address indexed msgSender,
-        address indexed target,
-        address indexed attester
-    );
-
-    function setShouldValidate(bool _shouldValidate) external {
-        shouldValidate = _shouldValidate;
-    }
-
-    function setShouldRevert(
-        bool _shouldRevert,
-        string memory _message
-    ) external {
-        shouldRevert = _shouldRevert;
-        revertMessage = _message;
-    }
-
-    function registerAttester(address _attester) external {
-        registeredAttesters[_attester] = true;
-    }
-
-    function deregisterAttester(address _attester) external {
-        registeredAttesters[_attester] = false;
-    }
-
-    function setPolicyID(string memory policyID) external override {
-        policies[msg.sender] = policyID;
-        emit PolicySet(msg.sender, policyID);
-    }
-
-    function getPolicyID(
-        address client
-    ) external view override returns (string memory) {
-        return policies[client];
-    }
-
-    function validateAttestation(
-        Statement memory _statement,
-        Attestation memory _attestation
-    ) external override returns (bool) {
-        if (shouldRevert) {
-            revert(revertMessage);
-        }
-
-        // Check if UUID has been used (replay protection)
-        require(
-            !usedUUIDs[_statement.uuid],
-            "MockPredicateRegistry: UUID already used"
-        );
-
-        // Mark UUID as used
-        usedUUIDs[_statement.uuid] = true;
-
-        emit StatementValidated(
-            _statement.msgSender,
-            _statement.target,
-            _attestation.attester
-        );
-
-        return shouldValidate;
-    }
-
-    function markUUIDAsUsed(string memory uuid) external {
-        usedUUIDs[uuid] = true;
-    }
-}
 
 contract PredicateRouterWrapperTest is Test {
     using TypeCasts for address;

--- a/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
@@ -16,7 +16,8 @@ import { HyperlaneContracts } from '../contracts/types.js';
 import { HyperlaneDeployer } from '../deploy/HyperlaneDeployer.js';
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
 import { HyperlaneHookDeployer } from '../hook/HyperlaneHookDeployer.js';
-import { HookConfig } from '../hook/types.js';
+import { HookFactories } from '../hook/contracts.js';
+import { HookConfig, HookType } from '../hook/types.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { IsmConfig } from '../ism/types.js';
 import { moduleMatchesConfig } from '../ism/utils.js';
@@ -220,7 +221,12 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
     if (typeof config === 'string') {
       return Object.values(hooks)[0];
     } else {
-      return hooks[config.type];
+      if (config.type === HookType.PREDICATE) {
+        throw new Error(
+          'Predicate hooks cannot be deployed via HyperlaneCoreDeployer, they must be pre-deployed',
+        );
+      }
+      return hooks[config.type as keyof HookFactories];
     }
   }
 

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -34,6 +34,7 @@ import {
 import { EvmHookModule } from '../hook/EvmHookModule.js';
 import { HookConfig } from '../hook/types.js';
 import { EvmIsmModule } from '../ism/EvmIsmModule.js';
+import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { IsmConfig } from '../ism/types.js';
 import { altVmChainLookup } from '../metadata/ChainMetadataManager.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
@@ -128,9 +129,16 @@ export async function executeWarpDeploy(
 
     switch (protocol) {
       case ProtocolType.Ethereum: {
+        const ismFactory = HyperlaneIsmFactory.fromAddressesMap(
+          registryAddresses,
+          multiProvider,
+          undefined,
+          contractVerifier,
+        );
+
         const deployer = warpDeployConfig.isNft
           ? new HypERC721Deployer(multiProvider)
-          : new HypERC20Deployer(multiProvider); // TODO: replace with EvmERC20WarpModule
+          : new HypERC20Deployer(multiProvider, ismFactory, contractVerifier); // TODO: replace with EvmERC20WarpModule
 
         const evmContracts = await deployer.deploy(protocolSpecificConfig);
         deployedContracts = {

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -175,6 +175,9 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
           derivedHookConfig =
             await this.deriveMailboxDefaultHookConfig(address);
           break;
+        case OnchainHookType.PREDICATE_ROUTER_WRAPPER:
+          derivedHookConfig = { type: HookType.PREDICATE, address };
+          break;
         default:
           throw new Error(
             `Unsupported HookType: ${OnchainHookType[onchainHookType]}`,

--- a/typescript/sdk/src/hook/HyperlaneHookDeployer.ts
+++ b/typescript/sdk/src/hook/HyperlaneHookDeployer.ts
@@ -197,12 +197,19 @@ export class HyperlaneHookDeployer extends HyperlaneDeployer<
         continue;
       }
 
+      if (hookConfig.type === HookType.PREDICATE) {
+        throw new Error(
+          'Predicate hooks cannot be deployed via HyperlaneHookDeployer, they must be pre-deployed',
+        );
+      }
       const subhooks = await this.deployContracts(
         chain,
         hookConfig,
         coreAddresses,
       );
-      aggregatedHooks.push(subhooks[hookConfig.type].address);
+      aggregatedHooks.push(
+        subhooks[hookConfig.type as keyof HookFactories].address,
+      );
       hooks = { ...hooks, ...subhooks };
     }
 
@@ -327,12 +334,18 @@ export class HyperlaneHookDeployer extends HyperlaneDeployer<
         if (typeof config.fallback === 'string') {
           fallbackAddress = config.fallback;
         } else {
+          if (config.fallback.type === HookType.PREDICATE) {
+            throw new Error(
+              'Predicate hooks cannot be deployed via HyperlaneHookDeployer, they must be pre-deployed',
+            );
+          }
           const fallbackHook = await this.deployContracts(
             chain,
             config.fallback,
             coreAddresses,
           );
-          fallbackAddress = fallbackHook[config.fallback.type].address;
+          fallbackAddress =
+            fallbackHook[config.fallback.type as keyof HookFactories].address;
         }
         routingHook = await this.deployContract(
           chain,
@@ -369,6 +382,11 @@ export class HyperlaneHookDeployer extends HyperlaneDeployer<
         prevHookConfig = hookConfig;
         prevHookAddress = hookConfig;
       } else {
+        if (hookConfig.type === HookType.PREDICATE) {
+          throw new Error(
+            'Predicate hooks cannot be deployed via HyperlaneHookDeployer, they must be pre-deployed',
+          );
+        }
         const hook = await this.deployContracts(
           chain,
           hookConfig,
@@ -376,10 +394,10 @@ export class HyperlaneHookDeployer extends HyperlaneDeployer<
         );
         routingConfigs.push({
           destination: destDomain,
-          hook: hook[hookConfig.type].address,
+          hook: hook[hookConfig.type as keyof HookFactories].address,
         });
         prevHookConfig = hookConfig;
-        prevHookAddress = hook[hookConfig.type].address;
+        prevHookAddress = hook[hookConfig.type as keyof HookFactories].address;
       }
     }
 
@@ -422,12 +440,18 @@ export class HyperlaneHookDeployer extends HyperlaneDeployer<
         continue;
       }
 
+      if (hookConfig.type === HookType.PREDICATE) {
+        throw new Error(
+          'Predicate hooks cannot be deployed via HyperlaneHookDeployer, they must be pre-deployed',
+        );
+      }
+
       const contracts = await this.deployContracts(
         chain,
         hookConfig.type,
         this.core[chain],
       );
-      hooks.push(contracts[hookConfig.type].address);
+      hooks.push(contracts[hookConfig.type as keyof HookFactories].address);
     }
 
     const [lowerHook, upperHook] = hooks;

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -28,10 +28,11 @@ export enum OnchainHookType {
   OP_L2_TO_L1,
   MAILBOX_DEFAULT_HOOK,
   AMOUNT_ROUTING,
+  CCTP,
+  PREDICATE_ROUTER_WRAPPER,
 }
 
 export const HookType = {
-  CUSTOM: 'custom',
   MERKLE_TREE: 'merkleTreeHook',
   INTERCHAIN_GAS_PAYMASTER: 'interchainGasPaymaster',
   AGGREGATION: 'aggregationHook',
@@ -44,12 +45,13 @@ export const HookType = {
   ARB_L2_TO_L1: 'arbL2ToL1Hook',
   MAILBOX_DEFAULT: 'defaultHook',
   CCIP: 'ccipHook',
+  PREDICATE: 'predicateHook',
 } as const;
 
 export type HookType = (typeof HookType)[keyof typeof HookType];
 
 export const HookTypeToContractNameMap: Record<
-  Exclude<HookType, typeof HookType.CUSTOM>,
+  Exclude<HookType, typeof HookType.PREDICATE>,
   string
 > = {
   [HookType.MERKLE_TREE]: 'merkleTreeHook',
@@ -120,6 +122,11 @@ export const ProtocolFeeSchema = OwnableSchema.extend({
 export const MerkleTreeSchema = z.object({
   type: z.literal(HookType.MERKLE_TREE),
 });
+
+export const PredicateHookSchema = z.object({
+  type: z.literal(HookType.PREDICATE),
+});
+export type PredicateHookConfig = z.infer<typeof PredicateHookSchema>;
 
 export const PausableHookSchema = PausableSchema.extend({
   type: z.literal(HookType.PAUSABLE),
@@ -214,6 +221,7 @@ export const HookConfigSchema = z.union([
   ArbL2ToL1HookSchema,
   MailboxDefaultHookSchema,
   CCIPHookSchema,
+  PredicateHookSchema,
 ]);
 
 // TODO: deprecate in favor of CoreConfigSchema

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -781,8 +781,19 @@ export {
   XERC20Type,
   XERC20TokenExtraBridgesLimits,
   XERC20TokenMetadata,
+  PredicateWrapperConfig,
+  PredicateWrapperConfigSchema,
+  isPredicateWrapperConfig,
 } from './token/types.js';
 export { getExtraLockBoxConfigs } from './token/xerc20.js';
+export {
+  PredicateApiClient,
+  PredicateAttestation,
+  PredicateAttestationRequest,
+  PredicateAttestationResponse,
+  PredicateWrapperDeployer,
+  PredicateWrapperDeploymentResult,
+} from './predicate/index.js';
 export {
   ChainMap,
   ChainName,

--- a/typescript/sdk/src/predicate/PredicateApiClient.test.ts
+++ b/typescript/sdk/src/predicate/PredicateApiClient.test.ts
@@ -1,0 +1,136 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import {
+  PredicateApiClient,
+  PredicateAttestationRequest,
+  PredicateAttestationResponse,
+} from './PredicateApiClient.js';
+
+describe('PredicateApiClient', () => {
+  let fetchStub: sinon.SinonStub;
+
+  const mockRequest: PredicateAttestationRequest = {
+    to: '0x1234567890123456789012345678901234567890',
+    from: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+    data: '0x',
+    msg_value: '0',
+    chain: 'sepolia',
+  };
+
+  const mockResponse: PredicateAttestationResponse = {
+    policy_id: 'policy_abc123',
+    policy_name: 'Test Policy',
+    verification_hash: 'x-test-hash',
+    is_compliant: true,
+    attestation: {
+      uuid: '550e8400-e29b-41d4-a716-446655440000',
+      expiration: Math.floor(Date.now() / 1000) + 3600,
+      attester: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+      signature: '0x1234abcd',
+    },
+  };
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+  });
+
+  it('should fetch attestation successfully', async () => {
+    fetchStub.resolves({
+      ok: true,
+      json: async () => mockResponse,
+    } as Response);
+
+    const client = new PredicateApiClient('test-api-key');
+    const result = await client.fetchAttestation(mockRequest);
+
+    expect(result.is_compliant).to.be.true;
+    expect(result.attestation.uuid).to.equal(mockResponse.attestation.uuid);
+    expect(fetchStub.calledOnce).to.be.true;
+  });
+
+  it('should throw on non-compliant response', async () => {
+    fetchStub.resolves({
+      ok: true,
+      json: async () => ({ ...mockResponse, is_compliant: false }),
+    } as Response);
+
+    const client = new PredicateApiClient('test-api-key');
+
+    try {
+      await client.fetchAttestation(mockRequest);
+      expect.fail('Expected error to be thrown');
+    } catch (error: any) {
+      expect(error.message).to.include('Transaction not compliant');
+    }
+  });
+
+  it('should throw on API error', async () => {
+    fetchStub.resolves({
+      ok: false,
+      status: 401,
+      text: async () => 'Unauthorized',
+    } as Response);
+
+    const client = new PredicateApiClient('test-api-key');
+
+    try {
+      await client.fetchAttestation(mockRequest);
+      expect.fail('Expected error to be thrown');
+    } catch (error: any) {
+      expect(error.message).to.include('Predicate API error (401)');
+      expect(error.message).to.include('Unauthorized');
+    }
+  });
+
+  it('should use custom base URL', async () => {
+    fetchStub.resolves({
+      ok: true,
+      json: async () => mockResponse,
+    } as Response);
+
+    const customUrl = 'https://custom.predicate.io/v2/attestation';
+    const client = new PredicateApiClient('test-api-key', customUrl);
+    await client.fetchAttestation(mockRequest);
+
+    expect(fetchStub.firstCall.args[0]).to.equal(customUrl);
+  });
+
+  it('should include API key in headers', async () => {
+    fetchStub.resolves({
+      ok: true,
+      json: async () => mockResponse,
+    } as Response);
+
+    const client = new PredicateApiClient('my-secret-key');
+    await client.fetchAttestation(mockRequest);
+
+    const callArgs = fetchStub.firstCall.args[1] as RequestInit;
+    expect((callArgs.headers as Record<string, string>)['x-api-key']).to.equal(
+      'my-secret-key',
+    );
+  });
+
+  it('should send correct request body', async () => {
+    fetchStub.resolves({
+      ok: true,
+      json: async () => mockResponse,
+    } as Response);
+
+    const client = new PredicateApiClient('test-api-key');
+    await client.fetchAttestation(mockRequest);
+
+    const callArgs = fetchStub.firstCall.args[1] as RequestInit;
+    const body = JSON.parse(callArgs.body as string);
+
+    expect(body.to).to.equal(mockRequest.to);
+    expect(body.from).to.equal(mockRequest.from);
+    expect(body.data).to.equal(mockRequest.data);
+    expect(body.msg_value).to.equal(mockRequest.msg_value);
+    expect(body.chain).to.equal(mockRequest.chain);
+  });
+});

--- a/typescript/sdk/src/predicate/PredicateApiClient.ts
+++ b/typescript/sdk/src/predicate/PredicateApiClient.ts
@@ -1,0 +1,73 @@
+import { rootLogger } from '@hyperlane-xyz/utils';
+
+const DEFAULT_PREDICATE_API_URL = 'https://api.predicate.io/v2/attestation';
+
+export interface PredicateAttestation {
+  uuid: string;
+  expiration: number;
+  attester: string;
+  signature: string;
+}
+
+export interface PredicateAttestationResponse {
+  policy_id: string;
+  policy_name: string;
+  verification_hash: string;
+  is_compliant: boolean;
+  attestation: PredicateAttestation;
+}
+
+export interface PredicateAttestationRequest {
+  to: string;
+  from: string;
+  data: string;
+  msg_value: string;
+  chain: string;
+}
+
+export class PredicateApiClient {
+  private readonly logger = rootLogger.child({ module: 'PredicateApiClient' });
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+
+  constructor(apiKey: string, baseUrl: string = DEFAULT_PREDICATE_API_URL) {
+    this.apiKey = apiKey;
+    this.baseUrl = baseUrl;
+  }
+
+  async fetchAttestation(
+    request: PredicateAttestationRequest,
+  ): Promise<PredicateAttestationResponse> {
+    this.logger.debug('Fetching attestation', {
+      to: request.to,
+      chain: request.chain,
+    });
+
+    const response = await fetch(this.baseUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Predicate API error (${response.status}): ${errorText}`);
+    }
+
+    const result: PredicateAttestationResponse = await response.json();
+
+    if (!result.is_compliant) {
+      throw new Error(
+        `Transaction not compliant: policy=${result.policy_id}, hash=${result.verification_hash}`,
+      );
+    }
+
+    this.logger.debug('Attestation received', {
+      uuid: result.attestation.uuid,
+    });
+    return result;
+  }
+}

--- a/typescript/sdk/src/predicate/PredicateDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/predicate/PredicateDeployer.hardhat-test.ts
@@ -1,0 +1,391 @@
+import { expect } from 'chai';
+import { Signer, constants } from 'ethers';
+import hre from 'hardhat';
+
+import {
+  ERC20Test__factory,
+  HypERC20Collateral,
+  HypERC20Collateral__factory,
+  MockPredicateRegistry,
+  MockPredicateRegistry__factory,
+  PredicateRouterWrapper__factory,
+  TokenRouter__factory,
+} from '@hyperlane-xyz/core';
+import { Address } from '@hyperlane-xyz/utils';
+
+import { TestChainName } from '../consts/testChains.js';
+import { HyperlaneContracts } from '../contracts/types.js';
+import { TestCoreDeployer } from '../core/TestCoreDeployer.js';
+import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDeployer.js';
+import { ProxyFactoryFactories } from '../deploy/contracts.js';
+import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
+import { MultiProtocolProvider } from '../providers/MultiProtocolProvider.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+import { EvmHypCollateralAdapter } from '../token/adapters/EvmTokenAdapter.js';
+
+import { PredicateWrapperDeployer } from './PredicateDeployer.js';
+
+describe('PredicateWrapperDeployer', async () => {
+  const chain = TestChainName.test1;
+  const MOCK_POLICY_ID = 'x-test-policy-123';
+
+  let multiProvider: MultiProvider;
+  let signer: Signer;
+  let signerAddress: Address;
+  let factoryContracts: HyperlaneContracts<ProxyFactoryFactories>;
+  let mailboxAddress: Address;
+  let testTokenAddress: Address;
+  let warpRouteAddress: Address;
+  let mockPredicateRegistry: MockPredicateRegistry;
+
+  before(async () => {
+    [signer] = await hre.ethers.getSigners();
+    signerAddress = await signer.getAddress();
+    multiProvider = MultiProvider.createTestMultiProvider({ signer });
+
+    const factoryDeployer = new HyperlaneProxyFactoryDeployer(multiProvider);
+    const contractsMap = await factoryDeployer.deploy(
+      multiProvider.mapKnownChains(() => ({})),
+    );
+
+    factoryContracts = contractsMap[chain];
+
+    const legacyIsmFactory = new HyperlaneIsmFactory(
+      contractsMap,
+      multiProvider,
+    );
+
+    const testCoreDeployer = new TestCoreDeployer(
+      multiProvider,
+      legacyIsmFactory,
+    );
+
+    const { mailbox } = (await testCoreDeployer.deployApp()).getContracts(
+      chain,
+    );
+    mailboxAddress = mailbox.address;
+
+    const testToken = await new ERC20Test__factory(signer).deploy(
+      'Test Token',
+      'TEST',
+      '1000000000000000000000000',
+      18,
+    );
+    await testToken.deployed();
+    testTokenAddress = testToken.address;
+
+    mockPredicateRegistry = await new MockPredicateRegistry__factory(
+      signer,
+    ).deploy();
+    await mockPredicateRegistry.deployed();
+
+    const collateral = await new HypERC20Collateral__factory(signer).deploy(
+      testTokenAddress,
+      1,
+      mailboxAddress,
+    );
+    await collateral.deployed();
+
+    await collateral.initialize(
+      constants.AddressZero,
+      constants.AddressZero,
+      signerAddress,
+    );
+    warpRouteAddress = collateral.address;
+  });
+
+  describe('deployPredicateWrapper', () => {
+    it('should deploy PredicateRouterWrapper contract', async () => {
+      const deployer = new PredicateWrapperDeployer(
+        multiProvider,
+        factoryContracts.staticAggregationHookFactory,
+      );
+
+      const wrapperAddress = await deployer.deployPredicateWrapper(
+        chain,
+        warpRouteAddress,
+        testTokenAddress,
+        {
+          predicateRegistry: mockPredicateRegistry.address,
+          policyId: MOCK_POLICY_ID,
+        },
+      );
+
+      expect(wrapperAddress).to.be.properAddress;
+
+      const code = await multiProvider
+        .getProvider(chain)
+        .getCode(wrapperAddress);
+      expect(code).to.not.equal('0x');
+    });
+  });
+
+  describe('createAggregationHook', () => {
+    it('should create aggregation hook with two hooks', async () => {
+      const deployer = new PredicateWrapperDeployer(
+        multiProvider,
+        factoryContracts.staticAggregationHookFactory,
+      );
+
+      const wrapperAddress = await deployer.deployPredicateWrapper(
+        chain,
+        warpRouteAddress,
+        testTokenAddress,
+        {
+          predicateRegistry: mockPredicateRegistry.address,
+          policyId: MOCK_POLICY_ID,
+        },
+      );
+
+      const existingHookAddress = '0x1234567890123456789012345678901234567890';
+
+      const aggregationHookAddress = await deployer.createAggregationHook(
+        chain,
+        wrapperAddress,
+        existingHookAddress,
+      );
+
+      expect(aggregationHookAddress).to.be.properAddress;
+
+      const code = await multiProvider
+        .getProvider(chain)
+        .getCode(aggregationHookAddress);
+      expect(code).to.not.equal('0x');
+    });
+  });
+
+  describe('deployAndConfigure', () => {
+    it('should deploy wrapper and aggregate with mailbox default hook when no existing hook', async () => {
+      const newCollateral = await new HypERC20Collateral__factory(
+        signer,
+      ).deploy(testTokenAddress, 1, mailboxAddress);
+      await newCollateral.deployed();
+      await newCollateral.initialize(
+        constants.AddressZero,
+        constants.AddressZero,
+        signerAddress,
+      );
+
+      const deployer = new PredicateWrapperDeployer(
+        multiProvider,
+        factoryContracts.staticAggregationHookFactory,
+      );
+
+      const result = await deployer.deployAndConfigure(
+        chain,
+        newCollateral.address,
+        testTokenAddress,
+        {
+          predicateRegistry: mockPredicateRegistry.address,
+          policyId: MOCK_POLICY_ID,
+        },
+      );
+
+      expect(result.wrapperAddress).to.be.properAddress;
+      expect(result.aggregationHookAddress).to.be.properAddress;
+
+      // Even with no existing hook, we aggregate with mailbox default hook for gas quoting
+      expect(result.wrapperAddress).to.not.equal(result.aggregationHookAddress);
+
+      const router = TokenRouter__factory.connect(
+        newCollateral.address,
+        signer,
+      );
+      const hookOnRouter = await router.hook();
+      expect(hookOnRouter).to.equal(result.aggregationHookAddress);
+    });
+
+    it('should create aggregation hook when existing hook is present', async () => {
+      const existingHook = await new ERC20Test__factory(signer).deploy(
+        'Dummy Hook',
+        'DH',
+        '0',
+        18,
+      );
+      await existingHook.deployed();
+
+      const newCollateral = await new HypERC20Collateral__factory(
+        signer,
+      ).deploy(testTokenAddress, 1, mailboxAddress);
+      await newCollateral.deployed();
+      await newCollateral.initialize(
+        existingHook.address,
+        constants.AddressZero,
+        signerAddress,
+      );
+
+      const deployer = new PredicateWrapperDeployer(
+        multiProvider,
+        factoryContracts.staticAggregationHookFactory,
+      );
+
+      const result = await deployer.deployAndConfigure(
+        chain,
+        newCollateral.address,
+        testTokenAddress,
+        {
+          predicateRegistry: mockPredicateRegistry.address,
+          policyId: MOCK_POLICY_ID,
+        },
+      );
+
+      expect(result.wrapperAddress).to.not.equal(result.aggregationHookAddress);
+
+      const router = TokenRouter__factory.connect(
+        newCollateral.address,
+        signer,
+      );
+      const hookOnRouter = await router.hook();
+      expect(hookOnRouter).to.equal(result.aggregationHookAddress);
+    });
+  });
+
+  describe('Adapter Predicate Support', () => {
+    let wrapperAddress: Address;
+    let collateralWithWrapper: HypERC20Collateral;
+    let multiProtocolProvider: MultiProtocolProvider;
+
+    before(async () => {
+      multiProtocolProvider =
+        MultiProtocolProvider.fromMultiProvider(multiProvider);
+
+      collateralWithWrapper = await new HypERC20Collateral__factory(
+        signer,
+      ).deploy(testTokenAddress, 1, mailboxAddress);
+      await collateralWithWrapper.deployed();
+      await collateralWithWrapper.initialize(
+        constants.AddressZero,
+        constants.AddressZero,
+        signerAddress,
+      );
+
+      const deployer = new PredicateWrapperDeployer(
+        multiProvider,
+        factoryContracts.staticAggregationHookFactory,
+      );
+      const result = await deployer.deployAndConfigure(
+        chain,
+        collateralWithWrapper.address,
+        testTokenAddress,
+        {
+          predicateRegistry: mockPredicateRegistry.address,
+          policyId: MOCK_POLICY_ID,
+        },
+      );
+      wrapperAddress = result.wrapperAddress;
+    });
+
+    it('should detect PredicateRouterWrapper on collateral adapter', async () => {
+      const adapter = new EvmHypCollateralAdapter(
+        chain,
+        multiProtocolProvider,
+        {
+          token: collateralWithWrapper.address,
+        },
+      );
+
+      const detectedWrapper = await (
+        adapter as any
+      ).getPredicateWrapperAddress();
+      expect(detectedWrapper).to.equal(wrapperAddress);
+    });
+
+    it('should return null when no PredicateRouterWrapper present', async () => {
+      const adapter = new EvmHypCollateralAdapter(
+        chain,
+        multiProtocolProvider,
+        {
+          token: warpRouteAddress,
+        },
+      );
+
+      const detectedWrapper = await (
+        adapter as any
+      ).getPredicateWrapperAddress();
+      expect(detectedWrapper).to.be.null;
+    });
+
+    it('should route approval to wrapper when wrapper present', async () => {
+      const adapter = new EvmHypCollateralAdapter(
+        chain,
+        multiProtocolProvider,
+        {
+          token: collateralWithWrapper.address,
+        },
+      );
+
+      const approveTx = await adapter.populateApproveTx({
+        weiAmountOrId: '1000000',
+        recipient: collateralWithWrapper.address,
+      });
+
+      expect(approveTx.to?.toLowerCase()).to.equal(
+        testTokenAddress.toLowerCase(),
+      );
+      expect(approveTx.data).to.include(wrapperAddress.slice(2).toLowerCase());
+    });
+
+    it('should throw error when attestation provided but no wrapper', async () => {
+      const adapter = new EvmHypCollateralAdapter(
+        chain,
+        multiProtocolProvider,
+        {
+          token: warpRouteAddress,
+        },
+      );
+
+      const mockAttestation = {
+        uuid: 'test-uuid',
+        expiration: Math.floor(Date.now() / 1000) + 3600,
+        attester: signerAddress,
+        signature: '0x1234',
+      };
+
+      try {
+        await adapter.populateTransferRemoteTx({
+          weiAmountOrId: '1000000',
+          destination: 2,
+          recipient: signerAddress,
+          attestation: mockAttestation,
+        });
+        expect.fail('Expected error to be thrown');
+      } catch (error: any) {
+        expect(error.message).to.include(
+          'Attestation provided but no PredicateRouterWrapper detected',
+        );
+      }
+    });
+
+    it('should populate transferRemoteWithAttestation when attestation provided', async () => {
+      const adapter = new EvmHypCollateralAdapter(
+        chain,
+        multiProtocolProvider,
+        {
+          token: collateralWithWrapper.address,
+        },
+      );
+
+      const mockAttestation = {
+        uuid: 'test-uuid',
+        expiration: Math.floor(Date.now() / 1000) + 3600,
+        attester: signerAddress,
+        signature: '0x1234',
+      };
+
+      const tx = await adapter.populateTransferRemoteTx({
+        weiAmountOrId: '1000000',
+        destination: 2,
+        recipient: signerAddress,
+        attestation: mockAttestation,
+        interchainGas: {
+          igpQuote: { amount: 0n },
+        },
+      });
+
+      expect(tx.to?.toLowerCase()).to.equal(wrapperAddress.toLowerCase());
+      const iface = PredicateRouterWrapper__factory.createInterface();
+      const selector = iface.getSighash('transferRemoteWithAttestation');
+      expect(tx.data?.startsWith(selector)).to.be.true;
+    });
+  });
+});

--- a/typescript/sdk/src/predicate/PredicateDeployer.ts
+++ b/typescript/sdk/src/predicate/PredicateDeployer.ts
@@ -1,0 +1,168 @@
+import { constants } from 'ethers';
+import { Logger } from 'pino';
+
+import {
+  Mailbox__factory,
+  PredicateRouterWrapper__factory,
+  StaticAggregationHookFactory,
+  TokenRouter__factory,
+} from '@hyperlane-xyz/core';
+import { Address, rootLogger } from '@hyperlane-xyz/utils';
+
+import { MultiProvider } from '../providers/MultiProvider.js';
+import { PredicateWrapperConfig } from '../token/types.js';
+import { ChainName } from '../types.js';
+
+export interface PredicateWrapperDeploymentResult {
+  wrapperAddress: Address;
+  aggregationHookAddress: Address;
+}
+
+export class PredicateWrapperDeployer {
+  private readonly logger: Logger;
+
+  constructor(
+    private readonly multiProvider: MultiProvider,
+    private readonly staticAggregationHookFactory: StaticAggregationHookFactory,
+    logger?: Logger,
+  ) {
+    this.logger =
+      logger ?? rootLogger.child({ module: 'PredicateWrapperDeployer' });
+  }
+
+  async deployPredicateWrapper(
+    chain: ChainName,
+    warpRouteAddress: Address,
+    tokenAddress: Address,
+    config: PredicateWrapperConfig,
+  ): Promise<Address> {
+    const signer = this.multiProvider.getSigner(chain);
+
+    this.logger.info(
+      {
+        chain,
+        warpRoute: warpRouteAddress,
+        registry: config.predicateRegistry,
+      },
+      'Deploying PredicateRouterWrapper',
+    );
+
+    const wrapper = await new PredicateRouterWrapper__factory(signer).deploy(
+      warpRouteAddress,
+      tokenAddress,
+      config.predicateRegistry,
+      config.policyId,
+    );
+    await wrapper.deployed();
+
+    this.logger.info(
+      { chain, address: wrapper.address },
+      'PredicateRouterWrapper deployed',
+    );
+    return wrapper.address;
+  }
+
+  async createAggregationHook(
+    chain: ChainName,
+    predicateWrapperAddress: Address,
+    existingHookAddress: Address,
+  ): Promise<Address> {
+    const signer = this.multiProvider.getSigner(chain);
+
+    this.logger.info(
+      {
+        chain,
+        predicateWrapper: predicateWrapperAddress,
+        existingHook: existingHookAddress,
+      },
+      'Creating aggregation hook',
+    );
+
+    const hooks = [predicateWrapperAddress, existingHookAddress];
+    const threshold = hooks.length;
+
+    const factory = this.staticAggregationHookFactory.connect(signer);
+
+    const existingAddress = await factory['getAddress(address[],uint8)'](
+      hooks,
+      threshold,
+    );
+    const code = await this.multiProvider
+      .getProvider(chain)
+      .getCode(existingAddress);
+
+    let aggregationHookAddress: Address;
+    if (code === '0x') {
+      const overrides = this.multiProvider.getTransactionOverrides(chain);
+      const tx = await factory['deploy(address[],uint8)'](
+        hooks,
+        threshold,
+        overrides,
+      );
+      await this.multiProvider.handleTx(chain, tx);
+      aggregationHookAddress = existingAddress;
+    } else {
+      this.logger.debug(
+        { chain, address: existingAddress },
+        'Recovered existing aggregation hook',
+      );
+      aggregationHookAddress = existingAddress;
+    }
+
+    this.logger.info(
+      { chain, address: aggregationHookAddress },
+      'Aggregation hook ready',
+    );
+    return aggregationHookAddress;
+  }
+
+  async deployAndConfigure(
+    chain: ChainName,
+    warpRouteAddress: Address,
+    tokenAddress: Address,
+    config: PredicateWrapperConfig,
+  ): Promise<PredicateWrapperDeploymentResult> {
+    const signer = this.multiProvider.getSigner(chain);
+    const warpRoute = TokenRouter__factory.connect(warpRouteAddress, signer);
+
+    const existingHook = await warpRoute.hook();
+
+    const wrapperAddress = await this.deployPredicateWrapper(
+      chain,
+      warpRouteAddress,
+      tokenAddress,
+      config,
+    );
+
+    let hookToAggregateWith: Address;
+    if (existingHook !== constants.AddressZero) {
+      hookToAggregateWith = existingHook;
+    } else {
+      const mailboxAddress = await warpRoute.mailbox();
+      const mailbox = Mailbox__factory.connect(mailboxAddress, signer);
+      hookToAggregateWith = await mailbox.defaultHook();
+      this.logger.info(
+        { chain, defaultHook: hookToAggregateWith },
+        'Using mailbox default hook for aggregation (warp route had no existing hook)',
+      );
+    }
+
+    const aggregationHookAddress = await this.createAggregationHook(
+      chain,
+      wrapperAddress,
+      hookToAggregateWith,
+    );
+
+    this.logger.info(
+      { chain, hook: aggregationHookAddress },
+      'Setting hook on warp route',
+    );
+    const tx = await warpRoute.setHook(aggregationHookAddress);
+    await this.multiProvider.handleTx(chain, tx);
+
+    return {
+      wrapperAddress,
+      aggregationHookAddress,
+    };
+  }
+}

--- a/typescript/sdk/src/predicate/index.ts
+++ b/typescript/sdk/src/predicate/index.ts
@@ -1,0 +1,11 @@
+export {
+  PredicateApiClient,
+  PredicateAttestation,
+  PredicateAttestationRequest,
+  PredicateAttestationResponse,
+} from './PredicateApiClient.js';
+
+export {
+  PredicateWrapperDeployer,
+  PredicateWrapperDeploymentResult,
+} from './PredicateDeployer.js';

--- a/typescript/sdk/src/test/testUtils.ts
+++ b/typescript/sdk/src/test/testUtils.ts
@@ -131,7 +131,7 @@ export const hookTypes = Object.values(HookType);
 export const hookTypesToFilter: HookType[] = [
   HookType.OP_STACK,
   HookType.ARB_L2_TO_L1,
-  HookType.CUSTOM,
+  HookType.PREDICATE,
   HookType.CCIP,
 ];
 export const DEFAULT_TOKEN_DECIMALS = 18;

--- a/typescript/sdk/src/token/adapters/ITokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/ITokenAdapter.ts
@@ -1,5 +1,6 @@
 import { Address, Domain, Numberish } from '@hyperlane-xyz/utils';
 
+import type { PredicateAttestation } from '../../predicate/PredicateApiClient.js';
 import { TokenMetadata } from '../types.js';
 
 export interface TransferParams {
@@ -15,6 +16,8 @@ export interface TransferParams {
 export interface TransferRemoteParams extends TransferParams {
   destination: Domain;
   customHook?: Address;
+  /** Optional Predicate attestation for compliance-gated warp routes */
+  attestation?: PredicateAttestation;
 }
 
 export interface QuoteTransferRemoteParams {

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -82,6 +82,22 @@ export const BaseMovableTokenConfigSchema = z.object({
     .optional(),
 });
 
+// Predicate wrapper configuration for compliance-gated transfers
+export const PredicateWrapperConfigSchema = z.object({
+  predicateRegistry: ZHash.describe('Predicate registry contract address'),
+  policyId: z
+    .string()
+    .min(1)
+    .describe('Predicate policy ID for attestation validation'),
+});
+
+export type PredicateWrapperConfig = z.infer<
+  typeof PredicateWrapperConfigSchema
+>;
+export const isPredicateWrapperConfig = isCompliant(
+  PredicateWrapperConfigSchema,
+);
+
 export const NativeTokenConfigSchema = TokenMetadataSchema.partial().extend({
   type: z.enum([TokenType.native, TokenType.nativeScaled]),
   ...BaseMovableTokenConfigSchema.shape,
@@ -127,6 +143,7 @@ export const CollateralTokenConfigSchema = TokenMetadataSchema.partial().extend(
         'Existing token address to extend with Warp Route functionality',
       ),
     ...BaseMovableTokenConfigSchema.shape,
+    predicateWrapper: PredicateWrapperConfigSchema.optional(),
   },
 );
 
@@ -218,6 +235,7 @@ export const isCollateralRebaseTokenConfig = isCompliant(
 export const SyntheticTokenConfigSchema = TokenMetadataSchema.partial().extend({
   type: z.enum([TokenType.synthetic, TokenType.syntheticUri]),
   initialSupply: z.string().or(z.number()).optional(),
+  predicateWrapper: PredicateWrapperConfigSchema.optional(),
 });
 export type SyntheticTokenConfig = z.infer<typeof SyntheticTokenConfigSchema>;
 export const isSyntheticTokenConfig = isCompliant(SyntheticTokenConfigSchema);


### PR DESCRIPTION
## Summary

Add SDK support for PredicateRouterWrapper to enable compliance-gated warp route transfers with Predicate attestations.

## Changes

### SDK - New Modules
- **PredicateApiClient**: API client for fetching compliance attestations from Predicate API
- **PredicateWrapperDeployer**: Deploys PredicateRouterWrapper and creates aggregation hooks
- **TokenDeployer integration**: `deployPredicateWrappers()` method in deploy flow

### SDK - Adapter Modifications
- Extended `TransferRemoteParams` with optional `attestation` field
- Added lazy `PredicateRouterWrapper` detection in `BaseEvmHypCollateralAdapter`
- Route approvals to wrapper when detected
- Route transfers through `transferRemoteWithAttestation()` when attestation provided
- Throw error if attestation provided but no wrapper detected

### SDK - Hook Support
- Added `PREDICATE_ROUTER_WRAPPER` hook type
- Extended `EvmHookReader` to detect PredicateRouterWrapper hooks
- Support detecting wrapper inside aggregation hooks

### Solidity (supporting SDK)
- Added `PREDICATE_ROUTER_WRAPPER` to `IPostDispatchHook.HookTypes` enum
- Extracted `MockPredicateRegistry` to shared contract for SDK hardhat tests
- Updated `PredicateRouterWrapper.hookType` to use new enum value

## Testing
- SDK unit tests: All passing (including 6 PredicateApiClient tests)
- SDK hardhat tests: 423 passing (including 9 predicate-related tests)
- Foundry tests: All passing