### PR TITLE
feat(skills): add force-retry procedure to debug-message skill

### DIFF
--- a/.claude/skills/debug-message/SKILL.md
+++ b/.claude/skills/debug-message/SKILL.md
@@ -156,9 +156,71 @@ If `CouldNotFetchMetadata` persists > 5 minutes:
 If `GasPaymentRequirementNotMet`:
 
 - Compare `current_payment.gas_amount` vs `tx_cost_estimate.gas_limit`
+- Compare `current_expenditure.gas_used` vs `current_payment.gas_amount` — if gas_used >> gas_amount, the deficit is unrecoverable
 - Message will auto-retry every ~3 min until gas prices drop or subsidy kicks in
 - Check `policy` field for subsidy ratio (e.g., 1/2 = relayer covers 50%)
-- Resolution: wait for gas prices to drop, or manually subsidize via IGP top-up
+- Resolution: wait for gas prices to drop, manually subsidize via IGP top-up, or force-retry (see below)
+
+### Force-Retry a Message (Bypassing Gas Payment Enforcement)
+
+When `GasPaymentRequirementNotMet` is unrecoverable (accumulated `gas_used` far exceeds `gas_amount`), you can temporarily bypass gas enforcement using the relayer's runtime API. **Requires engineer approval** — the `None` policy also bypasses sanctions-related checks in the enforcement pipeline.
+
+Before force-retrying, verify the underlying issue is resolved:
+
+- Check recent deliveries to the same destination chain for `executed: true` outcomes
+- If the original tx reverted, confirm the revert condition is transient (not a permanent contract bug)
+
+The relayer API runs on the **metrics port (9090)**, accessed via port-forward:
+
+```bash
+kubectl port-forward -n mainnet3 pod/omniscient-relayer-hyperlane-agent-relayer-0 19090:9090 > /dev/null 2>&1 &
+```
+
+**Step 1: Add temporary None IGP rule for the message**
+
+```bash
+curl -s -X POST http://localhost:19090/igp_rules \
+  -H 'Content-Type: application/json' \
+  -d '{"policy":"None","matching_list":[{"messageid":"0x<MESSAGE_ID>"}]}'
+# Returns {} on success. Rule inserted at index 0 (highest priority).
+```
+
+**Step 2: Trigger message retry**
+
+```bash
+curl -s -X POST http://localhost:19090/message_retry \
+  -H 'Content-Type: application/json' \
+  -d '[{"messageid":"0x<MESSAGE_ID>"}]'
+# Returns {"uuid":"...","evaluated":N,"matched":1}
+```
+
+**Step 3: Wait ~30-60s, then verify delivery**
+
+```bash
+gcloud logging read '[BASE_RELAYER_QUERY] AND "[MESSAGE_ID]" AND jsonPayload.fields.message:"Recording gas expenditure"' \
+  --project=abacus-labs-dev --limit=1 --format='value(jsonPayload.fields.outcome)' --freshness=5m
+# Look for executed: true
+```
+
+**Step 4: Remove temporary IGP rule (CRITICAL — do not skip)**
+
+```bash
+curl -s -X DELETE http://localhost:19090/igp_rules/0
+# Returns {} on success.
+```
+
+**Step 5: Kill port-forward**
+
+```bash
+kill %1 2>/dev/null
+```
+
+Other useful API endpoints:
+
+- GET /igp_rules — list all enforcement rules per chain
+- POST /message_retry matching fields: messageid, origindomain, destinationdomain, senderaddress, recipientaddress
+
+> **Note:** IGP rules added via API are in-memory only and do not survive pod restarts.
 
 ## Decoding Revert Selectors
 


### PR DESCRIPTION
## Summary
- Added a "Force-Retry a Message" section to the debug-message skill for handling unrecoverable `GasPaymentRequirementNotMet` cases
- Documents the step-by-step procedure to bypass IGP enforcement via the relayer runtime API (port-forward, add None IGP rule, retry, verify, cleanup)
- Added comparison of `gas_used` vs `gas_amount` to identify unrecoverable gas deficits

## Test plan
- [ ] Verify skill renders correctly in Claude Code
- [ ] Test force-retry procedure against a stuck message in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Documentation adds an operator runbook for bypassing relayer IGP enforcement (including sanctions-related checks) via runtime API, which could be misused if followed incorrectly despite no production code changes.
> 
> **Overview**
> Adds guidance to the `debug-message` skill to better diagnose `GasPaymentRequirementNotMet` by comparing `gas_used` vs `gas_amount` and recognizing unrecoverable deficits.
> 
> Documents a **force-retry** runbook that temporarily inserts a `None` IGP rule via the relayer metrics-port runtime API (`/igp_rules` + `/message_retry`), includes verification steps, and emphasizes mandatory cleanup by removing the rule afterward.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cd60201683bc16fbb7dd292a3534e8e699dc0eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->