### PR TITLE
perf(sdk): speed up evm warp reads

### DIFF
--- a/.changeset/bright-moles-rush.md
+++ b/.changeset/bright-moles-rush.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+EVM warp route reads now batch token-type probe calls through Multicall3 when available and start token fee derivation earlier so more of the same-chain work overlaps. Probe requests also recognize Base-style RPC bodies that wrap deterministic `ServerError(3)` reverts inside top-level `-32603` errors, so selector misses no longer fail warp reads on those providers.

--- a/.changeset/bright-moles-rush.md
+++ b/.changeset/bright-moles-rush.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-EVM warp route reads now batch token-type probe calls through Multicall3 when available and start token fee derivation earlier so more of the same-chain work overlaps. Probe requests also recognize Base-style RPC bodies that wrap deterministic `ServerError(3)` reverts inside top-level `-32603` errors, so selector misses no longer fail warp reads on those providers.
+EVM warp route reads now batch token-type probe calls through Multicall3 when available and start token fee derivation earlier so more of the same-chain work overlaps. Probe requests also recognize RPC bodies that wrap deterministic `ServerError(3)` reverts inside top-level `-32603` errors, so selector misses no longer fail warp reads on providers that use that error shape.

--- a/.changeset/warp-read-multicall.md
+++ b/.changeset/warp-read-multicall.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+EVM warp route reads and token metadata derivation batched same-chain contract reads through Multicall3 when available, with fallback to individual calls when it is not. Warp fee readers also batched routing fee lookups so warp read/apply/deploy use fewer RPC round-trips on supported chains.

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.ts
@@ -109,7 +109,9 @@ export class EvmTokenFeeReader extends HyperlaneReader {
         });
         break;
       default:
-        throw new Error(`Unsupported token fee type: ${onchainFeeType}`);
+        throw new Error(
+          `Unsupported token fee type: ${String(onchainFeeType)}`,
+        );
     }
 
     return derivedConfig;
@@ -203,7 +205,7 @@ export class EvmTokenFeeReader extends HyperlaneReader {
   ): Promise<DerivedTokenFeeConfig> {
     const { address, routingDestinations } = params;
     const routingFeeInterface = RoutingFee__factory.createInterface();
-    const [token, owner, maxFee, halfAmount] = (await this.readContractBatch([
+    const [token, owner] = (await this.readContractBatch([
       {
         target: address,
         contractInterface: routingFeeInterface,
@@ -214,17 +216,7 @@ export class EvmTokenFeeReader extends HyperlaneReader {
         contractInterface: routingFeeInterface,
         method: 'owner',
       },
-      {
-        target: address,
-        contractInterface: routingFeeInterface,
-        method: 'maxFee',
-      },
-      {
-        target: address,
-        contractInterface: routingFeeInterface,
-        method: 'halfAmount',
-      },
-    ])) as [Address, Address, BigNumber, BigNumber];
+    ])) as [Address, Address];
 
     const feeContracts: Record<ChainName, DerivedTokenFeeConfig> = {};
 

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.ts
@@ -1,4 +1,4 @@
-import { constants } from 'ethers';
+import { BigNumber, constants } from 'ethers';
 
 import {
   BaseFee__factory,
@@ -118,13 +118,29 @@ export class EvmTokenFeeReader extends HyperlaneReader {
   private async deriveLinearFeeConfig(
     address: Address,
   ): Promise<DerivedTokenFeeConfig> {
-    const tokenFee = LinearFee__factory.connect(address, this.provider);
-    const [token, owner, maxFee, halfAmount] = await Promise.all([
-      tokenFee.token(),
-      tokenFee.owner(),
-      tokenFee.maxFee(),
-      tokenFee.halfAmount(),
-    ]);
+    const linearFeeInterface = LinearFee__factory.createInterface();
+    const [token, owner, maxFee, halfAmount] = (await this.readContractBatch([
+      {
+        target: address,
+        contractInterface: linearFeeInterface,
+        method: 'token',
+      },
+      {
+        target: address,
+        contractInterface: linearFeeInterface,
+        method: 'owner',
+      },
+      {
+        target: address,
+        contractInterface: linearFeeInterface,
+        method: 'maxFee',
+      },
+      {
+        target: address,
+        contractInterface: linearFeeInterface,
+        method: 'halfAmount',
+      },
+    ])) as [Address, Address, BigNumber, BigNumber];
     const maxFeeBn = BigInt(maxFee.toString());
     const halfAmountBn = BigInt(halfAmount.toString());
     const bps = convertToBps(maxFeeBn, halfAmountBn);
@@ -186,18 +202,45 @@ export class EvmTokenFeeReader extends HyperlaneReader {
     params: TokenFeeReaderParams,
   ): Promise<DerivedTokenFeeConfig> {
     const { address, routingDestinations } = params;
-    const routingFee = RoutingFee__factory.connect(address, this.provider);
-    const [token, owner] = await Promise.all([
-      routingFee.token(),
-      routingFee.owner(),
-    ]);
+    const routingFeeInterface = RoutingFee__factory.createInterface();
+    const [token, owner, maxFee, halfAmount] = (await this.readContractBatch([
+      {
+        target: address,
+        contractInterface: routingFeeInterface,
+        method: 'token',
+      },
+      {
+        target: address,
+        contractInterface: routingFeeInterface,
+        method: 'owner',
+      },
+      {
+        target: address,
+        contractInterface: routingFeeInterface,
+        method: 'maxFee',
+      },
+      {
+        target: address,
+        contractInterface: routingFeeInterface,
+        method: 'halfAmount',
+      },
+    ])) as [Address, Address, BigNumber, BigNumber];
 
     const feeContracts: Record<ChainName, DerivedTokenFeeConfig> = {};
 
-    if (routingDestinations)
+    if (routingDestinations) {
+      const subFeeAddresses = await this.readContractBatch<Address>(
+        routingDestinations.map((destination) => ({
+          target: address,
+          contractInterface: routingFeeInterface,
+          method: 'feeContracts',
+          args: [destination],
+        })),
+      );
+
       await Promise.all(
-        routingDestinations.map(async (destination) => {
-          const subFeeAddress = await routingFee.feeContracts(destination);
+        routingDestinations.map(async (destination, index) => {
+          const subFeeAddress = subFeeAddresses[index];
           if (subFeeAddress === constants.AddressZero) return;
           const chainName = this.multiProvider.tryGetChainName(destination);
           if (!chainName) return;
@@ -206,6 +249,7 @@ export class EvmTokenFeeReader extends HyperlaneReader {
           });
         }),
       );
+    }
     return {
       type: TokenFeeType.RoutingFee,
       address,

--- a/typescript/sdk/src/metadata/chainMetadataTypes.ts
+++ b/typescript/sdk/src/metadata/chainMetadataTypes.ts
@@ -186,6 +186,13 @@ export const ChainMetadataSchemaObject = z.object({
     .optional()
     .describe('The human readable address prefix for the chains using bech32.'),
 
+  batchContractAddress: z
+    .string()
+    .optional()
+    .describe(
+      'Optional address of the batch/multicall contract when the chain does not use the canonical Multicall3 deployment address.',
+    ),
+
   blockExplorers: z
     .array(BlockExplorerSchema)
     .optional()

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.test.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.test.ts
@@ -1054,6 +1054,40 @@ describe('SmartProvider', () => {
       }
     });
 
+    it('probe requests treat nested ServerError(3) bodies as probe misses', async () => {
+      const probeMiss = new ProviderError(
+        'missing revert data in call exception',
+        EthersError.CALL_EXCEPTION,
+        '0x',
+        {
+          jsonRpcErrorCode: -32603,
+          jsonRpcBody: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            error: {
+              code: -32603,
+              message:
+                'ErrorObject { code: ServerError(3), message: "execution reverted", data: None }',
+            },
+          }),
+        },
+      );
+      const provider1 = MockProvider.error(probeMiss);
+      const provider2 = MockProvider.success('success2');
+      const smartProvider = new TestableSmartProvider([provider1, provider2]);
+
+      try {
+        await smartProvider.simpleProbePerform(ProviderMethod.Call, 1);
+        expect.fail('Should have thrown a probe miss');
+      } catch (e: any) {
+        expect(e).to.be.instanceOf(ProbeMissError);
+        expect(e.message).to.equal('missing revert data in call exception');
+        expect(e.cause).to.equal(probeMiss);
+        expect(provider1.called).to.be.true;
+        expect(provider2.called).to.be.false;
+      }
+    });
+
     it('probe requests still accept an earlier slow success after a later probe miss', async () => {
       const slowSuccess = MockProvider.success('success1', 120);
       const probeMiss = MockProvider.error(

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -124,7 +124,19 @@ type ProviderErrorClassification =
   | 'unknown';
 
 function getJsonRpcErrorCode(error: any): number | undefined {
-  return error?.error?.error?.code ?? error?.error?.code;
+  const explicitCode = error?.error?.error?.code ?? error?.error?.code;
+  if (typeof explicitCode === 'number' && explicitCode !== -32603) {
+    return explicitCode;
+  }
+
+  const nestedCodeMatch = getJsonRpcErrorMessage(error)?.match(
+    /ServerError\((-?\d+)\)/,
+  );
+  if (nestedCodeMatch) {
+    return Number(nestedCodeMatch[1]);
+  }
+
+  return typeof explicitCode === 'number' ? explicitCode : undefined;
 }
 
 function getJsonRpcErrorData(error: any): unknown {

--- a/typescript/sdk/src/router/EvmRouterReader.ts
+++ b/typescript/sdk/src/router/EvmRouterReader.ts
@@ -48,16 +48,30 @@ export class EvmRouterReader extends HyperlaneReader {
   async fetchMailboxClientConfig(
     routerAddress: Address,
   ): Promise<DerivedMailboxClientConfig> {
-    const mailboxClient = MailboxClient__factory.connect(
-      routerAddress,
-      this.provider,
-    );
-    const [mailbox, owner, hookAddress, ismAddress] = await Promise.all([
-      mailboxClient.mailbox(),
-      mailboxClient.owner(),
-      mailboxClient.hook(),
-      mailboxClient.interchainSecurityModule(),
-    ]);
+    const mailboxClientInterface = MailboxClient__factory.createInterface();
+    const [mailbox, owner, hookAddress, ismAddress] =
+      (await this.readContractBatch<Address>([
+        {
+          target: routerAddress,
+          contractInterface: mailboxClientInterface,
+          method: 'mailbox',
+        },
+        {
+          target: routerAddress,
+          contractInterface: mailboxClientInterface,
+          method: 'owner',
+        },
+        {
+          target: routerAddress,
+          contractInterface: mailboxClientInterface,
+          method: 'hook',
+        },
+        {
+          target: routerAddress,
+          contractInterface: mailboxClientInterface,
+          method: 'interchainSecurityModule',
+        },
+      ])) as [Address, Address, Address, Address];
 
     const derivedIsm = eqAddress(ismAddress, constants.AddressZero)
       ? constants.AddressZero
@@ -77,13 +91,21 @@ export class EvmRouterReader extends HyperlaneReader {
   async fetchRemoteRouters(routerAddress: Address): Promise<RemoteRouters> {
     const router = Router__factory.connect(routerAddress, this.provider);
     const domains = await router.domains();
+    const routerInterface = Router__factory.createInterface();
+    const routerAddresses = await this.readContractBatch<Address>(
+      domains.map((domain) => ({
+        target: routerAddress,
+        contractInterface: routerInterface,
+        method: 'routers',
+        args: [domain],
+      })),
+    );
 
     const routers = Object.fromEntries(
-      await Promise.all(
-        domains.map(async (domain) => {
-          return [domain, { address: await router.routers(domain) }];
-        }),
-      ),
+      domains.map((domain, index) => [
+        domain,
+        { address: routerAddresses[index] },
+      ]),
     );
     return RemoteRoutersSchema.parse(routers);
   }

--- a/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
@@ -1129,25 +1129,17 @@ describe('EvmWarpRouteReader', async () => {
       denominator: 1_000_000_000_000n,
     };
 
-    const mcConnectStub = sinon
-      .stub(CrossCollateralRouter__factory, 'connect')
-      .returns({
-        wrappedToken: sinon.stub().resolves(wrappedTokenAddress),
-        localDomain: sinon.stub().resolves(localDomain),
-        getCrossCollateralDomains: sinon
-          .stub()
-          .resolves([localDomain, remoteDomain]),
-        getCrossCollateralRouters: sinon
-          .stub()
-          .callsFake(async (domain: number) =>
-            domain === localDomain ? [localRouter] : [remoteRouter],
-          ),
-      } as any);
-    const tokenRouterConnectStub = sinon
-      .stub(TokenRouter__factory, 'connect')
-      .returns({
-        domains: sinon.stub().resolves([remoteDomain]),
-      } as any);
+    const batchStub = sinon
+      .stub(evmERC20WarpRouteReader as any, 'readContractBatch')
+      .onFirstCall()
+      .resolves([
+        wrappedTokenAddress,
+        [remoteDomain],
+        [localDomain, remoteDomain],
+        localDomain,
+      ])
+      .onSecondCall()
+      .resolves([[remoteRouter], [localRouter]]);
     const metadataStub = sinon
       .stub(evmERC20WarpRouteReader, 'fetchERC20Metadata')
       .resolves({
@@ -1176,8 +1168,7 @@ describe('EvmWarpRouteReader', async () => {
         [remoteDomain.toString()]: [remoteRouter],
       });
     } finally {
-      mcConnectStub.restore();
-      tokenRouterConnectStub.restore();
+      batchStub.restore();
       metadataStub.restore();
       scaleStub.restore();
     }
@@ -1192,12 +1183,10 @@ describe('EvmWarpRouteReader', async () => {
       .stub(TokenRouter__factory, 'connect')
       .returns({
         domains: sinon.stub().resolves([defaultDomain]),
-        destinationGas: sinon.stub().callsFake(async (domain: number) => {
-          if (domain === defaultDomain) return { toString: () => '100000' };
-          if (domain === mcOnlyDomain) return { toString: () => '200000' };
-          return { toString: () => '0' };
-        }),
       } as any);
+    const batchStub = sinon
+      .stub(evmERC20WarpRouteReader as any, 'readContractBatch')
+      .resolves([{ toString: () => '100000' }, { toString: () => '200000' }]);
 
     try {
       const gas = await evmERC20WarpRouteReader.fetchDestinationGas(
@@ -1208,6 +1197,7 @@ describe('EvmWarpRouteReader', async () => {
       expect(gas[defaultDomain]).to.equal('100000');
       expect(gas[mcOnlyDomain]).to.equal('200000');
     } finally {
+      batchStub.restore();
       tokenRouterStub.restore();
     }
   });

--- a/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
@@ -5,7 +5,6 @@ import sinon from 'sinon';
 import { zeroAddress } from 'viem';
 
 import {
-  CrossCollateralRouter__factory,
   ERC20Test,
   ERC20Test__factory,
   ERC4626,
@@ -735,7 +734,7 @@ describe('EvmWarpRouteReader', async () => {
     );
     expect(Object.keys(derivedConfig.remoteRouters!).length).to.equal(1);
     expect(
-      derivedConfig.remoteRouters![otherChainMetadata.domainId!].address,
+      derivedConfig.remoteRouters![otherChainMetadata.domainId].address,
     ).to.be.equal(addressToBytes32(warpRoute[otherChain].collateral.address));
   });
 
@@ -944,7 +943,7 @@ describe('EvmWarpRouteReader', async () => {
     expect(derivedConfig.tokenFee?.type).to.equal(TokenFeeType.RoutingFee);
     expect((derivedConfig.tokenFee as any).owner).to.equal(mailbox.address);
     expect(
-      Object.keys((derivedConfig.tokenFee as any).feeContracts as any),
+      Object.keys((derivedConfig.tokenFee as any).feeContracts),
     ).to.have.length(0);
   });
 
@@ -1211,12 +1210,10 @@ describe('EvmWarpRouteReader', async () => {
       .stub(TokenRouter__factory, 'connect')
       .returns({
         domains: sinon.stub().resolves([localDomain, remoteDomain]),
-        destinationGas: sinon.stub().callsFake(async (domain: number) => {
-          if (domain === localDomain) return { toString: () => '999' };
-          if (domain === remoteDomain) return { toString: () => '100000' };
-          return { toString: () => '0' };
-        }),
       } as any);
+    const batchStub = sinon
+      .stub(evmERC20WarpRouteReader as any, 'readContractBatch')
+      .resolves([{ toString: () => '100000' }]);
 
     try {
       const gas = await evmERC20WarpRouteReader.fetchDestinationGas(
@@ -1227,6 +1224,7 @@ describe('EvmWarpRouteReader', async () => {
       expect(gas[remoteDomain]).to.equal('100000');
       expect(gas[localDomain]).to.be.undefined;
     } finally {
+      batchStub.restore();
       tokenRouterStub.restore();
     }
   });

--- a/typescript/sdk/src/token/EvmWarpRouteReader.test.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.test.ts
@@ -49,7 +49,7 @@ describe('EvmWarpRouteReader', () => {
     const tokenFee = await evmWarpRouteReader.fetchTokenFee(
       routerAddress,
       undefined,
-      Promise.reject(new Error('transient domains failure')),
+      () => Promise.reject(new Error('transient domains failure')),
     );
 
     expect(tokenFee).to.equal(derivedTokenFeeConfig);
@@ -60,5 +60,28 @@ describe('EvmWarpRouteReader', () => {
         routingDestinations,
       }),
     ).to.equal(true);
+  });
+
+  it('does not start shared domains reads when token fee derivation returns early', async () => {
+    const routerAddress = randomAddress();
+    let getDestinationsCalls = 0;
+
+    sandbox.stub(TokenRouter__factory, 'connect').returns({
+      feeRecipient: sandbox.stub().resolves(randomAddress()),
+      domains: sandbox.stub().resolves([1, 2]),
+    } as any);
+    sandbox.stub(evmWarpRouteReader, 'fetchPackageVersion').resolves('9.9.9');
+
+    const tokenFee = await evmWarpRouteReader.fetchTokenFee(
+      routerAddress,
+      undefined,
+      () => {
+        getDestinationsCalls += 1;
+        return Promise.resolve([1, 2]);
+      },
+    );
+
+    expect(tokenFee).to.be.undefined;
+    expect(getDestinationsCalls).to.equal(0);
   });
 });

--- a/typescript/sdk/src/token/EvmWarpRouteReader.test.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.test.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { TokenRouter__factory } from '@hyperlane-xyz/core';
+
+import { TestChainName } from '../consts/testChains.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+import { randomAddress } from '../test/testUtils.js';
+
+import {
+  EvmWarpRouteReader,
+  TOKEN_FEE_CONTRACT_VERSION,
+} from './EvmWarpRouteReader.js';
+
+describe('EvmWarpRouteReader', () => {
+  let sandbox: sinon.SinonSandbox;
+  let evmWarpRouteReader: EvmWarpRouteReader;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    evmWarpRouteReader = new EvmWarpRouteReader(
+      MultiProvider.createTestMultiProvider(),
+      TestChainName.test1,
+    );
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('retries token router domains when a shared domains promise fails', async () => {
+    const routerAddress = randomAddress();
+    const feeRecipient = randomAddress();
+    const routingDestinations = [1, 2];
+    const derivedTokenFeeConfig = { address: feeRecipient } as any;
+    const domains = sandbox.stub().resolves(routingDestinations);
+
+    sandbox.stub(TokenRouter__factory, 'connect').returns({
+      feeRecipient: sandbox.stub().resolves(feeRecipient),
+      domains,
+    } as any);
+    sandbox
+      .stub(evmWarpRouteReader, 'fetchPackageVersion')
+      .resolves(TOKEN_FEE_CONTRACT_VERSION);
+    const deriveTokenFeeConfigStub = sandbox
+      .stub(evmWarpRouteReader.evmTokenFeeReader, 'deriveTokenFeeConfig')
+      .resolves(derivedTokenFeeConfig);
+
+    const tokenFee = await evmWarpRouteReader.fetchTokenFee(
+      routerAddress,
+      undefined,
+      Promise.reject(new Error('transient domains failure')),
+    );
+
+    expect(tokenFee).to.equal(derivedTokenFeeConfig);
+    expect(domains.calledOnce).to.equal(true);
+    expect(
+      deriveTokenFeeConfigStub.calledOnceWithExactly({
+        address: feeRecipient,
+        routingDestinations,
+      }),
+    ).to.equal(true);
+  });
+});

--- a/typescript/sdk/src/token/EvmWarpRouteReader.test.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.test.ts
@@ -1,16 +1,22 @@
+import { BigNumber } from 'ethers';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { TokenRouter__factory } from '@hyperlane-xyz/core';
+import {
+  IMessageTransmitter__factory,
+  TokenRouter__factory,
+} from '@hyperlane-xyz/core';
 
 import { TestChainName } from '../consts/testChains.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { randomAddress } from '../test/testUtils.js';
 
 import {
+  CCTP_PPM_PRECISION_VERSION,
   EvmWarpRouteReader,
   TOKEN_FEE_CONTRACT_VERSION,
 } from './EvmWarpRouteReader.js';
+import { TokenType } from './config.js';
 
 describe('EvmWarpRouteReader', () => {
   let sandbox: sinon.SinonSandbox;
@@ -83,5 +89,109 @@ describe('EvmWarpRouteReader', () => {
 
     expect(tokenFee).to.be.undefined;
     expect(getDestinationsCalls).to.equal(0);
+  });
+
+  it('decodes uint batch results before deriving cross-collateral config', async () => {
+    const routerAddress = randomAddress();
+    const wrappedTokenAddress = randomAddress();
+    const localDomain = 31337;
+    const remoteDomain = 31338;
+    const localRouter = randomAddress();
+    const remoteRouter = randomAddress();
+    const expectedScale = { numerator: 1n, denominator: 1n };
+
+    const batchStub = sandbox.stub(
+      evmWarpRouteReader as any,
+      'readContractBatch',
+    );
+    batchStub
+      .onFirstCall()
+      .callsFake(async (calls: any[]) => [
+        wrappedTokenAddress,
+        calls[1].decode([[BigNumber.from(remoteDomain)]]),
+        calls[2].decode([
+          [BigNumber.from(localDomain), BigNumber.from(remoteDomain)],
+        ]),
+        calls[3].decode([BigNumber.from(localDomain)]),
+      ]);
+    batchStub.onSecondCall().callsFake(async (calls: any[]) => {
+      expect(calls.map((call) => call.args?.[0])).to.deep.equal([
+        remoteDomain,
+        localDomain,
+      ]);
+      return [[remoteRouter], [localRouter]];
+    });
+    sandbox.stub(evmWarpRouteReader, 'fetchERC20Metadata').resolves({
+      name: 'Token',
+      symbol: 'TKN',
+      decimals: 18,
+      isNft: false,
+    });
+    sandbox.stub(evmWarpRouteReader, 'fetchScale').resolves(expectedScale);
+
+    const deriveCrossCollateralTokenConfig = (evmWarpRouteReader as any)
+      .deriveCrossCollateralTokenConfig as (address: string) => Promise<any>;
+    const derivedConfig = await deriveCrossCollateralTokenConfig.call(
+      evmWarpRouteReader,
+      routerAddress,
+    );
+
+    expect(derivedConfig.type).to.equal(TokenType.crossCollateral);
+    expect(derivedConfig.token).to.equal(wrappedTokenAddress);
+    expect(derivedConfig.scale).to.deep.equal(expectedScale);
+    expect(derivedConfig.crossCollateralRouters).to.deep.equal({
+      [remoteDomain.toString()]: [remoteRouter],
+      [localDomain.toString()]: [localRouter],
+    });
+  });
+
+  it('decodes minFinalityThreshold to a number for CCTP V2 batched reads', async () => {
+    const hypToken = randomAddress();
+    const messageTransmitter = randomAddress();
+    const tokenMessenger = randomAddress();
+    const urls = ['https://example.com'];
+
+    sandbox
+      .stub(evmWarpRouteReader as any, 'deriveHypCollateralTokenConfig')
+      .resolves({
+        type: TokenType.collateral,
+        token: randomAddress(),
+        name: 'Token',
+        symbol: 'TKN',
+        decimals: 6,
+        isNft: false,
+      });
+    const batchStub = sandbox.stub(
+      evmWarpRouteReader as any,
+      'readContractBatch',
+    );
+    batchStub
+      .onFirstCall()
+      .resolves([messageTransmitter, tokenMessenger, urls]);
+    batchStub
+      .onSecondCall()
+      .callsFake(async (calls: any[]) => [
+        calls[0].decode([BigNumber.from(1000)]),
+        calls[1].decode([BigNumber.from(123)]),
+      ]);
+    sandbox.stub(IMessageTransmitter__factory, 'connect').returns({
+      version: sandbox.stub().resolves(1),
+    } as any);
+    sandbox
+      .stub(evmWarpRouteReader, 'fetchPackageVersion')
+      .resolves(CCTP_PPM_PRECISION_VERSION);
+
+    const deriveHypCollateralCctpTokenConfig = (evmWarpRouteReader as any)
+      .deriveHypCollateralCctpTokenConfig as (address: string) => Promise<any>;
+    const derivedConfig = await deriveHypCollateralCctpTokenConfig.call(
+      evmWarpRouteReader,
+      hypToken,
+    );
+
+    expect(derivedConfig.type).to.equal(TokenType.collateralCctp);
+    expect(derivedConfig.cctpVersion).to.equal('V2');
+    expect(derivedConfig.minFinalityThreshold).to.equal(1000);
+    expect(derivedConfig.minFinalityThreshold).to.be.a('number');
+    expect(derivedConfig.maxFeeBps).to.equal(123);
   });
 });

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -264,6 +264,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
 
     let allowedRebalancers: Address[] | undefined;
     let allowedRebalancingBridges: MovableTokenConfig['allowedRebalancingBridges'];
+    let domains: number[] | undefined;
 
     // Only movable collateral tokens (collateral/native) have rebalancing config
     if (
@@ -289,7 +290,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       }
 
       try {
-        const domains = await movableToken.domains();
+        domains = await movableToken.domains();
         const allowedBridgesByDomain = await promiseObjAll(
           objMap(
             arrayToObject(domains.map((domain) => domain.toString())),
@@ -664,6 +665,8 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       return TokenType.XERC20;
     }
 
+    // This probe needs `{ from: warpRouteAddress }`, which the batched probe
+    // wrapper cannot express today.
     const fiatMintProbe = await this.probeContractCall(
       wrappedToken,
       IFiatToken__factory.createInterface(),
@@ -945,35 +948,32 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       const usesPpmName =
         contractVersion !== undefined &&
         compareVersions(contractVersion, CCTP_PPM_PRECISION_VERSION) >= 0;
+      const minFinalityThresholdCall = {
+        target: hypToken,
+        contractInterface: tokenBridgeV2Interface,
+        method: 'minFinalityThreshold',
+      };
 
-      const calls = [
-        {
-          target: hypToken,
-          contractInterface: tokenBridgeV2Interface,
-          method: 'minFinalityThreshold',
-        },
-      ] as const;
-
-      const [minFinalityThreshold] = (await this.readContractBatch(
-        calls as any,
-      )) as [number];
-
-      const maxFeePpm = usesPpmName
-        ? (
-            await this.readContractBatch<BigNumber>([
-              {
-                target: hypToken,
-                contractInterface: tokenBridgeV2Interface,
-                method: 'maxFeePpm',
-              },
-            ])
-          )[0]
-        : await TokenBridgeCctpV2__factory.connect(hypToken, this.provider)
-            .provider.call({
-              to: hypToken,
-              data: '0xbf769a3f',
-            })
-            .then((result) => BigNumber.from(result));
+      const [minFinalityThreshold, maxFeePpm] = usesPpmName
+        ? ((await this.readContractBatch<unknown>([
+            minFinalityThresholdCall,
+            {
+              target: hypToken,
+              contractInterface: tokenBridgeV2Interface,
+              method: 'maxFeePpm',
+            },
+          ])) as [number, BigNumber])
+        : await Promise.all([
+            this.readContractBatch<number>([minFinalityThresholdCall]).then(
+              ([result]) => result,
+            ),
+            TokenBridgeCctpV2__factory.connect(hypToken, this.provider)
+              .provider.call({
+                to: hypToken,
+                data: '0xbf769a3f',
+              })
+              .then((result) => BigNumber.from(result)),
+          ]);
 
       return {
         ...collateralConfig,

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -205,9 +205,14 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     const isOft = type === TokenType.collateralOft;
     const usesSentinelRouterConfig = isDepositAddressBridge || isOft;
     const tokenConfigPromise = this.fetchTokenConfig(type, warpRouteAddress);
-    const tokenRouterDomainsPromise = usesSentinelRouterConfig
+    let tokenRouterDomainsPromise: Promise<number[]> | undefined;
+    const getTokenRouterDomainsPromise = usesSentinelRouterConfig
       ? undefined
-      : TokenRouter__factory.connect(warpRouteAddress, this.provider).domains();
+      : () =>
+          (tokenRouterDomainsPromise ??= TokenRouter__factory.connect(
+            warpRouteAddress,
+            this.provider,
+          ).domains());
     const routerConfigPromise = usesSentinelRouterConfig
       ? Ownable__factory.connect(warpRouteAddress, this.provider)
           .owner()
@@ -292,7 +297,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       try {
         const tokenRouterDomains = await this.fetchTokenRouterDomains(
           movableToken,
-          tokenRouterDomainsPromise,
+          getTokenRouterDomainsPromise,
         );
         assert(
           tokenRouterDomains,
@@ -334,7 +339,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       isCrossCollateralTokenConfig(tokenConfig)
         ? tokenConfig.crossCollateralRouters
         : undefined,
-      tokenRouterDomainsPromise,
+      getTokenRouterDomainsPromise,
     );
     // CCTP tokens implement their own ISM (the contract itself acts as the ISM via AbstractCcipReadIsm).
     // The ISM is hardcoded and not configurable, so we return zero address to match deploy config expectations.
@@ -359,8 +364,9 @@ export class EvmWarpRouteReader extends EvmRouterReader {
 
   private async fetchTokenRouterDomains(
     tokenRouter: { domains: () => Promise<number[]> },
-    domainsPromise?: Promise<number[]>,
+    getDomainsPromise?: () => Promise<number[] | undefined>,
   ): Promise<number[] | undefined> {
+    const domainsPromise = getDomainsPromise?.();
     if (domainsPromise) {
       try {
         const domains = await domainsPromise;
@@ -388,7 +394,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     routerAddress: Address,
     destinations?: number[],
     crossCollateralRouters?: Record<string, string[]>,
-    destinationsPromise?: Promise<number[] | undefined>,
+    getDestinationsPromise?: () => Promise<number[] | undefined>,
   ): Promise<DerivedTokenFeeConfig | undefined> {
     const TokenRouter = TokenRouter__factory.connect(
       routerAddress,
@@ -425,7 +431,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
 
     const routingDestinations =
       destinations ??
-      (await this.fetchTokenRouterDomains(TokenRouter, destinationsPromise));
+      (await this.fetchTokenRouterDomains(TokenRouter, getDestinationsPromise));
 
     const normalizedCrossCollateralRouters = crossCollateralRouters
       ? Object.fromEntries(

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -207,15 +207,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     const tokenConfigPromise = this.fetchTokenConfig(type, warpRouteAddress);
     const tokenRouterDomainsPromise = usesSentinelRouterConfig
       ? undefined
-      : TokenRouter__factory.connect(warpRouteAddress, this.provider)
-          .domains()
-          .catch((error) => {
-            this.logger.debug(
-              `Failed to derive token router domains for routing fee config on "${this.chain}"`,
-              error,
-            );
-            return undefined;
-          });
+      : TokenRouter__factory.connect(warpRouteAddress, this.provider).domains();
     const routerConfigPromise = usesSentinelRouterConfig
       ? Ownable__factory.connect(warpRouteAddress, this.provider)
           .owner()
@@ -231,14 +223,11 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       (await isProxy(this.provider, warpRouteAddress))
         ? this.fetchProxyAdminConfig(warpRouteAddress)
         : undefined)();
-    const [tokenConfig, routerConfig, proxyAdmin, tokenFee] = await Promise.all(
-      [
-        tokenConfigPromise,
-        routerConfigPromise,
-        proxyAdminPromise,
-        tokenFeePromise,
-      ],
-    );
+    const [tokenConfig, routerConfig, proxyAdmin] = await Promise.all([
+      tokenConfigPromise,
+      routerConfigPromise,
+      proxyAdminPromise,
+    ]);
 
     const ccrEnrolledDomains: number[] = [];
     if (
@@ -301,9 +290,15 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       }
 
       try {
-        domains = tokenRouterDomainsPromise
-          ? await tokenRouterDomainsPromise
-          : await movableToken.domains();
+        const tokenRouterDomains = await this.fetchTokenRouterDomains(
+          movableToken,
+          tokenRouterDomainsPromise,
+        );
+        assert(
+          tokenRouterDomains,
+          `Failed to derive token router domains for allowed rebalancer bridges on "${this.chain}"`,
+        );
+        domains = tokenRouterDomains;
         const allowedBridgesByDomain = await promiseObjAll(
           objMap(
             arrayToObject(domains.map((domain) => domain.toString())),
@@ -336,10 +331,10 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     const tokenFee = await this.fetchTokenFee(
       warpRouteAddress,
       feeDestinations.length ? feeDestinations : undefined,
-      tokenRouterDomainsPromise,
       isCrossCollateralTokenConfig(tokenConfig)
         ? tokenConfig.crossCollateralRouters
         : undefined,
+      tokenRouterDomainsPromise,
     );
     // CCTP tokens implement their own ISM (the contract itself acts as the ISM via AbstractCcipReadIsm).
     // The ISM is hardcoded and not configurable, so we return zero address to match deploy config expectations.
@@ -362,11 +357,38 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     return derivedConfig;
   }
 
+  private async fetchTokenRouterDomains(
+    tokenRouter: { domains: () => Promise<number[]> },
+    domainsPromise?: Promise<number[]>,
+  ): Promise<number[] | undefined> {
+    if (domainsPromise) {
+      try {
+        const domains = await domainsPromise;
+        if (domains) return domains;
+      } catch (error) {
+        this.logger.debug(
+          `Failed to derive token router domains from shared read on "${this.chain}"`,
+          error,
+        );
+      }
+    }
+
+    try {
+      return await tokenRouter.domains();
+    } catch (error) {
+      this.logger.debug(
+        `Failed to derive token router domains on "${this.chain}"`,
+        error,
+      );
+      return undefined;
+    }
+  }
+
   public async fetchTokenFee(
     routerAddress: Address,
     destinations?: number[],
-    destinationsPromise?: Promise<number[] | undefined>,
     crossCollateralRouters?: Record<string, string[]>,
+    destinationsPromise?: Promise<number[] | undefined>,
   ): Promise<DerivedTokenFeeConfig | undefined> {
     const TokenRouter = TokenRouter__factory.connect(
       routerAddress,
@@ -403,15 +425,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
 
     const routingDestinations =
       destinations ??
-      (destinationsPromise
-        ? await destinationsPromise
-        : await TokenRouter.domains().catch((error) => {
-            this.logger.debug(
-              `Failed to derive token router domains for routing fee config on "${this.chain}"`,
-              error,
-            );
-            return undefined;
-          }));
+      (await this.fetchTokenRouterDomains(TokenRouter, destinationsPromise));
 
     const normalizedCrossCollateralRouters = crossCollateralRouters
       ? Object.fromEntries(

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -205,6 +205,17 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     const isOft = type === TokenType.collateralOft;
     const usesSentinelRouterConfig = isDepositAddressBridge || isOft;
     const tokenConfigPromise = this.fetchTokenConfig(type, warpRouteAddress);
+    const tokenRouterDomainsPromise = usesSentinelRouterConfig
+      ? undefined
+      : TokenRouter__factory.connect(warpRouteAddress, this.provider)
+          .domains()
+          .catch((error) => {
+            this.logger.debug(
+              `Failed to derive token router domains for routing fee config on "${this.chain}"`,
+              error,
+            );
+            return undefined;
+          });
     const routerConfigPromise = usesSentinelRouterConfig
       ? Ownable__factory.connect(warpRouteAddress, this.provider)
           .owner()
@@ -290,7 +301,9 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       }
 
       try {
-        domains = await movableToken.domains();
+        domains = tokenRouterDomainsPromise
+          ? await tokenRouterDomainsPromise
+          : await movableToken.domains();
         const allowedBridgesByDomain = await promiseObjAll(
           objMap(
             arrayToObject(domains.map((domain) => domain.toString())),
@@ -323,6 +336,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     const tokenFee = await this.fetchTokenFee(
       warpRouteAddress,
       feeDestinations.length ? feeDestinations : undefined,
+      tokenRouterDomainsPromise,
       isCrossCollateralTokenConfig(tokenConfig)
         ? tokenConfig.crossCollateralRouters
         : undefined,
@@ -351,6 +365,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
   public async fetchTokenFee(
     routerAddress: Address,
     destinations?: number[],
+    destinationsPromise?: Promise<number[] | undefined>,
     crossCollateralRouters?: Record<string, string[]>,
   ): Promise<DerivedTokenFeeConfig | undefined> {
     const TokenRouter = TokenRouter__factory.connect(
@@ -388,13 +403,15 @@ export class EvmWarpRouteReader extends EvmRouterReader {
 
     const routingDestinations =
       destinations ??
-      (await TokenRouter.domains().catch((error) => {
-        this.logger.debug(
-          `Failed to derive token router domains for routing fee config on "${this.chain}"`,
-          error,
-        );
-        return undefined;
-      }));
+      (destinationsPromise
+        ? await destinationsPromise
+        : await TokenRouter.domains().catch((error) => {
+            this.logger.debug(
+              `Failed to derive token router domains for routing fee config on "${this.chain}"`,
+              error,
+            );
+            return undefined;
+          }));
 
     const normalizedCrossCollateralRouters = crossCollateralRouters
       ? Object.fromEntries(

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -129,6 +129,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
   private readonly depositAddressDomainConfigsCache = new Map<
     Address,
     DepositAddressDomainConfigs
+  >();
   protected readonly packageVersionCache = new Map<string, string>();
   protected readonly packageVersionInflight = new Map<
     string,

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -408,9 +408,20 @@ export class EvmWarpRouteReader extends EvmRouterReader {
   public async fetchTokenFee(
     routerAddress: Address,
     destinations?: number[],
-    crossCollateralRouters?: Record<string, string[]>,
+    crossCollateralRoutersOrGetDestinations?:
+      | Record<string, string[]>
+      | (() => Promise<number[] | undefined>),
     getDestinationsPromise?: () => Promise<number[] | undefined>,
   ): Promise<DerivedTokenFeeConfig | undefined> {
+    const crossCollateralRouters =
+      typeof crossCollateralRoutersOrGetDestinations === 'function'
+        ? undefined
+        : crossCollateralRoutersOrGetDestinations;
+    const effectiveGetDestinationsPromise =
+      typeof crossCollateralRoutersOrGetDestinations === 'function'
+        ? crossCollateralRoutersOrGetDestinations
+        : getDestinationsPromise;
+
     const TokenRouter = TokenRouter__factory.connect(
       routerAddress,
       this.provider,
@@ -446,7 +457,10 @@ export class EvmWarpRouteReader extends EvmRouterReader {
 
     const routingDestinations =
       destinations ??
-      (await this.fetchTokenRouterDomains(TokenRouter, getDestinationsPromise));
+      (await this.fetchTokenRouterDomains(
+        TokenRouter,
+        effectiveGetDestinationsPromise,
+      ));
 
     const normalizedCrossCollateralRouters = crossCollateralRouters
       ? Object.fromEntries(
@@ -459,7 +473,9 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     return this.evmTokenFeeReader.deriveTokenFeeConfig({
       address: tokenFee,
       routingDestinations,
-      crossCollateralRouters: normalizedCrossCollateralRouters,
+      ...(normalizedCrossCollateralRouters
+        ? { crossCollateralRouters: normalizedCrossCollateralRouters }
+        : {}),
     });
   }
 

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -1,5 +1,5 @@
 import { compareVersions } from 'compare-versions';
-import { BigNumber, Contract, constants } from 'ethers';
+import { BigNumber, Contract, constants, utils } from 'ethers';
 
 import {
   CrossCollateralRouter__factory,
@@ -107,6 +107,20 @@ type DepositAddressDomainConfigs = [
   string[],
   BigNumber[],
 ];
+
+function decodeBigNumberResult(decoded: utils.Result): BigNumber {
+  return BigNumber.from(decoded[0]);
+}
+
+function decodeUint32Result(decoded: utils.Result): number {
+  return decodeBigNumberResult(decoded).toNumber();
+}
+
+function decodeUint32ArrayResult(decoded: utils.Result): number[] {
+  return (decoded[0] as ReadonlyArray<BigNumber | number | string>).map(
+    (value) => BigNumber.from(value).toNumber(),
+  );
+}
 
 export class EvmWarpRouteReader extends EvmRouterReader {
   protected readonly logger = rootLogger.child({
@@ -993,11 +1007,15 @@ export class EvmWarpRouteReader extends EvmRouterReader {
 
       const [minFinalityThreshold, maxFeePpm] = usesPpmName
         ? ((await this.readContractBatch<unknown>([
-            minFinalityThresholdCall,
+            {
+              ...minFinalityThresholdCall,
+              decode: decodeUint32Result,
+            },
             {
               target: hypToken,
               contractInterface: tokenBridgeV2Interface,
               method: 'maxFeePpm',
+              decode: decodeBigNumberResult,
             },
           ])) as [number, BigNumber])
         : await Promise.all([
@@ -1421,7 +1439,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       ],
       scale,
     ] = await Promise.all([
-      this.readContractBatch([
+      this.readContractBatch<unknown>([
         {
           target: hypTokenAddress,
           contractInterface: crossCollateralRouterInterface,
@@ -1431,18 +1449,21 @@ export class EvmWarpRouteReader extends EvmRouterReader {
           target: hypTokenAddress,
           contractInterface: tokenRouterInterface,
           method: 'domains',
+          decode: decodeUint32ArrayResult,
         },
         {
           target: hypTokenAddress,
           contractInterface: crossCollateralRouterInterface,
           method: 'getCrossCollateralDomains',
+          decode: decodeUint32ArrayResult,
         },
         {
           target: hypTokenAddress,
           contractInterface: crossCollateralRouterInterface,
           method: 'localDomain',
+          decode: decodeUint32Result,
         },
-      ]) as Promise<[Address, any[], any[], number]>,
+      ]) as Promise<[Address, number[], number[], number]>,
       this.fetchScale(hypTokenAddress),
     ]);
 
@@ -1452,11 +1473,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
 
     // Merge Router._routers domains, MC-enrolled domains, and localDomain
     const allDomains = [
-      ...new Set([
-        ...remoteDomains.map(Number),
-        ...crossCollateralDomains.map(Number),
-        localDomain,
-      ]),
+      ...new Set([...remoteDomains, ...crossCollateralDomains, localDomain]),
     ];
     const routersByDomain = await this.readContractBatch<string[]>(
       allDomains.map((domain) => ({

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -859,16 +859,25 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     const collateralConfig =
       await this.deriveHypCollateralTokenConfig(hypToken);
 
-    const tokenBridge = TokenBridgeCctpBase__factory.connect(
-      hypToken,
-      this.provider,
-    );
-
-    const [messageTransmitter, tokenMessenger, urls] = await Promise.all([
-      tokenBridge.messageTransmitter(),
-      tokenBridge.tokenMessenger(),
-      tokenBridge.urls(),
-    ]);
+    const tokenBridgeInterface = TokenBridgeCctpBase__factory.createInterface();
+    const [messageTransmitter, tokenMessenger, urls] =
+      (await this.readContractBatch([
+        {
+          target: hypToken,
+          contractInterface: tokenBridgeInterface,
+          method: 'messageTransmitter',
+        },
+        {
+          target: hypToken,
+          contractInterface: tokenBridgeInterface,
+          method: 'tokenMessenger',
+        },
+        {
+          target: hypToken,
+          contractInterface: tokenBridgeInterface,
+          method: 'urls',
+        },
+      ])) as [Address, Address, string[]];
 
     const onchainCctpVersion = await IMessageTransmitter__factory.connect(
       messageTransmitter,
@@ -885,29 +894,42 @@ export class EvmWarpRouteReader extends EvmRouterReader {
         urls,
       };
     } else if (onchainCctpVersion === 1) {
-      const tokenBridgeV2 = TokenBridgeCctpV2__factory.connect(
-        hypToken,
-        this.provider,
-      );
-
-      // Version-gate: >= 11.0.0 uses maxFeePpm(), older uses maxFeeBps()
+      const tokenBridgeV2Interface =
+        TokenBridgeCctpV2__factory.createInterface();
       const contractVersion = await this.fetchPackageVersion(hypToken);
       const usesPpmName =
         contractVersion !== undefined &&
         compareVersions(contractVersion, CCTP_PPM_PRECISION_VERSION) >= 0;
 
-      const [minFinalityThreshold, maxFeePpm] = await Promise.all([
-        tokenBridgeV2.minFinalityThreshold(),
-        usesPpmName
-          ? tokenBridgeV2.maxFeePpm()
-          : tokenBridgeV2.provider
-              .call({
-                to: hypToken,
-                // maxFeeBps() selector
-                data: '0xbf769a3f',
-              })
-              .then((result) => BigNumber.from(result)),
-      ]);
+      const calls = [
+        {
+          target: hypToken,
+          contractInterface: tokenBridgeV2Interface,
+          method: 'minFinalityThreshold',
+        },
+      ] as const;
+
+      const [minFinalityThreshold] = (await this.readContractBatch(
+        calls as any,
+      )) as [number];
+
+      const maxFeePpm = usesPpmName
+        ? (
+            await this.readContractBatch<BigNumber>([
+              {
+                target: hypToken,
+                contractInterface: tokenBridgeV2Interface,
+                method: 'maxFeePpm',
+              },
+            ])
+          )[0]
+        : await TokenBridgeCctpV2__factory.connect(hypToken, this.provider)
+            .provider.call({
+              to: hypToken,
+              data: '0xbf769a3f',
+            })
+            .then((result) => BigNumber.from(result));
+
       return {
         ...collateralConfig,
         type: TokenType.collateralCctp,
@@ -965,17 +987,35 @@ export class EvmWarpRouteReader extends EvmRouterReader {
   private async deriveHypCollateralOftTokenConfig(
     hypToken: Address,
   ): Promise<OftTokenConfig> {
-    const tokenBridge = TokenBridgeOft__factory.connect(
-      hypToken,
-      this.provider,
-    );
-
-    const [oft, token, extraOptions, domainMappingsRaw] = await Promise.all([
-      tokenBridge.oft(),
-      tokenBridge.token(),
-      tokenBridge.extraOptions(),
-      tokenBridge.getDomainMappings(),
-    ]);
+    const tokenBridgeInterface = TokenBridgeOft__factory.createInterface();
+    const [oft, token, extraOptions, domainMappingsRaw] =
+      (await this.readContractBatch([
+        {
+          target: hypToken,
+          contractInterface: tokenBridgeInterface,
+          method: 'oft',
+        },
+        {
+          target: hypToken,
+          contractInterface: tokenBridgeInterface,
+          method: 'token',
+        },
+        {
+          target: hypToken,
+          contractInterface: tokenBridgeInterface,
+          method: 'extraOptions',
+        },
+        {
+          target: hypToken,
+          contractInterface: tokenBridgeInterface,
+          method: 'getDomainMappings',
+        },
+      ])) as [
+        string,
+        Address,
+        string,
+        [Array<{ toString(): string }>, number[]],
+      ];
 
     const erc20Metadata = await this.fetchERC20Metadata(token);
 
@@ -1287,26 +1327,40 @@ export class EvmWarpRouteReader extends EvmRouterReader {
   private async deriveCrossCollateralTokenConfig(
     hypTokenAddress: Address,
   ): Promise<HypTokenConfig> {
-    const crossCollateralRouter = CrossCollateralRouter__factory.connect(
-      hypTokenAddress,
-      this.provider,
-    );
-    const tokenRouter = TokenRouter__factory.connect(
-      hypTokenAddress,
-      this.provider,
-    );
-
+    const crossCollateralRouterInterface =
+      CrossCollateralRouter__factory.createInterface();
+    const tokenRouterInterface = TokenRouter__factory.createInterface();
     const [
-      collateralTokenAddress,
-      remoteDomains,
-      crossCollateralDomains,
-      localDomain,
+      [
+        collateralTokenAddress,
+        remoteDomains,
+        crossCollateralDomains,
+        localDomain,
+      ],
       scale,
     ] = await Promise.all([
-      crossCollateralRouter.wrappedToken(),
-      tokenRouter.domains(),
-      crossCollateralRouter.getCrossCollateralDomains(),
-      crossCollateralRouter.localDomain(),
+      this.readContractBatch([
+        {
+          target: hypTokenAddress,
+          contractInterface: crossCollateralRouterInterface,
+          method: 'wrappedToken',
+        },
+        {
+          target: hypTokenAddress,
+          contractInterface: tokenRouterInterface,
+          method: 'domains',
+        },
+        {
+          target: hypTokenAddress,
+          contractInterface: crossCollateralRouterInterface,
+          method: 'getCrossCollateralDomains',
+        },
+        {
+          target: hypTokenAddress,
+          contractInterface: crossCollateralRouterInterface,
+          method: 'localDomain',
+        },
+      ]) as Promise<[Address, any[], any[], number]>,
       this.fetchScale(hypTokenAddress),
     ]);
 
@@ -1322,16 +1376,18 @@ export class EvmWarpRouteReader extends EvmRouterReader {
         localDomain,
       ]),
     ];
-    const crossCollateralRouters: Record<string, string[]> = {};
-
-    await Promise.all(
-      allDomains.map(async (domain) => {
-        const routers =
-          await crossCollateralRouter.getCrossCollateralRouters(domain);
-        if (routers.length > 0) {
-          crossCollateralRouters[domain.toString()] = [...routers];
-        }
-      }),
+    const routersByDomain = await this.readContractBatch<string[]>(
+      allDomains.map((domain) => ({
+        target: hypTokenAddress,
+        contractInterface: crossCollateralRouterInterface,
+        method: 'getCrossCollateralRouters',
+        args: [domain],
+      })),
+    );
+    const crossCollateralRouters = Object.fromEntries(
+      allDomains
+        .map((domain, index) => [domain.toString(), routersByDomain[index]])
+        .filter(([, routers]) => routers.length > 0),
     );
 
     return {
@@ -1347,12 +1403,24 @@ export class EvmWarpRouteReader extends EvmRouterReader {
   }
 
   async fetchERC20Metadata(tokenAddress: Address): Promise<TokenMetadata> {
-    const erc20 = HypERC20__factory.connect(tokenAddress, this.provider);
-    const [name, symbol, decimals] = await Promise.all([
-      erc20.name(),
-      erc20.symbol(),
-      erc20.decimals(),
-    ]);
+    const erc20Interface = HypERC20__factory.createInterface();
+    const [name, symbol, decimals] = (await this.readContractBatch([
+      {
+        target: tokenAddress,
+        contractInterface: erc20Interface,
+        method: 'name',
+      },
+      {
+        target: tokenAddress,
+        contractInterface: erc20Interface,
+        method: 'symbol',
+      },
+      {
+        target: tokenAddress,
+        contractInterface: erc20Interface,
+        method: 'decimals',
+      },
+    ])) as [string, string, number];
 
     return { name, symbol, decimals, isNft: false };
   }
@@ -1378,18 +1446,23 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       return;
     }
 
-    const tokenRouter = TokenRouter__factory.connect(
-      tokenRouterAddress,
-      this.provider,
-    );
-
     let result: NormalizedScale;
     if (hasScaleFractionInterface) {
-      // Read new format (scaleNumerator and scaleDenominator)
-      const [numerator, denominator] = await Promise.all([
-        tokenRouter.scaleNumerator(),
-        tokenRouter.scaleDenominator(),
-      ]);
+      const tokenRouterInterface = TokenRouter__factory.createInterface();
+      const [numerator, denominator] = (await this.readContractBatch<BigNumber>(
+        [
+          {
+            target: tokenRouterAddress,
+            contractInterface: tokenRouterInterface,
+            method: 'scaleNumerator',
+          },
+          {
+            target: tokenRouterAddress,
+            contractInterface: tokenRouterInterface,
+            method: 'scaleDenominator',
+          },
+        ],
+      )) as [BigNumber, BigNumber];
 
       result = {
         numerator: numerator.toBigInt(),
@@ -1499,13 +1572,18 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     const allDomains = [
       ...new Set([...routerDomains.map(Number), ...additionalDomains]),
     ].filter((domain) => domain !== selfDomain);
+    const routerInterface = TokenRouter__factory.createInterface();
+    const gasValues = await this.readContractBatch<BigNumber>(
+      allDomains.map((domain) => ({
+        target: warpRouteAddress,
+        contractInterface: routerInterface,
+        method: 'destinationGas',
+        args: [domain],
+      })),
+    );
 
     return Object.fromEntries(
-      await Promise.all(
-        allDomains.map(async (domain) => {
-          return [domain, (await warpRoute.destinationGas(domain)).toString()];
-        }),
-      ),
+      allDomains.map((domain, index) => [domain, gasValues[index].toString()]),
     );
   }
 }

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -220,11 +220,14 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       (await isProxy(this.provider, warpRouteAddress))
         ? this.fetchProxyAdminConfig(warpRouteAddress)
         : undefined)();
-    const [tokenConfig, routerConfig, proxyAdmin] = await Promise.all([
-      tokenConfigPromise,
-      routerConfigPromise,
-      proxyAdminPromise,
-    ]);
+    const [tokenConfig, routerConfig, proxyAdmin, tokenFee] = await Promise.all(
+      [
+        tokenConfigPromise,
+        routerConfigPromise,
+        proxyAdminPromise,
+        tokenFeePromise,
+      ],
+    );
 
     const ccrEnrolledDomains: number[] = [];
     if (
@@ -261,7 +264,6 @@ export class EvmWarpRouteReader extends EvmRouterReader {
 
     let allowedRebalancers: Address[] | undefined;
     let allowedRebalancingBridges: MovableTokenConfig['allowedRebalancingBridges'];
-    let domains: number[] | undefined;
 
     // Only movable collateral tokens (collateral/native) have rebalancing config
     if (
@@ -287,7 +289,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       }
 
       try {
-        domains = await movableToken.domains();
+        const domains = await movableToken.domains();
         const allowedBridgesByDomain = await promiseObjAll(
           objMap(
             arrayToObject(domains.map((domain) => domain.toString())),
@@ -324,7 +326,6 @@ export class EvmWarpRouteReader extends EvmRouterReader {
         ? tokenConfig.crossCollateralRouters
         : undefined,
     );
-
     // CCTP tokens implement their own ISM (the contract itself acts as the ISM via AbstractCcipReadIsm).
     // The ISM is hardcoded and not configurable, so we return zero address to match deploy config expectations.
     if (
@@ -529,141 +530,93 @@ export class EvmWarpRouteReader extends EvmRouterReader {
    * @returns The derived token type, which can be one of: collateralVault, collateral, native, or synthetic.
    */
   async deriveTokenType(warpRouteAddress: Address): Promise<TokenType> {
-    const contractTypes: Partial<
-      Record<TokenType, { factory: any; method: string }>
-    > = {
-      [TokenType.collateralVault]: {
+    const contractTypes = [
+      {
+        tokenType: TokenType.collateralVault,
         factory: HypERC4626OwnerCollateral__factory,
         method: 'assetDeposited',
       },
-      [TokenType.collateralVaultRebase]: {
+      {
+        tokenType: TokenType.collateralVaultRebase,
         factory: HypERC4626Collateral__factory,
         method: 'NULL_RECIPIENT',
       },
-      [TokenType.XERC20Lockbox]: {
+      {
+        tokenType: TokenType.XERC20Lockbox,
         factory: HypXERC20Lockbox__factory,
         method: 'lockbox',
       },
-      [TokenType.collateralDepositAddress]: {
+      {
+        tokenType: TokenType.collateralDepositAddress,
         factory: TokenBridgeDepositAddress__factory,
         method: 'getDomainConfigs',
       },
-      [TokenType.collateralOft]: {
+      {
+        tokenType: TokenType.collateralOft,
         factory: TokenBridgeOft__factory,
         method: 'oft',
       },
-      [TokenType.collateralCctp]: {
+      {
+        tokenType: TokenType.collateralCctp,
         factory: TokenBridgeCctpBase__factory,
         method: 'messageTransmitter',
       },
-      [TokenType.collateral]: {
+      {
+        tokenType: TokenType.collateral,
         factory: HypERC20Collateral__factory,
         method: 'wrappedToken',
       },
-      [TokenType.syntheticRebase]: {
+      {
+        tokenType: TokenType.syntheticRebase,
         factory: HypERC4626__factory,
         method: 'collateralDomain',
       },
-    };
+    ] as const;
+    const packageVersionPromise = this.fetchPackageVersion(warpRouteAddress);
 
     // Temporarily turn off SmartProvider logging
     // Provider errors are expected because deriving will call methods that may not exist in the Bytecode
     this.setSmartProviderLogLevel('silent');
 
     try {
-      // Use probe helpers so expected ABI misses do not enter SmartProvider's
-      // normal retry path during type inference.
-      for (const [tokenType, { factory, method }] of Object.entries(
-        contractTypes,
-      )) {
-        const probeResult = await this.probeContractCall(
-          warpRouteAddress,
-          factory.createInterface(),
+      const batchedProbeResults = await this.tryProbeContractBatch(
+        contractTypes.map(({ factory, method }) => ({
+          target: warpRouteAddress,
+          contractInterface: factory.createInterface(),
           method,
-        );
+        })),
+      );
+
+      for (let i = 0; i < contractTypes.length; i += 1) {
+        const { tokenType, factory, method } = contractTypes[i];
+        const probeResult =
+          batchedProbeResults !== undefined
+            ? batchedProbeResults[i]
+            : await this.probeContractCall(
+                warpRouteAddress,
+                factory.createInterface(),
+                method,
+              );
         if (probeResult === undefined) {
           continue;
         }
 
         if (tokenType === TokenType.collateral) {
-          const wrappedToken = probeResult as Address;
-
-          const xerc20Limit = await this.probeContractCall(
-            wrappedToken,
-            IXERC20__factory.createInterface(),
-            'mintingCurrentLimitOf(address)',
-            [warpRouteAddress],
-          );
-          if (xerc20Limit !== undefined) {
-            return TokenType.XERC20;
-          }
-
-          const fiatMintProbe = await this.probeContractCall(
-            wrappedToken,
-            IFiatToken__factory.createInterface(),
-            'mint',
-            [NON_ZERO_SENDER_ADDRESS, 1],
-            { from: warpRouteAddress },
-          );
-          if (fiatMintProbe !== undefined) {
-            return TokenType.collateralFiat;
-          }
-
-          const everclearAdapter = await this.probeContractCall(
+          return this.deriveCollateralSubtype(
             warpRouteAddress,
-            EverclearTokenBridge__factory.createInterface(),
-            'everclearAdapter',
+            probeResult as Address,
           );
-          if (everclearAdapter !== undefined) {
-            let everclearTokenType: TokenType = TokenType.collateralEverclear;
-            const depositGas = await this.probeContractEstimateGas({
-              from: NON_ZERO_SENDER_ADDRESS,
-              to: wrappedToken,
-              data: IWETH__factory.createInterface().encodeFunctionData(
-                'deposit',
-              ),
-              value: 0,
-            });
-
-            if (depositGas !== undefined) {
-              everclearTokenType = TokenType.ethEverclear;
-            }
-
-            return everclearTokenType;
-          }
-
-          const crossCollateralRouters = await this.probeContractCall(
-            warpRouteAddress,
-            CrossCollateralRouter__factory.createInterface(),
-            'getCrossCollateralRouters',
-            [0],
-          );
-          if (crossCollateralRouters !== undefined) {
-            return TokenType.crossCollateral;
-          }
         }
 
-        return tokenType as TokenType;
+        return tokenType;
       }
 
-      const packageVersion = await this.fetchPackageVersion(warpRouteAddress);
-      const hasTokenFeeInterface =
-        compareVersions(packageVersion, TOKEN_FEE_CONTRACT_VERSION) >= 0;
-
-      const isNativeToken = await this.isNativeWarpToken(
+      const fallbackTokenType = await this.deriveNativeOrSyntheticTokenType(
         warpRouteAddress,
-        hasTokenFeeInterface,
+        await packageVersionPromise,
       );
-      if (isNativeToken) {
-        return TokenType.native;
-      }
-
-      const isSyntheticToken = await this.isSyntheticWarpToken(
-        warpRouteAddress,
-        hasTokenFeeInterface,
-      );
-      if (isSyntheticToken) {
-        return TokenType.synthetic;
+      if (fallbackTokenType !== undefined) {
+        return fallbackTokenType;
       }
 
       throw new Error(
@@ -674,38 +627,101 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     }
   }
 
-  private async isNativeWarpToken(
+  private async deriveCollateralSubtype(
     warpRouteAddress: Address,
-    hasTokenFeeInterface: boolean,
-  ): Promise<boolean> {
-    if (hasTokenFeeInterface) {
-      const tokenAddress = await this.probeContractCall<Address>(
-        warpRouteAddress,
-        TokenRouter__factory.createInterface(),
-        'token',
-      );
+    wrappedToken: Address,
+  ): Promise<TokenType> {
+    const batchedSubtypeProbes = await this.tryProbeContractBatch([
+      {
+        target: wrappedToken,
+        contractInterface: IXERC20__factory.createInterface(),
+        method: 'mintingCurrentLimitOf(address)',
+        args: [warpRouteAddress],
+      },
+      {
+        target: warpRouteAddress,
+        contractInterface: EverclearTokenBridge__factory.createInterface(),
+        method: 'everclearAdapter',
+      },
+      {
+        target: warpRouteAddress,
+        contractInterface: CrossCollateralRouter__factory.createInterface(),
+        method: 'getCrossCollateralRouters',
+        args: [0],
+      },
+    ]);
 
-      return tokenAddress !== undefined && isZeroishAddress(tokenAddress);
+    const xerc20Limit =
+      batchedSubtypeProbes !== undefined
+        ? batchedSubtypeProbes[0]
+        : await this.probeContractCall(
+            wrappedToken,
+            IXERC20__factory.createInterface(),
+            'mintingCurrentLimitOf(address)',
+            [warpRouteAddress],
+          );
+    if (xerc20Limit !== undefined) {
+      return TokenType.XERC20;
     }
 
-    const gasEstimate = await this.probeContractEstimateGas(
-      await this.multiProvider.prepareTx(
-        this.chain,
-        {
-          to: warpRouteAddress,
-          value: BigNumber.from(0),
-        },
-        NON_ZERO_SENDER_ADDRESS,
-      ),
+    const fiatMintProbe = await this.probeContractCall(
+      wrappedToken,
+      IFiatToken__factory.createInterface(),
+      'mint',
+      [NON_ZERO_SENDER_ADDRESS, 1],
+      { from: warpRouteAddress },
     );
+    if (fiatMintProbe !== undefined) {
+      return TokenType.collateralFiat;
+    }
 
-    return gasEstimate !== undefined;
+    const everclearAdapter =
+      batchedSubtypeProbes !== undefined
+        ? batchedSubtypeProbes[1]
+        : await this.probeContractCall(
+            warpRouteAddress,
+            EverclearTokenBridge__factory.createInterface(),
+            'everclearAdapter',
+          );
+    if (everclearAdapter !== undefined) {
+      let everclearTokenType: TokenType = TokenType.collateralEverclear;
+      const depositGas = await this.probeContractEstimateGas({
+        from: NON_ZERO_SENDER_ADDRESS,
+        to: wrappedToken,
+        data: IWETH__factory.createInterface().encodeFunctionData('deposit'),
+        value: 0,
+      });
+
+      if (depositGas !== undefined) {
+        everclearTokenType = TokenType.ethEverclear;
+      }
+
+      return everclearTokenType;
+    }
+
+    const crossCollateralRouters =
+      batchedSubtypeProbes !== undefined
+        ? batchedSubtypeProbes[2]
+        : await this.probeContractCall(
+            warpRouteAddress,
+            CrossCollateralRouter__factory.createInterface(),
+            'getCrossCollateralRouters',
+            [0],
+          );
+    if (crossCollateralRouters !== undefined) {
+      return TokenType.crossCollateral;
+    }
+
+    return TokenType.collateral;
   }
 
-  private async isSyntheticWarpToken(
+  private async deriveNativeOrSyntheticTokenType(
     warpRouteAddress: Address,
-    hasTokenFeeInterface: boolean,
-  ): Promise<boolean> {
+    packageVersion: string,
+  ): Promise<TokenType | undefined> {
+    const hasTokenFeeInterface =
+      compareVersions(packageVersion, TOKEN_FEE_CONTRACT_VERSION) >= 0;
+
     if (hasTokenFeeInterface) {
       const tokenAddress = await this.probeContractCall<Address>(
         warpRouteAddress,
@@ -713,18 +729,47 @@ export class EvmWarpRouteReader extends EvmRouterReader {
         'token',
       );
 
-      return (
-        tokenAddress !== undefined && eqAddress(tokenAddress, warpRouteAddress)
-      );
+      if (tokenAddress === undefined) {
+        return undefined;
+      }
+      if (isZeroishAddress(tokenAddress)) {
+        return TokenType.native;
+      }
+      if (eqAddress(tokenAddress, warpRouteAddress)) {
+        return TokenType.synthetic;
+      }
+
+      return undefined;
     }
 
-    const decimals = await this.probeContractCall(
-      warpRouteAddress,
-      HypERC20__factory.createInterface(),
-      'decimals',
-    );
+    const [gasEstimateResult, decimalsResult] = await Promise.allSettled([
+      this.probeContractEstimateGas({
+        from: NON_ZERO_SENDER_ADDRESS,
+        to: warpRouteAddress,
+        value: BigNumber.from(0),
+      }),
+      this.probeContractCall(
+        warpRouteAddress,
+        HypERC20__factory.createInterface(),
+        'decimals',
+      ),
+    ]);
 
-    return decimals !== undefined;
+    if (gasEstimateResult.status === 'rejected') {
+      throw gasEstimateResult.reason;
+    }
+    if (gasEstimateResult.value !== undefined) {
+      return TokenType.native;
+    }
+
+    if (decimalsResult.status === 'rejected') {
+      throw decimalsResult.reason;
+    }
+    if (decimalsResult.value !== undefined) {
+      return TokenType.synthetic;
+    }
+
+    return undefined;
   }
 
   async fetchXERC20Config(

--- a/typescript/sdk/src/token/tokenMetadataUtils.test.ts
+++ b/typescript/sdk/src/token/tokenMetadataUtils.test.ts
@@ -1,0 +1,80 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import {
+  TestChainName,
+  test1,
+  testChainMetadata,
+} from '../consts/testChains.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+
+import { TokenMetadataMap } from './TokenMetadataMap.js';
+import { TokenType } from './config.js';
+import { deriveTokenMetadata } from './tokenMetadataUtils.js';
+import { WarpRouteDeployConfig } from './types.js';
+
+describe('deriveTokenMetadata', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('applies successful metadata updates before a later chain derivation fails', async () => {
+    const multiProvider = new MultiProvider(testChainMetadata);
+    const owner = '0x000000000000000000000000000000000000dEaD';
+    const mailbox = '0x000000000000000000000000000000000000b001';
+    const updateSpy = sandbox.spy(TokenMetadataMap.prototype, 'update');
+
+    sandbox.stub(multiProvider, 'getProtocol').returns(ProtocolType.Ethereum);
+    sandbox.stub(multiProvider, 'getChainMetadata').callsFake((chain) => {
+      if (chain === TestChainName.test2) {
+        throw new Error('test rpc error');
+      }
+      return testChainMetadata[chain];
+    });
+
+    const configMap: WarpRouteDeployConfig = {
+      [TestChainName.test1]: {
+        type: TokenType.native,
+        owner,
+        mailbox,
+        name: 'TKN',
+        symbol: 'TKN',
+        decimals: 18,
+      },
+      [TestChainName.test2]: {
+        type: TokenType.native,
+        owner,
+        mailbox,
+        name: 'TKN',
+        symbol: 'TKN',
+        decimals: 18,
+      },
+    };
+
+    try {
+      await deriveTokenMetadata(multiProvider, configMap);
+      expect.fail('expected deriveTokenMetadata to throw');
+    } catch (error) {
+      expect((error as Error).message).to.equal('test rpc error');
+    }
+
+    expect(
+      updateSpy.calledWith(
+        TestChainName.test1,
+        sinon.match({
+          decimals: test1.nativeToken!.decimals,
+          name: test1.nativeToken!.name,
+          symbol: test1.nativeToken!.symbol,
+        }),
+      ),
+    ).to.equal(true);
+  });
+});

--- a/typescript/sdk/src/token/tokenMetadataUtils.ts
+++ b/typescript/sdk/src/token/tokenMetadataUtils.ts
@@ -90,21 +90,28 @@ export async function deriveTokenMetadata(
         isEverclearCollateralTokenConfig(config)
       ) {
         const provider = multiProvider.getProvider(chain);
+        const batchContractAddress =
+          multiProvider.getChainMetadata(chain).batchContractAddress;
 
         if (config.isNft) {
           const erc721Interface = ERC721Enumerable__factory.createInterface();
-          const [name, symbol] = (await readContractsWithMulticall(provider, [
-            {
-              target: config.token,
-              contractInterface: erc721Interface,
-              method: 'name',
-            },
-            {
-              target: config.token,
-              contractInterface: erc721Interface,
-              method: 'symbol',
-            },
-          ])) as [string, string];
+          const [name, symbol] = (await readContractsWithMulticall(
+            provider,
+            [
+              {
+                target: config.token,
+                contractInterface: erc721Interface,
+                method: 'name',
+              },
+              {
+                target: config.token,
+                contractInterface: erc721Interface,
+                method: 'symbol',
+              },
+            ],
+            'latest',
+            batchContractAddress,
+          )) as [string, string];
           return [
             chain,
             TokenMetadataSchema.parse({
@@ -153,6 +160,8 @@ export async function deriveTokenMetadata(
               method: 'decimals',
             },
           ],
+          'latest',
+          batchContractAddress,
         )) as [string, string, number];
 
         return [

--- a/typescript/sdk/src/token/tokenMetadataUtils.ts
+++ b/typescript/sdk/src/token/tokenMetadataUtils.ts
@@ -60,10 +60,10 @@ export async function deriveTokenMetadata(
     }
   }
 
-  const derivedMetadata = await Promise.all(
+  await Promise.all(
     sortedEntries.map(async ([chain, config]) => {
       if (!isEVMLike(multiProvider.getProtocol(chain))) {
-        return [chain, undefined] as const;
+        return;
       }
 
       if (
@@ -71,14 +71,15 @@ export async function deriveTokenMetadata(
         isEverclearEthBridgeTokenConfig(config)
       ) {
         const nativeToken = multiProvider.getChainMetadata(chain).nativeToken;
-        return [
-          chain,
-          nativeToken
-            ? TokenMetadataSchema.parse({
-                ...nativeToken,
-              })
-            : undefined,
-        ] as const;
+        if (nativeToken) {
+          metadataMap.update(
+            chain,
+            TokenMetadataSchema.parse({
+              ...nativeToken,
+            }),
+          );
+        }
+        return;
       }
 
       if (
@@ -113,13 +114,14 @@ export async function deriveTokenMetadata(
             batchContractAddress,
             chain,
           )) as [string, string];
-          return [
+          metadataMap.update(
             chain,
             TokenMetadataSchema.parse({
               name,
               symbol,
             }),
-          ] as const;
+          );
+          return;
         }
 
         let token: string;
@@ -166,25 +168,17 @@ export async function deriveTokenMetadata(
           chain,
         )) as [string, string, number];
 
-        return [
+        metadataMap.update(
           chain,
           TokenMetadataSchema.parse({
             name,
             symbol,
             decimals,
           }),
-        ] as const;
+        );
       }
-
-      return [chain, undefined] as const;
     }),
   );
-
-  for (const [chain, metadata] of derivedMetadata) {
-    if (metadata) {
-      metadataMap.update(chain, metadata);
-    }
-  }
 
   metadataMap.finalize(validateScale);
   return metadataMap;

--- a/typescript/sdk/src/token/tokenMetadataUtils.ts
+++ b/typescript/sdk/src/token/tokenMetadataUtils.ts
@@ -111,6 +111,7 @@ export async function deriveTokenMetadata(
             ],
             'latest',
             batchContractAddress,
+            chain,
           )) as [string, string];
           return [
             chain,
@@ -162,6 +163,7 @@ export async function deriveTokenMetadata(
           ],
           'latest',
           batchContractAddress,
+          chain,
         )) as [string, string, number];
 
         return [

--- a/typescript/sdk/src/token/tokenMetadataUtils.ts
+++ b/typescript/sdk/src/token/tokenMetadataUtils.ts
@@ -7,6 +7,7 @@ import {
 import { isEVMLike } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../providers/MultiProvider.js';
+import { readContractsWithMulticall } from '../utils/multicall.js';
 
 import { TokenMetadataMap } from './TokenMetadataMap.js';
 import { TokenType } from './config.js';
@@ -57,90 +58,120 @@ export async function deriveTokenMetadata(
     if (isTokenMetadata(config)) {
       metadataMap.set(chain, TokenMetadataSchema.parse(config));
     }
+  }
 
-    if (!isEVMLike(multiProvider.getProtocol(chain))) {
-      continue;
-    }
-
-    if (
-      isNativeTokenConfig(config) ||
-      isEverclearEthBridgeTokenConfig(config)
-    ) {
-      const nativeToken = multiProvider.getChainMetadata(chain).nativeToken;
-      if (nativeToken) {
-        metadataMap.update(
-          chain,
-          TokenMetadataSchema.parse({
-            ...nativeToken,
-          }),
-        );
-        continue;
+  const derivedMetadata = await Promise.all(
+    sortedEntries.map(async ([chain, config]) => {
+      if (!isEVMLike(multiProvider.getProtocol(chain))) {
+        return [chain, undefined] as const;
       }
-    }
 
-    if (
-      isCollateralTokenConfig(config) ||
-      isCrossCollateralTokenConfig(config) ||
-      isXERC20TokenConfig(config) ||
-      isCctpTokenConfig(config) ||
-      isDepositAddressTokenConfig(config) ||
-      isEverclearCollateralTokenConfig(config)
-    ) {
-      const provider = multiProvider.getProvider(chain);
+      if (
+        isNativeTokenConfig(config) ||
+        isEverclearEthBridgeTokenConfig(config)
+      ) {
+        const nativeToken = multiProvider.getChainMetadata(chain).nativeToken;
+        return [
+          chain,
+          nativeToken
+            ? TokenMetadataSchema.parse({
+                ...nativeToken,
+              })
+            : undefined,
+        ] as const;
+      }
 
-      if (config.isNft) {
-        const erc721 = ERC721Enumerable__factory.connect(
-          config.token,
+      if (
+        isCollateralTokenConfig(config) ||
+        isCrossCollateralTokenConfig(config) ||
+        isXERC20TokenConfig(config) ||
+        isCctpTokenConfig(config) ||
+        isDepositAddressTokenConfig(config) ||
+        isEverclearCollateralTokenConfig(config)
+      ) {
+        const provider = multiProvider.getProvider(chain);
+
+        if (config.isNft) {
+          const erc721Interface = ERC721Enumerable__factory.createInterface();
+          const [name, symbol] = (await readContractsWithMulticall(provider, [
+            {
+              target: config.token,
+              contractInterface: erc721Interface,
+              method: 'name',
+            },
+            {
+              target: config.token,
+              contractInterface: erc721Interface,
+              method: 'symbol',
+            },
+          ])) as [string, string];
+          return [
+            chain,
+            TokenMetadataSchema.parse({
+              name,
+              symbol,
+            }),
+          ] as const;
+        }
+
+        let token: string;
+        switch (config.type) {
+          case TokenType.XERC20Lockbox:
+            token = await IXERC20Lockbox__factory.connect(
+              config.token,
+              provider,
+            ).callStatic.ERC20();
+            break;
+          case TokenType.collateralVault:
+            token = await IERC4626__factory.connect(
+              config.token,
+              provider,
+            ).callStatic.asset();
+            break;
+          default:
+            token = config.token;
+            break;
+        }
+
+        const erc20Interface = ERC20__factory.createInterface();
+        const [name, symbol, decimals] = (await readContractsWithMulticall(
           provider,
-        );
-        const [name, symbol] = await Promise.all([
-          erc721.name(),
-          erc721.symbol(),
-        ]);
-        metadataMap.update(
+          [
+            {
+              target: token,
+              contractInterface: erc20Interface,
+              method: 'name',
+            },
+            {
+              target: token,
+              contractInterface: erc20Interface,
+              method: 'symbol',
+            },
+            {
+              target: token,
+              contractInterface: erc20Interface,
+              method: 'decimals',
+            },
+          ],
+        )) as [string, string, number];
+
+        return [
           chain,
           TokenMetadataSchema.parse({
             name,
             symbol,
+            decimals,
           }),
-        );
-        continue;
+        ] as const;
       }
 
-      let token: string;
-      switch (config.type) {
-        case TokenType.XERC20Lockbox:
-          token = await IXERC20Lockbox__factory.connect(
-            config.token,
-            provider,
-          ).callStatic.ERC20();
-          break;
-        case TokenType.collateralVault:
-          token = await IERC4626__factory.connect(
-            config.token,
-            provider,
-          ).callStatic.asset();
-          break;
-        default:
-          token = config.token;
-          break;
-      }
+      return [chain, undefined] as const;
+    }),
+  );
 
-      const erc20 = ERC20__factory.connect(token, provider);
-      const [name, symbol, decimals] = await Promise.all([
-        erc20.name(),
-        erc20.symbol(),
-        erc20.decimals(),
-      ]);
-
-      metadataMap.update(
-        chain,
-        TokenMetadataSchema.parse({
-          name,
-          symbol,
-          decimals,
-        }),
-      );
+  for (const [chain, metadata] of derivedMetadata) {
+    if (metadata) {
+      metadataMap.update(chain, metadata);
     }
   }
 

--- a/typescript/sdk/src/utils/HyperlaneReader.test.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.test.ts
@@ -514,6 +514,29 @@ describe('HyperlaneReader', () => {
     ]);
   });
 
+  it('shares safe multicall support promises across concurrent callers', async () => {
+    const provider = new BatchReaderProvider({
+      supportsMulticall: true,
+      getCodeFailures: 1,
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const [firstResult, secondResult] = await Promise.all([
+      reader.testReadContractBatch(),
+      reader.testReadContractBatch(),
+    ]);
+
+    expect(firstResult).to.deep.equal([TEST_ADDRESS, TEST_ADDRESS_2]);
+    expect(secondResult).to.deep.equal([TEST_ADDRESS, TEST_ADDRESS_2]);
+    expect(provider.callTransactions.map((tx) => tx.to)).to.deep.equal([
+      TEST_ADDRESS,
+      TEST_ADDRESS_2,
+      TEST_ADDRESS,
+      TEST_ADDRESS_2,
+    ]);
+  });
+
   it('includes chain context when batched reads return failed subcalls', async () => {
     const provider = new BatchReaderProvider({
       supportsMulticall: true,

--- a/typescript/sdk/src/utils/HyperlaneReader.test.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.test.ts
@@ -67,6 +67,23 @@ class ReaderHarness extends HyperlaneReader {
       },
     ]) as Promise<[string, string]>;
   }
+
+  async testTryProbeContractBatch(): Promise<
+    [string | undefined, string | undefined] | undefined
+  > {
+    return this.tryProbeContractBatch<string>([
+      {
+        target: TEST_ADDRESS,
+        contractInterface: TEST_INTERFACE,
+        method: 'probe',
+      },
+      {
+        target: TEST_ADDRESS_2,
+        contractInterface: TEST_INTERFACE,
+        method: 'owner',
+      },
+    ]) as Promise<[string | undefined, string | undefined] | undefined>;
+  }
 }
 
 class ProbeReaderProvider extends providers.BaseProvider {
@@ -132,6 +149,7 @@ class BatchReaderProvider extends providers.BaseProvider {
     private readonly options: {
       supportsMulticall?: boolean;
       multicallError?: Error;
+      multicallSecondFailure?: boolean;
     } = {},
   ) {
     super({ name: 'test', chainId: 1 });
@@ -166,12 +184,17 @@ class BatchReaderProvider extends providers.BaseProvider {
               TEST_ADDRESS,
             ]),
           },
-          {
-            success: true,
-            returnData: TEST_INTERFACE.encodeFunctionResult('owner', [
-              TEST_ADDRESS_2,
-            ]),
-          },
+          this.options.multicallSecondFailure
+            ? {
+                success: false,
+                returnData: '0x',
+              }
+            : {
+                success: true,
+                returnData: TEST_INTERFACE.encodeFunctionResult('owner', [
+                  TEST_ADDRESS_2,
+                ]),
+              },
         ],
       ]);
     }
@@ -230,6 +253,36 @@ describe('HyperlaneReader', () => {
               code: -32000,
               data: '{}',
             },
+          },
+        },
+      ),
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const result = await reader.testProbeContractCall();
+
+    expect(result).to.be.undefined;
+  });
+
+  it('returns undefined when the RPC body nests ServerError(3) for regular providers', async () => {
+    const provider = new ProbeReaderProvider({
+      callError: Object.assign(
+        new Error('missing revert data in call exception'),
+        {
+          code: EthersError.CALL_EXCEPTION,
+          data: '0x',
+          error: {
+            code: EthersError.SERVER_ERROR,
+            body: JSON.stringify({
+              jsonrpc: '2.0',
+              id: 1,
+              error: {
+                code: -32603,
+                message:
+                  'ErrorObject { code: ServerError(3), message: "execution reverted", data: None }',
+              },
+            }),
           },
         },
       ),
@@ -421,5 +474,43 @@ describe('HyperlaneReader', () => {
       TEST_ADDRESS,
       TEST_ADDRESS_2,
     ]);
+  });
+
+  it('uses multicall for batched probe calls when available', async () => {
+    const provider = new BatchReaderProvider({ supportsMulticall: true });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const result = await reader.testTryProbeContractBatch();
+
+    expect(result).to.deep.equal([TEST_ADDRESS, TEST_ADDRESS_2]);
+    expect(provider.callTransactions).to.have.length(1);
+    expect(provider.callTransactions[0].to).to.equal(MULTICALL3_ADDRESS);
+  });
+
+  it('returns undefined when multicall probe batching is unavailable', async () => {
+    const provider = new BatchReaderProvider({ supportsMulticall: false });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const result = await reader.testTryProbeContractBatch();
+
+    expect(result).to.be.undefined;
+    expect(provider.callTransactions).to.have.length(0);
+  });
+
+  it('treats failed multicall probe subcalls as undefined', async () => {
+    const provider = new BatchReaderProvider({
+      supportsMulticall: true,
+      multicallSecondFailure: true,
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const result = await reader.testTryProbeContractBatch();
+
+    expect(result).to.deep.equal([TEST_ADDRESS, undefined]);
+    expect(provider.callTransactions).to.have.length(1);
+    expect(provider.callTransactions[0].to).to.equal(MULTICALL3_ADDRESS);
   });
 });

--- a/typescript/sdk/src/utils/HyperlaneReader.test.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.test.ts
@@ -12,8 +12,13 @@ import { HyperlaneReader } from './HyperlaneReader.js';
 
 const TEST_ADDRESS = '0x0000000000000000000000000000000000000001';
 const TEST_ADDRESS_2 = '0x0000000000000000000000000000000000000002';
+const MULTICALL3_ADDRESS = '0xcA11bde05977b3631167028862bE2a173976CA11';
 const TEST_INTERFACE = new utils.Interface([
   'function probe() view returns (address)',
+  'function owner() view returns (address)',
+]);
+const MULTICALL3_INTERFACE = new utils.Interface([
+  'function aggregate3((address target,bool allowFailure,bytes callData)[] calls) payable returns ((bool success,bytes returnData)[] returnData)',
 ]);
 
 class ReaderHarness extends HyperlaneReader {
@@ -46,6 +51,21 @@ class ReaderHarness extends HyperlaneReader {
       to: TEST_ADDRESS,
       ...overrides,
     });
+  }
+
+  async testReadContractBatch(): Promise<[string, string]> {
+    return this.readContractBatch<string>([
+      {
+        target: TEST_ADDRESS,
+        contractInterface: TEST_INTERFACE,
+        method: 'probe',
+      },
+      {
+        target: TEST_ADDRESS_2,
+        contractInterface: TEST_INTERFACE,
+        method: 'owner',
+      },
+    ]) as Promise<[string, string]>;
   }
 }
 
@@ -102,6 +122,77 @@ class ProbeMissSmartProvider extends HyperlaneSmartProvider {
 
   async probeEstimateGas(): Promise<BigNumber> {
     throw new ProbeMissError('probe miss');
+  }
+}
+
+class BatchReaderProvider extends providers.BaseProvider {
+  public readonly callTransactions: providers.TransactionRequest[] = [];
+
+  constructor(
+    private readonly options: {
+      supportsMulticall?: boolean;
+      multicallError?: Error;
+    } = {},
+  ) {
+    super({ name: 'test', chainId: 1 });
+  }
+
+  async getCode(address: string): Promise<string> {
+    return address.toLowerCase() === MULTICALL3_ADDRESS.toLowerCase() &&
+      this.options.supportsMulticall
+      ? '0x1234'
+      : '0x';
+  }
+
+  async call(
+    transaction: providers.TransactionRequest,
+    _blockTag?: providers.BlockTag,
+  ): Promise<string> {
+    this.callTransactions.push(transaction);
+
+    if (
+      transaction.to &&
+      transaction.to.toLowerCase() === MULTICALL3_ADDRESS.toLowerCase()
+    ) {
+      if (this.options.multicallError) {
+        throw this.options.multicallError;
+      }
+
+      return MULTICALL3_INTERFACE.encodeFunctionResult('aggregate3', [
+        [
+          {
+            success: true,
+            returnData: TEST_INTERFACE.encodeFunctionResult('probe', [
+              TEST_ADDRESS,
+            ]),
+          },
+          {
+            success: true,
+            returnData: TEST_INTERFACE.encodeFunctionResult('owner', [
+              TEST_ADDRESS_2,
+            ]),
+          },
+        ],
+      ]);
+    }
+
+    if (!transaction.to) {
+      throw new Error('missing target');
+    }
+
+    if (transaction.to.toLowerCase() === TEST_ADDRESS.toLowerCase()) {
+      return TEST_INTERFACE.encodeFunctionResult('probe', [TEST_ADDRESS]);
+    }
+
+    if (transaction.to.toLowerCase() === TEST_ADDRESS_2.toLowerCase()) {
+      return TEST_INTERFACE.encodeFunctionResult('owner', [TEST_ADDRESS_2]);
+    }
+
+    throw new Error(`unexpected target ${transaction.to}`);
+  }
+
+  async detectNetwork() {
+    return { name: 'test', chainId: 1 };
   }
 }
 
@@ -285,5 +376,50 @@ describe('HyperlaneReader', () => {
     expect(provider.lastEstimateGasTransaction?.maxPriorityFeePerGas).to.be
       .undefined;
     expect(provider.lastEstimateGasTransaction?.maxFeePerGas).to.be.undefined;
+  });
+
+  it('uses multicall for batched read calls when available', async () => {
+    const provider = new BatchReaderProvider({ supportsMulticall: true });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const result = await reader.testReadContractBatch();
+
+    expect(result).to.deep.equal([TEST_ADDRESS, TEST_ADDRESS_2]);
+    expect(provider.callTransactions).to.have.length(1);
+    expect(provider.callTransactions[0].to).to.equal(MULTICALL3_ADDRESS);
+  });
+
+  it('falls back to individual calls when multicall is unavailable', async () => {
+    const provider = new BatchReaderProvider({ supportsMulticall: false });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const result = await reader.testReadContractBatch();
+
+    expect(result).to.deep.equal([TEST_ADDRESS, TEST_ADDRESS_2]);
+    expect(provider.callTransactions).to.have.length(2);
+    expect(provider.callTransactions.map((tx) => tx.to)).to.deep.equal([
+      TEST_ADDRESS,
+      TEST_ADDRESS_2,
+    ]);
+  });
+
+  it('falls back to individual calls when the multicall request fails', async () => {
+    const provider = new BatchReaderProvider({
+      supportsMulticall: true,
+      multicallError: new Error('batch failed'),
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const result = await reader.testReadContractBatch();
+
+    expect(result).to.deep.equal([TEST_ADDRESS, TEST_ADDRESS_2]);
+    expect(provider.callTransactions.map((tx) => tx.to)).to.deep.equal([
+      MULTICALL3_ADDRESS,
+      TEST_ADDRESS,
+      TEST_ADDRESS_2,
+    ]);
   });
 });

--- a/typescript/sdk/src/utils/HyperlaneReader.test.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.test.ts
@@ -13,6 +13,8 @@ import { HyperlaneReader } from './HyperlaneReader.js';
 const TEST_ADDRESS = '0x0000000000000000000000000000000000000001';
 const TEST_ADDRESS_2 = '0x0000000000000000000000000000000000000002';
 const MULTICALL3_ADDRESS = '0xcA11bde05977b3631167028862bE2a173976CA11';
+const CUSTOM_BATCH_CONTRACT_ADDRESS =
+  '0x00000000000000000000000000000000000000bA';
 const TEST_INTERFACE = new utils.Interface([
   'function probe() view returns (address)',
   'function owner() view returns (address)',
@@ -150,13 +152,19 @@ class BatchReaderProvider extends providers.BaseProvider {
       supportsMulticall?: boolean;
       multicallError?: Error;
       multicallSecondFailure?: boolean;
+      multicallResult?: string;
+      batchContractAddress?: string;
     } = {},
   ) {
     super({ name: 'test', chainId: 1 });
   }
 
+  private get batchContractAddress(): string {
+    return this.options.batchContractAddress ?? MULTICALL3_ADDRESS;
+  }
+
   async getCode(address: string): Promise<string> {
-    return address.toLowerCase() === MULTICALL3_ADDRESS.toLowerCase() &&
+    return address.toLowerCase() === this.batchContractAddress.toLowerCase() &&
       this.options.supportsMulticall
       ? '0x1234'
       : '0x';
@@ -170,10 +178,14 @@ class BatchReaderProvider extends providers.BaseProvider {
 
     if (
       transaction.to &&
-      transaction.to.toLowerCase() === MULTICALL3_ADDRESS.toLowerCase()
+      transaction.to.toLowerCase() === this.batchContractAddress.toLowerCase()
     ) {
       if (this.options.multicallError) {
         throw this.options.multicallError;
+      }
+
+      if (this.options.multicallResult !== undefined) {
+        return this.options.multicallResult;
       }
 
       return MULTICALL3_INTERFACE.encodeFunctionResult('aggregate3', [
@@ -512,5 +524,42 @@ describe('HyperlaneReader', () => {
     expect(result).to.deep.equal([TEST_ADDRESS, undefined]);
     expect(provider.callTransactions).to.have.length(1);
     expect(provider.callTransactions[0].to).to.equal(MULTICALL3_ADDRESS);
+  });
+
+  it('returns undefined when batched probe wrappers return 0x', async () => {
+    const provider = new BatchReaderProvider({
+      supportsMulticall: true,
+      multicallResult: '0x',
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const result = await reader.testTryProbeContractBatch();
+
+    expect(result).to.be.undefined;
+    expect(provider.callTransactions).to.have.length(1);
+    expect(provider.callTransactions[0].to).to.equal(MULTICALL3_ADDRESS);
+  });
+
+  it('uses batchContractAddress from chain metadata for batched probe calls', async () => {
+    multiProvider = multiProvider.extendChainMetadata({
+      [TestChainName.test1]: {
+        batchContractAddress: CUSTOM_BATCH_CONTRACT_ADDRESS,
+      },
+    });
+    const provider = new BatchReaderProvider({
+      supportsMulticall: true,
+      batchContractAddress: CUSTOM_BATCH_CONTRACT_ADDRESS,
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    const result = await reader.testTryProbeContractBatch();
+
+    expect(result).to.deep.equal([TEST_ADDRESS, TEST_ADDRESS_2]);
+    expect(provider.callTransactions).to.have.length(1);
+    expect(provider.callTransactions[0].to).to.equal(
+      CUSTOM_BATCH_CONTRACT_ADDRESS,
+    );
   });
 });

--- a/typescript/sdk/src/utils/HyperlaneReader.test.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.test.ts
@@ -146,6 +146,7 @@ class ProbeMissSmartProvider extends HyperlaneSmartProvider {
 
 class BatchReaderProvider extends providers.BaseProvider {
   public readonly callTransactions: providers.TransactionRequest[] = [];
+  private remainingGetCodeFailures = 0;
 
   constructor(
     private readonly options: {
@@ -154,9 +155,11 @@ class BatchReaderProvider extends providers.BaseProvider {
       multicallSecondFailure?: boolean;
       multicallResult?: string;
       batchContractAddress?: string;
+      getCodeFailures?: number;
     } = {},
   ) {
     super({ name: 'test', chainId: 1 });
+    this.remainingGetCodeFailures = options.getCodeFailures ?? 0;
   }
 
   private get batchContractAddress(): string {
@@ -164,6 +167,11 @@ class BatchReaderProvider extends providers.BaseProvider {
   }
 
   async getCode(address: string): Promise<string> {
+    if (this.remainingGetCodeFailures > 0) {
+      this.remainingGetCodeFailures -= 1;
+      throw new Error('temporary getCode failure');
+    }
+
     return address.toLowerCase() === this.batchContractAddress.toLowerCase() &&
       this.options.supportsMulticall
       ? '0x1234'
@@ -486,6 +494,42 @@ describe('HyperlaneReader', () => {
       TEST_ADDRESS,
       TEST_ADDRESS_2,
     ]);
+  });
+
+  it('retries multicall support detection after transient getCode failures', async () => {
+    const provider = new BatchReaderProvider({
+      supportsMulticall: true,
+      getCodeFailures: 1,
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    await reader.testReadContractBatch();
+    await reader.testReadContractBatch();
+
+    expect(provider.callTransactions.map((tx) => tx.to)).to.deep.equal([
+      TEST_ADDRESS,
+      TEST_ADDRESS_2,
+      MULTICALL3_ADDRESS,
+    ]);
+  });
+
+  it('includes chain context when batched reads return failed subcalls', async () => {
+    const provider = new BatchReaderProvider({
+      supportsMulticall: true,
+      multicallSecondFailure: true,
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+
+    try {
+      await reader.testReadContractBatch();
+      expect.fail('Expected batched read to fail');
+    } catch (error) {
+      expect(String(error)).to.include(
+        'Multicall read failed for owner on 0x0000000000000000000000000000000000000002 (chain: test1)',
+      );
+    }
   });
 
   it('uses multicall for batched probe calls when available', async () => {

--- a/typescript/sdk/src/utils/HyperlaneReader.test.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.test.ts
@@ -86,6 +86,23 @@ class ReaderHarness extends HyperlaneReader {
       },
     ]) as Promise<[string | undefined, string | undefined] | undefined>;
   }
+
+  async testTryProbeContractBatchWithInterface(
+    contractInterface: utils.Interface,
+  ): Promise<[string | undefined, string | undefined] | undefined> {
+    return this.tryProbeContractBatch<string>([
+      {
+        target: TEST_ADDRESS,
+        contractInterface,
+        method: 'probe',
+      },
+      {
+        target: TEST_ADDRESS_2,
+        contractInterface: TEST_INTERFACE,
+        method: 'owner',
+      },
+    ]) as Promise<[string | undefined, string | undefined] | undefined>;
+  }
 }
 
 class ProbeReaderProvider extends providers.BaseProvider {
@@ -606,6 +623,30 @@ describe('HyperlaneReader', () => {
     expect(result).to.be.undefined;
     expect(provider.callTransactions).to.have.length(1);
     expect(provider.callTransactions[0].to).to.equal(MULTICALL3_ADDRESS);
+  });
+
+  it('returns undefined for batched probe decodes that hit BUFFER_OVERRUN', async () => {
+    const provider = new BatchReaderProvider({
+      supportsMulticall: true,
+    });
+    multiProvider.setProvider(TestChainName.test1, provider);
+    const reader = new ReaderHarness(multiProvider, TestChainName.test1);
+    const interfaceWithBufferOverrun = Object.assign(
+      Object.create(TEST_INTERFACE),
+      {
+        decodeFunctionResult: () => {
+          throw Object.assign(new Error('data out-of-bounds'), {
+            code: EthersError.BUFFER_OVERRUN,
+          });
+        },
+      },
+    ) as utils.Interface;
+
+    const result = await reader.testTryProbeContractBatchWithInterface(
+      interfaceWithBufferOverrun,
+    );
+
+    expect(result).to.deep.equal([undefined, TEST_ADDRESS_2]);
   });
 
   it('uses batchContractAddress from chain metadata for batched probe calls', async () => {

--- a/typescript/sdk/src/utils/HyperlaneReader.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.ts
@@ -8,7 +8,14 @@ import {
   isDeterministicCallException,
 } from '../providers/SmartProvider/SmartProvider.js';
 import { ChainNameOrId } from '../types.js';
-import { ReadContractCall, readContractsWithMulticall } from './multicall.js';
+import {
+  MULTICALL3_ADDRESS,
+  MULTICALL3_INTERFACE,
+  ReadContractCall,
+  normalizeDecodedResult,
+  readContractsWithMulticall,
+  supportsMulticall,
+} from './multicall.js';
 
 type NestedError = {
   cause?: unknown;
@@ -211,5 +218,68 @@ export class HyperlaneReader {
     blockTag: providers.BlockTag = 'latest',
   ): Promise<T[]> {
     return readContractsWithMulticall(this.provider, calls, blockTag);
+  }
+
+  protected async tryProbeContractBatch<T>(
+    calls: ReadContractCall<T>[],
+    blockTag: providers.BlockTag = 'latest',
+  ): Promise<Array<T | undefined> | undefined> {
+    if (!calls.length) {
+      return [];
+    }
+
+    if (!(await supportsMulticall(this.provider))) {
+      return undefined;
+    }
+
+    const response = await this.probeCall(
+      {
+        to: MULTICALL3_ADDRESS,
+        data: MULTICALL3_INTERFACE.encodeFunctionData('aggregate3', [
+          calls.map((call) => ({
+            target: call.target,
+            allowFailure: true,
+            callData: call.contractInterface.encodeFunctionData(
+              call.method,
+              call.args ?? [],
+            ),
+          })),
+        ]),
+      },
+      blockTag,
+    );
+    const [results] = MULTICALL3_INTERFACE.decodeFunctionResult(
+      'aggregate3',
+      response,
+    );
+
+    return calls.map((call, index) => {
+      const result = results[index] as {
+        success: boolean;
+        returnData: string;
+      };
+      if (!result.success || result.returnData === '0x') {
+        return undefined;
+      }
+
+      try {
+        return normalizeDecodedResult(
+          call.contractInterface.decodeFunctionResult(
+            call.method,
+            result.returnData,
+          ),
+          call.decode,
+        );
+      } catch (error) {
+        if (
+          (error as any)?.code === EthersError.INVALID_ARGUMENT ||
+          this.isProbeMissError(error)
+        ) {
+          return undefined;
+        }
+
+        throw error;
+      }
+    });
   }
 }

--- a/typescript/sdk/src/utils/HyperlaneReader.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.ts
@@ -1,5 +1,6 @@
 import { BigNumber, errors as EthersError, providers, utils } from 'ethers';
 import { LevelWithSilentOrString } from 'pino';
+import { rootLogger } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../providers/MultiProvider.js';
 import {
@@ -86,6 +87,7 @@ export async function performProbeEstimateGas(
 
 export class HyperlaneReader {
   provider: providers.Provider;
+  protected readonly logger = rootLogger.child({ module: 'HyperlaneReader' });
 
   constructor(
     protected readonly multiProvider: MultiProvider,
@@ -226,6 +228,7 @@ export class HyperlaneReader {
       calls,
       blockTag,
       this.getBatchContractAddress(),
+      this.multiProvider.getChainName(this.chain),
     );
   }
 
@@ -269,9 +272,13 @@ export class HyperlaneReader {
         'aggregate3',
         response,
       );
-    } catch {
+    } catch (error) {
       // Batched probe reads are an optimization only. If the wrapper call itself
       // is unavailable or returns unusable data, fall back to individual probes.
+      this.logger.debug(
+        { error, chain: this.chain, batchContractAddress },
+        'Failed to batch probe calls; falling back to individual probes',
+      );
       return undefined;
     }
 
@@ -291,7 +298,7 @@ export class HyperlaneReader {
         );
       } catch (error) {
         if (
-          (error as any)?.code === EthersError.INVALID_ARGUMENT ||
+          getNestedErrorWithCode(error, EthersError.INVALID_ARGUMENT) ||
           this.isProbeMissError(error)
         ) {
           return undefined;

--- a/typescript/sdk/src/utils/HyperlaneReader.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.ts
@@ -94,6 +94,10 @@ export class HyperlaneReader {
     this.provider = this.multiProvider.getProvider(chain);
   }
 
+  private getBatchContractAddress(): string | undefined {
+    return this.multiProvider.getChainMetadata(this.chain).batchContractAddress;
+  }
+
   /**
    * Conditionally sets the log level for a smart provider.
    *
@@ -217,7 +221,12 @@ export class HyperlaneReader {
     calls: ReadContractCall<T>[],
     blockTag: providers.BlockTag = 'latest',
   ): Promise<T[]> {
-    return readContractsWithMulticall(this.provider, calls, blockTag);
+    return readContractsWithMulticall(
+      this.provider,
+      calls,
+      blockTag,
+      this.getBatchContractAddress(),
+    );
   }
 
   protected async tryProbeContractBatch<T>(
@@ -228,36 +237,46 @@ export class HyperlaneReader {
       return [];
     }
 
-    if (!(await supportsMulticall(this.provider))) {
+    const batchContractAddress = this.getBatchContractAddress();
+    if (!(await supportsMulticall(this.provider, batchContractAddress))) {
       return undefined;
     }
 
-    const response = await this.probeCall(
-      {
-        to: MULTICALL3_ADDRESS,
-        data: MULTICALL3_INTERFACE.encodeFunctionData('aggregate3', [
-          calls.map((call) => ({
-            target: call.target,
-            allowFailure: true,
-            callData: call.contractInterface.encodeFunctionData(
-              call.method,
-              call.args ?? [],
-            ),
-          })),
-        ]),
-      },
-      blockTag,
-    );
-    const [results] = MULTICALL3_INTERFACE.decodeFunctionResult(
-      'aggregate3',
-      response,
-    );
+    let results: Array<{ success: boolean; returnData: string }>;
+    try {
+      const response = await this.probeCall(
+        {
+          to: batchContractAddress ?? MULTICALL3_ADDRESS,
+          data: MULTICALL3_INTERFACE.encodeFunctionData('aggregate3', [
+            calls.map((call) => ({
+              target: call.target,
+              allowFailure: true,
+              callData: call.contractInterface.encodeFunctionData(
+                call.method,
+                call.args ?? [],
+              ),
+            })),
+          ]),
+        },
+        blockTag,
+      );
+
+      if (response === '0x') {
+        return undefined;
+      }
+
+      [results] = MULTICALL3_INTERFACE.decodeFunctionResult(
+        'aggregate3',
+        response,
+      );
+    } catch {
+      // Batched probe reads are an optimization only. If the wrapper call itself
+      // is unavailable or returns unusable data, fall back to individual probes.
+      return undefined;
+    }
 
     return calls.map((call, index) => {
-      const result = results[index] as {
-        success: boolean;
-        returnData: string;
-      };
+      const result = results[index];
       if (!result.success || result.returnData === '0x') {
         return undefined;
       }

--- a/typescript/sdk/src/utils/HyperlaneReader.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.ts
@@ -299,6 +299,7 @@ export class HyperlaneReader {
       } catch (error) {
         if (
           getNestedErrorWithCode(error, EthersError.INVALID_ARGUMENT) ||
+          getNestedErrorWithCode(error, EthersError.BUFFER_OVERRUN) ||
           this.isProbeMissError(error)
         ) {
           return undefined;

--- a/typescript/sdk/src/utils/HyperlaneReader.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.ts
@@ -8,6 +8,7 @@ import {
   isDeterministicCallException,
 } from '../providers/SmartProvider/SmartProvider.js';
 import { ChainNameOrId } from '../types.js';
+import { ReadContractCall, readContractsWithMulticall } from './multicall.js';
 
 type NestedError = {
   cause?: unknown;
@@ -203,5 +204,12 @@ export class HyperlaneReader {
     }
 
     return isDeterministicCallException(callException);
+  }
+
+  protected async readContractBatch<T>(
+    calls: ReadContractCall<T>[],
+    blockTag: providers.BlockTag = 'latest',
+  ): Promise<T[]> {
+    return readContractsWithMulticall(this.provider, calls, blockTag);
   }
 }

--- a/typescript/sdk/src/utils/multicall.ts
+++ b/typescript/sdk/src/utils/multicall.ts
@@ -1,6 +1,6 @@
 import { providers, utils } from 'ethers';
 
-import { Address } from '@hyperlane-xyz/utils';
+import { Address, rootLogger } from '@hyperlane-xyz/utils';
 
 export const MULTICALL3_ADDRESS =
   '0xcA11bde05977b3631167028862bE2a173976CA11' as Address;
@@ -76,11 +76,17 @@ export async function supportsMulticall(
     multicallSupportCache.get(provider) ?? new Map<string, Promise<boolean>>();
   const supportPromise = provider
     .getCode(address)
-    .then((code) => code !== '0x')
-    .catch(() => false);
+    .then((code) => code !== '0x');
+  supportPromise.catch((error) => {
+    providerCache.delete(address);
+    rootLogger.debug(
+      { error, batchContractAddress: address },
+      'Failed to detect multicall support',
+    );
+  });
   providerCache.set(address, supportPromise);
   multicallSupportCache.set(provider, providerCache);
-  return supportPromise;
+  return supportPromise.catch(() => false);
 }
 
 export async function readContractsWithMulticall<T>(
@@ -88,6 +94,7 @@ export async function readContractsWithMulticall<T>(
   calls: ReadContractCall<T>[],
   blockTag: providers.BlockTag = 'latest',
   batchContractAddress?: string,
+  chainName?: string,
 ): Promise<T[]> {
   if (!calls.length) {
     return [];
@@ -122,7 +129,11 @@ export async function readContractsWithMulticall<T>(
       'aggregate3',
       response,
     );
-  } catch {
+  } catch (error) {
+    rootLogger.debug(
+      { error, batchContractAddress: address, chainName },
+      'Multicall wrapper call failed; falling back to individual calls',
+    );
     return callContractsIndividually(provider, calls, blockTag);
   }
 
@@ -133,7 +144,9 @@ export async function readContractsWithMulticall<T>(
     };
     if (!result.success) {
       throw new Error(
-        `Multicall read failed for ${call.method} on ${call.target}`,
+        `Multicall read failed for ${call.method} on ${call.target}${
+          chainName ? ` (chain: ${chainName})` : ''
+        }`,
       );
     }
 

--- a/typescript/sdk/src/utils/multicall.ts
+++ b/typescript/sdk/src/utils/multicall.ts
@@ -2,10 +2,10 @@ import { providers, utils } from 'ethers';
 
 import { Address } from '@hyperlane-xyz/utils';
 
-const MULTICALL3_ADDRESS =
+export const MULTICALL3_ADDRESS =
   '0xcA11bde05977b3631167028862bE2a173976CA11' as Address;
 
-const MULTICALL3_INTERFACE = new utils.Interface([
+export const MULTICALL3_INTERFACE = new utils.Interface([
   'function aggregate3((address target,bool allowFailure,bytes callData)[] calls) payable returns ((bool success,bytes returnData)[] returnData)',
 ]);
 
@@ -22,7 +22,7 @@ export interface ReadContractCall<T> {
   decode?: (decoded: utils.Result) => T;
 }
 
-function normalizeDecodedResult<T>(
+export function normalizeDecodedResult<T>(
   decoded: utils.Result,
   decode?: (decoded: utils.Result) => T,
 ): T {
@@ -58,7 +58,7 @@ async function callContractsIndividually<T>(
   );
 }
 
-async function supportsMulticall(
+export async function supportsMulticall(
   provider: providers.Provider,
 ): Promise<boolean> {
   const cached = multicallSupportCache.get(provider);

--- a/typescript/sdk/src/utils/multicall.ts
+++ b/typescript/sdk/src/utils/multicall.ts
@@ -77,16 +77,17 @@ export async function supportsMulticall(
   const supportPromise = provider
     .getCode(address)
     .then((code) => code !== '0x');
-  supportPromise.catch((error) => {
+  const safeSupportPromise = supportPromise.catch((error) => {
     providerCache.delete(address);
     rootLogger.debug(
       { error, batchContractAddress: address },
       'Failed to detect multicall support',
     );
+    return false;
   });
-  providerCache.set(address, supportPromise);
+  providerCache.set(address, safeSupportPromise);
   multicallSupportCache.set(provider, providerCache);
-  return supportPromise.catch(() => false);
+  return safeSupportPromise;
 }
 
 export async function readContractsWithMulticall<T>(

--- a/typescript/sdk/src/utils/multicall.ts
+++ b/typescript/sdk/src/utils/multicall.ts
@@ -11,7 +11,7 @@ export const MULTICALL3_INTERFACE = new utils.Interface([
 
 const multicallSupportCache = new WeakMap<
   providers.Provider,
-  Promise<boolean>
+  Map<string, Promise<boolean>>
 >();
 
 export interface ReadContractCall<T> {
@@ -31,6 +31,10 @@ export function normalizeDecodedResult<T>(
   }
 
   return (decoded.length === 1 ? decoded[0] : decoded) as T;
+}
+
+function getBatchContractAddress(batchContractAddress?: string): string {
+  return batchContractAddress ?? MULTICALL3_ADDRESS;
 }
 
 async function callContractsIndividually<T>(
@@ -60,17 +64,22 @@ async function callContractsIndividually<T>(
 
 export async function supportsMulticall(
   provider: providers.Provider,
+  batchContractAddress?: string,
 ): Promise<boolean> {
-  const cached = multicallSupportCache.get(provider);
+  const address = getBatchContractAddress(batchContractAddress);
+  const cached = multicallSupportCache.get(provider)?.get(address);
   if (cached) {
     return cached;
   }
 
+  const providerCache =
+    multicallSupportCache.get(provider) ?? new Map<string, Promise<boolean>>();
   const supportPromise = provider
-    .getCode(MULTICALL3_ADDRESS)
+    .getCode(address)
     .then((code) => code !== '0x')
     .catch(() => false);
-  multicallSupportCache.set(provider, supportPromise);
+  providerCache.set(address, supportPromise);
+  multicallSupportCache.set(provider, providerCache);
   return supportPromise;
 }
 
@@ -78,12 +87,14 @@ export async function readContractsWithMulticall<T>(
   provider: providers.Provider,
   calls: ReadContractCall<T>[],
   blockTag: providers.BlockTag = 'latest',
+  batchContractAddress?: string,
 ): Promise<T[]> {
   if (!calls.length) {
     return [];
   }
 
-  if (!(await supportsMulticall(provider))) {
+  const address = getBatchContractAddress(batchContractAddress);
+  if (!(await supportsMulticall(provider, address))) {
     return callContractsIndividually(provider, calls, blockTag);
   }
 
@@ -102,7 +113,7 @@ export async function readContractsWithMulticall<T>(
 
     const response = await provider.call(
       {
-        to: MULTICALL3_ADDRESS,
+        to: address,
         data: callData,
       },
       blockTag,

--- a/typescript/sdk/src/utils/multicall.ts
+++ b/typescript/sdk/src/utils/multicall.ts
@@ -1,0 +1,137 @@
+import { providers, utils } from 'ethers';
+
+import { Address } from '@hyperlane-xyz/utils';
+
+const MULTICALL3_ADDRESS =
+  '0xcA11bde05977b3631167028862bE2a173976CA11' as Address;
+
+const MULTICALL3_INTERFACE = new utils.Interface([
+  'function aggregate3((address target,bool allowFailure,bytes callData)[] calls) payable returns ((bool success,bytes returnData)[] returnData)',
+]);
+
+const multicallSupportCache = new WeakMap<
+  providers.Provider,
+  Promise<boolean>
+>();
+
+export interface ReadContractCall<T> {
+  target: Address;
+  contractInterface: utils.Interface;
+  method: string;
+  args?: readonly unknown[];
+  decode?: (decoded: utils.Result) => T;
+}
+
+function normalizeDecodedResult<T>(
+  decoded: utils.Result,
+  decode?: (decoded: utils.Result) => T,
+): T {
+  if (decode) {
+    return decode(decoded);
+  }
+
+  return (decoded.length === 1 ? decoded[0] : decoded) as T;
+}
+
+async function callContractsIndividually<T>(
+  provider: providers.Provider,
+  calls: ReadContractCall<T>[],
+  blockTag: providers.BlockTag,
+): Promise<T[]> {
+  return Promise.all(
+    calls.map(async (call) => {
+      const result = await provider.call(
+        {
+          to: call.target,
+          data: call.contractInterface.encodeFunctionData(
+            call.method,
+            call.args ?? [],
+          ),
+        },
+        blockTag,
+      );
+      return normalizeDecodedResult(
+        call.contractInterface.decodeFunctionResult(call.method, result),
+        call.decode,
+      );
+    }),
+  );
+}
+
+async function supportsMulticall(
+  provider: providers.Provider,
+): Promise<boolean> {
+  const cached = multicallSupportCache.get(provider);
+  if (cached) {
+    return cached;
+  }
+
+  const supportPromise = provider
+    .getCode(MULTICALL3_ADDRESS)
+    .then((code) => code !== '0x')
+    .catch(() => false);
+  multicallSupportCache.set(provider, supportPromise);
+  return supportPromise;
+}
+
+export async function readContractsWithMulticall<T>(
+  provider: providers.Provider,
+  calls: ReadContractCall<T>[],
+  blockTag: providers.BlockTag = 'latest',
+): Promise<T[]> {
+  if (!calls.length) {
+    return [];
+  }
+
+  if (!(await supportsMulticall(provider))) {
+    return callContractsIndividually(provider, calls, blockTag);
+  }
+
+  let results: readonly unknown[];
+  try {
+    const callData = MULTICALL3_INTERFACE.encodeFunctionData('aggregate3', [
+      calls.map((call) => ({
+        target: call.target,
+        allowFailure: true,
+        callData: call.contractInterface.encodeFunctionData(
+          call.method,
+          call.args ?? [],
+        ),
+      })),
+    ]);
+
+    const response = await provider.call(
+      {
+        to: MULTICALL3_ADDRESS,
+        data: callData,
+      },
+      blockTag,
+    );
+    [results] = MULTICALL3_INTERFACE.decodeFunctionResult(
+      'aggregate3',
+      response,
+    );
+  } catch {
+    return callContractsIndividually(provider, calls, blockTag);
+  }
+
+  return calls.map((call, index) => {
+    const result = results[index] as {
+      success: boolean;
+      returnData: string;
+    };
+    if (!result.success) {
+      throw new Error(
+        `Multicall read failed for ${call.method} on ${call.target}`,
+      );
+    }
+
+    return normalizeDecodedResult(
+      call.contractInterface.decodeFunctionResult(
+        call.method,
+        result.returnData,
+      ),
+      call.decode,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Stacked on #8434.

This follow-up speeds up EVM warp read paths by batching same-chain reads and probe calls through `Multicall3` when available, with safe fallback to individual calls when it is not.

Scope in this PR:
- `EvmRouterReader` batched mailbox client reads and remote router reads
- `EvmWarpRouteReader` batched destination gas, ERC20 metadata, cross-collateral router reads, token-type/subtype probes, and several token-specific read clusters
- `EvmTokenFeeReader` batched linear/routing fee reads and routing fee sub-contract lookups
- `deriveTokenMetadata()` batched ERC20/ERC721 metadata reads and parallelized per-chain derivation
- honored per-chain `batchContractAddress` metadata when batching via multicall
- started token fee derivation earlier so it overlaps with token/router reads
- treated nested `ServerError(3)` RPC bodies as deterministic probe misses
- added shared `readContractBatch()` / `tryProbeContractBatch()` / `readContractsWithMulticall()` helpers and tests

This is read-path only. It helps:
- `warp read`
- `warp apply` read/diff paths via `EvmWarpModule.read()`
- `warp deploy` metadata derivation via `deriveTokenMetadata()`

It does not batch transactions or add multicall-based writes.

## Why Wall Time Only Partly Moves

This patch reduces RPC round-trips and fallback churn more than pure wall-clock latency on a healthy RPC.

Most of the old code already used `Promise.all`, so many reads were already parallel. Replacing N parallel `eth_call`s with 1 `aggregate3` call reduces request count and provider pressure, but does not automatically reduce latency when the RPC already serves those requests concurrently.

So the expected win from this PR is:
- fewer RPC requests
- less pressure on public/fallback RPCs
- fewer probe-path failures on providers that wrap deterministic reverts oddly
- better completion rate on noisy routes

Not necessarily:
- huge wall-clock wins on a single healthy private RPC

I also tried separate hook/ISM reader batching/caching changes on top of this branch and reverted them. Live reads were flat to slightly worse (`USDC/ancient8-ethereum` `10.60s -> 11.95s`, `USDC/eclipsemainnet` `9.27s -> 10.33s`), so they are intentionally not part of this PR.

## Live Warp Read Sample

Refreshed on March 25, 2026 after the earlier table drifted. Sampled 10 mainnet3 warp route IDs from `typescript/infra/config/environments/mainnet3/warp/warpIds.ts`. Each route was run 3x with a nominal `60s` per-command cap, paired in order per route (`branch1, cli1, branch2, cli2, branch3, cli3`):

- branch: `pnpm -C typescript/cli exec tsx cli.ts warp read ...`
- released CLI: `hyperlane warp read ...`
- both sides reported `29.0.1`
- all successful branch/CLI output files were byte-identical

| Route | Chains | Branch runs | CLI runs | Branch med | CLI med |
| --- | ---: | --- | --- | ---: | ---: |
| `CBBTC/base-zeronetwork` | 2 | `12.11, 11.89, 17.92` | `38.29, 47.03, 33.44` | `12.11s` | `38.29s` |
| `USDC/ancient8-ethereum` | 2 | `11.77, 11.75, 12.56` | `35.87, 35.68, 31.56` | `11.77s` | `35.68s` |
| `USDC/ethereum-ink` | 2 | `8.05, 6.69, 7.08` | `11.04, 10.66, 10.74` | `7.08s` | `10.74s` |
| `CBBTC/base-ethereum-superseed` | 3 | `7.79, 11.68, 7.69` | `14.63, 14.34, 14.26` | `7.79s` | `14.34s` |
| `HYPER/arbitrum-base-bsc-ethereum-optimism` | 5 | `39.25, 52.04, 50.87` | `timeout, timeout, timeout` | `50.87s` | `-` |
| `USDC/arbitrum-base-ethereum-lisk-optimism-polygon-zeronetwork` | 7 | `50.24, 61.26, 51.57` | `timeout, timeout, timeout` | `51.57s` | `-` |
| `USDC/superseed` | 7 | `51.55, 72.34, 62.45` | `timeout, timeout, timeout` | `62.45s` | `-` |
| `USDT/arbitrum-ethereum-mantle-mode-polygon-scroll-zeronetwork` | 7 | `66.36, 71.49, 76.58` | `timeout, timeout, timeout` | `71.49s` | `-` |
| `ETH/arbitrum-base-blast-bsc-ethereum-gnosis-lisk-mantle-mode-optimism-polygon-scroll-zeronetwork-zoramainnet` | 14 | `72.63, 64.59, 62.49` | `timeout, timeout, timeout` | `64.59s` | `-` |
| `USDC/eclipsemainnet` | 14 | `12.73, 12.94, 9.79` | `timeout, timeout, timeout` | `12.73s` | `-` |

Takeaways:
- Branch completed `30/30` runs; released CLI completed `12/30` runs.
- On the 4 routes where both sides completed all 3 runs, branch median was ~`2.39x` faster on average.
- On the remaining 6 routes, branch completed `3/3` while the released CLI timed out `3/3` under the same cap.
- `USDC/eclipsemainnet` in particular moved from the earlier noisy `25-32s` band to `9.79-12.94s` on this rerun, so the old table was materially stale.

## Notes On Error Handling

The nested `ServerError(3)` handling is generic to the RPC error shape, not Base-specific chain logic. Base public RPCs were the concrete reproduction. If another provider on Arbitrum or elsewhere emits the same nested revert body inside top-level `-32603`, it gets the same deterministic probe handling; providers that do not emit that shape are unchanged.

## Verification

- `pnpm -C typescript/sdk exec mocha --config .mocharc.json src/providers/SmartProvider/SmartProvider.test.ts --exit`
- `pnpm -C typescript/sdk exec mocha --config .mocharc.json src/utils/HyperlaneReader.test.ts --exit`
- `NODE_OPTIONS='--import tsx/esm' pnpm -C typescript/sdk exec hardhat --config hardhat.config.cts test ./src/token/EvmWarpRouteReader.hardhat-test.ts`
- `NODE_OPTIONS='--import tsx/esm' pnpm -C typescript/sdk exec hardhat --config hardhat.config.cts test ./src/fee/EvmTokenFeeReader.hardhat-test.ts`
- `pnpm -C typescript/sdk exec eslint src/providers/SmartProvider/SmartProvider.ts src/providers/SmartProvider/SmartProvider.test.ts src/utils/multicall.ts src/utils/HyperlaneReader.ts src/utils/HyperlaneReader.test.ts src/router/EvmRouterReader.ts src/token/EvmWarpRouteReader.ts src/token/EvmWarpRouteReader.hardhat-test.ts src/token/tokenMetadataUtils.ts src/fee/EvmTokenFeeReader.ts`
- `pnpm -C typescript/sdk build`
- live `warp read` matrix above
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it rewires core EVM warp-route read/probe paths to use Multicall3 batching and new fallback logic, which could change error-handling and decoded results across varied RPC providers.
> 
> **Overview**
> Speeds up EVM warp-route reads by **batching same-chain `eth_call` clusters through Multicall3** (with automatic fallback to individual calls) and reordering work so **token fee derivation starts earlier and overlaps** other reads.
> 
> Adds shared batching utilities (`readContractsWithMulticall`, `HyperlaneReader.readContractBatch`, `HyperlaneReader.tryProbeContractBatch`) with caching of multicall support detection and improved error messages when subcalls fail, and wires these into `EvmWarpRouteReader`, `EvmRouterReader`, and `EvmTokenFeeReader` for domains/routers, destination gas, ERC20 metadata, cross-collateral routing, and routing-fee sublookups.
> 
> Improves probe robustness by treating RPC responses that wrap deterministic `ServerError(3)` reverts inside top-level `-32603` errors as probe misses, and extends chain metadata with optional `batchContractAddress` to support non-canonical multicall deployments; adds focused unit/hardhat tests for batching and the new error shape handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fc54f210f3a6b77335d9116b6ac4781c065f1f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

