### PR TITLE
fix: warp apply token fee removal

### DIFF
--- a/.changeset/blue-rivers-fix.md
+++ b/.changeset/blue-rivers-fix.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed warp apply when trying to remove warp fees from a warp route

--- a/typescript/sdk/src/token/EvmWarpModule.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.ts
@@ -1610,6 +1610,19 @@ export class EvmWarpModule extends HyperlaneModule<
     tokenReaderParams?: Partial<TokenFeeReaderParams>,
   ): Promise<AnnotatedEV5Transaction[]> {
     if (!expectedConfig.tokenFee) {
+      if (actualConfig.tokenFee) {
+        return [
+          {
+            annotation: 'Removing fee recipient...',
+            chainId: this.chainId,
+            to: this.args.addresses.deployedTokenRoute,
+            data: TokenRouter__factory.createInterface().encodeFunctionData(
+              'setFeeRecipient(address)',
+              [constants.AddressZero],
+            ),
+          },
+        ];
+      }
       return [];
     }
 


### PR DESCRIPTION
## Summary

- When `tokenFee` is absent from the warp config but present on-chain, `warp apply` now emits a `setFeeRecipient(address(0))` transaction to remove it
- Previously, absence of `tokenFee` in the expected config was silently treated as "no opinion", causing the "No updates needed" message even when a fee was still active on-chain

## Test plan

- [x] Run `warp apply` with `tokenFee` removed from a route that has one — confirm a `setFeeRecipient(address(0))` tx is generated
- [x] Run `warp apply` on a route with no `tokenFee` on-chain and none in config — confirm no tx is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)