### PR TITLE
fix: use correct decimals for Aleo wallet balance metric

### DIFF
--- a/rust/main/hyperlane-core/src/metrics/agent.rs
+++ b/rust/main/hyperlane-core/src/metrics/agent.rs
@@ -7,6 +7,7 @@ use crate::U256;
 const ETHEREUM_DECIMALS: u8 = 18;
 const COSMOS_DECIMALS: u8 = 6;
 const SOLANA_DECIMALS: u8 = 9;
+const ALEO_DECIMALS: u8 = 6;
 
 /// Interval for querying the prometheus metrics endpoint.
 /// This should be whatever the prometheus scrape interval is
@@ -25,6 +26,7 @@ pub fn decimals_by_protocol(protocol: HyperlaneDomainProtocol) -> u8 {
     match protocol {
         HyperlaneDomainProtocol::Cosmos | HyperlaneDomainProtocol::CosmosNative => COSMOS_DECIMALS,
         HyperlaneDomainProtocol::Sealevel => SOLANA_DECIMALS,
+        HyperlaneDomainProtocol::Aleo => ALEO_DECIMALS,
         _ => ETHEREUM_DECIMALS,
     }
 }


### PR DESCRIPTION
## Summary
- `hyperlane_wallet_balance{chain="aleo"}` was reporting values ~12 orders of magnitude too small (e.g. `9.74e-10` instead of `974.12`)
- Aleo stores balances in **microcredits** (6 decimals), but `decimals_by_protocol()` fell through to the `_ => ETHEREUM_DECIMALS` (18) default
- Added `ALEO_DECIMALS` const (6) and an `Aleo` arm to `decimals_by_protocol()`

## Motivation
Math: `974121737 / 10^18 = 9.74e-10` vs correct `974121737 / 10^6 = 974.12`

## Test plan
- [x] `cargo clippy --features aleo -- -D warnings` passes
- [x] `cargo test -p hyperlane-core` passes
- [x] Released to RC and confirmed `hyperlane_wallet_balance{chain="aleo"}` reports correct values in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Aleo blockchain network with correct decimal precision configuration. This ensures accurate value conversion and scaling across the platform's metrics system, enabling proper asset representation for Aleo-based transactions and calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->