### PR TITLE
feat(svm-sdk): sealevel fee support warp deployments [IGNORE FOR NOW]

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ catalogs:
     chalk:
       specifier: ^5.3.0
       version: 5.6.2
+    compare-versions:
+      specifier: ^6.1.1
+      version: 6.1.1
     cosmjs-types:
       specifier: ^0.9.0
       version: 0.9.0
@@ -2244,7 +2247,7 @@ importers:
         specifier: 'catalog:'
         version: 0.7.0
       compare-versions:
-        specifier: ^6.1.1
+        specifier: 'catalog:'
         version: 6.1.1
       cosmjs-types:
         specifier: 'catalog:'
@@ -2410,6 +2413,9 @@ importers:
       '@solana/kit':
         specifier: 'catalog:'
         version: 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      compare-versions:
+        specifier: 'catalog:'
+        version: 6.1.1
     devDependencies:
       '@hyperlane-xyz/tsconfig':
         specifier: workspace:^
@@ -2766,7 +2772,7 @@ importers:
         version: 2.2.1(typescript@6.0.2)
       '@rainbow-me/rainbowkit':
         specifier: ^2.2.0
-        version: 2.2.9(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.2)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))(wagmi@2.19.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.10)(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12))
+        version: 2.2.9(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.2)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.10)(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
       '@solana/wallet-adapter-react':
         specifier: ^0.15.32
         version: 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@6.0.2)
@@ -2793,7 +2799,7 @@ importers:
         version: 1.1.13(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@wagmi/core':
         specifier: ^2.12.26
-        version: 2.22.1(@tanstack/query-core@5.90.10)(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))
+        version: 2.22.1(@tanstack/query-core@5.90.10)(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -2811,13 +2817,13 @@ importers:
         version: 7.6.4
       starknetkit:
         specifier: 2.6.1
-        version: 2.6.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(starknet@7.6.4)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+        version: 2.6.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(starknet@7.6.4)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       viem:
         specifier: 'catalog:'
-        version: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+        version: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       wagmi:
         specifier: ^2.12.26
-        version: 2.19.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.10)(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
+        version: 2.19.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.10)(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       yaml:
         specifier: 'catalog:'
         version: 2.4.5
@@ -18886,16 +18892,16 @@ snapshots:
 
   '@balena/dockerignore@1.0.2': {}
 
-  '@base-org/account@2.4.0(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)':
+  '@base-org/account@2.4.0(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@coinbase/cdp-sdk': 1.38.6(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@6.0.2)(zod@4.1.12)
+      ox: 0.6.9(typescript@6.0.2)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -19283,15 +19289,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@coinbase/wallet-sdk@4.3.6(@types/react@18.3.27)(bufferutil@4.0.9)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@coinbase/wallet-sdk@4.3.6(@types/react@18.3.27)(bufferutil@4.0.9)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@6.0.2)(zod@4.1.12)
+      ox: 0.6.9(typescript@6.0.2)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -20651,11 +20657,11 @@ snapshots:
     optionalDependencies:
       '@trufflesuite/bigint-buffer': 1.1.9
 
-  '@gemini-wallet/core@0.3.2(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))':
+  '@gemini-wallet/core@0.3.2(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       '@metamask/rpc-errors': 7.0.2
       eventemitter3: 5.0.1
-      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -22704,7 +22710,7 @@ snapshots:
       reflect-metadata: 0.1.13
       secp256k1: 5.0.0
 
-  '@rainbow-me/rainbowkit@2.2.9(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.2)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))(wagmi@2.19.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.10)(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12))':
+  '@rainbow-me/rainbowkit@2.2.9(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.2)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.10)(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))':
     dependencies:
       '@tanstack/react-query': 5.90.10(react@18.3.1)
       '@vanilla-extract/css': 1.17.3(babel-plugin-macros@3.1.0)
@@ -22716,8 +22722,8 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.6.2(@types/react@18.3.27)(react@18.3.1)
       ua-parser-js: 1.0.41
-      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      wagmi: 2.19.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.10)(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
+      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      wagmi: 2.19.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.10)(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
     transitivePeerDependencies:
       - '@types/react'
       - babel-plugin-macros
@@ -23774,24 +23780,24 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-common@1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@reown/appkit-common@1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@reown/appkit-controllers@1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@18.3.27)(react@18.3.1)
-      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -23820,12 +23826,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-pay@1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@reown/appkit-pay@1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-controllers': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-ui': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-utils': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.27)(react@18.3.1))(zod@4.1.12)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-ui': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-utils': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.27)(react@18.3.1))(zod@3.25.76)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@18.3.27)(react@18.3.1)
     transitivePeerDependencies:
@@ -23860,12 +23866,12 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@reown/appkit-scaffold-ui@1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.27)(react@18.3.1))(zod@4.1.12)':
+  '@reown/appkit-scaffold-ui@1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.27)(react@18.3.1))(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-controllers': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-ui': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-utils': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.27)(react@18.3.1))(zod@4.1.12)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-ui': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-utils': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.27)(react@18.3.1))(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)
       lit: 3.3.0
     transitivePeerDependencies:
@@ -23897,10 +23903,10 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-ui@1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@reown/appkit-ui@1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-controllers': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -23932,16 +23938,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.27)(react@18.3.1))(zod@4.1.12)':
+  '@reown/appkit-utils@1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.27)(react@18.3.1))(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-controllers': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-polyfills': 1.7.8
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@18.3.27)(react@18.3.1)
-      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -23981,21 +23987,21 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@reown/appkit@1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@reown/appkit@1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-controllers': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-pay': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-pay': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-scaffold-ui': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.27)(react@18.3.1))(zod@4.1.12)
-      '@reown/appkit-ui': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@reown/appkit-utils': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.27)(react@18.3.1))(zod@4.1.12)
+      '@reown/appkit-scaffold-ui': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.27)(react@18.3.1))(zod@3.25.76)
+      '@reown/appkit-ui': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-utils': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@18.3.27)(react@18.3.1))(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)
       '@walletconnect/types': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/universal-provider': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@18.3.27)(react@18.3.1)
-      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -24161,9 +24167,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -24171,10 +24177,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -26688,7 +26694,7 @@ snapshots:
       '@turnkey/webauthn-stamper': 0.6.0
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
-      '@walletconnect/sign-client': 2.23.0(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
       cross-fetch: 3.2.0
       ethers: 6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -27411,19 +27417,19 @@ snapshots:
       loupe: 2.3.7
       pretty-format: 29.7.0
 
-  '@wagmi/connectors@6.1.4(61804c4d1f8323f8201487b11f7af0d4)':
+  '@wagmi/connectors@6.1.4(2bb13527e2b287710b3783f88216a145)':
     dependencies:
-      '@base-org/account': 2.4.0(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
-      '@coinbase/wallet-sdk': 4.3.6(@types/react@18.3.27)(bufferutil@4.0.9)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@gemini-wallet/core': 0.3.2(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))
+      '@base-org/account': 2.4.0(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@18.3.27)(bufferutil@4.0.9)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@gemini-wallet/core': 0.3.2(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.10)(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))
-      '@walletconnect/ethereum-provider': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.10)(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@walletconnect/ethereum-provider': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(c64f13a653b42277346e66abe7b65712)
-      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      porto: 0.2.35(4594984c98da5efedce51a690cc328be)
+      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -27465,11 +27471,11 @@ snapshots:
       - ws
       - zod
 
-  '@wagmi/core@2.22.1(@tanstack/query-core@5.90.10)(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))':
+  '@wagmi/core@2.22.1(@tanstack/query-core@5.90.10)(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@6.0.2)
-      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.0(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     optionalDependencies:
       '@tanstack/query-core': 5.90.10
@@ -27507,7 +27513,7 @@ snapshots:
     dependencies:
       '@wallet-standard/base': 1.1.0
 
-  '@walletconnect/core@2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@walletconnect/core@2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -27521,7 +27527,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/utils': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -27551,7 +27557,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@walletconnect/core@2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -27565,7 +27571,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/utils': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -27595,7 +27601,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@walletconnect/core@2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -27609,51 +27615,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(typescript@6.0.2)(zod@4.1.12)
-      '@walletconnect/window-getters': 1.0.1
-      es-toolkit: 1.39.3
-      events: 3.3.0
-      uint8arrays: 3.1.1
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/core@2.23.0(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@walletconnect/heartbeat': 1.2.2
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/logger': 3.0.0
-      '@walletconnect/relay-api': 1.0.11
-      '@walletconnect/relay-auth': 1.1.0
-      '@walletconnect/safe-json': 1.0.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.23.0(typescript@6.0.2)(zod@3.25.76)
+      '@walletconnect/utils': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(typescript@6.0.2)(zod@3.25.76)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.39.3
       events: 3.3.0
@@ -27687,18 +27649,18 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/ethereum-provider@2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@walletconnect/ethereum-provider@2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@reown/appkit': 1.7.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/sign-client': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/sign-client': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/universal-provider': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
-      '@walletconnect/utils': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/universal-provider': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -27844,16 +27806,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@walletconnect/sign-client@2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@walletconnect/core': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/core': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/utils': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -27880,16 +27842,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@walletconnect/sign-client@2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@walletconnect/core': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/core': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/utils': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -27916,52 +27878,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@walletconnect/sign-client@2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@walletconnect/core': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/core': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 3.0.0
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(typescript@6.0.2)(zod@4.1.12)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/sign-client@2.23.0(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@walletconnect/core': 2.23.0(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/events': 1.0.1
-      '@walletconnect/heartbeat': 1.2.2
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/logger': 3.0.0
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.23.0(typescript@6.0.2)(zod@3.25.76)
+      '@walletconnect/utils': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(typescript@6.0.2)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -28108,7 +28034,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/universal-provider@2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@walletconnect/universal-provider@2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -28117,9 +28043,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/sign-client': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/utils': 2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -28148,7 +28074,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/universal-provider@2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@walletconnect/universal-provider@2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -28157,9 +28083,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/sign-client': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/utils': 2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -28188,7 +28114,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@walletconnect/utils@2.21.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -28206,7 +28132,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      viem: 2.23.2(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -28232,7 +28158,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)':
+  '@walletconnect/utils@2.21.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -28250,7 +28176,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      viem: 2.23.2(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -28276,52 +28202,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(typescript@6.0.2)(zod@4.1.12)':
-    dependencies:
-      '@msgpack/msgpack': 3.1.2
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.6
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/logger': 3.0.0
-      '@walletconnect/relay-api': 1.0.11
-      '@walletconnect/relay-auth': 1.1.0
-      '@walletconnect/safe-json': 1.0.2
-      '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))
-      '@walletconnect/window-getters': 1.0.1
-      '@walletconnect/window-metadata': 1.0.1
-      blakejs: 1.2.1
-      bs58: 6.0.0
-      detect-browser: 5.3.0
-      ox: 0.9.3(typescript@6.0.2)(zod@4.1.12)
-      uint8arrays: 3.1.1
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - db0
-      - ioredis
-      - typescript
-      - uploadthing
-      - zod
-
-  '@walletconnect/utils@2.23.0(typescript@6.0.2)(zod@3.25.76)':
+  '@walletconnect/utils@2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(typescript@6.0.2)(zod@3.25.76)':
     dependencies:
       '@msgpack/msgpack': 3.1.2
       '@noble/ciphers': 1.3.0
@@ -28500,10 +28381,10 @@ snapshots:
       typescript: 6.0.2
       zod: 3.25.76
 
-  abitype@1.0.8(typescript@6.0.2)(zod@4.1.12):
+  abitype@1.0.8(typescript@6.0.2)(zod@3.25.76):
     optionalDependencies:
       typescript: 6.0.2
-      zod: 4.1.12
+      zod: 3.25.76
 
   abitype@1.1.0(typescript@6.0.2)(zod@3.22.4):
     optionalDependencies:
@@ -28514,11 +28395,6 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.2
       zod: 3.25.76
-
-  abitype@1.1.0(typescript@6.0.2)(zod@4.1.12):
-    optionalDependencies:
-      typescript: 6.0.2
-      zod: 4.1.12
 
   abitype@1.1.2(typescript@6.0.2)(zod@3.22.4):
     optionalDependencies:
@@ -33644,28 +33520,28 @@ snapshots:
 
   outdent@0.5.0: {}
 
-  ox@0.6.7(typescript@6.0.2)(zod@4.1.12):
+  ox@0.6.7(typescript@6.0.2)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.2(typescript@6.0.2)(zod@4.1.12)
+      abitype: 1.1.2(typescript@6.0.2)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.9(typescript@6.0.2)(zod@4.1.12):
+  ox@0.6.9(typescript@6.0.2)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.2(typescript@6.0.2)(zod@4.1.12)
+      abitype: 1.1.2(typescript@6.0.2)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 6.0.2
@@ -33702,21 +33578,6 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.9.3(typescript@6.0.2)(zod@4.1.12):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.1.2(typescript@6.0.2)(zod@4.1.12)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 6.0.2
-    transitivePeerDependencies:
-      - zod
-
   ox@0.9.6(typescript@6.0.2)(zod@3.22.4):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -33741,21 +33602,6 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.1.2(typescript@6.0.2)(zod@3.25.76)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 6.0.2
-    transitivePeerDependencies:
-      - zod
-
-  ox@0.9.6(typescript@6.0.2)(zod@4.1.12):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.1.2(typescript@6.0.2)(zod@4.1.12)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 6.0.2
@@ -34179,14 +34025,14 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(c64f13a653b42277346e66abe7b65712):
+  porto@0.2.35(4594984c98da5efedce51a690cc328be):
     dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.10)(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.10)(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       hono: 4.11.4
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@6.0.2)
       ox: 0.9.14(typescript@6.0.2)(zod@4.1.12)
-      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 4.1.12
       zustand: 5.0.8(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     optionalDependencies:
@@ -34194,7 +34040,7 @@ snapshots:
       react: 18.3.1
       react-native: 0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)
       typescript: 6.0.2
-      wagmi: 2.19.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.10)(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12)
+      wagmi: 2.19.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.10)(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -35862,14 +35708,14 @@ snapshots:
       pako: 2.1.0
       ts-mixer: 6.0.4
 
-  starknetkit@2.6.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(starknet@7.6.4)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12):
+  starknetkit@2.6.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(starknet@7.6.4)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@starknet-io/get-starknet': 4.0.8
       '@starknet-io/get-starknet-core': 4.0.8
       '@starknet-io/types-js': 0.7.10
       '@trpc/client': 10.45.2(@trpc/server@10.45.2)
       '@trpc/server': 10.45.2
-      '@walletconnect/sign-client': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      '@walletconnect/sign-client': 2.23.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       bowser: 2.12.1
       detect-browser: 5.3.0
       eventemitter3: 5.0.1
@@ -36946,15 +36792,15 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  viem@2.23.2(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12):
+  viem@2.23.2(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@6.0.2)(zod@4.1.12)
+      abitype: 1.0.8(typescript@6.0.2)(zod@3.25.76)
       isows: 1.0.6(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      ox: 0.6.7(typescript@6.0.2)(zod@4.1.12)
+      ox: 0.6.7(typescript@6.0.2)(zod@3.25.76)
       ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 6.0.2
@@ -36989,23 +36835,6 @@ snapshots:
       abitype: 1.1.0(typescript@6.0.2)(zod@3.25.76)
       isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.9.6(typescript@6.0.2)(zod@3.25.76)
-      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 6.0.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
-  viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@6.0.2)(zod@4.1.12)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      ox: 0.9.6(typescript@6.0.2)(zod@4.1.12)
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 6.0.2
@@ -37084,14 +36913,14 @@ snapshots:
       xml-name-validator: 4.0.0
     optional: true
 
-  wagmi@2.19.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.10)(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.1.12):
+  wagmi@2.19.4(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.90.10)(@tanstack/react-query@5.90.10(react@18.3.1))(@types/react@18.3.27)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@10.2.0)(react-native@0.82.1(@babel/core@7.28.5)(@types/react@18.3.27)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@6.0.2)(utf-8-validate@5.0.10)(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       '@tanstack/react-query': 5.90.10(react@18.3.1)
-      '@wagmi/connectors': 6.1.4(61804c4d1f8323f8201487b11f7af0d4)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.10)(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12))
+      '@wagmi/connectors': 6.1.4(2bb13527e2b287710b3783f88216a145)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.10)(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 18.3.1
       use-sync-external-store: 1.4.0(react@18.3.1)
-      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.1.12)
+      viem: 2.39.3(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,6 +43,7 @@ catalog:
   dotenv: ^10.0.0
   asn1.js: ^5.4.1
   uuid: ^10.0.0
+  compare-versions: ^6.1.1
 
   # Starknet
   starknet: ^7.4.0

--- a/typescript/provider-sdk/src/warp.ts
+++ b/typescript/provider-sdk/src/warp.ts
@@ -72,6 +72,8 @@ export interface BaseWarpConfig {
   remoteRouters?: RemoteRouters;
   destinationGas?: DestinationGas;
   scale?: number;
+  /** On-chain program/contract version. Used for explicit upgrade detection. */
+  contractVersion?: string;
 }
 
 export interface CollateralWarpConfig extends BaseWarpConfig {
@@ -112,6 +114,8 @@ export interface BaseDerivedWarpConfig {
   remoteRouters: RemoteRouters;
   destinationGas: DestinationGas;
   scale?: number;
+  /** On-chain program/contract version. Used for explicit upgrade detection. */
+  contractVersion?: string;
 }
 
 export interface DerivedCollateralWarpConfig extends BaseDerivedWarpConfig {
@@ -176,6 +180,8 @@ interface BaseWarpArtifactConfig {
   symbol?: string;
   decimals?: number;
   scale?: number;
+  /** On-chain program/contract version. Used for explicit upgrade detection. */
+  contractVersion?: string;
 }
 
 export interface CollateralWarpArtifactConfig extends BaseWarpArtifactConfig {
@@ -388,6 +394,7 @@ export function warpConfigToArtifact(
     remoteRouters,
     destinationGas,
     scale: config.scale,
+    contractVersion: config.contractVersion,
   };
 
   switch (config.type) {
@@ -555,6 +562,7 @@ export function warpArtifactToDerivedConfig(
     symbol: config.symbol,
     decimals: config.decimals,
     scale: config.scale,
+    contractVersion: config.contractVersion,
   };
 
   switch (config.type) {

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -165,7 +165,7 @@
     "@turnkey/solana": "catalog:",
     "bignumber.js": "catalog:",
     "borsh": "catalog:",
-    "compare-versions": "^6.1.1",
+    "compare-versions": "catalog:",
     "cosmjs-types": "catalog:",
     "cross-fetch": "^3.1.5",
     "ethers": "catalog:",

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -115,6 +115,8 @@ export function validateWarpConfigForAltVM(
     scale = Number(config.scale.numerator) / Number(config.scale.denominator);
   }
 
+  // TODO: full CLI compatibility for SVM fee deployment will be implemented
+  // in a follow-up PR (requires mapping EVM TokenFeeConfigInput → provider-sdk FeeConfig).
   const baseConfig = {
     owner: config.owner,
     mailbox: config.mailbox,
@@ -126,6 +128,7 @@ export function validateWarpConfigForAltVM(
     remoteRouters: config.remoteRouters,
     destinationGas: config.destinationGas,
     scale,
+    contractVersion: config.contractVersion,
   };
 
   switch (config.type) {

--- a/typescript/svm-sdk/package.json
+++ b/typescript/svm-sdk/package.json
@@ -46,7 +46,8 @@
     "@solana-program/loader-v3": "^0.3.0",
     "@solana-program/system": "^0.12.0",
     "@solana/errors": "^6.1.0",
-    "@solana/kit": "catalog:"
+    "@solana/kit": "catalog:",
+    "compare-versions": "catalog:"
   },
   "devDependencies": {
     "@hyperlane-xyz/tsconfig": "workspace:^",

--- a/typescript/svm-sdk/src/accounts/token.ts
+++ b/typescript/svm-sdk/src/accounts/token.ts
@@ -259,6 +259,13 @@ export function splitPluginDataAndFeeConfig(
     return { pluginData, feeConfig: null };
   }
 
+  const feeDataLen = pluginData.length - pluginSize;
+  // Option<FeeConfig> is 1 byte (tag=0, None) or 65 bytes (tag=1 + two 32-byte pubkeys).
+  assert(
+    feeDataLen === 1 || feeDataLen === 65,
+    `Unexpected fee config data size: ${feeDataLen} bytes (expected 1 or 65)`,
+  );
+
   const actualPluginData = pluginData.subarray(0, pluginSize);
   const cursor = new ByteCursor(pluginData.subarray(pluginSize));
 

--- a/typescript/svm-sdk/src/accounts/token.ts
+++ b/typescript/svm-sdk/src/accounts/token.ts
@@ -227,6 +227,55 @@ function readOptionAddress(cursor: ByteCursor): Address | null {
   return tag === 1 ? readAddress(cursor) : null;
 }
 
+// ---------------------------------------------------------------------------
+// Fee config decoding
+// On-chain layout: Option<FeeConfig> = 1 byte tag + (if Some: Pubkey + Pubkey)
+// Appended after plugin data in HyperlaneToken accounts (Phase 5+).
+// Pre-fee accounts have no trailing bytes after plugin data.
+// ---------------------------------------------------------------------------
+
+export interface TokenFeeConfig {
+  feeProgram: Address;
+  feeAccount: Address;
+}
+
+/** Plugin data sizes per token type (bytes). */
+export const NATIVE_PLUGIN_SIZE = 1;
+export const SYNTHETIC_PLUGIN_SIZE = 34;
+export const COLLATERAL_PLUGIN_SIZE = 98;
+
+/**
+ * Splits raw pluginData into actual plugin bytes and an optional FeeConfig.
+ *
+ * The base decoder reads all remaining bytes after remoteRouters as pluginData.
+ * For fee-enabled programs, the trailing bytes contain Option<FeeConfig> after
+ * the fixed-size plugin data. Pre-fee accounts have pluginData.length == pluginSize.
+ */
+export function splitPluginDataAndFeeConfig(
+  pluginData: Uint8Array,
+  pluginSize: number,
+): { pluginData: Uint8Array; feeConfig: TokenFeeConfig | null } {
+  if (pluginData.length <= pluginSize) {
+    return { pluginData, feeConfig: null };
+  }
+
+  const actualPluginData = pluginData.subarray(0, pluginSize);
+  const cursor = new ByteCursor(pluginData.subarray(pluginSize));
+
+  const tag = cursor.readU8();
+  if (tag === 0) {
+    return { pluginData: actualPluginData, feeConfig: null };
+  }
+
+  assert(tag === 1, `Invalid FeeConfig option tag: ${tag}`);
+  const feeProgram = readAddress(cursor);
+  const feeAccount = readAddress(cursor);
+  return {
+    pluginData: actualPluginData,
+    feeConfig: { feeProgram, feeAccount },
+  };
+}
+
 function readOptionIgpConfig(cursor: ByteCursor): {
   programId: Address;
   igpType: InterchainGasPaymasterType;

--- a/typescript/svm-sdk/src/clients/protocol.ts
+++ b/typescript/svm-sdk/src/clients/protocol.ts
@@ -78,7 +78,9 @@ export class SvmProtocolProvider implements ProtocolProvider {
     _context?: { mailbox?: string },
   ): IRawWarpArtifactManager {
     const rpc = createRpc(this.getRpcUrls(chainMetadata)[0]);
-    return new SvmWarpArtifactManager(rpc);
+    return new SvmWarpArtifactManager(rpc, {
+      chainName: chainMetadata.name,
+    });
   }
 
   createMailboxArtifactManager(

--- a/typescript/svm-sdk/src/clients/protocol.ts
+++ b/typescript/svm-sdk/src/clients/protocol.ts
@@ -100,7 +100,10 @@ export class SvmProtocolProvider implements ProtocolProvider {
     context: FeeReadContext,
   ): IRawFeeArtifactManager | null {
     const rpc = createRpc(this.getRpcUrls(chainMetadata)[0]);
-    return new SvmFeeArtifactManager(rpc, context, chainMetadata.domainId);
+    return new SvmFeeArtifactManager(rpc, context, {
+      domainId: chainMetadata.domainId,
+      chainName: chainMetadata.name,
+    });
   }
 
   getMinGas(): MinimumRequiredGasByAction {

--- a/typescript/svm-sdk/src/deploy/program-deployer.ts
+++ b/typescript/svm-sdk/src/deploy/program-deployer.ts
@@ -1,15 +1,12 @@
 import {
   getDeployWithMaxDataLenInstruction,
   getInitializeBufferInstruction,
-  getUpgradeInstruction,
   getWriteInstruction,
 } from '@solana-program/loader-v3';
 import { getCreateAccountInstruction } from '@solana-program/system';
 import {
   generateKeyPairSigner,
-  getAddressCodec,
   getAddressDecoder,
-  getProgramDerivedAddress,
   type Address,
   type Instruction,
   type TransactionSigner,
@@ -17,12 +14,14 @@ import {
 
 import { assert, rootLogger } from '@hyperlane-xyz/utils';
 
+import { getUpgradeInstruction } from '../instructions/loader.js';
+import { deriveProgramDataAddress } from '../pda.js';
+
 import { LOADER_V3_PROGRAM_ADDRESS } from '../constants.js';
 import { DEFAULT_WRITE_CHUNK_SIZE } from '../tx.js';
 import type { SvmReceipt, SvmRpc } from '../types.js';
 
 const logger = rootLogger.child({ module: 'ProgramDeployer' });
-const ADDRESS_CODEC = getAddressCodec();
 const BUFFER_METADATA_SIZE = 37;
 const PROGRAM_ACCOUNT_SIZE = 36;
 
@@ -68,12 +67,20 @@ export interface ExecutePlanArgs {
 
 export interface UpgradeProgramPlanArgs {
   payer: TransactionSigner;
+  /** Buffer authority — signs buffer init and writes. */
   authority: TransactionSigner;
   programAddress: Address;
   newProgramBytes: Uint8Array;
   getMinimumBalanceForRentExemption: (size: number) => Promise<bigint>;
   writeChunkSize?: number;
   bufferSigner?: TransactionSigner;
+  /**
+   * Program upgrade authority — signs the final Upgrade instruction.
+   * Defaults to `authority` when not specified (same signer for both).
+   * Set this when the program's on-chain upgrade authority differs from
+   * the buffer authority (e.g. multisig or third-party owned programs).
+   */
+  upgradeAuthority?: Address;
 }
 
 export async function createDeployProgramPlan(
@@ -219,17 +226,18 @@ export async function createUpgradeProgramPlan(
     });
   }
 
+  const finalizeAuthority = args.upgradeAuthority ?? args.authority.address;
   stages.push({
     label: 'upgrade-program',
     kind: DeployStageKind.Finalize,
     instructions: [
-      getUpgradeInstruction({
-        programDataAccount: programDataAddress,
-        programAccount: args.programAddress,
-        bufferAccount: bufferSigner.address,
-        spillAccount: args.payer.address,
-        authority: args.authority,
-      }),
+      getUpgradeInstruction(
+        programDataAddress,
+        args.programAddress,
+        bufferSigner.address,
+        args.payer.address,
+        finalizeAuthority,
+      ),
     ],
   });
 
@@ -319,16 +327,6 @@ export async function executeDeployPlan(
   }
 
   return receipts;
-}
-
-export async function deriveProgramDataAddress(
-  programAddress: Address,
-): Promise<Address> {
-  const pda = await getProgramDerivedAddress({
-    programAddress: LOADER_V3_PROGRAM_ADDRESS,
-    seeds: [ADDRESS_CODEC.encode(programAddress)],
-  });
-  return pda[0];
 }
 
 /**

--- a/typescript/svm-sdk/src/deploy/program-deployer.ts
+++ b/typescript/svm-sdk/src/deploy/program-deployer.ts
@@ -330,14 +330,19 @@ export async function executeDeployPlan(
 }
 
 /**
- * Reads the BPF loader upgradeable ProgramData account to return the current
- * upgrade authority, or null if the program is immutable or not found.
+ * BPF Loader v3 ProgramData account header size in bytes.
  *
- * ProgramData binary layout:
+ * Layout:
  *   [0-3]  u32 discriminant (= 3)
  *   [4-11] u64 slot
  *   [12]   u8  option tag (0 = None, 1 = Some)
  *   [13-44] [u8; 32] upgrade authority pubkey (only when tag = 1)
+ */
+export const PROGRAM_DATA_HEADER_SIZE = 45;
+
+/**
+ * Reads the BPF loader upgradeable ProgramData account to return the current
+ * upgrade authority, or null if the program is immutable or not found.
  */
 export async function getProgramUpgradeAuthority(
   rpc: SvmRpc,
@@ -348,9 +353,9 @@ export async function getProgramUpgradeAuthority(
     .getAccountInfo(programDataAddress, { encoding: 'base64' })
     .send();
   if (!account.value) return null;
-  const data = Buffer.from(account.value.data[0] as string, 'base64');
-  if (data.length < 45) return null;
+  const data = Buffer.from(account.value.data[0], 'base64');
+  if (data.length < PROGRAM_DATA_HEADER_SIZE) return null;
   const hasAuthority = data[12] === 1;
   if (!hasAuthority) return null;
-  return getAddressDecoder().decode(data.slice(13, 45));
+  return getAddressDecoder().decode(data.slice(13, PROGRAM_DATA_HEADER_SIZE));
 }

--- a/typescript/svm-sdk/src/fee/cross-collateral-routing-fee.ts
+++ b/typescript/svm-sdk/src/fee/cross-collateral-routing-fee.ts
@@ -42,7 +42,6 @@ import {
   routeDataToFeeStrategy,
 } from './fee-strategy-utils.js';
 import {
-  DEFAULT_FEE_SALT,
   FeeDataKind,
   type SvmDeployedFee,
   type SvmFeeWriterConfig,
@@ -75,7 +74,7 @@ export class SvmCrossCollateralRoutingFeeReader implements ArtifactReader<
   constructor(
     protected readonly rpc: SvmRpc,
     protected readonly context: FeeReadContext,
-    protected readonly salt: Uint8Array = DEFAULT_FEE_SALT,
+    protected readonly salt: Uint8Array,
   ) {}
 
   async read(
@@ -146,7 +145,7 @@ export class SvmCrossCollateralRoutingFeeWriter
     private readonly domainId: number,
     private readonly svmSigner: SvmSigner,
     context: FeeReadContext,
-    salt: Uint8Array = DEFAULT_FEE_SALT,
+    salt: Uint8Array,
   ) {
     super(rpc, context, salt);
   }

--- a/typescript/svm-sdk/src/fee/fee-artifact-manager.ts
+++ b/typescript/svm-sdk/src/fee/fee-artifact-manager.ts
@@ -37,14 +37,14 @@ import {
   SvmRegressiveFeeWriter,
 } from './regressive-fee.js';
 import { SvmRoutingFeeReader, SvmRoutingFeeWriter } from './routing-fee.js';
-import { DEFAULT_FEE_SALT } from './types.js';
+import { resolveFeeSalt } from './types.js';
 
 export class SvmFeeArtifactManager implements IRawFeeArtifactManager {
   constructor(
     private readonly rpc: SvmRpc,
     private readonly context: FeeReadContext,
-    private readonly domainId: number,
-    private readonly salt: Uint8Array = DEFAULT_FEE_SALT,
+    private readonly chainConfig: { domainId: number; chainName: string },
+    private readonly salt: Uint8Array = resolveFeeSalt(chainConfig.chainName),
   ) {}
 
   async readFee(
@@ -82,7 +82,7 @@ export class SvmFeeArtifactManager implements IRawFeeArtifactManager {
         new SvmLinearFeeWriter(
           { program },
           this.rpc,
-          this.domainId,
+          this.chainConfig.domainId,
           signer,
           this.salt,
         ),
@@ -90,7 +90,7 @@ export class SvmFeeArtifactManager implements IRawFeeArtifactManager {
         new SvmRegressiveFeeWriter(
           { program },
           this.rpc,
-          this.domainId,
+          this.chainConfig.domainId,
           signer,
           this.salt,
         ),
@@ -98,7 +98,7 @@ export class SvmFeeArtifactManager implements IRawFeeArtifactManager {
         new SvmProgressiveFeeWriter(
           { program },
           this.rpc,
-          this.domainId,
+          this.chainConfig.domainId,
           signer,
           this.salt,
         ),
@@ -106,7 +106,7 @@ export class SvmFeeArtifactManager implements IRawFeeArtifactManager {
         new SvmOffchainQuotedLinearFeeWriter(
           { program },
           this.rpc,
-          this.domainId,
+          this.chainConfig.domainId,
           signer,
           this.salt,
         ),
@@ -114,7 +114,7 @@ export class SvmFeeArtifactManager implements IRawFeeArtifactManager {
         new SvmRoutingFeeWriter(
           { program },
           this.rpc,
-          this.domainId,
+          this.chainConfig.domainId,
           signer,
           this.context,
           this.salt,
@@ -123,7 +123,7 @@ export class SvmFeeArtifactManager implements IRawFeeArtifactManager {
         new SvmCrossCollateralRoutingFeeWriter(
           { program },
           this.rpc,
-          this.domainId,
+          this.chainConfig.domainId,
           signer,
           this.context,
           this.salt,

--- a/typescript/svm-sdk/src/fee/leaf-fee.ts
+++ b/typescript/svm-sdk/src/fee/leaf-fee.ts
@@ -34,7 +34,6 @@ import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import { fetchFeeAccount } from './fee-query.js';
 import {
-  DEFAULT_FEE_SALT,
   FeeDataKind,
   type FeeStrategyKind,
   type SvmDeployedFee,
@@ -55,7 +54,7 @@ export abstract class SvmLeafFeeReader<
 
   constructor(
     protected readonly rpc: SvmRpc,
-    protected readonly salt: Uint8Array = DEFAULT_FEE_SALT,
+    protected readonly salt: Uint8Array,
   ) {}
 
   async read(address: string): Promise<ArtifactDeployed<C, SvmDeployedFee>> {
@@ -107,7 +106,7 @@ export abstract class SvmLeafFeeWriter<C extends LeafFeeConfig>
     rpc: SvmRpc,
     private readonly domainId: number,
     private readonly svmSigner: SvmSigner,
-    salt: Uint8Array = DEFAULT_FEE_SALT,
+    salt: Uint8Array,
   ) {
     super(rpc, salt);
   }

--- a/typescript/svm-sdk/src/fee/offchain-quoted-linear-fee.ts
+++ b/typescript/svm-sdk/src/fee/offchain-quoted-linear-fee.ts
@@ -34,7 +34,6 @@ import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import { fetchFeeAccount } from './fee-query.js';
 import {
-  DEFAULT_FEE_SALT,
   FeeDataKind,
   FeeStrategyKind,
   h160ToSigner,
@@ -49,7 +48,7 @@ export class SvmOffchainQuotedLinearFeeReader implements ArtifactReader<
 > {
   constructor(
     protected readonly rpc: SvmRpc,
-    protected readonly salt: Uint8Array = DEFAULT_FEE_SALT,
+    protected readonly salt: Uint8Array,
   ) {}
 
   async read(
@@ -104,7 +103,7 @@ export class SvmOffchainQuotedLinearFeeWriter
     rpc: SvmRpc,
     private readonly domainId: number,
     private readonly svmSigner: SvmSigner,
-    salt: Uint8Array = DEFAULT_FEE_SALT,
+    salt: Uint8Array,
   ) {
     super(rpc, salt);
   }

--- a/typescript/svm-sdk/src/fee/routing-fee.ts
+++ b/typescript/svm-sdk/src/fee/routing-fee.ts
@@ -41,7 +41,6 @@ import {
   routeDataToFeeStrategy,
 } from './fee-strategy-utils.js';
 import {
-  DEFAULT_FEE_SALT,
   FeeDataKind,
   type SvmDeployedFee,
   type SvmFeeWriterConfig,
@@ -56,7 +55,7 @@ export class SvmRoutingFeeReader implements ArtifactReader<
   constructor(
     protected readonly rpc: SvmRpc,
     protected readonly context: FeeReadContext,
-    protected readonly salt: Uint8Array = DEFAULT_FEE_SALT,
+    protected readonly salt: Uint8Array,
   ) {}
 
   async read(
@@ -113,7 +112,7 @@ export class SvmRoutingFeeWriter
     private readonly domainId: number,
     private readonly svmSigner: SvmSigner,
     context: FeeReadContext,
-    salt: Uint8Array = DEFAULT_FEE_SALT,
+    salt: Uint8Array,
   ) {
     super(rpc, context, salt);
   }

--- a/typescript/svm-sdk/src/fee/types.ts
+++ b/typescript/svm-sdk/src/fee/types.ts
@@ -25,6 +25,25 @@ export function deriveFeeSalt(context: string): Uint8Array {
   return keccak_256(new TextEncoder().encode(context));
 }
 
+/**
+ * Resolves the fee salt for a given chain.
+ *
+ * Checks the SVM_FEE_{CHAIN_NAME}_SALT env var. If set, the value is
+ * hashed with keccak256 to produce a 32-byte salt. If not set, returns
+ * DEFAULT_FEE_SALT (all zeros).
+ *
+ * This ensures consistency across fee artifact managers and warp writers
+ * within the same deployment session without leaking protocol-specific
+ * details into the config.
+ */
+export function resolveFeeSalt(chainName: string): Uint8Array {
+  const envKey = `SVM_FEE_${chainName.toUpperCase()}_SALT`;
+  const envValue =
+    typeof process !== 'undefined' ? process.env[envKey] : undefined;
+  if (!envValue) return DEFAULT_FEE_SALT;
+  return deriveFeeSalt(envValue);
+}
+
 /** On-chain FeeDataStrategy discriminant values. */
 export const FeeStrategyKind = {
   Linear: 0,

--- a/typescript/svm-sdk/src/index.ts
+++ b/typescript/svm-sdk/src/index.ts
@@ -185,7 +185,11 @@ export {
   SvmCrossCollateralRoutingFeeWriter as SealevelCrossCollateralRoutingFeeWriter,
 } from './fee/cross-collateral-routing-fee.js';
 export type { SvmDeployedFee as SealevelDeployedFee } from './fee/types.js';
-export { DEFAULT_FEE_SALT, deriveFeeSalt } from './fee/types.js';
+export {
+  DEFAULT_FEE_SALT,
+  deriveFeeSalt,
+  resolveFeeSalt,
+} from './fee/types.js';
 
 // Version detection
 export {

--- a/typescript/svm-sdk/src/index.ts
+++ b/typescript/svm-sdk/src/index.ts
@@ -40,6 +40,10 @@ export { HYPERLANE_SVM_PROGRAM_BYTES } from './hyperlane/program-bytes.js';
 // Low-level instruction builders
 export { getTransferOwnershipInstruction as getMultisigIsmTransferOwnershipInstruction } from './instructions/multisig-ism-message-id.js';
 export { getSetUpgradeAuthorityInstruction } from './instructions/loader.js';
+export {
+  GET_PROGRAM_VERSION_DISCRIMINATOR,
+  buildGetProgramVersionInstruction,
+} from './instructions/version.js';
 export { buildSetDefaultIsmInstruction } from './core/mailbox-tx.js';
 export { fetchMultisigIsmAccessControl } from './ism/ism-query.js';
 export { getProgramUpgradeAuthority } from './deploy/program-deployer.js';
@@ -182,3 +186,11 @@ export {
 } from './fee/cross-collateral-routing-fee.js';
 export type { SvmDeployedFee as SealevelDeployedFee } from './fee/types.js';
 export { DEFAULT_FEE_SALT, deriveFeeSalt } from './fee/types.js';
+
+// Version detection
+export {
+  queryProgramVersion,
+  compareVersions,
+  supportsFeeConfig,
+  SVM_PROGRAM_MINIMUM_FEE_SUPPORT_VERSION,
+} from './version/version-query.js';

--- a/typescript/svm-sdk/src/index.ts
+++ b/typescript/svm-sdk/src/index.ts
@@ -26,6 +26,7 @@ export { SvmValidatorAnnounceArtifactManager as SealevelValidatorAnnounceArtifac
 export { SvmIsmArtifactManager as SealevelIsmArtifactManager } from './ism/ism-artifact-manager.js';
 export { SvmHookArtifactManager as SealevelHookArtifactManager } from './hook/hook-artifact-manager.js';
 export { SvmFeeArtifactManager as SealevelFeeArtifactManager } from './fee/fee-artifact-manager.js';
+export { SvmWarpArtifactManager as SealevelWarpArtifactManager } from './warp/warp-artifact-manager.js';
 
 // ISM readers/writers
 export {

--- a/typescript/svm-sdk/src/instructions/loader.ts
+++ b/typescript/svm-sdk/src/instructions/loader.ts
@@ -1,7 +1,13 @@
 import type { Address } from '@solana/kit';
 
-import { deriveProgramDataAddress } from '../deploy/program-deployer.js';
-import { LOADER_V3_PROGRAM_ADDRESS } from '../constants.js';
+import { deriveProgramDataAddress } from '../pda.js';
+import {
+  CLOCK_SYSVAR_ADDRESS,
+  LOADER_V3_PROGRAM_ADDRESS,
+  RENT_SYSVAR_ADDRESS,
+  SYSTEM_PROGRAM_ADDRESS,
+} from '../constants.js';
+import { u32le } from '../codecs/binary.js';
 import type { SvmInstruction } from '../types.js';
 
 import {
@@ -9,14 +15,73 @@ import {
   readonlyAccount,
   readonlySignerAddress,
   writableAccount,
+  writableSignerAddress,
 } from './utils.js';
 
+/** BPF Loader Upgradeable SetAuthority discriminant (u32 LE). */
+const SET_AUTHORITY_DISCRIMINANT = new Uint8Array([4, 0, 0, 0]);
+
+/** BPF Loader Upgradeable Upgrade discriminant (u32 LE). */
+const UPGRADE_DISCRIMINANT = new Uint8Array([3, 0, 0, 0]);
+
+/** BPF Loader Upgradeable ExtendProgramChecked discriminant (variant 9). */
+const EXTEND_PROGRAM_CHECKED_DISCRIMINANT = 9;
+
 /**
- * Builds a BPF Loader Upgradeable SetAuthority instruction (discriminant = 4)
- * to transfer upgrade authority of a deployed program to a new address.
+ * Builds an ExtendProgramChecked instruction (variant 9).
  *
- * Uses address-only signers (no embedded keypair) consistent with the rest of
- * the codebase — signing is deferred to transaction submission.
+ * Requires the upgrade authority as signer. Variant 6 (ExtendProgram)
+ * is rejected on validators with the enable_extend_program_checked
+ * feature gate active (default on Agave 3.0+).
+ */
+export function getExtendProgramCheckedInstruction(
+  programDataAddress: Address,
+  programAddress: Address,
+  authority: Address,
+  payer: Address,
+  additionalBytes: number,
+): SvmInstruction {
+  const data = new Uint8Array(8);
+  data.set(u32le(EXTEND_PROGRAM_CHECKED_DISCRIMINANT), 0);
+  data.set(u32le(additionalBytes), 4);
+  return buildInstruction(
+    LOADER_V3_PROGRAM_ADDRESS,
+    [
+      writableAccount(programDataAddress),
+      writableAccount(programAddress),
+      readonlySignerAddress(authority),
+      readonlyAccount(SYSTEM_PROGRAM_ADDRESS),
+      writableSignerAddress(payer),
+    ],
+    data,
+  );
+}
+
+/**
+ * Builds a SetAuthority instruction to transfer buffer authority.
+ *
+ * Used before program upgrades when the buffer writer differs from the
+ * program's upgrade authority (the Loader requires both to match).
+ */
+export function getSetBufferAuthorityInstruction(
+  bufferAddress: Address,
+  currentAuthority: Address,
+  newAuthority: Address,
+): SvmInstruction {
+  return buildInstruction(
+    LOADER_V3_PROGRAM_ADDRESS,
+    [
+      writableAccount(bufferAddress),
+      readonlySignerAddress(currentAuthority),
+      readonlyAccount(newAuthority),
+    ],
+    SET_AUTHORITY_DISCRIMINANT,
+  );
+}
+
+/**
+ * Builds a SetAuthority instruction to transfer upgrade authority
+ * of a deployed program to a new address (or renounce it).
  */
 export async function getSetUpgradeAuthorityInstruction(
   programAddress: Address,
@@ -24,8 +89,6 @@ export async function getSetUpgradeAuthorityInstruction(
   newAuthority: Address | null,
 ): Promise<SvmInstruction> {
   const programDataAddress = await deriveProgramDataAddress(programAddress);
-  // SetAuthority discriminant: u32le(4)
-  const data = new Uint8Array([4, 0, 0, 0]);
   const accounts = [
     writableAccount(programDataAddress),
     readonlySignerAddress(currentAuthority),
@@ -33,5 +96,43 @@ export async function getSetUpgradeAuthorityInstruction(
   if (newAuthority) {
     accounts.push(readonlyAccount(newAuthority));
   }
-  return buildInstruction(LOADER_V3_PROGRAM_ADDRESS, accounts, data);
+
+  return buildInstruction(
+    LOADER_V3_PROGRAM_ADDRESS,
+    accounts,
+    SET_AUTHORITY_DISCRIMINANT,
+  );
+}
+
+/**
+ * Builds an Upgrade instruction using address-only signers.
+ *
+ * Unlike the @solana-program/loader-v3 getUpgradeInstruction which
+ * requires a TransactionSigner for the authority, this accepts a bare
+ * Address. The caller (authority holder) signs at transaction submission.
+ *
+ * Used when the upgrade authority differs from the buffer writer —
+ * the authority address is known but the keypair is not available
+ * to the code preparing the transaction.
+ */
+export function getUpgradeInstruction(
+  programDataAddress: Address,
+  programAddress: Address,
+  bufferAddress: Address,
+  spillAddress: Address,
+  authority: Address,
+): SvmInstruction {
+  return buildInstruction(
+    LOADER_V3_PROGRAM_ADDRESS,
+    [
+      writableAccount(programDataAddress),
+      writableAccount(programAddress),
+      writableAccount(bufferAddress),
+      writableAccount(spillAddress),
+      readonlyAccount(RENT_SYSVAR_ADDRESS),
+      readonlyAccount(CLOCK_SYSVAR_ADDRESS),
+      readonlySignerAddress(authority),
+    ],
+    UPGRADE_DISCRIMINANT,
+  );
 }

--- a/typescript/svm-sdk/src/instructions/token.ts
+++ b/typescript/svm-sdk/src/instructions/token.ts
@@ -35,6 +35,7 @@ import {
   InterchainGasPaymasterTypeKind,
   type RemoteRouterConfig,
 } from '../codecs/shared.js';
+import type { TokenFeeConfig } from '../accounts/token.js';
 import {
   PROGRAM_INSTRUCTION_DISCRIMINATOR,
   SYSTEM_PROGRAM_ADDRESS,
@@ -63,11 +64,6 @@ export enum TokenProgramInstructionKind {
   SetInterchainGasPaymaster = 6,
   TransferOwnership = 7,
   SetFeeConfig = 8,
-}
-
-export interface FeeConfigValue {
-  feeProgram: Address;
-  feeAccount: Address;
 }
 
 export interface TokenInitInstructionData {
@@ -99,7 +95,7 @@ export type TokenProgramInstructionData =
       value: [Address, InterchainGasPaymasterType] | null;
     }
   | { kind: 'transferOwnership'; value: Address | null }
-  | { kind: 'setFeeConfig'; value: FeeConfigValue | null };
+  | { kind: 'setFeeConfig'; value: TokenFeeConfig | null };
 
 interface TokenInitIgpValue {
   programId: Address;
@@ -382,7 +378,7 @@ export async function getTokenSetDestinationGasConfigsInstruction(
 export async function getTokenSetFeeConfigInstruction(
   programAddress: Address,
   owner: Address,
-  value: FeeConfigValue | null,
+  value: TokenFeeConfig | null,
 ): Promise<Instruction> {
   const { address: tokenPda } = await deriveHyperlaneTokenPda(programAddress);
   return buildInstruction(
@@ -498,7 +494,7 @@ function decodeOptionIgpTuple(
   ];
 }
 
-function decodeOptionFeeConfig(cursor: ByteCursor): FeeConfigValue | null {
+function decodeOptionFeeConfig(cursor: ByteCursor): TokenFeeConfig | null {
   const hasValue = cursor.readU8() === 1;
   if (!hasValue) return null;
   return {

--- a/typescript/svm-sdk/src/instructions/token.ts
+++ b/typescript/svm-sdk/src/instructions/token.ts
@@ -387,7 +387,11 @@ export async function getTokenSetFeeConfigInstruction(
   const { address: tokenPda } = await deriveHyperlaneTokenPda(programAddress);
   return buildInstruction(
     programAddress,
-    [writableAccount(tokenPda), readonlySignerAddress(owner)],
+    [
+      readonlyAccount(SYSTEM_PROGRAM_ADDRESS),
+      writableAccount(tokenPda),
+      writableSignerAddress(owner),
+    ],
     encodeTokenProgramInstruction({ kind: 'setFeeConfig', value }),
   );
 }

--- a/typescript/svm-sdk/src/instructions/token.ts
+++ b/typescript/svm-sdk/src/instructions/token.ts
@@ -62,6 +62,12 @@ export enum TokenProgramInstructionKind {
   SetInterchainSecurityModule = 5,
   SetInterchainGasPaymaster = 6,
   TransferOwnership = 7,
+  SetFeeConfig = 8,
+}
+
+export interface FeeConfigValue {
+  feeProgram: Address;
+  feeAccount: Address;
 }
 
 export interface TokenInitInstructionData {
@@ -92,7 +98,8 @@ export type TokenProgramInstructionData =
       kind: 'setInterchainGasPaymaster';
       value: [Address, InterchainGasPaymasterType] | null;
     }
-  | { kind: 'transferOwnership'; value: Address | null };
+  | { kind: 'transferOwnership'; value: Address | null }
+  | { kind: 'setFeeConfig'; value: FeeConfigValue | null };
 
 interface TokenInitIgpValue {
   programId: Address;
@@ -195,6 +202,17 @@ export function encodeTokenProgramInstruction(
         u8(TokenProgramInstructionKind.TransferOwnership),
         option(instruction.value, (addr) => ADDRESS_CODEC.encode(addr)),
       );
+    case 'setFeeConfig':
+      return concatBytes(
+        PROGRAM_INSTRUCTION_DISCRIMINATOR,
+        u8(TokenProgramInstructionKind.SetFeeConfig),
+        option(instruction.value, (fc) =>
+          concatBytes(
+            ADDRESS_CODEC.encode(fc.feeProgram),
+            ADDRESS_CODEC.encode(fc.feeAccount),
+          ),
+        ),
+      );
   }
 }
 
@@ -242,8 +260,10 @@ export function decodeTokenProgramInstruction(
       };
     case TokenProgramInstructionKind.TransferOwnership:
       return { kind: 'transferOwnership', value: decodeOptionAddress(cursor) };
+    case TokenProgramInstructionKind.SetFeeConfig:
+      return { kind: 'setFeeConfig', value: decodeOptionFeeConfig(cursor) };
     default:
-      if (kind <= TokenProgramInstructionKind.TransferOwnership) {
+      if (kind <= TokenProgramInstructionKind.SetFeeConfig) {
         throw new Error(
           `Token instruction kind ${kind} is recognized but decoding is not yet implemented`,
         );
@@ -359,6 +379,19 @@ export async function getTokenSetDestinationGasConfigsInstruction(
   );
 }
 
+export async function getTokenSetFeeConfigInstruction(
+  programAddress: Address,
+  owner: Address,
+  value: FeeConfigValue | null,
+): Promise<Instruction> {
+  const { address: tokenPda } = await deriveHyperlaneTokenPda(programAddress);
+  return buildInstruction(
+    programAddress,
+    [writableAccount(tokenPda), readonlySignerAddress(owner)],
+    encodeTokenProgramInstruction({ kind: 'setFeeConfig', value }),
+  );
+}
+
 export function encodeTokenInit(value: TokenInitInstructionData): Uint8Array {
   const normalized: TokenInitCodecValue = {
     mailbox: value.mailbox,
@@ -459,6 +492,15 @@ function decodeOptionIgpTuple(
     ADDRESS_CODEC.decode(cursor.readBytes(32)),
     decodeInterchainGasPaymasterType(cursor),
   ];
+}
+
+function decodeOptionFeeConfig(cursor: ByteCursor): FeeConfigValue | null {
+  const hasValue = cursor.readU8() === 1;
+  if (!hasValue) return null;
+  return {
+    feeProgram: ADDRESS_CODEC.decode(cursor.readBytes(32)),
+    feeAccount: ADDRESS_CODEC.decode(cursor.readBytes(32)),
+  };
 }
 
 function decodeVec<T>(

--- a/typescript/svm-sdk/src/instructions/version.ts
+++ b/typescript/svm-sdk/src/instructions/version.ts
@@ -1,0 +1,27 @@
+import type { Address } from '@solana/kit';
+
+import type { SvmInstruction } from '../types.js';
+
+/**
+ * 8-byte discriminator for GetProgramVersion.
+ * First 8 bytes of `sha256(b"hyperlane:get-program-version")`.
+ * Independent of any program's instruction enum — works on all
+ * Hyperlane SVM programs that implement PackageVersioned.
+ */
+export const GET_PROGRAM_VERSION_DISCRIMINATOR = new Uint8Array([
+  150, 230, 176, 162, 236, 96, 183, 171,
+]);
+
+/**
+ * Builds a GetProgramVersion instruction for any Hyperlane SVM program.
+ * No accounts are required.
+ */
+export function buildGetProgramVersionInstruction(
+  programAddress: Address,
+): SvmInstruction {
+  return {
+    programAddress,
+    accounts: [],
+    data: GET_PROGRAM_VERSION_DISCRIMINATOR,
+  };
+}

--- a/typescript/svm-sdk/src/pda.ts
+++ b/typescript/svm-sdk/src/pda.ts
@@ -1,4 +1,5 @@
 import {
+  getAddressCodec,
   getAddressEncoder,
   getProgramDerivedAddress,
   getU32Encoder,
@@ -6,6 +7,8 @@ import {
   type Address,
   type ReadonlyUint8Array,
 } from '@solana/kit';
+
+import { LOADER_V3_PROGRAM_ADDRESS } from './constants.js';
 
 import type { PdaWithBump } from './types.js';
 
@@ -325,4 +328,17 @@ export async function deriveStandingQuotePda(
     utf8.encode('-'),
     targetRouter,
   ]);
+}
+
+/**
+ * Derives the ProgramData address for a deployed BPF Loader v3 program.
+ */
+export async function deriveProgramDataAddress(
+  programAddress: Address,
+): Promise<Address> {
+  const pda = await getProgramDerivedAddress({
+    programAddress: LOADER_V3_PROGRAM_ADDRESS,
+    seeds: [getAddressCodec().encode(programAddress)],
+  });
+  return pda[0];
 }

--- a/typescript/svm-sdk/src/tests/collateral-token.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/collateral-token.e2e-test.ts
@@ -21,6 +21,7 @@ import {
   airdropSol,
   createSplMint,
 } from '../testing/setup.js';
+import { DEFAULT_FEE_SALT } from '../fee/types.js';
 import { SvmCollateralTokenWriter } from '../warp/collateral-token.js';
 
 import { defineWarpTokenTests } from './warp-token-suite.js';
@@ -89,6 +90,7 @@ describe('SVM Collateral Warp Token E2E Tests', function () {
       {
         program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
         ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
       },
       rpc,
       signer,

--- a/typescript/svm-sdk/src/tests/cross-collateral-token.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/cross-collateral-token.e2e-test.ts
@@ -22,6 +22,7 @@ import {
   airdropSol,
   createSplMint,
 } from '../testing/setup.js';
+import { DEFAULT_FEE_SALT } from '../fee/types.js';
 import { SvmCrossCollateralTokenWriter } from '../warp/cross-collateral-token.js';
 
 import { defineWarpTokenTests } from './warp-token-suite.js';
@@ -118,6 +119,7 @@ describe('SVM Cross-Collateral Warp Token E2E Tests', function () {
           programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCrossCollateral,
         },
         ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
       },
       rpc,
       signer,

--- a/typescript/svm-sdk/src/tests/fee-cross-collateral-routing.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/fee-cross-collateral-routing.e2e-test.ts
@@ -10,6 +10,7 @@ import {
   SvmCrossCollateralRoutingFeeReader,
   SvmCrossCollateralRoutingFeeWriter,
 } from '../fee/cross-collateral-routing-fee.js';
+import { DEFAULT_FEE_SALT } from '../fee/types.js';
 import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
 import { createRpc } from '../rpc.js';
 import { TEST_SVM_CHAIN_METADATA } from '../testing/constants.js';
@@ -51,6 +52,7 @@ describe('SVM CrossCollateralRouting Fee E2E Tests', function () {
       1,
       signer,
       ALL_CONTEXT,
+      DEFAULT_FEE_SALT,
     );
   });
 
@@ -87,7 +89,11 @@ describe('SVM CrossCollateralRouting Fee E2E Tests', function () {
     expect(receipts.length).to.be.greaterThan(0);
     expect(deployed.artifactState).to.equal(ArtifactState.DEPLOYED);
 
-    const reader = new SvmCrossCollateralRoutingFeeReader(rpc, ALL_CONTEXT);
+    const reader = new SvmCrossCollateralRoutingFeeReader(
+      rpc,
+      ALL_CONTEXT,
+      DEFAULT_FEE_SALT,
+    );
     const readResult = await reader.read(deployed.deployed.programId);
 
     expect(readResult.config.type).to.equal(FeeType.crossCollateralRouting);
@@ -148,7 +154,11 @@ describe('SVM CrossCollateralRouting Fee E2E Tests', function () {
       await signer.send(tx);
     }
 
-    const reader = new SvmCrossCollateralRoutingFeeReader(rpc, ALL_CONTEXT);
+    const reader = new SvmCrossCollateralRoutingFeeReader(
+      rpc,
+      ALL_CONTEXT,
+      DEFAULT_FEE_SALT,
+    );
     const readResult = await reader.read(deployed.deployed.programId);
     expect(readResult.config.routes[10]?.[ROUTER_B]?.type).to.equal(
       FeeStrategyType.progressive,
@@ -196,7 +206,11 @@ describe('SVM CrossCollateralRouting Fee E2E Tests', function () {
       await signer.send(tx);
     }
 
-    const reader = new SvmCrossCollateralRoutingFeeReader(rpc, ALL_CONTEXT);
+    const reader = new SvmCrossCollateralRoutingFeeReader(
+      rpc,
+      ALL_CONTEXT,
+      DEFAULT_FEE_SALT,
+    );
     const readResult = await reader.read(deployed.deployed.programId);
     expect(readResult.config.routes[10]?.[ROUTER_A]?.maxFee).to.equal('7777');
     expect(readResult.config.routes[10]?.[ROUTER_A]?.halfAmount).to.equal(
@@ -244,7 +258,11 @@ describe('SVM CrossCollateralRouting Fee E2E Tests', function () {
       await signer.send(tx);
     }
 
-    const reader = new SvmCrossCollateralRoutingFeeReader(rpc, ALL_CONTEXT);
+    const reader = new SvmCrossCollateralRoutingFeeReader(
+      rpc,
+      ALL_CONTEXT,
+      DEFAULT_FEE_SALT,
+    );
     const readResult = await reader.read(deployed.deployed.programId);
     expect(readResult.config.routes[10]?.[ROUTER_A]?.type).to.equal(
       FeeStrategyType.regressive,
@@ -296,7 +314,11 @@ describe('SVM CrossCollateralRouting Fee E2E Tests', function () {
       await signer.send(tx);
     }
 
-    const reader = new SvmCrossCollateralRoutingFeeReader(rpc, ALL_CONTEXT);
+    const reader = new SvmCrossCollateralRoutingFeeReader(
+      rpc,
+      ALL_CONTEXT,
+      DEFAULT_FEE_SALT,
+    );
     const readResult = await reader.read(deployed.deployed.programId);
     expect(readResult.config.routes[10]?.[ROUTER_A]).to.exist;
     expect(readResult.config.routes[10]?.[ROUTER_B]).to.be.undefined;

--- a/typescript/svm-sdk/src/tests/fee-linear.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/fee-linear.e2e-test.ts
@@ -3,6 +3,7 @@ import { before, describe } from 'mocha';
 
 import { SvmSigner } from '../clients/signer.js';
 import { SvmLinearFeeReader, SvmLinearFeeWriter } from '../fee/linear-fee.js';
+import { DEFAULT_FEE_SALT } from '../fee/types.js';
 import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
 import { createRpc } from '../rpc.js';
 import { TEST_SVM_CHAIN_METADATA } from '../testing/constants.js';
@@ -33,11 +34,12 @@ describe('SVM Linear Fee E2E Tests', function () {
       rpc,
       1,
       signer,
+      DEFAULT_FEE_SALT,
     );
 
     ctx = {
       writer,
-      reader: new SvmLinearFeeReader(rpc),
+      reader: new SvmLinearFeeReader(rpc, DEFAULT_FEE_SALT),
       signer,
       rpc,
       makeConfig: (overrides) => ({

--- a/typescript/svm-sdk/src/tests/fee-offchain-quoted-linear.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/fee-offchain-quoted-linear.e2e-test.ts
@@ -9,6 +9,7 @@ import {
   SvmOffchainQuotedLinearFeeReader,
   SvmOffchainQuotedLinearFeeWriter,
 } from '../fee/offchain-quoted-linear-fee.js';
+import { DEFAULT_FEE_SALT } from '../fee/types.js';
 import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
 import { createRpc } from '../rpc.js';
 import { TEST_SVM_CHAIN_METADATA } from '../testing/constants.js';
@@ -42,13 +43,14 @@ describe('SVM OffchainQuotedLinear Fee E2E Tests', function () {
       rpc,
       1,
       signer,
+      DEFAULT_FEE_SALT,
     );
   });
 
   // Reuse shared leaf tests (create/read, no-op update, params update, beneficiary update)
   defineLeafFeeTests<typeof FeeType.offchainQuotedLinear>(() => ({
     writer,
-    reader: new SvmOffchainQuotedLinearFeeReader(rpc),
+    reader: new SvmOffchainQuotedLinearFeeReader(rpc, DEFAULT_FEE_SALT),
     signer,
     rpc,
     makeConfig: (overrides) => ({
@@ -75,7 +77,7 @@ describe('SVM OffchainQuotedLinear Fee E2E Tests', function () {
       },
     });
 
-    const reader = new SvmOffchainQuotedLinearFeeReader(rpc);
+    const reader = new SvmOffchainQuotedLinearFeeReader(rpc, DEFAULT_FEE_SALT);
     const readResult = await reader.read(deployed.deployed.programId);
 
     expect(readResult.config.quoteSigners).to.have.length(2);
@@ -106,7 +108,7 @@ describe('SVM OffchainQuotedLinear Fee E2E Tests', function () {
       await signer.send(tx);
     }
 
-    const reader = new SvmOffchainQuotedLinearFeeReader(rpc);
+    const reader = new SvmOffchainQuotedLinearFeeReader(rpc, DEFAULT_FEE_SALT);
     const readResult = await reader.read(deployed.deployed.programId);
     expect(readResult.config.quoteSigners).to.have.length(2);
   });
@@ -133,7 +135,7 @@ describe('SVM OffchainQuotedLinear Fee E2E Tests', function () {
       await signer.send(tx);
     }
 
-    const reader = new SvmOffchainQuotedLinearFeeReader(rpc);
+    const reader = new SvmOffchainQuotedLinearFeeReader(rpc, DEFAULT_FEE_SALT);
     const readResult = await reader.read(deployed.deployed.programId);
     expect(readResult.config.quoteSigners).to.have.length(2);
     expect(
@@ -165,7 +167,7 @@ describe('SVM OffchainQuotedLinear Fee E2E Tests', function () {
     }
 
     // Must still read back as offchainQuotedLinear, not downgrade to linear
-    const reader = new SvmOffchainQuotedLinearFeeReader(rpc);
+    const reader = new SvmOffchainQuotedLinearFeeReader(rpc, DEFAULT_FEE_SALT);
     const readResult = await reader.read(deployed.deployed.programId);
     expect(readResult.config.type).to.equal(FeeType.offchainQuotedLinear);
     expect(readResult.config.quoteSigners).to.have.length(0);

--- a/typescript/svm-sdk/src/tests/fee-progressive.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/fee-progressive.e2e-test.ts
@@ -8,6 +8,7 @@ import {
   SvmProgressiveFeeReader,
   SvmProgressiveFeeWriter,
 } from '../fee/progressive-fee.js';
+import { DEFAULT_FEE_SALT } from '../fee/types.js';
 import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
 import { createRpc } from '../rpc.js';
 import { TEST_SVM_CHAIN_METADATA } from '../testing/constants.js';
@@ -38,11 +39,12 @@ describe('SVM Progressive Fee E2E Tests', function () {
       rpc,
       1,
       signer,
+      DEFAULT_FEE_SALT,
     );
 
     ctx = {
       writer,
-      reader: new SvmProgressiveFeeReader(rpc),
+      reader: new SvmProgressiveFeeReader(rpc, DEFAULT_FEE_SALT),
       signer,
       rpc,
       makeConfig: (overrides) => ({

--- a/typescript/svm-sdk/src/tests/fee-regressive.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/fee-regressive.e2e-test.ts
@@ -6,6 +6,7 @@ import {
   SvmRegressiveFeeReader,
   SvmRegressiveFeeWriter,
 } from '../fee/regressive-fee.js';
+import { DEFAULT_FEE_SALT } from '../fee/types.js';
 import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
 import { createRpc } from '../rpc.js';
 import { TEST_SVM_CHAIN_METADATA } from '../testing/constants.js';
@@ -37,11 +38,12 @@ describe('SVM Regressive Fee E2E Tests', function () {
       rpc,
       1,
       signer,
+      DEFAULT_FEE_SALT,
     );
 
     ctx = {
       writer,
-      reader: new SvmRegressiveFeeReader(rpc),
+      reader: new SvmRegressiveFeeReader(rpc, DEFAULT_FEE_SALT),
       signer,
       rpc,
       makeConfig: (overrides) => ({

--- a/typescript/svm-sdk/src/tests/fee-routing.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/fee-routing.e2e-test.ts
@@ -10,6 +10,7 @@ import {
   SvmRoutingFeeReader,
   SvmRoutingFeeWriter,
 } from '../fee/routing-fee.js';
+import { DEFAULT_FEE_SALT } from '../fee/types.js';
 import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
 import { createRpc } from '../rpc.js';
 import { TEST_SVM_CHAIN_METADATA } from '../testing/constants.js';
@@ -50,6 +51,7 @@ describe('SVM Routing Fee E2E Tests', function () {
       1,
       signer,
       ALL_DOMAINS_CONTEXT,
+      DEFAULT_FEE_SALT,
     );
   });
 
@@ -77,7 +79,11 @@ describe('SVM Routing Fee E2E Tests', function () {
     expect(receipts.length).to.be.greaterThan(0);
     expect(deployed.artifactState).to.equal(ArtifactState.DEPLOYED);
 
-    const reader = new SvmRoutingFeeReader(rpc, ALL_DOMAINS_CONTEXT);
+    const reader = new SvmRoutingFeeReader(
+      rpc,
+      ALL_DOMAINS_CONTEXT,
+      DEFAULT_FEE_SALT,
+    );
     const readResult = await reader.read(deployed.deployed.programId);
 
     expect(readResult.config.type).to.equal(FeeType.routing);
@@ -107,7 +113,11 @@ describe('SVM Routing Fee E2E Tests', function () {
       },
     });
 
-    const reader = new SvmRoutingFeeReader(rpc, ALL_DOMAINS_CONTEXT);
+    const reader = new SvmRoutingFeeReader(
+      rpc,
+      ALL_DOMAINS_CONTEXT,
+      DEFAULT_FEE_SALT,
+    );
     const readResult = await reader.read(deployed.deployed.programId);
 
     const route = readResult.config.routes[10];
@@ -160,7 +170,11 @@ describe('SVM Routing Fee E2E Tests', function () {
       await signer.send(tx);
     }
 
-    const reader = new SvmRoutingFeeReader(rpc, ALL_DOMAINS_CONTEXT);
+    const reader = new SvmRoutingFeeReader(
+      rpc,
+      ALL_DOMAINS_CONTEXT,
+      DEFAULT_FEE_SALT,
+    );
     const readResult = await reader.read(deployed.deployed.programId);
     expect(readResult.config.routes[20]?.type).to.equal(
       FeeStrategyType.progressive,
@@ -203,7 +217,11 @@ describe('SVM Routing Fee E2E Tests', function () {
       await signer.send(tx);
     }
 
-    const reader = new SvmRoutingFeeReader(rpc, ALL_DOMAINS_CONTEXT);
+    const reader = new SvmRoutingFeeReader(
+      rpc,
+      ALL_DOMAINS_CONTEXT,
+      DEFAULT_FEE_SALT,
+    );
     const readResult = await reader.read(deployed.deployed.programId);
     expect(readResult.config.routes[10]?.maxFee).to.equal('9999');
     expect(readResult.config.routes[10]?.halfAmount).to.equal('4444');
@@ -244,7 +262,11 @@ describe('SVM Routing Fee E2E Tests', function () {
       await signer.send(tx);
     }
 
-    const reader = new SvmRoutingFeeReader(rpc, ALL_DOMAINS_CONTEXT);
+    const reader = new SvmRoutingFeeReader(
+      rpc,
+      ALL_DOMAINS_CONTEXT,
+      DEFAULT_FEE_SALT,
+    );
     const readResult = await reader.read(deployed.deployed.programId);
     expect(readResult.config.routes[10]?.type).to.equal(
       FeeStrategyType.regressive,
@@ -292,7 +314,11 @@ describe('SVM Routing Fee E2E Tests', function () {
       await signer.send(tx);
     }
 
-    const reader = new SvmRoutingFeeReader(rpc, ALL_DOMAINS_CONTEXT);
+    const reader = new SvmRoutingFeeReader(
+      rpc,
+      ALL_DOMAINS_CONTEXT,
+      DEFAULT_FEE_SALT,
+    );
     const readResult = await reader.read(deployed.deployed.programId);
     expect(readResult.config.routes[10]).to.exist;
     expect(readResult.config.routes[20]).to.be.undefined;

--- a/typescript/svm-sdk/src/tests/fee-stress.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/fee-stress.e2e-test.ts
@@ -29,6 +29,7 @@ import { SvmRoutingFeeWriter } from '../fee/routing-fee.js';
 import {
   deriveFeeSalt,
   signerToH160,
+  DEFAULT_FEE_SALT,
   FeeDataKind,
   FeeStrategyKind,
 } from '../fee/types.js';
@@ -216,6 +217,7 @@ describe('SVM Fee Stress Tests — Finding Limits', function () {
           rpc,
           1,
           signer,
+          DEFAULT_FEE_SALT,
         );
 
         await writer.create({
@@ -248,6 +250,7 @@ describe('SVM Fee Stress Tests — Finding Limits', function () {
           1,
           signer,
           { knownRoutersPerDomain: { 1: new Set() } },
+          DEFAULT_FEE_SALT,
         );
 
         await writer.create({

--- a/typescript/svm-sdk/src/tests/native-token.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/native-token.e2e-test.ts
@@ -19,6 +19,7 @@ import {
   TEST_PROGRAM_IDS,
   airdropSol,
 } from '../testing/setup.js';
+import { DEFAULT_FEE_SALT } from '../fee/types.js';
 import { SvmNativeTokenWriter } from '../warp/native-token.js';
 
 import { defineWarpTokenTests } from './warp-token-suite.js';
@@ -83,6 +84,7 @@ describe('SVM Native Warp Token E2E Tests', function () {
       {
         program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenNative },
         ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
       },
       rpc,
       signer,

--- a/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
@@ -3,9 +3,13 @@ import { expect } from 'chai';
 import { before, describe, it } from 'mocha';
 
 import { ArtifactState } from '@hyperlane-xyz/provider-sdk/artifact';
-import { TokenType } from '@hyperlane-xyz/provider-sdk/warp';
+import { FeeType } from '@hyperlane-xyz/provider-sdk/fee';
 import type { IgpHookConfig } from '@hyperlane-xyz/provider-sdk/hook';
+import { TokenType } from '@hyperlane-xyz/provider-sdk/warp';
 import { sleep } from '@hyperlane-xyz/utils';
+
+import { SvmLinearFeeWriter } from '../fee/linear-fee.js';
+import { deriveFeeAccountPda } from '../pda.js';
 
 import { SvmSigner } from '../clients/signer.js';
 import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
@@ -131,6 +135,49 @@ describe('SVM Program Upgrade E2E Tests', function () {
 
     const afterUpgrade = await reader.read(programId);
     expect(afterUpgrade.config.contractVersion).to.equal('1.0.0');
+
+    // Verify SetFeeConfig works after upgrade — the whole point of upgrading
+    const feeWriter = new SvmLinearFeeWriter(
+      { program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenFee } },
+      rpc,
+      1,
+      signer,
+      DEFAULT_FEE_SALT,
+    );
+    const [deployedFee] = await feeWriter.create({
+      config: {
+        type: FeeType.linear,
+        owner: signer.getSignerAddress(),
+        beneficiary: signer.getSignerAddress(),
+        maxFee: '1000000',
+        halfAmount: '500000',
+      },
+    });
+    const feeProgram = address(deployedFee.deployed.programId);
+
+    const setFeeTxs = await upgradeWriter.update({
+      ...afterUpgrade,
+      config: {
+        ...afterUpgrade.config,
+        contractVersion: '1.0.0',
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgram },
+        },
+      },
+    });
+    expect(setFeeTxs).to.have.length(1);
+    for (const tx of setFeeTxs) {
+      await signer.send({ instructions: tx.instructions });
+    }
+
+    const withFee = await reader.read(programId);
+    const expectedPda = await deriveFeeAccountPda(feeProgram, DEFAULT_FEE_SALT);
+    expect(withFee.deployed.feeConfig).to.exist;
+    expect(withFee.deployed.feeConfig?.feeProgram).to.equal(feeProgram);
+    expect(withFee.deployed.feeConfig?.feeAccount).to.equal(
+      expectedPda.address,
+    );
   });
 
   it('should upgrade when authority differs from payer', async () => {

--- a/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
@@ -120,8 +120,8 @@ describe('SVM Program Upgrade E2E Tests', function () {
       },
     });
 
-    // Expect 2 authority txs: extend (new binary is larger) + upgrade
-    expect(updateTxs).to.have.length(2);
+    // Expect 3 authority txs: extend + upgrade + SetFeeConfig(None) migration
+    expect(updateTxs).to.have.length(3);
     for (const tx of updateTxs) {
       await signer.send({
         instructions: tx.instructions,
@@ -251,8 +251,8 @@ describe('SVM Program Upgrade E2E Tests', function () {
       },
     });
 
-    // Expect 2 authority txs: extend + upgrade, both with feePayer = signerB
-    expect(updateTxs).to.have.length(2);
+    // Expect 3 authority txs: extend + upgrade + migration, all with feePayer = signerB
+    expect(updateTxs).to.have.length(3);
     for (const tx of updateTxs) {
       expect(tx.feePayer).to.equal(signerB.getSignerAddress());
     }
@@ -408,6 +408,8 @@ describe('SVM Program Upgrade E2E Tests', function () {
       },
     });
 
+    // Remove the set fee tx to make the test fail
+    upgradeTxs.pop();
     for (const tx of upgradeTxs) {
       await signer.send({
         instructions: tx.instructions,
@@ -453,5 +455,85 @@ describe('SVM Program Upgrade E2E Tests', function () {
       const cause = (e as { cause?: { message?: string } }).cause;
       expect(cause?.message).to.include('serialize or deserialize');
     }
+  });
+
+  it('should succeed ownership transfer after upgrade with migration', async () => {
+    // Same setup as the failing test — legacy deploy with all options filled.
+    const legacyWriter = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: LEGACY_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
+      },
+      rpc,
+      signer,
+    );
+
+    const [deployed] = await legacyWriter.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        interchainSecurityModule: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: TEST_PROGRAM_IDS.testIsm },
+        },
+        hook: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: TEST_PROGRAM_IDS.igp },
+        },
+        remoteRouters: {
+          1: {
+            address:
+              '0x1111111111111111111111111111111111111111111111111111111111111111',
+          },
+        },
+        destinationGas: { 1: '100000' },
+      },
+    });
+
+    const programId = deployed.deployed.address;
+
+    const upgradeWriter = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
+      },
+      rpc,
+      signer,
+    );
+
+    const current = await legacyWriter.read(programId);
+
+    const newOwner = await SvmSigner.connectWithSigner(
+      [TEST_SVM_CHAIN_METADATA.rpcUrl],
+      '0x0000000000000000000000000000000000000000000000000000000000000004',
+    );
+    await airdropSol(rpc, address(newOwner.getSignerAddress()), 5_000_000_000n);
+
+    // Upgrade + migration + ownership transfer — all txs included
+    const allTxs = await upgradeWriter.update({
+      ...current,
+      config: {
+        ...current.config,
+        contractVersion: '1.0.0',
+        owner: newOwner.getSignerAddress(),
+      },
+    });
+
+    for (const tx of allTxs) {
+      await signer.send({
+        instructions: tx.instructions,
+        additionalSigners: tx.additionalSigners,
+        skipPreflight: true,
+      });
+    }
+
+    await sleep(1000);
+    const afterUpdate = await upgradeWriter.read(programId);
+    expect(afterUpdate.config.contractVersion).to.equal('1.0.0');
+    expect(afterUpdate.config.owner).to.equal(newOwner.getSignerAddress());
   });
 });

--- a/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
@@ -408,7 +408,8 @@ describe('SVM Program Upgrade E2E Tests', function () {
       },
     });
 
-    // Remove the set fee tx to make the test fail
+    // Remove the last tx (SetFeeConfig(None) migration) to simulate a partial
+    // upgrade. prepareProgramUpgrade always appends the migration tx last.
     upgradeTxs.pop();
     for (const tx of upgradeTxs) {
       await signer.send({

--- a/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
@@ -1,0 +1,294 @@
+import { address, type Address } from '@solana/kit';
+import { expect } from 'chai';
+import { before, describe, it } from 'mocha';
+
+import { ArtifactState } from '@hyperlane-xyz/provider-sdk/artifact';
+import { TokenType } from '@hyperlane-xyz/provider-sdk/warp';
+import type { IgpHookConfig } from '@hyperlane-xyz/provider-sdk/hook';
+import { sleep } from '@hyperlane-xyz/utils';
+
+import { SvmSigner } from '../clients/signer.js';
+import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
+import { LEGACY_SVM_PROGRAM_BYTES } from '../hyperlane/legacy-program-bytes.js';
+import { DEFAULT_IGP_SALT, SvmIgpHookWriter } from '../hook/igp-hook.js';
+import { createRpc } from '../rpc.js';
+import { TEST_SVM_CHAIN_METADATA } from '../testing/constants.js';
+import {
+  TEST_ATA_PAYER_FUNDING_AMOUNT,
+  TEST_PROGRAM_IDS,
+  airdropSol,
+  createSplMint,
+} from '../testing/setup.js';
+import {
+  SvmCollateralTokenReader,
+  SvmCollateralTokenWriter,
+} from '../warp/collateral-token.js';
+
+const TEST_PRIVATE_KEY =
+  '0x0000000000000000000000000000000000000000000000000000000000000001';
+
+describe('SVM Program Upgrade E2E Tests', function () {
+  this.timeout(600_000);
+
+  let rpc: ReturnType<typeof createRpc>;
+  let signer: SvmSigner;
+  let mailboxAddress: Address;
+  let collateralMint: Address;
+
+  before(async () => {
+    rpc = createRpc(TEST_SVM_CHAIN_METADATA.rpcUrl);
+    signer = await SvmSigner.connectWithSigner(
+      [TEST_SVM_CHAIN_METADATA.rpcUrl],
+      TEST_PRIVATE_KEY,
+    );
+    await airdropSol(rpc, address(signer.getSignerAddress()), 50_000_000_000n);
+    mailboxAddress = TEST_PROGRAM_IDS.mailbox;
+    collateralMint = await createSplMint(rpc, signer, 9);
+
+    const igpConfig: IgpHookConfig = {
+      type: 'interchainGasPaymaster',
+      owner: signer.getSignerAddress(),
+      beneficiary: signer.getSignerAddress(),
+      oracleKey: signer.getSignerAddress(),
+      overhead: { 1: 50000 },
+      oracleConfig: {
+        1: { gasPrice: '1', tokenExchangeRate: '1000000000000000000' },
+      },
+    };
+    const igpWriter = new SvmIgpHookWriter(
+      { program: { programId: TEST_PROGRAM_IDS.igp } },
+      rpc,
+      DEFAULT_IGP_SALT,
+      signer,
+    );
+    await igpWriter.create({
+      artifactState: ArtifactState.NEW,
+      config: igpConfig,
+    });
+  });
+
+  it('should deploy with legacy bytes, upgrade, and read new version', async () => {
+    const legacyWriter = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: LEGACY_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+      },
+      rpc,
+      signer,
+    );
+
+    const [deployed] = await legacyWriter.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+      },
+    });
+
+    const programId = deployed.deployed.address;
+
+    // Read — legacy program should have no contractVersion
+    const reader = new SvmCollateralTokenReader(rpc);
+    const beforeUpgrade = await reader.read(programId);
+    expect(beforeUpgrade.config.contractVersion).to.be.undefined;
+
+    // Update with new bytes and contractVersion to trigger upgrade
+    const upgradeWriter = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+      },
+      rpc,
+      signer,
+    );
+
+    const updateTxs = await upgradeWriter.update({
+      ...beforeUpgrade,
+      config: {
+        ...beforeUpgrade.config,
+        contractVersion: '1.0.0',
+      },
+    });
+
+    // Expect 2 authority txs: extend (new binary is larger) + upgrade
+    expect(updateTxs).to.have.length(2);
+    for (const tx of updateTxs) {
+      await signer.send({
+        instructions: tx.instructions,
+        additionalSigners: tx.additionalSigners,
+        skipPreflight: true,
+      });
+    }
+
+    // Wait for the upgrade to take effect (binary swap needs a slot advance)
+    await sleep(1000);
+
+    const afterUpgrade = await reader.read(programId);
+    expect(afterUpgrade.config.contractVersion).to.equal('1.0.0');
+  });
+
+  it('should upgrade when authority differs from payer', async () => {
+    // Signer A deploys with legacy bytes
+    const signerA = signer;
+    const legacyWriter = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: LEGACY_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+      },
+      rpc,
+      signerA,
+    );
+
+    const [deployed] = await legacyWriter.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signerA.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+      },
+    });
+
+    const programId = deployed.deployed.address;
+
+    // Transfer ownership + upgrade authority to Signer B
+    const signerB = await SvmSigner.connectWithSigner(
+      [TEST_SVM_CHAIN_METADATA.rpcUrl],
+      '0x0000000000000000000000000000000000000000000000000000000000000002',
+    );
+    await airdropSol(rpc, address(signerB.getSignerAddress()), 10_000_000_000n);
+
+    const current = await legacyWriter.read(programId);
+    const transferTxs = await legacyWriter.update({
+      ...current,
+      config: {
+        ...current.config,
+        owner: signerB.getSignerAddress(),
+      },
+    });
+    for (const tx of transferTxs) {
+      await signerA.send({
+        instructions: tx.instructions,
+        additionalSigners: tx.additionalSigners,
+      });
+    }
+
+    // Verify Signer B is now the owner
+    const afterTransfer = await legacyWriter.read(programId);
+    expect(afterTransfer.config.owner).to.equal(signerB.getSignerAddress());
+
+    // Signer A generates upgrade txs (pays for buffer) but upgrade authority is Signer B
+    const upgradeWriter = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+      },
+      rpc,
+      signerA,
+    );
+
+    const updateTxs = await upgradeWriter.update({
+      ...afterTransfer,
+      config: {
+        ...afterTransfer.config,
+        contractVersion: '1.0.0',
+      },
+    });
+
+    // Expect 2 authority txs: extend + upgrade, both with feePayer = signerB
+    expect(updateTxs).to.have.length(2);
+    for (const tx of updateTxs) {
+      expect(tx.feePayer).to.equal(signerB.getSignerAddress());
+    }
+
+    for (const tx of updateTxs) {
+      await signerB.send({
+        instructions: tx.instructions,
+        additionalSigners: tx.additionalSigners,
+        skipPreflight: true,
+      });
+    }
+
+    // Wait for the upgrade to take effect (binary swap needs a slot advance)
+    await sleep(1000);
+
+    const afterUpgrade = await upgradeWriter.read(programId);
+    expect(afterUpgrade.config.contractVersion).to.equal('1.0.0');
+  });
+
+  it('should reject downgrade attempt', async () => {
+    const writer = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+      },
+      rpc,
+      signer,
+    );
+
+    const [deployed] = await writer.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+      },
+    });
+
+    const current = await writer.read(deployed.deployed.address);
+    expect(current.config.contractVersion).to.equal('1.0.0');
+
+    try {
+      await writer.update({
+        ...current,
+        config: {
+          ...current.config,
+          contractVersion: '0.1.0',
+        },
+      });
+      expect.fail('Should have thrown on downgrade');
+    } catch (e: unknown) {
+      expect((e as Error).message).to.include('Cannot downgrade');
+    }
+  });
+
+  it('should skip upgrade when contractVersion matches', async () => {
+    const writer = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+      },
+      rpc,
+      signer,
+    );
+
+    const [deployed] = await writer.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+      },
+    });
+
+    const current = await writer.read(deployed.deployed.address);
+
+    const updateTxs = await writer.update({
+      ...current,
+      config: {
+        ...current.config,
+        contractVersion: current.config.contractVersion,
+      },
+    });
+
+    expect(updateTxs).to.have.length(0);
+  });
+});

--- a/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
@@ -345,4 +345,113 @@ describe('SVM Program Upgrade E2E Tests', function () {
 
     expect(updateTxs).to.have.length(0);
   });
+
+  it('should fail ownership transfer after upgrade without SetFeeConfig(None) migration', async () => {
+    // Deploy with legacy bytes
+    const legacyWriter = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: LEGACY_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
+      },
+      rpc,
+      signer,
+    );
+
+    // Deploy with ALL optional fields set (ISM, IGP, routers, gas) to maximize
+    // serialized size. When every Option is Some, the serialized data fills the
+    // allocated buffer exactly — leaving no room for the 1-byte fee_config tag
+    // that the new binary writes.
+    const [deployed] = await legacyWriter.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        interchainSecurityModule: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: TEST_PROGRAM_IDS.testIsm },
+        },
+        hook: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: TEST_PROGRAM_IDS.igp },
+        },
+        remoteRouters: {
+          1: {
+            address:
+              '0x1111111111111111111111111111111111111111111111111111111111111111',
+          },
+        },
+        destinationGas: { 1: '100000' },
+      },
+    });
+
+    const programId = deployed.deployed.address;
+
+    // Upgrade to new version
+    const upgradeWriter = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
+      },
+      rpc,
+      signer,
+    );
+
+    const current = await legacyWriter.read(programId);
+    const upgradeTxs = await upgradeWriter.update({
+      ...current,
+      config: {
+        ...current.config,
+        contractVersion: '1.0.0',
+      },
+    });
+
+    for (const tx of upgradeTxs) {
+      await signer.send({
+        instructions: tx.instructions,
+        additionalSigners: tx.additionalSigners,
+        skipPreflight: true,
+      });
+    }
+    await sleep(1000);
+
+    // Ownership transfer WITHOUT SetFeeConfig(None) migration fails.
+    // The new binary serializes fee_config: None (1 extra byte) but
+    // transfer_ownership uses store(account, false) — no realloc.
+    // When all optional fields are Some, the buffer is exactly full
+    // and the extra byte causes BorshIoError.
+    const newOwner = await SvmSigner.connectWithSigner(
+      [TEST_SVM_CHAIN_METADATA.rpcUrl],
+      '0x0000000000000000000000000000000000000000000000000000000000000003',
+    );
+    await airdropSol(rpc, address(newOwner.getSignerAddress()), 5_000_000_000n);
+
+    const afterUpgrade = await upgradeWriter.read(programId);
+    const ownershipTxs = await upgradeWriter.update({
+      ...afterUpgrade,
+      config: {
+        ...afterUpgrade.config,
+        contractVersion: '1.0.0',
+        owner: newOwner.getSignerAddress(),
+      },
+    });
+
+    expect(ownershipTxs.length).to.be.greaterThan(0);
+    try {
+      for (const tx of ownershipTxs) {
+        await signer.send({
+          instructions: tx.instructions,
+          additionalSigners: tx.additionalSigners,
+        });
+      }
+      expect.fail('Should have failed without SetFeeConfig(None) migration');
+    } catch (e: unknown) {
+      // BorshIoError surfaces in the cause chain as
+      // "Failed to serialize or deserialize account data".
+      const cause = (e as { cause?: { message?: string } }).cause;
+      expect(cause?.message).to.include('serialize or deserialize');
+    }
+  });
 });

--- a/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
@@ -19,6 +19,7 @@ import {
   airdropSol,
   createSplMint,
 } from '../testing/setup.js';
+import { DEFAULT_FEE_SALT } from '../fee/types.js';
 import {
   SvmCollateralTokenReader,
   SvmCollateralTokenWriter,
@@ -72,6 +73,7 @@ describe('SVM Program Upgrade E2E Tests', function () {
       {
         program: { programBytes: LEGACY_SVM_PROGRAM_BYTES.tokenCollateral },
         ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
       },
       rpc,
       signer,
@@ -100,6 +102,7 @@ describe('SVM Program Upgrade E2E Tests', function () {
       {
         program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
         ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
       },
       rpc,
       signer,
@@ -137,6 +140,7 @@ describe('SVM Program Upgrade E2E Tests', function () {
       {
         program: { programBytes: LEGACY_SVM_PROGRAM_BYTES.tokenCollateral },
         ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
       },
       rpc,
       signerA,
@@ -186,6 +190,7 @@ describe('SVM Program Upgrade E2E Tests', function () {
       {
         program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
         ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
       },
       rpc,
       signerA,
@@ -225,6 +230,7 @@ describe('SVM Program Upgrade E2E Tests', function () {
       {
         program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
         ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
       },
       rpc,
       signer,
@@ -263,6 +269,7 @@ describe('SVM Program Upgrade E2E Tests', function () {
       {
         program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
         ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
       },
       rpc,
       signer,

--- a/typescript/svm-sdk/src/tests/read-token.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/read-token.e2e-test.ts
@@ -14,7 +14,9 @@ describe('SVM Warp Token read E2E Tests', function () {
 
   before(async () => {
     rpc = createRpc('https://api.mainnet-beta.solana.com');
-    artifactManager = new SvmWarpArtifactManager(rpc);
+    artifactManager = new SvmWarpArtifactManager(rpc, {
+      chainName: 'solanamainnet',
+    });
   });
 
   for (const testCase of [

--- a/typescript/svm-sdk/src/tests/synthetic-token.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/synthetic-token.e2e-test.ts
@@ -20,6 +20,7 @@ import {
   TEST_PROGRAM_IDS,
   airdropSol,
 } from '../testing/setup.js';
+import { DEFAULT_FEE_SALT } from '../fee/types.js';
 import { SvmSyntheticTokenWriter } from '../warp/synthetic-token.js';
 
 import { defineWarpTokenTests } from './warp-token-suite.js';
@@ -84,6 +85,7 @@ describe('SVM Synthetic Warp Token E2E Tests', function () {
       {
         program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenSynthetic },
         ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
       },
       rpc,
       signer,

--- a/typescript/svm-sdk/src/tests/warp-fee-config.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/warp-fee-config.e2e-test.ts
@@ -1,0 +1,304 @@
+import { address, type Address } from '@solana/kit';
+import { expect } from 'chai';
+import { before, describe, it } from 'mocha';
+
+import { ArtifactState } from '@hyperlane-xyz/provider-sdk/artifact';
+import { FeeType } from '@hyperlane-xyz/provider-sdk/fee';
+import type { IgpHookConfig } from '@hyperlane-xyz/provider-sdk/hook';
+import { TokenType } from '@hyperlane-xyz/provider-sdk/warp';
+
+import { SvmSigner } from '../clients/signer.js';
+import { SvmLinearFeeWriter } from '../fee/linear-fee.js';
+import { DEFAULT_FEE_SALT, deriveFeeSalt } from '../fee/types.js';
+import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
+import { DEFAULT_IGP_SALT, SvmIgpHookWriter } from '../hook/igp-hook.js';
+import { deriveFeeAccountPda } from '../pda.js';
+import { createRpc } from '../rpc.js';
+import { TEST_SVM_CHAIN_METADATA } from '../testing/constants.js';
+import {
+  TEST_ATA_PAYER_FUNDING_AMOUNT,
+  TEST_PROGRAM_IDS,
+  airdropSol,
+  createSplMint,
+} from '../testing/setup.js';
+import {
+  SvmCollateralTokenReader,
+  SvmCollateralTokenWriter,
+} from '../warp/collateral-token.js';
+
+const TEST_PRIVATE_KEY =
+  '0x0000000000000000000000000000000000000000000000000000000000000001';
+
+const ALTERNATE_SALT = deriveFeeSalt('alternate-salt');
+
+describe('SVM Warp Fee Config E2E Tests', function () {
+  this.timeout(300_000);
+
+  let rpc: ReturnType<typeof createRpc>;
+  let signer: SvmSigner;
+  let mailboxAddress: Address;
+  let collateralMint: Address;
+  let feeProgramA: Address;
+  let feeProgramB: Address;
+
+  function makeWriter(feeSalt: Uint8Array = DEFAULT_FEE_SALT) {
+    return new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt,
+      },
+      rpc,
+      signer,
+    );
+  }
+
+  async function deployFee(salt: Uint8Array): Promise<Address> {
+    const feeWriter = new SvmLinearFeeWriter(
+      { program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenFee } },
+      rpc,
+      1,
+      signer,
+      salt,
+    );
+    const [deployed] = await feeWriter.create({
+      config: {
+        type: FeeType.linear,
+        owner: signer.getSignerAddress(),
+        beneficiary: signer.getSignerAddress(),
+        maxFee: '1000000',
+        halfAmount: '500000',
+      },
+    });
+    return address(deployed.deployed.programId);
+  }
+
+  before(async () => {
+    rpc = createRpc(TEST_SVM_CHAIN_METADATA.rpcUrl);
+    signer = await SvmSigner.connectWithSigner(
+      [TEST_SVM_CHAIN_METADATA.rpcUrl],
+      TEST_PRIVATE_KEY,
+    );
+    await airdropSol(rpc, address(signer.getSignerAddress()), 100_000_000_000n);
+    mailboxAddress = TEST_PROGRAM_IDS.mailbox;
+    collateralMint = await createSplMint(rpc, signer, 9);
+
+    const igpWriter = new SvmIgpHookWriter(
+      { program: { programId: TEST_PROGRAM_IDS.igp } },
+      rpc,
+      DEFAULT_IGP_SALT,
+      signer,
+    );
+    await igpWriter.create({
+      artifactState: ArtifactState.NEW,
+      config: {
+        type: 'interchainGasPaymaster',
+        owner: signer.getSignerAddress(),
+        beneficiary: signer.getSignerAddress(),
+        oracleKey: signer.getSignerAddress(),
+        overhead: { 1: 50000 },
+        oracleConfig: {
+          1: { gasPrice: '1', tokenExchangeRate: '1000000000000000000' },
+        },
+      } satisfies IgpHookConfig,
+    });
+
+    feeProgramA = await deployFee(DEFAULT_FEE_SALT);
+    feeProgramB = await deployFee(DEFAULT_FEE_SALT);
+  });
+
+  it('should set fee on deployment', async () => {
+    const writer = makeWriter();
+    const [deployed] = await writer.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramA },
+        },
+      },
+    });
+
+    const onChain = await new SvmCollateralTokenReader(rpc).read(
+      deployed.deployed.address,
+    );
+    const expectedPda = await deriveFeeAccountPda(
+      feeProgramA,
+      DEFAULT_FEE_SALT,
+    );
+
+    expect(onChain.deployed.feeConfig).to.exist;
+    expect(onChain.deployed.feeConfig?.feeProgram).to.equal(feeProgramA);
+    expect(onChain.deployed.feeConfig?.feeAccount).to.equal(
+      expectedPda.address,
+    );
+  });
+
+  it('should add fee via update when none was set', async () => {
+    const writer = makeWriter();
+    const [deployed] = await writer.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+      },
+    });
+
+    const current = await writer.read(deployed.deployed.address);
+    expect(current.deployed.feeConfig).to.be.undefined;
+
+    const updateTxs = await writer.update({
+      ...current,
+      config: {
+        ...current.config,
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramA },
+        },
+      },
+    });
+
+    expect(updateTxs).to.have.length(1);
+    for (const tx of updateTxs) {
+      await signer.send({ instructions: tx.instructions });
+    }
+
+    const afterUpdate = await writer.read(deployed.deployed.address);
+    expect(afterUpdate.deployed.feeConfig?.feeProgram).to.equal(feeProgramA);
+  });
+
+  it('should change from one fee program to another', async () => {
+    const writer = makeWriter();
+    const [deployed] = await writer.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramA },
+        },
+      },
+    });
+
+    const current = await writer.read(deployed.deployed.address);
+    expect(current.deployed.feeConfig?.feeProgram).to.equal(feeProgramA);
+
+    const updateTxs = await writer.update({
+      ...current,
+      config: {
+        ...current.config,
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramB },
+        },
+      },
+    });
+
+    expect(updateTxs).to.have.length(1);
+    for (const tx of updateTxs) {
+      await signer.send({ instructions: tx.instructions });
+    }
+
+    const afterUpdate = await writer.read(deployed.deployed.address);
+    expect(afterUpdate.deployed.feeConfig?.feeProgram).to.equal(feeProgramB);
+  });
+
+  it('should detect fee account change when program stays but salt differs', async () => {
+    // Deploy with default salt
+    const writer = makeWriter(DEFAULT_FEE_SALT);
+    const [deployed] = await writer.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramA },
+        },
+      },
+    });
+
+    const current = await writer.read(deployed.deployed.address);
+    const defaultPda = await deriveFeeAccountPda(feeProgramA, DEFAULT_FEE_SALT);
+    expect(current.deployed.feeConfig?.feeAccount).to.equal(defaultPda.address);
+
+    // Update with alternate salt — same program but different fee account PDA
+    const altWriter = makeWriter(ALTERNATE_SALT);
+    const updateTxs = await altWriter.update({
+      ...current,
+      config: {
+        ...current.config,
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramA },
+        },
+      },
+    });
+
+    expect(updateTxs).to.have.length(1);
+    for (const tx of updateTxs) {
+      await signer.send({ instructions: tx.instructions });
+    }
+
+    const afterUpdate = await altWriter.read(deployed.deployed.address);
+    const altPda = await deriveFeeAccountPda(feeProgramA, ALTERNATE_SALT);
+    expect(afterUpdate.deployed.feeConfig?.feeProgram).to.equal(feeProgramA);
+    expect(afterUpdate.deployed.feeConfig?.feeAccount).to.equal(altPda.address);
+    expect(afterUpdate.deployed.feeConfig?.feeAccount).to.not.equal(
+      defaultPda.address,
+    );
+  });
+
+  it('should remove fee via update', async () => {
+    const writer = makeWriter();
+    const [deployed] = await writer.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramA },
+        },
+      },
+    });
+
+    const current = await writer.read(deployed.deployed.address);
+    expect(current.deployed.feeConfig).to.exist;
+
+    const updateTxs = await writer.update({
+      ...current,
+      config: {
+        ...current.config,
+        fee: undefined,
+      },
+    });
+
+    expect(updateTxs).to.have.length(1);
+    for (const tx of updateTxs) {
+      await signer.send({ instructions: tx.instructions });
+    }
+
+    const afterUpdate = await writer.read(deployed.deployed.address);
+    expect(afterUpdate.deployed.feeConfig).to.be.undefined;
+    expect(afterUpdate.config.fee).to.be.undefined;
+  });
+});

--- a/typescript/svm-sdk/src/tests/warp-token-suite.ts
+++ b/typescript/svm-sdk/src/tests/warp-token-suite.ts
@@ -14,6 +14,10 @@ import { SvmSigner } from '../clients/signer.js';
 import { getProgramUpgradeAuthority } from '../deploy/program-deployer.js';
 import type { createRpc } from '../rpc.js';
 import { airdropSol } from '../testing/setup.js';
+import {
+  queryProgramVersion,
+  supportsFeeConfig,
+} from '../version/version-query.js';
 
 /**
  * Overrides that can be applied to any token type config.
@@ -73,6 +77,18 @@ export function defineWarpTokenTests(
     expect(onChain.config.hook).to.be.undefined;
     expect(onChain.config.interchainSecurityModule).to.be.undefined;
     expect(onChain.config.scale).to.equal(testScale);
+  });
+
+  it('should return program version after deploy', async () => {
+    const { rpc, signer } = getContext();
+    const version = await queryProgramVersion(
+      rpc,
+      address(deployedProgramId),
+      address(signer.getSignerAddress()),
+    );
+    expect(version).to.be.a('string');
+    expect(version).to.not.be.empty;
+    expect(supportsFeeConfig(version)).to.be.true;
   });
 
   it('should deploy with IGP and ISM configured and read them back', async () => {

--- a/typescript/svm-sdk/src/tests/warp-token-suite.ts
+++ b/typescript/svm-sdk/src/tests/warp-token-suite.ts
@@ -14,10 +14,7 @@ import { SvmSigner } from '../clients/signer.js';
 import { getProgramUpgradeAuthority } from '../deploy/program-deployer.js';
 import type { createRpc } from '../rpc.js';
 import { airdropSol } from '../testing/setup.js';
-import {
-  queryProgramVersion,
-  supportsFeeConfig,
-} from '../version/version-query.js';
+import { supportsFeeConfig } from '../version/version-query.js';
 
 /**
  * Overrides that can be applied to any token type config.
@@ -80,15 +77,11 @@ export function defineWarpTokenTests(
   });
 
   it('should return program version after deploy', async () => {
-    const { rpc, signer } = getContext();
-    const version = await queryProgramVersion(
-      rpc,
-      address(deployedProgramId),
-      address(signer.getSignerAddress()),
-    );
-    expect(version).to.be.a('string');
-    expect(version).to.not.be.empty;
-    expect(supportsFeeConfig(version)).to.be.true;
+    const { writer } = getContext();
+    const onChain = await writer.read(deployedProgramId);
+    expect(onChain.config.contractVersion).to.be.a('string');
+    expect(onChain.config.contractVersion).to.not.be.empty;
+    expect(supportsFeeConfig(onChain.config.contractVersion!)).to.be.true;
   });
 
   it('should deploy with IGP and ISM configured and read them back', async () => {

--- a/typescript/svm-sdk/src/tests/warp-tx.unit-test.ts
+++ b/typescript/svm-sdk/src/tests/warp-tx.unit-test.ts
@@ -5,7 +5,9 @@ import { describe, it } from 'mocha';
 import { ArtifactState } from '@hyperlane-xyz/provider-sdk/artifact';
 import type { RawNativeWarpArtifactConfig } from '@hyperlane-xyz/provider-sdk/warp';
 
-import { DEFAULT_FEE_SALT } from '../fee/types.js';
+import type { TokenFeeConfig } from '../accounts/token.js';
+import { DEFAULT_FEE_SALT, deriveFeeSalt } from '../fee/types.js';
+import { deriveFeeAccountPda } from '../pda.js';
 import type { SvmRpc } from '../types.js';
 import { computeWarpTokenUpdateInstructions } from '../warp/warp-tx.js';
 
@@ -14,6 +16,8 @@ const PROGRAM = address('2gqSMt66ZABt82TTQgrdxf7tJ4eQpLuYj6N29ieBQrH2');
 const ISM_A = address('11111111111111111111111111111112');
 const ISM_B = address('11111111111111111111111111111113');
 const NEW_OWNER = address('11111111111111111111111111111114');
+const FEE_PROGRAM_A = address('FeeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+const FEE_PROGRAM_B = address('FeeBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB');
 const ROUTER_HEX =
   '0x0000000000000000000000000000000000000000000000000000000000000001';
 
@@ -109,4 +113,106 @@ describe('computeWarpTokenUpdateInstructions — feePayer', () => {
       }
     });
   }
+});
+
+function feeArtifact(addr: string) {
+  return {
+    artifactState: ArtifactState.UNDERIVED,
+    deployed: { address: addr },
+  };
+}
+
+async function buildFeeConfig(
+  feeProgram: string,
+  salt: Uint8Array = DEFAULT_FEE_SALT,
+): Promise<TokenFeeConfig> {
+  const pda = await deriveFeeAccountPda(address(feeProgram), salt);
+  return { feeProgram: address(feeProgram), feeAccount: pda.address };
+}
+
+describe('computeWarpTokenUpdateInstructions — fee config diff', () => {
+  it('add fee: emits SetFeeConfig when current has no fee', async () => {
+    const txs = await computeWarpTokenUpdateInstructions(
+      makeConfig({}),
+      makeConfig({ fee: feeArtifact(FEE_PROGRAM_A) }),
+      PROGRAM,
+      OWNER,
+      createStubRpc(),
+      'test',
+      DEFAULT_FEE_SALT,
+      undefined,
+    );
+
+    expect(txs).to.have.length(1);
+    expect(txs[0].annotation).to.include('fee');
+  });
+
+  it('remove fee: emits SetFeeConfig(null) when expected has no fee', async () => {
+    const currentFee = await buildFeeConfig(FEE_PROGRAM_A);
+    const txs = await computeWarpTokenUpdateInstructions(
+      makeConfig({ fee: feeArtifact(FEE_PROGRAM_A) }),
+      makeConfig({}),
+      PROGRAM,
+      OWNER,
+      createStubRpc(),
+      'test',
+      DEFAULT_FEE_SALT,
+      currentFee,
+    );
+
+    expect(txs).to.have.length(1);
+    expect(txs[0].annotation).to.include('fee');
+  });
+
+  it('change fee program: emits SetFeeConfig when program differs', async () => {
+    const currentFee = await buildFeeConfig(FEE_PROGRAM_A);
+    const txs = await computeWarpTokenUpdateInstructions(
+      makeConfig({ fee: feeArtifact(FEE_PROGRAM_A) }),
+      makeConfig({ fee: feeArtifact(FEE_PROGRAM_B) }),
+      PROGRAM,
+      OWNER,
+      createStubRpc(),
+      'test',
+      DEFAULT_FEE_SALT,
+      currentFee,
+    );
+
+    expect(txs).to.have.length(1);
+    expect(txs[0].annotation).to.include('fee');
+  });
+
+  it('same fee program but different salt: emits SetFeeConfig when PDA differs', async () => {
+    const originalSalt = DEFAULT_FEE_SALT;
+    const differentSalt = deriveFeeSalt('alternate-salt');
+    const currentFee = await buildFeeConfig(FEE_PROGRAM_A, originalSalt);
+    const txs = await computeWarpTokenUpdateInstructions(
+      makeConfig({ fee: feeArtifact(FEE_PROGRAM_A) }),
+      makeConfig({ fee: feeArtifact(FEE_PROGRAM_A) }),
+      PROGRAM,
+      OWNER,
+      createStubRpc(),
+      'test',
+      differentSalt,
+      currentFee,
+    );
+
+    expect(txs).to.have.length(1);
+    expect(txs[0].annotation).to.include('fee');
+  });
+
+  it('no-op: returns no txs when fee config matches', async () => {
+    const currentFee = await buildFeeConfig(FEE_PROGRAM_A);
+    const txs = await computeWarpTokenUpdateInstructions(
+      makeConfig({ fee: feeArtifact(FEE_PROGRAM_A) }),
+      makeConfig({ fee: feeArtifact(FEE_PROGRAM_A) }),
+      PROGRAM,
+      OWNER,
+      createStubRpc(),
+      'test',
+      DEFAULT_FEE_SALT,
+      currentFee,
+    );
+
+    expect(txs).to.have.length(0);
+  });
 });

--- a/typescript/svm-sdk/src/tests/warp-tx.unit-test.ts
+++ b/typescript/svm-sdk/src/tests/warp-tx.unit-test.ts
@@ -5,8 +5,9 @@ import { describe, it } from 'mocha';
 import { ArtifactState } from '@hyperlane-xyz/provider-sdk/artifact';
 import type { RawNativeWarpArtifactConfig } from '@hyperlane-xyz/provider-sdk/warp';
 
-import { computeWarpTokenUpdateInstructions } from '../warp/warp-tx.js';
+import { DEFAULT_FEE_SALT } from '../fee/types.js';
 import type { SvmRpc } from '../types.js';
+import { computeWarpTokenUpdateInstructions } from '../warp/warp-tx.js';
 
 const OWNER = address('zUeFx6cfxedG2JnFtMKkTXnxgPa5M44tyaF9RrPunCp');
 const PROGRAM = address('2gqSMt66ZABt82TTQgrdxf7tJ4eQpLuYj6N29ieBQrH2');
@@ -99,6 +100,7 @@ describe('computeWarpTokenUpdateInstructions — feePayer', () => {
         OWNER,
         createStubRpc(),
         'test',
+        DEFAULT_FEE_SALT,
       );
 
       expect(txs).to.have.length(expectedTxCount);

--- a/typescript/svm-sdk/src/version/version-query.ts
+++ b/typescript/svm-sdk/src/version/version-query.ts
@@ -1,0 +1,140 @@
+/**
+ * Program version detection and comparison for Hyperlane SVM programs.
+ *
+ * All programs implementing the PackageVersioned trait respond to a
+ * universal 8-byte discriminator with their version string via
+ * set_return_data. This module queries and compares those versions.
+ */
+import {
+  type Address,
+  type Base64EncodedWireTransaction,
+  appendTransactionMessageInstructions,
+  blockhash,
+  compileTransactionMessage,
+  createTransactionMessage,
+  getCompiledTransactionMessageEncoder,
+  getShortU16Encoder,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+} from '@solana/kit';
+
+import { ByteCursor } from '../codecs/binary.js';
+import { buildGetProgramVersionInstruction } from '../instructions/version.js';
+import type { SvmRpc } from '../types.js';
+
+/** Minimum program version that supports SetFeeConfig and fee section. */
+export const SVM_PROGRAM_MINIMUM_FEE_SUPPORT_VERSION = '1.0.0';
+
+/**
+ * Queries the on-chain version of a deployed Hyperlane SVM program.
+ *
+ * Uses transaction simulation (no on-chain state change) to call the
+ * GetProgramVersion instruction and parse the return data.
+ *
+ * @returns The version string (e.g. "1.0.0") or null if the program
+ *          does not support versioning (pre-PackageVersioned programs).
+ */
+export async function queryProgramVersion(
+  rpc: SvmRpc,
+  programAddress: Address,
+  payer: Address,
+): Promise<string | null> {
+  const ix = buildGetProgramVersionInstruction(programAddress);
+
+  // Build a minimal v0 message for simulation. The fee payer must be an
+  // existing non-executable account (simulation validates existence even
+  // with sigVerify=false) and must differ from the invoked program.
+  const txMessage = createTransactionMessage({ version: 0 });
+  const withPayer = setTransactionMessageFeePayer(payer, txMessage);
+  const withLifetime = setTransactionMessageLifetimeUsingBlockhash(
+    {
+      blockhash: blockhash('11111111111111111111111111111111'),
+      lastValidBlockHeight: 0n,
+    },
+    withPayer,
+  );
+  const withIx = appendTransactionMessageInstructions([ix], withLifetime);
+  const compiled = compileTransactionMessage(withIx);
+  const messageBytes = getCompiledTransactionMessageEncoder().encode(compiled);
+
+  // Build full unsigned wire transaction (signature count + zero-filled
+  // signature slots + compiled message). The RPC requires a full
+  // VersionedTransaction even for simulation with sigVerify=false.
+  const sigCountBytes = getShortU16Encoder().encode(
+    compiled.header.numSignerAccounts,
+  );
+  const sigsLen = compiled.header.numSignerAccounts * 64;
+  const wireBytes = new Uint8Array(
+    sigCountBytes.length + sigsLen + messageBytes.length,
+  );
+  wireBytes.set(sigCountBytes, 0);
+  wireBytes.set(messageBytes, sigCountBytes.length + sigsLen);
+
+  // CAST: the branded type expects a signed wire transaction but we
+  // built an unsigned one — sigVerify=false makes this valid.
+  const base64Tx = Buffer.from(wireBytes).toString(
+    'base64',
+  ) as Base64EncodedWireTransaction;
+
+  try {
+    const { value: result } = await rpc
+      .simulateTransaction(base64Tx, {
+        encoding: 'base64',
+        commitment: 'confirmed',
+        sigVerify: false,
+        replaceRecentBlockhash: true,
+        accounts: { encoding: 'base64', addresses: [] },
+      })
+      .send();
+
+    if (result.err) return null;
+
+    const returnData = result.returnData;
+    if (!returnData?.data?.[0]) return null;
+
+    const raw = Buffer.from(returnData.data[0], 'base64');
+    return decodeSimulationReturnDataString(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decodes a SimulationReturnData<String> payload from Borsh.
+ *
+ * The Rust SimulationReturnData::new(version) serializes as:
+ *   - Borsh String: u32le length prefix + UTF-8 bytes
+ *   - trailing u8 tag (always 0)
+ */
+function decodeSimulationReturnDataString(raw: Uint8Array): string | null {
+  if (raw.length < 5) return null;
+  const cursor = new ByteCursor(raw);
+  const strLen = cursor.readU32LE();
+  if (strLen === 0 || strLen > raw.length - 4) return null;
+  const strBytes = cursor.readBytes(strLen);
+  return new TextDecoder().decode(strBytes);
+}
+
+/**
+ * Compares two semver version strings.
+ * @returns negative if a < b, 0 if equal, positive if a > b.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const va = pa[i] ?? 0;
+    const vb = pb[i] ?? 0;
+    if (va !== vb) return va - vb;
+  }
+  return 0;
+}
+
+/**
+ * Returns true if the given version supports fee configuration
+ * (SetFeeConfig instruction, fee section in TransferRemote).
+ */
+export function supportsFeeConfig(version: string | null): boolean {
+  if (!version) return false;
+  return compareVersions(version, SVM_PROGRAM_MINIMUM_FEE_SUPPORT_VERSION) >= 0;
+}

--- a/typescript/svm-sdk/src/version/version-query.ts
+++ b/typescript/svm-sdk/src/version/version-query.ts
@@ -18,9 +18,15 @@ import {
   setTransactionMessageLifetimeUsingBlockhash,
 } from '@solana/kit';
 
+import { compareVersions as compareSemver } from 'compare-versions';
+
+import { rootLogger } from '@hyperlane-xyz/utils';
+
 import { ByteCursor } from '../codecs/binary.js';
 import { buildGetProgramVersionInstruction } from '../instructions/version.js';
 import type { SvmRpc } from '../types.js';
+
+const logger = rootLogger.child({ module: 'version-query' });
 
 /** Minimum program version that supports SetFeeConfig and fee section. */
 export const SVM_PROGRAM_MINIMUM_FEE_SUPPORT_VERSION = '1.0.0';
@@ -94,7 +100,11 @@ export async function queryProgramVersion(
 
     const raw = Buffer.from(returnData.data[0], 'base64');
     return decodeSimulationReturnDataString(raw);
-  } catch {
+  } catch (error) {
+    logger.debug('Failed to query program version via simulation', {
+      programAddress,
+      error,
+    });
     return null;
   }
 }
@@ -117,17 +127,12 @@ function decodeSimulationReturnDataString(raw: Uint8Array): string | null {
 
 /**
  * Compares two semver version strings.
- * @returns negative if a < b, 0 if equal, positive if a > b.
+ * Uses the `compare-versions` library (same as the EVM SDK) which
+ * validates format and handles pre-release tags correctly.
+ * @returns -1 if a < b, 0 if equal, 1 if a > b.
  */
 export function compareVersions(a: string, b: string): number {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
-  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const va = pa[i] ?? 0;
-    const vb = pb[i] ?? 0;
-    if (va !== vb) return va - vb;
-  }
-  return 0;
+  return compareSemver(a, b);
 }
 
 /**

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -182,7 +182,7 @@ export class SvmCollateralTokenWriter
         splProgram === TOKEN_2022_PROGRAM_ADDRESS,
       `Mint ${collateralMint} is not owned by SPL Token or Token-2022 (owner: ${splProgram})`,
     );
-    const mintRawData = Buffer.from(mintInfo.value.data[0] as string, 'base64');
+    const mintRawData = Buffer.from(mintInfo.value.data[0], 'base64');
     const localDecimals = getMintDecimals(mintRawData);
     assertLocalDecimals(localDecimals);
     const remoteDecimals = scaleToRemoteDecimals(

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -285,6 +285,7 @@ export class SvmCollateralTokenWriter
         this.svmSigner,
         this.rpc,
         `collateral token ${programId}`,
+        parseAddress(current.config.owner),
       );
 
       txs.push(...(upgradeResult?.authorityTransactions ?? []));

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -35,7 +35,11 @@ import { deriveAtaPayerPda, deriveEscrowPda } from '../pda.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import type { SvmWarpTokenConfig } from './types.js';
-import { fetchTokenAccount, routerBytesToHex } from './warp-query.js';
+import {
+  fetchTokenAccount,
+  fetchWarpProgramVersion,
+  routerBytesToHex,
+} from './warp-query.js';
 import {
   applyPostInitConfig,
   assertLocalDecimals,
@@ -84,6 +88,12 @@ export class SvmCollateralTokenReader implements ArtifactReader<
         `warp route initialized with ${token.decimals} but mint reports ${metadata.decimals}`,
     );
 
+    const contractVersion = await fetchWarpProgramVersion(
+      this.rpc,
+      programId,
+      token.owner,
+    );
+
     const config: RawCollateralWarpArtifactConfig = {
       type: TokenType.collateral,
       owner: token.owner ?? ZERO_ADDRESS_HEX_32,
@@ -107,6 +117,7 @@ export class SvmCollateralTokenReader implements ArtifactReader<
       remoteRouters,
       destinationGas,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
+      contractVersion: contractVersion ?? undefined,
     };
 
     return {

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -49,6 +49,7 @@ import {
   remoteDecimalsToScale,
   scaleToRemoteDecimals,
 } from './warp-tx.js';
+import { prepareProgramUpgrade } from './warp-upgrade.js';
 
 export class SvmCollateralTokenReader implements ArtifactReader<
   RawCollateralWarpArtifactConfig,
@@ -258,7 +259,23 @@ export class SvmCollateralTokenWriter
       `Cannot update collateral token ${programId}: token has no owner`,
     );
 
-    return computeWarpTokenUpdateInstructions(
+    const txs: AnnotatedSvmTransaction[] = [];
+
+    if ('programBytes' in this.config.program) {
+      const upgradeResult = await prepareProgramUpgrade(
+        programId,
+        current.config.contractVersion,
+        artifact.config.contractVersion,
+        this.config.program.programBytes,
+        this.svmSigner,
+        this.rpc,
+        `collateral token ${programId}`,
+      );
+
+      txs.push(...(upgradeResult?.authorityTransactions ?? []));
+    }
+
+    const configUpdateTxs = await computeWarpTokenUpdateInstructions(
       current.config,
       artifact.config,
       programId,
@@ -266,5 +283,9 @@ export class SvmCollateralTokenWriter
       this.rpc,
       `collateral token ${programId}`,
     );
+
+    txs.push(...configUpdateTxs);
+
+    return txs;
   }
 }

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -246,6 +246,7 @@ export class SvmCollateralTokenWriter
         this.svmSigner,
         programAddress,
         tokenConfig,
+        this.config.feeSalt,
       )),
     );
 

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -20,7 +20,11 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import { fetchMintMetadata, getMintDecimals } from '../accounts/mint.js';
-import { decodeCollateralPlugin } from '../accounts/token.js';
+import {
+  COLLATERAL_PLUGIN_SIZE,
+  decodeCollateralPlugin,
+  splitPluginDataAndFeeConfig,
+} from '../accounts/token.js';
 import type { SvmSigner } from '../clients/signer.js';
 import {
   DEFAULT_COMPUTE_UNITS,
@@ -69,7 +73,11 @@ export class SvmCollateralTokenReader implements ArtifactReader<
       `Collateral token not initialized at ${programId}`,
     );
 
-    const plugin = decodeCollateralPlugin(token.pluginData);
+    const { pluginData, feeConfig } = splitPluginDataAndFeeConfig(
+      token.pluginData,
+      COLLATERAL_PLUGIN_SIZE,
+    );
+    const plugin = decodeCollateralPlugin(pluginData);
 
     const remoteRouters: Record<number, { address: string }> = {};
     for (const [domain, router] of token.remoteRouters.entries()) {
@@ -119,6 +127,12 @@ export class SvmCollateralTokenReader implements ArtifactReader<
       destinationGas,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
       contractVersion: contractVersion ?? undefined,
+      fee: feeConfig
+        ? {
+            artifactState: ArtifactState.UNDERIVED,
+            deployed: { address: feeConfig.feeProgram },
+          }
+        : undefined,
     };
 
     return {

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -38,7 +38,7 @@ import { readonlyAccount, writableAccount } from '../instructions/utils.js';
 import { deriveAtaPayerPda, deriveEscrowPda } from '../pda.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
-import type { SvmWarpTokenConfig } from './types.js';
+import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
 import {
   fetchTokenAccount,
   fetchWarpProgramVersion,
@@ -57,14 +57,14 @@ import { prepareProgramUpgrade } from './warp-upgrade.js';
 
 export class SvmCollateralTokenReader implements ArtifactReader<
   RawCollateralWarpArtifactConfig,
-  DeployedWarpAddress
+  SvmDeployedWarpAddress
 > {
   constructor(protected readonly rpc: SvmRpc) {}
 
   async read(
     programAddress: string,
   ): Promise<
-    ArtifactDeployed<RawCollateralWarpArtifactConfig, DeployedWarpAddress>
+    ArtifactDeployed<RawCollateralWarpArtifactConfig, SvmDeployedWarpAddress>
   > {
     const programId = parseAddress(programAddress);
     const token = await fetchTokenAccount(this.rpc, programId);
@@ -138,7 +138,7 @@ export class SvmCollateralTokenReader implements ArtifactReader<
     return {
       artifactState: ArtifactState.DEPLOYED,
       config,
-      deployed: { address: programId },
+      deployed: { address: programId, feeConfig: feeConfig ?? undefined },
     };
   }
 }
@@ -146,7 +146,7 @@ export class SvmCollateralTokenReader implements ArtifactReader<
 export class SvmCollateralTokenWriter
   extends SvmCollateralTokenReader
   implements
-    ArtifactWriter<RawCollateralWarpArtifactConfig, DeployedWarpAddress>
+    ArtifactWriter<RawCollateralWarpArtifactConfig, SvmDeployedWarpAddress>
 {
   constructor(
     private readonly config: SvmWarpTokenConfig,
@@ -160,7 +160,7 @@ export class SvmCollateralTokenWriter
     artifact: ArtifactNew<RawCollateralWarpArtifactConfig>,
   ): Promise<
     [
-      ArtifactDeployed<RawCollateralWarpArtifactConfig, DeployedWarpAddress>,
+      ArtifactDeployed<RawCollateralWarpArtifactConfig, SvmDeployedWarpAddress>,
       SvmReceipt[],
     ]
   > {
@@ -297,6 +297,8 @@ export class SvmCollateralTokenWriter
       parseAddress(current.config.owner),
       this.rpc,
       `collateral token ${programId}`,
+      this.config.feeSalt,
+      current.deployed.feeConfig,
     );
 
     txs.push(...configUpdateTxs);

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -13,7 +13,6 @@ import {
 } from '@hyperlane-xyz/provider-sdk/artifact';
 import {
   TokenType,
-  type DeployedWarpAddress,
   type RawCrossCollateralWarpArtifactConfig,
   computeCCRouterGasConfigUpdates,
   computeCrossCollateralRouterUpdates,
@@ -55,7 +54,7 @@ import {
 } from '../pda.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
-import type { SvmWarpTokenConfig } from './types.js';
+import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
 import {
   fetchTokenAccount,
   fetchWarpProgramVersion,
@@ -78,14 +77,17 @@ const MAX_CC_ROUTERS_PER_TX = 20;
 
 export class SvmCrossCollateralTokenReader implements ArtifactReader<
   RawCrossCollateralWarpArtifactConfig,
-  DeployedWarpAddress
+  SvmDeployedWarpAddress
 > {
   constructor(protected readonly rpc: SvmRpc) {}
 
   async read(
     programAddress: string,
   ): Promise<
-    ArtifactDeployed<RawCrossCollateralWarpArtifactConfig, DeployedWarpAddress>
+    ArtifactDeployed<
+      RawCrossCollateralWarpArtifactConfig,
+      SvmDeployedWarpAddress
+    >
   > {
     const programId = parseAddress(programAddress);
     const token = await fetchTokenAccount(this.rpc, programId);
@@ -184,7 +186,7 @@ export class SvmCrossCollateralTokenReader implements ArtifactReader<
     return {
       artifactState: ArtifactState.DEPLOYED,
       config,
-      deployed: { address: programId },
+      deployed: { address: programId, feeConfig: feeConfig ?? undefined },
     };
   }
 }
@@ -274,7 +276,7 @@ export async function buildCrossCollateralRouterUnenrollTxs(
 export class SvmCrossCollateralTokenWriter
   extends SvmCrossCollateralTokenReader
   implements
-    ArtifactWriter<RawCrossCollateralWarpArtifactConfig, DeployedWarpAddress>
+    ArtifactWriter<RawCrossCollateralWarpArtifactConfig, SvmDeployedWarpAddress>
 {
   constructor(
     private readonly config: SvmWarpTokenConfig,
@@ -290,7 +292,7 @@ export class SvmCrossCollateralTokenWriter
     [
       ArtifactDeployed<
         RawCrossCollateralWarpArtifactConfig,
-        DeployedWarpAddress
+        SvmDeployedWarpAddress
       >,
       SvmReceipt[],
     ]
@@ -406,7 +408,7 @@ export class SvmCrossCollateralTokenWriter
   async update(
     artifact: ArtifactDeployed<
       RawCrossCollateralWarpArtifactConfig,
-      DeployedWarpAddress
+      SvmDeployedWarpAddress
     >,
   ): Promise<AnnotatedSvmTransaction[]> {
     const programId = parseAddress(artifact.deployed.address);
@@ -483,6 +485,8 @@ export class SvmCrossCollateralTokenWriter
         ownerAddress,
         this.rpc,
         `cross-collateral token ${programId}`,
+        this.config.feeSalt,
+        current.deployed.feeConfig,
       )),
     );
 

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -68,6 +68,7 @@ import {
   remoteDecimalsToScale,
   scaleToRemoteDecimals,
 } from './warp-tx.js';
+import { prepareProgramUpgrade } from './warp-upgrade.js';
 
 const MAX_CC_ROUTERS_PER_TX = 20;
 
@@ -411,8 +412,24 @@ export class SvmCrossCollateralTokenWriter
       expectedCCRouters,
     );
 
-    // CC router updates first (need current owner before any ownership transfer)
     const txs: AnnotatedSvmTransaction[] = [];
+
+    // Program upgrade first (before any config changes)
+    if ('programBytes' in this.config.program) {
+      const upgradeResult = await prepareProgramUpgrade(
+        programId,
+        current.config.contractVersion,
+        artifact.config.contractVersion,
+        this.config.program.programBytes,
+        this.svmSigner,
+        this.rpc,
+        `cross-collateral token ${programId}`,
+      );
+
+      txs.push(...(upgradeResult?.authorityTransactions ?? []));
+    }
+
+    // CC router updates (need current owner before any ownership transfer)
 
     if (Object.keys(toUnenroll).length > 0) {
       txs.push(

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -441,6 +441,7 @@ export class SvmCrossCollateralTokenWriter
         this.svmSigner,
         this.rpc,
         `cross-collateral token ${programId}`,
+        ownerAddress,
       );
 
       txs.push(...(upgradeResult?.authorityTransactions ?? []));

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -27,7 +27,11 @@ import {
 
 import { decodeCrossCollateralStateAccount } from '../accounts/cross-collateral-token.js';
 import { getMintDecimals, fetchMintMetadata } from '../accounts/mint.js';
-import { decodeCollateralPlugin } from '../accounts/token.js';
+import {
+  COLLATERAL_PLUGIN_SIZE,
+  decodeCollateralPlugin,
+  splitPluginDataAndFeeConfig,
+} from '../accounts/token.js';
 import type { SvmSigner } from '../clients/signer.js';
 import {
   DEFAULT_COMPUTE_UNITS,
@@ -90,7 +94,11 @@ export class SvmCrossCollateralTokenReader implements ArtifactReader<
       `Cross-collateral token not initialized at ${programId}`,
     );
 
-    const plugin = decodeCollateralPlugin(token.pluginData);
+    const { pluginData, feeConfig } = splitPluginDataAndFeeConfig(
+      token.pluginData,
+      COLLATERAL_PLUGIN_SIZE,
+    );
+    const plugin = decodeCollateralPlugin(pluginData);
 
     // Read CC state
     const { address: ccStatePdaAddr } =
@@ -165,6 +173,12 @@ export class SvmCrossCollateralTokenReader implements ArtifactReader<
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
       crossCollateralRouters,
       contractVersion: contractVersion ?? undefined,
+      fee: feeConfig
+        ? {
+            artifactState: ArtifactState.UNDERIVED,
+            deployed: { address: feeConfig.feeProgram },
+          }
+        : undefined,
     };
 
     return {

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -54,6 +54,7 @@ import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 import type { SvmWarpTokenConfig } from './types.js';
 import {
   fetchTokenAccount,
+  fetchWarpProgramVersion,
   routerBytesToHex,
   routerHexToBytes,
 } from './warp-query.js';
@@ -132,6 +133,12 @@ export class SvmCrossCollateralTokenReader implements ArtifactReader<
         `warp route initialized with ${token.decimals} but mint reports ${metadata.decimals}`,
     );
 
+    const contractVersion = await fetchWarpProgramVersion(
+      this.rpc,
+      programId,
+      token.owner,
+    );
+
     const config: RawCrossCollateralWarpArtifactConfig = {
       type: TokenType.crossCollateral,
       owner: token.owner ?? ZERO_ADDRESS_HEX_32,
@@ -156,6 +163,7 @@ export class SvmCrossCollateralTokenReader implements ArtifactReader<
       destinationGas,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
       crossCollateralRouters,
+      contractVersion: contractVersion ?? undefined,
     };
 
     return {

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -377,6 +377,7 @@ export class SvmCrossCollateralTokenWriter
         this.svmSigner,
         programAddress,
         tokenConfig,
+        this.config.feeSalt,
       )),
     );
 

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -13,7 +13,6 @@ import {
 } from '../accounts/token.js';
 import {
   TokenType,
-  type DeployedWarpAddress,
   type RawNativeWarpArtifactConfig,
 } from '@hyperlane-xyz/provider-sdk/warp';
 import {
@@ -30,7 +29,7 @@ import { writableAccount } from '../instructions/utils.js';
 import { deriveNativeCollateralPda } from '../pda.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
-import type { SvmWarpTokenConfig } from './types.js';
+import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
 import {
   fetchTokenAccount,
   fetchWarpProgramVersion,
@@ -52,14 +51,14 @@ const SOL_DECIMALS = 9;
 
 export class SvmNativeTokenReader implements ArtifactReader<
   RawNativeWarpArtifactConfig,
-  DeployedWarpAddress
+  SvmDeployedWarpAddress
 > {
   constructor(protected readonly rpc: SvmRpc) {}
 
   async read(
     programAddress: string,
   ): Promise<
-    ArtifactDeployed<RawNativeWarpArtifactConfig, DeployedWarpAddress>
+    ArtifactDeployed<RawNativeWarpArtifactConfig, SvmDeployedWarpAddress>
   > {
     const programId = parseAddress(programAddress);
     const token = await fetchTokenAccount(this.rpc, programId);
@@ -117,14 +116,14 @@ export class SvmNativeTokenReader implements ArtifactReader<
     return {
       artifactState: ArtifactState.DEPLOYED,
       config,
-      deployed: { address: programId },
+      deployed: { address: programId, feeConfig: feeConfig ?? undefined },
     };
   }
 }
 
 export class SvmNativeTokenWriter
   extends SvmNativeTokenReader
-  implements ArtifactWriter<RawNativeWarpArtifactConfig, DeployedWarpAddress>
+  implements ArtifactWriter<RawNativeWarpArtifactConfig, SvmDeployedWarpAddress>
 {
   constructor(
     private readonly config: SvmWarpTokenConfig,
@@ -138,7 +137,7 @@ export class SvmNativeTokenWriter
     artifact: ArtifactNew<RawNativeWarpArtifactConfig>,
   ): Promise<
     [
-      ArtifactDeployed<RawNativeWarpArtifactConfig, DeployedWarpAddress>,
+      ArtifactDeployed<RawNativeWarpArtifactConfig, SvmDeployedWarpAddress>,
       SvmReceipt[],
     ]
   > {
@@ -206,7 +205,7 @@ export class SvmNativeTokenWriter
   async update(
     artifact: ArtifactDeployed<
       RawNativeWarpArtifactConfig,
-      DeployedWarpAddress
+      SvmDeployedWarpAddress
     >,
   ): Promise<AnnotatedSvmTransaction[]> {
     const programId = parseAddress(artifact.deployed.address);
@@ -240,6 +239,8 @@ export class SvmNativeTokenWriter
       parseAddress(current.config.owner),
       this.rpc,
       `native token ${programId}`,
+      this.config.feeSalt,
+      current.deployed.feeConfig,
     );
 
     txs.push(...configUpdateTxs);

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -227,6 +227,7 @@ export class SvmNativeTokenWriter
         this.svmSigner,
         this.rpc,
         `native token ${programId}`,
+        parseAddress(current.config.owner),
       );
 
       txs.push(...(upgradeResult?.authorityTransactions ?? []));

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -40,6 +40,7 @@ import {
   remoteDecimalsToScale,
   scaleToRemoteDecimals,
 } from './warp-tx.js';
+import { prepareProgramUpgrade } from './warp-upgrade.js';
 import { DEFAULT_COMPUTE_UNITS } from '../constants.js';
 
 /** Native SOL decimal precision. */
@@ -201,7 +202,23 @@ export class SvmNativeTokenWriter
       `Cannot update native token ${programId}: token has no owner`,
     );
 
-    return computeWarpTokenUpdateInstructions(
+    const txs: AnnotatedSvmTransaction[] = [];
+
+    if ('programBytes' in this.config.program) {
+      const upgradeResult = await prepareProgramUpgrade(
+        programId,
+        current.config.contractVersion,
+        artifact.config.contractVersion,
+        this.config.program.programBytes,
+        this.svmSigner,
+        this.rpc,
+        `native token ${programId}`,
+      );
+
+      txs.push(...(upgradeResult?.authorityTransactions ?? []));
+    }
+
+    const configUpdateTxs = await computeWarpTokenUpdateInstructions(
       current.config,
       artifact.config,
       programId,
@@ -209,5 +226,9 @@ export class SvmNativeTokenWriter
       this.rpc,
       `native token ${programId}`,
     );
+
+    txs.push(...configUpdateTxs);
+
+    return txs;
   }
 }

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -27,7 +27,11 @@ import { deriveNativeCollateralPda } from '../pda.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import type { SvmWarpTokenConfig } from './types.js';
-import { fetchTokenAccount, routerBytesToHex } from './warp-query.js';
+import {
+  fetchTokenAccount,
+  fetchWarpProgramVersion,
+  routerBytesToHex,
+} from './warp-query.js';
 import {
   applyPostInitConfig,
   assertLocalDecimals,
@@ -66,6 +70,12 @@ export class SvmNativeTokenReader implements ArtifactReader<
       destinationGas[domain] = gas.toString();
     }
 
+    const contractVersion = await fetchWarpProgramVersion(
+      this.rpc,
+      programId,
+      token.owner,
+    );
+
     const config: RawNativeWarpArtifactConfig = {
       type: TokenType.native,
       owner: token.owner ?? ZERO_ADDRESS_HEX_32,
@@ -86,6 +96,7 @@ export class SvmNativeTokenReader implements ArtifactReader<
       destinationGas,
       decimals: token.decimals,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
+      contractVersion: contractVersion ?? undefined,
     };
 
     return {

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -8,6 +8,10 @@ import {
   type ArtifactWriter,
 } from '@hyperlane-xyz/provider-sdk/artifact';
 import {
+  NATIVE_PLUGIN_SIZE,
+  splitPluginDataAndFeeConfig,
+} from '../accounts/token.js';
+import {
   TokenType,
   type DeployedWarpAddress,
   type RawNativeWarpArtifactConfig,
@@ -71,6 +75,10 @@ export class SvmNativeTokenReader implements ArtifactReader<
       destinationGas[domain] = gas.toString();
     }
 
+    const { feeConfig } = splitPluginDataAndFeeConfig(
+      token.pluginData,
+      NATIVE_PLUGIN_SIZE,
+    );
     const contractVersion = await fetchWarpProgramVersion(
       this.rpc,
       programId,
@@ -98,6 +106,12 @@ export class SvmNativeTokenReader implements ArtifactReader<
       decimals: token.decimals,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
       contractVersion: contractVersion ?? undefined,
+      fee: feeConfig
+        ? {
+            artifactState: ArtifactState.UNDERIVED,
+            deployed: { address: feeConfig.feeProgram },
+          }
+        : undefined,
     };
 
     return {

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -189,6 +189,7 @@ export class SvmNativeTokenWriter
         this.svmSigner,
         programAddress,
         tokenConfig,
+        this.config.feeSalt,
       )),
     );
 

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -24,6 +24,10 @@ import {
 } from '@solana/kit';
 
 import { fetchMintMetadata } from '../accounts/mint.js';
+import {
+  SYNTHETIC_PLUGIN_SIZE,
+  splitPluginDataAndFeeConfig,
+} from '../accounts/token.js';
 import type { SvmSigner } from '../clients/signer.js';
 import { concatBytes, u32le, u64le, u8 } from '../codecs/binary.js';
 import {
@@ -195,6 +199,10 @@ export class SvmSyntheticTokenReader implements ArtifactReader<
 
     const { address: mintPda } = await deriveSyntheticMintPda(programId);
     const metadata = await fetchMintMetadata(this.rpc, mintPda);
+    const { feeConfig } = splitPluginDataAndFeeConfig(
+      token.pluginData,
+      SYNTHETIC_PLUGIN_SIZE,
+    );
     const contractVersion = await fetchWarpProgramVersion(
       this.rpc,
       programId,
@@ -225,6 +233,12 @@ export class SvmSyntheticTokenReader implements ArtifactReader<
       metadataUri: metadata.uri,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
       contractVersion: contractVersion ?? undefined,
+      fee: feeConfig
+        ? {
+            artifactState: ArtifactState.UNDERIVED,
+            deployed: { address: feeConfig.feeProgram },
+          }
+        : undefined,
     };
 
     return {

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -429,6 +429,7 @@ export class SvmSyntheticTokenWriter
         this.svmSigner,
         this.rpc,
         `synthetic token ${programId}`,
+        parseAddress(current.config.owner),
       );
 
       txs.push(...(upgradeResult?.authorityTransactions ?? []));

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -7,7 +7,6 @@ import {
 } from '@hyperlane-xyz/provider-sdk/artifact';
 import {
   TokenType,
-  type DeployedWarpAddress,
   type RawSyntheticWarpArtifactConfig,
 } from '@hyperlane-xyz/provider-sdk/warp';
 import {
@@ -53,7 +52,7 @@ import type {
   SvmRpc,
 } from '../types.js';
 
-import type { SvmWarpTokenConfig } from './types.js';
+import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
 import {
   fetchTokenAccount,
   fetchWarpProgramVersion,
@@ -171,14 +170,14 @@ function createInitializeMetadataInstruction(
 
 export class SvmSyntheticTokenReader implements ArtifactReader<
   RawSyntheticWarpArtifactConfig,
-  DeployedWarpAddress
+  SvmDeployedWarpAddress
 > {
   constructor(protected readonly rpc: SvmRpc) {}
 
   async read(
     programAddress: string,
   ): Promise<
-    ArtifactDeployed<RawSyntheticWarpArtifactConfig, DeployedWarpAddress>
+    ArtifactDeployed<RawSyntheticWarpArtifactConfig, SvmDeployedWarpAddress>
   > {
     const programId = parseAddress(programAddress);
     const token = await fetchTokenAccount(this.rpc, programId);
@@ -244,14 +243,15 @@ export class SvmSyntheticTokenReader implements ArtifactReader<
     return {
       artifactState: ArtifactState.DEPLOYED,
       config,
-      deployed: { address: programId },
+      deployed: { address: programId, feeConfig: feeConfig ?? undefined },
     };
   }
 }
 
 export class SvmSyntheticTokenWriter
   extends SvmSyntheticTokenReader
-  implements ArtifactWriter<RawSyntheticWarpArtifactConfig, DeployedWarpAddress>
+  implements
+    ArtifactWriter<RawSyntheticWarpArtifactConfig, SvmDeployedWarpAddress>
 {
   constructor(
     private readonly config: SvmWarpTokenConfig,
@@ -265,7 +265,7 @@ export class SvmSyntheticTokenWriter
     artifact: ArtifactNew<RawSyntheticWarpArtifactConfig>,
   ): Promise<
     [
-      ArtifactDeployed<RawSyntheticWarpArtifactConfig, DeployedWarpAddress>,
+      ArtifactDeployed<RawSyntheticWarpArtifactConfig, SvmDeployedWarpAddress>,
       SvmReceipt[],
     ]
   > {
@@ -407,7 +407,7 @@ export class SvmSyntheticTokenWriter
   async update(
     artifact: ArtifactDeployed<
       RawSyntheticWarpArtifactConfig,
-      DeployedWarpAddress
+      SvmDeployedWarpAddress
     >,
   ): Promise<AnnotatedSvmTransaction[]> {
     const programId = parseAddress(artifact.deployed.address);
@@ -441,6 +441,8 @@ export class SvmSyntheticTokenWriter
       parseAddress(current.config.owner),
       this.rpc,
       `synthetic token ${programId}`,
+      this.config.feeSalt,
+      current.deployed.feeConfig,
     );
 
     txs.push(...configUpdateTxs);

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -64,6 +64,7 @@ import {
   remoteDecimalsToScale,
   scaleToRemoteDecimals,
 } from './warp-tx.js';
+import { prepareProgramUpgrade } from './warp-upgrade.js';
 
 // Borsh discriminator for the Token 2022 InitializeTokenMetadata instruction.
 const METADATA_INITIALIZE_DISCRIMINATOR = new Uint8Array([
@@ -402,7 +403,23 @@ export class SvmSyntheticTokenWriter
       `Cannot update synthetic token ${programId}: token has no owner`,
     );
 
-    return computeWarpTokenUpdateInstructions(
+    const txs: AnnotatedSvmTransaction[] = [];
+
+    if ('programBytes' in this.config.program) {
+      const upgradeResult = await prepareProgramUpgrade(
+        programId,
+        current.config.contractVersion,
+        artifact.config.contractVersion,
+        this.config.program.programBytes,
+        this.svmSigner,
+        this.rpc,
+        `synthetic token ${programId}`,
+      );
+
+      txs.push(...(upgradeResult?.authorityTransactions ?? []));
+    }
+
+    const configUpdateTxs = await computeWarpTokenUpdateInstructions(
       current.config,
       artifact.config,
       programId,
@@ -410,5 +427,9 @@ export class SvmSyntheticTokenWriter
       this.rpc,
       `synthetic token ${programId}`,
     );
+
+    txs.push(...configUpdateTxs);
+
+    return txs;
   }
 }

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -390,6 +390,7 @@ export class SvmSyntheticTokenWriter
         this.svmSigner,
         programAddress,
         tokenConfig,
+        this.config.feeSalt,
       )),
     );
 

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -50,7 +50,11 @@ import type {
 } from '../types.js';
 
 import type { SvmWarpTokenConfig } from './types.js';
-import { fetchTokenAccount, routerBytesToHex } from './warp-query.js';
+import {
+  fetchTokenAccount,
+  fetchWarpProgramVersion,
+  routerBytesToHex,
+} from './warp-query.js';
 import {
   applyPostInitConfig,
   assertLocalDecimals,
@@ -190,6 +194,11 @@ export class SvmSyntheticTokenReader implements ArtifactReader<
 
     const { address: mintPda } = await deriveSyntheticMintPda(programId);
     const metadata = await fetchMintMetadata(this.rpc, mintPda);
+    const contractVersion = await fetchWarpProgramVersion(
+      this.rpc,
+      programId,
+      token.owner,
+    );
 
     const config: RawSyntheticWarpArtifactConfig = {
       type: TokenType.synthetic,
@@ -214,6 +223,7 @@ export class SvmSyntheticTokenReader implements ArtifactReader<
       decimals: token.decimals,
       metadataUri: metadata.uri,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
+      contractVersion: contractVersion ?? undefined,
     };
 
     return {

--- a/typescript/svm-sdk/src/warp/types.ts
+++ b/typescript/svm-sdk/src/warp/types.ts
@@ -13,4 +13,6 @@ export type SvmWarpTokenConfig = Readonly<{
    * creation on transfer_out.
    */
   ataPayerFundingAmount: bigint;
+  /** Salt for fee account PDA derivation. Resolved from chain name by the artifact manager. */
+  feeSalt: Uint8Array;
 }>;

--- a/typescript/svm-sdk/src/warp/types.ts
+++ b/typescript/svm-sdk/src/warp/types.ts
@@ -1,3 +1,6 @@
+import type { DeployedWarpAddress } from '@hyperlane-xyz/provider-sdk/warp';
+
+import type { TokenFeeConfig } from '../accounts/token.js';
 import type { SvmProgramTarget } from '../types.js';
 
 /**
@@ -16,3 +19,14 @@ export type SvmWarpTokenConfig = Readonly<{
   /** Salt for fee account PDA derivation. Resolved from chain name by the artifact manager. */
   feeSalt: Uint8Array;
 }>;
+
+/**
+ * SVM-specific extension of DeployedWarpAddress that carries the
+ * on-chain fee configuration (both program ID and fee account PDA).
+ *
+ * Used for accurate fee config diffing during updates — the same fee
+ * program with a different salt produces a different fee account PDA.
+ */
+export interface SvmDeployedWarpAddress extends DeployedWarpAddress {
+  feeConfig?: TokenFeeConfig;
+}

--- a/typescript/svm-sdk/src/warp/warp-artifact-manager.ts
+++ b/typescript/svm-sdk/src/warp/warp-artifact-manager.ts
@@ -1,5 +1,7 @@
 import { address, type Rpc, type SolanaRpcApi } from '@solana/kit';
 
+import { resolveFeeSalt } from '../fee/types.js';
+
 import type {
   ArtifactReader,
   ArtifactWriter,
@@ -31,6 +33,10 @@ import { detectWarpTokenType } from './warp-query.js';
 export class SvmWarpArtifactManager implements IRawWarpArtifactManager {
   constructor(
     private readonly rpc: Rpc<SolanaRpcApi>,
+    chainConfig: { chainName: string },
+    private readonly feeSalt: Uint8Array = resolveFeeSalt(
+      chainConfig.chainName,
+    ),
     private readonly ataPayerFundingAmount: bigint = 100_000_000n,
   ) {}
 
@@ -77,6 +83,7 @@ export class SvmWarpArtifactManager implements IRawWarpArtifactManager {
           {
             program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenNative },
             ataPayerFundingAmount: this.ataPayerFundingAmount,
+            feeSalt: this.feeSalt,
           },
           this.rpc,
           signer,
@@ -88,6 +95,7 @@ export class SvmWarpArtifactManager implements IRawWarpArtifactManager {
               programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenSynthetic,
             },
             ataPayerFundingAmount: this.ataPayerFundingAmount,
+            feeSalt: this.feeSalt,
           },
           this.rpc,
           signer,
@@ -99,6 +107,7 @@ export class SvmWarpArtifactManager implements IRawWarpArtifactManager {
               programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral,
             },
             ataPayerFundingAmount: this.ataPayerFundingAmount,
+            feeSalt: this.feeSalt,
           },
           this.rpc,
           signer,
@@ -110,6 +119,7 @@ export class SvmWarpArtifactManager implements IRawWarpArtifactManager {
               programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCrossCollateral,
             },
             ataPayerFundingAmount: this.ataPayerFundingAmount,
+            feeSalt: this.feeSalt,
           },
           this.rpc,
           signer,

--- a/typescript/svm-sdk/src/warp/warp-query.ts
+++ b/typescript/svm-sdk/src/warp/warp-query.ts
@@ -14,6 +14,7 @@ import {
   deriveEscrowPda,
 } from '../pda.js';
 import type { SvmRpc } from '../types.js';
+import { queryProgramVersion } from '../version/version-query.js';
 
 export enum SvmWarpTokenType {
   Native = 'native',
@@ -88,6 +89,22 @@ export async function detectWarpTokenType(
   const result = matches[0];
   assert(result !== undefined, 'Unexpected empty matches after validation');
   return result;
+}
+
+/**
+ * Queries the on-chain program version for a warp route program.
+ * Uses the token owner as the simulation fee payer — the owner is a
+ * regular system-owned wallet that exists on-chain after deployment.
+ *
+ * Returns null if the token is not initialized or has no owner.
+ */
+export async function fetchWarpProgramVersion(
+  rpc: SvmRpc,
+  programId: Address,
+  owner: Address | null,
+): Promise<string | null> {
+  if (!owner) return null;
+  return queryProgramVersion(rpc, programId, owner);
 }
 
 /** Converts a 32-byte router H256 to a 0x-prefixed hex string. */

--- a/typescript/svm-sdk/src/warp/warp-query.ts
+++ b/typescript/svm-sdk/src/warp/warp-query.ts
@@ -34,7 +34,7 @@ export async function fetchTokenAccount(
   const { address: tokenPda } = await deriveHyperlaneTokenPda(programId);
   const account = await fetchEncodedAccount(rpc, tokenPda);
   if (!account.exists) return null;
-  return decodeHyperlaneTokenAccount(account.data as Uint8Array);
+  return decodeHyperlaneTokenAccount(Uint8Array.from(account.data));
 }
 
 /**

--- a/typescript/svm-sdk/src/warp/warp-tx.ts
+++ b/typescript/svm-sdk/src/warp/warp-tx.ts
@@ -20,13 +20,18 @@ import { getSetUpgradeAuthorityInstruction } from '../instructions/loader.js';
 import {
   getTokenEnrollRemoteRoutersInstruction,
   getTokenSetDestinationGasConfigsInstruction,
+  getTokenSetFeeConfigInstruction,
   getTokenSetInterchainGasPaymasterInstruction,
   getTokenSetInterchainSecurityModuleInstruction,
   getTokenTransferOwnershipInstruction,
   type TokenInitInstructionData,
 } from '../instructions/token.js';
 import { DEFAULT_IGP_SALT } from '../hook/igp-hook.js';
-import { deriveAtaPayerPda, deriveOverheadIgpAccountPda } from '../pda.js';
+import {
+  deriveAtaPayerPda,
+  deriveFeeAccountPda,
+  deriveOverheadIgpAccountPda,
+} from '../pda.js';
 import {
   buildInstruction,
   writableAccount,
@@ -185,7 +190,11 @@ export const MAX_GAS_CONFIGS_PER_TX = 60;
 export async function applyPostInitConfig(
   signer: SvmSigner,
   programId: Address,
-  config: Pick<RawWarpArtifactConfig, 'remoteRouters' | 'destinationGas'>,
+  config: Pick<
+    RawWarpArtifactConfig,
+    'remoteRouters' | 'destinationGas' | 'fee'
+  >,
+  feeSalt: Uint8Array,
 ): Promise<SvmReceipt[]> {
   const receipts: SvmReceipt[] = [];
 
@@ -221,6 +230,29 @@ export async function applyPostInitConfig(
               domain: parseInt(domain),
               gas: BigInt(gas),
             })),
+          ),
+        ],
+      }),
+    );
+  }
+
+  // Set fee config if the deployed artifact includes a fee program.
+  const feeDeployed = config.fee?.deployed;
+  if (feeDeployed) {
+    const feeAccountPda = await deriveFeeAccountPda(
+      parseAddress(feeDeployed.address),
+      feeSalt,
+    );
+    receipts.push(
+      await signer.send({
+        instructions: [
+          await getTokenSetFeeConfigInstruction(
+            programId,
+            signer.signer.address,
+            {
+              feeProgram: parseAddress(feeDeployed.address),
+              feeAccount: feeAccountPda.address,
+            },
           ),
         ],
       }),

--- a/typescript/svm-sdk/src/warp/warp-tx.ts
+++ b/typescript/svm-sdk/src/warp/warp-tx.ts
@@ -1,5 +1,7 @@
 import { type Address, address as parseAddress } from '@solana/kit';
 
+import type { TokenFeeConfig } from '../accounts/token.js';
+
 import {
   computeRemoteRoutersUpdates,
   type RawWarpArtifactConfig,
@@ -312,6 +314,8 @@ export async function computeWarpTokenUpdateInstructions(
   ownerAddress: Address,
   rpc: SvmRpc,
   label: string,
+  feeSalt: Uint8Array,
+  currentOnChainFeeConfig?: TokenFeeConfig,
 ): Promise<AnnotatedSvmTransaction[]> {
   const txs: AnnotatedSvmTransaction[] = [];
 
@@ -359,11 +363,49 @@ export async function computeWarpTokenUpdateInstructions(
     );
   }
 
+  // Fee config diff — compare the full (feeProgram, feeAccount) pair.
+  // Same program with a different salt produces a different fee account PDA.
+  const expectedFee = expected.fee?.deployed?.address;
+  if (expectedFee) {
+    const expectedFeePda = await deriveFeeAccountPda(
+      parseAddress(expectedFee),
+      feeSalt,
+    );
+    const expectedFeeConfig: TokenFeeConfig = {
+      feeProgram: parseAddress(expectedFee),
+      feeAccount: expectedFeePda.address,
+    };
+    const changed =
+      !currentOnChainFeeConfig ||
+      !eqAddressSol(
+        currentOnChainFeeConfig.feeProgram,
+        expectedFeeConfig.feeProgram,
+      ) ||
+      !eqAddressSol(
+        currentOnChainFeeConfig.feeAccount,
+        expectedFeeConfig.feeAccount,
+      );
+    if (changed) {
+      configInstructions.push(
+        await getTokenSetFeeConfigInstruction(
+          programId,
+          ownerAddress,
+          expectedFeeConfig,
+        ),
+      );
+    }
+  } else if (currentOnChainFeeConfig) {
+    // Expected has no fee but current does — remove it
+    configInstructions.push(
+      await getTokenSetFeeConfigInstruction(programId, ownerAddress, null),
+    );
+  }
+
   if (configInstructions.length > 0) {
     txs.push({
       feePayer: ownerAddress,
       instructions: configInstructions,
-      annotation: `Update ${label}: ISM/hook config`,
+      annotation: `Update ${label}: ISM/hook/fee config`,
     });
   }
 

--- a/typescript/svm-sdk/src/warp/warp-upgrade.ts
+++ b/typescript/svm-sdk/src/warp/warp-upgrade.ts
@@ -11,6 +11,7 @@ import { assert, eqAddressSol } from '@hyperlane-xyz/utils';
 
 import type { SvmSigner } from '../clients/signer.js';
 import {
+  PROGRAM_DATA_HEADER_SIZE,
   createUpgradeProgramPlan,
   DeployStageKind,
   executeDeployPlan,
@@ -27,9 +28,6 @@ import {
   supportsFeeConfig,
 } from '../version/version-query.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
-
-/** BPF Loader v3 ProgramData account header size (discriminant + slot + option + authority). */
-const PROGRAM_DATA_HEADER_SIZE = 45;
 
 /**
  * Handles program upgrade for a warp route token program.

--- a/typescript/svm-sdk/src/warp/warp-upgrade.ts
+++ b/typescript/svm-sdk/src/warp/warp-upgrade.ts
@@ -55,6 +55,8 @@ export async function prepareProgramUpgrade(
   signer: SvmSigner,
   rpc: SvmRpc,
   label: string,
+  /** Token owner address — signs the SetFeeConfig(None) migration (distinct from upgrade authority). */
+  owner: Address,
 ): Promise<{
   authorityTransactions: AnnotatedSvmTransaction[];
   receipts: SvmReceipt[];
@@ -133,15 +135,11 @@ export async function prepareProgramUpgrade(
 
   const result = await executeDeployPlan({
     plan,
-    executeStage: async (stage) => {
-      const receipt = await signer.send({
+    executeStage: async (stage) =>
+      signer.send({
         instructions: stage.instructions,
         additionalSigners: stage.additionalSigners,
-      });
-
-      receipts.push(receipt);
-      return receipt;
-    },
+      }),
   });
   receipts.push(...result);
 
@@ -162,7 +160,7 @@ export async function prepareProgramUpgrade(
     receipts.push(await signer.send({ instructions: [transferIx] }));
   }
 
-  // The final Upgrade instruction requires the upgrade authority to execute it.
+  // The Upgrade instruction requires the upgrade authority to sign it.
   authorityTransactions.push({
     feePayer: upgradeAuthority,
     instructions: finalizeStage.instructions,
@@ -175,15 +173,16 @@ export async function prepareProgramUpgrade(
   // that use store(account, false) — transfer_ownership, set_ism, set_igp —
   // will fail with BorshIoError. SetFeeConfig(None) uses store_with_rent_exempt_realloc
   // which grows the account and covers the rent delta.
+  //
+  // This MUST be a separate transaction — Solana's DELAY_VISIBILITY_SLOT_OFFSET
+  // means the new binary is only callable in the slot after the Upgrade tx.
+  // If this migration fails, the operator must manually send SetFeeConfig(None)
+  // to recover the program before any other config changes will succeed.
   if (!supportsFeeConfig(currentVersion ?? null)) {
     authorityTransactions.push({
-      feePayer: upgradeAuthority,
+      feePayer: owner,
       instructions: [
-        await getTokenSetFeeConfigInstruction(
-          programId,
-          upgradeAuthority,
-          null,
-        ),
+        await getTokenSetFeeConfigInstruction(programId, owner, null),
       ],
       annotation: `Migrate ${label}: realloc token account for fee_config field`,
     });

--- a/typescript/svm-sdk/src/warp/warp-upgrade.ts
+++ b/typescript/svm-sdk/src/warp/warp-upgrade.ts
@@ -1,0 +1,170 @@
+/**
+ * Program upgrade logic for warp route token programs.
+ *
+ * Separates upgrade concerns from config diffing (warp-tx.ts).
+ * Writers call this before computeWarpTokenUpdateInstructions
+ * when contractVersion in the expected config differs from current.
+ */
+import type { Address } from '@solana/kit';
+
+import { assert, eqAddressSol } from '@hyperlane-xyz/utils';
+
+import type { SvmSigner } from '../clients/signer.js';
+import {
+  createUpgradeProgramPlan,
+  DeployStageKind,
+  executeDeployPlan,
+  getProgramUpgradeAuthority,
+} from '../deploy/program-deployer.js';
+import {
+  getExtendProgramCheckedInstruction,
+  getSetBufferAuthorityInstruction,
+} from '../instructions/loader.js';
+import { deriveProgramDataAddress } from '../pda.js';
+import { compareVersions } from '../version/version-query.js';
+import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
+
+/** BPF Loader v3 ProgramData account header size (discriminant + slot + option + authority). */
+const PROGRAM_DATA_HEADER_SIZE = 45;
+
+/**
+ * Handles program upgrade for a warp route token program.
+ *
+ * Creates the buffer and writes program bytes using the provided signer,
+ * then returns transactions that require the upgrade authority to execute:
+ * - ExtendProgramChecked (if the new binary is larger)
+ * - Upgrade (swap the program binary)
+ *
+ * The returned transactions have feePayer set to the on-chain upgrade
+ * authority. When authority == signer, they can be executed immediately.
+ * When authority differs, the caller routes them to the authority.
+ *
+ * @returns Transactions for the authority, plus receipts from buffer prep.
+ *          Null if no upgrade is needed.
+ * @throws If downgrade is attempted, or the program is immutable.
+ */
+export async function prepareProgramUpgrade(
+  programId: Address,
+  currentVersion: string | undefined,
+  expectedVersion: string | undefined,
+  programBytes: Uint8Array,
+  signer: SvmSigner,
+  rpc: SvmRpc,
+  label: string,
+): Promise<{
+  authorityTransactions: AnnotatedSvmTransaction[];
+  receipts: SvmReceipt[];
+} | null> {
+  if (!expectedVersion || currentVersion === expectedVersion) {
+    return null;
+  }
+
+  if (currentVersion && compareVersions(expectedVersion, currentVersion) < 0) {
+    throw new Error(
+      `Cannot downgrade ${label}: deployed version ${currentVersion} is newer than expected ${expectedVersion}`,
+    );
+  }
+
+  const upgradeAuthority = await getProgramUpgradeAuthority(rpc, programId);
+  assert(
+    upgradeAuthority,
+    `Program upgrade required for ${label} but program is immutable (no upgrade authority)`,
+  );
+
+  const receipts: SvmReceipt[] = [];
+  const authorityTransactions: AnnotatedSvmTransaction[] = [];
+
+  // Check if the program data account needs extending for the new binary.
+  const programDataAddress = await deriveProgramDataAddress(programId);
+  const programDataAccount = await rpc
+    .getAccountInfo(programDataAddress, { encoding: 'base64' })
+    .send();
+  assert(
+    programDataAccount.value,
+    `Program data account not found for ${label}`,
+  );
+
+  const currentAccountSize = Buffer.from(
+    programDataAccount.value.data[0],
+    'base64',
+  ).length;
+  const currentMaxProgramLen = currentAccountSize - PROGRAM_DATA_HEADER_SIZE;
+  const additionalBytes = programBytes.length - currentMaxProgramLen;
+
+  if (additionalBytes > 0) {
+    const extendIx = getExtendProgramCheckedInstruction(
+      programDataAddress,
+      programId,
+      upgradeAuthority,
+      upgradeAuthority,
+      additionalBytes,
+    );
+
+    authorityTransactions.push({
+      feePayer: upgradeAuthority,
+      instructions: [extendIx],
+      annotation: `Extend ${label}: +${additionalBytes} bytes`,
+    });
+  }
+
+  // Create buffer and write new program bytes.
+  // Buffer is owned by the payer (signer). The final Upgrade instruction
+  // targets the real on-chain upgrade authority (which may differ).
+  const plan = await createUpgradeProgramPlan({
+    payer: signer.signer,
+    authority: signer.signer,
+    programAddress: programId,
+    newProgramBytes: programBytes,
+    upgradeAuthority,
+    getMinimumBalanceForRentExemption: (size: number) =>
+      rpc.getMinimumBalanceForRentExemption(BigInt(size)).send(),
+  });
+
+  // Execute buffer creation + writes immediately (payer-only, no authority needed).
+  const finalizeStage = plan.stages.pop();
+  assert(
+    finalizeStage && finalizeStage.kind === DeployStageKind.Finalize,
+    'Expected last stage to be the finalize/upgrade stage',
+  );
+
+  const result = await executeDeployPlan({
+    plan,
+    executeStage: async (stage) => {
+      const receipt = await signer.send({
+        instructions: stage.instructions,
+        additionalSigners: stage.additionalSigners,
+      });
+
+      receipts.push(receipt);
+      return receipt;
+    },
+  });
+  receipts.push(...result);
+
+  // Transfer buffer authority to the upgrade authority. The Loader requires
+  // the buffer authority to match the program's upgrade authority on Upgrade.
+  // When payer == upgradeAuthority this is a no-op (already matches).
+  if (!eqAddressSol(signer.signer.address, upgradeAuthority)) {
+    const initStage = plan.stages.find((s) => s.kind === DeployStageKind.Init);
+    assert(initStage, 'Expected init stage in upgrade plan');
+    const bufferSigner = initStage.additionalSigners?.[0];
+    assert(bufferSigner, 'Expected buffer signer in init stage');
+
+    const transferIx = getSetBufferAuthorityInstruction(
+      bufferSigner.address,
+      signer.signer.address,
+      upgradeAuthority,
+    );
+    receipts.push(await signer.send({ instructions: [transferIx] }));
+  }
+
+  // The final Upgrade instruction requires the upgrade authority to execute it.
+  authorityTransactions.push({
+    feePayer: upgradeAuthority,
+    instructions: finalizeStage.instructions,
+    additionalSigners: finalizeStage.additionalSigners,
+    annotation: `Upgrade ${label}: ${currentVersion ?? 'unknown'} → ${expectedVersion}`,
+  });
+
+  return { authorityTransactions, receipts };
+}

--- a/typescript/svm-sdk/src/warp/warp-upgrade.ts
+++ b/typescript/svm-sdk/src/warp/warp-upgrade.ts
@@ -20,8 +20,12 @@ import {
   getExtendProgramCheckedInstruction,
   getSetBufferAuthorityInstruction,
 } from '../instructions/loader.js';
+import { getTokenSetFeeConfigInstruction } from '../instructions/token.js';
 import { deriveProgramDataAddress } from '../pda.js';
-import { compareVersions } from '../version/version-query.js';
+import {
+  compareVersions,
+  supportsFeeConfig,
+} from '../version/version-query.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 /** BPF Loader v3 ProgramData account header size (discriminant + slot + option + authority). */
@@ -165,6 +169,25 @@ export async function prepareProgramUpgrade(
     additionalSigners: finalizeStage.additionalSigners,
     annotation: `Upgrade ${label}: ${currentVersion ?? 'unknown'} → ${expectedVersion}`,
   });
+
+  // Post-upgrade migration: when upgrading from a pre-fee binary, the token
+  // account is 1 byte too small (missing the fee_config Option tag). Handlers
+  // that use store(account, false) — transfer_ownership, set_ism, set_igp —
+  // will fail with BorshIoError. SetFeeConfig(None) uses store_with_rent_exempt_realloc
+  // which grows the account and covers the rent delta.
+  if (!supportsFeeConfig(currentVersion ?? null)) {
+    authorityTransactions.push({
+      feePayer: upgradeAuthority,
+      instructions: [
+        await getTokenSetFeeConfigInstruction(
+          programId,
+          upgradeAuthority,
+          null,
+        ),
+      ],
+      annotation: `Migrate ${label}: realloc token account for fee_config field`,
+    });
+  }
 
   return { authorityTransactions, receipts };
 }


### PR DESCRIPTION
### Description

  Adds fee management support to SVM warp token deployments, allowing SVM warp tokens to configure on-chain fee programs like EVM already does.

  **Core changes:**
  - `SetFeeConfig` instruction builder (kind=8) for setting/removing fee config on warp tokens
  - Fee config reading from on-chain state via `splitPluginDataAndFeeConfig` decoder
  - Fee config diffing in the warp token update flow (add, remove, change program, change salt)
  - Program version detection via transaction simulation (`queryProgramVersion`)
  - Explicit program upgrade flow (`prepareProgramUpgrade`) with version comparison and downgrade rejection
  - Auto-appended `SetFeeConfig(None)` migration after upgrading from pre-fee binaries (required to realloc the token account for the new fee_config field)
  - `contractVersion` added to shared provider-sdk `BaseWarpConfig` types
  - `SvmDeployedWarpAddress` type extending `DeployedWarpAddress` with optional `feeConfig` for accurate diffing
  - Legacy program bytes preserved for E2E upgrade testing

  **Fee salt changes:**
  - Fee salt is now mandatory on all fee reader/writer constructors (no implicit defaults)
  - `resolveFeeSalt(chainName)` resolves salt from `SVM_FEE_{CHAIN_NAME}_SALT` env var, falling back to zeros
  - Artifact managers handle salt resolution transparently

  ### Drive-by changes

  - Replaced hand-rolled `compareVersions` with `compare-versions` library (same as EVM SDK) to correctly handle malformed/pre-release version strings
  - Added `compare-versions` to workspace catalog; migrated EVM SDK from pinned version to catalog reference
  - Unified duplicate `FeeConfigValue` and `TokenFeeConfig` into single `TokenFeeConfig` type
  - Added trailing bytes length validation in `splitPluginDataAndFeeConfig`
  - Removed unnecessary `as string` and `as Uint8Array` casts
  - Shared `PROGRAM_DATA_HEADER_SIZE` constant between `program-deployer.ts` and `warp-upgrade.ts`
  - Exported `SvmWarpArtifactManager` from index.ts (consistent with other VM SDKs)
  - Moved `deriveProgramDataAddress` from `program-deployer.ts` to `pda.ts`
  - Custom `getUpgradeInstruction`, `getExtendProgramCheckedInstruction`, and `getSetBufferAuthorityInstruction` using address-only signers (supports upgrade authority ≠ buffer writer)
  - Passed `contractVersion` through `validateWarpConfigForAltVM` for Alt-VM deploy path
  - Fixed double receipt collection in `prepareProgramUpgrade`
  - Fixed post-upgrade `SetFeeConfig(None)` migration to use token owner instead of upgrade authority

  ### Related issues

  - Full CLI compatibility for SVM fee deployment (tokenFee → provider-sdk FeeConfig mapping) will be implemented in a follow-up PR
  - Beneficiary ATA creation during fee program `setBeneficiary` will be addressed in a follow-up PR

  ### Backward compatibility

  No — intentional breaking changes:

  - Fee salt is now a required parameter on all SVM fee reader/writer constructors (previously defaulted to zeros). Public-facing artifact managers (`SvmWarpArtifactManager`, `SvmFeeArtifactManager`) resolve defaults via
  `resolveFeeSalt(chainName)`, so consumers going through the standard API are unaffected.
  - `SvmWarpArtifactManager` and `SvmFeeArtifactManager` constructors now require `chainConfig: { chainName: string }`.
  - `SvmDeployedWarpAddress` extends `DeployedWarpAddress` with optional `feeConfig` — readers now return this extended type.
  - `contractVersion` added to provider-sdk `BaseWarpConfig`, `BaseDerivedWarpConfig`, and `BaseWarpArtifactConfig` (optional field, no impact on other VMs).

  ### Testing

  **E2E tests (11 new tests):**
  - `warp-fee-config.e2e-test.ts` — set fee on deploy, add/change/remove fee via update, salt-change detection
  - `program-upgrade.e2e-test.ts` — deploy with legacy bytes → upgrade → read version, authority differs from payer, downgrade rejection, version match skip, migration required proof, migration success with ownership transfer

  **Unit tests (5 new tests):**
  - `warp-tx.unit-test.ts` — fee config diff: add, remove, change program, same program with different salt, no-op

  **Shared suite additions:**
  - `warp-token-suite.ts` — program version assertion after deploy, `supportsFeeConfig` validation

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
