### PR TITLE
fix: set sender for EVM gas estimates

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/ism/interchain_security_module.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/ism/interchain_security_module.rs
@@ -150,11 +150,10 @@ where
                 metadata.to_owned().into(),
                 RawHyperlaneMessage::from(message).to_vec().into(),
             );
-            if self.domain.is_zksync_stack() {
-                // We use a random from address to ensure compatibility with zksync,
-                // but intentionally do not set this for other chains which may have assumptions
-                // around the presence of funds in the from address (which defaults to address(0)).
-                // Context here: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/4585
+            if let Some(sender) = ism.contract.client().default_sender() {
+                tx = tx.from(sender);
+            } else if self.domain.is_zksync_stack() {
+                // Use a non-zero fallback for zksync when no signer-backed sender exists.
                 tx = tx.from(RANDOM_ADDRESS);
             }
             match try_join(tx.call(), tx.estimate_gas()).await {

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
@@ -186,7 +186,8 @@ where
         tx: &TypedTransaction,
         function: &Function,
     ) -> ChainResult<U256> {
-        let contract_call = self.build_contract_call::<()>(tx.clone(), function.clone());
+        let tx = tx_with_estimate_gas_sender(tx.clone(), self.provider.default_sender());
+        let contract_call = self.build_contract_call::<()>(tx, function.clone());
         let gas_limit = contract_call.estimate_gas().await?.into();
         Ok(gas_limit)
     }
@@ -230,6 +231,7 @@ where
         precursors: Vec<(TypedTransaction, Function)>,
     ) -> ChainResult<U256> {
         let (multi_tx, multi_function) = multi_precursor;
+        let multi_tx = tx_with_estimate_gas_sender(multi_tx, self.provider.default_sender());
         let multicall_contract_call = self.build_contract_call::<()>(multi_tx, multi_function);
         let contract_calls = self.create_contract_calls(precursors);
 
@@ -302,6 +304,15 @@ where
     fn get_signer(&self) -> Option<H160> {
         self.provider.default_sender()
     }
+}
+
+fn tx_with_estimate_gas_sender(mut tx: TypedTransaction, sender: Option<H160>) -> TypedTransaction {
+    if tx.from().is_none() {
+        if let Some(sender) = sender {
+            tx.set_from(sender);
+        }
+    }
+    tx
 }
 
 impl<M> EthereumProvider<M>
@@ -575,4 +586,33 @@ where
         };
     }
     Err(not_found_error(id).into())
+}
+
+#[cfg(test)]
+mod tests {
+    use ethers_core::types::{transaction::eip2718::TypedTransaction, Eip1559TransactionRequest};
+
+    use super::*;
+
+    #[test]
+    fn tx_with_estimate_gas_sender_sets_missing_from() {
+        let sender = H160::repeat_byte(0x11);
+        let tx = TypedTransaction::Eip1559(Eip1559TransactionRequest::default());
+
+        let tx = tx_with_estimate_gas_sender(tx, Some(sender));
+
+        assert_eq!(tx.from(), Some(&sender));
+    }
+
+    #[test]
+    fn tx_with_estimate_gas_sender_preserves_existing_from() {
+        let existing_sender = H160::repeat_byte(0x22);
+        let default_sender = H160::repeat_byte(0x33);
+        let mut tx = TypedTransaction::Eip1559(Eip1559TransactionRequest::default());
+        tx.set_from(existing_sender);
+
+        let tx = tx_with_estimate_gas_sender(tx, Some(default_sender));
+
+        assert_eq!(tx.from(), Some(&existing_sender));
+    }
 }


### PR DESCRIPTION
## Summary
- set the provider default sender on lander `estimate_gas_limit` calls when the tx has no `from`
- set the provider default sender on batched estimate calls before `eth_estimateGas`
- use the ISM provider default sender for `dry_run_verify` gas estimates, keeping the zksync fallback when no sender is configured

Closes #4585

## Testing
- `rustfmt --edition 2021 --check chains/hyperlane-ethereum/src/rpc_clients/provider.rs chains/hyperlane-ethereum/src/ism/interchain_security_module.rs`
- `cargo test -p hyperlane-ethereum --lib tx_with_estimate_gas_sender`

Note: `cargo test -p hyperlane-ethereum tx_with_estimate_gas_sender` also reaches compilation, but the crate's unrelated `tests/signer_output.rs` integration test requires `hyperlane_core::test_utils`, which is gated behind the `test-utils` feature.