### PR TITLE
fix: solana routing fee

### DIFF
--- a/.changeset/brown-peaches-peel.md
+++ b/.changeset/brown-peaches-peel.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed routing fee for non-evm legs

--- a/typescript/cli/src/tests/cross-chain/warp/warp-cc-evm-svm.e2e-test.ts
+++ b/typescript/cli/src/tests/cross-chain/warp/warp-cc-evm-svm.e2e-test.ts
@@ -21,6 +21,7 @@ import {
   runSolanaNode,
 } from '@hyperlane-xyz/sealevel-sdk/testing';
 import {
+  TokenFeeType,
   TokenType,
   type WarpCoreConfig,
   type WarpRouteDeployConfig,
@@ -354,5 +355,76 @@ describe('hyperlane warp crossCollateral EVM+SVM e2e tests', function () {
       evmCCRoutersB,
       `EVM Route B should have EVM Route A enrolled as CC router on domain ${evmDomainId}`,
     ).to.include(evmRouterAHex32);
+  });
+
+  it('should deploy EVM collateral + SVM synthetic with RoutingFee tokenFee without error', async function () {
+    const evmOwner = new Wallet(EVM_KEY).address;
+    const svmOwner = svmSigner.getSignerAddress();
+    const DECIMALS = 9;
+    const SYMBOL = 'RTKN';
+
+    const evmToken = await deployToken(
+      EVM_KEY,
+      EVM_CHAIN,
+      DECIMALS,
+      SYMBOL,
+      'Routing Token',
+      REGISTRY_PATH,
+    );
+
+    const warpId = createWarpRouteConfigId(SYMBOL, `${EVM_CHAIN}-${SVM_CHAIN}`);
+    const warpDeployConfig: WarpRouteDeployConfig = {
+      [EVM_CHAIN]: {
+        type: TokenType.collateral,
+        token: evmToken.address,
+        mailbox: evmCoreAddresses.mailbox,
+        owner: evmOwner,
+        tokenFee: {
+          type: TokenFeeType.RoutingFee,
+          owner: evmOwner,
+          feeContracts: {
+            [SVM_CHAIN]: {
+              type: TokenFeeType.LinearFee,
+              bps: 50,
+            },
+          },
+        },
+      },
+      [SVM_CHAIN]: {
+        type: TokenType.synthetic,
+        mailbox: svmCoreAddresses.mailbox,
+        owner: svmOwner,
+        name: 'Routing Token',
+        symbol: SYMBOL,
+        decimals: DECIMALS,
+        metadataUri: 'https://test.example.com/rtkn-metadata.json',
+      },
+    };
+
+    writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpDeployConfig);
+
+    // Before the fix, enrollCrossChainRouters would fail with a
+    // RoutingFeeInputConfigSchema validation error because the EVM reader
+    // returns empty feeContracts when no SVM routers are enrolled yet.
+    await warpCommands.deployRaw({
+      warpRouteId: warpId,
+      warpDeployPath: WARP_DEPLOY_OUTPUT_PATH,
+      skipConfirmationPrompts: true,
+      extraArgs: [
+        `--key.${ProtocolType.Ethereum}`,
+        EVM_KEY,
+        `--key.${ProtocolType.Sealevel}`,
+        SVM_KEY,
+      ],
+    });
+
+    const warpCorePath = getWarpCoreConfigPath(SYMBOL, [EVM_CHAIN, SVM_CHAIN]);
+    const deployedConfig = await warpCommands.readConfig(
+      EVM_CHAIN,
+      warpCorePath,
+    );
+    expect(deployedConfig[EVM_CHAIN].tokenFee?.type).to.equal(
+      TokenFeeType.RoutingFee,
+    );
   });
 });

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -645,6 +645,17 @@ export async function enrollCrossChainRouters(
             owner: resolvedConfigMap[currentChain].owner,
             remoteRouters,
             destinationGas,
+            // For cross-protocol routes (EVM+SVM/Cosmos), the EVM deployer
+            // never enrolls non-EVM remote routers, so TokenRouter.domains()=[]
+            // at this point. The reader derives RoutingFee.feeContracts from
+            // enrolled domains, returning {} which fails
+            // RoutingFeeInputConfigSchema validation. Use the deploy config's
+            // tokenFee (non-empty feeContracts) so validation passes.
+            // EvmTokenFeeModule.update() reads actual on-chain state via
+            // routingDestinations and confirms no change is needed.
+            ...(resolvedConfigMap[currentChain].tokenFee && {
+              tokenFee: resolvedConfigMap[currentChain].tokenFee,
+            }),
           };
 
           transactions = await evmWarpModule.update(expectedConfig, {


### PR DESCRIPTION
### Description

`warp deploy` for cross-protocol routes (EVM + SVM/Cosmos) with a `RoutingFee` token fee failed during router enrollment with:

```
✅ Warp contract deployments complete
Start enrolling cross chain routers
Failed to create enroll router transactions for chain ethereumlocal1: [
  {
    "code": "custom",
    "path": [
      "tokenFee",
      "feeContracts"
    ],
    "message": "RoutingFee must define at least one destination fee"
  }
]
Error: Failed to create router enrollment transactions for 1 chain(s): ethereumlocal1: ...
```

**Root cause**: The EVM deployer (`HypERC20Deployer`) processes only EVM chains in its batch. When `enrollRemoteRouters()` runs, `solanalocal` isn't in `deployedContractsMap` (it's deployed separately in the SVM pass) and isn't a `foreignDeployment`, so no enrollment happens. `TokenRouter.domains()` on the EVM chain is `[]` at this point.

`deployAndConfigureTokenFees()` then correctly deploys the `RoutingFee` and `LinearFee` sub-fee contracts on-chain.

Later, `enrollCrossChainRouters()` calls `evmWarpModule.read()`. The reader derives `RoutingFee.feeContracts` from `TokenRouter.domains()`, which is still `[]` — so it returns `feeContracts: {}`. This empty object is spread into `expectedConfig`, which then fails `RoutingFeeInputConfigSchema` validation (requires ≥1 destination fee) when `evmWarpModule.update()` runs.

**Fix**: In `enrollCrossChainRouters()`, override `tokenFee` in `expectedConfig` with the original value from the deploy config (non-empty `feeContracts`) instead of the one read from chain. `EvmTokenFeeModule.update()` reads the actual on-chain state via `routingDestinations` and confirms no change is needed.

**Reproduction** (deploy config):

```yaml
ethereumlocal1:
  decimals: 9
  mailbox: "0x610178dA211FEF7D417bC0e6FeD39F05609AD788"
  name: Solana
  owner: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
  symbol: SOL
  tokenFee:
    feeContracts:
      solanalocal:
        bps: 6
        owner: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
        type: LinearFee
    owner: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
    type: RoutingFee
  type: synthetic
solanalocal:
  decimals: 9
  gas: 300000
  hook: GwHaw8ewMyzZn9vvrZEnTEAAYpLdkGYs195XWcLDCN4U
  mailbox: 692KZJaoe2KRcD6uhCQDLLXnLNA5ZLnfvdqjE4aX9iu1
  owner: GhX4cjAaRAPRTb9fkgLtLq9cYTLncRBGN3pa4KSKUv4J
  type: native
```

### Drive-by changes

None

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

Yes

### Testing

Manual — re-ran `pnpm hyperlane warp deploy` for `SOL/igra-solanatestnet` (EVM + Sealevel route with `RoutingFee`)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->