### PR TITLE
fix(ci): Restrict docker workflow tag triggers

### DIFF
--- a/.github/workflows/node-services-docker.yml
+++ b/.github/workflows/node-services-docker.yml
@@ -3,8 +3,6 @@ name: Build and Push Node Services Images to GCR
 on:
   push:
     branches: [main]
-    tags:
-      - '**'
   pull_request:
     paths:
       - 'typescript/rebalancer/**'

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
     tags:
-      - '**'
+      - 'agents-*'
   pull_request:
     paths:
       - 'rust/**'


### PR DESCRIPTION
## Summary
- `rust-docker.yml` was triggering on all tags (`**`) instead of just agent release tags
- `node-services-docker.yml` was also triggering on all tags unnecessarily
- This caused duplicate/unnecessary builds on npm package release tags like `@hyperlane-xyz/cosmos-sdk@24.0.0`

**Fix:**
- `rust-docker.yml`: Only trigger on `agents-*` tags
- `node-services-docker.yml`: Remove tag triggers (no dedicated release tags exist)

## Test plan
- [ ] Verify next npm release doesn't trigger docker builds
- [ ] Verify `agents-*` tags still trigger rust-docker workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to refine automated build and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->