### PR TITLE
fix(sdk): stale price cache fallback

### DIFF
--- a/.changeset/stale-price-cache-fallback.md
+++ b/.changeset/stale-price-cache-fallback.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Added stale-cache fallback to CoinGecko token price fetcher. When the API returns errors (e.g. 429 rate limiting), previously cached prices are returned instead of undefined, preventing metrics from going stale.

--- a/typescript/sdk/src/gas/token-prices.test.ts
+++ b/typescript/sdk/src/gas/token-prices.test.ts
@@ -50,15 +50,25 @@ describe('TokenPriceGetter', () => {
     });
 
     it('returns stale cached prices on API failure', async () => {
-      // First call populates cache
+      // First call populates cache (real timers)
       await tokenPriceGetter.getTokenPriceByIds(['ethereum', 'solana']);
-      // Subsequent call fails
-      stub.rejects(new Error('429 Too Many Requests'));
-      const result = await tokenPriceGetter.getTokenPriceByIds([
-        'ethereum',
-        'solana',
-      ]);
-      expect(result).to.eql([priceA, priceB]);
+
+      // Jump 15s ahead — past freshSeconds (10s) but before evictionSeconds (3h).
+      // This forces isFresh() to return false so the fetch path is actually hit.
+      const clock = sinon.useFakeTimers(Date.now() + 15_000);
+      try {
+        stub.rejects(new Error('429 Too Many Requests'));
+        const promise = tokenPriceGetter.getTokenPriceByIds([
+          'ethereum',
+          'solana',
+        ]);
+        // Resolve the internal sleep(10) timer
+        await clock.tickAsync(10);
+        const result = await promise;
+        expect(result).to.eql([priceA, priceB]);
+      } finally {
+        clock.restore();
+      }
     });
 
     it('returns undefined on API failure with no cache', async () => {
@@ -68,6 +78,28 @@ describe('TokenPriceGetter', () => {
         'solana',
       ]);
       expect(result).to.be.undefined;
+    });
+
+    it('returns undefined on API failure with partial cache', async () => {
+      // Populate cache for ethereum only
+      stub.resolves([priceA]);
+      await tokenPriceGetter.getTokenPriceByIds(['ethereum']);
+
+      // Jump past freshSeconds so both IDs need re-fetching
+      const clock = sinon.useFakeTimers(Date.now() + 15_000);
+      try {
+        stub.rejects(new Error('429 Too Many Requests'));
+        const promise = tokenPriceGetter.getTokenPriceByIds([
+          'ethereum',
+          'solana',
+        ]);
+        await clock.tickAsync(10);
+        const result = await promise;
+        // solana was never cached, so we cannot serve the full set
+        expect(result).to.be.undefined;
+      } finally {
+        clock.restore();
+      }
     });
   });
 

--- a/typescript/sdk/src/gas/token-prices.test.ts
+++ b/typescript/sdk/src/gas/token-prices.test.ts
@@ -49,22 +49,11 @@ describe('TokenPriceGetter', () => {
       ).to.eql([priceA, priceB]);
     });
 
-    it('returns stale cached prices when API fails', async () => {
-      // First call succeeds and populates cache
-      expect(
-        await tokenPriceGetter.getTokenPriceByIds(['ethereum', 'solana']),
-      ).to.eql([priceA, priceB]);
-
-      // Subsequent call fails (simulate 429 rate limiting)
-      stub.restore();
-      stub = sinon
-        .stub(tokenPriceGetter, 'fetchPriceData')
-        .rejects(new Error('No price found for ethereum'));
-
-      // Cache entries are stale (past freshSeconds) but not evicted,
-      // so the fallback should return them.
-      // We use expirySeconds=10 in beforeEach so freshness window is 10s;
-      // eviction is 3h default, so cached values are still valid.
+    it('returns stale cached prices on API failure', async () => {
+      // First call populates cache
+      await tokenPriceGetter.getTokenPriceByIds(['ethereum', 'solana']);
+      // Subsequent call fails
+      stub.rejects(new Error('429 Too Many Requests'));
       const result = await tokenPriceGetter.getTokenPriceByIds([
         'ethereum',
         'solana',
@@ -72,39 +61,12 @@ describe('TokenPriceGetter', () => {
       expect(result).to.eql([priceA, priceB]);
     });
 
-    it('returns undefined when API fails with no cache', async () => {
-      // Make the very first call fail — nothing in cache
-      stub.restore();
-      stub = sinon
-        .stub(tokenPriceGetter, 'fetchPriceData')
-        .rejects(new Error('No price found for ethereum'));
-
+    it('returns undefined on API failure with no cache', async () => {
+      stub.rejects(new Error('429 Too Many Requests'));
       const result = await tokenPriceGetter.getTokenPriceByIds([
         'ethereum',
         'solana',
       ]);
-      expect(result).to.be.undefined;
-    });
-
-    it('returns undefined when API fails and cache is only partial', async () => {
-      // Populate cache for ethereum only
-      stub.restore();
-      stub = sinon
-        .stub(tokenPriceGetter, 'fetchPriceData')
-        .resolves([priceA]);
-      await tokenPriceGetter.getTokenPriceByIds(['ethereum']);
-
-      // Now fail when querying both
-      stub.restore();
-      stub = sinon
-        .stub(tokenPriceGetter, 'fetchPriceData')
-        .rejects(new Error('rate limited'));
-
-      const result = await tokenPriceGetter.getTokenPriceByIds([
-        'ethereum',
-        'solana',
-      ]);
-      // solana was never cached, so we cannot serve the full set
       expect(result).to.be.undefined;
     });
   });

--- a/typescript/sdk/src/gas/token-prices.ts
+++ b/typescript/sdk/src/gas/token-prices.ts
@@ -51,18 +51,14 @@ class TokenPriceCache {
   }
 
   fetch(id: string): number {
+    const price = this.tryFetch(id);
+    if (price !== undefined) return price;
     const entry = this.cache.get(id);
-    if (!entry) {
-      throw new Error(`no entry found for ${id} in token price cache`);
-    }
-    const evictionTime = new Date(
-      entry.timestamp.getTime() + 1000 * this.evictionSeconds,
+    throw new Error(
+      entry
+        ? `evicted entry found for ${id} in token price cache`
+        : `no entry found for ${id} in token price cache`,
     );
-    const now = new Date();
-    if (now > evictionTime) {
-      throw new Error(`evicted entry found for ${id} in token price cache`);
-    }
-    return entry.price;
   }
 
   tryFetch(id: string): number | undefined {

--- a/typescript/sdk/src/gas/token-prices.ts
+++ b/typescript/sdk/src/gas/token-prices.ts
@@ -65,10 +65,6 @@ class TokenPriceCache {
     return entry.price;
   }
 
-  /**
-   * Non-throwing variant of fetch(). Returns the cached price if the entry
-   * exists and has not been evicted, otherwise returns undefined.
-   */
   tryFetch(id: string): number | undefined {
     const entry = this.cache.get(id);
     if (!entry) return undefined;


### PR DESCRIPTION
### Description

Fixes stale CoinGecko price metrics caused by 429 rate limiting. Previously, `getTokenPriceByIds` would return `undefined` on any API fetch error, even if valid (but stale) cached prices were available. This PR modifies `getTokenPriceByIds` to fall back to returning non-evicted cached prices when the CoinGecko API fails. It introduces a `TokenPriceCache.tryFetch()` method for safe retrieval of cached prices.

### Drive-by changes

*   Added unit tests for stale-cache fallback behavior.
*   Added a changeset file.

### Related issues

N/A

### Backward compatibility

Yes. The change improves resilience by returning stale data instead of `undefined` during API failures, which is a desired behavior.

### Testing

Unit Tests. New tests were added for stale-cache fallback, no-cache, and partial-cache scenarios.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-5501b352-a9a0-47b3-8de6-aa8fb17e490d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5501b352-a9a0-47b3-8de6-aa8fb17e490d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

