### PR TITLE
feat: cctp hook type

### DIFF
--- a/.changeset/mean-papayas-dance.md
+++ b/.changeset/mean-papayas-dance.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": minor
+---
+
+Added cctp hook type

--- a/.changeset/mean-papayas-dance.md
+++ b/.changeset/mean-papayas-dance.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/sdk": minor
 ---
 
-Added cctp hook type
+Added CCTP hook type

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -810,6 +810,12 @@ export class EvmHookModule extends HyperlaneModule<
         return this.deployAmountRoutingHook({ config });
       case HookType.CCIP:
         return this.deployCCIPHook({ config });
+      case HookType.CCTP:
+        // @ts-ignore
+        return IPostDispatchHook__factory.connect(
+          config.address,
+          this.multiProvider.getSignerOrProvider(this.args.chain),
+        );
       default:
         throw new Error(`Unsupported hook config: ${config}`);
     }

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -811,14 +811,9 @@ export class EvmHookModule extends HyperlaneModule<
       case HookType.CCIP:
         return this.deployCCIPHook({ config });
       case HookType.CCTP:
-      case HookType.CCTP:
         // TODO: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3773
         // we can remove the ts-ignore once we have a proper type for address Hooks
         // @ts-ignore
-        return IPostDispatchHook__factory.connect(
-          config.address,
-          this.multiProvider.getSignerOrProvider(this.args.chain),
-        );
         return IPostDispatchHook__factory.connect(
           config.address,
           this.multiProvider.getSignerOrProvider(this.args.chain),

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -811,7 +811,14 @@ export class EvmHookModule extends HyperlaneModule<
       case HookType.CCIP:
         return this.deployCCIPHook({ config });
       case HookType.CCTP:
+      case HookType.CCTP:
+        // TODO: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/3773
+        // we can remove the ts-ignore once we have a proper type for address Hooks
         // @ts-ignore
+        return IPostDispatchHook__factory.connect(
+          config.address,
+          this.multiProvider.getSignerOrProvider(this.args.chain),
+        );
         return IPostDispatchHook__factory.connect(
           config.address,
           this.multiProvider.getSignerOrProvider(this.args.chain),

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -179,6 +179,10 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
           derivedHookConfig = { type: HookType.PREDICATE, address };
           this._cache.set(address, derivedHookConfig);
           break;
+        case OnchainHookType.CCTP:
+          derivedHookConfig = { type: HookType.CCTP, address };
+          this._cache.set(address, derivedHookConfig);
+          break;
         default:
           throw new Error(
             `Unsupported HookType: ${OnchainHookType[onchainHookType]}`,

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -52,6 +52,11 @@ export const HookType = {
   ARB_L2_TO_L1: 'arbL2ToL1Hook',
   MAILBOX_DEFAULT: 'defaultHook',
   CCIP: 'ccipHook',
+  /**
+   * References a pre-deployed CCTP hook by address. Excluded from
+   * `DeployableHookType` — not deployed via `HyperlaneHookDeployer`; the
+   * `EvmHookModule.deploy` path just connects to `config.address`.
+   */
   CCTP: 'cctpHook',
   UNKNOWN: 'unknownHook',
   PREDICATE: 'predicateHook',

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -52,6 +52,7 @@ export const HookType = {
   ARB_L2_TO_L1: 'arbL2ToL1Hook',
   MAILBOX_DEFAULT: 'defaultHook',
   CCIP: 'ccipHook',
+  CCTP: 'cctpHook',
   UNKNOWN: 'unknownHook',
   PREDICATE: 'predicateHook',
 } as const;
@@ -60,7 +61,10 @@ export type HookType = (typeof HookType)[keyof typeof HookType];
 
 export type DeployableHookType = Exclude<
   HookType,
-  typeof HookType.CUSTOM | typeof HookType.PREDICATE | typeof HookType.UNKNOWN
+  | typeof HookType.CUSTOM
+  | typeof HookType.PREDICATE
+  | typeof HookType.UNKNOWN
+  | typeof HookType.CCTP
 >;
 
 export const HookTypeToContractNameMap: Record<DeployableHookType, string> = {
@@ -220,6 +224,12 @@ export const CCIPHookSchema = z.object({
   destinationChain: z.string(),
 });
 
+export const CctpHookSchema = z.object({
+  type: z.literal(HookType.CCTP),
+  address: ZHash,
+});
+export type CctpHookConfig = z.infer<typeof CctpHookSchema>;
+
 export const UnknownHookSchema = z
   .object({
     type: z.literal(HookType.UNKNOWN),
@@ -282,6 +292,7 @@ export const HookConfigSchema = z.union([
   ArbL2ToL1HookSchema,
   MailboxDefaultHookSchema,
   CCIPHookSchema,
+  CctpHookSchema,
   UnknownHookSchema,
   PredicateHookSchema,
 ]);

--- a/typescript/sdk/src/test/testUtils.ts
+++ b/typescript/sdk/src/test/testUtils.ts
@@ -135,6 +135,7 @@ export const hookTypesToFilter: HookType[] = [
   HookType.CUSTOM,
   HookType.PREDICATE,
   HookType.CCIP,
+  HookType.CCTP,
   HookType.UNKNOWN,
 ];
 export const DEFAULT_TOKEN_DECIMALS = 18;


### PR DESCRIPTION
### Description

Add cctp hook type to deploy and read configs like these:

```
arbitrumsepolia:
  hook:
    type: aggregationHook
    hooks:
      - type: cctpHook
        address: "0xbfcE950a54a2052aec323c8884F034373Ca9CAbD"
      - type: defaultHook
  interchainSecurityModule: "0xbfcE950a54a2052aec323c8884F034373Ca9CAbD"
  mailbox: "0x598facE78a4302f11E3de0bee1894Da0b2Cb71F8"
  owner: "0xe699ceCa237DD38e8f2Fa308D7d1a2BeCFC5493E"
  type: synthetic
basesepolia:
  hook:
    type: aggregationHook
    hooks:
      - type: cctpHook
        address: "0x6AD4F1CCBB4e897eFbBb2A62c7ccbBd7fe941848"
      - type: defaultHook
  interchainSecurityModule: "0x6AD4F1CCBB4e897eFbBb2A62c7ccbBd7fe941848"
  mailbox: "0x6966b0E55883d49BFB24539356a2f8A673E02039"
  owner: "0xe699ceCa237DD38e8f2Fa308D7d1a2BeCFC5493E"
  type: native
```


### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
