### PR TITLE
feat(sealevel): add eclipse IGP configs for BSC and Plasma

### DIFF
--- a/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
+++ b/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
@@ -346,6 +346,14 @@
       },
       "overhead": 166460
     },
+    "bsc": {
+      "oracleConfig": {
+        "tokenExchangeRate": "4079824281450053504",
+        "gasPrice": "1062892149",
+        "tokenDecimals": 18
+      },
+      "overhead": 166460
+    },
     "celestia": {
       "oracleConfig": {
         "tokenExchangeRate": "200440939042",
@@ -406,6 +414,14 @@
       "oracleConfig": {
         "tokenExchangeRate": "15000000000000000000",
         "gasPrice": "72272014",
+        "tokenDecimals": 18
+      },
+      "overhead": 166460
+    },
+    "plasma": {
+      "oracleConfig": {
+        "tokenExchangeRate": "761144329509827",
+        "gasPrice": "5697228536034",
         "tokenDecimals": 18
       },
       "overhead": 166460

--- a/typescript/infra/scripts/sealevel-helpers/print-gas-oracles.ts
+++ b/typescript/infra/scripts/sealevel-helpers/print-gas-oracles.ts
@@ -141,6 +141,8 @@ function getChainConnections(
       ['eclipsemainnet', 'optimism'],
       ['eclipsemainnet', 'polygon'],
       ['eclipsemainnet', 'tron'],
+      ['eclipsemainnet', 'bsc'],
+      ['eclipsemainnet', 'plasma'],
       // for solaxy routes
       ['solaxy', 'solanamainnet'],
       ['solaxy', 'ethereum'],


### PR DESCRIPTION
## Summary
- Added gas oracle configurations for BSC and Plasma chain connections to Eclipse mainnet
- Registered new `eclipsemainnet`↔`bsc` and `eclipsemainnet`↔`plasma` connections in the print-gas-oracles helper

## Test plan
- [ ] Verify gas oracle configs are correct via `print-gas-oracles` script
- [ ] Confirm oracle values match expected exchange rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates mainnet gas-oracle configuration values used for fee quoting on `eclipsemainnet` routes; incorrect rates/prices could cause mispriced IGP fees in production.
> 
> **Overview**
> Adds `mainnet3` gas oracle/overhead config entries for `eclipsemainnet -> bsc` and `eclipsemainnet -> plasma`.
> 
> Updates the `print-gas-oracles` helper to include the new `eclipsemainnet`↔`bsc` and `eclipsemainnet`↔`plasma` chain connections when generating sealevel IGP gas-oracle configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15bcaf69a177892b3cbdd70f2ffe5e30af6a7e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->