### PR TITLE
fix(sdk): replace z.coerce.bigint with pipe-based coercion for JSON schema compat

### DIFF
--- a/.changeset/bright-lizards-glow.md
+++ b/.changeset/bright-lizards-glow.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Replaced z.coerce.bigint().positive() with pipe-based coercion in TokenMetadataSchema scale field to fix zod-to-json-schema compatibility in the registry build.

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -33,6 +33,17 @@ export const contractVersionMatchesDependency = (version: string) => {
 
 export const VERSION_ERROR_MESSAGE = `Contract version must match the @hyperlane-xyz/core dependency version (${CONTRACTS_PACKAGE_VERSION})`;
 
+/**
+ * Coerces bigint or string to bigint with positivity check.
+ * Needed because bigints are serialised as strings in JSON/YAML
+ * and must be converted back on parse. Uses .refine() instead of
+ * .positive() to avoid bigint values in zod-to-json-schema output.
+ */
+const PositiveBigIntFromString = z
+  .union([z.bigint(), z.string().transform((s) => BigInt(s))])
+  .pipe(z.bigint())
+  .refine((n) => n > 0n, { message: 'Must be positive' });
+
 export const TokenMetadataSchema = z.object({
   name: z.string(),
   symbol: z.string(),
@@ -45,8 +56,8 @@ export const TokenMetadataSchema = z.object({
         denominator: z.number().int().gt(0),
       }),
       z.object({
-        numerator: z.coerce.bigint().positive(),
-        denominator: z.coerce.bigint().positive(),
+        numerator: PositiveBigIntFromString,
+        denominator: PositiveBigIntFromString,
       }),
     ])
     .optional(),

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -40,7 +40,23 @@ export const VERSION_ERROR_MESSAGE = `Contract version must match the @hyperlane
  * .positive() to avoid bigint values in zod-to-json-schema output.
  */
 const PositiveBigIntFromString = z
-  .union([z.bigint(), z.string().transform((s) => BigInt(s))])
+  .union([
+    z.bigint(),
+    z
+      .string()
+      .refine(
+        (s) => {
+          try {
+            BigInt(s);
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        { message: 'Must be a bigint-compatible string' },
+      )
+      .transform((s) => BigInt(s)),
+  ])
   .pipe(z.bigint())
   .refine((n) => n > 0n, { message: 'Must be positive' });
 


### PR DESCRIPTION
## Summary
Fixes the registry build failure caused by `z.coerce.bigint().positive()` in `TokenMetadataSchema`'s scale field (introduced in 8dfc5d18b0).

`zod-to-json-schema` calls `isOptional()` on schema properties, which internally does `safeParse(undefined)`. When it hits `z.coerce.bigint()`, zod eagerly calls `BigInt(undefined)` → TypeError crash. This breaks the registry's `zodToJsonSchema(WarpCoreConfigSchema)` call that generates `deployments/warp_routes/schema.json`.

## Fix
Replace `z.coerce.bigint().positive()` with:
```typescript
const PositiveBigIntFromString = z
  .union([
    z.bigint(),
    z.string()
      .refine((s) => {
        try { BigInt(s); return true; } catch { return false; }
      }, { message: 'Must be a bigint-compatible string' })
      .transform((s) => BigInt(s)),
  ])
  .pipe(z.bigint())
  .refine((n) => n > 0n, { message: 'Must be positive' });
```

This preserves the same runtime behavior (accepts bigint, coerces strings from JSON/YAML serialization round-trips, rejects non-positive values) while being compatible with `zod-to-json-schema`:
- `z.bigint()` inside a union instead of `z.coerce.bigint()` — `safeParse(undefined)` fails gracefully
- `.refine()` instead of `.positive()` — avoids embedding bigint values (`exclusiveMinimum: 0n`) in the JSON schema output that `JSON.stringify` can't serialize
- `.refine()` before `.transform()` on the string branch — validates bigint-compatibility before calling `BigInt(s)`, producing a clean ZodError instead of a raw SyntaxError on invalid strings (this also improves on the original `z.coerce.bigint()` which had the same throwing behavior)

## Verified
- SDK builds and all 48 scale/decimals tests pass
- Locally built SDK passes `zodToJsonSchema(WarpCoreConfigSchema)` against the registry's `zod-to-json-schema@3.22.5`
- `safeParse({ scale: { numerator: 'abc', denominator: '1' } })` correctly returns a ZodError instead of throwing

## Related
- Introduced in: 8dfc5d18b0 (`fix(sdk): use z.coerce.bigint for scale`)
- Breaks: hyperlane-xyz/hyperlane-registry#1477

🤖 Generated with [Claude Code](https://claude.com/claude-code)