### PR TITLE
fix: relay api gas payments

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
@@ -120,7 +120,7 @@ impl CcipReadIsmMetadataBuilder {
             .get_cached_call_result::<SerializedOffchainLookup>(ism_domain, fn_key, &call_params)
             .await
             .map_err(|err| {
-                warn!(error = %err, "Error when caching call result for {:?}", fn_key);
+                warn!(error = %err, message_id = ?message.id(), "Error when caching call result for {:?}", fn_key);
             })
             .ok()
             .flatten();
@@ -134,7 +134,7 @@ impl CcipReadIsmMetadataBuilder {
 
                 match response {
                     Ok(_) => {
-                        info!("incorrectly configured getOffchainVerifyInfo, expected revert");
+                        info!(message_id = ?message.id(), "incorrectly configured getOffchainVerifyInfo, expected revert");
                         return Err(MetadataBuildError::CouldNotFetch);
                     }
                     Err(raw_error) => {
@@ -152,7 +152,7 @@ impl CcipReadIsmMetadataBuilder {
                                 MetadataBuildError::FailedToBuild(msg)
                             })?
                         } else {
-                            info!(?raw_error, "unable to parse custom error out of revert");
+                            info!(?raw_error, message_id = ?message.id(), "unable to parse custom error out of revert");
                             return Err(MetadataBuildError::CouldNotFetch);
                         }
                     }
@@ -171,7 +171,7 @@ impl CcipReadIsmMetadataBuilder {
             )
             .await
             .map_err(|err| {
-                warn!(error = %err, "Error when caching call result for {:?}", fn_key);
+                warn!(error = %err, message_id = ?message.id(), "Error when caching call result for {:?}", fn_key);
             })
             .ok();
 
@@ -246,7 +246,7 @@ async fn metadata_build(
 
     for url in info.urls.iter() {
         if ccip_url_regex.is_match(url) {
-            tracing::warn!(?ism_address, url, "Suspicious CCIP read url");
+            tracing::warn!(?ism_address, url, message_id = ?message.id(), "Suspicious CCIP read url");
             continue;
         }
 
@@ -254,12 +254,22 @@ async fn metadata_build(
         // Move to the next URL only on hard failures.
         const MAX_PENDING_RETRIES: u32 = 30;
         let mut pending_attempts = 0u32;
+        tracing::info!(?ism_address, url, message_id = ?message.id(), "Fetching CCIP read offchain data");
         loop {
-            match fetch_offchain_data(ism_builder, &info, url, origin_tx_hash.clone()).await {
+            match fetch_offchain_data(
+                ism_builder,
+                &info,
+                url,
+                origin_tx_hash.clone(),
+                message.id(),
+            )
+            .await
+            {
                 Ok(data) => {
                     tracing::info!(
                         ?ism_address,
                         url,
+                        message_id = ?message.id(),
                         origin_tx_hash = ?origin_tx_hash,
                         attempts = pending_attempts,
                         "Successfully fetched offchain lookup data"
@@ -271,6 +281,7 @@ async fn metadata_build(
                     tracing::debug!(
                         ?ism_address,
                         url,
+                        message_id = ?message.id(),
                         origin_tx_hash = ?origin_tx_hash,
                         attempt = pending_attempts,
                         max = MAX_PENDING_RETRIES,
@@ -282,6 +293,7 @@ async fn metadata_build(
                     tracing::warn!(
                         ?ism_address,
                         url,
+                        message_id = ?message.id(),
                         origin_tx_hash = ?origin_tx_hash,
                         max = MAX_PENDING_RETRIES,
                         "Attestation still pending after max retries"
@@ -289,7 +301,7 @@ async fn metadata_build(
                     break;
                 }
                 Err(FetchOutcome::Failed(err)) => {
-                    tracing::warn!(?ism_address, url, origin_tx_hash = ?origin_tx_hash, error = ?err, "Failed to fetch offchain data");
+                    tracing::warn!(?ism_address, url, message_id = ?message.id(), origin_tx_hash = ?origin_tx_hash, error = ?err, "Failed to fetch offchain data");
                     break;
                 }
             }
@@ -344,6 +356,7 @@ async fn fetch_offchain_data(
     info: &OffchainLookup,
     url: &str,
     origin_tx_hash: Option<String>,
+    message_id: H256,
 ) -> Result<Metadata, FetchOutcome> {
     // Compute relayer authentication signature via EIP-191
     let maybe_signature_hex = if let Some(signer) = ism_builder.base.base_builder().get_signer() {
@@ -370,6 +383,7 @@ async fn fetch_offchain_data(
         tracing::debug!(
             url = interpolated_url,
             ?body,
+            ?message_id,
             "Sending POST request to offchain lookup server"
         );
         Client::new()
@@ -406,6 +420,7 @@ async fn fetch_offchain_data(
     tracing::debug!(
         response = response_body,
         status = status.as_u16(),
+        ?message_id,
         "Received response from offchain lookup server"
     );
 

--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -49,7 +49,8 @@ impl OpQueue {
         self.process_retry_requests().await;
         let mut queue = self.queue.lock().await;
         let mut popped = vec![];
-        while let Some(Reverse(op)) = queue.pop() {
+        while queue.peek().map_or(false, |Reverse(op)| op.is_ready()) {
+            let Reverse(op) = queue.pop().unwrap();
             popped.push(op);
             if popped.len() >= limit {
                 break;

--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -49,8 +49,7 @@ impl OpQueue {
         self.process_retry_requests().await;
         let mut queue = self.queue.lock().await;
         let mut popped = vec![];
-        while queue.peek().map_or(false, |Reverse(op)| op.is_ready()) {
-            let Reverse(op) = queue.pop().unwrap();
+        while let Some(Reverse(op)) = queue.pop() {
             popped.push(op);
             if popped.len() >= limit {
                 break;

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -893,12 +893,6 @@ impl PendingMessage {
         PendingOperationResult::NotReady
     }
 
-    fn is_ready(&self) -> bool {
-        self.next_attempt_after
-            .map(|a| Instant::now() >= a)
-            .unwrap_or(true)
-    }
-
     /// Record in HyperlaneDB and various metrics that this process has observed
     /// the successful processing of a message. An `Ok(())` value returned by
     /// this function is the 'commit' point in a message's lifetime for

--- a/rust/main/agents/relayer/src/relay_api/handlers.rs
+++ b/rust/main/agents/relayer/src/relay_api/handlers.rs
@@ -537,6 +537,7 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
         // returns false and no non-EVM indexer overrides it. Extending the relay API
         // to non-EVM chains requires a chain-specific is_cctp_v2 implementation.
         if !extracted.is_cctp_v2 {
+            warn!(message_id = ?extracted.message_id, "Rejecting non-CCTP V2 message");
             state.record_failure("not_cctp_v2");
             return Err(ServerError::InvalidRequest(
                 "Only EVM CCTP V2 messages are supported via the relay API".to_string(),
@@ -547,6 +548,12 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
         let msg_ctx = msg_ctxs
             .get(&(extracted.message.origin, extracted.message.destination))
             .ok_or_else(|| {
+                warn!(
+                    message_id = ?extracted.message_id,
+                    origin = extracted.message.origin,
+                    destination = extracted.message.destination,
+                    "No message context for origin/destination pair"
+                );
                 ServerError::InternalError(format!(
                     "No message context for origin {} to destination {}",
                     extracted.message.origin, extracted.message.destination
@@ -624,6 +631,7 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
         // Apply message filtering (whitelist, blacklist, address blacklist)
         if let Some(whitelist) = &state.message_whitelist {
             if !whitelist.msg_matches(&extracted.message, true) {
+                warn!(message_id = ?extracted.message_id, "Rejecting message not on whitelist");
                 state.record_failure("message_not_whitelisted");
                 return Err(ServerError::InvalidRequest(
                     "Message not whitelisted".to_string(),
@@ -633,6 +641,7 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
 
         if let Some(blacklist) = &state.message_blacklist {
             if blacklist.msg_matches(&extracted.message, false) {
+                warn!(message_id = ?extracted.message_id, "Rejecting blacklisted message");
                 state.record_failure("message_blacklisted");
                 return Err(ServerError::InvalidRequest(
                     "Message blacklisted".to_string(),
@@ -666,13 +675,13 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
             })?
             .clone();
 
-        // 3 retries is intentional for the relay API fast path — if it fails the
-        // contract indexer will re-queue it within seconds.
+        // 1 retry: one attempt in the relay API queue, then drop and let the
+        // contract indexer re-queue it within seconds via the classical path.
         let pending_msg = PendingMessage::maybe_from_persisted_retries(
             extracted.message.clone(),
             msg_ctx.clone(),
             app_context.clone(),
-            3,
+            1,
         )
         .map(|m| m.with_fail_fast())
         .ok_or_else(|| {

--- a/rust/main/agents/relayer/src/relay_api/handlers.rs
+++ b/rust/main/agents/relayer/src/relay_api/handlers.rs
@@ -738,8 +738,29 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
             let Some(db) = state.dbs.get(&v.origin_domain) else {
                 continue;
             };
-            match igp_indexer.fetch_logs_by_tx_hash(v.tx_hash).await {
-                Ok(payments) => {
+            match tokio::time::timeout(
+                Duration::from_secs(5),
+                igp_indexer.fetch_logs_by_tx_hash(v.tx_hash),
+            )
+            .await
+            {
+                Err(_) => {
+                    warn!(
+                        origin_domain = v.origin_domain,
+                        tx_hash = ?v.tx_hash,
+                        "IGP payment fetch timed out; background indexer will retry"
+                    );
+                }
+                Ok(Err(e)) => {
+                    warn!(
+                        origin_domain = v.origin_domain,
+                        tx_hash = ?v.tx_hash,
+                        error = %e,
+                        "Failed to fetch IGP payments from relay API receipt; \
+                         background indexer will retry"
+                    );
+                }
+                Ok(Ok(payments)) => {
                     if let Err(e) = db.store_logs(&payments).await {
                         warn!(
                             origin_domain = v.origin_domain,
@@ -756,15 +777,6 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
                             "Stored IGP payments from relay API receipt"
                         );
                     }
-                }
-                Err(e) => {
-                    warn!(
-                        origin_domain = v.origin_domain,
-                        tx_hash = ?v.tx_hash,
-                        error = %e,
-                        "Failed to fetch IGP payments from relay API receipt; \
-                         background indexer will retry"
-                    );
                 }
             }
         }

--- a/rust/main/agents/relayer/src/relay_api/handlers.rs
+++ b/rust/main/agents/relayer/src/relay_api/handlers.rs
@@ -738,8 +738,13 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
             let Some(db) = state.dbs.get(&v.origin_domain) else {
                 continue;
             };
+            // 2 s = one honest RPC attempt. EVM's fetch_logs_by_tx_hash uses
+            // call_and_retry_indefinitely with a 2 s inter-retry sleep; a timeout
+            // longer than 2 s would let the sleep run and add a full retry cycle
+            // to every /relay response when the RPC node is slow or flaky.
+            // This is best-effort — the background indexer is the fallback.
             match tokio::time::timeout(
-                Duration::from_secs(5),
+                Duration::from_secs(2),
                 igp_indexer.fetch_logs_by_tx_hash(v.tx_hash),
             )
             .await

--- a/rust/main/agents/relayer/src/relay_api/handlers.rs
+++ b/rust/main/agents/relayer/src/relay_api/handlers.rs
@@ -6,7 +6,9 @@ use axum::{
     Json, Router,
 };
 use hyperlane_base::db::HyperlaneRocksDB;
-use hyperlane_core::{HyperlaneMessage, Indexer, QueueOperation, H256, H512};
+use hyperlane_core::{
+    HyperlaneLogStore, HyperlaneMessage, Indexer, InterchainGasPayment, QueueOperation, H256, H512,
+};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
@@ -152,6 +154,10 @@ impl Drop for TxHashReservation {
 pub struct ServerState {
     // Required: server cannot function without these
     indexers: HashMap<String, Arc<dyn Indexer<HyperlaneMessage>>>,
+    /// IGP indexers keyed by origin domain id. Used to eagerly store gas payments from a
+    /// tx receipt before injecting the message into the processor queue, so the relayer's
+    /// gas payment check never races the background `tx_id_indexer_task`.
+    igp_indexers: HashMap<u32, Arc<dyn Indexer<InterchainGasPayment>>>,
     dbs: HashMap<u32, HyperlaneRocksDB>,
     send_channels: HashMap<u32, UnboundedSender<QueueOperation>>,
     msg_ctxs: HashMap<(u32, u32), Arc<MessageContext>>,
@@ -168,6 +174,7 @@ pub struct ServerState {
 impl ServerState {
     pub fn new(
         indexers: HashMap<String, Arc<dyn Indexer<HyperlaneMessage>>>,
+        igp_indexers: HashMap<u32, Arc<dyn Indexer<InterchainGasPayment>>>,
         dbs: HashMap<u32, HyperlaneRocksDB>,
         send_channels: HashMap<u32, UnboundedSender<QueueOperation>>,
         msg_ctxs: HashMap<(u32, u32), Arc<MessageContext>>,
@@ -175,6 +182,7 @@ impl ServerState {
     ) -> Self {
         Self {
             indexers,
+            igp_indexers,
             dbs,
             send_channels,
             msg_ctxs,
@@ -704,7 +712,65 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
         });
     }
 
-    // Phase 2: send all validated messages.
+    // Phase 2: eagerly store IGP payments from the tx receipt for each origin domain.
+    //
+    // The relayer's gas payment check runs immediately after a message enters the processor
+    // queue. Without this step the check races the background `tx_id_indexer_task`, which
+    // indexes the same receipt asynchronously and may arrive ~30 s later — causing spurious
+    // `GasPaymentNotFound` retries. By fetching and storing the payments here, before any
+    // message is enqueued, the race window is closed.
+    //
+    // Failures are non-fatal: log a warning and proceed. The background indexer still
+    // serves as a fallback, so a transient RPC error here doesn't break relay.
+    //
+    // We deduplicate by (origin_domain, tx_hash) so that a batch with multiple messages
+    // from the same tx only triggers one RPC call.
+    {
+        let mut seen: std::collections::HashSet<(u32, H512)> = std::collections::HashSet::new();
+        for v in &validated {
+            let key = (v.origin_domain, v.tx_hash);
+            if !seen.insert(key) {
+                continue;
+            }
+            let Some(igp_indexer) = state.igp_indexers.get(&v.origin_domain) else {
+                continue;
+            };
+            let Some(db) = state.dbs.get(&v.origin_domain) else {
+                continue;
+            };
+            match igp_indexer.fetch_logs_by_tx_hash(v.tx_hash).await {
+                Ok(payments) => {
+                    if let Err(e) = db.store_logs(&payments).await {
+                        warn!(
+                            origin_domain = v.origin_domain,
+                            tx_hash = ?v.tx_hash,
+                            error = %e,
+                            "Failed to store IGP payments from relay API receipt; \
+                             background indexer will retry"
+                        );
+                    } else {
+                        debug!(
+                            origin_domain = v.origin_domain,
+                            tx_hash = ?v.tx_hash,
+                            count = payments.len(),
+                            "Stored IGP payments from relay API receipt"
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        origin_domain = v.origin_domain,
+                        tx_hash = ?v.tx_hash,
+                        error = %e,
+                        "Failed to fetch IGP payments from relay API receipt; \
+                         background indexer will retry"
+                    );
+                }
+            }
+        }
+    }
+
+    // Phase 3: send all validated messages.
     //
     // Pre-check: verify every destination channel is open before sending anything.
     // UnboundedSender::send() only fails when the receiver (processor) has been

--- a/rust/main/agents/relayer/src/relay_api/tests.rs
+++ b/rust/main/agents/relayer/src/relay_api/tests.rs
@@ -11,8 +11,8 @@ use hyperlane_base::{
     db::{test_utils, HyperlaneRocksDB},
 };
 use hyperlane_core::{
-    ChainResult, HyperlaneDomain, HyperlaneMessage, Indexed, Indexer, LogMeta, QueueOperation,
-    H256, H512,
+    ChainResult, GasPaymentKey, HyperlaneDomain, HyperlaneMessage, Indexed, Indexer,
+    InterchainGasPayment, LogMeta, QueueOperation, H256, H512, U256,
 };
 use hyperlane_test::mocks::MockMailboxContract;
 use parking_lot::Mutex;
@@ -111,6 +111,46 @@ impl Indexer<HyperlaneMessage> for MockIndexer {
             .map(|m| (Indexed::new(m.clone()), LogMeta::default()))
             .collect();
         Ok((logs, self.is_cctp_v2_result))
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// MockIgpIndexer
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct MockIgpIndexer {
+    payments: Vec<(Indexed<InterchainGasPayment>, LogMeta)>,
+}
+
+impl MockIgpIndexer {
+    fn with_payments(payments: Vec<(Indexed<InterchainGasPayment>, LogMeta)>) -> Self {
+        Self { payments }
+    }
+}
+
+#[async_trait]
+impl Indexer<InterchainGasPayment> for MockIgpIndexer {
+    fn parse_tx_hash(&self, tx_hash: &str) -> ChainResult<H512> {
+        hyperlane_core::parse_evm_hex_tx_hash(tx_hash)
+    }
+
+    async fn fetch_logs_in_range(
+        &self,
+        _range: RangeInclusive<u32>,
+    ) -> ChainResult<Vec<(Indexed<InterchainGasPayment>, LogMeta)>> {
+        Ok(vec![])
+    }
+
+    async fn get_finalized_block_number(&self) -> ChainResult<u32> {
+        Ok(0)
+    }
+
+    async fn fetch_logs_by_tx_hash(
+        &self,
+        _tx_hash: H512,
+    ) -> ChainResult<Vec<(Indexed<InterchainGasPayment>, LogMeta)>> {
+        Ok(self.payments.clone())
     }
 }
 
@@ -532,4 +572,99 @@ async fn test_partial_send_failure_releases_dedup_for_retry() {
         StatusCode::TOO_MANY_REQUESTS,
         "after 500, same tx_hash must not be blocked by dedup cache"
     );
+}
+
+#[tokio::test]
+async fn test_igp_payments_stored_before_enqueue() {
+    // Compute the message ID so we can create a matching IGP payment.
+    let msg = test_msg(ORIGIN_ID, DEST_ID, 1);
+    let message_id = msg.id();
+
+    let payment = InterchainGasPayment {
+        message_id,
+        destination: DEST_ID,
+        payment: U256::from(100u64),
+        gas_amount: U256::from(200u64),
+    };
+    let igp_indexer = Arc::new(MockIgpIndexer::with_payments(vec![(
+        Indexed::new(payment),
+        LogMeta::default(),
+    )]));
+
+    // Build state manually so we can (a) inject the IGP indexer and (b) retain a
+    // clone of the DB to verify storage after the request.
+    let tempdir = TempDir::new().unwrap();
+    let db = test_utils::setup_db(tempdir.path().to_str().unwrap().to_owned());
+    let domain = HyperlaneDomain::new_test_domain("relay_api_igp_test");
+    let rocks_db = HyperlaneRocksDB::new(&domain, db);
+    let rocks_db_ref = rocks_db.clone(); // kept for post-request verification
+
+    let mock_builder = build_mock_base_builder(domain.clone(), domain.clone());
+    let msg_ctx = Arc::new(MessageContext {
+        destination_mailbox: Arc::new(mock_mailbox()),
+        origin_db: Arc::new(rocks_db.clone()),
+        cache: OptionalCache::new(None),
+        metadata_builder: Arc::new(mock_builder),
+        origin_gas_payment_enforcer: Arc::new(RwLock::new(GasPaymentEnforcer::new(
+            [],
+            rocks_db.clone(),
+        ))),
+        transaction_gas_limit: None,
+        metrics: dummy_submission_metrics(),
+        application_operation_verifier: Arc::new(DummyApplicationOperationVerifier {}),
+    });
+
+    let mut indexers = HashMap::new();
+    indexers.insert(
+        "ethereum".to_string(),
+        Arc::new(MockIndexer::cctp(msg)) as Arc<dyn Indexer<HyperlaneMessage>>,
+    );
+    let mut igp_indexers = HashMap::new();
+    igp_indexers.insert(
+        ORIGIN_ID,
+        igp_indexer as Arc<dyn Indexer<InterchainGasPayment>>,
+    );
+    let mut dbs = HashMap::new();
+    dbs.insert(ORIGIN_ID, rocks_db);
+    let (tx, mut rx) = mpsc::unbounded_channel::<QueueOperation>();
+    let mut send_channels = HashMap::new();
+    send_channels.insert(DEST_ID, tx);
+    let mut msg_ctxs = HashMap::new();
+    msg_ctxs.insert((ORIGIN_ID, DEST_ID), msg_ctx);
+
+    let metrics = RelayApiMetrics::new(&Registry::new()).unwrap();
+    let state = ServerState::new(
+        indexers,
+        igp_indexers,
+        dbs,
+        send_channels,
+        msg_ctxs,
+        metrics,
+    );
+
+    let cache = Arc::new(Mutex::new(TxHashCache::new(100)));
+    let status = send_relay(state.with_tx_hash_cache(cache).router(), TX_HASH).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(rx.try_recv().is_ok(), "message should have been enqueued");
+
+    // Verify the IGP payment was stored in the DB before the message entered the queue.
+    let key = GasPaymentKey {
+        message_id,
+        destination: DEST_ID,
+    };
+    let stored = rocks_db_ref
+        .retrieve_gas_payment_by_gas_payment_key(key)
+        .expect("DB lookup should not fail");
+    assert!(
+        stored.is_some(),
+        "IGP payment should have been stored by the relay handler before enqueue"
+    );
+    let stored = stored.unwrap();
+    assert_eq!(
+        stored.payment,
+        U256::from(100u64),
+        "payment amount mismatch"
+    );
+    assert_eq!(stored.gas_amount, U256::from(200u64), "gas amount mismatch");
 }

--- a/rust/main/agents/relayer/src/relay_api/tests.rs
+++ b/rust/main/agents/relayer/src/relay_api/tests.rs
@@ -197,7 +197,14 @@ async fn make_state_multi(
     }
 
     let metrics = RelayApiMetrics::new(&Registry::new()).unwrap();
-    let state = ServerState::new(indexers, dbs, send_channels, msg_ctxs, metrics);
+    let state = ServerState::new(
+        indexers,
+        HashMap::new(),
+        dbs,
+        send_channels,
+        msg_ctxs,
+        metrics,
+    );
 
     TestHarness {
         state,
@@ -498,7 +505,14 @@ async fn test_partial_send_failure_releases_dedup_for_retry() {
     msg_ctxs.insert((ORIGIN_ID, dest_b), msg_ctx.clone());
 
     let metrics = RelayApiMetrics::new(&Registry::new()).unwrap();
-    let state = ServerState::new(indexers, dbs, send_channels, msg_ctxs, metrics);
+    let state = ServerState::new(
+        indexers,
+        HashMap::new(),
+        dbs,
+        send_channels,
+        msg_ctxs,
+        metrics,
+    );
 
     let cache = Arc::new(Mutex::new(TxHashCache::new(100)));
     let router = state.with_tx_hash_cache(cache).router();

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -666,9 +666,16 @@ impl Relayer {
                 .map(|(domain, origin)| (domain.name().to_string(), origin.message_indexer.clone()))
                 .collect();
 
+            let igp_indexers: HashMap<u32, Arc<dyn Indexer<InterchainGasPayment>>> = self
+                .origins
+                .iter()
+                .filter_map(|(domain, origin)| origin.igp_indexer.clone().map(|i| (domain.id(), i)))
+                .collect();
+
             Some(
                 RelayApiState::new(
                     indexers,
+                    igp_indexers,
                     dbs.clone(),
                     send_channels,
                     msg_ctxs.clone(),

--- a/rust/main/agents/relayer/src/relayer/origin.rs
+++ b/rust/main/agents/relayer/src/relayer/origin.rs
@@ -36,6 +36,11 @@ pub struct Origin {
     /// API can reuse the existing RPC connection instead of opening a new one.
     pub message_indexer: Arc<dyn Indexer<HyperlaneMessage>>,
     pub interchain_gas_payment_sync: Option<InterchainGasPaymentSync>,
+    /// The underlying IGP indexer shared with `interchain_gas_payment_sync`. Exposed so the
+    /// relay API can eagerly store gas payments from a tx receipt before enqueuing the message,
+    /// closing the race window where the relayer checks for gas payment before the background
+    /// `tx_id_indexer_task` has stored it.
+    pub igp_indexer: Option<Arc<dyn Indexer<InterchainGasPayment>>>,
     pub merkle_tree_hook_sync: MerkleTreeHookSync,
 }
 
@@ -141,8 +146,8 @@ impl Factory for OriginFactory {
             res
         };
 
-        let interchain_gas_payment_sync = if self.igp_indexing_enabled {
-            let igp_sync = {
+        let (interchain_gas_payment_sync, igp_indexer) = if self.igp_indexing_enabled {
+            let (igp_sync, igp_idx) = {
                 let start_entity_init = Instant::now();
                 let res = self
                     .init_igp_sync(&domain, chain_conf, hyperlane_db.clone())
@@ -154,9 +159,9 @@ impl Factory for OriginFactory {
                 );
                 res
             };
-            Some(igp_sync)
+            (Some(igp_sync), Some(igp_idx))
         } else {
-            None
+            (None, None)
         };
 
         let merkle_tree_hook_sync = {
@@ -182,6 +187,7 @@ impl Factory for OriginFactory {
             message_sync,
             message_indexer,
             interchain_gas_payment_sync,
+            igp_indexer,
             merkle_tree_hook_sync,
         };
         Ok(origin)
@@ -266,7 +272,13 @@ impl OriginFactory {
         domain: &HyperlaneDomain,
         chain_conf: &ChainConf,
         db: Arc<HyperlaneRocksDB>,
-    ) -> Result<InterchainGasPaymentSync, FactoryError> {
+    ) -> Result<
+        (
+            InterchainGasPaymentSync,
+            Arc<dyn Indexer<InterchainGasPayment>>,
+        ),
+        FactoryError,
+    > {
         match InterchainGasPayment::indexing_cursor(domain.domain_protocol()) {
             CursorType::SequenceAware => Self::build_sequenced_contract_sync(
                 domain,
@@ -278,7 +290,12 @@ impl OriginFactory {
                 false,
             )
             .await
-            .map(|(r, _)| r as Arc<dyn ContractSyncer<_>>)
+            .map(|(r, i)| {
+                (
+                    r as Arc<dyn ContractSyncer<_>>,
+                    Arc::new(i) as Arc<dyn Indexer<_>>,
+                )
+            })
             .map_err(|err| {
                 FactoryError::InterchainGasPaymentSync(domain.to_string(), err.to_string())
             }),
@@ -292,7 +309,12 @@ impl OriginFactory {
                 false,
             )
             .await
-            .map(|(r, _)| r as Arc<dyn ContractSyncer<_>>)
+            .map(|(r, i)| {
+                (
+                    r as Arc<dyn ContractSyncer<_>>,
+                    Arc::new(i) as Arc<dyn Indexer<_>>,
+                )
+            })
             .map_err(|err| {
                 FactoryError::InterchainGasPaymentSync(domain.to_string(), err.to_string())
             }),

--- a/rust/main/hyperlane-core/src/traits/pending_operation.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation.rs
@@ -153,6 +153,12 @@ pub trait PendingOperation: Send + Sync + Debug + TryBatchAs<HyperlaneMessage> {
     /// returning `NotReady` if it is too early and matters.
     fn next_attempt_after(&self) -> Option<Instant>;
 
+    /// Whether this operation is ready to be attempted.
+    fn is_ready(&self) -> bool {
+        self.next_attempt_after()
+            .map_or(true, |t| Instant::now() >= t)
+    }
+
     /// Set the next time this operation should be attempted.
     fn set_next_attempt_after(&mut self, delay: Duration);
 

--- a/rust/main/hyperlane-core/src/traits/pending_operation.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation.rs
@@ -156,7 +156,7 @@ pub trait PendingOperation: Send + Sync + Debug + TryBatchAs<HyperlaneMessage> {
     /// Whether this operation is ready to be attempted.
     fn is_ready(&self) -> bool {
         self.next_attempt_after()
-            .map_or(true, |t| Instant::now() >= t)
+            .is_none_or(|t| Instant::now() >= t)
     }
 
     /// Set the next time this operation should be attempted.


### PR DESCRIPTION
### Description

This PR makes sure that when the relay api path is taken that the gas payment is fetched and written to the db before the message gets submitted to the submit queue. Before we had to wait for the slow contract indexer to write the gas payment to the db

Also improved logging by attaching the message id to the logs for better tracing

### Testing

Noticed and fixed this while testing the USDC/testnet-cctp-v2-fast route on testnet

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
