### PR TITLE
fix: add --no-error-on-unmatched-pattern to oxfmt md rule in lint-staged

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,7 +1,7 @@
 {
   "*.js": ["oxlint", "oxfmt --write"],
   "*.ts": ["oxlint", "oxfmt --write"],
-  "*.md": "oxfmt --write",
+  "*.md": "oxfmt --no-error-on-unmatched-pattern --write",
   "*.sol": "prettier --write",
   "*.json": "oxfmt --write"
 }


### PR DESCRIPTION
## Summary
- Added `--no-error-on-unmatched-pattern` to the `*.md` oxfmt rule in `.lintstagedrc`. oxfmt supports markdown but reads `.prettierignore` by default, which ignores `.changeset/`. When the only staged `.md` file is in an ignored directory, oxfmt exits with "Expected at least one target file", failing the pre-commit hook.

```
--no-error-on-unmatched-pattern — Do not exit with error when pattern is unmatched                                                                                                  
                                                                                                                                                                                      
  Normally when oxfmt receives a file path but skips it (e.g. because .prettierignore excludes it), it exits with code 2 and "Expected at least one target file." This flag makes it  
  exit 0 instead — a silent no-op when there's nothing to format.  
```

## Drive-by changes
None

## Related issues
Introduced in #7973 (prettier-to-oxfmt migration)

## Backward compatibility
Yes

## Testing
Verified committing `.changeset/*.md` files no longer fails the pre-commit hook.