### PR TITLE
feat: add same-chain swap rebalancing bridge

### DIFF
--- a/.changeset/swap-rebalancing-bridge.md
+++ b/.changeset/swap-rebalancing-bridge.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": minor
+---
+
+The core solidity package was extended with `SwapRebalancingBridge` for same-chain exact-input router rebalances, along with unit and fork test coverage.

--- a/solidity/contracts/test/TestSwapTarget.sol
+++ b/solidity/contracts/test/TestSwapTarget.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.22;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract TestSwapTarget {
+    using SafeERC20 for IERC20;
+
+    address public immutable inputToken;
+    address public immutable outputToken;
+
+    bool public shouldRevert;
+    uint256 public outputAmount;
+
+    constructor(address _inputToken, address _outputToken) {
+        inputToken = _inputToken;
+        outputToken = _outputToken;
+    }
+
+    function setOutputAmount(uint256 _outputAmount) external {
+        outputAmount = _outputAmount;
+    }
+
+    function setShouldRevert(bool _shouldRevert) external {
+        shouldRevert = _shouldRevert;
+    }
+
+    function swapExactInput(uint256 amountIn) external returns (uint256) {
+        if (shouldRevert) revert("TestSwapTarget: revert");
+        IERC20(inputToken).safeTransferFrom(
+            msg.sender,
+            address(this),
+            amountIn
+        );
+        IERC20(outputToken).safeTransfer(msg.sender, outputAmount);
+        return outputAmount;
+    }
+}

--- a/solidity/contracts/token/SwapRebalancingBridge.sol
+++ b/solidity/contracts/token/SwapRebalancingBridge.sol
@@ -1,0 +1,442 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.22;
+
+import {ITokenBridge, ITokenFee, Quote} from "../interfaces/ITokenBridge.sol";
+import {ISwapRebalancingBridge, SwapCall, PendingRebalance} from "./interfaces/ISwapRebalancingBridge.sol";
+import {PackageVersioned} from "../PackageVersioned.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+interface IMovableCollateralRouterLike {
+    function rebalance(
+        uint32 domain,
+        uint256 collateralAmount,
+        ITokenBridge bridge
+    ) external payable;
+
+    function token() external view returns (address);
+
+    function localDomain() external view returns (uint32);
+
+    function routers(uint32 domain) external view returns (bytes32);
+
+    function scaleNumerator() external view returns (uint256);
+
+    function scaleDenominator() external view returns (uint256);
+}
+
+interface ICrossCollateralRouterLike is IMovableCollateralRouterLike {
+    function crossCollateralRouters(
+        uint32 domain,
+        bytes32 router
+    ) external view returns (bool);
+}
+
+contract SwapRebalancingBridge is
+    ITokenBridge,
+    ISwapRebalancingBridge,
+    Ownable,
+    PackageVersioned
+{
+    using SafeERC20 for IERC20;
+    using Address for address;
+
+    mapping(address => bool) public authorizedRebalancers;
+    mapping(address => bool) public whitelistedTargets;
+    mapping(address => bool) public whitelistedAllowanceTargets;
+
+    PendingRebalance internal pending;
+    SwapCall[] internal pendingSwapCalls;
+
+    event RebalancerSet(address indexed rebalancer, bool allowed);
+    event TargetSet(address indexed target, bool allowed);
+    event AllowanceTargetSet(address indexed target, bool allowed);
+    event RebalanceStarted(
+        address indexed initiator,
+        address indexed sourceRouter,
+        address indexed destinationRouter,
+        uint256 amountIn,
+        uint256 requiredOut,
+        uint256 minAmountOut
+    );
+    event RebalanceExecuted(
+        address indexed initiator,
+        address indexed sourceRouter,
+        address indexed destinationRouter,
+        address inputToken,
+        address outputToken,
+        uint256 amountIn,
+        uint256 swapAmountOut,
+        uint256 requiredOut,
+        uint256 shortfallPulled,
+        uint256 surplusRefunded
+    );
+
+    error UnauthorizedRebalancer();
+    error RebalanceAlreadyPending();
+    error NoPendingRebalance();
+    error InvalidSourceRouter();
+    error InvalidDestinationRouter();
+    error DestinationNotEnrolled();
+    error InvalidDomain();
+    error DeadlineExpired();
+    error NativeValueNotAccepted();
+    error InvalidCallback();
+    error AmountOutTooLow();
+    error InputNotFullySpent();
+    error UnapprovedTarget();
+    error UnapprovedAllowanceTarget();
+    error InsufficientTopUp();
+
+    constructor() Ownable() {}
+
+    function setAuthorizedRebalancer(
+        address rebalancer,
+        bool allowed
+    ) external onlyOwner {
+        authorizedRebalancers[rebalancer] = allowed;
+        emit RebalancerSet(rebalancer, allowed);
+    }
+
+    function setTarget(address target, bool allowed) external onlyOwner {
+        whitelistedTargets[target] = allowed;
+        emit TargetSet(target, allowed);
+    }
+
+    function setAllowanceTarget(
+        address target,
+        bool allowed
+    ) external onlyOwner {
+        whitelistedAllowanceTargets[target] = allowed;
+        emit AllowanceTargetSet(target, allowed);
+    }
+
+    function pendingRebalance()
+        external
+        view
+        returns (PendingRebalance memory)
+    {
+        return pending;
+    }
+
+    function isEnrolledDestination(
+        address sourceRouter,
+        address destinationRouter
+    ) external view returns (bool) {
+        return
+            _isEnrolledDestination(
+                sourceRouter,
+                destinationRouter,
+                IMovableCollateralRouterLike(sourceRouter).localDomain()
+            );
+    }
+
+    function requiredOut(
+        address sourceRouter,
+        address destinationRouter,
+        uint256 amountIn
+    ) external view returns (uint256) {
+        return
+            _requiredOut(
+                IMovableCollateralRouterLike(sourceRouter),
+                IMovableCollateralRouterLike(destinationRouter),
+                amountIn
+            );
+    }
+
+    function executeRebalance(
+        address sourceRouter,
+        address destinationRouter,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline,
+        SwapCall[] calldata swapCalls
+    ) external payable {
+        if (!authorizedRebalancers[msg.sender]) revert UnauthorizedRebalancer();
+        if (msg.value != 0) revert NativeValueNotAccepted();
+        if (pending.sourceRouter != address(0))
+            revert RebalanceAlreadyPending();
+        if (deadline < block.timestamp) revert DeadlineExpired();
+        if (sourceRouter == address(0) || !sourceRouter.isContract()) {
+            revert InvalidSourceRouter();
+        }
+        if (
+            destinationRouter == address(0) || !destinationRouter.isContract()
+        ) {
+            revert InvalidDestinationRouter();
+        }
+
+        IMovableCollateralRouterLike source = IMovableCollateralRouterLike(
+            sourceRouter
+        );
+        IMovableCollateralRouterLike destination = IMovableCollateralRouterLike(
+            destinationRouter
+        );
+
+        uint32 localDomain = source.localDomain();
+        if (localDomain != destination.localDomain()) revert InvalidDomain();
+        if (
+            !_isEnrolledDestination(
+                sourceRouter,
+                destinationRouter,
+                localDomain
+            )
+        ) {
+            revert DestinationNotEnrolled();
+        }
+
+        address inputToken = source.token();
+        address outputToken = destination.token();
+        if (inputToken == address(0) || outputToken == address(0)) {
+            revert InvalidSourceRouter();
+        }
+
+        pending = PendingRebalance({
+            initiator: msg.sender,
+            sourceRouter: sourceRouter,
+            destinationRouter: destinationRouter,
+            inputToken: inputToken,
+            outputToken: outputToken,
+            localDomain: localDomain,
+            amountIn: amountIn,
+            minAmountOut: minAmountOut,
+            requiredOut: _requiredOut(source, destination, amountIn),
+            deadline: deadline
+        });
+        _storeSwapCalls(swapCalls);
+
+        emit RebalanceStarted(
+            msg.sender,
+            sourceRouter,
+            destinationRouter,
+            amountIn,
+            pending.requiredOut,
+            minAmountOut
+        );
+
+        source.rebalance(localDomain, amountIn, this);
+    }
+
+    function quoteTransferRemote(
+        uint32 destination,
+        bytes32,
+        uint256 amount
+    )
+        external
+        view
+        override(ITokenFee, ISwapRebalancingBridge)
+        returns (Quote[] memory quotes)
+    {
+        if (pending.sourceRouter == address(0)) revert NoPendingRebalance();
+        if (destination != pending.localDomain || amount != pending.amountIn) {
+            revert InvalidCallback();
+        }
+
+        quotes = new Quote[](3);
+        quotes[0] = Quote({token: address(0), amount: 0});
+        quotes[1] = Quote({
+            token: pending.inputToken,
+            amount: pending.amountIn
+        });
+        quotes[2] = Quote({token: pending.inputToken, amount: 0});
+    }
+
+    function transferRemote(
+        uint32 destination,
+        bytes32,
+        uint256 amount
+    ) external payable override returns (bytes32) {
+        if (pending.sourceRouter == address(0)) revert NoPendingRebalance();
+        if (msg.sender != pending.sourceRouter) revert InvalidCallback();
+        if (msg.value != 0) revert NativeValueNotAccepted();
+        if (destination != pending.localDomain || amount != pending.amountIn) {
+            revert InvalidCallback();
+        }
+
+        IERC20 inputToken = IERC20(pending.inputToken);
+        IERC20 outputToken = IERC20(pending.outputToken);
+
+        uint256 outputBefore = outputToken.balanceOf(address(this));
+        inputToken.safeTransferFrom(
+            msg.sender,
+            address(this),
+            pending.amountIn
+        );
+        _executeSwapCalls();
+        if (
+            pending.inputToken != pending.outputToken &&
+            inputToken.balanceOf(address(this)) != 0
+        ) revert InputNotFullySpent();
+        uint256 outputAfter = outputToken.balanceOf(address(this));
+        uint256 actualOut = outputAfter - outputBefore;
+
+        if (actualOut < pending.minAmountOut) revert AmountOutTooLow();
+
+        PendingRebalance memory current = pending;
+        _clearPending();
+
+        uint256 shortfallPulled = 0;
+        if (actualOut < current.requiredOut) {
+            shortfallPulled = current.requiredOut - actualOut;
+            outputToken.safeTransferFrom(
+                current.initiator,
+                address(this),
+                shortfallPulled
+            );
+            if (
+                outputToken.balanceOf(address(this)) <
+                outputBefore + current.requiredOut
+            ) revert InsufficientTopUp();
+        }
+
+        outputToken.safeTransfer(
+            current.destinationRouter,
+            current.requiredOut
+        );
+
+        uint256 surplusRefunded = 0;
+        uint256 remainingOutput = outputToken.balanceOf(address(this)) -
+            outputBefore;
+        if (remainingOutput > 0) {
+            surplusRefunded = remainingOutput;
+            outputToken.safeTransfer(current.initiator, surplusRefunded);
+        }
+
+        emit RebalanceExecuted(
+            current.initiator,
+            current.sourceRouter,
+            current.destinationRouter,
+            current.inputToken,
+            current.outputToken,
+            current.amountIn,
+            actualOut,
+            current.requiredOut,
+            shortfallPulled,
+            surplusRefunded
+        );
+        return bytes32(0);
+    }
+
+    function _isEnrolledDestination(
+        address sourceRouter,
+        address destinationRouter,
+        uint32 localDomain
+    ) internal view returns (bool) {
+        bytes32 encoded = bytes32(uint256(uint160(destinationRouter)));
+        if (
+            IMovableCollateralRouterLike(sourceRouter).routers(localDomain) ==
+            encoded
+        ) {
+            return true;
+        }
+
+        try
+            ICrossCollateralRouterLike(sourceRouter).crossCollateralRouters(
+                localDomain,
+                encoded
+            )
+        returns (bool ok) {
+            return ok;
+        } catch {
+            return false;
+        }
+    }
+
+    function _requiredOut(
+        IMovableCollateralRouterLike sourceRouter,
+        IMovableCollateralRouterLike destinationRouter,
+        uint256 amountIn
+    ) internal view returns (uint256) {
+        uint256 canonical = Math.mulDiv(
+            amountIn,
+            sourceRouter.scaleNumerator(),
+            sourceRouter.scaleDenominator(),
+            Math.Rounding.Down
+        );
+
+        return
+            Math.mulDiv(
+                canonical,
+                destinationRouter.scaleDenominator(),
+                destinationRouter.scaleNumerator(),
+                Math.Rounding.Down
+            );
+    }
+
+    function _storeSwapCalls(SwapCall[] calldata swapCalls) internal {
+        delete pendingSwapCalls;
+        uint256 length = swapCalls.length;
+        for (uint256 i = 0; i < length; ++i) {
+            pendingSwapCalls.push(
+                SwapCall({
+                    target: swapCalls[i].target,
+                    allowanceTarget: swapCalls[i].allowanceTarget,
+                    data: swapCalls[i].data
+                })
+            );
+        }
+    }
+
+    function _executeSwapCalls() internal {
+        IERC20 inputToken = IERC20(pending.inputToken);
+        IERC20 outputToken = IERC20(pending.outputToken);
+        uint256 length = pendingSwapCalls.length;
+
+        for (uint256 i = 0; i < length; ++i) {
+            SwapCall storage swapCall = pendingSwapCalls[i];
+            if (!whitelistedTargets[swapCall.target]) revert UnapprovedTarget();
+            if (
+                swapCall.allowanceTarget != address(0) &&
+                !whitelistedAllowanceTargets[swapCall.allowanceTarget]
+            ) revert UnapprovedAllowanceTarget();
+
+            if (swapCall.allowanceTarget != address(0)) {
+                uint256 inputBalance = inputToken.balanceOf(address(this));
+                if (inputBalance > 0) {
+                    inputToken.forceApprove(
+                        swapCall.allowanceTarget,
+                        inputBalance
+                    );
+                }
+
+                if (pending.outputToken != pending.inputToken) {
+                    uint256 outputBalance = outputToken.balanceOf(
+                        address(this)
+                    );
+                    if (outputBalance > 0) {
+                        outputToken.forceApprove(
+                            swapCall.allowanceTarget,
+                            outputBalance
+                        );
+                    }
+                }
+            }
+
+            (bool success, bytes memory returnData) = swapCall.target.call(
+                swapCall.data
+            );
+
+            if (swapCall.allowanceTarget != address(0)) {
+                inputToken.forceApprove(swapCall.allowanceTarget, 0);
+                if (pending.outputToken != pending.inputToken) {
+                    outputToken.forceApprove(swapCall.allowanceTarget, 0);
+                }
+            }
+
+            if (!success) {
+                assembly {
+                    revert(add(returnData, 32), mload(returnData))
+                }
+            }
+        }
+    }
+
+    function _clearPending() internal {
+        delete pending;
+        delete pendingSwapCalls;
+    }
+}

--- a/solidity/contracts/token/SwapRebalancingBridge.sol
+++ b/solidity/contracts/token/SwapRebalancingBridge.sol
@@ -86,6 +86,7 @@ contract SwapRebalancingBridge is
     error DeadlineExpired();
     error NativeValueNotAccepted();
     error InvalidCallback();
+    error InvalidScale();
     error AmountOutTooLow();
     error InputNotFullySpent();
     error UnapprovedTarget();
@@ -155,9 +156,8 @@ contract SwapRebalancingBridge is
         uint256 minAmountOut,
         uint256 deadline,
         SwapCall[] calldata swapCalls
-    ) external payable {
+    ) external {
         if (!authorizedRebalancers[msg.sender]) revert UnauthorizedRebalancer();
-        if (msg.value != 0) revert NativeValueNotAccepted();
         if (pending.sourceRouter != address(0))
             revert RebalanceAlreadyPending();
         if (deadline < block.timestamp) revert DeadlineExpired();
@@ -351,18 +351,31 @@ contract SwapRebalancingBridge is
         IMovableCollateralRouterLike destinationRouter,
         uint256 amountIn
     ) internal view returns (uint256) {
+        uint256 sourceScaleNumerator = sourceRouter.scaleNumerator();
+        uint256 sourceScaleDenominator = sourceRouter.scaleDenominator();
+        uint256 destinationScaleNumerator = destinationRouter.scaleNumerator();
+        uint256 destinationScaleDenominator = destinationRouter
+            .scaleDenominator();
+
+        if (
+            sourceScaleNumerator == 0 ||
+            sourceScaleDenominator == 0 ||
+            destinationScaleNumerator == 0 ||
+            destinationScaleDenominator == 0
+        ) revert InvalidScale();
+
         uint256 canonical = Math.mulDiv(
             amountIn,
-            sourceRouter.scaleNumerator(),
-            sourceRouter.scaleDenominator(),
+            sourceScaleNumerator,
+            sourceScaleDenominator,
             Math.Rounding.Down
         );
 
         return
             Math.mulDiv(
                 canonical,
-                destinationRouter.scaleDenominator(),
-                destinationRouter.scaleNumerator(),
+                destinationScaleDenominator,
+                destinationScaleNumerator,
                 Math.Rounding.Down
             );
     }
@@ -383,7 +396,6 @@ contract SwapRebalancingBridge is
 
     function _executeSwapCalls() internal {
         IERC20 inputToken = IERC20(pending.inputToken);
-        IERC20 outputToken = IERC20(pending.outputToken);
         uint256 length = pendingSwapCalls.length;
 
         for (uint256 i = 0; i < length; ++i) {
@@ -395,24 +407,11 @@ contract SwapRebalancingBridge is
             ) revert UnapprovedAllowanceTarget();
 
             if (swapCall.allowanceTarget != address(0)) {
-                uint256 inputBalance = inputToken.balanceOf(address(this));
-                if (inputBalance > 0) {
+                if (inputToken.balanceOf(address(this)) > 0) {
                     inputToken.forceApprove(
                         swapCall.allowanceTarget,
-                        inputBalance
+                        pending.amountIn
                     );
-                }
-
-                if (pending.outputToken != pending.inputToken) {
-                    uint256 outputBalance = outputToken.balanceOf(
-                        address(this)
-                    );
-                    if (outputBalance > 0) {
-                        outputToken.forceApprove(
-                            swapCall.allowanceTarget,
-                            outputBalance
-                        );
-                    }
                 }
             }
 
@@ -422,9 +421,6 @@ contract SwapRebalancingBridge is
 
             if (swapCall.allowanceTarget != address(0)) {
                 inputToken.forceApprove(swapCall.allowanceTarget, 0);
-                if (pending.outputToken != pending.inputToken) {
-                    outputToken.forceApprove(swapCall.allowanceTarget, 0);
-                }
             }
 
             if (!success) {

--- a/solidity/contracts/token/SwapRebalancingBridge.sol
+++ b/solidity/contracts/token/SwapRebalancingBridge.sol
@@ -36,6 +36,50 @@ interface ICrossCollateralRouterLike is IMovableCollateralRouterLike {
     ) external view returns (bool);
 }
 
+/// @title SwapRebalancingBridge
+/// @notice Same-chain `ITokenBridge` used by `MovableCollateralRouter` to pull
+/// source collateral, execute exact-input swap calls, and fund an enrolled
+/// destination router with the exact nominal amount implied by router scale
+/// math.
+/// @dev
+/// Intended usage:
+/// - owner whitelists authorized rebalancer EOAs, external swap `target`s, and
+/// ERC20 `allowanceTarget`s
+/// - rebalancer calls `executeRebalance(...)` with source router, intended
+/// destination router, `amountIn`, rebalancer stop-loss `minAmountOut`, and
+/// exact-input swap calldata
+/// - bridge verifies the destination router is enrolled on the source router
+/// via `routers(...)` or `crossCollateralRouters(...)`
+/// - bridge stores pending state, calls
+/// `sourceRouter.rebalance(localDomain, amountIn, this)`, receives the router
+/// callback, executes swap calls, tops up any output shortfall from the
+/// rebalancer in `outputToken`, transfers exactly `requiredOut` to the
+/// destination router, and refunds any surplus to the rebalancer
+///
+/// Accepted tradeoffs:
+/// - same-chain only
+/// - one in-flight rebalance per bridge
+/// - intended for exact-input router-style swaps where the external venue owns
+/// the hop path; not a fully generic multi-step token executor
+/// - computes nominal output using standard `TokenRouter`
+/// `scaleNumerator/scaleDenominator`; routers with custom inbound/outbound math
+/// need a different adapter design
+/// - ignores callback `recipient`; the rebalancer-supplied enrolled
+/// `destinationRouter` is authoritative
+///
+/// Ergonomics:
+/// - single-call entrypoint for the rebalancer
+/// - owner-managed allowlists bind arbitrary calldata to known swap venues
+/// - helper views expose destination enrollment and nominal amount calculations
+/// for offchain planning
+///
+/// Trust assumptions:
+/// - owner maintains a safe allowlist of swap venues and spenders
+/// - authorized rebalancers choose economically sane calldata and can fund
+/// output-token shortfalls
+/// - source router is configured to allow `rebalance(localDomain, amountIn,
+/// bridge)` to succeed
+/// - source and destination routers expose honest token and scale parameters
 contract SwapRebalancingBridge is
     ITokenBridge,
     ISwapRebalancingBridge,
@@ -95,6 +139,7 @@ contract SwapRebalancingBridge is
 
     constructor() Ownable() {}
 
+    /// @notice Adds or removes an authorized rebalancer.
     function setAuthorizedRebalancer(
         address rebalancer,
         bool allowed
@@ -103,11 +148,13 @@ contract SwapRebalancingBridge is
         emit RebalancerSet(rebalancer, allowed);
     }
 
+    /// @notice Adds or removes a permitted external call target.
     function setTarget(address target, bool allowed) external onlyOwner {
         whitelistedTargets[target] = allowed;
         emit TargetSet(target, allowed);
     }
 
+    /// @notice Adds or removes a permitted ERC20 allowance target.
     function setAllowanceTarget(
         address target,
         bool allowed
@@ -116,6 +163,7 @@ contract SwapRebalancingBridge is
         emit AllowanceTargetSet(target, allowed);
     }
 
+    /// @notice Returns the current in-flight rebalance, if any.
     function pendingRebalance()
         external
         view
@@ -124,6 +172,8 @@ contract SwapRebalancingBridge is
         return pending;
     }
 
+    /// @notice Returns whether `destinationRouter` is enrolled on
+    /// `sourceRouter` for the source router's local domain.
     function isEnrolledDestination(
         address sourceRouter,
         address destinationRouter
@@ -136,6 +186,8 @@ contract SwapRebalancingBridge is
             );
     }
 
+    /// @notice Returns the nominal destination amount implied by standard
+    /// router scale math.
     function requiredOut(
         address sourceRouter,
         address destinationRouter,
@@ -149,6 +201,12 @@ contract SwapRebalancingBridge is
             );
     }
 
+    /// @notice Starts a same-chain rebalance into an enrolled destination
+    /// router.
+    /// @dev
+    /// `minAmountOut` is the rebalancer's stop-loss threshold. LP protection is
+    /// enforced separately by requiring the destination router to receive
+    /// exactly `requiredOut`.
     function executeRebalance(
         address sourceRouter,
         address destinationRouter,
@@ -221,6 +279,10 @@ contract SwapRebalancingBridge is
         source.rebalance(localDomain, amountIn, this);
     }
 
+    /// @notice Callback quote used by `MovableCollateralRouter.rebalance`.
+    /// @dev Returns only the source-token pull quote. The callback `recipient`
+    /// is ignored because the bridge uses pending state to choose the actual
+    /// destination router.
     function quoteTransferRemote(
         uint32 destination,
         bytes32,
@@ -245,6 +307,12 @@ contract SwapRebalancingBridge is
         quotes[2] = Quote({token: pending.inputToken, amount: 0});
     }
 
+    /// @notice Pulls source collateral from the source router, executes swap
+    /// calls, and settles the destination router exactly.
+    /// @dev
+    /// If the swap under-delivers, the bridge pulls the shortfall from the
+    /// rebalancer in `outputToken`. If the swap over-delivers, the bridge
+    /// refunds the surplus to the rebalancer.
     function transferRemote(
         uint32 destination,
         bytes32,
@@ -271,6 +339,8 @@ contract SwapRebalancingBridge is
             pending.inputToken != pending.outputToken &&
             inputToken.balanceOf(address(this)) != 0
         ) revert InputNotFullySpent();
+        // When input and output token are the same, any unspent input is part
+        // of `actualOut` and is later refunded to the rebalancer as surplus.
         uint256 outputAfter = outputToken.balanceOf(address(this));
         uint256 actualOut = outputAfter - outputBefore;
 
@@ -321,6 +391,8 @@ contract SwapRebalancingBridge is
         return bytes32(0);
     }
 
+    /// @dev Checks destination enrollment against the source router's local
+    /// router mapping or cross-collateral enrollment set.
     function _isEnrolledDestination(
         address sourceRouter,
         address destinationRouter,
@@ -346,6 +418,8 @@ contract SwapRebalancingBridge is
         }
     }
 
+    /// @dev Computes the destination router's nominal credit using standard
+    /// `TokenRouter` scale math.
     function _requiredOut(
         IMovableCollateralRouterLike sourceRouter,
         IMovableCollateralRouterLike destinationRouter,
@@ -380,6 +454,7 @@ contract SwapRebalancingBridge is
             );
     }
 
+    /// @dev Copies calldata swap steps into storage for the router callback.
     function _storeSwapCalls(SwapCall[] calldata swapCalls) internal {
         delete pendingSwapCalls;
         uint256 length = swapCalls.length;
@@ -394,6 +469,8 @@ contract SwapRebalancingBridge is
         }
     }
 
+    /// @dev Executes whitelisted swap calls with temporary exact-input
+    /// approvals.
     function _executeSwapCalls() internal {
         IERC20 inputToken = IERC20(pending.inputToken);
         uint256 length = pendingSwapCalls.length;

--- a/solidity/contracts/token/interfaces/ISwapRebalancingBridge.sol
+++ b/solidity/contracts/token/interfaces/ISwapRebalancingBridge.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+import {Quote} from "../../interfaces/ITokenBridge.sol";
+
+struct SwapCall {
+    address target;
+    address allowanceTarget;
+    bytes data;
+}
+
+struct PendingRebalance {
+    address initiator;
+    address sourceRouter;
+    address destinationRouter;
+    address inputToken;
+    address outputToken;
+    uint32 localDomain;
+    uint256 amountIn;
+    uint256 minAmountOut;
+    uint256 requiredOut;
+    uint256 deadline;
+}
+
+interface ISwapRebalancingBridge {
+    function executeRebalance(
+        address sourceRouter,
+        address destinationRouter,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline,
+        SwapCall[] calldata swapCalls
+    ) external payable;
+
+    function setAuthorizedRebalancer(address rebalancer, bool allowed) external;
+
+    function setTarget(address target, bool allowed) external;
+
+    function setAllowanceTarget(address target, bool allowed) external;
+
+    function pendingRebalance() external view returns (PendingRebalance memory);
+
+    function quoteTransferRemote(
+        uint32 destination,
+        bytes32 recipient,
+        uint256 amount
+    ) external view returns (Quote[] memory);
+}

--- a/solidity/contracts/token/interfaces/ISwapRebalancingBridge.sol
+++ b/solidity/contracts/token/interfaces/ISwapRebalancingBridge.sol
@@ -30,7 +30,7 @@ interface ISwapRebalancingBridge {
         uint256 minAmountOut,
         uint256 deadline,
         SwapCall[] calldata swapCalls
-    ) external payable;
+    ) external;
 
     function setAuthorizedRebalancer(address rebalancer, bool allowed) external;
 
@@ -39,6 +39,17 @@ interface ISwapRebalancingBridge {
     function setAllowanceTarget(address target, bool allowed) external;
 
     function pendingRebalance() external view returns (PendingRebalance memory);
+
+    function isEnrolledDestination(
+        address sourceRouter,
+        address destinationRouter
+    ) external view returns (bool);
+
+    function requiredOut(
+        address sourceRouter,
+        address destinationRouter,
+        uint256 amountIn
+    ) external view returns (uint256);
 
     function quoteTransferRemote(
         uint32 destination,

--- a/solidity/contracts/token/interfaces/ISwapRebalancingBridge.sol
+++ b/solidity/contracts/token/interfaces/ISwapRebalancingBridge.sol
@@ -3,12 +3,23 @@ pragma solidity >=0.8.0;
 
 import {Quote} from "../../interfaces/ITokenBridge.sol";
 
+/// @notice A single externally executed swap step.
+/// @dev
+/// `target` is the contract called by the bridge.
+/// `allowanceTarget` is the contract that may spend the bridge's current
+/// `inputToken` balance for that step. This is usually the same router, but is
+/// split out so routers that delegate transfer rights to another contract can
+/// still be supported. Both addresses must be owner-whitelisted.
 struct SwapCall {
     address target;
     address allowanceTarget;
     bytes data;
 }
 
+/// @notice In-flight rebalance state persisted across the router callback.
+/// @dev
+/// `requiredOut` is the nominal amount the destination router must receive
+/// after applying standard `TokenRouter` scale math.
 struct PendingRebalance {
     address initiator;
     address sourceRouter;
@@ -22,7 +33,46 @@ struct PendingRebalance {
     uint256 deadline;
 }
 
+/// @title ISwapRebalancingBridge
+/// @notice Same-chain rebalance bridge that uses `MovableCollateralRouter` as
+/// a collateral release primitive and settles into an enrolled destination
+/// router after executing exact-input swap calls.
+/// @dev
+/// Intended usage:
+/// - owner whitelists rebalancer EOAs, swap targets, and allowance targets
+/// - rebalancer calls `executeRebalance(...)` with an enrolled destination
+/// router plus exact-input swap calldata
+/// - source router calls back into `quoteTransferRemote(...)` and
+/// `transferRemote(...)`
+/// - bridge pulls `amountIn` from the source router, executes swap calls, tops
+/// up any output shortfall from the rebalancer, transfers exactly
+/// `requiredOut` to the destination router, and refunds any surplus to the
+/// rebalancer
+///
+/// Accepted tradeoffs:
+/// - same-chain only
+/// - single in-flight rebalance per bridge
+/// - assumes standard `TokenRouter` scale math; custom inbound/outbound router
+/// math is out of scope
+/// - executor is intended for router-style exact-input swaps, not arbitrary
+/// multi-step token choreography where the bridge itself must manage
+/// intermediate-token balances
+///
+/// Trust assumptions:
+/// - owner curates safe `target` / `allowanceTarget` allowlists
+/// - authorized rebalancers choose economically sensible swap calldata and can
+/// absorb output-token shortfalls
+/// - source and destination routers expose honest token and scale parameters
+/// - source router configuration still must allow `rebalance(localDomain,
+/// amountIn, bridge)` to succeed
 interface ISwapRebalancingBridge {
+    /// @notice Starts a same-chain rebalance into an enrolled destination
+    /// router.
+    /// @dev
+    /// `minAmountOut` protects the rebalancer, not LPs. LP protection comes
+    /// from the bridge requiring the destination router to receive exactly
+    /// `requiredOut`, with any shortfall pulled from the rebalancer in
+    /// `outputToken`.
     function executeRebalance(
         address sourceRouter,
         address destinationRouter,
@@ -32,25 +82,36 @@ interface ISwapRebalancingBridge {
         SwapCall[] calldata swapCalls
     ) external;
 
+    /// @notice Adds or removes a permitted rebalancer EOA.
     function setAuthorizedRebalancer(address rebalancer, bool allowed) external;
 
+    /// @notice Adds or removes a permitted external call target.
     function setTarget(address target, bool allowed) external;
 
+    /// @notice Adds or removes a permitted ERC20 allowance target.
     function setAllowanceTarget(address target, bool allowed) external;
 
+    /// @notice Returns the current in-flight rebalance, if any.
     function pendingRebalance() external view returns (PendingRebalance memory);
 
+    /// @notice Returns whether `destinationRouter` is enrolled on
+    /// `sourceRouter` for its local domain.
     function isEnrolledDestination(
         address sourceRouter,
         address destinationRouter
     ) external view returns (bool);
 
+    /// @notice Returns the nominal destination amount implied by router scale
+    /// math.
     function requiredOut(
         address sourceRouter,
         address destinationRouter,
         uint256 amountIn
     ) external view returns (uint256);
 
+    /// @notice Callback quote consumed by `MovableCollateralRouter.rebalance`.
+    /// @dev The bridge returns only the source-token pull quote. The callback
+    /// `recipient` is not authoritative for the bridge's destination selection.
     function quoteTransferRemote(
         uint32 destination,
         bytes32 recipient,

--- a/solidity/test/token/SwapRebalancingBridge.fork.t.sol
+++ b/solidity/test/token/SwapRebalancingBridge.fork.t.sol
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.22;
+
+import "forge-std/Test.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {SwapRebalancingBridge} from "contracts/token/SwapRebalancingBridge.sol";
+import {ITokenBridge, Quote} from "contracts/interfaces/ITokenBridge.sol";
+import {SwapCall} from "contracts/token/interfaces/ISwapRebalancingBridge.sol";
+
+interface IUniswapV3Router {
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    function exactInputSingle(
+        ExactInputSingleParams calldata params
+    ) external payable returns (uint256 amountOut);
+}
+
+interface IAerodromeRouter {
+    struct Route {
+        address from;
+        address to;
+        bool stable;
+        address factory;
+    }
+
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        Route[] calldata routes,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+}
+
+contract MockForkRouter {
+    IERC20 public immutable wrappedToken;
+    uint32 public immutable localDomain;
+    uint256 public immutable scaleNumerator;
+    uint256 public immutable scaleDenominator;
+
+    mapping(uint32 => bytes32) public routers;
+
+    constructor(
+        IERC20 _token,
+        uint32 _localDomain,
+        uint256 _scaleNumerator,
+        uint256 _scaleDenominator
+    ) {
+        wrappedToken = _token;
+        localDomain = _localDomain;
+        scaleNumerator = _scaleNumerator;
+        scaleDenominator = _scaleDenominator;
+    }
+
+    function token() external view returns (address) {
+        return address(wrappedToken);
+    }
+
+    function setPrimaryRouter(uint32 domain, address router) external {
+        routers[domain] = bytes32(uint256(uint160(router)));
+    }
+
+    function rebalance(
+        uint32 domain,
+        uint256 collateralAmount,
+        ITokenBridge bridge
+    ) external payable {
+        Quote[] memory quotes = bridge.quoteTransferRemote(
+            domain,
+            bytes32(0),
+            collateralAmount
+        );
+        wrappedToken.approve(address(bridge), quotes[1].amount);
+        bridge.transferRemote(domain, bytes32(0), collateralAmount);
+    }
+}
+
+abstract contract SwapRebalancingBridgeForkTestBase is Test {
+    SwapRebalancingBridge internal bridge;
+    MockForkRouter internal sourceRouter;
+    MockForkRouter internal destinationRouter;
+    address internal rebalancer = makeAddr("rebalancer");
+
+    function _setUpFork(
+        string memory rpcAlias,
+        IERC20 sourceToken,
+        IERC20 destinationToken,
+        uint32 localDomain
+    ) internal {
+        vm.createSelectFork(vm.rpcUrl(rpcAlias));
+
+        bridge = new SwapRebalancingBridge();
+        sourceRouter = new MockForkRouter(sourceToken, localDomain, 1, 1);
+        destinationRouter = new MockForkRouter(
+            destinationToken,
+            localDomain,
+            1,
+            1
+        );
+        sourceRouter.setPrimaryRouter(localDomain, address(destinationRouter));
+
+        bridge.setAuthorizedRebalancer(rebalancer, true);
+    }
+
+    function _assertExactFunding(
+        IERC20 destinationToken,
+        uint256 requiredOut,
+        uint256 destinationBefore,
+        uint256 rebalancerBefore
+    ) internal view {
+        assertEq(
+            destinationToken.balanceOf(address(destinationRouter)) -
+                destinationBefore,
+            requiredOut
+        );
+        assertLe(destinationToken.balanceOf(rebalancer), rebalancerBefore);
+    }
+}
+
+contract SwapRebalancingBridgeEthereumForkTest is
+    SwapRebalancingBridgeForkTestBase
+{
+    address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address internal constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+    address internal constant UNISWAP_V3_ROUTER =
+        0xE592427A0AEce92De3Edee1F18E0157C05861564;
+    uint32 internal constant LOCAL_DOMAIN = 1;
+
+    function setUp() public {
+        _setUpFork("mainnet", IERC20(USDC), IERC20(USDT), LOCAL_DOMAIN);
+
+        bridge.setTarget(UNISWAP_V3_ROUTER, true);
+        bridge.setAllowanceTarget(UNISWAP_V3_ROUTER, true);
+
+        deal(USDC, address(sourceRouter), 1_000e6);
+        deal(USDT, rebalancer, 1_000e6);
+        vm.prank(rebalancer);
+        SafeERC20.forceApprove(
+            IERC20(USDT),
+            address(bridge),
+            type(uint256).max
+        );
+    }
+
+    function testFork_uniswapExactInputSingle_fundsDestinationRouterExactly()
+        public
+    {
+        uint256 amountIn = 100e6;
+        uint256 destinationBefore = IERC20(USDT).balanceOf(
+            address(destinationRouter)
+        );
+        uint256 rebalancerBefore = IERC20(USDT).balanceOf(rebalancer);
+
+        SwapCall[] memory swapCalls = new SwapCall[](1);
+        swapCalls[0] = SwapCall({
+            target: UNISWAP_V3_ROUTER,
+            allowanceTarget: UNISWAP_V3_ROUTER,
+            data: abi.encodeWithSelector(
+                IUniswapV3Router.exactInputSingle.selector,
+                IUniswapV3Router.ExactInputSingleParams({
+                    tokenIn: USDC,
+                    tokenOut: USDT,
+                    fee: 500,
+                    recipient: address(bridge),
+                    deadline: block.timestamp + 1 hours,
+                    amountIn: amountIn,
+                    amountOutMinimum: 1,
+                    sqrtPriceLimitX96: 0
+                })
+            )
+        });
+
+        vm.prank(rebalancer);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            amountIn,
+            1,
+            block.timestamp + 1 hours,
+            swapCalls
+        );
+
+        _assertExactFunding(
+            IERC20(USDT),
+            amountIn,
+            destinationBefore,
+            rebalancerBefore
+        );
+    }
+}
+
+contract SwapRebalancingBridgeBaseForkTest is
+    SwapRebalancingBridgeForkTestBase
+{
+    address internal constant USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+    address internal constant USDT = 0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2;
+    address internal constant AERODROME_ROUTER =
+        0xcF77a3Ba9A5CA399B7c97c74d54e5b1Beb874E43;
+    address internal constant AERODROME_FACTORY =
+        0x420DD381b31aEf6683db6B902084cB0FFECe40Da;
+    uint32 internal constant LOCAL_DOMAIN = 8453;
+
+    function setUp() public {
+        _setUpFork("base", IERC20(USDC), IERC20(USDT), LOCAL_DOMAIN);
+
+        bridge.setTarget(AERODROME_ROUTER, true);
+        bridge.setAllowanceTarget(AERODROME_ROUTER, true);
+
+        deal(USDC, address(sourceRouter), 1_000e6);
+        deal(USDT, rebalancer, 1_000e6);
+        vm.prank(rebalancer);
+        SafeERC20.forceApprove(
+            IERC20(USDT),
+            address(bridge),
+            type(uint256).max
+        );
+    }
+
+    function testFork_aerodromeExactInput_fundsDestinationRouterExactly()
+        public
+    {
+        uint256 amountIn = 100e6;
+        uint256 destinationBefore = IERC20(USDT).balanceOf(
+            address(destinationRouter)
+        );
+        uint256 rebalancerBefore = IERC20(USDT).balanceOf(rebalancer);
+
+        IAerodromeRouter.Route[] memory routes = new IAerodromeRouter.Route[](
+            1
+        );
+        routes[0] = IAerodromeRouter.Route({
+            from: USDC,
+            to: USDT,
+            stable: false,
+            factory: AERODROME_FACTORY
+        });
+
+        SwapCall[] memory swapCalls = new SwapCall[](1);
+        swapCalls[0] = SwapCall({
+            target: AERODROME_ROUTER,
+            allowanceTarget: AERODROME_ROUTER,
+            data: abi.encodeWithSelector(
+                IAerodromeRouter.swapExactTokensForTokens.selector,
+                amountIn,
+                1,
+                routes,
+                address(bridge),
+                block.timestamp + 1 hours
+            )
+        });
+
+        vm.prank(rebalancer);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            amountIn,
+            1,
+            block.timestamp + 1 hours,
+            swapCalls
+        );
+
+        _assertExactFunding(
+            IERC20(USDT),
+            amountIn,
+            destinationBefore,
+            rebalancerBefore
+        );
+    }
+}

--- a/solidity/test/token/SwapRebalancingBridge.fork.t.sol
+++ b/solidity/test/token/SwapRebalancingBridge.fork.t.sol
@@ -8,6 +8,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {SwapRebalancingBridge} from "contracts/token/SwapRebalancingBridge.sol";
 import {ITokenBridge, Quote} from "contracts/interfaces/ITokenBridge.sol";
 import {SwapCall} from "contracts/token/interfaces/ISwapRebalancingBridge.sol";
+import {Quotes} from "contracts/token/libs/Quotes.sol";
 
 interface IUniswapV3Router {
     struct ExactInputSingleParams {
@@ -44,6 +45,8 @@ interface IAerodromeRouter {
 }
 
 contract MockForkRouter {
+    using Quotes for Quote[];
+
     IERC20 public immutable wrappedToken;
     uint32 public immutable localDomain;
     uint256 public immutable scaleNumerator;
@@ -71,6 +74,10 @@ contract MockForkRouter {
         routers[domain] = bytes32(uint256(uint160(router)));
     }
 
+    function approveTokenForBridge(ITokenBridge bridge) external {
+        wrappedToken.approve(address(bridge), type(uint256).max);
+    }
+
     function rebalance(
         uint32 domain,
         uint256 collateralAmount,
@@ -81,7 +88,10 @@ contract MockForkRouter {
             bytes32(0),
             collateralAmount
         );
-        wrappedToken.approve(address(bridge), quotes[1].amount);
+        require(
+            quotes.extract(address(wrappedToken)) <= collateralAmount,
+            "unexpected fees"
+        );
         bridge.transferRemote(domain, bytes32(0), collateralAmount);
     }
 }
@@ -109,6 +119,7 @@ abstract contract SwapRebalancingBridgeForkTestBase is Test {
             1
         );
         sourceRouter.setPrimaryRouter(localDomain, address(destinationRouter));
+        sourceRouter.approveTokenForBridge(bridge);
 
         bridge.setAuthorizedRebalancer(rebalancer, true);
     }
@@ -197,6 +208,116 @@ contract SwapRebalancingBridgeEthereumForkTest is
             destinationBefore,
             rebalancerBefore
         );
+    }
+
+    function testFork_uniswapExactInputSingle_pullsShortfallFromRebalancer()
+        public
+    {
+        uint256 amountIn = 100e6;
+        destinationRouter = new MockForkRouter(
+            IERC20(USDT),
+            LOCAL_DOMAIN,
+            10,
+            11
+        );
+        sourceRouter.setPrimaryRouter(LOCAL_DOMAIN, address(destinationRouter));
+
+        uint256 destinationBefore = IERC20(USDT).balanceOf(
+            address(destinationRouter)
+        );
+        uint256 rebalancerBefore = IERC20(USDT).balanceOf(rebalancer);
+
+        vm.prank(rebalancer);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            amountIn,
+            1,
+            block.timestamp + 1 hours,
+            _uniswapSwapCalls(amountIn)
+        );
+
+        assertEq(
+            IERC20(USDT).balanceOf(address(destinationRouter)) -
+                destinationBefore,
+            110e6
+        );
+        assertLt(IERC20(USDT).balanceOf(rebalancer), rebalancerBefore);
+    }
+
+    function testFork_uniswapExactInputSingle_refundsSurplusToRebalancer()
+        public
+    {
+        uint256 amountIn = 100e6;
+        destinationRouter = new MockForkRouter(
+            IERC20(USDT),
+            LOCAL_DOMAIN,
+            10,
+            9
+        );
+        sourceRouter.setPrimaryRouter(LOCAL_DOMAIN, address(destinationRouter));
+
+        uint256 destinationBefore = IERC20(USDT).balanceOf(
+            address(destinationRouter)
+        );
+        uint256 rebalancerBefore = IERC20(USDT).balanceOf(rebalancer);
+
+        vm.prank(rebalancer);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            amountIn,
+            1,
+            block.timestamp + 1 hours,
+            _uniswapSwapCalls(amountIn)
+        );
+
+        assertEq(
+            IERC20(USDT).balanceOf(address(destinationRouter)) -
+                destinationBefore,
+            90e6
+        );
+        assertGt(IERC20(USDT).balanceOf(rebalancer), rebalancerBefore);
+    }
+
+    function testFork_uniswapExactInputSingle_revertsWhenAmountOutBelowMin()
+        public
+    {
+        uint256 amountIn = 100e6;
+
+        vm.prank(rebalancer);
+        vm.expectRevert(SwapRebalancingBridge.AmountOutTooLow.selector);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            amountIn,
+            200e6,
+            block.timestamp + 1 hours,
+            _uniswapSwapCalls(amountIn)
+        );
+    }
+
+    function _uniswapSwapCalls(
+        uint256 amountIn
+    ) internal view returns (SwapCall[] memory swapCalls) {
+        swapCalls = new SwapCall[](1);
+        swapCalls[0] = SwapCall({
+            target: UNISWAP_V3_ROUTER,
+            allowanceTarget: UNISWAP_V3_ROUTER,
+            data: abi.encodeWithSelector(
+                IUniswapV3Router.exactInputSingle.selector,
+                IUniswapV3Router.ExactInputSingleParams({
+                    tokenIn: USDC,
+                    tokenOut: USDT,
+                    fee: 500,
+                    recipient: address(bridge),
+                    deadline: block.timestamp + 1 hours,
+                    amountIn: amountIn,
+                    amountOutMinimum: 1,
+                    sqrtPriceLimitX96: 0
+                })
+            )
+        });
     }
 }
 

--- a/solidity/test/token/SwapRebalancingBridge.t.sol
+++ b/solidity/test/token/SwapRebalancingBridge.t.sol
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.22;
+
+import "forge-std/Test.sol";
+
+import {ERC20Test} from "contracts/test/ERC20Test.sol";
+import {TestSwapTarget} from "contracts/test/TestSwapTarget.sol";
+import {SwapRebalancingBridge} from "contracts/token/SwapRebalancingBridge.sol";
+import {ISwapRebalancingBridge, SwapCall} from "contracts/token/interfaces/ISwapRebalancingBridge.sol";
+import {ITokenBridge, Quote} from "contracts/interfaces/ITokenBridge.sol";
+
+contract MockRebalanceRouter {
+    ERC20Test public immutable wrappedToken;
+    uint32 public immutable localDomain;
+    uint256 public immutable scaleNumerator;
+    uint256 public immutable scaleDenominator;
+
+    mapping(uint32 => bytes32) public routers;
+    mapping(uint32 => mapping(bytes32 => bool)) public crossCollateralRouters;
+
+    bytes32 public callbackRecipient;
+    bool public quoteOnly;
+
+    constructor(
+        ERC20Test _token,
+        uint32 _localDomain,
+        uint256 _scaleNumerator,
+        uint256 _scaleDenominator
+    ) {
+        wrappedToken = _token;
+        localDomain = _localDomain;
+        scaleNumerator = _scaleNumerator;
+        scaleDenominator = _scaleDenominator;
+    }
+
+    function token() external view returns (address) {
+        return address(wrappedToken);
+    }
+
+    function setPrimaryRouter(uint32 domain, address router) external {
+        routers[domain] = _toBytes32(router);
+    }
+
+    function setCrossRouter(
+        uint32 domain,
+        address router,
+        bool enrolled
+    ) external {
+        crossCollateralRouters[domain][_toBytes32(router)] = enrolled;
+    }
+
+    function setCallbackRecipient(address recipient) external {
+        callbackRecipient = _toBytes32(recipient);
+    }
+
+    function setQuoteOnly(bool _quoteOnly) external {
+        quoteOnly = _quoteOnly;
+    }
+
+    function rebalance(
+        uint32 domain,
+        uint256 collateralAmount,
+        ITokenBridge bridge
+    ) external payable {
+        Quote[] memory quotes = bridge.quoteTransferRemote(
+            domain,
+            callbackRecipient,
+            collateralAmount
+        );
+        if (quoteOnly) return;
+        wrappedToken.approve(address(bridge), quotes[1].amount);
+        bridge.transferRemote(domain, callbackRecipient, collateralAmount);
+    }
+
+    function _toBytes32(address account) internal pure returns (bytes32) {
+        return bytes32(uint256(uint160(account)));
+    }
+}
+
+contract SwapRebalancingBridgeTest is Test {
+    uint32 internal constant LOCAL_DOMAIN = 10;
+
+    SwapRebalancingBridge internal bridge;
+    ERC20Test internal inputToken;
+    ERC20Test internal outputToken;
+    MockRebalanceRouter internal sourceRouter;
+    MockRebalanceRouter internal destinationRouter;
+    MockRebalanceRouter internal altDestinationRouter;
+    TestSwapTarget internal swapTarget;
+
+    address internal rebalancer = makeAddr("rebalancer");
+    address internal other = makeAddr("other");
+
+    function setUp() public {
+        bridge = new SwapRebalancingBridge();
+        inputToken = new ERC20Test("Input", "IN", 0, 6);
+        outputToken = new ERC20Test("Output", "OUT", 0, 18);
+
+        sourceRouter = new MockRebalanceRouter(
+            inputToken,
+            LOCAL_DOMAIN,
+            1e12,
+            1
+        );
+        destinationRouter = new MockRebalanceRouter(
+            outputToken,
+            LOCAL_DOMAIN,
+            1,
+            1
+        );
+        altDestinationRouter = new MockRebalanceRouter(
+            outputToken,
+            LOCAL_DOMAIN,
+            1,
+            1
+        );
+        sourceRouter.setPrimaryRouter(LOCAL_DOMAIN, address(destinationRouter));
+        sourceRouter.setCrossRouter(
+            LOCAL_DOMAIN,
+            address(altDestinationRouter),
+            true
+        );
+        sourceRouter.setCallbackRecipient(other);
+
+        swapTarget = new TestSwapTarget(
+            address(inputToken),
+            address(outputToken)
+        );
+        bridge.setAuthorizedRebalancer(rebalancer, true);
+        bridge.setTarget(address(swapTarget), true);
+        bridge.setAllowanceTarget(address(swapTarget), true);
+
+        inputToken.mintTo(address(sourceRouter), 1_000_000e6);
+        outputToken.mintTo(address(swapTarget), type(uint128).max);
+    }
+
+    function test_executeRebalance_revertsUnauthorized() public {
+        vm.expectRevert(SwapRebalancingBridge.UnauthorizedRebalancer.selector);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            100e6,
+            100e18,
+            block.timestamp + 1,
+            _swapCalls(100e6)
+        );
+    }
+
+    function test_executeRebalance_revertsWhenDestinationNotEnrolled() public {
+        MockRebalanceRouter unlisted = new MockRebalanceRouter(
+            outputToken,
+            LOCAL_DOMAIN,
+            1,
+            1
+        );
+        vm.prank(rebalancer);
+        vm.expectRevert(SwapRebalancingBridge.DestinationNotEnrolled.selector);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(unlisted),
+            100e6,
+            100e18,
+            block.timestamp + 1,
+            _swapCalls(100e6)
+        );
+    }
+
+    function test_executeRebalance_revertsWhenDomainMismatch() public {
+        MockRebalanceRouter remote = new MockRebalanceRouter(
+            outputToken,
+            99,
+            1,
+            1
+        );
+        sourceRouter.setPrimaryRouter(LOCAL_DOMAIN, address(remote));
+        vm.prank(rebalancer);
+        vm.expectRevert(SwapRebalancingBridge.InvalidDomain.selector);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(remote),
+            100e6,
+            100e18,
+            block.timestamp + 1,
+            _swapCalls(100e6)
+        );
+    }
+
+    function test_executeRebalance_revertsWhenDeadlineExpired() public {
+        vm.prank(rebalancer);
+        vm.expectRevert(SwapRebalancingBridge.DeadlineExpired.selector);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            100e6,
+            100e18,
+            block.timestamp - 1,
+            _swapCalls(100e6)
+        );
+    }
+
+    function test_quoteTransferRemote_returnsSourceTokenQuote() public {
+        sourceRouter.setQuoteOnly(true);
+        vm.prank(rebalancer);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            100e6,
+            100e18,
+            block.timestamp + 1,
+            _swapCalls(100e6)
+        );
+
+        Quote[] memory quotes = bridge.quoteTransferRemote(
+            LOCAL_DOMAIN,
+            bytes32(0),
+            100e6
+        );
+        assertEq(quotes.length, 3);
+        assertEq(quotes[0].token, address(0));
+        assertEq(quotes[0].amount, 0);
+        assertEq(quotes[1].token, address(inputToken));
+        assertEq(quotes[1].amount, 100e6);
+        assertEq(quotes[2].amount, 0);
+    }
+
+    function test_transferRemote_ignoresRecipientAndPaysExactNominal() public {
+        swapTarget.setOutputAmount(100e18);
+
+        vm.prank(rebalancer);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            100e6,
+            99e18,
+            block.timestamp + 1,
+            _swapCalls(100e6)
+        );
+
+        assertEq(outputToken.balanceOf(address(destinationRouter)), 100e18);
+        assertEq(outputToken.balanceOf(rebalancer), 0);
+    }
+
+    function test_transferRemote_pullsShortfallFromRebalancer() public {
+        swapTarget.setOutputAmount(97e18);
+        outputToken.mintTo(rebalancer, 10e18);
+        vm.prank(rebalancer);
+        outputToken.approve(address(bridge), type(uint256).max);
+
+        vm.prank(rebalancer);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            100e6,
+            90e18,
+            block.timestamp + 1,
+            _swapCalls(100e6)
+        );
+
+        assertEq(outputToken.balanceOf(address(destinationRouter)), 100e18);
+        assertEq(outputToken.balanceOf(rebalancer), 7e18);
+    }
+
+    function test_transferRemote_refundsSurplusToRebalancer() public {
+        swapTarget.setOutputAmount(103e18);
+
+        vm.prank(rebalancer);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            100e6,
+            90e18,
+            block.timestamp + 1,
+            _swapCalls(100e6)
+        );
+
+        assertEq(outputToken.balanceOf(address(destinationRouter)), 100e18);
+        assertEq(outputToken.balanceOf(rebalancer), 3e18);
+    }
+
+    function test_transferRemote_revertsWhenAmountOutBelowMin() public {
+        swapTarget.setOutputAmount(89e18);
+        outputToken.mintTo(rebalancer, 100e18);
+        vm.prank(rebalancer);
+        outputToken.approve(address(bridge), type(uint256).max);
+
+        vm.prank(rebalancer);
+        vm.expectRevert(SwapRebalancingBridge.AmountOutTooLow.selector);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            100e6,
+            90e18,
+            block.timestamp + 1,
+            _swapCalls(100e6)
+        );
+    }
+
+    function test_transferRemote_revertsOnUnapprovedTarget() public {
+        bridge.setTarget(address(swapTarget), false);
+
+        vm.prank(rebalancer);
+        vm.expectRevert(SwapRebalancingBridge.UnapprovedTarget.selector);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            100e6,
+            90e18,
+            block.timestamp + 1,
+            _swapCalls(100e6)
+        );
+    }
+
+    function test_transferRemote_revertsOnUnapprovedAllowanceTarget() public {
+        bridge.setAllowanceTarget(address(swapTarget), false);
+
+        vm.prank(rebalancer);
+        vm.expectRevert(
+            SwapRebalancingBridge.UnapprovedAllowanceTarget.selector
+        );
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            100e6,
+            90e18,
+            block.timestamp + 1,
+            _swapCalls(100e6)
+        );
+    }
+
+    function test_transferRemote_revertsIfInputNotFullySpent() public {
+        outputToken.mintTo(rebalancer, 100e18);
+        vm.prank(rebalancer);
+        outputToken.approve(address(bridge), type(uint256).max);
+
+        SwapCall[] memory noSwapCalls = new SwapCall[](0);
+
+        vm.prank(rebalancer);
+        vm.expectRevert(SwapRebalancingBridge.InputNotFullySpent.selector);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            100e6,
+            0,
+            block.timestamp + 1,
+            noSwapCalls
+        );
+    }
+
+    function test_transferRemote_clearsApprovalAfterSwap() public {
+        swapTarget.setOutputAmount(100e18);
+
+        vm.prank(rebalancer);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            100e6,
+            90e18,
+            block.timestamp + 1,
+            _swapCalls(100e6)
+        );
+
+        assertEq(inputToken.allowance(address(bridge), address(swapTarget)), 0);
+        assertEq(
+            outputToken.allowance(address(bridge), address(swapTarget)),
+            0
+        );
+    }
+
+    function test_executeRebalance_usesCrossCollateralEnrollmentPath() public {
+        swapTarget.setOutputAmount(100e18);
+
+        vm.prank(rebalancer);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(altDestinationRouter),
+            100e6,
+            90e18,
+            block.timestamp + 1,
+            _swapCalls(100e6)
+        );
+
+        assertEq(outputToken.balanceOf(address(altDestinationRouter)), 100e18);
+    }
+
+    function test_revertsOnConcurrentPendingRebalance() public {
+        sourceRouter.setQuoteOnly(true);
+        vm.prank(rebalancer);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            100e6,
+            90e18,
+            block.timestamp + 1,
+            _swapCalls(100e6)
+        );
+
+        vm.prank(rebalancer);
+        vm.expectRevert(SwapRebalancingBridge.RebalanceAlreadyPending.selector);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(destinationRouter),
+            100e6,
+            90e18,
+            block.timestamp + 1,
+            _swapCalls(100e6)
+        );
+    }
+
+    function _swapCalls(
+        uint256 amountIn
+    ) internal view returns (SwapCall[] memory calls) {
+        calls = new SwapCall[](1);
+        calls[0] = SwapCall({
+            target: address(swapTarget),
+            allowanceTarget: address(swapTarget),
+            data: abi.encodeWithSelector(
+                TestSwapTarget.swapExactInput.selector,
+                amountIn
+            )
+        });
+    }
+}

--- a/solidity/test/token/SwapRebalancingBridge.t.sol
+++ b/solidity/test/token/SwapRebalancingBridge.t.sol
@@ -8,8 +8,11 @@ import {TestSwapTarget} from "contracts/test/TestSwapTarget.sol";
 import {SwapRebalancingBridge} from "contracts/token/SwapRebalancingBridge.sol";
 import {ISwapRebalancingBridge, SwapCall} from "contracts/token/interfaces/ISwapRebalancingBridge.sol";
 import {ITokenBridge, Quote} from "contracts/interfaces/ITokenBridge.sol";
+import {Quotes} from "contracts/token/libs/Quotes.sol";
 
 contract MockRebalanceRouter {
+    using Quotes for Quote[];
+
     ERC20Test public immutable wrappedToken;
     uint32 public immutable localDomain;
     uint256 public immutable scaleNumerator;
@@ -57,6 +60,10 @@ contract MockRebalanceRouter {
         quoteOnly = _quoteOnly;
     }
 
+    function approveTokenForBridge(ITokenBridge bridge) external {
+        wrappedToken.approve(address(bridge), type(uint256).max);
+    }
+
     function rebalance(
         uint32 domain,
         uint256 collateralAmount,
@@ -68,7 +75,10 @@ contract MockRebalanceRouter {
             collateralAmount
         );
         if (quoteOnly) return;
-        wrappedToken.approve(address(bridge), quotes[1].amount);
+        require(
+            quotes.extract(address(wrappedToken)) <= collateralAmount,
+            "unexpected fees"
+        );
         bridge.transferRemote(domain, callbackRecipient, collateralAmount);
     }
 
@@ -132,6 +142,7 @@ contract SwapRebalancingBridgeTest is Test {
 
         inputToken.mintTo(address(sourceRouter), 1_000_000e6);
         outputToken.mintTo(address(swapTarget), type(uint128).max);
+        sourceRouter.approveTokenForBridge(bridge);
     }
 
     function test_executeRebalance_revertsUnauthorized() public {
@@ -194,6 +205,30 @@ contract SwapRebalancingBridgeTest is Test {
             100e6,
             100e18,
             block.timestamp - 1,
+            _swapCalls(100e6)
+        );
+    }
+
+    function test_executeRebalance_revertsWhenScaleIsZero() public {
+        MockRebalanceRouter invalidDestination = new MockRebalanceRouter(
+            outputToken,
+            LOCAL_DOMAIN,
+            0,
+            1
+        );
+        sourceRouter.setPrimaryRouter(
+            LOCAL_DOMAIN,
+            address(invalidDestination)
+        );
+
+        vm.prank(rebalancer);
+        vm.expectRevert(SwapRebalancingBridge.InvalidScale.selector);
+        bridge.executeRebalance(
+            address(sourceRouter),
+            address(invalidDestination),
+            100e6,
+            100e18,
+            block.timestamp + 1,
             _swapCalls(100e6)
         );
     }


### PR DESCRIPTION
## Summary

Adds `SwapRebalancingBridge`, a same-chain rebalance bridge that uses `MovableCollateralRouter.rebalance(...)` only as a source-collateral release primitive, then executes exact-input swap calls and settles an enrolled destination router with exact nominal output.

## Intended usage

- Owner whitelists:
  - authorized rebalancer EOAs
  - external swap `target`s
  - ERC20 `allowanceTarget`s
- Rebalancer calls `executeRebalance(sourceRouter, destinationRouter, amountIn, minAmountOut, deadline, swapCalls)`.
- Bridge verifies:
  - destination router is enrolled on source router via `routers(...)` or `crossCollateralRouters(...)`
  - source and destination routers share `localDomain`
- Bridge stores pending state and calls `sourceRouter.rebalance(localDomain, amountIn, this)`.
- Source router calls back into `quoteTransferRemote(...)` and `transferRemote(...)`.
- Bridge pulls `amountIn` from the source router, executes exact-input swap calls, then:
  - if `actualOut < requiredOut`, pulls the shortfall from the rebalancer in `outputToken`
  - transfers exactly `requiredOut` to the destination router
  - refunds any surplus to the rebalancer

## Accepted tradeoffs

- Same-chain only.
- Single in-flight rebalance per bridge.
- Exact-input swaps only.
- Intended for router-style venues where the venue owns the hop path.
- Not a fully generic arbitrary multi-step token executor where the bridge itself must manage intermediate-token balances.
- Nominal accounting assumes standard `TokenRouter` `scaleNumerator/scaleDenominator` math.
- Routers with custom inbound/outbound math are out of scope for v1.
- Callback `recipient` is intentionally ignored; the enrolled `destinationRouter` passed by the rebalancer is authoritative.

## Ergonomics

- Single-call entrypoint for rebalancers.
- Owner-managed allowlists constrain arbitrary calldata to known venues/spenders.
- Helper views:
  - `pendingRebalance()`
  - `isEnrolledDestination(...)`
  - `requiredOut(...)`
- Fork coverage includes real Uniswap on Ethereum and real Aerodrome on Base.

## Trust assumptions

- Owner curates safe `target` / `allowanceTarget` allowlists.
- Authorized rebalancers submit economically sane swap calldata.
- Rebalancers can fund output-token shortfalls.
- Source router is configured so `rebalance(localDomain, amountIn, bridge)` is allowed to execute.
- Source and destination routers expose honest token and scale parameters.

## Security / accounting properties

- LPs receive exact nominal `requiredOut` or the call reverts.
- Rebalancer bears downside in `outputToken`.
- Rebalancer receives upside in `outputToken`.
- Bridge does not keep execution alpha.
- Output-token approvals to swap venues were removed.
- Input-token approval is narrowed to `pending.amountIn`.
- Unspent input reverts when `inputToken != outputToken`.

## Tests

Local:
- `forge test --match-path test/token/SwapRebalancingBridge.t.sol`
- `forge test --match-path test/token/SwapRebalancingBridge.fork.t.sol`

Coverage includes:
- auth / enrollment / deadline
- ignored callback `recipient`
- exact nominal settlement
- shortfall top-up
- surplus refund
- `minAmountOut` revert
- whitelist failures
- approval cleanup
- zero-scale guard
- fork happy / deficit / surplus / revert paths on Ethereum Uniswap
- fork happy path on Base Aerodrome

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->