### PR TITLE
fix: cctp transfer validation

### DIFF
--- a/.changeset/little-boxes-yawn.md
+++ b/.changeset/little-boxes-yawn.md
@@ -1,0 +1,6 @@
+---
+"@hyperlane-xyz/cli": patch
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed cctp transfer validation

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -59,6 +59,7 @@ import {
   normalizeScale,
   splitWarpCoreAndExtendedConfigs,
   tokenTypeToStandard,
+  isOftTokenConfig,
 } from '@hyperlane-xyz/sdk';
 import {
   type Address,

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -50,6 +50,7 @@ import {
   getRouterAddressesFromWarpCoreConfig,
   getSubmitterBuilder,
   getTokenConnectionId,
+  isCctpTokenConfig,
   isCollateralTokenConfig,
   isCrossCollateralTokenConfig,
   isXERC20TokenConfig,
@@ -371,6 +372,7 @@ function generateTokenConfigs(
     const config = warpDeployConfig[chainName];
     const collateralAddressOrDenom =
       isCollateralTokenConfig(config) ||
+      isCctpTokenConfig(config) ||
       isXERC20TokenConfig(config) ||
       isCrossCollateralTokenConfig(config)
         ? (config as { token: string }).token // gets set in the above deriveTokenMetadata()

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -53,6 +53,8 @@ import {
   isCctpTokenConfig,
   isCollateralTokenConfig,
   isCrossCollateralTokenConfig,
+  isDepositAddressTokenConfig,
+  isEverclearCollateralTokenConfig,
   isXERC20TokenConfig,
   normalizeScale,
   splitWarpCoreAndExtendedConfigs,
@@ -374,7 +376,9 @@ function generateTokenConfigs(
       isCollateralTokenConfig(config) ||
       isCctpTokenConfig(config) ||
       isXERC20TokenConfig(config) ||
-      isCrossCollateralTokenConfig(config)
+      isCrossCollateralTokenConfig(config) ||
+      isDepositAddressTokenConfig(config) ||
+      isEverclearCollateralTokenConfig(config)
         ? (config as { token: string }).token // gets set in the above deriveTokenMetadata()
         : undefined;
 

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -378,7 +378,8 @@ function generateTokenConfigs(
       isXERC20TokenConfig(config) ||
       isCrossCollateralTokenConfig(config) ||
       isDepositAddressTokenConfig(config) ||
-      isEverclearCollateralTokenConfig(config)
+      isEverclearCollateralTokenConfig(config) ||
+      isOftTokenConfig(config)
         ? (config as { token: string }).token // gets set in the above deriveTokenMetadata()
         : undefined;
 

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -50,16 +50,10 @@ import {
   getRouterAddressesFromWarpCoreConfig,
   getSubmitterBuilder,
   getTokenConnectionId,
-  isCctpTokenConfig,
-  isCollateralTokenConfig,
   isCrossCollateralTokenConfig,
-  isDepositAddressTokenConfig,
-  isEverclearCollateralTokenConfig,
-  isXERC20TokenConfig,
   normalizeScale,
   splitWarpCoreAndExtendedConfigs,
   tokenTypeToStandard,
-  isOftTokenConfig,
 } from '@hyperlane-xyz/sdk';
 import {
   type Address,
@@ -374,14 +368,8 @@ function generateTokenConfigs(
   for (const chainName of Object.keys(contracts)) {
     const config = warpDeployConfig[chainName];
     const collateralAddressOrDenom =
-      isCollateralTokenConfig(config) ||
-      isCctpTokenConfig(config) ||
-      isXERC20TokenConfig(config) ||
-      isCrossCollateralTokenConfig(config) ||
-      isDepositAddressTokenConfig(config) ||
-      isEverclearCollateralTokenConfig(config) ||
-      isOftTokenConfig(config)
-        ? (config as { token: string }).token // gets set in the above deriveTokenMetadata()
+      'token' in config && typeof config.token === 'string'
+        ? config.token
         : undefined;
 
     const protocol = multiProvider.getProtocol(chainName);

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -850,6 +850,7 @@ export {
   HypTokenRouterConfigSchema,
   HypTokenRouterVirtualConfig,
   isCollateralRebaseTokenConfig,
+  isCctpTokenConfig,
   isCollateralTokenConfig,
   isMovableCollateralTokenConfig,
   isNativeTokenConfig,

--- a/typescript/sdk/src/token/TokenMetadata.ts
+++ b/typescript/sdk/src/token/TokenMetadata.ts
@@ -45,8 +45,15 @@ function matchesUnderlyingAsset(
       return true;
     }
 
+    // Only native-type collateral tokens (e.g. EvmHypNative) can be fungible
+    // with native tokens when no collateralAddressOrDenom is set — native
+    // tokens have no address by definition. ERC20 collateral tokens missing
+    // their collateralAddressOrDenom (e.g. incomplete config) must not be
+    // treated as native.
+    const hypNativeStandards = Object.values(PROTOCOL_TO_HYP_NATIVE_STANDARD);
     if (
       !source.collateralAddressOrDenom &&
+      hypNativeStandards.includes(source.standard as TokenStandard) &&
       (target.isNative() || target.isHypNative())
     ) {
       return true;

--- a/typescript/sdk/src/token/TokenMetadata.ts
+++ b/typescript/sdk/src/token/TokenMetadata.ts
@@ -45,15 +45,11 @@ function matchesUnderlyingAsset(
       return true;
     }
 
-    // Only native-type collateral tokens (e.g. EvmHypNative) can be fungible
-    // with native tokens when no collateralAddressOrDenom is set — native
-    // tokens have no address by definition. ERC20 collateral tokens missing
-    // their collateralAddressOrDenom (e.g. incomplete config) must not be
-    // treated as native.
-    const hypNativeStandards = Object.values(PROTOCOL_TO_HYP_NATIVE_STANDARD);
+    // Only HypNative collateral legitimately lacks collateralAddressOrDenom;
+    // any other collateralized token missing it is a config bug, not a native match.
     if (
       !source.collateralAddressOrDenom &&
-      hypNativeStandards.includes(source.standard as TokenStandard) &&
+      source.isHypNative() &&
       (target.isNative() || target.isHypNative())
     ) {
       return true;


### PR DESCRIPTION
### Description

Fixes a false \"Insufficient ETH for interchain gas\" error when sending USDC via CCTP v2 warp routes, even when the sender has sufficient ETH.

**Root cause — two bugs compounding:**

1. **Missing `collateralAddressOrDenom` in generated warp configs** ([`generateTokenConfigs`](typescript/cli/src/deploy/warp.ts)): `isCctpTokenConfig` was not included in the condition that sets `collateralAddressOrDenom`, so CCTP collateral tokens were deployed/written to config without the underlying USDC token address. The existing V1 CCTP config has this field; V2 fast/standard configs do not.

2. **Unsafe fungibility fallback in `matchesUnderlyingAsset`** ([`TokenMetadata.ts`](typescript/sdk/src/token/TokenMetadata.ts)): The function has a branch that says "if a collateralized token has no `collateralAddressOrDenom` AND the target is native ETH → treat as fungible." This was intended for `EvmHypNative` (which wraps native ETH and has no token address by definition), but it also fires for any ERC20 collateral token whose config is missing `collateralAddressOrDenom` — including CCTP USDC.

**Effect:** In `validateTokenBalances` (Check 2), `isFungibleWith` incorrectly returned `true` for USDC vs ETH. The balance check then used the sender's USDC raw balance (~939,729 = $0.94) instead of their ETH balance to cover the IGP fee quote (~45,419,750,949,540 wei ≈ 0.000045 ETH). 939,729 < 45,419,750,949,540 → error.

**Fixes:**

- `generateTokenConfigs` in `warp.ts`: add `isCctpTokenConfig(config)` to the condition so CCTP tokens get their `collateralAddressOrDenom` set on deploy (prevents recurrence for future deployments).
- `matchesUnderlyingAsset` in `TokenMetadata.ts`: restrict the native fallback to only fire when the source token's standard is actually a native-type (i.e. present in `PROTOCOL_TO_HYP_NATIVE_STANDARD`), making the SDK defensive against incomplete configs.
- Export `isCctpTokenConfig` from the SDK index so CLI can use it.

### Drive-by changes

None.

### Related issues

<!-- - Fixes #[issue number here] -->

### Backward compatibility

Yes. The `matchesUnderlyingAsset` change only tightens an incorrect fallback — tokens with a correct `collateralAddressOrDenom` are unaffected. The `generateTokenConfigs` change only affects newly generated configs.

### Testing

Manual: reproduced the failure with `hyperlane warp send` on the USDC/mainnet-cctp-v2-fast route (Ethereum → Arbitrum) and confirmed the error is gone after these changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->