### PR TITLE
feat(rebalancer): add Katana external bridge

### DIFF
--- a/.changeset/katana-external-bridge.md
+++ b/.changeset/katana-external-bridge.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': minor
+---
+
+The rebalancer gained a Katana external bridge that used the public LayerZero composer path for Ethereum USDC and Katana vbUSDC inventory rebalancing.

--- a/typescript/rebalancer/package.json
+++ b/typescript/rebalancer/package.json
@@ -36,7 +36,8 @@
     "test:e2e:ci": "sh -c 'mocha --config .mocharc.e2e.json \"src/e2e/*${REBALANCER_E2E_TEST}*.e2e-test.ts\" --exit'",
     "test:ci": "pnpm test",
     "start": "node dist/service.js",
-    "start:dev": "tsx src/service.ts"
+    "start:dev": "tsx src/service.ts",
+    "bridge:dev": "tsx src/scripts/externalBridge.ts"
   },
   "dependencies": {
     "@google-cloud/pino-logging-gcp-config": "catalog:",

--- a/typescript/rebalancer/src/bridges/KatanaBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/KatanaBridge.test.ts
@@ -1,0 +1,601 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import { pino } from 'pino';
+
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import type {
+  BridgeQuote,
+  BridgeQuoteParams,
+  ExternalBridgeConfig,
+} from '../interfaces/IExternalBridge.js';
+import { KatanaBridge, type KatanaBridgeRoute } from './KatanaBridge.js';
+import {
+  ETHEREUM_CHAIN_ID,
+  KATANA_CHAIN_ID,
+  KATANA_FORWARD_CONFIG,
+  KATANA_REVERSE_CONFIG,
+  applySlippage,
+  buildKatanaEthereumToKatana,
+  buildKatanaToEthereumCompose,
+  composerInterface,
+  oftInterface,
+  previewInterface,
+  type BuiltTx,
+} from './katanaUtils.js';
+
+const testLogger = pino({ level: 'silent' });
+const TEST_PRIVATE_KEY =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const TEST_WALLET = new ethers.Wallet(TEST_PRIVATE_KEY);
+
+const BRIDGE_CONFIG: ExternalBridgeConfig = {
+  integrator: 'hyperlane',
+  chainMetadata: {
+    ethereum: {
+      chainId: ETHEREUM_CHAIN_ID,
+      domainId: ETHEREUM_CHAIN_ID,
+      protocol: ProtocolType.Ethereum,
+      name: 'ethereum',
+      displayName: 'Ethereum',
+      rpcUrls: [{ http: 'https://ethereum.example' }],
+    },
+    katana: {
+      chainId: KATANA_CHAIN_ID,
+      domainId: KATANA_CHAIN_ID,
+      protocol: ProtocolType.Ethereum,
+      name: 'katana',
+      displayName: 'Katana',
+      rpcUrls: [{ http: 'https://katana.example' }],
+    },
+  },
+};
+
+class TestKatanaBridge extends KatanaBridge {
+  readonly callResults = new Map<string, string>();
+  readonly sentCalls: Array<{ chainId: number; key: string; call: BuiltTx }> =
+    [];
+  readonly receipts = new Map<string, ethers.providers.TransactionReceipt>();
+  nextReceipts: ethers.providers.TransactionReceipt[] = [];
+  nextFetchResponse = new Response(JSON.stringify({ messages: [] }), {
+    status: 200,
+  });
+  allowance = 0n;
+
+  setCallResult(
+    chainId: number,
+    to: string,
+    data: string,
+    result: string,
+  ): void {
+    this.callResults.set(`${chainId}:${to.toLowerCase()}:${data}`, result);
+  }
+
+  setReceipt(
+    chainId: number,
+    txHash: string,
+    receipt: ethers.providers.TransactionReceipt,
+  ): void {
+    this.receipts.set(`${chainId}:${txHash.toLowerCase()}`, receipt);
+  }
+
+  protected override async callContract(
+    chainId: number,
+    to: string,
+    data: string,
+  ): Promise<string> {
+    const key = `${chainId}:${to.toLowerCase()}:${data}`;
+    const result = this.callResults.get(key);
+    if (!result) {
+      throw new Error(`Missing test call result for ${key}`);
+    }
+    return result;
+  }
+
+  protected override async readAllowance(
+    _chainId: number,
+    _tokenAddress: string,
+    _owner: string,
+    _spender: string,
+  ): Promise<bigint> {
+    return this.allowance;
+  }
+
+  protected override async sendPreparedTransaction(
+    chainId: number,
+    key: string,
+    call: BuiltTx,
+  ): Promise<ethers.providers.TransactionReceipt> {
+    this.sentCalls.push({ chainId, key, call });
+    const receipt = this.nextReceipts.shift();
+    if (!receipt) {
+      throw new Error('Missing next test receipt');
+    }
+    return receipt;
+  }
+
+  protected override async getTransactionReceipt(
+    chainId: number,
+    txHash: string,
+  ): Promise<ethers.providers.TransactionReceipt | undefined> {
+    return this.receipts.get(`${chainId}:${txHash.toLowerCase()}`);
+  }
+
+  protected override async fetchWithRetry(
+    _url: string,
+    _options?: RequestInit,
+    _retries?: number,
+  ): Promise<Response> {
+    return this.nextFetchResponse;
+  }
+}
+
+function createReceipt(
+  transactionHash: string,
+  logs: ethers.providers.Log[],
+): ethers.providers.TransactionReceipt {
+  return {
+    transactionHash,
+    logs,
+  } as ethers.providers.TransactionReceipt;
+}
+
+function createEventLog(
+  address: string,
+  iface: ethers.utils.Interface,
+  eventName: string,
+  args: unknown[],
+): ethers.providers.Log {
+  const event = iface.getEvent(eventName);
+  const encoded = iface.encodeEventLog(event, args);
+  return {
+    address,
+    data: encoded.data,
+    topics: encoded.topics,
+  } as ethers.providers.Log;
+}
+
+function encodePreviewResult(
+  functionName: 'previewDeposit' | 'previewRedeem',
+  amount: bigint,
+): string {
+  return previewInterface.encodeFunctionResult(functionName, [amount]);
+}
+
+function encodeQuoteSendResult(
+  nativeFee: bigint,
+  lzTokenFee: bigint = 0n,
+): string {
+  return oftInterface.encodeFunctionResult('quoteSend', [
+    [nativeFee, lzTokenFee],
+  ]);
+}
+
+function encodeSecondaryChainBalanceResult(amount: bigint): string {
+  const localInterface = new ethers.utils.Interface([
+    'function secondaryChainBalance() view returns (uint256)',
+  ]);
+  return localInterface.encodeFunctionResult('secondaryChainBalance', [amount]);
+}
+
+function createForwardQuote(
+  route: KatanaBridgeRoute,
+): BridgeQuote<KatanaBridgeRoute> {
+  const requestParams: BridgeQuoteParams = {
+    fromChain: ETHEREUM_CHAIN_ID,
+    toChain: KATANA_CHAIN_ID,
+    fromToken: KATANA_FORWARD_CONFIG.fromToken,
+    toToken: KATANA_FORWARD_CONFIG.toToken,
+    fromAmount: 1_000_000n,
+    fromAddress: TEST_WALLET.address,
+    toAddress: TEST_WALLET.address,
+  };
+
+  return {
+    id: 'quote-forward',
+    tool: 'katana-vault-bridge',
+    fromAmount: requestParams.fromAmount!,
+    toAmount: route.previewAmount,
+    toAmountMin: route.sendParam.minAmountLD,
+    executionDuration: 120,
+    gasCosts: route.nativeFee,
+    feeCosts: 0n,
+    route,
+    requestParams,
+  };
+}
+
+describe('KatanaBridge.quote()', () => {
+  it('builds exact ethereum->katana calldata from previewDeposit + quoteSend', async () => {
+    const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
+    const recipient = TEST_WALLET.address;
+    const fromAmount = 1_000_000n;
+    const previewShares = 999_500n;
+    const nativeFee = 123_456n;
+
+    const previewData = previewInterface.encodeFunctionData('previewDeposit', [
+      fromAmount.toString(),
+    ]);
+    bridge.setCallResult(
+      ETHEREUM_CHAIN_ID,
+      KATANA_FORWARD_CONFIG.vaultAddress,
+      previewData,
+      encodePreviewResult('previewDeposit', previewShares),
+    );
+
+    const exactCall = buildKatanaEthereumToKatana({
+      vaultAddress: KATANA_FORWARD_CONFIG.vaultAddress,
+      composerAddress: KATANA_FORWARD_CONFIG.composerAddress,
+      shareOftAddress: KATANA_FORWARD_CONFIG.shareOftAddress,
+      underlyingTokenAddress: KATANA_FORWARD_CONFIG.fromToken,
+      dstEid: KATANA_FORWARD_CONFIG.dstEid,
+      recipient,
+      amountLD: fromAmount,
+      shareAmountLD: previewShares,
+      minShareAmountLD: applySlippage(previewShares, 0.005),
+      refundAddress: TEST_WALLET.address,
+      extraOptions: KATANA_FORWARD_CONFIG.extraOptions,
+      composeMsg: KATANA_FORWARD_CONFIG.composeMsg,
+      oftCmd: KATANA_FORWARD_CONFIG.oftCmd,
+    });
+    bridge.setCallResult(
+      ETHEREUM_CHAIN_ID,
+      exactCall.quoteRead.to,
+      exactCall.quoteRead.data,
+      encodeQuoteSendResult(nativeFee),
+    );
+
+    const quote = await bridge.quote({
+      fromChain: ETHEREUM_CHAIN_ID,
+      toChain: KATANA_CHAIN_ID,
+      fromToken: KATANA_FORWARD_CONFIG.fromToken,
+      toToken: KATANA_FORWARD_CONFIG.toToken,
+      fromAmount,
+      fromAddress: TEST_WALLET.address,
+      toAddress: recipient,
+    });
+
+    expect(quote.toAmount).to.equal(previewShares);
+    expect(quote.toAmountMin).to.equal(applySlippage(previewShares, 0.005));
+    expect(quote.gasCosts).to.equal(nativeFee);
+    expect(quote.route.executionCall.value).to.equal(nativeFee);
+    expect(quote.route.executionCall.data).to.equal(
+      exactCall.depositAndSendTx.data,
+    );
+    expect(quote.route.sendParam.amountLD).to.equal(previewShares);
+  });
+
+  it('builds exact katana->ethereum calldata from previewRedeem + quoteSend', async () => {
+    const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
+    const shareAmount = 1_000_000n;
+    const previewAssets = 998_000n;
+    const nativeFee = 456_789n;
+
+    const previewData = previewInterface.encodeFunctionData('previewRedeem', [
+      shareAmount.toString(),
+    ]);
+    bridge.setCallResult(
+      ETHEREUM_CHAIN_ID,
+      KATANA_REVERSE_CONFIG.vaultAddress,
+      previewData,
+      encodePreviewResult('previewRedeem', previewAssets),
+    );
+
+    const exactCall = buildKatanaToEthereumCompose({
+      vaultAddress: KATANA_REVERSE_CONFIG.vaultAddress,
+      composerAddress: KATANA_REVERSE_CONFIG.composerAddress,
+      shareTokenAddress: KATANA_REVERSE_CONFIG.shareTokenAddress,
+      shareOftAddress: KATANA_REVERSE_CONFIG.shareOftAddress,
+      dstEid: KATANA_REVERSE_CONFIG.dstEid,
+      recipient: TEST_WALLET.address,
+      shareAmountLD: shareAmount,
+      minShareAmountLD: shareAmount,
+      assetAmountLD: previewAssets,
+      minAssetAmountLD: applySlippage(previewAssets, 0.005),
+      refundAddress: TEST_WALLET.address,
+      extraOptions: KATANA_REVERSE_CONFIG.extraOptions,
+      receiveExtraOptions: KATANA_REVERSE_CONFIG.receiveExtraOptions,
+      oftCmd: KATANA_REVERSE_CONFIG.oftCmd,
+    });
+    bridge.setCallResult(
+      KATANA_CHAIN_ID,
+      exactCall.quoteRead.to,
+      exactCall.quoteRead.data,
+      encodeQuoteSendResult(nativeFee),
+    );
+    bridge.setCallResult(
+      KATANA_CHAIN_ID,
+      KATANA_REVERSE_CONFIG.shareOftAddress,
+      oftInterface.encodeFunctionData('secondaryChainBalance', []),
+      encodeSecondaryChainBalanceResult(2_000_000n),
+    );
+
+    const quote = await bridge.quote({
+      fromChain: KATANA_CHAIN_ID,
+      toChain: ETHEREUM_CHAIN_ID,
+      fromToken: KATANA_REVERSE_CONFIG.fromToken,
+      toToken: KATANA_REVERSE_CONFIG.toToken,
+      fromAmount: shareAmount,
+      fromAddress: TEST_WALLET.address,
+      toAddress: TEST_WALLET.address,
+    });
+
+    expect(quote.toAmount).to.equal(previewAssets);
+    expect(quote.toAmountMin).to.equal(applySlippage(previewAssets, 0.005));
+    expect(quote.gasCosts).to.equal(nativeFee);
+    expect(quote.route.executionCall.value).to.equal(nativeFee);
+    expect(quote.route.executionCall.data).to.equal(
+      oftInterface.encodeFunctionData('send', [
+        exactCall.sendParam,
+        { nativeFee, lzTokenFee: 0 },
+        TEST_WALLET.address,
+      ]),
+    );
+  });
+
+  it('rejects unsupported toAmount quotes', async () => {
+    const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
+    try {
+      await bridge.quote({
+        fromChain: ETHEREUM_CHAIN_ID,
+        toChain: KATANA_CHAIN_ID,
+        fromToken: KATANA_FORWARD_CONFIG.fromToken,
+        toToken: KATANA_FORWARD_CONFIG.toToken,
+        toAmount: 1n,
+        fromAddress: TEST_WALLET.address,
+      });
+      expect.fail('Expected quote to reject');
+    } catch (error) {
+      expect((error as Error).message).to.include('does not support toAmount');
+    }
+  });
+
+  it('rejects reverse quotes when secondaryChainBalance is insufficient', async () => {
+    const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
+    const shareAmount = 1_000_000n;
+    const previewData = previewInterface.encodeFunctionData('previewRedeem', [
+      shareAmount.toString(),
+    ]);
+    bridge.setCallResult(
+      ETHEREUM_CHAIN_ID,
+      KATANA_REVERSE_CONFIG.vaultAddress,
+      previewData,
+      encodePreviewResult('previewRedeem', 999_000n),
+    );
+
+    const exactCall = buildKatanaToEthereumCompose({
+      vaultAddress: KATANA_REVERSE_CONFIG.vaultAddress,
+      composerAddress: KATANA_REVERSE_CONFIG.composerAddress,
+      shareTokenAddress: KATANA_REVERSE_CONFIG.shareTokenAddress,
+      shareOftAddress: KATANA_REVERSE_CONFIG.shareOftAddress,
+      dstEid: KATANA_REVERSE_CONFIG.dstEid,
+      recipient: TEST_WALLET.address,
+      shareAmountLD: shareAmount,
+      minShareAmountLD: shareAmount,
+      assetAmountLD: 999_000n,
+      minAssetAmountLD: applySlippage(999_000n, 0.005),
+      refundAddress: TEST_WALLET.address,
+      extraOptions: KATANA_REVERSE_CONFIG.extraOptions,
+      receiveExtraOptions: KATANA_REVERSE_CONFIG.receiveExtraOptions,
+      oftCmd: KATANA_REVERSE_CONFIG.oftCmd,
+    });
+    bridge.setCallResult(
+      KATANA_CHAIN_ID,
+      exactCall.quoteRead.to,
+      exactCall.quoteRead.data,
+      encodeQuoteSendResult(1n),
+    );
+    bridge.setCallResult(
+      KATANA_CHAIN_ID,
+      KATANA_REVERSE_CONFIG.shareOftAddress,
+      oftInterface.encodeFunctionData('secondaryChainBalance', []),
+      encodeSecondaryChainBalanceResult(999_999n),
+    );
+
+    try {
+      await bridge.quote({
+        fromChain: KATANA_CHAIN_ID,
+        toChain: ETHEREUM_CHAIN_ID,
+        fromToken: KATANA_REVERSE_CONFIG.fromToken,
+        toToken: KATANA_REVERSE_CONFIG.toToken,
+        fromAmount: shareAmount,
+        fromAddress: TEST_WALLET.address,
+      });
+      expect.fail('Expected quote to reject');
+    } catch (error) {
+      expect((error as Error).message).to.include(
+        'Insufficient Katana secondaryChainBalance',
+      );
+    }
+  });
+});
+
+describe('KatanaBridge.execute()', () => {
+  it('sends approval then execution and extracts the guid', async () => {
+    const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
+    const guid =
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const exactCall = buildKatanaEthereumToKatana({
+      vaultAddress: KATANA_FORWARD_CONFIG.vaultAddress,
+      composerAddress: KATANA_FORWARD_CONFIG.composerAddress,
+      shareOftAddress: KATANA_FORWARD_CONFIG.shareOftAddress,
+      underlyingTokenAddress: KATANA_FORWARD_CONFIG.fromToken,
+      dstEid: KATANA_FORWARD_CONFIG.dstEid,
+      recipient: TEST_WALLET.address,
+      amountLD: 1_000_000n,
+      shareAmountLD: 999_000n,
+      minShareAmountLD: 998_000n,
+      refundAddress: TEST_WALLET.address,
+      extraOptions: KATANA_FORWARD_CONFIG.extraOptions,
+      composeMsg: KATANA_FORWARD_CONFIG.composeMsg,
+      oftCmd: KATANA_FORWARD_CONFIG.oftCmd,
+    });
+    const route: KatanaBridgeRoute = {
+      kind: 'ethereum-to-katana',
+      fromChainId: ETHEREUM_CHAIN_ID,
+      toChainId: KATANA_CHAIN_ID,
+      fromToken: KATANA_FORWARD_CONFIG.fromToken,
+      toToken: KATANA_FORWARD_CONFIG.toToken,
+      recipient: TEST_WALLET.address,
+      refundAddress: TEST_WALLET.address,
+      previewAmount: 999_000n,
+      nativeFee: 123n,
+      sendParam: exactCall.sendParam,
+      quoteRead: exactCall.quoteRead,
+      approvalCall: exactCall.assetApproveTx,
+      executionCall: { ...exactCall.depositAndSendTx, value: 123n },
+    };
+    const quote = createForwardQuote(route);
+
+    bridge.allowance = 0n;
+    bridge.nextReceipts = [
+      createReceipt('0xapprove', []),
+      createReceipt('0xexecute', [
+        createEventLog(route.executionCall.to, oftInterface, 'OFTSent', [
+          guid,
+          KATANA_FORWARD_CONFIG.dstEid,
+          TEST_WALLET.address,
+          999_000n,
+          999_000n,
+        ]),
+      ]),
+    ];
+
+    const result = await bridge.execute(quote, {
+      [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+    });
+
+    expect(result.txHash).to.equal('0xexecute');
+    expect(result.transferId).to.equal(guid);
+    expect(bridge.sentCalls).to.have.length(2);
+    expect(bridge.sentCalls[0].call.data).to.equal(route.approvalCall.data);
+    expect(bridge.sentCalls[1].call.data).to.equal(route.executionCall.data);
+    expect(bridge.sentCalls[1].call.value).to.equal(123n);
+  });
+
+  it('skips approval when allowance is sufficient', async () => {
+    const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
+    const exactCall = buildKatanaEthereumToKatana({
+      vaultAddress: KATANA_FORWARD_CONFIG.vaultAddress,
+      composerAddress: KATANA_FORWARD_CONFIG.composerAddress,
+      shareOftAddress: KATANA_FORWARD_CONFIG.shareOftAddress,
+      underlyingTokenAddress: KATANA_FORWARD_CONFIG.fromToken,
+      dstEid: KATANA_FORWARD_CONFIG.dstEid,
+      recipient: TEST_WALLET.address,
+      amountLD: 1_000_000n,
+      shareAmountLD: 999_000n,
+      minShareAmountLD: 998_000n,
+      refundAddress: TEST_WALLET.address,
+      extraOptions: KATANA_FORWARD_CONFIG.extraOptions,
+      composeMsg: KATANA_FORWARD_CONFIG.composeMsg,
+      oftCmd: KATANA_FORWARD_CONFIG.oftCmd,
+    });
+    const route: KatanaBridgeRoute = {
+      kind: 'ethereum-to-katana',
+      fromChainId: ETHEREUM_CHAIN_ID,
+      toChainId: KATANA_CHAIN_ID,
+      fromToken: KATANA_FORWARD_CONFIG.fromToken,
+      toToken: KATANA_FORWARD_CONFIG.toToken,
+      recipient: TEST_WALLET.address,
+      refundAddress: TEST_WALLET.address,
+      previewAmount: 999_000n,
+      nativeFee: 123n,
+      sendParam: exactCall.sendParam,
+      quoteRead: exactCall.quoteRead,
+      approvalCall: exactCall.assetApproveTx,
+      executionCall: { ...exactCall.depositAndSendTx, value: 123n },
+    };
+    const quote = createForwardQuote(route);
+
+    bridge.allowance = route.approvalCall.amount;
+    bridge.nextReceipts = [createReceipt('0xexecute', [])];
+
+    await bridge.execute(quote, {
+      [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+    });
+
+    expect(bridge.sentCalls).to.have.length(1);
+    expect(bridge.sentCalls[0].call.data).to.equal(route.executionCall.data);
+  });
+});
+
+describe('KatanaBridge.getStatus()', () => {
+  it('parses forward destination OFTReceived amount', async () => {
+    const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
+    bridge.nextFetchResponse = new Response(
+      JSON.stringify({
+        messages: [{ status: 'DELIVERED', dstTxHash: '0xdstforward' }],
+      }),
+      { status: 200 },
+    );
+    bridge.setReceipt(
+      KATANA_CHAIN_ID,
+      '0xdstforward',
+      createReceipt('0xdstforward', [
+        createEventLog(
+          KATANA_FORWARD_CONFIG.destinationShareOftAddress,
+          oftInterface,
+          'OFTReceived',
+          [
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            KATANA_FORWARD_CONFIG.dstEid,
+            TEST_WALLET.address,
+            777_000n,
+          ],
+        ),
+      ]),
+    );
+
+    const status = await bridge.getStatus(
+      '0xsource',
+      ETHEREUM_CHAIN_ID,
+      KATANA_CHAIN_ID,
+    );
+
+    expect(status).to.deep.equal({
+      status: 'complete',
+      receivingTxHash: '0xdstforward',
+      receivedAmount: 777_000n,
+    });
+  });
+
+  it('parses reverse destination Redeemed amount', async () => {
+    const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
+    bridge.nextFetchResponse = new Response(
+      JSON.stringify({
+        messages: [{ status: 'DELIVERED', dstTxHash: '0xdstreverse' }],
+      }),
+      { status: 200 },
+    );
+    bridge.setReceipt(
+      ETHEREUM_CHAIN_ID,
+      '0xdstreverse',
+      createReceipt('0xdstreverse', [
+        createEventLog(
+          KATANA_REVERSE_CONFIG.composerAddress,
+          composerInterface,
+          'Redeemed',
+          [
+            '0x0000000000000000000000000000000000000000000000000000000000000000',
+            '0x0000000000000000000000000000000000000000000000000000000000000000',
+            KATANA_REVERSE_CONFIG.dstEid,
+            500_000n,
+            499_000n,
+          ],
+        ),
+      ]),
+    );
+
+    const status = await bridge.getStatus(
+      '0xsource',
+      KATANA_CHAIN_ID,
+      ETHEREUM_CHAIN_ID,
+    );
+
+    expect(status).to.deep.equal({
+      status: 'complete',
+      receivingTxHash: '0xdstreverse',
+      receivedAmount: 499_000n,
+    });
+  });
+});

--- a/typescript/rebalancer/src/bridges/KatanaBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/KatanaBridge.test.ts
@@ -100,6 +100,12 @@ class TestKatanaBridge extends KatanaBridge {
   protected override async sleep(): Promise<void> {}
 }
 
+class InspectingKatanaBridge extends KatanaBridge {
+  getProviderFor(chainId: number): ethers.providers.StaticJsonRpcProvider {
+    return this.getProvider(chainId);
+  }
+}
+
 function createReceipt(
   transactionHash: string,
 ): ethers.providers.TransactionReceipt {
@@ -352,5 +358,31 @@ describe('KatanaBridge', () => {
       receivingTxHash: '0xreceivingtx',
       receivedAmount: 5_000_000n,
     });
+  });
+
+  it('uses static EVM providers and ignores non-EVM chainId collisions', () => {
+    const bridge = new InspectingKatanaBridge(
+      {
+        ...BRIDGE_CONFIG,
+        chainMetadata: {
+          ...BRIDGE_CONFIG.chainMetadata,
+          collision: {
+            chainId: ETHEREUM_CHAIN_ID,
+            domainId: 999_999,
+            protocol: ProtocolType.Sealevel,
+            name: 'collision',
+            displayName: 'Collision',
+            rpcUrls: [{ http: 'https://wrong.example' }],
+          },
+        },
+      },
+      testLogger,
+    );
+
+    const provider = bridge.getProviderFor(ETHEREUM_CHAIN_ID);
+
+    expect(provider).to.be.instanceOf(ethers.providers.StaticJsonRpcProvider);
+    expect(provider.connection.url).to.equal('https://ethereum.example');
+    expect(provider.network.chainId).to.equal(ETHEREUM_CHAIN_ID);
   });
 });

--- a/typescript/rebalancer/src/bridges/KatanaBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/KatanaBridge.test.ts
@@ -10,16 +10,21 @@ import type {
 } from '../interfaces/IExternalBridge.js';
 import { KatanaBridge, type KatanaBridgeRoute } from './KatanaBridge.js';
 import {
+  ERC20_ABI,
   ETHEREUM_CHAIN_ID,
   KATANA_CHAIN_ID,
   KATANA_FORWARD_CONFIG,
   KATANA_REVERSE_CONFIG,
+  oftInterface,
+  previewInterface,
 } from './katanaUtils.js';
 
 const testLogger = pino({ level: 'silent' });
 const TEST_PRIVATE_KEY =
   '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const TEST_WALLET = new ethers.Wallet(TEST_PRIVATE_KEY);
+const TEST_GUID = ethers.utils.hexZeroPad('0x1111', 32);
+const erc20Interface = new ethers.utils.Interface(ERC20_ABI);
 
 const BRIDGE_CONFIG: ExternalBridgeConfig = {
   integrator: 'hyperlane',
@@ -48,7 +53,20 @@ class TestKatanaBridge extends KatanaBridge {
   routeResponses: any[] = [];
   transactionResponses: any[][] = [];
   claimResponses: Array<any | Error> = [];
+  contractReadResults: string[] = [];
+  contractReads: Array<{ chainId: number; to: string; data: string }> = [];
+  currentBlockNumber = 1234;
   nextReceipts: ethers.providers.TransactionReceipt[] = [];
+  receiptResponses = new Map<
+    string,
+    ethers.providers.TransactionReceipt | null
+  >();
+  transactionDetails = new Map<
+    string,
+    ethers.providers.TransactionResponse | null
+  >();
+  logResponses: ethers.providers.Log[][] = [];
+  logFilters: ethers.providers.Filter[] = [];
   sentTransactions: Array<{ chainId: number; tx: any }> = [];
   allowance = 0n;
   lastRouteRequest?: Record<string, unknown>;
@@ -86,6 +104,49 @@ class TestKatanaBridge extends KatanaBridge {
     return this.allowance;
   }
 
+  protected override async readContract(
+    chainId: number,
+    to: string,
+    data: string,
+  ): Promise<string> {
+    this.contractReads.push({ chainId, to, data });
+    const result = this.contractReadResults.shift();
+    if (!result) throw new Error('Missing readContract response');
+    return result;
+  }
+
+  protected override async getCurrentBlockNumber(
+    _chainId: number,
+  ): Promise<number> {
+    return this.currentBlockNumber;
+  }
+
+  protected override async getTransactionReceipt(
+    chainId: number,
+    txHash: string,
+  ): Promise<ethers.providers.TransactionReceipt | null> {
+    return (
+      this.receiptResponses.get(`${chainId}:${txHash.toLowerCase()}`) ?? null
+    );
+  }
+
+  protected override async getTransaction(
+    chainId: number,
+    txHash: string,
+  ): Promise<ethers.providers.TransactionResponse | null> {
+    return (
+      this.transactionDetails.get(`${chainId}:${txHash.toLowerCase()}`) ?? null
+    );
+  }
+
+  protected override async getLogs(
+    _chainId: number,
+    filter: ethers.providers.Filter,
+  ): Promise<ethers.providers.Log[]> {
+    this.logFilters.push(filter);
+    return this.logResponses.shift() ?? [];
+  }
+
   protected override async sendPreparedTransaction(
     chainId: number,
     _privateKey: string,
@@ -106,10 +167,106 @@ class InspectingKatanaBridge extends KatanaBridge {
   }
 }
 
+class FeeRefreshingKatanaBridge extends KatanaBridge {
+  latestBlock: Partial<ethers.providers.Block> = {};
+  feeData: ethers.providers.FeeData = {
+    gasPrice: null,
+    maxFeePerGas: null,
+    maxPriorityFeePerGas: null,
+    lastBaseFeePerGas: null,
+  };
+
+  protected override async getLatestBlock(
+    _chainId: number,
+  ): Promise<ethers.providers.Block> {
+    return this.latestBlock as ethers.providers.Block;
+  }
+
+  protected override async getFeeData(
+    _chainId: number,
+  ): Promise<ethers.providers.FeeData> {
+    return this.feeData;
+  }
+
+  async inspectFeeOverrides(
+    tx: any,
+  ): Promise<
+    Pick<
+      ethers.providers.TransactionRequest,
+      'gasPrice' | 'maxFeePerGas' | 'maxPriorityFeePerGas'
+    >
+  > {
+    return this.resolveFeeOverrides(ETHEREUM_CHAIN_ID, tx);
+  }
+}
+
 function createReceipt(
   transactionHash: string,
+  logs: ethers.providers.Log[] = [],
 ): ethers.providers.TransactionReceipt {
-  return { transactionHash } as ethers.providers.TransactionReceipt;
+  return { transactionHash, logs } as ethers.providers.TransactionReceipt;
+}
+
+function createOftSentLog(
+  transactionHash: string,
+  amount: bigint,
+): ethers.providers.Log {
+  const encoded = oftInterface.encodeEventLog(
+    oftInterface.getEvent('OFTSent'),
+    [
+      TEST_GUID,
+      30101,
+      TEST_WALLET.address,
+      amount.toString(),
+      amount.toString(),
+    ],
+  );
+  return {
+    address: KATANA_REVERSE_CONFIG.shareOftAddress,
+    topics: encoded.topics,
+    data: encoded.data,
+    transactionHash,
+  } as ethers.providers.Log;
+}
+
+function createOftReceivedLog(transactionHash: string): ethers.providers.Log {
+  const encoded = oftInterface.encodeEventLog(
+    oftInterface.getEvent('OFTReceived'),
+    [TEST_GUID, 30375, KATANA_FORWARD_CONFIG.composerAddress, '4800000'],
+  );
+  return {
+    address: KATANA_FORWARD_CONFIG.shareOftAddress,
+    topics: encoded.topics,
+    data: encoded.data,
+    transactionHash,
+  } as ethers.providers.Log;
+}
+
+function createComposeSentLog(transactionHash: string): ethers.providers.Log {
+  return {
+    address: KATANA_REVERSE_CONFIG.composerAddress,
+    topics: [ethers.utils.id('Sent(bytes32)'), TEST_GUID],
+    data: '0x',
+    transactionHash,
+  } as ethers.providers.Log;
+}
+
+function createErc20TransferLog(
+  transactionHash: string,
+  token: string,
+  recipient: string,
+  amount: bigint,
+): ethers.providers.Log {
+  const encoded = erc20Interface.encodeEventLog(
+    erc20Interface.getEvent('Transfer'),
+    [ethers.constants.AddressZero, recipient, amount.toString()],
+  );
+  return {
+    address: token,
+    topics: encoded.topics,
+    data: encoded.data,
+    transactionHash,
+  } as ethers.providers.Log;
 }
 
 function createRoute(overrides?: Partial<any>): any {
@@ -193,27 +350,13 @@ describe('KatanaBridge', () => {
     expect(quote.route.executionTx.chainId).to.equal(ETHEREUM_CHAIN_ID);
   });
 
-  it('quotes katana -> ethereum via ARC route', async () => {
+  it('quotes katana -> ethereum via OFT compose route', async () => {
     const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
-    bridge.routeResponses = [
-      createRoute({
-        fromChainId: KATANA_CHAIN_ID,
-        toChainId: ETHEREUM_CHAIN_ID,
-        transactionRequest: {
-          from: TEST_WALLET.address.toLowerCase(),
-          to: '0x2a3dd3eb832af982ec71669e178424b10dca2ede',
-          data: '0xbeef',
-          value: '0',
-          gasLimit: '400000',
-          gasPrice: '1000000000',
-          chainId: KATANA_CHAIN_ID,
-        },
-        providerMetadata: {
-          agglayer: {
-            claimTransactionRequired: true,
-          },
-        },
-      }),
+    bridge.contractReadResults = [
+      previewInterface.encodeFunctionResult('previewRedeem', ['4800000']),
+      oftInterface.encodeFunctionResult('quoteSend', [
+        { nativeFee: '400000000000000', lzTokenFee: '0' },
+      ]),
     ];
 
     const quote = await bridge.quote({
@@ -226,63 +369,62 @@ describe('KatanaBridge', () => {
       toAddress: TEST_WALLET.address,
     });
 
-    expect(quote.route.claimTransactionRequired).to.equal(true);
+    expect(quote.toAmount).to.equal(4_800_000n);
+    expect(quote.toAmountMin).to.equal(4_776_000n);
+    expect(quote.gasCosts).to.equal(400_000_000_000_000n);
+    expect(quote.route.claimTransactionRequired).to.equal(false);
+    expect(quote.route.statusMode).to.equal('oft');
     expect(quote.route.executionTx.chainId).to.equal(KATANA_CHAIN_ID);
+    expect(quote.route.executionTx.to).to.equal(
+      KATANA_REVERSE_CONFIG.shareOftAddress,
+    );
+    expect(quote.route.approvalAddress).to.equal(
+      KATANA_REVERSE_CONFIG.shareOftAddress,
+    );
+    expect(bridge.contractReads[0].chainId).to.equal(ETHEREUM_CHAIN_ID);
+    expect(bridge.contractReads[0].to).to.equal(
+      KATANA_REVERSE_CONFIG.vaultAddress,
+    );
+    expect(bridge.contractReads[1].chainId).to.equal(KATANA_CHAIN_ID);
+    expect(bridge.contractReads[1].to).to.equal(
+      KATANA_REVERSE_CONFIG.shareOftAddress,
+    );
   });
 
   it('rejects reverse quote mode', async () => {
     const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
-
-    await expect(
-      bridge.quote({
+    let error: unknown;
+    try {
+      await bridge.quote({
         fromChain: ETHEREUM_CHAIN_ID,
         toChain: KATANA_CHAIN_ID,
         fromToken: KATANA_FORWARD_CONFIG.fromToken,
         toToken: KATANA_FORWARD_CONFIG.toToken,
         toAmount: 5_000_000n,
         fromAddress: TEST_WALLET.address,
-      }),
-    ).to.be.rejectedWith('KatanaBridge only supports fromAmount');
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).to.be.instanceOf(Error);
+    expect((error as Error).message).to.contain(
+      'KatanaBridge only supports fromAmount',
+    );
   });
 
-  it('executes katana -> ethereum with approval and claim submission', async () => {
+  it('executes katana -> ethereum with OFT approval and send', async () => {
     const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
-    bridge.routeResponses = [
-      createRoute({
-        fromChainId: KATANA_CHAIN_ID,
-        toChainId: ETHEREUM_CHAIN_ID,
-        transactionRequest: {
-          from: TEST_WALLET.address.toLowerCase(),
-          to: '0x2a3dd3eb832af982ec71669e178424b10dca2ede',
-          data: '0xbeef',
-          value: '0',
-          gasLimit: '400000',
-          gasPrice: '1000000000',
-          chainId: KATANA_CHAIN_ID,
-        },
-        providerMetadata: {
-          agglayer: {
-            claimTransactionRequired: true,
-          },
-        },
-      }),
+    bridge.contractReadResults = [
+      previewInterface.encodeFunctionResult('previewRedeem', ['4800000']),
+      oftInterface.encodeFunctionResult('quoteSend', [
+        { nativeFee: '400000000000000', lzTokenFee: '0' },
+      ]),
     ];
     bridge.allowance = 0n;
     bridge.nextReceipts = [
       createReceipt('0xapprove'),
-      createReceipt('0xsourcetx'),
-      createReceipt('0xclaimtx'),
-    ];
-    bridge.transactionResponses = [[], [createTransaction()]];
-    bridge.claimResponses = [
-      {
-        to: '0x2a3dd3eb832af982ec71669e178424b10dca2ede',
-        data: '0xclaim',
-        value: '0',
-        gasLimit: '500000',
-        gasPrice: '1000000000',
-        chainId: ETHEREUM_CHAIN_ID,
-      },
+      createReceipt('0xsourcetx', [createOftSentLog('0xsourcetx', 5_000_000n)]),
     ];
 
     const quote = (await bridge.quote({
@@ -300,10 +442,13 @@ describe('KatanaBridge', () => {
     });
 
     expect(result.txHash).to.equal('0xsourcetx');
-    expect(bridge.sentTransactions).to.have.length(3);
+    expect(bridge.sentTransactions).to.have.length(2);
     expect(bridge.sentTransactions[0].chainId).to.equal(KATANA_CHAIN_ID);
     expect(bridge.sentTransactions[1].chainId).to.equal(KATANA_CHAIN_ID);
-    expect(bridge.sentTransactions[2].chainId).to.equal(ETHEREUM_CHAIN_ID);
+    expect(bridge.sentTransactions[1].tx.to).to.equal(
+      KATANA_REVERSE_CONFIG.shareOftAddress,
+    );
+    expect(bridge.sentTransactions[1].tx.value).to.equal('400000000000000');
   });
 
   it('reads completion from ARC transaction status', async () => {
@@ -360,6 +505,171 @@ describe('KatanaBridge', () => {
     });
   });
 
+  it('reads completion from OFT destination receipt', async () => {
+    const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
+    bridge.contractReadResults = [
+      previewInterface.encodeFunctionResult('previewRedeem', ['4800000']),
+      oftInterface.encodeFunctionResult('quoteSend', [
+        { nativeFee: '400000000000000', lzTokenFee: '0' },
+      ]),
+    ];
+    bridge.allowance = 5_000_000n;
+    bridge.nextReceipts = [
+      createReceipt('0xsourcetx', [createOftSentLog('0xsourcetx', 5_000_000n)]),
+    ];
+
+    const quote = (await bridge.quote({
+      fromChain: KATANA_CHAIN_ID,
+      toChain: ETHEREUM_CHAIN_ID,
+      fromToken: KATANA_REVERSE_CONFIG.fromToken,
+      toToken: KATANA_REVERSE_CONFIG.toToken,
+      fromAmount: 5_000_000n,
+      fromAddress: TEST_WALLET.address,
+      toAddress: TEST_WALLET.address,
+    })) as BridgeQuote<KatanaBridgeRoute>;
+
+    await bridge.execute(quote, {
+      [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+    });
+
+    bridge.receiptResponses.set(
+      `${KATANA_CHAIN_ID}:0xsourcetx`,
+      createReceipt('0xsourcetx', [createOftSentLog('0xsourcetx', 5_000_000n)]),
+    );
+    bridge.logResponses = [[createOftReceivedLog('0xdesttx')]];
+    bridge.receiptResponses.set(
+      `${ETHEREUM_CHAIN_ID}:0xdesttx`,
+      createReceipt('0xdesttx', [
+        createErc20TransferLog(
+          '0xdesttx',
+          KATANA_REVERSE_CONFIG.toToken,
+          TEST_WALLET.address,
+          4_800_000n,
+        ),
+      ]),
+    );
+
+    const status = await bridge.getStatus(
+      '0xsourcetx',
+      KATANA_CHAIN_ID,
+      ETHEREUM_CHAIN_ID,
+    );
+
+    expect(status).to.deep.equal({
+      status: 'complete',
+      receivingTxHash: '0xdesttx',
+      receivedAmount: 4_800_000n,
+    });
+  });
+
+  it('reads completion from follow-up composer tx after OFT receipt', async () => {
+    const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
+    bridge.contractReadResults = [
+      previewInterface.encodeFunctionResult('previewRedeem', ['4800000']),
+      oftInterface.encodeFunctionResult('quoteSend', [
+        { nativeFee: '400000000000000', lzTokenFee: '0' },
+      ]),
+    ];
+    bridge.allowance = 5_000_000n;
+    bridge.nextReceipts = [
+      createReceipt('0xsourcetx', [createOftSentLog('0xsourcetx', 5_000_000n)]),
+    ];
+
+    const quote = (await bridge.quote({
+      fromChain: KATANA_CHAIN_ID,
+      toChain: ETHEREUM_CHAIN_ID,
+      fromToken: KATANA_REVERSE_CONFIG.fromToken,
+      toToken: KATANA_REVERSE_CONFIG.toToken,
+      fromAmount: 5_000_000n,
+      fromAddress: TEST_WALLET.address,
+      toAddress: TEST_WALLET.address,
+    })) as BridgeQuote<KatanaBridgeRoute>;
+
+    await bridge.execute(quote, {
+      [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+    });
+
+    bridge.receiptResponses.set(
+      `${KATANA_CHAIN_ID}:0xsourcetx`,
+      createReceipt('0xsourcetx', [createOftSentLog('0xsourcetx', 5_000_000n)]),
+    );
+    bridge.logResponses = [
+      [createOftReceivedLog('0xdesttx')],
+      [createComposeSentLog('0xcomposetx')],
+    ];
+    bridge.receiptResponses.set(
+      `${ETHEREUM_CHAIN_ID}:0xdesttx`,
+      createReceipt('0xdesttx'),
+    );
+    bridge.receiptResponses.set(
+      `${ETHEREUM_CHAIN_ID}:0xcomposetx`,
+      createReceipt('0xcomposetx', [
+        createErc20TransferLog(
+          '0xcomposetx',
+          KATANA_REVERSE_CONFIG.toToken,
+          TEST_WALLET.address,
+          4_800_000n,
+        ),
+      ]),
+    );
+
+    const status = await bridge.getStatus(
+      '0xsourcetx',
+      KATANA_CHAIN_ID,
+      ETHEREUM_CHAIN_ID,
+    );
+
+    expect(status).to.deep.equal({
+      status: 'complete',
+      receivingTxHash: '0xcomposetx',
+      receivedAmount: 4_800_000n,
+    });
+  });
+
+  it('rehydrates reverse OFT status from tx hash without prior execute state', async () => {
+    const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
+    bridge.currentBlockNumber = 100_000;
+    bridge.transactionDetails.set(`${KATANA_CHAIN_ID}:0xsourcetx`, {
+      from: TEST_WALLET.address,
+    } as ethers.providers.TransactionResponse);
+    bridge.receiptResponses.set(
+      `${KATANA_CHAIN_ID}:0xsourcetx`,
+      createReceipt('0xsourcetx', [createOftSentLog('0xsourcetx', 5_000_000n)]),
+    );
+    bridge.logResponses = [
+      [createOftReceivedLog('0xdesttx')],
+      [createComposeSentLog('0xcomposetx')],
+    ];
+    bridge.receiptResponses.set(
+      `${ETHEREUM_CHAIN_ID}:0xdesttx`,
+      createReceipt('0xdesttx'),
+    );
+    bridge.receiptResponses.set(
+      `${ETHEREUM_CHAIN_ID}:0xcomposetx`,
+      createReceipt('0xcomposetx', [
+        createErc20TransferLog(
+          '0xcomposetx',
+          KATANA_REVERSE_CONFIG.toToken,
+          TEST_WALLET.address,
+          4_800_000n,
+        ),
+      ]),
+    );
+
+    const status = await bridge.getStatus(
+      '0xsourcetx',
+      KATANA_CHAIN_ID,
+      ETHEREUM_CHAIN_ID,
+    );
+
+    expect(status).to.deep.equal({
+      status: 'complete',
+      receivingTxHash: '0xcomposetx',
+      receivedAmount: 4_800_000n,
+    });
+    expect(bridge.logFilters[0].fromBlock).to.equal(50_001);
+  });
+
   it('uses static EVM providers and ignores non-EVM chainId collisions', () => {
     const bridge = new InspectingKatanaBridge(
       {
@@ -384,5 +694,42 @@ describe('KatanaBridge', () => {
     expect(provider).to.be.instanceOf(ethers.providers.StaticJsonRpcProvider);
     expect(provider.connection.url).to.equal('https://ethereum.example');
     expect(provider.network.chainId).to.equal(ETHEREUM_CHAIN_ID);
+  });
+
+  it('refreshes stale gas price when it is below base fee', async () => {
+    const bridge = new FeeRefreshingKatanaBridge(BRIDGE_CONFIG, testLogger);
+    bridge.latestBlock = {
+      baseFeePerGas: ethers.BigNumber.from('1021381537'),
+    };
+    bridge.feeData = {
+      gasPrice: ethers.BigNumber.from('1021881537'),
+      maxFeePerGas: ethers.BigNumber.from('1200000000'),
+      maxPriorityFeePerGas: ethers.BigNumber.from('1000000'),
+      lastBaseFeePerGas: null,
+    };
+
+    const feeOverrides = await bridge.inspectFeeOverrides(
+      createRoute().transactionRequest,
+    );
+
+    expect(feeOverrides.gasPrice).to.equal(undefined);
+    expect(feeOverrides.maxFeePerGas?.toString()).to.equal('1200000000');
+    expect(feeOverrides.maxPriorityFeePerGas?.toString()).to.equal('1000000');
+  });
+
+  it('keeps provided gas price when it is already viable', async () => {
+    const bridge = new FeeRefreshingKatanaBridge(BRIDGE_CONFIG, testLogger);
+    bridge.latestBlock = {
+      baseFeePerGas: ethers.BigNumber.from('1000000000'),
+    };
+
+    const feeOverrides = await bridge.inspectFeeOverrides({
+      ...createRoute().transactionRequest,
+      gasPrice: '1100000000',
+    });
+
+    expect(feeOverrides.gasPrice?.toString()).to.equal('1100000000');
+    expect(feeOverrides.maxFeePerGas).to.equal(undefined);
+    expect(feeOverrides.maxPriorityFeePerGas).to.equal(undefined);
   });
 });

--- a/typescript/rebalancer/src/bridges/KatanaBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/KatanaBridge.test.ts
@@ -6,7 +6,6 @@ import { ProtocolType } from '@hyperlane-xyz/utils';
 
 import type {
   BridgeQuote,
-  BridgeQuoteParams,
   ExternalBridgeConfig,
 } from '../interfaces/IExternalBridge.js';
 import { KatanaBridge, type KatanaBridgeRoute } from './KatanaBridge.js';
@@ -15,13 +14,6 @@ import {
   KATANA_CHAIN_ID,
   KATANA_FORWARD_CONFIG,
   KATANA_REVERSE_CONFIG,
-  applySlippage,
-  buildKatanaEthereumToKatana,
-  buildKatanaToEthereumCompose,
-  composerInterface,
-  oftInterface,
-  previewInterface,
-  type BuiltTx,
 } from './katanaUtils.js';
 
 const testLogger = pino({ level: 'silent' });
@@ -31,6 +23,7 @@ const TEST_WALLET = new ethers.Wallet(TEST_PRIVATE_KEY);
 
 const BRIDGE_CONFIG: ExternalBridgeConfig = {
   integrator: 'hyperlane',
+  defaultSlippage: 0.005,
   chainMetadata: {
     ethereum: {
       chainId: ETHEREUM_CHAIN_ID,
@@ -52,550 +45,312 @@ const BRIDGE_CONFIG: ExternalBridgeConfig = {
 };
 
 class TestKatanaBridge extends KatanaBridge {
-  readonly callResults = new Map<string, string>();
-  readonly sentCalls: Array<{ chainId: number; key: string; call: BuiltTx }> =
-    [];
-  readonly receipts = new Map<string, ethers.providers.TransactionReceipt>();
+  routeResponses: any[] = [];
+  transactionResponses: any[][] = [];
+  claimResponses: Array<any | Error> = [];
   nextReceipts: ethers.providers.TransactionReceipt[] = [];
-  nextFetchResponse = new Response(JSON.stringify({ messages: [] }), {
-    status: 200,
-  });
+  sentTransactions: Array<{ chainId: number; tx: any }> = [];
   allowance = 0n;
+  lastRouteRequest?: Record<string, unknown>;
 
-  setCallResult(
-    chainId: number,
-    to: string,
-    data: string,
-    result: string,
-  ): void {
-    this.callResults.set(`${chainId}:${to.toLowerCase()}:${data}`, result);
+  protected override async requestRoutes(params: {
+    fromChainId: number;
+    toChainId: number;
+    fromTokenAddress: string;
+    toTokenAddress: string;
+    amount: string;
+    fromAddress: string;
+    toAddress: string;
+    slippage: number;
+  }): Promise<any[]> {
+    this.lastRouteRequest = params;
+    return this.routeResponses;
   }
 
-  setReceipt(
-    chainId: number,
-    txHash: string,
-    receipt: ethers.providers.TransactionReceipt,
-  ): void {
-    this.receipts.set(`${chainId}:${txHash.toLowerCase()}`, receipt);
+  protected override async requestUnsignedTransaction(): Promise<any> {
+    throw new Error('Unexpected build transaction call in test');
   }
 
-  protected override async callContract(
-    chainId: number,
-    to: string,
-    data: string,
-  ): Promise<string> {
-    const key = `${chainId}:${to.toLowerCase()}:${data}`;
-    const result = this.callResults.get(key);
-    if (!result) {
-      throw new Error(`Missing test call result for ${key}`);
-    }
-    return result;
+  protected override async requestTransactions(): Promise<any[]> {
+    return this.transactionResponses.shift() ?? [];
   }
 
-  protected override async readAllowance(
-    _chainId: number,
-    _tokenAddress: string,
-    _owner: string,
-    _spender: string,
-  ): Promise<bigint> {
+  protected override async requestClaimTransaction(): Promise<any> {
+    const next = this.claimResponses.shift();
+    if (next instanceof Error) throw next;
+    if (!next) throw new Error('Missing claim response');
+    return next;
+  }
+
+  protected override async readAllowance(): Promise<bigint> {
     return this.allowance;
   }
 
   protected override async sendPreparedTransaction(
     chainId: number,
-    key: string,
-    call: BuiltTx,
+    _privateKey: string,
+    tx: any,
   ): Promise<ethers.providers.TransactionReceipt> {
-    this.sentCalls.push({ chainId, key, call });
+    this.sentTransactions.push({ chainId, tx });
     const receipt = this.nextReceipts.shift();
-    if (!receipt) {
-      throw new Error('Missing next test receipt');
-    }
+    if (!receipt) throw new Error('Missing test receipt');
     return receipt;
   }
 
-  protected override async getTransactionReceipt(
-    chainId: number,
-    txHash: string,
-  ): Promise<ethers.providers.TransactionReceipt | undefined> {
-    return this.receipts.get(`${chainId}:${txHash.toLowerCase()}`);
-  }
-
-  protected override async fetchWithRetry(
-    _url: string,
-    _options?: RequestInit,
-    _retries?: number,
-  ): Promise<Response> {
-    return this.nextFetchResponse;
-  }
+  protected override async sleep(): Promise<void> {}
 }
 
 function createReceipt(
   transactionHash: string,
-  logs: ethers.providers.Log[],
 ): ethers.providers.TransactionReceipt {
+  return { transactionHash } as ethers.providers.TransactionReceipt;
+}
+
+function createRoute(overrides?: Partial<any>): any {
   return {
-    transactionHash,
-    logs,
-  } as ethers.providers.TransactionReceipt;
-}
-
-function createEventLog(
-  address: string,
-  iface: ethers.utils.Interface,
-  eventName: string,
-  args: unknown[],
-): ethers.providers.Log {
-  const event = iface.getEvent(eventName);
-  const encoded = iface.encodeEventLog(event, args);
-  return {
-    address,
-    data: encoded.data,
-    topics: encoded.topics,
-  } as ethers.providers.Log;
-}
-
-function encodePreviewResult(
-  functionName: 'previewDeposit' | 'previewRedeem',
-  amount: bigint,
-): string {
-  return previewInterface.encodeFunctionResult(functionName, [amount]);
-}
-
-function encodeQuoteSendResult(
-  nativeFee: bigint,
-  lzTokenFee: bigint = 0n,
-): string {
-  return oftInterface.encodeFunctionResult('quoteSend', [
-    [nativeFee, lzTokenFee],
-  ]);
-}
-
-function encodeSecondaryChainBalanceResult(amount: bigint): string {
-  const localInterface = new ethers.utils.Interface([
-    'function secondaryChainBalance() view returns (uint256)',
-  ]);
-  return localInterface.encodeFunctionResult('secondaryChainBalance', [amount]);
-}
-
-function createForwardQuote(
-  route: KatanaBridgeRoute,
-): BridgeQuote<KatanaBridgeRoute> {
-  const requestParams: BridgeQuoteParams = {
-    fromChain: ETHEREUM_CHAIN_ID,
-    toChain: KATANA_CHAIN_ID,
-    fromToken: KATANA_FORWARD_CONFIG.fromToken,
-    toToken: KATANA_FORWARD_CONFIG.toToken,
-    fromAmount: 1_000_000n,
-    fromAddress: TEST_WALLET.address,
-    toAddress: TEST_WALLET.address,
-  };
-
-  return {
-    id: 'quote-forward',
-    tool: 'katana-vault-bridge',
-    fromAmount: requestParams.fromAmount!,
-    toAmount: route.previewAmount,
-    toAmountMin: route.sendParam.minAmountLD,
-    executionDuration: 120,
-    gasCosts: route.nativeFee,
-    feeCosts: 0n,
-    route,
-    requestParams,
+    id: 'route-1',
+    provider: ['agglayer'],
+    fromChainId: ETHEREUM_CHAIN_ID,
+    toChainId: KATANA_CHAIN_ID,
+    fromAmount: '5000000',
+    toAmount: '5000000',
+    toAmountMin: '5000000',
+    feeCosts: [],
+    gasCosts: [{ amount: '1000000000000000' }],
+    steps: [
+      {
+        estimate: {
+          approvalAddress: '0x53e82abbb12638f09d9e624578ccb666217a765e',
+        },
+      },
+    ],
+    transactionRequest: {
+      from: TEST_WALLET.address.toLowerCase(),
+      to: '0x53e82abbb12638f09d9e624578ccb666217a765e',
+      data: '0xdeadbeef',
+      value: '0',
+      gasLimit: '1000000',
+      gasPrice: '1000000000',
+      chainId: ETHEREUM_CHAIN_ID,
+    },
+    providerMetadata: {
+      agglayer: {
+        claimTransactionRequired: false,
+      },
+    },
+    estimatedCompletionTime: 1200,
+    ...overrides,
   };
 }
 
-describe('KatanaBridge.quote()', () => {
-  it('builds exact ethereum->katana calldata from previewDeposit + quoteSend', async () => {
+function createTransaction(overrides?: Partial<any>): any {
+  return {
+    transactionHash: '0xsourcetx',
+    transactionHashes: ['0xsourcetx'],
+    status: 'BRIDGED',
+    sending: {
+      txHash: '0xsourcetx',
+      network: {
+        chainId: KATANA_CHAIN_ID,
+        networkId: 20,
+      },
+    },
+    receiving: null,
+    metadata: {
+      depositCount: 7,
+    },
+    ...overrides,
+  };
+}
+
+describe('KatanaBridge', () => {
+  it('quotes ethereum -> katana via ARC route', async () => {
     const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
-    const recipient = TEST_WALLET.address;
-    const fromAmount = 1_000_000n;
-    const previewShares = 999_500n;
-    const nativeFee = 123_456n;
-
-    const previewData = previewInterface.encodeFunctionData('previewDeposit', [
-      fromAmount.toString(),
-    ]);
-    bridge.setCallResult(
-      ETHEREUM_CHAIN_ID,
-      KATANA_FORWARD_CONFIG.vaultAddress,
-      previewData,
-      encodePreviewResult('previewDeposit', previewShares),
-    );
-
-    const exactCall = buildKatanaEthereumToKatana({
-      vaultAddress: KATANA_FORWARD_CONFIG.vaultAddress,
-      composerAddress: KATANA_FORWARD_CONFIG.composerAddress,
-      shareOftAddress: KATANA_FORWARD_CONFIG.shareOftAddress,
-      underlyingTokenAddress: KATANA_FORWARD_CONFIG.fromToken,
-      dstEid: KATANA_FORWARD_CONFIG.dstEid,
-      recipient,
-      amountLD: fromAmount,
-      shareAmountLD: previewShares,
-      minShareAmountLD: applySlippage(previewShares, 0.005),
-      refundAddress: TEST_WALLET.address,
-      extraOptions: KATANA_FORWARD_CONFIG.extraOptions,
-      composeMsg: KATANA_FORWARD_CONFIG.composeMsg,
-      oftCmd: KATANA_FORWARD_CONFIG.oftCmd,
-    });
-    bridge.setCallResult(
-      ETHEREUM_CHAIN_ID,
-      exactCall.quoteRead.to,
-      exactCall.quoteRead.data,
-      encodeQuoteSendResult(nativeFee),
-    );
+    bridge.routeResponses = [createRoute()];
 
     const quote = await bridge.quote({
       fromChain: ETHEREUM_CHAIN_ID,
       toChain: KATANA_CHAIN_ID,
       fromToken: KATANA_FORWARD_CONFIG.fromToken,
       toToken: KATANA_FORWARD_CONFIG.toToken,
-      fromAmount,
+      fromAmount: 5_000_000n,
       fromAddress: TEST_WALLET.address,
-      toAddress: recipient,
+      toAddress: TEST_WALLET.address,
     });
 
-    expect(quote.toAmount).to.equal(previewShares);
-    expect(quote.toAmountMin).to.equal(applySlippage(previewShares, 0.005));
-    expect(quote.gasCosts).to.equal(nativeFee);
-    expect(quote.route.executionCall.value).to.equal(nativeFee);
-    expect(quote.route.executionCall.data).to.equal(
-      exactCall.depositAndSendTx.data,
-    );
-    expect(quote.route.sendParam.amountLD).to.equal(previewShares);
+    expect(bridge.lastRouteRequest?.slippage).to.equal(0.5);
+    expect(quote.fromAmount).to.equal(5_000_000n);
+    expect(quote.toAmount).to.equal(5_000_000n);
+    expect(quote.toAmountMin).to.equal(5_000_000n);
+    expect(quote.gasCosts).to.equal(1_000_000_000_000_000n);
+    expect(quote.route.claimTransactionRequired).to.equal(false);
+    expect(quote.route.executionTx.chainId).to.equal(ETHEREUM_CHAIN_ID);
   });
 
-  it('builds exact katana->ethereum calldata from previewRedeem + quoteSend', async () => {
+  it('quotes katana -> ethereum via ARC route', async () => {
     const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
-    const shareAmount = 1_000_000n;
-    const previewAssets = 998_000n;
-    const nativeFee = 456_789n;
-
-    const previewData = previewInterface.encodeFunctionData('previewRedeem', [
-      shareAmount.toString(),
-    ]);
-    bridge.setCallResult(
-      ETHEREUM_CHAIN_ID,
-      KATANA_REVERSE_CONFIG.vaultAddress,
-      previewData,
-      encodePreviewResult('previewRedeem', previewAssets),
-    );
-
-    const exactCall = buildKatanaToEthereumCompose({
-      vaultAddress: KATANA_REVERSE_CONFIG.vaultAddress,
-      composerAddress: KATANA_REVERSE_CONFIG.composerAddress,
-      shareTokenAddress: KATANA_REVERSE_CONFIG.shareTokenAddress,
-      shareOftAddress: KATANA_REVERSE_CONFIG.shareOftAddress,
-      dstEid: KATANA_REVERSE_CONFIG.dstEid,
-      recipient: TEST_WALLET.address,
-      shareAmountLD: shareAmount,
-      minShareAmountLD: shareAmount,
-      assetAmountLD: previewAssets,
-      minAssetAmountLD: applySlippage(previewAssets, 0.005),
-      refundAddress: TEST_WALLET.address,
-      extraOptions: KATANA_REVERSE_CONFIG.extraOptions,
-      receiveExtraOptions: KATANA_REVERSE_CONFIG.receiveExtraOptions,
-      oftCmd: KATANA_REVERSE_CONFIG.oftCmd,
-    });
-    bridge.setCallResult(
-      KATANA_CHAIN_ID,
-      exactCall.quoteRead.to,
-      exactCall.quoteRead.data,
-      encodeQuoteSendResult(nativeFee),
-    );
-    bridge.setCallResult(
-      KATANA_CHAIN_ID,
-      KATANA_REVERSE_CONFIG.shareOftAddress,
-      oftInterface.encodeFunctionData('secondaryChainBalance', []),
-      encodeSecondaryChainBalanceResult(2_000_000n),
-    );
+    bridge.routeResponses = [
+      createRoute({
+        fromChainId: KATANA_CHAIN_ID,
+        toChainId: ETHEREUM_CHAIN_ID,
+        transactionRequest: {
+          from: TEST_WALLET.address.toLowerCase(),
+          to: '0x2a3dd3eb832af982ec71669e178424b10dca2ede',
+          data: '0xbeef',
+          value: '0',
+          gasLimit: '400000',
+          gasPrice: '1000000000',
+          chainId: KATANA_CHAIN_ID,
+        },
+        providerMetadata: {
+          agglayer: {
+            claimTransactionRequired: true,
+          },
+        },
+      }),
+    ];
 
     const quote = await bridge.quote({
       fromChain: KATANA_CHAIN_ID,
       toChain: ETHEREUM_CHAIN_ID,
       fromToken: KATANA_REVERSE_CONFIG.fromToken,
       toToken: KATANA_REVERSE_CONFIG.toToken,
-      fromAmount: shareAmount,
+      fromAmount: 5_000_000n,
       fromAddress: TEST_WALLET.address,
       toAddress: TEST_WALLET.address,
     });
 
-    expect(quote.toAmount).to.equal(previewAssets);
-    expect(quote.toAmountMin).to.equal(applySlippage(previewAssets, 0.005));
-    expect(quote.gasCosts).to.equal(nativeFee);
-    expect(quote.route.executionCall.value).to.equal(nativeFee);
-    expect(quote.route.executionCall.data).to.equal(
-      oftInterface.encodeFunctionData('send', [
-        exactCall.sendParam,
-        { nativeFee, lzTokenFee: 0 },
-        TEST_WALLET.address,
-      ]),
-    );
+    expect(quote.route.claimTransactionRequired).to.equal(true);
+    expect(quote.route.executionTx.chainId).to.equal(KATANA_CHAIN_ID);
   });
 
-  it('rejects unsupported toAmount quotes', async () => {
+  it('rejects reverse quote mode', async () => {
     const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
-    try {
-      await bridge.quote({
+
+    await expect(
+      bridge.quote({
         fromChain: ETHEREUM_CHAIN_ID,
         toChain: KATANA_CHAIN_ID,
         fromToken: KATANA_FORWARD_CONFIG.fromToken,
         toToken: KATANA_FORWARD_CONFIG.toToken,
-        toAmount: 1n,
+        toAmount: 5_000_000n,
         fromAddress: TEST_WALLET.address,
-      });
-      expect.fail('Expected quote to reject');
-    } catch (error) {
-      expect((error as Error).message).to.include('does not support toAmount');
-    }
+      }),
+    ).to.be.rejectedWith('KatanaBridge only supports fromAmount');
   });
 
-  it('rejects reverse quotes when secondaryChainBalance is insufficient', async () => {
+  it('executes katana -> ethereum with approval and claim submission', async () => {
     const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
-    const shareAmount = 1_000_000n;
-    const previewData = previewInterface.encodeFunctionData('previewRedeem', [
-      shareAmount.toString(),
-    ]);
-    bridge.setCallResult(
-      ETHEREUM_CHAIN_ID,
-      KATANA_REVERSE_CONFIG.vaultAddress,
-      previewData,
-      encodePreviewResult('previewRedeem', 999_000n),
-    );
-
-    const exactCall = buildKatanaToEthereumCompose({
-      vaultAddress: KATANA_REVERSE_CONFIG.vaultAddress,
-      composerAddress: KATANA_REVERSE_CONFIG.composerAddress,
-      shareTokenAddress: KATANA_REVERSE_CONFIG.shareTokenAddress,
-      shareOftAddress: KATANA_REVERSE_CONFIG.shareOftAddress,
-      dstEid: KATANA_REVERSE_CONFIG.dstEid,
-      recipient: TEST_WALLET.address,
-      shareAmountLD: shareAmount,
-      minShareAmountLD: shareAmount,
-      assetAmountLD: 999_000n,
-      minAssetAmountLD: applySlippage(999_000n, 0.005),
-      refundAddress: TEST_WALLET.address,
-      extraOptions: KATANA_REVERSE_CONFIG.extraOptions,
-      receiveExtraOptions: KATANA_REVERSE_CONFIG.receiveExtraOptions,
-      oftCmd: KATANA_REVERSE_CONFIG.oftCmd,
-    });
-    bridge.setCallResult(
-      KATANA_CHAIN_ID,
-      exactCall.quoteRead.to,
-      exactCall.quoteRead.data,
-      encodeQuoteSendResult(1n),
-    );
-    bridge.setCallResult(
-      KATANA_CHAIN_ID,
-      KATANA_REVERSE_CONFIG.shareOftAddress,
-      oftInterface.encodeFunctionData('secondaryChainBalance', []),
-      encodeSecondaryChainBalanceResult(999_999n),
-    );
-
-    try {
-      await bridge.quote({
-        fromChain: KATANA_CHAIN_ID,
-        toChain: ETHEREUM_CHAIN_ID,
-        fromToken: KATANA_REVERSE_CONFIG.fromToken,
-        toToken: KATANA_REVERSE_CONFIG.toToken,
-        fromAmount: shareAmount,
-        fromAddress: TEST_WALLET.address,
-      });
-      expect.fail('Expected quote to reject');
-    } catch (error) {
-      expect((error as Error).message).to.include(
-        'Insufficient Katana secondaryChainBalance',
-      );
-    }
-  });
-});
-
-describe('KatanaBridge.execute()', () => {
-  it('sends approval then execution and extracts the guid', async () => {
-    const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
-    const guid =
-      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-    const exactCall = buildKatanaEthereumToKatana({
-      vaultAddress: KATANA_FORWARD_CONFIG.vaultAddress,
-      composerAddress: KATANA_FORWARD_CONFIG.composerAddress,
-      shareOftAddress: KATANA_FORWARD_CONFIG.shareOftAddress,
-      underlyingTokenAddress: KATANA_FORWARD_CONFIG.fromToken,
-      dstEid: KATANA_FORWARD_CONFIG.dstEid,
-      recipient: TEST_WALLET.address,
-      amountLD: 1_000_000n,
-      shareAmountLD: 999_000n,
-      minShareAmountLD: 998_000n,
-      refundAddress: TEST_WALLET.address,
-      extraOptions: KATANA_FORWARD_CONFIG.extraOptions,
-      composeMsg: KATANA_FORWARD_CONFIG.composeMsg,
-      oftCmd: KATANA_FORWARD_CONFIG.oftCmd,
-    });
-    const route: KatanaBridgeRoute = {
-      kind: 'ethereum-to-katana',
-      fromChainId: ETHEREUM_CHAIN_ID,
-      toChainId: KATANA_CHAIN_ID,
-      fromToken: KATANA_FORWARD_CONFIG.fromToken,
-      toToken: KATANA_FORWARD_CONFIG.toToken,
-      recipient: TEST_WALLET.address,
-      refundAddress: TEST_WALLET.address,
-      previewAmount: 999_000n,
-      nativeFee: 123n,
-      sendParam: exactCall.sendParam,
-      quoteRead: exactCall.quoteRead,
-      approvalCall: exactCall.assetApproveTx,
-      executionCall: { ...exactCall.depositAndSendTx, value: 123n },
-    };
-    const quote = createForwardQuote(route);
-
+    bridge.routeResponses = [
+      createRoute({
+        fromChainId: KATANA_CHAIN_ID,
+        toChainId: ETHEREUM_CHAIN_ID,
+        transactionRequest: {
+          from: TEST_WALLET.address.toLowerCase(),
+          to: '0x2a3dd3eb832af982ec71669e178424b10dca2ede',
+          data: '0xbeef',
+          value: '0',
+          gasLimit: '400000',
+          gasPrice: '1000000000',
+          chainId: KATANA_CHAIN_ID,
+        },
+        providerMetadata: {
+          agglayer: {
+            claimTransactionRequired: true,
+          },
+        },
+      }),
+    ];
     bridge.allowance = 0n;
     bridge.nextReceipts = [
-      createReceipt('0xapprove', []),
-      createReceipt('0xexecute', [
-        createEventLog(route.executionCall.to, oftInterface, 'OFTSent', [
-          guid,
-          KATANA_FORWARD_CONFIG.dstEid,
-          TEST_WALLET.address,
-          999_000n,
-          999_000n,
-        ]),
-      ]),
+      createReceipt('0xapprove'),
+      createReceipt('0xsourcetx'),
+      createReceipt('0xclaimtx'),
     ];
+    bridge.transactionResponses = [[], [createTransaction()]];
+    bridge.claimResponses = [
+      {
+        to: '0x2a3dd3eb832af982ec71669e178424b10dca2ede',
+        data: '0xclaim',
+        value: '0',
+        gasLimit: '500000',
+        gasPrice: '1000000000',
+        chainId: ETHEREUM_CHAIN_ID,
+      },
+    ];
+
+    const quote = (await bridge.quote({
+      fromChain: KATANA_CHAIN_ID,
+      toChain: ETHEREUM_CHAIN_ID,
+      fromToken: KATANA_REVERSE_CONFIG.fromToken,
+      toToken: KATANA_REVERSE_CONFIG.toToken,
+      fromAmount: 5_000_000n,
+      fromAddress: TEST_WALLET.address,
+      toAddress: TEST_WALLET.address,
+    })) as BridgeQuote<KatanaBridgeRoute>;
 
     const result = await bridge.execute(quote, {
       [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
     });
 
-    expect(result.txHash).to.equal('0xexecute');
-    expect(result.transferId).to.equal(guid);
-    expect(bridge.sentCalls).to.have.length(2);
-    expect(bridge.sentCalls[0].call.data).to.equal(route.approvalCall.data);
-    expect(bridge.sentCalls[1].call.data).to.equal(route.executionCall.data);
-    expect(bridge.sentCalls[1].call.value).to.equal(123n);
+    expect(result.txHash).to.equal('0xsourcetx');
+    expect(bridge.sentTransactions).to.have.length(3);
+    expect(bridge.sentTransactions[0].chainId).to.equal(KATANA_CHAIN_ID);
+    expect(bridge.sentTransactions[1].chainId).to.equal(KATANA_CHAIN_ID);
+    expect(bridge.sentTransactions[2].chainId).to.equal(ETHEREUM_CHAIN_ID);
   });
 
-  it('skips approval when allowance is sufficient', async () => {
+  it('reads completion from ARC transaction status', async () => {
     const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
-    const exactCall = buildKatanaEthereumToKatana({
-      vaultAddress: KATANA_FORWARD_CONFIG.vaultAddress,
-      composerAddress: KATANA_FORWARD_CONFIG.composerAddress,
-      shareOftAddress: KATANA_FORWARD_CONFIG.shareOftAddress,
-      underlyingTokenAddress: KATANA_FORWARD_CONFIG.fromToken,
-      dstEid: KATANA_FORWARD_CONFIG.dstEid,
-      recipient: TEST_WALLET.address,
-      amountLD: 1_000_000n,
-      shareAmountLD: 999_000n,
-      minShareAmountLD: 998_000n,
-      refundAddress: TEST_WALLET.address,
-      extraOptions: KATANA_FORWARD_CONFIG.extraOptions,
-      composeMsg: KATANA_FORWARD_CONFIG.composeMsg,
-      oftCmd: KATANA_FORWARD_CONFIG.oftCmd,
-    });
-    const route: KatanaBridgeRoute = {
-      kind: 'ethereum-to-katana',
-      fromChainId: ETHEREUM_CHAIN_ID,
-      toChainId: KATANA_CHAIN_ID,
+    bridge.routeResponses = [createRoute()];
+    bridge.allowance = 5_000_000n;
+    bridge.nextReceipts = [createReceipt('0xsourcetx')];
+
+    const quote = (await bridge.quote({
+      fromChain: ETHEREUM_CHAIN_ID,
+      toChain: KATANA_CHAIN_ID,
       fromToken: KATANA_FORWARD_CONFIG.fromToken,
       toToken: KATANA_FORWARD_CONFIG.toToken,
-      recipient: TEST_WALLET.address,
-      refundAddress: TEST_WALLET.address,
-      previewAmount: 999_000n,
-      nativeFee: 123n,
-      sendParam: exactCall.sendParam,
-      quoteRead: exactCall.quoteRead,
-      approvalCall: exactCall.assetApproveTx,
-      executionCall: { ...exactCall.depositAndSendTx, value: 123n },
-    };
-    const quote = createForwardQuote(route);
-
-    bridge.allowance = route.approvalCall.amount;
-    bridge.nextReceipts = [createReceipt('0xexecute', [])];
+      fromAmount: 5_000_000n,
+      fromAddress: TEST_WALLET.address,
+      toAddress: TEST_WALLET.address,
+    })) as BridgeQuote<KatanaBridgeRoute>;
 
     await bridge.execute(quote, {
       [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
     });
 
-    expect(bridge.sentCalls).to.have.length(1);
-    expect(bridge.sentCalls[0].call.data).to.equal(route.executionCall.data);
-  });
-});
-
-describe('KatanaBridge.getStatus()', () => {
-  it('parses forward destination OFTReceived amount', async () => {
-    const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
-    bridge.nextFetchResponse = new Response(
-      JSON.stringify({
-        messages: [{ status: 'DELIVERED', dstTxHash: '0xdstforward' }],
-      }),
-      { status: 200 },
-    );
-    bridge.setReceipt(
-      KATANA_CHAIN_ID,
-      '0xdstforward',
-      createReceipt('0xdstforward', [
-        createEventLog(
-          KATANA_FORWARD_CONFIG.destinationShareOftAddress,
-          oftInterface,
-          'OFTReceived',
-          [
-            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-            KATANA_FORWARD_CONFIG.dstEid,
-            TEST_WALLET.address,
-            777_000n,
-          ],
-        ),
-      ]),
-    );
+    bridge.transactionResponses = [
+      [
+        createTransaction({
+          transactionHash: '0xsourcetx',
+          transactionHashes: ['0xsourcetx', '0xreceivingtx'],
+          status: 'CLAIMED',
+          sending: {
+            txHash: '0xsourcetx',
+            network: {
+              chainId: ETHEREUM_CHAIN_ID,
+              networkId: 0,
+            },
+          },
+          receiving: {
+            txHash: '0xreceivingtx',
+            amount: '5000000',
+          },
+        }),
+      ],
+    ];
 
     const status = await bridge.getStatus(
-      '0xsource',
+      '0xsourcetx',
       ETHEREUM_CHAIN_ID,
       KATANA_CHAIN_ID,
     );
 
     expect(status).to.deep.equal({
       status: 'complete',
-      receivingTxHash: '0xdstforward',
-      receivedAmount: 777_000n,
-    });
-  });
-
-  it('parses reverse destination Redeemed amount', async () => {
-    const bridge = new TestKatanaBridge(BRIDGE_CONFIG, testLogger);
-    bridge.nextFetchResponse = new Response(
-      JSON.stringify({
-        messages: [{ status: 'DELIVERED', dstTxHash: '0xdstreverse' }],
-      }),
-      { status: 200 },
-    );
-    bridge.setReceipt(
-      ETHEREUM_CHAIN_ID,
-      '0xdstreverse',
-      createReceipt('0xdstreverse', [
-        createEventLog(
-          KATANA_REVERSE_CONFIG.composerAddress,
-          composerInterface,
-          'Redeemed',
-          [
-            '0x0000000000000000000000000000000000000000000000000000000000000000',
-            '0x0000000000000000000000000000000000000000000000000000000000000000',
-            KATANA_REVERSE_CONFIG.dstEid,
-            500_000n,
-            499_000n,
-          ],
-        ),
-      ]),
-    );
-
-    const status = await bridge.getStatus(
-      '0xsource',
-      KATANA_CHAIN_ID,
-      ETHEREUM_CHAIN_ID,
-    );
-
-    expect(status).to.deep.equal({
-      status: 'complete',
-      receivingTxHash: '0xdstreverse',
-      receivedAmount: 499_000n,
+      receivingTxHash: '0xreceivingtx',
+      receivedAmount: 5_000_000n,
     });
   });
 });

--- a/typescript/rebalancer/src/bridges/KatanaBridge.ts
+++ b/typescript/rebalancer/src/bridges/KatanaBridge.ts
@@ -22,6 +22,10 @@ import {
   KATANA_CHAIN_ID,
   KATANA_FORWARD_CONFIG,
   KATANA_REVERSE_CONFIG,
+  applySlippage,
+  buildKatanaToEthereumCompose,
+  oftInterface,
+  previewInterface,
 } from './katanaUtils.js';
 
 type KatanaDirection = 'ethereum-to-katana' | 'katana-to-ethereum';
@@ -111,6 +115,12 @@ type ArcTransaction = {
 type KatanaExecutionState = {
   fromAddress: string;
   claimRequired: boolean;
+  destinationOftAddress?: string;
+  destinationStartBlock?: number;
+  destinationToken?: string;
+  expectedReceivedAmount?: bigint;
+  guid?: string;
+  kind: KatanaDirection;
   claimSubmittedTxHash?: string;
 };
 
@@ -123,8 +133,10 @@ export type KatanaBridgeRoute = {
   toToken: string;
   recipient: string;
   approvalAddress?: string;
+  destinationOftAddress?: string;
   executionTx: ArcUnsignedTransaction;
   claimTransactionRequired: boolean;
+  statusMode: 'arc' | 'oft';
 };
 
 const ARC_API_BASE_URL = 'https://arc-api.polygon.technology';
@@ -132,7 +144,13 @@ const DEFAULT_SLIPPAGE = 0.005;
 const TRANSACTION_POLL_INTERVAL_MS = 5_000;
 const CLAIM_SUBMISSION_TIMEOUT_MS = 10 * 60 * 1_000;
 const TRANSACTION_QUERY_LIMIT = 100;
+// Some Ethereum RPCs enforce an inclusive 50k block log window.
+const DESTINATION_LOG_LOOKBACK_BLOCKS = 49_999;
 const erc20Interface = new ethers.utils.Interface(ERC20_ABI);
+const transferTopic = erc20Interface.getEventTopic('Transfer');
+const oftReceivedTopic = oftInterface.getEventTopic('OFTReceived');
+const oftSentTopic = oftInterface.getEventTopic('OFTSent');
+const composeSentTopic = ethers.utils.id('Sent(bytes32)');
 
 function addressesEqual(a: string, b: string): boolean {
   return normalizeAddressEvm(a) === normalizeAddressEvm(b);
@@ -213,6 +231,15 @@ export class KatanaBridge implements IExternalBridge {
     assert(fromAmount !== undefined, 'KatanaBridge requires fromAmount');
     assert(fromAmount > 0n, 'KatanaBridge requires a positive fromAmount');
 
+    if (direction === 'katana-to-ethereum') {
+      return this.quoteKatanaToEthereumOft(
+        params,
+        recipient,
+        fromAmount,
+        slippage,
+      );
+    }
+
     const routes = await this.requestRoutes({
       fromChainId: fromChain,
       toChainId: toChain,
@@ -258,9 +285,11 @@ export class KatanaBridge implements IExternalBridge {
         toToken: normalizeAddressEvm(toToken),
         recipient,
         approvalAddress,
+        destinationOftAddress: undefined,
         executionTx,
         claimTransactionRequired:
           route.providerMetadata?.agglayer?.claimTransactionRequired === true,
+        statusMode: 'arc',
       },
       requestParams: params,
     };
@@ -301,6 +330,9 @@ export class KatanaBridge implements IExternalBridge {
       }
     }
 
+    const destinationStartBlock = await this.getCurrentBlockNumber(
+      route.toChainId,
+    );
     const sourceReceipt = await this.sendPreparedTransaction(
       route.executionTx.chainId,
       key,
@@ -310,7 +342,16 @@ export class KatanaBridge implements IExternalBridge {
 
     this.executionStateByTxHash.set(sourceTxHash, {
       fromAddress: signerAddress,
+      destinationOftAddress: route.destinationOftAddress,
+      destinationStartBlock,
+      destinationToken: route.toToken,
+      expectedReceivedAmount: quote.toAmountMin,
+      guid:
+        route.statusMode === 'oft'
+          ? this.extractOftGuidFromReceipt(sourceReceipt)
+          : undefined,
       claimRequired: route.claimTransactionRequired,
+      kind: route.kind,
     });
 
     if (route.claimTransactionRequired) {
@@ -336,12 +377,26 @@ export class KatanaBridge implements IExternalBridge {
 
   async getStatus(
     txHash: string,
-    _fromChain: number,
-    _toChain: number,
+    fromChain: number,
+    toChain: number,
   ): Promise<BridgeTransferStatus> {
     const normalizedTxHash = normalizeTxHash(txHash);
-    const state = this.executionStateByTxHash.get(normalizedTxHash);
+    let state = this.executionStateByTxHash.get(normalizedTxHash);
+    if (!state) {
+      state = await this.rehydrateExecutionState(
+        normalizedTxHash,
+        fromChain,
+        toChain,
+      );
+      if (state) {
+        this.executionStateByTxHash.set(normalizedTxHash, state);
+      }
+    }
     if (!state) return { status: 'not_found' };
+
+    if (state.kind === 'katana-to-ethereum' && !state.claimRequired) {
+      return this.getOftReverseStatus(normalizedTxHash, state);
+    }
 
     const tx = await this.findIndexedTransaction(
       state.fromAddress,
@@ -468,11 +523,104 @@ export class KatanaBridge implements IExternalBridge {
     );
   }
 
+  protected async readContract(
+    chainId: number,
+    to: string,
+    data: string,
+  ): Promise<string> {
+    return this.getProvider(chainId).call({ to, data });
+  }
+
+  protected async getCurrentBlockNumber(chainId: number): Promise<number> {
+    return this.getProvider(chainId).getBlockNumber();
+  }
+
+  protected async getTransactionReceipt(
+    chainId: number,
+    txHash: string,
+  ): Promise<ethers.providers.TransactionReceipt | null> {
+    return this.getProvider(chainId).getTransactionReceipt(txHash);
+  }
+
+  protected async getTransaction(
+    chainId: number,
+    txHash: string,
+  ): Promise<ethers.providers.TransactionResponse | null> {
+    return this.getProvider(chainId).getTransaction(txHash);
+  }
+
+  protected async getLogs(
+    chainId: number,
+    filter: ethers.providers.Filter,
+  ): Promise<ethers.providers.Log[]> {
+    return this.getProvider(chainId).getLogs(filter);
+  }
+
+  protected async getLatestBlock(
+    chainId: number,
+  ): Promise<ethers.providers.Block> {
+    return this.getProvider(chainId).getBlock('latest');
+  }
+
+  protected async getFeeData(
+    chainId: number,
+  ): Promise<ethers.providers.FeeData> {
+    return this.getProvider(chainId).getFeeData();
+  }
+
+  protected async resolveFeeOverrides(
+    chainId: number,
+    tx: ArcUnsignedTransaction,
+  ): Promise<
+    Pick<
+      ethers.providers.TransactionRequest,
+      'gasPrice' | 'maxFeePerGas' | 'maxPriorityFeePerGas'
+    >
+  > {
+    const gasPrice = tx.gasPrice
+      ? ethers.BigNumber.from(tx.gasPrice)
+      : undefined;
+    const maxFeePerGas = tx.maxFeePerGas
+      ? ethers.BigNumber.from(tx.maxFeePerGas)
+      : undefined;
+    const maxPriorityFeePerGas = tx.maxPriorityFeePerGas
+      ? ethers.BigNumber.from(tx.maxPriorityFeePerGas)
+      : undefined;
+    const latestBlock = await this.getLatestBlock(chainId);
+    const baseFeePerGas = latestBlock.baseFeePerGas;
+
+    if (
+      baseFeePerGas &&
+      ((gasPrice && gasPrice.lt(baseFeePerGas)) ||
+        (maxFeePerGas && maxFeePerGas.lt(baseFeePerGas)))
+    ) {
+      const feeData = await this.getFeeData(chainId);
+      if (feeData.maxFeePerGas && feeData.maxPriorityFeePerGas) {
+        return {
+          maxFeePerGas: feeData.maxFeePerGas,
+          maxPriorityFeePerGas: feeData.maxPriorityFeePerGas,
+        };
+      }
+      if (feeData.gasPrice) {
+        return {
+          gasPrice: feeData.gasPrice,
+        };
+      }
+    }
+
+    return {
+      gasPrice,
+      maxFeePerGas,
+      maxPriorityFeePerGas,
+    };
+  }
+
   protected async sendPreparedTransaction(
     chainId: number,
     privateKey: string,
     tx: ArcUnsignedTransaction,
   ): Promise<ethers.providers.TransactionReceipt> {
+    const feeOverrides = await this.resolveFeeOverrides(chainId, tx);
     const wallet = new ethers.Wallet(
       ensure0x(privateKey),
       this.getProvider(chainId),
@@ -482,13 +630,7 @@ export class KatanaBridge implements IExternalBridge {
       data: tx.data,
       value: tx.value ? ethers.BigNumber.from(tx.value) : undefined,
       gasLimit: tx.gasLimit ? ethers.BigNumber.from(tx.gasLimit) : undefined,
-      gasPrice: tx.gasPrice ? ethers.BigNumber.from(tx.gasPrice) : undefined,
-      maxFeePerGas: tx.maxFeePerGas
-        ? ethers.BigNumber.from(tx.maxFeePerGas)
-        : undefined,
-      maxPriorityFeePerGas: tx.maxPriorityFeePerGas
-        ? ethers.BigNumber.from(tx.maxPriorityFeePerGas)
-        : undefined,
+      ...feeOverrides,
     });
     return response.wait();
   }
@@ -507,6 +649,255 @@ export class KatanaBridge implements IExternalBridge {
       `Katana route ${route.id} did not include execution steps`,
     );
     return route;
+  }
+
+  private async quoteKatanaToEthereumOft(
+    params: BridgeQuoteParams,
+    recipient: string,
+    fromAmount: bigint,
+    slippage: number,
+  ): Promise<BridgeQuote<KatanaBridgeRoute>> {
+    const previewData = await this.readContract(
+      ETHEREUM_CHAIN_ID,
+      KATANA_REVERSE_CONFIG.vaultAddress,
+      previewInterface.encodeFunctionData('previewRedeem', [
+        fromAmount.toString(),
+      ]),
+    );
+    const previewResult = previewInterface.decodeFunctionResult(
+      'previewRedeem',
+      previewData,
+    );
+    const assetAmount = toBigInt(previewResult[0].toString());
+    const minAssetAmount = applySlippage(assetAmount, slippage);
+
+    const built = buildKatanaToEthereumCompose({
+      ...KATANA_REVERSE_CONFIG,
+      recipient,
+      refundAddress: params.fromAddress,
+      shareAmountLD: fromAmount,
+      minShareAmountLD: fromAmount,
+      assetAmountLD: assetAmount,
+      minAssetAmountLD: minAssetAmount,
+    });
+
+    const quoteData = await this.readContract(
+      KATANA_CHAIN_ID,
+      built.quoteRead.to,
+      built.quoteRead.data,
+    );
+    const quoteResult = oftInterface.decodeFunctionResult(
+      'quoteSend',
+      quoteData,
+    );
+    const nativeFee = toBigInt(quoteResult[0].nativeFee.toString());
+    const lzTokenFee = toBigInt(quoteResult[0].lzTokenFee.toString());
+    assert(lzTokenFee === 0n, 'Katana OFT unexpectedly required lzTokenFee');
+
+    return {
+      id: crypto.randomUUID(),
+      tool: 'oft',
+      fromAmount,
+      toAmount: assetAmount,
+      toAmountMin: minAssetAmount,
+      executionDuration: CLAIM_SUBMISSION_TIMEOUT_MS / 1_000,
+      gasCosts: nativeFee,
+      feeCosts: 0n,
+      route: {
+        id: crypto.randomUUID(),
+        kind: 'katana-to-ethereum',
+        fromChainId: KATANA_CHAIN_ID,
+        toChainId: ETHEREUM_CHAIN_ID,
+        fromToken: normalizeAddressEvm(params.fromToken),
+        toToken: normalizeAddressEvm(params.toToken),
+        recipient,
+        approvalAddress: built.shareApproveTx.spender,
+        destinationOftAddress: KATANA_FORWARD_CONFIG.shareOftAddress,
+        executionTx: this.buildOftExecutionTx(built.sendTx, nativeFee),
+        claimTransactionRequired: false,
+        statusMode: 'oft',
+      },
+      requestParams: params,
+    };
+  }
+
+  private buildOftExecutionTx(
+    tx: { to: string; data: string },
+    nativeFee: bigint,
+  ): ArcUnsignedTransaction {
+    const decoded = oftInterface.decodeFunctionData('send', tx.data);
+    return {
+      to: tx.to,
+      data: oftInterface.encodeFunctionData('send', [
+        decoded.sendParam,
+        { nativeFee: nativeFee.toString(), lzTokenFee: '0' },
+        decoded.refundAddress,
+      ]),
+      value: nativeFee.toString(),
+      chainId: KATANA_CHAIN_ID,
+    };
+  }
+
+  private extractOftGuidFromReceipt(
+    receipt: ethers.providers.TransactionReceipt,
+  ): string | undefined {
+    for (const log of receipt.logs) {
+      if (log.topics[0] !== oftSentTopic) continue;
+      const parsed = oftInterface.parseLog(log);
+      return ensure0x(parsed.args.guid);
+    }
+    return undefined;
+  }
+
+  private async getOftReverseStatus(
+    txHash: string,
+    state: KatanaExecutionState,
+  ): Promise<BridgeTransferStatus> {
+    assert(state.destinationOftAddress, 'Missing destination OFT address');
+    assert(state.destinationToken, 'Missing destination token');
+
+    const sourceReceipt = await this.getTransactionReceipt(
+      KATANA_CHAIN_ID,
+      txHash,
+    );
+    if (!sourceReceipt) {
+      return { status: 'pending', substatus: 'SOURCE_PENDING' };
+    }
+
+    const guid = state.guid ?? this.extractOftGuidFromReceipt(sourceReceipt);
+    if (!guid) {
+      return { status: 'pending', substatus: 'GUID_PENDING' };
+    }
+
+    const destinationLogs = await this.getLogs(ETHEREUM_CHAIN_ID, {
+      address: state.destinationOftAddress,
+      fromBlock: state.destinationStartBlock ?? 0,
+      toBlock: 'latest',
+      topics: [oftReceivedTopic, guid],
+    });
+
+    if (!destinationLogs.length) {
+      return { status: 'pending', substatus: 'OFT_IN_FLIGHT' };
+    }
+
+    const receivingTxHash = normalizeTxHash(destinationLogs[0].transactionHash);
+    const destinationReceipt = await this.getTransactionReceipt(
+      ETHEREUM_CHAIN_ID,
+      receivingTxHash,
+    );
+    if (!destinationReceipt) {
+      return { status: 'pending', substatus: 'DESTINATION_PENDING' };
+    }
+
+    const receivedAmount = this.extractReceivedTokenAmount(
+      destinationReceipt,
+      state.destinationToken,
+      state.fromAddress,
+    );
+    if (receivedAmount > 0n) {
+      return {
+        status: 'complete',
+        receivingTxHash,
+        receivedAmount,
+      };
+    }
+
+    const composeLogs = await this.getLogs(ETHEREUM_CHAIN_ID, {
+      address: KATANA_REVERSE_CONFIG.composerAddress,
+      fromBlock: destinationReceipt.blockNumber,
+      toBlock: 'latest',
+      topics: [composeSentTopic, guid],
+    });
+    if (!composeLogs.length) {
+      return { status: 'pending', substatus: 'OFT_RECEIVED' };
+    }
+
+    const composeTxHash = normalizeTxHash(composeLogs[0].transactionHash);
+    const composeReceipt = await this.getTransactionReceipt(
+      ETHEREUM_CHAIN_ID,
+      composeTxHash,
+    );
+    if (!composeReceipt) {
+      return { status: 'pending', substatus: 'COMPOSE_PENDING' };
+    }
+
+    const composedAmount = this.extractReceivedTokenAmount(
+      composeReceipt,
+      state.destinationToken,
+      state.fromAddress,
+    );
+    if (composedAmount === 0n) {
+      return { status: 'pending', substatus: 'COMPOSE_RECEIVED' };
+    }
+
+    return {
+      status: 'complete',
+      receivingTxHash: composeTxHash,
+      receivedAmount: composedAmount,
+    };
+  }
+
+  private async rehydrateExecutionState(
+    txHash: string,
+    fromChain: number,
+    toChain: number,
+  ): Promise<KatanaExecutionState | undefined> {
+    const transaction = await this.getTransaction(fromChain, txHash);
+    if (!transaction?.from) return undefined;
+
+    const fromAddress = normalizeAddressEvm(transaction.from);
+    const sourceReceipt = await this.getTransactionReceipt(fromChain, txHash);
+    const guid = sourceReceipt
+      ? this.extractOftGuidFromReceipt(sourceReceipt)
+      : undefined;
+
+    if (fromChain === KATANA_CHAIN_ID && toChain === ETHEREUM_CHAIN_ID) {
+      const latestDestinationBlock =
+        await this.getCurrentBlockNumber(ETHEREUM_CHAIN_ID);
+      return {
+        fromAddress,
+        claimRequired: false,
+        destinationOftAddress: KATANA_FORWARD_CONFIG.shareOftAddress,
+        destinationStartBlock: Math.max(
+          latestDestinationBlock - DESTINATION_LOG_LOOKBACK_BLOCKS,
+          0,
+        ),
+        destinationToken: KATANA_REVERSE_CONFIG.toToken,
+        guid,
+        kind: 'katana-to-ethereum',
+      };
+    }
+
+    if (fromChain === ETHEREUM_CHAIN_ID && toChain === KATANA_CHAIN_ID) {
+      return {
+        fromAddress,
+        claimRequired: false,
+        kind: 'ethereum-to-katana',
+      };
+    }
+
+    return undefined;
+  }
+
+  private extractReceivedTokenAmount(
+    receipt: ethers.providers.TransactionReceipt,
+    tokenAddress: string,
+    recipient: string,
+  ): bigint {
+    const recipientTopic = ethers.utils
+      .hexZeroPad(normalizeAddressEvm(recipient), 32)
+      .toLowerCase();
+
+    return receipt.logs.reduce((sum, log) => {
+      if (!addressesEqual(log.address, tokenAddress)) return sum;
+      if (
+        log.topics[0] !== transferTopic ||
+        log.topics[2]?.toLowerCase() !== recipientTopic
+      ) {
+        return sum;
+      }
+      return sum + toBigInt(log.data);
+    }, 0n);
   }
 
   private async waitForAndSubmitClaim(

--- a/typescript/rebalancer/src/bridges/KatanaBridge.ts
+++ b/typescript/rebalancer/src/bridges/KatanaBridge.ts
@@ -1,0 +1,662 @@
+import { ethers } from 'ethers';
+import type { ChainMetadata } from '@hyperlane-xyz/sdk';
+import {
+  ProtocolType,
+  assert,
+  ensure0x,
+  normalizeAddressEvm,
+} from '@hyperlane-xyz/utils';
+import type { Logger } from 'pino';
+
+import type {
+  BridgeQuote,
+  BridgeQuoteParams,
+  BridgeTransferResult,
+  BridgeTransferStatus,
+  ExternalBridgeConfig,
+  IExternalBridge,
+} from '../interfaces/IExternalBridge.js';
+import {
+  ERC20_ABI,
+  KATANA_FORWARD_CONFIG,
+  KATANA_REVERSE_CONFIG,
+  applySlippage,
+  buildKatanaEthereumToKatana,
+  buildKatanaToEthereumCompose,
+  composerInterface,
+  erc20Interface,
+  oftInterface,
+  previewInterface,
+  type ApprovalTx,
+  type BuiltRead,
+  type BuiltTx,
+  type OftSendParam,
+} from './katanaUtils.js';
+
+type KatanaDirection = 'ethereum-to-katana' | 'katana-to-ethereum';
+
+type LayerZeroScanMessage = {
+  status: string;
+  dstTxHash?: string;
+};
+
+type LayerZeroScanResponse = {
+  messages?: LayerZeroScanMessage[];
+};
+
+export type KatanaBridgeRoute = {
+  kind: KatanaDirection;
+  fromChainId: number;
+  toChainId: number;
+  fromToken: string;
+  toToken: string;
+  recipient: string;
+  refundAddress: string;
+  previewAmount: bigint;
+  nativeFee: bigint;
+  sendParam: OftSendParam;
+  quoteRead: BuiltRead;
+  approvalCall: ApprovalTx;
+  executionCall: BuiltTx;
+};
+
+const DEFAULT_SLIPPAGE = 0.005;
+const EXECUTION_DURATION_S = 120;
+const LAYERZERO_SCAN_API_URL = 'https://scan.layerzero-api.com/v1/messages/tx/';
+
+function toBigInt(value: unknown): bigint {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') return BigInt(value);
+  if (typeof value === 'string') return BigInt(value);
+  if (value && typeof value === 'object' && 'toString' in value) {
+    return BigInt((value as { toString: () => string }).toString());
+  }
+  throw new Error(`Unable to convert value to bigint: ${String(value)}`);
+}
+
+function addressesEqual(a: string, b: string): boolean {
+  return normalizeAddressEvm(a) === normalizeAddressEvm(b);
+}
+
+export class KatanaBridge implements IExternalBridge {
+  readonly externalBridgeId = 'katana';
+  readonly logger: Logger;
+
+  private readonly config: ExternalBridgeConfig;
+  private readonly chainMetadataByChainId: Map<number, ChainMetadata>;
+
+  constructor(config: ExternalBridgeConfig, logger: Logger) {
+    this.config = config;
+    this.logger = logger;
+    this.chainMetadataByChainId = new Map();
+    if (config.chainMetadata) {
+      for (const metadata of Object.values(config.chainMetadata)) {
+        if (metadata.chainId !== undefined) {
+          this.chainMetadataByChainId.set(Number(metadata.chainId), metadata);
+        }
+      }
+    }
+  }
+
+  getNativeTokenAddress(): string {
+    return ethers.constants.AddressZero;
+  }
+
+  async quote(
+    params: BridgeQuoteParams,
+  ): Promise<BridgeQuote<KatanaBridgeRoute>> {
+    const { fromChain, toChain, fromAmount, toAmount, fromToken, toToken } =
+      params;
+    const direction = this.getDirection(fromChain, toChain, fromToken, toToken);
+    const recipient = normalizeAddressEvm(
+      params.toAddress ?? params.fromAddress,
+    );
+    const refundAddress = normalizeAddressEvm(params.fromAddress);
+    const slippage =
+      params.slippage ?? this.config.defaultSlippage ?? DEFAULT_SLIPPAGE;
+
+    assert(direction, `Unsupported Katana route: ${fromChain} -> ${toChain}`);
+    assert(toAmount === undefined, 'KatanaBridge does not support toAmount');
+    assert(fromAmount !== undefined, 'KatanaBridge requires fromAmount');
+    assert(fromAmount > 0n, 'KatanaBridge requires a positive fromAmount');
+
+    if (direction === 'ethereum-to-katana') {
+      const previewShares = await this.probePreviewAmount(
+        fromChain,
+        KATANA_FORWARD_CONFIG.vaultAddress,
+        'previewDeposit',
+        fromAmount,
+      );
+      const exactCall = buildKatanaEthereumToKatana({
+        vaultAddress: KATANA_FORWARD_CONFIG.vaultAddress,
+        composerAddress: KATANA_FORWARD_CONFIG.composerAddress,
+        shareOftAddress: KATANA_FORWARD_CONFIG.shareOftAddress,
+        underlyingTokenAddress: KATANA_FORWARD_CONFIG.fromToken,
+        dstEid: KATANA_FORWARD_CONFIG.dstEid,
+        recipient,
+        amountLD: fromAmount,
+        shareAmountLD: previewShares,
+        minShareAmountLD: applySlippage(previewShares, slippage),
+        refundAddress,
+        extraOptions: KATANA_FORWARD_CONFIG.extraOptions,
+        composeMsg: KATANA_FORWARD_CONFIG.composeMsg,
+        oftCmd: KATANA_FORWARD_CONFIG.oftCmd,
+      });
+      const quoteFee = await this.probeQuoteSend(
+        fromChain,
+        exactCall.quoteRead,
+      );
+
+      return {
+        id: crypto.randomUUID(),
+        tool: 'katana-vault-bridge',
+        fromAmount,
+        toAmount: previewShares,
+        toAmountMin: exactCall.sendParam.minAmountLD,
+        executionDuration: EXECUTION_DURATION_S,
+        gasCosts: quoteFee.nativeFee,
+        feeCosts: 0n,
+        route: {
+          kind: direction,
+          fromChainId: fromChain,
+          toChainId: toChain,
+          fromToken: normalizeAddressEvm(fromToken),
+          toToken: normalizeAddressEvm(toToken),
+          recipient,
+          refundAddress,
+          previewAmount: previewShares,
+          nativeFee: quoteFee.nativeFee,
+          sendParam: exactCall.sendParam,
+          quoteRead: exactCall.quoteRead,
+          approvalCall: exactCall.assetApproveTx,
+          executionCall: {
+            ...exactCall.depositAndSendTx,
+            value: quoteFee.nativeFee,
+          },
+        },
+        requestParams: params,
+      };
+    }
+
+    const previewAssets = await this.probePreviewAmount(
+      toChain,
+      KATANA_REVERSE_CONFIG.vaultAddress,
+      'previewRedeem',
+      fromAmount,
+    );
+    const exactCall = buildKatanaToEthereumCompose({
+      vaultAddress: KATANA_REVERSE_CONFIG.vaultAddress,
+      composerAddress: KATANA_REVERSE_CONFIG.composerAddress,
+      shareTokenAddress: KATANA_REVERSE_CONFIG.shareTokenAddress,
+      shareOftAddress: KATANA_REVERSE_CONFIG.shareOftAddress,
+      dstEid: KATANA_REVERSE_CONFIG.dstEid,
+      recipient,
+      shareAmountLD: fromAmount,
+      minShareAmountLD: fromAmount,
+      assetAmountLD: previewAssets,
+      minAssetAmountLD: applySlippage(previewAssets, slippage),
+      refundAddress,
+      extraOptions: KATANA_REVERSE_CONFIG.extraOptions,
+      receiveExtraOptions: KATANA_REVERSE_CONFIG.receiveExtraOptions,
+      oftCmd: KATANA_REVERSE_CONFIG.oftCmd,
+    });
+    const quoteFee = await this.probeQuoteSend(fromChain, exactCall.quoteRead);
+    const secondaryChainBalance = await this.probeSecondaryChainBalance(
+      fromChain,
+      KATANA_REVERSE_CONFIG.shareOftAddress,
+    );
+    if (secondaryChainBalance !== undefined) {
+      assert(
+        secondaryChainBalance >= fromAmount,
+        `Insufficient Katana secondaryChainBalance: ${secondaryChainBalance} < ${fromAmount}`,
+      );
+    }
+
+    return {
+      id: crypto.randomUUID(),
+      tool: 'katana-vault-bridge',
+      fromAmount,
+      toAmount: previewAssets,
+      toAmountMin: exactCall.redemptionSendParam.minAmountLD,
+      executionDuration: EXECUTION_DURATION_S,
+      gasCosts: quoteFee.nativeFee,
+      feeCosts: 0n,
+      route: {
+        kind: direction,
+        fromChainId: fromChain,
+        toChainId: toChain,
+        fromToken: normalizeAddressEvm(fromToken),
+        toToken: normalizeAddressEvm(toToken),
+        recipient,
+        refundAddress,
+        previewAmount: previewAssets,
+        nativeFee: quoteFee.nativeFee,
+        sendParam: exactCall.sendParam,
+        quoteRead: exactCall.quoteRead,
+        approvalCall: exactCall.shareApproveTx,
+        executionCall: {
+          ...exactCall.sendTx,
+          value: quoteFee.nativeFee,
+          data: oftInterface.encodeFunctionData('send', [
+            exactCall.sendParam,
+            { nativeFee: quoteFee.nativeFee, lzTokenFee: 0 },
+            refundAddress,
+          ]),
+        },
+      },
+      requestParams: params,
+    };
+  }
+
+  async execute(
+    quote: BridgeQuote<KatanaBridgeRoute>,
+    privateKeys: Partial<Record<ProtocolType, string>>,
+  ): Promise<BridgeTransferResult> {
+    const route = quote.route;
+    assert(route, 'KatanaBridge requires a populated route');
+    assert(
+      route.kind === 'ethereum-to-katana' ||
+        route.kind === 'katana-to-ethereum',
+      'Invalid KatanaBridge route',
+    );
+
+    const key = privateKeys[ProtocolType.Ethereum];
+    assert(key, 'Missing EVM private key for KatanaBridge execution');
+
+    const signerAddress = normalizeAddressEvm(
+      new ethers.Wallet(ensure0x(key)).address,
+    );
+    this.validateExecutionQuote(quote, route, signerAddress);
+
+    const allowance = await this.readAllowance(
+      route.fromChainId,
+      route.approvalCall.tokenAddress,
+      signerAddress,
+      route.approvalCall.spender,
+    );
+    if (allowance < route.approvalCall.amount) {
+      await this.sendPreparedTransaction(route.fromChainId, key, {
+        to: route.approvalCall.to,
+        data: route.approvalCall.data,
+        value: 0n,
+      });
+    }
+
+    const receipt = await this.sendPreparedTransaction(
+      route.fromChainId,
+      key,
+      route.executionCall,
+    );
+    const transferId = this.extractGuidFromReceipt(receipt);
+
+    return {
+      txHash: receipt.transactionHash,
+      fromChain: route.fromChainId,
+      toChain: route.toChainId,
+      transferId,
+    };
+  }
+
+  async getStatus(
+    txHash: string,
+    fromChain: number,
+    toChain: number,
+  ): Promise<BridgeTransferStatus> {
+    const direction = this.getDirectionByChains(fromChain, toChain);
+    if (!direction) {
+      return {
+        status: 'failed',
+        error: `Unsupported Katana status route: ${fromChain} -> ${toChain}`,
+      };
+    }
+
+    const normalizedHash = txHash.startsWith('0x') ? txHash : `0x${txHash}`;
+    const response = await this.fetchWithRetry(
+      `${LAYERZERO_SCAN_API_URL}${normalizedHash}`,
+    );
+
+    if (response.status === 404) {
+      return { status: 'not_found' };
+    }
+
+    const data = (await response.json()) as LayerZeroScanResponse;
+    if (!data.messages?.length) {
+      return { status: 'not_found' };
+    }
+
+    const message = data.messages[0];
+    switch (message.status) {
+      case 'FAILED':
+      case 'BLOCKED':
+        return { status: 'failed', error: message.status };
+      case 'DELIVERED': {
+        const destinationTxHash = message.dstTxHash;
+        if (!destinationTxHash) {
+          return { status: 'pending', substatus: 'DELIVERED' };
+        }
+
+        const receipt = await this.getTransactionReceipt(
+          toChain,
+          destinationTxHash,
+        );
+        if (!receipt) {
+          return { status: 'pending', substatus: 'DELIVERED' };
+        }
+
+        const receivedAmount = this.extractReceivedAmount(direction, receipt);
+        if (receivedAmount === undefined) {
+          return {
+            status: 'failed',
+            error: 'Unable to parse Katana destination received amount',
+          };
+        }
+
+        return {
+          status: 'complete',
+          receivingTxHash: destinationTxHash,
+          receivedAmount,
+        };
+      }
+      case 'INFLIGHT':
+        return { status: 'pending', substatus: 'INFLIGHT' };
+      default:
+        return { status: 'pending', substatus: message.status };
+    }
+  }
+
+  protected getProvider(chainId: number): ethers.providers.JsonRpcProvider {
+    return new ethers.providers.JsonRpcProvider(this.getRpcUrl(chainId));
+  }
+
+  protected async callContract(
+    chainId: number,
+    to: string,
+    data: string,
+  ): Promise<string> {
+    return this.getProvider(chainId).call({ to, data });
+  }
+
+  protected async getTransactionReceipt(
+    chainId: number,
+    txHash: string,
+  ): Promise<ethers.providers.TransactionReceipt | undefined> {
+    return this.getProvider(chainId).getTransactionReceipt(txHash);
+  }
+
+  protected async sendPreparedTransaction(
+    chainId: number,
+    privateKey: string,
+    call: BuiltTx,
+  ): Promise<ethers.providers.TransactionReceipt> {
+    const provider = this.getProvider(chainId);
+    const wallet = new ethers.Wallet(ensure0x(privateKey), provider);
+    const tx = await wallet.sendTransaction({
+      to: call.to,
+      data: call.data,
+      value: call.value.toString(),
+    });
+    return tx.wait();
+  }
+
+  protected async fetchWithRetry(
+    url: string,
+    options?: RequestInit,
+    retries: number = 3,
+  ): Promise<Response> {
+    let lastError: Error | undefined;
+    for (let attempt = 0; attempt < retries; attempt++) {
+      if (attempt > 0) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, 1000 * 2 ** (attempt - 1)),
+        );
+      }
+      try {
+        const response = await fetch(url, options);
+        if (response.status === 404) return response;
+        if (
+          response.status >= 400 &&
+          response.status < 500 &&
+          response.status !== 429
+        ) {
+          const body = await response.text();
+          throw new Error(`HTTP ${response.status}: ${body}`);
+        }
+        if (response.ok) return response;
+        lastError = new Error(`HTTP ${response.status} from ${url}`);
+      } catch (error) {
+        if (error instanceof Error && /^HTTP 4\d\d/.test(error.message))
+          throw error;
+        lastError = error instanceof Error ? error : new Error(String(error));
+      }
+    }
+    throw lastError ?? new Error(`fetchWithRetry exhausted retries for ${url}`);
+  }
+
+  private getDirection(
+    fromChain: number,
+    toChain: number,
+    fromToken: string,
+    toToken: string,
+  ): KatanaDirection | undefined {
+    if (
+      fromChain === KATANA_FORWARD_CONFIG.fromChainId &&
+      toChain === KATANA_FORWARD_CONFIG.toChainId &&
+      addressesEqual(fromToken, KATANA_FORWARD_CONFIG.fromToken) &&
+      addressesEqual(toToken, KATANA_FORWARD_CONFIG.toToken)
+    ) {
+      return 'ethereum-to-katana';
+    }
+
+    if (
+      fromChain === KATANA_REVERSE_CONFIG.fromChainId &&
+      toChain === KATANA_REVERSE_CONFIG.toChainId &&
+      addressesEqual(fromToken, KATANA_REVERSE_CONFIG.fromToken) &&
+      addressesEqual(toToken, KATANA_REVERSE_CONFIG.toToken)
+    ) {
+      return 'katana-to-ethereum';
+    }
+
+    return undefined;
+  }
+
+  private getDirectionByChains(
+    fromChain: number,
+    toChain: number,
+  ): KatanaDirection | undefined {
+    if (
+      fromChain === KATANA_FORWARD_CONFIG.fromChainId &&
+      toChain === KATANA_FORWARD_CONFIG.toChainId
+    ) {
+      return 'ethereum-to-katana';
+    }
+    if (
+      fromChain === KATANA_REVERSE_CONFIG.fromChainId &&
+      toChain === KATANA_REVERSE_CONFIG.toChainId
+    ) {
+      return 'katana-to-ethereum';
+    }
+    return undefined;
+  }
+
+  private validateExecutionQuote(
+    quote: BridgeQuote<KatanaBridgeRoute>,
+    route: KatanaBridgeRoute,
+    signerAddress: string,
+  ): void {
+    const { requestParams } = quote;
+    const expectedDirection = this.getDirection(
+      requestParams.fromChain,
+      requestParams.toChain,
+      requestParams.fromToken,
+      requestParams.toToken,
+    );
+
+    assert(
+      expectedDirection === route.kind,
+      'Route kind does not match request',
+    );
+    assert(
+      requestParams.fromAmount === quote.fromAmount,
+      'Quote fromAmount does not match request',
+    );
+    assert(
+      addressesEqual(requestParams.fromAddress, signerAddress),
+      `Signer ${signerAddress} does not match quote.fromAddress ${requestParams.fromAddress}`,
+    );
+
+    const expectedRecipient = normalizeAddressEvm(
+      requestParams.toAddress ?? requestParams.fromAddress,
+    );
+    assert(
+      addressesEqual(route.recipient, expectedRecipient),
+      `Route recipient ${route.recipient} does not match quote recipient ${expectedRecipient}`,
+    );
+  }
+
+  private async probePreviewAmount(
+    chainId: number,
+    contractAddress: string,
+    functionName: 'previewDeposit' | 'previewRedeem',
+    amount: bigint,
+  ): Promise<bigint> {
+    const data = previewInterface.encodeFunctionData(functionName, [
+      amount.toString(),
+    ]);
+    const raw = await this.callContract(chainId, contractAddress, data);
+    const decoded = previewInterface.decodeFunctionResult(functionName, raw);
+    return toBigInt(decoded[0]);
+  }
+
+  private async probeQuoteSend(
+    chainId: number,
+    quoteRead: BuiltRead,
+  ): Promise<{ nativeFee: bigint; lzTokenFee: bigint }> {
+    const raw = await this.callContract(chainId, quoteRead.to, quoteRead.data);
+    const decoded = oftInterface.decodeFunctionResult('quoteSend', raw);
+    const fee = decoded.msgFee ?? decoded[0];
+    return {
+      nativeFee: toBigInt(fee.nativeFee),
+      lzTokenFee: toBigInt(fee.lzTokenFee),
+    };
+  }
+
+  private async probeSecondaryChainBalance(
+    chainId: number,
+    shareOftAddress: string,
+  ): Promise<bigint | undefined> {
+    try {
+      const data = oftInterface.encodeFunctionData('secondaryChainBalance', []);
+      const raw = await this.callContract(chainId, shareOftAddress, data);
+      const decoded = oftInterface.decodeFunctionResult(
+        'secondaryChainBalance',
+        raw,
+      );
+      return toBigInt(decoded[0]);
+    } catch {
+      return undefined;
+    }
+  }
+
+  protected async readAllowance(
+    chainId: number,
+    tokenAddress: string,
+    owner: string,
+    spender: string,
+  ): Promise<bigint> {
+    const provider = this.getProvider(chainId);
+    const token = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
+    return toBigInt(await token.allowance(owner, spender));
+  }
+
+  private extractGuidFromReceipt(
+    receipt: ethers.providers.TransactionReceipt,
+  ): string | undefined {
+    for (const log of receipt.logs) {
+      try {
+        const parsed = oftInterface.parseLog(log);
+        if (parsed.name === 'OFTSent') {
+          return parsed.args.guid;
+        }
+      } catch {}
+
+      try {
+        const parsed = composerInterface.parseLog(log);
+        if (parsed.name === 'Sent') {
+          return parsed.args.guid;
+        }
+      } catch {}
+    }
+
+    return undefined;
+  }
+
+  private extractReceivedAmount(
+    direction: KatanaDirection,
+    receipt: ethers.providers.TransactionReceipt,
+  ): bigint | undefined {
+    if (direction === 'ethereum-to-katana') {
+      for (const log of receipt.logs) {
+        if (
+          !addressesEqual(
+            log.address,
+            KATANA_FORWARD_CONFIG.destinationShareOftAddress,
+          )
+        ) {
+          continue;
+        }
+        try {
+          const parsed = oftInterface.parseLog(log);
+          if (parsed.name === 'OFTReceived') {
+            return toBigInt(parsed.args.amountReceivedLD);
+          }
+        } catch {}
+      }
+      return this.extractLargestTransfer(
+        receipt,
+        KATANA_FORWARD_CONFIG.toToken,
+      );
+    }
+
+    for (const log of receipt.logs) {
+      if (!addressesEqual(log.address, KATANA_REVERSE_CONFIG.composerAddress)) {
+        continue;
+      }
+      try {
+        const parsed = composerInterface.parseLog(log);
+        if (parsed.name === 'Redeemed') {
+          return toBigInt(parsed.args.assetAmt);
+        }
+      } catch {}
+    }
+
+    return this.extractLargestTransfer(receipt, KATANA_REVERSE_CONFIG.toToken);
+  }
+
+  private extractLargestTransfer(
+    receipt: ethers.providers.TransactionReceipt,
+    tokenAddress: string,
+  ): bigint | undefined {
+    let largest = 0n;
+
+    for (const log of receipt.logs) {
+      if (!addressesEqual(log.address, tokenAddress)) {
+        continue;
+      }
+      try {
+        const parsed = erc20Interface.parseLog(log);
+        if (parsed.name === 'Transfer') {
+          const value = toBigInt(parsed.args.value);
+          if (value > largest) largest = value;
+        }
+      } catch {}
+    }
+
+    return largest > 0n ? largest : undefined;
+  }
+
+  private getRpcUrl(chainId: number): string {
+    const rpcUrl = this.chainMetadataByChainId.get(chainId)?.rpcUrls?.[0]?.http;
+    assert(rpcUrl, `No RPC URL configured for chain ${chainId}`);
+    return rpcUrl;
+  }
+}

--- a/typescript/rebalancer/src/bridges/KatanaBridge.ts
+++ b/typescript/rebalancer/src/bridges/KatanaBridge.ts
@@ -182,7 +182,10 @@ export class KatanaBridge implements IExternalBridge {
     this.chainMetadataByChainId = new Map();
     if (config.chainMetadata) {
       for (const metadata of Object.values(config.chainMetadata)) {
-        if (metadata.chainId !== undefined) {
+        if (
+          metadata.chainId !== undefined &&
+          metadata.protocol === ProtocolType.Ethereum
+        ) {
           this.chainMetadataByChainId.set(Number(metadata.chainId), metadata);
         }
       }
@@ -440,8 +443,13 @@ export class KatanaBridge implements IExternalBridge {
     );
   }
 
-  protected getProvider(chainId: number): ethers.providers.JsonRpcProvider {
-    return new ethers.providers.JsonRpcProvider(this.getRpcUrl(chainId));
+  protected getProvider(
+    chainId: number,
+  ): ethers.providers.StaticJsonRpcProvider {
+    return new ethers.providers.StaticJsonRpcProvider(
+      this.getRpcUrl(chainId),
+      chainId,
+    );
   }
 
   protected async readAllowance(

--- a/typescript/rebalancer/src/bridges/KatanaBridge.ts
+++ b/typescript/rebalancer/src/bridges/KatanaBridge.ts
@@ -18,64 +18,151 @@ import type {
 } from '../interfaces/IExternalBridge.js';
 import {
   ERC20_ABI,
+  ETHEREUM_CHAIN_ID,
+  KATANA_CHAIN_ID,
   KATANA_FORWARD_CONFIG,
   KATANA_REVERSE_CONFIG,
-  applySlippage,
-  buildKatanaEthereumToKatana,
-  buildKatanaToEthereumCompose,
-  composerInterface,
-  erc20Interface,
-  oftInterface,
-  previewInterface,
-  type ApprovalTx,
-  type BuiltRead,
-  type BuiltTx,
-  type OftSendParam,
 } from './katanaUtils.js';
 
 type KatanaDirection = 'ethereum-to-katana' | 'katana-to-ethereum';
 
-type LayerZeroScanMessage = {
-  status: string;
-  dstTxHash?: string;
+type ArcApiSuccess<T> = {
+  status: 'success';
+  data: T;
 };
 
-type LayerZeroScanResponse = {
-  messages?: LayerZeroScanMessage[];
+type ArcApiError = {
+  status: 'error';
+  message: string;
+  name?: string;
+  code?: number;
+};
+
+type ArcApiResponse<T> = ArcApiSuccess<T> | ArcApiError;
+
+type ArcFeeCost = {
+  amount: string;
+  included?: boolean;
+};
+
+type ArcGasCost = {
+  amount: string;
+};
+
+type ArcStep = {
+  estimate: {
+    approvalAddress: string | null;
+  };
+};
+
+type ArcUnsignedTransaction = {
+  from?: string;
+  to: string;
+  data: string;
+  value: string;
+  gasLimit?: string;
+  gasPrice?: string;
+  maxFeePerGas?: string;
+  maxPriorityFeePerGas?: string;
+  chainId: number;
+};
+
+type ArcRoute = {
+  id: string;
+  provider: string[];
+  fromChainId: number;
+  toChainId: number;
+  fromAmount: string;
+  toAmount: string;
+  toAmountMin: string;
+  feeCosts: ArcFeeCost[];
+  gasCosts: ArcGasCost[];
+  steps: ArcStep[];
+  transactionRequest?: ArcUnsignedTransaction;
+  executionDuration?: number | null;
+  estimatedCompletionTime?: number | null;
+  providerMetadata?: {
+    agglayer?: {
+      claimTransactionRequired?: boolean;
+    };
+  };
+};
+
+type ArcTransaction = {
+  transactionHash: string;
+  transactionHashes?: string[];
+  status: string;
+  sending: {
+    txHash: string;
+    network: {
+      chainId: number;
+      networkId: number | null;
+    };
+  };
+  receiving?: {
+    txHash?: string | null;
+    amount?: string | null;
+  } | null;
+  metadata?: {
+    depositCount?: number | null;
+  };
+};
+
+type KatanaExecutionState = {
+  fromAddress: string;
+  claimRequired: boolean;
+  claimSubmittedTxHash?: string;
 };
 
 export type KatanaBridgeRoute = {
+  id: string;
   kind: KatanaDirection;
   fromChainId: number;
   toChainId: number;
   fromToken: string;
   toToken: string;
   recipient: string;
-  refundAddress: string;
-  previewAmount: bigint;
-  nativeFee: bigint;
-  sendParam: OftSendParam;
-  quoteRead: BuiltRead;
-  approvalCall: ApprovalTx;
-  executionCall: BuiltTx;
+  approvalAddress?: string;
+  executionTx: ArcUnsignedTransaction;
+  claimTransactionRequired: boolean;
 };
 
+const ARC_API_BASE_URL = 'https://arc-api.polygon.technology';
 const DEFAULT_SLIPPAGE = 0.005;
-const EXECUTION_DURATION_S = 120;
-const LAYERZERO_SCAN_API_URL = 'https://scan.layerzero-api.com/v1/messages/tx/';
-
-function toBigInt(value: unknown): bigint {
-  if (typeof value === 'bigint') return value;
-  if (typeof value === 'number') return BigInt(value);
-  if (typeof value === 'string') return BigInt(value);
-  if (value && typeof value === 'object' && 'toString' in value) {
-    return BigInt((value as { toString: () => string }).toString());
-  }
-  throw new Error(`Unable to convert value to bigint: ${String(value)}`);
-}
+const TRANSACTION_POLL_INTERVAL_MS = 5_000;
+const CLAIM_SUBMISSION_TIMEOUT_MS = 10 * 60 * 1_000;
+const TRANSACTION_QUERY_LIMIT = 100;
+const erc20Interface = new ethers.utils.Interface(ERC20_ABI);
 
 function addressesEqual(a: string, b: string): boolean {
   return normalizeAddressEvm(a) === normalizeAddressEvm(b);
+}
+
+function toBigInt(value: string | number | bigint | null | undefined): bigint {
+  assert(value !== null && value !== undefined, 'Missing bigint value');
+  if (typeof value === 'bigint') return value;
+  return BigInt(value);
+}
+
+function sumBigIntStrings(values: Array<{ amount: string }>): bigint {
+  return values.reduce((sum, value) => sum + BigInt(value.amount), 0n);
+}
+
+function normalizeTxHash(txHash: string): string {
+  return txHash.startsWith('0x')
+    ? txHash.toLowerCase()
+    : `0x${txHash.toLowerCase()}`;
+}
+
+function txMatchesHash(tx: ArcTransaction, txHash: string): boolean {
+  const normalized = normalizeTxHash(txHash);
+  return (
+    normalizeTxHash(tx.transactionHash) === normalized ||
+    normalizeTxHash(tx.sending.txHash) === normalized ||
+    tx.transactionHashes?.some(
+      (hash) => normalizeTxHash(hash) === normalized,
+    ) === true
+  );
 }
 
 export class KatanaBridge implements IExternalBridge {
@@ -84,6 +171,10 @@ export class KatanaBridge implements IExternalBridge {
 
   private readonly config: ExternalBridgeConfig;
   private readonly chainMetadataByChainId: Map<number, ChainMetadata>;
+  private readonly executionStateByTxHash = new Map<
+    string,
+    KatanaExecutionState
+  >();
 
   constructor(config: ExternalBridgeConfig, logger: Logger) {
     this.config = config;
@@ -111,138 +202,62 @@ export class KatanaBridge implements IExternalBridge {
     const recipient = normalizeAddressEvm(
       params.toAddress ?? params.fromAddress,
     );
-    const refundAddress = normalizeAddressEvm(params.fromAddress);
     const slippage =
       params.slippage ?? this.config.defaultSlippage ?? DEFAULT_SLIPPAGE;
 
     assert(direction, `Unsupported Katana route: ${fromChain} -> ${toChain}`);
-    assert(toAmount === undefined, 'KatanaBridge does not support toAmount');
+    assert(toAmount === undefined, 'KatanaBridge only supports fromAmount');
     assert(fromAmount !== undefined, 'KatanaBridge requires fromAmount');
     assert(fromAmount > 0n, 'KatanaBridge requires a positive fromAmount');
 
-    if (direction === 'ethereum-to-katana') {
-      const previewShares = await this.probePreviewAmount(
-        fromChain,
-        KATANA_FORWARD_CONFIG.vaultAddress,
-        'previewDeposit',
-        fromAmount,
-      );
-      const exactCall = buildKatanaEthereumToKatana({
-        vaultAddress: KATANA_FORWARD_CONFIG.vaultAddress,
-        composerAddress: KATANA_FORWARD_CONFIG.composerAddress,
-        shareOftAddress: KATANA_FORWARD_CONFIG.shareOftAddress,
-        underlyingTokenAddress: KATANA_FORWARD_CONFIG.fromToken,
-        dstEid: KATANA_FORWARD_CONFIG.dstEid,
-        recipient,
-        amountLD: fromAmount,
-        shareAmountLD: previewShares,
-        minShareAmountLD: applySlippage(previewShares, slippage),
-        refundAddress,
-        extraOptions: KATANA_FORWARD_CONFIG.extraOptions,
-        composeMsg: KATANA_FORWARD_CONFIG.composeMsg,
-        oftCmd: KATANA_FORWARD_CONFIG.oftCmd,
-      });
-      const quoteFee = await this.probeQuoteSend(
-        fromChain,
-        exactCall.quoteRead,
-      );
-
-      return {
-        id: crypto.randomUUID(),
-        tool: 'katana-vault-bridge',
-        fromAmount,
-        toAmount: previewShares,
-        toAmountMin: exactCall.sendParam.minAmountLD,
-        executionDuration: EXECUTION_DURATION_S,
-        gasCosts: quoteFee.nativeFee,
-        feeCosts: 0n,
-        route: {
-          kind: direction,
-          fromChainId: fromChain,
-          toChainId: toChain,
-          fromToken: normalizeAddressEvm(fromToken),
-          toToken: normalizeAddressEvm(toToken),
-          recipient,
-          refundAddress,
-          previewAmount: previewShares,
-          nativeFee: quoteFee.nativeFee,
-          sendParam: exactCall.sendParam,
-          quoteRead: exactCall.quoteRead,
-          approvalCall: exactCall.assetApproveTx,
-          executionCall: {
-            ...exactCall.depositAndSendTx,
-            value: quoteFee.nativeFee,
-          },
-        },
-        requestParams: params,
-      };
-    }
-
-    const previewAssets = await this.probePreviewAmount(
-      toChain,
-      KATANA_REVERSE_CONFIG.vaultAddress,
-      'previewRedeem',
-      fromAmount,
-    );
-    const exactCall = buildKatanaToEthereumCompose({
-      vaultAddress: KATANA_REVERSE_CONFIG.vaultAddress,
-      composerAddress: KATANA_REVERSE_CONFIG.composerAddress,
-      shareTokenAddress: KATANA_REVERSE_CONFIG.shareTokenAddress,
-      shareOftAddress: KATANA_REVERSE_CONFIG.shareOftAddress,
-      dstEid: KATANA_REVERSE_CONFIG.dstEid,
-      recipient,
-      shareAmountLD: fromAmount,
-      minShareAmountLD: fromAmount,
-      assetAmountLD: previewAssets,
-      minAssetAmountLD: applySlippage(previewAssets, slippage),
-      refundAddress,
-      extraOptions: KATANA_REVERSE_CONFIG.extraOptions,
-      receiveExtraOptions: KATANA_REVERSE_CONFIG.receiveExtraOptions,
-      oftCmd: KATANA_REVERSE_CONFIG.oftCmd,
+    const routes = await this.requestRoutes({
+      fromChainId: fromChain,
+      toChainId: toChain,
+      fromTokenAddress: normalizeAddressEvm(fromToken),
+      toTokenAddress: normalizeAddressEvm(toToken),
+      amount: fromAmount.toString(),
+      fromAddress: normalizeAddressEvm(params.fromAddress),
+      toAddress: recipient,
+      slippage: slippage * 100,
     });
-    const quoteFee = await this.probeQuoteSend(fromChain, exactCall.quoteRead);
-    const secondaryChainBalance = await this.probeSecondaryChainBalance(
-      fromChain,
-      KATANA_REVERSE_CONFIG.shareOftAddress,
+    const route = this.selectRoute(routes);
+    const executionTx =
+      route.transactionRequest ??
+      (await this.requestUnsignedTransaction(route));
+    const approvalAddress =
+      route.steps[0]?.estimate.approvalAddress ?? undefined;
+
+    assert(
+      BigInt(route.fromAmount) === fromAmount,
+      `Katana route fromAmount ${route.fromAmount} did not match request ${fromAmount}`,
     );
-    if (secondaryChainBalance !== undefined) {
-      assert(
-        secondaryChainBalance >= fromAmount,
-        `Insufficient Katana secondaryChainBalance: ${secondaryChainBalance} < ${fromAmount}`,
-      );
-    }
 
     return {
       id: crypto.randomUUID(),
-      tool: 'katana-vault-bridge',
+      tool: 'agglayer',
       fromAmount,
-      toAmount: previewAssets,
-      toAmountMin: exactCall.redemptionSendParam.minAmountLD,
-      executionDuration: EXECUTION_DURATION_S,
-      gasCosts: quoteFee.nativeFee,
-      feeCosts: 0n,
+      toAmount: BigInt(route.toAmount),
+      toAmountMin: BigInt(route.toAmountMin),
+      executionDuration:
+        route.estimatedCompletionTime ??
+        route.executionDuration ??
+        CLAIM_SUBMISSION_TIMEOUT_MS / 1_000,
+      gasCosts: sumBigIntStrings(route.gasCosts),
+      feeCosts: sumBigIntStrings(
+        route.feeCosts.filter((cost) => !cost.included),
+      ),
       route: {
+        id: route.id,
         kind: direction,
         fromChainId: fromChain,
         toChainId: toChain,
         fromToken: normalizeAddressEvm(fromToken),
         toToken: normalizeAddressEvm(toToken),
         recipient,
-        refundAddress,
-        previewAmount: previewAssets,
-        nativeFee: quoteFee.nativeFee,
-        sendParam: exactCall.sendParam,
-        quoteRead: exactCall.quoteRead,
-        approvalCall: exactCall.shareApproveTx,
-        executionCall: {
-          ...exactCall.sendTx,
-          value: quoteFee.nativeFee,
-          data: oftInterface.encodeFunctionData('send', [
-            exactCall.sendParam,
-            { nativeFee: quoteFee.nativeFee, lzTokenFee: 0 },
-            refundAddress,
-          ]),
-        },
+        approvalAddress,
+        executionTx,
+        claimTransactionRequired:
+          route.providerMetadata?.agglayer?.claimTransactionRequired === true,
       },
       requestParams: params,
     };
@@ -254,11 +269,6 @@ export class KatanaBridge implements IExternalBridge {
   ): Promise<BridgeTransferResult> {
     const route = quote.route;
     assert(route, 'KatanaBridge requires a populated route');
-    assert(
-      route.kind === 'ethereum-to-katana' ||
-        route.kind === 'katana-to-ethereum',
-      'Invalid KatanaBridge route',
-    );
 
     const key = privateKeys[ProtocolType.Ethereum];
     assert(key, 'Missing EVM private key for KatanaBridge execution');
@@ -268,293 +278,170 @@ export class KatanaBridge implements IExternalBridge {
     );
     this.validateExecutionQuote(quote, route, signerAddress);
 
-    const allowance = await this.readAllowance(
-      route.fromChainId,
-      route.approvalCall.tokenAddress,
-      signerAddress,
-      route.approvalCall.spender,
-    );
-    if (allowance < route.approvalCall.amount) {
-      await this.sendPreparedTransaction(route.fromChainId, key, {
-        to: route.approvalCall.to,
-        data: route.approvalCall.data,
-        value: 0n,
-      });
+    if (route.approvalAddress) {
+      const allowance = await this.readAllowance(
+        route.executionTx.chainId,
+        route.fromToken,
+        signerAddress,
+        route.approvalAddress,
+      );
+      if (allowance < quote.fromAmount) {
+        await this.sendPreparedTransaction(route.executionTx.chainId, key, {
+          to: route.fromToken,
+          data: erc20Interface.encodeFunctionData('approve', [
+            route.approvalAddress,
+            quote.fromAmount.toString(),
+          ]),
+          value: '0',
+          chainId: route.executionTx.chainId,
+        });
+      }
     }
 
-    const receipt = await this.sendPreparedTransaction(
-      route.fromChainId,
+    const sourceReceipt = await this.sendPreparedTransaction(
+      route.executionTx.chainId,
       key,
-      route.executionCall,
+      route.executionTx,
     );
-    const transferId = this.extractGuidFromReceipt(receipt);
+    const sourceTxHash = normalizeTxHash(sourceReceipt.transactionHash);
+
+    this.executionStateByTxHash.set(sourceTxHash, {
+      fromAddress: signerAddress,
+      claimRequired: route.claimTransactionRequired,
+    });
+
+    if (route.claimTransactionRequired) {
+      const claimReceipt = await this.waitForAndSubmitClaim(
+        sourceTxHash,
+        signerAddress,
+        key,
+      );
+      const state = this.executionStateByTxHash.get(sourceTxHash);
+      if (state) {
+        state.claimSubmittedTxHash = normalizeTxHash(
+          claimReceipt.transactionHash,
+        );
+      }
+    }
 
     return {
-      txHash: receipt.transactionHash,
+      txHash: sourceTxHash,
       fromChain: route.fromChainId,
       toChain: route.toChainId,
-      transferId,
     };
   }
 
   async getStatus(
     txHash: string,
-    fromChain: number,
-    toChain: number,
+    _fromChain: number,
+    _toChain: number,
   ): Promise<BridgeTransferStatus> {
-    const direction = this.getDirectionByChains(fromChain, toChain);
-    if (!direction) {
+    const normalizedTxHash = normalizeTxHash(txHash);
+    const state = this.executionStateByTxHash.get(normalizedTxHash);
+    if (!state) return { status: 'not_found' };
+
+    const tx = await this.findIndexedTransaction(
+      state.fromAddress,
+      normalizedTxHash,
+    );
+    if (!tx) {
+      return { status: 'pending', substatus: 'INDEXING' };
+    }
+
+    if (this.isFailedStatus(tx.status)) {
+      return { status: 'failed', error: tx.status };
+    }
+
+    const receivingTxHash =
+      tx.receiving?.txHash ??
+      tx.transactionHashes?.find(
+        (hash) => normalizeTxHash(hash) !== normalizedTxHash,
+      );
+
+    if (receivingTxHash && tx.receiving?.amount) {
       return {
-        status: 'failed',
-        error: `Unsupported Katana status route: ${fromChain} -> ${toChain}`,
+        status: 'complete',
+        receivingTxHash,
+        receivedAmount: BigInt(tx.receiving.amount),
       };
     }
 
-    const normalizedHash = txHash.startsWith('0x') ? txHash : `0x${txHash}`;
-    const response = await this.fetchWithRetry(
-      `${LAYERZERO_SCAN_API_URL}${normalizedHash}`,
+    return {
+      status: 'pending',
+      substatus:
+        tx.status === 'BRIDGED' && state.claimSubmittedTxHash
+          ? 'CLAIM_SUBMITTED'
+          : tx.status,
+    };
+  }
+
+  protected async requestRoutes(params: {
+    fromChainId: number;
+    toChainId: number;
+    fromTokenAddress: string;
+    toTokenAddress: string;
+    amount: string;
+    fromAddress: string;
+    toAddress: string;
+    slippage: number;
+  }): Promise<ArcRoute[]> {
+    const response = await this.fetchArcJson<ArcRoute[]>('/routes', {
+      method: 'POST',
+      body: JSON.stringify(params),
+    });
+    return this.requireSuccess(response, 'Failed to fetch Katana routes');
+  }
+
+  protected async requestUnsignedTransaction(
+    route: ArcRoute,
+  ): Promise<ArcUnsignedTransaction> {
+    const response = await this.fetchArcJson<ArcUnsignedTransaction>(
+      '/routes/build-transaction',
+      {
+        method: 'POST',
+        body: JSON.stringify(route.steps[0]),
+      },
     );
+    return this.requireSuccess(
+      response,
+      'Failed to build Katana unsigned transaction',
+    );
+  }
 
-    if (response.status === 404) {
-      return { status: 'not_found' };
-    }
+  protected async requestTransactions(
+    address: string,
+    limit: number = TRANSACTION_QUERY_LIMIT,
+  ): Promise<ArcTransaction[]> {
+    const query = new URLSearchParams({
+      'transactionsRequestQueryParams[address]': address,
+      'transactionsRequestQueryParams[limit]': String(limit),
+    });
+    const response = await this.fetchArcJson<ArcTransaction[]>(
+      `/transactions?${query.toString()}`,
+      { method: 'GET' },
+    );
+    return this.requireSuccess(response, 'Failed to fetch Katana transactions');
+  }
 
-    const data = (await response.json()) as LayerZeroScanResponse;
-    if (!data.messages?.length) {
-      return { status: 'not_found' };
-    }
-
-    const message = data.messages[0];
-    switch (message.status) {
-      case 'FAILED':
-      case 'BLOCKED':
-        return { status: 'failed', error: message.status };
-      case 'DELIVERED': {
-        const destinationTxHash = message.dstTxHash;
-        if (!destinationTxHash) {
-          return { status: 'pending', substatus: 'DELIVERED' };
-        }
-
-        const receipt = await this.getTransactionReceipt(
-          toChain,
-          destinationTxHash,
-        );
-        if (!receipt) {
-          return { status: 'pending', substatus: 'DELIVERED' };
-        }
-
-        const receivedAmount = this.extractReceivedAmount(direction, receipt);
-        if (receivedAmount === undefined) {
-          return {
-            status: 'failed',
-            error: 'Unable to parse Katana destination received amount',
-          };
-        }
-
-        return {
-          status: 'complete',
-          receivingTxHash: destinationTxHash,
-          receivedAmount,
-        };
-      }
-      case 'INFLIGHT':
-        return { status: 'pending', substatus: 'INFLIGHT' };
-      default:
-        return { status: 'pending', substatus: message.status };
-    }
+  protected async requestClaimTransaction(
+    sourceNetworkId: number,
+    depositCount: number,
+  ): Promise<ArcUnsignedTransaction> {
+    const response = await this.fetchArcJson<ArcUnsignedTransaction>(
+      '/routes/build-transaction-for-claim',
+      {
+        method: 'POST',
+        body: JSON.stringify({ sourceNetworkId, depositCount }),
+      },
+    );
+    return this.requireSuccess(
+      response,
+      'Failed to build Katana claim transaction',
+    );
   }
 
   protected getProvider(chainId: number): ethers.providers.JsonRpcProvider {
     return new ethers.providers.JsonRpcProvider(this.getRpcUrl(chainId));
-  }
-
-  protected async callContract(
-    chainId: number,
-    to: string,
-    data: string,
-  ): Promise<string> {
-    return this.getProvider(chainId).call({ to, data });
-  }
-
-  protected async getTransactionReceipt(
-    chainId: number,
-    txHash: string,
-  ): Promise<ethers.providers.TransactionReceipt | undefined> {
-    return this.getProvider(chainId).getTransactionReceipt(txHash);
-  }
-
-  protected async sendPreparedTransaction(
-    chainId: number,
-    privateKey: string,
-    call: BuiltTx,
-  ): Promise<ethers.providers.TransactionReceipt> {
-    const provider = this.getProvider(chainId);
-    const wallet = new ethers.Wallet(ensure0x(privateKey), provider);
-    const tx = await wallet.sendTransaction({
-      to: call.to,
-      data: call.data,
-      value: call.value.toString(),
-    });
-    return tx.wait();
-  }
-
-  protected async fetchWithRetry(
-    url: string,
-    options?: RequestInit,
-    retries: number = 3,
-  ): Promise<Response> {
-    let lastError: Error | undefined;
-    for (let attempt = 0; attempt < retries; attempt++) {
-      if (attempt > 0) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, 1000 * 2 ** (attempt - 1)),
-        );
-      }
-      try {
-        const response = await fetch(url, options);
-        if (response.status === 404) return response;
-        if (
-          response.status >= 400 &&
-          response.status < 500 &&
-          response.status !== 429
-        ) {
-          const body = await response.text();
-          throw new Error(`HTTP ${response.status}: ${body}`);
-        }
-        if (response.ok) return response;
-        lastError = new Error(`HTTP ${response.status} from ${url}`);
-      } catch (error) {
-        if (error instanceof Error && /^HTTP 4\d\d/.test(error.message))
-          throw error;
-        lastError = error instanceof Error ? error : new Error(String(error));
-      }
-    }
-    throw lastError ?? new Error(`fetchWithRetry exhausted retries for ${url}`);
-  }
-
-  private getDirection(
-    fromChain: number,
-    toChain: number,
-    fromToken: string,
-    toToken: string,
-  ): KatanaDirection | undefined {
-    if (
-      fromChain === KATANA_FORWARD_CONFIG.fromChainId &&
-      toChain === KATANA_FORWARD_CONFIG.toChainId &&
-      addressesEqual(fromToken, KATANA_FORWARD_CONFIG.fromToken) &&
-      addressesEqual(toToken, KATANA_FORWARD_CONFIG.toToken)
-    ) {
-      return 'ethereum-to-katana';
-    }
-
-    if (
-      fromChain === KATANA_REVERSE_CONFIG.fromChainId &&
-      toChain === KATANA_REVERSE_CONFIG.toChainId &&
-      addressesEqual(fromToken, KATANA_REVERSE_CONFIG.fromToken) &&
-      addressesEqual(toToken, KATANA_REVERSE_CONFIG.toToken)
-    ) {
-      return 'katana-to-ethereum';
-    }
-
-    return undefined;
-  }
-
-  private getDirectionByChains(
-    fromChain: number,
-    toChain: number,
-  ): KatanaDirection | undefined {
-    if (
-      fromChain === KATANA_FORWARD_CONFIG.fromChainId &&
-      toChain === KATANA_FORWARD_CONFIG.toChainId
-    ) {
-      return 'ethereum-to-katana';
-    }
-    if (
-      fromChain === KATANA_REVERSE_CONFIG.fromChainId &&
-      toChain === KATANA_REVERSE_CONFIG.toChainId
-    ) {
-      return 'katana-to-ethereum';
-    }
-    return undefined;
-  }
-
-  private validateExecutionQuote(
-    quote: BridgeQuote<KatanaBridgeRoute>,
-    route: KatanaBridgeRoute,
-    signerAddress: string,
-  ): void {
-    const { requestParams } = quote;
-    const expectedDirection = this.getDirection(
-      requestParams.fromChain,
-      requestParams.toChain,
-      requestParams.fromToken,
-      requestParams.toToken,
-    );
-
-    assert(
-      expectedDirection === route.kind,
-      'Route kind does not match request',
-    );
-    assert(
-      requestParams.fromAmount === quote.fromAmount,
-      'Quote fromAmount does not match request',
-    );
-    assert(
-      addressesEqual(requestParams.fromAddress, signerAddress),
-      `Signer ${signerAddress} does not match quote.fromAddress ${requestParams.fromAddress}`,
-    );
-
-    const expectedRecipient = normalizeAddressEvm(
-      requestParams.toAddress ?? requestParams.fromAddress,
-    );
-    assert(
-      addressesEqual(route.recipient, expectedRecipient),
-      `Route recipient ${route.recipient} does not match quote recipient ${expectedRecipient}`,
-    );
-  }
-
-  private async probePreviewAmount(
-    chainId: number,
-    contractAddress: string,
-    functionName: 'previewDeposit' | 'previewRedeem',
-    amount: bigint,
-  ): Promise<bigint> {
-    const data = previewInterface.encodeFunctionData(functionName, [
-      amount.toString(),
-    ]);
-    const raw = await this.callContract(chainId, contractAddress, data);
-    const decoded = previewInterface.decodeFunctionResult(functionName, raw);
-    return toBigInt(decoded[0]);
-  }
-
-  private async probeQuoteSend(
-    chainId: number,
-    quoteRead: BuiltRead,
-  ): Promise<{ nativeFee: bigint; lzTokenFee: bigint }> {
-    const raw = await this.callContract(chainId, quoteRead.to, quoteRead.data);
-    const decoded = oftInterface.decodeFunctionResult('quoteSend', raw);
-    const fee = decoded.msgFee ?? decoded[0];
-    return {
-      nativeFee: toBigInt(fee.nativeFee),
-      lzTokenFee: toBigInt(fee.lzTokenFee),
-    };
-  }
-
-  private async probeSecondaryChainBalance(
-    chainId: number,
-    shareOftAddress: string,
-  ): Promise<bigint | undefined> {
-    try {
-      const data = oftInterface.encodeFunctionData('secondaryChainBalance', []);
-      const raw = await this.callContract(chainId, shareOftAddress, data);
-      const decoded = oftInterface.decodeFunctionResult(
-        'secondaryChainBalance',
-        raw,
-      );
-      return toBigInt(decoded[0]);
-    } catch {
-      return undefined;
-    }
   }
 
   protected async readAllowance(
@@ -564,99 +451,262 @@ export class KatanaBridge implements IExternalBridge {
     spender: string,
   ): Promise<bigint> {
     const provider = this.getProvider(chainId);
-    const token = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
-    return toBigInt(await token.allowance(owner, spender));
+    const result = await provider.call({
+      to: tokenAddress,
+      data: erc20Interface.encodeFunctionData('allowance', [owner, spender]),
+    });
+    return toBigInt(
+      erc20Interface.decodeFunctionResult('allowance', result)[0].toString(),
+    );
   }
 
-  private extractGuidFromReceipt(
-    receipt: ethers.providers.TransactionReceipt,
-  ): string | undefined {
-    for (const log of receipt.logs) {
-      try {
-        const parsed = oftInterface.parseLog(log);
-        if (parsed.name === 'OFTSent') {
-          return parsed.args.guid;
-        }
-      } catch {}
+  protected async sendPreparedTransaction(
+    chainId: number,
+    privateKey: string,
+    tx: ArcUnsignedTransaction,
+  ): Promise<ethers.providers.TransactionReceipt> {
+    const wallet = new ethers.Wallet(
+      ensure0x(privateKey),
+      this.getProvider(chainId),
+    );
+    const response = await wallet.sendTransaction({
+      to: tx.to,
+      data: tx.data,
+      value: tx.value ? ethers.BigNumber.from(tx.value) : undefined,
+      gasLimit: tx.gasLimit ? ethers.BigNumber.from(tx.gasLimit) : undefined,
+      gasPrice: tx.gasPrice ? ethers.BigNumber.from(tx.gasPrice) : undefined,
+      maxFeePerGas: tx.maxFeePerGas
+        ? ethers.BigNumber.from(tx.maxFeePerGas)
+        : undefined,
+      maxPriorityFeePerGas: tx.maxPriorityFeePerGas
+        ? ethers.BigNumber.from(tx.maxPriorityFeePerGas)
+        : undefined,
+    });
+    return response.wait();
+  }
+
+  protected async sleep(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private selectRoute(routes: ArcRoute[]): ArcRoute {
+    const route = routes.find((candidate) =>
+      candidate.provider.some((provider) => provider === 'agglayer'),
+    );
+    assert(route, 'No AggLayer route returned for Katana bridge');
+    assert(
+      route.steps.length > 0,
+      `Katana route ${route.id} did not include execution steps`,
+    );
+    return route;
+  }
+
+  private async waitForAndSubmitClaim(
+    sourceTxHash: string,
+    fromAddress: string,
+    privateKey: string,
+  ): Promise<ethers.providers.TransactionReceipt> {
+    const deadline = Date.now() + CLAIM_SUBMISSION_TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+      const tx = await this.findIndexedTransaction(fromAddress, sourceTxHash);
+      if (!tx) {
+        await this.sleep(TRANSACTION_POLL_INTERVAL_MS);
+        continue;
+      }
+
+      if (tx.receiving?.txHash) {
+        return {
+          transactionHash: tx.receiving.txHash,
+        } as ethers.providers.TransactionReceipt;
+      }
+
+      const sourceNetworkId = tx.sending.network.networkId;
+      const depositCount = tx.metadata?.depositCount;
+      if (
+        sourceNetworkId === null ||
+        depositCount === null ||
+        depositCount === undefined
+      ) {
+        await this.sleep(TRANSACTION_POLL_INTERVAL_MS);
+        continue;
+      }
 
       try {
-        const parsed = composerInterface.parseLog(log);
-        if (parsed.name === 'Sent') {
-          return parsed.args.guid;
+        const claimTx = await this.requestClaimTransaction(
+          sourceNetworkId,
+          depositCount,
+        );
+        return this.sendPreparedTransaction(
+          claimTx.chainId,
+          privateKey,
+          claimTx,
+        );
+      } catch (error) {
+        if (this.isClaimNotReadyError(error)) {
+          await this.sleep(TRANSACTION_POLL_INTERVAL_MS);
+          continue;
         }
-      } catch {}
+        throw error;
+      }
+    }
+
+    throw new Error(`Timed out waiting for Katana claim for ${sourceTxHash}`);
+  }
+
+  private async findIndexedTransaction(
+    address: string,
+    txHash: string,
+  ): Promise<ArcTransaction | undefined> {
+    const transactions = await this.requestTransactions(address);
+    return transactions.find((tx) => txMatchesHash(tx, txHash));
+  }
+
+  private isClaimNotReadyError(error: unknown): boolean {
+    return (
+      error instanceof Error &&
+      error.message.toLowerCase().includes('transaction not ready to claim')
+    );
+  }
+
+  private isFailedStatus(status: string): boolean {
+    return ['FAILED', 'ERROR', 'REVERTED'].includes(status.toUpperCase());
+  }
+
+  private requireSuccess<T>(response: ArcApiResponse<T>, message: string): T {
+    if (response.status === 'success') return response.data;
+    throw new Error(`${message}: ${response.message}`);
+  }
+
+  private async fetchArcJson<T>(
+    path: string,
+    init: RequestInit,
+    retries: number = 3,
+  ): Promise<ArcApiResponse<T>> {
+    const url =
+      path.startsWith('http://') || path.startsWith('https://')
+        ? path
+        : `${ARC_API_BASE_URL}${path}`;
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        const response = await fetch(url, {
+          ...init,
+          headers: {
+            'content-type': 'application/json',
+            ...init.headers,
+          },
+        });
+        const rawBody = await response.text();
+        const parsedBody = rawBody
+          ? (JSON.parse(rawBody) as ArcApiResponse<T>)
+          : ({
+              status: 'error',
+              message: `HTTP ${response.status}`,
+            } as ArcApiResponse<T>);
+
+        if (response.ok) return parsedBody;
+
+        const errorMessage =
+          parsedBody.status === 'error'
+            ? parsedBody.message
+            : `HTTP ${response.status}: ${rawBody}`;
+        lastError = new Error(errorMessage);
+
+        if (response.status === 429 || response.status >= 500 || !response.ok) {
+          if (attempt < retries) {
+            await this.sleep(1_000 * 2 ** attempt);
+            continue;
+          }
+        }
+
+        throw lastError;
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        if (attempt < retries) {
+          await this.sleep(1_000 * 2 ** attempt);
+          continue;
+        }
+      }
+    }
+
+    throw lastError ?? new Error(`Failed to fetch Katana ARC endpoint: ${url}`);
+  }
+
+  private getDirection(
+    fromChain: number,
+    toChain: number,
+    fromToken: string,
+    toToken: string,
+  ): KatanaDirection | undefined {
+    if (
+      fromChain === ETHEREUM_CHAIN_ID &&
+      toChain === KATANA_CHAIN_ID &&
+      addressesEqual(fromToken, KATANA_FORWARD_CONFIG.fromToken) &&
+      addressesEqual(toToken, KATANA_FORWARD_CONFIG.toToken)
+    ) {
+      return 'ethereum-to-katana';
+    }
+
+    if (
+      fromChain === KATANA_CHAIN_ID &&
+      toChain === ETHEREUM_CHAIN_ID &&
+      addressesEqual(fromToken, KATANA_REVERSE_CONFIG.fromToken) &&
+      addressesEqual(toToken, KATANA_REVERSE_CONFIG.toToken)
+    ) {
+      return 'katana-to-ethereum';
     }
 
     return undefined;
   }
 
-  private extractReceivedAmount(
-    direction: KatanaDirection,
-    receipt: ethers.providers.TransactionReceipt,
-  ): bigint | undefined {
-    if (direction === 'ethereum-to-katana') {
-      for (const log of receipt.logs) {
-        if (
-          !addressesEqual(
-            log.address,
-            KATANA_FORWARD_CONFIG.destinationShareOftAddress,
-          )
-        ) {
-          continue;
-        }
-        try {
-          const parsed = oftInterface.parseLog(log);
-          if (parsed.name === 'OFTReceived') {
-            return toBigInt(parsed.args.amountReceivedLD);
-          }
-        } catch {}
-      }
-      return this.extractLargestTransfer(
-        receipt,
-        KATANA_FORWARD_CONFIG.toToken,
-      );
-    }
+  private validateExecutionQuote(
+    quote: BridgeQuote<KatanaBridgeRoute>,
+    route: KatanaBridgeRoute,
+    signerAddress: string,
+  ): void {
+    const expectedDirection = this.getDirection(
+      quote.requestParams.fromChain,
+      quote.requestParams.toChain,
+      quote.requestParams.fromToken,
+      quote.requestParams.toToken,
+    );
 
-    for (const log of receipt.logs) {
-      if (!addressesEqual(log.address, KATANA_REVERSE_CONFIG.composerAddress)) {
-        continue;
-      }
-      try {
-        const parsed = composerInterface.parseLog(log);
-        if (parsed.name === 'Redeemed') {
-          return toBigInt(parsed.args.assetAmt);
-        }
-      } catch {}
-    }
+    assert(
+      expectedDirection === route.kind,
+      'Route kind does not match request',
+    );
+    assert(
+      quote.requestParams.fromAmount === quote.fromAmount,
+      'Quote fromAmount does not match request',
+    );
+    assert(
+      addressesEqual(quote.requestParams.fromAddress, signerAddress),
+      `Signer ${signerAddress} does not match quote.fromAddress ${quote.requestParams.fromAddress}`,
+    );
 
-    return this.extractLargestTransfer(receipt, KATANA_REVERSE_CONFIG.toToken);
-  }
-
-  private extractLargestTransfer(
-    receipt: ethers.providers.TransactionReceipt,
-    tokenAddress: string,
-  ): bigint | undefined {
-    let largest = 0n;
-
-    for (const log of receipt.logs) {
-      if (!addressesEqual(log.address, tokenAddress)) {
-        continue;
-      }
-      try {
-        const parsed = erc20Interface.parseLog(log);
-        if (parsed.name === 'Transfer') {
-          const value = toBigInt(parsed.args.value);
-          if (value > largest) largest = value;
-        }
-      } catch {}
-    }
-
-    return largest > 0n ? largest : undefined;
+    const expectedRecipient = normalizeAddressEvm(
+      quote.requestParams.toAddress ?? quote.requestParams.fromAddress,
+    );
+    assert(
+      addressesEqual(route.recipient, expectedRecipient),
+      `Route recipient ${route.recipient} does not match quote recipient ${expectedRecipient}`,
+    );
+    assert(
+      route.executionTx.chainId === route.fromChainId,
+      `Katana execution chain ${route.executionTx.chainId} did not match source chain ${route.fromChainId}`,
+    );
   }
 
   private getRpcUrl(chainId: number): string {
-    const rpcUrl = this.chainMetadataByChainId.get(chainId)?.rpcUrls?.[0]?.http;
-    assert(rpcUrl, `No RPC URL configured for chain ${chainId}`);
+    const metadata = this.chainMetadataByChainId.get(chainId);
+    assert(
+      metadata,
+      `Missing chain metadata for Katana bridge chainId ${chainId}`,
+    );
+    const rpcUrl = metadata.rpcUrls?.[0]?.http;
+    assert(rpcUrl, `Missing RPC URL for Katana bridge chainId ${chainId}`);
     return rpcUrl;
   }
 }

--- a/typescript/rebalancer/src/bridges/katanaUtils.test.ts
+++ b/typescript/rebalancer/src/bridges/katanaUtils.test.ts
@@ -1,0 +1,126 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+
+import {
+  addressToBytes32,
+  buildKatanaEthereumToKatana,
+  buildKatanaToEthereumCompose,
+  oftInterface,
+} from './katanaUtils.js';
+
+const composerInterface = new ethers.utils.Interface([
+  'function depositAndSend(uint256 amount,(uint32 dstEid,bytes32 to,uint256 amountLD,uint256 minAmountLD,bytes extraOptions,bytes composeMsg,bytes oftCmd) sendParam,address refundAddress)',
+]);
+
+describe('katanaUtils', () => {
+  it('builds deterministic ethereum->katana composer artifacts', () => {
+    const result = buildKatanaEthereumToKatana({
+      vaultAddress: '0x1111111111111111111111111111111111111111',
+      composerAddress: '0x2222222222222222222222222222222222222222',
+      shareOftAddress: '0x3333333333333333333333333333333333333333',
+      underlyingTokenAddress: '0x4444444444444444444444444444444444444444',
+      dstEid: 30375,
+      recipient: '0x5555555555555555555555555555555555555555',
+      amountLD: 12_345_678n,
+      shareAmountLD: 12_300_000n,
+      minShareAmountLD: 12_000_000n,
+      refundAddress: '0x6666666666666666666666666666666666666666',
+      extraOptions: '0x01020304',
+      composeMsg: '0x',
+      oftCmd: '0x',
+    });
+
+    expect(result.recipientBytes32).to.equal(
+      addressToBytes32('0x5555555555555555555555555555555555555555'),
+    );
+    expect(result.previewDepositRead.args).to.deep.equal(['12345678']);
+    expect(result.assetApproveTx.args).to.deep.equal([
+      '0x2222222222222222222222222222222222222222',
+      '12345678',
+    ]);
+
+    const decodedQuote = oftInterface.decodeFunctionData(
+      'quoteSend',
+      result.quoteRead.data,
+    );
+    expect(decodedQuote.sendParam.dstEid).to.equal(30375);
+    expect(decodedQuote.sendParam.amountLD.toString()).to.equal('12300000');
+    expect(decodedQuote.sendParam.minAmountLD.toString()).to.equal('12000000');
+    expect(decodedQuote.sendParam.to).to.equal(
+      addressToBytes32('0x5555555555555555555555555555555555555555'),
+    );
+
+    const decodedDepositAndSend = composerInterface.decodeFunctionData(
+      'depositAndSend',
+      result.depositAndSendTx.data,
+    );
+    expect(decodedDepositAndSend.amount.toString()).to.equal('12345678');
+    expect(decodedDepositAndSend.sendParam.amountLD.toString()).to.equal(
+      '12300000',
+    );
+    expect(decodedDepositAndSend.refundAddress).to.equal(
+      '0x6666666666666666666666666666666666666666',
+    );
+  });
+
+  it('builds deterministic katana->ethereum compose redemption artifacts', () => {
+    const result = buildKatanaToEthereumCompose({
+      vaultAddress: '0x1111111111111111111111111111111111111111',
+      composerAddress: '0x2222222222222222222222222222222222222222',
+      shareTokenAddress: '0x3333333333333333333333333333333333333333',
+      shareOftAddress: '0x4444444444444444444444444444444444444444',
+      dstEid: 30101,
+      recipient: '0x5555555555555555555555555555555555555555',
+      shareAmountLD: 5_000_000n,
+      minShareAmountLD: 4_999_999n,
+      assetAmountLD: 4_500_000n,
+      minAssetAmountLD: 4_400_000n,
+      refundAddress: '0x6666666666666666666666666666666666666666',
+      extraOptions: '0x01020304',
+      receiveExtraOptions: '0x05060708',
+      oftCmd: '0x',
+    });
+
+    expect(result.composerBytes32).to.equal(
+      addressToBytes32('0x2222222222222222222222222222222222222222'),
+    );
+    expect(result.recipientBytes32).to.equal(
+      addressToBytes32('0x5555555555555555555555555555555555555555'),
+    );
+    expect(result.previewRedeemRead.args).to.deep.equal(['5000000']);
+
+    const decodedQuote = oftInterface.decodeFunctionData(
+      'quoteSend',
+      result.quoteRead.data,
+    );
+    expect(decodedQuote.sendParam.dstEid).to.equal(30101);
+    expect(decodedQuote.sendParam.amountLD.toString()).to.equal('5000000');
+    expect(decodedQuote.sendParam.minAmountLD.toString()).to.equal('4999999');
+    expect(decodedQuote.sendParam.to).to.equal(
+      addressToBytes32('0x2222222222222222222222222222222222222222'),
+    );
+
+    const decodedComposeMsg = ethers.utils.defaultAbiCoder.decode(
+      [
+        'tuple(uint32 dstEid,bytes32 to,uint256 amountLD,uint256 minAmountLD,bytes extraOptions,bytes composeMsg,bytes oftCmd)',
+        'uint256',
+      ],
+      decodedQuote.sendParam.composeMsg,
+    );
+    expect(decodedComposeMsg[0].to).to.equal(
+      addressToBytes32('0x5555555555555555555555555555555555555555'),
+    );
+    expect(decodedComposeMsg[0].amountLD.toString()).to.equal('4500000');
+    expect(decodedComposeMsg[0].minAmountLD.toString()).to.equal('4400000');
+    expect(decodedComposeMsg[1].toString()).to.equal('0');
+
+    const decodedSend = oftInterface.decodeFunctionData(
+      'send',
+      result.sendTx.data,
+    );
+    expect(decodedSend.refundAddress).to.equal(
+      '0x6666666666666666666666666666666666666666',
+    );
+    expect(decodedSend.fee.nativeFee.toString()).to.equal('0');
+  });
+});

--- a/typescript/rebalancer/src/bridges/katanaUtils.ts
+++ b/typescript/rebalancer/src/bridges/katanaUtils.ts
@@ -1,0 +1,448 @@
+import { ethers } from 'ethers';
+
+import {
+  assert,
+  isAddressEvm,
+  normalizeAddressEvm,
+} from '@hyperlane-xyz/utils';
+
+const ZERO_BYTES = '0x';
+
+export const KATANA_CHAIN_ID = 747474;
+export const ETHEREUM_CHAIN_ID = 1;
+
+export const KATANA_FORWARD_CONFIG = {
+  fromChainId: ETHEREUM_CHAIN_ID,
+  toChainId: KATANA_CHAIN_ID,
+  fromToken: normalizeAddressEvm('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'),
+  toToken: normalizeAddressEvm('0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36'),
+  vaultAddress: normalizeAddressEvm(
+    '0x53E82ABbb12638F09d9e624578ccB666217a765e',
+  ),
+  composerAddress: normalizeAddressEvm(
+    '0x8A35897fda9E024d2aC20a937193e099679eC477',
+  ),
+  shareOftAddress: normalizeAddressEvm(
+    '0xb5bADA33542a05395d504a25885e02503A957Bb3',
+  ),
+  destinationShareOftAddress: normalizeAddressEvm(
+    '0x807275727Dd3E640c5F2b5DE7d1eC72B4Dd293C0',
+  ),
+  dstEid: 30375,
+  extraOptions: '0x000301001101000000000000000000000000000186a0',
+  composeMsg: ZERO_BYTES,
+  oftCmd: ZERO_BYTES,
+} as const;
+
+export const KATANA_REVERSE_CONFIG = {
+  fromChainId: KATANA_CHAIN_ID,
+  toChainId: ETHEREUM_CHAIN_ID,
+  fromToken: normalizeAddressEvm('0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36'),
+  toToken: normalizeAddressEvm('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'),
+  shareTokenAddress: normalizeAddressEvm(
+    '0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36',
+  ),
+  shareOftAddress: normalizeAddressEvm(
+    '0x807275727Dd3E640c5F2b5DE7d1eC72B4Dd293C0',
+  ),
+  vaultAddress: normalizeAddressEvm(
+    '0x53E82ABbb12638F09d9e624578ccB666217a765e',
+  ),
+  composerAddress: normalizeAddressEvm(
+    '0x8A35897fda9E024d2aC20a937193e099679eC477',
+  ),
+  dstEid: 30101,
+  extraOptions: '0x0003010013030000000000000000000000000000000c3500',
+  receiveExtraOptions: '0x000301001101000000000000000000000000000186a0',
+  oftCmd: ZERO_BYTES,
+} as const;
+
+export const OFT_ABI = [
+  'event OFTSent(bytes32 indexed guid, uint32 dstEid, address indexed fromAddress, uint256 amountSentLD, uint256 amountReceivedLD)',
+  'event OFTReceived(bytes32 indexed guid, uint32 srcEid, address indexed toAddress, uint256 amountReceivedLD)',
+  'function quoteSend((uint32 dstEid,bytes32 to,uint256 amountLD,uint256 minAmountLD,bytes extraOptions,bytes composeMsg,bytes oftCmd) sendParam, bool payInLzToken) view returns ((uint256 nativeFee,uint256 lzTokenFee) msgFee)',
+  'function send((uint32 dstEid,bytes32 to,uint256 amountLD,uint256 minAmountLD,bytes extraOptions,bytes composeMsg,bytes oftCmd) sendParam, (uint256 nativeFee,uint256 lzTokenFee) fee, address refundAddress) payable returns ((bytes32 guid,uint64 nonce,(uint256 nativeFee,uint256 lzTokenFee) fee) msgReceipt,(uint256 amountSentLD,uint256 amountReceivedLD) oftReceipt)',
+  'function secondaryChainBalance() view returns (uint256)',
+];
+
+export const COMPOSER_ABI = [
+  'event Sent(bytes32 indexed guid)',
+  'event Deposited(bytes32 sender, bytes32 recipient, uint32 dstEid, uint256 assetAmt, uint256 shareAmt)',
+  'event Redeemed(bytes32 sender, bytes32 recipient, uint32 dstEid, uint256 shareAmt, uint256 assetAmt)',
+  'function depositAndSend(uint256 amount,(uint32 dstEid,bytes32 to,uint256 amountLD,uint256 minAmountLD,bytes extraOptions,bytes composeMsg,bytes oftCmd) sendParam,address refundAddress) payable',
+];
+
+export const PREVIEW_ABI = [
+  'function previewDeposit(uint256 assets) view returns (uint256 shares)',
+  'function previewRedeem(uint256 shares) view returns (uint256 assets)',
+];
+
+export const ERC20_ABI = [
+  'event Transfer(address indexed from, address indexed to, uint256 value)',
+  'function allowance(address owner, address spender) view returns (uint256)',
+  'function approve(address spender, uint256 amount) returns (bool)',
+];
+
+export const oftInterface = new ethers.utils.Interface(OFT_ABI);
+export const composerInterface = new ethers.utils.Interface(COMPOSER_ABI);
+export const previewInterface = new ethers.utils.Interface(PREVIEW_ABI);
+export const erc20Interface = new ethers.utils.Interface(ERC20_ABI);
+
+export type OftSendParam = {
+  dstEid: number;
+  to: string;
+  amountLD: bigint;
+  minAmountLD: bigint;
+  extraOptions: string;
+  composeMsg: string;
+  oftCmd: string;
+};
+
+export type BuiltRead = {
+  to: string;
+  data: string;
+};
+
+export type BuiltCallTemplateArg = string | number;
+
+export type BuiltCallTemplate = {
+  to: string;
+  function: string;
+  args: BuiltCallTemplateArg[];
+  note?: string;
+};
+
+export type BuiltTx = {
+  to: string;
+  data: string;
+  value: bigint;
+  valueSource?: string;
+};
+
+export type ApprovalTx = BuiltCallTemplate & {
+  tokenAddress: string;
+  spender: string;
+  amount: bigint;
+  data: string;
+};
+
+export type KatanaEthereumToKatanaArgs = {
+  vaultAddress: string;
+  composerAddress: string;
+  shareOftAddress: string;
+  underlyingTokenAddress: string;
+  dstEid: number;
+  recipient: string;
+  amountLD: bigint;
+  shareAmountLD?: bigint;
+  minShareAmountLD?: bigint;
+  refundAddress: string;
+  extraOptions?: string;
+  composeMsg?: string;
+  oftCmd?: string;
+};
+
+export type KatanaToEthereumArgs = {
+  vaultAddress: string;
+  composerAddress: string;
+  shareTokenAddress: string;
+  shareOftAddress: string;
+  dstEid: number;
+  recipient: string;
+  shareAmountLD: bigint;
+  minShareAmountLD?: bigint;
+  assetAmountLD?: bigint;
+  minAssetAmountLD?: bigint;
+  refundAddress: string;
+  extraOptions?: string;
+  receiveExtraOptions?: string;
+  oftCmd?: string;
+};
+
+export type BuiltKatanaEthereumToKatana = {
+  direction: 'ethereum-to-katana';
+  vaultAddress: string;
+  composerAddress: string;
+  shareOftAddress: string;
+  underlyingTokenAddress: string;
+  dstEid: number;
+  recipient: string;
+  recipientBytes32: string;
+  assetAmountLD: bigint;
+  sendParam: OftSendParam;
+  previewDepositRead: BuiltCallTemplate;
+  quoteRead: BuiltRead;
+  assetApproveTx: ApprovalTx;
+  depositAndSendTx: BuiltTx;
+};
+
+export type BuiltKatanaToEthereum = {
+  direction: 'katana-to-ethereum';
+  vaultAddress: string;
+  composerAddress: string;
+  shareTokenAddress: string;
+  shareOftAddress: string;
+  recipient: string;
+  recipientBytes32: string;
+  composerBytes32: string;
+  shareAmountLD: bigint;
+  redemptionSendParam: OftSendParam;
+  sendParam: OftSendParam;
+  previewRedeemRead: BuiltCallTemplate;
+  shareApproveTx: ApprovalTx;
+  quoteRead: BuiltRead;
+  sendTx: BuiltTx;
+};
+
+function normalizeHexBytes(value: string | undefined, label: string): string {
+  const normalized = value?.trim() || ZERO_BYTES;
+  assert(/^0x[0-9a-fA-F]*$/.test(normalized), `Invalid ${label}: ${value}`);
+  assert(normalized.length % 2 === 0, `Invalid ${label} byte length: ${value}`);
+  return normalized.toLowerCase();
+}
+
+export function normalizeAddress(value: string, label: string): string {
+  const normalized = normalizeAddressEvm(value);
+  assert(isAddressEvm(normalized), `Invalid ${label}: ${value}`);
+  return normalized;
+}
+
+export function addressToBytes32(address: string): string {
+  return `0x${normalizeAddress(address, 'address').slice(2).toLowerCase().padStart(64, '0')}`;
+}
+
+export function applySlippage(amount: bigint, slippage: number): bigint {
+  assert(slippage >= 0 && slippage < 1, `Invalid slippage: ${slippage}`);
+  const slippageBps = BigInt(Math.round(slippage * 10_000));
+  return (amount * (10_000n - slippageBps)) / 10_000n;
+}
+
+export function buildSendParam(args: {
+  dstEid: number;
+  recipient: string;
+  amountLD: bigint;
+  minAmountLD: bigint;
+  extraOptions?: string;
+  composeMsg?: string;
+  oftCmd?: string;
+}): OftSendParam {
+  return {
+    dstEid: args.dstEid,
+    to: addressToBytes32(args.recipient),
+    amountLD: args.amountLD,
+    minAmountLD: args.minAmountLD,
+    extraOptions: normalizeHexBytes(args.extraOptions, 'extraOptions'),
+    composeMsg: normalizeHexBytes(args.composeMsg, 'composeMsg'),
+    oftCmd: normalizeHexBytes(args.oftCmd, 'oftCmd'),
+  };
+}
+
+function quoteSendRead(oftAddress: string, sendParam: OftSendParam): BuiltRead {
+  return {
+    to: normalizeAddress(oftAddress, 'oftAddress'),
+    data: oftInterface.encodeFunctionData('quoteSend', [sendParam, false]),
+  };
+}
+
+function sendTxTemplate(args: {
+  oftAddress: string;
+  sendParam: OftSendParam;
+  refundAddress: string;
+}): BuiltTx {
+  return {
+    to: normalizeAddress(args.oftAddress, 'oftAddress'),
+    data: oftInterface.encodeFunctionData('send', [
+      args.sendParam,
+      { nativeFee: 0, lzTokenFee: 0 },
+      normalizeAddress(args.refundAddress, 'refundAddress'),
+    ]),
+    value: 0n,
+    valueSource:
+      'Set msg.value and fee.nativeFee from quoteSend.nativeFee; lzTokenFee stays 0',
+  };
+}
+
+function depositAndSendTxTemplate(args: {
+  composerAddress: string;
+  assetAmountLD: bigint;
+  sendParam: OftSendParam;
+  refundAddress: string;
+}): BuiltTx {
+  return {
+    to: normalizeAddress(args.composerAddress, 'composerAddress'),
+    data: composerInterface.encodeFunctionData('depositAndSend', [
+      args.assetAmountLD,
+      args.sendParam,
+      normalizeAddress(args.refundAddress, 'refundAddress'),
+    ]),
+    value: 0n,
+    valueSource:
+      'Set msg.value from quoteSend.nativeFee returned by the share OFT quote',
+  };
+}
+
+export function encodeComposerComposeMsg(
+  sendParam: OftSendParam,
+  msgValue: bigint = 0n,
+): string {
+  return ethers.utils.defaultAbiCoder.encode(
+    [
+      'tuple(uint32 dstEid,bytes32 to,uint256 amountLD,uint256 minAmountLD,bytes extraOptions,bytes composeMsg,bytes oftCmd)',
+      'uint256',
+    ],
+    [sendParam, msgValue],
+  );
+}
+
+export function buildKatanaEthereumToKatana(
+  args: KatanaEthereumToKatanaArgs,
+): BuiltKatanaEthereumToKatana {
+  const vaultAddress = normalizeAddress(args.vaultAddress, 'vaultAddress');
+  const composerAddress = normalizeAddress(
+    args.composerAddress,
+    'composerAddress',
+  );
+  const shareOftAddress = normalizeAddress(
+    args.shareOftAddress,
+    'shareOftAddress',
+  );
+  const underlyingTokenAddress = normalizeAddress(
+    args.underlyingTokenAddress,
+    'underlyingTokenAddress',
+  );
+  const recipient = normalizeAddress(args.recipient, 'recipient');
+  const assetAmountLD = args.amountLD;
+  const shareAmountLD = args.shareAmountLD ?? assetAmountLD;
+  const sendParam = buildSendParam({
+    dstEid: args.dstEid,
+    recipient,
+    amountLD: shareAmountLD,
+    minAmountLD: args.minShareAmountLD ?? shareAmountLD,
+    extraOptions: args.extraOptions,
+    composeMsg: args.composeMsg,
+    oftCmd: args.oftCmd,
+  });
+
+  const approvalData = erc20Interface.encodeFunctionData('approve', [
+    composerAddress,
+    assetAmountLD,
+  ]);
+
+  return {
+    direction: 'ethereum-to-katana',
+    vaultAddress,
+    composerAddress,
+    shareOftAddress,
+    underlyingTokenAddress,
+    dstEid: args.dstEid,
+    recipient,
+    recipientBytes32: sendParam.to,
+    assetAmountLD,
+    sendParam,
+    previewDepositRead: {
+      to: vaultAddress,
+      function: 'previewDeposit',
+      args: [assetAmountLD.toString()],
+      note: 'Refresh expected shares before quoteSend/depositAndSend',
+    },
+    quoteRead: quoteSendRead(shareOftAddress, sendParam),
+    assetApproveTx: {
+      to: underlyingTokenAddress,
+      function: 'approve',
+      args: [composerAddress, assetAmountLD.toString()],
+      tokenAddress: underlyingTokenAddress,
+      spender: composerAddress,
+      amount: assetAmountLD,
+      data: approvalData,
+      note: 'Approve the OVault composer for the exact asset amount',
+    },
+    depositAndSendTx: depositAndSendTxTemplate({
+      composerAddress,
+      assetAmountLD,
+      sendParam,
+      refundAddress: args.refundAddress,
+    }),
+  };
+}
+
+export function buildKatanaToEthereumCompose(
+  args: KatanaToEthereumArgs,
+): BuiltKatanaToEthereum {
+  const vaultAddress = normalizeAddress(args.vaultAddress, 'vaultAddress');
+  const composerAddress = normalizeAddress(
+    args.composerAddress,
+    'composerAddress',
+  );
+  const shareTokenAddress = normalizeAddress(
+    args.shareTokenAddress,
+    'shareTokenAddress',
+  );
+  const shareOftAddress = normalizeAddress(
+    args.shareOftAddress,
+    'shareOftAddress',
+  );
+  const recipient = normalizeAddress(args.recipient, 'recipient');
+  const shareAmountLD = args.shareAmountLD;
+  const assetAmountLD = args.assetAmountLD ?? shareAmountLD;
+
+  const redemptionSendParam = buildSendParam({
+    dstEid: args.dstEid,
+    recipient,
+    amountLD: assetAmountLD,
+    minAmountLD: args.minAssetAmountLD ?? assetAmountLD,
+    extraOptions: args.receiveExtraOptions,
+    composeMsg: ZERO_BYTES,
+    oftCmd: args.oftCmd,
+  });
+
+  const sendParam = buildSendParam({
+    dstEid: args.dstEid,
+    recipient: composerAddress,
+    amountLD: shareAmountLD,
+    minAmountLD: args.minShareAmountLD ?? shareAmountLD,
+    extraOptions: args.extraOptions,
+    composeMsg: encodeComposerComposeMsg(redemptionSendParam),
+    oftCmd: args.oftCmd,
+  });
+
+  const approvalData = erc20Interface.encodeFunctionData('approve', [
+    shareOftAddress,
+    shareAmountLD,
+  ]);
+
+  return {
+    direction: 'katana-to-ethereum',
+    vaultAddress,
+    composerAddress,
+    shareTokenAddress,
+    shareOftAddress,
+    recipient,
+    recipientBytes32: redemptionSendParam.to,
+    composerBytes32: sendParam.to,
+    shareAmountLD,
+    redemptionSendParam,
+    sendParam,
+    previewRedeemRead: {
+      to: vaultAddress,
+      function: 'previewRedeem',
+      args: [shareAmountLD.toString()],
+      note: 'Refresh expected assets before rebuilding the compose payload',
+    },
+    shareApproveTx: {
+      to: shareTokenAddress,
+      function: 'approve',
+      args: [shareOftAddress, shareAmountLD.toString()],
+      tokenAddress: shareTokenAddress,
+      spender: shareOftAddress,
+      amount: shareAmountLD,
+      data: approvalData,
+      note: 'Approve Katana vault shares to the share OFT before send',
+    },
+    quoteRead: quoteSendRead(shareOftAddress, sendParam),
+    sendTx: sendTxTemplate({
+      oftAddress: shareOftAddress,
+      sendParam,
+      refundAddress: args.refundAddress,
+    }),
+  };
+}

--- a/typescript/rebalancer/src/config/RebalancerConfig.test.ts
+++ b/typescript/rebalancer/src/config/RebalancerConfig.test.ts
@@ -788,7 +788,7 @@ describe('per-chain bridge configuration', () => {
     });
   });
 
-  it('should require externalBridges.lifi when executionType is inventory', () => {
+  it('should accept katana inventory config without lifi bridge config', () => {
     const data = {
       warpRouteId: 'test-route',
       strategy: [
@@ -798,6 +798,7 @@ describe('per-chain bridge configuration', () => {
             ethereum: {
               weighted: { weight: 100, tolerance: 5 },
               executionType: ExecutionType.Inventory,
+              externalBridge: ExternalBridgeType.Katana,
             },
           },
         },
@@ -805,13 +806,18 @@ describe('per-chain bridge configuration', () => {
       inventorySigners: {
         ethereum: '0x1234567890123456789012345678901234567890',
       },
+      externalBridges: {
+        katana: {
+          defaultSlippage: 0.01,
+        },
+      },
     };
 
     writeYamlOrJson(TEST_CONFIG_PATH_BRIDGE, data);
-
-    expect(() => RebalancerConfig.load(TEST_CONFIG_PATH_BRIDGE)).to.throw(
-      /externalBridges\.lifi.*required/i,
-    );
+    const config = RebalancerConfig.load(TEST_CONFIG_PATH_BRIDGE);
+    expect(config.externalBridges?.katana).to.deep.equal({
+      defaultSlippage: 0.01,
+    });
   });
 
   it('should require externalBridges.lifi when externalBridge is lifi', () => {

--- a/typescript/rebalancer/src/config/types.ts
+++ b/typescript/rebalancer/src/config/types.ts
@@ -36,6 +36,7 @@ export enum ExecutionType {
 
 export enum ExternalBridgeType {
   LiFi = 'lifi',
+  Katana = 'katana',
 }
 
 export const RebalancerMinAmountConfigSchema = z.object({
@@ -126,8 +127,13 @@ export const LiFiBridgeConfigSchema = z.object({
   defaultSlippage: z.number().optional(),
 });
 
+export const KatanaBridgeConfigSchema = z.object({
+  defaultSlippage: z.number().optional(),
+});
+
 export const ExternalBridgesConfigSchema = z.object({
   lifi: LiFiBridgeConfigSchema.optional(),
+  katana: KatanaBridgeConfigSchema.optional(),
 });
 
 export const RebalancerConfigSchema = z
@@ -372,15 +378,6 @@ export const RebalancerConfigSchema = z
           }
           // Other protocols: accept any non-empty string (future-proof)
         }
-      }
-
-      if (!config.externalBridges?.lifi?.integrator) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message:
-            'externalBridges.lifi is required when using inventory execution',
-          path: ['externalBridges', 'lifi'],
-        });
       }
     }
 

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -229,7 +229,10 @@ describe('InventoryRebalancer E2E', () => {
     inventoryRebalancer = new InventoryRebalancer(
       config,
       actionTracker as unknown as IActionTracker,
-      { lifi: bridge as unknown as IExternalBridge },
+      {
+        lifi: bridge as unknown as IExternalBridge,
+        katana: bridge as unknown as IExternalBridge,
+      },
       warpCore as unknown as WarpCore,
       multiProvider as unknown as MultiProvider,
       testLogger,
@@ -2807,6 +2810,59 @@ describe('InventoryRebalancer E2E', () => {
       expect(bridge.quote.callCount).to.equal(2);
       expect(bridge.quote.getCall(1).args[0].fromAmount).to.equal(rawBalance);
       expect(bridge.quote.getCall(1).args[0].toAmount).to.be.undefined;
+    });
+
+    it('forces forward quote mode for katana routes', async () => {
+      const amount = 1000n;
+      const rawBalance = 1100n;
+      const targetWithBuffer = 1050n;
+
+      const route = createTestRoute({
+        externalBridge: ExternalBridgeType.Katana,
+      });
+      createTestIntent({ amount });
+
+      inventoryRebalancer.setInventoryBalances({
+        [SOLANA_CHAIN]: 0n,
+        [ARBITRUM_CHAIN]: rawBalance,
+      });
+
+      bridge.quote
+        .onFirstCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: rawBalance,
+            toAmount: targetWithBuffer + 1n,
+            toAmountMin: targetWithBuffer + 1n,
+          }),
+        )
+        .onSecondCall()
+        .resolves(
+          createMockBridgeQuote({
+            fromAmount: targetWithBuffer,
+            toAmount: targetWithBuffer,
+            toAmountMin: targetWithBuffer,
+          }),
+        );
+
+      bridge.execute.resolves({
+        txHash: '0xKatanaForwardBridgeTxHash',
+        fromChain: 42161,
+        toChain: 1399811149,
+      });
+
+      const results = await inventoryRebalancer.rebalance([route]);
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.true;
+      expect(bridge.execute.calledOnce).to.be.true;
+      expect(bridge.quote.callCount).to.equal(2);
+      const katanaForwardCall = bridge.quote.getCall(1).args[0];
+      if (!katanaForwardCall?.fromAmount) {
+        throw new Error('Expected Katana forward execution quote');
+      }
+      expect(katanaForwardCall.fromAmount < rawBalance).to.be.true;
+      expect(katanaForwardCall.toAmount).to.be.undefined;
     });
 
     it('retries reverse quote as forward when exact-output exceeds source capacity', async () => {

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -854,7 +854,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         costMultiplier: MIN_VIABLE_COST_MULTIPLIER.toString(),
         intentId: intent.id,
       },
-      'Inventory below cost-based threshold on destination, triggering LiFi movement',
+      'Inventory below cost-based threshold on destination, triggering external bridge movement',
     );
 
     // Get all available source chains with raw inventory
@@ -1524,7 +1524,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         fromTokenAddress,
         toTokenAddress,
       },
-      'Resolved token addresses for LiFi bridge',
+      'Resolved token addresses for external bridge',
     );
 
     try {
@@ -1612,7 +1612,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           feeCosts: quote.feeCosts.toString(),
           intentId: intent.id,
         },
-        'Executing inventory movement via bridge quote',
+        'Executing inventory movement via external bridge quote',
       );
 
       this.logger.debug(
@@ -1626,7 +1626,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           gasCosts: quote.gasCosts.toString(),
           feeCosts: quote.feeCosts.toString(),
         },
-        'Received LiFi quote for inventory movement',
+        'Received external bridge quote for inventory movement',
       );
 
       // Build private keys map from all available inventory signers
@@ -1677,7 +1677,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           amountConsumed: inputRequired.toString(),
           totalConsumed: (currentConsumed + inputRequired).toString(),
         },
-        'Updated consumed inventory after LiFi bridge',
+        'Updated consumed inventory after external bridge',
       );
 
       return {

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -23,7 +23,7 @@ import {
   isEVMLike,
 } from '@hyperlane-xyz/utils';
 
-import type { ExternalBridgeType } from '../config/types.js';
+import { ExternalBridgeType } from '../config/types.js';
 import type {
   ExternalBridgeRegistry,
   IExternalBridge,
@@ -938,17 +938,39 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     for (const source of viableSources) {
       if (totalPlanned >= targetWithBuffer) break;
 
+      const sourceToken = this.getTokenForChain(source.chain);
+      const destinationToken = this.getTokenForChain(destination);
+      assert(sourceToken, `No token found for source chain: ${source.chain}`);
+      assert(
+        destinationToken,
+        `No token found for destination chain: ${destination}`,
+      );
+
       const remaining = targetWithBuffer - totalPlanned;
       const targetOutput =
         source.maxTargetOutput >= remaining
           ? remaining
           : source.maxTargetOutput;
+      const forwardInputCap =
+        route.externalBridge === ExternalBridgeType.Katana
+          ? denormalizeToLocal(
+              normalizeToCanonical(targetOutput, destinationToken),
+              sourceToken,
+            )
+          : source.maxSourceInput;
       const quoteMode: BridgeQuoteMode =
-        source.maxTargetOutput > remaining ? 'reverse' : 'forward';
+        route.externalBridge === ExternalBridgeType.Katana
+          ? 'forward'
+          : source.maxTargetOutput > remaining
+            ? 'reverse'
+            : 'forward';
 
       bridgePlans.push({
         chain: source.chain,
-        maxSourceInput: source.maxSourceInput,
+        maxSourceInput:
+          forwardInputCap < source.maxSourceInput
+            ? forwardInputCap
+            : source.maxSourceInput,
         targetOutput,
         quoteMode,
       });
@@ -1522,7 +1544,10 @@ export class InventoryRebalancer implements IInventoryRebalancer {
           toAddress,
         });
 
-      let quoteModeUsed = quoteMode;
+      let quoteModeUsed =
+        externalBridgeType === ExternalBridgeType.Katana
+          ? 'forward'
+          : quoteMode;
       let quote = await quoteWithMode(quoteModeUsed);
 
       if (quoteModeUsed === 'reverse' && quote.fromAmount > maxSourceInput) {

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -716,6 +716,10 @@ export class RebalancerContextFactory {
     return { rebalancers, externalBridgeRegistry, inventoryConfig };
   }
 
+  public createExternalBridgeRegistry(): Partial<ExternalBridgeRegistry> {
+    return this.buildExternalBridgeRegistry();
+  }
+
   /**
    * Creates a RebalancerOrchestrator with all required dependencies.
    */

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -20,6 +20,7 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import { LiFiBridge } from '../bridges/LiFiBridge.js';
+import { KatanaBridge } from '../bridges/KatanaBridge.js';
 import { type RebalancerConfig } from '../config/RebalancerConfig.js';
 import {
   ExecutionType,
@@ -645,6 +646,17 @@ export class RebalancerContextFactory {
               this.logger,
             );
           }
+          break;
+        }
+        case ExternalBridgeType.Katana: {
+          registry[ExternalBridgeType.Katana] = new KatanaBridge(
+            {
+              integrator: 'hyperlane',
+              defaultSlippage: externalBridges?.katana?.defaultSlippage,
+              chainMetadata: this.multiProvider.metadata,
+            },
+            this.logger,
+          );
           break;
         }
         default: {

--- a/typescript/rebalancer/src/scripts/externalBridge.ts
+++ b/typescript/rebalancer/src/scripts/externalBridge.ts
@@ -1,0 +1,366 @@
+#!/usr/bin/env node
+import { Wallet } from 'ethers';
+import { pino, type Logger } from 'pino';
+import { Keypair } from '@solana/web3.js';
+
+import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
+import { getRegistry } from '@hyperlane-xyz/registry/fs';
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+import {
+  applyRpcUrlOverridesFromEnv,
+  assert,
+  normalizeAddressEvm,
+  ProtocolType,
+  toWei,
+} from '@hyperlane-xyz/utils';
+
+import { RebalancerConfig } from '../config/RebalancerConfig.js';
+import { ExternalBridgeType } from '../config/types.js';
+import { RebalancerContextFactory } from '../factories/RebalancerContextFactory.js';
+import type { InventorySignerConfig } from '../core/InventoryRebalancer.js';
+import type {
+  BridgeTransferStatus,
+  IExternalBridge,
+} from '../interfaces/IExternalBridge.js';
+import {
+  getExternalBridgeUsage,
+  parseExternalBridgeArgs,
+  runExternalBridgeCommand,
+  type ExternalBridgeScriptOptions,
+  type ExternalBridgeScriptResult,
+  type ResolvedExternalBridgeContext,
+} from './externalBridgeRunner.js';
+import { getExternalBridgeTokenAddress } from '../utils/tokenUtils.js';
+import { parseSolanaPrivateKey } from '../utils/solanaKeyParser.js';
+
+async function main(): Promise<void> {
+  const options = parseExternalBridgeArgs(process.argv.slice(2));
+  const logger = pino({
+    level: process.env.LOG_LEVEL ?? (options.json ? 'error' : 'warn'),
+  });
+
+  try {
+    const context = await resolveExternalBridgeContext(options, logger);
+    const result = await runExternalBridgeCommand(
+      context,
+      options,
+      logger,
+      options.json ? undefined : printStatusUpdate,
+    );
+    printResult(result, options.json);
+  } catch (error) {
+    if (error instanceof Error && error.message === getExternalBridgeUsage()) {
+      process.stderr.write(`${error.message}\n`);
+      process.exit(1);
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      process.stderr.write(
+        `${JSON.stringify({ error: message }, bigintReplacer, 2)}\n`,
+      );
+    } else {
+      process.stderr.write(`External bridge script failed: ${message}\n`);
+    }
+    process.exit(1);
+  }
+}
+
+async function resolveExternalBridgeContext(
+  options: ExternalBridgeScriptOptions,
+  logger: Logger,
+): Promise<ResolvedExternalBridgeContext> {
+  const config = RebalancerConfig.load(options.configFile);
+  const inventoryPrivateKeys = loadInventoryPrivateKeysFromEnv(process.env);
+
+  const registryUri = process.env.REGISTRY_URI || DEFAULT_GITHUB_REGISTRY;
+  const registry = getRegistry({
+    registryUris: [registryUri],
+    enableProxy: true,
+    logger,
+  });
+  const chainMetadata = await registry.getMetadata();
+  applyRpcUrlOverridesFromEnv(chainMetadata);
+
+  const multiProvider = new MultiProvider(chainMetadata);
+  const contextFactory = await RebalancerContextFactory.create(
+    config,
+    multiProvider,
+    undefined,
+    registry,
+    logger,
+    inventoryPrivateKeys,
+  );
+  const bridgeRegistry = contextFactory.createExternalBridgeRegistry();
+  const bridge = bridgeRegistry[options.bridge];
+  assert(
+    bridge,
+    `Bridge ${options.bridge} is not configured for ${config.warpRouteId}`,
+  );
+
+  const originToken = contextFactory.getTokenForChain(options.origin);
+  assert(
+    originToken,
+    `Origin token not found for chain ${options.origin} in ${config.warpRouteId}`,
+  );
+  const destinationToken = contextFactory.getTokenForChain(options.destination);
+  assert(
+    destinationToken,
+    `Destination token not found for chain ${options.destination} in ${config.warpRouteId}`,
+  );
+
+  const fromChainId = Number(multiProvider.getChainId(options.origin));
+  const toChainId = Number(multiProvider.getChainId(options.destination));
+  assert(
+    Number.isFinite(fromChainId),
+    `Invalid chainId for origin ${options.origin}`,
+  );
+  assert(
+    Number.isFinite(toChainId),
+    `Invalid chainId for destination ${options.destination}`,
+  );
+
+  const fromTokenAddress = getExternalBridgeTokenAddress(
+    originToken,
+    options.bridge,
+    () => getNativeTokenAddress(bridge, options.bridge),
+  );
+  const toTokenAddress = getExternalBridgeTokenAddress(
+    destinationToken,
+    options.bridge,
+    () => getNativeTokenAddress(bridge, options.bridge),
+  );
+
+  const sourceProtocol = multiProvider.getProtocol(options.origin);
+  const destinationProtocol = multiProvider.getProtocol(options.destination);
+  const inventorySigners = config.inventorySigners;
+
+  let fromAddress: string | undefined;
+  let toAddress: string | undefined;
+  let amountLocal: bigint | undefined;
+
+  if (options.mode !== 'wait') {
+    const sourceKey = inventoryPrivateKeys[sourceProtocol];
+    assert(
+      sourceKey,
+      `Missing inventory signer key for source protocol ${sourceProtocol}. Set ${getInventoryKeyHint(
+        sourceProtocol,
+      )}.`,
+    );
+
+    fromAddress = resolveInventoryAddress(
+      sourceProtocol,
+      inventorySigners,
+      inventoryPrivateKeys,
+      true,
+    );
+    toAddress =
+      options.recipient ??
+      resolveDefaultRecipientAddress({
+        sourceProtocol,
+        destinationProtocol,
+        inventorySigners,
+        inventoryPrivateKeys,
+        sourceAddress: fromAddress,
+      });
+    assert(options.amount, '--amount is required');
+    amountLocal = BigInt(toWei(options.amount, originToken.decimals));
+  }
+
+  return {
+    bridgeType: options.bridge,
+    bridge,
+    origin: options.origin,
+    destination: options.destination,
+    fromChainId,
+    toChainId,
+    originToken,
+    destinationToken,
+    fromTokenAddress,
+    toTokenAddress,
+    fromAddress,
+    toAddress,
+    amountLocal,
+    privateKeys: inventoryPrivateKeys,
+  };
+}
+
+function loadInventoryPrivateKeysFromEnv(
+  env: NodeJS.ProcessEnv,
+): Partial<Record<ProtocolType, string>> {
+  const inventoryPrivateKeys: Partial<Record<ProtocolType, string>> = {};
+
+  for (const protocol of Object.values(ProtocolType)) {
+    const envKey = `HYP_INVENTORY_KEY_${protocol.toUpperCase()}`;
+    const value = env[envKey];
+    if (value) {
+      inventoryPrivateKeys[protocol] = value;
+    }
+  }
+
+  if (!inventoryPrivateKeys[ProtocolType.Ethereum] && env.HYP_INVENTORY_KEY) {
+    inventoryPrivateKeys[ProtocolType.Ethereum] = env.HYP_INVENTORY_KEY;
+  }
+
+  return inventoryPrivateKeys;
+}
+
+function resolveDefaultRecipientAddress(args: {
+  sourceProtocol: ProtocolType;
+  destinationProtocol: ProtocolType;
+  inventorySigners?: Partial<Record<ProtocolType, InventorySignerConfig>>;
+  inventoryPrivateKeys: Partial<Record<ProtocolType, string>>;
+  sourceAddress: string;
+}): string {
+  const destinationAddress = resolveInventoryAddress(
+    args.destinationProtocol,
+    args.inventorySigners,
+    args.inventoryPrivateKeys,
+    false,
+  );
+  if (destinationAddress) return destinationAddress;
+
+  assert(
+    args.destinationProtocol === args.sourceProtocol,
+    `Missing destination inventory signer for protocol ${args.destinationProtocol}. Set ${getInventoryKeyHint(
+      args.destinationProtocol,
+    )}, configure inventorySigners.${args.destinationProtocol}, or pass --recipient.`,
+  );
+  return args.sourceAddress;
+}
+
+function resolveInventoryAddress(
+  protocol: ProtocolType,
+  inventorySigners:
+    | Partial<Record<ProtocolType, InventorySignerConfig>>
+    | undefined,
+  inventoryPrivateKeys: Partial<Record<ProtocolType, string>>,
+  requireKey: boolean,
+): string {
+  const configuredAddress = inventorySigners?.[protocol]?.address;
+  const key = inventoryPrivateKeys[protocol];
+
+  if (!key) {
+    assert(
+      !requireKey || configuredAddress,
+      `Missing inventory signer key for protocol ${protocol}. Set ${getInventoryKeyHint(
+        protocol,
+      )}.`,
+    );
+    assert(
+      configuredAddress,
+      `Missing inventory signer address for ${protocol}`,
+    );
+    return configuredAddress;
+  }
+
+  const derivedAddress = deriveAddressForProtocol(protocol, key);
+  if (configuredAddress) {
+    const mismatch =
+      protocol === ProtocolType.Ethereum
+        ? normalizeAddressEvm(configuredAddress) !==
+          normalizeAddressEvm(derivedAddress)
+        : configuredAddress !== derivedAddress;
+    assert(
+      !mismatch,
+      `inventorySigners.${protocol} mismatch: config has ${configuredAddress} but env derives to ${derivedAddress}`,
+    );
+  }
+
+  return derivedAddress;
+}
+
+function deriveAddressForProtocol(
+  protocol: ProtocolType,
+  privateKey: string,
+): string {
+  switch (protocol) {
+    case ProtocolType.Ethereum:
+      return new Wallet(privateKey).address;
+    case ProtocolType.Sealevel: {
+      const keyBytes = parseSolanaPrivateKey(privateKey);
+      return Keypair.fromSecretKey(keyBytes).publicKey.toBase58();
+    }
+    default:
+      throw new Error(
+        `Unsupported protocol for inventory signer derivation: ${protocol}`,
+      );
+  }
+}
+
+function getNativeTokenAddress(
+  bridge: IExternalBridge,
+  bridgeType: ExternalBridgeType,
+): string {
+  assert(
+    bridge.getNativeTokenAddress,
+    `Bridge ${bridgeType} does not expose getNativeTokenAddress()`,
+  );
+  return bridge.getNativeTokenAddress();
+}
+
+function getInventoryKeyHint(protocol: ProtocolType): string {
+  return protocol === ProtocolType.Ethereum
+    ? 'HYP_INVENTORY_KEY_ETHEREUM (or fallback HYP_INVENTORY_KEY)'
+    : `HYP_INVENTORY_KEY_${protocol.toUpperCase()}`;
+}
+
+function printStatusUpdate(status: BridgeTransferStatus): void {
+  process.stdout.write(
+    `Bridge status: ${JSON.stringify(status, bigintReplacer, 2)}\n`,
+  );
+}
+
+function printResult(result: ExternalBridgeScriptResult, json: boolean): void {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result, bigintReplacer, 2)}\n`);
+    return;
+  }
+
+  switch (result.mode) {
+    case 'quote':
+      process.stdout.write(
+        [
+          `Quoted ${result.bridge} ${result.origin} -> ${result.destination}`,
+          `from=${result.quote.fromAmount} to=${result.quote.toAmount} min=${result.quote.toAmountMin}`,
+          `tool=${result.quote.tool} gas=${result.quote.gasCosts} fees=${result.quote.feeCosts}`,
+        ].join('\n') + '\n',
+      );
+      return;
+    case 'execute':
+      process.stdout.write(
+        [
+          `Executed ${result.bridge} ${result.origin} -> ${result.destination}`,
+          `txHash=${result.execution.txHash}`,
+          `from=${result.quote.fromAmount} to=${result.quote.toAmount} min=${result.quote.toAmountMin}`,
+        ].join('\n') + '\n',
+      );
+      return;
+    case 'wait':
+      process.stdout.write(
+        [
+          `Waited on ${result.bridge} ${result.origin} -> ${result.destination}`,
+          `txHash=${result.txHash}`,
+          `elapsedMs=${result.elapsedMs}`,
+          `status=${JSON.stringify(result.status, bigintReplacer)}`,
+        ].join('\n') + '\n',
+      );
+      return;
+    case 'run':
+      process.stdout.write(
+        [
+          `Completed ${result.bridge} ${result.origin} -> ${result.destination}`,
+          `txHash=${result.execution.txHash}`,
+          `elapsedMs=${result.elapsedMs}`,
+          `finalStatus=${JSON.stringify(result.finalStatus, bigintReplacer)}`,
+        ].join('\n') + '\n',
+      );
+      return;
+  }
+}
+
+function bigintReplacer(_key: string, value: unknown) {
+  return typeof value === 'bigint' ? value.toString() : value;
+}
+
+void main();

--- a/typescript/rebalancer/src/scripts/externalBridgeRunner.test.ts
+++ b/typescript/rebalancer/src/scripts/externalBridgeRunner.test.ts
@@ -1,0 +1,287 @@
+import { expect } from 'chai';
+import { pino } from 'pino';
+
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { ExternalBridgeType } from '../config/types.js';
+import type {
+  BridgeQuote,
+  BridgeTransferResult,
+  BridgeTransferStatus,
+  IExternalBridge,
+} from '../interfaces/IExternalBridge.js';
+import {
+  getExternalBridgeUsage,
+  parseExternalBridgeArgs,
+  runExternalBridgeCommand,
+  waitForBridgeCompletion,
+  type ExternalBridgeScriptOptions,
+  type ResolvedExternalBridgeContext,
+} from './externalBridgeRunner.js';
+
+const testLogger = pino({ level: 'silent' });
+
+class FakeBridge implements IExternalBridge {
+  readonly externalBridgeId = 'fake';
+  readonly logger = testLogger;
+
+  quoteResult: BridgeQuote = {
+    id: 'quote-1',
+    tool: 'fake-tool',
+    fromAmount: 5_000_000n,
+    toAmount: 4_900_000n,
+    toAmountMin: 4_800_000n,
+    executionDuration: 120,
+    gasCosts: 11n,
+    feeCosts: 22n,
+    route: { id: 'route-1' },
+    requestParams: {
+      fromChain: 1,
+      toChain: 747474,
+      fromToken: '0xfrom',
+      toToken: '0xto',
+      fromAmount: 5_000_000n,
+      fromAddress: '0xsource',
+      toAddress: '0xdest',
+    },
+  };
+
+  executeResult: BridgeTransferResult = {
+    txHash: '0xsource-tx',
+    fromChain: 1,
+    toChain: 747474,
+  };
+
+  statuses: BridgeTransferStatus[] = [{ status: 'pending', substatus: 'P1' }];
+  quoteCalls = 0;
+  executeCalls = 0;
+  getStatusCalls = 0;
+
+  async quote(): Promise<BridgeQuote> {
+    this.quoteCalls += 1;
+    return this.quoteResult;
+  }
+
+  async execute(): Promise<BridgeTransferResult> {
+    this.executeCalls += 1;
+    return this.executeResult;
+  }
+
+  async getStatus(): Promise<BridgeTransferStatus> {
+    const next = this.statuses[
+      Math.min(this.getStatusCalls, Math.max(this.statuses.length - 1, 0))
+    ] ?? { status: 'not_found' };
+    this.getStatusCalls += 1;
+    return next;
+  }
+}
+
+function createContext(bridge: IExternalBridge): ResolvedExternalBridgeContext {
+  return {
+    bridgeType: ExternalBridgeType.Katana,
+    bridge,
+    origin: 'ethereum',
+    destination: 'katana',
+    fromChainId: 1,
+    toChainId: 747474,
+    originToken: {
+      chainName: 'ethereum',
+      decimals: 6,
+    } as any,
+    destinationToken: {
+      chainName: 'katana',
+      decimals: 6,
+    } as any,
+    fromTokenAddress: '0xfrom',
+    toTokenAddress: '0xto',
+    fromAddress: '0xsource',
+    toAddress: '0xdest',
+    amountLocal: 5_000_000n,
+    privateKeys: {
+      [ProtocolType.Ethereum]: 'test-private-key',
+    },
+  };
+}
+
+function createOptions(
+  overrides?: Partial<ExternalBridgeScriptOptions>,
+): ExternalBridgeScriptOptions {
+  return {
+    configFile: '/tmp/test.yaml',
+    bridge: ExternalBridgeType.Katana,
+    origin: 'ethereum',
+    destination: 'katana',
+    amount: '5',
+    mode: 'run',
+    timeoutMs: 10_000,
+    pollIntervalMs: 1,
+    json: false,
+    ...overrides,
+  };
+}
+
+describe('externalBridgeRunner', () => {
+  it('parses quote args', () => {
+    const parsed = parseExternalBridgeArgs([
+      '--config',
+      '/tmp/cfg.yaml',
+      '--bridge',
+      'katana',
+      '--origin',
+      'ethereum',
+      '--destination',
+      'katana',
+      '--mode',
+      'quote',
+      '--amount',
+      '5',
+      '--json',
+    ]);
+
+    expect(parsed).to.deep.equal({
+      configFile: '/tmp/cfg.yaml',
+      bridge: ExternalBridgeType.Katana,
+      origin: 'ethereum',
+      destination: 'katana',
+      amount: '5',
+      recipient: undefined,
+      txHash: undefined,
+      mode: 'quote',
+      slippage: undefined,
+      timeoutMs: 900_000,
+      pollIntervalMs: 5_000,
+      json: true,
+    });
+  });
+
+  it('throws usage on help', () => {
+    expect(() => parseExternalBridgeArgs(['--help'])).to.throw(
+      getExternalBridgeUsage(),
+    );
+  });
+
+  it('waits until complete', async () => {
+    const bridge = new FakeBridge();
+    bridge.statuses = [
+      { status: 'pending', substatus: 'P1' },
+      { status: 'pending', substatus: 'P2' },
+      {
+        status: 'complete',
+        receivingTxHash: '0xdest',
+        receivedAmount: 4_800_000n,
+      },
+    ];
+    const seen: BridgeTransferStatus[] = [];
+
+    const result = await waitForBridgeCompletion({
+      bridge,
+      txHash: '0xsource-tx',
+      fromChain: 1,
+      toChain: 747474,
+      timeoutMs: 100,
+      pollIntervalMs: 1,
+      logger: testLogger,
+      sleep: async () => {},
+      onStatusChange: (status) => seen.push(status),
+    });
+
+    expect(result.status).to.deep.equal({
+      status: 'complete',
+      receivingTxHash: '0xdest',
+      receivedAmount: 4_800_000n,
+    });
+    expect(seen).to.deep.equal(bridge.statuses);
+  });
+
+  it('runs quote mode without executing', async () => {
+    const bridge = new FakeBridge();
+
+    const result = await runExternalBridgeCommand(
+      createContext(bridge),
+      createOptions({ mode: 'quote' }),
+      testLogger,
+    );
+
+    expect(result.mode).to.equal('quote');
+    expect(bridge.quoteCalls).to.equal(1);
+    expect(bridge.executeCalls).to.equal(0);
+  });
+
+  it('runs execute mode without waiting', async () => {
+    const bridge = new FakeBridge();
+
+    const result = await runExternalBridgeCommand(
+      createContext(bridge),
+      createOptions({ mode: 'execute' }),
+      testLogger,
+    );
+
+    expect(result.mode).to.equal('execute');
+    expect(bridge.quoteCalls).to.equal(1);
+    expect(bridge.executeCalls).to.equal(1);
+    expect(bridge.getStatusCalls).to.equal(0);
+  });
+
+  it('runs full quote-execute-wait flow', async () => {
+    const bridge = new FakeBridge();
+    bridge.statuses = [
+      { status: 'pending', substatus: 'INDEXING' },
+      {
+        status: 'complete',
+        receivingTxHash: '0xdest',
+        receivedAmount: 4_900_000n,
+      },
+    ];
+
+    const result = await runExternalBridgeCommand(
+      createContext(bridge),
+      createOptions({ mode: 'run', pollIntervalMs: 1 }),
+      testLogger,
+    );
+
+    expect(result.mode).to.equal('run');
+    if (result.mode !== 'run') throw new Error('Expected run result');
+    expect(result.mode).to.equal('run');
+    expect(bridge.quoteCalls).to.equal(1);
+    expect(bridge.executeCalls).to.equal(1);
+    expect(bridge.getStatusCalls).to.equal(2);
+    expect(result.finalStatus).to.deep.equal({
+      status: 'complete',
+      receivingTxHash: '0xdest',
+      receivedAmount: 4_900_000n,
+    });
+  });
+
+  it('waits on an existing tx hash without quoting', async () => {
+    const bridge = new FakeBridge();
+    bridge.statuses = [
+      {
+        status: 'complete',
+        receivingTxHash: '0xdest',
+        receivedAmount: 4_800_000n,
+      },
+    ];
+
+    const result = await runExternalBridgeCommand(
+      createContext(bridge),
+      createOptions({ mode: 'wait', txHash: '0xexisting', amount: undefined }),
+      testLogger,
+    );
+
+    expect(result.mode).to.equal('wait');
+    if (result.mode !== 'wait') throw new Error('Expected wait result');
+    expect(result.bridge).to.equal(ExternalBridgeType.Katana);
+    expect(result.origin).to.equal('ethereum');
+    expect(result.destination).to.equal('katana');
+    expect(result.txHash).to.equal('0xexisting');
+    expect(result.elapsedMs).to.be.greaterThanOrEqual(0);
+    expect(result.status).to.deep.equal({
+      status: 'complete',
+      receivingTxHash: '0xdest',
+      receivedAmount: 4_800_000n,
+    });
+    expect(bridge.quoteCalls).to.equal(0);
+    expect(bridge.executeCalls).to.equal(0);
+    expect(bridge.getStatusCalls).to.equal(1);
+  });
+});

--- a/typescript/rebalancer/src/scripts/externalBridgeRunner.ts
+++ b/typescript/rebalancer/src/scripts/externalBridgeRunner.ts
@@ -1,0 +1,438 @@
+import { assert } from '@hyperlane-xyz/utils';
+import type { Token } from '@hyperlane-xyz/sdk';
+import type { Logger } from 'pino';
+
+import { ExternalBridgeType } from '../config/types.js';
+import type {
+  BridgeQuote,
+  BridgeTransferResult,
+  BridgeTransferStatus,
+  IExternalBridge,
+} from '../interfaces/IExternalBridge.js';
+import type { ProtocolType } from '@hyperlane-xyz/utils';
+
+export type ExternalBridgeScriptMode = 'quote' | 'execute' | 'wait' | 'run';
+
+export type ExternalBridgeScriptOptions = {
+  configFile: string;
+  bridge: ExternalBridgeType;
+  origin: string;
+  destination: string;
+  amount?: string;
+  recipient?: string;
+  txHash?: string;
+  mode: ExternalBridgeScriptMode;
+  slippage?: number;
+  timeoutMs: number;
+  pollIntervalMs: number;
+  json: boolean;
+};
+
+export type ResolvedExternalBridgeContext = {
+  bridgeType: ExternalBridgeType;
+  bridge: IExternalBridge;
+  origin: string;
+  destination: string;
+  fromChainId: number;
+  toChainId: number;
+  originToken: Token;
+  destinationToken: Token;
+  fromTokenAddress: string;
+  toTokenAddress: string;
+  fromAddress?: string;
+  toAddress?: string;
+  amountLocal?: bigint;
+  privateKeys: Partial<Record<ProtocolType, string>>;
+};
+
+export type ExternalBridgeScriptResult =
+  | {
+      mode: 'quote';
+      bridge: ExternalBridgeType;
+      origin: string;
+      destination: string;
+      fromTokenAddress: string;
+      toTokenAddress: string;
+      fromAddress: string;
+      toAddress: string;
+      amountLocal: string;
+      quote: {
+        id: string;
+        tool: string;
+        fromAmount: string;
+        toAmount: string;
+        toAmountMin: string;
+        executionDuration: number;
+        gasCosts: string;
+        feeCosts: string;
+      };
+    }
+  | {
+      mode: 'execute';
+      bridge: ExternalBridgeType;
+      origin: string;
+      destination: string;
+      fromTokenAddress: string;
+      toTokenAddress: string;
+      fromAddress: string;
+      toAddress: string;
+      amountLocal: string;
+      quote: {
+        id: string;
+        tool: string;
+        fromAmount: string;
+        toAmount: string;
+        toAmountMin: string;
+        executionDuration: number;
+        gasCosts: string;
+        feeCosts: string;
+      };
+      execution: {
+        txHash: string;
+        fromChain: number;
+        toChain: number;
+        transferId?: string;
+      };
+    }
+  | {
+      mode: 'wait';
+      bridge: ExternalBridgeType;
+      origin: string;
+      destination: string;
+      txHash: string;
+      elapsedMs: number;
+      status: BridgeTransferStatus;
+    }
+  | {
+      mode: 'run';
+      bridge: ExternalBridgeType;
+      origin: string;
+      destination: string;
+      fromTokenAddress: string;
+      toTokenAddress: string;
+      fromAddress: string;
+      toAddress: string;
+      amountLocal: string;
+      quote: {
+        id: string;
+        tool: string;
+        fromAmount: string;
+        toAmount: string;
+        toAmountMin: string;
+        executionDuration: number;
+        gasCosts: string;
+        feeCosts: string;
+      };
+      execution: {
+        txHash: string;
+        fromChain: number;
+        toChain: number;
+        transferId?: string;
+      };
+      finalStatus: BridgeTransferStatus;
+      elapsedMs: number;
+    };
+
+type WaitOptions = {
+  bridge: IExternalBridge;
+  txHash: string;
+  fromChain: number;
+  toChain: number;
+  timeoutMs: number;
+  pollIntervalMs: number;
+  logger: Logger;
+  sleep?: (ms: number) => Promise<void>;
+  onStatusChange?: (status: BridgeTransferStatus) => void;
+};
+
+export function parseExternalBridgeArgs(
+  argv: string[],
+): ExternalBridgeScriptOptions {
+  const args = [...argv];
+  const getValue = (flag: string): string | undefined => {
+    const index = args.indexOf(flag);
+    if (index === -1) return undefined;
+    assert(index + 1 < args.length, `Missing value for ${flag}`);
+    return args[index + 1];
+  };
+  const hasFlag = (flag: string): boolean => args.includes(flag);
+
+  if (hasFlag('--help') || hasFlag('-h')) {
+    throw new Error(getExternalBridgeUsage());
+  }
+
+  const mode = (getValue('--mode') ?? 'run') as ExternalBridgeScriptMode;
+  assert(
+    ['quote', 'execute', 'wait', 'run'].includes(mode),
+    `Invalid --mode: ${mode}`,
+  );
+
+  const bridge = getValue('--bridge') as ExternalBridgeType | undefined;
+  assert(bridge, '--bridge is required');
+  assert(
+    Object.values(ExternalBridgeType).includes(bridge),
+    `Invalid --bridge: ${bridge}`,
+  );
+
+  const configFile = getValue('--config');
+  assert(configFile, '--config is required');
+
+  const origin = getValue('--origin');
+  assert(origin, '--origin is required');
+
+  const destination = getValue('--destination');
+  assert(destination, '--destination is required');
+
+  const amount = getValue('--amount');
+  const txHash = getValue('--tx-hash');
+
+  if (mode === 'wait') {
+    assert(txHash, '--tx-hash is required in wait mode');
+  } else {
+    assert(amount, '--amount is required unless --mode wait');
+  }
+
+  const slippageRaw = getValue('--slippage');
+  let slippage: number | undefined;
+  if (slippageRaw !== undefined) {
+    slippage = Number(slippageRaw);
+    assert(!Number.isNaN(slippage), `Invalid --slippage: ${slippageRaw}`);
+    assert(slippage >= 0, '--slippage must be non-negative');
+  }
+
+  const timeoutRaw = getValue('--timeout-ms');
+  const timeoutMs =
+    timeoutRaw === undefined ? 15 * 60_000 : Number.parseInt(timeoutRaw, 10);
+  assert(
+    Number.isFinite(timeoutMs) && timeoutMs > 0,
+    `Invalid --timeout-ms: ${timeoutRaw}`,
+  );
+
+  const pollRaw = getValue('--poll-interval-ms');
+  const pollIntervalMs =
+    pollRaw === undefined ? 5_000 : Number.parseInt(pollRaw, 10);
+  assert(
+    Number.isFinite(pollIntervalMs) && pollIntervalMs > 0,
+    `Invalid --poll-interval-ms: ${pollRaw}`,
+  );
+
+  return {
+    configFile,
+    bridge,
+    origin,
+    destination,
+    amount,
+    recipient: getValue('--recipient'),
+    txHash,
+    mode,
+    slippage,
+    timeoutMs,
+    pollIntervalMs,
+    json: hasFlag('--json'),
+  };
+}
+
+export function getExternalBridgeUsage(): string {
+  return [
+    'Usage:',
+    '  pnpm -C typescript/rebalancer bridge:dev --config <path> --bridge <katana|lifi> --origin <chain> --destination <chain> --mode <quote|execute|wait|run> [options]',
+    '',
+    'Options:',
+    '  --amount <token-units>         Required for quote/execute/run',
+    '  --tx-hash <hash>               Required for wait',
+    '  --recipient <address>          Optional destination recipient',
+    '  --slippage <decimal>           Optional slippage override (e.g. 0.005)',
+    '  --timeout-ms <ms>              Wait timeout, default 900000',
+    '  --poll-interval-ms <ms>        Wait poll interval, default 5000',
+    '  --json                         Emit machine-readable JSON',
+  ].join('\n');
+}
+
+export async function waitForBridgeCompletion({
+  bridge,
+  txHash,
+  fromChain,
+  toChain,
+  timeoutMs,
+  pollIntervalMs,
+  logger,
+  sleep = defaultSleep,
+  onStatusChange,
+}: WaitOptions): Promise<{ status: BridgeTransferStatus; elapsedMs: number }> {
+  const start = Date.now();
+  let lastSerialized: string | undefined;
+  let lastStatus: BridgeTransferStatus = { status: 'not_found' };
+
+  while (Date.now() - start < timeoutMs) {
+    lastStatus = await bridge.getStatus(txHash, fromChain, toChain);
+    const serialized = JSON.stringify(lastStatus, bigintReplacer);
+    if (serialized !== lastSerialized) {
+      lastSerialized = serialized;
+      onStatusChange?.(lastStatus);
+      logger.info(
+        {
+          txHash,
+          fromChain,
+          toChain,
+          bridge: bridge.externalBridgeId,
+          status: serialized,
+        },
+        'External bridge status changed',
+      );
+    }
+
+    if (lastStatus.status === 'complete' || lastStatus.status === 'failed') {
+      return {
+        status: lastStatus,
+        elapsedMs: Date.now() - start,
+      };
+    }
+
+    await sleep(pollIntervalMs);
+  }
+
+  throw new Error(
+    `Timed out waiting for external bridge completion for ${txHash}. Last status: ${JSON.stringify(
+      lastStatus,
+      bigintReplacer,
+    )}`,
+  );
+}
+
+export async function runExternalBridgeCommand(
+  context: ResolvedExternalBridgeContext,
+  options: ExternalBridgeScriptOptions,
+  logger: Logger,
+  onStatusChange?: (status: BridgeTransferStatus) => void,
+): Promise<ExternalBridgeScriptResult> {
+  if (options.mode === 'wait') {
+    assert(options.txHash, '--tx-hash is required in wait mode');
+    const waited = await waitForBridgeCompletion({
+      bridge: context.bridge,
+      txHash: options.txHash,
+      fromChain: context.fromChainId,
+      toChain: context.toChainId,
+      timeoutMs: options.timeoutMs,
+      pollIntervalMs: options.pollIntervalMs,
+      logger,
+      onStatusChange,
+    });
+
+    return {
+      mode: 'wait',
+      bridge: context.bridgeType,
+      origin: context.origin,
+      destination: context.destination,
+      txHash: options.txHash,
+      elapsedMs: waited.elapsedMs,
+      status: waited.status,
+    };
+  }
+
+  assert(context.fromAddress, 'Missing source inventory address');
+  assert(context.toAddress, 'Missing destination inventory address');
+  assert(context.amountLocal !== undefined, 'Missing bridge amount');
+
+  const quote = await context.bridge.quote({
+    fromChain: context.fromChainId,
+    toChain: context.toChainId,
+    fromToken: context.fromTokenAddress,
+    toToken: context.toTokenAddress,
+    fromAmount: context.amountLocal,
+    fromAddress: context.fromAddress,
+    toAddress: context.toAddress,
+    slippage: options.slippage,
+  });
+  const serializedQuote = serializeQuote(quote);
+
+  if (options.mode === 'quote') {
+    return {
+      mode: 'quote',
+      bridge: context.bridgeType,
+      origin: context.origin,
+      destination: context.destination,
+      fromTokenAddress: context.fromTokenAddress,
+      toTokenAddress: context.toTokenAddress,
+      fromAddress: context.fromAddress,
+      toAddress: context.toAddress,
+      amountLocal: context.amountLocal.toString(),
+      quote: serializedQuote,
+    };
+  }
+
+  const execution = await context.bridge.execute(quote, context.privateKeys);
+  const serializedExecution = serializeExecution(execution);
+
+  if (options.mode === 'execute') {
+    return {
+      mode: 'execute',
+      bridge: context.bridgeType,
+      origin: context.origin,
+      destination: context.destination,
+      fromTokenAddress: context.fromTokenAddress,
+      toTokenAddress: context.toTokenAddress,
+      fromAddress: context.fromAddress,
+      toAddress: context.toAddress,
+      amountLocal: context.amountLocal.toString(),
+      quote: serializedQuote,
+      execution: serializedExecution,
+    };
+  }
+
+  const waited = await waitForBridgeCompletion({
+    bridge: context.bridge,
+    txHash: execution.txHash,
+    fromChain: context.fromChainId,
+    toChain: context.toChainId,
+    timeoutMs: options.timeoutMs,
+    pollIntervalMs: options.pollIntervalMs,
+    logger,
+    onStatusChange,
+  });
+
+  return {
+    mode: 'run',
+    bridge: context.bridgeType,
+    origin: context.origin,
+    destination: context.destination,
+    fromTokenAddress: context.fromTokenAddress,
+    toTokenAddress: context.toTokenAddress,
+    fromAddress: context.fromAddress,
+    toAddress: context.toAddress,
+    amountLocal: context.amountLocal.toString(),
+    quote: serializedQuote,
+    execution: serializedExecution,
+    finalStatus: waited.status,
+    elapsedMs: waited.elapsedMs,
+  };
+}
+
+function serializeQuote(quote: BridgeQuote) {
+  return {
+    id: quote.id,
+    tool: quote.tool,
+    fromAmount: quote.fromAmount.toString(),
+    toAmount: quote.toAmount.toString(),
+    toAmountMin: quote.toAmountMin.toString(),
+    executionDuration: quote.executionDuration,
+    gasCosts: quote.gasCosts.toString(),
+    feeCosts: quote.feeCosts.toString(),
+  };
+}
+
+function serializeExecution(execution: BridgeTransferResult) {
+  return {
+    txHash: execution.txHash,
+    fromChain: execution.fromChain,
+    toChain: execution.toChain,
+    transferId: execution.transferId,
+  };
+}
+
+function bigintReplacer(_key: string, value: unknown) {
+  return typeof value === 'bigint' ? value.toString() : value;
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary
- add a Katana `IExternalBridge` for the public LayerZero composer path
- support exact-in `ethereum USDC -> katana vbUSDC` and `katana vbUSDC -> ethereum USDC`
- materialize exact calldata from live `previewDeposit` / `previewRedeem` and `quoteSend`, following the `private-agents#53` path builder pattern
- wire the new bridge into rebalancer config/factory and add focused builder/bridge/config tests

## Testing
- `pnpm -C typescript/rebalancer exec mocha --config .mocharc.json './src/bridges/katanaUtils.test.ts' './src/bridges/KatanaBridge.test.ts' './src/config/RebalancerConfig.test.ts' --exit`

## Notes
- `pnpm -C typescript/rebalancer build` is currently blocked by unrelated pre-existing type errors in `src/interfaces/IRebalancer.ts`, `src/strategy/MinAmountStrategy.ts`, `src/test/helpers.ts`, and `src/utils/balanceUtils.ts`
