### PR TITLE
fix(utils): use readUInt8 for browser Buffer polyfill compat

### DIFF
--- a/.changeset/fix-buffer-readuint8.md
+++ b/.changeset/fix-buffer-readuint8.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/utils': patch
 ---
 
-Fix `parseMessage` crash in browser environments by using `readUInt8` instead of the Node.js 16+ `readUint8` alias, which is missing from common Buffer polyfills.
+Fixed `parseMessage` crash in browser environments by using `readUInt8` instead of the Node.js 16+ `readUint8` alias, which is missing from common Buffer polyfills.

--- a/.changeset/fix-buffer-readuint8.md
+++ b/.changeset/fix-buffer-readuint8.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/utils': patch
+---
+
+Fix `parseMessage` crash in browser environments by using `readUInt8` instead of the Node.js 16+ `readUint8` alias, which is missing from common Buffer polyfills.

--- a/typescript/utils/src/messages.ts
+++ b/typescript/utils/src/messages.ts
@@ -65,7 +65,7 @@ export function parseMessage(message: string): ParsedMessage {
   const BODY_OFFSET = 77;
 
   const buf = Buffer.from(utils.arrayify(message));
-  const version = buf.readUint8(VERSION_OFFSET);
+  const version = buf.readUInt8(VERSION_OFFSET);
   const nonce = buf.readUInt32BE(NONCE_OFFSET);
   const origin = buf.readUInt32BE(ORIGIN_OFFSET);
   const sender = utils.hexlify(buf.subarray(SENDER_OFFSET, DESTINATION_OFFSET));


### PR DESCRIPTION
## Summary

`parseMessage` in `@hyperlane-xyz/utils` uses `buf.readUint8()` (lowercase 'i') which is a Node.js 16+ alias that does not exist on browser Buffer polyfills. This causes EVM message ID extraction to silently fail in the Warp UI — the error is caught by a try-catch and `undefined` is returned, so transfers complete but message tracking (explorer links, delivery status) breaks.

## Why this change is needed

The Warp UI runs `parseMessage` client-side in the browser. The browser doesn't have native `Buffer` — it relies on a polyfill. Next.js's compiled buffer polyfill (`next/dist/compiled/buffer`) only exposes the original `readUInt8` (capital 'I') method, not the `readUint8` alias added in Node.js 16. When called, it throws `TypeError: buf.readUint8 is not a function`, which gets swallowed by the surrounding try-catch and returns no message ID.

## Why Turbopack broke it

This code existed since August 2023 but only started failing after the Warp UI migrated from webpack to **Turbopack** (March 2026). With webpack, Next.js used `ProvidePlugin` to inject `Buffer` globally into client bundles:

```js
new bundler.ProvidePlugin({
  Buffer: [require.resolve('buffer'), 'Buffer'],
})
```

Turbopack does not support webpack plugins, so `ProvidePlugin` no longer applies. Turbopack handles Node.js globals differently, and the Buffer polyfill it provides lacks the lowercase `readUint8` alias.

## Why `readUInt8` over `readUint8`

Both are functionally identical in Node.js 16+ — `readUint8` is simply an alias for `readUInt8`. However, `readUInt8` (capital 'I') is the **original** method name that has existed since Node.js v0.x and is supported by every Buffer implementation including:
- Node.js native Buffer (all versions)
- The `buffer` npm polyfill (feross/buffer)
- Next.js's compiled buffer polyfill (`next/dist/compiled/buffer`)

`readUint8` (lowercase) was only added in Node.js 16 and is **not** present in common browser polyfills. Using `readUInt8` is the universally compatible choice.

## Test plan

- Tested in the browser — EVM message IDs are now correctly extracted after the fix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
