### PR TITLE
perf: cache shared external clients

### DIFF
--- a/.changeset/cache-shared-client-connections.md
+++ b/.changeset/cache-shared-client-connections.md
@@ -3,4 +3,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-Cosmos fee estimation clients are cached by reusing Stargate client connections across repeated estimates, with cache eviction on failures.
+Cosmos fee estimation clients were cached by reusing Stargate client connections across repeated estimates, with cache eviction on failures.

--- a/.changeset/cache-shared-client-connections.md
+++ b/.changeset/cache-shared-client-connections.md
@@ -3,4 +3,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-Cosmos fee estimation clients are cached by reusing Stargate client connections across repeated estimates.
+Cosmos fee estimation clients are cached by reusing Stargate client connections across repeated estimates, with cache eviction on failures.

--- a/.changeset/cache-shared-client-connections.md
+++ b/.changeset/cache-shared-client-connections.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cosmos-sdk': patch
+'@hyperlane-xyz/sdk': patch
+---
+
+Cosmos fee estimation clients are cached by reusing Stargate client connections across repeated estimates.

--- a/typescript/cosmos-sdk/src/clients/provider.ts
+++ b/typescript/cosmos-sdk/src/clients/provider.ts
@@ -172,6 +172,8 @@ export class CosmosNativeProvider implements AltVM.IProvider<EncodeObject> {
   private evictStargateClient(client: Promise<StargateClient>): void {
     if (this.stargateClient !== client) return;
 
+    // Disconnecting an evicted shared client can fail concurrent estimates on
+    // this provider, but avoids keeping a poisoned socket cached.
     this.stargateClient = undefined;
     void client.then(
       (stargateClient) => stargateClient.disconnect(),

--- a/typescript/cosmos-sdk/src/clients/provider.ts
+++ b/typescript/cosmos-sdk/src/clients/provider.ts
@@ -26,6 +26,10 @@ import {
 import { COSMOS_MODULE_MESSAGE_REGISTRY as R } from '../registry.js';
 import { getWarpTokenType } from '../warp/warp-query.js';
 
+function shouldCacheStargateClient(url: string): boolean {
+  return !url.startsWith('ws://') && !url.startsWith('wss://');
+}
+
 export class CosmosNativeProvider implements AltVM.IProvider<EncodeObject> {
   private readonly query: QueryClient &
     BankExtension &
@@ -110,36 +114,52 @@ export class CosmosNativeProvider implements AltVM.IProvider<EncodeObject> {
       req.senderPubKey,
       `Cosmos Native requires a sender public key to estimate the transaction fee`,
     );
-    const stargateClient = await this.getStargateClient();
+    const stargateClientPromise = this.getStargateClient();
+    let stargateClient: StargateClient | undefined;
 
-    const message = this.registry.encodeAsAny(req.transaction);
-    const pubKey = encodeSecp256k1Pubkey(
-      new Uint8Array(Buffer.from(strip0x(req.senderPubKey), 'hex')),
-    );
+    try {
+      stargateClient = await stargateClientPromise;
 
-    const queryClient = stargateClient['getQueryClient']();
-    assert(queryClient, `queryClient could not be found on stargate client`);
+      const message = this.registry.encodeAsAny(req.transaction);
+      const pubKey = encodeSecp256k1Pubkey(
+        new Uint8Array(Buffer.from(strip0x(req.senderPubKey), 'hex')),
+      );
 
-    const { sequence } = await stargateClient.getSequence(req.senderAddress);
-    const { gasInfo } = await queryClient.tx.simulate(
-      [message],
-      undefined,
-      pubKey,
-      sequence,
-    );
-    const gasUnits = Uint53.fromString(
-      gasInfo?.gasUsed.toString() ?? '0',
-    ).toNumber();
+      const queryClient = stargateClient['getQueryClient']();
+      assert(queryClient, `queryClient could not be found on stargate client`);
 
-    const gasPrice = parseFloat(req.estimatedGasPrice.toString());
-    return {
-      gasUnits: BigInt(gasUnits),
-      gasPrice,
-      fee: BigInt(Math.floor(gasUnits * gasPrice)),
-    };
+      const { sequence } = await stargateClient.getSequence(req.senderAddress);
+      const { gasInfo } = await queryClient.tx.simulate(
+        [message],
+        undefined,
+        pubKey,
+        sequence,
+      );
+      const gasUnits = Uint53.fromString(
+        gasInfo?.gasUsed.toString() ?? '0',
+      ).toNumber();
+
+      const gasPrice = parseFloat(req.estimatedGasPrice.toString());
+      return {
+        gasUnits: BigInt(gasUnits),
+        gasPrice,
+        fee: BigInt(Math.floor(gasUnits * gasPrice)),
+      };
+    } catch (error) {
+      this.evictStargateClient(stargateClientPromise);
+      throw error;
+    } finally {
+      if (!shouldCacheStargateClient(this.rpcUrls[0])) {
+        stargateClient?.disconnect();
+      }
+    }
   }
 
   private getStargateClient(): Promise<StargateClient> {
+    if (!shouldCacheStargateClient(this.rpcUrls[0])) {
+      return StargateClient.connect(this.rpcUrls[0]);
+    }
+
     this.stargateClient ??= StargateClient.connect(this.rpcUrls[0]).catch(
       (error) => {
         this.stargateClient = undefined;
@@ -147,6 +167,23 @@ export class CosmosNativeProvider implements AltVM.IProvider<EncodeObject> {
       },
     );
     return this.stargateClient;
+  }
+
+  private evictStargateClient(client: Promise<StargateClient>): void {
+    if (this.stargateClient !== client) return;
+
+    this.stargateClient = undefined;
+    void client.then(
+      (stargateClient) => stargateClient.disconnect(),
+      () => undefined,
+    );
+  }
+
+  disconnect(): void {
+    this.cometClient.disconnect();
+    if (this.stargateClient) {
+      this.evictStargateClient(this.stargateClient);
+    }
   }
 
   async isMessageDelivered(req: AltVM.ReqIsMessageDelivered): Promise<boolean> {

--- a/typescript/cosmos-sdk/src/clients/provider.ts
+++ b/typescript/cosmos-sdk/src/clients/provider.ts
@@ -5,7 +5,7 @@ import {
   type BankExtension,
   type MsgSendEncodeObject,
   QueryClient,
-  StargateClient,
+  type StargateClient,
   defaultRegistryTypes,
   setupBankExtension,
 } from '@cosmjs/stargate';
@@ -26,9 +26,11 @@ import {
 import { COSMOS_MODULE_MESSAGE_REGISTRY as R } from '../registry.js';
 import { getWarpTokenType } from '../warp/warp-query.js';
 
-export function shouldCacheStargateClient(url: string): boolean {
-  return !url.startsWith('ws://') && !url.startsWith('wss://');
-}
+import {
+  StargateClientCache,
+  disconnectStargateClient,
+  shouldCacheStargateClient,
+} from './stargate.js';
 
 export class CosmosNativeProvider implements AltVM.IProvider<EncodeObject> {
   private readonly query: QueryClient &
@@ -38,7 +40,7 @@ export class CosmosNativeProvider implements AltVM.IProvider<EncodeObject> {
   private readonly registry: Registry;
   private readonly cometClient: CometClient;
   private readonly rpcUrls: string[];
-  private stargateClient?: Promise<StargateClient>;
+  private readonly stargateClients = new StargateClientCache(1);
 
   static async connect(
     rpcUrls: string[],
@@ -125,8 +127,9 @@ export class CosmosNativeProvider implements AltVM.IProvider<EncodeObject> {
         new Uint8Array(Buffer.from(strip0x(req.senderPubKey), 'hex')),
       );
 
-      const queryClient = stargateClient['getQueryClient']();
-      assert(queryClient, `queryClient could not be found on stargate client`);
+      const queryClient = stargateClient
+        // @ts-ignore force access to protected method
+        .forceGetQueryClient();
 
       const { sequence } = await stargateClient.getSequence(req.senderAddress);
       const { gasInfo } = await queryClient.tx.simulate(
@@ -146,46 +149,22 @@ export class CosmosNativeProvider implements AltVM.IProvider<EncodeObject> {
         fee: BigInt(Math.floor(gasUnits * gasPrice)),
       };
     } catch (error) {
-      this.evictStargateClient(stargateClientPromise);
+      this.stargateClients.evict(this.rpcUrls[0], stargateClientPromise);
       throw error;
     } finally {
-      if (!shouldCacheStargateClient(this.rpcUrls[0])) {
-        stargateClient?.disconnect();
+      if (!shouldCacheStargateClient(this.rpcUrls[0]) && stargateClient) {
+        disconnectStargateClient(Promise.resolve(stargateClient));
       }
     }
   }
 
   private getStargateClient(): Promise<StargateClient> {
-    if (!shouldCacheStargateClient(this.rpcUrls[0])) {
-      return StargateClient.connect(this.rpcUrls[0]);
-    }
-
-    this.stargateClient ??= StargateClient.connect(this.rpcUrls[0]).catch(
-      (error) => {
-        this.stargateClient = undefined;
-        throw error;
-      },
-    );
-    return this.stargateClient;
-  }
-
-  private evictStargateClient(client: Promise<StargateClient>): void {
-    if (this.stargateClient !== client) return;
-
-    // Disconnecting an evicted shared client can fail concurrent estimates on
-    // this provider, but avoids keeping a poisoned socket cached.
-    this.stargateClient = undefined;
-    void client.then(
-      (stargateClient) => stargateClient.disconnect(),
-      () => undefined,
-    );
+    return this.stargateClients.get(this.rpcUrls[0]);
   }
 
   disconnect(): void {
     this.cometClient.disconnect();
-    if (this.stargateClient) {
-      this.evictStargateClient(this.stargateClient);
-    }
+    this.stargateClients.clear();
   }
 
   async isMessageDelivered(req: AltVM.ReqIsMessageDelivered): Promise<boolean> {

--- a/typescript/cosmos-sdk/src/clients/provider.ts
+++ b/typescript/cosmos-sdk/src/clients/provider.ts
@@ -152,7 +152,9 @@ export class CosmosNativeProvider implements AltVM.IProvider<EncodeObject> {
       this.stargateClients.evict(this.rpcUrls[0], stargateClientPromise);
       throw error;
     } finally {
-      if (!shouldCacheStargateClient(this.rpcUrls[0]) && stargateClient) {
+      if (shouldCacheStargateClient(this.rpcUrls[0])) {
+        this.stargateClients.release(stargateClientPromise);
+      } else if (stargateClient) {
         disconnectStargateClient(Promise.resolve(stargateClient));
       }
     }

--- a/typescript/cosmos-sdk/src/clients/provider.ts
+++ b/typescript/cosmos-sdk/src/clients/provider.ts
@@ -34,6 +34,7 @@ export class CosmosNativeProvider implements AltVM.IProvider<EncodeObject> {
   private readonly registry: Registry;
   private readonly cometClient: CometClient;
   private readonly rpcUrls: string[];
+  private stargateClient?: Promise<StargateClient>;
 
   static async connect(
     rpcUrls: string[],
@@ -109,7 +110,7 @@ export class CosmosNativeProvider implements AltVM.IProvider<EncodeObject> {
       req.senderPubKey,
       `Cosmos Native requires a sender public key to estimate the transaction fee`,
     );
-    const stargateClient = await StargateClient.connect(this.rpcUrls[0]);
+    const stargateClient = await this.getStargateClient();
 
     const message = this.registry.encodeAsAny(req.transaction);
     const pubKey = encodeSecp256k1Pubkey(
@@ -136,6 +137,16 @@ export class CosmosNativeProvider implements AltVM.IProvider<EncodeObject> {
       gasPrice,
       fee: BigInt(Math.floor(gasUnits * gasPrice)),
     };
+  }
+
+  private getStargateClient(): Promise<StargateClient> {
+    this.stargateClient ??= StargateClient.connect(this.rpcUrls[0]).catch(
+      (error) => {
+        this.stargateClient = undefined;
+        throw error;
+      },
+    );
+    return this.stargateClient;
   }
 
   async isMessageDelivered(req: AltVM.ReqIsMessageDelivered): Promise<boolean> {

--- a/typescript/cosmos-sdk/src/clients/provider.ts
+++ b/typescript/cosmos-sdk/src/clients/provider.ts
@@ -26,7 +26,7 @@ import {
 import { COSMOS_MODULE_MESSAGE_REGISTRY as R } from '../registry.js';
 import { getWarpTokenType } from '../warp/warp-query.js';
 
-function shouldCacheStargateClient(url: string): boolean {
+export function shouldCacheStargateClient(url: string): boolean {
   return !url.startsWith('ws://') && !url.startsWith('wss://');
 }
 

--- a/typescript/cosmos-sdk/src/clients/signer.ts
+++ b/typescript/cosmos-sdk/src/clients/signer.ts
@@ -138,6 +138,11 @@ export class CosmosNativeSigner
     return this.account.address;
   }
 
+  disconnect(): void {
+    super.disconnect();
+    this.signer.disconnect();
+  }
+
   supportsTransactionBatching(): boolean {
     return true;
   }

--- a/typescript/cosmos-sdk/src/clients/stargate.ts
+++ b/typescript/cosmos-sdk/src/clients/stargate.ts
@@ -1,0 +1,63 @@
+import { StargateClient } from '@cosmjs/stargate';
+
+import { rootLogger } from '@hyperlane-xyz/utils';
+
+export function shouldCacheStargateClient(url: string): boolean {
+  return !url.startsWith('ws://') && !url.startsWith('wss://');
+}
+
+export function disconnectStargateClient(
+  client: Promise<StargateClient>,
+): void {
+  void client
+    .then((stargateClient) => stargateClient.disconnect())
+    .catch((error) => {
+      rootLogger.debug({ error }, 'Failed to disconnect Stargate client');
+    });
+}
+
+export class StargateClientCache {
+  private readonly clients = new Map<string, Promise<StargateClient>>();
+
+  constructor(private readonly maxSize: number) {}
+
+  get(url: string): Promise<StargateClient> {
+    if (!shouldCacheStargateClient(url)) return StargateClient.connect(url);
+
+    let client = this.clients.get(url);
+    if (!client) {
+      client = StargateClient.connect(url).catch((error) => {
+        this.clients.delete(url);
+        throw error;
+      });
+    } else {
+      this.clients.delete(url);
+    }
+    this.clients.set(url, client);
+
+    // LRU eviction can disconnect a shared client another caller just received;
+    // callers evict and retry on estimate failure, and the cap is above normal
+    // concurrent chain fanout.
+    while (this.clients.size > this.maxSize) {
+      const oldestUrl = this.clients.keys().next().value;
+      if (!oldestUrl) break;
+      this.evict(oldestUrl);
+    }
+    return client;
+  }
+
+  evict(url: string, client?: Promise<StargateClient>): void {
+    const cachedClient = this.clients.get(url);
+    if (!cachedClient || (client && cachedClient !== client)) return;
+
+    this.clients.delete(url);
+    disconnectStargateClient(cachedClient);
+  }
+
+  clear(): void {
+    for (const client of this.clients.values()) {
+      disconnectStargateClient(client);
+    }
+    this.clients.clear();
+  }
+}

--- a/typescript/cosmos-sdk/src/clients/stargate.ts
+++ b/typescript/cosmos-sdk/src/clients/stargate.ts
@@ -16,48 +16,82 @@ export function disconnectStargateClient(
     });
 }
 
+interface StargateClientCacheEntry {
+  client: Promise<StargateClient>;
+  evicted: boolean;
+  leases: number;
+}
+
 export class StargateClientCache {
-  private readonly clients = new Map<string, Promise<StargateClient>>();
+  private readonly clients = new Map<string, StargateClientCacheEntry>();
+  private readonly entries = new Map<
+    Promise<StargateClient>,
+    StargateClientCacheEntry
+  >();
 
   constructor(private readonly maxSize: number) {}
 
   get(url: string): Promise<StargateClient> {
     if (!shouldCacheStargateClient(url)) return StargateClient.connect(url);
 
-    let client = this.clients.get(url);
-    if (!client) {
-      client = StargateClient.connect(url).catch((error) => {
-        this.clients.delete(url);
+    let entry = this.clients.get(url);
+    if (!entry) {
+      let pendingEntry: StargateClientCacheEntry;
+      const client = StargateClient.connect(url).catch((error) => {
+        const entry = pendingEntry;
+        entry.evicted = true;
+        if (this.clients.get(url) === entry) {
+          this.clients.delete(url);
+        }
+        this.disconnectIfIdle(entry);
         throw error;
       });
+      pendingEntry = { client, evicted: false, leases: 0 };
+      entry = pendingEntry;
+      this.entries.set(client, entry);
     } else {
       this.clients.delete(url);
     }
-    this.clients.set(url, client);
+    entry.leases += 1;
+    this.clients.set(url, entry);
 
-    // LRU eviction can disconnect a shared client another caller just received;
-    // callers evict and retry on estimate failure, and the cap is above normal
-    // concurrent chain fanout.
     while (this.clients.size > this.maxSize) {
       const oldestUrl = this.clients.keys().next().value;
       if (!oldestUrl) break;
       this.evict(oldestUrl);
     }
-    return client;
+    return entry.client;
   }
 
   evict(url: string, client?: Promise<StargateClient>): void {
-    const cachedClient = this.clients.get(url);
-    if (!cachedClient || (client && cachedClient !== client)) return;
+    const entry = this.clients.get(url);
+    if (!entry || (client && entry.client !== client)) return;
 
     this.clients.delete(url);
-    disconnectStargateClient(cachedClient);
+    entry.evicted = true;
+    this.disconnectIfIdle(entry);
+  }
+
+  release(client: Promise<StargateClient>): void {
+    const entry = this.entries.get(client);
+    if (!entry) return;
+
+    entry.leases -= 1;
+    this.disconnectIfIdle(entry);
   }
 
   clear(): void {
-    for (const client of this.clients.values()) {
-      disconnectStargateClient(client);
+    for (const entry of this.clients.values()) {
+      entry.evicted = true;
+      this.disconnectIfIdle(entry);
     }
     this.clients.clear();
+  }
+
+  private disconnectIfIdle(entry: StargateClientCacheEntry): void {
+    if (!entry.evicted || entry.leases > 0) return;
+
+    this.entries.delete(entry.client);
+    disconnectStargateClient(entry.client);
   }
 }

--- a/typescript/cosmos-sdk/src/index.ts
+++ b/typescript/cosmos-sdk/src/index.ts
@@ -1,6 +1,7 @@
 export * from './clients/protocol.js';
 export * from './clients/provider.js';
 export * from './clients/signer.js';
+export * from './clients/stargate.js';
 
 export * from './registry.js';
 

--- a/typescript/infra/src/agents/aws/client.ts
+++ b/typescript/infra/src/agents/aws/client.ts
@@ -1,0 +1,34 @@
+import { IAMClient } from '@aws-sdk/client-iam';
+import { KMSClient } from '@aws-sdk/client-kms';
+import { S3Client } from '@aws-sdk/client-s3';
+
+const iamClients = new Map<string, IAMClient>();
+const kmsClients = new Map<string, KMSClient>();
+const s3Clients = new Map<string, S3Client>();
+
+export function getAwsIamClient(region: string): IAMClient {
+  let client = iamClients.get(region);
+  if (!client) {
+    client = new IAMClient({ region });
+    iamClients.set(region, client);
+  }
+  return client;
+}
+
+export function getAwsKmsClient(region: string): KMSClient {
+  let client = kmsClients.get(region);
+  if (!client) {
+    client = new KMSClient({ region });
+    kmsClients.set(region, client);
+  }
+  return client;
+}
+
+export function getAwsS3Client(region: string): S3Client {
+  let client = s3Clients.get(region);
+  if (!client) {
+    client = new S3Client({ region });
+    s3Clients.set(region, client);
+  }
+  return client;
+}

--- a/typescript/infra/src/agents/aws/key.ts
+++ b/typescript/infra/src/agents/aws/key.ts
@@ -28,6 +28,8 @@ import { getEthereumAddress } from '../../utils/utils.js';
 import { keyIdentifier } from '../agent.js';
 import { CloudAgentKey } from '../keys.js';
 
+import { getAwsKmsClient } from './client.js';
+
 interface UnfetchedKey {
   fetched: false;
 }
@@ -40,7 +42,6 @@ interface FetchedKey {
 type RemoteKey = UnfetchedKey | FetchedKey;
 
 export class AgentAwsKey extends CloudAgentKey {
-  private client: KMSClient | undefined;
   private region: string;
   public remoteKey: RemoteKey = { fetched: false };
   protected logger: Logger;
@@ -69,15 +70,8 @@ export class AgentAwsKey extends CloudAgentKey {
   }
 
   async getClient(): Promise<KMSClient> {
-    if (this.client) {
-      this.logger.debug('Returning existing KMSClient instance');
-      return this.client;
-    }
-    this.logger.debug('Creating new KMSClient instance');
-    this.client = new KMSClient({
-      region: this.region,
-    });
-    return this.client;
+    this.logger.debug('Returning shared KMSClient instance');
+    return getAwsKmsClient(this.region);
   }
 
   get identifier() {

--- a/typescript/infra/src/agents/aws/user.ts
+++ b/typescript/infra/src/agents/aws/user.ts
@@ -20,6 +20,7 @@ import {
 } from '../../utils/gcloud.js';
 import { userIdentifier } from '../agent.js';
 
+import { getAwsIamClient } from './client.js';
 import { AgentAwsKey } from './key.js';
 
 export class AgentAwsUser {
@@ -34,7 +35,7 @@ export class AgentAwsUser {
     public readonly region: string,
     public readonly chainName?: ChainName,
   ) {
-    this.adminIamClient = new IAMClient({ region });
+    this.adminIamClient = getAwsIamClient(region);
   }
 
   // Creates the AWS user if it doesn't exist.

--- a/typescript/infra/src/agents/aws/validator-user.ts
+++ b/typescript/infra/src/agents/aws/validator-user.ts
@@ -15,6 +15,7 @@ import type { AgentContextConfig } from '../../config/agent/agent.js';
 import type { DeployEnvironment } from '../../config/deploy-environment.js';
 import { Role } from '../../roles.js';
 
+import { getAwsS3Client } from './client.js';
 import { AgentAwsKey } from './key.js';
 import { AgentAwsUser } from './user.js';
 
@@ -30,7 +31,7 @@ export class ValidatorAgentAwsUser extends AgentAwsUser {
     public readonly bucket: string,
   ) {
     super(environment, context, Role.Validator, region, chainName);
-    this.adminS3Client = new S3Client({ region });
+    this.adminS3Client = getAwsS3Client(region);
   }
 
   async createBucketIfNotExists() {

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -166,6 +166,10 @@ const secretMetadataOverridesCache = new Map<
   string,
   Promise<ChainMap<Partial<ChainMetadata>>>
 >();
+const githubSecretMetadataOverridesCache = new Map<
+  string,
+  Promise<ChainMap<Partial<ChainMetadata>>>
+>();
 
 export function getSecretMetadataOverrides(
   deployEnv: DeployEnvironment,
@@ -264,6 +268,24 @@ async function fetchSecretMetadataOverrides(
  * @returns A partial chain metadata map with the secret overrides.
  */
 export async function getSecretMetadataOverridesFromGitHubSecrets(
+  deployEnv: DeployEnvironment,
+  chains: string[],
+): Promise<ChainMap<Partial<ChainMetadata>>> {
+  const cacheKey = `${deployEnv}:${[...chains].sort().join(',')}`;
+  const cached = githubSecretMetadataOverridesCache.get(cacheKey);
+  if (cached) return cached;
+  const promise = fetchSecretMetadataOverridesFromGitHubSecrets(
+    deployEnv,
+    chains,
+  ).catch((error) => {
+    githubSecretMetadataOverridesCache.delete(cacheKey);
+    throw error;
+  });
+  githubSecretMetadataOverridesCache.set(cacheKey, promise);
+  return promise;
+}
+
+async function fetchSecretMetadataOverridesFromGitHubSecrets(
   deployEnv: DeployEnvironment,
   chains: string[],
 ): Promise<ChainMap<Partial<ChainMetadata>>> {

--- a/typescript/infra/src/deployment/verify.ts
+++ b/typescript/infra/src/deployment/verify.ts
@@ -3,6 +3,8 @@ import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import { fetchGCPSecret } from '../utils/gcloud.js';
 
+let explorerApiKeys: Promise<ChainMap<string>> | undefined;
+
 // read build artifact from given path
 export function extractBuildArtifact(buildArtifactPath: string): BuildArtifact {
   // check provided artifact is JSON
@@ -16,5 +18,11 @@ export function extractBuildArtifact(buildArtifactPath: string): BuildArtifact {
 
 // fetch explorer API keys from GCP
 export async function fetchExplorerApiKeys(): Promise<ChainMap<string>> {
-  return (await fetchGCPSecret('explorer-api-keys', true)) as any;
+  explorerApiKeys ??= fetchGCPSecret('explorer-api-keys', true)
+    .then((secret) => secret as ChainMap<string>)
+    .catch((error) => {
+      explorerApiKeys = undefined;
+      throw error;
+    });
+  return explorerApiKeys;
 }

--- a/typescript/infra/src/deployment/verify.ts
+++ b/typescript/infra/src/deployment/verify.ts
@@ -1,9 +1,19 @@
 import { BuildArtifact, ChainMap } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
 import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import { fetchGCPSecret } from '../utils/gcloud.js';
 
 let explorerApiKeys: ChainMap<string> | undefined;
+
+function isStringChainMap(value: unknown): value is ChainMap<string> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.values(value).every((entry) => typeof entry === 'string')
+  );
+}
 
 // read build artifact from given path
 export function extractBuildArtifact(buildArtifactPath: string): BuildArtifact {
@@ -20,6 +30,10 @@ export function extractBuildArtifact(buildArtifactPath: string): BuildArtifact {
 export async function fetchExplorerApiKeys(): Promise<ChainMap<string>> {
   if (explorerApiKeys !== undefined) return explorerApiKeys;
   const secret = await fetchGCPSecret('explorer-api-keys', true);
-  explorerApiKeys = secret as ChainMap<string>;
+  assert(
+    isStringChainMap(secret),
+    'explorer-api-keys secret must be a ChainMap<string>',
+  );
+  explorerApiKeys = secret;
   return explorerApiKeys;
 }

--- a/typescript/infra/src/deployment/verify.ts
+++ b/typescript/infra/src/deployment/verify.ts
@@ -3,7 +3,7 @@ import { readJson } from '@hyperlane-xyz/utils/fs';
 
 import { fetchGCPSecret } from '../utils/gcloud.js';
 
-let explorerApiKeys: Promise<ChainMap<string>> | undefined;
+let explorerApiKeys: ChainMap<string> | undefined;
 
 // read build artifact from given path
 export function extractBuildArtifact(buildArtifactPath: string): BuildArtifact {
@@ -18,11 +18,8 @@ export function extractBuildArtifact(buildArtifactPath: string): BuildArtifact {
 
 // fetch explorer API keys from GCP
 export async function fetchExplorerApiKeys(): Promise<ChainMap<string>> {
-  explorerApiKeys ??= fetchGCPSecret('explorer-api-keys', true)
-    .then((secret) => secret as ChainMap<string>)
-    .catch((error) => {
-      explorerApiKeys = undefined;
-      throw error;
-    });
+  if (explorerApiKeys !== undefined) return explorerApiKeys;
+  const secret = await fetchGCPSecret('explorer-api-keys', true);
+  explorerApiKeys = secret as ChainMap<string>;
   return explorerApiKeys;
 }

--- a/typescript/infra/src/utils/safeApiKey.ts
+++ b/typescript/infra/src/utils/safeApiKey.ts
@@ -4,20 +4,12 @@ import { fetchGCPSecret } from './gcloud.js';
 
 const safeApiKeySecretName = 'gnosis-safe-api-key';
 
-let safeApiKey: Promise<string> | undefined;
+let safeApiKey: string | undefined;
 
 export async function getSafeApiKey(): Promise<string> {
-  safeApiKey ??= fetchGCPSecret(safeApiKeySecretName, false)
-    .then((secret) => {
-      assert(
-        typeof secret === 'string',
-        'Safe API key secret must be a string',
-      );
-      return secret;
-    })
-    .catch((error) => {
-      safeApiKey = undefined;
-      throw error;
-    });
+  if (safeApiKey !== undefined) return safeApiKey;
+  const secret = await fetchGCPSecret(safeApiKeySecretName, false);
+  assert(typeof secret === 'string', 'Safe API key secret must be a string');
+  safeApiKey = secret;
   return safeApiKey;
 }

--- a/typescript/infra/src/utils/safeApiKey.ts
+++ b/typescript/infra/src/utils/safeApiKey.ts
@@ -4,8 +4,20 @@ import { fetchGCPSecret } from './gcloud.js';
 
 const safeApiKeySecretName = 'gnosis-safe-api-key';
 
+let safeApiKey: Promise<string> | undefined;
+
 export async function getSafeApiKey(): Promise<string> {
-  const secret = await fetchGCPSecret(safeApiKeySecretName, false);
-  assert(typeof secret === 'string', 'Safe API key secret must be a string');
-  return secret;
+  safeApiKey ??= fetchGCPSecret(safeApiKeySecretName, false)
+    .then((secret) => {
+      assert(
+        typeof secret === 'string',
+        'Safe API key secret must be a string',
+      );
+      return secret;
+    })
+    .catch((error) => {
+      safeApiKey = undefined;
+      throw error;
+    });
+  return safeApiKey;
 }

--- a/typescript/infra/test/aws-clients.test.ts
+++ b/typescript/infra/test/aws-clients.test.ts
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+
+import {
+  getAwsIamClient,
+  getAwsKmsClient,
+  getAwsS3Client,
+} from '../src/agents/aws/client.js';
+
+describe('AWS clients', () => {
+  it('reuses clients for the same region', () => {
+    expect(getAwsIamClient('us-east-1')).to.equal(getAwsIamClient('us-east-1'));
+    expect(getAwsKmsClient('us-east-1')).to.equal(getAwsKmsClient('us-east-1'));
+    expect(getAwsS3Client('us-east-1')).to.equal(getAwsS3Client('us-east-1'));
+  });
+
+  it('separates clients by region', () => {
+    expect(getAwsIamClient('us-east-1')).to.not.equal(
+      getAwsIamClient('us-west-2'),
+    );
+    expect(getAwsKmsClient('us-east-1')).to.not.equal(
+      getAwsKmsClient('us-west-2'),
+    );
+    expect(getAwsS3Client('us-east-1')).to.not.equal(
+      getAwsS3Client('us-west-2'),
+    );
+  });
+});

--- a/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
@@ -1,0 +1,133 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { StargateClient } from '@cosmjs/stargate';
+
+import { ProviderType } from './ProviderType.js';
+import {
+  clearCachedStargateClients,
+  estimateTransactionFeeCosmJsWasm,
+} from './transactionFeeEstimators.js';
+
+describe('transactionFeeEstimators', () => {
+  const sender = 'cosmos1sender';
+  const senderPubKey = `02${'aa'.repeat(32)}`;
+  const transaction = {
+    type: ProviderType.CosmJsWasm,
+    transaction: {
+      contractAddress: 'cosmos1contract',
+      msg: {},
+      funds: [],
+    },
+  } as any;
+
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    clearCachedStargateClients();
+    sandbox.restore();
+  });
+
+  function makeProvider(url: string) {
+    return {
+      type: ProviderType.CosmJsWasm,
+      provider: Promise.resolve({
+        cometClient: {
+          client: {
+            url,
+          },
+        },
+      }),
+    } as any;
+  }
+
+  function makeStargateClient(
+    simulate: sinon.SinonStub,
+  ): StargateClient & { disconnect: sinon.SinonStub } {
+    return {
+      disconnect: sandbox.stub(),
+      getSequence: sandbox.stub().resolves({ sequence: 1 }),
+      forceGetQueryClient: sandbox.stub().returns({
+        tx: {
+          simulate,
+        },
+      }),
+    } as unknown as StargateClient & { disconnect: sinon.SinonStub };
+  }
+
+  async function estimate(url: string) {
+    return estimateTransactionFeeCosmJsWasm({
+      transaction,
+      provider: makeProvider(url),
+      estimatedGasPrice: '2',
+      sender,
+      senderPubKey,
+    });
+  }
+
+  it('reuses cached Stargate clients for HTTP URLs', async () => {
+    const simulate = sandbox.stub().resolves({ gasInfo: { gasUsed: 10 } });
+    const client = makeStargateClient(simulate);
+    const connect = sandbox.stub(StargateClient, 'connect').resolves(client);
+
+    await estimate('https://cosmos-rpc.example');
+    await estimate('https://cosmos-rpc.example');
+
+    expect(
+      connect.calledOnceWithExactly('https://cosmos-rpc.example'),
+    ).to.equal(true);
+    expect(simulate.calledTwice).to.equal(true);
+  });
+
+  it('evicts cached Stargate clients when simulation fails', async () => {
+    const firstClient = makeStargateClient(
+      sandbox.stub().rejects(new Error('socket has disconnected')),
+    );
+    const secondClient = makeStargateClient(
+      sandbox.stub().resolves({ gasInfo: { gasUsed: 10 } }),
+    );
+    const connect = sandbox
+      .stub(StargateClient, 'connect')
+      .onFirstCall()
+      .resolves(firstClient)
+      .onSecondCall()
+      .resolves(secondClient);
+
+    try {
+      await estimate('https://cosmos-rpc.example');
+      throw new Error('Expected estimate to fail');
+    } catch (error) {
+      expect((error as Error).message).to.equal('socket has disconnected');
+    }
+    await estimate('https://cosmos-rpc.example');
+
+    expect(connect.calledTwice).to.equal(true);
+    expect(firstClient.disconnect.calledOnce).to.equal(true);
+  });
+
+  it('does not cache Stargate clients for WebSocket URLs', async () => {
+    const firstClient = makeStargateClient(
+      sandbox.stub().resolves({ gasInfo: { gasUsed: 10 } }),
+    );
+    const secondClient = makeStargateClient(
+      sandbox.stub().resolves({ gasInfo: { gasUsed: 10 } }),
+    );
+    const connect = sandbox
+      .stub(StargateClient, 'connect')
+      .onFirstCall()
+      .resolves(firstClient)
+      .onSecondCall()
+      .resolves(secondClient);
+
+    await estimate('wss://cosmos-rpc.example');
+    await estimate('wss://cosmos-rpc.example');
+
+    expect(connect.calledTwice).to.equal(true);
+    expect(firstClient.disconnect.calledOnce).to.equal(true);
+    expect(secondClient.disconnect.calledOnce).to.equal(true);
+  });
+});

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -259,6 +259,8 @@ export async function estimateTransactionFeeCosmJsWasm({
   } finally {
     if (!shouldCacheStargateClient(url)) {
       disconnectStargateClient(stargateClient);
+    } else {
+      stargateClientCache.release(stargateClient);
     }
   }
 }

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -3,14 +3,18 @@ import { wasmTypes } from '@cosmjs/cosmwasm-stargate';
 import { toUtf8 } from '@cosmjs/encoding';
 import { Uint53 } from '@cosmjs/math';
 import { Registry } from '@cosmjs/proto-signing';
-import { StargateClient, defaultRegistryTypes } from '@cosmjs/stargate';
+import { defaultRegistryTypes } from '@cosmjs/stargate';
 import { MsgExecuteContract } from 'cosmjs-types/cosmwasm/wasm/v1/tx.js';
 import type {
   providers as EV5Providers,
   PopulatedTransaction as EV5Transaction,
 } from 'ethers';
 
-import { shouldCacheStargateClient } from '@hyperlane-xyz/cosmos-sdk';
+import {
+  StargateClientCache,
+  disconnectStargateClient,
+  shouldCacheStargateClient,
+} from '@hyperlane-xyz/cosmos-sdk';
 import {
   Address,
   HexString,
@@ -51,57 +55,14 @@ export interface TransactionFeeEstimate {
   fee: number | bigint;
 }
 
-const maxStargateClientCacheSize = 32;
-const stargateClients = new Map<string, Promise<StargateClient>>();
-
-function disconnectStargateClient(client: Promise<StargateClient>): void {
-  void client.then(
-    (stargateClient) => stargateClient.disconnect(),
-    () => undefined,
-  );
-}
-
-function evictStargateClient(
-  url: string,
-  client?: Promise<StargateClient>,
-): void {
-  const cachedClient = stargateClients.get(url);
-  if (!cachedClient || (client && cachedClient !== client)) return;
-
-  // Disconnecting an evicted shared client can fail concurrent callers that
-  // were using it, but avoids keeping a poisoned socket in the process cache.
-  stargateClients.delete(url);
-  disconnectStargateClient(cachedClient);
-}
+const stargateClientCache = new StargateClientCache(32);
 
 export function clearCachedStargateClients(): void {
-  for (const client of stargateClients.values()) {
-    disconnectStargateClient(client);
-  }
-  stargateClients.clear();
+  stargateClientCache.clear();
 }
 
-function getStargateClient(url: string): Promise<StargateClient> {
-  if (!shouldCacheStargateClient(url)) return StargateClient.connect(url);
-
-  let client = stargateClients.get(url);
-  if (!client) {
-    client = StargateClient.connect(url).catch((error) => {
-      stargateClients.delete(url);
-      throw error;
-    });
-    stargateClients.set(url, client);
-  } else {
-    stargateClients.delete(url);
-    stargateClients.set(url, client);
-  }
-
-  while (stargateClients.size > maxStargateClientCacheSize) {
-    const oldestUrl = stargateClients.keys().next().value;
-    if (!oldestUrl) break;
-    evictStargateClient(oldestUrl);
-  }
-  return client;
+function getStargateClient(url: string) {
+  return stargateClientCache.get(url);
 }
 
 export async function estimateTransactionFeeEthersV5({
@@ -293,7 +254,7 @@ export async function estimateTransactionFeeCosmJsWasm({
       memo,
     });
   } catch (error) {
-    evictStargateClient(url, stargateClient);
+    stargateClientCache.evict(url, stargateClient);
     throw error;
   } finally {
     if (!shouldCacheStargateClient(url)) {

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -10,6 +10,7 @@ import type {
   PopulatedTransaction as EV5Transaction,
 } from 'ethers';
 
+import { shouldCacheStargateClient } from '@hyperlane-xyz/cosmos-sdk';
 import {
   Address,
   HexString,
@@ -52,10 +53,6 @@ export interface TransactionFeeEstimate {
 
 const maxStargateClientCacheSize = 32;
 const stargateClients = new Map<string, Promise<StargateClient>>();
-
-function shouldCacheStargateClient(url: string): boolean {
-  return !url.startsWith('ws://') && !url.startsWith('wss://');
-}
 
 function disconnectStargateClient(client: Promise<StargateClient>): void {
   void client.then(

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -50,9 +50,41 @@ export interface TransactionFeeEstimate {
   fee: number | bigint;
 }
 
+const maxStargateClientCacheSize = 32;
 const stargateClients = new Map<string, Promise<StargateClient>>();
 
+function shouldCacheStargateClient(url: string): boolean {
+  return !url.startsWith('ws://') && !url.startsWith('wss://');
+}
+
+function disconnectStargateClient(client: Promise<StargateClient>): void {
+  void client.then(
+    (stargateClient) => stargateClient.disconnect(),
+    () => undefined,
+  );
+}
+
+function evictStargateClient(
+  url: string,
+  client?: Promise<StargateClient>,
+): void {
+  const cachedClient = stargateClients.get(url);
+  if (!cachedClient || (client && cachedClient !== client)) return;
+
+  stargateClients.delete(url);
+  disconnectStargateClient(cachedClient);
+}
+
+export function clearCachedStargateClients(): void {
+  for (const client of stargateClients.values()) {
+    disconnectStargateClient(client);
+  }
+  stargateClients.clear();
+}
+
 function getStargateClient(url: string): Promise<StargateClient> {
+  if (!shouldCacheStargateClient(url)) return StargateClient.connect(url);
+
   let client = stargateClients.get(url);
   if (!client) {
     client = StargateClient.connect(url).catch((error) => {
@@ -60,6 +92,15 @@ function getStargateClient(url: string): Promise<StargateClient> {
       throw error;
     });
     stargateClients.set(url, client);
+  } else {
+    stargateClients.delete(url);
+    stargateClients.set(url, client);
+  }
+
+  while (stargateClients.size > maxStargateClientCacheSize) {
+    const oldestUrl = stargateClients.keys().next().value;
+    if (!oldestUrl) break;
+    evictStargateClient(oldestUrl);
   }
   return client;
 }
@@ -243,14 +284,23 @@ export async function estimateTransactionFeeCosmJsWasm({
   const url: string = wasmClient.cometClient.client.url;
   const stargateClient = getStargateClient(url);
 
-  return estimateTransactionFeeCosmJs({
-    transaction: { type: ProviderType.CosmJs, transaction: message },
-    provider: { type: ProviderType.CosmJs, provider: stargateClient },
-    estimatedGasPrice,
-    sender,
-    senderPubKey,
-    memo,
-  });
+  try {
+    return await estimateTransactionFeeCosmJs({
+      transaction: { type: ProviderType.CosmJs, transaction: message },
+      provider: { type: ProviderType.CosmJs, provider: stargateClient },
+      estimatedGasPrice,
+      sender,
+      senderPubKey,
+      memo,
+    });
+  } catch (error) {
+    evictStargateClient(url, stargateClient);
+    throw error;
+  } finally {
+    if (!shouldCacheStargateClient(url)) {
+      disconnectStargateClient(stargateClient);
+    }
+  }
 }
 
 export async function estimateTransactionFeeCosmJsNative({

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -71,6 +71,8 @@ function evictStargateClient(
   const cachedClient = stargateClients.get(url);
   if (!cachedClient || (client && cachedClient !== client)) return;
 
+  // Disconnecting an evicted shared client can fail concurrent callers that
+  // were using it, but avoids keeping a poisoned socket in the process cache.
   stargateClients.delete(url);
   disconnectStargateClient(cachedClient);
 }

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -50,6 +50,20 @@ export interface TransactionFeeEstimate {
   fee: number | bigint;
 }
 
+const stargateClients = new Map<string, Promise<StargateClient>>();
+
+function getStargateClient(url: string): Promise<StargateClient> {
+  let client = stargateClients.get(url);
+  if (!client) {
+    client = StargateClient.connect(url).catch((error) => {
+      stargateClients.delete(url);
+      throw error;
+    });
+    stargateClients.set(url, client);
+  }
+  return client;
+}
+
 export async function estimateTransactionFeeEthersV5({
   transaction,
   provider,
@@ -227,7 +241,7 @@ export async function estimateTransactionFeeCosmJsWasm({
   const wasmClient = await provider.provider;
   // @ts-ignore access a private field here to extract client URL
   const url: string = wasmClient.cometClient.client.url;
-  const stargateClient = StargateClient.connect(url);
+  const stargateClient = getStargateClient(url);
 
   return estimateTransactionFeeCosmJs({
     transaction: { type: ProviderType.CosmJs, transaction: message },


### PR DESCRIPTION
### Description

Caches additional shared resources similar to #8711:

- Reuses AWS IAM/KMS/S3 clients per region in infra agent helpers.
- Reuses Stargate clients for repeated Cosmos fee estimates, with failed connection attempts evicted from cache.
- Memoizes Safe and explorer API key secret fetches, with failed fetches evicted from cache.
- Caches CI GitHub-secret metadata overrides by environment and chain set.

### Validation

- `pnpm -C typescript/cosmos-sdk build`
- `pnpm -C typescript/sdk check`
- `pnpm -C typescript/infra exec mocha --config ../sdk/.mocharc.json test/aws-clients.test.ts`
- `pnpm exec oxlint -c oxlint.json typescript/infra/src/config/chain.ts typescript/infra/src/deployment/verify.ts typescript/infra/src/utils/safeApiKey.ts typescript/infra/src/agents/aws/client.ts typescript/infra/src/agents/aws/key.ts typescript/infra/src/agents/aws/user.ts typescript/infra/src/agents/aws/validator-user.ts typescript/infra/test/aws-clients.test.ts typescript/cosmos-sdk/src/clients/provider.ts typescript/sdk/src/providers/transactionFeeEstimators.ts`

Known baseline failures observed outside this patch:

- `pnpm -C typescript/infra check` fails on missing `RelayerConfig` relay API fields in `typescript/infra/src/config/agent/relayer.ts`.
- Full `pnpm -C typescript/cosmos-sdk lint` and `pnpm -C typescript/sdk lint` fail on existing unrelated lint errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes connection/secret-fetch lifecycles (Cosmos Stargate clients, AWS SDK clients, and secret metadata overrides), which could introduce stale caches or concurrency-related disconnect/eviction edge cases.
> 
> **Overview**
> Improves performance by **caching and reusing external client connections and secret lookups** across repeated operations.
> 
> Cosmos fee estimation now reuses `StargateClient` connections (skipping WebSocket URLs), adds cache eviction/disconnect on simulation/connect failures, and wires provider/signer `disconnect()` to clean up cached clients.
> 
> Infra now reuses AWS `IAMClient`/`KMSClient`/`S3Client` per region, and memoizes secret-derived configuration (Safe API key, explorer API keys, and CI GitHub-secret chain metadata overrides) with eviction on fetch errors; adds tests covering the new caching behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5f4af11e509c532c2f1705bba63cf5ddebe91d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->