### PR TITLE
fix(aleo-sdk): Use correct 'supply' field in getTotalSupply

### DIFF
--- a/typescript/aleo-sdk/src/clients/provider.ts
+++ b/typescript/aleo-sdk/src/clients/provider.ts
@@ -147,7 +147,7 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
       return 0n;
     }
 
-    return result['max_supply'];
+    return result['supply'];
   }
 
   async estimateTransactionFee(


### PR DESCRIPTION
## Description

The Aleo token mapping uses `supply` not `max_supply` for the current total supply. `getTotalSupply` was reading the wrong field, returning `undefined`.

### Drive-by changes

None

### Related issues

None

### Backward compatibility

Yes

### Testing

Manual verification of Aleo token mapping field names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the total supply calculation to return the accurate supply value instead of the maximum supply capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->