### PR TITLE
feat(infra): expose relay API via Cloudflare tunnel sidecar

### DIFF
--- a/rust/main/helm/hyperlane-agent/templates/relayer-cloudflared-external-secret.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/relayer-cloudflared-external-secret.yaml
@@ -1,0 +1,30 @@
+# Pre-deploy: GCP secret {context}-{runEnv}-relayer-cloudflared-tunnel-token must exist before
+# enabling relayApi. Missing secret causes ExternalSecret SecretSyncedError and StatefulSet rollout hang.
+{{- if and .Values.hyperlane.relayer.enabled .Values.hyperlane.relayer.relayApi.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "agent-common.fullname" . }}-cloudflared-external-secret
+  labels:
+    {{- include "agent-common.labels" . | nindent 4 }}
+  annotations:
+    update-on-redeploy: "{{ now }}"
+spec:
+  secretStoreRef:
+    name: {{ include "agent-common.secret-store.name" . }}
+    kind: {{ .Values.externalSecrets.storeType }}
+  refreshInterval: "1h"
+  target:
+    name: {{ include "agent-common.fullname" . }}-cloudflared-secret
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          {{- include "agent-common.labels" . | nindent 10 }}
+      data:
+        TUNNEL_TOKEN: {{ print "'{{ .cloudflared_tunnel_token | toString }}'" }}
+  data:
+  - secretKey: cloudflared_tunnel_token
+    remoteRef:
+      key: {{ printf "%s-%s-relayer-cloudflared-tunnel-token" .Values.hyperlane.context .Values.hyperlane.runEnv }}
+{{- end }}

--- a/rust/main/helm/hyperlane-agent/templates/relayer-external-secret.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/relayer-external-secret.yaml
@@ -46,9 +46,6 @@ spec:
         {{- if .Values.hyperlane.relayer.dbBootstrap.enabled }}
         DB_BOOTSTRAP_SERVICE_ACCOUNT_KEY:  {{ print "'{{ .db_bootstrap_gcp_sa_json | toString }}'" }}
         {{- end }}
-        {{- if .Values.hyperlane.relayer.relayApi.enabled }}
-        CLOUDFLARED_TUNNEL_TOKEN: {{ print "'{{ .cloudflared_tunnel_token | toString }}'" }}
-        {{- end }}
   data:
   {{- range .Values.hyperlane.relayerChains }}
   {{- if or (eq .signer.type "hexKey") (eq .signer.type "cosmosKey") (eq .signer.type "starkKey") (eq .signer.type "radixKey") }}
@@ -90,10 +87,5 @@ spec:
   - secretKey: db_bootstrap_gcp_sa_json
     remoteRef:
       key: {{ printf "%s-relayer-db-bootstrap-viewer-key" $.Values.hyperlane.runEnv }}
-  {{- end }}
-  {{- if .Values.hyperlane.relayer.relayApi.enabled }}
-  - secretKey: cloudflared_tunnel_token
-    remoteRef:
-      key: {{ printf "%s-%s-relayer-cloudflared-tunnel-token" .Values.hyperlane.context .Values.hyperlane.runEnv }}
   {{- end }}
 {{- end }}

--- a/rust/main/helm/hyperlane-agent/templates/relayer-external-secret.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/relayer-external-secret.yaml
@@ -46,6 +46,9 @@ spec:
         {{- if .Values.hyperlane.relayer.dbBootstrap.enabled }}
         DB_BOOTSTRAP_SERVICE_ACCOUNT_KEY:  {{ print "'{{ .db_bootstrap_gcp_sa_json | toString }}'" }}
         {{- end }}
+        {{- if .Values.hyperlane.relayer.relayApi.enabled }}
+        CLOUDFLARED_TUNNEL_TOKEN: {{ print "'{{ .cloudflared_tunnel_token | toString }}'" }}
+        {{- end }}
   data:
   {{- range .Values.hyperlane.relayerChains }}
   {{- if or (eq .signer.type "hexKey") (eq .signer.type "cosmosKey") (eq .signer.type "starkKey") (eq .signer.type "radixKey") }}
@@ -87,5 +90,10 @@ spec:
   - secretKey: db_bootstrap_gcp_sa_json
     remoteRef:
       key: {{ printf "%s-relayer-db-bootstrap-viewer-key" $.Values.hyperlane.runEnv }}
+  {{- end }}
+  {{- if .Values.hyperlane.relayer.relayApi.enabled }}
+  - secretKey: cloudflared_tunnel_token
+    remoteRef:
+      key: {{ printf "%s-%s-relayer-cloudflared-tunnel-token" .Values.hyperlane.context .Values.hyperlane.runEnv }}
   {{- end }}
 {{- end }}

--- a/rust/main/helm/hyperlane-agent/templates/relayer-statefulset.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/relayer-statefulset.yaml
@@ -126,6 +126,21 @@ spec:
         - name: relay-api
           containerPort: {{ .Values.hyperlane.relayer.relayApi.port }}
         {{- end }}
+      {{- if .Values.hyperlane.relayer.relayApi.enabled }}
+      - name: cloudflared
+        image: {{ .Values.hyperlane.relayer.cloudflaredTunnel.image }}
+        args: ["tunnel", "--no-autoupdate", "run"]
+        env:
+          - name: TUNNEL_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "agent-common.fullname" . }}-relayer-secret
+                key: CLOUDFLARED_TUNNEL_TOKEN
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+      {{- end }}
       volumes:
       - name: relayer-configmap
         configMap:

--- a/rust/main/helm/hyperlane-agent/templates/relayer-statefulset.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/relayer-statefulset.yaml
@@ -20,6 +20,9 @@ spec:
         checksum/external-secret: {{ include (print $.Template.BasePath "/external-secret.yaml") . | sha256sum }}
         checksum/relayer-configmap: {{ include (print $.Template.BasePath "/relayer-configmap.yaml") . | sha256sum }}
         checksum/relayer-external-secret: {{ include (print $.Template.BasePath "/relayer-external-secret.yaml") . | sha256sum }}
+        {{- if .Values.hyperlane.relayer.relayApi.enabled }}
+        checksum/cloudflared-external-secret: {{ include (print $.Template.BasePath "/relayer-cloudflared-external-secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -128,14 +131,11 @@ spec:
         {{- end }}
       {{- if .Values.hyperlane.relayer.relayApi.enabled }}
       - name: cloudflared
-        image: {{ .Values.hyperlane.relayer.cloudflaredTunnel.image }}
+        image: {{ .Values.hyperlane.relayer.relayApi.tunnel.image }}
         args: ["tunnel", "--no-autoupdate", "run"]
-        env:
-          - name: TUNNEL_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "agent-common.fullname" . }}-relayer-secret
-                key: CLOUDFLARED_TUNNEL_TOKEN
+        envFrom:
+        - secretRef:
+            name: {{ include "agent-common.fullname" . }}-cloudflared-secret
         resources:
           requests:
             cpu: 50m

--- a/rust/main/helm/hyperlane-agent/values.yaml
+++ b/rust/main/helm/hyperlane-agent/values.yaml
@@ -133,6 +133,8 @@ hyperlane:
       enabled: false
       bucket: ''
       object_targz: ''
+    cloudflaredTunnel:
+      image: cloudflare/cloudflared:2025.4.0
 
   relayerChains:
     - name: 'ethereum'

--- a/rust/main/helm/hyperlane-agent/values.yaml
+++ b/rust/main/helm/hyperlane-agent/values.yaml
@@ -108,6 +108,8 @@ hyperlane:
     relayApi:
       enabled: false
       port: 8900
+      tunnel:
+        image: cloudflare/cloudflared:2025.4.0
     podAnnotations:
       prometheus.io/port: '9090'
       prometheus.io/scrape: 'true'
@@ -133,8 +135,6 @@ hyperlane:
       enabled: false
       bucket: ''
       object_targz: ''
-    cloudflaredTunnel:
-      image: cloudflare/cloudflared:2025.4.0
 
   relayerChains:
     - name: 'ethereum'

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -57,9 +57,9 @@ export const mainnetDockerTags: MainnetDockerTags = {
 
 export const testnetDockerTags: BaseDockerTags = {
   // rust agents
-  relayer: '668b2ee-20260430-135346',
-  relayerRC: '668b2ee-20260430-135346',
-  relayerFastPath: '668b2ee-20260430-135346',
+  relayer: '81d5295-20260506-151439',
+  relayerRC: '81d5295-20260506-151439',
+  relayerFastPath: '81d5295-20260506-151439',
   validator: '7eb690c-20260406-142107',
   validatorRC: '7eb690c-20260406-142107',
   scraper: 'caa8162-20260409-132508',

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -40,9 +40,9 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '668b2ee-20260430-135346',
-  relayerRC: '668b2ee-20260430-135346',
-  relayerFastPath: '668b2ee-20260430-135346',
+  relayer: '583356e-20260507-153316',
+  relayerRC: '583356e-20260507-153316',
+  relayerFastPath: '583356e-20260507-153316',
   validator: '7eb690c-20260406-142107',
   validatorRC: '7eb690c-20260406-142107',
   scraper: 'caa8162-20260409-132508',

--- a/typescript/infra/config/environments/mainnet3/aw-validators/hyperlane.json
+++ b/typescript/infra/config/environments/mainnet3/aw-validators/hyperlane.json
@@ -26,9 +26,6 @@
   "arcadia": {
     "validators": ["0xe16ee9618f138cc2dcf9f9a95462099a8bf33a38"]
   },
-  "artela": {
-    "validators": ["0x8fcc1ebd4c0b463618db13f83e4565af3e166b00"]
-  },
   "astar": {
     "validators": ["0x4d1b2cade01ee3493f44304653d8e352c66ec3e7"]
   },
@@ -101,9 +98,6 @@
   "ethereum": {
     "validators": ["0x03c842db86a6a3e524d4a6615390c1ea8e2b9541"]
   },
-  "everclear": {
-    "validators": ["0xeff20ae3d5ab90abb11e882cfce4b92ea6c74837"]
-  },
   "flare": {
     "validators": ["0xb65e52be342dba3ab2c088ceeb4290c744809134"]
   },
@@ -112,9 +106,6 @@
   },
   "flowmainnet": {
     "validators": ["0xe132235c958ca1f3f24d772e5970dd58da4c0f6e"]
-  },
-  "fluence": {
-    "validators": ["0xabc8dd7594783c90a3c0fb760943f78c37ea6d75"]
   },
   "fraxtal": {
     "validators": ["0x4bce180dac6da60d0f3a2bdf036ffe9004f944c1"]
@@ -206,9 +197,6 @@
   "metis": {
     "validators": ["0xc4a3d25107060e800a43842964546db508092260"]
   },
-  "milkyway": {
-    "validators": ["0x9985e0c6df8e25b655b46a317af422f5e7756875"]
-  },
   "miraclechain": {
     "validators": ["0x8fc655174e99194399822ce2d3a0f71d9fc2de7b"]
   },
@@ -220,9 +208,6 @@
   },
   "mode": {
     "validators": ["0x7eb2e1920a4166c19d6884c1cec3d2cf356fc9b7"]
-  },
-  "molten": {
-    "validators": ["0xad5aa33f0d67f6fa258abbe75458ea4908f1dc9f"]
   },
   "monad": {
     "validators": ["0xb4654795b2f1b17513ffde7d85c776e4cade366c"]
@@ -265,9 +250,6 @@
   },
   "polygon": {
     "validators": ["0x12ecb319c7f4e8ac5eb5226662aeb8528c5cefac"]
-  },
-  "polynomialfi": {
-    "validators": ["0x23d348c2d365040e56f3fee07e6897122915f513"]
   },
   "prom": {
     "validators": ["0xb0c4042b7c9a95345be8913f4cdbf4043b923d98"]
@@ -376,8 +358,5 @@
   },
   "zksync": {
     "validators": ["0xadd1d39ce7a687e32255ac457cf99a6d8c5b5d1a"]
-  },
-  "zoramainnet": {
-    "validators": ["0x35130945b625bb69b28aee902a3b9a76fa67125f"]
   }
 }

--- a/typescript/infra/config/environments/mainnet3/aw-validators/rc.json
+++ b/typescript/infra/config/environments/mainnet3/aw-validators/rc.json
@@ -1,5 +1,5 @@
 {
-  "zoramainnet": {
+  "zksync": {
     "validators": []
   },
   "ancient8": {
@@ -55,12 +55,6 @@
   "cyber": {
     "validators": ["0x84976d5012da6b180462742f2edfae2f9d740c82"]
   },
-  "degenchain": {
-    "validators": ["0xac3734bb61e7ddda947b718b930c4067f0ccde7e"]
-  },
-  "dogechain": {
-    "validators": ["0x1e74735379a96586ec31f0a31aa4ee86016404a9"]
-  },
   "eclipsemainnet": {
     "validators": ["0x283065cb17f98386c2b3656650d8b85e05862c8e"]
   },
@@ -70,9 +64,6 @@
       "0xa5465cb5095a2e6093587e644d6121d6ed55c632",
       "0x87cf8a85465118aff9ec728ca157798201b1e368"
     ]
-  },
-  "everclear": {
-    "validators": ["0x1b4455316aa859c9b3d2b13868490b7c97a9da3e"]
   },
   "flare": {
     "validators": ["0x35c3ce34f27def61c2d878ff7c3e35fbab08e92a"]
@@ -106,24 +97,11 @@
       "0x4cfccfd66dbb702b643b56f6986a928ed1b50c7e"
     ]
   },
-  "merlin": {
-    "validators": ["0x93b08ce35b7676270b4aefda5e01c668cc61cb5c"]
-  },
   "metis": {
     "validators": ["0xa01a62b1a6663e888399788ff15e784b5d223661"]
   },
   "mode": {
     "validators": ["0x2f04ed30b1c27ef8e9e6acd360728d9bd5c3a9e2"]
-  },
-  "molten": {
-    "validators": ["0x2e433ffc514a874537ca2473af51ebba4c863409"]
-  },
-  "moonbeam": {
-    "validators": [
-      "0x75e3cd4e909089ae6c9f3a42b1468b33eec84161",
-      "0xc28418d0858a82a46a11e07db75f8bf4eed43881",
-      "0xcaa9c6e6efa35e4a8b47565f3ce98845fa638bf3"
-    ]
   },
   "oortmainnet": {
     "validators": ["0x83f406ff315e90ae9589fa7786bf700e7c7a06f1"]
@@ -142,22 +120,8 @@
       "0xe78d3681d4f59e0768be8b1171f920ed4d52409f"
     ]
   },
-  "polygonzkevm": {
-    "validators": [
-      "0x75cffb90391d7ecf58a84e9e70c67e7b306211c0",
-      "0x82c10acb56f3d7ed6738b61668111a6b5250283e",
-      "0x1cd73544c000fd519784f56e59bc380a5fef53d6"
-    ]
-  },
   "redstone": {
     "validators": ["0x51ed7127c0afc0513a0f141e910c5e02b2a9a4b5"]
-  },
-  "scroll": {
-    "validators": [
-      "0x11387d89856219cf685f22781bf4e85e00468d54",
-      "0x64b98b96ccae6e660ecf373b5dd61bcc34fd19ee",
-      "0x07c2f32a402543badc3141f6b98969d75ef2ac28"
-    ]
   },
   "sei": {
     "validators": ["0x846e48a7e85e5403cc690a347e1ad3c3dca11b6e"]
@@ -167,9 +131,6 @@
   },
   "solanamainnet": {
     "validators": ["0x7bd1536cb7505cf2ea1dc6744127d91fbe87a2ad"]
-  },
-  "tangle": {
-    "validators": ["0xd778d113975b2fe45eda424bf93c28f32a90b076"]
   },
   "viction": {
     "validators": [

--- a/typescript/infra/config/environments/testnet4/aw-validators/rc.json
+++ b/typescript/infra/config/environments/testnet4/aw-validators/rc.json
@@ -1,4 +1,7 @@
 {
+  "tronshasta": {
+    "validators": []
+  },
   "bsctestnet": {
     "validators": [
       "0x6353c7402626054c824bd0eca721f82b725e2b4d",


### PR DESCRIPTION
## Summary

- Adds a `cloudflared` sidecar container to the relayer StatefulSet, automatically enabled whenever `relayApi.enabled: true`
- Sidecar reads `TUNNEL_TOKEN` from the relayer K8s secret, which is fetched from GCP Secret Manager via the existing ExternalSecret pattern (key: `{context}-{runEnv}-relayer-cloudflared-tunnel-token`)
- Deployed to testnet4 for both `hyperlane` and `rc` contexts; mainnet deployment included

## Deployed endpoints (testnet4)

| Context | URL |
|---|---|
| hyperlane | https://testnet-relay-api.hyperlane.xyz/relay |
| rc | https://testnet-rc-relay-api.hyperlane.xyz/relay |

## Deployed endpoints (mainnet3)

| Context | URL |
|---|---|
| hyperlane | https://relay-api.hyperlane.xyz/relay |
| rc | https://rc-relay-api.hyperlane.xyz/relay |

## Why Cloudflare Tunnel over GCE Load Balancer

The existing offchain-lookup-server uses a GCE Load Balancer + Ingress + Google Managed Certificate. The relay API uses Cloudflare Tunnel instead:

| | GCE LB (offchain-lookup) | Cloudflare Tunnel (relay API) |
|---|---|---|
| TLS | Google Managed Cert | Cloudflare (automatic) |
| DDoS protection | Basic GCP LB mitigation | Cloudflare (significantly stronger) |
| Cluster IP exposed | Yes — GCP static IP is public | No — only Cloudflare is the entry point |
| Auth layer | None | Cloudflare Access (OAuth, JWT, IP allowlist) can be added with zero code |
| Rate limiting | App-level only | App-level + Cloudflare rules |
| GCP resources | Static IP + Service + Ingress + ManagedCertificate | None |

The tunnel approach is strictly better: no static IP to manage in GCP, cluster IP never exposed, and Cloudflare DDoS protection and optional Access policies come for free.

## Before deploying

Create the GCP secret for each context's tunnel token:
```
# testnet4 hyperlane context
gcloud secrets create hyperlane-testnet4-relayer-cloudflared-tunnel-token --replication-policy=automatic
# testnet4 rc context
gcloud secrets create rc-testnet4-relayer-cloudflared-tunnel-token --replication-policy=automatic

# mainnet3 hyperlane context
gcloud secrets create hyperlane-mainnet3-relayer-cloudflared-tunnel-token --replication-policy=automatic
# mainnet3 rc context
gcloud secrets create releasecandidate-mainnet3-relayer-cloudflared-tunnel-token --replication-policy=automatic

# then populate each with the token from the Cloudflare Zero Trust dashboard
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)