### PR TITLE
feat: support ICA native balance sentinel

### DIFF
--- a/.changeset/quiet-icas-collect.md
+++ b/.changeset/quiet-icas-collect.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": minor
+---
+
+Added ICA native balance sentinel support.

--- a/solidity/contracts/middleware/libs/Call.sol
+++ b/solidity/contracts/middleware/libs/Call.sol
@@ -6,6 +6,8 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {TypeCasts} from "../../libs/TypeCasts.sol";
 
 library CallLib {
+    uint256 internal constant NATIVE_BALANCE_SENTINEL = type(uint256).max;
+
     struct StaticCall {
         // supporting non EVM targets
         bytes32 to;
@@ -27,11 +29,15 @@ library CallLib {
     function call(
         Call memory _call
     ) internal returns (bytes memory returnData) {
+        uint256 value = _call.value == NATIVE_BALANCE_SENTINEL
+            ? address(this).balance
+            : _call.value;
+
         return
             Address.functionCallWithValue(
                 TypeCasts.bytes32ToAddress(_call.to),
                 _call.data,
-                _call.value
+                value
             );
     }
 

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -568,6 +568,32 @@ contract InterchainAccountRouterTestBase is Test {
         environment.processNextPendingMessage();
     }
 
+    function test_sendNativeBalanceSentinel() public {
+        uint256 value = 1 ether;
+        vm.deal(address(ica), value);
+
+        bytes memory data = abi.encodeCall(this.receiveValue, (value));
+        CallLib.Call memory call = CallLib.build(
+            address(this),
+            type(uint256).max,
+            data
+        );
+        CallLib.Call[] memory calls = new CallLib.Call[](1);
+        calls[0] = call;
+
+        originIcaRouter.callRemoteWithOverrides{value: gasPaymentQuote}(
+            destination,
+            routerOverride,
+            ismOverride,
+            calls,
+            bytes("")
+        );
+        vm.expectCall(address(this), value, data);
+        environment.processNextPendingMessage();
+
+        assertEq(address(ica).balance, 0);
+    }
+
     function testDifferentSalts() public {
         address owner = address(this);
 
@@ -1142,6 +1168,41 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
         // Cannot reveal twice
         vm.expectRevert("ICA: Invalid Reveal");
         ica.revealAndExecute(calls, salt);
+    }
+
+    function test_revealAndExecuteNativeBalanceSentinel() public {
+        uint256 value = 1 ether;
+        bytes memory data = abi.encodeCall(this.receiveValue, (value));
+        CallLib.Call memory call = CallLib.build(
+            address(this),
+            type(uint256).max,
+            data
+        );
+        CallLib.Call[] memory calls = new CallLib.Call[](1);
+        calls[0] = call;
+
+        bytes32 salt = keccak256("calls salt");
+        bytes32 commitment = _get_commitment(salt, calls);
+
+        originIcaRouter.callRemoteCommitReveal(
+            destination,
+            routerOverride,
+            ismOverride,
+            bytes(""),
+            new TestPostDispatchHook(),
+            bytes32(0),
+            commitment
+        );
+        environment.processNextPendingMessage();
+        assertEq(ica.commitments(commitment), true);
+
+        vm.deal(address(ica), value);
+        vm.expectCall(address(this), value, data);
+        bytes32 executedCommitment = ica.revealAndExecute(calls, salt);
+
+        assertEq(executedCommitment, commitment);
+        assertEq(ica.commitments(commitment), false);
+        assertEq(address(ica).balance, 0);
     }
 
     function testFuzz_readIsm_verify(


### PR DESCRIPTION
## Summary

Rebased for the Q3 2026 audit branch.

- Base: `audit-q3-2026`
- Head: `9392cd0c71`
- Adds ICA native balance sentinel support.
- Adds a `minor` changeset for `@hyperlane-xyz/core`.

## Verification

- `forge test --match-test 'test_sendNativeBalanceSentinel|test_revealAndExecuteNativeBalanceSentinel'`
  - 4 passed
