### PR TITLE
fix: handle uninitialized Aleo mappings in relayer contract sync

### DIFF
--- a/rust/main/chains/hyperlane-aleo/src/indexer/delivery.rs
+++ b/rust/main/chains/hyperlane-aleo/src/indexer/delivery.rs
@@ -122,10 +122,14 @@ impl<C: AleoClient> Indexer<H256> for AleoDeliveryIndexer<C> {
 impl<C: AleoClient> SequenceAwareIndexer<H256> for AleoDeliveryIndexer<C> {
     /// Return the latest finalized sequence (if any) and block number
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        let (mailbox, height) = self
+        let tip = AleoIndexer::get_finalized_block_number(self).await?;
+        let Some((mailbox, height)) = self
             .provider
             .get_mapping_value_meta::<AleoMailboxStruct>(&self.program, "mailbox", "true")
-            .await?;
+            .await?
+        else {
+            return Ok((None, tip));
+        };
         Ok((Some(mailbox.process_count), height))
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/indexer/dispatch.rs
+++ b/rust/main/chains/hyperlane-aleo/src/indexer/dispatch.rs
@@ -102,10 +102,14 @@ impl<C: AleoClient> Indexer<HyperlaneMessage> for AleoDispatchIndexer<C> {
 impl<C: AleoClient> SequenceAwareIndexer<HyperlaneMessage> for AleoDispatchIndexer<C> {
     /// Return the latest finalized sequence (if any) and block number
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        let (mailbox, height) = self
+        let tip = AleoIndexer::get_finalized_block_number(self).await?;
+        let Some((mailbox, height)) = self
             .provider
             .get_mapping_value_meta::<AleoMailboxStruct>(&self.program, "mailbox", "true")
-            .await?;
+            .await?
+        else {
+            return Ok((None, tip));
+        };
         Ok((Some(mailbox.nonce), height))
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/indexer/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-aleo/src/indexer/interchain_gas.rs
@@ -130,14 +130,18 @@ impl<C: AleoClient> Indexer<InterchainGasPayment> for AleoInterchainGasIndexer<C
 impl<C: AleoClient> SequenceAwareIndexer<InterchainGasPayment> for AleoInterchainGasIndexer<C> {
     /// Return the latest finalized sequence (if any) and block number
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        let (igp, height) = self
+        let tip = AleoIndexer::get_finalized_block_number(self).await?;
+        let Some((igp, height)) = self
             .client
             .get_mapping_value_meta::<AleoInterchainGasPaymaster>(
                 &self.program,
                 "igps",
                 &self.aleo_address.to_string(),
             )
-            .await?;
+            .await?
+        else {
+            return Ok((None, tip));
+        };
         Ok((Some(igp.count), height))
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/indexer/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-aleo/src/indexer/merkle_tree_hook.rs
@@ -129,14 +129,18 @@ impl<C: AleoClient> Indexer<MerkleTreeInsertion> for AleoMerkleTreeHook<C> {
 impl<C: AleoClient> SequenceAwareIndexer<MerkleTreeInsertion> for AleoMerkleTreeHook<C> {
     /// Return the latest finalized sequence (if any) and block number
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        let (mth, height) = self
+        let tip = AleoIndexer::get_finalized_block_number(self).await?;
+        let Some((mth, height)) = self
             .client
             .get_mapping_value_meta::<AleoMerkleTreeHookStruct>(
                 &self.program,
                 "merkle_tree_hooks",
                 &self.aleo_address.to_string(),
             )
-            .await?;
+            .await?
+        else {
+            return Ok((None, tip));
+        };
         Ok((Some(mth.tree.count), height))
     }
 }
@@ -147,14 +151,20 @@ impl<C: AleoClient> MerkleTreeHook for AleoMerkleTreeHook<C> {
     ///
     /// - `reorg_period` is ignored as Aleo has a BFT consensus algorithm with instant finality.
     async fn tree(&self, _reorg_period: &ReorgPeriod) -> ChainResult<IncrementalMerkleAtBlock> {
-        let (mth, block_height) = self
+        let Some((mth, block_height)) = self
             .client
             .get_mapping_value_meta::<AleoMerkleTreeHookStruct>(
                 &self.program,
                 "merkle_tree_hooks",
                 &self.aleo_address.to_string(),
             )
-            .await?;
+            .await?
+        else {
+            return Ok(IncrementalMerkleAtBlock {
+                tree: Default::default(),
+                block_height: None,
+            });
+        };
         Ok(IncrementalMerkleAtBlock {
             tree: mth.tree.into(),
             block_height: Some(block_height.into()),
@@ -182,14 +192,25 @@ impl<C: AleoClient> MerkleTreeHook for AleoMerkleTreeHook<C> {
         &self,
         _reorg_period: &ReorgPeriod,
     ) -> ChainResult<CheckpointAtBlock> {
-        let (mth, block_height) = self
+        let Some((mth, block_height)) = self
             .client
             .get_mapping_value_meta::<AleoMerkleTreeHookStruct>(
                 &self.program,
                 "merkle_tree_hooks",
                 &self.aleo_address.to_string(),
             )
-            .await?;
+            .await?
+        else {
+            return Ok(CheckpointAtBlock {
+                checkpoint: Checkpoint {
+                    merkle_tree_hook_address: self.address,
+                    mailbox_domain: self.domain.id(),
+                    root: H256::zero(),
+                    index: 0,
+                },
+                block_height: None,
+            });
+        };
         Ok(CheckpointAtBlock {
             checkpoint: Checkpoint {
                 merkle_tree_hook_address: self.address,

--- a/rust/main/chains/hyperlane-aleo/src/provider/traits.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/traits.rs
@@ -67,7 +67,7 @@ pub struct RpcClient<Client: HttpClient>(Client);
 
 #[derive(serde::Deserialize)]
 struct MappingValueWithMeta {
-    data: Plaintext<CurrentNetwork>,
+    data: Option<Plaintext<CurrentNetwork>>,
     height: u32,
 }
 
@@ -209,16 +209,20 @@ impl<Client: HttpClient> RpcClient<Client> {
         program_id: &str,
         mapping_name: &str,
         mapping_key: &str,
-    ) -> ChainResult<(T, u32)> {
+    ) -> ChainResult<Option<(T, u32)>> {
         let response: MappingValueWithMeta = self
             .request(
                 &format!("program/{program_id}/mapping/{mapping_name}/{mapping_key}"),
                 Some(serde_json::json!({ "metadata": true })),
             )
             .await?;
-        let plain_text = response.data;
-        let result = T::parse_value(plain_text).map_err(HyperlaneAleoError::from)?;
-        Ok((result, response.height))
+        match response.data {
+            None => Ok(None),
+            Some(plain_text) => {
+                let result = T::parse_value(plain_text).map_err(HyperlaneAleoError::from)?;
+                Ok(Some((result, response.height)))
+            }
+        }
     }
 
     /// Gets a transaction by ID


### PR DESCRIPTION
### Description

The Aleo node returns \`{"data": null, "height": N}\` for mappings that have not been written to yet (e.g. a freshly deployed mailbox or IGP before any messages are processed). The relayer was deserializing \`data\` as a non-optional \`Plaintext\`, causing a crash with \`invalid type: null, expected a string\` on startup.

Changes:
- **\`provider/traits.rs\`** — Made \`MappingValueWithMeta.data\` optional (\`Option<Plaintext>\`) and changed \`get_mapping_value_meta\` to return \`ChainResult<Option<(T, u32)>>\`.
- **All four indexers** (\`dispatch\`, \`delivery\`, \`interchain_gas\`, \`merkle_tree_hook\`) — Updated \`latest_sequence_count_and_tip\` to handle the \`None\` case by returning \`(None, tip)\` instead of crashing, where \`tip\` is the current finalized block number.
- **\`merkle_tree_hook\`** — Also updated \`tree()\` and \`latest_checkpoint()\` to return empty/zero defaults when the mapping is uninitialized.

### Drive-by changes

None.

### Related issues

None.

### Backward compatibility

Yes.

### Testing

Manual — relayer no longer crashes on startup against a freshly deployed Aleo devnet.