### PR TITLE
fix(sdk): assert effective scale unchanged during warp route upgrades

### DIFF
--- a/typescript/sdk/src/utils/decimals.test.ts
+++ b/typescript/sdk/src/utils/decimals.test.ts
@@ -7,7 +7,45 @@ import {
   WarpRouteDeployConfigMailboxRequired,
 } from '../token/types.js';
 
-import { verifyScale } from './decimals.js';
+import { scaleToScalar, verifyScale } from './decimals.js';
+
+describe(scaleToScalar.name, () => {
+  it('should return 1 for undefined', () => {
+    expect(scaleToScalar(undefined)).to.equal(1);
+  });
+
+  it('should return the number directly for numeric scale', () => {
+    expect(scaleToScalar(1_000_000_000_000)).to.equal(1_000_000_000_000);
+    expect(scaleToScalar(1)).to.equal(1);
+  });
+
+  it('should parse string scale', () => {
+    expect(scaleToScalar('1000000000000')).to.equal(1_000_000_000_000);
+    expect(scaleToScalar('1')).to.equal(1);
+  });
+
+  it('should compute numerator / denominator for fractional scale', () => {
+    expect(
+      scaleToScalar({ numerator: 1_000_000_000_000, denominator: 1 }),
+    ).to.equal(1_000_000_000_000);
+    expect(
+      scaleToScalar({ numerator: 1, denominator: 1_000_000_000_000 }),
+    ).to.equal(1e-12);
+    expect(scaleToScalar({ numerator: 1, denominator: 1 })).to.equal(1);
+  });
+
+  it('should handle string numerator and denominator', () => {
+    expect(
+      scaleToScalar({ numerator: '1000000000000', denominator: '1' }),
+    ).to.equal(1_000_000_000_000);
+  });
+
+  it('should treat legacy integer scale as equivalent to {numerator: scale, denominator: 1}', () => {
+    const legacy = 1_000_000_000_000;
+    const fractional = { numerator: 1_000_000_000_000, denominator: 1 };
+    expect(scaleToScalar(legacy)).to.equal(scaleToScalar(fractional));
+  });
+});
 
 describe(verifyScale.name, () => {
   const TOKEN_NAME = 'TOKEN';


### PR DESCRIPTION
## Summary

Addresses [ChainLight Q1 2026 Audit — Question 2](https://gist.github.com/this-is-chainlight/12e7b3f7cb1a43067cb0659a42146072#question-2--scale-upgrade-guarantee-pr7659) regarding scale upgrade guarantees.

- Extracted `scaleToScalar()` helper in `decimals.ts` — converts any scale representation (`number | string | {numerator, denominator} | undefined`) to a scalar number. Refactored `verifyScale()` to use it.
- Added assertion in `upgradeWarpRouteImplementationTx()` that verifies the effective scale (`numerator / denominator`) does not change during implementation upgrades. Scale values are `immutable` (baked into bytecode), so changing them during a proxy upgrade would cause in-flight messages to be decoded with incorrect scaling.
- Added unit tests for `scaleToScalar()` covering all input formats and legacy/fractional equivalence.

### Context

- The legacy single `scale` integer is equivalent to `(scaleNumerator=scale, scaleDenominator=1)`
- Expanding to chains with different decimals uses fresh deployments with appropriate scale — existing contracts' scales never change
- The SDK reader (`fetchScale`) is version-gated: `>= 11.0.0` reads fractional, older reads legacy `scale()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation during Warp Route upgrades to ensure scale configuration consistency remains constant.

* **Tests**
  * Expanded test coverage for scale conversion functionality, including edge cases with undefined inputs, numeric and string formats, fractional scales, and legacy equivalency patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
