### PR TITLE
fix: retry gas-cap-reached txs in inclusion stage

### DIFF
--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -31,6 +31,12 @@ pub const STAGE_NAME: &str = "InclusionStage";
 
 const MIN_TX_STATUS_CHECK_DELAY: Duration = Duration::from_millis(100);
 
+enum SubmitOutcome {
+    Submitted(Transaction),
+    TxAlreadyExists(Transaction),
+    TxGasCapReached(Transaction),
+}
+
 pub struct InclusionStage {
     pub(crate) pool: InclusionStagePool,
     tx_receiver: mpsc::Receiver<Transaction>,
@@ -175,7 +181,7 @@ impl InclusionStage {
             }
 
             if let Err(err) =
-                Self::try_process_tx(tx.clone(), finality_stage_sender, state, pool).await
+                Self::try_process_tx(tx.clone(), finality_stage_sender, state, pool, domain).await
             {
                 error!(?err, ?tx, "Error processing transaction. Dropping it");
 
@@ -284,6 +290,7 @@ impl InclusionStage {
         finality_stage_sender: &mpsc::Sender<Transaction>,
         state: &DispatcherState,
         pool: &InclusionStagePool,
+        domain: &str,
     ) -> Result<(), LanderError> {
         info!(?tx, "Processing inclusion stage transaction");
 
@@ -304,8 +311,15 @@ impl InclusionStage {
             pool_lock.insert(tx.uuid.clone(), tx.clone());
         }
 
-        Self::try_process_tx_with_next_status(tx, tx_status, finality_stage_sender, state, pool)
-            .await
+        Self::try_process_tx_with_next_status(
+            tx,
+            tx_status,
+            finality_stage_sender,
+            state,
+            pool,
+            domain,
+        )
+        .await
     }
 
     #[instrument(
@@ -319,6 +333,7 @@ impl InclusionStage {
         finality_stage_sender: &mpsc::Sender<Transaction>,
         state: &DispatcherState,
         pool: &InclusionStagePool,
+        domain: &str,
     ) -> Result<(), LanderError> {
         match tx_status {
             TransactionStatus::PendingInclusion | TransactionStatus::Mempool => {
@@ -328,7 +343,7 @@ impl InclusionStage {
                     info!(?tx, "Transaction is not ready for resubmission");
                     return Ok(());
                 }
-                Self::process_pending_tx(tx, state, pool).await
+                Self::process_pending_tx(tx, state, pool, domain).await
             }
             TransactionStatus::Included | TransactionStatus::Finalized => {
                 update_tx_status(state, &mut tx, tx_status.clone()).await?;
@@ -357,6 +372,7 @@ impl InclusionStage {
         mut tx: Transaction,
         state: &DispatcherState,
         pool: &InclusionStagePool,
+        domain: &str,
     ) -> Result<(), LanderError> {
         info!(?tx, "Processing pending transaction");
 
@@ -371,7 +387,26 @@ impl InclusionStage {
         tx = Self::estimate_tx(&tx, state).await?;
 
         // Submitting transaction to the node
-        tx = Self::submit_tx(&tx, state).await?;
+        let submit_outcome = Self::submit_tx(&tx, state).await?;
+        match submit_outcome {
+            SubmitOutcome::Submitted(submitted_tx)
+            | SubmitOutcome::TxAlreadyExists(submitted_tx) => {
+                tx = submitted_tx;
+            }
+            SubmitOutcome::TxGasCapReached(mut blocked_tx) => {
+                info!(
+                    ?blocked_tx,
+                    "Transaction reached gas cap for now; keeping it pending for later retry"
+                );
+                Self::update_inclusion_stage_metric(state, domain, &LanderError::TxGasCapReached);
+                let current_status = blocked_tx.status.clone();
+                update_tx_status(state, &mut blocked_tx, current_status).await?;
+                pool.lock()
+                    .await
+                    .insert(blocked_tx.uuid.clone(), blocked_tx);
+                return Ok(());
+            }
+        }
         info!(?tx, "Transaction submitted to node");
 
         state
@@ -393,7 +428,7 @@ impl InclusionStage {
     async fn submit_tx(
         tx: &Transaction,
         state: &DispatcherState,
-    ) -> Result<Transaction, LanderError> {
+    ) -> Result<SubmitOutcome, LanderError> {
         // create a temporary arcmutex so that submission retries are aware of tx fields (e.g. gas price)
         // set by previous retries when calling `adapter.submit`
         let tx_shared = Arc::new(Mutex::new(tx.clone()));
@@ -409,10 +444,18 @@ impl InclusionStage {
                     let submit_result = state.adapter.submit(&mut tx_guard).await;
 
                     match submit_result {
-                        Ok(()) => Ok(tx_guard.clone()),
+                        Ok(()) => Ok(SubmitOutcome::Submitted(tx_guard.clone())),
                         Err(err) if matches!(err, LanderError::TxAlreadyExists) => {
                             warn!(tx=?tx_guard, ?err, "Transaction resubmission failed, will check the status of transaction before dropping it");
-                            Ok(tx_guard.clone())
+                            Ok(SubmitOutcome::TxAlreadyExists(tx_guard.clone()))
+                        }
+                        Err(err) if matches!(err, LanderError::TxGasCapReached) => {
+                            warn!(
+                                tx=?tx_guard,
+                                ?err,
+                                "Transaction resubmission hit the current gas cap; keeping it for later retry"
+                            );
+                            Ok(SubmitOutcome::TxGasCapReached(tx_guard.clone()))
                         }
                         Err(err) => Err(err),
                     }

--- a/rust/main/lander/src/tests/evm/tests_inclusion_stage.rs
+++ b/rust/main/lander/src/tests/evm/tests_inclusion_stage.rs
@@ -1288,7 +1288,7 @@ async fn run_and_expect_successful_inclusion(
 
 #[tokio::test]
 #[traced_test]
-async fn test_tx_dropped_when_gas_reaches_3x_cap() {
+async fn test_tx_kept_pending_when_gas_reaches_3x_cap() {
     let block_time = TEST_BLOCK_TIME;
     let signer = H160::random();
 
@@ -1315,11 +1315,6 @@ async fn test_tx_dropped_when_gas_reaches_3x_cap() {
     mock_evm_provider
         .expect_get_transaction_receipt()
         .returning(|_| Ok(None));
-
-    // Mock send for the new transaction (after the first one is dropped)
-    mock_evm_provider
-        .expect_send()
-        .returning(|_, _| Ok(H256::random()));
 
     let (payload_db, tx_db, nonce_db) = tmp_dbs();
     let mut adapter = mock_ethereum_adapter(
@@ -1398,7 +1393,7 @@ async fn test_tx_dropped_when_gas_reaches_3x_cap() {
         .await
         .insert(tx_uuid.clone(), created_tx.clone());
 
-    // Process the transaction - it should be dropped due to hitting gas cap
+    // Process the transaction - it should remain pending for later retry
     let result = InclusionStage::process_txs_step(
         &inclusion_stage_pool,
         &finality_stage_sender,
@@ -1410,25 +1405,29 @@ async fn test_tx_dropped_when_gas_reaches_3x_cap() {
     // The result should be Ok (error is handled internally)
     assert!(result.is_ok(), "Inclusion stage should handle the error");
 
-    // The pool should be empty (tx was dropped)
+    // The tx should remain in the pool for later retry.
     assert!(
-        inclusion_stage_pool.lock().await.is_empty(),
-        "Transaction should be removed from pool"
+        inclusion_stage_pool.lock().await.contains_key(&tx_uuid),
+        "Transaction should remain in pool"
     );
 
-    // The transaction should be marked as Dropped in the DB
+    // The transaction should remain pending in the DB.
     let retrieved_tx = tx_db
         .retrieve_transaction_by_uuid(&tx_uuid)
         .await
         .unwrap()
         .unwrap();
     assert!(
-        matches!(retrieved_tx.status, TransactionStatus::Dropped(_)),
-        "Transaction should be dropped, got {:?}",
+        matches!(retrieved_tx.status, TransactionStatus::PendingInclusion),
+        "Transaction should remain pending, got {:?}",
         retrieved_tx.status
     );
+    assert_eq!(
+        retrieved_tx.submission_attempts, 6,
+        "Submission attempts should be persisted for later retry"
+    );
 
-    // The payload should be marked as Dropped in the DB
+    // The payload should remain associated with the pending transaction.
     for detail in &created_tx.payload_details {
         let payload = dispatcher_state
             .payload_db
@@ -1439,9 +1438,9 @@ async fn test_tx_dropped_when_gas_reaches_3x_cap() {
         assert!(
             matches!(
                 payload.status,
-                PayloadStatus::InTransaction(TransactionStatus::Dropped(_))
+                PayloadStatus::InTransaction(TransactionStatus::PendingInclusion)
             ),
-            "Payload should be dropped"
+            "Payload should remain pending"
         );
     }
 
@@ -1455,47 +1454,15 @@ async fn test_tx_dropped_when_gas_reaches_3x_cap() {
         "No transaction should be sent to finality stage"
     );
 
-    // CRITICAL TEST: Verify nonce is available for reuse
-    // Create a new transaction with the same signer
-    let new_txs = mock_evm_txs(
-        1,
-        &dispatcher_state.payload_db,
-        &dispatcher_state.tx_db,
-        TransactionStatus::PendingInclusion,
-        signer,
-        ExpectedTxType::Eip1559,
-    )
-    .await;
-    let new_tx = new_txs[0].clone();
-
-    inclusion_stage_pool
-        .lock()
-        .await
-        .insert(new_tx.uuid.clone(), new_tx.clone());
-
-    // Process the new transaction - it should be able to use the freed nonce
-    let result = InclusionStage::process_txs_step(
-        &inclusion_stage_pool,
-        &finality_stage_sender,
-        &dispatcher_state,
-        mock_domain,
-    )
-    .await;
-
-    assert!(
-        result.is_ok(),
-        "New transaction should be processed successfully"
-    );
-
-    // Verify the new transaction got assigned a nonce (nonce 1 should be reused)
+    // The nonce should remain stored on the pending tx for a future retry.
     let stored_nonce = nonce_db
-        .retrieve_nonce_by_transaction_uuid(&signer, &new_tx.uuid)
+        .retrieve_nonce_by_transaction_uuid(&signer, &tx_uuid)
         .await
         .unwrap();
     assert_eq!(
         stored_nonce,
         Some(U256::from(1)),
-        "New transaction should reuse the freed nonce"
+        "Pending transaction should retain its nonce for later retry"
     );
 }
 

--- a/rust/main/lander/src/tests/tron/tests_inclusion_stage.rs
+++ b/rust/main/lander/src/tests/tron/tests_inclusion_stage.rs
@@ -44,6 +44,8 @@ struct ConfigurableMockProvider {
     /// How many times to fail before succeeding
     fail_count: std::sync::Mutex<u32>,
     max_failures: u32,
+    /// Error to return for transient failures before succeeding
+    transient_submit_error: Option<String>,
     /// Finalized block number
     finalized_block: u32,
     /// Transaction receipt to return (None = not found, Some(None) = mempool, Some(Some(n)) = included at block n)
@@ -57,6 +59,7 @@ impl ConfigurableMockProvider {
             should_submit_fail: false,
             fail_count: std::sync::Mutex::new(0),
             max_failures: 0,
+            transient_submit_error: None,
             finalized_block: 100,
             receipt_block: None,
         }
@@ -80,6 +83,14 @@ impl ConfigurableMockProvider {
     fn with_retryable_error(max_failures: u32) -> Self {
         Self {
             max_failures,
+            ..Self::new()
+        }
+    }
+
+    fn with_transient_submit_error(error: &str, max_failures: u32) -> Self {
+        Self {
+            max_failures,
+            transient_submit_error: Some(error.to_string()),
             ..Self::new()
         }
     }
@@ -115,9 +126,11 @@ impl TronProviderForLander for ConfigurableMockProvider {
         let mut fail_count = self.fail_count.lock().unwrap();
         if *fail_count < self.max_failures {
             *fail_count += 1;
-            return Err(ChainCommunicationError::from_other_str(
-                "SERVER_BUSY: node is busy, please retry",
-            ));
+            let err = self
+                .transient_submit_error
+                .as_deref()
+                .unwrap_or("SERVER_BUSY: node is busy, please retry");
+            return Err(ChainCommunicationError::from_other_str(err));
         }
 
         Ok(H256::random())
@@ -504,6 +517,107 @@ async fn test_tron_inclusion_retryable_error() {
             .await
             .contains_key(&created_tx.uuid),
         "Transaction should remain in pool for status checking after submission"
+    );
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_tron_inclusion_bandwidth_error_is_retried_later() {
+    let block_time = Duration::from_millis(0);
+    let mock_provider = ConfigurableMockProvider::with_transient_submit_error("BANDWITH_ERROR", 1);
+
+    let dispatcher_state = mock_dispatcher_state_with_provider(mock_provider, block_time);
+    let (finality_stage_sender, _finality_stage_receiver) = mpsc::channel(100);
+    let inclusion_stage_pool = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+
+    let created_tx = mock_tron_tx(
+        &dispatcher_state.payload_db,
+        &dispatcher_state.tx_db,
+        TransactionStatus::PendingInclusion,
+    )
+    .await;
+
+    let tx_uuid = created_tx.uuid.clone();
+    let mock_domain = TEST_DOMAIN.into();
+    inclusion_stage_pool
+        .lock()
+        .await
+        .insert(tx_uuid.clone(), created_tx.clone());
+
+    let result = InclusionStage::process_txs_step(
+        &inclusion_stage_pool,
+        &finality_stage_sender,
+        &dispatcher_state,
+        mock_domain,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Bandwidth error should not drop transaction"
+    );
+    assert!(
+        inclusion_stage_pool.lock().await.contains_key(&tx_uuid),
+        "Transaction should remain in pool after bandwidth error"
+    );
+
+    let after_first_attempt = dispatcher_state
+        .tx_db
+        .retrieve_transaction_by_uuid(&tx_uuid)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        matches!(
+            after_first_attempt.status,
+            TransactionStatus::PendingInclusion
+        ),
+        "Transaction should stay pending after bandwidth error, got {:?}",
+        after_first_attempt.status
+    );
+    assert_eq!(
+        after_first_attempt.submission_attempts, 1,
+        "Submission attempt should be persisted for later retry"
+    );
+    assert_eq!(
+        dispatcher_state
+            .metrics
+            .inclusion_stage_error
+            .with_label_values(&[mock_domain, "TxGasCapReached", "false"])
+            .get(),
+        1,
+        "Bandwidth-triggered gas cap deferral should increment inclusion-stage error metric"
+    );
+
+    let result = InclusionStage::process_txs_step(
+        &inclusion_stage_pool,
+        &finality_stage_sender,
+        &dispatcher_state,
+        mock_domain,
+    )
+    .await;
+
+    assert!(result.is_ok(), "Second attempt should succeed");
+
+    let after_second_attempt = dispatcher_state
+        .tx_db
+        .retrieve_transaction_by_uuid(&tx_uuid)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        matches!(after_second_attempt.status, TransactionStatus::Mempool),
+        "Transaction should reach mempool after retry, got {:?}",
+        after_second_attempt.status
+    );
+    assert_eq!(
+        dispatcher_state
+            .metrics
+            .inclusion_stage_error
+            .with_label_values(&[mock_domain, "TxGasCapReached", "false"])
+            .get(),
+        1,
+        "Successful retry should not add another gas-cap error metric"
     );
 }
 


### PR DESCRIPTION
## Summary
- keep `TxGasCapReached` transactions pending in inclusion stage instead of dropping them immediately
- preserve inclusion-stage error metrics for deferred gas-cap events
- add regression coverage for Tron bandwidth-error recovery and the shared inclusion-stage gas-cap path

## Context
This addresses the broader fix requested from ENG-3584. The incident root cause on Tron was that a submission could hit `TxGasCapReached` transiently and become unrecoverable. This change adjusts inclusion-stage handling so those transactions stay retryable after later funding or state changes.

## Testing
- cargo test -p lander test_tron_error_bandwidth_error
- cargo test -p lander test_tron_inclusion_bandwidth_error_is_retried_later
- cargo test -p lander test_tx_kept_pending_when_gas_reaches_3x_cap

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
