### PR TITLE
fix(validator): remove rusoto-based AWS region validation

### DIFF
--- a/rust/main/agents/validator/src/settings.rs
+++ b/rust/main/agents/validator/src/settings.rs
@@ -293,12 +293,12 @@ fn parse_checkpoint_syncer(syncer: ValueParser) -> ConfigResult<CheckpointSyncer
                 .parse_string()
                 .end()
                 .map(str::to_owned);
-            // Using rusoto_core::Region just to get some input validation
-            let region: Option<rusoto_core::Region> = syncer
+            let region: Option<String> = syncer
                 .chain(&mut err)
                 .get_key("region")
-                .parse_from_str("Expected aws region")
-                .end();
+                .parse_string()
+                .end()
+                .map(str::to_owned);
             let folder = syncer
                 .chain(&mut err)
                 .get_opt_key("folder")
@@ -309,7 +309,7 @@ fn parse_checkpoint_syncer(syncer: ValueParser) -> ConfigResult<CheckpointSyncer
             cfg_unwrap_all!(&syncer.cwp, err: [bucket, region]);
             err.into_result(CheckpointSyncerConf::S3 {
                 bucket,
-                region: Region::new(region.name().to_owned()),
+                region: Region::new(region),
                 folder,
             })
         }

--- a/rust/main/hyperlane-base/src/settings/checkpoint_syncer.rs
+++ b/rust/main/hyperlane-base/src/settings/checkpoint_syncer.rs
@@ -2,7 +2,7 @@ use std::{env, path::PathBuf};
 
 use aws_config::Region;
 use core::str::FromStr;
-use eyre::{eyre, Context, Report, Result};
+use eyre::{eyre, Report, Result};
 use prometheus::IntGauge;
 use tracing::error;
 use ya_gcp::{AuthFlow, ServiceAccountAuth};
@@ -79,15 +79,7 @@ impl FromStr for CheckpointSyncerConf {
                 Ok(CheckpointSyncerConf::S3 {
                     bucket: bucket.into(),
                     folder,
-                    // Wildly, aws_config doesn't provide any client-side way to validate a region string, so while
-                    // we still have Rusoto around we just use that to validate the region string :)
-                    region: aws_config::Region::new(
-                        region
-                            .parse::<rusoto_core::Region>()
-                            .context("Invalid region when parsing storage location")?
-                            .name()
-                            .to_owned(),
-                    ),
+                    region: aws_config::Region::new(region.to_owned()),
                 })
             }
             "file" => Ok(CheckpointSyncerConf::LocalStorage {
@@ -288,6 +280,24 @@ mod test {
                 );
             }
             _ => panic!("Expected a reorg event error"),
+        }
+    }
+
+    #[test]
+    fn test_parse_s3_storage_location_with_new_region() {
+        use super::*;
+        let conf = CheckpointSyncerConf::from_str("s3://my-bucket/eu-central-2/folder").unwrap();
+        match conf {
+            CheckpointSyncerConf::S3 {
+                bucket,
+                folder,
+                region,
+            } => {
+                assert_eq!(bucket, "my-bucket");
+                assert_eq!(folder.as_deref(), Some("folder"));
+                assert_eq!(region.as_ref(), "eu-central-2");
+            }
+            _ => panic!("Expected S3 checkpoint syncer"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Validators running in newer AWS regions fail to start with:

> Not a valid AWS region: eu-central-2

The error came from `rusoto_core` 0.48.0, which hardcoded the set of known AWS regions. Rusoto is abandoned and never shipped support for regions launched after ~late 2022 (`eu-central-2` / Zurich, `ap-south-2`, `il-central-1`, `me-central-1`, `mx-central-1`, `ca-west-1`, `ap-southeast-5/7`, etc.).

The S3 client is built via `aws_config::Region::new(..)`, which is an intentional pass-through newtype (`pub struct Region(Cow<'static, str>)`) — the AWS SDK deliberately doesn't validate region strings because new regions launch regularly and private partitions have non-public ones. A bogus region surfaces at the first API call with a clear endpoint error.

So there's no need for client-side validation at all. This PR drops the rusoto check and passes the string straight through.

### Changes

- `hyperlane-base/src/settings/checkpoint_syncer.rs` — remove `rusoto_core::Region` parsing from the `s3://bucket/region/folder` URL parser (relayer side).
- `agents/validator/src/settings.rs` — remove `rusoto_core::Region` parsing from the validator's `checkpointSyncer.region` config field.
- Added a regression test: `s3://my-bucket/eu-central-2/folder` parses successfully.

The `rusoto_core` / `rusoto_kms` usage in `hyperlane-base/src/settings/signers.rs` for KMS signing is untouched — that path uses the `Region` enum to build KMS endpoints and would be a larger migration.

## Test plan

- [x] `cargo build -p hyperlane-base -p validator`
- [x] `cargo test -p hyperlane-base --lib settings::checkpoint_syncer`
- [x] `cargo clippy -p hyperlane-base -p validator -- -D warnings`
- [ ] Validator deploy in `eu-central-2` succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only relax S3 region parsing/validation for checkpoint syncer configs and adds a small unit test, without altering syncer behavior beyond accepting previously-rejected region names.
> 
> **Overview**
> Allows validators/agents to use **new AWS regions** (e.g. `eu-central-2`) for S3-backed checkpoint syncing by removing `rusoto_core::Region`-based parsing and treating the region as an opaque string passed to `aws_config::Region::new(..)`.
> 
> Updates both the validator config parser (`checkpointSyncer.region`) and `s3://bucket/region[/folder]` storage-location parsing, and adds a unit test asserting the new region string is preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3689b94740c91121d0dab51fe285bc2284e90c91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->