### PR TITLE
refactor(cctp): rename maxFeeBps to maxFeePpm for accurate denomination

### DIFF
--- a/.changeset/cctp-maxfee-ppm-rename.md
+++ b/.changeset/cctp-maxfee-ppm-rename.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/core': major
+'@hyperlane-xyz/sdk': minor
+---
+
+Renamed `maxFeeBps` to `maxFeePpm` on `TokenBridgeCctpV2` to accurately reflect the parts-per-million denomination. The on-chain getter, setter, event, and storage slot were all renamed. SDK handles both old (`maxFeeBps()`) and new (`maxFeePpm()`) contract interfaces via version-gated calls.


### PR DESCRIPTION
## Summary

Renames `maxFeeBps` to `maxFeePpm` on `TokenBridgeCctpV2` to accurately reflect the parts-per-million denomination (denominator `1_000_000`). The previous name implied basis points (denominator `10_000`), causing confusion in code and comments.

Addresses ChainLight Q1 2026 audit Question 1.

## Solidity Changes

**`contracts/token/TokenBridgeCctpV2.sol`**:
- `event MaxFeeBpsSet` → `event MaxFeePpmSet`
- `MAX_FEE_BPS_SLOT` → `MAX_FEE_PPM_SLOT` (storage slot string updated — safe since immutable-to-storage migration hasn't been released)
- `maxFeeBps()` → `maxFeePpm()`
- `setMaxFeeBps()` → `setMaxFeePpm()`
- Constructor param `_maxFeeBps` → `_maxFeePpm`
- All NatSpec updated to use "ppm" consistently
- Fixed misleading test comment: `50 // 0.5%` → `50 // 50 ppm = 0.5 bps = 0.005%`

## SDK Changes

**`EvmERC20WarpRouteReader.ts`**:
- Added `CCTP_PPM_STORAGE_VERSION = '10.2.0'` (when on-chain storage switched to ppm)
- Bumped `CCTP_PPM_PRECISION_VERSION` to `'11.0.0'` (when function names changed)
- Version-gated getter: `>= 11.0.0` calls `maxFeePpm()`, older calls `maxFeeBps()` via raw `eth_call`
- ppm→bps conversion still gated on `CCTP_PPM_STORAGE_VERSION` (covers both old and new contracts)

**`deploy.ts`**:
- Version-gated setter: `>= 11.0.0` calls `setMaxFeePpm()`, older calls `setMaxFeeBps()` via raw transaction
- ppm storage conversion gated on `CCTP_PPM_STORAGE_VERSION`

**No changes to**: SDK config schema (`maxFeeBps` field stays in bps for user-facing config), infra configs, or `types.ts`.

## Breaking Change

`TokenBridgeCctpV2` ABI changed — `maxFeeBps()` → `maxFeePpm()`, `setMaxFeeBps()` → `setMaxFeePpm()`, `MaxFeeBpsSet` → `MaxFeePpmSet`. The SDK handles both old and new interfaces transparently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token bridge fee configuration refactored to use parts-per-million (PPM) denomination for improved precision.
  * SDK now includes version-aware compatibility, supporting both legacy and updated fee configuration interfaces during the transition.

* **Breaking Changes**
  * Contract methods for token bridge fee management have been renamed. Existing implementations will need to update their integration points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->