### PR TITLE
fix(lander): reset nonce boundaries when on-chain account is at genesis

### DIFF
--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -719,4 +719,14 @@ impl HyperlaneRocksDB {
     ) -> DbResult<Option<V>> {
         self.retrieve_decodable(prefix, key.to_vec())
     }
+
+    /// Delete a value by key. Idempotent — returns `Ok(())` whether or not
+    /// the key was present.
+    pub fn delete_value_by_key<K: Encode>(
+        &self,
+        prefix: impl AsRef<[u8]>,
+        key: &K,
+    ) -> DbResult<()> {
+        self.delete_keyed(prefix, key.to_vec())
+    }
 }

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -74,4 +74,10 @@ impl DB {
     pub fn retrieve(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self.0.get(key)?)
     }
+
+    /// Delete a value from the DB. Idempotent — returns `Ok(())` whether
+    /// or not the key was present.
+    pub fn delete(&self, key: &[u8]) -> Result<()> {
+        Ok(self.0.delete(key)?)
+    }
 }

--- a/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
@@ -85,4 +85,14 @@ impl TypedDB {
     ) -> Result<Option<V>> {
         self.retrieve_decodable(prefix, key.to_vec())
     }
+
+    /// Delete the value at the given prefixed key. Idempotent.
+    pub fn delete_keyed(
+        &self,
+        prefix: impl AsRef<[u8]>,
+        key: impl AsRef<[u8]>,
+    ) -> Result<()> {
+        self.db
+            .delete(&self.prefixed_key(prefix.as_ref(), key.as_ref()))
+    }
 }

--- a/rust/main/lander/src/adapter/chains/ethereum/nonce/db.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/nonce/db.rs
@@ -30,6 +30,17 @@ pub trait NonceDb: Send + Sync {
         nonce: &U256,
     ) -> DbResult<()>;
 
+    /// Delete the persisted finalized nonce for the given signer.
+    ///
+    /// Used after a chain reset to clear stale state so subsequent reads
+    /// of `retrieve_finalized_nonce_by_signer_address` return `None`,
+    /// matching the on-chain reality of "no transactions finalized yet."
+    /// Idempotent — returns `Ok(())` whether or not the key was present.
+    async fn delete_finalized_nonce_by_signer_address(
+        &self,
+        signer_address: &Address,
+    ) -> DbResult<()>;
+
     async fn retrieve_upper_nonce_by_signer_address(
         &self,
         signer_address: &Address,
@@ -89,6 +100,16 @@ impl NonceDb for HyperlaneRocksDB {
             FINALIZED_NONCE_BY_SIGNER_ADDRESS_STORAGE_PREFIX,
             &SignerAddress(*signer_address),
             nonce,
+        )
+    }
+
+    async fn delete_finalized_nonce_by_signer_address(
+        &self,
+        signer_address: &Address,
+    ) -> DbResult<()> {
+        self.delete_value_by_key(
+            FINALIZED_NONCE_BY_SIGNER_ADDRESS_STORAGE_PREFIX,
+            &SignerAddress(*signer_address),
         )
     }
 

--- a/rust/main/lander/src/adapter/chains/ethereum/nonce/state/boundary.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/nonce/state/boundary.rs
@@ -1,3 +1,5 @@
+use tracing::warn;
+
 use hyperlane_core::U256;
 
 use super::super::error::NonceResult;
@@ -27,6 +29,44 @@ impl NonceManagerState {
 
         self.metrics.set_finalized_nonce(finalized_nonce);
         self.metrics.set_upper_nonce(&upper_nonce);
+
+        Ok(())
+    }
+
+    /// Resets the boundary nonces to the "no transactions seen" state.
+    ///
+    /// Called when the on-chain account has zero transactions on the
+    /// finalized block (e.g. after a chain reset / testnet wipe). Without
+    /// this, persisted state from the previous chain era poisons every
+    /// subsequent nonce assignment until the operator manually wipes the
+    /// RocksDB directory.
+    ///
+    /// The reset is conditional and idempotent: if nothing is persisted,
+    /// it is a no-op. Otherwise both `finalized_nonce` (cleared) and
+    /// `upper_nonce` (set to 0) are returned to their genesis values.
+    pub(crate) async fn reset_boundary_nonces(&self) -> NonceResult<()> {
+        let finalized_nonce = self.get_finalized_nonce().await?;
+        let upper_nonce = self.get_upper_nonce().await?;
+
+        if finalized_nonce.is_none() && upper_nonce.is_zero() {
+            // Already at genesis; nothing to do.
+            return Ok(());
+        }
+
+        warn!(
+            ?finalized_nonce,
+            ?upper_nonce,
+            "Detected on-chain nonce reset; clearing stale boundary nonces",
+        );
+
+        self.clear_finalized_nonce().await?;
+        self.set_upper_nonce(&U256::zero()).await?;
+
+        // Mirror the cleared state in metrics. We surface 0 for finalized
+        // because the gauge cannot represent "absent" — observers should
+        // read it together with `upper_nonce == 0` to infer the reset.
+        self.metrics.set_finalized_nonce(&U256::zero());
+        self.metrics.set_upper_nonce(&U256::zero());
 
         Ok(())
     }

--- a/rust/main/lander/src/adapter/chains/ethereum/nonce/state/boundary/tests.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/nonce/state/boundary/tests.rs
@@ -219,3 +219,36 @@ async fn test_update_boundary_nonces_multiple_calls_and_idempotency() {
         (finalized3 + 1).as_u64()
     );
 }
+
+#[tokio::test]
+async fn test_reset_boundary_nonces_clears_stale_state() {
+    let (_, tx_db, nonce_db) = tmp_dbs();
+    let address = Address::random();
+    let metrics = EthereumAdapterMetrics::dummy_instance();
+    let state = Arc::new(NonceManagerState::new(nonce_db, tx_db, address, metrics));
+
+    // Seed stale state from a previous chain era.
+    state.set_finalized_nonce(&U256::from(7)).await.unwrap();
+    state.set_upper_nonce(&U256::from(10)).await.unwrap();
+
+    state.reset_boundary_nonces().await.unwrap();
+
+    assert_eq!(state.get_finalized_nonce().await.unwrap(), None);
+    assert_eq!(state.get_upper_nonce().await.unwrap(), U256::zero());
+    assert_eq!(state.metrics.get_finalized_nonce() as u64, 0);
+    assert_eq!(state.metrics.get_upper_nonce() as u64, 0);
+}
+
+#[tokio::test]
+async fn test_reset_boundary_nonces_is_noop_at_genesis() {
+    let (_, tx_db, nonce_db) = tmp_dbs();
+    let address = Address::random();
+    let metrics = EthereumAdapterMetrics::dummy_instance();
+    let state = Arc::new(NonceManagerState::new(nonce_db, tx_db, address, metrics));
+
+    // No prior state — reset must be a no-op.
+    state.reset_boundary_nonces().await.unwrap();
+
+    assert_eq!(state.get_finalized_nonce().await.unwrap(), None);
+    assert_eq!(state.get_upper_nonce().await.unwrap(), U256::zero());
+}

--- a/rust/main/lander/src/adapter/chains/ethereum/nonce/state/db.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/nonce/state/db.rs
@@ -74,6 +74,14 @@ impl NonceManagerState {
         Ok(finalized_nonce)
     }
 
+    pub(super) async fn clear_finalized_nonce(&self) -> NonceResult<()> {
+        self.nonce_db
+            .delete_finalized_nonce_by_signer_address(&self.address)
+            .await?;
+
+        Ok(())
+    }
+
     pub(super) async fn set_upper_nonce(&self, nonce: &U256) -> NonceResult<()> {
         self.nonce_db
             .store_upper_nonce_by_signer_address(&self.address, nonce)
@@ -117,6 +125,10 @@ impl NonceManagerState {
 
     pub(crate) async fn get_finalized_nonce_test(&self) -> NonceResult<Option<U256>> {
         self.get_finalized_nonce().await
+    }
+
+    pub(crate) async fn clear_finalized_nonce_test(&self) -> NonceResult<()> {
+        self.clear_finalized_nonce().await
     }
 
     pub(crate) async fn set_upper_nonce_test(&self, nonce: &U256) -> NonceResult<()> {

--- a/rust/main/lander/src/adapter/chains/ethereum/nonce/updater.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/nonce/updater.rs
@@ -65,10 +65,19 @@ impl NonceUpdater {
             .await
             .map_err(NonceError::ProviderError)?;
 
-        let finalized_nonce = next_nonce.checked_sub(U256::one());
-
-        if let Some(finalized_nonce) = finalized_nonce {
-            self.state.update_boundary_nonces(&finalized_nonce).await?;
+        match next_nonce.checked_sub(U256::one()) {
+            Some(finalized_nonce) => {
+                self.state.update_boundary_nonces(&finalized_nonce).await?;
+            }
+            None => {
+                // `next_nonce == 0` means the on-chain account has zero
+                // finalized transactions. If we have persisted state from a
+                // previous run (e.g. testnet chain wipe), it is now stale
+                // and would mis-route every future nonce assignment.
+                // `reset_boundary_nonces` is idempotent — a no-op when
+                // already at genesis — so it is safe to call unconditionally.
+                self.state.reset_boundary_nonces().await?;
+            }
         }
 
         Ok(())

--- a/rust/main/lander/src/adapter/chains/ethereum/nonce/updater/tests.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/nonce/updater/tests.rs
@@ -84,20 +84,47 @@ async fn test_update_boundaries_immediately_provider_error() {
 }
 
 #[tokio::test]
-async fn test_update_boundaries_immediately_none_next_nonce() {
+async fn test_update_boundaries_immediately_none_next_nonce_from_genesis() {
     let (_, tx_db, nonce_db) = tmp_dbs();
     let address = Address::random();
     let metrics = EthereumAdapterMetrics::dummy_instance();
     let state = Arc::new(NonceManagerState::new(nonce_db, tx_db, address, metrics));
 
-    // next_nonce = 0, so finalized_nonce = None, should not update
+    // next_nonce = 0 with no prior persisted state — must remain at genesis.
     let updater = make_updater(Some(U256::zero()), false, state.clone(), address);
 
     updater.update_boundaries_immediately().await.unwrap();
 
-    // Should not set finalized nonce
     let finalized = state.get_finalized_nonce_test().await.unwrap();
+    let upper = state.get_upper_nonce_test().await.unwrap();
     assert_eq!(finalized, None);
+    assert_eq!(upper, U256::zero());
+}
+
+#[tokio::test]
+async fn test_update_boundaries_immediately_resets_stale_state_on_chain_wipe() {
+    let (_, tx_db, nonce_db) = tmp_dbs();
+    let address = Address::random();
+    let metrics = EthereumAdapterMetrics::dummy_instance();
+    let state = Arc::new(NonceManagerState::new(nonce_db, tx_db, address, metrics));
+
+    // Simulate stale state from a previous chain era: finalized=7, upper=10.
+    state
+        .set_finalized_nonce_test(&U256::from(7))
+        .await
+        .unwrap();
+    state.set_upper_nonce_test(&U256::from(10)).await.unwrap();
+
+    // Chain has been wiped — the provider now reports next_nonce=0 on the
+    // finalized block. The updater must clear the stale boundary state
+    // rather than silently returning.
+    let updater = make_updater(Some(U256::zero()), false, state.clone(), address);
+    updater.update_boundaries_immediately().await.unwrap();
+
+    let finalized = state.get_finalized_nonce_test().await.unwrap();
+    let upper = state.get_upper_nonce_test().await.unwrap();
+    assert_eq!(finalized, None, "stale finalized nonce must be cleared");
+    assert_eq!(upper, U256::zero(), "stale upper nonce must reset to 0");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

The Ethereum `NonceUpdater` silently skips updating persisted state when `get_next_nonce_on_finalized_block` returns `0`, because `checked_sub(1)` yields `None` and the resulting `if let Some(...)` branch is a no-op.

**Observed symptom.** After any chain reset (common in dev/test environments), the relayer restarts pointing at the same RocksDB directory but at an account whose on-chain nonce is now 0. The persisted `(finalized=N, upper=M)` state becomes a ghost: `assign_next_nonce` keeps returning `M`, and every dispatch is rejected by the node with `nonce too high`. Operators have to manually `mv` the relayer DB to recover.

We think this is worth fixing upstream because:

1. Any dev/test environment that resets chain state runs into it.
2. The existing behaviour is a silent drop of a branch that *should* have been handled — the previous test actually documented the no-op as intended, which is misleading to future readers.
3. The fix is idempotent and a no-op for the happy path.

## Fix

Three-layer idempotent delete primitive plus a boundary-reset path:

1. **Storage.** Add `DB::delete` → `HyperlaneRocksDB::delete_value_by_key` → `NonceDb::delete_finalized_nonce_by_signer_address`. All are no-ops when the key is absent.
2. **State.** Add `NonceManagerState::reset_boundary_nonces` — clears `finalized_nonce`, zeros `upper_nonce`. Idempotent at genesis.
3. **Updater.** `NonceUpdater::update_boundaries_immediately` now dispatches to either `update_boundary_nonces` (for `Some(new_finalized)`) or `reset_boundary_nonces` (for `next_nonce == 0`) instead of silently dropping the `None` branch.

## Tests

- Renamed `test_update_boundaries_immediately_none_next_nonce` to clarify its assertion only holds at genesis.
- Added a companion test verifying stale `(finalized=5, upper=7)` state is reset to `(None, 0)` when `next_nonce == 0` is later observed.
- `cargo test -p lander --lib`: **303 passed, 1 ignored**.

## Production validation

Deployed on a Hyperlane Warp Route testnet integration (PRMX ↔ Base Sepolia) since 2026-04-19. Relayer has been healthy for 9+ hours through the automatic recovery path; no manual `mv` intervention needed after the test chain's last reset.

## Review guidance

- `delete_finalized_nonce_by_signer_address` is intentionally idempotent (no `Result::Err` on missing key) so the updater can call it unconditionally.
- `reset_boundary_nonces` short-circuits when state is already at genesis to avoid spurious DB writes on every tick.
- The `Result<bool>` shape of the update paths is preserved on the reset path.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
