### PR TITLE
feat: update offchain-lookup-servers

### DIFF
--- a/typescript/infra/helm/offchain-lookup-server/values-mainnet.yaml
+++ b/typescript/infra/helm/offchain-lookup-server/values-mainnet.yaml
@@ -6,7 +6,7 @@ image:
   # Modify this tag to deploy a new revision.
   # Images can be found here:
   # https://github.com/orgs/hyperlane-xyz/packages/container/package/hyperlane-node-services
-  tag: d0dbf1a-20260406-190037
+  tag: dc8e560-20260417-072705
 
 # In Google Cloud Secret Manager, all secrets need to have a certain prefix in order to be accessible by
 # the Cluster Secret Store. For testnet this prefix is "hyperlane-testnet4"

--- a/typescript/infra/helm/offchain-lookup-server/values-testnet.yaml
+++ b/typescript/infra/helm/offchain-lookup-server/values-testnet.yaml
@@ -6,7 +6,7 @@ image:
   # Modify this tag to deploy a new revision.
   # Images can be found here:
   # https://github.com/orgs/hyperlane-xyz/packages/container/package/hyperlane-node-services
-  tag: d0dbf1a-20260406-190037
+  tag: dc8e560-20260417-072705
 
 # In Google Cloud Secret Manager, all secrets need to have a certain prefix in order to be accessible by
 # the Cluster Secret Store. For testnet this prefix is "hyperlane-testnet4"


### PR DESCRIPTION
### Description

Updated offchain lookup servers to latest version including the new origin_tx_hash for cctip read requests skipping the scraper db

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
