### PR TITLE
fix(sdk): native handling and local gas estimation in WarpCore for QuotedCalls

### DIFF
--- a/.changeset/quoted-calls-native-and-local-gas.md
+++ b/.changeset/quoted-calls-native-and-local-gas.md
@@ -1,0 +1,8 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Fix two `WarpCore` issues for `QuotedCalls` flows:
+
+- `resolveQuotedCallsParams` now treats `EvmHypNative` routes as native (zero-address token) by also checking `isHypNative()`. Previously, native warp routers were misidentified — `getQuotedTransferFee` returned `msg.value` (transfer amount + fee) as the IGP quote, so UIs displayed the bridged amount itself as "Interchain Gas".
+- `getLocalTransferFee` and `getLocalTransferFeeAmount` accept an optional `quotedCalls` param and forward it to `getTransferRemoteTxs`. Internal gas estimation now builds the actual `QuotedCalls.execute(...)` multicall instead of plain `transferRemote`, giving accurate pre-sign gas estimates for the QuotedCalls path. Callers were previously hardcoding `localQuote = 0`.

--- a/.changeset/quoted-calls-native-and-local-gas.md
+++ b/.changeset/quoted-calls-native-and-local-gas.md
@@ -2,7 +2,7 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-Fix two `WarpCore` issues for `QuotedCalls` flows:
+Fixed two `WarpCore` issues for `QuotedCalls` flows:
 
-- `resolveQuotedCallsParams` now treats `EvmHypNative` routes as native (zero-address token) by also checking `isHypNative()`. Previously, native warp routers were misidentified — `getQuotedTransferFee` returned `msg.value` (transfer amount + fee) as the IGP quote, so UIs displayed the bridged amount itself as "Interchain Gas".
-- `getLocalTransferFee` and `getLocalTransferFeeAmount` accept an optional `quotedCalls` param and forward it to `getTransferRemoteTxs`. Internal gas estimation now builds the actual `QuotedCalls.execute(...)` multicall instead of plain `transferRemote`, giving accurate pre-sign gas estimates for the QuotedCalls path. Callers were previously hardcoding `localQuote = 0`.
+- Updated `resolveQuotedCallsParams` to treat `EvmHypNative` routes as native (zero-address token) by also checking `isHypNative()`. Previously, native warp routers were misidentified — `getQuotedTransferFee` returned `msg.value` (transfer amount + fee) as the IGP quote, so UIs displayed the bridged amount itself as "Interchain Gas".
+- Added an optional `quotedCalls` param to `getLocalTransferFee` and `getLocalTransferFeeAmount`, forwarded to `getTransferRemoteTxs`. Internal gas estimation now builds the actual `QuotedCalls.execute(...)` multicall instead of plain `transferRemote`, giving accurate pre-sign gas estimates for the QuotedCalls path. Callers were previously hardcoding `localQuote = 0`.

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -355,7 +355,7 @@ export class WarpCore {
     // Typically the transfers require a single transaction
     if (txs.length === 1) {
       try {
-        return this.multiProvider.estimateTransactionFee({
+        return await this.multiProvider.estimateTransactionFee({
           chainNameOrId: originMetadata.name,
           transaction: txs[0],
           sender,

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -282,6 +282,7 @@ export class WarpCore {
     attestation,
     amount,
     destinationToken,
+    quotedCalls,
   }: {
     originToken: IToken;
     destination: ChainNameOrId;
@@ -292,6 +293,7 @@ export class WarpCore {
     attestation?: PredicateAttestation;
     amount?: bigint;
     destinationToken?: IToken;
+    quotedCalls?: QuotedCallsParams;
   }): Promise<TransactionFeeEstimate> {
     this.logger.debug(`Estimating local transfer gas to ${destination}`);
     const originMetadata = this.multiProvider.getChainMetadata(
@@ -342,6 +344,7 @@ export class WarpCore {
       tokenFeeQuote,
       attestation,
       destinationToken,
+      quotedCalls,
     });
 
     // Starknet does not support gas estimation without starknet account
@@ -399,6 +402,7 @@ export class WarpCore {
     attestation,
     amount,
     destinationToken,
+    quotedCalls,
   }: {
     originToken: IToken;
     destination: ChainNameOrId;
@@ -409,6 +413,7 @@ export class WarpCore {
     attestation?: PredicateAttestation;
     amount?: bigint;
     destinationToken?: IToken;
+    quotedCalls?: QuotedCallsParams;
   }): Promise<TokenAmount<IToken>> {
     const originMetadata = this.multiProvider.getChainMetadata(
       originToken.chainName,
@@ -431,6 +436,7 @@ export class WarpCore {
       attestation,
       amount,
       destinationToken,
+      quotedCalls,
     });
 
     // Get the local gas token. This assumes the chain's native token will pay for local gas
@@ -859,7 +865,7 @@ export class WarpCore {
     const tokenAddress = (
       collateral && !isZeroishAddress(collateral)
         ? collateral
-        : token.isNative()
+        : token.isNative() || token.isHypNative()
           ? '0x0000000000000000000000000000000000000000'
           : token.addressOrDenom
     ) as `0x${string}`;


### PR DESCRIPTION
## Summary

Two bugs in `WarpCore` surfaced while wiring up the offchain fee quoting flow in the warp UI:

### 1. Native warp routes misidentified in `resolveQuotedCallsParams`

`token.isNative()` only matches plain native standards (e.g. `Ether`), not `EvmHypNative`. As a result, native warp routers fell through to `token.addressOrDenom` (the router address) instead of resolving to `0x000…000`. Downstream, `getQuotedTransferFee` returned `msg.value` (transfer amount + fee) as the IGP quote — so UIs rendered the *bridged amount itself* as "Interchain Gas" (e.g. transferring 1 ETH → "Interchain Gas: 1 ETH ≈\$2,300"). The check now also accepts `isHypNative()`.

### 2. No way to estimate local gas for QuotedCalls

`getLocalTransferFee` / `getLocalTransferFeeAmount` had no `quotedCalls` parameter, so internal gas estimation always built a plain `transferRemote(...)` tx — not the actual `QuotedCalls.execute(...)` multicall the user signs. Callers had no way to get an accurate gas preview for the offchain quoting path and were hardcoding `localQuote = 0` in the UI. Both methods now accept an optional `quotedCalls?: QuotedCallsParams` and forward it to `getTransferRemoteTxs`.

## Behavior change

Backwards-compatible (additive). Pre-existing callers behave identically; new param is opt-in.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperlane-xyz/hyperlane-monorepo/pull/8699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
