### PR TITLE
fix: reduce cctp interval to 10 retries

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
@@ -250,9 +250,9 @@ async fn metadata_build(
             continue;
         }
 
-        // Retry this URL while attestation is pending (transient), up to 30 attempts at 1s intervals.
+        // Retry this URL while attestation is pending (transient), up to 10 attempts at 1s intervals.
         // Move to the next URL only on hard failures.
-        const MAX_PENDING_RETRIES: u32 = 30;
+        const MAX_PENDING_RETRIES: u32 = 10;
         let mut pending_attempts = 0u32;
         tracing::info!(?ism_address, url, message_id = ?message.id(), "Fetching CCIP read offchain data");
         loop {


### PR DESCRIPTION
### Description

This PR reduces the retries from 30 to 10 in order to preserve fast relaying for sub 10 second cctp fast messages without clogging up the metadata builder queue

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
