### PR TITLE
feat: blacklist ism cli

### DIFF
--- a/.changeset/black-tips-jam.md
+++ b/.changeset/black-tips-jam.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": minor
+---
+
+The Blacklist ISM contract is added to support owner-controlled message ID blocking.

--- a/.changeset/ninety-cats-push.md
+++ b/.changeset/ninety-cats-push.md
@@ -1,0 +1,8 @@
+---
+"@hyperlane-xyz/relayer": minor
+"@hyperlane-xyz/cli": minor
+"@hyperlane-xyz/sdk": minor
+"@hyperlane-xyz/core": minor
+---
+
+Added sdk and cli support for new BlacklistIsm

--- a/solidity/contracts/isms/BlacklistIsm.sol
+++ b/solidity/contracts/isms/BlacklistIsm.sol
@@ -21,7 +21,7 @@ contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
     uint8 public constant override moduleType = uint8(Types.NULL);
 
     /// @notice message ID => true if blacklisted
-    mapping(bytes32 => bool) public blacklistedIds;
+    mapping(bytes32 messageId => bool isBlacklisted) public blacklistedIds;
 
     event MessageBlacklisted(bytes32 indexed messageId);
     event MessageWhitelisted(bytes32 indexed messageId);

--- a/solidity/contracts/isms/BlacklistIsm.sol
+++ b/solidity/contracts/isms/BlacklistIsm.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+// ============ Internal Imports ============
+import {IInterchainSecurityModule} from "../interfaces/IInterchainSecurityModule.sol";
+import {Message} from "../libs/Message.sol";
+import {PackageVersioned} from "../PackageVersioned.sol";
+
+// ============ External Imports ============
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title BlacklistIsm
+ * @notice Rejects messages whose ID is blacklisted.
+ * Provides per-message-ID granularity for blocking reorged or malicious messages.
+ * For bulk nonce-range blocking, prefer NonceFloorIsm composed with DomainRoutingIsm.
+ */
+contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
+    using Message for bytes;
+
+    uint8 public constant override moduleType = uint8(Types.NULL);
+
+    /// @notice message ID => true if blacklisted
+    mapping(bytes32 => bool) public blacklistedIds;
+
+    event MessageBlacklisted(bytes32 indexed messageId);
+    event MessageWhitelisted(bytes32 indexed messageId);
+
+    constructor(address _owner) Ownable() {
+        _transferOwnership(_owner);
+    }
+
+    /// @notice Blacklist a batch of message IDs
+    function blacklist(bytes32[] calldata _ids) external onlyOwner {
+        for (uint256 i = 0; i < _ids.length; i++) {
+            blacklistedIds[_ids[i]] = true;
+            emit MessageBlacklisted(_ids[i]);
+        }
+    }
+
+    /// @notice Remove message IDs from the blacklist
+    function whitelist(bytes32[] calldata _ids) external onlyOwner {
+        for (uint256 i = 0; i < _ids.length; i++) {
+            delete blacklistedIds[_ids[i]];
+            emit MessageWhitelisted(_ids[i]);
+        }
+    }
+
+    /// @inheritdoc IInterchainSecurityModule
+    function verify(
+        bytes calldata,
+        bytes calldata _message
+    ) external view returns (bool) {
+        return !blacklistedIds[_message.id()];
+    }
+}

--- a/solidity/contracts/isms/BlacklistIsm.sol
+++ b/solidity/contracts/isms/BlacklistIsm.sol
@@ -24,7 +24,6 @@ contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
     mapping(bytes32 messageId => bool isBlacklisted) public blacklistedIds;
 
     event MessageBlacklisted(bytes32 indexed messageId);
-    event MessageWhitelisted(bytes32 indexed messageId);
 
     constructor(address _owner) Ownable() {
         _transferOwnership(_owner);
@@ -35,14 +34,6 @@ contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
         for (uint256 i = 0; i < _ids.length; i++) {
             blacklistedIds[_ids[i]] = true;
             emit MessageBlacklisted(_ids[i]);
-        }
-    }
-
-    /// @notice Remove message IDs from the blacklist
-    function whitelist(bytes32[] calldata _ids) external onlyOwner {
-        for (uint256 i = 0; i < _ids.length; i++) {
-            delete blacklistedIds[_ids[i]];
-            emit MessageWhitelisted(_ids[i]);
         }
     }
 

--- a/solidity/test/isms/BlacklistIsm.t.sol
+++ b/solidity/test/isms/BlacklistIsm.t.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT or Apache-2.0
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {BlacklistIsm} from "../../contracts/isms/BlacklistIsm.sol";
+import {IInterchainSecurityModule} from "../../contracts/interfaces/IInterchainSecurityModule.sol";
+import {MessageUtils} from "./IsmTestUtils.sol";
+
+contract BlacklistIsmTest is Test {
+    BlacklistIsm ism;
+
+    address owner;
+    bytes testMessage;
+    bytes32 testMessageId;
+
+    function setUp() public {
+        owner = msg.sender;
+        ism = new BlacklistIsm(owner);
+        testMessage = MessageUtils.formatMessage(
+            0,
+            42,
+            1983,
+            bytes32(0),
+            1,
+            bytes32(0),
+            ""
+        );
+        testMessageId = keccak256(testMessage);
+    }
+
+    function test_moduleType() public view {
+        assertEq(ism.moduleType(), uint8(IInterchainSecurityModule.Types.NULL));
+    }
+
+    function test_verify_acceptsByDefault() public view {
+        assertTrue(ism.verify("", testMessage));
+    }
+
+    function test_verify_rejectsBlacklisted() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+        vm.prank(owner);
+        ism.blacklist(ids);
+
+        assertFalse(ism.verify("", testMessage));
+    }
+
+    function test_verify_acceptsAfterWhitelist() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+
+        vm.prank(owner);
+        ism.blacklist(ids);
+        assertFalse(ism.verify("", testMessage));
+
+        vm.prank(owner);
+        ism.whitelist(ids);
+        assertTrue(ism.verify("", testMessage));
+    }
+
+    function test_blacklist_onlyOwner() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+        vm.expectRevert("Ownable: caller is not the owner");
+        ism.blacklist(ids);
+    }
+
+    function test_whitelist_onlyOwner() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+        vm.expectRevert("Ownable: caller is not the owner");
+        ism.whitelist(ids);
+    }
+
+    function test_blacklist_batch() public {
+        bytes memory msg1 = MessageUtils.formatMessage(
+            0,
+            1,
+            1983,
+            bytes32(0),
+            1,
+            bytes32(0),
+            ""
+        );
+        bytes memory msg2 = MessageUtils.formatMessage(
+            0,
+            2,
+            1983,
+            bytes32(0),
+            1,
+            bytes32(0),
+            ""
+        );
+        bytes memory msg3 = MessageUtils.formatMessage(
+            0,
+            3,
+            1983,
+            bytes32(0),
+            1,
+            bytes32(0),
+            ""
+        );
+
+        bytes32[] memory ids = new bytes32[](2);
+        ids[0] = keccak256(msg1);
+        ids[1] = keccak256(msg2);
+
+        vm.prank(owner);
+        ism.blacklist(ids);
+
+        assertFalse(ism.verify("", msg1));
+        assertFalse(ism.verify("", msg2));
+        assertTrue(ism.verify("", msg3));
+    }
+
+    function test_blacklist_emitsEvents() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+
+        vm.expectEmit(true, false, false, false);
+        emit BlacklistIsm.MessageBlacklisted(testMessageId);
+        vm.prank(owner);
+        ism.blacklist(ids);
+    }
+
+    function test_whitelist_emitsEvents() public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+
+        vm.prank(owner);
+        ism.blacklist(ids);
+
+        vm.expectEmit(true, false, false, false);
+        emit BlacklistIsm.MessageWhitelisted(testMessageId);
+        vm.prank(owner);
+        ism.whitelist(ids);
+    }
+
+    function test_verify_nonBlacklistedUnaffected() public {
+        bytes memory otherMessage = MessageUtils.formatMessage(
+            0,
+            999,
+            1,
+            bytes32(0),
+            1,
+            bytes32(0),
+            ""
+        );
+
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+        vm.prank(owner);
+        ism.blacklist(ids);
+
+        assertFalse(ism.verify("", testMessage));
+        assertTrue(ism.verify("", otherMessage));
+    }
+
+    function testFuzz_verify(bytes32 messageId) public {
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = testMessageId;
+        vm.prank(owner);
+        ism.blacklist(ids);
+
+        assertTrue(ism.blacklistedIds(testMessageId));
+        if (messageId == testMessageId) {
+            assertTrue(ism.blacklistedIds(messageId));
+        } else {
+            assertFalse(ism.blacklistedIds(messageId));
+        }
+    }
+}

--- a/solidity/test/isms/BlacklistIsm.t.sol
+++ b/solidity/test/isms/BlacklistIsm.t.sol
@@ -46,31 +46,11 @@ contract BlacklistIsmTest is Test {
         assertFalse(ism.verify("", testMessage));
     }
 
-    function test_verify_acceptsAfterWhitelist() public {
-        bytes32[] memory ids = new bytes32[](1);
-        ids[0] = testMessageId;
-
-        vm.prank(owner);
-        ism.blacklist(ids);
-        assertFalse(ism.verify("", testMessage));
-
-        vm.prank(owner);
-        ism.whitelist(ids);
-        assertTrue(ism.verify("", testMessage));
-    }
-
     function test_blacklist_onlyOwner() public {
         bytes32[] memory ids = new bytes32[](1);
         ids[0] = testMessageId;
         vm.expectRevert("Ownable: caller is not the owner");
         ism.blacklist(ids);
-    }
-
-    function test_whitelist_onlyOwner() public {
-        bytes32[] memory ids = new bytes32[](1);
-        ids[0] = testMessageId;
-        vm.expectRevert("Ownable: caller is not the owner");
-        ism.whitelist(ids);
     }
 
     function test_blacklist_batch() public {
@@ -124,19 +104,6 @@ contract BlacklistIsmTest is Test {
         ism.blacklist(ids);
     }
 
-    function test_whitelist_emitsEvents() public {
-        bytes32[] memory ids = new bytes32[](1);
-        ids[0] = testMessageId;
-
-        vm.prank(owner);
-        ism.blacklist(ids);
-
-        vm.expectEmit(true, false, false, false);
-        emit BlacklistIsm.MessageWhitelisted(testMessageId);
-        vm.prank(owner);
-        ism.whitelist(ids);
-    }
-
     function test_verify_nonBlacklistedUnaffected() public {
         bytes memory otherMessage = MessageUtils.formatMessage(
             0,
@@ -168,6 +135,39 @@ contract BlacklistIsmTest is Test {
             assertTrue(ism.blacklistedIds(messageId));
         } else {
             assertFalse(ism.blacklistedIds(messageId));
+        }
+    }
+
+    // Verifies that the set of written storage slots matches exactly the config IDs.
+    // blacklistedIds is at slot 1, so each entry lives at keccak256(abi.encode(id, 1)).
+    function test_storageMatchesConfig() public {
+        uint256 BLACKLISTED_IDS_SLOT = 1;
+
+        bytes32[] memory config = new bytes32[](3);
+        config[0] = keccak256("msg1");
+        config[1] = keccak256("msg2");
+        config[2] = keccak256("msg3");
+
+        vm.record();
+        vm.prank(owner);
+        ism.blacklist(config);
+        (, bytes32[] memory writeSlots) = vm.accesses(address(ism));
+
+        assertEq(writeSlots.length, config.length);
+
+        for (uint256 i = 0; i < config.length; i++) {
+            bytes32 expectedSlot = keccak256(
+                abi.encode(config[i], BLACKLISTED_IDS_SLOT)
+            );
+            bool found = false;
+            for (uint256 j = 0; j < writeSlots.length; j++) {
+                if (writeSlots[j] == expectedSlot) {
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue(found, "config ID missing from storage");
+            assertEq(vm.load(address(ism), expectedSlot), bytes32(uint256(1)));
         }
     }
 }

--- a/typescript/cli/src/config/ism.ts
+++ b/typescript/cli/src/config/ism.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import {
   type AggregationIsmConfig,
+  type BlacklistIsmConfig,
   type ChainMap,
   type IsmConfig,
   IsmConfigSchema,
@@ -86,6 +87,8 @@ const ISM_TYPE_DESCRIPTIONS: Record<string, string> = {
   [IsmType.TRUSTED_RELAYER]: 'Deliver messages from an authorized address',
   [IsmType.AMOUNT_ROUTING]:
     'Route messages based on the token amount to transfer',
+  [IsmType.BLACKLIST]:
+    'Reject specific messages by ID (surgical blocking for reorged or malicious messages)',
 };
 
 export async function createAdvancedIsmConfig(
@@ -127,6 +130,8 @@ export async function createAdvancedIsmConfig(
       return createTrustedRelayerConfig(context, true);
     case IsmType.AMOUNT_ROUTING:
       return createAmountRoutingIsmConfig(context);
+    case IsmType.BLACKLIST:
+      return createBlacklistIsmConfig();
     default:
       throw new Error(`Unsupported ISM type: ${moduleType}.`);
   }
@@ -183,6 +188,16 @@ export const createTrustedRelayerConfig = callWithConfigCreationLogs(
     };
   },
   IsmType.TRUSTED_RELAYER,
+);
+
+export const createBlacklistIsmConfig = callWithConfigCreationLogs(
+  async (): Promise<BlacklistIsmConfig> => {
+    const owner = await input({
+      message: 'Enter the owner address for the BlacklistIsm',
+    });
+    return { type: IsmType.BLACKLIST, owner, blacklistedMessageIds: [] };
+  },
+  IsmType.BLACKLIST,
 );
 
 export const createAggregationConfig = callWithConfigCreationLogs(

--- a/typescript/relayer/src/metadata/builder.ts
+++ b/typescript/relayer/src/metadata/builder.ts
@@ -67,6 +67,7 @@ export class BaseMetadataBuilder implements MetadataBuilder {
       case IsmType.PAUSABLE:
       case IsmType.CCIP:
       case IsmType.RATE_LIMITED:
+      case IsmType.BLACKLIST:
         return this.nullMetadataBuilder.build({ ...context, ism });
 
       case IsmType.MERKLE_ROOT_MULTISIG:

--- a/typescript/relayer/src/metadata/decode.ts
+++ b/typescript/relayer/src/metadata/decode.ts
@@ -14,6 +14,12 @@ export function decodeIsmMetadata(
   const { ism } = context;
   switch (ism.type) {
     case IsmType.TRUSTED_RELAYER:
+    case IsmType.TEST_ISM:
+    case IsmType.OP_STACK:
+    case IsmType.PAUSABLE:
+    case IsmType.CCIP:
+    case IsmType.RATE_LIMITED:
+    case IsmType.BLACKLIST:
       return NullMetadataBuilder.decode(ism);
 
     case IsmType.MERKLE_ROOT_MULTISIG:

--- a/typescript/relayer/src/metadata/types.ts
+++ b/typescript/relayer/src/metadata/types.ts
@@ -120,7 +120,8 @@ export interface NullMetadataBuildResult extends BaseMetadataBuildResult {
     | typeof IsmType.OP_STACK
     | typeof IsmType.PAUSABLE
     | typeof IsmType.CCIP
-    | typeof IsmType.RATE_LIMITED;
+    | typeof IsmType.RATE_LIMITED
+    | typeof IsmType.BLACKLIST;
   /** Always present for null ISMs */
   metadata: string;
 }

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -324,6 +324,8 @@ export {
   RoutingIsmConfig,
   RoutingIsmConfigSchema,
   SafeParseIsmConfigSchema,
+  BlacklistIsmConfig,
+  BlacklistIsmConfigSchema,
   RateLimitedIsmConfig,
   RateLimitedIsmConfigSchema,
   TrustedRelayerIsmConfig,

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -3,6 +3,7 @@ import { Logger } from 'pino';
 
 import {
   AbstractCcipReadIsm__factory,
+  BlacklistIsm__factory,
   DomainRoutingIsm__factory,
   PausableIsm__factory,
   RateLimitedIsm__factory,
@@ -37,6 +38,7 @@ import { normalizeConfig } from '../utils/ism.js';
 import { EvmIsmReader } from './EvmIsmReader.js';
 import { HyperlaneIsmFactory } from './HyperlaneIsmFactory.js';
 import {
+  BlacklistIsmConfig,
   DeployedIsm,
   DerivedIsmConfig,
   DomainRoutingIsmConfig,
@@ -258,6 +260,11 @@ export class EvmIsmModule extends HyperlaneModule<
       // owner is optional on RateLimitedIsmConfig — handle ownership here
       // rather than falling through to the generic transferOwnershipTransactions call
       return this.updateRateLimitedIsm({ current, target });
+    } else if (
+      current.type === IsmType.BLACKLIST &&
+      target.type === IsmType.BLACKLIST
+    ) {
+      updateTxs.push(...this.updateBlacklistIsm({ current, target }));
     } else {
       throw new Error(
         `Unsupported update to mutable ISM of type ${target.type}`,
@@ -463,6 +470,43 @@ export class EvmIsmModule extends HyperlaneModule<
           { owner: target.owner },
         ),
       );
+    }
+
+    return txs;
+  }
+
+  protected updateBlacklistIsm({
+    current,
+    target,
+  }: {
+    current: BlacklistIsmConfig;
+    target: BlacklistIsmConfig;
+  }): AnnotatedEV5Transaction[] {
+    const txs: AnnotatedEV5Transaction[] = [];
+    const currentIds = new Set(current.blacklistedMessageIds ?? []);
+    const targetIds = new Set(target.blacklistedMessageIds ?? []);
+
+    const toBlacklist = [...targetIds].filter((id) => !currentIds.has(id));
+    const toWhitelist = [...currentIds].filter((id) => !targetIds.has(id));
+
+    const ismInterface = BlacklistIsm__factory.createInterface();
+
+    if (toBlacklist.length) {
+      txs.push({
+        annotation: `Blacklisting ${toBlacklist.length} message ID(s) on BlacklistIsm on chain "${this.chain}" at address "${this.args.addresses.deployedIsm}"`,
+        chainId: this.chainId,
+        to: this.args.addresses.deployedIsm,
+        data: ismInterface.encodeFunctionData('blacklist', [toBlacklist]),
+      });
+    }
+
+    if (toWhitelist.length) {
+      txs.push({
+        annotation: `Whitelisting ${toWhitelist.length} message ID(s) on BlacklistIsm on chain "${this.chain}" at address "${this.args.addresses.deployedIsm}"`,
+        chainId: this.chainId,
+        to: this.args.addresses.deployedIsm,
+        data: ismInterface.encodeFunctionData('whitelist', [toWhitelist]),
+      });
     }
 
     return txs;

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -118,6 +118,16 @@ export class EvmIsmModule extends HyperlaneModule<
       return [];
     }
 
+    // If target is an address reference, use it directly — no comparison or
+    // deployment.  deriveIsmConfig would resolve it to a full config object and
+    // the structural diff would trigger a spurious redeploy of a perfectly good
+    // on-chain ISM.  The outer EvmWarpModule handles setInterchainSecurityModule
+    // based on whether deployedIsm changed.
+    if (typeof targetConfig === 'string') {
+      this.args.addresses.deployedIsm = targetConfig;
+      return [];
+    }
+
     // We need to normalize the current and target configs to compare.
     const normalizedTargetConfig: DerivedIsmConfig = normalizeConfig(
       await this.reader.deriveIsmConfig(targetConfig),
@@ -133,13 +143,6 @@ export class EvmIsmModule extends HyperlaneModule<
 
     // Update the module config to the target one as we are sure now that an update will be needed
     this.args.config = normalizedTargetConfig;
-
-    // if the new config is an address just point the module to the new address
-    if (typeof normalizedTargetConfig === 'string') {
-      this.args.addresses.deployedIsm = normalizedTargetConfig;
-
-      return [];
-    }
 
     // Conditions for deploying a new ISM:
     // - If updating from an address/custom config to a proper ISM config.

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -264,7 +264,7 @@ export class EvmIsmModule extends HyperlaneModule<
       current.type === IsmType.BLACKLIST &&
       target.type === IsmType.BLACKLIST
     ) {
-      updateTxs.push(...this.updateBlacklistIsm({ current, target }));
+      updateTxs.push(...(await this.updateBlacklistIsm({ current, target })));
     } else {
       throw new Error(
         `Unsupported update to mutable ISM of type ${target.type}`,
@@ -475,41 +475,38 @@ export class EvmIsmModule extends HyperlaneModule<
     return txs;
   }
 
-  protected updateBlacklistIsm({
-    current,
+  protected async updateBlacklistIsm({
     target,
   }: {
     current: BlacklistIsmConfig;
     target: BlacklistIsmConfig;
-  }): AnnotatedEV5Transaction[] {
-    const txs: AnnotatedEV5Transaction[] = [];
-    const currentIds = new Set(current.blacklistedMessageIds ?? []);
-    const targetIds = new Set(target.blacklistedMessageIds ?? []);
+  }): Promise<AnnotatedEV5Transaction[]> {
+    const targetIds = target.blacklistedMessageIds ?? [];
+    if (targetIds.length === 0) return [];
 
-    const toBlacklist = [...targetIds].filter((id) => !currentIds.has(id));
-    const toWhitelist = [...currentIds].filter((id) => !targetIds.has(id));
+    const contract = BlacklistIsm__factory.connect(
+      this.args.addresses.deployedIsm,
+      this.multiProvider.getProvider(this.chain),
+    );
 
-    const ismInterface = BlacklistIsm__factory.createInterface();
+    const onChain = await Promise.all(
+      targetIds.map((id) => contract.blacklistedIds(id)),
+    );
+    const toBlacklist = targetIds.filter((_, i) => !onChain[i]);
 
-    if (toBlacklist.length) {
-      txs.push({
+    if (toBlacklist.length === 0) return [];
+
+    return [
+      {
         annotation: `Blacklisting ${toBlacklist.length} message ID(s) on BlacklistIsm on chain "${this.chain}" at address "${this.args.addresses.deployedIsm}"`,
         chainId: this.chainId,
         to: this.args.addresses.deployedIsm,
-        data: ismInterface.encodeFunctionData('blacklist', [toBlacklist]),
-      });
-    }
-
-    if (toWhitelist.length) {
-      txs.push({
-        annotation: `Whitelisting ${toWhitelist.length} message ID(s) on BlacklistIsm on chain "${this.chain}" at address "${this.args.addresses.deployedIsm}"`,
-        chainId: this.chainId,
-        to: this.args.addresses.deployedIsm,
-        data: ismInterface.encodeFunctionData('whitelist', [toWhitelist]),
-      });
-    }
-
-    return txs;
+        data: BlacklistIsm__factory.createInterface().encodeFunctionData(
+          'blacklist',
+          [toBlacklist],
+        ),
+      },
+    ];
   }
 
   protected async deploy({

--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -617,8 +617,6 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
         address,
         type: IsmType.BLACKLIST,
         owner,
-        // Can't enumerate on-chain mapping entries; return empty array
-        blacklistedMessageIds: [],
       };
     } catch {
       this.logger.debug(

--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -6,6 +6,7 @@ import {
   AbstractRoutingIsm__factory,
   AmountRoutingIsm__factory,
   ArbL2ToL1Ism__factory,
+  BlacklistIsm__factory,
   CCIPIsm__factory,
   DefaultFallbackRoutingIsm__factory,
   IInterchainSecurityModule__factory,
@@ -603,6 +604,25 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
     } catch {
       this.logger.debug(
         'Error accessing "recipient" property, implying this is not a Rate Limited ISM.',
+        address,
+      );
+    }
+
+    // Detect BlacklistIsm by probing for its unique blacklistedIds(bytes32) selector.
+    const blacklistIsm = BlacklistIsm__factory.connect(address, this.provider);
+    try {
+      await blacklistIsm.blacklistedIds(ethers.constants.HashZero);
+      const owner = await blacklistIsm.owner();
+      return {
+        address,
+        type: IsmType.BLACKLIST,
+        owner,
+        // Can't enumerate on-chain mapping entries; return empty array
+        blacklistedMessageIds: [],
+      };
+    } catch {
+      this.logger.debug(
+        'Error accessing "blacklistedIds" property, implying this is not a Blacklist ISM.',
         address,
       );
     }

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
@@ -4,6 +4,7 @@ import { Logger } from 'pino';
 import {
   AmountRoutingIsm__factory,
   ArbL2ToL1Ism__factory,
+  BlacklistIsm__factory,
   CCIPIsm,
   CCIPIsm__factory,
   DefaultFallbackRoutingIsm,
@@ -63,6 +64,7 @@ import { getZKSyncArtifactByContractName } from '../utils/zksync.js';
 import {
   AggregationIsmConfig,
   AmountRoutingIsmConfig,
+  BlacklistIsmConfig,
   CCIPIsmConfig,
   DeployedIsm,
   DeployedIsmType,
@@ -85,6 +87,7 @@ const ismFactories = {
   [IsmType.ARB_L2_TO_L1]: new ArbL2ToL1Ism__factory(),
   [IsmType.CCIP]: new CCIPIsm__factory(),
   [IsmType.RATE_LIMITED]: new RateLimitedIsm__factory(),
+  [IsmType.BLACKLIST]: new BlacklistIsm__factory(),
 };
 
 const domainRoutingInitializationSize = (destination: ChainName) => {
@@ -263,6 +266,35 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
           [config.owner],
         );
         break;
+      case IsmType.BLACKLIST: {
+        const blacklistConfig = config as BlacklistIsmConfig;
+        const signer = this.multiProvider.getSigner(destination);
+        const signerAddress = await signer.getAddress();
+        const overrides =
+          this.multiProvider.getTransactionOverrides(destination);
+        // Deploy with signer as temporary owner so we can call blacklist() before transferring
+        contract = await this.deployer.deployContract(
+          destination,
+          IsmType.BLACKLIST,
+          [signerAddress],
+        );
+        const ism = BlacklistIsm__factory.connect(contract.address, signer);
+        if (blacklistConfig.blacklistedMessageIds?.length) {
+          const tx = await ism.blacklist(
+            blacklistConfig.blacklistedMessageIds,
+            overrides,
+          );
+          await this.multiProvider.handleTx(destination, tx);
+        }
+        if (!eqAddress(signerAddress, blacklistConfig.owner)) {
+          const tx = await ism.transferOwnership(
+            blacklistConfig.owner,
+            overrides,
+          );
+          await this.multiProvider.handleTx(destination, tx);
+        }
+        break;
+      }
       case IsmType.TRUSTED_RELAYER:
         assert(mailbox, `Mailbox address is required for deploying ${ismType}`);
         contract = await this.deployer.deployContract(

--- a/typescript/sdk/src/ism/types.ts
+++ b/typescript/sdk/src/ism/types.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import {
   AbstractCcipReadIsm,
   ArbL2ToL1Ism,
+  BlacklistIsm,
   CCIPIsm,
   IAggregationIsm,
   IInterchainSecurityModule,
@@ -74,6 +75,7 @@ export const IsmType = {
   CCIP: 'ccipIsm',
   OFFCHAIN_LOOKUP: 'offchainLookupIsm',
   RATE_LIMITED: 'rateLimitedIsm',
+  BLACKLIST: 'blacklistIsm',
   UNKNOWN: 'unknownIsm',
 } as const;
 
@@ -92,6 +94,7 @@ export const MUTABLE_ISM_TYPE: IsmType[] = [
   IsmType.OFFCHAIN_LOOKUP,
   IsmType.INCREMENTAL_ROUTING,
   IsmType.RATE_LIMITED,
+  IsmType.BLACKLIST,
 ];
 
 /**
@@ -143,6 +146,7 @@ export function ismTypeToModuleType(ismType: IsmType): ModuleType {
     case IsmType.TRUSTED_RELAYER:
     case IsmType.CCIP:
     case IsmType.RATE_LIMITED:
+    case IsmType.BLACKLIST:
       return ModuleType.NULL;
     case IsmType.ARB_L2_TO_L1:
       return ModuleType.ARB_L2_TO_L1;
@@ -191,7 +195,8 @@ export type NullIsmConfig =
   | OpStackIsmConfig
   | TrustedRelayerIsmConfig
   | CCIPIsmConfig
-  | RateLimitedIsmConfig;
+  | RateLimitedIsmConfig
+  | BlacklistIsmConfig;
 
 type BaseRoutingIsmConfig<
   T extends
@@ -265,6 +270,7 @@ export type DeployedIsmType = {
   [IsmType.OFFCHAIN_LOOKUP]: AbstractCcipReadIsm;
   [IsmType.INTERCHAIN_ACCOUNT_ROUTING]: InterchainAccountRouter;
   [IsmType.RATE_LIMITED]: RateLimitedIsm;
+  [IsmType.BLACKLIST]: BlacklistIsm;
   [IsmType.UNKNOWN]: IInterchainSecurityModule;
 };
 
@@ -326,6 +332,12 @@ export const RateLimitedIsmConfigSchema = z
     }
     return val;
   });
+
+export const BlacklistIsmConfigSchema = OwnableSchema.extend({
+  type: z.literal(IsmType.BLACKLIST),
+  blacklistedMessageIds: z.array(ZHash).optional(),
+});
+export type BlacklistIsmConfig = z.infer<typeof BlacklistIsmConfigSchema>;
 
 export const CCIPIsmConfigSchema = z.object({
   type: z.literal(IsmType.CCIP),
@@ -468,6 +480,7 @@ export const IsmConfigSchema = z.union([
   TrustedRelayerIsmConfigSchema,
   CCIPIsmConfigSchema,
   RateLimitedIsmConfigSchema,
+  BlacklistIsmConfigSchema,
   MultisigIsmConfigSchema,
   WeightedMultisigIsmConfigSchema,
   RoutingIsmConfigSchema,


### PR DESCRIPTION
### Description

Adds SDK and CLI support for the new `BlacklistIsm` contract — an ownable ISM that rejects messages whose ID appears in a blocklist. Owners can add/remove message IDs via `blacklist()`/`whitelist()` calls.

**SDK changes:**
- `IsmType.BLACKLIST` added to enum, `ismTypeToModuleType` (→ `ModuleType.NULL`), `MUTABLE_ISM_TYPE`, `DeployedIsmType`
- `BlacklistIsmConfigSchema` / `BlacklistIsmConfig` Zod schema and type
- `NullIsmConfig` union and `IsmConfigSchema` union updated
- `HyperlaneIsmFactory`: deploy case — deploys with signer as temporary owner, calls `blacklist()`, then transfers ownership to the configured owner
- `EvmIsmReader`: detects `BlacklistIsm` on-chain by probing `blacklistedIds(bytes32)` selector; returns `blacklistedMessageIds: []` (can't enumerate mappings)
- `EvmIsmModule`: `updateBlacklistIsm()` — diffs current vs target ID sets, emits `blacklist()`/`whitelist()` transactions for the delta

**Relayer changes (TypeScript):**
- `NullMetadataBuildResult.type` union extended with `'blacklistIsm'`
- Builder and decoder dispatch `IsmType.BLACKLIST` to `NullMetadataBuilder` (returns `0x` metadata, same as other NULL ISMs)
- Decoder switch expanded to cover all NULL ISM types (previously only `TRUSTED_RELAYER` was handled; others silently hit `default: throw`)

**CLI changes:**
- `ISM_TYPE_DESCRIPTIONS` entry for `BLACKLIST`
- `createBlacklistIsmConfig()` interactive config builder (prompts for owner; IDs added post-deploy or via YAML)

### Drive-by changes

- Fixed `EvmIsmReader` null ISM decoder: `TEST_ISM`, `OP_STACK`, `PAUSABLE`, `CCIP`, `RATE_LIMITED` now correctly route to `NullMetadataBuilder.decode()` instead of throwing

### Related issues

- Depends on #8756 (`BlacklistIsm.sol`)

### Backward compatibility

Yes — additive changes only. No existing ISM types or schemas modified.

### Testing

Manual — deployed a `staticAggregationIsm` (3/3: `defaultFallbackRoutingIsm` + `trustedRelayerIsm` + `blacklistIsm`) via `hyperlane ism deploy` and confirmed on-chain using `warp apply` with a Gnosis Safe TX Builder strategy.