### PR TITLE
chore: disable everclear in agents and keyfunder

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -44,6 +44,7 @@ import { getDomainId, getWarpAddresses } from '../../registry.js';
 import { environment, ethereumChainNames } from './chains.js';
 import { blacklistedMessageIds } from './customBlacklist.js';
 import aaveSenderAddresses from './misc-artifacts/aave-sender-addresses.json' with { type: 'json' };
+import everclearSenderAddresses from './misc-artifacts/everclear-sender-addresses.json' with { type: 'json' };
 import merklyErc20Addresses from './misc-artifacts/merkly-erc20-addresses.json' with { type: 'json' };
 import merklyEthAddresses from './misc-artifacts/merkly-eth-addresses.json' with { type: 'json' };
 import {
@@ -763,6 +764,12 @@ const metricAppContextsGetter = (): MetricAppContext[] => {
       // more poorly documented.
       name: 'aave',
       matchingList: senderMatchingList(aaveSenderAddresses),
+    },
+    {
+      // https://docs.everclear.org/resources/contracts/mainnet
+      // Messages between HubGateway (Everclear hub) <> EverclearSpoke (all other spoke chains)
+      name: 'everclear_gateway',
+      matchingList: senderMatchingList(everclearSenderAddresses),
     },
     // Manually specified for now until things are public
     {

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -44,7 +44,6 @@ import { getDomainId, getWarpAddresses } from '../../registry.js';
 import { environment, ethereumChainNames } from './chains.js';
 import { blacklistedMessageIds } from './customBlacklist.js';
 import aaveSenderAddresses from './misc-artifacts/aave-sender-addresses.json' with { type: 'json' };
-import everclearSenderAddresses from './misc-artifacts/everclear-sender-addresses.json' with { type: 'json' };
 import merklyErc20Addresses from './misc-artifacts/merkly-erc20-addresses.json' with { type: 'json' };
 import merklyEthAddresses from './misc-artifacts/merkly-eth-addresses.json' with { type: 'json' };
 import {
@@ -104,7 +103,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     endurance: true,
     eni: true,
     ethereum: true,
-    everclear: true,
+    everclear: false,
     fantom: false,
     flare: true,
     fluent: true,
@@ -253,7 +252,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     endurance: true,
     eni: true,
     ethereum: true,
-    everclear: true,
+    everclear: false,
     fantom: false,
     flare: true,
     fluent: true,
@@ -402,7 +401,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     endurance: true,
     eni: true,
     ethereum: true,
-    everclear: true,
+    everclear: false,
     fantom: false,
     flare: true,
     fluent: true,
@@ -764,12 +763,6 @@ const metricAppContextsGetter = (): MetricAppContext[] => {
       // more poorly documented.
       name: 'aave',
       matchingList: senderMatchingList(aaveSenderAddresses),
-    },
-    {
-      // https://docs.everclear.org/resources/contracts/mainnet
-      // Messages between HubGateway (Everclear hub) <> EverclearSpoke (all other spoke chains)
-      name: 'everclear_gateway',
-      matchingList: senderMatchingList(everclearSenderAddresses),
     },
     // Manually specified for now until things are public
     {

--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -64,7 +64,7 @@ export const keyFunderConfig: KeyFunderConfig<
     [Contexts.ReleaseCandidate]: [Role.Relayer],
     [Contexts.FastPath]: [Role.Relayer],
   },
-  chainsToSkip: [],
+  chainsToSkip: ['everclear'],
   // desired balance config, must be set for each chain
   desiredBalancePerChain: desiredRelayerBalancePerChain,
   // desired rebalancer balance config

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -78,6 +78,7 @@ export const chainsToSkip: ChainName[] = [
   'zeronetwork',
   'abstract',
   'sophon',
+  'everclear',
 
   ...getDisabledChains(),
 ];

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -78,6 +78,8 @@ export const chainsToSkip: ChainName[] = [
   'zeronetwork',
   'abstract',
   'sophon',
+
+  // permanently decommissioned
   'everclear',
 
   ...getDisabledChains(),


### PR DESCRIPTION
## Summary
- Disable `everclear` in the mainnet3 agent config for validator, relayer, and scraper roles.
- Remove the `everclear_gateway` metric app context from mainnet3 agents.
- Skip `everclear` in mainnet3 keyfunder so it will not process or fund that chain.

## Why
Everclear is being decommissioned from the monorepo runtime paths, so the mainnet3 agent and keyfunder configs should stop treating it as an active chain.

## Validation
- `pnpm --dir typescript/infra exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir typescript/keyfunder exec tsc -p tsconfig.json --noEmit`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that disables/omits the decommissioned `everclear` chain from agent runtime and key funding; main concern is accidental loss of intended monitoring/operations if `everclear` was still needed.
> 
> **Overview**
> Disables the `everclear` chain across mainnet3 operations by turning it off in the agent chain-role enablement lists (validator/relayer/scraper) and having keyfunder skip funding it.
> 
> Also marks `everclear` as **permanently decommissioned** in `chainsToSkip` so deploy/check/ICA tooling ignores it going forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7db1bdd8243a56f972ad81e1630bc2a61a8fbaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->