### PR TITLE
feat(sdk)!: move ICA helpers to subpath export

### DIFF
--- a/.changeset/sdk-subpath-exports.md
+++ b/.changeset/sdk-subpath-exports.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': major
+---
+
+Move ICA call helper exports from the SDK root and `middleware/account/InterchainAccount` to `middleware/account/icaCalls`, and expose fee, middleware account, and utility modules through package subpath exports.

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -12,16 +12,18 @@ import {
   AccountConfig,
   InterchainAccount,
   MultiProvider,
+} from '@hyperlane-xyz/sdk';
+import {
   PostCallsIcaType,
   PostCallsLegacyType,
   PostCallsSchema,
   PostCallsType,
-  isPostCallsIca,
   commitmentFromIcaCalls,
   commitmentFromRevealMessage,
   encodeIcaCalls,
+  isPostCallsIca,
   normalizeCalls,
-} from '@hyperlane-xyz/sdk';
+} from '@hyperlane-xyz/sdk/middleware/account/icaCalls';
 import {
   addressToBytes32,
   bytes32ToAddress,

--- a/typescript/ccip-server/tests/services/CallCommitmentsService.test.ts
+++ b/typescript/ccip-server/tests/services/CallCommitmentsService.test.ts
@@ -6,7 +6,7 @@ import {
   commitmentFromIcaCalls,
   isPostCallsIca,
   normalizeCalls,
-} from '@hyperlane-xyz/sdk';
+} from '@hyperlane-xyz/sdk/middleware/account/icaCalls';
 
 import { CallCommitmentsService } from '../../src/services/CallCommitmentsService.js';
 

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -25,6 +25,10 @@
       "types": "./dist/core/*.d.ts",
       "default": "./dist/core/*.js"
     },
+    "./fee/*": {
+      "types": "./dist/fee/*.d.ts",
+      "default": "./dist/fee/*.js"
+    },
     "./hook/*": {
       "types": "./dist/hook/*.d.ts",
       "default": "./dist/hook/*.js"
@@ -36,6 +40,10 @@
     "./metadata/*": {
       "types": "./dist/metadata/*.d.ts",
       "default": "./dist/metadata/*.js"
+    },
+    "./middleware/account/*": {
+      "types": "./dist/middleware/account/*.d.ts",
+      "default": "./dist/middleware/account/*.js"
     },
     "./providers/builders/*": {
       "types": "./dist/providers/builders/*.d.ts",
@@ -112,6 +120,10 @@
     "./types": {
       "types": "./dist/types.d.ts",
       "default": "./dist/types.js"
+    },
+    "./utils/*": {
+      "types": "./dist/utils/*.d.ts",
+      "default": "./dist/utils/*.js"
     },
     "./warp/*": {
       "types": "./dist/warp/*.d.ts",

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -409,17 +409,7 @@ export {
   interchainAccountFactories,
 } from './middleware/account/contracts.js';
 export {
-  commitmentFromIcaCalls,
-  commitmentFromRevealMessage,
-  encodeIcaCalls,
   InterchainAccount,
-  normalizeCalls,
-  PostCallsSchema,
-  PostCallsType,
-  PostCallsLegacyType,
-  PostCallsIcaType,
-  isPostCallsIca,
-  RawCallData,
   shareCallsWithPrivateRelayer,
 } from './middleware/account/InterchainAccount.js';
 export { InterchainAccountChecker } from './middleware/account/InterchainAccountChecker.js';

--- a/typescript/sdk/src/middleware/account/InterchainAccount.test.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.test.ts
@@ -9,11 +9,8 @@ import { TestChainName } from '../../consts/testChains.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
 import { randomAddress } from '../../test/testUtils.js';
 
-import {
-  InterchainAccount,
-  PostCallsSchema,
-  commitmentFromRevealMessage,
-} from './InterchainAccount.js';
+import { InterchainAccount } from './InterchainAccount.js';
+import { PostCallsSchema, commitmentFromRevealMessage } from './icaCalls.js';
 
 describe('commitmentFromRevealMessage', () => {
   // https://explorer.hyperlane.xyz/message/0xd123b9eb8fc8777adf50963b2ad283f05332c584a1e4002f9e4ad21bdafea069

--- a/typescript/sdk/src/middleware/account/InterchainAccount.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.ts
@@ -1,27 +1,21 @@
-import { BigNumber, PopulatedTransaction, ethers, utils } from 'ethers';
-import { z } from 'zod';
-
-import { ZHash } from '../../metadata/customZodTypes.js';
+import { BigNumber, PopulatedTransaction, ethers } from 'ethers';
 import {
   InterchainAccountRouter,
   InterchainAccountRouter__factory,
 } from '@hyperlane-xyz/core';
 import {
   Address,
-  CallData,
   addBufferToGasLimit,
   addressToBytes32,
   arrayToObject,
   bytes32ToAddress,
   eqAddress,
-  fromHexString,
   formatStandardHookMetadata,
   isZeroishAddress,
   objFilter,
   objMap,
   parseStandardHookMetadata,
   promiseObjAll,
-  toHexString,
 } from '@hyperlane-xyz/utils';
 
 import { appFromAddressesMapHelper } from '../../contracts/contracts.js';
@@ -43,6 +37,7 @@ import {
   InterchainAccountFactories,
   interchainAccountFactories,
 } from './contracts.js';
+import type { PostCallsType } from './icaCalls.js';
 import { AccountConfig, GetCallRemoteSettings } from './types.js';
 
 const IGP_DEFAULT_GAS = BigNumber.from(50_000);
@@ -518,109 +513,6 @@ export async function deployInterchainAccount(
       coreAddressesByChain,
     );
   return interchainAccountApp.deployAccount(chain, config);
-}
-
-export function encodeIcaCalls(calls: CallData[], salt: string) {
-  return (
-    salt +
-    utils.defaultAbiCoder
-      .encode(
-        ['tuple(bytes32 to,uint256 value,bytes data)[]'],
-        [
-          calls.map((c) => ({
-            to: addressToBytes32(c.to),
-            value: c.value || 0,
-            data: c.data,
-          })),
-        ],
-      )
-      .slice(2)
-  );
-}
-
-// Convenience function to transform value strings to bignumber
-export type RawCallData = {
-  to: string;
-  value?: string | number;
-  data: string;
-};
-
-export function normalizeCalls(calls: RawCallData[]): CallData[] {
-  return calls.map((call) => ({
-    to: addressToBytes32(call.to),
-    value: BigNumber.from(call.value || 0),
-    data: call.data,
-  }));
-}
-
-export function commitmentFromIcaCalls(
-  calls: CallData[],
-  salt: string,
-): string {
-  return utils.keccak256(encodeIcaCalls(calls, salt));
-}
-
-/**
- * Format of REVEAL message:
- * [   0:  1] MessageType.REVEAL (uint8)
- * [   1: 33] ICA ISM (bytes32)
- * [  33: 65] Commitment (bytes32)
- */
-export function commitmentFromRevealMessage(message: string): string {
-  const messageBuffer = fromHexString(message);
-
-  // Validate minimum length (65 bytes: 1 byte type + 32 bytes ISM + 32 bytes commitment)
-  if (messageBuffer.length < 65) {
-    throw new Error(
-      `Invalid reveal message: expected at least 65 bytes, got ${messageBuffer.length} bytes`,
-    );
-  }
-
-  // Extract commitment from bytes 33-65 (32 bytes)
-  const commitment = messageBuffer.subarray(33, 65);
-
-  return toHexString(commitment);
-}
-
-const PostCallsBaseSchema = z.object({
-  calls: z
-    .array(
-      z.object({
-        to: ZHash,
-        data: z.string(),
-        value: z.string().optional(),
-      }),
-    )
-    .min(1),
-  relayers: z.array(ZHash),
-  salt: ZHash,
-  ismOverride: ZHash.optional(),
-  originDomain: z.number(),
-});
-
-// Legacy shape: ICA derived from dispatch tx receipt events
-const PostCallsLegacySchema = PostCallsBaseSchema.extend({
-  commitmentDispatchTx: ZHash,
-});
-
-// New shape: ICA derived directly from destination + owner
-const PostCallsIcaSchema = PostCallsBaseSchema.extend({
-  destinationDomain: z.number(),
-  owner: ZHash,
-  userSalt: ZHash.optional(),
-});
-
-export const PostCallsSchema = z.union([
-  PostCallsIcaSchema,
-  PostCallsLegacySchema,
-]);
-
-export type PostCallsType = z.infer<typeof PostCallsSchema>;
-export type PostCallsLegacyType = z.infer<typeof PostCallsLegacySchema>;
-export type PostCallsIcaType = z.infer<typeof PostCallsIcaSchema>;
-
-export function isPostCallsIca(data: PostCallsType): data is PostCallsIcaType {
-  return 'destinationDomain' in data && 'owner' in data;
 }
 
 export async function shareCallsWithPrivateRelayer(

--- a/typescript/sdk/src/middleware/account/icaCalls.ts
+++ b/typescript/sdk/src/middleware/account/icaCalls.ts
@@ -1,0 +1,113 @@
+import { BigNumber, utils } from 'ethers';
+import { z } from 'zod';
+import {
+  CallData,
+  addressToBytes32,
+  fromHexString,
+  toHexString,
+} from '@hyperlane-xyz/utils';
+
+import { ZHash } from '../../metadata/customZodTypes.js';
+
+export function encodeIcaCalls(calls: CallData[], salt: string) {
+  return (
+    salt +
+    utils.defaultAbiCoder
+      .encode(
+        ['tuple(bytes32 to,uint256 value,bytes data)[]'],
+        [
+          calls.map((c) => ({
+            to: addressToBytes32(c.to),
+            value: c.value || 0,
+            data: c.data,
+          })),
+        ],
+      )
+      .slice(2)
+  );
+}
+
+// Convenience function to transform value strings to bignumber
+export type RawCallData = {
+  to: string;
+  value?: string | number;
+  data: string;
+};
+
+export function normalizeCalls(calls: RawCallData[]): CallData[] {
+  return calls.map((call) => ({
+    to: addressToBytes32(call.to),
+    value: BigNumber.from(call.value || 0),
+    data: call.data,
+  }));
+}
+
+export function commitmentFromIcaCalls(
+  calls: CallData[],
+  salt: string,
+): string {
+  return utils.keccak256(encodeIcaCalls(calls, salt));
+}
+
+/**
+ * Format of REVEAL message:
+ * [   0:  1] MessageType.REVEAL (uint8)
+ * [   1: 33] ICA ISM (bytes32)
+ * [  33: 65] Commitment (bytes32)
+ */
+export function commitmentFromRevealMessage(message: string): string {
+  const messageBuffer = fromHexString(message);
+
+  // Validate minimum length (65 bytes: 1 byte type + 32 bytes ISM + 32 bytes commitment)
+  if (messageBuffer.length < 65) {
+    throw new Error(
+      `Invalid reveal message: expected at least 65 bytes, got ${messageBuffer.length} bytes`,
+    );
+  }
+
+  // Extract commitment from bytes 33-65 (32 bytes)
+  const commitment = messageBuffer.subarray(33, 65);
+
+  return toHexString(commitment);
+}
+
+const PostCallsBaseSchema = z.object({
+  calls: z
+    .array(
+      z.object({
+        to: ZHash,
+        data: z.string(),
+        value: z.string().optional(),
+      }),
+    )
+    .min(1),
+  relayers: z.array(ZHash),
+  salt: ZHash,
+  ismOverride: ZHash.optional(),
+  originDomain: z.number(),
+});
+
+// Legacy shape: ICA derived from dispatch tx receipt events
+const PostCallsLegacySchema = PostCallsBaseSchema.extend({
+  commitmentDispatchTx: ZHash,
+});
+
+// New shape: ICA derived directly from destination + owner
+const PostCallsIcaSchema = PostCallsBaseSchema.extend({
+  destinationDomain: z.number(),
+  owner: ZHash,
+  userSalt: ZHash.optional(),
+});
+
+export const PostCallsSchema = z.union([
+  PostCallsIcaSchema,
+  PostCallsLegacySchema,
+]);
+
+export type PostCallsType = z.infer<typeof PostCallsSchema>;
+export type PostCallsLegacyType = z.infer<typeof PostCallsLegacySchema>;
+export type PostCallsIcaType = z.infer<typeof PostCallsIcaSchema>;
+
+export function isPostCallsIca(data: PostCallsType): data is PostCallsIcaType {
+  return 'destinationDomain' in data && 'owner' in data;
+}


### PR DESCRIPTION
## Summary

- Add SDK package subpath exports for `./fee/*`, `./middleware/account/*`, and `./utils/*`.
- Move ICA call-only helpers and schemas into `middleware/account/icaCalls`.
- Remove those ICA helper exports from the SDK root and `middleware/account/InterchainAccount`.
- Update ccip-server imports and tests to use the new ICA subpath.

## Breaking Change

This is intentionally a major SDK change. Consumers of `commitmentFromIcaCalls`, `commitmentFromRevealMessage`, `encodeIcaCalls`, `normalizeCalls`, `PostCallsSchema`, `isPostCallsIca`, and related `PostCalls*` or `RawCallData` types should import from:

```ts
import { PostCallsSchema, commitmentFromIcaCalls } from '@hyperlane-xyz/sdk/middleware/account/icaCalls';
```

## Stack

Downstream draft PRs depend on this SDK export surface:

- https://github.com/hyperlane-xyz/hyperlane-registry/pull/1524
- https://github.com/hyperlane-xyz/universal-router-engine/pull/11

Registry also uses the new `@hyperlane-xyz/sdk/utils/decimals` subpath to avoid copying scale-normalization logic.

## Validation

- `git diff --check`

Package builds/tests were not run locally because this checkout does not currently have monorepo dependencies installed.