### PR TITLE
feat(rebalancer): add fluent external bridge

### DIFF
--- a/.changeset/fluent-external-bridge.md
+++ b/.changeset/fluent-external-bridge.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': minor
+---
+
+The rebalancer gained a Fluent external bridge that uses Fluent's canonical NativeGateway to move native ETH between Ethereum and Fluent (chainId 25363). Status is read directly from `FluentBridge.getReceivedMessage(messageHash)`; no L1/L2 event log search is required. A new `bridge:direct` script (`src/scripts/bridgeDirect.ts`) lets operators invoke any registered `IExternalBridge` directly without a rebalancer config file. `BridgeTransferStatus.complete`'s `receivingTxHash` and `receivedAmount` fields were made optional since not every bridge needs to populate them.

--- a/typescript/rebalancer/package.json
+++ b/typescript/rebalancer/package.json
@@ -37,7 +37,8 @@
     "test:ci": "pnpm test",
     "start": "node dist/service.js",
     "start:dev": "tsx src/service.ts",
-    "bridge:dev": "tsx src/scripts/externalBridge.ts"
+    "bridge:dev": "tsx src/scripts/externalBridge.ts",
+    "bridge:direct": "tsx src/scripts/bridgeDirect.ts"
   },
   "dependencies": {
     "@google-cloud/pino-logging-gcp-config": "catalog:",

--- a/typescript/rebalancer/src/bridges/FluentBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/FluentBridge.test.ts
@@ -1,0 +1,375 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import { pino } from 'pino';
+
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import type { ExternalBridgeConfig } from '../interfaces/IExternalBridge.js';
+import { FluentBridge } from './FluentBridge.js';
+import {
+  ETHEREUM_CHAIN_ID,
+  FLUENT_BRIDGE_ADDRESS,
+  FLUENT_CHAIN_ID,
+  FLUENT_NATIVE_GATEWAY_ADDRESS,
+  MessageStatus,
+  NATIVE_TOKEN_SENTINEL,
+  fluentBridgeInterface,
+} from './fluentUtils.js';
+
+const testLogger = pino({ level: 'silent' });
+const TEST_PRIVATE_KEY =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const TEST_WALLET = new ethers.Wallet(TEST_PRIVATE_KEY);
+const TEST_MESSAGE_HASH = ethers.utils.hexZeroPad('0xabcd', 32);
+
+const BRIDGE_CONFIG: ExternalBridgeConfig = {
+  integrator: 'hyperlane',
+  chainMetadata: {
+    ethereum: {
+      chainId: ETHEREUM_CHAIN_ID,
+      domainId: ETHEREUM_CHAIN_ID,
+      protocol: ProtocolType.Ethereum,
+      name: 'ethereum',
+      displayName: 'Ethereum',
+      rpcUrls: [{ http: 'https://ethereum.example' }],
+    },
+    fluent: {
+      chainId: FLUENT_CHAIN_ID,
+      domainId: FLUENT_CHAIN_ID,
+      protocol: ProtocolType.Ethereum,
+      name: 'fluent',
+      displayName: 'Fluent',
+      rpcUrls: [{ http: 'https://fluent.example' }],
+    },
+  },
+};
+
+class TestFluentBridge extends FluentBridge {
+  messageFeeByChain = new Map<number, bigint>();
+  messageStatusByHash = new Map<string, number>();
+  currentBlockByChain = new Map<number, number>();
+  receiptResponses = new Map<
+    string,
+    ethers.providers.TransactionReceipt | null
+  >();
+  transactionDetails = new Map<
+    string,
+    ethers.providers.TransactionResponse | null
+  >();
+  sentTransactions: Array<{ chainId: number; tx: any }> = [];
+  nextReceipts: ethers.providers.TransactionReceipt[] = [];
+
+  protected override async readContract(
+    chainId: number,
+    to: string,
+    data: string,
+  ): Promise<string> {
+    if (
+      to.toLowerCase() === FLUENT_BRIDGE_ADDRESS.toLowerCase() &&
+      data.startsWith(fluentBridgeInterface.getSighash('getSentMessageFee'))
+    ) {
+      const fee = this.messageFeeByChain.get(chainId) ?? 0n;
+      return fluentBridgeInterface.encodeFunctionResult('getSentMessageFee', [
+        fee,
+      ]);
+    }
+    if (
+      to.toLowerCase() === FLUENT_BRIDGE_ADDRESS.toLowerCase() &&
+      data.startsWith(fluentBridgeInterface.getSighash('getReceivedMessage'))
+    ) {
+      const decoded = fluentBridgeInterface.decodeFunctionData(
+        'getReceivedMessage',
+        data,
+      );
+      const status =
+        this.messageStatusByHash.get(decoded[0] as string) ??
+        MessageStatus.None;
+      return fluentBridgeInterface.encodeFunctionResult('getReceivedMessage', [
+        status,
+      ]);
+    }
+    throw new Error(`Unexpected readContract call: ${to} ${data}`);
+  }
+
+  protected override async getCurrentBlockNumber(
+    chainId: number,
+  ): Promise<number> {
+    return this.currentBlockByChain.get(chainId) ?? 1_000_000;
+  }
+
+  protected override async getTransactionReceipt(
+    chainId: number,
+    txHash: string,
+  ): Promise<ethers.providers.TransactionReceipt | null> {
+    return (
+      this.receiptResponses.get(`${chainId}:${txHash.toLowerCase()}`) ?? null
+    );
+  }
+
+  protected override async getTransaction(
+    chainId: number,
+    txHash: string,
+  ): Promise<ethers.providers.TransactionResponse | null> {
+    return (
+      this.transactionDetails.get(`${chainId}:${txHash.toLowerCase()}`) ?? null
+    );
+  }
+
+  protected override async sendPreparedTransaction(
+    chainId: number,
+    _privateKey: string,
+    tx: any,
+  ): Promise<ethers.providers.TransactionReceipt> {
+    this.sentTransactions.push({ chainId, tx });
+    const receipt = this.nextReceipts.shift();
+    if (!receipt) throw new Error('Missing test receipt');
+    return receipt;
+  }
+}
+
+function createSentMessageReceipt(
+  txHash: string,
+  messageHash: string,
+): ethers.providers.TransactionReceipt {
+  const encoded = fluentBridgeInterface.encodeEventLog(
+    fluentBridgeInterface.getEvent('SentMessage'),
+    [
+      TEST_WALLET.address,
+      FLUENT_NATIVE_GATEWAY_ADDRESS,
+      1_000_000_000_000_000n,
+      0n,
+      ETHEREUM_CHAIN_ID,
+      1_000_500,
+      42,
+      messageHash,
+      '0xb9cca7a3',
+    ],
+  );
+  return {
+    transactionHash: txHash,
+    logs: [
+      {
+        address: FLUENT_BRIDGE_ADDRESS,
+        topics: encoded.topics,
+        data: encoded.data,
+        transactionHash: txHash,
+      } as ethers.providers.Log,
+    ],
+  } as ethers.providers.TransactionReceipt;
+}
+
+describe('FluentBridge', () => {
+  describe('quote', () => {
+    it('quotes ethereum -> fluent at 1:1 with on-chain message fee', async () => {
+      const bridge = new TestFluentBridge(BRIDGE_CONFIG, testLogger);
+      bridge.messageFeeByChain.set(ETHEREUM_CHAIN_ID, 0n);
+
+      const quote = await bridge.quote({
+        fromChain: ETHEREUM_CHAIN_ID,
+        toChain: FLUENT_CHAIN_ID,
+        fromToken: NATIVE_TOKEN_SENTINEL,
+        toToken: NATIVE_TOKEN_SENTINEL,
+        fromAmount: 1_000_000_000_000_000n,
+        fromAddress: TEST_WALLET.address,
+        toAddress: TEST_WALLET.address,
+      });
+
+      expect(quote.tool).to.equal('fluent');
+      expect(quote.fromAmount).to.equal(1_000_000_000_000_000n);
+      expect(quote.toAmount).to.equal(1_000_000_000_000_000n);
+      expect(quote.toAmountMin).to.equal(1_000_000_000_000_000n);
+      expect(quote.gasCosts).to.equal(0n);
+      expect(quote.feeCosts).to.equal(0n);
+      expect(quote.route.kind).to.equal('ethereum-to-fluent');
+      expect(quote.route.executionTx.chainId).to.equal(ETHEREUM_CHAIN_ID);
+      expect(quote.route.executionTx.value).to.equal(1_000_000_000_000_000n);
+      expect(quote.route.executionTx.to.toLowerCase()).to.equal(
+        FLUENT_NATIVE_GATEWAY_ADDRESS.toLowerCase(),
+      );
+    });
+
+    it('quotes fluent -> ethereum and includes the L2 fee in tx value', async () => {
+      const bridge = new TestFluentBridge(BRIDGE_CONFIG, testLogger);
+      bridge.messageFeeByChain.set(FLUENT_CHAIN_ID, 449_828_643_600_000n);
+
+      const quote = await bridge.quote({
+        fromChain: FLUENT_CHAIN_ID,
+        toChain: ETHEREUM_CHAIN_ID,
+        fromToken: NATIVE_TOKEN_SENTINEL,
+        toToken: NATIVE_TOKEN_SENTINEL,
+        fromAmount: 200_000_000_000_000n,
+        fromAddress: TEST_WALLET.address,
+        toAddress: TEST_WALLET.address,
+      });
+
+      expect(quote.gasCosts).to.equal(449_828_643_600_000n);
+      expect(quote.route.kind).to.equal('fluent-to-ethereum');
+      expect(quote.route.executionTx.chainId).to.equal(FLUENT_CHAIN_ID);
+      expect(quote.route.executionTx.value).to.equal(
+        200_000_000_000_000n + 449_828_643_600_000n,
+      );
+    });
+
+    it('rejects an unsupported chain pair', async () => {
+      const bridge = new TestFluentBridge(BRIDGE_CONFIG, testLogger);
+      let error: unknown;
+      try {
+        await bridge.quote({
+          fromChain: 137,
+          toChain: FLUENT_CHAIN_ID,
+          fromToken: NATIVE_TOKEN_SENTINEL,
+          toToken: NATIVE_TOKEN_SENTINEL,
+          fromAmount: 1n,
+          fromAddress: TEST_WALLET.address,
+        });
+      } catch (e) {
+        error = e;
+      }
+      expect((error as Error).message).to.match(/Unsupported Fluent route/);
+    });
+  });
+
+  describe('execute', () => {
+    it('sends sendNativeTokens and stores execution state keyed on tx hash', async () => {
+      const bridge = new TestFluentBridge(BRIDGE_CONFIG, testLogger);
+      bridge.messageFeeByChain.set(ETHEREUM_CHAIN_ID, 0n);
+      bridge.currentBlockByChain.set(FLUENT_CHAIN_ID, 1_000_000);
+      bridge.nextReceipts = [
+        createSentMessageReceipt('0xsourcetx', TEST_MESSAGE_HASH),
+      ];
+
+      const quote = await bridge.quote({
+        fromChain: ETHEREUM_CHAIN_ID,
+        toChain: FLUENT_CHAIN_ID,
+        fromToken: NATIVE_TOKEN_SENTINEL,
+        toToken: NATIVE_TOKEN_SENTINEL,
+        fromAmount: 1_000_000_000_000_000n,
+        fromAddress: TEST_WALLET.address,
+        toAddress: TEST_WALLET.address,
+      });
+
+      const result = await bridge.execute(quote, {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      });
+
+      expect(result.txHash).to.equal('0xsourcetx');
+      expect(result.transferId).to.equal(TEST_MESSAGE_HASH);
+      expect(result.fromChain).to.equal(ETHEREUM_CHAIN_ID);
+      expect(result.toChain).to.equal(FLUENT_CHAIN_ID);
+      expect(bridge.sentTransactions).to.have.length(1);
+      expect(bridge.sentTransactions[0].chainId).to.equal(ETHEREUM_CHAIN_ID);
+    });
+
+    it('throws if the source receipt is missing a SentMessage event', async () => {
+      const bridge = new TestFluentBridge(BRIDGE_CONFIG, testLogger);
+      bridge.messageFeeByChain.set(ETHEREUM_CHAIN_ID, 0n);
+      bridge.nextReceipts = [
+        { transactionHash: '0xsourcetx', logs: [] } as any,
+      ];
+
+      const quote = await bridge.quote({
+        fromChain: ETHEREUM_CHAIN_ID,
+        toChain: FLUENT_CHAIN_ID,
+        fromToken: NATIVE_TOKEN_SENTINEL,
+        toToken: NATIVE_TOKEN_SENTINEL,
+        fromAmount: 1_000_000_000_000_000n,
+        fromAddress: TEST_WALLET.address,
+        toAddress: TEST_WALLET.address,
+      });
+
+      let error: unknown;
+      try {
+        await bridge.execute(quote, {
+          [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+        });
+      } catch (e) {
+        error = e;
+      }
+      expect((error as Error).message).to.match(/SentMessage/);
+    });
+  });
+
+  describe('getStatus', () => {
+    async function setUpExecutedQuote(bridge: TestFluentBridge) {
+      bridge.messageFeeByChain.set(ETHEREUM_CHAIN_ID, 0n);
+      bridge.currentBlockByChain.set(FLUENT_CHAIN_ID, 1_000_000);
+      bridge.nextReceipts = [
+        createSentMessageReceipt('0xsourcetx', TEST_MESSAGE_HASH),
+      ];
+      const quote = await bridge.quote({
+        fromChain: ETHEREUM_CHAIN_ID,
+        toChain: FLUENT_CHAIN_ID,
+        fromToken: NATIVE_TOKEN_SENTINEL,
+        toToken: NATIVE_TOKEN_SENTINEL,
+        fromAmount: 1_000_000_000_000_000n,
+        fromAddress: TEST_WALLET.address,
+        toAddress: TEST_WALLET.address,
+      });
+      await bridge.execute(quote, {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      });
+    }
+
+    it('returns pending IN_FLIGHT when destination status is None', async () => {
+      const bridge = new TestFluentBridge(BRIDGE_CONFIG, testLogger);
+      await setUpExecutedQuote(bridge);
+
+      const status = await bridge.getStatus(
+        '0xsourcetx',
+        ETHEREUM_CHAIN_ID,
+        FLUENT_CHAIN_ID,
+      );
+      expect(status).to.deep.equal({
+        status: 'pending',
+        substatus: 'IN_FLIGHT',
+      });
+    });
+
+    it('returns failed when destination status is Failed', async () => {
+      const bridge = new TestFluentBridge(BRIDGE_CONFIG, testLogger);
+      await setUpExecutedQuote(bridge);
+      bridge.messageStatusByHash.set(TEST_MESSAGE_HASH, MessageStatus.Failed);
+
+      const status = await bridge.getStatus(
+        '0xsourcetx',
+        ETHEREUM_CHAIN_ID,
+        FLUENT_CHAIN_ID,
+      );
+      expect(status.status).to.equal('failed');
+    });
+
+    it('returns complete with receivedAmount derived from quote when destination status is Success', async () => {
+      const bridge = new TestFluentBridge(BRIDGE_CONFIG, testLogger);
+      await setUpExecutedQuote(bridge);
+      bridge.messageStatusByHash.set(TEST_MESSAGE_HASH, MessageStatus.Success);
+
+      const status = await bridge.getStatus(
+        '0xsourcetx',
+        ETHEREUM_CHAIN_ID,
+        FLUENT_CHAIN_ID,
+      );
+
+      expect(status).to.deep.equal({
+        status: 'complete',
+        receivedAmount: 1_000_000_000_000_000n,
+      });
+    });
+
+    it('returns not_found when the tx hash is unknown and not on-chain', async () => {
+      const bridge = new TestFluentBridge(BRIDGE_CONFIG, testLogger);
+      const status = await bridge.getStatus(
+        '0xunknowntx',
+        ETHEREUM_CHAIN_ID,
+        FLUENT_CHAIN_ID,
+      );
+      expect(status.status).to.equal('not_found');
+    });
+  });
+
+  describe('getNativeTokenAddress', () => {
+    it('returns the zero-address sentinel', () => {
+      const bridge = new FluentBridge(BRIDGE_CONFIG, testLogger);
+      expect(bridge.getNativeTokenAddress()).to.equal(NATIVE_TOKEN_SENTINEL);
+    });
+  });
+});

--- a/typescript/rebalancer/src/bridges/FluentBridge.ts
+++ b/typescript/rebalancer/src/bridges/FluentBridge.ts
@@ -1,0 +1,467 @@
+import { ethers } from 'ethers';
+import type { Logger } from 'pino';
+
+import type { ChainMetadata } from '@hyperlane-xyz/sdk';
+import {
+  ProtocolType,
+  assert,
+  ensure0x,
+  normalizeAddressEvm,
+} from '@hyperlane-xyz/utils';
+
+import type {
+  BridgeQuote,
+  BridgeQuoteParams,
+  BridgeTransferResult,
+  BridgeTransferStatus,
+  ExternalBridgeConfig,
+  IExternalBridge,
+} from '../interfaces/IExternalBridge.js';
+import {
+  ETHEREUM_CHAIN_ID,
+  FLUENT_CHAIN_ID,
+  FLUENT_FORWARD_CONFIG,
+  FLUENT_REVERSE_CONFIG,
+  type FluentDirection,
+  type FluentExecutionTx,
+  MessageStatus,
+  NATIVE_TOKEN_SENTINEL,
+  buildEthereumToFluentDeposit,
+  buildFluentToEthereumWithdraw,
+  extractMessageHashFromReceipt,
+  extractSentMessageFromReceipt,
+  fluentBridgeInterface,
+} from './fluentUtils.js';
+
+// Empirically observed timings (mainnet round-trip 2026-04-29):
+// deposit ~2 min, withdrawal ~6 min. Plus margin.
+const DEPOSIT_EXECUTION_DURATION_S = 5 * 60;
+const WITHDRAW_EXECUTION_DURATION_S = 15 * 60;
+
+export type FluentBridgeRoute = {
+  id: string;
+  kind: FluentDirection;
+  fromChainId: number;
+  toChainId: number;
+  fromToken: string;
+  toToken: string;
+  recipient: string;
+  executionTx: FluentExecutionTx;
+  messageFee: bigint;
+};
+
+type FluentExecutionState = {
+  kind: FluentDirection;
+  recipient: string;
+  expectedReceivedAmount: bigint;
+  messageHash?: string;
+};
+
+function addressesEqual(a: string, b: string): boolean {
+  return normalizeAddressEvm(a) === normalizeAddressEvm(b);
+}
+
+function normalizeTxHash(txHash: string): string {
+  return txHash.startsWith('0x')
+    ? txHash.toLowerCase()
+    : `0x${txHash.toLowerCase()}`;
+}
+
+export class FluentBridge implements IExternalBridge {
+  readonly externalBridgeId = 'fluent';
+  readonly logger: Logger;
+
+  private readonly chainMetadataByChainId: Map<number, ChainMetadata>;
+  private readonly executionStateByTxHash = new Map<
+    string,
+    FluentExecutionState
+  >();
+
+  constructor(config: ExternalBridgeConfig, logger: Logger) {
+    this.logger = logger;
+    this.chainMetadataByChainId = new Map();
+    if (config.chainMetadata) {
+      for (const metadata of Object.values(config.chainMetadata)) {
+        if (
+          metadata.chainId !== undefined &&
+          metadata.protocol === ProtocolType.Ethereum
+        ) {
+          this.chainMetadataByChainId.set(Number(metadata.chainId), metadata);
+        }
+      }
+    }
+  }
+
+  getNativeTokenAddress(): string {
+    return NATIVE_TOKEN_SENTINEL;
+  }
+
+  async quote(
+    params: BridgeQuoteParams,
+  ): Promise<BridgeQuote<FluentBridgeRoute>> {
+    const { fromChain, toChain, fromAmount, toAmount, fromToken, toToken } =
+      params;
+    const direction = this.getDirection(fromChain, toChain, fromToken, toToken);
+    assert(direction, `Unsupported Fluent route: ${fromChain} -> ${toChain}`);
+    assert(toAmount === undefined, 'FluentBridge only supports fromAmount');
+    assert(fromAmount !== undefined, 'FluentBridge requires fromAmount');
+    assert(fromAmount > 0n, 'FluentBridge requires a positive fromAmount');
+
+    const recipient = normalizeAddressEvm(
+      params.toAddress ?? params.fromAddress,
+    );
+    const messageFee = await this.readMessageFee(fromChain);
+
+    const config =
+      direction === 'ethereum-to-fluent'
+        ? FLUENT_FORWARD_CONFIG
+        : FLUENT_REVERSE_CONFIG;
+
+    const executionTx =
+      direction === 'ethereum-to-fluent'
+        ? buildEthereumToFluentDeposit({
+            nativeGateway: config.nativeGatewayAddress,
+            recipient,
+            amount: fromAmount,
+            messageFee,
+          })
+        : buildFluentToEthereumWithdraw({
+            nativeGateway: config.nativeGatewayAddress,
+            recipient,
+            amount: fromAmount,
+            messageFee,
+          });
+
+    return {
+      id: crypto.randomUUID(),
+      tool: 'fluent',
+      fromAmount,
+      // 1:1 native pass-through. No DEX hop and no liquidity, so no slippage.
+      toAmount: fromAmount,
+      toAmountMin: fromAmount,
+      executionDuration:
+        direction === 'ethereum-to-fluent'
+          ? DEPOSIT_EXECUTION_DURATION_S
+          : WITHDRAW_EXECUTION_DURATION_S,
+      gasCosts: messageFee,
+      feeCosts: 0n,
+      route: {
+        id: crypto.randomUUID(),
+        kind: direction,
+        fromChainId: fromChain,
+        toChainId: toChain,
+        fromToken: normalizeAddressEvm(fromToken),
+        toToken: normalizeAddressEvm(toToken),
+        recipient,
+        executionTx,
+        messageFee,
+      },
+      requestParams: params,
+    };
+  }
+
+  async execute(
+    quote: BridgeQuote<FluentBridgeRoute>,
+    privateKeys: Partial<Record<ProtocolType, string>>,
+  ): Promise<BridgeTransferResult> {
+    const route = quote.route;
+    assert(route, 'FluentBridge requires a populated route');
+
+    const key = privateKeys[ProtocolType.Ethereum];
+    assert(key, 'Missing EVM private key for FluentBridge execution');
+
+    const signerAddress = normalizeAddressEvm(
+      new ethers.Wallet(ensure0x(key)).address,
+    );
+    this.validateExecutionQuote(quote, route, signerAddress);
+
+    const sourceReceipt = await this.sendPreparedTransaction(
+      route.executionTx.chainId,
+      key,
+      route.executionTx,
+    );
+    const sourceTxHash = normalizeTxHash(sourceReceipt.transactionHash);
+    const messageHash = extractMessageHashFromReceipt(sourceReceipt);
+    assert(
+      messageHash,
+      `FluentBridge source tx ${sourceTxHash} did not emit a SentMessage event`,
+    );
+
+    this.executionStateByTxHash.set(sourceTxHash, {
+      kind: route.kind,
+      recipient: route.recipient,
+      expectedReceivedAmount: quote.toAmountMin,
+      messageHash,
+    });
+
+    return {
+      txHash: sourceTxHash,
+      fromChain: route.fromChainId,
+      toChain: route.toChainId,
+      transferId: messageHash,
+    };
+  }
+
+  async getStatus(
+    txHash: string,
+    fromChain: number,
+    toChain: number,
+  ): Promise<BridgeTransferStatus> {
+    const normalizedTxHash = normalizeTxHash(txHash);
+    let state = this.executionStateByTxHash.get(normalizedTxHash);
+    if (!state) {
+      const rehydrated = await this.rehydrateExecutionState(
+        normalizedTxHash,
+        fromChain,
+        toChain,
+      );
+      if (rehydrated) {
+        this.executionStateByTxHash.set(normalizedTxHash, rehydrated);
+        state = rehydrated;
+      }
+    }
+    if (!state) return { status: 'not_found' };
+
+    if (!state.messageHash) {
+      const sourceReceipt = await this.getTransactionReceipt(
+        fromChain,
+        normalizedTxHash,
+      );
+      if (!sourceReceipt) {
+        return { status: 'pending', substatus: 'SOURCE_PENDING' };
+      }
+      const messageHash = extractMessageHashFromReceipt(sourceReceipt);
+      if (!messageHash) {
+        return { status: 'pending', substatus: 'MESSAGE_HASH_PENDING' };
+      }
+      state.messageHash = messageHash;
+    }
+
+    const status = await this.readMessageStatus(toChain, state.messageHash);
+
+    if (status === MessageStatus.None) {
+      return { status: 'pending', substatus: 'IN_FLIGHT' };
+    }
+    if (status === MessageStatus.Failed) {
+      return {
+        status: 'failed',
+        error: 'destination call reverted',
+      };
+    }
+
+    // MessageStatus.Success: native ETH transit is 1:1, so receivedAmount
+    // is known statically from the source tx. We deliberately do NOT search
+    // L1 logs for the delivery tx — `getReceivedMessage(messageHash) = 2` is
+    // sufficient proof of completion.
+    return {
+      status: 'complete',
+      receivedAmount: state.expectedReceivedAmount,
+    };
+  }
+
+  protected getProvider(
+    chainId: number,
+  ): ethers.providers.StaticJsonRpcProvider {
+    return new ethers.providers.StaticJsonRpcProvider(
+      this.getRpcUrl(chainId),
+      chainId,
+    );
+  }
+
+  protected async readContract(
+    chainId: number,
+    to: string,
+    data: string,
+  ): Promise<string> {
+    return this.getProvider(chainId).call({ to, data });
+  }
+
+  protected async getCurrentBlockNumber(chainId: number): Promise<number> {
+    return this.getProvider(chainId).getBlockNumber();
+  }
+
+  protected async getTransactionReceipt(
+    chainId: number,
+    txHash: string,
+  ): Promise<ethers.providers.TransactionReceipt | null> {
+    return this.getProvider(chainId).getTransactionReceipt(txHash);
+  }
+
+  protected async getTransaction(
+    chainId: number,
+    txHash: string,
+  ): Promise<ethers.providers.TransactionResponse | null> {
+    return this.getProvider(chainId).getTransaction(txHash);
+  }
+
+  protected async sendPreparedTransaction(
+    chainId: number,
+    privateKey: string,
+    tx: FluentExecutionTx,
+  ): Promise<ethers.providers.TransactionReceipt> {
+    const wallet = new ethers.Wallet(
+      ensure0x(privateKey),
+      this.getProvider(chainId),
+    );
+    const response = await wallet.sendTransaction({
+      to: tx.to,
+      data: tx.data,
+      value: ethers.BigNumber.from(tx.value),
+    });
+    return response.wait();
+  }
+
+  protected async readMessageFee(chainId: number): Promise<bigint> {
+    const data = fluentBridgeInterface.encodeFunctionData(
+      'getSentMessageFee',
+      [],
+    );
+    const result = await this.readContract(
+      chainId,
+      this.getFluentBridgeAddress(chainId),
+      data,
+    );
+    const decoded = fluentBridgeInterface.decodeFunctionResult(
+      'getSentMessageFee',
+      result,
+    );
+    return BigInt(decoded[0].toString());
+  }
+
+  protected async readMessageStatus(
+    chainId: number,
+    messageHash: string,
+  ): Promise<number> {
+    const data = fluentBridgeInterface.encodeFunctionData(
+      'getReceivedMessage',
+      [messageHash],
+    );
+    const result = await this.readContract(
+      chainId,
+      this.getFluentBridgeAddress(chainId),
+      data,
+    );
+    const decoded = fluentBridgeInterface.decodeFunctionResult(
+      'getReceivedMessage',
+      result,
+    );
+    return Number(decoded[0]);
+  }
+
+  private async rehydrateExecutionState(
+    txHash: string,
+    fromChain: number,
+    toChain: number,
+  ): Promise<FluentExecutionState | undefined> {
+    const direction = this.getDirectionFromChains(fromChain, toChain);
+    if (!direction) return undefined;
+
+    const transaction = await this.getTransaction(fromChain, txHash);
+    if (!transaction?.from) return undefined;
+
+    const sourceReceipt = await this.getTransactionReceipt(fromChain, txHash);
+    const sentMessage = sourceReceipt
+      ? extractSentMessageFromReceipt(sourceReceipt)
+      : undefined;
+
+    // Without the original transferRecipient we fall back to the source signer.
+    // For rebalancer flows the signer is the recipient on the destination
+    // anyway (HypNative recipient = inventory signer address).
+    const recipient = normalizeAddressEvm(transaction.from);
+
+    return {
+      kind: direction,
+      recipient,
+      // Recover the cross-chain ETH amount from the SentMessage event
+      // (gross value minus the bridge fee).
+      expectedReceivedAmount: sentMessage?.bridgedAmount ?? 0n,
+      messageHash: sentMessage?.messageHash,
+    };
+  }
+
+  private getDirection(
+    fromChain: number,
+    toChain: number,
+    fromToken: string,
+    toToken: string,
+  ): FluentDirection | undefined {
+    const direction = this.getDirectionFromChains(fromChain, toChain);
+    if (!direction) return undefined;
+    const config =
+      direction === 'ethereum-to-fluent'
+        ? FLUENT_FORWARD_CONFIG
+        : FLUENT_REVERSE_CONFIG;
+    if (
+      addressesEqual(fromToken, config.fromToken) &&
+      addressesEqual(toToken, config.toToken)
+    ) {
+      return direction;
+    }
+    return undefined;
+  }
+
+  private getDirectionFromChains(
+    fromChain: number,
+    toChain: number,
+  ): FluentDirection | undefined {
+    if (fromChain === ETHEREUM_CHAIN_ID && toChain === FLUENT_CHAIN_ID) {
+      return 'ethereum-to-fluent';
+    }
+    if (fromChain === FLUENT_CHAIN_ID && toChain === ETHEREUM_CHAIN_ID) {
+      return 'fluent-to-ethereum';
+    }
+    return undefined;
+  }
+
+  private getFluentBridgeAddress(_chainId: number): string {
+    return FLUENT_FORWARD_CONFIG.fluentBridgeAddress;
+  }
+
+  private validateExecutionQuote(
+    quote: BridgeQuote<FluentBridgeRoute>,
+    route: FluentBridgeRoute,
+    signerAddress: string,
+  ): void {
+    const expectedDirection = this.getDirection(
+      quote.requestParams.fromChain,
+      quote.requestParams.toChain,
+      quote.requestParams.fromToken,
+      quote.requestParams.toToken,
+    );
+    assert(
+      expectedDirection === route.kind,
+      'Route kind does not match request',
+    );
+    assert(
+      quote.requestParams.fromAmount === quote.fromAmount,
+      'Quote fromAmount does not match request',
+    );
+    assert(
+      addressesEqual(quote.requestParams.fromAddress, signerAddress),
+      `Signer ${signerAddress} does not match quote.fromAddress ${quote.requestParams.fromAddress}`,
+    );
+
+    const expectedRecipient = normalizeAddressEvm(
+      quote.requestParams.toAddress ?? quote.requestParams.fromAddress,
+    );
+    assert(
+      addressesEqual(route.recipient, expectedRecipient),
+      `Route recipient ${route.recipient} does not match quote recipient ${expectedRecipient}`,
+    );
+    assert(
+      route.executionTx.chainId === route.fromChainId,
+      `Fluent execution chain ${route.executionTx.chainId} did not match source chain ${route.fromChainId}`,
+    );
+  }
+
+  private getRpcUrl(chainId: number): string {
+    const metadata = this.chainMetadataByChainId.get(chainId);
+    assert(
+      metadata,
+      `Missing chain metadata for Fluent bridge chainId ${chainId}`,
+    );
+    const rpcUrl = metadata.rpcUrls?.[0]?.http;
+    assert(rpcUrl, `Missing RPC URL for Fluent bridge chainId ${chainId}`);
+    return rpcUrl;
+  }
+}

--- a/typescript/rebalancer/src/bridges/fluentUtils.test.ts
+++ b/typescript/rebalancer/src/bridges/fluentUtils.test.ts
@@ -1,0 +1,151 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+
+import {
+  ETHEREUM_CHAIN_ID,
+  FLUENT_BRIDGE_ADDRESS,
+  FLUENT_CHAIN_ID,
+  FLUENT_NATIVE_GATEWAY_ADDRESS,
+  MessageStatus,
+  NATIVE_TOKEN_SENTINEL,
+  buildEthereumToFluentDeposit,
+  buildFluentToEthereumWithdraw,
+  extractMessageHashFromReceipt,
+  fluentBridgeInterface,
+  nativeGatewayInterface,
+  sentMessageTopic,
+} from './fluentUtils.js';
+
+const TEST_RECIPIENT = '0x3e0a78a330f2b97059a4d507ca9d8292b65b6fb5';
+
+describe('fluentUtils', () => {
+  describe('constants', () => {
+    it('exposes the verified mainnet contract addresses', () => {
+      expect(FLUENT_BRIDGE_ADDRESS.toLowerCase()).to.equal(
+        '0x9cacf613fc29015893728563f423fd26dcdb8ddc',
+      );
+      expect(FLUENT_NATIVE_GATEWAY_ADDRESS.toLowerCase()).to.equal(
+        '0x8976ca4e0c8467097da675399fb7db454a1b56dd',
+      );
+      expect(NATIVE_TOKEN_SENTINEL).to.equal(ethers.constants.AddressZero);
+      expect(FLUENT_CHAIN_ID).to.equal(25363);
+      expect(ETHEREUM_CHAIN_ID).to.equal(1);
+    });
+
+    it('uses the empirically verified MessageStatus enum mapping', () => {
+      expect(MessageStatus.None).to.equal(0);
+      expect(MessageStatus.Failed).to.equal(1);
+      expect(MessageStatus.Success).to.equal(2);
+    });
+  });
+
+  describe('buildEthereumToFluentDeposit', () => {
+    it('encodes sendNativeTokens(recipient) with value = amount + fee', () => {
+      const tx = buildEthereumToFluentDeposit({
+        nativeGateway: FLUENT_NATIVE_GATEWAY_ADDRESS,
+        recipient: TEST_RECIPIENT,
+        amount: 1_000_000_000_000_000n,
+        messageFee: 0n,
+      });
+
+      expect(tx.chainId).to.equal(ETHEREUM_CHAIN_ID);
+      expect(tx.to.toLowerCase()).to.equal(
+        FLUENT_NATIVE_GATEWAY_ADDRESS.toLowerCase(),
+      );
+      expect(tx.value).to.equal(1_000_000_000_000_000n);
+
+      const decoded = nativeGatewayInterface.decodeFunctionData(
+        'sendNativeTokens',
+        tx.data,
+      );
+      expect(decoded[0].toLowerCase()).to.equal(TEST_RECIPIENT);
+    });
+
+    it('adds the message fee to the tx value', () => {
+      const tx = buildEthereumToFluentDeposit({
+        nativeGateway: FLUENT_NATIVE_GATEWAY_ADDRESS,
+        recipient: TEST_RECIPIENT,
+        amount: 200_000_000_000_000n,
+        messageFee: 449_828_643_600_000n,
+      });
+      expect(tx.value).to.equal(200_000_000_000_000n + 449_828_643_600_000n);
+    });
+
+    it('rejects non-positive amounts', () => {
+      expect(() =>
+        buildEthereumToFluentDeposit({
+          nativeGateway: FLUENT_NATIVE_GATEWAY_ADDRESS,
+          recipient: TEST_RECIPIENT,
+          amount: 0n,
+          messageFee: 0n,
+        }),
+      ).to.throw(/Invalid amount/);
+    });
+  });
+
+  describe('buildFluentToEthereumWithdraw', () => {
+    it('mirrors deposit but uses the Fluent chainId', () => {
+      const tx = buildFluentToEthereumWithdraw({
+        nativeGateway: FLUENT_NATIVE_GATEWAY_ADDRESS,
+        recipient: TEST_RECIPIENT,
+        amount: 200_000_000_000_000n,
+        messageFee: 449_828_643_600_000n,
+      });
+      expect(tx.chainId).to.equal(FLUENT_CHAIN_ID);
+      expect(tx.value).to.equal(200_000_000_000_000n + 449_828_643_600_000n);
+      expect(tx.to.toLowerCase()).to.equal(
+        FLUENT_NATIVE_GATEWAY_ADDRESS.toLowerCase(),
+      );
+    });
+  });
+
+  describe('extractMessageHashFromReceipt', () => {
+    it('returns the messageHash from a SentMessage log', () => {
+      const messageHash = ethers.utils.hexZeroPad('0xabcd', 32);
+      const encoded = fluentBridgeInterface.encodeEventLog(
+        fluentBridgeInterface.getEvent('SentMessage'),
+        [
+          TEST_RECIPIENT,
+          FLUENT_NATIVE_GATEWAY_ADDRESS,
+          1_000_000_000_000_000n,
+          0n,
+          ETHEREUM_CHAIN_ID,
+          24_993_000,
+          809,
+          messageHash,
+          '0xb9cca7a3',
+        ],
+      );
+      const receipt = {
+        logs: [
+          {
+            address: FLUENT_BRIDGE_ADDRESS,
+            topics: encoded.topics,
+            data: encoded.data,
+          },
+        ],
+      } as ethers.providers.TransactionReceipt;
+      expect(extractMessageHashFromReceipt(receipt)).to.equal(messageHash);
+    });
+
+    it('returns undefined when no SentMessage log is present', () => {
+      const receipt = {
+        logs: [
+          {
+            topics: [ethers.utils.id('Unrelated()')],
+            data: '0x',
+          },
+        ],
+      } as ethers.providers.TransactionReceipt;
+      expect(extractMessageHashFromReceipt(receipt)).to.be.undefined;
+    });
+
+    it('exposes a deterministic SentMessage topic', () => {
+      expect(sentMessageTopic).to.equal(
+        ethers.utils.id(
+          'SentMessage(address,address,uint256,uint256,uint256,uint256,uint256,bytes32,bytes)',
+        ),
+      );
+    });
+  });
+});

--- a/typescript/rebalancer/src/bridges/fluentUtils.ts
+++ b/typescript/rebalancer/src/bridges/fluentUtils.ts
@@ -1,0 +1,160 @@
+import { ethers } from 'ethers';
+
+import { isAddressEvm, normalizeAddressEvm } from '@hyperlane-xyz/utils';
+
+export const FLUENT_CHAIN_ID = 25363;
+export const ETHEREUM_CHAIN_ID = 1;
+
+// Native-asset sentinel address used by IExternalBridge.getNativeTokenAddress()
+// (matches the LiFi convention).
+export const NATIVE_TOKEN_SENTINEL = ethers.constants.AddressZero;
+
+// Both deployments are at identical addresses on L1 and L2.
+export const FLUENT_BRIDGE_ADDRESS = normalizeAddressEvm(
+  '0x9CAcf613fC29015893728563f423fD26dCdB8Ddc',
+);
+export const FLUENT_NATIVE_GATEWAY_ADDRESS = normalizeAddressEvm(
+  '0x8976Ca4E0c8467097Da675399fB7DB454a1b56dd',
+);
+
+// MessageStatus enum returned by FluentBridge.getReceivedMessage(bytes32):
+// 0 = None (not yet delivered)
+// 1 = Failed (destination call reverted or out of gas)
+// 2 = Success (destination call succeeded; asset moved to recipient)
+// Verified empirically by mainnet round-trip on 2026-04-29.
+export const MessageStatus = {
+  None: 0,
+  Failed: 1,
+  Success: 2,
+} as const;
+export type MessageStatusValue =
+  (typeof MessageStatus)[keyof typeof MessageStatus];
+
+export const FLUENT_FORWARD_CONFIG = {
+  fromChainId: ETHEREUM_CHAIN_ID,
+  toChainId: FLUENT_CHAIN_ID,
+  fromToken: NATIVE_TOKEN_SENTINEL,
+  toToken: NATIVE_TOKEN_SENTINEL,
+  nativeGatewayAddress: FLUENT_NATIVE_GATEWAY_ADDRESS,
+  fluentBridgeAddress: FLUENT_BRIDGE_ADDRESS,
+} as const;
+
+export const FLUENT_REVERSE_CONFIG = {
+  fromChainId: FLUENT_CHAIN_ID,
+  toChainId: ETHEREUM_CHAIN_ID,
+  fromToken: NATIVE_TOKEN_SENTINEL,
+  toToken: NATIVE_TOKEN_SENTINEL,
+  nativeGatewayAddress: FLUENT_NATIVE_GATEWAY_ADDRESS,
+  fluentBridgeAddress: FLUENT_BRIDGE_ADDRESS,
+} as const;
+
+export const NATIVE_GATEWAY_ABI = [
+  'function sendNativeTokens(address to) payable',
+  'function getOtherSideGateway() view returns (address)',
+];
+
+// `receiveMessageWithProof` is the relayer-side delivery path used for
+// asset-bearing messages (selector 0x2731d657). Integrators do not call it;
+// it appears here for documentation only.
+export const FLUENT_BRIDGE_ABI = [
+  'function sendMessage(address to, bytes message) payable',
+  'function getReceivedMessage(bytes32 messageHash) view returns (uint8)',
+  'function getSentMessageFee() view returns (uint256)',
+  'event SentMessage(address indexed sender, address indexed to, uint256 value, uint256 fee, uint256 chainId, uint256 validUntilBlockNumber, uint256 nonce, bytes32 messageHash, bytes data)',
+];
+
+export const nativeGatewayInterface = new ethers.utils.Interface(
+  NATIVE_GATEWAY_ABI,
+);
+export const fluentBridgeInterface = new ethers.utils.Interface(
+  FLUENT_BRIDGE_ABI,
+);
+
+export const sentMessageTopic =
+  fluentBridgeInterface.getEventTopic('SentMessage');
+
+export type FluentDirection = 'ethereum-to-fluent' | 'fluent-to-ethereum';
+
+export type FluentNativeBridgeArgs = {
+  nativeGateway: string;
+  recipient: string;
+  amount: bigint;
+  messageFee: bigint;
+};
+
+export type FluentExecutionTx = {
+  to: string;
+  data: string;
+  value: bigint;
+  chainId: number;
+};
+
+export function normalizeAddress(value: string, label: string): string {
+  const normalized = normalizeAddressEvm(value);
+  if (!isAddressEvm(normalized)) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  return normalized;
+}
+
+function buildSendNativeTokensTx(
+  args: FluentNativeBridgeArgs,
+  chainId: number,
+): FluentExecutionTx {
+  const nativeGateway = normalizeAddress(args.nativeGateway, 'nativeGateway');
+  const recipient = normalizeAddress(args.recipient, 'recipient');
+  if (args.amount <= 0n) {
+    throw new Error(`Invalid amount: ${args.amount}`);
+  }
+  return {
+    to: nativeGateway,
+    data: nativeGatewayInterface.encodeFunctionData('sendNativeTokens', [
+      recipient,
+    ]),
+    value: args.amount + args.messageFee,
+    chainId,
+  };
+}
+
+export function buildEthereumToFluentDeposit(
+  args: FluentNativeBridgeArgs,
+): FluentExecutionTx {
+  return buildSendNativeTokensTx(args, ETHEREUM_CHAIN_ID);
+}
+
+export function buildFluentToEthereumWithdraw(
+  args: FluentNativeBridgeArgs,
+): FluentExecutionTx {
+  return buildSendNativeTokensTx(args, FLUENT_CHAIN_ID);
+}
+
+/**
+ * Parses a SentMessage log from a transaction receipt and returns the
+ * messageHash. Returns undefined if no matching log is found.
+ */
+export function extractMessageHashFromReceipt(
+  receipt: ethers.providers.TransactionReceipt,
+): string | undefined {
+  return extractSentMessageFromReceipt(receipt)?.messageHash;
+}
+
+/**
+ * Parses a SentMessage log and returns the messageHash plus the bridged
+ * amount (gross msg.value minus the bridge fee — i.e., what actually crosses
+ * to the destination). Returns undefined if no matching log is found.
+ */
+export function extractSentMessageFromReceipt(
+  receipt: ethers.providers.TransactionReceipt,
+): { messageHash: string; bridgedAmount: bigint } | undefined {
+  for (const log of receipt.logs) {
+    if (log.topics[0] !== sentMessageTopic) continue;
+    const parsed = fluentBridgeInterface.parseLog(log);
+    const value = BigInt(parsed.args.value.toString());
+    const fee = BigInt(parsed.args.fee.toString());
+    return {
+      messageHash: parsed.args.messageHash as string,
+      bridgedAmount: value - fee,
+    };
+  }
+  return undefined;
+}

--- a/typescript/rebalancer/src/config/types.ts
+++ b/typescript/rebalancer/src/config/types.ts
@@ -37,6 +37,7 @@ export enum ExecutionType {
 export enum ExternalBridgeType {
   LiFi = 'lifi',
   Katana = 'katana',
+  Fluent = 'fluent',
 }
 
 export const RebalancerMinAmountConfigSchema = z.object({
@@ -131,9 +132,15 @@ export const KatanaBridgeConfigSchema = z.object({
   defaultSlippage: z.number().optional(),
 });
 
+// FluentBridge moves native ETH at 1:1, so there are no per-bridge tunables.
+// The schema exists so a `fluent: {}` entry in YAML is recognized and signals
+// that the bridge should be registered.
+export const FluentBridgeConfigSchema = z.object({});
+
 export const ExternalBridgesConfigSchema = z.object({
   lifi: LiFiBridgeConfigSchema.optional(),
   katana: KatanaBridgeConfigSchema.optional(),
+  fluent: FluentBridgeConfigSchema.optional(),
 });
 
 export const RebalancerConfigSchema = z

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -21,6 +21,7 @@ import {
 
 import { LiFiBridge } from '../bridges/LiFiBridge.js';
 import { KatanaBridge } from '../bridges/KatanaBridge.js';
+import { FluentBridge } from '../bridges/FluentBridge.js';
 import { type RebalancerConfig } from '../config/RebalancerConfig.js';
 import {
   ExecutionType,
@@ -653,6 +654,16 @@ export class RebalancerContextFactory {
             {
               integrator: 'hyperlane',
               defaultSlippage: externalBridges?.katana?.defaultSlippage,
+              chainMetadata: this.multiProvider.metadata,
+            },
+            this.logger,
+          );
+          break;
+        }
+        case ExternalBridgeType.Fluent: {
+          registry[ExternalBridgeType.Fluent] = new FluentBridge(
+            {
+              integrator: 'hyperlane',
               chainMetadata: this.multiProvider.metadata,
             },
             this.logger,

--- a/typescript/rebalancer/src/interfaces/IExternalBridge.ts
+++ b/typescript/rebalancer/src/interfaces/IExternalBridge.ts
@@ -64,7 +64,7 @@ export interface BridgeTransferResult {
  */
 export type BridgeTransferStatus =
   | { status: 'pending'; substatus?: string }
-  | { status: 'complete'; receivingTxHash: string; receivedAmount: bigint }
+  | { status: 'complete'; receivingTxHash?: string; receivedAmount?: bigint }
   | { status: 'failed'; error?: string }
   | { status: 'not_found' };
 

--- a/typescript/rebalancer/src/scripts/bridgeDirect.ts
+++ b/typescript/rebalancer/src/scripts/bridgeDirect.ts
@@ -1,0 +1,415 @@
+#!/usr/bin/env node
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { Wallet, ethers } from 'ethers';
+import { pino, type Logger } from 'pino';
+
+import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
+import { getRegistry } from '@hyperlane-xyz/registry/fs';
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+import {
+  ProtocolType,
+  applyRpcUrlOverridesFromEnv,
+  assert,
+  ensure0x,
+  normalizeAddressEvm,
+} from '@hyperlane-xyz/utils';
+
+import { FluentBridge } from '../bridges/FluentBridge.js';
+import { KatanaBridge } from '../bridges/KatanaBridge.js';
+import { LiFiBridge } from '../bridges/LiFiBridge.js';
+import { ExternalBridgeType } from '../config/types.js';
+import type {
+  BridgeTransferStatus,
+  IExternalBridge,
+} from '../interfaces/IExternalBridge.js';
+
+import {
+  runExternalBridgeCommand,
+  type ExternalBridgeScriptMode,
+  type ExternalBridgeScriptOptions,
+  type ExternalBridgeScriptResult,
+  type ResolvedExternalBridgeContext,
+} from './externalBridgeRunner.js';
+
+const NATIVE_TOKEN_SENTINEL = ethers.constants.AddressZero;
+
+type DirectBridgeArgs = {
+  bridge: ExternalBridgeType;
+  origin: string;
+  destination: string;
+  mode: ExternalBridgeScriptMode | 'status';
+  amount?: string;
+  recipient?: string;
+  tokenAddress?: string;
+  txHash?: string;
+  privateKey?: string;
+  keyFile?: string;
+  timeoutMs: number;
+  pollIntervalMs: number;
+  json: boolean;
+};
+
+function getUsage(): string {
+  return [
+    'Usage:',
+    '  pnpm bridge:direct --bridge <fluent|katana|lifi> --origin <chain> --destination <chain> [options]',
+    '',
+    'Options:',
+    '  --mode <quote|execute|wait|run|status>   default: run',
+    '  --amount <human-readable>                e.g. 0.001ether, 1000000 (wei). Required for quote/execute/run',
+    '  --recipient <address>                    Optional; defaults to signer',
+    '  --token-address <address>                Optional; defaults to native sentinel for the bridge',
+    '  --tx-hash <hash>                         Required for wait/status',
+    '  --private-key <0x...>                    Or use --key-file',
+    '  --key-file <path>                        Path to file containing private key',
+    '  --timeout-ms <ms>                        Wait timeout, default 1800000 (30 min)',
+    '  --poll-interval-ms <ms>                  default 30000',
+    '  --json                                   Machine-readable JSON',
+  ].join('\n');
+}
+
+function parseDirectArgs(argv: string[]): DirectBridgeArgs {
+  const args = [...argv];
+  const getValue = (flag: string): string | undefined => {
+    const index = args.indexOf(flag);
+    if (index === -1) return undefined;
+    assert(index + 1 < args.length, `Missing value for ${flag}`);
+    return args[index + 1];
+  };
+  const hasFlag = (flag: string): boolean => args.includes(flag);
+
+  if (hasFlag('--help') || hasFlag('-h')) {
+    throw new Error(getUsage());
+  }
+
+  const bridge = getValue('--bridge') as ExternalBridgeType | undefined;
+  assert(bridge, '--bridge is required');
+  assert(
+    Object.values(ExternalBridgeType).includes(bridge),
+    `Invalid --bridge: ${bridge}`,
+  );
+
+  const origin = getValue('--origin');
+  assert(origin, '--origin is required');
+  const destination = getValue('--destination');
+  assert(destination, '--destination is required');
+
+  const mode = (getValue('--mode') ?? 'run') as DirectBridgeArgs['mode'];
+  assert(
+    ['quote', 'execute', 'wait', 'run', 'status'].includes(mode),
+    `Invalid --mode: ${mode}`,
+  );
+
+  const amount = getValue('--amount');
+  const txHash = getValue('--tx-hash');
+
+  if (mode === 'wait' || mode === 'status') {
+    assert(txHash, `--tx-hash is required in ${mode} mode`);
+  } else {
+    assert(amount, '--amount is required for quote/execute/run');
+  }
+
+  const timeoutRaw = getValue('--timeout-ms');
+  const timeoutMs =
+    timeoutRaw === undefined ? 30 * 60_000 : Number.parseInt(timeoutRaw, 10);
+  assert(
+    Number.isFinite(timeoutMs) && timeoutMs > 0,
+    `Invalid --timeout-ms: ${timeoutRaw}`,
+  );
+
+  const pollRaw = getValue('--poll-interval-ms');
+  const pollIntervalMs =
+    pollRaw === undefined ? 30_000 : Number.parseInt(pollRaw, 10);
+  assert(
+    Number.isFinite(pollIntervalMs) && pollIntervalMs > 0,
+    `Invalid --poll-interval-ms: ${pollRaw}`,
+  );
+
+  return {
+    bridge,
+    origin,
+    destination,
+    mode,
+    amount,
+    recipient: getValue('--recipient'),
+    tokenAddress: getValue('--token-address'),
+    txHash,
+    privateKey: getValue('--private-key'),
+    keyFile: getValue('--key-file'),
+    timeoutMs,
+    pollIntervalMs,
+    json: hasFlag('--json'),
+  };
+}
+
+function resolvePrivateKey(args: DirectBridgeArgs): string {
+  if (args.privateKey) return ensure0x(args.privateKey.trim());
+  assert(args.keyFile, 'Either --private-key or --key-file is required');
+  const expanded = args.keyFile.startsWith('~')
+    ? path.join(os.homedir(), args.keyFile.slice(1))
+    : args.keyFile;
+  const raw = fs.readFileSync(expanded, 'utf8').trim();
+  return ensure0x(raw);
+}
+
+function buildBridge(
+  bridgeType: ExternalBridgeType,
+  multiProvider: MultiProvider,
+  logger: Logger,
+): IExternalBridge {
+  const chainMetadata = multiProvider.metadata;
+  switch (bridgeType) {
+    case ExternalBridgeType.Fluent:
+      return new FluentBridge(
+        { integrator: 'hyperlane', chainMetadata },
+        logger,
+      );
+    case ExternalBridgeType.Katana:
+      return new KatanaBridge(
+        { integrator: 'hyperlane', chainMetadata },
+        logger,
+      );
+    case ExternalBridgeType.LiFi:
+      return new LiFiBridge({ integrator: 'hyperlane', chainMetadata }, logger);
+    default: {
+      const _exhaustive: never = bridgeType;
+      throw new Error(`Unsupported bridge type: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function parseAmountToWei(amount: string): bigint {
+  const trimmed = amount.trim();
+  // Allow ethers' parseUnits-style suffixes ("0.001ether", "100gwei") or plain wei integers.
+  const suffixMatch = trimmed.match(/^([0-9.]+)(ether|gwei|wei)$/i);
+  if (suffixMatch) {
+    const [, value, unit] = suffixMatch;
+    return BigInt(
+      ethers.utils.parseUnits(value, unit.toLowerCase()).toString(),
+    );
+  }
+  // Bare number -> wei (matches cast send --value semantics).
+  return BigInt(trimmed);
+}
+
+async function resolveContext(
+  args: DirectBridgeArgs,
+  logger: Logger,
+): Promise<ResolvedExternalBridgeContext> {
+  const registryUri = process.env.REGISTRY_URI || DEFAULT_GITHUB_REGISTRY;
+  const registry = getRegistry({
+    registryUris: [registryUri],
+    enableProxy: true,
+    logger,
+  });
+  const chainMetadata = await registry.getMetadata();
+  applyRpcUrlOverridesFromEnv(chainMetadata);
+
+  const multiProvider = new MultiProvider(chainMetadata);
+  const bridge = buildBridge(args.bridge, multiProvider, logger);
+
+  const fromChainId = Number(multiProvider.getChainId(args.origin));
+  const toChainId = Number(multiProvider.getChainId(args.destination));
+  assert(
+    Number.isFinite(fromChainId),
+    `Invalid chainId for origin ${args.origin}`,
+  );
+  assert(
+    Number.isFinite(toChainId),
+    `Invalid chainId for destination ${args.destination}`,
+  );
+
+  const tokenAddress = args.tokenAddress
+    ? normalizeAddressEvm(args.tokenAddress)
+    : (bridge.getNativeTokenAddress?.() ?? NATIVE_TOKEN_SENTINEL);
+
+  const privateKey = resolvePrivateKey(args);
+  const fromAddress = normalizeAddressEvm(new Wallet(privateKey).address);
+  const toAddress = args.recipient
+    ? normalizeAddressEvm(args.recipient)
+    : fromAddress;
+
+  let amountLocal: bigint | undefined;
+  if (args.mode !== 'wait' && args.mode !== 'status') {
+    assert(args.amount, '--amount is required');
+    amountLocal = parseAmountToWei(args.amount);
+  }
+
+  // Tokens are only used by runExternalBridgeCommand for serialization output;
+  // we only need their addressOrDenom field to round-trip into the result.
+  // Construct minimal placeholders that satisfy the field accesses.
+  const placeholderToken = {
+    addressOrDenom: tokenAddress,
+    decimals: 18,
+    chainName: args.origin,
+    standard: 'EvmHypNative',
+  } as unknown as ResolvedExternalBridgeContext['originToken'];
+
+  return {
+    bridgeType: args.bridge,
+    bridge,
+    origin: args.origin,
+    destination: args.destination,
+    fromChainId,
+    toChainId,
+    originToken: placeholderToken,
+    destinationToken: placeholderToken,
+    fromTokenAddress: tokenAddress,
+    toTokenAddress: tokenAddress,
+    fromAddress,
+    toAddress,
+    amountLocal,
+    privateKeys: { [ProtocolType.Ethereum]: privateKey },
+  };
+}
+
+function bigintReplacer(_key: string, value: unknown) {
+  return typeof value === 'bigint' ? value.toString() : value;
+}
+
+function printStatusUpdate(status: BridgeTransferStatus): void {
+  process.stdout.write(
+    `Bridge status: ${JSON.stringify(status, bigintReplacer, 2)}\n`,
+  );
+}
+
+function printResult(result: ExternalBridgeScriptResult, json: boolean): void {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result, bigintReplacer, 2)}\n`);
+    return;
+  }
+
+  switch (result.mode) {
+    case 'quote':
+      process.stdout.write(
+        [
+          `Quoted ${result.bridge} ${result.origin} -> ${result.destination}`,
+          `from=${result.quote.fromAmount} to=${result.quote.toAmount} min=${result.quote.toAmountMin}`,
+          `tool=${result.quote.tool} gas=${result.quote.gasCosts} fees=${result.quote.feeCosts}`,
+        ].join('\n') + '\n',
+      );
+      return;
+    case 'execute':
+      process.stdout.write(
+        [
+          `Executed ${result.bridge} ${result.origin} -> ${result.destination}`,
+          `txHash=${result.execution.txHash}`,
+          `transferId=${result.execution.transferId ?? '<none>'}`,
+        ].join('\n') + '\n',
+      );
+      return;
+    case 'wait':
+      process.stdout.write(
+        [
+          `Waited on ${result.bridge} ${result.origin} -> ${result.destination}`,
+          `txHash=${result.txHash}`,
+          `elapsedMs=${result.elapsedMs}`,
+          `status=${JSON.stringify(result.status, bigintReplacer)}`,
+        ].join('\n') + '\n',
+      );
+      return;
+    case 'run':
+      process.stdout.write(
+        [
+          `Completed ${result.bridge} ${result.origin} -> ${result.destination}`,
+          `txHash=${result.execution.txHash}`,
+          `elapsedMs=${result.elapsedMs}`,
+          `finalStatus=${JSON.stringify(result.finalStatus, bigintReplacer)}`,
+        ].join('\n') + '\n',
+      );
+      return;
+  }
+}
+
+async function runStatusMode(
+  args: DirectBridgeArgs,
+  context: ResolvedExternalBridgeContext,
+): Promise<void> {
+  assert(args.txHash, '--tx-hash is required in status mode');
+  const status = await context.bridge.getStatus(
+    args.txHash,
+    context.fromChainId,
+    context.toChainId,
+  );
+  if (args.json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          mode: 'status',
+          bridge: args.bridge,
+          origin: args.origin,
+          destination: args.destination,
+          txHash: args.txHash,
+          status,
+        },
+        bigintReplacer,
+        2,
+      )}\n`,
+    );
+  } else {
+    process.stdout.write(
+      `${args.bridge} ${args.origin} -> ${args.destination} ${args.txHash}: ${JSON.stringify(
+        status,
+        bigintReplacer,
+      )}\n`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseDirectArgs(process.argv.slice(2));
+  const logger = pino({
+    level: process.env.LOG_LEVEL ?? (args.json ? 'error' : 'warn'),
+  });
+
+  try {
+    const context = await resolveContext(args, logger);
+
+    if (args.mode === 'status') {
+      await runStatusMode(args, context);
+      return;
+    }
+
+    const runOptions: ExternalBridgeScriptOptions = {
+      configFile: '<direct>',
+      bridge: args.bridge,
+      origin: args.origin,
+      destination: args.destination,
+      mode: args.mode,
+      amount: args.amount,
+      recipient: args.recipient,
+      txHash: args.txHash,
+      slippage: undefined,
+      timeoutMs: args.timeoutMs,
+      pollIntervalMs: args.pollIntervalMs,
+      json: args.json,
+    };
+
+    const result = await runExternalBridgeCommand(
+      context,
+      runOptions,
+      logger,
+      args.json ? undefined : printStatusUpdate,
+    );
+    printResult(result, args.json);
+  } catch (error) {
+    if (error instanceof Error && error.message === getUsage()) {
+      process.stderr.write(`${error.message}\n`);
+      process.exit(1);
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    if (args.json) {
+      process.stderr.write(
+        `${JSON.stringify({ error: message }, bigintReplacer, 2)}\n`,
+      );
+    } else {
+      process.stderr.write(`bridge:direct failed: ${message}\n`);
+    }
+    process.exit(1);
+  }
+}
+
+void main();


### PR DESCRIPTION
## Summary

Adds a `FluentBridge` `IExternalBridge` implementation that moves native ETH between Ethereum (chainId 1) and Fluent (chainId 25363) via Fluent's canonical NativeGateway. Also adds a standalone `bridge:direct` CLI for ad-hoc `IExternalBridge` testing without a rebalancer config file.

**Stacked on** `codex/katana-external-bridge` — the new `bridgeDirect.ts` script reuses `runExternalBridgeCommand` from that branch's `externalBridgeRunner.ts`, and `fluentUtils.ts` shares the `normalizeAddress` helper from `katanaUtils.ts`. Once the Katana branch merges, this PR will be retargeted to `main`.

## What's in this PR

- `src/bridges/FluentBridge.ts` + `fluentUtils.ts` — `IExternalBridge` impl for native ETH. Single storage read for status (`getReceivedMessage(messageHash)`); no event log search.
- `src/scripts/bridgeDirect.ts` — standalone runner for any registered `IExternalBridge`, supports `quote / execute / wait / run / status` modes via `--key-file` or `--private-key`. Builds the bridge directly from `@hyperlane-xyz/registry` chain metadata, no `RebalancerConfig` needed.
- `src/interfaces/IExternalBridge.ts` — `BridgeTransferStatus.complete`'s `receivingTxHash` and `receivedAmount` fields are now optional. Existing implementations (Katana / LiFi / Mock) still populate them.
- `config/types.ts` — `ExternalBridgeType.Fluent` enum entry + empty `FluentBridgeConfigSchema` (no per-bridge tunables).
- `factories/RebalancerContextFactory.ts` — Fluent case in `buildExternalBridgeRegistry()`.
- `package.json` — new `bridge:direct` script alias.
- 19 unit tests (`FluentBridge.test.ts`, `fluentUtils.test.ts`).

## Why no event log search

Fluent's relayer auto-delivers asset moves via `receiveMessageWithProof`, and `FluentBridge.getReceivedMessage(bytes32)` returns the `MessageStatus` enum (`{None=0, Failed=1, Success=2}`, verified empirically). For native ETH at 1:1, `receivedAmount` is known statically from the source send (or recovered from the `SentMessage` event's `value - fee` on rehydration), so there's no need to scan for `ReceivedTokens` logs on the destination chain. This avoids the public-RPC 50k-block `eth_getLogs` window entirely.

## Empirical verification (mainnet, 2026-04-29)

Round-tripped 0.001 ETH end-to-end through the new `bridge:direct` CLI:

| Direction | Source tx | Destination tx | Wall time |
|---|---|---|---|
| Eth → Fluent (deposit) | `0xeb8b1bd6…ce595` | `0x589d7345…a4285` | 121 s |
| Fluent → Eth (withdrawal) | `0x4f4a98e9…f5e250` | `0xd9e3154c…0663f` | ~6 min |

Both arrived without any integrator-side claim — Fluent's relayer (EOA `0x4A0e8827…0853a48`) called `receiveMessageWithProof` on each destination chain.

## Test plan

- [x] `pnpm -C typescript/rebalancer test FluentBridge` — 19 new tests pass.
- [x] `pnpm -C typescript/rebalancer build` — clean.
- [x] Mainnet deposit + withdrawal verified via `bridge:direct --mode run`.
- [ ] Reviewer sanity-check the on-chain delivery txs via FluentScan / Etherscan.
- [ ] (Future, post-merge of Katana branch) Retarget this PR base from `codex/katana-external-bridge` to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)