### PR TITLE
feat(lander): bound EVM reorg detection and add manual reprocess APIs (ENG-3399)

### DIFF
--- a/docs/ai-agents/operational-debugging.md
+++ b/docs/ai-agents/operational-debugging.md
@@ -163,6 +163,16 @@ hyperlane_lander_gas_price{destination="linea"} / 1000000000
 rate(hyperlane_lander_finalized_transactions[5m])
 ```
 
+**Alert for manual Lander reorg intervention (new):**
+
+```promql
+max by (destination, signer) (
+  hyperlane_lander_reorg_manual_intervention_required
+) > 0
+```
+
+Set `for: 5m` and page the oncall. This indicates oversized nonce rollback was detected and automatic reprocessing was intentionally skipped.
+
 ### Debugging Workflow with Grafana + GCP
 
 1. **Start with Grafana metrics:**

--- a/rust/main/agents/relayer/src/server/evm/nonce.rs
+++ b/rust/main/agents/relayer/src/server/evm/nonce.rs
@@ -1,4 +1,6 @@
+pub mod inspect_reorged_transactions;
 pub mod overwrite_upper_nonce;
+pub mod reprocess_reorged_transactions;
 
 use std::{collections::HashMap, sync::Arc};
 
@@ -18,6 +20,14 @@ impl ServerState {
             .route(
                 "/evm/overwrite_upper_nonce",
                 post(overwrite_upper_nonce::handler),
+            )
+            .route(
+                "/evm/inspect_reorged_transactions",
+                post(inspect_reorged_transactions::handler),
+            )
+            .route(
+                "/evm/reprocess_reorged_transactions",
+                post(reprocess_reorged_transactions::handler),
             )
             .with_state(self)
     }

--- a/rust/main/agents/relayer/src/server/evm/nonce/inspect_reorged_transactions.rs
+++ b/rust/main/agents/relayer/src/server/evm/nonce/inspect_reorged_transactions.rs
@@ -1,0 +1,54 @@
+use axum::{extract::State, http::StatusCode, Json};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use hyperlane_base::server::utils::{
+    ServerErrorBody, ServerErrorResponse, ServerResult, ServerSuccessResponse,
+};
+use lander::ReorgedTransactionsInspection;
+
+use super::ServerState;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RequestBody {
+    pub domain_id: u32,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ResponseBody {
+    pub inspection: ReorgedTransactionsInspection,
+}
+
+/// Inspect transactions captured from an oversized reorg window.
+pub async fn handler(
+    State(state): State<ServerState>,
+    Json(payload): Json<RequestBody>,
+) -> ServerResult<ServerSuccessResponse<ResponseBody>> {
+    let RequestBody { domain_id } = payload;
+    debug!(domain_id, "Inspecting oversized reorg transactions");
+
+    let dispatcher_entrypoint = state.entrypoints.get(&domain_id).ok_or_else(|| {
+        warn!(domain_id, "Domain does not exist");
+        ServerErrorResponse::new(
+            StatusCode::NOT_FOUND,
+            ServerErrorBody {
+                message: format!("Domain {domain_id} does not exist"),
+            },
+        )
+    })?;
+
+    let inspection = dispatcher_entrypoint
+        .inspect_reorged_transactions()
+        .await
+        .map_err(|err| {
+            warn!(domain_id, ?err, "Failed to inspect reorged transactions");
+            ServerErrorResponse::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ServerErrorBody {
+                    message: format!("Failed to inspect reorged transactions: {err}"),
+                },
+            )
+        })?;
+
+    Ok(ServerSuccessResponse::new(ResponseBody { inspection }))
+}

--- a/rust/main/agents/relayer/src/server/evm/nonce/reprocess_reorged_transactions.rs
+++ b/rust/main/agents/relayer/src/server/evm/nonce/reprocess_reorged_transactions.rs
@@ -1,0 +1,67 @@
+use axum::{extract::State, http::StatusCode, Json};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use hyperlane_base::server::utils::{
+    ServerErrorBody, ServerErrorResponse, ServerResult, ServerSuccessResponse,
+};
+use lander::LanderError;
+
+use super::ServerState;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RequestBody {
+    pub domain_id: u32,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ResponseBody {
+    pub queued_transactions: usize,
+}
+
+/// Trigger manual reprocessing for transactions captured from an oversized reorg.
+pub async fn handler(
+    State(state): State<ServerState>,
+    Json(payload): Json<RequestBody>,
+) -> ServerResult<ServerSuccessResponse<ResponseBody>> {
+    let RequestBody { domain_id } = payload;
+    debug!(
+        domain_id,
+        "Triggering manual reprocessing for oversized reorg transactions"
+    );
+
+    let dispatcher_entrypoint = state.entrypoints.get(&domain_id).ok_or_else(|| {
+        warn!(domain_id, "Domain does not exist");
+        ServerErrorResponse::new(
+            StatusCode::NOT_FOUND,
+            ServerErrorBody {
+                message: format!("Domain {domain_id} does not exist"),
+            },
+        )
+    })?;
+
+    let queued_transactions = dispatcher_entrypoint
+        .trigger_reprocess_reorged_transactions()
+        .await
+        .map_err(|err| {
+            let status = match err {
+                LanderError::NonRetryableError(_) => StatusCode::BAD_REQUEST,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            warn!(
+                domain_id,
+                ?err,
+                "Failed to trigger manual reprocessing for oversized reorg transactions"
+            );
+            ServerErrorResponse::new(
+                status,
+                ServerErrorBody {
+                    message: format!("Failed to trigger reprocessing: {err}"),
+                },
+            )
+        })?;
+
+    Ok(ServerSuccessResponse::new(ResponseBody {
+        queued_transactions,
+    }))
+}

--- a/rust/main/agents/relayer/src/server/evm/nonce/reprocess_reorged_transactions.rs
+++ b/rust/main/agents/relayer/src/server/evm/nonce/reprocess_reorged_transactions.rs
@@ -16,7 +16,7 @@ pub struct RequestBody {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ResponseBody {
-    pub queued_transactions: usize,
+    pub queued_nonces: usize,
 }
 
 /// Trigger manual reprocessing for transactions captured from an oversized reorg.
@@ -40,7 +40,7 @@ pub async fn handler(
         )
     })?;
 
-    let queued_transactions = dispatcher_entrypoint
+    let queued_nonces = dispatcher_entrypoint
         .trigger_reprocess_reorged_transactions()
         .await
         .map_err(|err| {
@@ -61,7 +61,5 @@ pub async fn handler(
             )
         })?;
 
-    Ok(ServerSuccessResponse::new(ResponseBody {
-        queued_transactions,
-    }))
+    Ok(ServerSuccessResponse::new(ResponseBody { queued_nonces }))
 }

--- a/rust/main/lander/src/adapter.rs
+++ b/rust/main/lander/src/adapter.rs
@@ -2,7 +2,9 @@
 #![allow(unused_imports)]
 
 pub use chains::{AdapterFactory, EthereumTxPrecursor, RadixTxPrecursor, SealevelTxPrecursor};
-pub use core::{AdaptsChain, AdaptsChainAction, GasLimit, TxBuildingResult};
+pub use core::{
+    AdaptsChain, AdaptsChainAction, GasLimit, ReorgedTransactionsInspection, TxBuildingResult,
+};
 
 pub mod chains;
 mod core;

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
@@ -39,7 +39,7 @@ use crate::adapter::chains::ethereum::metrics::{
 };
 use crate::AdaptsChainAction;
 use crate::{
-    adapter::{core::TxBuildingResult, AdaptsChain, GasLimit},
+    adapter::{core::TxBuildingResult, AdaptsChain, GasLimit, ReorgedTransactionsInspection},
     dispatcher::{PayloadDb, PostInclusionMetricsSource, TransactionDb},
     payload::{FullPayload, PayloadDetails},
     transaction::{Transaction, TransactionStatus, TransactionUuid, VmSpecificTxData},
@@ -57,6 +57,21 @@ mod tx_status_checker;
 
 const NONCE_TOO_LOW_ERROR: &str = "nonce too low";
 const DEFAULT_MINIMUM_TIME_BETWEEN_RESUBMISSIONS: Duration = Duration::from_secs(1);
+const MAX_AUTOMATIC_REORG_REPROCESS_NONCES: u64 = 25;
+
+#[derive(Clone, Debug)]
+pub(crate) struct PendingManualReorgRange {
+    start_nonce: U256,
+    end_nonce: U256,
+    old_finalized_nonce: U256,
+    new_finalized_nonce: U256,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ReorgReprocessState {
+    pending_manual_reorg: Option<PendingManualReorgRange>,
+    manual_reprocess_requested: bool,
+}
 
 pub struct EthereumAdapter {
     pub estimated_block_time: Duration,
@@ -72,6 +87,7 @@ pub struct EthereumAdapter {
     pub signer: H160,
     pub minimum_time_between_resubmissions: Duration,
     pub metrics: EthereumAdapterMetrics,
+    pub(crate) reorg_reprocess_state: Arc<Mutex<ReorgReprocessState>>,
 }
 
 impl EthereumAdapter {
@@ -108,6 +124,8 @@ impl EthereumAdapter {
             dispatcher_metrics.get_finalized_nonce(domain, &signer.to_string()),
             dispatcher_metrics.get_upper_nonce(domain, &signer.to_string()),
             dispatcher_metrics.get_mismatched_nonce(domain, &signer.to_string()),
+            dispatcher_metrics.get_reorged_transactions(domain, &signer.to_string()),
+            dispatcher_metrics.get_reorg_manual_intervention_required(domain, &signer.to_string()),
         );
 
         let payload_db = db.clone() as Arc<dyn PayloadDb>;
@@ -129,6 +147,7 @@ impl EthereumAdapter {
             signer,
             minimum_time_between_resubmissions: DEFAULT_MINIMUM_TIME_BETWEEN_RESUBMISSIONS,
             metrics,
+            reorg_reprocess_state: Default::default(),
         };
 
         Ok(adapter)
@@ -377,6 +396,63 @@ impl EthereumAdapter {
 
     pub fn metrics(&self) -> &EthereumAdapterMetrics {
         &self.metrics
+    }
+
+    async fn collect_reorg_txs_in_range(
+        &self,
+        start_nonce: U256,
+        end_nonce: U256,
+    ) -> Result<Vec<Transaction>, LanderError> {
+        let mut txs = Vec::new();
+        let mut nonce = start_nonce;
+        while nonce <= end_nonce {
+            let tx_uuid = self.nonce_manager.state.get_tracked_tx_uuid(&nonce).await?;
+            if tx_uuid == TransactionUuid::default() {
+                debug!(
+                    ?nonce,
+                    "No tracked transaction UUID for nonce in reorg range"
+                );
+            } else if let Some(tx) = self.nonce_manager.state.get_tracked_tx(&tx_uuid).await? {
+                txs.push(tx);
+            } else {
+                debug!(
+                    ?nonce,
+                    ?tx_uuid,
+                    "No transaction found for nonce in reorg range"
+                );
+            }
+            nonce = nonce.saturating_add(U256::one());
+        }
+        Ok(txs)
+    }
+
+    async fn store_pending_manual_reorg_range(
+        &self,
+        old_finalized_nonce: U256,
+        new_finalized_nonce: U256,
+    ) {
+        let mut state = self.reorg_reprocess_state.lock().await;
+        state.pending_manual_reorg = Some(PendingManualReorgRange {
+            start_nonce: new_finalized_nonce.saturating_add(U256::one()),
+            end_nonce: old_finalized_nonce,
+            old_finalized_nonce,
+            new_finalized_nonce,
+        });
+        state.manual_reprocess_requested = false;
+        self.metrics.set_reorg_manual_intervention_required(true);
+    }
+
+    async fn take_requested_manual_reorg_range(&self) -> Option<PendingManualReorgRange> {
+        let mut state = self.reorg_reprocess_state.lock().await;
+        if !state.manual_reprocess_requested {
+            return None;
+        }
+        state.manual_reprocess_requested = false;
+        let range = state.pending_manual_reorg.take();
+        if range.is_some() {
+            self.metrics.set_reorg_manual_intervention_required(false);
+        }
+        range
     }
 }
 
@@ -730,6 +806,19 @@ impl AdaptsChain for EthereumAdapter {
     }
 
     async fn get_reprocess_txs(&self) -> Result<Vec<Transaction>, LanderError> {
+        if let Some(range) = self.take_requested_manual_reorg_range().await {
+            warn!(
+                ?range.old_finalized_nonce,
+                ?range.new_finalized_nonce,
+                ?range.start_nonce,
+                ?range.end_nonce,
+                "Manually triggering reprocessing for transactions captured from oversized reorg"
+            );
+            return self
+                .collect_reorg_txs_in_range(range.start_nonce, range.end_nonce)
+                .await;
+        }
+
         let old_finalized_nonce = self
             .nonce_manager
             .state
@@ -754,27 +843,72 @@ impl AdaptsChain for EthereumAdapter {
             "New finalized nonce is lower than old finalized nonce"
         );
 
-        let mut txs = Vec::new();
-        let mut nonce = new_finalized_nonce.saturating_add(U256::one());
-        while nonce <= old_finalized_nonce {
-            let tx_uuid = self.nonce_manager.state.get_tracked_tx_uuid(&nonce).await?;
-            if tx_uuid == TransactionUuid::default() {
-                debug!(
-                    ?nonce,
-                    "No tracked transaction UUID for nonce in reorg range"
-                );
-            } else if let Some(tx) = self.nonce_manager.state.get_tracked_tx(&tx_uuid).await? {
-                txs.push(tx);
-            } else {
-                debug!(
-                    ?nonce,
-                    ?tx_uuid,
-                    "No transaction found for nonce in reorg range"
-                );
-            }
-            nonce = nonce.saturating_add(U256::one());
+        let reorg_depth = old_finalized_nonce.saturating_sub(new_finalized_nonce);
+        let max_automatic_reorg_range = U256::from(MAX_AUTOMATIC_REORG_REPROCESS_NONCES);
+        if reorg_depth > max_automatic_reorg_range {
+            self.store_pending_manual_reorg_range(old_finalized_nonce, new_finalized_nonce)
+                .await;
+            self.metrics
+                .increment_reorged_transactions(reorg_depth.as_u64());
+            warn!(
+                ?old_finalized_nonce,
+                ?new_finalized_nonce,
+                ?reorg_depth,
+                max_automatic_reorg_range = MAX_AUTOMATIC_REORG_REPROCESS_NONCES,
+                "Oversized reorg detected; skipping automatic reprocessing and requiring manual intervention"
+            );
+            return Ok(Vec::new());
         }
-        Ok(txs)
+
+        self.collect_reorg_txs_in_range(
+            new_finalized_nonce.saturating_add(U256::one()),
+            old_finalized_nonce,
+        )
+        .await
+    }
+
+    async fn inspect_reorged_transactions(
+        &self,
+    ) -> Result<ReorgedTransactionsInspection, LanderError> {
+        let pending = {
+            self.reorg_reprocess_state
+                .lock()
+                .await
+                .pending_manual_reorg
+                .clone()
+        };
+        let Some(pending) = pending else {
+            return Ok(ReorgedTransactionsInspection::default());
+        };
+
+        let txs = self
+            .collect_reorg_txs_in_range(pending.start_nonce, pending.end_nonce)
+            .await?;
+        Ok(ReorgedTransactionsInspection {
+            manual_intervention_required: true,
+            old_finalized_nonce: Some(pending.old_finalized_nonce.to_string()),
+            new_finalized_nonce: Some(pending.new_finalized_nonce.to_string()),
+            reorg_start_nonce: Some(pending.start_nonce.to_string()),
+            reorg_end_nonce: Some(pending.end_nonce.to_string()),
+            transactions: txs,
+        })
+    }
+
+    async fn trigger_reprocess_reorged_transactions(&self) -> Result<usize, LanderError> {
+        let tx_count = self
+            .inspect_reorged_transactions()
+            .await?
+            .transactions
+            .len();
+        if tx_count == 0 {
+            return Err(LanderError::NonRetryableError(
+                "No oversized reorg transactions are pending manual reprocessing".to_string(),
+            ));
+        }
+
+        let mut state = self.reorg_reprocess_state.lock().await;
+        state.manual_reprocess_requested = true;
+        Ok(tx_count)
     }
 
     fn estimated_block_time(&self) -> &std::time::Duration {

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
@@ -935,7 +935,7 @@ impl AdaptsChain for EthereumAdapter {
             .end_nonce
             .saturating_sub(pending.start_nonce)
             .as_u64()
-            + 1;
+            .saturating_add(1);
         state.manual_reprocess_requested = true;
         Ok(queued_nonces as usize)
     }

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
@@ -925,20 +925,19 @@ impl AdaptsChain for EthereumAdapter {
     }
 
     async fn trigger_reprocess_reorged_transactions(&self) -> Result<usize, LanderError> {
-        let tx_count = self
-            .inspect_reorged_transactions()
-            .await?
-            .transactions
-            .len();
-        if tx_count == 0 {
-            return Err(LanderError::NonRetryableError(
-                "No oversized reorg transactions are pending manual reprocessing".to_string(),
-            ));
-        }
-
         let mut state = self.reorg_reprocess_state.lock().await;
+        let pending = state.pending_manual_reorg.as_ref().ok_or_else(|| {
+            LanderError::NonRetryableError(
+                "No oversized reorg transactions are pending manual reprocessing".to_string(),
+            )
+        })?;
+        let queued_nonces = pending
+            .end_nonce
+            .saturating_sub(pending.start_nonce)
+            .as_u64()
+            + 1;
         state.manual_reprocess_requested = true;
-        Ok(tx_count)
+        Ok(queued_nonces as usize)
     }
 
     fn estimated_block_time(&self) -> &std::time::Duration {

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter/tests.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter/tests.rs
@@ -1,4 +1,5 @@
 mod check_if_resubmission_makes_sense;
 mod tests_build;
+mod tests_reprocess;
 mod tests_submit;
 mod vm_specific_metrics;

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter/tests/tests_reprocess.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter/tests/tests_reprocess.rs
@@ -1,0 +1,154 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ethers::types::Address;
+use hyperlane_core::U256;
+
+use crate::adapter::chains::ethereum::tests::{dummy_evm_tx, ExpectedTxType, MockEvmProvider};
+use crate::adapter::AdaptsChain;
+use crate::dispatcher::TransactionDb;
+use crate::tests::evm::test_utils::mock_ethereum_adapter;
+use crate::tests::test_utils::tmp_dbs;
+use crate::{TransactionStatus, TransactionUuid};
+
+async fn store_tracked_tx(
+    adapter: &crate::adapter::chains::ethereum::EthereumAdapter,
+    tx_db: &Arc<dyn TransactionDb>,
+    nonce: u64,
+) -> TransactionUuid {
+    let tx_uuid = TransactionUuid::random();
+    adapter
+        .nonce_manager
+        .state
+        .set_tracked_tx_uuid_test(&U256::from(nonce), &tx_uuid)
+        .await
+        .unwrap();
+
+    let mut tx = dummy_evm_tx(
+        ExpectedTxType::Legacy,
+        Vec::new(),
+        TransactionStatus::Finalized,
+        adapter.signer,
+    );
+    tx.uuid = tx_uuid.clone();
+    tx_db.store_transaction_by_uuid(&tx).await.unwrap();
+    tx_uuid
+}
+
+#[tokio::test]
+async fn test_get_reprocess_txs_oversized_reorg_requires_manual_trigger() {
+    let (payload_db, tx_db, nonce_db) = tmp_dbs();
+    let mut provider = MockEvmProvider::new();
+
+    // old finalized nonce is set in DB to 200 below.
+    // next nonce 100 => new finalized nonce 99, depth 101 (>25)
+    provider
+        .expect_get_next_nonce_on_finalized_block()
+        .returning(|_, _| Ok(U256::from(100)));
+
+    let signer = Address::random();
+    let adapter = mock_ethereum_adapter(
+        provider,
+        payload_db,
+        tx_db.clone(),
+        nonce_db,
+        signer,
+        Duration::from_millis(100),
+        Duration::from_millis(100),
+    );
+
+    adapter
+        .nonce_manager
+        .state
+        .set_finalized_nonce_test(&U256::from(200))
+        .await
+        .unwrap();
+
+    let expected_uuids = HashSet::from([
+        store_tracked_tx(&adapter, &tx_db, 150).await,
+        store_tracked_tx(&adapter, &tx_db, 151).await,
+        store_tracked_tx(&adapter, &tx_db, 152).await,
+    ]);
+
+    let auto_reprocess_txs = adapter.get_reprocess_txs().await.unwrap();
+    assert!(
+        auto_reprocess_txs.is_empty(),
+        "oversized reorg should skip automatic reprocessing"
+    );
+
+    let inspection = adapter.inspect_reorged_transactions().await.unwrap();
+    assert!(inspection.manual_intervention_required);
+    assert_eq!(inspection.old_finalized_nonce.as_deref(), Some("200"));
+    assert_eq!(inspection.new_finalized_nonce.as_deref(), Some("99"));
+    assert_eq!(inspection.transactions.len(), 3);
+
+    let inspected_uuids: HashSet<_> = inspection
+        .transactions
+        .iter()
+        .map(|tx| tx.uuid.clone())
+        .collect();
+    assert_eq!(inspected_uuids, expected_uuids);
+
+    let queued = adapter
+        .trigger_reprocess_reorged_transactions()
+        .await
+        .unwrap();
+    assert_eq!(queued, 3);
+
+    let manual_reprocess_txs = adapter.get_reprocess_txs().await.unwrap();
+    assert_eq!(manual_reprocess_txs.len(), 3);
+    let manual_uuids: HashSet<_> = manual_reprocess_txs
+        .iter()
+        .map(|tx| tx.uuid.clone())
+        .collect();
+    assert_eq!(manual_uuids, expected_uuids);
+
+    let post_manual_inspection = adapter.inspect_reorged_transactions().await.unwrap();
+    assert!(!post_manual_inspection.manual_intervention_required);
+    assert!(post_manual_inspection.transactions.is_empty());
+}
+
+#[tokio::test]
+async fn test_get_reprocess_txs_small_reorg_reprocesses_automatically() {
+    let (payload_db, tx_db, nonce_db) = tmp_dbs();
+    let mut provider = MockEvmProvider::new();
+
+    // old finalized nonce is set in DB to 50 below.
+    // next nonce 41 => new finalized nonce 40, depth 10 (<=25)
+    provider
+        .expect_get_next_nonce_on_finalized_block()
+        .returning(|_, _| Ok(U256::from(41)));
+
+    let signer = Address::random();
+    let adapter = mock_ethereum_adapter(
+        provider,
+        payload_db,
+        tx_db.clone(),
+        nonce_db,
+        signer,
+        Duration::from_millis(100),
+        Duration::from_millis(100),
+    );
+
+    adapter
+        .nonce_manager
+        .state
+        .set_finalized_nonce_test(&U256::from(50))
+        .await
+        .unwrap();
+
+    let expected_uuids = HashSet::from([
+        store_tracked_tx(&adapter, &tx_db, 41).await,
+        store_tracked_tx(&adapter, &tx_db, 45).await,
+    ]);
+
+    let reprocess_txs = adapter.get_reprocess_txs().await.unwrap();
+    assert_eq!(reprocess_txs.len(), 2);
+    let actual_uuids: HashSet<_> = reprocess_txs.iter().map(|tx| tx.uuid.clone()).collect();
+    assert_eq!(actual_uuids, expected_uuids);
+
+    let inspection = adapter.inspect_reorged_transactions().await.unwrap();
+    assert!(!inspection.manual_intervention_required);
+    assert!(inspection.transactions.is_empty());
+}

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter/tests/tests_reprocess.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter/tests/tests_reprocess.rs
@@ -94,7 +94,7 @@ async fn test_get_reprocess_txs_oversized_reorg_requires_manual_trigger() {
         .trigger_reprocess_reorged_transactions()
         .await
         .unwrap();
-    assert_eq!(queued, 3);
+    assert_eq!(queued, 101);
 
     let manual_reprocess_txs = adapter.get_reprocess_txs().await.unwrap();
     assert_eq!(manual_reprocess_txs.len(), 3);

--- a/rust/main/lander/src/adapter/chains/ethereum/metrics.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/metrics.rs
@@ -22,8 +22,8 @@ pub struct EthereumAdapterMetrics {
     /// Counts how many times we've noticed the nonce in tx is different from nonce
     /// stored in db
     mismatch_nonce: IntGauge,
-    /// Number of transactions seen in oversized reorg windows.
-    reorged_transactions: IntCounter,
+    /// Number of nonces seen in reorg windows.
+    reorged_nonces: IntCounter,
     /// Whether oversized reorg processing needs manual intervention.
     reorg_manual_intervention_required: IntGauge,
 }
@@ -35,7 +35,7 @@ impl EthereumAdapterMetrics {
         finalized_nonce: IntGauge,
         upper_nonce: IntGauge,
         mismatch_nonce: IntGauge,
-        reorged_transactions: IntCounter,
+        reorged_nonces: IntCounter,
         reorg_manual_intervention_required: IntGauge,
     ) -> Self {
         Self {
@@ -44,7 +44,7 @@ impl EthereumAdapterMetrics {
             finalized_nonce,
             upper_nonce,
             mismatch_nonce,
-            reorged_transactions,
+            reorged_nonces,
             reorg_manual_intervention_required,
         }
     }
@@ -75,8 +75,8 @@ impl EthereumAdapterMetrics {
         &self.mismatch_nonce
     }
 
-    pub fn increment_reorged_transactions(&self, amount: u64) {
-        self.reorged_transactions.inc_by(amount);
+    pub fn increment_reorged_nonces(&self, amount: u64) {
+        self.reorged_nonces.inc_by(amount);
     }
 
     pub fn set_reorg_manual_intervention_required(&self, required: bool) {
@@ -100,7 +100,7 @@ impl EthereumAdapterMetrics {
             dispatcher_metrics.get_finalized_nonce(domain, signer),
             dispatcher_metrics.get_upper_nonce(domain, signer),
             dispatcher_metrics.get_mismatched_nonce(domain, signer),
-            dispatcher_metrics.get_reorged_transactions(domain, signer),
+            dispatcher_metrics.get_reorged_nonces(domain, signer),
             dispatcher_metrics.get_reorg_manual_intervention_required(domain, signer),
         )
     }

--- a/rust/main/lander/src/adapter/chains/ethereum/metrics.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/metrics.rs
@@ -1,7 +1,7 @@
 use ethers_core::abi::Int;
 use prometheus::{
     opts, register_int_gauge_vec_with_registry, register_int_gauge_with_registry, Encoder,
-    IntCounterVec, IntGauge, IntGaugeVec, Registry,
+    IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Registry,
 };
 use serde_json::to_string;
 
@@ -22,6 +22,10 @@ pub struct EthereumAdapterMetrics {
     /// Counts how many times we've noticed the nonce in tx is different from nonce
     /// stored in db
     mismatch_nonce: IntGauge,
+    /// Number of transactions seen in oversized reorg windows.
+    reorged_transactions: IntCounter,
+    /// Whether oversized reorg processing needs manual intervention.
+    reorg_manual_intervention_required: IntGauge,
 }
 
 impl EthereumAdapterMetrics {
@@ -31,6 +35,8 @@ impl EthereumAdapterMetrics {
         finalized_nonce: IntGauge,
         upper_nonce: IntGauge,
         mismatch_nonce: IntGauge,
+        reorged_transactions: IntCounter,
+        reorg_manual_intervention_required: IntGauge,
     ) -> Self {
         Self {
             domain,
@@ -38,6 +44,8 @@ impl EthereumAdapterMetrics {
             finalized_nonce,
             upper_nonce,
             mismatch_nonce,
+            reorged_transactions,
+            reorg_manual_intervention_required,
         }
     }
 
@@ -66,6 +74,15 @@ impl EthereumAdapterMetrics {
     pub fn get_mismatched_nonce(&self) -> &IntGauge {
         &self.mismatch_nonce
     }
+
+    pub fn increment_reorged_transactions(&self, amount: u64) {
+        self.reorged_transactions.inc_by(amount);
+    }
+
+    pub fn set_reorg_manual_intervention_required(&self, required: bool) {
+        self.reorg_manual_intervention_required
+            .set(if required { 1 } else { 0 });
+    }
 }
 
 #[cfg(test)]
@@ -83,6 +100,8 @@ impl EthereumAdapterMetrics {
             dispatcher_metrics.get_finalized_nonce(domain, signer),
             dispatcher_metrics.get_upper_nonce(domain, signer),
             dispatcher_metrics.get_mismatched_nonce(domain, signer),
+            dispatcher_metrics.get_reorged_transactions(domain, signer),
+            dispatcher_metrics.get_reorg_manual_intervention_required(domain, signer),
         )
     }
 

--- a/rust/main/lander/src/adapter/core.rs
+++ b/rust/main/lander/src/adapter/core.rs
@@ -26,6 +26,16 @@ pub enum AdaptsChainAction {
     OverwriteUpperNonce { nonce: Option<u64> },
 }
 
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+pub struct ReorgedTransactionsInspection {
+    pub manual_intervention_required: bool,
+    pub old_finalized_nonce: Option<String>,
+    pub new_finalized_nonce: Option<String>,
+    pub reorg_start_nonce: Option<String>,
+    pub reorg_end_nonce: Option<String>,
+    pub transactions: Vec<Transaction>,
+}
+
 #[derive(new, Debug, Clone, PartialEq)]
 pub struct TxBuildingResult {
     /// payload details for the payloads in this transaction
@@ -145,6 +155,19 @@ pub trait AdaptsChain: Send + Sync {
     /// as part of determining which transactions need reprocessing.
     async fn get_reprocess_txs(&self) -> Result<Vec<Transaction>, LanderError> {
         Ok(Vec::new())
+    }
+
+    /// Inspect transactions captured from a previously detected oversized reorg.
+    async fn inspect_reorged_transactions(
+        &self,
+    ) -> Result<ReorgedTransactionsInspection, LanderError> {
+        Ok(ReorgedTransactionsInspection::default())
+    }
+
+    /// Trigger manual reprocessing for transactions captured from a previously
+    /// detected oversized reorg.
+    async fn trigger_reprocess_reorged_transactions(&self) -> Result<usize, LanderError> {
+        Ok(0)
     }
 
     async fn run_command(&self, action: AdaptsChainAction) -> Result<(), LanderError> {

--- a/rust/main/lander/src/dispatcher/command_entrypoint.rs
+++ b/rust/main/lander/src/dispatcher/command_entrypoint.rs
@@ -1,15 +1,32 @@
 use async_trait::async_trait;
 
-use crate::{AdaptsChainAction, DispatcherEntrypoint, LanderError};
+use crate::{AdaptsChainAction, DispatcherEntrypoint, LanderError, ReorgedTransactionsInspection};
 
 #[async_trait]
 pub trait CommandEntrypoint: Sync + Send {
     async fn execute_command(&self, action: AdaptsChainAction) -> Result<(), LanderError>;
+    async fn inspect_reorged_transactions(
+        &self,
+    ) -> Result<ReorgedTransactionsInspection, LanderError>;
+    async fn trigger_reprocess_reorged_transactions(&self) -> Result<usize, LanderError>;
 }
 
 #[async_trait]
 impl CommandEntrypoint for DispatcherEntrypoint {
     async fn execute_command(&self, action: AdaptsChainAction) -> Result<(), LanderError> {
         self.inner.adapter.run_command(action).await
+    }
+
+    async fn inspect_reorged_transactions(
+        &self,
+    ) -> Result<ReorgedTransactionsInspection, LanderError> {
+        self.inner.adapter.inspect_reorged_transactions().await
+    }
+
+    async fn trigger_reprocess_reorged_transactions(&self) -> Result<usize, LanderError> {
+        self.inner
+            .adapter
+            .trigger_reprocess_reorged_transactions()
+            .await
     }
 }

--- a/rust/main/lander/src/dispatcher/metrics.rs
+++ b/rust/main/lander/src/dispatcher/metrics.rs
@@ -59,8 +59,8 @@ pub struct DispatcherMetrics {
     /// Counts how many times we've noticed the nonce in tx is different from nonce
     /// stored in db
     mismatched_nonce: IntGaugeVec,
-    /// Number of transactions identified in oversized reorg windows.
-    reorged_transactions: IntCounterVec,
+    /// Number of nonces identified in reorg windows.
+    reorged_nonces: IntCounterVec,
     /// Whether manual intervention is required for oversized reorg reprocessing.
     reorg_manual_intervention_required: IntGaugeVec,
     /// Gas limit set for the transaction, if applicable
@@ -212,10 +212,10 @@ impl DispatcherMetrics {
             &["destination", "signer",],
             registry.clone()
         )?;
-        let reorged_transactions = register_int_counter_vec_with_registry!(
+        let reorged_nonces = register_int_counter_vec_with_registry!(
             opts!(
-                namespaced("reorged_transactions"),
-                "Number of transactions observed in oversized reorg windows",
+                namespaced("reorged_nonces"),
+                "Number of nonces observed in reorg windows",
             ),
             &["destination", "signer",],
             registry.clone()
@@ -246,7 +246,7 @@ impl DispatcherMetrics {
             finalized_nonce,
             upper_nonce,
             mismatched_nonce,
-            reorged_transactions,
+            reorged_nonces,
             reorg_manual_intervention_required,
             gas_limit,
             inclusion_stage_error,
@@ -361,8 +361,8 @@ impl DispatcherMetrics {
             .clone()
     }
 
-    pub fn get_reorged_transactions(&self, destination: &str, signer: &str) -> IntCounter {
-        self.reorged_transactions
+    pub fn get_reorged_nonces(&self, destination: &str, signer: &str) -> IntCounter {
+        self.reorged_nonces
             .with_label_values(&[destination, signer])
             .clone()
     }

--- a/rust/main/lander/src/lib.rs
+++ b/rust/main/lander/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(clippy::arithmetic_side_effects)]
 
 pub use adapter::AdaptsChainAction;
+pub use adapter::ReorgedTransactionsInspection;
 pub use dispatcher::command_entrypoint::CommandEntrypoint;
 pub use dispatcher::entrypoint::{DispatcherEntrypoint, Entrypoint};
 pub use dispatcher::{DatabaseOrPath, Dispatcher, DispatcherMetrics, DispatcherSettings};
@@ -10,7 +11,9 @@ pub use payload::{
     DropReason as PayloadDropReason, FullPayload, PayloadStatus, PayloadUuid,
     RetryReason as PayloadRetryReason,
 };
-pub use transaction::{DropReason as TransactionDropReason, TransactionStatus, TransactionUuid};
+pub use transaction::{
+    DropReason as TransactionDropReason, Transaction, TransactionStatus, TransactionUuid,
+};
 
 mod adapter;
 mod dispatcher;

--- a/rust/main/lander/src/tests/evm/test_utils.rs
+++ b/rust/main/lander/src/tests/evm/test_utils.rs
@@ -145,6 +145,7 @@ pub fn mock_ethereum_adapter(
         signer,
         minimum_time_between_resubmissions,
         metrics,
+        reorg_reprocess_state: Default::default(),
     }
 }
 

--- a/rust/main/lander/src/tests/test_utils.rs
+++ b/rust/main/lander/src/tests/test_utils.rs
@@ -9,7 +9,7 @@ use hyperlane_core::identifiers::UniqueIdentifier;
 use hyperlane_core::KnownHyperlaneDomain;
 
 use crate::adapter::chains::ethereum::NonceDb;
-use crate::adapter::{AdaptsChain, GasLimit, TxBuildingResult};
+use crate::adapter::{AdaptsChain, GasLimit, ReorgedTransactionsInspection, TxBuildingResult};
 use crate::dispatcher::{DispatcherMetrics, PayloadDb, TransactionDb};
 use crate::error::LanderError;
 use crate::payload::{FullPayload, PayloadDetails, PayloadStatus};
@@ -37,6 +37,8 @@ mockall::mock! {
         async fn replace_tx(&self, _tx: &Transaction) -> Result<(), LanderError>;
         fn reprocess_txs_poll_rate(&self) -> Option<std::time::Duration>;
         async fn get_reprocess_txs(&self) -> Result<Vec<Transaction>, LanderError>;
+        async fn inspect_reorged_transactions(&self) -> Result<ReorgedTransactionsInspection, LanderError>;
+        async fn trigger_reprocess_reorged_transactions(&self) -> Result<usize, LanderError>;
         async fn post_finalized(&self) -> Result<(), LanderError>;
     }
 }


### PR DESCRIPTION
## Summary
- bound automatic EVM reorg tx reprocessing to a fixed max depth of 25 nonces
- skip automatic reprocessing entirely for oversized reorgs and require manual intervention
- persist oversized reorg nonce range for inspection and explicit manual trigger
- add relayer API endpoints:
  - `POST /evm/inspect_reorged_transactions`
  - `POST /evm/reprocess_reorged_transactions`
- add new Lander metrics for ops/alerting:
  - `hyperlane_lander_reorged_transactions`
  - `hyperlane_lander_reorg_manual_intervention_required`
- add focused tests for small vs oversized reorg behavior and manual trigger flow
- document alert query for manual intervention

## Testing
- `cd rust/main && cargo test -p lander tests_reprocess`
- `cd rust/main && cargo test -p relayer --no-run`
