### PR TITLE
feat(token): add L1FluentHypNative warp route

### DIFF
--- a/.changeset/fluent-l1-hyp-native.md
+++ b/.changeset/fluent-l1-hyp-native.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/core': minor
+---
+
+Added L1FluentHypNative, an Ethereum-side HypNative variant that forwards inbound native-ETH deliveries through L1HypNativeGateway (which wraps Fluent's L1→L2 bridge) instead of releasing on L1, while keeping outbound transferRemote and protocol-fee delivery unchanged on L1.

--- a/docs/fluent-warp-frontend.md
+++ b/docs/fluent-warp-frontend.md
@@ -1,0 +1,116 @@
+# Fluent Native ETH Warp — Frontend Integration
+
+Two-way native ETH bridge between **Fluent L2** and any Hyperlane-supported chain. Frontend hits two contract types:
+
+- **`L2HypNativeGateway`** on Fluent L2 — for **outbound** (L2 → peer).
+- Standard **`HypNative` warp route** on each peer chain — for **inbound** (peer → L2).
+
+Fluent L2 itself is _not_ a Hyperlane domain. Sender on peer specifies destination `11155111` (Ethereum) + L2 address as recipient; the L1 hub auto-forwards to Fluent L2.
+
+---
+
+## Domain IDs
+
+| Chain            | Hyperlane domain |
+| ---------------- | ---------------- |
+| Ethereum Sepolia | `11155111`       |
+| Arbitrum Sepolia | `421614`         |
+| Solana Devnet    | TBD              |
+
+## Addresses (testnet)
+
+| Contract                   | Chain       | Address                                      |
+| -------------------------- | ----------- | -------------------------------------------- |
+| `L2HypNativeGateway`       | Fluent L2   | `0xe3f87C557c51b296DbC886De05744f0D52ecBb77` |
+| `L1FluentHypNative` (warp) | Sepolia     | `0x6197dC5A4E021B0c2A67334D94704425f87374A7` |
+| `HypNative` (peer)         | Arb Sepolia | `0xC5790c39284BBd0a0707c553fE6d782948c11ED8` |
+
+---
+
+## Outbound: Fluent L2 → peer
+
+```solidity
+// L2HypNativeGateway
+function sendNativeTokens(
+    uint32  domain,     // peer's Hyperlane domain (e.g. 421614)
+    bytes32 recipient,  // peer-side address as bytes32
+    uint256 amount,     // exact-out ETH at the recipient
+    uint256 hypFee      // Hyperlane fee budget for L1 dispatch (>= 0.001 ether)
+) external payable;
+
+uint256 public constant MIN_HYP_FEE_NATIVE = 0.001 ether;
+```
+
+`msg.value = amount + hypFee + bridgeFee`
+
+- `bridgeFee = FluentBridge.getSentMessageFee()` — read live.
+- Excess is **not refunded**, it goes to the L1 fee reserve.
+- `hypFee` is a floor; if the live L1 quote is higher, the gateway tops up from its reserve.
+
+Recipient encoding for EVM peer:
+
+```ts
+const recipient32 = ethers.zeroPadValue(addr, 32);
+```
+
+Event:
+
+```solidity
+event NativeTransferInitiated(
+    uint32 indexed domain,
+    bytes32 indexed recipient,
+    uint256 amount,
+    address sender,
+    uint256 hypFee,
+    uint256 bridgeFee
+);
+```
+
+---
+
+## Inbound: peer → Fluent L2
+
+Standard Hyperlane `HypNative` on the peer. Destination is **always `11155111`** (Sepolia), recipient is the **L2 address**.
+
+```solidity
+// HypNative (peer chain)
+function transferRemote(
+    uint32  destination,  // 11155111
+    bytes32 recipient,    // L2 address as bytes32
+    uint256 amount
+) external payable returns (bytes32 messageId);
+
+function quoteGasPayment(uint32 destination) external view returns (uint256);
+```
+
+`msg.value = amount + quoteGasPayment(11155111)`
+
+ETA: ~1–3 min (Hyperlane relay + Fluent bridge to L2).
+
+Events:
+
+```solidity
+event SentTransferRemote(uint32 indexed destination, bytes32 indexed recipient, uint256 amount);
+// On L2 once delivered:
+event ReceivedTokens(address indexed from, address indexed to, uint256 amount);
+```
+
+---
+
+## Tracking a transfer
+
+1. Outbound L2: filter `NativeTransferInitiated` on `L2HypNativeGateway`.
+2. Inbound L2: filter `ReceivedTokens` on `L2HypNativeGateway`, match by `to` + `amount`.
+3. For peer ↔ L2 in either direction, the Hyperlane Explorer (`explorer.hyperlane.xyz`) can resolve a `messageId` to delivery status.
+
+## Errors to surface
+
+L2 gateway reverts:
+
+| Error                 | Cause                           | UX                          |
+| --------------------- | ------------------------------- | --------------------------- |
+| `InvalidTargetDomain` | `domain == 0`                   | Bad config                  |
+| `ZeroRecipient`       | `recipient == 0`                | Bad input                   |
+| `InvalidHyperlaneFee` | `hypFee < MIN_HYP_FEE_NATIVE`   | Raise fee, retry            |
+| `InvalidNativeAmount` | `msg.value < required`          | Re-quote `bridgeFee`, retry |
+| `AccountBlacklisted`  | Sender or recipient blacklisted | Show "address not eligible" |

--- a/solidity/contracts/token/extensions/L1FluentHypNative.sol
+++ b/solidity/contracts/token/extensions/L1FluentHypNative.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+import {HypNative} from "../HypNative.sol";
+import {TokenRouter} from "../libs/TokenRouter.sol";
+import {NativeCollateral} from "../libs/TokenCollateral.sol";
+import {TokenMessage} from "../libs/TokenMessage.sol";
+import {TypeCasts} from "../../libs/TypeCasts.sol";
+
+/**
+ * @dev Minimal inline view of `L1HypNativeGateway.sendNativeTokens`. Inlined here so this
+ *      contract stays self-contained — the Hyperlane monorepo cannot take a source-level
+ *      dependency on `fluentlabs/solidity-contracts`. Canonical declaration lives at
+ *      `contracts/interfaces/gateways/IHypNativeGateway.sol → IL1HypNativeGateway` in the
+ *      Fluent repo. The gateway internally re-encodes the L2 payload and forwards through
+ *      `FluentBridge.sendMessage`, so this interface is the only Fluent-side surface this
+ *      warp route touches.
+ */
+interface IL1HypNativeGateway {
+    /// @notice Forwards an inbound Hyperlane delivery as native ETH to Fluent L2.
+    /// @dev `msg.value` is the entire amount delivered on L2. Gateway-side auth is
+    ///      `msg.sender == configured warp route`, so this warp route must be set as
+    ///      `L1HypNativeGateway._warpRoute` via `setWarpRoute()` before inbound traffic
+    ///      can flow.
+    function sendNativeTokens(address to) external payable;
+}
+
+/**
+ * @title L1FluentHypNative
+ * @author Fluent Labs
+ *
+ * @notice Custom Hyperlane warp route on Ethereum: forwards inbound native-ETH Hyperlane
+ *         deliveries through `L1HypNativeGateway.sendNativeTokens` to Fluent L2 instead
+ *         of releasing ETH on L1. The gateway wraps `FluentBridge.sendMessage` together
+ *         with rate-limit and blacklist enforcement, so this warp route only knows about
+ *         the gateway. Outbound (`transferRemote`) is unchanged from stock {HypNative} so
+ *         the existing `L1HypNativeGateway` L2→external flow keeps working against this
+ *         implementation.
+ *
+ * @dev Inbound contract: {_handle} is overridden — NOT {_transferTo} — because
+ *      {_transferTo} is the shared primitive for *all* outbound native pushes from this
+ *      router, including ERC4626 LP withdrawals via {LpCollateralRouter._withdraw} and
+ *      fee distribution. Overriding it would redirect those flows through the L2 gateway,
+ *      which is wrong: LPs and `feeRecipient`s expect to receive ETH on L1. {_handle} is
+ *      the Hyperlane-delivery–specific seam, so the override lives there.
+ *
+ *      Deployment ordering: the gateway must call `setWarpRoute(address(this))` after
+ *      this contract is deployed and registered, otherwise inbound deliveries revert at
+ *      the gateway with `UnauthorizedWarpRoute`. That revert is itself benign — see the
+ *      revert-and-retry note below — but until the wiring is in place no inbound message
+ *      will be delivered.
+ *
+ *      Revert-and-retry: if anything in the gateway → bridge chain reverts
+ *      (`UnauthorizedWarpRoute`, `InvalidRecipient`, recipient blacklist hit, bridge
+ *      paused, destination de-whitelisted), {_handle} reverts → `Mailbox.process`
+ *      atomically rolls back `deliveries[_id]` → the message stays retryable via
+ *      permissionless `Mailbox.process(_metadata, _message)`. This matches every
+ *      Hyperlane warp route in upstream and is the canonical recovery mechanism. There
+ *      is intentionally no quarantine bucket.
+ *
+ *      Zero-recipient guard: a message decoded with `recipient == address(0)` is rejected
+ *      here with {ZeroRecipient} rather than at the gateway. The gateway would also
+ *      revert in this case, but its revert recurs indefinitely on every retry, turning
+ *      the message into a permanent retry tombstone. Failing fast at the warp route gives
+ *      monitoring a clear, locally-owned error to alert on.
+ *
+ *      Fee handling: {_transferFee} is overridden to keep protocol-fee delivery on L1
+ *      (canonical pattern from {TokenBridgeCctpBase} / {EverclearTokenBridge}). Without
+ *      this, a configured `feeRecipient` would receive its share on L2 instead of L1.
+ *
+ *      Storage: zero new storage slots. All Fluent-specific config is `immutable`.
+ *      Deployed behind a `TransparentUpgradeableProxy` like every other warp route in
+ *      this repo; the proxy admin gates upgrades and is distinct from the
+ *      `OwnableUpgradeable` owner inherited from {HypNative}.
+ */
+contract L1FluentHypNative is HypNative {
+    using TypeCasts for bytes32;
+    using TokenMessage for bytes;
+
+    /// @notice The `L1HypNativeGateway` that forwards inbound deliveries through Fluent's
+    ///         L1↔L2 bridge. Must be configured to recognize this warp route as its
+    ///         authorized caller (`L1HypNativeGateway.setWarpRoute(address(this))`).
+    IL1HypNativeGateway public immutable l1HypNativeGateway;
+
+    error GatewayAddressZero();
+    error ZeroRecipient();
+
+    constructor(
+        uint256 _scaleNumerator,
+        uint256 _scaleDenominator,
+        address _mailbox,
+        address _l1HypNativeGateway
+    ) HypNative(_scaleNumerator, _scaleDenominator, _mailbox) {
+        if (_l1HypNativeGateway == address(0)) revert GatewayAddressZero();
+        l1HypNativeGateway = IL1HypNativeGateway(_l1HypNativeGateway);
+    }
+
+    /**
+     * @inheritdoc TokenRouter
+     * @dev Decodes the canonical Hyperlane token message, applies inbound scaling, and
+     *      forwards the native amount through `L1HypNativeGateway.sendNativeTokens`
+     *      instead of releasing ETH on L1. The {ReceivedTransferRemote} event is emitted
+     *      with the unscaled message amount for indexer parity with stock {HypNative}.
+     *      Reverts with {ZeroRecipient} on `recipient == address(0)` so a malformed
+     *      source-chain dispatch surfaces immediately at this contract instead of
+     *      cycling through gateway-level retries.
+     */
+    function _handle(
+        uint32 _origin,
+        bytes32 /*_sender*/,
+        bytes calldata _message
+    ) internal override {
+        bytes32 recipientBytes = _message.recipient();
+        address recipient = recipientBytes.bytes32ToAddress();
+        if (recipient == address(0)) revert ZeroRecipient();
+
+        uint256 messageAmount = _message.amount();
+        uint256 localAmount = _inboundAmount(messageAmount);
+
+        emit ReceivedTransferRemote(_origin, recipientBytes, messageAmount);
+
+        l1HypNativeGateway.sendNativeTokens{value: localAmount}(recipient);
+    }
+
+    /**
+     * @inheritdoc TokenRouter
+     * @dev Keep protocol-fee delivery on L1 instead of forwarding through
+     *      {l1HypNativeGateway} to L2 (which is where the default
+     *      `_transferFee → _transferTo` would route it). `feeRecipient` is an L1 address.
+     */
+    function _transferFee(
+        address _recipient,
+        uint256 _amount
+    ) internal override {
+        NativeCollateral._transferTo(_recipient, _amount);
+    }
+}

--- a/solidity/script/ArbSepoliaHypNative.s.sol
+++ b/solidity/script/ArbSepoliaHypNative.s.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.22;
+
+import {HypNative} from "../contracts/token/HypNative.sol";
+import {TransparentUpgradeableProxy} from "../contracts/upgrade/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "../contracts/upgrade/ProxyAdmin.sol";
+import {TypeCasts} from "../contracts/libs/TypeCasts.sol";
+
+import "forge-std/Script.sol";
+
+/// @dev Deploys a stock HypNative on Arbitrum Sepolia as the peer of
+///      L1FluentHypNative on Sepolia.
+///
+///      Sign via `cast wallet`:
+///        forge script solidity/script/ArbSepoliaHypNative.s.sol:ArbSepoliaHypNativeScript \
+///          --rpc-url $ARB_SEPOLIA_RPC --account <name> --sender <addr> --broadcast --verify
+///
+///      After `run()`:
+///        1) Fill `WARP_ROUTE` with the proxy from run() and call enrollRemote().
+///        2) On the Sepolia side, also enroll this proxy back via
+///           L1FluentHypNative.s.sol:enrollRemote().
+contract ArbSepoliaHypNativeScript is Script {
+    using TypeCasts for address;
+
+    // ─── Deploy config (Arbitrum Sepolia) ───
+    address internal constant MAILBOX =
+        0x598facE78a4302f11E3de0bee1894Da0b2Cb71F8;
+    address internal constant HOOK = address(0);
+    address internal constant ISM = address(0);
+    address internal constant OWNER =
+        0x18FA4399b515F436E213AF5E5aD3337EbCb6E717;
+
+    // 1:1 — both legs are 18-decimal native ETH.
+    uint256 internal constant SCALE_NUMERATOR = 1;
+    uint256 internal constant SCALE_DENOMINATOR = 1;
+
+    // ─── Enroll config ───
+    address internal constant WARP_ROUTE =
+        0xC5790c39284BBd0a0707c553fE6d782948c11ED8;
+    uint32 internal constant REMOTE_DOMAIN = 11155111; // Sepolia
+    address internal constant REMOTE_ROUTER =
+        0x6197Dc5A4e021B0C2a67334d94704425F87374A7; // L1FluentHypNative on Sepolia
+
+    function run() public {
+        require(OWNER != address(0), "set OWNER constant");
+
+        vm.startBroadcast();
+
+        HypNative impl = new HypNative(
+            SCALE_NUMERATOR,
+            SCALE_DENOMINATOR,
+            MAILBOX
+        );
+
+        ProxyAdmin proxyAdmin = new ProxyAdmin();
+
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(impl),
+            address(proxyAdmin),
+            abi.encodeCall(HypNative.initialize, (HOOK, ISM, OWNER))
+        );
+
+        vm.stopBroadcast();
+
+        console.log("ProxyAdmin     :", address(proxyAdmin));
+        console.log("HypNative impl :", address(impl));
+        console.log("HypNative      :", address(proxy));
+    }
+
+    function enrollRemote() public {
+        require(WARP_ROUTE != address(0), "set WARP_ROUTE constant");
+
+        vm.startBroadcast();
+        HypNative(payable(WARP_ROUTE)).enrollRemoteRouter(
+            REMOTE_DOMAIN,
+            REMOTE_ROUTER.addressToBytes32()
+        );
+        vm.stopBroadcast();
+    }
+}

--- a/solidity/script/L1FluentHypNative.s.sol
+++ b/solidity/script/L1FluentHypNative.s.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.22;
+
+import {L1FluentHypNative} from "../contracts/token/extensions/L1FluentHypNative.sol";
+import {HypNative} from "../contracts/token/HypNative.sol";
+import {TransparentUpgradeableProxy} from "../contracts/upgrade/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "../contracts/upgrade/ProxyAdmin.sol";
+import {TypeCasts} from "../contracts/libs/TypeCasts.sol";
+
+import "forge-std/Script.sol";
+
+/// @dev Deploys `L1FluentHypNative` behind a fresh `ProxyAdmin` +
+///      `TransparentUpgradeableProxy`. Same flow as every other warp route in
+///      this repo: impl → proxy → `initialize(hook, ism, owner)`.
+///
+///      Sign via `cast wallet`:
+///        forge script solidity/script/L1FluentHypNative.s.sol:L1FluentHypNativeScript \
+///          --rpc-url $SEPOLIA_RPC --account <name> --sender <addr> --broadcast --verify
+///
+///      After `run()`:
+///        1) Gateway owner calls `L1HypNativeGateway.setWarpRoute(<proxy>)`.
+///        2) After the peer is deployed, fill `WARP_ROUTE` + `REMOTE_ROUTER`
+///           below and run with `--sig "enrollRemote()"`.
+contract L1FluentHypNativeScript is Script {
+    using TypeCasts for address;
+
+    // ─── Deploy config (Sepolia) ───
+    address internal constant MAILBOX =
+        0xfFAEF09B3cd11D9b20d1a19bECca54EEC2884766;
+    address internal constant GATEWAY =
+        0xe3f87C557c51b296DbC886De05744f0D52ecBb77;
+    address internal constant HOOK = address(0);
+    address internal constant ISM = address(0);
+    address internal constant OWNER =
+        0x18FA4399b515F436E213AF5E5aD3337EbCb6E717;
+
+    // 1:1 — L1 native ETH and L2 native ETH share 18 decimals on Fluent.
+    uint256 internal constant SCALE_NUMERATOR = 1;
+    uint256 internal constant SCALE_DENOMINATOR = 1;
+
+    // ─── Enroll config (fill after run() + peer deploy) ───
+    address internal constant WARP_ROUTE =
+        0x6197Dc5A4e021B0C2a67334d94704425F87374A7;
+    uint32 internal constant REMOTE_DOMAIN = 421614; // Arbitrum Sepolia
+    address internal constant REMOTE_ROUTER =
+        0xC5790c39284BBd0a0707c553fE6d782948c11ED8;
+
+    function run() public {
+        require(OWNER != address(0), "set OWNER constant");
+
+        vm.startBroadcast();
+
+        L1FluentHypNative impl = new L1FluentHypNative(
+            SCALE_NUMERATOR,
+            SCALE_DENOMINATOR,
+            MAILBOX,
+            GATEWAY
+        );
+
+        ProxyAdmin proxyAdmin = new ProxyAdmin();
+
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(impl),
+            address(proxyAdmin),
+            abi.encodeCall(HypNative.initialize, (HOOK, ISM, OWNER))
+        );
+
+        vm.stopBroadcast();
+
+        console.log("ProxyAdmin            :", address(proxyAdmin));
+        console.log("L1FluentHypNative impl:", address(impl));
+        console.log("L1FluentHypNative     :", address(proxy));
+    }
+
+    function enrollRemote() public {
+        require(WARP_ROUTE != address(0), "set WARP_ROUTE constant");
+        require(REMOTE_ROUTER != address(0), "set REMOTE_ROUTER constant");
+
+        vm.startBroadcast();
+        L1FluentHypNative(payable(WARP_ROUTE)).enrollRemoteRouter(
+            REMOTE_DOMAIN,
+            REMOTE_ROUTER.addressToBytes32()
+        );
+        vm.stopBroadcast();
+    }
+}

--- a/solidity/script/SendArbToFluentL2.s.sol
+++ b/solidity/script/SendArbToFluentL2.s.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.22;
+
+import {HypNative} from "../contracts/token/HypNative.sol";
+import {TypeCasts} from "../contracts/libs/TypeCasts.sol";
+
+import "forge-std/Script.sol";
+
+/// @dev Sends a test native-ETH transfer through the Arb Sepolia HypNative
+///      warp route, addressed to a Fluent L2 recipient. The L1FluentHypNative
+///      on Sepolia auto-forwards the inbound to L2 via L1HypNativeGateway.
+///
+///      Recipient is encoded with `TypeCasts.addressToBytes32` (low-20-bytes
+///      convention) to avoid the `cast --to-bytes32` right-padding pitfall.
+///
+///      Run:
+///        forge script solidity/script/SendArbToFluentL2.s.sol:SendArbToFluentL2Script \
+///          --rpc-url $(arbsepolia) --account <name> --sender <addr> --broadcast
+contract SendArbToFluentL2Script is Script {
+    using TypeCasts for address;
+
+    // HypNative on Arb Sepolia.
+    address internal constant WARP_ROUTE =
+        0xC5790c39284BBd0a0707c553fE6d782948c11ED8;
+    // Sepolia mailbox domain — L1FluentHypNative auto-forwards to Fluent L2.
+    uint32 internal constant DESTINATION = 11155111;
+    uint256 internal constant SEND_AMOUNT = 0.0001 ether;
+    address internal constant L2_RECIPIENT =
+        0x18FA4399b515F436E213AF5E5aD3337EbCb6E717;
+
+    function run() public {
+        bytes32 recipient32 = L2_RECIPIENT.addressToBytes32();
+        uint256 gasFee = HypNative(payable(WARP_ROUTE)).quoteGasPayment(
+            DESTINATION
+        );
+        uint256 totalValue = SEND_AMOUNT + gasFee;
+
+        console.log("amount    :", SEND_AMOUNT);
+        console.log("gasFee    :", gasFee);
+        console.log("totalValue:", totalValue);
+        console.log("recipient :", L2_RECIPIENT);
+
+        vm.startBroadcast();
+        bytes32 messageId = HypNative(payable(WARP_ROUTE)).transferRemote{
+            value: totalValue
+        }(DESTINATION, recipient32, SEND_AMOUNT);
+        vm.stopBroadcast();
+
+        console.log("messageId :");
+        console.logBytes32(messageId);
+        console.log("Track at  : https://explorer.hyperlane.xyz/message/");
+    }
+}

--- a/solidity/script/SendFluentToArb.s.sol
+++ b/solidity/script/SendFluentToArb.s.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.22;
+
+import {TypeCasts} from "../contracts/libs/TypeCasts.sol";
+
+import "forge-std/Script.sol";
+
+/// @dev Minimal inline views of Fluent contracts — this repo cannot take a
+///      source-level dependency on `fluentlabs/solidity-contracts`. Canonical
+///      declarations live in that repo:
+///        - L2HypNativeGateway: contracts/gateways/L2HypNativeGateway.sol
+///        - FluentBridge:       contracts/bridge/FluentBridge.sol
+interface IL2HypNativeGateway {
+    function sendNativeTokens(
+        uint32 domain,
+        bytes32 recipient,
+        uint256 amount,
+        uint256 hypFee
+    ) external payable;
+
+    function MIN_HYP_FEE_NATIVE() external view returns (uint256);
+}
+
+interface IFluentBridge {
+    function getSentMessageFee() external view returns (uint256);
+}
+
+/// @dev Sends a test native-ETH transfer from Fluent L2 to Arbitrum Sepolia via:
+///      L2HypNativeGateway → FluentBridge → L1HypNativeGateway →
+///      L1FluentHypNative.transferRemote → Hyperlane → HypNative on Arb.
+///
+///      Recipient is encoded with `TypeCasts.addressToBytes32` so the
+///      `cast --to-bytes32` right-padding pitfall is avoided.
+///
+///      Prerequisites for this flow to succeed end-to-end:
+///        1) `L1HypNativeGateway` on Sepolia must have an ETH reserve to cover
+///           drift between the user-supplied `hypFee` (estimate) and the live
+///           `quoteTransferRemote` on the warp route. Top up with a plain
+///           `cast send <gateway> --value <amount>` on Sepolia if needed.
+///        2) `L1FluentHypNative.destinationGas[421614]` should be configured
+///           (via `setDestinationGas`) so the live Hyperlane quote covers
+///           actual destination handle gas on Arb Sepolia.
+///        3) Stock `HypNative` on Arb Sepolia needs ETH liquidity (already
+///           seeded via `deposit()` earlier).
+///
+///      Run:
+///        forge script solidity/script/SendFluentToArb.s.sol:SendFluentToArbScript \
+///          --rpc-url $(testnet) --account <name> --sender <addr> --broadcast
+contract SendFluentToArbScript is Script {
+    using TypeCasts for address;
+
+    address internal constant L2_GATEWAY =
+        0xe3f87C557c51b296DbC886De05744f0D52ecBb77;
+    address internal constant BRIDGE =
+        0x9CAcf613fC29015893728563f423fD26dCdB8Ddc;
+    uint32 internal constant DESTINATION = 421614; // Arbitrum Sepolia
+    uint256 internal constant SEND_AMOUNT = 0.0001 ether;
+    /// @dev User-supplied Hyperlane dispatch-fee budget; floor on the L2 gateway is
+    ///      `MIN_HYP_FEE_NATIVE` (0.001 ether). L1 gateway tops up from its admin
+    ///      reserve if the live L1 quote exceeds this.
+    uint256 internal constant HYP_FEE = 0.001 ether;
+    address internal constant ARB_RECIPIENT =
+        0x18FA4399b515F436E213AF5E5aD3337EbCb6E717;
+
+    function run() public {
+        bytes32 recipient32 = ARB_RECIPIENT.addressToBytes32();
+        uint256 bridgeFee = IFluentBridge(BRIDGE).getSentMessageFee();
+        uint256 totalValue = SEND_AMOUNT + HYP_FEE + bridgeFee;
+
+        console.log("amount    :", SEND_AMOUNT);
+        console.log("hypFee    :", HYP_FEE);
+        console.log("bridgeFee :", bridgeFee);
+        console.log("totalValue:", totalValue);
+        console.log("recipient :", ARB_RECIPIENT);
+
+        vm.startBroadcast();
+        IL2HypNativeGateway(L2_GATEWAY).sendNativeTokens{value: totalValue}(
+            DESTINATION,
+            recipient32,
+            SEND_AMOUNT,
+            HYP_FEE
+        );
+        vm.stopBroadcast();
+    }
+}

--- a/solidity/test/token/extensions/L1FluentHypNative.t.sol
+++ b/solidity/test/token/extensions/L1FluentHypNative.t.sol
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+import "forge-std/Test.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import {HypNative} from "../../../contracts/token/HypNative.sol";
+import {TokenMessage} from "../../../contracts/token/libs/TokenMessage.sol";
+import {TypeCasts} from "../../../contracts/libs/TypeCasts.sol";
+import {MockMailbox} from "../../../contracts/mock/MockMailbox.sol";
+import {LinearFee} from "../../../contracts/token/fees/LinearFee.sol";
+import {Quote} from "../../../contracts/interfaces/ITokenBridge.sol";
+import {IL1HypNativeGateway, L1FluentHypNative} from "../../../contracts/token/extensions/L1FluentHypNative.sol";
+
+/// @dev Records the last call and can be toggled to revert with a typed selector.
+contract MockL1HypNativeGateway is IL1HypNativeGateway {
+    error GatewayPaused();
+
+    bool public shouldRevert;
+    uint256 public callCount;
+    address public lastTo;
+    uint256 public lastValue;
+
+    function setShouldRevert(bool _shouldRevert) external {
+        shouldRevert = _shouldRevert;
+    }
+
+    function sendNativeTokens(address to) external payable override {
+        if (shouldRevert) revert GatewayPaused();
+        callCount++;
+        lastTo = to;
+        lastValue = msg.value;
+    }
+}
+
+contract L1FluentHypNativeTest is Test {
+    using TypeCasts for address;
+
+    uint32 internal constant ORIGIN = 11;
+    uint32 internal constant L1_DOMAIN = 12;
+    uint256 internal constant SCALE = 1;
+    uint256 internal constant TRANSFER_AMOUNT = 1 ether;
+
+    address internal alice = makeAddr("alice");
+    address internal proxyAdmin = makeAddr("proxyAdmin");
+    bytes32 internal remoteRouter =
+        TypeCasts.addressToBytes32(makeAddr("remoteRouter"));
+
+    MockMailbox internal mailbox;
+    MockL1HypNativeGateway internal gateway;
+    L1FluentHypNative internal warpRoute;
+
+    event ReceivedTransferRemote(
+        uint32 indexed origin,
+        bytes32 indexed recipient,
+        uint256 amount
+    );
+
+    function setUp() public {
+        mailbox = new MockMailbox(L1_DOMAIN);
+        // Self-link for dispatch: we only validate inbound semantics here, so the
+        // outbound message just needs somewhere to land (MockMailbox refuses dispatch
+        // to an unconfigured remote).
+        mailbox.addRemoteMailbox(ORIGIN, mailbox);
+        gateway = new MockL1HypNativeGateway();
+
+        warpRoute = _deploy(SCALE, SCALE, address(gateway));
+        warpRoute.enrollRemoteRouter(ORIGIN, remoteRouter);
+    }
+
+    function _deploy(
+        uint256 _scaleN,
+        uint256 _scaleD,
+        address _gateway
+    ) internal returns (L1FluentHypNative) {
+        L1FluentHypNative impl = new L1FluentHypNative(
+            _scaleN,
+            _scaleD,
+            address(mailbox),
+            _gateway
+        );
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(impl),
+            proxyAdmin,
+            abi.encodeCall(
+                HypNative.initialize,
+                (address(0), address(0), address(this))
+            )
+        );
+        return L1FluentHypNative(payable(proxy));
+    }
+
+    function _handleAsMailbox(
+        uint256 _messageAmount,
+        address _recipient
+    ) internal {
+        bytes memory body = TokenMessage.format(
+            _recipient.addressToBytes32(),
+            _messageAmount
+        );
+        vm.prank(address(mailbox));
+        warpRoute.handle(ORIGIN, remoteRouter, body);
+    }
+
+    // ====================================================
+    // Constructor
+    // ====================================================
+
+    function test_RevertIf_constructor_zeroGateway() public {
+        vm.expectRevert(L1FluentHypNative.GatewayAddressZero.selector);
+        new L1FluentHypNative(SCALE, SCALE, address(mailbox), address(0));
+    }
+
+    function test_constructor_storesImmutables() public view {
+        assertEq(
+            address(warpRoute.l1HypNativeGateway()),
+            address(gateway),
+            "gateway immutable"
+        );
+        assertEq(warpRoute.token(), address(0), "native token sentinel");
+    }
+
+    // ====================================================
+    // _handle: happy path
+    // ====================================================
+
+    function test_handle_forwardsToL2() public {
+        vm.deal(address(warpRoute), TRANSFER_AMOUNT);
+
+        vm.expectEmit(true, true, true, true, address(warpRoute));
+        emit ReceivedTransferRemote(
+            ORIGIN,
+            alice.addressToBytes32(),
+            TRANSFER_AMOUNT
+        );
+
+        _handleAsMailbox(TRANSFER_AMOUNT, alice);
+
+        assertEq(gateway.callCount(), 1, "gateway called once");
+        assertEq(gateway.lastTo(), alice, "gateway called with L2 recipient");
+        assertEq(
+            gateway.lastValue(),
+            TRANSFER_AMOUNT,
+            "gateway received full transfer amount"
+        );
+        assertEq(
+            address(warpRoute).balance,
+            0,
+            "warp route balance drained to gateway"
+        );
+        assertEq(
+            address(gateway).balance,
+            TRANSFER_AMOUNT,
+            "gateway holds forwarded native"
+        );
+    }
+
+    // ====================================================
+    // _handle: gateway revert + retry semantics
+    // ====================================================
+
+    function test_RevertIf_handle_gatewayReverts() public {
+        vm.deal(address(warpRoute), TRANSFER_AMOUNT);
+        gateway.setShouldRevert(true);
+
+        vm.prank(address(mailbox));
+        vm.expectRevert(MockL1HypNativeGateway.GatewayPaused.selector);
+        warpRoute.handle(
+            ORIGIN,
+            remoteRouter,
+            TokenMessage.format(alice.addressToBytes32(), TRANSFER_AMOUNT)
+        );
+
+        // Funds remain in the warp route — Mailbox.process rolls back atomically.
+        assertEq(
+            address(warpRoute).balance,
+            TRANSFER_AMOUNT,
+            "funds retained on revert"
+        );
+        assertEq(gateway.callCount(), 0, "gateway not called");
+    }
+
+    /// @dev A malformed source-chain dispatch with `recipient == address(0)` must fail
+    /// fast at the warp route with a typed error, instead of cycling through the
+    /// gateway's `InvalidRecipient` revert on every retry forever.
+    function test_RevertIf_handle_zeroRecipient() public {
+        vm.deal(address(warpRoute), TRANSFER_AMOUNT);
+
+        vm.prank(address(mailbox));
+        vm.expectRevert(L1FluentHypNative.ZeroRecipient.selector);
+        warpRoute.handle(
+            ORIGIN,
+            remoteRouter,
+            TokenMessage.format(bytes32(0), TRANSFER_AMOUNT)
+        );
+
+        assertEq(
+            address(warpRoute).balance,
+            TRANSFER_AMOUNT,
+            "funds retained on zero-recipient revert"
+        );
+        assertEq(
+            gateway.callCount(),
+            0,
+            "gateway not called for zero-recipient message"
+        );
+    }
+
+    /// @dev Locks down the revert-and-retry design: a transient gateway failure
+    /// must not strand funds; the same message can be re-delivered after the
+    /// gateway recovers and proceeds end-to-end.
+    function test_handle_retryAfterTransientFailure() public {
+        vm.deal(address(warpRoute), TRANSFER_AMOUNT);
+
+        // First attempt: gateway paused → handle reverts, funds stay.
+        gateway.setShouldRevert(true);
+        vm.prank(address(mailbox));
+        vm.expectRevert(MockL1HypNativeGateway.GatewayPaused.selector);
+        warpRoute.handle(
+            ORIGIN,
+            remoteRouter,
+            TokenMessage.format(alice.addressToBytes32(), TRANSFER_AMOUNT)
+        );
+        assertEq(
+            address(warpRoute).balance,
+            TRANSFER_AMOUNT,
+            "funds retained on first attempt"
+        );
+        assertEq(gateway.callCount(), 0, "gateway not called on first attempt");
+
+        // Operator unpauses the gateway and retries the same message.
+        gateway.setShouldRevert(false);
+        _handleAsMailbox(TRANSFER_AMOUNT, alice);
+
+        assertEq(gateway.callCount(), 1, "gateway called on retry");
+        assertEq(
+            gateway.lastValue(),
+            TRANSFER_AMOUNT,
+            "retry forwards full amount"
+        );
+        assertEq(address(warpRoute).balance, 0, "funds drained on retry");
+        assertEq(
+            address(gateway).balance,
+            TRANSFER_AMOUNT,
+            "gateway holds forwarded native after retry"
+        );
+    }
+
+    // ====================================================
+    // _transferFee stays on L1
+    // ====================================================
+
+    /// @dev With a fee recipient configured, the protocol fee charged on an
+    /// outbound `transferRemote` must land on the L1 fee contract — it must
+    /// not be forwarded through the gateway to L2.
+    function test_transferFee_staysOnL1() public {
+        uint256 feeAmount = 0.1 ether;
+        LinearFee feeContract = new LinearFee(
+            address(0), // native token
+            feeAmount,
+            TRANSFER_AMOUNT, // halfAmount: produces feeAmount/2 at TRANSFER_AMOUNT
+            address(this)
+        );
+        warpRoute.setFeeRecipient(address(feeContract));
+
+        // LinearFee with maxFee=feeAmount and halfAmount=TRANSFER_AMOUNT yields
+        // (TRANSFER_AMOUNT * feeAmount) / (2 * TRANSFER_AMOUNT) = feeAmount / 2.
+        uint256 expectedFee = feeAmount / 2;
+
+        Quote[] memory quotes = warpRoute.quoteTransferRemote(
+            ORIGIN,
+            alice.addressToBytes32(),
+            TRANSFER_AMOUNT
+        );
+        assertEq(
+            quotes[1].amount,
+            TRANSFER_AMOUNT + expectedFee,
+            "quote includes internal fee"
+        );
+
+        uint256 mailboxGas = quotes[0].amount;
+        uint256 totalValue = mailboxGas + TRANSFER_AMOUNT + expectedFee;
+
+        uint256 gatewayBalanceBefore = address(gateway).balance;
+        uint256 feeContractBalanceBefore = address(feeContract).balance;
+
+        vm.deal(alice, totalValue);
+        vm.prank(alice);
+        warpRoute.transferRemote{value: totalValue}(
+            ORIGIN,
+            alice.addressToBytes32(),
+            TRANSFER_AMOUNT
+        );
+
+        // Fee landed on L1 (fee contract), not on the gateway.
+        assertEq(
+            address(feeContract).balance - feeContractBalanceBefore,
+            expectedFee,
+            "fee lands on L1 fee contract"
+        );
+        assertEq(
+            address(gateway).balance,
+            gatewayBalanceBefore,
+            "no funds forwarded to gateway on outbound"
+        );
+    }
+
+    receive() external payable {}
+}


### PR DESCRIPTION
### Description

  New Hyperlane warp route variant for Fluent Labs's L1↔L2 stack. Inbound native-ETH
  deliveries on Ethereum are forwarded through `L1HypNativeGateway.sendNativeTokens`
  (which wraps Fluent's L1→L2 bridge) instead of being released on L1, so end users on
   Fluent L2 receive ETH on L2. Outbound `transferRemote` is unchanged from stock
  `HypNative` — the existing `L1HypNativeGateway` L2→external flow keeps working.

  - forwards inbound deliveries to Fluent L2 via gateway
  - keeps outbound transferRemote and fees on L1
  - guards malformed zero-recipient messages

  **Design note.** `_handle` is overridden (not `_transferTo`) because `_transferTo`
  is shared by `LpCollateralRouter._withdraw` (LP redemptions) and `_transferFee`
  (protocol-fee distribution) — both must stay on L1. `_transferFee` is explicitly
  overridden to bypass `_transferTo` and release fees directly to the L1 fee
  recipient. Full rationale in the contract NatSpec.

  **Deployment precondition.** Before the first inbound delivery, the L1 gateway must
  call `setWarpRoute(address(this))` on this contract; otherwise inbound `_handle`
  reverts at the gateway with `UnauthorizedWarpRoute`. That revert is part of
  Hyperlane's standard revert-and-retry path — once the wiring is in place, pending
  messages process on retry.

  ### Drive-by changes

  None.

  ### Related issues

  N/A — Fluent-internal initiative.

  ### Backward compatibility

  Yes. New file only. No changes to existing contracts, storage layouts, or public
  interfaces. Zero risk to deployed warp routes.

  ### Testing

  Unit Tests — 7 Foundry tests in
  `solidity/test/token/extensions/L1FluentHypNative.t.sol`:


  **Deployment precondition.** Before the first inbound delivery, the L1 gateway must
  call `setWarpRoute(address(this))` on this contract; otherwise inbound `_handle`
  reverts at the gateway with `UnauthorizedWarpRoute`. That revert is part of
  Hyperlane's standard revert-and-retry path — once the wiring is in place, pending
  messages process on retry.

  ### Drive-by changes

  None.

  ### Related issues

  N/A — Fluent-internal initiative.

  ### Backward compatibility

  Yes. New file only. No changes to existing contracts, storage layouts, or public
  interfaces. Zero risk to deployed warp routes.

  ### Testing

  Unit Tests — 7 Foundry tests in
  `solidity/test/token/extensions/L1FluentHypNative.t.sol`:

  - `test_RevertIf_constructor_zeroGateway` — zero gateway address rejected
  - `test_constructor_storesImmutables` — gateway immutable wired correctly
  - `test_handle_forwardsToL2` — happy path: gateway receives correct recipient and
  value
  - `test_RevertIf_handle_gatewayReverts` — gateway revert bubbles up, funds retained
  on warp route
  - `test_RevertIf_handle_zeroRecipient` — malformed `bytes32(0)` recipient rejected
  with typed `ZeroRecipient`
  - `test_handle_retryAfterTransientFailure` — same message succeeds after transient
  gateway failure
  - `test_transferFee_staysOnL1` — outbound protocol fee lands on L1 fee contract,
  never reaches gateway

  All 7 pass. `pnpm -C solidity test:forge` shows no regressions; pre-existing
  fork-test failures are unrelated (missing `RPC_URL_*` env vars).