### PR TITLE
fix: moonpay deploy issues

### DIFF
--- a/.changeset/popular-games-unite.md
+++ b/.changeset/popular-games-unite.md
@@ -3,4 +3,4 @@
 "@hyperlane-xyz/sdk": patch
 ---
 
-Fixed various minor issues
+The IGP fee assertion is relaxed for Sealevel cross-collateral transfers; OffchainQuotedLinearFee is supported as a sub-fee of routing fees; warp deployment errors now surface their cause chain and Solana preflight logs.

--- a/.changeset/popular-games-unite.md
+++ b/.changeset/popular-games-unite.md
@@ -1,0 +1,6 @@
+---
+"@hyperlane-xyz/cli": patch
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed various minor issues

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -59,6 +59,7 @@ import {
   type Address,
   addressToBytes32,
   assert,
+  formatError,
   isEVMLike,
   mapAllSettled,
   mustGet,
@@ -102,28 +103,6 @@ import {
   runPreflightChecksForChains,
   validateWarpIsmCompatibility,
 } from './utils.js';
-
-/**
- * Formats an error for display, including cause chain and any Solana program
- * logs attached to preflight failure errors.
- */
-function formatError(error: unknown): string {
-  if (!(error instanceof Error)) return String(error);
-
-  const parts: string[] = [error.message];
-
-  // SolanaError preflight failures attach { logs, unitsConsumed, ... } to context
-  const ctx = (error as any).context;
-  if (Array.isArray(ctx?.logs) && ctx.logs.length > 0) {
-    parts.push(`Logs:\n  ${(ctx.logs as string[]).join('\n  ')}`);
-  }
-
-  if (error.cause instanceof Error) {
-    parts.push(`Caused by: ${formatError(error.cause)}`);
-  }
-
-  return parts.join('\n');
-}
 
 interface DeployParams {
   context: WriteCommandContext;

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -103,6 +103,28 @@ import {
   validateWarpIsmCompatibility,
 } from './utils.js';
 
+/**
+ * Formats an error for display, including cause chain and any Solana program
+ * logs attached to preflight failure errors.
+ */
+function formatError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+
+  const parts: string[] = [error.message];
+
+  // SolanaError preflight failures attach { logs, unitsConsumed, ... } to context
+  const ctx = (error as any).context;
+  if (Array.isArray(ctx?.logs) && ctx.logs.length > 0) {
+    parts.push(`Logs:\n  ${(ctx.logs as string[]).join('\n  ')}`);
+  }
+
+  if (error.cause instanceof Error) {
+    parts.push(`Caused by: ${formatError(error.cause)}`);
+  }
+
+  return parts.join('\n');
+}
+
 interface DeployParams {
   context: WriteCommandContext;
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
@@ -627,7 +649,7 @@ export async function extendWarpRoute(
       newDeployedContracts = { ...newDeployedContracts, ...contracts };
     }
     for (const [chain, error] of rejected) {
-      errorRed(`Failed to deploy extension to ${chain}: ${error.message}`);
+      errorRed(`Failed to deploy extension to ${chain}: ${formatError(error)}`);
       allRejected.set(chain, error);
     }
   }
@@ -638,11 +660,10 @@ export async function extendWarpRoute(
       const contracts = await deployExtension(chain);
       newDeployedContracts = { ...newDeployedContracts, ...contracts };
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      errorRed(`Failed to deploy extension to ${chain}: ${message}`);
+      errorRed(`Failed to deploy extension to ${chain}: ${formatError(error)}`);
       allRejected.set(
         chain,
-        error instanceof Error ? error : new Error(message),
+        error instanceof Error ? error : new Error(String(error)),
       );
     }
   }

--- a/typescript/sdk/src/fee/EvmTokenFeeDeployer.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeDeployer.ts
@@ -236,10 +236,18 @@ export class EvmTokenFeeDeployer extends HyperlaneDeployer<
       for (const [routerKey, routerFeeConfig] of Object.entries(
         destinationConfig,
       )) {
-        const deployedFeeContract = await this.deployFee(
-          chain,
-          routerFeeConfig,
-        );
+        const deployedFeeContract =
+          routerFeeConfig.type === TokenFeeType.OffchainQuotedLinearFee
+            ? BaseFee__factory.connect(
+                (
+                  await this.deployOffchainQuotedLinearFee(
+                    chain,
+                    routerFeeConfig,
+                  )
+                ).address,
+                this.multiProvider.getSigner(chain),
+              )
+            : await this.deployFee(chain, routerFeeConfig);
         destinationDomains.push(
           this.multiProvider.getDomainId(destinationChain),
         );

--- a/typescript/sdk/src/fee/EvmTokenFeeDeployer.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeDeployer.ts
@@ -236,24 +236,16 @@ export class EvmTokenFeeDeployer extends HyperlaneDeployer<
       for (const [routerKey, routerFeeConfig] of Object.entries(
         destinationConfig,
       )) {
-        let deployedFeeContract: BaseFee;
-        if (routerFeeConfig.type === TokenFeeType.OffchainQuotedLinearFee) {
-          const deployed = await this.deployOffchainQuotedLinearFee(
-            chain,
-            routerFeeConfig,
-          );
-          deployedFeeContract = BaseFee__factory.connect(
-            deployed.address,
-            this.multiProvider.getSigner(chain),
-          );
-        } else {
-          deployedFeeContract = await this.deployFee(chain, routerFeeConfig);
-        }
+        const { address } =
+          routerFeeConfig.type === TokenFeeType.OffchainQuotedLinearFee
+            ? await this.deployOffchainQuotedLinearFee(chain, routerFeeConfig)
+            : await this.deployFee(chain, routerFeeConfig);
+
         destinationDomains.push(
           this.multiProvider.getDomainId(destinationChain),
         );
         routerKeys.push(routerKey);
-        feeAddresses.push(deployedFeeContract.address);
+        feeAddresses.push(address);
       }
     }
 

--- a/typescript/sdk/src/fee/EvmTokenFeeDeployer.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeDeployer.ts
@@ -236,18 +236,19 @@ export class EvmTokenFeeDeployer extends HyperlaneDeployer<
       for (const [routerKey, routerFeeConfig] of Object.entries(
         destinationConfig,
       )) {
-        const deployedFeeContract =
-          routerFeeConfig.type === TokenFeeType.OffchainQuotedLinearFee
-            ? BaseFee__factory.connect(
-                (
-                  await this.deployOffchainQuotedLinearFee(
-                    chain,
-                    routerFeeConfig,
-                  )
-                ).address,
-                this.multiProvider.getSigner(chain),
-              )
-            : await this.deployFee(chain, routerFeeConfig);
+        let deployedFeeContract: BaseFee;
+        if (routerFeeConfig.type === TokenFeeType.OffchainQuotedLinearFee) {
+          const deployed = await this.deployOffchainQuotedLinearFee(
+            chain,
+            routerFeeConfig,
+          );
+          deployedFeeContract = BaseFee__factory.connect(
+            deployed.address,
+            this.multiProvider.getSigner(chain),
+          );
+        } else {
+          deployedFeeContract = await this.deployFee(chain, routerFeeConfig);
+        }
         destinationDomains.push(
           this.multiProvider.getDomainId(destinationChain),
         );

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -765,10 +765,12 @@ export class WarpCore {
         sender,
       });
     }
+    const igpDenom = transferQuote.igpQuote.addressOrDenom;
     assert(
-      !transferQuote.igpQuote.addressOrDenom ||
-        isZeroishAddress(transferQuote.igpQuote.addressOrDenom),
-      `CrossCollateralRouter transferRemoteTo requires native IGP fee; got ${transferQuote.igpQuote.addressOrDenom}`,
+      !igpDenom ||
+        isZeroishAddress(igpDenom) ||
+        originToken.protocol === ProtocolType.Sealevel,
+      `CrossCollateralRouter transferRemoteTo requires native IGP fee; got ${igpDenom}`,
     );
     const tokenFeeAmount = transferQuote.tokenFeeQuote?.amount ?? 0n;
     const totalDebit = amount + tokenFeeAmount;

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -767,9 +767,7 @@ export class WarpCore {
     }
     const igpDenom = transferQuote.igpQuote.addressOrDenom;
     assert(
-      !igpDenom ||
-        isZeroishAddress(igpDenom) ||
-        originToken.protocol === ProtocolType.Sealevel,
+      !igpDenom || isZeroishAddress(igpDenom) || igpDenom === 'lamport',
       `CrossCollateralRouter transferRemoteTo requires native IGP fee; got ${igpDenom}`,
     );
     const tokenFeeAmount = transferQuote.tokenFeeQuote?.amount ?? 0n;

--- a/typescript/utils/src/index.ts
+++ b/typescript/utils/src/index.ts
@@ -193,6 +193,7 @@ export {
 } from './sets.js';
 export {
   errorToString,
+  formatError,
   fromHexString,
   sanitizeString,
   streamToString,

--- a/typescript/utils/src/strings.ts
+++ b/typescript/utils/src/strings.ts
@@ -47,6 +47,39 @@ export function errorToString(error: any, maxLength = 300) {
   return trimToLength(JSON.stringify(details), maxLength);
 }
 
+interface ErrorWithContext {
+  context?: { logs?: unknown };
+}
+
+function isErrorWithContext(e: unknown): e is Error & ErrorWithContext {
+  return e instanceof Error && 'context' in e;
+}
+
+/**
+ * Formats an error for display, including the cause chain and any Solana
+ * program logs attached to preflight failure errors.
+ */
+export function formatError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+
+  const parts: string[] = [error.message];
+
+  // SolanaError preflight failures attach { logs, unitsConsumed, ... } to context
+  if (
+    isErrorWithContext(error) &&
+    Array.isArray(error.context?.logs) &&
+    error.context.logs.length > 0
+  ) {
+    parts.push(`Logs:\n  ${error.context.logs.join('\n  ')}`);
+  }
+
+  if (error.cause instanceof Error) {
+    parts.push(`Caused by: ${formatError(error.cause)}`);
+  }
+
+  return parts.join('\n');
+}
+
 export const fromHexString = (hexstr: string) =>
   Buffer.from(strip0x(hexstr), 'hex');
 

--- a/typescript/utils/src/strings.ts
+++ b/typescript/utils/src/strings.ts
@@ -59,7 +59,7 @@ function isErrorWithContext(e: unknown): e is Error & ErrorWithContext {
  * Formats an error for display, including the cause chain and any Solana
  * program logs attached to preflight failure errors.
  */
-export function formatError(error: unknown): string {
+export function formatError(error: unknown, depth = 0): string {
   if (!(error instanceof Error)) return String(error);
 
   const parts: string[] = [error.message];
@@ -73,8 +73,8 @@ export function formatError(error: unknown): string {
     parts.push(`Logs:\n  ${error.context.logs.join('\n  ')}`);
   }
 
-  if (error.cause instanceof Error) {
-    parts.push(`Caused by: ${formatError(error.cause)}`);
+  if (error.cause != null && depth < 10) {
+    parts.push(`Caused by: ${formatError(error.cause, depth + 1)}`);
   }
 
   return parts.join('\n');


### PR DESCRIPTION
### Description

Three fixes found during the CROSS/moonpay warp route deployment and testing:

**1. `WarpCore`: sol_xo→* transfers blocked by IGP fee assertion (`WarpCore.ts`)**

`getCrossCollateralTransferTxs()` asserted that the IGP fee denom must be zero/empty (native fee). On Sealevel, the native fee denom is `'lamport'`, which is not a zero address, so the assertion always failed. Fixed by allowing the assertion to pass when the origin token is on Sealevel.

**2. `EvmTokenFeeDeployer`: `OffchainQuotedLinearFee` routed to wrong deploy path (`EvmTokenFeeDeployer.ts`)**

`deployFee()` didn't handle `OffchainQuotedLinearFee` type. The deployer was falling into the generic path instead of calling `deployOffchainQuotedLinearFee()`. Fixed with an explicit branch.

**3. `extendWarpRoute`: error messages dropped cause chain and Solana logs (`warp.ts`)**

Error formatting in `extendWarpRoute` only showed `error.message`, discarding the cause chain and Solana preflight logs attached to `error.context.logs`. Added a `formatError()` helper that recursively includes `error.cause` and Solana program logs.

### Backward compatibility

Yes

### Testing

Manual — all 56 directed transfers (8 tokens × 7 destinations) of the CROSS/moonpay warp route executed successfully on mainnet.