### PR TITLE
fix(sdk): add probe-specific smart provider requests

### DIFF
--- a/.changeset/probe-request-kind.md
+++ b/.changeset/probe-request-kind.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Probe-specific SmartProvider request handling was added so contract-shape probes can short-circuit deterministic misses without using the normal read retry loop, while transport failures still fall through to other providers.

--- a/.changeset/probe-request-kind.md
+++ b/.changeset/probe-request-kind.md
@@ -1,5 +1,6 @@
 ---
+'@hyperlane-xyz/cli': patch
 '@hyperlane-xyz/sdk': patch
 ---
 
-Probe-specific SmartProvider request handling was added so contract-shape probes can short-circuit deterministic misses without using the normal read retry loop, while transport failures still fall through to other providers.
+Probe-specific SmartProvider request handling was added so contract-shape probes can short-circuit deterministic misses without using the normal read retry loop, while transport failures still fall through to other providers. Warp route reads now reuse package version lookups within a derivation, and CLI context setup reuses registry metadata when constructing provider containers.

--- a/typescript/cli/src/context/context.ts
+++ b/typescript/cli/src/context/context.ts
@@ -222,8 +222,8 @@ export async function getContext({
     !!skipConfirmation,
   );
 
-  const multiProvider = await getMultiProvider(registry);
-  const multiProtocolProvider = await getMultiProtocolProvider(registry);
+  const { multiProvider, multiProtocolProvider } =
+    await getProvidersFromRegistry(registry);
 
   // This mapping gets populated as part of signerMiddleware
   const altVmProviders: ChainMap<AltVM.IProvider> = {};
@@ -303,16 +303,19 @@ async function getSignerKeyMap(
  * @param customChains Custom chains specified by the user
  * @returns a new MultiProvider
  */
-async function getMultiProvider(registry: IRegistry, signer?: ethers.Signer) {
+export async function getProvidersFromRegistry(
+  registry: IRegistry,
+  signer?: ethers.Signer,
+) {
   const chainMetadata = await registry.getMetadata();
   const multiProvider = new MultiProvider(chainMetadata);
   if (signer) multiProvider.setSharedSigner(signer);
-  return multiProvider;
-}
 
-async function getMultiProtocolProvider(registry: IRegistry) {
-  const chainMetadata = await registry.getMetadata();
-  return new MultiProtocolProvider(chainMetadata);
+  return {
+    chainMetadata,
+    multiProvider,
+    multiProtocolProvider: new MultiProtocolProvider(chainMetadata),
+  };
 }
 
 /**

--- a/typescript/cli/src/tests/context/context.test.ts
+++ b/typescript/cli/src/tests/context/context.test.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { test1 } from '@hyperlane-xyz/sdk';
+
+import { getProvidersFromRegistry } from '../../context/context.js';
+
+describe('getProvidersFromRegistry', () => {
+  it('reads registry metadata once and reuses it for both provider containers', async () => {
+    const chainMetadata = { test1 };
+    const registry = {
+      getMetadata: sinon.stub().resolves(chainMetadata),
+    };
+
+    const providers = await getProvidersFromRegistry(registry as any);
+
+    expect(registry.getMetadata.callCount).to.equal(1);
+    expect(providers.chainMetadata).to.deep.equal(chainMetadata);
+    expect(providers.multiProvider.metadata).to.deep.equal(chainMetadata);
+    expect(providers.multiProtocolProvider.metadata).to.deep.equal(
+      chainMetadata,
+    );
+  });
+});

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -25,6 +25,7 @@
     "check": "tsc --noEmit",
     "clean": "rm -rf ./dist ./cache",
     "lint": "oxlint -c ../../oxlint.json",
+    "bench:smart-provider-probes": "tsx ./scripts/benchmark-smart-provider-probes.ts",
     "prepublishOnly": "pnpm build",
     "format": "oxfmt --write ./src",
     "test": "pnpm test:unit && pnpm test:hardhat && pnpm test:foundry",

--- a/typescript/sdk/scripts/benchmark-smart-provider-probes.ts
+++ b/typescript/sdk/scripts/benchmark-smart-provider-probes.ts
@@ -112,6 +112,14 @@ function formatMs(value: number): string {
   return `${value.toFixed(1)}ms`;
 }
 
+function formatSpeedup(readAvgMs: number, probeAvgMs: number): string {
+  if (probeAvgMs < 0.05) {
+    return `>${(readAvgMs / 0.05).toFixed(2)}x`;
+  }
+
+  return `${(readAvgMs / probeAvgMs).toFixed(2)}x`;
+}
+
 async function runScenario(
   scenario: Scenario,
   providerCount: number,
@@ -129,7 +137,6 @@ async function runScenario(
     benchmark(() => probeProvider.runProbeCall()),
   ]);
 
-  const speedup = readResult.avgMs / probeResult.avgMs;
   console.log(`\nScenario: ${scenario}`);
   console.log(
     `  read  avg=${formatMs(readResult.avgMs)} min=${formatMs(readResult.minMs)} max=${formatMs(readResult.maxMs)}`,
@@ -137,7 +144,9 @@ async function runScenario(
   console.log(
     `  probe avg=${formatMs(probeResult.avgMs)} min=${formatMs(probeResult.minMs)} max=${formatMs(probeResult.maxMs)}`,
   );
-  console.log(`  speedup=${speedup.toFixed(2)}x`);
+  console.log(
+    `  speedup=${formatSpeedup(readResult.avgMs, probeResult.avgMs)}`,
+  );
 }
 
 async function main(): Promise<void> {

--- a/typescript/sdk/scripts/benchmark-smart-provider-probes.ts
+++ b/typescript/sdk/scripts/benchmark-smart-provider-probes.ts
@@ -1,0 +1,156 @@
+/* eslint-disable no-console */
+
+import { HyperlaneJsonRpcProvider } from '../src/providers/SmartProvider/HyperlaneJsonRpcProvider.js';
+import { ProviderMethod } from '../src/providers/SmartProvider/ProviderMethods.js';
+import { HyperlaneSmartProvider } from '../src/providers/SmartProvider/SmartProvider.js';
+import {
+  SMART_PROVIDER_REQUEST_CONFIG,
+  SmartProviderRequestConfig,
+} from '../src/providers/SmartProvider/types.js';
+
+const TEST_ADDRESS = '0x0000000000000000000000000000000000000001';
+
+type Scenario = 'empty_response' | 'server_then_empty';
+
+class BenchmarkJsonRpcProvider extends HyperlaneJsonRpcProvider {
+  constructor(
+    private readonly scenario: Scenario,
+    private readonly index: number,
+    private readonly delayMs = 0,
+  ) {
+    super(
+      { http: `http://benchmark-${scenario}-${index}` },
+      { chainId: 1, name: 'benchmark' },
+    );
+  }
+
+  override async perform(method: string, params: any): Promise<any> {
+    if (this.delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, this.delayMs));
+    }
+
+    const requestConfig: SmartProviderRequestConfig | undefined =
+      params?.[SMART_PROVIDER_REQUEST_CONFIG];
+
+    if (method !== ProviderMethod.Call) {
+      return super.perform(method, params);
+    }
+
+    if (this.scenario === 'server_then_empty' && this.index === 0) {
+      throw Object.assign(new Error('connection refused'), {
+        code: 'SERVER_ERROR',
+      });
+    }
+
+    if (requestConfig?.allowEmptyCallResult) {
+      return '0x';
+    }
+
+    throw new Error('Invalid response from provider');
+  }
+}
+
+class BenchmarkSmartProvider extends HyperlaneSmartProvider {
+  constructor(rpcProviders: BenchmarkJsonRpcProvider[]) {
+    super(
+      { chainId: 1, name: 'benchmark' },
+      [{ http: 'http://placeholder' }],
+      [],
+      {
+        maxRetries: 3,
+        baseRetryDelayMs: 10,
+        fallbackStaggerMs: 25,
+      },
+    );
+
+    (this as any).explorerProviders = [];
+    (this as any).rpcProviders = rpcProviders;
+    (this as any).supportedMethods = [ProviderMethod.Call];
+  }
+
+  async runReadCall(): Promise<void> {
+    try {
+      await this.perform(ProviderMethod.Call, {
+        transaction: { to: TEST_ADDRESS },
+        blockTag: 'latest',
+      });
+    } catch (error) {
+      void error;
+    }
+  }
+
+  async runProbeCall(): Promise<void> {
+    try {
+      await this.probeCall({ to: TEST_ADDRESS });
+    } catch (error) {
+      void error;
+    }
+  }
+}
+
+async function benchmark(
+  run: () => Promise<void>,
+  iterations = 20,
+): Promise<{ avgMs: number; minMs: number; maxMs: number }> {
+  const times: number[] = [];
+
+  for (let i = 0; i < iterations; i += 1) {
+    const start = performance.now();
+    await run();
+    times.push(performance.now() - start);
+  }
+
+  const total = times.reduce((sum, value) => sum + value, 0);
+  return {
+    avgMs: total / times.length,
+    minMs: Math.min(...times),
+    maxMs: Math.max(...times),
+  };
+}
+
+function formatMs(value: number): string {
+  return `${value.toFixed(1)}ms`;
+}
+
+async function runScenario(
+  scenario: Scenario,
+  providerCount: number,
+): Promise<void> {
+  const buildProviders = () =>
+    Array.from({ length: providerCount }, (_, index) => {
+      return new BenchmarkJsonRpcProvider(scenario, index);
+    });
+
+  const readProvider = new BenchmarkSmartProvider(buildProviders());
+  const probeProvider = new BenchmarkSmartProvider(buildProviders());
+
+  const [readResult, probeResult] = await Promise.all([
+    benchmark(() => readProvider.runReadCall()),
+    benchmark(() => probeProvider.runProbeCall()),
+  ]);
+
+  const speedup = readResult.avgMs / probeResult.avgMs;
+  console.log(`\nScenario: ${scenario}`);
+  console.log(
+    `  read  avg=${formatMs(readResult.avgMs)} min=${formatMs(readResult.minMs)} max=${formatMs(readResult.maxMs)}`,
+  );
+  console.log(
+    `  probe avg=${formatMs(probeResult.avgMs)} min=${formatMs(probeResult.minMs)} max=${formatMs(probeResult.maxMs)}`,
+  );
+  console.log(`  speedup=${speedup.toFixed(2)}x`);
+}
+
+async function main(): Promise<void> {
+  console.log(
+    'Synthetic SmartProvider probe benchmark. Measures retry-policy overhead only.',
+  );
+
+  await runScenario('empty_response', 1);
+
+  await runScenario('server_then_empty', 2);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/typescript/sdk/src/hook/EvmHookReader.test.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.test.ts
@@ -200,7 +200,16 @@ describe('EvmHookReader', () => {
       .returns(mockContract as unknown as OPStackHook);
     sandbox
       .stub(evmHookReader as any, 'probeContractCall')
-      .resolves(OnchainHookType.ID_AUTH_ISM);
+      .callsFake(async (...args: unknown[]) => {
+        const method = args[2] as string;
+        if (method === 'hookType') {
+          return OnchainHookType.ID_AUTH_ISM;
+        }
+        if (method === 'l1Messenger') {
+          return l1Messenger;
+        }
+        return undefined;
+      });
 
     const expectedConfig: WithAddress<OpStackHookConfig> = {
       owner: mockOwner,
@@ -217,6 +226,42 @@ describe('EvmHookReader', () => {
     // should get same result if we call the specific method for the hook type
     const config = await evmHookReader.deriveOpStackConfig(mockAddress);
     expect(config).to.deep.equal(hookConfig);
+  });
+
+  it('should derive CCIP hook through probe helpers', async () => {
+    const ccipHookAddress = randomAddress();
+    const destinationDomain = test1.domainId;
+    const ism = randomAddress();
+
+    const mockContract = {
+      hookType: sandbox.stub().resolves(OnchainHookType.ID_AUTH_ISM),
+      destinationDomain: sandbox.stub().resolves(destinationDomain),
+      ism: sandbox.stub().resolves(ism),
+    };
+
+    sandbox
+      .stub(CCIPHook__factory, 'connect')
+      .returns(mockContract as unknown as CCIPHook);
+    sandbox
+      .stub(evmHookReader as any, 'probeContractCall')
+      .callsFake(async (...args: unknown[]) => {
+        const method = args[2] as string;
+        if (method === 'hookType') {
+          return OnchainHookType.ID_AUTH_ISM;
+        }
+        if (method === 'ccipDestination') {
+          return randomAddress();
+        }
+        return undefined;
+      });
+
+    const config = await evmHookReader.deriveHookConfig(ccipHookAddress);
+
+    expect(config).to.deep.equal({
+      address: ccipHookAddress,
+      type: HookType.CCIP,
+      destinationChain: TestChainName.test1,
+    });
   });
 
   it('should derive CCIPHook configuration correctly', async () => {

--- a/typescript/sdk/src/hook/EvmHookReader.test.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.test.ts
@@ -8,8 +8,6 @@ import {
   CCIPHook__factory,
   DefaultHook,
   DefaultHook__factory,
-  IPostDispatchHook,
-  IPostDispatchHook__factory,
   MerkleTreeHook,
   MerkleTreeHook__factory,
   OPStackHook,
@@ -65,8 +63,8 @@ describe('EvmHookReader', () => {
       .stub(MerkleTreeHook__factory, 'connect')
       .returns(mockContract as unknown as MerkleTreeHook);
     sandbox
-      .stub(IPostDispatchHook__factory, 'connect')
-      .returns(mockContract as unknown as IPostDispatchHook);
+      .stub(evmHookReader as any, 'probeContractCall')
+      .resolves(OnchainHookType.MERKLE_TREE);
 
     const expectedConfig: WithAddress<MerkleTreeHookConfig> = {
       address: mockAddress,
@@ -99,8 +97,8 @@ describe('EvmHookReader', () => {
       .stub(ProtocolFee__factory, 'connect')
       .returns(mockContract as unknown as ProtocolFee);
     sandbox
-      .stub(IPostDispatchHook__factory, 'connect')
-      .returns(mockContract as unknown as IPostDispatchHook);
+      .stub(evmHookReader as any, 'probeContractCall')
+      .resolves(OnchainHookType.PROTOCOL_FEE);
 
     const expectedConfig: WithAddress<ProtocolFeeHookConfig> = {
       owner: mockOwner,
@@ -135,8 +133,8 @@ describe('EvmHookReader', () => {
       .stub(PausableHook__factory, 'connect')
       .returns(mockContract as unknown as PausableHook);
     sandbox
-      .stub(IPostDispatchHook__factory, 'connect')
-      .returns(mockContract as unknown as IPostDispatchHook);
+      .stub(evmHookReader as any, 'probeContractCall')
+      .resolves(OnchainHookType.PAUSABLE);
 
     const expectedConfig: WithAddress<PausableHookConfig> = {
       owner: mockOwner,
@@ -167,8 +165,8 @@ describe('EvmHookReader', () => {
       .stub(DefaultHook__factory, 'connect')
       .returns(mockContract as unknown as DefaultHook);
     sandbox
-      .stub(IPostDispatchHook__factory, 'connect')
-      .returns(mockContract as unknown as IPostDispatchHook);
+      .stub(evmHookReader as any, 'probeContractCall')
+      .resolves(OnchainHookType.MAILBOX_DEFAULT_HOOK);
 
     const expectedConfig: WithAddress<MailboxDefaultHookConfig> = {
       address: mockAddress,
@@ -201,8 +199,8 @@ describe('EvmHookReader', () => {
       .stub(OPStackHook__factory, 'connect')
       .returns(mockContract as unknown as OPStackHook);
     sandbox
-      .stub(IPostDispatchHook__factory, 'connect')
-      .returns(mockContract as unknown as IPostDispatchHook);
+      .stub(evmHookReader as any, 'probeContractCall')
+      .resolves(OnchainHookType.ID_AUTH_ISM);
 
     const expectedConfig: WithAddress<OpStackHookConfig> = {
       owner: mockOwner,
@@ -236,9 +234,6 @@ describe('EvmHookReader', () => {
     sandbox
       .stub(CCIPHook__factory, 'connect')
       .returns(mockContract as unknown as CCIPHook);
-    sandbox
-      .stub(IPostDispatchHook__factory, 'connect')
-      .returns(mockContract as unknown as IPostDispatchHook);
 
     const config = await evmHookReader.deriveCcipConfig(ccipHookAddress);
 
@@ -263,9 +258,7 @@ describe('EvmHookReader', () => {
     sandbox
       .stub(MerkleTreeHook__factory, 'connect')
       .returns(mockContract as unknown as MerkleTreeHook);
-    sandbox
-      .stub(IPostDispatchHook__factory, 'connect')
-      .returns(mockContract as unknown as IPostDispatchHook);
+    sandbox.stub(evmHookReader as any, 'probeContractCall').resolves(undefined);
 
     // top-level method infers hook type
     try {

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -266,28 +266,27 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
   }
 
   async deriveIdAuthIsmConfig(address: Address): Promise<DerivedHookConfig> {
-    // First check if it's a CCIP hook
-    try {
-      const ccipHook = CCIPHook__factory.connect(address, this.provider);
-      // This method only exists on CCIPHook
-      await ccipHook.ccipDestination();
+    const ccipDestination = await this.probeContractCall(
+      address,
+      CCIPHook__factory.createInterface(),
+      'ccipDestination',
+    );
+    if (ccipDestination !== undefined) {
       return this.deriveCcipConfig(address);
-    } catch {
-      // Not a CCIP hook, try OPStack
-      try {
-        const opStackHook = OPStackHook__factory.connect(
-          address,
-          this.provider,
-        );
-        // This method only exists on OPStackHook
-        await opStackHook.l1Messenger();
-        return this.deriveOpStackConfig(address);
-      } catch {
-        throw new Error(
-          `Could not determine hook type - neither CCIP nor OPStack methods found`,
-        );
-      }
     }
+
+    const l1Messenger = await this.probeContractCall(
+      address,
+      OPStackHook__factory.createInterface(),
+      'l1Messenger',
+    );
+    if (l1Messenger !== undefined) {
+      return this.deriveOpStackConfig(address);
+    }
+
+    throw new Error(
+      `Could not determine hook type - neither CCIP nor OPStack methods found`,
+    );
   }
 
   async deriveCcipConfig(

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -132,13 +132,20 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
     let derivedHookConfig: DerivedHookConfig;
 
     try {
-      const hook = IPostDispatchHook__factory.connect(address, this.provider);
       this.logger.debug('Deriving HookConfig:', { address });
 
       // Temporarily turn off SmartProvider logging
       // Provider errors are expected because deriving will call methods that may not exist in the Bytecode
       this.setSmartProviderLogLevel('silent');
-      onchainHookType = await hook.hookType();
+      onchainHookType = await this.probeContractCall<OnchainHookType>(
+        address,
+        IPostDispatchHook__factory.createInterface(),
+        'hookType',
+      );
+      assert(
+        onchainHookType !== undefined,
+        'The provided hook contract might be outdated and not support hookType()',
+      );
 
       switch (onchainHookType) {
         case OnchainHookType.ROUTING:
@@ -181,18 +188,8 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
           );
       }
     } catch (e: any) {
-      let customMessage: string = `Failed to derive ${onchainHookType} hook (${address})`;
-      if (
-        !onchainHookType &&
-        e.message.includes('Invalid response from provider')
-      ) {
-        customMessage = customMessage.concat(
-          ` [The provided hook contract might be outdated and not support hookType()]`,
-        );
-        this.logger.info(`${customMessage}:\n\t${e}`);
-      } else {
-        this.logger.debug(`${customMessage}:\n\t${e}`);
-      }
+      const customMessage = `Failed to derive ${onchainHookType} hook (${address})`;
+      this.logger.debug(`${customMessage}:\n\t${e}`);
       throw new Error(`${customMessage}:\n\t${e}`);
     } finally {
       this.setSmartProviderLogLevel(getLogLevel()); // returns to original level defined by rootLogger

--- a/typescript/sdk/src/ism/EvmIsmReader.test.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.test.ts
@@ -73,8 +73,8 @@ describe('EvmIsmReader', () => {
       .stub(IMultisigIsm__factory, 'connect')
       .returns(mockContract as unknown as IMultisigIsm);
     sandbox
-      .stub(IInterchainSecurityModule__factory, 'connect')
-      .returns(mockContract as unknown as IInterchainSecurityModule);
+      .stub(evmIsmReader as any, 'probeContractCall')
+      .resolves(ModuleType.MESSAGE_ID_MULTISIG);
 
     const expectedConfig: WithAddress<MultisigIsmConfig> = {
       address: mockAddress,
@@ -112,6 +112,9 @@ describe('EvmIsmReader', () => {
     sandbox
       .stub(IInterchainSecurityModule__factory, 'connect')
       .returns(mockContract as unknown as IInterchainSecurityModule);
+    sandbox
+      .stub(evmIsmReader as any, 'probeContractCall')
+      .resolves(ModuleType.NULL);
 
     const expectedConfig: WithAddress<PausableIsmConfig> = {
       address: mockAddress,
@@ -154,6 +157,9 @@ describe('EvmIsmReader', () => {
     sandbox
       .stub(IInterchainSecurityModule__factory, 'connect')
       .returns(mockContract as unknown as IInterchainSecurityModule);
+    sandbox
+      .stub(evmIsmReader as any, 'probeContractCall')
+      .resolves(ModuleType.NULL);
 
     const expectedConfig: WithAddress<TestIsmConfig> = {
       address: mockAddress,
@@ -194,8 +200,8 @@ describe('EvmIsmReader', () => {
       .stub(TrustedRelayerIsm__factory, 'connect')
       .returns(mockContract as unknown as TrustedRelayerIsm);
     sandbox
-      .stub(IInterchainSecurityModule__factory, 'connect')
-      .returns(mockContract as unknown as IInterchainSecurityModule);
+      .stub(evmIsmReader as any, 'probeContractCall')
+      .resolves(ModuleType.ROUTING);
     sandbox.stub(Ownable__factory, 'connect').returns(mockContract as any);
     sandbox
       .stub(DefaultFallbackRoutingIsm__factory, 'connect')

--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -104,16 +104,20 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
     let moduleType: ModuleType | undefined = undefined;
     let derivedIsmConfig: DerivedIsmConfig;
     try {
-      const ism = IInterchainSecurityModule__factory.connect(
-        address,
-        this.provider,
-      );
       this.logger.debug('Deriving IsmConfig:', { address });
 
       // Temporarily turn off SmartProvider logging
       // Provider errors are expected because deriving will call methods that may not exist in the Bytecode
       this.setSmartProviderLogLevel('silent');
-      moduleType = await ism.moduleType();
+      moduleType = await this.probeContractCall<ModuleType>(
+        address,
+        IInterchainSecurityModule__factory.createInterface(),
+        'moduleType',
+      );
+      assert(
+        moduleType !== undefined,
+        'The provided ISM contract might be outdated and not support moduleType()',
+      );
 
       switch (moduleType) {
         case ModuleType.UNUSED:

--- a/typescript/sdk/src/providers/SmartProvider/HyperlaneJsonRpcProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/HyperlaneJsonRpcProvider.ts
@@ -56,16 +56,18 @@ export class HyperlaneJsonRpcProvider
       return this.performGetLogs(params);
     }
 
-    const requestConfig: SmartProviderRequestConfig | undefined =
-      params?.[SMART_PROVIDER_REQUEST_CONFIG];
-    const providerParams =
-      requestConfig === undefined || params == null
-        ? params
-        : Object.fromEntries(
-            Object.entries(params).filter(
-              ([key]) => key !== SMART_PROVIDER_REQUEST_CONFIG,
-            ),
-          );
+    let requestConfig: SmartProviderRequestConfig | undefined;
+    let providerParams = params;
+    if (params != null && typeof params === 'object') {
+      const {
+        [SMART_PROVIDER_REQUEST_CONFIG]: smartProviderRequestConfig,
+        ...rest
+      } = params as Record<PropertyKey, unknown>;
+      requestConfig = smartProviderRequestConfig as
+        | SmartProviderRequestConfig
+        | undefined;
+      providerParams = rest;
+    }
 
     const result = await super.perform(method, providerParams);
     if (

--- a/typescript/sdk/src/providers/SmartProvider/HyperlaneJsonRpcProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/HyperlaneJsonRpcProvider.ts
@@ -12,7 +12,11 @@ import {
   IProviderMethods,
   ProviderMethod,
 } from './ProviderMethods.js';
-import { RpcConfigWithConnectionInfo } from './types.js';
+import {
+  RpcConfigWithConnectionInfo,
+  SMART_PROVIDER_REQUEST_CONFIG,
+  SmartProviderRequestConfig,
+} from './types.js';
 
 const NUM_LOG_BLOCK_RANGES_TO_QUERY = 10;
 const NUM_PARALLEL_LOG_QUERIES = 5;
@@ -52,7 +56,18 @@ export class HyperlaneJsonRpcProvider
       return this.performGetLogs(params);
     }
 
-    const result = await super.perform(method, params);
+    const requestConfig: SmartProviderRequestConfig | undefined =
+      params?.[SMART_PROVIDER_REQUEST_CONFIG];
+    const providerParams =
+      requestConfig === undefined || params == null
+        ? params
+        : Object.fromEntries(
+            Object.entries(params).filter(
+              ([key]) => key !== SMART_PROVIDER_REQUEST_CONFIG,
+            ),
+          );
+
+    const result = await super.perform(method, providerParams);
     if (
       result === '0x' &&
       [
@@ -60,8 +75,11 @@ export class HyperlaneJsonRpcProvider
         ProviderMethod.GetBalance,
         ProviderMethod.GetBlock,
         ProviderMethod.GetBlockNumber,
-      ].includes(method as ProviderMethod)
+      ].includes(method as ProviderMethod) &&
+      !requestConfig?.allowEmptyCallResult
     ) {
+      // Normal reads treat bare 0x as malformed provider output. Probe reads
+      // opt in because selector misses are expected during type detection.
       this.logger.debug(
         `Received 0x result from ${method} for reqId ${reqId}.`,
       );

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.test.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.test.ts
@@ -142,6 +142,39 @@ class RetrySpySmartProvider extends HyperlaneSmartProvider {
   }
 }
 
+class FallbackOverrideSmartProvider extends HyperlaneSmartProvider {
+  public performWithFallbackCallCount = 0;
+  public performWithFallbackForPolicyCallCount = 0;
+
+  constructor() {
+    super({ chainId: 1, name: 'test' }, [{ http: 'http://provider' }], [], {
+      maxRetries: 1,
+      baseRetryDelayMs: 1,
+      fallbackStaggerMs: 1,
+    });
+  }
+
+  public async performReadForTest(): Promise<any> {
+    return this.perform(ProviderMethod.GetBlockNumber, {});
+  }
+
+  public async performProbeForTest(): Promise<string> {
+    return this.probeCall({
+      to: '0x0000000000000000000000000000000000000001',
+    });
+  }
+
+  protected override async performWithFallback(): Promise<any> {
+    this.performWithFallbackCallCount += 1;
+    return 'read-override';
+  }
+
+  protected override async performWithFallbackForPolicy(): Promise<any> {
+    this.performWithFallbackForPolicyCallCount += 1;
+    return 'policy-override';
+  }
+}
+
 class ProviderError extends Error {
   public readonly reason: string;
   public readonly code: string;
@@ -839,6 +872,26 @@ describe('SmartProvider', () => {
       }
 
       expect(threw, 'probeCall should have thrown').to.be.true;
+      expect(smartProvider.performWithFallbackForPolicyCallCount).to.equal(1);
+    });
+
+    it('perform still uses performWithFallback overrides for read requests', async () => {
+      const smartProvider = new FallbackOverrideSmartProvider();
+
+      const result = await smartProvider.performReadForTest();
+
+      expect(result).to.equal('read-override');
+      expect(smartProvider.performWithFallbackCallCount).to.equal(1);
+      expect(smartProvider.performWithFallbackForPolicyCallCount).to.equal(0);
+    });
+
+    it('probe requests still use performWithFallbackForPolicy directly', async () => {
+      const smartProvider = new FallbackOverrideSmartProvider();
+
+      const result = await smartProvider.performProbeForTest();
+
+      expect(result).to.equal('policy-override');
+      expect(smartProvider.performWithFallbackCallCount).to.equal(0);
       expect(smartProvider.performWithFallbackForPolicyCallCount).to.equal(1);
     });
 

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.test.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.test.ts
@@ -146,21 +146,33 @@ class ProviderError extends Error {
   public readonly reason: string;
   public readonly code: string;
   public readonly data?: string;
-  public readonly error?: { error?: { code?: number } };
+  public readonly error?: { error?: { code?: number; data?: unknown } };
 
   constructor(
     message: string,
     code: string,
     data?: string,
-    options?: { jsonRpcErrorCode?: number; hasNestedError?: boolean },
+    options?: {
+      jsonRpcErrorCode?: number;
+      jsonRpcErrorData?: unknown;
+      hasNestedError?: boolean;
+    },
   ) {
     super(message);
     this.reason = message;
     this.code = code;
     this.data = data;
     // Simulate ethers nested error structure for JSON-RPC errors
-    if (options?.jsonRpcErrorCode !== undefined) {
-      this.error = { error: { code: options.jsonRpcErrorCode } };
+    if (
+      options?.jsonRpcErrorCode !== undefined ||
+      options?.jsonRpcErrorData !== undefined
+    ) {
+      this.error = {
+        error: {
+          code: options?.jsonRpcErrorCode,
+          data: options?.jsonRpcErrorData,
+        },
+      };
     } else if (options?.hasNestedError) {
       // Has nested error but no JSON-RPC code (e.g., RPC connection issue)
       this.error = { error: {} };
@@ -517,6 +529,29 @@ describe('SmartProvider', () => {
       expect(e.message).to.equal('execution reverted');
       expect(e.cause).to.equal(error);
     });
+
+    it('treats CALL_EXCEPTION with Tron-style empty-object revert data as permanent (BlockchainError)', () => {
+      const error = new ProviderError(
+        'missing revert data in call exception',
+        EthersError.CALL_EXCEPTION,
+        '0x',
+        {
+          jsonRpcErrorCode: -32000,
+          jsonRpcErrorData: '{}',
+        },
+      );
+      const CombinedError = provider.testGetCombinedProviderError(
+        [error],
+        'Test fallback message',
+      );
+
+      const e: any = new CombinedError();
+
+      expect(e).to.be.instanceOf(BlockchainError);
+      expect(e.isRecoverable).to.equal(false);
+      expect(e.message).to.equal('missing revert data in call exception');
+      expect(e.cause).to.equal(error);
+    });
   });
 
   describe('performWithFallback', () => {
@@ -747,6 +782,34 @@ describe('SmartProvider', () => {
       }
     });
 
+    it('CALL_EXCEPTION with Tron-style empty-object revert data stops trying additional providers', async () => {
+      const tronStyleCallException = new ProviderError(
+        'missing revert data in call exception',
+        EthersError.CALL_EXCEPTION,
+        '0x',
+        {
+          jsonRpcErrorCode: -32000,
+          jsonRpcErrorData: '{}',
+        },
+      );
+
+      const provider1 = MockProvider.error(tronStyleCallException);
+      const provider2 = MockProvider.success('success2');
+      const provider = new TestableSmartProvider([provider1, provider2]);
+
+      try {
+        await provider.simplePerform('getBlockNumber', 1);
+        expect.fail('Should have thrown an error');
+      } catch (e: any) {
+        expect(e).to.be.instanceOf(BlockchainError);
+        expect(e.isRecoverable).to.equal(false);
+        expect(e.message).to.equal('missing revert data in call exception');
+        expect(e.cause).to.equal(tronStyleCallException);
+        expect(provider1.called).to.be.true;
+        expect(provider2.called).to.be.false;
+      }
+    });
+
     it('sendTransaction bypasses retryAsync to prevent duplicate submissions', async () => {
       const smartProvider = new RetrySpySmartProvider();
 
@@ -833,6 +896,32 @@ describe('SmartProvider', () => {
       } catch (e: any) {
         expect(e).to.be.instanceOf(ProbeMissError);
         expect(e.message).to.equal('execution reverted');
+        expect(e.cause).to.equal(probeMiss);
+        expect(provider1.called).to.be.true;
+        expect(provider2.called).to.be.false;
+      }
+    });
+
+    it('probe requests treat Tron-style empty-object CALL_EXCEPTION as probe misses', async () => {
+      const probeMiss = new ProviderError(
+        'missing revert data in call exception',
+        EthersError.CALL_EXCEPTION,
+        '0x',
+        {
+          jsonRpcErrorCode: -32000,
+          jsonRpcErrorData: '{}',
+        },
+      );
+      const provider1 = MockProvider.error(probeMiss);
+      const provider2 = MockProvider.success('success2');
+      const smartProvider = new TestableSmartProvider([provider1, provider2]);
+
+      try {
+        await smartProvider.simpleProbePerform(ProviderMethod.Call, 1);
+        expect.fail('Should have thrown a probe miss');
+      } catch (e: any) {
+        expect(e).to.be.instanceOf(ProbeMissError);
+        expect(e.message).to.equal('missing revert data in call exception');
         expect(e.cause).to.equal(probeMiss);
         expect(provider1.called).to.be.true;
         expect(provider2.called).to.be.false;

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.test.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.test.ts
@@ -8,8 +8,12 @@ import {
 } from './ProviderMethods.js';
 import type { HyperlaneEtherscanProvider } from './HyperlaneEtherscanProvider.js';
 import type { HyperlaneJsonRpcProvider } from './HyperlaneJsonRpcProvider.js';
-import { BlockchainError, HyperlaneSmartProvider } from './SmartProvider.js';
-import { ProviderStatus } from './types.js';
+import {
+  BlockchainError,
+  HyperlaneSmartProvider,
+  ProbeMissError,
+} from './SmartProvider.js';
+import { ProviderStatus, SmartProviderRequestKind } from './types.js';
 
 // Dummy provider for testing
 class MockProvider extends providers.BaseProvider implements IProviderMethods {
@@ -84,8 +88,9 @@ class TestableSmartProvider extends HyperlaneSmartProvider {
   public testGetCombinedProviderError(
     errors: any[],
     fallbackMsg: string,
+    requestKind = SmartProviderRequestKind.Read,
   ): new () => Error {
-    return this.getCombinedProviderError(errors, fallbackMsg);
+    return this.getCombinedProviderError(errors, fallbackMsg, requestKind);
   }
 
   public async simplePerform(method: string, reqId: number): Promise<any> {
@@ -96,10 +101,20 @@ class TestableSmartProvider extends HyperlaneSmartProvider {
       reqId,
     );
   }
+
+  public async simpleProbePerform(method: string, reqId: number): Promise<any> {
+    return this.performWithFallbackForPolicy(
+      method,
+      {},
+      this.mockProviders as any,
+      reqId,
+      this.getProbeRequestPolicy(),
+    );
+  }
 }
 
 class RetrySpySmartProvider extends HyperlaneSmartProvider {
-  public performWithFallbackCallCount = 0;
+  public performWithFallbackForPolicyCallCount = 0;
 
   constructor() {
     super({ chainId: 1, name: 'test' }, [{ http: 'http://provider' }], [], {
@@ -109,13 +124,20 @@ class RetrySpySmartProvider extends HyperlaneSmartProvider {
     });
   }
 
-  protected override async performWithFallback(
+  public async probeCallForTest(): Promise<string> {
+    return this.probeCall({
+      to: '0x0000000000000000000000000000000000000001',
+    });
+  }
+
+  protected override async performWithFallbackForPolicy(
     _method: string,
     _params: { [name: string]: any },
     _providers: Array<HyperlaneEtherscanProvider | HyperlaneJsonRpcProvider>,
     _reqId: number,
+    _policy: unknown,
   ): Promise<any> {
-    this.performWithFallbackCallCount += 1;
+    this.performWithFallbackForPolicyCallCount += 1;
     throw new ProviderError('connection refused', EthersError.SERVER_ERROR);
   }
 }
@@ -367,6 +389,27 @@ describe('SmartProvider', () => {
       expect(e.cause).to.equal(error);
     });
 
+    it('throws ProbeMissError for deterministic probe misses', () => {
+      const error = new ProviderError(
+        'execution reverted',
+        EthersError.CALL_EXCEPTION,
+        '0x08c379a0',
+      );
+      const CombinedError = provider.testGetCombinedProviderError(
+        [error],
+        'Test fallback message',
+        SmartProviderRequestKind.Probe,
+      );
+
+      const e: any = new CombinedError();
+
+      expect(e).to.be.instanceOf(ProbeMissError);
+      expect(e).to.not.be.instanceOf(BlockchainError);
+      expect(e.isRecoverable).to.equal(false);
+      expect(e.message).to.equal('execution reverted');
+      expect(e.cause).to.equal(error);
+    });
+
     const mixedErrorTestCases = [
       {
         name: 'SERVER_ERROR',
@@ -449,7 +492,6 @@ describe('SmartProvider', () => {
       // With nested error but no code 3, this should NOT be a BlockchainError
       expect(e).to.be.instanceOf(Error);
       expect(e).to.not.be.instanceOf(BlockchainError);
-      // Falls through to generic error handler (unhandled case)
       expect(e.message).to.equal('Test fallback message');
     });
 
@@ -720,8 +762,21 @@ describe('SmartProvider', () => {
         threw = true;
       }
       expect(threw, 'perform should have thrown').to.be.true;
-      // performWithFallback should be called exactly once (no retryAsync wrapping)
-      expect(smartProvider.performWithFallbackCallCount).to.equal(1);
+      expect(smartProvider.performWithFallbackForPolicyCallCount).to.equal(1);
+    });
+
+    it('probeCall bypasses retryAsync to fail fast on transport errors', async () => {
+      const smartProvider = new RetrySpySmartProvider();
+
+      let threw = false;
+      try {
+        await smartProvider.probeCallForTest();
+      } catch {
+        threw = true;
+      }
+
+      expect(threw, 'probeCall should have thrown').to.be.true;
+      expect(smartProvider.performWithFallbackForPolicyCallCount).to.equal(1);
     });
 
     it('sendTransaction waits for provider instead of racing against timeout', async () => {
@@ -740,6 +795,69 @@ describe('SmartProvider', () => {
       expect(provider1.called).to.be.true;
       expect(provider1.callCount).to.equal(1);
       expect(provider2.called).to.be.false;
+    });
+
+    it('probe requests fall through on server errors and succeed on the next provider', async () => {
+      const serverError = new ProviderError(
+        'connection refused',
+        EthersError.SERVER_ERROR,
+      );
+
+      const provider1 = MockProvider.error(serverError);
+      const provider2 = MockProvider.success('success2');
+      const smartProvider = new TestableSmartProvider([provider1, provider2]);
+
+      const result = await smartProvider.simpleProbePerform(
+        ProviderMethod.Call,
+        1,
+      );
+
+      expect(result).to.deep.equal('success2');
+      expect(provider1.called).to.be.true;
+      expect(provider2.called).to.be.true;
+    });
+
+    it('probe misses stop fallback and return ProbeMissError', async () => {
+      const probeMiss = new ProviderError(
+        'execution reverted',
+        EthersError.CALL_EXCEPTION,
+        '0x08c379a0',
+      );
+      const provider1 = MockProvider.error(probeMiss);
+      const provider2 = MockProvider.success('success2');
+      const smartProvider = new TestableSmartProvider([provider1, provider2]);
+
+      try {
+        await smartProvider.simpleProbePerform(ProviderMethod.Call, 1);
+        expect.fail('Should have thrown a probe miss');
+      } catch (e: any) {
+        expect(e).to.be.instanceOf(ProbeMissError);
+        expect(e.message).to.equal('execution reverted');
+        expect(e.cause).to.equal(probeMiss);
+        expect(provider1.called).to.be.true;
+        expect(provider2.called).to.be.false;
+      }
+    });
+
+    it('probe requests still accept an earlier slow success after a later probe miss', async () => {
+      const slowSuccess = MockProvider.success('success1', 120);
+      const probeMiss = MockProvider.error(
+        new ProviderError(
+          'call revert exception',
+          EthersError.CALL_EXCEPTION,
+          '0x',
+        ),
+      );
+      const smartProvider = new TestableSmartProvider([slowSuccess, probeMiss]);
+
+      const result = await smartProvider.simpleProbePerform(
+        ProviderMethod.Call,
+        1,
+      );
+
+      expect(result).to.equal('success1');
+      expect(slowSuccess.called).to.be.true;
+      expect(probeMiss.called).to.be.true;
     });
   });
 });

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.test.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.test.ts
@@ -179,7 +179,10 @@ class ProviderError extends Error {
   public readonly reason: string;
   public readonly code: string;
   public readonly data?: string;
-  public readonly error?: { error?: { code?: number; data?: unknown } };
+  public readonly error?: {
+    error?: { code?: number; data?: unknown; message?: string };
+    body?: string;
+  };
 
   constructor(
     message: string,
@@ -188,6 +191,8 @@ class ProviderError extends Error {
     options?: {
       jsonRpcErrorCode?: number;
       jsonRpcErrorData?: unknown;
+      jsonRpcErrorMessage?: string;
+      jsonRpcBody?: string;
       hasNestedError?: boolean;
     },
   ) {
@@ -204,7 +209,9 @@ class ProviderError extends Error {
         error: {
           code: options?.jsonRpcErrorCode,
           data: options?.jsonRpcErrorData,
+          message: options?.jsonRpcErrorMessage,
         },
+        body: options?.jsonRpcBody,
       };
     } else if (options?.hasNestedError) {
       // Has nested error but no JSON-RPC code (e.g., RPC connection issue)
@@ -571,6 +578,29 @@ describe('SmartProvider', () => {
         {
           jsonRpcErrorCode: -32000,
           jsonRpcErrorData: '{}',
+        },
+      );
+      const CombinedError = provider.testGetCombinedProviderError(
+        [error],
+        'Test fallback message',
+      );
+
+      const e: any = new CombinedError();
+
+      expect(e).to.be.instanceOf(BlockchainError);
+      expect(e.isRecoverable).to.equal(false);
+      expect(e.message).to.equal('missing revert data in call exception');
+      expect(e.cause).to.equal(error);
+    });
+
+    it('treats CALL_EXCEPTION with JSON-RPC -32000 execution reverted as permanent (BlockchainError)', () => {
+      const error = new ProviderError(
+        'missing revert data in call exception',
+        EthersError.CALL_EXCEPTION,
+        '0x',
+        {
+          jsonRpcErrorCode: -32000,
+          jsonRpcErrorMessage: 'execution reverted',
         },
       );
       const CombinedError = provider.testGetCombinedProviderError(
@@ -963,6 +993,32 @@ describe('SmartProvider', () => {
         {
           jsonRpcErrorCode: -32000,
           jsonRpcErrorData: '{}',
+        },
+      );
+      const provider1 = MockProvider.error(probeMiss);
+      const provider2 = MockProvider.success('success2');
+      const smartProvider = new TestableSmartProvider([provider1, provider2]);
+
+      try {
+        await smartProvider.simpleProbePerform(ProviderMethod.Call, 1);
+        expect.fail('Should have thrown a probe miss');
+      } catch (e: any) {
+        expect(e).to.be.instanceOf(ProbeMissError);
+        expect(e.message).to.equal('missing revert data in call exception');
+        expect(e.cause).to.equal(probeMiss);
+        expect(provider1.called).to.be.true;
+        expect(provider2.called).to.be.false;
+      }
+    });
+
+    it('probe requests treat JSON-RPC -32000 execution reverted CALL_EXCEPTION as probe misses', async () => {
+      const probeMiss = new ProviderError(
+        'missing revert data in call exception',
+        EthersError.CALL_EXCEPTION,
+        '0x',
+        {
+          jsonRpcErrorCode: -32000,
+          jsonRpcErrorMessage: 'execution reverted',
         },
       );
       const provider1 = MockProvider.error(probeMiss);

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.test.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.test.ts
@@ -166,7 +166,7 @@ class FallbackOverrideSmartProvider extends HyperlaneSmartProvider {
 
   protected override async performWithFallback(): Promise<any> {
     this.performWithFallbackCallCount += 1;
-    return 'read-override';
+    return 'fallback-override';
   }
 
   protected override async performWithFallbackForPolicy(): Promise<any> {
@@ -524,6 +524,23 @@ describe('SmartProvider', () => {
       // Without nested error, this IS a BlockchainError (decode failure is permanent)
       expect(e).to.be.instanceOf(BlockchainError);
       expect(e.isRecoverable).to.equal(false);
+    });
+
+    it('does not treat CALL_EXCEPTION without revert data or nested error as permanent', () => {
+      const error = new ProviderError(
+        'call revert exception',
+        EthersError.CALL_EXCEPTION,
+      );
+      const CombinedError = provider.testGetCombinedProviderError(
+        [error],
+        'Test fallback message',
+      );
+
+      const e: any = new CombinedError();
+
+      expect(e).to.be.instanceOf(Error);
+      expect(e).to.not.be.instanceOf(BlockchainError);
+      expect(e.message).to.equal('Test fallback message');
     });
 
     it('treats CALL_EXCEPTION with nested RPC error (not code 3) as recoverable', () => {
@@ -910,19 +927,19 @@ describe('SmartProvider', () => {
 
       const result = await smartProvider.performReadForTest();
 
-      expect(result).to.equal('read-override');
+      expect(result).to.equal('fallback-override');
       expect(smartProvider.performWithFallbackCallCount).to.equal(1);
       expect(smartProvider.performWithFallbackForPolicyCallCount).to.equal(0);
     });
 
-    it('probe requests still use performWithFallbackForPolicy directly', async () => {
+    it('probe requests use performWithFallback overrides too', async () => {
       const smartProvider = new FallbackOverrideSmartProvider();
 
       const result = await smartProvider.performProbeForTest();
 
-      expect(result).to.equal('policy-override');
-      expect(smartProvider.performWithFallbackCallCount).to.equal(0);
-      expect(smartProvider.performWithFallbackForPolicyCallCount).to.equal(1);
+      expect(result).to.equal('fallback-override');
+      expect(smartProvider.performWithFallbackCallCount).to.equal(1);
+      expect(smartProvider.performWithFallbackForPolicyCallCount).to.equal(0);
     });
 
     it('sendTransaction waits for provider instead of racing against timeout', async () => {

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -131,6 +131,24 @@ function getJsonRpcErrorData(error: any): unknown {
   return error?.error?.error?.data ?? error?.error?.data;
 }
 
+function getJsonRpcErrorMessage(error: any): string | undefined {
+  const nestedMessage = error?.error?.error?.message ?? error?.error?.message;
+  if (nestedMessage) {
+    return nestedMessage;
+  }
+
+  const body = error?.error?.body;
+  if (typeof body !== 'string') {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(body)?.error?.message;
+  } catch {
+    return undefined;
+  }
+}
+
 function isEmptyObjectLikeJsonRpcData(data: unknown): boolean {
   if (typeof data === 'string') {
     return data.trim() === '{}';
@@ -160,6 +178,15 @@ export function isDeterministicCallException(error: any): boolean {
   if (
     jsonRpcErrorCode === -32000 &&
     isEmptyObjectLikeJsonRpcData(getJsonRpcErrorData(error))
+  ) {
+    return true;
+  }
+
+  // Some RPCs surface selector misses as -32000 "execution reverted" without
+  // revert data. For probe requests, that is still a deterministic miss.
+  if (
+    jsonRpcErrorCode === -32000 &&
+    getJsonRpcErrorMessage(error)?.toLowerCase().includes('execution reverted')
   ) {
     return true;
   }

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -162,6 +162,10 @@ function isEmptyObjectLikeJsonRpcData(data: unknown): boolean {
   );
 }
 
+function isEmptyReturnDecodeFailure(error: any): boolean {
+  return error?.data === '0x' && !error?.error;
+}
+
 export function isDeterministicCallException(error: any): boolean {
   const hasRevertData = !!error?.data && error.data !== '0x';
   if (hasRevertData) {
@@ -191,7 +195,7 @@ export function isDeterministicCallException(error: any): boolean {
     return true;
   }
 
-  return !error?.error;
+  return isEmptyReturnDecodeFailure(error);
 }
 
 function classifyProviderError(
@@ -489,15 +493,13 @@ export class HyperlaneSmartProvider
     const reqId = this.requestCount;
 
     const performWithFallback = () =>
-      policy.kind === SmartProviderRequestKind.Read
-        ? this.performWithFallback(method, params, supportedProviders, reqId)
-        : this.performWithFallbackForPolicy(
-            method,
-            params,
-            supportedProviders,
-            reqId,
-            policy,
-          );
+      this.performWithFallback(
+        method,
+        params,
+        supportedProviders,
+        reqId,
+        policy,
+      );
 
     // SendTransaction must not be retried - it could cause duplicate submissions
     if (method === ProviderMethod.SendTransaction) {
@@ -555,13 +557,14 @@ export class HyperlaneSmartProvider
     params: { [name: string]: any },
     providers: Array<HyperlaneEtherscanProvider | HyperlaneJsonRpcProvider>,
     reqId: number,
+    policy = this.getReadRequestPolicy(),
   ): Promise<any> {
     return this.performWithFallbackForPolicy(
       method,
       params,
       providers,
       reqId,
-      this.getReadRequestPolicy(),
+      policy,
     );
   }
 
@@ -835,25 +838,19 @@ export class HyperlaneSmartProvider
       };
     }
 
-    const probeMissError = errors.find(
-      (e) => classifyProviderError(e, requestKind) === 'probe_miss',
-    );
+    const classifiedErrors = new Map<ProviderErrorClassification, any>();
+    for (const error of errors) {
+      const classification = classifyProviderError(error, requestKind);
+      if (!classifiedErrors.has(classification)) {
+        classifiedErrors.set(classification, error);
+      }
+    }
 
-    const rpcBlockchainError = errors.find(
-      (e) => classifyProviderError(e, requestKind) === 'permanent',
-    );
-
-    const rpcServerError = errors.find(
-      (e) => classifyProviderError(e, requestKind) === 'server',
-    );
-
-    const rpcTransientError = errors.find(
-      (e) => classifyProviderError(e, requestKind) === 'transient',
-    );
-
-    const timedOutError = errors.find(
-      (e) => e.status === ProviderStatus.Timeout,
-    );
+    const probeMissError = classifiedErrors.get('probe_miss');
+    const rpcBlockchainError = classifiedErrors.get('permanent');
+    const rpcServerError = classifiedErrors.get('server');
+    const rpcTransientError = classifiedErrors.get('transient');
+    const timedOutError = classifiedErrors.get('timeout');
 
     if (probeMissError) {
       return class extends ProbeMissError {

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -127,6 +127,23 @@ function getJsonRpcErrorCode(error: any): number | undefined {
   return error?.error?.error?.code ?? error?.error?.code;
 }
 
+function getJsonRpcErrorData(error: any): unknown {
+  return error?.error?.error?.data ?? error?.error?.data;
+}
+
+function isEmptyObjectLikeJsonRpcData(data: unknown): boolean {
+  if (typeof data === 'string') {
+    return data.trim() === '{}';
+  }
+
+  return (
+    data != null &&
+    typeof data === 'object' &&
+    !Array.isArray(data) &&
+    Object.keys(data).length === 0
+  );
+}
+
 export function isDeterministicCallException(error: any): boolean {
   const hasRevertData = !!error?.data && error.data !== '0x';
   if (hasRevertData) {
@@ -135,6 +152,15 @@ export function isDeterministicCallException(error: any): boolean {
 
   const jsonRpcErrorCode = getJsonRpcErrorCode(error);
   if (jsonRpcErrorCode === 3) {
+    return true;
+  }
+
+  // Some Tron RPCs surface selector misses as CALL_EXCEPTION with nested
+  // JSON-RPC -32000 and an empty object payload instead of revert data.
+  if (
+    jsonRpcErrorCode === -32000 &&
+    isEmptyObjectLikeJsonRpcData(getJsonRpcErrorData(error))
+  ) {
     return true;
   }
 

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -26,6 +26,9 @@ import {
   ProviderStatus,
   ProviderTimeoutResult,
   RpcConfigWithConnectionInfo,
+  SMART_PROVIDER_REQUEST_CONFIG,
+  SmartProviderRequestConfig,
+  SmartProviderRequestKind,
   SmartProviderOptions,
 } from './types.js';
 import { parseCustomRpcHeaders } from '../../utils/provider.js';
@@ -99,10 +102,99 @@ const DEFAULT_MAX_RETRIES = 1;
 const DEFAULT_BASE_RETRY_DELAY_MS = 250; // 0.25 seconds
 const DEFAULT_STAGGER_DELAY_MS = 1000; // 1 seconds
 const DEFAULT_PHASE2_WAIT_MULTIPLIER = 20;
+const INVALID_PROVIDER_RESPONSE_ERROR_MSG = 'Invalid response from provider';
 
 type HyperlaneProvider = HyperlaneEtherscanProvider | HyperlaneJsonRpcProvider;
 
+interface SmartProviderRequestPolicy {
+  kind: SmartProviderRequestKind;
+  allowEmptyCallResult?: boolean;
+  attempts: number;
+  baseRetryDelayMs: number;
+  fallbackStaggerMs: number;
+  phase2WaitMultiplier: number;
+}
+
+type ProviderErrorClassification =
+  | 'permanent'
+  | 'probe_miss'
+  | 'server'
+  | 'timeout'
+  | 'transient'
+  | 'unknown';
+
+function getJsonRpcErrorCode(error: any): number | undefined {
+  return error?.error?.error?.code ?? error?.error?.code;
+}
+
+export function isDeterministicCallException(error: any): boolean {
+  const hasRevertData = !!error?.data && error.data !== '0x';
+  if (hasRevertData) {
+    return true;
+  }
+
+  const jsonRpcErrorCode = getJsonRpcErrorCode(error);
+  if (jsonRpcErrorCode === 3) {
+    return true;
+  }
+
+  return !error?.error;
+}
+
+function classifyProviderError(
+  error: any,
+  requestKind: SmartProviderRequestKind,
+): ProviderErrorClassification {
+  if (error?.status === ProviderStatus.Timeout) {
+    return 'timeout';
+  }
+
+  if (error?.message === INVALID_PROVIDER_RESPONSE_ERROR_MSG) {
+    return 'transient';
+  }
+
+  const errorCode = error?.code;
+  if (RPC_SERVER_ERRORS.includes(errorCode)) {
+    return 'server';
+  }
+
+  if (errorCode === EthersError.CALL_EXCEPTION) {
+    if (isDeterministicCallException(error)) {
+      return requestKind === SmartProviderRequestKind.Probe
+        ? 'probe_miss'
+        : 'permanent';
+    }
+
+    return 'transient';
+  }
+
+  if (
+    requestKind === SmartProviderRequestKind.Probe &&
+    errorCode === EthersError.UNPREDICTABLE_GAS_LIMIT
+  ) {
+    return 'probe_miss';
+  }
+
+  if (RPC_BLOCKCHAIN_ERRORS.includes(errorCode)) {
+    return 'permanent';
+  }
+
+  return 'unknown';
+}
+
 export class BlockchainError extends Error {
+  public readonly isRecoverable = false;
+
+  constructor(message: string, options?: { cause?: Error }) {
+    super(message, options);
+  }
+
+  static {
+    this.prototype.name = this.name;
+  }
+}
+
+export class ProbeMissError extends Error {
   public readonly isRecoverable = false;
 
   constructor(message: string, options?: { cause?: Error }) {
@@ -271,6 +363,66 @@ export class HyperlaneSmartProvider
   }
 
   async perform(method: string, params: { [name: string]: any }): Promise<any> {
+    return this.performWithRequestPolicy(
+      method,
+      params,
+      this.getReadRequestPolicy(),
+    );
+  }
+
+  async probeCall(
+    transaction: providers.TransactionRequest,
+    blockTag: providers.BlockTag = 'latest',
+  ): Promise<string> {
+    return this.performWithRequestPolicy(
+      ProviderMethod.Call,
+      { transaction, blockTag },
+      this.getProbeRequestPolicy(),
+    );
+  }
+
+  async probeEstimateGas(
+    transaction: providers.TransactionRequest,
+  ): Promise<BigNumber> {
+    return BigNumber.from(
+      await this.performWithRequestPolicy(
+        ProviderMethod.EstimateGas,
+        { transaction },
+        this.getProbeRequestPolicy(),
+      ),
+    );
+  }
+
+  protected getReadRequestPolicy(): SmartProviderRequestPolicy {
+    return {
+      kind: SmartProviderRequestKind.Read,
+      attempts: this.options?.maxRetries ?? DEFAULT_MAX_RETRIES,
+      baseRetryDelayMs:
+        this.options?.baseRetryDelayMs ?? DEFAULT_BASE_RETRY_DELAY_MS,
+      fallbackStaggerMs:
+        this.options?.fallbackStaggerMs ?? DEFAULT_STAGGER_DELAY_MS,
+      phase2WaitMultiplier: DEFAULT_PHASE2_WAIT_MULTIPLIER,
+    };
+  }
+
+  protected getProbeRequestPolicy(): SmartProviderRequestPolicy {
+    return {
+      kind: SmartProviderRequestKind.Probe,
+      allowEmptyCallResult: true,
+      attempts: 1,
+      baseRetryDelayMs:
+        this.options?.baseRetryDelayMs ?? DEFAULT_BASE_RETRY_DELAY_MS,
+      fallbackStaggerMs:
+        this.options?.fallbackStaggerMs ?? DEFAULT_STAGGER_DELAY_MS,
+      phase2WaitMultiplier: DEFAULT_PHASE2_WAIT_MULTIPLIER,
+    };
+  }
+
+  protected async performWithRequestPolicy(
+    method: string,
+    params: { [name: string]: any },
+    policy: SmartProviderRequestPolicy,
+  ): Promise<any> {
     const allProviders = [...this.explorerProviders, ...this.rpcProviders];
     if (!allProviders.length) throw new Error('No providers available');
 
@@ -285,18 +437,26 @@ export class HyperlaneSmartProvider
 
     // SendTransaction must not be retried - it could cause duplicate submissions
     if (method === ProviderMethod.SendTransaction) {
-      return this.performWithFallback(
+      return this.performWithFallbackForPolicy(
         method,
         params,
         supportedProviders,
         reqId,
+        policy,
       );
     }
 
     return retryAsync(
-      () => this.performWithFallback(method, params, supportedProviders, reqId),
-      this.options?.maxRetries || DEFAULT_MAX_RETRIES,
-      this.options?.baseRetryDelayMs || DEFAULT_BASE_RETRY_DELAY_MS,
+      () =>
+        this.performWithFallbackForPolicy(
+          method,
+          params,
+          supportedProviders,
+          reqId,
+          policy,
+        ),
+      policy.attempts,
+      policy.baseRetryDelayMs,
     );
   }
 
@@ -345,6 +505,22 @@ export class HyperlaneSmartProvider
     providers: Array<HyperlaneEtherscanProvider | HyperlaneJsonRpcProvider>,
     reqId: number,
   ): Promise<any> {
+    return this.performWithFallbackForPolicy(
+      method,
+      params,
+      providers,
+      reqId,
+      this.getReadRequestPolicy(),
+    );
+  }
+
+  protected async performWithFallbackForPolicy(
+    method: string,
+    params: { [name: string]: any },
+    providers: Array<HyperlaneEtherscanProvider | HyperlaneJsonRpcProvider>,
+    reqId: number,
+    policy: SmartProviderRequestPolicy,
+  ): Promise<any> {
     let pIndex = 0;
     const providerResultPromises: Promise<ProviderPerformResult>[] = [];
     const providerResultErrors: unknown[] = [];
@@ -371,6 +547,7 @@ export class HyperlaneSmartProvider
         method,
         params,
         reqId,
+        policy,
       );
       // SendTransaction must not race against a timeout - we must wait for the
       // RPC response to avoid losing track of a submitted transaction
@@ -378,9 +555,7 @@ export class HyperlaneSmartProvider
       if (method === ProviderMethod.SendTransaction) {
         result = await resultPromise;
       } else {
-        const timeoutPromise = timeoutResult(
-          this.options?.fallbackStaggerMs || DEFAULT_STAGGER_DELAY_MS,
-        );
+        const timeoutPromise = timeoutResult(policy.fallbackStaggerMs);
         result = await Promise.race([resultPromise, timeoutPromise]);
       }
 
@@ -416,47 +591,24 @@ export class HyperlaneSmartProvider
             break providerLoop;
           }
 
-          // If this is a blockchain error, stop trying additional providers as it's a permanent failure
-          // For CALL_EXCEPTION, we need to distinguish:
-          // 1. Real revert with data - permanent (has revert data like "0x08c379a0...")
-          // 2. Real revert without data - permanent (has nested error.error.code === 3 from JSON-RPC)
-          // 3. Empty return data decode failure - permanent (no nested error, ethers failed to decode "0x")
-          // 4. Actual RPC issue - transient (has nested error but not code 3)
           const errorCode = (result.error as any)?.code;
-          const revertData = (result.error as any)?.data;
-          const hasRevertData = !!revertData && revertData !== '0x';
-          const nestedError = (result.error as any)?.error;
-          // JSON-RPC error code 3 definitively indicates execution revert (EIP-1474)
-          // Check both nested levels as ethers wraps errors in error.error.code structure
-          const jsonRpcErrorCode =
-            nestedError?.error?.code ?? nestedError?.code;
-          const isJsonRpcRevert = jsonRpcErrorCode === 3;
-          // No nested error means ethers failed to decode empty return data - this is permanent
-          const isEmptyReturnDecodeFailure =
-            errorCode === EthersError.CALL_EXCEPTION &&
-            !hasRevertData &&
-            !nestedError;
-          const isCallExceptionWithoutData =
-            errorCode === EthersError.CALL_EXCEPTION &&
-            !hasRevertData &&
-            !isJsonRpcRevert &&
-            !isEmptyReturnDecodeFailure;
-          const isPermanentBlockchainError =
-            RPC_BLOCKCHAIN_ERRORS.includes(errorCode) &&
-            !isCallExceptionWithoutData;
-
-          if (isPermanentBlockchainError) {
+          const errorClassification = classifyProviderError(
+            result.error,
+            policy.kind,
+          );
+          if (
+            errorClassification === 'permanent' ||
+            errorClassification === 'probe_miss'
+          ) {
+            const stopReason =
+              errorClassification === 'probe_miss'
+                ? 'a deterministic probe miss'
+                : 'a permanent failure';
             this.logger.debug(
               { ...providerMetadata },
-              `${errorCode} detected - stopping provider fallback as this is a permanent failure`,
+              `${errorCode} detected - stopping provider fallback as this is ${stopReason}`,
             );
             break providerLoop;
-          }
-          if (isCallExceptionWithoutData) {
-            this.logger.debug(
-              { ...providerMetadata },
-              `${errorCode} without revert data detected - treating as transient RPC error, will retry`,
-            );
           }
           this.logger.debug(
             {
@@ -486,14 +638,15 @@ export class HyperlaneSmartProvider
         `All providers failed on chain ${
           this.network.name
         } for method ${method} and params ${JSON.stringify(params, null, 2)}`,
+        policy.kind,
       );
       throw new CombinedError();
     }
 
     // Wait for at least one provider to succeed or all to fail/timeout
     const timeoutPromise = timeoutResult(
-      this.options?.fallbackStaggerMs || DEFAULT_STAGGER_DELAY_MS,
-      DEFAULT_PHASE2_WAIT_MULTIPLIER,
+      policy.fallbackStaggerMs,
+      policy.phase2WaitMultiplier,
     );
     const resultPromise = this.waitForProviderSuccess(providerResultPromises);
     const result = await Promise.race([resultPromise, timeoutPromise]);
@@ -505,6 +658,7 @@ export class HyperlaneSmartProvider
         const CombinedError = this.getCombinedProviderError(
           [result, ...providerResultErrors],
           `All providers timed out on chain ${this.network.name} for method ${method}`,
+          policy.kind,
         );
         throw new CombinedError();
       }
@@ -514,6 +668,7 @@ export class HyperlaneSmartProvider
           `All providers failed on chain ${
             this.network.name
           } for method ${method} and params ${JSON.stringify(params, null, 2)}`,
+          policy.kind,
         );
         throw new CombinedError();
       }
@@ -529,13 +684,18 @@ export class HyperlaneSmartProvider
     method: string,
     params: any,
     reqId: number,
+    policy: SmartProviderRequestPolicy,
   ): Promise<ProviderPerformResult> {
     try {
       if (this.options?.debug)
         this.logger.debug(
           `Provider #${pIndex} performing method ${method} for reqId ${reqId}`,
         );
-      const result = await provider.perform(method, params, reqId);
+      const result = await provider.perform(
+        method,
+        this.getProviderParams(provider, params, policy),
+        reqId,
+      );
       return { status: ProviderStatus.Success, value: result };
     } catch (error) {
       if (this.options?.debug)
@@ -545,6 +705,35 @@ export class HyperlaneSmartProvider
         );
       return { status: ProviderStatus.Error, error };
     }
+  }
+
+  protected getProviderParams(
+    provider: HyperlaneProvider,
+    params: any,
+    policy: SmartProviderRequestPolicy,
+  ): any {
+    if (
+      !(provider instanceof HyperlaneJsonRpcProvider) ||
+      params == null ||
+      typeof params !== 'object'
+    ) {
+      return params;
+    }
+
+    if (
+      policy.kind !== SmartProviderRequestKind.Probe &&
+      !policy.allowEmptyCallResult
+    ) {
+      return params;
+    }
+
+    return {
+      ...params,
+      [SMART_PROVIDER_REQUEST_CONFIG]: {
+        kind: policy.kind,
+        allowEmptyCallResult: policy.allowEmptyCallResult,
+      } satisfies SmartProviderRequestConfig,
+    };
   }
 
   // Returns the first success from a list a promises, or an error if all fail
@@ -584,6 +773,7 @@ export class HyperlaneSmartProvider
   protected getCombinedProviderError(
     errors: any[],
     fallbackMsg: string,
+    requestKind = SmartProviderRequestKind.Read,
   ): new () => Error {
     this.logger.debug(fallbackMsg);
     if (errors.length === 0) {
@@ -594,33 +784,35 @@ export class HyperlaneSmartProvider
       };
     }
 
-    // Find blockchain errors, but exclude CALL_EXCEPTION without revert data (likely RPC issues)
-    // Note: ethers sets data to "0x" when there's no actual revert data
-    // However, JSON-RPC error code 3 definitively indicates a contract revert (EIP-1474)
-    // Also, no nested error means ethers failed to decode empty return data - also permanent
-    const rpcBlockchainError = errors.find((e) => {
-      if (!RPC_BLOCKCHAIN_ERRORS.includes(e.code)) return false;
-      if (e.code !== EthersError.CALL_EXCEPTION) return true;
-      // For CALL_EXCEPTION, check if it's a real revert or decode failure
-      const hasRevertData = !!e.data && e.data !== '0x';
-      // Check for JSON-RPC error code 3 (nested in error.error.code by ethers)
-      // Also check shallower level as error nesting varies
-      const jsonRpcErrorCode = e.error?.error?.code ?? e.error?.code;
-      const isJsonRpcRevert = jsonRpcErrorCode === 3;
-      // No nested error means ethers failed to decode empty return data - permanent
-      const isEmptyReturnDecodeFailure = !e.error;
-      return hasRevertData || isJsonRpcRevert || isEmptyReturnDecodeFailure;
-    });
+    const probeMissError = errors.find(
+      (e) => classifyProviderError(e, requestKind) === 'probe_miss',
+    );
 
-    const rpcServerError = errors.find((e) =>
-      RPC_SERVER_ERRORS.includes(e.code),
+    const rpcBlockchainError = errors.find(
+      (e) => classifyProviderError(e, requestKind) === 'permanent',
+    );
+
+    const rpcServerError = errors.find(
+      (e) => classifyProviderError(e, requestKind) === 'server',
+    );
+
+    const rpcTransientError = errors.find(
+      (e) => classifyProviderError(e, requestKind) === 'transient',
     );
 
     const timedOutError = errors.find(
       (e) => e.status === ProviderStatus.Timeout,
     );
 
-    if (rpcBlockchainError) {
+    if (probeMissError) {
+      return class extends ProbeMissError {
+        constructor() {
+          super(probeMissError.reason ?? probeMissError.code ?? fallbackMsg, {
+            cause: probeMissError,
+          });
+        }
+      };
+    } else if (rpcBlockchainError) {
       // All blockchain errors are non-retryable and take priority
       return class extends BlockchainError {
         constructor() {
@@ -637,6 +829,14 @@ export class HyperlaneSmartProvider
               getSmartProviderErrorMessage(rpcServerError.code),
             { cause: rpcServerError },
           );
+        }
+      };
+    } else if (rpcTransientError) {
+      return class extends Error {
+        constructor() {
+          super(fallbackMsg, {
+            cause: rpcTransientError,
+          });
         }
       };
     } else if (timedOutError) {

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -559,6 +559,7 @@ export class HyperlaneSmartProvider
     reqId: number,
     policy = this.getReadRequestPolicy(),
   ): Promise<any> {
+    // Keep this thin wrapper as the protected override seam for subclasses.
     return this.performWithFallbackForPolicy(
       method,
       params,

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -461,26 +461,24 @@ export class HyperlaneSmartProvider
     this.requestCount += 1;
     const reqId = this.requestCount;
 
+    const performWithFallback = () =>
+      policy.kind === SmartProviderRequestKind.Read
+        ? this.performWithFallback(method, params, supportedProviders, reqId)
+        : this.performWithFallbackForPolicy(
+            method,
+            params,
+            supportedProviders,
+            reqId,
+            policy,
+          );
+
     // SendTransaction must not be retried - it could cause duplicate submissions
     if (method === ProviderMethod.SendTransaction) {
-      return this.performWithFallbackForPolicy(
-        method,
-        params,
-        supportedProviders,
-        reqId,
-        policy,
-      );
+      return performWithFallback();
     }
 
     return retryAsync(
-      () =>
-        this.performWithFallbackForPolicy(
-          method,
-          params,
-          supportedProviders,
-          reqId,
-          policy,
-        ),
+      performWithFallback,
       policy.attempts,
       policy.baseRetryDelayMs,
     );

--- a/typescript/sdk/src/providers/SmartProvider/types.ts
+++ b/typescript/sdk/src/providers/SmartProvider/types.ts
@@ -54,3 +54,16 @@ export interface SmartProviderOptions extends ProviderRetryOptions {
   fallbackStaggerMs?: number;
   debug?: boolean;
 }
+
+export const SMART_PROVIDER_REQUEST_CONFIG =
+  '__hyperlaneSmartProviderRequestConfig';
+
+export enum SmartProviderRequestKind {
+  Read = 'read',
+  Probe = 'probe',
+}
+
+export interface SmartProviderRequestConfig {
+  kind: SmartProviderRequestKind;
+  allowEmptyCallResult?: boolean;
+}

--- a/typescript/sdk/src/providers/SmartProvider/types.ts
+++ b/typescript/sdk/src/providers/SmartProvider/types.ts
@@ -55,8 +55,9 @@ export interface SmartProviderOptions extends ProviderRetryOptions {
   debug?: boolean;
 }
 
-export const SMART_PROVIDER_REQUEST_CONFIG =
-  '__hyperlaneSmartProviderRequestConfig';
+export const SMART_PROVIDER_REQUEST_CONFIG = Symbol(
+  'hyperlaneSmartProviderRequestConfig',
+);
 
 export enum SmartProviderRequestKind {
   Read = 'read',

--- a/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
@@ -1571,7 +1571,7 @@ describe('EvmWarpRouteReader', async () => {
       });
     });
 
-    it('should fail when modern version contract claims v10.0.0+ but is missing token() method', async () => {
+    it('should fail when modern version contract claims v10.0.0+ but probe misses token()', async () => {
       const config: WarpRouteDeployConfigMailboxRequired = {
         [chain]: {
           type: TokenType.native,
@@ -1583,35 +1583,61 @@ describe('EvmWarpRouteReader', async () => {
       const warpRoute = await deployer.deploy(config);
       const warpAddress = warpRoute[chain].native.address;
 
-      // Stub package version to claim it's modern (10.0.0+)
-      const mockPackageVersioned = {
-        PACKAGE_VERSION: sinon.stub().resolves(TOKEN_FEE_CONTRACT_VERSION),
-      };
       const fetchPackageVersionStub = sinon
-        .stub(PackageVersioned__factory, 'connect')
-        .returns(mockPackageVersioned as any);
+        .stub(evmERC20WarpRouteReader, 'fetchPackageVersion')
+        .resolves(TOKEN_FEE_CONTRACT_VERSION);
+      const probeContractCallStub = sinon
+        .stub(evmERC20WarpRouteReader as any, 'probeContractCall')
+        .resolves(undefined);
 
-      // Stub token() to throw error (simulating missing method)
-      const mockTokenRouter = {
-        token: sinon.stub().rejects(new Error('token() method not found')),
-      };
-      const tokenRouterStub = sinon
-        .stub(TokenRouter__factory, 'connect')
-        .returns(mockTokenRouter as any);
-
-      let thrownError: Error | undefined;
       try {
         await evmERC20WarpRouteReader.deriveTokenType(warpAddress);
+        expect.fail('Expected deriveTokenType to throw');
       } catch (error) {
-        thrownError = error as Error;
+        expect(String(error)).to.include(
+          `Error deriving token type for token at address "${warpAddress}"`,
+        );
+      } finally {
+        fetchPackageVersionStub.restore();
+        probeContractCallStub.restore();
       }
-      expect(thrownError?.message).to.include(
-        `Error deriving token type for token at address "${warpAddress}"`,
-      );
+    });
 
-      // Cleanup
-      fetchPackageVersionStub.restore();
-      tokenRouterStub.restore();
+    it('should surface transport failures during legacy native probing', async () => {
+      const config: WarpRouteDeployConfigMailboxRequired = {
+        [chain]: {
+          type: TokenType.native,
+          hook: await mailbox.defaultHook(),
+          ...baseConfig,
+        },
+      };
+
+      const warpRoute = await deployer.deploy(config);
+      const warpAddress = warpRoute[chain].native.address;
+
+      const transportError = Object.assign(new Error('connection refused'), {
+        code: 'SERVER_ERROR',
+      });
+      const fetchPackageVersionStub = sinon
+        .stub(evmERC20WarpRouteReader, 'fetchPackageVersion')
+        .resolves('9.0.0');
+      const probeContractCallStub = sinon
+        .stub(evmERC20WarpRouteReader as any, 'probeContractCall')
+        .resolves(undefined);
+      const probeContractEstimateGasStub = sinon
+        .stub(evmERC20WarpRouteReader as any, 'probeContractEstimateGas')
+        .rejects(transportError);
+
+      try {
+        await evmERC20WarpRouteReader.deriveTokenType(warpAddress);
+        expect.fail('Expected deriveTokenType to throw');
+      } catch (error) {
+        expect(String(error)).to.include('connection refused');
+      } finally {
+        fetchPackageVersionStub.restore();
+        probeContractCallStub.restore();
+        probeContractEstimateGasStub.restore();
+      }
     });
   });
 });

--- a/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
@@ -1088,6 +1088,31 @@ describe('EvmWarpRouteReader', async () => {
     fetchPackageVersionStub.restore();
   });
 
+  it('caches unknown package version fallbacks after non-call errors', async () => {
+    const packageVersion = sinon
+      .stub()
+      .rejects(new Error('temporary rpc failure'));
+    const fetchPackageVersionStub = sinon
+      .stub(PackageVersioned__factory, 'connect')
+      .returns({
+        PACKAGE_VERSION: packageVersion,
+      } as any);
+
+    const address = '0x1000000000000000000000000000000000000001';
+    const [first, second] = await Promise.all([
+      evmERC20WarpRouteReader.fetchPackageVersion(address),
+      evmERC20WarpRouteReader.fetchPackageVersion(address),
+    ]);
+    const third = await evmERC20WarpRouteReader.fetchPackageVersion(address);
+
+    expect(first).to.equal('0.0.0');
+    expect(second).to.equal('0.0.0');
+    expect(third).to.equal('0.0.0');
+    expect(packageVersion.callCount).to.equal(1);
+
+    fetchPackageVersionStub.restore();
+  });
+
   it('derives multicollateral config with scale from the router', async () => {
     const routerAddress = '0x1000000000000000000000000000000000000001';
     const wrappedTokenAddress = '0x2000000000000000000000000000000000000002';

--- a/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
@@ -1061,6 +1061,33 @@ describe('EvmWarpRouteReader', async () => {
     }
   });
 
+  it('caches package version lookups during a single warp route derivation', async () => {
+    const config: WarpRouteDeployConfigMailboxRequired = {
+      [chain]: {
+        ...baseConfig,
+        type: TokenType.collateral,
+        token: token.address,
+        hook: await mailbox.defaultHook(),
+      },
+    };
+
+    const warpRoute = await deployer.deploy(config);
+    const packageVersion = sinon.stub().resolves('12.0.0');
+    const fetchPackageVersionStub = sinon
+      .stub(PackageVersioned__factory, 'connect')
+      .returns({
+        PACKAGE_VERSION: packageVersion,
+      } as any);
+
+    await evmERC20WarpRouteReader.deriveWarpRouteConfig(
+      warpRoute[chain].collateral.address,
+    );
+
+    expect(packageVersion.callCount).to.equal(1);
+
+    fetchPackageVersionStub.restore();
+  });
+
   it('derives multicollateral config with scale from the router', async () => {
     const routerAddress = '0x1000000000000000000000000000000000000001';
     const wrappedTokenAddress = '0x2000000000000000000000000000000000000002';

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -115,6 +115,10 @@ export class EvmWarpRouteReader extends EvmRouterReader {
   private readonly depositAddressDomainConfigsCache = new Map<
     Address,
     DepositAddressDomainConfigs
+  protected readonly packageVersionCache = new Map<string, string>();
+  protected readonly packageVersionInflight = new Map<
+    string,
+    Promise<string>
   >();
 
   // Using null instead of undefined to force
@@ -197,28 +201,31 @@ export class EvmWarpRouteReader extends EvmRouterReader {
   ): Promise<DerivedTokenRouterConfig> {
     // Derive the config type
     const type = await this.deriveTokenType(warpRouteAddress);
-    const tokenConfig = await this.fetchTokenConfig(type, warpRouteAddress);
     const isDepositAddressBridge = type === TokenType.collateralDepositAddress;
-    // OFT and deposit-address bridges don't expose Router/MailboxClient interfaces.
     const isOft = type === TokenType.collateralOft;
     const usesSentinelRouterConfig = isDepositAddressBridge || isOft;
-    const routerConfig = usesSentinelRouterConfig
-      ? {
-          mailbox: constants.AddressZero,
-          owner: await Ownable__factory.connect(
-            warpRouteAddress,
-            this.provider,
-          ).owner(),
-          hook: constants.AddressZero,
-          interchainSecurityModule: constants.AddressZero,
-          remoteRouters: {},
-        }
-      : await this.readRouterConfig(warpRouteAddress);
-    // if the token has not been deployed as a proxy do not derive the config
-    // inevm warp routes are an example
-    const proxyAdmin = (await isProxy(this.provider, warpRouteAddress))
-      ? await this.fetchProxyAdminConfig(warpRouteAddress)
-      : undefined;
+    const tokenConfigPromise = this.fetchTokenConfig(type, warpRouteAddress);
+    const routerConfigPromise = usesSentinelRouterConfig
+      ? Ownable__factory.connect(warpRouteAddress, this.provider)
+          .owner()
+          .then((owner) => ({
+            mailbox: constants.AddressZero,
+            owner,
+            hook: constants.AddressZero,
+            interchainSecurityModule: constants.AddressZero,
+            remoteRouters: {},
+          }))
+      : this.readRouterConfig(warpRouteAddress);
+    const proxyAdminPromise = (async () =>
+      (await isProxy(this.provider, warpRouteAddress))
+        ? this.fetchProxyAdminConfig(warpRouteAddress)
+        : undefined)();
+    const [tokenConfig, routerConfig, proxyAdmin] = await Promise.all([
+      tokenConfigPromise,
+      routerConfigPromise,
+      proxyAdminPromise,
+    ]);
+
     const ccrEnrolledDomains: number[] = [];
     if (
       isCrossCollateralTokenConfig(tokenConfig) &&
@@ -228,6 +235,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
         ccrEnrolledDomains.push(Number(domain));
       }
     }
+
     // OFT contracts don't have destination gas config
     // For CrossCollateralRouter tokens, include domains from crossCollateralRouters so
     // fetchDestinationGas also reads gas for MC-only enrolled domains.
@@ -1405,24 +1413,42 @@ export class EvmWarpRouteReader extends EvmRouterReader {
   }
 
   async fetchPackageVersion(address: Address) {
-    const contractWithVersion = PackageVersioned__factory.connect(
-      address,
-      this.provider,
-    );
+    const cacheKey = address.toLowerCase();
+    const cachedVersion = this.packageVersionCache.get(cacheKey);
+    if (cachedVersion) return cachedVersion;
 
-    try {
-      return await contractWithVersion.PACKAGE_VERSION();
-    } catch (err: any) {
-      if (err.cause?.code && err.cause?.code === 'CALL_EXCEPTION') {
-        // PACKAGE_VERSION was introduced in @hyperlane-xyz/core@5.4.0
-        // See https://github.com/hyperlane-xyz/hyperlane-monorepo/releases/tag/%40hyperlane-xyz%2Fcore%405.4.0
-        // The real version of a contract without this function is below 5.4.0
-        return '5.3.9';
-      } else {
-        this.logger.error(`Error when fetching package version ${err}`);
-        return '0.0.0';
+    const inFlight = this.packageVersionInflight.get(cacheKey);
+    if (inFlight) return inFlight;
+
+    const versionPromise = (async () => {
+      const contractWithVersion = PackageVersioned__factory.connect(
+        address,
+        this.provider,
+      );
+
+      try {
+        const version = await contractWithVersion.PACKAGE_VERSION();
+        this.packageVersionCache.set(cacheKey, version);
+        return version;
+      } catch (err: any) {
+        if (err.cause?.code && err.cause?.code === 'CALL_EXCEPTION') {
+          // PACKAGE_VERSION was introduced in @hyperlane-xyz/core@5.4.0
+          // See https://github.com/hyperlane-xyz/hyperlane-monorepo/releases/tag/%40hyperlane-xyz%2Fcore%405.4.0
+          // The real version of a contract without this function is below 5.4.0
+          const legacyVersion = '5.3.9';
+          this.packageVersionCache.set(cacheKey, legacyVersion);
+          return legacyVersion;
+        } else {
+          this.logger.error(`Error when fetching package version ${err}`);
+          return '0.0.0';
+        }
+      } finally {
+        this.packageVersionInflight.delete(cacheKey);
       }
-    }
+    })();
+
+    this.packageVersionInflight.set(cacheKey, versionPromise);
+    return versionPromise;
   }
 
   async fetchProxyAdminConfig(

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -688,11 +688,16 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       return tokenAddress !== undefined && isZeroishAddress(tokenAddress);
     }
 
-    const gasEstimate = await this.probeContractEstimateGas({
-      from: NON_ZERO_SENDER_ADDRESS,
-      to: warpRouteAddress,
-      value: BigNumber.from(0),
-    });
+    const gasEstimate = await this.probeContractEstimateGas(
+      await this.multiProvider.prepareTx(
+        this.chain,
+        {
+          to: warpRouteAddress,
+          value: BigNumber.from(0),
+        },
+        NON_ZERO_SENDER_ADDRESS,
+      ),
+    );
 
     return gasEstimate !== undefined;
   }

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -1445,7 +1445,9 @@ export class EvmWarpRouteReader extends EvmRouterReader {
           return legacyVersion;
         } else {
           this.logger.error(`Error when fetching package version ${err}`);
-          return '0.0.0';
+          const unknownVersion = '0.0.0';
+          this.packageVersionCache.set(cacheKey, unknownVersion);
+          return unknownVersion;
         }
       } finally {
         this.packageVersionInflight.delete(cacheKey);

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -563,108 +563,79 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     this.setSmartProviderLogLevel('silent');
 
     try {
-      // First, try checking token specific methods
+      // Use probe helpers so expected ABI misses do not enter SmartProvider's
+      // normal retry path during type inference.
       for (const [tokenType, { factory, method }] of Object.entries(
         contractTypes,
       )) {
-        try {
-          const warpRoute = factory.connect(warpRouteAddress, this.provider);
-          const result = await warpRoute[method]();
-          if (tokenType === TokenType.collateralDepositAddress) {
-            this.depositAddressDomainConfigsCache.set(warpRouteAddress, result);
-          }
-          if (tokenType === TokenType.collateral) {
-            const wrappedToken = await warpRoute.wrappedToken();
-            try {
-              const xerc20 = IXERC20__factory.connect(
-                wrappedToken,
-                this.provider,
-              );
-              await xerc20['mintingCurrentLimitOf(address)'](warpRouteAddress);
-              return TokenType.XERC20;
-            } catch (error) {
-              this.logger.debug(
-                `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.XERC20}`,
-                error,
-              );
-            }
-
-            try {
-              const fiatToken = IFiatToken__factory.connect(
-                wrappedToken,
-                this.provider,
-              );
-
-              // Simulate minting tokens from the warp route contract
-              await fiatToken.callStatic.mint(NON_ZERO_SENDER_ADDRESS, 1, {
-                from: warpRouteAddress,
-              });
-
-              return TokenType.collateralFiat;
-            } catch (error) {
-              this.logger.debug(
-                `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.collateralFiat}`,
-                error,
-              );
-            }
-
-            try {
-              const maybeEverclearTokenBridge =
-                EverclearTokenBridge__factory.connect(
-                  warpRouteAddress,
-                  this.provider,
-                );
-
-              await maybeEverclearTokenBridge.callStatic.everclearAdapter();
-
-              let everclearTokenType: TokenType = TokenType.collateralEverclear;
-              try {
-                // if simulating an ETH transfer works this should be the WETH contract
-                await this.provider.estimateGas({
-                  from: NON_ZERO_SENDER_ADDRESS,
-                  to: wrappedToken,
-                  data: IWETH__factory.createInterface().encodeFunctionData(
-                    'deposit',
-                  ),
-                  value: 0,
-                });
-
-                everclearTokenType = TokenType.ethEverclear;
-              } catch (error) {
-                this.logger.debug(
-                  `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.collateralEverclear}`,
-                  error,
-                );
-              }
-
-              return everclearTokenType;
-            } catch (error) {
-              this.logger.debug(
-                `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.collateralEverclear}`,
-                error,
-              );
-            }
-
-            try {
-              const crossCollateralRouter =
-                CrossCollateralRouter__factory.connect(
-                  warpRouteAddress,
-                  this.provider,
-                );
-              await crossCollateralRouter.getCrossCollateralRouters(0);
-              return TokenType.crossCollateral;
-            } catch (error) {
-              this.logger.debug(
-                `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.crossCollateral}`,
-                error,
-              );
-            }
-          }
-
-          return tokenType as TokenType;
-        } catch {
+        const probeResult = await this.probeContractCall(
+          warpRouteAddress,
+          factory.createInterface(),
+          method,
+        );
+        if (probeResult === undefined) {
           continue;
         }
+
+        if (tokenType === TokenType.collateral) {
+          const wrappedToken = probeResult as Address;
+
+          const xerc20Limit = await this.probeContractCall(
+            wrappedToken,
+            IXERC20__factory.createInterface(),
+            'mintingCurrentLimitOf(address)',
+            [warpRouteAddress],
+          );
+          if (xerc20Limit !== undefined) {
+            return TokenType.XERC20;
+          }
+
+          const fiatMintProbe = await this.probeContractCall(
+            wrappedToken,
+            IFiatToken__factory.createInterface(),
+            'mint',
+            [NON_ZERO_SENDER_ADDRESS, 1],
+            { from: warpRouteAddress },
+          );
+          if (fiatMintProbe !== undefined) {
+            return TokenType.collateralFiat;
+          }
+
+          const everclearAdapter = await this.probeContractCall(
+            warpRouteAddress,
+            EverclearTokenBridge__factory.createInterface(),
+            'everclearAdapter',
+          );
+          if (everclearAdapter !== undefined) {
+            let everclearTokenType: TokenType = TokenType.collateralEverclear;
+            const depositGas = await this.probeContractEstimateGas({
+              from: NON_ZERO_SENDER_ADDRESS,
+              to: wrappedToken,
+              data: IWETH__factory.createInterface().encodeFunctionData(
+                'deposit',
+              ),
+              value: 0,
+            });
+
+            if (depositGas !== undefined) {
+              everclearTokenType = TokenType.ethEverclear;
+            }
+
+            return everclearTokenType;
+          }
+
+          const crossCollateralRouters = await this.probeContractCall(
+            warpRouteAddress,
+            CrossCollateralRouter__factory.createInterface(),
+            'getCrossCollateralRouters',
+            [0],
+          );
+          if (crossCollateralRouters !== undefined) {
+            return TokenType.crossCollateral;
+          }
+        }
+
+        return tokenType as TokenType;
       }
 
       const packageVersion = await this.fetchPackageVersion(warpRouteAddress);
@@ -699,70 +670,48 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     warpRouteAddress: Address,
     hasTokenFeeInterface: boolean,
   ): Promise<boolean> {
-    try {
-      if (hasTokenFeeInterface) {
-        const tokenRouter = TokenRouter__factory.connect(
-          warpRouteAddress,
-          this.provider,
-        );
-        const tokenAddress = await tokenRouter.token();
-
-        // Native token returns address(0)
-        return isZeroishAddress(tokenAddress);
-      } else {
-        // Check native using estimateGas to send 0 wei. Success implies that the Warp Route has a receive() function
-        await this.multiProvider.estimateGas(
-          this.chain,
-          {
-            to: warpRouteAddress,
-            value: BigNumber.from(0),
-          },
-          NON_ZERO_SENDER_ADDRESS, // Use non-zero address as signer is not provided for read commands
-        );
-        return true;
-      }
-    } catch (e) {
-      this.logger.debug(
-        `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.native}`,
-        e,
+    if (hasTokenFeeInterface) {
+      const tokenAddress = await this.probeContractCall<Address>(
+        warpRouteAddress,
+        TokenRouter__factory.createInterface(),
+        'token',
       );
 
-      return false;
+      return tokenAddress !== undefined && isZeroishAddress(tokenAddress);
     }
+
+    const gasEstimate = await this.probeContractEstimateGas({
+      from: NON_ZERO_SENDER_ADDRESS,
+      to: warpRouteAddress,
+      value: BigNumber.from(0),
+    });
+
+    return gasEstimate !== undefined;
   }
 
   private async isSyntheticWarpToken(
     warpRouteAddress: Address,
     hasTokenFeeInterface: boolean,
   ): Promise<boolean> {
-    try {
-      if (hasTokenFeeInterface) {
-        const tokenRouter = TokenRouter__factory.connect(
-          warpRouteAddress,
-          this.provider,
-        );
-        const tokenAddress = await tokenRouter.token();
-
-        // HypERC20.token() returns address(this)
-        return eqAddress(tokenAddress, warpRouteAddress);
-      } else {
-        const tokenRouter = HypERC20__factory.connect(
-          warpRouteAddress,
-          this.provider,
-        );
-
-        await tokenRouter.decimals();
-
-        return true;
-      }
-    } catch (error) {
-      this.logger.debug(
-        `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.synthetic}`,
-        error,
+    if (hasTokenFeeInterface) {
+      const tokenAddress = await this.probeContractCall<Address>(
+        warpRouteAddress,
+        TokenRouter__factory.createInterface(),
+        'token',
       );
 
-      return false;
+      return (
+        tokenAddress !== undefined && eqAddress(tokenAddress, warpRouteAddress)
+      );
     }
+
+    const decimals = await this.probeContractCall(
+      warpRouteAddress,
+      HypERC20__factory.createInterface(),
+      'decimals',
+    );
+
+    return decimals !== undefined;
   }
 
   async fetchXERC20Config(

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -115,6 +115,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
   private readonly depositAddressDomainConfigsCache = new Map<
     Address,
     DepositAddressDomainConfigs
+  >();
   protected readonly packageVersionCache = new Map<string, string>();
   protected readonly packageVersionInflight = new Map<
     string,

--- a/typescript/sdk/src/utils/HyperlaneReader.test.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.test.ts
@@ -24,9 +24,12 @@ class ReaderHarness extends HyperlaneReader {
     );
   }
 
-  async testProbeEstimateGas(): Promise<BigNumber | undefined> {
+  async testProbeEstimateGas(
+    overrides: providers.TransactionRequest = {},
+  ): Promise<BigNumber | undefined> {
     return this.probeContractEstimateGas({
       to: TEST_ADDRESS,
+      ...overrides,
     });
   }
 }
@@ -221,5 +224,24 @@ describe('HyperlaneReader', () => {
 
     expect(provider.lastCallTransaction?.type).to.equal(0);
     expect(provider.lastEstimateGasTransaction?.type).to.equal(0);
+  });
+
+  it('strips gas pricing fields before probe gas estimation', async () => {
+    const provider = new ProbeReaderProvider();
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    await reader.testProbeEstimateGas({
+      gasLimit: BigNumber.from(100000),
+      gasPrice: BigNumber.from(1),
+      maxPriorityFeePerGas: BigNumber.from(2),
+      maxFeePerGas: BigNumber.from(3),
+    });
+
+    expect(provider.lastEstimateGasTransaction?.gasLimit).to.be.undefined;
+    expect(provider.lastEstimateGasTransaction?.gasPrice).to.be.undefined;
+    expect(provider.lastEstimateGasTransaction?.maxPriorityFeePerGas).to.be
+      .undefined;
+    expect(provider.lastEstimateGasTransaction?.maxFeePerGas).to.be.undefined;
   });
 });

--- a/typescript/sdk/src/utils/HyperlaneReader.test.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.test.ts
@@ -32,6 +32,9 @@ class ReaderHarness extends HyperlaneReader {
 }
 
 class ProbeReaderProvider extends providers.BaseProvider {
+  public lastCallTransaction?: providers.TransactionRequest;
+  public lastEstimateGasTransaction?: providers.TransactionRequest;
+
   constructor(
     private readonly options: {
       callResult?: string;
@@ -43,9 +46,10 @@ class ProbeReaderProvider extends providers.BaseProvider {
   }
 
   async call(
-    _transaction: providers.TransactionRequest,
+    transaction: providers.TransactionRequest,
     _blockTag?: providers.BlockTag,
   ): Promise<string> {
+    this.lastCallTransaction = transaction;
     if (this.options.callError) {
       throw this.options.callError;
     }
@@ -54,8 +58,9 @@ class ProbeReaderProvider extends providers.BaseProvider {
   }
 
   async estimateGas(
-    _transaction: providers.TransactionRequest,
+    transaction: providers.TransactionRequest,
   ): Promise<BigNumber> {
+    this.lastEstimateGasTransaction = transaction;
     if (this.options.estimateGasError) {
       throw this.options.estimateGasError;
     }
@@ -192,5 +197,29 @@ describe('HyperlaneReader', () => {
     const result = await reader.testProbeEstimateGas();
 
     expect(result).to.be.undefined;
+  });
+
+  it('applies chain transaction overrides to probe calls and estimates', async () => {
+    multiProvider = new MultiProvider({
+      ...multiProvider.metadata,
+      [TestChainName.test1]: {
+        ...multiProvider.metadata[TestChainName.test1],
+        transactionOverrides: { type: 0 },
+      },
+    });
+    const provider = new ProbeReaderProvider({
+      callResult:
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    await Promise.all([
+      reader.testProbeContractCall(),
+      reader.testProbeEstimateGas(),
+    ]);
+
+    expect(provider.lastCallTransaction?.type).to.equal(0);
+    expect(provider.lastEstimateGasTransaction?.type).to.equal(0);
   });
 });

--- a/typescript/sdk/src/utils/HyperlaneReader.test.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.test.ts
@@ -11,16 +11,21 @@ import {
 import { HyperlaneReader } from './HyperlaneReader.js';
 
 const TEST_ADDRESS = '0x0000000000000000000000000000000000000001';
+const TEST_ADDRESS_2 = '0x0000000000000000000000000000000000000002';
 const TEST_INTERFACE = new utils.Interface([
   'function probe() view returns (address)',
 ]);
 
 class ReaderHarness extends HyperlaneReader {
-  async testProbeContractCall(): Promise<string | undefined> {
+  async testProbeContractCall(
+    txOverrides: providers.TransactionRequest = {},
+  ): Promise<string | undefined> {
     return this.probeContractCall<string>(
       TEST_ADDRESS,
       TEST_INTERFACE,
       'probe',
+      [],
+      txOverrides,
     );
   }
 
@@ -207,7 +212,7 @@ describe('HyperlaneReader', () => {
       ...multiProvider.metadata,
       [TestChainName.test1]: {
         ...multiProvider.metadata[TestChainName.test1],
-        transactionOverrides: { type: 0 },
+        transactionOverrides: { type: 0, from: TEST_ADDRESS_2 },
       },
     });
     const provider = new ProbeReaderProvider({
@@ -218,12 +223,14 @@ describe('HyperlaneReader', () => {
     const reader = new ReaderHarness(multiProvider, TestChainName.test1);
 
     await Promise.all([
-      reader.testProbeContractCall(),
-      reader.testProbeEstimateGas(),
+      reader.testProbeContractCall({ from: TEST_ADDRESS }),
+      reader.testProbeEstimateGas({ from: TEST_ADDRESS }),
     ]);
 
     expect(provider.lastCallTransaction?.type).to.equal(0);
+    expect(provider.lastCallTransaction?.from).to.equal(TEST_ADDRESS);
     expect(provider.lastEstimateGasTransaction?.type).to.equal(0);
+    expect(provider.lastEstimateGasTransaction?.from).to.equal(TEST_ADDRESS);
   });
 
   it('strips gas pricing fields before probe gas estimation', async () => {

--- a/typescript/sdk/src/utils/HyperlaneReader.test.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.test.ts
@@ -103,6 +103,30 @@ describe('HyperlaneReader', () => {
     expect(result).to.be.undefined;
   });
 
+  it('returns undefined on Tron-style deterministic probe misses from regular providers', async () => {
+    const provider = new ProbeReaderProvider({
+      callError: Object.assign(
+        new Error('missing revert data in call exception'),
+        {
+          code: EthersError.CALL_EXCEPTION,
+          data: '0x',
+          error: {
+            error: {
+              code: -32000,
+              data: '{}',
+            },
+          },
+        },
+      ),
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const result = await reader.testProbeContractCall();
+
+    expect(result).to.be.undefined;
+  });
+
   it('returns undefined on ProbeMissError from smart providers', async () => {
     multiProvider.setProvider(
       TestChainName.test1,

--- a/typescript/sdk/src/utils/HyperlaneReader.test.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.test.ts
@@ -34,6 +34,7 @@ class ReaderHarness extends HyperlaneReader {
 class ProbeReaderProvider extends providers.BaseProvider {
   constructor(
     private readonly options: {
+      callResult?: string;
       callError?: Error;
       estimateGasError?: Error;
     } = {},
@@ -49,7 +50,7 @@ class ProbeReaderProvider extends providers.BaseProvider {
       throw this.options.callError;
     }
 
-    return '0x';
+    return this.options.callResult ?? '0x';
   }
 
   async estimateGas(
@@ -118,6 +119,22 @@ describe('HyperlaneReader', () => {
           },
         },
       ),
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const result = await reader.testProbeContractCall();
+
+    expect(result).to.be.undefined;
+  });
+
+  it('returns undefined when decoding probe results surfaces revert data as CALL_EXCEPTION', async () => {
+    const provider = new ProbeReaderProvider({
+      callResult:
+        '0x08c379a000000000000000000000000000000000000000000000000000000000' +
+        '0000002000000000000000000000000000000000000000000000000000000000' +
+        '0000002146696174546f6b656e3a2063616c6c6572206973206e6f742061206d' +
+        '696e746572000000000000000000000000000000000000000000000000000000',
     });
     multiProvider.setProvider(TestChainName.test1, provider);
     const reader = new ReaderHarness(multiProvider, TestChainName.test1);

--- a/typescript/sdk/src/utils/HyperlaneReader.test.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.test.ts
@@ -1,0 +1,155 @@
+import { expect } from 'chai';
+import { BigNumber, errors as EthersError, providers, utils } from 'ethers';
+
+import { TestChainName } from '../consts/testChains.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+import {
+  HyperlaneSmartProvider,
+  ProbeMissError,
+} from '../providers/SmartProvider/SmartProvider.js';
+
+import { HyperlaneReader } from './HyperlaneReader.js';
+
+const TEST_ADDRESS = '0x0000000000000000000000000000000000000001';
+const TEST_INTERFACE = new utils.Interface([
+  'function probe() view returns (address)',
+]);
+
+class ReaderHarness extends HyperlaneReader {
+  async testProbeContractCall(): Promise<string | undefined> {
+    return this.probeContractCall<string>(
+      TEST_ADDRESS,
+      TEST_INTERFACE,
+      'probe',
+    );
+  }
+
+  async testProbeEstimateGas(): Promise<BigNumber | undefined> {
+    return this.probeContractEstimateGas({
+      to: TEST_ADDRESS,
+    });
+  }
+}
+
+class ProbeReaderProvider extends providers.BaseProvider {
+  constructor(
+    private readonly options: {
+      callError?: Error;
+      estimateGasError?: Error;
+    } = {},
+  ) {
+    super({ name: 'test', chainId: 1 });
+  }
+
+  async call(
+    _transaction: providers.TransactionRequest,
+    _blockTag?: providers.BlockTag,
+  ): Promise<string> {
+    if (this.options.callError) {
+      throw this.options.callError;
+    }
+
+    return '0x';
+  }
+
+  async estimateGas(
+    _transaction: providers.TransactionRequest,
+  ): Promise<BigNumber> {
+    if (this.options.estimateGasError) {
+      throw this.options.estimateGasError;
+    }
+
+    return BigNumber.from(1);
+  }
+
+  async detectNetwork() {
+    return { name: 'test', chainId: 1 };
+  }
+}
+
+class ProbeMissSmartProvider extends HyperlaneSmartProvider {
+  constructor() {
+    super({ chainId: 1, name: 'test' }, [{ http: 'http://provider' }], []);
+  }
+
+  async probeCall(): Promise<string> {
+    throw new ProbeMissError('probe miss');
+  }
+
+  async probeEstimateGas(): Promise<BigNumber> {
+    throw new ProbeMissError('probe miss');
+  }
+}
+
+describe('HyperlaneReader', () => {
+  let multiProvider: MultiProvider;
+
+  beforeEach(() => {
+    multiProvider = MultiProvider.createTestMultiProvider();
+  });
+
+  it('returns undefined on deterministic probe misses from regular providers', async () => {
+    const provider = new ProbeReaderProvider({
+      callError: Object.assign(new Error('call revert exception'), {
+        code: EthersError.CALL_EXCEPTION,
+        data: '0x',
+      }),
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const result = await reader.testProbeContractCall();
+
+    expect(result).to.be.undefined;
+  });
+
+  it('returns undefined on ProbeMissError from smart providers', async () => {
+    multiProvider.setProvider(
+      TestChainName.test1,
+      new ProbeMissSmartProvider(),
+    );
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const [callResult, gasResult] = await Promise.all([
+      reader.testProbeContractCall(),
+      reader.testProbeEstimateGas(),
+    ]);
+
+    expect(callResult).to.be.undefined;
+    expect(gasResult).to.be.undefined;
+  });
+
+  it('surfaces transport failures during probe calls', async () => {
+    const provider = new ProbeReaderProvider({
+      callError: Object.assign(new Error('connection refused'), {
+        code: EthersError.SERVER_ERROR,
+      }),
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    try {
+      await reader.testProbeContractCall();
+      expect.fail('Expected probe call to throw');
+    } catch (error) {
+      expect(String(error)).to.include('connection refused');
+    }
+  });
+
+  it('returns undefined on deterministic estimateGas misses', async () => {
+    const provider = new ProbeReaderProvider({
+      estimateGasError: Object.assign(
+        new Error('cannot estimate gas; transaction may fail'),
+        {
+          code: EthersError.UNPREDICTABLE_GAS_LIMIT,
+        },
+      ),
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const result = await reader.testProbeEstimateGas();
+
+    expect(result).to.be.undefined;
+  });
+});

--- a/typescript/sdk/src/utils/HyperlaneReader.test.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.test.ts
@@ -29,6 +29,16 @@ class ReaderHarness extends HyperlaneReader {
     );
   }
 
+  async testProbeContractCallWithInterface(
+    contractInterface: utils.Interface,
+  ): Promise<string | undefined> {
+    return this.probeContractCall<string>(
+      TEST_ADDRESS,
+      contractInterface,
+      'probe',
+    );
+  }
+
   async testProbeEstimateGas(
     overrides: providers.TransactionRequest = {},
   ): Promise<BigNumber | undefined> {
@@ -153,6 +163,31 @@ describe('HyperlaneReader', () => {
     const reader = new ReaderHarness(multiProvider, TestChainName.test1);
 
     const result = await reader.testProbeContractCall();
+
+    expect(result).to.be.undefined;
+  });
+
+  it('returns undefined when decoding probe results hits BUFFER_OVERRUN', async () => {
+    const provider = new ProbeReaderProvider({
+      callResult:
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+    const interfaceWithBufferOverrun = Object.assign(
+      Object.create(TEST_INTERFACE),
+      {
+        decodeFunctionResult: () => {
+          throw Object.assign(new Error('data out-of-bounds'), {
+            code: EthersError.BUFFER_OVERRUN,
+          });
+        },
+      },
+    ) as utils.Interface;
+
+    const result = await reader.testProbeContractCallWithInterface(
+      interfaceWithBufferOverrun,
+    );
 
     expect(result).to.be.undefined;
   });

--- a/typescript/sdk/src/utils/HyperlaneReader.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.ts
@@ -86,7 +86,10 @@ export class HyperlaneReader {
       const decoded = contractInterface.decodeFunctionResult(method, result);
       return (decoded.length === 1 ? decoded[0] : decoded) as T;
     } catch (error) {
-      if ((error as any)?.code === EthersError.INVALID_ARGUMENT) {
+      if (
+        (error as any)?.code === EthersError.INVALID_ARGUMENT ||
+        this.isProbeMissError(error)
+      ) {
         return undefined;
       }
 

--- a/typescript/sdk/src/utils/HyperlaneReader.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.ts
@@ -1,8 +1,12 @@
-import { providers } from 'ethers';
+import { BigNumber, errors as EthersError, providers, utils } from 'ethers';
 import { LevelWithSilentOrString } from 'pino';
 
 import { MultiProvider } from '../providers/MultiProvider.js';
-import { HyperlaneSmartProvider } from '../providers/SmartProvider/SmartProvider.js';
+import {
+  HyperlaneSmartProvider,
+  ProbeMissError,
+  isDeterministicCallException,
+} from '../providers/SmartProvider/SmartProvider.js';
 import { ChainNameOrId } from '../types.js';
 
 export class HyperlaneReader {
@@ -24,5 +28,111 @@ export class HyperlaneReader {
     if (this.provider instanceof HyperlaneSmartProvider) {
       this.provider.setLogLevel(level);
     }
+  }
+
+  protected async probeCall(
+    transaction: providers.TransactionRequest,
+    blockTag: providers.BlockTag = 'latest',
+  ): Promise<string> {
+    if (this.provider instanceof HyperlaneSmartProvider) {
+      return this.provider.probeCall(transaction, blockTag);
+    }
+
+    return this.provider.call(transaction, blockTag);
+  }
+
+  protected async probeEstimateGas(
+    transaction: providers.TransactionRequest,
+  ): Promise<BigNumber> {
+    if (this.provider instanceof HyperlaneSmartProvider) {
+      return this.provider.probeEstimateGas(transaction);
+    }
+
+    return this.provider.estimateGas(transaction);
+  }
+
+  protected async probeContractCall<T>(
+    address: string,
+    contractInterface: utils.Interface,
+    method: string,
+    args: unknown[] = [],
+    txOverrides: providers.TransactionRequest = {},
+    blockTag: providers.BlockTag = 'latest',
+  ): Promise<T | undefined> {
+    let result: string;
+
+    try {
+      result = await this.probeCall(
+        {
+          ...txOverrides,
+          to: address,
+          data: contractInterface.encodeFunctionData(method, args),
+        },
+        blockTag,
+      );
+    } catch (error) {
+      if (this.isProbeMissError(error)) {
+        return undefined;
+      }
+
+      throw error;
+    }
+
+    if (result === '0x') {
+      return undefined;
+    }
+
+    try {
+      const decoded = contractInterface.decodeFunctionResult(method, result);
+      return (decoded.length === 1 ? decoded[0] : decoded) as T;
+    } catch (error) {
+      if ((error as any)?.code === EthersError.INVALID_ARGUMENT) {
+        return undefined;
+      }
+
+      throw error;
+    }
+  }
+
+  protected async probeContractEstimateGas(
+    transaction: providers.TransactionRequest,
+  ): Promise<BigNumber | undefined> {
+    try {
+      return await this.probeEstimateGas(transaction);
+    } catch (error) {
+      if (this.isProbeMissError(error)) {
+        return undefined;
+      }
+
+      throw error;
+    }
+  }
+
+  protected isProbeMissError(error: unknown): boolean {
+    if (error instanceof ProbeMissError) {
+      return true;
+    }
+
+    const code =
+      (error as any)?.code ??
+      (error as any)?.cause?.code ??
+      (error as any)?.error?.cause?.code;
+
+    if (code === EthersError.UNPREDICTABLE_GAS_LIMIT) {
+      return true;
+    }
+
+    if (code !== EthersError.CALL_EXCEPTION) {
+      return false;
+    }
+
+    const callException =
+      (error as any)?.code === EthersError.CALL_EXCEPTION
+        ? error
+        : (error as any)?.cause?.code === EthersError.CALL_EXCEPTION
+          ? (error as any).cause
+          : (error as any)?.error?.cause;
+
+    return isDeterministicCallException(callException);
   }
 }

--- a/typescript/sdk/src/utils/HyperlaneReader.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.ts
@@ -9,6 +9,42 @@ import {
 } from '../providers/SmartProvider/SmartProvider.js';
 import { ChainNameOrId } from '../types.js';
 
+type NestedError = {
+  cause?: unknown;
+  error?: unknown;
+};
+
+function getNestedErrorWithCode(
+  error: unknown,
+  code: string,
+): { code: string } | undefined {
+  const queue: unknown[] = [error];
+  const visited = new Set<unknown>();
+
+  while (queue.length > 0) {
+    const candidate = queue.shift();
+    if (candidate == null || typeof candidate !== 'object') {
+      continue;
+    }
+    if (visited.has(candidate)) {
+      continue;
+    }
+    visited.add(candidate);
+
+    if (
+      'code' in candidate &&
+      (candidate as { code?: unknown }).code === code
+    ) {
+      return candidate as { code: string };
+    }
+
+    const nested = candidate as NestedError;
+    queue.push(nested.cause, nested.error);
+  }
+
+  return undefined;
+}
+
 export class HyperlaneReader {
   provider: providers.Provider;
 
@@ -34,21 +70,29 @@ export class HyperlaneReader {
     transaction: providers.TransactionRequest,
     blockTag: providers.BlockTag = 'latest',
   ): Promise<string> {
+    const txReq = {
+      ...transaction,
+      ...this.multiProvider.getTransactionOverrides(this.chain),
+    };
     if (this.provider instanceof HyperlaneSmartProvider) {
-      return this.provider.probeCall(transaction, blockTag);
+      return this.provider.probeCall(txReq, blockTag);
     }
 
-    return this.provider.call(transaction, blockTag);
+    return this.provider.call(txReq, blockTag);
   }
 
   protected async probeEstimateGas(
     transaction: providers.TransactionRequest,
   ): Promise<BigNumber> {
+    const txReq = {
+      ...transaction,
+      ...this.multiProvider.getTransactionOverrides(this.chain),
+    };
     if (this.provider instanceof HyperlaneSmartProvider) {
-      return this.provider.probeEstimateGas(transaction);
+      return this.provider.probeEstimateGas(txReq);
     }
 
-    return this.provider.estimateGas(transaction);
+    return this.provider.estimateGas(txReq);
   }
 
   protected async probeContractCall<T>(
@@ -87,7 +131,7 @@ export class HyperlaneReader {
       return (decoded.length === 1 ? decoded[0] : decoded) as T;
     } catch (error) {
       if (
-        (error as any)?.code === EthersError.INVALID_ARGUMENT ||
+        getNestedErrorWithCode(error, EthersError.INVALID_ARGUMENT) ||
         this.isProbeMissError(error)
       ) {
         return undefined;
@@ -116,25 +160,17 @@ export class HyperlaneReader {
       return true;
     }
 
-    const code =
-      (error as any)?.code ??
-      (error as any)?.cause?.code ??
-      (error as any)?.error?.cause?.code;
-
-    if (code === EthersError.UNPREDICTABLE_GAS_LIMIT) {
+    if (getNestedErrorWithCode(error, EthersError.UNPREDICTABLE_GAS_LIMIT)) {
       return true;
     }
 
-    if (code !== EthersError.CALL_EXCEPTION) {
+    const callException = getNestedErrorWithCode(
+      error,
+      EthersError.CALL_EXCEPTION,
+    );
+    if (!callException) {
       return false;
     }
-
-    const callException =
-      (error as any)?.code === EthersError.CALL_EXCEPTION
-        ? error
-        : (error as any)?.cause?.code === EthersError.CALL_EXCEPTION
-          ? (error as any).cause
-          : (error as any)?.error?.cause;
 
     return isDeterministicCallException(callException);
   }

--- a/typescript/sdk/src/utils/HyperlaneReader.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.ts
@@ -161,6 +161,7 @@ export class HyperlaneReader {
     } catch (error) {
       if (
         getNestedErrorWithCode(error, EthersError.INVALID_ARGUMENT) ||
+        getNestedErrorWithCode(error, EthersError.BUFFER_OVERRUN) ||
         this.isProbeMissError(error)
       ) {
         return undefined;

--- a/typescript/sdk/src/utils/HyperlaneReader.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.ts
@@ -45,6 +45,17 @@ function getNestedErrorWithCode(
   return undefined;
 }
 
+function buildProbeTransactionRequest(
+  multiProvider: MultiProvider,
+  chain: ChainNameOrId,
+  transaction: providers.TransactionRequest,
+): providers.TransactionRequest {
+  return {
+    ...multiProvider.getTransactionOverrides(chain),
+    ...transaction,
+  };
+}
+
 export async function performProbeEstimateGas(
   multiProvider: MultiProvider,
   chain: ChainNameOrId,
@@ -52,8 +63,7 @@ export async function performProbeEstimateGas(
   transaction: providers.TransactionRequest,
 ): Promise<BigNumber> {
   const txReq = {
-    ...transaction,
-    ...multiProvider.getTransactionOverrides(chain),
+    ...buildProbeTransactionRequest(multiProvider, chain, transaction),
     gasLimit: undefined,
     gasPrice: undefined,
     maxPriorityFeePerGas: undefined,
@@ -91,10 +101,11 @@ export class HyperlaneReader {
     transaction: providers.TransactionRequest,
     blockTag: providers.BlockTag = 'latest',
   ): Promise<string> {
-    const txReq = {
-      ...transaction,
-      ...this.multiProvider.getTransactionOverrides(this.chain),
-    };
+    const txReq = buildProbeTransactionRequest(
+      this.multiProvider,
+      this.chain,
+      transaction,
+    );
     if (this.provider instanceof HyperlaneSmartProvider) {
       return this.provider.probeCall(txReq, blockTag);
     }

--- a/typescript/sdk/src/utils/HyperlaneReader.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.ts
@@ -45,6 +45,27 @@ function getNestedErrorWithCode(
   return undefined;
 }
 
+export async function performProbeEstimateGas(
+  multiProvider: MultiProvider,
+  chain: ChainNameOrId,
+  provider: providers.Provider,
+  transaction: providers.TransactionRequest,
+): Promise<BigNumber> {
+  const txReq = {
+    ...transaction,
+    ...multiProvider.getTransactionOverrides(chain),
+    gasLimit: undefined,
+    gasPrice: undefined,
+    maxPriorityFeePerGas: undefined,
+    maxFeePerGas: undefined,
+  };
+  if (provider instanceof HyperlaneSmartProvider) {
+    return provider.probeEstimateGas(txReq);
+  }
+
+  return provider.estimateGas(txReq);
+}
+
 export class HyperlaneReader {
   provider: providers.Provider;
 
@@ -84,15 +105,12 @@ export class HyperlaneReader {
   protected async probeEstimateGas(
     transaction: providers.TransactionRequest,
   ): Promise<BigNumber> {
-    const txReq = {
-      ...transaction,
-      ...this.multiProvider.getTransactionOverrides(this.chain),
-    };
-    if (this.provider instanceof HyperlaneSmartProvider) {
-      return this.provider.probeEstimateGas(txReq);
-    }
-
-    return this.provider.estimateGas(txReq);
+    return performProbeEstimateGas(
+      this.multiProvider,
+      this.chain,
+      this.provider,
+      transaction,
+    );
   }
 
   protected async probeContractCall<T>(


### PR DESCRIPTION
## Summary
- added a first-class SmartProvider probe request kind so contract-shape probes bypass the outer retry loop without changing normal read semantics
- introduced `ProbeMissError` plus shared probe helpers so deterministic ABI misses/reverts become negative matches while transport failures still bubble or fall through to the next provider
- moved warp token, hook, and ISM type discovery onto the shared probe helpers and updated native payable checking to use probe-aware `estimateGas`
- handled Tron-style `CALL_EXCEPTION` payloads (`-32000` + empty-object nested data) as deterministic probe misses/reverts so warp enrollment derivation does not fail on Tron local RPCs
- added a synthetic benchmark script to compare read-style probing vs probe requests
- added a patch changeset for `@hyperlane-xyz/sdk`

## Relation to #8421
This PR tackles the same root issue as [#8421](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/8421): expected probe misses should not walk the full SmartProvider retry/fallback stack.

### Architecture
- `#8421` added probe-specific entrypoints/helpers, but still encoded probe policy partly as broad error swallowing in reader code and hard-capped probe fallback to `min(fallbackStaggerMs, 250ms) * 4` for phase 2.
- this PR makes probe a first-class SmartProvider request kind, returns an explicit `ProbeMissError`, and keeps probe miss semantics at the SmartProvider/shared `HyperlaneReader` boundary instead of inferring them from broad `BlockchainError` buckets in individual readers.
- this PR preserves the configured fallback window for probe requests. Probe calls still skip the outer retry loop, but they do not introduce a separate hard timeout cap that can reject a slow earlier provider.
- follow-up from Tron CI: this branch also treats Tron’s `CALL_EXCEPTION` / nested `-32000` / nested `data: "{}"` shape as deterministic for probe purposes. That was the missing classification behind the Tron warp deploy failures.

### Empirical Comparison
Fast-path probe misses are effectively equivalent between this branch and `#8421`.

| Scenario | This PR | `#8421` |
| --- | ---: | ---: |
| `empty_response` | success in `~0.4ms` | success in `~0.2ms` |
| `server_then_empty` | success in `~0.2ms` | success in `~0.1ms` |

The meaningful behavioral difference shows up when an earlier provider is slow but valid and a later provider returns an immediate probe miss. In a synthetic comparison with `fallbackStaggerMs=1000`, provider 0 succeeding at `~1.4s`, and provider 1 immediately probe-missing:

| Scenario | This PR | `#8421` |
| --- | ---: | ---: |
| `slow_success_then_probe_miss` | succeeds in `~1402ms` | fails in `~1252ms` |

These numbers isolate provider-policy behavior only; they are not end-to-end warp timings.

## Benchmark
Synthetic benchmark: `pnpm -C typescript/sdk bench:smart-provider-probes`

| Scenario | Read avg | Probe avg | Speedup |
| --- | ---: | ---: | ---: |
| `empty_response` | 31.3ms | 0.0ms | 1789.89x |
| `server_then_empty` | 31.8ms | 0.0ms | 1162.09x |

These numbers compare probe requests against the old read-style retry path on this branch.

## Testing
- `pnpm -C typescript/sdk exec mocha --config .mocharc.json src/providers/SmartProvider/SmartProvider.test.ts src/utils/HyperlaneReader.test.ts src/hook/EvmHookReader.test.ts src/ism/EvmIsmReader.test.ts --exit`
- `NODE_OPTIONS='--import tsx/esm' pnpm -C typescript/sdk exec hardhat --config hardhat.config.cts test ./src/token/EvmWarpRouteReader.hardhat-test.ts`
- `pnpm -C typescript/sdk exec eslint src/providers/SmartProvider/HyperlaneJsonRpcProvider.ts src/providers/SmartProvider/SmartProvider.ts src/providers/SmartProvider/SmartProvider.test.ts src/providers/SmartProvider/types.ts src/utils/HyperlaneReader.ts src/utils/HyperlaneReader.test.ts src/token/EvmWarpRouteReader.ts src/token/EvmWarpRouteReader.hardhat-test.ts src/token/checker.ts src/hook/EvmHookReader.ts src/hook/EvmHookReader.test.ts src/ism/EvmIsmReader.ts src/ism/EvmIsmReader.test.ts scripts/benchmark-smart-provider-probes.ts`
- `pnpm -C typescript/sdk bench:smart-provider-probes`
- `git diff --check HEAD~2..HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SmartProvider fallback/retry behavior and error classification for contract calls (including Tron-specific JSON-RPC shapes), which could affect how reads fail over across RPCs despite being well-covered by tests.
> 
> **Overview**
> Adds a **probe-specific request mode** to `HyperlaneSmartProvider` (`probeCall`/`probeEstimateGas`) that bypasses the outer retry loop, allows `0x` call results for ABI-shape detection, and introduces `ProbeMissError` so deterministic “method missing/revert” cases short-circuit without trying additional providers while transport/server errors still fall through.
> 
> Moves hook/ISM/warp-route type detection onto new shared `HyperlaneReader` probe helpers (`probeContractCall`, `probeContractEstimateGas`) and expands deterministic miss detection (including Tron-style `CALL_EXCEPTION` payloads). Also parallelizes parts of warp route config derivation and adds per-derivation caching for `PACKAGE_VERSION` lookups.
> 
> CLI context setup now reuses a single registry metadata fetch when constructing `MultiProvider` and `MultiProtocolProvider`, and the SDK adds a small benchmark script plus new/updated tests covering probe behavior and caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d39803d8d778c1dc01170bf627f55d41e2cf6258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->