### PR TITLE
fix: provider sdk warp read

### DIFF
--- a/.changeset/thick-ravens-jog.md
+++ b/.changeset/thick-ravens-jog.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/provider-sdk": patch
 ---
 
-fix: provider sdk warp read
+fixed provider-sdk warp read to preserve domain ID keys in derived warp config

--- a/.changeset/thick-ravens-jog.md
+++ b/.changeset/thick-ravens-jog.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/provider-sdk": patch
+---
+
+fix: provider sdk warp read

--- a/typescript/provider-sdk/src/warp.ts
+++ b/typescript/provider-sdk/src/warp.ts
@@ -406,28 +406,16 @@ export function warpArtifactToDerivedConfig(
 ): DerivedWarpConfig {
   const config = artifact.config;
 
-  // Convert remoteRouters from domain IDs back to chain names
+  // Keep remoteRouters with domain IDs as keys
   const remoteRouters: RemoteRouters = {};
   for (const [domainIdStr, router] of Object.entries(config.remoteRouters)) {
-    const domainId = parseInt(domainIdStr);
-    const chainName = chainLookup.getChainName(domainId);
-    if (!chainName) {
-      // Skip unknown domains
-      continue;
-    }
-    remoteRouters[chainName] = router;
+    remoteRouters[domainIdStr] = router;
   }
 
-  // Convert destinationGas from domain IDs back to chain names
+  // Keep destinationGas with domain IDs as keys
   const destinationGas: DestinationGas = {};
   for (const [domainIdStr, gas] of Object.entries(config.destinationGas)) {
-    const domainId = parseInt(domainIdStr);
-    const chainName = chainLookup.getChainName(domainId);
-    if (!chainName) {
-      // Skip unknown domains
-      continue;
-    }
-    destinationGas[chainName] = gas;
+    destinationGas[domainIdStr] = gas;
   }
 
   // Convert ISM artifact to config if present


### PR DESCRIPTION
### Description

Fix provider sdk warp read

before:

`remoteRouters:
        "ethereumlocal":
          address: "0x00000000000000000000000059b670e9fa9d0a427751af201d676719a970857b"
      destinationGas:
        "ethereumlocal": "64000"`

after

`remoteRouters:
        "31337":
          address: "0x00000000000000000000000059b670e9fa9d0a427751af201d676719a970857b"
      destinationGas:
        "31337": "64000"`

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed warp read functionality to properly handle domain identifiers in configuration transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->