### PR TITLE
chore: denylist USDC/paradex stuck message — blacklisted recipient

### DIFF
--- a/typescript/infra/config/environments/mainnet3/customBlacklist.ts
+++ b/typescript/infra/config/environments/mainnet3/customBlacklist.ts
@@ -237,4 +237,6 @@ export const blacklistedMessageIds = [
 
   // USDC/eclipsemainnet warp transfer to USDC contract itself [2026-01-30]
   '0x4190cf8c0419cd966fc96fcb9050be3d941cb06974667bd768f22e90abcec6a6',
+  // USDC/paradex user transfer to USDC contract address (blacklisted by Circle) [2026-04-27]
+  '0xeece23565b9bf5a344516b92a8bf857644f5ef29e49fd0b525c8f752452cf113',
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

## Summary
Added 1 message ID to the relayer denylist for USDC/paradex route.

## Details
- Message: `0xeece23565b9bf5a344516b92a8bf857644f5ef29e49fd0b525c8f752452cf113`
- Route: paradex → arbitrum (USDC/paradex app context)
- Error: "Blacklistable: account is blacklisted"
- Root cause: User set the USDC contract address as the transfer recipient. Circle blacklists the USDC contract on itself, so the transfer permanently reverts.
- 58 retries, undeliverable

### Drive-by changes

None.

### Related issues

None.

### Backward compatibility

Yes. This only adds one message ID to the relayer denylist config.

### Testing

- [x] Message ID is valid (66 chars, 0x-prefixed)
- [ ] Deploy relayer with updated denylist
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-facf299a-1124-4086-a4e4-02a6c43dccad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-facf299a-1124-4086-a4e4-02a6c43dccad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

