### PR TITLE
feat: add docker provenance, verify attestations when deploying

### DIFF
--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -35,6 +35,7 @@ jobs:
       contents: read
       id-token: write
       packages: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@v6
@@ -98,13 +99,22 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-          provenance: false
+          provenance: mode=max
+          sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             FOUNDRY_VERSION=${{ env.FOUNDRY_VERSION }}
             REGISTRY_COMMIT=${{ env.REGISTRY_VERSION }}
           platforms: ${{ steps.determine-platforms.outputs.platforms }}
+
+      - name: Attest build provenance
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/hyperlane-xyz/hyperlane-monorepo
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
       - name: Generate job summary
         if: always()

--- a/.github/workflows/node-services-docker.yml
+++ b/.github/workflows/node-services-docker.yml
@@ -35,6 +35,7 @@ jobs:
       id-token: write
       packages: write
       pull-requests: write
+      attestations: write
 
     steps:
       - name: Generate GitHub App Token
@@ -101,13 +102,22 @@ jobs:
           context: ./
           file: ./typescript/Dockerfile
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-          provenance: false
+          provenance: mode=max
+          sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             FOUNDRY_VERSION=${{ env.FOUNDRY_VERSION }}
             SERVICE_VERSION=${{ steps.taggen.outputs.TAG_SHA }}-${{ steps.taggen.outputs.TAG_DATE }}
           platforms: ${{ steps.determine-platforms.outputs.platforms }}
+
+      - name: Attest build provenance
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/hyperlane-xyz/hyperlane-node-services
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
       - name: Generate image tags output
         id: image-tags

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -32,6 +32,7 @@ jobs:
       id-token: write
       packages: write
       pull-requests: write
+      attestations: write
 
     steps:
       - name: Generate GitHub App Token
@@ -107,10 +108,19 @@ jobs:
           context: .
           file: ./rust/Dockerfile
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-          provenance: false
+          provenance: mode=max
+          sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ steps.determine-platforms.outputs.platforms }}
+
+      - name: Attest build provenance
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/hyperlane-xyz/hyperlane-agent
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
       - name: Comment image tags on PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && always()

--- a/docs/docker-image-policy.md
+++ b/docs/docker-image-policy.md
@@ -38,6 +38,60 @@ Additional tags applied automatically:
 - **PR number** (e.g., `pr-123`)
 - **Git tag** (e.g., `v2.1.0`); agent releases use `agents-*` tags which also produce semver tags
 
+## Verification
+
+All images pushed by `rust-docker.yml`, `monorepo-docker.yml`, and `node-services-docker.yml` carry a SLSA v1 build-provenance attestation, signed keyless via GitHub Actions OIDC and attached to the image digest as an OCI referrer.
+
+The attestation identifies:
+
+- repository: `hyperlane-xyz/hyperlane-monorepo`
+- workflow: the producing `.github/workflows/*.yml`
+- commit SHA
+- runner / builder
+- `startedOn` / `finishedOn` build timestamps
+
+### Verify with `gh`
+
+```bash
+gh attestation verify \
+  oci://ghcr.io/hyperlane-xyz/hyperlane-agent:<tag-or-digest> \
+  --repo hyperlane-xyz/hyperlane-monorepo
+```
+
+Add `--signer-workflow hyperlane-xyz/hyperlane-monorepo/.github/workflows/rust-docker.yml` to pin the producing workflow.
+
+### Verify with `cosign`
+
+```bash
+cosign verify-attestation \
+  --type slsaprovenance1 \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/hyperlane-xyz/hyperlane-monorepo/\.github/workflows/rust-docker\.yml@' \
+  ghcr.io/hyperlane-xyz/hyperlane-agent@<digest>
+```
+
+### Minimum build age (soak time)
+
+Provenance timestamps enable a "cool-off" gate in promotion pipelines. Extract `finishedOn` and compare against `now - soak`:
+
+```bash
+FINISHED=$(cosign verify-attestation \
+  --type slsaprovenance1 \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/hyperlane-xyz/hyperlane-monorepo/\.github/workflows/rust-docker\.yml@' \
+  ghcr.io/hyperlane-xyz/hyperlane-agent@<digest> \
+  | jq -r '.payload | @base64d | fromjson | .predicate.runDetails.metadata.finishedOn')
+
+AGE=$(( $(date -u +%s) - $(date -u -d "$FINISHED" +%s) ))
+[ "$AGE" -ge 86400 ] || { echo "image younger than 24h"; exit 1; }
+```
+
+Staging typically needs no soak; production can require ≥24h.
+
+### Pin deploys by digest
+
+Tags are mutable. For verification guarantees to hold end-to-end, promotion/deploy should resolve tag → digest once, verify the digest, then deploy the digest. See `typescript/infra/config/docker.ts` for the deployed-tag surface.
+
 ## Retention
 
 | Image type                           | Retention                       | Notes                         |

--- a/docs/docker-image-policy.md
+++ b/docs/docker-image-policy.md
@@ -26,6 +26,7 @@ The `hyperlane-node-services` image is a single unified image containing all Typ
 | `ccip-server`  | Offchain lookup server     |
 | `keyfunder`    | Agent key funder           |
 | `relayer`      | TypeScript relayer         |
+| `fee-quoting`  | Fee-quoting server         |
 
 ## Tagging
 

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -51,7 +51,11 @@ export const mainnetDockerTags: MainnetDockerTags = {
   keyFunder: '3b17358-20260315-183126',
   warpMonitor: '3b17358-20260315-183126',
   rebalancer: '1a19513-20260413-090011',
-  feeQuoting: '12d899d-20260325-184337',
+  // Bumped from the old standalone hyperlane-fee-quoting tag when the
+  // service was migrated onto hyperlane-node-services. Points at a
+  // post-migration node-services build that includes the fee-quoting
+  // bundle; bump again after the next signed main build lands.
+  feeQuoting: '1a19513-20260413-090011',
 };
 
 export const testnetDockerTags: BaseDockerTags = {

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -4,7 +4,6 @@ export const DockerImageNames = {
   AGENT: 'hyperlane-agent',
   MONOREPO: 'hyperlane-monorepo',
   NODE_SERVICES: 'hyperlane-node-services',
-  FEE_QUOTING: 'hyperlane-fee-quoting',
 } as const;
 
 type DockerImageReposType = {
@@ -43,7 +42,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   relayer: '7eb690c-20260406-142107',
   relayerRC: '7eb690c-20260406-142107',
   relayerFastPath: '7eb690c-20260406-142107',
-  validator: '7eb690c-20260406-142107',
+  validator: 'b24afdc-20260423-160239',
   validatorRC: '7eb690c-20260406-142107',
   scraper: 'caa8162-20260409-132508',
   // monorepo services

--- a/typescript/infra/helm/fee-quoting/templates/deployment.yaml
+++ b/typescript/infra/helm/fee-quoting/templates/deployment.yaml
@@ -52,6 +52,8 @@ spec:
             - secretRef:
                 name: {{ .Chart.Name }}-secrets
           env:
+            - name: SERVICE_NAME
+              value: fee-quoting
             - name: REGISTRY_URI
               value: {{ .Values.hyperlane.registryUri | quote }}
 {{- with .Values.env }}

--- a/typescript/infra/helm/fee-quoting/templates/deployment.yaml
+++ b/typescript/infra/helm/fee-quoting/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
                 name: {{ .Chart.Name }}-secrets
           env:
             - name: SERVICE_NAME
-              value: fee-quoting
+              value: {{ .Values.serviceName | default "fee-quoting" | quote }}
             - name: REGISTRY_URI
               value: {{ .Values.hyperlane.registryUri | quote }}
 {{- with .Values.env }}

--- a/typescript/infra/helm/fee-quoting/values.yaml
+++ b/typescript/infra/helm/fee-quoting/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/hyperlane-xyz/hyperlane-fee-quoting
+  repository: ghcr.io/hyperlane-xyz/hyperlane-node-services
   tag: latest
 
 hyperlane:

--- a/typescript/infra/scripts/agents/deploy-agents.ts
+++ b/typescript/infra/scripts/agents/deploy-agents.ts
@@ -5,6 +5,7 @@ import { execSync } from 'child_process';
 import { DockerImageRepos } from '../../config/docker.js';
 import { createAgentKeysIfNotExistsWithPrompt } from '../../src/agents/key-utils.js';
 import { RootAgentConfig } from '../../src/config/agent/agent.js';
+import { Role } from '../../src/roles.js';
 import { verifyImagesAndConfirm } from '../../src/utils/attestation.js';
 import {
   checkAgentImageExists,
@@ -12,6 +13,7 @@ import {
   warnIfPrTag,
 } from '../../src/utils/gcloud.js';
 import { HelmCommand } from '../../src/utils/helm.js';
+import { getArgs, withAgentRoles } from '../agent-utils.js';
 import { getConfigsBasedOnArgs } from '../core-utils.js';
 
 import { AgentCli } from './utils.js';
@@ -55,12 +57,11 @@ async function getCommitsBehindMain(): Promise<number> {
   }
 }
 
-async function checkDockerTagsExist(agentConfig: RootAgentConfig) {
-  const imagesToCheck: { agent: string; tag?: string }[] = [
-    { agent: 'scraper', tag: agentConfig.scraper?.docker.tag },
-    { agent: 'validators', tag: agentConfig.validators?.docker.tag },
-    { agent: 'relayer', tag: agentConfig.relayer?.docker.tag },
-  ];
+async function checkDockerTagsExist(
+  agentConfig: RootAgentConfig,
+  roles?: Role[],
+) {
+  const imagesToCheck = rolesToCheck(agentConfig, roles);
 
   let errors = false;
   for (const { agent, tag } of imagesToCheck) {
@@ -102,20 +103,43 @@ async function checkDockerTagsExist(agentConfig: RootAgentConfig) {
   }
 }
 
-async function verifyAgentAttestationsWithPrompt(agentConfig: RootAgentConfig) {
-  const refs = [
-    { component: 'scraper', tag: agentConfig.scraper?.docker.tag },
-    { component: 'validators', tag: agentConfig.validators?.docker.tag },
-    { component: 'relayer', tag: agentConfig.relayer?.docker.tag },
-  ]
-    .filter((r): r is { component: string; tag: string } => !!r.tag)
-    .map(({ component, tag }) => ({
-      component,
+async function verifyAgentAttestationsWithPrompt(
+  agentConfig: RootAgentConfig,
+  roles?: Role[],
+) {
+  const refs = rolesToCheck(agentConfig, roles)
+    .filter((r): r is { agent: string; role: Role; tag: string } => !!r.tag)
+    .map(({ agent, tag }) => ({
+      component: agent,
       image: DockerImageRepos.AGENT,
       tag,
     }));
 
   await verifyImagesAndConfirm(refs);
+}
+
+function rolesToCheck(
+  agentConfig: RootAgentConfig,
+  roles?: Role[],
+): { agent: string; role: Role; tag?: string }[] {
+  const all = [
+    {
+      agent: 'scraper',
+      role: Role.Scraper,
+      tag: agentConfig.scraper?.docker.tag,
+    },
+    {
+      agent: 'validators',
+      role: Role.Validator,
+      tag: agentConfig.validators?.docker.tag,
+    },
+    {
+      agent: 'relayer',
+      role: Role.Relayer,
+      tag: agentConfig.relayer?.docker.tag,
+    },
+  ];
+  return roles ? all.filter((r) => roles.includes(r.role)) : all;
 }
 
 async function main() {
@@ -126,9 +150,10 @@ async function main() {
   // whose keys / users are not chain-specific) will be attempted multiple times.
   // While this function still has these side effects, the workaround is to just
   // run the create-keys script first.
+  const { roles } = await withAgentRoles(getArgs()).argv;
   const { agentConfig } = await getConfigsBasedOnArgs();
-  await checkDockerTagsExist(agentConfig);
-  await verifyAgentAttestationsWithPrompt(agentConfig);
+  await checkDockerTagsExist(agentConfig, roles);
+  await verifyAgentAttestationsWithPrompt(agentConfig, roles);
 
   await createAgentKeysIfNotExistsWithPrompt(agentConfig);
 

--- a/typescript/infra/scripts/agents/deploy-agents.ts
+++ b/typescript/infra/scripts/agents/deploy-agents.ts
@@ -6,7 +6,10 @@ import { DockerImageRepos } from '../../config/docker.js';
 import { createAgentKeysIfNotExistsWithPrompt } from '../../src/agents/key-utils.js';
 import { RootAgentConfig } from '../../src/config/agent/agent.js';
 import { Role } from '../../src/roles.js';
-import { verifyImagesAndConfirm } from '../../src/utils/attestation.js';
+import {
+  ImageRef,
+  verifyImagesAndConfirm,
+} from '../../src/utils/attestation.js';
 import {
   checkAgentImageExists,
   checkMonorepoImageExists,
@@ -107,13 +110,15 @@ async function verifyAgentAttestationsWithPrompt(
   agentConfig: RootAgentConfig,
   roles?: Role[],
 ) {
-  const refs = rolesToCheck(agentConfig, roles)
-    .filter((r): r is { agent: string; role: Role; tag: string } => !!r.tag)
-    .map(({ agent, tag }) => ({
-      component: agent,
+  const refs: ImageRef[] = [];
+  for (const r of rolesToCheck(agentConfig, roles)) {
+    if (r.tag == null) continue;
+    refs.push({
+      component: r.agent,
       image: DockerImageRepos.AGENT,
-      tag,
-    }));
+      tag: r.tag,
+    });
+  }
 
   await verifyImagesAndConfirm(refs);
 }

--- a/typescript/infra/scripts/agents/deploy-agents.ts
+++ b/typescript/infra/scripts/agents/deploy-agents.ts
@@ -112,7 +112,7 @@ async function verifyAgentAttestationsWithPrompt(
 ) {
   const refs: ImageRef[] = [];
   for (const r of rolesToCheck(agentConfig, roles)) {
-    if (r.tag == null) continue;
+    if (!r.tag) continue;
     refs.push({
       component: r.agent,
       image: DockerImageRepos.AGENT,

--- a/typescript/infra/scripts/agents/deploy-agents.ts
+++ b/typescript/infra/scripts/agents/deploy-agents.ts
@@ -5,7 +5,7 @@ import { execSync } from 'child_process';
 import { DockerImageRepos } from '../../config/docker.js';
 import { createAgentKeysIfNotExistsWithPrompt } from '../../src/agents/key-utils.js';
 import { RootAgentConfig } from '../../src/config/agent/agent.js';
-import { preflightVerifyImages } from '../../src/utils/attestation.js';
+import { verifyImagesAndConfirm } from '../../src/utils/attestation.js';
 import {
   checkAgentImageExists,
   checkMonorepoImageExists,
@@ -115,25 +115,7 @@ async function verifyAgentAttestationsWithPrompt(agentConfig: RootAgentConfig) {
       tag,
     }));
 
-  if (refs.length === 0) return;
-
-  console.log(chalk.grey.italic('Verifying image attestations...'));
-  const { allVerified } = await preflightVerifyImages(refs);
-
-  const message = allVerified
-    ? 'All attestations verified. Continue with deploy?'
-    : chalk.red.bold(
-        'One or more images FAILED attestation verify. Continue with deploy anyway?',
-      );
-
-  const shouldContinue = await confirm({
-    message,
-    default: allVerified,
-  });
-  if (!shouldContinue) {
-    console.log(chalk.red.bold('Exiting...'));
-    process.exit(1);
-  }
+  await verifyImagesAndConfirm(refs);
 }
 
 async function main() {

--- a/typescript/infra/scripts/agents/deploy-agents.ts
+++ b/typescript/infra/scripts/agents/deploy-agents.ts
@@ -2,8 +2,10 @@ import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { execSync } from 'child_process';
 
+import { DockerImageRepos } from '../../config/docker.js';
 import { createAgentKeysIfNotExistsWithPrompt } from '../../src/agents/key-utils.js';
 import { RootAgentConfig } from '../../src/config/agent/agent.js';
+import { preflightVerifyImages } from '../../src/utils/attestation.js';
 import {
   checkAgentImageExists,
   checkMonorepoImageExists,
@@ -100,6 +102,40 @@ async function checkDockerTagsExist(agentConfig: RootAgentConfig) {
   }
 }
 
+async function verifyAgentAttestationsWithPrompt(agentConfig: RootAgentConfig) {
+  const refs = [
+    { component: 'scraper', tag: agentConfig.scraper?.docker.tag },
+    { component: 'validators', tag: agentConfig.validators?.docker.tag },
+    { component: 'relayer', tag: agentConfig.relayer?.docker.tag },
+  ]
+    .filter((r): r is { component: string; tag: string } => !!r.tag)
+    .map(({ component, tag }) => ({
+      component,
+      image: DockerImageRepos.AGENT,
+      tag,
+    }));
+
+  if (refs.length === 0) return;
+
+  console.log(chalk.grey.italic('Verifying image attestations...'));
+  const { allVerified } = await preflightVerifyImages(refs);
+
+  const message = allVerified
+    ? 'All attestations verified. Continue with deploy?'
+    : chalk.red.bold(
+        'One or more images FAILED attestation verify. Continue with deploy anyway?',
+      );
+
+  const shouldContinue = await confirm({
+    message,
+    default: allVerified,
+  });
+  if (!shouldContinue) {
+    console.log(chalk.red.bold('Exiting...'));
+    process.exit(1);
+  }
+}
+
 async function main() {
   // Note the create-keys script should be ran prior to running this script.
   // At the moment, `runAgentHelmCommand` has the side effect of creating keys / users
@@ -110,6 +146,7 @@ async function main() {
   // run the create-keys script first.
   const { agentConfig } = await getConfigsBasedOnArgs();
   await checkDockerTagsExist(agentConfig);
+  await verifyAgentAttestationsWithPrompt(agentConfig);
 
   await createAgentKeysIfNotExistsWithPrompt(agentConfig);
 

--- a/typescript/infra/scripts/check/deploy-check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/deploy-check-warp-deploy.ts
@@ -1,5 +1,6 @@
 import { Contexts } from '../../config/contexts.js';
 import { CheckWarpDeployHelmManager } from '../../src/check-warp-deploy/helm.js';
+import { verifyImagesAndConfirm } from '../../src/utils/attestation.js';
 import { HelmCommand } from '../../src/utils/helm.js';
 import { assertCorrectKubeContext } from '../agent-utils.js';
 import { getConfigsBasedOnArgs } from '../core-utils.js';
@@ -17,6 +18,14 @@ async function main() {
   if (!manager) {
     throw new Error('No checkWarpDeployConfig found');
   }
+
+  await verifyImagesAndConfirm([
+    {
+      component: 'check-warp-deploy',
+      image: manager.config.docker.repo,
+      tag: manager.config.docker.tag,
+    },
+  ]);
 
   await manager.runHelmCommand(HelmCommand.InstallOrUpgrade);
 }

--- a/typescript/infra/scripts/fee-quoting/deploy-fee-quoting.ts
+++ b/typescript/infra/scripts/fee-quoting/deploy-fee-quoting.ts
@@ -5,7 +5,9 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
+import { DockerImageRepos, mainnetDockerTags } from '../../config/docker.js';
 import { FeeQuotingHelmManager } from '../../src/fee-quoting/helm.js';
+import { verifyImagesAndConfirm } from '../../src/utils/attestation.js';
 import { HelmCommand } from '../../src/utils/helm.js';
 import {
   assertCorrectKubeContext,
@@ -21,6 +23,14 @@ async function main() {
     await withRegistryCommit(getArgs()).parse();
 
   await assertCorrectKubeContext(getEnvironmentConfig(environment));
+
+  await verifyImagesAndConfirm([
+    {
+      component: 'fee-quoting',
+      image: DockerImageRepos.FEE_QUOTING,
+      tag: mainnetDockerTags.feeQuoting,
+    },
+  ]);
 
   const helmManager = new FeeQuotingHelmManager(
     environment,

--- a/typescript/infra/scripts/fee-quoting/deploy-fee-quoting.ts
+++ b/typescript/infra/scripts/fee-quoting/deploy-fee-quoting.ts
@@ -5,7 +5,9 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
+import { DockerImageRepos, mainnetDockerTags } from '../../config/docker.js';
 import { FeeQuotingHelmManager } from '../../src/fee-quoting/helm.js';
+import { verifyImagesAndConfirm } from '../../src/utils/attestation.js';
 import { HelmCommand } from '../../src/utils/helm.js';
 import {
   assertCorrectKubeContext,
@@ -22,9 +24,13 @@ async function main() {
 
   await assertCorrectKubeContext(getEnvironmentConfig(environment));
 
-  // Note: FEE_QUOTING image is not built by a workflow in this repo and
-  // therefore has no attestation to verify. Add attestation verify here
-  // once the image is built + signed by CI.
+  await verifyImagesAndConfirm([
+    {
+      component: 'fee-quoting',
+      image: DockerImageRepos.NODE_SERVICES,
+      tag: mainnetDockerTags.feeQuoting,
+    },
+  ]);
 
   const helmManager = new FeeQuotingHelmManager(
     environment,

--- a/typescript/infra/scripts/fee-quoting/deploy-fee-quoting.ts
+++ b/typescript/infra/scripts/fee-quoting/deploy-fee-quoting.ts
@@ -5,9 +5,7 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
-import { DockerImageRepos, mainnetDockerTags } from '../../config/docker.js';
 import { FeeQuotingHelmManager } from '../../src/fee-quoting/helm.js';
-import { verifyImagesAndConfirm } from '../../src/utils/attestation.js';
 import { HelmCommand } from '../../src/utils/helm.js';
 import {
   assertCorrectKubeContext,
@@ -24,13 +22,9 @@ async function main() {
 
   await assertCorrectKubeContext(getEnvironmentConfig(environment));
 
-  await verifyImagesAndConfirm([
-    {
-      component: 'fee-quoting',
-      image: DockerImageRepos.FEE_QUOTING,
-      tag: mainnetDockerTags.feeQuoting,
-    },
-  ]);
+  // Note: FEE_QUOTING image is not built by a workflow in this repo and
+  // therefore has no attestation to verify. Add attestation verify here
+  // once the image is built + signed by CI.
 
   const helmManager = new FeeQuotingHelmManager(
     environment,

--- a/typescript/infra/scripts/funding/deploy-key-funder.ts
+++ b/typescript/infra/scripts/funding/deploy-key-funder.ts
@@ -4,7 +4,9 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 import { Contexts } from '../../config/contexts.js';
+import { DockerImageRepos } from '../../config/docker.js';
 import { KeyFunderHelmManager } from '../../src/funding/key-funder.js';
+import { preflightVerifyImages } from '../../src/utils/attestation.js';
 import {
   checkNodeServicesImageExists,
   warnIfPrTag,
@@ -39,6 +41,24 @@ async function main() {
           `Attempted to deploy key funder with image tag ${chalk.bold(tag)}, but it has not been published to the registry.`,
         ),
       );
+      process.exit(1);
+    }
+
+    console.log(chalk.grey.italic('Verifying image attestation...'));
+    const { allVerified } = await preflightVerifyImages([
+      { component: 'key-funder', image: DockerImageRepos.NODE_SERVICES, tag },
+    ]);
+
+    const shouldContinue = await confirm({
+      message: allVerified
+        ? 'Attestation verified. Continue with deploy?'
+        : chalk.red.bold(
+            'Image FAILED attestation verify. Continue with deploy anyway?',
+          ),
+      default: allVerified,
+    });
+    if (!shouldContinue) {
+      console.log(chalk.red.bold('Exiting...'));
       process.exit(1);
     }
   }

--- a/typescript/infra/scripts/funding/deploy-key-funder.ts
+++ b/typescript/infra/scripts/funding/deploy-key-funder.ts
@@ -6,7 +6,7 @@ import { join } from 'path';
 import { Contexts } from '../../config/contexts.js';
 import { DockerImageRepos } from '../../config/docker.js';
 import { KeyFunderHelmManager } from '../../src/funding/key-funder.js';
-import { preflightVerifyImages } from '../../src/utils/attestation.js';
+import { verifyImagesAndConfirm } from '../../src/utils/attestation.js';
 import {
   checkNodeServicesImageExists,
   warnIfPrTag,
@@ -44,23 +44,9 @@ async function main() {
       process.exit(1);
     }
 
-    console.log(chalk.grey.italic('Verifying image attestation...'));
-    const { allVerified } = await preflightVerifyImages([
+    await verifyImagesAndConfirm([
       { component: 'key-funder', image: DockerImageRepos.NODE_SERVICES, tag },
     ]);
-
-    const shouldContinue = await confirm({
-      message: allVerified
-        ? 'Attestation verified. Continue with deploy?'
-        : chalk.red.bold(
-            'Image FAILED attestation verify. Continue with deploy anyway?',
-          ),
-      default: allVerified,
-    });
-    if (!shouldContinue) {
-      console.log(chalk.red.bold('Exiting...'));
-      process.exit(1);
-    }
   }
 
   const defaultRegistryCommit = readRegistryRc();

--- a/typescript/infra/scripts/rebalancer/deploy-rebalancer.ts
+++ b/typescript/infra/scripts/rebalancer/deploy-rebalancer.ts
@@ -8,11 +8,13 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
+import { DockerImageRepos, mainnetDockerTags } from '../../config/docker.js';
 import { DeployEnvironment } from '../../src/config/deploy-environment.js';
 import {
   RebalancerHelmManager,
   getDeployedRebalancerWarpRouteIds,
 } from '../../src/rebalancer/helm.js';
+import { verifyImagesAndConfirm } from '../../src/utils/attestation.js';
 import { REBALANCER_HELM_RELEASE_PREFIX } from '../../src/utils/consts.js';
 import { validateRegistryCommit } from '../../src/utils/git.js';
 import { HelmCommand } from '../../src/utils/helm.js';
@@ -44,6 +46,14 @@ async function main() {
   ).parse();
 
   await assertCorrectKubeContext(getEnvironmentConfig(environment));
+
+  await verifyImagesAndConfirm([
+    {
+      component: 'rebalancer',
+      image: DockerImageRepos.NODE_SERVICES,
+      tag: mainnetDockerTags.rebalancer,
+    },
+  ]);
 
   let warpRouteIds: string[];
   if (warpRouteId) {

--- a/typescript/infra/scripts/warp-routes/deploy-warp-monitor.ts
+++ b/typescript/infra/scripts/warp-routes/deploy-warp-monitor.ts
@@ -9,7 +9,9 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import { Contexts } from '../../config/contexts.js';
+import { DockerImageRepos, mainnetDockerTags } from '../../config/docker.js';
 import { getWarpCoreConfig } from '../../config/registry.js';
+import { verifyImagesAndConfirm } from '../../src/utils/attestation.js';
 import { WARP_ROUTE_MONITOR_HELM_RELEASE_PREFIX } from '../../src/utils/consts.js';
 import { validateRegistryCommit } from '../../src/utils/git.js';
 import { HelmCommand } from '../../src/utils/helm.js';
@@ -40,6 +42,14 @@ async function main() {
   await timedAsync('assertCorrectKubeContext', () =>
     assertCorrectKubeContext(getEnvironmentConfig(environment)),
   );
+
+  await verifyImagesAndConfirm([
+    {
+      component: 'warp-monitor',
+      image: DockerImageRepos.NODE_SERVICES,
+      tag: mainnetDockerTags.warpMonitor,
+    },
+  ]);
 
   const envConfig = getEnvironmentConfig(environment);
 

--- a/typescript/infra/src/fee-quoting/helm.ts
+++ b/typescript/infra/src/fee-quoting/helm.ts
@@ -43,7 +43,7 @@ export class FeeQuotingHelmManager extends HelmManager {
     return {
       ...envValues,
       image: {
-        repository: DockerImageRepos.FEE_QUOTING,
+        repository: DockerImageRepos.NODE_SERVICES,
         tag: mainnetDockerTags.feeQuoting,
       },
       hyperlane: {

--- a/typescript/infra/src/fee-quoting/helm.ts
+++ b/typescript/infra/src/fee-quoting/helm.ts
@@ -4,6 +4,7 @@ import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
 
 import { DockerImageRepos, mainnetDockerTags } from '../../config/docker.js';
 import { DeployEnvironment } from '../config/deploy-environment.js';
+import { NODE_SERVICE_NAMES } from '../utils/consts.js';
 import { HelmManager } from '../utils/helm.js';
 import { getInfraPath } from '../utils/utils.js';
 import { readYaml } from '@hyperlane-xyz/utils/fs';
@@ -46,6 +47,7 @@ export class FeeQuotingHelmManager extends HelmManager {
         repository: DockerImageRepos.NODE_SERVICES,
         tag: mainnetDockerTags.feeQuoting,
       },
+      serviceName: NODE_SERVICE_NAMES.FEE_QUOTING,
       hyperlane: {
         ...envValues.hyperlane,
         runEnv: this.environment,

--- a/typescript/infra/src/utils/attestation.ts
+++ b/typescript/infra/src/utils/attestation.ts
@@ -67,7 +67,8 @@ function extractFinishedOn(rawJson: string): Date | undefined {
     const parsed = JSON.parse(rawJson);
     const entries = Array.isArray(parsed) ? parsed : [parsed];
     for (const entry of entries) {
-      const statement = entry?.verificationResult?.statement ?? entry?.statement;
+      const statement =
+        entry?.verificationResult?.statement ?? entry?.statement;
       const finishedOn =
         statement?.predicate?.runDetails?.metadata?.finishedOn ??
         statement?.predicate?.metadata?.buildFinishedOn;
@@ -92,32 +93,45 @@ function formatAge(ms: number): string {
   return `${m}m`;
 }
 
-export function printAttestationStatus(ref: ImageRef, status: AttestationStatus): void {
+export function printAttestationStatus(
+  ref: ImageRef,
+  status: AttestationStatus,
+): void {
   const imageStr = `${ref.image}:${ref.tag}`;
   if (status.verified) {
     console.log(
-      chalk.green(`✓ ${chalk.bold(ref.component)} attestation verified: ${imageStr}`),
+      chalk.green(
+        `✓ ${chalk.bold(ref.component)} attestation verified: ${imageStr}`,
+      ),
     );
     if (status.finishedOn && status.ageMs != null) {
       const line = `  built: ${status.finishedOn.toISOString()}  (age: ${formatAge(status.ageMs)})`;
       if (status.ageMs < YOUNG_BUILD_THRESHOLD_MS) {
-        console.log(chalk.yellow(`${line}  ⚠ young build — consider a soak period before prod`));
+        console.log(
+          chalk.yellow(
+            `${line}  ⚠ young build — consider a soak period before prod`,
+          ),
+        );
       } else {
         console.log(chalk.gray(line));
       }
     } else {
-      console.log(chalk.gray('  build age: unknown (could not parse provenance)'));
+      console.log(
+        chalk.gray('  build age: unknown (could not parse provenance)'),
+      );
     }
   } else {
     const bar = '!'.repeat(72);
     console.log('');
     console.log(chalk.red.bold(bar));
     console.log(
-      chalk.red.bold(`ATTESTATION VERIFY FAILED for ${ref.component} (${imageStr})`),
+      chalk.red.bold(
+        `ATTESTATION VERIFY FAILED for ${ref.component} (${imageStr})`,
+      ),
     );
     console.log(
       chalk.red.bold(
-        'Image may not have been built by this repo\'s CI. Supply-chain risk.',
+        "Image may not have been built by this repo's CI. Supply-chain risk.",
       ),
     );
     console.log(chalk.red(`reason: ${status.reason.split('\n')[0]}`));
@@ -126,9 +140,10 @@ export function printAttestationStatus(ref: ImageRef, status: AttestationStatus)
   }
 }
 
-export async function preflightVerifyImages(
-  refs: ImageRef[],
-): Promise<{ allVerified: boolean; results: Array<{ ref: ImageRef; status: AttestationStatus }> }> {
+export async function preflightVerifyImages(refs: ImageRef[]): Promise<{
+  allVerified: boolean;
+  results: Array<{ ref: ImageRef; status: AttestationStatus }>;
+}> {
   const seen = new Set<string>();
   const results: Array<{ ref: ImageRef; status: AttestationStatus }> = [];
   let allVerified = true;
@@ -138,7 +153,10 @@ export async function preflightVerifyImages(
     if (seen.has(key)) continue;
     seen.add(key);
 
-    const status = await verifyImageAttestation({ image: ref.image, tag: ref.tag });
+    const status = await verifyImageAttestation({
+      image: ref.image,
+      tag: ref.tag,
+    });
     printAttestationStatus(ref, status);
     results.push({ ref, status });
     if (!status.verified) allVerified = false;

--- a/typescript/infra/src/utils/attestation.ts
+++ b/typescript/infra/src/utils/attestation.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import { execSync } from 'child_process';
 
 const DEFAULT_REPO = 'hyperlane-xyz/hyperlane-monorepo';
+const YOUNG_BUILD_THRESHOLD_MS = 60 * 60 * 1000; // 1h
 
 export type AttestationStatus =
   | {
@@ -98,11 +99,12 @@ export function printAttestationStatus(ref: ImageRef, status: AttestationStatus)
       chalk.green(`✓ ${chalk.bold(ref.component)} attestation verified: ${imageStr}`),
     );
     if (status.finishedOn && status.ageMs != null) {
-      console.log(
-        chalk.gray(
-          `  built: ${status.finishedOn.toISOString()}  (age: ${formatAge(status.ageMs)})`,
-        ),
-      );
+      const line = `  built: ${status.finishedOn.toISOString()}  (age: ${formatAge(status.ageMs)})`;
+      if (status.ageMs < YOUNG_BUILD_THRESHOLD_MS) {
+        console.log(chalk.yellow(`${line}  ⚠ young build — consider a soak period before prod`));
+      } else {
+        console.log(chalk.gray(line));
+      }
     } else {
       console.log(chalk.gray('  build age: unknown (could not parse provenance)'));
     }

--- a/typescript/infra/src/utils/attestation.ts
+++ b/typescript/infra/src/utils/attestation.ts
@@ -1,3 +1,4 @@
+import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { execSync } from 'child_process';
 
@@ -142,4 +143,27 @@ export async function preflightVerifyImages(
   }
 
   return { allVerified, results };
+}
+
+export async function verifyImagesAndConfirm(refs: ImageRef[]): Promise<void> {
+  if (refs.length === 0) return;
+
+  console.log(chalk.grey.italic('Verifying image attestations...'));
+  const { allVerified } = await preflightVerifyImages(refs);
+
+  const message = allVerified
+    ? 'All attestations verified. Continue with deploy?'
+    : chalk.red.bold(
+        'One or more images FAILED attestation verify. Continue with deploy anyway?',
+      );
+
+  const shouldContinue = await confirm({
+    message,
+    default: allVerified,
+  });
+
+  if (!shouldContinue) {
+    console.log(chalk.red.bold('Exiting...'));
+    process.exit(1);
+  }
 }

--- a/typescript/infra/src/utils/attestation.ts
+++ b/typescript/infra/src/utils/attestation.ts
@@ -67,18 +67,57 @@ function extractFinishedOn(rawJson: string): Date | undefined {
     const parsed = JSON.parse(rawJson);
     const entries = Array.isArray(parsed) ? parsed : [parsed];
     for (const entry of entries) {
-      const statement =
-        entry?.verificationResult?.statement ?? entry?.statement;
-      const finishedOn =
-        statement?.predicate?.runDetails?.metadata?.finishedOn ??
-        statement?.predicate?.metadata?.buildFinishedOn;
-      if (typeof finishedOn === 'string') {
-        const d = new Date(finishedOn);
-        if (!isNaN(d.getTime())) return d;
+      const candidates: unknown[] = [
+        entry?.verificationResult?.statement,
+        entry?.statement,
+      ];
+      const dssePayload =
+        entry?.attestation?.bundle?.dsseEnvelope?.payload ??
+        entry?.bundle?.dsseEnvelope?.payload;
+      if (typeof dssePayload === 'string') {
+        try {
+          candidates.push(
+            JSON.parse(Buffer.from(dssePayload, 'base64').toString('utf8')),
+          );
+        } catch {
+          // ignore, next candidate
+        }
+      }
+      for (const c of candidates) {
+        const date = readFinishedOn(c);
+        if (date) return date;
       }
     }
   } catch {
     // ignore - treated as "verified but age unknown"
+  }
+  return undefined;
+}
+
+function readFinishedOn(statement: unknown): Date | undefined {
+  if (typeof statement !== 'object' || statement === null) return undefined;
+  const value = pickPath(statement, [
+    ['predicate', 'runDetails', 'metadata', 'finishedOn'],
+    ['predicate', 'metadata', 'buildFinishedOn'],
+  ]);
+  if (typeof value === 'string') {
+    const d = new Date(value);
+    if (!isNaN(d.getTime())) return d;
+  }
+  return undefined;
+}
+
+function pickPath(root: unknown, paths: string[][]): unknown {
+  for (const path of paths) {
+    let node: unknown = root;
+    for (const key of path) {
+      if (typeof node !== 'object' || node === null) {
+        node = undefined;
+        break;
+      }
+      node = (node as Record<string, unknown>)[key];
+    }
+    if (node !== undefined) return node;
   }
   return undefined;
 }

--- a/typescript/infra/src/utils/attestation.ts
+++ b/typescript/infra/src/utils/attestation.ts
@@ -151,15 +151,13 @@ export async function verifyImagesAndConfirm(refs: ImageRef[]): Promise<void> {
   console.log(chalk.grey.italic('Verifying image attestations...'));
   const { allVerified } = await preflightVerifyImages(refs);
 
-  const message = allVerified
-    ? 'All attestations verified. Continue with deploy?'
-    : chalk.red.bold(
-        'One or more images FAILED attestation verify. Continue with deploy anyway?',
-      );
+  if (allVerified) return;
 
   const shouldContinue = await confirm({
-    message,
-    default: allVerified,
+    message: chalk.red.bold(
+      'One or more images FAILED attestation verify. Continue with deploy anyway?',
+    ),
+    default: false,
   });
 
   if (!shouldContinue) {

--- a/typescript/infra/src/utils/attestation.ts
+++ b/typescript/infra/src/utils/attestation.ts
@@ -1,0 +1,145 @@
+import chalk from 'chalk';
+import { execSync } from 'child_process';
+
+const DEFAULT_REPO = 'hyperlane-xyz/hyperlane-monorepo';
+
+export type AttestationStatus =
+  | {
+      verified: true;
+      finishedOn?: Date;
+      ageMs?: number;
+    }
+  | {
+      verified: false;
+      reason: string;
+    };
+
+export interface ImageRef {
+  component: string;
+  image: string; // e.g. ghcr.io/hyperlane-xyz/hyperlane-agent
+  tag: string;
+}
+
+export async function verifyImageAttestation({
+  image,
+  tag,
+  repo = DEFAULT_REPO,
+}: {
+  image: string;
+  tag: string;
+  repo?: string;
+}): Promise<AttestationStatus> {
+  const ref = `oci://${image}:${tag}`;
+  try {
+    const raw = execSync(
+      `gh attestation verify ${ref} --repo ${repo} --format json`,
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    ).toString();
+
+    const finishedOn = extractFinishedOn(raw);
+    if (!finishedOn) {
+      return { verified: true };
+    }
+    return {
+      verified: true,
+      finishedOn,
+      ageMs: Date.now() - finishedOn.getTime(),
+    };
+  } catch (err: unknown) {
+    return { verified: false, reason: extractErrorMessage(err) };
+  }
+}
+
+function extractErrorMessage(err: unknown): string {
+  if (typeof err !== 'object' || err === null) {
+    return err instanceof Error ? err.message : 'unknown error';
+  }
+  const stderr = 'stderr' in err ? String(err.stderr ?? '').trim() : '';
+  const stdout = 'stdout' in err ? String(err.stdout ?? '').trim() : '';
+  const message = err instanceof Error ? err.message : '';
+  return stderr || stdout || message || 'unknown error';
+}
+
+function extractFinishedOn(rawJson: string): Date | undefined {
+  try {
+    const parsed = JSON.parse(rawJson);
+    const entries = Array.isArray(parsed) ? parsed : [parsed];
+    for (const entry of entries) {
+      const statement = entry?.verificationResult?.statement ?? entry?.statement;
+      const finishedOn =
+        statement?.predicate?.runDetails?.metadata?.finishedOn ??
+        statement?.predicate?.metadata?.buildFinishedOn;
+      if (typeof finishedOn === 'string') {
+        const d = new Date(finishedOn);
+        if (!isNaN(d.getTime())) return d;
+      }
+    }
+  } catch {
+    // ignore - treated as "verified but age unknown"
+  }
+  return undefined;
+}
+
+function formatAge(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  const d = Math.floor(s / 86400);
+  const h = Math.floor((s % 86400) / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+export function printAttestationStatus(ref: ImageRef, status: AttestationStatus): void {
+  const imageStr = `${ref.image}:${ref.tag}`;
+  if (status.verified) {
+    console.log(
+      chalk.green(`✓ ${chalk.bold(ref.component)} attestation verified: ${imageStr}`),
+    );
+    if (status.finishedOn && status.ageMs != null) {
+      console.log(
+        chalk.gray(
+          `  built: ${status.finishedOn.toISOString()}  (age: ${formatAge(status.ageMs)})`,
+        ),
+      );
+    } else {
+      console.log(chalk.gray('  build age: unknown (could not parse provenance)'));
+    }
+  } else {
+    const bar = '!'.repeat(72);
+    console.log('');
+    console.log(chalk.red.bold(bar));
+    console.log(
+      chalk.red.bold(`ATTESTATION VERIFY FAILED for ${ref.component} (${imageStr})`),
+    );
+    console.log(
+      chalk.red.bold(
+        'Image may not have been built by this repo\'s CI. Supply-chain risk.',
+      ),
+    );
+    console.log(chalk.red(`reason: ${status.reason.split('\n')[0]}`));
+    console.log(chalk.red.bold(bar));
+    console.log('');
+  }
+}
+
+export async function preflightVerifyImages(
+  refs: ImageRef[],
+): Promise<{ allVerified: boolean; results: Array<{ ref: ImageRef; status: AttestationStatus }> }> {
+  const seen = new Set<string>();
+  const results: Array<{ ref: ImageRef; status: AttestationStatus }> = [];
+  let allVerified = true;
+
+  for (const ref of refs) {
+    const key = `${ref.image}:${ref.tag}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const status = await verifyImageAttestation({ image: ref.image, tag: ref.tag });
+    printAttestationStatus(ref, status);
+    results.push({ ref, status });
+    if (!status.verified) allVerified = false;
+  }
+
+  return { allVerified, results };
+}

--- a/typescript/infra/src/utils/attestation.ts
+++ b/typescript/infra/src/utils/attestation.ts
@@ -67,7 +67,7 @@ function isNodeErrorCode(err: unknown, code: string): boolean {
     typeof err === 'object' &&
     err !== null &&
     'code' in err &&
-    (err as { code: unknown }).code === code
+    err.code === code
   );
 }
 
@@ -131,7 +131,7 @@ function extractFinishedOn(rawJson: string): FinishedOnResult {
       for (const t of tlogEntries) {
         const raw =
           typeof t === 'object' && t !== null && 'integratedTime' in t
-            ? (t as { integratedTime: unknown }).integratedTime
+            ? t.integratedTime
             : undefined;
         const seconds =
           typeof raw === 'string'

--- a/typescript/infra/src/utils/attestation.ts
+++ b/typescript/infra/src/utils/attestation.ts
@@ -1,6 +1,9 @@
 import { confirm } from '@inquirer/prompts';
 import chalk from 'chalk';
-import { execSync } from 'child_process';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileP = promisify(execFile);
 
 const DEFAULT_REPO = 'hyperlane-xyz/hyperlane-monorepo';
 const YOUNG_BUILD_THRESHOLD_MS = 60 * 60 * 1000; // 1h
@@ -33,12 +36,13 @@ export async function verifyImageAttestation({
 }): Promise<AttestationStatus> {
   const ref = `oci://${image}:${tag}`;
   try {
-    const raw = execSync(
-      `gh attestation verify ${ref} --repo ${repo} --format json`,
-      { stdio: ['ignore', 'pipe', 'pipe'] },
-    ).toString();
+    const { stdout } = await execFileP(
+      'gh',
+      ['attestation', 'verify', ref, '--repo', repo, '--format', 'json'],
+      { maxBuffer: 10 * 1024 * 1024 },
+    );
 
-    const finishedOn = extractFinishedOn(raw);
+    const finishedOn = extractFinishedOn(stdout);
     if (!finishedOn) {
       return { verified: true };
     }
@@ -205,19 +209,26 @@ export async function preflightVerifyImages(refs: ImageRef[]): Promise<{
   allVerified: boolean;
   results: Array<{ ref: ImageRef; status: AttestationStatus }>;
 }> {
+  const unique: ImageRef[] = [];
   const seen = new Set<string>();
-  const results: Array<{ ref: ImageRef; status: AttestationStatus }> = [];
-  let allVerified = true;
-
   for (const ref of refs) {
     const key = `${ref.image}:${ref.tag}`;
     if (seen.has(key)) continue;
     seen.add(key);
+    unique.push(ref);
+  }
 
-    const status = await verifyImageAttestation({
-      image: ref.image,
-      tag: ref.tag,
-    });
+  const statuses = await Promise.all(
+    unique.map((ref) =>
+      verifyImageAttestation({ image: ref.image, tag: ref.tag }),
+    ),
+  );
+
+  const results: Array<{ ref: ImageRef; status: AttestationStatus }> = [];
+  let allVerified = true;
+  for (let i = 0; i < unique.length; i++) {
+    const ref = unique[i];
+    const status = statuses[i];
     printAttestationStatus(ref, status);
     results.push({ ref, status });
     if (!status.verified) allVerified = false;

--- a/typescript/infra/src/utils/attestation.ts
+++ b/typescript/infra/src/utils/attestation.ts
@@ -13,6 +13,7 @@ export type AttestationStatus =
       verified: true;
       finishedOn?: Date;
       ageMs?: number;
+      ageUnknownReason?: string;
     }
   | {
       verified: false;
@@ -42,23 +43,37 @@ export async function verifyImageAttestation({
       { maxBuffer: 10 * 1024 * 1024 },
     );
 
-    const finishedOn = extractFinishedOn(stdout);
-    if (!finishedOn) {
-      return { verified: true };
+    const { date, reason } = extractFinishedOn(stdout);
+    if (!date) {
+      return { verified: true, ageUnknownReason: reason };
     }
     return {
       verified: true,
-      finishedOn,
-      ageMs: Date.now() - finishedOn.getTime(),
+      finishedOn: date,
+      ageMs: Date.now() - date.getTime(),
     };
   } catch (err: unknown) {
+    if (isNodeErrorCode(err, 'ENOENT')) {
+      throw new Error(
+        'gh CLI not found on PATH — install from https://cli.github.com to run attestation preflight. (This is a tooling error, not an image problem.)',
+      );
+    }
     return { verified: false, reason: extractErrorMessage(err) };
   }
 }
 
+function isNodeErrorCode(err: unknown, code: string): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === code
+  );
+}
+
 function extractErrorMessage(err: unknown): string {
   if (typeof err !== 'object' || err === null) {
-    return err instanceof Error ? err.message : 'unknown error';
+    return String(err);
   }
   const stderr = 'stderr' in err ? String(err.stderr ?? '').trim() : '';
   const stdout = 'stdout' in err ? String(err.stdout ?? '').trim() : '';
@@ -66,58 +81,75 @@ function extractErrorMessage(err: unknown): string {
   return stderr || stdout || message || 'unknown error';
 }
 
-function extractFinishedOn(rawJson: string): Date | undefined {
-  try {
-    const parsed = JSON.parse(rawJson);
-    const entries = Array.isArray(parsed) ? parsed : [parsed];
-    for (const entry of entries) {
-      // 1. SLSA provenance predicate (if present — not populated by
-      //    GitHub's attest-build-provenance, but other producers may)
-      const statementCandidates: unknown[] = [
-        entry?.verificationResult?.statement,
-        entry?.statement,
-      ];
-      const dssePayload =
-        entry?.attestation?.bundle?.dsseEnvelope?.payload ??
-        entry?.bundle?.dsseEnvelope?.payload;
-      if (typeof dssePayload === 'string') {
-        try {
-          statementCandidates.push(
-            JSON.parse(Buffer.from(dssePayload, 'base64').toString('utf8')),
-          );
-        } catch {
-          // ignore, next candidate
-        }
-      }
-      for (const c of statementCandidates) {
-        const date = readFinishedOn(c);
-        if (date) return date;
-      }
+interface FinishedOnResult {
+  date?: Date;
+  reason?: string;
+}
 
-      // 2. Rekor transparency-log integratedTime — when the attestation
-      //    was signed (typically within seconds of build completion).
-      const tlogEntries =
-        entry?.attestation?.bundle?.verificationMaterial?.tlogEntries ??
-        entry?.bundle?.verificationMaterial?.tlogEntries;
-      if (Array.isArray(tlogEntries)) {
-        for (const t of tlogEntries) {
-          const raw = t?.integratedTime;
-          const seconds =
-            typeof raw === 'string'
-              ? Number(raw)
-              : typeof raw === 'number'
-                ? raw
-                : NaN;
-          if (Number.isFinite(seconds) && seconds > 0) {
-            return new Date(seconds * 1000);
-          }
+function extractFinishedOn(rawJson: string): FinishedOnResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch (err) {
+    return {
+      reason: `JSON parse failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const entries = Array.isArray(parsed) ? parsed : [parsed];
+  for (const entry of entries) {
+    // 1. SLSA provenance predicate (if present — not populated by
+    //    GitHub's attest-build-provenance, but other producers may)
+    const statementCandidates: unknown[] = [
+      pickPath(entry, [['verificationResult', 'statement'], ['statement']]),
+    ];
+    const dssePayload = pickPath(entry, [
+      ['attestation', 'bundle', 'dsseEnvelope', 'payload'],
+      ['bundle', 'dsseEnvelope', 'payload'],
+    ]);
+    if (typeof dssePayload === 'string') {
+      try {
+        statementCandidates.push(
+          JSON.parse(Buffer.from(dssePayload, 'base64').toString('utf8')),
+        );
+      } catch {
+        // ignore, fall through to next candidate / tlog fallback
+      }
+    }
+    for (const c of statementCandidates) {
+      const date = readFinishedOn(c);
+      if (date) return { date };
+    }
+
+    // 2. Rekor transparency-log integratedTime — when the attestation
+    //    was signed (typically within seconds of build completion).
+    const tlogEntries = pickPath(entry, [
+      ['attestation', 'bundle', 'verificationMaterial', 'tlogEntries'],
+      ['bundle', 'verificationMaterial', 'tlogEntries'],
+    ]);
+    if (Array.isArray(tlogEntries)) {
+      for (const t of tlogEntries) {
+        const raw =
+          typeof t === 'object' && t !== null && 'integratedTime' in t
+            ? (t as { integratedTime: unknown }).integratedTime
+            : undefined;
+        const seconds =
+          typeof raw === 'string'
+            ? Number(raw)
+            : typeof raw === 'number'
+              ? raw
+              : NaN;
+        if (Number.isFinite(seconds) && seconds > 0) {
+          return { date: new Date(seconds * 1000) };
         }
       }
     }
-  } catch {
-    // ignore - treated as "verified but age unknown"
   }
-  return undefined;
+
+  return {
+    reason:
+      'no finishedOn in SLSA predicate and no Rekor integratedTime in bundle',
+  };
 }
 
 function readFinishedOn(statement: unknown): Date | undefined {
@@ -141,6 +173,8 @@ function pickPath(root: unknown, paths: string[][]): unknown {
         node = undefined;
         break;
       }
+      // CAST: safe after typeof === 'object' && !== null guard above;
+      // TS does not narrow unknown to an indexable shape on its own.
       node = (node as Record<string, unknown>)[key];
     }
     if (node !== undefined) return node;
@@ -181,9 +215,8 @@ export function printAttestationStatus(
         console.log(chalk.gray(line));
       }
     } else {
-      console.log(
-        chalk.gray('  build age: unknown (could not parse provenance)'),
-      );
+      const why = status.ageUnknownReason ?? 'no timestamp in provenance';
+      console.log(chalk.gray(`  build age: unknown (${why})`));
     }
   } else {
     const bar = '!'.repeat(72);
@@ -209,28 +242,52 @@ export async function preflightVerifyImages(refs: ImageRef[]): Promise<{
   allVerified: boolean;
   results: Array<{ ref: ImageRef; status: AttestationStatus }>;
 }> {
-  const unique: ImageRef[] = [];
-  const seen = new Set<string>();
+  // Group refs by image:tag so that when multiple components share a
+  // tag (common during coordinated agent releases), we verify once but
+  // still surface every component name in the printed status line.
+  const groups = new Map<
+    string,
+    { components: string[]; image: string; tag: string; refs: ImageRef[] }
+  >();
   for (const ref of refs) {
     const key = `${ref.image}:${ref.tag}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    unique.push(ref);
+    const existing = groups.get(key);
+    if (existing) {
+      existing.components.push(ref.component);
+      existing.refs.push(ref);
+    } else {
+      groups.set(key, {
+        components: [ref.component],
+        image: ref.image,
+        tag: ref.tag,
+        refs: [ref],
+      });
+    }
   }
 
+  const groupList = [...groups.values()];
   const statuses = await Promise.all(
-    unique.map((ref) =>
-      verifyImageAttestation({ image: ref.image, tag: ref.tag }),
+    groupList.map((g) =>
+      verifyImageAttestation({ image: g.image, tag: g.tag }),
     ),
   );
 
   const results: Array<{ ref: ImageRef; status: AttestationStatus }> = [];
   let allVerified = true;
-  for (let i = 0; i < unique.length; i++) {
-    const ref = unique[i];
+  for (let i = 0; i < groupList.length; i++) {
+    const group = groupList[i];
     const status = statuses[i];
-    printAttestationStatus(ref, status);
-    results.push({ ref, status });
+    printAttestationStatus(
+      {
+        component: group.components.join(', '),
+        image: group.image,
+        tag: group.tag,
+      },
+      status,
+    );
+    for (const ref of group.refs) {
+      results.push({ ref, status });
+    }
     if (!status.verified) allVerified = false;
   }
 

--- a/typescript/infra/src/utils/attestation.ts
+++ b/typescript/infra/src/utils/attestation.ts
@@ -67,7 +67,9 @@ function extractFinishedOn(rawJson: string): Date | undefined {
     const parsed = JSON.parse(rawJson);
     const entries = Array.isArray(parsed) ? parsed : [parsed];
     for (const entry of entries) {
-      const candidates: unknown[] = [
+      // 1. SLSA provenance predicate (if present — not populated by
+      //    GitHub's attest-build-provenance, but other producers may)
+      const statementCandidates: unknown[] = [
         entry?.verificationResult?.statement,
         entry?.statement,
       ];
@@ -76,16 +78,36 @@ function extractFinishedOn(rawJson: string): Date | undefined {
         entry?.bundle?.dsseEnvelope?.payload;
       if (typeof dssePayload === 'string') {
         try {
-          candidates.push(
+          statementCandidates.push(
             JSON.parse(Buffer.from(dssePayload, 'base64').toString('utf8')),
           );
         } catch {
           // ignore, next candidate
         }
       }
-      for (const c of candidates) {
+      for (const c of statementCandidates) {
         const date = readFinishedOn(c);
         if (date) return date;
+      }
+
+      // 2. Rekor transparency-log integratedTime — when the attestation
+      //    was signed (typically within seconds of build completion).
+      const tlogEntries =
+        entry?.attestation?.bundle?.verificationMaterial?.tlogEntries ??
+        entry?.bundle?.verificationMaterial?.tlogEntries;
+      if (Array.isArray(tlogEntries)) {
+        for (const t of tlogEntries) {
+          const raw = t?.integratedTime;
+          const seconds =
+            typeof raw === 'string'
+              ? Number(raw)
+              : typeof raw === 'number'
+                ? raw
+                : NaN;
+          if (Number.isFinite(seconds) && seconds > 0) {
+            return new Date(seconds * 1000);
+          }
+        }
       }
     }
   } catch {

--- a/typescript/infra/src/utils/consts.ts
+++ b/typescript/infra/src/utils/consts.ts
@@ -13,6 +13,7 @@ export const NODE_SERVICE_NAMES = {
   CCIP_SERVER: 'ccip-server',
   KEYFUNDER: 'keyfunder',
   RELAYER: 'relayer',
+  FEE_QUOTING: 'fee-quoting',
 } as const;
 /**
  * Get validator alias from defaultMultisigConfigs if available


### PR DESCRIPTION
## Summary

Ship-grade provenance for every Docker image we publish, plus preflight verification in every infra deploy script.

### Producer (CI)

All three GHCR image workflows now emit a GitHub-signed, Sigstore-verifiable SLSA build-provenance attestation attached to the pushed image digest as an OCI referrer:

- `.github/workflows/rust-docker.yml` → `ghcr.io/hyperlane-xyz/hyperlane-agent` (relayer, validator, scraper)
- `.github/workflows/monorepo-docker.yml` → `ghcr.io/hyperlane-xyz/hyperlane-monorepo`
- `.github/workflows/node-services-docker.yml` → `ghcr.io/hyperlane-xyz/hyperlane-node-services`

Each workflow now:
1. Declares `attestations: write`.
2. Enables `provenance: mode=max` + `sbom: true` in `depot/build-push-action`.
3. Runs `actions/attest-build-provenance@v2` after push (gated on the same condition as `push`).

No long-lived signing keys — keyless via the workflow's OIDC token.

### Consumer (infra deploy)

Every `typescript/infra/scripts/` entry point that installs an image from `config/docker.ts` now runs attestation verify as a preflight and prints build age:

- `deploy-agents.ts` — `hyperlane-agent`, filtered by `--role` so a validator-only deploy only verifies the validator image
- `deploy-key-funder.ts` — `hyperlane-node-services`
- `deploy-rebalancer.ts` — `hyperlane-node-services`
- `deploy-warp-monitor.ts` — `hyperlane-node-services`
- `deploy-check-warp-deploy.ts` (cronjob) — `hyperlane-monorepo`
- `deploy-fee-quoting.ts` — `hyperlane-node-services`

Centralised in `typescript/infra/src/utils/attestation.ts`:

- `verifyImageAttestation` shells to `gh attestation verify ... --format json` (promisified `execFile`).
- `preflightVerifyImages` dedupes by `image:tag` and runs verifies concurrently via `Promise.all`; prints status in input order after all settle (cuts full agent-deploy preflight from sequential 3× to one round-trip).
- `verifyImagesAndConfirm` is the single entry point used by deploy scripts.
- Build age comes from SLSA `predicate.runDetails.metadata.finishedOn` when present, with a fallback to the Rekor transparency-log `integratedTime` from the bundle's verification material (GitHub's `attest-build-provenance` doesn't populate `finishedOn` in the predicate).

### UX per the spec discussed on this PR

- **Verify succeeds** → green check + `built: <iso>  (age: <d/h/m>)` in grey. No prompt, deploy continues.
- **Verify succeeds but build is younger than 1h** → age line in yellow with a soak-period hint. Still no prompt.
- **Verify fails** → red-bold 72-char banner, "Image may not have been built by this repo's CI. Supply-chain risk.", the `gh` error reason, then an explicit prompt "Continue with deploy anyway?" with `default: false`. The user can still say yes.

Age is informational only — never a gate.

### Fee-quoting cleanup (drive-by)

The fee-quoting service is bundled into the `hyperlane-node-services` image (see `typescript/Dockerfile` and `docker-entrypoint.sh`), but `FeeQuotingHelmManager` and the chart were still pointing at a standalone `hyperlane-fee-quoting` image that no workflow in this repo produces. Fixed:

- `src/fee-quoting/helm.ts` → `DockerImageRepos.NODE_SERVICES`
- `helm/fee-quoting/values.yaml` default repo → `hyperlane-node-services`
- `helm/fee-quoting` deployment sets `SERVICE_NAME=fee-quoting` so the node-services entrypoint selects the right bundle
- Dropped `DockerImageNames.FEE_QUOTING` (no remaining callers)
- Documented `fee-quoting` in the `SERVICE_NAME` table in `docs/docker-image-policy.md`

### Docs

`docs/docker-image-policy.md` gained a **Verification** section with:

- `gh attestation verify` command
- `cosign verify-attestation` command (with certificate-identity-regexp pinning the producing workflow)
- a soak-time gate snippet reading `finishedOn` from SLSA provenance
- a note on digest-pinned deploys

## Test plan

- [ ] Confirm a push to this branch triggers each workflow and the `Attest build provenance` step succeeds for `hyperlane-agent` / `hyperlane-monorepo` / `hyperlane-node-services`
- [ ] Pull a built image and run `gh attestation verify oci://... --repo hyperlane-xyz/hyperlane-monorepo` locally
- [ ] Dry-run `deploy-agents.ts -e mainnet3 --role validator` — verify only the validator image gets checked, green + age line prints, no prompt
- [ ] Dry-run with a deliberately wrong tag — confirm the red-bold banner renders and the prompt defaults to no
- [ ] Dry-run `deploy-fee-quoting.ts` against mainnet3 — confirm verify passes (or fails with a clear reason until the first node-services image with a tag matching `mainnetDockerTags.feeQuoting` is resigned on main)
- [ ] Confirm fork PRs do not attempt to attest (no pushed image)

## Follow-ups (out of scope)

- Repoint any consumer tooling outside this repo at digest-pinned deploys and the verification commands in `docs/docker-image-policy.md`.
- Optional `cosign sign` layer for consumers that only understand bare image signatures (not attestations).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI image build outputs and adds a new attestation-verification preflight to multiple deploy scripts; failures or missing `gh` CLI can now block deployments unless explicitly overridden.
> 
> **Overview**
> Adds **SLSA build provenance + SBOM generation** to the three Docker publish workflows by enabling `provenance: mode=max`, `sbom: true`, granting `attestations: write`, and pushing an OCI provenance attestation via `actions/attest-build-provenance@v2` after successful image pushes.
> 
> Introduces a shared TypeScript utility (`infra/src/utils/attestation.ts`) that runs `gh attestation verify` for one or more image tags, prints build age, dedupes shared tags, and prompts before continuing when verification fails; this preflight is now invoked by multiple infra deploy entrypoints (agents, node-services-based deploys, and check-warp-deploy).
> 
> Cleans up fee-quoting deployment to run from the unified `hyperlane-node-services` image by updating Helm defaults/values, setting `SERVICE_NAME=fee-quoting`, adjusting `FeeQuotingHelmManager`, removing the standalone `hyperlane-fee-quoting` image name, and documenting `fee-quoting` plus verification guidance in `docs/docker-image-policy.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5db6572b6201da044adad3377b446856c8b7958e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->