### PR TITLE
feat: expand USDT/oft warp route to polygon, optimism, mantle, monad

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTOftWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTOftWarpConfig.ts
@@ -7,6 +7,7 @@ import {
 import { awIcas } from '../../governance/ica/aw.js';
 import { awSafes } from '../../governance/safe/aw.js';
 
+// USDT0 deployment docs: https://docs.usdt0.to/technical-documentation/deployments
 const deploymentChains = [
   'ethereum',
   'arbitrum',
@@ -19,6 +20,7 @@ const deploymentChains = [
 
 export type DeploymentChain = (typeof deploymentChains)[number];
 
+// LayerZero V2 endpoint IDs: https://docs.layerzero.network/v2/developers/evm/technical-reference/deployed-contracts
 const lzEids: Record<DeploymentChain, number> = {
   ethereum: 30101,
   arbitrum: 30110,
@@ -29,6 +31,7 @@ const lzEids: Record<DeploymentChain, number> = {
   monad: 30390,
 };
 
+// OFT/OFT Adapter addresses from https://docs.usdt0.to/technical-documentation/deployments
 const oftAddresses: Record<DeploymentChain, string> = {
   ethereum: '0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee',
   arbitrum: '0x14E4A1B13bf7F943c8ff7C51fb60FA964A298D92',

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTOftWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTOftWarpConfig.ts
@@ -42,15 +42,16 @@ const oftAddresses: Record<DeploymentChain, string> = {
   monad: '0x9151434b16b9763660705744891fA906F660EcC5',
 };
 
-// USDT0 is a separate token from original USDT on optimism, mantle, and monad
+// USDT0 is a separate token from original USDT on optimism, mantle, and monad.
+// On ethereum, arbitrum, plasma, and polygon the original USDT was upgraded in-place.
 const tokenAddresses: Record<DeploymentChain, string> = {
   ethereum: tokens.ethereum.USDT,
   arbitrum: tokens.arbitrum.USDT,
   plasma: tokens.plasma.USDT,
   polygon: tokens.polygon.USDT,
-  optimism: '0x01bFF41798a0BcF287b996046Ca68b395DbC1071',
-  mantle: '0x779Ded0c9e1022225f8E0630b35a9b54bE713736',
-  monad: '0xe7cd86e13AC4309349F30B3435a9d337750fC82D',
+  optimism: tokens.optimism.USDT0,
+  mantle: tokens.mantle.USDT0,
+  monad: tokens.monad.USDT0,
 };
 
 const ownersByChain: Record<DeploymentChain, string> = {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTOftWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTOftWarpConfig.ts
@@ -7,7 +7,15 @@ import {
 import { awIcas } from '../../governance/ica/aw.js';
 import { awSafes } from '../../governance/safe/aw.js';
 
-const deploymentChains = ['ethereum', 'arbitrum', 'plasma'] as const;
+const deploymentChains = [
+  'ethereum',
+  'arbitrum',
+  'plasma',
+  'polygon',
+  'optimism',
+  'mantle',
+  'monad',
+] as const;
 
 export type DeploymentChain = (typeof deploymentChains)[number];
 
@@ -15,12 +23,31 @@ const lzEids: Record<DeploymentChain, number> = {
   ethereum: 30101,
   arbitrum: 30110,
   plasma: 30383,
+  polygon: 30109,
+  optimism: 30111,
+  mantle: 30181,
+  monad: 30390,
 };
 
 const oftAddresses: Record<DeploymentChain, string> = {
   ethereum: '0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee',
   arbitrum: '0x14E4A1B13bf7F943c8ff7C51fb60FA964A298D92',
   plasma: '0x02ca37966753bDdDf11216B73B16C1dE756A7CF9',
+  polygon: '0x6BA10300f0DC58B7a1e4c0e41f5daBb7D7829e13',
+  optimism: '0xF03b4d9AC1D5d1E7c4cEf54C2A313b9fe051A0aD',
+  mantle: '0xcb768e263FB1C62214E7cab4AA8d036D76dc59CC',
+  monad: '0x9151434b16b9763660705744891fA906F660EcC5',
+};
+
+// USDT0 is a separate token from original USDT on optimism, mantle, and monad
+const tokenAddresses: Record<DeploymentChain, string> = {
+  ethereum: tokens.ethereum.USDT,
+  arbitrum: tokens.arbitrum.USDT,
+  plasma: tokens.plasma.USDT,
+  polygon: tokens.polygon.USDT,
+  optimism: '0x01bFF41798a0BcF287b996046Ca68b395DbC1071',
+  mantle: '0x779Ded0c9e1022225f8E0630b35a9b54bE713736',
+  monad: '0xe7cd86e13AC4309349F30B3435a9d337750fC82D',
 };
 
 const ownersByChain: Record<DeploymentChain, string> = {
@@ -28,6 +55,11 @@ const ownersByChain: Record<DeploymentChain, string> = {
   // arbitrum stays inline until awIcas.arbitrum is exported again in aw.ts
   arbitrum: '0xD2757Bbc28C80789Ed679f22Ac65597Cacf51A45',
   plasma: awIcas.plasma,
+  polygon: awIcas.polygon,
+  // optimism stays inline until awIcas.optimism is exported again in aw.ts
+  optimism: '0x1E2afA8d1B841c53eDe9474D188Cd4FcfEd40dDC',
+  mantle: awIcas.mantle,
+  monad: awIcas.monad,
 };
 
 export const getUSDTOftWarpConfig = async (
@@ -40,7 +72,7 @@ export const getUSDTOftWarpConfig = async (
         ...routerConfig[chain],
         owner: ownersByChain[chain],
         type: TokenType.collateralOft,
-        token: tokens[chain].USDT,
+        token: tokenAddresses[chain],
         oft: oftAddresses[chain],
         decimals: 6,
         name: 'Tether USD',

--- a/typescript/infra/src/config/warp.ts
+++ b/typescript/infra/src/config/warp.ts
@@ -54,6 +54,7 @@ export const tokens = {
   },
   mantle: {
     USDT: '0x201EBa5CC46D216Ce6DC03F6a759e8E766e956aE',
+    USDT0: '0x779Ded0c9e1022225f8E0630b35a9b54bE713736',
     WETH: '0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111',
   },
   mode: {
@@ -70,6 +71,7 @@ export const tokens = {
   optimism: {
     USDC: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
     USDT: '0x94b008aA00579c1307B0EF2c499aD98a8ce58e58',
+    USDT0: '0x01bFF41798a0BcF287b996046Ca68b395DbC1071',
     OP: '0x4200000000000000000000000000000000000042',
   },
   gnosis: {
@@ -91,6 +93,9 @@ export const tokens = {
   },
   tron: {
     USDT: '0xa614f803b6fd780986a42c78ec9c7f77e6ded13c', // converted from TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t
+  },
+  monad: {
+    USDT0: '0xe7cd86e13AC4309349F30B3435a9d337750fC82D',
   },
 };
 


### PR DESCRIPTION
## Summary
- Adds 4 new chains to the USDT/oft TokenBridgeOft warp route config: Polygon, Optimism, Mantle, Monad
- All OFT contracts verified on-chain with `oftVersion() = (0x02e49c2c, 1)` (OFTv2)
- Added explicit `tokenAddresses` map since USDT0 is a separate token (not an upgrade of original USDT) on Optimism, Mantle, and Monad

### New chains

| Chain | LZ EID | OFT Address | Token (USDT0) | Type |
|-------|--------|-------------|---------------|------|
| Polygon | 30109 | `0x6BA10300f0DC58B7a1e4c0e41f5daBb7D7829e13` | `0xc2132D05D31c914a87C6611C10748AEb04B58e8F` | OFT Adapter |
| Optimism | 30111 | `0xF03b4d9AC1D5d1E7c4cEf54C2A313b9fe051A0aD` | `0x01bFF41798a0BcF287b996046Ca68b395DbC1071` | OFT Adapter |
| Mantle | 30181 | `0xcb768e263FB1C62214E7cab4AA8d036D76dc59CC` | `0x779Ded0c9e1022225f8E0630b35a9b54bE713736` | OFT Adapter |
| Monad | 30390 | `0x9151434b16b9763660705744891fA906F660EcC5` | `0xe7cd86e13AC4309349F30B3435a9d337750fC82D` | Native OFT |

### Owners
- Polygon: `awIcas.polygon`
- Optimism: inline ICA `0x1E2afA8d1B841c53eDe9474D188Cd4FcfEd40dDC` (same pattern as arbitrum)
- Mantle: `awIcas.mantle`
- Monad: `awIcas.monad`

## Test plan
- [ ] Verify TypeScript compilation passes
- [ ] Deploy TokenBridgeOft contracts on new chains via `warp deploy`
- [ ] Register deployed addresses in hyperlane-registry
- [ ] Verify domain mappings are correctly configured post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)