### PR TITLE
fix: aleo token adapter backwards compatibility and warp token naming

### DIFF
--- a/.changeset/thin-candles-begin.md
+++ b/.changeset/thin-candles-begin.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/aleo-sdk": minor
+---
+
+Fixed aleo token adapters to support new transfer_as_signer methods and fix aleo-sdk for correct warp token names

--- a/typescript/aleo-sdk/src/clients/provider.ts
+++ b/typescript/aleo-sdk/src/clients/provider.ts
@@ -33,6 +33,19 @@ interface TransactionFeeCache {
 
 export class AleoProvider extends AleoBase implements AltVM.IProvider {
   private transactionFeeCache: TransactionFeeCache = {};
+  private signerTransferCache = new Map<string, boolean>();
+
+  private async hasSignerTransferFunctions(
+    programId: string,
+  ): Promise<boolean> {
+    if (this.signerTransferCache.has(programId)) {
+      return this.signerTransferCache.get(programId)!;
+    }
+    const program = await this.aleoClient.getProgram(programId);
+    const hasSigner = program.toString().includes('transfer_remote_as_signer');
+    this.signerTransferCache.set(programId, hasSigner);
+    return hasSigner;
+  }
 
   static async connect(
     rpcUrls: string[],
@@ -544,6 +557,8 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
 
     const amount = `${req.amount}${tokenType === AltVM.TokenType.native ? 'u64' : 'u128'}`;
 
+    const useSignerVariant = await this.hasSignerTransferFunctions(programId);
+
     if (req.customHookAddress) {
       const metadataBytes: number[] = fillArray(
         [...Buffer.from(strip0x(req.customHookMetadata || ''), 'hex')],
@@ -558,7 +573,9 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
 
       return {
         programName: programId,
-        functionName: 'transfer_remote_with_hook',
+        functionName: useSignerVariant
+          ? 'transfer_remote_with_hook_as'
+          : 'transfer_remote_with_hook',
         priorityFee: 0,
         privateFee: false,
         inputs: [
@@ -577,7 +594,9 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
 
     return {
       programName: programId,
-      functionName: 'transfer_remote',
+      functionName: useSignerVariant
+        ? 'transfer_remote_as_signer'
+        : 'transfer_remote',
       priorityFee: 0,
       privateFee: false,
       inputs: [

--- a/typescript/aleo-sdk/src/clients/signer.ts
+++ b/typescript/aleo-sdk/src/clients/signer.ts
@@ -1,5 +1,5 @@
 import { type AltVM } from '@hyperlane-xyz/provider-sdk';
-import { type TokenType } from '@hyperlane-xyz/provider-sdk/warp';
+import { TokenType } from '@hyperlane-xyz/provider-sdk/warp';
 import { assert, isNullish, retryAsync } from '@hyperlane-xyz/utils';
 
 import { type AleoProgram } from '../artifacts.js';
@@ -91,10 +91,14 @@ export class AleoSigner
     preferredSuffix?: string,
     maxAttempts = 20,
   ): Promise<string> {
+    if (tokenType === TokenType.native) {
+      return 'credits';
+    }
+
     const configuredSuffix = preferredSuffix || this.warpSuffix;
 
     if (configuredSuffix) {
-      const tokenProgramId = `${this.prefix}_${tokenType}_${configuredSuffix}.aleo`;
+      const tokenProgramId = `${this.prefix}_warp_token_${configuredSuffix}.aleo`;
 
       const isAlreadyDeployed = await this.isProgramDeployed(tokenProgramId);
       assert(
@@ -107,7 +111,7 @@ export class AleoSigner
 
     for (let i = 0; i < maxAttempts; i++) {
       const suffix = this.generateSuffix(SUFFIX_LENGTH_LONG);
-      const tokenProgramId = `${this.prefix}_${tokenType}_${suffix}.aleo`;
+      const tokenProgramId = `${this.prefix}_warp_token_${suffix}.aleo`;
 
       if (!(await this.isProgramDeployed(tokenProgramId))) {
         return suffix;

--- a/typescript/aleo-sdk/src/tests/7a_warp_native_artifacts.e2e-test.ts
+++ b/typescript/aleo-sdk/src/tests/7a_warp_native_artifacts.e2e-test.ts
@@ -3,6 +3,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { AltVM } from '@hyperlane-xyz/provider-sdk';
 import { ArtifactState } from '@hyperlane-xyz/provider-sdk/artifact';
+import type { DeployedRawWarpArtifact } from '@hyperlane-xyz/provider-sdk/warp';
 
 import { isNullish } from '@hyperlane-xyz/utils';
 
@@ -35,6 +36,7 @@ describe('7a. Aleo Warp Native Token Artifact API (e2e)', function () {
   let hookArtifactManager: AleoHookArtifactManager;
   let mailboxAddress: string;
   let savedWarpSuffix: string | undefined;
+  let preDeployedNativeToken: DeployedRawWarpArtifact;
 
   before(async () => {
     savedWarpSuffix = process.env['ALEO_WARP_SUFFIX'];
@@ -102,6 +104,22 @@ describe('7a. Aleo Warp Native Token Artifact API (e2e)', function () {
       ismManagerAddress: ismManagerProgramId,
       hookManagerAddress: hookManagerProgramId,
     });
+
+    // Deploy native token once — it always uses the fixed program name
+    // test_hyp_warp_token_credits.aleo, so all tests share it.
+    const nativeWriter = artifactManager.createWriter(
+      AltVM.TokenType.native,
+      aleoSigner,
+    );
+    [preDeployedNativeToken] = await nativeWriter.create({
+      config: {
+        type: AltVM.TokenType.native,
+        owner: aleoSigner.getSignerAddress(),
+        mailbox: mailboxAddress,
+        remoteRouters: {},
+        destinationGas: {},
+      },
+    });
   });
 
   after(() => {
@@ -118,6 +136,7 @@ describe('7a. Aleo Warp Native Token Artifact API (e2e)', function () {
       ismArtifactManager,
       hookArtifactManager,
       mailboxAddress,
+      preDeployedToken: preDeployedNativeToken,
     }),
     {
       type: AltVM.TokenType.native,

--- a/typescript/aleo-sdk/src/tests/warp-artifact-test-suite.ts
+++ b/typescript/aleo-sdk/src/tests/warp-artifact-test-suite.ts
@@ -32,6 +32,12 @@ export interface WarpTestSuiteContext {
   ismArtifactManager: AleoIsmArtifactManager;
   hookArtifactManager: AleoHookArtifactManager;
   mailboxAddress: string;
+  /**
+   * When provided, all tests reuse this pre-deployed token instead of calling
+   * `writer.create()`. Used for token types with a fixed program name (native)
+   * where multiple deployments are not possible.
+   */
+  preDeployedToken?: DeployedRawWarpArtifact;
 }
 
 export interface WarpTokenTestCase {
@@ -60,8 +66,52 @@ export function warpArtifactTestSuite(
     ctx = getContext();
   });
 
+  /**
+   * Returns a deployed token in the requested initial config state.
+   * When ctx.preDeployedToken is set, resets the shared token to match
+   * the given config via update transactions instead of deploying fresh.
+   */
+  async function getDeployedToken(
+    config: ReturnType<WarpTokenTestCase['getConfig']>,
+  ): Promise<DeployedRawWarpArtifact> {
+    const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
+    if (ctx.preDeployedToken) {
+      const target: DeployedRawWarpArtifact = {
+        ...ctx.preDeployedToken,
+        config: {
+          ...ctx.preDeployedToken.config,
+          remoteRouters: config.remoteRouters ?? {},
+          destinationGas: config.destinationGas ?? {},
+          interchainSecurityModule: config.interchainSecurityModule,
+          hook: config.hook,
+        },
+      };
+      const txs = await writer.update(target);
+      for (const tx of txs) {
+        await ctx.providerSdkSigner.sendAndConfirmTransaction(tx);
+      }
+      return target;
+    }
+    const [deployed] = await writer.create({ config });
+    return deployed;
+  }
+
   it('should create and read token', async () => {
     const config = getConfig();
+
+    if (ctx.preDeployedToken) {
+      const reader = ctx.artifactManager.createReader(type);
+      const readToken = await reader.read(
+        ctx.preDeployedToken.deployed.address,
+      );
+
+      expect(readToken.artifactState).to.equal(ArtifactState.DEPLOYED);
+      expect(readToken.config.type).to.equal(type);
+      expect(readToken.deployed.address).to.equal(
+        ctx.preDeployedToken.deployed.address,
+      );
+      return;
+    }
 
     const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
     const [result, receipts] = await writer.create({ config });
@@ -93,9 +143,7 @@ export function warpArtifactTestSuite(
     const initialConfig = getConfig();
 
     const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-    const [deployedToken] = await writer.create({
-      config: initialConfig,
-    });
+    const deployedToken = await getDeployedToken(initialConfig);
 
     // Update with remote routers
     const updatedConfig: DeployedRawWarpArtifact = {
@@ -158,9 +206,7 @@ export function warpArtifactTestSuite(
     };
 
     const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-    const [deployedToken] = await writer.create({
-      config: initialConfig,
-    });
+    const deployedToken = await getDeployedToken(initialConfig);
 
     // Remove DOMAIN_2
     const updatedConfig: DeployedRawWarpArtifact = {
@@ -208,9 +254,7 @@ export function warpArtifactTestSuite(
     };
 
     const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-    const [deployedToken] = await writer.create({
-      config: initialConfig,
-    });
+    const deployedToken = await getDeployedToken(initialConfig);
 
     // Verify initial gas value
     const reader = ctx.artifactManager.createReader(type);
@@ -251,6 +295,10 @@ export function warpArtifactTestSuite(
   });
 
   it('should transfer ownership via update (ownership last)', async () => {
+    if (ctx.preDeployedToken) {
+      // Ownership transfer is irreversible — skip to avoid breaking subsequent tests
+      return;
+    }
     const initialConfig = getConfig();
 
     const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
@@ -313,7 +361,7 @@ export function warpArtifactTestSuite(
     const config = getConfig();
 
     const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-    const [deployedToken] = await writer.create({ config });
+    const deployedToken = await getDeployedToken(config);
 
     const txs = await writer.update(deployedToken);
     expect(txs).to.be.an('array').with.length(0);
@@ -341,9 +389,7 @@ export function warpArtifactTestSuite(
       };
 
       const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-      const [deployedToken] = await writer.create({
-        config: initialConfig,
-      });
+      const deployedToken = await getDeployedToken(initialConfig);
 
       // Verify ISM is set
       const reader = ctx.artifactManager.createReader(type);
@@ -387,9 +433,7 @@ export function warpArtifactTestSuite(
       initialConfig.interchainSecurityModule = undefined;
 
       const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-      const [deployedToken] = await writer.create({
-        config: initialConfig,
-      });
+      const deployedToken = await getDeployedToken(initialConfig);
 
       // Verify ISM is unset
       const reader = ctx.artifactManager.createReader(type);
@@ -466,9 +510,7 @@ export function warpArtifactTestSuite(
       };
 
       const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-      const [deployedToken] = await writer.create({
-        config: initialConfig,
-      });
+      const deployedToken = await getDeployedToken(initialConfig);
 
       // Verify first ISM is set
       const reader = ctx.artifactManager.createReader(type);
@@ -534,9 +576,7 @@ export function warpArtifactTestSuite(
       };
 
       const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-      const [deployedToken] = await writer.create({
-        config: initialConfig,
-      });
+      const deployedToken = await getDeployedToken(initialConfig);
 
       // Update with same ISM (no change)
       const txs = await writer.update(deployedToken);
@@ -551,9 +591,7 @@ export function warpArtifactTestSuite(
       initialConfig.interchainSecurityModule = undefined;
 
       const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-      const [deployedToken] = await writer.create({
-        config: initialConfig,
-      });
+      const deployedToken = await getDeployedToken(initialConfig);
 
       // Update with ISM still undefined (no change)
       const txs = await writer.update(deployedToken);
@@ -566,9 +604,7 @@ export function warpArtifactTestSuite(
       const initialConfig = getConfig();
 
       const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-      const [deployedToken] = await writer.create({
-        config: initialConfig,
-      });
+      const deployedToken = await getDeployedToken(initialConfig);
 
       const updatedConfig: DeployedRawWarpArtifact = {
         ...deployedToken,
@@ -613,9 +649,7 @@ export function warpArtifactTestSuite(
       };
 
       const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-      const [deployedToken] = await writer.create({
-        config: initialConfig,
-      });
+      const deployedToken = await getDeployedToken(initialConfig);
 
       // Verify hook is set
       const reader = ctx.artifactManager.createReader(type);
@@ -659,9 +693,7 @@ export function warpArtifactTestSuite(
       initialConfig.hook = undefined;
 
       const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-      const [deployedToken] = await writer.create({
-        config: initialConfig,
-      });
+      const deployedToken = await getDeployedToken(initialConfig);
 
       // Verify hook is unset
       const reader = ctx.artifactManager.createReader(type);
@@ -738,9 +770,7 @@ export function warpArtifactTestSuite(
       };
 
       const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-      const [deployedToken] = await writer.create({
-        config: initialConfig,
-      });
+      const deployedToken = await getDeployedToken(initialConfig);
 
       // Verify first hook is set
       const reader = ctx.artifactManager.createReader(type);
@@ -806,9 +836,7 @@ export function warpArtifactTestSuite(
       };
 
       const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-      const [deployedToken] = await writer.create({
-        config: initialConfig,
-      });
+      const deployedToken = await getDeployedToken(initialConfig);
 
       // Update with same hook (no change)
       const txs = await writer.update(deployedToken);
@@ -823,9 +851,7 @@ export function warpArtifactTestSuite(
       initialConfig.hook = undefined;
 
       const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-      const [deployedToken] = await writer.create({
-        config: initialConfig,
-      });
+      const deployedToken = await getDeployedToken(initialConfig);
 
       // Update with hook still undefined (no change)
       const txs = await writer.update(deployedToken);
@@ -856,9 +882,7 @@ export function warpArtifactTestSuite(
       };
 
       const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-      const [deployedToken] = await writer.create({
-        config: initialConfig,
-      });
+      const deployedToken = await getDeployedToken(initialConfig);
 
       // Verify hook is set
       const reader = ctx.artifactManager.createReader(type);
@@ -906,9 +930,7 @@ export function warpArtifactTestSuite(
       const initialConfig = getConfig();
 
       const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-      const [deployedToken] = await writer.create({
-        config: initialConfig,
-      });
+      const deployedToken = await getDeployedToken(initialConfig);
 
       const updatedConfig: DeployedRawWarpArtifact = {
         ...deployedToken,
@@ -934,8 +956,7 @@ export function warpArtifactTestSuite(
   it(`should detect and read ${testCase.name} token via readWarpToken`, async () => {
     const config = getConfig();
 
-    const writer = ctx.artifactManager.createWriter(type, ctx.aleoSigner);
-    const [deployedToken] = await writer.create({ config });
+    const deployedToken = await getDeployedToken(config);
 
     // Read via generic readWarpToken (without knowing the type)
     const readToken = await ctx.artifactManager.readWarpToken(

--- a/typescript/aleo-sdk/src/utils/helper.ts
+++ b/typescript/aleo-sdk/src/utils/helper.ts
@@ -91,8 +91,14 @@ export function loadProgramsInDeployOrder(
           )
           .replaceAll(
             /(hyp_native|hyp_collateral|hyp_synthetic).aleo/g,
-            (_, p1) =>
-              `${p1}_${getCustomWarpSuffixFromEnv() || warpSuffix || coreSuffix}.aleo`,
+            (_, p1) => {
+              if (p1 === 'hyp_native') {
+                return `hyp_warp_token_credits.aleo`;
+              }
+              const effectiveSuffix =
+                getCustomWarpSuffixFromEnv() || warpSuffix || coreSuffix;
+              return `hyp_warp_token_${effectiveSuffix}.aleo`;
+            },
           ),
       ),
     );
@@ -173,9 +179,20 @@ constructor:
   return programs.map((p) => ({
     id: p.id(),
     name:
-      Object.keys(programRegistry).find((r) =>
-        p.id().startsWith(`${prefix}_${r.replaceAll('hyp_', '')}`),
-      ) || '',
+      Object.keys(programRegistry).find((r) => {
+        if (r === 'hyp_native') {
+          return p.id() === `${prefix}_warp_token_credits.aleo`;
+        }
+        if (
+          (r === 'hyp_collateral' || r === 'hyp_synthetic') &&
+          r === programName &&
+          p.id().startsWith(`${prefix}_warp_token_`) &&
+          p.id() !== `${prefix}_warp_token_credits.aleo`
+        ) {
+          return true;
+        }
+        return p.id().startsWith(`${prefix}_${r.replaceAll('hyp_', '')}`);
+      }) || '',
     program: p.toString(),
   }));
 }

--- a/typescript/cli/src/tests/aleo/warp/warp-apply-hook-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/warp/warp-apply-hook-updates.e2e-test.ts
@@ -67,7 +67,9 @@ describe('hyperlane warp apply Hook updates (Aleo E2E tests)', async function ()
   });
 
   beforeEach(() => {
-    // Generate unique short suffix for each test to avoid program name collisions
+    // Generate unique short suffix for each test to avoid program name collisions.
+    // Native tokens use a fixed program name (no suffix) and can only be initialized once,
+    // so hook update tests use synthetic tokens to get a fresh program per beforeEach call.
     const uniqueSuffix = Math.random().toString(36).substring(2, 8);
     process.env.ALEO_WARP_SUFFIX = uniqueSuffix;
   });
@@ -79,7 +81,7 @@ describe('hyperlane warp apply Hook updates (Aleo E2E tests)', async function ()
       get baseWarpConfig() {
         return {
           [TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_1]: {
-            type: TokenType.native,
+            type: TokenType.synthetic,
             mailbox: chain1CoreAddress.mailbox,
             owner: HYP_DEPLOYER_ADDRESS_BY_PROTOCOL.aleo,
             name: nativeTokenData.name,

--- a/typescript/cli/src/tests/aleo/warp/warp-apply-ism-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/warp/warp-apply-ism-updates.e2e-test.ts
@@ -67,7 +67,9 @@ describe('hyperlane warp apply ISM updates (Aleo E2E tests)', async function () 
   });
 
   beforeEach(() => {
-    // Generate unique short suffix for each test to avoid program name collisions
+    // Generate unique short suffix for each test to avoid program name collisions.
+    // Native tokens use a fixed program name (no suffix) and can only be initialized once,
+    // so ISM update tests use synthetic tokens to get a fresh program per beforeEach call.
     const uniqueSuffix = Math.random().toString(36).substring(2, 8);
     process.env.ALEO_WARP_SUFFIX = uniqueSuffix;
   });
@@ -79,7 +81,7 @@ describe('hyperlane warp apply ISM updates (Aleo E2E tests)', async function () 
       get baseWarpConfig() {
         return {
           [TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_1]: {
-            type: TokenType.native,
+            type: TokenType.synthetic,
             mailbox: chain1CoreAddress.mailbox,
             owner: HYP_DEPLOYER_ADDRESS_BY_PROTOCOL.aleo,
             name: nativeTokenData.name,

--- a/typescript/cli/src/tests/aleo/warp/warp-apply-ownership-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/warp/warp-apply-ownership-updates.e2e-test.ts
@@ -88,15 +88,20 @@ describe('hyperlane warp apply ownership (Aleo E2E tests)', async function () {
 
   let warpDeployConfig: WarpRouteDeployConfig;
   beforeEach(async () => {
-    // Generate unique short suffix for each test to avoid program name collisions
+    // Generate unique short suffix for each test to avoid program name collisions.
+    // Native tokens use a fixed program name (no suffix) and can only be initialized once,
+    // so ownership update tests use synthetic tokens to get a fresh program per beforeEach call.
     const uniqueSuffix = Math.random().toString(36).substring(2, 8);
     process.env.ALEO_WARP_SUFFIX = uniqueSuffix;
 
     warpDeployConfig = {
       [TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_1]: {
-        type: TokenType.native,
+        type: TokenType.synthetic,
         mailbox: chain1CoreAddress.mailbox,
         owner: HYP_DEPLOYER_ADDRESS_BY_PROTOCOL.aleo,
+        name: nativeTokenData.name,
+        symbol: nativeTokenData.symbol,
+        decimals: nativeTokenData.decimals,
       },
       [TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_2]: {
         type: TokenType.synthetic,

--- a/typescript/cli/src/tests/aleo/warp/warp-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/warp/warp-deploy.e2e-test.ts
@@ -95,13 +95,17 @@ describe('hyperlane warp deploy (Aleo E2E tests)', async function () {
     };
   });
 
-  let warpDeployConfig: WarpRouteDeployConfig;
   beforeEach(() => {
-    // Generate unique short suffix for each test to avoid program name collisions
+    // Generate unique short suffix for each test to avoid program name collisions.
+    // Note: native tokens always use the fixed suffix "credits" (ignoring ALEO_WARP_SUFFIX),
+    // so only one native token can be initialized per test run. Tests that need fresh
+    // programs per invocation must use synthetic/collateral token types.
     const uniqueSuffix = Math.random().toString(36).substring(2, 8);
     process.env.ALEO_WARP_SUFFIX = uniqueSuffix;
+  });
 
-    warpDeployConfig = {
+  it('should successfully deploy on multiple chains', async () => {
+    const warpDeployConfig: WarpRouteDeployConfig = {
       [TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_1]: {
         type: TokenType.native,
         mailbox: chain1CoreAddress.mailbox,
@@ -118,9 +122,7 @@ describe('hyperlane warp deploy (Aleo E2E tests)', async function () {
     };
 
     writeYamlOrJson(WARP_DEPLOY_PATH, warpDeployConfig);
-  });
 
-  it('should successfully deploy on multiple chains', async () => {
     const output = await hyperlaneWarp
       .deployRaw({
         warpRouteId: WARP_ROUTE_ID,
@@ -152,10 +154,30 @@ describe('hyperlane warp deploy (Aleo E2E tests)', async function () {
   });
 
   it('should deploy and set the owner to the expected one in the config', async () => {
+    // Native tokens use a fixed program name (no suffix) and can only be initialized once
+    // per test run, so this test uses synthetic tokens on both chains to get collision-free
+    // program names via ALEO_WARP_SUFFIX.
     const differentOwner =
       'aleo17m3l8a4hmf3wypzkf5lsausfdwq9etzyujd0vmqh35ledn2sgvqqzqkqal';
-    warpDeployConfig[TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_1].owner =
-      differentOwner;
+    const warpDeployConfig: WarpRouteDeployConfig = {
+      [TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_1]: {
+        type: TokenType.synthetic,
+        mailbox: chain1CoreAddress.mailbox,
+        owner: differentOwner,
+        name: nativeTokenData.name,
+        symbol: nativeTokenData.symbol,
+        decimals: nativeTokenData.decimals,
+      },
+      [TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_2]: {
+        type: TokenType.synthetic,
+        mailbox: chain2CoreAddress.mailbox,
+        owner: HYP_DEPLOYER_ADDRESS_BY_PROTOCOL.aleo,
+        name: nativeTokenData.name,
+        symbol: nativeTokenData.symbol,
+        decimals: nativeTokenData.decimals,
+      },
+    };
+
     writeYamlOrJson(WARP_DEPLOY_PATH, warpDeployConfig);
 
     const output = await hyperlaneWarp

--- a/typescript/cli/src/tests/aleo/warp/warp-read.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/warp/warp-read.e2e-test.ts
@@ -94,13 +94,10 @@ describe('hyperlane warp read (Aleo E2E tests)', async function () {
       [TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_1]: chain1CoreAddress,
       [TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_2]: chain2CoreAddress,
     };
-  });
 
-  beforeEach(() => {
-    // Generate unique short suffix for each test to avoid program name collisions
-    const uniqueSuffix = Math.random().toString(36).substring(2, 8);
-    process.env.ALEO_WARP_SUFFIX = uniqueSuffix;
-
+    // Deploy the native warp route once. Native tokens always use the fixed program name
+    // "credits" (ignoring ALEO_WARP_SUFFIX), so deploying once and sharing across all
+    // read tests avoids repeated re-initialization failures.
     warpDeployConfig = {
       [TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_1]: {
         type: TokenType.native,
@@ -118,19 +115,15 @@ describe('hyperlane warp read (Aleo E2E tests)', async function () {
     };
 
     writeYamlOrJson(WARP_DEPLOY_PATH, warpDeployConfig);
+    await hyperlaneWarp.deployRaw({
+      warpRouteId: WARP_ROUTE_ID,
+      skipConfirmationPrompts: true,
+      privateKey: HYP_KEY_BY_PROTOCOL.aleo,
+    });
   });
 
   describe('hyperlane warp read (no args)', () => {
     it('should exit early if no symbol or no chain and address', async () => {
-      await hyperlaneWarp
-        .deployRaw({
-          warpRouteId: WARP_ROUTE_ID,
-          skipConfirmationPrompts: true,
-          privateKey: HYP_KEY_BY_PROTOCOL.aleo,
-        })
-        .stdio('pipe')
-        .nothrow();
-
       const output = await hyperlaneWarp.readRaw({}).nothrow();
 
       expect(output.exitCode).to.equal(1);
@@ -140,14 +133,6 @@ describe('hyperlane warp read (Aleo E2E tests)', async function () {
 
   describe('hyperlane warp read --warpRouteId ...', () => {
     it('should successfully read the complete warp route config from all chains', async () => {
-      await hyperlaneWarp
-        .deployRaw({
-          warpRouteId: WARP_ROUTE_ID,
-          skipConfirmationPrompts: true,
-          privateKey: HYP_KEY_BY_PROTOCOL.aleo,
-        })
-        .stdio('pipe');
-
       const output = await hyperlaneWarp
         .readRaw({
           warpRouteId: WARP_ROUTE_ID,
@@ -174,14 +159,6 @@ describe('hyperlane warp read (Aleo E2E tests)', async function () {
 
   describe('hyperlane warp read --chain ... --warp-route-id ...', () => {
     it('should be able to read a warp route from a single chain', async function () {
-      await hyperlaneWarp
-        .deployRaw({
-          warpRouteId: WARP_ROUTE_ID,
-          skipConfirmationPrompts: true,
-          privateKey: HYP_KEY_BY_PROTOCOL.aleo,
-        })
-        .stdio('pipe');
-
       const warpReadResult = await hyperlaneWarp.readConfig(
         TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_1,
         WARP_CORE_PATH,

--- a/typescript/cli/src/tests/aleo/warp/warp-read.e2e-test.ts
+++ b/typescript/cli/src/tests/aleo/warp/warp-read.e2e-test.ts
@@ -94,15 +94,25 @@ describe('hyperlane warp read (Aleo E2E tests)', async function () {
       [TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_1]: chain1CoreAddress,
       [TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_2]: chain2CoreAddress,
     };
+  });
 
-    // Deploy the native warp route once. Native tokens always use the fixed program name
-    // "credits" (ignoring ALEO_WARP_SUFFIX), so deploying once and sharing across all
-    // read tests avoids repeated re-initialization failures.
+  beforeEach(async () => {
+    // Generate unique short suffix for each test to avoid program name collisions.
+    // Native tokens use a fixed program name (no suffix) and can only be initialized once,
+    // so read tests use synthetic tokens to get a fresh program per beforeEach call.
+    // (The global beforeEach in e2e-test.setup.ts wipes deployments/warp_routes before each
+    // test, so we must redeploy here rather than once in before.)
+    const uniqueSuffix = Math.random().toString(36).substring(2, 8);
+    process.env.ALEO_WARP_SUFFIX = uniqueSuffix;
+
     warpDeployConfig = {
       [TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_1]: {
-        type: TokenType.native,
+        type: TokenType.synthetic,
         mailbox: chain1CoreAddress.mailbox,
         owner: HYP_DEPLOYER_ADDRESS_BY_PROTOCOL.aleo,
+        name: nativeTokenData.name,
+        symbol: nativeTokenData.symbol,
+        decimals: nativeTokenData.decimals,
       },
       [TEST_CHAIN_NAMES_BY_PROTOCOL.aleo.CHAIN_NAME_2]: {
         type: TokenType.synthetic,


### PR DESCRIPTION
### Description

Two fixes to the Aleo SDK warp route deployment:

1. **Backwards-compatible transfer adapter**: The token adapter now detects at runtime whether the deployed warp token program supports `transfer_remote_as_signer` / `transfer_remote_with_hook_as_signer` (new) or the legacy `transfer_remote` / `transfer_remote_with_hook` (old) by fetching the program source and checking for the function name. The result is cached per program ID.

2. **Warp token naming convention**: Collateral and synthetic tokens now use `{prefix}_warp_token_{suffix}.aleo` (e.g. `test_hyp_warp_token_usdc.aleo`). Native tokens always use `{prefix}_warp_token_credits.aleo`, ignoring `ALEO_WARP_SUFFIX`.

### Backward compatibility

Yes — the adapter detects the function variant at runtime, so existing deployed programs (old naming or old transfer functions) continue to work.

### Testing

Manual — deployed USDC and USDT warp routes on Aleo testnet.