### PR TITLE
fix(rebalancer): decimal normalization for mixed-decimal warp routes

### DIFF
--- a/.changeset/rebalancer-decimal-followups.md
+++ b/.changeset/rebalancer-decimal-followups.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Mixed-decimal inventory follow-ups were fixed by failing fast on missing bridged supply, tightening bridge plan coverage, and formatting monitored inventory balances with token-aware decimals.

--- a/typescript/cli/src/tests/ethereum/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-rebalancer.e2e-test.ts
@@ -441,7 +441,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
       };
 
       const getProcessErrorOutput = (error: unknown): string => {
-        const outputs = [observedLines.join('\n')];
+        const outputs: string[] = [];
 
         outputs.push(getErrorLines(error).join('\n'));
 

--- a/typescript/cli/src/tests/ethereum/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-rebalancer.e2e-test.ts
@@ -369,6 +369,8 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     return new Promise((resolve, reject) => {
       let settled = false;
       const observedLines: string[] = [];
+      let stdoutCarry = '';
+      let stderrCarry = '';
 
       const settleSuccess = () => {
         if (settled) return;
@@ -384,15 +386,16 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         reject(error);
       };
 
-      const consumeOutput = (output: string) => {
-        const lines = output.split('\n').filter(Boolean);
-
+      const consumeLines = (lines: string[]) => {
         for (const line of lines) {
           observedLines.push(line);
           if (!expectedLogs.length) break;
           try {
-            const logJson = JSON.parse(line);
-            if (logJson.msg?.includes(expectedLogs[0])) {
+            const logJson = JSON.parse(line) as { msg?: unknown };
+            if (
+              typeof logJson.msg === 'string' &&
+              logJson.msg.includes(expectedLogs[0])
+            ) {
               expectedLogs.shift();
             }
           } catch (_e) {
@@ -407,15 +410,64 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         }
       };
 
-      const getProcessErrorOutput = (error: any): string => {
-        const outputs = [
-          observedLines.join('\n'),
-          typeof error.lines === 'function' ? error.lines().join('\n') : '',
-          typeof error.stdout === 'string' ? error.stdout : '',
-          typeof error.stderr === 'string' ? error.stderr : '',
-          error?.message ?? '',
-          error?.stack ?? '',
-        ];
+      const consumeChunk = (
+        output: string,
+        stream: 'stdout' | 'stderr',
+        flush = false,
+      ) => {
+        const buffered =
+          (stream === 'stdout' ? stdoutCarry : stderrCarry) + output;
+        const parts = buffered.split('\n');
+        const carry = flush ? '' : (parts.pop() ?? '');
+
+        if (stream === 'stdout') {
+          stdoutCarry = carry;
+        } else {
+          stderrCarry = carry;
+        }
+
+        consumeLines(parts.filter(Boolean));
+      };
+
+      const getErrorLines = (error: unknown): string[] => {
+        if (typeof error !== 'object' || error === null) return [];
+        const maybeError = error as { lines?: unknown };
+        if (typeof maybeError.lines !== 'function') return [];
+
+        const lines = maybeError.lines();
+        return Array.isArray(lines)
+          ? lines.filter((line): line is string => typeof line === 'string')
+          : [];
+      };
+
+      const getProcessErrorOutput = (error: unknown): string => {
+        const outputs = [observedLines.join('\n')];
+
+        outputs.push(getErrorLines(error).join('\n'));
+
+        if (typeof error === 'object' && error !== null) {
+          const maybeError = error as {
+            stdout?: unknown;
+            stderr?: unknown;
+            message?: unknown;
+            stack?: unknown;
+          };
+
+          if (typeof maybeError.stdout === 'string') {
+            outputs.push(maybeError.stdout);
+          }
+          if (typeof maybeError.stderr === 'string') {
+            outputs.push(maybeError.stderr);
+          }
+          if (typeof maybeError.message === 'string') {
+            outputs.push(maybeError.message);
+          }
+          if (typeof maybeError.stack === 'string') {
+            outputs.push(maybeError.stack);
+          }
+        } else if (typeof error === 'string') {
+          outputs.push(error);
+        }
 
         return outputs.filter(Boolean).join('\n');
       };
@@ -426,18 +478,17 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
       }, timeout);
 
       // Handle when the process exits due to an error that is not the expected log
-      rebalancer.catch((e) => {
+      rebalancer.catch((e: unknown) => {
+        consumeChunk('', 'stdout', true);
+        consumeChunk('', 'stderr', true);
         const combined = getProcessErrorOutput(e);
-        consumeOutput(combined);
+        consumeLines(combined.split('\n').filter(Boolean));
 
         if (!expectedLogs.length) {
           settleSuccess();
         } else {
-          const lines = typeof e.lines === 'function' ? e.lines() : [];
-          const lastLine =
-            Array.isArray(lines) && lines.length
-              ? lines[lines.length - 1]
-              : String(e);
+          const lines = getErrorLines(e);
+          const lastLine = lines.length ? lines[lines.length - 1] : String(e);
           settleError(
             new Error(
               `Process failed before logging: "${expectedLogs[0]}" with error: ${lastLine}`,
@@ -448,14 +499,16 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
       (async () => {
         for await (let chunk of rebalancer.stdout) {
           chunk = typeof chunk === 'string' ? chunk : chunk.toString();
-          consumeOutput(chunk);
+          consumeChunk(chunk, 'stdout');
         }
+        consumeChunk('', 'stdout', true);
       })().catch(settleError);
       (async () => {
         for await (let chunk of rebalancer.stderr) {
           chunk = typeof chunk === 'string' ? chunk : chunk.toString();
-          consumeOutput(chunk);
+          consumeChunk(chunk, 'stderr');
         }
+        consumeChunk('', 'stderr', true);
       })().catch(settleError);
     }).finally(async () => {
       // Perform a cleanup at the end

--- a/typescript/cli/src/tests/ethereum/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-rebalancer.e2e-test.ts
@@ -367,30 +367,78 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     })();
 
     return new Promise((resolve, reject) => {
+      let settled = false;
+      const observedLines: string[] = [];
+
+      const settleSuccess = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        resolve(void 0);
+      };
+
+      const settleError = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        reject(error);
+      };
+
+      const consumeOutput = (output: string) => {
+        const lines = output.split('\n').filter(Boolean);
+
+        for (const line of lines) {
+          observedLines.push(line);
+          if (!expectedLogs.length) break;
+          try {
+            const logJson = JSON.parse(line);
+            if (logJson.msg?.includes(expectedLogs[0])) {
+              expectedLogs.shift();
+            }
+          } catch (_e) {
+            if (line.includes(expectedLogs[0])) {
+              expectedLogs.shift();
+            }
+          }
+        }
+
+        if (!expectedLogs.length) {
+          settleSuccess();
+        }
+      };
+
+      const getProcessErrorOutput = (error: any): string => {
+        const outputs = [
+          observedLines.join('\n'),
+          typeof error.lines === 'function' ? error.lines().join('\n') : '',
+          typeof error.stdout === 'string' ? error.stdout : '',
+          typeof error.stderr === 'string' ? error.stderr : '',
+          error?.message ?? '',
+          error?.stack ?? '',
+        ];
+
+        return outputs.filter(Boolean).join('\n');
+      };
+
       // Use a timeout to prevent waiting for a log that might never happen and fail faster
       timeoutId = setTimeout(() => {
-        reject(new Error(`Timeout waiting for log: "${expectedLogs[0]}"`));
+        settleError(new Error(`Timeout waiting for log: "${expectedLogs[0]}"`));
       }, timeout);
 
       // Handle when the process exits due to an error that is not the expected log
       rebalancer.catch((e) => {
-        const lines = typeof e.lines === 'function' ? e.lines() : [];
-        const combined = Array.isArray(lines) ? lines.join('\n') : String(e);
+        const combined = getProcessErrorOutput(e);
+        consumeOutput(combined);
 
-        // Consume any expected logs that appear in the error output
-        while (expectedLogs.length && combined.includes(expectedLogs[0])) {
-          expectedLogs.shift();
-        }
-
-        clearTimeout(timeoutId);
         if (!expectedLogs.length) {
-          resolve(void 0);
+          settleSuccess();
         } else {
+          const lines = typeof e.lines === 'function' ? e.lines() : [];
           const lastLine =
             Array.isArray(lines) && lines.length
               ? lines[lines.length - 1]
               : String(e);
-          reject(
+          settleError(
             new Error(
               `Process failed before logging: "${expectedLogs[0]}" with error: ${lastLine}`,
             ),
@@ -398,32 +446,17 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         }
       });
       (async () => {
-        // Wait for the process to output the expected log.
         for await (let chunk of rebalancer.stdout) {
           chunk = typeof chunk === 'string' ? chunk : chunk.toString();
-          const lines = chunk.split('\n').filter(Boolean); // handle empty lines
-
-          for (const line of lines) {
-            if (!expectedLogs.length) break;
-            try {
-              const logJson = JSON.parse(line);
-              if (logJson.msg?.includes(expectedLogs[0])) {
-                expectedLogs.shift();
-              }
-            } catch (_e) {
-              // For non-json logs
-              if (line.includes(expectedLogs[0])) {
-                expectedLogs.shift();
-              }
-            }
-          }
-
-          if (!expectedLogs.length) {
-            resolve(void 0);
-            break;
-          }
+          consumeOutput(chunk);
         }
-      })().catch(reject);
+      })().catch(settleError);
+      (async () => {
+        for await (let chunk of rebalancer.stderr) {
+          chunk = typeof chunk === 'string' ? chunk : chunk.toString();
+          consumeOutput(chunk);
+        }
+      })().catch(settleError);
     }).finally(async () => {
       // Perform a cleanup at the end
       clearTimeout(timeoutId);

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -1526,6 +1526,48 @@ describe('InventoryRebalancer E2E', () => {
       expect(quotedTargetOutput).to.equal(expectedWithBuffer);
     });
 
+    it('plans LiFi target output in destination-local units for mixed-decimal routes', async () => {
+      const canonicalAmount = 1_000_000n;
+      const availableInventory = BigInt(2e18);
+      warpCore.tokens.find((t: any) => t.chainName === SOLANA_CHAIN)!.scale = {
+        numerator: 1n,
+        denominator: 1_000_000_000_000n,
+      };
+
+      const route = createTestRoute({ amount: canonicalAmount });
+      createTestIntent({ amount: canonicalAmount });
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: 0n,
+        [ARBITRUM_CHAIN]: availableInventory,
+      });
+
+      let quotedTargetOutput: bigint | undefined;
+      bridge.quote.callsFake(async (params: any) => {
+        if (params.toAmount !== undefined) {
+          quotedTargetOutput = params.toAmount;
+        }
+        return createMockBridgeQuote({
+          fromAmount: params.fromAmount ?? params.toAmount,
+          toAmount: params.toAmount ?? params.fromAmount,
+          toAmountMin: params.toAmount ?? params.fromAmount,
+          requestParams:
+            params.toAmount !== undefined
+              ? { ...params, toAmount: params.toAmount }
+              : { ...params, fromAmount: params.fromAmount },
+        });
+      });
+      bridge.execute.resolves({
+        txHash: '0xBridgeTxHash',
+        fromChain: 42161,
+        toChain: 1399811149,
+      });
+
+      await inventoryRebalancer.rebalance([route]);
+
+      expect(quotedTargetOutput).to.equal(1_050_000_000_000_000_000n);
+    });
+
     it('continues when some bridges fail', async () => {
       const amount = BigInt(1e18);
       const perChainInventory = BigInt(0.6e18);

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -396,6 +396,33 @@ describe('InventoryRebalancer E2E', () => {
       const actionParams = actionTracker.createRebalanceAction.lastCall.args[0];
       expect(actionParams.txHash).to.equal('0xSolanaTxHash');
     });
+
+    it('denormalizes inventory execution amounts but records canonical deposit amount', async () => {
+      const route = createTestRoute({ amount: 1_000_000n });
+      createTestIntent({ amount: 1_000_000n });
+      warpCore.tokens.find((t: any) => t.chainName === SOLANA_CHAIN)!.scale = {
+        numerator: 1n,
+        denominator: 1_000_000_000_000n,
+      };
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: 1_000_000_000_000_000_000n,
+        [ARBITRUM_CHAIN]: 0n,
+      });
+
+      const results = await inventoryRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.true;
+
+      const txParams = warpCore.getTransferRemoteTxs.firstCall.args[0];
+      expect(txParams.originTokenAmount.amount).to.equal(
+        1_000_000_000_000_000_000n,
+      );
+
+      const actionParams = actionTracker.createRebalanceAction.lastCall.args[0];
+      expect(actionParams.amount).to.equal(1_000_000n);
+    });
   });
 
   describe('Partial Fulfillment (Insufficient Inventory)', () => {

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -1851,6 +1851,64 @@ describe('InventoryRebalancer E2E', () => {
       expect(quotedTargetOutput).to.equal(1_050_000_000_000_000_000n);
     });
 
+    it('fails bridge execution when reverse quote exceeds planned source capacity', async () => {
+      const amount = BigInt(1e18);
+      const sourceInventory = BigInt(2e18);
+      const targetWithBuffer = (amount * 105n) / 100n;
+
+      const route = createTestRoute({ amount });
+      createTestIntent({ amount });
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: 0n,
+        [ARBITRUM_CHAIN]: sourceInventory,
+      });
+
+      bridge.quote
+        .onFirstCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: sourceInventory,
+            toAmount: sourceInventory,
+            toAmountMin: sourceInventory,
+            requestParams: {
+              fromChain: 42161,
+              toChain: 1399811149,
+              fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              toAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              fromAmount: sourceInventory,
+            },
+          }),
+        )
+        .onSecondCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: sourceInventory + 1n,
+            toAmount: targetWithBuffer,
+            toAmountMin: targetWithBuffer,
+            requestParams: {
+              fromChain: 42161,
+              toChain: 1399811149,
+              fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              toAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              toAmount: targetWithBuffer,
+            },
+          }),
+        );
+
+      const results = await inventoryRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.false;
+      expect(results[0].error).to.include('All inventory movements failed');
+      expect(results[0].error).to.include('exceeded planned source capacity');
+      expect(bridge.execute.called).to.be.false;
+    });
+
     it('continues when some bridges fail', async () => {
       const amount = BigInt(1e18);
       const perChainInventory = BigInt(0.6e18);

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -1762,6 +1762,53 @@ describe('InventoryRebalancer E2E', () => {
       expect(quotedTargetOutput).to.equal(expectedWithBuffer);
     });
 
+    it('bridges only the mixed-decimal shortfall after dust partial skip', async () => {
+      const canonicalAmount = 1n;
+      const destinationDust = 1_000_000_000_000n - 1n;
+      const sourceInventory = 1_000_000_000_000n;
+      warpCore.tokens.find((t: any) => t.chainName === SOLANA_CHAIN)!.scale = {
+        numerator: 1n,
+        denominator: 1_000_000_000_000n,
+      };
+
+      const route = createTestRoute({ amount: canonicalAmount });
+      createTestIntent({ amount: canonicalAmount });
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: destinationDust,
+        [ARBITRUM_CHAIN]: sourceInventory,
+      });
+
+      let reverseQuoteTargetOutput: bigint | undefined;
+      bridge.quote.callsFake(async (params: any) => {
+        if (params.toAmount !== undefined) {
+          reverseQuoteTargetOutput = params.toAmount;
+        }
+        return createMockBridgeQuote({
+          fromAmount: params.fromAmount ?? params.toAmount,
+          toAmount: params.toAmount ?? params.fromAmount,
+          toAmountMin: params.toAmount ?? params.fromAmount,
+          requestParams:
+            params.toAmount !== undefined
+              ? { ...params, toAmount: params.toAmount }
+              : { ...params, fromAmount: params.fromAmount },
+        });
+      });
+      bridge.execute.resolves({
+        txHash: '0xBridgeTxHash',
+        fromChain: 42161,
+        toChain: 1399811149,
+      });
+
+      const results = await inventoryRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.true;
+      expect(warpCore.getTransferRemoteTxs.called).to.be.false;
+      expect(bridge.execute.calledOnce).to.be.true;
+      expect(reverseQuoteTargetOutput).to.equal(1n);
+    });
+
     it('plans LiFi target output in destination-local units for mixed-decimal routes', async () => {
       const canonicalAmount = 1_000_000n;
       const availableInventory = BigInt(2e18);

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -1498,14 +1498,19 @@ describe('InventoryRebalancer E2E', () => {
         [ARBITRUM_CHAIN]: availableInventory,
       });
 
-      // Capture the quote amount from executeInventoryMovement
-      // (calculateMaxViableBridgeAmount doesn't quote for ERC20 tokens)
-      let quotedFromAmount: bigint | undefined;
+      let quotedTargetOutput: bigint | undefined;
       bridge.quote.callsFake(async (params: any) => {
-        quotedFromAmount = params.fromAmount;
+        if (params.toAmount !== undefined) {
+          quotedTargetOutput = params.toAmount;
+        }
         return createMockBridgeQuote({
           fromAmount: params.fromAmount ?? params.toAmount,
-          toAmount: params.fromAmount ?? params.toAmount,
+          toAmount: params.toAmount ?? params.fromAmount,
+          toAmountMin: params.toAmount ?? params.fromAmount,
+          requestParams:
+            params.toAmount !== undefined
+              ? { ...params, toAmount: params.toAmount }
+              : { ...params, fromAmount: params.fromAmount },
         });
       });
       bridge.execute.resolves({
@@ -1517,10 +1522,8 @@ describe('InventoryRebalancer E2E', () => {
       await inventoryRebalancer.rebalance([route]);
 
       // Verify: 5% buffer applied (1 ETH * 1.05 = 1.05 ETH)
-      // The bridge plan uses pre-validated amounts (for ERC20, full inventory available)
-      // But the target is (amount * 105%), so if source has >= target, we bridge exactly target
       const expectedWithBuffer = (amount * 105n) / 100n;
-      expect(quotedFromAmount).to.equal(expectedWithBuffer);
+      expect(quotedTargetOutput).to.equal(expectedWithBuffer);
     });
 
     it('continues when some bridges fail', async () => {
@@ -1748,14 +1751,36 @@ describe('InventoryRebalancer E2E', () => {
       });
 
       // Quote with high gas costs (but for ERC20, this shouldn't trigger viability check)
-      bridge.quote.resolves(
-        createMockBridgeQuote({
-          fromAmount: BigInt(1.05e18),
-          toAmount: BigInt(1e18),
-          gasCosts: BigInt(1e18), // Very high gas (would fail viability if this were native)
-          feeCosts: 0n,
-        }),
-      );
+      bridge.quote
+        .onFirstCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: tokenBalance,
+            toAmount: tokenBalance,
+            toAmountMin: tokenBalance,
+            gasCosts: BigInt(1e18), // Very high gas (would fail viability if this were native)
+            feeCosts: 0n,
+          }),
+        )
+        .onSecondCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: tokenBalance,
+            toAmount: tokenBalance,
+            toAmountMin: tokenBalance,
+            gasCosts: BigInt(1e18),
+            feeCosts: 0n,
+            requestParams: {
+              fromChain: 42161,
+              toChain: 1399811149,
+              fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              toAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              toAmount: tokenBalance,
+            },
+          }),
+        );
 
       bridge.execute.resolves({
         txHash: '0xERC20BridgeTxHash',
@@ -1769,6 +1794,7 @@ describe('InventoryRebalancer E2E', () => {
       expect(results).to.have.lengthOf(1);
       expect(results[0].success).to.be.true;
       expect(bridge.execute.calledOnce).to.be.true;
+      expect(bridge.quote.getCall(1)?.args[0].toAmount).to.equal(tokenBalance);
     });
 
     it('calculates max viable amount as inventory minus (gasCosts * 20) for native tokens', async () => {
@@ -1804,14 +1830,47 @@ describe('InventoryRebalancer E2E', () => {
       // maxViable = 1 ETH - 0.02 ETH = 0.98 ETH
       // 10% threshold = 0.1 ETH, estimatedGas (0.02) < threshold → viable
       const gasCosts = BigInt(0.001e18); // 0.001 ETH
-      bridge.quote.resolves(
-        createMockBridgeQuote({
-          fromAmount: rawBalance,
-          toAmount: rawBalance - BigInt(1e15),
-          gasCosts,
-          feeCosts: 0n,
-        }),
-      );
+      const maxViable = rawBalance - gasCosts * 20n;
+      bridge.quote
+        .onFirstCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: rawBalance,
+            toAmount: rawBalance - BigInt(1e15),
+            toAmountMin: rawBalance - BigInt(1e15),
+            gasCosts,
+            feeCosts: 0n,
+          }),
+        )
+        .onSecondCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: maxViable,
+            toAmount: maxViable - BigInt(1e15),
+            toAmountMin: maxViable - BigInt(1e15),
+            gasCosts,
+            feeCosts: 0n,
+          }),
+        )
+        .onThirdCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: BigInt(0.525e18),
+            toAmount: BigInt(0.525e18),
+            toAmountMin: BigInt(0.525e18),
+            gasCosts,
+            feeCosts: 0n,
+            requestParams: {
+              fromChain: 42161,
+              toChain: 1399811149,
+              fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              toAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              toAmount: BigInt(0.525e18),
+            },
+          }),
+        );
 
       bridge.execute.resolves({
         txHash: '0xSuccessBridgeTxHash',
@@ -1826,18 +1885,14 @@ describe('InventoryRebalancer E2E', () => {
       expect(results[0].success).to.be.true;
       expect(bridge.execute.calledOnce).to.be.true;
 
-      // Verify: The quoted fromAmount should be the target (since maxViable > target)
-      // For the execution quote (second quote call):
-      // targetWithBuffer = (0.5 ETH) * 1.05 = 0.525 ETH (for non-inventory execution, costs are 0)
-      const executionQuoteCall = bridge.quote
-        .getCalls()
-        .find(
-          (call: any) =>
-            call.args[0].fromAmount !== undefined &&
-            call.args[0].fromAmount !== rawBalance,
-        );
-      // Since maxViable (0.98 ETH) > targetWithBuffer (0.525 ETH), we bridge exactly targetWithBuffer
-      expect(executionQuoteCall).to.exist;
+      expect(bridge.quote.getCall(1)?.args[0].fromAmount).to.equal(maxViable);
+      const executionTargetOutput = bridge.quote.getCall(2)?.args[0].toAmount;
+      expect(executionTargetOutput).to.be.a('bigint');
+      if (executionTargetOutput === undefined) {
+        throw new Error('Expected reverse quote to set toAmount');
+      }
+      expect(executionTargetOutput > amount).to.be.true;
+      expect(executionTargetOutput <= maxViable).to.be.true;
     });
 
     it('handles quote failures gracefully by skipping the source chain', async () => {

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -1485,8 +1485,9 @@ describe('InventoryRebalancer E2E', () => {
     });
 
     it('does not inflate each split bridge plan to minViableTransfer', async () => {
-      const amount = 10_000_000_000_000_000n;
+      const amount = 7_000_000_000_000_000n;
       const perChainInventory = 6_000_000_000_000_000n;
+      const reservedGas = 1_000_000_000n;
 
       for (const token of warpCore.tokens) {
         if (
@@ -1529,6 +1530,25 @@ describe('InventoryRebalancer E2E', () => {
       expect(results).to.have.lengthOf(1);
       expect(results[0].success).to.be.true;
       expect(bridge.execute.callCount).to.equal(2);
+
+      const reverseQuoteRequests = bridge.quote
+        .getCalls()
+        .map((call) => call.args[0])
+        .filter((params) => params.toAmount !== undefined);
+      expect(reverseQuoteRequests).to.have.lengthOf(2);
+
+      const requestedOutputs = reverseQuoteRequests
+        .map((params) => params.toAmount as bigint)
+        .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+      const maxPerSourceOutput = perChainInventory - reservedGas;
+      const totalAvailableCapacity = maxPerSourceOutput * 2n;
+
+      expect(requestedOutputs.every((output) => output <= maxPerSourceOutput))
+        .to.be.true;
+      expect(requestedOutputs[0] < maxPerSourceOutput).to.be.true;
+      expect(requestedOutputs[1]).to.equal(maxPerSourceOutput);
+      expect(requestedOutputs[0] + requestedOutputs[1] < totalAvailableCapacity)
+        .to.be.true;
     });
 
     it('applies 5% buffer to total bridge amount', async () => {

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -1484,6 +1484,53 @@ describe('InventoryRebalancer E2E', () => {
       expect(bridge.execute.callCount).to.equal(2);
     });
 
+    it('does not inflate each split bridge plan to minViableTransfer', async () => {
+      const amount = 10_000_000_000_000_000n;
+      const perChainInventory = 6_000_000_000_000_000n;
+
+      for (const token of warpCore.tokens) {
+        if (
+          token.chainName === ARBITRUM_CHAIN ||
+          token.chainName === SOLANA_CHAIN ||
+          token.chainName === BASE_CHAIN
+        ) {
+          token.standard = TokenStandard.EvmHypNative;
+        }
+      }
+
+      const route = createTestRoute({ amount });
+      createTestIntent({ amount });
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: 0n,
+        [ARBITRUM_CHAIN]: perChainInventory,
+        [BASE_CHAIN]: perChainInventory,
+      });
+
+      bridge.quote.callsFake(async (params: any) =>
+        createMockBridgeQuote({
+          fromAmount: params.fromAmount ?? params.toAmount,
+          toAmount: params.toAmount ?? params.fromAmount,
+          toAmountMin: params.toAmount ?? params.fromAmount,
+          requestParams:
+            params.toAmount !== undefined
+              ? { ...params, toAmount: params.toAmount }
+              : { ...params, fromAmount: params.fromAmount },
+        }),
+      );
+      bridge.execute.resolves({
+        txHash: '0xBridgeTxHash',
+        fromChain: 42161,
+        toChain: 1399811149,
+      });
+
+      const results = await inventoryRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.true;
+      expect(bridge.execute.callCount).to.equal(2);
+    });
+
     it('applies 5% buffer to total bridge amount', async () => {
       // Need 1 ETH -> should plan to bridge 1.05 ETH total (with 5% buffer)
       const amount = BigInt(1e18); // 1 ETH

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -154,6 +154,9 @@ describe('InventoryRebalancer E2E', () => {
         }),
       },
       findToken: Sinon.stub().returns(null),
+      getMaxTransferAmount: Sinon.stub().callsFake(
+        async ({ balance }) => balance,
+      ),
       getTransferRemoteTxs: Sinon.stub().resolves([
         {
           category: 'transfer',
@@ -275,6 +278,21 @@ describe('InventoryRebalancer E2E', () => {
     actionTracker.createRebalanceIntent.resolves(intent);
 
     return intent;
+  }
+
+  function mockSuccessfulBridge(fromAmount: bigint, toAmount: bigint): void {
+    bridge.quote.resolves(
+      createMockBridgeQuote({
+        fromAmount,
+        toAmount,
+        toAmountMin: toAmount,
+      }),
+    );
+    bridge.execute.resolves({
+      txHash: '0xBridgeTxHash',
+      fromChain: 42161,
+      toChain: 1399811149,
+    });
   }
 
   describe('Basic Inventory Rebalance (Sufficient Inventory)', () => {
@@ -426,8 +444,9 @@ describe('InventoryRebalancer E2E', () => {
   });
 
   describe('Partial Fulfillment (Insufficient Inventory)', () => {
-    // Partial transfers happen when maxTransferable >= minViableTransfer
-    // For non-native tokens (EvmHypCollateral), minViableTransfer = 0, so partial always viable
+    // Partial transfers happen when maxTransferable >= minViableTransfer.
+    // For non-native tokens (EvmHypCollateral), minViableTransfer = 0, so any
+    // positive fee-aware maxTransferable remains viable.
     const PARTIAL_AMOUNT = BigInt(5e15); // 0.005 ETH - above threshold
     const FULL_AMOUNT = BigInt(1e16); // 0.01 ETH
 
@@ -460,6 +479,65 @@ describe('InventoryRebalancer E2E', () => {
       expect(actionParams.amount).to.equal(PARTIAL_AMOUNT);
     });
 
+    it('uses fee-aware maxTransferable for non-native token fees', async () => {
+      const requestedAmount = 19998000000n;
+      const availableInventory = 102466n;
+      const safeTransferAmount = 102400n;
+
+      warpCore.getMaxTransferAmount.resolves({ amount: safeTransferAmount });
+
+      const route = createTestRoute({ amount: requestedAmount });
+      createTestIntent({ amount: requestedAmount });
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: availableInventory,
+        [ARBITRUM_CHAIN]: 0n,
+      });
+
+      const results = await inventoryRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.true;
+      expect(warpCore.getMaxTransferAmount.calledOnce).to.be.true;
+
+      const maxTransferArgs = warpCore.getMaxTransferAmount.firstCall.args[0];
+      expect(maxTransferArgs.balance.amount).to.equal(availableInventory);
+      expect(maxTransferArgs.destination).to.equal(ARBITRUM_CHAIN);
+
+      const txParams = warpCore.getTransferRemoteTxs.lastCall.args[0];
+      expect(txParams.originTokenAmount.amount).to.equal(safeTransferAmount);
+      expect(txParams).to.not.have.property('interchainFee');
+      expect(txParams).to.not.have.property('tokenFeeQuote');
+
+      const actionParams = actionTracker.createRebalanceAction.lastCall.args[0];
+      expect(actionParams.amount).to.equal(safeTransferAmount);
+    });
+
+    it('downgrades full non-native transfers to partial when fee headroom is missing', async () => {
+      const requestedAmount = 102466n;
+      const safeTransferAmount = 102400n;
+
+      warpCore.getMaxTransferAmount.resolves({ amount: safeTransferAmount });
+
+      const route = createTestRoute({ amount: requestedAmount });
+      createTestIntent({ amount: requestedAmount });
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: requestedAmount,
+        [ARBITRUM_CHAIN]: 0n,
+      });
+
+      const results = await inventoryRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.true;
+      expect(bridge.execute.called).to.be.false;
+
+      const txParams = warpCore.getTransferRemoteTxs.lastCall.args[0];
+      expect(txParams.originTokenAmount.amount).to.equal(safeTransferAmount);
+      expect(txParams.originTokenAmount.amount).to.not.equal(requestedAmount);
+    });
+
     it('intent remains in_progress after partial fulfillment', async () => {
       const route = createTestRoute({ amount: FULL_AMOUNT });
       createTestIntent({ amount: FULL_AMOUNT });
@@ -474,6 +552,52 @@ describe('InventoryRebalancer E2E', () => {
 
       // Verify: Partial transfer succeeded
       expect(results[0].success).to.be.true;
+    });
+  });
+
+  describe('Fee-Aware Probe Fallback', () => {
+    it('bridges when non-native destination inventory is zero', async () => {
+      const requestedAmount = 10000000000n;
+      const bufferedBridgeAmount = (requestedAmount * 105n) / 100n;
+      const route = createTestRoute({ amount: requestedAmount });
+      createTestIntent({ amount: requestedAmount });
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: 0n,
+        [ARBITRUM_CHAIN]: 20000000000n,
+      });
+      mockSuccessfulBridge(bufferedBridgeAmount, bufferedBridgeAmount);
+
+      const results = await inventoryRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.true;
+      expect(warpCore.getMaxTransferAmount.called).to.be.false;
+      expect(warpCore.getTransferRemoteTxs.called).to.be.false;
+      expect(bridge.execute.calledOnce).to.be.true;
+
+      const actionParams =
+        actionTracker.createRebalanceAction.firstCall.args[0];
+      expect(actionParams.type).to.equal('inventory_movement');
+    });
+
+    it('returns failure for unrelated fee-aware probe errors', async () => {
+      const route = createTestRoute();
+      createTestIntent();
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: 1n,
+        [ARBITRUM_CHAIN]: 20000000000n,
+      });
+      warpCore.getMaxTransferAmount.rejects(new Error('RPC down'));
+
+      const results = await inventoryRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.false;
+      expect(results[0].error).to.include('RPC down');
+      expect(bridge.execute.called).to.be.false;
+      expect(actionTracker.createRebalanceAction.called).to.be.false;
     });
   });
 
@@ -652,6 +776,51 @@ describe('InventoryRebalancer E2E', () => {
 
       // Verify: No new intent was created (existing was continued)
       expect(actionTracker.createRebalanceIntent.called).to.be.false;
+    });
+
+    it('continues existing intent by bridging after recoverable fee-aware probe failure', async () => {
+      const existingIntent = createTestIntent({
+        id: 'existing-intent',
+        status: 'in_progress',
+        amount: 10000000000n,
+        externalBridge: ExternalBridgeType.LiFi,
+      });
+      const recoverableProbeError = new Error('Fee probe failed') as Error & {
+        cause?: unknown;
+      };
+      recoverableProbeError.cause = {
+        code: 'UNPREDICTABLE_GAS_LIMIT',
+        message: 'execution reverted: ERC20: transfer amount exceeds balance',
+      };
+
+      actionTracker.getPartiallyFulfilledInventoryIntents.resolves([
+        {
+          intent: existingIntent,
+          completedAmount: 0n,
+          remaining: 10000000000n,
+          hasInflightDeposit: false,
+        },
+      ]);
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: 1n,
+        [ARBITRUM_CHAIN]: 20000000000n,
+      });
+      warpCore.getMaxTransferAmount.rejects(recoverableProbeError);
+      mockSuccessfulBridge(10500000000n, 10500000000n);
+
+      const results = await inventoryRebalancer.rebalance([
+        createTestRoute({ amount: 5000000000n }),
+      ]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.true;
+      expect(bridge.execute.calledOnce).to.be.true;
+      expect(actionTracker.createRebalanceIntent.called).to.be.false;
+
+      const actionParams =
+        actionTracker.createRebalanceAction.firstCall.args[0];
+      expect(actionParams.type).to.equal('inventory_movement');
     });
   });
 

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -4,7 +4,6 @@ import {
   type ChainName,
   HyperlaneCore,
   type InterchainGasQuote,
-  type IToken,
   type MultiProtocolSignerSignerAccountInfo,
   type MultiProvider,
   Token,
@@ -969,22 +968,16 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         ? Token.FromChainMetadataNativeToken(originChainMetadata)
         : this.warpCore.findToken(origin, igpAddressOrDenom);
     assert(igpToken, `IGP fee token ${igpAddressOrDenom} is unknown`);
-    const interchainFee = new TokenAmount<IToken>(
-      gasQuote.igpQuote.amount,
-      igpToken,
-    );
+    const interchainFee = new TokenAmount(gasQuote.igpQuote.amount, igpToken);
 
-    let tokenFeeQuote: TokenAmount<IToken> | undefined;
+    let tokenFeeQuote: TokenAmount | undefined;
     if (gasQuote.tokenFeeQuote?.amount) {
       const feeAddress = gasQuote.tokenFeeQuote.addressOrDenom;
       const feeToken =
         !feeAddress || isZeroishAddress(feeAddress)
           ? Token.FromChainMetadataNativeToken(originChainMetadata)
           : originToken;
-      tokenFeeQuote = new TokenAmount<IToken>(
-        gasQuote.tokenFeeQuote.amount,
-        feeToken,
-      );
+      tokenFeeQuote = new TokenAmount(gasQuote.tokenFeeQuote.amount, feeToken);
     }
 
     const originTokenAmount = originToken.amount(amount);

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -4,6 +4,7 @@ import {
   type ChainName,
   HyperlaneCore,
   type InterchainGasQuote,
+  type IToken,
   type MultiProtocolSignerSignerAccountInfo,
   type MultiProvider,
   Token,
@@ -968,16 +969,22 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         ? Token.FromChainMetadataNativeToken(originChainMetadata)
         : this.warpCore.findToken(origin, igpAddressOrDenom);
     assert(igpToken, `IGP fee token ${igpAddressOrDenom} is unknown`);
-    const interchainFee = new TokenAmount(gasQuote.igpQuote.amount, igpToken);
+    const interchainFee = new TokenAmount(
+      gasQuote.igpQuote.amount,
+      igpToken,
+    ) as TokenAmount & { token: IToken };
 
-    let tokenFeeQuote: TokenAmount | undefined;
+    let tokenFeeQuote: (TokenAmount & { token: IToken }) | undefined;
     if (gasQuote.tokenFeeQuote?.amount) {
       const feeAddress = gasQuote.tokenFeeQuote.addressOrDenom;
       const feeToken =
         !feeAddress || isZeroishAddress(feeAddress)
           ? Token.FromChainMetadataNativeToken(originChainMetadata)
           : originToken;
-      tokenFeeQuote = new TokenAmount(gasQuote.tokenFeeQuote.amount, feeToken);
+      tokenFeeQuote = new TokenAmount(
+        gasQuote.tokenFeeQuote.amount,
+        feeToken,
+      ) as TokenAmount & { token: IToken };
     }
 
     const originTokenAmount = originToken.amount(amount);

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -11,6 +11,7 @@ import {
   ProviderType,
   SealevelCoreAdapter,
   TOKEN_COLLATERALIZED_STANDARDS,
+  type TokenAmount,
   type WarpTypedTransaction,
   type WarpCore,
   WarpTxCategory,
@@ -971,9 +972,11 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       assert(searchResult, `IGP fee token ${igpAddressOrDenom} is unknown`);
       igpToken = searchResult;
     }
-    const interchainFee = igpToken.amount(gasQuote.igpQuote.amount);
+    const interchainFee: TokenAmount<IToken> = igpToken.amount(
+      gasQuote.igpQuote.amount,
+    );
 
-    let tokenFeeQuote: ReturnType<IToken['amount']> | undefined;
+    let tokenFeeQuote: TokenAmount<IToken> | undefined;
     if (gasQuote.tokenFeeQuote?.amount) {
       const feeAddress = gasQuote.tokenFeeQuote.addressOrDenom;
       const feeToken: IToken =

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -1388,55 +1388,6 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       'Resolved token addresses for LiFi bridge',
     );
 
-    // Calculate minViableTransfer for the target chain
-    // If bridging less than this, the received amount won't be enough to execute transferRemote
-    // So we over-bridge to ensure we can complete the intent in the next cycle
-    const costs = await calculateTransferCosts(
-      targetChain, // FROM chain for transferRemote (the target of this bridge)
-      sourceChain, // TO chain for transferRemote (Hyperlane message destination)
-      targetOutputAmount, // availableInventory (not used for minViableTransfer calculation)
-      targetOutputAmount, // requestedAmount
-      this.multiProvider,
-      this.warpCore.multiProvider,
-      this.getTokenForChain.bind(this),
-      this.getInventorySignerAddress(targetChain),
-      isNativeTokenStandard,
-      this.logger,
-    );
-    const { minViableTransfer } = costs;
-
-    // If the requested amount is below minViableTransfer, adjust it up
-    // This ensures we bridge enough to actually complete the final transferRemote
-    const effectiveTargetOutput =
-      targetOutputAmount < minViableTransfer
-        ? minViableTransfer
-        : targetOutputAmount;
-
-    if (effectiveTargetOutput !== targetOutputAmount) {
-      this.logger.info(
-        {
-          originalAmount: targetOutputAmount.toString(),
-          effectiveAmount: effectiveTargetOutput.toString(),
-          minViableTransfer: minViableTransfer.toString(),
-          originalAmountFormatted: this.formatLocalAmount(
-            targetOutputAmount,
-            targetToken,
-          ),
-          effectiveAmountFormatted: this.formatLocalAmount(
-            effectiveTargetOutput,
-            targetToken,
-          ),
-          minViableTransferFormatted: this.formatLocalAmount(
-            minViableTransfer,
-            targetToken,
-          ),
-          adjustedUp: true,
-          intentId: intent.id,
-        },
-        'Over-bridging to minViableTransfer to ensure final transferRemote can complete',
-      );
-    }
-
     try {
       const externalBridge = this.getExternalBridge(externalBridgeType);
       const quote = await externalBridge.quote({
@@ -1444,7 +1395,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         toChain: targetChainId,
         fromToken: fromTokenAddress,
         toToken: toTokenAddress,
-        toAmount: effectiveTargetOutput,
+        toAmount: targetOutputAmount,
         fromAddress: this.getInventorySignerAddress(sourceChain),
         toAddress: this.getInventorySignerAddress(targetChain),
       });
@@ -1468,11 +1419,6 @@ export class InventoryRebalancer implements IInventoryRebalancer {
             targetOutputAmount,
             targetToken,
           ),
-          effectiveTargetOutput: effectiveTargetOutput.toString(),
-          effectiveTargetOutputFormatted: this.formatLocalAmount(
-            effectiveTargetOutput,
-            targetToken,
-          ),
           inputRequired: inputRequired.toString(),
           inputRequiredFormatted: this.formatLocalAmount(
             inputRequired,
@@ -1487,7 +1433,6 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           gasCosts: quote.gasCosts.toString(),
           feeCosts: quote.feeCosts.toString(),
           intentId: intent.id,
-          adjustedForMinViable: effectiveTargetOutput > targetOutputAmount,
         },
         'Executing inventory movement via LiFi reverse quote',
       );

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -52,6 +52,7 @@ import {
 import { parseSolanaPrivateKey } from '../utils/solanaKeyParser.js';
 import { toProtocolTransaction } from '../utils/transactionUtils.js';
 import {
+  alignLocalToCanonical,
   denormalizeToLocal,
   normalizeToCanonical,
 } from '../utils/balanceUtils.js';
@@ -75,6 +76,11 @@ const GAS_COST_MULTIPLIER = 20n;
  * If gas exceeds this threshold, the bridge is not economically worthwhile.
  */
 const MAX_GAS_PERCENT_THRESHOLD = 10n;
+
+type BridgeCapacity = {
+  maxSourceInput: bigint;
+  maxTargetOutput: bigint;
+};
 
 /**
  * Configuration for the InventoryRebalancer.
@@ -545,7 +551,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
 
     const sourceToken = this.getTokenForChain(destination);
     assert(sourceToken, `No token found for source chain: ${destination}`);
-    const localAmount = denormalizeToLocal(amount, sourceToken);
+    const requestedLocalAmount = denormalizeToLocal(amount, sourceToken);
 
     // Check available inventory on the DESTINATION (deficit) chain
     // We need inventory here because transferRemote is called FROM this chain
@@ -556,8 +562,8 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         checkingChain: destination,
         availableInventory: availableInventory.toString(),
         availableInventoryEth: (Number(availableInventory) / 1e18).toFixed(6),
-        requiredAmount: localAmount.toString(),
-        requiredAmountEth: (Number(localAmount) / 1e18).toFixed(6),
+        requiredAmount: requestedLocalAmount.toString(),
+        requiredAmountEth: (Number(requestedLocalAmount) / 1e18).toFixed(6),
       },
       'Checking effective inventory on destination (deficit) chain',
     );
@@ -568,7 +574,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       destination, // FROM chain (where transferRemote is called)
       origin, // TO chain (where Hyperlane message goes)
       availableInventory,
-      localAmount,
+      requestedLocalAmount,
       this.multiProvider,
       this.warpCore.multiProvider,
       this.getTokenForChain.bind(this),
@@ -587,11 +593,11 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         fromChain: destination,
         toChain: origin,
         availableInventoryEth: (Number(availableInventory) / 1e18).toFixed(6),
-        requestedAmountEth: (Number(localAmount) / 1e18).toFixed(6),
+        requestedAmountEth: (Number(requestedLocalAmount) / 1e18).toFixed(6),
         maxTransferableEth: (Number(maxTransferable) / 1e18).toFixed(6),
         minViableTransferEth: (Number(minViableTransfer) / 1e18).toFixed(6),
         totalInventoryEth: (Number(totalInventory) / 1e18).toFixed(6),
-        canFullyFulfill: maxTransferable >= localAmount,
+        canFullyFulfill: maxTransferable >= requestedLocalAmount,
         canPartialFulfill: maxTransferable >= minViableTransfer,
       },
       'Calculated max transferable amount with cost-based threshold',
@@ -599,11 +605,11 @@ export class InventoryRebalancer implements IInventoryRebalancer {
 
     // Early exit: If remaining amount is below minViableTransfer, complete the intent
     // This prevents infinite loops when the remaining amount is too small to economically bridge
-    if (localAmount < minViableTransfer) {
+    if (requestedLocalAmount < minViableTransfer) {
       this.logger.info(
         {
           intentId: intent.id,
-          amount: localAmount.toString(),
+          amount: requestedLocalAmount.toString(),
           minViableTransfer: minViableTransfer.toString(),
         },
         'Remaining amount below minViableTransfer, completing intent with acceptable loss',
@@ -624,13 +630,13 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       ...route,
       origin: destination, // transferRemote called FROM here
       destination: origin, // Hyperlane message goes TO here
-      amount: localAmount,
+      amount: requestedLocalAmount,
     };
 
-    if (maxTransferable >= localAmount) {
+    if (maxTransferable >= requestedLocalAmount) {
       // Sufficient inventory on destination - execute transferRemote directly
       const fulfilledCanonicalAmount = normalizeToCanonical(
-        localAmount,
+        requestedLocalAmount,
         sourceToken,
       );
       const result = await this.executeTransferRemote(
@@ -643,221 +649,250 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       return { ...result, route };
     } else if (maxTransferable > 0n && maxTransferable >= minViableTransfer) {
       // Partial transfer: Transfer available inventory when economically viable
-      const partialSwappedRoute: InventoryRoute = {
-        ...swappedRoute,
-        amount: maxTransferable,
-      };
-      const fulfilledCanonicalAmount = normalizeToCanonical(
+      const alignedExecution = alignLocalToCanonical(
         maxTransferable,
         sourceToken,
       );
-      const result = await this.executeTransferRemote(
-        partialSwappedRoute,
-        intent,
-        costs.gasQuote!,
-        fulfilledCanonicalAmount,
-      );
-
-      this.logger.info(
-        {
-          intentId: intent.id,
-          partialAmount: maxTransferable.toString(),
-          requestedAmount: localAmount.toString(),
-          remainingAmount: (localAmount - maxTransferable).toString(),
-        },
-        'Executed partial inventory deposit, remaining will be handled in future cycles',
-      );
-
-      // Return original strategy route in result (not the swapped execution route)
-      return { ...result, route };
-    } else {
-      // Inventory below cost-based threshold - trigger ExternalBridge movement TO destination chain
-      this.logger.info(
-        {
-          targetChain: destination,
-          maxTransferable: maxTransferable.toString(),
-          minViableTransfer: minViableTransfer.toString(),
-          costMultiplier: MIN_VIABLE_COST_MULTIPLIER.toString(),
-          intentId: intent.id,
-        },
-        'Inventory below cost-based threshold on destination, triggering LiFi movement',
-      );
-
-      // Get all available source chains with raw inventory
-      const allSources = this.selectAllSourceChains(destination);
-
-      if (allSources.length === 0) {
-        this.logger.warn(
+      if (alignedExecution.messageAmount === 0n) {
+        this.logger.info(
           {
-            origin,
-            destination,
-            amount: localAmount.toString(),
             intentId: intent.id,
+            maxTransferable: maxTransferable.toString(),
           },
-          'No inventory available on any monitored chain',
+          'Skipping partial transferRemote because available local amount cannot produce canonical progress',
         );
-
-        return {
-          route,
-          success: false,
-          error: 'No inventory available on any monitored chain',
+      } else {
+        const partialSwappedRoute: InventoryRoute = {
+          ...swappedRoute,
+          amount: alignedExecution.localAmount,
         };
-      }
-
-      // NEW: Calculate max viable amount for each source chain
-      // This uses the quote API to determine gas costs upfront
-      const viableSources: Array<{ chain: ChainName; maxViable: bigint }> = [];
-
-      for (const source of allSources) {
-        const maxViable = await this.calculateMaxViableBridgeAmount(
-          source.chain,
-          destination,
-          source.availableAmount,
-          route.externalBridge,
+        const result = await this.executeTransferRemote(
+          partialSwappedRoute,
+          intent,
+          costs.gasQuote!,
+          alignedExecution.messageAmount,
         );
 
-        if (maxViable > 0n) {
-          viableSources.push({ chain: source.chain, maxViable });
-        }
-      }
-
-      // Sort by max viable descending (bridge from largest sources first)
-      viableSources.sort((a, b) => (a.maxViable > b.maxViable ? -1 : 1));
-
-      if (viableSources.length === 0) {
-        this.logger.warn(
+        this.logger.info(
           {
-            targetChain: destination,
-            sourcesChecked: allSources.length,
             intentId: intent.id,
+            partialAmount: alignedExecution.localAmount.toString(),
+            partialAmountCanonical: alignedExecution.messageAmount.toString(),
+            requestedAmount: requestedLocalAmount.toString(),
+            requestedAmountCanonical: amount.toString(),
+            remainingAmountCanonical: (amount > alignedExecution.messageAmount
+              ? amount - alignedExecution.messageAmount
+              : 0n
+            ).toString(),
           },
-          'No viable bridge sources - all chains have insufficient inventory or high gas costs',
+          'Executed partial inventory deposit, remaining will be handled in future cycles',
         );
 
-        return {
-          route,
-          success: false,
-          error: 'No viable bridge sources available',
-        };
+        // Return original strategy route in result (not the swapped execution route)
+        return { ...result, route };
       }
-
-      // Create bridge plans using VIABLE amounts (gas already accounted for)
-      const targetWithBuffer =
-        ((localAmount + costs.totalCost) * (100n + BRIDGE_BUFFER_PERCENT)) /
-        100n;
-      const bridgePlans: Array<{ chain: ChainName; amount: bigint }> = [];
-      let totalPlanned = 0n;
-
-      for (const source of viableSources) {
-        if (totalPlanned >= targetWithBuffer) break;
-
-        const remaining = targetWithBuffer - totalPlanned;
-        const amountFromSource =
-          source.maxViable >= remaining ? remaining : source.maxViable; // Already gas-adjusted!
-
-        bridgePlans.push({
-          chain: source.chain,
-          amount: amountFromSource,
-        });
-        totalPlanned += amountFromSource;
-      }
-
-      this.logger.info(
-        {
-          targetChain: destination,
-          viableSources: viableSources.map((s) => ({
-            chain: s.chain,
-            maxViable: s.maxViable.toString(),
-            maxViableEth: (Number(s.maxViable) / 1e18).toFixed(6),
-          })),
-          bridgePlans: bridgePlans.map((p) => ({
-            chain: p.chain,
-            amount: p.amount.toString(),
-            amountEth: (Number(p.amount) / 1e18).toFixed(6),
-          })),
-          totalPlanned: totalPlanned.toString(),
-          targetWithBuffer: targetWithBuffer.toString(),
-          intentId: intent.id,
-        },
-        'Created bridge plans using gas-adjusted viable amounts',
-      );
-
-      // Execute all bridges in parallel
-      const bridgeResults = await Promise.allSettled(
-        bridgePlans.map((plan) =>
-          this.executeInventoryMovement(
-            plan.chain,
-            destination,
-            plan.amount,
-            intent,
-            route.externalBridge,
-          ),
-        ),
-      );
-
-      // Process results
-      let successCount = 0;
-      let totalBridged = 0n;
-      const failedErrors: string[] = [];
-
-      for (let i = 0; i < bridgeResults.length; i++) {
-        const result = bridgeResults[i];
-        const plan = bridgePlans[i];
-
-        if (result.status === 'fulfilled' && result.value.success) {
-          successCount++;
-          totalBridged += plan.amount;
-          this.logger.info(
-            {
-              sourceChain: plan.chain,
-              amount: plan.amount.toString(),
-              txHash: result.value.txHash,
-            },
-            'Inventory movement succeeded',
-          );
-        } else {
-          const error =
-            result.status === 'rejected'
-              ? result.reason?.message
-              : result.value.error;
-          if (error) {
-            failedErrors.push(`${plan.chain}: ${error}`);
-          }
-          this.logger.warn(
-            {
-              sourceChain: plan.chain,
-              amount: plan.amount.toString(),
-              error,
-            },
-            'Inventory movement failed',
-          );
-        }
-      }
-
-      if (successCount === 0) {
-        const errorDetails =
-          failedErrors.length > 0 ? ` (${failedErrors.join('; ')})` : '';
-        return {
-          route,
-          success: false,
-          error: `All inventory movements failed${errorDetails}`,
-        };
-      }
-
-      this.logger.info(
-        {
-          targetChain: destination,
-          successCount,
-          totalBridged: totalBridged.toString(),
-          targetAmount: amount.toString(),
-          targetAmountCanonical: route.amount.toString(),
-          intentId: intent.id,
-        },
-        'Parallel inventory movements completed, transferRemote will execute after bridges complete',
-      );
-
-      return { route, success: true };
     }
+
+    // Inventory below cost-based threshold - trigger ExternalBridge movement TO destination chain
+    this.logger.info(
+      {
+        targetChain: destination,
+        maxTransferable: maxTransferable.toString(),
+        minViableTransfer: minViableTransfer.toString(),
+        costMultiplier: MIN_VIABLE_COST_MULTIPLIER.toString(),
+        intentId: intent.id,
+      },
+      'Inventory below cost-based threshold on destination, triggering LiFi movement',
+    );
+
+    // Get all available source chains with raw inventory
+    const allSources = this.selectAllSourceChains(destination);
+
+    if (allSources.length === 0) {
+      this.logger.warn(
+        {
+          origin,
+          destination,
+          amount: requestedLocalAmount.toString(),
+          intentId: intent.id,
+        },
+        'No inventory available on any monitored chain',
+      );
+
+      return {
+        route,
+        success: false,
+        error: 'No inventory available on any monitored chain',
+      };
+    }
+
+    // Calculate source capacities in destination-local units.
+    const viableSources: Array<{
+      chain: ChainName;
+      maxSourceInput: bigint;
+      maxTargetOutput: bigint;
+    }> = [];
+
+    for (const source of allSources) {
+      const capacity = await this.calculateBridgeCapacity(
+        source.chain,
+        destination,
+        source.availableAmount,
+        route.externalBridge,
+      );
+
+      if (capacity.maxTargetOutput > 0n) {
+        viableSources.push({ chain: source.chain, ...capacity });
+      }
+    }
+
+    // Sort by destination output descending.
+    viableSources.sort((a, b) =>
+      a.maxTargetOutput > b.maxTargetOutput ? -1 : 1,
+    );
+
+    if (viableSources.length === 0) {
+      this.logger.warn(
+        {
+          targetChain: destination,
+          sourcesChecked: allSources.length,
+          intentId: intent.id,
+        },
+        'No viable bridge sources - all chains have insufficient inventory or high gas costs',
+      );
+
+      return {
+        route,
+        success: false,
+        error: 'No viable bridge sources available',
+      };
+    }
+
+    // Create bridge plans using destination-local output amounts.
+    const targetWithBuffer =
+      ((requestedLocalAmount + costs.totalCost) *
+        (100n + BRIDGE_BUFFER_PERCENT)) /
+      100n;
+    const bridgePlans: Array<{
+      chain: ChainName;
+      maxSourceInput: bigint;
+      targetOutput: bigint;
+    }> = [];
+    let totalPlanned = 0n;
+
+    for (const source of viableSources) {
+      if (totalPlanned >= targetWithBuffer) break;
+
+      const remaining = targetWithBuffer - totalPlanned;
+      const targetOutput =
+        source.maxTargetOutput >= remaining
+          ? remaining
+          : source.maxTargetOutput;
+
+      bridgePlans.push({
+        chain: source.chain,
+        maxSourceInput: source.maxSourceInput,
+        targetOutput,
+      });
+      totalPlanned += targetOutput;
+    }
+
+    this.logger.info(
+      {
+        targetChain: destination,
+        viableSources: viableSources.map((s) => ({
+          chain: s.chain,
+          maxSourceInput: s.maxSourceInput.toString(),
+          maxTargetOutput: s.maxTargetOutput.toString(),
+        })),
+        bridgePlans: bridgePlans.map((p) => ({
+          chain: p.chain,
+          maxSourceInput: p.maxSourceInput.toString(),
+          targetOutput: p.targetOutput.toString(),
+        })),
+        totalPlanned: totalPlanned.toString(),
+        targetWithBuffer: targetWithBuffer.toString(),
+        intentId: intent.id,
+      },
+      'Created bridge plans using gas-adjusted viable amounts',
+    );
+
+    // Execute all bridges in parallel
+    const bridgeResults = await Promise.allSettled(
+      bridgePlans.map((plan) =>
+        this.executeInventoryMovement(
+          plan.chain,
+          destination,
+          plan.targetOutput,
+          plan.maxSourceInput,
+          intent,
+          route.externalBridge,
+        ),
+      ),
+    );
+
+    // Process results
+    let successCount = 0;
+    let totalBridged = 0n;
+    const failedErrors: string[] = [];
+
+    for (let i = 0; i < bridgeResults.length; i++) {
+      const result = bridgeResults[i];
+      const plan = bridgePlans[i];
+
+      if (result.status === 'fulfilled' && result.value.success) {
+        successCount++;
+        totalBridged += plan.targetOutput;
+        this.logger.info(
+          {
+            sourceChain: plan.chain,
+            amount: plan.targetOutput.toString(),
+            txHash: result.value.txHash,
+          },
+          'Inventory movement succeeded',
+        );
+      } else {
+        const error =
+          result.status === 'rejected'
+            ? result.reason?.message
+            : result.value.error;
+        if (error) {
+          failedErrors.push(`${plan.chain}: ${error}`);
+        }
+        this.logger.warn(
+          {
+            sourceChain: plan.chain,
+            amount: plan.targetOutput.toString(),
+            error,
+          },
+          'Inventory movement failed',
+        );
+      }
+    }
+
+    if (successCount === 0) {
+      const errorDetails =
+        failedErrors.length > 0 ? ` (${failedErrors.join('; ')})` : '';
+      return {
+        route,
+        success: false,
+        error: `All inventory movements failed${errorDetails}`,
+      };
+    }
+
+    this.logger.info(
+      {
+        targetChain: destination,
+        successCount,
+        totalBridged: totalBridged.toString(),
+        targetAmount: requestedLocalAmount.toString(),
+        targetAmountCanonical: amount.toString(),
+        intentId: intent.id,
+      },
+      'Parallel inventory movements completed, transferRemote will execute after bridges complete',
+    );
+
+    return { route, success: true };
   }
 
   /**
@@ -1151,40 +1186,32 @@ export class InventoryRebalancer implements IInventoryRebalancer {
   }
 
   /**
-   * Calculate the maximum amount that can be bridged from a source chain.
-   * Uses LiFi quote to determine gas costs, applies 20x multiplier buffer.
-   * Returns 0 if gas exceeds 10% of inventory (not economically viable).
+   * Calculate the bridge capacity from a source chain in destination-local units.
+   * Uses LiFi quotes to conservatively estimate the destination output available
+   * from the source chain's current local inventory.
    *
-   * This is the key method for the gas-aware planning approach:
-   * - Gets a quote for the full raw inventory to determine actual gas costs
-   * - Applies conservative 20x buffer (LiFi underestimates by ~14x historically)
-   * - Returns 0 if gas > 10% of inventory (not worth bridging)
-   * - Returns inventory - estimatedGas if viable
-   *
-   * @param sourceChain - Chain to bridge from
-   * @param targetChain - Chain to bridge to
-   * @param rawInventory - Raw available inventory on source chain
-   * @param externalBridgeType - External bridge type to use
-   * @returns Maximum viable bridge amount (0 if not viable)
+   * For native-token sources, gas is reserved from the source inventory and the
+   * output capacity is re-quoted from the remaining source input.
    */
-  private async calculateMaxViableBridgeAmount(
+  private async calculateBridgeCapacity(
     sourceChain: ChainName,
     targetChain: ChainName,
     rawInventory: bigint,
     externalBridgeType: ExternalBridgeType,
-  ): Promise<bigint> {
+  ): Promise<BridgeCapacity> {
     const sourceToken = this.getTokenForChain(sourceChain);
     const targetToken = this.getTokenForChain(targetChain);
 
-    if (!sourceToken || !targetToken) return 0n;
-
-    // Only applies to native tokens (need gas from same balance)
-    if (!isNativeTokenStandard(sourceToken.standard)) {
-      return rawInventory; // ERC20s don't compete with gas
+    if (!sourceToken || !targetToken) {
+      return { maxSourceInput: 0n, maxTargetOutput: 0n };
     }
 
     // Convert HypNative token addresses to the external bridge's native token representation
-    const fromTokenAddress = this.getNativeTokenAddress(externalBridgeType);
+    const fromTokenAddress = getExternalBridgeTokenAddress(
+      sourceToken,
+      externalBridgeType,
+      this.getNativeTokenAddress.bind(this),
+    );
     const toTokenAddress = getExternalBridgeTokenAddress(
       targetToken,
       externalBridgeType,
@@ -1196,7 +1223,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
 
     try {
       const externalBridge = this.getExternalBridge(externalBridgeType);
-      const quote = await externalBridge.quote({
+      const initialQuote = await externalBridge.quote({
         fromChain: sourceChainId,
         toChain: targetChainId,
         fromToken: fromTokenAddress,
@@ -1206,48 +1233,58 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         toAddress: this.getInventorySignerAddress(targetChain),
       });
 
-      // Apply 20x multiplier on quoted gas (LiFi underestimates by ~14x)
-      const estimatedGas = quote.gasCosts * GAS_COST_MULTIPLIER;
+      let maxSourceInput = rawInventory;
+      let outputQuote = initialQuote;
 
-      // Viability check: gas should not exceed 10% of inventory
-      const maxGasThreshold = rawInventory / MAX_GAS_PERCENT_THRESHOLD;
-      if (estimatedGas > maxGasThreshold) {
-        this.logger.info(
-          {
-            sourceChain,
-            targetChain,
-            rawInventory: rawInventory.toString(),
-            rawInventoryEth: (Number(rawInventory) / 1e18).toFixed(6),
-            quotedGas: quote.gasCosts.toString(),
-            estimatedGas: estimatedGas.toString(),
-            estimatedGasEth: (Number(estimatedGas) / 1e18).toFixed(6),
-            maxGasThreshold: maxGasThreshold.toString(),
-            gasPercent: `${(Number(estimatedGas) * 100) / Number(rawInventory)}%`,
-          },
-          'Bridge not viable - gas cost exceeds 10% of inventory',
-        );
-        return 0n;
+      if (isNativeTokenStandard(sourceToken.standard)) {
+        const estimatedGas = initialQuote.gasCosts * GAS_COST_MULTIPLIER;
+        const maxGasThreshold = rawInventory / MAX_GAS_PERCENT_THRESHOLD;
+        if (estimatedGas > maxGasThreshold) {
+          this.logger.info(
+            {
+              sourceChain,
+              targetChain,
+              rawInventory: rawInventory.toString(),
+              quotedGas: initialQuote.gasCosts.toString(),
+              estimatedGas: estimatedGas.toString(),
+              maxGasThreshold: maxGasThreshold.toString(),
+            },
+            'Bridge not viable - gas cost exceeds 10% of inventory',
+          );
+          return { maxSourceInput: 0n, maxTargetOutput: 0n };
+        }
+
+        maxSourceInput = rawInventory - estimatedGas;
+        if (maxSourceInput <= 0n) {
+          return { maxSourceInput: 0n, maxTargetOutput: 0n };
+        }
+
+        outputQuote = await externalBridge.quote({
+          fromChain: sourceChainId,
+          toChain: targetChainId,
+          fromToken: fromTokenAddress,
+          toToken: toTokenAddress,
+          fromAmount: maxSourceInput,
+          fromAddress: this.getInventorySignerAddress(sourceChain),
+          toAddress: this.getInventorySignerAddress(targetChain),
+        });
       }
-
-      // Max viable = inventory minus estimated gas
-      const maxViable = rawInventory - estimatedGas;
 
       this.logger.info(
         {
           sourceChain,
           targetChain,
           rawInventory: rawInventory.toString(),
-          rawInventoryEth: (Number(rawInventory) / 1e18).toFixed(6),
-          quotedGas: quote.gasCosts.toString(),
-          estimatedGas: estimatedGas.toString(),
-          estimatedGasEth: (Number(estimatedGas) / 1e18).toFixed(6),
-          maxViable: maxViable.toString(),
-          maxViableEth: (Number(maxViable) / 1e18).toFixed(6),
+          maxSourceInput: maxSourceInput.toString(),
+          maxTargetOutput: outputQuote.toAmountMin.toString(),
         },
-        'Calculated max viable bridge amount',
+        'Calculated bridge capacity',
       );
 
-      return maxViable;
+      return {
+        maxSourceInput,
+        maxTargetOutput: outputQuote.toAmountMin,
+      };
     } catch (error) {
       this.logger.warn(
         {
@@ -1255,21 +1292,22 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           targetChain,
           error: (error as Error).message,
         },
-        'Failed to calculate max viable bridge amount, skipping chain',
+        'Failed to calculate bridge capacity, skipping chain',
       );
-      return 0n;
+      return { maxSourceInput: 0n, maxTargetOutput: 0n };
     }
   }
 
   /**
    * Execute inventory movement from source chain to target chain via LiFi bridge.
    *
-   * IMPORTANT: The amount parameter is now the MAX VIABLE amount (gas already subtracted
-   * by calculateMaxViableBridgeAmount). This method trusts that the amount is pre-validated.
+   * Uses reverse quotes (`toAmount`) so plans are expressed in target-chain local
+   * units and source-local spend is discovered by the bridge quote.
    *
    * @param sourceChain - Chain to move inventory from
    * @param targetChain - Chain to move inventory to (origin chain for rebalancing)
-   * @param amount - Pre-validated amount to bridge (gas already accounted for)
+   * @param targetOutputAmount - Destination-local amount to receive
+   * @param maxSourceInput - Maximum source-local amount available for this plan
    * @param intent - Rebalance intent for tracking
    * @param externalBridgeType - External bridge type to use
    * @returns Result with success status and optional txHash/error
@@ -1277,7 +1315,8 @@ export class InventoryRebalancer implements IInventoryRebalancer {
   private async executeInventoryMovement(
     sourceChain: ChainName,
     targetChain: ChainName,
-    amount: bigint,
+    targetOutputAmount: bigint,
+    maxSourceInput: bigint,
     intent: RebalanceIntent,
     externalBridgeType: ExternalBridgeType,
   ): Promise<{ success: boolean; txHash?: string; error?: string }> {
@@ -1332,8 +1371,8 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     const costs = await calculateTransferCosts(
       targetChain, // FROM chain for transferRemote (the target of this bridge)
       sourceChain, // TO chain for transferRemote (Hyperlane message destination)
-      amount, // availableInventory (not used for minViableTransfer calculation)
-      amount, // requestedAmount
+      targetOutputAmount, // availableInventory (not used for minViableTransfer calculation)
+      targetOutputAmount, // requestedAmount
       this.multiProvider,
       this.warpCore.multiProvider,
       this.getTokenForChain.bind(this),
@@ -1345,17 +1384,19 @@ export class InventoryRebalancer implements IInventoryRebalancer {
 
     // If the requested amount is below minViableTransfer, adjust it up
     // This ensures we bridge enough to actually complete the final transferRemote
-    const effectiveAmount =
-      amount < minViableTransfer ? minViableTransfer : amount;
+    const effectiveTargetOutput =
+      targetOutputAmount < minViableTransfer
+        ? minViableTransfer
+        : targetOutputAmount;
 
-    if (effectiveAmount !== amount) {
+    if (effectiveTargetOutput !== targetOutputAmount) {
       this.logger.info(
         {
-          originalAmount: amount.toString(),
-          effectiveAmount: effectiveAmount.toString(),
+          originalAmount: targetOutputAmount.toString(),
+          effectiveAmount: effectiveTargetOutput.toString(),
           minViableTransfer: minViableTransfer.toString(),
-          originalAmountEth: (Number(amount) / 1e18).toFixed(6),
-          effectiveAmountEth: (Number(effectiveAmount) / 1e18).toFixed(6),
+          originalAmountEth: (Number(targetOutputAmount) / 1e18).toFixed(6),
+          effectiveAmountEth: (Number(effectiveTargetOutput) / 1e18).toFixed(6),
           minViableTransferEth: (Number(minViableTransfer) / 1e18).toFixed(6),
           adjustedUp: true,
           intentId: intent.id,
@@ -1371,12 +1412,18 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         toChain: targetChainId,
         fromToken: fromTokenAddress,
         toToken: toTokenAddress,
-        fromAmount: effectiveAmount,
+        toAmount: effectiveTargetOutput,
         fromAddress: this.getInventorySignerAddress(sourceChain),
         toAddress: this.getInventorySignerAddress(targetChain),
       });
 
       const inputRequired = quote.fromAmount;
+      if (inputRequired > maxSourceInput) {
+        return {
+          success: false,
+          error: `Bridge input ${inputRequired} exceeded planned source capacity ${maxSourceInput}`,
+        };
+      }
 
       this.logger.info(
         {
@@ -1384,19 +1431,24 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           targetChain,
           sourceChainId,
           targetChainId,
-          preValidatedAmount: amount.toString(),
-          preValidatedAmountEth: (Number(amount) / 1e18).toFixed(6),
-          effectiveAmount: effectiveAmount.toString(),
-          effectiveAmountEth: (Number(effectiveAmount) / 1e18).toFixed(6),
+          requestedTargetOutput: targetOutputAmount.toString(),
+          requestedTargetOutputEth: (Number(targetOutputAmount) / 1e18).toFixed(
+            6,
+          ),
+          effectiveTargetOutput: effectiveTargetOutput.toString(),
+          effectiveTargetOutputEth: (
+            Number(effectiveTargetOutput) / 1e18
+          ).toFixed(6),
           inputRequired: inputRequired.toString(),
           expectedOutput: quote.toAmount.toString(),
+          expectedOutputMin: quote.toAmountMin.toString(),
           expectedOutputEth: (Number(quote.toAmount) / 1e18).toFixed(6),
           gasCosts: quote.gasCosts.toString(),
           feeCosts: quote.feeCosts.toString(),
           intentId: intent.id,
-          adjustedForMinViable: effectiveAmount > amount,
+          adjustedForMinViable: effectiveTargetOutput > targetOutputAmount,
         },
-        'Executing inventory movement via LiFi with pre-validated amount',
+        'Executing inventory movement via LiFi reverse quote',
       );
 
       this.logger.debug(
@@ -1468,7 +1520,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         {
           sourceChain,
           targetChain,
-          amount: amount.toString(),
+          amount: targetOutputAmount.toString(),
           intentId: intent.id,
           error: (error as Error).message,
         },

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -51,6 +51,10 @@ import {
 } from '../utils/tokenUtils.js';
 import { parseSolanaPrivateKey } from '../utils/solanaKeyParser.js';
 import { toProtocolTransaction } from '../utils/transactionUtils.js';
+import {
+  denormalizeToLocal,
+  normalizeToCanonical,
+} from '../utils/balanceUtils.js';
 
 /**
  * Buffer percentage to add when bridging inventory.
@@ -533,11 +537,15 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       {
         strategyRoute: `${origin} (surplus) → ${destination} (deficit)`,
         executionRoute: `transferRemote FROM ${destination} TO ${origin}`,
-        amount: amount.toString(),
+        canonicalAmount: amount.toString(),
         intentId: intent.id,
       },
       'Executing inventory route',
     );
+
+    const sourceToken = this.getTokenForChain(destination);
+    assert(sourceToken, `No token found for source chain: ${destination}`);
+    const localAmount = denormalizeToLocal(amount, sourceToken);
 
     // Check available inventory on the DESTINATION (deficit) chain
     // We need inventory here because transferRemote is called FROM this chain
@@ -548,8 +556,8 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         checkingChain: destination,
         availableInventory: availableInventory.toString(),
         availableInventoryEth: (Number(availableInventory) / 1e18).toFixed(6),
-        requiredAmount: amount.toString(),
-        requiredAmountEth: (Number(amount) / 1e18).toFixed(6),
+        requiredAmount: localAmount.toString(),
+        requiredAmountEth: (Number(localAmount) / 1e18).toFixed(6),
       },
       'Checking effective inventory on destination (deficit) chain',
     );
@@ -560,7 +568,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       destination, // FROM chain (where transferRemote is called)
       origin, // TO chain (where Hyperlane message goes)
       availableInventory,
-      amount,
+      localAmount,
       this.multiProvider,
       this.warpCore.multiProvider,
       this.getTokenForChain.bind(this),
@@ -579,11 +587,11 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         fromChain: destination,
         toChain: origin,
         availableInventoryEth: (Number(availableInventory) / 1e18).toFixed(6),
-        requestedAmountEth: (Number(amount) / 1e18).toFixed(6),
+        requestedAmountEth: (Number(localAmount) / 1e18).toFixed(6),
         maxTransferableEth: (Number(maxTransferable) / 1e18).toFixed(6),
         minViableTransferEth: (Number(minViableTransfer) / 1e18).toFixed(6),
         totalInventoryEth: (Number(totalInventory) / 1e18).toFixed(6),
-        canFullyFulfill: maxTransferable >= amount,
+        canFullyFulfill: maxTransferable >= localAmount,
         canPartialFulfill: maxTransferable >= minViableTransfer,
       },
       'Calculated max transferable amount with cost-based threshold',
@@ -591,11 +599,11 @@ export class InventoryRebalancer implements IInventoryRebalancer {
 
     // Early exit: If remaining amount is below minViableTransfer, complete the intent
     // This prevents infinite loops when the remaining amount is too small to economically bridge
-    if (amount < minViableTransfer) {
+    if (localAmount < minViableTransfer) {
       this.logger.info(
         {
           intentId: intent.id,
-          amount: amount.toString(),
+          amount: localAmount.toString(),
           minViableTransfer: minViableTransfer.toString(),
         },
         'Remaining amount below minViableTransfer, completing intent with acceptable loss',
@@ -616,14 +624,20 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       ...route,
       origin: destination, // transferRemote called FROM here
       destination: origin, // Hyperlane message goes TO here
+      amount: localAmount,
     };
 
-    if (maxTransferable >= amount) {
+    if (maxTransferable >= localAmount) {
       // Sufficient inventory on destination - execute transferRemote directly
+      const fulfilledCanonicalAmount = normalizeToCanonical(
+        localAmount,
+        sourceToken,
+      );
       const result = await this.executeTransferRemote(
         swappedRoute,
         intent,
         costs.gasQuote!,
+        fulfilledCanonicalAmount,
       );
       // Return original strategy route in result (not the swapped execution route)
       return { ...result, route };
@@ -633,18 +647,23 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         ...swappedRoute,
         amount: maxTransferable,
       };
+      const fulfilledCanonicalAmount = normalizeToCanonical(
+        maxTransferable,
+        sourceToken,
+      );
       const result = await this.executeTransferRemote(
         partialSwappedRoute,
         intent,
         costs.gasQuote!,
+        fulfilledCanonicalAmount,
       );
 
       this.logger.info(
         {
           intentId: intent.id,
           partialAmount: maxTransferable.toString(),
-          requestedAmount: amount.toString(),
-          remainingAmount: (amount - maxTransferable).toString(),
+          requestedAmount: localAmount.toString(),
+          remainingAmount: (localAmount - maxTransferable).toString(),
         },
         'Executed partial inventory deposit, remaining will be handled in future cycles',
       );
@@ -672,7 +691,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           {
             origin,
             destination,
-            amount: amount.toString(),
+            amount: localAmount.toString(),
             intentId: intent.id,
           },
           'No inventory available on any monitored chain',
@@ -724,7 +743,8 @@ export class InventoryRebalancer implements IInventoryRebalancer {
 
       // Create bridge plans using VIABLE amounts (gas already accounted for)
       const targetWithBuffer =
-        ((amount + costs.totalCost) * (100n + BRIDGE_BUFFER_PERCENT)) / 100n;
+        ((localAmount + costs.totalCost) * (100n + BRIDGE_BUFFER_PERCENT)) /
+        100n;
       const bridgePlans: Array<{ chain: ChainName; amount: bigint }> = [];
       let totalPlanned = 0n;
 
@@ -830,6 +850,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           successCount,
           totalBridged: totalBridged.toString(),
           targetAmount: amount.toString(),
+          targetAmountCanonical: route.amount.toString(),
           intentId: intent.id,
         },
         'Parallel inventory movements completed, transferRemote will execute after bridges complete',
@@ -858,6 +879,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     route: InventoryRoute,
     intent: RebalanceIntent,
     gasQuote: InterchainGasQuote,
+    fulfilledCanonicalAmount: bigint,
   ): Promise<InventoryExecutionResult> {
     const { origin, destination, amount } = route;
 
@@ -974,7 +996,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       intentId: intent.id,
       origin: this.multiProvider.getDomainId(origin),
       destination: destinationDomain,
-      amount,
+      amount: fulfilledCanonicalAmount,
       type: 'inventory_deposit',
       txHash: transferTxHash,
       messageId,

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -3,28 +3,19 @@ import type { Logger } from 'pino';
 import {
   type ChainName,
   HyperlaneCore,
-  type InterchainGasQuote,
-  type IToken,
   type MultiProtocolSignerSignerAccountInfo,
   type MultiProvider,
-  Token,
   ProviderType,
   SealevelCoreAdapter,
   TOKEN_COLLATERALIZED_STANDARDS,
-  type TokenAmount,
+  type Token,
   type WarpTypedTransaction,
   type WarpCore,
   WarpTxCategory,
   getSignerForChain,
   type TypedTransactionReceipt,
 } from '@hyperlane-xyz/sdk';
-import {
-  ProtocolType,
-  assert,
-  ensure0x,
-  fromWei,
-  isZeroishAddress,
-} from '@hyperlane-xyz/utils';
+import { ProtocolType, assert, ensure0x, fromWei } from '@hyperlane-xyz/utils';
 
 import type { ExternalBridgeType } from '../config/types.js';
 import type {
@@ -82,6 +73,66 @@ type BridgeCapacity = {
   maxSourceInput: bigint;
   maxTargetOutput: bigint;
 };
+
+const RECOVERABLE_MAX_TRANSFER_ERROR_MESSAGES = [
+  'balance may be insufficient',
+  'transfer amount exceeds balance',
+  'insufficient balance',
+];
+
+function hasRecoverableMaxTransferErrorMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes('unpredictable_gas_limit') ||
+    RECOVERABLE_MAX_TRANSFER_ERROR_MESSAGES.some((pattern) =>
+      normalized.includes(pattern),
+    )
+  );
+}
+
+function isRecoverableMaxTransferProbeError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  const stack: unknown[] = [error];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current == null) continue;
+
+    if (typeof current === 'string') {
+      if (hasRecoverableMaxTransferErrorMessage(current)) return true;
+      continue;
+    }
+
+    if (typeof current !== 'object') continue;
+    if (seen.has(current)) continue;
+    seen.add(current);
+
+    const candidate = current as {
+      code?: unknown;
+      message?: unknown;
+      cause?: unknown;
+      error?: unknown;
+    };
+
+    if (
+      typeof candidate.code === 'string' &&
+      candidate.code.toUpperCase() === 'UNPREDICTABLE_GAS_LIMIT'
+    ) {
+      return true;
+    }
+
+    if (
+      typeof candidate.message === 'string' &&
+      hasRecoverableMaxTransferErrorMessage(candidate.message)
+    ) {
+      return true;
+    }
+
+    stack.push(candidate.cause, candidate.error);
+  }
+
+  return false;
+}
 
 /**
  * Configuration for the InventoryRebalancer.
@@ -557,6 +608,8 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     const sourceToken = this.getTokenForChain(destination);
     assert(sourceToken, `No token found for source chain: ${destination}`);
     const requestedLocalAmount = denormalizeToLocal(amount, sourceToken);
+    const executionSender = this.getInventorySignerAddress(destination);
+    const executionRecipient = this.getInventorySignerAddress(origin);
 
     // Check available inventory on the DESTINATION (deficit) chain
     // We need inventory here because transferRemote is called FROM this chain
@@ -589,11 +642,68 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       this.multiProvider,
       this.warpCore.multiProvider,
       this.getTokenForChain.bind(this),
-      this.getInventorySignerAddress(destination),
+      executionSender,
       isNativeTokenStandard,
       this.logger,
     );
-    const { maxTransferable, minViableTransfer } = costs;
+    const { minViableTransfer } = costs;
+    let maxTransferable = costs.maxTransferable;
+
+    if (!isNativeTokenStandard(sourceToken.standard)) {
+      if (availableInventory === 0n) {
+        maxTransferable = 0n;
+        this.logger.debug(
+          {
+            fromChain: destination,
+            toChain: origin,
+            requestedAmount: requestedLocalAmount.toString(),
+          },
+          'Skipping fee-aware max transferable probe because destination inventory is zero',
+        );
+      } else {
+        try {
+          const feeAwareMaxTransfer = await this.warpCore.getMaxTransferAmount({
+            balance: sourceToken.amount(availableInventory),
+            destination: origin,
+            sender: executionSender,
+            recipient: executionRecipient,
+          });
+
+          maxTransferable =
+            feeAwareMaxTransfer.amount < requestedLocalAmount
+              ? feeAwareMaxTransfer.amount
+              : requestedLocalAmount;
+
+          this.logger.debug(
+            {
+              fromChain: destination,
+              toChain: origin,
+              availableInventory: availableInventory.toString(),
+              requestedAmount: requestedLocalAmount.toString(),
+              feeAwareMaxTransferable: maxTransferable.toString(),
+            },
+            'Calculated fee-aware max transferable amount for non-native route',
+          );
+        } catch (error) {
+          if (!isRecoverableMaxTransferProbeError(error)) {
+            throw error;
+          }
+
+          maxTransferable = 0n;
+          this.logger.warn(
+            {
+              fromChain: destination,
+              toChain: origin,
+              availableInventory: availableInventory.toString(),
+              requestedAmount: requestedLocalAmount.toString(),
+              error: error instanceof Error ? error.message : String(error),
+              intentId: intent.id,
+            },
+            'Fee-aware max transferable probe failed due to insufficient balance, falling back to external bridge',
+          );
+        }
+      }
+    }
 
     // Calculate total inventory across all chains
     // Note: consumedInventory tracking is handled separately within this cycle
@@ -665,7 +775,6 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       const result = await this.executeTransferRemote(
         swappedRoute,
         intent,
-        costs.gasQuote!,
         fulfilledCanonicalAmount,
       );
       // Return original strategy route in result (not the swapped execution route)
@@ -692,7 +801,6 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         const result = await this.executeTransferRemote(
           partialSwappedRoute,
           intent,
-          costs.gasQuote!,
           alignedExecution.messageAmount,
         );
 
@@ -931,12 +1039,10 @@ export class InventoryRebalancer implements IInventoryRebalancer {
    *
    * @param route - The transfer route (swapped direction)
    * @param intent - The rebalance intent being executed
-   * @param gasQuote - Pre-calculated gas quote from calculateTransferCosts
    */
   private async executeTransferRemote(
     route: InventoryRoute,
     intent: RebalanceIntent,
-    gasQuote: InterchainGasQuote,
     fulfilledCanonicalAmount: bigint,
   ): Promise<InventoryExecutionResult> {
     const { origin, destination, amount } = route;
@@ -949,42 +1055,9 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     const destinationDomain = this.multiProvider.getDomainId(destination);
 
     this.logger.debug(
-      {
-        origin,
-        destination,
-        amount: amount.toString(),
-        gasQuote: {
-          igpQuote: gasQuote.igpQuote.amount.toString(),
-          tokenFeeQuote: gasQuote.tokenFeeQuote?.amount?.toString() ?? 'none',
-        },
-      },
-      'Using pre-calculated gas quote for transferRemote',
+      { origin, destination, amount: amount.toString() },
+      'Building transferRemote transactions for exact execution amount',
     );
-
-    // Convert pre-calculated gas quote to TokenAmount for WarpCore
-    const originChainMetadata = this.multiProvider.getChainMetadata(origin);
-    const igpAddressOrDenom = gasQuote.igpQuote.addressOrDenom;
-    let igpToken: IToken;
-    if (!igpAddressOrDenom || isZeroishAddress(igpAddressOrDenom)) {
-      igpToken = Token.FromChainMetadataNativeToken(originChainMetadata);
-    } else {
-      const searchResult = this.warpCore.findToken(origin, igpAddressOrDenom);
-      assert(searchResult, `IGP fee token ${igpAddressOrDenom} is unknown`);
-      igpToken = searchResult;
-    }
-    const interchainFee: TokenAmount<IToken> = igpToken.amount(
-      gasQuote.igpQuote.amount,
-    );
-
-    let tokenFeeQuote: TokenAmount<IToken> | undefined;
-    if (gasQuote.tokenFeeQuote?.amount) {
-      const feeAddress = gasQuote.tokenFeeQuote.addressOrDenom;
-      const feeToken: IToken =
-        !feeAddress || isZeroishAddress(feeAddress)
-          ? Token.FromChainMetadataNativeToken(originChainMetadata)
-          : originToken;
-      tokenFeeQuote = feeToken.amount(gasQuote.tokenFeeQuote.amount);
-    }
 
     const originTokenAmount = originToken.amount(amount);
     const transferTxs = await this.warpCore.getTransferRemoteTxs({
@@ -992,8 +1065,6 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       destination,
       sender: this.getInventorySignerAddress(origin),
       recipient: this.getInventorySignerAddress(destination),
-      interchainFee,
-      tokenFeeQuote,
     });
     assert(
       transferTxs.length > 0,

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -1474,6 +1474,8 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         'Inventory movement transaction executed',
       );
 
+      // Keep bridge consumption in source-local units; intent fulfillment only
+      // advances from canonical inventory_deposit amounts after transferRemote.
       await this.actionTracker.createRebalanceAction({
         intentId: intent.id,
         origin: this.multiProvider.getDomainId(sourceChain),

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -1224,10 +1224,8 @@ export class InventoryRebalancer implements IInventoryRebalancer {
   ): Promise<BridgeCapacity> {
     const sourceToken = this.getTokenForChain(sourceChain);
     const targetToken = this.getTokenForChain(targetChain);
-
-    if (!sourceToken || !targetToken) {
-      return { maxSourceInput: 0n, maxTargetOutput: 0n };
-    }
+    assert(sourceToken, `No token found for source chain: ${sourceChain}`);
+    assert(targetToken, `No token found for target chain: ${targetChain}`);
 
     // Convert HypNative token addresses to the external bridge's native token representation
     const fromTokenAddress = getExternalBridgeTokenAddress(

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -11,7 +11,6 @@ import {
   ProviderType,
   SealevelCoreAdapter,
   TOKEN_COLLATERALIZED_STANDARDS,
-  TokenAmount,
   type WarpTypedTransaction,
   type WarpCore,
   WarpTxCategory,
@@ -964,27 +963,24 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     // Convert pre-calculated gas quote to TokenAmount for WarpCore
     const originChainMetadata = this.multiProvider.getChainMetadata(origin);
     const igpAddressOrDenom = gasQuote.igpQuote.addressOrDenom;
-    const igpToken =
-      !igpAddressOrDenom || isZeroishAddress(igpAddressOrDenom)
-        ? Token.FromChainMetadataNativeToken(originChainMetadata)
-        : this.warpCore.findToken(origin, igpAddressOrDenom);
-    assert(igpToken, `IGP fee token ${igpAddressOrDenom} is unknown`);
-    const interchainFee = new TokenAmount(
-      gasQuote.igpQuote.amount,
-      igpToken,
-    ) as TokenAmount & { token: IToken };
+    let igpToken: IToken;
+    if (!igpAddressOrDenom || isZeroishAddress(igpAddressOrDenom)) {
+      igpToken = Token.FromChainMetadataNativeToken(originChainMetadata);
+    } else {
+      const searchResult = this.warpCore.findToken(origin, igpAddressOrDenom);
+      assert(searchResult, `IGP fee token ${igpAddressOrDenom} is unknown`);
+      igpToken = searchResult;
+    }
+    const interchainFee = igpToken.amount(gasQuote.igpQuote.amount);
 
-    let tokenFeeQuote: (TokenAmount & { token: IToken }) | undefined;
+    let tokenFeeQuote: ReturnType<IToken['amount']> | undefined;
     if (gasQuote.tokenFeeQuote?.amount) {
       const feeAddress = gasQuote.tokenFeeQuote.addressOrDenom;
-      const feeToken =
+      const feeToken: IToken =
         !feeAddress || isZeroishAddress(feeAddress)
           ? Token.FromChainMetadataNativeToken(originChainMetadata)
           : originToken;
-      tokenFeeQuote = new TokenAmount(
-        gasQuote.tokenFeeQuote.amount,
-        feeToken,
-      ) as TokenAmount & { token: IToken };
+      tokenFeeQuote = feeToken.amount(gasQuote.tokenFeeQuote.amount);
     }
 
     const originTokenAmount = originToken.amount(amount);

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -22,6 +22,7 @@ import {
   ProtocolType,
   assert,
   ensure0x,
+  fromWei,
   isZeroishAddress,
 } from '@hyperlane-xyz/utils';
 
@@ -298,6 +299,10 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     return total;
   }
 
+  private formatLocalAmount(amount: bigint, token: Token): string {
+    return fromWei(amount.toString(), token.decimals);
+  }
+
   /**
    * Get the effective available inventory for a chain, accounting for
    * inventory already consumed during this execution cycle.
@@ -561,9 +566,15 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       {
         checkingChain: destination,
         availableInventory: availableInventory.toString(),
-        availableInventoryEth: (Number(availableInventory) / 1e18).toFixed(6),
+        availableInventoryFormatted: this.formatLocalAmount(
+          availableInventory,
+          sourceToken,
+        ),
         requiredAmount: requestedLocalAmount.toString(),
-        requiredAmountEth: (Number(requestedLocalAmount) / 1e18).toFixed(6),
+        requiredAmountFormatted: this.formatLocalAmount(
+          requestedLocalAmount,
+          sourceToken,
+        ),
       },
       'Checking effective inventory on destination (deficit) chain',
     );
@@ -592,13 +603,25 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       {
         fromChain: destination,
         toChain: origin,
-        availableInventoryEth: (Number(availableInventory) / 1e18).toFixed(6),
-        requestedAmountEth: (Number(requestedLocalAmount) / 1e18).toFixed(6),
-        maxTransferableEth: (Number(maxTransferable) / 1e18).toFixed(6),
-        minViableTransferEth: (Number(minViableTransfer) / 1e18).toFixed(6),
-        totalInventoryEth: (Number(totalInventory) / 1e18).toFixed(6),
+        availableInventoryFormatted: this.formatLocalAmount(
+          availableInventory,
+          sourceToken,
+        ),
+        requestedAmountFormatted: this.formatLocalAmount(
+          requestedLocalAmount,
+          sourceToken,
+        ),
+        maxTransferableFormatted: this.formatLocalAmount(
+          maxTransferable,
+          sourceToken,
+        ),
+        minViableTransferFormatted: this.formatLocalAmount(
+          minViableTransfer,
+          sourceToken,
+        ),
         canFullyFulfill: maxTransferable >= requestedLocalAmount,
         canPartialFulfill: maxTransferable >= minViableTransfer,
+        totalInventory: totalInventory.toString(),
       },
       'Calculated max transferable amount with cost-based threshold',
     );
@@ -1395,9 +1418,18 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           originalAmount: targetOutputAmount.toString(),
           effectiveAmount: effectiveTargetOutput.toString(),
           minViableTransfer: minViableTransfer.toString(),
-          originalAmountEth: (Number(targetOutputAmount) / 1e18).toFixed(6),
-          effectiveAmountEth: (Number(effectiveTargetOutput) / 1e18).toFixed(6),
-          minViableTransferEth: (Number(minViableTransfer) / 1e18).toFixed(6),
+          originalAmountFormatted: this.formatLocalAmount(
+            targetOutputAmount,
+            targetToken,
+          ),
+          effectiveAmountFormatted: this.formatLocalAmount(
+            effectiveTargetOutput,
+            targetToken,
+          ),
+          minViableTransferFormatted: this.formatLocalAmount(
+            minViableTransfer,
+            targetToken,
+          ),
           adjustedUp: true,
           intentId: intent.id,
         },
@@ -1432,17 +1464,26 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           sourceChainId,
           targetChainId,
           requestedTargetOutput: targetOutputAmount.toString(),
-          requestedTargetOutputEth: (Number(targetOutputAmount) / 1e18).toFixed(
-            6,
+          requestedTargetOutputFormatted: this.formatLocalAmount(
+            targetOutputAmount,
+            targetToken,
           ),
           effectiveTargetOutput: effectiveTargetOutput.toString(),
-          effectiveTargetOutputEth: (
-            Number(effectiveTargetOutput) / 1e18
-          ).toFixed(6),
+          effectiveTargetOutputFormatted: this.formatLocalAmount(
+            effectiveTargetOutput,
+            targetToken,
+          ),
           inputRequired: inputRequired.toString(),
+          inputRequiredFormatted: this.formatLocalAmount(
+            inputRequired,
+            sourceToken,
+          ),
           expectedOutput: quote.toAmount.toString(),
           expectedOutputMin: quote.toAmountMin.toString(),
-          expectedOutputEth: (Number(quote.toAmount) / 1e18).toFixed(6),
+          expectedOutputFormatted: this.formatLocalAmount(
+            quote.toAmount,
+            targetToken,
+          ),
           gasCosts: quote.gasCosts.toString(),
           feeCosts: quote.feeCosts.toString(),
           intentId: intent.id,

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -900,10 +900,12 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     }
 
     // Create bridge plans using destination-local output amounts.
+    const shortfall =
+      requestedLocalAmount > availableInventory
+        ? requestedLocalAmount - availableInventory
+        : 0n;
     const targetWithBuffer =
-      ((requestedLocalAmount + costs.totalCost) *
-        (100n + BRIDGE_BUFFER_PERCENT)) /
-      100n;
+      ((shortfall + costs.totalCost) * (100n + BRIDGE_BUFFER_PERCENT)) / 100n;
     const bridgePlans: Array<{
       chain: ChainName;
       maxSourceInput: bigint;
@@ -942,6 +944,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           targetOutput: p.targetOutput.toString(),
         })),
         totalPlanned: totalPlanned.toString(),
+        shortfall: shortfall.toString(),
         targetWithBuffer: targetWithBuffer.toString(),
         intentId: intent.id,
       },

--- a/typescript/rebalancer/src/core/Rebalancer.test.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.test.ts
@@ -337,6 +337,43 @@ describe('Rebalancer', () => {
       expect(results).to.have.lengthOf(1);
       expect(results[0].success).to.be.false;
     });
+
+    it('should denormalize canonical route amounts before quote and populate calls', async () => {
+      const ctx = createRebalancerTestContext(['ethereum', 'arbitrum']);
+      ctx.tokensByChainName.ethereum.scale = {
+        numerator: 1,
+        denominator: 1_000_000_000_000,
+      };
+
+      sandbox.stub(HyperlaneCore, 'getDispatchedMessages').returns([
+        {
+          id: '0x1111111111111111111111111111111111111111111111111111111111111111',
+        } as any,
+      ]);
+
+      const rebalancer = new Rebalancer(
+        ctx.warpCore,
+        ctx.chainMetadata,
+        ctx.tokensByChainName,
+        ctx.multiProvider as any,
+        createMockActionTracker(),
+        testLogger,
+      );
+
+      await rebalancer.rebalance([
+        buildTestMovableCollateralRoute({
+          amount: 1_000_000n,
+        }),
+      ]);
+
+      expect(ctx.adapters.ethereum.getRebalanceQuotes.calledOnce).to.be.true;
+      expect(
+        ctx.adapters.ethereum.getRebalanceQuotes.firstCall.args[3],
+      ).to.equal(1_000_000_000_000_000_000n);
+      expect(
+        ctx.adapters.ethereum.populateRebalanceTx.firstCall.args[1],
+      ).to.equal(1_000_000_000_000_000_000n);
+    });
   });
 
   describe('executeTransactions()', () => {

--- a/typescript/rebalancer/src/core/Rebalancer.test.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.test.ts
@@ -229,6 +229,53 @@ describe('Rebalancer', () => {
       expect(results[0].success).to.be.false;
     });
 
+    it('should log scaled route amounts using origin local units', async () => {
+      const ctx = createRebalancerTestContext(['ethereum']);
+      ctx.tokensByChainName.ethereum.scale = {
+        numerator: 1,
+        denominator: 1_000_000_000_000,
+      };
+
+      const logger = {
+        child: Sinon.stub(),
+        info: Sinon.stub(),
+        warn: Sinon.stub(),
+        error: Sinon.stub(),
+      };
+      logger.child.returns(logger);
+
+      const rebalancer = new Rebalancer(
+        ctx.warpCore,
+        ctx.chainMetadata,
+        ctx.tokensByChainName,
+        ctx.multiProvider as any,
+        createMockActionTracker(),
+        logger as any,
+      );
+
+      const route = buildTestMovableCollateralRoute({
+        origin: 'ethereum',
+        destination: 'arbitrum',
+        amount: 1_000_000n,
+      });
+      const results = await rebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.false;
+      const validationErrorCall = logger.error
+        .getCalls()
+        .find(
+          (call) =>
+            call.args[1] ===
+            'Route validation failed: destination token not found.',
+        );
+      expect(validationErrorCall).to.not.be.undefined;
+      expect(validationErrorCall!.args[0].amount).to.equal('1.0');
+      expect(validationErrorCall!.args[1]).to.equal(
+        'Route validation failed: destination token not found.',
+      );
+    });
+
     it('should fail when signer is not a rebalancer', async () => {
       const ctx = createRebalancerTestContext(['ethereum', 'arbitrum'], {
         ethereum: { isRebalancer: false },

--- a/typescript/rebalancer/src/core/Rebalancer.test.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.test.ts
@@ -270,7 +270,7 @@ describe('Rebalancer', () => {
             'Route validation failed: destination token not found.',
         );
       expect(validationErrorCall).to.not.be.undefined;
-      expect(validationErrorCall!.args[0].amount).to.equal('1.0');
+      expect(validationErrorCall!.args[0].amount).to.equal(1);
       expect(validationErrorCall!.args[1]).to.equal(
         'Route validation failed: destination token not found.',
       );

--- a/typescript/rebalancer/src/core/Rebalancer.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.ts
@@ -25,10 +25,12 @@ import { MovableCollateralRoute } from '../interfaces/IStrategy.js';
 import { type Metrics } from '../metrics/Metrics.js';
 import type { IActionTracker } from '../tracking/IActionTracker.js';
 import type { RebalanceIntent } from '../tracking/types.js';
+import { denormalizeToLocal } from '../utils/balanceUtils.js';
 
 // Internal types with intentId for tracking
 type InternalExecutionResult = MovableCollateralExecutionResult & {
   intentId: string;
+  localAmount?: bigint;
 };
 
 type InternalRoute = MovableCollateralRoute & { intentId: string };
@@ -104,7 +106,10 @@ export class Rebalancer implements IMovableCollateralRebalancer {
         if (token) {
           this.metrics.recordRebalanceAmount(
             result.route,
-            token.amount(result.route.amount),
+            token.amount(
+              result.localAmount ??
+                denormalizeToLocal(result.route.amount, token),
+            ),
           );
         }
       }
@@ -264,8 +269,9 @@ export class Rebalancer implements IMovableCollateralRebalancer {
     const originToken = this.tokensByChainName[origin];
     const destinationToken = this.tokensByChainName[destination];
     const destinationChainMeta = this.chainMetadata[destination];
+    const localAmount = denormalizeToLocal(amount, originToken);
 
-    const originTokenAmount = originToken.amount(amount);
+    const originTokenAmount = originToken.amount(localAmount);
     const decimalFormattedAmount =
       originTokenAmount.getDecimalFormattedAmount();
     const originHypAdapter = originToken.getHypAdapter(
@@ -281,7 +287,7 @@ export class Rebalancer implements IMovableCollateralRebalancer {
         bridge,
         destinationChainMeta.domainId,
         destinationToken.addressOrDenom,
-        amount,
+        localAmount,
       );
     } catch (error) {
       this.logger.error(
@@ -302,7 +308,7 @@ export class Rebalancer implements IMovableCollateralRebalancer {
     try {
       populatedTx = await originHypAdapter.populateRebalanceTx(
         destinationChainMeta.domainId,
-        amount,
+        localAmount,
         bridge,
         quotes,
       );
@@ -676,6 +682,7 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       success: true,
       messageId: dispatchedMessages[0].id,
       txHash: receipt.transactionHash,
+      localAmount: transaction.originTokenAmount.amount,
     };
   }
 

--- a/typescript/rebalancer/src/core/Rebalancer.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.ts
@@ -25,11 +25,15 @@ import { MovableCollateralRoute } from '../interfaces/IStrategy.js';
 import { type Metrics } from '../metrics/Metrics.js';
 import type { IActionTracker } from '../tracking/IActionTracker.js';
 import type { RebalanceIntent } from '../tracking/types.js';
-import { denormalizeToLocal } from '../utils/balanceUtils.js';
+import {
+  denormalizeToLocal,
+  normalizeToCanonical,
+} from '../utils/balanceUtils.js';
 
 // Internal types with intentId for tracking
 type InternalExecutionResult = MovableCollateralExecutionResult & {
   intentId: string;
+  canonicalAmount?: bigint;
   localAmount?: bigint;
 };
 
@@ -155,7 +159,7 @@ export class Rebalancer implements IMovableCollateralRebalancer {
           intentId,
           origin: this.multiProvider.getDomainId(result.route.origin),
           destination: this.multiProvider.getDomainId(result.route.destination),
-          amount: result.route.amount,
+          amount: result.canonicalAmount ?? result.route.amount,
           type: 'rebalance_message',
           messageId: result.messageId,
           txHash: result.txHash,
@@ -682,6 +686,10 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       success: true,
       messageId: dispatchedMessages[0].id,
       txHash: receipt.transactionHash,
+      canonicalAmount: normalizeToCanonical(
+        transaction.originTokenAmount.amount,
+        transaction.originTokenAmount.token,
+      ),
       localAmount: transaction.originTokenAmount.amount,
     };
   }

--- a/typescript/rebalancer/src/core/Rebalancer.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.ts
@@ -347,7 +347,8 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       return false;
     }
 
-    const originTokenAmount = originToken.amount(amount);
+    const localAmount = denormalizeToLocal(amount, originToken);
+    const originTokenAmount = originToken.amount(localAmount);
     const decimalFormattedAmount =
       originTokenAmount.getDecimalFormattedAmount();
 

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
@@ -646,7 +646,6 @@ describe('RebalancerOrchestrator', () => {
       expect(inventoryRebalancer.rebalance.calledWith([])).to.be.false;
     });
 
-    // eslint-disable-next-line jest/expect-expect
     it('should NOT call inventoryRebalancer.rebalance([]) when inventoryRebalancer is not in rebalancers', async () => {
       const strategy = createMockStrategy();
       strategy.getRebalancingRoutes.returns([]);

--- a/typescript/rebalancer/src/core/RebalancerService.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerService.test.ts
@@ -366,6 +366,41 @@ describe('RebalancerService', () => {
       expect(calledRoutes[0].destination).to.equal('arbitrum');
     });
 
+    it('should normalize manual amount to canonical units when token has scale', async () => {
+      const rebalancer = createMockRebalancer();
+      const warpCore = {
+        tokens: [
+          {
+            ...createMockToken('ethereum'),
+            decimals: 18,
+            scale: { numerator: 1n, denominator: 1_000_000_000_000n },
+          },
+          createMockToken('arbitrum'),
+        ],
+        multiProvider: createMockMultiProvider(),
+      } as unknown as WarpCore;
+
+      const contextFactory = createMockContextFactory({ rebalancer, warpCore });
+      sandbox.stub(RebalancerContextFactory, 'create').resolves(contextFactory);
+
+      const service = new RebalancerService(
+        createMockMultiProvider(),
+        undefined,
+        {} as any,
+        createMockRebalancerConfig(),
+        { mode: 'manual', logger: testLogger },
+      );
+
+      await service.executeManual({
+        origin: 'ethereum',
+        destination: 'arbitrum',
+        amount: '1',
+      });
+
+      const calledRoutes = rebalancer.rebalance.firstCall.args[0];
+      expect(calledRoutes[0].amount).to.equal(1_000_000n);
+    });
+
     it('should throw when origin token not found', async () => {
       const warpCore = {
         tokens: [createMockToken('arbitrum')],

--- a/typescript/rebalancer/src/core/RebalancerService.ts
+++ b/typescript/rebalancer/src/core/RebalancerService.ts
@@ -1,9 +1,12 @@
 import { Logger } from 'pino';
 
 import { IRegistry } from '@hyperlane-xyz/registry';
-import { type MultiProvider, Token } from '@hyperlane-xyz/sdk';
-import type { MultiProviderAdapter } from '@hyperlane-xyz/sdk/providers/MultiProviderAdapter';
-import { ProtocolType, assert, toWei } from '@hyperlane-xyz/utils';
+import {
+  type MultiProtocolProvider,
+  type MultiProvider,
+  Token,
+} from '@hyperlane-xyz/sdk';
+import { ProtocolType, assert } from '@hyperlane-xyz/utils';
 
 import { RebalancerConfig } from '../config/RebalancerConfig.js';
 import {
@@ -27,6 +30,7 @@ import { Metrics } from '../metrics/Metrics.js';
 import { type InventoryMonitorConfig, Monitor } from '../monitor/Monitor.js';
 import type { IActionTracker } from '../tracking/IActionTracker.js';
 import { InflightContextAdapter } from '../tracking/InflightContextAdapter.js';
+import { normalizeConfiguredAmount } from '../utils/balanceUtils.js';
 
 import type { RebalancerOrchestrator } from './RebalancerOrchestrator.js';
 
@@ -121,7 +125,7 @@ export class RebalancerService {
   private orchestrator?: RebalancerOrchestrator;
   constructor(
     private readonly multiProvider: MultiProvider,
-    private readonly multiProtocolProvider: MultiProviderAdapter | undefined,
+    private readonly multiProtocolProvider: MultiProtocolProvider | undefined,
     private readonly registry: IRegistry,
     private readonly rebalancerConfig: RebalancerConfig,
     private readonly config: RebalancerServiceConfig,
@@ -293,7 +297,7 @@ export class RebalancerService {
       const manualRoute: MovableCollateralRoute & { intentId: string } = {
         origin,
         destination,
-        amount: BigInt(toWei(amount, originToken.decimals)),
+        amount: normalizeConfiguredAmount(amount, originToken),
         executionType: 'movableCollateral',
         bridge,
         intentId: `manual-${Date.now()}`,

--- a/typescript/rebalancer/src/e2e/harness/TestHelpers.ts
+++ b/typescript/rebalancer/src/e2e/harness/TestHelpers.ts
@@ -25,10 +25,9 @@ export async function getFirstMonitorEvent(
   return new Promise((resolve, reject) => {
     let settled = false;
 
-    async function finalize(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      cb: (v: any) => void,
-      value: unknown,
+    async function finalize<T>(
+      cb: (v: T) => void,
+      value: T,
       timer: ReturnType<typeof setTimeout>,
     ) {
       if (settled) return;

--- a/typescript/rebalancer/src/e2e/harness/TestHelpers.ts
+++ b/typescript/rebalancer/src/e2e/harness/TestHelpers.ts
@@ -26,7 +26,8 @@ export async function getFirstMonitorEvent(
     let settled = false;
 
     async function finalize(
-      cb: (v: any) => void, // eslint-disable-line @typescript-eslint/no-explicit-any -- accepts both resolve and reject
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cb: (v: any) => void,
       value: unknown,
       timer: ReturnType<typeof setTimeout>,
     ) {

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
@@ -340,10 +340,67 @@ describe('RebalancerContextFactory', () => {
             : ProtocolType.Ethereum,
       }));
 
-      await expect(
-        (factory as any).createInventoryRebalancerAndConfig({} as any, {}),
-      ).to.be.rejectedWith(
+      let error: Error | undefined;
+      try {
+        await (factory as any).createInventoryRebalancerAndConfig(
+          {} as any,
+          {},
+        );
+      } catch (caught) {
+        error = caught as Error;
+      }
+
+      expect(error?.message).to.contain(
         `Missing inventory signer key for protocol ${ProtocolType.Sealevel}`,
+      );
+    });
+
+    it('should fail early when an inventory-relevant chain has no token', async () => {
+      const { multiProvider } = createMockMultiProvider([
+        { name: 'ethereum', protocol: ProtocolType.Ethereum },
+        { name: 'arbitrum', protocol: ProtocolType.Ethereum },
+      ]);
+
+      const config = {
+        ...createMockConfig(),
+        inventorySigners: {
+          [ProtocolType.Ethereum]: {
+            address: TEST_ADDRESSES.ethereum,
+            key: '0xabc123',
+          },
+        },
+      } as RebalancerConfig;
+      config.strategyConfig[0].chains.arbitrum.executionType =
+        ExecutionType.Inventory;
+
+      const factory = await createFactory(config, multiProvider, {
+        tokens: [
+          createToken(
+            'ethereum',
+            TEST_ADDRESSES.ethereum,
+            TokenStandard.EvmHypCollateral,
+          ),
+        ],
+      });
+
+      const getChainMetadataStub = factory.getWarpCore().multiProvider
+        .getChainMetadata as Sinon.SinonStub;
+      getChainMetadataStub.callsFake(() => ({
+        protocol: ProtocolType.Ethereum,
+      }));
+
+      let error: Error | undefined;
+      try {
+        await (factory as any).createInventoryRebalancerAndConfig(
+          {} as any,
+          {},
+        );
+      } catch (caught) {
+        error = caught as Error;
+      }
+
+      expect(error?.message).to.equal(
+        'No token found for inventory-relevant chain arbitrum in warp route USDC/paradex',
       );
     });
 
@@ -414,9 +471,17 @@ describe('RebalancerContextFactory', () => {
             : ProtocolType.Ethereum,
       }));
 
-      await expect(
-        (factory as any).createInventoryRebalancerAndConfig({} as any, {}),
-      ).to.be.rejectedWith(
+      let error: Error | undefined;
+      try {
+        await (factory as any).createInventoryRebalancerAndConfig(
+          {} as any,
+          {},
+        );
+      } catch (caught) {
+        error = caught as Error;
+      }
+
+      expect(error?.message).to.contain(
         `Inventory rebalancing does not support protocol '${ProtocolType.Cosmos}'`,
       );
     });

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
@@ -277,6 +277,48 @@ describe('RebalancerContextFactory', () => {
       );
     });
 
+    it('should fail fast when bridged supply is unavailable during initial collateral calculation', async () => {
+      const { multiProvider } = createMockMultiProvider([
+        { name: 'ethereum', protocol: ProtocolType.Ethereum },
+        { name: 'arbitrum', protocol: ProtocolType.Ethereum },
+      ]);
+
+      const factory = await createFactory(createMockConfig(), multiProvider, {
+        tokens: [
+          createToken(
+            'ethereum',
+            TEST_ADDRESSES.ethereum,
+            TokenStandard.EvmHypCollateral,
+          ),
+          createToken(
+            'arbitrum',
+            TEST_ADDRESSES.arbitrum,
+            TokenStandard.EvmHypSynthetic,
+          ),
+        ],
+      });
+
+      const collateralToken = factory
+        .getWarpCore()
+        .tokens.find((token) => token.chainName === 'ethereum');
+      assert(collateralToken, 'Expected ethereum collateral token in test');
+
+      sandbox.stub(collateralToken, 'getHypAdapter').returns({
+        getBridgedSupply: sandbox.stub().resolves(undefined),
+      } as any);
+
+      let error: Error | undefined;
+      try {
+        await factory.createStrategy();
+      } catch (caught) {
+        error = caught as Error;
+      }
+
+      expect(error?.message).to.equal(
+        'Missing bridged supply for ethereum while computing initial total collateral for warp route USDC/paradex',
+      );
+    });
+
     it('should fail early when inventory override origin protocol signer key is missing', async () => {
       const sealevelChain = 'solana';
       const evmChain = 'ethereum';

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
@@ -247,6 +247,36 @@ describe('RebalancerContextFactory', () => {
       expect(providerChains).to.include('arbitrum');
     });
 
+    it('should fail fast when bridgeMinAcceptedAmount is configured for a chain without a token', async () => {
+      const { multiProvider } = createMockMultiProvider([
+        { name: 'ethereum', protocol: ProtocolType.Ethereum },
+        { name: 'arbitrum', protocol: ProtocolType.Ethereum },
+      ]);
+
+      const config = createMockConfig();
+      config.strategyConfig[0].chains.arbitrum.bridgeMinAcceptedAmount = 1;
+
+      let error: Error | undefined;
+      try {
+        const factory = await createFactory(config, multiProvider, {
+          tokens: [
+            createToken(
+              'ethereum',
+              TEST_ADDRESSES.ethereum,
+              TokenStandard.EvmHypCollateral,
+            ),
+          ],
+        } as WarpCoreConfig);
+        await factory.createStrategy();
+      } catch (caught) {
+        error = caught as Error;
+      }
+
+      expect(error?.message).to.equal(
+        'No token found for configured strategy chain arbitrum in warp route USDC/paradex',
+      );
+    });
+
     it('should fail early when inventory override origin protocol signer key is missing', async () => {
       const sealevelChain = 'solana';
       const evmChain = 'ethereum';

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -250,7 +250,10 @@ export class RebalancerContextFactory {
       );
       if (chainConfig?.bridgeMinAcceptedAmount) {
         const token = this.tokensByChainName[chainName];
-        if (!token) continue;
+        assert(
+          token,
+          `No token found for configured strategy chain ${chainName} in warp route ${this.config.warpRouteId}`,
+        );
         minAmountsByChain[chainName] = normalizeConfiguredAmount(
           chainConfig.bridgeMinAcceptedAmount,
           token,

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -11,14 +11,7 @@ import {
   WarpCore,
   type WarpCoreConfig,
 } from '@hyperlane-xyz/sdk';
-import type { MultiProviderAdapter } from '@hyperlane-xyz/sdk/providers/MultiProviderAdapter';
-import {
-  Address,
-  assert,
-  ProtocolType,
-  objMap,
-  toWei,
-} from '@hyperlane-xyz/utils';
+import { Address, assert, ProtocolType, objMap } from '@hyperlane-xyz/utils';
 
 import { LiFiBridge } from '../bridges/LiFiBridge.js';
 import { type RebalancerConfig } from '../config/RebalancerConfig.js';
@@ -64,6 +57,10 @@ import {
   ExplorerClient,
   type IExplorerClient,
 } from '../utils/ExplorerClient.js';
+import {
+  normalizeConfiguredAmount,
+  normalizeToCanonical,
+} from '../utils/balanceUtils.js';
 import { isCollateralizedTokenEligibleForRebalancing } from '../utils/tokenUtils.js';
 
 const DEFAULT_EXPLORER_URL =
@@ -75,7 +72,7 @@ export class RebalancerContextFactory {
    * @param warpCore - An instance of `WarpCore` configured for the specified `warpRouteId`.
    * @param tokensByChainName - A map of chain->token to ease the lookup of token by chain
    * @param multiProvider - MultiProvider instance (for movable collateral operations)
-   * @param multiProtocolProvider - MultiProviderAdapter instance (with mailbox metadata)
+   * @param multiProtocolProvider - MultiProtocolProvider instance (with mailbox metadata)
    * @param registry - IRegistry instance
    * @param logger - Logger instance
    */
@@ -84,7 +81,7 @@ export class RebalancerContextFactory {
     private readonly warpCore: WarpCore,
     private readonly tokensByChainName: ChainMap<Token>,
     private readonly multiProvider: MultiProvider,
-    private readonly multiProtocolProvider: MultiProviderAdapter,
+    private readonly multiProtocolProvider: MultiProtocolProvider,
     private readonly registry: IRegistry,
     private readonly logger: Logger,
     private readonly inventorySignerKeysByProtocol?: Partial<
@@ -95,14 +92,14 @@ export class RebalancerContextFactory {
   /**
    * @param config - The rebalancer config
    * @param multiProvider - MultiProvider instance (for movable collateral operations)
-   * @param multiProtocolProvider - MultiProviderAdapter instance (optional, created from multiProvider if not provided)
+   * @param multiProtocolProvider - MultiProtocolProvider instance (optional, created from multiProvider if not provided)
    * @param registry - IRegistry instance
    * @param logger - Logger instance
    */
   public static async create(
     config: RebalancerConfig,
     multiProvider: MultiProvider,
-    multiProtocolProvider: MultiProviderAdapter | undefined,
+    multiProtocolProvider: MultiProtocolProvider | undefined,
     registry: IRegistry,
     logger: Logger,
     inventorySignerKeysByProtocol?: Partial<Record<ProtocolType, string>>,
@@ -147,7 +144,7 @@ export class RebalancerContextFactory {
       multiProvider.getProvider(chain);
     }
 
-    // Create MultiProviderAdapter (convert from MultiProvider if not provided)
+    // Create MultiProtocolProvider (convert from MultiProvider if not provided)
     const mpp =
       multiProtocolProvider ??
       MultiProtocolProvider.fromMultiProvider(multiProvider);
@@ -253,9 +250,10 @@ export class RebalancerContextFactory {
       );
       if (chainConfig?.bridgeMinAcceptedAmount) {
         const token = this.tokensByChainName[chainName];
-        const decimals = token?.decimals ?? 18;
-        minAmountsByChain[chainName] = BigInt(
-          toWei(chainConfig.bridgeMinAcceptedAmount, decimals),
+        if (!token) continue;
+        minAmountsByChain[chainName] = normalizeConfiguredAmount(
+          chainConfig.bridgeMinAcceptedAmount,
+          token,
         );
       }
     }
@@ -762,7 +760,10 @@ export class RebalancerContextFactory {
         ) {
           const adapter = token.getHypAdapter(this.warpCore.multiProvider);
           const bridgedSupply = await adapter.getBridgedSupply();
-          initialTotalCollateral += bridgedSupply ?? 0n;
+          initialTotalCollateral += normalizeToCanonical(
+            bridgedSupply ?? 0n,
+            token,
+          );
         }
       }),
     );

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -461,6 +461,13 @@ export class RebalancerContextFactory {
       return null;
     }
 
+    for (const chain of allRelevantChains) {
+      assert(
+        this.tokensByChainName[chain],
+        `No token found for inventory-relevant chain ${chain} in warp route ${this.config.warpRouteId}`,
+      );
+    }
+
     const requiredProtocols = new Set(
       allRelevantChains.map((chain) => {
         const metadata = this.warpCore.multiProvider.getChainMetadata(chain);

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -770,10 +770,11 @@ export class RebalancerContextFactory {
         ) {
           const adapter = token.getHypAdapter(this.warpCore.multiProvider);
           const bridgedSupply = await adapter.getBridgedSupply();
-          initialTotalCollateral += normalizeToCanonical(
-            bridgedSupply ?? 0n,
-            token,
+          assert(
+            bridgedSupply !== undefined,
+            `Missing bridged supply for ${token.chainName} while computing initial total collateral for warp route ${this.config.warpRouteId}`,
           );
+          initialTotalCollateral += normalizeToCanonical(bridgedSupply, token);
         }
       }),
     );

--- a/typescript/rebalancer/src/interfaces/IRebalancer.ts
+++ b/typescript/rebalancer/src/interfaces/IRebalancer.ts
@@ -1,5 +1,6 @@
 import {
   type EvmMovableCollateralAdapter,
+  type IToken,
   type TokenAmount,
 } from '@hyperlane-xyz/sdk';
 
@@ -48,10 +49,12 @@ export type IInventoryRebalancer = IRebalancer<
   InventoryExecutionResult
 >;
 
+type PreparedOriginTokenAmount = TokenAmount & { token: IToken };
+
 export type PreparedTransaction = {
   populatedTx: Awaited<
     ReturnType<EvmMovableCollateralAdapter['populateRebalanceTx']>
   >;
   route: MovableCollateralRoute & { intentId: string };
-  originTokenAmount: TokenAmount;
+  originTokenAmount: PreparedOriginTokenAmount;
 };

--- a/typescript/rebalancer/src/interfaces/IRebalancer.ts
+++ b/typescript/rebalancer/src/interfaces/IRebalancer.ts
@@ -49,7 +49,7 @@ export type IInventoryRebalancer = IRebalancer<
   InventoryExecutionResult
 >;
 
-type PreparedOriginTokenAmount = TokenAmount & { token: IToken };
+type PreparedOriginTokenAmount = TokenAmount<IToken>;
 
 export type PreparedTransaction = {
   populatedTx: Awaited<

--- a/typescript/rebalancer/src/monitor/Monitor.ts
+++ b/typescript/rebalancer/src/monitor/Monitor.ts
@@ -143,23 +143,26 @@ export class Monitor implements IMonitor {
             const tokensByChain = new Map(
               this.warpCore.tokens.map((token) => [token.chainName, token]),
             );
+            // CAST: inventoryBalances keys come from configured monitor chains,
+            // but Object.entries widens them to string.
+            const inventoryBalanceEntries = Object.entries(
+              inventoryBalances,
+            ) as [ChainName, bigint][];
             this.logger.info(
               {
                 chainsMonitored: Object.keys(inventoryBalances).length,
-                balances: Object.entries(inventoryBalances).map(
-                  ([chain, balance]) => {
-                    const token = tokensByChain.get(chain as ChainName);
-                    return {
-                      chain,
-                      tokenSymbol: token?.symbol,
-                      balance: balance.toString(),
-                      balanceFormatted: fromWei(
-                        balance.toString(),
-                        token?.decimals,
-                      ),
-                    };
-                  },
-                ),
+                balances: inventoryBalanceEntries.map(([chain, balance]) => {
+                  const token = tokensByChain.get(chain);
+                  return {
+                    chain,
+                    tokenSymbol: token?.symbol,
+                    balance: balance.toString(),
+                    balanceFormatted: fromWei(
+                      balance.toString(),
+                      token?.decimals,
+                    ),
+                  };
+                }),
               },
               'Inventory balances fetched',
             );

--- a/typescript/rebalancer/src/monitor/Monitor.ts
+++ b/typescript/rebalancer/src/monitor/Monitor.ts
@@ -6,7 +6,7 @@ import {
   type Token,
   type WarpCore,
 } from '@hyperlane-xyz/sdk';
-import { Address, ProtocolType, sleep } from '@hyperlane-xyz/utils';
+import { Address, ProtocolType, fromWei, sleep } from '@hyperlane-xyz/utils';
 
 import {
   type ConfirmedBlockTag,
@@ -140,15 +140,25 @@ export class Monitor implements IMonitor {
           const inventoryBalances = await this.fetchInventoryBalances();
           if (Object.keys(inventoryBalances).length > 0) {
             event.inventoryBalances = inventoryBalances;
+            const tokensByChain = new Map(
+              this.warpCore.tokens.map((token) => [token.chainName, token]),
+            );
             this.logger.info(
               {
                 chainsMonitored: Object.keys(inventoryBalances).length,
                 balances: Object.entries(inventoryBalances).map(
-                  ([chain, balance]) => ({
-                    chain,
-                    balance: balance.toString(),
-                    balanceEth: (Number(balance) / 1e18).toFixed(6),
-                  }),
+                  ([chain, balance]) => {
+                    const token = tokensByChain.get(chain as ChainName);
+                    return {
+                      chain,
+                      tokenSymbol: token?.symbol,
+                      balance: balance.toString(),
+                      balanceFormatted: fromWei(
+                        balance.toString(),
+                        token?.decimals,
+                      ),
+                    };
+                  },
                 ),
               },
               'Inventory balances fetched',

--- a/typescript/rebalancer/src/strategy/BaseStrategy.ts
+++ b/typescript/rebalancer/src/strategy/BaseStrategy.ts
@@ -1,7 +1,6 @@
 import { type Logger } from 'pino';
 
 import type { ChainMap, ChainName, Token } from '@hyperlane-xyz/sdk';
-import { toWei } from '@hyperlane-xyz/utils';
 
 import type {
   IStrategy,
@@ -18,6 +17,7 @@ import {
   createStrategyRoute,
   getBridgeConfig,
 } from '../utils/bridgeUtils.js';
+import { normalizeConfiguredAmount } from '../utils/balanceUtils.js';
 
 export type Delta = { chain: ChainName; amount: bigint };
 
@@ -528,21 +528,24 @@ export abstract class BaseStrategy implements IStrategy {
             route.origin,
             route.destination,
           );
-          const minAmount = BigInt(
-            toWei(bridgeConfig.bridgeMinAcceptedAmount, token.decimals),
-          );
-          if (route.amount < minAmount) {
-            this.logger.info(
-              {
-                context: this.constructor.name,
-                origin: route.origin,
-                destination: route.destination,
-                amount: route.amount.toString(),
-                minAmount: minAmount.toString(),
-              },
-              'Dropping route below bridgeMinAcceptedAmount',
+          if (bridgeConfig.bridgeMinAcceptedAmount != null) {
+            const minAmount = normalizeConfiguredAmount(
+              bridgeConfig.bridgeMinAcceptedAmount,
+              token,
             );
-            return false;
+            if (route.amount < minAmount) {
+              this.logger.info(
+                {
+                  context: this.constructor.name,
+                  origin: route.origin,
+                  destination: route.destination,
+                  amount: route.amount.toString(),
+                  minAmount: minAmount.toString(),
+                },
+                'Dropping route below bridgeMinAcceptedAmount',
+              );
+              return false;
+            }
           }
         }
       }

--- a/typescript/rebalancer/src/strategy/CollateralDeficitStrategy.ts
+++ b/typescript/rebalancer/src/strategy/CollateralDeficitStrategy.ts
@@ -1,7 +1,6 @@
 import { Logger } from 'pino';
 
 import { type ChainMap, type ChainName, type Token } from '@hyperlane-xyz/sdk';
-import { toWei } from '@hyperlane-xyz/utils';
 
 import {
   type CollateralDeficitStrategyConfig,
@@ -20,6 +19,7 @@ import {
   isInventoryConfig,
   isMovableCollateralConfig,
 } from '../utils/bridgeUtils.js';
+import { normalizeConfiguredAmount } from '../utils/balanceUtils.js';
 
 import { BaseStrategy, type Delta } from './BaseStrategy.js';
 
@@ -102,8 +102,9 @@ export class CollateralDeficitStrategy extends BaseStrategy {
     for (const chain of this.chains) {
       const balance = simulatedBalances[chain];
       const token = this.getTokenByChainName(chain);
-      const bufferWei = BigInt(
-        toWei(this.config[chain].buffer, token.decimals),
+      const bufferWei = normalizeConfiguredAmount(
+        this.config[chain].buffer,
+        token,
       );
 
       if (balance < 0n) {

--- a/typescript/rebalancer/src/strategy/MinAmountStrategy.test.ts
+++ b/typescript/rebalancer/src/strategy/MinAmountStrategy.test.ts
@@ -567,7 +567,55 @@ describe('MinAmountStrategy', () => {
             {},
           ),
       ).to.throw(
-        `Consider reducing the targets as the canonical sum (340000000000000000000) is greater than sum of collaterals (300000000000000000000)`,
+        `Consider reducing the targets as the sum (340) is greater than sum of collaterals (300)`,
+      );
+    });
+
+    it('should keep minAmount validation errors human-readable for mixed-decimal routes', () => {
+      const mixedTokensByChainName: ChainMap<Token> = {
+        [chain1]: new Token({
+          ...tokenArgs,
+          chainName: chain1,
+          decimals: 18,
+          scale: { numerator: 1, denominator: 1_000_000_000_000 },
+        }),
+        [chain2]: new Token({
+          ...tokenArgs,
+          chainName: chain2,
+          decimals: 6,
+        }),
+      };
+
+      expect(
+        () =>
+          new MinAmountStrategy(
+            {
+              [chain1]: {
+                minAmount: {
+                  min: '100',
+                  target: '120',
+                  type: RebalancerMinAmountType.Absolute,
+                },
+                bridge: AddressZero,
+                bridgeLockTime: 1,
+              },
+              [chain2]: {
+                minAmount: {
+                  min: '100',
+                  target: '120',
+                  type: RebalancerMinAmountType.Absolute,
+                },
+                bridge: AddressZero,
+                bridgeLockTime: 1,
+              },
+            },
+            mixedTokensByChainName,
+            230_000_000n,
+            testLogger,
+            {},
+          ),
+      ).to.throw(
+        `Consider reducing the targets as the sum (240) is greater than sum of collaterals (230)`,
       );
     });
 

--- a/typescript/rebalancer/src/strategy/MinAmountStrategy.test.ts
+++ b/typescript/rebalancer/src/strategy/MinAmountStrategy.test.ts
@@ -64,7 +64,6 @@ describe('MinAmountStrategy', () => {
       ).to.throw('At least two chains must be configured');
     });
 
-    // eslint-disable-next-line jest/expect-expect -- testing constructor doesn't throw
     it('should create a strategy with minAmount and target using absolute values', () => {
       new MinAmountStrategy(
         {
@@ -94,7 +93,6 @@ describe('MinAmountStrategy', () => {
       );
     });
 
-    // eslint-disable-next-line jest/expect-expect -- testing constructor doesn't throw
     it('should create a strategy with minAmount and target using relative values', () => {
       new MinAmountStrategy(
         {
@@ -415,6 +413,65 @@ describe('MinAmountStrategy', () => {
       ]);
     });
 
+    it('should normalize absolute thresholds for mixed-decimal routes', () => {
+      const mixedTokensByChainName: ChainMap<Token> = {
+        [chain1]: new Token({
+          ...tokenArgs,
+          chainName: chain1,
+          decimals: 18,
+          scale: { numerator: 1, denominator: 1_000_000_000_000 },
+        }),
+        [chain2]: new Token({
+          ...tokenArgs,
+          chainName: chain2,
+          decimals: 6,
+        }),
+      };
+      const config = {
+        [chain1]: {
+          minAmount: {
+            min: '100',
+            target: '120',
+            type: RebalancerMinAmountType.Absolute,
+          },
+          bridge: AddressZero,
+          bridgeLockTime: 1,
+        },
+        [chain2]: {
+          minAmount: {
+            min: '100',
+            target: '120',
+            type: RebalancerMinAmountType.Absolute,
+          },
+          bridge: AddressZero,
+          bridgeLockTime: 1,
+        },
+      };
+
+      const strategy = new MinAmountStrategy(
+        config,
+        mixedTokensByChainName,
+        250_000_000n,
+        testLogger,
+        extractBridgeConfigs(config),
+      );
+
+      const routes = strategy.getRebalancingRoutes({
+        [chain1]: 50_000_000n,
+        [chain2]: 200_000_000n,
+      });
+
+      expect(routes).to.deep.equal([
+        {
+          origin: chain2,
+          destination: chain1,
+          amount: 70_000_000n,
+          bridge: AddressZero,
+          executionType: 'movableCollateral',
+        },
+      ]);
+    });
+
     it('should return multiple routes for multiple chains below minimum amount', () => {
       const config = {
         [chain1]: {
@@ -510,7 +567,7 @@ describe('MinAmountStrategy', () => {
             {},
           ),
       ).to.throw(
-        `Consider reducing the targets as the sum (340) is greater than sum of collaterals (300)`,
+        `Consider reducing the targets as the canonical sum (340000000000000000000) is greater than sum of collaterals (300000000000000000000)`,
       );
     });
 

--- a/typescript/rebalancer/src/strategy/MinAmountStrategy.test.ts
+++ b/typescript/rebalancer/src/strategy/MinAmountStrategy.test.ts
@@ -10,8 +10,10 @@ import {
 } from '@hyperlane-xyz/sdk';
 
 import { RebalancerMinAmountType } from '../config/types.js';
+import { type MonitorEvent } from '../interfaces/IMonitor.js';
 import type { RawBalances } from '../interfaces/IStrategy.js';
 import { extractBridgeConfigs } from '../test/helpers.js';
+import { getRawBalances } from '../utils/balanceUtils.js';
 
 import { MinAmountStrategy } from './MinAmountStrategy.js';
 
@@ -460,6 +462,87 @@ describe('MinAmountStrategy', () => {
         [chain1]: 50_000_000n,
         [chain2]: 200_000_000n,
       });
+
+      expect(routes).to.deep.equal([
+        {
+          origin: chain2,
+          destination: chain1,
+          amount: 70_000_000n,
+          bridge: AddressZero,
+          executionType: 'movableCollateral',
+        },
+      ]);
+    });
+
+    it('normalizes mixed-decimal local balances before routing', () => {
+      const mixedTokensByChainName: ChainMap<Token> = {
+        [chain1]: new Token({
+          ...tokenArgs,
+          chainName: chain1,
+          standard: TokenStandard.EvmHypCollateral,
+          decimals: 18,
+          scale: { numerator: 1, denominator: 1_000_000_000_000 },
+        }),
+        [chain2]: new Token({
+          ...tokenArgs,
+          chainName: chain2,
+          standard: TokenStandard.EvmHypCollateral,
+          decimals: 6,
+        }),
+      };
+      const config = {
+        [chain1]: {
+          minAmount: {
+            min: '100',
+            target: '120',
+            type: RebalancerMinAmountType.Absolute,
+          },
+          bridge: AddressZero,
+          bridgeLockTime: 1,
+        },
+        [chain2]: {
+          minAmount: {
+            min: '100',
+            target: '120',
+            type: RebalancerMinAmountType.Absolute,
+          },
+          bridge: AddressZero,
+          bridgeLockTime: 1,
+        },
+      };
+
+      const strategy = new MinAmountStrategy(
+        config,
+        mixedTokensByChainName,
+        250_000_000n,
+        testLogger,
+        extractBridgeConfigs(config),
+      );
+
+      const event: MonitorEvent = {
+        tokensInfo: [
+          {
+            token: mixedTokensByChainName[chain1],
+            bridgedSupply: 50_000_000_000_000_000_000n,
+          },
+          {
+            token: mixedTokensByChainName[chain2],
+            bridgedSupply: 200_000_000n,
+          },
+        ],
+        confirmedBlockTags: {
+          [chain1]: 1,
+          [chain2]: 1,
+        },
+      };
+
+      const rawBalances = getRawBalances([chain1, chain2], event, testLogger);
+      expect(rawBalances).to.deep.equal({
+        [chain1]: 50_000_000n,
+        [chain2]: 200_000_000n,
+      });
+
+      const routes = strategy.getRebalancingRoutes(rawBalances);
 
       expect(routes).to.deep.equal([
         {

--- a/typescript/rebalancer/src/strategy/MinAmountStrategy.test.ts
+++ b/typescript/rebalancer/src/strategy/MinAmountStrategy.test.ts
@@ -619,6 +619,54 @@ describe('MinAmountStrategy', () => {
       );
     });
 
+    it('should keep fractional minAmount validation errors human-readable across heterogeneous decimals', () => {
+      const mixedTokensByChainName: ChainMap<Token> = {
+        [chain1]: new Token({
+          ...tokenArgs,
+          chainName: chain1,
+          decimals: 6,
+        }),
+        [chain2]: new Token({
+          ...tokenArgs,
+          chainName: chain2,
+          decimals: 18,
+          scale: { numerator: 1, denominator: 1_000_000_000_000 },
+        }),
+      };
+
+      expect(
+        () =>
+          new MinAmountStrategy(
+            {
+              [chain1]: {
+                minAmount: {
+                  min: '100',
+                  target: '120.25',
+                  type: RebalancerMinAmountType.Absolute,
+                },
+                bridge: AddressZero,
+                bridgeLockTime: 1,
+              },
+              [chain2]: {
+                minAmount: {
+                  min: '100',
+                  target: '120.25',
+                  type: RebalancerMinAmountType.Absolute,
+                },
+                bridge: AddressZero,
+                bridgeLockTime: 1,
+              },
+            },
+            mixedTokensByChainName,
+            230_500_000n,
+            testLogger,
+            {},
+          ),
+      ).to.throw(
+        `Consider reducing the targets as the sum (240.5) is greater than sum of collaterals (230.5)`,
+      );
+    });
+
     it('should handle case where there is not enough surplus to meet all minimum requirements by scaling down deficits', () => {
       const config = {
         [chain1]: {

--- a/typescript/rebalancer/src/strategy/MinAmountStrategy.ts
+++ b/typescript/rebalancer/src/strategy/MinAmountStrategy.ts
@@ -2,7 +2,6 @@ import { BigNumber } from 'bignumber.js';
 import { type Logger } from 'pino';
 
 import { type ChainMap, type Token } from '@hyperlane-xyz/sdk';
-import { fromWei, toWei } from '@hyperlane-xyz/utils';
 
 import {
   type MinAmountStrategyConfig,
@@ -16,6 +15,7 @@ import type {
 } from '../interfaces/IStrategy.js';
 import { type Metrics } from '../metrics/Metrics.js';
 import type { BridgeConfigWithOverride } from '../utils/bridgeUtils.js';
+import { normalizeConfiguredAmount } from '../utils/balanceUtils.js';
 
 import { BaseStrategy, type Delta } from './BaseStrategy.js';
 
@@ -116,9 +116,13 @@ export class MinAmountStrategy extends BaseStrategy {
         if (chainConfig.minAmount.type === RebalancerMinAmountType.Absolute) {
           const token = this.getTokenByChainName(chain);
 
-          minAmount = BigInt(toWei(chainConfig.minAmount.min, token.decimals));
-          targetAmount = BigInt(
-            toWei(chainConfig.minAmount.target, token.decimals),
+          minAmount = normalizeConfiguredAmount(
+            chainConfig.minAmount.min,
+            token,
+          );
+          targetAmount = normalizeConfiguredAmount(
+            chainConfig.minAmount.target,
+            token,
           );
         } else {
           minAmount = BigInt(
@@ -172,27 +176,18 @@ export class MinAmountStrategy extends BaseStrategy {
 
     if (minAmountType === RebalancerMinAmountType.Absolute) {
       let totalTargets = 0n;
-      let decimals: number = 0;
 
       for (const chainName of this.chains) {
         const token = this.getTokenByChainName(chainName);
-        // all the tokens have the same amount of decimals
-        decimals = token.decimals;
-
-        totalTargets += BigInt(
-          toWei(config[chainName].minAmount.target, token.decimals),
+        totalTargets += normalizeConfiguredAmount(
+          config[chainName].minAmount.target,
+          token,
         );
       }
 
       if (totalTargets > totalCollateral) {
         throw new Error(
-          `Consider reducing the targets as the sum (${fromWei(
-            totalTargets.toString(),
-            decimals,
-          )}) is greater than sum of collaterals (${fromWei(
-            totalCollateral.toString(),
-            decimals,
-          )})`,
+          `Consider reducing the targets as the canonical sum (${totalTargets}) is greater than sum of collaterals (${totalCollateral})`,
         );
       }
     }

--- a/typescript/rebalancer/src/strategy/MinAmountStrategy.ts
+++ b/typescript/rebalancer/src/strategy/MinAmountStrategy.ts
@@ -1,7 +1,12 @@
 import { BigNumber } from 'bignumber.js';
 import { type Logger } from 'pino';
 
-import { type ChainMap, type Token } from '@hyperlane-xyz/sdk';
+import {
+  localAmountFromMessage,
+  type ChainMap,
+  type Token,
+} from '@hyperlane-xyz/sdk';
+import { fromWei } from '@hyperlane-xyz/utils';
 
 import {
   type MinAmountStrategyConfig,
@@ -176,6 +181,7 @@ export class MinAmountStrategy extends BaseStrategy {
 
     if (minAmountType === RebalancerMinAmountType.Absolute) {
       let totalTargets = 0n;
+      const displayToken = this.getTokenByChainName(this.chains[0]);
 
       for (const chainName of this.chains) {
         const token = this.getTokenByChainName(chainName);
@@ -187,9 +193,20 @@ export class MinAmountStrategy extends BaseStrategy {
 
       if (totalTargets > totalCollateral) {
         throw new Error(
-          `Consider reducing the targets as the canonical sum (${totalTargets}) is greater than sum of collaterals (${totalCollateral})`,
+          `Consider reducing the targets as the sum (${this.formatCanonicalAmount(
+            totalTargets,
+            displayToken,
+          )}) is greater than sum of collaterals (${this.formatCanonicalAmount(
+            totalCollateral,
+            displayToken,
+          )})`,
         );
       }
     }
+  }
+
+  private formatCanonicalAmount(amount: bigint, token: Token): string {
+    const localAmount = localAmountFromMessage(amount, token.scale);
+    return fromWei(localAmount.toString(), token.decimals);
   }
 }

--- a/typescript/rebalancer/src/test/helpers.ts
+++ b/typescript/rebalancer/src/test/helpers.ts
@@ -10,7 +10,7 @@ import {
   type InterchainGasQuote,
   type MultiProvider,
   type Token,
-  type TokenAmount,
+  TokenAmount,
   type WarpCore,
 } from '@hyperlane-xyz/sdk';
 
@@ -116,19 +116,14 @@ export function buildTestPreparedTransaction(
 
 // === Mock Factories ===
 
-export function createMockTokenAmount(
-  amount: bigint,
-): TokenAmount & { token: IToken } {
-  return {
-    amount,
-    token: {
-      name: 'TestToken',
-      symbol: 'TEST',
-      decimals: 18,
-      addressOrDenom: TEST_ADDRESSES.token,
-    },
-    getDecimalFormattedAmount: () => ethers.utils.formatEther(amount),
-  } as unknown as TokenAmount & { token: IToken };
+export function createMockTokenAmount(amount: bigint): TokenAmount<IToken> {
+  const token = {
+    name: 'TestToken',
+    symbol: 'TEST',
+    decimals: 18,
+    addressOrDenom: TEST_ADDRESSES.token,
+  } as IToken;
+  return new TokenAmount(amount, token);
 }
 
 export interface MockAdapterConfig {

--- a/typescript/rebalancer/src/test/helpers.ts
+++ b/typescript/rebalancer/src/test/helpers.ts
@@ -6,6 +6,7 @@ import {
   type ChainMetadata,
   type ChainName,
   EvmMovableCollateralAdapter,
+  type IToken,
   type InterchainGasQuote,
   type MultiProvider,
   type Token,
@@ -115,7 +116,9 @@ export function buildTestPreparedTransaction(
 
 // === Mock Factories ===
 
-export function createMockTokenAmount(amount: bigint): TokenAmount {
+export function createMockTokenAmount(
+  amount: bigint,
+): TokenAmount & { token: IToken } {
   return {
     amount,
     token: {
@@ -125,7 +128,7 @@ export function createMockTokenAmount(amount: bigint): TokenAmount {
       addressOrDenom: TEST_ADDRESSES.token,
     },
     getDecimalFormattedAmount: () => ethers.utils.formatEther(amount),
-  } as unknown as TokenAmount;
+  } as unknown as TokenAmount & { token: IToken };
 }
 
 export interface MockAdapterConfig {

--- a/typescript/rebalancer/src/test/helpers.ts
+++ b/typescript/rebalancer/src/test/helpers.ts
@@ -173,6 +173,7 @@ export interface MockTokenConfig {
   name?: string;
   decimals?: number;
   addressOrDenom?: string;
+  scale?: Token['scale'];
   adapter?: ReturnType<typeof createMockAdapter>;
 }
 
@@ -181,6 +182,7 @@ export function createMockToken(config: MockTokenConfig = {}) {
     name = 'TestToken',
     decimals = 18,
     addressOrDenom = TEST_ADDRESSES.token,
+    scale,
     adapter = createMockAdapter(),
   } = config;
 
@@ -188,6 +190,7 @@ export function createMockToken(config: MockTokenConfig = {}) {
     name,
     decimals,
     addressOrDenom,
+    scale,
     amount: (amt: bigint) => createMockTokenAmount(amt),
     getHypAdapter: Sinon.stub().returns(adapter),
   };

--- a/typescript/rebalancer/src/test/lifiMocks.ts
+++ b/typescript/rebalancer/src/test/lifiMocks.ts
@@ -128,15 +128,18 @@ export function createMockBridgeQuote(
   const route = overrides?.route as
     | { action?: { fromChainId?: number; toChainId?: number } }
     | undefined;
+  const usesReverseQuote = overrides?.requestParams?.toAmount !== undefined;
 
   const defaultRequestParams: BridgeQuoteParams = {
     fromChain: 42161,
     toChain: 1399811149,
     fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
     toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
-    fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     toAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-    fromAmount: 10000000000n,
+    fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    ...(usesReverseQuote
+      ? { toAmount: 9950000000n }
+      : { fromAmount: 10000000000n }),
   };
   const requestParams: BridgeQuoteParams = {
     ...defaultRequestParams,

--- a/typescript/rebalancer/src/tracking/ActionTracker.test.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.test.ts
@@ -807,6 +807,53 @@ describe('ActionTracker', () => {
       expect(partialIntents[0].remaining).to.equal(600000000000000000n); // 0.6 ETH remaining
     });
 
+    it('ignores inventory_movement amounts when computing remaining', async () => {
+      await rebalanceIntentStore.save({
+        id: 'partial-intent-with-movement',
+        status: 'in_progress',
+        origin: 1,
+        destination: 2,
+        amount: 1000000000000000000n,
+        executionMethod: 'inventory',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+
+      await rebalanceActionStore.save({
+        id: 'action-deposit',
+        type: 'inventory_deposit',
+        status: 'complete',
+        intentId: 'partial-intent-with-movement',
+        origin: 1,
+        destination: 2,
+        amount: 400000000000000000n,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+
+      await rebalanceActionStore.save({
+        id: 'action-movement',
+        type: 'inventory_movement',
+        status: 'complete',
+        intentId: 'partial-intent-with-movement',
+        origin: 3,
+        destination: 2,
+        amount: 9000000000000000000n,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      });
+
+      const partialIntents =
+        await tracker.getPartiallyFulfilledInventoryIntents();
+
+      expect(partialIntents).to.have.lengthOf(1);
+      expect(partialIntents[0].intent.id).to.equal(
+        'partial-intent-with-movement',
+      );
+      expect(partialIntents[0].completedAmount).to.equal(400000000000000000n);
+      expect(partialIntents[0].remaining).to.equal(600000000000000000n);
+    });
+
     it('does not return non-inventory intents', async () => {
       // Create a not_started intent without executionMethod: 'inventory'
       await rebalanceIntentStore.save({

--- a/typescript/rebalancer/src/tracking/ActionTracker.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.ts
@@ -636,7 +636,8 @@ export class ActionTracker implements IActionTracker {
         );
       }
 
-      // Compute amounts from action states
+      // Only inventory_deposit amounts advance fulfillment. inventory_movement
+      // amounts stay in source-local units and only gate retries/stale cleanup.
       const completedAmount = actions
         .filter(
           (a) => a.status === 'complete' && a.type === 'inventory_deposit',

--- a/typescript/rebalancer/src/utils/balanceUtils.test.ts
+++ b/typescript/rebalancer/src/utils/balanceUtils.test.ts
@@ -152,4 +152,10 @@ describe('scale helpers', () => {
   it('normalizes configured amount using token decimals and scale', () => {
     expect(normalizeConfiguredAmount('1', token)).to.equal(1_000_000n);
   });
+
+  it('normalizes sub-unit local dust to zero canonical amount', () => {
+    expect(normalizeConfiguredAmount('0.000000000000000001', token)).to.equal(
+      0n,
+    );
+  });
 });

--- a/typescript/rebalancer/src/utils/balanceUtils.test.ts
+++ b/typescript/rebalancer/src/utils/balanceUtils.test.ts
@@ -10,6 +10,7 @@ import {
   alignLocalToCanonical,
   denormalizeToLocal,
   getRawBalances,
+  isIdentityScale,
   getTokenScale,
   normalizeConfiguredAmount,
   normalizeToCanonical,
@@ -127,6 +128,25 @@ describe('scale helpers', () => {
       numerator: 1n,
       denominator: 1n,
     });
+  });
+
+  it('treats equivalent ratios as identity scale', () => {
+    expect(isIdentityScale({} as Token)).to.be.true;
+    expect(
+      isIdentityScale({
+        scale: { numerator: 1, denominator: 1 },
+      } as Token),
+    ).to.be.true;
+    expect(
+      isIdentityScale({
+        scale: { numerator: 5, denominator: 5 },
+      } as Token),
+    ).to.be.true;
+    expect(
+      isIdentityScale({
+        scale: { numerator: 10, denominator: 20 },
+      } as Token),
+    ).to.be.false;
   });
 
   it('normalizes configured amount using token decimals and scale', () => {

--- a/typescript/rebalancer/src/utils/balanceUtils.test.ts
+++ b/typescript/rebalancer/src/utils/balanceUtils.test.ts
@@ -6,7 +6,13 @@ import { type ChainName, type Token, TokenStandard } from '@hyperlane-xyz/sdk';
 
 import { type MonitorEvent } from '../interfaces/IMonitor.js';
 
-import { getRawBalances } from './balanceUtils.js';
+import {
+  denormalizeToLocal,
+  getRawBalances,
+  getTokenScale,
+  normalizeConfiguredAmount,
+  normalizeToCanonical,
+} from './balanceUtils.js';
 
 const testLogger = pino({ level: 'silent' });
 
@@ -45,6 +51,16 @@ describe('getRawBalances', () => {
     });
   });
 
+  it('should normalize bridged supply to canonical units when token has scale', () => {
+    token.scale = { numerator: 1, denominator: 1_000_000_000_000 };
+    tokenBridgedSupply = 1_000_000_000_000_000_000n;
+    event.tokensInfo[0].bridgedSupply = tokenBridgedSupply;
+
+    expect(getRawBalances(chains, event, testLogger)).to.deep.equal({
+      mainnet: 1_000_000n,
+    });
+  });
+
   it('should return the bridged supply for the token (EvmHypNative)', () => {
     token.standard = TokenStandard.EvmHypNative;
 
@@ -71,5 +87,35 @@ describe('getRawBalances', () => {
     expect(() => getRawBalances(chains, event, testLogger)).to.throw(
       'bridgedSupply should not be undefined for collateralized token 0xAddress',
     );
+  });
+});
+
+describe('scale helpers', () => {
+  const token = {
+    decimals: 18,
+    scale: { numerator: 1, denominator: 1_000_000_000_000 },
+  } as unknown as Token;
+
+  it('normalizes local amount to canonical amount', () => {
+    expect(normalizeToCanonical(1_000_000_000_000_000_000n, token)).to.equal(
+      1_000_000n,
+    );
+  });
+
+  it('denormalizes canonical amount to local amount', () => {
+    expect(denormalizeToLocal(1_000_000n, token)).to.equal(
+      1_000_000_000_000_000_000n,
+    );
+  });
+
+  it('returns identity scale when scale is undefined', () => {
+    expect(getTokenScale({} as Token)).to.deep.equal({
+      numerator: 1n,
+      denominator: 1n,
+    });
+  });
+
+  it('normalizes configured amount using token decimals and scale', () => {
+    expect(normalizeConfiguredAmount('1', token)).to.equal(1_000_000n);
   });
 });

--- a/typescript/rebalancer/src/utils/balanceUtils.test.ts
+++ b/typescript/rebalancer/src/utils/balanceUtils.test.ts
@@ -7,6 +7,7 @@ import { type ChainName, type Token, TokenStandard } from '@hyperlane-xyz/sdk';
 import { type MonitorEvent } from '../interfaces/IMonitor.js';
 
 import {
+  alignLocalToCanonical,
   denormalizeToLocal,
   getRawBalances,
   getTokenScale,
@@ -106,6 +107,19 @@ describe('scale helpers', () => {
     expect(denormalizeToLocal(1_000_000n, token)).to.equal(
       1_000_000_000_000_000_000n,
     );
+  });
+
+  it('aligns local amount to exact canonical progress', () => {
+    expect(alignLocalToCanonical(999_999_999_999n, token)).to.deep.equal({
+      localAmount: 0n,
+      messageAmount: 0n,
+    });
+    expect(
+      alignLocalToCanonical(1_000_000_000_000_500_000n, token),
+    ).to.deep.equal({
+      localAmount: 1_000_000_000_000_000_000n,
+      messageAmount: 1_000_000n,
+    });
   });
 
   it('returns identity scale when scale is undefined', () => {

--- a/typescript/rebalancer/src/utils/balanceUtils.ts
+++ b/typescript/rebalancer/src/utils/balanceUtils.ts
@@ -1,9 +1,14 @@
 import { type Logger } from 'pino';
 
 import {
+  type IToken,
+  alignLocalAmountToMessage,
+  messageAmountFromLocal,
+  minLocalAmountForMessage,
   normalizeScale,
   type ChainName,
   type NormalizedScale,
+  type ScaleAlignment,
   type Token,
 } from '@hyperlane-xyz/sdk';
 import { toWei } from '@hyperlane-xyz/utils';
@@ -24,24 +29,23 @@ export function isIdentityScale(token: Token): boolean {
 
 export function normalizeToCanonical(
   localAmount: bigint,
-  tokenOrScale: Token | NormalizedScale,
+  tokenOrScale: Token | IToken | NormalizedScale,
 ): bigint {
-  const scale =
-    'numerator' in tokenOrScale && 'denominator' in tokenOrScale
-      ? tokenOrScale
-      : getTokenScale(tokenOrScale);
-  return (localAmount * scale.numerator) / scale.denominator;
+  return messageAmountFromLocal(localAmount, getScaleInput(tokenOrScale));
 }
 
 export function denormalizeToLocal(
   canonicalAmount: bigint,
-  tokenOrScale: Token | NormalizedScale,
+  tokenOrScale: Token | IToken | NormalizedScale,
 ): bigint {
-  const scale =
-    'numerator' in tokenOrScale && 'denominator' in tokenOrScale
-      ? tokenOrScale
-      : getTokenScale(tokenOrScale);
-  return (canonicalAmount * scale.denominator) / scale.numerator;
+  return minLocalAmountForMessage(canonicalAmount, getScaleInput(tokenOrScale));
+}
+
+export function alignLocalToCanonical(
+  localAmount: bigint,
+  tokenOrScale: Token | IToken | NormalizedScale,
+): ScaleAlignment {
+  return alignLocalAmountToMessage(localAmount, getScaleInput(tokenOrScale));
 }
 
 export function normalizeConfiguredAmount(
@@ -49,6 +53,12 @@ export function normalizeConfiguredAmount(
   token: Token,
 ): bigint {
   return normalizeToCanonical(BigInt(toWei(amount, token.decimals)), token);
+}
+
+function getScaleInput(tokenOrScale: Token | IToken | NormalizedScale) {
+  return 'numerator' in tokenOrScale && 'denominator' in tokenOrScale
+    ? tokenOrScale
+    : tokenOrScale.scale;
 }
 
 /**

--- a/typescript/rebalancer/src/utils/balanceUtils.ts
+++ b/typescript/rebalancer/src/utils/balanceUtils.ts
@@ -1,11 +1,55 @@
 import { type Logger } from 'pino';
 
-import { type ChainName } from '@hyperlane-xyz/sdk';
+import {
+  normalizeScale,
+  type ChainName,
+  type NormalizedScale,
+  type Token,
+} from '@hyperlane-xyz/sdk';
+import { toWei } from '@hyperlane-xyz/utils';
 
 import { type MonitorEvent } from '../interfaces/IMonitor.js';
 import { type RawBalances } from '../interfaces/IStrategy.js';
 
 import { isCollateralizedTokenEligibleForRebalancing } from './tokenUtils.js';
+
+export function getTokenScale(token: Token): NormalizedScale {
+  return normalizeScale(token.scale);
+}
+
+export function isIdentityScale(token: Token): boolean {
+  const scale = getTokenScale(token);
+  return scale.numerator === 1n && scale.denominator === 1n;
+}
+
+export function normalizeToCanonical(
+  localAmount: bigint,
+  tokenOrScale: Token | NormalizedScale,
+): bigint {
+  const scale =
+    'numerator' in tokenOrScale && 'denominator' in tokenOrScale
+      ? tokenOrScale
+      : getTokenScale(tokenOrScale);
+  return (localAmount * scale.numerator) / scale.denominator;
+}
+
+export function denormalizeToLocal(
+  canonicalAmount: bigint,
+  tokenOrScale: Token | NormalizedScale,
+): bigint {
+  const scale =
+    'numerator' in tokenOrScale && 'denominator' in tokenOrScale
+      ? tokenOrScale
+      : getTokenScale(tokenOrScale);
+  return (canonicalAmount * scale.denominator) / scale.numerator;
+}
+
+export function normalizeConfiguredAmount(
+  amount: string | number,
+  token: Token,
+): bigint {
+  return normalizeToCanonical(BigInt(toWei(amount, token.decimals)), token);
+}
 
 /**
  * Returns the raw balances required by the strategies from the monitor event
@@ -58,7 +102,22 @@ export function getRawBalances(
       );
     }
 
-    balances[token.chainName] = bridgedSupply;
+    const normalizedBalance = normalizeToCanonical(bridgedSupply, token);
+    balances[token.chainName] = normalizedBalance;
+
+    if (!isIdentityScale(token)) {
+      logger.debug(
+        {
+          context: getRawBalances.name,
+          chain: token.chainName,
+          tokenSymbol: token.symbol,
+          bridgedSupply: bridgedSupply.toString(),
+          normalizedBalance: normalizedBalance.toString(),
+          scale: getTokenScale(token),
+        },
+        'Normalized bridged supply to canonical units',
+      );
+    }
   }
 
   return balances;

--- a/typescript/rebalancer/src/utils/balanceUtils.ts
+++ b/typescript/rebalancer/src/utils/balanceUtils.ts
@@ -6,6 +6,7 @@ import {
   messageAmountFromLocal,
   minLocalAmountForMessage,
   normalizeScale,
+  scalesEqual,
   type ChainName,
   type NormalizedScale,
   type ScaleAlignment,
@@ -23,8 +24,7 @@ export function getTokenScale(token: Token): NormalizedScale {
 }
 
 export function isIdentityScale(token: Token): boolean {
-  const scale = getTokenScale(token);
-  return scale.numerator === 1n && scale.denominator === 1n;
+  return scalesEqual(token.scale, undefined);
 }
 
 export function normalizeToCanonical(

--- a/typescript/rebalancer/src/utils/balanceUtils.ts
+++ b/typescript/rebalancer/src/utils/balanceUtils.ts
@@ -38,6 +38,8 @@ export function denormalizeToLocal(
   canonicalAmount: bigint,
   tokenOrScale: Token | IToken | NormalizedScale,
 ): bigint {
+  // Use ceil semantics so the returned local amount always produces at least
+  // the requested canonical progress once the token router floors on outbound.
   return minLocalAmountForMessage(canonicalAmount, getScaleInput(tokenOrScale));
 }
 

--- a/typescript/rebalancer/src/utils/blockTag.ts
+++ b/typescript/rebalancer/src/utils/blockTag.ts
@@ -2,8 +2,10 @@ import type { Logger } from 'pino';
 
 import { providers } from 'ethers';
 
-import { EthJsonRpcBlockParameterTag } from '@hyperlane-xyz/sdk';
-import type { MinimalProviderRegistry } from '@hyperlane-xyz/sdk/providers/MinimalProviderRegistry';
+import {
+  EthJsonRpcBlockParameterTag,
+  type MultiProtocolProvider,
+} from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
 import type { ConfirmedBlockTag } from '../interfaces/IMonitor.js';
 
@@ -11,13 +13,16 @@ import type { ConfirmedBlockTag } from '../interfaces/IMonitor.js';
  * Get the confirmed block tag for a chain, accounting for reorg period.
  * Returns a block number that is safe from reorgs, or a named tag like 'finalized'.
  *
- * @param multiProvider - MinimalProviderRegistry instance
+ * @param multiProvider - Provider registry with chain metadata and ethers access
  * @param chainName - Name of the chain
  * @param logger - Optional logger for warnings
  * @returns Confirmed block tag (number, named tag, or undefined on error)
  */
 export async function getConfirmedBlockTag(
-  multiProvider: MinimalProviderRegistry,
+  multiProvider: Pick<
+    MultiProtocolProvider,
+    'getChainMetadata' | 'getEthersV5Provider'
+  >,
   chainName: string,
   logger?: Logger,
 ): Promise<ConfirmedBlockTag> {


### PR DESCRIPTION
## Summary
- Adds decimal normalization to the rebalancer so it correctly handles tokens with different decimals across chains (e.g., BSC USDC 18-dec vs 6-dec USDC elsewhere)
- Normalizes balances and strategy thresholds to canonical (message-format) decimals using Token.scale
- Denormalizes route amounts back to local decimals before execution
- Updates SDK Token schema to accept fractional scale format {numerator, denominator} alongside legacy number format

## Changes
- `typescript/rebalancer/src/utils/balanceUtils.ts` — scale normalization utilities + balance normalization in getRawBalances
- `typescript/rebalancer/src/strategy/CollateralDeficitStrategy.ts` — normalize buffer threshold
- `typescript/rebalancer/src/strategy/MinAmountStrategy.ts` — normalize absolute min/target thresholds + validateAmounts
- `typescript/rebalancer/src/strategy/BaseStrategy.ts` — normalize bridgeMinAcceptedAmount filter
- `typescript/rebalancer/src/core/Rebalancer.ts` — denormalize before movable collateral execution
- `typescript/rebalancer/src/core/InventoryRebalancer.ts` — denormalize before inventory/LiFi execution
- `typescript/sdk/src/token/IToken.ts` — accept {numerator, denominator} in scale schema
- `typescript/sdk/src/warp/WarpCore.ts` — handle new scale type in convertToScaledAmount

## Testing
- Tested live with USDCSTAGE route including BSC (18-dec USDC) + 6-dec chains
- Verified: deficit detection, LiFi bridge quotes, cross-decimal execution all work correctly
- Unit tests cover identity scale, mixed-decimal, roundtrip precision