### PR TITLE
feat: add BSC and Solana inventory routes for USDC/eclipsemainnet rebalancer

### DIFF
--- a/.changeset/lifi-chainid-collision-fix.md
+++ b/.changeset/lifi-chainid-collision-fix.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+LiFi chain metadata resolution was fixed for non-EVM chain ID collisions during rebalancer bridge execution.

--- a/typescript/infra/config/environments/mainnet3/rebalancer/USDC/eclipsemainnet-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/USDC/eclipsemainnet-config.yaml
@@ -1,7 +1,7 @@
 warpRouteId: USDC/eclipsemainnet
 inventorySigners:
   ethereum: '0x6056e8E8e5Db30ffa9d721e3D73b3D558011FdA9'
-  sealevel: '5seKh2p3B8Kq9nAE7X4svfX9uLt81wWAiDJuLK1XNgXf'
+  sealevel: '4ZJoMHQPEMkeExtFQLbuh8nB21dxHj741dSo6oJ5BcMo'
 externalBridges:
   lifi:
     integrator: rebalancer
@@ -10,36 +10,45 @@ strategy:
   chains:
     ethereum:
       weighted:
-        weight: 29
+        weight: 27
         tolerance: 5
       bridgeLockTime: 1800
       bridgeMinAcceptedAmount: 3500
       bridge: '0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23'
       override:
+        bsc:
+          executionType: inventory
+          externalBridge: lifi
         solanamainnet:
           executionType: inventory
           externalBridge: lifi
 
     base:
       weighted:
-        weight: 24
+        weight: 22
         tolerance: 5
       bridgeLockTime: 1800
       bridgeMinAcceptedAmount: 3500
       bridge: '0x33e94B6D2ae697c16a750dB7c3d9443622C4405a'
       override:
+        bsc:
+          executionType: inventory
+          externalBridge: lifi
         solanamainnet:
           executionType: inventory
           externalBridge: lifi
 
     arbitrum:
       weighted:
-        weight: 17
+        weight: 16
         tolerance: 5
       bridgeLockTime: 1800
       bridgeMinAcceptedAmount: 3500
       bridge: '0x4c19c653a8419A475d9B6735511cB81C15b8d9b2'
       override:
+        bsc:
+          executionType: inventory
+          externalBridge: lifi
         solanamainnet:
           executionType: inventory
           externalBridge: lifi
@@ -52,6 +61,9 @@ strategy:
       bridgeMinAcceptedAmount: 3500
       bridge: '0x33e94B6D2ae697c16a750dB7c3d9443622C4405a'
       override:
+        bsc:
+          executionType: inventory
+          externalBridge: lifi
         solanamainnet:
           executionType: inventory
           externalBridge: lifi
@@ -64,6 +76,9 @@ strategy:
       bridgeMinAcceptedAmount: 2500
       bridge: '0x33e94B6D2ae697c16a750dB7c3d9443622C4405a'
       override:
+        bsc:
+          executionType: inventory
+          externalBridge: lifi
         solanamainnet:
           executionType: inventory
           externalBridge: lifi
@@ -76,6 +91,9 @@ strategy:
       bridgeMinAcceptedAmount: 3500
       bridge: '0x33e94B6D2ae697c16a750dB7c3d9443622C4405a'
       override:
+        bsc:
+          executionType: inventory
+          externalBridge: lifi
         solanamainnet:
           executionType: inventory
           externalBridge: lifi
@@ -88,9 +106,19 @@ strategy:
       bridgeMinAcceptedAmount: 2500
       bridge: '0x33e94B6D2ae697c16a750dB7c3d9443622C4405a'
       override:
+        bsc:
+          executionType: inventory
+          externalBridge: lifi
         solanamainnet:
           executionType: inventory
           externalBridge: lifi
+
+    bsc:
+      weighted:
+        weight: 5
+        tolerance: 3
+      executionType: inventory
+      externalBridge: lifi
 
     solanamainnet:
       weighted:

--- a/typescript/infra/helm/rebalancer/templates/_helpers.tpl
+++ b/typescript/infra/helm/rebalancer/templates/_helpers.tpl
@@ -88,6 +88,12 @@ The rebalancer container
     value: $(HYP_REBALANCER_KEY)
   - name: HYP_INVENTORY_KEY
     value: $(HYP_INVENTORY_KEY)
+  - name: HYP_INVENTORY_KEY_ETHEREUM
+    value: $(HYP_INVENTORY_KEY_ETHEREUM)
+  {{- if has "sealevel" .Values.hyperlane.inventorySignerProtocols }}
+  - name: HYP_INVENTORY_KEY_SEALEVEL
+    value: $(HYP_INVENTORY_KEY_SEALEVEL)
+  {{- end }}
   - name: COINGECKO_API_KEY
     value: $(COINGECKO_API_KEY)
   - name: REBALANCER_CONFIG_FILE

--- a/typescript/infra/helm/rebalancer/templates/env-var-external-secret.yaml
+++ b/typescript/infra/helm/rebalancer/templates/env-var-external-secret.yaml
@@ -24,6 +24,10 @@ spec:
         # Extract only the privateKey field from the JSON
         HYP_REBALANCER_KEY: {{ print "'{{ $json := .rebalancer_key | fromJson }}{{ $json.privateKey }}'" }}
         HYP_INVENTORY_KEY: {{ print "'{{ $json := .inventory_rebalancer_key | fromJson }}{{ $json.privateKey }}'" }}
+        HYP_INVENTORY_KEY_ETHEREUM: {{ print "'{{ $json := .inventory_rebalancer_key | fromJson }}{{ $json.privateKey }}'" }}
+        {{- if has "sealevel" .Values.hyperlane.inventorySignerProtocols }}
+        HYP_INVENTORY_KEY_SEALEVEL: {{ print "'{{ $json := .inventory_rebalancer_key_sealevel | fromJson }}{{ $json.privateKey }}'" }}
+        {{- end }}
         {{- range .Values.hyperlane.chains }}
         RPC_URL_{{ . | upper | replace "-" "_" }}: {{ printf "'{{ index (.%s_rpcs | fromJson) 0 }}'" . }}
         {{- end }}
@@ -37,6 +41,11 @@ spec:
   - secretKey: inventory_rebalancer_key
     remoteRef:
       key: {{ printf "hyperlane-%s-key-inventoryrebalancer" .Values.hyperlane.runEnv }}
+  {{- if has "sealevel" .Values.hyperlane.inventorySignerProtocols }}
+  - secretKey: inventory_rebalancer_key_sealevel
+    remoteRef:
+      key: {{ printf "hyperlane-%s-key-sealevel-inventoryrebalancer" .Values.hyperlane.runEnv }}
+  {{- end }}
   {{- range .Values.hyperlane.chains }}
   - secretKey: {{ printf "%s_rpcs" . }}
     remoteRef:

--- a/typescript/infra/helm/rebalancer/values.yaml
+++ b/typescript/infra/helm/rebalancer/values.yaml
@@ -11,6 +11,7 @@ hyperlane:
   withMetrics: true
   # Used for fetching private RPC secrets
   chains: []
+  inventorySignerProtocols: []
 nameOverride: ''
 fullnameOverride: ''
 externalSecrets:

--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -37,6 +37,7 @@ export class RebalancerHelmManager extends HelmManager {
 
   private rebalancerConfigContent: string = '';
   private rebalancerChains: string[] = [];
+  private inventorySignerProtocols: string[] = [];
 
   constructor(
     readonly warpRouteId: string,
@@ -84,6 +85,9 @@ export class RebalancerHelmManager extends HelmManager {
       rebalancerConfigFile,
       'utf8',
     );
+    this.inventorySignerProtocols = Object.keys(
+      validationResult.data.inventorySigners ?? {},
+    );
   }
 
   get namespace() {
@@ -109,6 +113,7 @@ export class RebalancerHelmManager extends HelmManager {
         withMetrics: this.withMetrics,
         // Used for fetching private RPC secrets
         chains: this.rebalancerChains,
+        inventorySignerProtocols: this.inventorySignerProtocols,
       },
     };
   }

--- a/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
@@ -688,12 +688,27 @@ describe('LiFiBridge constructor chainMetadataByChainId', function () {
 
   it('should prefer Ethereum metadata for LiFi chainId lookups when non-EVM chainIds collide', () => {
     const bridge = new LiFiBridge(DUPLICATE_CHAIN_ID_CONFIG, testLogger);
+    const quote = createTestQuote(
+      { fromChainId: 1 },
+      {
+        fromChain: 1,
+        toChain: 1151111081099710,
+      },
+    );
 
-    expect((bridge as any).getProtocolTypeForChainId(1)).to.equal(
-      ProtocolType.Ethereum,
-    );
-    expect((bridge as any).getRpcUrlForChainId(1)).to.equal(
-      'https://ethereum-rpc.local',
-    );
+    return bridge
+      .execute(quote, {
+        [ProtocolType.Ethereum]: '0x1234',
+      })
+      .catch((error: unknown) => {
+        const msg = error instanceof Error ? error.message : String(error);
+        expect(
+          isValidationError(msg),
+          `Expected non-validation error but got: ${msg}`,
+        ).to.equal(false);
+        expect(msg).to.not.include('Missing private key');
+        expect(msg).to.not.include('protocol radix');
+        expect(msg.toLowerCase()).to.include('private key');
+      });
   });
 });

--- a/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
@@ -34,6 +34,36 @@ const SOLANA_CHAIN_METADATA_CONFIG: ExternalBridgeConfig = {
   },
 };
 
+const DUPLICATE_CHAIN_ID_CONFIG: ExternalBridgeConfig = {
+  integrator: 'test-rebalancer',
+  chainMetadata: {
+    ethereum: {
+      chainId: 1,
+      protocol: ProtocolType.Ethereum,
+      name: 'ethereum',
+      displayName: 'Ethereum',
+      domainId: 1,
+      rpcUrls: [{ http: 'https://ethereum-rpc.local' }],
+    },
+    radix: {
+      chainId: 1,
+      protocol: ProtocolType.Radix,
+      name: 'radix',
+      displayName: 'Radix',
+      domainId: 1001,
+      rpcUrls: [{ http: 'https://radix-rpc.local' }],
+    },
+    solanamainnet: {
+      chainId: 1399811149,
+      protocol: ProtocolType.Sealevel,
+      name: 'solanamainnet',
+      displayName: 'Solana',
+      domainId: 1399811149,
+      rpcUrls: [{ http: 'https://api.mainnet-beta.solana.com' }],
+    },
+  },
+};
+
 // Use all-digit hex addresses to avoid EIP-55 checksum case mutations
 const TOKEN_ADDR = '0x1234567890123456789012345678901234567890';
 const SENDER_ADDR = '0x9876543210987654321098765432109876543210';
@@ -654,5 +684,16 @@ describe('LiFiBridge constructor chainMetadataByChainId', function () {
       expect(msg).to.include('toToken');
       expect(msg).to.include('does not match requested');
     }
+  });
+
+  it('should prefer Ethereum metadata for LiFi chainId lookups when non-EVM chainIds collide', () => {
+    const bridge = new LiFiBridge(DUPLICATE_CHAIN_ID_CONFIG, testLogger);
+
+    expect((bridge as any).getProtocolTypeForChainId(1)).to.equal(
+      ProtocolType.Ethereum,
+    );
+    expect((bridge as any).getRpcUrlForChainId(1)).to.equal(
+      'https://ethereum-rpc.local',
+    );
   });
 });

--- a/typescript/rebalancer/src/bridges/LiFiBridge.ts
+++ b/typescript/rebalancer/src/bridges/LiFiBridge.ts
@@ -133,21 +133,27 @@ export class LiFiBridge implements IExternalBridge {
   constructor(config: ExternalBridgeConfig, logger: Logger) {
     this.config = config;
     this.logger = logger;
-    // Build chainId -> metadata map for O(1) lookups
+    // Build LiFi chainId -> metadata map for O(1) lookups.
+    // Numeric chainIds are only unique for EVM chains; non-EVM chains can
+    // legitimately collide (e.g. radix and ethereum both use 1), so index
+    // non-EVM chains only through explicit Hyperlane-domain -> LiFi mappings.
     this.chainMetadataByChainId = new Map();
     if (config.chainMetadata) {
+      const metadataByDomainId = new Map<number, ChainMetadata>();
       for (const metadata of Object.values(config.chainMetadata)) {
+        metadataByDomainId.set(metadata.domainId, metadata);
         if (metadata.chainId !== undefined) {
-          this.chainMetadataByChainId.set(Number(metadata.chainId), metadata);
+          if (metadata.protocol === ProtocolType.Ethereum) {
+            this.chainMetadataByChainId.set(Number(metadata.chainId), metadata);
+          }
         }
       }
-      // Also key by LiFi chain IDs so both Hyperlane domains and LiFi IDs resolve to the same metadata.
+      // Also key by LiFi chain IDs so both Hyperlane domains and LiFi IDs
+      // resolve to the same metadata for non-EVM chains like Solana.
       for (const [hyperlaneDomainId, lifiChainId] of Object.entries(
         HYPERLANE_TO_LIFI_CHAIN_IDS,
       )) {
-        const metadata = this.chainMetadataByChainId.get(
-          Number(hyperlaneDomainId),
-        );
+        const metadata = metadataByDomainId.get(Number(hyperlaneDomainId));
         if (metadata !== undefined) {
           this.chainMetadataByChainId.set(Number(lifiChainId), metadata);
         }


### PR DESCRIPTION
## Summary
- add BSC inventory/LiFi routing to the USDC/eclipsemainnet rebalancer config
- wire protocol-specific inventory signer keys through rebalancer Helm values/templates
- fix LiFi source protocol resolution when non-EVM chains share numeric chain IDs