### PR TITLE
fix: ica gas estimation

### DIFF
--- a/.changeset/blue-moose-refuse.md
+++ b/.changeset/blue-moose-refuse.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/sdk": patch
 ---
 
-Fixed ICA gas estimation
+The EvmIcaTxSubmitter now dynamically estimates destination-chain handle() gas via estimateIcaHandleGas instead of relying on the 50k default, so the encoded gasLimit matches the IGP payment and is sufficient for multi-call ICA transactions.

--- a/.changeset/blue-moose-refuse.md
+++ b/.changeset/blue-moose-refuse.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed ICA gas estimation

--- a/typescript/sdk/src/providers/transactions/submitter/IcaTxSubmitter.test.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/IcaTxSubmitter.test.ts
@@ -1,0 +1,107 @@
+import { expect } from 'chai';
+import { BigNumber } from 'ethers';
+import sinon from 'sinon';
+
+import {
+  bytes32ToAddress,
+  formatStandardHookMetadata,
+} from '@hyperlane-xyz/utils';
+
+import { TestChainName } from '../../../consts/testChains.js';
+import { MultiProvider } from '../../MultiProvider.js';
+import { randomAddress } from '../../../test/testUtils.js';
+
+import { EvmIcaTxSubmitter } from './IcaTxSubmitter.js';
+
+describe('EvmIcaTxSubmitter.submit', () => {
+  const origin = TestChainName.test1;
+  const destination = TestChainName.test2;
+
+  let sandbox: sinon.SinonSandbox;
+  let multiProvider: MultiProvider;
+  let mockApp: Record<string, sinon.SinonStub>;
+  let mockSubmitter: { submit: sinon.SinonStub };
+
+  const owner = randomAddress();
+  const originRouter = randomAddress();
+  const destRouter = randomAddress();
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    multiProvider = MultiProvider.createTestMultiProvider();
+    mockApp = {
+      estimateIcaHandleGas: sandbox.stub(),
+      getCallRemote: sandbox.stub(),
+    };
+    mockSubmitter = { submit: sandbox.stub().resolves([]) };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  function makeSubmitter(overrides: Record<string, unknown> = {}) {
+    const config = {
+      chain: origin,
+      owner,
+      destinationChain: destination,
+      originInterchainAccountRouter: originRouter,
+      destinationInterchainAccountRouter: destRouter,
+      ...overrides,
+    };
+    // EvmIcaTxSubmitter has a protected constructor; bypass for testing
+    return new (EvmIcaTxSubmitter as any)(
+      config,
+      mockSubmitter,
+      multiProvider,
+      mockApp,
+    );
+  }
+
+  it('encodes estimated gas into hookMetadata and passes same icaConfig to both estimate and getCallRemote', async () => {
+    const estimatedGas = BigNumber.from(150_000);
+    mockApp.estimateIcaHandleGas.resolves(estimatedGas);
+    mockApp.getCallRemote.resolves({
+      to: randomAddress(),
+      data: '0x',
+      value: undefined,
+    });
+
+    const { chainId: destChainId } =
+      multiProvider.getChainMetadata(destination);
+    const tx = {
+      to: randomAddress(),
+      data: '0x1234',
+      chainId: destChainId,
+    };
+
+    const submitter = makeSubmitter();
+    await submitter.submit(tx);
+
+    const expectedIcaConfig = {
+      origin,
+      owner,
+      ismOverride: undefined,
+      routerOverride: destRouter,
+      localRouter: originRouter,
+    };
+
+    // Both methods receive the same icaConfig
+    expect(mockApp.estimateIcaHandleGas.calledOnce).to.be.true;
+    expect(mockApp.estimateIcaHandleGas.firstCall.args[0].config).to.deep.equal(
+      expectedIcaConfig,
+    );
+
+    expect(mockApp.getCallRemote.calledOnce).to.be.true;
+    expect(mockApp.getCallRemote.firstCall.args[0].config).to.deep.equal(
+      expectedIcaConfig,
+    );
+
+    // hookMetadata passed to getCallRemote encodes the estimated gas
+    const expectedHookMetadata = formatStandardHookMetadata({
+      refundAddress: bytes32ToAddress(owner),
+      gasLimit: estimatedGas.toBigInt(),
+    });
+    expect(mockApp.getCallRemote.firstCall.args[0].hookMetadata).to.equal(
+      expectedHookMetadata,
+    );
+  });
+});

--- a/typescript/sdk/src/providers/transactions/submitter/IcaTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/IcaTxSubmitter.ts
@@ -134,7 +134,23 @@ export class EvmIcaTxSubmitter implements TxSubmitterInterface<ProtocolType.Ethe
     );
 
     const refundAddress = bytes32ToAddress(this.config.owner);
-    const hookMetadata = formatStandardHookMetadata({ refundAddress });
+    const icaConfig = {
+      origin: this.config.chain,
+      owner: this.config.owner,
+      ismOverride: this.config.interchainSecurityModule,
+      routerOverride: this.config.destinationInterchainAccountRouter,
+      localRouter: this.config.originInterchainAccountRouter,
+    };
+    const gasLimit = await this.interchainAccountApp.estimateIcaHandleGas({
+      origin: this.config.chain,
+      destination: this.config.destinationChain,
+      innerCalls,
+      config: icaConfig,
+    });
+    const hookMetadata = formatStandardHookMetadata({
+      refundAddress,
+      gasLimit: BigInt(gasLimit.toString()),
+    });
 
     const icaTx = await this.interchainAccountApp.getCallRemote({
       chain: this.config.chain,

--- a/typescript/sdk/src/providers/transactions/submitter/IcaTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/IcaTxSubmitter.ts
@@ -80,6 +80,9 @@ export class EvmIcaTxSubmitter implements TxSubmitterInterface<ProtocolType.Ethe
         chain: config.chain,
         destinationChain: config.destinationChain,
         originInterchainAccountRouter: interchainAccountRouterAddress,
+        destinationInterchainAccountRouter:
+          config.destinationInterchainAccountRouter,
+        interchainSecurityModule: config.interchainSecurityModule,
       },
       internalSubmitter,
       multiProvider,
@@ -149,20 +152,14 @@ export class EvmIcaTxSubmitter implements TxSubmitterInterface<ProtocolType.Ethe
     });
     const hookMetadata = formatStandardHookMetadata({
       refundAddress,
-      gasLimit: BigInt(gasLimit.toString()),
+      gasLimit: gasLimit.toBigInt(),
     });
 
     const icaTx = await this.interchainAccountApp.getCallRemote({
       chain: this.config.chain,
       destination: this.config.destinationChain,
       innerCalls,
-      config: {
-        origin: this.config.chain,
-        owner: this.config.owner,
-        ismOverride: this.config.interchainSecurityModule,
-        routerOverride: this.config.destinationInterchainAccountRouter,
-        localRouter: this.config.originInterchainAccountRouter,
-      },
+      config: icaConfig,
       hookMetadata,
     });
 


### PR DESCRIPTION
### Description

`EvmIcaTxSubmitter` was building `hookMetadata` with only a `refundAddress` and no `gasLimit`, causing all ICA transactions to default to 50,000 gas on the destination chain. This is insufficient for multi-call transactions (e.g. two `transferOwnership` calls cost ~60k alone, plus ~50k ICA overhead).

The fix calls `estimateIcaHandleGas` before building the hookMetadata, which:
1. Tries on-chain estimation via `handle()` with a safety buffer
2. Falls back to per-call gas estimation + overhead
3. Falls back to a static 200k if on-chain estimation fails entirely

This ensures the encoded `gasLimit` in `hookMetadata` matches the IGP payment, and is actually sufficient to execute the destination calls.

### Drive-by changes

None.

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

Yes — the gas limit was previously under-estimated (50k hardcoded), so this is strictly an improvement. IGP payment will increase to match the higher gas limit, which is correct and necessary.

### Testing

Manual — verified regenerated ICA tx encodes 176k gas (on-chain estimate with buffer) vs the previous 50k, and that the IGP value matches.