### PR TITLE
fix(registry): tolerate subset HTTP overlay misses

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
       "typechain@8.3.2": "patches/typechain@8.3.2.patch",
       "node-fetch@2.7.0": "patches/node-fetch@2.7.0.patch",
       "bigint-buffer@1.1.5": "patches/bigint-buffer@1.1.5.patch",
-      "node-fetch@3.3.2": "patches/node-fetch@3.3.2.patch"
+      "node-fetch@3.3.2": "patches/node-fetch@3.3.2.patch",
+      "@hyperlane-xyz/registry@23.12.0": "patches/@hyperlane-xyz__registry@23.12.0.patch"
     }
   }
 }

--- a/patches/@hyperlane-xyz__registry@23.12.0.patch
+++ b/patches/@hyperlane-xyz__registry@23.12.0.patch
@@ -1,0 +1,108 @@
+diff --git a/dist/registry/MergedRegistry.js b/dist/registry/MergedRegistry.js
+index 8115fcf..39a8013 100644
+--- a/dist/registry/MergedRegistry.js
++++ b/dist/registry/MergedRegistry.js
+@@ -1,4 +1,10 @@
+ import { objMerge } from '../utils.js';
++function isRegistrySubsetMiss(error) {
++    if (!error || typeof error !== 'object')
++        return false;
++    const status = error.status ?? error.statusCode ?? error.response?.status;
++    return Number(status) === 404;
++}
+ import { RegistryType } from './IRegistry.js';
+ /**
+  * A registry that accepts multiple sub-registries.
+@@ -22,7 +28,9 @@ export class MergedRegistry {
+         throw new Error('getUri method not applicable to MergedRegistry');
+     }
+     async listRegistryContent() {
+-        const results = await this.multiRegistryRead((r) => r.listRegistryContent());
++        const results = await this.multiRegistryRead((r) => r.listRegistryContent(), {
++            tolerateSubsetMisses: true,
++        });
+         return results.reduce((acc, content) => objMerge(acc, content), {
+             chains: {},
+             deployments: {
+@@ -35,14 +43,18 @@ export class MergedRegistry {
+         return Object.keys(await this.getMetadata());
+     }
+     async getMetadata() {
+-        const results = await this.multiRegistryRead((r) => r.getMetadata());
++        const results = await this.multiRegistryRead((r) => r.getMetadata(), {
++            tolerateSubsetMisses: true,
++        });
+         return results.reduce((acc, content) => objMerge(acc, content), {});
+     }
+     async getChainMetadata(chainName) {
+         return (await this.getMetadata())[chainName] || null;
+     }
+     async getAddresses() {
+-        const results = await this.multiRegistryRead((r) => r.getAddresses());
++        const results = await this.multiRegistryRead((r) => r.getAddresses(), {
++            tolerateSubsetMisses: true,
++        });
+         return results.reduce((acc, content) => objMerge(acc, content), {});
+     }
+     async getChainAddresses(chainName) {
+@@ -62,19 +74,27 @@ export class MergedRegistry {
+         return this.multiRegistryWrite(async (registry) => await registry.removeChain(chain), 'removeChain', `removing chain ${chain}`);
+     }
+     async getWarpRoute(id) {
+-        const results = await this.multiRegistryRead((r) => r.getWarpRoute(id));
++        const results = await this.multiRegistryRead((r) => r.getWarpRoute(id), {
++            tolerateSubsetMisses: true,
++        });
+         return results.find((r) => !!r) || null;
+     }
+     async getWarpDeployConfig(id) {
+-        const results = await this.multiRegistryRead((r) => r.getWarpDeployConfig(id));
++        const results = await this.multiRegistryRead((r) => r.getWarpDeployConfig(id), {
++            tolerateSubsetMisses: true,
++        });
+         return results.find((r) => !!r) || null;
+     }
+     async getWarpRoutes(filter) {
+-        const results = await this.multiRegistryRead((r) => r.getWarpRoutes(filter));
++        const results = await this.multiRegistryRead((r) => r.getWarpRoutes(filter), {
++            tolerateSubsetMisses: true,
++        });
+         return results.reduce((acc, content) => objMerge(acc, content), {});
+     }
+     async getWarpDeployConfigs(filter) {
+-        const results = await this.multiRegistryRead((r) => r.getWarpDeployConfigs(filter));
++        const results = await this.multiRegistryRead((r) => r.getWarpDeployConfigs(filter), {
++            tolerateSubsetMisses: true,
++        });
+         return results.reduce((acc, content) => objMerge(acc, content), {});
+     }
+     async addWarpRoute(config, options) {
+@@ -83,8 +103,26 @@ export class MergedRegistry {
+     async addWarpRouteConfig(config, options) {
+         return this.multiRegistryWrite(async (registry) => await registry.addWarpRouteConfig(config, options), 'addWarpRouteConfig', 'adding warp route deploy config');
+     }
+-    multiRegistryRead(readFn) {
+-        return Promise.all(this.registries.map(readFn));
++    async multiRegistryRead(readFn, options = {}) {
++        const { tolerateSubsetMisses = false } = options;
++        const reads = this.registries.map((registry) => Promise.resolve().then(() => readFn(registry)));
++        if (!tolerateSubsetMisses) {
++            return Promise.all(reads);
++        }
++        const results = await Promise.allSettled(reads);
++        const values = [];
++        for (const [index, result] of results.entries()) {
++            if (result.status === 'fulfilled') {
++                values.push(result.value);
++                continue;
++            }
++            if (index > 0 && isRegistrySubsetMiss(result.reason)) {
++                values.push(null);
++                continue;
++            }
++            throw result.reason;
++        }
++        return values;
+     }
+     async multiRegistryWrite(writeFn, methodName, logMsg) {
+         for (const registry of this.registries) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ overrides:
   xmlhttprequest-ssl: 4.0.0
 
 patchedDependencies:
+  '@hyperlane-xyz/registry@23.12.0':
+    hash: 113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41
+    path: patches/@hyperlane-xyz__registry@23.12.0.patch
   bigint-buffer@1.1.5:
     hash: cd06d79b9cff13280e1a45a0f15abf67bc4ada4d7ad42bdfe120982ffa4340a2
     path: patches/bigint-buffer@1.1.5.patch
@@ -571,7 +574,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 23.12.0(patch_hash=113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41)
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -719,7 +722,7 @@ importers:
         version: link:../rebalancer
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 23.12.0(patch_hash=113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41)
       '@hyperlane-xyz/relayer':
         specifier: workspace:*
         version: link:../relayer
@@ -1025,7 +1028,7 @@ importers:
     dependencies:
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 23.12.0(patch_hash=113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41)
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1137,7 +1140,7 @@ importers:
         version: link:../../solidity
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 23.12.0(patch_hash=113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41)
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1246,7 +1249,7 @@ importers:
     dependencies:
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 23.12.0(patch_hash=113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41)
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1385,7 +1388,7 @@ importers:
         version: link:../rebalancer
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 23.12.0(patch_hash=113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41)
       '@hyperlane-xyz/relayer':
         specifier: workspace:*
         version: link:../relayer
@@ -1590,7 +1593,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 23.12.0(patch_hash=113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41)
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1840,7 +1843,7 @@ importers:
         version: link:../provider-sdk
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 23.12.0(patch_hash=113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41)
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1967,7 +1970,7 @@ importers:
         version: link:../rebalancer
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 23.12.0(patch_hash=113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41)
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -2037,7 +2040,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 23.12.0(patch_hash=113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41)
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -2455,7 +2458,7 @@ importers:
         version: link:../provider-sdk
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 23.12.0(patch_hash=113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41)
       '@hyperlane-xyz/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2615,7 +2618,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 23.12.0(patch_hash=113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41)
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -2818,7 +2821,7 @@ importers:
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 23.12.0(patch_hash=113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41)
       '@hyperlane-xyz/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -21305,7 +21308,7 @@ snapshots:
 
   '@humanwhocodes/momoa@2.0.4': {}
 
-  '@hyperlane-xyz/registry@23.12.0':
+  '@hyperlane-xyz/registry@23.12.0(patch_hash=113fd556c07dcd0ae53206e6d9681a2015667185b64da17d427fa57358b88d41)':
     dependencies:
       jszip: 3.10.1
       yaml: 2.4.5

--- a/typescript/infra/test/merged-registry.test.ts
+++ b/typescript/infra/test/merged-registry.test.ts
@@ -1,0 +1,400 @@
+import { expect } from 'chai';
+
+import { MergedRegistry, type IRegistry } from '@hyperlane-xyz/registry';
+
+type HttpLikeError = Error & {
+  response?: { status?: number };
+  status?: number | string;
+  statusCode?: number | string;
+};
+
+function make404Error(message: string): HttpLikeError {
+  const error = new Error(message) as HttpLikeError;
+  error.status = '404';
+  return error;
+}
+
+function makeResponse404Error(message: string): HttpLikeError {
+  const error = new Error(message) as HttpLikeError;
+  error.response = { status: 404 };
+  return error;
+}
+
+describe('MergedRegistry', () => {
+  it('returns the first successful warp route even if a later registry 404s', async () => {
+    const warpRoute = { routeId: 'TEST/route', source: 'public' } as const;
+    const publicRegistry = {
+      getWarpRoute: async () => warpRoute,
+    } as unknown as IRegistry;
+    const overlayRegistry = {
+      getWarpRoute: async () => {
+        throw make404Error('Warp route not found');
+      },
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, overlayRegistry],
+    });
+
+    const result = await registry.getWarpRoute('TEST/route');
+
+    expect(result).to.equal(warpRoute);
+  });
+
+  it('throws when the first registry 404s on a warp route lookup', async () => {
+    const publicRegistry = {
+      getWarpRoute: async () => {
+        throw make404Error('Warp route not found');
+      },
+    } as unknown as IRegistry;
+    const overlayRegistry = {
+      getWarpRoute: async () => ({ routeId: 'TEST/route', source: 'overlay' }),
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, overlayRegistry],
+    });
+
+    let caught: unknown;
+    try {
+      await registry.getWarpRoute('TEST/route');
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.be.instanceOf(Error);
+    expect((caught as Error).message).to.equal('Warp route not found');
+  });
+
+  it('returns the first successful deploy config even if a later registry 404s', async () => {
+    const warpDeployConfig = {
+      routeId: 'TEST/route',
+      source: 'public',
+    } as const;
+    const publicRegistry = {
+      getWarpDeployConfig: async () => warpDeployConfig,
+    } as unknown as IRegistry;
+    const overlayRegistry = {
+      getWarpDeployConfig: async () => {
+        throw make404Error('Warp deploy config not found');
+      },
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, overlayRegistry],
+    });
+
+    const result = await registry.getWarpDeployConfig('TEST/route');
+
+    expect(result).to.equal(warpDeployConfig);
+  });
+
+  it('returns metadata from earlier registries when a later registry returns a response-shaped 404', async () => {
+    const publicRegistry = {
+      getMetadata: async () => ({
+        ethereum: { chainId: 1, displayName: 'public' },
+      }),
+    } as unknown as IRegistry;
+    const overlayRegistry = {
+      getMetadata: async () => {
+        throw makeResponse404Error('metadata not found');
+      },
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, overlayRegistry],
+    });
+
+    const result = await registry.getChainMetadata('ethereum');
+
+    expect(result?.displayName).to.equal('public');
+  });
+
+  it('throws when the first registry 404s on metadata lookup', async () => {
+    const publicRegistry = {
+      getMetadata: async () => {
+        throw make404Error('metadata not found');
+      },
+    } as unknown as IRegistry;
+    const overlayRegistry = {
+      getMetadata: async () => ({
+        ethereum: { chainId: 1, displayName: 'overlay' },
+      }),
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, overlayRegistry],
+    });
+
+    let caught: unknown;
+    try {
+      await registry.getChainMetadata('ethereum');
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.be.instanceOf(Error);
+    expect((caught as Error).message).to.equal('metadata not found');
+  });
+
+  it('falls through to later registries when earlier ones have no route', async () => {
+    const warpRoute = { routeId: 'TEST/route', source: 'overlay' } as const;
+    const missingRegistry = {
+      getWarpRoute: async () => null,
+    } as unknown as IRegistry;
+    const overlayRegistry = {
+      getWarpRoute: async () => warpRoute,
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [missingRegistry, overlayRegistry],
+    });
+
+    const result = await registry.getWarpRoute('TEST/route');
+
+    expect(result).to.equal(warpRoute);
+  });
+
+  it('uses later-registry precedence for chain metadata overlays', async () => {
+    const publicRegistry = {
+      getMetadata: async () => ({
+        ethereum: { chainId: 1, displayName: 'public' },
+      }),
+    } as unknown as IRegistry;
+    const overlayRegistry = {
+      getMetadata: async () => ({
+        ethereum: { chainId: 1, displayName: 'overlay' },
+      }),
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, overlayRegistry],
+    });
+
+    const result = await registry.getChainMetadata('ethereum');
+
+    expect(result?.displayName).to.equal('overlay');
+  });
+
+  it('falls through to earlier chain metadata when a later overlay misses', async () => {
+    const publicRegistry = {
+      getMetadata: async () => ({
+        ethereum: { chainId: 1, displayName: 'public' },
+      }),
+    } as unknown as IRegistry;
+    const overlayRegistry = {
+      getMetadata: async () => {
+        throw make404Error('metadata not found');
+      },
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, overlayRegistry],
+    });
+
+    const result = await registry.getChainMetadata('ethereum');
+
+    expect(result?.displayName).to.equal('public');
+  });
+
+  it('uses later-registry precedence when merging full metadata maps', async () => {
+    const publicRegistry = {
+      getMetadata: async () => ({
+        ethereum: { chainId: 1, displayName: 'public' },
+      }),
+    } as unknown as IRegistry;
+    const overlayRegistry = {
+      getMetadata: async () => ({
+        ethereum: { chainId: 1, displayName: 'overlay' },
+        base: { chainId: 8453, displayName: 'Base' },
+      }),
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, overlayRegistry],
+    });
+
+    const result = await registry.getMetadata();
+
+    expect(result.ethereum.displayName).to.equal('overlay');
+    expect(result.base.displayName).to.equal('Base');
+  });
+
+  it('uses later-registry precedence for core address overlays', async () => {
+    const publicRegistry = {
+      getAddresses: async () => ({
+        ethereum: { mailbox: '0x1111', interchainGasPaymaster: '0x2222' },
+      }),
+    } as unknown as IRegistry;
+    const overlayRegistry = {
+      getAddresses: async () => ({
+        ethereum: { mailbox: '0xaaaa', interchainGasPaymaster: '0xbbbb' },
+      }),
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, overlayRegistry],
+    });
+
+    const result = await registry.getChainAddresses('ethereum');
+
+    expect(result?.mailbox).to.equal('0xaaaa');
+  });
+
+  it('falls through to earlier core addresses when a later overlay misses', async () => {
+    const publicRegistry = {
+      getAddresses: async () => ({
+        ethereum: { mailbox: '0x1111', interchainGasPaymaster: '0x2222' },
+      }),
+    } as unknown as IRegistry;
+    const overlayRegistry = {
+      getAddresses: async () => {
+        throw make404Error('addresses not found');
+      },
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, overlayRegistry],
+    });
+
+    const result = await registry.getChainAddresses('ethereum');
+
+    expect(result?.mailbox).to.equal('0x1111');
+  });
+
+  it('throws when the first registry 404s on core address lookup', async () => {
+    const publicRegistry = {
+      getAddresses: async () => {
+        throw make404Error('addresses not found');
+      },
+    } as unknown as IRegistry;
+    const overlayRegistry = {
+      getAddresses: async () => ({
+        ethereum: { mailbox: '0xaaaa', interchainGasPaymaster: '0xbbbb' },
+      }),
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, overlayRegistry],
+    });
+
+    let caught: unknown;
+    try {
+      await registry.getChainAddresses('ethereum');
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.be.instanceOf(Error);
+    expect((caught as Error).message).to.equal('addresses not found');
+  });
+
+  it('uses later-registry precedence when merging full address maps', async () => {
+    const publicRegistry = {
+      getAddresses: async () => ({
+        ethereum: { mailbox: '0x1111', interchainGasPaymaster: '0x2222' },
+      }),
+    } as unknown as IRegistry;
+    const overlayRegistry = {
+      getAddresses: async () => ({
+        ethereum: { mailbox: '0xaaaa', interchainGasPaymaster: '0xbbbb' },
+        base: { mailbox: '0xcccc', interchainGasPaymaster: '0xdddd' },
+      }),
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, overlayRegistry],
+    });
+
+    const result = await registry.getAddresses();
+
+    expect(result.ethereum.mailbox).to.equal('0xaaaa');
+    expect(result.base.mailbox).to.equal('0xcccc');
+  });
+
+  it('returns registry content from earlier registries when a later overlay misses', async () => {
+    const publicRegistry = {
+      listRegistryContent: async () => ({
+        chains: {
+          ethereum: {
+            metadata: 'chains/ethereum/metadata.yaml',
+          },
+        },
+        deployments: {
+          warpRoutes: {
+            'TEST/route': 'deployments/warp_routes/TEST/route-config.yaml',
+          },
+          warpDeployConfig: {},
+        },
+      }),
+    } as unknown as IRegistry;
+    const overlayRegistry = {
+      listRegistryContent: async () => {
+        throw make404Error('registry content not found');
+      },
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, overlayRegistry],
+    });
+
+    const result = await registry.listRegistryContent();
+
+    expect(result.chains.ethereum.metadata).to.equal(
+      'chains/ethereum/metadata.yaml',
+    );
+    expect(result.deployments.warpRoutes['TEST/route']).to.equal(
+      'deployments/warp_routes/TEST/route-config.yaml',
+    );
+  });
+
+  it('still throws non-404 registry errors', async () => {
+    const publicRegistry = {
+      getWarpRoute: async () => ({ routeId: 'TEST/route' }),
+    } as unknown as IRegistry;
+    const brokenOverlayRegistry = {
+      getWarpRoute: async () => {
+        throw new Error('overlay unavailable');
+      },
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, brokenOverlayRegistry],
+    });
+
+    let caught: unknown;
+    try {
+      await registry.getWarpRoute('TEST/route');
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.be.instanceOf(Error);
+    expect((caught as Error).message).to.equal('overlay unavailable');
+  });
+
+  it('still throws non-404 deploy-config errors', async () => {
+    const publicRegistry = {
+      getWarpDeployConfig: async () => ({ routeId: 'TEST/route' }),
+    } as unknown as IRegistry;
+    const brokenOverlayRegistry = {
+      getWarpDeployConfig: async () => {
+        throw new Error('overlay unavailable');
+      },
+    } as unknown as IRegistry;
+
+    const registry = new MergedRegistry({
+      registries: [publicRegistry, brokenOverlayRegistry],
+    });
+
+    let caught: unknown;
+    try {
+      await registry.getWarpDeployConfig('TEST/route');
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.be.instanceOf(Error);
+    expect((caught as Error).message).to.equal('overlay unavailable');
+  });
+});


### PR DESCRIPTION
## Summary
- tolerate 404 subset misses from later merged registries on common read paths
- keep existing precedence semantics unchanged
- add targeted tests that assert existing warp-route, metadata, and core-address precedence while covering 404 fallback behavior

## Validation
- `pnpm -C typescript/infra exec mocha --config ../sdk/.mocharc.json test/merged-registry.test.ts`
  - blocked: missing `/node_modules/.pnpm/node_modules/@hyperlane-xyz/sdk/dist/index.js` in this worktree
- `pnpm -C typescript/sdk build`
  - blocked by broader workspace dependency resolution failures for missing built packages like `@hyperlane-xyz/core` in this worktree