### PR TITLE
chore(ci): update Claude model to opus 4.6

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,10 @@ on:
   issue_comment:
     types: [created]
 
+env:
+  CLAUDE_OPUS_MODEL: claude-opus-4-6
+  CLAUDE_SONNET_MODEL: claude-sonnet-4-5
+
 concurrency:
   group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: false
@@ -82,7 +86,7 @@ jobs:
           track_progress: true
           use_sticky_comment: true
           claude_args: |
-            --model claude-opus-4-6
+            --model ${{ env.CLAUDE_OPUS_MODEL }}
             --max-turns 30
 
   # Security-focused review: auto on PR or manual via @claude security
@@ -166,7 +170,7 @@ jobs:
           upload-results: true
           exclude-directories: 'node_modules,dist,coverage,artifacts,cache,typechain'
           claudecode-timeout: '15'
-          claude-model: claude-opus-4-6
+          claude-model: ${{ env.CLAUDE_OPUS_MODEL }}
           custom-security-scan-instructions: '.github/prompts/security-scan.md'
 
   # Trail of Bits security skills: auto on PR or manual via @claude security
@@ -275,7 +279,7 @@ jobs:
           track_progress: true
           use_sticky_comment: true
           claude_args: |
-            --model claude-opus-4-6
+            --model ${{ env.CLAUDE_OPUS_MODEL }}
             --max-turns 25
 
   # Interactive @claude mentions in comments
@@ -343,5 +347,5 @@ jobs:
           track_progress: true
           use_sticky_comment: true
           claude_args: |
-            --model claude-sonnet-4-5
+            --model ${{ env.CLAUDE_SONNET_MODEL }}
             --max-turns 20


### PR DESCRIPTION
## Summary
- Update `claude-opus-4-5` to `claude-opus-4-6` in the Claude code review workflow (code review, security review, and ToB security skills jobs)

## Test plan
- [ ] Verify workflow triggers correctly on next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)