### PR TITLE
test(sdk): cover sealevel cross-collateral warp route selection

### DIFF
--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -1144,6 +1144,73 @@ describe('WarpCore', () => {
     }
   });
 
+  it('Treats Sealevel cross-collateral to EVM cross-collateral as transferRemoteTo route', async () => {
+    const sealevelCrossCollateral = new Token({
+      chainName: testSealevelChain.name,
+      standard: TokenStandard.SealevelHypCrossCollateral,
+      addressOrDenom: '4UMNyNWW75zo69hxoJaRX5iXNUa5FdRPZZa9vDVCiESg',
+      collateralAddressOrDenom: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      decimals: 6,
+      symbol: 'USDC',
+      name: 'USDC',
+    });
+    const evmCrossCollateral = new Token({
+      chainName: test2.name,
+      standard: TokenStandard.EvmHypCrossCollateralRouter,
+      addressOrDenom: '0x8358D8291e3bEDb04804975eEa0fe9fe0fAfB147',
+      collateralAddressOrDenom: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      decimals: 6,
+      symbol: 'USDC',
+      name: 'USDC',
+    });
+    sealevelCrossCollateral.addConnection({ token: evmCrossCollateral });
+    evmCrossCollateral.addConnection({ token: sealevelCrossCollateral });
+
+    const crossCollateralWarpCore = new WarpCore(multiProvider, [
+      sealevelCrossCollateral,
+      evmCrossCollateral,
+    ]);
+    const quoteTransferRemoteToGas = sinon.stub().resolves({
+      igpQuote: { amount: 1n },
+      tokenFeeQuote: { amount: 0n },
+    });
+    const populateTransferRemoteToTx = sinon.stub().resolves({});
+    const populateTransferRemoteTx = sinon.stub().resolves({});
+    const originAdapterStub = sinon
+      .stub(sealevelCrossCollateral, 'getHypAdapter')
+      .returns({
+        quoteTransferRemoteToGas,
+        populateTransferRemoteToTx,
+        populateTransferRemoteTx,
+        isApproveRequired: sinon.stub().resolves(false),
+        isRevokeApprovalRequired: sinon.stub().resolves(false),
+      } as any);
+
+    try {
+      expect(
+        (crossCollateralWarpCore as any).isCrossCollateralTransfer(
+          sealevelCrossCollateral,
+          evmCrossCollateral,
+        ),
+      ).to.equal(true);
+
+      const result = await crossCollateralWarpCore.getTransferRemoteTxs({
+        originTokenAmount: sealevelCrossCollateral.amount(TRANSFER_AMOUNT),
+        destination: test2.name,
+        sender: MOCK_ADDRESS,
+        recipient: MOCK_ADDRESS,
+        destinationToken: evmCrossCollateral,
+      });
+
+      expect(result).to.have.length(1);
+      expect(result[0].category).to.equal(WarpTxCategory.Transfer);
+      sinon.assert.calledOnce(populateTransferRemoteToTx);
+      sinon.assert.notCalled(populateTransferRemoteTx);
+    } finally {
+      originAdapterStub.restore();
+    }
+  });
+
   it('Converts destination minimum transfer amount into origin decimals correctly', async () => {
     const destinationAdapterStub = sinon
       .stub(sealevelHypSynthetic, 'getAdapter')


### PR DESCRIPTION
## Summary
- add a WarpCore regression test for Sealevel cross-collateral -> EVM cross-collateral transfers
- assert the route is treated as cross-collateral and uses transferRemoteTo rather than generic transferRemote
- lock in the source behavior already present from #8446 so it does not regress in a future release

## Testing
- pnpm -C typescript/sdk exec mocha --config .mocharc.json ./src/warp/WarpCore.test.ts --grep "Sealevel cross-collateral to EVM cross-collateral" --exit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
