### PR TITLE
feat(sdk): add swap utilities for Metaswaps cross-chain swaps

### DIFF
--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -890,6 +890,7 @@ export {
   WarpCoreFeeEstimate,
 } from './warp/types.js';
 export { WarpCore, WarpCoreOptions } from './warp/WarpCore.js';
+export * from './swap/index.js';
 export { EvmTimelockReader } from './timelock/evm/EvmTimelockReader.js';
 export { EvmTimelockDeployer } from './timelock/evm/EvmTimelockDeployer.js';
 export {

--- a/typescript/sdk/src/swap/CommitmentClient.ts
+++ b/typescript/sdk/src/swap/CommitmentClient.ts
@@ -1,0 +1,57 @@
+import {
+  commitmentFromIcaCalls,
+  encodeIcaCalls,
+  normalizeCalls,
+} from '../middleware/account/InterchainAccount.js';
+
+import { CommitmentParams } from './types.js';
+
+export class CommitmentClient {
+  constructor(private readonly serviceUrl: string) {}
+
+  async postCommitment(
+    params: CommitmentParams,
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      const calls = normalizeCalls(params.calls);
+      const commitment = commitmentFromIcaCalls(calls, params.salt);
+      const encodedCalls = encodeIcaCalls(calls, params.salt);
+
+      const resp = await fetch(this.serviceUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          calls: params.calls,
+          encodedCalls,
+          salt: params.salt,
+          commitment,
+          originDomain: params.originDomain,
+          destinationDomain: params.destinationDomain,
+          owner: params.owner,
+          ismOverride: params.ismOverride,
+        }),
+      });
+
+      if (!resp.ok) {
+        return {
+          success: false,
+          error: `Failed to post commitment: ${resp.status} ${await resp.text()}`,
+        };
+      }
+
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  buildCommitmentHash(
+    calls: Array<{ to: string; data: string; value: string }>,
+    salt: string,
+  ): string {
+    return commitmentFromIcaCalls(normalizeCalls(calls), salt);
+  }
+}

--- a/typescript/sdk/src/swap/IcaDerivation.ts
+++ b/typescript/sdk/src/swap/IcaDerivation.ts
@@ -1,0 +1,60 @@
+import { OwnableMulticall__factory } from '@hyperlane-xyz/core';
+import { addressToBytes32 } from '@hyperlane-xyz/utils';
+import { constants, utils } from 'ethers';
+
+import { IcaConfig } from './types.js';
+
+const MINIMAL_PROXY_PREFIX = '0x3d602d80600a3d3981f3363d3d373d3d3d363d73';
+const MINIMAL_PROXY_SUFFIX = '0x5af43d82803e903d91602b57fd5bf3';
+
+function normalizeSalt(userSalt?: string): string {
+  if (!userSalt) return constants.HashZero;
+  if (utils.isHexString(userSalt, 32)) return userSalt;
+  return utils.keccak256(utils.toUtf8Bytes(userSalt));
+}
+
+function getSalt(config: IcaConfig): string {
+  return utils.keccak256(
+    utils.solidityPack(
+      ['uint32', 'bytes32', 'bytes32', 'bytes32', 'bytes32'],
+      [
+        config.origin,
+        addressToBytes32(config.owner),
+        addressToBytes32(config.routerAddress),
+        addressToBytes32(config.ismAddress),
+        normalizeSalt(config.userSalt),
+      ],
+    ),
+  );
+}
+
+function getImplementationAddress(routerAddress: string): string {
+  const implementationInitCode = utils.hexConcat([
+    OwnableMulticall__factory.bytecode,
+    utils.defaultAbiCoder.encode(['address'], [routerAddress]),
+  ]);
+  return utils.getCreate2Address(
+    routerAddress,
+    constants.HashZero,
+    utils.keccak256(implementationInitCode),
+  );
+}
+
+function getProxyBytecodeHash(implementationAddress: string): string {
+  const proxyBytecode = utils.hexConcat([
+    MINIMAL_PROXY_PREFIX,
+    implementationAddress,
+    MINIMAL_PROXY_SUFFIX,
+  ]);
+  return utils.keccak256(proxyBytecode);
+}
+
+export function deriveIcaAddress(config: IcaConfig): string {
+  const implementationAddress = getImplementationAddress(config.routerAddress);
+  const bytecodeHash = getProxyBytecodeHash(implementationAddress);
+  return utils.getCreate2Address(
+    config.routerAddress,
+    getSalt(config),
+    bytecodeHash,
+  );
+}

--- a/typescript/sdk/src/swap/SwapQuoter.ts
+++ b/typescript/sdk/src/swap/SwapQuoter.ts
@@ -1,0 +1,136 @@
+import { Contract, BigNumber, constants, providers } from 'ethers';
+
+import {
+  BridgeQuote,
+  SwapAndBridgeParams,
+  SwapQuote,
+  TotalQuote,
+} from './types.js';
+
+const QUOTER_V2_ABI = [
+  'function quoteExactInputSingle((address tokenIn, address tokenOut, uint256 amountIn, uint24 fee, uint160 sqrtPriceLimitX96)) external returns (uint256 amountOut, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)',
+];
+
+const WARP_ROUTE_ABI = [
+  'function quoteTransferRemote(uint32 destination, bytes32 recipient, uint256 amount) external view returns ((address token, uint256 amount)[] quotes)',
+];
+
+export const QUOTER_ADDRESSES = {
+  arbitrum: '0x61fFE014bA17989E743c5F6cB21bF9697530B21e',
+  base: '0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a',
+};
+
+function resolveQuoterAddress(chainId: number): string {
+  if (chainId === 42161) return QUOTER_ADDRESSES.arbitrum;
+  if (chainId === 8453) return QUOTER_ADDRESSES.base;
+  throw new Error(`Unsupported chainId ${chainId} for QuoterV2`);
+}
+
+function toRate(amountIn: BigNumber, amountOut: BigNumber): string {
+  if (amountIn.isZero()) return '0';
+  return amountOut.mul(constants.WeiPerEther).div(amountIn).toString();
+}
+
+function slippageBps(slippage: number): number {
+  return Math.max(0, Math.floor(slippage * 100));
+}
+
+export async function getSwapQuote(
+  provider: providers.Provider,
+  tokenIn: string,
+  tokenOut: string,
+  amountIn: BigNumber,
+  fee = 500,
+): Promise<BigNumber> {
+  if (tokenIn.toLowerCase() === tokenOut.toLowerCase()) {
+    return amountIn;
+  }
+
+  const network = await provider.getNetwork();
+  const quoterAddress = resolveQuoterAddress(network.chainId);
+  const quoter = new Contract(quoterAddress, QUOTER_V2_ABI, provider);
+  const quote = await quoter.callStatic.quoteExactInputSingle({
+    tokenIn,
+    tokenOut,
+    amountIn,
+    fee,
+    sqrtPriceLimitX96: 0,
+  });
+
+  return quote.amountOut;
+}
+
+export async function getBridgeFee(
+  provider: providers.Provider,
+  warpRouteAddress: string,
+  destination: number,
+  amount: BigNumber,
+): Promise<BridgeQuote> {
+  const warpRoute = new Contract(warpRouteAddress, WARP_ROUTE_ABI, provider);
+  const quotes: Array<{ token: string; amount: BigNumber }> =
+    await warpRoute.callStatic.quoteTransferRemote(
+      destination,
+      constants.HashZero,
+      amount,
+    );
+  const feeQuote = quotes[0];
+
+  return {
+    fee: feeQuote?.amount ?? BigNumber.from(0),
+    feeToken: feeQuote?.token ?? constants.AddressZero,
+  };
+}
+
+export async function getTotalQuote(
+  quoteProviders: {
+    origin: providers.Provider;
+    destination: providers.Provider;
+  },
+  params: SwapAndBridgeParams,
+): Promise<TotalQuote> {
+  const originSwapOutput = await getSwapQuote(
+    quoteProviders.origin,
+    params.originToken,
+    params.bridgeToken,
+    params.amount,
+  );
+
+  const bridge = await getBridgeFee(
+    quoteProviders.origin,
+    params.warpRouteAddress,
+    params.destinationDomain,
+    originSwapOutput,
+  );
+
+  const bridgedAmount = originSwapOutput.sub(bridge.fee);
+
+  const destinationSwapOutput = await getSwapQuote(
+    quoteProviders.destination,
+    params.bridgeToken,
+    params.destinationToken,
+    bridgedAmount,
+  );
+
+  const estimatedOutput = destinationSwapOutput;
+  const minimumReceived = estimatedOutput
+    .mul(10_000 - slippageBps(params.slippage))
+    .div(10_000);
+
+  const quote: SwapQuote = {
+    originSwapOutput,
+    originSwapRate: toRate(params.amount, originSwapOutput),
+    bridgeFee: bridge.fee,
+    destinationSwapOutput,
+    destinationSwapRate: toRate(bridgedAmount, destinationSwapOutput),
+    estimatedOutput,
+    minimumReceived,
+    slippage: params.slippage,
+  };
+
+  return {
+    originSwap: quote,
+    bridge,
+    estimatedOutput,
+    minimumReceived,
+  };
+}

--- a/typescript/sdk/src/swap/UniversalRouterEncoder.ts
+++ b/typescript/sdk/src/swap/UniversalRouterEncoder.ts
@@ -1,0 +1,202 @@
+import { addressToBytes32, eqAddress } from '@hyperlane-xyz/utils';
+import { BigNumber, constants, utils } from 'ethers';
+
+import { SwapAndBridgeParams, UniversalRouterCommand } from './types.js';
+
+export const Commands = {
+  V3_SWAP_EXACT_IN: 0x00,
+  BRIDGE_TOKEN: 0x12,
+  EXECUTE_CROSS_CHAIN: 0x13,
+} as const;
+
+export const BridgeTypes = {
+  HYP_ERC20_COLLATERAL: 0x03,
+} as const;
+
+export type BridgeTokenParams = {
+  bridgeType: number;
+  recipient: string;
+  token: string;
+  bridge: string;
+  amount: BigNumber;
+  msgFee: BigNumber;
+  tokenFee: BigNumber;
+  domain: number;
+  payerIsUser: boolean;
+};
+
+export type ExecuteCrossChainParams = {
+  domain: number;
+  icaRouter: string;
+  remoteRouter: string;
+  ism: string;
+  commitment: string;
+  msgFee: BigNumber;
+  token: string;
+  tokenFee: BigNumber;
+  hook: string;
+  hookMetadata: string;
+};
+
+export type V3SwapExactInParams = {
+  recipient: string;
+  amountIn: BigNumber;
+  amountOutMinimum: BigNumber;
+  path: string;
+  payerIsUser: boolean;
+};
+
+export function encodeBridgeToken(
+  params: BridgeTokenParams,
+): UniversalRouterCommand {
+  const encodedInput = utils.defaultAbiCoder.encode(
+    [
+      'uint8',
+      'bytes32',
+      'address',
+      'address',
+      'uint256',
+      'uint256',
+      'uint256',
+      'uint32',
+      'bool',
+    ],
+    [
+      params.bridgeType,
+      addressToBytes32(params.recipient),
+      params.token,
+      params.bridge,
+      params.amount,
+      params.msgFee,
+      params.tokenFee,
+      params.domain,
+      params.payerIsUser,
+    ],
+  );
+
+  return {
+    commandType: Commands.BRIDGE_TOKEN,
+    encodedInput,
+  };
+}
+
+export function encodeExecuteCrossChain(
+  params: ExecuteCrossChainParams,
+): UniversalRouterCommand {
+  const encodedInput = utils.defaultAbiCoder.encode(
+    [
+      'uint32',
+      'address',
+      'bytes32',
+      'bytes32',
+      'bytes32',
+      'uint256',
+      'address',
+      'uint256',
+      'bytes',
+      'bytes',
+    ],
+    [
+      params.domain,
+      params.icaRouter,
+      addressToBytes32(params.remoteRouter),
+      addressToBytes32(params.ism),
+      params.commitment,
+      params.msgFee,
+      params.token,
+      params.tokenFee,
+      params.hook,
+      params.hookMetadata,
+    ],
+  );
+
+  return {
+    commandType: Commands.EXECUTE_CROSS_CHAIN,
+    encodedInput,
+  };
+}
+
+export function encodeV3SwapExactIn(
+  params: V3SwapExactInParams,
+): UniversalRouterCommand {
+  const encodedInput = utils.defaultAbiCoder.encode(
+    ['address', 'uint256', 'uint256', 'bytes', 'bool'],
+    [
+      params.recipient,
+      params.amountIn,
+      params.amountOutMinimum,
+      params.path,
+      params.payerIsUser,
+    ],
+  );
+
+  return {
+    commandType: Commands.V3_SWAP_EXACT_IN,
+    encodedInput,
+  };
+}
+
+export function buildSwapAndBridgeTx(params: SwapAndBridgeParams): {
+  commands: string;
+  inputs: string[];
+} {
+  const encodedCommands: UniversalRouterCommand[] = [];
+
+  if (!eqAddress(params.originToken, params.bridgeToken)) {
+    const path = utils.solidityPack(
+      ['address', 'uint24', 'address'],
+      [params.originToken, 500, params.bridgeToken],
+    );
+    encodedCommands.push(
+      encodeV3SwapExactIn({
+        recipient: params.universalRouterAddress,
+        amountIn: params.amount,
+        amountOutMinimum: BigNumber.from(0),
+        path,
+        payerIsUser: true,
+      }),
+    );
+  }
+
+  encodedCommands.push(
+    encodeBridgeToken({
+      bridgeType: BridgeTypes.HYP_ERC20_COLLATERAL,
+      recipient: params.recipient,
+      token: params.bridgeToken,
+      bridge: params.warpRouteAddress,
+      amount: params.amount,
+      msgFee: BigNumber.from(0),
+      tokenFee: BigNumber.from(0),
+      domain: params.destinationDomain,
+      payerIsUser: true,
+    }),
+  );
+
+  encodedCommands.push(
+    encodeExecuteCrossChain({
+      domain: params.destinationDomain,
+      icaRouter: params.icaRouterAddress,
+      remoteRouter: params.icaRouterAddress,
+      ism: constants.AddressZero,
+      commitment: constants.HashZero,
+      msgFee: BigNumber.from(0),
+      token: params.bridgeToken,
+      tokenFee: BigNumber.from(0),
+      hook: '0x',
+      hookMetadata: '0x',
+    }),
+  );
+
+  const commands =
+    '0x' +
+    encodedCommands
+      .map((command) =>
+        utils.hexZeroPad(utils.hexlify(command.commandType), 1).slice(2),
+      )
+      .join('');
+
+  return {
+    commands,
+    inputs: encodedCommands.map((command) => command.encodedInput),
+  };
+}

--- a/typescript/sdk/src/swap/index.ts
+++ b/typescript/sdk/src/swap/index.ts
@@ -1,0 +1,5 @@
+export * from './types.js';
+export * from './UniversalRouterEncoder.js';
+export * from './SwapQuoter.js';
+export * from './CommitmentClient.js';
+export * from './IcaDerivation.js';

--- a/typescript/sdk/src/swap/types.ts
+++ b/typescript/sdk/src/swap/types.ts
@@ -1,0 +1,61 @@
+import { BigNumber } from 'ethers';
+
+export interface SwapQuote {
+  originSwapOutput: BigNumber;
+  originSwapRate: string;
+  bridgeFee: BigNumber;
+  destinationSwapOutput: BigNumber;
+  destinationSwapRate: string;
+  estimatedOutput: BigNumber;
+  minimumReceived: BigNumber;
+  slippage: number;
+}
+
+export interface BridgeQuote {
+  fee: BigNumber;
+  feeToken: string;
+}
+
+export interface TotalQuote {
+  originSwap: SwapQuote;
+  bridge: BridgeQuote;
+  estimatedOutput: BigNumber;
+  minimumReceived: BigNumber;
+}
+
+export interface SwapAndBridgeParams {
+  originToken: string;
+  bridgeToken: string;
+  destinationToken: string;
+  amount: BigNumber;
+  recipient: string;
+  originDomain: number;
+  destinationDomain: number;
+  warpRouteAddress: string;
+  icaRouterAddress: string;
+  universalRouterAddress: string;
+  slippage: number;
+}
+
+export interface UniversalRouterCommand {
+  commandType: number;
+  encodedInput: string;
+}
+
+export interface CommitmentParams {
+  calls: Array<{ to: string; data: string; value: string }>;
+  salt: string;
+  originDomain: number;
+  destinationDomain: number;
+  owner: string;
+  ismOverride?: string;
+}
+
+export interface IcaConfig {
+  origin: number;
+  destination: number;
+  owner: string;
+  routerAddress: string;
+  ismAddress: string;
+  userSalt?: string;
+}


### PR DESCRIPTION
## Summary
- Added `typescript/sdk/src/swap/` module with utilities for Metaswaps cross-chain swap flow (Arbitrum ↔ Base)
- Universal Router command encoder (V3_SWAP_EXACT_IN, BRIDGE_TOKEN, EXECUTE_CROSS_CHAIN)
- Swap quoter (Uniswap V3 QuoterV2 + warp route bridge fee)
- Commitment client (wraps existing commitmentFromIcaCalls, shareCallsWithPrivateRelayer)
- ICA address derivation (CREATE2)
- All exported from SDK entry point

## Context
This is the SDK foundation for Metaswaps — any-to-any cross-chain token swaps using the Velodrome Universal Router, 3-message commit-reveal protocol, and Interchain Accounts. The warp-ui-template PR will consume these utilities via a beta release.

## Changes
- `typescript/sdk/src/swap/types.ts` — SwapQuote, SwapAndBridgeParams, CommitmentParams, IcaConfig types
- `typescript/sdk/src/swap/UniversalRouterEncoder.ts` — Command encoding for Velodrome Universal Router
- `typescript/sdk/src/swap/SwapQuoter.ts` — On-chain quote fetching
- `typescript/sdk/src/swap/CommitmentClient.ts` — Call Commitments Service client
- `typescript/sdk/src/swap/IcaDerivation.ts` — ICA address derivation
- `typescript/sdk/src/swap/index.ts` — Re-exports
- `typescript/sdk/src/index.ts` — Added swap module export