### PR TITLE
feat: whitelist moonpay route for fastpath relayer

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -42,7 +42,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
   relayer: '668b2ee-20260430-135346',
   relayerRC: '668b2ee-20260430-135346',
-  relayerFastPath: '668b2ee-20260430-135346',
+  relayerFastPath: 'becede9-20260507-130623',
   validator: '7eb690c-20260406-142107',
   validatorRC: '7eb690c-20260406-142107',
   scraper: 'caa8162-20260409-132508',

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -1058,6 +1058,21 @@ const fastPathUsdtMatchingList = chainMapMatchingList({
   ethereum: '0xd4463cB3c90b3F49c673310BEC9bC18311134B47',
 });
 
+// CROSS Moonpay USDC - https://github.com/hyperlane-xyz/hyperlane-registry/blob/main/deployments/warp_routes/CROSS/moonpay-config.yaml
+const fastPathCrossMoonpayUsdcMatchingList = chainMapMatchingList({
+  arbitrum: '0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0',
+  base: '0x253821543C24623ecD3ceBCEd704359AF16CF38f',
+  citrea: '0x2bef59e84615371304bd731601f6344F5F304504',
+  ethereum: '0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F',
+});
+
+// CROSS Moonpay USDT - https://github.com/hyperlane-xyz/hyperlane-registry/blob/main/deployments/warp_routes/CROSS/moonpay-config.yaml
+const fastPathCrossMoonpayUsdtMatchingList = chainMapMatchingList({
+  arbitrum: '0x75a9297db5F0349fd1d6f4030953Fe17175e06d4',
+  base: '0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96',
+  ethereum: '0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3',
+});
+
 const fastPath: RootAgentConfig = {
   ...contextBase,
   context: Contexts.FastPath,
@@ -1073,7 +1088,12 @@ const fastPath: RootAgentConfig = {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.relayerFastPath,
     },
-    whitelist: [...fastPathUsdcMatchingList, ...fastPathUsdtMatchingList],
+    whitelist: [
+      ...fastPathUsdcMatchingList,
+      ...fastPathUsdtMatchingList,
+      ...fastPathCrossMoonpayUsdcMatchingList,
+      ...fastPathCrossMoonpayUsdtMatchingList,
+    ],
     blacklist,
     gasPaymentEnforcement,
     reorgPeriodOverrides: { ethereum: 1 },

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -31,6 +31,7 @@ import {
   consistentSenderRecipientMatchingList,
   icaMatchingList,
   matchingList,
+  multiAddressChainMapMatchingList,
   routerMatchingList,
   senderMatchingList,
   warpRouteMatchingList,
@@ -1058,19 +1059,25 @@ const fastPathUsdtMatchingList = chainMapMatchingList({
   ethereum: '0xd4463cB3c90b3F49c673310BEC9bC18311134B47',
 });
 
-// CROSS Moonpay USDC - https://github.com/hyperlane-xyz/hyperlane-registry/blob/main/deployments/warp_routes/CROSS/moonpay-config.yaml
-const fastPathCrossMoonpayUsdcMatchingList = chainMapMatchingList({
-  arbitrum: '0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0',
-  base: '0x253821543C24623ecD3ceBCEd704359AF16CF38f',
-  citrea: '0x2bef59e84615371304bd731601f6344F5F304504',
-  ethereum: '0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F',
-});
-
-// CROSS Moonpay USDT - https://github.com/hyperlane-xyz/hyperlane-registry/blob/main/deployments/warp_routes/CROSS/moonpay-config.yaml
-const fastPathCrossMoonpayUsdtMatchingList = chainMapMatchingList({
-  arbitrum: '0x75a9297db5F0349fd1d6f4030953Fe17175e06d4',
-  base: '0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96',
-  ethereum: '0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3',
+// CROSS Moonpay - https://github.com/hyperlane-xyz/hyperlane-registry/blob/main/deployments/warp_routes/CROSS/moonpay-config.yaml
+// Single route with mixed underlying token types (USDC/USDT per chain), so both addresses per chain
+// must be in the same matching list to cover cross-type transfers (e.g. ethereum USDC → arbitrum USDT).
+const fastPathCrossMoonpayMatchingList = multiAddressChainMapMatchingList({
+  arbitrum: [
+    '0xeBC079D41C41a0ef7e54aa7Af867df9a621C9bE0', // USDC
+    '0x75a9297db5F0349fd1d6f4030953Fe17175e06d4', // USDT
+  ],
+  base: [
+    '0x253821543C24623ecD3ceBCEd704359AF16CF38f', // USDC
+    '0x7abBb4ea8a5895127500CF0C15830C9Eb9f61F96', // USDT
+  ],
+  citrea: [
+    '0x2bef59e84615371304bd731601f6344F5F304504', // USDC
+  ],
+  ethereum: [
+    '0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F', // USDC
+    '0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3', // USDT
+  ],
 });
 
 const fastPath: RootAgentConfig = {
@@ -1091,8 +1098,7 @@ const fastPath: RootAgentConfig = {
     whitelist: [
       ...fastPathUsdcMatchingList,
       ...fastPathUsdtMatchingList,
-      ...fastPathCrossMoonpayUsdcMatchingList,
-      ...fastPathCrossMoonpayUsdtMatchingList,
+      ...fastPathCrossMoonpayMatchingList,
     ],
     blacklist,
     gasPaymentEnforcement,

--- a/typescript/infra/src/config/agent/relayer.test.ts
+++ b/typescript/infra/src/config/agent/relayer.test.ts
@@ -2,7 +2,69 @@ import { expect } from 'chai';
 
 import { addressToBytes32 } from '@hyperlane-xyz/utils';
 
-import { IcaMessageType, icaMatchingList } from './relayer.js';
+import {
+  IcaMessageType,
+  icaMatchingList,
+  multiAddressChainMapMatchingList,
+} from './relayer.js';
+
+describe('multiAddressChainMapMatchingList', () => {
+  const addrA = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const addrB = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const addrC = '0xcccccccccccccccccccccccccccccccccccccccc';
+
+  it('expands all (source, destination) pairs, skipping self-pairs', () => {
+    const result = multiAddressChainMapMatchingList({
+      ethereum: [addrA],
+      optimism: [addrC],
+      base: [addrB],
+    });
+    // 3 chains → 3*2 = 6 entries
+    expect(result).to.have.lengthOf(6);
+    result.forEach((entry) =>
+      expect(entry.originDomain).to.not.equal(entry.destinationDomain),
+    );
+  });
+
+  it('sets senderAddress and recipientAddress as bytes32 arrays for the correct chains', () => {
+    const result = multiAddressChainMapMatchingList({
+      ethereum: [addrA, addrB], // domain 1
+      optimism: [addrC], // domain 10
+    });
+    expect(result).to.have.lengthOf(2);
+
+    const ethToOp = result.find(
+      (e) => e.originDomain === 1 && e.destinationDomain === 10,
+    );
+    expect(ethToOp).to.exist;
+    expect(ethToOp!.senderAddress).to.deep.equal(
+      [addrA, addrB].map((a) => addressToBytes32(a)),
+    );
+    expect(ethToOp!.recipientAddress).to.deep.equal([addressToBytes32(addrC)]);
+
+    const opToEth = result.find(
+      (e) => e.originDomain === 10 && e.destinationDomain === 1,
+    );
+    expect(opToEth).to.exist;
+    expect(opToEth!.senderAddress).to.deep.equal([addressToBytes32(addrC)]);
+    expect(opToEth!.recipientAddress).to.deep.equal(
+      [addrA, addrB].map((a) => addressToBytes32(a)),
+    );
+  });
+
+  it('deduplicates addresses within a chain', () => {
+    const result = multiAddressChainMapMatchingList({
+      ethereum: [addrA, addrA, addrB],
+      optimism: [addrC],
+    });
+    const ethToOp = result.find(
+      (e) => e.originDomain === 1 && e.destinationDomain === 10,
+    );
+    expect(ethToOp!.senderAddress).to.deep.equal(
+      [addrA, addrB].map((a) => addressToBytes32(a)),
+    );
+  });
+});
 
 describe('icaMatchingList', () => {
   // Velodrome Universal Router owner used in mainnet config

--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -6,7 +6,6 @@ import {
   AgentConfig,
   ChainMap,
   GasPaymentEnforcement,
-  HyperlaneAddresses,
   HyperlaneAddressesMap,
   HyperlaneFactories,
   IsmCacheConfig,
@@ -383,11 +382,9 @@ export function consistentSenderRecipientMatchingList(
 export function chainMapMatchingList(
   chainMap: ChainMap<Address>,
 ): MatchingList {
-  // Convert to a router matching list
-  const routers = objMap(chainMap, (chain, address) => ({
-    router: address,
-  }));
-  return routerMatchingList(routers);
+  return multiAddressChainMapMatchingList(
+    objMap(chainMap, (_chain, address) => [address]),
+  );
 }
 
 // Create a matching list for chains that have multiple addresses (e.g. mixed token types in one warp route).
@@ -403,12 +400,12 @@ export function multiAddressChainMapMatchingList(
       if (source === destination) continue;
       list.push({
         originDomain: getDomainId(source),
-        senderAddress: chainAddresses[source].map((addr) =>
+        senderAddress: Array.from(new Set(chainAddresses[source])).map((addr) =>
           addressToBytes32(addr),
         ),
         destinationDomain: getDomainId(destination),
-        recipientAddress: chainAddresses[destination].map((addr) =>
-          addressToBytes32(addr),
+        recipientAddress: Array.from(new Set(chainAddresses[destination])).map(
+          (addr) => addressToBytes32(addr),
         ),
       });
     }
@@ -421,32 +418,11 @@ export function multiAddressChainMapMatchingList(
 export function matchingList<F extends HyperlaneFactories>(
   addressesMap: HyperlaneAddressesMap<F>,
 ): MatchingList {
-  const chains = Object.keys(addressesMap);
-
-  // matching list must have at least one element so bypass and check before returning
-  const matchingList: MatchingList = [];
-
-  for (const source of chains) {
-    for (const destination of chains) {
-      if (source === destination) {
-        continue;
-      }
-
-      const uniqueAddresses = (addresses: HyperlaneAddresses<F>) =>
-        Array.from(new Set(Object.values(addresses)).values()).map((s) =>
-          addressToBytes32(s),
-        );
-
-      matchingList.push({
-        originDomain: getDomainId(source),
-        senderAddress: uniqueAddresses(addressesMap[source]),
-        destinationDomain: getDomainId(destination),
-        recipientAddress: uniqueAddresses(addressesMap[destination]),
-      });
-    }
-  }
-
-  return matchingList;
+  return multiAddressChainMapMatchingList(
+    objMap(addressesMap, (_chain, addresses) =>
+      Array.from(new Set<string>(Object.values(addresses))),
+    ),
+  );
 }
 
 /**

--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -390,6 +390,33 @@ export function chainMapMatchingList(
   return routerMatchingList(routers);
 }
 
+// Create a matching list for chains that have multiple addresses (e.g. mixed token types in one warp route).
+// Generates entries for all (source, destination) pairs where sender/recipient arrays include all addresses for that chain.
+export function multiAddressChainMapMatchingList(
+  chainAddresses: ChainMap<Address[]>,
+): MatchingList {
+  const chains = Object.keys(chainAddresses);
+  const list: MatchingList = [];
+
+  for (const source of chains) {
+    for (const destination of chains) {
+      if (source === destination) continue;
+      list.push({
+        originDomain: getDomainId(source),
+        senderAddress: chainAddresses[source].map((addr) =>
+          addressToBytes32(addr),
+        ),
+        destinationDomain: getDomainId(destination),
+        recipientAddress: chainAddresses[destination].map((addr) =>
+          addressToBytes32(addr),
+        ),
+      });
+    }
+  }
+
+  return list;
+}
+
 // Create a matching list for the given contract addresses
 export function matchingList<F extends HyperlaneFactories>(
   addressesMap: HyperlaneAddressesMap<F>,


### PR DESCRIPTION
### Description

Adds the new moonpay route to the fastpath relayer's whitelist

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
