### PR TITLE
fix(rebalancer): align bridge execution with planned quote mode

### DIFF
--- a/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
@@ -557,6 +557,49 @@ describe('LiFiBridge.quote() input validation', function () {
   });
 });
 
+describe('LiFiBridge.quote() routing policy', function () {
+  let bridge: LiFiBridge;
+
+  beforeEach(() => {
+    bridge = new LiFiBridge(BRIDGE_CONFIG, testLogger);
+  });
+
+  it('should use RECOMMENDED order for reverse toAmount quotes', async () => {
+    const originalFetch = globalThis.fetch;
+    let requestUrl = '';
+
+    globalThis.fetch = (async (input: URL | RequestInfo) => {
+      requestUrl = String(input);
+      return {
+        ok: true,
+        json: async () =>
+          createLiFiStep({
+            toChainId: 1151111081099710,
+            toAmount: '5000000000',
+          }),
+      } as Response;
+    }) as typeof fetch;
+
+    try {
+      const quote = await bridge.quote({
+        fromChain: 42161,
+        toChain: 1151111081099710,
+        fromToken: TOKEN_ADDR,
+        toToken: TOKEN_ADDR,
+        fromAddress: SENDER_ADDR,
+        toAddress: SENDER_ADDR,
+        toAmount: 5000000000n,
+      });
+      const params = new URL(requestUrl).searchParams;
+
+      expect(params.get('order')).to.equal('RECOMMENDED');
+      expect(quote.requestParams.toAmount).to.equal(5000000000n);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
 describe('LiFiBridge.getStatus()', function () {
   let bridge: LiFiBridge;
 

--- a/typescript/rebalancer/src/bridges/LiFiBridge.ts
+++ b/typescript/rebalancer/src/bridges/LiFiBridge.ts
@@ -381,7 +381,7 @@ export class LiFiBridge implements IExternalBridge {
       slippage: (params.slippage ?? this.config.defaultSlippage ?? 0.005)
         .toFixed(4)
         .replace(/\.?0+$/, ''),
-      order: 'CHEAPEST',
+      order: 'RECOMMENDED',
       integrator: this.config.integrator,
     });
 

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -1700,24 +1700,29 @@ describe('InventoryRebalancer E2E', () => {
       expect(results[0].success).to.be.true;
       expect(bridge.execute.callCount).to.equal(2);
 
-      const reverseQuoteRequests = bridge.quote
-        .getCalls()
-        .map((call) => call.args[0])
-        .filter((params) => params.toAmount !== undefined);
-      expect(reverseQuoteRequests).to.have.lengthOf(2);
-
-      const requestedOutputs = reverseQuoteRequests
-        .map((params) => params.toAmount as bigint)
-        .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
       const maxPerSourceOutput = perChainInventory - reservedGas;
-      const totalAvailableCapacity = maxPerSourceOutput * 2n;
+      const executionQuoteRequests = bridge.quote
+        .getCalls()
+        .slice(-2)
+        .map((call) => call.args[0]);
+      expect(executionQuoteRequests).to.have.lengthOf(2);
 
-      expect(requestedOutputs.every((output) => output <= maxPerSourceOutput))
-        .to.be.true;
-      expect(requestedOutputs[0] < maxPerSourceOutput).to.be.true;
-      expect(requestedOutputs[1]).to.equal(maxPerSourceOutput);
-      expect(requestedOutputs[0] + requestedOutputs[1] < totalAvailableCapacity)
-        .to.be.true;
+      const forwardQuoteRequests = executionQuoteRequests.filter(
+        (params) => params.fromAmount !== undefined,
+      );
+      const reverseQuoteRequests = executionQuoteRequests.filter(
+        (params) => params.toAmount !== undefined,
+      );
+      const forwardAmounts = forwardQuoteRequests.map(
+        (params) => params.fromAmount as bigint,
+      );
+
+      expect(
+        forwardQuoteRequests.length + reverseQuoteRequests.length,
+      ).to.equal(2);
+      expect(forwardQuoteRequests.length).to.be.greaterThan(0);
+      expect(forwardAmounts.every((amount) => amount <= maxPerSourceOutput)).to
+        .be.true;
     });
 
     it('applies 5% buffer to total bridge amount', async () => {
@@ -1851,7 +1856,7 @@ describe('InventoryRebalancer E2E', () => {
       expect(quotedTargetOutput).to.equal(1_050_000_000_000_000_000n);
     });
 
-    it('fails bridge execution when reverse quote exceeds planned source capacity', async () => {
+    it('retries forward execution when reverse quote exceeds planned source capacity', async () => {
       const amount = BigInt(1e18);
       const sourceInventory = BigInt(2e18);
       const targetWithBuffer = (amount * 105n) / 100n;
@@ -1898,15 +1903,43 @@ describe('InventoryRebalancer E2E', () => {
               toAmount: targetWithBuffer,
             },
           }),
+        )
+        .onThirdCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: sourceInventory,
+            toAmount: targetWithBuffer - 1n,
+            toAmountMin: targetWithBuffer - 1n,
+            requestParams: {
+              fromChain: 42161,
+              toChain: 1399811149,
+              fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              toAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              fromAmount: sourceInventory,
+            },
+          }),
         );
+
+      bridge.execute.resolves({
+        txHash: '0xBridgeTxHash',
+        fromChain: 42161,
+        toChain: 1399811149,
+      });
 
       const results = await inventoryRebalancer.rebalance([route]);
 
       expect(results).to.have.lengthOf(1);
-      expect(results[0].success).to.be.false;
-      expect(results[0].error).to.include('All inventory movements failed');
-      expect(results[0].error).to.include('exceeded planned source capacity');
-      expect(bridge.execute.called).to.be.false;
+      expect(results[0].success).to.be.true;
+      expect(bridge.execute.calledOnce).to.be.true;
+      expect(bridge.quote.getCall(1)?.args[0].toAmount).to.equal(
+        targetWithBuffer,
+      );
+      expect(bridge.quote.getCall(2)?.args[0].fromAmount).to.equal(
+        sourceInventory,
+      );
+      expect(bridge.quote.getCall(2)?.args[0].toAmount).to.be.undefined;
     });
 
     it('continues when some bridges fail', async () => {
@@ -2177,7 +2210,10 @@ describe('InventoryRebalancer E2E', () => {
       expect(results).to.have.lengthOf(1);
       expect(results[0].success).to.be.true;
       expect(bridge.execute.calledOnce).to.be.true;
-      expect(bridge.quote.getCall(1)?.args[0].toAmount).to.equal(tokenBalance);
+      expect(bridge.quote.getCall(1)?.args[0].fromAmount).to.equal(
+        tokenBalance,
+      );
+      expect(bridge.quote.getCall(1)?.args[0].toAmount).to.be.undefined;
     });
 
     it('calculates max viable amount as inventory minus (gasCosts * 20) for native tokens', async () => {
@@ -2276,6 +2312,109 @@ describe('InventoryRebalancer E2E', () => {
       }
       expect(executionTargetOutput > amount).to.be.true;
       expect(executionTargetOutput <= maxViable).to.be.true;
+    });
+
+    it('uses forward quote when target output exactly matches source capacity', async () => {
+      const amount = 1000n;
+      const rawBalance = 1100n;
+      const targetWithBuffer = 1050n;
+
+      const route = createTestRoute({ amount });
+      createTestIntent({ amount });
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: 0n,
+        [ARBITRUM_CHAIN]: rawBalance,
+      });
+
+      bridge.quote
+        .onFirstCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: rawBalance,
+            toAmount: targetWithBuffer,
+            toAmountMin: targetWithBuffer,
+          }),
+        )
+        .onSecondCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: rawBalance,
+            toAmount: targetWithBuffer,
+            toAmountMin: targetWithBuffer,
+          }),
+        );
+
+      bridge.execute.resolves({
+        txHash: '0xForwardBoundaryBridgeTxHash',
+        fromChain: 42161,
+        toChain: 1399811149,
+      });
+
+      const results = await inventoryRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.true;
+      expect(bridge.execute.calledOnce).to.be.true;
+      expect(bridge.quote.getCall(1)?.args[0].fromAmount).to.equal(rawBalance);
+      expect(bridge.quote.getCall(1)?.args[0].toAmount).to.be.undefined;
+    });
+
+    it('retries reverse quote as forward when exact-output exceeds source capacity', async () => {
+      const amount = 1000n;
+      const rawBalance = 1100n;
+      const targetWithBuffer = 1050n;
+
+      const route = createTestRoute({ amount });
+      createTestIntent({ amount });
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: 0n,
+        [ARBITRUM_CHAIN]: rawBalance,
+      });
+
+      bridge.quote
+        .onFirstCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: rawBalance,
+            toAmount: 1051n,
+            toAmountMin: 1051n,
+          }),
+        )
+        .onSecondCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: rawBalance + 1n,
+            toAmount: targetWithBuffer,
+            toAmountMin: targetWithBuffer,
+          }),
+        )
+        .onThirdCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: rawBalance,
+            toAmount: 1049n,
+            toAmountMin: 1049n,
+          }),
+        );
+
+      bridge.execute.resolves({
+        txHash: '0xForwardFallbackBridgeTxHash',
+        fromChain: 42161,
+        toChain: 1399811149,
+      });
+
+      const results = await inventoryRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.true;
+      expect(bridge.execute.calledOnce).to.be.true;
+      expect(bridge.quote.getCall(1)?.args[0].toAmount).to.equal(
+        targetWithBuffer,
+      );
+      expect(bridge.quote.getCall(2)?.args[0].fromAmount).to.equal(rawBalance);
+      expect(bridge.quote.getCall(2)?.args[0].toAmount).to.be.undefined;
     });
 
     it('handles quote failures gracefully by skipping the source chain', async () => {

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -13,7 +13,7 @@ import {
   WarpTxCategory,
   type WarpCore,
 } from '@hyperlane-xyz/sdk';
-import { ProtocolType } from '@hyperlane-xyz/utils';
+import { assert, ProtocolType } from '@hyperlane-xyz/utils';
 
 import { ExternalBridgeType } from '../config/types.js';
 import type { IExternalBridge } from '../interfaces/IExternalBridge.js';
@@ -2161,12 +2161,16 @@ describe('InventoryRebalancer E2E', () => {
         .getCalls()
         .find(
           (call: ReturnType<typeof logger.info.getCall>) =>
-            call.args[1] ===
-            'Parallel inventory movements completed, transferRemote will execute after bridges complete',
+            call.args[0] &&
+            typeof call.args[0] === 'object' &&
+            Object.prototype.hasOwnProperty.call(
+              call.args[0],
+              'totalQuotedOutputMin',
+            ),
         );
 
-      expect(summaryCall).to.exist;
-      expect(summaryCall!.args[0].totalQuotedOutputMin).to.equal(
+      assert(summaryCall, 'Expected summary log with totalQuotedOutputMin');
+      expect(summaryCall.args[0].totalQuotedOutputMin).to.equal(
         BigInt(1.01e18).toString(),
       );
     });

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -1949,6 +1949,89 @@ describe('InventoryRebalancer E2E', () => {
       expect(bridge.quote.getCall(2).args[0].toAmount).to.be.undefined;
     });
 
+    it('fails when forward retry still exceeds planned source capacity', async () => {
+      const amount = BigInt(1e18);
+      const sourceInventory = BigInt(2e18);
+      const targetWithBuffer = (amount * 105n) / 100n;
+
+      const route = createTestRoute({ amount });
+      createTestIntent({ amount });
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: 0n,
+        [ARBITRUM_CHAIN]: sourceInventory,
+      });
+
+      bridge.quote
+        .onFirstCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: sourceInventory,
+            toAmount: sourceInventory,
+            toAmountMin: sourceInventory,
+            requestParams: {
+              fromChain: 42161,
+              toChain: 1399811149,
+              fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              toAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              fromAmount: sourceInventory,
+            },
+          }),
+        )
+        .onSecondCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: sourceInventory + 1n,
+            toAmount: targetWithBuffer,
+            toAmountMin: targetWithBuffer,
+            requestParams: {
+              fromChain: 42161,
+              toChain: 1399811149,
+              fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              toAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              toAmount: targetWithBuffer,
+            },
+          }),
+        )
+        .onThirdCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: sourceInventory + 1n,
+            toAmount: targetWithBuffer - 1n,
+            toAmountMin: targetWithBuffer - 1n,
+            requestParams: {
+              fromChain: 42161,
+              toChain: 1399811149,
+              fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              toAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              fromAmount: sourceInventory,
+            },
+          }),
+        );
+
+      const results = await inventoryRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.false;
+      expect(results[0].error).to.include('All inventory movements failed');
+      expect(results[0].error).to.include('exceeded planned source capacity');
+      expect(bridge.quote.callCount).to.equal(3);
+      expect(bridge.execute.called).to.be.false;
+      expect(bridge.quote.getCall(1).args[0].toAmount).to.equal(
+        targetWithBuffer,
+      );
+      expect(bridge.quote.getCall(2).args[0].fromAmount).to.equal(
+        sourceInventory,
+      );
+      expect(bridge.quote.getCall(2).args[0].toAmount).to.be.undefined;
+    });
+
     it('logs actual successful bridge output floors instead of planned output totals', async () => {
       const amount = BigInt(1e18);
       const perChainInventory = BigInt(0.6e18);

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -2075,6 +2075,61 @@ describe('InventoryRebalancer E2E', () => {
       expect(bridge.execute.called).to.be.false;
     });
 
+    it('preserves non-Error rejection reasons from parallel bridge execution', async () => {
+      const amount = BigInt(1e18);
+      const sourceInventory = BigInt(2e18);
+
+      const route = createTestRoute({ amount });
+      createTestIntent({ amount });
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: 0n,
+        [ARBITRUM_CHAIN]: sourceInventory,
+      });
+
+      bridge.quote.onFirstCall().resolves(
+        createMockBridgeQuote({
+          fromAmount: sourceInventory,
+          toAmount: sourceInventory,
+          toAmountMin: sourceInventory,
+          requestParams: {
+            fromChain: 42161,
+            toChain: 1399811149,
+            fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+            toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+            fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            toAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            fromAmount: sourceInventory,
+          },
+        }),
+      );
+
+      // Simulate a foreign promise rejecting with a non-Error reason at runtime.
+      const rejectionReason = 'bridge exploded' as unknown as Error;
+
+      const executeInventoryMovementStub = Sinon.stub(
+        inventoryRebalancer as unknown as {
+          executeInventoryMovement: () => Promise<unknown>;
+        },
+        'executeInventoryMovement',
+      ).callsFake(() =>
+        Promise.resolve().then(() => {
+          throw rejectionReason;
+        }),
+      );
+
+      const results = await inventoryRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.false;
+      expect(results[0].error).to.include('All inventory movements failed');
+      expect(results[0].error).to.include('arbitrum: bridge exploded');
+      expect(executeInventoryMovementStub.calledOnce).to.be.true;
+      expect(bridge.execute.called).to.be.false;
+
+      executeInventoryMovementStub.restore();
+    });
+
     it('logs actual successful bridge output floors instead of planned output totals', async () => {
       const amount = BigInt(1e18);
       const perChainInventory = BigInt(0.6e18);

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -1,6 +1,7 @@
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { Wallet } from 'ethers';
+import type { Logger } from 'pino';
 import { pino } from 'pino';
 import Sinon, { type SinonStubbedInstance } from 'sinon';
 
@@ -1723,6 +1724,11 @@ describe('InventoryRebalancer E2E', () => {
       expect(forwardQuoteRequests.length).to.be.greaterThan(0);
       expect(forwardAmounts.every((amount) => amount <= maxPerSourceOutput)).to
         .be.true;
+      expect(
+        reverseQuoteRequests.every(
+          (params) => (params.toAmount as bigint) <= maxPerSourceOutput,
+        ),
+      ).to.be.true;
     });
 
     it('applies 5% buffer to total bridge amount', async () => {
@@ -1933,13 +1939,110 @@ describe('InventoryRebalancer E2E', () => {
       expect(results).to.have.lengthOf(1);
       expect(results[0].success).to.be.true;
       expect(bridge.execute.calledOnce).to.be.true;
-      expect(bridge.quote.getCall(1)?.args[0].toAmount).to.equal(
+      expect(bridge.quote.callCount).to.equal(3);
+      expect(bridge.quote.getCall(1).args[0].toAmount).to.equal(
         targetWithBuffer,
       );
-      expect(bridge.quote.getCall(2)?.args[0].fromAmount).to.equal(
+      expect(bridge.quote.getCall(2).args[0].fromAmount).to.equal(
         sourceInventory,
       );
-      expect(bridge.quote.getCall(2)?.args[0].toAmount).to.be.undefined;
+      expect(bridge.quote.getCall(2).args[0].toAmount).to.be.undefined;
+    });
+
+    it('logs actual successful bridge output floors instead of planned output totals', async () => {
+      const amount = BigInt(1e18);
+      const perChainInventory = BigInt(0.6e18);
+      const logger = {
+        info: Sinon.stub(),
+        debug: Sinon.stub(),
+        warn: Sinon.stub(),
+        error: Sinon.stub(),
+      };
+
+      const localRebalancer = new InventoryRebalancer(
+        config,
+        actionTracker as unknown as IActionTracker,
+        { lifi: bridge as unknown as IExternalBridge },
+        warpCore as unknown as WarpCore,
+        multiProvider as unknown as MultiProvider,
+        logger as unknown as Logger,
+      );
+
+      const route = createTestRoute({ amount });
+      createTestIntent({ amount });
+
+      localRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: 0n,
+        [ARBITRUM_CHAIN]: perChainInventory,
+        [BASE_CHAIN]: perChainInventory,
+      });
+
+      bridge.quote
+        .onCall(0)
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: perChainInventory,
+            toAmount: BigInt(0.525e18),
+            toAmountMin: BigInt(0.525e18),
+          }),
+        )
+        .onCall(1)
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: perChainInventory,
+            toAmount: BigInt(0.525e18),
+            toAmountMin: BigInt(0.525e18),
+          }),
+        )
+        .onCall(2)
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: perChainInventory,
+            toAmount: BigInt(0.505e18),
+            toAmountMin: BigInt(0.5e18),
+          }),
+        )
+        .onCall(3)
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: perChainInventory,
+            toAmount: BigInt(0.515e18),
+            toAmountMin: BigInt(0.51e18),
+          }),
+        );
+
+      bridge.execute
+        .onFirstCall()
+        .resolves({
+          txHash: '0xSuccessTxHash1',
+          fromChain: 42161,
+          toChain: 1399811149,
+        })
+        .onSecondCall()
+        .resolves({
+          txHash: '0xSuccessTxHash2',
+          fromChain: 8453,
+          toChain: 1399811149,
+        });
+
+      const results = await localRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.true;
+      expect(bridge.execute.callCount).to.equal(2);
+
+      const summaryCall = logger.info
+        .getCalls()
+        .find(
+          (call: ReturnType<typeof logger.info.getCall>) =>
+            call.args[1] ===
+            'Parallel inventory movements completed, transferRemote will execute after bridges complete',
+        );
+
+      expect(summaryCall).to.exist;
+      expect(summaryCall!.args[0].totalQuotedOutputMin).to.equal(
+        BigInt(1.01e18).toString(),
+      );
     });
 
     it('continues when some bridges fail', async () => {
@@ -2210,10 +2313,9 @@ describe('InventoryRebalancer E2E', () => {
       expect(results).to.have.lengthOf(1);
       expect(results[0].success).to.be.true;
       expect(bridge.execute.calledOnce).to.be.true;
-      expect(bridge.quote.getCall(1)?.args[0].fromAmount).to.equal(
-        tokenBalance,
-      );
-      expect(bridge.quote.getCall(1)?.args[0].toAmount).to.be.undefined;
+      expect(bridge.quote.callCount).to.equal(2);
+      expect(bridge.quote.getCall(1).args[0].fromAmount).to.equal(tokenBalance);
+      expect(bridge.quote.getCall(1).args[0].toAmount).to.be.undefined;
     });
 
     it('calculates max viable amount as inventory minus (gasCosts * 20) for native tokens', async () => {
@@ -2303,9 +2405,10 @@ describe('InventoryRebalancer E2E', () => {
       expect(results).to.have.lengthOf(1);
       expect(results[0].success).to.be.true;
       expect(bridge.execute.calledOnce).to.be.true;
+      expect(bridge.quote.callCount).to.equal(3);
 
-      expect(bridge.quote.getCall(1)?.args[0].fromAmount).to.equal(maxViable);
-      const executionTargetOutput = bridge.quote.getCall(2)?.args[0].toAmount;
+      expect(bridge.quote.getCall(1).args[0].fromAmount).to.equal(maxViable);
+      const executionTargetOutput = bridge.quote.getCall(2).args[0].toAmount;
       expect(executionTargetOutput).to.be.a('bigint');
       if (executionTargetOutput === undefined) {
         throw new Error('Expected reverse quote to set toAmount');
@@ -2356,8 +2459,9 @@ describe('InventoryRebalancer E2E', () => {
       expect(results).to.have.lengthOf(1);
       expect(results[0].success).to.be.true;
       expect(bridge.execute.calledOnce).to.be.true;
-      expect(bridge.quote.getCall(1)?.args[0].fromAmount).to.equal(rawBalance);
-      expect(bridge.quote.getCall(1)?.args[0].toAmount).to.be.undefined;
+      expect(bridge.quote.callCount).to.equal(2);
+      expect(bridge.quote.getCall(1).args[0].fromAmount).to.equal(rawBalance);
+      expect(bridge.quote.getCall(1).args[0].toAmount).to.be.undefined;
     });
 
     it('retries reverse quote as forward when exact-output exceeds source capacity', async () => {
@@ -2410,11 +2514,12 @@ describe('InventoryRebalancer E2E', () => {
       expect(results).to.have.lengthOf(1);
       expect(results[0].success).to.be.true;
       expect(bridge.execute.calledOnce).to.be.true;
-      expect(bridge.quote.getCall(1)?.args[0].toAmount).to.equal(
+      expect(bridge.quote.callCount).to.equal(3);
+      expect(bridge.quote.getCall(1).args[0].toAmount).to.equal(
         targetWithBuffer,
       );
-      expect(bridge.quote.getCall(2)?.args[0].fromAmount).to.equal(rawBalance);
-      expect(bridge.quote.getCall(2)?.args[0].toAmount).to.be.undefined;
+      expect(bridge.quote.getCall(2).args[0].fromAmount).to.equal(rawBalance);
+      expect(bridge.quote.getCall(2).args[0].toAmount).to.be.undefined;
     });
 
     it('handles quote failures gracefully by skipping the source chain', async () => {

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -2032,6 +2032,49 @@ describe('InventoryRebalancer E2E', () => {
       expect(bridge.quote.getCall(2).args[0].toAmount).to.be.undefined;
     });
 
+    it('fails gracefully when execute-time bridge quote rejects', async () => {
+      const amount = BigInt(1e18);
+      const sourceInventory = BigInt(2e18);
+
+      const route = createTestRoute({ amount });
+      createTestIntent({ amount });
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: 0n,
+        [ARBITRUM_CHAIN]: sourceInventory,
+      });
+
+      bridge.quote
+        .onFirstCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: sourceInventory,
+            toAmount: sourceInventory,
+            toAmountMin: sourceInventory,
+            requestParams: {
+              fromChain: 42161,
+              toChain: 1399811149,
+              fromToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              toToken: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+              fromAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              toAddress: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              fromAmount: sourceInventory,
+            },
+          }),
+        )
+        .onSecondCall()
+        .rejects(new Error('LiFi API timeout'));
+
+      const results = await inventoryRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.false;
+      expect(results[0].error).to.include('All inventory movements failed');
+      expect(results[0].error).to.include('LiFi API timeout');
+      expect(bridge.quote.callCount).to.equal(2);
+      expect(bridge.execute.called).to.be.false;
+    });
+
     it('logs actual successful bridge output floors instead of planned output totals', async () => {
       const amount = BigInt(1e18);
       const perChainInventory = BigInt(0.6e18);

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -74,6 +74,8 @@ type BridgeCapacity = {
   maxTargetOutput: bigint;
 };
 
+type BridgeQuoteMode = 'forward' | 'reverse';
+
 const RECOVERABLE_MAX_TRANSFER_ERROR_MESSAGES = [
   'balance may be insufficient',
   'transfer amount exceeds balance',
@@ -910,6 +912,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       chain: ChainName;
       maxSourceInput: bigint;
       targetOutput: bigint;
+      quoteMode: BridgeQuoteMode;
     }> = [];
     let totalPlanned = 0n;
 
@@ -921,11 +924,14 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         source.maxTargetOutput >= remaining
           ? remaining
           : source.maxTargetOutput;
+      const quoteMode: BridgeQuoteMode =
+        source.maxTargetOutput > remaining ? 'reverse' : 'forward';
 
       bridgePlans.push({
         chain: source.chain,
         maxSourceInput: source.maxSourceInput,
         targetOutput,
+        quoteMode,
       });
       totalPlanned += targetOutput;
     }
@@ -942,6 +948,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           chain: p.chain,
           maxSourceInput: p.maxSourceInput.toString(),
           targetOutput: p.targetOutput.toString(),
+          quoteMode: p.quoteMode,
         })),
         totalPlanned: totalPlanned.toString(),
         shortfall: shortfall.toString(),
@@ -959,6 +966,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           destination,
           plan.targetOutput,
           plan.maxSourceInput,
+          plan.quoteMode,
           intent,
           route.externalBridge,
         ),
@@ -1395,13 +1403,15 @@ export class InventoryRebalancer implements IInventoryRebalancer {
   /**
    * Execute inventory movement from source chain to target chain via LiFi bridge.
    *
-   * Uses reverse quotes (`toAmount`) so plans are expressed in target-chain local
-   * units and source-local spend is discovered by the bridge quote.
+   * Quote mode is chosen during planning:
+   * - `reverse`: request an exact target-chain output when the source has headroom
+   * - `forward`: spend the source cap directly when source inventory is the limiter
    *
    * @param sourceChain - Chain to move inventory from
    * @param targetChain - Chain to move inventory to (origin chain for rebalancing)
    * @param targetOutputAmount - Destination-local amount to receive
    * @param maxSourceInput - Maximum source-local amount available for this plan
+   * @param quoteMode - Whether to execute this bridge plan as exact-input or exact-output
    * @param intent - Rebalance intent for tracking
    * @param externalBridgeType - External bridge type to use
    * @returns Result with success status and optional txHash/error
@@ -1411,6 +1421,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     targetChain: ChainName,
     targetOutputAmount: bigint,
     maxSourceInput: bigint,
+    quoteMode: BridgeQuoteMode,
     intent: RebalanceIntent,
     externalBridgeType: ExternalBridgeType,
   ): Promise<{ success: boolean; txHash?: string; error?: string }> {
@@ -1459,17 +1470,90 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       'Resolved token addresses for LiFi bridge',
     );
 
+    const costs = await calculateTransferCosts(
+      targetChain,
+      sourceChain,
+      targetOutputAmount,
+      targetOutputAmount,
+      this.multiProvider,
+      this.warpCore.multiProvider,
+      this.getTokenForChain.bind(this),
+      this.getInventorySignerAddress(targetChain),
+      isNativeTokenStandard,
+      this.logger,
+    );
+    const { minViableTransfer } = costs;
+
+    // If the requested amount is below minViableTransfer, adjust it up.
+    // This ensures we bridge enough to actually complete the final transferRemote.
+    const effectiveTargetOutput =
+      targetOutputAmount < minViableTransfer
+        ? minViableTransfer
+        : targetOutputAmount;
+
+    if (effectiveTargetOutput !== targetOutputAmount) {
+      this.logger.info(
+        {
+          originalAmount: targetOutputAmount.toString(),
+          effectiveAmount: effectiveTargetOutput.toString(),
+          minViableTransfer: minViableTransfer.toString(),
+          originalAmountFormatted: this.formatLocalAmount(
+            targetOutputAmount,
+            targetToken,
+          ),
+          effectiveAmountFormatted: this.formatLocalAmount(
+            effectiveTargetOutput,
+            targetToken,
+          ),
+          minViableTransferFormatted: this.formatLocalAmount(
+            minViableTransfer,
+            targetToken,
+          ),
+          adjustedUp: true,
+          intentId: intent.id,
+        },
+        'Over-bridging to minViableTransfer to ensure final transferRemote can complete',
+      );
+    }
+
     try {
       const externalBridge = this.getExternalBridge(externalBridgeType);
-      const quote = await externalBridge.quote({
-        fromChain: sourceChainId,
-        toChain: targetChainId,
-        fromToken: fromTokenAddress,
-        toToken: toTokenAddress,
-        toAmount: targetOutputAmount,
-        fromAddress: this.getInventorySignerAddress(sourceChain),
-        toAddress: this.getInventorySignerAddress(targetChain),
-      });
+      const fromAddress = this.getInventorySignerAddress(sourceChain);
+      const toAddress = this.getInventorySignerAddress(targetChain);
+      const quoteWithMode = async (mode: BridgeQuoteMode) =>
+        externalBridge.quote({
+          fromChain: sourceChainId,
+          toChain: targetChainId,
+          fromToken: fromTokenAddress,
+          toToken: toTokenAddress,
+          ...(mode === 'forward'
+            ? { fromAmount: maxSourceInput }
+            : { toAmount: effectiveTargetOutput }),
+          fromAddress,
+          toAddress,
+        });
+
+      let quoteModeUsed = quoteMode;
+      let quote = await quoteWithMode(quoteModeUsed);
+
+      if (quoteModeUsed === 'reverse' && quote.fromAmount > maxSourceInput) {
+        this.logger.warn(
+          {
+            sourceChain,
+            targetChain,
+            plannedQuoteMode: quoteMode,
+            requestedTargetOutput: targetOutputAmount.toString(),
+            effectiveTargetOutput: effectiveTargetOutput.toString(),
+            quotedInput: quote.fromAmount.toString(),
+            maxSourceInput: maxSourceInput.toString(),
+            intentId: intent.id,
+          },
+          'Reverse bridge quote exceeded source capacity, retrying with forward quote',
+        );
+
+        quoteModeUsed = 'forward';
+        quote = await quoteWithMode(quoteModeUsed);
+      }
 
       const inputRequired = quote.fromAmount;
       if (inputRequired > maxSourceInput) {
@@ -1490,6 +1574,13 @@ export class InventoryRebalancer implements IInventoryRebalancer {
             targetOutputAmount,
             targetToken,
           ),
+          quoteModePlanned: quoteMode,
+          quoteModeUsed,
+          effectiveTargetOutput: effectiveTargetOutput.toString(),
+          effectiveTargetOutputFormatted: this.formatLocalAmount(
+            effectiveTargetOutput,
+            targetToken,
+          ),
           inputRequired: inputRequired.toString(),
           inputRequiredFormatted: this.formatLocalAmount(
             inputRequired,
@@ -1504,8 +1595,9 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           gasCosts: quote.gasCosts.toString(),
           feeCosts: quote.feeCosts.toString(),
           intentId: intent.id,
+          adjustedForMinViable: effectiveTargetOutput > targetOutputAmount,
         },
-        'Executing inventory movement via LiFi reverse quote',
+        'Executing inventory movement via bridge quote',
       );
 
       this.logger.debug(

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -1014,9 +1014,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         const error =
           result.status === 'rejected'
             ? result.reason?.message
-            : result.value.success
-              ? undefined
-              : result.value.error;
+            : result.value.error;
         if (error) {
           failedErrors.push(`${plan.chain}: ${error}`);
         }

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -76,6 +76,20 @@ type BridgeCapacity = {
 
 type BridgeQuoteMode = 'forward' | 'reverse';
 
+type InventoryMovementExecutionResult =
+  | {
+      success: true;
+      txHash: string;
+      inputRequired: bigint;
+      quotedOutput: bigint;
+      quotedOutputMin: bigint;
+      quoteModeUsed: BridgeQuoteMode;
+    }
+  | {
+      success: false;
+      error: string;
+    };
+
 const RECOVERABLE_MAX_TRANSFER_ERROR_MESSAGES = [
   'balance may be insufficient',
   'transfer amount exceeds balance',
@@ -975,7 +989,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
 
     // Process results
     let successCount = 0;
-    let totalBridged = 0n;
+    let totalQuotedOutputMin = 0n;
     const failedErrors: string[] = [];
 
     for (let i = 0; i < bridgeResults.length; i++) {
@@ -984,11 +998,14 @@ export class InventoryRebalancer implements IInventoryRebalancer {
 
       if (result.status === 'fulfilled' && result.value.success) {
         successCount++;
-        totalBridged += plan.targetOutput;
+        totalQuotedOutputMin += result.value.quotedOutputMin;
         this.logger.info(
           {
             sourceChain: plan.chain,
-            amount: plan.targetOutput.toString(),
+            plannedTargetOutput: plan.targetOutput.toString(),
+            quotedOutput: result.value.quotedOutput.toString(),
+            quotedOutputMin: result.value.quotedOutputMin.toString(),
+            quoteModeUsed: result.value.quoteModeUsed,
             txHash: result.value.txHash,
           },
           'Inventory movement succeeded',
@@ -997,14 +1014,16 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         const error =
           result.status === 'rejected'
             ? result.reason?.message
-            : result.value.error;
+            : result.value.success
+              ? undefined
+              : result.value.error;
         if (error) {
           failedErrors.push(`${plan.chain}: ${error}`);
         }
         this.logger.warn(
           {
             sourceChain: plan.chain,
-            amount: plan.targetOutput.toString(),
+            plannedTargetOutput: plan.targetOutput.toString(),
             error,
           },
           'Inventory movement failed',
@@ -1026,7 +1045,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       {
         targetChain: destination,
         successCount,
-        totalBridged: totalBridged.toString(),
+        totalQuotedOutputMin: totalQuotedOutputMin.toString(),
         targetAmount: requestedLocalAmount.toString(),
         targetAmountCanonical: amount.toString(),
         intentId: intent.id,
@@ -1424,7 +1443,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     quoteMode: BridgeQuoteMode,
     intent: RebalanceIntent,
     externalBridgeType: ExternalBridgeType,
-  ): Promise<{ success: boolean; txHash?: string; error?: string }> {
+  ): Promise<InventoryMovementExecutionResult> {
     const sourceToken = this.getTokenForChain(sourceChain);
     if (!sourceToken) {
       return {
@@ -1470,52 +1489,6 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       'Resolved token addresses for LiFi bridge',
     );
 
-    const costs = await calculateTransferCosts(
-      targetChain,
-      sourceChain,
-      targetOutputAmount,
-      targetOutputAmount,
-      this.multiProvider,
-      this.warpCore.multiProvider,
-      this.getTokenForChain.bind(this),
-      this.getInventorySignerAddress(targetChain),
-      isNativeTokenStandard,
-      this.logger,
-    );
-    const { minViableTransfer } = costs;
-
-    // If the requested amount is below minViableTransfer, adjust it up.
-    // This ensures we bridge enough to actually complete the final transferRemote.
-    const effectiveTargetOutput =
-      targetOutputAmount < minViableTransfer
-        ? minViableTransfer
-        : targetOutputAmount;
-
-    if (effectiveTargetOutput !== targetOutputAmount) {
-      this.logger.info(
-        {
-          originalAmount: targetOutputAmount.toString(),
-          effectiveAmount: effectiveTargetOutput.toString(),
-          minViableTransfer: minViableTransfer.toString(),
-          originalAmountFormatted: this.formatLocalAmount(
-            targetOutputAmount,
-            targetToken,
-          ),
-          effectiveAmountFormatted: this.formatLocalAmount(
-            effectiveTargetOutput,
-            targetToken,
-          ),
-          minViableTransferFormatted: this.formatLocalAmount(
-            minViableTransfer,
-            targetToken,
-          ),
-          adjustedUp: true,
-          intentId: intent.id,
-        },
-        'Over-bridging to minViableTransfer to ensure final transferRemote can complete',
-      );
-    }
-
     try {
       const externalBridge = this.getExternalBridge(externalBridgeType);
       const fromAddress = this.getInventorySignerAddress(sourceChain);
@@ -1528,7 +1501,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           toToken: toTokenAddress,
           ...(mode === 'forward'
             ? { fromAmount: maxSourceInput }
-            : { toAmount: effectiveTargetOutput }),
+            : { toAmount: targetOutputAmount }),
           fromAddress,
           toAddress,
         });
@@ -1543,7 +1516,6 @@ export class InventoryRebalancer implements IInventoryRebalancer {
             targetChain,
             plannedQuoteMode: quoteMode,
             requestedTargetOutput: targetOutputAmount.toString(),
-            effectiveTargetOutput: effectiveTargetOutput.toString(),
             quotedInput: quote.fromAmount.toString(),
             maxSourceInput: maxSourceInput.toString(),
             intentId: intent.id,
@@ -1551,6 +1523,8 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           'Reverse bridge quote exceeded source capacity, retrying with forward quote',
         );
 
+        // Spend the full source cap on fallback; minor output drift is acceptable
+        // and will be reconciled by later cycles rather than risking livelock.
         quoteModeUsed = 'forward';
         quote = await quoteWithMode(quoteModeUsed);
       }
@@ -1576,26 +1550,26 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           ),
           quoteModePlanned: quoteMode,
           quoteModeUsed,
-          effectiveTargetOutput: effectiveTargetOutput.toString(),
-          effectiveTargetOutputFormatted: this.formatLocalAmount(
-            effectiveTargetOutput,
-            targetToken,
-          ),
+          retriedAsForward:
+            quoteMode === 'reverse' && quoteModeUsed === 'forward',
           inputRequired: inputRequired.toString(),
           inputRequiredFormatted: this.formatLocalAmount(
             inputRequired,
             sourceToken,
           ),
-          expectedOutput: quote.toAmount.toString(),
-          expectedOutputMin: quote.toAmountMin.toString(),
-          expectedOutputFormatted: this.formatLocalAmount(
+          quotedOutput: quote.toAmount.toString(),
+          quotedOutputMin: quote.toAmountMin.toString(),
+          quotedOutputFormatted: this.formatLocalAmount(
             quote.toAmount,
+            targetToken,
+          ),
+          quotedOutputMinFormatted: this.formatLocalAmount(
+            quote.toAmountMin,
             targetToken,
           ),
           gasCosts: quote.gasCosts.toString(),
           feeCosts: quote.feeCosts.toString(),
           intentId: intent.id,
-          adjustedForMinViable: effectiveTargetOutput > targetOutputAmount,
         },
         'Executing inventory movement via bridge quote',
       );
@@ -1665,22 +1639,31 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         'Updated consumed inventory after LiFi bridge',
       );
 
-      return { success: true, txHash: result.txHash };
+      return {
+        success: true,
+        txHash: result.txHash,
+        inputRequired,
+        quotedOutput: quote.toAmount,
+        quotedOutputMin: quote.toAmountMin,
+        quoteModeUsed,
+      };
     } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
       this.logger.error(
         {
           sourceChain,
           targetChain,
           amount: targetOutputAmount.toString(),
           intentId: intent.id,
-          error: (error as Error).message,
+          error: errorMessage,
         },
         'Failed to execute inventory movement',
       );
 
       return {
         success: false,
-        error: (error as Error).message,
+        error: errorMessage,
       };
     }
   }

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -1011,10 +1011,12 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           'Inventory movement succeeded',
         );
       } else {
-        const error =
-          result.status === 'rejected'
-            ? result.reason?.message
-            : result.value.error;
+        let error: string | undefined;
+        if (result.status === 'rejected') {
+          error = result.reason?.message;
+        } else if (!result.value.success) {
+          error = result.value.error;
+        }
         if (error) {
           failedErrors.push(`${plan.chain}: ${error}`);
         }

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -1013,7 +1013,17 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       } else {
         let error: string | undefined;
         if (result.status === 'rejected') {
-          error = result.reason?.message;
+          if (result.reason instanceof Error) {
+            error = result.reason.message;
+          } else if (typeof result.reason === 'string') {
+            error = result.reason;
+          } else {
+            try {
+              error = JSON.stringify(result.reason) ?? String(result.reason);
+            } catch {
+              error = String(result.reason);
+            }
+          }
         } else if (!result.value.success) {
           error = result.value.error;
         }


### PR DESCRIPTION
## Summary
- align bridge execution with the quote mode chosen during planning
- keep source-limited inventory movements on forward quotes
- avoid reverse-quote overshoot causing retries and livelock

## Stack
- base for #8626
