### PR TITLE
fix(sdk): bigint scale helpers and WarpCore collateral check for mixed-decimal routes

### DIFF
--- a/.changeset/wise-horses-chew.md
+++ b/.changeset/wise-horses-chew.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Shared scale conversion helpers were exported, and WarpCore preserved legacy collateral checks for mixed-decimal routes when scale metadata is missing.

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -913,12 +913,20 @@ export {
 } from './types.js';
 export { getCosmosRegistryChain } from './utils/cosmos.js';
 export {
+  alignLocalAmountToMessage,
   DEFAULT_SCALE,
+  localAmountFromMessage,
+  messageAmountFromLocal,
+  minLocalAmountForMessage,
   normalizeScale,
   scalesEqual,
   verifyScale,
 } from './utils/decimals.js';
-export type { NormalizedScale, ScaleInput } from './utils/decimals.js';
+export type {
+  NormalizedScale,
+  ScaleAlignment,
+  ScaleInput,
+} from './utils/decimals.js';
 export { filterByChains } from './utils/filter.js';
 export {
   ANVIL_RPC_METHODS,

--- a/typescript/sdk/src/token/ITokenMetadata.ts
+++ b/typescript/sdk/src/token/ITokenMetadata.ts
@@ -50,9 +50,9 @@ export const TokenConfigSchema = z.object({
     .string()
     .optional()
     .describe('The CoinGecko id of the token, used for price lookups'),
-  scale: TokenMetadataSchema.shape.scale
-    .optional()
-    .describe('The scaling factor of the token'),
+  scale: TokenMetadataSchema.shape.scale.describe(
+    'The scaling factor of the token',
+  ),
   warpRouteId: z
     .string()
     .min(1)

--- a/typescript/sdk/src/token/ITokenMetadata.ts
+++ b/typescript/sdk/src/token/ITokenMetadata.ts
@@ -11,6 +11,7 @@ import {
   TokenConnectionConfigSchema,
 } from './TokenConnection.js';
 import { TokenStandard } from './TokenStandard.js';
+import { TokenMetadataSchema } from './types.js';
 
 export const TokenConfigSchema = z.object({
   chainName: ZChainName.describe(
@@ -49,7 +50,9 @@ export const TokenConfigSchema = z.object({
     .string()
     .optional()
     .describe('The CoinGecko id of the token, used for price lookups'),
-  scale: ZUint.lt(256).optional().describe('The scaling factor of the token'),
+  scale: TokenMetadataSchema.shape.scale
+    .optional()
+    .describe('The scaling factor of the token'),
   warpRouteId: z
     .string()
     .min(1)

--- a/typescript/sdk/src/utils/decimals.test.ts
+++ b/typescript/sdk/src/utils/decimals.test.ts
@@ -144,7 +144,7 @@ describe('scale conversion helpers', () => {
   it('rejects negative message amounts for ceil local conversion', () => {
     expect(() =>
       minLocalAmountForMessage(-1n, { numerator: 1n, denominator: 3n }),
-    ).to.throw('Numerator must be non-negative');
+    ).to.throw('Message amount must be non-negative');
   });
 
   it('aligns local amounts to exact message progress without leaking local dust', () => {

--- a/typescript/sdk/src/utils/decimals.test.ts
+++ b/typescript/sdk/src/utils/decimals.test.ts
@@ -176,6 +176,27 @@ describe('scale conversion helpers', () => {
       alignLocalAmountToMessage(-1n, { numerator: 1n, denominator: 3n }),
     ).to.throw('Local amount must be non-negative');
   });
+
+  it('returns identity for undefined scale', () => {
+    expect(messageAmountFromLocal(42n, undefined)).to.equal(42n);
+    expect(localAmountFromMessage(42n, undefined)).to.equal(42n);
+  });
+
+  it('handles zero amounts', () => {
+    expect(
+      messageAmountFromLocal(0n, { numerator: 1n, denominator: 3n }),
+    ).to.equal(0n);
+    expect(
+      localAmountFromMessage(0n, { numerator: 3n, denominator: 2n }),
+    ).to.equal(0n);
+  });
+
+  it('round-trips exact-divisible amounts', () => {
+    const scale = { numerator: 3n, denominator: 2n };
+    const local = 6n;
+    const message = messageAmountFromLocal(local, scale);
+    expect(localAmountFromMessage(message, scale)).to.equal(local);
+  });
 });
 
 describe(verifyScale.name, () => {

--- a/typescript/sdk/src/utils/decimals.test.ts
+++ b/typescript/sdk/src/utils/decimals.test.ts
@@ -7,7 +7,15 @@ import {
   WarpRouteDeployConfigMailboxRequired,
 } from '../token/types.js';
 
-import { normalizeScale, scalesEqual, verifyScale } from './decimals.js';
+import {
+  alignLocalAmountToMessage,
+  localAmountFromMessage,
+  messageAmountFromLocal,
+  minLocalAmountForMessage,
+  normalizeScale,
+  scalesEqual,
+  verifyScale,
+} from './decimals.js';
 
 describe(normalizeScale.name, () => {
   it('should normalize undefined to DEFAULT_SCALE', () => {
@@ -102,6 +110,71 @@ describe(scalesEqual.name, () => {
     const slightlyDifferent = { numerator: 10n ** 18n + 1n, denominator: 1n };
     expect(scalesEqual(large, large)).to.be.true;
     expect(scalesEqual(large, slightlyDifferent)).to.be.false;
+  });
+});
+
+describe('scale conversion helpers', () => {
+  it('converts local amount to message amount using floor rounding', () => {
+    expect(
+      messageAmountFromLocal(5n, { numerator: 1n, denominator: 3n }),
+    ).to.equal(1n);
+    expect(
+      messageAmountFromLocal(2n, { numerator: 3n, denominator: 2n }),
+    ).to.equal(3n);
+  });
+
+  it('converts message amount to local amount using inbound floor rounding', () => {
+    expect(
+      localAmountFromMessage(7n, { numerator: 3n, denominator: 2n }),
+    ).to.equal(4n);
+    expect(
+      localAmountFromMessage(1n, { numerator: 1n, denominator: 3n }),
+    ).to.equal(3n);
+  });
+
+  it('computes the minimum local amount needed to reach a message amount', () => {
+    expect(
+      minLocalAmountForMessage(7n, { numerator: 3n, denominator: 2n }),
+    ).to.equal(5n);
+    expect(
+      minLocalAmountForMessage(2n, { numerator: 1n, denominator: 3n }),
+    ).to.equal(6n);
+  });
+
+  it('rejects negative message amounts for ceil local conversion', () => {
+    expect(() =>
+      minLocalAmountForMessage(-1n, { numerator: 1n, denominator: 3n }),
+    ).to.throw('Numerator must be non-negative');
+  });
+
+  it('aligns local amounts to exact message progress without leaking local dust', () => {
+    expect(
+      alignLocalAmountToMessage(5n, { numerator: 1n, denominator: 3n }),
+    ).to.deep.equal({
+      localAmount: 3n,
+      messageAmount: 1n,
+    });
+    expect(
+      alignLocalAmountToMessage(5n, { numerator: 3n, denominator: 2n }),
+    ).to.deep.equal({
+      localAmount: 5n,
+      messageAmount: 7n,
+    });
+    expect(
+      alignLocalAmountToMessage(999_999_999_999n, {
+        numerator: 1n,
+        denominator: 1_000_000_000_000n,
+      }),
+    ).to.deep.equal({
+      localAmount: 0n,
+      messageAmount: 0n,
+    });
+  });
+
+  it('rejects negative local amounts for alignment', () => {
+    expect(() =>
+      alignLocalAmountToMessage(-1n, { numerator: 1n, denominator: 3n }),
+    ).to.throw('Local amount must be non-negative');
   });
 });
 

--- a/typescript/sdk/src/utils/decimals.ts
+++ b/typescript/sdk/src/utils/decimals.ts
@@ -25,6 +25,11 @@ export const DEFAULT_SCALE: NormalizedScale = {
   denominator: 1n,
 };
 
+export type ScaleAlignment = {
+  localAmount: bigint;
+  messageAmount: bigint;
+};
+
 /**
  * Converts any accepted scale variant to NormalizedScale (bigint).
  */
@@ -36,6 +41,66 @@ export function normalizeScale(scale: ScaleInput | undefined): NormalizedScale {
   return {
     numerator: BigInt(scale.numerator),
     denominator: BigInt(scale.denominator),
+  };
+}
+
+function assertValidScale(scale: NormalizedScale): void {
+  assert(
+    scale.numerator > 0n && scale.denominator > 0n,
+    `Scale must be positive, got ${scale.numerator}/${scale.denominator}`,
+  );
+}
+
+function ceilDiv(numerator: bigint, denominator: bigint): bigint {
+  assert(denominator > 0n, 'Denominator must be positive');
+  assert(numerator >= 0n, 'Numerator must be non-negative');
+  if (numerator === 0n) return 0n;
+  return (numerator + denominator - 1n) / denominator;
+}
+
+export function messageAmountFromLocal(
+  localAmount: bigint,
+  scale: ScaleInput | undefined,
+): bigint {
+  const normalized = normalizeScale(scale);
+  assertValidScale(normalized);
+  return (localAmount * normalized.numerator) / normalized.denominator;
+}
+
+export function localAmountFromMessage(
+  messageAmount: bigint,
+  scale: ScaleInput | undefined,
+): bigint {
+  const normalized = normalizeScale(scale);
+  assertValidScale(normalized);
+  return (messageAmount * normalized.denominator) / normalized.numerator;
+}
+
+export function minLocalAmountForMessage(
+  messageAmount: bigint,
+  scale: ScaleInput | undefined,
+): bigint {
+  const normalized = normalizeScale(scale);
+  assertValidScale(normalized);
+  return ceilDiv(messageAmount * normalized.denominator, normalized.numerator);
+}
+
+export function alignLocalAmountToMessage(
+  localAmount: bigint,
+  scale: ScaleInput | undefined,
+): ScaleAlignment {
+  assert(localAmount >= 0n, 'Local amount must be non-negative');
+  const messageAmount = messageAmountFromLocal(localAmount, scale);
+  if (messageAmount === 0n) {
+    return {
+      localAmount: 0n,
+      messageAmount: 0n,
+    };
+  }
+
+  return {
+    localAmount: minLocalAmountForMessage(messageAmount, scale),
+    messageAmount,
   };
 }
 

--- a/typescript/sdk/src/utils/decimals.ts
+++ b/typescript/sdk/src/utils/decimals.ts
@@ -82,6 +82,7 @@ export function minLocalAmountForMessage(
   messageAmount: bigint,
   scale: ScaleInput | undefined,
 ): bigint {
+  assert(messageAmount >= 0n, 'Message amount must be non-negative');
   const normalized = normalizeScale(scale);
   assertValidScale(normalized);
   return ceilDiv(messageAmount * normalized.denominator, normalized.numerator);

--- a/typescript/sdk/src/utils/decimals.ts
+++ b/typescript/sdk/src/utils/decimals.ts
@@ -62,6 +62,7 @@ export function messageAmountFromLocal(
   localAmount: bigint,
   scale: ScaleInput | undefined,
 ): bigint {
+  assert(localAmount >= 0n, 'Local amount must be non-negative');
   const normalized = normalizeScale(scale);
   assertValidScale(normalized);
   return (localAmount * normalized.numerator) / normalized.denominator;
@@ -71,6 +72,7 @@ export function localAmountFromMessage(
   messageAmount: bigint,
   scale: ScaleInput | undefined,
 ): bigint {
+  assert(messageAmount >= 0n, 'Message amount must be non-negative');
   const normalized = normalizeScale(scale);
   assertValidScale(normalized);
   return (messageAmount * normalized.denominator) / normalized.numerator;

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -267,13 +267,138 @@ describe('WarpCore', () => {
       ).to.equal(expectedResult);
     };
 
-    await testCollateral(evmHypNativeScale1, testScale2.name, 10n, false);
-    await testCollateral(evmHypNativeScale1, testScale2.name, 1n, true);
-    await testCollateral(evmHypNativeScale2, testScale1.name, 10n, true);
-    await testCollateral(evmHypNativeScale2, testScale1.name, 100n, true);
-    await testCollateral(evmHypNativeScale2, testScale1.name, 101n, false);
+    const originalScale1 = evmHypNativeScale1.scale;
+    const originalScale2 = evmHypNativeScale2.scale;
 
-    stubs.forEach((s) => s.restore());
+    try {
+      await testCollateral(evmHypNativeScale1, testScale2.name, 10n, false);
+      await testCollateral(evmHypNativeScale1, testScale2.name, 1n, true);
+      await testCollateral(evmHypNativeScale2, testScale1.name, 10n, true);
+      await testCollateral(evmHypNativeScale2, testScale1.name, 100n, true);
+      await testCollateral(evmHypNativeScale2, testScale1.name, 101n, false);
+
+      evmHypNativeScale1.scale = { numerator: 100n, denominator: 10n };
+      evmHypNativeScale2.scale = { numerator: 10n, denominator: 10n };
+
+      await testCollateral(evmHypNativeScale1, testScale2.name, 10n, false);
+      await testCollateral(evmHypNativeScale1, testScale2.name, 1n, true);
+      await testCollateral(evmHypNativeScale2, testScale1.name, 10n, true);
+      await testCollateral(evmHypNativeScale2, testScale1.name, 100n, true);
+      await testCollateral(evmHypNativeScale2, testScale1.name, 101n, false);
+    } finally {
+      evmHypNativeScale1.scale = originalScale1;
+      evmHypNativeScale2.scale = originalScale2;
+      stubs.forEach((s) => s.restore());
+    }
+  });
+
+  it('Preserves decimals fallback for mixed-decimal routes missing scale', async () => {
+    const originToken = new Token({
+      chainName: test1.name,
+      standard: TokenStandard.EvmHypCollateral,
+      addressOrDenom: zeroAddress,
+      decimals: 18,
+      symbol: 'TEST',
+      name: 'Test Token',
+      connections: [],
+    });
+    const destinationToken = new Token({
+      chainName: test2.name,
+      standard: TokenStandard.EvmHypCollateral,
+      addressOrDenom: zeroAddress,
+      decimals: 6,
+      symbol: 'TEST',
+      name: 'Test Token',
+      connections: [],
+    });
+    originToken.connections!.push({ token: destinationToken });
+    const mixedDecimalWarpCore = new WarpCore(multiProvider, [
+      originToken,
+      destinationToken,
+    ]);
+    const originStub = sinon.stub(originToken, 'getHypAdapter').returns({
+      getBalance: () => Promise.resolve(1_000_000n),
+      getBridgedSupply: () => Promise.resolve(1_000_000n),
+    } as any);
+    const destinationStub = sinon
+      .stub(destinationToken, 'getHypAdapter')
+      .returns({
+        getBalance: () => Promise.resolve(1_000_000n),
+        getBridgedSupply: () => Promise.resolve(1_000_000n),
+      } as any);
+
+    try {
+      expect(
+        await mixedDecimalWarpCore.isDestinationCollateralSufficient({
+          originTokenAmount: originToken.amount(1_000_000_000_000_000_000n),
+          destination: test2.name,
+        }),
+      ).to.be.true;
+      expect(
+        await mixedDecimalWarpCore.isDestinationCollateralSufficient({
+          originTokenAmount: originToken.amount(1_000_000_000_000_000_001n),
+          destination: test2.name,
+        }),
+      ).to.be.false;
+    } finally {
+      originStub.restore();
+      destinationStub.restore();
+    }
+  });
+
+  it('Uses message-space collateral checks when one side has rational scale and the other uses implicit identity', async () => {
+    const originToken = new Token({
+      chainName: test1.name,
+      standard: TokenStandard.EvmHypCollateral,
+      addressOrDenom: zeroAddress,
+      decimals: 18,
+      scale: { numerator: 2, denominator: 1_000_000_000_000 },
+      symbol: 'TEST',
+      name: 'Test Token',
+      connections: [],
+    });
+    const destinationToken = new Token({
+      chainName: test2.name,
+      standard: TokenStandard.EvmHypCollateral,
+      addressOrDenom: zeroAddress,
+      decimals: 6,
+      symbol: 'TEST',
+      name: 'Test Token',
+      connections: [],
+    });
+    originToken.connections!.push({ token: destinationToken });
+    const scaledWarpCore = new WarpCore(multiProvider, [
+      originToken,
+      destinationToken,
+    ]);
+    const originStub = sinon.stub(originToken, 'getHypAdapter').returns({
+      getBalance: () => Promise.resolve(1_000_000n),
+      getBridgedSupply: () => Promise.resolve(1_000_000n),
+    } as any);
+    const destinationStub = sinon
+      .stub(destinationToken, 'getHypAdapter')
+      .returns({
+        getBalance: () => Promise.resolve(1_000_000n),
+        getBridgedSupply: () => Promise.resolve(1_000_000n),
+      } as any);
+
+    try {
+      expect(
+        await scaledWarpCore.isDestinationCollateralSufficient({
+          originTokenAmount: originToken.amount(500_000_000_000_000_000n),
+          destination: test2.name,
+        }),
+      ).to.be.true;
+      expect(
+        await scaledWarpCore.isDestinationCollateralSufficient({
+          originTokenAmount: originToken.amount(750_000_000_000_000_000n),
+          destination: test2.name,
+        }),
+      ).to.be.false;
+    } finally {
+      originStub.restore();
+      destinationStub.restore();
+    }
   });
 
   it('Validates transfers', async () => {

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -401,6 +401,145 @@ describe('WarpCore', () => {
     }
   });
 
+  it('Uses message-space collateral checks when destination has scale and origin uses implicit identity', async () => {
+    // Reverse of the previous test: origin is the "simple" 6-dec side,
+    // destination is 18-dec with a rational scale.
+    const originToken = new Token({
+      chainName: test1.name,
+      standard: TokenStandard.EvmHypCollateral,
+      addressOrDenom: zeroAddress,
+      decimals: 6,
+      symbol: 'TEST',
+      name: 'Test Token',
+      connections: [],
+    });
+    const destinationToken = new Token({
+      chainName: test2.name,
+      standard: TokenStandard.EvmHypCollateral,
+      addressOrDenom: zeroAddress,
+      decimals: 18,
+      scale: { numerator: 2, denominator: 1_000_000_000_000 },
+      symbol: 'TEST',
+      name: 'Test Token',
+      connections: [],
+    });
+    originToken.connections!.push({ token: destinationToken });
+    const scaledWarpCore = new WarpCore(multiProvider, [
+      originToken,
+      destinationToken,
+    ]);
+    // dest has 1_000_000 local units; scale {2, 1e12} → message = 1_000_000 * 2 / 1e12 = 0
+    // So even a small origin amount should be insufficient.
+    const originStub = sinon.stub(originToken, 'getHypAdapter').returns({
+      getBalance: () => Promise.resolve(1_000_000n),
+      getBridgedSupply: () => Promise.resolve(1_000_000n),
+    } as any);
+    const destinationStub = sinon
+      .stub(destinationToken, 'getHypAdapter')
+      .returns({
+        getBalance: () => Promise.resolve(1_000_000n),
+        getBridgedSupply: () => Promise.resolve(1_000_000n),
+      } as any);
+
+    try {
+      // origin 1_000_000 (6-dec, identity scale) → message = 1_000_000
+      // dest 1_000_000 (18-dec, scale 2/1e12) → message = 0 (floor)
+      expect(
+        await scaledWarpCore.isDestinationCollateralSufficient({
+          originTokenAmount: originToken.amount(1n),
+          destination: test2.name,
+        }),
+      ).to.be.false;
+
+      // Give dest enough balance: 500_000_000_000_000_000 * 2 / 1e12 = 1_000_000
+      destinationStub.restore();
+      const destinationStub2 = sinon
+        .stub(destinationToken, 'getHypAdapter')
+        .returns({
+          getBalance: () => Promise.resolve(500_000_000_000_000_000n),
+          getBridgedSupply: () => Promise.resolve(500_000_000_000_000_000n),
+        } as any);
+
+      expect(
+        await scaledWarpCore.isDestinationCollateralSufficient({
+          originTokenAmount: originToken.amount(1_000_000n),
+          destination: test2.name,
+        }),
+      ).to.be.true;
+
+      destinationStub2.restore();
+    } finally {
+      originStub.restore();
+    }
+  });
+
+  it('Uses message-space collateral checks when both tokens have non-trivial scale and different decimals', async () => {
+    // Production-realistic: origin 18-dec with scale-down {1, 1e12},
+    // dest 6-dec with scale-up {2, 1}.
+    // origin message amount = localAmount * 1 / 1e12
+    // dest message amount = localAmount * 2 / 1
+    const originToken = new Token({
+      chainName: test1.name,
+      standard: TokenStandard.EvmHypCollateral,
+      addressOrDenom: zeroAddress,
+      decimals: 18,
+      scale: { numerator: 1, denominator: 1_000_000_000_000 },
+      symbol: 'TEST',
+      name: 'Test Token',
+      connections: [],
+    });
+    const destinationToken = new Token({
+      chainName: test2.name,
+      standard: TokenStandard.EvmHypCollateral,
+      addressOrDenom: zeroAddress,
+      decimals: 6,
+      scale: { numerator: 2, denominator: 1 },
+      symbol: 'TEST',
+      name: 'Test Token',
+      connections: [],
+    });
+    originToken.connections!.push({ token: destinationToken });
+    const scaledWarpCore = new WarpCore(multiProvider, [
+      originToken,
+      destinationToken,
+    ]);
+    const originStub = sinon.stub(originToken, 'getHypAdapter').returns({
+      getBalance: () => Promise.resolve(1_000_000n),
+      getBridgedSupply: () => Promise.resolve(1_000_000n),
+    } as any);
+    // dest balance 500_000: message = 500_000 * 2 = 1_000_000
+    const destinationStub = sinon
+      .stub(destinationToken, 'getHypAdapter')
+      .returns({
+        getBalance: () => Promise.resolve(500_000n),
+        getBridgedSupply: () => Promise.resolve(500_000n),
+      } as any);
+
+    try {
+      // origin 1_000_000_000_000_000_000 (1 token in 18-dec)
+      // → message = 1e18 * 1 / 1e12 = 1_000_000
+      // dest message = 500_000 * 2 = 1_000_000 → sufficient
+      expect(
+        await scaledWarpCore.isDestinationCollateralSufficient({
+          originTokenAmount: originToken.amount(1_000_000_000_000_000_000n),
+          destination: test2.name,
+        }),
+      ).to.be.true;
+
+      // origin 2e18 → message = 2_000_000
+      // dest message = 1_000_000 → insufficient
+      expect(
+        await scaledWarpCore.isDestinationCollateralSufficient({
+          originTokenAmount: originToken.amount(2_000_000_000_000_000_000n),
+          destination: test2.name,
+        }),
+      ).to.be.false;
+    } finally {
+      originStub.restore();
+      destinationStub.restore();
+    }
+  });
+
   it('Validates transfers', async () => {
     const balanceStubs = warpCore.tokens.map((t) =>
       sinon.stub(t, 'getBalance').resolves({ amount: MOCK_BALANCE } as any),

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -9,7 +9,6 @@ import {
   assert,
   convertDecimalsToIntegerString,
   convertToProtocolAddress,
-  convertToScaledAmount,
   isEVMLike,
   isValidAddress,
   isZeroishAddress,
@@ -57,6 +56,7 @@ import {
 import type { QuotedCallsParams } from '../quoted-calls/types.js';
 import { TokenPullMode } from '../quoted-calls/types.js';
 import { ChainName, ChainNameOrId } from '../types.js';
+import { messageAmountFromLocal } from '../utils/decimals.js';
 
 import {
   FeeConstantConfig,
@@ -1242,34 +1242,36 @@ export class WarpCore {
     const destinationBalance = await this.getTokenCollateral(
       resolvedDestinationToken,
     );
-
-    const destinationBalanceInOriginDecimals = convertDecimalsToIntegerString(
-      resolvedDestinationToken.decimals,
-      originToken.decimals,
-      destinationBalance.toString(),
-    );
-
-    // check for scaling factor
     if (
-      originToken.scale &&
-      resolvedDestinationToken.scale &&
-      originToken.scale !== resolvedDestinationToken.scale
+      originToken.decimals !== resolvedDestinationToken.decimals &&
+      originToken.scale === undefined &&
+      resolvedDestinationToken.scale === undefined
     ) {
-      const precisionFactor = 100_000;
-      const scaledAmount = convertToScaledAmount({
-        fromScale: originToken.scale,
-        toScale: resolvedDestinationToken.scale,
-        amount,
-        precisionFactor,
-      });
-
-      return (
-        BigInt(destinationBalanceInOriginDecimals) * BigInt(precisionFactor) >=
-        scaledAmount
+      const destinationBalanceInOriginDecimals = BigInt(
+        convertDecimalsToIntegerString(
+          resolvedDestinationToken.decimals,
+          originToken.decimals,
+          destinationBalance.toString(),
+        ),
       );
+      const isSufficient = destinationBalanceInOriginDecimals >= amount;
+      this.logger.debug(
+        `${originTokenAmount.token.symbol} to ${destination} has ${
+          isSufficient ? 'sufficient' : 'INSUFFICIENT'
+        } collateral`,
+      );
+      return isSufficient;
     }
 
-    const isSufficient = BigInt(destinationBalanceInOriginDecimals) >= amount;
+    const requiredMessageAmount = messageAmountFromLocal(
+      amount,
+      originToken.scale,
+    );
+    const availableMessageAmount = messageAmountFromLocal(
+      destinationBalance,
+      resolvedDestinationToken.scale,
+    );
+    const isSufficient = availableMessageAmount >= requiredMessageAmount;
     this.logger.debug(
       `${originTokenAmount.token.symbol} to ${destination} has ${
         isSufficient ? 'sufficient' : 'INSUFFICIENT'

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -1242,6 +1242,13 @@ export class WarpCore {
     const destinationBalance = await this.getTokenCollateral(
       resolvedDestinationToken,
     );
+    // Legacy fallback: when both scales are undefined but decimals differ,
+    // we can't use message-space comparison because messageAmountFromLocal
+    // with identity scale would compare raw local units across different
+    // decimal spaces. Fall back to decimal conversion instead.
+    // Well-configured routes should have scale set — verifyScale() catches
+    // this at deploy time. Misconfigured routes that reach the message-space
+    // path below will safely return false (insufficient).
     if (
       originToken.decimals !== resolvedDestinationToken.decimals &&
       originToken.scale === undefined &&

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -1248,7 +1248,7 @@ export class WarpCore {
     // decimal spaces. Fall back to decimal conversion instead.
     // Well-configured routes should have scale set — verifyScale() catches
     // this at deploy time. Misconfigured routes that reach the message-space
-    // path below will safely return false (insufficient).
+    // path below may produce incorrect results.
     if (
       originToken.decimals !== resolvedDestinationToken.decimals &&
       originToken.scale === undefined &&

--- a/typescript/warp-monitor/src/explorer.test.ts
+++ b/typescript/warp-monitor/src/explorer.test.ts
@@ -38,14 +38,23 @@ describe('Explorer Pending Transfers', () => {
       expect(
         messageAmountToTokenBaseUnits(messageAmount, 1_000_000_000_000),
       ).to.equal(1234567n);
+      expect(
+        messageAmountToTokenBaseUnits(messageAmount, {
+          numerator: 1,
+          denominator: 1_000_000_000_000,
+        }),
+      ).to.equal(messageAmount * 1_000_000_000_000n);
       expect(messageAmountToTokenBaseUnits(100n, 1)).to.equal(100n);
       expect(messageAmountToTokenBaseUnits(100n, 10)).to.equal(10n);
     });
 
     it('throws on invalid scale', () => {
       expect(() => messageAmountToTokenBaseUnits(1n, 0)).to.throw(
-        'Invalid token scale',
+        'Scale must be positive',
       );
+      expect(() =>
+        messageAmountToTokenBaseUnits(1n, { numerator: 0, denominator: 1 }),
+      ).to.throw('Scale must be positive');
     });
   });
 

--- a/typescript/warp-monitor/src/explorer.ts
+++ b/typescript/warp-monitor/src/explorer.ts
@@ -1,6 +1,11 @@
 import type { Logger } from 'pino';
 
-import type { ChainName, Token } from '@hyperlane-xyz/sdk';
+import {
+  localAmountFromMessage,
+  type ChainName,
+  type ScaleInput,
+  type Token,
+} from '@hyperlane-xyz/sdk';
 import {
   bytes32ToAddress,
   isValidAddressEvm,
@@ -27,7 +32,7 @@ export type RouterNodeMetadata = {
   tokenName: string;
   tokenSymbol: string;
   tokenDecimals: number;
-  tokenScale?: number;
+  tokenScale?: ScaleInput;
   token: Token;
 };
 
@@ -71,14 +76,9 @@ function isValidEvmWarpRecipient(recipientBytes32: string): boolean {
 
 export function messageAmountToTokenBaseUnits(
   amountMessageUnits: bigint,
-  tokenScale?: number,
+  tokenScale?: ScaleInput,
 ): bigint {
-  const scale = BigInt(tokenScale ?? 1);
-  if (scale <= 0n) {
-    throw new Error(`Invalid token scale ${scale.toString()}`);
-  }
-
-  return amountMessageUnits / scale;
+  return localAmountFromMessage(amountMessageUnits, tokenScale);
 }
 
 export class ExplorerPendingTransfersClient {


### PR DESCRIPTION
## Summary
- Extracted the SDK-level scale/decimals fixes from #8563 (rebalancer PR) into a standalone PR
- Added bigint scale conversion helpers (`messageAmountFromLocal`, `localAmountFromMessage`, `minLocalAmountForMessage`, `alignLocalAmountToMessage`) to `decimals.ts`
- Updated `TokenConfigSchema` to accept `{numerator, denominator}` scale format alongside plain numbers
- Rewrote `WarpCore.isDestinationCollateralSufficient` to compare in message-space, fixing unit mismatch and precision loss bugs when origin/dest have different decimals+scales
- Added legacy decimal-conversion fallback for mixed-decimal routes where both scales are `undefined`

## Bugs fixed
These are SDK-level fixes for the bugs documented in the scale/decimals audit:

| Bug | Description | Fix |
|-----|-------------|-----|
| 1 | `convertToScaledAmount` can't handle `{num,den}` objects | New helpers accept all `ScaleInput` variants via `normalizeScale` |
| 2 | Precision loss via `Math.floor` in float arithmetic | Pure bigint math throughout, no intermediate floats |
| 3 | Unit mismatch in `isDestinationCollateralSufficient` | Both sides now compared in message-space |
| 4 | `!==` reference equality on scale objects | Legacy path only triggers when both scales are `undefined`; message-space path handles all formats |

## Note
The warp-ui display bug (`fromWei` using origin decimals instead of dest decimals) is in the warp-ui-template repo and will be addressed separately.

## Related
- Extracted from #8563 (rebalancer decimal normalization PR by @Mo-Hussain)
- Review comments from that PR (coderabbitai, paulbalaji, claude) are already incorporated: `&&` for fallback condition, `ceilDiv` assert, `alignLocalAmountToMessage` negative rejection, test covering message-space path

## Test plan
- [x] All new scale conversion helpers have unit tests (floor rounding, ceil rounding, alignment, negative rejection)
- [x] `WarpCore.test.ts` covers: plain number scales, rational `{num,den}` scales, legacy fallback for missing scale, one-sided rational scale with implicit identity
- [x] SDK builds cleanly (`pnpm -C typescript/sdk build`)
- [x] All 43 relevant tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
