### PR TITLE
fix(sdk): validate CCR router scales in warp check

### DIFF
--- a/.changeset/green-dolphins-attend.md
+++ b/.changeset/green-dolphins-attend.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Warp check validated scale against configured crossCollateralRouters.

--- a/typescript/sdk/src/token/warpCheck.test.ts
+++ b/typescript/sdk/src/token/warpCheck.test.ts
@@ -1,0 +1,167 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { CrossCollateralRouter__factory } from '@hyperlane-xyz/core';
+import { addressToBytes32 } from '@hyperlane-xyz/utils';
+
+import { test1, test2, testSealevelChain } from '../consts/testChains.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+
+import { EvmWarpRouteReader } from './EvmWarpRouteReader.js';
+import { TokenType } from './config.js';
+import { getScaleViolations } from './warpCheck.js';
+
+const MAILBOX = '0x000000000000000000000000000000000000b001';
+const OWNER = '0x000000000000000000000000000000000000dEaD';
+const ROUTER_B = '0x2222222222222222222222222222222222222222';
+const TOKEN_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const TOKEN_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+type ScaleValidationParams = Parameters<typeof getScaleViolations>[0];
+type ScaleValidationWarpRouteConfig = ScaleValidationParams['warpRouteConfig'];
+
+function buildMultiProvider(): MultiProvider {
+  return new MultiProvider({
+    [test1.name]: test1,
+    [test2.name]: test2,
+    [testSealevelChain.name]: testSealevelChain,
+  });
+}
+
+function stubConfiguredRouterMetadata({
+  decimals,
+  scale,
+}: {
+  decimals: number;
+  scale?: Awaited<ReturnType<EvmWarpRouteReader['fetchScale']>>;
+}) {
+  const connectStub = sinon
+    .stub(CrossCollateralRouter__factory, 'connect')
+    .returns({
+      wrappedToken: async () => TOKEN_B,
+      // CAST: unit test only uses wrappedToken()
+    } as ReturnType<typeof CrossCollateralRouter__factory.connect>);
+
+  const metadataStub = sinon
+    .stub(EvmWarpRouteReader.prototype, 'fetchERC20Metadata')
+    .resolves({
+      decimals,
+      isNft: false,
+      name: 'TOKEN',
+      symbol: 'TOKEN',
+    });
+
+  const scaleStub = sinon
+    .stub(EvmWarpRouteReader.prototype, 'fetchScale')
+    .resolves(scale);
+
+  return { connectStub, metadataStub, scaleStub };
+}
+
+function buildCrossCollateralConfig({
+  crossCollateralRouters,
+  decimals,
+  scale,
+}: {
+  crossCollateralRouters?: Record<string, string[]>;
+  decimals: number;
+  scale?: number;
+}): ScaleValidationWarpRouteConfig[string] {
+  return {
+    crossCollateralRouters,
+    decimals,
+    mailbox: MAILBOX,
+    name: 'TOKEN',
+    owner: OWNER,
+    scale,
+    symbol: 'TOKEN',
+    token: TOKEN_A,
+    type: TokenType.crossCollateral,
+  };
+}
+
+describe('getScaleViolations', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('passes when an off-subroute configured CCR router shares the same effective scale', async () => {
+    const { connectStub, metadataStub, scaleStub } =
+      stubConfiguredRouterMetadata({ decimals: 18 });
+
+    const warpRouteConfig: ScaleValidationWarpRouteConfig = {
+      [test1.name]: buildCrossCollateralConfig({
+        crossCollateralRouters: {
+          [test2.domainId.toString()]: [addressToBytes32(ROUTER_B)],
+        },
+        decimals: 6,
+        scale: 1_000_000_000_000,
+      }),
+    };
+
+    const violations = await getScaleViolations({
+      multiProvider: buildMultiProvider(),
+      warpRouteConfig,
+    });
+
+    expect(violations).to.deep.equal([]);
+    expect(
+      connectStub.calledOnceWithExactly(ROUTER_B, sinon.match.object),
+    ).to.equal(true);
+    expect(metadataStub.calledOnceWithExactly(TOKEN_B)).to.equal(true);
+    expect(scaleStub.calledOnceWithExactly(ROUTER_B)).to.equal(true);
+  });
+
+  it('fails when an off-subroute configured CCR router has mismatched decimals', async () => {
+    stubConfiguredRouterMetadata({ decimals: 8 });
+
+    const warpRouteConfig: ScaleValidationWarpRouteConfig = {
+      [test1.name]: buildCrossCollateralConfig({
+        crossCollateralRouters: {
+          [test2.domainId.toString()]: [addressToBytes32(ROUTER_B)],
+        },
+        decimals: 6,
+        scale: 1_000_000_000_000,
+      }),
+    };
+
+    const violations = await getScaleViolations({
+      multiProvider: buildMultiProvider(),
+      warpRouteConfig,
+    });
+
+    expect(violations).to.deep.equal([
+      {
+        actual: 'invalid-or-missing',
+        chain: 'route',
+        expected: 'consistent-with-decimals',
+        name: 'scale',
+        type: 'ScaleMismatch',
+      },
+    ]);
+  });
+
+  it('skips configured CCR routers on non-EVM chains', async () => {
+    const connectStub = sinon.stub(CrossCollateralRouter__factory, 'connect');
+
+    const warpRouteConfig: ScaleValidationWarpRouteConfig = {
+      [test1.name]: buildCrossCollateralConfig({
+        crossCollateralRouters: {
+          [testSealevelChain.domainId.toString()]: [
+            'So11111111111111111111111111111111111111112',
+          ],
+        },
+        decimals: 6,
+        scale: 1_000_000_000_000,
+      }),
+    };
+
+    const violations = await getScaleViolations({
+      multiProvider: buildMultiProvider(),
+      warpRouteConfig,
+    });
+
+    expect(violations).to.deep.equal([]);
+    expect(connectStub.notCalled).to.equal(true);
+  });
+});

--- a/typescript/sdk/src/token/warpCheck.ts
+++ b/typescript/sdk/src/token/warpCheck.ts
@@ -1,4 +1,5 @@
 import {
+  CrossCollateralRouter__factory,
   IERC4626__factory,
   IXERC20Lockbox__factory,
   Ownable__factory,
@@ -8,11 +9,15 @@ import {
   type Address,
   type ObjectDiff,
   assert,
+  bytes32ToAddress,
+  concurrentMap,
   deepCopy,
   diffObjMerge,
   eqAddress,
+  isAddressEvm,
   isEVMLike,
   keepOnlyDiffObjects,
+  normalizeAddressEvm,
   objFilter,
   objMap,
   promiseObjAll,
@@ -20,6 +25,7 @@ import {
 
 import { isProxy, proxyAdmin } from '../deploy/proxy.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
+import { resolveRouterMapConfig } from '../router/types.js';
 import { ChainName } from '../types.js';
 import { verifyScale } from '../utils/decimals.js';
 import { WarpCoreConfig } from '../warp/types.js';
@@ -35,6 +41,7 @@ import {
 import {
   DerivedWarpRouteDeployConfig,
   HypTokenRouterVirtualConfig,
+  TokenMetadata,
   WarpRouteDeployConfigMailboxRequired,
   derivedHookAddress,
   derivedIsmAddress,
@@ -63,6 +70,16 @@ export interface WarpRouteCheckResult {
   scaleViolations: WarpRouteCheckViolation[];
   violations: WarpRouteCheckViolation[];
 }
+
+type ScaleValidationWarpRouteConfig = WarpRouteDeployConfigMailboxRequired &
+  Record<string, Partial<HypTokenRouterVirtualConfig>>;
+
+type CrossCollateralRouterRef = {
+  chain: string;
+  metadataKey: string;
+  routerAddress: string;
+  routerId: string;
+};
 
 async function getWarpRouteConfigsByCore({
   multiProvider,
@@ -157,7 +174,10 @@ export async function checkWarpRouteDeployConfig({
 
   const diff = keepOnlyDiffObjects(rawDiff) as Record<string, ObjectDiff>; // CAST: keepOnlyDiffObjects returns `any`; rawDiff is constructed as a chain-keyed ObjectDiff map
   const diffViolations = flattenWarpRouteCheckDiff(diff);
-  const scaleViolations = getScaleViolations(expandedWarpDeployConfig);
+  const scaleViolations = await getScaleViolations({
+    multiProvider,
+    warpRouteConfig: expandedWarpDeployConfig,
+  });
 
   return {
     diff,
@@ -420,11 +440,141 @@ function flattenDiffNode(
   return [];
 }
 
-function getScaleViolations(
-  warpRouteConfig: WarpRouteDeployConfigMailboxRequired &
-    Record<string, Partial<HypTokenRouterVirtualConfig>>,
-): WarpRouteCheckViolation[] {
-  if (verifyScale(warpRouteConfig)) {
+function collectConfiguredCrossCollateralRouters({
+  multiProvider,
+  warpRouteConfig,
+}: {
+  multiProvider: MultiProvider;
+  warpRouteConfig: ScaleValidationWarpRouteConfig;
+}): CrossCollateralRouterRef[] {
+  const routerRefs = new Map<string, CrossCollateralRouterRef>();
+
+  for (const config of Object.values(warpRouteConfig)) {
+    if (
+      !isCrossCollateralTokenConfig(config) ||
+      !config.crossCollateralRouters
+    ) {
+      continue;
+    }
+
+    const crossCollateralRouters = resolveRouterMapConfig(
+      multiProvider,
+      config.crossCollateralRouters,
+    );
+
+    for (const [domain, routers] of Object.entries(crossCollateralRouters)) {
+      const chain = multiProvider.tryGetChainName(Number(domain));
+      if (!chain || !isEVMLike(multiProvider.getProtocol(chain))) {
+        continue;
+      }
+
+      for (const routerId of routers) {
+        const routerAddress = normalizeAddressEvm(
+          isAddressEvm(routerId) ? routerId : bytes32ToAddress(routerId),
+        );
+        const metadataKey = `${chain}:${routerAddress.toLowerCase()}`;
+        routerRefs.set(metadataKey, {
+          chain,
+          metadataKey,
+          routerAddress,
+          routerId,
+        });
+      }
+    }
+  }
+
+  return [...routerRefs.values()];
+}
+
+async function fetchConfiguredCrossCollateralRouterMetadata({
+  multiProvider,
+  readerByChain,
+  routerRef,
+}: {
+  multiProvider: MultiProvider;
+  readerByChain: Map<string, EvmWarpRouteReader>;
+  routerRef: CrossCollateralRouterRef;
+}): Promise<readonly [string, TokenMetadata]> {
+  const { chain, metadataKey, routerAddress, routerId } = routerRef;
+  const reader =
+    readerByChain.get(chain) ?? new EvmWarpRouteReader(multiProvider, chain);
+  readerByChain.set(chain, reader);
+
+  try {
+    const crossCollateralRouter = CrossCollateralRouter__factory.connect(
+      routerAddress,
+      multiProvider.getProvider(chain),
+    );
+    const [wrappedTokenAddress, scale] = await Promise.all([
+      crossCollateralRouter.wrappedToken(),
+      reader.fetchScale(routerAddress),
+    ]);
+    const metadata = await reader.fetchERC20Metadata(wrappedTokenAddress);
+
+    return [metadataKey, { ...metadata, scale }] as const;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to derive configured crossCollateral router ${routerId} on ${chain}: ${message}`,
+    );
+  }
+}
+
+async function buildScaleValidationMetadataMap({
+  multiProvider,
+  warpRouteConfig,
+}: {
+  multiProvider: MultiProvider;
+  warpRouteConfig: ScaleValidationWarpRouteConfig;
+}): Promise<Map<string, TokenMetadata>> {
+  const metadataByKey = new Map<string, TokenMetadata>(
+    Object.entries(warpRouteConfig).map(([chain, config]) => [
+      chain,
+      {
+        decimals: config.decimals,
+        name: config.name ?? 'unknown',
+        scale: config.scale,
+        symbol: config.symbol ?? 'unknown',
+      },
+    ]),
+  );
+
+  const readerByChain = new Map<string, EvmWarpRouteReader>();
+  const configuredRouters = collectConfiguredCrossCollateralRouters({
+    multiProvider,
+    warpRouteConfig,
+  });
+  const configuredRouterMetadata = await concurrentMap(
+    6,
+    configuredRouters,
+    async (routerRef) =>
+      fetchConfiguredCrossCollateralRouterMetadata({
+        multiProvider,
+        readerByChain,
+        routerRef,
+      }),
+  );
+
+  for (const [metadataKey, metadata] of configuredRouterMetadata) {
+    metadataByKey.set(metadataKey, metadata);
+  }
+
+  return metadataByKey;
+}
+
+export async function getScaleViolations({
+  multiProvider,
+  warpRouteConfig,
+}: {
+  multiProvider: MultiProvider;
+  warpRouteConfig: ScaleValidationWarpRouteConfig;
+}): Promise<WarpRouteCheckViolation[]> {
+  const scaleValidationMetadata = await buildScaleValidationMetadataMap({
+    multiProvider,
+    warpRouteConfig,
+  });
+
+  if (verifyScale(scaleValidationMetadata)) {
     return [];
   }
 

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -58,11 +58,6 @@ describe('WarpCore', () => {
   let cw20: Token;
   let cosmosIbc: Token;
 
-  // Stub MultiProvider fee estimation to avoid real network calls
-  sinon
-    .stub(multiProvider, 'estimateTransactionFee')
-    .returns(Promise.resolve(MOCK_LOCAL_QUOTE));
-
   before(() => {
     const exampleConfig = yamlParse(
       fs.readFileSync('./src/warp/test-warp-core-config.yaml', 'utf-8'),
@@ -82,6 +77,16 @@ describe('WarpCore', () => {
       cw20,
       cosmosIbc,
     ] = warpCore.tokens;
+  });
+
+  beforeEach(() => {
+    sinon
+      .stub(multiProvider, 'estimateTransactionFee')
+      .returns(Promise.resolve(MOCK_LOCAL_QUOTE));
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   it('Constructs', () => {


### PR DESCRIPTION
## Summary
- validate warp scale against configured `crossCollateralRouters`, even when those routers are outside the immediate route subset
- keep the logic in SDK `warpCheck` instead of reviving the older CLI-only approach
- add focused unit coverage for matching, mismatched, and non-EVM configured CCR routers

## Why
`#8554` moves warp checking into the SDK. The remaining useful part of `#8506` is the CCR off-subroute scale-validation behavior, which still needs to live at the SDK layer.

## Stack
This PR is stacked on top of `#8554`.
Base branch: `pbio/warp-check-cli-shared`

## Validation
- `pnpm -C typescript/sdk check`
- `pnpm -C typescript/sdk exec mocha --config .mocharc.json './src/token/warpCheck.test.ts' --exit`
- `NODE_OPTIONS='--import tsx/esm' pnpm -C typescript/sdk exec hardhat --config hardhat.config.cts test ./src/token/deploy.hardhat-test.ts --grep 'checkWarpRouteDeployConfig'`

## Root Cause
Scale validation previously only considered the expanded route subset. Configured cross-collateral routers outside that subset were ignored, so mismatched CCR scale could slip past warp check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new on-chain metadata fetching for configured `crossCollateralRouters` (including off-subroute routers), which can affect warp check behavior and introduce new RPC/error paths despite test coverage.
> 
> **Overview**
> Warp route scale validation now also considers *configured* `crossCollateralRouters` (even when those routers are outside the expanded route subset) by fetching each router’s `wrappedToken` metadata and derived scale on EVM chains and including them in `verifyScale`.
> 
> `getScaleViolations` is updated to be async, perform concurrent metadata collection/deduping, and skip non-EVM configured routers; new unit tests cover matching scale, mismatched decimals, and non-EVM skipping. A small test fix moves the `estimateTransactionFee` stub in `WarpCore.test.ts` to per-test setup/teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5be93d4f01bbb54bb092c10513fd9c0db65fda24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
