### PR TITLE
feat(infra): add Turnkey roles for IGP owner and warp fees owner

### DIFF
--- a/typescript/infra/src/roles.ts
+++ b/typescript/infra/src/roles.ts
@@ -46,5 +46,5 @@ export enum TurnkeyRole {
   EvmRebalancer = 'evm-rebalancer',
   EvmIgpClaimer = 'evm-igp-claimer',
   EvmIgpOwner = 'evm-igp-owner',
-  EvmWarpFeesOwner = 'warp-fees-owner',
+  EvmWarpFeesOwner = 'evm-warp-fees-owner',
 }

--- a/typescript/infra/src/roles.ts
+++ b/typescript/infra/src/roles.ts
@@ -45,5 +45,6 @@ export enum TurnkeyRole {
   EvmDeployer = 'evm-deployer',
   EvmRebalancer = 'evm-rebalancer',
   EvmIgpClaimer = 'evm-igp-claimer',
-  EvmIgpUpdater = 'evm-igp-updater',
+  EvmIgpOwner = 'evm-igp-owner',
+  EvmWarpFeesOwner = 'warp-fees-owner',
 }

--- a/typescript/infra/src/utils/turnkey.ts
+++ b/typescript/infra/src/utils/turnkey.ts
@@ -43,7 +43,8 @@ export async function createTurnkeySigner(
       case TurnkeyRole.EvmLegacyDeployer:
       case TurnkeyRole.EvmRebalancer:
       case TurnkeyRole.EvmIgpClaimer:
-      case TurnkeyRole.EvmIgpUpdater:
+      case TurnkeyRole.EvmIgpOwner:
+      case TurnkeyRole.EvmWarpFeesOwner:
         signer = new TurnkeyEvmSigner(turnkeyConfig);
         break;
       default:


### PR DESCRIPTION
## Summary
- Replaced `EvmIgpUpdater` with `EvmIgpOwner` (IGP is now managed by owner, not a separate updater role)
- Added `EvmWarpFeesOwner` role for the new warp fees owner Turnkey secret

Maps to GCP secrets: `mainnet3-turnkey-evm-igp-owner` and `mainnet3-turnkey-warp-fees-owner`

## Test plan
- [ ] Verify GCP secrets are accessible with the new names
- [ ] Test signer creation for both new roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Turnkey role identifiers used to derive GCP secret names and signer selection, which can break operational scripts if secrets/role strings aren’t updated consistently.
> 
> **Overview**
> Adds new Turnkey operational roles `EvmIgpOwner` and `EvmWarpFeesOwner`, and removes `EvmIgpUpdater` from `TurnkeyRole`.
> 
> Updates `createTurnkeySigner` to treat the new roles as EVM roles (using `TurnkeyEvmSigner`), which also changes the derived GCP secret names via the role string values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76b5f02852ab6339e9515556ab52ea04d3e75c44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->