### PR TITLE
fix(monitor): transfer detection for sealevel inflight messages

### DIFF
--- a/typescript/warp-monitor/src/explorer.test.ts
+++ b/typescript/warp-monitor/src/explorer.test.ts
@@ -183,7 +183,7 @@ describe('Explorer Pending Transfers', () => {
     expect(thrown!.message).to.contain('GraphQL errors');
   });
 
-  it('counts sealevel-origin pending transfers even when sender is not a router', async () => {
+  it('counts sealevel-origin pending transfers without querying non-evm routers as recipients', async () => {
     const router = '0x00000000000000000000000000000000000000aa';
     const nodes: RouterNodeMetadata[] = [
       {
@@ -203,8 +203,8 @@ describe('Explorer Pending Transfers', () => {
           'USDC|solanamainnet|So11111111111111111111111111111111111111112',
         chainName: 'solanamainnet' as any,
         domainId: 1399811149,
-        routerAddress: '0x00000000000000000000000000000000000000cc',
-        tokenAddress: '0x00000000000000000000000000000000000000dd',
+        routerAddress: 'So11111111111111111111111111111111111111112',
+        tokenAddress: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
         tokenName: 'USD Coin',
         tokenSymbol: 'USDC',
         tokenDecimals: 6,
@@ -260,7 +260,6 @@ describe('Explorer Pending Transfers', () => {
     expect(body.variables.originDomains).to.deep.equal([8453, 1399811149]);
     expect(body.variables.recipients).to.deep.equal([
       '\\x00000000000000000000000000000000000000aa',
-      '\\x00000000000000000000000000000000000000cc',
     ]);
   });
 });

--- a/typescript/warp-monitor/src/explorer.test.ts
+++ b/typescript/warp-monitor/src/explorer.test.ts
@@ -182,4 +182,85 @@ describe('Explorer Pending Transfers', () => {
     expect(thrown).to.not.equal(undefined);
     expect(thrown!.message).to.contain('GraphQL errors');
   });
+
+  it('counts sealevel-origin pending transfers even when sender is not a router', async () => {
+    const router = '0x00000000000000000000000000000000000000aa';
+    const nodes: RouterNodeMetadata[] = [
+      {
+        nodeId: 'USDC|base|0xrouter',
+        chainName: 'base' as any,
+        domainId: 8453,
+        routerAddress: router,
+        tokenAddress: '0x00000000000000000000000000000000000000bb',
+        tokenName: 'USD Coin',
+        tokenSymbol: 'USDC',
+        tokenDecimals: 6,
+        tokenScale: 1_000_000_000_000,
+        token: {} as any,
+      },
+      {
+        nodeId:
+          'USDC|solanamainnet|So11111111111111111111111111111111111111112',
+        chainName: 'solanamainnet' as any,
+        domainId: 1399811149,
+        routerAddress: '0x00000000000000000000000000000000000000cc',
+        tokenAddress: '0x00000000000000000000000000000000000000dd',
+        tokenName: 'USD Coin',
+        tokenSymbol: 'USDC',
+        tokenDecimals: 6,
+        tokenScale: 1_000_000_000_000,
+        token: {} as any,
+      },
+    ];
+
+    const amountCanonical18 = 2000000000000000000n;
+    const amountHex = amountCanonical18.toString(16).padStart(64, '0');
+    const recipientBytes32 =
+      '0000000000000000000000004444444444444444444444444444444444444444';
+    const messageBody = `0x${recipientBytes32}${amountHex}`;
+    const fetchStub = sinon.stub(globalThis, 'fetch' as any).resolves({
+      ok: true,
+      json: async () => ({
+        data: {
+          message_view: [
+            {
+              msg_id:
+                '\\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+              origin_domain_id: 1399811149,
+              destination_domain_id: 8453,
+              sender:
+                '\\xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+              recipient:
+                '\\x00000000000000000000000000000000000000000000000000000000000000aa',
+              message_body: messageBody,
+              send_occurred_at: null,
+            },
+          ],
+        },
+      }),
+    } as any);
+
+    const client = new ExplorerPendingTransfersClient(
+      'https://explorer.example/v1/graphql',
+      nodes,
+      rootLogger,
+    );
+
+    const transfers = await client.getPendingDestinationTransfers();
+
+    expect(transfers).to.have.length(1);
+    expect(transfers[0].originDomainId).to.equal(1399811149);
+    expect(transfers[0].destinationNodeId).to.equal('USDC|base|0xrouter');
+    expect(transfers[0].amountBaseUnits).to.equal(2000000n);
+
+    const [, requestInit] = fetchStub.firstCall.args;
+    const body = JSON.parse(requestInit.body);
+    expect(body.query).to.not.contain('sender: { _in: $senders }');
+    expect(body.variables).to.not.have.property('senders');
+    expect(body.variables.originDomains).to.deep.equal([8453, 1399811149]);
+    expect(body.variables.recipients).to.deep.equal([
+      '\\x00000000000000000000000000000000000000aa',
+      '\\x00000000000000000000000000000000000000cc',
+    ]);
+  });
 });

--- a/typescript/warp-monitor/src/explorer.ts
+++ b/typescript/warp-monitor/src/explorer.ts
@@ -96,9 +96,11 @@ export class ExplorerPendingTransfersClient {
     this.nodeByDestinationKey = new Map<string, RouterNodeMetadata>();
 
     for (const node of nodes) {
+      domains.add(node.domainId);
+      if (!isValidAddressEvm(node.routerAddress)) continue;
+
       const routerLower = node.routerAddress.toLowerCase();
       routers.add(routerLower);
-      domains.add(node.domainId);
       this.nodeByDestinationKey.set(`${node.domainId}:${routerLower}`, node);
     }
 

--- a/typescript/warp-monitor/src/explorer.ts
+++ b/typescript/warp-monitor/src/explorer.ts
@@ -187,7 +187,6 @@ export class ExplorerPendingTransfersClient {
     if (this.routers.length === 0 || this.domains.length === 0) return [];
 
     const variables = {
-      senders: this.routers.map((router) => this.toBytea(router)),
       recipients: this.routers.map((router) => this.toBytea(router)),
       originDomains: this.domains,
       destinationDomains: this.domains,
@@ -196,7 +195,6 @@ export class ExplorerPendingTransfersClient {
 
     const query = `
       query WarpMonitorInflightTransfers(
-        $senders: [bytea!],
         $recipients: [bytea!],
         $originDomains: [Int!],
         $destinationDomains: [Int!],
@@ -206,7 +204,6 @@ export class ExplorerPendingTransfersClient {
           where: {
             _and: [
               { is_delivered: { _eq: false } },
-              { sender: { _in: $senders } },
               { recipient: { _in: $recipients } },
               { origin_domain_id: { _in: $originDomains } },
               { destination_domain_id: { _in: $destinationDomains } }

--- a/typescript/warp-monitor/src/monitor.test.ts
+++ b/typescript/warp-monitor/src/monitor.test.ts
@@ -340,7 +340,8 @@ describe('WarpMonitor', () => {
       chainMetadata: Record<string, { domainId: number }>,
     ) => RouterNodeMetadata[];
 
-    const routerNodes = buildRouterNodes(
+    const routerNodes = buildRouterNodes.call(
+      monitor,
       {
         tokens: [
           {

--- a/typescript/warp-monitor/src/monitor.test.ts
+++ b/typescript/warp-monitor/src/monitor.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import type { IRegistry } from '@hyperlane-xyz/registry';
 import type { Token, WarpCore } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
 import type {
   PendingDestinationTransfer,
   RouterNodeMetadata,
@@ -323,5 +324,64 @@ describe('WarpMonitor', () => {
       );
     expect(inventoryLine).to.exist;
     expect(inventoryLine!.trim().endsWith(' 1')).to.equal(true);
+  });
+
+  it('builds router nodes for non-evm tokens so their domains reach explorer queries', () => {
+    const monitor = new WarpMonitor(
+      {
+        warpRouteId: 'MULTI/sealevel-origin-test',
+        checkFrequency: 10_000,
+      },
+      {} as IRegistry,
+    );
+
+    const buildRouterNodes = (monitor as any).buildRouterNodes as (
+      warpCore: WarpCore,
+      chainMetadata: Record<string, { domainId: number }>,
+    ) => RouterNodeMetadata[];
+
+    const routerNodes = buildRouterNodes(
+      {
+        tokens: [
+          {
+            chainName: 'base',
+            addressOrDenom: '0x00000000000000000000000000000000000000AA',
+            collateralAddressOrDenom:
+              '0x00000000000000000000000000000000000000BB',
+            name: 'USD Coin',
+            symbol: 'USDC',
+            decimals: 6,
+            scale: 1_000_000_000_000,
+          },
+          {
+            chainName: 'solanamainnet',
+            addressOrDenom: 'So11111111111111111111111111111111111111112',
+            collateralAddressOrDenom:
+              'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            name: 'USD Coin',
+            symbol: 'USDC',
+            decimals: 6,
+            scale: 1_000_000_000_000,
+            protocol: ProtocolType.Sealevel,
+          },
+        ] as Token[],
+      } as WarpCore,
+      {
+        base: { domainId: 8453 },
+        solanamainnet: { domainId: 1399811149 },
+      },
+    );
+
+    expect(routerNodes.map((node) => node.domainId)).to.deep.equal([
+      8453, 1399811149,
+    ]);
+    expect(routerNodes.map((node) => node.routerAddress)).to.deep.equal([
+      '0x00000000000000000000000000000000000000aa',
+      'So11111111111111111111111111111111111111112',
+    ]);
+    expect(routerNodes.map((node) => node.nodeId)).to.deep.equal([
+      'USDC|base|0x00000000000000000000000000000000000000aa',
+      'USDC|solanamainnet|So11111111111111111111111111111111111111112',
+    ]);
   });
 });

--- a/typescript/warp-monitor/src/monitor.ts
+++ b/typescript/warp-monitor/src/monitor.ts
@@ -19,7 +19,6 @@ import {
   Token,
   TokenType,
   WarpCore,
-  type WarpRouteDeployConfig,
 } from '@hyperlane-xyz/sdk';
 import {
   ProtocolType,
@@ -60,6 +59,8 @@ type PendingDestinationAggregate = {
   count: number;
   oldestPendingSeconds: number;
 };
+
+type WarpDeployConfig = Awaited<ReturnType<IRegistry['getWarpDeployConfig']>>;
 
 export class WarpMonitor {
   private readonly config: WarpMonitorConfig;
@@ -158,7 +159,7 @@ export class WarpMonitor {
   private async pollAndUpdateWarpRouteMetrics(
     checkFrequency: number,
     warpCore: WarpCore,
-    warpDeployConfig: WarpRouteDeployConfig | null,
+    warpDeployConfig: WarpDeployConfig,
     chainMetadata: ChainMap<ChainMetadata>,
     warpRouteId: string,
     coingeckoApiKey: string | undefined,
@@ -388,7 +389,7 @@ export class WarpMonitor {
   // Updates the metrics for a single token in a warp route.
   private async updateTokenMetrics(
     warpCore: WarpCore,
-    warpDeployConfig: WarpRouteDeployConfig | null,
+    warpDeployConfig: WarpDeployConfig,
     token: Token,
     tokenPriceGetter: TokenPriceGetter,
     warpRouteId: string,
@@ -577,12 +578,10 @@ export class WarpMonitor {
         continue;
       }
       const metadata = chainMetadata[token.chainName];
-      if (!ethersUtils.isAddress(token.addressOrDenom)) continue;
-
       const domainId = metadata.domainId;
-      const routerAddress = ethersUtils
-        .getAddress(token.addressOrDenom)
-        .toLowerCase();
+      const routerAddress = this.normalizeRouterIdentifier(
+        token.addressOrDenom,
+      );
       const key = `${domainId}:${routerAddress}`;
       if (nodeByKey.has(key)) continue;
 
@@ -591,9 +590,9 @@ export class WarpMonitor {
         chainName: token.chainName,
         domainId,
         routerAddress,
-        tokenAddress: (
-          token.collateralAddressOrDenom ?? token.addressOrDenom
-        ).toLowerCase(),
+        tokenAddress: this.normalizeRouterIdentifier(
+          token.collateralAddressOrDenom ?? token.addressOrDenom,
+        ),
         tokenName: token.name,
         tokenSymbol: token.symbol,
         tokenDecimals: token.decimals,
@@ -606,7 +605,15 @@ export class WarpMonitor {
   }
 
   private buildNodeId(token: Token): string {
-    return `${token.symbol}|${token.chainName}|${token.addressOrDenom.toLowerCase()}`;
+    return `${token.symbol}|${token.chainName}|${this.normalizeRouterIdentifier(token.addressOrDenom)}`;
+  }
+
+  private normalizeRouterIdentifier(addressOrDenom: string): string {
+    if (ethersUtils.isAddress(addressOrDenom)) {
+      return ethersUtils.getAddress(addressOrDenom).toLowerCase();
+    }
+
+    return addressOrDenom;
   }
 
   private formatTokenAmount(token: Token, amount: bigint): number {


### PR DESCRIPTION
Fix warp-monitor pending transfer detection for Sealevel-origin messages by dropping the sender-router filter from inflight transfer discovery. Adds a regression test for the Citrea router case where the sender is not the route router.\n\nValidation: targeted warp-monitor test execution is currently blocked in this checkout by dependency resolution issues in typescript/sdk / tron-sdk (missing @hyperlane-xyz/tron-sdk dist and then missing Node type defs during tron-sdk build).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
