### PR TITLE
fix(relayer): refresh ForwardBackwardIterator frontier when DB highest_seen advances

### DIFF
--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -109,14 +109,69 @@ impl ForwardBackwardIterator {
                     return Ok(Some(low_nonce_message));
                 }
 
-                // If both iterators give us unindexed messages, there are no messages at the moment
-                (MessageStatus::Unindexed, MessageStatus::Unindexed) => return Ok(None),
+                // If both iterators give us unindexed messages, there are no messages
+                // at the current iterator position. Before giving up, re-read the DB's
+                // highest seen nonce: ContractSync may have indexed new messages while
+                // our iterator was pinned at its cached frontier (this happens on any
+                // relayer restart before a direction's first non-zero nonce was stored,
+                // and after RocksDB wipes combined with `index.from` past the old cursor).
+                // If the DB has advanced, jump the iterator forward and retry.
+                (MessageStatus::Unindexed, MessageStatus::Unindexed) => {
+                    if !self.refresh_from_db_if_lagging() {
+                        return Ok(None);
+                    }
+                }
             }
             // This loop may iterate through millions of processed messages, blocking the runtime.
             // So, to avoid starving other futures in this task, yield to the runtime
             // on each iteration
             tokio::task::yield_now().await;
         }
+    }
+
+    /// Re-reads `retrieve_highest_seen_message_nonce` from the DB. If the DB's
+    /// highest stored nonce is greater than the iterator's current high-water
+    /// mark, advances both iterators so subsequent probes reach the new
+    /// frontier without requiring a process restart.
+    ///
+    /// Without this, the `ForwardBackwardIterator` captures `highest_seen`
+    /// exactly once at construction. Any nonces written to the DB by
+    /// `ContractSync` after that point go unseen: the forward iterator keeps
+    /// probing the same stale nonce (which is `Unindexed`) and the loop
+    /// returns `Ok(None)` forever — the `message_processor` / Lander pipeline
+    /// receives no work.
+    ///
+    /// Returns `true` if the iterators were advanced, `false` otherwise.
+    fn refresh_from_db_if_lagging(&mut self) -> bool {
+        let db = self.high_nonce_iter.db.clone();
+        let Some(db_highest) = db.retrieve_highest_seen_message_nonce().ok().flatten() else {
+            return false;
+        };
+        let current_high = self.high_nonce_iter.nonce.unwrap_or_default();
+        if db_highest <= current_high {
+            return false;
+        }
+        debug!(
+            db_highest,
+            current_high,
+            domain = ?self._domain,
+            "DB highest_seen_message_nonce is ahead of the loader; jumping iterator forward"
+        );
+        self.high_nonce_iter.nonce = Some(db_highest);
+        // Seed the backward scan just below the new frontier so any messages
+        // between the loader's old position and `db_highest` are still
+        // picked up. Leave the backward iterator alone if it has already
+        // progressed past this point (i.e. its nonce is lower than the new
+        // target).
+        let target_low = db_highest.saturating_sub(1);
+        let should_advance_low = match self.low_nonce_iter.nonce {
+            Some(n) => n < target_low,
+            None => true,
+        };
+        if should_advance_low {
+            self.low_nonce_iter.nonce = Some(target_low);
+        }
+        true
     }
 }
 

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -1,3 +1,4 @@
+use std::sync::Mutex;
 use std::time::Instant;
 
 use prometheus::IntCounterVec;
@@ -301,4 +302,116 @@ async fn test_forward_backward_iterator() {
         forward_backward_iterator.high_nonce_iter.nonce,
         Some(MAX_ONCHAIN_NONCE + 1)
     );
+}
+
+/// Regression for the `MessageDbLoader` nonce-cache bug (SBP-371 / PRMX
+/// Warp Route 2026-04-18): `ForwardBackwardIterator::new` reads
+/// `retrieve_highest_seen_message_nonce` exactly once. When the relayer
+/// starts against an empty DB (e.g. after a RocksDB wipe, or before the
+/// first message for a direction has been indexed), the forward iterator is
+/// pinned at `Some(0)` forever. Any messages `ContractSync` later writes to
+/// the DB are never surfaced to the processor, even though they exist in
+/// RocksDB and show up in `hyperlane_last_known_message_nonce`.
+///
+/// The fix in `refresh_from_db_if_lagging` re-reads the DB's highest nonce
+/// when both iterators hit `Unindexed`, and jumps the forward (and, if it
+/// would otherwise stay behind, backward) iterator forward.
+///
+/// This simulates the PRMX scenario where `index.from` cursored past low
+/// nonces after a RocksDB wipe: the first message `ContractSync` actually
+/// stores has nonce 5, not nonce 0. With the pre-fix behaviour the forward
+/// iterator probes nonce 0 (not present → `Unindexed`) and the backward
+/// iterator has `None` (→ `Unindexed`), so `try_get_next_message` returns
+/// `None` indefinitely — that's what caused the 4+ hour stall on
+/// 2026-04-18 and forced a `docker restart` to rebuild the iterator.
+#[tokio::test]
+async fn db_loader_jumps_to_new_high_nonce_after_empty_start() {
+    let mut mock_db = MockDb::new();
+
+    // Shared DB highest-seen-nonce state; flipped by the test body between
+    // loader calls to simulate `ContractSync` writing a new message.
+    let db_highest: Arc<Mutex<Option<u32>>> = Arc::new(Mutex::new(None));
+    let db_highest_for_nonce = db_highest.clone();
+    let db_highest_for_msgs = db_highest.clone();
+
+    mock_db
+        .expect_domain()
+        .return_const(dummy_domain(0, "dummy_domain"));
+
+    mock_db
+        .expect_retrieve_highest_seen_message_nonce()
+        .returning(move || Ok(*db_highest_for_nonce.lock().unwrap()));
+
+    // Simulates `index.from` starting past low nonces: only the exact
+    // highest-seen nonce is present in the DB. Nonces below it were never
+    // indexed and will never be indexed (for this test).
+    mock_db
+        .expect_retrieve_message_by_nonce()
+        .returning(move |nonce| {
+            let highest = *db_highest_for_msgs.lock().unwrap();
+            match highest {
+                Some(h) if nonce == h => Ok(Some(dummy_hyperlane_message(
+                    &dummy_domain(1, "dummy_domain"),
+                    nonce,
+                ))),
+                _ => Ok(None),
+            }
+        });
+
+    mock_db
+        .expect_retrieve_processed_by_nonce()
+        .returning(|_| Ok(Some(false)));
+
+    let dummy_metrics = dummy_message_loader_metrics();
+    let db = Arc::new(mock_db);
+
+    let mut iter = ForwardBackwardIterator::new(db.clone());
+
+    // Empty DB at construction: highest_seen is None, so the forward
+    // iterator defaults to `Some(0)` via `unwrap_or_default`, and the
+    // backward iterator at `None` (after one `iterate()` on the Low
+    // direction with an initial `None`, which is a no-op).
+    assert_eq!(iter.high_nonce_iter.nonce, Some(0));
+    assert_eq!(iter.low_nonce_iter.nonce, None);
+
+    // Nothing indexed yet → both iterators report `Unindexed`, the refresh
+    // finds no new frontier (db_highest still None), loader correctly
+    // returns None.
+    let first = iter
+        .try_get_next_message(&dummy_metrics)
+        .await
+        .expect("try_get_next_message should not error on empty DB");
+    assert!(
+        first.is_none(),
+        "expected None when DB has no indexed messages"
+    );
+
+    // Simulate ContractSync indexing message with nonce 5 (and updating
+    // highest_seen to 5) *after* the loader was constructed. Nonces 0..4
+    // remain absent from the DB — this mirrors post-wipe `index.from`
+    // behaviour where low nonces are skipped entirely.
+    *db_highest.lock().unwrap() = Some(5);
+
+    // Without `refresh_from_db_if_lagging`, this call stays at nonce 0
+    // (probe returns None), the backward iterator is `None`, both hit
+    // `Unindexed`, and the loader returns `None` forever until restart.
+    // With the fix, the refresh detects the DB frontier has advanced to 5,
+    // jumps the forward iterator to 5, finds the message, and returns it.
+    let caught_up = iter
+        .try_get_next_message(&dummy_metrics)
+        .await
+        .expect("try_get_next_message should not error after DB frontier advances")
+        .expect("iterator must catch up to the DB's new highest nonce without a restart");
+    assert_eq!(
+        caught_up.nonce, 5,
+        "expected the forward iterator to jump to the new DB frontier (nonce 5)"
+    );
+
+    // The forward iterator should have advanced past the delivered nonce
+    // so the next tick probes nonce 6, not nonce 5 again.
+    assert_eq!(iter.high_nonce_iter.nonce, Some(6));
+    // The backward iterator should now be seeded just below the new
+    // frontier so any gaps between the old (0) and new (5) positions can
+    // still be picked up on subsequent ticks.
+    assert_eq!(iter.low_nonce_iter.nonce, Some(4));
 }


### PR DESCRIPTION
## Summary

`ForwardBackwardIterator::new` reads `retrieve_highest_seen_message_nonce` exactly once at construction ([db_loader.rs#L57](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/rust/main/agents/relayer/src/msg/db_loader.rs#L57)). When the relayer starts against an empty DB — on first boot before a direction has ever indexed a non-zero nonce, or after a RocksDB wipe combined with `index.from` cursoring past the old position — the forward iterator is pinned at `Some(0)` forever. Any messages `ContractSync` later writes to the DB are never surfaced to `message_processor`: the forward probe keeps returning `Unindexed` at the stale nonce, the backward iterator is `None`, and `try_get_next_message` returns `Ok(None)` indefinitely. Only a process restart (which rebuilds the iterator) recovers.

This PR detects the stuck state in the `(Unindexed, Unindexed)` arm of `try_get_next_message` and re-reads `retrieve_highest_seen_message_nonce` from the DB. If the DB frontier is ahead of the iterator's cached position, both iterators jump forward (the backward one only if it would otherwise stay behind the new frontier) and the loop retries.

## Observed symptom

Observed on a Warp Route deployment (`HypERC20Collateral` on Base Sepolia ↔ `HypERC20Synthetic` on a Substrate-EVM chain) on 2026-04-18:

- `hyperlane_last_known_message_nonce{domain="basesepolia"}` advanced correctly to 91815 as `ContractSync` indexed two new messages.
- `/list_operations` returned empty for 4+ hours; no prepare/submit spans appeared in the relayer logs for those nonces.
- `/messages?destination_domain=...` and the `storage` / `retrieve_message_by_nonce` path confirmed the messages were present in RocksDB.
- `docker restart` on the relayer container delivered both messages within ~30s of coming back up.
- The reverse direction exhibited the identical symptom later the same day and required a second restart.

The restart works because `ForwardBackwardIterator::new` re-reads the (now-populated) `highest_seen_message_nonce` and initialises to the correct frontier — which is exactly what this patch does at runtime without requiring a restart.

## Fix

- New method `ForwardBackwardIterator::refresh_from_db_if_lagging()` that re-reads `retrieve_highest_seen_message_nonce` and advances both iterators when the DB frontier is ahead of the loader's cache.
- Called from the `(MessageStatus::Unindexed, MessageStatus::Unindexed)` match arm in `try_get_next_message`. If refresh advances the iterator, the outer loop retries; otherwise, behaviour is unchanged (returns `Ok(None)`).
- The backward iterator is only advanced if it would otherwise stay behind the new frontier, preserving the existing backward-scan semantics.

## Test coverage

Regression test `db_loader_jumps_to_new_high_nonce_after_empty_start` in `rust/main/agents/relayer/src/msg/db_loader/tests.rs`:

1. Construct loader against an empty mock DB → `high_nonce_iter.nonce == Some(0)`, `low_nonce_iter.nonce == None`.
2. First `try_get_next_message` returns `Ok(None)` (DB still empty; refresh is a no-op).
3. Simulate `ContractSync` writing nonce 5 and updating `highest_seen_message_nonce` to `Some(5)`. Nonces 0..4 remain absent (mirrors post-wipe `index.from` behaviour).
4. Second `try_get_next_message` must return the nonce-5 message without a process restart.

Verified the test fails against pre-patch `HEAD` (panic: \"iterator must catch up to the DB's new highest nonce without a restart\") and passes with the patch applied.

```
cargo test -p relayer --lib db_loader
3 passed; 0 failed
```

## Test plan

- [x] `cargo check -p relayer --tests` clean
- [x] Existing `test_forward_backward_iterator` and `test_full_pending_message_persistence_flow` still pass
- [x] New regression test fails without the patch, passes with it
- [ ] Live verification on Base Sepolia ↔ Substrate-EVM Warp Route (in progress on my infra — happy to attach logs when it completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)