### PR TITLE
feat(cli): add Predicate attestation support to warp send

### DIFF
--- a/.changeset/predicate-cli-integration.md
+++ b/.changeset/predicate-cli-integration.md
@@ -1,0 +1,13 @@
+---
+'@hyperlane-xyz/cli': minor
+---
+
+Added CLI support for Predicate attestations in warp send command.
+
+CLI Changes:
+- Added `--predicate-api-key` option to `warp send` for automatic attestation fetching from Predicate API
+- Added `--attestation` option to `warp send` for using pre-obtained attestations (JSON string)
+- Added validation to prevent Predicate usage with native token warp routes (only ERC20 supported)
+- Detect PredicateRouterWrapper address and send to Predicate API for correct attestation target
+- Added E2E tests for warp send with Predicate attestations
+- Added example YAML configs for Predicate warp routes

--- a/typescript/cli/examples/warp-base.yaml
+++ b/typescript/cli/examples/warp-base.yaml
@@ -1,0 +1,25 @@
+    base:
+      owner: "0x380ad2e410688e0153125d01a6af9c4C27F7F0eC"
+      mailbox: "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
+      hook:
+        type: predicateHook
+        address: "0x9995F95aaA827347Bc2AAbF862dF75Ead6E8b97a"
+      interchainSecurityModule: "0x0000000000000000000000000000000000000000"
+      remoteRouters:
+        "1":
+          address: "0x0000000000000000000000005f72c2d341884ddf0f8a18155d8172f56ae1eeec"
+      name: USD Coin
+      symbol: USDC
+      decimals: 6
+      isNft: false
+      contractVersion: 10.1.5
+      type: collateral
+      token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+      allowedRebalancers: []
+      allowedRebalancingBridges: {}
+      proxyAdmin:
+        address: "0x475bB419502213fdb44d89ad94A1234fA3d7B2f9"
+        owner: "0x380ad2e410688e0153125d01a6af9c4C27F7F0eC"
+      destinationGas:
+        "1": "64000"
+    

--- a/typescript/cli/examples/warp-config-predicate-mainnet.yaml
+++ b/typescript/cli/examples/warp-config-predicate-mainnet.yaml
@@ -1,0 +1,13 @@
+base:
+  type: collateral
+  token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+  mailbox: '0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D'
+  owner: '0x380ad2e410688e0153125d01a6af9c4C27F7F0eC'
+  predicateWrapper:
+    predicateRegistry: '0xe15a8Ca5BD8464283818088c1760d8f23B6a216E'
+    policyId: 'x-managed-policy-157b68744498ccac3201a806ef6036ac'
+
+ethereum:
+  type: synthetic
+  mailbox: '0xc005dc82818d67AF737725bD4bf75435d065D239'
+  owner: '0x380ad2e410688e0153125d01a6af9c4C27F7F0eC'

--- a/typescript/cli/examples/warp-deployed-predicate-mainnet.yaml
+++ b/typescript/cli/examples/warp-deployed-predicate-mainnet.yaml
@@ -1,0 +1,19 @@
+tokens:
+  - chainName: base
+    standard: EvmHypCollateral
+    decimals: 6
+    symbol: USDC
+    name: USD Coin
+    addressOrDenom: '0x659CAFbe5A0A5B8357192E7C280Fd1f77C28Bd9C'
+    collateralAddressOrDenom: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+    connections:
+      - token: 'ethereum|ethereum|0x5f72C2D341884Ddf0F8A18155d8172f56Ae1eEEc'
+
+  - chainName: ethereum
+    standard: EvmHypSynthetic
+    decimals: 6
+    symbol: USDC
+    name: USD Coin
+    addressOrDenom: '0x5f72C2D341884Ddf0F8A18155d8172f56Ae1eEEc'
+    connections:
+      - token: 'ethereum|base|0x659CAFbe5A0A5B8357192E7C280Fd1f77C28Bd9C'

--- a/typescript/cli/examples/warp-ethereum.yaml
+++ b/typescript/cli/examples/warp-ethereum.yaml
@@ -1,0 +1,20 @@
+    ethereum:
+      owner: "0x380ad2e410688e0153125d01a6af9c4C27F7F0eC"
+      mailbox: "0xc005dc82818d67AF737725bD4bf75435d065D239"
+      hook: "0x0000000000000000000000000000000000000000"
+      interchainSecurityModule: "0x0000000000000000000000000000000000000000"
+      remoteRouters:
+        "8453":
+          address: "0x000000000000000000000000659cafbe5a0a5b8357192e7c280fd1f77c28bd9c"
+      name: USD Coin
+      symbol: USDC
+      decimals: 6
+      isNft: false
+      contractVersion: 10.1.5
+      type: synthetic
+      proxyAdmin:
+        address: "0x0fbF624e7FD62e01f83862AFdc6a33A6338dB857"
+        owner: "0x380ad2e410688e0153125d01a6af9c4C27F7F0eC"
+      destinationGas:
+        "8453": "68000"
+    

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -265,6 +265,8 @@ const send: CommandModuleWithWriteContext<
       recipient?: string;
       chains?: string;
       skipValidation?: boolean;
+      predicateApiKey?: string;
+      attestation?: string;
     }
 > = {
   command: 'send',
@@ -292,6 +294,14 @@ const send: CommandModuleWithWriteContext<
       description: 'Skip transfer validation (e.g., collateral checks)',
       default: false,
     },
+    'predicate-api-key': {
+      type: 'string',
+      description: 'Predicate API key for fetching attestations automatically',
+    },
+    attestation: {
+      type: 'string',
+      description: 'Pre-obtained Predicate attestation (JSON string)',
+    },
   },
   handler: async ({
     context,
@@ -307,6 +317,8 @@ const send: CommandModuleWithWriteContext<
     roundTrip,
     chains: chainsAsString,
     skipValidation,
+    predicateApiKey,
+    attestation,
   }) => {
     const warpCoreConfig = await getWarpCoreConfigOrExit({
       symbol,
@@ -359,6 +371,8 @@ const send: CommandModuleWithWriteContext<
       skipWaitForDelivery: quick,
       selfRelay: relay,
       skipValidation,
+      predicateApiKey,
+      attestation,
     });
     logGreen(
       `✅ Successfully sent messages for chains: ${chains.join(' ➡️ ')}`,

--- a/typescript/cli/src/tests/ethereum/commands/warp.ts
+++ b/typescript/cli/src/tests/ethereum/commands/warp.ts
@@ -237,6 +237,8 @@ export function hyperlaneWarpSendRelay({
   value = 2,
   chains,
   roundTrip,
+  predicateApiKey,
+  attestation,
 }: {
   origin?: string;
   destination?: string;
@@ -245,6 +247,8 @@ export function hyperlaneWarpSendRelay({
   value?: number | string;
   chains?: string;
   roundTrip?: boolean;
+  predicateApiKey?: string;
+  attestation?: string;
 }): ProcessPromise {
   return $`${localTestRunCmdPrefix()} hyperlane warp send \
         ${relay ? '--relay' : []} \
@@ -257,7 +261,9 @@ export function hyperlaneWarpSendRelay({
         --yes \
         --amount ${value} \
         ${chains ? ['--chains', chains] : []} \
-        ${roundTrip ? ['--round-trip'] : []} `;
+        ${roundTrip ? ['--round-trip'] : []} \
+        ${predicateApiKey ? ['--predicate-api-key', predicateApiKey] : []} \
+        ${attestation ? ['--attestation', attestation] : []} `;
 }
 
 export function hyperlaneWarpRebalancer(

--- a/typescript/cli/src/tests/ethereum/fixtures/warp-config-predicate-base-ethereum.yaml
+++ b/typescript/cli/src/tests/ethereum/fixtures/warp-config-predicate-base-ethereum.yaml
@@ -1,0 +1,20 @@
+# Base (collateral USDC) -> Ethereum (synthetic) warp route with Predicate compliance
+#
+# This configuration deploys a warp route that uses Predicate for compliance-gated transfers.
+# Users must call transferRemoteWithAttestation() on the PredicateRouterWrapper contract
+# instead of transferRemote() on the underlying warp route.
+#
+# Usage:
+#   hyperlane warp deploy --config warp-config-predicate-base-ethereum.yaml --key <private-key>
+
+base:
+  type: collateral
+  token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  mailbox: "0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D"
+  predicateWrapper:
+    predicateRegistry: "0xe15a8Ca5BD8464283818088c1760d8f23B6a216E"
+    policyId: "x-managed-policy-157b68744498ccac3201a806ef6036ac"
+
+ethereum:
+  type: synthetic
+  mailbox: "0xc005dc82818d67AF737725bD4bf75435d065D239"

--- a/typescript/cli/src/tests/ethereum/fixtures/warp-deploy-predicate-command.sh
+++ b/typescript/cli/src/tests/ethereum/fixtures/warp-deploy-predicate-command.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Deploy a Base -> Ethereum USDC warp route with Predicate compliance
+
+set -e
+
+CONFIG_FILE="warp-config-predicate-base-ethereum.yaml"
+WARP_ROUTE_ID="usdc-base-ethereum-predicate"
+
+hyperlane warp deploy \
+  --config "$CONFIG_FILE" \
+  --key "$HYP_KEY" \
+  --warp-route-id "$WARP_ROUTE_ID" \
+  --yes

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy-predicate.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy-predicate.e2e-test.ts
@@ -1,0 +1,239 @@
+import { JsonRpcProvider } from '@ethersproject/providers';
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { Wallet, ethers } from 'ethers';
+
+import {
+  ERC20Test__factory,
+  MockPredicateRegistry__factory,
+  TokenRouter__factory,
+} from '@hyperlane-xyz/core';
+import { type ChainAddresses } from '@hyperlane-xyz/registry';
+import {
+  type ChainMetadata,
+  type CollateralTokenConfig,
+  TokenType,
+  type WarpCoreConfig,
+  type WarpRouteDeployConfig,
+} from '@hyperlane-xyz/sdk';
+import { type Address } from '@hyperlane-xyz/utils';
+
+import { readYamlOrJson, writeYamlOrJson } from '../../../utils/files.js';
+import { deployOrUseExistingCore } from '../commands/core.js';
+import { hyperlaneWarpDeploy, readWarpConfig } from '../commands/warp.js';
+import {
+  ANVIL_KEY,
+  CHAIN_2_METADATA_PATH,
+  CHAIN_3_METADATA_PATH,
+  CHAIN_NAME_2,
+  CHAIN_NAME_3,
+  CORE_CONFIG_PATH,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  TEMP_PATH,
+  WARP_DEPLOY_OUTPUT_PATH,
+  getCombinedWarpRoutePath,
+} from '../consts.js';
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+chai.should();
+
+describe('hyperlane warp deploy with Predicate e2e tests', async function () {
+  this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
+
+  let chain2Metadata: ChainMetadata;
+  let chain3Metadata: ChainMetadata;
+  let chain2Addresses: ChainAddresses = {};
+  let chain3Addresses: ChainAddresses = {};
+
+  let ownerAddress: Address;
+  let walletChain2: Wallet;
+  let providerChain2: JsonRpcProvider;
+  let providerChain3: JsonRpcProvider;
+
+  let testTokenAddress: Address;
+  let mockPredicateRegistryAddress: Address;
+
+  const MOCK_POLICY_ID = 'x-test-policy-predicate-e2e';
+
+  before(async function () {
+    chain2Metadata = readYamlOrJson(CHAIN_2_METADATA_PATH);
+    chain3Metadata = readYamlOrJson(CHAIN_3_METADATA_PATH);
+
+    providerChain2 = new JsonRpcProvider(chain2Metadata.rpcUrls[0].http);
+    providerChain3 = new JsonRpcProvider(chain3Metadata.rpcUrls[0].http);
+    walletChain2 = new Wallet(ANVIL_KEY).connect(providerChain2);
+    ownerAddress = walletChain2.address;
+
+    [chain2Addresses, chain3Addresses] = await Promise.all([
+      deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY),
+      deployOrUseExistingCore(CHAIN_NAME_3, CORE_CONFIG_PATH, ANVIL_KEY),
+    ]);
+
+    const testToken = await new ERC20Test__factory(walletChain2).deploy(
+      'Test Token',
+      'TEST',
+      '1000000000000000000000000',
+      18,
+    );
+    await testToken.deployed();
+    testTokenAddress = testToken.address;
+
+    const mockRegistry = await new MockPredicateRegistry__factory(
+      walletChain2,
+    ).deploy();
+    await mockRegistry.deployed();
+    mockPredicateRegistryAddress = mockRegistry.address;
+  });
+
+  describe('collateral token with Predicate wrapper', () => {
+    const warpDeployPath = `${TEMP_PATH}/warp-deploy-predicate-collateral.yaml`;
+    const warpCoreConfigPath = getCombinedWarpRoutePath('PRED', [
+      CHAIN_NAME_2,
+      CHAIN_NAME_3,
+    ]);
+
+    it('should deploy collateral warp route with Predicate wrapper', async function () {
+      const warpConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.collateral,
+          token: testTokenAddress,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+          predicateWrapper: {
+            predicateRegistry: mockPredicateRegistryAddress,
+            policyId: MOCK_POLICY_ID,
+          },
+        },
+        [CHAIN_NAME_3]: {
+          type: TokenType.synthetic,
+          mailbox: chain3Addresses.mailbox,
+          owner: ownerAddress,
+        },
+      };
+
+      writeYamlOrJson(warpDeployPath, warpConfig);
+
+      await hyperlaneWarpDeploy(warpDeployPath, 'PRED/anvil2-anvil3');
+
+      const deployedConfig = await readWarpConfig(
+        CHAIN_NAME_2,
+        warpCoreConfigPath,
+        WARP_DEPLOY_OUTPUT_PATH,
+      );
+
+      expect(deployedConfig[CHAIN_NAME_2].type).to.equal(TokenType.collateral);
+      const collateralConfig = deployedConfig[
+        CHAIN_NAME_2
+      ] as CollateralTokenConfig;
+      expect(collateralConfig.token).to.equal(testTokenAddress);
+
+      const warpCoreConfig: WarpCoreConfig = readYamlOrJson(warpCoreConfigPath);
+      const chain2Token = warpCoreConfig.tokens.find(
+        (t) => t.chainName === CHAIN_NAME_2,
+      );
+      expect(chain2Token).to.exist;
+      expect(chain2Token!.addressOrDenom).to.exist;
+      expect(ethers.utils.isAddress(chain2Token!.addressOrDenom!)).to.be.true;
+
+      const router = TokenRouter__factory.connect(
+        chain2Token!.addressOrDenom!,
+        walletChain2,
+      );
+      const hookAddress = await router.hook();
+      expect(hookAddress).to.not.equal(
+        '0x0000000000000000000000000000000000000000',
+      );
+    });
+  });
+
+  describe('synthetic token with Predicate wrapper', () => {
+    const warpDeployPath = `${TEMP_PATH}/warp-deploy-predicate-synthetic.yaml`;
+    const warpCoreConfigPath = getCombinedWarpRoutePath('PREDSYN', [
+      CHAIN_NAME_2,
+      CHAIN_NAME_3,
+    ]);
+
+    let mockPredicateRegistryChain3: Address;
+
+    before(async function () {
+      const walletChain3 = new Wallet(ANVIL_KEY).connect(providerChain3);
+      const mockRegistry = await new MockPredicateRegistry__factory(
+        walletChain3,
+      ).deploy();
+      await mockRegistry.deployed();
+      mockPredicateRegistryChain3 = mockRegistry.address;
+    });
+
+    it('should deploy synthetic warp route with Predicate wrapper', async function () {
+      const warpConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.collateral,
+          token: testTokenAddress,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+        },
+        [CHAIN_NAME_3]: {
+          type: TokenType.synthetic,
+          mailbox: chain3Addresses.mailbox,
+          owner: ownerAddress,
+          predicateWrapper: {
+            predicateRegistry: mockPredicateRegistryChain3,
+            policyId: MOCK_POLICY_ID,
+          },
+        },
+      };
+
+      writeYamlOrJson(warpDeployPath, warpConfig);
+
+      await hyperlaneWarpDeploy(warpDeployPath, 'PREDSYN/anvil2-anvil3');
+
+      const warpCoreConfig: WarpCoreConfig = readYamlOrJson(warpCoreConfigPath);
+      const chain3Token = warpCoreConfig.tokens.find(
+        (t) => t.chainName === CHAIN_NAME_3,
+      );
+      expect(chain3Token).to.exist;
+      expect(chain3Token!.addressOrDenom).to.exist;
+      expect(ethers.utils.isAddress(chain3Token!.addressOrDenom!)).to.be.true;
+
+      const walletChain3 = new Wallet(ANVIL_KEY).connect(providerChain3);
+      const router = TokenRouter__factory.connect(
+        chain3Token!.addressOrDenom!,
+        walletChain3,
+      );
+      const hookAddress = await router.hook();
+      expect(hookAddress).to.not.equal(
+        '0x0000000000000000000000000000000000000000',
+      );
+    });
+  });
+
+  describe('native token with Predicate wrapper should fail', () => {
+    const warpDeployPath = `${TEMP_PATH}/warp-deploy-predicate-native.yaml`;
+
+    it('should fail to deploy native warp route with Predicate wrapper', async function () {
+      const warpConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.native,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+          predicateWrapper: {
+            predicateRegistry: mockPredicateRegistryAddress,
+            policyId: MOCK_POLICY_ID,
+          },
+        } as any,
+        [CHAIN_NAME_3]: {
+          type: TokenType.synthetic,
+          mailbox: chain3Addresses.mailbox,
+          owner: ownerAddress,
+        },
+      };
+
+      writeYamlOrJson(warpDeployPath, warpConfig);
+
+      await expect(
+        hyperlaneWarpDeploy(warpDeployPath, 'PREDNATIVE/anvil2-anvil3'),
+      ).to.be.rejected;
+    });
+  });
+});

--- a/typescript/cli/src/tests/ethereum/warp/warp-send-predicate.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-send-predicate.e2e-test.ts
@@ -1,0 +1,304 @@
+import { JsonRpcProvider } from '@ethersproject/providers';
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { Wallet } from 'ethers';
+import sinon from 'sinon';
+
+import {
+  ERC20Test__factory,
+  MockPredicateRegistry__factory,
+} from '@hyperlane-xyz/core';
+import { type ChainAddresses } from '@hyperlane-xyz/registry';
+import {
+  type ChainMetadata,
+  TokenType,
+  type WarpRouteDeployConfig,
+} from '@hyperlane-xyz/sdk';
+import { type Address } from '@hyperlane-xyz/utils';
+
+import { WarpSendLogs } from '../../../send/transfer.js';
+import { readYamlOrJson, writeYamlOrJson } from '../../../utils/files.js';
+import { deployOrUseExistingCore } from '../commands/core.js';
+import {
+  hyperlaneWarpDeploy,
+  hyperlaneWarpSendRelay,
+} from '../commands/warp.js';
+import {
+  ANVIL_KEY,
+  CHAIN_2_METADATA_PATH,
+  CHAIN_NAME_2,
+  CHAIN_NAME_3,
+  CORE_CONFIG_PATH,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  TEMP_PATH,
+  getCombinedWarpRoutePath,
+} from '../consts.js';
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe('hyperlane warp send with Predicate e2e tests', async function () {
+  this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
+
+  let chain2Metadata: ChainMetadata;
+  let chain2Addresses: ChainAddresses = {};
+  let chain3Addresses: ChainAddresses = {};
+
+  let ownerAddress: Address;
+  let walletChain2: Wallet;
+  let providerChain2: JsonRpcProvider;
+
+  let testTokenAddress: Address;
+  let mockPredicateRegistryAddress: Address;
+
+  const MOCK_POLICY_ID = 'x-test-policy-predicate-send-e2e';
+
+  before(async function () {
+    chain2Metadata = readYamlOrJson(CHAIN_2_METADATA_PATH);
+
+    providerChain2 = new JsonRpcProvider(chain2Metadata.rpcUrls[0].http);
+    walletChain2 = new Wallet(ANVIL_KEY).connect(providerChain2);
+    ownerAddress = walletChain2.address;
+
+    [chain2Addresses, chain3Addresses] = await Promise.all([
+      deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY),
+      deployOrUseExistingCore(CHAIN_NAME_3, CORE_CONFIG_PATH, ANVIL_KEY),
+    ]);
+
+    const testToken = await new ERC20Test__factory(walletChain2).deploy(
+      'Predicate Send Test Token',
+      'PSTEST',
+      '1000000000000000000000000',
+      18,
+    );
+    await testToken.deployed();
+    testTokenAddress = testToken.address;
+
+    const mockRegistry = await new MockPredicateRegistry__factory(
+      walletChain2,
+    ).deploy();
+    await mockRegistry.deployed();
+    mockPredicateRegistryAddress = mockRegistry.address;
+  });
+
+  describe('transfer with pre-obtained attestation', () => {
+    const warpDeployPath = `${TEMP_PATH}/warp-deploy-predicate-send.yaml`;
+    const warpCoreConfigPath = getCombinedWarpRoutePath('PREDSEND', [
+      CHAIN_NAME_2,
+      CHAIN_NAME_3,
+    ]);
+
+    before(async function () {
+      const warpConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.collateral,
+          token: testTokenAddress,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+          predicateWrapper: {
+            predicateRegistry: mockPredicateRegistryAddress,
+            policyId: MOCK_POLICY_ID,
+          },
+        },
+        [CHAIN_NAME_3]: {
+          type: TokenType.synthetic,
+          mailbox: chain3Addresses.mailbox,
+          owner: ownerAddress,
+        },
+      };
+
+      writeYamlOrJson(warpDeployPath, warpConfig);
+      await hyperlaneWarpDeploy(warpDeployPath, 'PREDSEND/anvil2-anvil3');
+    });
+
+    it('should transfer using --attestation flag', async function () {
+      const mockAttestation = JSON.stringify({
+        uuid: '550e8400-e29b-41d4-a716-446655440000',
+        expiration: Math.floor(Date.now() / 1000) + 3600,
+        attester: mockPredicateRegistryAddress,
+        signature:
+          '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12',
+      });
+
+      const { exitCode, stdout } = await hyperlaneWarpSendRelay({
+        origin: CHAIN_NAME_2,
+        destination: CHAIN_NAME_3,
+        warpCorePath: warpCoreConfigPath,
+        value: 1,
+        attestation: mockAttestation,
+      });
+
+      expect(exitCode).to.equal(0);
+      expect(stdout).to.include(WarpSendLogs.SUCCESS);
+    });
+  });
+
+  describe('transfer with API key (mocked fetch)', () => {
+    const warpDeployPath = `${TEMP_PATH}/warp-deploy-predicate-send-api.yaml`;
+    const warpCoreConfigPath = getCombinedWarpRoutePath('PREDSENDAPI', [
+      CHAIN_NAME_2,
+      CHAIN_NAME_3,
+    ]);
+
+    let fetchStub: sinon.SinonStub;
+
+    before(async function () {
+      const warpConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.collateral,
+          token: testTokenAddress,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+          predicateWrapper: {
+            predicateRegistry: mockPredicateRegistryAddress,
+            policyId: MOCK_POLICY_ID,
+          },
+        },
+        [CHAIN_NAME_3]: {
+          type: TokenType.synthetic,
+          mailbox: chain3Addresses.mailbox,
+          owner: ownerAddress,
+        },
+      };
+
+      writeYamlOrJson(warpDeployPath, warpConfig);
+      await hyperlaneWarpDeploy(warpDeployPath, 'PREDSENDAPI/anvil2-anvil3');
+    });
+
+    beforeEach(() => {
+      fetchStub = sinon.stub(global, 'fetch');
+      fetchStub.resolves({
+        ok: true,
+        json: async () => ({
+          policy_id: MOCK_POLICY_ID,
+          policy_name: 'Test Policy',
+          verification_hash: 'x-test-hash',
+          is_compliant: true,
+          attestation: {
+            uuid: '550e8400-e29b-41d4-a716-446655440001',
+            expiration: Math.floor(Date.now() / 1000) + 3600,
+            attester: mockPredicateRegistryAddress,
+            signature:
+              '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12',
+          },
+        }),
+      } as Response);
+    });
+
+    afterEach(() => {
+      fetchStub.restore();
+    });
+
+    it('should fetch attestation and transfer using --predicate-api-key flag', async function () {
+      const { exitCode, stdout } = await hyperlaneWarpSendRelay({
+        origin: CHAIN_NAME_2,
+        destination: CHAIN_NAME_3,
+        warpCorePath: warpCoreConfigPath,
+        value: 1,
+        predicateApiKey: 'test-api-key',
+      });
+
+      expect(exitCode).to.equal(0);
+      expect(stdout).to.include(WarpSendLogs.SUCCESS);
+      expect(fetchStub.calledOnce).to.be.true;
+
+      const callArgs = fetchStub.firstCall.args[1] as RequestInit;
+      expect(
+        (callArgs.headers as Record<string, string>)['x-api-key'],
+      ).to.equal('test-api-key');
+    });
+  });
+
+  describe('native token with predicate should fail', () => {
+    const warpDeployPath = `${TEMP_PATH}/warp-deploy-native-send.yaml`;
+    const warpCoreConfigPath = getCombinedWarpRoutePath('NATIVESEND', [
+      CHAIN_NAME_2,
+      CHAIN_NAME_3,
+    ]);
+
+    before(async function () {
+      const warpConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.native,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+        },
+        [CHAIN_NAME_3]: {
+          type: TokenType.synthetic,
+          mailbox: chain3Addresses.mailbox,
+          owner: ownerAddress,
+        },
+      };
+
+      writeYamlOrJson(warpDeployPath, warpConfig);
+      await hyperlaneWarpDeploy(warpDeployPath, 'NATIVESEND/anvil2-anvil3');
+    });
+
+    it('should fail with helpful error message when using attestation with native token', async function () {
+      const mockAttestation = JSON.stringify({
+        uuid: '550e8400-e29b-41d4-a716-446655440000',
+        expiration: Math.floor(Date.now() / 1000) + 3600,
+        attester: mockPredicateRegistryAddress,
+        signature: '0x1234',
+      });
+
+      const { exitCode, stderr } = await hyperlaneWarpSendRelay({
+        origin: CHAIN_NAME_2,
+        destination: CHAIN_NAME_3,
+        warpCorePath: warpCoreConfigPath,
+        value: 1,
+        attestation: mockAttestation,
+      }).nothrow();
+
+      expect(exitCode).to.not.equal(0);
+      expect(stderr).to.include('native token');
+    });
+  });
+
+  describe('attestation without predicate wrapper should fail', () => {
+    const warpDeployPath = `${TEMP_PATH}/warp-deploy-no-predicate.yaml`;
+    const warpCoreConfigPath = getCombinedWarpRoutePath('NOPRED', [
+      CHAIN_NAME_2,
+      CHAIN_NAME_3,
+    ]);
+
+    before(async function () {
+      const warpConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.collateral,
+          token: testTokenAddress,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+        },
+        [CHAIN_NAME_3]: {
+          type: TokenType.synthetic,
+          mailbox: chain3Addresses.mailbox,
+          owner: ownerAddress,
+        },
+      };
+
+      writeYamlOrJson(warpDeployPath, warpConfig);
+      await hyperlaneWarpDeploy(warpDeployPath, 'NOPRED/anvil2-anvil3');
+    });
+
+    it('should fail when route has no PredicateRouterWrapper', async function () {
+      const mockAttestation = JSON.stringify({
+        uuid: '550e8400-e29b-41d4-a716-446655440000',
+        expiration: Math.floor(Date.now() / 1000) + 3600,
+        attester: mockPredicateRegistryAddress,
+        signature: '0x1234',
+      });
+
+      const { exitCode, stderr } = await hyperlaneWarpSendRelay({
+        origin: CHAIN_NAME_2,
+        destination: CHAIN_NAME_3,
+        warpCorePath: warpCoreConfigPath,
+        value: 1,
+        attestation: mockAttestation,
+      }).nothrow();
+
+      expect(exitCode).to.not.equal(0);
+      expect(stderr).to.include('PredicateRouterWrapper');
+    });
+  });
+});

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -14,6 +14,7 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
+import type { PredicateAttestation } from '../predicate/PredicateApiClient.js';
 import { MultiProtocolProvider } from '../providers/MultiProtocolProvider.js';
 import {
   TransactionFeeEstimate,
@@ -364,6 +365,7 @@ export class WarpCore {
     recipient,
     interchainFee,
     tokenFeeQuote,
+    attestation,
   }: {
     originTokenAmount: TokenAmount;
     destination: ChainNameOrId;
@@ -371,6 +373,8 @@ export class WarpCore {
     recipient: Address;
     interchainFee?: TokenAmount;
     tokenFeeQuote?: TokenAmount;
+    /** Optional Predicate attestation for compliance-gated warp routes */
+    attestation?: PredicateAttestation;
   }): Promise<Array<WarpTypedTransaction>> {
     const transactions: Array<WarpTypedTransaction> = [];
 
@@ -495,6 +499,7 @@ export class WarpCore {
       recipient,
       interchainGas,
       customHook: token.igpTokenAddressOrDenom,
+      attestation,
     });
 
     this.logger.debug(`Remote transfer tx for ${token.symbol} populated`);


### PR DESCRIPTION
## Summary
Add CLI support for Predicate compliance-gated warp route transfers via `--predicate-api-key` and `--attestation` options on the `warp send` command.

## Changes
- **`typescript/cli/src/commands/warp.ts`** - Add `--predicate-api-key` and `--attestation` CLI options
- **`typescript/cli/src/send/transfer.ts`** - Implement attestation fetching from Predicate API and PredicateRouterWrapper detection
- **`typescript/sdk/src/warp/WarpCore.ts`** - Add `attestation` parameter to `getTransferRemoteTxs()`
- **E2E tests** - Add tests for predicate warp send scenarios
- **Example configs** - Add YAML configs for Predicate warp routes

## Usage
```bash
# Automatic attestation fetching
hyperlane warp send --origin base --destination ethereum \
  --warp warp-config.yaml \
  --predicate-api-key <API_KEY> \
  --amount 1000000 --recipient 0x...

# Pre-obtained attestation
hyperlane warp send --origin base --destination ethereum \
  --warp warp-config.yaml \
  --attestation '{"uuid":"...","expiration":...,"attester":"0x...","signature":"0x..."}' \
  --amount 1000000 --recipient 0x...
```

## Testing
- E2E tests added for predicate send scenarios
- Manually tested on Base → Ethereum mainnet transfer

## Depends On
This PR targets `vk/c314-implement-sdk-cl` (SDK branch with Predicate wrapper support)