### PR TITLE
feat(widgets): export Skeleton on a narrow subpath

### DIFF
--- a/.changeset/small-pans-divide.md
+++ b/.changeset/small-pans-divide.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/widgets': patch
 ---
 
-Added a narrow `@hyperlane-xyz/widgets/animations/Skeleton` export.
+Added `@hyperlane-xyz/widgets/animations/*` subpath exports.

--- a/.changeset/small-pans-divide.md
+++ b/.changeset/small-pans-divide.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/widgets': patch
+---
+
+Added a narrow `@hyperlane-xyz/widgets/animations/Skeleton` export.

--- a/typescript/widgets/package.json
+++ b/typescript/widgets/package.json
@@ -23,6 +23,10 @@
       "default": "./dist/index.js"
     },
     "./styles.css": "./dist/styles.css",
+    "./animations/Skeleton": {
+      "types": "./dist/animations/Skeleton.d.ts",
+      "default": "./dist/animations/Skeleton.js"
+    },
     "./chains/*": {
       "types": "./dist/chains/*.d.ts",
       "default": "./dist/chains/*.js"

--- a/typescript/widgets/package.json
+++ b/typescript/widgets/package.json
@@ -23,9 +23,9 @@
       "default": "./dist/index.js"
     },
     "./styles.css": "./dist/styles.css",
-    "./animations/Skeleton": {
-      "types": "./dist/animations/Skeleton.d.ts",
-      "default": "./dist/animations/Skeleton.js"
+    "./animations/*": {
+      "types": "./dist/animations/*.d.ts",
+      "default": "./dist/animations/*.js"
     },
     "./chains/*": {
       "types": "./dist/chains/*.d.ts",


### PR DESCRIPTION
## Summary
- add a narrow `@hyperlane-xyz/widgets/animations/Skeleton` export
- avoid widening consumers back to the root `@hyperlane-xyz/widgets` barrel for a trivial placeholder
- keep scope to the single export plus changeset

## Why
Warp UI currently keeps a local loading skeleton in a hot-path modal because `Skeleton` is only available from the widgets root barrel. This follow-up gives consumers a narrow path so they can reuse the shared component without reintroducing the broad import surface.

## Validation
- `pnpm --filter @hyperlane-xyz/widgets build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes package `exports` to expose additional subpath entrypoints and adds a changeset; runtime code is unchanged.
> 
> **Overview**
> Adds `@hyperlane-xyz/widgets/animations/*` subpath exports in `@hyperlane-xyz/widgets` so consumers can import animation modules (e.g. `.../animations/Skeleton`) without going through the root barrel.
> 
> Includes a patch changeset to publish the updated export map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e805c8c4ee374feb6ca59b6047a1861f5ca69092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
