### PR TITLE
fix(widgets): use HTTP polling for Solana tx confirmation

### DIFF
--- a/.changeset/fix-solana-confirm-polling.md
+++ b/.changeset/fix-solana-confirm-polling.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/widgets': patch
 ---
 
-Replace WebSocket-based `confirmTransaction` with HTTP polling (`getSignatureStatuses`) for Solana transaction confirmation. Fixes hangs with RPC providers that don't support `signatureSubscribe`.
+Replaced WebSocket-based `confirmTransaction` with HTTP polling (`getSignatureStatuses`) for Solana transaction confirmation. Fixed hangs with RPC providers that don't support `signatureSubscribe`.

--- a/.changeset/fix-solana-confirm-polling.md
+++ b/.changeset/fix-solana-confirm-polling.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/widgets': patch
+---
+
+Replace WebSocket-based `confirmTransaction` with HTTP polling (`getSignatureStatuses`) for Solana transaction confirmation. Fixes hangs with RPC providers that don't support `signatureSubscribe`.

--- a/typescript/widgets/src/walletIntegrations/solana.ts
+++ b/typescript/widgets/src/walletIntegrations/solana.ts
@@ -11,6 +11,8 @@ import type { ITokenMetadata } from '@hyperlane-xyz/sdk/token/ITokenMetadata';
 import type { ChainName } from '@hyperlane-xyz/sdk/types';
 import type { WarpTypedTransaction } from '@hyperlane-xyz/sdk/warp/types';
 
+import { sleep } from '@hyperlane-xyz/utils';
+
 import { widgetLogger } from '../logger.js';
 
 import {
@@ -119,7 +121,7 @@ export function useSolanaTransactionFns(
             // Tolerate transient RPC errors (timeouts, rate limits)
             logger.warn('Transient error polling tx confirmation', error);
           }
-          await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+          await sleep(POLL_INTERVAL_MS);
         }
         const tx = await connection.getTransaction(signature, {
           commitment: 'confirmed',

--- a/typescript/widgets/src/walletIntegrations/solana.ts
+++ b/typescript/widgets/src/walletIntegrations/solana.ts
@@ -87,22 +87,37 @@ export function useSolanaTransactionFns(
         // (e.g. Alchemy) don't support that method.
         const POLL_INTERVAL_MS = 2000;
         while (true) {
-          const { value } = await connection.getSignatureStatuses([signature]);
-          const status = value?.[0];
-          if (status?.err) {
-            throw new Error(
-              `Transaction failed: ${JSON.stringify(status.err)}`,
-            );
-          }
-          if (
-            status?.confirmationStatus === 'confirmed' ||
-            status?.confirmationStatus === 'finalized'
-          ) {
-            break;
-          }
-          const blockHeight = await connection.getBlockHeight();
-          if (blockHeight > lastValidBlockHeight) {
-            throw new Error('Transaction expired: block height exceeded');
+          try {
+            const { value } = await connection.getSignatureStatuses([
+              signature,
+            ]);
+            const status = value?.[0];
+            if (status?.err) {
+              throw new Error(
+                `Transaction failed: ${JSON.stringify(status.err)}`,
+              );
+            }
+            if (
+              status?.confirmationStatus === 'confirmed' ||
+              status?.confirmationStatus === 'finalized'
+            ) {
+              break;
+            }
+            const blockHeight = await connection.getBlockHeight();
+            if (blockHeight > lastValidBlockHeight) {
+              throw new Error('Transaction expired: block height exceeded');
+            }
+          } catch (error) {
+            // Re-throw definitive failures (tx error, expiry)
+            if (
+              error instanceof Error &&
+              (error.message.startsWith('Transaction failed') ||
+                error.message.startsWith('Transaction expired'))
+            ) {
+              throw error;
+            }
+            // Tolerate transient RPC errors (timeouts, rate limits)
+            logger.warn('Transient error polling tx confirmation', error);
           }
           await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
         }
@@ -110,7 +125,10 @@ export function useSolanaTransactionFns(
           commitment: 'confirmed',
           maxSupportedTransactionVersion: 0,
         });
-        return { type: ProviderType.SolanaWeb3, receipt: tx! };
+        if (!tx) {
+          throw new Error(`Transaction ${signature} confirmed but not found`);
+        }
+        return { type: ProviderType.SolanaWeb3, receipt: tx };
       };
 
       return { hash: signature, confirm };

--- a/typescript/widgets/src/walletIntegrations/solana.ts
+++ b/typescript/widgets/src/walletIntegrations/solana.ts
@@ -73,7 +73,7 @@ export function useSolanaTransactionFns(
       const connection = new Connection(rpcUrl, 'confirmed');
       const {
         context: { slot: minContextSlot },
-        value: { blockhash, lastValidBlockHeight },
+        value: { lastValidBlockHeight },
       } = await connection.getLatestBlockhashAndContext();
 
       logger.debug(`Sending tx on chain ${chainName}`);
@@ -81,14 +81,37 @@ export function useSolanaTransactionFns(
         minContextSlot,
       });
 
-      const confirm = (): Promise<TypedTransactionReceipt> =>
-        connection
-          .confirmTransaction({ blockhash, lastValidBlockHeight, signature })
-          .then(() => connection.getTransaction(signature))
-          .then((r) => ({
-            type: ProviderType.SolanaWeb3,
-            receipt: r!,
-          }));
+      const confirm = async (): Promise<TypedTransactionReceipt> => {
+        // Poll via HTTP instead of connection.confirmTransaction which
+        // relies on signatureSubscribe (WebSocket) — many RPC providers
+        // (e.g. Alchemy) don't support that method.
+        const POLL_INTERVAL_MS = 2000;
+        while (true) {
+          const { value } = await connection.getSignatureStatuses([signature]);
+          const status = value?.[0];
+          if (status?.err) {
+            throw new Error(
+              `Transaction failed: ${JSON.stringify(status.err)}`,
+            );
+          }
+          if (
+            status?.confirmationStatus === 'confirmed' ||
+            status?.confirmationStatus === 'finalized'
+          ) {
+            break;
+          }
+          const blockHeight = await connection.getBlockHeight();
+          if (blockHeight > lastValidBlockHeight) {
+            throw new Error('Transaction expired: block height exceeded');
+          }
+          await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+        }
+        const tx = await connection.getTransaction(signature, {
+          commitment: 'confirmed',
+          maxSupportedTransactionVersion: 0,
+        });
+        return { type: ProviderType.SolanaWeb3, receipt: tx! };
+      };
 
       return { hash: signature, confirm };
     },


### PR DESCRIPTION
## Summary

Replace `connection.confirmTransaction()` with HTTP polling using `getSignatureStatuses` for Solana transaction confirmation in the widgets package.

## Problem

`connection.confirmTransaction()` from `@solana/web3.js` internally uses `signatureSubscribe`, a WebSocket subscription method. Many RPC providers (e.g. Alchemy) don't support this method, returning:

```
JSON-RPC error calling signatureSubscribe: { code: -32601, message: "Method 'signatureSubscribe' not found" }
```

When this happens:
1. The WebSocket subscription fails silently
2. The HTTP-based `getSignatureStatus` poll (gated behind subscription setup) never runs
3. After ~1-2 min, block height exceeds the limit → throws `TransactionExpiredBlockheightExceededError`
4. The UI shows the transfer as failed/hanging even though the on-chain tx succeeded

Examples of transactions after the fix the UI confirmed properly:
- solana: https://explorer.hyperlane.xyz/message/0xa14c75f0fedbdda54f6ad9ff1d24a317d2846b7b525f7c8de6931984edd6a262
- tested in eclipse just in case: https://explorer.hyperlane.xyz/message/0xc48c854bbe52a3b33a89ec1ea0c93131e93dd3c14021e63f37de2cd2193bf266

## Fix

Replace `confirmTransaction` with a polling loop that uses only HTTP RPC methods:
- `getSignatureStatuses` — checks if the tx is confirmed/finalized
- `getBlockHeight` — checks if the tx has expired

No WebSocket dependency. Works with all RPC providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
