### PR TITLE
chore: denylist orphaned superswap reveal message

### DIFF
--- a/typescript/infra/config/environments/mainnet3/customBlacklist.ts
+++ b/typescript/infra/config/environments/mainnet3/customBlacklist.ts
@@ -237,4 +237,7 @@ export const blacklistedMessageIds = [
 
   // USDC/eclipsemainnet warp transfer to USDC contract itself [2026-01-30]
   '0x4190cf8c0419cd966fc96fcb9050be3d941cb06974667bd768f22e90abcec6a6',
+
+  // superswap_ica_v2 orphaned reveal — commitment never persisted to offchain-lookup-server [2026-04-15]
+  '0x5376b3ae4771f09304c3eb46eee9f1c7107ff54735ca1a96ac2ff5186ddeac52',
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Added 1 message ID to the relayer denylist
- App context: `superswap_ica_v2`
- Route: Ink → Unichain
- Message ID: `0x5376b3ae4771f09304c3eb46eee9f1c7107ff54735ca1a96ac2ff5186ddeac52`

## Reason
The Superswap ICA reveal message is permanently stuck with `CouldNotFetchMetadata` because the commitment (`0x1444550fdfb4020609c9bda77e11eec76e880bd500740089c10df691ce5189dd`) was never persisted to the offchain-lookup-server DB by the frontend. The sibling messages (USDC warp transfer + ICA commit) were delivered successfully — user funds are safe in their ICA on Unichain.

## Test plan
- [ ] Review message ID is correct
- [ ] Deploy relayer with updated denylist

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cd1bb25-256a-4dcf-983d-c45dae79f01c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cd1bb25-256a-4dcf-983d-c45dae79f01c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

