### PR TITLE
feat(svm-sdk): svm sdk warp fee integration

### DIFF
--- a/.changeset/svm-warp-fee-integration.md
+++ b/.changeset/svm-warp-fee-integration.md
@@ -1,5 +1,5 @@
 ---
-'@hyperlane-xyz/sealevel-sdk': minor
+'@hyperlane-xyz/sealevel-sdk': major
 '@hyperlane-xyz/provider-sdk': patch
 '@hyperlane-xyz/sdk': patch
 ---

--- a/.changeset/svm-warp-fee-integration.md
+++ b/.changeset/svm-warp-fee-integration.md
@@ -1,0 +1,7 @@
+---
+'@hyperlane-xyz/sealevel-sdk': minor
+'@hyperlane-xyz/provider-sdk': patch
+'@hyperlane-xyz/sdk': patch
+---
+
+SVM warp route fee integration was added — warp tokens can now reference a deployed fee program via SetFeeConfig, with full create/read/update support and fee PDA validation. Token account decoder was updated to read the trailing Option<FeeConfig> field. Program version detection was added via GetProgramVersion simulation, enabling explicit program upgrades with ExtendProgramChecked and version-gated upgrade flow. Added contractVersion field to provider-sdk warp config types. compare-versions package added to workspace catalog.

--- a/.changeset/svm-warp-fee-integration.md
+++ b/.changeset/svm-warp-fee-integration.md
@@ -4,4 +4,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-SVM warp route fee integration was added — warp tokens can now reference a deployed fee program via SetFeeConfig, with full create/read/update support and fee PDA validation. Token account decoder was updated to read the trailing Option<FeeConfig> field. Program version detection was added via GetProgramVersion simulation, enabling explicit program upgrades with ExtendProgramChecked and version-gated upgrade flow. Added contractVersion field to provider-sdk warp config types. compare-versions package added to workspace catalog.
+SVM warp route fee integration was added. Warp token writers wired SetFeeConfig into the create and update flows with fee PDA validation, and readers were updated to surface the on-chain fee config. The token account decoder was extended to read the trailing Option<FeeConfig> field. Program version detection was added via GetProgramVersion simulation, gating explicit program upgrades that emit ExtendProgramChecked and Upgrade against the deployed BPF Loader v3 program. A contractVersion field was added to the provider-sdk warp config types, and compare-versions was promoted to the workspace catalog.

--- a/.github/workflows/test-sdk-e2e.yml
+++ b/.github/workflows/test-sdk-e2e.yml
@@ -174,6 +174,8 @@ jobs:
           - cross-collateral-token
           - provider
           - read-token
+          - program-upgrade
+          - warp-fee-config
         include:
           - test: read-token
             continue-on-error: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2417,6 +2417,9 @@ importers:
       '@solana/kit':
         specifier: 'catalog:'
         version: 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      compare-versions:
+        specifier: 'catalog:'
+        version: 6.1.1
     devDependencies:
       '@hyperlane-xyz/tsconfig':
         specifier: workspace:^

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -107,9 +107,6 @@ catalog:
   '@turnkey/sdk-server': ^4.12.0
   '@turnkey/solana': ^1.1.12
 
-  # Versioning
-  compare-versions: ^6.1.1
-
   # Prometheus
   prom-client: ^14.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -107,6 +107,9 @@ catalog:
   '@turnkey/sdk-server': ^4.12.0
   '@turnkey/solana': ^1.1.12
 
+  # Versioning
+  compare-versions: ^6.1.1
+
   # Prometheus
   prom-client: ^14.0.1
 

--- a/typescript/provider-sdk/src/warp.ts
+++ b/typescript/provider-sdk/src/warp.ts
@@ -72,6 +72,7 @@ export interface BaseWarpConfig {
   remoteRouters?: RemoteRouters;
   destinationGas?: DestinationGas;
   scale?: number;
+  contractVersion?: string;
 }
 
 export interface CollateralWarpConfig extends BaseWarpConfig {
@@ -112,6 +113,7 @@ export interface BaseDerivedWarpConfig {
   remoteRouters: RemoteRouters;
   destinationGas: DestinationGas;
   scale?: number;
+  contractVersion?: string;
 }
 
 export interface DerivedCollateralWarpConfig extends BaseDerivedWarpConfig {
@@ -176,6 +178,7 @@ interface BaseWarpArtifactConfig {
   symbol?: string;
   decimals?: number;
   scale?: number;
+  contractVersion?: string;
 }
 
 export interface CollateralWarpArtifactConfig extends BaseWarpArtifactConfig {
@@ -388,6 +391,7 @@ export function warpConfigToArtifact(
     remoteRouters,
     destinationGas,
     scale: config.scale,
+    contractVersion: config.contractVersion,
   };
 
   switch (config.type) {
@@ -561,6 +565,7 @@ export function warpArtifactToDerivedConfig(
     symbol: config.symbol,
     decimals: config.decimals,
     scale: config.scale,
+    contractVersion: config.contractVersion,
   };
 
   switch (config.type) {

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -140,6 +140,7 @@ export function validateWarpConfigForAltVM(
     remoteRouters: config.remoteRouters,
     destinationGas: config.destinationGas,
     scale,
+    contractVersion: config.contractVersion,
   };
 
   switch (config.type) {

--- a/typescript/svm-sdk/package.json
+++ b/typescript/svm-sdk/package.json
@@ -46,7 +46,8 @@
     "@solana-program/loader-v3": "^0.3.0",
     "@solana-program/system": "^0.12.0",
     "@solana/errors": "^6.1.0",
-    "@solana/kit": "catalog:"
+    "@solana/kit": "catalog:",
+    "compare-versions": "catalog:"
   },
   "devDependencies": {
     "@hyperlane-xyz/tsconfig": "workspace:^",

--- a/typescript/svm-sdk/scripts/run-e2e-test.sh
+++ b/typescript/svm-sdk/scripts/run-e2e-test.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ -z "${SVM_SDK_E2E_TEST}" ]; then
   echo "Error: SVM_SDK_E2E_TEST env var is required."
-  echo "Available tests: ism, hook, mailbox, validator-announce, native-token, synthetic-token, collateral-token, provider, read-token"
+  echo "Available tests: ism, hook, mailbox, validator-announce, native-token, synthetic-token, collateral-token, cross-collateral-token, provider, read-token, program-upgrade, warp-fee-config"
   echo "Usage: SVM_SDK_E2E_TEST=ism pnpm test:e2e"
   exit 1
 fi

--- a/typescript/svm-sdk/src/accounts/token.ts
+++ b/typescript/svm-sdk/src/accounts/token.ts
@@ -20,6 +20,16 @@ const IGP_PROGRAM_DATA_DISCRIMINATOR = ascii8('PRGMDATA');
 const IGP_ACCOUNT_DISCRIMINATOR = ascii8('IGP_____');
 const OVERHEAD_IGP_ACCOUNT_DISCRIMINATOR = ascii8('OVRHDIGP');
 
+export interface TokenFeeConfig {
+  feeProgram: Address;
+  feeAccount: Address;
+}
+
+/** Plugin data sizes per token type (bytes). */
+export const NATIVE_PLUGIN_SIZE = 1;
+export const SYNTHETIC_PLUGIN_SIZE = 34;
+export const COLLATERAL_PLUGIN_SIZE = 98;
+
 export interface HyperlaneTokenAccountData {
   bump: number;
   mailbox: Address;
@@ -36,6 +46,7 @@ export interface HyperlaneTokenAccountData {
   destinationGas: Map<number, bigint>;
   remoteRouters: Map<number, Uint8Array>;
   pluginData: Uint8Array;
+  feeConfig: TokenFeeConfig | null;
 }
 
 export interface IgpProgramData {
@@ -61,8 +72,11 @@ export interface OverheadIgpAccountData {
 
 export function decodeHyperlaneTokenAccount(
   raw: Uint8Array,
+  pluginSize: number,
 ): HyperlaneTokenAccountData | null {
-  const wrapped = decodeAccountData(raw, decodeHyperlaneTokenInner);
+  const wrapped = decodeAccountData(raw, (cursor) =>
+    decodeHyperlaneTokenInner(cursor, pluginSize),
+  );
   return wrapped.data;
 }
 
@@ -107,8 +121,8 @@ export function decodeOverheadIgpAccount(
 
 function decodeHyperlaneTokenInner(
   cursor: ByteCursor,
+  pluginSize: number,
 ): HyperlaneTokenAccountData {
-  // Kept manual because payload ends with trailing pluginData (remainder bytes).
   const bump = cursor.readU8();
   const mailbox = readAddress(cursor);
   const mailboxProcessAuthority = readAddress(cursor);
@@ -120,7 +134,14 @@ function decodeHyperlaneTokenInner(
   const interchainGasPaymaster = readOptionIgpConfig(cursor);
   const destinationGas = decodeMapU32U64(cursor);
   const remoteRouters = decodeMapU32H256(cursor);
-  const pluginData = cursor.readBytes(cursor.remaining());
+  const pluginData = cursor.readBytes(pluginSize);
+
+  // fee_config: Option<FeeConfig> — trailing field, backward-compatible.
+  // Pre-fee accounts have no trailing bytes; treat as None.
+  let feeConfig: TokenFeeConfig | null = null;
+  if (cursor.remaining() > 0) {
+    feeConfig = readOptionFeeConfig(cursor);
+  }
 
   return {
     bump,
@@ -135,6 +156,7 @@ function decodeHyperlaneTokenInner(
     destinationGas,
     remoteRouters,
     pluginData,
+    feeConfig,
   };
 }
 
@@ -216,6 +238,15 @@ function readOptionAddress(cursor: ByteCursor): Address | null {
   const tag = cursor.readU8();
   assert(tag === 0 || tag === 1, `Invalid option tag: ${tag}`);
   return tag === 1 ? readAddress(cursor) : null;
+}
+
+function readOptionFeeConfig(cursor: ByteCursor): TokenFeeConfig | null {
+  const tag = cursor.readU8();
+  if (tag === 0) return null;
+  assert(tag === 1, `Invalid FeeConfig option tag: ${tag}`);
+  const feeProgram = readAddress(cursor);
+  const feeAccount = readAddress(cursor);
+  return { feeProgram, feeAccount };
 }
 
 function readOptionIgpConfig(cursor: ByteCursor): {

--- a/typescript/svm-sdk/src/accounts/token.ts
+++ b/typescript/svm-sdk/src/accounts/token.ts
@@ -19,6 +19,7 @@ import {
 const IGP_PROGRAM_DATA_DISCRIMINATOR = ascii8('PRGMDATA');
 const IGP_ACCOUNT_DISCRIMINATOR = ascii8('IGP_____');
 const OVERHEAD_IGP_ACCOUNT_DISCRIMINATOR = ascii8('OVRHDIGP');
+const TOKEN_FEE_CONFIG_DISCRIMINATOR = ascii8('TOKFEEV1');
 
 export interface TokenFeeConfig {
   feeProgram: Address;
@@ -136,12 +137,9 @@ function decodeHyperlaneTokenInner(
   const remoteRouters = decodeMapU32H256(cursor);
   const pluginData = cursor.readBytes(pluginSize);
 
-  // fee_config: Option<FeeConfig> — trailing field, backward-compatible.
-  // Pre-fee accounts have no trailing bytes; treat as None.
-  let feeConfig: TokenFeeConfig | null = null;
-  if (cursor.remaining() > 0) {
-    feeConfig = readOptionFeeConfig(cursor);
-  }
+  // fee_config: OptionalDiscriminatedData<FeeConfig> — trailing field,
+  // backward-compatible. Absent or non-matching tail means None.
+  const feeConfig = readOptionFeeConfig(cursor);
 
   return {
     bump,
@@ -241,9 +239,14 @@ function readOptionAddress(cursor: ByteCursor): Address | null {
 }
 
 function readOptionFeeConfig(cursor: ByteCursor): TokenFeeConfig | null {
-  const tag = cursor.readU8();
-  if (tag === 0) return null;
-  assert(tag === 1, `Invalid FeeConfig option tag: ${tag}`);
+  if (cursor.remaining() < 8) return null;
+  const discriminator = cursor.readBytes(8);
+  // A trailing tail without the TOKFEEV1 discriminator is stale data left by
+  // an earlier layout; the on-chain program tolerates it as None, so do we.
+  const mismatch = discriminator.some(
+    (value, i) => value !== TOKEN_FEE_CONFIG_DISCRIMINATOR[i],
+  );
+  if (mismatch) return null;
   const feeProgram = readAddress(cursor);
   const feeAccount = readAddress(cursor);
   return { feeProgram, feeAccount };

--- a/typescript/svm-sdk/src/clients/protocol.ts
+++ b/typescript/svm-sdk/src/clients/protocol.ts
@@ -79,7 +79,9 @@ export class SvmProtocolProvider implements ProtocolProvider {
     _context?: { mailbox?: string },
   ): IRawWarpArtifactManager {
     const rpc = createRpc(this.getRpcUrls(chainMetadata)[0]);
-    return new SvmWarpArtifactManager(rpc);
+    return new SvmWarpArtifactManager(rpc, {
+      chainName: chainMetadata.name,
+    });
   }
 
   createMailboxArtifactManager(

--- a/typescript/svm-sdk/src/clients/provider.ts
+++ b/typescript/svm-sdk/src/clients/provider.ts
@@ -39,6 +39,10 @@ export class SvmProvider implements AltVM.IProvider<SvmTransaction> {
     this.rpcUrls = rpcUrls;
   }
 
+  getRpc(): SvmRpc {
+    return this.rpc;
+  }
+
   // ### QUERY BASE ###
 
   async isHealthy(): Promise<boolean> {

--- a/typescript/svm-sdk/src/constants.ts
+++ b/typescript/svm-sdk/src/constants.ts
@@ -46,3 +46,7 @@ export const COMPUTE_BUDGET_PROGRAM_ID = castAddress(
 
 // Default compute unit budget for SVM deployment transactions.
 export const DEFAULT_COMPUTE_UNITS = 400_000;
+
+// Solana per-transaction compute unit ceiling. Use for heavy txs (e.g. BPF
+// program upgrade + extend) where headroom matters more than priority cost.
+export const MAX_COMPUTE_UNITS = 1_400_000;

--- a/typescript/svm-sdk/src/deploy/program-deployer.ts
+++ b/typescript/svm-sdk/src/deploy/program-deployer.ts
@@ -1,15 +1,12 @@
 import {
   getDeployWithMaxDataLenInstruction,
   getInitializeBufferInstruction,
-  getUpgradeInstruction,
   getWriteInstruction,
 } from '@solana-program/loader-v3';
 import { getCreateAccountInstruction } from '@solana-program/system';
 import {
   generateKeyPairSigner,
-  getAddressCodec,
   getAddressDecoder,
-  getProgramDerivedAddress,
   type Address,
   type Instruction,
   type TransactionSigner,
@@ -18,11 +15,12 @@ import {
 import { assert, rootLogger } from '@hyperlane-xyz/utils';
 
 import { LOADER_V3_PROGRAM_ADDRESS } from '../constants.js';
+import { getUpgradeInstruction } from '../instructions/loader.js';
+import { deriveProgramDataAddress } from '../pda.js';
 import { DEFAULT_WRITE_CHUNK_SIZE } from '../tx.js';
 import type { SvmReceipt, SvmRpc } from '../types.js';
 
 const logger = rootLogger.child({ module: 'ProgramDeployer' });
-const ADDRESS_CODEC = getAddressCodec();
 const BUFFER_METADATA_SIZE = 37;
 const PROGRAM_ACCOUNT_SIZE = 36;
 
@@ -72,6 +70,8 @@ export interface UpgradeProgramPlanArgs {
   programAddress: Address;
   newProgramBytes: Uint8Array;
   getMinimumBalanceForRentExemption: (size: number) => Promise<bigint>;
+  /** On-chain upgrade authority. Defaults to authority.address. */
+  upgradeAuthority?: Address;
   writeChunkSize?: number;
   bufferSigner?: TransactionSigner;
 }
@@ -219,17 +219,18 @@ export async function createUpgradeProgramPlan(
     });
   }
 
+  const finalizeAuthority = args.upgradeAuthority ?? args.authority.address;
   stages.push({
     label: 'upgrade-program',
     kind: DeployStageKind.Finalize,
     instructions: [
-      getUpgradeInstruction({
-        programDataAccount: programDataAddress,
-        programAccount: args.programAddress,
-        bufferAccount: bufferSigner.address,
-        spillAccount: args.payer.address,
-        authority: args.authority,
-      }),
+      getUpgradeInstruction(
+        programDataAddress,
+        args.programAddress,
+        bufferSigner.address,
+        args.payer.address,
+        finalizeAuthority,
+      ),
     ],
   });
 
@@ -321,25 +322,18 @@ export async function executeDeployPlan(
   return receipts;
 }
 
-export async function deriveProgramDataAddress(
-  programAddress: Address,
-): Promise<Address> {
-  const pda = await getProgramDerivedAddress({
-    programAddress: LOADER_V3_PROGRAM_ADDRESS,
-    seeds: [ADDRESS_CODEC.encode(programAddress)],
-  });
-  return pda[0];
-}
-
 /**
- * Reads the BPF loader upgradeable ProgramData account to return the current
- * upgrade authority, or null if the program is immutable or not found.
- *
- * ProgramData binary layout:
+ * Size of the ProgramData account header:
  *   [0-3]  u32 discriminant (= 3)
  *   [4-11] u64 slot
  *   [12]   u8  option tag (0 = None, 1 = Some)
  *   [13-44] [u8; 32] upgrade authority pubkey (only when tag = 1)
+ */
+export const PROGRAM_DATA_HEADER_SIZE = 45;
+
+/**
+ * Reads the BPF loader upgradeable ProgramData account to return the current
+ * upgrade authority, or null if the program is immutable or not found.
  */
 export async function getProgramUpgradeAuthority(
   rpc: SvmRpc,
@@ -351,8 +345,8 @@ export async function getProgramUpgradeAuthority(
     .send();
   if (!account.value) return null;
   const data = Buffer.from(account.value.data[0] as string, 'base64');
-  if (data.length < 45) return null;
+  if (data.length < PROGRAM_DATA_HEADER_SIZE) return null;
   const hasAuthority = data[12] === 1;
   if (!hasAuthority) return null;
-  return getAddressDecoder().decode(data.slice(13, 45));
+  return getAddressDecoder().decode(data.slice(13, PROGRAM_DATA_HEADER_SIZE));
 }

--- a/typescript/svm-sdk/src/deploy/program-deployer.ts
+++ b/typescript/svm-sdk/src/deploy/program-deployer.ts
@@ -344,7 +344,7 @@ export async function getProgramUpgradeAuthority(
     .getAccountInfo(programDataAddress, { encoding: 'base64' })
     .send();
   if (!account.value) return null;
-  const data = Buffer.from(account.value.data[0] as string, 'base64');
+  const data = Buffer.from(account.value.data[0], 'base64');
   if (data.length < PROGRAM_DATA_HEADER_SIZE) return null;
   const hasAuthority = data[12] === 1;
   if (!hasAuthority) return null;

--- a/typescript/svm-sdk/src/instructions/loader.ts
+++ b/typescript/svm-sdk/src/instructions/loader.ts
@@ -1,7 +1,13 @@
 import type { Address } from '@solana/kit';
 
-import { deriveProgramDataAddress } from '../deploy/program-deployer.js';
-import { LOADER_V3_PROGRAM_ADDRESS } from '../constants.js';
+import { deriveProgramDataAddress } from '../pda.js';
+import {
+  CLOCK_SYSVAR_ADDRESS,
+  LOADER_V3_PROGRAM_ADDRESS,
+  RENT_SYSVAR_ADDRESS,
+  SYSTEM_PROGRAM_ADDRESS,
+} from '../constants.js';
+import { u32le } from '../codecs/binary.js';
 import type { SvmInstruction } from '../types.js';
 
 import {
@@ -9,14 +15,73 @@ import {
   readonlyAccount,
   readonlySignerAddress,
   writableAccount,
+  writableSignerAddress,
 } from './utils.js';
 
+/** BPF Loader Upgradeable SetAuthority discriminant (u32 LE). */
+const SET_AUTHORITY_DISCRIMINANT = new Uint8Array([4, 0, 0, 0]);
+
+/** BPF Loader Upgradeable Upgrade discriminant (u32 LE). */
+const UPGRADE_DISCRIMINANT = new Uint8Array([3, 0, 0, 0]);
+
+/** BPF Loader Upgradeable ExtendProgramChecked discriminant (variant 9). */
+const EXTEND_PROGRAM_CHECKED_DISCRIMINANT = 9;
+
 /**
- * Builds a BPF Loader Upgradeable SetAuthority instruction (discriminant = 4)
- * to transfer upgrade authority of a deployed program to a new address.
+ * Builds an ExtendProgramChecked instruction (variant 9).
  *
- * Uses address-only signers (no embedded keypair) consistent with the rest of
- * the codebase — signing is deferred to transaction submission.
+ * Requires the upgrade authority as signer. Variant 6 (ExtendProgram)
+ * is rejected on validators with the enable_extend_program_checked
+ * feature gate active (default on Agave 3.0+).
+ */
+export function getExtendProgramCheckedInstruction(
+  programDataAddress: Address,
+  programAddress: Address,
+  authority: Address,
+  payer: Address,
+  additionalBytes: number,
+): SvmInstruction {
+  const data = new Uint8Array(8);
+  data.set(u32le(EXTEND_PROGRAM_CHECKED_DISCRIMINANT), 0);
+  data.set(u32le(additionalBytes), 4);
+  return buildInstruction(
+    LOADER_V3_PROGRAM_ADDRESS,
+    [
+      writableAccount(programDataAddress),
+      writableAccount(programAddress),
+      readonlySignerAddress(authority),
+      readonlyAccount(SYSTEM_PROGRAM_ADDRESS),
+      writableSignerAddress(payer),
+    ],
+    data,
+  );
+}
+
+/**
+ * Builds a SetAuthority instruction to transfer buffer authority.
+ *
+ * Used before program upgrades when the buffer writer differs from the
+ * program's upgrade authority (the Loader requires both to match).
+ */
+export function getSetBufferAuthorityInstruction(
+  bufferAddress: Address,
+  currentAuthority: Address,
+  newAuthority: Address,
+): SvmInstruction {
+  return buildInstruction(
+    LOADER_V3_PROGRAM_ADDRESS,
+    [
+      writableAccount(bufferAddress),
+      readonlySignerAddress(currentAuthority),
+      readonlyAccount(newAuthority),
+    ],
+    SET_AUTHORITY_DISCRIMINANT,
+  );
+}
+
+/**
+ * Builds a SetAuthority instruction to transfer upgrade authority
+ * of a deployed program to a new address (or renounce it).
  */
 export async function getSetUpgradeAuthorityInstruction(
   programAddress: Address,
@@ -24,8 +89,6 @@ export async function getSetUpgradeAuthorityInstruction(
   newAuthority: Address | null,
 ): Promise<SvmInstruction> {
   const programDataAddress = await deriveProgramDataAddress(programAddress);
-  // SetAuthority discriminant: u32le(4)
-  const data = new Uint8Array([4, 0, 0, 0]);
   const accounts = [
     writableAccount(programDataAddress),
     readonlySignerAddress(currentAuthority),
@@ -33,5 +96,43 @@ export async function getSetUpgradeAuthorityInstruction(
   if (newAuthority) {
     accounts.push(readonlyAccount(newAuthority));
   }
-  return buildInstruction(LOADER_V3_PROGRAM_ADDRESS, accounts, data);
+
+  return buildInstruction(
+    LOADER_V3_PROGRAM_ADDRESS,
+    accounts,
+    SET_AUTHORITY_DISCRIMINANT,
+  );
+}
+
+/**
+ * Builds an Upgrade instruction using address-only signers.
+ *
+ * Unlike the @solana-program/loader-v3 getUpgradeInstruction which
+ * requires a TransactionSigner for the authority, this accepts a bare
+ * Address. The caller (authority holder) signs at transaction submission.
+ *
+ * Used when the upgrade authority differs from the buffer writer —
+ * the authority address is known but the keypair is not available
+ * to the code preparing the transaction.
+ */
+export function getUpgradeInstruction(
+  programDataAddress: Address,
+  programAddress: Address,
+  bufferAddress: Address,
+  spillAddress: Address,
+  authority: Address,
+): SvmInstruction {
+  return buildInstruction(
+    LOADER_V3_PROGRAM_ADDRESS,
+    [
+      writableAccount(programDataAddress),
+      writableAccount(programAddress),
+      writableAccount(bufferAddress),
+      writableAccount(spillAddress),
+      readonlyAccount(RENT_SYSVAR_ADDRESS),
+      readonlyAccount(CLOCK_SYSVAR_ADDRESS),
+      readonlySignerAddress(authority),
+    ],
+    UPGRADE_DISCRIMINANT,
+  );
 }

--- a/typescript/svm-sdk/src/instructions/token.ts
+++ b/typescript/svm-sdk/src/instructions/token.ts
@@ -35,6 +35,7 @@ import {
   InterchainGasPaymasterTypeKind,
   type RemoteRouterConfig,
 } from '../codecs/shared.js';
+import type { TokenFeeConfig } from '../accounts/token.js';
 import {
   PROGRAM_INSTRUCTION_DISCRIMINATOR,
   SYSTEM_PROGRAM_ADDRESS,
@@ -62,6 +63,7 @@ export enum TokenProgramInstructionKind {
   SetInterchainSecurityModule = 5,
   SetInterchainGasPaymaster = 6,
   TransferOwnership = 7,
+  SetFeeConfig = 8,
 }
 
 export interface TokenInitInstructionData {
@@ -92,7 +94,8 @@ export type TokenProgramInstructionData =
       kind: 'setInterchainGasPaymaster';
       value: [Address, InterchainGasPaymasterType] | null;
     }
-  | { kind: 'transferOwnership'; value: Address | null };
+  | { kind: 'transferOwnership'; value: Address | null }
+  | { kind: 'setFeeConfig'; value: TokenFeeConfig | null };
 
 interface TokenInitIgpValue {
   programId: Address;
@@ -195,6 +198,17 @@ export function encodeTokenProgramInstruction(
         u8(TokenProgramInstructionKind.TransferOwnership),
         option(instruction.value, (addr) => ADDRESS_CODEC.encode(addr)),
       );
+    case 'setFeeConfig':
+      return concatBytes(
+        PROGRAM_INSTRUCTION_DISCRIMINATOR,
+        u8(TokenProgramInstructionKind.SetFeeConfig),
+        option(instruction.value, (fc) =>
+          concatBytes(
+            ADDRESS_CODEC.encode(fc.feeProgram),
+            ADDRESS_CODEC.encode(fc.feeAccount),
+          ),
+        ),
+      );
   }
 }
 
@@ -242,8 +256,10 @@ export function decodeTokenProgramInstruction(
       };
     case TokenProgramInstructionKind.TransferOwnership:
       return { kind: 'transferOwnership', value: decodeOptionAddress(cursor) };
+    case TokenProgramInstructionKind.SetFeeConfig:
+      return { kind: 'setFeeConfig', value: decodeOptionFeeConfig(cursor) };
     default:
-      if (kind <= TokenProgramInstructionKind.TransferOwnership) {
+      if (kind <= TokenProgramInstructionKind.SetFeeConfig) {
         throw new Error(
           `Token instruction kind ${kind} is recognized but decoding is not yet implemented`,
         );
@@ -461,6 +477,15 @@ function decodeOptionIgpTuple(
   ];
 }
 
+function decodeOptionFeeConfig(cursor: ByteCursor): TokenFeeConfig | null {
+  const hasValue = cursor.readU8() === 1;
+  if (!hasValue) return null;
+  return {
+    feeProgram: ADDRESS_CODEC.decode(cursor.readBytes(32)),
+    feeAccount: ADDRESS_CODEC.decode(cursor.readBytes(32)),
+  };
+}
+
 function decodeVec<T>(
   cursor: ByteCursor,
   decoder: (cursor: ByteCursor) => T,
@@ -471,4 +496,30 @@ function decodeVec<T>(
     out.push(decoder(cursor));
   }
   return out;
+}
+
+// ====== SetFeeConfig instruction builder ======
+
+export async function getTokenSetFeeConfigInstruction(
+  programAddress: Address,
+  owner: Address,
+  value: TokenFeeConfig | null,
+): Promise<Instruction> {
+  const { address: tokenPda } = await deriveHyperlaneTokenPda(programAddress);
+  const accounts = [
+    readonlyAccount(SYSTEM_PROGRAM_ADDRESS),
+    writableAccount(tokenPda),
+    writableSignerAddress(owner),
+  ];
+  if (value) {
+    accounts.push(
+      readonlyAccount(value.feeProgram),
+      readonlyAccount(value.feeAccount),
+    );
+  }
+  return buildInstruction(
+    programAddress,
+    accounts,
+    encodeTokenProgramInstruction({ kind: 'setFeeConfig', value }),
+  );
 }

--- a/typescript/svm-sdk/src/instructions/token.ts
+++ b/typescript/svm-sdk/src/instructions/token.ts
@@ -43,6 +43,7 @@ import {
 import {
   deriveHyperlaneTokenPda,
   deriveMailboxDispatchAuthorityPda,
+  deriveMailboxOutboxPda,
 } from '../pda.js';
 import {
   buildInstruction,
@@ -63,7 +64,8 @@ export enum TokenProgramInstructionKind {
   SetInterchainSecurityModule = 5,
   SetInterchainGasPaymaster = 6,
   TransferOwnership = 7,
-  SetFeeConfig = 8,
+  TransferRemoteWithMemo = 8,
+  SetFeeConfig = 9,
 }
 
 export interface TokenInitInstructionData {
@@ -503,6 +505,7 @@ function decodeVec<T>(
 export async function getTokenSetFeeConfigInstruction(
   programAddress: Address,
   owner: Address,
+  mailbox: Address,
   value: TokenFeeConfig | null,
 ): Promise<Instruction> {
   const { address: tokenPda } = await deriveHyperlaneTokenPda(programAddress);
@@ -512,9 +515,11 @@ export async function getTokenSetFeeConfigInstruction(
     writableSignerAddress(owner),
   ];
   if (value) {
+    const outboxPda = await deriveMailboxOutboxPda(mailbox);
     accounts.push(
       readonlyAccount(value.feeProgram),
       readonlyAccount(value.feeAccount),
+      readonlyAccount(outboxPda.address),
     );
   }
   return buildInstruction(

--- a/typescript/svm-sdk/src/instructions/version.ts
+++ b/typescript/svm-sdk/src/instructions/version.ts
@@ -1,0 +1,27 @@
+import type { Address } from '@solana/kit';
+
+import type { SvmInstruction } from '../types.js';
+
+/**
+ * 8-byte discriminator for GetProgramVersion.
+ * First 8 bytes of `sha256(b"hyperlane:get-program-version")`.
+ * Independent of any program's instruction enum — works on all
+ * Hyperlane SVM programs that implement PackageVersioned.
+ */
+export const GET_PROGRAM_VERSION_DISCRIMINATOR = new Uint8Array([
+  150, 230, 176, 162, 236, 96, 183, 171,
+]);
+
+/**
+ * Builds a GetProgramVersion instruction for any Hyperlane SVM program.
+ * No accounts are required.
+ */
+export function buildGetProgramVersionInstruction(
+  programAddress: Address,
+): SvmInstruction {
+  return {
+    programAddress,
+    accounts: [],
+    data: GET_PROGRAM_VERSION_DISCRIMINATOR,
+  };
+}

--- a/typescript/svm-sdk/src/pda.ts
+++ b/typescript/svm-sdk/src/pda.ts
@@ -9,6 +9,7 @@ import {
 
 import { assert } from '@hyperlane-xyz/utils';
 
+import { LOADER_V3_PROGRAM_ADDRESS } from './constants.js';
 import type { PdaWithBump } from './types.js';
 
 const utf8 = getUtf8Encoder();
@@ -319,4 +320,16 @@ export async function deriveCrossCollateralRoutePda(
     utf8.encode('-'),
     targetRouter,
   ]);
+}
+
+// ====== BPF Loader PDAs ======
+
+export async function deriveProgramDataAddress(
+  programAddress: Address,
+): Promise<Address> {
+  const pda = await getProgramDerivedAddress({
+    programAddress: LOADER_V3_PROGRAM_ADDRESS,
+    seeds: [addressEncoder.encode(programAddress)],
+  });
+  return pda[0];
 }

--- a/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
@@ -6,6 +6,7 @@ import { ArtifactState } from '@hyperlane-xyz/provider-sdk/artifact';
 import { FeeParamsType, FeeType } from '@hyperlane-xyz/provider-sdk/fee';
 import type { IgpHookConfig } from '@hyperlane-xyz/provider-sdk/hook';
 import { TokenType } from '@hyperlane-xyz/provider-sdk/warp';
+import { sleep } from '@hyperlane-xyz/utils';
 
 import { SvmSigner } from '../clients/signer.js';
 import { SvmLinearFeeWriter } from '../fee/linear-fee.js';
@@ -30,9 +31,11 @@ import { supportsFeeConfig } from '../version/version-query.js';
 const TEST_PRIVATE_KEY =
   '0x0000000000000000000000000000000000000000000000000000000000000001';
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+// `skipPreflight` and the post-send sleep below are test-validator-only
+// workarounds. On mainnet the signer waits for the tx to land on chain, which
+// gives the cluster time to refresh its program cache before the next read.
+// The local test validator confirms much faster, so without these guards the
+// follow-up read can race the validator's program cache and see stale state.
 
 describe('SVM Program Upgrade E2E Tests', function () {
   this.timeout(600_000);
@@ -310,5 +313,104 @@ describe('SVM Program Upgrade E2E Tests', function () {
     expect(afterUpdate.config.owner).to.equal(newOwner.getSignerAddress());
     expect(afterUpdate.deployed.feeConfig).to.exist;
     expect(afterUpdate.deployed.feeConfig?.feeProgram).to.equal(feeProgramId);
+  });
+
+  it('should upgrade a warp route whose upgrade authority is a different key', async () => {
+    // Deploy legacy program owned by signer (initial upgrade authority = signer)
+    const legacyWriter = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: LEGACY_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+      },
+      rpc,
+      signer,
+    );
+
+    const [deployed] = await legacyWriter.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        interchainSecurityModule: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: TEST_PROGRAM_IDS.testIsm },
+        },
+        hook: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: TEST_PROGRAM_IDS.igp },
+        },
+        remoteRouters: {
+          1: {
+            address:
+              '0x1111111111111111111111111111111111111111111111111111111111111111',
+          },
+        },
+        destinationGas: { 1: '100000' },
+      },
+    });
+
+    const programId = deployed.deployed.address;
+
+    // Transfer warp-token ownership and BPF upgrade authority to newOwner BEFORE the upgrade
+    const newOwner = await SvmSigner.connectWithSigner(
+      [TEST_SVM_CHAIN_METADATA.rpcUrl],
+      '0x0000000000000000000000000000000000000000000000000000000000000005',
+    );
+    await airdropSol(rpc, address(newOwner.getSignerAddress()), 5_000_000_000n);
+
+    const beforeTransfer = await legacyWriter.read(programId);
+    const transferTxs = await legacyWriter.update({
+      ...beforeTransfer,
+      config: {
+        ...beforeTransfer.config,
+        owner: newOwner.getSignerAddress(),
+      },
+    });
+
+    for (const tx of transferTxs) {
+      await signer.send({
+        instructions: tx.instructions,
+        additionalSigners: tx.additionalSigners,
+        skipPreflight: true,
+      });
+    }
+    await sleep(1000);
+
+    // signer still has SOL to pay for the buffer but is no longer the upgrade authority.
+    // This forces the SetBufferAuthority(signer → newOwner) branch in prepareProgramUpgrade.
+    const upgradeWriter = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+      },
+      rpc,
+      signer,
+    );
+
+    const currentAfterTransfer = await upgradeWriter.read(programId);
+    const upgradeTxs = await upgradeWriter.update({
+      ...currentAfterTransfer,
+      config: {
+        ...currentAfterTransfer.config,
+        contractVersion: '1.0.0',
+      },
+    });
+
+    // Returned txs (extend + upgrade) require newOwner to sign as the upgrade authority.
+    for (const tx of upgradeTxs) {
+      await newOwner.send({
+        instructions: tx.instructions,
+        additionalSigners: tx.additionalSigners,
+        skipPreflight: true,
+      });
+    }
+    await sleep(1000);
+
+    const afterUpgrade = await upgradeWriter.read(programId);
+    expect(afterUpgrade.config.contractVersion).to.equal('1.0.0');
+    expect(supportsFeeConfig(afterUpgrade.config.contractVersion)).to.equal(
+      true,
+    );
   });
 });

--- a/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
@@ -12,10 +12,12 @@ import { TokenType } from '@hyperlane-xyz/provider-sdk/warp';
 import { sleep } from '@hyperlane-xyz/utils';
 
 import { SvmSigner } from '../clients/signer.js';
+import { SvmMailboxWriter } from '../core/mailbox.js';
 import { SvmLinearFeeWriter } from '../fee/linear-fee.js';
 import { DEFAULT_FEE_SALT } from '../fee/types.js';
 import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
 import { DEFAULT_IGP_SALT, SvmIgpHookWriter } from '../hook/igp-hook.js';
+import { SvmTestIsmWriter } from '../ism/test-ism.js';
 import { createRpc } from '../rpc.js';
 import { TEST_SVM_CHAIN_METADATA } from '../testing/constants.js';
 import { LEGACY_SVM_PROGRAM_BYTES } from '../testing/legacy/legacy-program-bytes.js';
@@ -80,11 +82,49 @@ describe('SVM Program Upgrade E2E Tests', function () {
       } satisfies IgpHookConfig,
     });
 
+    const testIsmAddress = TEST_PROGRAM_IDS.testIsm;
+    const ismWriter = new SvmTestIsmWriter(
+      { program: { programId: testIsmAddress } },
+      rpc,
+      signer,
+    );
+    await ismWriter.create({
+      artifactState: ArtifactState.NEW,
+      config: { type: 'testIsm' },
+    });
+
+    // Initialize mailbox — SetFeeConfig reads localDomain from the outbox PDA
+    const mailboxWriter = new SvmMailboxWriter(
+      {
+        program: { programId: mailboxAddress },
+        domainId: TEST_SVM_CHAIN_METADATA.domainId,
+      },
+      rpc,
+      signer,
+    );
+    await mailboxWriter.create({
+      config: {
+        owner: signer.getSignerAddress(),
+        defaultIsm: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: testIsmAddress },
+        },
+        defaultHook: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: mailboxAddress },
+        },
+        requiredHook: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: mailboxAddress },
+        },
+      },
+    });
+
     // Deploy a fee program for post-upgrade fee config test
     const feeWriter = new SvmLinearFeeWriter(
       { program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenFee } },
       rpc,
-      1,
+      TEST_SVM_CHAIN_METADATA.domainId,
       signer,
       DEFAULT_FEE_SALT,
     );

--- a/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
@@ -1,0 +1,314 @@
+import { address, type Address } from '@solana/kit';
+import { expect } from 'chai';
+import { before, describe, it } from 'mocha';
+
+import { ArtifactState } from '@hyperlane-xyz/provider-sdk/artifact';
+import { FeeParamsType, FeeType } from '@hyperlane-xyz/provider-sdk/fee';
+import type { IgpHookConfig } from '@hyperlane-xyz/provider-sdk/hook';
+import { TokenType } from '@hyperlane-xyz/provider-sdk/warp';
+
+import { SvmSigner } from '../clients/signer.js';
+import { SvmLinearFeeWriter } from '../fee/linear-fee.js';
+import { DEFAULT_FEE_SALT } from '../fee/types.js';
+import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
+import { DEFAULT_IGP_SALT, SvmIgpHookWriter } from '../hook/igp-hook.js';
+import { createRpc } from '../rpc.js';
+import { TEST_SVM_CHAIN_METADATA } from '../testing/constants.js';
+import { LEGACY_SVM_PROGRAM_BYTES } from '../testing/legacy/legacy-program-bytes.js';
+import {
+  TEST_ATA_PAYER_FUNDING_AMOUNT,
+  TEST_PROGRAM_IDS,
+  airdropSol,
+  createSplMint,
+} from '../testing/setup.js';
+import {
+  SvmCollateralTokenReader,
+  SvmCollateralTokenWriter,
+} from '../warp/collateral-token.js';
+import { supportsFeeConfig } from '../version/version-query.js';
+
+const TEST_PRIVATE_KEY =
+  '0x0000000000000000000000000000000000000000000000000000000000000001';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('SVM Program Upgrade E2E Tests', function () {
+  this.timeout(600_000);
+
+  let rpc: ReturnType<typeof createRpc>;
+  let signer: SvmSigner;
+  let mailboxAddress: Address;
+  let collateralMint: Address;
+  let feeProgramId: Address;
+
+  before(async () => {
+    rpc = createRpc(TEST_SVM_CHAIN_METADATA.rpcUrl);
+    signer = await SvmSigner.connectWithSigner(
+      [TEST_SVM_CHAIN_METADATA.rpcUrl],
+      TEST_PRIVATE_KEY,
+    );
+    await airdropSol(rpc, address(signer.getSignerAddress()), 100_000_000_000n);
+    mailboxAddress = TEST_PROGRAM_IDS.mailbox;
+    collateralMint = await createSplMint(rpc, signer, 9);
+
+    // Setup IGP for tests that use hook
+    const igpWriter = new SvmIgpHookWriter(
+      { program: { programId: TEST_PROGRAM_IDS.igp } },
+      rpc,
+      DEFAULT_IGP_SALT,
+      signer,
+    );
+    await igpWriter.create({
+      artifactState: ArtifactState.NEW,
+      config: {
+        type: 'interchainGasPaymaster',
+        owner: signer.getSignerAddress(),
+        beneficiary: signer.getSignerAddress(),
+        oracleKey: signer.getSignerAddress(),
+        overhead: { 1: 50000 },
+        oracleConfig: {
+          1: { gasPrice: '1', tokenExchangeRate: '1000000000000000000' },
+        },
+      } satisfies IgpHookConfig,
+    });
+
+    // Deploy a fee program for post-upgrade fee config test
+    const feeWriter = new SvmLinearFeeWriter(
+      { program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenFee } },
+      rpc,
+      1,
+      signer,
+      DEFAULT_FEE_SALT,
+    );
+    const [deployedFee] = await feeWriter.create({
+      config: {
+        type: FeeType.linear,
+        owner: signer.getSignerAddress(),
+        beneficiary: signer.getSignerAddress(),
+        params: {
+          type: FeeParamsType.raw,
+          maxFee: '1000000',
+          halfAmount: '500000',
+        },
+      },
+    });
+    feeProgramId = address(deployedFee.deployed.programId);
+  });
+
+  it('should deploy with legacy bytes, upgrade, and read new version', async () => {
+    const legacyWriter = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: LEGACY_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+      },
+      rpc,
+      signer,
+    );
+
+    const [deployed] = await legacyWriter.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+      },
+    });
+
+    const legacyRead = await legacyWriter.read(deployed.deployed.address);
+    expect(legacyRead.config.contractVersion).to.be.undefined;
+
+    const newWriter = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+      },
+      rpc,
+      signer,
+    );
+
+    const updateTxs = await newWriter.update({
+      ...legacyRead,
+      config: {
+        ...legacyRead.config,
+        contractVersion: '1.0.0',
+      },
+    });
+
+    expect(updateTxs.length).to.be.greaterThan(0);
+    for (const tx of updateTxs) {
+      await signer.send({
+        instructions: tx.instructions,
+        additionalSigners: tx.additionalSigners,
+        skipPreflight: true,
+      });
+    }
+
+    await sleep(1000);
+    const upgraded = await new SvmCollateralTokenReader(rpc).read(
+      deployed.deployed.address,
+    );
+    expect(upgraded.config.contractVersion).to.be.a('string');
+    expect(supportsFeeConfig(upgraded.config.contractVersion)).to.equal(true);
+  });
+
+  it('should reject downgrade attempt', async () => {
+    const writer = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+      },
+      rpc,
+      signer,
+    );
+
+    const [deployed] = await writer.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+      },
+    });
+
+    const current = await writer.read(deployed.deployed.address);
+    expect(current.config.contractVersion).to.equal('1.0.0');
+
+    try {
+      await writer.update({
+        ...current,
+        config: {
+          ...current.config,
+          contractVersion: '0.1.0',
+        },
+      });
+      expect.fail('Should have thrown on downgrade');
+    } catch (err: unknown) {
+      expect((err as Error).message).to.include('Cannot downgrade');
+    }
+  });
+
+  it('should skip upgrade when contractVersion matches', async () => {
+    const writer = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+      },
+      rpc,
+      signer,
+    );
+
+    const [deployed] = await writer.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+      },
+    });
+
+    const current = await writer.read(deployed.deployed.address);
+
+    const updateTxs = await writer.update({
+      ...current,
+      config: {
+        ...current.config,
+        contractVersion: current.config.contractVersion,
+      },
+    });
+
+    expect(updateTxs).to.have.length(0);
+  });
+
+  it('should be fully functional after upgrade from legacy', async () => {
+    // Deploy with legacy binary and all options filled
+    const legacyWriter = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: LEGACY_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+      },
+      rpc,
+      signer,
+    );
+
+    const [deployed] = await legacyWriter.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        interchainSecurityModule: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: TEST_PROGRAM_IDS.testIsm },
+        },
+        hook: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: TEST_PROGRAM_IDS.igp },
+        },
+        remoteRouters: {
+          1: {
+            address:
+              '0x1111111111111111111111111111111111111111111111111111111111111111',
+          },
+        },
+        destinationGas: { 1: '100000' },
+      },
+    });
+
+    const programId = deployed.deployed.address;
+
+    // Upgrade + set fee config + transfer ownership in one update
+    const upgradeWriter = new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt: DEFAULT_FEE_SALT,
+      },
+      rpc,
+      signer,
+    );
+
+    const current = await legacyWriter.read(programId);
+
+    const newOwner = await SvmSigner.connectWithSigner(
+      [TEST_SVM_CHAIN_METADATA.rpcUrl],
+      '0x0000000000000000000000000000000000000000000000000000000000000004',
+    );
+    await airdropSol(rpc, address(newOwner.getSignerAddress()), 5_000_000_000n);
+
+    const allTxs = await upgradeWriter.update({
+      ...current,
+      config: {
+        ...current.config,
+        contractVersion: '1.0.0',
+        owner: newOwner.getSignerAddress(),
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramId },
+        },
+      },
+    });
+
+    for (const tx of allTxs) {
+      await signer.send({
+        instructions: tx.instructions,
+        additionalSigners: tx.additionalSigners,
+        skipPreflight: true,
+      });
+    }
+
+    await sleep(1000);
+    const afterUpdate = await upgradeWriter.read(programId);
+    expect(afterUpdate.config.contractVersion).to.equal('1.0.0');
+    expect(afterUpdate.config.owner).to.equal(newOwner.getSignerAddress());
+    expect(afterUpdate.deployed.feeConfig).to.exist;
+    expect(afterUpdate.deployed.feeConfig?.feeProgram).to.equal(feeProgramId);
+  });
+});

--- a/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/program-upgrade.e2e-test.ts
@@ -1,6 +1,9 @@
 import { address, type Address } from '@solana/kit';
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { before, describe, it } from 'mocha';
+
+chai.use(chaiAsPromised);
 
 import { ArtifactState } from '@hyperlane-xyz/provider-sdk/artifact';
 import { FeeParamsType, FeeType } from '@hyperlane-xyz/provider-sdk/fee';
@@ -182,18 +185,15 @@ describe('SVM Program Upgrade E2E Tests', function () {
     const current = await writer.read(deployed.deployed.address);
     expect(current.config.contractVersion).to.equal('1.0.0');
 
-    try {
-      await writer.update({
+    await expect(
+      writer.update({
         ...current,
         config: {
           ...current.config,
           contractVersion: '0.1.0',
         },
-      });
-      expect.fail('Should have thrown on downgrade');
-    } catch (err: unknown) {
-      expect((err as Error).message).to.include('Cannot downgrade');
-    }
+      }),
+    ).to.be.rejectedWith('Cannot downgrade');
   });
 
   it('should skip upgrade when contractVersion matches', async () => {

--- a/typescript/svm-sdk/src/tests/read-token.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/read-token.e2e-test.ts
@@ -14,7 +14,9 @@ describe('SVM Warp Token read E2E Tests', function () {
 
   before(async () => {
     rpc = createRpc('https://api.mainnet-beta.solana.com');
-    artifactManager = new SvmWarpArtifactManager(rpc);
+    artifactManager = new SvmWarpArtifactManager(rpc, {
+      chainName: 'solanamainnet',
+    });
   });
 
   for (const testCase of [

--- a/typescript/svm-sdk/src/tests/token-account-decode.unit-test.ts
+++ b/typescript/svm-sdk/src/tests/token-account-decode.unit-test.ts
@@ -1,0 +1,132 @@
+import { address, getAddressEncoder } from '@solana/kit';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { assert } from '@hyperlane-xyz/utils';
+
+import {
+  decodeHyperlaneTokenAccount,
+  NATIVE_PLUGIN_SIZE,
+  type TokenFeeConfig,
+} from '../accounts/token.js';
+import { concatBytes, u32le, u8 } from '../codecs/binary.js';
+
+const ADDRESS_ENCODER = getAddressEncoder();
+
+const MAILBOX = address('11111111111111111111111111111112');
+const PROCESS_AUTHORITY = address('11111111111111111111111111111113');
+const FEE_PROGRAM = address('11111111111111111111111111111114');
+const FEE_ACCOUNT = address('11111111111111111111111111111115');
+
+const FEE_DISCRIMINATOR = Uint8Array.from('TOKFEEV1', (char) =>
+  char.charCodeAt(0),
+);
+const FEE_PAYLOAD = concatBytes(
+  ADDRESS_ENCODER.encode(FEE_PROGRAM),
+  ADDRESS_ENCODER.encode(FEE_ACCOUNT),
+);
+
+const PLUGIN_DATA = new Uint8Array(NATIVE_PLUGIN_SIZE).fill(7);
+
+function buildTokenAccountBytes(tail: Uint8Array): Uint8Array {
+  return Uint8Array.from(
+    concatBytes(
+      u8(1), // AccountData initialized flag
+      u8(255), // bump
+      ADDRESS_ENCODER.encode(MAILBOX),
+      ADDRESS_ENCODER.encode(PROCESS_AUTHORITY),
+      u8(254), // dispatchAuthorityBump
+      u8(9), // decimals
+      u8(18), // remoteDecimals
+      u8(0), // owner: None
+      u8(0), // interchainSecurityModule: None
+      u8(0), // interchainGasPaymaster: None
+      u32le(0), // destinationGas: empty
+      u32le(0), // remoteRouters: empty
+      PLUGIN_DATA,
+      tail,
+    ),
+  );
+}
+
+interface DecodeCase {
+  name: string;
+  tail: Uint8Array;
+  expectedFeeConfig: TokenFeeConfig | null;
+}
+
+const cases: DecodeCase[] = [
+  {
+    name: 'no trailing bytes (pre-fee account)',
+    tail: new Uint8Array(0),
+    expectedFeeConfig: null,
+  },
+  {
+    name: 'TOKFEEV1 discriminator with full payload',
+    tail: Uint8Array.from(concatBytes(FEE_DISCRIMINATOR, FEE_PAYLOAD)),
+    expectedFeeConfig: { feeProgram: FEE_PROGRAM, feeAccount: FEE_ACCOUNT },
+  },
+  {
+    name: 'short garbage tail (< 8 bytes)',
+    tail: Uint8Array.from([0xff, 0x01, 0x02, 0x03, 0x04]),
+    expectedFeeConfig: null,
+  },
+  {
+    name: 'stale tail without discriminator',
+    tail: new Uint8Array(16).fill(0xff),
+    expectedFeeConfig: null,
+  },
+  {
+    name: 'full payload followed by extra trailing bytes',
+    tail: Uint8Array.from(
+      concatBytes(FEE_DISCRIMINATOR, FEE_PAYLOAD, new Uint8Array(4).fill(0xaa)),
+    ),
+    expectedFeeConfig: { feeProgram: FEE_PROGRAM, feeAccount: FEE_ACCOUNT },
+  },
+];
+
+describe('decodeHyperlaneTokenAccount — trailing fee_config', () => {
+  for (const { name, tail, expectedFeeConfig } of cases) {
+    it(`${name}: feeConfig ${expectedFeeConfig ? 'parsed' : 'null'}`, () => {
+      const decoded = decodeHyperlaneTokenAccount(
+        buildTokenAccountBytes(tail),
+        NATIVE_PLUGIN_SIZE,
+      );
+      assert(decoded, 'expected token account to decode');
+      expect(decoded.feeConfig).to.deep.equal(expectedFeeConfig);
+    });
+  }
+
+  it('throws on TOKFEEV1 discriminator with truncated payload', () => {
+    const bytes = buildTokenAccountBytes(
+      Uint8Array.from(
+        concatBytes(FEE_DISCRIMINATOR, new Uint8Array(10).fill(1)),
+      ),
+    );
+    expect(() =>
+      decodeHyperlaneTokenAccount(bytes, NATIVE_PLUGIN_SIZE),
+    ).to.throw('Buffer underflow');
+  });
+
+  it('decodes base fields alongside the fee config tail', () => {
+    const decoded = decodeHyperlaneTokenAccount(
+      buildTokenAccountBytes(
+        Uint8Array.from(concatBytes(FEE_DISCRIMINATOR, FEE_PAYLOAD)),
+      ),
+      NATIVE_PLUGIN_SIZE,
+    );
+    assert(decoded, 'expected token account to decode');
+    expect(decoded.bump).to.equal(255);
+    expect(decoded.mailbox).to.equal(MAILBOX);
+    expect(decoded.mailboxProcessAuthority).to.equal(PROCESS_AUTHORITY);
+    expect(decoded.dispatchAuthorityBump).to.equal(254);
+    expect(decoded.decimals).to.equal(9);
+    expect(decoded.remoteDecimals).to.equal(18);
+    expect(decoded.owner).to.equal(null);
+    expect(decoded.interchainSecurityModule).to.equal(null);
+    expect(decoded.interchainGasPaymaster).to.equal(null);
+    expect(decoded.destinationGas.size).to.equal(0);
+    expect(decoded.remoteRouters.size).to.equal(0);
+    expect(decoded.pluginData).to.deep.equal(PLUGIN_DATA);
+  });
+});

--- a/typescript/svm-sdk/src/tests/warp-fee-config.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/warp-fee-config.e2e-test.ts
@@ -1,0 +1,324 @@
+import { address, type Address } from '@solana/kit';
+import { expect } from 'chai';
+import { before, describe, it } from 'mocha';
+
+import { ArtifactState } from '@hyperlane-xyz/provider-sdk/artifact';
+import { FeeParamsType, FeeType } from '@hyperlane-xyz/provider-sdk/fee';
+import type { IgpHookConfig } from '@hyperlane-xyz/provider-sdk/hook';
+import { TokenType } from '@hyperlane-xyz/provider-sdk/warp';
+
+import { SvmSigner } from '../clients/signer.js';
+import { SvmLinearFeeWriter } from '../fee/linear-fee.js';
+import { DEFAULT_FEE_SALT, deriveFeeSalt } from '../fee/types.js';
+import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
+import { DEFAULT_IGP_SALT, SvmIgpHookWriter } from '../hook/igp-hook.js';
+import { deriveFeeAccountPda } from '../pda.js';
+import { createRpc } from '../rpc.js';
+import { TEST_SVM_CHAIN_METADATA } from '../testing/constants.js';
+import {
+  TEST_ATA_PAYER_FUNDING_AMOUNT,
+  TEST_PROGRAM_IDS,
+  airdropSol,
+  createSplMint,
+} from '../testing/setup.js';
+import {
+  SvmCollateralTokenReader,
+  SvmCollateralTokenWriter,
+} from '../warp/collateral-token.js';
+
+const TEST_PRIVATE_KEY =
+  '0x0000000000000000000000000000000000000000000000000000000000000001';
+
+const ALTERNATE_SALT = deriveFeeSalt('alternate-salt');
+
+const rawParams = {
+  type: FeeParamsType.raw,
+  maxFee: '1000000',
+  halfAmount: '500000',
+} as const;
+
+describe('SVM Warp Fee Config E2E Tests', function () {
+  this.timeout(300_000);
+
+  let rpc: ReturnType<typeof createRpc>;
+  let signer: SvmSigner;
+  let mailboxAddress: Address;
+  let collateralMint: Address;
+  let feeProgramA: Address;
+  let feeProgramB: Address;
+
+  function makeWriter(feeSalt: Uint8Array = DEFAULT_FEE_SALT) {
+    return new SvmCollateralTokenWriter(
+      {
+        program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral },
+        ataPayerFundingAmount: TEST_ATA_PAYER_FUNDING_AMOUNT,
+        feeSalt,
+      },
+      rpc,
+      signer,
+    );
+  }
+
+  async function deployFee(salt: Uint8Array): Promise<Address> {
+    const feeWriter = new SvmLinearFeeWriter(
+      { program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenFee } },
+      rpc,
+      1,
+      signer,
+      salt,
+    );
+    const [deployed] = await feeWriter.create({
+      config: {
+        type: FeeType.linear,
+        owner: signer.getSignerAddress(),
+        beneficiary: signer.getSignerAddress(),
+        params: rawParams,
+      },
+    });
+    return address(deployed.deployed.programId);
+  }
+
+  before(async () => {
+    rpc = createRpc(TEST_SVM_CHAIN_METADATA.rpcUrl);
+    signer = await SvmSigner.connectWithSigner(
+      [TEST_SVM_CHAIN_METADATA.rpcUrl],
+      TEST_PRIVATE_KEY,
+    );
+    await airdropSol(rpc, address(signer.getSignerAddress()), 100_000_000_000n);
+    mailboxAddress = TEST_PROGRAM_IDS.mailbox;
+    collateralMint = await createSplMint(rpc, signer, 9);
+
+    const igpWriter = new SvmIgpHookWriter(
+      { program: { programId: TEST_PROGRAM_IDS.igp } },
+      rpc,
+      DEFAULT_IGP_SALT,
+      signer,
+    );
+    await igpWriter.create({
+      artifactState: ArtifactState.NEW,
+      config: {
+        type: 'interchainGasPaymaster',
+        owner: signer.getSignerAddress(),
+        beneficiary: signer.getSignerAddress(),
+        oracleKey: signer.getSignerAddress(),
+        overhead: { 1: 50000 },
+        oracleConfig: {
+          1: { gasPrice: '1', tokenExchangeRate: '1000000000000000000' },
+        },
+      } satisfies IgpHookConfig,
+    });
+
+    feeProgramA = await deployFee(DEFAULT_FEE_SALT);
+    feeProgramB = await deployFee(DEFAULT_FEE_SALT);
+
+    // Init another fee account on feeProgramA with alternate salt for salt-change test
+    const altFeeWriter = new SvmLinearFeeWriter(
+      { program: { programId: feeProgramA } },
+      rpc,
+      1,
+      signer,
+      ALTERNATE_SALT,
+    );
+    await altFeeWriter.create({
+      config: {
+        type: FeeType.linear,
+        owner: signer.getSignerAddress(),
+        beneficiary: signer.getSignerAddress(),
+        params: rawParams,
+      },
+    });
+  });
+
+  it('should set fee on deployment', async () => {
+    const writer = makeWriter();
+    const [deployed] = await writer.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramA },
+        },
+      },
+    });
+
+    const onChain = await new SvmCollateralTokenReader(rpc).read(
+      deployed.deployed.address,
+    );
+    const expectedPda = await deriveFeeAccountPda(
+      feeProgramA,
+      DEFAULT_FEE_SALT,
+    );
+
+    expect(onChain.deployed.feeConfig).to.exist;
+    expect(onChain.deployed.feeConfig?.feeProgram).to.equal(feeProgramA);
+    expect(onChain.deployed.feeConfig?.feeAccount).to.equal(
+      expectedPda.address,
+    );
+  });
+
+  it('should add fee via update when none was set', async () => {
+    const writer = makeWriter();
+    const [deployed] = await writer.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+      },
+    });
+
+    const current = await writer.read(deployed.deployed.address);
+    expect(current.deployed.feeConfig).to.be.undefined;
+
+    const updateTxs = await writer.update({
+      ...current,
+      config: {
+        ...current.config,
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramA },
+        },
+      },
+    });
+
+    expect(updateTxs).to.have.length(1);
+    for (const tx of updateTxs) {
+      await signer.send({ instructions: tx.instructions });
+    }
+
+    const afterUpdate = await writer.read(deployed.deployed.address);
+    expect(afterUpdate.deployed.feeConfig?.feeProgram).to.equal(feeProgramA);
+  });
+
+  it('should change from one fee program to another', async () => {
+    const writer = makeWriter();
+    const [deployed] = await writer.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramA },
+        },
+      },
+    });
+
+    const current = await writer.read(deployed.deployed.address);
+    expect(current.deployed.feeConfig?.feeProgram).to.equal(feeProgramA);
+
+    const updateTxs = await writer.update({
+      ...current,
+      config: {
+        ...current.config,
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramB },
+        },
+      },
+    });
+
+    expect(updateTxs).to.have.length(1);
+    for (const tx of updateTxs) {
+      await signer.send({ instructions: tx.instructions });
+    }
+
+    const afterUpdate = await writer.read(deployed.deployed.address);
+    expect(afterUpdate.deployed.feeConfig?.feeProgram).to.equal(feeProgramB);
+  });
+
+  it('should detect fee account change when same program but different salt', async () => {
+    const writer = makeWriter(DEFAULT_FEE_SALT);
+    const [deployed] = await writer.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramA },
+        },
+      },
+    });
+
+    const current = await writer.read(deployed.deployed.address);
+    const defaultPda = await deriveFeeAccountPda(feeProgramA, DEFAULT_FEE_SALT);
+    expect(current.deployed.feeConfig?.feeAccount).to.equal(defaultPda.address);
+
+    // Update with alternate salt — same program but different fee account PDA
+    const altWriter = makeWriter(ALTERNATE_SALT);
+    const updateTxs = await altWriter.update({
+      ...current,
+      config: {
+        ...current.config,
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramA },
+        },
+      },
+    });
+
+    expect(updateTxs).to.have.length(1);
+    for (const tx of updateTxs) {
+      await signer.send({ instructions: tx.instructions });
+    }
+
+    const afterUpdate = await altWriter.read(deployed.deployed.address);
+    const altPda = await deriveFeeAccountPda(feeProgramA, ALTERNATE_SALT);
+    expect(afterUpdate.deployed.feeConfig?.feeProgram).to.equal(feeProgramA);
+    expect(afterUpdate.deployed.feeConfig?.feeAccount).to.equal(altPda.address);
+    expect(afterUpdate.deployed.feeConfig?.feeAccount).to.not.equal(
+      defaultPda.address,
+    );
+  });
+
+  it('should remove fee via update', async () => {
+    const writer = makeWriter();
+    const [deployed] = await writer.create({
+      config: {
+        type: TokenType.collateral,
+        owner: signer.getSignerAddress(),
+        mailbox: mailboxAddress,
+        token: collateralMint,
+        remoteRouters: {},
+        destinationGas: {},
+        fee: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: feeProgramA },
+        },
+      },
+    });
+
+    const current = await writer.read(deployed.deployed.address);
+    expect(current.deployed.feeConfig).to.exist;
+
+    const updateTxs = await writer.update({
+      ...current,
+      config: {
+        ...current.config,
+        fee: undefined,
+      },
+    });
+
+    expect(updateTxs).to.have.length(1);
+    for (const tx of updateTxs) {
+      await signer.send({ instructions: tx.instructions });
+    }
+
+    const afterUpdate = await writer.read(deployed.deployed.address);
+    expect(afterUpdate.deployed.feeConfig).to.be.undefined;
+  });
+});

--- a/typescript/svm-sdk/src/tests/warp-fee-config.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/warp-fee-config.e2e-test.ts
@@ -8,10 +8,12 @@ import type { IgpHookConfig } from '@hyperlane-xyz/provider-sdk/hook';
 import { TokenType } from '@hyperlane-xyz/provider-sdk/warp';
 
 import { SvmSigner } from '../clients/signer.js';
+import { SvmMailboxWriter } from '../core/mailbox.js';
 import { SvmLinearFeeWriter } from '../fee/linear-fee.js';
 import { DEFAULT_FEE_SALT, deriveFeeSalt } from '../fee/types.js';
 import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
 import { DEFAULT_IGP_SALT, SvmIgpHookWriter } from '../hook/igp-hook.js';
+import { SvmTestIsmWriter } from '../ism/test-ism.js';
 import { deriveFeeAccountPda } from '../pda.js';
 import { createRpc } from '../rpc.js';
 import { TEST_SVM_CHAIN_METADATA } from '../testing/constants.js';
@@ -63,7 +65,7 @@ describe('SVM Warp Fee Config E2E Tests', function () {
     const feeWriter = new SvmLinearFeeWriter(
       { program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenFee } },
       rpc,
-      1,
+      TEST_SVM_CHAIN_METADATA.domainId,
       signer,
       salt,
     );
@@ -108,6 +110,44 @@ describe('SVM Warp Fee Config E2E Tests', function () {
       } satisfies IgpHookConfig,
     });
 
+    const testIsmAddress = TEST_PROGRAM_IDS.testIsm;
+    const ismWriter = new SvmTestIsmWriter(
+      { program: { programId: testIsmAddress } },
+      rpc,
+      signer,
+    );
+    await ismWriter.create({
+      artifactState: ArtifactState.NEW,
+      config: { type: 'testIsm' },
+    });
+
+    // Initialize mailbox — SetFeeConfig reads localDomain from the outbox PDA
+    const mailboxWriter = new SvmMailboxWriter(
+      {
+        program: { programId: mailboxAddress },
+        domainId: TEST_SVM_CHAIN_METADATA.domainId,
+      },
+      rpc,
+      signer,
+    );
+    await mailboxWriter.create({
+      config: {
+        owner: signer.getSignerAddress(),
+        defaultIsm: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: testIsmAddress },
+        },
+        defaultHook: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: mailboxAddress },
+        },
+        requiredHook: {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: mailboxAddress },
+        },
+      },
+    });
+
     feeProgramA = await deployFee(DEFAULT_FEE_SALT);
     feeProgramB = await deployFee(DEFAULT_FEE_SALT);
 
@@ -115,7 +155,7 @@ describe('SVM Warp Fee Config E2E Tests', function () {
     const altFeeWriter = new SvmLinearFeeWriter(
       { program: { programId: feeProgramA } },
       rpc,
-      1,
+      TEST_SVM_CHAIN_METADATA.domainId,
       signer,
       ALTERNATE_SALT,
     );

--- a/typescript/svm-sdk/src/tests/warp-fee-config.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/warp-fee-config.e2e-test.ts
@@ -161,6 +161,10 @@ describe('SVM Warp Fee Config E2E Tests', function () {
     );
     expect(onChain.config.fee).to.exist;
     expect(onChain.config.fee?.deployed?.address).to.equal(feeProgramA);
+
+    // No-op update with the same fee config should produce zero txs.
+    const noopTxs = await writer.update(onChain);
+    expect(noopTxs).to.have.length(0);
   });
 
   it('should add fee via update when none was set', async () => {

--- a/typescript/svm-sdk/src/tests/warp-fee-config.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/warp-fee-config.e2e-test.ts
@@ -159,6 +159,8 @@ describe('SVM Warp Fee Config E2E Tests', function () {
     expect(onChain.deployed.feeConfig?.feeAccount).to.equal(
       expectedPda.address,
     );
+    expect(onChain.config.fee).to.exist;
+    expect(onChain.config.fee?.deployed?.address).to.equal(feeProgramA);
   });
 
   it('should add fee via update when none was set', async () => {
@@ -195,6 +197,7 @@ describe('SVM Warp Fee Config E2E Tests', function () {
 
     const afterUpdate = await writer.read(deployed.deployed.address);
     expect(afterUpdate.deployed.feeConfig?.feeProgram).to.equal(feeProgramA);
+    expect(afterUpdate.config.fee?.deployed?.address).to.equal(feeProgramA);
   });
 
   it('should change from one fee program to another', async () => {
@@ -320,5 +323,6 @@ describe('SVM Warp Fee Config E2E Tests', function () {
 
     const afterUpdate = await writer.read(deployed.deployed.address);
     expect(afterUpdate.deployed.feeConfig).to.be.undefined;
+    expect(afterUpdate.config.fee).to.be.undefined;
   });
 });

--- a/typescript/svm-sdk/src/tests/warp-token-suite.ts
+++ b/typescript/svm-sdk/src/tests/warp-token-suite.ts
@@ -4,6 +4,8 @@ import { it } from 'mocha';
 
 import type { ArtifactWriter } from '@hyperlane-xyz/provider-sdk/artifact';
 import { ArtifactState } from '@hyperlane-xyz/provider-sdk/artifact';
+
+import { supportsFeeConfig } from '../version/version-query.js';
 import type {
   DeployedWarpAddress,
   RawNativeWarpArtifactConfig,
@@ -73,6 +75,8 @@ export function defineWarpTokenTests(
     expect(onChain.config.hook).to.be.undefined;
     expect(onChain.config.interchainSecurityModule).to.be.undefined;
     expect(onChain.config.scale).to.equal(testScale);
+    expect(onChain.config.contractVersion).to.be.a('string');
+    expect(supportsFeeConfig(onChain.config.contractVersion)).to.equal(true);
   });
 
   it('should deploy with IGP and ISM configured and read them back', async () => {

--- a/typescript/svm-sdk/src/types.ts
+++ b/typescript/svm-sdk/src/types.ts
@@ -64,6 +64,13 @@ export type SvmProgramTarget =
   | { programId: Address }
   | { programBytes: Uint8Array };
 
+/** Type guard: target carries program bytes (deploy/upgrade case). */
+export function hasProgramBytes(
+  target: SvmProgramTarget,
+): target is { programBytes: Uint8Array } {
+  return 'programBytes' in target;
+}
+
 /** ISM deployed data — the address IS the program. */
 export interface SvmDeployedIsm extends DeployedIsmAddress {
   programId: Address;

--- a/typescript/svm-sdk/src/version/version-query.ts
+++ b/typescript/svm-sdk/src/version/version-query.ts
@@ -6,6 +6,13 @@
  * set_return_data. This module queries and compares those versions.
  */
 import {
+  SOLANA_ERROR__INSTRUCTION_ERROR__BORSH_IO_ERROR,
+  SOLANA_ERROR__INSTRUCTION_ERROR__INVALID_INSTRUCTION_DATA,
+  SOLANA_ERROR__INSTRUCTION_ERROR__PROGRAM_FAILED_TO_COMPLETE,
+  getSolanaErrorFromTransactionError,
+  isSolanaError,
+} from '@solana/errors';
+import {
   type Address,
   type Base64EncodedWireTransaction,
   appendTransactionMessageInstructions,
@@ -94,13 +101,33 @@ export async function queryProgramVersion(
     })
     .send();
 
-  // Simulation error → program doesn't support versioning (pre-PackageVersioned)
+  // A pre-PackageVersioned program rejects the GetProgramVersion discriminator
+  // via Borsh decode failure, InvalidInstructionData, or panic. Any other error
+  // (BlockhashNotFound, AccountNotFound, etc.) is an infra failure that would
+  // otherwise be silently misclassified as a pre-versioned program.
   if (result.err) {
-    logger.debug(
-      'Program version query returned error (likely pre-versioned program)',
-      { programAddress, err: result.err },
-    );
-    return null;
+    const solanaError = getSolanaErrorFromTransactionError(result.err);
+    if (
+      isSolanaError(
+        solanaError,
+        SOLANA_ERROR__INSTRUCTION_ERROR__INVALID_INSTRUCTION_DATA,
+      ) ||
+      isSolanaError(
+        solanaError,
+        SOLANA_ERROR__INSTRUCTION_ERROR__BORSH_IO_ERROR,
+      ) ||
+      isSolanaError(
+        solanaError,
+        SOLANA_ERROR__INSTRUCTION_ERROR__PROGRAM_FAILED_TO_COMPLETE,
+      )
+    ) {
+      logger.debug('Pre-versioned program rejected GetProgramVersion', {
+        programAddress,
+        err: result.err,
+      });
+      return null;
+    }
+    throw solanaError;
   }
 
   const returnData = result.returnData;

--- a/typescript/svm-sdk/src/version/version-query.ts
+++ b/typescript/svm-sdk/src/version/version-query.ts
@@ -1,0 +1,145 @@
+/**
+ * Program version detection and comparison for Hyperlane SVM programs.
+ *
+ * All programs implementing the PackageVersioned trait respond to a
+ * universal 8-byte discriminator with their version string via
+ * set_return_data. This module queries and compares those versions.
+ */
+import {
+  type Address,
+  type Base64EncodedWireTransaction,
+  appendTransactionMessageInstructions,
+  blockhash,
+  compileTransactionMessage,
+  createTransactionMessage,
+  getCompiledTransactionMessageEncoder,
+  getShortU16Encoder,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+} from '@solana/kit';
+
+import { compareVersions as compareSemver } from 'compare-versions';
+
+import { rootLogger } from '@hyperlane-xyz/utils';
+
+import { ByteCursor } from '../codecs/binary.js';
+import { buildGetProgramVersionInstruction } from '../instructions/version.js';
+import type { SvmRpc } from '../types.js';
+
+const logger = rootLogger.child({ module: 'version-query' });
+
+/** Minimum program version that supports SetFeeConfig and fee section. */
+export const SVM_PROGRAM_MINIMUM_FEE_SUPPORT_VERSION = '1.0.0';
+
+/**
+ * Queries the on-chain version of a deployed Hyperlane SVM program.
+ *
+ * Uses transaction simulation (no on-chain state change) to call the
+ * GetProgramVersion instruction and parse the return data.
+ *
+ * @returns The version string (e.g. "1.0.0") or null if the program
+ *          does not support versioning (pre-PackageVersioned programs).
+ * @throws On RPC/network failures — only returns null for programs that
+ *         reject the instruction (InvalidInstructionData).
+ */
+export async function queryProgramVersion(
+  rpc: SvmRpc,
+  programAddress: Address,
+  payer: Address,
+): Promise<string | null> {
+  const ix = buildGetProgramVersionInstruction(programAddress);
+
+  // Build a minimal v0 message for simulation. The fee payer must be an
+  // existing non-executable account (simulation validates existence even
+  // with sigVerify=false) and must differ from the invoked program.
+  const txMessage = createTransactionMessage({ version: 0 });
+  const withPayer = setTransactionMessageFeePayer(payer, txMessage);
+  const withLifetime = setTransactionMessageLifetimeUsingBlockhash(
+    {
+      blockhash: blockhash('11111111111111111111111111111111'),
+      lastValidBlockHeight: 0n,
+    },
+    withPayer,
+  );
+  const withIx = appendTransactionMessageInstructions([ix], withLifetime);
+  const compiled = compileTransactionMessage(withIx);
+  const messageBytes = getCompiledTransactionMessageEncoder().encode(compiled);
+
+  // Build full unsigned wire transaction (signature count + zero-filled
+  // signature slots + compiled message). The RPC requires a full
+  // VersionedTransaction even for simulation with sigVerify=false.
+  const sigCountBytes = getShortU16Encoder().encode(
+    compiled.header.numSignerAccounts,
+  );
+  const sigsLen = compiled.header.numSignerAccounts * 64;
+  const wireBytes = new Uint8Array(
+    sigCountBytes.length + sigsLen + messageBytes.length,
+  );
+  wireBytes.set(sigCountBytes, 0);
+  wireBytes.set(messageBytes, sigCountBytes.length + sigsLen);
+
+  // CAST: the branded type expects a signed wire transaction but we
+  // built an unsigned one — sigVerify=false makes this valid.
+  const base64Tx = Buffer.from(wireBytes).toString(
+    'base64',
+  ) as Base64EncodedWireTransaction;
+
+  const { value: result } = await rpc
+    .simulateTransaction(base64Tx, {
+      encoding: 'base64',
+      commitment: 'confirmed',
+      sigVerify: false,
+      replaceRecentBlockhash: true,
+      accounts: { encoding: 'base64', addresses: [] },
+    })
+    .send();
+
+  // Simulation error → program doesn't support versioning (pre-PackageVersioned)
+  if (result.err) {
+    logger.debug(
+      'Program version query returned error (likely pre-versioned program)',
+      { programAddress, err: result.err },
+    );
+    return null;
+  }
+
+  const returnData = result.returnData;
+  if (!returnData?.data?.[0]) return null;
+
+  const raw = Buffer.from(returnData.data[0], 'base64');
+  return decodeSimulationReturnDataString(raw);
+}
+
+/**
+ * Decodes a SimulationReturnData<String> payload from Borsh.
+ *
+ * The Rust SimulationReturnData::new(version) serializes as:
+ *   - Borsh String: u32le length prefix + UTF-8 bytes
+ *   - trailing u8 tag (always 0)
+ */
+function decodeSimulationReturnDataString(raw: Uint8Array): string | null {
+  if (raw.length < 5) return null;
+  const cursor = new ByteCursor(raw);
+  const strLen = cursor.readU32LE();
+  if (strLen === 0 || strLen > raw.length - 4) return null;
+  const strBytes = cursor.readBytes(strLen);
+  return new TextDecoder().decode(strBytes);
+}
+
+/**
+ * Compares two semver version strings.
+ * Uses the `compare-versions` library (same as the EVM SDK).
+ * @returns -1 if a < b, 0 if equal, 1 if a > b.
+ */
+export function compareVersions(a: string, b: string): number {
+  return compareSemver(a, b);
+}
+
+/**
+ * Returns true if the given version supports fee configuration
+ * (SetFeeConfig instruction, fee section in TransferRemote).
+ */
+export function supportsFeeConfig(version: string | null): boolean {
+  if (!version) return false;
+  return compareVersions(version, SVM_PROGRAM_MINIMUM_FEE_SUPPORT_VERSION) >= 0;
+}

--- a/typescript/svm-sdk/src/version/version-query.ts
+++ b/typescript/svm-sdk/src/version/version-query.ts
@@ -139,7 +139,7 @@ export function compareVersions(a: string, b: string): number {
  * Returns true if the given version supports fee configuration
  * (SetFeeConfig instruction, fee section in TransferRemote).
  */
-export function supportsFeeConfig(version: string | null): boolean {
+export function supportsFeeConfig(version: string | null | undefined): boolean {
   if (!version) return false;
   return compareVersions(version, SVM_PROGRAM_MINIMUM_FEE_SUPPORT_VERSION) >= 0;
 }

--- a/typescript/svm-sdk/src/version/version-query.ts
+++ b/typescript/svm-sdk/src/version/version-query.ts
@@ -27,7 +27,7 @@ import {
 
 import { compareVersions as compareSemver } from 'compare-versions';
 
-import { rootLogger } from '@hyperlane-xyz/utils';
+import { assert, rootLogger } from '@hyperlane-xyz/utils';
 
 import { ByteCursor } from '../codecs/binary.js';
 import { buildGetProgramVersionInstruction } from '../instructions/version.js';
@@ -144,13 +144,15 @@ export async function queryProgramVersion(
  *   - Borsh String: u32le length prefix + UTF-8 bytes
  *   - trailing u8 tag (always 0)
  */
-function decodeSimulationReturnDataString(raw: Uint8Array): string | null {
-  if (raw.length < 5) return null;
+function decodeSimulationReturnDataString(raw: Uint8Array): string {
+  assert(raw.length >= 5, 'SimulationReturnData<String> too short');
   const cursor = new ByteCursor(raw);
   const strLen = cursor.readU32LE();
-  if (strLen === 0 || strLen > raw.length - 4) return null;
-  const strBytes = cursor.readBytes(strLen);
-  return new TextDecoder().decode(strBytes);
+  assert(
+    raw.length === 4 + strLen + 1,
+    `Malformed SimulationReturnData<String>: expected ${4 + strLen + 1} bytes, got ${raw.length}`,
+  );
+  return new TextDecoder().decode(cursor.readBytes(strLen));
 }
 
 /**

--- a/typescript/svm-sdk/src/version/version-query.ts
+++ b/typescript/svm-sdk/src/version/version-query.ts
@@ -142,7 +142,8 @@ export async function queryProgramVersion(
  *
  * The Rust SimulationReturnData::new(version) serializes as:
  *   - Borsh String: u32le length prefix + UTF-8 bytes
- *   - trailing u8 tag (always 0)
+ *   - trailing u8 tag set to u8::MAX (255), non-zero on purpose to avoid
+ *     Solana's return-data zero-truncation bug (solana-labs/solana#31391)
  */
 function decodeSimulationReturnDataString(raw: Uint8Array): string {
   assert(raw.length >= 5, 'SimulationReturnData<String> too short');

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -34,6 +34,7 @@ import { deriveAtaPayerPda, deriveEscrowPda } from '../pda.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
+import { prepareProgramUpgrade } from './warp-upgrade.js';
 import {
   fetchCollateralTokenAccount,
   fetchWarpProgramVersion,
@@ -261,7 +262,22 @@ export class SvmCollateralTokenWriter
       `Cannot update collateral token ${programId}: token has no owner`,
     );
 
-    return computeWarpTokenUpdateInstructions(
+    const txs: AnnotatedSvmTransaction[] = [];
+
+    if ('programBytes' in this.config.program) {
+      const upgradeResult = await prepareProgramUpgrade(
+        programId,
+        current.config.contractVersion,
+        artifact.config.contractVersion,
+        this.config.program.programBytes,
+        this.svmSigner,
+        this.rpc,
+        `collateral token ${programId}`,
+      );
+      txs.push(...(upgradeResult?.authorityTransactions ?? []));
+    }
+
+    const configUpdateTxs = await computeWarpTokenUpdateInstructions(
       current.config,
       artifact.config,
       programId,
@@ -271,5 +287,8 @@ export class SvmCollateralTokenWriter
       this.config.feeSalt,
       current.deployed.feeConfig,
     );
+    txs.push(...configUpdateTxs);
+
+    return txs;
   }
 }

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -35,7 +35,11 @@ import { deriveAtaPayerPda, deriveEscrowPda } from '../pda.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import type { SvmWarpTokenConfig } from './types.js';
-import { fetchCollateralTokenAccount, routerBytesToHex } from './warp-query.js';
+import {
+  fetchCollateralTokenAccount,
+  fetchWarpProgramVersion,
+  routerBytesToHex,
+} from './warp-query.js';
 import {
   applyPostInitConfig,
   assertLocalDecimals,
@@ -84,6 +88,12 @@ export class SvmCollateralTokenReader implements ArtifactReader<
         `warp route initialized with ${token.decimals} but mint reports ${metadata.decimals}`,
     );
 
+    const contractVersion = await fetchWarpProgramVersion(
+      this.rpc,
+      programId,
+      token.owner,
+    );
+
     const config: RawCollateralWarpArtifactConfig = {
       type: TokenType.collateral,
       owner: token.owner ?? ZERO_ADDRESS_HEX_32,
@@ -107,6 +117,7 @@ export class SvmCollateralTokenReader implements ArtifactReader<
       remoteRouters,
       destinationGas,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
+      contractVersion: contractVersion ?? undefined,
     };
 
     return {

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -177,7 +177,7 @@ export class SvmCollateralTokenWriter
         splProgram === TOKEN_2022_PROGRAM_ADDRESS,
       `Mint ${collateralMint} is not owned by SPL Token or Token-2022 (owner: ${splProgram})`,
     );
-    const mintRawData = Buffer.from(mintInfo.value.data[0] as string, 'base64');
+    const mintRawData = Buffer.from(mintInfo.value.data[0], 'base64');
     const localDecimals = getMintDecimals(mintRawData);
     assertLocalDecimals(localDecimals);
     const remoteDecimals = scaleToRemoteDecimals(

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -271,6 +271,7 @@ export class SvmCollateralTokenWriter
 
     const txs: AnnotatedSvmTransaction[] = [];
 
+    let upgradingToVersion: string | undefined;
     if (hasProgramBytes(this.config.program)) {
       const upgradeResult = await prepareProgramUpgrade(
         programId,
@@ -282,6 +283,9 @@ export class SvmCollateralTokenWriter
         `collateral token ${programId}`,
       );
       txs.push(...(upgradeResult?.authorityTransactions ?? []));
+      upgradingToVersion = upgradeResult?.authorityTransactions
+        ? artifact.config.contractVersion
+        : undefined;
     }
 
     const configUpdateTxs = await computeWarpTokenUpdateInstructions(
@@ -293,6 +297,7 @@ export class SvmCollateralTokenWriter
       `collateral token ${programId}`,
       this.config.feeSalt,
       current.deployed.feeConfig,
+      upgradingToVersion,
     );
     txs.push(...configUpdateTxs);
 

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -9,7 +9,6 @@ import {
 } from '@hyperlane-xyz/provider-sdk/artifact';
 import {
   TokenType,
-  type DeployedWarpAddress,
   type RawCollateralWarpArtifactConfig,
 } from '@hyperlane-xyz/provider-sdk/warp';
 import {
@@ -34,7 +33,7 @@ import { readonlyAccount, writableAccount } from '../instructions/utils.js';
 import { deriveAtaPayerPda, deriveEscrowPda } from '../pda.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
-import type { SvmWarpTokenConfig } from './types.js';
+import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
 import {
   fetchCollateralTokenAccount,
   fetchWarpProgramVersion,
@@ -52,14 +51,14 @@ import {
 
 export class SvmCollateralTokenReader implements ArtifactReader<
   RawCollateralWarpArtifactConfig,
-  DeployedWarpAddress
+  SvmDeployedWarpAddress
 > {
   constructor(protected readonly rpc: SvmRpc) {}
 
   async read(
     programAddress: string,
   ): Promise<
-    ArtifactDeployed<RawCollateralWarpArtifactConfig, DeployedWarpAddress>
+    ArtifactDeployed<RawCollateralWarpArtifactConfig, SvmDeployedWarpAddress>
   > {
     const programId = parseAddress(programAddress);
     const token = await fetchCollateralTokenAccount(this.rpc, programId);
@@ -123,7 +122,10 @@ export class SvmCollateralTokenReader implements ArtifactReader<
     return {
       artifactState: ArtifactState.DEPLOYED,
       config,
-      deployed: { address: programId },
+      deployed: {
+        address: programId,
+        feeConfig: token.feeConfig ?? undefined,
+      },
     };
   }
 }
@@ -131,7 +133,7 @@ export class SvmCollateralTokenReader implements ArtifactReader<
 export class SvmCollateralTokenWriter
   extends SvmCollateralTokenReader
   implements
-    ArtifactWriter<RawCollateralWarpArtifactConfig, DeployedWarpAddress>
+    ArtifactWriter<RawCollateralWarpArtifactConfig, SvmDeployedWarpAddress>
 {
   constructor(
     private readonly config: SvmWarpTokenConfig,
@@ -145,7 +147,7 @@ export class SvmCollateralTokenWriter
     artifact: ArtifactNew<RawCollateralWarpArtifactConfig>,
   ): Promise<
     [
-      ArtifactDeployed<RawCollateralWarpArtifactConfig, DeployedWarpAddress>,
+      ArtifactDeployed<RawCollateralWarpArtifactConfig, SvmDeployedWarpAddress>,
       SvmReceipt[],
     ]
   > {
@@ -247,7 +249,7 @@ export class SvmCollateralTokenWriter
   async update(
     artifact: ArtifactDeployed<
       RawCollateralWarpArtifactConfig,
-      DeployedWarpAddress
+      SvmDeployedWarpAddress
     >,
   ): Promise<AnnotatedSvmTransaction[]> {
     const programId = parseAddress(artifact.deployed.address);

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -35,7 +35,7 @@ import { deriveAtaPayerPda, deriveEscrowPda } from '../pda.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import type { SvmWarpTokenConfig } from './types.js';
-import { fetchTokenAccount, routerBytesToHex } from './warp-query.js';
+import { fetchCollateralTokenAccount, routerBytesToHex } from './warp-query.js';
 import {
   applyPostInitConfig,
   assertLocalDecimals,
@@ -58,7 +58,7 @@ export class SvmCollateralTokenReader implements ArtifactReader<
     ArtifactDeployed<RawCollateralWarpArtifactConfig, DeployedWarpAddress>
   > {
     const programId = parseAddress(programAddress);
-    const token = await fetchTokenAccount(this.rpc, programId);
+    const token = await fetchCollateralTokenAccount(this.rpc, programId);
     assert(
       !isNullish(token),
       `Collateral token not initialized at ${programId}`,

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -233,6 +233,7 @@ export class SvmCollateralTokenWriter
         this.svmSigner,
         programAddress,
         tokenConfig,
+        this.config.feeSalt,
       )),
     );
 

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -31,6 +31,7 @@ import { resolveProgram } from '../deploy/resolve-program.js';
 import { getTokenInitInstruction } from '../instructions/token.js';
 import { readonlyAccount, writableAccount } from '../instructions/utils.js';
 import { deriveAtaPayerPda, deriveEscrowPda } from '../pda.js';
+import { hasProgramBytes } from '../types.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
@@ -270,7 +271,7 @@ export class SvmCollateralTokenWriter
 
     const txs: AnnotatedSvmTransaction[] = [];
 
-    if ('programBytes' in this.config.program) {
+    if (hasProgramBytes(this.config.program)) {
       const upgradeResult = await prepareProgramUpgrade(
         programId,
         current.config.contractVersion,

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -118,6 +118,12 @@ export class SvmCollateralTokenReader implements ArtifactReader<
       destinationGas,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
       contractVersion: contractVersion ?? undefined,
+      fee: token.feeConfig
+        ? {
+            artifactState: ArtifactState.UNDERIVED,
+            deployed: { address: token.feeConfig.feeProgram },
+          }
+        : undefined,
     };
 
     return {

--- a/typescript/svm-sdk/src/warp/collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/collateral-token.ts
@@ -268,6 +268,8 @@ export class SvmCollateralTokenWriter
       parseAddress(current.config.owner),
       this.rpc,
       `collateral token ${programId}`,
+      this.config.feeSalt,
+      current.deployed.feeConfig,
     );
   }
 }

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -428,6 +428,7 @@ export class SvmCrossCollateralTokenWriter
     const txs: AnnotatedSvmTransaction[] = [];
 
     // Program upgrade first (before any config changes)
+    let upgradingToVersion: string | undefined;
     if (hasProgramBytes(this.config.program)) {
       const upgradeResult = await prepareProgramUpgrade(
         programId,
@@ -439,6 +440,9 @@ export class SvmCrossCollateralTokenWriter
         `cross-collateral token ${programId}`,
       );
       txs.push(...(upgradeResult?.authorityTransactions ?? []));
+      upgradingToVersion = upgradeResult?.authorityTransactions
+        ? artifact.config.contractVersion
+        : undefined;
     }
 
     // CC router updates (need current owner before any ownership transfer)
@@ -482,6 +486,7 @@ export class SvmCrossCollateralTokenWriter
         `cross-collateral token ${programId}`,
         this.config.feeSalt,
         current.deployed.feeConfig,
+        upgradingToVersion,
       )),
     );
 

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -53,7 +53,7 @@ import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import type { SvmWarpTokenConfig } from './types.js';
 import {
-  fetchTokenAccount,
+  fetchCrossCollateralTokenAccount,
   routerBytesToHex,
   routerHexToBytes,
 } from './warp-query.js';
@@ -82,7 +82,7 @@ export class SvmCrossCollateralTokenReader implements ArtifactReader<
     ArtifactDeployed<RawCrossCollateralWarpArtifactConfig, DeployedWarpAddress>
   > {
     const programId = parseAddress(programAddress);
-    const token = await fetchTokenAccount(this.rpc, programId);
+    const token = await fetchCrossCollateralTokenAccount(this.rpc, programId);
     assert(
       !isNullish(token),
       `Cross-collateral token not initialized at ${programId}`,

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -457,6 +457,8 @@ export class SvmCrossCollateralTokenWriter
         ownerAddress,
         this.rpc,
         `cross-collateral token ${programId}`,
+        this.config.feeSalt,
+        current.deployed.feeConfig,
       )),
     );
 

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -54,6 +54,7 @@ import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 import type { SvmWarpTokenConfig } from './types.js';
 import {
   fetchCrossCollateralTokenAccount,
+  fetchWarpProgramVersion,
   routerBytesToHex,
   routerHexToBytes,
 } from './warp-query.js';
@@ -132,6 +133,12 @@ export class SvmCrossCollateralTokenReader implements ArtifactReader<
         `warp route initialized with ${token.decimals} but mint reports ${metadata.decimals}`,
     );
 
+    const contractVersion = await fetchWarpProgramVersion(
+      this.rpc,
+      programId,
+      token.owner,
+    );
+
     const config: RawCrossCollateralWarpArtifactConfig = {
       type: TokenType.crossCollateral,
       owner: token.owner ?? ZERO_ADDRESS_HEX_32,
@@ -155,6 +162,7 @@ export class SvmCrossCollateralTokenReader implements ArtifactReader<
       remoteRouters,
       destinationGas,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
+      contractVersion: contractVersion ?? undefined,
       crossCollateralRouters,
     };
 

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -48,6 +48,7 @@ import {
   deriveEscrowPda,
   deriveMailboxOutboxPda,
 } from '../pda.js';
+import { hasProgramBytes } from '../types.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
@@ -427,7 +428,7 @@ export class SvmCrossCollateralTokenWriter
     const txs: AnnotatedSvmTransaction[] = [];
 
     // Program upgrade first (before any config changes)
-    if ('programBytes' in this.config.program) {
+    if (hasProgramBytes(this.config.program)) {
       const upgradeResult = await prepareProgramUpgrade(
         programId,
         current.config.contractVersion,

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -166,6 +166,12 @@ export class SvmCrossCollateralTokenReader implements ArtifactReader<
       destinationGas,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
       contractVersion: contractVersion ?? undefined,
+      fee: token.feeConfig
+        ? {
+            artifactState: ArtifactState.UNDERIVED,
+            deployed: { address: token.feeConfig.feeProgram },
+          }
+        : undefined,
       crossCollateralRouters,
     };
 

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -361,12 +361,13 @@ export class SvmCrossCollateralTokenWriter
       );
     }
 
-    // Apply standard post-init config (remote routers + destination gas)
+    // Apply standard post-init config (remote routers + destination gas + fee)
     receipts.push(
       ...(await applyPostInitConfig(
         this.svmSigner,
         programAddress,
         tokenConfig,
+        this.config.feeSalt,
       )),
     );
 

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -13,7 +13,6 @@ import {
 } from '@hyperlane-xyz/provider-sdk/artifact';
 import {
   TokenType,
-  type DeployedWarpAddress,
   type RawCrossCollateralWarpArtifactConfig,
   computeCCRouterGasConfigUpdates,
   computeCrossCollateralRouterUpdates,
@@ -51,7 +50,7 @@ import {
 } from '../pda.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
-import type { SvmWarpTokenConfig } from './types.js';
+import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
 import {
   fetchCrossCollateralTokenAccount,
   fetchWarpProgramVersion,
@@ -73,14 +72,17 @@ const MAX_CC_ROUTERS_PER_TX = 20;
 
 export class SvmCrossCollateralTokenReader implements ArtifactReader<
   RawCrossCollateralWarpArtifactConfig,
-  DeployedWarpAddress
+  SvmDeployedWarpAddress
 > {
   constructor(protected readonly rpc: SvmRpc) {}
 
   async read(
     programAddress: string,
   ): Promise<
-    ArtifactDeployed<RawCrossCollateralWarpArtifactConfig, DeployedWarpAddress>
+    ArtifactDeployed<
+      RawCrossCollateralWarpArtifactConfig,
+      SvmDeployedWarpAddress
+    >
   > {
     const programId = parseAddress(programAddress);
     const token = await fetchCrossCollateralTokenAccount(this.rpc, programId);
@@ -169,7 +171,10 @@ export class SvmCrossCollateralTokenReader implements ArtifactReader<
     return {
       artifactState: ArtifactState.DEPLOYED,
       config,
-      deployed: { address: programId },
+      deployed: {
+        address: programId,
+        feeConfig: token.feeConfig ?? undefined,
+      },
     };
   }
 }
@@ -259,7 +264,7 @@ export async function buildCrossCollateralRouterUnenrollTxs(
 export class SvmCrossCollateralTokenWriter
   extends SvmCrossCollateralTokenReader
   implements
-    ArtifactWriter<RawCrossCollateralWarpArtifactConfig, DeployedWarpAddress>
+    ArtifactWriter<RawCrossCollateralWarpArtifactConfig, SvmDeployedWarpAddress>
 {
   constructor(
     private readonly config: SvmWarpTokenConfig,
@@ -275,7 +280,7 @@ export class SvmCrossCollateralTokenWriter
     [
       ArtifactDeployed<
         RawCrossCollateralWarpArtifactConfig,
-        DeployedWarpAddress
+        SvmDeployedWarpAddress
       >,
       SvmReceipt[],
     ]
@@ -390,7 +395,7 @@ export class SvmCrossCollateralTokenWriter
   async update(
     artifact: ArtifactDeployed<
       RawCrossCollateralWarpArtifactConfig,
-      DeployedWarpAddress
+      SvmDeployedWarpAddress
     >,
   ): Promise<AnnotatedSvmTransaction[]> {
     const programId = parseAddress(artifact.deployed.address);

--- a/typescript/svm-sdk/src/warp/cross-collateral-token.ts
+++ b/typescript/svm-sdk/src/warp/cross-collateral-token.ts
@@ -51,6 +51,7 @@ import {
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
+import { prepareProgramUpgrade } from './warp-upgrade.js';
 import {
   fetchCrossCollateralTokenAccount,
   fetchWarpProgramVersion,
@@ -417,8 +418,23 @@ export class SvmCrossCollateralTokenWriter
       expectedCCRouters,
     );
 
-    // CC router updates first (need current owner before any ownership transfer)
     const txs: AnnotatedSvmTransaction[] = [];
+
+    // Program upgrade first (before any config changes)
+    if ('programBytes' in this.config.program) {
+      const upgradeResult = await prepareProgramUpgrade(
+        programId,
+        current.config.contractVersion,
+        artifact.config.contractVersion,
+        this.config.program.programBytes,
+        this.svmSigner,
+        this.rpc,
+        `cross-collateral token ${programId}`,
+      );
+      txs.push(...(upgradeResult?.authorityTransactions ?? []));
+    }
+
+    // CC router updates (need current owner before any ownership transfer)
 
     if (Object.keys(toUnenroll).length > 0) {
       txs.push(

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -211,6 +211,8 @@ export class SvmNativeTokenWriter
       parseAddress(current.config.owner),
       this.rpc,
       `native token ${programId}`,
+      this.config.feeSalt,
+      current.deployed.feeConfig,
     );
   }
 }

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -9,7 +9,6 @@ import {
 } from '@hyperlane-xyz/provider-sdk/artifact';
 import {
   TokenType,
-  type DeployedWarpAddress,
   type RawNativeWarpArtifactConfig,
 } from '@hyperlane-xyz/provider-sdk/warp';
 import {
@@ -26,7 +25,7 @@ import { writableAccount } from '../instructions/utils.js';
 import { deriveNativeCollateralPda } from '../pda.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
-import type { SvmWarpTokenConfig } from './types.js';
+import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
 import {
   fetchNativeTokenAccount,
   fetchWarpProgramVersion,
@@ -47,14 +46,14 @@ const SOL_DECIMALS = 9;
 
 export class SvmNativeTokenReader implements ArtifactReader<
   RawNativeWarpArtifactConfig,
-  DeployedWarpAddress
+  SvmDeployedWarpAddress
 > {
   constructor(protected readonly rpc: SvmRpc) {}
 
   async read(
     programAddress: string,
   ): Promise<
-    ArtifactDeployed<RawNativeWarpArtifactConfig, DeployedWarpAddress>
+    ArtifactDeployed<RawNativeWarpArtifactConfig, SvmDeployedWarpAddress>
   > {
     const programId = parseAddress(programAddress);
     const token = await fetchNativeTokenAccount(this.rpc, programId);
@@ -102,14 +101,17 @@ export class SvmNativeTokenReader implements ArtifactReader<
     return {
       artifactState: ArtifactState.DEPLOYED,
       config,
-      deployed: { address: programId },
+      deployed: {
+        address: programId,
+        feeConfig: token.feeConfig ?? undefined,
+      },
     };
   }
 }
 
 export class SvmNativeTokenWriter
   extends SvmNativeTokenReader
-  implements ArtifactWriter<RawNativeWarpArtifactConfig, DeployedWarpAddress>
+  implements ArtifactWriter<RawNativeWarpArtifactConfig, SvmDeployedWarpAddress>
 {
   constructor(
     private readonly config: SvmWarpTokenConfig,
@@ -123,7 +125,7 @@ export class SvmNativeTokenWriter
     artifact: ArtifactNew<RawNativeWarpArtifactConfig>,
   ): Promise<
     [
-      ArtifactDeployed<RawNativeWarpArtifactConfig, DeployedWarpAddress>,
+      ArtifactDeployed<RawNativeWarpArtifactConfig, SvmDeployedWarpAddress>,
       SvmReceipt[],
     ]
   > {
@@ -190,7 +192,7 @@ export class SvmNativeTokenWriter
   async update(
     artifact: ArtifactDeployed<
       RawNativeWarpArtifactConfig,
-      DeployedWarpAddress
+      SvmDeployedWarpAddress
     >,
   ): Promise<AnnotatedSvmTransaction[]> {
     const programId = parseAddress(artifact.deployed.address);

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -23,6 +23,7 @@ import { resolveProgram } from '../deploy/resolve-program.js';
 import { getTokenInitInstruction } from '../instructions/token.js';
 import { writableAccount } from '../instructions/utils.js';
 import { deriveNativeCollateralPda } from '../pda.js';
+import { hasProgramBytes } from '../types.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
@@ -213,7 +214,7 @@ export class SvmNativeTokenWriter
 
     const txs: AnnotatedSvmTransaction[] = [];
 
-    if ('programBytes' in this.config.program) {
+    if (hasProgramBytes(this.config.program)) {
       const upgradeResult = await prepareProgramUpgrade(
         programId,
         current.config.contractVersion,

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -26,6 +26,7 @@ import { deriveNativeCollateralPda } from '../pda.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
+import { prepareProgramUpgrade } from './warp-upgrade.js';
 import {
   fetchNativeTokenAccount,
   fetchWarpProgramVersion,
@@ -204,7 +205,22 @@ export class SvmNativeTokenWriter
       `Cannot update native token ${programId}: token has no owner`,
     );
 
-    return computeWarpTokenUpdateInstructions(
+    const txs: AnnotatedSvmTransaction[] = [];
+
+    if ('programBytes' in this.config.program) {
+      const upgradeResult = await prepareProgramUpgrade(
+        programId,
+        current.config.contractVersion,
+        artifact.config.contractVersion,
+        this.config.program.programBytes,
+        this.svmSigner,
+        this.rpc,
+        `native token ${programId}`,
+      );
+      txs.push(...(upgradeResult?.authorityTransactions ?? []));
+    }
+
+    const configUpdateTxs = await computeWarpTokenUpdateInstructions(
       current.config,
       artifact.config,
       programId,
@@ -214,5 +230,8 @@ export class SvmNativeTokenWriter
       this.config.feeSalt,
       current.deployed.feeConfig,
     );
+    txs.push(...configUpdateTxs);
+
+    return txs;
   }
 }

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -27,7 +27,7 @@ import { deriveNativeCollateralPda } from '../pda.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import type { SvmWarpTokenConfig } from './types.js';
-import { fetchTokenAccount, routerBytesToHex } from './warp-query.js';
+import { fetchNativeTokenAccount, routerBytesToHex } from './warp-query.js';
 import {
   applyPostInitConfig,
   assertLocalDecimals,
@@ -53,7 +53,7 @@ export class SvmNativeTokenReader implements ArtifactReader<
     ArtifactDeployed<RawNativeWarpArtifactConfig, DeployedWarpAddress>
   > {
     const programId = parseAddress(programAddress);
-    const token = await fetchTokenAccount(this.rpc, programId);
+    const token = await fetchNativeTokenAccount(this.rpc, programId);
     assert(!isNullish(token), `Native token not initialized at ${programId}`);
 
     const remoteRouters: Record<number, { address: string }> = {};

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -214,6 +214,7 @@ export class SvmNativeTokenWriter
 
     const txs: AnnotatedSvmTransaction[] = [];
 
+    let upgradingToVersion: string | undefined;
     if (hasProgramBytes(this.config.program)) {
       const upgradeResult = await prepareProgramUpgrade(
         programId,
@@ -225,6 +226,9 @@ export class SvmNativeTokenWriter
         `native token ${programId}`,
       );
       txs.push(...(upgradeResult?.authorityTransactions ?? []));
+      upgradingToVersion = upgradeResult?.authorityTransactions
+        ? artifact.config.contractVersion
+        : undefined;
     }
 
     const configUpdateTxs = await computeWarpTokenUpdateInstructions(
@@ -236,6 +240,7 @@ export class SvmNativeTokenWriter
       `native token ${programId}`,
       this.config.feeSalt,
       current.deployed.feeConfig,
+      upgradingToVersion,
     );
     txs.push(...configUpdateTxs);
 

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -176,6 +176,7 @@ export class SvmNativeTokenWriter
         this.svmSigner,
         programAddress,
         tokenConfig,
+        this.config.feeSalt,
       )),
     );
 

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -97,6 +97,12 @@ export class SvmNativeTokenReader implements ArtifactReader<
       decimals: token.decimals,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
       contractVersion: contractVersion ?? undefined,
+      fee: token.feeConfig
+        ? {
+            artifactState: ArtifactState.UNDERIVED,
+            deployed: { address: token.feeConfig.feeProgram },
+          }
+        : undefined,
     };
 
     return {

--- a/typescript/svm-sdk/src/warp/native-token.ts
+++ b/typescript/svm-sdk/src/warp/native-token.ts
@@ -27,7 +27,11 @@ import { deriveNativeCollateralPda } from '../pda.js';
 import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
 
 import type { SvmWarpTokenConfig } from './types.js';
-import { fetchNativeTokenAccount, routerBytesToHex } from './warp-query.js';
+import {
+  fetchNativeTokenAccount,
+  fetchWarpProgramVersion,
+  routerBytesToHex,
+} from './warp-query.js';
 import {
   applyPostInitConfig,
   assertLocalDecimals,
@@ -66,6 +70,12 @@ export class SvmNativeTokenReader implements ArtifactReader<
       destinationGas[domain] = gas.toString();
     }
 
+    const contractVersion = await fetchWarpProgramVersion(
+      this.rpc,
+      programId,
+      token.owner,
+    );
+
     const config: RawNativeWarpArtifactConfig = {
       type: TokenType.native,
       owner: token.owner ?? ZERO_ADDRESS_HEX_32,
@@ -86,6 +96,7 @@ export class SvmNativeTokenReader implements ArtifactReader<
       destinationGas,
       decimals: token.decimals,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
+      contractVersion: contractVersion ?? undefined,
     };
 
     return {

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -225,6 +225,12 @@ export class SvmSyntheticTokenReader implements ArtifactReader<
       metadataUri: metadata.uri,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
       contractVersion: contractVersion ?? undefined,
+      fee: token.feeConfig
+        ? {
+            artifactState: ArtifactState.UNDERIVED,
+            deployed: { address: token.feeConfig.feeProgram },
+          }
+        : undefined,
     };
 
     return {

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -417,6 +417,7 @@ export class SvmSyntheticTokenWriter
 
     const txs: AnnotatedSvmTransaction[] = [];
 
+    let upgradingToVersion: string | undefined;
     if (hasProgramBytes(this.config.program)) {
       const upgradeResult = await prepareProgramUpgrade(
         programId,
@@ -428,6 +429,9 @@ export class SvmSyntheticTokenWriter
         `synthetic token ${programId}`,
       );
       txs.push(...(upgradeResult?.authorityTransactions ?? []));
+      upgradingToVersion = upgradeResult?.authorityTransactions
+        ? artifact.config.contractVersion
+        : undefined;
     }
 
     const configUpdateTxs = await computeWarpTokenUpdateInstructions(
@@ -439,6 +443,7 @@ export class SvmSyntheticTokenWriter
       `synthetic token ${programId}`,
       this.config.feeSalt,
       current.deployed.feeConfig,
+      upgradingToVersion,
     );
     txs.push(...configUpdateTxs);
 

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -414,6 +414,8 @@ export class SvmSyntheticTokenWriter
       parseAddress(current.config.owner),
       this.rpc,
       `synthetic token ${programId}`,
+      this.config.feeSalt,
+      current.deployed.feeConfig,
     );
   }
 }

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -41,6 +41,7 @@ import {
   writableSigner,
 } from '../instructions/utils.js';
 import { deriveAtaPayerPda, deriveSyntheticMintPda } from '../pda.js';
+import { hasProgramBytes } from '../types.js';
 import type {
   AnnotatedSvmTransaction,
   SvmInstruction,
@@ -416,7 +417,7 @@ export class SvmSyntheticTokenWriter
 
     const txs: AnnotatedSvmTransaction[] = [];
 
-    if ('programBytes' in this.config.program) {
+    if (hasProgramBytes(this.config.program)) {
       const upgradeResult = await prepareProgramUpgrade(
         programId,
         current.config.contractVersion,

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -7,7 +7,6 @@ import {
 } from '@hyperlane-xyz/provider-sdk/artifact';
 import {
   TokenType,
-  type DeployedWarpAddress,
   type RawSyntheticWarpArtifactConfig,
 } from '@hyperlane-xyz/provider-sdk/warp';
 import {
@@ -49,7 +48,7 @@ import type {
   SvmRpc,
 } from '../types.js';
 
-import type { SvmWarpTokenConfig } from './types.js';
+import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
 import {
   fetchSyntheticTokenAccount,
   fetchWarpProgramVersion,
@@ -166,14 +165,14 @@ function createInitializeMetadataInstruction(
 
 export class SvmSyntheticTokenReader implements ArtifactReader<
   RawSyntheticWarpArtifactConfig,
-  DeployedWarpAddress
+  SvmDeployedWarpAddress
 > {
   constructor(protected readonly rpc: SvmRpc) {}
 
   async read(
     programAddress: string,
   ): Promise<
-    ArtifactDeployed<RawSyntheticWarpArtifactConfig, DeployedWarpAddress>
+    ArtifactDeployed<RawSyntheticWarpArtifactConfig, SvmDeployedWarpAddress>
   > {
     const programId = parseAddress(programAddress);
     const token = await fetchSyntheticTokenAccount(this.rpc, programId);
@@ -230,14 +229,18 @@ export class SvmSyntheticTokenReader implements ArtifactReader<
     return {
       artifactState: ArtifactState.DEPLOYED,
       config,
-      deployed: { address: programId },
+      deployed: {
+        address: programId,
+        feeConfig: token.feeConfig ?? undefined,
+      },
     };
   }
 }
 
 export class SvmSyntheticTokenWriter
   extends SvmSyntheticTokenReader
-  implements ArtifactWriter<RawSyntheticWarpArtifactConfig, DeployedWarpAddress>
+  implements
+    ArtifactWriter<RawSyntheticWarpArtifactConfig, SvmDeployedWarpAddress>
 {
   constructor(
     private readonly config: SvmWarpTokenConfig,
@@ -251,7 +254,7 @@ export class SvmSyntheticTokenWriter
     artifact: ArtifactNew<RawSyntheticWarpArtifactConfig>,
   ): Promise<
     [
-      ArtifactDeployed<RawSyntheticWarpArtifactConfig, DeployedWarpAddress>,
+      ArtifactDeployed<RawSyntheticWarpArtifactConfig, SvmDeployedWarpAddress>,
       SvmReceipt[],
     ]
   > {
@@ -392,7 +395,7 @@ export class SvmSyntheticTokenWriter
   async update(
     artifact: ArtifactDeployed<
       RawSyntheticWarpArtifactConfig,
-      DeployedWarpAddress
+      SvmDeployedWarpAddress
     >,
   ): Promise<AnnotatedSvmTransaction[]> {
     const programId = parseAddress(artifact.deployed.address);

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -50,7 +50,11 @@ import type {
 } from '../types.js';
 
 import type { SvmWarpTokenConfig } from './types.js';
-import { fetchSyntheticTokenAccount, routerBytesToHex } from './warp-query.js';
+import {
+  fetchSyntheticTokenAccount,
+  fetchWarpProgramVersion,
+  routerBytesToHex,
+} from './warp-query.js';
 import {
   applyPostInitConfig,
   assertLocalDecimals,
@@ -191,6 +195,12 @@ export class SvmSyntheticTokenReader implements ArtifactReader<
     const { address: mintPda } = await deriveSyntheticMintPda(programId);
     const metadata = await fetchMintMetadata(this.rpc, mintPda);
 
+    const contractVersion = await fetchWarpProgramVersion(
+      this.rpc,
+      programId,
+      token.owner,
+    );
+
     const config: RawSyntheticWarpArtifactConfig = {
       type: TokenType.synthetic,
       owner: token.owner ?? ZERO_ADDRESS_HEX_32,
@@ -214,6 +224,7 @@ export class SvmSyntheticTokenReader implements ArtifactReader<
       decimals: token.decimals,
       metadataUri: metadata.uri,
       scale: remoteDecimalsToScale(token.decimals, token.remoteDecimals),
+      contractVersion: contractVersion ?? undefined,
     };
 
     return {

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -49,6 +49,7 @@ import type {
 } from '../types.js';
 
 import type { SvmDeployedWarpAddress, SvmWarpTokenConfig } from './types.js';
+import { prepareProgramUpgrade } from './warp-upgrade.js';
 import {
   fetchSyntheticTokenAccount,
   fetchWarpProgramVersion,
@@ -407,7 +408,22 @@ export class SvmSyntheticTokenWriter
       `Cannot update synthetic token ${programId}: token has no owner`,
     );
 
-    return computeWarpTokenUpdateInstructions(
+    const txs: AnnotatedSvmTransaction[] = [];
+
+    if ('programBytes' in this.config.program) {
+      const upgradeResult = await prepareProgramUpgrade(
+        programId,
+        current.config.contractVersion,
+        artifact.config.contractVersion,
+        this.config.program.programBytes,
+        this.svmSigner,
+        this.rpc,
+        `synthetic token ${programId}`,
+      );
+      txs.push(...(upgradeResult?.authorityTransactions ?? []));
+    }
+
+    const configUpdateTxs = await computeWarpTokenUpdateInstructions(
       current.config,
       artifact.config,
       programId,
@@ -417,5 +433,8 @@ export class SvmSyntheticTokenWriter
       this.config.feeSalt,
       current.deployed.feeConfig,
     );
+    txs.push(...configUpdateTxs);
+
+    return txs;
   }
 }

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -379,6 +379,7 @@ export class SvmSyntheticTokenWriter
         this.svmSigner,
         programAddress,
         tokenConfig,
+        this.config.feeSalt,
       )),
     );
 

--- a/typescript/svm-sdk/src/warp/synthetic-token.ts
+++ b/typescript/svm-sdk/src/warp/synthetic-token.ts
@@ -50,7 +50,7 @@ import type {
 } from '../types.js';
 
 import type { SvmWarpTokenConfig } from './types.js';
-import { fetchTokenAccount, routerBytesToHex } from './warp-query.js';
+import { fetchSyntheticTokenAccount, routerBytesToHex } from './warp-query.js';
 import {
   applyPostInitConfig,
   assertLocalDecimals,
@@ -172,7 +172,7 @@ export class SvmSyntheticTokenReader implements ArtifactReader<
     ArtifactDeployed<RawSyntheticWarpArtifactConfig, DeployedWarpAddress>
   > {
     const programId = parseAddress(programAddress);
-    const token = await fetchTokenAccount(this.rpc, programId);
+    const token = await fetchSyntheticTokenAccount(this.rpc, programId);
     assert(
       !isNullish(token),
       `Synthetic token not initialized at ${programId}`,

--- a/typescript/svm-sdk/src/warp/types.ts
+++ b/typescript/svm-sdk/src/warp/types.ts
@@ -24,6 +24,12 @@ export type SvmWarpTokenConfig = Readonly<{
  * SVM-specific extension of DeployedWarpAddress that carries the
  * on-chain fee configuration (both program ID and fee account PDA).
  * Used for accurate fee config diffing during updates.
+ *
+ * Note: cross-VM tooling that round-trips through the bare
+ * `IRawWarpArtifactManager` / `DeployedWarpAddress` shape will drop
+ * the `feeConfig` field. This is intentional — at apply time the SVM
+ * reader re-fetches the on-chain truth before diffing, so the artifact
+ * doesn't need to round-trip the field for correctness.
  */
 export interface SvmDeployedWarpAddress extends DeployedWarpAddress {
   feeConfig?: TokenFeeConfig;

--- a/typescript/svm-sdk/src/warp/types.ts
+++ b/typescript/svm-sdk/src/warp/types.ts
@@ -1,3 +1,6 @@
+import type { DeployedWarpAddress } from '@hyperlane-xyz/provider-sdk/warp';
+
+import type { TokenFeeConfig } from '../accounts/token.js';
 import type { SvmProgramTarget } from '../types.js';
 
 /**
@@ -14,3 +17,12 @@ export type SvmWarpTokenConfig = Readonly<{
    */
   ataPayerFundingAmount: bigint;
 }>;
+
+/**
+ * SVM-specific extension of DeployedWarpAddress that carries the
+ * on-chain fee configuration (both program ID and fee account PDA).
+ * Used for accurate fee config diffing during updates.
+ */
+export interface SvmDeployedWarpAddress extends DeployedWarpAddress {
+  feeConfig?: TokenFeeConfig;
+}

--- a/typescript/svm-sdk/src/warp/types.ts
+++ b/typescript/svm-sdk/src/warp/types.ts
@@ -16,6 +16,8 @@ export type SvmWarpTokenConfig = Readonly<{
    * creation on transfer_out.
    */
   ataPayerFundingAmount: bigint;
+  /** Salt for fee account PDA derivation. Resolved from chain name if not provided. */
+  feeSalt?: Uint8Array;
 }>;
 
 /**

--- a/typescript/svm-sdk/src/warp/warp-artifact-manager.ts
+++ b/typescript/svm-sdk/src/warp/warp-artifact-manager.ts
@@ -12,6 +12,7 @@ import type {
   WarpType,
 } from '@hyperlane-xyz/provider-sdk/warp';
 import type { SvmSigner } from '../clients/signer.js';
+import { resolveFeeSalt } from '../fee/types.js';
 import { HYPERLANE_SVM_PROGRAM_BYTES } from '../hyperlane/program-bytes.js';
 import {
   SvmCollateralTokenReader,
@@ -31,7 +32,11 @@ import { detectWarpTokenType } from './warp-query.js';
 export class SvmWarpArtifactManager implements IRawWarpArtifactManager {
   constructor(
     private readonly rpc: Rpc<SolanaRpcApi>,
+    chainConfig: { chainName: string },
     private readonly ataPayerFundingAmount: bigint = 100_000_000n,
+    private readonly feeSalt: Uint8Array = resolveFeeSalt(
+      chainConfig.chainName,
+    ),
   ) {}
 
   async readWarpToken(tokenAddress: string): Promise<DeployedRawWarpArtifact> {
@@ -77,6 +82,7 @@ export class SvmWarpArtifactManager implements IRawWarpArtifactManager {
           {
             program: { programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenNative },
             ataPayerFundingAmount: this.ataPayerFundingAmount,
+            feeSalt: this.feeSalt,
           },
           this.rpc,
           signer,
@@ -88,6 +94,7 @@ export class SvmWarpArtifactManager implements IRawWarpArtifactManager {
               programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenSynthetic,
             },
             ataPayerFundingAmount: this.ataPayerFundingAmount,
+            feeSalt: this.feeSalt,
           },
           this.rpc,
           signer,
@@ -99,6 +106,7 @@ export class SvmWarpArtifactManager implements IRawWarpArtifactManager {
               programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCollateral,
             },
             ataPayerFundingAmount: this.ataPayerFundingAmount,
+            feeSalt: this.feeSalt,
           },
           this.rpc,
           signer,
@@ -110,6 +118,7 @@ export class SvmWarpArtifactManager implements IRawWarpArtifactManager {
               programBytes: HYPERLANE_SVM_PROGRAM_BYTES.tokenCrossCollateral,
             },
             ataPayerFundingAmount: this.ataPayerFundingAmount,
+            feeSalt: this.feeSalt,
           },
           this.rpc,
           signer,

--- a/typescript/svm-sdk/src/warp/warp-query.ts
+++ b/typescript/svm-sdk/src/warp/warp-query.ts
@@ -1,6 +1,27 @@
-import { type Address, fetchEncodedAccount } from '@solana/kit';
+import {
+  type Address,
+  address as parseAddress,
+  fetchEncodedAccount,
+} from '@solana/kit';
 
-import { assert, fromHexString, toHexString } from '@hyperlane-xyz/utils';
+import {
+  assert,
+  fromHexString,
+  rootLogger,
+  toHexString,
+} from '@hyperlane-xyz/utils';
+
+const logger = rootLogger.child({ module: 'warp-query' });
+
+/**
+ * Known-funded mainnet address used as a fallback simulation fee payer.
+ * Solana simulation requires the fee payer to exist and hold SOL even with
+ * sigVerify=false; production token owners (multisigs, governance) often
+ * don't hold SOL, so we fall back to this when the owner can't pay.
+ */
+const FALLBACK_SIMULATION_PAYER = parseAddress(
+  '9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf',
+);
 
 import {
   COLLATERAL_PLUGIN_SIZE,
@@ -125,16 +146,28 @@ export async function detectWarpTokenType(
 
 /**
  * Queries the on-chain program version for a warp token program.
- * Uses the token owner as the simulation fee payer (must exist on-chain).
- * Returns null if the owner is null (can't simulate without a payer).
+ *
+ * Uses the token owner as the simulation fee payer when present, falling
+ * back to a known-funded mainnet address when the owner is null or the
+ * owner-paid simulation fails (e.g. production owner has no SOL).
  */
 export async function fetchWarpProgramVersion(
   rpc: SvmRpc,
   programId: Address,
   owner: Address | null,
 ): Promise<string | null> {
-  if (!owner) return null;
-  return queryProgramVersion(rpc, programId, owner);
+  if (owner) {
+    try {
+      return await queryProgramVersion(rpc, programId, owner);
+    } catch (err) {
+      logger.debug(
+        'Owner-as-payer simulation failed; retrying with fallback payer',
+        { programId, owner, err },
+      );
+    }
+  }
+
+  return queryProgramVersion(rpc, programId, FALLBACK_SIMULATION_PAYER);
 }
 
 /** Converts a 32-byte router H256 to a 0x-prefixed hex string. */

--- a/typescript/svm-sdk/src/warp/warp-query.ts
+++ b/typescript/svm-sdk/src/warp/warp-query.ts
@@ -17,6 +17,7 @@ import {
   deriveEscrowPda,
 } from '../pda.js';
 import type { SvmRpc } from '../types.js';
+import { queryProgramVersion } from '../version/version-query.js';
 
 export enum SvmWarpTokenType {
   Native = 'native',
@@ -120,6 +121,20 @@ export async function detectWarpTokenType(
   const result = matches[0];
   assert(result !== undefined, 'Unexpected empty matches after validation');
   return result;
+}
+
+/**
+ * Queries the on-chain program version for a warp token program.
+ * Uses the token owner as the simulation fee payer (must exist on-chain).
+ * Returns null if the owner is null (can't simulate without a payer).
+ */
+export async function fetchWarpProgramVersion(
+  rpc: SvmRpc,
+  programId: Address,
+  owner: Address | null,
+): Promise<string | null> {
+  if (!owner) return null;
+  return queryProgramVersion(rpc, programId, owner);
 }
 
 /** Converts a 32-byte router H256 to a 0x-prefixed hex string. */

--- a/typescript/svm-sdk/src/warp/warp-query.ts
+++ b/typescript/svm-sdk/src/warp/warp-query.ts
@@ -3,8 +3,11 @@ import { type Address, fetchEncodedAccount } from '@solana/kit';
 import { assert, fromHexString, toHexString } from '@hyperlane-xyz/utils';
 
 import {
+  COLLATERAL_PLUGIN_SIZE,
   decodeHyperlaneTokenAccount,
   type HyperlaneTokenAccountData,
+  NATIVE_PLUGIN_SIZE,
+  SYNTHETIC_PLUGIN_SIZE,
 } from '../accounts/token.js';
 import {
   deriveCrossCollateralStatePda,
@@ -29,11 +32,40 @@ export enum SvmWarpTokenType {
 export async function fetchTokenAccount(
   rpc: SvmRpc,
   programId: Address,
+  pluginSize: number,
 ): Promise<HyperlaneTokenAccountData | null> {
   const { address: tokenPda } = await deriveHyperlaneTokenPda(programId);
   const account = await fetchEncodedAccount(rpc, tokenPda);
   if (!account.exists) return null;
-  return decodeHyperlaneTokenAccount(account.data as Uint8Array);
+  return decodeHyperlaneTokenAccount(Uint8Array.from(account.data), pluginSize);
+}
+
+export function fetchNativeTokenAccount(
+  rpc: SvmRpc,
+  programId: Address,
+): Promise<HyperlaneTokenAccountData | null> {
+  return fetchTokenAccount(rpc, programId, NATIVE_PLUGIN_SIZE);
+}
+
+export function fetchSyntheticTokenAccount(
+  rpc: SvmRpc,
+  programId: Address,
+): Promise<HyperlaneTokenAccountData | null> {
+  return fetchTokenAccount(rpc, programId, SYNTHETIC_PLUGIN_SIZE);
+}
+
+export function fetchCollateralTokenAccount(
+  rpc: SvmRpc,
+  programId: Address,
+): Promise<HyperlaneTokenAccountData | null> {
+  return fetchTokenAccount(rpc, programId, COLLATERAL_PLUGIN_SIZE);
+}
+
+export function fetchCrossCollateralTokenAccount(
+  rpc: SvmRpc,
+  programId: Address,
+): Promise<HyperlaneTokenAccountData | null> {
+  return fetchTokenAccount(rpc, programId, COLLATERAL_PLUGIN_SIZE);
 }
 
 /**

--- a/typescript/svm-sdk/src/warp/warp-tx.ts
+++ b/typescript/svm-sdk/src/warp/warp-tx.ts
@@ -20,13 +20,20 @@ import { getSetUpgradeAuthorityInstruction } from '../instructions/loader.js';
 import {
   getTokenEnrollRemoteRoutersInstruction,
   getTokenSetDestinationGasConfigsInstruction,
+  getTokenSetFeeConfigInstruction,
   getTokenSetInterchainGasPaymasterInstruction,
   getTokenSetInterchainSecurityModuleInstruction,
   getTokenTransferOwnershipInstruction,
   type TokenInitInstructionData,
 } from '../instructions/token.js';
 import { DEFAULT_IGP_SALT } from '../hook/igp-hook.js';
-import { deriveAtaPayerPda, deriveOverheadIgpAccountPda } from '../pda.js';
+import { fetchFeeAccount } from '../fee/fee-query.js';
+import { DEFAULT_FEE_SALT } from '../fee/types.js';
+import {
+  deriveAtaPayerPda,
+  deriveFeeAccountPda,
+  deriveOverheadIgpAccountPda,
+} from '../pda.js';
 import {
   buildInstruction,
   writableAccount,
@@ -185,7 +192,11 @@ export const MAX_GAS_CONFIGS_PER_TX = 60;
 export async function applyPostInitConfig(
   signer: SvmSigner,
   programId: Address,
-  config: Pick<RawWarpArtifactConfig, 'remoteRouters' | 'destinationGas'>,
+  config: Pick<
+    RawWarpArtifactConfig,
+    'remoteRouters' | 'destinationGas' | 'fee'
+  >,
+  feeSalt: Uint8Array = DEFAULT_FEE_SALT,
 ): Promise<SvmReceipt[]> {
   const receipts: SvmReceipt[] = [];
 
@@ -221,6 +232,40 @@ export async function applyPostInitConfig(
               domain: parseInt(domain),
               gas: BigInt(gas),
             })),
+          ),
+        ],
+      }),
+    );
+  }
+
+  // Set fee config if a deployed fee artifact is present
+  const feeDeployed = config.fee?.deployed;
+  if (feeDeployed) {
+    const feeProgram = parseAddress(feeDeployed.address);
+    const { address: feeAccountPda } = await deriveFeeAccountPda(
+      feeProgram,
+      feeSalt,
+    );
+
+    // Validate the fee PDA exists before setting it on the token
+    const feeAccount = await fetchFeeAccount(
+      signer.getRpc(),
+      feeProgram,
+      feeSalt,
+    );
+    assert(
+      feeAccount,
+      `Fee account PDA not initialized at program ${feeDeployed.address} with the given salt. ` +
+        'Deploy the fee program first before setting it on the warp token.',
+    );
+
+    receipts.push(
+      await signer.send({
+        instructions: [
+          await getTokenSetFeeConfigInstruction(
+            programId,
+            signer.signer.address,
+            { feeProgram, feeAccount: feeAccountPda },
           ),
         ],
       }),

--- a/typescript/svm-sdk/src/warp/warp-tx.ts
+++ b/typescript/svm-sdk/src/warp/warp-tx.ts
@@ -9,6 +9,7 @@ import {
   eqAddressSol,
   eqOptionalAddress,
   isZeroishAddress,
+  toHexString,
 } from '@hyperlane-xyz/utils';
 
 import type { SvmSigner } from '../clients/signer.js';
@@ -30,6 +31,7 @@ import {
 import { DEFAULT_IGP_SALT } from '../hook/igp-hook.js';
 import { fetchFeeAccount } from '../fee/fee-query.js';
 import { DEFAULT_FEE_SALT } from '../fee/types.js';
+import { supportsFeeConfig } from '../version/version-query.js';
 import {
   deriveAtaPayerPda,
   deriveFeeAccountPda,
@@ -256,8 +258,8 @@ export async function applyPostInitConfig(
     );
     assert(
       feeAccount,
-      `Fee account PDA not initialized at program ${feeDeployed.address} with the given salt. ` +
-        'Deploy the fee program first before setting it on the warp token.',
+      `Fee account PDA not initialized at program ${feeDeployed.address} with salt ${toHexString(Buffer.from(feeSalt))}. ` +
+        'Deploy the fee program first, or check that SVM_FEE_<CHAIN>_SALT is set correctly for this program id.',
     );
 
     receipts.push(
@@ -328,6 +330,7 @@ export async function computeWarpTokenUpdateInstructions(
   label: string,
   feeSalt: Uint8Array = DEFAULT_FEE_SALT,
   currentOnChainFeeConfig?: TokenFeeConfig,
+  upgradingToVersion?: string,
 ): Promise<AnnotatedSvmTransaction[]> {
   const txs: AnnotatedSvmTransaction[] = [];
 
@@ -386,6 +389,11 @@ export async function computeWarpTokenUpdateInstructions(
   // 2. Fee config diff
   const expectedFee = expected.fee?.deployed?.address;
   if (expectedFee) {
+    const effectiveVersion = upgradingToVersion ?? current.contractVersion;
+    assert(
+      supportsFeeConfig(effectiveVersion),
+      `Cannot set fee config: program at ${programId} is version ${effectiveVersion ?? 'pre-PackageVersioned'} which does not support fee config. Set contractVersion in the expected config and provide program bytes to upgrade first.`,
+    );
     const expectedFeeProgram = parseAddress(expectedFee);
     const { address: expectedFeePda } = await deriveFeeAccountPda(
       expectedFeeProgram,
@@ -415,7 +423,8 @@ export async function computeWarpTokenUpdateInstructions(
       );
       assert(
         feeAccount,
-        `Fee account PDA not initialized at program ${expectedFee} with the given salt.`,
+        `Fee account PDA not initialized at program ${expectedFee} with salt ${toHexString(Buffer.from(feeSalt))}. ` +
+          'Check that SVM_FEE_<CHAIN>_SALT is set correctly for this program id.',
       );
 
       txs.push({

--- a/typescript/svm-sdk/src/warp/warp-tx.ts
+++ b/typescript/svm-sdk/src/warp/warp-tx.ts
@@ -17,6 +17,7 @@ import { InterchainGasPaymasterTypeKind } from '../codecs/shared.js';
 import { SYSTEM_PROGRAM_ADDRESS } from '../constants.js';
 import { getProgramUpgradeAuthority } from '../deploy/program-deployer.js';
 import { getSetUpgradeAuthorityInstruction } from '../instructions/loader.js';
+import type { TokenFeeConfig } from '../accounts/token.js';
 import {
   getTokenEnrollRemoteRoutersInstruction,
   getTokenSetDestinationGasConfigsInstruction,
@@ -325,6 +326,8 @@ export async function computeWarpTokenUpdateInstructions(
   ownerAddress: Address,
   rpc: SvmRpc,
   label: string,
+  feeSalt: Uint8Array = DEFAULT_FEE_SALT,
+  currentOnChainFeeConfig?: TokenFeeConfig,
 ): Promise<AnnotatedSvmTransaction[]> {
   const txs: AnnotatedSvmTransaction[] = [];
 
@@ -380,7 +383,64 @@ export async function computeWarpTokenUpdateInstructions(
     });
   }
 
-  // 2. Router diff — the same domain set (toUnenroll/toEnroll) drives both
+  // 2. Fee config diff
+  const expectedFee = expected.fee?.deployed?.address;
+  if (expectedFee) {
+    const expectedFeeProgram = parseAddress(expectedFee);
+    const { address: expectedFeePda } = await deriveFeeAccountPda(
+      expectedFeeProgram,
+      feeSalt,
+    );
+    const expectedFeeConfig: TokenFeeConfig = {
+      feeProgram: expectedFeeProgram,
+      feeAccount: expectedFeePda,
+    };
+
+    const changed =
+      !currentOnChainFeeConfig ||
+      !eqAddressSol(
+        currentOnChainFeeConfig.feeProgram,
+        expectedFeeConfig.feeProgram,
+      ) ||
+      !eqAddressSol(
+        currentOnChainFeeConfig.feeAccount,
+        expectedFeeConfig.feeAccount,
+      );
+
+    if (changed) {
+      const feeAccount = await fetchFeeAccount(
+        rpc,
+        expectedFeeProgram,
+        feeSalt,
+      );
+      assert(
+        feeAccount,
+        `Fee account PDA not initialized at program ${expectedFee} with the given salt.`,
+      );
+
+      txs.push({
+        feePayer: ownerAddress,
+        instructions: [
+          await getTokenSetFeeConfigInstruction(
+            programId,
+            ownerAddress,
+            expectedFeeConfig,
+          ),
+        ],
+        annotation: `Update ${label}: set fee config`,
+      });
+    }
+  } else if (currentOnChainFeeConfig) {
+    txs.push({
+      feePayer: ownerAddress,
+      instructions: [
+        await getTokenSetFeeConfigInstruction(programId, ownerAddress, null),
+      ],
+      annotation: `Update ${label}: remove fee config`,
+    });
+  }
+
+  // 3. Router diff — the same domain set (toUnenroll/toEnroll) drives both
   //    router and gas config changes, batched independently because gas config
   //    instructions are smaller and allow more entries per tx.
   const diff = computeRemoteRoutersUpdates(
@@ -480,7 +540,7 @@ export async function computeWarpTokenUpdateInstructions(
   const expectedOwnerAddress =
     expected.owner && !isZeroishAddress(expected.owner) ? expected.owner : null;
 
-  // 3. Ownership change — own tx
+  // 4. Ownership change — own tx
   if (!eqOptionalAddress(current.owner, expected.owner, eqAddressSol)) {
     txs.push({
       feePayer: ownerAddress,
@@ -495,7 +555,7 @@ export async function computeWarpTokenUpdateInstructions(
     });
   }
 
-  // 4. Upgrade authority — always last tx.
+  // 5. Upgrade authority — always last tx.
   // Skip when the program is immutable (no current authority).
   const currentUpgradeAuthority = await getProgramUpgradeAuthority(
     rpc,

--- a/typescript/svm-sdk/src/warp/warp-tx.ts
+++ b/typescript/svm-sdk/src/warp/warp-tx.ts
@@ -197,7 +197,7 @@ export async function applyPostInitConfig(
   programId: Address,
   config: Pick<
     RawWarpArtifactConfig,
-    'remoteRouters' | 'destinationGas' | 'fee'
+    'mailbox' | 'remoteRouters' | 'destinationGas' | 'fee'
   >,
   feeSalt: Uint8Array = DEFAULT_FEE_SALT,
 ): Promise<SvmReceipt[]> {
@@ -268,6 +268,7 @@ export async function applyPostInitConfig(
           await getTokenSetFeeConfigInstruction(
             programId,
             signer.signer.address,
+            parseAddress(config.mailbox),
             { feeProgram, feeAccount: feeAccountPda },
           ),
         ],
@@ -433,6 +434,7 @@ export async function computeWarpTokenUpdateInstructions(
           await getTokenSetFeeConfigInstruction(
             programId,
             ownerAddress,
+            parseAddress(current.mailbox),
             expectedFeeConfig,
           ),
         ],
@@ -443,7 +445,12 @@ export async function computeWarpTokenUpdateInstructions(
     txs.push({
       feePayer: ownerAddress,
       instructions: [
-        await getTokenSetFeeConfigInstruction(programId, ownerAddress, null),
+        await getTokenSetFeeConfigInstruction(
+          programId,
+          ownerAddress,
+          parseAddress(current.mailbox),
+          null,
+        ),
       ],
       annotation: `Update ${label}: remove fee config`,
     });

--- a/typescript/svm-sdk/src/warp/warp-upgrade.ts
+++ b/typescript/svm-sdk/src/warp/warp-upgrade.ts
@@ -1,0 +1,154 @@
+/**
+ * Program upgrade logic for warp route token programs.
+ *
+ * Separates upgrade concerns from config diffing (warp-tx.ts).
+ * Writers call this before computeWarpTokenUpdateInstructions
+ * when contractVersion in the expected config differs from current.
+ */
+import type { Address } from '@solana/kit';
+
+import { assert, eqAddressSol } from '@hyperlane-xyz/utils';
+
+import type { SvmSigner } from '../clients/signer.js';
+import {
+  PROGRAM_DATA_HEADER_SIZE,
+  createUpgradeProgramPlan,
+  DeployStageKind,
+  executeDeployPlan,
+  getProgramUpgradeAuthority,
+} from '../deploy/program-deployer.js';
+import { deriveProgramDataAddress } from '../pda.js';
+import {
+  getExtendProgramCheckedInstruction,
+  getSetBufferAuthorityInstruction,
+} from '../instructions/loader.js';
+import { compareVersions } from '../version/version-query.js';
+import type { AnnotatedSvmTransaction, SvmReceipt, SvmRpc } from '../types.js';
+
+/**
+ * Handles program upgrade for a warp route token program.
+ *
+ * Creates the buffer and writes program bytes using the provided signer,
+ * then returns transactions that require the upgrade authority to execute.
+ *
+ * @returns Upgrade transactions plus receipts from buffer prep.
+ *          Null if no upgrade is needed.
+ * @throws If downgrade is attempted, or the program is immutable.
+ */
+export async function prepareProgramUpgrade(
+  programId: Address,
+  currentVersion: string | undefined,
+  expectedVersion: string | undefined,
+  programBytes: Uint8Array,
+  signer: SvmSigner,
+  rpc: SvmRpc,
+  label: string,
+): Promise<{
+  authorityTransactions: AnnotatedSvmTransaction[];
+  receipts: SvmReceipt[];
+} | null> {
+  if (!expectedVersion || currentVersion === expectedVersion) {
+    return null;
+  }
+
+  if (currentVersion && compareVersions(expectedVersion, currentVersion) < 0) {
+    throw new Error(
+      `Cannot downgrade ${label}: deployed version ${currentVersion} is newer than expected ${expectedVersion}`,
+    );
+  }
+
+  const upgradeAuthority = await getProgramUpgradeAuthority(rpc, programId);
+  assert(
+    upgradeAuthority,
+    `Program upgrade required for ${label} but program is immutable (no upgrade authority)`,
+  );
+
+  const receipts: SvmReceipt[] = [];
+  const authorityTransactions: AnnotatedSvmTransaction[] = [];
+
+  // Check if the program data account needs extending for the new binary.
+  const programDataAddress = await deriveProgramDataAddress(programId);
+  const programDataAccount = await rpc
+    .getAccountInfo(programDataAddress, { encoding: 'base64' })
+    .send();
+  assert(
+    programDataAccount.value,
+    `Program data account not found for ${label}`,
+  );
+
+  const currentAccountSize = Buffer.from(
+    programDataAccount.value.data[0] as string,
+    'base64',
+  ).length;
+  const currentMaxProgramLen = currentAccountSize - PROGRAM_DATA_HEADER_SIZE;
+  const additionalBytes = programBytes.length - currentMaxProgramLen;
+
+  if (additionalBytes > 0) {
+    authorityTransactions.push({
+      feePayer: upgradeAuthority,
+      instructions: [
+        getExtendProgramCheckedInstruction(
+          programDataAddress,
+          programId,
+          upgradeAuthority,
+          upgradeAuthority,
+          additionalBytes,
+        ),
+      ],
+      annotation: `Extend ${label}: +${additionalBytes} bytes`,
+    });
+  }
+
+  // Create buffer and write new program bytes.
+  const plan = await createUpgradeProgramPlan({
+    payer: signer.signer,
+    authority: signer.signer,
+    programAddress: programId,
+    newProgramBytes: programBytes,
+    upgradeAuthority,
+    getMinimumBalanceForRentExemption: (size: number) =>
+      rpc.getMinimumBalanceForRentExemption(BigInt(size)).send(),
+  });
+
+  // Execute buffer creation + writes immediately (payer-only, no authority needed).
+  const finalizeStage = plan.stages.pop();
+  assert(
+    finalizeStage && finalizeStage.kind === DeployStageKind.Finalize,
+    'Expected last stage to be the finalize/upgrade stage',
+  );
+
+  const result = await executeDeployPlan({
+    plan,
+    executeStage: async (stage) =>
+      signer.send({
+        instructions: stage.instructions,
+        additionalSigners: stage.additionalSigners,
+      }),
+  });
+  receipts.push(...result);
+
+  // Transfer buffer authority to the upgrade authority if they differ.
+  if (!eqAddressSol(signer.signer.address, upgradeAuthority)) {
+    const initStage = plan.stages.find((s) => s.kind === DeployStageKind.Init);
+    assert(initStage, 'Expected init stage in upgrade plan');
+    const bufferSigner = initStage.additionalSigners?.[0];
+    assert(bufferSigner, 'Expected buffer signer in init stage');
+
+    const transferIx = getSetBufferAuthorityInstruction(
+      bufferSigner.address,
+      signer.signer.address,
+      upgradeAuthority,
+    );
+    receipts.push(await signer.send({ instructions: [transferIx] }));
+  }
+
+  // Upgrade instruction — requires upgrade authority to sign.
+  authorityTransactions.push({
+    feePayer: upgradeAuthority,
+    instructions: finalizeStage.instructions,
+    additionalSigners: finalizeStage.additionalSigners,
+    annotation: `Upgrade ${label}: ${currentVersion ?? 'unknown'} → ${expectedVersion}`,
+  });
+
+  return { authorityTransactions, receipts };
+}

--- a/typescript/svm-sdk/src/warp/warp-upgrade.ts
+++ b/typescript/svm-sdk/src/warp/warp-upgrade.ts
@@ -86,7 +86,7 @@ export async function prepareProgramUpgrade(
   );
 
   const currentAccountSize = Buffer.from(
-    programDataAccount.value.data[0] as string,
+    programDataAccount.value.data[0],
     'base64',
   ).length;
   const currentMaxProgramLen = currentAccountSize - PROGRAM_DATA_HEADER_SIZE;

--- a/typescript/svm-sdk/src/warp/warp-upgrade.ts
+++ b/typescript/svm-sdk/src/warp/warp-upgrade.ts
@@ -10,6 +10,7 @@ import type { Address } from '@solana/kit';
 import { assert, eqAddressSol } from '@hyperlane-xyz/utils';
 
 import type { SvmSigner } from '../clients/signer.js';
+import { MAX_COMPUTE_UNITS } from '../constants.js';
 import {
   PROGRAM_DATA_HEADER_SIZE,
   createUpgradeProgramPlan,
@@ -47,11 +48,19 @@ export async function prepareProgramUpgrade(
   authorityTransactions: AnnotatedSvmTransaction[];
   receipts: SvmReceipt[];
 } | null> {
-  if (!expectedVersion || currentVersion === expectedVersion) {
+  if (!expectedVersion) {
     return null;
   }
 
-  if (currentVersion && compareVersions(expectedVersion, currentVersion) < 0) {
+  const cmp = currentVersion
+    ? compareVersions(expectedVersion, currentVersion)
+    : 1;
+
+  if (cmp === 0) {
+    return null;
+  }
+
+  if (cmp < 0) {
     throw new Error(
       `Cannot downgrade ${label}: deployed version ${currentVersion} is newer than expected ${expectedVersion}`,
     );
@@ -95,6 +104,7 @@ export async function prepareProgramUpgrade(
           additionalBytes,
         ),
       ],
+      computeUnits: MAX_COMPUTE_UNITS,
       annotation: `Extend ${label}: +${additionalBytes} bytes`,
     });
   }
@@ -147,6 +157,7 @@ export async function prepareProgramUpgrade(
     feePayer: upgradeAuthority,
     instructions: finalizeStage.instructions,
     additionalSigners: finalizeStage.additionalSigners,
+    computeUnits: MAX_COMPUTE_UNITS,
     annotation: `Upgrade ${label}: ${currentVersion ?? 'unknown'} → ${expectedVersion}`,
   });
 


### PR DESCRIPTION
### Description

  Adds TypeScript SDK support for SVM warp routes that integrate with the SVM fee program from #8698. The branch covers the full lifecycle for the four SVM warp token types (native, synthetic, collateral, cross-collateral):

  - **Wire format & instructions.** Added a `TokenFeeConfig` type and extended the `HyperlaneToken` account decoder to read the trailing `Option<FeeConfig>` field with EOF-as-None semantics so pre-fee accounts keep deserializing. Added the
   `SetFeeConfig` instruction builder. Added the `GetProgramVersion` instruction builder + universal 8-byte discriminator and a simulation-based `queryProgramVersion` that decodes the Borsh `SimulationReturnData<String>` payload.
  - **Readers.** Token readers now surface the on-chain `feeConfig` (program + PDA) and the deployed program version. Reader output round-trips through the writer's diff so an unchanged config produces zero update transactions.
  - **Writers — fee config.** Create flow wires `SetFeeConfig` after token init when the config carries a fee program; update flow diffs the on-chain `Option<FeeConfig>` against the expected one and emits SetFeeConfig only when the
  program/PDA actually changes (Some→Some, Some→None, None→Some). The fee-account PDA is validated on-chain before SetFeeConfig is issued. `feeSalt` is plumbed through the warp artifact manager and resolved per chain via env var.
  - **Writers — program upgrade.** Added an explicit, version-gated upgrade flow (`prepareProgramUpgrade`) that compares the on-chain version against the user-supplied `contractVersion` (mirroring the EVM behaviour: no `contractVersion` →
  no upgrade). It creates the buffer + writes new program bytes immediately, optionally transfers the buffer authority when signer ≠ upgrade authority, and returns the `ExtendProgramChecked` and `Upgrade` transactions for the upgrade
  authority to execute. BPF Loader v3 instruction builders (`ExtendProgramChecked`, `SetBufferAuthority`) and the `programData` PDA derivation were added. Update flow also reconciles BPF upgrade authority with the warp-token owner when
  ownership changes.
  - **Cross-package.** Added `contractVersion?: string` to the `provider-sdk` warp config / derived / artifact base types and propagated it through the AltVM path in `sdk`. Promoted `compare-versions` to the workspace catalog so EVM and
  SVM share the same library.
  - **Tests + CI.** Two new E2E suites — `warp-fee-config` (fee lifecycle, salt-driven PDA change, no-op-update assertion) and `program-upgrade` (legacy → 1.0.0 deploy + read, downgrade rejection, equal-version skip, full functional
  upgrade with ownership + fee in one update, cross-authority upgrade) — both wired into the SVM SDK E2E CI matrix. Legacy program bytes are preserved alongside the current bytes for upgrade-path coverage.

  The CLI integration that lets operators drive these flows from `hyperlane warp deploy/apply` is intentionally out of scope and will follow.

  ### Drive-by changes

  - Added a `hasProgramBytes` type guard for `SvmProgramTarget` and replaced the four `'programBytes' in this.config.program` checks across token writers.
  - Added a `MAX_COMPUTE_UNITS` constant and applied it to the returned upgrade transactions for headroom.
  - Inspected simulation errors via `@solana/errors` so only Borsh / `InvalidInstructionData` / `ProgramFailedToComplete` are treated as pre-PackageVersioned; other infra errors now surface instead of silently returning `null`.
  - Switched the upgrade version-equality check to a semver-aware compare so non-canonical strings like `1.0.0+build` no longer trigger a redundant upgrade.
  - Deduplicated the local `sleep` helper in tests in favour of `@hyperlane-xyz/utils`.
  - Added the `chainName` plumbing on `SvmWarpArtifactManager` so the per-chain fee-salt env var lookup has a key.

  ### Related issues

  Depends on https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/8698 (Rust on-chain programs).

  ### Backward compatibility

  Yes. `contractVersion` is optional on every interface it was added to. The `HyperlaneToken` Borsh decoder treats EOF as `None` so pre-fee accounts keep deserializing, and the on-chain Rust program does the same on its side. Program
  upgrade is opt-in: it only fires when the user explicitly sets `contractVersion` in the expected config (same gating model as EVM). Existing pre-PackageVersioned warp programs read back as `contractVersion: undefined` and are otherwise
  untouched.

  ### Testing

  Unit Tests + E2E.

  - 58 unit tests passing (existing).
  - Two new E2E suites in the CI matrix:
    - `warp-fee-config` — set fee on deploy (with no-op update assertion), add fee via update, change fee program, detect fee-account change driven by salt, remove fee via update.
    - `program-upgrade` — legacy → 1.0.0 deploy + read, downgrade rejection, equal-version skip, full functional upgrade with ownership transfer + fee config in one update, cross-authority upgrade where ownership and BPF upgrade authority
  are transferred to a different key BEFORE the upgrade so the `SetBufferAuthority(signer → newOwner)` branch and authority-signed `Upgrade` tx are exercised.
  - Existing token-type E2E suites (native, synthetic, collateral, cross-collateral) re-validated locally to cover the type-guard refactor.