### PR TITLE
feat(sdk): add IGP fee token oracle config and warp route feeHook support

### DIFF
--- a/.changeset/igp-fee-token-support.md
+++ b/.changeset/igp-fee-token-support.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Added SDK support for IGP fee token oracle configuration and warp route feeHook. The IGP schema now accepts `tokenOracleConfig` for per-ERC20 gas oracle configs, and warp route configs accept `feeHook` for setting the IGP address as a fee hook on TokenRouter. Full pipeline support across deploy, read, update, and check flows.

--- a/.changeset/neat-igp-upgrades.md
+++ b/.changeset/neat-igp-upgrades.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-The compare-versions dependency was moved to the workspace catalog, and contract-version utility helpers were exported for infra reuse.
+The compare-versions dependency was moved to the workspace catalog.

--- a/.changeset/neat-igp-upgrades.md
+++ b/.changeset/neat-igp-upgrades.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The compare-versions dependency was moved to the workspace catalog.

--- a/.changeset/neat-igp-upgrades.md
+++ b/.changeset/neat-igp-upgrades.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-The compare-versions dependency was moved to the workspace catalog.
+The compare-versions dependency was moved to the workspace catalog, and contract-version utility helpers were exported for infra reuse.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1471,6 +1471,9 @@ importers:
       chalk:
         specifier: 'catalog:'
         version: 5.6.2
+      compare-versions:
+        specifier: ^6.1.1
+        version: 6.1.1
       deep-object-diff:
         specifier: ^1.1.9
         version: 1.1.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ catalogs:
     chalk:
       specifier: ^5.3.0
       version: 5.6.2
+    compare-versions:
+      specifier: ^6.1.1
+      version: 6.1.1
     cosmjs-types:
       specifier: ^0.9.0
       version: 0.9.0
@@ -1472,7 +1475,7 @@ importers:
         specifier: 'catalog:'
         version: 5.6.2
       compare-versions:
-        specifier: ^6.1.1
+        specifier: 'catalog:'
         version: 6.1.1
       deep-object-diff:
         specifier: ^1.1.9
@@ -2248,7 +2251,7 @@ importers:
         specifier: 'catalog:'
         version: 0.7.0
       compare-versions:
-        specifier: ^6.1.1
+        specifier: 'catalog:'
         version: 6.1.1
       cosmjs-types:
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,7 @@ catalog:
   yaml: 2.4.5
   lodash-es: ^4.17.21
   borsh: ^0.7.0
+  compare-versions: ^6.1.1
   dotenv: ^10.0.0
   asn1.js: ^5.4.1
   uuid: ^10.0.0

--- a/typescript/cli/src/commands/hook.ts
+++ b/typescript/cli/src/commands/hook.ts
@@ -1,5 +1,7 @@
 import { type CommandModule } from 'yargs';
 
+import { assert } from '@hyperlane-xyz/utils';
+
 import {
   type CommandModuleWithContext,
   type CommandModuleWithWriteContext,
@@ -97,7 +99,14 @@ export const read: CommandModuleWithContext<{
     await readHookConfig({
       ...args,
       feeTokens: args.feeTokens
-        ? args.feeTokens.split(',').map((t) => t.trim())
+        ? (() => {
+            const tokens = args.feeTokens!.split(',').map((t) => t.trim());
+            assert(
+              tokens.every((t) => t.length > 0),
+              '--fee-tokens contains an empty entry; check for trailing commas or double commas',
+            );
+            return tokens;
+          })()
         : undefined,
     });
     process.exit(0);

--- a/typescript/cli/src/commands/hook.ts
+++ b/typescript/cli/src/commands/hook.ts
@@ -73,6 +73,7 @@ export const read: CommandModuleWithContext<{
   chain: string;
   address: string;
   out: string;
+  feeTokens?: string;
 }> = {
   command: 'read',
   describe: 'Reads onchain Hook configuration for a given address',
@@ -83,11 +84,22 @@ export const read: CommandModuleWithContext<{
     },
     address: addressCommandOption('Address of the Hook to read.', true),
     out: outputFileCommandOption(),
+    'fee-tokens': {
+      type: 'string',
+      description:
+        'Comma-separated ERC20 fee token addresses to include token oracle config (IGP hooks only)',
+      alias: 'ft',
+    },
   },
   handler: async (args) => {
     logGray('Hyperlane Hook Read');
     logGray('------------------');
-    await readHookConfig(args);
+    await readHookConfig({
+      ...args,
+      feeTokens: args.feeTokens
+        ? args.feeTokens.split(',').map((t) => t.trim())
+        : undefined,
+    });
     process.exit(0);
   },
 };

--- a/typescript/cli/src/hook/read.ts
+++ b/typescript/cli/src/hook/read.ts
@@ -3,6 +3,7 @@ import { type ChainName, EvmHookReader } from '@hyperlane-xyz/sdk';
 import {
   type Address,
   ProtocolType,
+  assert,
   stringifyObject,
 } from '@hyperlane-xyz/utils';
 
@@ -43,6 +44,10 @@ export async function readHookConfig({
       break;
     }
     default: {
+      assert(
+        !feeTokens,
+        `--fee-tokens is only supported for EVM chains (${ProtocolType.Ethereum}, ${ProtocolType.Tron}), not ${protocol}`,
+      );
       const metadata = context.multiProvider.getChainMetadata(chain);
       const addresses = await context.registry.getChainAddresses(chain);
       const hookReader = createHookReader(metadata, context.multiProvider, {

--- a/typescript/cli/src/hook/read.ts
+++ b/typescript/cli/src/hook/read.ts
@@ -18,18 +18,20 @@ export async function readHookConfig({
   chain,
   address,
   out,
+  feeTokens,
 }: {
   context: CommandContext;
   chain: ChainName;
   address: Address;
   out?: string;
+  feeTokens?: Address[];
 }): Promise<void> {
   const protocol = context.multiProvider.getProtocol(chain);
   switch (protocol) {
     case ProtocolType.Tron:
     case ProtocolType.Ethereum: {
       const hookReader = new EvmHookReader(context.multiProvider, chain);
-      const config = await hookReader.deriveHookConfig(address);
+      const config = await hookReader.deriveHookConfig(address, feeTokens);
       const stringConfig = stringifyObject(config, resolveFileFormat(out), 2);
       if (!out) {
         logBlue(`Hook Config at ${address} on ${chain}:`);

--- a/typescript/infra/.gitignore
+++ b/typescript/infra/.gitignore
@@ -7,6 +7,7 @@ deployment-plan.yaml
 deployment-plans/
 test/outputs
 safe-tx-output/
+igp-upgrade-output/
 config/environments/test/core/
 config/environments/test/igp/
 config/environments/test/ism/

--- a/typescript/infra/.gitignore
+++ b/typescript/infra/.gitignore
@@ -11,6 +11,5 @@ igp-upgrade-output/
 config/environments/test/core/
 config/environments/test/igp/
 config/environments/test/ism/
-safe-tx-output/
 safe-tx-parse-results*
 squads-tx-parse-results*

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -80,7 +80,7 @@
     "borsh": "catalog:",
     "bs58": "^6.0.0",
     "chalk": "catalog:",
-    "compare-versions": "^6.1.1",
+    "compare-versions": "catalog:",
     "deep-object-diff": "^1.1.9",
     "dotenv": "catalog:",
     "json-stable-stringify": "^1.1.1",

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -80,6 +80,7 @@
     "borsh": "catalog:",
     "bs58": "^6.0.0",
     "chalk": "catalog:",
+    "compare-versions": "^6.1.1",
     "deep-object-diff": "^1.1.9",
     "dotenv": "catalog:",
     "json-stable-stringify": "^1.1.1",

--- a/typescript/infra/scripts/igp/clone-igp-with-token-oracle.ts
+++ b/typescript/infra/scripts/igp/clone-igp-with-token-oracle.ts
@@ -170,12 +170,16 @@ async function main() {
   const missingPriceData = remoteChains.filter(
     (c) => !gasPrices[c] || !tokenPrices[c],
   );
-  assert(
-    missingPriceData.length === 0,
-    `Missing gasPrice or tokenPrice data in ${environment} for: ${missingPriceData.join(', ')}`,
-  );
+  if (missingPriceData.length > 0) {
+    rootLogger.warn(
+      { missingChains: missingPriceData },
+      `Missing gasPrice or tokenPrice data in ${environment} for some chains — skipping them`,
+    );
+  }
 
-  const oracledRemotes = remoteChains;
+  const oracledRemotes = remoteChains.filter(
+    (c) => gasPrices[c] && tokenPrices[c],
+  );
 
   // ── 3. Build tokenOracleConfig ────────────────────────────────────────────
   // Substitute the ERC20 fee token as the "local native token" so the exchange

--- a/typescript/infra/scripts/igp/clone-igp-with-token-oracle.ts
+++ b/typescript/infra/scripts/igp/clone-igp-with-token-oracle.ts
@@ -99,6 +99,19 @@ async function main() {
     }).argv;
 
   assert(chain, '--chain is required');
+  assert(
+    ethers.utils.isAddress(existingIgp),
+    '--existing-igp must be a valid address',
+  );
+  assert(
+    ethers.utils.isAddress(feeToken),
+    '--fee-token must be a valid address',
+  );
+  assert(Number(feeTokenPrice) > 0, '--fee-token-price must be positive');
+  assert(
+    Number.isInteger(feeTokenDecimals) && feeTokenDecimals >= 0,
+    '--fee-token-decimals must be a non-negative integer',
+  );
 
   const envConfig = getEnvironmentConfig(environment);
   const multiProvider = await envConfig.getMultiProvider(
@@ -154,22 +167,15 @@ async function main() {
     'tokenPrices.json',
   );
 
-  const missingGasPrices = remoteChains.filter((c) => !gasPrices[c]);
-  if (missingGasPrices.length > 0) {
-    rootLogger.warn(
-      { missing: missingGasPrices },
-      'Remote chains missing gas price data — they will be excluded from the token oracle',
-    );
-  }
-
-  const oracledRemotes = remoteChains.filter(
-    (c) => gasPrices[c] && tokenPrices[c],
+  const missingPriceData = remoteChains.filter(
+    (c) => !gasPrices[c] || !tokenPrices[c],
   );
   assert(
-    oracledRemotes.length > 0,
-    `No remote chains have both gasPrice and tokenPrice data in ${environment}. ` +
-      `Missing: ${remoteChains.join(', ')}`,
+    missingPriceData.length === 0,
+    `Missing gasPrice or tokenPrice data in ${environment} for: ${missingPriceData.join(', ')}`,
   );
+
+  const oracledRemotes = remoteChains;
 
   // ── 3. Build tokenOracleConfig ────────────────────────────────────────────
   // Substitute the ERC20 fee token as the "local native token" so the exchange
@@ -280,7 +286,10 @@ async function main() {
   );
 }
 
-main().catch((error) => {
-  console.error(error);
+main().catch((error: unknown) => {
+  rootLogger.error(
+    { error: error instanceof Error ? error.message : String(error) },
+    'Fatal error',
+  );
   process.exit(1);
 });

--- a/typescript/infra/scripts/igp/clone-igp-with-token-oracle.ts
+++ b/typescript/infra/scripts/igp/clone-igp-with-token-oracle.ts
@@ -1,0 +1,286 @@
+/**
+ * Reads an existing IGP's on-chain config, then deploys a brand-new non-legacy
+ * IGP with the same native oracle config + tokenOracleConfig for an ERC20 fee
+ * token. Useful for upgrading a legacy IGP or adding token-fee support without
+ * touching the chain's core IGP.
+ *
+ * After deployment, set the printed IGP address as `feeHook` in the warp route
+ * config and run `hyperlane warp deploy` / `warp apply`.
+ *
+ * Usage (dry-run — logs computed config, does not deploy):
+ *   pnpm exec tsx scripts/igp/clone-igp-with-token-oracle.ts \
+ *     -e testnet4 -x hyperlane \
+ *     --chain basesepolia \
+ *     --existing-igp 0x28B02B97a850872C4D33C3E024fab6499ad96564 \
+ *     --fee-token 0x036CbD53842c5426634e7929541eC2318f3dCF7e \
+ *     --fee-token-price 1 \
+ *     --fee-token-decimals 6
+ *
+ * Usage (deploy):
+ *   ... --execute
+ */
+
+import { readFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+import {
+  ChainGasOracleParams,
+  ChainMap,
+  EvmHookReader,
+  GasPriceConfig,
+  HookType,
+  HyperlaneIgpDeployer,
+  IgpConfig,
+  getLocalStorageGasOracleConfig,
+} from '@hyperlane-xyz/sdk';
+import { ProtocolType, assert, rootLogger } from '@hyperlane-xyz/utils';
+
+import { ethers } from 'ethers';
+
+import { Contexts } from '../../config/contexts.js';
+import { EXCHANGE_RATE_MARGIN_PCT } from '../../src/config/gas-oracle.js';
+import { mustGetChainNativeToken } from '../../src/utils/utils.js';
+import { Role } from '../../src/roles.js';
+import { getArgs, withChain, withContext } from '../agent-utils.js';
+import { getEnvironmentConfig } from '../core-utils.js';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+function loadEnvJson<T>(environment: string, filename: string): T {
+  const path = resolve(
+    __dirname,
+    `../../config/environments/${environment}/${filename}`,
+  );
+  return JSON.parse(readFileSync(path, 'utf-8')) as T;
+}
+
+async function main() {
+  const {
+    environment,
+    context = Contexts.Hyperlane,
+    chain,
+    existingIgp,
+    feeToken,
+    feeTokenPrice,
+    feeTokenDecimals,
+    privateKey,
+    execute,
+  } = await withContext(withChain(getArgs()))
+    .option('existing-igp', {
+      type: 'string',
+      description: 'Address of the existing IGP to clone config from',
+      demandOption: true,
+    })
+    .option('fee-token', {
+      type: 'string',
+      description: 'ERC20 token address to accept as fee on this chain',
+      demandOption: true,
+    })
+    .option('fee-token-price', {
+      type: 'string',
+      description: 'USD price of the fee token (e.g. "1" for USDC)',
+      demandOption: true,
+    })
+    .option('fee-token-decimals', {
+      type: 'number',
+      description: 'Decimal places of the fee token (e.g. 6 for USDC)',
+      demandOption: true,
+    })
+    .option('private-key', {
+      type: 'string',
+      description:
+        'Private key hex to use instead of GCP deployer key (useful to avoid nonce conflicts on busy shared keys)',
+    })
+    .option('execute', {
+      type: 'boolean',
+      description: 'Send transactions; omit for dry-run',
+      default: false,
+    }).argv;
+
+  assert(chain, '--chain is required');
+
+  const envConfig = getEnvironmentConfig(environment);
+  const multiProvider = await envConfig.getMultiProvider(
+    context,
+    Role.Deployer,
+    true,
+    [chain],
+  );
+
+  if (privateKey) {
+    const wallet = new ethers.Wallet(privateKey);
+    multiProvider.setSharedSigner(wallet);
+    rootLogger.info({ address: wallet.address }, 'Using provided private key');
+  }
+
+  // ── 1. Read existing IGP config ──────────────────────────────────────────
+  rootLogger.info(
+    { chain, igp: existingIgp },
+    'Reading existing IGP config...',
+  );
+  const reader = new EvmHookReader(multiProvider, chain);
+  const existing = await reader.deriveIgpConfig(existingIgp);
+
+  assert(
+    existing.type === HookType.INTERCHAIN_GAS_PAYMASTER,
+    `Address ${existingIgp} is not an IGP (got type ${existing.type})`,
+  );
+
+  const remoteChains = Object.keys(existing.oracleConfig ?? {});
+  assert(
+    remoteChains.length > 0,
+    'Existing IGP has no configured remote chains',
+  );
+
+  rootLogger.info(
+    {
+      owner: existing.owner,
+      oracleKey: existing.oracleKey,
+      beneficiary: existing.beneficiary,
+      igpVersion: (existing as any).igpVersion ?? 'current',
+      remoteChains,
+    },
+    'Existing IGP config',
+  );
+
+  // ── 2. Load env gas & token prices for token oracle computation ──────────
+  const gasPrices = loadEnvJson<ChainMap<GasPriceConfig>>(
+    environment,
+    'gasPrices.json',
+  );
+  const tokenPrices = loadEnvJson<ChainMap<string>>(
+    environment,
+    'tokenPrices.json',
+  );
+
+  const missingGasPrices = remoteChains.filter((c) => !gasPrices[c]);
+  if (missingGasPrices.length > 0) {
+    rootLogger.warn(
+      { missing: missingGasPrices },
+      'Remote chains missing gas price data — they will be excluded from the token oracle',
+    );
+  }
+
+  const oracledRemotes = remoteChains.filter(
+    (c) => gasPrices[c] && tokenPrices[c],
+  );
+  assert(
+    oracledRemotes.length > 0,
+    `No remote chains have both gasPrice and tokenPrice data in ${environment}. ` +
+      `Missing: ${remoteChains.join(', ')}`,
+  );
+
+  // ── 3. Build tokenOracleConfig ────────────────────────────────────────────
+  // Substitute the ERC20 fee token as the "local native token" so the exchange
+  // rate resolves to: remote-native-token priced in fee-token.
+  const gasOracleParams: ChainMap<ChainGasOracleParams> = {
+    [chain]: {
+      gasPrice: gasPrices[chain],
+      nativeToken: {
+        price: feeTokenPrice,
+        decimals: feeTokenDecimals,
+      },
+    },
+  };
+  for (const remote of oracledRemotes) {
+    gasOracleParams[remote] = {
+      gasPrice: gasPrices[remote],
+      nativeToken: {
+        price: tokenPrices[remote],
+        decimals: mustGetChainNativeToken(remote).decimals,
+      },
+    };
+  }
+
+  const flooredPairs: string[] = [];
+  const tokenOracleEntries = getLocalStorageGasOracleConfig({
+    local: chain,
+    localProtocolType: ProtocolType.Ethereum,
+    gasOracleParams,
+    exchangeRateMarginPct: EXCHANGE_RATE_MARGIN_PCT,
+    onPrecisionFallback: ({ local, remote }) =>
+      flooredPairs.push(`${local} -> ${remote}`),
+  });
+
+  if (flooredPairs.length > 0) {
+    rootLogger.warn(
+      { pairs: flooredPairs },
+      'Exchange rate floored to 1 for these pairs (expected at low testnet prices)',
+    );
+  }
+
+  rootLogger.info(
+    { feeToken, config: tokenOracleEntries },
+    'Computed tokenOracleConfig',
+  );
+
+  // ── 4. Assemble new IgpConfig ─────────────────────────────────────────────
+  const deployerAddress = await multiProvider.getSignerAddress(chain);
+
+  const igpConfig: IgpConfig = {
+    type: HookType.INTERCHAIN_GAS_PAYMASTER,
+    // Preserve ownership from the existing IGP
+    owner: existing.owner,
+    oracleKey: existing.oracleKey ?? existing.owner,
+    beneficiary: existing.beneficiary,
+    // Existing native oracle config and overhead carry over unchanged
+    oracleConfig: existing.oracleConfig ?? {},
+    overhead: existing.overhead ?? {},
+    // New: token oracle config for the ERC20 fee token
+    tokenOracleConfig: {
+      [feeToken]: tokenOracleEntries,
+    },
+    // No igpVersion set → non-legacy (newest contract)
+  };
+
+  rootLogger.info(
+    {
+      chain,
+      owner: igpConfig.owner,
+      oracleKey: igpConfig.oracleKey,
+      beneficiary: igpConfig.beneficiary,
+      remoteChains: Object.keys(igpConfig.oracleConfig ?? {}),
+      tokenFeeRemotes: Object.keys(tokenOracleEntries),
+    },
+    'New IGP config assembled',
+  );
+
+  if (!execute) {
+    rootLogger.info(
+      { deployer: deployerAddress },
+      'Dry-run complete. Pass --execute to deploy.',
+    );
+    // Print the full assembled config as JSON so it can be inspected / diffed
+    console.log(JSON.stringify(igpConfig, null, 2));
+    return;
+  }
+
+  // ── 5. Deploy new IGP (no cached addresses → always fresh) ────────────────
+  rootLogger.info({ chain, deployer: deployerAddress }, 'Deploying new IGP...');
+  const deployer = new HyperlaneIgpDeployer(multiProvider);
+  // Intentionally do NOT call deployer.cacheAddressesMap() so every contract
+  // is deployed fresh, regardless of what's in the registry.
+  const contracts = await deployer.deployContracts(chain, igpConfig);
+
+  const igpAddress = contracts.interchainGasPaymaster.address;
+  rootLogger.info({ chain, igp: igpAddress }, 'New IGP deployed');
+
+  console.log(
+    JSON.stringify(
+      {
+        chain,
+        igp: igpAddress,
+        proxyAdmin: contracts.proxyAdmin.address,
+        storageGasOracle: contracts.storageGasOracle.address,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -51,10 +51,11 @@ import { getEnvAddresses } from '../../config/registry.js';
 import { chainsToSkip, legacyIgpChains } from '../../src/config/chain.js';
 import { determineGovernanceType, Owner } from '../../src/governance.js';
 import { GovernanceType } from '../../src/governanceTypes.js';
-import { GOVERNOR_MAX_BATCH_SIZE } from '../../src/govern/HyperlaneAppGovernor.js';
+import { GOVERNOR_MAX_BATCH_SIZE } from '../../src/govern/constants.js';
 import { SafeMultiSend } from '../../src/govern/multisend.js';
 import { Role } from '../../src/roles.js';
 import { logTable } from '../../src/utils/log.js';
+import { getTimelockLogBlockRange } from '../../src/utils/timelock.js';
 import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
 import {
   getArgs,
@@ -70,10 +71,9 @@ const OUTPUT_ROOT = 'igp-upgrade-output';
 const CANCUN_PROBE_INIT_CODE = '0x5f5f5d5f5c5f5260205ff3';
 // Timelock upgrade idempotency needs log scanning because CREATE deployments
 // change the implementation address in the scheduled calldata across reruns.
-// Keep chunks below common provider log limits; widen manually if an older
-// still-pending operation must be detected.
+// The per-query block range comes from the same conservative timelock helper
+// used by the pending-timelock scripts.
 const TIMELOCK_LOOKBACK_BLOCKS = 2_000_000;
-const TIMELOCK_LOG_CHUNK_BLOCKS = 50_000;
 
 type UpgradeCall = {
   to: Address;
@@ -106,6 +106,13 @@ type SafeCallGroup = {
   calls: UpgradeCall[];
   batchIndex?: number;
   batchCount?: number;
+};
+
+type IcaCallGroup = {
+  destination: ChainName;
+  governanceType: GovernanceType;
+  owner: Address;
+  calls: UpgradeCall[];
 };
 
 type ProposalResult = {
@@ -343,12 +350,14 @@ export function callMatchesTimelockIdempotency({
 }
 
 async function getExistingTimelockOperation({
+  chain,
   provider,
   timelock,
   call,
   idempotency,
   currentOperationId,
 }: {
+  chain: ChainName;
   provider: ethers.providers.Provider;
   timelock: ReturnType<typeof TimelockController__factory.connect>;
   call: UpgradeCall;
@@ -369,15 +378,13 @@ async function getExistingTimelockOperation({
   const latestBlock = await provider.getBlockNumber();
   const fromBlock = Math.max(0, latestBlock - TIMELOCK_LOOKBACK_BLOCKS);
   const eventFilter = timelock.filters.CallScheduled();
+  const logBlockRange = getTimelockLogBlockRange(chain);
   for (
     let startBlock = fromBlock;
     startBlock <= latestBlock;
-    startBlock += TIMELOCK_LOG_CHUNK_BLOCKS + 1
+    startBlock += logBlockRange + 1
   ) {
-    const endBlock = Math.min(
-      latestBlock,
-      startBlock + TIMELOCK_LOG_CHUNK_BLOCKS,
-    );
+    const endBlock = Math.min(latestBlock, startBlock + logBlockRange);
     const logs = await timelock.queryFilter(eventFilter, startBlock, endBlock);
     for (const log of logs) {
       const { id, target, value, data } = log.args;
@@ -459,6 +466,67 @@ function addSafeCall(
     safeAddress,
     calls: [call],
   });
+}
+
+function getIcaCallGroupKey({
+  destination,
+  governanceType,
+  owner,
+}: {
+  destination: ChainName;
+  governanceType: GovernanceType;
+  owner: Address;
+}) {
+  return `${destination}:${governanceType}:${owner}`;
+}
+
+function addIcaCall(
+  groups: Map<string, IcaCallGroup>,
+  destination: ChainName,
+  governanceType: GovernanceType,
+  owner: Address,
+  call: UpgradeCall,
+) {
+  const key = getIcaCallGroupKey({ destination, governanceType, owner });
+  const existing = groups.get(key);
+  if (existing) {
+    existing.calls.push(call);
+    return;
+  }
+
+  groups.set(key, {
+    destination,
+    governanceType,
+    owner,
+    calls: [call],
+  });
+}
+
+async function assertIcaOwner({
+  ica,
+  destination,
+  governanceType,
+  ownerAddress,
+}: {
+  ica: InterchainAccount;
+  destination: ChainName;
+  governanceType: GovernanceType;
+  ownerAddress: Address;
+}) {
+  const owner = getGovernanceSafes(governanceType)[ETHEREUM_CHAIN];
+  assert(
+    owner,
+    `No ${governanceType} Safe configured on ${ETHEREUM_CHAIN}; cannot propose ICA call for ${destination}`,
+  );
+
+  const expectedIca = await ica.getAccount(destination, {
+    origin: ETHEREUM_CHAIN,
+    owner,
+  });
+  assert(
+    eqAddress(expectedIca, ownerAddress),
+    `[${destination}] expected ${governanceType} ICA ${expectedIca}, but owner is ${ownerAddress}`,
+  );
 }
 
 function toUpgradeCall(
@@ -549,6 +617,7 @@ export function getUpgradeTargetImplementation({
       return decodedImplementation;
     }
   } catch {
+    // Not a ProxyAdmin.upgrade call; callers use undefined as a non-match.
     return undefined;
   }
 
@@ -597,6 +666,7 @@ async function getGovernedCallOwner({
 
 async function routeGovernedCall({
   groups,
+  icaGroups,
   ica,
   chain,
   call,
@@ -604,6 +674,7 @@ async function routeGovernedCall({
   timelockIdempotency,
 }: {
   groups: Map<string, SafeCallGroup>;
+  icaGroups: Map<string, IcaCallGroup>;
   ica: InterchainAccount;
   chain: ChainName;
   call: UpgradeCall;
@@ -639,17 +710,16 @@ async function routeGovernedCall({
           governanceType,
         };
       }
-      await addIcaSafeCall({
-        groups,
+      await assertIcaOwner({
         ica,
         destination: chain,
         governanceType,
-        innerCall: call,
-        expectedRemoteOwner: ownerAddress,
+        ownerAddress,
       });
+      addIcaCall(icaGroups, chain, governanceType, ownerAddress, call);
       return {
         status: 'queued',
-        detail: `queued ${governanceType} ICA tx from ethereum: ${call.description}`,
+        detail: `queued ${governanceType} ICA inner tx from ethereum: ${call.description}`,
         ownerType,
         governanceType,
       };
@@ -761,6 +831,66 @@ async function addIcaSafeCall({
   });
 }
 
+async function flushIcaCallGroups({
+  safeGroups,
+  icaGroups,
+  ica,
+}: {
+  safeGroups: Map<string, SafeCallGroup>;
+  icaGroups: Map<string, IcaCallGroup>;
+  ica: InterchainAccount;
+}) {
+  for (const group of icaGroups.values()) {
+    const safes = getGovernanceSafes(group.governanceType);
+    const owner = safes[ETHEREUM_CHAIN];
+    assert(
+      owner,
+      `No ${group.governanceType} Safe configured on ${ETHEREUM_CHAIN}; cannot propose ICA call for ${group.destination}`,
+    );
+
+    const accountConfig = {
+      origin: ETHEREUM_CHAIN,
+      owner,
+    };
+    const innerCalls = group.calls.map((call) => ({
+      to: call.to,
+      data: call.data,
+      value: call.value.toString(),
+    }));
+    const gasLimit = await ica.estimateIcaHandleGas({
+      origin: ETHEREUM_CHAIN,
+      destination: group.destination,
+      innerCalls,
+      config: accountConfig,
+    });
+    const hookMetadata = formatStandardHookMetadata({
+      gasLimit: gasLimit.toBigInt(),
+      refundAddress: accountConfig.owner,
+    });
+    const callRemote = await ica.getCallRemote({
+      chain: ETHEREUM_CHAIN,
+      destination: group.destination,
+      innerCalls,
+      config: accountConfig,
+      hookMetadata,
+    });
+
+    assert(
+      callRemote.to && callRemote.data,
+      `[${group.destination}] could not build ICA callRemote transaction`,
+    );
+
+    addSafeCall(safeGroups, ETHEREUM_CHAIN, group.governanceType, {
+      to: callRemote.to,
+      data: callRemote.data,
+      value: callRemote.value ?? BigNumber.from(0),
+      description: `ICA ${group.destination}: ${group.calls.length} ordered tx(s): ${group.calls
+        .map((call) => call.description)
+        .join('; ')}`,
+    });
+  }
+}
+
 async function routeTimelockCall({
   groups,
   ica,
@@ -801,6 +931,7 @@ async function routeTimelockCall({
   );
 
   const existingOperation = await getExistingTimelockOperation({
+    chain,
     provider,
     timelock,
     call: innerCall,
@@ -1130,6 +1261,7 @@ async function main() {
   );
   const ica = InterchainAccount.fromAddressesMap(icaAddresses, multiProvider);
   const safeGroups = new Map<string, SafeCallGroup>();
+  const icaGroups = new Map<string, IcaCallGroup>();
   const plans: ChainPlan[] = [];
 
   for (const chain of targetChains) {
@@ -1288,6 +1420,7 @@ async function main() {
         );
         const route = await routeGovernedCall({
           groups: safeGroups,
+          icaGroups,
           ica,
           chain,
           call: upgradeCall,
@@ -1369,6 +1502,7 @@ async function main() {
         });
         const route = await routeGovernedCall({
           groups: safeGroups,
+          icaGroups,
           ica,
           chain,
           call,
@@ -1427,6 +1561,12 @@ async function main() {
       });
     }
   }
+
+  await flushIcaCallGroups({
+    safeGroups,
+    icaGroups,
+    ica,
+  });
 
   const groups = splitSafeCallGroups([...safeGroups.values()]);
   const runDir = join(

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -21,7 +21,6 @@ import {
 import {
   Address,
   assert,
-  bytes32ToAddress,
   eqAddress,
   formatStandardHookMetadata,
   isEVMLike,
@@ -29,23 +28,23 @@ import {
 } from '@hyperlane-xyz/utils';
 import { readJson } from '@hyperlane-xyz/utils/fs';
 import { BigNumber, ethers } from 'ethers';
+import { compareVersions } from 'compare-versions';
 
 import { Contexts } from '../../config/contexts.js';
 import {
   getGovernanceIcas,
   getGovernanceSafes,
-  getGovernanceTimelocks,
 } from '../../config/environments/mainnet3/governance/utils.js';
 import { getEnvAddresses } from '../../config/registry.js';
 import {
-  legacyEthIcaRouter,
-  legacyIcaChainRouters,
+  chainsToSkip,
+  legacyIcaChains,
   legacyIgpChains,
 } from '../../src/config/chain.js';
+import type { DeployEnvironment } from '../../src/config/deploy-environment.js';
 import { determineGovernanceType, Owner } from '../../src/governance.js';
 import { GovernanceType } from '../../src/governanceTypes.js';
 import { SafeMultiSend } from '../../src/govern/multisend.js';
-import type { DeployEnvironment } from '../../src/config/deploy-environment.js';
 import { getEnvironmentDirectory } from '../../src/paths.js';
 import { logTable } from '../../src/utils/log.js';
 import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
@@ -91,6 +90,15 @@ type SafeCallGroup = {
   calls: UpgradeCall[];
 };
 
+type ProposalResult = {
+  chain: ChainName;
+  governanceType: GovernanceType;
+  safeAddress: Address;
+  status: 'proposed' | 'error' | 'skipped';
+  detail: string;
+  hashes?: string[];
+};
+
 type VerificationArtifact = {
   name: string;
   address: Address;
@@ -102,22 +110,8 @@ function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function compareSemver(a: string, b: string): number {
-  const aParts = a.split('.').map((part) => parseInt(part, 10));
-  const bParts = b.split('.').map((part) => parseInt(part, 10));
-  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
-    const aPart = aParts[i] ?? 0;
-    const bPart = bParts[i] ?? 0;
-    if (aPart !== bPart) return aPart > bPart ? 1 : -1;
-  }
-  return 0;
-}
-
-function getImplementationAddress(
-  chain: ChainName,
-  implementations: ChainMap<Address>,
-): Address | undefined {
-  return implementations[chain];
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 function getImplementationAddressesFromVerificationArtifacts(
@@ -154,6 +148,34 @@ function getImplementationAddressesFromVerificationArtifacts(
   return implementations;
 }
 
+function getImplementationAddressOverrides(
+  filepath: string,
+  supportedChains: Set<ChainName>,
+): ChainMap<Address> {
+  const rawOverrides = readJson<unknown>(filepath);
+  assert(isRecord(rawOverrides), `${filepath} must contain a JSON object`);
+
+  const overrides: ChainMap<Address> = {};
+  for (const [chain, value] of Object.entries(rawOverrides)) {
+    assert(
+      supportedChains.has(chain),
+      `${filepath} contains unsupported chain ${chain}`,
+    );
+    assert(typeof value === 'string', `${filepath} ${chain} must be a string`);
+    assert(
+      ethers.utils.isAddress(value),
+      `${filepath} ${chain} is not an EVM address: ${value}`,
+    );
+    assert(
+      !eqAddress(value, ethers.constants.AddressZero),
+      `${filepath} ${chain} implementation is zero address`,
+    );
+    overrides[chain] = value;
+  }
+
+  return overrides;
+}
+
 async function getCurrentVersion(
   chain: ChainName,
   provider: ethers.providers.Provider,
@@ -170,6 +192,40 @@ async function getCurrentVersion(
     );
     return undefined;
   }
+}
+
+async function assertTargetImplementation({
+  chain,
+  provider,
+  targetImplementation,
+}: {
+  chain: ChainName;
+  provider: ethers.providers.Provider;
+  targetImplementation: Address;
+}): Promise<void> {
+  assert(
+    ethers.utils.isAddress(targetImplementation),
+    `[${chain}] target implementation is not an EVM address: ${targetImplementation}`,
+  );
+  assert(
+    !eqAddress(targetImplementation, ethers.constants.AddressZero),
+    `[${chain}] target implementation is zero address`,
+  );
+
+  const code = await provider.getCode(targetImplementation);
+  assert(
+    code !== '0x',
+    `[${chain}] target implementation ${targetImplementation} has no deployed code`,
+  );
+
+  const targetVersion = await PackageVersioned__factory.connect(
+    targetImplementation,
+    provider,
+  ).PACKAGE_VERSION();
+  assert(
+    targetVersion === CONTRACTS_PACKAGE_VERSION,
+    `[${chain}] target implementation ${targetImplementation} exposes PACKAGE_VERSION ${targetVersion}, expected ${CONTRACTS_PACKAGE_VERSION}`,
+  );
 }
 
 async function assertCancunCompatible(
@@ -272,13 +328,6 @@ async function addIcaSafeCall({
   const accountConfig = {
     origin: ETHEREUM_CHAIN,
     owner,
-    ...(legacyIcaChainRouters[destination]
-      ? {
-          localRouter: legacyEthIcaRouter,
-          routerOverride:
-            legacyIcaChainRouters[destination].interchainAccountRouter,
-        }
-      : {}),
   };
   const expectedIca = await ica.getAccount(destination, accountConfig);
   const ownerAddress =
@@ -305,10 +354,9 @@ async function addIcaSafeCall({
     innerCalls,
     config: accountConfig,
   });
-  const refundAddress = bytes32ToAddress(accountConfig.owner);
   const hookMetadata = formatStandardHookMetadata({
     gasLimit: gasLimit.toBigInt(),
-    refundAddress,
+    refundAddress: accountConfig.owner,
   });
   const callRemote = await ica.getCallRemote({
     chain: ETHEREUM_CHAIN,
@@ -431,7 +479,8 @@ async function writeSafeBatchFiles({
   groups: SafeCallGroup[];
   multiProvider: Parameters<typeof EV5GnosisSafeTxBuilder.create>[0];
   runDir: string;
-}) {
+}): Promise<Set<string>> {
+  const rawFallbackGroupKeys = new Set<string>();
   for (const group of groups) {
     let builder: EV5GnosisSafeTxBuilder;
     try {
@@ -441,6 +490,9 @@ async function writeSafeBatchFiles({
         safeAddress: group.safeAddress,
       });
     } catch (error) {
+      rawFallbackGroupKeys.add(
+        getSafeGroupKey(group.chain, group.governanceType),
+      );
       const filepath = join(
         runDir,
         `${group.chain}-${group.governanceType}.raw.json`,
@@ -448,6 +500,7 @@ async function writeSafeBatchFiles({
       mkdirSync(dirname(filepath), { recursive: true });
       await writeAndFormatJsonAtPath(filepath, {
         chain: group.chain,
+        chainId: multiProvider.getEvmChainId(group.chain),
         safeAddress: group.safeAddress,
         governanceType: group.governanceType,
         note: 'Raw calldata. NOT a Safe Transaction Builder file (no usable tx service for this chain); submit manually.',
@@ -483,6 +536,7 @@ async function writeSafeBatchFiles({
       `[${group.chain}] wrote ${group.governanceType} Safe batch ${filepath}`,
     );
   }
+  return rawFallbackGroupKeys;
 }
 
 async function proposeSafeGroups({
@@ -491,24 +545,48 @@ async function proposeSafeGroups({
 }: {
   groups: SafeCallGroup[];
   multiProvider: Parameters<typeof SafeMultiSend.initialize>[0];
-}) {
+}): Promise<ProposalResult[]> {
+  const results: ProposalResult[] = [];
   for (const group of groups) {
-    const safeMultiSend = await SafeMultiSend.initialize(
-      multiProvider,
-      group.chain,
-      group.safeAddress,
-    );
-    const hashes = await safeMultiSend.sendTransactions(
-      group.calls.map((call) => ({
-        to: call.to,
-        data: call.data,
-        value: call.value,
-      })),
-    );
-    rootLogger.info(
-      `[${group.chain}] proposed ${group.calls.length} ${group.governanceType} tx(s): ${hashes.join(', ')}`,
-    );
+    try {
+      const safeMultiSend = await SafeMultiSend.initialize(
+        multiProvider,
+        group.chain,
+        group.safeAddress,
+      );
+      const hashes = await safeMultiSend.sendTransactions(
+        group.calls.map((call) => ({
+          to: call.to,
+          data: call.data,
+          value: call.value,
+        })),
+      );
+      results.push({
+        chain: group.chain,
+        governanceType: group.governanceType,
+        safeAddress: group.safeAddress,
+        status: 'proposed',
+        detail: `proposed ${group.calls.length} tx(s)`,
+        hashes,
+      });
+      rootLogger.info(
+        `[${group.chain}] proposed ${group.calls.length} ${group.governanceType} tx(s): ${hashes.join(', ')}`,
+      );
+    } catch (error) {
+      const detail = formatError(error);
+      results.push({
+        chain: group.chain,
+        governanceType: group.governanceType,
+        safeAddress: group.safeAddress,
+        status: 'error',
+        detail,
+      });
+      rootLogger.error(
+        `[${group.chain}] failed to propose ${group.governanceType} Safe tx(s): ${detail}`,
+      );
+    }
   }
+  return results;
 }
 
 async function main() {
@@ -551,8 +629,13 @@ async function main() {
     !propose || chains?.length || all,
     'Refusing to propose for all compatible chains without --all. Pass --chains or --all.',
   );
+  assert(
+    environment === 'mainnet3',
+    'This script only supports mainnet3 because governance Safe, ICA, and timelock config is imported from mainnet3.',
+  );
 
   const envConfig = getEnvironmentConfig(environment);
+  const supportedChains = new Set(envConfig.supportedChainNames);
   const chainAddresses = getEnvAddresses(environment);
   const implementationAddresses = {
     ...getImplementationAddressesFromVerificationArtifacts(
@@ -560,21 +643,43 @@ async function main() {
       chainAddresses,
     ),
     ...(implementationAddressesFile
-      ? readJson<ChainMap<Address>>(implementationAddressesFile)
+      ? getImplementationAddressOverrides(
+          implementationAddressesFile,
+          supportedChains,
+        )
       : {}),
   };
   const requested = chains && chains.length > 0 ? new Set(chains) : undefined;
+
+  if (requested) {
+    for (const chain of requested) {
+      if (!supportedChains.has(chain)) {
+        rootLogger.warn(
+          `[${chain}] requested but not supported in ${environment}; skipping`,
+        );
+      } else if (legacyIgpChains.includes(chain)) {
+        rootLogger.warn(
+          `[${chain}] requested but in legacyIgpChains; skipping`,
+        );
+      } else if (chainsToSkip.includes(chain)) {
+        rootLogger.warn(`[${chain}] requested but in chainsToSkip; skipping`);
+      }
+    }
+  }
+
   const targetChains = envConfig.supportedChainNames.filter((chain) => {
     if (requested && !requested.has(chain)) return false;
     if (legacyIgpChains.includes(chain)) return false;
+    if (chainsToSkip.includes(chain)) return false;
     return true;
   });
+  const providerChains = Array.from(new Set([...targetChains, ETHEREUM_CHAIN]));
 
   const multiProvider = await envConfig.getMultiProvider(
     context,
     undefined,
     true,
-    targetChains,
+    providerChains,
   );
   const icaAddresses = Object.fromEntries(
     Object.entries(chainAddresses).filter(
@@ -610,10 +715,7 @@ async function main() {
     }
 
     const provider = multiProvider.getProvider(chain);
-    const targetImplementation = getImplementationAddress(
-      chain,
-      implementationAddresses,
-    );
+    const targetImplementation = implementationAddresses[chain];
     try {
       if (!skipEvmPreflight) {
         await assertCancunCompatible(chain, provider);
@@ -633,26 +735,8 @@ async function main() {
         interchainGasPaymaster,
       );
       if (
-        targetImplementation &&
-        eqAddress(currentImplementation, targetImplementation)
-      ) {
-        plans.push({
-          chain,
-          interchainGasPaymaster,
-          currentImplementation,
-          targetImplementation,
-          currentVersion,
-          targetVersion: CONTRACTS_PACKAGE_VERSION,
-          proxyAdmin: actualProxyAdmin,
-          status: 'no change',
-          detail: 'proxy already points at target implementation',
-        });
-        continue;
-      }
-
-      if (
         currentVersion &&
-        compareSemver(currentVersion, CONTRACTS_PACKAGE_VERSION) >= 0
+        compareVersions(currentVersion, CONTRACTS_PACKAGE_VERSION) >= 0
       ) {
         plans.push({
           chain,
@@ -682,6 +766,27 @@ async function main() {
         continue;
       }
 
+      await assertTargetImplementation({
+        chain,
+        provider,
+        targetImplementation,
+      });
+
+      if (eqAddress(currentImplementation, targetImplementation)) {
+        plans.push({
+          chain,
+          interchainGasPaymaster,
+          currentImplementation,
+          targetImplementation,
+          currentVersion,
+          targetVersion: CONTRACTS_PACKAGE_VERSION,
+          proxyAdmin: actualProxyAdmin,
+          status: 'no change',
+          detail: 'proxy already points at target implementation',
+        });
+        continue;
+      }
+
       const proxyAdminOwner = await Ownable__factory.connect(
         actualProxyAdmin,
         provider,
@@ -707,6 +812,24 @@ async function main() {
           detail = `queued ${governanceType} Safe proposal`;
           break;
         case Owner.ICA:
+          if (legacyIcaChains.includes(chain)) {
+            plans.push({
+              chain,
+              interchainGasPaymaster,
+              currentImplementation,
+              targetImplementation,
+              currentVersion,
+              targetVersion: CONTRACTS_PACKAGE_VERSION,
+              proxyAdmin: actualProxyAdmin,
+              proxyAdminOwner,
+              ownerType,
+              governanceType,
+              status: 'manual',
+              detail:
+                'ProxyAdmin is owned by a legacy V1 ICA; script only builds V2 ICA calls',
+            });
+            continue;
+          }
           await addIcaSafeCall({
             groups: safeGroups,
             ica,
@@ -803,10 +926,45 @@ async function main() {
     OUTPUT_ROOT,
     new Date().toISOString().replace(/[:.]/g, '-'),
   );
-  await writeSafeBatchFiles({ groups, multiProvider, runDir });
+  const rawFallbackGroupKeys = await writeSafeBatchFiles({
+    groups,
+    multiProvider,
+    runDir,
+  });
 
+  const proposalResults: ProposalResult[] = [];
   if (propose) {
-    await proposeSafeGroups({ groups, multiProvider });
+    for (const group of groups) {
+      if (
+        !rawFallbackGroupKeys.has(
+          getSafeGroupKey(group.chain, group.governanceType),
+        )
+      ) {
+        continue;
+      }
+      const detail =
+        'skipped propose because only raw fallback calldata was written; submit manually';
+      proposalResults.push({
+        chain: group.chain,
+        governanceType: group.governanceType,
+        safeAddress: group.safeAddress,
+        status: 'skipped',
+        detail,
+      });
+      rootLogger.warn(`[${group.chain}] ${detail}`);
+    }
+
+    proposalResults.push(
+      ...(await proposeSafeGroups({
+        groups: groups.filter(
+          (group) =>
+            !rawFallbackGroupKeys.has(
+              getSafeGroupKey(group.chain, group.governanceType),
+            ),
+        ),
+        multiProvider,
+      })),
+    );
   }
 
   const output = {
@@ -816,6 +974,7 @@ async function main() {
     mode: propose ? 'propose' : 'dry-run',
     legacyIgpChains,
     ...(postUpgradeConfigCommand ? { postUpgradeConfigCommand } : {}),
+    ...(proposalResults.length > 0 ? { proposalResults } : {}),
     safeGroups: groups.map((group) => ({
       chain: group.chain,
       governanceType: group.governanceType,
@@ -842,7 +1001,10 @@ async function main() {
       ].join('\n'),
     );
   }
-  if (plans.some((plan) => plan.status === 'error')) {
+  if (
+    plans.some((plan) => plan.status === 'error') ||
+    proposalResults.some((result) => result.status === 'error')
+  ) {
     process.exitCode = 1;
   }
 }

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -202,6 +202,24 @@ function getSafeGroupKey(chain: ChainName, governanceType: GovernanceType) {
   return `${chain}:${governanceType}`;
 }
 
+function getPostUpgradeConfigCommand({
+  environment,
+  context,
+  chains,
+}: {
+  environment: string;
+  context: string;
+  chains: ChainName[];
+}) {
+  return [
+    'pnpm --dir typescript/infra exec tsx scripts/deploy.ts',
+    `--environment ${environment}`,
+    `--context ${context}`,
+    '--module igp',
+    `--chains ${chains.join(' ')}`,
+  ].join(' ');
+}
+
 function addSafeCall(
   groups: Map<string, SafeCallGroup>,
   chain: ChainName,
@@ -770,6 +788,17 @@ async function main() {
   }
 
   const groups = [...safeGroups.values()];
+  const queuedUpgradeChains = plans
+    .filter((plan) => plan.status === 'queued')
+    .map((plan) => plan.chain);
+  const postUpgradeConfigCommand =
+    queuedUpgradeChains.length > 0
+      ? getPostUpgradeConfigCommand({
+          environment,
+          context,
+          chains: queuedUpgradeChains,
+        })
+      : undefined;
   const runDir = join(
     OUTPUT_ROOT,
     new Date().toISOString().replace(/[:.]/g, '-'),
@@ -786,6 +815,7 @@ async function main() {
     targetVersion: CONTRACTS_PACKAGE_VERSION,
     mode: propose ? 'propose' : 'dry-run',
     legacyIgpChains,
+    ...(postUpgradeConfigCommand ? { postUpgradeConfigCommand } : {}),
     safeGroups: groups.map((group) => ({
       chain: group.chain,
       governanceType: group.governanceType,
@@ -802,6 +832,15 @@ async function main() {
 
   if (!propose) {
     rootLogger.info(`Dry run: Safe batch files written under ${runDir}`);
+  }
+  if (postUpgradeConfigCommand) {
+    rootLogger.warn(
+      [
+        'After the upgrade transactions execute and any ICA messages relay, immediately apply IGP config.',
+        'The upgraded IGP reads native gas params from new storage slots; until config is applied, native gas payments may be underquoted or zero.',
+        postUpgradeConfigCommand,
+      ].join('\n'),
+    );
   }
   if (plans.some((plan) => plan.status === 'error')) {
     process.exitCode = 1;

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -35,13 +35,10 @@ import { Contexts } from '../../config/contexts.js';
 import {
   getGovernanceIcas,
   getGovernanceSafes,
+  getLegacyGovernanceIcas,
 } from '../../config/environments/mainnet3/governance/utils.js';
 import { getEnvAddresses } from '../../config/registry.js';
-import {
-  chainsToSkip,
-  legacyIcaChains,
-  legacyIgpChains,
-} from '../../src/config/chain.js';
+import { chainsToSkip, legacyIgpChains } from '../../src/config/chain.js';
 import type { DeployEnvironment } from '../../src/config/deploy-environment.js';
 import { determineGovernanceType, Owner } from '../../src/governance.js';
 import { GovernanceType } from '../../src/governanceTypes.js';
@@ -883,7 +880,8 @@ async function main() {
           detail = `queued ${governanceType} Safe proposal`;
           break;
         case Owner.ICA:
-          if (legacyIcaChains.includes(chain)) {
+          const legacyIcaOwner = getLegacyGovernanceIcas(governanceType)[chain];
+          if (legacyIcaOwner && eqAddress(legacyIcaOwner, proxyAdminOwner)) {
             plans.push({
               chain,
               interchainGasPaymaster,

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -68,6 +68,10 @@ import { getEnvironmentConfig } from '../core-utils.js';
 const ETHEREUM_CHAIN: ChainName = 'ethereum';
 const OUTPUT_ROOT = 'igp-upgrade-output';
 const CANCUN_PROBE_INIT_CODE = '0x5f5f5d5f5c5f5260205ff3';
+// Timelock upgrade idempotency needs log scanning because CREATE deployments
+// change the implementation address in the scheduled calldata across reruns.
+// Keep chunks below common provider log limits; widen manually if an older
+// still-pending operation must be detected.
 const TIMELOCK_LOOKBACK_BLOCKS = 2_000_000;
 const TIMELOCK_LOG_CHUNK_BLOCKS = 50_000;
 
@@ -387,9 +391,6 @@ async function getExistingTimelockOperation({
         })
       ) {
         continue;
-      }
-      if (await timelock.isOperationDone(id)) {
-        return { id, status: 'done' };
       }
       if (
         (await timelock.isOperationPending(id)) ||
@@ -1296,7 +1297,7 @@ async function main() {
             proxyAddress: interchainGasPaymaster,
           },
         });
-        status = route.status === 'done' ? 'error' : route.status;
+        status = route.status === 'done' ? 'skipped' : route.status;
         ownerType = route.ownerType;
         governanceType = route.governanceType;
         routeDetails.push(route.detail);
@@ -1324,7 +1325,7 @@ async function main() {
             status,
             detail:
               route.status === 'done'
-                ? route.detail
+                ? `${route.detail}; upgrade already executed`
                 : `${route.detail}; ${transactions.length - 1} config tx(s) deferred until the timelock upgrade executes`,
             ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
           });

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -551,11 +551,17 @@ function getTargetIgpConfig(chain: ChainName, config: IgpConfig): IgpConfig {
     `[${chain}] expected InterchainGasPaymaster config, got ${config.type}`,
   );
 
+  // Strip tokenOracleConfig: those oracles require the new implementation and
+  // will be deployed/configured by deploy.ts -m igp after this upgrade executes.
+  const { tokenOracleConfig: _stripped, ...rest } = deepCopy(config) as {
+    tokenOracleConfig?: unknown;
+    [key: string]: unknown;
+  };
   return {
-    ...deepCopy(config),
+    ...rest,
     contractVersion: CONTRACTS_PACKAGE_VERSION,
     owner: config.ownerOverrides?.interchainGasPaymaster ?? config.owner,
-  };
+  } as IgpConfig;
 }
 
 async function buildHookUpdateTransactions({

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -1,10 +1,9 @@
-import { existsSync, mkdirSync } from 'fs';
+import { mkdirSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { pathToFileURL } from 'url';
 
 import {
   CONTRACTS_PACKAGE_VERSION,
-  InterchainGasPaymaster__factory,
   Ownable__factory,
   PackageVersioned__factory,
   ProxyAdmin__factory,
@@ -14,21 +13,27 @@ import {
   AnnotatedEV5Transaction,
   ChainMap,
   ChainName,
+  ChainNameOrId,
   EV5GnosisSafeTxBuilder,
+  EvmHookModule,
+  HookType,
+  IgpConfig,
   InterchainAccount,
+  MultiProvider,
   PROPOSER_ROLE,
+  extractIsmAndHookFactoryAddresses,
   proxyAdmin,
   proxyImplementation,
 } from '@hyperlane-xyz/sdk';
 import {
   Address,
   assert,
+  deepCopy,
   eqAddress,
   formatStandardHookMetadata,
   isEVMLike,
   rootLogger,
 } from '@hyperlane-xyz/utils';
-import { readJson } from '@hyperlane-xyz/utils/fs';
 import { BigNumber, ethers } from 'ethers';
 import { compareVersions } from 'compare-versions';
 
@@ -38,13 +43,13 @@ import {
   getGovernanceSafes,
   getLegacyGovernanceIcas,
 } from '../../config/environments/mainnet3/governance/utils.js';
+import { DEPLOYER } from '../../config/environments/mainnet3/owners.js';
 import { getEnvAddresses } from '../../config/registry.js';
 import { chainsToSkip, legacyIgpChains } from '../../src/config/chain.js';
-import type { DeployEnvironment } from '../../src/config/deploy-environment.js';
 import { determineGovernanceType, Owner } from '../../src/governance.js';
 import { GovernanceType } from '../../src/governanceTypes.js';
 import { SafeMultiSend } from '../../src/govern/multisend.js';
-import { getEnvironmentDirectory } from '../../src/paths.js';
+import { Role } from '../../src/roles.js';
 import { logTable } from '../../src/utils/log.js';
 import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
 import {
@@ -60,7 +65,6 @@ const ETHEREUM_CHAIN: ChainName = 'ethereum';
 const OUTPUT_ROOT = 'igp-upgrade-output';
 const CANCUN_PROBE_INIT_CODE = '0x5f5f5d5f5c5f5260205ff3';
 const MAX_SAFE_BATCH_SIZE = 120;
-const IGP_ARTIFACT_NAME = 'InterchainGasPaymaster';
 
 type UpgradeCall = {
   to: Address;
@@ -80,6 +84,8 @@ type ChainPlan = {
   proxyAdminOwner?: Address;
   ownerType?: Owner | null;
   governanceType?: GovernanceType;
+  transactionCount?: number;
+  simulatedDeployments?: SimulatedDeployment[];
   status: string;
   detail: string;
 };
@@ -102,12 +108,81 @@ type ProposalResult = {
   hashes?: string[];
 };
 
-type VerificationArtifact = {
-  name: string;
+type SimulatedDeployment = {
+  chain: ChainName;
+  contractName: string;
   address: Address;
-  isProxy?: boolean;
-  expectedimplementation?: Address;
+  nonce: number;
 };
+
+class DryRunDeployMultiProvider extends MultiProvider {
+  readonly simulatedDeployments: SimulatedDeployment[] = [];
+  private readonly nextNonces: ChainMap<number> = {};
+
+  constructor(
+    base: MultiProvider,
+    private readonly deployerAddress: Address,
+  ) {
+    super(base.metadata, {
+      ...base.options,
+      providers: base.providers,
+      signers: base.signers,
+    });
+  }
+
+  override async getSignerAddress(_chainNameOrId: ChainNameOrId) {
+    return this.deployerAddress;
+  }
+
+  override async handleDeploy<
+    F extends Parameters<MultiProvider['handleDeploy']>[1],
+  >(
+    chainNameOrId: ChainNameOrId,
+    factory: F,
+    params: Parameters<F['deploy']>,
+  ): Promise<Awaited<ReturnType<F['deploy']>>> {
+    assert(
+      'attach' in factory && typeof factory.attach === 'function',
+      `[${chainNameOrId}] dry-run deployment simulation only supports ethers factories`,
+    );
+
+    const chain = this.getChainName(chainNameOrId);
+    const nonce =
+      this.nextNonces[chain] ??
+      (await this.getProvider(chain).getTransactionCount(this.deployerAddress));
+    this.nextNonces[chain] = nonce + 1;
+
+    const address = ethers.utils.getContractAddress({
+      from: this.deployerAddress,
+      nonce,
+    });
+    const contractName = factory.constructor.name.replace(/__factory$/, '');
+    this.simulatedDeployments.push({
+      chain,
+      contractName,
+      address,
+      nonce,
+    });
+
+    rootLogger.info(
+      `[${chain}] dry-run simulated ${contractName} deployment at ${address} from ${this.deployerAddress} nonce ${nonce}`,
+    );
+
+    const contract = factory.attach(address);
+    Object.defineProperty(contract, 'deployTransaction', {
+      value: factory.getDeployTransaction(...params),
+    });
+    return contract as Awaited<ReturnType<F['deploy']>>;
+  }
+
+  override async handleTx(): Promise<never> {
+    throw new Error('Dry-run deployment simulation attempted to send a tx');
+  }
+
+  override async sendTransaction(): Promise<never> {
+    throw new Error('Dry-run deployment simulation attempted to send a tx');
+  }
+}
 
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -136,131 +211,6 @@ export function isMissingPackageVersionError(error: unknown): boolean {
     typeof error.message === 'string' &&
     error.message.includes('data="0x"')
   );
-}
-
-function getImplementationAddressesFromVerificationModule({
-  environment,
-  module,
-  chainAddresses,
-}: {
-  environment: DeployEnvironment;
-  module: 'igp' | 'core';
-  chainAddresses: ChainMap<{ interchainGasPaymaster?: Address }>;
-}): ChainMap<Address> {
-  const filepath = join(
-    getEnvironmentDirectory(environment),
-    module,
-    'verification.json',
-  );
-  if (!existsSync(filepath)) return {};
-
-  const implementations: ChainMap<Address> = {};
-  const artifactsByChain = readJson<ChainMap<VerificationArtifact[]>>(filepath);
-  for (const [chain, artifacts] of Object.entries(artifactsByChain)) {
-    const interchainGasPaymaster =
-      chainAddresses[chain]?.interchainGasPaymaster;
-    if (!interchainGasPaymaster) continue;
-
-    const proxyArtifact = artifacts.find(
-      (artifact) =>
-        artifact.isProxy &&
-        artifact.expectedimplementation &&
-        eqAddress(artifact.address, interchainGasPaymaster),
-    );
-    if (!proxyArtifact?.expectedimplementation) continue;
-    const expectedImplementation = proxyArtifact.expectedimplementation;
-
-    const implementationArtifact = artifacts.find(
-      (artifact) =>
-        artifact.name === IGP_ARTIFACT_NAME &&
-        eqAddress(artifact.address, expectedImplementation),
-    );
-    if (!implementationArtifact) {
-      rootLogger.warn(
-        `[${chain}] ${module}/verification.json proxy target ${expectedImplementation} has no ${IGP_ARTIFACT_NAME} artifact entry; ignoring`,
-      );
-      continue;
-    }
-
-    implementations[chain] = expectedImplementation;
-  }
-
-  return implementations;
-}
-
-export function mergeImplementationAddresses({
-  igpImplementations,
-  coreImplementations,
-}: {
-  igpImplementations: ChainMap<Address>;
-  coreImplementations: ChainMap<Address>;
-}): ChainMap<Address> {
-  const implementations: ChainMap<Address> = { ...igpImplementations };
-
-  for (const [chain, coreImplementation] of Object.entries(
-    coreImplementations,
-  )) {
-    const igpImplementation = igpImplementations[chain];
-    if (!igpImplementation) {
-      implementations[chain] = coreImplementation;
-      continue;
-    }
-    if (!eqAddress(igpImplementation, coreImplementation)) {
-      rootLogger.warn(
-        `[${chain}] igp/core verification implementation mismatch; using igp ${igpImplementation} over core ${coreImplementation}`,
-      );
-    }
-  }
-
-  return implementations;
-}
-
-function getImplementationAddressesFromVerificationArtifacts(
-  environment: DeployEnvironment,
-  chainAddresses: ChainMap<{ interchainGasPaymaster?: Address }>,
-): ChainMap<Address> {
-  const igpImplementations = getImplementationAddressesFromVerificationModule({
-    environment,
-    module: 'igp',
-    chainAddresses,
-  });
-  const coreImplementations = getImplementationAddressesFromVerificationModule({
-    environment,
-    module: 'core',
-    chainAddresses,
-  });
-  return mergeImplementationAddresses({
-    igpImplementations,
-    coreImplementations,
-  });
-}
-
-export function getImplementationAddressOverrides(
-  filepath: string,
-  supportedChains: Set<ChainName>,
-): ChainMap<Address> {
-  const rawOverrides = readJson<unknown>(filepath);
-  assert(isRecord(rawOverrides), `${filepath} must contain a JSON object`);
-
-  const overrides: ChainMap<Address> = {};
-  for (const [chain, value] of Object.entries(rawOverrides)) {
-    assert(
-      supportedChains.has(chain),
-      `${filepath} contains unsupported chain ${chain}`,
-    );
-    assert(typeof value === 'string', `${filepath} ${chain} must be a string`);
-    assert(
-      ethers.utils.isAddress(value),
-      `${filepath} ${chain} is not an EVM address: ${value}`,
-    );
-    assert(
-      !eqAddress(value, ethers.constants.AddressZero),
-      `${filepath} ${chain} implementation is zero address`,
-    );
-    overrides[chain] = value;
-  }
-
-  return overrides;
 }
 
 async function getCurrentVersion(
@@ -297,52 +247,6 @@ function isVersionAtLeastTarget({
       { cause: error },
     );
   }
-}
-
-async function assertTargetImplementation({
-  chain,
-  provider,
-  targetImplementation,
-}: {
-  chain: ChainName;
-  provider: ethers.providers.Provider;
-  targetImplementation: Address;
-}): Promise<void> {
-  assert(
-    ethers.utils.isAddress(targetImplementation),
-    `[${chain}] target implementation is not an EVM address: ${targetImplementation}`,
-  );
-  assert(
-    !eqAddress(targetImplementation, ethers.constants.AddressZero),
-    `[${chain}] target implementation is zero address`,
-  );
-
-  const code = await provider.getCode(targetImplementation);
-  assert(
-    code !== '0x',
-    `[${chain}] target implementation ${targetImplementation} has no deployed code`,
-  );
-  const igpInterface = InterchainGasPaymaster__factory.createInterface();
-  for (const signature of [
-    'quoteGasPayment(uint32,uint256)',
-    'payForGas(bytes32,uint32,uint256,address)',
-    'setDestinationGasConfigs',
-  ]) {
-    const selector = igpInterface.getSighash(signature);
-    assert(
-      code.toLowerCase().includes(selector.slice(2).toLowerCase()),
-      `[${chain}] target implementation ${targetImplementation} is missing IGP selector ${signature}`,
-    );
-  }
-
-  const targetVersion = await PackageVersioned__factory.connect(
-    targetImplementation,
-    provider,
-  ).PACKAGE_VERSION();
-  assert(
-    targetVersion === CONTRACTS_PACKAGE_VERSION,
-    `[${chain}] target implementation ${targetImplementation} exposes PACKAGE_VERSION ${targetVersion}, expected ${CONTRACTS_PACKAGE_VERSION}`,
-  );
 }
 
 async function assertProxyAdmin({
@@ -417,41 +321,6 @@ function getSafeGroupKey(chain: ChainName, governanceType: GovernanceType) {
   return `${chain}:${governanceType}`;
 }
 
-export function getPostUpgradeConfigCommand({
-  environment,
-  context,
-  chains,
-}: {
-  environment: string;
-  context: string;
-  chains: ChainName[];
-}) {
-  return [
-    'pnpm --dir typescript/infra exec tsx scripts/deploy.ts',
-    `--environment ${environment}`,
-    `--context ${context}`,
-    '--module igp',
-    `--chains ${chains.join(' ')}`,
-  ].join(' ');
-}
-
-export function getPostUpgradeConfigChains(plans: ChainPlan[]): ChainName[] {
-  return plans
-    .filter((plan) => plan.status === 'queued')
-    .map((plan) => plan.chain);
-}
-
-export function getTimelockPostExecutionConfigChains(
-  plans: ChainPlan[],
-): ChainName[] {
-  return plans
-    .filter(
-      (plan) =>
-        plan.status === 'timelock queued' || plan.status === 'scheduled',
-    )
-    .map((plan) => plan.chain);
-}
-
 function splitSafeCallGroups(groups: SafeCallGroup[]): SafeCallGroup[] {
   const splitGroups: SafeCallGroup[] = [];
 
@@ -503,6 +372,227 @@ function addSafeCall(
     safeAddress,
     calls: [call],
   });
+}
+
+function toUpgradeCall(
+  tx: AnnotatedEV5Transaction,
+  defaultDescription: string,
+): UpgradeCall {
+  assert(tx.to, `${defaultDescription} is missing a target address`);
+  assert(tx.data, `${defaultDescription} is missing calldata`);
+
+  return {
+    to: tx.to,
+    data: tx.data,
+    value: tx.value ? BigNumber.from(tx.value) : BigNumber.from(0),
+    description: tx.annotation ?? defaultDescription,
+  };
+}
+
+function getTargetIgpConfig(chain: ChainName, config: IgpConfig): IgpConfig {
+  assert(
+    config.type === HookType.INTERCHAIN_GAS_PAYMASTER,
+    `[${chain}] expected InterchainGasPaymaster config, got ${config.type}`,
+  );
+
+  return {
+    ...deepCopy(config),
+    contractVersion: CONTRACTS_PACKAGE_VERSION,
+    owner: config.ownerOverrides?.interchainGasPaymaster ?? config.owner,
+  };
+}
+
+async function buildHookUpdateTransactions({
+  chain,
+  config,
+  addresses,
+  multiProvider,
+}: {
+  chain: ChainName;
+  config: IgpConfig;
+  addresses: ChainMap<Address>;
+  multiProvider: MultiProvider;
+}): Promise<AnnotatedEV5Transaction[]> {
+  assert(addresses.mailbox, `[${chain}] missing mailbox address`);
+  assert(addresses.proxyAdmin, `[${chain}] missing proxyAdmin address`);
+  assert(
+    addresses.interchainGasPaymaster,
+    `[${chain}] missing interchainGasPaymaster address`,
+  );
+
+  const targetConfig = getTargetIgpConfig(chain, config);
+  const module = new EvmHookModule(multiProvider, {
+    chain,
+    config: targetConfig,
+    addresses: {
+      ...extractIsmAndHookFactoryAddresses(addresses),
+      mailbox: addresses.mailbox,
+      proxyAdmin: addresses.proxyAdmin,
+      deployedHook: addresses.interchainGasPaymaster,
+    },
+  });
+
+  return module.update(deepCopy(targetConfig));
+}
+
+export function getUpgradeTargetImplementation({
+  tx,
+  proxyAdminAddress,
+  proxyAddress,
+}: {
+  tx: AnnotatedEV5Transaction;
+  proxyAdminAddress: Address;
+  proxyAddress: Address;
+}): Address | undefined {
+  if (!tx.to || !tx.data || !eqAddress(tx.to, proxyAdminAddress)) {
+    return undefined;
+  }
+
+  try {
+    const decoded = ProxyAdmin__factory.createInterface().decodeFunctionData(
+      'upgrade',
+      tx.data,
+    );
+    const [decodedProxy, decodedImplementation] = decoded;
+    if (
+      typeof decodedProxy === 'string' &&
+      typeof decodedImplementation === 'string' &&
+      eqAddress(decodedProxy, proxyAddress)
+    ) {
+      return decodedImplementation;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+export function getDeferredTimelockConfigChains(
+  plans: Pick<ChainPlan, 'chain' | 'status' | 'detail'>[],
+): ChainName[] {
+  return plans
+    .filter(
+      (plan) =>
+        (plan.status === 'timelock queued' || plan.status === 'scheduled') &&
+        plan.detail.includes('config tx(s) deferred'),
+    )
+    .map((plan) => plan.chain);
+}
+
+async function getGovernedCallOwner({
+  chain,
+  provider,
+  call,
+  proxyAdminAddress,
+  proxyAddress,
+  currentImplementation,
+}: {
+  chain: ChainName;
+  provider: ethers.providers.Provider;
+  call: UpgradeCall;
+  proxyAdminAddress: Address;
+  proxyAddress: Address;
+  currentImplementation: Address;
+}): Promise<Address> {
+  if (eqAddress(call.to, proxyAdminAddress)) {
+    return assertProxyAdmin({
+      chain,
+      provider,
+      proxyAdminAddress,
+      proxyAddress,
+      expectedImplementation: currentImplementation,
+    });
+  }
+
+  return Ownable__factory.connect(call.to, provider).owner();
+}
+
+async function routeGovernedCall({
+  groups,
+  ica,
+  chain,
+  call,
+  ownerAddress,
+}: {
+  groups: Map<string, SafeCallGroup>;
+  ica: InterchainAccount;
+  chain: ChainName;
+  call: UpgradeCall;
+  ownerAddress: Address;
+}): Promise<{
+  status: 'queued' | 'timelock queued' | 'scheduled' | 'done' | 'manual';
+  detail: string;
+  ownerType: Owner | null;
+  governanceType: GovernanceType;
+}> {
+  const { ownerType, governanceType } = await determineGovernanceType(
+    chain,
+    ownerAddress,
+  );
+
+  switch (ownerType) {
+    case Owner.SAFE:
+      addSafeCall(groups, chain, governanceType, call);
+      return {
+        status: 'queued',
+        detail: `queued ${governanceType} Safe tx: ${call.description}`,
+        ownerType,
+        governanceType,
+      };
+    case Owner.ICA:
+      const legacyIcaOwner = getLegacyGovernanceIcas(governanceType)[chain];
+      if (legacyIcaOwner && eqAddress(legacyIcaOwner, ownerAddress)) {
+        return {
+          status: 'manual',
+          detail: 'owned by a legacy V1 ICA; script only builds V2 ICA calls',
+          ownerType,
+          governanceType,
+        };
+      }
+      await addIcaSafeCall({
+        groups,
+        ica,
+        destination: chain,
+        governanceType,
+        innerCall: call,
+        expectedRemoteOwner: ownerAddress,
+      });
+      return {
+        status: 'queued',
+        detail: `queued ${governanceType} ICA tx from ethereum: ${call.description}`,
+        ownerType,
+        governanceType,
+      };
+    case Owner.TIMELOCK:
+      return {
+        ...(await routeTimelockCall({
+          groups,
+          ica,
+          chain,
+          governanceType,
+          timelockAddress: ownerAddress,
+          innerCall: call,
+        })),
+        ownerType,
+        governanceType,
+      };
+    case Owner.DEPLOYER:
+      return {
+        status: 'manual',
+        detail:
+          'owned by deployer; script does not execute deployer-key governed calls',
+        ownerType,
+        governanceType,
+      };
+    default:
+      return {
+        status: 'manual',
+        detail: `unknown owner ${ownerAddress}`,
+        ownerType,
+        governanceType,
+      };
+  }
 }
 
 async function addIcaSafeCall({
@@ -860,18 +950,12 @@ async function main() {
     outFile,
     propose,
     all,
-    implementationAddressesFile,
     skipEvmPreflight,
   } = await withOutputFile(
     withChains(
       withContext(
         withPropose(
           getArgs()
-            .option('implementationAddressesFile', {
-              type: 'string',
-              describe:
-                'Optional JSON map of chain name to already deployed InterchainGasPaymaster implementation address. Overrides verification artifacts.',
-            })
             .option('all', {
               type: 'boolean',
               default: false,
@@ -904,18 +988,6 @@ async function main() {
   const envConfig = getEnvironmentConfig(environment);
   const supportedChains = new Set(envConfig.supportedChainNames);
   const chainAddresses = getEnvAddresses(environment);
-  const implementationAddresses = {
-    ...getImplementationAddressesFromVerificationArtifacts(
-      environment,
-      chainAddresses,
-    ),
-    ...(implementationAddressesFile
-      ? getImplementationAddressOverrides(
-          implementationAddressesFile,
-          supportedChains,
-        )
-      : {}),
-  };
   const requested = chains && chains.length > 0 ? new Set(chains) : undefined;
 
   if (requested) {
@@ -948,12 +1020,15 @@ async function main() {
   );
   const providerChains = Array.from(new Set([...targetChains, ETHEREUM_CHAIN]));
 
-  const multiProvider = await envConfig.getMultiProvider(
+  const baseMultiProvider = await envConfig.getMultiProvider(
     context,
-    undefined,
+    propose ? Role.Deployer : undefined,
     true,
     providerChains,
   );
+  const multiProvider = propose
+    ? baseMultiProvider
+    : new DryRunDeployMultiProvider(baseMultiProvider, DEPLOYER);
   const icaAddresses = Object.fromEntries(
     Object.entries(chainAddresses).filter(
       ([, addresses]) => !!addresses.interchainAccountRouter,
@@ -988,11 +1063,12 @@ async function main() {
     }
 
     const provider = multiProvider.getProvider(chain);
-    const targetImplementation = implementationAddresses[chain];
+    const config = envConfig.igp[chain];
     try {
       if (!skipEvmPreflight) {
         await assertCancunCompatible(chain, provider);
       }
+      assert(config, `[${chain}] missing IGP config`);
 
       const currentImplementation = await proxyImplementation(
         provider,
@@ -1007,62 +1083,6 @@ async function main() {
         provider,
         interchainGasPaymaster,
       );
-      if (
-        currentVersion &&
-        isVersionAtLeastTarget({
-          chain,
-          currentVersion,
-        })
-      ) {
-        plans.push({
-          chain,
-          interchainGasPaymaster,
-          currentImplementation,
-          targetImplementation,
-          currentVersion,
-          targetVersion: CONTRACTS_PACKAGE_VERSION,
-          proxyAdmin: actualProxyAdmin,
-          status: 'skipped',
-          detail: 'current contract version is already >= target version',
-        });
-        continue;
-      }
-
-      if (!targetImplementation) {
-        plans.push({
-          chain,
-          interchainGasPaymaster,
-          currentImplementation,
-          currentVersion,
-          targetVersion: CONTRACTS_PACKAGE_VERSION,
-          proxyAdmin: actualProxyAdmin,
-          status: 'error',
-          detail: 'missing implementation address',
-        });
-        continue;
-      }
-
-      await assertTargetImplementation({
-        chain,
-        provider,
-        targetImplementation,
-      });
-
-      if (eqAddress(currentImplementation, targetImplementation)) {
-        plans.push({
-          chain,
-          interchainGasPaymaster,
-          currentImplementation,
-          targetImplementation,
-          currentVersion,
-          targetVersion: CONTRACTS_PACKAGE_VERSION,
-          proxyAdmin: actualProxyAdmin,
-          status: 'no change',
-          detail: 'proxy already points at target implementation',
-        });
-        continue;
-      }
-
       const proxyAdminOwner = await assertProxyAdmin({
         chain,
         provider,
@@ -1070,108 +1090,30 @@ async function main() {
         proxyAddress: interchainGasPaymaster,
         expectedImplementation: currentImplementation,
       });
-      const { ownerType, governanceType } = await determineGovernanceType(
-        chain,
-        proxyAdminOwner,
-      );
-      const upgradeCall: UpgradeCall = {
-        to: actualProxyAdmin,
-        data: ProxyAdmin__factory.createInterface().encodeFunctionData(
-          'upgrade',
-          [interchainGasPaymaster, targetImplementation],
-        ),
-        value: BigNumber.from(0),
-        description: `Upgrade IGP ${interchainGasPaymaster} to ${CONTRACTS_PACKAGE_VERSION} implementation ${targetImplementation}`,
-      };
 
-      let detail: string;
-      let status = 'queued';
-      switch (ownerType) {
-        case Owner.SAFE:
-          addSafeCall(safeGroups, chain, governanceType, upgradeCall);
-          detail = `queued ${governanceType} Safe proposal`;
-          break;
-        case Owner.ICA:
-          const legacyIcaOwner = getLegacyGovernanceIcas(governanceType)[chain];
-          if (legacyIcaOwner && eqAddress(legacyIcaOwner, proxyAdminOwner)) {
-            plans.push({
-              chain,
-              interchainGasPaymaster,
-              currentImplementation,
-              targetImplementation,
-              currentVersion,
-              targetVersion: CONTRACTS_PACKAGE_VERSION,
-              proxyAdmin: actualProxyAdmin,
-              proxyAdminOwner,
-              ownerType,
-              governanceType,
-              status: 'manual',
-              detail:
-                'ProxyAdmin is owned by a legacy V1 ICA; script only builds V2 ICA calls',
-            });
-            continue;
-          }
-          await addIcaSafeCall({
-            groups: safeGroups,
-            ica,
-            destination: chain,
-            governanceType,
-            innerCall: upgradeCall,
-          });
-          detail = `queued ${governanceType} ICA proposal from ethereum`;
-          break;
-        case Owner.TIMELOCK:
-          const timelockRoute = await routeTimelockCall({
-            groups: safeGroups,
-            ica,
-            chain,
-            governanceType,
-            timelockAddress: proxyAdminOwner,
-            innerCall: upgradeCall,
-          });
-          if (timelockRoute.status === 'scheduled') {
-            plans.push({
-              chain,
-              interchainGasPaymaster,
-              currentImplementation,
-              targetImplementation,
-              currentVersion,
-              targetVersion: CONTRACTS_PACKAGE_VERSION,
-              proxyAdmin: actualProxyAdmin,
-              proxyAdminOwner,
-              ownerType,
-              governanceType,
-              status: 'scheduled',
-              detail: timelockRoute.detail,
-            });
-            continue;
-          }
-          if (timelockRoute.status === 'done') {
-            plans.push({
-              chain,
-              interchainGasPaymaster,
-              currentImplementation,
-              targetImplementation,
-              currentVersion,
-              targetVersion: CONTRACTS_PACKAGE_VERSION,
-              proxyAdmin: actualProxyAdmin,
-              proxyAdminOwner,
-              ownerType,
-              governanceType,
-              status: 'error',
-              detail: timelockRoute.detail,
-            });
-            continue;
-          }
-          detail = timelockRoute.detail;
-          status = timelockRoute.status;
-          break;
-        case Owner.DEPLOYER:
+      const implementationUpgradeRequired =
+        !currentVersion ||
+        !isVersionAtLeastTarget({
+          chain,
+          currentVersion,
+        });
+      if (implementationUpgradeRequired) {
+        const { ownerType, governanceType } = await determineGovernanceType(
+          chain,
+          proxyAdminOwner,
+        );
+        const legacyIcaOwner = getLegacyGovernanceIcas(governanceType)[chain];
+        if (
+          ownerType === Owner.DEPLOYER ||
+          !ownerType ||
+          (ownerType === Owner.ICA &&
+            legacyIcaOwner &&
+            eqAddress(legacyIcaOwner, proxyAdminOwner))
+        ) {
           plans.push({
             chain,
             interchainGasPaymaster,
             currentImplementation,
-            targetImplementation,
             currentVersion,
             targetVersion: CONTRACTS_PACKAGE_VERSION,
             proxyAdmin: actualProxyAdmin,
@@ -1180,10 +1122,89 @@ async function main() {
             governanceType,
             status: 'manual',
             detail:
-              'ProxyAdmin is deployer-owned; script does not execute deployer-key upgrades',
+              ownerType === Owner.ICA
+                ? 'ProxyAdmin is owned by a legacy V1 ICA; script only builds V2 ICA calls'
+                : `ProxyAdmin owner ${proxyAdminOwner} is not routeable`,
           });
           continue;
-        default:
+        }
+      }
+
+      const deploymentsBefore =
+        multiProvider instanceof DryRunDeployMultiProvider
+          ? multiProvider.simulatedDeployments.length
+          : 0;
+      const transactions = await buildHookUpdateTransactions({
+        chain,
+        config,
+        addresses,
+        multiProvider,
+      });
+      const simulatedDeployments =
+        multiProvider instanceof DryRunDeployMultiProvider
+          ? multiProvider.simulatedDeployments.slice(deploymentsBefore)
+          : undefined;
+
+      if (transactions.length === 0) {
+        plans.push({
+          chain,
+          interchainGasPaymaster,
+          currentImplementation,
+          currentVersion,
+          targetVersion: CONTRACTS_PACKAGE_VERSION,
+          proxyAdmin: actualProxyAdmin,
+          proxyAdminOwner,
+          status: 'no change',
+          detail: 'hook module produced no update transactions',
+          ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
+        });
+        continue;
+      }
+
+      const upgradeIndex = transactions.findIndex(
+        (tx) =>
+          !!getUpgradeTargetImplementation({
+            tx,
+            proxyAdminAddress: actualProxyAdmin,
+            proxyAddress: interchainGasPaymaster,
+          }),
+      );
+      const targetImplementation =
+        upgradeIndex >= 0
+          ? getUpgradeTargetImplementation({
+              tx: transactions[upgradeIndex],
+              proxyAdminAddress: actualProxyAdmin,
+              proxyAddress: interchainGasPaymaster,
+            })
+          : undefined;
+
+      const routeDetails: string[] = [];
+      let status = 'queued';
+      let ownerType: Owner | null | undefined;
+      let governanceType: GovernanceType | undefined;
+
+      if (upgradeIndex >= 0) {
+        const upgradeCall = toUpgradeCall(
+          transactions[upgradeIndex],
+          `Upgrade IGP ${interchainGasPaymaster} to ${CONTRACTS_PACKAGE_VERSION}`,
+        );
+        const route = await routeGovernedCall({
+          groups: safeGroups,
+          ica,
+          chain,
+          call: upgradeCall,
+          ownerAddress: proxyAdminOwner,
+        });
+        status = route.status === 'done' ? 'error' : route.status;
+        ownerType = route.ownerType;
+        governanceType = route.governanceType;
+        routeDetails.push(route.detail);
+
+        if (
+          route.status === 'timelock queued' ||
+          route.status === 'scheduled' ||
+          route.status === 'done'
+        ) {
           plans.push({
             chain,
             interchainGasPaymaster,
@@ -1195,10 +1216,72 @@ async function main() {
             proxyAdminOwner,
             ownerType,
             governanceType,
-            status: 'manual',
-            detail: `unknown ProxyAdmin owner ${proxyAdminOwner}`,
+            transactionCount: 1,
+            status,
+            detail:
+              route.status === 'done'
+                ? route.detail
+                : `${route.detail}; ${transactions.length - 1} config tx(s) deferred until the timelock upgrade executes`,
+            ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
           });
           continue;
+        }
+
+        if (route.status === 'manual') {
+          plans.push({
+            chain,
+            interchainGasPaymaster,
+            currentImplementation,
+            targetImplementation,
+            currentVersion,
+            targetVersion: CONTRACTS_PACKAGE_VERSION,
+            proxyAdmin: actualProxyAdmin,
+            proxyAdminOwner,
+            ownerType,
+            governanceType,
+            transactionCount: 1,
+            status,
+            detail: route.detail,
+            ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
+          });
+          continue;
+        }
+      }
+
+      for (const [index, transaction] of transactions.entries()) {
+        if (index === upgradeIndex) continue;
+        const call = toUpgradeCall(
+          transaction,
+          `IGP update tx ${index + 1} for ${chain}`,
+        );
+        const ownerAddress = await getGovernedCallOwner({
+          chain,
+          provider,
+          call,
+          proxyAdminAddress: actualProxyAdmin,
+          proxyAddress: interchainGasPaymaster,
+          currentImplementation,
+        });
+        const route = await routeGovernedCall({
+          groups: safeGroups,
+          ica,
+          chain,
+          call,
+          ownerAddress,
+        });
+        ownerType ??= route.ownerType;
+        governanceType ??= route.governanceType;
+        routeDetails.push(route.detail);
+        if (route.status === 'manual' || route.status === 'done') {
+          status = route.status === 'done' ? 'error' : route.status;
+          break;
+        }
+        if (
+          route.status === 'timelock queued' ||
+          route.status === 'scheduled'
+        ) {
+          status = route.status;
+        }
       }
 
       plans.push({
@@ -1212,14 +1295,15 @@ async function main() {
         proxyAdminOwner,
         ownerType,
         governanceType,
+        transactionCount: transactions.length,
         status,
-        detail,
+        detail: routeDetails.join('; '),
+        ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
       });
     } catch (error) {
       plans.push({
         chain,
         interchainGasPaymaster,
-        targetImplementation,
         targetVersion: CONTRACTS_PACKAGE_VERSION,
         status: 'error',
         detail: formatError(error),
@@ -1228,25 +1312,6 @@ async function main() {
   }
 
   const groups = splitSafeCallGroups([...safeGroups.values()]);
-  const queuedUpgradeChains = getPostUpgradeConfigChains(plans);
-  const timelockPostExecutionChains =
-    getTimelockPostExecutionConfigChains(plans);
-  const postUpgradeConfigCommand =
-    queuedUpgradeChains.length > 0
-      ? getPostUpgradeConfigCommand({
-          environment,
-          context,
-          chains: queuedUpgradeChains,
-        })
-      : undefined;
-  const timelockPostExecutionConfigCommand =
-    timelockPostExecutionChains.length > 0
-      ? getPostUpgradeConfigCommand({
-          environment,
-          context,
-          chains: timelockPostExecutionChains,
-        })
-      : undefined;
   const runDir = join(
     OUTPUT_ROOT,
     new Date().toISOString().replace(/[:.]/g, '-'),
@@ -1282,10 +1347,6 @@ async function main() {
     targetVersion: CONTRACTS_PACKAGE_VERSION,
     mode: propose ? 'propose' : 'dry-run',
     legacyIgpChains,
-    ...(postUpgradeConfigCommand ? { postUpgradeConfigCommand } : {}),
-    ...(timelockPostExecutionConfigCommand
-      ? { timelockPostExecutionConfigCommand }
-      : {}),
     ...(proposalResults.length > 0 ? { proposalResults } : {}),
     safeGroups: groups.map((group) => ({
       chain: group.chain,
@@ -1307,21 +1368,12 @@ async function main() {
   if (!propose) {
     rootLogger.info(`Dry run: Safe batch files written under ${runDir}`);
   }
-  if (postUpgradeConfigCommand) {
+  const deferredTimelockChains = getDeferredTimelockConfigChains(plans);
+  if (deferredTimelockChains.length > 0) {
     rootLogger.warn(
       [
-        'After the upgrade transactions execute and any ICA messages relay, immediately apply IGP config.',
-        'The upgraded IGP reads native gas params from new storage slots; until config is applied, native gas payments may be underquoted or zero.',
-        postUpgradeConfigCommand,
-      ].join('\n'),
-    );
-  }
-  if (timelockPostExecutionConfigCommand) {
-    rootLogger.warn(
-      [
-        'After the timelock upgrade operation executes, immediately apply IGP config on these chains.',
-        'Do not run this command after only scheduling the timelock operation.',
-        timelockPostExecutionConfigCommand,
+        `Config txs were deferred for timelock-owned upgrade chain(s): ${deferredTimelockChains.join(', ')}`,
+        'Execute the timelock upgrade first, then rerun this script for those chains to propose the hook-module config txs.',
       ].join('\n'),
     );
   }

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -1,6 +1,5 @@
-import { mkdirSync } from 'fs';
+import { existsSync, mkdirSync } from 'fs';
 import { basename, dirname, join } from 'path';
-import yargs from 'yargs';
 
 import {
   CONTRACTS_PACKAGE_VERSION,
@@ -46,6 +45,8 @@ import {
 import { determineGovernanceType, Owner } from '../../src/governance.js';
 import { GovernanceType } from '../../src/governanceTypes.js';
 import { SafeMultiSend } from '../../src/govern/multisend.js';
+import type { DeployEnvironment } from '../../src/config/deploy-environment.js';
+import { getEnvironmentDirectory } from '../../src/paths.js';
 import { logTable } from '../../src/utils/log.js';
 import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
 import {
@@ -90,6 +91,13 @@ type SafeCallGroup = {
   calls: UpgradeCall[];
 };
 
+type VerificationArtifact = {
+  name: string;
+  address: Address;
+  isProxy?: boolean;
+  expectedimplementation?: Address;
+};
+
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -110,6 +118,40 @@ function getImplementationAddress(
   implementations: ChainMap<Address>,
 ): Address | undefined {
   return implementations[chain];
+}
+
+function getImplementationAddressesFromVerificationArtifacts(
+  environment: DeployEnvironment,
+  chainAddresses: ChainMap<{ interchainGasPaymaster?: Address }>,
+): ChainMap<Address> {
+  const implementations: ChainMap<Address> = {};
+  for (const module of ['igp', 'core']) {
+    const filepath = join(
+      getEnvironmentDirectory(environment),
+      module,
+      'verification.json',
+    );
+    if (!existsSync(filepath)) continue;
+
+    const artifactsByChain =
+      readJson<ChainMap<VerificationArtifact[]>>(filepath);
+    for (const [chain, artifacts] of Object.entries(artifactsByChain)) {
+      const interchainGasPaymaster =
+        chainAddresses[chain]?.interchainGasPaymaster;
+      if (!interchainGasPaymaster) continue;
+
+      const proxyArtifact = artifacts.find(
+        (artifact) =>
+          artifact.isProxy &&
+          artifact.expectedimplementation &&
+          eqAddress(artifact.address, interchainGasPaymaster),
+      );
+      if (proxyArtifact?.expectedimplementation) {
+        implementations[chain] = proxyArtifact.expectedimplementation;
+      }
+    }
+  }
+  return implementations;
 }
 
 async function getCurrentVersion(
@@ -469,8 +511,7 @@ async function main() {
             .option('implementationAddressesFile', {
               type: 'string',
               describe:
-                'JSON map of chain name to already deployed InterchainGasPaymaster implementation address',
-              demandOption: true,
+                'Optional JSON map of chain name to already deployed InterchainGasPaymaster implementation address. Overrides verification artifacts.',
             })
             .option('all', {
               type: 'boolean',
@@ -493,10 +534,17 @@ async function main() {
     'Refusing to propose for all compatible chains without --all. Pass --chains or --all.',
   );
 
-  const implementationAddresses = readJson<ChainMap<Address>>(
-    implementationAddressesFile,
-  );
   const envConfig = getEnvironmentConfig(environment);
+  const chainAddresses = getEnvAddresses(environment);
+  const implementationAddresses = {
+    ...getImplementationAddressesFromVerificationArtifacts(
+      environment,
+      chainAddresses,
+    ),
+    ...(implementationAddressesFile
+      ? readJson<ChainMap<Address>>(implementationAddressesFile)
+      : {}),
+  };
   const requested = chains && chains.length > 0 ? new Set(chains) : undefined;
   const targetChains = envConfig.supportedChainNames.filter((chain) => {
     if (requested && !requested.has(chain)) return false;
@@ -510,7 +558,6 @@ async function main() {
     true,
     targetChains,
   );
-  const chainAddresses = getEnvAddresses(environment);
   const icaAddresses = Object.fromEntries(
     Object.entries(chainAddresses).filter(
       ([, addresses]) => !!addresses.interchainAccountRouter,

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync } from 'fs';
 import { basename, dirname, join } from 'path';
+import { pathToFileURL } from 'url';
 
 import {
   CONTRACTS_PACKAGE_VERSION,
@@ -114,6 +115,27 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+function getNestedRecord(
+  value: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  return isRecord(value[key]) ? value[key] : undefined;
+}
+
+export function isMissingPackageVersionError(error: unknown): boolean {
+  if (!isRecord(error)) return false;
+
+  const nestedError = getNestedRecord(error, 'error');
+  const data = typeof error.data === 'string' ? error.data : nestedError?.data;
+  if (error.code === 'CALL_EXCEPTION' && data === '0x') return true;
+
+  return (
+    error.code === 'CALL_EXCEPTION' &&
+    typeof error.message === 'string' &&
+    error.message.includes('data="0x"')
+  );
+}
+
 function getImplementationAddressesFromVerificationArtifacts(
   environment: DeployEnvironment,
   chainAddresses: ChainMap<{ interchainGasPaymaster?: Address }>,
@@ -148,7 +170,7 @@ function getImplementationAddressesFromVerificationArtifacts(
   return implementations;
 }
 
-function getImplementationAddressOverrides(
+export function getImplementationAddressOverrides(
   filepath: string,
   supportedChains: Set<ChainName>,
 ): ChainMap<Address> {
@@ -187,6 +209,7 @@ async function getCurrentVersion(
       provider,
     ).PACKAGE_VERSION();
   } catch (error) {
+    if (!isMissingPackageVersionError(error)) throw error;
     rootLogger.info(
       `[${chain}] IGP does not expose PACKAGE_VERSION: ${formatError(error)}`,
     );
@@ -258,7 +281,7 @@ function getSafeGroupKey(chain: ChainName, governanceType: GovernanceType) {
   return `${chain}:${governanceType}`;
 }
 
-function getPostUpgradeConfigCommand({
+export function getPostUpgradeConfigCommand({
   environment,
   context,
   chains,
@@ -274,6 +297,12 @@ function getPostUpgradeConfigCommand({
     '--module igp',
     `--chains ${chains.join(' ')}`,
   ].join(' ');
+}
+
+export function getPostUpgradeConfigChains(plans: ChainPlan[]): ChainName[] {
+  return plans
+    .filter((plan) => plan.status === 'queued')
+    .map((plan) => plan.chain);
 }
 
 function addSafeCall(
@@ -393,7 +422,7 @@ async function routeTimelockCall({
   governanceType: GovernanceType;
   timelockAddress: Address;
   innerCall: UpgradeCall;
-}): Promise<string> {
+}): Promise<{ status: 'queued' | 'scheduled'; detail: string }> {
   const provider = ica.multiProvider.getProvider(chain);
   const timelock = TimelockController__factory.connect(
     timelockAddress,
@@ -418,7 +447,10 @@ async function routeTimelockCall({
     (await timelock.isOperationReady(operationId)) ||
     (await timelock.isOperationDone(operationId));
   if (isScheduled) {
-    return `timelock operation already scheduled/done: ${operationId}`;
+    return {
+      status: 'scheduled',
+      detail: `timelock operation already scheduled/done: ${operationId}`,
+    };
   }
 
   const scheduleCall: UpgradeCall = {
@@ -461,7 +493,10 @@ async function routeTimelockCall({
     });
   }
 
-  return `timelock operation queued for scheduling: ${operationId}`;
+  return {
+    status: 'queued',
+    detail: `timelock operation queued for scheduling: ${operationId}`,
+  };
 }
 
 function getGovernanceIcaAddress(
@@ -587,6 +622,42 @@ async function proposeSafeGroups({
     }
   }
   return results;
+}
+
+export function splitProposableGroups({
+  groups,
+  rawFallbackGroupKeys,
+}: {
+  groups: SafeCallGroup[];
+  rawFallbackGroupKeys: Set<string>;
+}): {
+  proposableGroups: SafeCallGroup[];
+  skippedProposalResults: ProposalResult[];
+} {
+  const proposableGroups: SafeCallGroup[] = [];
+  const skippedProposalResults: ProposalResult[] = [];
+
+  for (const group of groups) {
+    if (
+      !rawFallbackGroupKeys.has(
+        getSafeGroupKey(group.chain, group.governanceType),
+      )
+    ) {
+      proposableGroups.push(group);
+      continue;
+    }
+
+    skippedProposalResults.push({
+      chain: group.chain,
+      governanceType: group.governanceType,
+      safeAddress: group.safeAddress,
+      status: 'skipped',
+      detail:
+        'skipped propose because only raw fallback calldata was written; submit manually',
+    });
+  }
+
+  return { proposableGroups, skippedProposalResults };
 }
 
 async function main() {
@@ -840,7 +911,7 @@ async function main() {
           detail = `queued ${governanceType} ICA proposal from ethereum`;
           break;
         case Owner.TIMELOCK:
-          detail = await routeTimelockCall({
+          const timelockRoute = await routeTimelockCall({
             groups: safeGroups,
             ica,
             chain,
@@ -848,6 +919,24 @@ async function main() {
             timelockAddress: proxyAdminOwner,
             innerCall: upgradeCall,
           });
+          if (timelockRoute.status === 'scheduled') {
+            plans.push({
+              chain,
+              interchainGasPaymaster,
+              currentImplementation,
+              targetImplementation,
+              currentVersion,
+              targetVersion: CONTRACTS_PACKAGE_VERSION,
+              proxyAdmin: actualProxyAdmin,
+              proxyAdminOwner,
+              ownerType,
+              governanceType,
+              status: 'scheduled',
+              detail: timelockRoute.detail,
+            });
+            continue;
+          }
+          detail = timelockRoute.detail;
           break;
         case Owner.DEPLOYER:
           plans.push({
@@ -911,9 +1000,7 @@ async function main() {
   }
 
   const groups = [...safeGroups.values()];
-  const queuedUpgradeChains = plans
-    .filter((plan) => plan.status === 'queued')
-    .map((plan) => plan.chain);
+  const queuedUpgradeChains = getPostUpgradeConfigChains(plans);
   const postUpgradeConfigCommand =
     queuedUpgradeChains.length > 0
       ? getPostUpgradeConfigCommand({
@@ -934,34 +1021,18 @@ async function main() {
 
   const proposalResults: ProposalResult[] = [];
   if (propose) {
-    for (const group of groups) {
-      if (
-        !rawFallbackGroupKeys.has(
-          getSafeGroupKey(group.chain, group.governanceType),
-        )
-      ) {
-        continue;
-      }
-      const detail =
-        'skipped propose because only raw fallback calldata was written; submit manually';
-      proposalResults.push({
-        chain: group.chain,
-        governanceType: group.governanceType,
-        safeAddress: group.safeAddress,
-        status: 'skipped',
-        detail,
-      });
-      rootLogger.warn(`[${group.chain}] ${detail}`);
+    const { proposableGroups, skippedProposalResults } = splitProposableGroups({
+      groups,
+      rawFallbackGroupKeys,
+    });
+    proposalResults.push(...skippedProposalResults);
+    for (const result of skippedProposalResults) {
+      rootLogger.warn(`[${result.chain}] ${result.detail}`);
     }
 
     proposalResults.push(
       ...(await proposeSafeGroups({
-        groups: groups.filter(
-          (group) =>
-            !rawFallbackGroupKeys.has(
-              getSafeGroupKey(group.chain, group.governanceType),
-            ),
-        ),
+        groups: proposableGroups,
         multiProvider,
       })),
     );
@@ -1009,7 +1080,12 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  rootLogger.error(error);
-  process.exit(1);
-});
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    rootLogger.error(error);
+    process.exit(1);
+  });
+}

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'url';
 
 import {
   CONTRACTS_PACKAGE_VERSION,
+  InterchainGasPaymaster__factory,
   Ownable__factory,
   PackageVersioned__factory,
   ProxyAdmin__factory,
@@ -58,6 +59,8 @@ import { getEnvironmentConfig } from '../core-utils.js';
 const ETHEREUM_CHAIN: ChainName = 'ethereum';
 const OUTPUT_ROOT = 'igp-upgrade-output';
 const CANCUN_PROBE_INIT_CODE = '0x5f5f5d5f5c5f5260205ff3';
+const MAX_SAFE_BATCH_SIZE = 120;
+const IGP_ARTIFACT_NAME = 'InterchainGasPaymaster';
 
 type UpgradeCall = {
   to: Address;
@@ -86,6 +89,8 @@ type SafeCallGroup = {
   governanceType: GovernanceType;
   safeAddress: Address;
   calls: UpgradeCall[];
+  batchIndex?: number;
+  batchCount?: number;
 };
 
 type ProposalResult = {
@@ -109,7 +114,7 @@ function formatError(error: unknown): string {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function getNestedRecord(
@@ -133,38 +138,101 @@ export function isMissingPackageVersionError(error: unknown): boolean {
   );
 }
 
+function getImplementationAddressesFromVerificationModule({
+  environment,
+  module,
+  chainAddresses,
+}: {
+  environment: DeployEnvironment;
+  module: 'igp' | 'core';
+  chainAddresses: ChainMap<{ interchainGasPaymaster?: Address }>;
+}): ChainMap<Address> {
+  const filepath = join(
+    getEnvironmentDirectory(environment),
+    module,
+    'verification.json',
+  );
+  if (!existsSync(filepath)) return {};
+
+  const implementations: ChainMap<Address> = {};
+  const artifactsByChain = readJson<ChainMap<VerificationArtifact[]>>(filepath);
+  for (const [chain, artifacts] of Object.entries(artifactsByChain)) {
+    const interchainGasPaymaster =
+      chainAddresses[chain]?.interchainGasPaymaster;
+    if (!interchainGasPaymaster) continue;
+
+    const proxyArtifact = artifacts.find(
+      (artifact) =>
+        artifact.isProxy &&
+        artifact.expectedimplementation &&
+        eqAddress(artifact.address, interchainGasPaymaster),
+    );
+    if (!proxyArtifact?.expectedimplementation) continue;
+    const expectedImplementation = proxyArtifact.expectedimplementation;
+
+    const implementationArtifact = artifacts.find(
+      (artifact) =>
+        artifact.name === IGP_ARTIFACT_NAME &&
+        eqAddress(artifact.address, expectedImplementation),
+    );
+    if (!implementationArtifact) {
+      rootLogger.warn(
+        `[${chain}] ${module}/verification.json proxy target ${expectedImplementation} has no ${IGP_ARTIFACT_NAME} artifact entry; ignoring`,
+      );
+      continue;
+    }
+
+    implementations[chain] = expectedImplementation;
+  }
+
+  return implementations;
+}
+
+export function mergeImplementationAddresses({
+  igpImplementations,
+  coreImplementations,
+}: {
+  igpImplementations: ChainMap<Address>;
+  coreImplementations: ChainMap<Address>;
+}): ChainMap<Address> {
+  const implementations: ChainMap<Address> = { ...igpImplementations };
+
+  for (const [chain, coreImplementation] of Object.entries(
+    coreImplementations,
+  )) {
+    const igpImplementation = igpImplementations[chain];
+    if (!igpImplementation) {
+      implementations[chain] = coreImplementation;
+      continue;
+    }
+    if (!eqAddress(igpImplementation, coreImplementation)) {
+      rootLogger.warn(
+        `[${chain}] igp/core verification implementation mismatch; using igp ${igpImplementation} over core ${coreImplementation}`,
+      );
+    }
+  }
+
+  return implementations;
+}
+
 function getImplementationAddressesFromVerificationArtifacts(
   environment: DeployEnvironment,
   chainAddresses: ChainMap<{ interchainGasPaymaster?: Address }>,
 ): ChainMap<Address> {
-  const implementations: ChainMap<Address> = {};
-  for (const module of ['igp', 'core']) {
-    const filepath = join(
-      getEnvironmentDirectory(environment),
-      module,
-      'verification.json',
-    );
-    if (!existsSync(filepath)) continue;
-
-    const artifactsByChain =
-      readJson<ChainMap<VerificationArtifact[]>>(filepath);
-    for (const [chain, artifacts] of Object.entries(artifactsByChain)) {
-      const interchainGasPaymaster =
-        chainAddresses[chain]?.interchainGasPaymaster;
-      if (!interchainGasPaymaster) continue;
-
-      const proxyArtifact = artifacts.find(
-        (artifact) =>
-          artifact.isProxy &&
-          artifact.expectedimplementation &&
-          eqAddress(artifact.address, interchainGasPaymaster),
-      );
-      if (proxyArtifact?.expectedimplementation) {
-        implementations[chain] = proxyArtifact.expectedimplementation;
-      }
-    }
-  }
-  return implementations;
+  const igpImplementations = getImplementationAddressesFromVerificationModule({
+    environment,
+    module: 'igp',
+    chainAddresses,
+  });
+  const coreImplementations = getImplementationAddressesFromVerificationModule({
+    environment,
+    module: 'core',
+    chainAddresses,
+  });
+  return mergeImplementationAddresses({
+    igpImplementations,
+    coreImplementations,
+  });
 }
 
 export function getImplementationAddressOverrides(
@@ -214,6 +282,23 @@ async function getCurrentVersion(
   }
 }
 
+function isVersionAtLeastTarget({
+  chain,
+  currentVersion,
+}: {
+  chain: ChainName;
+  currentVersion: string;
+}): boolean {
+  try {
+    return compareVersions(currentVersion, CONTRACTS_PACKAGE_VERSION) >= 0;
+  } catch (error) {
+    throw new Error(
+      `[${chain}] current PACKAGE_VERSION ${currentVersion} is not valid semver`,
+      { cause: error },
+    );
+  }
+}
+
 async function assertTargetImplementation({
   chain,
   provider,
@@ -237,6 +322,18 @@ async function assertTargetImplementation({
     code !== '0x',
     `[${chain}] target implementation ${targetImplementation} has no deployed code`,
   );
+  const igpInterface = InterchainGasPaymaster__factory.createInterface();
+  for (const signature of [
+    'quoteGasPayment(uint32,uint256)',
+    'payForGas(bytes32,uint32,uint256,address)',
+    'setDestinationGasConfigs',
+  ]) {
+    const selector = igpInterface.getSighash(signature);
+    assert(
+      code.toLowerCase().includes(selector.slice(2).toLowerCase()),
+      `[${chain}] target implementation ${targetImplementation} is missing IGP selector ${signature}`,
+    );
+  }
 
   const targetVersion = await PackageVersioned__factory.connect(
     targetImplementation,
@@ -246,6 +343,48 @@ async function assertTargetImplementation({
     targetVersion === CONTRACTS_PACKAGE_VERSION,
     `[${chain}] target implementation ${targetImplementation} exposes PACKAGE_VERSION ${targetVersion}, expected ${CONTRACTS_PACKAGE_VERSION}`,
   );
+}
+
+async function assertProxyAdmin({
+  chain,
+  provider,
+  proxyAdminAddress,
+  proxyAddress,
+  expectedImplementation,
+}: {
+  chain: ChainName;
+  provider: ethers.providers.Provider;
+  proxyAdminAddress: Address;
+  proxyAddress: Address;
+  expectedImplementation: Address;
+}): Promise<Address> {
+  const code = await provider.getCode(proxyAdminAddress);
+  assert(
+    code !== '0x',
+    `[${chain}] ProxyAdmin ${proxyAdminAddress} has no deployed code`,
+  );
+
+  const proxyAdminInterface = ProxyAdmin__factory.createInterface();
+  const implementationResult = await provider.call({
+    to: proxyAdminAddress,
+    data: proxyAdminInterface.encodeFunctionData('getProxyImplementation', [
+      proxyAddress,
+    ]),
+  });
+  const [proxyAdminImplementation] = proxyAdminInterface.decodeFunctionResult(
+    'getProxyImplementation',
+    implementationResult,
+  );
+  assert(
+    typeof proxyAdminImplementation === 'string',
+    `[${chain}] ProxyAdmin ${proxyAdminAddress} returned invalid implementation for ${proxyAddress}`,
+  );
+  assert(
+    eqAddress(proxyAdminImplementation, expectedImplementation),
+    `[${chain}] ProxyAdmin ${proxyAdminAddress} reports implementation ${proxyAdminImplementation}, expected ${expectedImplementation}`,
+  );
+
+  return Ownable__factory.connect(proxyAdminAddress, provider).owner();
 }
 
 async function assertCancunCompatible(
@@ -300,6 +439,43 @@ export function getPostUpgradeConfigChains(plans: ChainPlan[]): ChainName[] {
   return plans
     .filter((plan) => plan.status === 'queued')
     .map((plan) => plan.chain);
+}
+
+export function getTimelockPostExecutionConfigChains(
+  plans: ChainPlan[],
+): ChainName[] {
+  return plans
+    .filter(
+      (plan) =>
+        plan.status === 'timelock queued' || plan.status === 'scheduled',
+    )
+    .map((plan) => plan.chain);
+}
+
+function splitSafeCallGroups(groups: SafeCallGroup[]): SafeCallGroup[] {
+  const splitGroups: SafeCallGroup[] = [];
+
+  for (const group of groups) {
+    if (group.calls.length <= MAX_SAFE_BATCH_SIZE) {
+      splitGroups.push(group);
+      continue;
+    }
+
+    const batchCount = Math.ceil(group.calls.length / MAX_SAFE_BATCH_SIZE);
+    for (let batchIndex = 0; batchIndex < batchCount; batchIndex++) {
+      splitGroups.push({
+        ...group,
+        calls: group.calls.slice(
+          batchIndex * MAX_SAFE_BATCH_SIZE,
+          (batchIndex + 1) * MAX_SAFE_BATCH_SIZE,
+        ),
+        batchIndex: batchIndex + 1,
+        batchCount,
+      });
+    }
+  }
+
+  return splitGroups;
 }
 
 function addSafeCall(
@@ -419,7 +595,10 @@ async function routeTimelockCall({
   governanceType: GovernanceType;
   timelockAddress: Address;
   innerCall: UpgradeCall;
-}): Promise<{ status: 'queued' | 'scheduled'; detail: string }> {
+}): Promise<{
+  status: 'timelock queued' | 'scheduled' | 'done';
+  detail: string;
+}> {
   const provider = ica.multiProvider.getProvider(chain);
   const timelock = TimelockController__factory.connect(
     timelockAddress,
@@ -439,10 +618,17 @@ async function routeTimelockCall({
     salt,
   );
 
+  const isDone = await timelock.isOperationDone(operationId);
+  if (isDone) {
+    return {
+      status: 'done',
+      detail: `timelock operation already executed but proxy still points at the old implementation: ${operationId}`,
+    };
+  }
+
   const isScheduled =
     (await timelock.isOperationPending(operationId)) ||
-    (await timelock.isOperationReady(operationId)) ||
-    (await timelock.isOperationDone(operationId));
+    (await timelock.isOperationReady(operationId));
   if (isScheduled) {
     return {
       status: 'scheduled',
@@ -491,7 +677,7 @@ async function routeTimelockCall({
   }
 
   return {
-    status: 'queued',
+    status: 'timelock queued',
     detail: `timelock operation queued for scheduling: ${operationId}`,
   };
 }
@@ -525,9 +711,12 @@ async function writeSafeBatchFiles({
       rawFallbackGroupKeys.add(
         getSafeGroupKey(group.chain, group.governanceType),
       );
+      const batchSuffix = group.batchCount
+        ? `-${group.batchIndex}-of-${group.batchCount}`
+        : '';
       const filepath = join(
         runDir,
-        `${group.chain}-${group.governanceType}.raw.json`,
+        `${group.chain}-${group.governanceType}${batchSuffix}.raw.json`,
       );
       mkdirSync(dirname(filepath), { recursive: true });
       await writeAndFormatJsonAtPath(filepath, {
@@ -535,6 +724,9 @@ async function writeSafeBatchFiles({
         chainId: multiProvider.getEvmChainId(group.chain),
         safeAddress: group.safeAddress,
         governanceType: group.governanceType,
+        ...(group.batchIndex && group.batchCount
+          ? { batchIndex: group.batchIndex, batchCount: group.batchCount }
+          : {}),
         note: 'Raw calldata. NOT a Safe Transaction Builder file (no usable tx service for this chain); submit manually.',
         error: formatError(error),
         transactions: group.calls.map((call) => ({
@@ -558,9 +750,12 @@ async function writeSafeBatchFiles({
       chainId,
     }));
     const batch = await builder.submit(...txs);
+    const batchSuffix = group.batchCount
+      ? `-${group.batchIndex}-of-${group.batchCount}`
+      : '';
     const filepath = join(
       runDir,
-      `${group.chain}-${group.governanceType}.json`,
+      `${group.chain}-${group.governanceType}${batchSuffix}.json`,
     );
     mkdirSync(dirname(filepath), { recursive: true });
     await writeAndFormatJsonAtPath(filepath, batch);
@@ -701,6 +896,10 @@ async function main() {
     environment === 'mainnet3',
     'This script only supports mainnet3 because governance Safe, ICA, and timelock config is imported from mainnet3.',
   );
+  assert(
+    !skipEvmPreflight,
+    'mainnet3 IGP upgrades require the Cancun/PUSH0 preflight; remove --skipEvmPreflight.',
+  );
 
   const envConfig = getEnvironmentConfig(environment);
   const supportedChains = new Set(envConfig.supportedChainNames);
@@ -741,6 +940,12 @@ async function main() {
     if (chainsToSkip.includes(chain)) return false;
     return true;
   });
+  assert(
+    targetChains.length > 0,
+    requested
+      ? 'No requested chains remain after supported/legacy/skip filtering.'
+      : 'No compatible chains remain after legacy/skip filtering.',
+  );
   const providerChains = Array.from(new Set([...targetChains, ETHEREUM_CHAIN]));
 
   const multiProvider = await envConfig.getMultiProvider(
@@ -804,7 +1009,10 @@ async function main() {
       );
       if (
         currentVersion &&
-        compareVersions(currentVersion, CONTRACTS_PACKAGE_VERSION) >= 0
+        isVersionAtLeastTarget({
+          chain,
+          currentVersion,
+        })
       ) {
         plans.push({
           chain,
@@ -855,10 +1063,13 @@ async function main() {
         continue;
       }
 
-      const proxyAdminOwner = await Ownable__factory.connect(
-        actualProxyAdmin,
+      const proxyAdminOwner = await assertProxyAdmin({
+        chain,
         provider,
-      ).owner();
+        proxyAdminAddress: actualProxyAdmin,
+        proxyAddress: interchainGasPaymaster,
+        expectedImplementation: currentImplementation,
+      });
       const { ownerType, governanceType } = await determineGovernanceType(
         chain,
         proxyAdminOwner,
@@ -874,6 +1085,7 @@ async function main() {
       };
 
       let detail: string;
+      let status = 'queued';
       switch (ownerType) {
         case Owner.SAFE:
           addSafeCall(safeGroups, chain, governanceType, upgradeCall);
@@ -934,7 +1146,25 @@ async function main() {
             });
             continue;
           }
+          if (timelockRoute.status === 'done') {
+            plans.push({
+              chain,
+              interchainGasPaymaster,
+              currentImplementation,
+              targetImplementation,
+              currentVersion,
+              targetVersion: CONTRACTS_PACKAGE_VERSION,
+              proxyAdmin: actualProxyAdmin,
+              proxyAdminOwner,
+              ownerType,
+              governanceType,
+              status: 'error',
+              detail: timelockRoute.detail,
+            });
+            continue;
+          }
           detail = timelockRoute.detail;
+          status = timelockRoute.status;
           break;
         case Owner.DEPLOYER:
           plans.push({
@@ -982,7 +1212,7 @@ async function main() {
         proxyAdminOwner,
         ownerType,
         governanceType,
-        status: 'queued',
+        status,
         detail,
       });
     } catch (error) {
@@ -997,14 +1227,24 @@ async function main() {
     }
   }
 
-  const groups = [...safeGroups.values()];
+  const groups = splitSafeCallGroups([...safeGroups.values()]);
   const queuedUpgradeChains = getPostUpgradeConfigChains(plans);
+  const timelockPostExecutionChains =
+    getTimelockPostExecutionConfigChains(plans);
   const postUpgradeConfigCommand =
     queuedUpgradeChains.length > 0
       ? getPostUpgradeConfigCommand({
           environment,
           context,
           chains: queuedUpgradeChains,
+        })
+      : undefined;
+  const timelockPostExecutionConfigCommand =
+    timelockPostExecutionChains.length > 0
+      ? getPostUpgradeConfigCommand({
+          environment,
+          context,
+          chains: timelockPostExecutionChains,
         })
       : undefined;
   const runDir = join(
@@ -1043,12 +1283,18 @@ async function main() {
     mode: propose ? 'propose' : 'dry-run',
     legacyIgpChains,
     ...(postUpgradeConfigCommand ? { postUpgradeConfigCommand } : {}),
+    ...(timelockPostExecutionConfigCommand
+      ? { timelockPostExecutionConfigCommand }
+      : {}),
     ...(proposalResults.length > 0 ? { proposalResults } : {}),
     safeGroups: groups.map((group) => ({
       chain: group.chain,
       governanceType: group.governanceType,
       safeAddress: group.safeAddress,
       transactionCount: group.calls.length,
+      ...(group.batchIndex && group.batchCount
+        ? { batchIndex: group.batchIndex, batchCount: group.batchCount }
+        : {}),
     })),
     plans,
   };
@@ -1070,9 +1316,19 @@ async function main() {
       ].join('\n'),
     );
   }
+  if (timelockPostExecutionConfigCommand) {
+    rootLogger.warn(
+      [
+        'After the timelock upgrade operation executes, immediately apply IGP config on these chains.',
+        'Do not run this command after only scheduling the timelock operation.',
+        timelockPostExecutionConfigCommand,
+      ].join('\n'),
+    );
+  }
   if (
     plans.some((plan) => plan.status === 'error') ||
-    proposalResults.some((result) => result.status === 'error')
+    proposalResults.some((result) => result.status === 'error') ||
+    (propose && rawFallbackGroupKeys.size > 0)
   ) {
     process.exitCode = 1;
   }

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -633,6 +633,8 @@ async function routeGovernedCall({
   call,
   ownerAddress,
   timelockIdempotency,
+  propose,
+  multiProvider,
 }: {
   groups: Map<string, SafeCallGroup>;
   icaGroups: Map<string, IcaCallGroup>;
@@ -641,8 +643,16 @@ async function routeGovernedCall({
   call: UpgradeCall;
   ownerAddress: Address;
   timelockIdempotency?: TimelockIdempotency;
+  propose: boolean;
+  multiProvider: MultiProvider;
 }): Promise<{
-  status: 'queued' | 'timelock queued' | 'scheduled' | 'done' | 'manual';
+  status:
+    | 'queued'
+    | 'timelock queued'
+    | 'scheduled'
+    | 'done'
+    | 'manual'
+    | 'executed';
   detail: string;
   ownerType: Owner | null;
   governanceType: GovernanceType;
@@ -699,13 +709,38 @@ async function routeGovernedCall({
         governanceType,
       };
     case Owner.DEPLOYER:
-      return {
-        status: 'manual',
-        detail:
-          'owned by deployer; script does not execute deployer-key governed calls',
-        ownerType,
-        governanceType,
-      };
+      if (!propose) {
+        return {
+          status: 'manual',
+          detail:
+            'owned by deployer; pass --propose to execute directly with deployer key',
+          ownerType,
+          governanceType,
+        };
+      }
+      try {
+        rootLogger.info(
+          `[${chain}] executing deployer-key upgrade: ${call.description}`,
+        );
+        await multiProvider.sendTransaction(chain, {
+          to: call.to,
+          data: call.data,
+          value: call.value,
+        });
+        return {
+          status: 'executed',
+          detail: `executed deployer-key upgrade: ${call.description}`,
+          ownerType,
+          governanceType,
+        };
+      } catch (error) {
+        return {
+          status: 'manual',
+          detail: `deployer-key upgrade failed: ${error instanceof Error ? error.message : String(error)}`,
+          ownerType,
+          governanceType,
+        };
+      }
     default:
       return {
         status: 'manual',
@@ -1299,13 +1334,13 @@ async function main() {
           proxyAdminOwner,
         );
         const legacyIcaOwner = getLegacyGovernanceIcas(governanceType)[chain];
-        if (
-          ownerType === Owner.DEPLOYER ||
+        const isUnroutable =
           ownerType === Owner.UNKNOWN ||
           (ownerType === Owner.ICA &&
             legacyIcaOwner &&
-            eqAddress(legacyIcaOwner, proxyAdminOwner))
-        ) {
+            eqAddress(legacyIcaOwner, proxyAdminOwner)) ||
+          (ownerType === Owner.DEPLOYER && !propose);
+        if (isUnroutable) {
           plans.push({
             chain,
             interchainGasPaymaster,
@@ -1320,7 +1355,9 @@ async function main() {
             detail:
               ownerType === Owner.ICA
                 ? 'ProxyAdmin is owned by a legacy V1 ICA; script only builds V2 ICA calls'
-                : `ProxyAdmin owner ${proxyAdminOwner} is not routeable`,
+                : ownerType === Owner.DEPLOYER
+                  ? 'owned by deployer; pass --propose to execute directly with deployer key'
+                  : `ProxyAdmin owner ${proxyAdminOwner} is not routeable`,
           });
           return;
         }
@@ -1398,6 +1435,8 @@ async function main() {
             type: 'proxyAdminUpgrade',
             proxyAddress: interchainGasPaymaster,
           },
+          propose,
+          multiProvider,
         });
         const status = route.status === 'done' ? 'skipped' : route.status;
         ownerType = route.ownerType;
@@ -1531,9 +1570,13 @@ async function main() {
     .filter(
       (plan) =>
         !!plan.targetImplementation &&
-        ['queued', 'timelock queued', 'scheduled', 'skipped'].includes(
-          plan.status,
-        ),
+        [
+          'queued',
+          'timelock queued',
+          'scheduled',
+          'skipped',
+          'executed',
+        ].includes(plan.status),
     )
     .map((plan) => plan.chain);
   if (upgradeChains.length > 0) {

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -26,6 +26,10 @@ import {
   proxyImplementation,
 } from '@hyperlane-xyz/sdk';
 import {
+  isMissingSelectorCallException,
+  isValidContractVersion,
+} from '@hyperlane-xyz/sdk/utils/contract';
+import {
   Address,
   assert,
   deepCopy,
@@ -35,7 +39,6 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 import { BigNumber, ethers } from 'ethers';
-import { compareVersions } from 'compare-versions';
 
 import { Contexts } from '../../config/contexts.js';
 import {
@@ -48,6 +51,7 @@ import { getEnvAddresses } from '../../config/registry.js';
 import { chainsToSkip, legacyIgpChains } from '../../src/config/chain.js';
 import { determineGovernanceType, Owner } from '../../src/governance.js';
 import { GovernanceType } from '../../src/governanceTypes.js';
+import { GOVERNOR_MAX_BATCH_SIZE } from '../../src/govern/HyperlaneAppGovernor.js';
 import { SafeMultiSend } from '../../src/govern/multisend.js';
 import { Role } from '../../src/roles.js';
 import { logTable } from '../../src/utils/log.js';
@@ -64,7 +68,8 @@ import { getEnvironmentConfig } from '../core-utils.js';
 const ETHEREUM_CHAIN: ChainName = 'ethereum';
 const OUTPUT_ROOT = 'igp-upgrade-output';
 const CANCUN_PROBE_INIT_CODE = '0x5f5f5d5f5c5f5260205ff3';
-const MAX_SAFE_BATCH_SIZE = 120;
+const TIMELOCK_LOOKBACK_BLOCKS = 2_000_000;
+const TIMELOCK_LOG_CHUNK_BLOCKS = 50_000;
 
 type UpgradeCall = {
   to: Address;
@@ -188,29 +193,8 @@ function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function getNestedRecord(
-  value: Record<string, unknown>,
-  key: string,
-): Record<string, unknown> | undefined {
-  return isRecord(value[key]) ? value[key] : undefined;
-}
-
 export function isMissingPackageVersionError(error: unknown): boolean {
-  if (!isRecord(error)) return false;
-
-  const nestedError = getNestedRecord(error, 'error');
-  const data = typeof error.data === 'string' ? error.data : nestedError?.data;
-  if (error.code === 'CALL_EXCEPTION' && data === '0x') return true;
-
-  return (
-    error.code === 'CALL_EXCEPTION' &&
-    typeof error.message === 'string' &&
-    error.message.includes('data="0x"')
-  );
+  return isMissingSelectorCallException(error);
 }
 
 async function getCurrentVersion(
@@ -233,20 +217,11 @@ async function getCurrentVersion(
 }
 
 function isVersionAtLeastTarget({
-  chain,
   currentVersion,
 }: {
-  chain: ChainName;
   currentVersion: string;
 }): boolean {
-  try {
-    return compareVersions(currentVersion, CONTRACTS_PACKAGE_VERSION) >= 0;
-  } catch (error) {
-    throw new Error(
-      `[${chain}] current PACKAGE_VERSION ${currentVersion} is not valid semver`,
-      { cause: error },
-    );
-  }
+  return isValidContractVersion(currentVersion, CONTRACTS_PACKAGE_VERSION);
 }
 
 async function assertProxyAdmin({
@@ -309,12 +284,123 @@ async function assertCancunCompatible(
   }
 }
 
-function timelockSalt(chain: ChainName, callData: string): string {
+type TimelockOperationMatch = {
+  id: string;
+  status: 'scheduled' | 'done';
+};
+
+type TimelockIdempotency = {
+  type: 'proxyAdminUpgrade';
+  proxyAddress: Address;
+};
+
+function timelockSalt(chain: ChainName, description: string): string {
   return ethers.utils.keccak256(
     ethers.utils.toUtf8Bytes(
-      `hyperlane-igp-upgrade:${chain}:${CONTRACTS_PACKAGE_VERSION}:${callData}`,
+      `hyperlane-igp-upgrade:${chain}:${CONTRACTS_PACKAGE_VERSION}:${description}`,
     ),
   );
+}
+
+export function callMatchesTimelockIdempotency({
+  call,
+  scheduledTarget,
+  scheduledValue,
+  scheduledData,
+  idempotency,
+}: {
+  call: UpgradeCall;
+  scheduledTarget: Address;
+  scheduledValue: BigNumber;
+  scheduledData: string;
+  idempotency?: TimelockIdempotency;
+}): boolean {
+  if (!eqAddress(scheduledTarget, call.to)) return false;
+  if (!scheduledValue.eq(call.value)) return false;
+
+  if (!idempotency) {
+    return scheduledData === call.data;
+  }
+
+  if (idempotency.type === 'proxyAdminUpgrade') {
+    return (
+      getUpgradeTargetImplementation({
+        tx: {
+          to: scheduledTarget,
+          data: scheduledData,
+        },
+        proxyAdminAddress: call.to,
+        proxyAddress: idempotency.proxyAddress,
+      }) !== undefined
+    );
+  }
+
+  return false;
+}
+
+async function getExistingTimelockOperation({
+  provider,
+  timelock,
+  call,
+  idempotency,
+  currentOperationId,
+}: {
+  provider: ethers.providers.Provider;
+  timelock: ReturnType<typeof TimelockController__factory.connect>;
+  call: UpgradeCall;
+  idempotency?: TimelockIdempotency;
+  currentOperationId: string;
+}): Promise<TimelockOperationMatch | undefined> {
+  if (await timelock.isOperationDone(currentOperationId)) {
+    return { id: currentOperationId, status: 'done' };
+  }
+  if (
+    (await timelock.isOperationPending(currentOperationId)) ||
+    (await timelock.isOperationReady(currentOperationId))
+  ) {
+    return { id: currentOperationId, status: 'scheduled' };
+  }
+  if (!idempotency) return undefined;
+
+  const latestBlock = await provider.getBlockNumber();
+  const fromBlock = Math.max(0, latestBlock - TIMELOCK_LOOKBACK_BLOCKS);
+  const eventFilter = timelock.filters.CallScheduled();
+  for (
+    let startBlock = fromBlock;
+    startBlock <= latestBlock;
+    startBlock += TIMELOCK_LOG_CHUNK_BLOCKS + 1
+  ) {
+    const endBlock = Math.min(
+      latestBlock,
+      startBlock + TIMELOCK_LOG_CHUNK_BLOCKS,
+    );
+    const logs = await timelock.queryFilter(eventFilter, startBlock, endBlock);
+    for (const log of logs) {
+      const { id, target, value, data } = log.args;
+      if (
+        !callMatchesTimelockIdempotency({
+          call,
+          scheduledTarget: target,
+          scheduledValue: value,
+          scheduledData: data,
+          idempotency,
+        })
+      ) {
+        continue;
+      }
+      if (await timelock.isOperationDone(id)) {
+        return { id, status: 'done' };
+      }
+      if (
+        (await timelock.isOperationPending(id)) ||
+        (await timelock.isOperationReady(id))
+      ) {
+        return { id, status: 'scheduled' };
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function getSafeGroupKey(chain: ChainName, governanceType: GovernanceType) {
@@ -325,18 +411,18 @@ function splitSafeCallGroups(groups: SafeCallGroup[]): SafeCallGroup[] {
   const splitGroups: SafeCallGroup[] = [];
 
   for (const group of groups) {
-    if (group.calls.length <= MAX_SAFE_BATCH_SIZE) {
+    if (group.calls.length <= GOVERNOR_MAX_BATCH_SIZE) {
       splitGroups.push(group);
       continue;
     }
 
-    const batchCount = Math.ceil(group.calls.length / MAX_SAFE_BATCH_SIZE);
+    const batchCount = Math.ceil(group.calls.length / GOVERNOR_MAX_BATCH_SIZE);
     for (let batchIndex = 0; batchIndex < batchCount; batchIndex++) {
       splitGroups.push({
         ...group,
         calls: group.calls.slice(
-          batchIndex * MAX_SAFE_BATCH_SIZE,
-          (batchIndex + 1) * MAX_SAFE_BATCH_SIZE,
+          batchIndex * GOVERNOR_MAX_BATCH_SIZE,
+          (batchIndex + 1) * GOVERNOR_MAX_BATCH_SIZE,
         ),
         batchIndex: batchIndex + 1,
         batchCount,
@@ -514,12 +600,14 @@ async function routeGovernedCall({
   chain,
   call,
   ownerAddress,
+  timelockIdempotency,
 }: {
   groups: Map<string, SafeCallGroup>;
   ica: InterchainAccount;
   chain: ChainName;
   call: UpgradeCall;
   ownerAddress: Address;
+  timelockIdempotency?: TimelockIdempotency;
 }): Promise<{
   status: 'queued' | 'timelock queued' | 'scheduled' | 'done' | 'manual';
   detail: string;
@@ -573,6 +661,7 @@ async function routeGovernedCall({
           governanceType,
           timelockAddress: ownerAddress,
           innerCall: call,
+          idempotency: timelockIdempotency,
         })),
         ownerType,
         governanceType,
@@ -678,6 +767,7 @@ async function routeTimelockCall({
   governanceType,
   timelockAddress,
   innerCall,
+  idempotency,
 }: {
   groups: Map<string, SafeCallGroup>;
   ica: InterchainAccount;
@@ -685,6 +775,7 @@ async function routeTimelockCall({
   governanceType: GovernanceType;
   timelockAddress: Address;
   innerCall: UpgradeCall;
+  idempotency?: TimelockIdempotency;
 }): Promise<{
   status: 'timelock queued' | 'scheduled' | 'done';
   detail: string;
@@ -695,7 +786,7 @@ async function routeTimelockCall({
     provider,
   );
   const delay = await timelock.getMinDelay();
-  const salt = timelockSalt(chain, innerCall.data);
+  const salt = timelockSalt(chain, innerCall.description);
   const predecessor = ethers.constants.HashZero;
   const targets = [innerCall.to];
   const values = [innerCall.value];
@@ -708,21 +799,23 @@ async function routeTimelockCall({
     salt,
   );
 
-  const isDone = await timelock.isOperationDone(operationId);
-  if (isDone) {
+  const existingOperation = await getExistingTimelockOperation({
+    provider,
+    timelock,
+    call: innerCall,
+    idempotency,
+    currentOperationId: operationId,
+  });
+  if (existingOperation?.status === 'done') {
     return {
       status: 'done',
-      detail: `timelock operation already executed but proxy still points at the old implementation: ${operationId}`,
+      detail: `timelock operation already executed: ${existingOperation.id}`,
     };
   }
-
-  const isScheduled =
-    (await timelock.isOperationPending(operationId)) ||
-    (await timelock.isOperationReady(operationId));
-  if (isScheduled) {
+  if (existingOperation?.status === 'scheduled') {
     return {
       status: 'scheduled',
-      detail: `timelock operation already scheduled/done: ${operationId}`,
+      detail: `timelock operation already scheduled: ${existingOperation.id}`,
     };
   }
 
@@ -1094,7 +1187,6 @@ async function main() {
       const implementationUpgradeRequired =
         !currentVersion ||
         !isVersionAtLeastTarget({
-          chain,
           currentVersion,
         });
       if (implementationUpgradeRequired) {
@@ -1105,7 +1197,7 @@ async function main() {
         const legacyIcaOwner = getLegacyGovernanceIcas(governanceType)[chain];
         if (
           ownerType === Owner.DEPLOYER ||
-          !ownerType ||
+          ownerType === Owner.UNKNOWN ||
           (ownerType === Owner.ICA &&
             legacyIcaOwner &&
             eqAddress(legacyIcaOwner, proxyAdminOwner))
@@ -1182,6 +1274,11 @@ async function main() {
       let status = 'queued';
       let ownerType: Owner | null | undefined;
       let governanceType: GovernanceType | undefined;
+      let routedTransactionCount = 0;
+      let manualTransactionCount = 0;
+      let doneTransactionCount = 0;
+      let hasTimelockQueued = false;
+      let hasScheduled = false;
 
       if (upgradeIndex >= 0) {
         const upgradeCall = toUpgradeCall(
@@ -1194,11 +1291,18 @@ async function main() {
           chain,
           call: upgradeCall,
           ownerAddress: proxyAdminOwner,
+          timelockIdempotency: {
+            type: 'proxyAdminUpgrade',
+            proxyAddress: interchainGasPaymaster,
+          },
         });
         status = route.status === 'done' ? 'error' : route.status;
         ownerType = route.ownerType;
         governanceType = route.governanceType;
         routeDetails.push(route.detail);
+        if (route.status !== 'done') {
+          routedTransactionCount += 1;
+        }
 
         if (
           route.status === 'timelock queued' ||
@@ -1216,7 +1320,7 @@ async function main() {
             proxyAdminOwner,
             ownerType,
             governanceType,
-            transactionCount: 1,
+            transactionCount: routedTransactionCount,
             status,
             detail:
               route.status === 'done'
@@ -1239,7 +1343,7 @@ async function main() {
             proxyAdminOwner,
             ownerType,
             governanceType,
-            transactionCount: 1,
+            transactionCount: routedTransactionCount,
             status,
             detail: route.detail,
             ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
@@ -1272,16 +1376,28 @@ async function main() {
         ownerType ??= route.ownerType;
         governanceType ??= route.governanceType;
         routeDetails.push(route.detail);
-        if (route.status === 'manual' || route.status === 'done') {
-          status = route.status === 'done' ? 'error' : route.status;
-          break;
+        if (route.status === 'manual') {
+          manualTransactionCount += 1;
+          continue;
         }
-        if (
-          route.status === 'timelock queued' ||
-          route.status === 'scheduled'
-        ) {
-          status = route.status;
+        if (route.status === 'done') {
+          doneTransactionCount += 1;
+          continue;
         }
+
+        routedTransactionCount += 1;
+        hasTimelockQueued ||= route.status === 'timelock queued';
+        hasScheduled ||= route.status === 'scheduled';
+      }
+
+      if (manualTransactionCount > 0) {
+        status = routedTransactionCount > 0 ? 'partial' : 'manual';
+      } else if (hasTimelockQueued) {
+        status = 'timelock queued';
+      } else if (hasScheduled) {
+        status = 'scheduled';
+      } else if (routedTransactionCount === 0 && doneTransactionCount > 0) {
+        status = 'skipped';
       }
 
       plans.push({
@@ -1295,7 +1411,7 @@ async function main() {
         proxyAdminOwner,
         ownerType,
         governanceType,
-        transactionCount: transactions.length,
+        transactionCount: routedTransactionCount,
         status,
         detail: routeDetails.join('; '),
         ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -32,6 +32,7 @@ import {
 import {
   Address,
   assert,
+  concurrentMap,
   deepCopy,
   eqAddress,
   formatStandardHookMetadata,
@@ -624,46 +625,6 @@ export function getUpgradeTargetImplementation({
   return undefined;
 }
 
-export function getDeferredTimelockConfigChains(
-  plans: Pick<ChainPlan, 'chain' | 'status' | 'detail'>[],
-): ChainName[] {
-  return plans
-    .filter(
-      (plan) =>
-        (plan.status === 'timelock queued' || plan.status === 'scheduled') &&
-        plan.detail.includes('config tx(s) deferred'),
-    )
-    .map((plan) => plan.chain);
-}
-
-async function getGovernedCallOwner({
-  chain,
-  provider,
-  call,
-  proxyAdminAddress,
-  proxyAddress,
-  currentImplementation,
-}: {
-  chain: ChainName;
-  provider: ethers.providers.Provider;
-  call: UpgradeCall;
-  proxyAdminAddress: Address;
-  proxyAddress: Address;
-  currentImplementation: Address;
-}): Promise<Address> {
-  if (eqAddress(call.to, proxyAdminAddress)) {
-    return assertProxyAdmin({
-      chain,
-      provider,
-      proxyAdminAddress,
-      proxyAddress,
-      expectedImplementation: currentImplementation,
-    });
-  }
-
-  return Ownable__factory.connect(call.to, provider).owner();
-}
-
 async function routeGovernedCall({
   groups,
   icaGroups,
@@ -1176,6 +1137,7 @@ async function main() {
     propose,
     all,
     skipEvmPreflight,
+    concurrency: chainConcurrency,
   } = await withOutputFile(
     withChains(
       withContext(
@@ -1191,6 +1153,11 @@ async function main() {
               type: 'boolean',
               default: false,
               describe: 'Skip Cancun/PUSH0 eth_call preflight',
+            })
+            .option('concurrency', {
+              type: 'number',
+              default: 8,
+              describe: 'Number of chains to plan concurrently',
             }),
         ),
       ),
@@ -1209,6 +1176,7 @@ async function main() {
     !skipEvmPreflight,
     'mainnet3 IGP upgrades require the Cancun/PUSH0 preflight; remove --skipEvmPreflight.',
   );
+  assert(chainConcurrency > 0, '--concurrency must be greater than 0');
 
   const envConfig = getEnvironmentConfig(environment);
   const supportedChains = new Set(envConfig.supportedChainNames);
@@ -1263,8 +1231,11 @@ async function main() {
   const safeGroups = new Map<string, SafeCallGroup>();
   const icaGroups = new Map<string, IcaCallGroup>();
   const plans: ChainPlan[] = [];
+  const targetChainIndexes = new Map(
+    targetChains.map((chain, index) => [chain, index]),
+  );
 
-  for (const chain of targetChains) {
+  await concurrentMap(chainConcurrency, targetChains, async (chain) => {
     const metadata = multiProvider.getChainMetadata(chain);
     if (!isEVMLike(metadata.protocol)) {
       plans.push({
@@ -1273,7 +1244,7 @@ async function main() {
         status: 'skipped',
         detail: `non-EVM protocol ${metadata.protocol}`,
       });
-      continue;
+      return;
     }
 
     const addresses = chainAddresses[chain];
@@ -1285,7 +1256,7 @@ async function main() {
         status: 'skipped',
         detail: 'missing interchainGasPaymaster in registry',
       });
-      continue;
+      return;
     }
 
     const provider = multiProvider.getProvider(chain);
@@ -1351,13 +1322,15 @@ async function main() {
                 ? 'ProxyAdmin is owned by a legacy V1 ICA; script only builds V2 ICA calls'
                 : `ProxyAdmin owner ${proxyAdminOwner} is not routeable`,
           });
-          continue;
+          return;
         }
       }
 
       const deploymentsBefore =
         multiProvider instanceof DryRunDeployMultiProvider
-          ? multiProvider.simulatedDeployments.length
+          ? multiProvider.simulatedDeployments.filter(
+              (deployment) => deployment.chain === chain,
+            ).length
           : 0;
       const transactions = await buildHookUpdateTransactions({
         chain,
@@ -1367,7 +1340,9 @@ async function main() {
       });
       const simulatedDeployments =
         multiProvider instanceof DryRunDeployMultiProvider
-          ? multiProvider.simulatedDeployments.slice(deploymentsBefore)
+          ? multiProvider.simulatedDeployments
+              .filter((deployment) => deployment.chain === chain)
+              .slice(deploymentsBefore)
           : undefined;
 
       if (transactions.length === 0) {
@@ -1383,7 +1358,7 @@ async function main() {
           detail: 'hook module produced no update transactions',
           ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
         });
-        continue;
+        return;
       }
 
       const upgradeIndex = transactions.findIndex(
@@ -1403,15 +1378,9 @@ async function main() {
             })
           : undefined;
 
-      const routeDetails: string[] = [];
-      let status = 'queued';
       let ownerType: Owner | null | undefined;
       let governanceType: GovernanceType | undefined;
       let routedTransactionCount = 0;
-      let manualTransactionCount = 0;
-      let doneTransactionCount = 0;
-      let hasTimelockQueued = false;
-      let hasScheduled = false;
 
       if (upgradeIndex >= 0) {
         const upgradeCall = toUpgradeCall(
@@ -1430,109 +1399,37 @@ async function main() {
             proxyAddress: interchainGasPaymaster,
           },
         });
-        status = route.status === 'done' ? 'skipped' : route.status;
+        const status = route.status === 'done' ? 'skipped' : route.status;
         ownerType = route.ownerType;
         governanceType = route.governanceType;
-        routeDetails.push(route.detail);
-        if (route.status !== 'done') {
+        if (route.status === 'queued' || route.status === 'timelock queued') {
           routedTransactionCount += 1;
         }
-
-        if (
-          route.status === 'timelock queued' ||
-          route.status === 'scheduled' ||
-          route.status === 'done'
-        ) {
-          plans.push({
-            chain,
-            interchainGasPaymaster,
-            currentImplementation,
-            targetImplementation,
-            currentVersion,
-            targetVersion: CONTRACTS_PACKAGE_VERSION,
-            proxyAdmin: actualProxyAdmin,
-            proxyAdminOwner,
-            ownerType,
-            governanceType,
-            transactionCount: routedTransactionCount,
-            status,
-            detail:
-              route.status === 'done'
-                ? `${route.detail}; upgrade already executed`
-                : `${route.detail}; ${transactions.length - 1} config tx(s) deferred until the timelock upgrade executes`,
-            ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
-          });
-          continue;
-        }
-
-        if (route.status === 'manual') {
-          plans.push({
-            chain,
-            interchainGasPaymaster,
-            currentImplementation,
-            targetImplementation,
-            currentVersion,
-            targetVersion: CONTRACTS_PACKAGE_VERSION,
-            proxyAdmin: actualProxyAdmin,
-            proxyAdminOwner,
-            ownerType,
-            governanceType,
-            transactionCount: routedTransactionCount,
-            status,
-            detail: route.detail,
-            ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
-          });
-          continue;
-        }
-      }
-
-      for (const [index, transaction] of transactions.entries()) {
-        if (index === upgradeIndex) continue;
-        const call = toUpgradeCall(
-          transaction,
-          `IGP update tx ${index + 1} for ${chain}`,
-        );
-        const ownerAddress = await getGovernedCallOwner({
+        const configTxCount = transactions.length - 1;
+        plans.push({
           chain,
-          provider,
-          call,
-          proxyAdminAddress: actualProxyAdmin,
-          proxyAddress: interchainGasPaymaster,
+          interchainGasPaymaster,
           currentImplementation,
+          targetImplementation,
+          currentVersion,
+          targetVersion: CONTRACTS_PACKAGE_VERSION,
+          proxyAdmin: actualProxyAdmin,
+          proxyAdminOwner,
+          ownerType,
+          governanceType,
+          transactionCount: routedTransactionCount,
+          status,
+          detail: [
+            route.status === 'done'
+              ? `${route.detail}; upgrade already executed`
+              : route.detail,
+            configTxCount > 0
+              ? `${configTxCount} hook-module config tx(s) intentionally not proposed; run deploy.ts -m igp after upgrade execution`
+              : 'run deploy.ts -m igp after upgrade execution to apply/confirm config',
+          ].join('; '),
+          ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
         });
-        const route = await routeGovernedCall({
-          groups: safeGroups,
-          icaGroups,
-          ica,
-          chain,
-          call,
-          ownerAddress,
-        });
-        ownerType ??= route.ownerType;
-        governanceType ??= route.governanceType;
-        routeDetails.push(route.detail);
-        if (route.status === 'manual') {
-          manualTransactionCount += 1;
-          continue;
-        }
-        if (route.status === 'done') {
-          doneTransactionCount += 1;
-          continue;
-        }
-
-        routedTransactionCount += 1;
-        hasTimelockQueued ||= route.status === 'timelock queued';
-        hasScheduled ||= route.status === 'scheduled';
-      }
-
-      if (manualTransactionCount > 0) {
-        status = routedTransactionCount > 0 ? 'partial' : 'manual';
-      } else if (hasTimelockQueued) {
-        status = 'timelock queued';
-      } else if (hasScheduled) {
-        status = 'scheduled';
-      } else if (routedTransactionCount === 0 && doneTransactionCount > 0) {
-        status = 'skipped';
+        return;
       }
 
       plans.push({
@@ -1546,9 +1443,9 @@ async function main() {
         proxyAdminOwner,
         ownerType,
         governanceType,
-        transactionCount: routedTransactionCount,
-        status,
-        detail: routeDetails.join('; '),
+        transactionCount: 0,
+        status: 'no upgrade',
+        detail: `${transactions.length} hook-module config tx(s) intentionally not proposed; run deploy.ts -m igp to apply config`,
         ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
       });
     } catch (error) {
@@ -1560,7 +1457,12 @@ async function main() {
         detail: formatError(error),
       });
     }
-  }
+  });
+  plans.sort(
+    (a, b) =>
+      (targetChainIndexes.get(a.chain) ?? Number.MAX_SAFE_INTEGER) -
+      (targetChainIndexes.get(b.chain) ?? Number.MAX_SAFE_INTEGER),
+  );
 
   await flushIcaCallGroups({
     safeGroups,
@@ -1625,12 +1527,20 @@ async function main() {
   if (!propose) {
     rootLogger.info(`Dry run: Safe batch files written under ${runDir}`);
   }
-  const deferredTimelockChains = getDeferredTimelockConfigChains(plans);
-  if (deferredTimelockChains.length > 0) {
+  const upgradeChains = plans
+    .filter(
+      (plan) =>
+        !!plan.targetImplementation &&
+        ['queued', 'timelock queued', 'scheduled', 'skipped'].includes(
+          plan.status,
+        ),
+    )
+    .map((plan) => plan.chain);
+  if (upgradeChains.length > 0) {
     rootLogger.warn(
       [
-        `Config txs were deferred for timelock-owned upgrade chain(s): ${deferredTimelockChains.join(', ')}`,
-        'Execute the timelock upgrade first, then rerun this script for those chains to propose the hook-module config txs.',
+        `Upgrade-only mode: apply IGP config after upgrade execution for chain(s): ${upgradeChains.join(', ')}`,
+        `pnpm -C typescript/infra exec tsx scripts/deploy.ts -e ${environment} -x ${context} -m igp --chains ${upgradeChains.join(' ')}`,
       ].join('\n'),
     );
   }

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -1,0 +1,767 @@
+import { mkdirSync } from 'fs';
+import { basename, dirname, join } from 'path';
+import yargs from 'yargs';
+
+import {
+  CONTRACTS_PACKAGE_VERSION,
+  Ownable__factory,
+  PackageVersioned__factory,
+  ProxyAdmin__factory,
+  TimelockController__factory,
+} from '@hyperlane-xyz/core';
+import {
+  AnnotatedEV5Transaction,
+  ChainMap,
+  ChainName,
+  EV5GnosisSafeTxBuilder,
+  InterchainAccount,
+  PROPOSER_ROLE,
+  proxyAdmin,
+  proxyImplementation,
+} from '@hyperlane-xyz/sdk';
+import {
+  Address,
+  assert,
+  bytes32ToAddress,
+  eqAddress,
+  formatStandardHookMetadata,
+  isEVMLike,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
+import { readJson } from '@hyperlane-xyz/utils/fs';
+import { BigNumber, ethers } from 'ethers';
+
+import { Contexts } from '../../config/contexts.js';
+import {
+  getGovernanceIcas,
+  getGovernanceSafes,
+  getGovernanceTimelocks,
+} from '../../config/environments/mainnet3/governance/utils.js';
+import { getEnvAddresses } from '../../config/registry.js';
+import {
+  legacyEthIcaRouter,
+  legacyIcaChainRouters,
+  legacyIgpChains,
+} from '../../src/config/chain.js';
+import { determineGovernanceType, Owner } from '../../src/governance.js';
+import { GovernanceType } from '../../src/governanceTypes.js';
+import { SafeMultiSend } from '../../src/govern/multisend.js';
+import { logTable } from '../../src/utils/log.js';
+import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
+import {
+  getArgs,
+  withChains,
+  withContext,
+  withOutputFile,
+  withPropose,
+} from '../agent-utils.js';
+import { getEnvironmentConfig } from '../core-utils.js';
+
+const ETHEREUM_CHAIN: ChainName = 'ethereum';
+const OUTPUT_ROOT = 'igp-upgrade-output';
+const CANCUN_PROBE_INIT_CODE = '0x5f5f5d5f5c5f5260205ff3';
+
+type UpgradeCall = {
+  to: Address;
+  data: string;
+  value: BigNumber;
+  description: string;
+};
+
+type ChainPlan = {
+  chain: ChainName;
+  interchainGasPaymaster?: Address;
+  currentImplementation?: Address;
+  targetImplementation?: Address;
+  currentVersion?: string;
+  targetVersion: string;
+  proxyAdmin?: Address;
+  proxyAdminOwner?: Address;
+  ownerType?: Owner | null;
+  governanceType?: GovernanceType;
+  status: string;
+  detail: string;
+};
+
+type SafeCallGroup = {
+  chain: ChainName;
+  governanceType: GovernanceType;
+  safeAddress: Address;
+  calls: UpgradeCall[];
+};
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function compareSemver(a: string, b: string): number {
+  const aParts = a.split('.').map((part) => parseInt(part, 10));
+  const bParts = b.split('.').map((part) => parseInt(part, 10));
+  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+    const aPart = aParts[i] ?? 0;
+    const bPart = bParts[i] ?? 0;
+    if (aPart !== bPart) return aPart > bPart ? 1 : -1;
+  }
+  return 0;
+}
+
+function getImplementationAddress(
+  chain: ChainName,
+  implementations: ChainMap<Address>,
+): Address | undefined {
+  return implementations[chain];
+}
+
+async function getCurrentVersion(
+  chain: ChainName,
+  provider: ethers.providers.Provider,
+  igpAddress: Address,
+): Promise<string | undefined> {
+  try {
+    return await PackageVersioned__factory.connect(
+      igpAddress,
+      provider,
+    ).PACKAGE_VERSION();
+  } catch (error) {
+    rootLogger.info(
+      `[${chain}] IGP does not expose PACKAGE_VERSION: ${formatError(error)}`,
+    );
+    return undefined;
+  }
+}
+
+async function assertCancunCompatible(
+  chain: ChainName,
+  provider: ethers.providers.Provider,
+) {
+  try {
+    const result = await provider.call({ data: CANCUN_PROBE_INIT_CODE });
+    assert(
+      result === ethers.constants.HashZero,
+      `[${chain}] Cancun probe returned unexpected data: ${result}`,
+    );
+  } catch (error) {
+    throw new Error(
+      `[${chain}] Cancun/PUSH0 preflight failed; keep this chain in legacyIgpChains or override only after manual verification`,
+      { cause: error },
+    );
+  }
+}
+
+function timelockSalt(chain: ChainName, callData: string): string {
+  return ethers.utils.keccak256(
+    ethers.utils.toUtf8Bytes(
+      `hyperlane-igp-upgrade:${chain}:${CONTRACTS_PACKAGE_VERSION}:${callData}`,
+    ),
+  );
+}
+
+function getSafeGroupKey(chain: ChainName, governanceType: GovernanceType) {
+  return `${chain}:${governanceType}`;
+}
+
+function addSafeCall(
+  groups: Map<string, SafeCallGroup>,
+  chain: ChainName,
+  governanceType: GovernanceType,
+  call: UpgradeCall,
+) {
+  const safeAddress = getGovernanceSafes(governanceType)[chain];
+  assert(
+    safeAddress,
+    `No ${governanceType} Safe configured on ${chain}; cannot propose ${call.description}`,
+  );
+
+  const key = getSafeGroupKey(chain, governanceType);
+  const existing = groups.get(key);
+  if (existing) {
+    existing.calls.push(call);
+    return;
+  }
+
+  groups.set(key, {
+    chain,
+    governanceType,
+    safeAddress,
+    calls: [call],
+  });
+}
+
+async function addIcaSafeCall({
+  groups,
+  ica,
+  destination,
+  governanceType,
+  innerCall,
+  expectedRemoteOwner,
+}: {
+  groups: Map<string, SafeCallGroup>;
+  ica: InterchainAccount;
+  destination: ChainName;
+  governanceType: GovernanceType;
+  innerCall: UpgradeCall;
+  expectedRemoteOwner?: Address;
+}) {
+  const safes = getGovernanceSafes(governanceType);
+  const owner = safes[ETHEREUM_CHAIN];
+  assert(
+    owner,
+    `No ${governanceType} Safe configured on ${ETHEREUM_CHAIN}; cannot propose ICA call for ${destination}`,
+  );
+
+  const accountConfig = {
+    origin: ETHEREUM_CHAIN,
+    owner,
+    ...(legacyIcaChainRouters[destination]
+      ? {
+          localRouter: legacyEthIcaRouter,
+          routerOverride:
+            legacyIcaChainRouters[destination].interchainAccountRouter,
+        }
+      : {}),
+  };
+  const expectedIca = await ica.getAccount(destination, accountConfig);
+  const ownerAddress =
+    expectedRemoteOwner ??
+    (await Ownable__factory.connect(
+      innerCall.to,
+      ica.multiProvider.getProvider(destination),
+    ).owner());
+  assert(
+    eqAddress(expectedIca, ownerAddress),
+    `[${destination}] expected ${governanceType} ICA ${expectedIca}, but ${innerCall.to} owner is ${ownerAddress}`,
+  );
+
+  const innerCalls = [
+    {
+      to: innerCall.to,
+      data: innerCall.data,
+      value: innerCall.value.toString(),
+    },
+  ];
+  const gasLimit = await ica.estimateIcaHandleGas({
+    origin: ETHEREUM_CHAIN,
+    destination,
+    innerCalls,
+    config: accountConfig,
+  });
+  const refundAddress = bytes32ToAddress(accountConfig.owner);
+  const hookMetadata = formatStandardHookMetadata({
+    gasLimit: gasLimit.toBigInt(),
+    refundAddress,
+  });
+  const callRemote = await ica.getCallRemote({
+    chain: ETHEREUM_CHAIN,
+    destination,
+    innerCalls,
+    config: accountConfig,
+    hookMetadata,
+  });
+
+  assert(
+    callRemote.to && callRemote.data,
+    `[${destination}] could not build ICA callRemote transaction`,
+  );
+
+  addSafeCall(groups, ETHEREUM_CHAIN, governanceType, {
+    to: callRemote.to,
+    data: callRemote.data,
+    value: callRemote.value ?? BigNumber.from(0),
+    description: `ICA ${destination}: ${innerCall.description}`,
+  });
+}
+
+async function routeTimelockCall({
+  groups,
+  ica,
+  chain,
+  governanceType,
+  timelockAddress,
+  innerCall,
+}: {
+  groups: Map<string, SafeCallGroup>;
+  ica: InterchainAccount;
+  chain: ChainName;
+  governanceType: GovernanceType;
+  timelockAddress: Address;
+  innerCall: UpgradeCall;
+}): Promise<string> {
+  const provider = ica.multiProvider.getProvider(chain);
+  const timelock = TimelockController__factory.connect(
+    timelockAddress,
+    provider,
+  );
+  const delay = await timelock.getMinDelay();
+  const salt = timelockSalt(chain, innerCall.data);
+  const predecessor = ethers.constants.HashZero;
+  const targets = [innerCall.to];
+  const values = [innerCall.value];
+  const payloads = [innerCall.data];
+  const operationId = await timelock.hashOperationBatch(
+    targets,
+    values,
+    payloads,
+    predecessor,
+    salt,
+  );
+
+  const isScheduled =
+    (await timelock.isOperationPending(operationId)) ||
+    (await timelock.isOperationReady(operationId)) ||
+    (await timelock.isOperationDone(operationId));
+  if (isScheduled) {
+    return `timelock operation already scheduled/done: ${operationId}`;
+  }
+
+  const scheduleCall: UpgradeCall = {
+    to: timelockAddress,
+    data: timelock.interface.encodeFunctionData('scheduleBatch', [
+      targets,
+      values,
+      payloads,
+      predecessor,
+      salt,
+      delay,
+    ]),
+    value: BigNumber.from(0),
+    description: `Schedule timelock operation ${operationId}: ${innerCall.description}`,
+  };
+
+  const proposer =
+    chain === ETHEREUM_CHAIN
+      ? getGovernanceSafes(governanceType)[ETHEREUM_CHAIN]
+      : getGovernanceIcaAddress(chain, governanceType);
+  assert(
+    proposer,
+    `[${chain}] no ${governanceType} proposer address available for timelock ${timelockAddress}`,
+  );
+  assert(
+    await timelock.hasRole(PROPOSER_ROLE, proposer),
+    `[${chain}] ${proposer} does not have PROPOSER_ROLE on timelock ${timelockAddress}`,
+  );
+
+  if (chain === ETHEREUM_CHAIN) {
+    addSafeCall(groups, ETHEREUM_CHAIN, governanceType, scheduleCall);
+  } else {
+    await addIcaSafeCall({
+      groups,
+      ica,
+      destination: chain,
+      governanceType,
+      innerCall: scheduleCall,
+      expectedRemoteOwner: proposer,
+    });
+  }
+
+  return `timelock operation queued for scheduling: ${operationId}`;
+}
+
+function getGovernanceIcaAddress(
+  chain: ChainName,
+  governanceType: GovernanceType,
+): Address | undefined {
+  return getGovernanceIcas(governanceType)[chain];
+}
+
+async function writeSafeBatchFiles({
+  groups,
+  multiProvider,
+  runDir,
+}: {
+  groups: SafeCallGroup[];
+  multiProvider: Parameters<typeof EV5GnosisSafeTxBuilder.create>[0];
+  runDir: string;
+}) {
+  for (const group of groups) {
+    let builder: EV5GnosisSafeTxBuilder;
+    try {
+      builder = await EV5GnosisSafeTxBuilder.create(multiProvider, {
+        version: '1.0',
+        chain: group.chain,
+        safeAddress: group.safeAddress,
+      });
+    } catch (error) {
+      const filepath = join(
+        runDir,
+        `${group.chain}-${group.governanceType}.raw.json`,
+      );
+      mkdirSync(dirname(filepath), { recursive: true });
+      await writeAndFormatJsonAtPath(filepath, {
+        chain: group.chain,
+        safeAddress: group.safeAddress,
+        governanceType: group.governanceType,
+        note: 'Raw calldata. NOT a Safe Transaction Builder file (no usable tx service for this chain); submit manually.',
+        error: formatError(error),
+        transactions: group.calls.map((call) => ({
+          to: call.to,
+          value: call.value.toString(),
+          data: call.data,
+          description: call.description,
+        })),
+      });
+      rootLogger.warn(
+        `[${group.chain}] wrote raw ${group.governanceType} payload ${basename(filepath)}`,
+      );
+      continue;
+    }
+
+    const chainId = multiProvider.getEvmChainId(group.chain);
+    const txs: AnnotatedEV5Transaction[] = group.calls.map((call) => ({
+      to: call.to,
+      data: call.data,
+      value: call.value,
+      chainId,
+    }));
+    const batch = await builder.submit(...txs);
+    const filepath = join(
+      runDir,
+      `${group.chain}-${group.governanceType}.json`,
+    );
+    mkdirSync(dirname(filepath), { recursive: true });
+    await writeAndFormatJsonAtPath(filepath, batch);
+    rootLogger.info(
+      `[${group.chain}] wrote ${group.governanceType} Safe batch ${filepath}`,
+    );
+  }
+}
+
+async function proposeSafeGroups({
+  groups,
+  multiProvider,
+}: {
+  groups: SafeCallGroup[];
+  multiProvider: Parameters<typeof SafeMultiSend.initialize>[0];
+}) {
+  for (const group of groups) {
+    const safeMultiSend = await SafeMultiSend.initialize(
+      multiProvider,
+      group.chain,
+      group.safeAddress,
+    );
+    const hashes = await safeMultiSend.sendTransactions(
+      group.calls.map((call) => ({
+        to: call.to,
+        data: call.data,
+        value: call.value,
+      })),
+    );
+    rootLogger.info(
+      `[${group.chain}] proposed ${group.calls.length} ${group.governanceType} tx(s): ${hashes.join(', ')}`,
+    );
+  }
+}
+
+async function main() {
+  const {
+    environment,
+    context = Contexts.Hyperlane,
+    chains,
+    outFile,
+    propose,
+    all,
+    implementationAddressesFile,
+    skipEvmPreflight,
+  } = await withOutputFile(
+    withChains(
+      withContext(
+        withPropose(
+          getArgs()
+            .option('implementationAddressesFile', {
+              type: 'string',
+              describe:
+                'JSON map of chain name to already deployed InterchainGasPaymaster implementation address',
+              demandOption: true,
+            })
+            .option('all', {
+              type: 'boolean',
+              default: false,
+              describe:
+                'Confirm proposing for every compatible chain when --chains is omitted',
+            })
+            .option('skipEvmPreflight', {
+              type: 'boolean',
+              default: false,
+              describe: 'Skip Cancun/PUSH0 eth_call preflight',
+            }),
+        ),
+      ),
+    ),
+  ).argv;
+
+  assert(
+    !propose || chains?.length || all,
+    'Refusing to propose for all compatible chains without --all. Pass --chains or --all.',
+  );
+
+  const implementationAddresses = readJson<ChainMap<Address>>(
+    implementationAddressesFile,
+  );
+  const envConfig = getEnvironmentConfig(environment);
+  const requested = chains && chains.length > 0 ? new Set(chains) : undefined;
+  const targetChains = envConfig.supportedChainNames.filter((chain) => {
+    if (requested && !requested.has(chain)) return false;
+    if (legacyIgpChains.includes(chain)) return false;
+    return true;
+  });
+
+  const multiProvider = await envConfig.getMultiProvider(
+    context,
+    undefined,
+    true,
+    targetChains,
+  );
+  const chainAddresses = getEnvAddresses(environment);
+  const icaAddresses = Object.fromEntries(
+    Object.entries(chainAddresses).filter(
+      ([, addresses]) => !!addresses.interchainAccountRouter,
+    ),
+  );
+  const ica = InterchainAccount.fromAddressesMap(icaAddresses, multiProvider);
+  const safeGroups = new Map<string, SafeCallGroup>();
+  const plans: ChainPlan[] = [];
+
+  for (const chain of targetChains) {
+    const metadata = multiProvider.getChainMetadata(chain);
+    if (!isEVMLike(metadata.protocol)) {
+      plans.push({
+        chain,
+        targetVersion: CONTRACTS_PACKAGE_VERSION,
+        status: 'skipped',
+        detail: `non-EVM protocol ${metadata.protocol}`,
+      });
+      continue;
+    }
+
+    const addresses = chainAddresses[chain];
+    const interchainGasPaymaster = addresses?.interchainGasPaymaster;
+    if (!interchainGasPaymaster) {
+      plans.push({
+        chain,
+        targetVersion: CONTRACTS_PACKAGE_VERSION,
+        status: 'skipped',
+        detail: 'missing interchainGasPaymaster in registry',
+      });
+      continue;
+    }
+
+    const provider = multiProvider.getProvider(chain);
+    const targetImplementation = getImplementationAddress(
+      chain,
+      implementationAddresses,
+    );
+    try {
+      if (!skipEvmPreflight) {
+        await assertCancunCompatible(chain, provider);
+      }
+
+      const currentImplementation = await proxyImplementation(
+        provider,
+        interchainGasPaymaster,
+      );
+      const currentVersion = await getCurrentVersion(
+        chain,
+        provider,
+        interchainGasPaymaster,
+      );
+      const actualProxyAdmin = await proxyAdmin(
+        provider,
+        interchainGasPaymaster,
+      );
+      if (
+        targetImplementation &&
+        eqAddress(currentImplementation, targetImplementation)
+      ) {
+        plans.push({
+          chain,
+          interchainGasPaymaster,
+          currentImplementation,
+          targetImplementation,
+          currentVersion,
+          targetVersion: CONTRACTS_PACKAGE_VERSION,
+          proxyAdmin: actualProxyAdmin,
+          status: 'no change',
+          detail: 'proxy already points at target implementation',
+        });
+        continue;
+      }
+
+      if (
+        currentVersion &&
+        compareSemver(currentVersion, CONTRACTS_PACKAGE_VERSION) >= 0
+      ) {
+        plans.push({
+          chain,
+          interchainGasPaymaster,
+          currentImplementation,
+          targetImplementation,
+          currentVersion,
+          targetVersion: CONTRACTS_PACKAGE_VERSION,
+          proxyAdmin: actualProxyAdmin,
+          status: 'skipped',
+          detail: 'current contract version is already >= target version',
+        });
+        continue;
+      }
+
+      if (!targetImplementation) {
+        plans.push({
+          chain,
+          interchainGasPaymaster,
+          currentImplementation,
+          currentVersion,
+          targetVersion: CONTRACTS_PACKAGE_VERSION,
+          proxyAdmin: actualProxyAdmin,
+          status: 'error',
+          detail: 'missing implementation address',
+        });
+        continue;
+      }
+
+      const proxyAdminOwner = await Ownable__factory.connect(
+        actualProxyAdmin,
+        provider,
+      ).owner();
+      const { ownerType, governanceType } = await determineGovernanceType(
+        chain,
+        proxyAdminOwner,
+      );
+      const upgradeCall: UpgradeCall = {
+        to: actualProxyAdmin,
+        data: ProxyAdmin__factory.createInterface().encodeFunctionData(
+          'upgrade',
+          [interchainGasPaymaster, targetImplementation],
+        ),
+        value: BigNumber.from(0),
+        description: `Upgrade IGP ${interchainGasPaymaster} to ${CONTRACTS_PACKAGE_VERSION} implementation ${targetImplementation}`,
+      };
+
+      let detail: string;
+      switch (ownerType) {
+        case Owner.SAFE:
+          addSafeCall(safeGroups, chain, governanceType, upgradeCall);
+          detail = `queued ${governanceType} Safe proposal`;
+          break;
+        case Owner.ICA:
+          await addIcaSafeCall({
+            groups: safeGroups,
+            ica,
+            destination: chain,
+            governanceType,
+            innerCall: upgradeCall,
+          });
+          detail = `queued ${governanceType} ICA proposal from ethereum`;
+          break;
+        case Owner.TIMELOCK:
+          detail = await routeTimelockCall({
+            groups: safeGroups,
+            ica,
+            chain,
+            governanceType,
+            timelockAddress: proxyAdminOwner,
+            innerCall: upgradeCall,
+          });
+          break;
+        case Owner.DEPLOYER:
+          plans.push({
+            chain,
+            interchainGasPaymaster,
+            currentImplementation,
+            targetImplementation,
+            currentVersion,
+            targetVersion: CONTRACTS_PACKAGE_VERSION,
+            proxyAdmin: actualProxyAdmin,
+            proxyAdminOwner,
+            ownerType,
+            governanceType,
+            status: 'manual',
+            detail:
+              'ProxyAdmin is deployer-owned; script does not execute deployer-key upgrades',
+          });
+          continue;
+        default:
+          plans.push({
+            chain,
+            interchainGasPaymaster,
+            currentImplementation,
+            targetImplementation,
+            currentVersion,
+            targetVersion: CONTRACTS_PACKAGE_VERSION,
+            proxyAdmin: actualProxyAdmin,
+            proxyAdminOwner,
+            ownerType,
+            governanceType,
+            status: 'manual',
+            detail: `unknown ProxyAdmin owner ${proxyAdminOwner}`,
+          });
+          continue;
+      }
+
+      plans.push({
+        chain,
+        interchainGasPaymaster,
+        currentImplementation,
+        targetImplementation,
+        currentVersion,
+        targetVersion: CONTRACTS_PACKAGE_VERSION,
+        proxyAdmin: actualProxyAdmin,
+        proxyAdminOwner,
+        ownerType,
+        governanceType,
+        status: 'queued',
+        detail,
+      });
+    } catch (error) {
+      plans.push({
+        chain,
+        interchainGasPaymaster,
+        targetImplementation,
+        targetVersion: CONTRACTS_PACKAGE_VERSION,
+        status: 'error',
+        detail: formatError(error),
+      });
+    }
+  }
+
+  const groups = [...safeGroups.values()];
+  const runDir = join(
+    OUTPUT_ROOT,
+    new Date().toISOString().replace(/[:.]/g, '-'),
+  );
+  await writeSafeBatchFiles({ groups, multiProvider, runDir });
+
+  if (propose) {
+    await proposeSafeGroups({ groups, multiProvider });
+  }
+
+  const output = {
+    environment,
+    context,
+    targetVersion: CONTRACTS_PACKAGE_VERSION,
+    mode: propose ? 'propose' : 'dry-run',
+    legacyIgpChains,
+    safeGroups: groups.map((group) => ({
+      chain: group.chain,
+      governanceType: group.governanceType,
+      safeAddress: group.safeAddress,
+      transactionCount: group.calls.length,
+    })),
+    plans,
+  };
+
+  if (outFile) {
+    await writeAndFormatJsonAtPath(outFile, output);
+  }
+  logTable(plans, ['chain', 'status', 'ownerType', 'governanceType', 'detail']);
+
+  if (!propose) {
+    rootLogger.info(`Dry run: Safe batch files written under ${runDir}`);
+  }
+  if (plans.some((plan) => plan.status === 'error')) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  rootLogger.error(error);
+  process.exit(1);
+});

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -73,6 +73,9 @@ export const legacyIgpChains: ChainName[] = Array.from(
     'incentiv',
     'metis',
     'ontology',
+    'taiko',
+    'torus',
+
     // Keep chains with repeatedly unreliable deployment/proposal execution on
     // legacy IGP for now.
     'astar',
@@ -80,8 +83,6 @@ export const legacyIgpChains: ChainName[] = Array.from(
     'prom',
     'pulsechain',
     'sei',
-    'taiko',
-    'torus',
     'viction',
     'xrplevm',
     ...getDisabledChains(),

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -73,11 +73,17 @@ export const legacyIgpChains: ChainName[] = Array.from(
     'incentiv',
     'metis',
     'ontology',
+    // Keep chains with repeatedly unreliable deployment/proposal execution on
+    // legacy IGP for now.
+    'astar',
+    'krown',
     'prom',
     'pulsechain',
+    'sei',
     'taiko',
     'torus',
     'viction',
+    'xrplevm',
     ...getDisabledChains(),
   ]),
 );

--- a/typescript/infra/src/govern/HyperlaneAppGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneAppGovernor.ts
@@ -40,10 +40,9 @@ import {
   SafeMultiSend,
   SignerMultiSend,
 } from './multisend.js';
+import { GOVERNOR_MAX_BATCH_SIZE } from './constants.js';
 import type { AnnotatedCallData, InferredCall } from './types.js';
 import { SubmissionType } from './types.js';
-
-export const GOVERNOR_MAX_BATCH_SIZE = 120;
 
 export abstract class HyperlaneAppGovernor<
   App extends HyperlaneApp<any>,

--- a/typescript/infra/src/govern/HyperlaneAppGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneAppGovernor.ts
@@ -43,6 +43,8 @@ import {
 import type { AnnotatedCallData, InferredCall } from './types.js';
 import { SubmissionType } from './types.js';
 
+export const GOVERNOR_MAX_BATCH_SIZE = 120;
+
 export abstract class HyperlaneAppGovernor<
   App extends HyperlaneApp<any>,
   Config extends OwnableConfig,
@@ -178,13 +180,15 @@ export abstract class HyperlaneAppGovernor<
           );
           try {
             // Process calls in batches up to max size of 120
-            const maxBatchSize = 120;
             for (
               let i = 0;
               i < callsForSubmissionType.length;
-              i += maxBatchSize
+              i += GOVERNOR_MAX_BATCH_SIZE
             ) {
-              const batch = callsForSubmissionType.slice(i, i + maxBatchSize);
+              const batch = callsForSubmissionType.slice(
+                i,
+                i + GOVERNOR_MAX_BATCH_SIZE,
+              );
               const sendBatch = () =>
                 multiSend.sendTransactions(
                   batch.map((call) => ({

--- a/typescript/infra/src/govern/HyperlaneIgpGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneIgpGovernor.ts
@@ -9,10 +9,12 @@ import {
   IgpConfig,
   IgpGasOraclesViolation,
   IgpOverheadViolation,
+  IgpTokenGasOraclesViolation,
   IgpViolation,
   IgpViolationType,
   OwnerViolation,
 } from '@hyperlane-xyz/sdk';
+import { rootLogger } from '@hyperlane-xyz/utils';
 
 import { HyperlaneAppGovernor } from '../govern/HyperlaneAppGovernor.js';
 
@@ -124,6 +126,18 @@ export class HyperlaneIgpGovernor extends HyperlaneAppGovernor<
               .join(', ')}`,
           },
         };
+      }
+      case IgpViolationType.TokenGasOracles: {
+        const tokenGasViolation = violation as IgpTokenGasOraclesViolation;
+        rootLogger.warn(
+          {
+            chain: tokenGasViolation.chain,
+            feeToken: tokenGasViolation.feeToken,
+            missingRemotes: Object.keys(tokenGasViolation.actual),
+          },
+          'TokenGasOracles violation requires manual remediation via HyperlaneIgpDeployer — no automatic fix available',
+        );
+        return undefined;
       }
       default:
         throw new Error(

--- a/typescript/infra/src/govern/constants.ts
+++ b/typescript/infra/src/govern/constants.ts
@@ -1,0 +1,1 @@
+export const GOVERNOR_MAX_BATCH_SIZE = 120;

--- a/typescript/infra/src/utils/timelock.ts
+++ b/typescript/infra/src/utils/timelock.ts
@@ -137,16 +137,24 @@ export async function timelockConfigMatches({
   return { matches: issues.length === 0, issues };
 }
 
-const rpcBlockRangesByChain: ChainMap<number> = {
+export const DEFAULT_TIMELOCK_LOG_BLOCK_RANGE = 999;
+
+export const timelockLogBlockRangeByChain: ChainMap<number> = {
   // The rpc limits to a max of 1024 blocks
   moonbeam: 1024,
   // The rpc limits to a max of 5000 blocks
   merlin: 5000,
   // The rpc limits to a max of 1000 blocks
   xlayer: 1000,
-  // The rpc limits to a max of 1000 blocks
+  // The rpc limits to a max of 5000 blocks
   dogechain: 5000,
 };
+
+export function getTimelockLogBlockRange(chain: ChainName): number {
+  return (
+    timelockLogBlockRangeByChain[chain] ?? DEFAULT_TIMELOCK_LOG_BLOCK_RANGE
+  );
+}
 
 export function getTimelockConfigs({
   chains,
@@ -201,7 +209,7 @@ async function getPendingTimelockTxsOnChain(
     chain,
     multiProvider,
     timelockAddress,
-    paginationBlockRange: rpcBlockRangesByChain[chain] ?? 10_000,
+    paginationBlockRange: getTimelockLogBlockRange(chain),
   });
 
   let scheduledTxs: Awaited<

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -1,0 +1,165 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { expect } from 'chai';
+import { BigNumber } from 'ethers';
+
+import { GovernanceType } from '../src/governanceTypes.js';
+import {
+  getImplementationAddressOverrides,
+  getPostUpgradeConfigChains,
+  isMissingPackageVersionError,
+  splitProposableGroups,
+} from '../scripts/igp/upgrade-compatible-igps.js';
+
+describe('upgrade-compatible-igps', () => {
+  describe('isMissingPackageVersionError', () => {
+    it('only treats missing selector call exceptions as missing package version', () => {
+      expect(
+        isMissingPackageVersionError({
+          code: 'CALL_EXCEPTION',
+          data: '0x',
+        }),
+      ).to.equal(true);
+      expect(
+        isMissingPackageVersionError({
+          code: 'CALL_EXCEPTION',
+          error: { data: '0x' },
+        }),
+      ).to.equal(true);
+      expect(
+        isMissingPackageVersionError({
+          code: 'CALL_EXCEPTION',
+          message: 'call reverted with data="0x"',
+        }),
+      ).to.equal(true);
+
+      expect(
+        isMissingPackageVersionError({
+          code: 'SERVER_ERROR',
+          message: 'Invalid response from provider',
+        }),
+      ).to.equal(false);
+      expect(
+        isMissingPackageVersionError({
+          code: 'CALL_EXCEPTION',
+          data: '0x1234',
+        }),
+      ).to.equal(false);
+    });
+  });
+
+  describe('getImplementationAddressOverrides', () => {
+    const supportedChains = new Set(['ethereum', 'arbitrum']);
+    let dir: string;
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'igp-upgrade-test-'));
+    });
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    function writeOverrides(value: unknown) {
+      const filepath = join(dir, 'overrides.json');
+      writeFileSync(filepath, JSON.stringify(value));
+      return filepath;
+    }
+
+    it('loads valid chain implementation overrides', () => {
+      const implementation = '0x1111111111111111111111111111111111111111';
+      const filepath = writeOverrides({ ethereum: implementation });
+
+      expect(
+        getImplementationAddressOverrides(filepath, supportedChains),
+      ).to.deep.equal({
+        ethereum: implementation,
+      });
+    });
+
+    it('rejects unsupported chains and invalid addresses', () => {
+      expect(() =>
+        getImplementationAddressOverrides(
+          writeOverrides({
+            unknown: '0x1111111111111111111111111111111111111111',
+          }),
+          supportedChains,
+        ),
+      ).to.throw('unsupported chain unknown');
+
+      expect(() =>
+        getImplementationAddressOverrides(
+          writeOverrides({
+            ethereum: '0x0000000000000000000000000000000000000000',
+          }),
+          supportedChains,
+        ),
+      ).to.throw('implementation is zero address');
+
+      expect(() =>
+        getImplementationAddressOverrides(
+          writeOverrides({ ethereum: 'not-an-address' }),
+          supportedChains,
+        ),
+      ).to.throw('is not an EVM address');
+    });
+  });
+
+  it('only includes newly queued upgrades in the post-upgrade config command', () => {
+    expect(
+      getPostUpgradeConfigChains([
+        {
+          chain: 'ethereum',
+          targetVersion: '1.0.0',
+          status: 'queued',
+          detail: 'new safe proposal',
+        },
+        {
+          chain: 'arbitrum',
+          targetVersion: '1.0.0',
+          status: 'scheduled',
+          detail: 'timelock operation already scheduled/done',
+        },
+      ]),
+    ).to.deep.equal(['ethereum']);
+  });
+
+  it('splits raw fallback Safe groups out of propose mode', () => {
+    const safeGroup = {
+      chain: 'ethereum',
+      governanceType: GovernanceType.AbacusWorks,
+      safeAddress: '0x1111111111111111111111111111111111111111',
+      calls: [
+        {
+          to: '0x2222222222222222222222222222222222222222',
+          data: '0x',
+          value: BigNumber.from(0),
+          description: 'upgrade',
+        },
+      ],
+    };
+    const rawFallbackGroup = {
+      ...safeGroup,
+      chain: 'arbitrum',
+    };
+
+    const result = splitProposableGroups({
+      groups: [safeGroup, rawFallbackGroup],
+      rawFallbackGroupKeys: new Set([
+        `${rawFallbackGroup.chain}:${rawFallbackGroup.governanceType}`,
+      ]),
+    });
+
+    expect(result.proposableGroups).to.deep.equal([safeGroup]);
+    expect(result.skippedProposalResults).to.deep.include({
+      chain: 'arbitrum',
+      governanceType: GovernanceType.AbacusWorks,
+      safeAddress: rawFallbackGroup.safeAddress,
+      status: 'skipped',
+      detail:
+        'skipped propose because only raw fallback calldata was written; submit manually',
+    });
+  });
+});

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -133,6 +133,99 @@ describe('upgrade-compatible-igps', () => {
         },
       }),
     ).to.equal(true);
+
+    expect(
+      callMatchesTimelockIdempotency({
+        call: {
+          to: proxyAdmin,
+          value: BigNumber.from(0),
+          data: iface.encodeFunctionData('upgrade', [
+            proxy,
+            firstImplementation,
+          ]),
+          description: 'upgrade',
+        },
+        scheduledTarget: '0x5555555555555555555555555555555555555555',
+        scheduledValue: BigNumber.from(0),
+        scheduledData: iface.encodeFunctionData('upgrade', [
+          proxy,
+          secondImplementation,
+        ]),
+        idempotency: {
+          type: 'proxyAdminUpgrade',
+          proxyAddress: proxy,
+        },
+      }),
+    ).to.equal(false);
+
+    expect(
+      callMatchesTimelockIdempotency({
+        call: {
+          to: proxyAdmin,
+          value: BigNumber.from(0),
+          data: iface.encodeFunctionData('upgrade', [
+            proxy,
+            firstImplementation,
+          ]),
+          description: 'upgrade',
+        },
+        scheduledTarget: proxyAdmin,
+        scheduledValue: BigNumber.from(1),
+        scheduledData: iface.encodeFunctionData('upgrade', [
+          proxy,
+          secondImplementation,
+        ]),
+        idempotency: {
+          type: 'proxyAdminUpgrade',
+          proxyAddress: proxy,
+        },
+      }),
+    ).to.equal(false);
+
+    expect(
+      callMatchesTimelockIdempotency({
+        call: {
+          to: proxyAdmin,
+          value: BigNumber.from(0),
+          data: iface.encodeFunctionData('upgrade', [
+            proxy,
+            firstImplementation,
+          ]),
+          description: 'upgrade',
+        },
+        scheduledTarget: proxyAdmin,
+        scheduledValue: BigNumber.from(0),
+        scheduledData: iface.encodeFunctionData('upgrade', [
+          '0x6666666666666666666666666666666666666666',
+          secondImplementation,
+        ]),
+        idempotency: {
+          type: 'proxyAdminUpgrade',
+          proxyAddress: proxy,
+        },
+      }),
+    ).to.equal(false);
+
+    expect(
+      callMatchesTimelockIdempotency({
+        call: {
+          to: proxyAdmin,
+          value: BigNumber.from(0),
+          data: iface.encodeFunctionData('upgrade', [
+            proxy,
+            firstImplementation,
+          ]),
+          description: 'upgrade',
+        },
+        scheduledTarget: proxyAdmin,
+        scheduledValue: BigNumber.from(0),
+        scheduledData: '0x1234',
+        idempotency: {
+          type: 'proxyAdminUpgrade',
+          proxyAddress: proxy,
+        },
+      }),
+    ).to.equal(false);
   });
 
   it('splits raw fallback Safe groups out of propose mode', () => {

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -6,7 +6,6 @@ import { GovernanceType } from '../src/governanceTypes.js';
 import { getTimelockLogBlockRange } from '../src/utils/timelock.js';
 import {
   callMatchesTimelockIdempotency,
-  getDeferredTimelockConfigChains,
   getUpgradeTargetImplementation,
   isMissingPackageVersionError,
   splitProposableGroups,
@@ -53,34 +52,6 @@ describe('upgrade-compatible-igps', () => {
         }),
       ).to.equal(false);
     });
-  });
-
-  it('detects timelock chains with deferred config txs', () => {
-    const plans = [
-      {
-        chain: 'ethereum',
-        targetVersion: '1.0.0',
-        status: 'queued',
-        detail: 'new safe proposal',
-      },
-      {
-        chain: 'arbitrum',
-        targetVersion: '1.0.0',
-        status: 'timelock queued',
-        detail: 'timelock schedule proposal; 2 config tx(s) deferred',
-      },
-      {
-        chain: 'optimism',
-        targetVersion: '1.0.0',
-        status: 'scheduled',
-        detail: 'timelock operation already scheduled; 1 config tx(s) deferred',
-      },
-    ];
-
-    expect(getDeferredTimelockConfigChains(plans)).to.deep.equal([
-      'arbitrum',
-      'optimism',
-    ]);
   });
 
   it('uses conservative timelock log block ranges', () => {

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -4,6 +4,7 @@ import { BigNumber } from 'ethers';
 
 import { GovernanceType } from '../src/governanceTypes.js';
 import {
+  callMatchesTimelockIdempotency,
   getDeferredTimelockConfigChains,
   getUpgradeTargetImplementation,
   isMissingPackageVersionError,
@@ -36,6 +37,12 @@ describe('upgrade-compatible-igps', () => {
         isMissingPackageVersionError({
           code: 'SERVER_ERROR',
           message: 'Invalid response from provider',
+        }),
+      ).to.equal(true);
+      expect(
+        isMissingPackageVersionError({
+          code: 'SERVER_ERROR',
+          message: 'rate limited',
         }),
       ).to.equal(false);
       expect(
@@ -94,6 +101,38 @@ describe('upgrade-compatible-igps', () => {
         proxyAddress: proxy,
       }),
     ).to.equal(implementation);
+  });
+
+  it('matches timelock IGP upgrade operations across different implementations', () => {
+    const proxyAdmin = '0x1111111111111111111111111111111111111111';
+    const proxy = '0x2222222222222222222222222222222222222222';
+    const firstImplementation = '0x3333333333333333333333333333333333333333';
+    const secondImplementation = '0x4444444444444444444444444444444444444444';
+    const iface = ProxyAdmin__factory.createInterface();
+
+    expect(
+      callMatchesTimelockIdempotency({
+        call: {
+          to: proxyAdmin,
+          value: BigNumber.from(0),
+          data: iface.encodeFunctionData('upgrade', [
+            proxy,
+            firstImplementation,
+          ]),
+          description: 'upgrade',
+        },
+        scheduledTarget: proxyAdmin,
+        scheduledValue: BigNumber.from(0),
+        scheduledData: iface.encodeFunctionData('upgrade', [
+          proxy,
+          secondImplementation,
+        ]),
+        idempotency: {
+          type: 'proxyAdminUpgrade',
+          proxyAddress: proxy,
+        },
+      }),
+    ).to.equal(true);
   });
 
   it('splits raw fallback Safe groups out of propose mode', () => {

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -9,7 +9,9 @@ import { GovernanceType } from '../src/governanceTypes.js';
 import {
   getImplementationAddressOverrides,
   getPostUpgradeConfigChains,
+  getTimelockPostExecutionConfigChains,
   isMissingPackageVersionError,
+  mergeImplementationAddresses,
   splitProposableGroups,
 } from '../scripts/igp/upgrade-compatible-igps.js';
 
@@ -82,6 +84,13 @@ describe('upgrade-compatible-igps', () => {
     it('rejects unsupported chains and invalid addresses', () => {
       expect(() =>
         getImplementationAddressOverrides(
+          writeOverrides(['0x1111111111111111111111111111111111111111']),
+          supportedChains,
+        ),
+      ).to.throw('must contain a JSON object');
+
+      expect(() =>
+        getImplementationAddressOverrides(
           writeOverrides({
             unknown: '0x1111111111111111111111111111111111111111',
           }),
@@ -107,23 +116,50 @@ describe('upgrade-compatible-igps', () => {
     });
   });
 
-  it('only includes newly queued upgrades in the post-upgrade config command', () => {
+  it('splits immediate and timelock post-upgrade config chains', () => {
+    const plans = [
+      {
+        chain: 'ethereum',
+        targetVersion: '1.0.0',
+        status: 'queued',
+        detail: 'new safe proposal',
+      },
+      {
+        chain: 'arbitrum',
+        targetVersion: '1.0.0',
+        status: 'timelock queued',
+        detail: 'timelock schedule proposal',
+      },
+      {
+        chain: 'optimism',
+        targetVersion: '1.0.0',
+        status: 'scheduled',
+        detail: 'timelock operation already scheduled',
+      },
+    ];
+
+    expect(getPostUpgradeConfigChains(plans)).to.deep.equal(['ethereum']);
+    expect(getTimelockPostExecutionConfigChains(plans)).to.deep.equal([
+      'arbitrum',
+      'optimism',
+    ]);
+  });
+
+  it('prefers igp verification implementations over core fallback', () => {
     expect(
-      getPostUpgradeConfigChains([
-        {
-          chain: 'ethereum',
-          targetVersion: '1.0.0',
-          status: 'queued',
-          detail: 'new safe proposal',
+      mergeImplementationAddresses({
+        igpImplementations: {
+          ethereum: '0x1111111111111111111111111111111111111111',
         },
-        {
-          chain: 'arbitrum',
-          targetVersion: '1.0.0',
-          status: 'scheduled',
-          detail: 'timelock operation already scheduled/done',
+        coreImplementations: {
+          ethereum: '0x2222222222222222222222222222222222222222',
+          arbitrum: '0x3333333333333333333333333333333333333333',
         },
-      ]),
-    ).to.deep.equal(['ethereum']);
+      }),
+    ).to.deep.equal({
+      ethereum: '0x1111111111111111111111111111111111111111',
+      arbitrum: '0x3333333333333333333333333333333333333333',
+    });
   });
 
   it('splits raw fallback Safe groups out of propose mode', () => {

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 
 import { GovernanceType } from '../src/governanceTypes.js';
+import { getTimelockLogBlockRange } from '../src/utils/timelock.js';
 import {
   callMatchesTimelockIdempotency,
   getDeferredTimelockConfigChains,
@@ -80,6 +81,11 @@ describe('upgrade-compatible-igps', () => {
       'arbitrum',
       'optimism',
     ]);
+  });
+
+  it('uses conservative timelock log block ranges', () => {
+    expect(getTimelockLogBlockRange('ethereum')).to.equal(999);
+    expect(getTimelockLogBlockRange('xlayer')).to.equal(1000);
   });
 
   it('extracts target implementation from ProxyAdmin upgrade calldata', () => {

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -1,17 +1,12 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
-
+import { ProxyAdmin__factory } from '@hyperlane-xyz/core';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 
 import { GovernanceType } from '../src/governanceTypes.js';
 import {
-  getImplementationAddressOverrides,
-  getPostUpgradeConfigChains,
-  getTimelockPostExecutionConfigChains,
+  getDeferredTimelockConfigChains,
+  getUpgradeTargetImplementation,
   isMissingPackageVersionError,
-  mergeImplementationAddresses,
   splitProposableGroups,
 } from '../scripts/igp/upgrade-compatible-igps.js';
 
@@ -52,71 +47,7 @@ describe('upgrade-compatible-igps', () => {
     });
   });
 
-  describe('getImplementationAddressOverrides', () => {
-    const supportedChains = new Set(['ethereum', 'arbitrum']);
-    let dir: string;
-
-    beforeEach(() => {
-      dir = mkdtempSync(join(tmpdir(), 'igp-upgrade-test-'));
-    });
-
-    afterEach(() => {
-      rmSync(dir, { recursive: true, force: true });
-    });
-
-    function writeOverrides(value: unknown) {
-      const filepath = join(dir, 'overrides.json');
-      writeFileSync(filepath, JSON.stringify(value));
-      return filepath;
-    }
-
-    it('loads valid chain implementation overrides', () => {
-      const implementation = '0x1111111111111111111111111111111111111111';
-      const filepath = writeOverrides({ ethereum: implementation });
-
-      expect(
-        getImplementationAddressOverrides(filepath, supportedChains),
-      ).to.deep.equal({
-        ethereum: implementation,
-      });
-    });
-
-    it('rejects unsupported chains and invalid addresses', () => {
-      expect(() =>
-        getImplementationAddressOverrides(
-          writeOverrides(['0x1111111111111111111111111111111111111111']),
-          supportedChains,
-        ),
-      ).to.throw('must contain a JSON object');
-
-      expect(() =>
-        getImplementationAddressOverrides(
-          writeOverrides({
-            unknown: '0x1111111111111111111111111111111111111111',
-          }),
-          supportedChains,
-        ),
-      ).to.throw('unsupported chain unknown');
-
-      expect(() =>
-        getImplementationAddressOverrides(
-          writeOverrides({
-            ethereum: '0x0000000000000000000000000000000000000000',
-          }),
-          supportedChains,
-        ),
-      ).to.throw('implementation is zero address');
-
-      expect(() =>
-        getImplementationAddressOverrides(
-          writeOverrides({ ethereum: 'not-an-address' }),
-          supportedChains,
-        ),
-      ).to.throw('is not an EVM address');
-    });
-  });
-
-  it('splits immediate and timelock post-upgrade config chains', () => {
+  it('detects timelock chains with deferred config txs', () => {
     const plans = [
       {
         chain: 'ethereum',
@@ -128,38 +59,41 @@ describe('upgrade-compatible-igps', () => {
         chain: 'arbitrum',
         targetVersion: '1.0.0',
         status: 'timelock queued',
-        detail: 'timelock schedule proposal',
+        detail: 'timelock schedule proposal; 2 config tx(s) deferred',
       },
       {
         chain: 'optimism',
         targetVersion: '1.0.0',
         status: 'scheduled',
-        detail: 'timelock operation already scheduled',
+        detail: 'timelock operation already scheduled; 1 config tx(s) deferred',
       },
     ];
 
-    expect(getPostUpgradeConfigChains(plans)).to.deep.equal(['ethereum']);
-    expect(getTimelockPostExecutionConfigChains(plans)).to.deep.equal([
+    expect(getDeferredTimelockConfigChains(plans)).to.deep.equal([
       'arbitrum',
       'optimism',
     ]);
   });
 
-  it('prefers igp verification implementations over core fallback', () => {
+  it('extracts target implementation from ProxyAdmin upgrade calldata', () => {
+    const proxyAdmin = '0x1111111111111111111111111111111111111111';
+    const proxy = '0x2222222222222222222222222222222222222222';
+    const implementation = '0x3333333333333333333333333333333333333333';
+    const data = ProxyAdmin__factory.createInterface().encodeFunctionData(
+      'upgrade',
+      [proxy, implementation],
+    );
+
     expect(
-      mergeImplementationAddresses({
-        igpImplementations: {
-          ethereum: '0x1111111111111111111111111111111111111111',
+      getUpgradeTargetImplementation({
+        tx: {
+          to: proxyAdmin,
+          data,
         },
-        coreImplementations: {
-          ethereum: '0x2222222222222222222222222222222222222222',
-          arbitrum: '0x3333333333333333333333333333333333333333',
-        },
+        proxyAdminAddress: proxyAdmin,
+        proxyAddress: proxy,
       }),
-    ).to.deep.equal({
-      ethereum: '0x1111111111111111111111111111111111111111',
-      arbitrum: '0x3333333333333333333333333333333333333333',
-    });
+    ).to.equal(implementation);
   });
 
   it('splits raw fallback Safe groups out of propose mode', () => {

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -177,7 +177,7 @@
     "@turnkey/solana": "catalog:",
     "bignumber.js": "catalog:",
     "borsh": "catalog:",
-    "compare-versions": "^6.1.1",
+    "compare-versions": "catalog:",
     "cosmjs-types": "catalog:",
     "cross-fetch": "^3.1.5",
     "ethers": "catalog:",

--- a/typescript/sdk/src/deploy/proxy.ts
+++ b/typescript/sdk/src/deploy/proxy.ts
@@ -46,7 +46,7 @@ async function assertCodeExists(
       }
     },
     5,
-    2000,
+    500,
   );
 }
 

--- a/typescript/sdk/src/deploy/proxy.ts
+++ b/typescript/sdk/src/deploy/proxy.ts
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import { Provider as ZKSyncProvider } from 'zksync-ethers';
 
 import { ProxyAdmin__factory } from '@hyperlane-xyz/core';
-import { Address, ChainId, eqAddress } from '@hyperlane-xyz/utils';
+import { Address, ChainId, eqAddress, retryAsync } from '@hyperlane-xyz/utils';
 
 import { transferOwnershipTransactions } from '../contracts/contracts.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
@@ -36,10 +36,18 @@ async function assertCodeExists(
   provider: EthersLikeProvider,
   contract: Address,
 ): Promise<void> {
-  const code = await provider.getCode(contract);
-  if (code === '0x') {
-    throw new Error(`Contract at ${contract} has no code`);
-  }
+  // Retry to handle RPC lag where a just-confirmed tx isn't yet visible on
+  // all nodes in a load-balanced pool.
+  await retryAsync(
+    async () => {
+      const code = await provider.getCode(contract);
+      if (code === '0x') {
+        throw new Error(`Contract at ${contract} has no code`);
+      }
+    },
+    5,
+    2000,
+  );
 }
 
 export async function proxyImplementation(

--- a/typescript/sdk/src/gas/HyperlaneIgpChecker.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpChecker.ts
@@ -13,6 +13,7 @@ import {
   IgpConfig,
   IgpGasOraclesViolation,
   IgpOverheadViolation,
+  IgpTokenGasOraclesViolation,
   IgpViolationType,
 } from './types.js';
 
@@ -26,6 +27,7 @@ export class HyperlaneIgpChecker extends HyperlaneAppChecker<
     await this.checkBytecodes(chain);
     await this.checkOverheadInterchainGasPaymaster(chain);
     await this.checkInterchainGasPaymaster(chain);
+    await this.checkTokenGasOracles(chain);
   }
 
   async checkDomainOwnership(chain: ChainName): Promise<void> {
@@ -169,6 +171,52 @@ export class HyperlaneIgpChecker extends HyperlaneAppChecker<
         expected: expectedBeneficiary,
       };
       this.addViolation(violation);
+    }
+  }
+
+  async checkTokenGasOracles(local: ChainName): Promise<void> {
+    const config = this.configMap[local];
+    if (!config.tokenOracleConfig) return;
+
+    const coreContracts = this.app.getContracts(local);
+    const igp = coreContracts.interchainGasPaymaster;
+
+    for (const [feeToken, remoteConfigs] of Object.entries(
+      config.tokenOracleConfig,
+    )) {
+      const violation: IgpTokenGasOraclesViolation = {
+        type: 'InterchainGasPaymaster',
+        subType: IgpViolationType.TokenGasOracles,
+        contract: igp,
+        chain: local,
+        actual: {},
+        expected: {},
+        feeToken,
+      };
+
+      for (const remote of Object.keys(remoteConfigs)) {
+        const remoteId = this.multiProvider.tryGetDomainId(remote);
+        if (remoteId === null) {
+          this.app.logger.warn(
+            `Skipping token oracle check ${local} -> ${remote} for fee token ${feeToken}`,
+          );
+          continue;
+        }
+
+        const actualOracle = await igp.tokenGasOracles(feeToken, remoteId);
+        // Expected oracle is non-zero (should be configured)
+        if (
+          eqAddress(actualOracle, '0x0000000000000000000000000000000000000000')
+        ) {
+          const remoteChain = remote as ChainName;
+          violation.actual[remoteChain] = actualOracle;
+          violation.expected[remoteChain] = 'configured';
+        }
+      }
+
+      if (Object.keys(violation.actual).length > 0) {
+        this.addViolation(violation);
+      }
     }
   }
 }

--- a/typescript/sdk/src/gas/HyperlaneIgpChecker.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpChecker.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
 
 import { eqAddress } from '@hyperlane-xyz/utils';
 
@@ -194,25 +194,24 @@ export class HyperlaneIgpChecker extends HyperlaneAppChecker<
         feeToken,
       };
 
-      for (const remote of Object.keys(remoteConfigs)) {
-        const remoteId = this.multiProvider.tryGetDomainId(remote);
-        if (remoteId === null) {
-          this.app.logger.warn(
-            `Skipping token oracle check ${local} -> ${remote} for fee token ${feeToken}`,
-          );
-          continue;
-        }
+      // TODO: this checker only verifies that an oracle slot is non-zero; it
+      // does not validate the tokenExchangeRate / gasPrice stored in the oracle.
+      await Promise.all(
+        Object.keys(remoteConfigs).map(async (remote) => {
+          const remoteId = this.multiProvider.tryGetDomainId(remote);
+          if (remoteId === null) {
+            this.app.logger.warn(
+              `Skipping token oracle check ${local} -> ${remote} for fee token ${feeToken}`,
+            );
+            return;
+          }
 
-        const actualOracle = await igp.tokenGasOracles(feeToken, remoteId);
-        // Expected oracle is non-zero (should be configured)
-        if (
-          eqAddress(actualOracle, '0x0000000000000000000000000000000000000000')
-        ) {
-          const remoteChain = remote as ChainName;
-          violation.actual[remoteChain] = actualOracle;
-          violation.expected[remoteChain] = 'configured';
-        }
-      }
+          const actualOracle = await igp.tokenGasOracles(feeToken, remoteId);
+          if (eqAddress(actualOracle, ethers.constants.AddressZero)) {
+            violation.actual[remote as ChainName] = actualOracle;
+          }
+        }),
+      );
 
       if (Object.keys(violation.actual).length > 0) {
         this.addViolation(violation);

--- a/typescript/sdk/src/gas/HyperlaneIgpChecker.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpChecker.ts
@@ -2,6 +2,8 @@ import { BigNumber, ethers } from 'ethers';
 
 import { eqAddress } from '@hyperlane-xyz/utils';
 
+import { throwIfNotMissingSelector } from '../utils/contract.js';
+
 import { BytecodeHash } from '../consts/bytecode.js';
 import { HyperlaneAppChecker } from '../deploy/HyperlaneAppChecker.js';
 import { proxyImplementation } from '../deploy/proxy.js';
@@ -206,9 +208,14 @@ export class HyperlaneIgpChecker extends HyperlaneAppChecker<
             return;
           }
 
-          const actualOracle = await igp.tokenGasOracles(feeToken, remoteId);
-          if (eqAddress(actualOracle, ethers.constants.AddressZero)) {
-            violation.actual[remote as ChainName] = actualOracle;
+          try {
+            const actualOracle = await igp.tokenGasOracles(feeToken, remoteId);
+            if (eqAddress(actualOracle, ethers.constants.AddressZero)) {
+              violation.actual[remote as ChainName] = actualOracle;
+            }
+          } catch (error) {
+            throwIfNotMissingSelector(error);
+            // Legacy IGP contracts don't have tokenGasOracles — skip silently.
           }
         }),
       );

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -24,7 +24,6 @@ import { ChainName } from '../types.js';
 
 import { IgpFactories, igpFactories } from './contracts.js';
 import {
-  StorageGasOracleConfig,
   oracleConfigToOracleData,
   serializeDifference,
 } from './oracle/types.js';
@@ -418,111 +417,6 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
           );
         });
       }
-    }
-  }
-
-  async deployTokenGasOracles(
-    chain: ChainName,
-    igp: InterchainGasPaymaster,
-    config: IgpConfig,
-  ): Promise<StorageGasOracle[]> {
-    if (!config.tokenOracleConfig) return [];
-
-    const tokenOracles: StorageGasOracle[] = [];
-
-    for (const [feeToken, remoteConfigs] of Object.entries(
-      config.tokenOracleConfig,
-    )) {
-      this.logger.info(
-        `Deploying StorageGasOracle for fee token ${feeToken} on ${chain}...`,
-      );
-      const oracle = await this.deployContract(chain, 'storageGasOracle', []);
-      tokenOracles.push(oracle);
-
-      // Configure remote gas data on the oracle
-      await this.configureTokenOracle(chain, oracle, remoteConfigs);
-
-      // Set the oracle on the IGP for this fee token
-      const tokenGasOracleConfigs: InterchainGasPaymaster.TokenGasOracleConfigStruct[] =
-        [];
-      for (const remote of Object.keys(remoteConfigs)) {
-        const remoteId = this.multiProvider.tryGetDomainId(remote);
-        if (remoteId === null) {
-          this.logger.warn(
-            `Skipping token oracle ${chain} -> ${remote} for fee token ${feeToken}`,
-          );
-          continue;
-        }
-        tokenGasOracleConfigs.push({
-          feeToken,
-          remoteDomain: remoteId,
-          gasOracle: oracle.address,
-        });
-      }
-
-      if (tokenGasOracleConfigs.length > 0) {
-        await this.runIfOwner(chain, igp, async () => {
-          const estimatedGas = await igp.estimateGas.setTokenGasOracles(
-            tokenGasOracleConfigs,
-          );
-          return this.multiProvider.handleTx(
-            chain,
-            igp.setTokenGasOracles(tokenGasOracleConfigs, {
-              gasLimit: addBufferToGasLimit(estimatedGas),
-              ...this.multiProvider.getTransactionOverrides(chain),
-            }),
-          );
-        });
-      }
-
-      // Transfer ownership to oracleKey
-      await this.runIfOwner(chain, oracle, async () =>
-        this.multiProvider.handleTx(
-          chain,
-          oracle.transferOwnership(config.oracleKey, {
-            ...this.multiProvider.getTransactionOverrides(chain),
-          }),
-        ),
-      );
-    }
-
-    return tokenOracles;
-  }
-
-  private async configureTokenOracle(
-    chain: ChainName,
-    oracle: StorageGasOracle,
-    remoteConfigs: Record<string, StorageGasOracleConfig>,
-  ): Promise<void> {
-    const configsToSet: Array<StorageGasOracle.RemoteGasDataConfigStruct> = [];
-
-    for (const [remote, desired] of Object.entries(remoteConfigs)) {
-      const remoteDomain = this.multiProvider.tryGetDomainId(remote);
-      if (remoteDomain === null) continue;
-
-      const actual = await oracle.remoteGasData(remoteDomain);
-      const desiredData = oracleConfigToOracleData(desired);
-
-      if (
-        !actual.gasPrice.eq(desired.gasPrice) ||
-        !actual.tokenExchangeRate.eq(desired.tokenExchangeRate)
-      ) {
-        configsToSet.push({ remoteDomain, ...desiredData });
-      }
-    }
-
-    if (configsToSet.length > 0) {
-      await this.runIfOwner(chain, oracle, async () => {
-        const estimatedGas =
-          await oracle.estimateGas.setRemoteGasDataConfigs(configsToSet);
-        return this.multiProvider.handleTx(
-          chain,
-          oracle.setRemoteGasDataConfigs(configsToSet, {
-            gasLimit: addBufferToGasLimit(estimatedGas),
-            ...this.multiProvider.getTransactionOverrides(chain),
-          }),
-        );
-      });
     }
   }
 

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -401,19 +401,27 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
 
       if (tokenOracleParams.length > 0) {
         await this.runIfOwner(chain, igp, async () => {
-          this.logger.info(
-            `Setting token gas oracles for ${feeToken} on ${chain} (domains ${tokenOracleParams
-              .map((p) => p.remoteDomain)
-              .join(', ')})`,
-          );
-          const estimatedGas =
-            await igp.estimateGas.setTokenGasOracles(tokenOracleParams);
-          await this.multiProvider.handleTx(
+          await submitBatched(
             chain,
-            igp.setTokenGasOracles(tokenOracleParams, {
-              gasLimit: addBufferToGasLimit(estimatedGas),
-              ...this.multiProvider.getTransactionOverrides(chain),
-            }),
+            tokenOracleParams,
+            async (batch) => {
+              this.logger.info(
+                `Setting token gas oracles for ${feeToken} on ${chain} (domains ${batch
+                  .map((p) => p.remoteDomain)
+                  .join(', ')})`,
+              );
+              const estimatedGas =
+                await igp.estimateGas.setTokenGasOracles(batch);
+              await this.multiProvider.handleTx(
+                chain,
+                igp.setTokenGasOracles(batch, {
+                  gasLimit: addBufferToGasLimit(estimatedGas),
+                  ...this.multiProvider.getTransactionOverrides(chain),
+                }),
+              );
+            },
+            this.logger,
+            'token gas oracles',
           );
         });
       }

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -24,6 +24,7 @@ import { ChainName } from '../types.js';
 
 import { IgpFactories, igpFactories } from './contracts.js';
 import {
+  StorageGasOracleConfig,
   oracleConfigToOracleData,
   serializeDifference,
 } from './oracle/types.js';
@@ -420,6 +421,111 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
     }
   }
 
+  async deployTokenGasOracles(
+    chain: ChainName,
+    igp: InterchainGasPaymaster,
+    config: IgpConfig,
+  ): Promise<StorageGasOracle[]> {
+    if (!config.tokenOracleConfig) return [];
+
+    const tokenOracles: StorageGasOracle[] = [];
+
+    for (const [feeToken, remoteConfigs] of Object.entries(
+      config.tokenOracleConfig,
+    )) {
+      this.logger.info(
+        `Deploying StorageGasOracle for fee token ${feeToken} on ${chain}...`,
+      );
+      const oracle = await this.deployContract(chain, 'storageGasOracle', []);
+      tokenOracles.push(oracle);
+
+      // Configure remote gas data on the oracle
+      await this.configureTokenOracle(chain, oracle, remoteConfigs);
+
+      // Set the oracle on the IGP for this fee token
+      const tokenGasOracleConfigs: InterchainGasPaymaster.TokenGasOracleConfigStruct[] =
+        [];
+      for (const remote of Object.keys(remoteConfigs)) {
+        const remoteId = this.multiProvider.tryGetDomainId(remote);
+        if (remoteId === null) {
+          this.logger.warn(
+            `Skipping token oracle ${chain} -> ${remote} for fee token ${feeToken}`,
+          );
+          continue;
+        }
+        tokenGasOracleConfigs.push({
+          feeToken,
+          remoteDomain: remoteId,
+          gasOracle: oracle.address,
+        });
+      }
+
+      if (tokenGasOracleConfigs.length > 0) {
+        await this.runIfOwner(chain, igp, async () => {
+          const estimatedGas = await igp.estimateGas.setTokenGasOracles(
+            tokenGasOracleConfigs,
+          );
+          return this.multiProvider.handleTx(
+            chain,
+            igp.setTokenGasOracles(tokenGasOracleConfigs, {
+              gasLimit: addBufferToGasLimit(estimatedGas),
+              ...this.multiProvider.getTransactionOverrides(chain),
+            }),
+          );
+        });
+      }
+
+      // Transfer ownership to oracleKey
+      await this.runIfOwner(chain, oracle, async () =>
+        this.multiProvider.handleTx(
+          chain,
+          oracle.transferOwnership(config.oracleKey, {
+            ...this.multiProvider.getTransactionOverrides(chain),
+          }),
+        ),
+      );
+    }
+
+    return tokenOracles;
+  }
+
+  private async configureTokenOracle(
+    chain: ChainName,
+    oracle: StorageGasOracle,
+    remoteConfigs: Record<string, StorageGasOracleConfig>,
+  ): Promise<void> {
+    const configsToSet: Array<StorageGasOracle.RemoteGasDataConfigStruct> = [];
+
+    for (const [remote, desired] of Object.entries(remoteConfigs)) {
+      const remoteDomain = this.multiProvider.tryGetDomainId(remote);
+      if (remoteDomain === null) continue;
+
+      const actual = await oracle.remoteGasData(remoteDomain);
+      const desiredData = oracleConfigToOracleData(desired);
+
+      if (
+        !actual.gasPrice.eq(desired.gasPrice) ||
+        !actual.tokenExchangeRate.eq(desired.tokenExchangeRate)
+      ) {
+        configsToSet.push({ remoteDomain, ...desiredData });
+      }
+    }
+
+    if (configsToSet.length > 0) {
+      await this.runIfOwner(chain, oracle, async () => {
+        const estimatedGas =
+          await oracle.estimateGas.setRemoteGasDataConfigs(configsToSet);
+        return this.multiProvider.handleTx(
+          chain,
+          oracle.setRemoteGasDataConfigs(configsToSet, {
+            gasLimit: addBufferToGasLimit(estimatedGas),
+            ...this.multiProvider.getTransactionOverrides(chain),
+          }),
+        );
+      });
+    }
+  }
+
   async deployContracts(
     chain: ChainName,
     config: IgpConfig,
@@ -437,6 +543,9 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
       storageGasOracle,
       config,
     );
+
+    // Deploy per-token gas oracles for ERC20 fee payments
+    await this.deployTokenGasOracles(chain, interchainGasPaymaster, config);
 
     const contracts = {
       proxyAdmin,

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -544,9 +544,6 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
       config,
     );
 
-    // Deploy per-token gas oracles for ERC20 fee payments
-    await this.deployTokenGasOracles(chain, interchainGasPaymaster, config);
-
     const contracts = {
       proxyAdmin,
       storageGasOracle,

--- a/typescript/sdk/src/gas/types.ts
+++ b/typescript/sdk/src/gas/types.ts
@@ -59,6 +59,7 @@ export enum IgpViolationType {
   Beneficiary = 'Beneficiary',
   GasOracles = 'GasOracles',
   Overhead = 'Overhead',
+  TokenGasOracles = 'TokenGasOracles',
 }
 
 export interface IgpViolation extends CheckerViolation {
@@ -85,4 +86,12 @@ export interface IgpOverheadViolation extends IgpViolation {
   contract: InterchainGasPaymaster;
   actual: ChainMap<BigNumber>;
   expected: ChainMap<BigNumber>;
+}
+
+export interface IgpTokenGasOraclesViolation extends IgpViolation {
+  subType: IgpViolationType.TokenGasOracles;
+  contract: InterchainGasPaymaster;
+  actual: ChainMap<Address>;
+  expected: ChainMap<Address>;
+  feeToken: Address;
 }

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -190,9 +190,24 @@ export class EvmHookModule extends HyperlaneModule<
   }
 
   public async read(): Promise<DerivedHookConfig | string> {
-    return typeof this.args.config === 'string'
-      ? this.args.addresses.deployedHook
-      : this.reader.deriveHookConfig(this.args.addresses.deployedHook);
+    if (typeof this.args.config === 'string') {
+      return this.args.addresses.deployedHook;
+    }
+
+    // For IGP hooks with tokenOracleConfig, pass fee tokens to the reader
+    if (
+      typeof this.args.config === 'object' &&
+      this.args.config.type === HookType.INTERCHAIN_GAS_PAYMASTER &&
+      this.args.config.tokenOracleConfig
+    ) {
+      const feeTokens = Object.keys(this.args.config.tokenOracleConfig);
+      return this.reader.deriveIgpConfig(
+        this.args.addresses.deployedHook,
+        feeTokens,
+      );
+    }
+
+    return this.reader.deriveHookConfig(this.args.addresses.deployedHook);
   }
 
   public async update(
@@ -1448,6 +1463,14 @@ export class EvmHookModule extends HyperlaneModule<
       config,
     });
 
+    // Deploy per-token gas oracles for ERC20 fee payments
+    if (config.tokenOracleConfig) {
+      await this.deployTokenGasOracles({
+        igp: interchainGasPaymaster,
+        config,
+      });
+    }
+
     return interchainGasPaymaster;
   }
 
@@ -1540,6 +1563,71 @@ export class EvmHookModule extends HyperlaneModule<
     );
 
     return routingHook;
+  }
+
+  protected async deployTokenGasOracles({
+    igp,
+    config,
+  }: {
+    igp: InterchainGasPaymaster;
+    config: IgpHookConfig;
+  }): Promise<void> {
+    if (!config.tokenOracleConfig) return;
+
+    for (const [feeToken, remoteConfigs] of Object.entries(
+      config.tokenOracleConfig,
+    )) {
+      this.logger.info(
+        `Deploying StorageGasOracle for fee token ${feeToken}...`,
+      );
+
+      // Deploy a StorageGasOracle for this fee token
+      const oracle = await this.deployer.deployContractFromFactory(
+        this.chain,
+        new StorageGasOracle__factory(),
+        'storageGasOracle',
+        [],
+      );
+
+      // Configure remote gas data on the oracle
+      const configureTxs = await this.updateStorageGasOracle({
+        gasOracle: oracle.address,
+        targetOracleConfig: remoteConfigs,
+        targetOverhead: config.overhead,
+      });
+      for (const tx of configureTxs) {
+        await this.multiProvider.sendTransaction(this.chain, tx);
+      }
+
+      // Set the oracle on the IGP for this fee token
+      const tokenGasOracleConfigs: {
+        feeToken: string;
+        remoteDomain: number;
+        gasOracle: string;
+      }[] = [];
+      for (const remote of Object.keys(remoteConfigs)) {
+        const remoteId = this.multiProvider.tryGetDomainId(remote);
+        if (!remoteId) continue;
+        tokenGasOracleConfigs.push({
+          feeToken,
+          remoteDomain: remoteId,
+          gasOracle: oracle.address,
+        });
+      }
+
+      if (tokenGasOracleConfigs.length > 0) {
+        await this.multiProvider.handleTx(
+          this.chain,
+          igp.setTokenGasOracles(tokenGasOracleConfigs, this.txOverrides),
+        );
+      }
+
+      // Transfer ownership to oracleKey
+      await this.multiProvider.handleTx(
+        this.chain,
+        oracle.transferOwnership(config.oracleKey, this.txOverrides),
+      );
+    }
   }
 
   protected async deployStorageGasOracle({

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -1457,19 +1457,12 @@ export class EvmHookModule extends HyperlaneModule<
       config,
     });
 
-    // Deploy the InterchainGasPaymaster
+    // Deploy the InterchainGasPaymaster (handles token gas oracle wiring
+    // via updateIgpTokenGasOracles before transferring ownership)
     const interchainGasPaymaster = await this.deployInterchainGasPaymaster({
       storageGasOracle,
       config,
     });
-
-    // Deploy per-token gas oracles for ERC20 fee payments
-    if (config.tokenOracleConfig) {
-      await this.deployTokenGasOracles({
-        igp: interchainGasPaymaster,
-        config,
-      });
-    }
 
     return interchainGasPaymaster;
   }
@@ -1563,71 +1556,6 @@ export class EvmHookModule extends HyperlaneModule<
     );
 
     return routingHook;
-  }
-
-  protected async deployTokenGasOracles({
-    igp,
-    config,
-  }: {
-    igp: InterchainGasPaymaster;
-    config: IgpHookConfig;
-  }): Promise<void> {
-    if (!config.tokenOracleConfig) return;
-
-    for (const [feeToken, remoteConfigs] of Object.entries(
-      config.tokenOracleConfig,
-    )) {
-      this.logger.info(
-        `Deploying StorageGasOracle for fee token ${feeToken}...`,
-      );
-
-      // Deploy a StorageGasOracle for this fee token
-      const oracle = await this.deployer.deployContractFromFactory(
-        this.chain,
-        new StorageGasOracle__factory(),
-        'storageGasOracle',
-        [],
-      );
-
-      // Configure remote gas data on the oracle
-      const configureTxs = await this.updateStorageGasOracle({
-        gasOracle: oracle.address,
-        targetOracleConfig: remoteConfigs,
-        targetOverhead: config.overhead,
-      });
-      for (const tx of configureTxs) {
-        await this.multiProvider.sendTransaction(this.chain, tx);
-      }
-
-      // Set the oracle on the IGP for this fee token
-      const tokenGasOracleConfigs: {
-        feeToken: string;
-        remoteDomain: number;
-        gasOracle: string;
-      }[] = [];
-      for (const remote of Object.keys(remoteConfigs)) {
-        const remoteId = this.multiProvider.tryGetDomainId(remote);
-        if (!remoteId) continue;
-        tokenGasOracleConfigs.push({
-          feeToken,
-          remoteDomain: remoteId,
-          gasOracle: oracle.address,
-        });
-      }
-
-      if (tokenGasOracleConfigs.length > 0) {
-        await this.multiProvider.handleTx(
-          this.chain,
-          igp.setTokenGasOracles(tokenGasOracleConfigs, this.txOverrides),
-        );
-      }
-
-      // Transfer ownership to oracleKey
-      await this.multiProvider.handleTx(
-        this.chain,
-        oracle.transferOwnership(config.oracleKey, this.txOverrides),
-      );
-    }
   }
 
   protected async deployStorageGasOracle({

--- a/typescript/sdk/src/hook/EvmHookReader.test.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.test.ts
@@ -421,7 +421,14 @@ describe('EvmHookReader', () => {
         .resolves(OnchainHookType.INTERCHAIN_GAS_PAYMASTER),
       owner: sandbox.stub().resolves(mockOwner),
       beneficiary: sandbox.stub().resolves(mockBeneficiary),
-      getExchangeRateAndGasPrice: sandbox.stub().rejects(new Error('no data')),
+      quoteSigners: sandbox.stub().rejects(missingSelectorError()),
+      getExchangeRateAndGasPrice: sandbox
+        .stub()
+        .callsFake((domainId: number) =>
+          Promise.reject(
+            new Error(`Configured IGP doesn't support domain ${domainId}`),
+          ),
+        ),
       destinationGasLimit: sandbox.stub().resolves(ethers.BigNumber.from(0)),
       destinationGasConfigs: sandbox.stub().resolves({
         gasOracle: mockOracleAddress,
@@ -433,7 +440,11 @@ describe('EvmHookReader', () => {
     // tokenGasOracles returns zero for all domains except when feeToken matches
     mockIgp.tokenGasOracles.resolves(ethers.constants.AddressZero);
     // No configured domains for native oracle
-    mockIgp.getExchangeRateAndGasPrice.rejects(new Error('no data'));
+    mockIgp.getExchangeRateAndGasPrice.callsFake((domainId: number) =>
+      Promise.reject(
+        new Error(`Configured IGP doesn't support domain ${domainId}`),
+      ),
+    );
 
     sandbox
       .stub(InterchainGasPaymaster__factory, 'connect')

--- a/typescript/sdk/src/hook/EvmHookReader.test.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.test.ts
@@ -475,6 +475,68 @@ describe('EvmHookReader', () => {
     expect(configZeroOracle.tokenOracleConfig).to.be.undefined;
   });
 
+  it('should populate tokenOracleConfig when tokenGasOracles returns non-zero oracle', async () => {
+    const mockAddress = randomAddress();
+    const mockOwner = randomAddress();
+    const mockBeneficiary = randomAddress();
+    const mockOracleAddress = randomAddress();
+    const feeToken = randomAddress();
+    const domainId = test1.domainId;
+
+    sandbox.stub(evmHookReader, 'possibleDomainIds').returns([domainId]);
+
+    const mockIgp = {
+      hookType: sandbox
+        .stub()
+        .resolves(OnchainHookType.INTERCHAIN_GAS_PAYMASTER),
+      owner: sandbox.stub().resolves(mockOwner),
+      beneficiary: sandbox.stub().resolves(mockBeneficiary),
+      quoteSigners: sandbox.stub().rejects(missingSelectorError()),
+      getExchangeRateAndGasPrice: sandbox
+        .stub()
+        .rejects(
+          new Error(`Configured IGP doesn't support domain ${domainId}`),
+        ),
+      destinationGasLimit: sandbox.stub().resolves(ethers.BigNumber.from(0)),
+      destinationGasConfigs: sandbox.stub().resolves({
+        gasOracle: mockOracleAddress,
+        gasOverhead: ethers.BigNumber.from(0),
+      }),
+      tokenGasOracles: sandbox.stub().resolves(mockOracleAddress), // non-zero oracle for all calls
+    };
+
+    sandbox
+      .stub(InterchainGasPaymaster__factory, 'connect')
+      .returns(mockIgp as unknown as InterchainGasPaymaster);
+    sandbox
+      .stub(IPostDispatchHook__factory, 'connect')
+      .returns(mockIgp as unknown as IPostDispatchHook);
+
+    const mockOracle = {
+      owner: sandbox.stub().resolves(mockOwner),
+      remoteGasData: sandbox.stub().resolves({
+        tokenExchangeRate: ethers.BigNumber.from('15000000000'),
+        gasPrice: ethers.BigNumber.from('500000000'),
+      }),
+    };
+    sandbox
+      .stub(StorageGasOracle__factory, 'connect')
+      .returns(mockOracle as unknown as StorageGasOracle);
+
+    const config = await evmHookReader.deriveIgpConfig(mockAddress, [feeToken]);
+
+    expect(mockOracle.remoteGasData.calledOnce).to.be.true;
+    expect(config.tokenOracleConfig).to.deep.equal({
+      [feeToken]: {
+        [test1.name]: {
+          tokenExchangeRate: '15000000000',
+          gasPrice: '500000000',
+          tokenDecimals: test1.nativeToken?.decimals,
+        },
+      },
+    });
+  });
+
   /*
     Testing for more nested hook types can be done manually by reading from existing contracts onchain.
     Examples of nested hook types include:

--- a/typescript/sdk/src/hook/EvmHookReader.test.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.test.ts
@@ -22,6 +22,8 @@ import {
   PausableHook__factory,
   ProtocolFee,
   ProtocolFee__factory,
+  StorageGasOracle,
+  StorageGasOracle__factory,
 } from '@hyperlane-xyz/core';
 import { WithAddress } from '@hyperlane-xyz/utils';
 
@@ -404,6 +406,62 @@ describe('EvmHookReader', () => {
         `Failed to derive undefined hook (${mockAddress}):`,
       );
     }
+  });
+
+  it('should derive IGP config with tokenOracleConfig', async () => {
+    const mockAddress = randomAddress();
+    const mockOwner = randomAddress();
+    const mockBeneficiary = randomAddress();
+    const mockOracleAddress = randomAddress();
+    const feeToken = randomAddress();
+
+    const mockIgp = {
+      hookType: sandbox
+        .stub()
+        .resolves(OnchainHookType.INTERCHAIN_GAS_PAYMASTER),
+      owner: sandbox.stub().resolves(mockOwner),
+      beneficiary: sandbox.stub().resolves(mockBeneficiary),
+      getExchangeRateAndGasPrice: sandbox.stub().rejects(new Error('no data')),
+      destinationGasLimit: sandbox.stub().resolves(ethers.BigNumber.from(0)),
+      destinationGasConfigs: sandbox.stub().resolves({
+        gasOracle: mockOracleAddress,
+        gasOverhead: ethers.BigNumber.from(0),
+      }),
+      tokenGasOracles: sandbox.stub(),
+    };
+
+    // tokenGasOracles returns zero for all domains except when feeToken matches
+    mockIgp.tokenGasOracles.resolves(ethers.constants.AddressZero);
+    // No configured domains for native oracle
+    mockIgp.getExchangeRateAndGasPrice.rejects(new Error('no data'));
+
+    sandbox
+      .stub(InterchainGasPaymaster__factory, 'connect')
+      .returns(mockIgp as unknown as InterchainGasPaymaster);
+    sandbox
+      .stub(IPostDispatchHook__factory, 'connect')
+      .returns(mockIgp as unknown as IPostDispatchHook);
+
+    const mockOracle = {
+      owner: sandbox.stub().resolves(mockOwner),
+      remoteGasData: sandbox.stub().resolves({
+        tokenExchangeRate: ethers.BigNumber.from('15000000000'),
+        gasPrice: ethers.BigNumber.from('500000000'),
+      }),
+    };
+    sandbox
+      .stub(StorageGasOracle__factory, 'connect')
+      .returns(mockOracle as unknown as StorageGasOracle);
+
+    // No fee tokens provided - should not have tokenOracleConfig
+    const configNoTokens = await evmHookReader.deriveIgpConfig(mockAddress);
+    expect(configNoTokens.tokenOracleConfig).to.be.undefined;
+
+    // With fee tokens but all return zero address - should be undefined
+    const configZeroOracle = await evmHookReader.deriveIgpConfig(mockAddress, [
+      feeToken,
+    ]);
+    expect(configZeroOracle.tokenOracleConfig).to.be.undefined;
   });
 
   /*

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -591,7 +591,8 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
                 tokenExchangeRate: tokenExchangeRate.toString(),
                 gasPrice: gasPrice.toString(),
               };
-            } catch {
+            } catch (error) {
+              throwIfNotMissingSelector(error);
               // Domain not configured for this fee token
             }
           },

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -39,6 +39,7 @@ import { ChainNameOrId } from '../types.js';
 import { HyperlaneReader } from '../utils/HyperlaneReader.js';
 import {
   isMissingSelectorCallException,
+  isMissingSelectorRevert,
   throwIfNotMissingSelector,
 } from '../utils/contract.js';
 
@@ -488,9 +489,11 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
       try {
         return { quoteSigners: await hook.quoteSigners() };
       } catch (error) {
-        // quoteSigners() only exists on v2+ IGPs. Any failure (missing selector,
-        // SmartProvider "All providers failed" wrapping a revert, etc.) means
-        // this is a legacy IGP.
+        // quoteSigners() only exists on v2+ IGPs. A missing-selector revert
+        // (CALL_EXCEPTION with empty data) means this is a legacy IGP.
+        // Network errors and other transient failures must propagate so the
+        // caller can distinguish a legacy IGP from a provider outage.
+        if (!isMissingSelectorRevert(error)) throw error;
         this.logger.debug(
           'quoteSigners() call failed — treating as legacy IGP',
           { address, error },

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -566,7 +566,11 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
       for (const feeToken of feeTokens) {
         const tokenConfig: Record<
           string,
-          { gasPrice: string; tokenExchangeRate: string }
+          {
+            gasPrice: string;
+            tokenExchangeRate: string;
+            tokenDecimals?: number;
+          }
         > = {};
         await concurrentMap(
           this.concurrency,
@@ -585,11 +589,14 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
               );
               const { tokenExchangeRate, gasPrice } =
                 await oracle.remoteGasData(domainId);
-              const { name: chainName } =
+              const { name: chainName, nativeToken } =
                 this.multiProvider.getChainMetadata(domainId);
               tokenConfig[chainName] = {
                 tokenExchangeRate: tokenExchangeRate.toString(),
                 gasPrice: gasPrice.toString(),
+                ...(nativeToken?.decimals !== undefined
+                  ? { tokenDecimals: nativeToken.decimals }
+                  : {}),
               };
             } catch (error) {
               throwIfNotMissingSelector(error);

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -613,7 +613,7 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
       oracleKey: oracleKey ?? owner,
       overhead,
       oracleConfig,
-      tokenOracleConfig,
+      ...(tokenOracleConfig ? { tokenOracleConfig } : {}),
       ...(quoteSignersResult.igpVersion
         ? { igpVersion: quoteSignersResult.igpVersion }
         : {}),

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -40,7 +40,6 @@ import { HyperlaneReader } from '../utils/HyperlaneReader.js';
 import {
   isMissingSelectorCallException,
   throwIfNotMissingSelector,
-  throwIfNotMissingSelectorRevert,
 } from '../utils/contract.js';
 
 import {
@@ -489,9 +488,12 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
       try {
         return { quoteSigners: await hook.quoteSigners() };
       } catch (error) {
-        throwIfNotMissingSelectorRevert(error);
+        // quoteSigners() only exists on v2+ IGPs. Any failure (missing selector,
+        // SmartProvider "All providers failed" wrapping a revert, etc.) means
+        // this is a legacy IGP.
         this.logger.debug(
-          'quoteSigners() not available on this IGP version, skipping',
+          'quoteSigners() call failed — treating as legacy IGP',
+          { address, error },
         );
         return { quoteSigners: [], igpVersion: IgpVersion.Legacy };
       }

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -140,6 +140,7 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
 
   async deriveHookConfigFromAddress(
     address: Address,
+    feeTokens?: Address[],
   ): Promise<DerivedHookConfig> {
     this.logger.debug('Deriving HookConfig:', { address });
 
@@ -178,7 +179,7 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
           derivedHookConfig = await this.deriveMerkleTreeConfig(address);
           break;
         case OnchainHookType.INTERCHAIN_GAS_PAYMASTER:
-          derivedHookConfig = await this.deriveIgpConfig(address);
+          derivedHookConfig = await this.deriveIgpConfig(address, feeTokens);
           break;
         case OnchainHookType.FALLBACK_ROUTING:
           derivedHookConfig = await this.deriveFallbackRoutingConfig(address);
@@ -252,9 +253,10 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
    */
   public async deriveHookConfig(
     config: HookConfig,
+    feeTokens?: Address[],
   ): Promise<DerivedHookConfig> {
     if (typeof config === 'string')
-      return this.deriveHookConfigFromAddress(config);
+      return this.deriveHookConfigFromAddress(config, feeTokens);
 
     // Extend the inner hooks
     switch (config.type) {

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers';
+import { constants, ethers } from 'ethers';
 
 import {
   AmountRoutingHook__factory,
@@ -85,7 +85,10 @@ export interface HookReader {
   deriveAggregationConfig(
     address: Address,
   ): Promise<WithAddress<AggregationHookConfig>>;
-  deriveIgpConfig(address: Address): Promise<WithAddress<IgpHookConfig>>;
+  deriveIgpConfig(
+    address: Address,
+    feeTokens?: Address[],
+  ): Promise<WithAddress<IgpHookConfig>>;
   deriveProtocolFeeConfig(
     address: Address,
   ): Promise<WithAddress<ProtocolFeeHookConfig>>;
@@ -468,7 +471,10 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
           .map((chainName) => this.multiProvider.getDomainId(chainName));
   }
 
-  async deriveIgpConfig(address: Address): Promise<WithAddress<IgpHookConfig>> {
+  async deriveIgpConfig(
+    address: Address,
+    feeTokens?: Address[],
+  ): Promise<WithAddress<IgpHookConfig>> {
     const hook = InterchainGasPaymaster__factory.connect(
       address,
       this.provider,
@@ -553,6 +559,52 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
       oracleKey = resolvedOracleKeys[0];
     }
 
+    // Read token oracle configs for ERC20 fee tokens
+    let tokenOracleConfig: IgpHookConfig['tokenOracleConfig'];
+    if (feeTokens && feeTokens.length > 0) {
+      tokenOracleConfig = {};
+      for (const feeToken of feeTokens) {
+        const tokenConfig: Record<
+          string,
+          { gasPrice: string; tokenExchangeRate: string }
+        > = {};
+        await concurrentMap(
+          this.concurrency,
+          this.possibleDomainIds(),
+          async (domainId) => {
+            try {
+              const oracleAddress = await hook.tokenGasOracles(
+                feeToken,
+                domainId,
+              );
+              if (eqAddress(oracleAddress, constants.AddressZero)) return;
+
+              const oracle = StorageGasOracle__factory.connect(
+                oracleAddress,
+                this.provider,
+              );
+              const { tokenExchangeRate, gasPrice } =
+                await oracle.remoteGasData(domainId);
+              const { name: chainName } =
+                this.multiProvider.getChainMetadata(domainId);
+              tokenConfig[chainName] = {
+                tokenExchangeRate: tokenExchangeRate.toString(),
+                gasPrice: gasPrice.toString(),
+              };
+            } catch {
+              // Domain not configured for this fee token
+            }
+          },
+        );
+        if (Object.keys(tokenConfig).length > 0) {
+          tokenOracleConfig[feeToken] = tokenConfig;
+        }
+      }
+      if (Object.keys(tokenOracleConfig).length === 0) {
+        tokenOracleConfig = undefined;
+      }
+    }
+
     const config: WithAddress<IgpHookConfig> = {
       owner,
       address,
@@ -561,6 +613,7 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
       oracleKey: oracleKey ?? owner,
       overhead,
       oracleConfig,
+      tokenOracleConfig,
       ...(quoteSignersResult.igpVersion
         ? { igpVersion: quoteSignersResult.igpVersion }
         : {}),

--- a/typescript/sdk/src/hook/types.test.ts
+++ b/typescript/sdk/src/hook/types.test.ts
@@ -1,45 +1,198 @@
 import { expect } from 'chai';
+import { ethers } from 'ethers';
 
-import { HookConfigSchema, HookType } from './types.js';
+import { randomAddress } from '../test/testUtils.js';
 
-const ADDRESS = '0x0000000000000000000000000000000000000001';
+import { HookConfigSchema, HookType, IgpSchema } from './types.js';
+
+const SOME_ADDRESS = ethers.Wallet.createRandom().address;
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
-const igpConfig = (feeToken: string, remote = 'test1') => ({
-  type: HookType.INTERCHAIN_GAS_PAYMASTER,
-  owner: ADDRESS,
-  beneficiary: ADDRESS,
-  oracleKey: ADDRESS,
-  overhead: {},
-  oracleConfig: {},
-  tokenOracleConfig: {
-    [feeToken]: {
-      [remote]: {
-        tokenExchangeRate: '1',
-        gasPrice: '1',
+describe('IgpSchema', () => {
+  const baseConfig = {
+    type: HookType.INTERCHAIN_GAS_PAYMASTER,
+    owner: SOME_ADDRESS,
+    beneficiary: SOME_ADDRESS,
+    oracleKey: SOME_ADDRESS,
+    overhead: { ethereum: 60000 },
+    oracleConfig: {
+      ethereum: {
+        gasPrice: '1000000000',
+        tokenExchangeRate: '10000000000',
       },
     },
-  },
+  };
+
+  it('should parse valid IGP config without tokenOracleConfig', () => {
+    const result = IgpSchema.safeParse(baseConfig);
+    expect(result.success).to.be.true;
+  });
+
+  it('should parse valid IGP config with tokenOracleConfig', () => {
+    const feeToken = randomAddress();
+    const config = {
+      ...baseConfig,
+      tokenOracleConfig: {
+        [feeToken]: {
+          ethereum: {
+            gasPrice: '500000000',
+            tokenExchangeRate: '20000000000',
+          },
+        },
+      },
+    };
+    const result = IgpSchema.safeParse(config);
+    expect(result.success).to.be.true;
+    if (result.success) {
+      expect(result.data.tokenOracleConfig).to.not.be.undefined;
+      expect(result.data.tokenOracleConfig![feeToken]).to.deep.equal({
+        ethereum: {
+          gasPrice: '500000000',
+          tokenExchangeRate: '20000000000',
+        },
+      });
+    }
+  });
+
+  it('should parse config with multiple fee tokens in tokenOracleConfig', () => {
+    const feeToken1 = randomAddress();
+    const feeToken2 = randomAddress();
+    const config = {
+      ...baseConfig,
+      tokenOracleConfig: {
+        [feeToken1]: {
+          ethereum: {
+            gasPrice: '500000000',
+            tokenExchangeRate: '20000000000',
+          },
+        },
+        [feeToken2]: {
+          ethereum: {
+            gasPrice: '1000000000',
+            tokenExchangeRate: '15000000000',
+          },
+          arbitrum: {
+            gasPrice: '100000000',
+            tokenExchangeRate: '10000000000',
+          },
+        },
+      },
+    };
+    const result = IgpSchema.safeParse(config);
+    expect(result.success).to.be.true;
+    if (result.success) {
+      expect(Object.keys(result.data.tokenOracleConfig!)).to.have.lengthOf(2);
+    }
+  });
+
+  it('should parse config with tokenOracleConfig including tokenDecimals', () => {
+    const feeToken = randomAddress();
+    const config = {
+      ...baseConfig,
+      tokenOracleConfig: {
+        [feeToken]: {
+          ethereum: {
+            gasPrice: '500000000',
+            tokenExchangeRate: '20000000000',
+            tokenDecimals: 6,
+          },
+        },
+      },
+    };
+    const result = IgpSchema.safeParse(config);
+    expect(result.success).to.be.true;
+  });
+
+  it('should reject tokenOracleConfig with missing gasPrice', () => {
+    const feeToken = randomAddress();
+    const config = {
+      ...baseConfig,
+      tokenOracleConfig: {
+        [feeToken]: {
+          ethereum: {
+            tokenExchangeRate: '20000000000',
+          },
+        },
+      },
+    };
+    const result = IgpSchema.safeParse(config);
+    expect(result.success).to.be.false;
+  });
+
+  it('should reject tokenOracleConfig with missing tokenExchangeRate', () => {
+    const feeToken = randomAddress();
+    const config = {
+      ...baseConfig,
+      tokenOracleConfig: {
+        [feeToken]: {
+          ethereum: {
+            gasPrice: '500000000',
+          },
+        },
+      },
+    };
+    const result = IgpSchema.safeParse(config);
+    expect(result.success).to.be.false;
+  });
 });
 
-describe('IgpSchema tokenOracleConfig', () => {
+describe('IgpSchema tokenOracleConfig key validation', () => {
+  const baseConfig = {
+    type: HookType.INTERCHAIN_GAS_PAYMASTER,
+    owner: SOME_ADDRESS,
+    beneficiary: SOME_ADDRESS,
+    oracleKey: SOME_ADDRESS,
+    overhead: {},
+    oracleConfig: {},
+  };
+
   it('allows non-zero EVM fee-token keys and chain-name remote keys', () => {
-    expect(HookConfigSchema.safeParse(igpConfig(ADDRESS)).success).to.be.true;
+    const feeToken = randomAddress();
+    const config = {
+      ...baseConfig,
+      tokenOracleConfig: {
+        [feeToken]: {
+          ethereum: { tokenExchangeRate: '1', gasPrice: '1' },
+        },
+      },
+    };
+    expect(HookConfigSchema.safeParse(config).success).to.be.true;
   });
 
   it('rejects zero-address fee-token keys', () => {
-    expect(HookConfigSchema.safeParse(igpConfig(ZERO_ADDRESS)).success).to.be
-      .false;
+    const config = {
+      ...baseConfig,
+      tokenOracleConfig: {
+        [ZERO_ADDRESS]: {
+          ethereum: { tokenExchangeRate: '1', gasPrice: '1' },
+        },
+      },
+    };
+    expect(HookConfigSchema.safeParse(config).success).to.be.false;
   });
 
   it('rejects non-address fee-token keys', () => {
-    expect(HookConfigSchema.safeParse(igpConfig('NATIVE_TOKEN')).success).to.be
-      .false;
+    const config = {
+      ...baseConfig,
+      tokenOracleConfig: {
+        NATIVE_TOKEN: {
+          ethereum: { tokenExchangeRate: '1', gasPrice: '1' },
+        },
+      },
+    };
+    expect(HookConfigSchema.safeParse(config).success).to.be.false;
   });
 
   it('rejects invalid remote chain keys', () => {
-    expect(
-      HookConfigSchema.safeParse(igpConfig(ADDRESS, 'not-a-chain')).success,
-    ).to.be.false;
+    const feeToken = randomAddress();
+    const config = {
+      ...baseConfig,
+      tokenOracleConfig: {
+        [feeToken]: {
+          'not-a-chain': { tokenExchangeRate: '1', gasPrice: '1' },
+        },
+      },
+    };
+    expect(HookConfigSchema.safeParse(config).success).to.be.false;
   });
 });

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -9,7 +9,10 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
-import { ProtocolAgnositicGasOracleConfigWithTypicalCostSchema } from '../gas/oracle/types.js';
+import {
+  ProtocolAgnositicGasOracleConfigSchema,
+  ProtocolAgnositicGasOracleConfigWithTypicalCostSchema,
+} from '../gas/oracle/types.js';
 import { ZChainName, ZHash } from '../metadata/customZodTypes.js';
 import {
   ChainMap,
@@ -237,10 +240,7 @@ export const IgpSchema = OwnableSchema.extend({
   tokenOracleConfig: z
     .record(
       FeeTokenAddressSchema,
-      z.record(
-        ZChainName,
-        ProtocolAgnositicGasOracleConfigWithTypicalCostSchema,
-      ),
+      z.record(ZChainName, ProtocolAgnositicGasOracleConfigSchema),
     )
     .optional(),
 });

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -50,13 +50,6 @@ export {
   isContractAddress,
   assertIsContractAddress,
 } from './contracts/contracts.js';
-export {
-  isMissingSelectorCallException,
-  isMissingSelectorRevert,
-  isValidContractVersion,
-  throwIfNotMissingSelector,
-  throwIfNotMissingSelectorRevert,
-} from './utils/contract.js';
 export { MUTABLE_HOOK_TYPE, OnchainHookType } from './hook/types.js';
 export { MUTABLE_ISM_TYPE } from './ism/types.js';
 

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -226,6 +226,7 @@ export {
   IgpConfig,
   IgpGasOraclesViolation,
   IgpOverheadViolation,
+  IgpTokenGasOraclesViolation,
   IgpViolation,
   IgpViolationType,
 } from './gas/types.js';

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -50,6 +50,13 @@ export {
   isContractAddress,
   assertIsContractAddress,
 } from './contracts/contracts.js';
+export {
+  isMissingSelectorCallException,
+  isMissingSelectorRevert,
+  isValidContractVersion,
+  throwIfNotMissingSelector,
+  throwIfNotMissingSelectorRevert,
+} from './utils/contract.js';
 export { MUTABLE_HOOK_TYPE, OnchainHookType } from './hook/types.js';
 export { MUTABLE_ISM_TYPE } from './ism/types.js';
 

--- a/typescript/sdk/src/router/types.test.ts
+++ b/typescript/sdk/src/router/types.test.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+
+import { GasRouterConfigSchema } from './types.js';
+
+const SOME_ADDRESS = ethers.Wallet.createRandom().address;
+
+describe('GasRouterConfigSchema', () => {
+  const baseConfig = {
+    owner: SOME_ADDRESS,
+    mailbox: SOME_ADDRESS,
+  };
+
+  it('should accept config without feeHook', () => {
+    const result = GasRouterConfigSchema.safeParse(baseConfig);
+    expect(result.success).to.be.true;
+  });
+
+  it('should accept config with feeHook', () => {
+    const result = GasRouterConfigSchema.safeParse({
+      ...baseConfig,
+      feeHook: SOME_ADDRESS,
+    });
+    expect(result.success).to.be.true;
+    if (result.success) {
+      expect(result.data.feeHook).to.equal(SOME_ADDRESS);
+    }
+  });
+
+  it('should reject feeHook with invalid address', () => {
+    const result = GasRouterConfigSchema.safeParse({
+      ...baseConfig,
+      feeHook: 'not-an-address',
+    });
+    expect(result.success).to.be.false;
+  });
+});

--- a/typescript/sdk/src/router/types.ts
+++ b/typescript/sdk/src/router/types.ts
@@ -149,4 +149,5 @@ export const DestinationGasSchema = z.record(
 export const GasRouterConfigSchema = RouterConfigSchema.extend({
   gas: z.number().optional(),
   destinationGas: DestinationGasSchema.optional(),
+  feeHook: ZHash.optional(),
 });

--- a/typescript/sdk/src/token/EvmWarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.hardhat-test.ts
@@ -1267,7 +1267,8 @@ describe('EvmWarpModule', async () => {
 
       // Verify feeHook was set
       const updatedConfig = await evmERC20WarpModule.read();
-      expect(eqAddress(updatedConfig.feeHook!, feeHookAddress)).to.be.true;
+      assert(updatedConfig.feeHook != null, 'feeHook should be set');
+      expect(eqAddress(updatedConfig.feeHook, feeHookAddress)).to.be.true;
     });
 
     for (const tokenType of movableCollateralTypes) {

--- a/typescript/sdk/src/token/EvmWarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.hardhat-test.ts
@@ -1242,7 +1242,10 @@ describe('EvmWarpModule', async () => {
     it('should update the feeHook', async () => {
       const config: HypTokenRouterConfig = {
         ...baseConfig,
-        type: TokenType.native,
+        type: TokenType.synthetic,
+        name: TOKEN_NAME,
+        symbol: TOKEN_NAME,
+        decimals: TOKEN_DECIMALS,
       };
 
       const evmERC20WarpModule = await EvmWarpModule.create({

--- a/typescript/sdk/src/token/EvmWarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.hardhat-test.ts
@@ -1239,6 +1239,37 @@ describe('EvmWarpModule', async () => {
       expect(updatedConfig.destinationGas![domain]).to.equal('5000');
     });
 
+    it('should update the feeHook', async () => {
+      const config: HypTokenRouterConfig = {
+        ...baseConfig,
+        type: TokenType.native,
+      };
+
+      const evmERC20WarpModule = await EvmWarpModule.create({
+        chain,
+        config,
+        multiProvider,
+        proxyFactoryFactories: ismFactoryAddresses,
+      });
+
+      // Verify no feeHook initially
+      const initialConfig = await evmERC20WarpModule.read();
+      expect(initialConfig.feeHook).to.be.undefined;
+
+      // Set feeHook to a random address
+      const feeHookAddress = randomAddress();
+      const txs = await evmERC20WarpModule.update({
+        ...config,
+        feeHook: feeHookAddress,
+      });
+      expect(txs.length).to.equal(1);
+      await sendTxs(txs);
+
+      // Verify feeHook was set
+      const updatedConfig = await evmERC20WarpModule.read();
+      expect(eqAddress(updatedConfig.feeHook!, feeHookAddress)).to.be.true;
+    });
+
     for (const tokenType of movableCollateralTypes) {
       it(`should add a new rebalancer on the deployed token if it is of type "${tokenType}"`, async () => {
         const initialRebalancer = randomAddress();

--- a/typescript/sdk/src/token/EvmWarpModule.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.ts
@@ -1650,6 +1650,8 @@ export class EvmWarpModule extends HyperlaneModule<
     actualConfig: DerivedTokenRouterConfig,
     expectedConfig: HypTokenRouterConfig,
   ): AnnotatedEV5Transaction[] {
+    if (isOftTokenConfig(expectedConfig)) return [];
+
     const expectedFeeHook = expectedConfig.feeHook;
     const actualFeeHook = actualConfig.feeHook;
 

--- a/typescript/sdk/src/token/EvmWarpModule.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.ts
@@ -1657,6 +1657,9 @@ export class EvmWarpModule extends HyperlaneModule<
 
     // No change needed
     if (!expectedFeeHook && !actualFeeHook) return [];
+    // Unset in expected config → leave the on-chain feeHook unchanged.
+    // Clearing an existing feeHook requires an explicit address(0) in the config.
+    if (!expectedFeeHook && actualFeeHook) return [];
     if (
       expectedFeeHook &&
       actualFeeHook &&

--- a/typescript/sdk/src/token/EvmWarpModule.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.ts
@@ -269,6 +269,7 @@ export class EvmWarpModule extends HyperlaneModule<
         actualConfig,
         expectedConfig,
       )),
+      ...this.createFeeHookUpdateTxs(actualConfig, expectedConfig),
       ...this.createUnenrollRemoteRoutersUpdateTxs(
         actualConfig,
         expectedConfig,
@@ -1643,6 +1644,36 @@ export class EvmWarpModule extends HyperlaneModule<
       ],
       deploysNewWrapper: true,
     };
+  }
+
+  createFeeHookUpdateTxs(
+    actualConfig: DerivedTokenRouterConfig,
+    expectedConfig: HypTokenRouterConfig,
+  ): AnnotatedEV5Transaction[] {
+    const expectedFeeHook = expectedConfig.feeHook;
+    const actualFeeHook = actualConfig.feeHook;
+
+    // No change needed
+    if (!expectedFeeHook && !actualFeeHook) return [];
+    if (
+      expectedFeeHook &&
+      actualFeeHook &&
+      eqAddress(expectedFeeHook, actualFeeHook)
+    )
+      return [];
+
+    const newFeeHook = expectedFeeHook ?? constants.AddressZero;
+    return [
+      {
+        chainId: this.chainId,
+        annotation: `Setting feeHook to ${newFeeHook}`,
+        to: this.args.addresses.deployedTokenRoute,
+        data: TokenRouter__factory.createInterface().encodeFunctionData(
+          'setFeeHook',
+          [newFeeHook],
+        ),
+      },
+    ];
   }
 
   /**

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -331,6 +331,9 @@ export class EvmWarpRouteReader extends EvmRouterReader {
         : undefined,
     );
 
+    // Read feeHook (IGP address for ERC20 gas payments)
+    const feeHook = await this.fetchFeeHook(warpRouteAddress);
+
     // CCTP tokens implement their own ISM (the contract itself acts as the ISM via AbstractCcipReadIsm).
     // The ISM is hardcoded and not configurable, so we return zero address to match deploy config expectations.
     if (
@@ -353,6 +356,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       proxyAdmin,
       destinationGas,
       tokenFee,
+      feeHook,
       ...(predicateWrapper && { predicateWrapper }),
     };
     return derivedConfig;
@@ -429,6 +433,23 @@ export class EvmWarpRouteReader extends EvmRouterReader {
         );
         if (found) return found;
       }
+    }
+    return undefined;
+  }
+
+  public async fetchFeeHook(
+    routerAddress: Address,
+  ): Promise<Address | undefined> {
+    try {
+      const router = TokenRouter__factory.connect(routerAddress, this.provider);
+      const feeHookAddress = await router.feeHook();
+      if (!isZeroishAddress(feeHookAddress)) {
+        return feeHookAddress;
+      }
+    } catch {
+      this.logger.debug(
+        `Token at "${routerAddress}" on chain "${this.chain}" does not support feeHook`,
+      );
     }
     return undefined;
   }

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -446,7 +446,8 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       if (!isZeroishAddress(feeHookAddress)) {
         return feeHookAddress;
       }
-    } catch {
+    } catch (error) {
+      throwIfNotMissingSelector(error);
       this.logger.debug(
         `Token at "${routerAddress}" on chain "${this.chain}" does not support feeHook`,
       );

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -29,6 +29,7 @@ import {
   IXERC20VS,
   IXERC20VS__factory,
   IXERC20__factory,
+  Mailbox__factory,
   MovableCollateralRouter,
   MovableCollateralRouter__factory,
   PredicateRouterWrapper__factory,
@@ -482,26 +483,64 @@ export class EvmHypSyntheticAdapter
     const [igpQuote, ...feeQuotes] = await this.contract[
       'quoteTransferRemote(uint32,bytes32,uint256)'
     ](destination, recipBytes32, amount.toString());
-    const [, igpAmount] = igpQuote;
+    const [igpTokenAddress, igpAmountBN] = igpQuote;
+    const igpAmount = BigInt(igpAmountBN.toString());
 
     const tokenFeeQuotes: Quote[] = feeQuotes.map((quote: RawTupleQuote) => ({
       addressOrDenom: quote[0],
       amount: BigInt(quote[1].toString()),
     }));
 
-    // Because the amount is added on  the fees, we need to subtract it from the actual fees
-    const tokenFeeQuote: Quote | undefined =
+    // When the IGP accepts an ERC20 fee token (igpTokenAddress is non-zero), fold
+    // igpAmount into tokenFeeQuote so it's included in the ERC20 approval.
+    // The mailbox's requiredHook (ProtocolFee) may still require a small native ETH
+    // payment; get that separately so we send the correct msg.value.
+    const isErc20Igp = !isZeroishAddress(igpTokenAddress);
+
+    // Because the amount is added on the fees, we need to subtract it from the actual fees
+    const baseTokenFee =
       tokenFeeQuotes.length > 0
-        ? {
-            addressOrDenom: tokenFeeQuotes[0].addressOrDenom, // the contract enforces the token address to be the same as the route
-            amount:
-              tokenFeeQuotes.reduce((sum, q) => sum + q.amount, 0n) - amount,
-          }
+        ? tokenFeeQuotes.reduce((sum, q) => sum + q.amount, 0n) - amount
+        : 0n;
+    const totalTokenFee = baseTokenFee + (isErc20Igp ? igpAmount : 0n);
+    const tokenFeeAddress =
+      tokenFeeQuotes.length > 0
+        ? tokenFeeQuotes[0].addressOrDenom
+        : isErc20Igp
+          ? igpTokenAddress
+          : undefined;
+
+    const tokenFeeQuote: Quote | undefined =
+      totalTokenFee > 0n && tokenFeeAddress
+        ? { addressOrDenom: tokenFeeAddress, amount: totalTokenFee }
         : undefined;
+
+    // For ERC20 IGPs, compute the native ETH the mailbox requiredHook still needs.
+    // The igpAmount from quoteTransferRemote sums requiredHook + USDC_IGP quotes in
+    // mixed denominations; the requiredHook's native fee must be sent as msg.value.
+    let nativeEthFee = 0n;
+    if (isErc20Igp) {
+      try {
+        const provider = this.getProvider();
+        const mailboxAddr = await this.contract.mailbox();
+        const mailbox = Mailbox__factory.connect(mailboxAddr, provider);
+        const requiredHookAddr = await mailbox.requiredHook();
+        const requiredHook = IPostDispatchHook__factory.connect(
+          requiredHookAddr,
+          provider,
+        );
+        // ProtocolFee._quoteDispatch ignores metadata/message, returns protocolFee
+        const rawFee = await requiredHook.quoteDispatch('0x', '0x');
+        nativeEthFee = BigInt(rawFee.toString());
+      } catch {
+        // If the mailbox doesn't have a requiredHook or quoteDispatch fails,
+        // fall back to 0 (no native ETH needed).
+      }
+    }
 
     return {
       igpQuote: {
-        amount: BigInt(igpAmount.toString()),
+        amount: isErc20Igp ? nativeEthFee : igpAmount,
       },
       tokenFeeQuote,
     };

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -499,6 +499,13 @@ export class EvmHypSyntheticAdapter
     const erc20Quotes = allQuotes.filter(
       (q) => !isZeroishAddress(q.addressOrDenom),
     );
+    const erc20Denoms = new Set(
+      erc20Quotes.map((q) => q.addressOrDenom.toLowerCase()),
+    );
+    assert(
+      erc20Denoms.size <= 1,
+      `Unexpected multi-token ERC20 fee quotes: ${[...erc20Denoms].join(', ')}`,
+    );
     const tokenFeeAmount = allQuotes.reduce((sum, q, i) => {
       if (isZeroishAddress(q.addressOrDenom)) return sum;
       return sum + q.amount - (i === 1 ? amount : 0n);

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -29,7 +29,6 @@ import {
   IXERC20VS,
   IXERC20VS__factory,
   IXERC20__factory,
-  Mailbox__factory,
   MovableCollateralRouter,
   MovableCollateralRouter__factory,
   PredicateRouterWrapper__factory,
@@ -480,68 +479,40 @@ export class EvmHypSyntheticAdapter
     assert(recipient, 'Recipient must be defined for quoteTransferRemoteGas');
 
     const recipBytes32 = addressToBytes32(addressToByteHexString(recipient));
-    const [igpQuote, ...feeQuotes] = await this.contract[
+    const rawQuotes: RawTupleQuote[] = await this.contract[
       'quoteTransferRemote(uint32,bytes32,uint256)'
     ](destination, recipBytes32, amount.toString());
-    const [igpTokenAddress, igpAmountBN] = igpQuote;
-    const igpAmount = BigInt(igpAmountBN.toString());
 
-    const tokenFeeQuotes: Quote[] = feeQuotes.map((quote: RawTupleQuote) => ({
-      addressOrDenom: quote[0],
-      amount: BigInt(quote[1].toString()),
+    const allQuotes = rawQuotes.map((q) => ({
+      addressOrDenom: q[0] as Address,
+      amount: BigInt(q[1].toString()),
     }));
 
-    // When the IGP accepts an ERC20 fee token (igpTokenAddress is non-zero), fold
-    // igpAmount into tokenFeeQuote so it's included in the ERC20 approval.
-    // The mailbox's requiredHook (ProtocolFee) may still require a small native ETH
-    // payment; get that separately so we send the correct msg.value.
-    const isErc20Igp = !isZeroishAddress(igpTokenAddress);
+    // Native quotes (token == address(0)) → msg.value sent with transferRemote
+    const nativeAmount = allQuotes
+      .filter((q) => isZeroishAddress(q.addressOrDenom))
+      .reduce((sum, q) => sum + q.amount, 0n);
 
-    // Because the amount is added on the fees, we need to subtract it from the actual fees
-    const baseTokenFee =
-      tokenFeeQuotes.length > 0
-        ? tokenFeeQuotes.reduce((sum, q) => sum + q.amount, 0n) - amount
-        : 0n;
-    const totalTokenFee = baseTokenFee + (isErc20Igp ? igpAmount : 0n);
-    const tokenFeeAddress =
-      tokenFeeQuotes.length > 0
-        ? tokenFeeQuotes[0].addressOrDenom
-        : isErc20Igp
-          ? igpTokenAddress
-          : undefined;
-
+    // ERC20 quotes → must be approved before transferRemote.
+    // quotes[1] always has token = token() with amount = transfer_amount + feeAmount.
+    // Subtract transfer_amount from index 1 only, so we get just the fee portion.
+    const erc20Quotes = allQuotes.filter(
+      (q) => !isZeroishAddress(q.addressOrDenom),
+    );
+    const tokenFeeAmount = allQuotes.reduce((sum, q, i) => {
+      if (isZeroishAddress(q.addressOrDenom)) return sum;
+      return sum + q.amount - (i === 1 ? amount : 0n);
+    }, 0n);
     const tokenFeeQuote: Quote | undefined =
-      totalTokenFee > 0n && tokenFeeAddress
-        ? { addressOrDenom: tokenFeeAddress, amount: totalTokenFee }
+      tokenFeeAmount > 0n
+        ? {
+            addressOrDenom: erc20Quotes[0].addressOrDenom,
+            amount: tokenFeeAmount,
+          }
         : undefined;
 
-    // For ERC20 IGPs, compute the native ETH the mailbox requiredHook still needs.
-    // The igpAmount from quoteTransferRemote sums requiredHook + USDC_IGP quotes in
-    // mixed denominations; the requiredHook's native fee must be sent as msg.value.
-    let nativeEthFee = 0n;
-    if (isErc20Igp) {
-      try {
-        const provider = this.getProvider();
-        const mailboxAddr = await this.contract.mailbox();
-        const mailbox = Mailbox__factory.connect(mailboxAddr, provider);
-        const requiredHookAddr = await mailbox.requiredHook();
-        const requiredHook = IPostDispatchHook__factory.connect(
-          requiredHookAddr,
-          provider,
-        );
-        // ProtocolFee._quoteDispatch ignores metadata/message, returns protocolFee
-        const rawFee = await requiredHook.quoteDispatch('0x', '0x');
-        nativeEthFee = BigInt(rawFee.toString());
-      } catch {
-        // If the mailbox doesn't have a requiredHook or quoteDispatch fails,
-        // fall back to 0 (no native ETH needed).
-      }
-    }
-
     return {
-      igpQuote: {
-        amount: isErc20Igp ? nativeEthFee : igpAmount,
-      },
+      igpQuote: { amount: nativeAmount },
       tokenFeeQuote,
     };
   }

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -827,13 +827,12 @@ abstract class TokenDeployer<
   }
 
   protected async setFeeHooks(
-    configMap: ChainMap<HypTokenConfig>,
+    configMap: ChainMap<HypTokenRouterConfig>,
     deployedContractsMap: HyperlaneContractsMap<Factories>,
   ): Promise<void> {
     await promiseObjAll(
       objMap(configMap, async (chain, config) => {
-        const fullConfig = config as HypTokenRouterConfig;
-        if (!fullConfig.feeHook) return;
+        if (!config.feeHook) return;
 
         const routerAddress = this.router(deployedContractsMap[chain]).address;
         const router = TokenRouter__factory.connect(
@@ -841,12 +840,10 @@ abstract class TokenDeployer<
           this.multiProvider.getSigner(chain),
         );
 
-        this.logger.info(
-          `Setting feeHook on ${chain} to ${fullConfig.feeHook}`,
-        );
+        this.logger.info(`Setting feeHook on ${chain} to ${config.feeHook}`);
         await this.multiProvider.handleTx(
           chain,
-          router.setFeeHook(fullConfig.feeHook),
+          router.setFeeHook(config.feeHook),
         );
       }),
     );

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -832,7 +832,7 @@ abstract class TokenDeployer<
   ): Promise<void> {
     await promiseObjAll(
       objMap(configMap, async (chain, config) => {
-        if (!config.feeHook) return;
+        if (!config.feeHook || isOftTokenConfig(config)) return;
 
         const routerAddress = this.router(deployedContractsMap[chain]).address;
         const router = TokenRouter__factory.connect(
@@ -843,7 +843,9 @@ abstract class TokenDeployer<
         this.logger.info(`Setting feeHook on ${chain} to ${config.feeHook}`);
         await this.multiProvider.handleTx(
           chain,
-          router.setFeeHook(config.feeHook),
+          router.setFeeHook(config.feeHook, {
+            ...this.multiProvider.getTransactionOverrides(chain),
+          }),
         );
       }),
     );

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -826,6 +826,32 @@ abstract class TokenDeployer<
     );
   }
 
+  protected async setFeeHooks(
+    configMap: ChainMap<HypTokenConfig>,
+    deployedContractsMap: HyperlaneContractsMap<Factories>,
+  ): Promise<void> {
+    await promiseObjAll(
+      objMap(configMap, async (chain, config) => {
+        const fullConfig = config as HypTokenRouterConfig;
+        if (!fullConfig.feeHook) return;
+
+        const routerAddress = this.router(deployedContractsMap[chain]).address;
+        const router = TokenRouter__factory.connect(
+          routerAddress,
+          this.multiProvider.getSigner(chain),
+        );
+
+        this.logger.info(
+          `Setting feeHook on ${chain} to ${fullConfig.feeHook}`,
+        );
+        await this.multiProvider.handleTx(
+          chain,
+          router.setFeeHook(fullConfig.feeHook),
+        );
+      }),
+    );
+  }
+
   protected async enrollCrossCollateralRouters(
     configMap: ChainMap<HypTokenConfig>,
     deployedContractsMap: HyperlaneContractsMap<Factories>,
@@ -1076,6 +1102,8 @@ abstract class TokenDeployer<
         deployedContractsMap,
       );
     }
+
+    await this.setFeeHooks(configMap, deployedContractsMap);
 
     await super.transferOwnership(deployedContractsMap, configMap);
 

--- a/typescript/sdk/src/token/types.test.ts
+++ b/typescript/sdk/src/token/types.test.ts
@@ -516,4 +516,17 @@ describe('WarpRouteDeployConfigSchema refine', () => {
       });
     }
   });
+
+  describe('feeHook', () => {
+    it('should accept config with feeHook', () => {
+      config.arbitrum.feeHook = SOME_ADDRESS;
+      const result = WarpRouteDeployConfigSchema.safeParse(config);
+      expect(result.success).to.be.true;
+    });
+
+    it('should accept config without feeHook', () => {
+      const result = WarpRouteDeployConfigSchema.safeParse(config);
+      expect(result.success).to.be.true;
+    });
+  });
 });

--- a/typescript/sdk/src/utils/contract.ts
+++ b/typescript/sdk/src/utils/contract.ts
@@ -3,6 +3,10 @@ import { providers } from 'ethers';
 
 import { Address, chunk, isNullish, strip0x } from '@hyperlane-xyz/utils';
 
+/**
+ * Returns true when the deployed contract version is already at or above the
+ * target version.
+ */
 export function isValidContractVersion(
   currentVersion: string,
   targetVersion: string,

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -560,9 +560,13 @@ export class WarpCore {
       },
     };
 
+    // Include the ERC20 fee (tokenFeeQuote) in the approval threshold so that
+    // allowance checks account for hookFee charged by the feeHook contract.
+    const feeQuote = tokenFeeQuote?.amount ?? 0n;
+
     const [isApproveRequired, isRevokeApprovalRequired] = await Promise.all([
       this.isApproveRequired({
-        originTokenAmount,
+        originTokenAmount: originTokenAmount.plus(feeQuote),
         owner: sender,
       }),
       hypAdapter.isRevokeApprovalRequired(
@@ -581,8 +585,6 @@ export class WarpCore {
     }
 
     if (isApproveRequired) {
-      // feeQuote is required to be approved for routes that have fees set
-      const feeQuote = tokenFeeQuote?.amount ?? 0n;
       const amountToApprove = amount + feeQuote;
       preTransferRemoteTxs.push([
         amountToApprove.toString(),


### PR DESCRIPTION
## Summary

- Added `tokenOracleConfig` to IGP schema for per-fee-token gas oracle configs (exchange rates)
- Added `feeHook` to warp route config for setting the IGP address as a fee hook
- IGP deployer deploys per-token `StorageGasOracle` contracts and calls `setTokenGasOracles`
- Warp route deployer calls `setFeeHook` post-deploy when configured
- `EvmWarpRouteReader` reads `feeHook()` from on-chain TokenRouter
- `EvmHookReader.deriveIgpConfig()` accepts optional `feeTokens` param to read token oracle configs
- IGP checker verifies token gas oracle configuration

## Test plan

- [x] Schema validation tests for `IgpSchema.tokenOracleConfig` (6 tests)
- [x] Schema validation tests for `GasRouterConfigSchema.feeHook` (3 tests)
- [x] `WarpRouteDeployConfigSchema` feeHook tests (2 tests)
- [x] `EvmHookReader` IGP tokenOracleConfig reader test (1 test)
- [ ] Existing Solidity tests cover contract-level behavior (`TokenRouterIgp.t.sol`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
