### PR TITLE
feat: add evm-like runtime provider builder exports

### DIFF
--- a/.changeset/ten-apes-smash.md
+++ b/.changeset/ten-apes-smash.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Added narrow runtime provider-builder exports for Tron and EVM-like consumers.

--- a/typescript/sdk/src/providers/runtime/evmLike.test.ts
+++ b/typescript/sdk/src/providers/runtime/evmLike.test.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+
+import { ProviderType } from '../ProviderType.js';
+
+import { evmLikeRuntimeProviderBuilders } from './evmLike.js';
+import { evmRuntimeProviderBuilders } from './evm.js';
+import { tronRuntimeProviderBuilders } from './tron.js';
+
+describe('runtime provider builders', () => {
+  it('exports a narrow tron runtime builder map', () => {
+    expect(tronRuntimeProviderBuilders).to.have.keys([ProviderType.Tron]);
+  });
+
+  it('exports a merged evm-like runtime builder map', () => {
+    expect(evmLikeRuntimeProviderBuilders).to.include(
+      evmRuntimeProviderBuilders,
+    );
+    expect(evmLikeRuntimeProviderBuilders).to.include(
+      tronRuntimeProviderBuilders,
+    );
+    expect(evmLikeRuntimeProviderBuilders).to.have.keys([
+      ProviderType.EthersV5,
+      ProviderType.GnosisTxBuilder,
+      ProviderType.Viem,
+      ProviderType.ZkSync,
+      ProviderType.Tron,
+    ]);
+  });
+});

--- a/typescript/sdk/src/providers/runtime/evmLike.ts
+++ b/typescript/sdk/src/providers/runtime/evmLike.ts
@@ -1,0 +1,9 @@
+import type { ProviderBuilderMap } from '../defaultProviderBuilderMaps.js';
+
+import { evmRuntimeProviderBuilders } from './evm.js';
+import { tronRuntimeProviderBuilders } from './tron.js';
+
+export const evmLikeRuntimeProviderBuilders: Partial<ProviderBuilderMap> = {
+  ...evmRuntimeProviderBuilders,
+  ...tronRuntimeProviderBuilders,
+};

--- a/typescript/sdk/src/providers/runtime/tron.ts
+++ b/typescript/sdk/src/providers/runtime/tron.ts
@@ -1,0 +1,7 @@
+import type { ProviderBuilderMap } from '../defaultProviderBuilderMaps.js';
+import { ProviderType } from '../ProviderType.js';
+import { defaultTronProviderBuilder } from '../builders/tron.js';
+
+export const tronRuntimeProviderBuilders: Partial<ProviderBuilderMap> = {
+  [ProviderType.Tron]: defaultTronProviderBuilder,
+};


### PR DESCRIPTION
## Summary

Adds narrow SDK runtime builder exports for Tron and EVM-like consumers:

- `@hyperlane-xyz/sdk/providers/runtime/tron`
- `@hyperlane-xyz/sdk/providers/runtime/evmLike`

`runtime/tron` exports only the Tron runtime builder map.
`runtime/evmLike` merges the existing EVM runtime builders with the new Tron runtime builder.

## Why this is not duplicating an existing surface

The SDK already has broad provider-builder exports:

- `@hyperlane-xyz/sdk/providers/providerBuilders`
- `@hyperlane-xyz/sdk/providers/defaultProviderBuilderMaps`
- `MultiProtocolProvider`, which internally wires `defaultProviderBuilderMap`

Those surfaces intentionally include every VM builder.
That is fine for the full SDK/provider path, but it is the wrong shape for `hyperlane-explorer#301`, whose goal is to preserve functionality while narrowing the provider/runtime graph in hot browser paths.

The existing narrow runtime surface is only:

- `@hyperlane-xyz/sdk/providers/runtime/evm`

So the actual gap was:
- we already had a narrow EVM runtime bundle
- we did not have the equivalent narrow Tron runtime bundle
- we also did not have a combined narrow `evmLike` bundle for consumers whose logic intentionally treats Ethereum + Tron together

That is what this PR adds.

## Why no `package.json` export change was needed

The SDK already exposes a wildcard runtime subpath in `typescript/sdk/package.json`:

- `"./providers/runtime/*"`

So any new file added under `typescript/sdk/src/providers/runtime/` is already publishable as a public subpath after build.

That means this PR is **not** about expanding the package export surface.
It is about changing the **module shape available behind that existing surface**.

Concretely:
- `src/providers/runtime/tron.ts` becomes `@hyperlane-xyz/sdk/providers/runtime/tron`
- `src/providers/runtime/evmLike.ts` becomes `@hyperlane-xyz/sdk/providers/runtime/evmLike`

## What the technical gain actually is

The gain is not "new exports now exist in package.json".
The gain is that consumers now have a **narrow module to import** for EVM-like runtime builders.

Before this PR, if Explorer wanted to preserve Tron support, the obvious existing options were broad ones like:

```ts
import { defaultProviderBuilderMap } from '@hyperlane-xyz/sdk/providers/defaultProviderBuilderMaps';
```

That pulls the broad builder map, which includes every VM builder.

After this PR, Explorer can instead do:

```ts
import { evmLikeRuntimeProviderBuilders } from '@hyperlane-xyz/sdk/providers/runtime/evmLike';
```

That pulls only the narrow EVM-like runtime module.

So the actual win is:
- smaller import graph
- smaller runtime/bundle drag
- preserves Tron parity for Explorer without reopening the all-VM provider-builder surface

## Why `evmLike`, not `all VMs`

Explorer `#290`'s fee parsing logic is intentionally scoped to EVM-like chains.
In practice that means:
- Ethereum
- Tron

So a narrow `evmLike` runtime surface is the smallest SDK shape that preserves parity for that Explorer path.

Exporting a single combined runtime surface for all VMs would largely collapse back into the broad builder-map problem this optimization work is trying to avoid.
That would weaken the bundle/runtime win from `hyperlane-explorer#301`.

## Long-term direction

If other consumers need the same treatment later, the scalable pattern is:

- keep per-VM narrow runtime exports such as `runtime/evm`, `runtime/tron`, and future `runtime/<vm>` surfaces
- add small combined surfaces only where a real consumer boundary exists, like `runtime/evmLike`
- avoid a catch-all `runtime/all` export, because that mostly recreates the broad builder graph

So yes, broader per-VM runtime parity may make sense over time.
But this PR keeps scope tight to the actual Explorer need instead of widening the runtime surface speculatively.

## Why

Explorer `#301` is trying to keep functional parity while narrowing provider imports.
Explorer `#290` currently wants EVM-like fee parsing support for both Ethereum and Tron.

Without a narrow Tron runtime surface, Explorer has to choose between:
- dropping Tron fee support, or
- widening back to broader SDK provider surfaces

This keeps the narrow runtime-import story intact while preserving the Tron path.

## Follow-up

This is intended to unblock:
- hyperlane-xyz/hyperlane-explorer#301
- hyperlane-xyz/hyperlane-explorer#290

Explorer can either:
- merge `evmRuntimeProviderBuilders` + `tronRuntimeProviderBuilders` itself, or
- import the combined `evmLikeRuntimeProviderBuilders` surface directly

## Test plan

- `pnpm --filter @hyperlane-xyz/sdk exec mocha --config .mocharc.json ./src/providers/runtime/evmLike.test.ts --exit`
- `pnpm --filter @hyperlane-xyz/sdk build`