### PR TITLE
fix: warp check deposit address

### DIFF
--- a/.changeset/shy-islands-walk.md
+++ b/.changeset/shy-islands-walk.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed warp check for collateralDepositAddress routes

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -53,6 +53,7 @@ import {
   WarpRouteDeployConfigMailboxRequired,
   isCollateralTokenConfig,
   isCrossCollateralTokenConfig,
+  isDepositAddressTokenConfig,
   isMovableCollateralTokenConfig,
   isNativeTokenConfig,
   isOftTokenConfig,
@@ -423,6 +424,16 @@ export function normalizeWarpDeployConfigForCheck(params: {
   const { multiProvider, warpDeployConfig } = params;
 
   return objMap(warpDeployConfig, (_chain, config) => {
+    if (isDepositAddressTokenConfig(config)) {
+      return {
+        ...config,
+        mailbox: constants.AddressZero,
+        interchainSecurityModule: constants.AddressZero,
+        remoteRouters: {},
+        destinationGas: undefined,
+      };
+    }
+
     if (!isOftTokenConfig(config)) {
       return config;
     }


### PR DESCRIPTION
### Description

Fix warp check for collateral deposit address routes

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

Manual warp check tests with moonpay ironbridge routes
