### PR TITLE
fix(aleo-sdk): getBridgedSupply query

### DIFF
--- a/typescript/aleo-sdk/src/clients/provider.ts
+++ b/typescript/aleo-sdk/src/clients/provider.ts
@@ -147,7 +147,7 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
       return 0n;
     }
 
-    return result['max_supply'];
+    return result['supply'];
   }
 
   async estimateTransactionFee(
@@ -483,7 +483,7 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
     const { programId } = fromAleoAddress(req.tokenAddress);
 
     const metadata = await this.queryMappingValue(
-      req.tokenAddress,
+      programId,
       'app_metadata',
       'true',
     );

--- a/typescript/aleo-sdk/src/tests/4_warp.e2e-test.ts
+++ b/typescript/aleo-sdk/src/tests/4_warp.e2e-test.ts
@@ -487,6 +487,11 @@ describe('4. aleo sdk warp e2e tests', async function () {
       mailboxAddress,
     });
     expect(mailbox.nonce).to.equal(1);
+
+    const supply = await signer.getBridgedSupply({
+      tokenAddress: nativeTokenAddress,
+    });
+    expect(supply).to.equal(1000000n);
   });
 
   step('remote transfer with custom hook', async () => {
@@ -556,6 +561,11 @@ describe('4. aleo sdk warp e2e tests', async function () {
       mailboxAddress,
     });
     expect(mailbox.nonce).to.equal(2);
+
+    const supply = await signer.getBridgedSupply({
+      tokenAddress: nativeTokenAddress,
+    });
+    expect(supply).to.equal(2000000n);
   });
 
   step('remote transfer with custom hook and metadata', async () => {
@@ -628,6 +638,11 @@ describe('4. aleo sdk warp e2e tests', async function () {
       mailboxAddress,
     });
     expect(mailbox.nonce).to.equal(3);
+
+    const supply = await signer.getBridgedSupply({
+      tokenAddress: nativeTokenAddress,
+    });
+    expect(supply).to.equal(3000000n);
   });
 
   step('unenroll remote router', async () => {


### PR DESCRIPTION
### Description

There was an error in the getBridgedSupply query for aleo. This PR fixes it and adds some test. This is required for the warp monitor to function correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected token supply calculation logic.
  * Fixed bridged supply tracking for cross-chain token transfers.

* **Tests**
  * Added validation tests to ensure bridged supply accurately reflects cumulative remote transfer amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->