### PR TITLE
chore: clarify USDC/paradex denylist reason

### DIFF
--- a/typescript/infra/config/environments/mainnet3/customBlacklist.ts
+++ b/typescript/infra/config/environments/mainnet3/customBlacklist.ts
@@ -237,6 +237,6 @@ export const blacklistedMessageIds = [
 
   // USDC/eclipsemainnet warp transfer to USDC contract itself [2026-01-30]
   '0x4190cf8c0419cd966fc96fcb9050be3d941cb06974667bd768f22e90abcec6a6',
-  // USDC/paradex - Circle USDC blacklisted recipient on Arbitrum [2026-05-01]
+  // USDC/paradex - warp transfer to USDC contract address as recipient [2026-05-01]
   '0xeece23565b9bf5a344516b92a8bf857644f5ef29e49fd0b525c8f752452cf113',
 ];

--- a/typescript/infra/config/environments/mainnet3/customBlacklist.ts
+++ b/typescript/infra/config/environments/mainnet3/customBlacklist.ts
@@ -172,7 +172,8 @@ export const blacklistedMessageIds = [
   // Superseed dest:
   // 7/1/2025
   '0x84c7565f1f0b0fc7b5571c86e9f23187d4078779f607b13f73c6016efcf90bc4',
-  // Paradex USDC:
+  // USDC/paradex
+  // warp message with the Arbitrum USDC token contract encoded as recipient in the message body.
   // 8/27/2025
   '0x151135eda5f04110084c6673d23f041d9141a50bdb02de028e32fe7f4e14e7c2',
 


### PR DESCRIPTION
## Summary
- Added 1 message ID to the relayer denylist for the USDC/paradex route.
- The stuck message is undeliverable because the warp recipient encoded in the message body is the Arbitrum USDC token contract itself (`0xaf88d065e77c8cC2239327C5EDb3A432268e5831`).
- This is not a case of Circle blacklisting a user account; the contract is effectively self-blacklisted to prevent permanently locked funds.
- The denylist entry matches the existing pattern used for similar undeliverable USDC warp messages.

## Investigation
- In the relayer, pre-submit simulation failures from `process_estimate_costs` are recorded as `ErrorEstimatingGas` unless a chain/application-specific verifier upgrades them to an `ApplicationReport` (`rust/main/agents/relayer/src/msg/pending_message.rs`).
- The generic status string for that path is `Error estimating costs for process call` (`rust/main/hyperlane-core/src/traits/pending_operation.rs`).
- This repo does not contain explorer UI code. From repo evidence, the gap is general to relayer-side `ErrorEstimatingGas` / pre-submit failures unless extra classification exists, not specific to this USDC revert.

## Test plan
- [x] Review blacklist message ID and comment
- [ ] Deploy relayer with updated denylist
