### PR TITLE
chore(relayer): add metadata subpath export and re-export types

### DIFF
--- a/.changeset/export-metadata-build-types.md
+++ b/.changeset/export-metadata-build-types.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/relayer": patch
+---
+
+Re-export metadata build result types from public API

--- a/.changeset/export-metadata-build-types.md
+++ b/.changeset/export-metadata-build-types.md
@@ -2,4 +2,5 @@
 "@hyperlane-xyz/relayer": patch
 ---
 
-Re-export metadata build result types from public API
+Re-export metadata build result types from the relayer public API and add a
+`@hyperlane-xyz/relayer/metadata` subpath export for metadata-only imports.

--- a/.changeset/export-metadata-build-types.md
+++ b/.changeset/export-metadata-build-types.md
@@ -2,5 +2,5 @@
 "@hyperlane-xyz/relayer": patch
 ---
 
-Re-export metadata build result types from the relayer public API and add a
+Re-exported metadata build result types from the relayer public API and added a
 `@hyperlane-xyz/relayer/metadata` subpath export for metadata-only imports.

--- a/typescript/relayer/README.md
+++ b/typescript/relayer/README.md
@@ -34,6 +34,14 @@ await relayer.relayMessage(dispatchTx);
 relayer.start();
 ```
 
+### Metadata-Only Usage
+
+For metadata builders without the relayer runtime API, use the `/metadata` export:
+
+```typescript
+import { BaseMetadataBuilder } from '@hyperlane-xyz/relayer/metadata';
+```
+
 ### Node.js Daemon Mode
 
 For Node.js environments with filesystem access, use the `/fs` export:
@@ -107,6 +115,7 @@ cacheFile: ./relayer-cache.json
 | Export                      | Description                               | Browser-safe |
 | --------------------------- | ----------------------------------------- | ------------ |
 | `@hyperlane-xyz/relayer`    | Core relayer, metadata builders, schemas  | Yes          |
+| `@hyperlane-xyz/relayer/metadata` | Metadata builders only                | Yes          |
 | `@hyperlane-xyz/relayer/fs` | RelayerService, loadConfig (file loading) | No (Node.js) |
 
 ## Prometheus Metrics

--- a/typescript/relayer/README.md
+++ b/typescript/relayer/README.md
@@ -112,11 +112,11 @@ cacheFile: ./relayer-cache.json
 
 ## Package Exports
 
-| Export                      | Description                               | Browser-safe |
-| --------------------------- | ----------------------------------------- | ------------ |
-| `@hyperlane-xyz/relayer`    | Core relayer, metadata builders, schemas  | Yes          |
-| `@hyperlane-xyz/relayer/metadata` | Metadata builders only                | Yes          |
-| `@hyperlane-xyz/relayer/fs` | RelayerService, loadConfig (file loading) | No (Node.js) |
+| Export                            | Description                               | Browser-safe |
+| --------------------------------- | ----------------------------------------- | ------------ |
+| `@hyperlane-xyz/relayer`          | Core relayer, metadata builders, schemas  | Yes          |
+| `@hyperlane-xyz/relayer/metadata` | Metadata builders only                    | Yes          |
+| `@hyperlane-xyz/relayer/fs`       | RelayerService, loadConfig (file loading) | No (Node.js) |
 
 ## Prometheus Metrics
 

--- a/typescript/relayer/package.json
+++ b/typescript/relayer/package.json
@@ -21,6 +21,9 @@
   "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
+      "metadata": [
+        "./dist/metadata/index.d.ts"
+      ],
       "fs": [
         "./dist/fs/index.d.ts"
       ]
@@ -30,6 +33,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./metadata": {
+      "types": "./dist/metadata/index.d.ts",
+      "default": "./dist/metadata/index.js"
     },
     "./fs": {
       "types": "./dist/fs/index.d.ts",

--- a/typescript/relayer/src/metadata/builder.ts
+++ b/typescript/relayer/src/metadata/builder.ts
@@ -65,6 +65,7 @@ export class BaseMetadataBuilder implements MetadataBuilder {
       case IsmType.TEST_ISM:
       case IsmType.OP_STACK:
       case IsmType.PAUSABLE:
+      case IsmType.CCIP:
         return this.nullMetadataBuilder.build({ ...context, ism });
 
       case IsmType.MERKLE_ROOT_MULTISIG:

--- a/typescript/relayer/src/metadata/index.ts
+++ b/typescript/relayer/src/metadata/index.ts
@@ -10,7 +10,21 @@ export { MultisigMetadata, MultisigMetadataBuilder } from './multisig.js';
 export { NullMetadata, NullMetadataBuilder } from './null.js';
 export { DynamicRoutingMetadataBuilder, RoutingMetadata } from './routing.js';
 export type {
+  AggregationMetadataBuildResult,
+  ArbL2ToL1MetadataBuildResult,
+  CcipReadMetadataBuildResult,
+  MetadataBuildResult,
   MetadataBuilder,
   MetadataContext,
+  MultisigMetadataBuildResult,
+  NullMetadataBuildResult,
+  RoutingMetadataBuildResult,
   StructuredMetadata,
+  ValidatorInfo,
+} from './types.js';
+export {
+  ValidatorStatus,
+  getSignedValidatorCount,
+  isMetadataBuildable,
+  isQuorumMet,
 } from './types.js';


### PR DESCRIPTION
## Summary
- Re-export metadata build result types (`MetadataBuildResult`, `ValidatorInfo`, etc.) from the relayer's public API
- Add `@hyperlane-xyz/relayer/metadata` subpath export for lightweight imports without pulling in the full relayer

Consumers can now:
```ts
import { BaseMetadataBuilder } from '@hyperlane-xyz/relayer/metadata';
import type { MetadataBuildResult, ValidatorInfo } from '@hyperlane-xyz/relayer/metadata';
```

Needed by hyperlane-explorer for validator signature status display (hyperlane-xyz/hyperlane-explorer#253).

## Test plan
- [ ] Verify `pnpm --filter @hyperlane-xyz/relayer build` passes
- [ ] Verify subpath import resolves correctly with `moduleResolution: "bundler"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily packaging/type-export changes plus a small ISM switch-case update; low risk aside from potential module resolution/export map regressions for consumers.
> 
> **Overview**
> Adds a new `@hyperlane-xyz/relayer/metadata` subpath export (with `exports` + `typesVersions`) so consumers can import metadata builders without pulling in the full relayer runtime, and documents this usage in the README.
> 
> Expands `src/metadata/index.ts` to re-export metadata build-result and validator-related types/utilities (e.g., `MetadataBuildResult`, `ValidatorInfo`, quorum helpers) and treats `IsmType.CCIP` as `NullMetadata` in `BaseMetadataBuilder`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad829097bc5e879192a01c5c54fab16ac8a47eb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->