### PR TITLE
fix(sdk): deploy sub-fee contracts sequentially to prevent nonce collisions

### DIFF
--- a/.changeset/fix-sequential-fee-deploy.md
+++ b/.changeset/fix-sequential-fee-deploy.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Fixed nonce collision in EvmTokenFeeModule by deploying sub-fee contracts sequentially instead of in parallel.


### PR DESCRIPTION
### Description

Fixes a nonce collision bug in `EvmTokenFeeModule.updateRoutingFee()` that occurs when deploying multiple sub-fee contracts on the same chain.

#### Problem

`updateRoutingFee()` used `promiseObjAll(objMap(...))` to iterate over `targetConfig.feeContracts`, which deploys all sub-fee contracts **in parallel**. When multiple destinations need new `LinearFee` contracts (or any sub-fee redeployment) on the same chain, each deployment uses the same signer. Since these transactions are fired concurrently, they all read the same nonce from the signer, causing `nonce too low` errors for all but the first transaction.

This manifests during `warp apply` when adding multiple new destinations to a `RoutingFee` contract — the first deploy succeeds but subsequent ones fail with nonce collisions.

#### Solution

Replaced the parallel `promiseObjAll(objMap(...))` with a sequential `for...of Object.entries(...)` loop. Each sub-fee contract is now deployed one at a time, ensuring the signer's nonce increments correctly between deployments.

This is the same pattern used by `EvmIsmModule.updateRoutingIsm()` and `EvmHookModule` for their sub-contract deployments, which face the identical shared-signer constraint.

The `promiseObjAll` and `objMap` imports are retained since they're still used in `expandConfig()`.

### Drive-by changes

None

### Related issues

None

### Backward compatibility

Yes — no interface changes, only execution order of deployments changed from parallel to sequential.

### Testing

- SDK build: passes (`pnpm -C typescript/sdk build`)
- SDK unit tests: 720 passing (7 pre-existing SmartProvider foundry test failures unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed nonce collision issue in fee contract deployment, ensuring more reliable and stable initialization of sub-fee contracts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->