### PR TITLE
chore(license): transition commercial code to BUSL-1.1

### DIFF
--- a/LICENSE-APACHE-2.0
+++ b/LICENSE-APACHE-2.0
@@ -1,0 +1,193 @@
+# Apache License
+
+_Version 2.0, January 2004_  
+_&lt;<http://www.apache.org/licenses/>&gt;_
+
+### Terms and Conditions for use, reproduction, and distribution
+
+#### 1. Definitions
+
+“License” shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+“Licensor” shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+“Legal Entity” shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, “control” means **(i)** the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
+outstanding shares, or **(iii)** beneficial ownership of such entity.
+
+“You” (or “Your”) shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+“Source” form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+“Object” form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+“Work” shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+“Derivative Works” shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+“Contribution” shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+“submitted” means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as “Not a Contribution.”
+
+“Contributor” shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+#### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+#### 3. Grant of Patent License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+#### 4. Redistribution
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+- **(a)** You must give any other recipients of the Work or Derivative Works a copy of
+  this License; and
+- **(b)** You must cause any modified files to carry prominent notices stating that You
+  changed the files; and
+- **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
+  all copyright, patent, trademark, and attribution notices from the Source form
+  of the Work, excluding those notices that do not pertain to any part of the
+  Derivative Works; and
+- **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
+  Derivative Works that You distribute must include a readable copy of the
+  attribution notices contained within such NOTICE file, excluding those notices
+  that do not pertain to any part of the Derivative Works, in at least one of the
+  following places: within a NOTICE text file distributed as part of the
+  Derivative Works; within the Source form or documentation, if provided along
+  with the Derivative Works; or, within a display generated by the Derivative
+  Works, if and wherever such third-party notices normally appear. The contents of
+  the NOTICE file are for informational purposes only and do not modify the
+  License. You may add Your own attribution notices within Derivative Works that
+  You distribute, alongside or as an addendum to the NOTICE text from the Work,
+  provided that such additional attribution notices cannot be construed as
+  modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+#### 5. Submission of Contributions
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+#### 6. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+#### 7. Disclaimer of Warranty
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+#### 8. Limitation of Liability
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+#### 9. Accepting Warranty or Additional Liability
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+_END OF TERMS AND CONDITIONS_
+
+### APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets `[]` replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same “printed page” as the copyright notice for easier identification within
+third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/LICENSE-BUSL-1.1
+++ b/LICENSE-BUSL-1.1
@@ -1,0 +1,115 @@
+Business Source License 1.1
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+-----------------------------------------------------------------------------
+
+Parameters
+
+Licensor:             Abacus Works, Inc.
+
+Licensed Work:        Hyperlane (portions as designated by SPDX headers)
+                      The Licensed Work is (c) 2024-2026 Abacus Works, Inc.
+
+Additional Use Grant: You may make use of the Licensed Work, provided that
+                      you do not use the Licensed Work for a Commercial
+                      Purpose.
+
+                      A "Commercial Purpose" means use in or for a product or
+                      service that competes with the Licensed Work or any
+                      other product or service made available by the Licensor,
+                      including but not limited to cross-chain token bridging,
+                      stablecoin routing, interchain swap infrastructure, and
+                      interchain account or query middleware.
+
+                      You may use the Licensed Work for non-production
+                      purposes including development, testing, and personal
+                      education.
+
+Change Date:          Four years from the date of each release of the
+                      Licensed Work.
+
+Change License:       Apache License, Version 2.0
+
+For information about alternative licensing arrangements for the Licensed
+Work, please contact: licensing@hyperlane.xyz
+
+-----------------------------------------------------------------------------
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+-----------------------------------------------------------------------------
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+
+-----------------------------------------------------------------------------
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,193 +1,51 @@
-# Apache License
+# Licenses
 
-_Version 2.0, January 2004_  
-_&lt;<http://www.apache.org/licenses/>&gt;_
+This repository contains code under multiple licenses.
+Each source file indicates its license via an SPDX-License-Identifier header.
 
-### Terms and Conditions for use, reproduction, and distribution
+## Apache License 2.0 / MIT
 
-#### 1. Definitions
+Core protocol contracts, interfaces, base libraries, agents, SDK, and
+utilities are licensed under Apache-2.0 (or MIT OR Apache-2.0 for some files).
 
-“License” shall mean the terms and conditions for use, reproduction, and
-distribution as defined by Sections 1 through 9 of this document.
+See `LICENSE-APACHE-2.0` for the full Apache 2.0 license text.
 
-“Licensor” shall mean the copyright owner or entity authorized by the copyright
-owner that is granting the License.
+## Business Source License 1.1
 
-“Legal Entity” shall mean the union of the acting entity and all other entities
-that control, are controlled by, or are under common control with that entity.
-For the purposes of this definition, “control” means **(i)** the power, direct or
-indirect, to cause the direction or management of such entity, whether by
-contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
-outstanding shares, or **(iii)** beneficial ownership of such entity.
+Commercial and product code including advanced token contracts, middleware,
+infrastructure tooling, and CLI are licensed under BUSL-1.1.
 
-“You” (or “Your”) shall mean an individual or Legal Entity exercising
-permissions granted by this License.
+See `LICENSE-BUSL-1.1` for the full license text including the
+Additional Use Grant and Change Date.
 
-“Source” form shall mean the preferred form for making modifications, including
-but not limited to software source code, documentation source, and configuration
-files.
+## Directory Breakdown
 
-“Object” form shall mean any form resulting from mechanical transformation or
-translation of a Source form, including but not limited to compiled object code,
-generated documentation, and conversions to other media types.
+### Apache 2.0 (or MIT OR Apache-2.0)
+- `solidity/contracts/Mailbox.sol`
+- `solidity/contracts/interfaces/` (all)
+- `solidity/contracts/libs/`
+- `solidity/contracts/client/`
+- `solidity/contracts/isms/`
+- `solidity/contracts/hooks/`
+- `solidity/contracts/upgrade/`
+- `solidity/contracts/PackageVersioned.sol`
+- `solidity/contracts/token/HypERC20.sol`
+- `solidity/contracts/token/HypERC20Collateral.sol`
+- `solidity/contracts/token/HypERC721.sol`
+- `solidity/contracts/token/HypERC721Collateral.sol`
+- `solidity/contracts/token/HypNative.sol`
+- `solidity/contracts/token/libs/TokenRouter.sol`
+- `solidity/contracts/token/libs/TokenMessage.sol`
+- `rust/`
+- `typescript/sdk/`
+- `typescript/utils/`
 
-“Work” shall mean the work of authorship, whether in Source or Object form, made
-available under the License, as indicated by a copyright notice that is included
-in or attached to the work (an example is provided in the Appendix below).
-
-“Derivative Works” shall mean any work, whether in Source or Object form, that
-is based on (or derived from) the Work and for which the editorial revisions,
-annotations, elaborations, or other modifications represent, as a whole, an
-original work of authorship. For the purposes of this License, Derivative Works
-shall not include works that remain separable from, or merely link (or bind by
-name) to the interfaces of, the Work and Derivative Works thereof.
-
-“Contribution” shall mean any work of authorship, including the original version
-of the Work and any modifications or additions to that Work or Derivative Works
-thereof, that is intentionally submitted to Licensor for inclusion in the Work
-by the copyright owner or by an individual or Legal Entity authorized to submit
-on behalf of the copyright owner. For the purposes of this definition,
-“submitted” means any form of electronic, verbal, or written communication sent
-to the Licensor or its representatives, including but not limited to
-communication on electronic mailing lists, source code control systems, and
-issue tracking systems that are managed by, or on behalf of, the Licensor for
-the purpose of discussing and improving the Work, but excluding communication
-that is conspicuously marked or otherwise designated in writing by the copyright
-owner as “Not a Contribution.”
-
-“Contributor” shall mean Licensor and any individual or Legal Entity on behalf
-of whom a Contribution has been received by Licensor and subsequently
-incorporated within the Work.
-
-#### 2. Grant of Copyright License
-
-Subject to the terms and conditions of this License, each Contributor hereby
-grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
-irrevocable copyright license to reproduce, prepare Derivative Works of,
-publicly display, publicly perform, sublicense, and distribute the Work and such
-Derivative Works in Source or Object form.
-
-#### 3. Grant of Patent License
-
-Subject to the terms and conditions of this License, each Contributor hereby
-grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
-irrevocable (except as stated in this section) patent license to make, have
-made, use, offer to sell, sell, import, and otherwise transfer the Work, where
-such license applies only to those patent claims licensable by such Contributor
-that are necessarily infringed by their Contribution(s) alone or by combination
-of their Contribution(s) with the Work to which such Contribution(s) was
-submitted. If You institute patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Work or a
-Contribution incorporated within the Work constitutes direct or contributory
-patent infringement, then any patent licenses granted to You under this License
-for that Work shall terminate as of the date such litigation is filed.
-
-#### 4. Redistribution
-
-You may reproduce and distribute copies of the Work or Derivative Works thereof
-in any medium, with or without modifications, and in Source or Object form,
-provided that You meet the following conditions:
-
-- **(a)** You must give any other recipients of the Work or Derivative Works a copy of
-  this License; and
-- **(b)** You must cause any modified files to carry prominent notices stating that You
-  changed the files; and
-- **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
-  all copyright, patent, trademark, and attribution notices from the Source form
-  of the Work, excluding those notices that do not pertain to any part of the
-  Derivative Works; and
-- **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
-  Derivative Works that You distribute must include a readable copy of the
-  attribution notices contained within such NOTICE file, excluding those notices
-  that do not pertain to any part of the Derivative Works, in at least one of the
-  following places: within a NOTICE text file distributed as part of the
-  Derivative Works; within the Source form or documentation, if provided along
-  with the Derivative Works; or, within a display generated by the Derivative
-  Works, if and wherever such third-party notices normally appear. The contents of
-  the NOTICE file are for informational purposes only and do not modify the
-  License. You may add Your own attribution notices within Derivative Works that
-  You distribute, alongside or as an addendum to the NOTICE text from the Work,
-  provided that such additional attribution notices cannot be construed as
-  modifying the License.
-
-You may add Your own copyright statement to Your modifications and may provide
-additional or different license terms and conditions for use, reproduction, or
-distribution of Your modifications, or for any such Derivative Works as a whole,
-provided Your use, reproduction, and distribution of the Work otherwise complies
-with the conditions stated in this License.
-
-#### 5. Submission of Contributions
-
-Unless You explicitly state otherwise, any Contribution intentionally submitted
-for inclusion in the Work by You to the Licensor shall be under the terms and
-conditions of this License, without any additional terms or conditions.
-Notwithstanding the above, nothing herein shall supersede or modify the terms of
-any separate license agreement you may have executed with Licensor regarding
-such Contributions.
-
-#### 6. Trademarks
-
-This License does not grant permission to use the trade names, trademarks,
-service marks, or product names of the Licensor, except as required for
-reasonable and customary use in describing the origin of the Work and
-reproducing the content of the NOTICE file.
-
-#### 7. Disclaimer of Warranty
-
-Unless required by applicable law or agreed to in writing, Licensor provides the
-Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
-including, without limitation, any warranties or conditions of TITLE,
-NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
-solely responsible for determining the appropriateness of using or
-redistributing the Work and assume any risks associated with Your exercise of
-permissions under this License.
-
-#### 8. Limitation of Liability
-
-In no event and under no legal theory, whether in tort (including negligence),
-contract, or otherwise, unless required by applicable law (such as deliberate
-and grossly negligent acts) or agreed to in writing, shall any Contributor be
-liable to You for damages, including any direct, indirect, special, incidental,
-or consequential damages of any character arising as a result of this License or
-out of the use or inability to use the Work (including but not limited to
-damages for loss of goodwill, work stoppage, computer failure or malfunction, or
-any and all other commercial damages or losses), even if such Contributor has
-been advised of the possibility of such damages.
-
-#### 9. Accepting Warranty or Additional Liability
-
-While redistributing the Work or Derivative Works thereof, You may choose to
-offer, and charge a fee for, acceptance of support, warranty, indemnity, or
-other liability obligations and/or rights consistent with this License. However,
-in accepting such obligations, You may act only on Your own behalf and on Your
-sole responsibility, not on behalf of any other Contributor, and only if You
-agree to indemnify, defend, and hold each Contributor harmless for any liability
-incurred by, or claims asserted against, such Contributor by reason of your
-accepting any such warranty or additional liability.
-
-_END OF TERMS AND CONDITIONS_
-
-### APPENDIX: How to apply the Apache License to your work
-
-To apply the Apache License to your work, attach the following boilerplate
-notice, with the fields enclosed by brackets `[]` replaced with your own
-identifying information. (Don't include the brackets!) The text should be
-enclosed in the appropriate comment syntax for the file format. We also
-recommend that a file or class name and description of purpose be included on
-the same “printed page” as the copyright notice for easier identification within
-third-party archives.
-
-    Copyright [yyyy] [name of copyright owner]
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+### BUSL-1.1
+- `solidity/contracts/token/TokenBridgeCctpBase.sol`
+- `solidity/contracts/token/TokenBridgeCctpV1.sol`
+- `solidity/contracts/token/TokenBridgeCctpV2.sol`
+- `solidity/contracts/token/extensions/` (all)
+- `solidity/contracts/token/libs/` (all files EXCEPT TokenRouter.sol and TokenMessage.sol)
+- `solidity/contracts/middleware/` (all)
+- `typescript/infra/`
+- `typescript/cli/`

--- a/solidity/contracts/middleware/AbstractInterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/AbstractInterchainAccountRouter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
 /*@@@@@@@       @@@@@@@@@

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
 /*@@@@@@@       @@@@@@@@@

--- a/solidity/contracts/middleware/InterchainQueryRouter.sol
+++ b/solidity/contracts/middleware/InterchainQueryRouter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============

--- a/solidity/contracts/middleware/MinimalInterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/MinimalInterchainAccountRouter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
 /*@@@@@@@       @@@@@@@@@

--- a/solidity/contracts/middleware/libs/Call.sol
+++ b/solidity/contracts/middleware/libs/Call.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
+++ b/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {CallLib} from "./Call.sol";

--- a/solidity/contracts/middleware/libs/InterchainQueryMessage.sol
+++ b/solidity/contracts/middleware/libs/InterchainQueryMessage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
 import {CallLib} from "./Call.sol";

--- a/solidity/contracts/middleware/libs/OwnableMulticall.sol
+++ b/solidity/contracts/middleware/libs/OwnableMulticall.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
 // ============ Internal Imports ============

--- a/solidity/contracts/token/TokenBridgeCctpBase.sol
+++ b/solidity/contracts/token/TokenBridgeCctpBase.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {TokenRouter} from "./libs/TokenRouter.sol";

--- a/solidity/contracts/token/TokenBridgeCctpV1.sol
+++ b/solidity/contracts/token/TokenBridgeCctpV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {TokenBridgeCctpBase} from "./TokenBridgeCctpBase.sol";

--- a/solidity/contracts/token/TokenBridgeCctpV2.sol
+++ b/solidity/contracts/token/TokenBridgeCctpV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {TokenBridgeCctpBase} from "./TokenBridgeCctpBase.sol";

--- a/solidity/contracts/token/extensions/HypERC4626.sol
+++ b/solidity/contracts/token/extensions/HypERC4626.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 /*@@@@@@@       @@@@@@@@@

--- a/solidity/contracts/token/extensions/HypERC4626Collateral.sol
+++ b/solidity/contracts/token/extensions/HypERC4626Collateral.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 /*@@@@@@@       @@@@@@@@@

--- a/solidity/contracts/token/extensions/HypERC4626OwnerCollateral.sol
+++ b/solidity/contracts/token/extensions/HypERC4626OwnerCollateral.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 /*@@@@@@@       @@@@@@@@@

--- a/solidity/contracts/token/extensions/HypERC721URICollateral.sol
+++ b/solidity/contracts/token/extensions/HypERC721URICollateral.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {HypERC721Collateral} from "../HypERC721Collateral.sol";

--- a/solidity/contracts/token/extensions/HypERC721URIStorage.sol
+++ b/solidity/contracts/token/extensions/HypERC721URIStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {HypERC721} from "../HypERC721.sol";

--- a/solidity/contracts/token/extensions/HypFiatToken.sol
+++ b/solidity/contracts/token/extensions/HypFiatToken.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {IFiatToken} from "../interfaces/IFiatToken.sol";

--- a/solidity/contracts/token/extensions/HypXERC20.sol
+++ b/solidity/contracts/token/extensions/HypXERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {IXERC20} from "../interfaces/IXERC20.sol";

--- a/solidity/contracts/token/extensions/HypXERC20Lockbox.sol
+++ b/solidity/contracts/token/extensions/HypXERC20Lockbox.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {IXERC20Lockbox} from "../interfaces/IXERC20Lockbox.sol";

--- a/solidity/contracts/token/extensions/OPL2ToL1TokenBridgeNative.sol
+++ b/solidity/contracts/token/extensions/OPL2ToL1TokenBridgeNative.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {HypNative} from "../../token/HypNative.sol";

--- a/solidity/contracts/token/extensions/WHypERC4626.sol
+++ b/solidity/contracts/token/extensions/WHypERC4626.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/solidity/contracts/token/libs/AmountPartition.sol
+++ b/solidity/contracts/token/libs/AmountPartition.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 // ============ External Imports ============

--- a/solidity/contracts/token/libs/LpCollateralRouter.sol
+++ b/solidity/contracts/token/libs/LpCollateralRouter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============

--- a/solidity/contracts/token/libs/MovableCollateralRouter.sol
+++ b/solidity/contracts/token/libs/MovableCollateralRouter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {ITokenBridge, Quote} from "../../interfaces/ITokenBridge.sol";

--- a/solidity/contracts/token/libs/Quotes.sol
+++ b/solidity/contracts/token/libs/Quotes.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {Quote} from "../../interfaces/ITokenBridge.sol";

--- a/solidity/contracts/token/libs/TokenCollateral.sol
+++ b/solidity/contracts/token/libs/TokenCollateral.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {IWETH} from "../interfaces/IWETH.sol";

--- a/typescript/cli/cli.ts
+++ b/typescript/cli/cli.ts
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import yargs from 'yargs';
 

--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -10,7 +10,7 @@
     "Typescript"
   ],
   "homepage": "https://www.hyperlane.xyz",
-  "license": "Apache-2.0",
+  "license": "BUSL-1.1",
   "repository": "https://github.com/hyperlane-xyz/hyperlane-monorepo",
   "bin": {
     "hyperlane": "./bundle/index.js"

--- a/typescript/cli/src/avs/check.ts
+++ b/typescript/cli/src/avs/check.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type Wallet } from 'ethers';
 
 import {

--- a/typescript/cli/src/avs/config.ts
+++ b/typescript/cli/src/avs/config.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type ChainMap } from '@hyperlane-xyz/sdk';
 import { type Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/cli/src/avs/stakeRegistry.ts
+++ b/typescript/cli/src/avs/stakeRegistry.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { password } from '@inquirer/prompts';
 import { type BigNumberish, Wallet, utils } from 'ethers';
 

--- a/typescript/cli/src/check/warp.ts
+++ b/typescript/cli/src/check/warp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { stringify as yamlStringify } from 'yaml';
 
 import {

--- a/typescript/cli/src/commands/avs.ts
+++ b/typescript/cli/src/commands/avs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type CommandModule, type Options } from 'yargs';
 
 import { type ChainName } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/commands/config.ts
+++ b/typescript/cli/src/commands/config.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type CommandModule } from 'yargs';
 
 import { readChainConfigs } from '../config/chain.js';

--- a/typescript/cli/src/commands/core.ts
+++ b/typescript/cli/src/commands/core.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { stringify as yamlStringify } from 'yaml';
 import { type CommandModule } from 'yargs';
 

--- a/typescript/cli/src/commands/fork.ts
+++ b/typescript/cli/src/commands/fork.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   type RawForkedChainConfigByChain,
   RawForkedChainConfigByChainSchema,

--- a/typescript/cli/src/commands/hook.ts
+++ b/typescript/cli/src/commands/hook.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type CommandModule } from 'yargs';
 
 import { type CommandModuleWithContext } from '../context/types.js';

--- a/typescript/cli/src/commands/ica.ts
+++ b/typescript/cli/src/commands/ica.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type CommandModule } from 'yargs';
 
 import { type CommandModuleWithWriteContext } from '../context/types.js';

--- a/typescript/cli/src/commands/ism.ts
+++ b/typescript/cli/src/commands/ism.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type CommandModule } from 'yargs';
 
 import {

--- a/typescript/cli/src/commands/options.test.ts
+++ b/typescript/cli/src/commands/options.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { coerceStringArray } from './options.js';

--- a/typescript/cli/src/commands/options.ts
+++ b/typescript/cli/src/commands/options.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import os from 'os';
 import { type Options } from 'yargs';
 

--- a/typescript/cli/src/commands/registry.ts
+++ b/typescript/cli/src/commands/registry.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type CommandModule } from 'yargs';
 
 import { createAgentConfig } from '../config/agent.js';

--- a/typescript/cli/src/commands/relayer.ts
+++ b/typescript/cli/src/commands/relayer.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { HyperlaneRelayer, RelayerCacheSchema } from '@hyperlane-xyz/relayer';
 import { type ChainMap, HyperlaneCore } from '@hyperlane-xyz/sdk';
 import { type Address } from '@hyperlane-xyz/utils';

--- a/typescript/cli/src/commands/send.ts
+++ b/typescript/cli/src/commands/send.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 import { type CommandModule, type Options } from 'yargs';
 

--- a/typescript/cli/src/commands/signCommands.test.ts
+++ b/typescript/cli/src/commands/signCommands.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import {

--- a/typescript/cli/src/commands/signCommands.ts
+++ b/typescript/cli/src/commands/signCommands.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // Commands that send tx and require a key to sign.
 // It's useful to have this listed here so the context
 

--- a/typescript/cli/src/commands/status.ts
+++ b/typescript/cli/src/commands/status.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type CommandModuleWithContext } from '../context/types.js';
 import { checkMessageStatus } from '../status/message.js';
 

--- a/typescript/cli/src/commands/strategy.ts
+++ b/typescript/cli/src/commands/strategy.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { stringify as yamlStringify } from 'yaml';
 import { type CommandModule } from 'yargs';
 

--- a/typescript/cli/src/commands/submit.ts
+++ b/typescript/cli/src/commands/submit.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { groupBy } from 'lodash-es';
 
 import {

--- a/typescript/cli/src/commands/types.ts
+++ b/typescript/cli/src/commands/types.ts
@@ -1,2 +1,3 @@
+// SPDX-License-Identifier: BUSL-1.1
 export const ChainTypes = ['mainnet', 'testnet'];
 export type ChainType = (typeof ChainTypes)[number];

--- a/typescript/cli/src/commands/utils.ts
+++ b/typescript/cli/src/commands/utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import type { CommandModule } from 'yargs';
 
 import {

--- a/typescript/cli/src/commands/validator.ts
+++ b/typescript/cli/src/commands/validator.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type CommandModule } from 'yargs';
 
 import {

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import util from 'util';
 import { stringify as yamlStringify } from 'yaml';
 import { type CommandModule } from 'yargs';

--- a/typescript/cli/src/commands/xerc20.ts
+++ b/typescript/cli/src/commands/xerc20.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { groupBy } from 'lodash-es';
 import { stringify as yamlStringify } from 'yaml';
 import { type CommandModule } from 'yargs';

--- a/typescript/cli/src/config/agent.ts
+++ b/typescript/cli/src/config/agent.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 import { fromError } from 'zod-validation-error';
 

--- a/typescript/cli/src/config/chain.test.ts
+++ b/typescript/cli/src/config/chain.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { readChainConfigs } from './chain.js';

--- a/typescript/cli/src/config/chain.ts
+++ b/typescript/cli/src/config/chain.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm, input, select } from '@inquirer/prompts';
 import { ethers } from 'ethers';
 import { stringify as yamlStringify } from 'yaml';

--- a/typescript/cli/src/config/core.ts
+++ b/typescript/cli/src/config/core.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { stringify as yamlStringify } from 'yaml';
 
 import {

--- a/typescript/cli/src/config/hooks.ts
+++ b/typescript/cli/src/config/hooks.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm, input, select } from '@inquirer/prompts';
 import { BigNumber as BigNumberJs } from 'bignumber.js';
 import { ethers } from 'ethers';

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { input, select } from '@inquirer/prompts';
 import { z } from 'zod';
 

--- a/typescript/cli/src/config/multisig.ts
+++ b/typescript/cli/src/config/multisig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm, input } from '@inquirer/prompts';
 import { z } from 'zod';
 

--- a/typescript/cli/src/config/prompts.ts
+++ b/typescript/cli/src/config/prompts.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 
 export const autoConfirm = async (

--- a/typescript/cli/src/config/strategy.ts
+++ b/typescript/cli/src/config/strategy.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm, input, password, select } from '@inquirer/prompts';
 import { Wallet } from 'ethers';
 import { stringify as yamlStringify } from 'yaml';

--- a/typescript/cli/src/config/submit.ts
+++ b/typescript/cli/src/config/submit.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { stringify as yamlStringify } from 'yaml';
 
 import {

--- a/typescript/cli/src/config/utils.ts
+++ b/typescript/cli/src/config/utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   type HookConfig,
   type HookType,

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm, input, select } from '@inquirer/prompts';
 import { stringify as yamlStringify } from 'yaml';
 

--- a/typescript/cli/src/consts.ts
+++ b/typescript/cli/src/consts.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type MinimumRequiredGasByAction } from '@hyperlane-xyz/provider-sdk';
 
 export const ETHEREUM_MINIMUM_GAS: MinimumRequiredGasByAction = {

--- a/typescript/cli/src/context/altvm-signer-config.ts
+++ b/typescript/cli/src/context/altvm-signer-config.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
 import type { ExtendedChainSubmissionStrategy } from '../submitters/types.js';

--- a/typescript/cli/src/context/altvm.ts
+++ b/typescript/cli/src/context/altvm.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { input, password } from '@inquirer/prompts';
 
 import {

--- a/typescript/cli/src/context/context.ts
+++ b/typescript/cli/src/context/context.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import { type ethers } from 'ethers';
 

--- a/typescript/cli/src/context/strategies/chain/chainResolver.test.ts
+++ b/typescript/cli/src/context/strategies/chain/chainResolver.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { TxSubmitterType } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/context/strategies/chain/chainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/chainResolver.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   RebalancerConfig,
   getStrategyChainNames,

--- a/typescript/cli/src/context/strategies/signer/BaseMultiProtocolSigner.ts
+++ b/typescript/cli/src/context/strategies/signer/BaseMultiProtocolSigner.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { password } from '@inquirer/prompts';
 import { type Signer } from 'ethers';
 

--- a/typescript/cli/src/context/strategies/signer/MultiProtocolSignerFactory.ts
+++ b/typescript/cli/src/context/strategies/signer/MultiProtocolSignerFactory.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type Signer, Wallet } from 'ethers';
 import { Wallet as ZKSyncWallet } from 'zksync-ethers';
 

--- a/typescript/cli/src/context/strategies/signer/MultiProtocolSignerManager.ts
+++ b/typescript/cli/src/context/strategies/signer/MultiProtocolSignerManager.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type BigNumber, type Signer } from 'ethers';
 import { type Logger } from 'pino';
 

--- a/typescript/cli/src/context/types.ts
+++ b/typescript/cli/src/context/types.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import type { ethers } from 'ethers';
 import type { CommandModule } from 'yargs';
 import { z } from 'zod';

--- a/typescript/cli/src/deploy/configValidation.ts
+++ b/typescript/cli/src/deploy/configValidation.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 /**
  * Configuration validation utilities for converting SDK types to provider-sdk types.
  *

--- a/typescript/cli/src/deploy/core.ts
+++ b/typescript/cli/src/deploy/core.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { stringify as yamlStringify } from 'yaml';
 
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';

--- a/typescript/cli/src/deploy/ica.ts
+++ b/typescript/cli/src/deploy/ica.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   type AccountConfig,
   type ChainName,

--- a/typescript/cli/src/deploy/utils.ts
+++ b/typescript/cli/src/deploy/utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import { BigNumber, ethers } from 'ethers';
 import path from 'path';

--- a/typescript/cli/src/deploy/warp.test.ts
+++ b/typescript/cli/src/deploy/warp.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import { stringify as yamlStringify } from 'yaml';
 

--- a/typescript/cli/src/fees/warp.ts
+++ b/typescript/cli/src/fees/warp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   type ChainMap,
   CoinGeckoTokenPriceGetter,

--- a/typescript/cli/src/fork/fork.ts
+++ b/typescript/cli/src/fork/fork.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { JsonRpcProvider, type Log } from '@ethersproject/providers';
 import { ethers } from 'ethers';
 import { execa } from 'execa';

--- a/typescript/cli/src/hook/read.ts
+++ b/typescript/cli/src/hook/read.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { createHookReader } from '@hyperlane-xyz/deploy-sdk';
 import { type ChainName, EvmHookReader } from '@hyperlane-xyz/sdk';
 import {

--- a/typescript/cli/src/ism/deploy.ts
+++ b/typescript/cli/src/ism/deploy.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
 import { createIsmWriter } from '@hyperlane-xyz/deploy-sdk';
 import {

--- a/typescript/cli/src/ism/read.ts
+++ b/typescript/cli/src/ism/read.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { createIsmReader } from '@hyperlane-xyz/deploy-sdk';
 import {
   type ChainName,

--- a/typescript/cli/src/logger.ts
+++ b/typescript/cli/src/logger.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk, { type ChalkInstance } from 'chalk';
 import { type pino } from 'pino';
 

--- a/typescript/cli/src/read/core.ts
+++ b/typescript/cli/src/read/core.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { createCoreReader } from '@hyperlane-xyz/deploy-sdk';
 import {
   type ChainName,

--- a/typescript/cli/src/read/warp.ts
+++ b/typescript/cli/src/read/warp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/cli/src/send/message.ts
+++ b/typescript/cli/src/send/message.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { stringify as yamlStringify } from 'yaml';
 
 import { GasAction } from '@hyperlane-xyz/provider-sdk';

--- a/typescript/cli/src/send/transfer.ts
+++ b/typescript/cli/src/send/transfer.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type TransactionReceipt } from '@ethersproject/providers';
 import { stringify as yamlStringify } from 'yaml';
 

--- a/typescript/cli/src/status/message.test.ts
+++ b/typescript/cli/src/status/message.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { type DispatchedMessage, type MultiProvider } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/status/message.ts
+++ b/typescript/cli/src/status/message.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import type { TransactionReceipt } from '@ethersproject/providers';
 import { input } from '@inquirer/prompts';
 

--- a/typescript/cli/src/submitters/EV5FileSubmitter.ts
+++ b/typescript/cli/src/submitters/EV5FileSubmitter.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type Logger } from 'pino';
 
 import {

--- a/typescript/cli/src/submitters/types.ts
+++ b/typescript/cli/src/submitters/types.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { z } from 'zod';
 
 import {

--- a/typescript/cli/src/tests/aleo/core/core-apply-hooks.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/core/core-apply-hooks.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { type CoreConfig, type HookConfig, HookType } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/aleo/core/core-apply-ism.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/core/core-apply-ism.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import {

--- a/typescript/cli/src/tests/aleo/core/core-apply-mailbox.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/core/core-apply-mailbox.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { type CoreConfig } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/aleo/core/core-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/core/core-deploy.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import {

--- a/typescript/cli/src/tests/aleo/core/core-read.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/core/core-read.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { type CoreConfig, HookType, IsmType } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/aleo/e2e-test.setup.ts
+++ b/typescript/cli/src/tests/aleo/e2e-test.setup.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import fs from 'fs';
 import { type StartedTestContainer } from 'testcontainers';
 

--- a/typescript/cli/src/tests/aleo/ism.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/ism.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { normalizeConfig } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/aleo/warp/warp-apply-hook-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/warp/warp-apply-hook-updates.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type ChainAddresses } from '@hyperlane-xyz/registry';
 import { TokenType } from '@hyperlane-xyz/sdk';
 import { ProtocolType, assert } from '@hyperlane-xyz/utils';

--- a/typescript/cli/src/tests/aleo/warp/warp-apply-ism-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/warp/warp-apply-ism-updates.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type ChainAddresses } from '@hyperlane-xyz/registry';
 import { TokenType } from '@hyperlane-xyz/sdk';
 import { ProtocolType, assert } from '@hyperlane-xyz/utils';

--- a/typescript/cli/src/tests/aleo/warp/warp-apply-ownership-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/warp/warp-apply-ownership-updates.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { type ChainAddresses } from '@hyperlane-xyz/registry';

--- a/typescript/cli/src/tests/aleo/warp/warp-apply-route-extension.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/warp/warp-apply-route-extension.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type ChainAddresses } from '@hyperlane-xyz/registry';
 import {
   type ChainMap,

--- a/typescript/cli/src/tests/aleo/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/warp/warp-deploy.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { type ChainAddresses } from '@hyperlane-xyz/registry';

--- a/typescript/cli/src/tests/aleo/warp/warp-read.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/warp/warp-read.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { type ChainAddresses } from '@hyperlane-xyz/registry';

--- a/typescript/cli/src/tests/commands/core.ts
+++ b/typescript/cli/src/tests/commands/core.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { $, type ProcessPromise } from 'zx';
 
 import { type ChainAddresses } from '@hyperlane-xyz/registry';

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type ProcessOutput, type ProcessPromise } from 'zx';
 
 import { inCIMode, sleep } from '@hyperlane-xyz/utils';

--- a/typescript/cli/src/tests/commands/ism.ts
+++ b/typescript/cli/src/tests/commands/ism.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { $, type ProcessPromise } from 'zx';
 
 import { type ChainName, type IsmConfig } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/commands/submit.ts
+++ b/typescript/cli/src/tests/commands/submit.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { $ } from 'zx';
 
 import { localTestRunCmdPrefix } from './helpers.js';

--- a/typescript/cli/src/tests/commands/warp-config-sync.ts
+++ b/typescript/cli/src/tests/commands/warp-config-sync.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { assert } from '@hyperlane-xyz/utils';
 
 import { isFile, readYamlOrJson, writeYamlOrJson } from '../../utils/files.js';

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { $, type ProcessPromise } from 'zx';
 
 import {

--- a/typescript/cli/src/tests/constants.ts
+++ b/typescript/cli/src/tests/constants.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { TEST_ALEO_PRIVATE_KEY } from '@hyperlane-xyz/aleo-sdk/testing';
 import { type TestChainMetadata } from '@hyperlane-xyz/provider-sdk/chain';
 import {

--- a/typescript/cli/src/tests/context/altvm-signer-config.test.ts
+++ b/typescript/cli/src/tests/context/altvm-signer-config.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { TxSubmitterType } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/context/create-altvm-signers.test.ts
+++ b/typescript/cli/src/tests/context/create-altvm-signers.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/typescript/cli/src/tests/context/ensure-evm-signers.test.ts
+++ b/typescript/cli/src/tests/context/ensure-evm-signers.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { Wallet as ZKSyncWallet } from 'zksync-ethers';
 

--- a/typescript/cli/src/tests/cosmosnative/commands/helpers.ts
+++ b/typescript/cli/src/tests/cosmosnative/commands/helpers.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 import path from 'path';
 

--- a/typescript/cli/src/tests/cosmosnative/consts.ts
+++ b/typescript/cli/src/tests/cosmosnative/consts.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { createWarpRouteConfigId } from '@hyperlane-xyz/registry';
 
 export const E2E_TEST_CONFIGS_PATH = './test-configs';

--- a/typescript/cli/src/tests/cosmosnative/core/core-apply.e2e-test.ts
+++ b/typescript/cli/src/tests/cosmosnative/core/core-apply.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 import { expect } from 'chai';
 

--- a/typescript/cli/src/tests/cosmosnative/core/core-check.e2e-test.ts
+++ b/typescript/cli/src/tests/cosmosnative/core/core-check.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { $ } from 'zx';
 

--- a/typescript/cli/src/tests/cosmosnative/core/core-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/cosmosnative/core/core-deploy.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 import { expect } from 'chai';
 

--- a/typescript/cli/src/tests/cosmosnative/core/core-read.e2e-test.ts
+++ b/typescript/cli/src/tests/cosmosnative/core/core-read.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 import { expect } from 'chai';
 

--- a/typescript/cli/src/tests/cosmosnative/e2e-test.setup.ts
+++ b/typescript/cli/src/tests/cosmosnative/e2e-test.setup.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import fs from 'fs';
 
 import { REGISTRY_PATH } from './consts.js';

--- a/typescript/cli/src/tests/cosmosnative/ism.e2e-test.ts
+++ b/typescript/cli/src/tests/cosmosnative/ism.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { normalizeConfig } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/cosmosnative/warp/warp-apply-ism-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/cosmosnative/warp/warp-apply-ism-updates.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 
 import { type ChainAddresses } from '@hyperlane-xyz/registry';

--- a/typescript/cli/src/tests/cosmosnative/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/cosmosnative/warp/warp-deploy.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';

--- a/typescript/cli/src/tests/cosmosnative/warp/warp-read.e2e-test.ts
+++ b/typescript/cli/src/tests/cosmosnative/warp/warp-read.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { DirectSecp256k1Wallet } from '@cosmjs/proto-signing';
 import { expect } from 'chai';
 

--- a/typescript/cli/src/tests/cross-chain/e2e-test.setup.ts
+++ b/typescript/cli/src/tests/cross-chain/e2e-test.setup.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import fs from 'fs';
 import { type StartedDockerComposeEnvironment } from 'testcontainers';
 

--- a/typescript/cli/src/tests/cross-chain/warp/warp-apply.e2e-test.ts
+++ b/typescript/cli/src/tests/cross-chain/warp/warp-apply.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { Wallet } from 'ethers';

--- a/typescript/cli/src/tests/cross-chain/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/cross-chain/warp/warp-deploy.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { Wallet } from 'ethers';

--- a/typescript/cli/src/tests/cross-chain/warp/warp-send.e2e-test.ts
+++ b/typescript/cli/src/tests/cross-chain/warp/warp-send.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { Wallet } from 'ethers';

--- a/typescript/cli/src/tests/ethereum/commands/core.ts
+++ b/typescript/cli/src/tests/ethereum/commands/core.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { $, type ProcessPromise } from 'zx';
 
 import { type ChainAddresses } from '@hyperlane-xyz/registry';

--- a/typescript/cli/src/tests/ethereum/commands/helpers.ts
+++ b/typescript/cli/src/tests/ethereum/commands/helpers.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 import http from 'http';
 import path from 'path';

--- a/typescript/cli/src/tests/ethereum/commands/ica.ts
+++ b/typescript/cli/src/tests/ethereum/commands/ica.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { $, type ProcessPromise } from 'zx';
 
 import { type ChainName } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/ethereum/commands/warp.ts
+++ b/typescript/cli/src/tests/ethereum/commands/warp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Wallet, ethers } from 'ethers';
 import { $, type ProcessOutput, type ProcessPromise } from 'zx';
 

--- a/typescript/cli/src/tests/ethereum/commands/xerc20.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/commands/xerc20.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
 import { $ } from 'zx';

--- a/typescript/cli/src/tests/ethereum/consts.ts
+++ b/typescript/cli/src/tests/ethereum/consts.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/typescript/cli/src/tests/ethereum/core/core-apply.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/core/core-apply.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { type Signer, Wallet, ethers } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/core/core-check.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/core/core-check.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { $ } from 'zx';
 

--- a/typescript/cli/src/tests/ethereum/core/core-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/core/core-deploy.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { type Signer, Wallet, ethers } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/core/core-init.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/core/core-init.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/core/core-read.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/core/core-read.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { type Signer, Wallet, ethers } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/deployTestErc20.ts
+++ b/typescript/cli/src/tests/ethereum/deployTestErc20.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Wallet, providers } from 'ethers';
 import fs from 'fs';
 

--- a/typescript/cli/src/tests/ethereum/e2e-test.setup.ts
+++ b/typescript/cli/src/tests/ethereum/e2e-test.setup.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import fs from 'fs';
 
 import { type ChainMetadata } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/ethereum/fixtures/warp-test-fixture.ts
+++ b/typescript/cli/src/tests/ethereum/fixtures/warp-test-fixture.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   type WarpCoreConfig,
   type WarpRouteDeployConfig,

--- a/typescript/cli/src/tests/ethereum/hooks.test.ts
+++ b/typescript/cli/src/tests/ethereum/hooks.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { HookType, type HooksConfigMap } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/ethereum/ica/ica-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/ica/ica-deploy.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { Wallet, ethers } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/ism.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/ism.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { normalizeConfig } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/ethereum/ism.test.ts
+++ b/typescript/cli/src/tests/ethereum/ism.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { type ChainMap, type IsmConfig, IsmType } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/ethereum/relay.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/relay.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { createWarpRouteConfigId } from '@hyperlane-xyz/registry';
 import { TokenType } from '@hyperlane-xyz/sdk';
 

--- a/typescript/cli/src/tests/ethereum/send-message.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/send-message.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { $ } from 'zx';
 

--- a/typescript/cli/src/tests/ethereum/status.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/status.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import fs from 'fs';
 import os from 'os';

--- a/typescript/cli/src/tests/ethereum/submit/submit.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/submit/submit.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { type PopulatedTransaction as EV5Transaction, ethers } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-hook-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-hook-updates.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import {

--- a/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-ism-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-ism-updates.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { ethers } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-ownership-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-ownership-updates.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { TokenFeeType, TokenType, randomAddress } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-rebalancing-config.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-rebalancing-config.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { expect } from 'chai';
 

--- a/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-simple-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-simple-updates.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { ethers } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-submitters.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-submitters.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { type Signer, Wallet, ethers } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/warp/warp-bridge-1.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-bridge-1.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/typescript/cli/src/tests/ethereum/warp/warp-bridge-2.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-bridge-2.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/typescript/cli/src/tests/ethereum/warp/warp-bridge-utils.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-bridge-utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { Wallet } from 'ethers';
 import { parseUnits } from 'ethers/lib/utils.js';

--- a/typescript/cli/src/tests/ethereum/warp/warp-check-1.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-check-1.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/warp/warp-check-2.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-check-2.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { type Signer, Wallet, ethers } from 'ethers';
 import { zeroAddress } from 'viem';

--- a/typescript/cli/src/tests/ethereum/warp/warp-check-3.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-check-3.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
 import { zeroAddress } from 'viem';

--- a/typescript/cli/src/tests/ethereum/warp/warp-check-4.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-check-4.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/warp/warp-check-5.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-check-5.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { type Signer, Wallet, ethers } from 'ethers';
 import { zeroAddress } from 'viem';

--- a/typescript/cli/src/tests/ethereum/warp/warp-check-ica.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-check-ica.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { Wallet, ethers } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/warp/warp-cross-collateral.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-cross-collateral.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { parseUnits } from 'ethers/lib/utils.js';
 

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy-1.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy-1.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { JsonRpcProvider } from '@ethersproject/providers';
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy-2.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy-2.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { JsonRpcProvider } from '@ethersproject/providers';
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';

--- a/typescript/cli/src/tests/ethereum/warp/warp-extend-basic.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-extend-basic.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/warp/warp-extend-config.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-extend-config.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/warp/warp-extend-recovery.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-extend-recovery.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/warp/warp-extend-resumable.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-extend-resumable.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/warp/warp-init.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-init.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/warp/warp-read.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-read.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
 

--- a/typescript/cli/src/tests/ethereum/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-rebalancer.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { Wallet, ethers } from 'ethers';

--- a/typescript/cli/src/tests/ethereum/warp/warp-send.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-send.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { expect } from 'chai';
 import { Wallet, ethers } from 'ethers';

--- a/typescript/cli/src/tests/helpers/core-ism-hook-test-factory.ts
+++ b/typescript/cli/src/tests/helpers/core-ism-hook-test-factory.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import {

--- a/typescript/cli/src/tests/helpers/warp-hook-test-factory.ts
+++ b/typescript/cli/src/tests/helpers/warp-hook-test-factory.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { AltVM } from '@hyperlane-xyz/provider-sdk';

--- a/typescript/cli/src/tests/helpers/warp-ism-test-factory.ts
+++ b/typescript/cli/src/tests/helpers/warp-ism-test-factory.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { type IsmConfig } from '@hyperlane-xyz/provider-sdk/ism';

--- a/typescript/cli/src/tests/nodes.ts
+++ b/typescript/cli/src/tests/nodes.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { GenericContainer, Wait } from 'testcontainers';
 
 import { type TestChainMetadata } from '@hyperlane-xyz/provider-sdk/chain';

--- a/typescript/cli/src/tests/radix/core/core-apply-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/radix/core/core-apply-updates.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
 import { HyperlaneE2ECoreTestCommands } from '../../commands/core.js';

--- a/typescript/cli/src/tests/radix/core/core-apply.e2e-test.ts
+++ b/typescript/cli/src/tests/radix/core/core-apply.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import {

--- a/typescript/cli/src/tests/radix/core/core-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/radix/core/core-deploy.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import {

--- a/typescript/cli/src/tests/radix/e2e-test.setup.ts
+++ b/typescript/cli/src/tests/radix/e2e-test.setup.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import fs from 'fs';
 import { type StartedDockerComposeEnvironment } from 'testcontainers';
 

--- a/typescript/cli/src/tests/radix/ism.e2e-test.ts
+++ b/typescript/cli/src/tests/radix/ism.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { normalizeConfig } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/radix/warp/warp-apply-ism-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/radix/warp/warp-apply-ism-updates.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type ChainAddresses } from '@hyperlane-xyz/registry';
 import { TokenType } from '@hyperlane-xyz/sdk';
 import { ProtocolType, assert } from '@hyperlane-xyz/utils';

--- a/typescript/cli/src/tests/radix/warp/warp-apply-ownership-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/radix/warp/warp-apply-ownership-updates.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { type ChainAddresses } from '@hyperlane-xyz/registry';

--- a/typescript/cli/src/tests/radix/warp/warp-apply-route-extension.e2e-test.ts
+++ b/typescript/cli/src/tests/radix/warp/warp-apply-route-extension.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type ChainAddresses } from '@hyperlane-xyz/registry';
 import {
   type ChainMap,

--- a/typescript/cli/src/tests/radix/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/radix/warp/warp-deploy.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { type ChainAddresses } from '@hyperlane-xyz/registry';

--- a/typescript/cli/src/tests/sealevel/core/core-apply.e2e-test.ts
+++ b/typescript/cli/src/tests/sealevel/core/core-apply.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { type CoreConfig } from '@hyperlane-xyz/sdk';

--- a/typescript/cli/src/tests/sealevel/core/core-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/sealevel/core/core-deploy.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { type ChainAddresses } from '@hyperlane-xyz/registry';

--- a/typescript/cli/src/tests/sealevel/e2e-test.setup.ts
+++ b/typescript/cli/src/tests/sealevel/e2e-test.setup.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import fs from 'fs';
 
 import {

--- a/typescript/cli/src/tests/test-setup.ts
+++ b/typescript/cli/src/tests/test-setup.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { LogFormat, LogLevel, configureRootLogger } from '@hyperlane-xyz/utils';
 
 // mute logging in tests

--- a/typescript/cli/src/tests/utils.e2e-test.ts
+++ b/typescript/cli/src/tests/utils.e2e-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { $ } from 'zx';
 

--- a/typescript/cli/src/tests/utils.ts
+++ b/typescript/cli/src/tests/utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import * as chai from 'chai';
 
 import { type ChainAddresses } from '@hyperlane-xyz/registry';

--- a/typescript/cli/src/utils/balances.ts
+++ b/typescript/cli/src/utils/balances.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { BigNumber as BN } from 'bignumber.js';
 import { BigNumber } from 'ethers';
 import { formatUnits } from 'ethers/lib/utils.js';

--- a/typescript/cli/src/utils/chains.test.ts
+++ b/typescript/cli/src/utils/chains.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import {

--- a/typescript/cli/src/utils/chains.ts
+++ b/typescript/cli/src/utils/chains.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Separator, confirm } from '@inquirer/prompts';
 import search from '@inquirer/search';
 import select from '@inquirer/select';

--- a/typescript/cli/src/utils/cli-options.ts
+++ b/typescript/cli/src/utils/cli-options.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // Functions used to manipulate CLI specific options
 
 /**

--- a/typescript/cli/src/utils/env.ts
+++ b/typescript/cli/src/utils/env.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { z } from 'zod';
 
 const envScheme = z.object({

--- a/typescript/cli/src/utils/errors.ts
+++ b/typescript/cli/src/utils/errors.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 export class WrappedError extends Error {
   constructor(message: string, cause?: Error) {
     super(message, cause ? { cause } : undefined);

--- a/typescript/cli/src/utils/files.ts
+++ b/typescript/cli/src/utils/files.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { input } from '@inquirer/prompts';
 import select from '@inquirer/select';
 import fs from 'fs';

--- a/typescript/cli/src/utils/input.ts
+++ b/typescript/cli/src/utils/input.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   Separator,
   type Theme,

--- a/typescript/cli/src/utils/keys.ts
+++ b/typescript/cli/src/utils/keys.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { input } from '@inquirer/prompts';
 import { ethers, type providers } from 'ethers';
 

--- a/typescript/cli/src/utils/output.ts
+++ b/typescript/cli/src/utils/output.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 
 export enum ViolationDiffType {

--- a/typescript/cli/src/utils/relay.ts
+++ b/typescript/cli/src/utils/relay.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type TransactionReceipt } from '@ethersproject/providers';
 
 import { type IRegistry } from '@hyperlane-xyz/registry';

--- a/typescript/cli/src/utils/time.test.ts
+++ b/typescript/cli/src/utils/time.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { getTimestampForFilename } from './time.js';

--- a/typescript/cli/src/utils/time.ts
+++ b/typescript/cli/src/utils/time.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 export function getTimestampForFilename() {
   const pad = (n: number) =>
     n.toLocaleString('en-US', {

--- a/typescript/cli/src/utils/tokens.ts
+++ b/typescript/cli/src/utils/tokens.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import select from '@inquirer/select';
 
 import { type IRegistry } from '@hyperlane-xyz/registry';

--- a/typescript/cli/src/utils/version-check.ts
+++ b/typescript/cli/src/utils/version-check.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import latestVersion from 'latest-version';
 
 import { log } from '../logger.js';

--- a/typescript/cli/src/utils/warp-send.ts
+++ b/typescript/cli/src/utils/warp-send.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type ChainName, type MultiProvider } from '@hyperlane-xyz/sdk';
 import { isEVMLike } from '@hyperlane-xyz/utils';
 

--- a/typescript/cli/src/utils/warp.test.ts
+++ b/typescript/cli/src/utils/warp.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import type { IRegistry } from '@hyperlane-xyz/registry';

--- a/typescript/cli/src/utils/warp.ts
+++ b/typescript/cli/src/utils/warp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import search from '@inquirer/search';
 
 import { filterWarpRoutesIds } from '@hyperlane-xyz/registry';

--- a/typescript/cli/src/validator/address.ts
+++ b/typescript/cli/src/validator/address.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { GetPublicKeyCommand, KMSClient } from '@aws-sdk/client-kms';
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { input } from '@inquirer/prompts';

--- a/typescript/cli/src/validator/preFlightCheck.ts
+++ b/typescript/cli/src/validator/preFlightCheck.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { MerkleTreeHook__factory } from '@hyperlane-xyz/core';
 import { HyperlaneCore, S3Validator } from '@hyperlane-xyz/sdk';
 import { type Address } from '@hyperlane-xyz/utils';

--- a/typescript/cli/src/validator/utils.ts
+++ b/typescript/cli/src/validator/utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   type MerkleTreeHook,
   type ValidatorAnnounce,

--- a/typescript/cli/src/verify/warp.ts
+++ b/typescript/cli/src/verify/warp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { type ContractFactory } from 'ethers';
 
 import { buildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';

--- a/typescript/cli/src/version.ts
+++ b/typescript/cli/src/version.ts
@@ -1,1 +1,2 @@
+// SPDX-License-Identifier: BUSL-1.1
 export const VERSION = '29.0.0';

--- a/typescript/infra/config/contexts.ts
+++ b/typescript/infra/config/contexts.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // All valid deployment contexts. Environments may use just a subset of these contexts.
 export enum Contexts {
   Hyperlane = 'hyperlane',

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 const GHCR_REGISTRY = 'ghcr.io/hyperlane-xyz';
 
 export const DockerImageNames = {

--- a/typescript/infra/config/environments/agents.ts
+++ b/typescript/infra/config/environments/agents.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { agents as mainnet3Agents } from './mainnet3/agent.js';
 import { agents as testAgents } from './test/agent.js';
 import { agents as testnet4Agents } from './testnet4/agent.js';

--- a/typescript/infra/config/environments/index.ts
+++ b/typescript/infra/config/environments/index.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { environment as mainnet3 } from './mainnet3/index.js';
 import { environment as test } from './test/index.js';
 import { environment as testnet4 } from './testnet4/index.js';

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   AgentSealevelHeliusFeeLevel,
   AgentSealevelPriorityFeeOracle,

--- a/typescript/infra/config/environments/mainnet3/chains.ts
+++ b/typescript/infra/config/environments/mainnet3/chains.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { IRegistry } from '@hyperlane-xyz/registry';
 import { ChainMap, ChainMetadata, ChainName } from '@hyperlane-xyz/sdk';
 

--- a/typescript/infra/config/environments/mainnet3/core.ts
+++ b/typescript/infra/config/environments/mainnet3/core.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { BigNumber, ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/customBlacklist.ts
+++ b/typescript/infra/config/environments/mainnet3/customBlacklist.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 export const blacklistedMessageIds = [
   // ezETH
   '0xb9cfeb4a22b65903ca7cb514fd752feba0622a0495878d508d19a91734d89cc4',

--- a/typescript/infra/config/environments/mainnet3/eden.ts
+++ b/typescript/infra/config/environments/mainnet3/eden.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { BigNumber, ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { objMap } from '@hyperlane-xyz/utils';
 
 import { KeyFunderConfig } from '../../../src/config/funding.js';

--- a/typescript/infra/config/environments/mainnet3/governance/ica/_awLegacy.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/ica/_awLegacy.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // Found by running:
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';

--- a/typescript/infra/config/environments/mainnet3/governance/ica/_regularLegacy.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/ica/_regularLegacy.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/governance/ica/aw.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/ica/aw.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // Found by running:
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';

--- a/typescript/infra/config/environments/mainnet3/governance/ica/regular.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/ica/regular.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // Found by running:
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';

--- a/typescript/infra/config/environments/mainnet3/governance/ica/warpFees.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/ica/warpFees.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/governance/safe/aw.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/safe/aw.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/governance/safe/irregular.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/safe/irregular.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/governance/safe/ousdt.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/safe/ousdt.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/governance/safe/regular.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/safe/regular.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/governance/safe/warpFees.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/safe/warpFees.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/governance/signers/aw.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/signers/aw.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Address } from '@hyperlane-xyz/utils';
 
 export const awSigners: Address[] = [

--- a/typescript/infra/config/environments/mainnet3/governance/signers/irregular.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/signers/irregular.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Address } from '@hyperlane-xyz/utils';
 
 export const irregularSigners: Address[] = [

--- a/typescript/infra/config/environments/mainnet3/governance/signers/regular.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/signers/regular.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Address } from '@hyperlane-xyz/utils';
 
 export const regularSigners: Address[] = [

--- a/typescript/infra/config/environments/mainnet3/governance/signers/warpFees.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/signers/warpFees.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { awSigners, awThreshold } from './aw.js';
 
 export const warpFeesSigners = awSigners;

--- a/typescript/infra/config/environments/mainnet3/governance/timelock/aw.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/timelock/aw.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/governance/timelock/regular.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/timelock/regular.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/governance/utils.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainName } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, ChainName, HookType, IgpConfig } from '@hyperlane-xyz/sdk';
 import { exclude, objMap } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/index.ts
+++ b/typescript/infra/config/environments/mainnet3/index.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainName } from '@hyperlane-xyz/sdk';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/infrastructure.ts
+++ b/typescript/infra/config/environments/mainnet3/infrastructure.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { InfrastructureConfig } from '../../../src/config/infrastructure.js';
 
 export const infrastructure: InfrastructureConfig = {

--- a/typescript/infra/config/environments/mainnet3/owners.ts
+++ b/typescript/infra/config/environments/mainnet3/owners.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, OwnableConfig } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/supportedChainNames.ts
+++ b/typescript/infra/config/environments/mainnet3/supportedChainNames.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // These chains may be any protocol type.
 // Placing them here instead of adjacent chains file to avoid circular dep
 export const mainnet3SupportedChainNames = [

--- a/typescript/infra/config/environments/mainnet3/tron.ts
+++ b/typescript/infra/config/environments/mainnet3/tron.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { BigNumber, ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/validators.ts
+++ b/typescript/infra/config/environments/mainnet3/validators.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ValidatorBaseChainConfigMap } from '../../../src/config/agent/validator.js';
 import { Contexts } from '../../contexts.js';
 import { getReorgPeriod } from '../../registry.js';

--- a/typescript/infra/config/environments/mainnet3/warp/cctp.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/cctp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // from https://developers.circle.com/stablecoins/evm-smart-contracts
 
 export const tokenMessengerV1Addresses = {

--- a/typescript/infra/config/environments/mainnet3/warp/checkWarpDeploy.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/checkWarpDeploy.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { CheckWarpDeployConfig } from '../../../../src/config/funding.js';
 import { DockerImageRepos, mainnetDockerTags } from '../../../docker.js';
 import { environment } from '../chains.js';

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getAleoUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getAleoUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HypTokenRouterConfig,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getAncient8EthereumUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getAncient8EthereumUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getAppchainBaseUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getAppchainBaseUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumAvalancheBaseBscEthereumLumiaprismOptimismPolygonLUMIAWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumAvalancheBaseBscEthereumLumiaprismOptimismPolygonLUMIAWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   ChainSubmissionStrategy,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumBaseBlastBscEthereumGnosisMantleModeOptimismPolygonScrollZeroNetworkZoraMainnetETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumBaseBlastBscEthereumGnosisMantleModeOptimismPolygonScrollZeroNetworkZoraMainnetETHWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumBaseEthereumLumiaprismOptimismPolygonETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumBaseEthereumLumiaprismOptimismPolygonETHWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumBaseEthereumOptimismPolygonZeroNetworkUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumBaseEthereumOptimismPolygonZeroNetworkUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumEthereumMantleModePolygonScrollZeroNetworkUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumEthereumMantleModePolygonScrollZeroNetworkUSDTWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumTiaWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumTiaWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HypTokenRouterConfig,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseEthereumSuperseedCBBTCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseEthereumSuperseedCBBTCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseSolanaTRUMPWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseSolanaTRUMPWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HypTokenRouterConfig,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseZeroNetworkCBBTCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getBaseZeroNetworkCBBTCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getBscHyperevmEnzoBTCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getBscHyperevmEnzoBTCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getBscHyperevmSTBTCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getBscHyperevmSTBTCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getBscMilkywayMILKWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getBscMilkywayMILKWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HypTokenRouterConfig,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getBsquaredUBTCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getBsquaredUBTCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   ChainSubmissionStrategy,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getCCTPConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getCCTPConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   ChainName,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getCarrchainCARRWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getCarrchainCARRWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HookType,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getCarrchainUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getCarrchainUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import assert from 'assert';
 
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getCarrchainUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getCarrchainUSDTWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import assert from 'assert';
 
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getCarrchainWBTCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getCarrchainWBTCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import assert from 'assert';
 
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getETHStageWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getETHStageWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumESWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumESWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumSolanaUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumSolanaUSDTWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumTETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumTETHWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumWBTCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumWBTCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseStrideSTTIAWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseStrideSTTIAWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HypTokenRouterConfig,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseStrideTIAWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseStrideTIAWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HypTokenRouterConfig,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCSTAGEWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCSTAGEWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig } from '@hyperlane-xyz/sdk';
 
 import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   ChainSubmissionStrategy,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getElectroneumUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getElectroneumUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEniWarpConfigs.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEniWarpConfigs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumInkUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumInkUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumLineaTurtleWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumLineaTurtleWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumVictionUSDTWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumZircuitRe7LRTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEthereumZircuitRe7LRTWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getIncentivUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getIncentivUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getLitLitchainWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getLitLitchainWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getLumiaUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getLumiaUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HypTokenRouterConfig,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getMantapacificTiaWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getMantapacificTiaWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HypTokenRouterConfig,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getMantraUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getMantraUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getMatchainUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getMatchainUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import assert from 'assert';
 
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getMitosisMITOWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getMitosisMITOWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HookType,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getParadexUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getParadexUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
 import { assert } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getPulsechainUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getPulsechainUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getRadixUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getRadixUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HypTokenRouterConfig,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHSTAGEWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHSTAGEWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { getGnosisSafeBuilderStrategyConfigGenerator } from '../../../utils.js';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { parseEther } from 'ethers/lib/utils.js';
 
 import { Mailbox__factory } from '@hyperlane-xyz/core';

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoPZETHSTAGEWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoPZETHSTAGEWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { pick } from '@hyperlane-xyz/utils';
 
 import { getGnosisSafeBuilderStrategyConfigGenerator } from '../../../utils.js';

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoPZETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoPZETHWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { pick } from '@hyperlane-xyz/utils';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoREZBaseEthereum.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoREZBaseEthereum.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { pick } from '@hyperlane-xyz/utils';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoREZStaging.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoREZStaging.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { pick } from '@hyperlane-xyz/utils';
 
 import { getGnosisSafeBuilderStrategyConfigGenerator } from '../../../utils.js';

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getSubtensorUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getSubtensorUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
 import { assert } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getSuperseedUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getSuperseedUSDCWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HypTokenConfig,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTSTAGEWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTSTAGEWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
 import { ethers } from 'ethers';
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getVictionETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getVictionETHWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getoUSDTTokenWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getoUSDTTokenWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getoXAUTTokenWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getoXAUTTokenWarpConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HypTokenRouterConfig,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/utils.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import assert from 'assert';
 
 import {

--- a/typescript/infra/config/environments/mainnet3/warp/consts.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/consts.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // The amount of gas to pay for when performing a transferRemote to a Sealevel chain.
 export const SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT = 300_000;
 

--- a/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 export enum WarpRouteIds {
   BscMilkywayMILK = 'MILK/bsc-milkyway',
   Ancient8EthereumUSDC = 'USDC/ancient8-ethereum',

--- a/typescript/infra/config/environments/test/agent.ts
+++ b/typescript/infra/config/environments/test/agent.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   GasPaymentEnforcementPolicyType,
   RpcConsensusType,

--- a/typescript/infra/config/environments/test/aggregationIsm.ts
+++ b/typescript/infra/config/environments/test/aggregationIsm.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { AggregationIsmConfig, IsmType } from '@hyperlane-xyz/sdk';
 
 import { merkleRootMultisig, messageIdMultisig } from './multisigIsm.js';

--- a/typescript/infra/config/environments/test/chains.ts
+++ b/typescript/infra/config/environments/test/chains.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   testChainMetadata as defaultTestChainMetadata,
   testChains as defaultTestChains,

--- a/typescript/infra/config/environments/test/core.ts
+++ b/typescript/infra/config/environments/test/core.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { BigNumber, ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/test/gas-oracle.ts
+++ b/typescript/infra/config/environments/test/gas-oracle.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, GasPriceConfig } from '@hyperlane-xyz/sdk';
 
 import {

--- a/typescript/infra/config/environments/test/igp.ts
+++ b/typescript/infra/config/environments/test/igp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HookType,

--- a/typescript/infra/config/environments/test/index.ts
+++ b/typescript/infra/config/environments/test/index.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { JsonRpcProvider } from '@ethersproject/providers';
 
 import { MultiProvider } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/config/environments/test/infra.ts
+++ b/typescript/infra/config/environments/test/infra.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { InfrastructureConfig } from '../../../src/config/infrastructure.js';
 
 export const infra: InfrastructureConfig = {

--- a/typescript/infra/config/environments/test/multisigIsm.ts
+++ b/typescript/infra/config/environments/test/multisigIsm.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   IsmType,

--- a/typescript/infra/config/environments/test/owners.ts
+++ b/typescript/infra/config/environments/test/owners.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, OwnableConfig } from '@hyperlane-xyz/sdk';
 
 import { testChainNames } from './chains.js';

--- a/typescript/infra/config/environments/test/routingIsm.ts
+++ b/typescript/infra/config/environments/test/routingIsm.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { IsmType, RoutingIsmConfig } from '@hyperlane-xyz/sdk';
 
 import { multisigIsm } from './multisigIsm.js';

--- a/typescript/infra/config/environments/test/validators.ts
+++ b/typescript/infra/config/environments/test/validators.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainName } from '@hyperlane-xyz/sdk';
 
 import {

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   GasPaymentEnforcement,
   GasPaymentEnforcementPolicyType,

--- a/typescript/infra/config/environments/testnet4/chains.ts
+++ b/typescript/infra/config/environments/testnet4/chains.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { IRegistry } from '@hyperlane-xyz/registry';
 import { ChainMap, ChainMetadata, ChainName } from '@hyperlane-xyz/sdk';
 

--- a/typescript/infra/config/environments/testnet4/core.ts
+++ b/typescript/infra/config/environments/testnet4/core.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { BigNumber, ethers } from 'ethers';
 
 import {

--- a/typescript/infra/config/environments/testnet4/funding.ts
+++ b/typescript/infra/config/environments/testnet4/funding.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { KeyFunderConfig } from '../../../src/config/funding.js';
 import { Role } from '../../../src/roles.js';
 import { Contexts } from '../../contexts.js';

--- a/typescript/infra/config/environments/testnet4/igp.ts
+++ b/typescript/infra/config/environments/testnet4/igp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, ChainName, HookType, IgpConfig } from '@hyperlane-xyz/sdk';
 import { Address, exclude, objMap } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/config/environments/testnet4/index.ts
+++ b/typescript/infra/config/environments/testnet4/index.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { IRegistry } from '@hyperlane-xyz/registry';
 import { ChainName } from '@hyperlane-xyz/sdk';
 

--- a/typescript/infra/config/environments/testnet4/infrastructure.ts
+++ b/typescript/infra/config/environments/testnet4/infrastructure.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { InfrastructureConfig } from '../../../src/config/infrastructure.js';
 
 export const infrastructure: InfrastructureConfig = {

--- a/typescript/infra/config/environments/testnet4/owners.ts
+++ b/typescript/infra/config/environments/testnet4/owners.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, OwnableConfig } from '@hyperlane-xyz/sdk';
 
 import { ethereumChainNames } from './chains.js';

--- a/typescript/infra/config/environments/testnet4/supportedChainNames.ts
+++ b/typescript/infra/config/environments/testnet4/supportedChainNames.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // Placing them here instead of adjacent chains file to avoid circular dep
 export const testnet4SupportedChainNames = [
   'aleotestnet',

--- a/typescript/infra/config/environments/testnet4/validators.ts
+++ b/typescript/infra/config/environments/testnet4/validators.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ValidatorBaseChainConfigMap } from '../../../src/config/agent/validator.js';
 import { Contexts } from '../../contexts.js';
 import { getReorgPeriod } from '../../registry.js';

--- a/typescript/infra/config/environments/testnet4/warp/cctp.ts
+++ b/typescript/infra/config/environments/testnet4/warp/cctp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // from https://developers.circle.com/stablecoins/evm-smart-contracts
 
 export const tokenMessengerAddresses = {

--- a/typescript/infra/config/environments/testnet4/warp/getCCTPConfig.ts
+++ b/typescript/infra/config/environments/testnet4/warp/getCCTPConfig.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   HypTokenRouterConfig,

--- a/typescript/infra/config/environments/testnet4/warp/warpIds.ts
+++ b/typescript/infra/config/environments/testnet4/warp/warpIds.ts
@@ -1,1 +1,2 @@
+// SPDX-License-Identifier: BUSL-1.1
 export enum WarpRouteIds {}

--- a/typescript/infra/config/environments/utils.ts
+++ b/typescript/infra/config/environments/utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainName,
   ChainSubmissionStrategy,

--- a/typescript/infra/config/multisigIsm.ts
+++ b/typescript/infra/config/multisigIsm.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   ChainName,

--- a/typescript/infra/config/rcMultisigIsmConfigs.ts
+++ b/typescript/infra/config/rcMultisigIsmConfigs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   AW_VALIDATOR_ALIAS,
   ChainMap,

--- a/typescript/infra/config/registry.ts
+++ b/typescript/infra/config/registry.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 

--- a/typescript/infra/config/routingIsm.ts
+++ b/typescript/infra/config/routingIsm.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   AggregationIsmConfig,
   ChainMap,

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { IRegistry } from '@hyperlane-xyz/registry';
 import { getRegistry } from '@hyperlane-xyz/registry/fs';
 import {

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -9,7 +9,7 @@
     "Typescript"
   ],
   "homepage": "https://www.hyperlane.xyz",
-  "license": "Apache-2.0",
+  "license": "BUSL-1.1",
   "repository": "https://github.com/hyperlane-xyz/hyperlane-monorepo",
   "type": "module",
   "scripts": {

--- a/typescript/infra/scripts/agent-utils.ts
+++ b/typescript/infra/scripts/agent-utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { checkbox, select } from '@inquirer/prompts';
 import chalk from 'chalk';
 import path, { join } from 'path';

--- a/typescript/infra/scripts/agents/deploy-agents.ts
+++ b/typescript/infra/scripts/agents/deploy-agents.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { execSync } from 'child_process';

--- a/typescript/infra/scripts/agents/remove-agent-deploys.ts
+++ b/typescript/infra/scripts/agents/remove-agent-deploys.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { HelmCommand } from '../../src/utils/helm.js';
 
 import { AgentCli } from './utils.js';

--- a/typescript/infra/scripts/agents/restart-agents.ts
+++ b/typescript/infra/scripts/agents/restart-agents.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { AgentCli } from './utils.js';
 
 async function main() {

--- a/typescript/infra/scripts/agents/retry-messages.ts
+++ b/typescript/infra/scripts/agents/retry-messages.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { spawn } from 'child_process';
 
 import { Contexts } from '../../config/contexts.js';

--- a/typescript/infra/scripts/agents/update-agent-config.ts
+++ b/typescript/infra/scripts/agents/update-agent-config.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // eslint-disable-next-line
 import fs from 'fs';
 

--- a/typescript/infra/scripts/agents/update-agents-diff.ts
+++ b/typescript/infra/scripts/agents/update-agents-diff.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { HelmCommand } from '../../src/utils/helm.js';
 
 import { AgentCli } from './utils.js';

--- a/typescript/infra/scripts/agents/utils.ts
+++ b/typescript/infra/scripts/agents/utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
 

--- a/typescript/infra/scripts/alt-vm/igp.ts
+++ b/typescript/infra/scripts/alt-vm/igp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { BigNumber } from 'bignumber.js';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import prompts from 'prompts';

--- a/typescript/infra/scripts/check/check-deploy.ts
+++ b/typescript/infra/scripts/check/check-deploy.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   getCheckDeployArgs,
   getGovernor,

--- a/typescript/infra/scripts/check/check-owner-ica.ts
+++ b/typescript/infra/scripts/check/check-owner-ica.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { AccountConfig, InterchainAccount } from '@hyperlane-xyz/sdk';
 import {
   Address,

--- a/typescript/infra/scripts/check/check-rpc-urls.ts
+++ b/typescript/infra/scripts/check/check-rpc-urls.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import { rootLogger } from '@hyperlane-xyz/utils';

--- a/typescript/infra/scripts/check/check-sealevel-validators.ts
+++ b/typescript/infra/scripts/check/check-sealevel-validators.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 // eslint-disable-next-line
 import fs from 'fs';

--- a/typescript/infra/scripts/check/check-utils.ts
+++ b/typescript/infra/scripts/check/check-utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Registry } from 'prom-client';
 
 import {

--- a/typescript/infra/scripts/check/check-validator-announce.ts
+++ b/typescript/infra/scripts/check/check-validator-announce.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap, defaultMultisigConfigs } from '@hyperlane-xyz/sdk';
 import { eqAddress } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/scripts/check/check-validator-rpcs.ts
+++ b/typescript/infra/scripts/check/check-validator-rpcs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import {

--- a/typescript/infra/scripts/check/check-validator-version.ts
+++ b/typescript/infra/scripts/check/check-validator-version.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { execSync } from 'child_process';
 
 import {

--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import { Gauge, Registry } from 'prom-client';
 

--- a/typescript/infra/scripts/check/deploy-check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/deploy-check-warp-deploy.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Contexts } from '../../config/contexts.js';
 import { CheckWarpDeployHelmManager } from '../../src/check-warp-deploy/helm.js';
 import { HelmCommand } from '../../src/utils/helm.js';

--- a/typescript/infra/scripts/core-utils.ts
+++ b/typescript/infra/scripts/core-utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { HyperlaneCore, MultiProvider } from '@hyperlane-xyz/sdk';
 
 import { Contexts } from '../config/contexts.js';

--- a/typescript/infra/scripts/cosmos-helpers/deploy-ism-payload.ts
+++ b/typescript/infra/scripts/cosmos-helpers/deploy-ism-payload.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { stringify as yamlStringify } from 'yaml';
 
 import { defaultMultisigConfigs } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/scripts/cosmos-helpers/generate-igp-commands.ts
+++ b/typescript/infra/scripts/cosmos-helpers/generate-igp-commands.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Argv } from 'yargs';
 
 import rawGasPrices from '../../config/environments/mainnet3/gasPrices.json' with { type: 'json' };

--- a/typescript/infra/scripts/cosmos-helpers/generate-ism-command.ts
+++ b/typescript/infra/scripts/cosmos-helpers/generate-ism-command.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Argv } from 'yargs';
 
 import { defaultMultisigConfigs } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/scripts/debug-message.ts
+++ b/typescript/infra/scripts/debug-message.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { TestRecipient__factory } from '@hyperlane-xyz/core';
 import {
   ChainName,

--- a/typescript/infra/scripts/deploy-infra-external-secrets.ts
+++ b/typescript/infra/scripts/deploy-infra-external-secrets.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { runExternalSecretsHelmCommand } from '../src/infrastructure/external-secrets/external-secrets.js';
 import { HelmCommand } from '../src/utils/helm.js';
 

--- a/typescript/infra/scripts/deploy-infra-monitoring.ts
+++ b/typescript/infra/scripts/deploy-infra-monitoring.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { runPrometheusHelmCommand } from '../src/infrastructure/monitoring/prometheus.js';
 import { HelmCommand } from '../src/utils/helm.js';
 

--- a/typescript/infra/scripts/deploy.ts
+++ b/typescript/infra/scripts/deploy.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 import fs from 'fs';
 import path from 'path';

--- a/typescript/infra/scripts/funding/calculate-relayer-daily-burn.ts
+++ b/typescript/infra/scripts/funding/calculate-relayer-daily-burn.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { input, select } from '@inquirer/prompts';
 import postgres from 'postgres';
 import yargs from 'yargs';

--- a/typescript/infra/scripts/funding/deploy-key-funder.ts
+++ b/typescript/infra/scripts/funding/deploy-key-funder.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm, input } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { readFileSync } from 'fs';

--- a/typescript/infra/scripts/funding/fund-deterministic-key-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-deterministic-key-from-deployer.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { BigNumber } from 'ethers';
 import { format } from 'util';
 

--- a/typescript/infra/scripts/funding/fund-wallet-from-deployer-key.ts
+++ b/typescript/infra/scripts/funding/fund-wallet-from-deployer-key.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { formatUnits } from 'ethers/lib/utils.js';
 import { format } from 'util';
 

--- a/typescript/infra/scripts/funding/read-alert-thresholds.ts
+++ b/typescript/infra/scripts/funding/read-alert-thresholds.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import yargs from 'yargs';
 
 import { rootLogger } from '@hyperlane-xyz/utils';

--- a/typescript/infra/scripts/funding/reclaim-from-igp.ts
+++ b/typescript/infra/scripts/funding/reclaim-from-igp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import { formatEther, parseEther } from 'ethers/lib/utils.js';
 

--- a/typescript/infra/scripts/funding/update-balance-thresholds.ts
+++ b/typescript/infra/scripts/funding/update-balance-thresholds.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { input, select } from '@inquirer/prompts';
 import yargs from 'yargs';
 

--- a/typescript/infra/scripts/funding/vanguard.ts
+++ b/typescript/infra/scripts/funding/vanguard.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import { formatUnits, parseUnits } from 'ethers/lib/utils.js';
 import yargs from 'yargs';

--- a/typescript/infra/scripts/funding/write-alert.ts
+++ b/typescript/infra/scripts/funding/write-alert.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import { ChildProcess } from 'child_process';
 import yargs from 'yargs';

--- a/typescript/infra/scripts/gas/get-typical-remote-gas-amounts.ts
+++ b/typescript/infra/scripts/gas/get-typical-remote-gas-amounts.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { stringifyObject } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/scripts/gas/print-all-gas-oracles.ts
+++ b/typescript/infra/scripts/gas/print-all-gas-oracles.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { stringifyObject } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/scripts/get-warp-route-ids.ts
+++ b/typescript/infra/scripts/get-warp-route-ids.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { getRegistry } from '../config/registry.js';
 
 async function main() {

--- a/typescript/infra/scripts/github-utils.ts
+++ b/typescript/infra/scripts/github-utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Argv } from 'yargs';
 
 export function withRegistryUris<T>(args: Argv<T>) {

--- a/typescript/infra/scripts/http-registry.ts
+++ b/typescript/infra/scripts/http-registry.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { HttpServer } from '@hyperlane-xyz/http-registry-server';
 import { IRegistry } from '@hyperlane-xyz/registry';
 import { assert } from '@hyperlane-xyz/utils';

--- a/typescript/infra/scripts/keys/create-keys.ts
+++ b/typescript/infra/scripts/keys/create-keys.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { createAgentKeysIfNotExistsWithPrompt } from '../../src/agents/key-utils.js';
 import { getAgentConfigsBasedOnArgs } from '../agent-utils.js';
 

--- a/typescript/infra/scripts/keys/delete-keys.ts
+++ b/typescript/infra/scripts/keys/delete-keys.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { deleteAgentKeys } from '../../src/agents/key-utils.js';
 import { getAgentConfigsBasedOnArgs } from '../agent-utils.js';
 

--- a/typescript/infra/scripts/keys/get-key-addresses.ts
+++ b/typescript/infra/scripts/keys/get-key-addresses.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import prompts from 'prompts';
 
 import { ProtocolType } from '../../../utils/dist/types.js';

--- a/typescript/infra/scripts/keys/get-key.ts
+++ b/typescript/infra/scripts/keys/get-key.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { getCloudAgentKey } from '../../src/agents/key-utils.js';
 import { getArgs, withAgentRole, withContext } from '../agent-utils.js';
 import { getConfigsBasedOnArgs } from '../core-utils.js';

--- a/typescript/infra/scripts/keys/get-owner-ica.ts
+++ b/typescript/infra/scripts/keys/get-owner-ica.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { IRegistry } from '@hyperlane-xyz/registry';
 import {
   AccountConfig,

--- a/typescript/infra/scripts/keys/get-timelocks.ts
+++ b/typescript/infra/scripts/keys/get-timelocks.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { EvmTimelockDeployer } from '@hyperlane-xyz/sdk';
 import {
   LogFormat,

--- a/typescript/infra/scripts/keys/rotate-key.ts
+++ b/typescript/infra/scripts/keys/rotate-key.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   getAgentConfig,
   getArgs,

--- a/typescript/infra/scripts/keys/update-key.ts
+++ b/typescript/infra/scripts/keys/update-key.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   getAgentConfig,
   getArgs,

--- a/typescript/infra/scripts/module-can-verify.ts
+++ b/typescript/infra/scripts/module-can-verify.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { moduleCanCertainlyVerify } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/scripts/print-balances.ts
+++ b/typescript/infra/scripts/print-balances.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { formatUnits } from 'ethers/lib/utils.js';
 
 import { Contexts } from '../config/contexts.js';

--- a/typescript/infra/scripts/print-gas-prices.ts
+++ b/typescript/infra/scripts/print-gas-prices.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Provider } from '@ethersproject/providers';
 import { ethers } from 'ethers';
 import path from 'path';

--- a/typescript/infra/scripts/print-mailbox-owner.ts
+++ b/typescript/infra/scripts/print-mailbox-owner.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainAddresses } from '@hyperlane-xyz/registry';
 import {
   ChainMap,

--- a/typescript/infra/scripts/print-token-prices.ts
+++ b/typescript/infra/scripts/print-token-prices.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import path from 'path';
 

--- a/typescript/infra/scripts/print-warp-routers.ts
+++ b/typescript/infra/scripts/print-warp-routers.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { strip0x } from '@hyperlane-xyz/utils';
 
 import { getWarpCoreConfig } from '../config/registry.js';

--- a/typescript/infra/scripts/rebalancer/deploy-rebalancer.ts
+++ b/typescript/infra/scripts/rebalancer/deploy-rebalancer.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { checkbox, input } from '@inquirer/prompts';
 import path from 'path';
 

--- a/typescript/infra/scripts/relay.ts
+++ b/typescript/infra/scripts/relay.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { HyperlaneRelayer, RelayerCacheSchema } from '@hyperlane-xyz/relayer';
 
 import { readFile, writeFile } from 'fs/promises';

--- a/typescript/infra/scripts/run-anvil.ts
+++ b/typescript/infra/scripts/run-anvil.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { spawn } from 'child_process';
 
 import { getArgs, withChainRequired } from './agent-utils.js';

--- a/typescript/infra/scripts/safes/combine-txs.ts
+++ b/typescript/infra/scripts/safes/combine-txs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // Import necessary modules
 import { SafeTransaction } from '@safe-global/safe-core-sdk-types';
 // eslint-disable-next-line

--- a/typescript/infra/scripts/safes/create-safe.ts
+++ b/typescript/infra/scripts/safes/create-safe.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import Safe, {
   SafeAccountConfig,
   ContractNetworksConfig,

--- a/typescript/infra/scripts/safes/delete-pending-txs.ts
+++ b/typescript/infra/scripts/safes/delete-pending-txs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import yargs from 'yargs';
 
 import { rootLogger } from '@hyperlane-xyz/utils';

--- a/typescript/infra/scripts/safes/delete-tx.ts
+++ b/typescript/infra/scripts/safes/delete-tx.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import yargs from 'yargs';
 
 import { rootLogger } from '@hyperlane-xyz/utils';

--- a/typescript/infra/scripts/safes/get-pending-txs.ts
+++ b/typescript/infra/scripts/safes/get-pending-txs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
 import yargs from 'yargs';

--- a/typescript/infra/scripts/safes/governance/check-safe-signers.ts
+++ b/typescript/infra/scripts/safes/governance/check-safe-signers.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import Safe from '@safe-global/protocol-kit';
 import yargs from 'yargs';
 

--- a/typescript/infra/scripts/safes/governance/test-icas.ts
+++ b/typescript/infra/scripts/safes/governance/test-icas.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import yargs from 'yargs';
 
 import { InterchainAccount } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/scripts/safes/governance/update-signers.ts
+++ b/typescript/infra/scripts/safes/governance/update-signers.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import Safe from '@safe-global/protocol-kit';
 import yargs from 'yargs';
 

--- a/typescript/infra/scripts/safes/migrate-to-typed-signatures.ts
+++ b/typescript/infra/scripts/safes/migrate-to-typed-signatures.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { BigNumber } from 'ethers';

--- a/typescript/infra/scripts/safes/parse-txs.ts
+++ b/typescript/infra/scripts/safes/parse-txs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import { BigNumber } from 'ethers';
 import yargs from 'yargs';

--- a/typescript/infra/scripts/sealevel-helpers/print-chain-metadatas.ts
+++ b/typescript/infra/scripts/sealevel-helpers/print-chain-metadatas.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { pick } from '@hyperlane-xyz/utils';
 
 import { getArgs } from '../agent-utils.js';

--- a/typescript/infra/scripts/sealevel-helpers/print-gas-oracles.ts
+++ b/typescript/infra/scripts/sealevel-helpers/print-gas-oracles.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   ChainName,

--- a/typescript/infra/scripts/sealevel-helpers/print-multisig-ism-config.ts
+++ b/typescript/infra/scripts/sealevel-helpers/print-multisig-ism-config.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { IsmType } from '@hyperlane-xyz/sdk';
 
 import { Contexts } from '../../config/contexts.js';

--- a/typescript/infra/scripts/sealevel-helpers/update-gas-oracles.ts
+++ b/typescript/infra/scripts/sealevel-helpers/update-gas-oracles.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import { Connection, PublicKey } from '@solana/web3.js';
 import { deserializeUnchecked } from 'borsh';

--- a/typescript/infra/scripts/sealevel-helpers/update-multisig-ism-config.ts
+++ b/typescript/infra/scripts/sealevel-helpers/update-multisig-ism-config.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import {
   PublicKey,

--- a/typescript/infra/scripts/secret-rpc-urls/analyze-rpc-domains.ts
+++ b/typescript/infra/scripts/secret-rpc-urls/analyze-rpc-domains.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainName } from '@hyperlane-xyz/sdk';
 import { assert } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/scripts/secret-rpc-urls/debug-rpc-url-health.ts
+++ b/typescript/infra/scripts/secret-rpc-urls/debug-rpc-url-health.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 
 import { ChainMetadata } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/scripts/secret-rpc-urls/get-rpc-urls.ts
+++ b/typescript/infra/scripts/secret-rpc-urls/get-rpc-urls.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   getSecretRpcEndpoints,
   secretRpcEndpointsExist,

--- a/typescript/infra/scripts/secret-rpc-urls/set-rpc-urls.ts
+++ b/typescript/infra/scripts/secret-rpc-urls/set-rpc-urls.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { setRpcUrlsInteractive } from '../../src/utils/rpcUrls.js';
 import {
   assertCorrectKubeContext,

--- a/typescript/infra/scripts/send-test-messages.ts
+++ b/typescript/infra/scripts/send-test-messages.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Provider } from '@ethersproject/providers';
 import { Wallet } from 'ethers';
 import fs from 'fs';

--- a/typescript/infra/scripts/squads/cancel-proposal.ts
+++ b/typescript/infra/scripts/squads/cancel-proposal.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
 import yargs from 'yargs';

--- a/typescript/infra/scripts/squads/get-pending-txs.ts
+++ b/typescript/infra/scripts/squads/get-pending-txs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
 import yargs from 'yargs';

--- a/typescript/infra/scripts/squads/parse-txs.ts
+++ b/typescript/infra/scripts/squads/parse-txs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import yargs from 'yargs';
 

--- a/typescript/infra/scripts/squads/read-proposal.ts
+++ b/typescript/infra/scripts/squads/read-proposal.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import yargs, { Argv } from 'yargs';
 

--- a/typescript/infra/scripts/timelocks/cancel-pending-txs.ts
+++ b/typescript/infra/scripts/timelocks/cancel-pending-txs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import yargs from 'yargs';
 
 import {

--- a/typescript/infra/scripts/timelocks/cancel-tx.ts
+++ b/typescript/infra/scripts/timelocks/cancel-tx.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import yargs from 'yargs';
 
 import {

--- a/typescript/infra/scripts/timelocks/get-pending-txs.ts
+++ b/typescript/infra/scripts/timelocks/get-pending-txs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
 import yargs from 'yargs';

--- a/typescript/infra/scripts/timelocks/parse-txs.ts
+++ b/typescript/infra/scripts/timelocks/parse-txs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import yargs from 'yargs';
 

--- a/typescript/infra/scripts/validators/announce-validators.ts
+++ b/typescript/infra/scripts/validators/announce-validators.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import { ethers } from 'ethers';
 import { readFileSync } from 'fs';

--- a/typescript/infra/scripts/validators/find-reorg.ts
+++ b/typescript/infra/scripts/validators/find-reorg.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { MerkleTreeHook, MerkleTreeHook__factory } from '@hyperlane-xyz/core';
 import { getValidatorFromStorageLocation } from '@hyperlane-xyz/sdk';
 import { rootLogger } from '@hyperlane-xyz/utils';

--- a/typescript/infra/scripts/validators/print-latest-checkpoints.ts
+++ b/typescript/infra/scripts/validators/print-latest-checkpoints.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ValidatorAnnounce__factory } from '@hyperlane-xyz/core';
 import {
   ChainMap,

--- a/typescript/infra/scripts/validators/print-reorg-status.ts
+++ b/typescript/infra/scripts/validators/print-reorg-status.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ValidatorAnnounce__factory } from '@hyperlane-xyz/core';
 import {
   ChainMap,

--- a/typescript/infra/scripts/validators/verify-validators.ts
+++ b/typescript/infra/scripts/validators/verify-validators.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { CoreConfig } from '@hyperlane-xyz/sdk';
 import { objFilter, objMap, promiseObjAll } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/scripts/verify.ts
+++ b/typescript/infra/scripts/verify.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   ChainMap,
   ExplorerLicenseType,

--- a/typescript/infra/scripts/warp-routes/deploy-warp-monitor.ts
+++ b/typescript/infra/scripts/warp-routes/deploy-warp-monitor.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { checkbox, input } from '@inquirer/prompts';
 
 import {

--- a/typescript/infra/scripts/warp-routes/export-svm-config.ts
+++ b/typescript/infra/scripts/warp-routes/export-svm-config.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { execSync } from 'child_process';
 import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'path';

--- a/typescript/infra/scripts/warp-routes/export-warp-configs.ts
+++ b/typescript/infra/scripts/warp-routes/export-warp-configs.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ESLint } from 'eslint';
 import { parse as yamlParse, stringify as yamlStringify } from 'yaml';
 

--- a/typescript/infra/scripts/warp-routes/generate-strategy-config.ts
+++ b/typescript/infra/scripts/warp-routes/generate-strategy-config.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import prompts from 'prompts';
 
 import {

--- a/typescript/infra/scripts/warp-routes/generate-warp-config.ts
+++ b/typescript/infra/scripts/warp-routes/generate-warp-config.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { stringify as yamlStringify } from 'yaml';
 
 import { WarpRouteDeployConfigSchema } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/scripts/warp-routes/ousdt/prune-warp-config.ts
+++ b/typescript/infra/scripts/warp-routes/ousdt/prune-warp-config.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import yargs from 'yargs';
 

--- a/typescript/infra/scripts/warp-routes/ousdt/update-submitter-strategy.ts
+++ b/typescript/infra/scripts/warp-routes/ousdt/update-submitter-strategy.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { stringify as yamlStringify } from 'yaml';

--- a/typescript/infra/scripts/warp-routes/status.ts
+++ b/typescript/infra/scripts/warp-routes/status.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import yargs from 'yargs';
 

--- a/typescript/infra/scripts/warp-routes/utils.ts
+++ b/typescript/infra/scripts/warp-routes/utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Contexts } from '../../config/contexts.js';
 import { Role } from '../../src/roles.js';
 import {

--- a/typescript/infra/src/agents/agent.ts
+++ b/typescript/infra/src/agents/agent.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainName } from '@hyperlane-xyz/sdk';
 
 import { Contexts } from '../../config/contexts.js';

--- a/typescript/infra/src/agents/aws/key.ts
+++ b/typescript/infra/src/agents/aws/key.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   AliasListEntry,
   CreateAliasCommand,

--- a/typescript/infra/src/agents/aws/user.ts
+++ b/typescript/infra/src/agents/aws/user.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   CreateAccessKeyCommand,
   CreateUserCommand,

--- a/typescript/infra/src/agents/aws/validator-user.ts
+++ b/typescript/infra/src/agents/aws/validator-user.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   CreateBucketCommand,
   DeletePublicAccessBlockCommand,

--- a/typescript/infra/src/agents/aws/validator.ts
+++ b/typescript/infra/src/agents/aws/validator.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { S3Receipt, S3Validator } from '@hyperlane-xyz/sdk';
 import {
   Checkpoint,

--- a/typescript/infra/src/agents/gcp.ts
+++ b/typescript/infra/src/agents/gcp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { encodeSecp256k1Pubkey, pubkeyToAddress } from '@cosmjs/amino';
 import { Keypair } from '@solana/web3.js';
 import { Wallet, ethers } from 'ethers';

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { join } from 'path';
 
 import {

--- a/typescript/infra/src/agents/key-utils.ts
+++ b/typescript/infra/src/agents/key-utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { join } from 'path';

--- a/typescript/infra/src/agents/keys.ts
+++ b/typescript/infra/src/agents/keys.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ethers } from 'ethers';
 import { Provider as ZkProvider, Wallet as ZkWallet } from 'zksync-ethers';
 

--- a/typescript/infra/src/check-warp-deploy/helm.ts
+++ b/typescript/infra/src/check-warp-deploy/helm.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { join } from 'path';
 
 import { Contexts } from '../../config/contexts.js';

--- a/typescript/infra/src/coingecko/utils.ts
+++ b/typescript/infra/src/coingecko/utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Logger } from 'pino';
 
 import { DeployEnvironment } from '../config/environment.js';

--- a/typescript/infra/src/config/agent/agent.ts
+++ b/typescript/infra/src/config/agent/agent.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   AgentChainMetadata,
   AgentSealevelPriorityFeeOracle,

--- a/typescript/infra/src/config/agent/relayer.test.ts
+++ b/typescript/infra/src/config/agent/relayer.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { addressToBytes32 } from '@hyperlane-xyz/utils';

--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { BigNumberish } from 'ethers';
 import { Logger } from 'pino';
 import { z } from 'zod';

--- a/typescript/infra/src/config/agent/scraper.ts
+++ b/typescript/infra/src/config/agent/scraper.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   AgentConfig,
   ChainMap,

--- a/typescript/infra/src/config/agent/validator.ts
+++ b/typescript/infra/src/config/agent/validator.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   AgentConfig,
   AgentSignerKeyType,

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { providers } from 'ethers';
 
 import { IRegistry } from '@hyperlane-xyz/registry';

--- a/typescript/infra/src/config/environment.ts
+++ b/typescript/infra/src/config/environment.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { IRegistry } from '@hyperlane-xyz/registry';
 import {
   ChainMap,

--- a/typescript/infra/src/config/funding.ts
+++ b/typescript/infra/src/config/funding.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { z } from 'zod';
 
 import { ChainMap, ChainName } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/src/config/funding/alert-query-templates.ts
+++ b/typescript/infra/src/config/funding/alert-query-templates.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // alert queries currently need to support special cases i.e cross VM (sealevel and cosmos chains) and ata payer (sealevel). These special cases are hard coded for now. We aim to add cross VM support to the key and will be able to remove special casing in the future
 export const LOW_URGENCY_KEY_FUNDER_HEADER = `# Note: use last_over_time(hyperlane_wallet_balance{}[1d]) to be resilient to gaps in the 'hyperlane_wallet_balance'
 # that occur due to key funder only running every hour or so.

--- a/typescript/infra/src/config/funding/balances.ts
+++ b/typescript/infra/src/config/funding/balances.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { join } from 'path';
 
 import { ChainMap } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/src/config/funding/grafanaAlerts.ts
+++ b/typescript/infra/src/config/funding/grafanaAlerts.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   HIGH_URGENCY_RELAYER_FOOTER,
   HIGH_URGENCY_RELAYER_HEADER,

--- a/typescript/infra/src/config/gas-oracle.ts
+++ b/typescript/infra/src/config/gas-oracle.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { BigNumber as BigNumberJs } from 'bignumber.js';
 import { BigNumber } from 'ethers';
 import { z } from 'zod';

--- a/typescript/infra/src/config/infrastructure.ts
+++ b/typescript/infra/src/config/infrastructure.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import type { KubernetesResources } from './agent/agent.js';
 
 export interface HelmImageValues {

--- a/typescript/infra/src/config/squads.ts
+++ b/typescript/infra/src/config/squads.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { PublicKey } from '@solana/web3.js';
 
 import { ChainMap, ChainName } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/src/config/warp.ts
+++ b/typescript/infra/src/config/warp.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { OwnableConfig, RouterConfig } from '@hyperlane-xyz/sdk';
 
 // Common collateral tokens to be used by warp route deployments.

--- a/typescript/infra/src/deployment/deploy.ts
+++ b/typescript/infra/src/deployment/deploy.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 
 import {

--- a/typescript/infra/src/deployment/testcontracts/testquerysender.ts
+++ b/typescript/infra/src/deployment/testcontracts/testquerysender.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { TestQuerySender__factory } from '@hyperlane-xyz/core';
 import {
   ChainName,

--- a/typescript/infra/src/deployment/verify.ts
+++ b/typescript/infra/src/deployment/verify.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { BuildArtifact, ChainMap } from '@hyperlane-xyz/sdk';
 import { readJson } from '@hyperlane-xyz/utils/fs';
 

--- a/typescript/infra/src/funding/alerts.ts
+++ b/typescript/infra/src/funding/alerts.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap } from '@hyperlane-xyz/sdk';
 
 import {

--- a/typescript/infra/src/funding/balances.ts
+++ b/typescript/infra/src/funding/balances.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { rootLogger } from '@hyperlane-xyz/utils';
 import { readJson } from '@hyperlane-xyz/utils/fs';

--- a/typescript/infra/src/funding/deterministic-keys.ts
+++ b/typescript/infra/src/funding/deterministic-keys.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Wallet, utils } from 'ethers';
 
 import { Contexts } from '../../config/contexts.js';

--- a/typescript/infra/src/funding/key-funder.ts
+++ b/typescript/infra/src/funding/key-funder.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { BigNumber, ethers } from 'ethers';
 import { join } from 'path';
 import YAML from 'yaml';

--- a/typescript/infra/src/govern/HyperlaneAppGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneAppGovernor.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import { BigNumber } from 'ethers';
 import prompts from 'prompts';

--- a/typescript/infra/src/govern/HyperlaneCoreGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneCoreGovernor.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import { BigNumber } from 'ethers';
 

--- a/typescript/infra/src/govern/HyperlaneHaasGovernor.test.ts
+++ b/typescript/infra/src/govern/HyperlaneHaasGovernor.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import sinon from 'sinon';

--- a/typescript/infra/src/govern/HyperlaneHaasGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneHaasGovernor.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import { BigNumber } from 'ethers';
 

--- a/typescript/infra/src/govern/HyperlaneICAChecker.ts
+++ b/typescript/infra/src/govern/HyperlaneICAChecker.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 
 import {

--- a/typescript/infra/src/govern/HyperlaneIgpGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneIgpGovernor.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { BigNumber, ethers } from 'ethers';
 
 import { InterchainGasPaymaster } from '@hyperlane-xyz/core';

--- a/typescript/infra/src/govern/ProxiedRouterGovernor.ts
+++ b/typescript/infra/src/govern/ProxiedRouterGovernor.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { BigNumber } from 'ethers';
 
 import {

--- a/typescript/infra/src/govern/multisend.ts
+++ b/typescript/infra/src/govern/multisend.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import SafeApiKit from '@safe-global/api-kit';
 import Safe from '@safe-global/protocol-kit';
 import { SafeTransaction } from '@safe-global/safe-core-sdk-types';

--- a/typescript/infra/src/governance.ts
+++ b/typescript/infra/src/governance.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Argv } from 'yargs';
 
 import { ChainName } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/src/infrastructure/external-secrets/external-secrets.ts
+++ b/typescript/infra/src/infrastructure/external-secrets/external-secrets.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 
 import { sleep } from '@hyperlane-xyz/utils';

--- a/typescript/infra/src/infrastructure/monitoring/grafana.ts
+++ b/typescript/infra/src/infrastructure/monitoring/grafana.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { inCIMode, rootLogger } from '@hyperlane-xyz/utils';
 

--- a/typescript/infra/src/infrastructure/monitoring/prometheus.ts
+++ b/typescript/infra/src/infrastructure/monitoring/prometheus.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChildProcess, spawn } from 'child_process';
 
 import { rootLogger } from '@hyperlane-xyz/utils';

--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import fs from 'fs';
 import path from 'path';

--- a/typescript/infra/src/roles.ts
+++ b/typescript/infra/src/roles.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 export enum Role {
   Validator = 'validator',
   Relayer = 'relayer',

--- a/typescript/infra/src/tx/govern-transaction-reader.ts
+++ b/typescript/infra/src/tx/govern-transaction-reader.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Result } from '@ethersproject/abi';
 import {
   MetaTransactionData,

--- a/typescript/infra/src/tx/squads-transaction-reader.ts
+++ b/typescript/infra/src/tx/squads-transaction-reader.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 /**
  * Squads transaction parser for Hyperlane operations
  * Parses VaultTransaction instructions to verify governance operations

--- a/typescript/infra/src/tx/utils.ts
+++ b/typescript/infra/src/tx/utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
 

--- a/typescript/infra/src/utils/consts.ts
+++ b/typescript/infra/src/utils/consts.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { ChainName, defaultMultisigConfigs } from '@hyperlane-xyz/sdk';
 
 export const REBALANCER_HELM_RELEASE_PREFIX = 'hyperlane-rebalancer';

--- a/typescript/infra/src/utils/fork.ts
+++ b/typescript/infra/src/utils/fork.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
 
 import { ChainName, MultiProvider } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/src/utils/gcloud.ts
+++ b/typescript/infra/src/utils/gcloud.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { SecretManagerServiceClient } from '@google-cloud/secret-manager';
 import fs from 'fs';
 

--- a/typescript/infra/src/utils/git.ts
+++ b/typescript/infra/src/utils/git.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import { exec } from 'child_process';
 import { promisify } from 'util';

--- a/typescript/infra/src/utils/helm.ts
+++ b/typescript/infra/src/utils/helm.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';

--- a/typescript/infra/src/utils/k8s.ts
+++ b/typescript/infra/src/utils/k8s.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 
 import { pollAsync } from '@hyperlane-xyz/utils';

--- a/typescript/infra/src/utils/log.ts
+++ b/typescript/infra/src/utils/log.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import Table from 'cli-table3';
 

--- a/typescript/infra/src/utils/rpcUrls.ts
+++ b/typescript/infra/src/utils/rpcUrls.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import input from '@inquirer/input';
 import { Separator, checkbox, confirm } from '@inquirer/prompts';
 import select from '@inquirer/select';

--- a/typescript/infra/src/utils/safe.ts
+++ b/typescript/infra/src/utils/safe.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { JsonRpcSigner } from '@ethersproject/providers';
 import SafeApiKit, {
   SafeMultisigTransactionListResponse,

--- a/typescript/infra/src/utils/sealevel.ts
+++ b/typescript/infra/src/utils/sealevel.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   AccountMeta,
   ComputeBudgetProgram,

--- a/typescript/infra/src/utils/squads.ts
+++ b/typescript/infra/src/utils/squads.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   PublicKey,
   TransactionInstruction,

--- a/typescript/infra/src/utils/timelock.ts
+++ b/typescript/infra/src/utils/timelock.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import { BigNumber, ethers } from 'ethers';
 

--- a/typescript/infra/src/utils/turnkey.ts
+++ b/typescript/infra/src/utils/turnkey.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import {
   MultiProvider,
   TurnkeyConfig,

--- a/typescript/infra/src/utils/utils.ts
+++ b/typescript/infra/src/utils/utils.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 // @ts-ignore
 import asn1 from 'asn1.js';
 import { exec } from 'child_process';

--- a/typescript/infra/src/utils/violation.ts
+++ b/typescript/infra/src/utils/violation.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import chalk from 'chalk';
 import { addedDiff, deletedDiff, updatedDiff } from 'deep-object-diff';
 import stringify from 'json-stable-stringify';

--- a/typescript/infra/src/warp-monitor/helm.ts
+++ b/typescript/infra/src/warp-monitor/helm.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { confirm } from '@inquirer/prompts';
 import path from 'path';
 

--- a/typescript/infra/test/agent-configs.test.ts
+++ b/typescript/infra/test/agent-configs.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { AgentConfig } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/test/balance-alerts.test.ts
+++ b/typescript/infra/test/balance-alerts.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { ChainMap } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/test/cloud-agent-keys.test.ts
+++ b/typescript/infra/test/cloud-agent-keys.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { Contexts } from '../config/contexts.js';

--- a/typescript/infra/test/environment.test.ts
+++ b/typescript/infra/test/environment.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import {

--- a/typescript/infra/test/gitleaks.test.ts
+++ b/typescript/infra/test/gitleaks.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { Keypair } from '@solana/web3.js';
 import { expect } from 'chai';
 import { execSync } from 'child_process';

--- a/typescript/infra/test/govern.hardhat-test.ts
+++ b/typescript/infra/test/govern.hardhat-test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers.js';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';

--- a/typescript/infra/test/rebalancer.test.ts
+++ b/typescript/infra/test/rebalancer.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { environments } from '../config/environments/index.js';

--- a/typescript/infra/test/safe.test.ts
+++ b/typescript/infra/test/safe.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 

--- a/typescript/infra/test/warp-configs.test.ts
+++ b/typescript/infra/test/warp-configs.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/typescript/infra/test/warpIds.test.ts
+++ b/typescript/infra/test/warpIds.test.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 import { expect } from 'chai';
 
 import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';


### PR DESCRIPTION
## Summary

- Adds `LICENSE-BUSL-1.1` (BSL 1.1, Licensor: Abacus Works Inc, 4-year rolling change date to Apache 2.0)
- Preserves original Apache 2.0 text as `LICENSE-APACHE-2.0`
- Replaces `LICENSE.md` with dual-license overview and directory breakdown
- Flips SPDX headers on 18 token contract files and all 8 middleware contract files to `BUSL-1.1`
- Adds `// SPDX-License-Identifier: BUSL-1.1` to all 503 TypeScript files in `infra/` and `cli/`
- Updates `package.json` license fields for `cli` and `infra` packages

## What stays Apache-2.0

- Mailbox, all interfaces, ISMs, hooks, libs, client/
- Basic warp route contracts: HypERC20, HypERC20Collateral, HypERC721, HypERC721Collateral, HypNative
- token/libs/TokenRouter, token/libs/TokenMessage
- All Rust agent code
- typescript/sdk/, typescript/utils/

## What moves to BUSL-1.1

- token/TokenBridgeCctpBase, TokenBridgeCctpV1, TokenBridgeCctpV2
- token/extensions/* (all 10 files: ERC4626 variants, FiatToken, XERC20, etc.)
- token/libs/ (5 files: AmountPartition, LpCollateralRouter, MovableCollateralRouter, Quotes, TokenCollateral)
- middleware/* (all 8 files)
- typescript/infra/ (306 .ts files)
- typescript/cli/ (197 .ts files)

## Test plan

- [x] All 18 flipped token files have `BUSL-1.1` SPDX header
- [x] All 8 middleware files have `BUSL-1.1` SPDX header
- [x] Excluded files (HypERC20, HypERC20Collateral, HypERC721, HypERC721Collateral, HypNative, TokenRouter, TokenMessage) retain original headers
- [x] `solidity/contracts/interfaces/` non-vendored files are untouched
- [x] `typescript/sdk/` and `typescript/utils/` have zero BUSL references
- [x] `rust/` has zero BUSL references
- [x] `cli.ts` shebang preserved on line 1, SPDX on line 2
- [x] 306 infra + 197 cli .ts files all have BUSL-1.1 headers
- [x] package.json: cli=BUSL-1.1, infra=BUSL-1.1, sdk=Apache-2.0, utils=Apache-2.0
- [x] Three license files at root: LICENSE.md, LICENSE-APACHE-2.0, LICENSE-BUSL-1.1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
