### PR TITLE
chore: filter disabled chains from grafana balance alerts

### DIFF
--- a/typescript/infra/scripts/funding/write-alert.ts
+++ b/typescript/infra/scripts/funding/write-alert.ts
@@ -17,7 +17,11 @@ import {
   ProvisionedAlertRule,
   alertConfigMapping,
 } from '../../src/config/funding/grafanaAlerts.js';
-import { parseBalancesPromQLQuery } from '../../src/funding/alerts.js';
+import {
+  filterAlertChains,
+  getNoAlertChains,
+  parseBalancesPromQLQuery,
+} from '../../src/funding/alerts.js';
 import { validateThresholds } from '../../src/funding/balances.js';
 import {
   fetchGrafanaAlert,
@@ -79,6 +83,7 @@ async function main() {
     const alertsToUpdate = Object.values(AlertType);
     const alertUpdateInfo: AlertUpdateInfo[] = [];
     const missingChainErrors: RegressionError[] = [];
+    const noAlertChains = getNoAlertChains();
 
     for (const alert of alertsToUpdate) {
       // fetch alertRule config from Grafana via the Grafana API
@@ -92,10 +97,23 @@ async function main() {
 
       // parse the current thresholds from the existing query
       const existingQuery = alertRule.queries[0];
-      const currentThresholds = parseBalancesPromQLQuery(
+      let currentThresholds = parseBalancesPromQLQuery(
         existingQuery,
         alertConfigMapping[alert].walletName,
       );
+
+      // Drop disabled / decommissioned / known-down chains from both sides so
+      // they're stripped from the new query without prompting as "missing".
+      const droppedChains = Object.keys(currentThresholds).filter((chain) =>
+        noAlertChains.has(chain),
+      );
+      if (droppedChains.length > 0) {
+        rootLogger.info(
+          `Removing ${droppedChains.length} no-alert chain(s) from ${alert}: ${droppedChains.join(', ')}`,
+        );
+      }
+      proposedThresholds = filterAlertChains(proposedThresholds, noAlertChains);
+      currentThresholds = filterAlertChains(currentThresholds, noAlertChains);
 
       // log an error if a chain is defined in current thresholds but not in the proposed thresholds
       // this is to ensure that we don't introduce a regression where a chain is no longer being monitored

--- a/typescript/infra/src/funding/alerts.ts
+++ b/typescript/infra/src/funding/alerts.ts
@@ -1,5 +1,6 @@
-import { ChainMap } from '@hyperlane-xyz/sdk';
+import { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
 
+import { getDisabledChains } from '../config/chain.js';
 import {
   AlertType,
   WalletName,
@@ -9,6 +10,33 @@ import {
   fetchGrafanaAlert,
   fetchGrafanaServiceAccountToken,
 } from '../infrastructure/monitoring/grafana.js';
+
+// Chains we should not generate Grafana balance alerts for, in addition to
+// any chain marked as disabled in the registry. Mirrors the alert-relevant
+// subset of `chainsToSkip` in src/config/chain.ts.
+const ADDITIONAL_NO_ALERT_CHAINS: ChainName[] = [
+  // permanently decommissioned
+  'everclear',
+  'milkyway',
+
+  // downtime
+  'molten',
+  'fluence',
+  'tangle',
+];
+
+export function getNoAlertChains(): Set<ChainName> {
+  return new Set([...getDisabledChains(), ...ADDITIONAL_NO_ALERT_CHAINS]);
+}
+
+export function filterAlertChains<T>(
+  thresholds: ChainMap<T>,
+  noAlertChains: Set<ChainName>,
+): ChainMap<T> {
+  return Object.fromEntries(
+    Object.entries(thresholds).filter(([chain]) => !noAlertChains.has(chain)),
+  );
+}
 
 export function parseBalancesPromQLQuery(
   query: string,


### PR DESCRIPTION
## Summary
- Adds `getNoAlertChains()` (registry-disabled chains ∪ `everclear`, `milkyway` decommissioned ∪ `molten`, `fluence`, `tangle` downtime) and a `filterAlertChains` helper to `src/funding/alerts.ts`.
- `scripts/funding/write-alert.ts` now strips these chains from both the proposed thresholds (read from JSON) and the parsed-from-Grafana current thresholds before computing the diff and missing-chain checks. Result: when the script runs, those chains are silently dropped from the regenerated PromQL query, removing the alerts on Grafana for them, with a single `info` log listing what was dropped.
- Disabled status is sourced programmatically from the registry via the existing `getDisabledChains()`, so newly disabled chains will be picked up automatically on the next run.

## Test plan
- [ ] CI / typecheck passes
- [ ] Run `write-alert.ts` (dry-run first) and confirm the listed chains are no longer in the regenerated query and that no missing-chain prompts fire for them
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes which chains have balance alerts generated/updated, potentially removing monitoring for chains if the no-alert list is incorrect or registry status is mis-set.
> 
> **Overview**
> Updates the Grafana balance-alert update flow to *automatically exclude* chains that should not be monitored (registry-disabled chains plus a small hardcoded set of decommissioned/known-down chains).
> 
> Adds `getNoAlertChains()` and `filterAlertChains()` in `src/funding/alerts.ts`, and applies this filtering in `scripts/funding/write-alert.ts` to strip those chains from both the proposed JSON thresholds and the thresholds parsed from the existing Grafana query before diffing/missing-chain checks, with an info log listing any removed chains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f200f611a5c8c651a8996c58f2c288c8983a28f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->