### PR TITLE
feat: add NonceFloorIsm for reorg replay protection

### DIFF
--- a/solidity/contracts/isms/NonceFloorIsm.sol
+++ b/solidity/contracts/isms/NonceFloorIsm.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+// ============ Internal Imports ============
+import {IInterchainSecurityModule} from "../interfaces/IInterchainSecurityModule.sol";
+import {Message} from "../libs/Message.sol";
+import {PackageVersioned} from "../PackageVersioned.sol";
+
+/**
+ * @title NonceFloorIsm
+ * @notice Rejects messages with nonce <= floor for a given origin domain.
+ * Designed to block reorged/replayed messages after a chain reorganization.
+ * Intended to be composed with other ISMs via AggregationIsm or RoutingIsm.
+ */
+contract NonceFloorIsm is IInterchainSecurityModule, PackageVersioned {
+    using Message for bytes;
+
+    uint8 public constant override moduleType = uint8(Types.NULL);
+
+    /// @notice origin domain => highest rejected nonce (inclusive)
+    mapping(uint32 => uint32) public nonceFloors;
+
+    /// @notice Emitted when a nonce floor is set for an origin domain
+    event NonceFloorSet(uint32 indexed origin, uint32 floor);
+
+    /// @param origins The origin domains
+    /// @param floors The nonce floors (messages with nonce <= floor are rejected)
+    constructor(uint32[] memory origins, uint32[] memory floors) {
+        require(origins.length == floors.length, "length mismatch");
+        for (uint256 i = 0; i < origins.length; i++) {
+            require(nonceFloors[origins[i]] == 0, "floor already set");
+            require(floors[i] > 0, "floor must be > 0");
+            nonceFloors[origins[i]] = floors[i];
+            emit NonceFloorSet(origins[i], floors[i]);
+        }
+    }
+
+    /// @inheritdoc IInterchainSecurityModule
+    /// @dev Returns false if the message nonce is at or below the floor for its origin.
+    /// Messages from origins without a floor are always accepted.
+    function verify(
+        bytes calldata,
+        bytes calldata _message
+    ) external view returns (bool) {
+        uint32 floor = nonceFloors[_message.origin()];
+        if (floor == 0) return true;
+        return _message.nonce() > floor;
+    }
+}

--- a/solidity/contracts/isms/NonceFloorIsm.sol
+++ b/solidity/contracts/isms/NonceFloorIsm.sol
@@ -8,42 +8,29 @@ import {PackageVersioned} from "../PackageVersioned.sol";
 
 /**
  * @title NonceFloorIsm
- * @notice Rejects messages with nonce <= floor for a given origin domain.
+ * @notice Rejects messages with nonce <= floor.
  * Designed to block reorged/replayed messages after a chain reorganization.
- * Intended to be composed with other ISMs via AggregationIsm or RoutingIsm.
+ * Scope to specific origins by composing with DomainRoutingIsm.
  */
 contract NonceFloorIsm is IInterchainSecurityModule, PackageVersioned {
     using Message for bytes;
 
     uint8 public constant override moduleType = uint8(Types.NULL);
 
-    /// @notice origin domain => highest rejected nonce (inclusive)
-    mapping(uint32 => uint32) public nonceFloors;
+    /// @notice Messages with nonce <= this value are rejected
+    uint32 public immutable nonceFloor;
 
-    /// @notice Emitted when a nonce floor is set for an origin domain
-    event NonceFloorSet(uint32 indexed origin, uint32 floor);
-
-    /// @param origins The origin domains
-    /// @param floors The nonce floors (messages with nonce <= floor are rejected)
-    constructor(uint32[] memory origins, uint32[] memory floors) {
-        require(origins.length == floors.length, "length mismatch");
-        for (uint256 i = 0; i < origins.length; i++) {
-            require(nonceFloors[origins[i]] == 0, "floor already set");
-            require(floors[i] > 0, "floor must be > 0");
-            nonceFloors[origins[i]] = floors[i];
-            emit NonceFloorSet(origins[i], floors[i]);
-        }
+    /// @param _nonceFloor The highest rejected nonce (inclusive)
+    constructor(uint32 _nonceFloor) {
+        require(_nonceFloor > 0, "floor must be > 0");
+        nonceFloor = _nonceFloor;
     }
 
     /// @inheritdoc IInterchainSecurityModule
-    /// @dev Returns false if the message nonce is at or below the floor for its origin.
-    /// Messages from origins without a floor are always accepted.
     function verify(
         bytes calldata,
         bytes calldata _message
     ) external view returns (bool) {
-        uint32 floor = nonceFloors[_message.origin()];
-        if (floor == 0) return true;
-        return _message.nonce() > floor;
+        return _message.nonce() > nonceFloor;
     }
 }

--- a/solidity/test/isms/NonceFloorIsm.t.sol
+++ b/solidity/test/isms/NonceFloorIsm.t.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT or Apache-2.0
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {NonceFloorIsm} from "../../contracts/isms/NonceFloorIsm.sol";
+import {IInterchainSecurityModule} from "../../contracts/interfaces/IInterchainSecurityModule.sol";
+import {MessageUtils} from "./IsmTestUtils.sol";
+
+contract NonceFloorIsmTest is Test {
+    NonceFloorIsm ism;
+
+    uint32 constant ORIGIN = 1983;
+    uint32 constant FLOOR = 1092;
+    uint32 constant OTHER_ORIGIN = 1;
+
+    function setUp() public {
+        uint32[] memory origins = new uint32[](1);
+        origins[0] = ORIGIN;
+        uint32[] memory floors = new uint32[](1);
+        floors[0] = FLOOR;
+        ism = new NonceFloorIsm(origins, floors);
+    }
+
+    function _message(
+        uint32 origin,
+        uint32 nonce
+    ) internal pure returns (bytes memory) {
+        return
+            MessageUtils.formatMessage(
+                0,
+                nonce,
+                origin,
+                bytes32(0),
+                0,
+                bytes32(0),
+                ""
+            );
+    }
+
+    function test_moduleType() public view {
+        assertEq(ism.moduleType(), uint8(IInterchainSecurityModule.Types.NULL));
+    }
+
+    function test_nonceFloor() public view {
+        assertEq(ism.nonceFloors(ORIGIN), FLOOR);
+    }
+
+    function test_verify_rejectsAtFloor() public view {
+        assertFalse(ism.verify("", _message(ORIGIN, FLOOR)));
+    }
+
+    function test_verify_rejectsBelowFloor() public view {
+        assertFalse(ism.verify("", _message(ORIGIN, 0)));
+        assertFalse(ism.verify("", _message(ORIGIN, 1)));
+        assertFalse(ism.verify("", _message(ORIGIN, FLOOR - 1)));
+    }
+
+    function test_verify_acceptsAboveFloor() public view {
+        assertTrue(ism.verify("", _message(ORIGIN, FLOOR + 1)));
+        assertTrue(ism.verify("", _message(ORIGIN, FLOOR + 100)));
+        assertTrue(ism.verify("", _message(ORIGIN, type(uint32).max)));
+    }
+
+    function test_verify_acceptsUnknownOrigin() public view {
+        assertTrue(ism.verify("", _message(OTHER_ORIGIN, 0)));
+        assertTrue(ism.verify("", _message(OTHER_ORIGIN, 1)));
+    }
+
+    function test_constructor_lengthMismatch() public {
+        uint32[] memory origins = new uint32[](1);
+        origins[0] = ORIGIN;
+        uint32[] memory floors = new uint32[](0);
+        vm.expectRevert("length mismatch");
+        new NonceFloorIsm(origins, floors);
+    }
+
+    function test_constructor_zeroFloor() public {
+        uint32[] memory origins = new uint32[](1);
+        origins[0] = 999;
+        uint32[] memory floors = new uint32[](1);
+        floors[0] = 0;
+        vm.expectRevert("floor must be > 0");
+        new NonceFloorIsm(origins, floors);
+    }
+
+    function test_constructor_duplicateOrigin() public {
+        uint32[] memory origins = new uint32[](2);
+        origins[0] = ORIGIN;
+        origins[1] = ORIGIN;
+        uint32[] memory floors = new uint32[](2);
+        floors[0] = 100;
+        floors[1] = 200;
+        vm.expectRevert("floor already set");
+        new NonceFloorIsm(origins, floors);
+    }
+
+    function test_constructor_multipleOrigins() public {
+        uint32[] memory origins = new uint32[](2);
+        origins[0] = ORIGIN;
+        origins[1] = OTHER_ORIGIN;
+        uint32[] memory floors = new uint32[](2);
+        floors[0] = 1092;
+        floors[1] = 500;
+        NonceFloorIsm multi = new NonceFloorIsm(origins, floors);
+
+        assertEq(multi.nonceFloors(ORIGIN), 1092);
+        assertEq(multi.nonceFloors(OTHER_ORIGIN), 500);
+
+        assertFalse(multi.verify("", _message(ORIGIN, 1092)));
+        assertFalse(multi.verify("", _message(OTHER_ORIGIN, 500)));
+
+        assertTrue(multi.verify("", _message(ORIGIN, 1093)));
+        assertTrue(multi.verify("", _message(OTHER_ORIGIN, 501)));
+    }
+
+    function test_constructor_emitsEvents() public {
+        uint32[] memory origins = new uint32[](1);
+        origins[0] = ORIGIN;
+        uint32[] memory floors = new uint32[](1);
+        floors[0] = FLOOR;
+
+        vm.expectEmit(true, false, false, true);
+        emit NonceFloorIsm.NonceFloorSet(ORIGIN, FLOOR);
+        new NonceFloorIsm(origins, floors);
+    }
+
+    function testFuzz_verify(uint32 nonce) public view {
+        if (nonce <= FLOOR) {
+            assertFalse(ism.verify("", _message(ORIGIN, nonce)));
+        } else {
+            assertTrue(ism.verify("", _message(ORIGIN, nonce)));
+        }
+    }
+}

--- a/solidity/test/isms/NonceFloorIsm.t.sol
+++ b/solidity/test/isms/NonceFloorIsm.t.sol
@@ -10,27 +10,18 @@ import {MessageUtils} from "./IsmTestUtils.sol";
 contract NonceFloorIsmTest is Test {
     NonceFloorIsm ism;
 
-    uint32 constant ORIGIN = 1983;
     uint32 constant FLOOR = 1092;
-    uint32 constant OTHER_ORIGIN = 1;
 
     function setUp() public {
-        uint32[] memory origins = new uint32[](1);
-        origins[0] = ORIGIN;
-        uint32[] memory floors = new uint32[](1);
-        floors[0] = FLOOR;
-        ism = new NonceFloorIsm(origins, floors);
+        ism = new NonceFloorIsm(FLOOR);
     }
 
-    function _message(
-        uint32 origin,
-        uint32 nonce
-    ) internal pure returns (bytes memory) {
+    function _message(uint32 nonce) internal pure returns (bytes memory) {
         return
             MessageUtils.formatMessage(
                 0,
                 nonce,
-                origin,
+                0,
                 bytes32(0),
                 0,
                 bytes32(0),
@@ -43,93 +34,35 @@ contract NonceFloorIsmTest is Test {
     }
 
     function test_nonceFloor() public view {
-        assertEq(ism.nonceFloors(ORIGIN), FLOOR);
+        assertEq(ism.nonceFloor(), FLOOR);
     }
 
     function test_verify_rejectsAtFloor() public view {
-        assertFalse(ism.verify("", _message(ORIGIN, FLOOR)));
+        assertFalse(ism.verify("", _message(FLOOR)));
     }
 
     function test_verify_rejectsBelowFloor() public view {
-        assertFalse(ism.verify("", _message(ORIGIN, 0)));
-        assertFalse(ism.verify("", _message(ORIGIN, 1)));
-        assertFalse(ism.verify("", _message(ORIGIN, FLOOR - 1)));
+        assertFalse(ism.verify("", _message(0)));
+        assertFalse(ism.verify("", _message(1)));
+        assertFalse(ism.verify("", _message(FLOOR - 1)));
     }
 
     function test_verify_acceptsAboveFloor() public view {
-        assertTrue(ism.verify("", _message(ORIGIN, FLOOR + 1)));
-        assertTrue(ism.verify("", _message(ORIGIN, FLOOR + 100)));
-        assertTrue(ism.verify("", _message(ORIGIN, type(uint32).max)));
-    }
-
-    function test_verify_acceptsUnknownOrigin() public view {
-        assertTrue(ism.verify("", _message(OTHER_ORIGIN, 0)));
-        assertTrue(ism.verify("", _message(OTHER_ORIGIN, 1)));
-    }
-
-    function test_constructor_lengthMismatch() public {
-        uint32[] memory origins = new uint32[](1);
-        origins[0] = ORIGIN;
-        uint32[] memory floors = new uint32[](0);
-        vm.expectRevert("length mismatch");
-        new NonceFloorIsm(origins, floors);
+        assertTrue(ism.verify("", _message(FLOOR + 1)));
+        assertTrue(ism.verify("", _message(FLOOR + 100)));
+        assertTrue(ism.verify("", _message(type(uint32).max)));
     }
 
     function test_constructor_zeroFloor() public {
-        uint32[] memory origins = new uint32[](1);
-        origins[0] = 999;
-        uint32[] memory floors = new uint32[](1);
-        floors[0] = 0;
         vm.expectRevert("floor must be > 0");
-        new NonceFloorIsm(origins, floors);
-    }
-
-    function test_constructor_duplicateOrigin() public {
-        uint32[] memory origins = new uint32[](2);
-        origins[0] = ORIGIN;
-        origins[1] = ORIGIN;
-        uint32[] memory floors = new uint32[](2);
-        floors[0] = 100;
-        floors[1] = 200;
-        vm.expectRevert("floor already set");
-        new NonceFloorIsm(origins, floors);
-    }
-
-    function test_constructor_multipleOrigins() public {
-        uint32[] memory origins = new uint32[](2);
-        origins[0] = ORIGIN;
-        origins[1] = OTHER_ORIGIN;
-        uint32[] memory floors = new uint32[](2);
-        floors[0] = 1092;
-        floors[1] = 500;
-        NonceFloorIsm multi = new NonceFloorIsm(origins, floors);
-
-        assertEq(multi.nonceFloors(ORIGIN), 1092);
-        assertEq(multi.nonceFloors(OTHER_ORIGIN), 500);
-
-        assertFalse(multi.verify("", _message(ORIGIN, 1092)));
-        assertFalse(multi.verify("", _message(OTHER_ORIGIN, 500)));
-
-        assertTrue(multi.verify("", _message(ORIGIN, 1093)));
-        assertTrue(multi.verify("", _message(OTHER_ORIGIN, 501)));
-    }
-
-    function test_constructor_emitsEvents() public {
-        uint32[] memory origins = new uint32[](1);
-        origins[0] = ORIGIN;
-        uint32[] memory floors = new uint32[](1);
-        floors[0] = FLOOR;
-
-        vm.expectEmit(true, false, false, true);
-        emit NonceFloorIsm.NonceFloorSet(ORIGIN, FLOOR);
-        new NonceFloorIsm(origins, floors);
+        new NonceFloorIsm(0);
     }
 
     function testFuzz_verify(uint32 nonce) public view {
         if (nonce <= FLOOR) {
-            assertFalse(ism.verify("", _message(ORIGIN, nonce)));
+            assertFalse(ism.verify("", _message(nonce)));
         } else {
-            assertTrue(ism.verify("", _message(ORIGIN, nonce)));
+            assertTrue(ism.verify("", _message(nonce)));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Added `NonceFloorIsm` — a minimal, immutable ISM that rejects messages with `nonce <= nonceFloor`
- Single `immutable uint32` constructor parameter — no storage reads, no owner, no mutability
- NULL module type — scope to specific origins by composing with `DomainRoutingIsm`
- Designed to permanently block reorged/replayed messages after a chain reorganization

## Motivation
After a deep chain reorg, the Mailbox's merkle tree contains new message IDs for the same logical transactions. Validators must attest to the full tree (they cannot skip leaves), so these reorged messages become provable and deliverable — creating double-spend risk for warp routes.

`NonceFloorIsm` blocks delivery of all messages at or below a nonce threshold. Since reorgs affect contiguous nonce ranges and messages in that range have typically already been delivered (so `Mailbox.delivered()` blocks the unchanged ones anyway), a simple floor is sufficient.

## Usage
```solidity
// Deploy: reject all messages with nonce <= 1092
NonceFloorIsm ism = new NonceFloorIsm(1092);

// Compose via DomainRoutingIsm to scope to a specific origin:
// origin 1983 → AggregationISM(MultisigISM, NonceFloorIsm{1092})
// all others  → MultisigISM (unchanged)
```

## Test plan
- [x] Forge tests pass: `forge test --match-contract NonceFloorIsmTest` (7/7)
- [x] Messages at floor are rejected
- [x] Messages below floor are rejected
- [x] Messages above floor are accepted
- [x] Constructor rejects zero floor
- [x] Fuzz test across full uint32 nonce range

🤖 Generated with [Claude Code](https://claude.com/claude-code)