### PR TITLE
fix(aleo-sdk): make aleo deployments resilient to explorer/rpc api flakiness

### DIFF
--- a/.changeset/aleo-deploy-resilience.md
+++ b/.changeset/aleo-deploy-resilience.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/aleo-sdk': patch
+---
+
+Aleo deployments were made resilient to transient explorer 5xx during program-import fetches inside snarkVM, and to the propagation lag between tx confirmation and /program/<id> readability.

--- a/typescript/aleo-sdk/src/clients/signer.ts
+++ b/typescript/aleo-sdk/src/clients/signer.ts
@@ -1,9 +1,12 @@
 import { type AltVM } from '@hyperlane-xyz/provider-sdk';
 import { TokenType } from '@hyperlane-xyz/provider-sdk/warp';
-import { assert, isNullish, retryAsync } from '@hyperlane-xyz/utils';
+import { assert, isNullish, retryAsync, sleep } from '@hyperlane-xyz/utils';
 
 import { type AleoProgram } from '../artifacts.js';
+import { withAleoFetchRetry } from '../utils/fetch-retry.js';
 import {
+  PROGRAM_AVAILABILITY_MAX_ATTEMPTS,
+  PROGRAM_AVAILABILITY_POLL_INTERVAL_MS,
   RETRY_ATTEMPTS,
   RETRY_DELAY_MS,
   SUFFIX_LENGTH_LONG,
@@ -86,6 +89,59 @@ export class AleoSigner
     );
   }
 
+  // Poll /program/<id> directly via the SDK's host so we can react to the
+  // actual HTTP status code instead of pattern-matching SDK error messages
+  // (which are wrapped through several layers and not part of any stable
+  // contract). 404 = not visible yet (retry); any other non-OK = real
+  // failure (surface immediately).
+  private async waitForProgramVisibility(
+    programId: string,
+    txId: string,
+  ): Promise<void> {
+    assert(
+      typeof globalThis.fetch === 'function',
+      'Program visibility polling requires globalThis.fetch',
+    );
+
+    const url = `${this.aleoClient.host}/program/${programId}`;
+    let lastError: unknown;
+
+    for (let i = 0; i < PROGRAM_AVAILABILITY_MAX_ATTEMPTS; i++) {
+      let res: Response;
+      try {
+        res = await withAleoFetchRetry(() => fetch(url));
+      } catch (err) {
+        // Transient network error on an idempotent GET — retry.
+        lastError = err;
+        await sleep(PROGRAM_AVAILABILITY_POLL_INTERVAL_MS);
+        continue;
+      }
+
+      if (res.ok) return;
+
+      if (res.status === 404) {
+        lastError = new Error(`Program ${programId} not yet at ${url}`);
+        await sleep(PROGRAM_AVAILABILITY_POLL_INTERVAL_MS);
+        continue;
+      }
+
+      // Any other status (auth, server error after GET retries, etc.) is a
+      // real failure — surface it without burning the full poll budget.
+      const body = await res.text().catch(() => '<unreadable body>');
+      throw new Error(
+        `Unexpected ${res.status} from ${url} while waiting for program ` +
+          `visibility after tx ${txId}: ${body}`,
+      );
+    }
+
+    const detail =
+      lastError instanceof Error ? lastError.message : String(lastError);
+    throw new Error(
+      `Program ${programId} not visible at ${url} after tx ${txId} ` +
+        `(${PROGRAM_AVAILABILITY_MAX_ATTEMPTS} attempts): ${detail}`,
+    );
+  }
+
   async getWarpTokenSuffix(
     tokenType: TokenType,
     preferredSuffix?: string,
@@ -141,25 +197,38 @@ export class AleoSigner
       }
 
       try {
+        // buildDeploymentTransaction runs snarkVM in WASM and fetches each
+        // imported program (/program/<id>) via globalThis.fetch. Explorer
+        // nodes return transient 5xx; wrap fetch for the duration of the
+        // build so those reads retry instead of aborting after the proofs.
         const tx = this.skipProofs
           ? await this.programManager.buildDevnodeDeploymentTransaction({
               program,
               priorityFee: 0,
               privateFee: false,
             })
-          : await this.programManager.buildDeploymentTransaction(
-              program,
-              0,
-              false,
-              undefined,
-              undefined,
-              undefined,
+          : await withAleoFetchRetry(() =>
+              this.programManager.buildDeploymentTransaction(
+                program,
+                0,
+                false,
+                undefined,
+                undefined,
+                undefined,
+              ),
             );
 
+        // Broadcast is not idempotent — do not retry.
         const txId =
           await this.programManager.networkClient.submitTransaction(tx);
 
         await this.aleoClient.waitForTransactionConfirmation(txId);
+
+        // /transaction/confirmed/<txId> can flip to accepted before
+        // /program/<id> is readable. Subsequent steps (e.g. buildExecutionTx
+        // during init) fetch the program from the explorer and 404. Poll
+        // until the program is visible before returning.
+        await this.waitForProgramVisibility(id, txId);
       } catch (err) {
         if (this.isProgramAlreadyExistsError(err, id)) {
           continue;

--- a/typescript/aleo-sdk/src/utils/fetch-retry.ts
+++ b/typescript/aleo-sdk/src/utils/fetch-retry.ts
@@ -1,0 +1,122 @@
+import { sleep } from '@hyperlane-xyz/utils';
+
+import { RETRY_ATTEMPTS, RETRY_DELAY_MS } from './helper.js';
+
+// The @provablehq/sdk runs snarkVM in WASM, which calls globalThis.fetch to
+// load each imported program (/program/<id>) during buildDeploymentTransaction.
+// Aleo explorer nodes return transient 5xx / connection-reset errors, and a
+// single failure aborts the deploy after expensive local proof work.
+//
+// We can't intercept those WASM-internal calls any other way, but globally
+// patching fetch has a wide blast radius (read-only providers, unrelated
+// caller code, non-idempotent POSTs amplified by other retry layers). So this
+// helper wraps the patch in a try/finally scope and only retries idempotent
+// reads (GET/HEAD) on transient failures.
+//
+let fetchRetryLock: Promise<void> = Promise.resolve();
+
+export interface FetchRetryOptions {
+  attempts?: number;
+  baseDelayMs?: number;
+  shouldRetryResponse?: (
+    res: Response,
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => boolean;
+  shouldRetryError?: (
+    err: unknown,
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => boolean;
+}
+
+function getMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  if (init?.method) return init.method.toUpperCase();
+  if (typeof input === 'object' && 'method' in input) {
+    return input.method.toUpperCase();
+  }
+  return 'GET';
+}
+
+function isIdempotent(input: RequestInfo | URL, init?: RequestInit): boolean {
+  const method = getMethod(input, init);
+  return method === 'GET' || method === 'HEAD';
+}
+
+function defaultShouldRetryResponse(
+  res: Response,
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): boolean {
+  if (!isIdempotent(input, init)) return false;
+  return res.status >= 500 && res.status < 600;
+}
+
+function defaultShouldRetryError(
+  err: unknown,
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): boolean {
+  if (err instanceof Error && err.name === 'AbortError') return false;
+  // Only retry network errors on idempotent reads. A POST that errors
+  // may have already been received by the server; resubmitting risks
+  // duplicate broadcasts or "already seen" rejections.
+  return isIdempotent(input, init);
+}
+
+export async function withAleoFetchRetry<T>(
+  callback: () => Promise<T>,
+  options: FetchRetryOptions = {},
+): Promise<T> {
+  let releaseLock!: () => void;
+  const previousLock = fetchRetryLock;
+  fetchRetryLock = new Promise<void>((resolve) => {
+    releaseLock = resolve;
+  });
+  await previousLock;
+
+  if (typeof globalThis.fetch !== 'function') {
+    releaseLock();
+    throw new Error('withAleoFetchRetry requires globalThis.fetch');
+  }
+
+  try {
+    const {
+      attempts = RETRY_ATTEMPTS,
+      baseDelayMs = RETRY_DELAY_MS,
+      shouldRetryResponse = defaultShouldRetryResponse,
+      shouldRetryError = defaultShouldRetryError,
+    } = options;
+
+    const originalFetch = globalThis.fetch.bind(globalThis);
+
+    globalThis.fetch = async (input, init) => {
+      let lastErr: unknown;
+      for (let i = 0; i < attempts; i++) {
+        try {
+          const res = await originalFetch(input, init);
+          if (shouldRetryResponse(res, input, init) && i < attempts - 1) {
+            await sleep(baseDelayMs * 2 ** i);
+            continue;
+          }
+          return res;
+        } catch (err) {
+          lastErr = err;
+          if (!shouldRetryError(err, input, init) || i === attempts - 1) {
+            throw err;
+          }
+          await sleep(baseDelayMs * 2 ** i);
+        }
+      }
+      throw lastErr;
+    };
+
+    try {
+      return await callback();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  } finally {
+    releaseLock();
+  }
+}

--- a/typescript/aleo-sdk/src/utils/helper.ts
+++ b/typescript/aleo-sdk/src/utils/helper.ts
@@ -32,6 +32,11 @@ export function getNetworkPrefix(aleoNetworkId: AleoNetworkId): string {
 export const RETRY_ATTEMPTS = 10;
 export const RETRY_DELAY_MS = 100;
 
+// After a deployment tx is confirmed, /program/<id> can take additional
+// seconds to become readable. Poll with generous patience (3min total).
+export const PROGRAM_AVAILABILITY_POLL_INTERVAL_MS = 3_000;
+export const PROGRAM_AVAILABILITY_MAX_ATTEMPTS = 60;
+
 export const SUFFIX_LENGTH_LONG = 6;
 export const SUFFIX_LENGTH_SHORT = 3;
 


### PR DESCRIPTION
### Description

  Make Aleo deployments resilient to two failure modes observed on Aleo testnet:

  1. **Transient 5xx during program-import fetches.** `@provablehq/sdk` runs snarkVM in WASM and calls `globalThis.fetch` to load each imported program (`/program/<id>`) inside `buildDeploymentTransaction`. A single transient 5xx from the
  explorer aborted the deploy after expensive local proof work.
  2. **Propagation lag between tx confirmation and program readability.** After `waitForTransactionConfirmation` reports `accepted`, `/program/<id>` can still 404 for several seconds, so the next step (e.g. `buildExecutionTransaction` for
  the init tx) fails with "is neither a program name or a valid program".

  Changes (all in `typescript/aleo-sdk`):

  - New `withAleoFetchRetry(callback, options?)` in `src/utils/fetch-retry.ts`:
    - Saves and restores `globalThis.fetch` in `try/finally`; the patch lives only for the duration of `callback`.
    - Serialises overlapping invocations via an async lock so concurrent callers don't lose the `originalFetch` reference.
    - Only retries idempotent reads — `defaultShouldRetryResponse` retries `GET`/`HEAD` on 5xx; `defaultShouldRetryError` retries network errors on `GET`/`HEAD` only and never on `AbortError`.
    - Throws a clear error if `globalThis.fetch` is missing (Node 16 without polyfill).
  - `deployProgram` (`src/clients/signer.ts`): wraps only `buildDeploymentTransaction` with `withAleoFetchRetry`. `submitTransaction` is intentionally **not** retried — broadcast is non-idempotent.
  - New `waitForProgramVisibility(programId, txId)`: after `waitForTransactionConfirmation`, polls `${aleoClient.host}/program/<id>` directly via `fetch` (wrapped in `withAleoFetchRetry` for 5xx tolerance). Reacts on the actual HTTP status
   code: 404 → keep polling (up to 3 min); any other non-OK → surface immediately so root causes (auth, server faults) aren't masked as "program not visible".
  - New constants `PROGRAM_AVAILABILITY_POLL_INTERVAL_MS` (3s) and `PROGRAM_AVAILABILITY_MAX_ATTEMPTS` (60) in `src/utils/helper.ts`.

  ### Drive-by changes

  None.

  ### Related issues

  None.

  ### Backward compatibility

  Yes. Strictly additive — no public API or behavior changes for callers. Existing successful deploys go through the same code path with extra tolerance for transient explorer failures and post-confirmation lag.

  ### Testing

  Manual + e2e:

  - `pnpm -C typescript/aleo-sdk test:e2e` with `ALEO_SDK_E2E_TEST=7c_warp_synthetic_artifacts` — 20/20 passing (run twice — once after initial refactor, once after concurrency-lock follow-up).
  - Manual repro: the originally failing testnet deploy (`Failed to deployProgram(hyp_synthetic) ... error sending request` and the follow-up `Failed to initialize synthetic warp token program ... 404`) completes end-to-end with these
  changes.