### PR TITLE
feat(keyfunder): support OP Stack bridge funding

### DIFF
--- a/typescript/keyfunder/README.md
+++ b/typescript/keyfunder/README.md
@@ -8,6 +8,7 @@ The KeyFunder service:
 
 - Funds agent keys (relayers, rebalancer) to maintain desired balances
 - Claims accumulated fees from InterchainGasPaymaster (IGP) contracts
+- Bridges native tokens to OP Stack child-chain funder wallets
 - Sweeps excess funds from the funder wallet to a safe address
 
 ## Configuration
@@ -47,6 +48,14 @@ chains:
     igp:
       address: '0x3b6044acd6767f017e99318AA6Ef93b7B06A5a22'
       claimThreshold: '0.1'
+  optimism:
+    bridge:
+      type: opStack
+      parentChain: ethereum
+      standardBridge: '0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1'
+      threshold: '0.2'
+      targetBalance: '1.0'
+      minGasLimit: 200000
 
 metrics:
   jobName: 'keyfunder-mainnet3'
@@ -65,6 +74,13 @@ chainsToSkip: []
 | `chains`                                 | Per-chain configuration                                                                          |
 | `chains.<chain>.balances`                | Map of role name to desired balance                                                              |
 | `chains.<chain>.balances.<role>`         | Target balance decimal string (e.g., "0.5" ETH; up to 18 decimals)                               |
+| `chains.<chain>.bridge`                  | Native token bridge configuration                                                                |
+| `chains.<chain>.bridge.type`             | Bridge type; currently supports `opStack`                                                        |
+| `chains.<chain>.bridge.parentChain`      | Chain name where the bridge transaction should be sent                                           |
+| `chains.<chain>.bridge.standardBridge`   | OP Stack L1StandardBridge address on the parent chain                                            |
+| `chains.<chain>.bridge.threshold`        | Child-chain funder balance below which bridge funding is triggered                               |
+| `chains.<chain>.bridge.targetBalance`    | Child-chain funder balance to reach after bridge funding; must be greater than `threshold`       |
+| `chains.<chain>.bridge.minGasLimit`      | Minimum gas limit passed to `bridgeETHTo` (default: 200000)                                      |
 | `chains.<chain>.igp`                     | IGP claim configuration                                                                          |
 | `chains.<chain>.igp.address`             | IGP contract address (required when `igp` is specified)                                          |
 | `chains.<chain>.igp.claimThreshold`      | Minimum IGP balance before claiming (decimal string; up to 18 decimals)                          |
@@ -142,6 +158,10 @@ Keys are funded when their balance drops below 40% of the desired balance. The f
 ### IGP Claims
 
 When the IGP contract balance exceeds the claim threshold, accumulated fees are claimed to the funder wallet.
+
+### OP Stack Bridge Funding
+
+When `bridge.type` is `opStack`, the child-chain funder balance is checked before key funding. If it is below `threshold`, the keyfunder sends native tokens through the configured parent-chain `standardBridge` to bring the child-chain funder up to `targetBalance`.
 
 ### Sweep
 

--- a/typescript/keyfunder/src/config/types.test.ts
+++ b/typescript/keyfunder/src/config/types.test.ts
@@ -177,6 +177,20 @@ describe('KeyFunderConfig Schemas', () => {
       expect(result.success).to.be.false;
     });
 
+    it('should reject OP Stack bridge target equal to threshold', () => {
+      const config = {
+        bridge: {
+          type: BridgeType.OpStack,
+          parentChain: 'ethereum',
+          standardBridge: '0x4200000000000000000000000000000000000010',
+          threshold: '1',
+          targetBalance: '1',
+        },
+      };
+      const result = ChainConfigSchema.safeParse(config);
+      expect(result.success).to.be.false;
+    });
+
     it('should reject OP Stack zero address bridge', () => {
       const config = {
         bridge: {

--- a/typescript/keyfunder/src/config/types.test.ts
+++ b/typescript/keyfunder/src/config/types.test.ts
@@ -8,6 +8,7 @@ import {
   KeyFunderConfigSchema,
   RoleConfigSchema,
   SweepConfigSchema,
+  BridgeType,
 } from './types.js';
 
 describe('KeyFunderConfig Schemas', () => {
@@ -143,6 +144,37 @@ describe('KeyFunderConfig Schemas', () => {
       };
       const result = ChainConfigSchema.safeParse(config);
       expect(result.success).to.be.true;
+    });
+
+    it('should validate OP Stack bridge config', () => {
+      const config = {
+        bridge: {
+          type: BridgeType.OpStack,
+          parentChain: 'ethereum',
+          standardBridge: '0x4200000000000000000000000000000000000010',
+          threshold: '0.2',
+          targetBalance: '1',
+        },
+      };
+      const result = ChainConfigSchema.safeParse(config);
+      expect(result.success).to.be.true;
+      if (result.success) {
+        expect(result.data.bridge?.minGasLimit).to.equal(200_000);
+      }
+    });
+
+    it('should reject OP Stack bridge target below threshold', () => {
+      const config = {
+        bridge: {
+          type: BridgeType.OpStack,
+          parentChain: 'ethereum',
+          standardBridge: '0x4200000000000000000000000000000000000010',
+          threshold: '1',
+          targetBalance: '0.9',
+        },
+      };
+      const result = ChainConfigSchema.safeParse(config);
+      expect(result.success).to.be.false;
     });
 
     it('should reject invalid balance value', () => {

--- a/typescript/keyfunder/src/config/types.test.ts
+++ b/typescript/keyfunder/src/config/types.test.ts
@@ -177,6 +177,20 @@ describe('KeyFunderConfig Schemas', () => {
       expect(result.success).to.be.false;
     });
 
+    it('should reject OP Stack zero address bridge', () => {
+      const config = {
+        bridge: {
+          type: BridgeType.OpStack,
+          parentChain: 'ethereum',
+          standardBridge: '0x0000000000000000000000000000000000000000',
+          threshold: '0.2',
+          targetBalance: '1',
+        },
+      };
+      const result = ChainConfigSchema.safeParse(config);
+      expect(result.success).to.be.false;
+    });
+
     it('should reject invalid balance value', () => {
       const config = {
         balances: {

--- a/typescript/keyfunder/src/config/types.ts
+++ b/typescript/keyfunder/src/config/types.ts
@@ -6,6 +6,11 @@ const AddressSchema = z
     /^0x[a-fA-F0-9]{40}$/,
     'Must be a valid Ethereum address (0x-prefixed, 40 hex characters)',
   );
+const NonZeroAddressSchema = AddressSchema.refine(
+  (address) =>
+    address.toLowerCase() !== '0x0000000000000000000000000000000000000000',
+  'Must not be the zero address',
+);
 
 // Requires leading digit (e.g., "0.5" not ".5") for YAML readability
 const BalanceStringSchema = z
@@ -75,7 +80,7 @@ export const OpStackBridgeConfigSchema = z
   .object({
     type: z.literal(BridgeType.OpStack),
     parentChain: z.string().min(1),
-    standardBridge: AddressSchema,
+    standardBridge: NonZeroAddressSchema,
     threshold: BalanceStringSchema,
     targetBalance: BalanceStringSchema,
     minGasLimit: z.number().int().nonnegative().default(200_000),

--- a/typescript/keyfunder/src/config/types.ts
+++ b/typescript/keyfunder/src/config/types.ts
@@ -15,6 +15,10 @@ const BalanceStringSchema = z
     'Must be a valid non-negative decimal string with leading digit (e.g., "0.5" not ".5", up to 18 decimals)',
   );
 
+export const BridgeType = {
+  OpStack: 'opStack',
+} as const;
+
 export const RoleConfigSchema = z.object({
   address: AddressSchema,
 });
@@ -67,8 +71,28 @@ export const SweepConfigSchema = z
     },
   );
 
+export const OpStackBridgeConfigSchema = z
+  .object({
+    type: z.literal(BridgeType.OpStack),
+    parentChain: z.string().min(1),
+    standardBridge: AddressSchema,
+    threshold: BalanceStringSchema,
+    targetBalance: BalanceStringSchema,
+    minGasLimit: z.number().int().nonnegative().default(200_000),
+  })
+  .refine(
+    (data) => compareBalanceStrings(data.targetBalance, data.threshold) > 0,
+    {
+      message: 'Bridge targetBalance must be greater than threshold',
+      path: ['targetBalance'],
+    },
+  );
+
+export const BridgeConfigSchema = OpStackBridgeConfigSchema;
+
 export const ChainConfigSchema = z.object({
   balances: z.record(z.string(), BalanceStringSchema).optional(),
+  bridge: BridgeConfigSchema.optional(),
   igp: IgpConfigSchema.optional(),
   sweep: SweepConfigSchema.optional(),
 });
@@ -108,6 +132,8 @@ export const KeyFunderConfigSchema = z
 export type RoleConfig = z.infer<typeof RoleConfigSchema>;
 export type IgpConfig = z.infer<typeof IgpConfigSchema>;
 export type SweepConfig = z.infer<typeof SweepConfigSchema>;
+export type OpStackBridgeConfig = z.infer<typeof OpStackBridgeConfigSchema>;
+export type BridgeConfig = z.infer<typeof BridgeConfigSchema>;
 export type ChainConfig = z.infer<typeof ChainConfigSchema>;
 export type MetricsConfig = z.infer<typeof MetricsConfigSchema>;
 export type KeyFunderConfig = z.infer<typeof KeyFunderConfigSchema>;
@@ -117,4 +143,25 @@ export interface ResolvedKeyConfig {
   address: string;
   role: string;
   desiredBalance: string;
+}
+
+function compareBalanceStrings(left: string, right: string): number {
+  const leftParts = splitBalance(left);
+  const rightParts = splitBalance(right);
+
+  if (leftParts.integer !== rightParts.integer) {
+    return leftParts.integer > rightParts.integer ? 1 : -1;
+  }
+  if (leftParts.fraction !== rightParts.fraction) {
+    return leftParts.fraction > rightParts.fraction ? 1 : -1;
+  }
+  return 0;
+}
+
+function splitBalance(balance: string): { integer: bigint; fraction: string } {
+  const [integer, fraction = ''] = balance.split('.');
+  return {
+    integer: BigInt(integer),
+    fraction: fraction.padEnd(18, '0'),
+  };
 }

--- a/typescript/keyfunder/src/core/KeyFunder.test.ts
+++ b/typescript/keyfunder/src/core/KeyFunder.test.ts
@@ -1,12 +1,43 @@
 import { expect } from 'chai';
+import { BigNumber, Wallet } from 'ethers';
+import type { ContractReceipt } from 'ethers';
 import type { Logger } from 'pino';
 import sinon from 'sinon';
 
 import { MultiProvider } from '@hyperlane-xyz/sdk';
 
-import type { KeyFunderConfig } from '../config/types.js';
+import { BridgeType, type KeyFunderConfig } from '../config/types.js';
 
 import { KeyFunder } from './KeyFunder.js';
+
+const nullLogger = {
+  child: () => nullLogger,
+  debug: () => undefined,
+  error: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+} as unknown as Logger;
+
+function createReceipt(transactionHash: string): ContractReceipt {
+  return {
+    to: '0x0000000000000000000000000000000000000001',
+    from: '0x0000000000000000000000000000000000000002',
+    contractAddress: '',
+    transactionIndex: 0,
+    gasUsed: BigNumber.from(0),
+    logsBloom: '',
+    blockHash: '0xabc',
+    transactionHash,
+    logs: [],
+    blockNumber: 1,
+    confirmations: 1,
+    cumulativeGasUsed: BigNumber.from(0),
+    effectiveGasPrice: BigNumber.from(0),
+    byzantium: true,
+    type: 0,
+    events: [],
+  };
+}
 
 describe('KeyFunder', () => {
   afterEach(() => {
@@ -85,5 +116,112 @@ describe('KeyFunder', () => {
     expect(
       (infoArgs[0] as { durationSeconds: unknown }).durationSeconds,
     ).to.be.a('number');
+  });
+
+  it('should bridge to an OP Stack chain when child funder balance is below threshold', async () => {
+    const childFunder = '0x1111111111111111111111111111111111111111';
+    const parentSigner = Wallet.createRandom();
+    const childProvider = {
+      getBalance: sinon.stub().resolves(BigNumber.from(0)),
+    } as unknown as ReturnType<MultiProvider['getProvider']>;
+    sinon
+      .stub(parentSigner, 'getBalance')
+      .resolves(BigNumber.from(10).pow(18).mul(2));
+
+    const multiProvider = sinon.createStubInstance(MultiProvider);
+    multiProvider.getSignerAddress.withArgs('optimism').resolves(childFunder);
+    multiProvider.getProvider.withArgs('optimism').returns(childProvider);
+    multiProvider.getSigner.withArgs('ethereum').returns(parentSigner);
+    multiProvider.getTransactionOverrides.withArgs('ethereum').returns({});
+    multiProvider.handleTx.resolves(createReceipt('0xabc'));
+    multiProvider.tryGetExplorerTxUrl.returns(null);
+
+    const bridgeETHTo = sinon.stub().resolves({ hash: '0xabc' });
+    const config: KeyFunderConfig = {
+      version: '1',
+      roles: {},
+      chains: {
+        optimism: {
+          bridge: {
+            type: BridgeType.OpStack,
+            parentChain: 'ethereum',
+            standardBridge: '0x4200000000000000000000000000000000000010',
+            threshold: '0.5',
+            targetBalance: '1',
+            minGasLimit: 200_000,
+          },
+        },
+      },
+    };
+
+    const keyFunder = new KeyFunder(multiProvider, config, {
+      logger: nullLogger,
+      opStackStandardBridgeFactory: () => ({ bridgeETHTo }),
+    });
+    sinon
+      .stub(
+        keyFunder as unknown as {
+          recordFunderBalance: (chain: string) => Promise<void>;
+        },
+        'recordFunderBalance',
+      )
+      .resolves();
+
+    await keyFunder.fundChain('optimism');
+
+    sinon.assert.calledOnce(bridgeETHTo);
+    expect(bridgeETHTo.firstCall.args[0]).to.equal(childFunder);
+    expect(bridgeETHTo.firstCall.args[1]).to.equal(200_000);
+    expect(bridgeETHTo.firstCall.args[2]).to.equal('0x');
+    expect(bridgeETHTo.firstCall.args[3].value.eq(BigNumber.from(10).pow(18)))
+      .to.be.true;
+    expect(multiProvider.handleTx.calledWith('ethereum')).to.be.true;
+  });
+
+  it('should skip OP Stack bridge when child funder balance is sufficient', async () => {
+    const childFunder = '0x1111111111111111111111111111111111111111';
+    const childProvider = {
+      getBalance: sinon.stub().resolves(BigNumber.from(10).pow(18)),
+    } as unknown as ReturnType<MultiProvider['getProvider']>;
+
+    const multiProvider = sinon.createStubInstance(MultiProvider);
+    multiProvider.getSignerAddress.withArgs('optimism').resolves(childFunder);
+    multiProvider.getProvider.withArgs('optimism').returns(childProvider);
+
+    const bridgeETHTo = sinon.stub();
+    const config: KeyFunderConfig = {
+      version: '1',
+      roles: {},
+      chains: {
+        optimism: {
+          bridge: {
+            type: BridgeType.OpStack,
+            parentChain: 'ethereum',
+            standardBridge: '0x4200000000000000000000000000000000000010',
+            threshold: '0.5',
+            targetBalance: '1',
+            minGasLimit: 200_000,
+          },
+        },
+      },
+    };
+
+    const keyFunder = new KeyFunder(multiProvider, config, {
+      logger: nullLogger,
+      opStackStandardBridgeFactory: () => ({ bridgeETHTo }),
+    });
+    sinon
+      .stub(
+        keyFunder as unknown as {
+          recordFunderBalance: (chain: string) => Promise<void>;
+        },
+        'recordFunderBalance',
+      )
+      .resolves();
+
+    await keyFunder.fundChain('optimism');
+
+    sinon.assert.notCalled(bridgeETHTo);
+    expect(multiProvider.handleTx.called).to.be.false;
   });
 });

--- a/typescript/keyfunder/src/core/KeyFunder.ts
+++ b/typescript/keyfunder/src/core/KeyFunder.ts
@@ -1,11 +1,14 @@
-import { BigNumber, ethers } from 'ethers';
+import { BigNumber, Contract, ethers } from 'ethers';
+import type { ContractTransaction, Signer, providers } from 'ethers';
 import type { Logger } from 'pino';
 
 import { HyperlaneIgp, MultiProvider } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
 
 import type {
   ChainConfig,
   KeyFunderConfig,
+  OpStackBridgeConfig,
   ResolvedKeyConfig,
 } from '../config/types.js';
 import type { KeyFunderMetrics } from '../metrics/Metrics.js';
@@ -14,12 +17,32 @@ const MIN_DELTA_NUMERATOR = BigNumber.from(6);
 const MIN_DELTA_DENOMINATOR = BigNumber.from(10);
 
 const CHAIN_FUNDING_TIMEOUT_MS = 60_000;
+const OP_STACK_STANDARD_BRIDGE_ABI = [
+  'function bridgeETHTo(address _to, uint32 _minGasLimit, bytes calldata _extraData) external payable',
+];
+
+type BridgeOverrides = Partial<providers.TransactionRequest> & {
+  value: BigNumber;
+};
+
+interface OpStackStandardBridge {
+  bridgeETHTo(
+    to: string,
+    minGasLimit: number,
+    extraData: string,
+    overrides: BridgeOverrides,
+  ): Promise<ContractTransaction>;
+}
 
 export interface KeyFunderOptions {
   logger: Logger;
   metrics?: KeyFunderMetrics;
   skipIgpClaim?: boolean;
   igp?: HyperlaneIgp;
+  opStackStandardBridgeFactory?: (
+    standardBridge: string,
+    signer: Signer,
+  ) => OpStackStandardBridge;
 }
 
 export class KeyFunder {
@@ -89,6 +112,10 @@ export class KeyFunder {
 
     if (!this.options.skipIgpClaim && chainConfig.igp) {
       await this.claimFromIgp(chain, chainConfig);
+    }
+
+    if (chainConfig.bridge) {
+      await this.bridgeToOpStack(chain, chainConfig.bridge);
     }
 
     try {
@@ -199,6 +226,102 @@ export class KeyFunder {
       );
       logger.info('IGP claim completed');
     }
+  }
+
+  private async bridgeToOpStack(
+    chain: string,
+    bridgeConfig: OpStackBridgeConfig,
+  ): Promise<void> {
+    const logger = this.options.logger.child({
+      chain,
+      operation: 'op-stack-bridge',
+      parentChain: bridgeConfig.parentChain,
+    });
+    const childFunderAddress = await this.multiProvider.getSignerAddress(chain);
+    const childFunderBalance = await this.multiProvider
+      .getProvider(chain)
+      .getBalance(childFunderAddress);
+    const threshold = ethers.utils.parseEther(bridgeConfig.threshold);
+
+    logger.info(
+      {
+        childFunderAddress,
+        childFunderBalance: ethers.utils.formatEther(childFunderBalance),
+        threshold: ethers.utils.formatEther(threshold),
+      },
+      'Checking OP Stack bridge conditions',
+    );
+
+    if (childFunderBalance.gte(threshold)) {
+      logger.debug('Child funder balance sufficient, skipping bridge');
+      return;
+    }
+
+    const targetBalance = ethers.utils.parseEther(bridgeConfig.targetBalance);
+    const bridgeAmount = targetBalance.sub(childFunderBalance);
+    const parentSigner = this.multiProvider.getSigner(bridgeConfig.parentChain);
+    const parentFunderAddress = await parentSigner.getAddress();
+    const parentFunderBalance = await parentSigner.getBalance();
+
+    assert(
+      parentFunderBalance.gte(bridgeAmount),
+      `Insufficient parent funder balance on ${bridgeConfig.parentChain}: has ${ethers.utils.formatEther(parentFunderBalance)}, needs ${ethers.utils.formatEther(bridgeAmount)}`,
+    );
+
+    logger.info(
+      {
+        bridgeAmount: ethers.utils.formatEther(bridgeAmount),
+        childFunderAddress,
+        parentFunderAddress,
+        parentFunderBalance: ethers.utils.formatEther(parentFunderBalance),
+        standardBridge: bridgeConfig.standardBridge,
+      },
+      'Bridging native tokens to OP Stack chain',
+    );
+
+    const standardBridge = this.createOpStackStandardBridge(
+      bridgeConfig.standardBridge,
+      parentSigner,
+    );
+    const tx = standardBridge.bridgeETHTo(
+      childFunderAddress,
+      bridgeConfig.minGasLimit,
+      '0x',
+      {
+        ...this.multiProvider.getTransactionOverrides(bridgeConfig.parentChain),
+        value: bridgeAmount,
+      },
+    );
+    const receipt = await this.multiProvider.handleTx(
+      bridgeConfig.parentChain,
+      tx,
+    );
+
+    logger.info(
+      {
+        txHash: receipt.transactionHash,
+        txUrl: this.multiProvider.tryGetExplorerTxUrl(
+          bridgeConfig.parentChain,
+          { hash: receipt.transactionHash },
+        ),
+      },
+      'OP Stack bridge transaction completed',
+    );
+  }
+
+  private createOpStackStandardBridge(
+    standardBridge: string,
+    signer: Signer,
+  ): OpStackStandardBridge {
+    return (
+      this.options.opStackStandardBridgeFactory ??
+      ((address: string, contractSigner: Signer) =>
+        new Contract(
+          address,
+          OP_STACK_STANDARD_BRIDGE_ABI,
+          contractSigner,
+        ) as unknown as OpStackStandardBridge)
+    )(standardBridge, signer);
   }
 
   private async fundKeys(

--- a/typescript/keyfunder/src/core/KeyFunder.ts
+++ b/typescript/keyfunder/src/core/KeyFunder.ts
@@ -315,12 +315,17 @@ export class KeyFunder {
   ): OpStackStandardBridge {
     return (
       this.options.opStackStandardBridgeFactory ??
-      ((address: string, contractSigner: Signer) =>
-        new Contract(
+      ((address: string, contractSigner: Signer) => {
+        const contract = new Contract(
           address,
           OP_STACK_STANDARD_BRIDGE_ABI,
           contractSigner,
-        ) as unknown as OpStackStandardBridge)
+        );
+        return {
+          bridgeETHTo: (to, minGasLimit, extraData, overrides) =>
+            contract.bridgeETHTo(to, minGasLimit, extraData, overrides),
+        };
+      })
     )(standardBridge, signer);
   }
 

--- a/typescript/keyfunder/src/index.ts
+++ b/typescript/keyfunder/src/index.ts
@@ -1,9 +1,12 @@
 export { KeyFunderConfigLoader } from './config/KeyFunderConfig.js';
 export {
+  BridgeType,
   KeyFunderConfigSchema,
   RoleConfigSchema,
   IgpConfigSchema,
   SweepConfigSchema,
+  BridgeConfigSchema,
+  OpStackBridgeConfigSchema,
   ChainConfigSchema,
   MetricsConfigSchema,
 } from './config/types.js';
@@ -13,6 +16,8 @@ export type {
   RoleConfig,
   IgpConfig,
   SweepConfig,
+  BridgeConfig,
+  OpStackBridgeConfig,
   ChainConfig,
   MetricsConfig,
   ResolvedKeyConfig,


### PR DESCRIPTION
Description

Adds OP Stack native bridge funding support to the new keyfunder so child-chain funder balances can be topped up from a configured parent chain before key funding runs.

Changes:
- add OP Stack bridge config schema and exports
- bridge to the configured L1StandardBridge when the child funder balance is below threshold
- document the keyfunder bridge config
- add config validation and keyfunder behavior tests

Related issues

Fixes #3402
/claim #3402

Testing

- `pnpm -C typescript/keyfunder format`
- `pnpm -C typescript/keyfunder lint`
- `pnpm -C typescript/keyfunder build`
- `pnpm -C typescript/keyfunder test`
- `git diff --check`