### PR TITLE
chore(starknet-sdk): make starknet e2e tests go brrr

### DIFF
--- a/.changeset/fast-starknet-tests.md
+++ b/.changeset/fast-starknet-tests.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/starknet-sdk': patch
+---
+
+Starknet devnet switched to instant per-transaction block mining and starknet.js polling interval reduced for fast block times, speeding up e2e tests ~5x.

--- a/typescript/cli/test-configs/test-registry/chains/starknet1/metadata.yaml
+++ b/typescript/cli/test-configs/test-registry/chains/starknet1/metadata.yaml
@@ -5,7 +5,7 @@ blockExplorers:
     url: http://127.0.0.1:5050
 blocks:
   confirmations: 0
-  estimateBlockTime: 5
+  estimateBlockTime: 0.25
   reorgPeriod: 0
 chainId: '0x534e5f5345504f4c4941'
 displayName: Starknet1

--- a/typescript/cli/test-configs/test-registry/chains/starknet2/metadata.yaml
+++ b/typescript/cli/test-configs/test-registry/chains/starknet2/metadata.yaml
@@ -5,7 +5,7 @@ blockExplorers:
     url: http://127.0.0.1:5051
 blocks:
   confirmations: 0
-  estimateBlockTime: 5
+  estimateBlockTime: 0.25
   reorgPeriod: 0
 chainId: '0x534e5f5345504f4c4941'
 displayName: Starknet2

--- a/typescript/starknet-sdk/src/clients/provider.ts
+++ b/typescript/starknet-sdk/src/clients/provider.ts
@@ -20,6 +20,7 @@ import {
   addressToBytes32,
   assert,
   ensure0x,
+  isNullish,
   isZeroishAddress,
 } from '@hyperlane-xyz/utils';
 
@@ -105,8 +106,9 @@ export class StarknetProvider implements AltVM.IProvider<StarknetAnnotatedTx> {
     const metadata = extraParams.metadata;
     assert(rpcUrls.length > 0, 'at least one rpc url is required');
 
-    const blockTime = metadata.blocks?.estimateBlockTime ?? 0;
-    const transactionRetryIntervalFallback = blockTime <= 1 ? 1000 : undefined;
+    const blockTime = metadata.blocks?.estimateBlockTime;
+    const transactionRetryIntervalFallback =
+      !isNullish(blockTime) && blockTime <= 1 ? 1000 : undefined;
 
     const provider = new RpcProvider({
       nodeUrl: rpcUrls[0],

--- a/typescript/starknet-sdk/src/clients/provider.ts
+++ b/typescript/starknet-sdk/src/clients/provider.ts
@@ -104,7 +104,14 @@ export class StarknetProvider implements AltVM.IProvider<StarknetAnnotatedTx> {
     assert(extraParams?.metadata, 'metadata missing for Starknet provider');
     const metadata = extraParams.metadata;
     assert(rpcUrls.length > 0, 'at least one rpc url is required');
-    const provider = new RpcProvider({ nodeUrl: rpcUrls[0] });
+
+    const blockTime = metadata.blocks?.estimateBlockTime ?? 0;
+    const transactionRetryIntervalFallback = blockTime <= 1 ? 1000 : undefined;
+
+    const provider = new RpcProvider({
+      nodeUrl: rpcUrls[0],
+      transactionRetryIntervalFallback,
+    });
     return new StarknetProvider(provider, metadata, rpcUrls);
   }
 

--- a/typescript/starknet-sdk/src/testing/constants.ts
+++ b/typescript/starknet-sdk/src/testing/constants.ts
@@ -24,7 +24,7 @@ export const TEST_STARKNET_CHAIN_METADATA: TestChainMetadata = {
   },
   blocks: {
     confirmations: 0,
-    estimateBlockTime: 5,
+    estimateBlockTime: 0.5,
   },
   rpcUrls: [{ http: 'http://127.0.0.1:5050' }],
   rpcPort: 5050,

--- a/typescript/starknet-sdk/src/testing/node.ts
+++ b/typescript/starknet-sdk/src/testing/node.ts
@@ -79,7 +79,8 @@ export async function runStarknetNode(
             '--state-archive-capacity',
             'full',
             '--block-generation-on',
-            '5',
+            'transaction',
+            '--lite-mode',
             '--seed',
             '0',
           ])


### PR DESCRIPTION
### Description

  Sped up Starknet e2e tests by switching the devnet to instant block mining and reducing the starknet.js transaction polling interval.

  - Changed devnet from 5s periodic block generation to per-transaction instant mining (`--block-generation-on transaction`) and added `--lite-mode` to skip block hash calculation
  - Set `transactionRetryIntervalFallback` to 1000ms on `RpcProvider` when `estimateBlockTime <= 1`, avoiding the starknet.js 5000ms default
  - Updated `estimateBlockTime` in test chain metadata to reflect faster devnet: 0.5s (SDK), 0.25s (CLI starknet1/starknet2)

  ### Drive-by changes

  None

  ### Related issues

  None

  ### Backward compatibility

  Yes — the provider change only applies when `estimateBlockTime <= 1` (test devnets). Chains with normal block times are unaffected (starknet.js default is used).

  ### Testing

  Manual — ran starknet-sdk and CLI e2e tests locally, confirmed all pass with ~5x speedup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
