### PR TITLE
fix(sdk): normalize scale in warp check for config vs on-chain comparison

### DIFF
--- a/.changeset/quiet-rivers-flow.md
+++ b/.changeset/quiet-rivers-flow.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Normalized scale values in warp route check so plain numbers from config and {numerator, denominator} objects from on-chain reader compare equal during diff.

--- a/typescript/sdk/src/token/configUtils.test.ts
+++ b/typescript/sdk/src/token/configUtils.test.ts
@@ -72,6 +72,7 @@ describe('configUtils', () => {
               },
             ],
           },
+          scale: { numerator: 1n, denominator: 1n },
         },
       },
       {
@@ -96,6 +97,7 @@ describe('configUtils', () => {
               address: ADDRESS,
             },
           },
+          scale: { numerator: 1n, denominator: 1n },
         },
       },
       {
@@ -118,6 +120,7 @@ describe('configUtils', () => {
             address: ADDRESS,
             owner: ADDRESS,
           },
+          scale: { numerator: 1n, denominator: 1n },
         },
       },
       {
@@ -169,6 +172,7 @@ describe('configUtils', () => {
             owner: 'milk169dcaz397j75tjfpl6ykm23dfrv39dqd58lsag',
             type: 'native',
           },
+          scale: { numerator: 1n, denominator: 1n },
         },
         input: {
           bsc: {
@@ -246,6 +250,7 @@ describe('configUtils', () => {
       expect(transformedObj).to.eql({
         type: TokenType.collateral,
         token: ADDRESS,
+        scale: { numerator: 1n, denominator: 1n },
         tokenFee: {
           type: TokenFeeType.LinearFee,
           owner: ADDRESS,
@@ -273,6 +278,7 @@ describe('configUtils', () => {
       expect(transformedObj).to.eql({
         type: TokenType.collateral,
         token: ADDRESS,
+        scale: { numerator: 1n, denominator: 1n },
         tokenFee: {
           type: TokenFeeType.OffchainQuotedLinearFee,
           owner: ADDRESS,
@@ -309,6 +315,7 @@ describe('configUtils', () => {
       expect(transformedObj).to.eql({
         type: TokenType.collateral,
         token: ADDRESS,
+        scale: { numerator: 1n, denominator: 1n },
         tokenFee: {
           type: TokenFeeType.RoutingFee,
           owner: ADDRESS,
@@ -360,6 +367,7 @@ describe('configUtils', () => {
       expect(transformedObj).to.eql({
         type: TokenType.collateral,
         token: ADDRESS,
+        scale: { numerator: 1n, denominator: 1n },
         tokenFee: {
           type: TokenFeeType.CrossCollateralRoutingFee,
           owner: ADDRESS,
@@ -406,6 +414,7 @@ describe('configUtils', () => {
       expect(transformedObj).to.eql({
         type: TokenType.collateral,
         token: ADDRESS,
+        scale: { numerator: 1n, denominator: 1n },
         tokenFee: {
           type: TokenFeeType.CrossCollateralRoutingFee,
           owner: ADDRESS,
@@ -445,6 +454,7 @@ describe('configUtils', () => {
       expect(transformedObj).to.eql({
         type: TokenType.collateral,
         token: ADDRESS,
+        scale: { numerator: 1n, denominator: 1n },
         tokenFee: {
           type: TokenFeeType.RoutingFee,
           owner: ADDRESS,

--- a/typescript/sdk/src/token/configUtils.test.ts
+++ b/typescript/sdk/src/token/configUtils.test.ts
@@ -233,6 +233,44 @@ describe('configUtils', () => {
       });
     }
 
+    it('normalizes plain number scale to {numerator, denominator} bigint', () => {
+      const transformedObj = transformConfigToCheck({
+        type: TokenType.collateral,
+        token: ADDRESS,
+        scale: 1000000000000,
+      } as any);
+
+      expect(transformedObj.scale).to.eql({
+        numerator: 1000000000000n,
+        denominator: 1n,
+      });
+    });
+
+    it('normalizes {number, number} scale to {bigint, bigint}', () => {
+      const transformedObj = transformConfigToCheck({
+        type: TokenType.collateral,
+        token: ADDRESS,
+        scale: { numerator: 1, denominator: 1000000000000 },
+      } as any);
+
+      expect(transformedObj.scale).to.eql({
+        numerator: 1n,
+        denominator: 1000000000000n,
+      });
+    });
+
+    it('normalizes undefined scale to identity {1n, 1n}', () => {
+      const transformedObj = transformConfigToCheck({
+        type: TokenType.collateral,
+        token: ADDRESS,
+      } as any);
+
+      expect(transformedObj.scale).to.eql({
+        numerator: 1n,
+        denominator: 1n,
+      });
+    });
+
     it('normalizes LinearFee maxFee/halfAmount so equivalent bps configs compare equal', () => {
       const transformedObj = transformConfigToCheck({
         type: TokenType.collateral,

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -31,6 +31,7 @@ import { EvmIsmReader } from '../ism/EvmIsmReader.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { DestinationGas, RemoteRouters } from '../router/types.js';
 import { ChainMap } from '../types.js';
+import { normalizeScale } from '../utils/decimals.js';
 import { WarpCoreConfig } from '../warp/types.js';
 
 import { EvmWarpRouteReader } from './EvmWarpRouteReader.js';
@@ -685,6 +686,16 @@ export function transformConfigToCheck(
     clonedTokenConfig.tokenFee = normalizeTokenFeeForCheck(
       clonedTokenConfig.tokenFee,
     );
+  }
+
+  // Normalize scale so plain numbers and {numerator, denominator} objects compare equal.
+  // Uses !== null so undefined passes through to normalizeScale as identity {1n,1n}.
+  if (clonedTokenConfig.scale !== null) {
+    const normalized = normalizeScale(clonedTokenConfig.scale);
+    clonedTokenConfig.scale = {
+      numerator: normalized.numerator,
+      denominator: normalized.denominator,
+    };
   }
 
   return sortArraysInObject(

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -688,15 +688,9 @@ export function transformConfigToCheck(
     );
   }
 
-  // Normalize scale so plain numbers and {numerator, denominator} objects compare equal.
-  // Uses !== null so undefined passes through to normalizeScale as identity {1n,1n}.
-  if (clonedTokenConfig.scale !== null) {
-    const normalized = normalizeScale(clonedTokenConfig.scale);
-    clonedTokenConfig.scale = {
-      numerator: normalized.numerator,
-      denominator: normalized.denominator,
-    };
-  }
+  // normalizeScale(undefined) -> {1n,1n}, matching EvmWarpRouteReader.fetchScale's
+  // identity-collapse so both sides of the diff agree symmetrically.
+  clonedTokenConfig.scale = normalizeScale(clonedTokenConfig.scale);
 
   return sortArraysInObject(
     transformObj(clonedTokenConfig, transformWarpDeployConfigToCheck),


### PR DESCRIPTION
## Summary
Fixes false scale diff violations in `hyperlane warp check` where config values (plain numbers like `scale: 1000000000000`) were compared against on-chain values (objects like `{numerator: 1000000000000, denominator: 1}`) and reported as mismatches even though they're semantically equal.

## Root cause
The on-chain reader (`EvmWarpRouteReader.fetchScale`) always returns scale as `{numerator: bigint, denominator: bigint}` — even for legacy contracts with a single `scale()` function, it wraps it as `{numerator: scale, denominator: 1n}`. But deploy/config files use plain numbers. `diffObjMerge` does a structural comparison, so `1000000000000 !== {numerator: 1000000000000n, denominator: 1n}`.

## Fix
Normalize scale in `transformConfigToCheck` (which already normalizes other fields like `tokenFee` and `allowedRebalancers`) using `normalizeScale()` from the SDK. Both sides get converted to `{numerator: bigint, denominator: bigint}` before comparison.

Uses `!== null` (not `!= null`) so `undefined` values pass through to `normalizeScale` which returns identity `{1n, 1n}` — matching the on-chain reader which also returns `undefined` for identity scale.

## Related
- hyperlane-xyz/hyperlane-registry#1480 — adds missing scale fields to registry config files
- #8594 — SDK scale helpers
- #8602 — `ZBigNumberish.refine()` + `validateZodResult` fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

## Test

Tested locally running warp check against the modified routes in the registry 

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
