### PR TITLE
feat(infra): enable viction scraping

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -483,8 +483,8 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     torus: true,
     unichain: true,
     vana: true,
-    // Has RPC non-compliance that breaks scraping.
-    viction: false,
+    // Note: default rpc.viction.xyz endpoint can't be used for scraping (returns 429s).
+    viction: true,
     worldchain: true,
     xai: true,
     xlayer: true,


### PR DESCRIPTION
## Summary
- Re-enabled viction for the scraper agent role
- Updated comment to document that `rpc.viction.xyz` can't be used for scraping (returns 429s)

## Context
Viction was disabled for scraping with the comment "Has RPC non-compliance that breaks scraping." Investigation showed the issue was `rpc.viction.xyz` returning HTTP 429 Cloudflare rate-limit responses. The other configured providers (dwellir, drpc) pass all scraper-relevant RPC methods cleanly.

Scraper has been running with viction enabled and confirmed working — all 3 indexers (message_dispatch, message_delivery, gas_payment) are successfully writing to the database.

Companion explorer PR: https://github.com/hyperlane-xyz/hyperlane-explorer/pull/271

## Test plan
- [x] Verified dwellir and drpc pass all scraper RPC methods (eth_getLogs, eth_getTransactionReceipt, eth_getBlockByNumber, etc.)
- [x] Deployed scraper with viction enabled, confirmed no errors in logs
- [x] Confirmed all 3 indexers writing data to DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled viction support for Validator and Scraper roles in mainnet3 environment configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->