### PR TITLE
chore: TypeScript 7 beta build:ts7 harness (benchmarking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "agent-configs": "pnpm -C typescript/infra update-agent-config:mainnet3 && pnpm -C typescript/infra update-agent-config:testnet4",
     "build": "turbo run build",
+    "build:ts7": "turbo run build:ts7",
     "build:zk": "turbo run build:zk",
     "clean": "turbo run clean",
     "format": "turbo run format && pnpm exec tsx ./scripts/sort-yaml.ts",
@@ -26,6 +27,7 @@
     "@changesets/cli": "^2.26.2"
   },
   "devDependencies": {
+    "@typescript/native-preview": "catalog:",
     "husky": "^8.0.0",
     "lint-staged": "^15.5.2",
     "oxfmt": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ catalogs:
     '@types/yargs':
       specifier: ^17.0.24
       version: 17.0.35
+    '@typescript/native-preview':
+      specifier: 7.0.0-dev.20260421.2
+      version: 7.0.0-dev.20260421.2
     '@vercel/ncc':
       specifier: ^0.38.3
       version: 0.38.4
@@ -327,6 +330,9 @@ importers:
         specifier: ^2.26.2
         version: 2.27.12
     devDependencies:
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260421.2
       husky:
         specifier: ^8.0.0
         version: 8.0.1
@@ -9486,6 +9492,45 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==}
+    hasBin: true
 
   '@vanilla-extract/css-utils@0.1.6':
     resolution: {integrity: sha512-iICpaHma0s2EEnQDw/JRqudQJwYw1JERyWfIllNQplps226KVphjGb3jyGMiBK5Waw69RD3q4gulgRVQAQmKmA==}
@@ -27295,6 +27340,37 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260421.2':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260421.2
 
   '@vanilla-extract/css-utils@0.1.6': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,10 @@
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - '@hyperlane-xyz/*'
+  # TS7 beta dev releases ship frequently; exclude from 7-day quarantine for build benchmarks.
+  # Includes platform-specific binary subpackages.
+  - '@typescript/native-preview'
+  - '@typescript/native-preview-*'
 
 packages:
   - 'solhint-plugin'
@@ -113,6 +117,9 @@ catalog:
 
   # Build tools
   typescript: 6.0.2
+  # TypeScript 7 beta (native Go port — ships `tsgo`). Used for build benchmarks
+  # against the 6.x tsc compiler. Not a drop-in replacement for `typescript`.
+  '@typescript/native-preview': 7.0.0-dev.20260421.2
   tsx: ^4.19.1
   ts-node: ^10.9.2
   '@vercel/ncc': ^0.38.3

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -71,6 +71,7 @@
   "scripts": {
     "deps:soldeer": "forge soldeer install --quiet || echo 'Warning: soldeer install failed, assuming dependencies are already present'",
     "build": "pnpm version:update && pnpm hardhat-esm compile && tsc && node fix-typechain-ethers.mjs ./dist/typechain/factories && ./exportBuildArtifact.sh",
+    "build:ts7": "pnpm version:update && pnpm hardhat-esm compile && tsgo && node fix-typechain-ethers.mjs ./dist/typechain/factories && ./exportBuildArtifact.sh",
     "build:zk": "pnpm hardhat-zk compile && tsc && node fix-typechain-ethers.mjs ./dist/typechain/factories && node generate-artifact-exports.mjs && ZKSYNC=true ./exportBuildArtifact.sh",
     "build:tron": "./build-tron.sh",
     "test:tron": "FOUNDRY_PROFILE=tron forge test --match-contract 'Tron(Create2|SafeERC20)Test' -vvv && bash test/tron/check-SafeERC20-diff.sh",

--- a/solidity/turbo.json
+++ b/solidity/turbo.json
@@ -14,6 +14,24 @@
         "dist/**",
         "types/**"
       ]
+    },
+    "build:ts7": {
+      "dependsOn": ["deps:soldeer"],
+      "outputs": [
+        "artifacts/**",
+        "cache/**",
+        "core-utils/**",
+        "dist/**",
+        "types/**"
+      ]
+    },
+    "build:tron": {
+      "dependsOn": ["deps:soldeer"],
+      "outputs": [
+        "cache-tron/**",
+        "artifacts-tron/**",
+        "dist/tron/typechain/**"
+      ]
     }
   }
 }

--- a/starknet/package.json
+++ b/starknet/package.json
@@ -25,6 +25,7 @@
     "fetch-contracts": "./scripts/fetch-contracts-release.sh",
     "generate-artifacts": "tsx ./scripts/generate-artifacts.ts",
     "build": "tsc && pnpm fetch-contracts && pnpm generate-artifacts",
+    "build:ts7": "tsgo && pnpm fetch-contracts && pnpm generate-artifacts",
     "clean": "rm -rf ./dist ./release",
     "lint": "oxlint -c ../oxlint.json",
     "format": "oxfmt --write ./src"

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "cache/**", "src/generated/**"]
     },
+    "build:ts7": {
+      "dependsOn": ["^build:ts7"],
+      "outputs": ["dist/**", "cache/**", "src/generated/**"]
+    },
     "build:zk": {
       "dependsOn": ["build"],
       "outputs": ["dist/**", "artifacts-zk/**", "cache-zk/**"]

--- a/typescript/aleo-sdk/package.json
+++ b/typescript/aleo-sdk/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "prebuild": "node scripts/generate-artifacts.js",
     "build": "pnpm prebuild && rm -rf ./dist && tsc",
+    "build:ts7": "pnpm prebuild && rm -rf ./dist && tsgo",
     "format": "oxfmt --write ./src",
     "lint": "oxlint -c ../../oxlint.json",
     "clean": "rm -rf ./dist ./cache",

--- a/typescript/ccip-server/package.json
+++ b/typescript/ccip-server/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "postinstall": "prisma generate",
     "build": "prisma generate && tsc -p tsconfig.json",
+    "build:ts7": "prisma generate && tsgo -p tsconfig.json",
     "bundle": "rm -rf ./bundle && ncc build ./dist/server.js -o bundle -e @google-cloud/pino-logging-gcp-config && node ../../scripts/ncc.post-bundle.mjs",
     "start": "tsx src/server.ts",
     "dev": "NODE_ENV=development LOG_FORMAT=pretty tsx watch src/server.ts",

--- a/typescript/cli/package.json
+++ b/typescript/cli/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "hyperlane": "node ./dist/cli.js",
     "build": "pnpm version:update && NODE_OPTIONS='--max-old-space-size=4096' tsc",
+    "build:ts7": "pnpm version:update && NODE_OPTIONS='--max-old-space-size=4096' tsgo",
     "bundle": "rm -rf ./bundle && ncc build ./dist/cli.js -o bundle && node ../../scripts/ncc.post-bundle.mjs",
     "dev": "pnpm version:update && tsc --watch",
     "clean": "rm -rf ./dist && rm -rf ./bundle",

--- a/typescript/cosmos-sdk/package.json
+++ b/typescript/cosmos-sdk/package.json
@@ -32,6 +32,7 @@
   },
   "scripts": {
     "build": "rm -rf ./dist && tsc",
+    "build:ts7": "rm -rf ./dist && tsgo",
     "format": "oxfmt --write ./src",
     "lint": "oxlint -c ../../oxlint.json",
     "clean": "rm -rf ./dist ./cache",

--- a/typescript/cosmos-types/package.json
+++ b/typescript/cosmos-types/package.json
@@ -22,6 +22,7 @@
   },
   "scripts": {
     "build": "rm -rf ./dist && tsc",
+    "build:ts7": "rm -rf ./dist && tsgo",
     "format": "oxfmt --write ./src",
     "lint": "oxlint -c ../../oxlint.json",
     "clean": "rm -rf ./dist ./cache",

--- a/typescript/deploy-sdk/package.json
+++ b/typescript/deploy-sdk/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "build:ts7": "tsgo",
     "check": "tsc --noEmit",
     "dev": "tsc --watch",
     "lint": "oxlint -c ../../oxlint.json",

--- a/typescript/fee-quoting/package.json
+++ b/typescript/fee-quoting/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "build:ts7": "tsgo",
     "bundle": "rm -rf ./bundle && ncc build ./dist/scripts/run-server.js -o bundle -e @google-cloud/pino-logging-gcp-config && node ../../scripts/ncc.post-bundle.mjs",
     "dev": "tsx watch scripts/run-server.ts",
     "start": "tsx scripts/run-server.ts",

--- a/typescript/helloworld/package.json
+++ b/typescript/helloworld/package.json
@@ -20,6 +20,7 @@
   "exports": "./dist/index.js",
   "scripts": {
     "build": "pnpm hardhat-esm clean && pnpm hardhat-esm compile && pnpm exec tsc",
+    "build:ts7": "pnpm hardhat-esm clean && pnpm hardhat-esm compile && pnpm exec tsgo",
     "clean": "pnpm hardhat-esm clean && rm -rf dist cache src/types",
     "coverage": "pnpm hardhat-esm coverage",
     "lint": "solhint contracts/**/*.sol",

--- a/typescript/helloworld/src/multiProtocolApp/sealevelAdapter.ts
+++ b/typescript/helloworld/src/multiProtocolApp/sealevelAdapter.ts
@@ -83,12 +83,14 @@ export class SealevelHelloWorldAdapter
     const connection = this.getProvider();
     const recentBlockhash = (await connection.getLatestBlockhash('finalized'))
       .blockhash;
-    // @ts-ignore Workaround for bug in the web3 lib, sometimes uses recentBlockhash and sometimes uses blockhash
-    const transaction = new Transaction({
+    // Workaround for bug in the web3 lib, sometimes uses recentBlockhash and sometimes uses blockhash.
+    // Using an intermediate variable bypasses excess-property checks in both tsc 6 and tsgo 7.
+    const txOpts = {
       feePayer: senderPubKey,
       blockhash: recentBlockhash,
       recentBlockhash,
-    }).add(txInstruction);
+    };
+    const transaction = new Transaction(txOpts).add(txInstruction);
     transaction.partialSign(randomWallet);
 
     return { type: ProviderType.SolanaWeb3, transaction };

--- a/typescript/http-registry-server/package.json
+++ b/typescript/http-registry-server/package.json
@@ -14,6 +14,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "build:ts7": "tsgo -p tsconfig.json",
     "clean": "rm -rf ./dist",
     "start": "node dist/scripts/run-server.js",
     "start:dev": "NODE_ENV=development LOG_FORMAT=pretty node dist/scripts/run-server.js",

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "start:http-registry": "tsx scripts/http-registry.ts",
     "build": "tsc",
+    "build:ts7": "tsgo",
     "check": "tsc --noEmit",
     "clean": "rm -rf ./dist ./cache",
     "deploy-core": "tsx scripts/deploy.ts -e test -m core",

--- a/typescript/keyfunder/package.json
+++ b/typescript/keyfunder/package.json
@@ -23,6 +23,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "build:ts7": "tsgo",
     "bundle": "rm -rf ./bundle && ncc build ./dist/service.js -o bundle -e @google-cloud/pino-logging-gcp-config && node ../../scripts/ncc.post-bundle.mjs",
     "clean": "rm -rf dist cache bundle",
     "dev": "tsc --watch",

--- a/typescript/metrics/package.json
+++ b/typescript/metrics/package.json
@@ -21,6 +21,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "build:ts7": "tsgo",
     "clean": "rm -rf dist",
     "dev": "tsc --watch",
     "lint": "oxlint -c ../../oxlint.json",

--- a/typescript/provider-sdk/package.json
+++ b/typescript/provider-sdk/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "build:ts7": "tsgo",
     "check": "tsc --noEmit",
     "dev": "tsc --watch",
     "lint": "oxlint -c ../../oxlint.json",

--- a/typescript/radix-sdk/package.json
+++ b/typescript/radix-sdk/package.json
@@ -33,6 +33,7 @@
   },
   "scripts": {
     "build": "rm -rf ./dist && tsc",
+    "build:ts7": "rm -rf ./dist && tsgo",
     "format": "oxfmt --write ./src",
     "lint": "oxlint -c ../../oxlint.json",
     "clean": "rm -rf ./dist ./cache",

--- a/typescript/rebalancer-sim/package.json
+++ b/typescript/rebalancer-sim/package.json
@@ -23,6 +23,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "build:ts7": "tsgo",
     "clean": "rm -rf dist cache",
     "dev": "tsc --watch",
     "generate-scenarios": "tsx scripts/generate-scenarios.ts",

--- a/typescript/rebalancer/package.json
+++ b/typescript/rebalancer/package.json
@@ -25,6 +25,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "build:ts7": "tsgo",
     "build:dist": "tsc -p tsconfig.build.json",
     "bundle": "pnpm build:dist && rm -rf ./bundle && ncc build ./dist/service.js -o bundle -e @google-cloud/pino-logging-gcp-config && node ../../scripts/ncc.post-bundle.mjs",
     "clean": "rm -rf dist cache bundle",

--- a/typescript/relayer/package.json
+++ b/typescript/relayer/package.json
@@ -45,6 +45,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "build:ts7": "tsgo",
     "bundle": "rm -rf ./bundle && ncc build ./dist/fs/service.js -o bundle -e @google-cloud/pino-logging-gcp-config && node ../../scripts/ncc.post-bundle.mjs",
     "clean": "rm -rf dist cache bundle",
     "dev": "tsc --watch",

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -120,6 +120,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "build:ts7": "tsgo",
     "dev": "tsc --watch",
     "check": "tsc --noEmit",
     "clean": "rm -rf ./dist ./cache",

--- a/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
@@ -503,12 +503,14 @@ export class SealevelHypCrossCollateralAdapter
       await this.getProvider().getLatestBlockhash('finalized')
     ).blockhash;
 
-    // @ts-expect-error Workaround for bug in the web3 lib, sometimes uses recentBlockhash and sometimes uses blockhash
-    const tx = new Transaction({
+    // Workaround for bug in the web3 lib, sometimes uses recentBlockhash and sometimes uses blockhash.
+    // Using an intermediate variable bypasses excess-property checks in both tsc 6 and tsgo 7.
+    const txOpts = {
       feePayer: sender,
       blockhash: recentBlockhash,
       recentBlockhash,
-    })
+    };
+    const tx = new Transaction(txOpts)
       .add(setComputeLimitInstruction)
       .add(setPriorityFeeInstruction)
       .add(transferInstruction);

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -509,12 +509,14 @@ export abstract class SealevelHypTokenAdapter
       await this.getProvider().getLatestBlockhash('finalized')
     ).blockhash;
 
-    // @ts-ignore Workaround for bug in the web3 lib, sometimes uses recentBlockhash and sometimes uses blockhash
-    const tx = new Transaction({
+    // Workaround for bug in the web3 lib, sometimes uses recentBlockhash and sometimes uses blockhash.
+    // Using an intermediate variable bypasses excess-property checks in both tsc 6 and tsgo 7.
+    const txOpts = {
       feePayer: fromWalletPubKey,
       blockhash: recentBlockhash,
       recentBlockhash,
-    })
+    };
+    const tx = new Transaction(txOpts)
       .add(setComputeLimitInstruction)
       .add(setPriorityFeeInstruction)
       .add(transferRemoteInstruction);

--- a/typescript/starknet-sdk/package.json
+++ b/typescript/starknet-sdk/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "build": "rm -rf ./dist && tsc",
+    "build:ts7": "rm -rf ./dist && tsgo",
     "format": "oxfmt --write ./src",
     "lint": "oxlint -c ../../oxlint.json",
     "clean": "rm -rf ./dist ./cache",

--- a/typescript/svm-sdk/package.json
+++ b/typescript/svm-sdk/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "build": "rm -rf ./dist && tsc && cp -r ./src/testing/fixtures ./dist/testing/fixtures",
+    "build:ts7": "rm -rf ./dist && tsgo && cp -r ./src/testing/fixtures ./dist/testing/fixtures",
     "program:build": "(cd ../../rust/sealevel/programs && bash build-programs.sh)",
     "program:generate": "node scripts/generate-program-bytes.mjs",
     "program:check": "node scripts/check-program-bytes-hash.mjs",

--- a/typescript/tron-sdk/package.json
+++ b/typescript/tron-sdk/package.json
@@ -33,6 +33,7 @@
   },
   "scripts": {
     "build": "rm -rf ./dist && tsc",
+    "build:ts7": "rm -rf ./dist && tsgo",
     "format": "oxfmt --write src/**/*.ts",
     "lint": "oxlint -c ../../oxlint.json",
     "clean": "rm -rf ./dist ./cache ./coverage",

--- a/typescript/tron-sdk/turbo.json
+++ b/typescript/tron-sdk/turbo.json
@@ -4,6 +4,10 @@
     "build": {
       "dependsOn": ["@hyperlane-xyz/core#build:tron", "^build"],
       "outputs": ["dist/**"]
+    },
+    "build:ts7": {
+      "dependsOn": ["@hyperlane-xyz/core#build:tron", "^build:ts7"],
+      "outputs": ["dist/**"]
     }
   }
 }

--- a/typescript/utils/package.json
+++ b/typescript/utils/package.json
@@ -39,6 +39,7 @@
   "scripts": {
     "dev": "tsc -w",
     "build": "tsc -p tsconfig.build.json",
+    "build:ts7": "tsgo -p tsconfig.build.json",
     "clean": "rm -rf ./dist",
     "check": "tsc --noEmit",
     "lint": "oxlint -c ../../oxlint.json",

--- a/typescript/warp-monitor/package.json
+++ b/typescript/warp-monitor/package.json
@@ -17,6 +17,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
+    "build:ts7": "tsgo",
     "bundle": "rm -rf ./bundle && ncc build ./dist/service.js -o bundle -e @google-cloud/pino-logging-gcp-config && node ../../scripts/ncc.post-bundle.mjs",
     "clean": "rm -rf dist cache bundle",
     "dev": "tsc --watch",

--- a/typescript/warp-widget/package.json
+++ b/typescript/warp-widget/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "build:ts7": "tsgo",
     "clean": "rm -rf ./dist ./cache",
     "lint": "oxlint -c ../../oxlint.json",
     "format": "oxfmt --write ./src"

--- a/typescript/widgets/package.json
+++ b/typescript/widgets/package.json
@@ -62,7 +62,9 @@
   },
   "scripts": {
     "build": "pnpm build:ts && pnpm build:css",
+    "build:ts7": "pnpm build:ts7-only && pnpm build:css",
     "build:ts": "tsc",
+    "build:ts7-only": "tsgo",
     "build:css": "tailwindcss -c ./tailwind.config.cjs -i ./src/styles.css -o ./dist/styles.css --minify",
     "clean": "rm -rf ./dist ./cache ./storybook-static",
     "lint": "oxlint -c ../../oxlint.json",


### PR DESCRIPTION
## Summary

- Adds `@typescript/native-preview@7.0.0-dev.20260421.2` (TS 7 beta, CLI = `tsgo`) as a root devDep + catalog entry.
- Mirrors each TS-compiling package's `build` script as `build:ts7` with `tsc` swapped for `tsgo` (27 packages across `typescript/`, `solidity/`, `starknet/`).
- Adds a `build:ts7` turbo task and root `pnpm build:ts7` so both compilers run against the same tree.
- **Not** a TS 6 replacement — regular `pnpm build` still uses `tsc` from the existing `typescript: 6.0.2` catalog entry.

Draft PR — opened to compare cold build time between the existing `tsc` and `tsgo`.

## Benchmark results (local, macOS arm64)

Measured with `pnpm -w turbo run clean && /usr/bin/time -p pnpm <task> --force` after both compilers were fully installed. Each path runs all 29 workspace build tasks (TS + hardhat compile + typechain + prisma + tailwindcss + forge tron build).

| Build | Wall | User CPU | Sys CPU | Turbo reported |
|---|---|---|---|---|
| **`pnpm build` (tsc 6.0.2)** | **130.3 s** | 300.4 s | 29.7 s | 2 m 9.5 s |
| **`pnpm build:ts7` (tsgo 7.0.0-dev)** | **90.5 s** | 206.6 s | 23.7 s | 1 m 29.7 s |
| Warm `pnpm build` (turbo cache hit) | 4.3 s | — | — | 2.5 s |
| Warm `pnpm build:ts7` (turbo cache hit) | 3.4 s | — | — | 2.6 s |

**tsgo is ~30% faster end-to-end on the full cold monorepo build** (130 s → 90 s wall, ~40 s absolute). User-CPU reduction is similar (~31 %). Warm numbers are cache-dominated and uninformative.

The actual per-package `tsc → tsgo` speedup is larger than 30 % — the cold build wall time includes non-TS work (forge/tron compile, hardhat/typechain for `core` + `helloworld`, prisma codegen, tailwindcss) that runs identically in both paths.

## Why native-preview vs. a `typescript@7-beta` bump

Per the [TS 7 beta announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/), TS 7 beta ships under `@typescript/native-preview` with the `tsgo` binary; the stable release will eventually publish under `typescript`. No drop-in replacement exists today. Keeping both installed side-by-side is the cleanest way to benchmark.

## Build fixes required to reach parity

Getting `build:ts7` green on all 29 tasks required three code changes. These are real behavioral differences between `tsc 6.0.2` and `tsgo 7.0.0-dev.20260421.2`, not tooling issues:

1. **`@ts-expect-error` / `@ts-ignore` scope differs.** `tsc 6` applies the directive to the full next statement; `tsgo 7` applies it only to the immediate next line. For a multi-line `new Transaction({ ... })` call where a single property (`blockhash`) violates the ctor type, no single directive position satisfies both. Fixed by extracting the object literal into an intermediate variable, which bypasses excess-property checks in both compilers without casts. Affects 3 call sites (`sdk/SealevelCrossCollateralAdapter.ts`, `sdk/SealevelTokenAdapter.ts`, `helloworld/sealevelAdapter.ts`).
2. **`core#build:tron` dependency restructuring.** The existing `build:tron → build` turbo edge caused `core#build` and `core#build:ts7` to run concurrently in the TS 7 path, racing on hardhat-esm / typechain output (`MalformedAbiError: Not a json`). `solidity/turbo.json` now overrides `build:tron` to depend on `deps:soldeer` directly; `build-tron.sh` only needs soldeer, not the tsc output.
3. **Turbo `build:ts7` task wiring.** `tron-sdk/turbo.json` mirrors its existing `build` override to depend on `@hyperlane-xyz/core#build:tron`, and `solidity/turbo.json` declares the `build:ts7` task.

## Notes

- `pnpm minimumReleaseAge` (7 days) blocks TS 7 dev builds, so `@typescript/native-preview` and `@typescript/native-preview-*` (platform binaries) are added to `minimumReleaseAgeExclude`.
- No tsconfig changes — repo has no `target: es5`, no `baseUrl`, no legacy `module: amd/umd/systemjs/none` (the other TS 7 breaking changes).
- `widgets` splits `build:ts7-only` + `build:css` to mirror its existing `build:ts` + `build:css` pattern.

## Test plan

- [x] `pnpm install` succeeds on a clean checkout
- [x] `pnpm exec tsgo --version` reports 7.0.0-dev
- [x] `pnpm build` (TS 6, cold): 29/29 tasks succeed, 130 s wall
- [x] `pnpm build:ts7` (TS 7, cold): 29/29 tasks succeed, 90 s wall
- [x] Directive-position fixes build cleanly under both tsc 6 and tsgo 7
- [ ] CI confirms on linux-x64 runner hardware