### PR TITLE
fix(agents): remove rusoto-based AWS region validation for signer config

### DIFF
--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -456,8 +456,9 @@ fn parse_signer(signer: ValueParser) -> ConfigResult<SignerConf> {
             let region = signer
                 .chain(&mut err)
                 .get_key("region")
-                .parse_from_str("Expected AWS region")
-                .unwrap_or_default();
+                .parse_string()
+                .unwrap_or_default()
+                .to_owned();
             err.into_result(SignerConf::Aws { id, region })
         }};
         (cosmosKey) => {{

--- a/rust/main/hyperlane-base/src/settings/signers.rs
+++ b/rust/main/hyperlane-base/src/settings/signers.rs
@@ -7,6 +7,7 @@ use ethers::utils::hex::ToHex;
 use eyre::{bail, Context, Report};
 use rusoto_core::Region;
 use rusoto_kms::KmsClient;
+use std::str::FromStr;
 use tracing::instrument;
 
 use hyperlane_core::{AccountAddressType, H256};
@@ -15,6 +16,16 @@ use super::aws_credentials::AwsChainCredentialsProvider;
 use crate::types::utils;
 
 const AWS_SIGNER_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Resolve an AWS region string into a `rusoto_core::Region` without relying on
+/// rusoto's `FromStr` allowlist, which rejects regions added after rusoto was
+/// last updated (e.g. `eu-central-2`).
+fn resolve_kms_region(region: &str) -> Region {
+    Region::from_str(region).unwrap_or_else(|_| Region::Custom {
+        name: region.to_owned(),
+        endpoint: format!("https://kms.{region}.amazonaws.com"),
+    })
+}
 
 /// Signer types
 #[derive(Default, Debug, Clone)]
@@ -30,7 +41,7 @@ pub enum SignerConf {
         /// The UUID identifying the AWS KMS Key
         id: String,
         /// The AWS region
-        region: Region,
+        region: String,
     },
     /// Cosmos Specific key
     CosmosKey {
@@ -100,7 +111,7 @@ impl BuildableWithSignerConf for hyperlane_ethereum::Signers {
                     .map_err(|err| eyre::eyre!(err.to_string()))?;
                 let client = KmsClient::new_with_client(
                     rusoto_core::Client::new_with(AwsChainCredentialsProvider::new(), http_client),
-                    region.clone(),
+                    resolve_kms_region(region),
                 );
                 let signer = AwsSigner::new(client, id, 0, Some(AWS_SIGNER_TIMEOUT)).await?;
                 hyperlane_ethereum::Signers::Aws(signer)
@@ -142,7 +153,7 @@ impl BuildableWithSignerConf for hyperlane_tron::TronSigner {
                     .map_err(|err| eyre::eyre!(err.to_string()))?;
                 let client = KmsClient::new_with_client(
                     rusoto_core::Client::new_with(AwsChainCredentialsProvider::new(), http_client),
-                    region.clone(),
+                    resolve_kms_region(region),
                 );
                 let signer = AwsSigner::new(client, id, 0, Some(AWS_SIGNER_TIMEOUT)).await?;
                 Ok(hyperlane_tron::TronSigner::Aws(signer))
@@ -323,8 +334,27 @@ impl ChainSigner for hyperlane_aleo::AleoSigner {
 mod tests {
     use ethers::{signers::LocalWallet, utils::hex};
     use hyperlane_core::{AccountAddressType, Encode, H256};
+    use rusoto_core::Region;
 
+    use super::resolve_kms_region;
     use crate::settings::{ChainSigner, SignerConf};
+
+    #[test]
+    fn resolve_kms_region_known_region_uses_enum_variant() {
+        assert_eq!(resolve_kms_region("us-east-1"), Region::UsEast1);
+    }
+
+    #[test]
+    fn resolve_kms_region_unknown_region_uses_custom() {
+        let region = resolve_kms_region("eu-central-2");
+        match region {
+            Region::Custom { name, endpoint } => {
+                assert_eq!(name, "eu-central-2");
+                assert_eq!(endpoint, "https://kms.eu-central-2.amazonaws.com");
+            }
+            other => panic!("expected Region::Custom, got {other:?}"),
+        }
+    }
 
     #[test]
     fn address_h256_ethereum() {


### PR DESCRIPTION
## Summary

Follow-up to #8669. That PR removed rusoto's `FromStr`-backed region validation for the S3 checkpoint syncer, but the same validation remained on the agent signer config paths (`validator.region`, `chains.<chain>.signer.region`), so operators trying to use newer AWS regions like `eu-central-2` still hit:

```
config_path: chains.fluent.signer.region
error: Expected AWS region
Caused by: Not a valid AWS region: eu-central-2
```

Store `SignerConf::Aws.region` as a `String` and defer resolution to a `rusoto_core::Region` to KMS client construction. If the region name is known to rusoto we keep using the matching enum variant (which preserves endpoint behavior for AWS partitions like China / GovCloud); otherwise we synthesize a commercial-partition KMS endpoint (`https://kms.<region>.amazonaws.com`) via `Region::Custom`.

## Test plan

- [ ] `cargo test -p hyperlane-base settings::signers::tests::resolve_kms_region`
- [ ] CI clippy + cargo test
- [ ] Manual: start an agent with `--chains.<chain>.signer.region=eu-central-2` and confirm it no longer rejects parsing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches AWS KMS signer construction and config parsing; mis-resolving regions could break AWS-backed signing at runtime, but the change is localized and covered by unit tests.
> 
> **Overview**
> Agent signer config no longer rejects newer AWS region strings: `SignerConf::Aws.region` is now stored as a `String` during parsing instead of being validated/parsed into `rusoto_core::Region`.
> 
> At KMS client creation time, the code now resolves the string into a `Region`, falling back to `Region::Custom` with a synthesized `kms.<region>.amazonaws.com` endpoint when rusoto doesn’t recognize the region; adds unit tests for known vs unknown region resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e672e7b06d3e186289134e327d14529056351863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->