### PR TITLE
fix(sdk): make warp check OFT-aware

### DIFF
--- a/.changeset/swift-ducks-drift.md
+++ b/.changeset/swift-ducks-drift.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Updated warp check to validate OFT routes using OFT-specific sentinel router state and normalized empty extraOptions/domainMappings values.

--- a/typescript/sdk/src/token/configUtils.test.ts
+++ b/typescript/sdk/src/token/configUtils.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { constants } from 'ethers';
-import { zeroAddress } from 'viem';
 
 import {
   DEFAULT_ROUTER_KEY,
@@ -666,9 +665,9 @@ describe('configUtils', () => {
         destinationGas: undefined,
         domainMappings: { [test2.domainId]: 30110 },
         extraOptions: undefined,
-        hook: zeroAddress,
-        interchainSecurityModule: zeroAddress,
-        mailbox: zeroAddress,
+        hook: constants.AddressZero,
+        interchainSecurityModule: constants.AddressZero,
+        mailbox: constants.AddressZero,
         name: 'USDT',
         oft: OTHER_ADDRESS,
         owner: ADDRESS,
@@ -702,7 +701,9 @@ describe('configUtils', () => {
         warpDeployConfig,
       });
 
-      expect(normalized[test1.name]?.extraOptions).to.equal('0xdeadbeef');
+      expect(normalized[test1.name]).to.deep.include({
+        extraOptions: '0xdeadbeef',
+      });
     });
 
     it('leaves non-OFT configs unchanged', () => {

--- a/typescript/sdk/src/token/configUtils.test.ts
+++ b/typescript/sdk/src/token/configUtils.test.ts
@@ -10,18 +10,31 @@ import {
 } from '../fee/types.js';
 import { HookType } from '../hook/types.js';
 import { IsmType } from '../ism/types.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+import { test1, test2 } from '../consts/testChains.js';
 import type { WarpCoreConfig } from '../warp/types.js';
 
 import { TokenType } from './config.js';
 import {
   filterWarpCoreConfigMapByChains,
   getChainsFromWarpCoreConfig,
+  normalizeWarpDeployConfigForCheck,
   resolveTokenFeeAddress,
   transformConfigToCheck,
   warpCoreConfigMatchesChains,
 } from './configUtils.js';
 import { TokenStandard } from './TokenStandard.js';
-import { HypTokenConfig } from './types.js';
+import {
+  HypTokenConfig,
+  WarpRouteDeployConfigMailboxRequired,
+} from './types.js';
+
+function buildMultiProvider(): MultiProvider {
+  return new MultiProvider({
+    [test1.name]: test1,
+    [test2.name]: test2,
+  });
+}
 
 describe('configUtils', () => {
   describe(transformConfigToCheck.name, () => {
@@ -556,13 +569,8 @@ describe('configUtils', () => {
       expect(result.token).to.equal(ROUTER_ADDRESS);
       expect(result.type).to.equal(TokenFeeType.RoutingFee);
 
-      const routingResult = result as ResolvedRoutingFeeConfigInput;
-      expect(routingResult.feeContracts.ethereum.token).to.equal(
-        ROUTER_ADDRESS,
-      );
-      expect(routingResult.feeContracts.arbitrum.token).to.equal(
-        ROUTER_ADDRESS,
-      );
+      expect(result.feeContracts.ethereum.token).to.equal(ROUTER_ADDRESS);
+      expect(result.feeContracts.arbitrum.token).to.equal(ROUTER_ADDRESS);
     });
 
     it('should handle RoutingFee with empty feeContracts', () => {
@@ -616,6 +624,78 @@ describe('configUtils', () => {
       expect(result.feeContracts.ethereum[ROUTER_KEY]?.token).to.equal(
         ROUTER_ADDRESS,
       );
+    });
+  });
+
+  describe(normalizeWarpDeployConfigForCheck.name, () => {
+    const ADDRESS = '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359';
+    const OTHER_ADDRESS = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    it('normalizes OFT configs to sentinel router state for checks', () => {
+      const warpDeployConfig: WarpRouteDeployConfigMailboxRequired = {
+        [test1.name]: {
+          decimals: 6,
+          destinationGas: { [test2.name]: '12345' },
+          domainMappings: { [test2.name]: 30110 },
+          extraOptions: '0x',
+          hook: OTHER_ADDRESS,
+          interchainSecurityModule: OTHER_ADDRESS,
+          mailbox: ADDRESS,
+          name: 'USDT',
+          oft: OTHER_ADDRESS,
+          owner: ADDRESS,
+          remoteRouters: {
+            [test2.name]: {
+              address: OTHER_ADDRESS,
+            },
+          },
+          symbol: 'USDT',
+          token: ADDRESS,
+          type: TokenType.collateralOft,
+        },
+      };
+
+      const normalized = normalizeWarpDeployConfigForCheck({
+        multiProvider: buildMultiProvider(),
+        warpDeployConfig,
+      });
+
+      expect(normalized[test1.name]).to.deep.equal({
+        decimals: 6,
+        destinationGas: undefined,
+        domainMappings: { [test2.domainId]: 30110 },
+        extraOptions: undefined,
+        hook: constants.AddressZero,
+        interchainSecurityModule: constants.AddressZero,
+        mailbox: constants.AddressZero,
+        name: 'USDT',
+        oft: OTHER_ADDRESS,
+        owner: ADDRESS,
+        remoteRouters: {},
+        symbol: 'USDT',
+        token: ADDRESS,
+        type: TokenType.collateralOft,
+      });
+    });
+
+    it('leaves non-OFT configs unchanged', () => {
+      const warpDeployConfig: WarpRouteDeployConfigMailboxRequired = {
+        [test1.name]: {
+          decimals: 18,
+          mailbox: ADDRESS,
+          name: 'TOKEN',
+          owner: ADDRESS,
+          symbol: 'TKN',
+          type: TokenType.synthetic,
+        },
+      };
+
+      const normalized = normalizeWarpDeployConfigForCheck({
+        multiProvider: buildMultiProvider(),
+        warpDeployConfig,
+      });
+
+      expect(normalized).to.deep.equal(warpDeployConfig);
     });
   });
 

--- a/typescript/sdk/src/token/configUtils.test.ts
+++ b/typescript/sdk/src/token/configUtils.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { constants } from 'ethers';
+import { zeroAddress } from 'viem';
 
 import {
   DEFAULT_ROUTER_KEY,
@@ -665,9 +666,9 @@ describe('configUtils', () => {
         destinationGas: undefined,
         domainMappings: { [test2.domainId]: 30110 },
         extraOptions: undefined,
-        hook: constants.AddressZero,
-        interchainSecurityModule: constants.AddressZero,
-        mailbox: constants.AddressZero,
+        hook: zeroAddress,
+        interchainSecurityModule: zeroAddress,
+        mailbox: zeroAddress,
         name: 'USDT',
         oft: OTHER_ADDRESS,
         owner: ADDRESS,
@@ -676,6 +677,32 @@ describe('configUtils', () => {
         token: ADDRESS,
         type: TokenType.collateralOft,
       });
+    });
+
+    it('preserves non-empty OFT extraOptions', () => {
+      const warpDeployConfig: WarpRouteDeployConfigMailboxRequired = {
+        [test1.name]: {
+          decimals: 6,
+          domainMappings: { [test2.name]: 30110 },
+          extraOptions: '0xdeadbeef',
+          hook: OTHER_ADDRESS,
+          interchainSecurityModule: OTHER_ADDRESS,
+          mailbox: ADDRESS,
+          name: 'USDT',
+          oft: OTHER_ADDRESS,
+          owner: ADDRESS,
+          symbol: 'USDT',
+          token: ADDRESS,
+          type: TokenType.collateralOft,
+        },
+      };
+
+      const normalized = normalizeWarpDeployConfigForCheck({
+        multiProvider: buildMultiProvider(),
+        warpDeployConfig,
+      });
+
+      expect(normalized[test1.name]?.extraOptions).to.equal('0xdeadbeef');
     });
 
     it('leaves non-OFT configs unchanged', () => {

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -428,7 +428,7 @@ export function normalizeWarpDeployConfigForCheck(params: {
 
     return {
       ...config,
-      mailbox: constants.AddressZero,
+      mailbox: zeroAddress,
       hook: zeroAddress,
       interchainSecurityModule: zeroAddress,
       remoteRouters: {},

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -428,9 +428,9 @@ export function normalizeWarpDeployConfigForCheck(params: {
 
     return {
       ...config,
-      mailbox: zeroAddress,
-      hook: zeroAddress,
-      interchainSecurityModule: zeroAddress,
+      mailbox: constants.AddressZero,
+      hook: constants.AddressZero,
+      interchainSecurityModule: constants.AddressZero,
       remoteRouters: {},
       destinationGas: undefined,
       domainMappings: resolveRouterMapConfig(

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -29,7 +29,11 @@ import {
 import { EvmHookReader } from '../hook/EvmHookReader.js';
 import { EvmIsmReader } from '../ism/EvmIsmReader.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
-import { DestinationGas, RemoteRouters } from '../router/types.js';
+import {
+  DestinationGas,
+  RemoteRouters,
+  resolveRouterMapConfig,
+} from '../router/types.js';
 import { ChainMap } from '../types.js';
 import { WarpCoreConfig } from '../warp/types.js';
 
@@ -50,6 +54,7 @@ import {
   isCrossCollateralTokenConfig,
   isMovableCollateralTokenConfig,
   isNativeTokenConfig,
+  isOftTokenConfig,
   isSyntheticRebaseTokenConfig,
   isSyntheticTokenConfig,
 } from './types.js';
@@ -408,6 +413,34 @@ export async function expandWarpDeployConfig(params: {
       return chainConfig;
     }),
   );
+}
+
+export function normalizeWarpDeployConfigForCheck(params: {
+  multiProvider: MultiProvider;
+  warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
+}): WarpRouteDeployConfigMailboxRequired {
+  const { multiProvider, warpDeployConfig } = params;
+
+  return objMap(warpDeployConfig, (_chain, config) => {
+    if (!isOftTokenConfig(config)) {
+      return config;
+    }
+
+    return {
+      ...config,
+      mailbox: constants.AddressZero,
+      hook: zeroAddress,
+      interchainSecurityModule: zeroAddress,
+      remoteRouters: {},
+      destinationGas: undefined,
+      domainMappings: resolveRouterMapConfig(
+        multiProvider,
+        config.domainMappings,
+      ),
+      extraOptions:
+        config.extraOptions === '0x' ? undefined : config.extraOptions,
+    };
+  });
 }
 
 /**

--- a/typescript/sdk/src/token/warpCheck.ts
+++ b/typescript/sdk/src/token/warpCheck.ts
@@ -614,8 +614,8 @@ function stringifyViolationValue(value: unknown): string {
   if (
     typeof value === 'number' ||
     typeof value === 'boolean' ||
-    typeof value === 'bigint' ||
-    typeof value === 'symbol'
+    typeof value === 'symbol' ||
+    typeof value === 'function'
   ) {
     return value.toString();
   }

--- a/typescript/sdk/src/token/warpCheck.ts
+++ b/typescript/sdk/src/token/warpCheck.ts
@@ -36,6 +36,7 @@ import {
   expandVirtualWarpDeployConfig,
   expandWarpDeployConfig,
   getRouterAddressesFromWarpCoreConfig,
+  normalizeWarpDeployConfigForCheck,
   transformConfigToCheck,
 } from './configUtils.js';
 import {
@@ -155,8 +156,12 @@ export async function checkWarpRouteDeployConfig({
     expandedOnChainWarpConfig,
     validateScale: false,
   });
+  const normalizedWarpDeployConfig = normalizeWarpDeployConfigForCheck({
+    multiProvider,
+    warpDeployConfig: expandedWarpDeployConfig,
+  });
   const evmExpandedWarpDeployConfig = objFilter(
-    expandedWarpDeployConfig,
+    normalizedWarpDeployConfig,
     (chain, _config): _config is (typeof expandedWarpDeployConfig)[string] =>
       isEVMLike(multiProvider.getProtocol(chain)),
   );
@@ -176,7 +181,7 @@ export async function checkWarpRouteDeployConfig({
   const diffViolations = flattenWarpRouteCheckDiff(diff);
   const scaleViolations = await getScaleViolations({
     multiProvider,
-    warpRouteConfig: expandedWarpDeployConfig,
+    warpRouteConfig: normalizedWarpDeployConfig,
   });
 
   return {
@@ -598,8 +603,21 @@ function stringifyViolationValue(value: unknown): string {
     return '';
   }
 
-  if (value === null || typeof value !== 'object') {
-    return String(value);
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value === null) {
+    return 'null';
+  }
+
+  if (
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint' ||
+    typeof value === 'symbol'
+  ) {
+    return value.toString();
   }
 
   if (Array.isArray(value)) {


### PR DESCRIPTION
## Summary
- make `warp check` treat `collateralOft` routes as non-router routes
- normalize OFT check state to sentinel router values plus normalized `domainMappings` / `extraOptions`
- add focused SDK coverage for OFT check normalization

## Note
- the `stringifyViolationValue` change in `warpCheck.ts` was a drive-by lint cleanup in a touched file
- it is not part of the OFT checker logic change

## Validation
- `pnpm -C typescript/sdk check`
- `pnpm -C typescript/sdk exec oxlint -c ../../oxlint.json src/token/configUtils.ts src/token/warpCheck.ts src/token/configUtils.test.ts`
- `pnpm -C typescript/sdk exec mocha --config .mocharc.json './src/token/configUtils.test.ts' './src/token/warpCheck.test.ts' --exit`
- `pnpm -C typescript/sdk build`
- `pnpm -C typescript/cli hyperlane --registry http://127.0.0.1:3334 -y warp check --warp-route-id USDT/oft`

The live `USDT/oft` check no longer reports OFT/router false positives. It now only reports real contract verification diffs (`implementation: expected verified, actual unverified`) on ethereum/arbitrum/plasma.
