### PR TITLE
feat(infra): add mainnet3 inventory rebalancer balances for key funder

### DIFF
--- a/typescript/infra/config/environments/mainnet3/balances/desiredInventoryRebalancerBalances.json
+++ b/typescript/infra/config/environments/mainnet3/balances/desiredInventoryRebalancerBalances.json
@@ -7,6 +7,6 @@
   "optimism": 0.01,
   "plasma": 15,
   "polygon": 20,
-  "tron": 100,
+  "tron": 40,
   "unichain": 0.01
 }

--- a/typescript/infra/config/environments/mainnet3/balances/desiredInventoryRebalancerBalances.json
+++ b/typescript/infra/config/environments/mainnet3/balances/desiredInventoryRebalancerBalances.json
@@ -2,8 +2,11 @@
   "arbitrum": 0.01,
   "avalanche": 0.5,
   "base": 0.01,
+  "bsc": 0.01,
   "ethereum": 0.01,
   "optimism": 0.01,
+  "plasma": 15,
   "polygon": 20,
+  "tron": 100,
   "unichain": 0.01
 }


### PR DESCRIPTION
## Summary
This extracts the `desiredInventoryRebalancerBalances.json` change from #8586 into a standalone PR off `main`.

Goal: unblock deploying key funder with the updated mainnet3 inventory rebalancer balances before the full PR stack merges.

## Changes
- add `bsc: 0.01`
- add `plasma: 15`
- add `tron: 100`

## Notes
- scope intentionally limited to `typescript/infra/config/environments/mainnet3/balances/desiredInventoryRebalancerBalances.json`
- no Helm or other stacked PR changes included
