### PR TITLE
feat(infra): enable USDT/oft rebalancing for Eclipse USDT warp

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.ts
@@ -161,8 +161,6 @@ export const buildEclipseUSDTWarpConfig = async (
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
   const { ownersByChain, programIds, proxyAdmins } = options;
 
-  // Rebalancing sourced from the USDT/oft + USDT/oft-legacy routes. This block
-  // was previously commented out while those routes were absent from the registry.
   const rebalancingConfigByChain = getRebalancingBridgesConfigFor(
     rebalanceableCollateralChains,
     [WarpRouteIds.USDTOft, WarpRouteIds.USDTOftLegacy],

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.ts
@@ -8,8 +8,10 @@ import { getWarpFeeOwner } from '../../governance/utils.js';
 import { chainOwners } from '../../owners.js';
 import { SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT } from '../consts.js';
 import { usdtTokenAddresses } from '../tokens.js';
+import { WarpRouteIds } from '../warpIds.js';
 import {
   getFixedRoutingFeeConfig,
+  getRebalancingBridgesConfigFor,
   getRebalancingUSDTConfigForChain,
   scaleDownConfig,
 } from './utils.js';
@@ -159,11 +161,12 @@ export const buildEclipseUSDTWarpConfig = async (
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
   const { ownersByChain, programIds, proxyAdmins } = options;
 
-  // TODO: uncomment when USDTOft warp routes are in the registry
-  // const rebalancingConfigByChain = getRebalancingBridgesConfigFor(
-  //   rebalanceableCollateralChains,
-  //   [WarpRouteIds.USDTOft, WarpRouteIds.USDTOftLegacy],
-  // );
+  // Rebalancing sourced from the USDT/oft + USDT/oft-legacy routes. This block
+  // was previously commented out while those routes were absent from the registry.
+  const rebalancingConfigByChain = getRebalancingBridgesConfigFor(
+    rebalanceableCollateralChains,
+    [WarpRouteIds.USDTOft, WarpRouteIds.USDTOftLegacy],
+  );
 
   const configs: Array<[DeploymentChain, HypTokenRouterConfig]> = [];
 
@@ -175,7 +178,7 @@ export const buildEclipseUSDTWarpConfig = async (
       chain,
       routerConfig,
       ownersByChain,
-      // rebalancingConfigByChain,
+      rebalancingConfigByChain,
     );
     configs.push([
       chain,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/utils.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/utils.ts
@@ -191,8 +191,6 @@ export const getRebalancingUSDTConfigForChain = (
   currentChain: keyof typeof usdtTokenAddresses,
   routerConfigByChain: ChainMap<RouterConfigWithoutOwner>,
   ownersByChain: ChainMap<Address>,
-  // Rebalancing wiring was previously commented out while USDT/oft and
-  // USDT/oft-legacy routes were absent from the registry.
   rebalancingConfigByChain: ChainMap<RebalancingConfig>,
 ): HypTokenRouterConfig => {
   const owner = ownersByChain[currentChain];

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/utils.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/utils.ts
@@ -191,8 +191,9 @@ export const getRebalancingUSDTConfigForChain = (
   currentChain: keyof typeof usdtTokenAddresses,
   routerConfigByChain: ChainMap<RouterConfigWithoutOwner>,
   ownersByChain: ChainMap<Address>,
-  // TODO: uncomment when USDTOft warp routes are in the registry
-  // rebalancingConfigByChain: ChainMap<RebalancingConfig>,
+  // Rebalancing wiring was previously commented out while USDT/oft and
+  // USDT/oft-legacy routes were absent from the registry.
+  rebalancingConfigByChain: ChainMap<RebalancingConfig>,
 ): HypTokenRouterConfig => {
   const owner = ownersByChain[currentChain];
   assert(owner, `Owner not found for chain ${currentChain}`);
@@ -203,22 +204,21 @@ export const getRebalancingUSDTConfigForChain = (
     `USDT token address not found for chain ${currentChain}`,
   );
 
-  // TODO: uncomment when USDTOft warp routes are in the registry
-  // const currentRebalancingConfig = rebalancingConfigByChain[currentChain];
-  // assert(
-  //   currentRebalancingConfig,
-  //   `Rebalancing config not found for chain ${currentChain}`,
-  // );
-  // const { allowedRebalancers, allowedRebalancingBridges } =
-  //   currentRebalancingConfig;
+  const currentRebalancingConfig = rebalancingConfigByChain[currentChain];
+  assert(
+    currentRebalancingConfig,
+    `Rebalancing config not found for chain ${currentChain}`,
+  );
+  const { allowedRebalancers, allowedRebalancingBridges } =
+    currentRebalancingConfig;
 
   return {
     type: TokenType.collateral,
     token: usdtTokenAddress,
     mailbox: routerConfigByChain[currentChain].mailbox,
     owner,
-    // allowedRebalancers,
-    // allowedRebalancingBridges,
+    allowedRebalancers,
+    allowedRebalancingBridges,
   };
 };
 


### PR DESCRIPTION
## Summary

- Wires `getRebalancingBridgesConfigFor` into `getEclipseUSDTWarpConfig` with `[WarpRouteIds.USDTOft, WarpRouteIds.USDTOftLegacy]` now that both routes are in the registry (PRs [#1447](https://github.com/hyperlane-xyz/hyperlane-registry/pull/1447), [#1448](https://github.com/hyperlane-xyz/hyperlane-registry/pull/1448)).
- Threads `rebalancingConfigByChain` through `getRebalancingUSDTConfigForChain` so collateral configs for ethereum / arbitrum / plasma / tron carry `allowedRebalancers` and `allowedRebalancingBridges`.
- Replaces TODO comments that gated this on registry availability with short historical notes.

### Chain coverage

Union across the two routes covers all four rebalanceable collateral chains:

| Chain    | `USDT/oft` | `USDT/oft-legacy` |
| -------- | ---------- | ----------------- |
| ethereum | ✅         | ✅                |
| arbitrum | ✅         | ✅                |
| plasma   | ✅         | ❌                |
| tron     | ❌         | ✅                |

Intersection-per-pair: every pair is bridged except plasma↔tron (no single route spans both). ethereum↔arbitrum gets two bridges (one per route).

## Test plan

- [x] `pnpm -C typescript/infra build` — passes.
- [x] `pnpm oxlint` on changed files — clean.
- [x] `pnpm format` — no diff.
- [ ] Run `/warp-route-check` against the Eclipse USDT deployment to confirm no unintended drift vs. on-chain state.
- [ ] Spot-check output of `getEclipseUSDTWarpConfig` locally: verify `allowedRebalancers = [REBALANCER]` and `allowedRebalancingBridges` entries match the coverage table above for each of the four chains.