### PR TITLE
[codex] refactor relayer read-only paths onto MultiProviderAdapter

### DIFF
--- a/.changeset/light-relayer-read-paths.md
+++ b/.changeset/light-relayer-read-paths.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/sdk': patch
+'@hyperlane-xyz/relayer': patch
+---
+
+Migrated relayer read-only config derivation and metadata reads onto `MultiProviderAdapter` and widened the SDK EVM readers to accept the lighter read-provider interface.

--- a/typescript/relayer/src/core/HyperlaneRelayer.ts
+++ b/typescript/relayer/src/core/HyperlaneRelayer.ts
@@ -12,6 +12,7 @@ import {
   IsmConfig,
   MultiProvider,
 } from '@hyperlane-xyz/sdk';
+import { MultiProviderAdapter } from '@hyperlane-xyz/sdk/providers/MultiProviderAdapter';
 import {
   Address,
   WithAddress,
@@ -36,6 +37,7 @@ type DerivedIsmConfig = WithAddress<Exclude<IsmConfig, Address>>;
 
 export class HyperlaneRelayer {
   protected multiProvider: MultiProvider;
+  protected readonly readProviderRegistry: MultiProviderAdapter;
   protected metadataBuilder: BaseMetadataBuilder;
   protected readonly core: HyperlaneCore;
   protected readonly retryTimeout: number;
@@ -66,8 +68,14 @@ export class HyperlaneRelayer {
     this.core = core;
     this.retryTimeout = retryTimeout;
     this.logger = core.logger.child({ module: 'Relayer' });
-    this.metadataBuilder = new BaseMetadataBuilder(core);
     this.multiProvider = core.multiProvider;
+    this.readProviderRegistry = MultiProviderAdapter.fromMultiProvider(
+      this.multiProvider,
+    );
+    this.metadataBuilder = new BaseMetadataBuilder(
+      core,
+      this.readProviderRegistry,
+    );
     this.observer = observer;
     if (whitelist) {
       this.whitelist = objMap(
@@ -96,7 +104,7 @@ export class HyperlaneRelayer {
       config = this.cache.hook[chain][hook] as DerivedHookConfig | undefined;
     } else {
       const evmHookReader = new EvmHookReader(
-        this.multiProvider,
+        this.readProviderRegistry,
         chain,
         undefined,
         messageContext,
@@ -130,7 +138,7 @@ export class HyperlaneRelayer {
       config = this.cache.ism[chain][cacheKey] as DerivedIsmConfig | undefined;
     } else {
       const evmIsmReader = new EvmIsmReader(
-        this.multiProvider,
+        this.readProviderRegistry,
         chain,
         undefined,
         messageContext,
@@ -354,8 +362,8 @@ export class HyperlaneRelayer {
 
       try {
         // TODO: handle batching
-        const dispatchReceipt = await this.multiProvider
-          .getProvider(parsed.origin)
+        const dispatchReceipt = await this.readProviderRegistry
+          .getEvmProvider(parsed.origin)
           .getTransactionReceipt(dispatchTx);
 
         await this.relayMessage(dispatchReceipt, undefined, dispatchMsg);

--- a/typescript/relayer/src/metadata/arbL2ToL1.ts
+++ b/typescript/relayer/src/metadata/arbL2ToL1.ts
@@ -20,6 +20,7 @@ import {
   IsmType,
   findMatchingLogEvents,
 } from '@hyperlane-xyz/sdk';
+import type { MultiProviderAdapter } from '@hyperlane-xyz/sdk/providers/MultiProviderAdapter';
 import { WithAddress, assert, rootLogger } from '@hyperlane-xyz/utils';
 
 import type {
@@ -41,6 +42,7 @@ const ArbSys = ArbSys__factory.createInterface();
 export class ArbL2ToL1MetadataBuilder implements MetadataBuilder {
   constructor(
     protected readonly core: HyperlaneCore,
+    protected readonly readProviderRegistry: MultiProviderAdapter,
     protected readonly logger = rootLogger.child({
       module: 'ArbL2ToL1MetadataBuilder',
     }),
@@ -63,7 +65,9 @@ export class ArbL2ToL1MetadataBuilder implements MetadataBuilder {
     // if the executeTransaction call is already successful, we can call with null metadata
     const ism = AbstractMessageIdAuthorizedIsm__factory.connect(
       context.ism.address,
-      this.core.multiProvider.getSigner(context.message.parsed.destination),
+      this.readProviderRegistry.getEvmProvider(
+        context.message.parsed.destination,
+      ),
     );
     const verified = await ism.isVerified(context.message.message);
     if (verified) {
@@ -160,11 +164,11 @@ export class ArbL2ToL1MetadataBuilder implements MetadataBuilder {
       };
 
       const reader = new ChildToParentMessageReader(
-        this.core.multiProvider.getProvider(context.hook.destinationChain),
+        this.readProviderRegistry.getEvmProvider(context.hook.destinationChain),
         l2ToL1TxEvent,
       );
 
-      const originChainMetadata = this.core.multiProvider.getChainMetadata(
+      const originChainMetadata = this.readProviderRegistry.getChainMetadata(
         context.message.parsed.origin,
       );
       if (typeof originChainMetadata.chainId == 'string') {

--- a/typescript/relayer/src/metadata/builder.ts
+++ b/typescript/relayer/src/metadata/builder.ts
@@ -6,6 +6,7 @@ import {
   MerkleTreeHookConfig,
   MultiProvider,
 } from '@hyperlane-xyz/sdk';
+import { MultiProviderAdapter } from '@hyperlane-xyz/sdk/providers/MultiProviderAdapter';
 import {
   WithAddress,
   assert,
@@ -36,15 +37,31 @@ export class BaseMetadataBuilder implements MetadataBuilder {
   public ccipReadMetadataBuilder: OffchainLookupMetadataBuilder;
 
   public multiProvider: MultiProvider;
+  public readProviderRegistry: MultiProviderAdapter;
   protected logger = rootLogger.child({ module: 'BaseMetadataBuilder' });
 
-  constructor(core: HyperlaneCore) {
-    this.multisigMetadataBuilder = new MultisigMetadataBuilder(core);
+  constructor(
+    core: HyperlaneCore,
+    readProviderRegistry = MultiProviderAdapter.fromMultiProvider(
+      core.multiProvider,
+    ),
+  ) {
+    this.readProviderRegistry = readProviderRegistry;
+    this.multisigMetadataBuilder = new MultisigMetadataBuilder(
+      core,
+      readProviderRegistry,
+    );
     this.aggregationMetadataBuilder = new AggregationMetadataBuilder(this);
     this.routingMetadataBuilder = new DynamicRoutingMetadataBuilder(this);
     this.nullMetadataBuilder = new NullMetadataBuilder(core.multiProvider);
-    this.arbL2ToL1MetadataBuilder = new ArbL2ToL1MetadataBuilder(core);
-    this.ccipReadMetadataBuilder = new OffchainLookupMetadataBuilder(core);
+    this.arbL2ToL1MetadataBuilder = new ArbL2ToL1MetadataBuilder(
+      core,
+      readProviderRegistry,
+    );
+    this.ccipReadMetadataBuilder = new OffchainLookupMetadataBuilder(
+      core,
+      readProviderRegistry,
+    );
     this.multiProvider = core.multiProvider;
   }
 

--- a/typescript/relayer/src/metadata/ccipread.ts
+++ b/typescript/relayer/src/metadata/ccipread.ts
@@ -7,6 +7,7 @@ import {
   OffchainLookupIsmConfig,
   offchainLookupRequestMessageHash,
 } from '@hyperlane-xyz/sdk';
+import type { MultiProviderAdapter } from '@hyperlane-xyz/sdk/providers/MultiProviderAdapter';
 import { WithAddress, ensure0x } from '@hyperlane-xyz/utils';
 
 import type {
@@ -51,17 +52,17 @@ function extractRevertData(error: unknown): string | undefined {
 
 export class OffchainLookupMetadataBuilder implements MetadataBuilder {
   readonly type = IsmType.OFFCHAIN_LOOKUP;
-  private core: HyperlaneCore;
 
-  constructor(core: HyperlaneCore) {
-    this.core = core;
-  }
+  constructor(
+    private readonly core: HyperlaneCore,
+    private readonly readProviderRegistry: MultiProviderAdapter,
+  ) {}
 
   async build(
     context: MetadataContext<WithAddress<OffchainLookupIsmConfig>>,
   ): Promise<CcipReadMetadataBuildResult> {
     const { ism, message } = context;
-    const provider = this.core.multiProvider.getProvider(
+    const provider = this.readProviderRegistry.getEvmProvider(
       message.parsed.destination,
     );
     const contract = AbstractCcipReadIsm__factory.connect(

--- a/typescript/relayer/src/metadata/multisig.ts
+++ b/typescript/relayer/src/metadata/multisig.ts
@@ -1,6 +1,9 @@
 import { joinSignature, splitSignature } from 'ethers/lib/utils.js';
 
-import { MerkleTreeHook__factory } from '@hyperlane-xyz/core';
+import {
+  MerkleTreeHook__factory,
+  ValidatorAnnounce__factory,
+} from '@hyperlane-xyz/core';
 import {
   ChainName,
   HyperlaneCore,
@@ -10,6 +13,7 @@ import {
   S3Validator,
   defaultMultisigConfigs,
 } from '@hyperlane-xyz/sdk';
+import type { MultiProviderAdapter } from '@hyperlane-xyz/sdk/providers/MultiProviderAdapter';
 import {
   Address,
   Checkpoint,
@@ -68,6 +72,7 @@ export class MultisigMetadataBuilder implements MetadataBuilder {
 
   constructor(
     protected readonly core: HyperlaneCore,
+    protected readonly readProviderRegistry: MultiProviderAdapter,
     protected readonly logger = rootLogger.child({
       module: 'MultisigMetadataBuilder',
     }),
@@ -98,8 +103,10 @@ export class MultisigMetadataBuilder implements MetadataBuilder {
     );
 
     if (toFetch.length > 0) {
-      const validatorAnnounce =
-        this.core.getContracts(originChain).validatorAnnounce;
+      const validatorAnnounce = ValidatorAnnounce__factory.connect(
+        this.core.getContracts(originChain).validatorAnnounce.address,
+        this.readProviderRegistry.getEvmProvider(originChain),
+      );
 
       const storageLocations =
         await validatorAnnounce.getAnnouncedStorageLocations(toFetch);
@@ -162,7 +169,7 @@ export class MultisigMetadataBuilder implements MetadataBuilder {
   }> {
     this.logger.debug({ match, validators }, 'Fetching validator checkpoints');
 
-    const originChain = this.core.multiProvider.getChainName(match.origin);
+    const originChain = this.readProviderRegistry.getChainName(match.origin);
     const s3Validators = await this.s3Validators(originChain, validators);
 
     const { fulfilled, rejected } = await mapAllSettled(

--- a/typescript/relayer/src/metadata/routing.ts
+++ b/typescript/relayer/src/metadata/routing.ts
@@ -35,9 +35,10 @@ export class StaticRoutingMetadataBuilder implements MetadataBuilder {
     context: MetadataContext<WithAddress<DomainRoutingIsmConfig>>,
     maxDepth = 10,
   ): Promise<RoutingMetadataBuildResult> {
-    const originChain = this.baseMetadataBuilder.multiProvider.getChainName(
-      context.message.parsed.origin,
-    );
+    const originChain =
+      this.baseMetadataBuilder.readProviderRegistry.getChainName(
+        context.message.parsed.origin,
+      );
     const originContext = {
       ...context,
       ism: context.ism.domains[originChain] as DerivedIsmConfig,
@@ -92,19 +93,20 @@ export class DynamicRoutingMetadataBuilder extends StaticRoutingMetadataBuilder 
     maxDepth = 10,
   ): Promise<RoutingMetadataBuildResult> {
     const { message, ism } = context;
-    const originChain = this.baseMetadataBuilder.multiProvider.getChainName(
-      message.parsed.origin,
-    );
+    const originChain =
+      this.baseMetadataBuilder.readProviderRegistry.getChainName(
+        message.parsed.origin,
+      );
     const destination = message.parsed.destination;
     const provider =
-      this.baseMetadataBuilder.multiProvider.getProvider(destination);
+      this.baseMetadataBuilder.readProviderRegistry.getEvmProvider(destination);
 
     // Helper to derive new ISM config and recurse
     const deriveAndRecurse = async (
       moduleAddress: string,
     ): Promise<RoutingMetadataBuildResult> => {
       const ismReader = new EvmIsmReader(
-        this.baseMetadataBuilder.multiProvider,
+        this.baseMetadataBuilder.readProviderRegistry,
         destination,
       );
       const nextConfig = await ismReader.deriveIsmConfig(moduleAddress);

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -32,9 +32,11 @@ import {
 
 import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
 import { DispatchedMessage } from '../core/types.js';
-import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainNameOrId } from '../types.js';
-import { HyperlaneReader } from '../utils/HyperlaneReader.js';
+import {
+  EvmReadProviderRegistry,
+  HyperlaneReader,
+} from '../utils/HyperlaneReader.js';
 
 import {
   AggregationHookConfig,
@@ -101,7 +103,7 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
   private _cache: Map<Address, any> = new Map();
 
   constructor(
-    protected readonly multiProvider: MultiProvider,
+    protected readonly multiProvider: EvmReadProviderRegistry,
     protected readonly chain: ChainNameOrId,
     protected readonly concurrency: number = multiProvider.tryGetRpcConcurrency(
       chain,

--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -33,9 +33,11 @@ import { getChainNameFromCCIPSelector } from '../ccip/utils.js';
 import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
 import { DispatchedMessage } from '../core/types.js';
 import { ChainTechnicalStack } from '../metadata/chainMetadataTypes.js';
-import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainMap, ChainNameOrId } from '../types.js';
-import { HyperlaneReader } from '../utils/HyperlaneReader.js';
+import {
+  EvmReadProviderRegistry,
+  HyperlaneReader,
+} from '../utils/HyperlaneReader.js';
 import { contractHasString } from '../utils/contract.js';
 
 import {
@@ -82,7 +84,7 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
   protected isZkSyncChain: boolean;
 
   constructor(
-    protected readonly multiProvider: MultiProvider,
+    protected readonly multiProvider: EvmReadProviderRegistry,
     protected readonly chain: ChainNameOrId,
     protected readonly concurrency: number = multiProvider.tryGetRpcConcurrency(
       chain,

--- a/typescript/sdk/src/providers/MultiProtocolProvider.test.ts
+++ b/typescript/sdk/src/providers/MultiProtocolProvider.test.ts
@@ -54,6 +54,8 @@ describe('MultiProtocolProvider', () => {
       multiProvider.setProvider('zksync', provider);
 
       const adapted = MultiProtocolProvider.fromMultiProvider(multiProvider);
+      expect(multiProvider.getEvmProvider('zksync')).to.equal(provider);
+      expect(adapted.getEvmProvider('zksync')).to.equal(provider);
       expect(adapted.getProvider('zksync', ProviderType.ZkSync).type).to.equal(
         ProviderType.ZkSync,
       );
@@ -73,6 +75,8 @@ describe('MultiProtocolProvider', () => {
       const adapter = MultiProviderAdapter.fromMultiProvider(multiProvider);
       const adapted = MultiProtocolProvider.fromMultiProvider(multiProvider);
 
+      expect(adapter.getEvmProvider('zksync')).to.be.instanceOf(ZKSyncProvider);
+      expect(adapted.getEvmProvider('zksync')).to.be.instanceOf(ZKSyncProvider);
       expect(adapter.getProvider('zksync').type).to.equal(ProviderType.ZkSync);
       expect(adapted.getProvider('zksync').type).to.equal(ProviderType.ZkSync);
     });

--- a/typescript/sdk/src/providers/MultiProvider.ts
+++ b/typescript/sdk/src/providers/MultiProvider.ts
@@ -162,6 +162,10 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
     return provider;
   }
 
+  getEvmProvider(chainNameOrId: ChainNameOrId): Provider {
+    return this.getProvider(chainNameOrId);
+  }
+
   /**
    * Sets an Ethers provider for a given chain name or domain id
    * @throws if chain's metadata has not been set

--- a/typescript/sdk/src/providers/MultiProviderAdapter.ts
+++ b/typescript/sdk/src/providers/MultiProviderAdapter.ts
@@ -1,3 +1,5 @@
+import { providers } from 'ethers';
+
 import {
   Address,
   HexString,
@@ -139,6 +141,21 @@ export class MultiProviderAdapter<
       chainNameOrId,
       type ?? this.getDefaultProviderType(chainNameOrId),
     );
+  }
+
+  getEvmProvider(chainNameOrId: ChainNameOrId): providers.Provider {
+    const providerType = this.getDefaultProviderType(chainNameOrId);
+    if (
+      providerType === ProviderType.EthersV5 ||
+      providerType === ProviderType.Tron ||
+      providerType === ProviderType.ZkSync
+    ) {
+      return this.getSpecificProvider<providers.Provider>(
+        chainNameOrId,
+        providerType,
+      );
+    }
+    throw new Error(`No EVM provider available for ${chainNameOrId}`);
   }
 
   toMultiProvider(options?: MultiProviderOptions): MultiProvider<MetaExt> {

--- a/typescript/sdk/src/utils/HyperlaneReader.ts
+++ b/typescript/sdk/src/utils/HyperlaneReader.ts
@@ -1,18 +1,31 @@
 import { providers } from 'ethers';
 import { LevelWithSilentOrString } from 'pino';
 
-import { MultiProvider } from '../providers/MultiProvider.js';
+import type { ChainMetadata } from '../metadata/chainMetadataTypes.js';
 import { HyperlaneSmartProvider } from '../providers/SmartProvider/SmartProvider.js';
-import { ChainNameOrId } from '../types.js';
+import type { ChainName, ChainNameOrId } from '../types.js';
 
-export class HyperlaneReader {
+export interface EvmReadProviderRegistry<MetaExt = {}> {
+  getEvmProvider(chainNameOrId: ChainNameOrId): providers.Provider;
+  getChainMetadata(chainNameOrId: ChainNameOrId): ChainMetadata<MetaExt>;
+  getChainName(chainNameOrId: ChainNameOrId): ChainName;
+  tryGetChainName(chainNameOrId: ChainNameOrId): string | null;
+  getKnownChainNames(): string[];
+  getDomainId(chainNameOrId: ChainNameOrId): number;
+  tryGetRpcConcurrency(
+    chainNameOrId: ChainNameOrId,
+    index?: number,
+  ): number | null;
+}
+
+export class HyperlaneReader<MetaExt = {}> {
   provider: providers.Provider;
 
   constructor(
-    protected readonly multiProvider: MultiProvider,
+    protected readonly multiProvider: EvmReadProviderRegistry<MetaExt>,
     protected readonly chain: ChainNameOrId,
   ) {
-    this.provider = this.multiProvider.getProvider(chain);
+    this.provider = this.multiProvider.getEvmProvider(chain);
   }
 
   /**


### PR DESCRIPTION
Superseded by #8612 from `pbio/relayer-read-paths-lightweight`.