### PR TITLE
feat: add registry-backed submitter references

### DIFF
--- a/.changeset/submitter-reference-registry.md
+++ b/.changeset/submitter-reference-registry.md
@@ -1,0 +1,7 @@
+---
+'@hyperlane-xyz/sdk': patch
+'@hyperlane-xyz/cli': patch
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Registry-backed submitter references were added for resolving submitter metadata through the SDK, CLI, and rebalancer without requiring consumers to pass raw private keys directly.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2246,6 +2246,9 @@ importers:
       viem:
         specifier: 'catalog:'
         version: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      yaml:
+        specifier: 'catalog:'
+        version: 2.4.5
       zksync-ethers:
         specifier: 'catalog:'
         version: 5.11.0(ethers@5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -2322,9 +2325,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
-      yaml:
-        specifier: 'catalog:'
-        version: 2.4.5
 
   typescript/starknet-sdk:
     dependencies:

--- a/typescript/cli/README.md
+++ b/typescript/cli/README.md
@@ -56,6 +56,36 @@ View SDK contract addresses: `hyperlane chains addresses`
 
 Send test message: `hyperlane send message`
 
+## Submitter strategies
+
+The CLI accepts per-chain submission strategies with a `submitter` block. There are now three main ways to provide that submitter config:
+
+- Inline submitter metadata: put the full submitter config directly in the strategy file.
+- `file` submitter: write transactions to disk instead of sending them. Useful for offline review/signing flows, not for shared credential lookup.
+- `submitter_ref`: keep the strategy small and resolve the real submitter config from the registry at runtime.
+
+`submitter_ref` is a registry-backed indirection layer. Instead of embedding a private key or multisig config inline, the strategy points at a top-level registry entry under `submitters/`. The resolved payload can be either a bare submitter object or a `{ submitter: ... }` strategy wrapper.
+
+```yaml
+# strategy.yaml
+arbitrum:
+  submitter:
+    type: submitter_ref
+    ref: submitters/dev-arbitrum
+```
+
+```yaml
+# <registry>/submitters/dev-arbitrum.yaml
+submitter:
+  type: jsonRpc
+  chain: arbitrum
+  privateKey: ${HYP_KEY}
+```
+
+Compared with inline config, `submitter_ref` keeps reusable submitter definitions in one place and lets multiple configs share them. Compared with `file` submitters, `submitter_ref` still resolves to a real on-chain submitter and executes transactions normally.
+
+Resolution is done against the same registries the CLI already loads. Local registries are read from disk. HTTPS-backed registries are fetched over HTTP(S), and when an auth token is configured for registry access the CLI forwards it as `Authorization: Bearer <token>` while resolving submitter refs.
+
 ### Address conversion utilities
 
 Convert address to bytes32: `hyperlane address to-bytes32 --address <address> [--protocol <protocol>]`

--- a/typescript/cli/src/commands/submit.ts
+++ b/typescript/cli/src/commands/submit.ts
@@ -1,13 +1,12 @@
 import { groupBy } from 'lodash-es';
 
-import {
-  type SubmissionStrategy,
-  SubmissionStrategySchema,
-} from '@hyperlane-xyz/sdk';
-
 import { getTransactions, runSubmit } from '../config/submit.js';
 import { type CommandModuleWithWriteContext } from '../context/types.js';
 import { logBlue, logGray, logRed } from '../logger.js';
+import {
+  type ExtendedSubmissionStrategy,
+  ExtendedSubmissionStrategySchema,
+} from '../submitters/types.js';
 import { isFile, readYamlOrJson } from '../utils/files.js';
 
 import {
@@ -81,9 +80,9 @@ export const submitCommand: CommandModuleWithWriteContext<{
  */
 export function readSubmissionStrategy(
   submissionStrategyFilepath: string,
-): SubmissionStrategy {
+): ExtendedSubmissionStrategy {
   const submissionStrategyFileContent = readYamlOrJson(
     submissionStrategyFilepath.trim(),
   );
-  return SubmissionStrategySchema.parse(submissionStrategyFileContent);
+  return ExtendedSubmissionStrategySchema.parse(submissionStrategyFileContent);
 }

--- a/typescript/cli/src/context/context.ts
+++ b/typescript/cli/src/context/context.ts
@@ -16,6 +16,7 @@ import {
   ExplorerFamily,
   MultiProtocolProvider,
   MultiProvider,
+  UnresolvedSubmissionStrategySchema,
   type UnresolvedSubmissionStrategy,
   resolveSubmissionStrategy,
 } from '@hyperlane-xyz/sdk';
@@ -29,7 +30,10 @@ import {
 
 import { isSignCommand } from '../commands/signCommands.js';
 import { readChainSubmissionStrategyConfig } from '../config/strategy.js';
-import { CustomTxSubmitterType } from '../submitters/types.js';
+import {
+  CustomTxSubmitterType,
+  type ExtendedSubmissionStrategy,
+} from '../submitters/types.js';
 import { createSubmitterReferenceRegistry } from '../submitters/registry.js';
 import { detectAndConfirmOrPrompt } from '../utils/input.js';
 import { getSigner } from '../utils/keys.js';
@@ -91,6 +95,12 @@ function toOptionalSignerKey(value: unknown): ContextSettings['key'] {
   if (typeof value === 'string') return value;
   if (value === undefined) return undefined;
   return SignerKeyProtocolMapSchema.parse(value);
+}
+
+function parseUnresolvedSubmissionStrategy(
+  strategy: ExtendedSubmissionStrategy,
+): UnresolvedSubmissionStrategy {
+  return UnresolvedSubmissionStrategySchema.parse(strategy);
 }
 
 export async function contextMiddleware(argv: ContextMiddlewareArgv) {
@@ -186,7 +196,7 @@ export async function signerMiddleware(argv: ContextMiddlewareArgv) {
           return [
             chain,
             await resolveSubmissionStrategy(
-              strategy as UnresolvedSubmissionStrategy,
+              parseUnresolvedSubmissionStrategy(strategy),
               createSubmitterReferenceRegistry(argv.context.registry),
               chain,
             ),
@@ -445,16 +455,13 @@ export async function ensureEvmSignersForChains(
             return [chain, strategy];
           }
 
-          assert(
-            context.registry,
-            'Registry is required to resolve submitter references',
-          );
-
           return [
             chain,
             await resolveSubmissionStrategy(
-              strategy as UnresolvedSubmissionStrategy,
-              createSubmitterReferenceRegistry(context.registry),
+              parseUnresolvedSubmissionStrategy(strategy),
+              context.registry
+                ? createSubmitterReferenceRegistry(context.registry)
+                : undefined,
               chain,
             ),
           ];

--- a/typescript/cli/src/context/context.ts
+++ b/typescript/cli/src/context/context.ts
@@ -173,21 +173,25 @@ export async function signerMiddleware(argv: ContextMiddlewareArgv) {
   if (!requiresKey) return;
   assert(key, 'Expected signer keys when running signer middleware');
 
+  const chainsSet = new Set(chains);
   const resolvedStrategyConfig = Object.fromEntries(
     await Promise.all(
-      Object.entries(strategyConfig).map(async ([chain, strategy]) => {
-        if (strategy.submitter.type === CustomTxSubmitterType.FILE) {
-          return [chain, strategy];
-        }
+      Object.entries(strategyConfig)
+        .filter(([chain]) => chainsSet.has(chain))
+        .map(async ([chain, strategy]) => {
+          if (strategy.submitter.type === CustomTxSubmitterType.FILE) {
+            return [chain, strategy];
+          }
 
-        return [
-          chain,
-          await resolveSubmissionStrategy(
-            strategy as UnresolvedSubmissionStrategy,
-            createSubmitterReferenceRegistry(argv.context.registry),
-          ),
-        ];
-      }),
+          return [
+            chain,
+            await resolveSubmissionStrategy(
+              strategy as UnresolvedSubmissionStrategy,
+              createSubmitterReferenceRegistry(argv.context.registry),
+              chain,
+            ),
+          ];
+        }),
     ),
   );
 
@@ -431,26 +435,30 @@ export async function ensureEvmSignersForChains(
   const strategyConfig = context.strategyPath
     ? await readChainSubmissionStrategyConfig(context.strategyPath)
     : {};
+  const missingSignerChainSet = new Set(missingSignerChains);
   const resolvedStrategyConfig = Object.fromEntries(
     await Promise.all(
-      Object.entries(strategyConfig).map(async ([chain, strategy]) => {
-        if (strategy.submitter.type === CustomTxSubmitterType.FILE) {
-          return [chain, strategy];
-        }
+      Object.entries(strategyConfig)
+        .filter(([chain]) => missingSignerChainSet.has(chain))
+        .map(async ([chain, strategy]) => {
+          if (strategy.submitter.type === CustomTxSubmitterType.FILE) {
+            return [chain, strategy];
+          }
 
-        assert(
-          context.registry,
-          'Registry is required to resolve submitter references',
-        );
+          assert(
+            context.registry,
+            'Registry is required to resolve submitter references',
+          );
 
-        return [
-          chain,
-          await resolveSubmissionStrategy(
-            strategy as UnresolvedSubmissionStrategy,
-            createSubmitterReferenceRegistry(context.registry),
-          ),
-        ];
-      }),
+          return [
+            chain,
+            await resolveSubmissionStrategy(
+              strategy as UnresolvedSubmissionStrategy,
+              createSubmitterReferenceRegistry(context.registry),
+              chain,
+            ),
+          ];
+        }),
     ),
   );
 

--- a/typescript/cli/src/context/context.ts
+++ b/typescript/cli/src/context/context.ts
@@ -197,7 +197,10 @@ export async function signerMiddleware(argv: ContextMiddlewareArgv) {
             chain,
             await resolveSubmissionStrategy(
               parseUnresolvedSubmissionStrategy(strategy),
-              extendRegistryWithSubmitters(argv.context.registry),
+              extendRegistryWithSubmitters(
+                argv.context.registry,
+                argv.context.authToken,
+              ),
               chain,
             ),
           ];
@@ -275,6 +278,7 @@ export async function getContext({
   ];
 
   return {
+    authToken,
     registry,
     requiresKey,
     chainMetadata: multiProvider.metadata,
@@ -421,6 +425,7 @@ export async function ensureEvmSignersForChains(
     key: SignerKeyProtocolMap;
     multiProvider: MultiProvider;
     multiProtocolProvider: MultiProtocolProvider;
+    authToken?: string;
     registry?: IRegistry;
     strategyPath?: string;
   },
@@ -460,7 +465,10 @@ export async function ensureEvmSignersForChains(
             await resolveSubmissionStrategy(
               parseUnresolvedSubmissionStrategy(strategy),
               context.registry
-                ? extendRegistryWithSubmitters(context.registry)
+                ? extendRegistryWithSubmitters(
+                    context.registry,
+                    context.authToken,
+                  )
                 : undefined,
               chain,
             ),

--- a/typescript/cli/src/context/context.ts
+++ b/typescript/cli/src/context/context.ts
@@ -34,7 +34,7 @@ import {
   CustomTxSubmitterType,
   type ExtendedSubmissionStrategy,
 } from '../submitters/types.js';
-import { createSubmitterReferenceRegistry } from '../submitters/registry.js';
+import { extendRegistryWithSubmitters } from '../submitters/registry.js';
 import { detectAndConfirmOrPrompt } from '../utils/input.js';
 import { getSigner } from '../utils/keys.js';
 
@@ -197,7 +197,7 @@ export async function signerMiddleware(argv: ContextMiddlewareArgv) {
             chain,
             await resolveSubmissionStrategy(
               parseUnresolvedSubmissionStrategy(strategy),
-              createSubmitterReferenceRegistry(argv.context.registry),
+              extendRegistryWithSubmitters(argv.context.registry),
               chain,
             ),
           ];
@@ -460,7 +460,7 @@ export async function ensureEvmSignersForChains(
             await resolveSubmissionStrategy(
               parseUnresolvedSubmissionStrategy(strategy),
               context.registry
-                ? createSubmitterReferenceRegistry(context.registry)
+                ? extendRegistryWithSubmitters(context.registry)
                 : undefined,
               chain,
             ),

--- a/typescript/cli/src/context/context.ts
+++ b/typescript/cli/src/context/context.ts
@@ -16,17 +16,21 @@ import {
   ExplorerFamily,
   MultiProtocolProvider,
   MultiProvider,
+  type UnresolvedSubmissionStrategy,
+  resolveSubmissionStrategy,
 } from '@hyperlane-xyz/sdk';
 import {
   type Address,
   ProtocolType,
-  isEVMLike,
   assert,
+  isEVMLike,
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
 import { isSignCommand } from '../commands/signCommands.js';
 import { readChainSubmissionStrategyConfig } from '../config/strategy.js';
+import { CustomTxSubmitterType } from '../submitters/types.js';
+import { createSubmitterReferenceRegistry } from '../submitters/registry.js';
 import { detectAndConfirmOrPrompt } from '../utils/input.js';
 import { getSigner } from '../utils/keys.js';
 
@@ -169,11 +173,29 @@ export async function signerMiddleware(argv: ContextMiddlewareArgv) {
   if (!requiresKey) return;
   assert(key, 'Expected signer keys when running signer middleware');
 
+  const resolvedStrategyConfig = Object.fromEntries(
+    await Promise.all(
+      Object.entries(strategyConfig).map(async ([chain, strategy]) => {
+        if (strategy.submitter.type === CustomTxSubmitterType.FILE) {
+          return [chain, strategy];
+        }
+
+        return [
+          chain,
+          await resolveSubmissionStrategy(
+            strategy as UnresolvedSubmissionStrategy,
+            createSubmitterReferenceRegistry(argv.context.registry),
+          ),
+        ];
+      }),
+    ),
+  );
+
   /**
    * Extracts signer config
    */
   const multiProtocolSigner = await MultiProtocolSignerManager.init(
-    strategyConfig,
+    resolvedStrategyConfig,
     chains,
     multiProtocolProvider,
     { key },
@@ -191,7 +213,7 @@ export async function signerMiddleware(argv: ContextMiddlewareArgv) {
     argv.context.multiProvider,
     chains,
     key,
-    strategyConfig,
+    resolvedStrategyConfig,
   );
 
   return;
@@ -385,6 +407,7 @@ export async function ensureEvmSignersForChains(
     key: SignerKeyProtocolMap;
     multiProvider: MultiProvider;
     multiProtocolProvider: MultiProtocolProvider;
+    registry?: IRegistry;
     strategyPath?: string;
   },
   chains: ChainName[],
@@ -408,11 +431,33 @@ export async function ensureEvmSignersForChains(
   const strategyConfig = context.strategyPath
     ? await readChainSubmissionStrategyConfig(context.strategyPath)
     : {};
+  const resolvedStrategyConfig = Object.fromEntries(
+    await Promise.all(
+      Object.entries(strategyConfig).map(async ([chain, strategy]) => {
+        if (strategy.submitter.type === CustomTxSubmitterType.FILE) {
+          return [chain, strategy];
+        }
+
+        assert(
+          context.registry,
+          'Registry is required to resolve submitter references',
+        );
+
+        return [
+          chain,
+          await resolveSubmissionStrategy(
+            strategy as UnresolvedSubmissionStrategy,
+            createSubmitterReferenceRegistry(context.registry),
+          ),
+        ];
+      }),
+    ),
+  );
 
   // Use MultiProtocolSignerManager to create signers properly
   // This handles ZkSync chains and strategy-based keys
   const signerManager = await MultiProtocolSignerManager.init(
-    strategyConfig,
+    resolvedStrategyConfig,
     missingSignerChains,
     context.multiProtocolProvider,
     { key: context.key },

--- a/typescript/cli/src/context/strategies/chain/chainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/chainResolver.ts
@@ -432,7 +432,8 @@ async function resolveSubmitChains(
 export function getSubmitterChains(
   submitter: ExtendedSubmissionStrategy['submitter'],
 ): ChainName[] {
-  const chains: ChainName[] = submitter.chain ? [submitter.chain] : [];
+  const chains: ChainName[] =
+    'chain' in submitter && submitter.chain ? [submitter.chain] : [];
   if (submitter.type === TxSubmitterType.INTERCHAIN_ACCOUNT) {
     if (submitter.destinationChain) chains.push(submitter.destinationChain);
     if (submitter.internalSubmitter)

--- a/typescript/cli/src/context/strategies/chain/chainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/chainResolver.ts
@@ -434,6 +434,7 @@ export function getSubmitterChains(
 ): ChainName[] {
   const chains: ChainName[] =
     'chain' in submitter && submitter.chain ? [submitter.chain] : [];
+  // submitter_ref has no chain until resolved; caller adds the destination chain separately.
   if (submitter.type === TxSubmitterType.INTERCHAIN_ACCOUNT) {
     if (submitter.destinationChain) chains.push(submitter.destinationChain);
     if (submitter.internalSubmitter)

--- a/typescript/cli/src/context/strategies/signer/BaseMultiProtocolSigner.ts
+++ b/typescript/cli/src/context/strategies/signer/BaseMultiProtocolSigner.ts
@@ -1,23 +1,17 @@
 import { password } from '@inquirer/prompts';
 import { type Signer } from 'ethers';
 
-import {
-  type MultiProtocolProvider,
-  type TxSubmitterType,
-} from '@hyperlane-xyz/sdk';
+import { type ChainName, type MultiProtocolProvider } from '@hyperlane-xyz/sdk';
 import { type Address } from '@hyperlane-xyz/utils';
-
-import { type ExtendedChainSubmissionStrategy } from '../../../submitters/types.js';
 
 export type TypedSigner = Signer;
 
-export type SignerConfig = Omit<
-  Extract<
-    ExtendedChainSubmissionStrategy[string]['submitter'],
-    { type: TxSubmitterType.JSON_RPC }
-  >,
-  'type'
->;
+export type SignerConfig = {
+  chain: ChainName;
+  extraParams?: Record<string, string>;
+  privateKey?: string;
+  userAddress?: Address;
+};
 
 export interface IMultiProtocolSigner {
   getSigner(config: SignerConfig): Promise<TypedSigner>;

--- a/typescript/cli/src/context/types.ts
+++ b/typescript/cli/src/context/types.ts
@@ -48,6 +48,7 @@ export interface CommandContext extends Omit<
   BaseContext,
   'key' | 'skipConfirmation'
 > {
+  authToken?: string;
   key?: SignerKeyProtocolMap;
   registry: IRegistry;
   chainMetadata: ChainMap<ChainMetadata>;

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -86,7 +86,7 @@ import {
 } from '../logger.js';
 import { WarpSendLogs } from '../send/transfer.js';
 import { EV5FileSubmitter } from '../submitters/EV5FileSubmitter.js';
-import { createSubmitterReferenceRegistry } from '../submitters/registry.js';
+import { extendRegistryWithSubmitters } from '../submitters/registry.js';
 import {
   CustomTxSubmitterType,
   type ExtendedChainSubmissionStrategy,
@@ -1235,7 +1235,7 @@ export async function getSubmitterByStrategy<T extends ProtocolType>({
         (strategyToUse as SubmissionStrategy)
       : await resolveSubmissionStrategy(
           UnresolvedSubmissionStrategySchema.parse(strategyToUse),
-          createSubmitterReferenceRegistry(registry),
+          extendRegistryWithSubmitters(registry),
           chain,
         );
 

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -1235,7 +1235,7 @@ export async function getSubmitterByStrategy<T extends ProtocolType>({
         (strategyToUse as SubmissionStrategy)
       : await resolveSubmissionStrategy(
           UnresolvedSubmissionStrategySchema.parse(strategyToUse),
-          extendRegistryWithSubmitters(registry),
+          extendRegistryWithSubmitters(registry, context.authToken),
           chain,
         );
 

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -36,6 +36,7 @@ import {
   type TxSubmitterBuilder,
   TxSubmitterType,
   type TypedAnnotatedTransaction,
+  type UnresolvedSubmissionStrategy,
   type WarpCoreConfig,
   WarpCoreConfigSchema,
   type WarpRouteDeployConfig,
@@ -54,6 +55,7 @@ import {
   isCrossCollateralTokenConfig,
   isXERC20TokenConfig,
   normalizeScale,
+  resolveSubmissionStrategy,
   splitWarpCoreAndExtendedConfigs,
   tokenTypeToStandard,
 } from '@hyperlane-xyz/sdk';
@@ -84,6 +86,7 @@ import {
 } from '../logger.js';
 import { WarpSendLogs } from '../send/transfer.js';
 import { EV5FileSubmitter } from '../submitters/EV5FileSubmitter.js';
+import { createSubmitterReferenceRegistry } from '../submitters/registry.js';
 import {
   CustomTxSubmitterType,
   type ExtendedChainSubmissionStrategy,
@@ -1225,14 +1228,22 @@ export async function getSubmitterByStrategy<T extends ProtocolType>({
     };
   }
 
+  const resolvedStrategy =
+    strategyToUse.submitter.type === CustomTxSubmitterType.FILE
+      ? (strategyToUse as SubmissionStrategy)
+      : await resolveSubmissionStrategy(
+          strategyToUse as UnresolvedSubmissionStrategy,
+          createSubmitterReferenceRegistry(registry),
+        );
+
   return {
     submitter: await getSubmitterBuilder<T>({
-      submissionStrategy: strategyToUse as SubmissionStrategy, // TODO: fix this
+      submissionStrategy: resolvedStrategy,
       multiProvider,
       coreAddressesByChain: await registry.getAddresses(),
       additionalSubmitterFactories,
     }),
-    config: submissionStrategy,
+    config: strategyToUse,
   };
 }
 

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -36,7 +36,7 @@ import {
   type TxSubmitterBuilder,
   TxSubmitterType,
   type TypedAnnotatedTransaction,
-  type UnresolvedSubmissionStrategy,
+  UnresolvedSubmissionStrategySchema,
   type WarpCoreConfig,
   WarpCoreConfigSchema,
   type WarpRouteDeployConfig,
@@ -1230,9 +1230,11 @@ export async function getSubmitterByStrategy<T extends ProtocolType>({
 
   const resolvedStrategy =
     strategyToUse.submitter.type === CustomTxSubmitterType.FILE
-      ? (strategyToUse as SubmissionStrategy)
+      ? // CAST: FILE submitters are handled by additionalSubmitterFactories below,
+        // but the shared SDK SubmissionStrategy type only models built-in submitters.
+        (strategyToUse as SubmissionStrategy)
       : await resolveSubmissionStrategy(
-          strategyToUse as UnresolvedSubmissionStrategy,
+          UnresolvedSubmissionStrategySchema.parse(strategyToUse),
           createSubmitterReferenceRegistry(registry),
           chain,
         );

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -1234,6 +1234,7 @@ export async function getSubmitterByStrategy<T extends ProtocolType>({
       : await resolveSubmissionStrategy(
           strategyToUse as UnresolvedSubmissionStrategy,
           createSubmitterReferenceRegistry(registry),
+          chain,
         );
 
   return {
@@ -1243,7 +1244,7 @@ export async function getSubmitterByStrategy<T extends ProtocolType>({
       coreAddressesByChain: await registry.getAddresses(),
       additionalSubmitterFactories,
     }),
-    config: strategyToUse,
+    config: resolvedStrategy,
   };
 }
 

--- a/typescript/cli/src/status/message.ts
+++ b/typescript/cli/src/status/message.ts
@@ -89,6 +89,7 @@ export async function checkMessageStatus({
           key: context.key,
           multiProtocolProvider: context.multiProtocolProvider,
           multiProvider: context.multiProvider,
+          registry: context.registry,
           strategyPath: context.strategyPath,
         },
         destinationChains,

--- a/typescript/cli/src/submitters/registry.test.ts
+++ b/typescript/cli/src/submitters/registry.test.ts
@@ -9,11 +9,13 @@ describe('extendRegistryWithSubmitters', () => {
   const originalFetch = globalThis.fetch;
   const fetchPayloads = new Map<string, string>();
   let fetchCalls: string[];
+  let fetchHeaders: Array<Record<string, string> | undefined>;
 
   beforeEach(() => {
     fetchPayloads.clear();
     fetchCalls = [];
-    globalThis.fetch = async (input) => {
+    fetchHeaders = [];
+    globalThis.fetch = async (input, init) => {
       const url =
         typeof input === 'string'
           ? input
@@ -21,6 +23,7 @@ describe('extendRegistryWithSubmitters', () => {
             ? input.href
             : input.url;
       fetchCalls.push(url);
+      fetchHeaders.push(init?.headers as Record<string, string> | undefined);
       const ok = fetchPayloads.has(url);
       return {
         ok,
@@ -33,6 +36,43 @@ describe('extendRegistryWithSubmitters', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+  });
+
+  it('forwards auth tokens for remote submitter refs', async () => {
+    fetchPayloads.set(
+      'https://registry.example/submitters/dev-ethereum.yaml',
+      [
+        'type: jsonRpc',
+        'chain: ethereum',
+        'privateKey: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"',
+        '',
+      ].join('\n'),
+    );
+
+    const registry = extendRegistryWithSubmitters(
+      {
+        uri: 'https://registry.example',
+        getUri(itemPath?: string) {
+          return itemPath
+            ? `https://registry.example/${itemPath}`
+            : 'https://registry.example';
+        },
+      } as IRegistry,
+      'secret-token',
+    );
+
+    const submitter = await registry.getSubmitter?.('submitters/dev-ethereum');
+
+    expect(submitter).to.deep.equal({
+      type: TxSubmitterType.JSON_RPC,
+      chain: 'ethereum',
+      privateKey:
+        '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    });
+    expect(fetchHeaders).to.deep.equal([
+      { Authorization: 'Bearer secret-token' },
+      { Authorization: 'Bearer secret-token' },
+    ]);
   });
 
   it('prefers later child registries over earlier child registries', async () => {

--- a/typescript/cli/src/submitters/registry.test.ts
+++ b/typescript/cli/src/submitters/registry.test.ts
@@ -21,8 +21,11 @@ describe('createSubmitterReferenceRegistry', () => {
             ? input.href
             : input.url;
       fetchCalls.push(url);
+      const ok = fetchPayloads.has(url);
       return {
-        ok: fetchPayloads.has(url),
+        ok,
+        status: ok ? 200 : 404,
+        statusText: ok ? 'OK' : 'Not Found',
         text: async () => fetchPayloads.get(url)!,
       } as Response;
     };
@@ -96,5 +99,30 @@ describe('createSubmitterReferenceRegistry', () => {
 
     expect(submitter).to.equal(null);
     expect(fetchCalls).to.deep.equal([]);
+  });
+
+  it('throws on malformed submitter payloads', async () => {
+    fetchPayloads.set(
+      'https://registry.example/submitters/dev-ethereum.yaml',
+      'type: [',
+    );
+
+    const registry = createSubmitterReferenceRegistry({
+      uri: 'https://registry.example',
+      getUri(itemPath?: string) {
+        return itemPath
+          ? `https://registry.example/${itemPath}`
+          : 'https://registry.example';
+      },
+    } as IRegistry);
+
+    try {
+      await registry.getSubmitter?.('submitters/dev-ethereum');
+      throw new Error('Expected malformed submitter payload to throw');
+    } catch (error) {
+      expect((error as Error).message).to.include(
+        'Failed to parse submitter reference payload',
+      );
+    }
   });
 });

--- a/typescript/cli/src/submitters/registry.test.ts
+++ b/typescript/cli/src/submitters/registry.test.ts
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+
+import { type IRegistry } from '@hyperlane-xyz/registry';
+import { TxSubmitterType } from '@hyperlane-xyz/sdk';
+
+import { createSubmitterReferenceRegistry } from './registry.js';
+
+describe('createSubmitterReferenceRegistry', () => {
+  const originalFetch = globalThis.fetch;
+  const fetchPayloads = new Map<string, string>();
+  let fetchCalls: string[];
+
+  beforeEach(() => {
+    fetchPayloads.clear();
+    fetchCalls = [];
+    globalThis.fetch = async (input) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      fetchCalls.push(url);
+      return {
+        ok: fetchPayloads.has(url),
+        text: async () => fetchPayloads.get(url)!,
+      } as Response;
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('checks the current registry after child registries miss', async () => {
+    fetchPayloads.set(
+      'https://registry.example/submitters/dev-ethereum.yaml',
+      [
+        'type: jsonRpc',
+        'chain: ethereum',
+        'privateKey: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"',
+        '',
+      ].join('\n'),
+    );
+
+    const registry = createSubmitterReferenceRegistry({
+      uri: 'https://registry.example',
+      getUri(itemPath?: string) {
+        return itemPath
+          ? `https://registry.example/${itemPath}`
+          : 'https://registry.example';
+      },
+      registries: [
+        {
+          uri: 'https://empty.example',
+          getUri(itemPath?: string) {
+            return itemPath
+              ? `https://empty.example/${itemPath}`
+              : 'https://empty.example';
+          },
+        },
+      ],
+    } as IRegistry & { registries: IRegistry[] });
+
+    const submitter = await registry.getSubmitter?.('submitters/dev-ethereum');
+
+    expect(submitter).to.deep.equal({
+      type: TxSubmitterType.JSON_RPC,
+      chain: 'ethereum',
+      privateKey:
+        '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    });
+  });
+
+  it('does not fetch submitter refs over insecure HTTP by default', async () => {
+    fetchPayloads.set(
+      'http://registry.example/submitters/dev-ethereum.yaml',
+      [
+        'type: jsonRpc',
+        'chain: ethereum',
+        'privateKey: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"',
+        '',
+      ].join('\n'),
+    );
+
+    const registry = createSubmitterReferenceRegistry({
+      uri: 'http://registry.example',
+      getUri(itemPath?: string) {
+        return itemPath
+          ? `http://registry.example/${itemPath}`
+          : 'http://registry.example';
+      },
+    } as IRegistry);
+
+    const submitter = await registry.getSubmitter?.('submitters/dev-ethereum');
+
+    expect(submitter).to.equal(null);
+    expect(fetchCalls).to.deep.equal([]);
+  });
+});

--- a/typescript/cli/src/submitters/registry.ts
+++ b/typescript/cli/src/submitters/registry.ts
@@ -13,11 +13,14 @@ export type SubmitterRegistry = IRegistry & {
 
 export function extendRegistryWithSubmitters(
   registry: IRegistry,
+  authToken?: string,
 ): SubmitterRegistry {
+  // CAST: submitter lookup is attached dynamically so SDK lookup code can use
+  // plain IRegistry instances without widening the upstream registry package type.
   const extendedRegistry = registry as SubmitterRegistry;
   if (!Object.hasOwn(extendedRegistry, 'getSubmitter')) {
     extendedRegistry.getSubmitter = async (ref) =>
-      readSubmitterReference(registry, ref);
+      readSubmitterReference(registry, ref, authToken);
   }
   return extendedRegistry;
 }
@@ -25,11 +28,16 @@ export function extendRegistryWithSubmitters(
 async function readSubmitterReference(
   registry: IRegistry,
   ref: string,
+  authToken?: string,
 ): Promise<unknown> {
   const childRegistries = getRegistryChildren(registry);
   if (childRegistries?.length) {
     for (const childRegistry of childRegistries.slice().reverse()) {
-      const payload = await readSubmitterReference(childRegistry, ref);
+      const payload = await readSubmitterReference(
+        childRegistry,
+        ref,
+        authToken,
+      );
       if (payload) return payload;
     }
   }
@@ -38,7 +46,7 @@ async function readSubmitterReference(
     const source = safeGetUri(registry, itemPath);
     if (!source) continue;
 
-    const payload = await loadPayload(source);
+    const payload = await loadPayload(source, authToken);
     if (payload) return payload;
   }
 
@@ -104,9 +112,14 @@ function safeGetUri(
   }
 }
 
-async function loadPayload(source: string): Promise<unknown> {
+async function loadPayload(
+  source: string,
+  authToken?: string,
+): Promise<unknown> {
   if (isFetchableUrl(source)) {
-    const response = await fetch(source);
+    const response = await fetch(source, {
+      headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
+    });
     if (response.status === 404) return null;
     assert(
       response.ok,

--- a/typescript/cli/src/submitters/registry.ts
+++ b/typescript/cli/src/submitters/registry.ts
@@ -23,7 +23,7 @@ export function createSubmitterReferenceRegistry(
 async function readSubmitterReference(
   registry: IRegistry,
   ref: string,
-): Promise<unknown | null> {
+): Promise<unknown> {
   const childRegistries = (registry as IRegistry & { registries?: IRegistry[] })
     .registries;
   if (childRegistries?.length) {
@@ -31,7 +31,6 @@ async function readSubmitterReference(
       const payload = await readSubmitterReference(childRegistry, ref);
       if (payload) return payload;
     }
-    return null;
   }
 
   for (const itemPath of getCandidateItemPaths(ref, registry)) {
@@ -94,9 +93,9 @@ function safeGetUri(
   }
 }
 
-async function loadPayload(source: string): Promise<unknown | null> {
+async function loadPayload(source: string): Promise<unknown> {
   try {
-    if (source.startsWith('http://') || source.startsWith('https://')) {
+    if (isFetchableUrl(source)) {
       const response = await fetch(source);
       if (!response.ok) return null;
       return parseSubmitterReferencePayload(await response.text(), source);
@@ -105,5 +104,13 @@ async function loadPayload(source: string): Promise<unknown | null> {
     return readYamlOrJson(source);
   } catch {
     return null;
+  }
+}
+
+function isFetchableUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
   }
 }

--- a/typescript/cli/src/submitters/registry.ts
+++ b/typescript/cli/src/submitters/registry.ts
@@ -1,66 +1,16 @@
-import { type IRegistry, WarpRouteFilterParams } from '@hyperlane-xyz/registry';
+import { type IRegistry } from '@hyperlane-xyz/registry';
 import {
-  type SubmissionStrategy,
-  SubmissionStrategySchema,
   type SubmitterReferenceRegistry,
   parseSubmitterReferencePayload,
-  resolveSubmitterMetadata,
 } from '@hyperlane-xyz/sdk';
-import { readYamlOrJson } from '@hyperlane-xyz/utils/fs';
+import { assert } from '@hyperlane-xyz/utils';
 
-import { AbstractService } from './abstractService.js';
-import { RegistryService } from './registryService.js';
-
-export class RootService extends AbstractService {
-  constructor(registryService: RegistryService) {
-    super(registryService);
-  }
-
-  async getMetadata() {
-    return this.withRegistry(async (registry) => {
-      return registry.getMetadata();
-    });
-  }
-
-  async getAddresses() {
-    return this.withRegistry(async (registry) => {
-      return registry.getAddresses();
-    });
-  }
-
-  async getChains() {
-    return this.withRegistry(async (registry) => {
-      return registry.getChains();
-    });
-  }
-
-  async listRegistryContent() {
-    return this.withRegistry(async (registry) => {
-      return registry.listRegistryContent();
-    });
-  }
-
-  async getWarpRoutes(filter?: WarpRouteFilterParams) {
-    return this.withRegistry(async (registry) => {
-      return registry.getWarpRoutes(filter);
-    });
-  }
-
-  async getSubmitter(id: string): Promise<SubmissionStrategy> {
-    return this.withRegistry(async (registry) => {
-      const submitter = await resolveSubmitterMetadata(
-        { type: 'submitter_ref', ref: `submitters/${id}` },
-        createSubmitterReferenceRegistry(registry),
-      );
-      return SubmissionStrategySchema.parse({ submitter });
-    });
-  }
-}
+import { readYamlOrJson } from '../utils/files.js';
 
 const SUBMITTER_DIRECTORY = 'submitters';
 const SUPPORTED_EXTENSIONS = ['', '.yaml', '.yml', '.json'];
 
-function createSubmitterReferenceRegistry(
+export function createSubmitterReferenceRegistry(
   registry: IRegistry,
 ): SubmitterReferenceRegistry {
   return {
@@ -100,11 +50,10 @@ function getCandidateItemPaths(ref: string, registry: IRegistry): string[] {
     /^\/+/,
     '',
   );
-  if (!normalizedRef.startsWith(`${SUBMITTER_DIRECTORY}/`)) {
-    throw new Error(
-      `Submitter reference ${ref} must target a top-level ${SUBMITTER_DIRECTORY}/ entry`,
-    );
-  }
+  assert(
+    normalizedRef.startsWith(`${SUBMITTER_DIRECTORY}/`),
+    `Submitter reference ${ref} must target a top-level ${SUBMITTER_DIRECTORY}/ entry`,
+  );
 
   if (
     SUPPORTED_EXTENSIONS.some(

--- a/typescript/cli/src/submitters/registry.ts
+++ b/typescript/cli/src/submitters/registry.ts
@@ -1,9 +1,5 @@
 import { type IRegistry } from '@hyperlane-xyz/registry';
-import {
-  type SubmitterReferenceRegistry,
-  getSubmitterRegistryChildren,
-  parseSubmitterReferencePayload,
-} from '@hyperlane-xyz/sdk';
+import { parseSubmitterReferencePayload } from '@hyperlane-xyz/sdk';
 import { assert } from '@hyperlane-xyz/utils';
 
 import { readYamlOrJson } from '../utils/files.js';
@@ -11,23 +7,28 @@ import { readYamlOrJson } from '../utils/files.js';
 const SUBMITTER_DIRECTORY = 'submitters';
 const SUPPORTED_EXTENSIONS = ['', '.yaml', '.yml', '.json'];
 
-export function createSubmitterReferenceRegistry(
+export type SubmitterRegistry = IRegistry & {
+  getSubmitter(ref: string): Promise<unknown>;
+};
+
+export function extendRegistryWithSubmitters(
   registry: IRegistry,
-): SubmitterReferenceRegistry {
-  return {
-    uri: registry.uri,
-    getUri: (itemPath) => safeGetUri(registry, itemPath) ?? registry.uri,
-    getSubmitter: async (ref) => readSubmitterReference(registry, ref),
-  };
+): SubmitterRegistry {
+  const extendedRegistry = registry as SubmitterRegistry;
+  if (!Object.hasOwn(extendedRegistry, 'getSubmitter')) {
+    extendedRegistry.getSubmitter = async (ref) =>
+      readSubmitterReference(registry, ref);
+  }
+  return extendedRegistry;
 }
 
 async function readSubmitterReference(
   registry: IRegistry,
   ref: string,
 ): Promise<unknown> {
-  const childRegistries = getSubmitterRegistryChildren(registry);
+  const childRegistries = getRegistryChildren(registry);
   if (childRegistries?.length) {
-    for (const childRegistry of childRegistries) {
+    for (const childRegistry of childRegistries.slice().reverse()) {
       const payload = await readSubmitterReference(childRegistry, ref);
       if (payload) return payload;
     }
@@ -44,11 +45,21 @@ async function readSubmitterReference(
   return null;
 }
 
-function getCandidateItemPaths(ref: string, registry: IRegistry): string[] {
-  const normalizedRef = (stripRegistryRoot(ref, registry) ?? ref).replace(
-    /^\/+/,
-    '',
+function getRegistryChildren(registry: IRegistry): IRegistry[] {
+  if (!('registries' in registry) || !Array.isArray(registry.registries)) {
+    return [];
+  }
+
+  return registry.registries.filter(
+    (child): child is IRegistry => !!child && typeof child === 'object',
   );
+}
+
+function getCandidateItemPaths(ref: string, registry: IRegistry): string[] {
+  const strippedRef = stripRegistryRoot(ref, registry);
+  if (!strippedRef && isUrl(ref)) return [];
+
+  const normalizedRef = (strippedRef ?? ref).replace(/^\/+/, '');
   assert(
     normalizedRef.startsWith(`${SUBMITTER_DIRECTORY}/`),
     `Submitter reference ${ref} must target a top-level ${SUBMITTER_DIRECTORY}/ entry`,

--- a/typescript/cli/src/submitters/registry.ts
+++ b/typescript/cli/src/submitters/registry.ts
@@ -1,6 +1,7 @@
 import { type IRegistry } from '@hyperlane-xyz/registry';
 import {
   type SubmitterReferenceRegistry,
+  getSubmitterRegistryChildren,
   parseSubmitterReferencePayload,
 } from '@hyperlane-xyz/sdk';
 import { assert } from '@hyperlane-xyz/utils';
@@ -24,8 +25,7 @@ async function readSubmitterReference(
   registry: IRegistry,
   ref: string,
 ): Promise<unknown> {
-  const childRegistries = (registry as IRegistry & { registries?: IRegistry[] })
-    .registries;
+  const childRegistries = getSubmitterRegistryChildren(registry);
   if (childRegistries?.length) {
     for (const childRegistry of childRegistries) {
       const payload = await readSubmitterReference(childRegistry, ref);
@@ -94,22 +94,46 @@ function safeGetUri(
 }
 
 async function loadPayload(source: string): Promise<unknown> {
-  try {
-    if (isFetchableUrl(source)) {
-      const response = await fetch(source);
-      if (!response.ok) return null;
-      return parseSubmitterReferencePayload(await response.text(), source);
-    }
-
-    return readYamlOrJson(source);
-  } catch {
-    return null;
+  if (isFetchableUrl(source)) {
+    const response = await fetch(source);
+    if (response.status === 404) return null;
+    assert(
+      response.ok,
+      `Failed to fetch submitter reference ${source}: ${response.status} ${response.statusText}`,
+    );
+    return parseSubmitterReferencePayload(await response.text(), source);
   }
+  if (isUrl(source)) return null;
+
+  try {
+    return readYamlOrJson(source);
+  } catch (error) {
+    if (isNotFoundError(error)) return null;
+    throw error;
+  }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+  );
 }
 
 function isFetchableUrl(value: string): boolean {
   try {
     return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
   } catch {
     return false;
   }

--- a/typescript/cli/src/submitters/types.test.ts
+++ b/typescript/cli/src/submitters/types.test.ts
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+
+import { TxSubmitterType } from '@hyperlane-xyz/sdk';
+
+import {
+  CustomTxSubmitterType,
+  ExtendedChainSubmissionStrategySchema,
+} from './types.js';
+
+describe('ExtendedChainSubmissionStrategySchema', () => {
+  it('preserves malformed strategy entries for zod validation', () => {
+    const result = ExtendedChainSubmissionStrategySchema.safeParse({
+      ethereum: {},
+    });
+
+    expect(result.success).to.equal(false);
+  });
+
+  it('fills missing file submitter chain from strategy chain', () => {
+    const strategy = ExtendedChainSubmissionStrategySchema.parse({
+      ethereum: {
+        submitter: {
+          type: CustomTxSubmitterType.FILE,
+          filepath: '/tmp/transactions.yaml',
+        },
+      },
+    });
+
+    expect(strategy.ethereum.submitter).to.deep.equal({
+      type: CustomTxSubmitterType.FILE,
+      filepath: '/tmp/transactions.yaml',
+      chain: 'ethereum',
+    });
+  });
+
+  it('rejects file submitter chain mismatch', () => {
+    const result = ExtendedChainSubmissionStrategySchema.safeParse({
+      ethereum: {
+        submitter: {
+          type: CustomTxSubmitterType.FILE,
+          filepath: '/tmp/transactions.yaml',
+          chain: 'arbitrum',
+        },
+      },
+    });
+
+    expect(result.success).to.equal(false);
+  });
+
+  it('preserves submitter refs without resolving them', () => {
+    const strategy = ExtendedChainSubmissionStrategySchema.parse({
+      ethereum: {
+        submitter: {
+          type: TxSubmitterType.SUBMITTER_REF,
+          ref: 'submitters/ethereum',
+        },
+      },
+    });
+
+    expect(strategy.ethereum.submitter).to.deep.equal({
+      type: TxSubmitterType.SUBMITTER_REF,
+      ref: 'submitters/ethereum',
+    });
+  });
+});

--- a/typescript/cli/src/submitters/types.ts
+++ b/typescript/cli/src/submitters/types.ts
@@ -78,10 +78,15 @@ function preprocessExtendedChainSubmissionStrategy(value: unknown): unknown {
         ];
       }
 
+      if (typeof submitter.type !== 'string') {
+        return [chain, strategy];
+      }
+
+      const typedSubmitter = { ...submitter, type: submitter.type };
       const processed = preprocessChainSubmissionStrategy<{
-        submitter: SubmitterMetadata;
+        submitter: { type: string };
       }>({
-        [chain]: { submitter: submitter as SubmitterMetadata },
+        [chain]: { submitter: typedSubmitter },
       });
       return [chain, processed[chain]];
     }),
@@ -101,10 +106,12 @@ function refineExtendedChainSubmissionStrategy(
           submitter.type !== CustomTxSubmitterType.FILE
         );
       })
-      .map(([chain, strategy]) => [
-        chain,
-        { submitter: strategy.submitter as SubmitterMetadata },
-      ]),
+      .map(([chain, strategy]) => {
+        return [
+          chain,
+          { submitter: SubmitterMetadataSchema.parse(strategy.submitter) },
+        ];
+      }),
   );
 
   refineChainSubmissionStrategy(standardStrategies, ctx);

--- a/typescript/cli/src/submitters/types.ts
+++ b/typescript/cli/src/submitters/types.ts
@@ -4,6 +4,7 @@ import {
   type SubmitterMetadata,
   SubmitterMetadataSchema,
   TxSubmitterType,
+  UnresolvedSubmitterReferenceSchema,
   ZChainName,
   preprocessChainSubmissionStrategy,
   refineChainSubmissionStrategy,
@@ -24,29 +25,98 @@ const FileSubmitterMetadataSchema = z.object({
   ...FileTxSubmitterPropsSchema.shape,
 });
 
-type FileSubmitterMetadata = z.infer<typeof FileSubmitterMetadataSchema>;
+type ExtendedSubmitterMetadata =
+  | SubmitterMetadata
+  | z.output<typeof FileSubmitterMetadataSchema>
+  | z.output<typeof UnresolvedSubmitterReferenceSchema>;
 
-type ExtendedSubmitterMetadata = SubmitterMetadata | FileSubmitterMetadata;
+const ExtendedSubmitterMetadataSchema: z.ZodType<
+  ExtendedSubmitterMetadata,
+  z.ZodTypeDef,
+  unknown
+> = z.union([
+  SubmitterMetadataSchema,
+  FileSubmitterMetadataSchema,
+  UnresolvedSubmitterReferenceSchema,
+]);
 
-// @ts-expect-error recursive schema causes type inference errors
-const ExtendedSubmitterMetadataSchema: z.ZodSchema<ExtendedSubmitterMetadata> =
-  SubmitterMetadataSchema.or(FileSubmitterMetadataSchema);
-
-export const ExtendedSubmissionStrategySchema: z.ZodSchema<{
+export type ExtendedSubmissionStrategy = {
   submitter: ExtendedSubmitterMetadata;
-}> = z.object({
+};
+
+export const ExtendedSubmissionStrategySchema: z.ZodType<
+  ExtendedSubmissionStrategy,
+  z.ZodTypeDef,
+  unknown
+> = z.object({
   submitter: ExtendedSubmitterMetadataSchema,
 });
 
-export type ExtendedSubmissionStrategy = z.infer<
-  typeof ExtendedSubmissionStrategySchema
->;
+function preprocessExtendedChainSubmissionStrategy(
+  value: unknown,
+): Record<string, ExtendedSubmissionStrategy> {
+  const strategies = value as Record<string, ExtendedSubmissionStrategy>;
 
-export const ExtendedChainSubmissionStrategySchema = z.preprocess(
-  preprocessChainSubmissionStrategy,
+  return Object.fromEntries(
+    Object.entries(strategies).map(([chain, strategy]) => {
+      const submitter = strategy.submitter;
+      if (submitter.type === 'submitter_ref') {
+        return [chain, strategy];
+      }
+
+      if (submitter.type === CustomTxSubmitterType.FILE) {
+        return [
+          chain,
+          {
+            submitter: {
+              ...submitter,
+              chain: submitter.chain ?? chain,
+            },
+          },
+        ];
+      }
+
+      const processed = preprocessChainSubmissionStrategy<{
+        submitter: SubmitterMetadata;
+      }>({
+        [chain]: { submitter },
+      });
+      return [chain, processed[chain]];
+    }),
+  );
+}
+
+function refineExtendedChainSubmissionStrategy(
+  value: Record<string, ExtendedSubmissionStrategy>,
+  ctx: z.RefinementCtx,
+) {
+  const standardStrategies = Object.fromEntries(
+    Object.entries(value)
+      .filter(([, strategy]) => {
+        const submitter = strategy.submitter;
+        return (
+          submitter.type !== 'submitter_ref' &&
+          submitter.type !== CustomTxSubmitterType.FILE
+        );
+      })
+      .map(([chain, strategy]) => [
+        chain,
+        { submitter: strategy.submitter as SubmitterMetadata },
+      ]),
+  );
+
+  refineChainSubmissionStrategy(standardStrategies, ctx);
+}
+
+export const ExtendedChainSubmissionStrategySchema: z.ZodType<
+  Record<string, ExtendedSubmissionStrategy>,
+  z.ZodTypeDef,
+  unknown
+> = z.preprocess(
+  preprocessExtendedChainSubmissionStrategy,
   z
     .record(ZChainName, ExtendedSubmissionStrategySchema)
-    .superRefine(refineChainSubmissionStrategy),
+    .superRefine(refineExtendedChainSubmissionStrategy),
 );
 
 export type ExtendedChainSubmissionStrategy = z.infer<

--- a/typescript/cli/src/submitters/types.ts
+++ b/typescript/cli/src/submitters/types.ts
@@ -52,15 +52,17 @@ export const ExtendedSubmissionStrategySchema: z.ZodType<
   submitter: ExtendedSubmitterMetadataSchema,
 });
 
-function preprocessExtendedChainSubmissionStrategy(
-  value: unknown,
-): Record<string, ExtendedSubmissionStrategy> {
-  const strategies = value as Record<string, ExtendedSubmissionStrategy>;
+function preprocessExtendedChainSubmissionStrategy(value: unknown): unknown {
+  if (!isRecord(value)) return value;
 
   return Object.fromEntries(
-    Object.entries(strategies).map(([chain, strategy]) => {
+    Object.entries(value).map(([chain, strategy]) => {
+      if (!isRecord(strategy) || !isRecord(strategy.submitter)) {
+        return [chain, strategy];
+      }
+
       const submitter = strategy.submitter;
-      if (submitter.type === 'submitter_ref') {
+      if (submitter.type === TxSubmitterType.SUBMITTER_REF) {
         return [chain, strategy];
       }
 
@@ -79,7 +81,7 @@ function preprocessExtendedChainSubmissionStrategy(
       const processed = preprocessChainSubmissionStrategy<{
         submitter: SubmitterMetadata;
       }>({
-        [chain]: { submitter },
+        [chain]: { submitter: submitter as SubmitterMetadata },
       });
       return [chain, processed[chain]];
     }),
@@ -95,7 +97,7 @@ function refineExtendedChainSubmissionStrategy(
       .filter(([, strategy]) => {
         const submitter = strategy.submitter;
         return (
-          submitter.type !== 'submitter_ref' &&
+          submitter.type !== TxSubmitterType.SUBMITTER_REF &&
           submitter.type !== CustomTxSubmitterType.FILE
         );
       })
@@ -106,6 +108,24 @@ function refineExtendedChainSubmissionStrategy(
   );
 
   refineChainSubmissionStrategy(standardStrategies, ctx);
+
+  for (const [chain, strategy] of Object.entries(value)) {
+    const { submitter } = strategy;
+    if (
+      submitter.type === CustomTxSubmitterType.FILE &&
+      submitter.chain !== chain
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `File submitter chain ${submitter.chain} must match strategy chain ${chain}`,
+        path: [chain, 'submitter', 'chain'],
+      });
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
 export const ExtendedChainSubmissionStrategySchema: z.ZodType<

--- a/typescript/cli/src/tests/ethereum/submit/submit.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/submit/submit.e2e-test.ts
@@ -179,7 +179,7 @@ describe('hyperlane submit', function () {
     writeYamlOrJson(strategyPath, {
       [CHAIN_NAME_2]: {
         submitter: {
-          type: 'submitter_ref',
+          type: TxSubmitterType.SUBMITTER_REF,
           ref: `${REGISTRY_PATH}/submitters/chain2-owner`,
         },
       },

--- a/typescript/cli/src/tests/ethereum/submit/submit.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/submit/submit.e2e-test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { type PopulatedTransaction as EV5Transaction, ethers } from 'ethers';
+import { mkdirSync } from 'fs';
 
 import { type XERC20VSTest, XERC20VSTest__factory } from '@hyperlane-xyz/core';
 import { TxSubmitterType, randomAddress } from '@hyperlane-xyz/sdk';
@@ -14,6 +15,7 @@ import {
   CHAIN_NAME_2,
   CHAIN_NAME_3,
   DEFAULT_E2E_TEST_TIMEOUT,
+  REGISTRY_PATH,
   TEMP_PATH,
 } from '../consts.js';
 
@@ -160,6 +162,44 @@ describe('hyperlane submit', function () {
       initialBalances[0].add(chain2MintAmount).toNumber(),
       initialBalances[1].add(chain3MintAmount).toNumber(),
     ]);
+  });
+
+  it('should execute a submitter reference strategy', async function () {
+    mkdirSync(`${REGISTRY_PATH}/submitters`, { recursive: true });
+    const submitterPath = `${REGISTRY_PATH}/submitters/chain2-owner.yaml`;
+    writeYamlOrJson(submitterPath, {
+      submitter: {
+        type: TxSubmitterType.JSON_RPC,
+        chain: CHAIN_NAME_2,
+        privateKey: ANVIL_KEY,
+      },
+    });
+
+    const strategyPath = `${TEMP_PATH}/submitter-reference-strategy.yaml`;
+    writeYamlOrJson(strategyPath, {
+      [CHAIN_NAME_2]: {
+        submitter: {
+          type: 'submitter_ref',
+          ref: `${REGISTRY_PATH}/submitters/chain2-owner`,
+        },
+      },
+    });
+
+    const chain2MintAmount = randomInt(1, 1000);
+    const transaction = await getMintOnlyOwnerTransaction(
+      xerc20Chain2,
+      ALICE,
+      chain2MintAmount,
+      ANVIL2_CHAIN_ID,
+    );
+    const transactionsPath = `${TEMP_PATH}/submitter-reference-transactions.yaml`;
+    writeYamlOrJson(transactionsPath, [transaction]);
+
+    const initialBalance = await xerc20Chain2.balanceOf(ALICE);
+    await hyperlaneSubmit({ strategyPath, transactionsPath });
+    expect(await xerc20Chain2.balanceOf(ALICE)).to.eql(
+      initialBalance.add(chain2MintAmount),
+    );
   });
 
   describe('FileSubmitter', function () {

--- a/typescript/http-registry-server/HttpServer.ts
+++ b/typescript/http-registry-server/HttpServer.ts
@@ -17,6 +17,7 @@ import { WarpService } from './src/services/warpService.js';
 import { FileSystemRegistryWatcher } from './src/services/watcherService.js';
 
 export interface HttpServerOptions {
+  authToken?: string;
   writeMode?: boolean;
 }
 
@@ -24,6 +25,7 @@ export class HttpServer {
   app: Express;
   protected readonly logger: Logger;
   private registryService: RegistryService | null = null;
+  protected readonly authToken?: string;
   protected readonly writeMode: boolean;
 
   private constructor(
@@ -32,6 +34,7 @@ export class HttpServer {
     options: HttpServerOptions = {},
   ) {
     this.logger = logger;
+    this.authToken = options.authToken;
     this.writeMode = options.writeMode ?? false;
     this.app = express();
     this.app.set('trust proxy', true); // trust proxy for x-forwarded-for header
@@ -102,7 +105,7 @@ export class HttpServer {
       // add routes
       this.app.use(
         '/',
-        createRootRouter(new RootService(this.registryService)),
+        createRootRouter(new RootService(this.registryService, this.authToken)),
       );
       this.app.use(
         '/chain',

--- a/typescript/http-registry-server/README.md
+++ b/typescript/http-registry-server/README.md
@@ -4,7 +4,7 @@ An HTTP server that provides a RESTful API for accessing data from the Hyperlane
 
 ## Features
 
-- **RESTful API**: Exposes Hyperlane registry data (chains, addresses, warp routes) via a simple and consistent API.
+- **RESTful API**: Exposes Hyperlane registry data (chains, addresses, warp routes, submitters) via a simple and consistent API.
 - **Auto-Refresh**: Periodically fetches the latest registry data to stay up-to-date.
 - **Configurable**: Easily configure the server's port, host, and data refresh interval via environment variables.
 - **Structured Logging**: Uses `pino` for structured, performant logging, with pretty-printing for development environments.
@@ -31,6 +31,8 @@ The server is configured using environment variables. You can place these in a `
 | `REFRESH_INTERVAL` | The interval (in ms) to refresh registry data.   | `60000` (60 seconds) |
 | `LOG_LEVEL`        | The minimum log level to output.                 | `info`               |
 | `LOG_FORMAT`       | The log format. Set to `pretty` for development. | `json`               |
+
+If you start the server with `--authToken`, that token is also forwarded as `Authorization: Bearer <token>` when resolving remote `submitter_ref` entries from HTTPS registries.
 
 ## Usage
 
@@ -78,6 +80,22 @@ The server is configured using environment variables. You can place these in a `
 - **`GET /warp-routes`**
   - Retrieves a list of all warp routes, with optional filtering.
   - **Query Parameters**: Based on `WarpRouteFilterSchema` from `@hyperlane-xyz/registry`.
+- **`GET /submitters/:id`**
+  - Resolves a top-level registry submitter entry from `submitters/:id`.
+  - Returns a normalized submission strategy payload in the form `{ "submitter": ... }`.
+  - Useful for clients that store `type: submitter_ref` in config and want the server to resolve the backing submitter metadata.
+- **`GET /submitter/:id`**
+  - Singular alias for `GET /submitters/:id`.
+
+`submitter_ref` is a registry-backed submitter pointer:
+
+```yaml
+submitter:
+  type: submitter_ref
+  ref: submitters/dev-ethereum
+```
+
+The referenced entry must live at the registry top level under `submitters/`, for example `submitters/dev-ethereum.yaml`. The server resolves that ref by checking the served registry, reading local files directly, or fetching HTTPS-backed entries with the configured auth token. The response contains the resolved submitter metadata, not the unresolved ref.
 
 ### Chains
 

--- a/typescript/http-registry-server/scripts/run-server.ts
+++ b/typescript/http-registry-server/scripts/run-server.ts
@@ -55,7 +55,10 @@ async function main() {
     });
   };
 
-  const server = await HttpServer.create(getRegistryInstance, { writeMode });
+  const server = await HttpServer.create(getRegistryInstance, {
+    authToken,
+    writeMode,
+  });
   await server.start(port?.toString(), refreshInterval?.toString());
 }
 

--- a/typescript/http-registry-server/src/routes/root.ts
+++ b/typescript/http-registry-server/src/routes/root.ts
@@ -1,9 +1,21 @@
 import { Request, Response, Router } from 'express';
+import { z } from 'zod';
 
 import { WarpRouteFilterSchema } from '@hyperlane-xyz/registry';
 
-import { validateQueryParams } from '../middleware/validateRequest.js';
+import {
+  validateQueryParams,
+  validateRequestParam,
+} from '../middleware/validateRequest.js';
 import { RootService } from '../services/rootService.js';
+
+const SubmitterIdSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (id) => !id.split('/').includes('..'),
+    'Submitter id must not contain parent directory segments',
+  );
 
 export function createRootRouter(rootService: RootService): Router {
   const router = Router();
@@ -48,8 +60,16 @@ export function createRootRouter(rootService: RootService): Router {
     res.json(submitter);
   };
 
-  router.get('/submitters/:id', getSubmitter);
-  router.get('/submitter/:id', getSubmitter);
+  router.get(
+    '/submitters/:id',
+    validateRequestParam('id', SubmitterIdSchema),
+    getSubmitter,
+  );
+  router.get(
+    '/submitter/:id',
+    validateRequestParam('id', SubmitterIdSchema),
+    getSubmitter,
+  );
 
   return router;
 }

--- a/typescript/http-registry-server/src/routes/root.ts
+++ b/typescript/http-registry-server/src/routes/root.ts
@@ -43,5 +43,13 @@ export function createRootRouter(rootService: RootService): Router {
     },
   );
 
+  const getSubmitter = async (req: Request, res: Response) => {
+    const submitter = await rootService.getSubmitter(req.params.id);
+    res.json(submitter);
+  };
+
+  router.get('/submitters/:id', getSubmitter);
+  router.get('/submitter/:id', getSubmitter);
+
   return router;
 }

--- a/typescript/http-registry-server/src/services/rootService.ts
+++ b/typescript/http-registry-server/src/services/rootService.ts
@@ -12,7 +12,10 @@ import { AbstractService } from './abstractService.js';
 import { RegistryService } from './registryService.js';
 
 export class RootService extends AbstractService {
-  constructor(registryService: RegistryService) {
+  constructor(
+    registryService: RegistryService,
+    private readonly authToken?: string,
+  ) {
     super(registryService);
   }
 
@@ -50,7 +53,7 @@ export class RootService extends AbstractService {
     return this.withRegistry(async (registry) => {
       const submitter = await resolveSubmitterMetadata(
         { type: TxSubmitterType.SUBMITTER_REF, ref: `submitters/${id}` },
-        extendRegistryWithSubmitters(registry),
+        extendRegistryWithSubmitters(registry, this.authToken),
       );
       return SubmissionStrategySchema.parse({ submitter });
     });
@@ -66,11 +69,14 @@ export type SubmitterRegistry = IRegistry & {
 
 export function extendRegistryWithSubmitters(
   registry: IRegistry,
+  authToken?: string,
 ): SubmitterRegistry {
+  // CAST: submitter lookup is attached dynamically so SDK lookup code can use
+  // plain IRegistry instances without widening the upstream registry package type.
   const extendedRegistry = registry as SubmitterRegistry;
   if (!Object.hasOwn(extendedRegistry, 'getSubmitter')) {
     extendedRegistry.getSubmitter = async (ref) =>
-      readSubmitterReference(registry, ref);
+      readSubmitterReference(registry, ref, authToken);
   }
   return extendedRegistry;
 }
@@ -78,11 +84,16 @@ export function extendRegistryWithSubmitters(
 async function readSubmitterReference(
   registry: IRegistry,
   ref: string,
+  authToken?: string,
 ): Promise<unknown> {
   const childRegistries = getRegistryChildren(registry);
   if (childRegistries?.length) {
     for (const childRegistry of childRegistries.slice().reverse()) {
-      const payload = await readSubmitterReference(childRegistry, ref);
+      const payload = await readSubmitterReference(
+        childRegistry,
+        ref,
+        authToken,
+      );
       if (payload) return payload;
     }
   }
@@ -91,7 +102,7 @@ async function readSubmitterReference(
     const source = safeGetUri(registry, itemPath);
     if (!source) continue;
 
-    const payload = await loadPayload(source);
+    const payload = await loadPayload(source, authToken);
     if (payload) return payload;
   }
 
@@ -158,9 +169,14 @@ function safeGetUri(
   }
 }
 
-async function loadPayload(source: string): Promise<unknown> {
+async function loadPayload(
+  source: string,
+  authToken?: string,
+): Promise<unknown> {
   if (isFetchableUrl(source)) {
-    const response = await fetch(source);
+    const response = await fetch(source, {
+      headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
+    });
     if (response.status === 404) return null;
     if (!response.ok) {
       throw new Error(

--- a/typescript/http-registry-server/src/services/rootService.ts
+++ b/typescript/http-registry-server/src/services/rootService.ts
@@ -3,6 +3,7 @@ import {
   type SubmissionStrategy,
   SubmissionStrategySchema,
   type SubmitterReferenceRegistry,
+  TxSubmitterType,
   parseSubmitterReferencePayload,
   resolveSubmitterMetadata,
 } from '@hyperlane-xyz/sdk';
@@ -49,7 +50,7 @@ export class RootService extends AbstractService {
   async getSubmitter(id: string): Promise<SubmissionStrategy> {
     return this.withRegistry(async (registry) => {
       const submitter = await resolveSubmitterMetadata(
-        { type: 'submitter_ref', ref: `submitters/${id}` },
+        { type: TxSubmitterType.SUBMITTER_REF, ref: `submitters/${id}` },
         createSubmitterReferenceRegistry(registry),
       );
       return SubmissionStrategySchema.parse({ submitter });
@@ -73,7 +74,7 @@ function createSubmitterReferenceRegistry(
 async function readSubmitterReference(
   registry: IRegistry,
   ref: string,
-): Promise<unknown | null> {
+): Promise<unknown> {
   const childRegistries = (registry as IRegistry & { registries?: IRegistry[] })
     .registries;
   if (childRegistries?.length) {
@@ -81,7 +82,6 @@ async function readSubmitterReference(
       const payload = await readSubmitterReference(childRegistry, ref);
       if (payload) return payload;
     }
-    return null;
   }
 
   for (const itemPath of getCandidateItemPaths(ref, registry)) {
@@ -145,9 +145,9 @@ function safeGetUri(
   }
 }
 
-async function loadPayload(source: string): Promise<unknown | null> {
+async function loadPayload(source: string): Promise<unknown> {
   try {
-    if (source.startsWith('http://') || source.startsWith('https://')) {
+    if (isFetchableUrl(source)) {
       const response = await fetch(source);
       if (!response.ok) return null;
       return parseSubmitterReferencePayload(await response.text(), source);
@@ -156,5 +156,13 @@ async function loadPayload(source: string): Promise<unknown | null> {
     return readYamlOrJson(source);
   } catch {
     return null;
+  }
+}
+
+function isFetchableUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
   }
 }

--- a/typescript/http-registry-server/src/services/rootService.ts
+++ b/typescript/http-registry-server/src/services/rootService.ts
@@ -2,9 +2,7 @@ import { type IRegistry, WarpRouteFilterParams } from '@hyperlane-xyz/registry';
 import {
   type SubmissionStrategy,
   SubmissionStrategySchema,
-  type SubmitterReferenceRegistry,
   TxSubmitterType,
-  getSubmitterRegistryChildren,
   parseSubmitterReferencePayload,
   resolveSubmitterMetadata,
 } from '@hyperlane-xyz/sdk';
@@ -52,7 +50,7 @@ export class RootService extends AbstractService {
     return this.withRegistry(async (registry) => {
       const submitter = await resolveSubmitterMetadata(
         { type: TxSubmitterType.SUBMITTER_REF, ref: `submitters/${id}` },
-        createSubmitterReferenceRegistry(registry),
+        extendRegistryWithSubmitters(registry),
       );
       return SubmissionStrategySchema.parse({ submitter });
     });
@@ -62,23 +60,28 @@ export class RootService extends AbstractService {
 const SUBMITTER_DIRECTORY = 'submitters';
 const SUPPORTED_EXTENSIONS = ['', '.yaml', '.yml', '.json'];
 
-function createSubmitterReferenceRegistry(
+export type SubmitterRegistry = IRegistry & {
+  getSubmitter(ref: string): Promise<unknown>;
+};
+
+export function extendRegistryWithSubmitters(
   registry: IRegistry,
-): SubmitterReferenceRegistry {
-  return {
-    uri: registry.uri,
-    getUri: (itemPath) => safeGetUri(registry, itemPath) ?? registry.uri,
-    getSubmitter: async (ref) => readSubmitterReference(registry, ref),
-  };
+): SubmitterRegistry {
+  const extendedRegistry = registry as SubmitterRegistry;
+  if (!Object.hasOwn(extendedRegistry, 'getSubmitter')) {
+    extendedRegistry.getSubmitter = async (ref) =>
+      readSubmitterReference(registry, ref);
+  }
+  return extendedRegistry;
 }
 
 async function readSubmitterReference(
   registry: IRegistry,
   ref: string,
 ): Promise<unknown> {
-  const childRegistries = getSubmitterRegistryChildren(registry);
+  const childRegistries = getRegistryChildren(registry);
   if (childRegistries?.length) {
-    for (const childRegistry of childRegistries) {
+    for (const childRegistry of childRegistries.slice().reverse()) {
       const payload = await readSubmitterReference(childRegistry, ref);
       if (payload) return payload;
     }
@@ -95,11 +98,21 @@ async function readSubmitterReference(
   return null;
 }
 
-function getCandidateItemPaths(ref: string, registry: IRegistry): string[] {
-  const normalizedRef = (stripRegistryRoot(ref, registry) ?? ref).replace(
-    /^\/+/,
-    '',
+function getRegistryChildren(registry: IRegistry): IRegistry[] {
+  if (!('registries' in registry) || !Array.isArray(registry.registries)) {
+    return [];
+  }
+
+  return registry.registries.filter(
+    (child): child is IRegistry => !!child && typeof child === 'object',
   );
+}
+
+function getCandidateItemPaths(ref: string, registry: IRegistry): string[] {
+  const strippedRef = stripRegistryRoot(ref, registry);
+  if (!strippedRef && isUrl(ref)) return [];
+
+  const normalizedRef = (strippedRef ?? ref).replace(/^\/+/, '');
   if (!normalizedRef.startsWith(`${SUBMITTER_DIRECTORY}/`)) {
     throw new Error(
       `Submitter reference ${ref} must target a top-level ${SUBMITTER_DIRECTORY}/ entry`,

--- a/typescript/http-registry-server/src/services/rootService.ts
+++ b/typescript/http-registry-server/src/services/rootService.ts
@@ -4,6 +4,7 @@ import {
   SubmissionStrategySchema,
   type SubmitterReferenceRegistry,
   TxSubmitterType,
+  getSubmitterRegistryChildren,
   parseSubmitterReferencePayload,
   resolveSubmitterMetadata,
 } from '@hyperlane-xyz/sdk';
@@ -75,8 +76,7 @@ async function readSubmitterReference(
   registry: IRegistry,
   ref: string,
 ): Promise<unknown> {
-  const childRegistries = (registry as IRegistry & { registries?: IRegistry[] })
-    .registries;
+  const childRegistries = getSubmitterRegistryChildren(registry);
   if (childRegistries?.length) {
     for (const childRegistry of childRegistries) {
       const payload = await readSubmitterReference(childRegistry, ref);
@@ -146,22 +146,47 @@ function safeGetUri(
 }
 
 async function loadPayload(source: string): Promise<unknown> {
-  try {
-    if (isFetchableUrl(source)) {
-      const response = await fetch(source);
-      if (!response.ok) return null;
-      return parseSubmitterReferencePayload(await response.text(), source);
+  if (isFetchableUrl(source)) {
+    const response = await fetch(source);
+    if (response.status === 404) return null;
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch submitter reference ${source}: ${response.status} ${response.statusText}`,
+      );
     }
-
-    return readYamlOrJson(source);
-  } catch {
-    return null;
+    return parseSubmitterReferencePayload(await response.text(), source);
   }
+  if (isUrl(source)) return null;
+
+  try {
+    return readYamlOrJson(source);
+  } catch (error) {
+    if (isNotFoundError(error)) return null;
+    throw error;
+  }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+  );
 }
 
 function isFetchableUrl(value: string): boolean {
   try {
     return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
   } catch {
     return false;
   }

--- a/typescript/http-registry-server/test/routes/root.test.ts
+++ b/typescript/http-registry-server/test/routes/root.test.ts
@@ -304,6 +304,14 @@ describe('Root Routes', () => {
 
       expect(response.body.message).to.include('Submitter fetch failed');
     });
+
+    it('should reject parent directory submitter ids', async () => {
+      await request(app)
+        .get('/submitters/%2e%2e')
+        .expect(AppConstants.HTTP_STATUS_BAD_REQUEST);
+
+      expect(mockRootService.getSubmitter.called).to.be.false;
+    });
   });
 
   describe('health endpoints', () => {

--- a/typescript/http-registry-server/test/routes/root.test.ts
+++ b/typescript/http-registry-server/test/routes/root.test.ts
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 import request from 'supertest';
 
 import { WarpRouteFilterParams } from '@hyperlane-xyz/registry';
+import { TxSubmitterType } from '@hyperlane-xyz/sdk';
 
 import { AppConstants } from '../../src/constants/AppConstants.js';
 import { createErrorHandler } from '../../src/middleware/errorHandler.js';
@@ -250,6 +251,58 @@ describe('Root Routes', () => {
 
       expect(mockRootService.getWarpRoutes.calledWith(multipleFilters)).to.be
         .true;
+    });
+  });
+
+  describe('GET /submitters/:id', () => {
+    it('should return a resolved submitter strategy', async () => {
+      const submitter = {
+        submitter: {
+          type: TxSubmitterType.JSON_RPC as const,
+          chain: 'ethereum',
+          privateKey:
+            '0x0123456789012345678901234567890123456789012345678901234567890123',
+        },
+      };
+      mockRootService.getSubmitter.resolves(submitter);
+
+      const response = await request(app)
+        .get('/submitters/dev-ethereum')
+        .expect(AppConstants.HTTP_STATUS_OK);
+
+      expect(response.body).to.deep.equal(submitter);
+      expect(mockRootService.getSubmitter.calledWith('dev-ethereum')).to.be
+        .true;
+    });
+
+    it('should keep the singular alias working', async () => {
+      const submitter = {
+        submitter: {
+          type: TxSubmitterType.JSON_RPC as const,
+          chain: 'ethereum',
+          privateKey:
+            '0x0123456789012345678901234567890123456789012345678901234567890123',
+        },
+      };
+      mockRootService.getSubmitter.resolves(submitter);
+
+      const response = await request(app)
+        .get('/submitter/dev-ethereum')
+        .expect(AppConstants.HTTP_STATUS_OK);
+
+      expect(response.body).to.deep.equal(submitter);
+      expect(mockRootService.getSubmitter.calledWith('dev-ethereum')).to.be
+        .true;
+    });
+
+    it('should handle service errors', async () => {
+      mockRootService.getSubmitter.rejects(new Error('Submitter fetch failed'));
+
+      const response = await request(app)
+        .get('/submitters/dev-ethereum')
+        .expect(AppConstants.HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+      expect(response.body.message).to.include('Submitter fetch failed');
     });
   });
 

--- a/typescript/http-registry-server/test/services/rootService.test.ts
+++ b/typescript/http-registry-server/test/services/rootService.test.ts
@@ -3,16 +3,14 @@ import { expect } from 'chai';
 import { type IRegistry } from '@hyperlane-xyz/registry';
 import { TxSubmitterType } from '@hyperlane-xyz/sdk';
 
-import { extendRegistryWithSubmitters } from './registry.js';
+import { extendRegistryWithSubmitters } from '../../src/services/rootService.js';
 
 describe('extendRegistryWithSubmitters', () => {
   const originalFetch = globalThis.fetch;
   const fetchPayloads = new Map<string, string>();
-  let fetchCalls: string[];
 
   beforeEach(() => {
     fetchPayloads.clear();
-    fetchCalls = [];
     globalThis.fetch = async (input) => {
       const url =
         typeof input === 'string'
@@ -20,7 +18,6 @@ describe('extendRegistryWithSubmitters', () => {
           : input instanceof URL
             ? input.href
             : input.url;
-      fetchCalls.push(url);
       const ok = fetchPayloads.has(url);
       return {
         ok,
@@ -90,74 +87,6 @@ describe('extendRegistryWithSubmitters', () => {
     });
   });
 
-  it('checks the current registry after child registries miss', async () => {
-    fetchPayloads.set(
-      'https://registry.example/submitters/dev-ethereum.yaml',
-      [
-        'type: jsonRpc',
-        'chain: ethereum',
-        'privateKey: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"',
-        '',
-      ].join('\n'),
-    );
-
-    const registry = extendRegistryWithSubmitters({
-      uri: 'https://registry.example',
-      getUri(itemPath?: string) {
-        return itemPath
-          ? `https://registry.example/${itemPath}`
-          : 'https://registry.example';
-      },
-      registries: [
-        {
-          uri: 'https://empty.example',
-          getUri(itemPath?: string) {
-            return itemPath
-              ? `https://empty.example/${itemPath}`
-              : 'https://empty.example';
-          },
-        },
-      ],
-    } as unknown as IRegistry & { registries: IRegistry[] });
-
-    const submitter = await registry.getSubmitter?.(
-      'https://registry.example/submitters/dev-ethereum',
-    );
-
-    expect(submitter).to.deep.equal({
-      type: TxSubmitterType.JSON_RPC,
-      chain: 'ethereum',
-      privateKey:
-        '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-    });
-  });
-
-  it('does not fetch submitter refs over insecure HTTP by default', async () => {
-    fetchPayloads.set(
-      'http://registry.example/submitters/dev-ethereum.yaml',
-      [
-        'type: jsonRpc',
-        'chain: ethereum',
-        'privateKey: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"',
-        '',
-      ].join('\n'),
-    );
-
-    const registry = extendRegistryWithSubmitters({
-      uri: 'http://registry.example',
-      getUri(itemPath?: string) {
-        return itemPath
-          ? `http://registry.example/${itemPath}`
-          : 'http://registry.example';
-      },
-    } as IRegistry);
-
-    const submitter = await registry.getSubmitter?.('submitters/dev-ethereum');
-
-    expect(submitter).to.equal(null);
-    expect(fetchCalls).to.deep.equal([]);
-  });
-
   it('throws on malformed local submitter refs', async () => {
     const registry = extendRegistryWithSubmitters({
       uri: 'https://registry.example',
@@ -174,31 +103,6 @@ describe('extendRegistryWithSubmitters', () => {
     } catch (error) {
       expect((error as Error).message).to.include(
         'must target a top-level submitters/ entry',
-      );
-    }
-  });
-
-  it('throws on malformed submitter payloads', async () => {
-    fetchPayloads.set(
-      'https://registry.example/submitters/dev-ethereum.yaml',
-      'type: [',
-    );
-
-    const registry = extendRegistryWithSubmitters({
-      uri: 'https://registry.example',
-      getUri(itemPath?: string) {
-        return itemPath
-          ? `https://registry.example/${itemPath}`
-          : 'https://registry.example';
-      },
-    } as IRegistry);
-
-    try {
-      await registry.getSubmitter?.('submitters/dev-ethereum');
-      throw new Error('Expected malformed submitter payload to throw');
-    } catch (error) {
-      expect((error as Error).message).to.include(
-        'Failed to parse submitter reference payload',
       );
     }
   });

--- a/typescript/http-registry-server/test/services/rootService.test.ts
+++ b/typescript/http-registry-server/test/services/rootService.test.ts
@@ -8,16 +8,19 @@ import { extendRegistryWithSubmitters } from '../../src/services/rootService.js'
 describe('extendRegistryWithSubmitters', () => {
   const originalFetch = globalThis.fetch;
   const fetchPayloads = new Map<string, string>();
+  let fetchHeaders: Array<Record<string, string> | undefined>;
 
   beforeEach(() => {
     fetchPayloads.clear();
-    globalThis.fetch = async (input) => {
+    fetchHeaders = [];
+    globalThis.fetch = async (input, init) => {
       const url =
         typeof input === 'string'
           ? input
           : input instanceof URL
             ? input.href
             : input.url;
+      fetchHeaders.push(init?.headers as Record<string, string> | undefined);
       const ok = fetchPayloads.has(url);
       return {
         ok,
@@ -30,6 +33,43 @@ describe('extendRegistryWithSubmitters', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+  });
+
+  it('forwards auth tokens for remote submitter refs', async () => {
+    fetchPayloads.set(
+      'https://registry.example/submitters/dev-ethereum.yaml',
+      [
+        'type: jsonRpc',
+        'chain: ethereum',
+        'privateKey: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"',
+        '',
+      ].join('\n'),
+    );
+
+    const registry = extendRegistryWithSubmitters(
+      {
+        uri: 'https://registry.example',
+        getUri(itemPath?: string) {
+          return itemPath
+            ? `https://registry.example/${itemPath}`
+            : 'https://registry.example';
+        },
+      } as IRegistry,
+      'secret-token',
+    );
+
+    const submitter = await registry.getSubmitter?.('submitters/dev-ethereum');
+
+    expect(submitter).to.deep.equal({
+      type: TxSubmitterType.JSON_RPC,
+      chain: 'ethereum',
+      privateKey:
+        '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    });
+    expect(fetchHeaders).to.deep.equal([
+      { Authorization: 'Bearer secret-token' },
+      { Authorization: 'Bearer secret-token' },
+    ]);
   });
 
   it('prefers later child registries over earlier child registries', async () => {

--- a/typescript/rebalancer/README.md
+++ b/typescript/rebalancer/README.md
@@ -60,6 +60,21 @@ pnpm --filter @hyperlane-xyz/rebalancer start
 node dist/service.js
 ```
 
+The service also supports registry-backed submitter references:
+
+- `HYP_REBALANCER_SUBMITTER_REF`: resolves the movable-collateral submitter from the registry.
+- `HYP_INVENTORY_SUBMITTER_REF`: resolves the inventory submitter from the registry.
+- `GH_AUTH_TOKEN`: optional bearer token forwarded when the referenced submitter lives behind an authenticated HTTPS registry.
+
+Refs should point at top-level `submitters/...` registry entries and currently must resolve to private-key-backed `jsonRpc` submitters. Example:
+
+```bash
+export REGISTRY_URI=https://github.com/hyperlane-xyz/hyperlane-registry
+export GH_AUTH_TOKEN=...
+export HYP_REBALANCER_SUBMITTER_REF=submitters/prod-ethereum-rebalancer
+export HYP_INVENTORY_SUBMITTER_REF=submitters/prod-ethereum-inventory
+```
+
 ### Programmatic Usage
 
 ```typescript

--- a/typescript/rebalancer/src/service.test.ts
+++ b/typescript/rebalancer/src/service.test.ts
@@ -3,16 +3,14 @@ import { expect } from 'chai';
 import { type IRegistry } from '@hyperlane-xyz/registry';
 import { TxSubmitterType } from '@hyperlane-xyz/sdk';
 
-import { extendRegistryWithSubmitters } from './registry.js';
+import { extendRegistryWithSubmitters } from './service.js';
 
 describe('extendRegistryWithSubmitters', () => {
   const originalFetch = globalThis.fetch;
   const fetchPayloads = new Map<string, string>();
-  let fetchCalls: string[];
 
   beforeEach(() => {
     fetchPayloads.clear();
-    fetchCalls = [];
     globalThis.fetch = async (input) => {
       const url =
         typeof input === 'string'
@@ -20,7 +18,6 @@ describe('extendRegistryWithSubmitters', () => {
           : input instanceof URL
             ? input.href
             : input.url;
-      fetchCalls.push(url);
       const ok = fetchPayloads.has(url);
       return {
         ok,
@@ -90,74 +87,6 @@ describe('extendRegistryWithSubmitters', () => {
     });
   });
 
-  it('checks the current registry after child registries miss', async () => {
-    fetchPayloads.set(
-      'https://registry.example/submitters/dev-ethereum.yaml',
-      [
-        'type: jsonRpc',
-        'chain: ethereum',
-        'privateKey: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"',
-        '',
-      ].join('\n'),
-    );
-
-    const registry = extendRegistryWithSubmitters({
-      uri: 'https://registry.example',
-      getUri(itemPath?: string) {
-        return itemPath
-          ? `https://registry.example/${itemPath}`
-          : 'https://registry.example';
-      },
-      registries: [
-        {
-          uri: 'https://empty.example',
-          getUri(itemPath?: string) {
-            return itemPath
-              ? `https://empty.example/${itemPath}`
-              : 'https://empty.example';
-          },
-        },
-      ],
-    } as unknown as IRegistry & { registries: IRegistry[] });
-
-    const submitter = await registry.getSubmitter?.(
-      'https://registry.example/submitters/dev-ethereum',
-    );
-
-    expect(submitter).to.deep.equal({
-      type: TxSubmitterType.JSON_RPC,
-      chain: 'ethereum',
-      privateKey:
-        '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-    });
-  });
-
-  it('does not fetch submitter refs over insecure HTTP by default', async () => {
-    fetchPayloads.set(
-      'http://registry.example/submitters/dev-ethereum.yaml',
-      [
-        'type: jsonRpc',
-        'chain: ethereum',
-        'privateKey: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"',
-        '',
-      ].join('\n'),
-    );
-
-    const registry = extendRegistryWithSubmitters({
-      uri: 'http://registry.example',
-      getUri(itemPath?: string) {
-        return itemPath
-          ? `http://registry.example/${itemPath}`
-          : 'http://registry.example';
-      },
-    } as IRegistry);
-
-    const submitter = await registry.getSubmitter?.('submitters/dev-ethereum');
-
-    expect(submitter).to.equal(null);
-    expect(fetchCalls).to.deep.equal([]);
-  });
-
   it('throws on malformed local submitter refs', async () => {
     const registry = extendRegistryWithSubmitters({
       uri: 'https://registry.example',
@@ -174,31 +103,6 @@ describe('extendRegistryWithSubmitters', () => {
     } catch (error) {
       expect((error as Error).message).to.include(
         'must target a top-level submitters/ entry',
-      );
-    }
-  });
-
-  it('throws on malformed submitter payloads', async () => {
-    fetchPayloads.set(
-      'https://registry.example/submitters/dev-ethereum.yaml',
-      'type: [',
-    );
-
-    const registry = extendRegistryWithSubmitters({
-      uri: 'https://registry.example',
-      getUri(itemPath?: string) {
-        return itemPath
-          ? `https://registry.example/${itemPath}`
-          : 'https://registry.example';
-      },
-    } as IRegistry);
-
-    try {
-      await registry.getSubmitter?.('submitters/dev-ethereum');
-      throw new Error('Expected malformed submitter payload to throw');
-    } catch (error) {
-      expect((error as Error).message).to.include(
-        'Failed to parse submitter reference payload',
       );
     }
   });

--- a/typescript/rebalancer/src/service.ts
+++ b/typescript/rebalancer/src/service.ts
@@ -39,6 +39,7 @@ import {
   MultiProvider,
   type SubmitterReferenceRegistry,
   TxSubmitterType,
+  getSubmitterRegistryChildren,
   parseSubmitterReferencePayload,
   resolveSubmitterMetadata,
 } from '@hyperlane-xyz/sdk';
@@ -375,8 +376,7 @@ async function readSubmitterReference(
   ref: string,
   authToken?: string,
 ): Promise<unknown> {
-  const childRegistries = (registry as IRegistry & { registries?: IRegistry[] })
-    .registries;
+  const childRegistries = getSubmitterRegistryChildren(registry);
   if (childRegistries?.length) {
     for (const childRegistry of childRegistries) {
       const payload = await readSubmitterReference(
@@ -453,24 +453,49 @@ async function loadPayload(
   source: string,
   authToken?: string,
 ): Promise<unknown> {
-  try {
-    if (isFetchableUrl(source)) {
-      const response = await fetch(source, {
-        headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
-      });
-      if (!response.ok) return null;
-      return parseSubmitterReferencePayload(await response.text(), source);
+  if (isFetchableUrl(source)) {
+    const response = await fetch(source, {
+      headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
+    });
+    if (response.status === 404) return null;
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch submitter reference ${source}: ${response.status} ${response.statusText}`,
+      );
     }
-
-    return readYamlOrJson(source);
-  } catch {
-    return null;
+    return parseSubmitterReferencePayload(await response.text(), source);
   }
+  if (isUrl(source)) return null;
+
+  try {
+    return readYamlOrJson(source);
+  } catch (error) {
+    if (isNotFoundError(error)) return null;
+    throw error;
+  }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+  );
 }
 
 function isFetchableUrl(value: string): boolean {
   try {
     return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
   } catch {
     return false;
   }

--- a/typescript/rebalancer/src/service.ts
+++ b/typescript/rebalancer/src/service.ts
@@ -29,6 +29,7 @@
  */
 import { Wallet } from 'ethers';
 import { Keypair } from '@solana/web3.js';
+import { pathToFileURL } from 'url';
 
 import {
   DEFAULT_GITHUB_REGISTRY,
@@ -37,9 +38,7 @@ import {
 import { getRegistry } from '@hyperlane-xyz/registry/fs';
 import {
   MultiProvider,
-  type SubmitterReferenceRegistry,
   TxSubmitterType,
-  getSubmitterRegistryChildren,
   parseSubmitterReferencePayload,
   resolveSubmitterMetadata,
 } from '@hyperlane-xyz/sdk';
@@ -142,7 +141,7 @@ async function main(): Promise<void> {
     if (rebalancerSubmitterRef) {
       const rebalancerSubmitter = await resolveSubmitterMetadata(
         { type: TxSubmitterType.SUBMITTER_REF, ref: rebalancerSubmitterRef },
-        createSubmitterReferenceRegistry(registry, process.env.GH_AUTH_TOKEN),
+        extendRegistryWithSubmitters(registry, process.env.GH_AUTH_TOKEN),
       );
       if (rebalancerSubmitter.type !== TxSubmitterType.JSON_RPC) {
         throw new Error(
@@ -175,7 +174,7 @@ async function main(): Promise<void> {
     if (inventorySubmitterRef) {
       const inventorySubmitter = await resolveSubmitterMetadata(
         { type: TxSubmitterType.SUBMITTER_REF, ref: inventorySubmitterRef },
-        createSubmitterReferenceRegistry(registry, process.env.GH_AUTH_TOKEN),
+        extendRegistryWithSubmitters(registry, process.env.GH_AUTH_TOKEN),
       );
       if (inventorySubmitter.type !== TxSubmitterType.JSON_RPC) {
         throw new Error(
@@ -349,26 +348,34 @@ async function main(): Promise<void> {
   }
 }
 
-// Run the service
-main().catch((error) => {
-  const err = error as Error;
-  rootLogger.error({ error: err.message, stack: err.stack }, 'Fatal error');
-  process.exit(1);
-});
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    const err = error as Error;
+    rootLogger.error({ error: err.message, stack: err.stack }, 'Fatal error');
+    process.exit(1);
+  });
+}
 
 const SUBMITTER_DIRECTORY = 'submitters';
 const SUPPORTED_EXTENSIONS = ['', '.yaml', '.yml', '.json'];
 
-function createSubmitterReferenceRegistry(
+export type SubmitterRegistry = IRegistry & {
+  getSubmitter(ref: string): Promise<unknown>;
+};
+
+export function extendRegistryWithSubmitters(
   registry: IRegistry,
   authToken?: string,
-): SubmitterReferenceRegistry {
-  return {
-    uri: registry.uri,
-    getUri: (itemPath) => safeGetUri(registry, itemPath) ?? registry.uri,
-    getSubmitter: async (ref) =>
-      readSubmitterReference(registry, ref, authToken),
-  };
+): SubmitterRegistry {
+  const extendedRegistry = registry as SubmitterRegistry;
+  if (!Object.hasOwn(extendedRegistry, 'getSubmitter')) {
+    extendedRegistry.getSubmitter = async (ref) =>
+      readSubmitterReference(registry, ref, authToken);
+  }
+  return extendedRegistry;
 }
 
 async function readSubmitterReference(
@@ -376,9 +383,9 @@ async function readSubmitterReference(
   ref: string,
   authToken?: string,
 ): Promise<unknown> {
-  const childRegistries = getSubmitterRegistryChildren(registry);
+  const childRegistries = getRegistryChildren(registry);
   if (childRegistries?.length) {
-    for (const childRegistry of childRegistries) {
+    for (const childRegistry of childRegistries.slice().reverse()) {
       const payload = await readSubmitterReference(
         childRegistry,
         ref,
@@ -399,11 +406,21 @@ async function readSubmitterReference(
   return null;
 }
 
-function getCandidateItemPaths(ref: string, registry: IRegistry): string[] {
-  const normalizedRef = (stripRegistryRoot(ref, registry) ?? ref).replace(
-    /^\/+/,
-    '',
+function getRegistryChildren(registry: IRegistry): IRegistry[] {
+  if (!('registries' in registry) || !Array.isArray(registry.registries)) {
+    return [];
+  }
+
+  return registry.registries.filter(
+    (child): child is IRegistry => !!child && typeof child === 'object',
   );
+}
+
+function getCandidateItemPaths(ref: string, registry: IRegistry): string[] {
+  const strippedRef = stripRegistryRoot(ref, registry);
+  if (!strippedRef && isUrl(ref)) return [];
+
+  const normalizedRef = (strippedRef ?? ref).replace(/^\/+/, '');
   if (!normalizedRef.startsWith(`${SUBMITTER_DIRECTORY}/`)) {
     throw new Error(
       `Submitter reference ${ref} must target a top-level ${SUBMITTER_DIRECTORY}/ entry`,

--- a/typescript/rebalancer/src/service.ts
+++ b/typescript/rebalancer/src/service.ts
@@ -20,6 +20,7 @@
  * - MONITOR_ONLY: Run in monitor-only mode without executing transactions (default: "false")
  * - LOG_LEVEL: Logging level (default: "info") - supported by pino
  * - REGISTRY_URI: Registry URI for chain metadata. Can include /tree/{commit} to pin version (default: GitHub registry)
+ * - GH_AUTH_TOKEN: GitHub auth token for private or rate-limited registry access (optional)
  * - RPC_URL_<CHAIN>: Override RPC URL for a specific chain (e.g., RPC_URL_ETHEREUM, RPC_URL_ARBITRUM)
  *
  * Usage:
@@ -133,13 +134,14 @@ async function main(): Promise<void> {
       registryUris: [registryUri],
       enableProxy: true,
       logger: rootLogger,
+      authToken: process.env.GH_AUTH_TOKEN,
     });
     logger.info({ registryUri }, '✅ Initialized registry');
 
     if (rebalancerSubmitterRef) {
       const rebalancerSubmitter = await resolveSubmitterMetadata(
-        { type: 'submitter_ref', ref: rebalancerSubmitterRef },
-        createSubmitterReferenceRegistry(registry),
+        { type: TxSubmitterType.SUBMITTER_REF, ref: rebalancerSubmitterRef },
+        createSubmitterReferenceRegistry(registry, process.env.GH_AUTH_TOKEN),
       );
       if (rebalancerSubmitter.type !== TxSubmitterType.JSON_RPC) {
         throw new Error(
@@ -171,8 +173,8 @@ async function main(): Promise<void> {
 
     if (inventorySubmitterRef) {
       const inventorySubmitter = await resolveSubmitterMetadata(
-        { type: 'submitter_ref', ref: inventorySubmitterRef },
-        createSubmitterReferenceRegistry(registry),
+        { type: TxSubmitterType.SUBMITTER_REF, ref: inventorySubmitterRef },
+        createSubmitterReferenceRegistry(registry, process.env.GH_AUTH_TOKEN),
       );
       if (inventorySubmitter.type !== TxSubmitterType.JSON_RPC) {
         throw new Error(
@@ -358,33 +360,39 @@ const SUPPORTED_EXTENSIONS = ['', '.yaml', '.yml', '.json'];
 
 function createSubmitterReferenceRegistry(
   registry: IRegistry,
+  authToken?: string,
 ): SubmitterReferenceRegistry {
   return {
     uri: registry.uri,
     getUri: (itemPath) => safeGetUri(registry, itemPath) ?? registry.uri,
-    getSubmitter: async (ref) => readSubmitterReference(registry, ref),
+    getSubmitter: async (ref) =>
+      readSubmitterReference(registry, ref, authToken),
   };
 }
 
 async function readSubmitterReference(
   registry: IRegistry,
   ref: string,
-): Promise<unknown | null> {
+  authToken?: string,
+): Promise<unknown> {
   const childRegistries = (registry as IRegistry & { registries?: IRegistry[] })
     .registries;
   if (childRegistries?.length) {
     for (const childRegistry of childRegistries) {
-      const payload = await readSubmitterReference(childRegistry, ref);
+      const payload = await readSubmitterReference(
+        childRegistry,
+        ref,
+        authToken,
+      );
       if (payload) return payload;
     }
-    return null;
   }
 
   for (const itemPath of getCandidateItemPaths(ref, registry)) {
     const source = safeGetUri(registry, itemPath);
     if (!source) continue;
 
-    const payload = await loadPayload(source);
+    const payload = await loadPayload(source, authToken);
     if (payload) return payload;
   }
 
@@ -441,10 +449,15 @@ function safeGetUri(
   }
 }
 
-async function loadPayload(source: string): Promise<unknown | null> {
+async function loadPayload(
+  source: string,
+  authToken?: string,
+): Promise<unknown> {
   try {
-    if (source.startsWith('http://') || source.startsWith('https://')) {
-      const response = await fetch(source);
+    if (isFetchableUrl(source)) {
+      const response = await fetch(source, {
+        headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
+      });
       if (!response.ok) return null;
       return parseSubmitterReferencePayload(await response.text(), source);
     }
@@ -452,5 +465,13 @@ async function loadPayload(source: string): Promise<unknown | null> {
     return readYamlOrJson(source);
   } catch {
     return null;
+  }
+}
+
+function isFetchableUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
   }
 }

--- a/typescript/rebalancer/src/service.ts
+++ b/typescript/rebalancer/src/service.ts
@@ -8,9 +8,11 @@
  *
  * Environment Variables:
  * - REBALANCER_CONFIG_FILE: Path to the rebalancer configuration YAML file (required)
+ * - HYP_REBALANCER_SUBMITTER_REF: Submitter reference URI for movable collateral rebalancing operations
  * - HYP_REBALANCER_KEY: Private key for movable collateral rebalancing operations (preferred)
  * - HYP_KEY: Fallback private key for HYP_REBALANCER_KEY (optional)
  * - HYP_INVENTORY_KEY_<PROTOCOL>: Private key for inventory operations per protocol (e.g., HYP_INVENTORY_KEY_ETHEREUM, HYP_INVENTORY_KEY_SEALEVEL)
+ * - HYP_INVENTORY_SUBMITTER_REF: Submitter reference URI for inventory operations (optional)
  * - COINGECKO_API_KEY: API key for CoinGecko price fetching (optional, for metrics)
  * - HYP_INVENTORY_KEY: Backward-compatible fallback for Ethereum inventory signer (optional, use HYP_INVENTORY_KEY_ETHEREUM preferentially)
  * - CHECK_FREQUENCY: Balance check frequency in ms (default: 60000)
@@ -27,15 +29,25 @@
 import { Wallet } from 'ethers';
 import { Keypair } from '@solana/web3.js';
 
-import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
+import {
+  DEFAULT_GITHUB_REGISTRY,
+  type IRegistry,
+} from '@hyperlane-xyz/registry';
 import { getRegistry } from '@hyperlane-xyz/registry/fs';
-import { MultiProvider } from '@hyperlane-xyz/sdk';
+import {
+  MultiProvider,
+  type SubmitterReferenceRegistry,
+  TxSubmitterType,
+  parseSubmitterReferencePayload,
+  resolveSubmitterMetadata,
+} from '@hyperlane-xyz/sdk';
 import {
   applyRpcUrlOverridesFromEnv,
   createServiceLogger,
   ProtocolType,
   rootLogger,
 } from '@hyperlane-xyz/utils';
+import { readYamlOrJson } from '@hyperlane-xyz/utils/fs';
 
 import { RebalancerConfig } from './config/RebalancerConfig.js';
 import { RebalancerService } from './core/RebalancerService.js';
@@ -51,18 +63,14 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const rebalancerPrivateKey =
+  const rebalancerSubmitterRef = process.env.HYP_REBALANCER_SUBMITTER_REF;
+  let rebalancerPrivateKey =
     process.env.HYP_REBALANCER_KEY ?? process.env.HYP_KEY;
-  if (!rebalancerPrivateKey) {
-    rootLogger.error(
-      'HYP_REBALANCER_KEY (or HYP_KEY) environment variable is required',
-    );
-    process.exit(1);
-  }
 
   // Build per-protocol private key map from env vars.
   // Naming: HYP_INVENTORY_KEY_<UPPERCASE_PROTOCOL> (e.g., HYP_INVENTORY_KEY_ETHEREUM).
   // HYP_INVENTORY_KEY (no suffix) is kept as backward-compatible fallback for Ethereum only.
+  const inventorySubmitterRef = process.env.HYP_INVENTORY_SUBMITTER_REF;
   const inventoryPrivateKeys: Partial<Record<ProtocolType, string>> = {};
   for (const protocol of Object.values(ProtocolType)) {
     const envKey = `HYP_INVENTORY_KEY_${protocol.toUpperCase()}`;
@@ -127,6 +135,67 @@ async function main(): Promise<void> {
       logger: rootLogger,
     });
     logger.info({ registryUri }, '✅ Initialized registry');
+
+    if (rebalancerSubmitterRef) {
+      const rebalancerSubmitter = await resolveSubmitterMetadata(
+        { type: 'submitter_ref', ref: rebalancerSubmitterRef },
+        createSubmitterReferenceRegistry(registry),
+      );
+      if (rebalancerSubmitter.type !== TxSubmitterType.JSON_RPC) {
+        throw new Error(
+          `HYP_REBALANCER_SUBMITTER_REF must resolve to ${TxSubmitterType.JSON_RPC}, got ${rebalancerSubmitter.type}`,
+        );
+      }
+      if (!rebalancerSubmitter.privateKey) {
+        throw new Error(
+          `HYP_REBALANCER_SUBMITTER_REF must resolve to a private-key-backed ${TxSubmitterType.JSON_RPC} submitter`,
+        );
+      }
+      rebalancerPrivateKey = rebalancerSubmitter.privateKey;
+      logger.info(
+        {
+          rebalancerAddress:
+            rebalancerSubmitter.userAddress ??
+            new Wallet(rebalancerSubmitter.privateKey).address,
+          rebalancerSubmitterRef,
+        },
+        '✅ Resolved rebalancer submitter reference',
+      );
+    }
+    if (!rebalancerPrivateKey) {
+      rootLogger.error(
+        'HYP_REBALANCER_SUBMITTER_REF or HYP_REBALANCER_KEY (or HYP_KEY) environment variable is required',
+      );
+      process.exit(1);
+    }
+
+    if (inventorySubmitterRef) {
+      const inventorySubmitter = await resolveSubmitterMetadata(
+        { type: 'submitter_ref', ref: inventorySubmitterRef },
+        createSubmitterReferenceRegistry(registry),
+      );
+      if (inventorySubmitter.type !== TxSubmitterType.JSON_RPC) {
+        throw new Error(
+          `HYP_INVENTORY_SUBMITTER_REF must resolve to ${TxSubmitterType.JSON_RPC}, got ${inventorySubmitter.type}`,
+        );
+      }
+      if (!inventorySubmitter.privateKey) {
+        throw new Error(
+          `HYP_INVENTORY_SUBMITTER_REF must resolve to a private-key-backed ${TxSubmitterType.JSON_RPC} submitter`,
+        );
+      }
+      inventoryPrivateKeys[ProtocolType.Ethereum] =
+        inventorySubmitter.privateKey;
+      logger.info(
+        {
+          inventoryAddress:
+            inventorySubmitter.userAddress ??
+            new Wallet(inventorySubmitter.privateKey).address,
+          inventorySubmitterRef,
+        },
+        '✅ Resolved inventory submitter reference',
+      );
+    }
 
     // Get chain metadata from registry
     const chainMetadata = await registry.getMetadata();
@@ -283,3 +352,105 @@ main().catch((error) => {
   rootLogger.error({ error: err.message, stack: err.stack }, 'Fatal error');
   process.exit(1);
 });
+
+const SUBMITTER_DIRECTORY = 'submitters';
+const SUPPORTED_EXTENSIONS = ['', '.yaml', '.yml', '.json'];
+
+function createSubmitterReferenceRegistry(
+  registry: IRegistry,
+): SubmitterReferenceRegistry {
+  return {
+    uri: registry.uri,
+    getUri: (itemPath) => safeGetUri(registry, itemPath) ?? registry.uri,
+    getSubmitter: async (ref) => readSubmitterReference(registry, ref),
+  };
+}
+
+async function readSubmitterReference(
+  registry: IRegistry,
+  ref: string,
+): Promise<unknown | null> {
+  const childRegistries = (registry as IRegistry & { registries?: IRegistry[] })
+    .registries;
+  if (childRegistries?.length) {
+    for (const childRegistry of childRegistries) {
+      const payload = await readSubmitterReference(childRegistry, ref);
+      if (payload) return payload;
+    }
+    return null;
+  }
+
+  for (const itemPath of getCandidateItemPaths(ref, registry)) {
+    const source = safeGetUri(registry, itemPath);
+    if (!source) continue;
+
+    const payload = await loadPayload(source);
+    if (payload) return payload;
+  }
+
+  return null;
+}
+
+function getCandidateItemPaths(ref: string, registry: IRegistry): string[] {
+  const normalizedRef = (stripRegistryRoot(ref, registry) ?? ref).replace(
+    /^\/+/,
+    '',
+  );
+  if (!normalizedRef.startsWith(`${SUBMITTER_DIRECTORY}/`)) {
+    throw new Error(
+      `Submitter reference ${ref} must target a top-level ${SUBMITTER_DIRECTORY}/ entry`,
+    );
+  }
+
+  if (
+    SUPPORTED_EXTENSIONS.some(
+      (extension) => extension && normalizedRef.endsWith(extension),
+    )
+  ) {
+    return [normalizedRef];
+  }
+
+  return SUPPORTED_EXTENSIONS.map((suffix) => `${normalizedRef}${suffix}`);
+}
+
+function stripRegistryRoot(ref: string, registry: IRegistry): string | null {
+  const roots = [registry.uri, safeGetUri(registry)]
+    .filter(
+      (value, index, values): value is string =>
+        !!value && values.indexOf(value) === index,
+    )
+    .sort((a, b) => b.length - a.length);
+
+  for (const root of roots) {
+    if (ref.startsWith(root)) {
+      return ref.slice(root.length).replace(/^\/+/, '');
+    }
+  }
+
+  return null;
+}
+
+function safeGetUri(
+  registry: IRegistry,
+  itemPath?: string,
+): string | undefined {
+  try {
+    return registry.getUri(itemPath);
+  } catch {
+    return undefined;
+  }
+}
+
+async function loadPayload(source: string): Promise<unknown | null> {
+  try {
+    if (source.startsWith('http://') || source.startsWith('https://')) {
+      const response = await fetch(source);
+      if (!response.ok) return null;
+      return parseSubmitterReferencePayload(await response.text(), source);
+    }
+
+    return readYamlOrJson(source);
+  } catch {
+    return null;
+  }
+}

--- a/typescript/rebalancer/src/service.ts
+++ b/typescript/rebalancer/src/service.ts
@@ -370,6 +370,8 @@ export function extendRegistryWithSubmitters(
   registry: IRegistry,
   authToken?: string,
 ): SubmitterRegistry {
+  // CAST: submitter lookup is attached dynamically so SDK lookup code can use
+  // plain IRegistry instances without widening the upstream registry package type.
   const extendedRegistry = registry as SubmitterRegistry;
   if (!Object.hasOwn(extendedRegistry, 'getSubmitter')) {
     extendedRegistry.getSubmitter = async (ref) =>

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -73,6 +73,7 @@
     "pino": "catalog:",
     "starknet": "catalog:",
     "viem": "catalog:",
+    "yaml": "catalog:",
     "zksync-ethers": "catalog:",
     "zod": "catalog:"
   },
@@ -99,8 +100,7 @@
     "solidity-coverage": "catalog:",
     "ts-node": "catalog:",
     "tsx": "catalog:",
-    "typescript": "catalog:",
-    "yaml": "catalog:"
+    "typescript": "catalog:"
   },
   "peerDependencies": {
     "@ethersproject/abi": "*"

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -538,10 +538,9 @@ export {
   UnresolvedSubmitterReferenceSchema,
 } from './providers/transactions/submitter/types.js';
 export {
-  SubmitterReferenceRegistry,
+  SubmitterLookup,
   UnresolvedSubmissionStrategy,
   UnresolvedSubmissionStrategySchema,
-  getSubmitterRegistryChildren,
   parseSubmitterReferencePayload,
   resolveSubmissionStrategy,
   resolveSubmitterMetadata,

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -541,6 +541,7 @@ export {
   SubmitterReferenceRegistry,
   UnresolvedSubmissionStrategy,
   UnresolvedSubmissionStrategySchema,
+  getSubmitterRegistryChildren,
   parseSubmitterReferencePayload,
   resolveSubmissionStrategy,
   resolveSubmitterMetadata,

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -534,7 +534,17 @@ export { TxSubmitterType } from './providers/transactions/submitter/TxSubmitterT
 export {
   SubmitterMetadata,
   SubmitterMetadataSchema,
+  UnresolvedSubmitterReference,
+  UnresolvedSubmitterReferenceSchema,
 } from './providers/transactions/submitter/types.js';
+export {
+  SubmitterReferenceRegistry,
+  UnresolvedSubmissionStrategy,
+  UnresolvedSubmissionStrategySchema,
+  parseSubmitterReferencePayload,
+  resolveSubmissionStrategy,
+  resolveSubmitterMetadata,
+} from './providers/transactions/submitter/reference.js';
 
 export {
   EV5GnosisSafeTxSubmitterProps,

--- a/typescript/sdk/src/providers/transactions/submitter/TxSubmitterTypes.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/TxSubmitterTypes.ts
@@ -5,4 +5,5 @@ export enum TxSubmitterType {
   GNOSIS_TX_BUILDER = 'gnosisSafeTxBuilder',
   INTERCHAIN_ACCOUNT = 'interchainAccount',
   TIMELOCK_CONTROLLER = 'timelockController',
+  SUBMITTER_REF = 'submitter_ref',
 }

--- a/typescript/sdk/src/providers/transactions/submitter/reference.test.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/reference.test.ts
@@ -1,0 +1,167 @@
+import { expect } from 'chai';
+
+import { TxSubmitterType } from './TxSubmitterTypes.js';
+import {
+  resolveSubmissionStrategy,
+  resolveSubmitterMetadata,
+} from './reference.js';
+
+describe('submitter references', () => {
+  const originalFetch = globalThis.fetch;
+  const fetchPayloads = new Map<string, string>();
+
+  beforeEach(() => {
+    fetchPayloads.clear();
+    globalThis.fetch = async (input) => {
+      const url = input.toString();
+      return {
+        ok: fetchPayloads.has(url),
+        text: async () => fetchPayloads.get(url)!,
+      } as Response;
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('resolves submitter metadata from a registry payload', async () => {
+    const submitter = await resolveSubmitterMetadata(
+      {
+        type: 'submitter_ref',
+        ref: 'mock://registry/submitters/rebalancer',
+      },
+      {
+        getSubmitter: async () => ({
+          type: TxSubmitterType.JSON_RPC,
+          chain: 'ethereum',
+          userAddress: '0x1111111111111111111111111111111111111111',
+          privateKey:
+            '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        }),
+      },
+    );
+
+    expect(submitter).to.deep.equal({
+      type: TxSubmitterType.JSON_RPC,
+      chain: 'ethereum',
+      userAddress: '0x1111111111111111111111111111111111111111',
+      privateKey:
+        '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    });
+  });
+
+  it('resolves submission strategies from registry payloads', async () => {
+    const strategy = await resolveSubmissionStrategy(
+      {
+        submitter: {
+          type: 'submitter_ref',
+          ref: 'mock://registry/submitters/rebalancer',
+        },
+      },
+      {
+        getSubmitter: async () => ({
+          submitter: {
+            type: TxSubmitterType.JSON_RPC,
+            chain: 'ethereum',
+            userAddress: '0x1111111111111111111111111111111111111111',
+            privateKey:
+              '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          },
+        }),
+      },
+    );
+
+    expect(strategy.submitter.type).to.equal(TxSubmitterType.JSON_RPC);
+    if (strategy.submitter.type !== TxSubmitterType.JSON_RPC) {
+      throw new Error('Expected jsonRpc submitter');
+    }
+    expect(strategy.submitter.chain).to.equal('ethereum');
+    expect(strategy.submitter.privateKey).to.equal(
+      '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    );
+  });
+
+  it('resolves submitter refs from an IRegistry-compatible getUri interface', async () => {
+    fetchPayloads.set(
+      'https://registry.example/submitters/dev-ethereum.yaml',
+      [
+        'submitter:',
+        '  type: jsonRpc',
+        '  chain: ethereum',
+        '  privateKey: "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"',
+        '',
+      ].join('\n'),
+    );
+
+    const strategy = await resolveSubmissionStrategy(
+      {
+        submitter: {
+          type: 'submitter_ref',
+          ref: 'https://registry.example/submitters/dev-ethereum',
+        },
+      },
+      {
+        uri: 'https://registry.example',
+        getUri(itemPath?: string) {
+          return itemPath
+            ? `https://registry.example/${itemPath}`
+            : 'https://registry.example';
+        },
+      },
+    );
+
+    expect(strategy.submitter.type).to.equal(TxSubmitterType.JSON_RPC);
+    if (strategy.submitter.type !== TxSubmitterType.JSON_RPC) {
+      throw new Error('Expected jsonRpc submitter');
+    }
+    expect(strategy.submitter.privateKey).to.equal(
+      '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+    );
+  });
+
+  it('resolves submitter refs from merged registries whose getUri throws', async () => {
+    fetchPayloads.set(
+      'https://registry.example/submitters/dev-ethereum.yaml',
+      [
+        'type: jsonRpc',
+        'chain: ethereum',
+        'privateKey: "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"',
+        '',
+      ].join('\n'),
+    );
+
+    const strategy = await resolveSubmissionStrategy(
+      {
+        submitter: {
+          type: 'submitter_ref',
+          ref: 'https://registry.example/submitters/dev-ethereum',
+        },
+      },
+      {
+        uri: '__merged_registry__',
+        getUri() {
+          throw new Error('getUri method not applicable to MergedRegistry');
+        },
+        registries: [
+          {
+            uri: 'https://registry.example',
+            getUri(itemPath?: string) {
+              return itemPath
+                ? `https://registry.example/${itemPath}`
+                : 'https://registry.example';
+            },
+          },
+        ],
+      },
+    );
+
+    expect(strategy.submitter.type).to.equal(TxSubmitterType.JSON_RPC);
+    if (strategy.submitter.type !== TxSubmitterType.JSON_RPC) {
+      throw new Error('Expected jsonRpc submitter');
+    }
+    expect(strategy.submitter.privateKey).to.equal(
+      '0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+    );
+  });
+});

--- a/typescript/sdk/src/providers/transactions/submitter/reference.test.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/reference.test.ts
@@ -28,7 +28,7 @@ describe('submitter references', () => {
   it('resolves submitter metadata from a registry payload', async () => {
     const submitter = await resolveSubmitterMetadata(
       {
-        type: 'submitter_ref',
+        type: TxSubmitterType.SUBMITTER_REF,
         ref: 'mock://registry/submitters/rebalancer',
       },
       {
@@ -55,7 +55,7 @@ describe('submitter references', () => {
     const strategy = await resolveSubmissionStrategy(
       {
         submitter: {
-          type: 'submitter_ref',
+          type: TxSubmitterType.SUBMITTER_REF,
           ref: 'mock://registry/submitters/rebalancer',
         },
       },
@@ -70,6 +70,7 @@ describe('submitter references', () => {
           },
         }),
       },
+      'ethereum',
     );
 
     expect(strategy.submitter.type).to.equal(TxSubmitterType.JSON_RPC);
@@ -80,6 +81,31 @@ describe('submitter references', () => {
     expect(strategy.submitter.privateKey).to.equal(
       '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
     );
+  });
+
+  it('rejects submitter refs that resolve to a different chain', async () => {
+    try {
+      await resolveSubmissionStrategy(
+        {
+          submitter: {
+            type: TxSubmitterType.SUBMITTER_REF,
+            ref: 'mock://registry/submitters/rebalancer',
+          },
+        },
+        {
+          getSubmitter: async () => ({
+            type: TxSubmitterType.JSON_RPC,
+            chain: 'arbitrum',
+          }),
+        },
+        'ethereum',
+      );
+      throw new Error('Expected resolveSubmissionStrategy to fail');
+    } catch (error) {
+      expect((error as Error).message).to.include(
+        'Submitter reference resolved to chain arbitrum, expected ethereum',
+      );
+    }
   });
 
   it('resolves submitter refs from an IRegistry-compatible getUri interface', async () => {
@@ -97,7 +123,7 @@ describe('submitter references', () => {
     const strategy = await resolveSubmissionStrategy(
       {
         submitter: {
-          type: 'submitter_ref',
+          type: TxSubmitterType.SUBMITTER_REF,
           ref: 'https://registry.example/submitters/dev-ethereum',
         },
       },
@@ -109,6 +135,7 @@ describe('submitter references', () => {
             : 'https://registry.example';
         },
       },
+      'ethereum',
     );
 
     expect(strategy.submitter.type).to.equal(TxSubmitterType.JSON_RPC);
@@ -134,7 +161,7 @@ describe('submitter references', () => {
     const strategy = await resolveSubmissionStrategy(
       {
         submitter: {
-          type: 'submitter_ref',
+          type: TxSubmitterType.SUBMITTER_REF,
           ref: 'https://registry.example/submitters/dev-ethereum',
         },
       },
@@ -154,6 +181,7 @@ describe('submitter references', () => {
           },
         ],
       },
+      'ethereum',
     );
 
     expect(strategy.submitter.type).to.equal(TxSubmitterType.JSON_RPC);
@@ -163,5 +191,88 @@ describe('submitter references', () => {
     expect(strategy.submitter.privateKey).to.equal(
       '0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
     );
+  });
+
+  it('checks the current registry after child registries miss', async () => {
+    fetchPayloads.set(
+      'https://registry.example/submitters/dev-ethereum.yaml',
+      [
+        'type: jsonRpc',
+        'chain: ethereum',
+        'privateKey: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"',
+        '',
+      ].join('\n'),
+    );
+
+    const strategy = await resolveSubmissionStrategy(
+      {
+        submitter: {
+          type: TxSubmitterType.SUBMITTER_REF,
+          ref: 'https://registry.example/submitters/dev-ethereum',
+        },
+      },
+      {
+        uri: 'https://registry.example',
+        getUri(itemPath?: string) {
+          return itemPath
+            ? `https://registry.example/${itemPath}`
+            : 'https://registry.example';
+        },
+        registries: [
+          {
+            uri: 'https://empty.example',
+            getUri(itemPath?: string) {
+              return itemPath
+                ? `https://empty.example/${itemPath}`
+                : 'https://empty.example';
+            },
+          },
+        ],
+      },
+      'ethereum',
+    );
+
+    expect(strategy.submitter.type).to.equal(TxSubmitterType.JSON_RPC);
+    if (strategy.submitter.type !== TxSubmitterType.JSON_RPC) {
+      throw new Error('Expected jsonRpc submitter');
+    }
+    expect(strategy.submitter.privateKey).to.equal(
+      '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    );
+  });
+
+  it('does not fetch submitter refs over insecure HTTP by default', async () => {
+    fetchPayloads.set(
+      'http://registry.example/submitters/dev-ethereum.yaml',
+      [
+        'type: jsonRpc',
+        'chain: ethereum',
+        'privateKey: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"',
+        '',
+      ].join('\n'),
+    );
+
+    try {
+      await resolveSubmissionStrategy(
+        {
+          submitter: {
+            type: TxSubmitterType.SUBMITTER_REF,
+            ref: 'http://registry.example/submitters/dev-ethereum',
+          },
+        },
+        {
+          uri: 'http://registry.example',
+          getUri(itemPath?: string) {
+            return itemPath
+              ? `http://registry.example/${itemPath}`
+              : 'http://registry.example';
+          },
+        },
+        'ethereum',
+      );
+      throw new Error('Expected resolveSubmissionStrategy to fail');
+    } catch (error) {
+      expect((error as Error).message).to.include('Submitter reference');
+    }
   });
 });

--- a/typescript/sdk/src/providers/transactions/submitter/reference.test.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/reference.test.ts
@@ -9,13 +9,25 @@ import {
 describe('submitter references', () => {
   const originalFetch = globalThis.fetch;
   const fetchPayloads = new Map<string, string>();
+  const fetchStatuses = new Map<string, number>();
 
   beforeEach(() => {
     fetchPayloads.clear();
+    fetchStatuses.clear();
     globalThis.fetch = async (input) => {
-      const url = input.toString();
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      const status =
+        fetchStatuses.get(url) ?? (fetchPayloads.has(url) ? 200 : 404);
+      const ok = status >= 200 && status < 300;
       return {
-        ok: fetchPayloads.has(url),
+        ok,
+        status,
+        statusText: ok ? 'OK' : status === 404 ? 'Not Found' : 'Error',
         text: async () => fetchPayloads.get(url)!,
       } as Response;
     };
@@ -273,6 +285,70 @@ describe('submitter references', () => {
       throw new Error('Expected resolveSubmissionStrategy to fail');
     } catch (error) {
       expect((error as Error).message).to.include('Submitter reference');
+    }
+  });
+
+  it('throws on malformed submitter reference payloads from direct registries', async () => {
+    fetchPayloads.set(
+      'https://registry.example/submitters/dev-ethereum.yaml',
+      'type: [',
+    );
+
+    try {
+      await resolveSubmissionStrategy(
+        {
+          submitter: {
+            type: TxSubmitterType.SUBMITTER_REF,
+            ref: 'https://registry.example/submitters/dev-ethereum',
+          },
+        },
+        {
+          uri: 'https://registry.example',
+          getUri(itemPath?: string) {
+            return itemPath
+              ? `https://registry.example/${itemPath}`
+              : 'https://registry.example';
+          },
+        },
+        'ethereum',
+      );
+      throw new Error('Expected resolveSubmissionStrategy to fail');
+    } catch (error) {
+      expect((error as Error).message).to.include(
+        'Failed to parse submitter reference payload',
+      );
+    }
+  });
+
+  it('throws on non-404 fetch errors from direct registries', async () => {
+    fetchStatuses.set(
+      'https://registry.example/submitters/dev-ethereum.yaml',
+      500,
+    );
+
+    try {
+      await resolveSubmissionStrategy(
+        {
+          submitter: {
+            type: TxSubmitterType.SUBMITTER_REF,
+            ref: 'https://registry.example/submitters/dev-ethereum',
+          },
+        },
+        {
+          uri: 'https://registry.example',
+          getUri(itemPath?: string) {
+            return itemPath
+              ? `https://registry.example/${itemPath}`
+              : 'https://registry.example';
+          },
+        },
+        'ethereum',
+      );
+      throw new Error('Expected resolveSubmissionStrategy to fail');
+    } catch (error) {
+      expect((error as Error).message).to.include(
+        'Failed to fetch submitter reference https://registry.example/submitters/dev-ethereum.yaml: 500 Error',
+      );
     }
   });
 });

--- a/typescript/sdk/src/providers/transactions/submitter/reference.test.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/reference.test.ts
@@ -2,42 +2,13 @@ import { expect } from 'chai';
 
 import { TxSubmitterType } from './TxSubmitterTypes.js';
 import {
+  parseSubmitterReferencePayload,
   resolveSubmissionStrategy,
   resolveSubmitterMetadata,
 } from './reference.js';
 
 describe('submitter references', () => {
-  const originalFetch = globalThis.fetch;
-  const fetchPayloads = new Map<string, string>();
-  const fetchStatuses = new Map<string, number>();
-
-  beforeEach(() => {
-    fetchPayloads.clear();
-    fetchStatuses.clear();
-    globalThis.fetch = async (input) => {
-      const url =
-        typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.href
-            : input.url;
-      const status =
-        fetchStatuses.get(url) ?? (fetchPayloads.has(url) ? 200 : 404);
-      const ok = status >= 200 && status < 300;
-      return {
-        ok,
-        status,
-        statusText: ok ? 'OK' : status === 404 ? 'Not Found' : 'Error',
-        text: async () => fetchPayloads.get(url)!,
-      } as Response;
-    };
-  });
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  it('resolves submitter metadata from a registry payload', async () => {
+  it('resolves submitter metadata from a lookup payload', async () => {
     const submitter = await resolveSubmitterMetadata(
       {
         type: TxSubmitterType.SUBMITTER_REF,
@@ -63,7 +34,7 @@ describe('submitter references', () => {
     });
   });
 
-  it('resolves submission strategies from registry payloads', async () => {
+  it('resolves submission strategies from lookup payloads', async () => {
     const strategy = await resolveSubmissionStrategy(
       {
         submitter: {
@@ -120,195 +91,65 @@ describe('submitter references', () => {
     }
   });
 
-  it('resolves submitter refs from an IRegistry-compatible getUri interface', async () => {
-    fetchPayloads.set(
-      'https://registry.example/submitters/dev-ethereum.yaml',
-      [
-        'submitter:',
-        '  type: jsonRpc',
-        '  chain: ethereum',
-        '  privateKey: "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"',
-        '',
-      ].join('\n'),
-    );
-
-    const strategy = await resolveSubmissionStrategy(
-      {
-        submitter: {
-          type: TxSubmitterType.SUBMITTER_REF,
-          ref: 'https://registry.example/submitters/dev-ethereum',
-        },
-      },
-      {
-        uri: 'https://registry.example',
-        getUri(itemPath?: string) {
-          return itemPath
-            ? `https://registry.example/${itemPath}`
-            : 'https://registry.example';
-        },
-      },
-      'ethereum',
-    );
-
-    expect(strategy.submitter.type).to.equal(TxSubmitterType.JSON_RPC);
-    if (strategy.submitter.type !== TxSubmitterType.JSON_RPC) {
-      throw new Error('Expected jsonRpc submitter');
-    }
-    expect(strategy.submitter.privateKey).to.equal(
-      '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
-    );
-  });
-
-  it('resolves submitter refs from merged registries whose getUri throws', async () => {
-    fetchPayloads.set(
-      'https://registry.example/submitters/dev-ethereum.yaml',
-      [
-        'type: jsonRpc',
-        'chain: ethereum',
-        'privateKey: "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"',
-        '',
-      ].join('\n'),
-    );
-
-    const strategy = await resolveSubmissionStrategy(
-      {
-        submitter: {
-          type: TxSubmitterType.SUBMITTER_REF,
-          ref: 'https://registry.example/submitters/dev-ethereum',
-        },
-      },
-      {
-        uri: '__merged_registry__',
-        getUri() {
-          throw new Error('getUri method not applicable to MergedRegistry');
-        },
-        registries: [
-          {
-            uri: 'https://registry.example',
-            getUri(itemPath?: string) {
-              return itemPath
-                ? `https://registry.example/${itemPath}`
-                : 'https://registry.example';
-            },
-          },
-        ],
-      },
-      'ethereum',
-    );
-
-    expect(strategy.submitter.type).to.equal(TxSubmitterType.JSON_RPC);
-    if (strategy.submitter.type !== TxSubmitterType.JSON_RPC) {
-      throw new Error('Expected jsonRpc submitter');
-    }
-    expect(strategy.submitter.privateKey).to.equal(
-      '0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
-    );
-  });
-
-  it('checks the current registry after child registries miss', async () => {
-    fetchPayloads.set(
-      'https://registry.example/submitters/dev-ethereum.yaml',
-      [
-        'type: jsonRpc',
-        'chain: ethereum',
-        'privateKey: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"',
-        '',
-      ].join('\n'),
-    );
-
-    const strategy = await resolveSubmissionStrategy(
-      {
-        submitter: {
-          type: TxSubmitterType.SUBMITTER_REF,
-          ref: 'https://registry.example/submitters/dev-ethereum',
-        },
-      },
-      {
-        uri: 'https://registry.example',
-        getUri(itemPath?: string) {
-          return itemPath
-            ? `https://registry.example/${itemPath}`
-            : 'https://registry.example';
-        },
-        registries: [
-          {
-            uri: 'https://empty.example',
-            getUri(itemPath?: string) {
-              return itemPath
-                ? `https://empty.example/${itemPath}`
-                : 'https://empty.example';
-            },
-          },
-        ],
-      },
-      'ethereum',
-    );
-
-    expect(strategy.submitter.type).to.equal(TxSubmitterType.JSON_RPC);
-    if (strategy.submitter.type !== TxSubmitterType.JSON_RPC) {
-      throw new Error('Expected jsonRpc submitter');
-    }
-    expect(strategy.submitter.privateKey).to.equal(
-      '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-    );
-  });
-
-  it('does not fetch submitter refs over insecure HTTP by default', async () => {
-    fetchPayloads.set(
-      'http://registry.example/submitters/dev-ethereum.yaml',
-      [
-        'type: jsonRpc',
-        'chain: ethereum',
-        'privateKey: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"',
-        '',
-      ].join('\n'),
-    );
-
+  it('throws when a submitter lookup is missing', async () => {
     try {
       await resolveSubmissionStrategy(
         {
           submitter: {
             type: TxSubmitterType.SUBMITTER_REF,
-            ref: 'http://registry.example/submitters/dev-ethereum',
+            ref: 'submitters/dev-ethereum',
           },
         },
         {
-          uri: 'http://registry.example',
-          getUri(itemPath?: string) {
-            return itemPath
-              ? `http://registry.example/${itemPath}`
-              : 'http://registry.example';
-          },
+          getSubmitter: async () => null,
         },
         'ethereum',
       );
       throw new Error('Expected resolveSubmissionStrategy to fail');
     } catch (error) {
-      expect((error as Error).message).to.include('Submitter reference');
+      expect((error as Error).message).to.include(
+        'Submitter reference submitters/dev-ethereum was not found',
+      );
     }
   });
 
-  it('throws on malformed submitter reference payloads from direct registries', async () => {
-    fetchPayloads.set(
-      'https://registry.example/submitters/dev-ethereum.yaml',
-      'type: [',
-    );
-
+  it('throws when a lookup payload is malformed', async () => {
     try {
       await resolveSubmissionStrategy(
         {
           submitter: {
             type: TxSubmitterType.SUBMITTER_REF,
-            ref: 'https://registry.example/submitters/dev-ethereum',
+            ref: 'submitters/dev-ethereum',
           },
         },
         {
-          uri: 'https://registry.example',
-          getUri(itemPath?: string) {
-            return itemPath
-              ? `https://registry.example/${itemPath}`
-              : 'https://registry.example';
+          getSubmitter: async () => ({ type: 'not-a-submitter' }),
+        },
+        'ethereum',
+      );
+      throw new Error('Expected resolveSubmissionStrategy to fail');
+    } catch (error) {
+      expect((error as Error).message).to.include(
+        'Submitter reference submitters/dev-ethereum did not resolve to SubmitterMetadata or SubmissionStrategy',
+      );
+    }
+  });
+
+  it('propagates parse errors from lookup payloads', async () => {
+    try {
+      await resolveSubmissionStrategy(
+        {
+          submitter: {
+            type: TxSubmitterType.SUBMITTER_REF,
+            ref: 'submitters/dev-ethereum',
           },
+        },
+        {
+          getSubmitter: () =>
+            parseSubmitterReferencePayload(
+              'type: [',
+              'submitters/dev-ethereum.yaml',
+            ),
         },
         'ethereum',
       );
@@ -320,34 +161,22 @@ describe('submitter references', () => {
     }
   });
 
-  it('throws on non-404 fetch errors from direct registries', async () => {
-    fetchStatuses.set(
-      'https://registry.example/submitters/dev-ethereum.yaml',
-      500,
-    );
-
+  it('throws when no lookup is provided', async () => {
     try {
       await resolveSubmissionStrategy(
         {
           submitter: {
             type: TxSubmitterType.SUBMITTER_REF,
-            ref: 'https://registry.example/submitters/dev-ethereum',
+            ref: 'submitters/dev-ethereum',
           },
         },
-        {
-          uri: 'https://registry.example',
-          getUri(itemPath?: string) {
-            return itemPath
-              ? `https://registry.example/${itemPath}`
-              : 'https://registry.example';
-          },
-        },
+        undefined,
         'ethereum',
       );
       throw new Error('Expected resolveSubmissionStrategy to fail');
     } catch (error) {
       expect((error as Error).message).to.include(
-        'Failed to fetch submitter reference https://registry.example/submitters/dev-ethereum.yaml: 500 Error',
+        'Submitter reference submitters/dev-ethereum requires a submitter lookup',
       );
     }
   });

--- a/typescript/sdk/src/providers/transactions/submitter/reference.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/reference.ts
@@ -17,13 +17,23 @@ import {
 import { TxSubmitterType } from './TxSubmitterTypes.js';
 
 export interface SubmitterReferenceRegistry {
-  getSubmitter?(
-    ref: string,
-  ): Promise<unknown | null | undefined> | unknown | null | undefined;
+  getSubmitter?(ref: string): unknown;
   getUri?(itemPath?: string): string;
   uri?: string;
   registries?: Array<Partial<SubmitterReferenceRegistry>>;
   allowInsecureHttp?: boolean;
+}
+
+export function getSubmitterRegistryChildren<TRegistry extends object>(
+  registry: TRegistry,
+): TRegistry[] {
+  if (!('registries' in registry) || !Array.isArray(registry.registries)) {
+    return [];
+  }
+
+  return registry.registries.filter(
+    (child): child is TRegistry => !!child && typeof child === 'object',
+  );
 }
 
 const SUBMITTER_DIRECTORY = 'submitters';
@@ -138,16 +148,14 @@ export function parseSubmitterReferencePayload(
 async function loadSubmitterReferenceFromRegistry(
   registry: Partial<SubmitterReferenceRegistry>,
   ref: string,
-): Promise<unknown | null> {
-  if (registry.registries?.length) {
-    for (const childRegistry of registry.registries) {
-      const payload = await loadSubmitterReferenceFromRegistry(
-        childRegistry,
-        ref,
-      );
-      if (payload) {
-        return payload;
-      }
+): Promise<unknown> {
+  for (const childRegistry of getSubmitterRegistryChildren(registry)) {
+    const payload = await loadSubmitterReferenceFromRegistry(
+      childRegistry,
+      ref,
+    );
+    if (payload) {
+      return payload;
     }
   }
 
@@ -242,19 +250,27 @@ async function loadReferencePayload(
   source: string,
   registry: Partial<SubmitterReferenceRegistry>,
 ): Promise<string | null> {
-  try {
-    if (!isFetchableUrl(source, registry.allowInsecureHttp)) {
-      return null;
-    }
-
-    const response = await fetch(source);
-    if (!response.ok) {
-      return null;
-    }
-    return response.text();
-  } catch {
+  if (!isFetchableUrl(source, registry.allowInsecureHttp)) {
     return null;
   }
+
+  let response: Response;
+  try {
+    response = await fetch(source);
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch submitter reference ${source}: ${String(error)}`,
+    );
+  }
+
+  if (response.status === 404) {
+    return null;
+  }
+  assert(
+    response.ok,
+    `Failed to fetch submitter reference ${source}: ${response.status} ${response.statusText}`,
+  );
+  return response.text();
 }
 
 function hasSupportedExtension(value: string): boolean {

--- a/typescript/sdk/src/providers/transactions/submitter/reference.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/reference.ts
@@ -1,0 +1,251 @@
+import { parse as parseYaml } from 'yaml';
+import { z } from 'zod';
+
+import { assert } from '@hyperlane-xyz/utils';
+
+import {
+  SubmissionStrategy,
+  SubmissionStrategySchema,
+} from './builder/types.js';
+import {
+  SubmitterMetadata,
+  SubmitterMetadataSchema,
+  UnresolvedSubmitterReference,
+  UnresolvedSubmitterReferenceSchema,
+} from './types.js';
+
+export interface SubmitterReferenceRegistry {
+  getSubmitter?(
+    ref: string,
+  ): Promise<unknown | null | undefined> | unknown | null | undefined;
+  getUri?(itemPath?: string): string;
+  uri?: string;
+  registries?: Array<Partial<SubmitterReferenceRegistry>>;
+}
+
+const SUBMITTER_DIRECTORY = 'submitters';
+const SUPPORTED_EXTENSIONS = ['', '.yaml', '.yml', '.json'];
+
+export const UnresolvedSubmissionStrategySchema = z
+  .object({
+    submitter: z.union([
+      SubmitterMetadataSchema,
+      UnresolvedSubmitterReferenceSchema,
+    ]),
+  })
+  .strict();
+
+export type UnresolvedSubmissionStrategy = z.infer<
+  typeof UnresolvedSubmissionStrategySchema
+>;
+
+function isUnresolvedSubmitterReference(
+  value: SubmitterMetadata | UnresolvedSubmitterReference,
+): value is UnresolvedSubmitterReference {
+  return value.type === 'submitter_ref';
+}
+
+function parseResolvedSubmitterPayload(
+  payload: unknown,
+  ref: string,
+): SubmitterMetadata {
+  const strategyResult = SubmissionStrategySchema.safeParse(payload);
+  if (strategyResult.success) {
+    return strategyResult.data.submitter;
+  }
+
+  const metadataResult = SubmitterMetadataSchema.safeParse(payload);
+  if (metadataResult.success) {
+    return metadataResult.data;
+  }
+
+  throw new Error(
+    `Submitter reference ${ref} did not resolve to SubmitterMetadata or SubmissionStrategy`,
+  );
+}
+
+export async function resolveSubmitterMetadata(
+  submitter:
+    | SubmitterMetadata
+    | UnresolvedSubmitterReference
+    | Promise<SubmitterMetadata | UnresolvedSubmitterReference>,
+  registry?: Partial<SubmitterReferenceRegistry>,
+): Promise<SubmitterMetadata> {
+  const awaitedSubmitter = await submitter;
+  if (!isUnresolvedSubmitterReference(awaitedSubmitter)) {
+    return awaitedSubmitter;
+  }
+
+  assert(
+    registry,
+    `Submitter reference ${awaitedSubmitter.ref} requires a registry`,
+  );
+
+  const payload =
+    (registry.getSubmitter
+      ? await registry.getSubmitter(awaitedSubmitter.ref)
+      : null) ??
+    (await loadSubmitterReferenceFromRegistry(registry, awaitedSubmitter.ref));
+  assert(payload, `Submitter reference ${awaitedSubmitter.ref} was not found`);
+  return parseResolvedSubmitterPayload(payload, awaitedSubmitter.ref);
+}
+
+export async function resolveSubmissionStrategy(
+  strategy:
+    | UnresolvedSubmissionStrategy
+    | SubmissionStrategy
+    | Promise<UnresolvedSubmissionStrategy | SubmissionStrategy>,
+  registry?: Partial<SubmitterReferenceRegistry>,
+): Promise<SubmissionStrategy> {
+  const awaitedStrategy = await strategy;
+  return {
+    ...awaitedStrategy,
+    submitter: await resolveSubmitterMetadata(
+      awaitedStrategy.submitter,
+      registry,
+    ),
+  };
+}
+
+export function parseSubmitterReferencePayload(
+  payload: string,
+  source: string,
+): unknown {
+  try {
+    return JSON.parse(payload);
+  } catch {
+    try {
+      return parseYaml(payload);
+    } catch (error) {
+      throw new Error(
+        `Failed to parse submitter reference payload from ${source}: ${String(error)}`,
+      );
+    }
+  }
+}
+
+async function loadSubmitterReferenceFromRegistry(
+  registry: Partial<SubmitterReferenceRegistry>,
+  ref: string,
+): Promise<unknown | null> {
+  if (registry.registries?.length) {
+    for (const childRegistry of registry.registries) {
+      const payload = await loadSubmitterReferenceFromRegistry(
+        childRegistry,
+        ref,
+      );
+      if (payload) {
+        return payload;
+      }
+    }
+
+    return null;
+  }
+
+  assert(
+    registry.getUri || registry.uri,
+    `Submitter reference ${ref} requires a registry with getSubmitter(ref), getUri(itemPath), or uri support`,
+  );
+
+  for (const itemPath of getCandidateItemPaths(ref, registry)) {
+    for (const source of getCandidateSources(itemPath, registry)) {
+      const payload = await loadReferencePayload(source);
+      if (payload) {
+        return parseSubmitterReferencePayload(payload, source);
+      }
+    }
+  }
+
+  return null;
+}
+
+function getCandidateItemPaths(
+  ref: string,
+  registry: Partial<SubmitterReferenceRegistry>,
+): string[] {
+  const relativeRef = stripRegistryRoot(ref, registry) ?? ref;
+  const normalizedRef = relativeRef.replace(/^\/+/, '');
+  assert(
+    normalizedRef.startsWith(`${SUBMITTER_DIRECTORY}/`),
+    `Submitter reference ${ref} must target a top-level ${SUBMITTER_DIRECTORY}/ entry`,
+  );
+
+  if (hasSupportedExtension(normalizedRef)) {
+    return [normalizedRef];
+  }
+
+  return SUPPORTED_EXTENSIONS.map((suffix) => `${normalizedRef}${suffix}`);
+}
+
+function stripRegistryRoot(
+  ref: string,
+  registry: Partial<SubmitterReferenceRegistry>,
+): string | null {
+  const roots = [registry.uri, safeGetUri(registry)]
+    .filter(
+      (value, index, values): value is string =>
+        !!value && values.indexOf(value) === index,
+    )
+    .sort((a, b) => b.length - a.length);
+
+  for (const root of roots) {
+    if (ref.startsWith(root)) {
+      return ref.slice(root.length).replace(/^\/+/, '');
+    }
+  }
+
+  return null;
+}
+
+function getCandidateSources(
+  itemPath: string,
+  registry: Partial<SubmitterReferenceRegistry>,
+): string[] {
+  const sources = [safeGetUri(registry, itemPath)];
+
+  if (registry.uri && registry.uri !== '__merged_registry__') {
+    sources.push(`${registry.uri.replace(/\/+$/, '')}/${itemPath}`);
+  }
+
+  return sources.filter(
+    (source, index, values): source is string =>
+      !!source && values.indexOf(source) === index,
+  );
+}
+
+function safeGetUri(
+  registry: Partial<SubmitterReferenceRegistry>,
+  itemPath?: string,
+): string | undefined {
+  try {
+    return registry.getUri?.(itemPath);
+  } catch {
+    return undefined;
+  }
+}
+
+async function loadReferencePayload(source: string): Promise<string | null> {
+  try {
+    if (!isHttpUrl(source)) {
+      return null;
+    }
+
+    const response = await fetch(source);
+    if (!response.ok) {
+      return null;
+    }
+    return response.text();
+  } catch {
+    return null;
+  }
+}
+
+function hasSupportedExtension(value: string): boolean {
+  return SUPPORTED_EXTENSIONS.some((extension) => {
+    return extension.length > 0 && value.endsWith(extension);
+  });
+}
+
+function isHttpUrl(value: string): boolean {
+  return value.startsWith('http://') || value.startsWith('https://');
+}

--- a/typescript/sdk/src/providers/transactions/submitter/reference.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/reference.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { assert } from '@hyperlane-xyz/utils';
 
+import { ChainName } from '../../../types.js';
 import {
   SubmissionStrategy,
   SubmissionStrategySchema,
@@ -13,6 +14,7 @@ import {
   UnresolvedSubmitterReference,
   UnresolvedSubmitterReferenceSchema,
 } from './types.js';
+import { TxSubmitterType } from './TxSubmitterTypes.js';
 
 export interface SubmitterReferenceRegistry {
   getSubmitter?(
@@ -21,6 +23,7 @@ export interface SubmitterReferenceRegistry {
   getUri?(itemPath?: string): string;
   uri?: string;
   registries?: Array<Partial<SubmitterReferenceRegistry>>;
+  allowInsecureHttp?: boolean;
 }
 
 const SUBMITTER_DIRECTORY = 'submitters';
@@ -42,7 +45,7 @@ export type UnresolvedSubmissionStrategy = z.infer<
 function isUnresolvedSubmitterReference(
   value: SubmitterMetadata | UnresolvedSubmitterReference,
 ): value is UnresolvedSubmitterReference {
-  return value.type === 'submitter_ref';
+  return value.type === TxSubmitterType.SUBMITTER_REF;
 }
 
 function parseResolvedSubmitterPayload(
@@ -96,14 +99,22 @@ export async function resolveSubmissionStrategy(
     | SubmissionStrategy
     | Promise<UnresolvedSubmissionStrategy | SubmissionStrategy>,
   registry?: Partial<SubmitterReferenceRegistry>,
+  expectedChain?: ChainName,
 ): Promise<SubmissionStrategy> {
   const awaitedStrategy = await strategy;
+  const shouldAssertChain =
+    expectedChain && isUnresolvedSubmitterReference(awaitedStrategy.submitter);
+  const submitter = await resolveSubmitterMetadata(
+    awaitedStrategy.submitter,
+    registry,
+  );
+  assert(
+    !shouldAssertChain || submitter.chain === expectedChain,
+    `Submitter reference resolved to chain ${submitter.chain}, expected ${expectedChain}`,
+  );
   return {
     ...awaitedStrategy,
-    submitter: await resolveSubmitterMetadata(
-      awaitedStrategy.submitter,
-      registry,
-    ),
+    submitter,
   };
 }
 
@@ -138,8 +149,6 @@ async function loadSubmitterReferenceFromRegistry(
         return payload;
       }
     }
-
-    return null;
   }
 
   assert(
@@ -149,7 +158,7 @@ async function loadSubmitterReferenceFromRegistry(
 
   for (const itemPath of getCandidateItemPaths(ref, registry)) {
     for (const source of getCandidateSources(itemPath, registry)) {
-      const payload = await loadReferencePayload(source);
+      const payload = await loadReferencePayload(source, registry);
       if (payload) {
         return parseSubmitterReferencePayload(payload, source);
       }
@@ -163,7 +172,12 @@ function getCandidateItemPaths(
   ref: string,
   registry: Partial<SubmitterReferenceRegistry>,
 ): string[] {
-  const relativeRef = stripRegistryRoot(ref, registry) ?? ref;
+  const strippedRef = stripRegistryRoot(ref, registry);
+  if (!strippedRef && isAbsoluteUrl(ref)) {
+    return [];
+  }
+
+  const relativeRef = strippedRef ?? ref;
   const normalizedRef = relativeRef.replace(/^\/+/, '');
   assert(
     normalizedRef.startsWith(`${SUBMITTER_DIRECTORY}/`),
@@ -224,9 +238,12 @@ function safeGetUri(
   }
 }
 
-async function loadReferencePayload(source: string): Promise<string | null> {
+async function loadReferencePayload(
+  source: string,
+  registry: Partial<SubmitterReferenceRegistry>,
+): Promise<string | null> {
   try {
-    if (!isHttpUrl(source)) {
+    if (!isFetchableUrl(source, registry.allowInsecureHttp)) {
       return null;
     }
 
@@ -246,6 +263,23 @@ function hasSupportedExtension(value: string): boolean {
   });
 }
 
-function isHttpUrl(value: string): boolean {
-  return value.startsWith('http://') || value.startsWith('https://');
+function isFetchableUrl(value: string, allowInsecureHttp = false): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === 'https:' ||
+      (allowInsecureHttp && url.protocol === 'http:')
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/typescript/sdk/src/providers/transactions/submitter/reference.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/reference.ts
@@ -16,28 +16,9 @@ import {
 } from './types.js';
 import { TxSubmitterType } from './TxSubmitterTypes.js';
 
-export interface SubmitterReferenceRegistry {
-  getSubmitter?(ref: string): unknown;
-  getUri?(itemPath?: string): string;
-  uri?: string;
-  registries?: Array<Partial<SubmitterReferenceRegistry>>;
-  allowInsecureHttp?: boolean;
+export interface SubmitterLookup {
+  getSubmitter(ref: string): unknown;
 }
-
-export function getSubmitterRegistryChildren<TRegistry extends object>(
-  registry: TRegistry,
-): TRegistry[] {
-  if (!('registries' in registry) || !Array.isArray(registry.registries)) {
-    return [];
-  }
-
-  return registry.registries.filter(
-    (child): child is TRegistry => !!child && typeof child === 'object',
-  );
-}
-
-const SUBMITTER_DIRECTORY = 'submitters';
-const SUPPORTED_EXTENSIONS = ['', '.yaml', '.yml', '.json'];
 
 export const UnresolvedSubmissionStrategySchema = z
   .object({
@@ -82,7 +63,7 @@ export async function resolveSubmitterMetadata(
     | SubmitterMetadata
     | UnresolvedSubmitterReference
     | Promise<SubmitterMetadata | UnresolvedSubmitterReference>,
-  registry?: Partial<SubmitterReferenceRegistry>,
+  lookup?: SubmitterLookup,
 ): Promise<SubmitterMetadata> {
   const awaitedSubmitter = await submitter;
   if (!isUnresolvedSubmitterReference(awaitedSubmitter)) {
@@ -90,15 +71,11 @@ export async function resolveSubmitterMetadata(
   }
 
   assert(
-    registry,
-    `Submitter reference ${awaitedSubmitter.ref} requires a registry`,
+    lookup,
+    `Submitter reference ${awaitedSubmitter.ref} requires a submitter lookup`,
   );
 
-  const payload =
-    (registry.getSubmitter
-      ? await registry.getSubmitter(awaitedSubmitter.ref)
-      : null) ??
-    (await loadSubmitterReferenceFromRegistry(registry, awaitedSubmitter.ref));
+  const payload = await lookup.getSubmitter(awaitedSubmitter.ref);
   assert(payload, `Submitter reference ${awaitedSubmitter.ref} was not found`);
   return parseResolvedSubmitterPayload(payload, awaitedSubmitter.ref);
 }
@@ -108,7 +85,7 @@ export async function resolveSubmissionStrategy(
     | UnresolvedSubmissionStrategy
     | SubmissionStrategy
     | Promise<UnresolvedSubmissionStrategy | SubmissionStrategy>,
-  registry?: Partial<SubmitterReferenceRegistry>,
+  lookup?: SubmitterLookup,
   expectedChain?: ChainName,
 ): Promise<SubmissionStrategy> {
   const awaitedStrategy = await strategy;
@@ -116,7 +93,7 @@ export async function resolveSubmissionStrategy(
     expectedChain && isUnresolvedSubmitterReference(awaitedStrategy.submitter);
   const submitter = await resolveSubmitterMetadata(
     awaitedStrategy.submitter,
-    registry,
+    lookup,
   );
   assert(
     !shouldAssertChain || submitter.chain === expectedChain,
@@ -142,160 +119,5 @@ export function parseSubmitterReferencePayload(
         `Failed to parse submitter reference payload from ${source}: ${String(error)}`,
       );
     }
-  }
-}
-
-async function loadSubmitterReferenceFromRegistry(
-  registry: Partial<SubmitterReferenceRegistry>,
-  ref: string,
-): Promise<unknown> {
-  for (const childRegistry of getSubmitterRegistryChildren(registry)) {
-    const payload = await loadSubmitterReferenceFromRegistry(
-      childRegistry,
-      ref,
-    );
-    if (payload) {
-      return payload;
-    }
-  }
-
-  assert(
-    registry.getUri || registry.uri,
-    `Submitter reference ${ref} requires a registry with getSubmitter(ref), getUri(itemPath), or uri support`,
-  );
-
-  for (const itemPath of getCandidateItemPaths(ref, registry)) {
-    for (const source of getCandidateSources(itemPath, registry)) {
-      const payload = await loadReferencePayload(source, registry);
-      if (payload) {
-        return parseSubmitterReferencePayload(payload, source);
-      }
-    }
-  }
-
-  return null;
-}
-
-function getCandidateItemPaths(
-  ref: string,
-  registry: Partial<SubmitterReferenceRegistry>,
-): string[] {
-  const strippedRef = stripRegistryRoot(ref, registry);
-  if (!strippedRef && isAbsoluteUrl(ref)) {
-    return [];
-  }
-
-  const relativeRef = strippedRef ?? ref;
-  const normalizedRef = relativeRef.replace(/^\/+/, '');
-  assert(
-    normalizedRef.startsWith(`${SUBMITTER_DIRECTORY}/`),
-    `Submitter reference ${ref} must target a top-level ${SUBMITTER_DIRECTORY}/ entry`,
-  );
-
-  if (hasSupportedExtension(normalizedRef)) {
-    return [normalizedRef];
-  }
-
-  return SUPPORTED_EXTENSIONS.map((suffix) => `${normalizedRef}${suffix}`);
-}
-
-function stripRegistryRoot(
-  ref: string,
-  registry: Partial<SubmitterReferenceRegistry>,
-): string | null {
-  const roots = [registry.uri, safeGetUri(registry)]
-    .filter(
-      (value, index, values): value is string =>
-        !!value && values.indexOf(value) === index,
-    )
-    .sort((a, b) => b.length - a.length);
-
-  for (const root of roots) {
-    if (ref.startsWith(root)) {
-      return ref.slice(root.length).replace(/^\/+/, '');
-    }
-  }
-
-  return null;
-}
-
-function getCandidateSources(
-  itemPath: string,
-  registry: Partial<SubmitterReferenceRegistry>,
-): string[] {
-  const sources = [safeGetUri(registry, itemPath)];
-
-  if (registry.uri && registry.uri !== '__merged_registry__') {
-    sources.push(`${registry.uri.replace(/\/+$/, '')}/${itemPath}`);
-  }
-
-  return sources.filter(
-    (source, index, values): source is string =>
-      !!source && values.indexOf(source) === index,
-  );
-}
-
-function safeGetUri(
-  registry: Partial<SubmitterReferenceRegistry>,
-  itemPath?: string,
-): string | undefined {
-  try {
-    return registry.getUri?.(itemPath);
-  } catch {
-    return undefined;
-  }
-}
-
-async function loadReferencePayload(
-  source: string,
-  registry: Partial<SubmitterReferenceRegistry>,
-): Promise<string | null> {
-  if (!isFetchableUrl(source, registry.allowInsecureHttp)) {
-    return null;
-  }
-
-  let response: Response;
-  try {
-    response = await fetch(source);
-  } catch (error) {
-    throw new Error(
-      `Failed to fetch submitter reference ${source}: ${String(error)}`,
-    );
-  }
-
-  if (response.status === 404) {
-    return null;
-  }
-  assert(
-    response.ok,
-    `Failed to fetch submitter reference ${source}: ${response.status} ${response.statusText}`,
-  );
-  return response.text();
-}
-
-function hasSupportedExtension(value: string): boolean {
-  return SUPPORTED_EXTENSIONS.some((extension) => {
-    return extension.length > 0 && value.endsWith(extension);
-  });
-}
-
-function isFetchableUrl(value: string, allowInsecureHttp = false): boolean {
-  try {
-    const url = new URL(value);
-    return (
-      url.protocol === 'https:' ||
-      (allowInsecureHttp && url.protocol === 'http:')
-    );
-  } catch {
-    return false;
-  }
-}
-
-function isAbsoluteUrl(value: string): boolean {
-  try {
-    new URL(value);
-    return true;
-  } catch {
-    return false;
   }
 }

--- a/typescript/sdk/src/providers/transactions/submitter/types.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/types.ts
@@ -1,13 +1,14 @@
 import { z } from 'zod';
 
 import { EvmSubmitterMetadataSchema } from './ethersV5/types.js';
+import { TxSubmitterType } from './TxSubmitterTypes.js';
 
 export const SubmitterMetadataSchema = EvmSubmitterMetadataSchema;
 export type SubmitterMetadata = z.infer<typeof EvmSubmitterMetadataSchema>;
 
 export const UnresolvedSubmitterReferenceSchema = z
   .object({
-    type: z.literal('submitter_ref'),
+    type: z.literal(TxSubmitterType.SUBMITTER_REF),
     ref: z.string().min(1),
   })
   .strict();

--- a/typescript/sdk/src/providers/transactions/submitter/types.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/types.ts
@@ -4,3 +4,14 @@ import { EvmSubmitterMetadataSchema } from './ethersV5/types.js';
 
 export const SubmitterMetadataSchema = EvmSubmitterMetadataSchema;
 export type SubmitterMetadata = z.infer<typeof EvmSubmitterMetadataSchema>;
+
+export const UnresolvedSubmitterReferenceSchema = z
+  .object({
+    type: z.literal('submitter_ref'),
+    ref: z.string().min(1),
+  })
+  .strict();
+
+export type UnresolvedSubmitterReference = z.infer<
+  typeof UnresolvedSubmitterReferenceSchema
+>;


### PR DESCRIPTION
## Summary
- Add SDK submitter_ref lookup for resolving submitter metadata and submission strategies
- Add HTTP registry submitter routes and tests
- Wire submitter_ref support through CLI submit/warp/signer paths and rebalancer env refs
- Add CLI Ethereum E2E coverage for resolving a submitter ref and submitting a tx
- Refactor after review feedback so SDK only depends on a minimal `SubmitterLookup.getSubmitter(ref)` shape; URI/root/child traversal stays in registry-aware IRegistry extensions in CLI/http-registry-server/rebalancer

## Tests
- pnpm build
- pnpm --filter @hyperlane-xyz/cli build
- pnpm -C typescript/sdk exec mocha --config .mocharc.json ./src/providers/transactions/submitter/reference.test.ts --exit
- CLI_E2E_TEST=submit pnpm -C typescript/cli test:ethereum:e2e
- pnpm -C typescript/sdk check
- pnpm -C typescript/sdk build
- pnpm -C typescript/cli build
- pnpm -C typescript/http-registry-server build
- pnpm -C typescript/rebalancer build
- pnpm -C typescript/sdk exec mocha --config .mocharc.json './src/providers/transactions/submitter/reference.test.ts' --exit
- pnpm -C typescript/cli exec mocha --config .mocharc.json './src/submitters/registry.test.ts' --exit
- pnpm -C typescript/http-registry-server exec mocha --config .mocharc.json './test/services/rootService.test.ts' './test/routes/root.test.ts' --exit
- pnpm -C typescript/rebalancer exec mocha --config .mocharc.json './src/service.test.ts' --exit
- File-scoped oxlint on changed sdk/cli/http-registry-server/rebalancer files (package-wide lint has pre-existing unrelated failures)
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->