### PR TITLE
fix: safe api key strategy

### DIFF
--- a/.changeset/loud-horses-begin.md
+++ b/.changeset/loud-horses-begin.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed safe tx building by allowing api key in strategy

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxBuilder.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxBuilder.ts
@@ -38,12 +38,14 @@ export class EV5GnosisSafeTxBuilder extends EV5GnosisSafeTxSubmitter {
     multiProvider: MultiProvider,
     props: EV5GnosisSafeTxBuilderProps,
   ): Promise<EV5GnosisSafeTxBuilder> {
-    const { chain, safeAddress } = props;
+    const { chain, safeAddress, apiKey } = props;
     const { safe, safeService } =
       await EV5GnosisSafeTxSubmitter.initSafeAndService(
         chain,
         multiProvider,
         safeAddress,
+        undefined,
+        apiKey,
       );
     return new EV5GnosisSafeTxBuilder(multiProvider, props, safe, safeService);
   }

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.ts
@@ -42,6 +42,7 @@ export class EV5GnosisSafeTxSubmitter implements EV5TxSubmitterInterface {
     multiProvider: MultiProvider,
     safeAddress: Address,
     signerKey?: string,
+    apiKey?: string,
   ): Promise<{ safe: Safe.default; safeService: SafeApiKit.default }> {
     const { gnosisSafeTransactionServiceUrl } =
       multiProvider.getChainMetadata(chain);
@@ -50,8 +51,14 @@ export class EV5GnosisSafeTxSubmitter implements EV5TxSubmitterInterface {
       `Must set gnosisSafeTransactionServiceUrl in the Registry metadata for ${chain}`,
     );
 
-    const safe = await getSafe(chain, multiProvider, safeAddress, signerKey);
-    const safeService = await getSafeService(chain, multiProvider);
+    const safe = await getSafe(
+      chain,
+      multiProvider,
+      safeAddress,
+      signerKey,
+      apiKey,
+    );
+    const safeService = getSafeService(chain, multiProvider, apiKey);
     return { safe, safeService };
   }
 
@@ -59,7 +66,7 @@ export class EV5GnosisSafeTxSubmitter implements EV5TxSubmitterInterface {
     multiProvider: MultiProvider,
     props: EV5GnosisSafeTxSubmitterProps,
   ): Promise<EV5GnosisSafeTxSubmitter> {
-    const { chain, safeAddress } = props;
+    const { chain, safeAddress, apiKey } = props;
 
     const signer = multiProvider.getSigner(chain);
     const signerAddress = await signer.getAddress();
@@ -68,6 +75,7 @@ export class EV5GnosisSafeTxSubmitter implements EV5TxSubmitterInterface {
       chain,
       multiProvider,
       safeAddress,
+      apiKey,
     );
     assert(
       authorized,
@@ -88,6 +96,7 @@ export class EV5GnosisSafeTxSubmitter implements EV5TxSubmitterInterface {
         multiProvider,
         safeAddress,
         safeSignerKey,
+        apiKey,
       );
 
     return new EV5GnosisSafeTxSubmitter(

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/types.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/types.ts
@@ -15,6 +15,7 @@ import { TxSubmitterType } from '../TxSubmitterTypes.js';
 export const EV5GnosisSafeTxSubmitterPropsSchema = z.object({
   chain: ZChainName,
   safeAddress: ZHash,
+  apiKey: z.string().optional(),
 });
 
 export type EV5GnosisSafeTxSubmitterProps = z.infer<
@@ -25,6 +26,7 @@ export const EV5GnosisSafeTxBuilderPropsSchema = z.object({
   version: z.string().default('1.0'),
   chain: ZChainName,
   safeAddress: ZHash,
+  apiKey: z.string().optional(),
 });
 
 export type EV5GnosisSafeTxBuilderProps = z.infer<

--- a/typescript/sdk/src/utils/gnosisSafe.ts
+++ b/typescript/sdk/src/utils/gnosisSafe.ts
@@ -20,8 +20,9 @@ export function safeApiKeyRequired(txServiceUrl: string): boolean {
 export function getSafeService(
   chain: ChainName,
   multiProvider: MultiProvider,
+  apiKey?: string,
 ): SafeApiKit.default {
-  const { gnosisSafeTransactionServiceUrl, gnosisSafeApiKey } =
+  const { gnosisSafeTransactionServiceUrl, gnosisSafeApiKey: metadataApiKey } =
     multiProvider.getChainMetadata(chain);
   let txServiceUrl = gnosisSafeTransactionServiceUrl;
   if (!txServiceUrl) {
@@ -44,12 +45,14 @@ export function getSafeService(
     throw new Error(`Chain is not an EVM chain: ${chain}`);
   }
 
+  const resolvedApiKey = apiKey ?? metadataApiKey;
+
   // @ts-ignore
   return new SafeApiKit({
     chainId: BigInt(chainId),
     txServiceUrl,
     // Only provide apiKey if the url contains safe.global or 5afe.dev
-    apiKey: safeApiKeyRequired(txServiceUrl) ? gnosisSafeApiKey : undefined,
+    apiKey: safeApiKeyRequired(txServiceUrl) ? resolvedApiKey : undefined,
   });
 }
 
@@ -110,12 +113,13 @@ export async function getSafe(
   multiProvider: MultiProvider,
   safeAddress: Address,
   signer?: SafeProviderConfig['signer'],
+  apiKey?: string,
 ): Promise<Safe.default> {
   // Get the chain id for the given chain
   const chainId = `${multiProvider.getEvmChainId(chain)}`;
 
   // Get the safe version
-  const safeService = getSafeService(chain, multiProvider);
+  const safeService = getSafeService(chain, multiProvider, apiKey);
 
   const { version: rawSafeVersion } = await retryAsync(
     () => safeService.getSafeInfo(safeAddress),
@@ -183,14 +187,21 @@ export async function canProposeSafeTransactions(
   chain: ChainName,
   multiProvider: MultiProvider,
   safeAddress: Address,
+  apiKey?: string,
 ): Promise<boolean> {
   let safeService: SafeApiKit.default;
   try {
-    safeService = getSafeService(chain, multiProvider);
+    safeService = getSafeService(chain, multiProvider, apiKey);
   } catch {
     return false;
   }
-  const safe = await getSafe(chain, multiProvider, safeAddress);
+  const safe = await getSafe(
+    chain,
+    multiProvider,
+    safeAddress,
+    undefined,
+    apiKey,
+  );
   const delegates = await getSafeDelegates(safeService, safeAddress);
   const owners = await safe.getOwners();
   return delegates.includes(proposer) || owners.includes(proposer);

--- a/typescript/sdk/src/utils/gnosisSafe.ts
+++ b/typescript/sdk/src/utils/gnosisSafe.ts
@@ -45,7 +45,9 @@ export function getSafeService(
     throw new Error(`Chain is not an EVM chain: ${chain}`);
   }
 
-  const resolvedApiKey = apiKey ?? metadataApiKey;
+  const resolvedApiKey = apiKey?.trim()
+    ? apiKey.trim()
+    : metadataApiKey?.trim() || undefined;
 
   // @ts-ignore
   return new SafeApiKit({


### PR DESCRIPTION
### Description

Adds `apiKey` as an optional field to `EV5GnosisSafeTxSubmitterProps` and `EV5GnosisSafeTxBuilderProps`, and threads it through `getSafe`, `getSafeService`, and `canProposeSafeTransactions`.

This lets operators specify the Safe API key directly in their submission strategy YAML rather than having to paste it into chain registry metadata on every deployment. The key is resolved with the following priority:

1. `apiKey` in the strategy config (new)
2. `gnosisSafeApiKey` in chain metadata (existing)

Example strategy:
```yaml
ethereum:
  submitter:
    type: gnosisSafeTxBuilder
    chain: ethereum
    safeAddress: "0x..."
    apiKey: "your-key-here"
```

### Drive-by changes

None.

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

Yes — `apiKey` is optional and existing configs without it continue to work as before.

### Testing

Manual — verified `warp apply` succeeds locally with the key set in the strategy file.