### PR TITLE
feat: QuotedCalls exact in sentinel

### DIFF
--- a/solidity/contracts/token/QuotedCalls.sol
+++ b/solidity/contracts/token/QuotedCalls.sol
@@ -16,6 +16,7 @@ pragma solidity >=0.8.0;
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {ReentrancyGuardTransient} from "../libs/ReentrancyGuardTransient.sol";
 import {IAllowanceTransfer} from "permit2/interfaces/IAllowanceTransfer.sol";
 
@@ -25,14 +26,27 @@ import {Quote, ITokenBridge} from "../interfaces/ITokenBridge.sol";
 import {StandardHookMetadata} from "../hooks/libs/StandardHookMetadata.sol";
 import {CallLib} from "../middleware/libs/Call.sol";
 import {PackageVersioned} from "../PackageVersioned.sol";
+import {Quotes} from "./libs/Quotes.sol";
 
 interface ICrossCollateralRouter {
+    function transferRemote(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _amount
+    ) external payable returns (bytes32);
+
     function transferRemoteTo(
         uint32 _destination,
         bytes32 _recipient,
         uint256 _amount,
         bytes32 _targetRouter
     ) external payable returns (bytes32);
+
+    function quoteTransferRemote(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _amount
+    ) external view returns (Quote[] memory);
 
     function quoteTransferRemoteTo(
         uint32 _destination,
@@ -88,6 +102,10 @@ library CalldataHeadLib {
     /// @dev Sentinel: resolve to the contract's entire token/ETH balance.
     uint256 internal constant CONTRACT_BALANCE =
         0x8000000000000000000000000000000000000000000000000000000000000000;
+
+    /// @dev Sentinel: infer max exact-in bridge amount from contract balance.
+    uint256 internal constant BRIDGE_MAX_AVAILABLE_EXACT_IN =
+        0x8000000000000000000000000000000000000000000000000000000000000001;
 
     function readAddress(
         bytes calldata input,
@@ -167,6 +185,7 @@ library CalldataHeadLib {
  */
 contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
     using SafeERC20 for IERC20;
+    using Quotes for Quote[];
 
     // ============ Immutables ============
 
@@ -177,11 +196,19 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
     /// @notice Sentinel: resolve amount to this contract's entire token balance
     uint256 public constant CONTRACT_BALANCE = CalldataHeadLib.CONTRACT_BALANCE;
 
+    /// @notice Sentinel: infer max exact-in bridge amount from current balance
+    uint256 public constant BRIDGE_MAX_AVAILABLE_EXACT_IN =
+        CalldataHeadLib.BRIDGE_MAX_AVAILABLE_EXACT_IN;
+
     // ============ Command Types ============
     //
     // Amount/value fields support CONTRACT_BALANCE sentinel to resolve at
     // execution time. For ERC20 amounts this resolves to the contract's token
     // balance; for native value it resolves to address(this).balance.
+    //
+    // TRANSFER_REMOTE / TRANSFER_REMOTE_TO amount additionally support
+    // BRIDGE_MAX_AVAILABLE_EXACT_IN, which infers the largest transfer amount
+    // spendable from current contract balance under a linear-fee assumption.
     //
     // SAFETY INVARIANT: users may hold standing ERC-20 approvals to
     // this contract (used by TRANSFER_FROM / PERMIT2_TRANSFER_FROM).
@@ -215,13 +242,15 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
     uint256 public constant TRANSFER_FROM = 0x03;
 
     /// @notice Execute a warp route transferRemote, approving the route first.
-    /// @dev amount and approval resolve via _resolveAmount (supports CONTRACT_BALANCE).
+    /// @dev amount supports CONTRACT_BALANCE and BRIDGE_MAX_AVAILABLE_EXACT_IN.
+    ///      approval resolves via _resolveAmount (supports CONTRACT_BALANCE).
     ///      value resolves native ETH to forward (supports CONTRACT_BALANCE).
     /// inputs: abi.encode(address warpRoute, uint32 destination, bytes32 recipient, uint256 amount, uint256 value, address token, uint256 approval)
     uint256 public constant TRANSFER_REMOTE = 0x04;
 
     /// @notice Execute a cross-collateral transferRemoteTo, approving the router first.
-    /// @dev Same resolution semantics as TRANSFER_REMOTE.
+    /// @dev amount supports CONTRACT_BALANCE and BRIDGE_MAX_AVAILABLE_EXACT_IN.
+    ///      Other fields mirror TRANSFER_REMOTE resolution semantics.
     /// inputs: abi.encode(address router, uint32 destination, bytes32 recipient, uint256 amount, bytes32 targetRouter, uint256 value, address token, uint256 approval)
     uint256 public constant TRANSFER_REMOTE_TO = 0x05;
 
@@ -400,11 +429,7 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
     }
 
     function _dispatchTransferRemote(bytes calldata input) internal {
-        TransferRemoteParams memory p = abi.decode(
-            input,
-            (TransferRemoteParams)
-        );
-        p.amount = _resolveAmount(p.token, p.amount);
+        TransferRemoteParams memory p = _prepareTransferRemoteParams(input);
         p.value = _resolveAmount(address(0), p.value);
         _approve(p.token, p.warpRoute, _resolveAmount(p.token, p.approval));
         ITokenBridge(p.warpRoute).transferRemote{value: p.value}(
@@ -415,11 +440,7 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
     }
 
     function _dispatchTransferRemoteTo(bytes calldata input) internal {
-        TransferRemoteToParams memory p = abi.decode(
-            input,
-            (TransferRemoteToParams)
-        );
-        p.amount = _resolveAmount(p.token, p.amount);
+        TransferRemoteToParams memory p = _prepareTransferRemoteToParams(input);
         p.value = _resolveAmount(address(0), p.value);
         _approve(p.token, p.router, _resolveAmount(p.token, p.approval));
         ICrossCollateralRouter(p.router).transferRemoteTo{value: p.value}(
@@ -549,59 +570,84 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
 
     function _quoteTransferRemote(
         bytes calldata input
-    ) internal view returns (Quote[] memory) {
-        (
-            address warpRoute,
-            uint32 destination,
-            bytes32 recipient,
-            uint256 amount,
-            ,
-            ,
-
-        ) = abi.decode(
-                input,
-                (address, uint32, bytes32, uint256, uint256, address, uint256)
-            );
+    ) private view returns (Quote[] memory) {
+        TransferRemoteParams memory p = _prepareTransferRemoteParams(input);
         return
-            ITokenBridge(warpRoute).quoteTransferRemote(
-                destination,
-                recipient,
-                amount
+            ITokenBridge(p.warpRoute).quoteTransferRemote(
+                p.destination,
+                p.recipient,
+                p.amount
             );
     }
 
     function _quoteTransferRemoteTo(
         bytes calldata input
-    ) internal view returns (Quote[] memory) {
-        (
-            address router,
-            uint32 destination,
-            bytes32 recipient,
-            uint256 amount,
-            bytes32 targetRouter,
-            ,
-            ,
-
-        ) = abi.decode(
-                input,
-                (
-                    address,
-                    uint32,
-                    bytes32,
-                    uint256,
-                    bytes32,
-                    uint256,
-                    address,
-                    uint256
-                )
-            );
+    ) private view returns (Quote[] memory) {
+        TransferRemoteToParams memory p = _prepareTransferRemoteToParams(input);
         return
-            ICrossCollateralRouter(router).quoteTransferRemoteTo(
-                destination,
-                recipient,
-                amount,
-                targetRouter
+            ICrossCollateralRouter(p.router).quoteTransferRemoteTo(
+                p.destination,
+                p.recipient,
+                p.amount,
+                p.targetRouter
             );
+    }
+
+    function _prepareTransferRemoteParams(
+        bytes calldata input
+    ) private view returns (TransferRemoteParams memory p) {
+        p = abi.decode(input, (TransferRemoteParams));
+        if (p.amount != BRIDGE_MAX_AVAILABLE_EXACT_IN) {
+            p.amount = _resolveAmount(p.token, p.amount);
+            return p;
+        }
+
+        uint256 available = _resolveAmount(p.token, CONTRACT_BALANCE);
+        p.amount = _resolveBridgeAmount(
+            available,
+            ITokenBridge(p.warpRoute)
+                .quoteTransferRemote(p.destination, p.recipient, available)
+                .extract(p.token)
+        );
+    }
+
+    function _prepareTransferRemoteToParams(
+        bytes calldata input
+    ) private view returns (TransferRemoteToParams memory p) {
+        p = abi.decode(input, (TransferRemoteToParams));
+        if (p.amount != BRIDGE_MAX_AVAILABLE_EXACT_IN) {
+            p.amount = _resolveAmount(p.token, p.amount);
+            return p;
+        }
+
+        uint256 available = _resolveAmount(p.token, CONTRACT_BALANCE);
+        p.amount = _resolveBridgeAmount(
+            available,
+            ICrossCollateralRouter(p.router)
+                .quoteTransferRemoteTo(
+                    p.destination,
+                    p.recipient,
+                    available,
+                    p.targetRouter
+                )
+                .extract(p.token)
+        );
+    }
+
+    function _resolveBridgeAmount(
+        uint256 available,
+        uint256 quotedTotal
+    ) private pure returns (uint256) {
+        if (available == 0) return 0;
+        return _invertBridgeExactIn(available, quotedTotal);
+    }
+
+    function _invertBridgeExactIn(
+        uint256 available,
+        uint256 totalQuoted
+    ) private pure returns (uint256) {
+        if (totalQuoted <= available) return available;
+        return Math.mulDiv(available, available, totalQuoted);
     }
 
     function _quoteIcaGasPayment(

--- a/solidity/contracts/token/QuotedCalls.sol
+++ b/solidity/contracts/token/QuotedCalls.sol
@@ -103,8 +103,8 @@ library CalldataHeadLib {
     uint256 internal constant CONTRACT_BALANCE =
         0x8000000000000000000000000000000000000000000000000000000000000000;
 
-    /// @dev Sentinel: infer max exact-in bridge amount from contract balance.
-    uint256 internal constant BRIDGE_MAX_AVAILABLE_EXACT_IN =
+    /// @dev Sentinel: infer bridge exact-in amount from the resolved approval budget.
+    uint256 internal constant BRIDGE_EXACT_IN =
         0x8000000000000000000000000000000000000000000000000000000000000001;
 
     function readAddress(
@@ -196,9 +196,8 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
     /// @notice Sentinel: resolve amount to this contract's entire token balance
     uint256 public constant CONTRACT_BALANCE = CalldataHeadLib.CONTRACT_BALANCE;
 
-    /// @notice Sentinel: infer max exact-in bridge amount from current balance
-    uint256 public constant BRIDGE_MAX_AVAILABLE_EXACT_IN =
-        CalldataHeadLib.BRIDGE_MAX_AVAILABLE_EXACT_IN;
+    /// @notice Sentinel: infer bridge exact-in amount from resolved approval budget
+    uint256 public constant BRIDGE_EXACT_IN = CalldataHeadLib.BRIDGE_EXACT_IN;
 
     // ============ Command Types ============
     //
@@ -207,8 +206,10 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
     // balance; for native value it resolves to address(this).balance.
     //
     // TRANSFER_REMOTE / TRANSFER_REMOTE_TO amount additionally support
-    // BRIDGE_MAX_AVAILABLE_EXACT_IN, which infers the largest transfer amount
-    // spendable from current contract balance under a linear-fee assumption.
+    // BRIDGE_EXACT_IN, which infers the largest transfer amount
+    // spendable from the resolved approval budget under a linear-fee assumption.
+    // Using approval = CONTRACT_BALANCE preserves the "max available exact-in"
+    // behavior from current contract balance.
     //
     // SAFETY INVARIANT: users may hold standing ERC-20 approvals to
     // this contract (used by TRANSFER_FROM / PERMIT2_TRANSFER_FROM).
@@ -242,14 +243,16 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
     uint256 public constant TRANSFER_FROM = 0x03;
 
     /// @notice Execute a warp route transferRemote, approving the route first.
-    /// @dev amount supports CONTRACT_BALANCE and BRIDGE_MAX_AVAILABLE_EXACT_IN.
+    /// @dev amount supports CONTRACT_BALANCE and BRIDGE_EXACT_IN.
+    ///      For the exact-in sentinel, approval is the gross spend budget.
     ///      approval resolves via _resolveAmount (supports CONTRACT_BALANCE).
     ///      value resolves native ETH to forward (supports CONTRACT_BALANCE).
     /// inputs: abi.encode(address warpRoute, uint32 destination, bytes32 recipient, uint256 amount, uint256 value, address token, uint256 approval)
     uint256 public constant TRANSFER_REMOTE = 0x04;
 
     /// @notice Execute a cross-collateral transferRemoteTo, approving the router first.
-    /// @dev amount supports CONTRACT_BALANCE and BRIDGE_MAX_AVAILABLE_EXACT_IN.
+    /// @dev amount supports CONTRACT_BALANCE and BRIDGE_EXACT_IN.
+    ///      For the exact-in sentinel, approval is the gross spend budget.
     ///      Other fields mirror TRANSFER_REMOTE resolution semantics.
     /// inputs: abi.encode(address router, uint32 destination, bytes32 recipient, uint256 amount, bytes32 targetRouter, uint256 value, address token, uint256 approval)
     uint256 public constant TRANSFER_REMOTE_TO = 0x05;
@@ -597,12 +600,12 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
         bytes calldata input
     ) private view returns (TransferRemoteParams memory p) {
         p = abi.decode(input, (TransferRemoteParams));
-        if (p.amount != BRIDGE_MAX_AVAILABLE_EXACT_IN) {
+        if (p.amount != BRIDGE_EXACT_IN) {
             p.amount = _resolveAmount(p.token, p.amount);
             return p;
         }
 
-        uint256 available = _resolveAmount(p.token, CONTRACT_BALANCE);
+        uint256 available = _resolveAmount(p.token, p.approval);
         p.amount = _resolveBridgeAmount(
             available,
             ITokenBridge(p.warpRoute)
@@ -615,12 +618,12 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
         bytes calldata input
     ) private view returns (TransferRemoteToParams memory p) {
         p = abi.decode(input, (TransferRemoteToParams));
-        if (p.amount != BRIDGE_MAX_AVAILABLE_EXACT_IN) {
+        if (p.amount != BRIDGE_EXACT_IN) {
             p.amount = _resolveAmount(p.token, p.amount);
             return p;
         }
 
-        uint256 available = _resolveAmount(p.token, CONTRACT_BALANCE);
+        uint256 available = _resolveAmount(p.token, p.approval);
         p.amount = _resolveBridgeAmount(
             available,
             ICrossCollateralRouter(p.router)

--- a/solidity/test/token/QuotedCalls.t.sol
+++ b/solidity/test/token/QuotedCalls.t.sol
@@ -137,13 +137,20 @@ contract MockOptionalTargetBridge {
     using SafeERC20 for IERC20;
 
     IERC20 public immutable token;
-    uint256 public fee;
+    uint256 public feeNumerator;
+    uint256 public feeDenominator;
+    uint256 public lastAmount;
     bytes32 public lastTargetRouter;
     bool public usedTransferRemoteTo;
 
-    constructor(IERC20 _token, uint256 _fee) {
+    constructor(IERC20 _token, uint256 _feeNumerator, uint256 _feeDenominator) {
         token = _token;
-        fee = _fee;
+        feeNumerator = _feeNumerator;
+        feeDenominator = _feeDenominator;
+    }
+
+    function _fee(uint256 amount) internal view returns (uint256) {
+        return Math.mulDiv(amount, feeNumerator, feeDenominator);
     }
 
     function transferRemote(
@@ -152,8 +159,13 @@ contract MockOptionalTargetBridge {
         uint256 amount
     ) external payable returns (bytes32) {
         usedTransferRemoteTo = false;
+        lastAmount = amount;
         lastTargetRouter = bytes32(0);
-        token.safeTransferFrom(msg.sender, address(this), amount + fee);
+        token.safeTransferFrom(
+            msg.sender,
+            address(this),
+            amount + _fee(amount)
+        );
         return bytes32("remote");
     }
 
@@ -164,8 +176,13 @@ contract MockOptionalTargetBridge {
         bytes32 targetRouter
     ) external payable returns (bytes32) {
         usedTransferRemoteTo = true;
+        lastAmount = amount;
         lastTargetRouter = targetRouter;
-        token.safeTransferFrom(msg.sender, address(this), amount + fee);
+        token.safeTransferFrom(
+            msg.sender,
+            address(this),
+            amount + _fee(amount)
+        );
         return bytes32("remoteTo");
     }
 
@@ -175,7 +192,7 @@ contract MockOptionalTargetBridge {
         uint256 amount
     ) external view returns (Quote[] memory quotes) {
         quotes = new Quote[](1);
-        quotes[0] = Quote(address(token), amount + fee);
+        quotes[0] = Quote(address(token), amount + _fee(amount));
     }
 
     function quoteTransferRemoteTo(
@@ -185,7 +202,7 @@ contract MockOptionalTargetBridge {
         bytes32
     ) external view returns (Quote[] memory quotes) {
         quotes = new Quote[](1);
-        quotes[0] = Quote(address(token), amount + fee);
+        quotes[0] = Quote(address(token), amount + _fee(amount));
     }
 }
 
@@ -343,7 +360,8 @@ contract QuotedCallsTest is Test {
         quotedCalls = new QuotedCalls(IAllowanceTransfer(address(permit2)));
         optionalTargetBridge = new MockOptionalTargetBridge(
             IERC20(address(primaryToken)),
-            1e18
+            1,
+            100
         );
 
         // ALICE approves MockPermit2 for token pulls (one-time)
@@ -1073,10 +1091,25 @@ contract QuotedCallsTest is Test {
         vm.stopPrank();
     }
 
-    function test_transferRemoteTo_zeroTargetRouter_usesTransferRemoteTo()
+    function test_transferRemoteTo_withBridgeExactInFromApprovalBudget()
         public
     {
-        uint256 totalTokens = TRANSFER_AMT + 1e18;
+        uint256 EXACT_IN = quotedCalls.BRIDGE_EXACT_IN();
+        uint256 totalTokens = 200e18;
+        uint256 budget = TRANSFER_AMT + 1e18;
+        bytes32 targetRouter = bytes32(uint256(0xBEEF));
+        uint256 expectedAmount = Math.mulDiv(
+            budget,
+            budget,
+            optionalTargetBridge
+                .quoteTransferRemoteTo(
+                    DESTINATION,
+                    BOB.addressToBytes32(),
+                    budget,
+                    targetRouter
+                )
+                .extract(address(primaryToken))
+        );
 
         bytes1[] memory cmds = new bytes1[](2);
         bytes[] memory ins = new bytes[](2);
@@ -1088,11 +1121,11 @@ contract QuotedCallsTest is Test {
             address(optionalTargetBridge),
             DESTINATION,
             BOB.addressToBytes32(),
-            TRANSFER_AMT,
-            bytes32(0),
+            EXACT_IN,
+            targetRouter,
             0,
             address(primaryToken),
-            totalTokens
+            budget
         );
 
         (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
@@ -1103,11 +1136,18 @@ contract QuotedCallsTest is Test {
         vm.stopPrank();
 
         assertTrue(optionalTargetBridge.usedTransferRemoteTo());
-        assertEq(optionalTargetBridge.lastTargetRouter(), bytes32(0));
-        assertEq(
+        assertEq(optionalTargetBridge.lastTargetRouter(), targetRouter);
+        assertApproxEqAbs(
             primaryToken.balanceOf(address(optionalTargetBridge)),
-            totalTokens
+            budget,
+            1
         );
+        assertApproxEqAbs(
+            primaryToken.balanceOf(address(quotedCalls)),
+            totalTokens - budget,
+            1
+        );
+        assertApproxEqAbs(optionalTargetBridge.lastAmount(), expectedAmount, 1);
     }
 
     // ============ Tests: IGP + Fee Quote ============

--- a/solidity/test/token/QuotedCalls.t.sol
+++ b/solidity/test/token/QuotedCalls.t.sol
@@ -934,10 +934,10 @@ contract QuotedCallsTest is Test {
         assertEq(address(quotedCalls).balance, 0);
     }
 
-    /// @dev Use BRIDGE_MAX_AVAILABLE_EXACT_IN to invert amount from total token budget.
+    /// @dev Use BRIDGE_EXACT_IN to invert amount from total token budget.
     function test_transferRemote_withBridgeMaxAvailableExactIn() public {
         uint256 CONTRACT_BAL = quotedCalls.CONTRACT_BALANCE();
-        uint256 EXACT_IN = quotedCalls.BRIDGE_MAX_AVAILABLE_EXACT_IN();
+        uint256 EXACT_IN = quotedCalls.BRIDGE_EXACT_IN();
         uint256 totalTokens = 0.1 ether;
         uint256 expectedAmount = Math.mulDiv(
             totalTokens,
@@ -983,6 +983,65 @@ contract QuotedCallsTest is Test {
             1
         );
         assertLe(primaryToken.balanceOf(address(quotedCalls)), 1);
+        assertApproxEqAbs(remoteToken.balanceOf(BOB), expectedAmount, 1);
+    }
+
+    /// @dev Use BRIDGE_EXACT_IN with a literal approval budget.
+    function test_transferRemote_withBridgeMaxExactInFromApprovalBudget()
+        public
+    {
+        uint256 EXACT_IN = quotedCalls.BRIDGE_EXACT_IN();
+        uint256 totalTokens = 0.2 ether;
+        uint256 budget = 0.1 ether;
+        uint256 expectedAmount = Math.mulDiv(
+            budget,
+            budget,
+            localToken
+                .quoteTransferRemote(
+                    DESTINATION,
+                    BOB.addressToBytes32(),
+                    budget
+                )
+                .extract(address(primaryToken))
+        );
+
+        bytes1[] memory cmds = new bytes1[](3);
+        bytes[] memory ins = new bytes[](3);
+        (cmds[0], ins[0]) = _cmdSubmitQuote(_buildFeeQuote(ALICE));
+        (cmds[1], ins[1]) = _cmdTransferFrom(
+            address(primaryToken),
+            totalTokens
+        );
+        (cmds[2], ins[2]) = _cmdTransferRemote(
+            address(localToken),
+            DESTINATION,
+            BOB.addressToBytes32(),
+            EXACT_IN,
+            0,
+            address(primaryToken),
+            budget
+        );
+
+        (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
+
+        vm.startPrank(ALICE);
+        primaryToken.approve(address(quotedCalls), totalTokens);
+        quotedCalls.execute(commands, inputs);
+        vm.stopPrank();
+
+        remoteMailbox.processNextInboundMessage();
+
+        assertEq(primaryToken.balanceOf(ALICE), 1000e18 - totalTokens);
+        assertApproxEqAbs(
+            primaryToken.balanceOf(address(quotedFee)),
+            budget - expectedAmount,
+            1
+        );
+        assertApproxEqAbs(
+            primaryToken.balanceOf(address(quotedCalls)),
+            totalTokens - budget,
+            1
+        );
         assertApproxEqAbs(remoteToken.balanceOf(BOB), expectedAmount, 1);
     }
 
@@ -1616,11 +1675,12 @@ contract QuotedCallsTest is Test {
         assertGt(tokenTotal, TRANSFER_AMT, "token total should include fee");
     }
 
-    /// @dev quoteExecute resolves BRIDGE_MAX_AVAILABLE_EXACT_IN from prefunded balance.
+    /// @dev quoteExecute resolves BRIDGE_EXACT_IN from prefunded balance.
     function test_quoteExecute_transferRemote_bridgeMaxAvailableExactIn()
         public
     {
-        uint256 EXACT_IN = quotedCalls.BRIDGE_MAX_AVAILABLE_EXACT_IN();
+        uint256 CONTRACT_BAL = quotedCalls.CONTRACT_BALANCE();
+        uint256 EXACT_IN = quotedCalls.BRIDGE_EXACT_IN();
         uint256 totalTokens = 0.1 ether;
         uint256 expectedAmount = Math.mulDiv(
             totalTokens,
@@ -1653,7 +1713,7 @@ contract QuotedCallsTest is Test {
             EXACT_IN,
             0,
             address(primaryToken),
-            0
+            CONTRACT_BAL
         );
         (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
 
@@ -1667,6 +1727,61 @@ contract QuotedCallsTest is Test {
             totalTokens,
             "bridge quote should fit within available balance"
         );
+        assertApproxEqAbs(
+            results[1][1].amount,
+            expectedSpend,
+            1,
+            "resolved spend mismatch"
+        );
+    }
+
+    /// @dev quoteExecute resolves BRIDGE_EXACT_IN from literal approval budget.
+    function test_quoteExecute_transferRemote_bridgeMaxExactInFromApprovalBudget()
+        public
+    {
+        uint256 EXACT_IN = quotedCalls.BRIDGE_EXACT_IN();
+        uint256 totalTokens = 0.2 ether;
+        uint256 budget = 0.1 ether;
+        uint256 expectedAmount = Math.mulDiv(
+            budget,
+            budget,
+            localToken
+                .quoteTransferRemote(
+                    DESTINATION,
+                    BOB.addressToBytes32(),
+                    budget
+                )
+                .extract(address(primaryToken))
+        );
+        uint256 expectedSpend = localToken
+            .quoteTransferRemote(
+                DESTINATION,
+                BOB.addressToBytes32(),
+                expectedAmount
+            )
+            .extract(address(primaryToken));
+
+        primaryToken.transfer(address(quotedCalls), totalTokens);
+
+        bytes1[] memory cmds = new bytes1[](2);
+        bytes[] memory ins = new bytes[](2);
+        (cmds[0], ins[0]) = _cmdSubmitQuote(_buildFeeQuote(address(this)));
+        (cmds[1], ins[1]) = _cmdTransferRemote(
+            address(localToken),
+            DESTINATION,
+            BOB.addressToBytes32(),
+            EXACT_IN,
+            0,
+            address(primaryToken),
+            budget
+        );
+        (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
+
+        Quote[][] memory results = quotedCalls.quoteExecute(commands, inputs);
+
+        assertEq(results[1].length, 3, "TRANSFER_REMOTE returns 3 quotes");
+        (, uint256 tokenTotal, ) = _sumQuotes(results);
+        assertLe(tokenTotal, budget, "quote should fit approval budget");
         assertApproxEqAbs(
             results[1][1].amount,
             expectedSpend,

--- a/solidity/test/token/QuotedCalls.t.sol
+++ b/solidity/test/token/QuotedCalls.t.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.13;
 
 import {Test} from "forge-std/Test.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IAllowanceTransfer} from "permit2/interfaces/IAllowanceTransfer.sol";
 
 import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
@@ -30,6 +32,7 @@ import {CallLib} from "../../contracts/middleware/libs/Call.sol";
 import {Quote} from "../../contracts/interfaces/ITokenBridge.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ReentrancyGuardTransient} from "../../contracts/libs/ReentrancyGuardTransient.sol";
+import {Quotes} from "../../contracts/token/libs/Quotes.sol";
 
 /// @dev Contract that attempts reentrancy via the SWEEP ETH callback.
 contract ReentrantAttacker {
@@ -130,8 +133,65 @@ contract MockPermit2 {
     }
 }
 
+contract MockOptionalTargetBridge {
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable token;
+    uint256 public fee;
+    bytes32 public lastTargetRouter;
+    bool public usedTransferRemoteTo;
+
+    constructor(IERC20 _token, uint256 _fee) {
+        token = _token;
+        fee = _fee;
+    }
+
+    function transferRemote(
+        uint32,
+        bytes32,
+        uint256 amount
+    ) external payable returns (bytes32) {
+        usedTransferRemoteTo = false;
+        lastTargetRouter = bytes32(0);
+        token.safeTransferFrom(msg.sender, address(this), amount + fee);
+        return bytes32("remote");
+    }
+
+    function transferRemoteTo(
+        uint32,
+        bytes32,
+        uint256 amount,
+        bytes32 targetRouter
+    ) external payable returns (bytes32) {
+        usedTransferRemoteTo = true;
+        lastTargetRouter = targetRouter;
+        token.safeTransferFrom(msg.sender, address(this), amount + fee);
+        return bytes32("remoteTo");
+    }
+
+    function quoteTransferRemote(
+        uint32,
+        bytes32,
+        uint256 amount
+    ) external view returns (Quote[] memory quotes) {
+        quotes = new Quote[](1);
+        quotes[0] = Quote(address(token), amount + fee);
+    }
+
+    function quoteTransferRemoteTo(
+        uint32,
+        bytes32,
+        uint256 amount,
+        bytes32
+    ) external view returns (Quote[] memory quotes) {
+        quotes = new Quote[](1);
+        quotes[0] = Quote(address(token), amount + fee);
+    }
+}
+
 contract QuotedCallsTest is Test {
     using TypeCasts for address;
+    using Quotes for Quote[];
 
     uint32 constant ORIGIN = 11;
     uint32 constant DESTINATION = 12;
@@ -165,6 +225,7 @@ contract QuotedCallsTest is Test {
     StorageGasOracle gasOracle;
     OffchainQuotedLinearFee quotedFee;
     QuotedCalls quotedCalls;
+    MockOptionalTargetBridge optionalTargetBridge;
 
     function setUp() public {
         signer = vm.addr(signerPk);
@@ -280,6 +341,10 @@ contract QuotedCallsTest is Test {
         primaryToken.transfer(address(localToken), 1000e18);
 
         quotedCalls = new QuotedCalls(IAllowanceTransfer(address(permit2)));
+        optionalTargetBridge = new MockOptionalTargetBridge(
+            IERC20(address(primaryToken)),
+            1e18
+        );
 
         // ALICE approves MockPermit2 for token pulls (one-time)
         vm.prank(ALICE);
@@ -869,6 +934,58 @@ contract QuotedCallsTest is Test {
         assertEq(address(quotedCalls).balance, 0);
     }
 
+    /// @dev Use BRIDGE_MAX_AVAILABLE_EXACT_IN to invert amount from total token budget.
+    function test_transferRemote_withBridgeMaxAvailableExactIn() public {
+        uint256 CONTRACT_BAL = quotedCalls.CONTRACT_BALANCE();
+        uint256 EXACT_IN = quotedCalls.BRIDGE_MAX_AVAILABLE_EXACT_IN();
+        uint256 totalTokens = 0.1 ether;
+        uint256 expectedAmount = Math.mulDiv(
+            totalTokens,
+            totalTokens,
+            localToken
+                .quoteTransferRemote(
+                    DESTINATION,
+                    BOB.addressToBytes32(),
+                    totalTokens
+                )
+                .extract(address(primaryToken))
+        );
+        bytes1[] memory cmds = new bytes1[](3);
+        bytes[] memory ins = new bytes[](3);
+        (cmds[0], ins[0]) = _cmdSubmitQuote(_buildFeeQuote(ALICE));
+        (cmds[1], ins[1]) = _cmdTransferFrom(
+            address(primaryToken),
+            totalTokens
+        );
+        (cmds[2], ins[2]) = _cmdTransferRemote(
+            address(localToken),
+            DESTINATION,
+            BOB.addressToBytes32(),
+            EXACT_IN,
+            0,
+            address(primaryToken),
+            CONTRACT_BAL
+        );
+
+        (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
+
+        vm.startPrank(ALICE);
+        primaryToken.approve(address(quotedCalls), totalTokens);
+        quotedCalls.execute(commands, inputs);
+        vm.stopPrank();
+
+        remoteMailbox.processNextInboundMessage();
+
+        assertEq(primaryToken.balanceOf(ALICE), 1000e18 - totalTokens);
+        assertApproxEqAbs(
+            primaryToken.balanceOf(address(quotedFee)),
+            totalTokens - expectedAmount,
+            1
+        );
+        assertLe(primaryToken.balanceOf(address(quotedCalls)), 1);
+        assertApproxEqAbs(remoteToken.balanceOf(BOB), expectedAmount, 1);
+    }
+
     // ============ Tests: No Quotes Reverts ============
 
     function test_execute_noQuotes_reverts() public {
@@ -895,6 +1012,43 @@ contract QuotedCallsTest is Test {
         vm.expectRevert();
         quotedCalls.execute(commands, inputs);
         vm.stopPrank();
+    }
+
+    function test_transferRemoteTo_zeroTargetRouter_usesTransferRemoteTo()
+        public
+    {
+        uint256 totalTokens = TRANSFER_AMT + 1e18;
+
+        bytes1[] memory cmds = new bytes1[](2);
+        bytes[] memory ins = new bytes[](2);
+        (cmds[0], ins[0]) = _cmdTransferFrom(
+            address(primaryToken),
+            totalTokens
+        );
+        (cmds[1], ins[1]) = _cmdTransferRemoteTo(
+            address(optionalTargetBridge),
+            DESTINATION,
+            BOB.addressToBytes32(),
+            TRANSFER_AMT,
+            bytes32(0),
+            0,
+            address(primaryToken),
+            totalTokens
+        );
+
+        (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
+
+        vm.startPrank(ALICE);
+        primaryToken.approve(address(quotedCalls), totalTokens);
+        quotedCalls.execute(commands, inputs);
+        vm.stopPrank();
+
+        assertTrue(optionalTargetBridge.usedTransferRemoteTo());
+        assertEq(optionalTargetBridge.lastTargetRouter(), bytes32(0));
+        assertEq(
+            primaryToken.balanceOf(address(optionalTargetBridge)),
+            totalTokens
+        );
     }
 
     // ============ Tests: IGP + Fee Quote ============
@@ -1460,6 +1614,65 @@ contract QuotedCallsTest is Test {
         assertEq(results[1].length, 3, "TRANSFER_REMOTE returns 3 quotes");
         (, uint256 tokenTotal, ) = _sumQuotes(results);
         assertGt(tokenTotal, TRANSFER_AMT, "token total should include fee");
+    }
+
+    /// @dev quoteExecute resolves BRIDGE_MAX_AVAILABLE_EXACT_IN from prefunded balance.
+    function test_quoteExecute_transferRemote_bridgeMaxAvailableExactIn()
+        public
+    {
+        uint256 EXACT_IN = quotedCalls.BRIDGE_MAX_AVAILABLE_EXACT_IN();
+        uint256 totalTokens = 0.1 ether;
+        uint256 expectedAmount = Math.mulDiv(
+            totalTokens,
+            totalTokens,
+            localToken
+                .quoteTransferRemote(
+                    DESTINATION,
+                    BOB.addressToBytes32(),
+                    totalTokens
+                )
+                .extract(address(primaryToken))
+        );
+        uint256 expectedSpend = localToken
+            .quoteTransferRemote(
+                DESTINATION,
+                BOB.addressToBytes32(),
+                expectedAmount
+            )
+            .extract(address(primaryToken));
+
+        primaryToken.transfer(address(quotedCalls), totalTokens);
+
+        bytes1[] memory cmds = new bytes1[](2);
+        bytes[] memory ins = new bytes[](2);
+        (cmds[0], ins[0]) = _cmdSubmitQuote(_buildFeeQuote(address(this)));
+        (cmds[1], ins[1]) = _cmdTransferRemote(
+            address(localToken),
+            DESTINATION,
+            BOB.addressToBytes32(),
+            EXACT_IN,
+            0,
+            address(primaryToken),
+            0
+        );
+        (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
+
+        Quote[][] memory results = quotedCalls.quoteExecute(commands, inputs);
+
+        assertEq(results[1].length, 3, "TRANSFER_REMOTE returns 3 quotes");
+        (, uint256 tokenTotal, ) = _sumQuotes(results);
+        assertLe(tokenTotal, totalTokens, "quote should fit available balance");
+        assertLe(
+            results[1][1].amount,
+            totalTokens,
+            "bridge quote should fit within available balance"
+        );
+        assertApproxEqAbs(
+            results[1][1].amount,
+            expectedSpend,
+            1,
+            "resolved spend mismatch"
+        );
     }
 
     /// @dev quoteExecute with TRANSFER_REMOTE using ERC20 IGP fee token


### PR DESCRIPTION
## Summary
- renamed the bridge exact-in sentinel to BRIDGE_EXACT_IN
- clarified bridge exact-in semantics so the inferred amount is derived from the resolved approval budget
- preserved the old max-available behavior via approval = CONTRACT_BALANCE
- kept separate plain vs targeted bridge preparation paths and explicit narrow bridge interfaces

## Testing
- forge test --offline --match-path test/token/QuotedCalls.t.sol --match-test "test_(transferRemote_withBridgeMaxAvailableExactIn|transferRemote_withBridgeMaxExactInFromApprovalBudget|quoteExecute_transferRemote_bridgeMaxAvailableExactIn|quoteExecute_transferRemote_bridgeMaxExactInFromApprovalBudget)"
- forge test --offline --match-path test/token/QuotedCalls.t.sol --match-test "test_(transferRemoteTo_zeroTargetRouter_usesTransferRemoteTo|transferRemote_withBridgeMaxAvailableExactIn|quoteExecute_transferRemote_bridgeMaxAvailableExactIn)"