### PR TITLE
feat: add BlacklistIsm for per-message-ID blocking

### DIFF
--- a/.changeset/black-tips-jam.md
+++ b/.changeset/black-tips-jam.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": minor
+---
+
+The Blacklist ISM contract is added to support owner-controlled message ID blocking.

--- a/.changeset/black-tips-jam.md
+++ b/.changeset/black-tips-jam.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/core": minor
 ---
 
-The Blacklist ISM contract is added to support owner-controlled message ID blocking.
+The Blacklist ISM contract is added to support owner-controlled message ID blocking. Blacklisted IDs are stored in an enumerable set, exposing a `values()` getter so the full blacklist can be read on-chain and off-chain. Entries are append-only and permanent.

--- a/solidity/contracts/isms/BlacklistIsm.sol
+++ b/solidity/contracts/isms/BlacklistIsm.sol
@@ -21,7 +21,7 @@ contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
     uint8 public constant override moduleType = uint8(Types.NULL);
 
     /// @notice message ID => true if blacklisted
-    mapping(bytes32 => bool) public blacklistedIds;
+    mapping(bytes32 messageId => bool isBlacklisted) public blacklistedIds;
 
     event MessageBlacklisted(bytes32 indexed messageId);
     event MessageWhitelisted(bytes32 indexed messageId);

--- a/solidity/contracts/isms/BlacklistIsm.sol
+++ b/solidity/contracts/isms/BlacklistIsm.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+// ============ Internal Imports ============
+import {IInterchainSecurityModule} from "../interfaces/IInterchainSecurityModule.sol";
+import {Message} from "../libs/Message.sol";
+import {PackageVersioned} from "../PackageVersioned.sol";
+
+// ============ External Imports ============
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title BlacklistIsm
+ * @notice Rejects messages whose ID is blacklisted.
+ * Provides per-message-ID granularity for blocking reorged or malicious messages.
+ * For bulk nonce-range blocking, prefer NonceFloorIsm composed with DomainRoutingIsm.
+ */
+contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
+    using Message for bytes;
+
+    uint8 public constant override moduleType = uint8(Types.NULL);
+
+    /// @notice message ID => true if blacklisted
+    mapping(bytes32 => bool) public blacklistedIds;
+
+    event MessageBlacklisted(bytes32 indexed messageId);
+    event MessageWhitelisted(bytes32 indexed messageId);
+
+    constructor(address _owner) Ownable() {
+        _transferOwnership(_owner);
+    }
+
+    /// @notice Blacklist a batch of message IDs
+    function blacklist(bytes32[] calldata _ids) external onlyOwner {
+        for (uint256 i = 0; i < _ids.length; i++) {
+            blacklistedIds[_ids[i]] = true;
+            emit MessageBlacklisted(_ids[i]);
+        }
+    }
+
+    /// @notice Remove message IDs from the blacklist
+    function whitelist(bytes32[] calldata _ids) external onlyOwner {
+        for (uint256 i = 0; i < _ids.length; i++) {
+            delete blacklistedIds[_ids[i]];
+            emit MessageWhitelisted(_ids[i]);
+        }
+    }
+
+    /// @inheritdoc IInterchainSecurityModule
+    function verify(
+        bytes calldata,
+        bytes calldata _message
+    ) external view returns (bool) {
+        return !blacklistedIds[_message.id()];
+    }
+}

--- a/solidity/contracts/isms/BlacklistIsm.sol
+++ b/solidity/contracts/isms/BlacklistIsm.sol
@@ -8,22 +8,25 @@ import {PackageVersioned} from "../PackageVersioned.sol";
 
 // ============ External Imports ============
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 /**
  * @title BlacklistIsm
  * @notice Rejects messages whose ID is blacklisted.
  * Provides per-message-ID granularity for blocking reorged or malicious messages.
  * For bulk nonce-range blocking, prefer NonceFloorIsm composed with DomainRoutingIsm.
- * @dev Append-only: entries are permanent and cannot be removed. Compose with
- * `DomainRoutingIsm` to swap modules if recovery is needed.
+ * @dev Append-only: entries are permanent and cannot be removed. There is no
+ * removal path by design. Compose with `DomainRoutingIsm` to swap modules if
+ * recovery is needed.
  */
 contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
     using Message for bytes;
+    using EnumerableSet for EnumerableSet.Bytes32Set;
 
     uint8 public constant override moduleType = uint8(Types.NULL);
 
-    /// @notice message ID => true if blacklisted
-    mapping(bytes32 messageId => bool isBlacklisted) public blacklistedIds;
+    /// @notice Set of blacklisted message IDs (append-only).
+    EnumerableSet.Bytes32Set private _blacklistedIds;
 
     event MessageBlacklisted(bytes32 indexed messageId);
 
@@ -31,12 +34,26 @@ contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
         _transferOwnership(_owner);
     }
 
-    /// @notice Blacklist a batch of message IDs
+    /**
+     * @notice Blacklist a batch of message IDs.
+     * @dev Entries are permanent; there is no removal path by design.
+     */
     function blacklist(bytes32[] calldata _ids) external onlyOwner {
         for (uint256 i = 0; i < _ids.length; i++) {
-            blacklistedIds[_ids[i]] = true;
-            emit MessageBlacklisted(_ids[i]);
+            if (_blacklistedIds.add(_ids[i])) {
+                emit MessageBlacklisted(_ids[i]);
+            }
         }
+    }
+
+    /// @notice Returns true if the message ID is blacklisted.
+    function blacklistedIds(bytes32 _id) external view returns (bool) {
+        return _blacklistedIds.contains(_id);
+    }
+
+    /// @notice Returns all blacklisted message IDs, enabling off-chain enumeration.
+    function values() external view returns (bytes32[] memory) {
+        return _blacklistedIds.values();
     }
 
     /// @inheritdoc IInterchainSecurityModule
@@ -44,6 +61,6 @@ contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
         bytes calldata,
         bytes calldata _message
     ) external view returns (bool) {
-        return !blacklistedIds[_message.id()];
+        return !_blacklistedIds.contains(_message.id());
     }
 }

--- a/solidity/contracts/isms/BlacklistIsm.sol
+++ b/solidity/contracts/isms/BlacklistIsm.sol
@@ -24,7 +24,6 @@ contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
     mapping(bytes32 messageId => bool isBlacklisted) public blacklistedIds;
 
     event MessageBlacklisted(bytes32 indexed messageId);
-    event MessageWhitelisted(bytes32 indexed messageId);
 
     constructor(address _owner) Ownable() {
         _transferOwnership(_owner);
@@ -35,14 +34,6 @@ contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
         for (uint256 i = 0; i < _ids.length; i++) {
             blacklistedIds[_ids[i]] = true;
             emit MessageBlacklisted(_ids[i]);
-        }
-    }
-
-    /// @notice Remove message IDs from the blacklist
-    function whitelist(bytes32[] calldata _ids) external onlyOwner {
-        for (uint256 i = 0; i < _ids.length; i++) {
-            delete blacklistedIds[_ids[i]];
-            emit MessageWhitelisted(_ids[i]);
         }
     }
 

--- a/solidity/contracts/isms/BlacklistIsm.sol
+++ b/solidity/contracts/isms/BlacklistIsm.sol
@@ -14,6 +14,8 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
  * @notice Rejects messages whose ID is blacklisted.
  * Provides per-message-ID granularity for blocking reorged or malicious messages.
  * For bulk nonce-range blocking, prefer NonceFloorIsm composed with DomainRoutingIsm.
+ * @dev Append-only: entries are permanent and cannot be removed. Compose with
+ * `DomainRoutingIsm` to swap modules if recovery is needed.
  */
 contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
     using Message for bytes;

--- a/solidity/test/isms/BlacklistIsm.t.sol
+++ b/solidity/test/isms/BlacklistIsm.t.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT or Apache-2.0
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {BlacklistIsm} from "../../contracts/isms/BlacklistIsm.sol";
+import {IInterchainSecurityModule} from "../../contracts/interfaces/IInterchainSecurityModule.sol";
+import {MessageUtils} from "./IsmTestUtils.sol";
+
+contract BlacklistIsmTest is Test {
+    BlacklistIsm ism;
+
+    address owner;
+    bytes testMessage;
+    bytes32 testMessageId;
+
+    function setUp() public {
+        owner = msg.sender;
+        ism = new BlacklistIsm(owner);
+        testMessage = MessageUtils.formatMessage(
+            0,
+            42,
+            1983,
+            bytes32(0),
+            1,
+            bytes32(0),
+            ""
+        );
+        testMessageId = keccak256(testMessage);
+    }
+
+    function test_moduleType() public view {
+        assertEq(ism.moduleType(), uint8(IInterchainSecurityModule.Types.NULL));
+    }
+
+    function test_verify_acceptsByDefault() public view {
+        assertTrue(ism.verify("", testMessage));
+    }
+
+    function test_verify_rejectsBlacklisted() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+        vm.prank(owner);
+        ism.blacklist(ids);
+
+        assertFalse(ism.verify("", testMessage));
+    }
+
+    function test_verify_acceptsAfterWhitelist() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+
+        vm.prank(owner);
+        ism.blacklist(ids);
+        assertFalse(ism.verify("", testMessage));
+
+        vm.prank(owner);
+        ism.whitelist(ids);
+        assertTrue(ism.verify("", testMessage));
+    }
+
+    function test_blacklist_onlyOwner() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+        vm.expectRevert("Ownable: caller is not the owner");
+        ism.blacklist(ids);
+    }
+
+    function test_whitelist_onlyOwner() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+        vm.expectRevert("Ownable: caller is not the owner");
+        ism.whitelist(ids);
+    }
+
+    function test_blacklist_batch() public {
+        bytes memory msg1 = MessageUtils.formatMessage(
+            0,
+            1,
+            1983,
+            bytes32(0),
+            1,
+            bytes32(0),
+            ""
+        );
+        bytes memory msg2 = MessageUtils.formatMessage(
+            0,
+            2,
+            1983,
+            bytes32(0),
+            1,
+            bytes32(0),
+            ""
+        );
+        bytes memory msg3 = MessageUtils.formatMessage(
+            0,
+            3,
+            1983,
+            bytes32(0),
+            1,
+            bytes32(0),
+            ""
+        );
+
+        bytes32[] memory ids = new bytes32[](2);
+        ids[0] = keccak256(msg1);
+        ids[1] = keccak256(msg2);
+
+        vm.prank(owner);
+        ism.blacklist(ids);
+
+        assertFalse(ism.verify("", msg1));
+        assertFalse(ism.verify("", msg2));
+        assertTrue(ism.verify("", msg3));
+    }
+
+    function test_blacklist_emitsEvents() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+
+        vm.expectEmit(true, false, false, false);
+        emit BlacklistIsm.MessageBlacklisted(testMessageId);
+        vm.prank(owner);
+        ism.blacklist(ids);
+    }
+
+    function test_whitelist_emitsEvents() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+
+        vm.prank(owner);
+        ism.blacklist(ids);
+
+        vm.expectEmit(true, false, false, false);
+        emit BlacklistIsm.MessageWhitelisted(testMessageId);
+        vm.prank(owner);
+        ism.whitelist(ids);
+    }
+
+    function test_verify_nonBlacklistedUnaffected() public {
+        bytes memory otherMessage = MessageUtils.formatMessage(
+            0,
+            999,
+            1,
+            bytes32(0),
+            1,
+            bytes32(0),
+            ""
+        );
+
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+        vm.prank(owner);
+        ism.blacklist(ids);
+
+        assertFalse(ism.verify("", testMessage));
+        assertTrue(ism.verify("", otherMessage));
+    }
+
+    function testFuzz_verify(bytes32 messageId) public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+        vm.prank(owner);
+        ism.blacklist(ids);
+
+        assertTrue(ism.blacklistedIds(testMessageId));
+        if (messageId == testMessageId) {
+            assertTrue(ism.blacklistedIds(messageId));
+        } else {
+            assertFalse(ism.blacklistedIds(messageId));
+        }
+    }
+}

--- a/solidity/test/isms/BlacklistIsm.t.sol
+++ b/solidity/test/isms/BlacklistIsm.t.sol
@@ -138,36 +138,46 @@ contract BlacklistIsmTest is Test {
         }
     }
 
-    // Verifies that the set of written storage slots matches exactly the config IDs.
-    // blacklistedIds is at slot 1, so each entry lives at keccak256(abi.encode(id, 1)).
-    function test_storageMatchesConfig() public {
-        uint256 BLACKLISTED_IDS_SLOT = 1;
-
+    // Verifies the on-chain set is enumerable and matches exactly the config IDs.
+    function test_values_matchesConfig() public {
         bytes32[] memory config = new bytes32[](3);
         config[0] = keccak256("msg1");
         config[1] = keccak256("msg2");
         config[2] = keccak256("msg3");
 
-        vm.record();
         vm.prank(owner);
         ism.blacklist(config);
-        (, bytes32[] memory writeSlots) = vm.accesses(address(ism));
 
-        assertEq(writeSlots.length, config.length);
+        bytes32[] memory stored = ism.values();
+        assertEq(stored.length, config.length);
 
         for (uint256 i = 0; i < config.length; i++) {
-            bytes32 expectedSlot = keccak256(
-                abi.encode(config[i], BLACKLISTED_IDS_SLOT)
-            );
+            assertTrue(ism.blacklistedIds(config[i]));
             bool found = false;
-            for (uint256 j = 0; j < writeSlots.length; j++) {
-                if (writeSlots[j] == expectedSlot) {
+            for (uint256 j = 0; j < stored.length; j++) {
+                if (stored[j] == config[i]) {
                     found = true;
                     break;
                 }
             }
-            assertTrue(found, "config ID missing from storage");
-            assertEq(vm.load(address(ism), expectedSlot), bytes32(uint256(1)));
+            assertTrue(found, "config ID missing from values()");
         }
+    }
+
+    // Re-blacklisting an existing ID is a no-op: no duplicate, no event.
+    function test_blacklist_idempotent() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+
+        vm.prank(owner);
+        ism.blacklist(ids);
+        assertEq(ism.values().length, 1);
+
+        // No event expected on the second call.
+        vm.recordLogs();
+        vm.prank(owner);
+        ism.blacklist(ids);
+        assertEq(vm.getRecordedLogs().length, 0);
+        assertEq(ism.values().length, 1);
     }
 }

--- a/solidity/test/isms/BlacklistIsm.t.sol
+++ b/solidity/test/isms/BlacklistIsm.t.sol
@@ -46,31 +46,11 @@ contract BlacklistIsmTest is Test {
         assertFalse(ism.verify("", testMessage));
     }
 
-    function test_verify_acceptsAfterWhitelist() public {
-        bytes32[] memory ids = new bytes32[](1);
-        ids[0] = testMessageId;
-
-        vm.prank(owner);
-        ism.blacklist(ids);
-        assertFalse(ism.verify("", testMessage));
-
-        vm.prank(owner);
-        ism.whitelist(ids);
-        assertTrue(ism.verify("", testMessage));
-    }
-
     function test_blacklist_onlyOwner() public {
         bytes32[] memory ids = new bytes32[](1);
         ids[0] = testMessageId;
         vm.expectRevert("Ownable: caller is not the owner");
         ism.blacklist(ids);
-    }
-
-    function test_whitelist_onlyOwner() public {
-        bytes32[] memory ids = new bytes32[](1);
-        ids[0] = testMessageId;
-        vm.expectRevert("Ownable: caller is not the owner");
-        ism.whitelist(ids);
     }
 
     function test_blacklist_batch() public {
@@ -124,19 +104,6 @@ contract BlacklistIsmTest is Test {
         ism.blacklist(ids);
     }
 
-    function test_whitelist_emitsEvents() public {
-        bytes32[] memory ids = new bytes32[](1);
-        ids[0] = testMessageId;
-
-        vm.prank(owner);
-        ism.blacklist(ids);
-
-        vm.expectEmit(true, false, false, false);
-        emit BlacklistIsm.MessageWhitelisted(testMessageId);
-        vm.prank(owner);
-        ism.whitelist(ids);
-    }
-
     function test_verify_nonBlacklistedUnaffected() public {
         bytes memory otherMessage = MessageUtils.formatMessage(
             0,
@@ -168,6 +135,39 @@ contract BlacklistIsmTest is Test {
             assertTrue(ism.blacklistedIds(messageId));
         } else {
             assertFalse(ism.blacklistedIds(messageId));
+        }
+    }
+
+    // Verifies that the set of written storage slots matches exactly the config IDs.
+    // blacklistedIds is at slot 1, so each entry lives at keccak256(abi.encode(id, 1)).
+    function test_storageMatchesConfig() public {
+        uint256 BLACKLISTED_IDS_SLOT = 1;
+
+        bytes32[] memory config = new bytes32[](3);
+        config[0] = keccak256("msg1");
+        config[1] = keccak256("msg2");
+        config[2] = keccak256("msg3");
+
+        vm.record();
+        vm.prank(owner);
+        ism.blacklist(config);
+        (, bytes32[] memory writeSlots) = vm.accesses(address(ism));
+
+        assertEq(writeSlots.length, config.length);
+
+        for (uint256 i = 0; i < config.length; i++) {
+            bytes32 expectedSlot = keccak256(
+                abi.encode(config[i], BLACKLISTED_IDS_SLOT)
+            );
+            bool found = false;
+            for (uint256 j = 0; j < writeSlots.length; j++) {
+                if (writeSlots[j] == expectedSlot) {
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue(found, "config ID missing from storage");
+            assertEq(vm.load(address(ism), expectedSlot), bytes32(uint256(1)));
         }
     }
 }


### PR DESCRIPTION
## Summary

Rebased for the Q3 2026 audit branch.

- Base: `audit-q3-2026`
- Head: `24e9ee522a`
- Adds `BlacklistIsm` for per-message-ID blocking.
- Owners can append blacklisted message IDs; verification rejects blacklisted IDs and accepts non-blacklisted IDs.

## Verification

- `forge test --match-path test/isms/BlacklistIsm.t.sol`
  - 9 passed
