### PR TITLE
fix(solidity): reject future standing quote issuedAt [HL-2026Q2-001]

### DIFF
--- a/.changeset/bright-quotes-settle.md
+++ b/.changeset/bright-quotes-settle.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": patch
+---
+
+Fixed standing offchain quote replacement validation.

--- a/.changeset/quoter-issued-at-bounds.md
+++ b/.changeset/quoter-issued-at-bounds.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": patch
+---
+
+AbstractOffchainQuoter.submitQuote was updated to reject standing quotes with future-dated issuedAt and to bound their lifetime by MAX_STANDING_TTL (7 days), preventing a compromised signer from permanently locking the monotonic issuedAt barrier with an indefinite expiry (HL-2026Q2-001). Transient quotes (expiry == issuedAt) are unaffected.

--- a/.changeset/quoter-issued-at-bounds.md
+++ b/.changeset/quoter-issued-at-bounds.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/core": patch
 ---
 
-AbstractOffchainQuoter.submitQuote was updated to reject standing quotes with future-dated issuedAt and to bound their lifetime by MAX_STANDING_TTL (7 days), preventing a compromised signer from permanently locking the monotonic issuedAt barrier with an indefinite expiry (HL-2026Q2-001). Transient quotes (expiry == issuedAt) are unaffected.
+AbstractOffchainQuoter.submitQuote was updated to reject standing quotes with future-dated issuedAt, preventing a compromised signer from permanently locking the monotonic issuedAt barrier near uint48 max with an indefinite expiry (HL-2026Q2-001). A later legitimate quote can always overwrite by having a strictly larger issuedAt at submission time. Transient quotes (expiry == issuedAt) are unaffected.

--- a/solidity/contracts/libs/AbstractOffchainQuoter.sol
+++ b/solidity/contracts/libs/AbstractOffchainQuoter.sol
@@ -43,6 +43,11 @@ abstract contract AbstractOffchainQuoter is IOffchainQuoter {
     bytes32 private constant _NAME_HASH = keccak256("OffchainQuoter");
     bytes32 private constant _VERSION_HASH = keccak256("1");
 
+    /// @dev Maximum lifetime of a standing quote. Bounds the window in which a
+    ///      malicious or compromised signer's quote remains resolvable, and
+    ///      caps the issuedAt monotonicity barrier for future overwrites.
+    uint48 internal constant MAX_STANDING_TTL = 7 days;
+
     // ============ ERC-7201 Namespaced Storage ============
 
     /// @custom:storage-location erc7201:hyperlane.storage.AbstractOffchainQuoter
@@ -87,6 +92,14 @@ abstract contract AbstractOffchainQuoter is IOffchainQuoter {
     ) external {
         if (sq.expiry < sq.issuedAt) revert InvalidQuote();
         if (uint48(block.timestamp) > sq.expiry) revert QuoteExpired();
+        // Standing quotes (expiry != issuedAt) must not be future-dated and
+        // must have bounded TTL. Prevents a malicious signer from locking the
+        // monotonic issuedAt barrier near uint48 max with an indefinite expiry.
+        if (sq.expiry != sq.issuedAt) {
+            if (sq.issuedAt > uint48(block.timestamp)) revert InvalidQuote();
+            if (sq.expiry - sq.issuedAt > MAX_STANDING_TTL)
+                revert InvalidQuote();
+        }
         // submitter field restricts who can submit (e.g. QuotedCalls only).
         // address(0) means unrestricted — any caller may submit.
         if (sq.submitter != address(0) && msg.sender != sq.submitter) {

--- a/solidity/contracts/libs/AbstractOffchainQuoter.sol
+++ b/solidity/contracts/libs/AbstractOffchainQuoter.sol
@@ -43,11 +43,6 @@ abstract contract AbstractOffchainQuoter is IOffchainQuoter {
     bytes32 private constant _NAME_HASH = keccak256("OffchainQuoter");
     bytes32 private constant _VERSION_HASH = keccak256("1");
 
-    /// @dev Maximum lifetime of a standing quote. Bounds the window in which a
-    ///      malicious or compromised signer's quote remains resolvable, and
-    ///      caps the issuedAt monotonicity barrier for future overwrites.
-    uint48 internal constant MAX_STANDING_TTL = 7 days;
-
     // ============ ERC-7201 Namespaced Storage ============
 
     /// @custom:storage-location erc7201:hyperlane.storage.AbstractOffchainQuoter
@@ -92,13 +87,13 @@ abstract contract AbstractOffchainQuoter is IOffchainQuoter {
     ) external {
         if (sq.expiry < sq.issuedAt) revert InvalidQuote();
         if (uint48(block.timestamp) > sq.expiry) revert QuoteExpired();
-        // Standing quotes (expiry != issuedAt) must not be future-dated and
-        // must have bounded TTL. Prevents a malicious signer from locking the
-        // monotonic issuedAt barrier near uint48 max with an indefinite expiry.
-        if (sq.expiry != sq.issuedAt) {
-            if (sq.issuedAt > uint48(block.timestamp)) revert InvalidQuote();
-            if (sq.expiry - sq.issuedAt > MAX_STANDING_TTL)
-                revert InvalidQuote();
+        // Standing quotes (expiry != issuedAt) must not be future-dated.
+        // Prevents a malicious signer from locking the monotonic issuedAt
+        // barrier near uint48 max with an indefinite expiry; a future legitimate
+        // quote can always overwrite by virtue of having a strictly larger
+        // issuedAt at submission time.
+        if (sq.expiry != sq.issuedAt && sq.issuedAt > uint48(block.timestamp)) {
+            revert InvalidQuote();
         }
         // submitter field restricts who can submit (e.g. QuotedCalls only).
         // address(0) means unrestricted — any caller may submit.

--- a/solidity/test/igps/IGPOffchainQuoting.t.sol
+++ b/solidity/test/igps/IGPOffchainQuoting.t.sol
@@ -691,12 +691,14 @@ contract IGPOffchainQuotingTest is Test {
         );
 
         // Advance time so the newer quote's issuedAt is not future-dated.
-        vm.warp(block.timestamp + 1);
-        uint48 later = uint48(block.timestamp);
+        // Use `now_ + 1` directly rather than re-reading block.timestamp into a
+        // local — under FOUNDRY_PROFILE=coverage --ir-minimum the optimizer can
+        // reorder a `block.timestamp` read above the preceding `vm.warp(...)`.
+        uint48 later = now_ + 1;
+        vm.warp(later);
 
         uint128 newRate = 3e10;
         uint128 newPrice = 200;
-        vm.warp(now_ + 1);
         _submitStanding(
             address(0),
             DEST,

--- a/solidity/test/igps/IGPOffchainQuoting.t.sol
+++ b/solidity/test/igps/IGPOffchainQuoting.t.sol
@@ -440,6 +440,91 @@ contract IGPOffchainQuotingTest is Test {
         assertEq(fee, expected);
     }
 
+    function test_standingQuote_futureIssuedAt_reverts() public {
+        uint48 now_ = uint48(block.timestamp);
+        SignedQuote memory sq = SignedQuote({
+            context: abi.encodePacked(address(0), DEST, address(this)),
+            data: _encodeGasData(EXCHANGE_RATE, GAS_PRICE),
+            issuedAt: now_ + 1,
+            expiry: now_ + 3600,
+            salt: bytes32(0),
+            submitter: address(0)
+        });
+        bytes memory sig = _signQuote(sq);
+        vm.expectRevert(AbstractOffchainQuoter.InvalidQuote.selector);
+        igp.submitQuote(sq, sig);
+    }
+
+    function test_standingQuote_ttlExceedsMax_reverts() public {
+        uint48 now_ = uint48(block.timestamp);
+        uint48 ttl = uint48(7 days) + 1;
+        SignedQuote memory sq = SignedQuote({
+            context: abi.encodePacked(address(0), DEST, address(this)),
+            data: _encodeGasData(EXCHANGE_RATE, GAS_PRICE),
+            issuedAt: now_,
+            expiry: now_ + ttl,
+            salt: bytes32(0),
+            submitter: address(0)
+        });
+        bytes memory sig = _signQuote(sq);
+        vm.expectRevert(AbstractOffchainQuoter.InvalidQuote.selector);
+        igp.submitQuote(sq, sig);
+    }
+
+    function test_standingQuote_ttlAtMax_succeeds() public {
+        uint48 now_ = uint48(block.timestamp);
+        SignedQuote memory sq = SignedQuote({
+            context: abi.encodePacked(address(0), DEST, address(this)),
+            data: _encodeGasData(EXCHANGE_RATE, GAS_PRICE),
+            issuedAt: now_,
+            expiry: now_ + uint48(7 days),
+            salt: bytes32(0),
+            submitter: address(0)
+        });
+        bytes memory sig = _signQuote(sq);
+        igp.submitQuote(sq, sig);
+
+        // Verify quote is active
+        uint256 fee = igp.quoteGasPayment(DEST, GAS_LIMIT);
+        uint256 expected = (uint256(GAS_LIMIT) *
+            uint256(GAS_PRICE) *
+            uint256(EXCHANGE_RATE)) / 1e10;
+        assertEq(fee, expected);
+    }
+
+    /// @dev Attack from HL-2026Q2-001: a compromised signer attempts to lock the
+    ///      monotonic issuedAt barrier near uint48 max with an indefinite expiry.
+    ///      The not-before and TTL checks now reject this.
+    function test_standingQuote_brickingAttack_reverts() public {
+        SignedQuote memory sq = SignedQuote({
+            context: abi.encodePacked(address(0), DEST, address(this)),
+            data: _encodeGasData(EXCHANGE_RATE, GAS_PRICE),
+            issuedAt: type(uint48).max - 1,
+            expiry: type(uint48).max,
+            salt: bytes32(0),
+            submitter: address(0)
+        });
+        bytes memory sig = _signQuote(sq);
+        vm.expectRevert(AbstractOffchainQuoter.InvalidQuote.selector);
+        igp.submitQuote(sq, sig);
+    }
+
+    function test_transientQuote_futureIssuedAt_allowed() public {
+        // Transient quotes (expiry == issuedAt) are exempt from the not-before
+        // and TTL checks; they auto-clear at end of transaction.
+        uint48 future = uint48(block.timestamp) + 1000;
+        SignedQuote memory sq = SignedQuote({
+            context: _igpContext(address(0), DEST, address(this)),
+            data: _encodeGasData(EXCHANGE_RATE, GAS_PRICE),
+            issuedAt: future,
+            expiry: future,
+            salt: bytes32(0),
+            submitter: address(0)
+        });
+        bytes memory sig = _signQuote(sq);
+        igp.submitQuote(sq, sig);
+    }
+
     // ============ Priority ============
 
     function test_transientOverStanding() public {
@@ -641,6 +726,10 @@ contract IGPOffchainQuotingTest is Test {
             now_ + 3600
         );
 
+        // Advance time so the newer quote's issuedAt is not future-dated.
+        vm.warp(block.timestamp + 1);
+        uint48 later = uint48(block.timestamp);
+
         uint128 newRate = 3e10;
         uint128 newPrice = 200;
         _submitStanding(
@@ -649,8 +738,8 @@ contract IGPOffchainQuotingTest is Test {
             address(this),
             newRate,
             newPrice,
-            now_ + 1,
-            now_ + 7200
+            later,
+            later + 7200
         );
 
         OffchainQuotedIGP.StoredGasQuote memory sq = igp.offchainQuotes(
@@ -660,8 +749,8 @@ contract IGPOffchainQuotingTest is Test {
         );
         assertEq(sq.tokenExchangeRate, newRate);
         assertEq(sq.gasPrice, newPrice);
-        assertEq(sq.issuedAt, now_ + 1);
-        assertEq(sq.expiry, now_ + 7200);
+        assertEq(sq.issuedAt, later);
+        assertEq(sq.expiry, later + 7200);
     }
 
     // ============ Zero Fee ============

--- a/solidity/test/igps/IGPOffchainQuoting.t.sol
+++ b/solidity/test/igps/IGPOffchainQuoting.t.sol
@@ -131,7 +131,7 @@ contract IGPOffchainQuotingTest is Test {
         uint48 expiry
     ) internal {
         SignedQuote memory sq = SignedQuote({
-            context: abi.encodePacked(feeToken, dest, sender_),
+            context: _igpContext(feeToken, dest, sender_),
             data: _encodeGasData(rate, gasPrice),
             issuedAt: issuedAt,
             expiry: expiry,
@@ -370,7 +370,7 @@ contract IGPOffchainQuotingTest is Test {
     function test_submitQuote_expiryBeforeIssuedAt_reverts() public {
         uint48 now_ = uint48(block.timestamp);
         SignedQuote memory sq = SignedQuote({
-            context: abi.encodePacked(address(0), DEST, address(this)),
+            context: _igpContext(address(0), DEST, address(this)),
             data: _encodeGasData(EXCHANGE_RATE, GAS_PRICE),
             issuedAt: now_ + 100,
             expiry: now_,
@@ -396,7 +396,7 @@ contract IGPOffchainQuotingTest is Test {
 
         // Older issuedAt should revert
         SignedQuote memory sq = SignedQuote({
-            context: abi.encodePacked(address(0), DEST, address(this)),
+            context: _igpContext(address(0), DEST, address(this)),
             data: _encodeGasData(3e10, 200),
             issuedAt: now_ - 1,
             expiry: now_ + 7200,
@@ -422,7 +422,7 @@ contract IGPOffchainQuotingTest is Test {
 
         // Same issuedAt should be silently skipped (no revert, no update)
         SignedQuote memory sq = SignedQuote({
-            context: abi.encodePacked(address(0), DEST, address(this)),
+            context: _igpContext(address(0), DEST, address(this)),
             data: _encodeGasData(3e10, 200),
             issuedAt: now_,
             expiry: now_ + 7200,
@@ -443,7 +443,7 @@ contract IGPOffchainQuotingTest is Test {
     function test_standingQuote_futureIssuedAt_reverts() public {
         uint48 now_ = uint48(block.timestamp);
         SignedQuote memory sq = SignedQuote({
-            context: abi.encodePacked(address(0), DEST, address(this)),
+            context: _igpContext(address(0), DEST, address(this)),
             data: _encodeGasData(EXCHANGE_RATE, GAS_PRICE),
             issuedAt: now_ + 1,
             expiry: now_ + 3600,
@@ -461,7 +461,7 @@ contract IGPOffchainQuotingTest is Test {
     ///      for a later legitimate quote.
     function test_standingQuote_brickingAttack_reverts() public {
         SignedQuote memory sq = SignedQuote({
-            context: abi.encodePacked(address(0), DEST, address(this)),
+            context: _igpContext(address(0), DEST, address(this)),
             data: _encodeGasData(EXCHANGE_RATE, GAS_PRICE),
             issuedAt: type(uint48).max - 1,
             expiry: type(uint48).max,
@@ -471,6 +471,49 @@ contract IGPOffchainQuotingTest is Test {
         bytes memory sig = _signQuote(sq);
         vm.expectRevert(AbstractOffchainQuoter.InvalidQuote.selector);
         igp.submitQuote(sq, sig);
+    }
+
+    /// @dev Residual DoS surface from HL-2026Q2-001: the not-before check only
+    ///      rejects future-dated standing quotes, it does NOT cap the expiry
+    ///      window or sanitize the quoted rate/price. A standing quote issued
+    ///      `now` with max rate and gas price overflows `_computeGasFee`, so any
+    ///      dispatch quoting that context reverts until the quote expires. This
+    ///      anchors the residual risk as a regression marker.
+    function test_standingQuote_overflowDoS_revertsUntilExpiry() public {
+        uint48 now_ = uint48(block.timestamp);
+        uint48 expiry = now_ + 3600;
+        _submitStanding(
+            address(0),
+            DEST,
+            address(this),
+            type(uint128).max,
+            type(uint128).max,
+            now_,
+            expiry
+        );
+
+        // _computeGasFee = gasLimit * gasPrice * rate / SCALE overflows uint256.
+        vm.expectRevert();
+        igp.quoteGasPayment(DEST, GAS_LIMIT);
+
+        bytes memory message = MessageUtils.formatMessage(
+            0,
+            0,
+            ORIGIN,
+            address(this).addressToBytes32(),
+            DEST,
+            address(0x1).addressToBytes32(),
+            "hello"
+        );
+        bytes memory metadata = StandardHookMetadata.overrideGasLimit(
+            GAS_LIMIT
+        );
+        vm.expectRevert();
+        igp.quoteDispatch(metadata, message);
+
+        // After expiry the poisoned quote stops resolving; falls back to oracle.
+        vm.warp(expiry + 1);
+        assertEq(igp.quoteGasPayment(DEST, GAS_LIMIT), 30_000_000);
     }
 
     function test_transientQuote_futureIssuedAt_allowed() public {
@@ -555,7 +598,7 @@ contract IGPOffchainQuotingTest is Test {
         uint48 now_ = uint48(block.timestamp);
 
         SignedQuote memory sq = SignedQuote({
-            context: abi.encodePacked(address(0), DEST, address(this)),
+            context: _igpContext(address(0), DEST, address(this)),
             data: _encodeGasData(EXCHANGE_RATE, GAS_PRICE),
             issuedAt: now_,
             expiry: now_,

--- a/solidity/test/igps/IGPOffchainQuoting.t.sol
+++ b/solidity/test/igps/IGPOffchainQuoting.t.sol
@@ -696,6 +696,7 @@ contract IGPOffchainQuotingTest is Test {
 
         uint128 newRate = 3e10;
         uint128 newPrice = 200;
+        vm.warp(now_ + 1);
         _submitStanding(
             address(0),
             DEST,

--- a/solidity/test/igps/IGPOffchainQuoting.t.sol
+++ b/solidity/test/igps/IGPOffchainQuoting.t.sol
@@ -455,46 +455,10 @@ contract IGPOffchainQuotingTest is Test {
         igp.submitQuote(sq, sig);
     }
 
-    function test_standingQuote_ttlExceedsMax_reverts() public {
-        uint48 now_ = uint48(block.timestamp);
-        uint48 ttl = uint48(7 days) + 1;
-        SignedQuote memory sq = SignedQuote({
-            context: abi.encodePacked(address(0), DEST, address(this)),
-            data: _encodeGasData(EXCHANGE_RATE, GAS_PRICE),
-            issuedAt: now_,
-            expiry: now_ + ttl,
-            salt: bytes32(0),
-            submitter: address(0)
-        });
-        bytes memory sig = _signQuote(sq);
-        vm.expectRevert(AbstractOffchainQuoter.InvalidQuote.selector);
-        igp.submitQuote(sq, sig);
-    }
-
-    function test_standingQuote_ttlAtMax_succeeds() public {
-        uint48 now_ = uint48(block.timestamp);
-        SignedQuote memory sq = SignedQuote({
-            context: abi.encodePacked(address(0), DEST, address(this)),
-            data: _encodeGasData(EXCHANGE_RATE, GAS_PRICE),
-            issuedAt: now_,
-            expiry: now_ + uint48(7 days),
-            salt: bytes32(0),
-            submitter: address(0)
-        });
-        bytes memory sig = _signQuote(sq);
-        igp.submitQuote(sq, sig);
-
-        // Verify quote is active
-        uint256 fee = igp.quoteGasPayment(DEST, GAS_LIMIT);
-        uint256 expected = (uint256(GAS_LIMIT) *
-            uint256(GAS_PRICE) *
-            uint256(EXCHANGE_RATE)) / 1e10;
-        assertEq(fee, expected);
-    }
-
     /// @dev Attack from HL-2026Q2-001: a compromised signer attempts to lock the
     ///      monotonic issuedAt barrier near uint48 max with an indefinite expiry.
-    ///      The not-before and TTL checks now reject this.
+    ///      The not-before check rejects this, leaving overwrite always possible
+    ///      for a later legitimate quote.
     function test_standingQuote_brickingAttack_reverts() public {
         SignedQuote memory sq = SignedQuote({
             context: abi.encodePacked(address(0), DEST, address(this)),

--- a/solidity/test/token/OffchainQuotedLinearFee.t.sol
+++ b/solidity/test/token/OffchainQuotedLinearFee.t.sol
@@ -720,6 +720,7 @@ contract OffchainQuotedLinearFeeTest is Test {
         uint48 later = uint48(block.timestamp);
 
         // Submit newer standing quote (higher issuedAt) with different params
+        vm.warp(now_ + 1);
         _submitStanding(
             DEST,
             RECIPIENT,

--- a/solidity/test/token/OffchainQuotedLinearFee.t.sol
+++ b/solidity/test/token/OffchainQuotedLinearFee.t.sol
@@ -716,11 +716,13 @@ contract OffchainQuotedLinearFeeTest is Test {
         );
 
         // Advance time so the newer quote's issuedAt is not future-dated.
-        vm.warp(block.timestamp + 1);
-        uint48 later = uint48(block.timestamp);
+        // Use `now_ + 1` directly rather than re-reading block.timestamp into a
+        // local — under FOUNDRY_PROFILE=coverage --ir-minimum the optimizer can
+        // reorder a `block.timestamp` read above the preceding `vm.warp(...)`.
+        uint48 later = now_ + 1;
+        vm.warp(later);
 
         // Submit newer standing quote (higher issuedAt) with different params
-        vm.warp(now_ + 1);
         _submitStanding(
             DEST,
             RECIPIENT,

--- a/solidity/test/token/OffchainQuotedLinearFee.t.sol
+++ b/solidity/test/token/OffchainQuotedLinearFee.t.sol
@@ -715,6 +715,10 @@ contract OffchainQuotedLinearFeeTest is Test {
             _computeFee(firstMaxFee, HALF_AMOUNT, AMOUNT)
         );
 
+        // Advance time so the newer quote's issuedAt is not future-dated.
+        vm.warp(block.timestamp + 1);
+        uint48 later = uint48(block.timestamp);
+
         // Submit newer standing quote (higher issuedAt) with different params
         _submitStanding(
             DEST,
@@ -722,8 +726,8 @@ contract OffchainQuotedLinearFeeTest is Test {
             WILDCARD_AMOUNT,
             secondMaxFee,
             secondHalfAmount,
-            now_ + 1,
-            now_ + 7200
+            later,
+            later + 7200
         );
 
         // New params are used


### PR DESCRIPTION
## Summary

Rebased for the Q3 2026 audit branch.

- Base: `audit-q3-2026`
- Head: `2ecd1b4298`
- Rejects standing quotes with future `issuedAt` values so quote replacement cannot be delayed indefinitely.
- Drops the max-standing-TTL approach in favor of the not-before check.
- Adds a `patch` changeset for `@hyperlane-xyz/core`.
- Updates replacement tests to advance time before submitting newer standing quotes.

## Verification

- `forge test --match-test 'test_offchainQuotes_updatedByNewerQuote|test_standingQuote_replacementUsesNewParams'`
  - 2 passed
- `forge coverage --offline --match-test 'test_offchainQuotes_updatedByNewerQuote|test_standingQuote_replacementUsesNewParams'`
  - passed
