### PR TITLE
Harden sealevel receipt polling

### DIFF
--- a/typescript/cli/src/send/transfer.test.ts
+++ b/typescript/cli/src/send/transfer.test.ts
@@ -40,10 +40,14 @@ describe('fetchSealevelReceiptWithLogs', () => {
   });
 
   it('throws when Solana logs never become available', async () => {
+    let calls = 0;
     const context = {
       multiProtocolProvider: {
         getSolanaWeb3Provider: () => ({
-          getTransaction: async () => ({ meta: { logMessages: [] } }),
+          getTransaction: async () => {
+            calls += 1;
+            return { meta: { logMessages: [] } };
+          },
         }),
       },
     } as any;
@@ -63,6 +67,39 @@ describe('fetchSealevelReceiptWithLogs', () => {
         'Transaction logs unavailable for Solana transaction missing-logs-signature',
       );
     }
+    expect(calls).to.equal(2);
+  });
+
+  it('retries through transient getTransaction errors', async () => {
+    let calls = 0;
+    const receipt = {
+      meta: { logMessages: ['Dispatched message to 1234, ID deadbeef'] },
+    };
+    const context = {
+      multiProtocolProvider: {
+        getSolanaWeb3Provider: () => ({
+          getTransaction: async () => {
+            calls += 1;
+            if (calls === 1) throw new Error('temporary rpc failure');
+            return receipt;
+          },
+        }),
+      },
+    } as any;
+
+    const typedReceipt = await fetchSealevelReceiptWithLogs(
+      context,
+      'solanamainnet',
+      'transient-signature',
+      0,
+      2,
+    );
+
+    expect(calls).to.equal(2);
+    expect(typedReceipt).to.deep.equal({
+      type: ProviderType.SolanaWeb3,
+      receipt,
+    });
   });
 });
 
@@ -108,6 +145,7 @@ describe('submitAltVmTransferTx', () => {
         transaction,
         extraSigners: [extraSigner],
       },
+      timeoutSec: 30,
     });
 
     expect(signerCalls).to.deep.equal([

--- a/typescript/cli/src/send/transfer.ts
+++ b/typescript/cli/src/send/transfer.ts
@@ -108,15 +108,29 @@ export async function fetchSealevelReceiptWithLogs(
   pollIntervalMs = SEALEVEL_RECEIPT_POLL_INTERVAL_MS,
   maxAttempts = SEALEVEL_RECEIPT_MAX_ATTEMPTS,
 ): Promise<TypedTransactionReceipt> {
+  assert(
+    Number.isFinite(pollIntervalMs) && pollIntervalMs >= 0,
+    `Invalid Sealevel receipt poll interval: ${pollIntervalMs}`,
+  );
+  assert(
+    Number.isInteger(maxAttempts) && maxAttempts > 0,
+    `Invalid Sealevel receipt maxAttempts: ${maxAttempts}`,
+  );
   const connection =
     context.multiProtocolProvider.getSolanaWeb3Provider(origin);
   let receipt = null;
+  let lastError: unknown;
 
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-    receipt = await connection.getTransaction(signature, {
-      commitment: 'confirmed',
-      maxSupportedTransactionVersion: 0,
-    });
+    try {
+      receipt = await connection.getTransaction(signature, {
+        commitment: 'confirmed',
+        maxSupportedTransactionVersion: 0,
+      });
+      lastError = undefined;
+    } catch (error) {
+      lastError = error;
+    }
 
     if (receipt?.meta?.logMessages?.length) {
       return {
@@ -130,8 +144,12 @@ export async function fetchSealevelReceiptWithLogs(
     }
   }
 
+  const suffix =
+    lastError === undefined
+      ? ''
+      : ` (last getTransaction error: ${lastError instanceof Error ? lastError.message : String(lastError)})`;
   throw new Error(
-    `Transaction logs unavailable for Solana transaction ${signature}`,
+    `Transaction logs unavailable for Solana transaction ${signature}${suffix}`,
   );
 }
 
@@ -150,11 +168,13 @@ export async function submitAltVmTransferTx({
   signer,
   origin,
   tx,
+  timeoutSec,
 }: {
   context: Pick<WriteCommandContext, 'multiProtocolProvider'>;
   signer: AltVmTransferSigner;
   origin: ChainName;
   tx: ExecutableAltVmTransfer;
+  timeoutSec: number;
 }): Promise<TypedTransactionReceipt> {
   if (!isAnnotatedTx(tx.transaction)) {
     throw new Error(
@@ -169,7 +189,16 @@ export async function submitAltVmTransferTx({
   );
 
   return tx.type === ProviderType.SolanaWeb3
-    ? fetchSealevelReceiptWithLogs(context, origin, txReceipt.signature)
+    ? fetchSealevelReceiptWithLogs(
+        context,
+        origin,
+        txReceipt.signature,
+        SEALEVEL_RECEIPT_POLL_INTERVAL_MS,
+        Math.max(
+          SEALEVEL_RECEIPT_MAX_ATTEMPTS,
+          Math.ceil((timeoutSec * 1000) / SEALEVEL_RECEIPT_POLL_INTERVAL_MS),
+        ),
+      )
     : toTypedAltVmReceipt(tx.type, txReceipt);
 }
 
@@ -531,6 +560,7 @@ async function executeDelivery({
         signer,
         origin,
         tx,
+        timeoutSec,
       });
       txReceipts.push(typedReceipt);
       if (tx.category === WarpTxCategory.Transfer) {


### PR DESCRIPTION
## Summary
- move sealevel receipt polling hardening out of #8567
- retry through transient getTransaction failures
- derive polling budget from CLI timeout

## Testing
- pnpm -C typescript/cli exec mocha --config .mocharc.json src/send/transfer.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
