### PR TITLE
feat(warp-monitor): support Solana routers and protocol inventory

### DIFF
--- a/typescript/warp-monitor/src/monitor.test.ts
+++ b/typescript/warp-monitor/src/monitor.test.ts
@@ -612,7 +612,7 @@ describe('WarpMonitor', () => {
       'CROSS/ctusd',
       pendingTransfersClient as ExplorerPendingTransfersClient,
       200,
-      '0xEA2117b24F7947647Bec60527B68f4244AE40c01',
+      '  0xEA2117b24F7947647Bec60527B68f4244AE40c01  ',
     );
 
     expect(calls).to.deep.equal([

--- a/typescript/warp-monitor/src/monitor.test.ts
+++ b/typescript/warp-monitor/src/monitor.test.ts
@@ -277,6 +277,71 @@ describe('WarpMonitor', () => {
     );
   });
 
+  it('skips Ethereum nodes with malformed router addresses', () => {
+    const monitor = new WarpMonitor(
+      {
+        warpRouteId: 'CROSS/ctusd',
+        checkFrequency: 10_000,
+      },
+      {} as IRegistry,
+    );
+
+    const nodes = invokeBuildRouterNodes(
+      monitor,
+      {
+        tokens: [
+          {
+            symbol: 'USDC',
+            chainName: 'ethereum',
+            addressOrDenom: 'not-an-evm-address',
+            collateralAddressOrDenom:
+              '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+            decimals: 6,
+            name: 'USD Coin',
+            protocol: ProtocolType.Ethereum,
+          } as Token,
+        ],
+      } as WarpCore,
+      {
+        ethereum: { domainId: 1 },
+      },
+    );
+
+    expect(nodes).to.have.length(0);
+  });
+
+  it('skips Ethereum nodes with malformed collateral addresses', () => {
+    const monitor = new WarpMonitor(
+      {
+        warpRouteId: 'CROSS/ctusd',
+        checkFrequency: 10_000,
+      },
+      {} as IRegistry,
+    );
+
+    const nodes = invokeBuildRouterNodes(
+      monitor,
+      {
+        tokens: [
+          {
+            symbol: 'USDC',
+            chainName: 'ethereum',
+            addressOrDenom: '0xd4463cB3c90b3F49c673310BEC9bC18311134B47',
+            collateralAddressOrDenom: 'not-an-evm-address',
+            decimals: 6,
+            name: 'USD Coin',
+            protocol: ProtocolType.Ethereum,
+          } as Token,
+        ],
+      } as WarpCore,
+      {
+        ethereum: { domainId: 1 },
+      },
+    );
+
+    expect(nodes).to.have.length(0);
+  });
+
   it('excludes Solana router nodes from explorer queries', () => {
     const monitor = new WarpMonitor(
       {

--- a/typescript/warp-monitor/src/monitor.test.ts
+++ b/typescript/warp-monitor/src/monitor.test.ts
@@ -20,12 +20,15 @@ function createMockToken({
   collateralized,
   decimals,
   getBalance = async () => 0n,
+  protocol = ProtocolType.Ethereum,
 }: {
   collateralized: boolean;
   decimals: number;
-  getBalance?: () => Promise<bigint>;
+  getBalance?: (address: string) => Promise<bigint>;
+  protocol?: ProtocolType;
 }): Token {
   return {
+    protocol,
     isCollateralized: () => collateralized,
     amount: ((amount: bigint) => ({
       getDecimalFormattedAmount: () => Number(amount) / 10 ** decimals,
@@ -82,8 +85,22 @@ function invokeBuildRouterNodes(
   return buildRouterNodes.call(monitor, warpCore, chainMetadata);
 }
 
+function invokeBuildExplorerRouterNodes(
+  monitor: WarpMonitor,
+  routerNodes: RouterNodeMetadata[],
+): RouterNodeMetadata[] {
+  const buildExplorerRouterNodes = (monitor as any)
+    .buildExplorerRouterNodes as (
+    routerNodes: RouterNodeMetadata[],
+  ) => RouterNodeMetadata[];
+
+  return buildExplorerRouterNodes.call(monitor, routerNodes);
+}
+
 describe('WarpMonitor', () => {
   afterEach(() => {
+    delete process.env.INVENTORY_ADDRESS_ETHEREUM;
+    delete process.env.INVENTORY_ADDRESS_SEALEVEL;
     resetPendingDestinationMetrics();
     resetInventoryBalanceMetrics();
   });
@@ -260,6 +277,62 @@ describe('WarpMonitor', () => {
     );
   });
 
+  it('excludes Solana router nodes from explorer queries', () => {
+    const monitor = new WarpMonitor(
+      {
+        warpRouteId: 'CROSS/ctusd',
+        checkFrequency: 10_000,
+        explorerApiUrl: 'https://explorer.example/graphql',
+      },
+      {} as IRegistry,
+    );
+
+    const evmNodeId = 'USDC|base|0x1234567890123456789012345678901234567890';
+    const sealevelNodeId =
+      'USDC|solanamainnet|SolRouter1111111111111111111111111111111';
+    const routerNodes: RouterNodeMetadata[] = [
+      {
+        nodeId: evmNodeId,
+        chainName: 'base' as RouterNodeMetadata['chainName'],
+        domainId: 8453,
+        routerAddress: '0x1234567890123456789012345678901234567890',
+        tokenAddress: '0xabcdef1234567890123456789012345678901234',
+        tokenName: 'USD Coin',
+        tokenSymbol: 'USDC',
+        tokenDecimals: 6,
+        token: createMockToken({
+          collateralized: true,
+          decimals: 6,
+          protocol: ProtocolType.Ethereum,
+        }),
+      },
+      {
+        nodeId: sealevelNodeId,
+        chainName: 'solanamainnet' as RouterNodeMetadata['chainName'],
+        domainId: 1399811149,
+        routerAddress: 'SolRouter1111111111111111111111111111111',
+        tokenAddress: 'SolMint1111111111111111111111111111111111',
+        tokenName: 'USD Coin',
+        tokenSymbol: 'USDC',
+        tokenDecimals: 6,
+        token: createMockToken({
+          collateralized: true,
+          decimals: 6,
+          protocol: ProtocolType.Sealevel,
+        }),
+      },
+    ];
+
+    const explorerRouterNodes = invokeBuildExplorerRouterNodes(
+      monitor,
+      routerNodes,
+    );
+
+    expect(explorerRouterNodes.map((node) => node.nodeId)).to.deep.equal([
+      evmNodeId,
+    ]);
+  });
+
   it('does not emit inventory metrics when balance read fails', async () => {
     const monitor = new WarpMonitor(
       {
@@ -319,6 +392,167 @@ describe('WarpMonitor', () => {
     expect(
       inventoryLines.some((line) => line.includes(`node_id="${nodeId}"`)),
     ).to.equal(false);
+  });
+
+  it('uses protocol-specific inventory addresses when configured', async () => {
+    process.env.INVENTORY_ADDRESS_ETHEREUM =
+      '0xEA2117b24F7947647Bec60527B68f4244AE40c01';
+    process.env.INVENTORY_ADDRESS_SEALEVEL =
+      'EqC3NZkibWavWcT6HnU8tz4jiFxTEayKQyEPz3KZU4uc';
+
+    const monitor = new WarpMonitor(
+      {
+        warpRouteId: 'CROSS/ctusd',
+        checkFrequency: 10_000,
+      },
+      {} as IRegistry,
+    );
+
+    const evmNodeId = 'USDC|base|0xroutera';
+    const sealevelNodeId =
+      'USDC|solanamainnet|SolRouter1111111111111111111111111111111';
+    const calls: string[] = [];
+    const routerNodes: RouterNodeMetadata[] = [
+      {
+        nodeId: evmNodeId,
+        chainName: 'base' as RouterNodeMetadata['chainName'],
+        domainId: 8453,
+        routerAddress: '0xroutera',
+        tokenAddress: '0xtokena',
+        tokenName: 'USD Coin',
+        tokenSymbol: 'USDC',
+        tokenDecimals: 6,
+        token: createMockToken({
+          collateralized: true,
+          decimals: 6,
+          getBalance: async (address: string) => {
+            calls.push(address);
+            return 2_000_000n;
+          },
+        }),
+      },
+      {
+        nodeId: sealevelNodeId,
+        chainName: 'solanamainnet' as RouterNodeMetadata['chainName'],
+        domainId: 1399811149,
+        routerAddress: 'SolRouter1111111111111111111111111111111',
+        tokenAddress: 'SolMint1111111111111111111111111111111111',
+        tokenName: 'USD Coin',
+        tokenSymbol: 'USDC',
+        tokenDecimals: 6,
+        token: createMockToken({
+          collateralized: true,
+          decimals: 6,
+          protocol: ProtocolType.Sealevel,
+          getBalance: async (address: string) => {
+            calls.push(address);
+            return 3_000_000n;
+          },
+        }),
+      },
+    ];
+
+    const pendingTransfersClient: Pick<
+      ExplorerPendingTransfersClient,
+      'getPendingDestinationTransfers'
+    > = {
+      async getPendingDestinationTransfers() {
+        return [] as PendingDestinationTransfer[];
+      },
+    };
+
+    await invokeUpdatePendingAndInventoryMetrics(
+      monitor,
+      { multiProvider: {} } as WarpCore,
+      routerNodes,
+      new Map(),
+      'CROSS/ctusd',
+      pendingTransfersClient as ExplorerPendingTransfersClient,
+      200,
+    );
+
+    expect(calls).to.deep.equal([
+      '0xEA2117b24F7947647Bec60527B68f4244AE40c01',
+      'EqC3NZkibWavWcT6HnU8tz4jiFxTEayKQyEPz3KZU4uc',
+    ]);
+  });
+
+  it('does not use the global inventory address for Sealevel nodes', async () => {
+    const monitor = new WarpMonitor(
+      {
+        warpRouteId: 'CROSS/ctusd',
+        checkFrequency: 10_000,
+      },
+      {} as IRegistry,
+    );
+
+    const evmNodeId = 'USDC|base|0xroutera';
+    const sealevelNodeId =
+      'USDC|solanamainnet|SolRouter1111111111111111111111111111111';
+    const calls: string[] = [];
+    const routerNodes: RouterNodeMetadata[] = [
+      {
+        nodeId: evmNodeId,
+        chainName: 'base' as RouterNodeMetadata['chainName'],
+        domainId: 8453,
+        routerAddress: '0xroutera',
+        tokenAddress: '0xtokena',
+        tokenName: 'USD Coin',
+        tokenSymbol: 'USDC',
+        tokenDecimals: 6,
+        token: createMockToken({
+          collateralized: true,
+          decimals: 6,
+          getBalance: async (address: string) => {
+            calls.push(`evm:${address}`);
+            return 2_000_000n;
+          },
+        }),
+      },
+      {
+        nodeId: sealevelNodeId,
+        chainName: 'solanamainnet' as RouterNodeMetadata['chainName'],
+        domainId: 1399811149,
+        routerAddress: 'SolRouter1111111111111111111111111111111',
+        tokenAddress: 'SolMint1111111111111111111111111111111111',
+        tokenName: 'USD Coin',
+        tokenSymbol: 'USDC',
+        tokenDecimals: 6,
+        token: createMockToken({
+          collateralized: true,
+          decimals: 6,
+          protocol: ProtocolType.Sealevel,
+          getBalance: async (address: string) => {
+            calls.push(`sealevel:${address}`);
+            return 3_000_000n;
+          },
+        }),
+      },
+    ];
+
+    const pendingTransfersClient: Pick<
+      ExplorerPendingTransfersClient,
+      'getPendingDestinationTransfers'
+    > = {
+      async getPendingDestinationTransfers() {
+        return [] as PendingDestinationTransfer[];
+      },
+    };
+
+    await invokeUpdatePendingAndInventoryMetrics(
+      monitor,
+      { multiProvider: {} } as WarpCore,
+      routerNodes,
+      new Map(),
+      'CROSS/ctusd',
+      pendingTransfersClient as ExplorerPendingTransfersClient,
+      200,
+      '0xEA2117b24F7947647Bec60527B68f4244AE40c01',
+    );
+
+    expect(calls).to.deep.equal([
+      'evm:0xEA2117b24F7947647Bec60527B68f4244AE40c01',
+    ]);
   });
 
   it('resets pending metrics and still updates inventory when explorer query fails', async () => {

--- a/typescript/warp-monitor/src/monitor.test.ts
+++ b/typescript/warp-monitor/src/monitor.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import type { IRegistry } from '@hyperlane-xyz/registry';
 import type { Token, WarpCore } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
 import type {
   PendingDestinationTransfer,
   RouterNodeMetadata,
@@ -66,6 +67,19 @@ async function invokeUpdatePendingAndInventoryMetrics(
     explorerQueryLimit,
     inventoryAddress,
   );
+}
+
+function invokeBuildRouterNodes(
+  monitor: WarpMonitor,
+  warpCore: WarpCore,
+  chainMetadata: Record<string, { domainId: number }>,
+): RouterNodeMetadata[] {
+  const buildRouterNodes = (monitor as any).buildRouterNodes as (
+    warpCore: WarpCore,
+    chainMetadata: Record<string, { domainId: number }>,
+  ) => RouterNodeMetadata[];
+
+  return buildRouterNodes.call(monitor, warpCore, chainMetadata);
 }
 
 describe('WarpMonitor', () => {
@@ -192,6 +206,58 @@ describe('WarpMonitor', () => {
         line.includes(`node_id="${nonCollateralizedNodeId}"`),
       ),
     ).to.equal(false);
+  });
+
+  it('includes Solana cross-collateral nodes without lowercasing base58 addresses', () => {
+    const monitor = new WarpMonitor(
+      {
+        warpRouteId: 'CROSS/ctusd',
+        checkFrequency: 10_000,
+      },
+      {} as IRegistry,
+    );
+
+    const evmToken = {
+      symbol: 'USDC',
+      chainName: 'ethereum',
+      addressOrDenom: '0xd4463cB3c90b3F49c673310BEC9bC18311134B47',
+      collateralAddressOrDenom: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      decimals: 6,
+      name: 'USD Coin',
+      protocol: ProtocolType.Ethereum,
+    } as Token;
+    const solanaToken = {
+      symbol: 'USDC',
+      chainName: 'solanamainnet',
+      addressOrDenom: 'HxwQM6D6FpqZJkemVKyhQpD2k8cHefg1PG4iWH5aXdrr',
+      collateralAddressOrDenom: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      decimals: 6,
+      name: 'USD Coin',
+      protocol: ProtocolType.Sealevel,
+    } as Token;
+
+    const nodes = invokeBuildRouterNodes(
+      monitor,
+      { tokens: [evmToken, solanaToken] } as WarpCore,
+      {
+        ethereum: { domainId: 1 },
+        solanamainnet: { domainId: 1399811149 },
+      },
+    );
+
+    expect(nodes).to.have.length(2);
+    expect(nodes.map((node) => node.nodeId)).to.include(
+      'USDC|solanamainnet|HxwQM6D6FpqZJkemVKyhQpD2k8cHefg1PG4iWH5aXdrr',
+    );
+    expect(nodes.map((node) => node.routerAddress)).to.include(
+      'HxwQM6D6FpqZJkemVKyhQpD2k8cHefg1PG4iWH5aXdrr',
+    );
+    expect(nodes.map((node) => node.tokenAddress)).to.include(
+      'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    );
+    expect(nodes.map((node) => node.routerAddress)).to.include(
+      '0xd4463cb3c90b3f49c673310bec9bc18311134b47',
+    );
   });
 
   it('does not emit inventory metrics when balance read fails', async () => {

--- a/typescript/warp-monitor/src/monitor.ts
+++ b/typescript/warp-monitor/src/monitor.ts
@@ -123,8 +123,13 @@ export class WarpMonitor {
     const warpDeployConfig =
       await this.registry.getWarpDeployConfig(warpRouteId);
     const routerNodes = this.buildRouterNodes(warpCore, chainMetadata);
+    const explorerRouterNodes = this.buildExplorerRouterNodes(routerNodes);
     const pendingTransfersClient = explorerApiUrl
-      ? new ExplorerPendingTransfersClient(explorerApiUrl, routerNodes, logger)
+      ? new ExplorerPendingTransfersClient(
+          explorerApiUrl,
+          explorerRouterNodes,
+          logger,
+        )
       : undefined;
 
     logger.info(
@@ -134,8 +139,11 @@ export class WarpMonitor {
         tokenCount: warpCore.tokens.length,
         chains: warpCore.getTokenChains(),
         crossCollateralNodeCount: routerNodes.length,
+        explorerNodeCount: explorerRouterNodes.length,
         explorerEnabled: !!pendingTransfersClient,
-        inventoryTrackingEnabled: !!inventoryAddress,
+        inventoryTrackingEnabled: routerNodes.some((node) =>
+          this.getConfiguredInventoryAddress(node, inventoryAddress),
+        ),
       },
       'Starting warp route monitor',
     );
@@ -351,13 +359,18 @@ export class WarpMonitor {
       );
     }
 
-    if (!inventoryAddress) return;
-
     await Promise.all(
       routerNodes.map(async (node) => {
+        const configuredInventoryAddress = this.getConfiguredInventoryAddress(
+          node,
+          inventoryAddress,
+        );
+        if (!configuredInventoryAddress) return;
         try {
           const adapter = node.token.getAdapter(warpCore.multiProvider);
-          const inventoryBalance = await adapter.getBalance(inventoryAddress);
+          const inventoryBalance = await adapter.getBalance(
+            configuredInventoryAddress,
+          );
 
           updateInventoryBalanceMetrics({
             warpRouteId,
@@ -367,7 +380,7 @@ export class WarpMonitor {
             tokenAddress: node.tokenAddress,
             tokenSymbol: node.tokenSymbol,
             tokenName: node.tokenName,
-            inventoryAddress,
+            inventoryAddress: configuredInventoryAddress,
             inventoryBalance: this.formatTokenAmount(
               node.token,
               inventoryBalance,
@@ -383,6 +396,24 @@ export class WarpMonitor {
         }
       }),
     );
+  }
+
+  private getConfiguredInventoryAddress(
+    node: RouterNodeMetadata,
+    inventoryAddress?: string,
+  ): string | undefined {
+    const protocolInventoryAddress =
+      process.env[
+        `INVENTORY_ADDRESS_${node.token.protocol.toUpperCase()}`
+      ]?.trim();
+
+    if (protocolInventoryAddress) {
+      return protocolInventoryAddress;
+    }
+
+    return node.token.protocol === ProtocolType.Ethereum
+      ? inventoryAddress
+      : undefined;
   }
 
   // Updates the metrics for a single token in a warp route.
@@ -598,6 +629,16 @@ export class WarpMonitor {
     }
 
     return [...nodeByKey.values()];
+  }
+
+  private buildExplorerRouterNodes(
+    routerNodes: RouterNodeMetadata[],
+  ): RouterNodeMetadata[] {
+    return routerNodes.filter(
+      (node) =>
+        node.token.protocol === ProtocolType.Ethereum &&
+        ethersUtils.isAddress(node.routerAddress),
+    );
   }
 
   private buildNodeId(token: Token): string {

--- a/typescript/warp-monitor/src/monitor.ts
+++ b/typescript/warp-monitor/src/monitor.ts
@@ -411,8 +411,13 @@ export class WarpMonitor {
       return protocolInventoryAddress;
     }
 
-    return node.token.protocol === ProtocolType.Ethereum
-      ? inventoryAddress
+    if (node.token.protocol !== ProtocolType.Ethereum) {
+      return undefined;
+    }
+
+    const fallbackInventoryAddress = inventoryAddress?.trim();
+    return fallbackInventoryAddress && fallbackInventoryAddress.length > 0
+      ? fallbackInventoryAddress
       : undefined;
   }
 

--- a/typescript/warp-monitor/src/monitor.ts
+++ b/typescript/warp-monitor/src/monitor.ts
@@ -577,12 +577,9 @@ export class WarpMonitor {
         continue;
       }
       const metadata = chainMetadata[token.chainName];
-      if (!ethersUtils.isAddress(token.addressOrDenom)) continue;
 
       const domainId = metadata.domainId;
-      const routerAddress = ethersUtils
-        .getAddress(token.addressOrDenom)
-        .toLowerCase();
+      const routerAddress = this.normalizeNodeAddress(token);
       const key = `${domainId}:${routerAddress}`;
       if (nodeByKey.has(key)) continue;
 
@@ -591,9 +588,7 @@ export class WarpMonitor {
         chainName: token.chainName,
         domainId,
         routerAddress,
-        tokenAddress: (
-          token.collateralAddressOrDenom ?? token.addressOrDenom
-        ).toLowerCase(),
+        tokenAddress: this.normalizeTokenAddress(token),
         tokenName: token.name,
         tokenSymbol: token.symbol,
         tokenDecimals: token.decimals,
@@ -606,7 +601,24 @@ export class WarpMonitor {
   }
 
   private buildNodeId(token: Token): string {
-    return `${token.symbol}|${token.chainName}|${token.addressOrDenom.toLowerCase()}`;
+    return `${token.symbol}|${token.chainName}|${this.normalizeNodeAddress(token)}`;
+  }
+
+  private normalizeNodeAddress(token: Token): string {
+    if (token.protocol === ProtocolType.Ethereum) {
+      return ethersUtils.getAddress(token.addressOrDenom).toLowerCase();
+    }
+
+    return token.addressOrDenom;
+  }
+
+  private normalizeTokenAddress(token: Token): string {
+    const address = token.collateralAddressOrDenom ?? token.addressOrDenom;
+    if (token.protocol === ProtocolType.Ethereum) {
+      return ethersUtils.getAddress(address).toLowerCase();
+    }
+
+    return address;
   }
 
   private formatTokenAmount(token: Token, amount: bigint): number {

--- a/typescript/warp-monitor/src/monitor.ts
+++ b/typescript/warp-monitor/src/monitor.ts
@@ -608,6 +608,16 @@ export class WarpMonitor {
         continue;
       }
       const metadata = chainMetadata[token.chainName];
+      if (token.protocol === ProtocolType.Ethereum) {
+        const tokenAddress =
+          token.collateralAddressOrDenom ?? token.addressOrDenom;
+        if (
+          !ethersUtils.isAddress(token.addressOrDenom) ||
+          !ethersUtils.isAddress(tokenAddress)
+        ) {
+          continue;
+        }
+      }
 
       const domainId = metadata.domainId;
       const routerAddress = this.normalizeNodeAddress(token);

--- a/typescript/warp-monitor/src/service.ts
+++ b/typescript/warp-monitor/src/service.ts
@@ -54,11 +54,7 @@ async function main(): Promise<void> {
 
   const coingeckoApiKey = process.env.COINGECKO_API_KEY;
   const explorerApiUrl = process.env.EXPLORER_API_URL;
-  const trimmedInventoryAddress = process.env.INVENTORY_ADDRESS?.trim();
-  const inventoryAddress =
-    trimmedInventoryAddress !== undefined && trimmedInventoryAddress.length > 0
-      ? trimmedInventoryAddress
-      : undefined;
+  const inventoryAddress = process.env.INVENTORY_ADDRESS;
 
   let explorerQueryLimit = 200;
   if (process.env.EXPLORER_QUERY_LIMIT) {

--- a/typescript/warp-monitor/src/service.ts
+++ b/typescript/warp-monitor/src/service.ts
@@ -1,7 +1,4 @@
 #!/usr/bin/env node
-import { realpathSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-
 /**
  * Hyperlane Warp Monitor Service Entry Point
  *
@@ -120,12 +117,7 @@ async function main(): Promise<void> {
   }
 }
 
-if (
-  process.argv[1] &&
-  realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1])
-) {
-  main().catch((error) => {
-    rootLogger.error({ error }, 'Fatal error');
-    process.exit(1);
-  });
-}
+main().catch((error) => {
+  rootLogger.error({ error }, 'Fatal error');
+  process.exit(1);
+});

--- a/typescript/warp-monitor/src/service.ts
+++ b/typescript/warp-monitor/src/service.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 /**
@@ -56,7 +57,11 @@ async function main(): Promise<void> {
 
   const coingeckoApiKey = process.env.COINGECKO_API_KEY;
   const explorerApiUrl = process.env.EXPLORER_API_URL;
-  const inventoryAddress = process.env.INVENTORY_ADDRESS;
+  const trimmedInventoryAddress = process.env.INVENTORY_ADDRESS?.trim();
+  const inventoryAddress =
+    trimmedInventoryAddress !== undefined && trimmedInventoryAddress.length > 0
+      ? trimmedInventoryAddress
+      : undefined;
 
   let explorerQueryLimit = 200;
   if (process.env.EXPLORER_QUERY_LIMIT) {
@@ -115,7 +120,10 @@ async function main(): Promise<void> {
   }
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+if (
+  process.argv[1] &&
+  realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1])
+) {
   main().catch((error) => {
     rootLogger.error({ error }, 'Fatal error');
     process.exit(1);

--- a/typescript/warp-monitor/src/service.ts
+++ b/typescript/warp-monitor/src/service.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { fileURLToPath } from 'node:url';
+
 /**
  * Hyperlane Warp Monitor Service Entry Point
  *
@@ -15,7 +17,8 @@
  * - RPC_URL_<CHAIN>: Override RPC URL for a specific chain (e.g., RPC_URL_ETHEREUM, RPC_URL_ARBITRUM)
  * - EXPLORER_API_URL: Hyperlane explorer GraphQL endpoint for pending transfer liabilities (optional)
  * - EXPLORER_QUERY_LIMIT: Max pending transfer rows fetched per cycle (default: 200)
- * - INVENTORY_ADDRESS: Address whose per-node inventory balances should be tracked (optional)
+ * - INVENTORY_ADDRESS: Default Ethereum address whose per-node inventory balances should be tracked (optional)
+ * - INVENTORY_ADDRESS_<PROTOCOL>: Protocol-specific inventory address (e.g. INVENTORY_ADDRESS_ETHEREUM, INVENTORY_ADDRESS_SEALEVEL) (optional)
  *
  * Usage:
  *   node dist/service.js
@@ -112,8 +115,9 @@ async function main(): Promise<void> {
   }
 }
 
-// Run the service
-main().catch((error) => {
-  rootLogger.error({ error }, 'Fatal error');
-  process.exit(1);
-});
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    rootLogger.error({ error }, 'Fatal error');
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- include Solana router nodes in warp-monitor route-node handling instead of filtering non-EVM addresses out
- preserve non-EVM router address casing while still normalizing EVM addresses
- keep explorer pending-transfer queries limited to EVM/bytea-compatible router nodes
- support inventory addresses by protocol family through `INVENTORY_ADDRESS_<PROTOCOL>` env vars, such as `INVENTORY_ADDRESS_ETHEREUM` and `INVENTORY_ADDRESS_SEALEVEL`
- keep legacy `INVENTORY_ADDRESS` fallback EVM-only; non-EVM inventory requires explicit protocol env var
- centralize inventory address trimming/fallback handling in `getConfiguredInventoryAddress`

## Why
This is the monitor-side piece needed for CROSS/ctusd Solana CCR testing:
- local monitor output now includes both Solana nodes
- projected deficit / pending destination metrics can be emitted for EVM nodes without Solana base58 routers breaking explorer bytea filters
- inventory metrics can target a shared EVM owner and a separate Solana owner without listing every chain

## Review update
- rebased/cleaned branch onto current `origin/main`
- dropped old xeno SVM adapter history now already present through later merged PRs
- branch diff now only touches `typescript/warp-monitor/src/`
- filtered `ExplorerPendingTransfersClient` input to EVM router nodes while preserving all router nodes for collateral/inventory metrics
- restored malformed EVM router/collateral skip behavior before normalization
- switched protocol inventory config from JSON env parsing to `INVENTORY_ADDRESS_<PROTOCOL>` env vars
- removed the service entry guard and restored unconditional `main()` execution
- centralized protocol-specific inventory lookup, trimming, empty-as-unset handling, and EVM-only legacy fallback in `getConfiguredInventoryAddress`

## Validation
- `pnpm turbo run build --filter=@hyperlane-xyz/warp-monitor...`
- `pnpm --dir typescript/warp-monitor lint`
- `pnpm --dir typescript/warp-monitor build`
- `pnpm --dir typescript/warp-monitor test`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
