### PR TITLE
fix: Set from address when performing eth_estimateGas calls

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
@@ -187,6 +187,15 @@ where
         function: &Function,
     ) -> ChainResult<U256> {
         let contract_call = self.build_contract_call::<()>(tx.clone(), function.clone());
+        // Set the from address to the signer to ensure the gas estimation is
+        // performed from the relayer's address. Without this, some chains
+        // (e.g. Citrea) estimate as if the call is from the zero address,
+        // which may have no funds and cause "Not enough funds for L1 fee" errors.
+        let contract_call = if let Some(signer) = self.get_signer() {
+            contract_call.from(signer)
+        } else {
+            contract_call
+        };
         let gas_limit = contract_call.estimate_gas().await?.into();
         Ok(gas_limit)
     }


### PR DESCRIPTION
## Summary

When performing \eth_estimateGas\ without a \rom\ address, some chains (e.g. Citrea testnet) estimate as if the call is made from the zero address. Since the zero address has no funds, this causes \'Not enough funds for L1 fee'\ errors even when the relayer has sufficient balance.

## Fix

In \ust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs\, the \estimate_gas_limit\ method now sets the \rom\ address to the relayer's signer address before calling \estimate_gas()\:

\\\ust
let contract_call = if let Some(signer) = self.get_signer() {
    contract_call.from(signer)
} else {
    contract_call
};
\\\

This ensures the gas estimation is performed from the relayer's address rather than the zero address.

## Fixes

Fixes #4585

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
