### PR TITLE
fix: core read for outdated hooks

### DIFF
--- a/.changeset/modern-paws-flow.md
+++ b/.changeset/modern-paws-flow.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed core read for outdated hooks

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -189,19 +189,16 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
           );
       }
     } catch (e: any) {
-      let customMessage: string = `Failed to derive ${onchainHookType} hook (${address})`;
-      if (
-        !onchainHookType &&
-        e.message.includes('Invalid response from provider')
-      ) {
-        customMessage = customMessage.concat(
-          ` [The provided hook contract might be outdated and not support hookType()]`,
+      if (!onchainHookType) {
+        this.logger.warn(
+          `Failed to derive hook type for ${address} [contract may be outdated and not support hookType()], falling back to unknown:\n\t${e}`,
         );
-        this.logger.info(`${customMessage}:\n\t${e}`);
+        derivedHookConfig = { type: HookType.UNKNOWN, address };
       } else {
+        const customMessage = `Failed to derive ${onchainHookType} hook (${address})`;
         this.logger.debug(`${customMessage}:\n\t${e}`);
+        throw new Error(`${customMessage}:\n\t${e}`);
       }
-      throw new Error(`${customMessage}:\n\t${e}`);
     } finally {
       this.setSmartProviderLogLevel(getLogLevel()); // returns to original level defined by rootLogger
     }


### PR DESCRIPTION
### Description

Fixed core read for outdated hooks

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
