### PR TITLE
fix: use enumerable set for blacklist ism

### DIFF
--- a/solidity/contracts/isms/BlacklistIsm.sol
+++ b/solidity/contracts/isms/BlacklistIsm.sol
@@ -8,6 +8,7 @@ import {PackageVersioned} from "../PackageVersioned.sol";
 
 // ============ External Imports ============
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 /**
  * @title BlacklistIsm
@@ -17,11 +18,11 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
  */
 contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
     using Message for bytes;
+    using EnumerableSet for EnumerableSet.Bytes32Set;
 
     uint8 public constant override moduleType = uint8(Types.NULL);
 
-    /// @notice message ID => true if blacklisted
-    mapping(bytes32 messageId => bool isBlacklisted) public blacklistedIds;
+    EnumerableSet.Bytes32Set private _blacklistedIds;
 
     event MessageBlacklisted(bytes32 indexed messageId);
     event MessageWhitelisted(bytes32 indexed messageId);
@@ -33,7 +34,7 @@ contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
     /// @notice Blacklist a batch of message IDs
     function blacklist(bytes32[] calldata _ids) external onlyOwner {
         for (uint256 i = 0; i < _ids.length; i++) {
-            blacklistedIds[_ids[i]] = true;
+            _blacklistedIds.add(_ids[i]);
             emit MessageBlacklisted(_ids[i]);
         }
     }
@@ -41,9 +42,14 @@ contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
     /// @notice Remove message IDs from the blacklist
     function whitelist(bytes32[] calldata _ids) external onlyOwner {
         for (uint256 i = 0; i < _ids.length; i++) {
-            delete blacklistedIds[_ids[i]];
+            _blacklistedIds.remove(_ids[i]);
             emit MessageWhitelisted(_ids[i]);
         }
+    }
+
+    /// @notice Returns all blacklisted message IDs
+    function blacklistedIds() external view returns (bytes32[] memory) {
+        return _blacklistedIds.values();
     }
 
     /// @inheritdoc IInterchainSecurityModule
@@ -51,6 +57,6 @@ contract BlacklistIsm is IInterchainSecurityModule, Ownable, PackageVersioned {
         bytes calldata,
         bytes calldata _message
     ) external view returns (bool) {
-        return !blacklistedIds[_message.id()];
+        return !_blacklistedIds.contains(_message.id());
     }
 }

--- a/solidity/test/isms/BlacklistIsm.t.sol
+++ b/solidity/test/isms/BlacklistIsm.t.sol
@@ -163,11 +163,32 @@ contract BlacklistIsmTest is Test {
         vm.prank(owner);
         ism.blacklist(ids);
 
-        assertTrue(ism.blacklistedIds(testMessageId));
+        bytes32[] memory listed = ism.blacklistedIds();
+        assertEq(listed.length, 1);
+        assertEq(listed[0], testMessageId);
+
         if (messageId == testMessageId) {
-            assertTrue(ism.blacklistedIds(messageId));
-        } else {
-            assertFalse(ism.blacklistedIds(messageId));
+            assertFalse(ism.verify("", abi.encodePacked(messageId)));
         }
+    }
+
+    function test_blacklistedIds_enumeration() public {
+        bytes32[] memory ids = new bytes32[](2);
+        ids[0] = testMessageId;
+        ids[1] = keccak256("other");
+        vm.prank(owner);
+        ism.blacklist(ids);
+
+        bytes32[] memory listed = ism.blacklistedIds();
+        assertEq(listed.length, 2);
+
+        vm.prank(owner);
+        bytes32[] memory removeOne = new bytes32[](1);
+        removeOne[0] = ids[0];
+        ism.whitelist(removeOne);
+
+        listed = ism.blacklistedIds();
+        assertEq(listed.length, 1);
+        assertEq(listed[0], ids[1]);
     }
 }


### PR DESCRIPTION
### Description

Replaces `mapping(bytes32 => bool)` with `EnumerableSet.Bytes32Set` in `BlacklistIsm` and adds a `blacklistedIds()` getter that returns all blacklisted IDs.

**Why:** The SDK/CLI reader (`EvmIsmReader.deriveNullConfig`) needs to reconstruct the full on-chain config to support `warp apply` and config-diff flows. Without enumeration, the reader always returns `blacklistedMessageIds: []`, causing every `apply` run to re-submit redundant transactions.

**Hot-path cost is unchanged:** `EnumerableSet.contains()` resolves to a single SLOAD against the internal `_positions` mapping — identical to the old `mapping(bytes32 => bool)` lookup.

**Trade-offs:**
- Write cost doubles (~2 SSTOREs per entry vs 1) — acceptable given sets are small by design
- `blacklistedIds()` is O(n) and subject to node-level `eth_call` gas caps (e.g. Alchemy caps at 550M gas, ~260k entries before hitting that ceiling); practical limit is non-issue for any realistic blacklist size

### Drive-by changes

- Updated `BlacklistIsm.t.sol` tests to use the new enumeration getter and added `test_blacklistedIds_enumeration` covering add/remove round-trips

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

No — storage layout changes. Existing deployed `BlacklistIsm` instances cannot be upgraded in-place; new deployments required.

### Testing

Unit tests (`BlacklistIsm.t.sol`)