### PR TITLE
fix(starknet): increase gas estimate multiplier to prevent L1 data gas reverts

### DIFF
--- a/rust/main/chains/hyperlane-starknet/src/utils.rs
+++ b/rust/main/chains/hyperlane-starknet/src/utils.rs
@@ -321,11 +321,12 @@ pub(crate) async fn get_block_height_u32(
 }
 
 /// The starknet-rs SDK defaults `gas_estimate_multiplier` to 1.5x, which has
-/// proven insufficient for L1 data gas on some StarkNet chains (e.g. Paradex),
-/// where actual L1 data gas can exceed the 1.5x-buffered estimate by a small
-/// margin, causing "Insufficient max L1DataGas" reverts. A 2.0x multiplier
-/// provides adequate headroom.
-const GAS_ESTIMATE_MULTIPLIER: f64 = 2.0;
+/// proven insufficient for L1 data gas on some StarkNet chains (e.g. Paradex)
+/// during transient L1 blob gas price fluctuations. Actual L1 data gas can
+/// exceed the 1.5x-buffered estimate by a small margin (~3%), causing
+/// "Insufficient max L1DataGas" reverts. A 1.75x multiplier provides adequate
+/// headroom without over-budgeting. Unused gas budget is not charged.
+const GAS_ESTIMATE_MULTIPLIER: f64 = 1.75;
 
 /// Sends a transaction and gets the transaction receipt.
 /// Returns the transaction outcome if the receipt is available.

--- a/rust/main/chains/hyperlane-starknet/src/utils.rs
+++ b/rust/main/chains/hyperlane-starknet/src/utils.rs
@@ -320,6 +320,13 @@ pub(crate) async fn get_block_height_u32(
         .map_err(ChainCommunicationError::from_other)
 }
 
+/// The starknet-rs SDK defaults `gas_estimate_multiplier` to 1.5x, which has
+/// proven insufficient for L1 data gas on some StarkNet chains (e.g. Paradex),
+/// where actual L1 data gas can exceed the 1.5x-buffered estimate by a small
+/// margin, causing "Insufficient max L1DataGas" reverts. A 2.0x multiplier
+/// provides adequate headroom.
+const GAS_ESTIMATE_MULTIPLIER: f64 = 2.0;
+
 /// Sends a transaction and gets the transaction receipt.
 /// Returns the transaction outcome if the receipt is available.
 pub async fn send_and_confirm(
@@ -327,6 +334,7 @@ pub async fn send_and_confirm(
     contract_call: ExecutionV3<'_, SingleOwnerAccount<JsonProvider, LocalWallet>>,
 ) -> ChainResult<TxOutcome> {
     let tx = contract_call
+        .gas_estimate_multiplier(GAS_ESTIMATE_MULTIPLIER)
         .send()
         .await
         .map_err(HyperlaneStarknetError::from)?;


### PR DESCRIPTION
## Summary

- Increased StarkNet gas estimate multiplier from SDK default 1.5x to 1.75x in `send_and_confirm()`, the central transaction submission function for all StarkNet chains
- Fixes intermittent "Insufficient max L1DataGas" transaction reverts observed on Paradex during transient L1 blob gas price fluctuations
- Most Paradex deliveries succeed with the default 1.5x — this is a safety net for edge cases where L1 data gas spikes between estimation and execution

## Context

Solana→Paradex DIME transfer ([0x2bf341b3...](https://explorer.hyperlane.xyz/message/0x2bf341b38cbd8fd758544167f49613b6737faa7a6bddcbfcd3cae1a11d1049fe)) reverted on-chain with "Insufficient max L1DataGas: max amount: 1056, actual used: 1088". The starknet-rs SDK estimated ~704 L1 data gas units and applied its default 1.5x buffer (→ 1056), but actual consumption was 1088 (~1.545x the estimate).

The revert burned 2.67T gas in a single attempt, creating a permanent gas payment deficit that made the message unretryable by the existing relayer. A fresh relayer deployment with this fix can retry the message successfully (fresh DB has no prior expenditure history).

1.75x gives ~13% headroom over the observed worst case (1.545x). Unused gas budget is not charged on StarkNet, so the only cost is a slightly higher declared `max_fee`.

## Test plan

- [ ] Deploy fresh relayer with this fix and verify the stuck 700K DIME message delivers
- [ ] Monitor Paradex delivery revert rate after deployment


🤖 Generated with [Claude Code](https://claude.com/claude-code)