### PR TITLE
chore(infra): right-size mainnet3 agent requests

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -805,32 +805,32 @@ const metricAppContextsGetter = (): MetricAppContext[] => {
   ];
 };
 
-// Resource requests are based on observed usage found in https://abacusworks.grafana.net/d/FSR9YWr7k
+// Resource requests are based on a Grafana Cloud review from January 15, 2026 to April 15, 2026.
 const relayerResources = {
   requests: {
-    cpu: '20000m',
-    memory: '55G',
+    cpu: '10000m',
+    memory: '52G',
   },
 };
 
 const fastPathRelayerResources = {
   requests: {
-    cpu: '8000m',
-    memory: '16G',
+    cpu: '1000m',
+    memory: '4Gi',
   },
 };
 
 const validatorResources = {
   requests: {
-    cpu: '500m',
-    memory: '1G',
+    cpu: '350m',
+    memory: '512Mi',
   },
 };
 
 const scraperResources = {
   requests: {
-    cpu: '2000m',
-    memory: '4G',
+    cpu: '1500m',
+    memory: '1Gi',
   },
 };
 


### PR DESCRIPTION
## Summary
- right-size mainnet3 agent requests from the January 15, 2026 to April 15, 2026 Grafana Cloud review
- cut the main relayer CPU request and trim its memory request conservatively
- reduce fastpath relayer, validator, and scraper requests to match the observed 90-day envelope with headroom

## Request changes
- main relayer: `20 CPU / 55G` -> `10 CPU / 52G`
- fastpath relayer: `8 CPU / 16G` -> `1 CPU / 4Gi`
- validators: `500m / 1G` -> `350m / 512Mi`
- scraper: `2 CPU / 4G` -> `1500m / 1Gi`

## Validation
- checked the exact config diff
- ran `git diff --check`

## Follow-up outside this repo
The relayer node-pool floor change (`relayer-pool-1 minNodeCount 3 -> 2`) still appears to be managed outside this repository, so it is not part of this diff.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
