### PR TITLE
fix: return approved tokens for bridges

### DIFF
--- a/.changeset/cuddly-sheep-battle.md
+++ b/.changeset/cuddly-sheep-battle.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Return approved tokens for bridges

--- a/.changeset/cuddly-sheep-battle.md
+++ b/.changeset/cuddly-sheep-battle.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/sdk": patch
 ---
 
-Return approved tokens for bridges
+Returned approved tokens for bridges

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -300,9 +300,31 @@ export class EvmWarpRouteReader extends EvmRouterReader {
           ),
         );
 
+        const collateralTokenAddress =
+          'token' in tokenConfig ? tokenConfig.token : undefined;
+
         allowedRebalancingBridges = objFilter(
-          objMap(allowedBridgesByDomain, (_domain, bridges) =>
-            bridges.map((bridge) => ({ bridge })),
+          await promiseObjAll(
+            objMap(allowedBridgesByDomain, async (_domain, bridges) =>
+              Promise.all(
+                bridges.map(async (bridge) => {
+                  if (!collateralTokenAddress) {
+                    return { bridge };
+                  }
+                  const erc20 = HypERC20__factory.connect(
+                    collateralTokenAddress,
+                    this.provider,
+                  );
+                  const allowance = await erc20.allowance(
+                    warpRouteAddress,
+                    bridge,
+                  );
+                  return allowance.eq(constants.MaxUint256)
+                    ? { bridge, approvedTokens: [collateralTokenAddress] }
+                    : { bridge };
+                }),
+              ),
+            ),
           ),
           // Remove domains that do not have allowed bridges
           (_domain, bridges): bridges is any => bridges.length !== 0,


### PR DESCRIPTION
### Description

This PR fixes the warp reader by returning the approved tokens for bridges, fixing the false positive diffs in the warp route checker

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

Manual warp read testing on moonpay routes
