### PR TITLE
fix(infra): add retry logic for sanctioned addresses fetch

### DIFF
--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -19,6 +19,7 @@ import {
   addressToBytes32,
   isValidAddressEvm,
   objMap,
+  retryAsync,
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
@@ -230,8 +231,14 @@ export class RelayerConfigHelper extends AgentConfigHelper<RelayerConfig> {
           },
           'Fetching sanctioned addresses',
         );
-        const json = await fetch(rawUrl);
-        const sanctionedAddresses = schema.parse(await json.json());
+        const sanctionedAddresses = await retryAsync(
+          async () => {
+            const json = await fetch(rawUrl);
+            return schema.parse(await json.json());
+          },
+          3, // attempts
+          1000, // 1s base delay
+        );
         return sanctionedAddresses;
       }),
     );


### PR DESCRIPTION
## Summary
- Wrapped `getSanctionedAddresses` fetch calls with `retryAsync` to handle transient network failures
- Uses 3 attempts with 1s exponential backoff base delay
- Fixes CI flakes caused by `ECONNRESET` errors when fetching OFAC sanctioned address lists

## Test plan
- [x] CI passes on retry (the fix is for transient failures)

Fixes flake: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/21710883976/job/62613876672

🤖 Generated with [Claude Code](https://claude.com/claude-code)