### PR TITLE
Fix #4585: Set 'from' address when performing eth_estimateGas calls

### DIFF
--- a/typescript/sdk/src/utils/gas.ts
+++ b/typescript/sdk/src/utils/gas.ts
@@ -19,6 +19,7 @@ export interface EstimateCallGasParams {
   data: string;
   value?: BigNumber;
   fallback?: BigNumber;
+  from?: Address;
 }
 
 /**
@@ -55,6 +56,7 @@ export async function estimateCallGas(
       to: params.to,
       data: params.data,
       value: params.value,
+      from: params.from,
     });
   } catch {
     return fallback;


### PR DESCRIPTION
Fixes hyperlane-xyz/hyperlane-monorepo#4585

## Problem

When performing \eth_estimateGas\ calls without a \rom\ address specified, some chains (e.g. Citrea) estimate as if the call is made from the zero address. This causes estimation failures when the relayer has no funds at the zero address.

## Solution

Added an optional \rom?: Address\ field to \EstimateCallGasParams\ and pass it through to \provider.estimateGas()\. This allows callers (like the ICA gas estimation in \InterchainAccount.ts\) to specify the sender address for accurate gas estimation on chains that require it.

## Changes

- \	ypescript/sdk/src/utils/gas.ts\: Added \rom?: Address\ to \EstimateCallGasParams\ interface and passed it to \estimateGas\ call

## Testing

The change is backward-compatible (optional field). Existing callers without the \rom\ field will behave as before.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
