### PR TITLE
fix(infra): apply custom_rpc_header to set-rpc-urls health check

### DIFF
--- a/.changeset/lukso-rpc-headers-export.md
+++ b/.changeset/lukso-rpc-headers-export.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+The `parseCustomRpcHeaders` utility is now exported from the SDK barrel so consumers outside `SmartProvider` can apply the `custom_rpc_header` URL convention to their own RPC clients.

--- a/typescript/infra/src/utils/rpcUrls.ts
+++ b/typescript/infra/src/utils/rpcUrls.ts
@@ -3,7 +3,7 @@ import { Separator, checkbox, confirm } from '@inquirer/prompts';
 import select from '@inquirer/select';
 import { ethers } from 'ethers';
 
-import { ChainName } from '@hyperlane-xyz/sdk';
+import { ChainName, parseCustomRpcHeaders } from '@hyperlane-xyz/sdk';
 import { assert, isEVMLike, timeout } from '@hyperlane-xyz/utils';
 
 import { getChain } from '../../config/registry.js';
@@ -819,7 +819,10 @@ async function testProvider(chain: ChainName, url: string): Promise<boolean> {
     return true;
   }
 
-  const provider = new ethers.providers.StaticJsonRpcProvider(url);
+  const { url: cleanUrl, headers } = parseCustomRpcHeaders(url);
+  const provider = new ethers.providers.StaticJsonRpcProvider(
+    Object.keys(headers).length > 0 ? { url: cleanUrl, headers } : cleanUrl,
+  );
   const expectedChainId = chainMetadata.chainId;
 
   try {

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -520,6 +520,7 @@ export {
   ProviderRetryOptions,
   SmartProviderOptions,
 } from './providers/SmartProvider/types.js';
+export { parseCustomRpcHeaders } from './utils/provider.js';
 export { CallData, CallDataSchema } from './providers/transactions/types.js';
 export {
   randomAddress,


### PR DESCRIPTION
## Summary

- `testProvider` in `set-rpc-urls.ts` instantiated `ethers.providers.StaticJsonRpcProvider(url)` directly, bypassing the `custom_rpc_header=Name:Value` query-string convention that `SmartProvider` (TS) and the Rust agents already strip into real HTTP headers.
- Result: any RPC URL that requires bearer auth via the `custom_rpc_header` convention failed the health check (e.g. Lukso archive: 403 → "could not detect network"), even though it would work fine at agent runtime.
- Fix: route the URL through `parseCustomRpcHeaders` in `testProvider` and pass `{ url, headers }` to ethers when headers are present. Also exports `parseCustomRpcHeaders` from the SDK barrel.

## Test plan

- [ ] `pnpm tsx scripts/secret-rpc-urls/set-rpc-urls.ts -e mainnet3 -c lukso` with a `custom_rpc_header=Authorization:Bearer%20<token>` URL passes the health check
- [ ] Plain URLs (no `custom_rpc_header`) still work unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to RPC URL validation to pass optional HTTP headers through to ethers, plus a barrel export; behavior is unchanged for plain URLs.
> 
> **Overview**
> Fixes the RPC URL health check in `typescript/infra` to honor the `custom_rpc_header=Name:Value` query-string convention by parsing headers via `parseCustomRpcHeaders` and passing `{ url, headers }` into `ethers.providers.StaticJsonRpcProvider` when present.
> 
> Also exports `parseCustomRpcHeaders` from the `@hyperlane-xyz/sdk` barrel (with a changeset bump) so non-`SmartProvider` consumers can apply the same URL-to-headers convention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13ad3646dbd07d083cc882b0f223bf1382a53ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->