### PR TITLE
feat(rebalancer): add MesonBridge for Tron/Plasma USDT rebalancing

### DIFF
--- a/.changeset/tron-rebalancer-support.md
+++ b/.changeset/tron-rebalancer-support.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/rebalancer': minor
 ---
 
-Added Tron blockchain support to the rebalancer using ProtocolType.Tron. Tron chains are treated as EVM-like for signer creation, block tag resolution, gas estimation, and transaction receipt parsing. LiFi bridge gracefully skips Tron chains (no Tron-compatible aggregator yet).
+Added Tron blockchain support to the rebalancer using ProtocolType.Tron. Tron chains were treated as EVM-like for signer creation, block tag resolution, gas estimation, and transaction receipt parsing. The LiFi bridge was updated to gracefully skip Tron chains as no Tron-compatible aggregator is available.

--- a/.changeset/tron-rebalancer-support.md
+++ b/.changeset/tron-rebalancer-support.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': minor
+---
+
+Added Tron blockchain support to the rebalancer using ProtocolType.Tron. Tron chains are treated as EVM-like for signer creation, block tag resolution, gas estimation, and transaction receipt parsing. LiFi bridge gracefully skips Tron chains (no Tron-compatible aggregator yet).

--- a/typescript/infra/config/environments/mainnet3/rebalancer/USDC/tron-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/USDC/tron-config.yaml
@@ -1,0 +1,50 @@
+warpRouteId: USDC/tron
+
+# Tron inventory signer address
+# Note: Tron addresses start with 'T' and are base58-encoded
+inventorySigners:
+  tron: "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb"
+
+externalBridges:
+  lifi:
+    integrator: rebalancer
+
+strategy:
+  rebalanceStrategy: weighted
+  chains:
+    # Tron is treated as EVM-like for:
+    # - Signer creation (uses ethers-compatible wallet)
+    # - Block tag resolution (reorgPeriod must be numeric, not 'finalized')
+    # - Gas estimation and transaction receipt parsing
+    # - LiFi bridge gracefully skips Tron (no Tron-compatible aggregator yet)
+    tron:
+      weighted:
+        weight: 15
+        tolerance: 5
+      # reorgPeriod: Use numeric block count instead of named tags like 'finalized'
+      # Tron produces blocks every ~3 seconds, so 100 blocks ≈ 5 minutes
+      reorgPeriod: 100
+      bridgeLockTime: 1800
+      bridgeMinAcceptedAmount: 3500
+      # Placeholder bridge address (would be actual Tron contract address in production)
+      bridge: "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb"
+      # Note: LiFi bridge will skip Tron chains as there is no Tron-compatible aggregator yet
+      # The rebalancer will gracefully handle this by using inventory-based rebalancing
+      override: {}
+
+# IMPORTANT: Tron-specific considerations
+# 1. Gas Limit Buffering (Double-Buffering):
+#    - Rebalancer's addBufferToGasLimit() adds a multiplier (e.g., 1.2x)
+#    - TronWallet independently applies 1.5x multiplier to feeLimit
+#    - Combined effect: gas estimates are multiplied by ~1.8x
+#    - See: typescript/tron-sdk/src/ethers/TronWallet.ts:34-38
+#
+# 2. Block Tags:
+#    - Tron does not support named block tags like 'finalized' or 'safe'
+#    - Always use numeric reorgPeriod (block count) instead
+#    - Example: reorgPeriod: 100 means wait 100 blocks for finality
+#
+# 3. LiFi Bridge Support:
+#    - LiFi does not currently support Tron as a destination/source chain
+#    - Rebalancer will skip LiFi bridge for Tron and fall back to inventory-based rebalancing
+#    - This is handled gracefully in the bridge execution logic

--- a/typescript/infra/config/environments/mainnet3/rebalancer/USDC/tron-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/USDC/tron-config.yaml
@@ -1,9 +1,9 @@
 warpRouteId: USDC/tron
 
 # Tron inventory signer address
-# Note: Tron addresses start with 'T' and are base58-encoded
+# Note: Rebalancer requires 0x-prefixed hex addresses (not base58 'T...' format)
 inventorySigners:
-  tron: "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb"
+  tron: "0x0000000000000000000000000000000000000001"
 
 externalBridges:
   lifi:
@@ -27,7 +27,7 @@ strategy:
       bridgeLockTime: 1800
       bridgeMinAcceptedAmount: 3500
       # Placeholder bridge address (would be actual Tron contract address in production)
-      bridge: "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb"
+      bridge: "0x0000000000000000000000000000000000000001"
       # Note: LiFi bridge will skip Tron chains as there is no Tron-compatible aggregator yet
       # The rebalancer will gracefully handle this by using inventory-based rebalancing
       override: {}

--- a/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
@@ -672,4 +672,20 @@ describe('LiFiBridge Tron protocol handling', function () {
       ),
     ).to.be.false;
   });
+
+  it('throws for genuinely unknown protocol type', async () => {
+    const bridge = new LiFiBridge(BRIDGE_CONFIG, testLogger);
+    const quote = createTestQuote();
+
+    try {
+      await bridge.execute(quote, {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+        [ProtocolType.Cosmos]: TEST_PRIVATE_KEY,
+      });
+      expect.fail('Should have thrown for unknown protocol Cosmos');
+    } catch (error: unknown) {
+      const msg = (error as Error).message;
+      expect(msg).to.include('Unsupported protocol');
+    }
+  });
 });

--- a/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
@@ -627,6 +627,7 @@ describe('LiFiBridge Tron protocol handling', function () {
         [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
         [ProtocolType.Tron]: TEST_PRIVATE_KEY,
       });
+      expect.fail('Expected execute to throw');
     } catch (error: unknown) {
       const msg = (error as Error).message;
       // Should NOT be a Tron-related error — just post-validation SDK/RPC error

--- a/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
@@ -613,3 +613,63 @@ describe('LiFiBridge constructor chainMetadataByChainId', function () {
     }
   });
 });
+
+describe('LiFiBridge Tron protocol handling', function () {
+  it('configureLiFiProviders does not throw when Tron key is present (logs warning)', async () => {
+    const bridge = new LiFiBridge(BRIDGE_CONFIG, testLogger);
+
+    // configureLiFiProviders is private — invoke via execute which calls it internally.
+    // Tron is an unsupported LiFi protocol, so it should warn but not throw.
+    const quote = createTestQuote();
+
+    try {
+      await bridge.execute(quote, {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+        [ProtocolType.Tron]: TEST_PRIVATE_KEY,
+      });
+    } catch (error: unknown) {
+      const msg = (error as Error).message;
+      // Should NOT be a Tron-related error — just post-validation SDK/RPC error
+      expect(msg).to.not.include('Tron');
+      expect(msg).to.not.include('unsupported protocol');
+    }
+  });
+
+  it('addressesEqual uses case-insensitive comparison for Tron hex addresses', () => {
+    const TRON_CHAIN_ID = 728126428;
+    const TRON_CHAIN_METADATA_CONFIG: ExternalBridgeConfig = {
+      integrator: 'test-rebalancer',
+      chainMetadata: {
+        tron: {
+          chainId: TRON_CHAIN_ID,
+          protocol: ProtocolType.Tron,
+          name: 'tron',
+          displayName: 'Tron',
+          domainId: TRON_CHAIN_ID,
+          rpcUrls: [{ http: 'https://api.trongrid.io/jsonrpc' }],
+        },
+      },
+    };
+
+    const bridge = new LiFiBridge(TRON_CHAIN_METADATA_CONFIG, testLogger);
+    const addressesEqualFn = (bridge as any).addressesEqual.bind(bridge);
+
+    // Tron uses hex addresses where case is insignificant (EVM-like)
+    expect(
+      addressesEqualFn(
+        '0xAbCdEf1234567890AbCdEf1234567890AbCdEf12',
+        '0xabcdef1234567890abcdef1234567890abcdef12',
+        TRON_CHAIN_ID,
+      ),
+    ).to.be.true;
+
+    // Different addresses should not be equal
+    expect(
+      addressesEqualFn(
+        '0xAbCdEf1234567890AbCdEf1234567890AbCdEf12',
+        '0x1111111111111111111111111111111111111111',
+        TRON_CHAIN_ID,
+      ),
+    ).to.be.false;
+  });
+});

--- a/typescript/rebalancer/src/bridges/LiFiBridge.ts
+++ b/typescript/rebalancer/src/bridges/LiFiBridge.ts
@@ -189,6 +189,7 @@ export class LiFiBridge implements IExternalBridge {
   private addressesEqual(a: string, b: string, chainId: number): boolean {
     const protocol = this.getProtocolTypeForChainId(chainId);
     // Sealevel uses base58 addresses where case is significant.
+    // EVM and Tron use hex addresses where case is insignificant.
     if (protocol === ProtocolType.Sealevel) {
       return a === b;
     }
@@ -244,9 +245,11 @@ export class LiFiBridge implements IExternalBridge {
           break;
         }
         default:
-          throw new Error(
-            `Unsupported protocol type '${protocol}' for LiFi provider`,
+          this.logger.warn(
+            { protocol },
+            `Skipping unsupported protocol for LiFi provider — no LiFi bridge support for ${protocol}`,
           );
+          break;
       }
     }
 

--- a/typescript/rebalancer/src/bridges/LiFiBridge.ts
+++ b/typescript/rebalancer/src/bridges/LiFiBridge.ts
@@ -110,6 +110,13 @@ function toBase58SolanaKey(rawKey: string): string {
  *
  * @see https://docs.li.fi/integrate-li.fi-sdk
  */
+/**
+ * Protocols known to be unsupported by LiFi.
+ * Only Tron is explicitly unsupported (no LiFi aggregator available).
+ * All other unknown protocols will throw to preserve fail-fast behavior.
+ */
+const LIFI_UNSUPPORTED_PROTOCOLS = new Set([ProtocolType.Tron]);
+
 export class LiFiBridge implements IExternalBridge {
   private static readonly NATIVE_TOKEN_ADDRESS =
     '0x0000000000000000000000000000000000000000';
@@ -245,11 +252,16 @@ export class LiFiBridge implements IExternalBridge {
           break;
         }
         default:
-          this.logger.warn(
-            { protocol },
-            `Skipping unsupported protocol for LiFi provider — no LiFi bridge support for ${protocol}`,
+          if (LIFI_UNSUPPORTED_PROTOCOLS.has(protocol as ProtocolType)) {
+            this.logger.warn(
+              { protocol },
+              `Skipping unsupported protocol for LiFi provider — no LiFi bridge support for ${protocol}`,
+            );
+            break;
+          }
+          throw new Error(
+            `Unsupported protocol type '${protocol}' for LiFi provider`,
           );
-          break;
       }
     }
 

--- a/typescript/rebalancer/src/bridges/MesonBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/MesonBridge.test.ts
@@ -1,0 +1,424 @@
+import { expect } from 'chai';
+import { pino } from 'pino';
+import sinon from 'sinon';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+import { MesonBridge } from './MesonBridge.js';
+import {
+  createMesonEncodeResponse,
+  createMesonPriceResponse,
+  createMesonSwapResponse,
+  createMesonStatusResponse,
+  createMockMesonBridgeQuote,
+  createMesonFetchStub,
+} from '../test/mesonMocks.js';
+import { evmChainIdToMesonChain } from './mesonUtils.js';
+
+const testLogger = pino({ level: 'silent' });
+const TEST_PRIVATE_KEY =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const FROM_CHAIN = 1; // Ethereum
+const TO_CHAIN = 728126428; // Tron
+
+describe('MesonBridge.quote()', function () {
+  let bridge: MesonBridge;
+
+  beforeEach(() => {
+    bridge = new MesonBridge({}, testLogger);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return a quote for fromAmount', async () => {
+    createMesonFetchStub([
+      { ok: true, status: 200, body: createMesonPriceResponse() },
+    ]);
+
+    const quote = await bridge.quote({
+      fromChain: FROM_CHAIN,
+      toChain: TO_CHAIN,
+      fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+      toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+      fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      fromAmount: 10_000_000n,
+    });
+
+    expect(quote.fromAmount).to.equal(10_000_000n);
+    expect(quote.tool).to.equal('meson');
+    expect(quote.id).to.be.a('string');
+    expect(quote.id).to.have.length.greaterThan(0);
+  });
+
+  it('should return a quote for toAmount', async () => {
+    createMesonFetchStub([
+      { ok: true, status: 200, body: createMesonPriceResponse() },
+    ]);
+
+    const quote = await bridge.quote({
+      fromChain: FROM_CHAIN,
+      toChain: TO_CHAIN,
+      fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+      toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+      fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      toAmount: 10_000_000n,
+    });
+
+    expect(quote.toAmount).to.be.a('bigint');
+    expect(quote.tool).to.equal('meson');
+  });
+
+  it('should throw when both fromAmount and toAmount are provided', async () => {
+    createMesonFetchStub();
+
+    try {
+      await bridge.quote({
+        fromChain: FROM_CHAIN,
+        toChain: TO_CHAIN,
+        fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        fromAmount: 10_000_000n,
+        toAmount: 10_000_000n,
+      });
+      expect.fail('Expected quote to throw');
+    } catch (error: unknown) {
+      expect((error as Error).message).to.include('exactly one');
+    }
+  });
+
+  it('should throw when neither fromAmount nor toAmount is provided', async () => {
+    createMesonFetchStub();
+
+    try {
+      await bridge.quote({
+        fromChain: FROM_CHAIN,
+        toChain: TO_CHAIN,
+        fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      });
+      expect.fail('Expected quote to throw');
+    } catch (error: unknown) {
+      expect((error as Error).message).to.include('exactly one');
+    }
+  });
+
+  it('should throw when fromAmount is 0n', async () => {
+    createMesonFetchStub();
+
+    try {
+      await bridge.quote({
+        fromChain: FROM_CHAIN,
+        toChain: TO_CHAIN,
+        fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        fromAmount: 0n,
+      });
+      expect.fail('Expected quote to throw');
+    } catch (error: unknown) {
+      expect((error as Error).message).to.include('must be positive');
+    }
+  });
+
+  it('should throw when toAmount is 0n', async () => {
+    createMesonFetchStub();
+
+    try {
+      await bridge.quote({
+        fromChain: FROM_CHAIN,
+        toChain: TO_CHAIN,
+        fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        toAmount: 0n,
+      });
+      expect.fail('Expected quote to throw');
+    } catch (error: unknown) {
+      expect((error as Error).message).to.include('must be positive');
+    }
+  });
+
+  it('should throw when API returns an error', async () => {
+    createMesonFetchStub([
+      {
+        ok: true,
+        status: 200,
+        body: { error: { code: 400, message: 'bad request' } },
+      },
+    ]);
+
+    try {
+      await bridge.quote({
+        fromChain: FROM_CHAIN,
+        toChain: TO_CHAIN,
+        fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        fromAmount: 10_000_000n,
+      });
+      expect.fail('Expected quote to throw');
+    } catch (error: unknown) {
+      expect((error as Error).message).to.include('Meson price error');
+    }
+  });
+
+  it('should warn when amount exceeds 20k USDT limit', async () => {
+    createMesonFetchStub([
+      { ok: true, status: 200, body: createMesonPriceResponse() },
+    ]);
+
+    const quote = await bridge.quote({
+      fromChain: FROM_CHAIN,
+      toChain: TO_CHAIN,
+      fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+      toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+      fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      fromAmount: 25_000_000_000n, // 25k USDT in 6 decimals
+    });
+
+    expect(quote).to.exist;
+    expect(quote.fromAmount).to.equal(25_000_000_000n);
+  });
+});
+
+describe('MesonBridge.execute()', function () {
+  let bridge: MesonBridge;
+
+  beforeEach(() => {
+    bridge = new MesonBridge({}, testLogger);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should sign and submit a swap successfully', async () => {
+    createMesonFetchStub([
+      { ok: true, status: 200, body: createMesonEncodeResponse() },
+      { ok: true, status: 200, body: createMesonSwapResponse() },
+    ]);
+
+    const quote = createMockMesonBridgeQuote({
+      requestParams: {
+        fromChain: FROM_CHAIN,
+        toChain: TO_CHAIN,
+        fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        fromAmount: 10_000_000n,
+      },
+    });
+
+    const result = await bridge.execute(quote, {
+      [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+    });
+
+    expect(result.txHash).to.be.a('string');
+    expect(result.fromChain).to.equal(FROM_CHAIN);
+    expect(result.toChain).to.equal(TO_CHAIN);
+    expect(result.transferId).to.be.a('string');
+  });
+
+  it('should throw when private key is missing', async () => {
+    const quote = createMockMesonBridgeQuote();
+
+    try {
+      await bridge.execute(quote, {});
+      expect.fail('Expected execute to throw');
+    } catch (error: unknown) {
+      expect((error as Error).message).to.include('Missing private key');
+    }
+  });
+
+  it('should throw when encode API returns an error', async () => {
+    createMesonFetchStub([
+      {
+        ok: true,
+        status: 200,
+        body: { error: { code: 400, message: 'invalid swap params' } },
+      },
+    ]);
+
+    const quote = createMockMesonBridgeQuote();
+
+    try {
+      await bridge.execute(quote, {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      });
+      expect.fail('Expected execute to throw');
+    } catch (error: unknown) {
+      expect((error as Error).message).to.include('Meson encode error');
+    }
+  });
+
+  it('should throw when Meson API returns an error on swap submit', async () => {
+    createMesonFetchStub([
+      { ok: true, status: 200, body: createMesonEncodeResponse() },
+      {
+        ok: true,
+        status: 200,
+        body: { error: { code: 500, message: 'server error' } },
+      },
+    ]);
+
+    const quote = createMockMesonBridgeQuote();
+
+    try {
+      await bridge.execute(quote, {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      });
+      expect.fail('Expected execute to throw');
+    } catch (error: unknown) {
+      expect((error as Error).message).to.include('Meson swap error');
+    }
+  });
+});
+
+describe('MesonBridge.getStatus()', function () {
+  let bridge: MesonBridge;
+
+  beforeEach(() => {
+    bridge = new MesonBridge({}, testLogger);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return complete status for RELEASED swap', async () => {
+    sinon.stub(globalThis, 'fetch').resolves({
+      ok: true,
+      status: 200,
+      json: async () => createMesonStatusResponse('RELEASED'),
+      text: async () => JSON.stringify(createMesonStatusResponse('RELEASED')),
+    } as Response);
+
+    const status = await bridge.getStatus(
+      '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+      FROM_CHAIN,
+      TO_CHAIN,
+    );
+
+    expect(status.status).to.equal('complete');
+    expect(status).to.have.property('receivingTxHash');
+    expect(status).to.have.property('receivedAmount');
+    if (status.status === 'complete') {
+      expect(status.receivingTxHash).to.be.a('string');
+      expect(status.receivedAmount).to.be.a('bigint');
+    }
+  });
+
+  it('should return pending status for BONDED swap', async () => {
+    sinon.stub(globalThis, 'fetch').resolves({
+      ok: true,
+      status: 200,
+      json: async () => createMesonStatusResponse('BONDED'),
+      text: async () => JSON.stringify(createMesonStatusResponse('BONDED')),
+    } as Response);
+
+    const status = await bridge.getStatus(
+      '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+      FROM_CHAIN,
+      TO_CHAIN,
+    );
+
+    expect(status.status).to.equal('pending');
+    if (status.status === 'pending') {
+      expect(status.substatus).to.equal('bonded');
+    }
+  });
+
+  it('should return failed status for CANCELLED swap', async () => {
+    sinon.stub(globalThis, 'fetch').resolves({
+      ok: true,
+      status: 200,
+      json: async () => createMesonStatusResponse('CANCELLED'),
+      text: async () => JSON.stringify(createMesonStatusResponse('CANCELLED')),
+    } as Response);
+
+    const status = await bridge.getStatus(
+      '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+      FROM_CHAIN,
+      TO_CHAIN,
+    );
+
+    expect(status.status).to.equal('failed');
+    if (status.status === 'failed') {
+      expect(status.error).to.equal('swap cancelled');
+    }
+  });
+
+  it('should return pending for unknown status', async () => {
+    sinon.stub(globalThis, 'fetch').resolves({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        result: { status: 'UNKNOWN_STATUS' },
+      }),
+      text: async () =>
+        JSON.stringify({ result: { status: 'UNKNOWN_STATUS' } }),
+    } as Response);
+
+    const status = await bridge.getStatus(
+      '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+      FROM_CHAIN,
+      TO_CHAIN,
+    );
+
+    expect(status.status).to.equal('pending');
+  });
+
+  it('should return not_found when API returns error', async () => {
+    sinon.stub(globalThis, 'fetch').resolves({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        error: { code: 404, message: 'not found' },
+      }),
+      text: async () =>
+        JSON.stringify({ error: { code: 404, message: 'not found' } }),
+    } as Response);
+
+    const status = await bridge.getStatus(
+      '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+      FROM_CHAIN,
+      TO_CHAIN,
+    );
+
+    expect(status.status).to.equal('not_found');
+  });
+
+  it('should return not_found when fetch throws', async function () {
+    this.timeout(10000);
+    sinon.stub(globalThis, 'fetch').rejects(new Error('network error'));
+
+    const status = await bridge.getStatus(
+      '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+      FROM_CHAIN,
+      TO_CHAIN,
+    );
+
+    expect(status.status).to.equal('not_found');
+  });
+});
+
+describe('MesonBridge chain mapping', function () {
+  it('should map all 5 supported chains correctly', () => {
+    expect(evmChainIdToMesonChain(728126428)).to.equal('tron');
+    expect(evmChainIdToMesonChain(1)).to.equal('eth');
+    expect(evmChainIdToMesonChain(56)).to.equal('bnb');
+    expect(evmChainIdToMesonChain(42161)).to.equal('arb');
+    expect(evmChainIdToMesonChain(9745)).to.equal('plasma');
+  });
+
+  it('should throw for unsupported chain ID', () => {
+    try {
+      evmChainIdToMesonChain(99999);
+      expect.fail('Expected evmChainIdToMesonChain to throw');
+    } catch (error: unknown) {
+      expect((error as Error).message).to.include('Unsupported chain ID');
+    }
+  });
+});

--- a/typescript/rebalancer/src/bridges/MesonBridge.ts
+++ b/typescript/rebalancer/src/bridges/MesonBridge.ts
@@ -1,0 +1,400 @@
+import { ethers } from 'ethers';
+import type { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
+import { ProtocolType, assert } from '@hyperlane-xyz/utils';
+import type { Logger } from 'pino';
+import { v4 as uuidv4 } from 'uuid';
+
+import type {
+  BridgeQuote,
+  BridgeQuoteParams,
+  BridgeTransferResult,
+  BridgeTransferStatus,
+  IExternalBridge,
+} from '../interfaces/IExternalBridge.js';
+import {
+  MESON_API_BASE,
+  evmChainIdToMesonChain,
+  toMesonTokenId,
+  type MesonEncodeResponse,
+  type MesonPriceResponse,
+  type MesonStatusResponse,
+  type MesonSwapResponse,
+} from './mesonUtils.js';
+
+const TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 3;
+const BASE_BACKOFF_MS = 1_000;
+const MESON_SOFT_LIMIT_USDT = 20_000n * 1_000_000n;
+const MESON_TOOL = 'meson';
+const USDT_SYMBOL = 'USDT';
+
+class NonRetryableHttpError extends Error {}
+
+export class MesonBridge implements IExternalBridge {
+  readonly externalBridgeId = MESON_TOOL;
+  readonly logger: Logger;
+  private readonly apiUrl: string;
+  private readonly defaultSlippage: number;
+
+  constructor(
+    config: {
+      apiUrl?: string;
+      defaultSlippage?: number;
+      chainMetadata?: ChainMap<ChainMetadata>;
+    },
+    logger: Logger,
+  ) {
+    this.logger = logger;
+    this.apiUrl = config.apiUrl ?? MESON_API_BASE;
+    this.defaultSlippage = config.defaultSlippage ?? 0;
+    void config.chainMetadata;
+  }
+
+  async quote(
+    params: BridgeQuoteParams,
+  ): Promise<BridgeQuote<MesonPriceResponse>> {
+    const hasFromAmount = params.fromAmount !== undefined;
+    const hasToAmount = params.toAmount !== undefined;
+    assert(
+      hasFromAmount !== hasToAmount,
+      'Must specify exactly one of fromAmount or toAmount',
+    );
+    assert(
+      params.fromAmount === undefined || params.fromAmount > 0n,
+      'fromAmount must be positive',
+    );
+    assert(
+      params.toAmount === undefined || params.toAmount > 0n,
+      'toAmount must be positive',
+    );
+
+    const amountValue = params.fromAmount ?? params.toAmount!;
+    const from = toMesonTokenId(
+      evmChainIdToMesonChain(params.fromChain),
+      USDT_SYMBOL,
+    );
+    const to = toMesonTokenId(
+      evmChainIdToMesonChain(params.toChain),
+      USDT_SYMBOL,
+    );
+
+    if (amountValue > MESON_SOFT_LIMIT_USDT) {
+      this.logger.warn(
+        {
+          fromChain: params.fromChain,
+          toChain: params.toChain,
+          from,
+          to,
+          amount: amountValue.toString(),
+          limit: MESON_SOFT_LIMIT_USDT.toString(),
+        },
+        'Meson quote amount exceeds soft 20k USDT limit',
+      );
+    }
+
+    const mode = params.fromAmount !== undefined ? 'fromAmount' : 'toAmount';
+    this.logger.debug(
+      {
+        mode,
+        fromChain: params.fromChain,
+        toChain: params.toChain,
+        from,
+        to,
+        amount: amountValue.toString(),
+        slippage: params.slippage ?? this.defaultSlippage,
+      },
+      'Requesting Meson quote',
+    );
+
+    const response = await this.fetchWithRetry(`${this.apiUrl}/price`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        from,
+        to,
+        amount: amountValue.toString(),
+      }),
+    });
+    const data = (await response.json()) as MesonPriceResponse;
+    if (data.error) {
+      throw new Error(
+        `Meson price error: ${data.error.code} ${data.error.message}`,
+      );
+    }
+    assert(data.result, 'Meson /price missing result');
+
+    const feeCosts = this.parseMesonAmount(data.result.totalFee);
+    const toAmount = amountValue > feeCosts ? amountValue - feeCosts : 0n;
+    const quoteId = uuidv4();
+
+    this.logger.info(
+      {
+        quoteId,
+        mode,
+        fromAmount: amountValue.toString(),
+        toAmount: toAmount.toString(),
+        feeCosts: feeCosts.toString(),
+      },
+      'Meson quote received',
+    );
+
+    return {
+      id: quoteId,
+      tool: MESON_TOOL,
+      fromAmount: amountValue,
+      toAmount,
+      toAmountMin: toAmount,
+      executionDuration: 300,
+      gasCosts: 0n,
+      feeCosts,
+      route: data,
+      requestParams: { ...params },
+    };
+  }
+
+  async execute(
+    quote: BridgeQuote<MesonPriceResponse>,
+    privateKeys: Partial<Record<ProtocolType, string>>,
+  ): Promise<BridgeTransferResult> {
+    const privateKey = privateKeys[ProtocolType.Ethereum];
+    assert(privateKey, 'Missing private key for ProtocolType.Ethereum');
+
+    const wallet = new ethers.Wallet(privateKey);
+    const amountValue =
+      quote.requestParams.fromAmount ?? quote.requestParams.toAmount;
+    assert(amountValue, 'Meson execute missing amount in request params');
+    const from = toMesonTokenId(
+      evmChainIdToMesonChain(quote.requestParams.fromChain),
+      USDT_SYMBOL,
+    );
+    const to = toMesonTokenId(
+      evmChainIdToMesonChain(quote.requestParams.toChain),
+      USDT_SYMBOL,
+    );
+    const fromAddress = wallet.address;
+    const recipient =
+      quote.requestParams.toAddress ?? quote.requestParams.fromAddress;
+    assert(recipient, 'Meson execute missing recipient');
+
+    this.logger.info(
+      { quoteId: quote.id, fromAddress, recipient, from, to, amountValue },
+      'Encoding Meson swap',
+    );
+
+    const encodeResponse = await this.fetchWithRetry(`${this.apiUrl}/swap`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        from,
+        to,
+        amount: amountValue.toString(),
+        fromAddress,
+        recipient,
+      }),
+    });
+    const encodeData = (await encodeResponse.json()) as MesonEncodeResponse;
+    if (encodeData.error) {
+      throw new Error(
+        `Meson encode error: ${encodeData.error.code} ${encodeData.error.message}`,
+      );
+    }
+    assert(encodeData.result, 'Meson /swap encode missing result');
+    const { encoded, signingRequest } = encodeData.result;
+    const signingKeyWallet = wallet as ethers.Wallet & {
+      signingKey?: {
+        sign?: (digest: string) => { serialized: string };
+        signDigest?: (digest: string) => ethers.Signature;
+      };
+      _signingKey?: () => {
+        signDigest: (digest: string) => ethers.Signature;
+      };
+    };
+    const signature =
+      typeof signingKeyWallet.signingKey?.sign === 'function'
+        ? signingKeyWallet.signingKey.sign(signingRequest.hash).serialized
+        : typeof signingKeyWallet.signingKey?.signDigest === 'function'
+          ? ethers.utils.joinSignature(
+              signingKeyWallet.signingKey.signDigest(signingRequest.hash),
+            )
+          : signingKeyWallet._signingKey
+            ? ethers.utils.joinSignature(
+                signingKeyWallet._signingKey().signDigest(signingRequest.hash),
+              )
+            : (() => {
+                throw new Error('Meson execute wallet cannot sign hash');
+              })();
+
+    this.logger.info(
+      {
+        quoteId: quote.id,
+        encoded,
+        fromAddress,
+        recipient,
+      },
+      'Submitting Meson swap',
+    );
+
+    const submitResponse = await this.fetchWithRetry(
+      `${this.apiUrl}/swap/${encoded}`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ fromAddress, recipient, signature }),
+      },
+    );
+    const submitData = (await submitResponse.json()) as MesonSwapResponse;
+    if (submitData.error) {
+      throw new Error(
+        `Meson swap error: ${submitData.error.code} ${submitData.error.message}`,
+      );
+    }
+
+    const swapId = submitData.result?.swapId ?? encoded;
+
+    this.logger.info(
+      {
+        quoteId: quote.id,
+        txHash: encoded,
+        fromChain: quote.requestParams.fromChain,
+        toChain: quote.requestParams.toChain,
+        swapId,
+      },
+      'Meson swap submitted',
+    );
+
+    return {
+      txHash: encoded,
+      fromChain: quote.requestParams.fromChain,
+      toChain: quote.requestParams.toChain,
+      transferId: swapId,
+    };
+  }
+
+  async getStatus(
+    txHash: string,
+    fromChain: number,
+    toChain: number,
+  ): Promise<BridgeTransferStatus> {
+    this.logger.debug(
+      { txHash, fromChain, toChain },
+      'Fetching Meson swap status',
+    );
+
+    try {
+      const response = await this.fetchWithRetry(
+        `${this.apiUrl}/swap/${txHash}`,
+        {
+          method: 'GET',
+        },
+      );
+      const data = (await response.json()) as MesonStatusResponse;
+
+      if (data.error || !data.result) {
+        return { status: 'not_found' };
+      }
+
+      switch (data.result.status) {
+        case 'RELEASED':
+          return {
+            status: 'complete',
+            receivingTxHash: data.result.outHash ?? '',
+            receivedAmount: BigInt(data.result.amount ?? '0'),
+          };
+        case 'BONDED':
+          return { status: 'pending', substatus: 'bonded' };
+        case 'CANCELLED':
+          return { status: 'failed', error: 'swap cancelled' };
+        default:
+          return { status: 'pending' };
+      }
+    } catch (error) {
+      this.logger.warn(
+        { txHash, fromChain, toChain, error },
+        'Meson status lookup failed',
+      );
+      return { status: 'not_found' };
+    }
+  }
+
+  private async fetchWithRetry(
+    url: string,
+    options?: RequestInit,
+  ): Promise<Response> {
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt += 1) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+      try {
+        const response = await fetch(url, {
+          ...options,
+          signal: controller.signal,
+        });
+        if (response.ok) {
+          return response;
+        }
+
+        const responseText = await response.text();
+        const error = new Error(
+          `Meson API request failed: ${response.status} ${response.statusText} - ${responseText}`,
+        );
+
+        if (response.status !== 429 && response.status < 500) {
+          throw new NonRetryableHttpError(error.message);
+        }
+        if (attempt === MAX_RETRIES) {
+          throw error;
+        }
+
+        const backoffMs = BASE_BACKOFF_MS * 2 ** attempt;
+        this.logger.warn(
+          {
+            url,
+            status: response.status,
+            attempt: attempt + 1,
+            backoffMs,
+          },
+          'Meson request failed, retrying',
+        );
+        await this.sleep(backoffMs);
+      } catch (error) {
+        clearTimeout(timeout);
+
+        if (error instanceof NonRetryableHttpError) {
+          throw error;
+        }
+        if (attempt === MAX_RETRIES) {
+          throw error;
+        }
+
+        const backoffMs = BASE_BACKOFF_MS * 2 ** attempt;
+        this.logger.warn(
+          { url, attempt: attempt + 1, backoffMs, error },
+          'Meson request errored, retrying',
+        );
+        await this.sleep(backoffMs);
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+
+    throw new Error('Meson API request failed after retries');
+  }
+
+  private parseMesonAmount(value?: string): bigint {
+    if (!value) return 0n;
+    const normalized = value.trim();
+    if (/^\d+$/.test(normalized)) {
+      return BigInt(normalized);
+    }
+    const [wholePart, fractionalPart = ''] = normalized.split('.');
+    if (!/^\d+$/.test(wholePart) || !/^\d*$/.test(fractionalPart)) {
+      return 0n;
+    }
+    const paddedFractional = (fractionalPart + '000000').slice(0, 6);
+    return BigInt(wholePart) * 1_000_000n + BigInt(paddedFractional || '0');
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/typescript/rebalancer/src/bridges/mesonUtils.ts
+++ b/typescript/rebalancer/src/bridges/mesonUtils.ts
@@ -1,0 +1,217 @@
+/**
+ * Meson Finance bridge utilities.
+ * Chain/token mapping and API type definitions for MesonBridge implementation.
+ * API docs: https://meson.dev/getting-started/api-integration
+ */
+
+// ============================================================================
+// Chain Mappings
+// ============================================================================
+
+const EVM_TO_MESON_CHAIN: Record<number, string> = {
+  1: 'eth',
+  56: 'bnb',
+  42161: 'arb',
+  728126428: 'tron',
+  9745: 'plasma',
+};
+
+const MESON_TO_EVM_CHAIN: Record<string, number> = {
+  eth: 1,
+  bnb: 56,
+  arb: 42161,
+  tron: 728126428,
+  plasma: 9745,
+};
+
+// ============================================================================
+// API Base URLs
+// ============================================================================
+
+export const MESON_API_BASE = 'https://relayer.meson.fi/api/v1';
+export const MESON_TESTNET_API_BASE = 'https://testnet-relayer.meson.fi/api/v1';
+
+// ============================================================================
+// Chain/Token Conversion Functions
+// ============================================================================
+
+/**
+ * Convert EVM chain ID to Meson chain identifier.
+ * @param chainId - EVM numeric chain ID
+ * @returns Meson chain string (e.g., 'eth', 'tron')
+ * @throws Error if chain ID is not supported
+ */
+export function evmChainIdToMesonChain(chainId: number): string {
+  const mesonChain = EVM_TO_MESON_CHAIN[chainId];
+  if (!mesonChain) {
+    const supported = Object.keys(EVM_TO_MESON_CHAIN).join(', ');
+    throw new Error(
+      `Unsupported chain ID for Meson: ${chainId}. Supported: ${supported}`,
+    );
+  }
+  return mesonChain;
+}
+
+/**
+ * Convert Meson chain identifier to EVM chain ID.
+ * @param mesonChain - Meson chain string (e.g., 'eth', 'tron')
+ * @returns EVM numeric chain ID
+ * @throws Error if Meson chain is not supported
+ */
+export function mesonChainToEvmChainId(mesonChain: string): number {
+  const chainId = MESON_TO_EVM_CHAIN[mesonChain];
+  if (chainId === undefined) {
+    const supported = Object.keys(MESON_TO_EVM_CHAIN).join(', ');
+    throw new Error(
+      `Unsupported Meson chain: ${mesonChain}. Supported: ${supported}`,
+    );
+  }
+  return chainId;
+}
+
+/**
+ * Convert Meson chain and token symbol to Meson token ID.
+ * @param mesonChain - Meson chain identifier (e.g., 'tron')
+ * @param tokenSymbol - Token symbol (e.g., 'USDT')
+ * @returns Meson token ID (e.g., 'tron:usdt')
+ */
+export function toMesonTokenId(
+  mesonChain: string,
+  tokenSymbol: string,
+): string {
+  return `${mesonChain}:${tokenSymbol.toLowerCase()}`;
+}
+
+/**
+ * Parse Meson token ID into chain and token components.
+ * @param mesonTokenId - Meson token ID (e.g., 'tron:usdt')
+ * @returns Object with chain and token properties
+ * @throws Error if format is invalid
+ */
+export function fromMesonTokenId(mesonTokenId: string): {
+  chain: string;
+  token: string;
+} {
+  const parts = mesonTokenId.split(':');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(
+      `Invalid Meson token ID format: ${mesonTokenId}. Expected format: chain:token`,
+    );
+  }
+  return {
+    chain: parts[0],
+    token: parts[1],
+  };
+}
+
+// ============================================================================
+// API Type Interfaces
+// ============================================================================
+
+/**
+ * Response from Meson /price endpoint.
+ * Used to get quote and encoded swap data for signing.
+ */
+export interface MesonPriceResponse {
+  result?: {
+    serviceFee: string;
+    lpFee: string;
+    totalFee: string;
+    converted?: unknown;
+  };
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+
+export interface MesonEncodeResponse {
+  result?: {
+    encoded: string;
+    fromAddress: string;
+    recipient: string;
+    initiator: string;
+    fee: {
+      serviceFee: string;
+      lpFee: string;
+      totalFee: string;
+    };
+    signingRequest: {
+      message: string;
+      hash: string;
+    };
+    tx?: {
+      to: string;
+      value: string;
+      data: string;
+    };
+  };
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+
+/**
+ * Response from Meson /swap endpoint.
+ * Returned after submitting a signed swap.
+ */
+export interface MesonSwapResponse {
+  result?: {
+    swapId: string;
+  };
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+
+/**
+ * Response from Meson /swap?hash= endpoint.
+ * Used to check status of a submitted swap.
+ */
+export interface MesonStatusResponse {
+  result?: {
+    _id?: string;
+    encoded?: string;
+    status?: string; // e.g. 'BONDED', 'RELEASED', 'CANCELLED' or numeric
+    fromAddress?: string;
+    recipient?: string;
+    expireTs?: number;
+    fromChain?: string;
+    toChain?: string;
+    inChain?: string;
+    outChain?: string;
+    hash?: string; // origin tx hash
+    outHash?: string; // destination tx hash
+    amount?: string; // received amount
+  };
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+
+/**
+ * Token information from Meson /limits endpoint.
+ */
+export interface MesonLimitsToken {
+  id: string;
+  symbol: string;
+  name: string;
+  decimals: number;
+  addr?: string;
+  min: string;
+  max: string;
+}
+
+/**
+ * Chain information from Meson /limits endpoint.
+ */
+export interface MesonLimitsChain {
+  id: string;
+  name: string;
+  chainId: string;
+  address: string;
+  tokens: MesonLimitsToken[];
+}

--- a/typescript/rebalancer/src/config/RebalancerConfig.test.ts
+++ b/typescript/rebalancer/src/config/RebalancerConfig.test.ts
@@ -572,6 +572,139 @@ describe('RebalancerConfig', () => {
   });
 });
 
+describe('Tron inventorySigners validation', () => {
+  const TEST_CONFIG_PATH_TRON = join(tmpdir(), 'rebalancer-tron-test.yaml');
+
+  afterEach(() => {
+    rmSync(TEST_CONFIG_PATH_TRON, { force: true });
+  });
+
+  it('should accept valid Tron T-prefix base58 address in inventorySigners', () => {
+    const data: RebalancerConfigFileInput = {
+      warpRouteId: 'test-tron-route',
+      strategy: [
+        {
+          rebalanceStrategy: RebalancerStrategyOptions.Weighted,
+          chains: {
+            tron: {
+              weighted: { weight: 50, tolerance: 5 },
+              executionType: ExecutionType.Inventory,
+              externalBridge: ExternalBridgeType.LiFi,
+            },
+            ethereum: {
+              weighted: { weight: 50, tolerance: 5 },
+              executionType: ExecutionType.Inventory,
+              externalBridge: ExternalBridgeType.LiFi,
+            },
+          },
+        },
+      ],
+      inventorySigners: {
+        tron: {
+          address: 'TJRabPrwbZy45sbavfcjinPJC18kjpRTv8',
+          key: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+        },
+        ethereum: {
+          address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+          key: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+        },
+      },
+      externalBridges: {
+        lifi: {
+          integrator: 'test-app',
+        },
+      },
+    };
+
+    writeYamlOrJson(TEST_CONFIG_PATH_TRON, data);
+    expect(() => RebalancerConfig.load(TEST_CONFIG_PATH_TRON)).to.not.throw();
+  });
+
+  it('should accept valid 0x hex address for Tron inventorySigners', () => {
+    const data: RebalancerConfigFileInput = {
+      warpRouteId: 'test-tron-route',
+      strategy: [
+        {
+          rebalanceStrategy: RebalancerStrategyOptions.Weighted,
+          chains: {
+            tron: {
+              weighted: { weight: 50, tolerance: 5 },
+              executionType: ExecutionType.Inventory,
+              externalBridge: ExternalBridgeType.LiFi,
+            },
+            ethereum: {
+              weighted: { weight: 50, tolerance: 5 },
+              executionType: ExecutionType.Inventory,
+              externalBridge: ExternalBridgeType.LiFi,
+            },
+          },
+        },
+      ],
+      inventorySigners: {
+        tron: {
+          address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+          key: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+        },
+        ethereum: {
+          address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+          key: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+        },
+      },
+      externalBridges: {
+        lifi: {
+          integrator: 'test-app',
+        },
+      },
+    };
+
+    writeYamlOrJson(TEST_CONFIG_PATH_TRON, data);
+    expect(() => RebalancerConfig.load(TEST_CONFIG_PATH_TRON)).to.not.throw();
+  });
+
+  it('should reject invalid Tron address in inventorySigners', () => {
+    const data: RebalancerConfigFileInput = {
+      warpRouteId: 'test-tron-route',
+      strategy: [
+        {
+          rebalanceStrategy: RebalancerStrategyOptions.Weighted,
+          chains: {
+            tron: {
+              weighted: { weight: 50, tolerance: 5 },
+              executionType: ExecutionType.Inventory,
+              externalBridge: ExternalBridgeType.LiFi,
+            },
+            ethereum: {
+              weighted: { weight: 50, tolerance: 5 },
+              executionType: ExecutionType.Inventory,
+              externalBridge: ExternalBridgeType.LiFi,
+            },
+          },
+        },
+      ],
+      inventorySigners: {
+        tron: {
+          address: 'INVALID_TRON_ADDRESS',
+          key: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+        },
+        ethereum: {
+          address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+          key: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+        },
+      },
+      externalBridges: {
+        lifi: {
+          integrator: 'test-app',
+        },
+      },
+    };
+
+    writeYamlOrJson(TEST_CONFIG_PATH_TRON, data);
+    expect(() => RebalancerConfig.load(TEST_CONFIG_PATH_TRON)).to.throw(
+      /must be a valid Tron address/,
+    );
+  });
+});
+
 describe('per-chain bridge configuration', () => {
   const TEST_CONFIG_PATH_BRIDGE = join(tmpdir(), 'rebalancer-bridge-test.yaml');
 

--- a/typescript/rebalancer/src/config/RebalancerConfig.test.ts
+++ b/typescript/rebalancer/src/config/RebalancerConfig.test.ts
@@ -808,7 +808,7 @@ describe('per-chain bridge configuration', () => {
     writeYamlOrJson(TEST_CONFIG_PATH_BRIDGE, data);
 
     expect(() => RebalancerConfig.load(TEST_CONFIG_PATH_BRIDGE)).to.throw(
-      /externalBridges\.lifi.*required/i,
+      /inventory execution but has no.*externalBridge.*configured/i,
     );
   });
 

--- a/typescript/rebalancer/src/config/types.ts
+++ b/typescript/rebalancer/src/config/types.ts
@@ -40,6 +40,7 @@ export enum ExecutionType {
 
 export enum ExternalBridgeType {
   LiFi = 'lifi',
+  Meson = 'meson',
 }
 
 export const RebalancerMinAmountConfigSchema = z.object({
@@ -130,8 +131,14 @@ export const LiFiBridgeConfigSchema = z.object({
   defaultSlippage: z.number().optional(),
 });
 
+export const MesonBridgeConfigSchema = z.object({
+  apiUrl: z.string().url().optional(),
+  defaultSlippage: z.number().optional(),
+});
+
 export const ExternalBridgesConfigSchema = z.object({
   lifi: LiFiBridgeConfigSchema.optional(),
+  meson: MesonBridgeConfigSchema.optional(),
 });
 
 export const RebalancerConfigSchema = z
@@ -378,12 +385,48 @@ export const RebalancerConfigSchema = z
         }
       }
 
-      if (!config.externalBridges?.lifi?.integrator) {
+      // Collect all bridge types used across strategies
+      const usedBridgeTypes = new Set<ExternalBridgeType>();
+      for (const strategy of config.strategy) {
+        for (const [, chainConfig] of Object.entries(strategy.chains)) {
+          if (chainConfig.externalBridge) {
+            usedBridgeTypes.add(chainConfig.externalBridge);
+          }
+          if (chainConfig.override) {
+            for (const overrideConfig of Object.values(chainConfig.override)) {
+              const merged = {
+                ...chainConfig,
+                ...(overrideConfig as Record<string, unknown>),
+              };
+              if ((merged as any).externalBridge) {
+                usedBridgeTypes.add(
+                  (merged as any).externalBridge as ExternalBridgeType,
+                );
+              }
+            }
+          }
+        }
+      }
+      if (
+        usedBridgeTypes.has(ExternalBridgeType.LiFi) &&
+        !config.externalBridges?.lifi?.integrator
+      ) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message:
-            'externalBridges.lifi is required when using inventory execution',
+            'externalBridges.lifi is required when any chain uses externalBridge: lifi',
           path: ['externalBridges', 'lifi'],
+        });
+      }
+      if (
+        usedBridgeTypes.has(ExternalBridgeType.Meson) &&
+        !config.externalBridges?.meson
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'externalBridges.meson is required when any chain uses externalBridge: meson',
+          path: ['externalBridges', 'meson'],
         });
       }
     }

--- a/typescript/rebalancer/src/config/types.ts
+++ b/typescript/rebalancer/src/config/types.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import { ProtocolType, isAddressEvm } from '@hyperlane-xyz/utils';
+import {
+  ProtocolType,
+  isAddressEvm,
+  isValidAddressTron,
+} from '@hyperlane-xyz/utils';
 
 export enum RebalancerStrategyOptions {
   Weighted = 'weighted',
@@ -358,6 +362,14 @@ export const RebalancerConfigSchema = z
               ctx.addIssue({
                 code: z.ZodIssueCode.custom,
                 message: `inventorySigners.${protocol} must be a valid Solana base58 address (32-44 chars), got: ${signerConfig.address}`,
+                path: ['inventorySigners', protocol],
+              });
+            }
+          } else if (protocol === ProtocolType.Tron) {
+            if (!isValidAddressTron(signerConfig.address)) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `inventorySigners.${protocol} must be a valid Tron address (T-prefix base58 or 0x hex), got: ${signerConfig.address}`,
                 path: ['inventorySigners', protocol],
               });
             }

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -398,6 +398,177 @@ describe('InventoryRebalancer E2E', () => {
     });
   });
 
+  it('uses IMultiProtocolSigner path for tron transfer txs', async () => {
+    // Re-use SOLANA_CHAIN slot but treat it as Tron protocol.
+    // This mirrors the Sealevel test above which also re-uses the same slot.
+    const route = createTestRoute({ amount: 5000000000n });
+    createTestIntent({ amount: 5000000000n });
+
+    inventoryRebalancer.setInventoryBalances({
+      [SOLANA_CHAIN]: 5000000000n,
+      [ARBITRUM_CHAIN]: 0n,
+    });
+
+    config.inventorySigners[ProtocolType.Tron] = {
+      address: INVENTORY_SIGNER,
+      key: TEST_PRIVATE_KEY,
+    };
+
+    warpCore.multiProvider.getChainMetadata.callsFake((chain: ChainName) => ({
+      name: chain,
+      protocol:
+        chain === SOLANA_CHAIN ? ProtocolType.Tron : ProtocolType.Ethereum,
+      blocks: { reorgPeriod: 1 },
+    }));
+
+    const sendAndConfirmStub = Sinon.stub(
+      InventoryRebalancer.prototype as any,
+      'sendAndConfirmInventoryTx',
+    ).resolves({ txHash: '0xTronTxHash' });
+
+    multiProvider.sendTransaction.resetHistory();
+    warpCore.getTransferRemoteTxs.resolves([
+      {
+        category: WarpTxCategory.Transfer,
+        type: ProviderType.EthersV5,
+        transaction: {} as any,
+      },
+    ]);
+
+    const results = await inventoryRebalancer.rebalance([route]);
+
+    expect(results).to.have.lengthOf(1);
+    expect(results[0].success).to.be.true;
+    expect(sendAndConfirmStub.calledOnce).to.be.true;
+    expect(sendAndConfirmStub.firstCall.args[0]).to.equal(SOLANA_CHAIN);
+    expect(multiProvider.sendTransaction.called).to.be.false;
+
+    const actionParams = actionTracker.createRebalanceAction.lastCall.args[0];
+    expect(actionParams.txHash).to.equal('0xTronTxHash');
+  });
+
+  it('buildSignerAccountConfig returns correct config for Tron protocol', () => {
+    config.inventorySigners[ProtocolType.Tron] = {
+      address: INVENTORY_SIGNER,
+      key: TEST_PRIVATE_KEY,
+    };
+
+    const buildFn = (inventoryRebalancer as any).buildSignerAccountConfig.bind(
+      inventoryRebalancer,
+    );
+    const result = buildFn(
+      ProtocolType.Tron,
+      TEST_PRIVATE_KEY,
+      'tron' as ChainName,
+    );
+
+    expect(result.protocol).to.equal(ProtocolType.Tron);
+    expect(result.privateKey).to.equal(TEST_PRIVATE_KEY);
+    // Tron uses same 0x-prefixed hex key format as Ethereum
+    expect(result.privateKey.startsWith('0x')).to.be.true;
+  });
+
+  it('getTransactionReceipt returns EthersV5 type for Tron chain', async () => {
+    const TRON_CHAIN = 'tron' as ChainName;
+    const mockReceipt = {
+      transactionHash: '0xTronReceipt',
+      logs: [],
+    };
+
+    warpCore.multiProvider.getChainMetadata.callsFake((chain: ChainName) => ({
+      name: chain,
+      protocol:
+        chain === TRON_CHAIN ? ProtocolType.Tron : ProtocolType.Ethereum,
+    }));
+
+    warpCore.multiProvider.getEthersV5Provider.returns({
+      getTransactionReceipt: Sinon.stub().resolves(mockReceipt),
+    });
+
+    const getReceiptFn = (
+      inventoryRebalancer as any
+    ).getTransactionReceipt.bind(inventoryRebalancer);
+    const receipt = await getReceiptFn(TRON_CHAIN, '0xTronTxHash');
+
+    expect(receipt).to.not.be.undefined;
+    expect(receipt.type).to.equal(ProviderType.EthersV5);
+    expect(receipt.receipt).to.deep.equal(mockReceipt);
+  });
+
+  it('extractDispatchedMessageId parses Tron dispatch logs via EthersV5 path', async () => {
+    const TRON_CHAIN = 'tron' as ChainName;
+
+    warpCore.multiProvider.getChainMetadata.callsFake((chain: ChainName) => ({
+      name: chain,
+      protocol:
+        chain === TRON_CHAIN ? ProtocolType.Tron : ProtocolType.Ethereum,
+    }));
+
+    // Mock EthersV5 provider returning a receipt with no dispatch logs
+    warpCore.multiProvider.getEthersV5Provider.returns({
+      getTransactionReceipt: Sinon.stub().resolves({
+        transactionHash: '0xTronTx',
+        logs: [],
+      }),
+    });
+
+    const extractFn = (
+      inventoryRebalancer as any
+    ).extractDispatchedMessageId.bind(inventoryRebalancer);
+    // With empty logs, no message ID should be found (undefined)
+    const messageId = await extractFn(TRON_CHAIN, '0xTronTx');
+    expect(messageId).to.be.undefined;
+  });
+
+  it('accepts multi-protocol config with Ethereum + Tron + Sealevel signers', () => {
+    config.inventorySigners[ProtocolType.Tron] = {
+      address: INVENTORY_SIGNER,
+      key: TEST_PRIVATE_KEY,
+    };
+    config.inventorySigners[ProtocolType.Sealevel] = {
+      address: 'SoLANAAddReSs1234567890123456789012345678',
+      key: '1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32',
+    };
+
+    // Should not throw during construction
+    const rebalancer = new InventoryRebalancer(
+      config,
+      actionTracker as unknown as IActionTracker,
+      { lifi: bridge as unknown as IExternalBridge },
+      warpCore as unknown as WarpCore,
+      multiProvider as unknown as MultiProvider,
+      testLogger,
+    );
+
+    expect(rebalancer).to.be.instanceOf(InventoryRebalancer);
+    expect(config.inventorySigners[ProtocolType.Ethereum]).to.exist;
+    expect(config.inventorySigners[ProtocolType.Tron]).to.exist;
+    expect(config.inventorySigners[ProtocolType.Sealevel]).to.exist;
+  });
+
+  it('Tron chain is accepted in inventoryChains config', () => {
+    const tronConfig: InventoryRebalancerConfig = {
+      inventorySigners: {
+        [ProtocolType.Tron]: {
+          address: INVENTORY_SIGNER,
+          key: TEST_PRIVATE_KEY,
+        },
+      },
+      inventoryChains: ['tron' as ChainName, ARBITRUM_CHAIN],
+    };
+
+    const rebalancer = new InventoryRebalancer(
+      tronConfig,
+      actionTracker as unknown as IActionTracker,
+      { lifi: bridge as unknown as IExternalBridge },
+      warpCore as unknown as WarpCore,
+      multiProvider as unknown as MultiProvider,
+      testLogger,
+    );
+
+    expect(rebalancer).to.be.instanceOf(InventoryRebalancer);
+  });
+
   describe('Partial Fulfillment (Insufficient Inventory)', () => {
     // Partial transfers happen when maxTransferable >= minViableTransfer
     // For non-native tokens (EvmHypCollateral), minViableTransfer = 0, so partial always viable

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -21,6 +21,7 @@ import {
   ProtocolType,
   assert,
   ensure0x,
+  isEVMLike,
   isZeroishAddress,
 } from '@hyperlane-xyz/utils';
 
@@ -1024,6 +1025,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
   ): MultiProtocolSignerSignerAccountInfo {
     void chain;
     switch (protocol) {
+      case ProtocolType.Tron:
       case ProtocolType.Ethereum:
         return { protocol, privateKey: ensure0x(key) };
       case ProtocolType.Sealevel:
@@ -1063,7 +1065,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     try {
       const protocol = this.getProtocolForChain(origin);
 
-      if (protocol === ProtocolType.Ethereum) {
+      if (isEVMLike(protocol)) {
         const provider =
           this.warpCore.multiProvider.getEthersV5Provider(origin);
         const receipt = await provider.getTransactionReceipt(txHash);

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
@@ -218,6 +218,36 @@ describe('RebalancerContextFactory', () => {
       expect(multiProvider.getProvider.firstCall.args[0]).to.equal('ethereum');
     });
 
+    it('should initialize providers for Tron chains (EVM-like)', async () => {
+      const { multiProvider } = createMockMultiProvider([
+        { name: 'ethereum', protocol: ProtocolType.Ethereum },
+        { name: 'tron', protocol: ProtocolType.Tron },
+      ]);
+
+      await callCreate(multiProvider, {
+        tokens: [
+          createToken(
+            'ethereum',
+            TEST_ADDRESSES.ethereum,
+            TokenStandard.EvmHypCollateral,
+          ),
+          createToken(
+            'tron',
+            '0xTronToken1234567890',
+            TokenStandard.TronHypCollateral,
+          ),
+        ],
+      });
+
+      // Tron is EVM-like, so getProvider should be called for both chains
+      expect(multiProvider.getProvider.callCount).to.equal(2);
+      const providerChains = multiProvider.getProvider
+        .getCalls()
+        .map((c) => c.args[0]);
+      expect(providerChains).to.include('ethereum');
+      expect(providerChains).to.include('tron');
+    });
+
     it('should call getProvider for all chains when all are EVM', async () => {
       const { multiProvider } = createMockMultiProvider([
         { name: 'ethereum', protocol: ProtocolType.Ethereum },
@@ -315,6 +345,84 @@ describe('RebalancerContextFactory', () => {
       ).to.be.rejectedWith(
         `Missing inventory signer key for protocol ${ProtocolType.Sealevel}`,
       );
+    });
+
+    it('should accept Tron as a supported inventory protocol', async () => {
+      const tronChain = 'tron';
+      const evmChain = 'ethereum';
+      const { multiProvider } = createMockMultiProvider([
+        { name: evmChain, protocol: ProtocolType.Ethereum },
+        { name: tronChain, protocol: ProtocolType.Tron },
+      ]);
+
+      const config = {
+        warpRouteId: 'USDC/tron-route',
+        strategyConfig: [
+          {
+            rebalanceStrategy: RebalancerStrategyOptions.Weighted,
+            chains: {
+              [tronChain]: {
+                bridge: TEST_ADDRESSES.bridge,
+                weighted: { weight: 50n, tolerance: 10n },
+                override: {
+                  [evmChain]: {
+                    executionType: ExecutionType.Inventory,
+                  },
+                },
+              },
+              [evmChain]: {
+                bridge: TEST_ADDRESSES.bridge,
+                weighted: { weight: 50n, tolerance: 10n },
+              },
+            },
+          },
+        ],
+        inventorySigners: {
+          [ProtocolType.Ethereum]: {
+            address: TEST_ADDRESSES.ethereum,
+            key: '0xabc123',
+          },
+          [ProtocolType.Tron]: {
+            address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+            key: '0xdef456',
+          },
+        },
+        intentTTL: DEFAULT_INTENT_TTL_MS,
+      } as RebalancerConfig;
+
+      const factory = await createFactory(config, multiProvider, {
+        tokens: [
+          createToken(
+            evmChain,
+            TEST_ADDRESSES.ethereum,
+            TokenStandard.EvmHypSynthetic,
+          ),
+          createToken(
+            tronChain,
+            '0xTronToken123',
+            TokenStandard.TronHypCollateral,
+          ),
+        ],
+      });
+
+      const getChainMetadataStub = factory.getWarpCore().multiProvider
+        .getChainMetadata as Sinon.SinonStub;
+      getChainMetadataStub.callsFake((chainName: string) => ({
+        protocol:
+          chainName === tronChain ? ProtocolType.Tron : ProtocolType.Ethereum,
+      }));
+
+      // Should NOT reject — Tron is in SUPPORTED_INVENTORY_PROTOCOLS
+      // The call may throw for other reasons (missing adapters), but not for unsupported protocol
+      try {
+        await (factory as any).createInventoryRebalancerAndConfig(
+          {} as any,
+          {},
+        );
+      } catch (error: unknown) {
+        const msg = (error as Error).message;
+        expect(msg).to.not.include("does not support protocol 'tron'");
+      }
     });
 
     it('should fail early when inventory chain uses unsupported protocol', async () => {

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -21,6 +21,7 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import { LiFiBridge } from '../bridges/LiFiBridge.js';
+import { MesonBridge } from '../bridges/MesonBridge.js';
 import { type RebalancerConfig } from '../config/RebalancerConfig.js';
 import {
   ExecutionType,
@@ -626,6 +627,18 @@ export class RebalancerContextFactory {
               this.logger,
             );
           }
+          break;
+        }
+        case ExternalBridgeType.Meson: {
+          const mesonConfig = externalBridges?.meson;
+          registry[ExternalBridgeType.Meson] = new MesonBridge(
+            {
+              apiUrl: mesonConfig?.apiUrl,
+              defaultSlippage: mesonConfig?.defaultSlippage,
+              chainMetadata: this.multiProvider.metadata,
+            },
+            this.logger,
+          );
           break;
         }
         default: {

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -14,6 +14,7 @@ import {
 import {
   Address,
   assert,
+  isEVMLike,
   ProtocolType,
   objMap,
   toWei,
@@ -139,7 +140,7 @@ export class RebalancerContextFactory {
       ...new Set(warpCoreConfig.tokens.map((t) => t.chainName)),
     ];
     for (const chain of warpChains) {
-      if (multiProvider.getProtocol(chain) !== ProtocolType.Ethereum) {
+      if (!isEVMLike(multiProvider.getProtocol(chain))) {
         logger.debug({ chain }, 'Skipping provider init for non-EVM chain');
         continue;
       }
@@ -370,7 +371,7 @@ export class RebalancerContextFactory {
       rebalancerAddress,
       inventorySignerAddresses: this.config.inventorySigners
         ? (Object.entries(this.config.inventorySigners)
-            .filter(([protocol]) => protocol === ProtocolType.Ethereum)
+            .filter(([protocol]) => isEVMLike(protocol as ProtocolType))
             .map(([, signerConfig]) => signerConfig)
             .map((s) => s.address)
             .filter(Boolean) as Address[])
@@ -470,6 +471,7 @@ export class RebalancerContextFactory {
     const SUPPORTED_INVENTORY_PROTOCOLS = new Set([
       ProtocolType.Ethereum,
       ProtocolType.Sealevel,
+      ProtocolType.Tron,
     ]);
     for (const protocol of requiredProtocols) {
       const chainsForProtocol = allRelevantChains.filter(
@@ -479,7 +481,7 @@ export class RebalancerContextFactory {
       );
       assert(
         SUPPORTED_INVENTORY_PROTOCOLS.has(protocol),
-        `Inventory rebalancing does not support protocol '${protocol}' (chains: ${chainsForProtocol.join(', ')}). Supported: ethereum, sealevel`,
+        `Inventory rebalancing does not support protocol '${protocol}' (chains: ${chainsForProtocol.join(', ')}). Supported: ethereum, sealevel, tron`,
       );
     }
     for (const protocol of requiredProtocols) {

--- a/typescript/rebalancer/src/service.ts
+++ b/typescript/rebalancer/src/service.ts
@@ -33,6 +33,7 @@ import { MultiProvider } from '@hyperlane-xyz/sdk';
 import {
   applyRpcUrlOverridesFromEnv,
   createServiceLogger,
+  isEVMLike,
   ProtocolType,
   rootLogger,
 } from '@hyperlane-xyz/utils';
@@ -162,6 +163,10 @@ async function main(): Promise<void> {
         const keyBytes = parseSolanaPrivateKey(privateKey);
         const keypair = Keypair.fromSecretKey(keyBytes);
         derivedAddress = keypair.publicKey.toBase58();
+      } else if (protocol === ProtocolType.Tron) {
+        // Tron uses same hex private key format as Ethereum.
+        // Derive 0x-prefixed hex address via ethers Wallet (TronWallet extends Wallet).
+        derivedAddress = new Wallet(privateKey).address;
       } else {
         logger.warn(
           { protocol },
@@ -174,10 +179,9 @@ async function main(): Promise<void> {
       const configuredAddress =
         rebalancerConfig.inventorySigners?.[protocol as ProtocolType]?.address;
       if (configuredAddress) {
-        const mismatch =
-          protocol === ProtocolType.Ethereum
-            ? configuredAddress.toLowerCase() !== derivedAddress.toLowerCase()
-            : configuredAddress !== derivedAddress;
+        const mismatch = isEVMLike(protocol as ProtocolType)
+          ? configuredAddress.toLowerCase() !== derivedAddress.toLowerCase()
+          : configuredAddress !== derivedAddress;
         if (mismatch) {
           throw new Error(
             `inventorySigners.${protocol} mismatch: config has ${configuredAddress} but HYP_INVENTORY_KEY_${protocol.toUpperCase()} derives to ${derivedAddress}`,

--- a/typescript/rebalancer/src/service.ts
+++ b/typescript/rebalancer/src/service.ts
@@ -157,16 +157,14 @@ async function main(): Promise<void> {
 
       let derivedAddress: string;
 
-      if (protocol === ProtocolType.Ethereum) {
+      if (isEVMLike(protocol as ProtocolType)) {
+        // Tron uses same hex private key format as Ethereum.
+        // Derive 0x-prefixed hex address via ethers Wallet (TronWallet extends Wallet).
         derivedAddress = new Wallet(privateKey).address;
       } else if (protocol === ProtocolType.Sealevel) {
         const keyBytes = parseSolanaPrivateKey(privateKey);
         const keypair = Keypair.fromSecretKey(keyBytes);
         derivedAddress = keypair.publicKey.toBase58();
-      } else if (protocol === ProtocolType.Tron) {
-        // Tron uses same hex private key format as Ethereum.
-        // Derive 0x-prefixed hex address via ethers Wallet (TronWallet extends Wallet).
-        derivedAddress = new Wallet(privateKey).address;
       } else {
         logger.warn(
           { protocol },

--- a/typescript/rebalancer/src/test/mesonMocks.ts
+++ b/typescript/rebalancer/src/test/mesonMocks.ts
@@ -1,0 +1,143 @@
+import Sinon, { type SinonStub } from 'sinon';
+
+import type { BridgeQuote } from '../interfaces/IExternalBridge.js';
+import type {
+  MesonPriceResponse,
+  MesonEncodeResponse,
+  MesonSwapResponse,
+  MesonStatusResponse,
+} from '../bridges/mesonUtils.js';
+
+export function createMesonPriceResponse(
+  overrides?: Partial<MesonPriceResponse['result']>,
+): MesonPriceResponse {
+  return {
+    result: {
+      serviceFee: '0',
+      lpFee: '0.01',
+      totalFee: '0.01',
+      ...overrides,
+    },
+  };
+}
+
+export function createMesonEncodeResponse(
+  overrides?: Partial<MesonEncodeResponse['result']>,
+): MesonEncodeResponse {
+  return {
+    result: {
+      encoded:
+        '0x010000989680d8abcdef1234567890abcdef1234567890abcdef1234567890ab',
+      fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      recipient: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      initiator: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      fee: { serviceFee: '0', lpFee: '0.01', totalFee: '0.01' },
+      signingRequest: {
+        message: '0x19457468657265756d205369676e6564204d657373616765',
+        hash: '0x230ca80a1234567890abcdef1234567890abcdef1234567890abcdef12345678',
+      },
+      ...overrides,
+    },
+  };
+}
+
+export function createMesonSwapResponse(
+  overrides?: Partial<MesonSwapResponse['result']>,
+): MesonSwapResponse {
+  return {
+    result: {
+      swapId:
+        '0x03ae219d1234567890abcdef1234567890abcdef1234567890abcdef12345678',
+      ...overrides,
+    },
+  };
+}
+
+export function createMesonStatusResponse(
+  status: 'BONDED' | 'RELEASED' | 'CANCELLED',
+  overrides?: Partial<MesonStatusResponse['result']>,
+): MesonStatusResponse {
+  const baseResult = {
+    _id: 'swap-123',
+    encoded:
+      '0x010000989680d8abcdef1234567890abcdef1234567890abcdef1234567890ab',
+    status,
+    fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    recipient: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+    expireTs: Math.floor(Date.now() / 1000) + 3600,
+    fromChain: 'eth',
+    toChain: 'tron',
+    inChain: '1',
+    outChain: '728126428',
+    hash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+  };
+
+  const statusSpecificResult =
+    status === 'RELEASED'
+      ? {
+          ...baseResult,
+          outHash:
+            '0x2222222222222222222222222222222222222222222222222222222222222222',
+          amount: '9993000',
+        }
+      : baseResult;
+
+  return {
+    result: {
+      ...statusSpecificResult,
+      ...overrides,
+    },
+  };
+}
+
+export function createMockMesonBridgeQuote(
+  overrides?: Partial<BridgeQuote<MesonPriceResponse>>,
+): BridgeQuote<MesonPriceResponse> {
+  const fromChain = overrides?.requestParams?.fromChain ?? 1;
+  const toChain = overrides?.requestParams?.toChain ?? 728126428;
+  const fromAmount = overrides?.fromAmount ?? 10_000_000n;
+  const toAmount = overrides?.toAmount ?? 9_990_000n;
+  const toAmountMin = overrides?.toAmountMin ?? 9_990_000n;
+
+  return {
+    id: 'meson-quote-123',
+    tool: 'meson',
+    fromAmount,
+    toAmount,
+    toAmountMin,
+    executionDuration: 300,
+    gasCosts: 0n,
+    feeCosts: 10_000n,
+    route: createMesonPriceResponse(),
+    requestParams: {
+      fromChain,
+      toChain,
+      fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+      toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+      fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      toAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      fromAmount,
+    },
+    ...overrides,
+  };
+}
+
+export function createMesonFetchStub(
+  responses?: Array<{ ok: boolean; status: number; body: unknown }>,
+): SinonStub {
+  const stub = Sinon.stub(globalThis, 'fetch');
+  const defaultResponses = responses ?? [
+    { ok: true, status: 200, body: createMesonPriceResponse() },
+  ];
+
+  defaultResponses.forEach((r, i) => {
+    stub.onCall(i).resolves({
+      ok: r.ok,
+      status: r.status,
+      json: async () => r.body,
+      text: async () => JSON.stringify(r.body),
+    } as Response);
+  });
+
+  return stub;
+}

--- a/typescript/rebalancer/src/utils/blockTag.test.ts
+++ b/typescript/rebalancer/src/utils/blockTag.test.ts
@@ -49,4 +49,22 @@ describe('getConfirmedBlockTag', () => {
     const result = await getConfirmedBlockTag(mpp, 'solana');
     expect(result).to.be.undefined;
   });
+
+  it('returns undefined for Tron chain with string reorgPeriod (named block tags not supported)', async () => {
+    const logger = { warn: Sinon.stub() };
+    mpp.getChainMetadata.returns({
+      protocol: ProtocolType.Tron,
+      name: 'tron',
+      chainId: 728126428,
+      blocks: { reorgPeriod: 'finalized' },
+    } as any);
+
+    const result = await getConfirmedBlockTag(mpp, 'tron', logger as any);
+    expect(result).to.be.undefined;
+    expect(logger.warn.calledOnce).to.be.true;
+    const warnCall = logger.warn.getCall(0);
+    expect(warnCall.args[1]).to.include(
+      'Tron does not support named block tags',
+    );
+  });
 });

--- a/typescript/rebalancer/src/utils/blockTag.test.ts
+++ b/typescript/rebalancer/src/utils/blockTag.test.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import { providers } from 'ethers';
+import Sinon from 'sinon';
+
+import { MultiProtocolProvider } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { getConfirmedBlockTag } from './blockTag.js';
+
+describe('getConfirmedBlockTag', () => {
+  let mpp: Sinon.SinonStubbedInstance<MultiProtocolProvider>;
+
+  beforeEach(() => {
+    mpp = Sinon.createStubInstance(MultiProtocolProvider);
+  });
+
+  afterEach(() => {
+    Sinon.restore();
+  });
+
+  it('returns a confirmed block number for Tron chain (EVM-like)', async () => {
+    mpp.getChainMetadata.returns({
+      protocol: ProtocolType.Tron,
+      name: 'tron',
+      chainId: 728126428,
+      blocks: { reorgPeriod: 20 },
+    } as any);
+
+    const mockProvider = {
+      send: Sinon.stub().resolves('0x64'), // 100 in hex
+      getBlockNumber: Sinon.stub().resolves(100),
+    };
+    // Make instanceof check pass
+    Object.setPrototypeOf(mockProvider, providers.JsonRpcProvider.prototype);
+    mpp.getEthersV5Provider.returns(mockProvider as any);
+
+    const result = await getConfirmedBlockTag(mpp, 'tron');
+    // 100 - 20 = 80
+    expect(result).to.equal(80);
+  });
+
+  it('returns undefined for Sealevel chain (non-EVM-like)', async () => {
+    mpp.getChainMetadata.returns({
+      protocol: ProtocolType.Sealevel,
+      name: 'solana',
+      chainId: 1399811149,
+    } as any);
+
+    const result = await getConfirmedBlockTag(mpp, 'solana');
+    expect(result).to.be.undefined;
+  });
+});

--- a/typescript/rebalancer/src/utils/blockTag.ts
+++ b/typescript/rebalancer/src/utils/blockTag.ts
@@ -6,7 +6,7 @@ import {
   EthJsonRpcBlockParameterTag,
   MultiProtocolProvider,
 } from '@hyperlane-xyz/sdk';
-import { isEVMLike } from '@hyperlane-xyz/utils';
+import { isEVMLike, ProtocolType } from '@hyperlane-xyz/utils';
 import type { ConfirmedBlockTag } from '../interfaces/IMonitor.js';
 
 /**
@@ -34,6 +34,13 @@ export async function getConfirmedBlockTag(
 
     const reorgPeriod = metadata.blocks?.reorgPeriod ?? 32;
     if (typeof reorgPeriod === 'string') {
+      if (metadata.protocol === ProtocolType.Tron) {
+        logger?.warn(
+          { chain: chainName, reorgPeriod },
+          'Tron does not support named block tags — ignoring string reorgPeriod, using latest block',
+        );
+        return undefined;
+      }
       return reorgPeriod as EthJsonRpcBlockParameterTag;
     }
 

--- a/typescript/rebalancer/src/utils/blockTag.ts
+++ b/typescript/rebalancer/src/utils/blockTag.ts
@@ -6,7 +6,7 @@ import {
   EthJsonRpcBlockParameterTag,
   MultiProtocolProvider,
 } from '@hyperlane-xyz/sdk';
-import { ProtocolType } from '@hyperlane-xyz/utils';
+import { isEVMLike } from '@hyperlane-xyz/utils';
 import type { ConfirmedBlockTag } from '../interfaces/IMonitor.js';
 
 /**
@@ -26,8 +26,9 @@ export async function getConfirmedBlockTag(
   try {
     const metadata = multiProvider.getChainMetadata(chainName);
 
-    // Only EVM chains support block tag queries
-    if (metadata.protocol !== ProtocolType.Ethereum) {
+    // Only EVM-like chains support block tag queries (e.g., Ethereum, Tron).
+    // Tron uses TronJsonRpcProvider which supports eth_blockNumber
+    if (!isEVMLike(metadata.protocol)) {
       return undefined;
     }
 

--- a/typescript/rebalancer/src/utils/gasEstimation.test.ts
+++ b/typescript/rebalancer/src/utils/gasEstimation.test.ts
@@ -1,0 +1,99 @@
+import { expect } from 'chai';
+import { BigNumber } from 'ethers';
+import { pino } from 'pino';
+import Sinon from 'sinon';
+
+import type { ChainName, MultiProvider, Token } from '@hyperlane-xyz/sdk';
+import { TokenStandard } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { calculateTransferCosts } from './gasEstimation.js';
+
+const testLogger = pino({ level: 'silent' });
+
+describe('calculateTransferCosts — Tron vs Sealevel protocol path', () => {
+  afterEach(() => {
+    Sinon.restore();
+  });
+
+  function createMockDeps(protocol: ProtocolType) {
+    const mockAdapter = {
+      quoteTransferRemoteGas: Sinon.stub().resolves({
+        igpQuote: { amount: 1000n },
+        tokenFeeQuote: { amount: 0n, addressOrDenom: '' },
+      }),
+      populateTransferRemoteTx: Sinon.stub().resolves({
+        to: '0xRouter',
+        data: '0x',
+        value: 1000n,
+      }),
+    };
+
+    const mockToken = {
+      standard: TokenStandard.EvmHypNative, // Native so we reach the isEVMLike check
+      getHypAdapter: Sinon.stub().returns(mockAdapter),
+    } as unknown as Token;
+
+    const multiProvider = {
+      getDomainId: Sinon.stub().returns(42161),
+      getProtocol: Sinon.stub().returns(protocol),
+      getProvider: Sinon.stub().returns({
+        estimateGas: Sinon.stub().resolves(BigNumber.from(200000)),
+        getFeeData: Sinon.stub().resolves({
+          maxFeePerGas: BigNumber.from(10_000_000_000n),
+          gasPrice: BigNumber.from(10_000_000_000n),
+        }),
+      }),
+    } as unknown as MultiProvider;
+
+    const getTokenForChain = Sinon.stub().returns(mockToken);
+    const isNativeTokenStandard = Sinon.stub().returns(true);
+
+    return { multiProvider, getTokenForChain, isNativeTokenStandard };
+  }
+
+  it('Tron origin (EVM-like) produces non-zero gasCost for native tokens', async () => {
+    const { multiProvider, getTokenForChain, isNativeTokenStandard } =
+      createMockDeps(ProtocolType.Tron);
+
+    const result = await calculateTransferCosts(
+      'tron' as ChainName,
+      'arbitrum' as ChainName,
+      10000000000000000000n, // 10 ETH available
+      1000000000000000000n, // 1 ETH requested
+      multiProvider,
+      {} as any, // warpCoreMultiProvider
+      getTokenForChain,
+      '0xInventorySigner',
+      isNativeTokenStandard,
+      testLogger,
+    );
+
+    // Tron is EVM-like — gas estimation runs, producing gasCost > 0
+    expect(result.gasCost > 0n).to.be.true;
+    expect(result.igpCost).to.equal(1000n);
+    expect(result.maxTransferable > 0n).to.be.true;
+  });
+
+  it('Sealevel origin (non-EVM) returns gasCost = 0 for native tokens', async () => {
+    const { multiProvider, getTokenForChain, isNativeTokenStandard } =
+      createMockDeps(ProtocolType.Sealevel);
+
+    const result = await calculateTransferCosts(
+      'solana' as ChainName,
+      'arbitrum' as ChainName,
+      200000000000n,
+      100000000000n,
+      multiProvider,
+      {} as any,
+      getTokenForChain,
+      '0xInventorySigner',
+      isNativeTokenStandard,
+      testLogger,
+    );
+
+    // Sealevel is non-EVM — gasCost is 0 (skips gas estimation)
+    expect(result.gasCost).to.equal(0n);
+    expect(result.igpCost).to.equal(1000n);
+  });
+});

--- a/typescript/rebalancer/src/utils/gasEstimation.ts
+++ b/typescript/rebalancer/src/utils/gasEstimation.ts
@@ -11,8 +11,8 @@ import {
 } from '@hyperlane-xyz/sdk';
 import {
   addBufferToGasLimit,
+  isEVMLike,
   isZeroishAddress,
-  ProtocolType,
 } from '@hyperlane-xyz/utils';
 
 /**
@@ -211,13 +211,13 @@ export async function calculateTransferCosts(
       ? (gasQuote.tokenFeeQuote?.amount ?? 0n)
       : 0n;
 
-  // Skip gas estimation for non-EVM chains (e.g., Solana).
+  // Skip gas estimation for non-EVM-like chains (e.g., Solana).
   // Non-EVM chains have negligible base fees (~5000 lamports ~$0.0001 on Solana)
   // compared to EVM gas costs ($0.50-$50/tx). The IGP (Interchain Gas Paymaster)
   // reservation dominates the cost, not chain-specific gas. Thus gasCost=0 is a
-  // safe approximation for non-EVM origin chains.
+  // safe approximation for non-EVM-like origin chains.
   const originProtocol = multiProvider.getProtocol(originChain);
-  if (originProtocol !== ProtocolType.Ethereum) {
+  if (!isEVMLike(originProtocol)) {
     const totalCost = igpCost + tokenFeeCost;
     let maxTransferable: bigint;
     if (availableInventory <= totalCost) {

--- a/typescript/rebalancer/src/utils/tokenUtils.ts
+++ b/typescript/rebalancer/src/utils/tokenUtils.ts
@@ -13,15 +13,18 @@ const REBALANCEABLE_TOKEN_COLLATERALIZED_STANDARDS = new Set<TokenStandard>([
   TokenStandard.EvmHypNative,
   TokenStandard.SealevelHypCollateral,
   TokenStandard.SealevelHypNative,
+  TokenStandard.TronHypCollateral,
+  TokenStandard.TronHypNative,
 ]);
 
-// SDK-backed native token standard check scoped to EVM and Sealevel only (2-protocol scope).
+// SDK-backed native token standard check scoped to EVM, Sealevel, and Tron (3-protocol scope).
 // NOTE: We intentionally do NOT use the full PROTOCOL_TO_HYP_NATIVE_STANDARD map (all 7 protocols)
-// because the rebalancer only supports EVM and Sealevel native token bridging.
+// because the rebalancer only supports EVM, Sealevel, and Tron native token bridging.
 // Expanding this would change gas reservation behavior for other protocols.
 const REBALANCER_NATIVE_STANDARDS = new Set([
   PROTOCOL_TO_HYP_NATIVE_STANDARD[ProtocolType.Ethereum],
   PROTOCOL_TO_HYP_NATIVE_STANDARD[ProtocolType.Sealevel],
+  PROTOCOL_TO_HYP_NATIVE_STANDARD[ProtocolType.Tron],
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- Adds `MesonBridge` implementing `IExternalBridge` for USDT bridging via [Meson Finance](https://meson.fi) REST API
- Enables rebalancing across **Tron, Plasma, Ethereum, BSC, and Arbitrum** — chains not supported by LiFi
- No new npm dependencies (uses native `fetch()`)

## Changes

| File | Description |
|------|-------------|
| `MesonBridge.ts` | Full `IExternalBridge` implementation (3-step API: price → encode → submit) |
| `mesonUtils.ts` | Chain/token mappings, API types, constants |
| `MesonBridge.test.ts` | 19 tests covering quote, execute, status, error handling, retries |
| `mesonMocks.ts` | Test fixtures for Meson API responses |
| `types.ts` | Added `meson` to `ExternalBridgeType` |
| `RebalancerContextFactory.ts` | Wired `MesonBridge` into factory |
| `RebalancerConfig.test.ts` | Updated config validation tests |

## Notes

- Stacked on `feat/tron-rebalancer-support`
- `LiFiBridge` and `IExternalBridge` are untouched
- Meson has a soft $20k USDT limit per swap (documented, not enforced — splitting is a future enhancement)
- 343 rebalancer tests passing