### PR TITLE
fix: decimals config getter for ETH/viction

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getVictionETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getVictionETHWarpConfig.ts
@@ -74,7 +74,7 @@ export const getVictionETHWarpConfig = async (
       currentChain,
       {
         ...baseConfig,
-
+        decimals: 18,
         tokenFee: getFixedRoutingFeeConfig(
           getWarpFeeOwner(currentChain),
           feeDestinations,


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->
Add decimals to ETH/viction config getter
### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated token decimal configuration in the Viction ETH setup for mainnet environments to ensure proper token representation. The native chain configuration now explicitly includes 18-decimal token precision specification, enabling accurate calculations of token amounts, correct formatting in user interfaces, and consistent behavior across integrated network services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->