### PR TITLE
chore: update claude models

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   CLAUDE_OPUS_MODEL: claude-opus-4-7
-  CLAUDE_SONNET_MODEL: claude-sonnet-4-5
+  CLAUDE_SONNET_MODEL: claude-sonnet-4-6
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,7 @@ on:
     types: [created]
 
 env:
-  CLAUDE_OPUS_MODEL: claude-opus-4-6
+  CLAUDE_OPUS_MODEL: claude-opus-4-7
   CLAUDE_SONNET_MODEL: claude-sonnet-4-5
 
 concurrency:


### PR DESCRIPTION
Updates `CLAUDE_OPUS_MODEL` from `claude-opus-4-6` to `claude-opus-4-7`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only configuration change that just switches model identifiers; low blast radius, with the main risk being different review output/behavior from the new model versions.
> 
> **Overview**
> Updates the GitHub Actions workflow `.github/workflows/claude-code-review.yml` to use newer Claude model versions by bumping `CLAUDE_OPUS_MODEL` to `claude-opus-4-7` and `CLAUDE_SONNET_MODEL` to `claude-sonnet-4-6` for the automated review/assistant jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5e2c97999aef19061a2117dfe1a2dc0caecc78c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->