### PR TITLE
fix: catch possible private keys in staged changes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -19,8 +19,8 @@ if [ "$GITHUB_ACTIONS" != "true" ]; then
         exit 1
     fi
 
-    # Broad private key check on staged diff. May produce false positives — set SKIP_PK_CHECK=1 to bypass if intentional.
-    if [ "$SKIP_PK_CHECK" != "1" ]; then
+    # Broad private key check on staged diff. May produce false positives — set SKIP_KEY_CHECK=1 to bypass if intentional.
+    if [ "$SKIP_KEY_CHECK" != "1" ]; then
         STAGED_DIFF=$(git diff --cached | awk '/^\+\+\+ b\// { file=substr($0,7) } /^\+[^+]/ { print file ":" $0 }')
         EVM_MATCHES=$(echo "$STAGED_DIFF"    | grep -E '\b(0x)?[0-9a-fA-F]{64}\b' || true)
         BASE58_MATCHES=$(echo "$STAGED_DIFF" | grep -E '\b[1-9A-HJ-NP-Za-km-z]{87,88}\b' || true)
@@ -29,7 +29,7 @@ if [ "$GITHUB_ACTIONS" != "true" ]; then
         if [ -n "$ALL_MATCHES" ]; then
             echo "⚠️  Possible private key detected in staged changes."
             echo "$ALL_MATCHES"
-            echo "   If this is a non-sensitive value (e.g. tx hash), re-run with: SKIP_PK_CHECK=1 git commit"
+            echo "   If this is a non-sensitive value (e.g. tx hash), re-run with: SKIP_KEY_CHECK=1 git commit"
             exit 1
         fi
     fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -20,11 +20,11 @@ if [ "$GITHUB_ACTIONS" != "true" ]; then
     fi
 
     # Broad private key check on staged diff. May produce false positives — use --no-verify to bypass if intentional.
-    STAGED_DIFF=$(git diff --cached)
-    EVM_MATCHES=$(echo "$STAGED_DIFF"    | grep -nE '\b(0x)?[0-9a-fA-F]{64}\b' || true)
-    BASE58_MATCHES=$(echo "$STAGED_DIFF" | grep -nE '\b[1-9A-HJ-NP-Za-km-z]{87,88}\b' || true)
-    CLI_MATCHES=$(echo "$STAGED_DIFF"    | grep -nE '\[(\s*[0-9]{1,3}\s*,\s*){63}[0-9]{1,3}\s*\]' || true)
-    ALL_MATCHES="${EVM_MATCHES}${BASE58_MATCHES}${CLI_MATCHES}"
+    STAGED_DIFF=$(git diff --cached | awk '/^\+\+\+ b\// { file=substr($0,7) } /^\+[^+]/ { print file ":" $0 }')
+    EVM_MATCHES=$(echo "$STAGED_DIFF"    | grep -E '\b(0x)?[0-9a-fA-F]{64}\b' || true)
+    BASE58_MATCHES=$(echo "$STAGED_DIFF" | grep -E '\b[1-9A-HJ-NP-Za-km-z]{87,88}\b' || true)
+    CLI_MATCHES=$(echo "$STAGED_DIFF"    | grep -E '\[(\s*[0-9]{1,3}\s*,\s*){63}[0-9]{1,3}\s*\]' || true)
+    ALL_MATCHES=$(printf '%s\n%s\n%s' "$EVM_MATCHES" "$BASE58_MATCHES" "$CLI_MATCHES" | sed '/^$/d')
     if [ -n "$ALL_MATCHES" ]; then
         echo "⚠️  Possible private key detected in staged changes."
         echo "$ALL_MATCHES"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -19,17 +19,19 @@ if [ "$GITHUB_ACTIONS" != "true" ]; then
         exit 1
     fi
 
-    # Broad private key check on staged diff. May produce false positives — use --no-verify to bypass if intentional.
-    STAGED_DIFF=$(git diff --cached | awk '/^\+\+\+ b\// { file=substr($0,7) } /^\+[^+]/ { print file ":" $0 }')
-    EVM_MATCHES=$(echo "$STAGED_DIFF"    | grep -E '\b(0x)?[0-9a-fA-F]{64}\b' || true)
-    BASE58_MATCHES=$(echo "$STAGED_DIFF" | grep -E '\b[1-9A-HJ-NP-Za-km-z]{87,88}\b' || true)
-    CLI_MATCHES=$(echo "$STAGED_DIFF"    | grep -E '\[(\s*[0-9]{1,3}\s*,\s*){63}[0-9]{1,3}\s*\]' || true)
-    ALL_MATCHES=$(printf '%s\n%s\n%s' "$EVM_MATCHES" "$BASE58_MATCHES" "$CLI_MATCHES" | sed '/^$/d')
-    if [ -n "$ALL_MATCHES" ]; then
-        echo "⚠️  Possible private key detected in staged changes."
-        echo "$ALL_MATCHES"
-        echo "   If this is a non-sensitive value (e.g. tx hash), re-run with: git commit --no-verify"
-        exit 1
+    # Broad private key check on staged diff. May produce false positives — set SKIP_PK_CHECK=1 to bypass if intentional.
+    if [ "$SKIP_PK_CHECK" != "1" ]; then
+        STAGED_DIFF=$(git diff --cached | awk '/^\+\+\+ b\// { file=substr($0,7) } /^\+[^+]/ { print file ":" $0 }')
+        EVM_MATCHES=$(echo "$STAGED_DIFF"    | grep -E '\b(0x)?[0-9a-fA-F]{64}\b' || true)
+        BASE58_MATCHES=$(echo "$STAGED_DIFF" | grep -E '\b[1-9A-HJ-NP-Za-km-z]{87,88}\b' || true)
+        CLI_MATCHES=$(echo "$STAGED_DIFF"    | grep -E '\[(\s*[0-9]{1,3}\s*,\s*){63}[0-9]{1,3}\s*\]' || true)
+        ALL_MATCHES=$(printf '%s\n%s\n%s' "$EVM_MATCHES" "$BASE58_MATCHES" "$CLI_MATCHES" | sed '/^$/d')
+        if [ -n "$ALL_MATCHES" ]; then
+            echo "⚠️  Possible private key detected in staged changes."
+            echo "$ALL_MATCHES"
+            echo "   If this is a non-sensitive value (e.g. tx hash), re-run with: SKIP_PK_CHECK=1 git commit"
+            exit 1
+        fi
     fi
 fi
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -18,6 +18,19 @@ if [ "$GITHUB_ACTIONS" != "true" ]; then
         echo "Please remove any secrets, credentials, or sensitive information before committing."
         exit 1
     fi
+
+    # Broad private key check on staged diff. May produce false positives — use --no-verify to bypass if intentional.
+    STAGED_DIFF=$(git diff --cached)
+    EVM_MATCHES=$(echo "$STAGED_DIFF"    | grep -nE '\b(0x)?[0-9a-fA-F]{64}\b' || true)
+    BASE58_MATCHES=$(echo "$STAGED_DIFF" | grep -nE '\b[1-9A-HJ-NP-Za-km-z]{87,88}\b' || true)
+    CLI_MATCHES=$(echo "$STAGED_DIFF"    | grep -nE '\[(\s*[0-9]{1,3}\s*,\s*){63}[0-9]{1,3}\s*\]' || true)
+    ALL_MATCHES="${EVM_MATCHES}${BASE58_MATCHES}${CLI_MATCHES}"
+    if [ -n "$ALL_MATCHES" ]; then
+        echo "⚠️  Possible private key detected in staged changes."
+        echo "$ALL_MATCHES"
+        echo "   If this is a non-sensitive value (e.g. tx hash), re-run with: git commit --no-verify"
+        exit 1
+    fi
 fi
 
 pnpm lint-staged --concurrent false


### PR DESCRIPTION
### Description

Added broad private key grep on staged diff in `.husky/pre-commit`. Runs on top of the existing gitleaks check and catches keys that may slip through due to missing context. False positives are expected (e.g. zero-padded ABI-encoded addresses) — bypassable with `SKIP_KEY_CHECK=1 git commit`, which skips only this check while all other hooks (gitleaks, lint-staged, cargo fmt) still run.

This is intentionally not added to gitleaks and only to husky since this should only run locally. If we would add this to gitleaks the pr actions would always fail on the false positives even if the user allowed for example a tx hash with `SKIP_KEY_CHECK=1` locally.

The check scans only added lines (filters out removed and context lines from the diff) and prefixes each match with its source file path for easier diagnosis.

Patterns checked:
- EVM/Cosmos/Starknet hex keys (with or without `0x` prefix)
- Solana Base58 keys
- Solana CLI byte array keypairs

### False positive analysis

Checked the last 100 commits on main — 20 would have triggered. All false positives. Categories:

| Pattern | Examples |
|---|---|
| Zero-padded ABI-encoded addresses | `mainnet_config.json`, warp config YAMLs |
| Well-known test keys | Hardhat default key `0xac0974...` in docs/tests |
| EIP-1967 storage slots | `cast storage` commands in skill docs |
| Solidity storage slot constants | `offchain-fee-quoting` contract constants |
| Starknet addresses | 63-char hex values in starknet SDK tests |
| Dummy/placeholder hex values | `0x1111...`, `0x0000...0001` in tests |

The bypass rate is high enough that developers will routinely need `SKIP_KEY_CHECK=1` for legitimate commits. Future improvements could include excluding test/docs files or filtering zero-heavy strings (ABI-encoded addresses).

### Backward compatibility

Yes

### Testing

Manual