### PR TITLE
feat: add selective widget wallet surfaces

### DIFF
--- a/.changeset/neat-taxis-breathe.md
+++ b/.changeset/neat-taxis-breathe.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/widgets': patch
+---
+
+Added selective wallet integration base components that accept injected protocol state instead of eagerly wiring every wallet hook.

--- a/typescript/widgets/src/walletIntegrations/AccountList.tsx
+++ b/typescript/widgets/src/walletIntegrations/AccountList.tsx
@@ -3,7 +3,7 @@ import React, { ButtonHTMLAttributes } from 'react';
 
 import type { MinimalProviderRegistry } from '@hyperlane-xyz/sdk/providers/MinimalProviderRegistry';
 import type { ChainName } from '@hyperlane-xyz/sdk/types';
-import { ProtocolType, objKeys } from '@hyperlane-xyz/utils';
+import { ProtocolType } from '@hyperlane-xyz/utils';
 
 import { Button } from '../components/Button.js';
 import { IconButton } from '../components/IconButton.js';
@@ -18,27 +18,42 @@ import { useAccounts } from '../walletIntegrations/accounts.js';
 import { useDisconnectFns } from '../walletIntegrations/disconnectFns.js';
 import { useWalletDetails } from '../walletIntegrations/walletDetails.js';
 
-import { AccountInfo, WalletDetails } from './types.js';
+import {
+  AccountInfo,
+  ProtocolDisconnectFns,
+  ProtocolWalletDetailsMap,
+  WalletDetails,
+} from './types.js';
 
 const logger = widgetLogger.child({ module: 'walletIntegrations/AccountList' });
+const EMPTY_WALLET_DETAILS: WalletDetails = {};
 
-export function AccountList({
-  multiProvider,
+type SharedAccountListProps = {
+  onClickConnectWallet: () => void;
+  onCopySuccess?: () => void;
+  className?: string;
+  chainName?: ChainName;
+};
+
+export type BaseAccountListProps = SharedAccountListProps & {
+  readyAccounts: AccountInfo[];
+  disconnectFns: ProtocolDisconnectFns;
+  walletDetails: ProtocolWalletDetailsMap;
+};
+
+export type AccountListProps = SharedAccountListProps & {
+  multiProvider: MinimalProviderRegistry;
+};
+
+export function BaseAccountList({
+  readyAccounts,
+  disconnectFns,
+  walletDetails,
   onClickConnectWallet,
   onCopySuccess,
   className,
   chainName,
-}: {
-  multiProvider: MinimalProviderRegistry;
-  onClickConnectWallet: () => void;
-  onCopySuccess?: () => void;
-  className?: string;
-  chainName?: string;
-}) {
-  const { readyAccounts } = useAccounts(multiProvider);
-  const disconnectFns = useDisconnectFns();
-  const walletDetails = useWalletDetails();
-
+}: BaseAccountListProps) {
   const onClickDisconnect = async (protocol: ProtocolType) => {
     try {
       const disconnectFn = disconnectFns[protocol];
@@ -49,7 +64,7 @@ export function AccountList({
   };
 
   const onClickDisconnectAll = async () => {
-    for (const protocol of objKeys(disconnectFns)) {
+    for (const protocol of Object.keys(disconnectFns) as ProtocolType[]) {
       await onClickDisconnect(protocol);
     }
   };
@@ -60,7 +75,7 @@ export function AccountList({
         <AccountSummary
           key={i}
           account={acc}
-          walletDetails={walletDetails[acc.protocol]}
+          walletDetails={walletDetails[acc.protocol] ?? EMPTY_WALLET_DETAILS}
           onCopySuccess={onCopySuccess}
           onClickDisconnect={() => onClickDisconnect(acc.protocol)}
           chainName={chainName}
@@ -81,6 +96,23 @@ export function AccountList({
         <div className="htw-ml-2 htw-text-sm">Disconnect all wallets</div>
       </Button>
     </div>
+  );
+}
+
+// Full-matrix convenience wrapper. Selective consumers should use
+// BaseAccountList with protocol-specific hooks and injected state.
+export function AccountList({ multiProvider, ...props }: AccountListProps) {
+  const { readyAccounts } = useAccounts(multiProvider);
+  const disconnectFns = useDisconnectFns();
+  const walletDetails = useWalletDetails();
+
+  return (
+    <BaseAccountList
+      readyAccounts={readyAccounts}
+      disconnectFns={disconnectFns}
+      walletDetails={walletDetails}
+      {...props}
+    />
   );
 }
 

--- a/typescript/widgets/src/walletIntegrations/ConnectWalletButton.tsx
+++ b/typescript/widgets/src/walletIntegrations/ConnectWalletButton.tsx
@@ -13,9 +13,25 @@ import { useIsSsr } from '../utils/ssr.js';
 import { WalletLogo } from './WalletLogo.js';
 import { getAddressFromAccountAndChain } from './accountUtils.js';
 import { useAccounts } from './accounts.js';
+import type {
+  AccountInfo,
+  ProtocolWalletDetailsMap,
+  WalletDetails,
+} from './types.js';
 import { useWalletDetails } from './walletDetails.js';
 
-type Props = {
+const EMPTY_WALLET_DETAILS: WalletDetails = {};
+
+export type BaseConnectWalletButtonProps = {
+  readyAccounts: AccountInfo[];
+  walletDetails: ProtocolWalletDetailsMap;
+  onClickWhenConnected: () => void;
+  onClickWhenUnconnected: () => void;
+  countClassName?: string;
+  chainName?: ChainName;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+export type ConnectWalletButtonProps = {
   multiProvider: MinimalProviderRegistry;
   onClickWhenConnected: () => void;
   onClickWhenUnconnected: () => void;
@@ -23,19 +39,17 @@ type Props = {
   chainName?: ChainName;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
-export function ConnectWalletButton({
-  multiProvider,
+export function BaseConnectWalletButton({
+  readyAccounts,
+  walletDetails,
   onClickWhenConnected,
   onClickWhenUnconnected,
   className,
   countClassName,
   chainName,
   ...rest
-}: Props) {
+}: BaseConnectWalletButtonProps) {
   const isSsr = useIsSsr();
-
-  const { readyAccounts } = useAccounts(multiProvider);
-  const walletDetails = useWalletDetails();
 
   const numReady = readyAccounts.length;
   const firstAccount = readyAccounts[0];
@@ -46,7 +60,9 @@ export function ConnectWalletButton({
   );
 
   const firstWallet =
-    walletDetails[firstAccount?.protocol || ProtocolType.Ethereum];
+    (firstAccount && walletDetails[firstAccount.protocol]) ||
+    walletDetails[ProtocolType.Ethereum] ||
+    EMPTY_WALLET_DETAILS;
 
   if (isSsr) {
     // https://github.com/wagmi-dev/wagmi/issues/542#issuecomment-1144178142
@@ -115,5 +131,23 @@ export function ConnectWalletButton({
         )}
       </div>
     </div>
+  );
+}
+
+// Full-matrix convenience wrapper. Selective consumers should use
+// BaseConnectWalletButton with protocol-specific hooks and injected state.
+export function ConnectWalletButton({
+  multiProvider,
+  ...props
+}: ConnectWalletButtonProps) {
+  const { readyAccounts } = useAccounts(multiProvider);
+  const walletDetails = useWalletDetails();
+
+  return (
+    <BaseConnectWalletButton
+      readyAccounts={readyAccounts}
+      walletDetails={walletDetails}
+      {...props}
+    />
   );
 }

--- a/typescript/widgets/src/walletIntegrations/MultiProtocolWalletModal.tsx
+++ b/typescript/widgets/src/walletIntegrations/MultiProtocolWalletModal.tsx
@@ -6,20 +6,23 @@ import { Modal } from '../layout/Modal.js';
 import { PROTOCOL_TO_LOGO } from '../logos/protocols.js';
 
 import { useConnectFns } from './multiProtocol.js';
+import type { ProtocolConnectFns } from './types.js';
 
-export function MultiProtocolWalletModal({
-  isOpen,
-  close,
-  protocols,
-  onProtocolSelected,
-}: {
+export type BaseMultiProtocolWalletModalProps = {
+  connectFns: ProtocolConnectFns;
   isOpen: boolean;
   close: () => void;
   protocols?: ProtocolType[]; // defaults to all protocols if not provided
   onProtocolSelected?: (protocol: ProtocolType) => void;
-}) {
-  const connectFns = useConnectFns();
+};
 
+export function BaseMultiProtocolWalletModal({
+  connectFns,
+  isOpen,
+  close,
+  protocols,
+  onProtocolSelected,
+}: BaseMultiProtocolWalletModalProps) {
   const onClickProtocol = (protocol: ProtocolType) => {
     close();
     const connectFn = connectFns[protocol];
@@ -99,6 +102,18 @@ export function MultiProtocolWalletModal({
       </div>
     </Modal>
   );
+}
+
+export type MultiProtocolWalletModalProps = Omit<
+  BaseMultiProtocolWalletModalProps,
+  'connectFns'
+>;
+
+// Full-matrix convenience wrapper. Selective consumers should use
+// BaseMultiProtocolWalletModal with protocol-specific hooks and injected state.
+export function MultiProtocolWalletModal(props: MultiProtocolWalletModalProps) {
+  const connectFns = useConnectFns();
+  return <BaseMultiProtocolWalletModal connectFns={connectFns} {...props} />;
 }
 
 function ProtocolButton({

--- a/typescript/widgets/src/walletIntegrations/types.ts
+++ b/typescript/widgets/src/walletIntegrations/types.ts
@@ -25,6 +25,14 @@ export interface WalletDetails {
   logoUrl?: string;
 }
 
+export type ProtocolConnectFns = Partial<Record<ProtocolType, () => void>>;
+export type ProtocolDisconnectFns = Partial<
+  Record<ProtocolType, () => Promise<void>>
+>;
+export type ProtocolWalletDetailsMap = Partial<
+  Record<ProtocolType, WalletDetails>
+>;
+
 export interface ActiveChainInfo {
   chainDisplayName?: string;
   chainName?: ChainName;


### PR DESCRIPTION
## Summary
- add `BaseConnectWalletButton`, `BaseAccountList`, and `BaseMultiProtocolWalletModal` that accept injected protocol-specific state instead of eagerly wiring every wallet hook
- keep the existing `ConnectWalletButton`, `AccountList`, and `MultiProtocolWalletModal` wrappers as full-matrix convenience APIs
- add the supporting public wallet map types and a widgets changeset
- rebase this stacked PR onto the latest `#8575` head and latest `main`

## Why
`#8575` makes SDK runtime registration explicit, but widgets still force consumers through the full wallet hook matrix. That keeps the current convenience path, but it does not give selective consumers a clean way to compose only the wallet protocols they want.

This PR makes the wallet UI surfaces injectable so downstream apps can keep the existing visuals without importing every wallet integration hook.

## Gist
- context / current stack state / remaining follow-ups: https://gist.github.com/paulbalaji/3b02a115746386bb199187dc5a1c3ec9

## Downstream usage
Existing widget consumers are unchanged:

```tsx
<ConnectWalletButton multiProvider={multiProvider} ... />
```

Selective consumers can now inject only the protocols they care about:

```tsx
const evmAccount = useEthereumAccount(multiProvider);
const evmWalletDetails = useEthereumWalletDetails();

<BaseConnectWalletButton
  readyAccounts={evmAccount.isReady ? [evmAccount] : []}
  walletDetails={{ [ProtocolType.Ethereum]: evmWalletDetails }}
  onClickWhenConnected={openMenu}
  onClickWhenUnconnected={connectEvm}
/>
```

The same pattern now exists for `AccountList` and `MultiProtocolWalletModal`.

## Validation
- `pnpm -C typescript/widgets build`
- `pnpm -C typescript/widgets exec oxlint -c ../../oxlint.json src/walletIntegrations/types.ts src/walletIntegrations/ConnectWalletButton.tsx src/walletIntegrations/AccountList.tsx src/walletIntegrations/MultiProtocolWalletModal.tsx`
- `pnpm install` from repo root on `pbio/widgets-selective-wallet-surfaces`
- `pnpm build` from repo root on `pbio/widgets-selective-wallet-surfaces`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily additive API surface and light refactoring of wallet UI components; existing wrapper props remain intact, with minimal behavioral changes aside from safer defaults when wallet details are missing.
> 
> **Overview**
> Adds injectable *base* wallet UI components (`BaseConnectWalletButton`, `BaseAccountList`, `BaseMultiProtocolWalletModal`) that accept protocol-specific accounts/connect-disconnect functions/wallet metadata via props, enabling consumers to integrate only selected wallet protocols.
> 
> Keeps the existing `ConnectWalletButton`, `AccountList`, and `MultiProtocolWalletModal` as convenience wrappers that still wire the full hook matrix internally, and introduces new public `Protocol*` map types plus a patch changeset for `@hyperlane-xyz/widgets`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c269a1dfe0e7f63d1febae51ef886e9c7c28b972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
