### PR TITLE
fix(tron-sdk): parse custom_rpc_header in TronJsonRpcProvider and TronTransactionBuilder

### DIFF
--- a/.changeset/tron-custom-rpc-headers.md
+++ b/.changeset/tron-custom-rpc-headers.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/tron-sdk": patch
+---
+
+TronJsonRpcProvider and TronTransactionBuilder now parse custom_rpc_header query params into HTTP headers, fixing auth with third-party RPC providers like Tatum.

--- a/.changeset/tron-custom-rpc-headers.md
+++ b/.changeset/tron-custom-rpc-headers.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/tron-sdk": patch
 ---
 
-TronJsonRpcProvider and TronTransactionBuilder now parse custom_rpc_header query params into HTTP headers, fixing auth with third-party RPC providers like Tatum.
+TronJsonRpcProvider and TronTransactionBuilder were updated to parse custom_rpc_header query params into HTTP headers, fixing auth with third-party RPC providers like Tatum.

--- a/typescript/tron-sdk/src/ethers/TronJsonRpcProvider.ts
+++ b/typescript/tron-sdk/src/ethers/TronJsonRpcProvider.ts
@@ -2,6 +2,8 @@ import { BigNumber, providers } from 'ethers';
 
 import { retryAsync } from '@hyperlane-xyz/utils';
 
+import { parseCustomHeaders } from './TronWallet.js';
+
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_BASE_RETRY_MS = 250;
 
@@ -31,7 +33,15 @@ export class TronJsonRpcProvider extends providers.StaticJsonRpcProvider {
     maxRetries = DEFAULT_MAX_RETRIES,
     baseRetryMs = DEFAULT_BASE_RETRY_MS,
   ) {
-    super(host, network);
+    const headers = parseCustomHeaders(host);
+    const hasHeaders = Object.keys(headers).length > 0;
+    let cleanUrl = host;
+    if (hasHeaders) {
+      const parsed = new URL(host);
+      parsed.searchParams.delete('custom_rpc_header');
+      cleanUrl = parsed.toString();
+    }
+    super(hasHeaders ? { url: cleanUrl, headers } : host, network);
     this.host = host;
     this.maxRetries = maxRetries;
     this.baseRetryMs = baseRetryMs;

--- a/typescript/tron-sdk/src/ethers/TronJsonRpcProvider.ts
+++ b/typescript/tron-sdk/src/ethers/TronJsonRpcProvider.ts
@@ -35,7 +35,7 @@ export class TronJsonRpcProvider extends providers.StaticJsonRpcProvider {
   ) {
     const { url: cleanUrl, headers } = stripCustomRpcHeaders(host);
     const hasHeaders = Object.keys(headers).length > 0;
-    super(hasHeaders ? { url: cleanUrl, headers } : host, network);
+    super(hasHeaders ? { url: cleanUrl, headers } : cleanUrl, network);
     this.host = host;
     this.maxRetries = maxRetries;
     this.baseRetryMs = baseRetryMs;

--- a/typescript/tron-sdk/src/ethers/TronJsonRpcProvider.ts
+++ b/typescript/tron-sdk/src/ethers/TronJsonRpcProvider.ts
@@ -2,7 +2,7 @@ import { BigNumber, providers } from 'ethers';
 
 import { retryAsync } from '@hyperlane-xyz/utils';
 
-import { parseCustomHeaders } from './TronWallet.js';
+import { stripCustomRpcHeaders } from './urlUtils.js';
 
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_BASE_RETRY_MS = 250;
@@ -33,14 +33,8 @@ export class TronJsonRpcProvider extends providers.StaticJsonRpcProvider {
     maxRetries = DEFAULT_MAX_RETRIES,
     baseRetryMs = DEFAULT_BASE_RETRY_MS,
   ) {
-    const headers = parseCustomHeaders(host);
+    const { url: cleanUrl, headers } = stripCustomRpcHeaders(host);
     const hasHeaders = Object.keys(headers).length > 0;
-    let cleanUrl = host;
-    if (hasHeaders) {
-      const parsed = new URL(host);
-      parsed.searchParams.delete('custom_rpc_header');
-      cleanUrl = parsed.toString();
-    }
     super(hasHeaders ? { url: cleanUrl, headers } : host, network);
     this.host = host;
     this.maxRetries = maxRetries;

--- a/typescript/tron-sdk/src/ethers/TronWallet.ts
+++ b/typescript/tron-sdk/src/ethers/TronWallet.ts
@@ -184,7 +184,7 @@ export class TronTransactionBuilder extends TronWeb {
     // Use URL API so /jsonrpc goes into the pathname, not after query params.
     let rpcUrl = jsonRpcUrl;
     if (!rpcUrl) {
-      const u = new URL(cleanTronWebUrl);
+      const u = new URL(tronWebUrl);
       if (!u.pathname.endsWith('/jsonrpc')) {
         u.pathname = u.pathname.replace(/\/$/, '') + '/jsonrpc';
       }

--- a/typescript/tron-sdk/src/ethers/TronWallet.ts
+++ b/typescript/tron-sdk/src/ethers/TronWallet.ts
@@ -9,28 +9,7 @@ import {
   TronJsonRpcProvider,
 } from './TronJsonRpcProvider.js';
 import { TransactionRequest } from '@ethersproject/providers';
-
-/**
- * Extract custom_rpc_header query params from a URL into a headers object.
- * e.g. "https://api.trongrid.io?custom_rpc_header=TRON-PRO-API-KEY:abc"
- * returns { "TRON-PRO-API-KEY": "abc" }
- */
-export function parseCustomHeaders(url: string): Record<string, string> {
-  const headers: Record<string, string> = {};
-  try {
-    const parsed = new URL(url);
-    for (const [key, value] of parsed.searchParams) {
-      if (key !== 'custom_rpc_header') continue;
-      const colonIdx = value.indexOf(':');
-      if (colonIdx > 0) {
-        headers[value.slice(0, colonIdx)] = value.slice(colonIdx + 1);
-      }
-    }
-  } catch {
-    // Not a valid URL, return empty headers
-  }
-  return headers;
-}
+import { stripCustomRpcHeaders } from './urlUtils.js';
 
 /** Union of possible TronWeb transaction types */
 export type TronTransaction =
@@ -80,13 +59,11 @@ export class TronWallet extends Wallet {
     // TronWeb needs the base HTTP API URL — strip /jsonrpc path if present, and
     // fall back to public TronGrid for third-party providers that only serve JSON-RPC.
     // Extract custom headers before stripping path, as they may contain API keys.
-    const headers = parseCustomHeaders(tronUrl);
-    const parsed = new URL(tronUrl);
+    const { url: cleanTronUrl, headers } = stripCustomRpcHeaders(tronUrl);
+    const parsed = new URL(cleanTronUrl);
     if (parsed.pathname.endsWith('/jsonrpc')) {
       parsed.pathname = parsed.pathname.slice(0, -8);
     }
-    // Strip custom_rpc_header params from the base URL
-    parsed.searchParams.delete('custom_rpc_header');
     const baseUrl = parsed.toString();
     const tronWebUrl =
       /^https?:\/\/(localhost|127\.0\.0\.1|[^/]*trongrid)/.test(baseUrl)
@@ -196,14 +173,9 @@ export class TronTransactionBuilder extends TronWeb {
     headers?: Record<string, string>,
   ) {
     // Strip custom_rpc_header from the URL and merge with any provided headers
-    const parsedHeaders = parseCustomHeaders(tronWebUrl);
+    const { url: cleanTronWebUrl, headers: parsedHeaders } =
+      stripCustomRpcHeaders(tronWebUrl);
     const mergedHeaders = { ...parsedHeaders, ...headers };
-    let cleanTronWebUrl = tronWebUrl;
-    if (Object.keys(parsedHeaders).length > 0) {
-      const parsed = new URL(tronWebUrl);
-      parsed.searchParams.delete('custom_rpc_header');
-      cleanTronWebUrl = parsed.toString();
-    }
     super({ fullHost: cleanTronWebUrl, headers: mergedHeaders });
 
     this.tronAddress = tronAddress;

--- a/typescript/tron-sdk/src/ethers/TronWallet.ts
+++ b/typescript/tron-sdk/src/ethers/TronWallet.ts
@@ -15,7 +15,7 @@ import { TransactionRequest } from '@ethersproject/providers';
  * e.g. "https://api.trongrid.io?custom_rpc_header=TRON-PRO-API-KEY:abc"
  * returns { "TRON-PRO-API-KEY": "abc" }
  */
-function parseCustomHeaders(url: string): Record<string, string> {
+export function parseCustomHeaders(url: string): Record<string, string> {
   const headers: Record<string, string> = {};
   try {
     const parsed = new URL(url);
@@ -195,14 +195,29 @@ export class TronTransactionBuilder extends TronWeb {
     jsonRpcUrl?: string,
     headers?: Record<string, string>,
   ) {
-    super({ fullHost: tronWebUrl, headers });
+    // Strip custom_rpc_header from the URL and merge with any provided headers
+    const parsedHeaders = parseCustomHeaders(tronWebUrl);
+    const mergedHeaders = { ...parsedHeaders, ...headers };
+    let cleanTronWebUrl = tronWebUrl;
+    if (Object.keys(parsedHeaders).length > 0) {
+      const parsed = new URL(tronWebUrl);
+      parsed.searchParams.delete('custom_rpc_header');
+      cleanTronWebUrl = parsed.toString();
+    }
+    super({ fullHost: cleanTronWebUrl, headers: mergedHeaders });
 
     this.tronAddress = tronAddress;
     this.setAddress(this.tronAddress);
-    // Use provided JSON-RPC URL, or derive from TronWeb URL
-    const rpcUrl =
-      jsonRpcUrl ??
-      (tronWebUrl.endsWith('/jsonrpc') ? tronWebUrl : `${tronWebUrl}/jsonrpc`);
+    // Use provided JSON-RPC URL, or derive from TronWeb URL.
+    // Use URL API so /jsonrpc goes into the pathname, not after query params.
+    let rpcUrl = jsonRpcUrl;
+    if (!rpcUrl) {
+      const u = new URL(tronWebUrl);
+      if (!u.pathname.endsWith('/jsonrpc')) {
+        u.pathname = u.pathname.replace(/\/$/, '') + '/jsonrpc';
+      }
+      rpcUrl = u.toString();
+    }
     this.provider = new TronJsonRpcProvider(rpcUrl);
     this.tronAddressHex = this.address.toHex(this.tronAddress);
   }

--- a/typescript/tron-sdk/src/ethers/TronWallet.ts
+++ b/typescript/tron-sdk/src/ethers/TronWallet.ts
@@ -184,7 +184,7 @@ export class TronTransactionBuilder extends TronWeb {
     // Use URL API so /jsonrpc goes into the pathname, not after query params.
     let rpcUrl = jsonRpcUrl;
     if (!rpcUrl) {
-      const u = new URL(tronWebUrl);
+      const u = new URL(cleanTronWebUrl);
       if (!u.pathname.endsWith('/jsonrpc')) {
         u.pathname = u.pathname.replace(/\/$/, '') + '/jsonrpc';
       }

--- a/typescript/tron-sdk/src/ethers/urlUtils.test.ts
+++ b/typescript/tron-sdk/src/ethers/urlUtils.test.ts
@@ -73,4 +73,11 @@ describe('stripCustomRpcHeaders', () => {
     expect(result.url).to.equal(url);
     expect(result.headers).to.deep.equal({});
   });
+
+  it('strips malformed custom_rpc_header without colon', () => {
+    const url = 'https://host/jsonrpc?custom_rpc_header=nocolon';
+    const result = stripCustomRpcHeaders(url);
+    expect(result.url).to.equal('https://host/jsonrpc');
+    expect(result.headers).to.deep.equal({});
+  });
 });

--- a/typescript/tron-sdk/src/ethers/urlUtils.test.ts
+++ b/typescript/tron-sdk/src/ethers/urlUtils.test.ts
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+
+import { parseCustomHeaders, stripCustomRpcHeaders } from './urlUtils.js';
+
+describe('parseCustomHeaders', () => {
+  it('extracts a single custom_rpc_header', () => {
+    const url =
+      'https://api.trongrid.io?custom_rpc_header=TRON-PRO-API-KEY:abc123';
+    expect(parseCustomHeaders(url)).to.deep.equal({
+      'TRON-PRO-API-KEY': 'abc123',
+    });
+  });
+
+  it('extracts multiple custom_rpc_header params', () => {
+    const url =
+      'https://host?custom_rpc_header=x-api-key:key1&custom_rpc_header=Authorization:Bearer%20token';
+    expect(parseCustomHeaders(url)).to.deep.equal({
+      'x-api-key': 'key1',
+      Authorization: 'Bearer token',
+    });
+  });
+
+  it('handles header values with colons', () => {
+    const url = 'https://host?custom_rpc_header=x-api-key:token:with:colons';
+    expect(parseCustomHeaders(url)).to.deep.equal({
+      'x-api-key': 'token:with:colons',
+    });
+  });
+
+  it('returns empty object for URL without custom_rpc_header', () => {
+    const url = 'https://api.trongrid.io/jsonrpc';
+    expect(parseCustomHeaders(url)).to.deep.equal({});
+  });
+
+  it('returns empty object for invalid URL', () => {
+    expect(parseCustomHeaders('not-a-url')).to.deep.equal({});
+  });
+
+  it('ignores malformed header values without colon', () => {
+    const url = 'https://host?custom_rpc_header=nocolon';
+    expect(parseCustomHeaders(url)).to.deep.equal({});
+  });
+});
+
+describe('stripCustomRpcHeaders', () => {
+  it('strips custom_rpc_header and returns clean URL with headers', () => {
+    const url =
+      'https://tron-mainnet.gateway.tatum.io/jsonrpc?custom_rpc_header=x-api-key:abc123';
+    const result = stripCustomRpcHeaders(url);
+    expect(result.url).to.equal(
+      'https://tron-mainnet.gateway.tatum.io/jsonrpc',
+    );
+    expect(result.headers).to.deep.equal({ 'x-api-key': 'abc123' });
+  });
+
+  it('preserves non-custom_rpc_header query params', () => {
+    const url = 'https://host/jsonrpc?custom_rpc_header=x-api-key:abc&other=1';
+    const result = stripCustomRpcHeaders(url);
+    expect(result.url).to.equal('https://host/jsonrpc?other=1');
+    expect(result.headers).to.deep.equal({ 'x-api-key': 'abc' });
+  });
+
+  it('returns original URL unchanged when no custom_rpc_header', () => {
+    const url = 'https://api.trongrid.io/jsonrpc';
+    const result = stripCustomRpcHeaders(url);
+    expect(result.url).to.equal(url);
+    expect(result.headers).to.deep.equal({});
+  });
+
+  it('returns original URL unchanged when xApiKey query param is used', () => {
+    const url = 'https://tron-mainnet.gateway.tatum.io/jsonrpc?xApiKey=abc123';
+    const result = stripCustomRpcHeaders(url);
+    expect(result.url).to.equal(url);
+    expect(result.headers).to.deep.equal({});
+  });
+});

--- a/typescript/tron-sdk/src/ethers/urlUtils.ts
+++ b/typescript/tron-sdk/src/ethers/urlUtils.ts
@@ -1,0 +1,43 @@
+/**
+ * Parse custom_rpc_header query params from a URL into a headers object.
+ * e.g. "https://api.trongrid.io?custom_rpc_header=TRON-PRO-API-KEY:abc"
+ * returns { "TRON-PRO-API-KEY": "abc" }
+ */
+export function parseCustomHeaders(url: string): Record<string, string> {
+  const headers: Record<string, string> = {};
+  try {
+    const parsed = new URL(url);
+    for (const [key, value] of parsed.searchParams) {
+      if (key !== 'custom_rpc_header') continue;
+      const colonIdx = value.indexOf(':');
+      if (colonIdx > 0) {
+        headers[value.slice(0, colonIdx)] = value.slice(colonIdx + 1);
+      }
+    }
+  } catch {
+    // Not a valid URL, return empty headers
+  }
+  return headers;
+}
+
+/**
+ * Strip custom_rpc_header query params from a URL and return the clean URL
+ * along with the extracted headers.
+ *
+ * e.g. "https://host/jsonrpc?custom_rpc_header=x-api-key:abc&other=1"
+ * returns { url: "https://host/jsonrpc?other=1", headers: { "x-api-key": "abc" } }
+ *
+ * If no custom_rpc_header params are present, returns the original URL unchanged.
+ */
+export function stripCustomRpcHeaders(url: string): {
+  url: string;
+  headers: Record<string, string>;
+} {
+  const headers = parseCustomHeaders(url);
+  if (Object.keys(headers).length === 0) {
+    return { url, headers };
+  }
+  const parsed = new URL(url);
+  parsed.searchParams.delete('custom_rpc_header');
+  return { url: parsed.toString(), headers };
+}

--- a/typescript/tron-sdk/src/ethers/urlUtils.ts
+++ b/typescript/tron-sdk/src/ethers/urlUtils.ts
@@ -34,10 +34,15 @@ export function stripCustomRpcHeaders(url: string): {
   headers: Record<string, string>;
 } {
   const headers = parseCustomHeaders(url);
-  if (Object.keys(headers).length === 0) {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
     return { url, headers };
   }
-  const parsed = new URL(url);
+  if (!parsed.searchParams.has('custom_rpc_header')) {
+    return { url, headers };
+  }
   parsed.searchParams.delete('custom_rpc_header');
   return { url: parsed.toString(), headers };
 }


### PR DESCRIPTION
## Summary
- `TronJsonRpcProvider` now strips `custom_rpc_header` query params from the URL and passes them as real HTTP headers to ethers via `ConnectionInfo`, matching the existing `parseCustomHeaders` pattern in `TronWallet`
- `TronTransactionBuilder` now strips `custom_rpc_header` from its `tronWebUrl` before passing to TronWeb, preventing malformed URLs when TronWeb appends API paths (e.g. `/wallet/triggersmartcontract`)
- Fixed `/jsonrpc` path appending to use `URL` API instead of string concatenation, preventing it from being placed after query params

## Context
Third-party Tron RPC providers like Tatum require API key authentication via HTTP headers. The `custom_rpc_header` convention (e.g. `?custom_rpc_header=x-api-key:KEY`) was already supported by `TronWallet` but not by `TronJsonRpcProvider` or `TronTransactionBuilder`, causing:
1. JSON-RPC calls sent without auth headers → 401/paid-plan errors
2. TronWeb native API URLs malformed as `host?custom_rpc_header=...key/wallet/triggersmartcontract` → 404

## Test plan
- [ ] Verify `custom_rpc_header` is stripped from URL and sent as HTTP header for JSON-RPC calls
- [ ] Verify TronWeb native API calls use clean base URL with headers
- [ ] Verify existing TronGrid URLs (no `custom_rpc_header`) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
