### PR TITLE
feat(ci): add react doctor workflow for widgets

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,0 +1,25 @@
+name: react-doctor
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'typescript/widgets/**'
+  workflow_dispatch:
+
+jobs:
+  react-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: React Doctor
+        id: react-doctor
+        uses: millionco/react-doctor@0.0.1
+        with:
+          directory: typescript/widgets
+          verbose: 'true'
+
+      - name: Print score
+        run: |
+          echo "React Doctor score: ${{ steps.react-doctor.outputs.score }}/100"


### PR DESCRIPTION
## Summary
- Adds [React Doctor](https://github.com/marketplace/actions/react-doctor) GitHub Action scoped to `typescript/widgets/`
- Scans for React security, performance, correctness, and accessibility issues on PRs that touch widgets
- Produces a 0-100 health score with actionable diagnostics across 60+ rules

## Test plan
- [ ] Verify workflow triggers only on PRs touching `typescript/widgets/**`
- [ ] Review initial score and diagnostics output

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change scoped to a specific path; primary risk is workflow noise or dependency/version issues in the external action.
> 
> **Overview**
> Introduces a new GitHub Actions workflow, `react-doctor`, that runs on PRs to `main` *only when `typescript/widgets/**` changes* (and via manual dispatch).
> 
> The job checks out the repo, runs `millionco/react-doctor@0.0.1` against `typescript/widgets` with verbose output, and prints the resulting 0–100 score to the workflow log.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6eeb56417ba0fe981528d175f54185b03638fcaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->