### PR TITLE
fix(sdk): prevent transfers where recipient is the destination router or collateral token

### DIFF
--- a/.changeset/warm-jets-sing.md
+++ b/.changeset/warm-jets-sing.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Rejected WarpCore transfers when the recipient equals the destination router or collateral token address, preventing permanent fund loss.

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -399,6 +399,55 @@ describe('WarpCore', () => {
     });
   });
 
+  it('Rejects transfers where recipient is the destination router or collateral contract', async () => {
+    const balanceStubs = warpCore.tokens.map((t) =>
+      sinon.stub(t, 'getBalance').resolves({ amount: MOCK_BALANCE } as any),
+    );
+    const quoteStubs = warpCore.tokens.map((t) =>
+      sinon.stub(t, 'getHypAdapter').returns({
+        quoteTransferRemoteGas: () =>
+          Promise.resolve({ igpQuote: MOCK_INTERCHAIN_QUOTE }),
+        isApproveRequired: () => Promise.resolve(false),
+        populateTransferRemoteTx: () => Promise.resolve({}),
+        getMinimumTransferAmount: () => Promise.resolve(10n),
+        getBalance: () => Promise.resolve(MOCK_BALANCE),
+        getBridgedSupply: () => Promise.resolve(MOCK_BALANCE),
+        getMintLimit: () => Promise.resolve(MEDIUM_MOCK_BALANCE),
+        getMintMaxLimit: () => Promise.resolve(MEDIUM_MOCK_BALANCE),
+        isRevokeApprovalRequired: () => Promise.resolve(false),
+      } as any),
+    );
+
+    // recipient === destination router
+    const routerAddress = evmHypSynthetic.addressOrDenom;
+    const recipientIsRouter = await warpCore.validateTransfer({
+      originTokenAmount: evmHypNative.amount(TRANSFER_AMOUNT),
+      destination: test2.name,
+      recipient: routerAddress,
+      sender: MOCK_ADDRESS,
+    });
+    expect(Object.keys(recipientIsRouter || {})[0]).to.equal('recipient');
+    expect(Object.values(recipientIsRouter || {})[0]).to.include('router');
+
+    // recipient === destination collateral token (simulate via temporary override)
+    const fakeCollateral = '0x000000000000000000000000000000000000dead';
+    (evmHypSynthetic as any).collateralAddressOrDenom = fakeCollateral;
+    const recipientIsCollateral = await warpCore.validateTransfer({
+      originTokenAmount: evmHypNative.amount(TRANSFER_AMOUNT),
+      destination: test2.name,
+      recipient: fakeCollateral,
+      sender: MOCK_ADDRESS,
+    });
+    (evmHypSynthetic as any).collateralAddressOrDenom = undefined;
+    expect(Object.keys(recipientIsCollateral || {})[0]).to.equal('recipient');
+    expect(Object.values(recipientIsCollateral || {})[0]).to.include(
+      'collateral',
+    );
+
+    balanceStubs.forEach((s) => s.restore());
+    quoteStubs.forEach((s) => s.restore());
+  });
+
   it('Validates destination token routing', async () => {
     const balanceStubs = warpCore.tokens.map((t) =>
       sinon.stub(t, 'getBalance').resolves({ amount: MOCK_BALANCE } as any),

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -418,34 +418,36 @@ describe('WarpCore', () => {
       } as any),
     );
 
-    // recipient === destination router
-    const routerAddress = evmHypSynthetic.addressOrDenom;
-    const recipientIsRouter = await warpCore.validateTransfer({
-      originTokenAmount: evmHypNative.amount(TRANSFER_AMOUNT),
-      destination: test2.name,
-      recipient: routerAddress,
-      sender: MOCK_ADDRESS,
-    });
-    expect(Object.keys(recipientIsRouter || {})[0]).to.equal('recipient');
-    expect(Object.values(recipientIsRouter || {})[0]).to.include('router');
+    try {
+      // recipient === destination router
+      const routerAddress = evmHypSynthetic.addressOrDenom;
+      const recipientIsRouter = await warpCore.validateTransfer({
+        originTokenAmount: evmHypNative.amount(TRANSFER_AMOUNT),
+        destination: test2.name,
+        recipient: routerAddress,
+        sender: MOCK_ADDRESS,
+      });
+      expect(Object.keys(recipientIsRouter || {})[0]).to.equal('recipient');
+      expect(Object.values(recipientIsRouter || {})[0]).to.include('router');
 
-    // recipient === destination collateral token (simulate via temporary override)
-    const fakeCollateral = '0x000000000000000000000000000000000000dead';
-    (evmHypSynthetic as any).collateralAddressOrDenom = fakeCollateral;
-    const recipientIsCollateral = await warpCore.validateTransfer({
-      originTokenAmount: evmHypNative.amount(TRANSFER_AMOUNT),
-      destination: test2.name,
-      recipient: fakeCollateral,
-      sender: MOCK_ADDRESS,
-    });
-    (evmHypSynthetic as any).collateralAddressOrDenom = undefined;
-    expect(Object.keys(recipientIsCollateral || {})[0]).to.equal('recipient');
-    expect(Object.values(recipientIsCollateral || {})[0]).to.include(
-      'collateral',
-    );
-
-    balanceStubs.forEach((s) => s.restore());
-    quoteStubs.forEach((s) => s.restore());
+      // recipient === destination collateral token (simulate via temporary override)
+      const fakeCollateral = '0x000000000000000000000000000000000000dead';
+      (evmHypSynthetic as any).collateralAddressOrDenom = fakeCollateral;
+      const recipientIsCollateral = await warpCore.validateTransfer({
+        originTokenAmount: evmHypNative.amount(TRANSFER_AMOUNT),
+        destination: test2.name,
+        recipient: fakeCollateral,
+        sender: MOCK_ADDRESS,
+      });
+      expect(Object.keys(recipientIsCollateral || {})[0]).to.equal('recipient');
+      expect(Object.values(recipientIsCollateral || {})[0]).to.include(
+        'collateral',
+      );
+    } finally {
+      (evmHypSynthetic as any).collateralAddressOrDenom = undefined;
+      balanceStubs.forEach((s) => s.restore());
+      quoteStubs.forEach((s) => s.restore());
+    }
   });
 
   it('Validates destination token routing', async () => {

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -10,6 +10,7 @@ import {
   convertDecimalsToIntegerString,
   convertToProtocolAddress,
   convertToScaledAmount,
+  eqAddress,
   isEVMLike,
   isValidAddress,
   isZeroishAddress,
@@ -1344,6 +1345,12 @@ export class WarpCore {
       return { destinationToken: resolvedDestinationToken.error };
     }
 
+    const recipientContractError = this.validateRecipientNotRouter(
+      recipient,
+      resolvedDestinationToken,
+    );
+    if (recipientContractError) return recipientContractError;
+
     const amountError = await this.validateAmount(
       originTokenAmount,
       destination,
@@ -1436,6 +1443,30 @@ export class WarpCore {
         this.logger.error(`Recipient prefix should be ${bech32Prefix}`);
         return { recipient: 'Invalid recipient prefix' };
       }
+    }
+    return null;
+  }
+
+  /**
+   * Ensure recipient is not the destination router or collateral token contract.
+   * Sending to those addresses results in permanent fund loss.
+   */
+  protected validateRecipientNotRouter(
+    recipient: Address,
+    destinationToken: IToken,
+  ): Record<string, string> | null {
+    const routerAddress = destinationToken.addressOrDenom;
+    const collateralAddress = destinationToken.collateralAddressOrDenom;
+    if (routerAddress && eqAddress(recipient, routerAddress)) {
+      return {
+        recipient: 'Recipient is the router contract; funds would be lost',
+      };
+    }
+    if (collateralAddress && eqAddress(recipient, collateralAddress)) {
+      return {
+        recipient:
+          'Recipient is the collateral token contract; funds would be lost',
+      };
     }
     return null;
   }


### PR DESCRIPTION
Fixes #4964.

## Problem

`WarpCore.validateTransfer` did not check whether the recipient address matches the destination router contract or its underlying collateral token. Transferring to either of those addresses locks the funds permanently — the router can't process a message it sent to itself, and the collateral token has no recovery path.

## Fix

Added `validateRecipientNotRouter` called inside `validateTransfer` after the destination token is resolved. It compares the recipient against:
- `destinationToken.addressOrDenom` (the router contract)
- `destinationToken.collateralAddressOrDenom` (the collateral ERC-20, when present)

Uses `eqAddress` from `@hyperlane-xyz/utils` for protocol-aware case-insensitive comparison.

Returns `{ recipient: '...' }` so the error surfaces in the same field as other recipient errors.

## Tests

Added a test case in `WarpCore.test.ts` that:
- Fails when recipient equals the destination router address
- Fails when recipient equals the destination collateral token address (simulated via temporary property override, consistent with existing test patterns)