### PR TITLE
feat(sealevel): add SOL warp route config for Solana-Celestia

### DIFF
--- a/rust/sealevel/environments/mainnet3/warp-routes/SOL-celestia/token-config.json
+++ b/rust/sealevel/environments/mainnet3/warp-routes/SOL-celestia/token-config.json
@@ -1,0 +1,18 @@
+{
+  "solanamainnet": {
+    "type": "native",
+    "decimals": 9,
+    "name": "Solana",
+    "symbol": "SOL",
+    "owner": "9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf",
+    "uri": "https://raw.githubusercontent.com/hyperlane-xyz/hyperlane-registry/main/deployments/warp_routes/SOL/metadata.json",
+    "interchainGasPaymaster": "AkeHBbE5JkwVppujCQQ6WuxsVsJtruBAjUo6fDCFp6fF"
+  },
+  "celestia": {
+    "type": "synthetic",
+    "decimals": 9,
+    "name": "SOL",
+    "symbol": "SOL",
+    "foreignDeployment": "0x726f757465725f6170700000000000000000000000000002000000000000000a"
+  }
+}

--- a/rust/sealevel/environments/mainnet3/warp-routes/SOL/program-ids.json
+++ b/rust/sealevel/environments/mainnet3/warp-routes/SOL/program-ids.json
@@ -1,0 +1,10 @@
+{
+  "celestia": {
+    "hex": "0x726f757465725f6170700000000000000000000000000002000000000000000a",
+    "base58": "8hi42sG6MAUwJi3u9YbCrmqgsS1bDADu322p29GzrCZf"
+  },
+  "solanamainnet": {
+    "hex": "0x2f09ee7b04e4bb9bedf09825c2964c04899f1778190b9dbf3c3b09863b106221",
+    "base58": "4Acwq4Sw8Y7rZT8traFYmYsxZ86MAe2pQtGgkjh1mHP6"
+  }
+}


### PR DESCRIPTION
## Summary
- Added Sealevel deployment config for the SOL warp route (Solana ↔ Celestia)
- Includes token config (native SOL on Solana, synthetic on Celestia) and program IDs

Companion to https://github.com/hyperlane-xyz/hyperlane-registry/pull/1388

## Test plan
- [ ] Verify config matches deployed programs

🤖 Generated with [Claude Code](https://claude.com/claude-code)