### PR TITLE
fix(sdk): preserve scale from deploy config in deriveTokenMetadata

### DIFF
--- a/typescript/sdk/src/token/tokenMetadataUtils.ts
+++ b/typescript/sdk/src/token/tokenMetadataUtils.ts
@@ -122,6 +122,7 @@ export async function deriveTokenMetadata(
           name,
           symbol,
           decimals,
+          ...(config.scale != null && { scale: config.scale }),
         }),
       );
     }


### PR DESCRIPTION
## Summary

Fixes `scale` being silently dropped during `deriveTokenMetadata` when the deploy config doesn't include explicit `name`/`symbol` fields.

## Root Cause

`deriveTokenMetadata` only captures `scale` from the deploy config when `isTokenMetadata(config)` returns true, which requires both `name` and `symbol` as mandatory fields. Most deploy configs omit these (they're derived from on-chain ERC20 reads). The on-chain read at line 112-126 fetches `name`, `symbol`, `decimals` but NOT `scale`, so it's lost.

This causes `verifyScale` to fail on cross-decimal routes (e.g., BSC 18-decimal USDT + 6-decimal chains) because all chains end up with `scale: undefined`.

## Fix

Include `scale` from the deploy config in the `TokenMetadataSchema.parse()` call during the on-chain ERC20 metadata read:

```typescript
TokenMetadataSchema.parse({
  name,
  symbol,
  decimals,
  ...(config.scale != null && { scale: config.scale }),
})
```

## Reproduction

```typescript
// Deploy config WITHOUT name/symbol (common) but WITH scale
const bscConfig = { decimals: 18, scale: { numerator: 1, denominator: 1e12 }, type: 'collateral', ... };
isTokenMetadata(bscConfig) // → false (no name/symbol) → scale never set
// After on-chain read: metadata has { name, symbol, decimals } but NO scale
// finalize() → "Found invalid or missing scale for inconsistent decimals"
```

## Testing

- 429 SDK unit tests passing (0 failing)
- Verified fix with manual reproduction script