### PR TITLE
fix(sdk): fix scale schema compat with zod-to-json-schema and type inference

### DIFF
--- a/.changeset/calm-foxes-sing.md
+++ b/.changeset/calm-foxes-sing.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Replaced z.coerce.bigint().positive() with ZBigNumberish.refine() in TokenMetadataSchema scale field for zod-to-json-schema compatibility. Fixed validateZodResult generic to correctly return output type for schemas with transforms.

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -11,7 +11,7 @@ import {
   IsmType,
   OffchainLookupIsmConfigSchema,
 } from '../ism/types.js';
-import { ZHash } from '../metadata/customZodTypes.js';
+import { ZBigNumberish, ZHash } from '../metadata/customZodTypes.js';
 import {
   DerivedRouterConfig,
   GasRouterConfigSchema,
@@ -34,31 +34,13 @@ export const contractVersionMatchesDependency = (version: string) => {
 export const VERSION_ERROR_MESSAGE = `Contract version must match the @hyperlane-xyz/core dependency version (${CONTRACTS_PACKAGE_VERSION})`;
 
 /**
- * Coerces bigint or string to bigint with positivity check.
- * Needed because bigints are serialised as strings in JSON/YAML
- * and must be converted back on parse. Uses .refine() instead of
- * .positive() to avoid bigint values in zod-to-json-schema output.
+ * Coerces string to bigint at runtime with positivity check.
+ * Needed because bigints are serialized as strings in JSON/YAML
+ * and must be converted back on parse.
  */
-const PositiveBigIntFromString = z
-  .union([
-    z.bigint(),
-    z
-      .string()
-      .refine(
-        (s) => {
-          try {
-            BigInt(s);
-            return true;
-          } catch {
-            return false;
-          }
-        },
-        { message: 'Must be a bigint-compatible string' },
-      )
-      .transform((s) => BigInt(s)),
-  ])
-  .pipe(z.bigint())
-  .refine((n) => n > 0n, { message: 'Must be positive' });
+const PositiveZBigNumberish = ZBigNumberish.refine((n) => n > 0n, {
+  message: 'Must be positive',
+});
 
 export const TokenMetadataSchema = z.object({
   name: z.string(),
@@ -72,8 +54,8 @@ export const TokenMetadataSchema = z.object({
         denominator: z.number().int().gt(0),
       }),
       z.object({
-        numerator: PositiveBigIntFromString,
-        denominator: PositiveBigIntFromString,
+        numerator: PositiveZBigNumberish,
+        denominator: PositiveZBigNumberish,
       }),
     ])
     .optional(),

--- a/typescript/sdk/src/utils/schemas.test.ts
+++ b/typescript/sdk/src/utils/schemas.test.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import { z } from 'zod';
+
+import { validateZodResult } from './schemas.js';
+
+describe('validateZodResult', () => {
+  it('returns parsed data on success', () => {
+    const schema = z.object({ name: z.string() });
+    const result = schema.safeParse({ name: 'hello' });
+    expect(validateZodResult(result)).to.deep.equal({ name: 'hello' });
+  });
+
+  it('throws on validation failure', () => {
+    const schema = z.object({ name: z.string() });
+    const result = schema.safeParse({ name: 123 });
+    expect(() => validateZodResult(result)).to.throw();
+  });
+
+  it('returns output type for schemas with transforms', () => {
+    const schema = z.object({
+      value: z.string().transform((s) => parseInt(s, 10)),
+    });
+    const result = schema.safeParse({ value: '42' });
+    const parsed = validateZodResult(result);
+    expect(parsed.value).to.equal(42);
+    expect(typeof parsed.value).to.equal('number');
+  });
+
+  it('handles schemas with bigint coercion', () => {
+    const schema = z.object({
+      amount: z.bigint().or(z.string().regex(/^\d+$/).transform(BigInt)),
+    });
+    const result = schema.safeParse({ amount: '1000000000000' });
+    const parsed = validateZodResult(result);
+    expect(parsed.amount).to.equal(1000000000000n);
+  });
+});

--- a/typescript/sdk/src/utils/schemas.ts
+++ b/typescript/sdk/src/utils/schemas.ts
@@ -7,10 +7,10 @@ export function isCompliant<S extends z.ZodTypeAny>(schema: S) {
     schema.safeParse(config).success;
 }
 
-export function validateZodResult<T>(
-  result: SafeParseReturnType<T, T>,
+export function validateZodResult<I, O>(
+  result: SafeParseReturnType<I, O>,
   desc: string = 'config',
-): T {
+): O {
   if (!result.success) {
     rootLogger.warn(`Invalid ${desc}`, result.error);
     throw new Error(`Invalid desc: ${result.error.toString()}`);


### PR DESCRIPTION
## Summary
Fixes two issues from the `PositiveBigIntFromString` schema introduced in #8595:

1. **Warp-UI type error**: The `union+pipe+refine` approach leaks `string | bigint` as the input type. Since `validateZodResult<T>(SafeParseReturnType<T, T>)` unifies input and output into one `T`, this widens the return type to include `string`, causing type incompatibility in the warp-ui (`warpCoreConfig.ts:138`).

2. **Unnecessary custom schema**: `ZBigNumberish` already exists in `customZodTypes.ts` and handles the same bigint/number/string coercion pattern used across the SDK.

## Fix

**`types.ts`**: Replace the custom `PositiveBigIntFromString` (union+pipe+refine) with `ZBigNumberish.refine(n => n > 0n)`. Reuses the existing utility instead of reinventing it.

**`schemas.ts`**: Change `validateZodResult` generic from `<T>(SafeParseReturnType<T, T>): T` to `<I, O>(SafeParseReturnType<I, O>): O` so transform-based schemas correctly return the output type instead of widening input+output.

## Verified
- Registry: `zodToJsonSchema(WarpCoreConfigSchema)` succeeds with valid JSON output
- Warp-UI: `tsc --noEmit` passes (tested via `pnpm link:monorepo`)
- SDK: builds clean, all 48 scale/decimals tests pass
- New tests for `validateZodResult` covering transforms and bigint coercion

## Related
- #8594 — SDK scale helpers (introduced `TokenMetadataSchema.shape.scale` in `TokenConfigSchema`)
- #8595 — First fix attempt (`PositiveBigIntFromString` union+pipe+refine, caused type leak)
- hyperlane-xyz/hyperlane-registry#1477 — Registry build failure
- hyperlane-xyz/hyperlane-warp-ui-template#1053 — Warp-UI type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)