### PR TITLE
chore(infra): update key funder docker image tag

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -47,7 +47,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   // monorepo services
   checkWarpDeploy: 'main',
   // standalone services
-  keyFunder: 'b29a170-20260128-174848',
+  keyFunder: '859a5cc-20260215-033315',
   warpMonitor: '6b6fd0b-20260123-121413',
   rebalancer: '6b6fd0b-20260123-121418',
 };
@@ -60,5 +60,5 @@ export const testnetDockerTags: BaseDockerTags = {
   validatorRC: 'be98c4b-20260206-122528',
   scraper: 'be98c4b-20260206-122528',
   // standalone services
-  keyFunder: 'b29a170-20260128-174848',
+  keyFunder: '859a5cc-20260215-033315',
 };


### PR DESCRIPTION
## Summary

- Updated key funder docker image tag to `859a5cc-20260215-033315` (mainnet + testnet)
- Already deployed to mainnet3 and testnet4

🤖 Generated with [Claude Code](https://claude.com/claude-code)