### PR TITLE
feat(infra): script to verify CROSS/moonpay Iron autoramps against the registry

### DIFF
--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -23,6 +23,7 @@
     "deploy-hook": "tsx scripts/deploy.ts -e test -m hook",
     "hardhat-esm": "NODE_OPTIONS='--import tsx/esm' hardhat --config hardhat.config.cts",
     "kathy": "pnpm tsx ./scripts/send-test-messages.ts",
+    "verify:iron-moonpay": "tsx scripts/iron/verify-moonpay-autoramps.ts",
     "format": "oxfmt --write ./src ./config ./scripts ./test",
     "test:warp": "mocha --config ../sdk/.mocharc.json test/warp-configs.test.ts",
     "test:gitleaks": "mocha --config ../sdk/.mocharc.json test/gitleaks.test.ts",

--- a/typescript/infra/scripts/iron/README.md
+++ b/typescript/infra/scripts/iron/README.md
@@ -29,10 +29,20 @@ The script exits 0 when every lane passes, exits 1 on any mismatch.
 
 ### Run
 
+`IRON_API_KEY` is loaded from `typescript/infra/.env` automatically
+(via `dotenv`), or read from the shell environment as a fallback.
+`.env*` is already gitignored under `typescript/infra/`.
+
 ```bash
-export IRON_API_KEY=<key>
 cd typescript/infra
+echo 'IRON_API_KEY=<your-iron-key>' > .env   # one-time setup
 pnpm verify:iron-moonpay
+```
+
+If you'd rather pass the key inline, that still works:
+
+```bash
+IRON_API_KEY=<your-iron-key> pnpm verify:iron-moonpay
 ```
 
 ### Flags

--- a/typescript/infra/scripts/iron/README.md
+++ b/typescript/infra/scripts/iron/README.md
@@ -37,11 +37,14 @@ pnpm verify:iron-moonpay
 
 ### Flags
 
-| Flag                         | Default                  | Notes                                                               |
-| ---------------------------- | ------------------------ | ------------------------------------------------------------------- |
-| `--autoramp-ids <id>,<id>,…` | discovered via Iron API  | Skip discovery; check a fixed set of UUIDs.                         |
-| `--warp-route-id`            | `USDC/moonpay`           | Registry warp route used as source of truth for routers.            |
-| `--ironbridge-route-id`      | `CROSS/ctusd-ironbridge` | Registry warp deploy used as source of truth for deposit addresses. |
+| Flag                    | Default                  | Notes                                                               |
+| ----------------------- | ------------------------ | ------------------------------------------------------------------- |
+| `--warp-route-id`       | `USDC/moonpay`           | Registry warp route used as source of truth for routers.            |
+| `--ironbridge-route-id` | `CROSS/ctusd-ironbridge` | Registry warp deploy used as source of truth for deposit addresses. |
+
+The set of MCR autoramp IDs is hardcoded in the script
+(`MOONPAY_MCR_AUTORAMP_IDS`); changing the set is a code change, not a
+CLI flag.
 
 ### Output
 

--- a/typescript/infra/scripts/iron/README.md
+++ b/typescript/infra/scripts/iron/README.md
@@ -5,25 +5,30 @@ registry's source-of-truth YAMLs.
 
 ## `verify-moonpay-autoramps.ts`
 
-Verifies the six MCR Iron autoramps for `CROSS/moonpay`
-(arb / base / ethereum USDC ↔ citrea ctUSD) against the registry.
+Verifies the eight MCR Iron autoramps for `CROSS/moonpay` against the
+registry — six for the USDC iron bridge (arb / base / ethereum USDC ↔
+citrea ctUSD) and two for the USDT iron bridge (ethereum USDT ↔ citrea
+ctUSD).
 
 Per autoramp, the script confirms:
 
 1. **Recipient is the right warp router.** Iron's `recipient.address`
-   equals the destination chain's router address in
-   `deployments/warp_routes/USDC/moonpay-config.yaml`.
+   equals the destination chain's router address in the relevant
+   moonpay config yaml (`USDC/moonpay` for USDC + citrea legs;
+   `USDT/moonpay` for the ethereum USDT leg).
 2. **Deposit address is the right TBA pre-image.** Iron's
    `deposit_account.address` equals the `depositAddress` declared for
-   that (origin, destination, recipient-router) tuple in
-   `deployments/warp_routes/CROSS/ctusd-ironbridge-deploy.yaml`.
+   that (origin, destination, recipient-router) tuple in the ironbridge
+   deploy yaml (`CROSS/ctusd-usdc-ironbridge` or
+   `CROSS/ctusd-usdt-ironbridge`).
 3. **Bytes32 router key matches the moonpay router** (sanity check on
    the destination encoding inside the ironbridge deploy doc).
 
-Both registry artifacts are read via `getRegistry()` from the local
+All registry artifacts are read via `getRegistry()` from the local
 checkout — no GitHub fetch, no on-chain RPC. The registry needs to be
-on a branch where both `USDC/moonpay` and `CROSS/ctusd-ironbridge` are
-present (e.g. `feat/moonpay-deployment`).
+on a branch where `USDC/moonpay`, `USDT/moonpay`,
+`CROSS/ctusd-usdc-ironbridge`, and `CROSS/ctusd-usdt-ironbridge` are
+all present.
 
 The script exits 0 when every lane passes, exits 1 on any mismatch.
 
@@ -47,14 +52,13 @@ IRON_API_KEY=<your-iron-key> pnpm verify:iron-moonpay
 
 ### Flags
 
-| Flag                    | Default                  | Notes                                                               |
-| ----------------------- | ------------------------ | ------------------------------------------------------------------- |
-| `--warp-route-id`       | `USDC/moonpay`           | Registry warp route used as source of truth for routers.            |
-| `--ironbridge-route-id` | `CROSS/ctusd-ironbridge` | Registry warp deploy used as source of truth for deposit addresses. |
+| Flag | Default | Notes |
+| ---- | ------- | ----- |
 
-The set of MCR autoramp IDs is hardcoded in the script
-(`MOONPAY_MCR_AUTORAMP_IDS`); changing the set is a code change, not a
-CLI flag.
+There are no CLI flags. Both the USDC and USDT iron bridge autoramp sets
+are verified unconditionally. The autoramp IDs are hardcoded in the script
+(`USDC_IRONBRIDGE_AUTORAMP_IDS`, `USDT_IRONBRIDGE_AUTORAMP_IDS`);
+adding new lanes is a code change.
 
 ### Output
 

--- a/typescript/infra/scripts/iron/README.md
+++ b/typescript/infra/scripts/iron/README.md
@@ -1,0 +1,53 @@
+# Iron autoramp verification
+
+Scripts that cross-check Iron autoramp configuration against the
+registry's source-of-truth YAMLs.
+
+## `verify-moonpay-autoramps.ts`
+
+Verifies the six MCR Iron autoramps for `CROSS/moonpay`
+(arb / base / ethereum USDC ↔ citrea ctUSD) against the registry.
+
+Per autoramp, the script confirms:
+
+1. **Recipient is the right warp router.** Iron's `recipient.address`
+   equals the destination chain's router address in
+   `deployments/warp_routes/USDC/moonpay-config.yaml`.
+2. **Deposit address is the right TBA pre-image.** Iron's
+   `deposit_account.address` equals the `depositAddress` declared for
+   that (origin, destination, recipient-router) tuple in
+   `deployments/warp_routes/CROSS/ctusd-ironbridge-deploy.yaml`.
+3. **Bytes32 router key matches the moonpay router** (sanity check on
+   the destination encoding inside the ironbridge deploy doc).
+
+Both registry artifacts are read via `getRegistry()` from the local
+checkout — no GitHub fetch, no on-chain RPC. The registry needs to be
+on a branch where both `USDC/moonpay` and `CROSS/ctusd-ironbridge` are
+present (e.g. `feat/moonpay-deployment`).
+
+The script exits 0 when every lane passes, exits 1 on any mismatch.
+
+### Run
+
+```bash
+export IRON_API_KEY=<key>
+cd typescript/infra
+pnpm verify:iron-moonpay
+```
+
+### Flags
+
+| Flag                         | Default                  | Notes                                                               |
+| ---------------------------- | ------------------------ | ------------------------------------------------------------------- |
+| `--autoramp-ids <id>,<id>,…` | discovered via Iron API  | Skip discovery; check a fixed set of UUIDs.                         |
+| `--warp-route-id`            | `USDC/moonpay`           | Registry warp route used as source of truth for routers.            |
+| `--ironbridge-route-id`      | `CROSS/ctusd-ironbridge` | Registry warp deploy used as source of truth for deposit addresses. |
+
+### Output
+
+Prints a per-autoramp PASS/FAIL table, plus an explicit failure reason
+list for any failing row, plus a summary line:
+
+```
+… passed, … failed
+```

--- a/typescript/infra/scripts/iron/verify-moonpay-autoramps.ts
+++ b/typescript/infra/scripts/iron/verify-moonpay-autoramps.ts
@@ -1,20 +1,20 @@
 /**
- * Verifies the six MCR Iron autoramps for `CROSS/moonpay` against the
- * registry. Per-lane checks:
+ * Verifies Iron autoramps for `CROSS/moonpay` (USDC + USDT iron bridges)
+ * against the registry. Per-lane checks:
  *
  *   A. iron.deposit_account.address
  *      == ctusd-ironbridge.<src>.destinationConfigs.<dst>.<routerKey>.depositAddress
  *   B. iron.recipient.address
  *      == decode(routerKey)        // bytes32 -> 20-byte EVM address
  *   C. iron.recipient.address
- *      == USDC/moonpay token where chainName=<dst>
+ *      == warp-route token where chainName=<dst>
  *
- * Source of truth:
- *   - `deployments/warp_routes/USDC/moonpay-config.yaml` (router addresses)
- *   - `deployments/warp_routes/CROSS/ctusd-ironbridge-deploy.yaml`
- *     (depositAddress + bytes32-encoded destination router keys)
- * Both read via `getRegistry()` from the local registry checkout —
- * `<monorepo>/../../hyperlane-registry`. No RPC, no GitHub fetch.
+ * USDC iron bridge (6 lanes): USDC/moonpay as router source of truth.
+ * USDT iron bridge (2 lanes): merges USDC/moonpay (citrea router) +
+ *   USDT/moonpay (ethereum router) as router source of truth.
+ *
+ * Source of truth files read via `getRegistry()` from the local registry
+ * checkout — `<monorepo>/../../hyperlane-registry`. No RPC, no GitHub fetch.
  *
  * Required env: IRON_API_KEY
  */
@@ -24,8 +24,6 @@
 // real environment when there's no `.env`.
 import 'dotenv/config';
 
-import yargs from 'yargs';
-
 import type { WarpCoreConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
 import { bytes32ToAddress, eqAddress } from '@hyperlane-xyz/utils';
 
@@ -33,22 +31,27 @@ import { getRegistry } from '../../config/registry.js';
 
 const IRON_API_BASE = 'https://api.iron.xyz/api';
 
-const DEFAULT_WARP_ROUTE_ID = 'USDC/moonpay';
-const DEFAULT_IRONBRIDGE_ROUTE_ID = 'CROSS/ctusd-ironbridge';
-
-// The six MCR autoramps for `CROSS/moonpay` (arb / base / ethereum USDC ↔
-// citrea ctUSD). Hardcoded rather than discovered via Iron's listing
-// endpoint so the script's expected scope is explicit + grepable.
+// The six MCR autoramps for the USDC iron bridge (arb / base / ethereum USDC ↔
+// citrea ctUSD). Hardcoded rather than discovered via Iron's listing endpoint
+// so the script's expected scope is explicit + grepable.
 // Inventory autoramps (sol XO ↔ EVM USDC) are intentionally NOT in this
 // list — they have a different recipient (operator inventory wallet, not
 // a warp router) and are out of scope for this verifier.
-const MOONPAY_MCR_AUTORAMP_IDS = [
+const USDC_IRONBRIDGE_AUTORAMP_IDS = [
   '019e02ea-d0b9-7967-8475-3249a4990204', // Mint   arbitrum USDC -> citrea ctUSD
   '019e02ec-6416-7331-bd86-f01bc4309770', // Mint   base USDC     -> citrea ctUSD
   '019e02ec-d5b3-771e-9318-c692c0047064', // Mint   ethereum USDC -> citrea ctUSD
   '019e02ed-a694-753f-b848-7f40da70e5fc', // Redeem citrea ctUSD  -> arbitrum USDC
   '019e02ee-60c3-72e2-a75a-70666c6224b3', // Redeem citrea ctUSD  -> base USDC
   '019e02ee-f696-78fe-9d79-6165e010fa09', // Redeem citrea ctUSD  -> ethereum USDC
+];
+
+// The two MCR autoramps for the USDT iron bridge (ethereum USDT ↔ citrea ctUSD).
+// Recipient for eth->citrea is the citrea router in USDC/moonpay; recipient for
+// citrea->eth is the ethereum router in USDT/moonpay.
+const USDT_IRONBRIDGE_AUTORAMP_IDS = [
+  '019e0749-766f-7149-b1ed-e3904b9e2bbe', // Mint   ethereum USDT -> citrea ctUSD
+  '019e0762-ea8e-72b3-a2ee-70eaa6faaa5f', // Redeem citrea ctUSD  -> ethereum USDT
 ];
 
 // Iron API → registry chain-name normalisation. Iron returns capitalised
@@ -104,23 +107,25 @@ interface RegistryArtifacts {
 }
 
 async function loadRegistryArtifacts(
-  warpRouteId: string,
+  warpRouteIds: string[],
   ironbridgeRouteId: string,
 ): Promise<RegistryArtifacts> {
   const registry = getRegistry();
-
-  const moonpay = (await registry.getWarpRoute(
-    warpRouteId,
-  )) as WarpCoreConfig | null;
-  if (!moonpay) {
-    throw new Error(
-      `Could not resolve warp route '${warpRouteId}' from registry at ${registry.getUri()}. ` +
-        `Make sure the registry checkout is on the moonpay branch.`,
-    );
-  }
   const moonpayRouterByChain = new Map<string, string>();
-  for (const token of moonpay.tokens) {
-    moonpayRouterByChain.set(token.chainName, token.addressOrDenom!);
+
+  for (const warpRouteId of warpRouteIds) {
+    const route = (await registry.getWarpRoute(
+      warpRouteId,
+    )) as WarpCoreConfig | null;
+    if (!route) {
+      throw new Error(
+        `Could not resolve warp route '${warpRouteId}' from registry at ${registry.getUri()}. ` +
+          `Make sure the registry checkout is on the moonpay branch.`,
+      );
+    }
+    for (const token of route.tokens) {
+      moonpayRouterByChain.set(token.chainName, token.addressOrDenom!);
+    }
   }
 
   const ironbridgeDeploy = (await registry.getWarpDeployConfig(
@@ -278,22 +283,6 @@ function printTable(rows: LaneCheck[]): void {
 }
 
 async function main(): Promise<void> {
-  const argv = await yargs(process.argv.slice(2))
-    .option('warp-route-id', {
-      type: 'string',
-      default: DEFAULT_WARP_ROUTE_ID,
-      describe:
-        'Registry warp route ID providing destination router addresses.',
-    })
-    .option('ironbridge-route-id', {
-      type: 'string',
-      default: DEFAULT_IRONBRIDGE_ROUTE_ID,
-      describe:
-        'Registry warp deploy ID providing TBA destinationConfigs (depositAddress + router keys).',
-    })
-    .strict()
-    .parseAsync();
-
   const ironApiKey = process.env.IRON_API_KEY;
   if (!ironApiKey) {
     console.error('IRON_API_KEY env var is required.');
@@ -302,21 +291,41 @@ async function main(): Promise<void> {
 
   // Load registry artifacts BEFORE hitting Iron — fails fast on a wrong
   // registry checkout / branch.
-  const artifacts = await loadRegistryArtifacts(
-    argv.warpRouteId,
-    argv.ironbridgeRouteId,
+  const usdcArtifacts = await loadRegistryArtifacts(
+    ['USDC/moonpay'],
+    'CROSS/ctusd-usdc-ironbridge',
+  );
+  // USDT iron bridge recipients span two routes: citrea router lives in
+  // USDC/moonpay; ethereum router lives in USDT/moonpay.
+  const usdtArtifacts = await loadRegistryArtifacts(
+    ['USDC/moonpay', 'USDT/moonpay'],
+    'CROSS/ctusd-usdt-ironbridge',
   );
 
   const checks: LaneCheck[] = [];
-  for (const id of MOONPAY_MCR_AUTORAMP_IDS) {
+
+  console.log('=== USDC iron bridge ===');
+  for (const id of USDC_IRONBRIDGE_AUTORAMP_IDS) {
     const autoramp = await ironRequest<IronAutoramp>(
       `/autoramps/${id}`,
       ironApiKey,
     );
-    checks.push(verifyLane(autoramp, artifacts));
+    checks.push(verifyLane(autoramp, usdcArtifacts));
   }
+  printTable(checks.slice(0, USDC_IRONBRIDGE_AUTORAMP_IDS.length));
 
-  printTable(checks);
+  console.log('');
+  console.log('=== USDT iron bridge ===');
+  const usdtChecks: LaneCheck[] = [];
+  for (const id of USDT_IRONBRIDGE_AUTORAMP_IDS) {
+    const autoramp = await ironRequest<IronAutoramp>(
+      `/autoramps/${id}`,
+      ironApiKey,
+    );
+    usdtChecks.push(verifyLane(autoramp, usdtArtifacts));
+  }
+  checks.push(...usdtChecks);
+  printTable(usdtChecks);
 
   const failed = checks.filter((c) => c.failures.length > 0);
   if (failed.length > 0) {

--- a/typescript/infra/scripts/iron/verify-moonpay-autoramps.ts
+++ b/typescript/infra/scripts/iron/verify-moonpay-autoramps.ts
@@ -22,6 +22,7 @@
 import yargs from 'yargs';
 
 import type { WarpCoreConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
+import { bytes32ToAddress, eqAddress } from '@hyperlane-xyz/utils';
 
 import { getRegistry } from '../../config/registry.js';
 
@@ -29,6 +30,21 @@ const IRON_API_BASE = 'https://api.iron.xyz/api';
 
 const DEFAULT_WARP_ROUTE_ID = 'USDC/moonpay';
 const DEFAULT_IRONBRIDGE_ROUTE_ID = 'CROSS/ctusd-ironbridge';
+
+// The six MCR autoramps for `CROSS/moonpay` (arb / base / ethereum USDC ↔
+// citrea ctUSD). Hardcoded rather than discovered via Iron's listing
+// endpoint so the script's expected scope is explicit + grepable.
+// Inventory autoramps (sol XO ↔ EVM USDC) are intentionally NOT in this
+// list — they have a different recipient (operator inventory wallet, not
+// a warp router) and are out of scope for this verifier.
+const MOONPAY_MCR_AUTORAMP_IDS = [
+  '019e02ea-d0b9-7967-8475-3249a4990204', // Mint   arbitrum USDC -> citrea ctUSD
+  '019e02ec-6416-7331-bd86-f01bc4309770', // Mint   base USDC     -> citrea ctUSD
+  '019e02ec-d5b3-771e-9318-c692c0047064', // Mint   ethereum USDC -> citrea ctUSD
+  '019e02ed-a694-753f-b848-7f40da70e5fc', // Redeem citrea ctUSD  -> arbitrum USDC
+  '019e02ee-60c3-72e2-a75a-70666c6224b3', // Redeem citrea ctUSD  -> base USDC
+  '019e02ee-f696-78fe-9d79-6165e010fa09', // Redeem citrea ctUSD  -> ethereum USDC
+];
 
 // Iron API → registry chain-name normalisation. Iron returns capitalised
 // names on `deposit_account.chain` / `recipient.blockchain`; the registry
@@ -49,11 +65,6 @@ interface IronAutoramp {
   recipient: { address: string; blockchain: string };
 }
 
-interface IronAutorampListResponse {
-  cursor?: string;
-  items: IronAutoramp[];
-}
-
 interface LaneCheck {
   autorampId: string;
   name: string;
@@ -69,22 +80,6 @@ interface LaneCheck {
   failures: string[];
 }
 
-const eqHex = (a: string, b: string): boolean =>
-  a.toLowerCase() === b.toLowerCase();
-
-/** Decode a 32-byte hex value to a 20-byte EVM address (the bytes32 used
- *  as a key in `destinationConfigs.<dst>` is the destination router
- *  pointer, padded with leading zeros). */
-function bytes32ToAddress(bytes32: string): string {
-  const hex = bytes32.startsWith('0x') ? bytes32.slice(2) : bytes32;
-  if (hex.length !== 64) {
-    throw new Error(
-      `Expected 32-byte hex (64 chars), got ${hex.length}: ${bytes32}`,
-    );
-  }
-  return `0x${hex.slice(24)}`;
-}
-
 async function ironRequest<T>(path: string, apiKey: string): Promise<T> {
   const res = await fetch(`${IRON_API_BASE}${path}`, {
     headers: { 'X-API-Key': apiKey },
@@ -94,37 +89,6 @@ async function ironRequest<T>(path: string, apiKey: string): Promise<T> {
     throw new Error(`Iron API ${path} failed: HTTP ${res.status} ${body}`);
   }
   return (await res.json()) as T;
-}
-
-/** Discover MCR moonpay autoramps via API, paginating until exhausted.
- *  Filters by `name` containing 'CROSS/moonpay' and excluding 'Inventory'
- *  (those are the sol-XO inventory autoramps, out of scope). */
-async function discoverMoonpayMcrAutorampIds(
-  apiKey: string,
-): Promise<string[]> {
-  const ids: string[] = [];
-  const seen = new Set<string>();
-  let cursor: string | undefined;
-  while (true) {
-    const qs = cursor
-      ? `/autoramps?limit=100&cursor=${encodeURIComponent(cursor)}`
-      : '/autoramps?limit=100';
-    const page = await ironRequest<IronAutorampListResponse>(qs, apiKey);
-    for (const a of page.items ?? []) {
-      const name = a.name ?? '';
-      if (
-        name.includes('CROSS/moonpay') &&
-        !name.includes('Inventory') &&
-        !seen.has(a.id)
-      ) {
-        ids.push(a.id);
-        seen.add(a.id);
-      }
-    }
-    if (!page.cursor || page.cursor === cursor) break;
-    cursor = page.cursor;
-  }
-  return ids;
 }
 
 interface RegistryArtifacts {
@@ -242,14 +206,17 @@ function verifyLane(
     );
   } else {
     expectedDepositAddress = lane.depositAddress;
-    depositMatch = eqHex(autoramp.deposit_account.address, lane.depositAddress);
+    depositMatch = eqAddress(
+      autoramp.deposit_account.address,
+      lane.depositAddress,
+    );
     if (!depositMatch) {
       failures.push(
         `deposit address mismatch: iron=${autoramp.deposit_account.address} ironbridge=${lane.depositAddress}`,
       );
     }
     if (moonpayRouter) {
-      routerKeyMatch = eqHex(lane.routerFromKey, moonpayRouter);
+      routerKeyMatch = eqAddress(lane.routerFromKey, moonpayRouter);
       if (!routerKeyMatch) {
         failures.push(
           `router key in ironbridge bytes32 (${lane.routerFromKey}) does not match moonpay router for ${destination} (${moonpayRouter})`,
@@ -262,7 +229,7 @@ function verifyLane(
     failures.push(`No moonpay router for destination chain ${destination}`);
   } else {
     expectedRecipientAddress = moonpayRouter;
-    recipientMatch = eqHex(autoramp.recipient.address, moonpayRouter);
+    recipientMatch = eqAddress(autoramp.recipient.address, moonpayRouter);
     if (!recipientMatch) {
       failures.push(
         `recipient mismatch: iron=${autoramp.recipient.address} moonpay-router=${moonpayRouter}`,
@@ -307,11 +274,6 @@ function printTable(rows: LaneCheck[]): void {
 
 async function main(): Promise<void> {
   const argv = await yargs(process.argv.slice(2))
-    .option('autoramp-ids', {
-      type: 'string',
-      describe:
-        'Comma-separated list of Iron autoramp UUIDs. Skip discovery via Iron API.',
-    })
     .option('warp-route-id', {
       type: 'string',
       default: DEFAULT_WARP_ROUTE_ID,
@@ -340,22 +302,8 @@ async function main(): Promise<void> {
     argv.ironbridgeRouteId,
   );
 
-  const autorampIds = argv.autorampIds
-    ? argv.autorampIds
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean)
-    : await discoverMoonpayMcrAutorampIds(ironApiKey);
-
-  if (autorampIds.length === 0) {
-    console.error(
-      'No moonpay MCR autoramps found via Iron API. Pass --autoramp-ids explicitly if discovery filter missed them.',
-    );
-    process.exit(2);
-  }
-
   const checks: LaneCheck[] = [];
-  for (const id of autorampIds) {
+  for (const id of MOONPAY_MCR_AUTORAMP_IDS) {
     const autoramp = await ironRequest<IronAutoramp>(
       `/autoramps/${id}`,
       ironApiKey,

--- a/typescript/infra/scripts/iron/verify-moonpay-autoramps.ts
+++ b/typescript/infra/scripts/iron/verify-moonpay-autoramps.ts
@@ -19,6 +19,11 @@
  * Required env: IRON_API_KEY
  */
 
+// Load `IRON_API_KEY` (and any other env) from `typescript/infra/.env`
+// when present. The file is gitignored. Falls back silently to the
+// real environment when there's no `.env`.
+import 'dotenv/config';
+
 import yargs from 'yargs';
 
 import type { WarpCoreConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';

--- a/typescript/infra/scripts/iron/verify-moonpay-autoramps.ts
+++ b/typescript/infra/scripts/iron/verify-moonpay-autoramps.ts
@@ -1,0 +1,388 @@
+/**
+ * Verifies the six MCR Iron autoramps for `CROSS/moonpay` against the
+ * registry. Per-lane checks:
+ *
+ *   A. iron.deposit_account.address
+ *      == ctusd-ironbridge.<src>.destinationConfigs.<dst>.<routerKey>.depositAddress
+ *   B. iron.recipient.address
+ *      == decode(routerKey)        // bytes32 -> 20-byte EVM address
+ *   C. iron.recipient.address
+ *      == USDC/moonpay token where chainName=<dst>
+ *
+ * Source of truth:
+ *   - `deployments/warp_routes/USDC/moonpay-config.yaml` (router addresses)
+ *   - `deployments/warp_routes/CROSS/ctusd-ironbridge-deploy.yaml`
+ *     (depositAddress + bytes32-encoded destination router keys)
+ * Both read via `getRegistry()` from the local registry checkout —
+ * `<monorepo>/../../hyperlane-registry`. No RPC, no GitHub fetch.
+ *
+ * Required env: IRON_API_KEY
+ */
+
+import yargs from 'yargs';
+
+import type { WarpCoreConfig, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
+
+import { getRegistry } from '../../config/registry.js';
+
+const IRON_API_BASE = 'https://api.iron.xyz/api';
+
+const DEFAULT_WARP_ROUTE_ID = 'USDC/moonpay';
+const DEFAULT_IRONBRIDGE_ROUTE_ID = 'CROSS/ctusd-ironbridge';
+
+// Iron API → registry chain-name normalisation. Iron returns capitalised
+// names on `deposit_account.chain` / `recipient.blockchain`; the registry
+// keys configs by lowercase chain name.
+const IRON_CHAIN_TO_REGISTRY: Record<string, string> = {
+  Arbitrum: 'arbitrum',
+  Base: 'base',
+  Ethereum: 'ethereum',
+  Citrea: 'citrea',
+};
+
+interface IronAutoramp {
+  id: string;
+  name: string;
+  kind: 'Mint' | 'Redeem';
+  status: string;
+  deposit_account: { address: string; chain: string };
+  recipient: { address: string; blockchain: string };
+}
+
+interface IronAutorampListResponse {
+  cursor?: string;
+  items: IronAutoramp[];
+}
+
+interface LaneCheck {
+  autorampId: string;
+  name: string;
+  origin: string;
+  destination: string;
+  ironDepositAddress: string;
+  ironRecipientAddress: string;
+  expectedDepositAddress?: string;
+  expectedRecipientAddress?: string;
+  depositMatch: boolean;
+  recipientMatch: boolean;
+  routerKeyMatch: boolean;
+  failures: string[];
+}
+
+const eqHex = (a: string, b: string): boolean =>
+  a.toLowerCase() === b.toLowerCase();
+
+/** Decode a 32-byte hex value to a 20-byte EVM address (the bytes32 used
+ *  as a key in `destinationConfigs.<dst>` is the destination router
+ *  pointer, padded with leading zeros). */
+function bytes32ToAddress(bytes32: string): string {
+  const hex = bytes32.startsWith('0x') ? bytes32.slice(2) : bytes32;
+  if (hex.length !== 64) {
+    throw new Error(
+      `Expected 32-byte hex (64 chars), got ${hex.length}: ${bytes32}`,
+    );
+  }
+  return `0x${hex.slice(24)}`;
+}
+
+async function ironRequest<T>(path: string, apiKey: string): Promise<T> {
+  const res = await fetch(`${IRON_API_BASE}${path}`, {
+    headers: { 'X-API-Key': apiKey },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Iron API ${path} failed: HTTP ${res.status} ${body}`);
+  }
+  return (await res.json()) as T;
+}
+
+/** Discover MCR moonpay autoramps via API, paginating until exhausted.
+ *  Filters by `name` containing 'CROSS/moonpay' and excluding 'Inventory'
+ *  (those are the sol-XO inventory autoramps, out of scope). */
+async function discoverMoonpayMcrAutorampIds(
+  apiKey: string,
+): Promise<string[]> {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  let cursor: string | undefined;
+  while (true) {
+    const qs = cursor
+      ? `/autoramps?limit=100&cursor=${encodeURIComponent(cursor)}`
+      : '/autoramps?limit=100';
+    const page = await ironRequest<IronAutorampListResponse>(qs, apiKey);
+    for (const a of page.items ?? []) {
+      const name = a.name ?? '';
+      if (
+        name.includes('CROSS/moonpay') &&
+        !name.includes('Inventory') &&
+        !seen.has(a.id)
+      ) {
+        ids.push(a.id);
+        seen.add(a.id);
+      }
+    }
+    if (!page.cursor || page.cursor === cursor) break;
+    cursor = page.cursor;
+  }
+  return ids;
+}
+
+interface RegistryArtifacts {
+  /** chainName -> warp router (addressOrDenom from moonpay-config.yaml) */
+  moonpayRouterByChain: Map<string, string>;
+  /** ironbridge deploy doc, indexed by origin chain */
+  ironbridgeDeploy: WarpRouteDeployConfig;
+}
+
+async function loadRegistryArtifacts(
+  warpRouteId: string,
+  ironbridgeRouteId: string,
+): Promise<RegistryArtifacts> {
+  const registry = getRegistry();
+
+  const moonpay = (await registry.getWarpRoute(
+    warpRouteId,
+  )) as WarpCoreConfig | null;
+  if (!moonpay) {
+    throw new Error(
+      `Could not resolve warp route '${warpRouteId}' from registry at ${registry.getUri()}. ` +
+        `Make sure the registry checkout is on the moonpay branch.`,
+    );
+  }
+  const moonpayRouterByChain = new Map<string, string>();
+  for (const token of moonpay.tokens) {
+    moonpayRouterByChain.set(token.chainName, token.addressOrDenom!);
+  }
+
+  const ironbridgeDeploy = (await registry.getWarpDeployConfig(
+    ironbridgeRouteId,
+  )) as WarpRouteDeployConfig | null;
+  if (!ironbridgeDeploy) {
+    throw new Error(
+      `Could not resolve deploy config '${ironbridgeRouteId}' from registry at ${registry.getUri()}. ` +
+        `Expected file: deployments/warp_routes/${ironbridgeRouteId}-deploy.yaml`,
+    );
+  }
+
+  return { moonpayRouterByChain, ironbridgeDeploy };
+}
+
+/** Look up the (depositAddress, decoded-router) pair for a given (origin,
+ *  destination) lane in the ironbridge deploy doc. Returns undefined if
+ *  the lane isn't configured. */
+function lookupLane(
+  ironbridgeDeploy: WarpRouteDeployConfig,
+  origin: string,
+  destination: string,
+): { depositAddress: string; routerFromKey: string } | undefined {
+  const originCfg = (ironbridgeDeploy as Record<string, unknown>)[origin] as
+    | {
+        destinationConfigs?: Record<
+          string,
+          Record<string, { depositAddress: string }>
+        >;
+      }
+    | undefined;
+  const destMap = originCfg?.destinationConfigs?.[destination];
+  if (!destMap) return undefined;
+  const entries = Object.entries(destMap);
+  if (entries.length === 0) return undefined;
+  if (entries.length > 1) {
+    throw new Error(
+      `Multiple destination router keys configured for ${origin}->${destination}; ` +
+        `this script assumes one router per lane (got ${entries.length}).`,
+    );
+  }
+  const [routerKey, { depositAddress }] = entries[0];
+  return { depositAddress, routerFromKey: bytes32ToAddress(routerKey) };
+}
+
+function verifyLane(
+  autoramp: IronAutoramp,
+  artifacts: RegistryArtifacts,
+): LaneCheck {
+  const failures: string[] = [];
+
+  const ironOriginChain = autoramp.deposit_account.chain;
+  const ironDestChain = autoramp.recipient.blockchain;
+
+  const origin = IRON_CHAIN_TO_REGISTRY[ironOriginChain];
+  const destination = IRON_CHAIN_TO_REGISTRY[ironDestChain];
+
+  if (!origin || !destination) {
+    failures.push(
+      `Unrecognised chain on autoramp: deposit=${ironOriginChain} recipient=${ironDestChain}`,
+    );
+    return {
+      autorampId: autoramp.id,
+      name: autoramp.name,
+      origin: ironOriginChain,
+      destination: ironDestChain,
+      ironDepositAddress: autoramp.deposit_account.address,
+      ironRecipientAddress: autoramp.recipient.address,
+      depositMatch: false,
+      recipientMatch: false,
+      routerKeyMatch: false,
+      failures,
+    };
+  }
+
+  const lane = lookupLane(artifacts.ironbridgeDeploy, origin, destination);
+  const moonpayRouter = artifacts.moonpayRouterByChain.get(destination);
+
+  let expectedDepositAddress: string | undefined;
+  let expectedRecipientAddress: string | undefined;
+  let depositMatch = false;
+  let recipientMatch = false;
+  let routerKeyMatch = false;
+
+  if (!lane) {
+    failures.push(
+      `No ironbridge config for lane ${origin}->${destination} (deploy doc missing destinationConfigs entry)`,
+    );
+  } else {
+    expectedDepositAddress = lane.depositAddress;
+    depositMatch = eqHex(autoramp.deposit_account.address, lane.depositAddress);
+    if (!depositMatch) {
+      failures.push(
+        `deposit address mismatch: iron=${autoramp.deposit_account.address} ironbridge=${lane.depositAddress}`,
+      );
+    }
+    if (moonpayRouter) {
+      routerKeyMatch = eqHex(lane.routerFromKey, moonpayRouter);
+      if (!routerKeyMatch) {
+        failures.push(
+          `router key in ironbridge bytes32 (${lane.routerFromKey}) does not match moonpay router for ${destination} (${moonpayRouter})`,
+        );
+      }
+    }
+  }
+
+  if (!moonpayRouter) {
+    failures.push(`No moonpay router for destination chain ${destination}`);
+  } else {
+    expectedRecipientAddress = moonpayRouter;
+    recipientMatch = eqHex(autoramp.recipient.address, moonpayRouter);
+    if (!recipientMatch) {
+      failures.push(
+        `recipient mismatch: iron=${autoramp.recipient.address} moonpay-router=${moonpayRouter}`,
+      );
+    }
+  }
+
+  return {
+    autorampId: autoramp.id,
+    name: autoramp.name,
+    origin,
+    destination,
+    ironDepositAddress: autoramp.deposit_account.address,
+    ironRecipientAddress: autoramp.recipient.address,
+    expectedDepositAddress,
+    expectedRecipientAddress,
+    depositMatch,
+    recipientMatch,
+    routerKeyMatch,
+    failures,
+  };
+}
+
+function printTable(rows: LaneCheck[]): void {
+  const headers = ['Autoramp', 'Lane', 'deposit', 'recipient', 'router-key'];
+  const data = rows.map((r) => [
+    r.name.length > 60 ? `${r.name.slice(0, 57)}...` : r.name,
+    `${r.origin} → ${r.destination}`,
+    r.depositMatch ? 'PASS' : 'FAIL',
+    r.recipientMatch ? 'PASS' : 'FAIL',
+    r.routerKeyMatch ? 'PASS' : 'FAIL',
+  ]);
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...data.map((row) => row[i].length)),
+  );
+  const fmt = (cells: string[]) =>
+    cells.map((c, i) => c.padEnd(widths[i])).join('  ');
+  console.log(fmt(headers));
+  console.log(widths.map((w) => '-'.repeat(w)).join('  '));
+  for (const row of data) console.log(fmt(row));
+}
+
+async function main(): Promise<void> {
+  const argv = await yargs(process.argv.slice(2))
+    .option('autoramp-ids', {
+      type: 'string',
+      describe:
+        'Comma-separated list of Iron autoramp UUIDs. Skip discovery via Iron API.',
+    })
+    .option('warp-route-id', {
+      type: 'string',
+      default: DEFAULT_WARP_ROUTE_ID,
+      describe:
+        'Registry warp route ID providing destination router addresses.',
+    })
+    .option('ironbridge-route-id', {
+      type: 'string',
+      default: DEFAULT_IRONBRIDGE_ROUTE_ID,
+      describe:
+        'Registry warp deploy ID providing TBA destinationConfigs (depositAddress + router keys).',
+    })
+    .strict()
+    .parseAsync();
+
+  const ironApiKey = process.env.IRON_API_KEY;
+  if (!ironApiKey) {
+    console.error('IRON_API_KEY env var is required.');
+    process.exit(2);
+  }
+
+  // Load registry artifacts BEFORE hitting Iron — fails fast on a wrong
+  // registry checkout / branch.
+  const artifacts = await loadRegistryArtifacts(
+    argv.warpRouteId,
+    argv.ironbridgeRouteId,
+  );
+
+  const autorampIds = argv.autorampIds
+    ? argv.autorampIds
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : await discoverMoonpayMcrAutorampIds(ironApiKey);
+
+  if (autorampIds.length === 0) {
+    console.error(
+      'No moonpay MCR autoramps found via Iron API. Pass --autoramp-ids explicitly if discovery filter missed them.',
+    );
+    process.exit(2);
+  }
+
+  const checks: LaneCheck[] = [];
+  for (const id of autorampIds) {
+    const autoramp = await ironRequest<IronAutoramp>(
+      `/autoramps/${id}`,
+      ironApiKey,
+    );
+    checks.push(verifyLane(autoramp, artifacts));
+  }
+
+  printTable(checks);
+
+  const failed = checks.filter((c) => c.failures.length > 0);
+  if (failed.length > 0) {
+    console.error('');
+    for (const c of failed) {
+      console.error(`FAIL ${c.autorampId} (${c.origin} → ${c.destination}):`);
+      for (const f of c.failures) console.error(`  - ${f}`);
+    }
+  }
+
+  console.log('');
+  console.log(
+    `${checks.length - failed.length} passed, ${failed.length} failed`,
+  );
+  process.exit(failed.length === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('Error:', err instanceof Error ? err.message : err);
+  if (err instanceof Error && err.stack) console.error(err.stack);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Adds `pnpm verify:iron-moonpay` (`typescript/infra/scripts/iron/verify-moonpay-autoramps.ts`) — a registry-only cross-check of the six MCR Iron autoramps for `CROSS/moonpay` (arb / base / ethereum USDC ↔ citrea ctUSD).

Per autoramp it confirms:

- Iron's `recipient.address` equals the destination chain's router in `deployments/warp_routes/USDC/moonpay-config.yaml`.
- Iron's `deposit_account.address` equals the `depositAddress` declared for that (origin, destination, recipient-router) tuple in `deployments/warp_routes/CROSS/ctusd-ironbridge-deploy.yaml`.
- The bytes32 router key inside the ironbridge deploy doc decodes to the same moonpay router address.

Both registry artifacts are read via `getRegistry()` from the local `<monorepo>/../../hyperlane-registry` checkout — no GitHub fetch, no on-chain RPC. Replaces the manual cross-check Haggis ran in [the deploy thread](https://hyperlaneworkspace.slack.com/archives/C097MB9LR6U/p1778160137271799).

`IRON_API_KEY` is the only required env var. The script discovers the six MCR autoramps via the Iron API by name (`CROSS/moonpay … !Inventory`) or accepts a fixed set via `--autoramp-ids`. Mismatches print a FAIL row + specific reason and exit 1; full pass exits 0; missing env exits 2.

Depends on registry PR hyperlane-xyz/hyperlane-registry#1520 (`feat/moonpay-deployment`) being checked out locally for the script to find both warp configs.

## Test plan

- [x] Happy path against `feat/moonpay-deployment` registry checkout — 6/6 PASS, exit 0.
- [x] Negative test (flip a `depositAddress` byte in `ctusd-ironbridge-deploy.yaml`) — affected lane reports FAIL with the specific reason, summary `5 passed, 1 failed`, exit 1.
- [x] Missing `IRON_API_KEY` — clean error message, exit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)