### PR TITLE
chore: apply weighted rebalancing for USDC/igra

### DIFF
--- a/typescript/infra/config/environments/mainnet3/rebalancer/USDC/igra-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/USDC/igra-config.yaml
@@ -1,58 +1,52 @@
 warpRouteId: USDC/igra
 
 strategy:
-  rebalanceStrategy: minAmount
+  rebalanceStrategy: weighted
   chains:
     ethereum:
-      minAmount:
-        type: 'absolute'
-        min: 100
-        target: 150
+      weighted:
+        weight: 35
+        tolerance: 5
       bridgeLockTime: 1800
-      bridgeMinAcceptedAmount: 50
+      bridgeMinAcceptedAmount: 1000
       bridge: '0x8c8D831E1e879604b4B304a2c951B8AEe3aB3a23'
 
     arbitrum:
-      minAmount:
-        type: 'absolute'
-        min: 100
-        target: 150
+      weighted:
+        weight: 20
+        tolerance: 5
       bridgeLockTime: 1800
-      bridgeMinAcceptedAmount: 50
+      bridgeMinAcceptedAmount: 1000
       bridge: '0x4c19c653a8419A475d9B6735511cB81C15b8d9b2'
 
     base:
-      minAmount:
-        type: 'absolute'
-        min: 100
-        target: 150
+      weighted:
+        weight: 20
+        tolerance: 5
       bridgeLockTime: 1800
-      bridgeMinAcceptedAmount: 50
+      bridgeMinAcceptedAmount: 1000
       bridge: '0x33e94B6D2ae697c16a750dB7c3d9443622C4405a'
 
     polygon:
-      minAmount:
-        type: 'absolute'
-        min: 100
-        target: 150
+      weighted:
+        weight: 10
+        tolerance: 5
       bridgeLockTime: 1800
-      bridgeMinAcceptedAmount: 50
+      bridgeMinAcceptedAmount: 1000
       bridge: '0x33e94B6D2ae697c16a750dB7c3d9443622C4405a'
 
     optimism:
-      minAmount:
-        type: 'absolute'
-        min: 100
-        target: 150
+      weighted:
+        weight: 10
+        tolerance: 5
       bridgeLockTime: 1800
-      bridgeMinAcceptedAmount: 50
+      bridgeMinAcceptedAmount: 1000
       bridge: '0x33e94B6D2ae697c16a750dB7c3d9443622C4405a'
 
     avalanche:
-      minAmount:
-        type: 'absolute'
-        min: 100
-        target: 150
+      weighted:
+        weight: 5
+        tolerance: 5
       bridgeLockTime: 1800
-      bridgeMinAcceptedAmount: 50
+      bridgeMinAcceptedAmount: 1000
       bridge: '0x33e94B6D2ae697c16a750dB7c3d9443622C4405a'


### PR DESCRIPTION
### Description

Since the USDC/igra route has enough liquidity by now we can update the rebalancing config from the min amount strategy to the planned weighted rebalancing strategy according to the linear ticket: https://linear.app/hyperlane-xyz/issue/AW-542/igra-usdc

### Testing

Tested with monitor mode, it proposes several rebalances

`{
  routes: [
    { from: 'polygon', to: 'ethereum', amount: '6179687234' },
    { from: 'polygon', to: 'arbitrum', amount: '5405539963' },
    { from: 'base', to: 'optimism', amount: '2357348418' },
    { from: 'base', to: 'avalanche', amount: '1439943717' }
  ]
} Routes proposed`