### PR TITLE
fix: warp check cross collateral

### DIFF
--- a/.changeset/olive-boxes-flash.md
+++ b/.changeset/olive-boxes-flash.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/cli": patch
+---
+
+Added warp check support for cross collateral routes

--- a/.changeset/olive-boxes-flash.md
+++ b/.changeset/olive-boxes-flash.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/cli": patch
 ---
 
-Added warp check support for cross collateral routes
+Added warp check support for cross-collateral routes

--- a/typescript/cli/src/check/warp.test.ts
+++ b/typescript/cli/src/check/warp.test.ts
@@ -1,0 +1,182 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { TokenStandard, type WarpCoreConfig } from '@hyperlane-xyz/sdk';
+
+import { checkCrossCollateralWarpRoute } from './warp.js';
+
+function buildCrossCollateralToken({
+  chainName,
+  symbol,
+  address,
+  decimals,
+}: {
+  chainName: string;
+  symbol: string;
+  address: string;
+  decimals: number;
+}) {
+  return {
+    chainName,
+    standard: TokenStandard.EvmHypCrossCollateralRouter,
+    decimals,
+    symbol,
+    name: symbol,
+    addressOrDenom: address,
+    collateralAddressOrDenom: address,
+  };
+}
+
+const ROUTER_A = '0x1111111111111111111111111111111111111111';
+const ROUTER_B = '0x2222222222222222222222222222222222222222';
+const ROUTER_UNRELATED = '0x9999999999999999999999999999999999999999';
+
+const CROSS_CORE_CONFIG: WarpCoreConfig = {
+  tokens: [
+    buildCrossCollateralToken({
+      chainName: 'anvil2',
+      symbol: 'USDC',
+      address: ROUTER_A,
+      decimals: 6,
+    }),
+    buildCrossCollateralToken({
+      chainName: 'anvil3',
+      symbol: 'USDT',
+      address: ROUTER_B,
+      decimals: 6,
+    }),
+  ],
+};
+
+function buildContext(
+  allRoutes: Record<string, { coreConfig: WarpCoreConfig; deployConfig: any }>,
+) {
+  const getWarpRoutes = sinon
+    .stub()
+    .resolves(
+      Object.fromEntries(
+        Object.entries(allRoutes).map(([id, r]) => [id, r.coreConfig]),
+      ),
+    );
+  const getWarpDeployConfig = sinon.stub();
+  const getChainAddresses = sinon.stub().resolves({ mailbox: ROUTER_A });
+
+  for (const [id, route] of Object.entries(allRoutes)) {
+    getWarpDeployConfig.withArgs(id).resolves(route.deployConfig);
+  }
+
+  return {
+    context: {
+      registry: { getWarpRoutes, getWarpDeployConfig, getChainAddresses },
+      multiProvider: {
+        getDomainId: () => 31337,
+        getProtocol: () => 'ethereum',
+      },
+    } as any,
+  };
+}
+
+describe('checkCrossCollateralWarpRoute', () => {
+  afterEach(() => sinon.restore());
+
+  it('throws when no constituent routes match the CROSS token addresses', async () => {
+    const { context } = buildContext({
+      'UNRELATED/route': {
+        coreConfig: {
+          tokens: [
+            buildCrossCollateralToken({
+              chainName: 'anvil2',
+              symbol: 'WETH',
+              address: ROUTER_UNRELATED,
+              decimals: 18,
+            }),
+          ],
+        },
+        deployConfig: { anvil2: {} },
+      },
+    });
+
+    let thrown: Error | undefined;
+    try {
+      await checkCrossCollateralWarpRoute({
+        context,
+        warpCoreConfig: CROSS_CORE_CONFIG,
+        warpRouteId: 'CROSS/test',
+      });
+    } catch (e) {
+      thrown = e as Error;
+    }
+
+    expect(thrown?.message).to.include(
+      'no constituent routes could be identified',
+    );
+  });
+
+  it('surfaces an error when a matched constituent has no deploy config', async () => {
+    const { context } = buildContext({
+      'USDC/test': {
+        coreConfig: {
+          tokens: [
+            buildCrossCollateralToken({
+              chainName: 'anvil2',
+              symbol: 'USDC',
+              address: ROUTER_A,
+              decimals: 6,
+            }),
+          ],
+        },
+        deployConfig: null, // missing
+      },
+    });
+
+    let thrown: Error | undefined;
+    try {
+      await checkCrossCollateralWarpRoute({
+        context,
+        warpCoreConfig: CROSS_CORE_CONFIG,
+        warpRouteId: 'CROSS/test',
+      });
+    } catch (e) {
+      thrown = e as Error;
+    }
+
+    expect(thrown).to.exist;
+    expect(thrown?.message).to.include('No warp route deploy config found');
+  });
+
+  it('excludes non-CrossCollateralRouter routes even if their addresses overlap', async () => {
+    const { context } = buildContext({
+      'USDC/test': {
+        coreConfig: {
+          tokens: [
+            {
+              chainName: 'anvil2',
+              standard: TokenStandard.EvmHypCollateral, // not a CrossCollateral standard
+              decimals: 6,
+              symbol: 'USDC',
+              name: 'USDC',
+              addressOrDenom: ROUTER_A,
+              collateralAddressOrDenom: ROUTER_A,
+            },
+          ],
+        },
+        deployConfig: { anvil2: {} },
+      },
+    });
+
+    let thrown: Error | undefined;
+    try {
+      await checkCrossCollateralWarpRoute({
+        context,
+        warpCoreConfig: CROSS_CORE_CONFIG,
+        warpRouteId: 'CROSS/test',
+      });
+    } catch (e) {
+      thrown = e as Error;
+    }
+
+    expect(thrown?.message).to.include(
+      'no constituent routes could be identified',
+    );
+  });
+});

--- a/typescript/cli/src/check/warp.ts
+++ b/typescript/cli/src/check/warp.ts
@@ -3,8 +3,10 @@ import { stringify as yamlStringify } from 'yaml';
 import {
   type AccountConfig,
   InterchainAccount,
+  type WarpCoreConfig,
   type WarpRouteCheckResult,
   type WarpRouteDeployConfigMailboxRequired,
+  checkWarpRouteDeployConfig,
 } from '@hyperlane-xyz/sdk';
 import {
   type ObjectDiff,
@@ -15,6 +17,7 @@ import {
   normalizeAddressEvm,
 } from '@hyperlane-xyz/utils';
 
+import { readWarpRouteDeployConfig } from '../config/warp.js';
 import { type CommandContext } from '../context/types.js';
 import { log, logGreen, logRed, warnYellow } from '../logger.js';
 import { formatYamlViolationsOutput } from '../utils/output.js';
@@ -130,4 +133,80 @@ export async function runWarpIcaOwnerCheck({
   }
 
   logGreen('No violations found');
+}
+
+/**
+ * Checks a combined CROSS warp route by finding its constituent routes (those whose
+ * tokens are a subset of the CROSS config's tokens) and checking each one separately.
+ * Used when a CROSS route has no deploy config of its own.
+ */
+export async function checkCrossCollateralWarpRoute({
+  context,
+  warpCoreConfig,
+  warpRouteId,
+}: {
+  context: CommandContext;
+  warpCoreConfig: WarpCoreConfig;
+  warpRouteId: string;
+}): Promise<WarpRouteCheckResult> {
+  const crossAddresses = new Set(
+    warpCoreConfig.tokens
+      .filter((t) => t.addressOrDenom)
+      .map((t) => t.addressOrDenom!.toLowerCase()),
+  );
+
+  const allRoutes = await context.registry.getWarpRoutes();
+  const constituentRouteIds: string[] = [];
+
+  for (const [routeId, routeCoreConfig] of Object.entries(allRoutes)) {
+    if (routeId === warpRouteId) continue;
+    if (routeCoreConfig.tokens.length === 0) continue;
+
+    if (
+      routeCoreConfig.tokens.every(
+        (t) =>
+          t.addressOrDenom &&
+          crossAddresses.has(t.addressOrDenom.toLowerCase()),
+      )
+    ) {
+      constituentRouteIds.push(routeId);
+    }
+  }
+
+  assert(
+    constituentRouteIds.length > 0,
+    `No deploy config found for "${warpRouteId}" and no constituent routes could be identified. ` +
+      `Ensure constituent routes have deploy configs in the registry.`,
+  );
+
+  const combinedResult: WarpRouteCheckResult = {
+    isValid: true,
+    violations: [],
+    diff: {},
+    scaleViolations: [],
+  };
+
+  for (const constituentId of constituentRouteIds) {
+    const constituentCoreConfig = allRoutes[constituentId];
+    const constituentDeployConfig = await readWarpRouteDeployConfig({
+      context,
+      warpRouteId: constituentId,
+    });
+
+    const result = await checkWarpRouteDeployConfig({
+      multiProvider: context.multiProvider,
+      warpCoreConfig: constituentCoreConfig,
+      warpDeployConfig: constituentDeployConfig,
+    });
+
+    combinedResult.isValid = combinedResult.isValid && result.isValid;
+    combinedResult.violations.push(...result.violations);
+    combinedResult.scaleViolations.push(...result.scaleViolations);
+
+    for (const [chain, diff] of Object.entries(result.diff)) {
+      combinedResult.diff[`${constituentId}/${chain}`] = diff;
+    }
+  }
+
+  return combinedResult;
 }

--- a/typescript/cli/src/check/warp.ts
+++ b/typescript/cli/src/check/warp.ts
@@ -3,6 +3,7 @@ import { stringify as yamlStringify } from 'yaml';
 import {
   type AccountConfig,
   InterchainAccount,
+  TOKEN_CROSS_COLLATERAL_STANDARDS,
   type WarpCoreConfig,
   type WarpRouteCheckResult,
   type WarpRouteDeployConfigMailboxRequired,
@@ -166,7 +167,9 @@ export async function checkCrossCollateralWarpRoute({
       routeCoreConfig.tokens.every(
         (t) =>
           t.addressOrDenom &&
-          crossAddresses.has(t.addressOrDenom.toLowerCase()),
+          crossAddresses.has(t.addressOrDenom.toLowerCase()) &&
+          t.standard &&
+          TOKEN_CROSS_COLLATERAL_STANDARDS.has(t.standard),
       )
     ) {
       constituentRouteIds.push(routeId);

--- a/typescript/cli/src/check/warp.ts
+++ b/typescript/cli/src/check/warp.ts
@@ -150,9 +150,9 @@ export async function checkCrossCollateralWarpRoute({
   warpRouteId: string;
 }): Promise<WarpRouteCheckResult> {
   const crossAddresses = new Set(
-    warpCoreConfig.tokens
-      .filter((t) => t.addressOrDenom)
-      .map((t) => t.addressOrDenom!.toLowerCase()),
+    warpCoreConfig.tokens.flatMap((t) =>
+      t.addressOrDenom ? [t.addressOrDenom.toLowerCase()] : [],
+    ),
   );
 
   const allRoutes = await context.registry.getWarpRoutes();

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -593,10 +593,14 @@ export const check: CommandModuleWithContext<
         !ica,
         'Cannot perform ICA owner check for combined CROSS routes (no deploy config)',
       );
+      assert(
+        context.resolvedWarpRouteId,
+        'resolvedWarpRouteId must be set for CROSS routes',
+      );
       const result = await checkCrossCollateralWarpRoute({
         context,
         warpCoreConfig: context.warpCoreConfig,
-        warpRouteId: context.resolvedWarpRouteId!,
+        warpRouteId: context.resolvedWarpRouteId,
       });
       await runWarpRouteCheck({ result });
       process.exit(0);

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -16,7 +16,11 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
-import { runWarpIcaOwnerCheck, runWarpRouteCheck } from '../check/warp.js';
+import {
+  checkCrossCollateralWarpRoute,
+  runWarpIcaOwnerCheck,
+  runWarpRouteCheck,
+} from '../check/warp.js';
 import { createWarpRouteDeployConfig } from '../config/warp.js';
 import {
   type CommandContext,
@@ -581,6 +585,22 @@ export const check: CommandModuleWithContext<
     chains,
   }) => {
     logCommandHeader('Hyperlane Warp Check');
+
+    // CROSS route case: resolver set warpCoreConfig but not warpDeployConfig
+    // (combined CROSS routes have no deploy config of their own)
+    if (context.warpCoreConfig && !context.warpDeployConfig) {
+      assert(
+        !ica,
+        'Cannot perform ICA owner check for combined CROSS routes (no deploy config)',
+      );
+      const result = await checkCrossCollateralWarpRoute({
+        context,
+        warpCoreConfig: context.warpCoreConfig,
+        warpRouteId: context.resolvedWarpRouteId!,
+      });
+      await runWarpRouteCheck({ result });
+      process.exit(0);
+    }
 
     let { warpCoreConfig, warpDeployConfig } =
       await getWarpConfigsFromContextOrRegistry({

--- a/typescript/cli/src/context/strategies/chain/chainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/chainResolver.ts
@@ -8,6 +8,7 @@ import {
   DeployedCoreAddressesSchema,
   EvmCoreModule,
   TxSubmitterType,
+  WarpCoreConfigSchema,
 } from '@hyperlane-xyz/sdk';
 import { ProtocolType, assert, isEVMLike } from '@hyperlane-xyz/utils';
 
@@ -25,6 +26,7 @@ import {
   getWarpConfigs,
   getWarpRouteDeployConfig,
   getWarpCoreConfigOrExit,
+  resolveWarpRouteId,
 } from '../../../utils/warp.js';
 import { requestAndSaveApiKeys } from '../../apiKeys.js';
 
@@ -52,8 +54,9 @@ export async function resolveChains(
     case CommandType.WARP_READ:
       return resolveWarpReadChains(argv);
     case CommandType.WARP_APPLY:
-    case CommandType.WARP_CHECK:
       return resolveWarpConfigChains(argv);
+    case CommandType.WARP_CHECK:
+      return resolveWarpCheckChains(argv);
     case CommandType.WARP_REBALANCER:
       return resolveWarpRebalancerChains(argv);
 
@@ -140,6 +143,40 @@ async function resolveWarpConfigChains(
     'No chains found in warp route deployment config',
   );
   return argv.context.chains;
+}
+
+async function resolveWarpCheckChains(
+  argv: Record<string, any>,
+): Promise<ChainName[]> {
+  const context = argv.context;
+  const resolvedId = await resolveWarpRouteId({
+    context,
+    warpRouteId: argv.warpRouteId,
+  });
+
+  const rawDeployConfig =
+    await context.registry.getWarpDeployConfig(resolvedId);
+  if (!rawDeployConfig) {
+    // CROSS route: no deploy config, get chains from core config
+    const warpCoreConfigRaw = await context.registry.getWarpRoute(resolvedId);
+    assert(warpCoreConfigRaw, `No warp route config found for "${resolvedId}"`);
+
+    const warpCoreConfig = WarpCoreConfigSchema.parse(warpCoreConfigRaw);
+    const uniqueChains = [
+      ...new Set(warpCoreConfig.tokens.map((t) => t.chainName)),
+    ];
+    assert(
+      uniqueChains.length > 0,
+      `No chains found for warp route "${resolvedId}"`,
+    );
+
+    context.warpCoreConfig = warpCoreConfig;
+    context.resolvedWarpRouteId = resolvedId;
+    context.chains = uniqueChains;
+    return uniqueChains;
+  }
+
+  return resolveWarpConfigChains(argv);
 }
 
 async function resolveWarpSendChains(


### PR DESCRIPTION
### Description

Adds warp check support for cross collateral routes. Because they are combined from multiple routes and has no own deploy yaml we have to "rebuild" it and can then start comparing

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

Tested with CROSS/moonpay route
