### PR TITLE
fix(sdk): use vault maxWithdraw for ERC-4626 collateral balance check

### DIFF
--- a/.changeset/erc4626-vault-collateral-fix.md
+++ b/.changeset/erc4626-vault-collateral-fix.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The ERC-4626 vault collateral balance check was fixed to use vault.maxWithdraw() instead of wrappedToken().balanceOf(). For vault-based collateral contracts (EvmHypOwnerCollateral), the previous approach returned 0 because the contract holds vault shares rather than the underlying asset directly. This caused "Insufficient collateral on destination" errors blocking all outbound transfers.

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -691,6 +691,7 @@ export {
 } from './token/adapters/CosmWasmTokenAdapter.js';
 export {
   EvmHypCollateralAdapter,
+  EvmHypVaultCollateralAdapter,
   EvmMovableCollateralAdapter,
   EvmHypNativeAdapter,
   EvmHypSyntheticAdapter,

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -900,10 +900,13 @@ export class EvmHypCollateralFiatAdapter
 }
 
 export class EvmHypVaultCollateralAdapter
-  extends EvmMovableCollateralAdapter
+  extends BaseEvmHypCollateralAdapter
   implements IHypTokenAdapter<PopulatedTransaction>
 {
-  public readonly vaultCollateralContract: HypERC4626Collateral;
+  public override collateralContract: HypERC4626Collateral;
+  protected readonly vaultAddress = new LazyAsync(() =>
+    this.collateralContract.vault(),
+  );
 
   constructor(
     public readonly chainName: ChainName,
@@ -911,15 +914,19 @@ export class EvmHypVaultCollateralAdapter
     public readonly addresses: { token: Address },
   ) {
     super(chainName, multiProvider, addresses);
-    this.vaultCollateralContract = HypERC4626Collateral__factory.connect(
+    this.collateralContract = HypERC4626Collateral__factory.connect(
       addresses.token,
       this.getProvider(),
     );
   }
 
+  protected override async loadWrappedTokenAddress(): Promise<Address> {
+    return this.collateralContract.wrappedToken();
+  }
+
   override async getBalance(address: Address): Promise<bigint> {
     const vault = ERC4626__factory.connect(
-      await this.vaultCollateralContract.vault(),
+      await this.vaultAddress.get(),
       this.getProvider(),
     );
     const maxWithdraw = await vault.maxWithdraw(toEvmAddress(address));
@@ -930,12 +937,12 @@ export class EvmHypVaultCollateralAdapter
     blockTag?: number | EthJsonRpcBlockParameterTag;
   }): Promise<bigint | undefined> {
     const vault = ERC4626__factory.connect(
-      await this.vaultCollateralContract.vault(),
+      await this.vaultAddress.get(),
       this.getProvider(),
     );
     const overrides = buildBlockTagOverrides(options?.blockTag);
     const maxWithdraw = await vault.maxWithdraw(
-      this.addresses.token,
+      toEvmAddress(this.addresses.token),
       overrides,
     );
     return maxWithdraw.toBigInt();

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -899,6 +899,49 @@ export class EvmHypCollateralFiatAdapter
   }
 }
 
+export class EvmHypVaultCollateralAdapter
+  extends EvmMovableCollateralAdapter
+  implements IHypTokenAdapter<PopulatedTransaction>
+{
+  public readonly vaultCollateralContract: HypERC4626Collateral;
+
+  constructor(
+    public readonly chainName: ChainName,
+    public readonly multiProvider: MultiProviderAdapter,
+    public readonly addresses: { token: Address },
+  ) {
+    super(chainName, multiProvider, addresses);
+    this.vaultCollateralContract = HypERC4626Collateral__factory.connect(
+      addresses.token,
+      this.getProvider(),
+    );
+  }
+
+  override async getBalance(address: Address): Promise<bigint> {
+    const vault = ERC4626__factory.connect(
+      await this.vaultCollateralContract.vault(),
+      this.getProvider(),
+    );
+    const maxWithdraw = await vault.maxWithdraw(toEvmAddress(address));
+    return maxWithdraw.toBigInt();
+  }
+
+  override async getBridgedSupply(options?: {
+    blockTag?: number | EthJsonRpcBlockParameterTag;
+  }): Promise<bigint | undefined> {
+    const vault = ERC4626__factory.connect(
+      await this.vaultCollateralContract.vault(),
+      this.getProvider(),
+    );
+    const overrides = buildBlockTagOverrides(options?.blockTag);
+    const maxWithdraw = await vault.maxWithdraw(
+      this.addresses.token,
+      overrides,
+    );
+    return maxWithdraw.toBigInt();
+  }
+}
+
 export class EvmHypRebaseCollateralAdapter
   extends BaseEvmHypCollateralAdapter
   implements IHypTokenAdapter<PopulatedTransaction>

--- a/typescript/sdk/src/token/adapters/evmHyp.ts
+++ b/typescript/sdk/src/token/adapters/evmHyp.ts
@@ -11,10 +11,8 @@ export function createEvmHypAdapter(
   return createEvmLikeHypAdapter(multiProvider, token, {
     native: TokenStandard.EvmNative,
     hypNative: TokenStandard.EvmHypNative,
-    hypCollateral: [
-      TokenStandard.EvmHypCollateral,
-      TokenStandard.EvmHypOwnerCollateral,
-    ],
+    hypCollateral: [TokenStandard.EvmHypCollateral],
+    hypVaultCollateral: [TokenStandard.EvmHypOwnerCollateral],
     hypCrossCollateralRouter: TokenStandard.EvmHypCrossCollateralRouter,
     hypRebaseCollateral: TokenStandard.EvmHypRebaseCollateral,
     hypCollateralFiat: TokenStandard.EvmHypCollateralFiat,

--- a/typescript/sdk/src/token/adapters/evmLikeHyp.ts
+++ b/typescript/sdk/src/token/adapters/evmLikeHyp.ts
@@ -4,6 +4,7 @@ import {
   EvmHypRebaseCollateralAdapter,
   EvmHypSyntheticAdapter,
   EvmHypSyntheticRebaseAdapter,
+  EvmHypVaultCollateralAdapter,
   EvmHypXERC20Adapter,
   EvmHypXERC20LockboxAdapter,
   EvmMovableCollateralAdapter,
@@ -25,6 +26,7 @@ export function createEvmLikeHypAdapter(
     native: TokenStandard;
     hypNative: TokenStandard;
     hypCollateral: readonly TokenStandard[];
+    hypVaultCollateral: readonly TokenStandard[];
     hypCrossCollateralRouter: TokenStandard;
     hypRebaseCollateral: TokenStandard;
     hypCollateralFiat: TokenStandard;
@@ -54,6 +56,14 @@ export function createEvmLikeHypAdapter(
 
   if (standards.hypCollateral.some((candidate) => candidate === standard)) {
     return new EvmMovableCollateralAdapter(chainName, multiProvider, {
+      token: addressOrDenom,
+    });
+  }
+
+  if (
+    standards.hypVaultCollateral.some((candidate) => candidate === standard)
+  ) {
+    return new EvmHypVaultCollateralAdapter(chainName, multiProvider, {
       token: addressOrDenom,
     });
   }

--- a/typescript/sdk/src/token/adapters/tronHyp.ts
+++ b/typescript/sdk/src/token/adapters/tronHyp.ts
@@ -11,10 +11,8 @@ export function createTronHypAdapter(
   return createEvmLikeHypAdapter(multiProvider, token, {
     native: TokenStandard.TronNative,
     hypNative: TokenStandard.TronHypNative,
-    hypCollateral: [
-      TokenStandard.TronHypCollateral,
-      TokenStandard.TronHypOwnerCollateral,
-    ],
+    hypCollateral: [TokenStandard.TronHypCollateral],
+    hypVaultCollateral: [TokenStandard.TronHypOwnerCollateral],
     hypCrossCollateralRouter: TokenStandard.TronHypCrossCollateralRouter,
     hypRebaseCollateral: TokenStandard.TronHypRebaseCollateral,
     hypCollateralFiat: TokenStandard.TronHypCollateralFiat,


### PR DESCRIPTION
## Summary
- `BaseEvmHypCollateralAdapter.getBalance()` calls `wrappedToken().balanceOf(contract)` which returns the underlying asset balance. For ERC-4626 vault collateral (`EvmHypOwnerCollateral`), the contract holds vault shares (not the underlying directly), so `balanceOf` returns 0.
- This caused `WarpCore.isDestinationCollateralSufficient()` to always fail, blocking all outbound transfers in the UI with "Insufficient collateral on destination".
- Added `EvmHypVaultCollateralAdapter` which uses the vault's `maxWithdraw()` to correctly report available collateral in underlying asset terms. Moved `EvmHypOwnerCollateral` / `TronHypOwnerCollateral` token standards to use this new adapter instead of the generic `EvmMovableCollateralAdapter`.

## Changes
- **EvmTokenAdapter.ts**: New `EvmHypVaultCollateralAdapter` class extending `EvmMovableCollateralAdapter`, overriding `getBalance()` and `getBridgedSupply()` to use `vault.maxWithdraw()` instead of `wrappedToken().balanceOf()`
- **evmLikeHyp.ts**: Added `hypVaultCollateral` field to standards config and routing logic for the new adapter
- **evmHyp.ts**: Moved `EvmHypOwnerCollateral` from `hypCollateral` to new `hypVaultCollateral` field
- **tronHyp.ts**: Same change for `TronHypOwnerCollateral`
- **index.ts**: Exported `EvmHypVaultCollateralAdapter`

## Test plan
- [ ] Verify `pnpm build` passes (confirmed locally)
- [ ] Verify `pnpm lint` passes (confirmed locally)
- [ ] Test with a vault collateral warp route (e.g. steakUSDT) that `getBalance()` returns correct non-zero underlying value
- [ ] Confirm outbound transfers no longer blocked by "Insufficient collateral on destination"
- [ ] Verify non-vault collateral routes still work correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)