### PR TITLE
fix: improve derive token type

### DIFF
--- a/.changeset/thin-deers-judge.md
+++ b/.changeset/thin-deers-judge.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Improved derive token type by only fetching code once

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -43,6 +43,7 @@ import {
   objMap,
   promiseObjAll,
   rootLogger,
+  strip0x,
 } from '@hyperlane-xyz/utils';
 
 import { ExplorerLicenseType } from '../block-explorer/etherscan.js';
@@ -67,7 +68,12 @@ import { DestinationGas } from '../router/types.js';
 import { ChainName, ChainNameOrId, DeployedOwnableConfig } from '../types.js';
 import { NormalizedScale } from '../utils/decimals.js';
 
-import { isProxy, proxyAdmin, proxyImplementation } from './../deploy/proxy.js';
+import {
+  isProxy,
+  isStorageEmpty,
+  proxyAdmin,
+  proxyImplementation,
+} from './../deploy/proxy.js';
 import { NON_ZERO_SENDER_ADDRESS, TokenType } from './config.js';
 import {
   CctpTokenConfig,
@@ -615,7 +621,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     try {
       // Fetch implementation bytecode once; scanning selectors locally avoids
       // reverted eth_calls for methods that don't exist on the contract.
-      // Read the EIP-1967 impl slot directly so UUPS/beacon proxies (which have
+      // Read the EIP-1967 impl slot directly so UUPS proxies (which have
       // an empty admin slot) are resolved correctly alongside TransparentProxy.
       // Wrapped in try/catch so EOAs / bad addresses don't throw here — bytecode
       // will be '0x' and the selector guard falls through to probes as pre-PR.
@@ -636,7 +642,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
         // When bytecode is unavailable ('0x'), fall through to the probe anyway
         // to preserve pre-optimization behavior on zero-impl / flaky-RPC paths.
         const selector = factory.createInterface().getSighash(method);
-        if (bytecode !== '0x' && !bytecode.includes(selector.slice(2)))
+        if (!isStorageEmpty(bytecode) && !bytecode.includes(strip0x(selector)))
           continue;
 
         try {

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -674,43 +674,26 @@ export class EvmWarpRouteReader extends EvmRouterReader {
                 'everclearAdapter',
               );
             if (bytecode.includes(everclearSelector.slice(2))) {
+              let everclearTokenType: TokenType = TokenType.collateralEverclear;
               try {
-                const maybeEverclearTokenBridge =
-                  EverclearTokenBridge__factory.connect(
-                    warpRouteAddress,
-                    this.provider,
-                  );
+                // if simulating an ETH transfer works this should be the WETH contract
+                await this.provider.estimateGas({
+                  from: NON_ZERO_SENDER_ADDRESS,
+                  to: wrappedToken,
+                  data: IWETH__factory.createInterface().encodeFunctionData(
+                    'deposit',
+                  ),
+                  value: 0,
+                });
 
-                await maybeEverclearTokenBridge.callStatic.everclearAdapter();
-
-                let everclearTokenType: TokenType =
-                  TokenType.collateralEverclear;
-                try {
-                  // if simulating an ETH transfer works this should be the WETH contract
-                  await this.provider.estimateGas({
-                    from: NON_ZERO_SENDER_ADDRESS,
-                    to: wrappedToken,
-                    data: IWETH__factory.createInterface().encodeFunctionData(
-                      'deposit',
-                    ),
-                    value: 0,
-                  });
-
-                  everclearTokenType = TokenType.ethEverclear;
-                } catch (error) {
-                  this.logger.debug(
-                    `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.collateralEverclear}`,
-                    error,
-                  );
-                }
-
-                return everclearTokenType;
+                everclearTokenType = TokenType.ethEverclear;
               } catch (error) {
                 this.logger.debug(
                   `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.collateralEverclear}`,
                   error,
                 );
               }
+              return everclearTokenType;
             }
 
             const crossCollateralSelector =
@@ -718,20 +701,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
                 'getCrossCollateralRouters',
               );
             if (bytecode.includes(crossCollateralSelector.slice(2))) {
-              try {
-                const crossCollateralRouter =
-                  CrossCollateralRouter__factory.connect(
-                    warpRouteAddress,
-                    this.provider,
-                  );
-                await crossCollateralRouter.getCrossCollateralRouters(0);
-                return TokenType.crossCollateral;
-              } catch (error) {
-                this.logger.debug(
-                  `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.crossCollateral}`,
-                  error,
-                );
-              }
+              return TokenType.crossCollateral;
             }
           }
 

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -608,6 +608,13 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       },
     };
 
+    // Fetch implementation bytecode once; scanning selectors locally avoids
+    // reverted eth_calls for methods that don't exist on the contract.
+    const implAddress = (await isProxy(this.provider, warpRouteAddress))
+      ? await proxyImplementation(this.provider, warpRouteAddress)
+      : warpRouteAddress;
+    const bytecode = await this.provider.getCode(implAddress);
+
     // Temporarily turn off SmartProvider logging
     // Provider errors are expected because deriving will call methods that may not exist in the Bytecode
     this.setSmartProviderLogLevel('silent');
@@ -617,6 +624,10 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       for (const [tokenType, { factory, method }] of Object.entries(
         contractTypes,
       )) {
+        // Skip if selector absent from bytecode — avoids reverted eth_calls
+        const selector = factory.createInterface().getSighash(method);
+        if (!bytecode.includes(selector.slice(2))) continue;
+
         try {
           const warpRoute = factory.connect(warpRouteAddress, this.provider);
           const result = await warpRoute[method]();
@@ -658,56 +669,69 @@ export class EvmWarpRouteReader extends EvmRouterReader {
               );
             }
 
-            try {
-              const maybeEverclearTokenBridge =
-                EverclearTokenBridge__factory.connect(
-                  warpRouteAddress,
-                  this.provider,
-                );
-
-              await maybeEverclearTokenBridge.callStatic.everclearAdapter();
-
-              let everclearTokenType: TokenType = TokenType.collateralEverclear;
+            const everclearSelector =
+              EverclearTokenBridge__factory.createInterface().getSighash(
+                'everclearAdapter',
+              );
+            if (bytecode.includes(everclearSelector.slice(2))) {
               try {
-                // if simulating an ETH transfer works this should be the WETH contract
-                await this.provider.estimateGas({
-                  from: NON_ZERO_SENDER_ADDRESS,
-                  to: wrappedToken,
-                  data: IWETH__factory.createInterface().encodeFunctionData(
-                    'deposit',
-                  ),
-                  value: 0,
-                });
+                const maybeEverclearTokenBridge =
+                  EverclearTokenBridge__factory.connect(
+                    warpRouteAddress,
+                    this.provider,
+                  );
 
-                everclearTokenType = TokenType.ethEverclear;
+                await maybeEverclearTokenBridge.callStatic.everclearAdapter();
+
+                let everclearTokenType: TokenType =
+                  TokenType.collateralEverclear;
+                try {
+                  // if simulating an ETH transfer works this should be the WETH contract
+                  await this.provider.estimateGas({
+                    from: NON_ZERO_SENDER_ADDRESS,
+                    to: wrappedToken,
+                    data: IWETH__factory.createInterface().encodeFunctionData(
+                      'deposit',
+                    ),
+                    value: 0,
+                  });
+
+                  everclearTokenType = TokenType.ethEverclear;
+                } catch (error) {
+                  this.logger.debug(
+                    `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.collateralEverclear}`,
+                    error,
+                  );
+                }
+
+                return everclearTokenType;
               } catch (error) {
                 this.logger.debug(
                   `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.collateralEverclear}`,
                   error,
                 );
               }
-
-              return everclearTokenType;
-            } catch (error) {
-              this.logger.debug(
-                `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.collateralEverclear}`,
-                error,
-              );
             }
 
-            try {
-              const crossCollateralRouter =
-                CrossCollateralRouter__factory.connect(
-                  warpRouteAddress,
-                  this.provider,
-                );
-              await crossCollateralRouter.getCrossCollateralRouters(0);
-              return TokenType.crossCollateral;
-            } catch (error) {
-              this.logger.debug(
-                `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.crossCollateral}`,
-                error,
+            const crossCollateralSelector =
+              CrossCollateralRouter__factory.createInterface().getSighash(
+                'getCrossCollateralRouters',
               );
+            if (bytecode.includes(crossCollateralSelector.slice(2))) {
+              try {
+                const crossCollateralRouter =
+                  CrossCollateralRouter__factory.connect(
+                    warpRouteAddress,
+                    this.provider,
+                  );
+                await crossCollateralRouter.getCrossCollateralRouters(0);
+                return TokenType.crossCollateral;
+              } catch (error) {
+                this.logger.debug(
+                  `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.crossCollateral}`,
+                  error,
+                );
+              }
             }
           }
 

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -608,25 +608,36 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       },
     };
 
-    // Fetch implementation bytecode once; scanning selectors locally avoids
-    // reverted eth_calls for methods that don't exist on the contract.
-    const implAddress = (await isProxy(this.provider, warpRouteAddress))
-      ? await proxyImplementation(this.provider, warpRouteAddress)
-      : warpRouteAddress;
-    const bytecode = await this.provider.getCode(implAddress);
-
     // Temporarily turn off SmartProvider logging
     // Provider errors are expected because deriving will call methods that may not exist in the Bytecode
     this.setSmartProviderLogLevel('silent');
 
     try {
+      // Fetch implementation bytecode once; scanning selectors locally avoids
+      // reverted eth_calls for methods that don't exist on the contract.
+      // Read the EIP-1967 impl slot directly so UUPS/beacon proxies (which have
+      // an empty admin slot) are resolved correctly alongside TransparentProxy.
+      // Wrapped in try/catch so EOAs / bad addresses don't throw here — bytecode
+      // will be '0x' and the selector guard falls through to probes as pre-PR.
+      let implAddress = warpRouteAddress;
+      try {
+        const impl = await proxyImplementation(this.provider, warpRouteAddress);
+        if (!isZeroishAddress(impl)) implAddress = impl;
+      } catch {
+        // not a proxy or address has no code — use warpRouteAddress directly
+      }
+      const bytecode = await this.provider.getCode(implAddress);
+
       // First, try checking token specific methods
       for (const [tokenType, { factory, method }] of Object.entries(
         contractTypes,
       )) {
-        // Skip if selector absent from bytecode — avoids reverted eth_calls
+        // Skip if selector absent from bytecode — avoids reverted eth_calls.
+        // When bytecode is unavailable ('0x'), fall through to the probe anyway
+        // to preserve pre-optimization behavior on zero-impl / flaky-RPC paths.
         const selector = factory.createInterface().getSighash(method);
-        if (!bytecode.includes(selector.slice(2))) continue;
+        if (bytecode !== '0x' && !bytecode.includes(selector.slice(2)))
+          continue;
 
         try {
           const warpRoute = factory.connect(warpRouteAddress, this.provider);

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -669,11 +669,15 @@ export class EvmWarpRouteReader extends EvmRouterReader {
               );
             }
 
-            const everclearSelector =
-              EverclearTokenBridge__factory.createInterface().getSighash(
-                'everclearAdapter',
-              );
-            if (bytecode.includes(everclearSelector.slice(2))) {
+            try {
+              const maybeEverclearTokenBridge =
+                EverclearTokenBridge__factory.connect(
+                  warpRouteAddress,
+                  this.provider,
+                );
+
+              await maybeEverclearTokenBridge.callStatic.everclearAdapter();
+
               let everclearTokenType: TokenType = TokenType.collateralEverclear;
               try {
                 // if simulating an ETH transfer works this should be the WETH contract
@@ -693,15 +697,28 @@ export class EvmWarpRouteReader extends EvmRouterReader {
                   error,
                 );
               }
+
               return everclearTokenType;
+            } catch (error) {
+              this.logger.debug(
+                `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.collateralEverclear}`,
+                error,
+              );
             }
 
-            const crossCollateralSelector =
-              CrossCollateralRouter__factory.createInterface().getSighash(
-                'getCrossCollateralRouters',
-              );
-            if (bytecode.includes(crossCollateralSelector.slice(2))) {
+            try {
+              const crossCollateralRouter =
+                CrossCollateralRouter__factory.connect(
+                  warpRouteAddress,
+                  this.provider,
+                );
+              await crossCollateralRouter.getCrossCollateralRouters(0);
               return TokenType.crossCollateral;
+            } catch (error) {
+              this.logger.debug(
+                `Warp route token at address "${warpRouteAddress}" on chain "${this.chain}" is not a ${TokenType.crossCollateral}`,
+                error,
+              );
             }
           }
 


### PR DESCRIPTION
### Description

Instead of making an \`eth_call\` for every possible token type, fetch the implementation bytecode once and scan for function selectors locally. If a selector isn't present in the bytecode, the probe is skipped — no RPC call made.

The 8 main-loop probes are eliminated for contracts that don't have those methods. The nested collateral sub-checks (XERC20, fiatToken, everclear, crossCollateral) are unchanged.

**Worst case — synthetic/native token (all 8 probes miss):**
- Before: 8 reverted \`eth_call\`s + 3 fallback = ~27 actual RPC requests (SmartProvider retries each revert 3×)
- After: 5 setup calls (\`getCode\`/\`getStorageAt\`) + 0 probes + 3 fallback = 8 requests, none reverted

**How it works:**
- Resolve proxy implementation address via EIP-1967 slot, then fetch bytecode with \`getCode\` (2 \`getStorageAt\` + 2 \`getCode\` for proxy, 1 \`getCode\` for non-proxy)
- Before each probe in the \`contractTypes\` loop, check if the 4-byte selector appears in the bytecode; skip if not

### Drive-by changes

None

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

Yes

### Testing

Manual