### PR TITLE
fix(infra): filter missing chains out of registry startup

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -58,6 +58,10 @@ import {
 import { validatorChainConfig } from './validators.js';
 import { WarpRouteIds } from './warp/warpIds.js';
 
+const supportedChainNamesInRegistrySet = new Set<ChainName>(
+  supportedChainNamesInRegistry,
+);
+
 // The chains here must be consistent with the environment's supportedChainNames, which is
 // checked / enforced at runtime & in the CI pipeline.
 //
@@ -523,8 +527,14 @@ export const scraperOnlyChains: BaseScraperConfig['scraperOnlyChains'] = {
 };
 
 export const hyperlaneContextAgentChainNames = getAgentChainNamesFromConfig(
-  hyperlaneContextAgentChainConfig,
-  mainnet3SupportedChainNames,
+  objMap(hyperlaneContextAgentChainConfig, (_, roleConfig) =>
+    Object.fromEntries(
+      Object.entries(roleConfig).filter(([chain]) =>
+        supportedChainNamesInRegistrySet.has(chain as ChainName),
+      ),
+    ),
+  ) as AgentChainConfig<typeof supportedChainNamesInRegistry>,
+  supportedChainNamesInRegistry,
 );
 
 const sealevelPriorityFeeOracleConfigGetter = (

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -41,7 +41,11 @@ import { Contexts } from '../../contexts.js';
 import { DockerImageRepos, mainnetDockerTags } from '../../docker.js';
 import { getDomainId, getWarpAddresses } from '../../registry.js';
 
-import { environment, ethereumChainNames } from './chains.js';
+import {
+  environment,
+  ethereumChainNames,
+  supportedChainNamesInRegistry,
+} from './chains.js';
 import { blacklistedMessageIds } from './customBlacklist.js';
 import aaveSenderAddresses from './misc-artifacts/aave-sender-addresses.json' with { type: 'json' };
 import everclearSenderAddresses from './misc-artifacts/everclear-sender-addresses.json' with { type: 'json' };
@@ -576,7 +580,7 @@ const sealevelTransactionSubmitterConfigGetter = (
 const contextBase = {
   namespace: environment,
   runEnv: environment,
-  environmentChainNames: supportedChainNames,
+  environmentChainNames: supportedChainNamesInRegistry,
   aws: {
     region: 'us-east-1',
   },

--- a/typescript/infra/config/environments/mainnet3/chains.ts
+++ b/typescript/infra/config/environments/mainnet3/chains.ts
@@ -1,14 +1,33 @@
 import { IRegistry } from '@hyperlane-xyz/registry';
 import { ChainMap, ChainMetadata, ChainName } from '@hyperlane-xyz/sdk';
+import { rootLogger } from '@hyperlane-xyz/utils';
 
 import { getRegistryForEnvironment } from '../../../src/config/chain.js';
+import { getRegistry as getBaseRegistry } from '../../../config/registry.js';
 import { isEthereumProtocolChain } from '../../../src/utils/utils.js';
 
 import { supportedChainNames } from './supportedChainNames.js';
 
 export const environment = 'mainnet3';
 
-export const ethereumChainNames = supportedChainNames.filter(
+const baseRegistry = getBaseRegistry();
+
+function isChainPresentInBaseRegistry(chainName: ChainName): boolean {
+  const chainMetadata = baseRegistry.getChainMetadata(chainName);
+  if (!chainMetadata) {
+    rootLogger.warn(
+      { chainName },
+      'Skipping chain missing from base registry while deriving chain lists',
+    );
+  }
+  return !!chainMetadata;
+}
+
+export const supportedChainNamesInRegistry = supportedChainNames.filter(
+  isChainPresentInBaseRegistry,
+);
+
+export const ethereumChainNames = supportedChainNamesInRegistry.filter(
   isEthereumProtocolChain,
 );
 
@@ -144,7 +163,7 @@ export const chainMetadataOverrides: ChainMap<Partial<ChainMetadata>> = {
 
 export const getRegistry = async (
   useSecrets = true,
-  chains: ChainName[] = supportedChainNames,
+  chains: ChainName[] = supportedChainNamesInRegistry,
 ): Promise<IRegistry> =>
   getRegistryForEnvironment(
     environment,

--- a/typescript/infra/config/environments/mainnet3/chains.ts
+++ b/typescript/infra/config/environments/mainnet3/chains.ts
@@ -1,9 +1,10 @@
 import { IRegistry } from '@hyperlane-xyz/registry';
 import { ChainMap, ChainMetadata, ChainName } from '@hyperlane-xyz/sdk';
-import { rootLogger } from '@hyperlane-xyz/utils';
-
 import { getRegistryForEnvironment } from '../../../src/config/chain.js';
-import { getRegistry as getBaseRegistry } from '../../../config/registry.js';
+import {
+  getRegistry as getBaseRegistry,
+  isChainPresentInRegistry,
+} from '../../../config/registry.js';
 import { isEthereumProtocolChain } from '../../../src/utils/utils.js';
 
 import { supportedChainNames } from './supportedChainNames.js';
@@ -12,19 +13,8 @@ export const environment = 'mainnet3';
 
 const baseRegistry = getBaseRegistry();
 
-function isChainPresentInBaseRegistry(chainName: ChainName): boolean {
-  const chainMetadata = baseRegistry.getChainMetadata(chainName);
-  if (!chainMetadata) {
-    rootLogger.warn(
-      { chainName },
-      'Skipping chain missing from base registry while deriving chain lists',
-    );
-  }
-  return !!chainMetadata;
-}
-
 export const supportedChainNamesInRegistry = supportedChainNames.filter(
-  isChainPresentInBaseRegistry,
+  (chainName) => isChainPresentInRegistry(baseRegistry, environment, chainName),
 );
 
 export const ethereumChainNames = supportedChainNamesInRegistry.filter(

--- a/typescript/infra/config/environments/mainnet3/core.ts
+++ b/typescript/infra/config/environments/mainnet3/core.ts
@@ -28,7 +28,7 @@ import { getEdenCoreConfig } from './eden.js';
 import { getTronCoreConfig } from './tron.js';
 import { igp } from './igp.js';
 import { DEPLOYER, ethereumChainOwners } from './owners.js';
-import { supportedChainNames } from './supportedChainNames.js';
+import { supportedChainNamesInRegistry } from './chains.js';
 
 // There are no static ISMs or hooks for zkSync, this means
 // that the default ISM is a routing ISM and the default hook
@@ -47,13 +47,14 @@ export const core: ChainMap<CoreConfig> = objMap(
     }
 
     const originMultisigs: ChainMap<MultisigConfig> = Object.fromEntries(
-      supportedChainNames
+      supportedChainNamesInRegistry
         // no reflexivity
         .filter((chain) => chain !== local)
         // exclude forma as it's not a core chain
         .filter((chain) => chain !== 'forma')
         // exclude eden as it's only connected to celestia
         .filter((chain) => chain !== 'eden')
+        .filter((chain) => !!defaultMultisigConfigs[chain])
         .map((origin) => [origin, defaultMultisigConfigs[origin]]),
     );
 

--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -1,5 +1,11 @@
-import { ChainMap, ChainName, HookType, IgpConfig } from '@hyperlane-xyz/sdk';
-import { exclude, objMap } from '@hyperlane-xyz/utils';
+import {
+  ChainMap,
+  ChainName,
+  HookType,
+  IgpConfig,
+  defaultMultisigConfigs,
+} from '@hyperlane-xyz/sdk';
+import { exclude, objFilter, objMap } from '@hyperlane-xyz/utils';
 
 import {
   AllStorageGasOracleConfigs,
@@ -9,12 +15,15 @@ import {
 
 import { getEdenIgpConfig } from './eden.js';
 import { getTronIgpConfig } from './tron.js';
+import { supportedChainNamesInRegistry } from './chains.js';
 import gasPrices from './gasPrices.json' with { type: 'json' };
 import { DEPLOYER, chainOwners } from './owners.js';
-import { supportedChainNames } from './supportedChainNames.js';
 import rawTokenPrices from './tokenPrices.json' with { type: 'json' };
 
 const tokenPrices: ChainMap<string> = rawTokenPrices;
+const supportedIgpChainNames = supportedChainNamesInRegistry.filter(
+  (chain) => !!defaultMultisigConfigs[chain],
+);
 
 function getOracleConfigWithOverrides(origin: ChainName) {
   const oracleConfig = storageGasOracleConfig[origin];
@@ -41,15 +50,21 @@ function getOracleConfigWithOverrides(origin: ChainName) {
 
 const storageGasOracleConfig: AllStorageGasOracleConfigs =
   getAllStorageGasOracleConfigs(
-    supportedChainNames,
+    supportedIgpChainNames,
     tokenPrices,
     gasPrices,
     (local, remote) => getOverheadWithOverrides(local, remote),
     true,
   );
 
-export const igp: ChainMap<IgpConfig> = objMap(
+const supportedIgpChainOwners = objFilter(
   chainOwners,
+  (chain, owner): owner is (typeof chainOwners)[string] =>
+    chain in storageGasOracleConfig || chain === 'eden' || chain === 'tron',
+);
+
+export const igp: ChainMap<IgpConfig> = objMap(
+  supportedIgpChainOwners,
   (local, owner): IgpConfig => {
     if (local === 'eden') {
       return getEdenIgpConfig(owner, storageGasOracleConfig);
@@ -70,7 +85,7 @@ export const igp: ChainMap<IgpConfig> = objMap(
       oracleKey: DEPLOYER,
       beneficiary: DEPLOYER,
       overhead: Object.fromEntries(
-        exclude(local, supportedChainNames).map((remote) => [
+        exclude(local, supportedIgpChainNames).map((remote) => [
           remote,
           getOverheadWithOverrides(local, remote),
         ]),

--- a/typescript/infra/config/environments/mainnet3/index.ts
+++ b/typescript/infra/config/environments/mainnet3/index.ts
@@ -10,18 +10,21 @@ import { Role } from '../../../src/roles.js';
 import { Contexts } from '../../contexts.js';
 
 import { agents } from './agent.js';
-import { environment as environmentName, getRegistry } from './chains.js';
+import {
+  environment as environmentName,
+  getRegistry,
+  supportedChainNamesInRegistry,
+} from './chains.js';
 import { core } from './core.js';
 import { keyFunderConfig } from './funding.js';
 import { igp } from './igp.js';
 import { infrastructure } from './infrastructure.js';
 import { chainOwners } from './owners.js';
-import { supportedChainNames } from './supportedChainNames.js';
 import { checkWarpDeployConfig } from './warp/checkWarpDeploy.js';
 
 export const environment: EnvironmentConfig = {
   environment: environmentName,
-  supportedChainNames,
+  supportedChainNames: supportedChainNamesInRegistry,
   getRegistry,
   getMultiProtocolProvider: async () =>
     getMultiProtocolProvider(await getRegistry()),
@@ -32,7 +35,7 @@ export const environment: EnvironmentConfig = {
     chains?: ChainName[],
   ) => {
     const providerChains =
-      chains && chains.length > 0 ? chains : supportedChainNames;
+      chains && chains.length > 0 ? chains : supportedChainNamesInRegistry;
     return getMultiProviderForRole(
       environmentName,
       providerChains,
@@ -45,7 +48,13 @@ export const environment: EnvironmentConfig = {
   getKeys: (
     context: Contexts = Contexts.Hyperlane,
     role: Role = Role.Deployer,
-  ) => getKeysForRole(environmentName, supportedChainNames, context, role),
+  ) =>
+    getKeysForRole(
+      environmentName,
+      supportedChainNamesInRegistry,
+      context,
+      role,
+    ),
   agents,
   core,
   igp,

--- a/typescript/infra/config/environments/mainnet3/tron.ts
+++ b/typescript/infra/config/environments/mainnet3/tron.ts
@@ -139,7 +139,7 @@ export function getTronCoreConfig(
     type: HookType.FALLBACK_ROUTING,
     ...owner,
     domains: Object.fromEntries(
-      TRON_CONNECTED_CHAINS.map((chain) => [
+      tronConnectedChainsWithMultisigs.map((chain) => [
         chain,
         {
           type: HookType.AGGREGATION,

--- a/typescript/infra/config/environments/mainnet3/tron.ts
+++ b/typescript/infra/config/environments/mainnet3/tron.ts
@@ -46,10 +46,17 @@ export const TRON_CONNECTED_CHAINS = [
   'blast',
 ];
 
+const tronConnectedChainsWithMultisigs = TRON_CONNECTED_CHAINS.filter(
+  (chain) => !!defaultMultisigConfigs[chain],
+);
+
 export function getTronIgpConfig(
   owner: OwnableConfig,
   storageGasOracleConfig: Record<string, any>,
 ): IgpConfig {
+  const tronConnectedChains = tronConnectedChainsWithMultisigs.filter(
+    (remote) => !!storageGasOracleConfig['tron']?.[remote],
+  );
   return {
     type: HookType.INTERCHAIN_GAS_PAYMASTER,
     ...owner,
@@ -61,13 +68,13 @@ export function getTronIgpConfig(
     oracleKey: DEPLOYER,
     beneficiary: DEPLOYER,
     overhead: Object.fromEntries(
-      TRON_CONNECTED_CHAINS.map((remote) => [
+      tronConnectedChains.map((remote) => [
         remote,
         getOverheadWithOverrides('tron', remote),
       ]),
     ),
     oracleConfig: Object.fromEntries(
-      TRON_CONNECTED_CHAINS.map((remote) => {
+      tronConnectedChains.map((remote) => {
         const config = storageGasOracleConfig['tron'][remote];
         assert(config, `Missing gas oracle config for tron -> ${remote}`);
         return [remote, config];
@@ -83,7 +90,7 @@ export function getTronCoreConfig(
   const routingIsm: RoutingIsmConfig = {
     type: IsmType.ROUTING,
     domains: Object.fromEntries(
-      TRON_CONNECTED_CHAINS.map((chain) => {
+      tronConnectedChainsWithMultisigs.map((chain) => {
         const multisig = defaultMultisigConfigs[chain];
         const merkleRoot = multisigConfigToIsmConfig(
           IsmType.MERKLE_ROOT_MULTISIG,

--- a/typescript/infra/config/environments/mainnet3/validators.ts
+++ b/typescript/infra/config/environments/mainnet3/validators.ts
@@ -16,11 +16,8 @@ export const validatorChainConfig = (
     supportedChainNamesInRegistry,
   );
   const getReorgPeriod = (chain: ChainName): string | number =>
-    supportedChainNamesInRegistrySet.has(chain)
-      ? resolveReorgPeriod(chain)
-      : 0;
-  return objFilter(
-    {
+    supportedChainNamesInRegistrySet.has(chain) ? resolveReorgPeriod(chain) : 0;
+  const validatorConfigs: ValidatorBaseChainConfigMap = {
     ancient8: {
       interval: 5,
       reorgPeriod: getReorgPeriod('ancient8'),
@@ -1654,7 +1651,10 @@ export const validatorChainConfig = (
         'kiichain',
       ),
     },
-  },
+  };
+
+  return objFilter(
+    validatorConfigs,
     (chain, config): config is ValidatorBaseChainConfigMap[string] =>
       supportedChainNamesInRegistrySet.has(chain),
   );

--- a/typescript/infra/config/environments/mainnet3/validators.ts
+++ b/typescript/infra/config/environments/mainnet3/validators.ts
@@ -1,3 +1,4 @@
+import { ChainName } from '@hyperlane-xyz/sdk';
 import { objFilter } from '@hyperlane-xyz/utils';
 
 import { ValidatorBaseChainConfigMap } from '../../../src/config/agent/validator.js';
@@ -11,14 +12,12 @@ export const validatorChainConfig = (
   context: Contexts,
 ): ValidatorBaseChainConfigMap => {
   const validatorsConfig = validatorBaseConfigsFn(environment, context);
-  const supportedChainNamesInRegistrySet = new Set(supportedChainNamesInRegistry);
-  const getReorgPeriod = (
-    chain: keyof ValidatorBaseChainConfigMap,
-  ): string | number =>
-    supportedChainNamesInRegistrySet.has(chain as string)
-      ? resolveReorgPeriod(
-          chain as Parameters<typeof resolveReorgPeriod>[0],
-        )
+  const supportedChainNamesInRegistrySet = new Set<ChainName>(
+    supportedChainNamesInRegistry,
+  );
+  const getReorgPeriod = (chain: ChainName): string | number =>
+    supportedChainNamesInRegistrySet.has(chain)
+      ? resolveReorgPeriod(chain)
       : 0;
   return objFilter(
     {

--- a/typescript/infra/config/environments/mainnet3/validators.ts
+++ b/typescript/infra/config/environments/mainnet3/validators.ts
@@ -1,15 +1,27 @@
+import { objFilter } from '@hyperlane-xyz/utils';
+
 import { ValidatorBaseChainConfigMap } from '../../../src/config/agent/validator.js';
 import { Contexts } from '../../contexts.js';
-import { getReorgPeriod } from '../../registry.js';
+import { getReorgPeriod as resolveReorgPeriod } from '../../registry.js';
 import { validatorBaseConfigsFn } from '../utils.js';
 
-import { environment } from './chains.js';
+import { environment, supportedChainNamesInRegistry } from './chains.js';
 
 export const validatorChainConfig = (
   context: Contexts,
 ): ValidatorBaseChainConfigMap => {
   const validatorsConfig = validatorBaseConfigsFn(environment, context);
-  return {
+  const supportedChainNamesInRegistrySet = new Set(supportedChainNamesInRegistry);
+  const getReorgPeriod = (
+    chain: keyof ValidatorBaseChainConfigMap,
+  ): string | number =>
+    supportedChainNamesInRegistrySet.has(chain as string)
+      ? resolveReorgPeriod(
+          chain as Parameters<typeof resolveReorgPeriod>[0],
+        )
+      : 0;
+  return objFilter(
+    {
     ancient8: {
       interval: 5,
       reorgPeriod: getReorgPeriod('ancient8'),
@@ -1643,5 +1655,8 @@ export const validatorChainConfig = (
         'kiichain',
       ),
     },
-  };
+  },
+    (chain, config): config is ValidatorBaseChainConfigMap[string] =>
+      supportedChainNamesInRegistrySet.has(chain),
+  );
 };

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -1,4 +1,5 @@
 import {
+  ChainName,
   GasPaymentEnforcement,
   GasPaymentEnforcementPolicyType,
   IsmCacheConfig,
@@ -8,7 +9,7 @@ import {
   ModuleType,
   RpcConsensusType,
 } from '@hyperlane-xyz/sdk';
-import { addressToBytes32 } from '@hyperlane-xyz/utils';
+import { addressToBytes32, objMap } from '@hyperlane-xyz/utils';
 
 import {
   AgentChainConfig,
@@ -34,6 +35,10 @@ import {
   testnet4SupportedChainNames,
 } from './supportedChainNames.js';
 import { validatorChainConfig } from './validators.js';
+
+const supportedChainNamesInRegistrySet = new Set<ChainName>(
+  supportedChainNamesInRegistry,
+);
 
 // The chains here must be consistent with the environment's supportedChainNames, which is
 // checked / enforced at runtime & in the CI pipeline.
@@ -121,8 +126,14 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
 };
 
 export const hyperlaneContextAgentChainNames = getAgentChainNamesFromConfig(
-  hyperlaneContextAgentChainConfig,
-  testnet4SupportedChainNames,
+  objMap(hyperlaneContextAgentChainConfig, (_, roleConfig) =>
+    Object.fromEntries(
+      Object.entries(roleConfig).filter(([chain]) =>
+        supportedChainNamesInRegistrySet.has(chain as ChainName),
+      ),
+    ),
+  ) as AgentChainConfig<typeof supportedChainNamesInRegistry>,
+  supportedChainNamesInRegistry,
 );
 
 const contextBase = {

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -24,7 +24,11 @@ import { Contexts } from '../../contexts.js';
 import { DockerImageRepos, testnetDockerTags } from '../../docker.js';
 import { getDomainId } from '../../registry.js';
 
-import { environment, ethereumChainNames } from './chains.js';
+import {
+  environment,
+  ethereumChainNames,
+  supportedChainNamesInRegistry,
+} from './chains.js';
 import {
   supportedChainNames,
   testnet4SupportedChainNames,
@@ -124,7 +128,7 @@ export const hyperlaneContextAgentChainNames = getAgentChainNamesFromConfig(
 const contextBase = {
   namespace: environment,
   runEnv: environment,
-  environmentChainNames: supportedChainNames,
+  environmentChainNames: supportedChainNamesInRegistry,
   aws: {
     region: 'us-east-1',
   },

--- a/typescript/infra/config/environments/testnet4/chains.ts
+++ b/typescript/infra/config/environments/testnet4/chains.ts
@@ -1,9 +1,10 @@
 import { IRegistry } from '@hyperlane-xyz/registry';
 import { ChainMap, ChainMetadata, ChainName } from '@hyperlane-xyz/sdk';
-import { rootLogger } from '@hyperlane-xyz/utils';
-
 import { getRegistryForEnvironment } from '../../../src/config/chain.js';
-import { getRegistry as getBaseRegistry } from '../../../config/registry.js';
+import {
+  getRegistry as getBaseRegistry,
+  isChainPresentInRegistry,
+} from '../../../config/registry.js';
 import { isEthereumProtocolChain } from '../../../src/utils/utils.js';
 
 import { supportedChainNames } from './supportedChainNames.js';
@@ -12,19 +13,8 @@ export const environment = 'testnet4';
 
 const baseRegistry = getBaseRegistry();
 
-function isChainPresentInBaseRegistry(chainName: ChainName): boolean {
-  const chainMetadata = baseRegistry.getChainMetadata(chainName);
-  if (!chainMetadata) {
-    rootLogger.warn(
-      { chainName },
-      'Skipping chain missing from base registry while deriving chain lists',
-    );
-  }
-  return !!chainMetadata;
-}
-
 export const supportedChainNamesInRegistry = supportedChainNames.filter(
-  isChainPresentInBaseRegistry,
+  (chainName) => isChainPresentInRegistry(baseRegistry, environment, chainName),
 );
 
 export const ethereumChainNames = supportedChainNamesInRegistry.filter(

--- a/typescript/infra/config/environments/testnet4/chains.ts
+++ b/typescript/infra/config/environments/testnet4/chains.ts
@@ -1,14 +1,33 @@
 import { IRegistry } from '@hyperlane-xyz/registry';
 import { ChainMap, ChainMetadata, ChainName } from '@hyperlane-xyz/sdk';
+import { rootLogger } from '@hyperlane-xyz/utils';
 
 import { getRegistryForEnvironment } from '../../../src/config/chain.js';
+import { getRegistry as getBaseRegistry } from '../../../config/registry.js';
 import { isEthereumProtocolChain } from '../../../src/utils/utils.js';
 
 import { supportedChainNames } from './supportedChainNames.js';
 
 export const environment = 'testnet4';
 
-export const ethereumChainNames = supportedChainNames.filter(
+const baseRegistry = getBaseRegistry();
+
+function isChainPresentInBaseRegistry(chainName: ChainName): boolean {
+  const chainMetadata = baseRegistry.getChainMetadata(chainName);
+  if (!chainMetadata) {
+    rootLogger.warn(
+      { chainName },
+      'Skipping chain missing from base registry while deriving chain lists',
+    );
+  }
+  return !!chainMetadata;
+}
+
+export const supportedChainNamesInRegistry = supportedChainNames.filter(
+  isChainPresentInBaseRegistry,
+);
+
+export const ethereumChainNames = supportedChainNamesInRegistry.filter(
   isEthereumProtocolChain,
 );
 
@@ -36,7 +55,7 @@ export const chainMetadataOverrides: ChainMap<Partial<ChainMetadata>> = {
 
 export const getRegistry = async (
   useSecrets = true,
-  chains: ChainName[] = supportedChainNames,
+  chains: ChainName[] = supportedChainNamesInRegistry,
 ): Promise<IRegistry> =>
   getRegistryForEnvironment(
     environment,

--- a/typescript/infra/config/environments/testnet4/core.ts
+++ b/typescript/infra/config/environments/testnet4/core.ts
@@ -26,7 +26,7 @@ import { getChain } from '../../registry.js';
 
 import { igp } from './igp.js';
 import { ethereumChainOwners } from './owners.js';
-import { supportedChainNames } from './supportedChainNames.js';
+import { supportedChainNamesInRegistry } from './chains.js';
 
 // Rome Testnet is an EVM within an SVM, and so the gas metering is vastly different to vanilla EVM.
 // Owing to this, the gas usage numbers are 10-12x higher due to the different metering.
@@ -37,8 +37,8 @@ import { supportedChainNames } from './supportedChainNames.js';
 export const core: ChainMap<CoreConfig> = objMap(
   ethereumChainOwners,
   (local, owner) => {
-    const connectedChains = supportedChainNames.filter(
-      (chain) => chain !== local,
+    const connectedChains = supportedChainNamesInRegistry.filter(
+      (chain) => chain !== local && !!defaultMultisigConfigs[chain],
     );
 
     // Create a map of connected chains to their default multisig configs

--- a/typescript/infra/config/environments/testnet4/igp.ts
+++ b/typescript/infra/config/environments/testnet4/igp.ts
@@ -1,5 +1,5 @@
 import { ChainMap, ChainName, HookType, IgpConfig } from '@hyperlane-xyz/sdk';
-import { Address, exclude, objMap } from '@hyperlane-xyz/utils';
+import { Address, exclude, objFilter, objMap } from '@hyperlane-xyz/utils';
 
 import {
   AllStorageGasOracleConfigs,
@@ -38,8 +38,14 @@ export const storageGasOracleConfig: AllStorageGasOracleConfigs =
     false,
   );
 
-export const igp: ChainMap<IgpConfig> = objMap(
+const supportedIgpOwners = objFilter(
   owners,
+  (chain, ownerConfig): ownerConfig is (typeof owners)[string] =>
+    chain in storageGasOracleConfig,
+);
+
+export const igp: ChainMap<IgpConfig> = objMap(
+  supportedIgpOwners,
   (chain, ownerConfig): IgpConfig => {
     return {
       type: HookType.INTERCHAIN_GAS_PAYMASTER,

--- a/typescript/infra/config/environments/testnet4/igp.ts
+++ b/typescript/infra/config/environments/testnet4/igp.ts
@@ -7,9 +7,9 @@ import {
   getOverhead,
 } from '../../../src/config/gas-oracle.js';
 
+import { supportedChainNamesInRegistry } from './chains.js';
 import gasPrices from './gasPrices.json' with { type: 'json' };
 import { owners } from './owners.js';
-import { supportedChainNames } from './supportedChainNames.js';
 import rawTokenPrices from './tokenPrices.json' with { type: 'json' };
 
 const tokenPrices: ChainMap<string> = rawTokenPrices;
@@ -31,7 +31,7 @@ function getOracleConfigWithOverrides(origin: ChainName) {
 
 export const storageGasOracleConfig: AllStorageGasOracleConfigs =
   getAllStorageGasOracleConfigs(
-    supportedChainNames,
+    supportedChainNamesInRegistry,
     tokenPrices,
     gasPrices,
     (local, remote) => getOverheadWithOverrides(local, remote),
@@ -49,7 +49,7 @@ export const igp: ChainMap<IgpConfig> = objMap(
       oracleConfig: getOracleConfigWithOverrides(chain),
       overhead: Object.fromEntries(
         // no need to set overhead for chain to itself
-        exclude(chain, supportedChainNames).map((remote) => [
+        exclude(chain, supportedChainNamesInRegistry).map((remote) => [
           remote,
           getOverheadWithOverrides(chain, remote),
         ]),

--- a/typescript/infra/config/environments/testnet4/index.ts
+++ b/typescript/infra/config/environments/testnet4/index.ts
@@ -15,17 +15,16 @@ import { agents } from './agent.js';
 import {
   chainMetadataOverrides,
   environment as environmentName,
+  supportedChainNamesInRegistry,
 } from './chains.js';
 import { core } from './core.js';
 import { keyFunderConfig } from './funding.js';
 import { igp } from './igp.js';
 import { infrastructure } from './infrastructure.js';
 import { owners } from './owners.js';
-import { supportedChainNames } from './supportedChainNames.js';
-
 const getRegistry = async (
   useSecrets = true,
-  chains: ChainName[] = supportedChainNames,
+  chains: ChainName[] = supportedChainNamesInRegistry,
 ): Promise<IRegistry> =>
   getRegistryForEnvironment(
     environmentName,
@@ -36,7 +35,7 @@ const getRegistry = async (
 
 export const environment: EnvironmentConfig = {
   environment: environmentName,
-  supportedChainNames,
+  supportedChainNames: supportedChainNamesInRegistry,
   getRegistry,
   getMultiProtocolProvider: async () =>
     getMultiProtocolProvider(await getRegistry()),
@@ -47,7 +46,7 @@ export const environment: EnvironmentConfig = {
     chains?: ChainName[],
   ) => {
     const providerChains =
-      chains && chains.length > 0 ? chains : supportedChainNames;
+      chains && chains.length > 0 ? chains : supportedChainNamesInRegistry;
     return getMultiProviderForRole(
       environmentName,
       providerChains,
@@ -60,7 +59,13 @@ export const environment: EnvironmentConfig = {
   getKeys: (
     context: Contexts = Contexts.Hyperlane,
     role: Role = Role.Deployer,
-  ) => getKeysForRole(environmentName, supportedChainNames, context, role),
+  ) =>
+    getKeysForRole(
+      environmentName,
+      supportedChainNamesInRegistry,
+      context,
+      role,
+    ),
   agents,
   core,
   igp,

--- a/typescript/infra/config/environments/testnet4/validators.ts
+++ b/typescript/infra/config/environments/testnet4/validators.ts
@@ -16,11 +16,8 @@ export const validatorChainConfig = (
     supportedChainNamesInRegistry,
   );
   const getReorgPeriod = (chain: ChainName): string | number =>
-    supportedChainNamesInRegistrySet.has(chain)
-      ? resolveReorgPeriod(chain)
-      : 0;
-  return objFilter(
-    {
+    supportedChainNamesInRegistrySet.has(chain) ? resolveReorgPeriod(chain) : 0;
+  const validatorConfigs: ValidatorBaseChainConfigMap = {
     arbitrumsepolia: {
       interval: 5,
       reorgPeriod: getReorgPeriod('arbitrumsepolia'),
@@ -301,7 +298,10 @@ export const validatorChainConfig = (
         'tronshasta',
       ),
     },
-  },
+  };
+
+  return objFilter(
+    validatorConfigs,
     (chain, config): config is ValidatorBaseChainConfigMap[string] =>
       supportedChainNamesInRegistrySet.has(chain),
   );

--- a/typescript/infra/config/environments/testnet4/validators.ts
+++ b/typescript/infra/config/environments/testnet4/validators.ts
@@ -1,3 +1,4 @@
+import { ChainName } from '@hyperlane-xyz/sdk';
 import { objFilter } from '@hyperlane-xyz/utils';
 
 import { ValidatorBaseChainConfigMap } from '../../../src/config/agent/validator.js';
@@ -11,14 +12,12 @@ export const validatorChainConfig = (
   context: Contexts,
 ): ValidatorBaseChainConfigMap => {
   const validatorsConfig = validatorBaseConfigsFn(environment, context);
-  const supportedChainNamesInRegistrySet = new Set(supportedChainNamesInRegistry);
-  const getReorgPeriod = (
-    chain: keyof ValidatorBaseChainConfigMap,
-  ): string | number =>
-    supportedChainNamesInRegistrySet.has(chain as string)
-      ? resolveReorgPeriod(
-          chain as Parameters<typeof resolveReorgPeriod>[0],
-        )
+  const supportedChainNamesInRegistrySet = new Set<ChainName>(
+    supportedChainNamesInRegistry,
+  );
+  const getReorgPeriod = (chain: ChainName): string | number =>
+    supportedChainNamesInRegistrySet.has(chain)
+      ? resolveReorgPeriod(chain)
       : 0;
   return objFilter(
     {

--- a/typescript/infra/config/environments/testnet4/validators.ts
+++ b/typescript/infra/config/environments/testnet4/validators.ts
@@ -1,15 +1,27 @@
+import { objFilter } from '@hyperlane-xyz/utils';
+
 import { ValidatorBaseChainConfigMap } from '../../../src/config/agent/validator.js';
 import { Contexts } from '../../contexts.js';
-import { getReorgPeriod } from '../../registry.js';
+import { getReorgPeriod as resolveReorgPeriod } from '../../registry.js';
 import { validatorBaseConfigsFn } from '../utils.js';
 
-import { environment } from './chains.js';
+import { environment, supportedChainNamesInRegistry } from './chains.js';
 
 export const validatorChainConfig = (
   context: Contexts,
 ): ValidatorBaseChainConfigMap => {
   const validatorsConfig = validatorBaseConfigsFn(environment, context);
-  return {
+  const supportedChainNamesInRegistrySet = new Set(supportedChainNamesInRegistry);
+  const getReorgPeriod = (
+    chain: keyof ValidatorBaseChainConfigMap,
+  ): string | number =>
+    supportedChainNamesInRegistrySet.has(chain as string)
+      ? resolveReorgPeriod(
+          chain as Parameters<typeof resolveReorgPeriod>[0],
+        )
+      : 0;
+  return objFilter(
+    {
     arbitrumsepolia: {
       interval: 5,
       reorgPeriod: getReorgPeriod('arbitrumsepolia'),
@@ -290,5 +302,8 @@ export const validatorChainConfig = (
         'tronshasta',
       ),
     },
-  };
+  },
+    (chain, config): config is ValidatorBaseChainConfigMap[string] =>
+      supportedChainNamesInRegistrySet.has(chain),
+  );
 };

--- a/typescript/infra/config/registry.ts
+++ b/typescript/infra/config/registry.ts
@@ -74,6 +74,21 @@ export function getRegistry(): FileSystemRegistry {
   return registry;
 }
 
+export function isChainPresentInRegistry(
+  registry: Pick<FileSystemRegistry, 'getChainMetadata'>,
+  environment: string,
+  chainName: ChainName,
+): boolean {
+  const chainMetadata = registry.getChainMetadata(chainName);
+  if (!chainMetadata) {
+    rootLogger.warn(
+      { chainName, environment },
+      'Skipping chain missing from base registry while deriving chain lists',
+    );
+  }
+  return !!chainMetadata;
+}
+
 function getRegistryFromUris(registryUris?: string[]): IRegistry {
   if (registryUris && registryUris.length > 0) {
     return getMergedRegistry({ registryUris, enableProxy: true });

--- a/typescript/infra/src/config/gas-oracle.ts
+++ b/typescript/infra/src/config/gas-oracle.ts
@@ -353,6 +353,10 @@ export function getOverhead(local: ChainName, remote: ChainName): number {
 
   if (isEVMLike(remoteProtocol)) {
     if (!localMultisigConfig) {
+      rootLogger.warn(
+        { local, remote, remoteProtocol },
+        'Missing local multisig config while deriving overhead; using default',
+      );
       return FOREIGN_DEFAULT_OVERHEAD;
     }
     return multisigIsmVerificationCost(
@@ -362,9 +366,14 @@ export function getOverhead(local: ChainName, remote: ChainName): number {
   }
 
   if (remoteProtocol === ProtocolType.Starknet) {
-    return localMultisigConfig
-      ? 10_000_000 + 40_000_000 * localMultisigConfig.threshold
-      : FOREIGN_DEFAULT_OVERHEAD;
+    if (!localMultisigConfig) {
+      rootLogger.warn(
+        { local, remote, remoteProtocol },
+        'Missing local multisig config while deriving overhead; using default',
+      );
+      return FOREIGN_DEFAULT_OVERHEAD;
+    }
+    return 10_000_000 + 40_000_000 * localMultisigConfig.threshold;
   }
 
   if (remoteProtocol === ProtocolType.Aleo) {

--- a/typescript/infra/src/config/gas-oracle.ts
+++ b/typescript/infra/src/config/gas-oracle.ts
@@ -349,16 +349,22 @@ const FOREIGN_DEFAULT_OVERHEAD = 600_000;
 // Overhead for interchain messaging
 export function getOverhead(local: ChainName, remote: ChainName): number {
   const remoteProtocol = getChain(remote).protocol;
+  const localMultisigConfig = defaultMultisigConfigs[local];
 
   if (isEVMLike(remoteProtocol)) {
+    if (!localMultisigConfig) {
+      return FOREIGN_DEFAULT_OVERHEAD;
+    }
     return multisigIsmVerificationCost(
-      defaultMultisigConfigs[local].threshold,
-      defaultMultisigConfigs[local].validators.length,
+      localMultisigConfig.threshold,
+      localMultisigConfig.validators.length,
     );
   }
 
   if (remoteProtocol === ProtocolType.Starknet) {
-    return 10_000_000 + 40_000_000 * defaultMultisigConfigs[local].threshold;
+    return localMultisigConfig
+      ? 10_000_000 + 40_000_000 * localMultisigConfig.threshold
+      : FOREIGN_DEFAULT_OVERHEAD;
   }
 
   if (remoteProtocol === ProtocolType.Aleo) {


### PR DESCRIPTION
## Summary
- filter environment chain lists against the base registry before deriving agent and validator config
- keep mainnet3/testnet4 validator and index config aligned with the filtered chain sets
- narrow mainnet3 igp/core/tron startup paths so the private http registry can initialize even when deprecated chains are still listed in supportedChainNames

## Validation
- ran `pnpm -C typescript/infra start:http-registry -- --environment mainnet3 --port 3333`
- confirmed startup now gets past the previous missing-chain crashes and reaches GCP secret fetch / registry initialization
- repo-wide `tsc --noEmit` still has unrelated pre-existing failures outside this diff
