### PR TITLE
fix(sdk): connect mailbox with current signer in deliver()

### DIFF
--- a/.changeset/fix-status-relay-signer.md
+++ b/.changeset/fix-status-relay-signer.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/sdk': patch
+'@hyperlane-xyz/cli': patch
+---
+
+Fixed `deliver()` and `sendMessage()` in HyperlaneCore to connect the mailbox with the current signer at call time, preventing "sending a transaction requires a signer" errors when signers are added after construction. The `status --relay` command now exits non-zero when relay fails.

--- a/typescript/cli/src/status/message.ts
+++ b/typescript/cli/src/status/message.ts
@@ -152,7 +152,16 @@ export async function checkMessageStatus({
         const merkleAddress = coreAddresses[origin].merkleTreeHook;
         stubMerkleTreeConfig(relayer, origin, hookAddress, merkleAddress);
       }
-      await relayer.relayAll(dispatchedReceipt, relayable);
+      // relayAll returns a receipt per message: either from the relay tx or,
+      // if the message was already delivered, from getProcessedReceipt.
+      const results = await relayer.relayAll(dispatchedReceipt, relayable);
+      const delivered = Object.values(results).flat().length;
+      const failed = relayable.length - delivered;
+      if (failed > 0) {
+        logRed(`Failed to relay ${failed}/${relayable.length} messages`);
+        process.exit(1);
+      }
+      logGreen(`Relayed ${delivered} message(s)`);
     } else if (undelivered.length > 0) {
       warnYellow(
         'No messages could be relayed - missing signers for all destination chains',

--- a/typescript/cli/src/tests/ethereum/status.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/status.e2e-test.ts
@@ -146,6 +146,13 @@ describe('hyperlane status e2e tests', async function () {
       });
 
       expect(exitCode).to.equal(0);
+
+      // Verify the message is now delivered
+      const { stdout } = await hyperlaneStatus({
+        origin: CHAIN_NAME_2,
+        messageId,
+      });
+      expect(stdout).to.include('was delivered');
     });
 
     it('should prompt for key when using --relay without providing key', async () => {

--- a/typescript/cli/src/tests/ethereum/status.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/status.e2e-test.ts
@@ -128,6 +128,26 @@ describe('hyperlane status e2e tests', async function () {
       expect(exitCode).to.equal(0);
     });
 
+    it('should actually deliver the message when relaying', async () => {
+      // Send a message with quick mode so it is NOT auto-delivered
+      const sendResult = await hyperlaneSendMessage(
+        CHAIN_NAME_2,
+        CHAIN_NAME_3,
+        { quick: true },
+      );
+      const messageId = extractMessageId(sendResult.stdout);
+
+      // Relay via status --relay. Exits non-zero if relay fails.
+      const { exitCode } = await hyperlaneStatus({
+        origin: CHAIN_NAME_2,
+        messageId,
+        relay: true,
+        key: ANVIL_KEY,
+      });
+
+      expect(exitCode).to.equal(0);
+    });
+
     it('should prompt for key when using --relay without providing key', async () => {
       // Send a message first
       const sendResult = await hyperlaneSendMessage(

--- a/typescript/sdk/src/core/HyperlaneCore.ts
+++ b/typescript/sdk/src/core/HyperlaneCore.ts
@@ -150,7 +150,9 @@ export class HyperlaneCore extends HyperlaneApp<CoreFactories> {
     hook?: Address,
     metadata?: string,
   ): Promise<{ dispatchTx: TransactionReceipt; message: DispatchedMessage }> {
-    const mailbox = this.getContracts(origin).mailbox;
+    const mailbox = this.getContracts(origin).mailbox.connect(
+      this.multiProvider.getSigner(origin),
+    );
     const destinationDomain = this.multiProvider.getDomainId(destination);
     const recipientBytes32 = addressToBytes32(recipient);
     const quote = await this.quoteGasPayment(

--- a/typescript/sdk/src/core/HyperlaneCore.ts
+++ b/typescript/sdk/src/core/HyperlaneCore.ts
@@ -334,15 +334,14 @@ export class HyperlaneCore extends HyperlaneApp<CoreFactories> {
     ismMetadata: string,
   ): Promise<ethers.ContractReceipt> {
     const destinationChain = this.getDestination(message);
+    const mailbox = this.getContracts(destinationChain).mailbox.connect(
+      this.multiProvider.getSigner(destinationChain),
+    );
     const txOverrides =
       this.multiProvider.getTransactionOverrides(destinationChain);
     return this.multiProvider.handleTx(
       destinationChain,
-      this.getContracts(destinationChain).mailbox.process(
-        ismMetadata,
-        message.message,
-        { ...txOverrides },
-      ),
+      mailbox.process(ismMetadata, message.message, { ...txOverrides }),
     );
   }
 


### PR DESCRIPTION
## Summary
- `HyperlaneCore.deliver()` now reconnects the mailbox contract with the current signer from `MultiProvider` at call time, instead of relying on the stale connection from construction
- `status --relay` now exits non-zero when relay fails (previously silently swallowed errors and exited 0)
- Added e2e test that verifies `status --relay` actually delivers the message

## Context
`hyperlane status --relay` was failing with `"sending a transaction requires a signer"`. The destination chain signer is added lazily (after `HyperlaneCore` is constructed), but `deliver()` was using the mailbox contract as connected at construction time — which only had a read-only `Provider`.

## Test plan
- [x] `CLI_E2E_TEST=status pnpm -C typescript/cli test:ethereum:e2e` passes (6/6)
- [x] Manually verified relay of stuck messages to Story mainnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
