### PR TITLE
feat(rebalancer): add CCTP warp external bridge

### DIFF
--- a/typescript/rebalancer/src/bridges/CctpWarpBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/CctpWarpBridge.test.ts
@@ -1,0 +1,321 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import { pino } from 'pino';
+import Sinon from 'sinon';
+
+import type { IRegistry } from '@hyperlane-xyz/registry';
+import {
+  HyperlaneCore,
+  MultiProvider,
+  type WarpTypedTransaction,
+} from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { CctpWarpBridge } from './CctpWarpBridge.js';
+
+const testLogger = pino({ level: 'silent' });
+
+class TestableCctpWarpBridge extends CctpWarpBridge {
+  public selectedPath(): string {
+    return this.getSelectedRegistryRelativePath();
+  }
+}
+
+function createMockRegistry(): IRegistry {
+  return {
+    uri: '/tmp/mock-registry',
+  } as IRegistry;
+}
+
+function createFakeToken(chainName: string, connectedTo?: string) {
+  const token = {
+    chainName,
+    amount: (amount: bigint) => ({ amount, token }),
+    getConnectionForChain: (destination: string) =>
+      destination === connectedTo ? { token: destination } : undefined,
+  };
+  return token;
+}
+
+function encodeWarpRouteBody(amount: bigint): string {
+  const recipient = ethers.utils.hexZeroPad('0x1234', 32);
+  const encodedAmount = ethers.utils.hexZeroPad(
+    ethers.BigNumber.from(amount.toString()).toHexString(),
+    32,
+  );
+  return `${recipient}${encodedAmount.slice(2)}`;
+}
+
+describe('CctpWarpBridge', () => {
+  let sandbox: Sinon.SinonSandbox;
+  let multiProvider: Sinon.SinonStubbedInstance<MultiProvider>;
+
+  beforeEach(() => {
+    sandbox = Sinon.createSandbox();
+    multiProvider = sandbox.createStubInstance(MultiProvider);
+    multiProvider.getChainId.callsFake((chain) => {
+      if (chain === 'ethereum') return 1;
+      if (chain === 'arbitrum') return 42161;
+      throw new Error(`Unexpected chain ${String(chain)}`);
+    });
+    multiProvider.getDomainId.callsFake((chain) => {
+      if (chain === 'ethereum') return 1;
+      if (chain === 'arbitrum') return 42161;
+      throw new Error(`Unexpected chain ${String(chain)}`);
+    });
+    multiProvider.getProtocol.returns(ProtocolType.Ethereum);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('selects the fast registry config path', () => {
+    const bridge = new TestableCctpWarpBridge(
+      { mode: 'fast' },
+      multiProvider as unknown as MultiProvider,
+      createMockRegistry(),
+      testLogger,
+    );
+
+    expect(bridge.selectedPath()).to.equal(
+      'deployments/warp_routes/USDC/mainnet-cctp-v2-fast-config.yaml',
+    );
+  });
+
+  it('selects the standard registry config path', () => {
+    const bridge = new TestableCctpWarpBridge(
+      { mode: 'standard' },
+      multiProvider as unknown as MultiProvider,
+      createMockRegistry(),
+      testLogger,
+    );
+
+    expect(bridge.selectedPath()).to.equal(
+      'deployments/warp_routes/USDC/mainnet-cctp-v2-standard-config.yaml',
+    );
+  });
+
+  it('rejects toAmount quotes', async () => {
+    const bridge = new CctpWarpBridge(
+      { mode: 'fast' },
+      multiProvider as unknown as MultiProvider,
+      createMockRegistry(),
+      testLogger,
+    );
+
+    try {
+      await bridge.quote({
+        fromChain: 1,
+        toChain: 42161,
+        fromToken: '0xfrom',
+        toToken: '0xto',
+        fromAddress: '0x123',
+        toAmount: 1n,
+      });
+      expect.fail('Expected quote to throw');
+    } catch (error) {
+      expect((error as Error).message).to.include(
+        'does not support toAmount quotes',
+      );
+    }
+  });
+
+  it('quotes using the selected warp route pair and token fee output', async () => {
+    const bridge = new CctpWarpBridge(
+      { mode: 'fast' },
+      multiProvider as unknown as MultiProvider,
+      createMockRegistry(),
+      testLogger,
+    );
+    const fromToken = createFakeToken('ethereum', 'arbitrum');
+    const toToken = createFakeToken('arbitrum');
+    const estimateTransferRemoteFees = sandbox.stub().resolves({
+      interchainQuote: { amount: 55n },
+      localQuote: { amount: 0n },
+      tokenFeeQuote: { amount: 7n },
+    });
+
+    sandbox.stub(bridge as any, 'getContext').resolves({
+      warpCore: {
+        tokens: [fromToken, toToken],
+        estimateTransferRemoteFees,
+      },
+    });
+
+    const quote = await bridge.quote({
+      fromChain: 1,
+      toChain: 42161,
+      fromToken: '0xignored-from',
+      toToken: '0xignored-to',
+      fromAddress: '0xsender',
+      fromAmount: 100n,
+    });
+
+    expect(quote.tool).to.equal('hyperlane-cctp-warp');
+    expect(quote.fromAmount).to.equal(100n);
+    expect(quote.toAmount).to.equal(93n);
+    expect(quote.toAmountMin).to.equal(93n);
+    expect(quote.gasCosts).to.equal(55n);
+    expect(quote.feeCosts).to.equal(7n);
+    expect(quote.route).to.deep.equal({
+      mode: 'fast',
+      fromChainName: 'ethereum',
+      toChainName: 'arbitrum',
+      fromAddress: '0xsender',
+      toAddress: '0xsender',
+    });
+    expect(estimateTransferRemoteFees.calledOnce).to.equal(true);
+  });
+
+  it('executes transfer txs and returns the dispatched message id as transferId', async () => {
+    const bridge = new CctpWarpBridge(
+      { mode: 'fast' },
+      multiProvider as unknown as MultiProvider,
+      createMockRegistry(),
+      testLogger,
+    );
+    const fromToken = createFakeToken('ethereum', 'arbitrum');
+    const toToken = createFakeToken('arbitrum');
+    const transferTxs = sandbox.stub().resolves([
+      {
+        category: 'approval',
+        type: 'ethersV5',
+      } as unknown as WarpTypedTransaction,
+      {
+        category: 'transfer',
+        type: 'ethersV5',
+      } as unknown as WarpTypedTransaction,
+    ]);
+    const provider = {
+      getTransactionReceipt: sandbox.stub().resolves({ logs: [] }),
+    };
+
+    sandbox.stub(bridge as any, 'getContext').resolves({
+      warpCore: {
+        tokens: [fromToken, toToken],
+        getTransferRemoteTxs: transferTxs,
+        multiProvider: {
+          getChainMetadata: sandbox.stub().returns({}),
+        },
+      },
+    });
+    sandbox
+      .stub(bridge as any, 'sendWarpTransaction')
+      .onFirstCall()
+      .resolves('0xapprove')
+      .onSecondCall()
+      .resolves('0xtransfer');
+    multiProvider.getProvider.returns(provider as any);
+    sandbox
+      .stub(HyperlaneCore, 'getDispatchedMessages')
+      .returns([{ id: '0xmessage-id' } as any]);
+
+    const result = await bridge.execute(
+      {
+        id: 'quote-id',
+        tool: 'hyperlane-cctp-warp',
+        fromAmount: 100n,
+        toAmount: 100n,
+        toAmountMin: 100n,
+        executionDuration: 0,
+        gasCosts: 0n,
+        feeCosts: 0n,
+        route: {
+          mode: 'fast',
+          fromChainName: 'ethereum',
+          toChainName: 'arbitrum',
+          fromAddress: '0xsender',
+          toAddress: '0xrecipient',
+        },
+        requestParams: {
+          fromChain: 1,
+          toChain: 42161,
+          fromToken: '0xignored-from',
+          toToken: '0xignored-to',
+          fromAddress: '0xsender',
+          fromAmount: 100n,
+        },
+      },
+      { [ProtocolType.Ethereum]: '0xabc123' },
+    );
+
+    expect(result).to.deep.equal({
+      txHash: '0xtransfer',
+      fromChain: 1,
+      toChain: 42161,
+      transferId: '0xmessage-id',
+    });
+  });
+
+  it('returns pending status when the message has not been delivered', async () => {
+    const bridge = new CctpWarpBridge(
+      { mode: 'fast' },
+      multiProvider as unknown as MultiProvider,
+      createMockRegistry(),
+      testLogger,
+    );
+    const provider = {
+      getTransactionReceipt: sandbox.stub().resolves({ logs: [] }),
+    };
+
+    sandbox.stub(bridge as any, 'getContext').resolves({
+      warpCore: {
+        tokens: [createFakeToken('ethereum'), createFakeToken('arbitrum')],
+      },
+      hyperlaneCore: {
+        getDestination: sandbox.stub().returns('arbitrum'),
+        isDelivered: sandbox.stub().resolves(false),
+      },
+    });
+    multiProvider.getProvider.returns(provider as any);
+    sandbox.stub(HyperlaneCore, 'getDispatchedMessages').returns([
+      {
+        id: '0xmessage-id',
+        parsed: { body: encodeWarpRouteBody(88n) },
+      } as any,
+    ]);
+
+    const status = await bridge.getStatus('0xtx', 1, 42161);
+    expect(status).to.deep.equal({ status: 'pending' });
+  });
+
+  it('returns complete status with processed tx hash and parsed received amount', async () => {
+    const bridge = new CctpWarpBridge(
+      { mode: 'fast' },
+      multiProvider as unknown as MultiProvider,
+      createMockRegistry(),
+      testLogger,
+    );
+    const provider = {
+      getTransactionReceipt: sandbox.stub().resolves({ logs: [] }),
+    };
+
+    sandbox.stub(bridge as any, 'getContext').resolves({
+      warpCore: {
+        tokens: [createFakeToken('ethereum'), createFakeToken('arbitrum')],
+      },
+      hyperlaneCore: {
+        getDestination: sandbox.stub().returns('arbitrum'),
+        isDelivered: sandbox.stub().resolves(true),
+        getProcessedReceipt: sandbox
+          .stub()
+          .resolves({ transactionHash: '0xprocessed' }),
+      },
+    });
+    multiProvider.getProvider.returns(provider as any);
+    sandbox.stub(HyperlaneCore, 'getDispatchedMessages').returns([
+      {
+        id: '0xmessage-id',
+        parsed: { body: encodeWarpRouteBody(91n) },
+      } as any,
+    ]);
+
+    const status = await bridge.getStatus('0xtx', 1, 42161);
+    expect(status).to.deep.equal({
+      status: 'complete',
+      receivingTxHash: '0xprocessed',
+      receivedAmount: 91n,
+    });
+  });
+});

--- a/typescript/rebalancer/src/bridges/CctpWarpBridge.ts
+++ b/typescript/rebalancer/src/bridges/CctpWarpBridge.ts
@@ -1,0 +1,484 @@
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+import type { Logger } from 'pino';
+import { parse as parseYaml } from 'yaml';
+
+import type { IRegistry } from '@hyperlane-xyz/registry';
+import {
+  type ChainMap,
+  type ChainName,
+  getSignerForChain,
+  HyperlaneCore,
+  MultiProtocolProvider,
+  type MultiProvider,
+  type Token,
+  type WarpCoreConfig,
+  WarpCore,
+  type WarpTypedTransaction,
+  WarpTxCategory,
+} from '@hyperlane-xyz/sdk';
+import {
+  assert,
+  ensure0x,
+  parseWarpRouteMessage,
+  ProtocolType,
+} from '@hyperlane-xyz/utils';
+import { readYamlOrJson } from '@hyperlane-xyz/utils/fs';
+
+import type {
+  BridgeQuote,
+  BridgeQuoteParams,
+  BridgeTransferResult,
+  BridgeTransferStatus,
+  IExternalBridge,
+} from '../interfaces/IExternalBridge.js';
+import { toProtocolTransaction } from '../utils/transactionUtils.js';
+
+const FAST_CONFIG_RELATIVE_PATH =
+  'deployments/warp_routes/USDC/mainnet-cctp-v2-fast-config.yaml';
+const STANDARD_CONFIG_RELATIVE_PATH =
+  'deployments/warp_routes/USDC/mainnet-cctp-v2-standard-config.yaml';
+
+export type CctpWarpBridgeMode = 'fast' | 'standard';
+
+export interface CctpWarpBridgeConfig {
+  mode: CctpWarpBridgeMode;
+}
+
+type CctpWarpBridgeRoute = {
+  mode: CctpWarpBridgeMode;
+  fromChainName: ChainName;
+  toChainName: ChainName;
+  fromAddress: string;
+  toAddress: string;
+};
+
+type CctpWarpBridgeContext = {
+  warpCore: WarpCore;
+  hyperlaneCore: HyperlaneCore;
+};
+
+export class CctpWarpBridge implements IExternalBridge {
+  readonly externalBridgeId = 'cctpWarp';
+  readonly logger: Logger;
+
+  private contextPromise?: Promise<CctpWarpBridgeContext>;
+
+  constructor(
+    private readonly config: CctpWarpBridgeConfig,
+    private readonly multiProvider: MultiProvider,
+    private readonly registry: IRegistry,
+    logger: Logger,
+  ) {
+    this.logger = logger;
+  }
+
+  protected getSelectedRegistryRelativePath(): string {
+    return this.config.mode === 'fast'
+      ? FAST_CONFIG_RELATIVE_PATH
+      : STANDARD_CONFIG_RELATIVE_PATH;
+  }
+
+  protected async getContext(): Promise<CctpWarpBridgeContext> {
+    if (!this.contextPromise) {
+      this.contextPromise = this.buildContext();
+    }
+    return this.contextPromise;
+  }
+
+  private async buildContext(): Promise<CctpWarpBridgeContext> {
+    const warpCoreConfig = await this.loadWarpCoreConfig();
+    const addresses = await this.registry.getAddresses();
+
+    const warpChains = [
+      ...new Set(warpCoreConfig.tokens.map((t) => t.chainName)),
+    ];
+    for (const chain of warpChains) {
+      if (this.multiProvider.getProtocol(chain) === ProtocolType.Ethereum) {
+        this.multiProvider.getProvider(chain);
+      }
+    }
+
+    const mailboxes = Object.fromEntries(
+      Object.entries(addresses).map(([chain, chainAddresses]) => [
+        chain,
+        { mailbox: chainAddresses.mailbox },
+      ]),
+    ) as ChainMap<{ mailbox?: string }>;
+
+    const multiProtocolProvider = MultiProtocolProvider.fromMultiProvider(
+      this.multiProvider,
+    );
+    const extendedMultiProtocolProvider =
+      multiProtocolProvider.extendChainMetadata(mailboxes);
+
+    return {
+      warpCore: WarpCore.FromConfig(
+        extendedMultiProtocolProvider,
+        warpCoreConfig,
+      ),
+      hyperlaneCore: HyperlaneCore.fromAddressesMap(
+        addresses,
+        this.multiProvider,
+      ),
+    };
+  }
+
+  protected async loadWarpCoreConfig(): Promise<WarpCoreConfig> {
+    const baseUri = this.getRegistryUri();
+    const relativePath = this.getSelectedRegistryRelativePath();
+
+    if (!baseUri) {
+      throw new Error(
+        'Registry URI is unavailable; cannot load CCTP warp config',
+      );
+    }
+
+    if (this.isRemoteUri(baseUri)) {
+      const url = this.toConfigUrl(baseUri, relativePath);
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch CCTP warp config from ${url}: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      return parseYaml(await response.text()) as WarpCoreConfig;
+    }
+
+    const localPath = this.toLocalConfigPath(baseUri, relativePath);
+    return readYamlOrJson<WarpCoreConfig>(localPath);
+  }
+
+  protected getRegistryUri(): string | undefined {
+    if (
+      'getUri' in this.registry &&
+      typeof this.registry.getUri === 'function'
+    ) {
+      return this.registry.getUri();
+    }
+    if ('uri' in this.registry && typeof this.registry.uri === 'string') {
+      return this.registry.uri;
+    }
+    return undefined;
+  }
+
+  private isRemoteUri(uri: string): boolean {
+    return /^https?:\/\//.test(uri);
+  }
+
+  private toLocalConfigPath(baseUri: string, relativePath: string): string {
+    if (baseUri.startsWith('file://')) {
+      return join(fileURLToPath(baseUri), relativePath);
+    }
+    return join(baseUri, relativePath);
+  }
+
+  private toConfigUrl(baseUri: string, relativePath: string): string {
+    const url = new URL(baseUri);
+
+    if (url.hostname === 'github.com') {
+      const pathParts = url.pathname.split('/').filter(Boolean);
+      assert(
+        pathParts.length >= 2,
+        `Unsupported GitHub registry URI: ${baseUri}`,
+      );
+
+      const [owner, repo, maybeTree, ...rest] = pathParts;
+      const ref = maybeTree === 'tree' ? rest.join('/') || 'main' : 'main';
+      return `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${relativePath}`;
+    }
+
+    const normalized = baseUri.endsWith('/') ? baseUri : `${baseUri}/`;
+    return new URL(relativePath, normalized).toString();
+  }
+
+  async quote(
+    params: BridgeQuoteParams,
+  ): Promise<BridgeQuote<CctpWarpBridgeRoute>> {
+    assert(
+      params.toAmount === undefined,
+      'CCTP warp bridge does not support toAmount quotes',
+    );
+    assert(
+      params.fromAmount !== undefined,
+      'CCTP warp bridge requires fromAmount quotes',
+    );
+    assert(params.fromAmount > 0n, 'fromAmount must be positive');
+
+    const { warpCore } = await this.getContext();
+    const route = this.resolveBridgeRoute(warpCore, params);
+    const fromToken = this.getWarpTokenForChain(warpCore, route.fromChainName);
+    const toToken = this.getWarpTokenForChain(warpCore, route.toChainName);
+
+    const feeEstimate = await warpCore.estimateTransferRemoteFees({
+      originTokenAmount: fromToken.amount(params.fromAmount),
+      destination: route.toChainName,
+      recipient: route.toAddress,
+      sender: route.fromAddress,
+      destinationToken: toToken,
+    });
+
+    const tokenFeeAmount = feeEstimate.tokenFeeQuote?.amount ?? 0n;
+    const receivedAmount =
+      params.fromAmount > tokenFeeAmount
+        ? params.fromAmount - tokenFeeAmount
+        : 0n;
+
+    return {
+      id: `${this.externalBridgeId}-${this.config.mode}-${Date.now()}`,
+      tool: 'hyperlane-cctp-warp',
+      fromAmount: params.fromAmount,
+      toAmount: receivedAmount,
+      toAmountMin: receivedAmount,
+      executionDuration: 0,
+      gasCosts: feeEstimate.interchainQuote.amount,
+      feeCosts: tokenFeeAmount,
+      route,
+      requestParams: params,
+    };
+  }
+
+  async execute(
+    quote: BridgeQuote<CctpWarpBridgeRoute>,
+    privateKeys: Partial<Record<ProtocolType, string>>,
+  ): Promise<BridgeTransferResult> {
+    const { warpCore } = await this.getContext();
+    const route = this.parseRoute(quote.route);
+    const fromToken = this.getWarpTokenForChain(warpCore, route.fromChainName);
+    const toToken = this.getWarpTokenForChain(warpCore, route.toChainName);
+    const sourceProtocol = this.multiProvider.getProtocol(route.fromChainName);
+    const privateKey = privateKeys[sourceProtocol];
+
+    assert(
+      route.mode === this.config.mode,
+      `Quote mode ${route.mode} does not match bridge mode ${this.config.mode}`,
+    );
+    assert(
+      privateKey,
+      `Missing private key for protocol ${sourceProtocol} on ${route.fromChainName}`,
+    );
+
+    const txs = await warpCore.getTransferRemoteTxs({
+      originTokenAmount: fromToken.amount(quote.fromAmount),
+      destination: route.toChainName,
+      sender: route.fromAddress,
+      recipient: route.toAddress,
+      destinationToken: toToken,
+    });
+
+    assert(txs.length > 0, 'Expected at least one transferRemote transaction');
+
+    let transferTxHash: string | undefined;
+    for (const tx of txs) {
+      const txHash = await this.sendWarpTransaction(
+        route.fromChainName,
+        tx,
+        privateKey,
+        warpCore.multiProvider,
+      );
+      if (tx.category === WarpTxCategory.Transfer) {
+        transferTxHash = txHash;
+      }
+    }
+
+    assert(transferTxHash, 'No transfer transaction hash found');
+
+    const receipt = await this.multiProvider
+      .getProvider(route.fromChainName)
+      .getTransactionReceipt(transferTxHash);
+    assert(receipt, `Transfer transaction ${transferTxHash} receipt not found`);
+
+    const dispatchedMessages = HyperlaneCore.getDispatchedMessages(receipt);
+    assert(
+      dispatchedMessages.length === 1,
+      `Expected exactly 1 dispatched message, got ${dispatchedMessages.length}`,
+    );
+
+    return {
+      txHash: transferTxHash,
+      fromChain: quote.requestParams.fromChain,
+      toChain: quote.requestParams.toChain,
+      transferId: dispatchedMessages[0].id,
+    };
+  }
+
+  async getStatus(
+    txHash: string,
+    fromChain: number,
+    toChain: number,
+  ): Promise<BridgeTransferStatus> {
+    try {
+      const { hyperlaneCore, warpCore } = await this.getContext();
+      const fromChainName = this.resolveChainName(warpCore, fromChain);
+      const expectedToChainName = this.resolveChainName(warpCore, toChain);
+      const receipt = await this.multiProvider
+        .getProvider(fromChainName)
+        .getTransactionReceipt(txHash);
+
+      if (!receipt) {
+        return { status: 'not_found' };
+      }
+
+      const dispatchedMessages = HyperlaneCore.getDispatchedMessages(receipt);
+      if (dispatchedMessages.length !== 1) {
+        return {
+          status: 'failed',
+          error: `Expected exactly 1 dispatched message, got ${dispatchedMessages.length}`,
+        };
+      }
+
+      const dispatched = dispatchedMessages[0];
+      const actualToChainName = hyperlaneCore.getDestination(dispatched);
+      if (actualToChainName !== expectedToChainName) {
+        return {
+          status: 'failed',
+          error: `Dispatched destination ${actualToChainName} does not match expected ${expectedToChainName}`,
+        };
+      }
+
+      const delivered = await hyperlaneCore.isDelivered(dispatched);
+      if (!delivered) {
+        return { status: 'pending' };
+      }
+
+      const { amount } = parseWarpRouteMessage(dispatched.parsed.body);
+
+      try {
+        const processedReceipt =
+          await hyperlaneCore.getProcessedReceipt(dispatched);
+        return {
+          status: 'complete',
+          receivingTxHash: processedReceipt.transactionHash,
+          receivedAmount: amount,
+        };
+      } catch (error) {
+        this.logger.warn(
+          {
+            txHash,
+            messageId: dispatched.id,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          'Delivered CCTP warp message found without process receipt, falling back to origin tx hash',
+        );
+        return {
+          status: 'complete',
+          receivingTxHash: txHash,
+          receivedAmount: amount,
+        };
+      }
+    } catch (error) {
+      return {
+        status: 'failed',
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  protected async sendWarpTransaction(
+    chainName: ChainName,
+    tx: WarpTypedTransaction,
+    privateKey: string,
+    multiProtocolProvider: MultiProtocolProvider<{ mailbox?: string }>,
+  ): Promise<string> {
+    const signer = await getSignerForChain(
+      chainName,
+      {
+        protocol: ProtocolType.Ethereum,
+        privateKey: ensure0x(privateKey),
+      },
+      multiProtocolProvider,
+    );
+    const metadata = multiProtocolProvider.getChainMetadata(chainName);
+    const configuredConfirmations =
+      metadata.blocks?.reorgPeriod ?? metadata.blocks?.confirmations;
+    const waitConfirmations =
+      typeof configuredConfirmations === 'number' ? configuredConfirmations : 1;
+
+    return signer.sendAndConfirmTransaction(
+      toProtocolTransaction(tx, ProtocolType.Ethereum),
+      { waitConfirmations },
+    );
+  }
+
+  private resolveBridgeRoute(
+    warpCore: WarpCore,
+    params: BridgeQuoteParams,
+  ): CctpWarpBridgeRoute {
+    const fromChainName = this.resolveChainName(warpCore, params.fromChain);
+    const toChainName = this.resolveChainName(warpCore, params.toChain);
+    const toAddress = params.toAddress ?? params.fromAddress;
+    const fromToken = this.getWarpTokenForChain(warpCore, fromChainName);
+
+    assert(
+      fromToken.getConnectionForChain(toChainName),
+      `No CCTP warp route connection from ${fromChainName} to ${toChainName}`,
+    );
+
+    return {
+      mode: this.config.mode,
+      fromChainName,
+      toChainName,
+      fromAddress: params.fromAddress,
+      toAddress,
+    };
+  }
+
+  private resolveChainName(warpCore: WarpCore, chainRef: number): ChainName {
+    const chainNames = [...new Set(warpCore.tokens.map((t) => t.chainName))];
+
+    for (const chainName of chainNames) {
+      const chainId = Number(this.multiProvider.getChainId(chainName));
+      const domainId = this.multiProvider.getDomainId(chainName);
+      if (chainId === chainRef || domainId === chainRef) {
+        return chainName;
+      }
+    }
+
+    throw new Error(`Unsupported CCTP warp chain reference ${chainRef}`);
+  }
+
+  private getWarpTokenForChain(
+    warpCore: WarpCore,
+    chainName: ChainName,
+  ): Token {
+    const token = warpCore.tokens.find((t) => t.chainName === chainName);
+    assert(token, `No CCTP warp token configured for chain ${chainName}`);
+    return token;
+  }
+
+  private parseRoute(route: unknown): CctpWarpBridgeRoute {
+    assert(route && typeof route === 'object', 'CCTP warp route is missing');
+    const parsed = route as Partial<CctpWarpBridgeRoute>;
+
+    assert(
+      parsed.mode === 'fast' || parsed.mode === 'standard',
+      'CCTP warp route mode is invalid',
+    );
+    assert(
+      typeof parsed.fromChainName === 'string',
+      'CCTP warp route fromChainName is invalid',
+    );
+    assert(
+      typeof parsed.toChainName === 'string',
+      'CCTP warp route toChainName is invalid',
+    );
+    assert(
+      typeof parsed.fromAddress === 'string',
+      'CCTP warp route fromAddress is invalid',
+    );
+    assert(
+      typeof parsed.toAddress === 'string',
+      'CCTP warp route toAddress is invalid',
+    );
+
+    return {
+      mode: parsed.mode,
+      fromChainName: parsed.fromChainName,
+      toChainName: parsed.toChainName,
+      fromAddress: parsed.fromAddress,
+      toAddress: parsed.toAddress,
+    };
+  }
+}

--- a/typescript/rebalancer/src/config/RebalancerConfig.test.ts
+++ b/typescript/rebalancer/src/config/RebalancerConfig.test.ts
@@ -653,7 +653,7 @@ describe('per-chain bridge configuration', () => {
     });
   });
 
-  it('should require externalBridges.lifi when executionType is inventory', () => {
+  it('should require externalBridge when executionType is inventory', () => {
     const data = {
       warpRouteId: 'test-route',
       strategy: [
@@ -663,6 +663,7 @@ describe('per-chain bridge configuration', () => {
             ethereum: {
               weighted: { weight: 100, tolerance: 5 },
               executionType: ExecutionType.Inventory,
+              externalBridge: ExternalBridgeType.LiFi,
             },
           },
         },
@@ -675,7 +676,7 @@ describe('per-chain bridge configuration', () => {
     writeYamlOrJson(TEST_CONFIG_PATH_BRIDGE, data);
 
     expect(() => RebalancerConfig.load(TEST_CONFIG_PATH_BRIDGE)).to.throw(
-      /externalBridges\.lifi.*required/i,
+      /externalBridge/i,
     );
   });
 
@@ -706,7 +707,68 @@ describe('per-chain bridge configuration', () => {
     );
   });
 
-  it('should require externalBridge field when executionType is inventory', () => {
+  it('should accept externalBridges.cctpWarp when externalBridge is cctpWarp', () => {
+    const data: RebalancerConfigFileInput = {
+      warpRouteId: 'test-route',
+      strategy: [
+        {
+          rebalanceStrategy: RebalancerStrategyOptions.Weighted,
+          chains: {
+            ethereum: {
+              weighted: { weight: 100, tolerance: 5 },
+              executionType: ExecutionType.Inventory,
+              externalBridge: ExternalBridgeType.CctpWarp,
+            },
+          },
+        },
+      ],
+      inventorySigners: {
+        ethereum: '0x1234567890123456789012345678901234567890',
+      },
+      externalBridges: {
+        cctpWarp: {
+          mode: 'fast',
+        },
+      },
+    };
+
+    writeYamlOrJson(TEST_CONFIG_PATH_BRIDGE, data);
+    const config = RebalancerConfig.load(TEST_CONFIG_PATH_BRIDGE);
+
+    expect(config.strategyConfig[0].chains.ethereum.externalBridge).to.equal(
+      ExternalBridgeType.CctpWarp,
+    );
+    expect(config.externalBridges?.cctpWarp?.mode).to.equal('fast');
+  });
+
+  it('should require externalBridges.cctpWarp when externalBridge is cctpWarp', () => {
+    const data = {
+      warpRouteId: 'test-route',
+      strategy: [
+        {
+          rebalanceStrategy: RebalancerStrategyOptions.Weighted,
+          chains: {
+            ethereum: {
+              weighted: { weight: 100, tolerance: 5 },
+              executionType: ExecutionType.Inventory,
+              externalBridge: ExternalBridgeType.CctpWarp,
+            },
+          },
+        },
+      ],
+      inventorySigners: {
+        ethereum: '0x1234567890123456789012345678901234567890',
+      },
+    };
+
+    writeYamlOrJson(TEST_CONFIG_PATH_BRIDGE, data);
+
+    expect(() => RebalancerConfig.load(TEST_CONFIG_PATH_BRIDGE)).to.throw(
+      /externalBridges\.cctpWarp.*required|cctpWarp.*not configured/i,
+    );
+  });
+
+  it('should require externalBridge field when executionType is inventory even when externalBridges are configured', () => {
     const data = {
       warpRouteId: 'test-route',
       strategy: [

--- a/typescript/rebalancer/src/config/types.ts
+++ b/typescript/rebalancer/src/config/types.ts
@@ -36,6 +36,7 @@ export enum ExecutionType {
 
 export enum ExternalBridgeType {
   LiFi = 'lifi',
+  CctpWarp = 'cctpWarp',
 }
 
 export const RebalancerMinAmountConfigSchema = z.object({
@@ -126,8 +127,15 @@ export const LiFiBridgeConfigSchema = z.object({
   defaultSlippage: z.number().optional(),
 });
 
+export const CctpWarpBridgeModeSchema = z.enum(['fast', 'standard']);
+
+export const CctpWarpBridgeConfigSchema = z.object({
+  mode: CctpWarpBridgeModeSchema,
+});
+
 export const ExternalBridgesConfigSchema = z.object({
   lifi: LiFiBridgeConfigSchema.optional(),
+  cctpWarp: CctpWarpBridgeConfigSchema.optional(),
 });
 
 export const RebalancerConfigSchema = z
@@ -365,16 +373,44 @@ export const RebalancerConfigSchema = z
           // Other protocols: accept any non-empty string (future-proof)
         }
       }
-
-      if (!config.externalBridges?.lifi?.integrator) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message:
-            'externalBridges.lifi is required when using inventory execution',
-          path: ['externalBridges', 'lifi'],
-        });
-      }
     }
+
+    const getMissingExternalBridgeConfigPath = (
+      externalBridge: ExternalBridgeType | undefined,
+    ): (string | number)[] | undefined => {
+      switch (externalBridge) {
+        case ExternalBridgeType.LiFi:
+          return config.externalBridges?.lifi?.integrator
+            ? undefined
+            : ['externalBridges', 'lifi'];
+        case ExternalBridgeType.CctpWarp:
+          return config.externalBridges?.cctpWarp?.mode
+            ? undefined
+            : ['externalBridges', 'cctpWarp'];
+        case undefined:
+          return undefined;
+        default: {
+          const _exhaustive: never = externalBridge;
+          return _exhaustive;
+        }
+      }
+    };
+
+    const getExternalBridgeConfigError = (
+      chainName: string,
+      externalBridge: ExternalBridgeType,
+    ): string => {
+      switch (externalBridge) {
+        case ExternalBridgeType.LiFi:
+          return `Chain '${chainName}' uses externalBridge: 'lifi' but externalBridges.lifi is not configured`;
+        case ExternalBridgeType.CctpWarp:
+          return `Chain '${chainName}' uses externalBridge: 'cctpWarp' but externalBridges.cctpWarp is not configured`;
+        default: {
+          const _exhaustive: never = externalBridge;
+          return `Unsupported external bridge '${_exhaustive}'`;
+        }
+      }
+    };
 
     for (
       let strategyIndex = 0;
@@ -383,25 +419,29 @@ export const RebalancerConfigSchema = z
     ) {
       const strategy = config.strategy[strategyIndex];
       for (const [chainName, chainConfig] of Object.entries(strategy.chains)) {
-        const checkLifiBridge = (
+        const checkExternalBridgeConfig = (
           externalBridge: ExternalBridgeType | undefined,
           path: (string | number)[],
         ) => {
-          if (
-            externalBridge === ExternalBridgeType.LiFi &&
-            !config.externalBridges?.lifi?.integrator
-          ) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: `Chain '${chainName}' uses externalBridge: 'lifi' but externalBridges.lifi is not configured`,
-              path,
-            });
-          }
+          if (!externalBridge) return;
+
+          const missingPath =
+            getMissingExternalBridgeConfigPath(externalBridge);
+          if (!missingPath) return;
+
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: getExternalBridgeConfigError(chainName, externalBridge),
+            path,
+          });
         };
 
-        checkLifiBridge(chainConfig.externalBridge, [
-          'externalBridges',
-          'lifi',
+        checkExternalBridgeConfig(chainConfig.externalBridge, [
+          'strategy',
+          strategyIndex,
+          'chains',
+          chainName,
+          'externalBridge',
         ]);
 
         if (chainConfig.override) {
@@ -412,7 +452,7 @@ export const RebalancerConfigSchema = z
               ...chainConfig,
               ...(overrideConfig as Record<string, unknown>),
             };
-            checkLifiBridge(
+            checkExternalBridgeConfig(
               merged.externalBridge as ExternalBridgeType | undefined,
               [
                 'strategy',

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -19,6 +19,7 @@ import {
   toWei,
 } from '@hyperlane-xyz/utils';
 
+import { CctpWarpBridge } from '../bridges/CctpWarpBridge.js';
 import { LiFiBridge } from '../bridges/LiFiBridge.js';
 import { type RebalancerConfig } from '../config/RebalancerConfig.js';
 import {
@@ -623,6 +624,20 @@ export class RebalancerContextFactory {
                 defaultSlippage: lifiConfig.defaultSlippage,
                 chainMetadata: this.multiProvider.metadata,
               },
+              this.logger,
+            );
+          }
+          break;
+        }
+        case ExternalBridgeType.CctpWarp: {
+          const cctpWarpConfig = externalBridges?.cctpWarp;
+          if (cctpWarpConfig?.mode) {
+            registry[ExternalBridgeType.CctpWarp] = new CctpWarpBridge(
+              {
+                mode: cctpWarpConfig.mode,
+              },
+              this.multiProvider,
+              this.registry,
               this.logger,
             );
           }


### PR DESCRIPTION
## Summary
- add `cctpWarp` external bridge support to the rebalancer
- load the USDC CCTP v2 fast/standard warp configs from the registry URI
- implement bridge `quote`/`execute`/`getStatus` using WarpCore + Hyperlane message delivery status
- make external bridge config validation bridge-specific instead of globally requiring LiFi
- add bridge/config tests for the new path

## Testing
- `pnpm -C typescript/rebalancer build`
- `pnpm -C typescript/rebalancer exec mocha --config .mocharc.json src/config/RebalancerConfig.test.ts --exit`
- `pnpm -C typescript/rebalancer exec mocha --config .mocharc.json src/bridges/CctpWarpBridge.test.ts --exit`
