### PR TITLE
feat(infra): rotate tollkeeper on RPC rotation

### DIFF
--- a/typescript/infra/src/tollkeeper/helm.ts
+++ b/typescript/infra/src/tollkeeper/helm.ts
@@ -1,0 +1,79 @@
+import { DeployEnvironment } from '../config/environment.js';
+import { HelmManager, HelmValues } from '../utils/helm.js';
+import { execCmd } from '../utils/utils.js';
+
+// Tollkeeper (https://github.com/hyperlane-xyz/tollkeeper) is deployed from a
+// separate repo. This manager only exists so that the set-rpc-urls script can
+// refresh tollkeeper's k8s secret and restart its pods after rotating shared
+// `{env}-rpc-endpoints-{chain}` GCP secrets. It does not deploy the chart.
+const RELEASE_NAMES: Partial<Record<DeployEnvironment, string>> = {
+  mainnet3: 'tollkeeper-staging',
+};
+
+const RPC_ENV_PREFIX = 'RPC_URL_';
+
+export class TollkeeperHelmManager extends HelmManager {
+  readonly helmReleaseName: string;
+  readonly namespace: string;
+  readonly helmChartPath: string = '';
+
+  private constructor(environment: DeployEnvironment, releaseName: string) {
+    super();
+    this.helmReleaseName = releaseName;
+    this.namespace = environment;
+  }
+
+  async helmValues(): Promise<HelmValues> {
+    throw new Error(
+      'TollkeeperHelmManager does not deploy; chart lives in hyperlane-xyz/tollkeeper',
+    );
+  }
+
+  // Tollkeeper is a Deployment (chart labels pods with `app=<release>`), so the
+  // base StatefulSet-only pod discovery returns nothing. Filter on ReplicaSet
+  // ownership to get Deployment-managed pods.
+  async getManagedK8sPods(): Promise<string[]> {
+    const [output] = await execCmd(
+      `kubectl get pods --selector=app=${this.helmReleaseName} -o jsonpath='{range .items[?(@.metadata.ownerReferences[0].kind=="ReplicaSet")]}{.metadata.name}{"\\n"}{end}' -n ${this.namespace}`,
+    );
+    return output.split('\n').filter(Boolean);
+  }
+
+  // The tollkeeper chart doesn't use the standard `app.kubernetes.io/instance`
+  // label, so read the secret name directly off the Deployment's envFrom.
+  async getExistingK8sSecrets(): Promise<string[]> {
+    const [output] = await execCmd(
+      `kubectl get deployment ${this.helmReleaseName} -n ${this.namespace} --ignore-not-found -o jsonpath='{.spec.template.spec.containers[*].envFrom[*].secretRef.name}'`,
+    );
+    return output.split(/\s+/).filter(Boolean);
+  }
+
+  async includesChain(chain: string): Promise<boolean> {
+    const secrets = await this.getExistingK8sSecrets();
+    if (secrets.length === 0) return false;
+
+    const [output] = await execCmd(
+      `kubectl get secret ${secrets[0]} -n ${this.namespace} --ignore-not-found -o jsonpath='{.data}'`,
+    );
+
+    const needle = `${RPC_ENV_PREFIX}${chain.toUpperCase().replaceAll('-', '_')}`;
+    const keys = Object.keys(JSON.parse(output || '{}'));
+    return keys.includes(needle);
+  }
+
+  static async getManagerForChain(
+    environment: DeployEnvironment,
+    chain: string,
+  ): Promise<TollkeeperHelmManager | null> {
+    const releaseName = RELEASE_NAMES[environment];
+    if (!releaseName) return null;
+
+    const manager = new TollkeeperHelmManager(environment, releaseName);
+    const [existsOutput] = await execCmd(
+      `kubectl get deployment ${releaseName} -n ${environment} --ignore-not-found -o name`,
+    );
+    if (!existsOutput.trim()) return null;
+
+    return (await manager.includesChain(chain)) ? manager : null;
+  }
+}

--- a/typescript/infra/src/tollkeeper/helm.ts
+++ b/typescript/infra/src/tollkeeper/helm.ts
@@ -6,8 +6,8 @@ import { execCmd } from '../utils/utils.js';
 // separate repo. This manager only exists so that the set-rpc-urls script can
 // refresh tollkeeper's k8s secret and restart its pods after rotating shared
 // `{env}-rpc-endpoints-{chain}` GCP secrets. It does not deploy the chart.
-const RELEASE_NAMES: Partial<Record<DeployEnvironment, string>> = {
-  mainnet3: 'tollkeeper-staging',
+const RELEASE_NAMES: Partial<Record<DeployEnvironment, string[]>> = {
+  mainnet3: ['tollkeeper-prod', 'tollkeeper-staging'],
 };
 
 const RPC_ENV_PREFIX = 'RPC_URL_';
@@ -61,19 +61,21 @@ export class TollkeeperHelmManager extends HelmManager {
     return keys.includes(needle);
   }
 
-  static async getManagerForChain(
+  static async getManagersForChain(
     environment: DeployEnvironment,
     chain: string,
-  ): Promise<TollkeeperHelmManager | null> {
-    const releaseName = RELEASE_NAMES[environment];
-    if (!releaseName) return null;
-
-    const manager = new TollkeeperHelmManager(environment, releaseName);
-    const [existsOutput] = await execCmd(
-      `kubectl get deployment ${releaseName} -n ${environment} --ignore-not-found -o name`,
+  ): Promise<TollkeeperHelmManager[]> {
+    const releaseNames = RELEASE_NAMES[environment] ?? [];
+    const managers = await Promise.all(
+      releaseNames.map(async (releaseName) => {
+        const manager = new TollkeeperHelmManager(environment, releaseName);
+        const [existsOutput] = await execCmd(
+          `kubectl get deployment ${releaseName} -n ${environment} --ignore-not-found -o name`,
+        );
+        if (!existsOutput.trim()) return null;
+        return (await manager.includesChain(chain)) ? manager : null;
+      }),
     );
-    if (!existsOutput.trim()) return null;
-
-    return (await manager.includesChain(chain)) ? manager : null;
+    return managers.filter((m): m is TollkeeperHelmManager => m !== null);
   }
 }

--- a/typescript/infra/src/tollkeeper/helm.ts
+++ b/typescript/infra/src/tollkeeper/helm.ts
@@ -29,14 +29,11 @@ export class TollkeeperHelmManager extends HelmManager {
     );
   }
 
-  // Tollkeeper is a Deployment (chart labels pods with `app=<release>`), so the
-  // base StatefulSet-only pod discovery returns nothing. Filter on ReplicaSet
-  // ownership to get Deployment-managed pods.
+  // Pod restarts go through `kubectl rollout restart` (see restartDeployment)
+  // rather than the shared pod-delete flow: Deployment pods get new names on
+  // delete, which breaks the name-based wait in refreshK8sResources.
   async getManagedK8sPods(): Promise<string[]> {
-    const [output] = await execCmd(
-      `kubectl get pods --selector=app=${this.helmReleaseName} -o jsonpath='{range .items[?(@.metadata.ownerReferences[0].kind=="ReplicaSet")]}{.metadata.name}{"\\n"}{end}' -n ${this.namespace}`,
-    );
-    return output.split('\n').filter(Boolean);
+    return [];
   }
 
   // The tollkeeper chart doesn't use the standard `app.kubernetes.io/instance`
@@ -52,13 +49,29 @@ export class TollkeeperHelmManager extends HelmManager {
     const secrets = await this.getExistingK8sSecrets();
     if (secrets.length === 0) return false;
 
-    const [output] = await execCmd(
-      `kubectl get secret ${secrets[0]} -n ${this.namespace} --ignore-not-found -o jsonpath='{.data}'`,
-    );
-
+    // Query the specific RPC_URL_<CHAIN> key. `-o jsonpath='{.data}'` would
+    // render the map in Go format (`map[K:V ...]`), not JSON — parsing fails.
+    // Targeting the key directly returns its base64 value if present, else
+    // empty string.
     const needle = `${RPC_ENV_PREFIX}${chain.toUpperCase().replaceAll('-', '_')}`;
-    const keys = Object.keys(JSON.parse(output || '{}'));
-    return keys.includes(needle);
+    const [output] = await execCmd(
+      `kubectl get secret ${secrets[0]} -n ${this.namespace} --ignore-not-found -o jsonpath='{.data.${needle}}'`,
+    );
+    return output.trim().length > 0;
+  }
+
+  // Deployment-aware restart: rolls pods without name-based polling.
+  async restartDeployment(): Promise<void> {
+    console.log(
+      `🔄 Restarting deployment ${this.helmReleaseName} in ${this.namespace}...`,
+    );
+    await execCmd(
+      `kubectl rollout restart deployment/${this.helmReleaseName} -n ${this.namespace}`,
+    );
+    await execCmd(
+      `kubectl rollout status deployment/${this.helmReleaseName} -n ${this.namespace} --timeout=180s`,
+    );
+    console.log(`✅  ${this.helmReleaseName} rollout complete`);
   }
 
   static async getManagersForChain(

--- a/typescript/infra/src/utils/k8s.ts
+++ b/typescript/infra/src/utils/k8s.ts
@@ -94,12 +94,19 @@ async function getExistingK8sSecrets(
   existing: string[];
   missing: string[];
 }> {
+  // `-o name` outputs `secret/NAME` per line and works for both single-named
+  // and multi-named queries. The `.items[*]` jsonpath used previously silently
+  // returned empty for single-name queries (kubectl only wraps multi-named
+  // resources in a List) — causing the wait poll to time out.
   const [output] = await execCmd(
     `kubectl get secret ${resourceNames.join(
       ' ',
-    )} -n ${namespace} --ignore-not-found -o jsonpath='{.items[*].metadata.name}'`,
+    )} -n ${namespace} --ignore-not-found -o name`,
   );
-  const existing = output.split(' ').filter(Boolean);
+  const existing = output
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => line.replace(/^secret\//, ''));
   const missing = resourceNames.filter(
     (resource) => !existing.includes(resource),
   );

--- a/typescript/infra/src/utils/rpcUrls.ts
+++ b/typescript/infra/src/utils/rpcUrls.ts
@@ -498,18 +498,24 @@ async function selectTollkeeper(
   environment: DeployEnvironment,
   chain: string,
 ): Promise<TollkeeperHelmManager[]> {
-  const manager = await TollkeeperHelmManager.getManagerForChain(
+  const managers = await TollkeeperHelmManager.getManagersForChain(
     environment,
     chain,
   );
-  if (!manager) {
+  if (managers.length === 0) {
     return [];
   }
 
-  const cont = await confirm({
-    message: `Refresh tollkeeper (${manager.helmReleaseName}) — it reads RPC_URL_${chain.toUpperCase().replaceAll('-', '_')} from the shared secret?`,
+  const selection = await checkbox({
+    message: `Select tollkeeper instances to refresh (serve RPC_URL_${chain.toUpperCase().replaceAll('-', '_')})`,
+    choices: managers.map((manager, i) => ({
+      name: manager.helmReleaseName,
+      value: i,
+      checked: true,
+    })),
   });
-  return cont ? [manager] : [];
+
+  return managers.filter((_, i) => selection.includes(i));
 }
 
 async function selectCronJobs(

--- a/typescript/infra/src/utils/rpcUrls.ts
+++ b/typescript/infra/src/utils/rpcUrls.ts
@@ -20,6 +20,7 @@ import {
 import { DeployEnvironment } from '../config/environment.js';
 import { KeyFunderHelmManager } from '../funding/key-funder.js';
 import { RebalancerHelmManager } from '../rebalancer/helm.js';
+import { TollkeeperHelmManager } from '../tollkeeper/helm.js';
 import { WarpRouteMonitorHelmManager } from '../warp-monitor/helm.js';
 
 import { disableGCPSecretVersion } from './gcloud.js';
@@ -293,6 +294,7 @@ async function refreshDependentK8sResourcesInteractive(
   const coreManagers = await selectCoreInfrastructure(environment, chain);
   const warpManagers = await selectWarpMonitors(environment, chain);
   const rebalancerManagers = await selectRebalancers(environment, chain);
+  const tollkeeperManagers = await selectTollkeeper(environment, chain);
   const cronjobManagers = await selectCronJobs(environment);
 
   // Services get both secret and pod refresh
@@ -300,6 +302,7 @@ async function refreshDependentK8sResourcesInteractive(
     ...coreManagers,
     ...warpManagers,
     ...rebalancerManagers,
+    ...tollkeeperManagers,
   ];
   // CronJobs only get secret refresh (they pick up new secrets on next scheduled run)
   const allManagersForSecrets = [...serviceManagers, ...cronjobManagers];
@@ -489,6 +492,24 @@ async function selectRebalancers(
   });
 
   return rebalancerManagers.filter((_, i) => selection.includes(i));
+}
+
+async function selectTollkeeper(
+  environment: DeployEnvironment,
+  chain: string,
+): Promise<TollkeeperHelmManager[]> {
+  const manager = await TollkeeperHelmManager.getManagerForChain(
+    environment,
+    chain,
+  );
+  if (!manager) {
+    return [];
+  }
+
+  const cont = await confirm({
+    message: `Refresh tollkeeper (${manager.helmReleaseName}) — it reads RPC_URL_${chain.toUpperCase().replaceAll('-', '_')} from the shared secret?`,
+  });
+  return cont ? [manager] : [];
 }
 
 async function selectCronJobs(

--- a/typescript/infra/src/utils/rpcUrls.ts
+++ b/typescript/infra/src/utils/rpcUrls.ts
@@ -297,15 +297,22 @@ async function refreshDependentK8sResourcesInteractive(
   const tollkeeperManagers = await selectTollkeeper(environment, chain);
   const cronjobManagers = await selectCronJobs(environment);
 
-  // Services get both secret and pod refresh
+  // StatefulSet-backed services: both secret and pod refresh through the
+  // shared (name-based) flow.
   const serviceManagers = [
     ...coreManagers,
     ...warpManagers,
     ...rebalancerManagers,
-    ...tollkeeperManagers,
   ];
-  // CronJobs only get secret refresh (they pick up new secrets on next scheduled run)
-  const allManagersForSecrets = [...serviceManagers, ...cronjobManagers];
+  // Tollkeeper gets secret refresh through the shared flow, but pod refresh
+  // via `kubectl rollout restart` — its Deployment pods get new names on
+  // delete, which would break name-based polling in refreshK8sResources.
+  // CronJobs only get secret refresh (pods pick up new secrets on next run).
+  const allManagersForSecrets = [
+    ...serviceManagers,
+    ...tollkeeperManagers,
+    ...cronjobManagers,
+  ];
 
   if (allManagersForSecrets.length > 0) {
     await refreshK8sResources(
@@ -320,6 +327,9 @@ async function refreshDependentK8sResourcesInteractive(
       K8sResourceType.POD,
       environment,
     );
+  }
+  for (const manager of tollkeeperManagers) {
+    await manager.restartDeployment();
   }
 }
 


### PR DESCRIPTION
## Summary

Tollkeeper's helm chart lives in [hyperlane-xyz/tollkeeper](https://github.com/hyperlane-xyz/tollkeeper) but its `ExternalSecret` reads the same `{env}-rpc-endpoints-{chain}` GCP secrets that `set-rpc-urls` rotates. Today, tollkeeper pods keep serving stale RPC URLs after a rotation until the 1h ExternalSecret refresh plus a manual restart.

Adds a minimal `TollkeeperHelmManager` so the rotation script restarts tollkeeper pods automatically when the rotated chain is one it serves.

### Design notes

- Does not deploy — `helmValues()` throws. Only implements the k8s refresh surface (`getManagedK8sPods`, `getExistingK8sSecrets`).
- Pod discovery uses `app=<release>` + ReplicaSet owner filter, since tollkeeper is a `Deployment` (base `HelmManager.getManagedK8sPods` is StatefulSet-only) and the chart doesn't set `app.kubernetes.io/instance`.
- Secret name read directly off the Deployment's `envFrom.secretRef.name` — no helm values dependency.
- Chain detection via live secret's `RPC_URL_*` keys — no hardcoded chain list, stays in sync with tollkeeper's own config.
- `RELEASE_NAMES` maps env → release (`mainnet3: tollkeeper-staging` only for now; add testnet4 when it's deployed).
- Checked fee-quoting and offchain-lookup-server — neither uses private RPC secrets, so no manager needed for them.

## Test plan

- [ ] Dry-run `set-rpc-urls` against a mainnet3 chain that tollkeeper serves (e.g. `ethereum`) — verify it prompts to refresh tollkeeper and lists the correct secret + pod
- [ ] Dry-run against a chain tollkeeper does NOT serve — verify no tollkeeper prompt
- [ ] Full rotation on a low-traffic chain — verify pod comes back healthy with new RPC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production infra automation by adding kubectl-driven secret discovery and Deployment rollouts; mis-detection or rollout failures could delay or interrupt tollkeeper instances during rotations.
> 
> **Overview**
> Adds a non-deploying `TollkeeperHelmManager` so `set-rpc-urls` can detect tollkeeper instances that consume a rotated chain’s `RPC_URL_*` secret and include their secrets in the refresh flow.
> 
> Updates the rotation workflow to optionally restart selected tollkeeper Deployments via `kubectl rollout restart/status` (instead of pod deletion) so pods pick up updated RPC URLs immediately.
> 
> Fixes `refreshK8sResources` secret polling by switching kubectl secret discovery to `-o name`, which correctly handles single-secret queries and avoids wait timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 438d54a786831921bd9e517fe6b596cdc1aa27c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->