### PR TITLE
fix(sdk): move block-explorer hardhat tests from Base to Ethereum mainnet

### DIFF
--- a/typescript/sdk/src/consts/testChains.ts
+++ b/typescript/sdk/src/consts/testChains.ts
@@ -1,9 +1,6 @@
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
-import {
-  ChainTechnicalStack,
-  ExplorerFamily,
-} from '../metadata/chainMetadataTypes.js';
+import { ExplorerFamily } from '../metadata/chainMetadataTypes.js';
 import type { ChainMetadata } from '../metadata/chainMetadataTypes.js';
 import type { ChainMap, ChainName } from '../types.js';
 
@@ -194,26 +191,29 @@ export const testStarknetChain: ChainMetadata = {
   ],
 };
 
-// Address of a timelock contract on base that can be used for integration tests
-export const KNOWN_BASE_TIMELOCK_CONTRACT =
-  '0x733BC1F0D76AB8f0AB7C1c8044ECc4720Cd402AD';
+// Address of the ENS DAO TimelockController contract on Ethereum mainnet,
+// used for integration tests that exercise the block explorer path.
+// Chosen because Base's Blockscout `getcontractcreation` endpoint has been
+// observed to hang in CI, while eth.blockscout.com is reliable.
+export const KNOWN_ETHEREUM_TIMELOCK_CONTRACT =
+  '0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7';
 
-// Base chain metadata for testing with block explorer
-export const baseTestChain: ChainMetadata = {
+// Ethereum mainnet metadata for testing with a live block explorer
+export const ethereumTestChain: ChainMetadata = {
   blockExplorers: [
     {
-      apiUrl: 'https://base.blockscout.com/api',
+      apiUrl: 'https://eth.blockscout.com/api',
       family: ExplorerFamily.Blockscout,
-      name: 'Base Explorer',
-      url: 'https://base.blockscout.com',
+      name: 'Ethereum Explorer',
+      url: 'https://eth.blockscout.com',
     },
   ],
-  blocks: { confirmations: 3, estimateBlockTime: 2, reorgPeriod: 10 },
-  chainId: 8453,
-  displayName: 'Base',
-  domainId: 8453,
+  blocks: { confirmations: 3, estimateBlockTime: 12, reorgPeriod: 14 },
+  chainId: 1,
+  displayName: 'Ethereum',
+  domainId: 1,
   gasCurrencyCoinGeckoId: 'ethereum',
-  name: 'base',
+  name: 'ethereum',
   nativeToken: {
     decimals: 18,
     name: 'Ether',
@@ -221,15 +221,12 @@ export const baseTestChain: ChainMetadata = {
   },
   protocol: ProtocolType.Ethereum,
   rpcUrls: [
-    { http: 'https://base.publicnode.com' },
-    { http: 'https://mainnet.base.org' },
-    { http: 'https://base.blockpi.network/v1/rpc/public' },
-    { http: 'https://base.drpc.org' },
-    { http: 'https://base.llamarpc.com' },
-    { http: 'https://1rpc.io/base' },
-    { http: 'https://base-pokt.nodies.app' },
+    { http: 'https://ethereum-rpc.publicnode.com' },
+    { http: 'https://eth.llamarpc.com' },
+    { http: 'https://1rpc.io/eth' },
+    { http: 'https://ethereum.blockpi.network/v1/rpc/public' },
+    { http: 'https://eth.drpc.org' },
   ],
-  technicalStack: ChainTechnicalStack.OpStack,
 };
 
 export const multiProtocolTestChainMetadata: ChainMap<ChainMetadata> = {

--- a/typescript/sdk/src/rpc/evm/EvmEventLogsReader.hardhat-test.ts
+++ b/typescript/sdk/src/rpc/evm/EvmEventLogsReader.hardhat-test.ts
@@ -10,9 +10,9 @@ import { ERC20Test, ERC20Test__factory } from '@hyperlane-xyz/core';
 import { assert } from '@hyperlane-xyz/utils';
 
 import {
-  KNOWN_BASE_TIMELOCK_CONTRACT,
+  KNOWN_ETHEREUM_TIMELOCK_CONTRACT,
   TestChainName,
-  baseTestChain,
+  ethereumTestChain,
 } from '../../consts/testChains.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
 import { randomAddress, randomInt } from '../../test/testUtils.js';
@@ -370,11 +370,11 @@ describe('EvmEventLogsReader', () => {
       await deployTestErc20();
 
       multiProvider = new MultiProvider({
-        base: baseTestChain,
+        ethereum: ethereumTestChain,
       });
       reader = EvmEventLogsReader.fromConfig(
         {
-          chain: baseTestChain.name,
+          chain: ethereumTestChain.name,
         },
         multiProvider,
       );
@@ -382,15 +382,15 @@ describe('EvmEventLogsReader', () => {
 
     it('should get the expected number of events when fromBlock is not provided', async () => {
       const res = await reader.getLogsByTopic({
-        contractAddress: KNOWN_BASE_TIMELOCK_CONTRACT,
+        contractAddress: KNOWN_ETHEREUM_TIMELOCK_CONTRACT,
         // CallExecuted signature
         eventTopic:
           '0xc2617efa69bab66782fa219543714338489c4e9e178271560a91b82c3f612b58',
         // Omitting from block to test getting contract deployment block from explorer
-        toBlock: 32986242,
+        toBlock: 15_000_000,
       });
 
-      expect(res.length).to.equal(5);
+      expect(res.length).to.equal(17);
     });
   });
 

--- a/typescript/sdk/src/timelock/evm/EvmTimelockReader.hardhat-test.ts
+++ b/typescript/sdk/src/timelock/evm/EvmTimelockReader.hardhat-test.ts
@@ -1023,7 +1023,11 @@ describe(EvmTimelockReader.name, () => {
     });
   });
 
-  describe(`${EvmTimelockReader.name} (Block Explorer)`, () => {
+  describe(`${EvmTimelockReader.name} (Block Explorer)`, function () {
+    // Live Blockscout API calls are slow/flaky; bump timeout and retry.
+    this.timeout(120_000);
+    this.retries(2);
+
     let reader: EvmTimelockReader;
     let multiProvider: MultiProvider;
 

--- a/typescript/sdk/src/timelock/evm/EvmTimelockReader.hardhat-test.ts
+++ b/typescript/sdk/src/timelock/evm/EvmTimelockReader.hardhat-test.ts
@@ -9,9 +9,9 @@ import { TimelockController__factory } from '@hyperlane-xyz/core';
 import { assert, deepCopy, normalizeAddressEvm } from '@hyperlane-xyz/utils';
 
 import {
-  KNOWN_BASE_TIMELOCK_CONTRACT,
+  KNOWN_ETHEREUM_TIMELOCK_CONTRACT,
   TestChainName,
-  baseTestChain,
+  ethereumTestChain,
   test1,
 } from '../../consts/testChains.js';
 import { ChainMetadata } from '../../metadata/chainMetadataTypes.js';
@@ -1023,21 +1023,17 @@ describe(EvmTimelockReader.name, () => {
     });
   });
 
-  describe(`${EvmTimelockReader.name} (Block Explorer)`, function () {
-    // Live Blockscout API calls are slow/flaky; bump timeout and retry.
-    this.timeout(120_000);
-    this.retries(2);
-
+  describe(`${EvmTimelockReader.name} (Block Explorer)`, () => {
     let reader: EvmTimelockReader;
     let multiProvider: MultiProvider;
 
     beforeEach(async () => {
       multiProvider = new MultiProvider({
-        base: baseTestChain,
+        ethereum: ethereumTestChain,
       });
       reader = EvmTimelockReader.fromConfig({
-        chain: baseTestChain.name,
-        timelockAddress: KNOWN_BASE_TIMELOCK_CONTRACT,
+        chain: ethereumTestChain.name,
+        timelockAddress: KNOWN_ETHEREUM_TIMELOCK_CONTRACT,
         multiProvider,
       });
     });


### PR DESCRIPTION
## Summary

Base's Blockscout `getcontractcreation` endpoint has been consistently hanging (no response for 30s+), making `EvmTimelockReader` and `EvmEventLogsReader` block-explorer tests time out in CI.

Switched the test fixture from Base to Ethereum mainnet (`eth.blockscout.com` is reliable), using the ENS DAO TimelockController (`0xFe89cc...4b7`) — a deployed OZ TimelockController with historical `CallScheduled`/`CallExecuted` events.

## Changes

- `baseTestChain` → `ethereumTestChain` (Ethereum mainnet + `eth.blockscout.com`)
- `KNOWN_BASE_TIMELOCK_CONTRACT` → `KNOWN_ETHEREUM_TIMELOCK_CONTRACT` (ENS DAO timelock)
- Expected `CallExecuted` count updated to 17 at `toBlock=15_000_000` (stable historical snapshot)
- Reverted the prior 120s-timeout/retries workaround — it did not help because the upstream HTTP request simply never returned.

## Validation (local)

- `pnpm -C typescript/sdk test:unit` → 521 passing
- `pnpm -C typescript/sdk test:hardhat` → 509 passing
- Block-explorer describes ran 3× back-to-back, each ~2s, deterministic.

## Context

Surfaced by https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/24678546673/job/72171024943 (PR #8637, unrelated changes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to test fixtures and live block-explorer integration tests, with no production logic changes. Residual risk is continued flakiness due to reliance on a third-party explorer API.
> 
> **Overview**
> Updates the SDK’s live *block-explorer* integration tests to use Ethereum mainnet Blockscout instead of Base to reduce CI flakiness (notably around contract-creation lookup).
> 
> Replaces the Base test chain fixture and known timelock address with `ethereumTestChain`/`KNOWN_ETHEREUM_TIMELOCK_CONTRACT`, and adjusts the affected expectations (e.g., `toBlock` and expected log count) in `EvmEventLogsReader` and `EvmTimelockReader` hardhat tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f8edcb9201a99e38929060a0ee50ec07a6a8c98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->