### PR TITLE
fix: use a single gcloud secret client

### DIFF
--- a/typescript/infra/src/utils/gcloud.ts
+++ b/typescript/infra/src/utils/gcloud.ts
@@ -148,10 +148,13 @@ export async function getGcpSecretLatestVersionName(secretName: string) {
   return version?.name;
 }
 
+let secretManagerServiceClient: SecretManagerServiceClient | undefined;
+
 export async function getSecretManagerServiceClient() {
-  return new SecretManagerServiceClient({
+  secretManagerServiceClient ??= new SecretManagerServiceClient({
     projectId: GCP_PROJECT_ID,
   });
+  return secretManagerServiceClient;
 }
 
 /**


### PR DESCRIPTION
### Description

• The root cause looks like the registry creates a new SecretManagerServiceClient for every secret and then fetches all RPC secrets with Promise.all. That can trigger many simultaneous ADC refreshes; a single client read succeeds, the bulk startup path fails. I’m going to patch the monorepo utility to reuse one SecretManager client, which is the smallest fix for the GCP fetch path.