### PR TITLE
fix(utils): make bytesToProtocolAddress format-only

### DIFF
--- a/.changeset/no-validate-bytes-to-protocol-address.md
+++ b/.changeset/no-validate-bytes-to-protocol-address.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/utils": patch
+---
+
+`bytesToProtocolAddress` no longer asserts that input bytes are non-zero. The function name describes a formatting operation, and decoders (explorer, CLI display, debug printouts) need to render stored zero-bytes addresses rather than throw. Zero-address rejection during transfer construction still happens at the inverse `addressToBytes` and at the WarpCore `validateRecipient` layer.

--- a/.changeset/sdk-zero-recipient-guard.md
+++ b/.changeset/sdk-zero-recipient-guard.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Restored zero-recipient safety after `bytesToProtocolAddress` was made format-only: added explicit `assert(!isZeroishAddress(recipient))` to `EvmNativeTokenAdapter.populateTransferTx`, `EvmTokenAdapter.populateApproveTx`, `EvmTokenAdapter.populateTransferTx`, and `CosmNativeHypCollateralAdapter.populateTransferRemoteTx`. `WarpCore.validateRecipient` already gates the user-facing path; the adapter-level guards cover direct callers (tests, scripts).

--- a/typescript/sdk/src/token/adapters/CosmosModuleTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/CosmosModuleTokenAdapter.ts
@@ -9,6 +9,7 @@ import {
   assert,
   convertToProtocolAddress,
   isAddressCosmos,
+  isZeroishAddress,
 } from '@hyperlane-xyz/utils';
 
 import { BaseCosmNativeAdapter } from '../../app/MultiProtocolApp.js';
@@ -250,6 +251,11 @@ export class CosmNativeHypCollateralAdapter
       params.destination,
     );
     const destinationProtocol = destinationMetadata.protocol;
+
+    assert(
+      !isZeroishAddress(params.recipient),
+      `Refusing to construct cosmos remote transfer to zero recipient (${params.recipient})`,
+    );
 
     return provider.getRemoteTransferTransaction({
       signer: params.fromAccountOwner!,

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -146,6 +146,10 @@ export class EvmNativeTokenAdapter
     weiAmountOrId,
     recipient,
   }: TransferParams): Promise<PopulatedTransaction> {
+    assert(
+      !isZeroishAddress(recipient),
+      `Refusing to construct EVM native transfer to zero address (${recipient})`,
+    );
     const value = BigNumber.from(weiAmountOrId.toString());
     return { value, to: toEvmAddress(recipient) };
   }
@@ -218,6 +222,10 @@ export class EvmTokenAdapter<T extends ERC20 = ERC20>
     weiAmountOrId,
     recipient,
   }: TransferParams): Promise<PopulatedTransaction> {
+    assert(
+      !isZeroishAddress(recipient),
+      `Refusing to approve to zero address (${recipient})`,
+    );
     return this.contract.populateTransaction.approve(
       toEvmAddress(recipient),
       weiAmountOrId.toString(),
@@ -228,6 +236,10 @@ export class EvmTokenAdapter<T extends ERC20 = ERC20>
     weiAmountOrId,
     recipient,
   }: TransferParams): Promise<PopulatedTransaction> {
+    assert(
+      !isZeroishAddress(recipient),
+      `Refusing to construct ERC20 transfer to zero address (${recipient})`,
+    );
     return this.contract.populateTransaction.transfer(
       toEvmAddress(recipient),
       weiAmountOrId.toString(),

--- a/typescript/utils/src/addresses.test.ts
+++ b/typescript/utils/src/addresses.test.ts
@@ -107,13 +107,17 @@ describe('Address utilities', () => {
         ),
       ).to.equal(STARKNET_NON_ZERO_ADDR);
     });
-    it('Rejects zeroish addresses', () => {
-      expect(() =>
-        bytesToProtocolAddress(
-          new Uint8Array([0, 0, 0]),
-          ProtocolType.Ethereum,
-        ),
-      ).to.throw(Error);
+    it('Decodes all-zero bytes to the protocol zero address', () => {
+      // Scraper / on-chain data sometimes carries zero-byte addresses (e.g.
+      // unset destination_tx_sender). The decoder must format them rather
+      // than throw, leaving zero-address rejection to the transfer
+      // construction path (`addressToBytes`).
+      expect(
+        bytesToProtocolAddress(new Uint8Array(20), ProtocolType.Ethereum),
+      ).to.equal('0x0000000000000000000000000000000000000000');
+      expect(
+        bytesToProtocolAddress(new Uint8Array(32), ProtocolType.Starknet),
+      ).to.equal(STARKNET_ZERO_ADDR);
     });
   });
 

--- a/typescript/utils/src/addresses.ts
+++ b/typescript/utils/src/addresses.ts
@@ -691,10 +691,10 @@ export function bytesToProtocolAddress(
   toProtocol: ProtocolType,
   prefix?: string,
 ) {
-  assert(
-    bytes.length && !bytes.every((b) => b == 0),
-    'address bytes must not be empty',
-  );
+  // Formatting only: the inverse `addressToBytes` still rejects empty/all-zero
+  // input so transfer construction stays guarded. Callers that decode stored
+  // data (explorer, CLI display, debug printouts) need this to return the
+  // protocol's zero-address string instead of throwing.
   if (toProtocol === ProtocolType.Ethereum) {
     return bytesToAddressEvm(bytes);
   } else if (toProtocol === ProtocolType.Sealevel) {


### PR DESCRIPTION
## Summary

- Drop the `assert(bytes.length && !bytes.every((b) => b == 0), ...)` from `bytesToProtocolAddress`. The function name implies formatting; the validation belonged on the inverse path that constructs transfers, not on the decode path.
- Decoders (Hyperlane Explorer, Warp UI, CLI display, debug printouts) now format an all-zero / empty bytea into the protocol's zero-address string (Starknet 32-byte zero, Cosmos bech32 zero, Sealevel base58 zero, EVM `0x0...0`, etc.) instead of throwing.
- Update the matching unit test to assert the new behavior.
- Add explicit `assert(!isZeroishAddress(recipient))` at the four warp transfer construction sites that previously relied on the relaxed assert for safety: `EvmNativeTokenAdapter.populateTransferTx`, `EvmTokenAdapter.populateApproveTx`, `EvmTokenAdapter.populateTransferTx`, `CosmNativeHypCollateralAdapter.populateTransferRemoteTx`.

## Why

The scraper indexes `origin_tx_sender` as 20 all-zero bytes for some non-EVM transactions (observed on paradex mainnet, e.g. message [`0x77a1…da61`](https://explorer.hyperlane.xyz/message/0x77a1f8758523f98bcc87b0f0d0ea0433dc67e790308e554c5ea45710ec45da61)). The Hyperlane Explorer's `parseMessage` calls `postgresByteaToAddress` → `bytesToProtocolAddress`, which throws on the all-zero input. `parseMessage` catches the throw and returns `null`, so the explorer page renders "Message not found" and falls back to PI search across every EVM chain. Same row returns from Hasura just fine.

The initial hotfix attempt (hyperlane-explorer#328, since closed) returned the raw hex string from the explorer's `postgresByteaToAddress`. That was wrong for non-EVM chains — it would render `0x000…` instead of the protocol-correct zero (Cosmos bech32, Sealevel base58, etc.). Relaxing the assert at the utils layer means every decoder gets protocol-correct formatting without any change to its own code.

## Consumer audit

I went through every caller of `bytesToProtocolAddress` and `convertToProtocolAddress` (which calls `bytesToProtocolAddress` internally) and classified them by purpose:

**Display / decode (now correctly format zero address, no change needed):**
- `hyperlane-explorer`: `features/messages/queries/encoding.ts`, `features/messages/utils.ts`, `utils/url.ts`
- `hyperlane-warp-ui-template`: `features/messages/queries/encoding.ts`, `features/messages/useMessageHistory.ts`
- monorepo CLI: `cli/src/commands/message.ts`, `cli/src/commands/utils.ts`

**Estimation (sender used as recipient stand-in — benign):**
- `WarpCore.ts:316` (sender→destination protocol for gas estimation)
- `transactionFeeEstimators.ts:432` (Tron sender→EVM format)

**Transfer construction (previously relied on the assert — now gated explicitly):**
- `EvmNativeTokenAdapter.populateTransferTx` → adds `assert(!isZeroishAddress(recipient))`
- `EvmTokenAdapter.populateApproveTx` → adds `assert(!isZeroishAddress(recipient))`
- `EvmTokenAdapter.populateTransferTx` → adds `assert(!isZeroishAddress(recipient))`
- `CosmNativeHypCollateralAdapter.populateTransferRemoteTx` → adds `assert(!isZeroishAddress(recipient))`

**Transfer construction with separate guard (no change needed):**
- `SealevelTokenAdapter.populateTransferRemoteTx` / `SealevelCrossCollateralAdapter.populateTransferRemoteToTx` — both encode via `addressToBytes`, which keeps its own non-zero assert.
- `WarpCore.validateRecipient` continues to reject `isZeroishAddress(recipient)` upstream for all protocols.

Net: any path that constructs a transfer to a zero recipient still fails fast; any path that just decodes stored on-chain or scraper data renders the protocol's zero address correctly.

## Test plan

- [x] `pnpm -C typescript/utils test` (337 passing, including the rewritten zero-bytes case)
- [x] `pnpm -C typescript/utils build`
- [x] `pnpm -C typescript/sdk build`
- [x] `pnpm -C typescript/sdk test:unit` (535 passing)
- [x] `pnpm lint`
- [ ] CI green