### PR TITLE
feat(infra): add USDC/ctusd-ironbridge-staging warp route getter

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDCCtUSDIronBridgeStagingWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDCCtUSDIronBridgeStagingWarpConfig.ts
@@ -1,0 +1,84 @@
+import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
+import { addressToBytes32 } from '@hyperlane-xyz/utils';
+
+import {
+  RouterConfigWithoutOwner,
+  tokens,
+} from '../../../../../src/config/warp.js';
+
+// Owner of every TokenBridgeDepositAddress instance. Controls only
+// add/removeDestinationConfig; intentionally distinct from the cross-collateral
+// router's MCR rebalancer so a deployer-key compromise can't redirect Iron
+// deposits without also moving funds via the MCR.
+const BRIDGE_OWNER = '0x3e0A78A330F2b97059A4D507ca9d8292b65B6FB5';
+
+// CROSS/ctusd cross-collateral routers (the Iron autoramp receivers).
+const CTUSD_ROUTERS = {
+  arbitrum: '0x62fe676dff1e7ABBCcbedc8BABc993827b9fb189',
+  base: '0xd54A15f8dF8C6dD9Ef3b5589BE0bF37EC6f61F91',
+  ethereum: '0xd4463cB3c90b3F49c673310BEC9bC18311134B47',
+  citrea: '0x38E8720EBE02e7c5254F9De9F81440C7a770a9c6',
+} as const;
+
+type CtUSDChain = keyof typeof CTUSD_ROUTERS;
+
+// Iron-issued deposit addresses, one per (origin, dest) lane. Source: the 6
+// "Staging MovableCollateral Market" autoramps on Iron customer
+// 019d44d2-fc8e-74d2-8f92-1a69cf4e10a7 created 2026-05-01, verified via
+// GET https://api.iron.xyz/api/autoramps.
+const IRON_DEPOSITS: Record<CtUSDChain, Partial<Record<CtUSDChain, string>>> = {
+  arbitrum: { citrea: '0xe11a54ad85e4f04962c93f26d2c746f610a61933' }, // 019de402-b49e
+  base: { citrea: '0x99dcac2e06090fc843feb0f36516ac7e0b351fcf' }, // 019de402-4cfc
+  ethereum: { citrea: '0xba16a57c15c95fd89f096e7c9bb98d1fe25583b3' }, // 019de401-c8b5
+  citrea: {
+    arbitrum: '0x1e9ad719e6dd6c86370d7a0f99430e86fe0f1039', // 019de409-00d7
+    base: '0xdb99b7f572d22429fc9dbde5a32c3f159eb17e30', // 019de40a-695f
+    ethereum: '0x33d51a880f83df9b9560d826e0a6de022d285da1', // 019de404-39a7
+  },
+};
+
+const ORIGIN_TOKENS: Record<CtUSDChain, string> = {
+  arbitrum: tokens.arbitrum.USDC,
+  base: tokens.base.USDC,
+  ethereum: tokens.ethereum.USDC,
+  citrea: tokens.citrea.ctUSD,
+};
+
+function destinationConfigsFor(origin: CtUSDChain) {
+  const lanes = IRON_DEPOSITS[origin];
+  return Object.fromEntries(
+    Object.entries(lanes).map(([dest, depositAddress]) => [
+      dest,
+      {
+        [addressToBytes32(CTUSD_ROUTERS[dest as CtUSDChain])]: {
+          depositAddress,
+          feeBps: '0',
+        },
+      },
+    ]),
+  );
+}
+
+export const getUSDCCtUSDIronBridgeStagingWarpConfig = async (
+  routerConfig: ChainMap<RouterConfigWithoutOwner>,
+): Promise<ChainMap<HypTokenRouterConfig>> => {
+  const origins: readonly CtUSDChain[] = [
+    'arbitrum',
+    'base',
+    'ethereum',
+    'citrea',
+  ];
+
+  return Object.fromEntries(
+    origins.map((origin) => [
+      origin,
+      {
+        ...routerConfig[origin],
+        type: TokenType.collateralDepositAddress,
+        token: ORIGIN_TOKENS[origin],
+        owner: BRIDGE_OWNER,
+        destinationConfigs: destinationConfigsFor(origin),
+      },
+    ]),
+  );
+};

--- a/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
@@ -148,6 +148,7 @@ export enum WarpRouteIds {
 
   // ctUSD
   CitreaUSD = 'ctUSD/citrea',
+  USDCCtUSDIronBridgeStaging = 'USDC/ctusd-ironbridge-staging',
 
   // TODO: uncomment when USDTOft warp routes are in the registry
   // USDT OFT

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -137,6 +137,7 @@ import {
 import { WarpRouteIds } from './environments/mainnet3/warp/warpIds.js';
 import { getCCTPWarpConfig as getTestnetCCTPWarpConfig } from './environments/testnet4/warp/getCCTPConfig.js';
 import { DEFAULT_REGISTRY_URI } from './registry.js';
+import { getUSDCCtUSDIronBridgeStagingWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDCCtUSDIronBridgeStagingWarpConfig.js';
 import { getUSDTOftWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDTOftWarpConfig.js';
 import { getUSDTOftLegacyWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDTOftLegacyWarpConfig.js';
 import { getUSDTSTAGEWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDTSTAGEWarpConfig.js';
@@ -228,6 +229,8 @@ export const warpConfigGetterMap: Record<string, WarpConfigGetter> = {
   [WarpRouteIds.AleoUSDC]: getAleoUSDCWarpConfig,
   [WarpRouteIds.USDTOft]: getUSDTOftWarpConfig,
   [WarpRouteIds.USDTOftLegacy]: getUSDTOftLegacyWarpConfig,
+  [WarpRouteIds.USDCCtUSDIronBridgeStaging]:
+    getUSDCCtUSDIronBridgeStagingWarpConfig,
 };
 
 type StrategyConfigGetter = () => ChainSubmissionStrategy;

--- a/typescript/infra/src/config/warp.ts
+++ b/typescript/infra/src/config/warp.ts
@@ -40,6 +40,9 @@ export const tokens = {
     USDT: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
     USDC: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
   },
+  citrea: {
+    ctUSD: '0x8D82c4E3c936C7B5724A382a9c5a4E6Eb7aB6d5D',
+  },
   avalanche: {
     USDC: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
   },


### PR DESCRIPTION
## Summary

Adds the `USDC/ctusd-ironbridge-staging` warp route — a standalone `TokenBridgeDepositAddress` set that pairs with the staging cross-collateral route `CROSS/ctusd` on the `codex/nambrot-cross-collateral-deploy` registry branch. The new route lets `MovableCollateralRouter.rebalance()` push USDC/ctUSD to Iron's autoramp deposit addresses, which then settle into the destination cross-collateral router via Iron's smart-contract receivers (per Charlie's Apr 30 confirmation).

- `WarpRouteIds.USDCCtUSDIronBridgeStaging = 'USDC/ctusd-ironbridge-staging'`
- New getter `getUSDCCtUSDIronBridgeStagingWarpConfig.ts` — emits one `TokenType.collateralDepositAddress` per origin chain (arbitrum, base, ethereum, citrea), each with `destinationConfigs` pointing at the 6 "Staging MovableCollateral Market" Iron autoramps created on 2026-05-01.
- Bridge contract owner pinned to deployer EOA `0x3e0A78A3…6FB5` (separate from the MCR owner `0xEA2117b2…0c01`, so deposit-address auth is independent of rebalance auth).
- Adds `tokens.citrea.ctUSD` constant.

Paired registry PR: hyperlane-xyz/hyperlane-registry#1515 (deploy artifact regenerated from this getter).

## Test plan

- [x] `pnpm --filter @hyperlane-xyz/infra exec tsx scripts/warp-routes/export-warp-configs.ts --environment mainnet3 --warpRouteIds USDC/ctusd-ironbridge-staging` produces a clean YAML matching the 6 autoramp deposit addresses 1:1.
- [x] `pnpm hyperlane warp deploy --warpRouteId USDC/ctusd-ironbridge-staging` deploys 4 contracts and runs 6 `addDestinationConfig` calls on mainnet (2026-05-04). All on-chain reads via `cast` confirm correct token, owner, and per-lane deposit addresses.
- [x] End-to-end manual test: 11 USDC arb→citrea via `transferRemote` settled in ~2 min, ctUSD landed in citrea router (10.991724 received — Iron applied 75 bps via the customer fee profile, separate follow-up).
- [ ] Etherscan verification re-run with valid `ETHERSCAN_API_KEY` (verification step failed during deploy due to Invalid API Key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)