### PR TITLE
ci: fix siren emoji for package publish failure alerts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,9 +321,9 @@ jobs:
           webhook: ${{ secrets.SLACK_INCIDENTS_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
-            text: ":red-siren: NPM package publish failed — see workflow run for details"
+            text: ":alert: NPM package publish failed — see workflow run for details"
             blocks:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: ":red-siren: *NPM package publish failed*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run #${{ github.run_number }}>"
+                  text: ":alert: *NPM package publish failed*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run #${{ github.run_number }}>"


### PR DESCRIPTION
### Description

ci: fix siren emoji for package publish failure alerts

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the Slack message payload emoji in the release workflow; no behavior or permissions changes.
> 
> **Overview**
> Updates the `notify-publish-failure` Slack notification in `.github/workflows/release.yml` to use `:alert:` instead of `:red-siren:` in both the top-level text and the block message for NPM publish failure alerts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50d6cd757f92a91959356386ff16c20286a2cd5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->