### PR TITLE
test(sdk): cover sealevel cross-collateral warp routing

### DIFF
--- a/.changeset/registry-bump-cli-sdk.md
+++ b/.changeset/registry-bump-cli-sdk.md
@@ -1,0 +1,6 @@
+---
+"@hyperlane-xyz/cli": patch
+"@hyperlane-xyz/sdk": patch
+---
+
+The registry dependency was bumped to 24.3.0 so CLI and SDK consumers pick up tolerant merged-registry overlay reads.

--- a/.changeset/registry-bump-cli-sdk.md
+++ b/.changeset/registry-bump-cli-sdk.md
@@ -1,6 +1,5 @@
 ---
 "@hyperlane-xyz/cli": patch
-"@hyperlane-xyz/sdk": patch
 ---
 
-The registry dependency was bumped to 24.3.0 so CLI and SDK consumers pick up tolerant merged-registry overlay reads.
+The registry dependency was bumped to 24.3.0 so CLI consumers pick up tolerant merged-registry overlay reads.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: ^1.3.0
       version: 1.3.0
     '@hyperlane-xyz/registry':
-      specifier: 23.12.0
-      version: 23.12.0
+      specifier: 24.3.0
+      version: 24.3.0
     '@inquirer/prompts':
       specifier: 3.3.2
       version: 3.3.2
@@ -571,7 +571,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 24.3.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -719,7 +719,7 @@ importers:
         version: link:../rebalancer
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 24.3.0
       '@hyperlane-xyz/relayer':
         specifier: workspace:*
         version: link:../relayer
@@ -1025,7 +1025,7 @@ importers:
     dependencies:
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 24.3.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1137,7 +1137,7 @@ importers:
         version: link:../../solidity
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 24.3.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1246,7 +1246,7 @@ importers:
     dependencies:
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 24.3.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1385,7 +1385,7 @@ importers:
         version: link:../rebalancer
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 24.3.0
       '@hyperlane-xyz/relayer':
         specifier: workspace:*
         version: link:../relayer
@@ -1590,7 +1590,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 24.3.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1840,7 +1840,7 @@ importers:
         version: link:../provider-sdk
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 24.3.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1967,7 +1967,7 @@ importers:
         version: link:../rebalancer
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 24.3.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -2037,7 +2037,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 24.3.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -2455,7 +2455,7 @@ importers:
         version: link:../provider-sdk
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 24.3.0
       '@hyperlane-xyz/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2615,7 +2615,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 24.3.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -2818,7 +2818,7 @@ importers:
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 23.12.0
+        version: 24.3.0
       '@hyperlane-xyz/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -5111,8 +5111,8 @@ packages:
     resolution: {integrity: sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==}
     engines: {node: '>=10.10.0'}
 
-  '@hyperlane-xyz/registry@23.12.0':
-    resolution: {integrity: sha512-KK3N2wC35xZhF8KFHD3awQ/GEPwT4G6Fquwcb3bjXaPPh/JwMRzHfeoyLQeTx2lA4cfSeODkDPRgmkrXDo2JqQ==}
+  '@hyperlane-xyz/registry@24.3.0':
+    resolution: {integrity: sha512-nd0ndJf7HmakuFCwm0gKOZoVXQukEaVponXecjCuIGM8apGA0M9AhhBbsRD2f+JjKmOcZ2vehQaQfd270tGBXQ==}
     engines: {node: '>=24'}
 
   '@img/sharp-darwin-arm64@0.33.5':
@@ -21305,7 +21305,7 @@ snapshots:
 
   '@humanwhocodes/momoa@2.0.4': {}
 
-  '@hyperlane-xyz/registry@23.12.0':
+  '@hyperlane-xyz/registry@24.3.0':
     dependencies:
       jszip: 3.10.1
       yaml: 2.4.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -79,7 +79,7 @@ catalog:
   '@aws-sdk/client-kms': ^3.577.0
 
   # Registry
-  '@hyperlane-xyz/registry': 23.12.0
+  '@hyperlane-xyz/registry': 24.3.0
 
   # CLI prompts
   '@inquirer/prompts': 3.3.2

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -875,6 +875,73 @@ describe('WarpCore', () => {
     }
   });
 
+  it('Treats Sealevel cross-collateral to EVM cross-collateral as transferRemoteTo route', async () => {
+    const sealevelCrossCollateral = new Token({
+      chainName: testSealevelChain.name,
+      standard: TokenStandard.SealevelHypCrossCollateral,
+      addressOrDenom: '4UMNyNWW75zo69hxoJaRX5iXNUa5FdRPZZa9vDVCiESg',
+      collateralAddressOrDenom: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      decimals: 6,
+      symbol: 'USDC',
+      name: 'USDC',
+    });
+    const evmCrossCollateral = new Token({
+      chainName: test2.name,
+      standard: TokenStandard.EvmHypCrossCollateralRouter,
+      addressOrDenom: '0x8358D8291e3bEDb04804975eEa0fe9fe0fAfB147',
+      collateralAddressOrDenom: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      decimals: 6,
+      symbol: 'USDC',
+      name: 'USDC',
+    });
+    sealevelCrossCollateral.addConnection({ token: evmCrossCollateral });
+    evmCrossCollateral.addConnection({ token: sealevelCrossCollateral });
+
+    const crossCollateralWarpCore = new WarpCore(multiProvider, [
+      sealevelCrossCollateral,
+      evmCrossCollateral,
+    ]);
+    const quoteTransferRemoteToGas = sinon.stub().resolves({
+      igpQuote: { amount: 1n },
+      tokenFeeQuote: { amount: 0n },
+    });
+    const populateTransferRemoteToTx = sinon.stub().resolves({});
+    const populateTransferRemoteTx = sinon.stub().resolves({});
+    const originAdapterStub = sinon
+      .stub(sealevelCrossCollateral, 'getHypAdapter')
+      .returns({
+        quoteTransferRemoteToGas,
+        populateTransferRemoteToTx,
+        populateTransferRemoteTx,
+        isApproveRequired: sinon.stub().resolves(false),
+        isRevokeApprovalRequired: sinon.stub().resolves(false),
+      } as any);
+
+    try {
+      expect(
+        (crossCollateralWarpCore as any).isCrossCollateralTransfer(
+          sealevelCrossCollateral,
+          evmCrossCollateral,
+        ),
+      ).to.equal(true);
+
+      const result = await crossCollateralWarpCore.getTransferRemoteTxs({
+        originTokenAmount: sealevelCrossCollateral.amount(TRANSFER_AMOUNT),
+        destination: test2.name,
+        sender: MOCK_ADDRESS,
+        recipient: MOCK_ADDRESS,
+        destinationToken: evmCrossCollateral,
+      });
+
+      expect(result).to.have.length(1);
+      expect(result[0].category).to.equal(WarpTxCategory.Transfer);
+      sinon.assert.calledOnce(populateTransferRemoteToTx);
+      sinon.assert.notCalled(populateTransferRemoteTx);
+    } finally {
+      originAdapterStub.restore();
+    }
+  });
+
   it('Converts destination minimum transfer amount into origin decimals correctly', async () => {
     const destinationAdapterStub = sinon
       .stub(sealevelHypSynthetic, 'getAdapter')


### PR DESCRIPTION
## Summary
- add a WarpCore regression test for SealevelHypCrossCollateral -> EvmHypCrossCollateralRouter routes
- assert WarpCore classifies the route as cross-collateral
- assert getTransferRemoteTxs uses the transferRemoteTo path instead of the generic transferRemote path

## Testing
- pnpm -C typescript/sdk exec mocha --config .mocharc.json './src/warp/WarpCore.test.ts' --grep "Treats Sealevel cross-collateral to EVM cross-collateral as transferRemoteTo route" --exit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
