### PR TITLE
fix(widgets): revert cosmos active chain to empty object

### DIFF
--- a/.changeset/fix-cosmos-active-chain.md
+++ b/.changeset/fix-cosmos-active-chain.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/widgets": patch
 ---
 
-Fix Cosmos transfers failing with "must be connected to origin chain" by reverting useCosmosActiveChain to return empty ActiveChainInfo, since CosmosKit doesn't have the concept of an active chain
+Fixed Cosmos transfers failing with "must be connected to origin chain" by reverting useCosmosActiveChain to return empty ActiveChainInfo, since CosmosKit doesn't have the concept of an active chain

--- a/.changeset/fix-cosmos-active-chain.md
+++ b/.changeset/fix-cosmos-active-chain.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/widgets": patch
+---
+
+Fix Cosmos transfers failing with "must be connected to origin chain" by reverting useCosmosActiveChain to return empty ActiveChainInfo, since CosmosKit doesn't have the concept of an active chain

--- a/typescript/widgets/src/walletIntegrations/cosmosWallet.ts
+++ b/typescript/widgets/src/walletIntegrations/cosmosWallet.ts
@@ -88,21 +88,11 @@ export function useCosmosDisconnectFn(): () => Promise<void> {
 }
 
 export function useCosmosActiveChain(
-  multiProvider: MinimalProviderRegistry,
+  _multiProvider: MinimalProviderRegistry,
 ): ActiveChainInfo {
-  const chainToContext = useChains(getCosmosChainNames(multiProvider));
-  const activeChainName = Object.entries(chainToContext).find(
-    ([, context]) => !!context.address,
-  )?.[0];
-
-  return useMemo<ActiveChainInfo>(() => {
-    if (!activeChainName) return {};
-    const chainMetadata = multiProvider.tryGetChainMetadata(activeChainName);
-    return {
-      chainName: activeChainName,
-      chainDisplayName: chainMetadata?.displayName || activeChainName,
-    };
-  }, [activeChainName, multiProvider]);
+  // CosmosKit doesn't have the concept of an active chain;
+  // wallets connect to each chain independently.
+  return useMemo(() => ({}) as ActiveChainInfo, []);
 }
 
 export function getCosmosChains(

--- a/typescript/widgets/src/walletIntegrations/cosmosWallet.ts
+++ b/typescript/widgets/src/walletIntegrations/cosmosWallet.ts
@@ -92,7 +92,7 @@ export function useCosmosActiveChain(
 ): ActiveChainInfo {
   // CosmosKit doesn't have the concept of an active chain;
   // wallets connect to each chain independently.
-  return useMemo(() => ({}) as ActiveChainInfo, []);
+  return useMemo<ActiveChainInfo>(() => ({}), []);
 }
 
 export function getCosmosChains(


### PR DESCRIPTION
## Summary

- Cosmos transfers fail with `Cosmos wallet must be connected to origin chain <chain>` when the user is connected to multiple cosmos chains
- Root cause: #8433 changed `useCosmosActiveChain` to return the first connected cosmos chain instead of `{}`. This causes a chain mismatch when transferring from a chain that isn't the first one found, triggering `switchNetwork` which always throws for Cosmos
- CosmosKit doesn't have the concept of an active chain — wallets connect to each chain independently. The previous behavior of returning `{}` was correct, so `activeChainName` is `undefined` and the `switchNetwork` check short-circuits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
