### PR TITLE
feat(skills): add transferRemote test step to warp-route-check skill

### DIFF
--- a/.claude/skills/warp-route-check/skill.md
+++ b/.claude/skills/warp-route-check/skill.md
@@ -425,10 +425,14 @@ OLD_ISM=$(cast call $DEST_MAILBOX "defaultIsm()(address)" --rpc-url http://local
 # so `hyperlane warp send --relay` uses null metadata instead of trying to derive
 # multisig/routing metadata on the fork.
 TEST_DEPLOYER_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-TEST_ISM_ADDRESS=$(forge create --root solidity contracts/test/TestIsm.sol:TestIsm \
+# Ensure Foundry dependencies are materialized in fresh worktrees/checkouts.
+pnpm -C solidity deps:soldeer
+TEST_ISM_ADDRESS=$(forge create \
+  --root solidity \
   --broadcast \
   --rpc-url http://localhost:<DEST-PORT> \
   --private-key $TEST_DEPLOYER_KEY \
+  contracts/test/TestIsm.sol:TestIsm \
   | awk '/Deployed to:/ {print $3}')
 
 # Confirm the fork bypass ISM has the expected Hyperlane behavior:

--- a/.claude/skills/warp-route-check/skill.md
+++ b/.claude/skills/warp-route-check/skill.md
@@ -398,6 +398,104 @@ hyperlane warp check \
 
 **NOTE**: Warp check may show provider errors for newly added chains - this is expected.
 
+### Step 8b: Test transferRemote on Fork
+
+After verifying configuration with `warp check`, test that an actual token transfer works on the forked chains. This catches issues that config checks miss: broken `transferRemote` calldata, token accounting bugs (lock/mint/burn/unlock), and message dispatch failures.
+
+#### 8b.1 Pick an Origin → Destination Pair
+
+Choose one origin → destination pair from the warp route. Prefer a pair where both chains have transactions (i.e., both were modified), so you're testing the freshly configured path.
+
+#### 8b.2 Bypass ISM on Destination (Required for Self-Relay)
+
+Forked mainnet chains have real multisig ISMs that require validator signatures. Since there are no validators on anvil forks, you must set a permissive ISM on the destination so self-relay can deliver the message.
+
+```bash
+# 1. Get the mailbox address for the destination chain from the forked registry
+DEST_MAILBOX=$(cast call <warp-router-address> "mailbox()(address)" --rpc-url http://localhost:<DEST-PORT>)
+
+# 2. Get the mailbox owner
+MAILBOX_OWNER=$(cast call $DEST_MAILBOX "owner()(address)" --rpc-url http://localhost:<DEST-PORT>)
+
+# 3. Get the current default ISM (to restore later if needed)
+OLD_ISM=$(cast call $DEST_MAILBOX "defaultIsm()(address)" --rpc-url http://localhost:<DEST-PORT>)
+
+# 4. Deploy a TestRecipient-style "accept all" ISM
+# The simplest approach: deploy a minimal contract that returns true for verify()
+# Or use the existing TestIsm if deployed. For anvil forks, we can use a shortcut:
+# Set code at a fresh address to always return true for verify(bytes,bytes)
+TEST_ISM_ADDRESS="0x0000000000000000000000000000000000000042"
+# Minimal bytecode: returns true for any call
+cast rpc anvil_setCode $TEST_ISM_ADDRESS "0x600160005260206000F3" --rpc-url http://localhost:<DEST-PORT>
+
+# 5. Impersonate mailbox owner and set the permissive ISM
+cast rpc anvil_impersonateAccount $MAILBOX_OWNER --rpc-url http://localhost:<DEST-PORT>
+BALANCE="0x56BC75E2D63100000"
+cast rpc anvil_setBalance $MAILBOX_OWNER $BALANCE --rpc-url http://localhost:<DEST-PORT>
+cast send $DEST_MAILBOX "setDefaultIsm(address)" $TEST_ISM_ADDRESS --from $MAILBOX_OWNER --rpc-url http://localhost:<DEST-PORT> --unlocked
+cast rpc anvil_stopImpersonatingAccount $MAILBOX_OWNER --rpc-url http://localhost:<DEST-PORT>
+```
+
+**NOTE**: If the warp router has a custom ISM set (not using the mailbox default), you'll need to impersonate the router owner and call `setInterchainSecurityModule(address)` on the router instead.
+
+#### 8b.3 Fund the Test Sender
+
+```bash
+# Generate a test private key (or use a well-known anvil key)
+TEST_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+TEST_SENDER="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"  # Anvil account 0
+
+# Fund with native gas on origin
+cast rpc anvil_setBalance $TEST_SENDER "0x56BC75E2D63100000" --rpc-url http://localhost:<ORIGIN-PORT>
+
+# For collateral/ERC20 routes: mint or transfer tokens to the test sender
+# Option A: If the token has a mint function (e.g., test tokens)
+# cast send <token-address> "mint(address,uint256)" $TEST_SENDER 1000000000000000000 ...
+
+# Option B: Impersonate a whale holder and transfer
+# Find a top holder from the fork state, impersonate, and transfer
+# cast rpc anvil_impersonateAccount <whale> --rpc-url http://localhost:<ORIGIN-PORT>
+# cast send <token-address> "transfer(address,uint256)" $TEST_SENDER <amount> --from <whale> --rpc-url http://localhost:<ORIGIN-PORT> --unlocked
+
+# Option C: For native token routes, setBalance is sufficient (already done above)
+
+# Also fund on destination for self-relay gas
+cast rpc anvil_setBalance $TEST_SENDER "0x56BC75E2D63100000" --rpc-url http://localhost:<DEST-PORT>
+```
+
+#### 8b.4 Run the Transfer
+
+```bash
+HYP_KEY=$TEST_KEY \
+hyperlane warp send \
+  --registry <YOUR-ACTUAL-forked-registry-url-from-step-4> \
+  --warp-route-id <warp-route-id> \
+  --origin <origin-chain> \
+  --destination <destination-chain> \
+  --amount 1 \
+  --relay \
+  --skip-validation \
+  --yes
+```
+
+**Key flags:**
+- `--relay` — Self-relay the message (no real relayer on forks)
+- `--skip-validation` — Skip balance/collateral checks that may fail on forks
+- `--amount 1` — Use smallest practical amount (1 wei or 1 unit)
+
+#### 8b.5 Verify Result
+
+- **Success**: The CLI should log `Transfer was self-relayed!` and show the message ID
+- **Failure**: Check the error output. Common issues:
+  - `Ownable: caller is not the owner` on ISM bypass → wrong mailbox owner or router has custom ISM
+  - `insufficient funds` → test sender not funded with tokens (for collateral routes)
+  - `message already delivered` → ISM bypass not working, retry with router-level ISM override
+  - Timeout waiting for delivery → self-relay failed, check ISM was properly set
+
+**Capture output** to `/tmp/warp-transfer-test.log` for the final report.
+
+**NOTE**: This step is optional but strongly recommended. If it fails due to ISM complexity (e.g., routing ISMs, aggregation ISMs), document the failure and move on — the config check in Step 8 still validates the deployment.
+
 ### Step 9: Interpret Results
 
 Analyze the warp check output carefully:
@@ -515,6 +613,14 @@ Create a comprehensive markdown report with the following sections:
 ### Chains WITHOUT Transactions
 
 [List of chains not modified and their expected violations]
+
+## Transfer Test Results
+
+- **Origin → Destination**: <chain-a> → <chain-b>
+- **Amount**: <amount>
+- **Result**: ✅ Success / ❌ Failed (reason)
+- **Message ID**: <id> (if successful)
+- **ISM Bypass**: Yes (TestIsm at 0x...0042 set on destination mailbox)
 
 ## Decoded Transactions (Heimdall Output)
 

--- a/.claude/skills/warp-route-check/skill.md
+++ b/.claude/skills/warp-route-check/skill.md
@@ -425,7 +425,7 @@ OLD_ISM=$(cast call $DEST_MAILBOX "defaultIsm()(address)" --rpc-url http://local
 # so `hyperlane warp send --relay` uses null metadata instead of trying to derive
 # multisig/routing metadata on the fork.
 TEST_DEPLOYER_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-TEST_ISM_ADDRESS=$(forge create solidity/contracts/test/TestIsm.sol:TestIsm \
+TEST_ISM_ADDRESS=$(forge create --root solidity contracts/test/TestIsm.sol:TestIsm \
   --broadcast \
   --rpc-url http://localhost:<DEST-PORT> \
   --private-key $TEST_DEPLOYER_KEY \

--- a/.claude/skills/warp-route-check/skill.md
+++ b/.claude/skills/warp-route-check/skill.md
@@ -420,13 +420,21 @@ MAILBOX_OWNER=$(cast call $DEST_MAILBOX "owner()(address)" --rpc-url http://loca
 # 3. Get the current default ISM (to restore later if needed)
 OLD_ISM=$(cast call $DEST_MAILBOX "defaultIsm()(address)" --rpc-url http://localhost:<DEST-PORT>)
 
-# 4. Deploy a TestRecipient-style "accept all" ISM
-# The simplest approach: deploy a minimal contract that returns true for verify()
-# Or use the existing TestIsm if deployed. For anvil forks, we can use a shortcut:
-# Set code at a fresh address to always return true for verify(bytes,bytes)
-TEST_ISM_ADDRESS="0x0000000000000000000000000000000000000042"
-# Minimal bytecode: returns true for any call
-cast rpc anvil_setCode $TEST_ISM_ADDRESS "0x600160005260206000F3" --rpc-url http://localhost:<DEST-PORT>
+# 4. Deploy Hyperlane's TestIsm.
+# TestIsm returns Types.NULL from moduleType() and true from verify(bytes,bytes),
+# so `hyperlane warp send --relay` uses null metadata instead of trying to derive
+# multisig/routing metadata on the fork.
+TEST_DEPLOYER_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+TEST_ISM_ADDRESS=$(forge create solidity/contracts/test/TestIsm.sol:TestIsm \
+  --broadcast \
+  --rpc-url http://localhost:<DEST-PORT> \
+  --private-key $TEST_DEPLOYER_KEY \
+  | awk '/Deployed to:/ {print $3}')
+
+# Confirm the fork bypass ISM has the expected Hyperlane behavior:
+# moduleType() == 6 (Types.NULL) and verify(...) == true.
+cast call $TEST_ISM_ADDRESS "moduleType()(uint8)" --rpc-url http://localhost:<DEST-PORT>
+cast call $TEST_ISM_ADDRESS "verify(bytes,bytes)(bool)" 0x 0x --rpc-url http://localhost:<DEST-PORT>
 
 # 5. Impersonate mailbox owner and set the permissive ISM
 cast rpc anvil_impersonateAccount $MAILBOX_OWNER --rpc-url http://localhost:<DEST-PORT>
@@ -479,6 +487,7 @@ hyperlane warp send \
 ```
 
 **Key flags:**
+
 - `--relay` — Self-relay the message (no real relayer on forks)
 - `--skip-validation` — Skip balance/collateral checks that may fail on forks
 - `--amount 1` — Use smallest practical amount (1 wei or 1 unit)
@@ -620,7 +629,7 @@ Create a comprehensive markdown report with the following sections:
 - **Amount**: <amount>
 - **Result**: ✅ Success / ❌ Failed (reason)
 - **Message ID**: <id> (if successful)
-- **ISM Bypass**: Yes (TestIsm at 0x...0042 set on destination mailbox)
+- **ISM Bypass**: Yes (TestIsm deployed at <address> set on destination mailbox)
 
 ## Decoded Transactions (Heimdall Output)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

## Summary
- Adds Step 8b to the warp-route-check skill that tests an actual `transferRemote` on forked anvil chains
- Covers ISM bypass (required since forks lack real validators), sender funding, and transfer execution via `hyperlane warp send --relay`
- Includes the transfer test result in the final validation report

## Context
The warp fork test previously only validated configuration state via `warp check`. This misses runtime issues like broken transferRemote calldata, token accounting bugs, and message dispatch failures. The new step tests the actual transfer path end-to-end.

### Drive-by changes
- None.

### Related issues
- None.

### Backward compatibility
Yes. Documentation-only skill update.

### Testing
## Test plan
- [ ] Run the warp-route-check skill with the new step against a known warp route fork
- [ ] Verify the ISM bypass works on forked mainnet chains
- [ ] Verify the transfer succeeds and is self-relayed

### Review updates
- 2026-04-09: Replaced the `anvil_setCode` accept-all stub with deployment of `solidity/contracts/test/TestIsm.sol:TestIsm` after reproducing that the stub returned `moduleType() == 1`; validated `moduleType() == 6`, `verify(...) == true`, and `oxfmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbc2249f-ce43-4b55-8787-4a081f4c518a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbc2249f-ce43-4b55-8787-4a081f4c518a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
