### PR TITLE
chore: migrate to pnpm 11

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -86,7 +86,7 @@ RUN NODE_VER=$(ls "$NODENV_ROOT/plugins/node-build/share/node-build/" \
     nodenv global "$NODE_VER" && \
     nodenv rehash && \
     corepack enable pnpm && \
-    corepack prepare pnpm@latest --activate && \
+    corepack prepare pnpm@11.1.3 --activate && \
     nodenv rehash
 
 # --------------------------------------------------------------------------

--- a/.github/actions/pnpm-build-with-cache/action.yml
+++ b/.github/actions/pnpm-build-with-cache/action.yml
@@ -9,6 +9,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version-file: .nvmrc
+
     - name: Setup Foundry
       uses: ./.github/actions/setup-foundry
 

--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -38,9 +38,9 @@ runs:
       uses: buildjet/cache@v4
       with:
         path: ${{ steps.pnpm-store.outputs.store_path }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-pnpm-store-
+          ${{ runner.os }}-pnpm-11-store-
 
     - name: Cache (GitHub)
       id: github-cache
@@ -48,6 +48,6 @@ runs:
       uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-store.outputs.store_path }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-pnpm-store-
+          ${{ runner.os }}-pnpm-11-store-

--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -38,7 +38,7 @@ runs:
       uses: buildjet/cache@v4
       with:
         path: ${{ steps.pnpm-store.outputs.store_path }}
-        key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-11-store-
 
@@ -48,6 +48,6 @@ runs:
       uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-store.outputs.store_path }}
-        key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-11-store-

--- a/.github/workflows/cli-install-test.yml
+++ b/.github/workflows/cli-install-test.yml
@@ -22,14 +22,13 @@ jobs:
     strategy:
       matrix:
         os: ${{ (github.event_name == 'schedule' || inputs.include-windows) && fromJson('["depot-ubuntu-24.04", "depot-macos-15", "depot-windows-2025-8"]') || fromJson('["depot-ubuntu-24.04", "depot-macos-15"]') }}
-        node-version: [24, 25]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: .nvmrc
 
       - name: install-hyperlane-cli
         id: install-hyperlane-cli

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -6,6 +6,7 @@ on:
       - 'Dockerfile'
       - 'docker-entrypoint.sh'
       - '.dockerignore'
+      - '.nvmrc'
       - '.registryrc'
       - '.github/workflows/monorepo-docker.yml'
       - 'pnpm-lock.yaml'
@@ -14,6 +15,7 @@ on:
       - 'Dockerfile'
       - 'docker-entrypoint.sh'
       - '.dockerignore'
+      - '.nvmrc'
       - '.registryrc'
       - '.github/workflows/monorepo-docker.yml'
       - 'pnpm-lock.yaml'
@@ -81,6 +83,12 @@ jobs:
           FOUNDRY_VERSION=$(cat solidity/.foundryrc)
           echo "FOUNDRY_VERSION=$FOUNDRY_VERSION" >> $GITHUB_ENV
 
+      - name: Read Node version
+        shell: bash
+        run: |
+          NODE_VERSION=$(cat .nvmrc)
+          echo "NODE_VERSION=${NODE_VERSION#v}" >> $GITHUB_ENV
+
       - name: Determine platforms
         id: determine-platforms
         run: |
@@ -102,6 +110,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
+            NODE_VERSION=${{ env.NODE_VERSION }}
             FOUNDRY_VERSION=${{ env.FOUNDRY_VERSION }}
             REGISTRY_COMMIT=${{ env.REGISTRY_VERSION }}
           platforms: ${{ steps.determine-platforms.outputs.platforms }}

--- a/.github/workflows/node-services-docker.yml
+++ b/.github/workflows/node-services-docker.yml
@@ -7,6 +7,7 @@ on:
       - 'typescript/Dockerfile'
       - 'typescript/docker-entrypoint.sh'
       - '.dockerignore'
+      - '.nvmrc'
       - '.github/workflows/node-services-docker.yml'
       - 'pnpm-lock.yaml'
   pull_request:
@@ -14,6 +15,7 @@ on:
       - 'typescript/Dockerfile'
       - 'typescript/docker-entrypoint.sh'
       - '.dockerignore'
+      - '.nvmrc'
       - '.github/workflows/node-services-docker.yml'
       - 'pnpm-lock.yaml'
   workflow_dispatch:
@@ -84,6 +86,11 @@ jobs:
           FOUNDRY_VERSION=$(cat solidity/.foundryrc)
           echo "FOUNDRY_VERSION=$FOUNDRY_VERSION" >> $GITHUB_ENV
 
+      - name: Read Node version
+        run: |
+          NODE_VERSION=$(cat .nvmrc)
+          echo "NODE_VERSION=${NODE_VERSION#v}" >> $GITHUB_ENV
+
       - name: Determine platforms
         id: determine-platforms
         run: |
@@ -105,6 +112,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
+            NODE_VERSION=${{ env.NODE_VERSION }}
             FOUNDRY_VERSION=${{ env.FOUNDRY_VERSION }}
             SERVICE_VERSION=${{ steps.taggen.outputs.TAG_SHA }}-${{ steps.taggen.outputs.TAG_DATE }}
           platforms: ${{ steps.determine-platforms.outputs.platforms }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:24-slim
+ARG NODE_VERSION=24
+FROM node:${NODE_VERSION}-slim
 
 WORKDIR /hyperlane-monorepo
 

--- a/package.json
+++ b/package.json
@@ -36,26 +36,5 @@
     "tsx": "catalog:",
     "turbo": "^2.8.11"
   },
-  "packageManager": "pnpm@10.30.2",
-  "pnpm": {
-    "overrides": {
-      "async": "^2.6.4",
-      "fetch-ponyfill": "^7.1",
-      "flat": "^5.0.2",
-      "globals": "^16.3.0",
-      "lodash": "^4.17.21",
-      "recursive-readdir": "^2.2.3",
-      "underscore": "^1.13",
-      "undici": "^5.11",
-      "@babel/parser": "^7.22.7",
-      "@typechain/ethers-v5": "11.1.2",
-      "xmlhttprequest-ssl": "4.0.0"
-    },
-    "patchedDependencies": {
-      "typechain@8.3.2": "patches/typechain@8.3.2.patch",
-      "node-fetch@2.7.0": "patches/node-fetch@2.7.0.patch",
-      "bigint-buffer@1.1.5": "patches/bigint-buffer@1.1.5.patch",
-      "node-fetch@3.3.2": "patches/node-fetch@3.3.2.patch"
-    }
-  }
+  "packageManager": "pnpm@11.1.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,18 +306,10 @@ overrides:
   xmlhttprequest-ssl: 4.0.0
 
 patchedDependencies:
-  bigint-buffer@1.1.5:
-    hash: cd06d79b9cff13280e1a45a0f15abf67bc4ada4d7ad42bdfe120982ffa4340a2
-    path: patches/bigint-buffer@1.1.5.patch
-  node-fetch@2.7.0:
-    hash: 59af5fd5e6879432f6c8aaafe72ade0e018951d8576db2aedda3d59e5a7bc024
-    path: patches/node-fetch@2.7.0.patch
-  node-fetch@3.3.2:
-    hash: 9872737c7a2d7862012132c60c476cac6a03a48fe575d80388b4ba1176583bf9
-    path: patches/node-fetch@3.3.2.patch
-  typechain@8.3.2:
-    hash: fbb49bf3d1f71d8430767373c9ae33cd36e1aedd8ae9584d00dc90775f804950
-    path: patches/typechain@8.3.2.patch
+  bigint-buffer@1.1.5: cd06d79b9cff13280e1a45a0f15abf67bc4ada4d7ad42bdfe120982ffa4340a2
+  node-fetch@2.7.0: 59af5fd5e6879432f6c8aaafe72ade0e018951d8576db2aedda3d59e5a7bc024
+  node-fetch@3.3.2: 9872737c7a2d7862012132c60c476cac6a03a48fe575d80388b4ba1176583bf9
+  typechain@8.3.2: fbb49bf3d1f71d8430767373c9ae33cd36e1aedd8ae9584d00dc90775f804950
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -172,3 +172,20 @@ catalog:
   zod-validation-error: ^3.3.0
   yargs: ^17.7.2
   chalk: ^5.3.0
+overrides:
+  async: ^2.6.4
+  fetch-ponyfill: ^7.1
+  flat: ^5.0.2
+  globals: ^16.3.0
+  lodash: ^4.17.21
+  recursive-readdir: ^2.2.3
+  underscore: ^1.13
+  undici: ^5.11
+  '@babel/parser': ^7.22.7
+  '@typechain/ethers-v5': 11.1.2
+  xmlhttprequest-ssl: 4.0.0
+patchedDependencies:
+  typechain@8.3.2: patches/typechain@8.3.2.patch
+  node-fetch@2.7.0: patches/node-fetch@2.7.0.patch
+  bigint-buffer@1.1.5: patches/bigint-buffer@1.1.5.patch
+  node-fetch@3.3.2: patches/node-fetch@3.3.2.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -189,3 +189,23 @@ patchedDependencies:
   node-fetch@2.7.0: patches/node-fetch@2.7.0.patch
   bigint-buffer@1.1.5: patches/bigint-buffer@1.1.5.patch
   node-fetch@3.3.2: patches/node-fetch@3.3.2.patch
+allowBuilds:
+  '@prisma/engines': true
+  '@trufflesuite/bigint-buffer': true
+  bigint-buffer: true
+  bufferutil: true
+  core-js: true
+  core-js-pure: true
+  cpu-features: true
+  esbuild: true
+  keccak: true
+  node-hid: true
+  prisma: true
+  protobufjs: true
+  secp256k1: true
+  sharp: true
+  ssh2: true
+  tiny-secp256k1: true
+  usb: true
+  utf-8-validate: true
+  workerd: true

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -8,7 +8,8 @@
 # Runtime env:
 #   SERVICE_NAME - One of: rebalancer, warp-monitor, ccip-server, keyfunder, relayer, fee-quoting
 
-FROM node:24-slim AS builder
+ARG NODE_VERSION=24
+FROM node:${NODE_VERSION}-slim AS builder
 
 WORKDIR /hyperlane-monorepo
 
@@ -161,7 +162,7 @@ RUN SERVICES_DIR=/hyperlane-monorepo/services && \
     done
 
 # Production stage - minimal Alpine image with all service bundles
-FROM node:24-alpine AS runner
+FROM node:${NODE_VERSION}-alpine AS runner
 
 WORKDIR /app
 

--- a/typescript/cosmos-types/Dockerfile
+++ b/typescript/cosmos-types/Dockerfile
@@ -1,10 +1,10 @@
 ARG NODE_VERSION=24
-FROM bufbuild/buf:1.50.1 AS builder
+FROM bufbuild/buf:1.50.1 as BUILDER
 FROM node:${NODE_VERSION}-alpine
 
 RUN npm install -g ts-proto@v1.181.2
 
-COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=BUILDER /usr/local/bin /usr/local/bin
 
 # Inject user id and group id to avoid permission issues when running as a root user
 ARG USER_ID=1000

--- a/typescript/cosmos-types/Dockerfile
+++ b/typescript/cosmos-types/Dockerfile
@@ -1,9 +1,10 @@
-FROM bufbuild/buf:1.50.1 as BUILDER
-FROM node:24-alpine
+ARG NODE_VERSION=24
+FROM bufbuild/buf:1.50.1 AS builder
+FROM node:${NODE_VERSION}-alpine
 
 RUN npm install -g ts-proto@v1.181.2
 
-COPY --from=BUILDER /usr/local/bin /usr/local/bin
+COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Inject user id and group id to avoid permission issues when running as a root user
 ARG USER_ID=1000


### PR DESCRIPTION
## Summary
- Bumped the repo package manager pin to pnpm 11.1.3.
- Moved pnpm overrides and patched dependency config from `package.json#pnpm` into `pnpm-workspace.yaml` for pnpm 11.
- Pinned the Cursor image pnpm install to pnpm 11.1.3 instead of floating latest.

## Validation
- `pnpm@11.1.3 install --lockfile-only --ignore-scripts`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm install --frozen-lockfile`
- `git diff --check`

## Notes
- The frozen install emitted existing local-bin warnings for `hyperlane-rebalancer` because the workspace package output was not built locally.