### PR TITLE
fix: use --writeMode in warp-deploy skills for http-registry

### DIFF
--- a/.claude/skills/warp-deploy-init-route/SKILL.md
+++ b/.claude/skills/warp-deploy-init-route/SKILL.md
@@ -471,7 +471,7 @@ Assemble the full deploy command. The command must be run from `typescript/cli`.
 
 > **Note:** The HTTP registry must be running before executing this command (started in Step 8). Start it first, then use its URL here.
 
-```bash
+```test
 cd /path/to/hyperlane-monorepo/typescript/cli && pnpm hyperlane warp deploy \
   --registry http://localhost:<port> \
   --warp-route-id <TOKEN>/<new-chain> \
@@ -493,7 +493,7 @@ Show the user the exact command with env variable names substituted (e.g. `$MY_E
 
 If the user confirms, first start the HTTP registry in the background to get private RPC URLs from Secret Manager:
 
-```bash
+```test
 cd <MONOREPO_ROOT> && pnpm -C typescript/infra start:http-registry --writeMode
 ```
 

--- a/.claude/skills/warp-deploy-init-route/SKILL.md
+++ b/.claude/skills/warp-deploy-init-route/SKILL.md
@@ -494,7 +494,7 @@ Show the user the exact command with env variable names substituted (e.g. `$MY_E
 If the user confirms, first start the HTTP registry in the background to get private RPC URLs from Secret Manager:
 
 ```bash
-cd <MONOREPO_ROOT> && pnpm -C typescript/infra start:http-registry
+cd <MONOREPO_ROOT> && pnpm -C typescript/infra start:http-registry --writeMode
 ```
 
 Run with `run_in_background: true`. Wait for the server to be ready by checking the logs for a line like `Listening on http://localhost:<port>`. Note the port (typically `3333`) and the background task/shell ID — you will need both to stop the server after the skill completes.
@@ -506,11 +506,10 @@ Tell the user upfront:
 > Chains: `<list all chains>`
 > You'll see the full output when it completes.
 
-Then run the deploy command from `typescript/cli`. Pass the local registry path **first** and the HTTP registry **second** — later entries take priority for reads (so HTTP private RPCs win), but both are in the merged write set (so local writes succeed when HTTP returns 405). Always use a 10-minute timeout (600000ms). Always include `--yes`:
+Then run the deploy command from `typescript/cli`. Use only the HTTP registry — it is started with `--writeMode` so it handles both private RPC reads and artifact writes. Always use a 10-minute timeout (600000ms). Always include `--yes`:
 
 ```bash
 cd /path/to/hyperlane-monorepo/typescript/cli && pnpm hyperlane warp deploy \
-  --registry $(pwd)/../hyperlane-registry \
   --registry http://localhost:<port> \
   --warp-route-id <TOKEN>/<new-chain> \
   --key.ethereum $MY_ETH_KEY_VAR \
@@ -559,7 +558,6 @@ cd /path/to/hyperlane-monorepo/typescript/cli
 
 # Forward (no fee on this direction for standard routes)
 pnpm hyperlane warp send \
-  --registry $(pwd)/../hyperlane-registry \
   --registry http://localhost:<port> \
   --origin <chain1> --destination <chain2> \
   --amount 10000 --key $MY_PK \
@@ -567,7 +565,6 @@ pnpm hyperlane warp send \
 
 # Return (fee charged — use reduced amount)
 pnpm hyperlane warp send \
-  --registry $(pwd)/../hyperlane-registry \
   --registry http://localhost:<port> \
   --origin <chain2> --destination <chain1> \
   --amount 9000 --key $MY_PK \
@@ -583,7 +580,6 @@ cd /path/to/hyperlane-monorepo/typescript/cli
 
 # For each synthetic chain: send native → synthetic (forward, no fee)
 pnpm hyperlane warp send \
-  --registry $(pwd)/../hyperlane-registry \
   --registry http://localhost:<port> \
   --origin <native-chain> --destination <synthetic-chain> \
   --amount 10000 --key $MY_PK \
@@ -591,7 +587,6 @@ pnpm hyperlane warp send \
 
 # Then return: synthetic → native (fee charged — use reduced amount)
 pnpm hyperlane warp send \
-  --registry $(pwd)/../hyperlane-registry \
   --registry http://localhost:<port> \
   --origin <synthetic-chain> --destination <native-chain> \
   --amount 9000 --key $MY_PK \

--- a/.claude/skills/warp-deploy-init-route/SKILL.md
+++ b/.claude/skills/warp-deploy-init-route/SKILL.md
@@ -467,13 +467,13 @@ Use the provided variable name(s) to build the command.
 
 ### 7d: Build and Show the Command
 
-Assemble the full deploy command. The command must be run from `typescript/cli`. Always include `--yes` to skip the interactive confirmation prompt:
+Assemble the full deploy command. The command must be run from `typescript/cli`. Always include `--yes` to skip the interactive confirmation prompt and a 10-minute timeout (600000ms).
+
+> **Note:** The HTTP registry must be running before executing this command (started in Step 8). Start it first, then use its URL here.
 
 ```bash
-cd typescript/cli
-
-pnpm hyperlane warp deploy \
-  --registry $REGISTRY_PATH \
+cd /path/to/hyperlane-monorepo/typescript/cli && pnpm hyperlane warp deploy \
+  --registry http://localhost:<port> \
   --warp-route-id <TOKEN>/<new-chain> \
   --key.ethereum $MY_ETH_KEY_VAR \
   [--key.sealevel $MY_SOL_KEY_VAR]   # only if sealevel chains present
@@ -481,7 +481,7 @@ pnpm hyperlane warp deploy \
   --yes
 ```
 
-Where `<TOKEN>/<new-chain>` is the warp route ID from Step 7a, and `$MY_ETH_KEY_VAR` etc. are the env variable names provided in 7c.
+Where `<TOKEN>/<new-chain>` is the warp route ID from Step 7a, `<port>` is the HTTP registry port (typically `3333`), and `$MY_ETH_KEY_VAR` etc. are the env variable names provided in 7c.
 
 Show the user the exact command with env variable names substituted (e.g. `$MY_ETH_KEY_VAR`), never key values. Then ask:
 

--- a/.claude/skills/warp-deploy-init-route/SKILL.md
+++ b/.claude/skills/warp-deploy-init-route/SKILL.md
@@ -467,11 +467,11 @@ Use the provided variable name(s) to build the command.
 
 ### 7d: Build and Show the Command
 
-Assemble the full deploy command. The command must be run from `typescript/cli`. Always include `--yes` to skip the interactive confirmation prompt and a 10-minute timeout (600000ms).
+Assemble the full deploy command. The command must be run from `typescript/cli`. Always include `--yes` to skip the interactive confirmation prompt.
 
 > **Note:** The HTTP registry must be running before executing this command (started in Step 8). Start it first, then use its URL here.
 
-```test
+```bash
 cd /path/to/hyperlane-monorepo/typescript/cli && pnpm hyperlane warp deploy \
   --registry http://localhost:<port> \
   --warp-route-id <TOKEN>/<new-chain> \
@@ -493,7 +493,7 @@ Show the user the exact command with env variable names substituted (e.g. `$MY_E
 
 If the user confirms, first start the HTTP registry in the background to get private RPC URLs from Secret Manager:
 
-```test
+```bash
 cd <MONOREPO_ROOT> && pnpm -C typescript/infra start:http-registry --writeMode
 ```
 
@@ -506,7 +506,7 @@ Tell the user upfront:
 > Chains: `<list all chains>`
 > You'll see the full output when it completes.
 
-Then run the deploy command from `typescript/cli`. Use only the HTTP registry — it is started with `--writeMode` so it handles both private RPC reads and artifact writes. Always use a 10-minute timeout (600000ms). Always include `--yes`:
+Then run the deploy command from `typescript/cli`. Use only the HTTP registry — it is started with `--writeMode` so it handles both private RPC reads and artifact writes. Always include `--yes`:
 
 ```bash
 cd /path/to/hyperlane-monorepo/typescript/cli && pnpm hyperlane warp deploy \

--- a/.claude/skills/warp-deploy-update-owners/SKILL.md
+++ b/.claude/skills/warp-deploy-update-owners/SKILL.md
@@ -113,18 +113,17 @@ Write the updated deploy.yaml back to the registry path. Show the user the diff 
 First, start the HTTP registry in the background to use private RPC URLs:
 
 ```bash
-cd <MONOREPO_ROOT> && pnpm -C typescript/infra start:http-registry
+cd <MONOREPO_ROOT> && pnpm -C typescript/infra start:http-registry --writeMode
 ```
 
 Run with `run_in_background: true`. Wait for the log line `Server running` and note the port (typically `3333`) and the background task ID — needed to stop the server after this step.
 
-Assemble the warp apply command. Pass local registry first, HTTP registry second — local receives writes, HTTP provides private RPCs for reads:
+Assemble the warp apply command. Use only the HTTP registry — started with `--writeMode` so it handles both private RPC reads and writes:
 
 ```bash
 cd typescript/cli
 
 pnpm hyperlane warp apply \
-  --registry $(pwd)/../hyperlane-registry \
   --registry http://localhost:<port> \
   --key.ethereum $MY_ETH_KEY_VAR \
   [--key.sealevel $MY_SOL_KEY_VAR]  # only if sealevel chains present
@@ -153,7 +152,6 @@ After warp apply completes, run warp read to confirm all ownership transfers too
 cd /path/to/hyperlane-monorepo/typescript/cli
 
 pnpm hyperlane warp read \
-  --registry $(pwd)/../hyperlane-registry \
   --registry http://localhost:<port> \
   -w <WARP_ROUTE_ID>
 ```
@@ -315,7 +313,7 @@ After showing the PR URL, tell the user:
 ## Notes
 
 - The registry path is `$(pwd)/../hyperlane-registry` when run from the monorepo root. The hyperlane-registry repo is expected to be cloned at the same level as hyperlane-monorepo.
-- Always pass `--registry $(pwd)/../hyperlane-registry --registry http://localhost:<port>` to CLI commands — local first (writes succeed here), HTTP last (private RPCs take priority for reads). HTTP returning 405 on writes is expected and non-fatal.
+- Always pass `--registry http://localhost:<port>` to CLI commands — the HTTP registry is started with `--writeMode` so it handles both private RPC reads and artifact writes.
 - If the ticket has links to token contracts on block explorers, use those addresses
 - Chain-level `owner` is typically an Abacus Works Safe address specified in the ticket
 - `tokenFee` block `owner` defaults to the Hyperlane ICA address from `warpFees.ts` unless the ticket says otherwise

--- a/.claude/skills/warp-deploy-update-owners/SKILL.md
+++ b/.claude/skills/warp-deploy-update-owners/SKILL.md
@@ -137,7 +137,7 @@ Show the user the exact command and ask:
 
 > **Ready to run warp apply to transfer ownership?** Type `yes` to execute, or `no` to run manually.
 
-If the user confirms, run it with a 10-minute timeout (600000ms). Show the full output on completion.
+If the user confirms, run it. Show the full output on completion.
 
 **On failure:** stop the HTTP registry (Step 10e), show the error, and stop. Do not proceed to Step 11. Common issues:
 


### PR DESCRIPTION
## Summary

- `warp-deploy-init-route` and `warp-deploy-update-owners` skills now start the HTTP registry with `--writeMode` so it accepts artifact writes
- Drop the redundant `--registry $(pwd)/../hyperlane-registry` flag from all `warp deploy`, `warp apply`, `warp read`, and `warp send` commands — the HTTP registry alone handles both private RPC reads and artifact writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)