### PR TITLE
fix(solidity): handle false-return ERC20 transfers for Tron routes

### DIFF
--- a/solidity/contracts/hooks/igp/InterchainGasPaymaster.sol
+++ b/solidity/contracts/hooks/igp/InterchainGasPaymaster.sol
@@ -22,6 +22,7 @@ import {IPostDispatchHook} from "../../interfaces/hooks/IPostDispatchHook.sol";
 import {AbstractPostDispatchHook} from "../libs/AbstractPostDispatchHook.sol";
 import {Indexed} from "../../libs/Indexed.sol";
 import {EnumerableDomainSet} from "../../libs/EnumerableDomainSet.sol";
+import {SafeERC20Ext} from "../../libs/SafeERC20Ext.sol";
 
 // ============ External Imports ============
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
@@ -48,6 +49,7 @@ contract InterchainGasPaymaster is
 {
     using Address for address payable;
     using SafeERC20 for IERC20;
+    using SafeERC20Ext for IERC20;
     using Message for bytes;
     using StandardHookMetadata for bytes;
     // ============ Constants ============
@@ -149,7 +151,7 @@ contract InterchainGasPaymaster is
      */
     function claimToken(address _token) external {
         uint256 _balance = IERC20(_token).balanceOf(address(this));
-        IERC20(_token).safeTransfer(beneficiary, _balance);
+        IERC20(_token).safeTransferWithBalanceCheck(beneficiary, _balance);
     }
 
     /**

--- a/solidity/contracts/libs/SafeERC20Ext.sol
+++ b/solidity/contracts/libs/SafeERC20Ext.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+/**
+ * @notice Tolerates tokens that incorrectly return `false` on a successful
+ * transfer, as long as exact balances moved.
+ */
+library SafeERC20Ext {
+    using Address for address;
+
+    function safeTransferWithBalanceCheck(
+        IERC20 token,
+        address recipient,
+        uint256 amount
+    ) internal {
+        uint256 senderBalanceBefore = token.balanceOf(address(this));
+        uint256 recipientBalanceBefore = token.balanceOf(recipient);
+
+        bytes memory returndata = address(token).functionCall(
+            abi.encodeCall(IERC20.transfer, (recipient, amount))
+        );
+
+        if (returndata.length == 0 || abi.decode(returndata, (bool))) {
+            return;
+        }
+
+        uint256 senderBalanceAfter = token.balanceOf(address(this));
+        uint256 recipientBalanceAfter = token.balanceOf(recipient);
+
+        require(
+            senderBalanceBefore >= senderBalanceAfter &&
+                senderBalanceBefore - senderBalanceAfter == amount &&
+                recipientBalanceAfter >= recipientBalanceBefore &&
+                recipientBalanceAfter - recipientBalanceBefore == amount,
+            "SafeERC20: ERC20 operation did not succeed"
+        );
+    }
+}

--- a/solidity/contracts/test/ERC20Test.sol
+++ b/solidity/contracts/test/ERC20Test.sol
@@ -309,12 +309,29 @@ contract XERC20LockboxTest is IXERC20Lockbox {
 
 contract NonCompliantERC20Test {
     // Returns returns void, instead of bool of an ERC20 compliant token
-    function approve(address _to, uint _value) public {}
+    function approve(address _to, uint256 _value) public {}
 
     function allowance(
         address owner,
         address spender
     ) public view virtual returns (uint256) {
         return 0;
+    }
+}
+
+contract FalseReturnERC20Test is ERC20Test {
+    constructor(
+        string memory name,
+        string memory symbol,
+        uint256 totalSupply,
+        uint8 __decimals
+    ) ERC20Test(name, symbol, totalSupply, __decimals) {}
+
+    function transfer(
+        address to,
+        uint256 amount
+    ) public override returns (bool) {
+        super.transfer(to, amount);
+        return false;
     }
 }

--- a/solidity/contracts/token/TokenBridgeCctpBase.sol
+++ b/solidity/contracts/token/TokenBridgeCctpBase.sol
@@ -13,6 +13,7 @@ import {TokenMessage} from "./libs/TokenMessage.sol";
 import {IPostDispatchHook} from "../interfaces/hooks/IPostDispatchHook.sol";
 import {StandardHookMetadata} from "../hooks/libs/StandardHookMetadata.sol";
 import {IMessageHandler} from "../interfaces/cctp/IMessageHandler.sol";
+import {SafeERC20Ext} from "../libs/SafeERC20Ext.sol";
 import {TypeCasts} from "../libs/TypeCasts.sol";
 import {MovableCollateralRouter, MovableCollateralRouterStorage} from "./libs/MovableCollateralRouter.sol";
 import {TokenRouter} from "./libs/TokenRouter.sol";
@@ -51,6 +52,7 @@ abstract contract TokenBridgeCctpBase is
     using Message for bytes;
     using TypeCasts for bytes32;
     using SafeERC20 for IERC20;
+    using SafeERC20Ext for IERC20;
 
     // using custom errors for bytecode size limitations
     // end users will not see these in their wallet (at config and process time)
@@ -104,12 +106,14 @@ abstract contract TokenBridgeCctpBase is
         IMessageTransmitter _messageTransmitter,
         ITokenMessenger _tokenMessenger
     ) TokenRouter(_SCALE, _SCALE, _mailbox) {
-        if (_messageTransmitter.version() != _getCCTPVersion())
+        if (_messageTransmitter.version() != _getCCTPVersion()) {
             revert InvalidCCTPVersion();
+        }
         messageTransmitter = _messageTransmitter;
 
-        if (_tokenMessenger.messageBodyVersion() != _getCCTPVersion())
+        if (_tokenMessenger.messageBodyVersion() != _getCCTPVersion()) {
             revert InvalidCCTPVersion();
+        }
         tokenMessenger = _tokenMessenger;
 
         wrappedToken = IERC20(_erc20);
@@ -221,8 +225,9 @@ abstract contract TokenBridgeCctpBase is
         uint32 _hyperlaneDomain
     ) public view returns (uint32) {
         Domain memory domain = _hyperlaneDomainMap[_hyperlaneDomain];
-        if (domain.hyperlane != _hyperlaneDomain)
+        if (domain.hyperlane != _hyperlaneDomain) {
             revert CircleDomainNotConfigured();
+        }
 
         return domain.circle;
     }
@@ -231,8 +236,9 @@ abstract contract TokenBridgeCctpBase is
         uint32 _circleDomain
     ) public view returns (uint32) {
         Domain memory domain = _circleDomainMap[_circleDomain];
-        if (domain.circle != _circleDomain)
+        if (domain.circle != _circleDomain) {
             revert HyperlaneDomainNotConfigured();
+        }
 
         return domain.hyperlane;
     }
@@ -283,8 +289,9 @@ abstract contract TokenBridgeCctpBase is
         if (circleRecipient == address(tokenMessenger)) {
             // prevent hyperlane message recipient configured with CCTP ISM
             // from verifying and handling token messages
-            if (_hyperlaneMessage.recipientAddress() != address(this))
+            if (_hyperlaneMessage.recipientAddress() != address(this)) {
                 revert InvalidTokenMessageRecipient();
+            }
             _validateTokenMessage(_hyperlaneMessage, cctpMessage);
         }
         // check if CCTP message is a GMP message to this contract
@@ -306,13 +313,15 @@ abstract contract TokenBridgeCctpBase is
         bytes32 circleSender,
         bytes32 messageId
     ) internal returns (bool) {
-        if (msg.sender != address(messageTransmitter))
+        if (msg.sender != address(messageTransmitter)) {
             revert NotMessageTransmitter();
+        }
 
         // ensure that the message was sent from the hook on the origin chain
         uint32 origin = circleDomainToHyperlaneDomain(circleSource);
-        if (_mustHaveRemoteRouter(origin) != circleSender)
+        if (_mustHaveRemoteRouter(origin) != circleSender) {
             revert UnauthorizedCircleSender();
+        }
 
         isVerified[messageId] = true;
 
@@ -332,7 +341,8 @@ abstract contract TokenBridgeCctpBase is
 
     /// @inheritdoc AbstractPostDispatchHook
     function _quoteDispatch(
-        bytes calldata /*metadata*/,
+        bytes calldata,
+        /*metadata*/
         bytes calldata /*message*/
     ) internal pure override returns (uint256) {
         return 0;
@@ -384,7 +394,7 @@ abstract contract TokenBridgeCctpBase is
         address _recipient,
         uint256 _amount
     ) internal override {
-        wrappedToken.safeTransfer(_recipient, _amount);
+        wrappedToken.safeTransferWithBalanceCheck(_recipient, _amount);
     }
 
     function _bridgeViaCircle(

--- a/solidity/contracts/token/fees/BaseFee.sol
+++ b/solidity/contracts/token/fees/BaseFee.sol
@@ -2,11 +2,11 @@
 pragma solidity >=0.8.0;
 
 import {ITokenFee, Quote} from "../../interfaces/ITokenBridge.sol";
+import {PackageVersioned} from "../../PackageVersioned.sol";
+import {SafeERC20Ext} from "../../libs/SafeERC20Ext.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
-import {PackageVersioned} from "../../PackageVersioned.sol";
 
 enum FeeType {
     ZERO,
@@ -18,7 +18,7 @@ enum FeeType {
 
 abstract contract BaseFee is Ownable, ITokenFee, PackageVersioned {
     using Address for address payable;
-    using SafeERC20 for IERC20;
+    using SafeERC20Ext for IERC20;
 
     /**
      * @notice The ERC20 token for which this fee contract applies.
@@ -58,13 +58,15 @@ abstract contract BaseFee is Ownable, ITokenFee, PackageVersioned {
             payable(beneficiary).sendValue(address(this).balance);
         } else {
             uint256 balance = token.balanceOf(address(this));
-            token.safeTransfer(beneficiary, balance);
+            token.safeTransferWithBalanceCheck(beneficiary, balance);
         }
     }
 
     function quoteTransferRemote(
-        uint32 /*_destination*/,
-        bytes32 /*_recipient*/,
+        uint32,
+        /*_destination*/
+        bytes32,
+        /*_recipient*/
         uint256 _amount
     ) external view virtual returns (Quote[] memory quotes) {
         quotes = new Quote[](1);

--- a/solidity/contracts/token/libs/TokenCollateral.sol
+++ b/solidity/contracts/token/libs/TokenCollateral.sol
@@ -8,6 +8,7 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {SafeERC20Ext} from "../../libs/SafeERC20Ext.sol";
 
 /**
  * @title Handles deposits and withdrawals of native token collateral.
@@ -47,6 +48,7 @@ library WETHCollateral {
  */
 library ERC20Collateral {
     using SafeERC20 for IERC20;
+    using SafeERC20Ext for IERC20;
 
     function _transferFromSender(IERC20 token, uint256 _amount) internal {
         token.safeTransferFrom(msg.sender, address(this), _amount);
@@ -57,7 +59,7 @@ library ERC20Collateral {
         address _recipient,
         uint256 _amount
     ) internal {
-        token.safeTransfer(_recipient, _amount);
+        token.safeTransferWithBalanceCheck(_recipient, _amount);
     }
 }
 

--- a/solidity/test/token/Fees.t.sol
+++ b/solidity/test/token/Fees.t.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 import {Test} from "forge-std/Test.sol";
-import {ERC20Test} from "../../contracts/test/ERC20Test.sol";
+import {ERC20Test, FalseReturnERC20Test} from "../../contracts/test/ERC20Test.sol";
 
 import {BaseFee, FeeType} from "../../contracts/token/fees/BaseFee.sol";
 import {LinearFee} from "../../contracts/token/fees/LinearFee.sol";
@@ -69,7 +69,7 @@ contract LinearFeeTest is BaseFeeTest {
     }
 
     function test_LinearFee_Type() public {
-        assertEq(uint(feeContract.feeType()), uint(FeeType.LINEAR));
+        assertEq(uint256(feeContract.feeType()), uint256(FeeType.LINEAR));
     }
 
     function test_LinearFee_Quote(
@@ -125,6 +125,30 @@ contract LinearFeeTest is BaseFeeTest {
     }
 }
 
+contract LinearFeeFalseReturnClaimTest is Test {
+    address internal constant OWNER = address(0x123);
+    address internal constant BENEFICIARY = address(0x456);
+
+    FalseReturnERC20Test internal token;
+    LinearFee internal feeContract;
+
+    function setUp() public {
+        token = new FalseReturnERC20Test("Test Token", "TST", 0, 18);
+        feeContract = new LinearFee(address(token), 1000, 10000, OWNER);
+    }
+
+    function test_Claim_falseReturnTransferSucceeds() public {
+        uint256 amount = 100e18;
+        token.mintTo(address(feeContract), amount);
+
+        vm.prank(OWNER);
+        feeContract.claim(BENEFICIARY);
+
+        assertEq(token.balanceOf(BENEFICIARY), amount);
+        assertEq(token.balanceOf(address(feeContract)), 0);
+    }
+}
+
 // --- ProgressiveFee Tests ---
 
 contract ProgressiveFeeTest is BaseFeeTest {
@@ -142,7 +166,7 @@ contract ProgressiveFeeTest is BaseFeeTest {
     }
 
     function test_ProgressiveFee_Type() public {
-        assertEq(uint(feeContract.feeType()), uint(FeeType.PROGRESSIVE));
+        assertEq(uint256(feeContract.feeType()), uint256(FeeType.PROGRESSIVE));
     }
 
     function test_ProgressiveFee_Quote(
@@ -271,7 +295,7 @@ contract RegressiveFeeTest is BaseFeeTest {
     }
 
     function test_RegressiveFee_Type() public {
-        assertEq(uint(feeContract.feeType()), uint(FeeType.REGRESSIVE));
+        assertEq(uint256(feeContract.feeType()), uint256(FeeType.REGRESSIVE));
     }
 
     function test_RegressiveFee_Quote(
@@ -354,7 +378,7 @@ contract RoutingFeeTest is BaseFeeTest {
     }
 
     function test_RoutingFee_Type() public {
-        assertEq(uint(routingFee.feeType()), uint(FeeType.ROUTING));
+        assertEq(uint256(routingFee.feeType()), uint256(FeeType.ROUTING));
     }
 
     function test_Quote_NoFeeContract() public {

--- a/solidity/test/token/HypERC20.t.sol
+++ b/solidity/test/token/HypERC20.t.sol
@@ -19,7 +19,7 @@ import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transpa
 import {Mailbox} from "../../contracts/Mailbox.sol";
 import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
 import {MockMailbox} from "../../contracts/mock/MockMailbox.sol";
-import {XERC20LockboxTest, XERC20Test, FiatTokenTest, ERC20Test} from "../../contracts/test/ERC20Test.sol";
+import {XERC20LockboxTest, XERC20Test, FiatTokenTest, ERC20Test, FalseReturnERC20Test} from "../../contracts/test/ERC20Test.sol";
 import {TestPostDispatchHook} from "../../contracts/test/TestPostDispatchHook.sol";
 import {TestInterchainGasPaymaster} from "../../contracts/test/TestInterchainGasPaymaster.sol";
 import {GasRouter} from "../../contracts/client/GasRouter.sol";
@@ -510,6 +510,58 @@ contract HypERC20CollateralTest is HypTokenTest {
             GAS_LIMIT * igp.gasPrice()
         );
         assertEq(_localTokenBalanceOf(ALICE), balanceBefore - TRANSFER_AMT);
+    }
+}
+
+contract HypERC20CollateralFalseReturnTransferTest is HypTokenTest {
+    using TypeCasts for address;
+
+    HypERC20Collateral internal erc20Collateral;
+
+    function setUp() public override {
+        super.setUp();
+
+        primaryToken = new FalseReturnERC20Test(
+            NAME,
+            SYMBOL,
+            TOTAL_SUPPLY,
+            DECIMALS
+        );
+
+        localToken = new HypERC20Collateral(
+            address(primaryToken),
+            SCALE,
+            SCALE,
+            address(localMailbox)
+        );
+        erc20Collateral = HypERC20Collateral(address(localToken));
+
+        erc20Collateral.enrollRemoteRouter(
+            DESTINATION,
+            address(remoteToken).addressToBytes32()
+        );
+
+        primaryToken.transfer(address(localToken), 1000e18);
+        primaryToken.transfer(ALICE, 1000e18);
+
+        _enrollRemoteTokenRouter();
+    }
+
+    function _localTokenBalanceOf(
+        address _account
+    ) internal view override returns (uint256) {
+        return ERC20Test(primaryToken).balanceOf(_account);
+    }
+
+    function testHandle_falseReturnTransferSucceeds() public {
+        uint256 aliceBalanceBefore = _localTokenBalanceOf(ALICE);
+
+        _handleLocalTransfer(TRANSFER_AMT);
+
+        assertEq(
+            _localTokenBalanceOf(ALICE),
+            aliceBalanceBefore + TRANSFER_AMT
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

This fixes Tron USDT-style collateral routes where `transfer()` can succeed while returning `false`, causing OpenZeppelin `SafeERC20.safeTransfer` to revert.

That behavior was blocking:

- `Tron -> X` fee-bearing sends, because `_transferFee` eventually used `safeTransfer`
- `X -> Tron` deliveries, because inbound collateral release used `safeTransfer`

## What changed

- Added `SafeERC20Ext.safeTransferWithBalanceCheck`, which only tolerates a `false` return if exact sender/recipient balance deltas prove the transfer succeeded
- Swapped the affected outgoing transfer sites to that helper:
  - collateral release
  - fee contract claims
  - IGP token claims
  - CCTP fee payouts
- Added a `FalseReturnERC20Test` mock plus regression tests for:
  - inbound collateral delivery
  - fee-bearing collateral sends
  - fee contract claims

## Why this shape

I did not make this a blanket "ignore false" change.

The helper still reverts unless:

- router balance decreases by exactly `amount`
- recipient balance increases by exactly `amount`

So this stays incompatible with fee-on-transfer tokens, which is intentional.

## Testing

```bash
forge test --match-contract HypERC20CollateralFalseReturnTransferTest -vv
forge test --match-contract LinearFeeFalseReturnClaimTest -vv
forge test --match-contract HypERC20CollateralTest --match-test testRemoteTransfer_withFee -vv
```

## Investigation references

- Consolidated summary gist:
  https://gist.github.com/paulbalaji/5a8ad4d7bec4efdd8eb8ab34f6855eb4
- Outbound fee-path investigation:
  https://gist.github.com/paulbalaji/ed621bb1f6ff761245a6597353635898
- Token behavior investigation:
  https://gist.github.com/yorhodes/a6eccbeba27ff76355c3d761e84d6a35
- Inbound delivery investigation:
  https://gist.github.com/Xaroz/a92c19dd9a873c26ead71dd78bcc7d5a
- Affected warp config:
  https://gist.github.com/Xaroz/380067ae0ae8299608d42f884ddeb6aa

## Concrete examples

- Reverting fee-bearing Tron tx:
  https://tronscan.org/#/transaction/e917e8516bf77dcdc48eb3ca194239acbb5bc01c0f52d7eb86a5c23535a0a7f8/internal-transactions
- Successful Tron tx after removing `feeRecipient`:
  https://tronscan.org/#/transaction/5384f8d7ee9ece37aa83aeda64cd1c220fc5ce57bc174f0d1d3bc0a9a511f4a4/internal-transactions
- Successful message after removing `feeRecipient`:
  https://explorer.hyperlane.xyz/message/0x172e01037d091f37aeff619513378aa09c8674462cc4d17b68716d535d046505
- Stuck `Arbitrum -> Tron` message:
  https://explorer.hyperlane.xyz/message/0xb54ab054b55a9ec0ebb2f6918cadf2852e857d8e771de3887d6e543e65beb668
- Stuck `BSC -> Tron` message:
  https://explorer.hyperlane.xyz/message/0x54227aa154b73ed4b0911bb6126fff26e08176c249afdd52962c49f717ffa142

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple token-transfer paths (collateral withdrawals, fee payouts, IGP claims, CCTP fee transfers) to support non-standard ERC20s; mistakes could block transfers or incorrectly accept partial transfers for unusual tokens.
> 
> **Overview**
> Adds `SafeERC20Ext.safeTransferWithBalanceCheck`, a transfer helper that tolerates ERC20s returning `false` *only if* sender/recipient balance deltas prove the exact `amount` moved.
> 
> Updates several payout/withdrawal sites (`TokenCollateral` ERC20 releases, `BaseFee.claim`, `InterchainGasPaymaster.claimToken`, and `TokenBridgeCctpBase._transferFee`) to use this helper instead of OpenZeppelin `SafeERC20.safeTransfer`, and adds a `FalseReturnERC20Test` plus regression tests covering fee claims and inbound collateral delivery.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1aa6dc2d4c01691e794566e536199ea7a62be87c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->