### PR TITLE
feat: add RateLimitedHook support to warp deploy and apply

### DIFF
--- a/.changeset/shy-seas-greet.md
+++ b/.changeset/shy-seas-greet.md
@@ -1,0 +1,6 @@
+---
+"@hyperlane-xyz/cli": minor
+"@hyperlane-xyz/sdk": minor
+---
+
+Added rate-limited hook support.

--- a/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-hook-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-hook-updates.e2e-test.ts
@@ -8,7 +8,7 @@ import {
   normalizeConfig,
   randomAddress,
 } from '@hyperlane-xyz/sdk';
-import { ProtocolType } from '@hyperlane-xyz/utils';
+import { ProtocolType, type WithAddress } from '@hyperlane-xyz/utils';
 
 import { writeYamlOrJson } from '../../../../utils/files.js';
 import { HyperlaneE2ECoreTestCommands } from '../../../commands/core.js';
@@ -131,6 +131,14 @@ describe('hyperlane warp apply E2E (hook updates)', async function () {
       updatedMaxCapacity;
     await writeYamlOrJson(DEFAULT_EVM_WARP_DEPLOY_PATH, warpDeployConfig);
 
+    const configBeforeApply = await evmWarpCommands.readConfig(
+      chain,
+      DEFAULT_EVM_WARP_CORE_PATH,
+    );
+    const hookAddressBeforeApply = (
+      configBeforeApply[chain].hook as WithAddress<RateLimitedHookConfig>
+    ).address;
+
     await evmWarpCommands.applyRaw({
       warpRouteId: DEFAULT_EVM_WARP_ID,
       hypKey: HYP_KEY_BY_PROTOCOL.ethereum,
@@ -141,8 +149,11 @@ describe('hyperlane warp apply E2E (hook updates)', async function () {
       DEFAULT_EVM_WARP_CORE_PATH,
     );
 
-    const hook = updatedConfig[chain].hook as RateLimitedHookConfig;
+    const hook = updatedConfig[chain]
+      .hook as WithAddress<RateLimitedHookConfig>;
     expect(hook.type).to.equal(HookType.RATE_LIMITED);
     expect(hook.maxCapacity).to.equal(updatedMaxCapacity);
+    // address must be unchanged — setRefillRate is in-place, not a redeploy
+    expect(hook.address).to.equal(hookAddressBeforeApply);
   });
 });

--- a/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-hook-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-hook-updates.e2e-test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import {
   HookType,
+  type RateLimitedHookConfig,
   TokenType,
   type WarpRouteDeployConfig,
   normalizeConfig,
@@ -99,5 +100,49 @@ describe('hyperlane warp apply E2E (hook updates)', async function () {
           .hook,
       ),
     );
+  });
+
+  it('should deploy a warp route with a RateLimitedHook and update its maxCapacity in place', async () => {
+    const chain = TEST_CHAIN_NAMES_BY_PROTOCOL.ethereum.CHAIN_NAME_2;
+    const owner = HYP_DEPLOYER_ADDRESS_BY_PROTOCOL.ethereum;
+    const initialMaxCapacity = (86400n * 100n).toString();
+    const updatedMaxCapacity = (86400n * 200n).toString();
+
+    const warpDeployConfig: WarpRouteDeployConfig = {
+      [chain]: {
+        type: TokenType.native,
+        owner,
+        hook: {
+          type: HookType.RATE_LIMITED,
+          maxCapacity: initialMaxCapacity,
+          owner,
+        } as RateLimitedHookConfig,
+      },
+    };
+
+    await writeYamlOrJson(DEFAULT_EVM_WARP_DEPLOY_PATH, warpDeployConfig);
+    await evmWarpCommands.deploy(
+      HYP_KEY_BY_PROTOCOL.ethereum,
+      DEFAULT_EVM_WARP_ID,
+    );
+
+    // Update maxCapacity in place (sender unchanged — same hook contract, just setRefillRate)
+    (warpDeployConfig[chain].hook as RateLimitedHookConfig).maxCapacity =
+      updatedMaxCapacity;
+    await writeYamlOrJson(DEFAULT_EVM_WARP_DEPLOY_PATH, warpDeployConfig);
+
+    await evmWarpCommands.applyRaw({
+      warpRouteId: DEFAULT_EVM_WARP_ID,
+      hypKey: HYP_KEY_BY_PROTOCOL.ethereum,
+    });
+
+    const updatedConfig = await evmWarpCommands.readConfig(
+      chain,
+      DEFAULT_EVM_WARP_CORE_PATH,
+    );
+
+    const hook = updatedConfig[chain].hook as RateLimitedHookConfig;
+    expect(hook.type).to.equal(HookType.RATE_LIMITED);
+    expect(hook.maxCapacity).to.equal(updatedMaxCapacity);
   });
 });

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy-1.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy-1.e2e-test.ts
@@ -17,6 +17,7 @@ import {
   HookType,
   type IsmConfig,
   IsmType,
+  type RateLimitedHookConfig,
   TokenType,
   type WarpRouteDeployConfig,
   normalizeConfig,
@@ -679,6 +680,95 @@ describe('hyperlane warp deploy e2e tests', async function () {
       expect(normalizeConfig(collateralRebaseConfig.hook)).to.deep.equal(
         normalizeConfig(hook),
       );
+    });
+
+    it('should deploy with a RateLimitedHook', async () => {
+      const maxCapacity = (86400n * 1000n).toString();
+      const hook: RateLimitedHookConfig = {
+        type: HookType.RATE_LIMITED,
+        maxCapacity,
+        owner: ownerAddress,
+      };
+      const warpConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.native,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+          hook,
+        },
+      };
+
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpConfig);
+      await hyperlaneWarpDeploy(WARP_DEPLOY_OUTPUT_PATH);
+
+      const nativeSymbol = chain2Metadata.nativeToken?.symbol ?? 'ETH';
+      const WARP_CORE_CONFIG_PATH = GET_WARP_DEPLOY_CORE_CONFIG_OUTPUT_PATH(
+        WARP_DEPLOY_OUTPUT_PATH,
+        nativeSymbol,
+      );
+
+      const deployedConfig = (
+        await readWarpConfig(
+          CHAIN_NAME_2,
+          WARP_CORE_CONFIG_PATH,
+          WARP_DEPLOY_OUTPUT_PATH,
+        )
+      )[CHAIN_NAME_2];
+
+      const deployedHook = deployedConfig.hook as RateLimitedHookConfig;
+      expect(deployedHook.type).to.equal(HookType.RATE_LIMITED);
+      expect(deployedHook.maxCapacity).to.equal(maxCapacity);
+    });
+
+    it('should deploy a RateLimitedHook nested inside an AggregationHook', async () => {
+      const maxCapacity = (86400n * 500n).toString();
+      const warpConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.native,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+          hook: {
+            type: HookType.AGGREGATION,
+            hooks: [
+              { type: HookType.MERKLE_TREE },
+              {
+                type: HookType.RATE_LIMITED,
+                maxCapacity,
+                owner: ownerAddress,
+              } as RateLimitedHookConfig,
+            ],
+          },
+        },
+      };
+
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpConfig);
+      await hyperlaneWarpDeploy(WARP_DEPLOY_OUTPUT_PATH);
+
+      const nativeSymbol = chain2Metadata.nativeToken?.symbol ?? 'ETH';
+      const WARP_CORE_CONFIG_PATH = GET_WARP_DEPLOY_CORE_CONFIG_OUTPUT_PATH(
+        WARP_DEPLOY_OUTPUT_PATH,
+        nativeSymbol,
+      );
+
+      const deployedConfig = (
+        await readWarpConfig(
+          CHAIN_NAME_2,
+          WARP_CORE_CONFIG_PATH,
+          WARP_DEPLOY_OUTPUT_PATH,
+        )
+      )[CHAIN_NAME_2];
+
+      const aggregation = deployedConfig.hook as {
+        type: typeof HookType.AGGREGATION;
+        hooks: RateLimitedHookConfig[];
+      };
+      expect(aggregation.type).to.equal(HookType.AGGREGATION);
+
+      const rateLimitedHook = aggregation.hooks.find(
+        (h) => h.type === HookType.RATE_LIMITED,
+      );
+      expect(rateLimitedHook).to.exist;
+      expect(rateLimitedHook!.maxCapacity).to.equal(maxCapacity);
     });
 
     it('should send a message from origin to destination in the correct order', async function () {

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -80,6 +80,13 @@ import { ContractVerifier } from './verify/ContractVerifier.js';
 
 type ChainAddresses = Record<string, string>;
 
+type RateLimitedHookDeployInput = {
+  hookConfig: HookConfig;
+  chainAddresses: ChainAddresses;
+  ccipContractCache: CCIPContractCache;
+  proxyAdminAddress: Address | undefined;
+};
+
 const SUPPORTED_ALTVM_TOKEN_TYPES = new Set<TokenType>([
   TokenType.synthetic,
   TokenType.collateral,
@@ -185,6 +192,29 @@ export function validateWarpConfigForAltVM(
   }
 }
 
+// Subclass that injects rate-limited hook deployment between configureClients and
+// transferOwnership so that setHook() is called while the deployer signer still owns the token.
+class RateLimitedHookERC20Deployer extends HypERC20Deployer {
+  constructor(
+    multiProvider: MultiProvider,
+    ismFactory: HyperlaneIsmFactory | undefined,
+    contractVerifier: ContractVerifier | undefined,
+    private readonly preTransferFn: (
+      deployedTokens: ChainMap<Address>,
+    ) => Promise<void>,
+  ) {
+    super(multiProvider, ismFactory, contractVerifier);
+  }
+
+  protected override async beforeTransferOwnership(
+    contractsMap: HyperlaneContractsMap<HypERC20Factories>,
+  ): Promise<void> {
+    await this.preTransferFn(
+      objMap(contractsMap, (_, contracts) => getRouter(contracts).address),
+    );
+  }
+}
+
 export async function executeWarpDeploy(
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired,
   multiProvider: MultiProvider,
@@ -204,14 +234,10 @@ export async function executeWarpDeploy(
     contractVerifier,
   );
 
-  // Snapshot hook configs that contain RATE_LIMITED before resolveWarpIsmAndHook strips them.
-  // These hooks need the token router address (not yet deployed), so we defer them.
-  const rateLimitedHookSnapshots: ChainMap<HookConfig> = {};
-  for (const [chain, config] of Object.entries(warpDeployConfig)) {
-    if (config.hook && hookTreeContainsRateLimited(config.hook as HookConfig)) {
-      rateLimitedHookSnapshots[chain] = config.hook as HookConfig;
-    }
-  }
+  // Hooks containing RATE_LIMITED need the token router address as sender, so they are deferred
+  // until after token deployment. resolveWarpIsmAndHook populates this map (EVM/Tron only) and
+  // returns undefined for those hooks, causing them to be set later via setHook().
+  const rateLimitedHookSnapshots: ChainMap<RateLimitedHookDeployInput> = {};
 
   // For each chain in WarpRouteConfig, deploy each Ism Factory, if it's not in the registry
   // Then return a modified config with the ism and/or hook address as a string
@@ -222,6 +248,7 @@ export async function executeWarpDeploy(
     registryAddresses,
     ismFactoryDeployer,
     contractVerifier,
+    rateLimitedHookSnapshots,
   );
 
   // Initialize with unsupported chains so that they are enrolled
@@ -271,18 +298,42 @@ export async function executeWarpDeploy(
     switch (protocol) {
       case ProtocolType.Tron:
       case ProtocolType.Ethereum: {
+        const ismFactory = HyperlaneIsmFactory.fromAddressesMap(
+          registryAddresses,
+          multiProvider,
+          undefined,
+          contractVerifier,
+        );
+
         const deployer = warpDeployConfig.isNft
           ? new HypERC721Deployer(multiProvider)
-          : new HypERC20Deployer( // TODO: replace with EvmERC20WarpModule
-              multiProvider,
-              HyperlaneIsmFactory.fromAddressesMap(
-                registryAddresses,
+          : isObjEmpty(rateLimitedHookSnapshots)
+            ? new HypERC20Deployer(multiProvider, ismFactory, contractVerifier) // TODO: replace with EvmERC20WarpModule
+            : new RateLimitedHookERC20Deployer(
                 multiProvider,
-                undefined,
+                ismFactory,
                 contractVerifier,
-              ),
-              contractVerifier,
-            );
+                // Called BEFORE transferOwnership — deployer signer still owns the token here.
+                async (deployedTokens) => {
+                  const chainSnapshots = objFilter(
+                    rateLimitedHookSnapshots,
+                    (chain, _v): _v is RateLimitedHookDeployInput =>
+                      chain in deployedTokens,
+                  );
+                  if (isObjEmpty(chainSnapshots)) return;
+                  const deployedHooks = await deployAndWireRateLimitedHooks(
+                    chainSnapshots,
+                    deployedTokens,
+                    multiProvider,
+                    contractVerifier,
+                  );
+                  for (const [chain, hookAddress] of Object.entries(
+                    deployedHooks,
+                  )) {
+                    warpDeployConfig[chain].hook = hookAddress;
+                  }
+                },
+              );
 
         const evmContracts = await deployer.deploy(protocolSpecificConfig);
         deployedContracts = {
@@ -328,64 +379,70 @@ export async function executeWarpDeploy(
     }
   }
 
-  if (Object.keys(rateLimitedHookSnapshots).length > 0) {
-    await deployAndWireRateLimitedHooks(
-      rateLimitedHookSnapshots,
-      deployedContracts,
-      multiProvider,
-      registryAddresses,
-      contractVerifier,
-    );
-  }
-
   return deployedContracts;
 }
 
 async function deployAndWireRateLimitedHooks(
-  snapshots: ChainMap<HookConfig>,
+  snapshots: ChainMap<RateLimitedHookDeployInput>,
   deployedTokens: ChainMap<Address>,
   multiProvider: MultiProvider,
-  registryAddresses: ChainMap<ChainAddresses>,
   contractVerifier?: ContractVerifier,
-): Promise<void> {
-  await promiseObjAll(
-    objMap(snapshots, async (chain, hookConfig) => {
-      const tokenAddress = mustGet(deployedTokens, chain);
-      const chainAddresses = registryAddresses[chain];
-      assert(chainAddresses, `No registry addresses for ${chain}`);
-
-      const proxyAdminAddress = (
-        await multiProvider.handleDeploy(chain, new ProxyAdmin__factory(), [])
-      ).address;
-
-      const evmHookModule = await EvmHookModule.create({
+): Promise<ChainMap<Address>> {
+  return promiseObjAll(
+    objMap(
+      snapshots,
+      async (
         chain,
-        multiProvider,
-        coreAddresses: {
-          mailbox: chainAddresses.mailbox,
-          proxyAdmin: proxyAdminAddress,
-          rateLimitedSender: tokenAddress,
-        },
-        config: hookConfig,
-        proxyFactoryFactories:
-          extractIsmAndHookFactoryAddresses(chainAddresses),
-        contractVerifier,
-      });
+        { hookConfig, chainAddresses, ccipContractCache, proxyAdminAddress },
+      ) => {
+        const tokenAddress = mustGet(deployedTokens, chain);
+        assert(chainAddresses, `No registry addresses for ${chain}`);
 
-      const { deployedHook } = evmHookModule.serialize();
-      assert(deployedHook, `Failed to get deployed hook address for ${chain}`);
+        const resolvedProxyAdminAddress: Address =
+          proxyAdminAddress ??
+          (
+            await multiProvider.handleDeploy(
+              chain,
+              new ProxyAdmin__factory(),
+              [],
+            )
+          ).address;
 
-      rootLogger.info(
-        `Wiring RateLimitedHook ${deployedHook} to token ${tokenAddress} on ${chain}`,
-      );
-      const txOverrides = multiProvider.getTransactionOverrides(chain);
-      const signer = multiProvider.getSigner(chain);
-      const token = MailboxClient__factory.connect(tokenAddress, signer);
-      await multiProvider.handleTx(
-        chain,
-        token.setHook(deployedHook, txOverrides),
-      );
-    }),
+        const evmHookModule = await EvmHookModule.create({
+          chain,
+          multiProvider,
+          coreAddresses: {
+            mailbox: chainAddresses.mailbox,
+            proxyAdmin: resolvedProxyAdminAddress,
+            rateLimitedSender: tokenAddress,
+          },
+          config: hookConfig,
+          ccipContractCache,
+          proxyFactoryFactories:
+            extractIsmAndHookFactoryAddresses(chainAddresses),
+          contractVerifier,
+        });
+
+        const { deployedHook } = evmHookModule.serialize();
+        assert(
+          deployedHook,
+          `Failed to get deployed hook address for ${chain}`,
+        );
+
+        rootLogger.info(
+          `Wiring RateLimitedHook ${deployedHook} to token ${tokenAddress} on ${chain}`,
+        );
+        const txOverrides = multiProvider.getTransactionOverrides(chain);
+        const signer = multiProvider.getSigner(chain);
+        const token = MailboxClient__factory.connect(tokenAddress, signer);
+        await multiProvider.handleTx(
+          chain,
+          token.setHook(deployedHook, txOverrides),
+        );
+
+        return deployedHook;
+      },
+    ),
   );
 }
 
@@ -396,6 +453,7 @@ async function resolveWarpIsmAndHook(
   registryAddresses: ChainMap<ChainAddresses>,
   ismFactoryDeployer: HyperlaneProxyFactoryDeployer,
   contractVerifier: ContractVerifier,
+  rateLimitedHookSnapshots: ChainMap<RateLimitedHookDeployInput>,
 ): Promise<WarpRouteDeployConfigMailboxRequired> {
   return promiseObjAll(
     objMap(warpConfig, async (chain, config) => {
@@ -426,6 +484,7 @@ async function resolveWarpIsmAndHook(
         contractVerifier,
         ismFactoryDeployer,
         warpConfig: config,
+        rateLimitedHookSnapshots,
       });
       return config;
     }),
@@ -520,6 +579,7 @@ async function createWarpHook({
   altVmSigners,
   contractVerifier,
   warpConfig,
+  rateLimitedHookSnapshots,
 }: {
   ccipContractCache: CCIPContractCache;
   chain: string;
@@ -529,6 +589,7 @@ async function createWarpHook({
   contractVerifier?: ContractVerifier;
   warpConfig: HypTokenRouterConfig;
   ismFactoryDeployer: HyperlaneProxyFactoryDeployer;
+  rateLimitedHookSnapshots: ChainMap<RateLimitedHookDeployInput>;
 }): Promise<HookConfig | undefined> {
   const { hook } = warpConfig;
 
@@ -539,11 +600,25 @@ async function createWarpHook({
     return hook;
   }
 
-  // RATE_LIMITED hooks need the token router address as sender — defer until post-token deploy
+  // RATE_LIMITED hooks need the token router address as sender — defer until post-token deploy.
+  // Only EVM/Tron support EvmHookModule; non-EVM chains skip deferred deployment entirely.
   if (hookTreeContainsRateLimited(hook)) {
-    rootLogger.info(
-      `RATE_LIMITED hook on ${chain} — deferring deployment until after token deployment`,
-    );
+    const protocol = multiProvider.getProtocol(chain);
+    if (protocol === ProtocolType.Ethereum || protocol === ProtocolType.Tron) {
+      rootLogger.info(
+        `RATE_LIMITED hook on ${chain} — deferring deployment until after token deployment`,
+      );
+      rateLimitedHookSnapshots[chain] = {
+        hookConfig: hook,
+        chainAddresses,
+        ccipContractCache,
+        proxyAdminAddress: warpConfig.proxyAdmin?.address,
+      };
+    } else {
+      rootLogger.info(
+        `RATE_LIMITED hook on ${chain} — skipping (non-EVM chain does not support deferred hook deployment)`,
+      );
+    }
     return undefined;
   }
 

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -305,6 +305,11 @@ export async function executeWarpDeploy(
           contractVerifier,
         );
 
+        assert(
+          !warpDeployConfig.isNft || isObjEmpty(rateLimitedHookSnapshots),
+          'RATE_LIMITED hooks are not supported for NFT warp routes (HypERC721Deployer has no beforeTransferOwnership override)',
+        );
+
         const deployer = warpDeployConfig.isNft
           ? new HypERC721Deployer(multiProvider)
           : isObjEmpty(rateLimitedHookSnapshots)
@@ -601,24 +606,26 @@ async function createWarpHook({
   }
 
   // RATE_LIMITED hooks need the token router address as sender — defer until post-token deploy.
-  // Only EVM/Tron support EvmHookModule; non-EVM chains skip deferred deployment entirely.
+  // Only EVM/Tron support EvmHookModule; foreignDeployment and non-EVM chains cannot wire the hook.
   if (hookTreeContainsRateLimited(hook)) {
+    assert(
+      !warpConfig.foreignDeployment,
+      `RATE_LIMITED hook configured on ${chain} but it is a foreignDeployment — hook cannot be wired post-deploy`,
+    );
     const protocol = multiProvider.getProtocol(chain);
-    if (protocol === ProtocolType.Ethereum || protocol === ProtocolType.Tron) {
-      rootLogger.info(
-        `RATE_LIMITED hook on ${chain} — deferring deployment until after token deployment`,
-      );
-      rateLimitedHookSnapshots[chain] = {
-        hookConfig: hook,
-        chainAddresses,
-        ccipContractCache,
-        proxyAdminAddress: warpConfig.proxyAdmin?.address,
-      };
-    } else {
-      rootLogger.info(
-        `RATE_LIMITED hook on ${chain} — skipping (non-EVM chain does not support deferred hook deployment)`,
-      );
-    }
+    assert(
+      protocol === ProtocolType.Ethereum || protocol === ProtocolType.Tron,
+      `RATE_LIMITED hook is only supported on EVM/Tron chains; ${chain} uses protocol ${protocol}`,
+    );
+    rootLogger.info(
+      `RATE_LIMITED hook on ${chain} — deferring deployment until after token deployment`,
+    );
+    rateLimitedHookSnapshots[chain] = {
+      hookConfig: hook,
+      chainAddresses,
+      ccipContractCache,
+      proxyAdminAddress: warpConfig.proxyAdmin?.address,
+    };
     return undefined;
   }
 

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -1,4 +1,7 @@
-import { ProxyAdmin__factory } from '@hyperlane-xyz/core';
+import {
+  MailboxClient__factory,
+  ProxyAdmin__factory,
+} from '@hyperlane-xyz/core';
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
 import {
   createHookWriter,
@@ -49,6 +52,7 @@ import {
 } from '../contracts/types.js';
 import { EvmHookModule } from '../hook/EvmHookModule.js';
 import { HookConfig } from '../hook/types.js';
+import { hookTreeContainsRateLimited } from '../hook/utils.js';
 import { EvmIsmModule } from '../ism/EvmIsmModule.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { IsmConfig } from '../ism/types.js';
@@ -200,6 +204,15 @@ export async function executeWarpDeploy(
     contractVerifier,
   );
 
+  // Snapshot hook configs that contain RATE_LIMITED before resolveWarpIsmAndHook strips them.
+  // These hooks need the token router address (not yet deployed), so we defer them.
+  const rateLimitedHookSnapshots: ChainMap<HookConfig> = {};
+  for (const [chain, config] of Object.entries(warpDeployConfig)) {
+    if (config.hook && hookTreeContainsRateLimited(config.hook as HookConfig)) {
+      rateLimitedHookSnapshots[chain] = config.hook as HookConfig;
+    }
+  }
+
   // For each chain in WarpRouteConfig, deploy each Ism Factory, if it's not in the registry
   // Then return a modified config with the ism and/or hook address as a string
   const modifiedConfig = await resolveWarpIsmAndHook(
@@ -315,7 +328,65 @@ export async function executeWarpDeploy(
     }
   }
 
+  if (Object.keys(rateLimitedHookSnapshots).length > 0) {
+    await deployAndWireRateLimitedHooks(
+      rateLimitedHookSnapshots,
+      deployedContracts,
+      multiProvider,
+      registryAddresses,
+      contractVerifier,
+    );
+  }
+
   return deployedContracts;
+}
+
+async function deployAndWireRateLimitedHooks(
+  snapshots: ChainMap<HookConfig>,
+  deployedTokens: ChainMap<Address>,
+  multiProvider: MultiProvider,
+  registryAddresses: ChainMap<ChainAddresses>,
+  contractVerifier?: ContractVerifier,
+): Promise<void> {
+  await promiseObjAll(
+    objMap(snapshots, async (chain, hookConfig) => {
+      const tokenAddress = mustGet(deployedTokens, chain);
+      const chainAddresses = registryAddresses[chain];
+      assert(chainAddresses, `No registry addresses for ${chain}`);
+
+      const proxyAdminAddress = (
+        await multiProvider.handleDeploy(chain, new ProxyAdmin__factory(), [])
+      ).address;
+
+      const evmHookModule = await EvmHookModule.create({
+        chain,
+        multiProvider,
+        coreAddresses: {
+          mailbox: chainAddresses.mailbox,
+          proxyAdmin: proxyAdminAddress,
+          rateLimitedSender: tokenAddress,
+        },
+        config: hookConfig,
+        proxyFactoryFactories:
+          extractIsmAndHookFactoryAddresses(chainAddresses),
+        contractVerifier,
+      });
+
+      const { deployedHook } = evmHookModule.serialize();
+      assert(deployedHook, `Failed to get deployed hook address for ${chain}`);
+
+      rootLogger.info(
+        `Wiring RateLimitedHook ${deployedHook} to token ${tokenAddress} on ${chain}`,
+      );
+      const txOverrides = multiProvider.getTransactionOverrides(chain);
+      const signer = multiProvider.getSigner(chain);
+      const token = MailboxClient__factory.connect(tokenAddress, signer);
+      await multiProvider.handleTx(
+        chain,
+        token.setHook(deployedHook, txOverrides),
+      );
+    }),
+  );
 }
 
 async function resolveWarpIsmAndHook(
@@ -466,6 +537,14 @@ async function createWarpHook({
       `Config Hook is ${!hook ? 'empty' : hook}, skipping deployment.`,
     );
     return hook;
+  }
+
+  // RATE_LIMITED hooks need the token router address as sender — defer until post-token deploy
+  if (hookTreeContainsRateLimited(hook)) {
+    rootLogger.info(
+      `RATE_LIMITED hook on ${chain} — deferring deployment until after token deployment`,
+    );
+    return undefined;
   }
 
   rootLogger.info(`Loading registry factory addresses for ${chain}...`);

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -42,6 +42,7 @@ import {
   MUTABLE_HOOK_TYPE,
   PausableHookConfig,
   ProtocolFeeHookConfig,
+  RateLimitedHookConfig,
 } from './types.js';
 
 const hookTypes = Object.values(HookType);
@@ -818,6 +819,25 @@ describe('EvmHookModule', async () => {
 
       // expect 1 tx to update the paused state
       await expectTxsAndUpdate(hook, config, 1);
+    });
+
+    it('should update maxCapacity on RateLimitedHook in place via setRefillRate', async () => {
+      const owner = await multiProvider.getSignerAddress(chain);
+      const config: RateLimitedHookConfig = {
+        owner,
+        type: HookType.RATE_LIMITED,
+        maxCapacity: (86400n * 100n).toString(),
+      };
+
+      const { hook, initialHookAddress } = await createHook(config);
+
+      config.maxCapacity = (86400n * 200n).toString();
+
+      // exactly 1 tx — setRefillRate, not a redeploy
+      await expectTxsAndUpdate(hook, config, 1);
+
+      // address unchanged: in-place update, not a new deployment
+      expect(hook.serialize().deployedHook).to.equal(initialHookAddress);
     });
 
     for (const type of [HookType.ROUTING, HookType.FALLBACK_ROUTING]) {

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -158,15 +158,11 @@ describe('EvmHookModule', async () => {
   async function createHook(
     config: HookConfig,
   ): Promise<{ hook: EvmHookModule; initialHookAddress: Address }> {
-    const rateLimitedSender =
-      typeof config !== 'string' && config.type === HookType.RATE_LIMITED
-        ? randomAddress()
-        : undefined;
     const hook = await EvmHookModule.create({
       chain,
       config,
       proxyFactoryFactories: proxyFactoryAddresses,
-      coreAddresses: { ...coreAddresses, rateLimitedSender },
+      coreAddresses: { ...coreAddresses, rateLimitedSender: randomAddress() },
       multiProvider,
     });
     testHook = hook;

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -158,11 +158,15 @@ describe('EvmHookModule', async () => {
   async function createHook(
     config: HookConfig,
   ): Promise<{ hook: EvmHookModule; initialHookAddress: Address }> {
+    const rateLimitedSender =
+      typeof config !== 'string' && config.type === HookType.RATE_LIMITED
+        ? randomAddress()
+        : undefined;
     const hook = await EvmHookModule.create({
       chain,
       config,
       proxyFactoryFactories: proxyFactoryAddresses,
-      coreAddresses,
+      coreAddresses: { ...coreAddresses, rateLimitedSender },
       multiProvider,
     });
     testHook = hook;

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -908,14 +908,12 @@ export class EvmHookModule extends HyperlaneModule<
   }): Promise<RateLimitedHook> {
     this.logger.debug('Deploying RateLimitedHook...');
     const deployer = new HookDeployer(this.multiProvider, hookFactories);
+    const sender = this.args.addresses.rateLimitedSender;
+    assert(sender, 'rateLimitedSender is required to deploy RateLimitedHook');
     const hook = await deployer.deployContract(
       this.chain,
       HookType.RATE_LIMITED,
-      [
-        this.args.addresses.mailbox,
-        config.maxCapacity,
-        this.args.addresses.rateLimitedSender ?? ethers.constants.AddressZero,
-      ],
+      [this.args.addresses.mailbox, config.maxCapacity, sender],
     );
 
     if (config.owner) {

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -25,6 +25,8 @@ import {
   ProxyAdmin__factory,
   ProtocolFee,
   ProtocolFee__factory,
+  RateLimitedHook,
+  RateLimitedHook__factory,
   StaticAggregationHook,
   StaticAggregationHookFactory__factory,
   StaticAggregationHook__factory,
@@ -91,12 +93,15 @@ import {
   OpStackHookConfig,
   PausableHookConfig,
   ProtocolFeeHookConfig,
+  RateLimitedHookConfig,
 } from './types.js';
 
 type HookModuleAddresses = {
   deployedHook: Address;
   mailbox: Address;
   proxyAdmin: Address;
+  // Injected by warp deploy path; used as constructor arg for RateLimitedHook.
+  rateLimitedSender?: Address;
 };
 
 class HookDeployer extends HyperlaneDeployer<{}, HookFactories> {
@@ -229,7 +234,9 @@ export class EvmHookModule extends HyperlaneModule<
     chain: ChainNameOrId;
     config: HookConfig;
     proxyFactoryFactories: HyperlaneAddresses<ProxyFactoryFactories>;
-    coreAddresses: Omit<CoreAddresses, 'validatorAnnounce' | 'quotedCalls'>;
+    coreAddresses: Omit<CoreAddresses, 'validatorAnnounce' | 'quotedCalls'> & {
+      rateLimitedSender?: Address;
+    };
     multiProvider: MultiProvider;
     ccipContractCache?: CCIPContractCache;
     contractVerifier?: ContractVerifier;
@@ -339,6 +346,14 @@ export class EvmHookModule extends HyperlaneModule<
         currentConfig: current,
         targetConfig: target,
       });
+    } else if (
+      current.type === HookType.RATE_LIMITED &&
+      target.type === HookType.RATE_LIMITED
+    ) {
+      updateTxs = await this.updateRateLimitedHook({
+        currentConfig: current,
+        targetConfig: target,
+      });
     } else {
       throw new Error(`Unsupported hook type: ${target.type}`);
     }
@@ -350,7 +365,7 @@ export class EvmHookModule extends HyperlaneModule<
     ).owner();
 
     // Return an ownership transfer transaction if required
-    if (!eqAddress(target.owner, owner)) {
+    if (target.owner != null && !eqAddress(target.owner, owner)) {
       updateTxs.push({
         annotation: 'Transferring ownership of ownable Hook...',
         chainId: this.chainId,
@@ -387,6 +402,30 @@ export class EvmHookModule extends HyperlaneModule<
         chainId: this.chainId,
         to: this.args.addresses.deployedHook,
         data,
+      });
+    }
+
+    return updateTxs;
+  }
+
+  protected async updateRateLimitedHook({
+    currentConfig,
+    targetConfig,
+  }: {
+    currentConfig: RateLimitedHookConfig;
+    targetConfig: RateLimitedHookConfig;
+  }): Promise<AnnotatedEV5Transaction[]> {
+    const updateTxs: AnnotatedEV5Transaction[] = [];
+
+    if (currentConfig.maxCapacity !== targetConfig.maxCapacity) {
+      updateTxs.push({
+        annotation: `Setting maxCapacity on RateLimitedHook on chain "${this.chain}" and address "${this.args.addresses.deployedHook}"`,
+        chainId: this.chainId,
+        to: this.args.addresses.deployedHook,
+        data: RateLimitedHook__factory.createInterface().encodeFunctionData(
+          'setRefillRate',
+          [targetConfig.maxCapacity],
+        ),
       });
     }
 
@@ -818,6 +857,8 @@ export class EvmHookModule extends HyperlaneModule<
           config.address,
           this.multiProvider.getSignerOrProvider(this.args.chain),
         );
+      case HookType.RATE_LIMITED:
+        return this.deployRateLimitedHook({ config });
       default:
         throw new Error(`Unsupported hook config: ${config}`);
     }
@@ -856,6 +897,33 @@ export class EvmHookModule extends HyperlaneModule<
       this.chain,
       hook.transferOwnership(config.owner, this.txOverrides),
     );
+
+    return hook;
+  }
+
+  protected async deployRateLimitedHook({
+    config,
+  }: {
+    config: RateLimitedHookConfig;
+  }): Promise<RateLimitedHook> {
+    this.logger.debug('Deploying RateLimitedHook...');
+    const deployer = new HookDeployer(this.multiProvider, hookFactories);
+    const hook = await deployer.deployContract(
+      this.chain,
+      HookType.RATE_LIMITED,
+      [
+        this.args.addresses.mailbox,
+        config.maxCapacity,
+        this.args.addresses.rateLimitedSender ?? ethers.constants.AddressZero,
+      ],
+    );
+
+    if (config.owner) {
+      await this.multiProvider.handleTx(
+        this.chain,
+        hook.transferOwnership(config.owner, this.txOverrides),
+      );
+    }
 
     return hook;
   }

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -365,7 +365,7 @@ export class EvmHookModule extends HyperlaneModule<
     ).owner();
 
     // Return an ownership transfer transaction if required
-    if (target.owner != null && !eqAddress(target.owner, owner)) {
+    if (!eqAddress(target.owner, owner)) {
       updateTxs.push({
         annotation: 'Transferring ownership of ownable Hook...',
         chainId: this.chainId,
@@ -419,7 +419,7 @@ export class EvmHookModule extends HyperlaneModule<
 
     if (currentConfig.maxCapacity !== targetConfig.maxCapacity) {
       updateTxs.push({
-        annotation: `Setting maxCapacity on RateLimitedHook on chain "${this.chain}" and address "${this.args.addresses.deployedHook}"`,
+        annotation: `Setting refill rate on RateLimitedHook on chain "${this.chain}" and address "${this.args.addresses.deployedHook}"`,
         chainId: this.chainId,
         to: this.args.addresses.deployedHook,
         data: RateLimitedHook__factory.createInterface().encodeFunctionData(

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -15,6 +15,7 @@ import {
   OPStackHook__factory,
   PausableHook__factory,
   ProtocolFee__factory,
+  RateLimitedHook__factory,
   StaticAggregationHook__factory,
   StorageGasOracle__factory,
 } from '@hyperlane-xyz/core';
@@ -53,6 +54,7 @@ import {
   OpStackHookConfig,
   PausableHookConfig,
   ProtocolFeeHookConfig,
+  RateLimitedHookConfig,
   RoutingHookConfig,
 } from './types.js';
 
@@ -85,6 +87,9 @@ export interface HookReader {
   ): Promise<WithAddress<PausableHookConfig>>;
   deriveIdAuthIsmConfig(address: Address): Promise<DerivedHookConfig>;
   deriveCcipConfig(address: Address): Promise<WithAddress<CCIPHookConfig>>;
+  deriveRateLimitedHookConfig(
+    address: Address,
+  ): Promise<WithAddress<RateLimitedHookConfig>>;
   assertHookType(
     hookType: OnchainHookType,
     expectedType: OnchainHookType,
@@ -182,6 +187,9 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
         case OnchainHookType.CCTP:
           derivedHookConfig = { type: HookType.CCTP, address };
           this._cache.set(address, derivedHookConfig);
+          break;
+        case OnchainHookType.RATE_LIMITED:
+          derivedHookConfig = await this.deriveRateLimitedHookConfig(address);
           break;
         default:
           throw new Error(
@@ -312,6 +320,28 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
       address,
       type: HookType.CCIP,
       destinationChain,
+    };
+
+    this._cache.set(address, config);
+
+    return config;
+  }
+
+  async deriveRateLimitedHookConfig(
+    address: Address,
+  ): Promise<WithAddress<RateLimitedHookConfig>> {
+    const hook = RateLimitedHook__factory.connect(address, this.provider);
+
+    const [maxCapacity, owner] = await Promise.all([
+      hook.maxCapacity(),
+      hook.owner(),
+    ]);
+
+    const config: WithAddress<RateLimitedHookConfig> = {
+      address,
+      type: HookType.RATE_LIMITED,
+      maxCapacity: maxCapacity.toString(),
+      owner,
     };
 
     this._cache.set(address, config);

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -332,10 +332,13 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
   ): Promise<WithAddress<RateLimitedHookConfig>> {
     const hook = RateLimitedHook__factory.connect(address, this.provider);
 
-    const [maxCapacity, owner] = await Promise.all([
+    const [hookType, maxCapacity, owner] = await Promise.all([
+      hook.hookType(),
       hook.maxCapacity(),
       hook.owner(),
     ]);
+
+    this.assertHookType(hookType, OnchainHookType.RATE_LIMITED);
 
     const config: WithAddress<RateLimitedHookConfig> = {
       address,

--- a/typescript/sdk/src/hook/contracts.ts
+++ b/typescript/sdk/src/hook/contracts.ts
@@ -10,6 +10,7 @@ import {
   OPStackHook__factory,
   PausableHook__factory,
   ProtocolFee__factory,
+  RateLimitedHook__factory,
   StaticAggregationHook__factory,
 } from '@hyperlane-xyz/core';
 import { ValueOf } from '@hyperlane-xyz/utils';
@@ -29,6 +30,7 @@ export const hookFactories = {
   [HookType.AMOUNT_ROUTING]: new AmountRoutingHook__factory(),
   [HookType.MAILBOX_DEFAULT]: new DefaultHook__factory(),
   [HookType.CCIP]: new CCIPHook__factory(),
+  [HookType.RATE_LIMITED]: new RateLimitedHook__factory(),
 };
 
 export type HookFactories = typeof hookFactories;

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 
-import { Address, WithAddress, isNullish } from '@hyperlane-xyz/utils';
+import {
+  Address,
+  WithAddress,
+  isNullish,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
 
 import { ProtocolAgnositicGasOracleConfigWithTypicalCostSchema } from '../gas/oracle/types.js';
 import { ZHash } from '../metadata/customZodTypes.js';
@@ -58,6 +63,11 @@ export const HookType = {
    * `EvmHookModule.deploy` path just connects to `config.address`.
    */
   CCTP: 'cctpHook',
+  /**
+   * Rate-limits outbound token volume on the origin chain at dispatch time.
+   * Warp-route only. Not valid for core required/default hooks.
+   */
+  RATE_LIMITED: 'rateLimitedHook',
   UNKNOWN: 'unknownHook',
   PREDICATE: 'predicateHook',
 } as const;
@@ -85,6 +95,7 @@ export const HookTypeToContractNameMap: Record<DeployableHookType, string> = {
   [HookType.ARB_L2_TO_L1]: 'arbL2ToL1Hook',
   [HookType.MAILBOX_DEFAULT]: 'defaultHook',
   [HookType.CCIP]: 'ccipHook',
+  [HookType.RATE_LIMITED]: 'rateLimitedHook',
 };
 
 export type MerkleTreeHookConfig = z.infer<typeof MerkleTreeSchema>;
@@ -94,6 +105,7 @@ export type PausableHookConfig = z.infer<typeof PausableHookSchema>;
 export type OpStackHookConfig = z.infer<typeof OpStackHookSchema>;
 export type ArbL2ToL1HookConfig = z.infer<typeof ArbL2ToL1HookSchema>;
 export type MailboxDefaultHookConfig = z.infer<typeof MailboxDefaultHookSchema>;
+export type RateLimitedHookConfig = z.infer<typeof RateLimitedHookSchema>;
 
 export type CCIPHookConfig = z.infer<typeof CCIPHookSchema>;
 // explicitly typed to avoid zod circular dependency
@@ -129,6 +141,7 @@ export const MUTABLE_HOOK_TYPE: HookType[] = [
   HookType.ROUTING,
   HookType.FALLBACK_ROUTING,
   HookType.PAUSABLE,
+  HookType.RATE_LIMITED,
 ];
 
 export const ProtocolFeeSchema = OwnableSchema.extend({
@@ -242,6 +255,29 @@ export const UnknownHookSchema = z
   .passthrough();
 export type UnknownHookConfig = z.infer<typeof UnknownHookSchema>;
 
+export const RateLimitedHookSchema = OwnableSchema.partial()
+  .extend({
+    type: z.literal(HookType.RATE_LIMITED),
+    maxCapacity: z
+      .string()
+      .regex(/^\d+$/, 'maxCapacity must be a base-10 integer string'),
+  })
+  .refine((val) => BigInt(val.maxCapacity) >= 86400n, {
+    message: 'maxCapacity must be at least 86400',
+    path: ['maxCapacity'],
+  })
+  .transform((val) => {
+    const capacity = BigInt(val.maxCapacity);
+    if (capacity % 86400n !== 0n) {
+      const rounded = ((capacity / 86400n) * 86400n).toString();
+      rootLogger.warn(
+        `RateLimitedHook maxCapacity ${val.maxCapacity} is not divisible by 86400; rounding down to ${rounded}`,
+      );
+      return { ...val, maxCapacity: rounded };
+    }
+    return val;
+  });
+
 const KnownHookTypes: string[] = Object.values(HookType).filter(
   (t) => t !== HookType.UNKNOWN,
 );
@@ -298,6 +334,7 @@ export const HookConfigSchema = z.union([
   MailboxDefaultHookSchema,
   CCIPHookSchema,
   CctpHookSchema,
+  RateLimitedHookSchema,
   UnknownHookSchema,
   PredicateHookSchema,
 ]);

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -1,11 +1,6 @@
 import { z } from 'zod';
 
-import {
-  Address,
-  WithAddress,
-  isNullish,
-  rootLogger,
-} from '@hyperlane-xyz/utils';
+import { Address, WithAddress, isNullish } from '@hyperlane-xyz/utils';
 
 import { ProtocolAgnositicGasOracleConfigWithTypicalCostSchema } from '../gas/oracle/types.js';
 import { ZHash } from '../metadata/customZodTypes.js';
@@ -255,27 +250,19 @@ export const UnknownHookSchema = z
   .passthrough();
 export type UnknownHookConfig = z.infer<typeof UnknownHookSchema>;
 
-export const RateLimitedHookSchema = OwnableSchema.partial()
-  .extend({
-    type: z.literal(HookType.RATE_LIMITED),
-    maxCapacity: z
-      .string()
-      .regex(/^\d+$/, 'maxCapacity must be a base-10 integer string'),
-  })
+export const RateLimitedHookSchema = OwnableSchema.extend({
+  type: z.literal(HookType.RATE_LIMITED),
+  maxCapacity: z
+    .string()
+    .regex(/^\d+$/, 'maxCapacity must be a base-10 integer string'),
+})
   .refine((val) => BigInt(val.maxCapacity) >= 86400n, {
     message: 'maxCapacity must be at least 86400',
     path: ['maxCapacity'],
   })
-  .transform((val) => {
-    const capacity = BigInt(val.maxCapacity);
-    if (capacity % 86400n !== 0n) {
-      const rounded = ((capacity / 86400n) * 86400n).toString();
-      rootLogger.warn(
-        `RateLimitedHook maxCapacity ${val.maxCapacity} is not divisible by 86400; rounding down to ${rounded}`,
-      );
-      return { ...val, maxCapacity: rounded };
-    }
-    return val;
+  .refine((val) => BigInt(val.maxCapacity) % 86400n === 0n, {
+    message: 'maxCapacity must be a multiple of 86400 (seconds per day)',
+    path: ['maxCapacity'],
   });
 
 const KnownHookTypes: string[] = Object.values(HookType).filter(

--- a/typescript/sdk/src/hook/updates.ts
+++ b/typescript/sdk/src/hook/updates.ts
@@ -28,6 +28,7 @@ type UpdateHookParams = {
   setHookFunctionCallEncoder: (newHookAddress: Address) => string;
   ccipContractCache?: CCIPContractCache;
   contractVerifier?: ContractVerifier;
+  rateLimitedSender?: Address;
 };
 
 export async function getEvmHookUpdateTransactions(
@@ -48,6 +49,7 @@ export async function getEvmHookUpdateTransactions(
     multiProvider,
     ccipContractCache,
     contractVerifier,
+    rateLimitedSender,
   } = updateHookParams;
 
   const hookModule = new EvmHookModule(
@@ -63,6 +65,7 @@ export async function getEvmHookUpdateTransactions(
           typeof actualHookConfig === 'string'
             ? actualHookConfig
             : actualHookConfig.address,
+        ...(rateLimitedSender ? { rateLimitedSender } : {}),
       },
     },
     ccipContractCache,

--- a/typescript/sdk/src/hook/utils.ts
+++ b/typescript/sdk/src/hook/utils.ts
@@ -2,10 +2,7 @@ import { ChainTechnicalStack } from '../metadata/chainMetadataTypes.js';
 
 import {
   AggregationHookConfig,
-  AmountRoutingHookConfig,
   DerivedHookConfig,
-  DomainRoutingHookConfig,
-  FallbackRoutingHookConfig,
   HookConfig,
   HookType,
 } from './types.js';
@@ -40,31 +37,25 @@ export function hookTreeContainsRateLimited(
   if (!hook || typeof hook === 'string') return false;
   if (hook.type === HookType.RATE_LIMITED) return true;
   if (hook.type === HookType.AGGREGATION) {
-    return (hook as AggregationHookConfig).hooks.some((h) =>
-      hookTreeContainsRateLimited(h as HookConfig),
-    );
+    return hook.hooks.some(hookTreeContainsRateLimited);
   }
-  if (
-    hook.type === HookType.ROUTING ||
-    hook.type === HookType.FALLBACK_ROUTING
-  ) {
-    const routing = hook as DomainRoutingHookConfig | FallbackRoutingHookConfig;
-    if (
-      Object.values(routing.domains).some((h) =>
-        hookTreeContainsRateLimited(h as HookConfig),
-      )
-    )
-      return true;
-    if ('fallback' in routing)
-      return hookTreeContainsRateLimited(routing.fallback as HookConfig);
-    return false;
+  if (hook.type === HookType.ROUTING) {
+    return Object.values(hook.domains).some(hookTreeContainsRateLimited);
+  }
+  if (hook.type === HookType.FALLBACK_ROUTING) {
+    return (
+      Object.values(hook.domains).some(hookTreeContainsRateLimited) ||
+      hookTreeContainsRateLimited(hook.fallback)
+    );
   }
   if (hook.type === HookType.AMOUNT_ROUTING) {
-    const ar = hook as AmountRoutingHookConfig;
     return (
-      hookTreeContainsRateLimited(ar.lowerHook) ||
-      hookTreeContainsRateLimited(ar.upperHook)
+      hookTreeContainsRateLimited(hook.lowerHook) ||
+      hookTreeContainsRateLimited(hook.upperHook)
     );
+  }
+  if (hook.type === HookType.ARB_L2_TO_L1) {
+    return hookTreeContainsRateLimited(hook.childHook as HookConfig);
   }
   return false;
 }

--- a/typescript/sdk/src/hook/utils.ts
+++ b/typescript/sdk/src/hook/utils.ts
@@ -1,14 +1,15 @@
 import { ChainTechnicalStack } from '../metadata/chainMetadataTypes.js';
 
-import { AggregationHookConfig, DerivedHookConfig, HookType } from './types.js';
+import {
+  AggregationHookConfig,
+  AmountRoutingHookConfig,
+  DerivedHookConfig,
+  DomainRoutingHookConfig,
+  FallbackRoutingHookConfig,
+  HookConfig,
+  HookType,
+} from './types.js';
 
-/**
- * Checks if the given hook type is compatible with the chain's technical stack.
- *
- * @param {HookType} params.hookType - The type of hook
- * @param {ChainTechnicalStack | undefined} params.chainTechnicalStack - The technical stack of the chain
- * @returns {boolean} True if the hook type is compatible with the chain, false otherwise
- */
 /**
  * Strips the PREDICATE sub-hook from an aggregation hook config.
  * If the aggregation contains exactly one non-predicate hook, unwraps it.
@@ -31,6 +32,41 @@ export function stripPredicateSubHook(
   if (remaining.length === 1) return remaining[0] as DerivedHookConfig | string;
   // Multiple non-predicate hooks remain — can't construct without on-chain address
   return hook;
+}
+
+export function hookTreeContainsRateLimited(
+  hook: HookConfig | undefined,
+): boolean {
+  if (!hook || typeof hook === 'string') return false;
+  if (hook.type === HookType.RATE_LIMITED) return true;
+  if (hook.type === HookType.AGGREGATION) {
+    return (hook as AggregationHookConfig).hooks.some((h) =>
+      hookTreeContainsRateLimited(h as HookConfig),
+    );
+  }
+  if (
+    hook.type === HookType.ROUTING ||
+    hook.type === HookType.FALLBACK_ROUTING
+  ) {
+    const routing = hook as DomainRoutingHookConfig | FallbackRoutingHookConfig;
+    if (
+      Object.values(routing.domains).some((h) =>
+        hookTreeContainsRateLimited(h as HookConfig),
+      )
+    )
+      return true;
+    if ('fallback' in routing)
+      return hookTreeContainsRateLimited(routing.fallback as HookConfig);
+    return false;
+  }
+  if (hook.type === HookType.AMOUNT_ROUTING) {
+    const ar = hook as AmountRoutingHookConfig;
+    return (
+      hookTreeContainsRateLimited(ar.lowerHook) ||
+      hookTreeContainsRateLimited(ar.upperHook)
+    );
+  }
+  return false;
 }
 
 export const isHookCompatible = ({

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -259,9 +259,11 @@ export {
   PausableHookSchema,
   ProtocolFeeHookConfig,
   ProtocolFeeSchema,
+  RateLimitedHookConfig,
+  RateLimitedHookSchema,
   SafeParseHookConfigSchema,
 } from './hook/types.js';
-export { isHookCompatible } from './hook/utils.js';
+export { hookTreeContainsRateLimited, isHookCompatible } from './hook/utils.js';
 export { EvmIsmReader } from './ism/EvmIsmReader.js';
 export { HyperlaneIsmFactory } from './ism/HyperlaneIsmFactory.js';
 // Note: MetadataBuilder types are now exported from @hyperlane-xyz/relayer

--- a/typescript/sdk/src/router/HyperlaneRouterDeployer.ts
+++ b/typescript/sdk/src/router/HyperlaneRouterDeployer.ts
@@ -107,6 +107,11 @@ export abstract class HyperlaneRouterDeployer<
     );
   }
 
+  protected async beforeTransferOwnership(
+    _contractsMap: HyperlaneContractsMap<Factories>,
+    _configMap: ChainMap<Config>,
+  ): Promise<void> {}
+
   async transferOwnership(
     contractsMap: HyperlaneContractsMap<Factories>,
     configMap: ChainMap<Config>,
@@ -150,6 +155,7 @@ export abstract class HyperlaneRouterDeployer<
     );
     await this.deployAndConfigureTokenFees(deployedContractsMap, configMap);
     await this.configureClients(deployedContractsMap, configMap);
+    await this.beforeTransferOwnership(deployedContractsMap, configMap);
     await this.transferOwnership(deployedContractsMap, configMap);
     this.logger.debug(`Finished deploying router contracts for all chains.`);
 

--- a/typescript/sdk/src/test/testUtils.ts
+++ b/typescript/sdk/src/test/testUtils.ts
@@ -279,7 +279,7 @@ export function randomHookConfig(
       return {
         owner: randomAddress(),
         type: hookType,
-        maxCapacity: (86400 + Math.floor(Math.random() * 1000000)).toString(),
+        maxCapacity: ((1 + Math.floor(Math.random() * 100)) * 86400).toString(),
       };
 
     default:

--- a/typescript/sdk/src/test/testUtils.ts
+++ b/typescript/sdk/src/test/testUtils.ts
@@ -275,6 +275,13 @@ export function randomHookConfig(
         upperHook: randomHookConfig(depth + 1, maxDepth),
       };
 
+    case HookType.RATE_LIMITED:
+      return {
+        owner: randomAddress(),
+        type: hookType,
+        maxCapacity: (86400 + Math.floor(Math.random() * 1000000)).toString(),
+      };
+
     default:
       throw new Error(`Unsupported Hook type: ${hookType}`);
   }

--- a/typescript/sdk/src/token/EvmWarpModule.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.ts
@@ -1237,6 +1237,7 @@ export class EvmWarpModule extends HyperlaneModule<
           mailbox: actualConfig.mailbox,
           multiProvider: this.multiProvider,
           proxyAdminAddress,
+          rateLimitedSender: this.args.addresses.deployedTokenRoute,
         },
       );
       hookTransactions = result.transactions;


### PR DESCRIPTION
## Summary

- Added `RateLimitedHook` as a deployable hook type for warp routes, including full deploy, read, and apply (in-place update) support.
- Solves the chicken-and-egg problem: `RateLimitedHook` requires the token router address as its immutable `sender`, but hooks are deployed before tokens. The deploy flow now snapshots RATE_LIMITED configs, skips them during hook deploy, deploys them after the token is wired, then calls `setHook()` on the token.
- `sender` is fully internal — users never specify it, it is not printed by `warp read`, and it is not in the public `RateLimitedHookConfig` type. The token router address is threaded through `HookModuleAddresses.rateLimitedSender` and `UpdateHookParams.rateLimitedSender`.
- `maxCapacity` updates via `warp apply` call `setRefillRate()` in-place (no redeploy needed); `RATE_LIMITED` is included in `MUTABLE_HOOK_TYPE`.
- Nested RATE_LIMITED hooks inside `AGGREGATION` trees are handled by `hookTreeContainsRateLimited`, which walks the full hook tree.

## Files changed

| File | Change |
|------|--------|
| `hook/types.ts` | Added `RateLimitedHookSchema`, `RateLimitedHookConfig`, `MUTABLE_HOOK_TYPE` entry |
| `hook/contracts.ts` | Registered `RateLimitedHook__factory` |
| `hook/EvmHookReader.ts` | Added `deriveRateLimitedHookConfig` (no sender field) |
| `hook/EvmHookModule.ts` | Added deploy + in-place update (`setRefillRate`) for RATE_LIMITED; added `rateLimitedSender` to `HookModuleAddresses` |
| `hook/updates.ts` | Added `rateLimitedSender` to `UpdateHookParams` |
| `hook/utils.ts` | Added `hookTreeContainsRateLimited` |
| `deploy/warp.ts` | Snapshot + deferred deploy for RATE_LIMITED hooks via `deployAndWireRateLimitedHooks` |
| `token/EvmWarpModule.ts` | Passes `rateLimitedSender` (deployed token route) through hook update path |
| `index.ts` | Exports `RateLimitedHookConfig`, `RateLimitedHookSchema`, `hookTreeContainsRateLimited`, `isHookCompatible` |
| `warp-deploy-1.e2e-test.ts` | Added deploy tests for direct and aggregation-nested RATE_LIMITED hooks |
| `warp-apply-hook-updates.e2e-test.ts` | Added apply test for in-place `maxCapacity` update |

## Test plan

- [ ] `pnpm -C typescript/cli test:ethereum:e2e` — all warp deploy and apply tests pass
- [ ] "should deploy with a RateLimitedHook" — verifies type and maxCapacity after deploy
- [ ] "should deploy a RateLimitedHook nested inside an AggregationHook" — verifies nested hook wiring
- [ ] "should deploy a warp route with a RateLimitedHook and update its maxCapacity in place" — verifies `setRefillRate` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)