### PR TITLE
feat(sdk): svm token adapters fee flow support (not offchain yet)

### DIFF
--- a/.changeset/svm-token-adapters-fee-flow.md
+++ b/.changeset/svm-token-adapters-fee-flow.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+SVM token adapters were updated to support the on-chain fee flow: `quoteTransferRemoteGas` returns both warp-fee and IGP quotes when the route opts in, `populateTransferRemote(To)Tx` splices the fee + new-flow IGP sections into the account list, and transactions are compiled as `VersionedTransaction` with the registered Address Lookup Tables when `WarpCoreConfig.options.sealevel.altAddresses` is set. `SolTransaction` was widened to `Transaction | VersionedTransaction`; downstream wallet adapters already accept this union, so external consumers require no changes.

--- a/.changeset/svm-token-adapters-fee-flow.md
+++ b/.changeset/svm-token-adapters-fee-flow.md
@@ -1,5 +1,5 @@
 ---
-'@hyperlane-xyz/sdk': patch
+'@hyperlane-xyz/sdk': major
 ---
 
-SVM token adapters were updated to support the on-chain fee flow: `quoteTransferRemoteGas` returns both warp-fee and IGP quotes when the route opts in, `populateTransferRemote(To)Tx` splices the fee + new-flow IGP sections into the account list, and transactions are compiled as `VersionedTransaction` with the registered Address Lookup Tables when `WarpCoreConfig.options.sealevel.altAddresses` is set. `SolTransaction` was widened to `Transaction | VersionedTransaction`; downstream wallet adapters already accept this union, so external consumers require no changes.
+SVM token adapters were updated to support the on-chain fee flow: `quoteTransferRemoteGas` returns both warp-fee and IGP quotes when the route opts in, `populateTransferRemote(To)Tx` splices the fee + new-flow IGP sections into the account list, and transactions are compiled as `VersionedTransaction` with the registered Address Lookup Tables when `WarpCoreConfig.options.sealevel.altAddresses` is set. The exported `SolanaWeb3Transaction.transaction` field and the `SvmTransactionSigner.signTransaction` signature were widened from `Transaction` to `Transaction | VersionedTransaction`, a breaking change for consumers that call legacy-`Transaction`-only members without first narrowing the union.

--- a/typescript/sdk/src/gas/adapters/SealevelIgpAdapter.ts
+++ b/typescript/sdk/src/gas/adapters/SealevelIgpAdapter.ts
@@ -28,6 +28,7 @@ import {
   SealevelGasOverheadConfig,
   SealevelIgpData,
   SealevelIgpDataSchema,
+  SealevelIgpFeeConfig,
   SealevelIgpInstruction,
   SealevelIgpQuoteGasPaymentInstruction,
   SealevelIgpQuoteGasPaymentResponse,
@@ -40,6 +41,7 @@ import {
   SealevelSetDestinationGasOverheadsInstructionSchema,
   SealevelSetGasOracleConfigsInstruction,
   SealevelSetGasOracleConfigsInstructionSchema,
+  decodeTrailingIgpFeeConfig,
 } from './serialization.js';
 
 export interface IgpPaymentKeys {
@@ -226,7 +228,25 @@ export class SealevelIgpAdapter extends SealevelIgpProgramAdapter {
       SealevelAccountDataWrapper,
       accountInfo.data,
     );
-    return accountData.data as SealevelIgpData;
+
+    const data = accountData.data;
+    assert(
+      data instanceof SealevelIgpData,
+      'Decoded wrapper.data is not SealevelIgpData',
+    );
+
+    const consumedSize = serialize(SealevelIgpDataSchema, accountData).length;
+    data.fee_config = decodeTrailingIgpFeeConfig(
+      Buffer.from(accountInfo.data),
+      consumedSize,
+    );
+    return data;
+  }
+
+  async getFeeConfig(): Promise<SealevelIgpFeeConfig | undefined> {
+    const { fee_config } = await this.getAccountInfo();
+
+    return fee_config;
   }
 
   // Should match https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs#L536-L581

--- a/typescript/sdk/src/gas/adapters/serialization.test.ts
+++ b/typescript/sdk/src/gas/adapters/serialization.test.ts
@@ -1,0 +1,85 @@
+import { expect } from 'chai';
+
+import {
+  SealevelIgpFeeConfig,
+  decodeTrailingIgpFeeConfig,
+} from './serialization.js';
+
+describe('decodeTrailingIgpFeeConfig', () => {
+  const CONSUMED = 80;
+
+  function build(trailing: Buffer | null): Buffer {
+    const header = Buffer.alloc(CONSUMED, 0xff);
+    return trailing ? Buffer.concat([header, trailing]) : header;
+  }
+
+  it('returns undefined for pre-upgrade accounts (no trailing bytes)', () => {
+    expect(decodeTrailingIgpFeeConfig(build(null), CONSUMED)).to.equal(
+      undefined,
+    );
+  });
+
+  it('returns undefined for explicit None (lone 0u8 trailing)', () => {
+    expect(
+      decodeTrailingIgpFeeConfig(build(Buffer.from([0])), CONSUMED),
+    ).to.equal(undefined);
+  });
+
+  it('decodes Some with multiple signers', () => {
+    const signer1 = Buffer.alloc(20, 0x11);
+    const signer2 = Buffer.alloc(20, 0x22);
+    const trailing = Buffer.concat([
+      Buffer.from([1]), // Option tag
+      Buffer.from([0x02, 0x00, 0x00, 0x00]), // 2 signers (u32 LE)
+      signer1,
+      signer2,
+      Buffer.from([0x39, 0x05, 0x00, 0x00]), // domain_id = 1337
+      Buffer.from([0xd2, 0x02, 0x96, 0x49, 0x00, 0x00, 0x00, 0x00]), // min_issued_at = 1234567890
+    ]);
+    const decoded: SealevelIgpFeeConfig | undefined =
+      decodeTrailingIgpFeeConfig(build(trailing), CONSUMED);
+    expect(decoded?.signers).to.deep.equal([
+      '0x1111111111111111111111111111111111111111',
+      '0x2222222222222222222222222222222222222222',
+    ]);
+    expect(decoded?.domain_id).to.equal(1337);
+    expect(decoded?.min_issued_at).to.equal(1234567890n);
+  });
+
+  it('decodes Some with zero signers', () => {
+    const trailing = Buffer.concat([
+      Buffer.from([1]),
+      Buffer.from([0x00, 0x00, 0x00, 0x00]), // 0 signers
+      Buffer.from([0x05, 0x00, 0x00, 0x00]), // domain_id = 5
+      Buffer.alloc(8, 0), // min_issued_at = 0
+    ]);
+    const decoded = decodeTrailingIgpFeeConfig(build(trailing), CONSUMED);
+    expect(decoded?.signers).to.deep.equal([]);
+    expect(decoded?.domain_id).to.equal(5);
+    expect(decoded?.min_issued_at).to.equal(0n);
+  });
+
+  it('throws on invalid Option tag', () => {
+    expect(() =>
+      decodeTrailingIgpFeeConfig(build(Buffer.from([7])), CONSUMED),
+    ).to.throw('Invalid igp.fee_config Option tag: 7');
+  });
+
+  it('throws on truncated signers length', () => {
+    expect(() =>
+      decodeTrailingIgpFeeConfig(build(Buffer.from([1, 0x01, 0x00])), CONSUMED),
+    ).to.throw('Truncated igp.fee_config');
+  });
+
+  it('throws on truncated payload', () => {
+    const trailing = Buffer.concat([
+      Buffer.from([1]),
+      Buffer.from([0x01, 0x00, 0x00, 0x00]), // 1 signer
+      Buffer.alloc(20, 0xaa), // signer
+      Buffer.from([0x05]), // truncated domain_id
+    ]);
+    expect(() =>
+      decodeTrailingIgpFeeConfig(build(trailing), CONSUMED),
+    ).to.throw('Truncated igp.fee_config');
+  });
+});

--- a/typescript/sdk/src/gas/adapters/serialization.test.ts
+++ b/typescript/sdk/src/gas/adapters/serialization.test.ts
@@ -7,6 +7,8 @@ import {
 
 describe('decodeTrailingIgpFeeConfig', () => {
   const CONSUMED = 80;
+  // `IgpFeeConfig::DISCRIMINATOR` in hyperlane-sealevel-igp/src/accounts.rs.
+  const DISCRIMINATOR = Buffer.from('IGPFEEV1', 'ascii');
 
   function build(trailing: Buffer | null): Buffer {
     const header = Buffer.alloc(CONSUMED, 0xff);
@@ -19,17 +21,24 @@ describe('decodeTrailingIgpFeeConfig', () => {
     );
   });
 
-  it('returns undefined for explicit None (lone 0u8 trailing)', () => {
+  it('returns undefined for a tail shorter than the discriminator', () => {
     expect(
       decodeTrailingIgpFeeConfig(build(Buffer.from([0])), CONSUMED),
     ).to.equal(undefined);
+  });
+
+  it('returns undefined for a stale non-matching tail', () => {
+    const stale = Buffer.alloc(40, 0x01);
+    expect(decodeTrailingIgpFeeConfig(build(stale), CONSUMED)).to.equal(
+      undefined,
+    );
   });
 
   it('decodes Some with multiple signers', () => {
     const signer1 = Buffer.alloc(20, 0x11);
     const signer2 = Buffer.alloc(20, 0x22);
     const trailing = Buffer.concat([
-      Buffer.from([1]), // Option tag
+      DISCRIMINATOR,
       Buffer.from([0x02, 0x00, 0x00, 0x00]), // 2 signers (u32 LE)
       signer1,
       signer2,
@@ -48,7 +57,7 @@ describe('decodeTrailingIgpFeeConfig', () => {
 
   it('decodes Some with zero signers', () => {
     const trailing = Buffer.concat([
-      Buffer.from([1]),
+      DISCRIMINATOR,
       Buffer.from([0x00, 0x00, 0x00, 0x00]), // 0 signers
       Buffer.from([0x05, 0x00, 0x00, 0x00]), // domain_id = 5
       Buffer.alloc(8, 0), // min_issued_at = 0
@@ -59,21 +68,42 @@ describe('decodeTrailingIgpFeeConfig', () => {
     expect(decoded?.min_issued_at).to.equal(0n);
   });
 
-  it('throws on invalid Option tag', () => {
-    expect(() =>
-      decodeTrailingIgpFeeConfig(build(Buffer.from([7])), CONSUMED),
-    ).to.throw('Invalid igp.fee_config Option tag: 7');
+  it('decodes a negative min_issued_at (signed i64)', () => {
+    const trailing = Buffer.concat([
+      DISCRIMINATOR,
+      Buffer.from([0x00, 0x00, 0x00, 0x00]), // 0 signers
+      Buffer.from([0x05, 0x00, 0x00, 0x00]), // domain_id = 5
+      Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]), // -1 (i64 LE)
+    ]);
+    const decoded = decodeTrailingIgpFeeConfig(build(trailing), CONSUMED);
+    expect(decoded?.min_issued_at).to.equal(-1n);
   });
 
-  it('throws on truncated signers length', () => {
+  it('decodes Some even when stale bytes trail the payload', () => {
+    const trailing = Buffer.concat([
+      DISCRIMINATOR,
+      Buffer.from([0x00, 0x00, 0x00, 0x00]), // 0 signers
+      Buffer.from([0x05, 0x00, 0x00, 0x00]), // domain_id = 5
+      Buffer.alloc(8, 0), // min_issued_at = 0
+      Buffer.alloc(16, 0xcc), // stale over-allocated tail
+    ]);
+    const decoded = decodeTrailingIgpFeeConfig(build(trailing), CONSUMED);
+    expect(decoded?.domain_id).to.equal(5);
+    expect(decoded?.min_issued_at).to.equal(0n);
+  });
+
+  it('throws on a matching discriminator with a truncated signers length', () => {
     expect(() =>
-      decodeTrailingIgpFeeConfig(build(Buffer.from([1, 0x01, 0x00])), CONSUMED),
+      decodeTrailingIgpFeeConfig(
+        build(Buffer.concat([DISCRIMINATOR, Buffer.from([0x01, 0x00])])),
+        CONSUMED,
+      ),
     ).to.throw('Truncated igp.fee_config');
   });
 
-  it('throws on truncated payload', () => {
+  it('throws on a matching discriminator with a truncated payload', () => {
     const trailing = Buffer.concat([
-      Buffer.from([1]),
+      DISCRIMINATOR,
       Buffer.from([0x01, 0x00, 0x00, 0x00]), // 1 signer
       Buffer.alloc(20, 0xaa), // signer
       Buffer.from([0x05]), // truncated domain_id

--- a/typescript/sdk/src/gas/adapters/serialization.ts
+++ b/typescript/sdk/src/gas/adapters/serialization.ts
@@ -75,7 +75,13 @@ export function decodeTrailingIgpFeeConfig(
   }
   const domain_id = rawAccountData.readUInt32LE(offset);
   offset += U32_BYTES;
-  const min_issued_at = rawAccountData.readBigInt64LE(offset);
+  // Use DataView for i64 — Node's readBigInt64LE is missing from common
+  // browser Buffer polyfills (e.g., Turbopack).
+  const min_issued_at = new DataView(
+    rawAccountData.buffer,
+    rawAccountData.byteOffset + offset,
+    I64_BYTES,
+  ).getBigInt64(0, true);
 
   return { signers, domain_id, min_issued_at };
 }

--- a/typescript/sdk/src/gas/adapters/serialization.ts
+++ b/typescript/sdk/src/gas/adapters/serialization.ts
@@ -7,6 +7,7 @@ import {
   SealevelInstructionWrapper,
   getSealevelAccountDataSchema,
   getSealevelSimulationReturnDataSchema,
+  readOptionalDiscriminatedTrailing,
 } from '../../utils/sealevelSerialization.js';
 
 /**
@@ -23,63 +24,60 @@ export interface SealevelIgpFeeConfig {
   min_issued_at: bigint;
 }
 
-const IGP_FEE_CONFIG_OPTION_NONE_TAG = 0;
-const IGP_FEE_CONFIG_OPTION_SOME_TAG = 1;
+/// `IgpFeeConfig::DISCRIMINATOR` in hyperlane-sealevel-igp/src/accounts.rs.
+const IGP_FEE_CONFIG_DISCRIMINATOR = Buffer.from('IGPFEEV1', 'ascii');
 const H160_BYTES = 20;
 const U32_BYTES = 4;
 const I64_BYTES = 8;
 
 /**
  * Decode the optional trailing IgpFeeConfig from an Igp account's raw data.
- * Handles all three layouts per `read_optional_trailing` in account-utils:
- * empty (pre-upgrade), `[0u8]` (defensive None), or `[1u8] + payload` (Some).
+ * The trailing field is an `OptionalDiscriminatedData<IgpFeeConfig>`: empty
+ * when absent, or `[DISCRIMINATOR (8)][signers (borsh set)][domain_id (u32)]
+ * [min_issued_at (i64)]` when present.
  *
- * Hand-rolled (no borsh dependency for the payload) because borsh-js 0.7
+ * The payload is hand-decoded (no borsh dependency) because borsh-js 0.7
  * lacks native i64 support for `min_issued_at`.
  */
 export function decodeTrailingIgpFeeConfig(
   rawAccountData: Buffer,
   consumedSize: number,
 ): SealevelIgpFeeConfig | undefined {
-  if (rawAccountData.length <= consumedSize) return undefined;
-
-  const tag = rawAccountData[consumedSize];
-  if (tag === IGP_FEE_CONFIG_OPTION_NONE_TAG) return undefined;
-  assert(
-    tag === IGP_FEE_CONFIG_OPTION_SOME_TAG,
-    `Invalid igp.fee_config Option tag: ${tag}`,
+  const payload = readOptionalDiscriminatedTrailing(
+    rawAccountData,
+    consumedSize,
+    IGP_FEE_CONFIG_DISCRIMINATOR,
   );
+  if (payload === undefined) return undefined;
 
-  let offset = consumedSize + 1;
+  let offset = 0;
   assert(
-    rawAccountData.length >= offset + U32_BYTES,
-    `Truncated igp.fee_config: signers length prefix missing at offset ${offset}`,
+    payload.length >= offset + U32_BYTES,
+    `Truncated igp.fee_config: signers length prefix missing`,
   );
-  const signersLen = rawAccountData.readUInt32LE(offset);
+  const signersLen = payload.readUInt32LE(offset);
   offset += U32_BYTES;
 
   const payloadEnd = offset + signersLen * H160_BYTES + U32_BYTES + I64_BYTES;
   assert(
-    rawAccountData.length >= payloadEnd,
-    `Truncated igp.fee_config: expected payload through offset ${payloadEnd}, got ${rawAccountData.length}`,
+    payload.length >= payloadEnd,
+    `Truncated igp.fee_config: expected payload through offset ${payloadEnd}, got ${payload.length}`,
   );
 
   const signers: string[] = [];
   for (let i = 0; i < signersLen; i++) {
     signers.push(
-      toHexString(
-        Buffer.from(rawAccountData.subarray(offset, offset + H160_BYTES)),
-      ),
+      toHexString(Buffer.from(payload.subarray(offset, offset + H160_BYTES))),
     );
     offset += H160_BYTES;
   }
-  const domain_id = rawAccountData.readUInt32LE(offset);
+  const domain_id = payload.readUInt32LE(offset);
   offset += U32_BYTES;
   // Use DataView for i64 — Node's readBigInt64LE is missing from common
   // browser Buffer polyfills (e.g., Turbopack).
   const min_issued_at = new DataView(
-    rawAccountData.buffer,
-    rawAccountData.byteOffset + offset,
+    payload.buffer,
+    payload.byteOffset + offset,
     I64_BYTES,
   ).getBigInt64(0, true);
 

--- a/typescript/sdk/src/gas/adapters/serialization.ts
+++ b/typescript/sdk/src/gas/adapters/serialization.ts
@@ -259,7 +259,9 @@ export const SealevelIgpDataSchema = new Map<any, any>([
  * IGP instruction Borsh Schema
  */
 
-// Should match Instruction in https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/8f8853bcd7105a6dd7af3a45c413b137ded6e888/rust/sealevel/programs/hyperlane-sealevel-igp/src/instruction.rs#L19-L42
+// Should match Instruction in
+// rust/sealevel/programs/hyperlane-sealevel-igp/src/instruction.rs
+// (extended in the fee-flow upgrade after Claim=10).
 export enum SealevelIgpInstruction {
   Init,
   InitIgp,
@@ -272,7 +274,51 @@ export enum SealevelIgpInstruction {
   SetDestinationGasOverheads,
   SetGasOracleConfigs,
   Claim,
+  SetIgpQuoteConfig,
+  SetIgpQuoteSigner,
+  SetIgpMinIssuedAt,
+  SubmitIgpQuote,
+  CloseIgpTransientQuote,
+  CloseIgpStandingQuote,
+  GetIgpQuoteAccountMetas,
 }
+
+/// Simulation-only instruction returning the account metas required for an
+/// IGP quote (new flow). Mirrors `GetIgpQuoteAccountMetas` in
+/// rust/sealevel/programs/hyperlane-sealevel-igp/src/instruction.rs.
+export class SealevelGetIgpQuoteAccountMetasInstruction {
+  destination_domain!: number;
+  sender!: Uint8Array; // 32 bytes (Pubkey)
+  scoped_salt!: Uint8Array | null; // 32 bytes if Some, null = standing only
+
+  constructor(fields: any) {
+    Object.assign(this, fields);
+  }
+}
+
+export const SealevelGetIgpQuoteAccountMetasSchema = new Map<any, any>([
+  [
+    SealevelInstructionWrapper,
+    {
+      kind: 'struct',
+      fields: [
+        ['instruction', 'u8'],
+        ['data', SealevelGetIgpQuoteAccountMetasInstruction],
+      ],
+    },
+  ],
+  [
+    SealevelGetIgpQuoteAccountMetasInstruction,
+    {
+      kind: 'struct',
+      fields: [
+        ['destination_domain', 'u32'],
+        ['sender', [32]],
+        ['scoped_salt', { kind: 'option', type: [32] }],
+      ],
+    },
+  ],
+]);
 
 export class SealevelIgpQuoteGasPaymentInstruction {
   destination_domain!: number;

--- a/typescript/sdk/src/gas/adapters/serialization.ts
+++ b/typescript/sdk/src/gas/adapters/serialization.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from '@solana/web3.js';
 
-import { Domain } from '@hyperlane-xyz/utils';
+import { Domain, assert, toHexString } from '@hyperlane-xyz/utils';
 
 import {
   SealevelAccountDataWrapper,
@@ -8,6 +8,77 @@ import {
   getSealevelAccountDataSchema,
   getSealevelSimulationReturnDataSchema,
 } from '../../utils/sealevelSerialization.js';
+
+/**
+ * Offchain quoting configuration on an Igp account (trailing optional field
+ * introduced in the SVM fee-flow upgrade). Mirrors `IgpFeeConfig` in
+ * rust/sealevel/programs/hyperlane-sealevel-igp/src/accounts.rs.
+ */
+export interface SealevelIgpFeeConfig {
+  /// Authorized secp256k1 signer addresses (0x-prefixed hex, 20 bytes each).
+  signers: string[];
+  /// Hyperlane domain ID for cross-chain replay prevention.
+  domain_id: number;
+  /// Emergency revocation threshold (Unix timestamp).
+  min_issued_at: bigint;
+}
+
+const IGP_FEE_CONFIG_OPTION_NONE_TAG = 0;
+const IGP_FEE_CONFIG_OPTION_SOME_TAG = 1;
+const H160_BYTES = 20;
+const U32_BYTES = 4;
+const I64_BYTES = 8;
+
+/**
+ * Decode the optional trailing IgpFeeConfig from an Igp account's raw data.
+ * Handles all three layouts per `read_optional_trailing` in account-utils:
+ * empty (pre-upgrade), `[0u8]` (defensive None), or `[1u8] + payload` (Some).
+ *
+ * Hand-rolled (no borsh dependency for the payload) because borsh-js 0.7
+ * lacks native i64 support for `min_issued_at`.
+ */
+export function decodeTrailingIgpFeeConfig(
+  rawAccountData: Buffer,
+  consumedSize: number,
+): SealevelIgpFeeConfig | undefined {
+  if (rawAccountData.length <= consumedSize) return undefined;
+
+  const tag = rawAccountData[consumedSize];
+  if (tag === IGP_FEE_CONFIG_OPTION_NONE_TAG) return undefined;
+  assert(
+    tag === IGP_FEE_CONFIG_OPTION_SOME_TAG,
+    `Invalid igp.fee_config Option tag: ${tag}`,
+  );
+
+  let offset = consumedSize + 1;
+  assert(
+    rawAccountData.length >= offset + U32_BYTES,
+    `Truncated igp.fee_config: signers length prefix missing at offset ${offset}`,
+  );
+  const signersLen = rawAccountData.readUInt32LE(offset);
+  offset += U32_BYTES;
+
+  const payloadEnd = offset + signersLen * H160_BYTES + U32_BYTES + I64_BYTES;
+  assert(
+    rawAccountData.length >= payloadEnd,
+    `Truncated igp.fee_config: expected payload through offset ${payloadEnd}, got ${rawAccountData.length}`,
+  );
+
+  const signers: string[] = [];
+  for (let i = 0; i < signersLen; i++) {
+    signers.push(
+      toHexString(
+        Buffer.from(rawAccountData.subarray(offset, offset + H160_BYTES)),
+      ),
+    );
+    offset += H160_BYTES;
+  }
+  const domain_id = rawAccountData.readUInt32LE(offset);
+  offset += U32_BYTES;
+  const min_issued_at = rawAccountData.readBigInt64LE(offset);
+
+  return { signers, domain_id, min_issued_at };
+}
 
 // Should match https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/rust/sealevel/programs/hyperlane-sealevel-igp/src/accounts.rs#L24
 export enum SealevelInterchainGasPaymasterType {
@@ -151,6 +222,9 @@ export class SealevelIgpData {
   beneficiary!: Uint8Array; // 32 bytes
   beneficiary_pub_key!: PublicKey;
   gas_oracles!: Map<number, SealevelGasOracle>;
+  /// Trailing optional offchain-quoting configuration. Hydrated post-decode
+  /// via `decodeTrailingIgpFeeConfig`; NOT part of SealevelIgpDataSchema.
+  fee_config?: SealevelIgpFeeConfig;
 
   constructor(fields: any) {
     Object.assign(this, fields);

--- a/typescript/sdk/src/providers/ProviderType.ts
+++ b/typescript/sdk/src/providers/ProviderType.ts
@@ -8,9 +8,25 @@ import type { DeliverTxResponse, StargateClient } from '@cosmjs/stargate';
 import type {
   Connection,
   Keypair,
-  Transaction as SolTransaction,
+  Transaction as SolLegacyTransaction,
+  VersionedTransaction as SolVersionedTransaction,
   VersionedTransactionResponse as SolTransactionReceipt,
 } from '@solana/web3.js';
+
+/**
+ * Union of the two on-the-wire transaction shapes Sealevel adapters may
+ * emit: legacy `Transaction` for routes that fit in 1232 bytes, and
+ * `VersionedTransaction` for routes that need Address Lookup Tables to
+ * compress the account list (e.g. fee + new-flow IGP transfer_remote
+ * calls which carry 40+ accounts).
+ *
+ * Downstream wallet adapters (@solana/wallet-adapter-react, the warp UI
+ * template's MockSolanaAdapter) already accept this union via the
+ * standard `WalletAdapter.sendTransaction` overload. Consumers that
+ * call legacy-only methods (e.g. `.partialSign`) must branch on the
+ * runtime type.
+ */
+type SolTransaction = SolLegacyTransaction | SolVersionedTransaction;
 import type {
   Contract as EV5Contract,
   providers as EV5Providers,

--- a/typescript/sdk/src/providers/ProviderType.ts
+++ b/typescript/sdk/src/providers/ProviderType.ts
@@ -12,21 +12,6 @@ import type {
   VersionedTransaction as SolVersionedTransaction,
   VersionedTransactionResponse as SolTransactionReceipt,
 } from '@solana/web3.js';
-
-/**
- * Union of the two on-the-wire transaction shapes Sealevel adapters may
- * emit: legacy `Transaction` for routes that fit in 1232 bytes, and
- * `VersionedTransaction` for routes that need Address Lookup Tables to
- * compress the account list (e.g. fee + new-flow IGP transfer_remote
- * calls which carry 40+ accounts).
- *
- * Downstream wallet adapters (@solana/wallet-adapter-react, the warp UI
- * template's MockSolanaAdapter) already accept this union via the
- * standard `WalletAdapter.sendTransaction` overload. Consumers that
- * call legacy-only methods (e.g. `.partialSign`) must branch on the
- * runtime type.
- */
-type SolTransaction = SolLegacyTransaction | SolVersionedTransaction;
 import type {
   Contract as EV5Contract,
   providers as EV5Providers,
@@ -63,6 +48,21 @@ import type {
 } from '@hyperlane-xyz/radix-sdk/runtime';
 import type { Annotated, KnownProtocolType } from '@hyperlane-xyz/utils';
 import { ProtocolType } from '@hyperlane-xyz/utils';
+
+/**
+ * Union of the two on-the-wire transaction shapes Sealevel adapters may
+ * emit: legacy `Transaction` for routes that fit in 1232 bytes, and
+ * `VersionedTransaction` for routes that need Address Lookup Tables to
+ * compress the account list (e.g. fee + new-flow IGP transfer_remote
+ * calls which carry 40+ accounts).
+ *
+ * Downstream wallet adapters (@solana/wallet-adapter-react, the warp UI
+ * template's MockSolanaAdapter) already accept this union via the
+ * standard `WalletAdapter.sendTransaction` overload. Consumers that
+ * call legacy-only methods (e.g. `.partialSign`) must branch on the
+ * runtime type.
+ */
+type SolTransaction = SolLegacyTransaction | SolVersionedTransaction;
 
 export enum ProviderType {
   EthersV5 = 'ethers-v5',

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -5,6 +5,7 @@ import { Uint53 } from '@cosmjs/math';
 import { Registry } from '@cosmjs/proto-signing';
 import { defaultRegistryTypes } from '@cosmjs/stargate';
 import { MsgExecuteContract } from 'cosmjs-types/cosmwasm/wasm/v1/tx.js';
+import { VersionedTransaction } from '@solana/web3.js';
 import type {
   providers as EV5Providers,
   PopulatedTransaction as EV5Transaction,
@@ -155,9 +156,14 @@ export async function estimateTransactionFeeSolanaWeb3({
   provider: SolanaWeb3Provider;
 }): Promise<TransactionFeeEstimate> {
   const connection = provider.provider;
-  const { value } = await connection.simulateTransaction(
-    transaction.transaction,
-  );
+  // `Connection.simulateTransaction` has separate overloads for legacy
+  // `Transaction` and `VersionedTransaction`; the union doesn't satisfy
+  // either branch directly, so branch on runtime type to pick the right one.
+  const inner = transaction.transaction;
+  const { value } =
+    inner instanceof VersionedTransaction
+      ? await connection.simulateTransaction(inner)
+      : await connection.simulateTransaction(inner);
   assert(!value.err, `Solana gas estimation failed: ${JSON.stringify(value)}`);
   const gasUnits = BigInt(value.unitsConsumed || 0);
   const recentFees = await connection.getRecentPrioritizationFees();

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -156,10 +156,11 @@ export async function estimateTransactionFeeSolanaWeb3({
   provider: SolanaWeb3Provider;
 }): Promise<TransactionFeeEstimate> {
   const connection = provider.provider;
-  // `Connection.simulateTransaction` has separate overloads for legacy
-  // `Transaction` and `VersionedTransaction`; the union doesn't satisfy
-  // either branch directly, so branch on runtime type to pick the right one.
   const inner = transaction.transaction;
+  // The two arms are intentionally identical: `Connection.simulateTransaction`
+  // has separate overloads for legacy `Transaction` and `VersionedTransaction`
+  // and the union satisfies neither, so we branch purely to narrow `inner` to a
+  // concrete type and let overload resolution pick the matching signature.
   const { value } =
     inner instanceof VersionedTransaction
       ? await connection.simulateTransaction(inner)

--- a/typescript/sdk/src/signers/svm/solana-web3js.ts
+++ b/typescript/sdk/src/signers/svm/solana-web3js.ts
@@ -1,4 +1,5 @@
 import {
+  type Blockhash,
   ComputeBudgetProgram,
   Connection,
   Keypair,
@@ -6,7 +7,26 @@ import {
   Transaction,
   TransactionConfirmationStatus,
   TransactionInstruction,
+  VersionedTransaction,
 } from '@solana/web3.js';
+
+/**
+ * Rewrite a `VersionedTransaction`'s blockhash and clear its signatures so
+ * the caller can re-sign with the fresh blockhash. `MessageV0.recentBlockhash`
+ * is declared `readonly` in TypeScript but is a plain mutable field at
+ * runtime; the same pattern is used by `@solana/wallet-adapter` resubmit
+ * examples. Returns the same instance for chaining.
+ */
+function stampVersionedBlockhash(
+  tx: VersionedTransaction,
+  blockhash: Blockhash,
+): VersionedTransaction {
+  (tx.message as { recentBlockhash: Blockhash }).recentBlockhash = blockhash;
+  for (let i = 0; i < tx.signatures.length; i++) {
+    tx.signatures[i] = new Uint8Array(64);
+  }
+  return tx;
+}
 
 import { Address, ProtocolType, rootLogger, sleep } from '@hyperlane-xyz/utils';
 
@@ -18,11 +38,15 @@ import { ChainName } from '../../types.js';
 import { IMultiProtocolSigner } from '../types.js';
 
 /**
- * Interface for SVM transaction signers
+ * Interface for SVM transaction signers. Accepts both legacy `Transaction`
+ * and `VersionedTransaction` — the latter is required by Sealevel warp
+ * transfer_remote calls compressed with Address Lookup Tables.
  */
 export interface SvmTransactionSigner {
   readonly publicKey: PublicKey;
-  signTransaction(transaction: Transaction): Promise<Transaction>;
+  signTransaction<T extends Transaction | VersionedTransaction>(
+    transaction: T,
+  ): Promise<T>;
 }
 
 export interface SvmSignerConfig {
@@ -57,8 +81,17 @@ export class KeypairSvmTransactionSigner implements SvmTransactionSigner {
     this.publicKey = this.keypair.publicKey;
   }
 
-  async signTransaction(transaction: Transaction): Promise<Transaction> {
-    transaction.partialSign(this.keypair);
+  async signTransaction<T extends Transaction | VersionedTransaction>(
+    transaction: T,
+  ): Promise<T> {
+    // `VersionedTransaction.sign([signer])` populates only the signer's
+    // slot (other signature slots stay as their pre-initialized zero bytes),
+    // matching the partial-sign semantics of legacy `Transaction.partialSign`.
+    if (transaction instanceof VersionedTransaction) {
+      transaction.sign([this.keypair]);
+    } else {
+      transaction.partialSign(this.keypair);
+    }
     return transaction;
   }
 }
@@ -158,27 +191,35 @@ export class SvmMultiProtocolSignerAdapter implements IMultiProtocolSigner<Proto
    * Sign and confirm transaction with blockhash resubmit on expiry
    */
   private async signAndConfirm(
-    transaction: Transaction,
+    transaction: Transaction | VersionedTransaction,
     extraSigners?: Keypair[],
   ): Promise<string> {
     // Get initial blockhash
     const { blockhash, lastValidBlockHeight } =
       await this.svmProvider.getLatestBlockhash(this.config.commitment);
 
-    transaction.recentBlockhash = blockhash;
-
-    if (!transaction.feePayer) {
-      transaction.feePayer = this.signer.publicKey;
+    if (transaction instanceof VersionedTransaction) {
+      stampVersionedBlockhash(transaction, blockhash);
+      // `VersionedTransaction.sign([signer])` only populates the signer's
+      // slot (matches partial-sign semantics of legacy `partialSign`).
+      for (const signer of extraSigners ?? []) {
+        transaction.sign([signer]);
+      }
+    } else {
+      transaction.recentBlockhash = blockhash;
+      if (!transaction.feePayer) {
+        transaction.feePayer = this.signer.publicKey;
+      }
+      // Sign with extra signers first (e.g., randomWallet for Sealevel
+      // transferRemote). Uses partialSign to avoid clearing any existing
+      // signatures. This re-signs with the fresh blockhash, overwriting
+      // the adapter's pre-sign.
+      for (const signer of extraSigners ?? []) {
+        transaction.partialSign(signer);
+      }
     }
 
-    // Sign with extra signers first (e.g., randomWallet for Sealevel transferRemote).
-    // Uses partialSign to avoid clearing any existing signatures.
-    // This re-signs with the fresh blockhash, overwriting the adapter's pre-sign.
-    for (const signer of extraSigners ?? []) {
-      transaction.partialSign(signer);
-    }
-
-    // Sign with main signer (uses partialSign via KeypairSvmTransactionSigner)
+    // Sign with main signer (preserves extra signers' signatures)
     const signedTx = await this.signer.signTransaction(transaction);
 
     // Send initial transaction
@@ -200,7 +241,7 @@ export class SvmMultiProtocolSignerAdapter implements IMultiProtocolSigner<Proto
    */
   private async pollForConfirmation(
     initialSignature: string,
-    transaction: Transaction,
+    transaction: Transaction | VersionedTransaction,
     lastValidBlockHeight: number,
     extraSigners?: Keypair[],
   ): Promise<string> {
@@ -264,7 +305,7 @@ export class SvmMultiProtocolSignerAdapter implements IMultiProtocolSigner<Proto
    */
   private async checkAndResubmitIfExpired(
     signature: string,
-    transaction: Transaction,
+    transaction: Transaction | VersionedTransaction,
     lastValidBlockHeight: number,
     extraSigners?: Keypair[],
   ): Promise<{ signature: string; lastValidBlockHeight: number } | null> {
@@ -285,11 +326,16 @@ export class SvmMultiProtocolSignerAdapter implements IMultiProtocolSigner<Proto
     const { blockhash, lastValidBlockHeight: newLastValid } =
       await this.svmProvider.getLatestBlockhash(this.config.commitment);
 
-    transaction.recentBlockhash = blockhash;
-
-    // Re-sign extra signers with new blockhash
-    for (const signer of extraSigners ?? []) {
-      transaction.partialSign(signer);
+    if (transaction instanceof VersionedTransaction) {
+      stampVersionedBlockhash(transaction, blockhash);
+      for (const signer of extraSigners ?? []) {
+        transaction.sign([signer]);
+      }
+    } else {
+      transaction.recentBlockhash = blockhash;
+      for (const signer of extraSigners ?? []) {
+        transaction.partialSign(signer);
+      }
     }
 
     const signedTx = await this.signer.signTransaction(transaction);
@@ -338,7 +384,9 @@ export class SvmMultiProtocolSignerAdapter implements IMultiProtocolSigner<Proto
   /**
    * Send signed transaction to network
    */
-  private async sendRawTransaction(transaction: Transaction): Promise<string> {
+  private async sendRawTransaction(
+    transaction: Transaction | VersionedTransaction,
+  ): Promise<string> {
     return await this.svmProvider.sendRawTransaction(transaction.serialize(), {
       skipPreflight: false,
       maxRetries: 3,

--- a/typescript/sdk/src/signers/svm/solana-web3js.ts
+++ b/typescript/sdk/src/signers/svm/solana-web3js.ts
@@ -10,24 +10,6 @@ import {
   VersionedTransaction,
 } from '@solana/web3.js';
 
-/**
- * Rewrite a `VersionedTransaction`'s blockhash and clear its signatures so
- * the caller can re-sign with the fresh blockhash. `MessageV0.recentBlockhash`
- * is declared `readonly` in TypeScript but is a plain mutable field at
- * runtime; the same pattern is used by `@solana/wallet-adapter` resubmit
- * examples. Returns the same instance for chaining.
- */
-function stampVersionedBlockhash(
-  tx: VersionedTransaction,
-  blockhash: Blockhash,
-): VersionedTransaction {
-  (tx.message as { recentBlockhash: Blockhash }).recentBlockhash = blockhash;
-  for (let i = 0; i < tx.signatures.length; i++) {
-    tx.signatures[i] = new Uint8Array(64);
-  }
-  return tx;
-}
-
 import { Address, ProtocolType, rootLogger, sleep } from '@hyperlane-xyz/utils';
 
 import { SEALEVEL_PRIORITY_FEES } from '../../consts/sealevel.js';
@@ -36,6 +18,25 @@ import { SendTransactionOptions } from '../../providers/MultiProvider.js';
 import { SolanaWeb3Transaction } from '../../providers/ProviderType.js';
 import { ChainName } from '../../types.js';
 import { IMultiProtocolSigner } from '../types.js';
+
+/**
+ * Rewrite a `VersionedTransaction`'s blockhash and clear its signatures so
+ * the caller can re-sign with the fresh blockhash. `MessageV0.recentBlockhash`
+ * is declared `readonly` in TypeScript but is a plain mutable field at
+ * runtime; the same pattern is used by `@solana/wallet-adapter` resubmit
+ * examples. `Object.assign` performs the write without a type assertion.
+ * Returns the same instance for chaining.
+ */
+function stampVersionedBlockhash(
+  tx: VersionedTransaction,
+  blockhash: Blockhash,
+): VersionedTransaction {
+  Object.assign(tx.message, { recentBlockhash: blockhash });
+  for (let i = 0; i < tx.signatures.length; i++) {
+    tx.signatures[i] = new Uint8Array(64);
+  }
+  return tx;
+}
 
 /**
  * Interface for SVM transaction signers. Accepts both legacy `Transaction`

--- a/typescript/sdk/src/signers/svm/turnkey.ts
+++ b/typescript/sdk/src/signers/svm/turnkey.ts
@@ -1,4 +1,4 @@
-import { PublicKey, Transaction } from '@solana/web3.js';
+import { PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
 import { TurnkeySigner as TurnkeySolanaSigner } from '@turnkey/solana';
 
 import { rootLogger } from '@hyperlane-xyz/utils';
@@ -77,7 +77,9 @@ export class TurnkeySealevelSigner implements SvmTransactionSigner {
    * This method uses Turnkey's secure enclave to sign the transaction
    * and enforces any policies configured in Turnkey (e.g., IGP-only restrictions)
    */
-  async signTransaction(transaction: Transaction): Promise<Transaction> {
+  async signTransaction<T extends Transaction | VersionedTransaction>(
+    transaction: T,
+  ): Promise<T> {
     logger.debug('Signing transaction with Turnkey');
 
     try {

--- a/typescript/sdk/src/token/Token.test.ts
+++ b/typescript/sdk/src/token/Token.test.ts
@@ -3,7 +3,7 @@ import { SystemProgram } from '@solana/web3.js';
 import { expect } from 'chai';
 import { ethers } from 'ethers';
 
-import { Address, ProtocolType } from '@hyperlane-xyz/utils';
+import { Address, ProtocolType, assert } from '@hyperlane-xyz/utils';
 
 import {
   TestChainName,
@@ -21,6 +21,7 @@ import { TokenArgs } from './IToken.js';
 import { Token } from './Token.js';
 import { TokenConnectionType } from './TokenConnection.js';
 import { TokenStandard } from './TokenStandard.js';
+import { SealevelHypNativeAdapter } from './adapters/SealevelTokenAdapter.js';
 
 // null values represent TODOs here, ideally all standards should be tested
 const STANDARD_TO_TOKEN: Record<TokenStandard, TokenArgs | null> = {
@@ -509,6 +510,63 @@ describe('Token', () => {
       expect(() => evmNativeToken.getHypAdapter(multiProvider)).to.throw(
         'not found in multiProvider',
       );
+    });
+
+    it('forwards WarpCoreConfig sealevel.altAddresses to SealevelHypNativeAdapter', () => {
+      const multiProvider =
+        MultiProtocolProvider.createTestMultiProtocolProvider(
+          createMailboxTestMetadata(),
+        );
+
+      const altAddresses = {
+        core: 'AyD8sj1iCNDmF7QKytrkF35cE9NipJ4UNkCJSiPnEKAQ',
+        warpSpecific: ['9Ngnk7jVz9LFmddRPm3JknUYsbDpVQqJj1Sb3upDtRfQ'],
+      };
+      const sealevelNativeToken = new Token(
+        {
+          chainName: testSealevelChain.name,
+          standard: TokenStandard.SealevelHypNative,
+          addressOrDenom: '4UMNyNWW75zo69hxoJaRX5iXNUa5FdRPZZa9vDVCiESg',
+          decimals: 9,
+          symbol: 'SOL',
+          name: 'SOL',
+        },
+        {
+          sealevel: {
+            altAddresses: { [testSealevelChain.name]: altAddresses },
+          },
+        },
+      );
+
+      const adapter = sealevelNativeToken.getHypAdapter(multiProvider);
+      assert(
+        adapter instanceof SealevelHypNativeAdapter,
+        'expected SealevelHypNativeAdapter',
+      );
+      expect(adapter.addresses.altAddresses).to.deep.equal(altAddresses);
+    });
+
+    it('leaves altAddresses undefined when WarpCore options omit them', () => {
+      const multiProvider =
+        MultiProtocolProvider.createTestMultiProtocolProvider(
+          createMailboxTestMetadata(),
+        );
+
+      const sealevelNativeToken = new Token({
+        chainName: testSealevelChain.name,
+        standard: TokenStandard.SealevelHypNative,
+        addressOrDenom: '4UMNyNWW75zo69hxoJaRX5iXNUa5FdRPZZa9vDVCiESg',
+        decimals: 9,
+        symbol: 'SOL',
+        name: 'SOL',
+      });
+
+      const adapter = sealevelNativeToken.getHypAdapter(multiProvider);
+      assert(
+        adapter instanceof SealevelHypNativeAdapter,
+        'expected SealevelHypNativeAdapter',
+      );
+      expect(adapter.addresses.altAddresses).to.equal(undefined);
     });
   });
 

--- a/typescript/sdk/src/token/Token.ts
+++ b/typescript/sdk/src/token/Token.ts
@@ -10,8 +10,9 @@ import {
 
 import type { MultiProviderAdapter } from '../providers/MultiProviderAdapter.js';
 import { ChainName } from '../types.js';
+import type { WarpCoreConfig } from '../warp/types.js';
 
-import type { IToken } from './IToken.js';
+import type { IToken, TokenArgs } from './IToken.js';
 import { TokenAmount } from './TokenAmount.js';
 import { TokenConnection, TokenConnectionType } from './TokenConnection.js';
 import { TokenStandard } from './TokenStandard.js';
@@ -55,6 +56,13 @@ import { createStarknetHypAdapter } from './adapters/starknetHyp.js';
 import { createTronHypAdapter } from './adapters/tronHyp.js';
 
 export class Token extends TokenMetadata implements IToken {
+  protected readonly warpCoreOptions?: WarpCoreConfig['options'];
+
+  constructor(args: TokenArgs, warpCoreOptions?: WarpCoreConfig['options']) {
+    super(args);
+    this.warpCoreOptions = warpCoreOptions;
+  }
+
   override amount(amount: Numberish): TokenAmount<this> {
     return new TokenAmount(amount, this);
   }
@@ -192,7 +200,7 @@ export class Token extends TokenMetadata implements IToken {
     const hypAdapter =
       createEvmHypAdapter(multiProvider, this) ||
       createTronHypAdapter(multiProvider, this) ||
-      createSealevelHypAdapter(multiProvider, this) ||
+      createSealevelHypAdapter(multiProvider, this, this.warpCoreOptions) ||
       createCosmosHypAdapter(multiProvider, this) ||
       createStarknetHypAdapter(multiProvider, this) ||
       createRadixHypAdapter(multiProvider, this) ||

--- a/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.test.ts
+++ b/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.test.ts
@@ -186,21 +186,4 @@ describe('SealevelHypCrossCollateralAdapter', () => {
       });
     }
   });
-
-  describe('deriveIgpQuoteAuthorityAccount', () => {
-    // Full seed-lockstep with the on-chain igp_quote_authority PDA is validated
-    // in the SVM e2e harness; this guards the specific regression of reusing
-    // the mailbox dispatch authority for the quoted-IGP sender authority.
-    it('derives a PDA distinct from the mailbox dispatch authority', () => {
-      expect(adapter.deriveIgpQuoteAuthorityAccount().toBase58()).to.not.equal(
-        adapter.deriveMessageDispatchAuthorityAccount().toBase58(),
-      );
-    });
-
-    it('is deterministic', () => {
-      expect(adapter.deriveIgpQuoteAuthorityAccount().toBase58()).to.equal(
-        adapter.deriveIgpQuoteAuthorityAccount().toBase58(),
-      );
-    });
-  });
 });

--- a/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.test.ts
+++ b/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.test.ts
@@ -1,0 +1,206 @@
+import { PublicKey } from '@solana/web3.js';
+import { expect } from 'chai';
+
+import {
+  Address,
+  Domain,
+  addressToBytes,
+  padBytesToLength,
+} from '@hyperlane-xyz/utils';
+
+import { TestChainName, testChainMetadata } from '../../consts/testChains.js';
+import { MultiProtocolProvider } from '../../providers/MultiProtocolProvider.js';
+
+import type { InterchainGasQuote, Quote } from './ITokenAdapter.js';
+import { SealevelHypCrossCollateralAdapter } from './SealevelCrossCollateralAdapter.js';
+import {
+  SealevelHyperlaneTokenData,
+  SealevelTokenFeeConfig,
+} from './serialization.js';
+
+const PLACEHOLDER = '11111111111111111111111111111111';
+const SENDER = new PublicKey(Buffer.alloc(32, 3)).toBase58();
+const RECIPIENT = new PublicKey(Buffer.alloc(32, 5)).toBase58();
+const WARP_FEE_AMOUNT = 777n;
+// Router passed explicitly to the "To" quote path.
+const PASSED_ROUTER = new PublicKey(Buffer.alloc(32, 9)).toBase58();
+// Router registered in the on-chain remote_routers map for the local domain,
+// resolved by the non-"To" quote path.
+const REGISTERED_ROUTER = new Uint8Array(Buffer.alloc(32, 7));
+
+// Stub the two provider-touching dependencies so the local-transfer quote
+// orchestration can be exercised without a validator: `getTokenAccountData`
+// (RPC account fetch) and `quoteWarpFee` (fee-program simulation).
+class TestCcAdapter extends SealevelHypCrossCollateralAdapter {
+  tokenDataStub!: SealevelHyperlaneTokenData;
+  warpFeeCalls: Array<{ destination: Domain; targetRouter: Uint8Array }> = [];
+
+  override getTokenAccountData(): Promise<SealevelHyperlaneTokenData> {
+    return Promise.resolve(this.tokenDataStub);
+  }
+
+  override quoteWarpFee(args: {
+    feeConfig: SealevelTokenFeeConfig;
+    payer: PublicKey;
+    destination: Domain;
+    recipient: Address;
+    amount: bigint;
+    targetRouter: Uint8Array;
+  }): Promise<Quote> {
+    this.warpFeeCalls.push({
+      destination: args.destination,
+      targetRouter: args.targetRouter,
+    });
+    return Promise.resolve({ amount: WARP_FEE_AMOUNT, addressOrDenom: 'FEE' });
+  }
+}
+
+function buildTokenData({
+  withFee,
+  localDomain,
+}: {
+  withFee: boolean;
+  localDomain: Domain;
+}): SealevelHyperlaneTokenData {
+  const data = new SealevelHyperlaneTokenData({
+    bump: 1,
+    mailbox: new Uint8Array(32),
+    mailbox_process_authority: new Uint8Array(32),
+    dispatch_authority_bump: 1,
+    decimals: 9,
+    remote_decimals: 9,
+    remote_routers: new Map<number, Uint8Array>([
+      [localDomain, REGISTERED_ROUTER],
+    ]),
+  });
+  if (withFee) {
+    data.fee_config = {
+      feeProgram: new PublicKey(PLACEHOLDER),
+      feeAccount: new PublicKey(PLACEHOLDER),
+    };
+  }
+  return data;
+}
+
+// A local-transfer quote case. `withFee` discriminates the expectation shape:
+// a fee-configured route must surface `tokenFeeQuote` quoted against
+// `expectedTargetRouter`; an unconfigured route must not.
+type LocalQuoteCase = {
+  name: string;
+  invoke: (
+    adapter: TestCcAdapter,
+    localDomain: Domain,
+  ) => Promise<InterchainGasQuote>;
+} & ({ withFee: true; expectedTargetRouter: Uint8Array } | { withFee: false });
+
+const LOCAL_QUOTE_CASES: LocalQuoteCase[] = [
+  {
+    name: 'quoteTransferRemoteToGas quotes the warp fee against the passed router',
+    withFee: true,
+    expectedTargetRouter: padBytesToLength(addressToBytes(PASSED_ROUTER), 32),
+    invoke: (adapter, localDomain) =>
+      adapter.quoteTransferRemoteToGas({
+        destination: localDomain,
+        recipient: RECIPIENT,
+        amount: 1000n,
+        targetRouter: PASSED_ROUTER,
+        sender: SENDER,
+      }),
+  },
+  {
+    name: 'quoteTransferRemoteToGas returns a zero quote with no tokenFeeQuote when fee_config is absent',
+    withFee: false,
+    invoke: (adapter, localDomain) =>
+      adapter.quoteTransferRemoteToGas({
+        destination: localDomain,
+        recipient: RECIPIENT,
+        amount: 1000n,
+        targetRouter: PASSED_ROUTER,
+        sender: SENDER,
+      }),
+  },
+  {
+    name: 'quoteTransferRemoteGas quotes the warp fee against the registered router',
+    withFee: true,
+    expectedTargetRouter: REGISTERED_ROUTER,
+    invoke: (adapter, localDomain) =>
+      adapter.quoteTransferRemoteGas({
+        destination: localDomain,
+        sender: SENDER,
+        recipient: RECIPIENT,
+        amount: 1000n,
+      }),
+  },
+  {
+    name: 'quoteTransferRemoteGas returns a zero quote with no tokenFeeQuote when fee_config is absent',
+    withFee: false,
+    invoke: (adapter, localDomain) =>
+      adapter.quoteTransferRemoteGas({
+        destination: localDomain,
+        sender: SENDER,
+        recipient: RECIPIENT,
+        amount: 1000n,
+      }),
+  },
+];
+
+describe('SealevelHypCrossCollateralAdapter', () => {
+  let multiProvider: MultiProtocolProvider;
+  let adapter: TestCcAdapter;
+  let localDomain: Domain;
+
+  beforeEach(() => {
+    multiProvider = new MultiProtocolProvider(testChainMetadata);
+    localDomain = multiProvider.getDomainId(TestChainName.test1);
+    adapter = new TestCcAdapter(TestChainName.test1, multiProvider, {
+      warpRouter: PLACEHOLDER,
+      token: PLACEHOLDER,
+      mailbox: PLACEHOLDER,
+    });
+  });
+
+  describe('local-transfer quoting', () => {
+    for (const testCase of LOCAL_QUOTE_CASES) {
+      it(testCase.name, async () => {
+        adapter.tokenDataStub = buildTokenData({
+          withFee: testCase.withFee,
+          localDomain,
+        });
+
+        const quote = await testCase.invoke(adapter, localDomain);
+
+        // Local transfers never make an IGP payment.
+        expect(quote.igpQuote.amount).to.equal(0n);
+        if (testCase.withFee) {
+          expect(quote.tokenFeeQuote?.amount).to.equal(WARP_FEE_AMOUNT);
+          expect(adapter.warpFeeCalls).to.have.length(1);
+          expect(adapter.warpFeeCalls[0].destination).to.equal(localDomain);
+          // The fee must be quoted against the destination router.
+          expect(
+            Buffer.from(adapter.warpFeeCalls[0].targetRouter),
+          ).to.deep.equal(Buffer.from(testCase.expectedTargetRouter));
+        } else {
+          expect(quote.tokenFeeQuote).to.equal(undefined);
+          expect(adapter.warpFeeCalls).to.have.length(0);
+        }
+      });
+    }
+  });
+
+  describe('deriveIgpQuoteAuthorityAccount', () => {
+    // Full seed-lockstep with the on-chain igp_quote_authority PDA is validated
+    // in the SVM e2e harness; this guards the specific regression of reusing
+    // the mailbox dispatch authority for the quoted-IGP sender authority.
+    it('derives a PDA distinct from the mailbox dispatch authority', () => {
+      expect(adapter.deriveIgpQuoteAuthorityAccount().toBase58()).to.not.equal(
+        adapter.deriveMessageDispatchAuthorityAccount().toBase58(),
+      );
+    });
+
+    it('is deterministic', () => {
+      expect(adapter.deriveIgpQuoteAuthorityAccount().toBase58()).to.equal(
+        adapter.deriveIgpQuoteAuthorityAccount().toBase58(),
+      );
+    });
+  });
+});

--- a/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
@@ -27,6 +27,7 @@ import type {
   TransferRemoteParams,
   TransferRemoteToParams,
 } from './ITokenAdapter.js';
+import { parseSimulationAccountMetas } from './sealevelFee.js';
 import {
   SealevelHypCollateralAdapter,
   TRANSFER_REMOTE_COMPUTE_LIMIT,
@@ -42,9 +43,6 @@ import {
 
 // CC program discriminator (8 bytes of 2s)
 const CC_DISCRIMINATOR = Buffer.from([2, 2, 2, 2, 2, 2, 2, 2]);
-
-// Each SerializableAccountMeta is: pubkey (32) + is_signer (1) + is_writable (1) = 34 bytes
-const SERIALIZABLE_ACCOUNT_META_SIZE = 34;
 
 export class SealevelHypCrossCollateralAdapter
   extends SealevelHypCollateralAdapter
@@ -359,24 +357,7 @@ export class SealevelHypCrossCollateralAdapter
       `HandleLocalAccountMetas simulation returned no data. The target program may not implement HandleLocalAccountMetas.\nLogs: ${logs?.join('\n')}`,
     );
 
-    const data = Buffer.from(base64Data, 'base64');
-    // First 4 bytes are the Vec length (little-endian u32)
-    const count = data.readUInt32LE(0);
-    const expectedLength = 4 + count * SERIALIZABLE_ACCOUNT_META_SIZE;
-    assert(
-      data.length >= expectedLength,
-      `HandleLocalAccountMetas returned truncated data: expected ${expectedLength} bytes, got ${data.length}`,
-    );
-    const accountMetas: Array<AccountMeta> = [];
-    for (let i = 0; i < count; i++) {
-      const offset = 4 + i * SERIALIZABLE_ACCOUNT_META_SIZE;
-      const pubkey = new PublicKey(data.subarray(offset, offset + 32));
-      const isSigner = data[offset + 32] !== 0;
-      const isWritable = data[offset + 33] !== 0;
-      accountMetas.push({ pubkey, isSigner, isWritable });
-    }
-
-    return accountMetas;
+    return parseSimulationAccountMetas(Buffer.from(base64Data, 'base64'));
   }
 
   // Should match rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/src/processor.rs transfer_remote_to_local

--- a/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
@@ -103,11 +103,17 @@ export class SealevelHypCrossCollateralAdapter
     mailbox,
     randomWallet,
     igp,
+    feeSection,
+    igpQuotedSection,
   }: {
     sender: PublicKey;
     mailbox: PublicKey;
     randomWallet: PublicKey;
     igp?: IgpPaymentKeys;
+    /** Spliced after slot 9 (dispatched message PDA) when token.fee_config is Some. */
+    feeSection?: AccountMeta[];
+    /** Spliced between the gas-payment PDA and the configured IGP account when inner Igp.fee_config is Some. */
+    igpQuotedSection?: AccountMeta[];
   }): Promise<Array<AccountMeta>> {
     let keys: Array<AccountMeta> = [
       // 0.   [executable] The system program.
@@ -156,18 +162,23 @@ export class SealevelHypCrossCollateralAdapter
       },
     ];
 
+    // Fee section — spliced when token.fee_config is Some on chain.
+    if (feeSection) {
+      keys = [...keys, ...feeSection];
+    }
+
     if (igp) {
       keys = [
         ...keys,
-        // 10.   [executable] The IGP program.
+        // [executable] The IGP program.
         { pubkey: igp.programId, isSigner: false, isWritable: false },
-        // 11.   [writeable] The IGP program data.
+        // [writeable] The IGP program data.
         {
           pubkey: SealevelOverheadIgpAdapter.deriveIgpProgramPda(igp.programId),
           isSigner: false,
           isWritable: true,
         },
-        // 12.   [writeable] Gas payment PDA.
+        // [writeable] Gas payment PDA.
         {
           pubkey: SealevelOverheadIgpAdapter.deriveGasPaymentPda(
             igp.programId,
@@ -177,10 +188,14 @@ export class SealevelHypCrossCollateralAdapter
           isWritable: true,
         },
       ];
+      // Quoted-mode extension — spliced when inner Igp.fee_config is Some.
+      if (igpQuotedSection) {
+        keys = [...keys, ...igpQuotedSection];
+      }
       if (igp.overheadIgpAccount) {
         keys = [
           ...keys,
-          // 13.   [] OPTIONAL - The Overhead IGP account, if the configured IGP is an Overhead IGP.
+          // [] OPTIONAL - The Overhead IGP account, if the configured IGP is an Overhead IGP.
           {
             pubkey: igp.overheadIgpAccount,
             isSigner: false,
@@ -190,7 +205,7 @@ export class SealevelHypCrossCollateralAdapter
       }
       keys = [
         ...keys,
-        // 14.   [writeable] The Overhead's inner IGP account (or the normal IGP account if there's no Overhead IGP).
+        // [writeable] The Overhead's inner IGP account (or the normal IGP account if there's no Overhead IGP).
         { pubkey: igp.igpAccount, isSigner: false, isWritable: true },
       ];
     }
@@ -326,12 +341,15 @@ export class SealevelHypCrossCollateralAdapter
     senderProgram,
     amount,
     recipient,
+    feeSection,
   }: {
     sender: PublicKey;
     targetProgram: PublicKey;
     senderProgram: PublicKey;
     amount: bigint;
     recipient: Uint8Array;
+    /** Spliced after the target program when token.fee_config is Some. */
+    feeSection?: AccountMeta[];
   }): Promise<Array<AccountMeta>> {
     const handleLocalAccountMetas = await this.simulateHandleLocalAccountMetas({
       targetProgram,
@@ -372,7 +390,9 @@ export class SealevelHypCrossCollateralAdapter
       },
       // 5.   [executable] The target program.
       { pubkey: targetProgram, isSigner: false, isWritable: false },
-      // 6.   [executable] The SPL token program for the mint.
+      // Fee section — spliced when token.fee_config is Some on chain.
+      ...(feeSection ?? []),
+      // [executable] The SPL token program for the mint.
       {
         pubkey: await this.getTokenProgramId(),
         isSigner: false,
@@ -418,6 +438,18 @@ export class SealevelHypCrossCollateralAdapter
     );
     const localDomain = this.multiProvider.getDomainId(this.chainName);
 
+    const tokenData = await this.getTokenAccountData();
+    // CC fee account uses the destination warp router H256 in its
+    // standing-quote PDA seeds.
+    const feeSection = tokenData.fee_config
+      ? await this.buildFeeSectionKeys({
+          feeConfig: tokenData.fee_config,
+          payer: sender,
+          destination,
+          targetRouter: targetRouterBytes,
+        })
+      : undefined;
+
     if (destination === localDomain) {
       const targetProgram = new PublicKey(targetRouter);
       const keys = await this.getTransferRemoteToLocalKeyList({
@@ -426,6 +458,7 @@ export class SealevelHypCrossCollateralAdapter
         senderProgram: this.warpProgramPubKey,
         amount: BigInt(amount),
         recipient: recipientBytes,
+        feeSection,
       });
 
       return this.createTransferRemoteToTx({
@@ -441,11 +474,25 @@ export class SealevelHypCrossCollateralAdapter
         ? extraSigners[0]
         : Keypair.generate();
       const mailbox = new PublicKey(this.addresses.mailbox);
+      const igpState = await this.innerIgpFeeState.get();
+      const igpProgramId =
+        tokenData.interchain_gas_paymaster?.program_id_pubkey;
+      const igpQuotedSection =
+        igpState?.feeConfig && igpProgramId
+          ? await this.buildIgpQuotedSectionKeys({
+              igpProgramId,
+              innerIgpAccount: igpState.innerIgpAccount,
+              payer: sender,
+              destination,
+            })
+          : undefined;
       const keys = await this.getTransferRemoteToRemoteKeyList({
         sender,
         mailbox,
         randomWallet: randomWallet.publicKey,
         igp: await this.getIgpKeys(),
+        feeSection,
+        igpQuotedSection,
       });
 
       return this.createTransferRemoteToTx({

--- a/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
@@ -22,6 +22,9 @@ import {
 import { SealevelInstructionWrapper } from '../../utils/sealevelSerialization.js';
 import type {
   IHypCrossCollateralAdapter,
+  InterchainGasQuote,
+  QuoteTransferRemoteParams,
+  TransferRemoteParams,
   TransferRemoteToParams,
 } from './ITokenAdapter.js';
 import {
@@ -79,6 +82,59 @@ export class SealevelHypCrossCollateralAdapter
       // CC fee account uses the destination warp router H256 in its
       // standing-quote PDA seeds.
       targetRouter: padBytesToLength(addressToBytes(params.targetRouter), 32),
+    });
+  }
+
+  // Override base impl which seeds the standing-quote PDA with H256::zero();
+  // CC fee accounts seed with the destination warp router pulled from the
+  // on-chain remote_routers map.
+  override async quoteTransferRemoteGas(
+    params: QuoteTransferRemoteParams,
+  ): Promise<InterchainGasQuote> {
+    const localDomain = this.multiProvider.getDomainId(this.chainName);
+    if (params.destination === localDomain) {
+      return { igpQuote: { amount: 0n } };
+    }
+    const tokenData = await this.getTokenAccountData();
+    const remoteRouterBytes = tokenData.remote_routers?.get(params.destination);
+    assert(
+      remoteRouterBytes,
+      `No remote router registered for destination domain ${params.destination}`,
+    );
+    return this.quoteTransferGas({
+      destination: params.destination,
+      sender: params.sender,
+      recipient: params.recipient,
+      amount: params.amount,
+      targetRouter: remoteRouterBytes,
+    });
+  }
+
+  // Override base impl which seeds the fee section with H256::zero(); resolve
+  // the destination warp router and delegate to populateTransferRemoteToTx.
+  override async populateTransferRemoteTx({
+    weiAmountOrId,
+    destination,
+    recipient,
+    fromAccountOwner,
+    extraSigners,
+  }: TransferRemoteParams): Promise<Transaction | VersionedTransaction> {
+    const tokenData = await this.getTokenAccountData();
+    const remoteRouterBytes = tokenData.remote_routers?.get(destination);
+    assert(
+      remoteRouterBytes,
+      `No remote router registered for destination domain ${destination}`,
+    );
+    // 32-byte canonical form → base58 round-trips through addressToBytesSol
+    // back to the same 32 bytes (works for both EVM-padded and native SVM
+    // target routers).
+    return this.populateTransferRemoteToTx({
+      amount: weiAmountOrId,
+      destination,
+      recipient,
+      fromAccountOwner,
+      targetRouter: new PublicKey(remoteRouterBytes).toBase58(),
+      extraSigners,
     });
   }
 

--- a/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
@@ -8,6 +8,7 @@ import {
   SystemProgram,
   Transaction,
   TransactionInstruction,
+  MessageV0,
   VersionedTransaction,
 } from '@solana/web3.js';
 import { serialize } from 'borsh';
@@ -427,7 +428,7 @@ export class SealevelHypCrossCollateralAdapter
     fromAccountOwner,
     targetRouter,
     extraSigners,
-  }: TransferRemoteToParams): Promise<Transaction> {
+  }: TransferRemoteToParams): Promise<Transaction | VersionedTransaction> {
     assert(fromAccountOwner, 'fromAccountOwner required for Sealevel');
 
     const sender = new PublicKey(fromAccountOwner);
@@ -523,7 +524,7 @@ export class SealevelHypCrossCollateralAdapter
     targetRouterBytes: Uint8Array;
     sender: PublicKey;
     randomWallet?: Keypair;
-  }): Promise<Transaction> {
+  }): Promise<Transaction | VersionedTransaction> {
     const value = new SealevelInstructionWrapper({
       instruction: SealevelCCInstructionKind.TransferRemoteTo,
       data: new SealevelCCTransferRemoteToInstruction({
@@ -552,18 +553,51 @@ export class SealevelHypCrossCollateralAdapter
       await this.getProvider().getLatestBlockhash('finalized')
     ).blockhash;
 
-    // @ts-expect-error Workaround for bug in the web3 lib, sometimes uses recentBlockhash and sometimes uses blockhash
-    const tx = new Transaction({
-      feePayer: sender,
-      blockhash: recentBlockhash,
-      recentBlockhash,
-    })
-      .add(setComputeLimitInstruction)
-      .add(setPriorityFeeInstruction)
-      .add(transferInstruction);
+    const instructions = [
+      setComputeLimitInstruction,
+      setPriorityFeeInstruction,
+      transferInstruction,
+    ];
 
-    if (randomWallet) {
-      tx.partialSign(randomWallet);
+    let tx: Transaction | VersionedTransaction;
+    if (this.addresses.altAddresses) {
+      // ALT path: when the route registers ALT addresses, compile a v0
+      // message so the on-chain account-key list stays under Solana's
+      // 1232-byte tx limit (40+ accounts on new-flow fee + IGP routes).
+      const addressLookupTableAccounts =
+        await this.addressLookupTableAccounts.get();
+      const message = MessageV0.compile({
+        payerKey: sender,
+        instructions,
+        recentBlockhash,
+        addressLookupTableAccounts,
+      });
+      const versionedTx = new VersionedTransaction(message);
+
+      // Only fills the randomWallet's slot; the user wallet's slot stays
+      // empty for the wallet-adapter chain to populate later. Local-domain
+      // CC transfers don't have a unique-message PDA, so randomWallet is
+      // undefined and we skip pre-signing.
+      if (randomWallet) {
+        versionedTx.sign([randomWallet]);
+      }
+
+      tx = versionedTx;
+    } else {
+      // Legacy path — unchanged for routes without ALT.
+      // @ts-expect-error Workaround for bug in the web3 lib, sometimes uses recentBlockhash and sometimes uses blockhash
+      tx = new Transaction({
+        feePayer: sender,
+        blockhash: recentBlockhash,
+        recentBlockhash,
+      })
+        .add(setComputeLimitInstruction)
+        .add(setPriorityFeeInstruction)
+        .add(transferInstruction);
+
+      if (randomWallet) {
+        tx.partialSign(randomWallet);
+      }
     }
 
     return tx;

--- a/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
@@ -70,13 +70,15 @@ export class SealevelHypCrossCollateralAdapter
       return { igpQuote: { amount: 0n } };
     }
 
-    const quote = await this.quoteTransferRemoteGas({
+    return this.quoteTransferGas({
       destination: params.destination,
       sender: params.sender,
+      recipient: params.recipient,
+      amount: BigInt(params.amount),
+      // CC fee account uses the destination warp router H256 in its
+      // standing-quote PDA seeds.
+      targetRouter: padBytesToLength(addressToBytes(params.targetRouter), 32),
     });
-    return {
-      igpQuote: { amount: BigInt(quote.igpQuote.amount) },
-    };
   }
 
   // Should match rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/src/processor.rs transfer_remote_to_remote

--- a/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
@@ -1,4 +1,10 @@
-import { addressToBytes, assert, padBytesToLength } from '@hyperlane-xyz/utils';
+import {
+  Address,
+  Domain,
+  addressToBytes,
+  assert,
+  padBytesToLength,
+} from '@hyperlane-xyz/utils';
 import {
   AccountMeta,
   ComputeBudgetProgram,
@@ -69,7 +75,13 @@ export class SealevelHypCrossCollateralAdapter
   ) {
     const localDomain = this.multiProvider.getDomainId(this.chainName);
     if (params.destination === localDomain) {
-      return { igpQuote: { amount: 0n } };
+      return this.quoteLocalTransferGas({
+        sender: params.sender,
+        recipient: params.recipient,
+        amount: BigInt(params.amount),
+        destination: params.destination,
+        targetRouter: padBytesToLength(addressToBytes(params.targetRouter), 32),
+      });
     }
 
     return this.quoteTransferGas({
@@ -83,6 +95,45 @@ export class SealevelHypCrossCollateralAdapter
     });
   }
 
+  /**
+   * Quote a same-domain (local) CrossCollateral transfer. Local transfers make
+   * no IGP payment, but `transfer_remote_to_local` still debits the warp fee
+   * on-chain when fee_config is set (quoted against the destination router), so
+   * surface it as `tokenFeeQuote` to keep cost display and balance validation
+   * consistent with what the transaction actually charges.
+   */
+  private async quoteLocalTransferGas({
+    sender,
+    recipient,
+    amount,
+    destination,
+    targetRouter,
+  }: {
+    sender?: Address;
+    recipient?: Address;
+    amount?: bigint;
+    destination: Domain;
+    targetRouter: Uint8Array;
+  }): Promise<InterchainGasQuote> {
+    const tokenData = await this.getTokenAccountData();
+    if (!tokenData.fee_config) {
+      return { igpQuote: { amount: 0n } };
+    }
+    assert(
+      sender && recipient && amount !== undefined,
+      'sender, recipient, and amount required for Sealevel warp-fee quote',
+    );
+    const tokenFeeQuote = await this.quoteWarpFee({
+      feeConfig: tokenData.fee_config,
+      payer: new PublicKey(sender),
+      destination,
+      recipient,
+      amount,
+      targetRouter,
+    });
+    return { igpQuote: { amount: 0n }, tokenFeeQuote };
+  }
+
   // Override base impl which seeds the standing-quote PDA with H256::zero();
   // CC fee accounts seed with the destination warp router pulled from the
   // on-chain remote_routers map.
@@ -90,15 +141,22 @@ export class SealevelHypCrossCollateralAdapter
     params: QuoteTransferRemoteParams,
   ): Promise<InterchainGasQuote> {
     const localDomain = this.multiProvider.getDomainId(this.chainName);
-    if (params.destination === localDomain) {
-      return { igpQuote: { amount: 0n } };
-    }
     const tokenData = await this.getTokenAccountData();
     const remoteRouterBytes = tokenData.remote_routers?.get(params.destination);
     assert(
       remoteRouterBytes,
       `No remote router registered for destination domain ${params.destination}`,
     );
+    if (params.destination === localDomain) {
+      return this.quoteLocalTransferGas({
+        sender: params.sender,
+        recipient: params.recipient,
+        amount: params.amount,
+        destination: params.destination,
+        targetRouter: remoteRouterBytes,
+      });
+    }
+
     return this.quoteTransferGas({
       destination: params.destination,
       sender: params.sender,

--- a/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelCrossCollateralAdapter.ts
@@ -44,7 +44,7 @@ const SERIALIZABLE_ACCOUNT_META_SIZE = 34;
 
 export class SealevelHypCrossCollateralAdapter
   extends SealevelHypCollateralAdapter
-  implements IHypCrossCollateralAdapter<Transaction>
+  implements IHypCrossCollateralAdapter<Transaction | VersionedTransaction>
 {
   deriveCrossCollateralStatePda(): PublicKey {
     return this.derivePda(

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -344,10 +344,16 @@ export class SealevelTokenAdapter
   }
 }
 
+export interface SealevelAltAddresses {
+  core: Address;
+  warpSpecific: Address[];
+}
+
 interface HypTokenAddresses {
   token: Address;
   warpRouter: Address;
   mailbox: Address;
+  altAddresses?: SealevelAltAddresses;
 }
 
 export abstract class SealevelHypTokenAdapter
@@ -749,6 +755,7 @@ export class SealevelHypNativeAdapter extends SealevelHypTokenAdapter {
       token?: Address;
       warpRouter: Address;
       mailbox: Address;
+      altAddresses?: SealevelAltAddresses;
     },
   ) {
     // Pass in placeholder address for 'token' to avoid errors in the parent classes

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -9,6 +9,7 @@ import {
 } from '@solana/spl-token';
 import {
   AccountMeta,
+  AddressLookupTableAccount,
   ComputeBudgetProgram,
   Keypair,
   PublicKey,
@@ -475,6 +476,43 @@ export abstract class SealevelHypTokenAdapter
    */
   protected getFeeTokenAddressOrDenom(): string | undefined {
     return this.tokenMintPubKey.toBase58();
+  }
+
+  /// Cached `AddressLookupTableAccount`s fetched from
+  /// `this.addresses.altAddresses`. Empty when no ALT addresses are
+  /// configured (legacy routes). Used by populateTransferRemote(To)Tx to
+  /// compile a `VersionedTransaction` whose account-key footprint fits
+  /// under Solana's 1232-byte transaction size limit when the new fee +
+  /// IGP-quoted-mode sections push the count past what a legacy
+  /// `Transaction` can carry.
+  protected readonly addressLookupTableAccounts = new LazyAsync(() =>
+    this.loadAddressLookupTableAccounts(),
+  );
+
+  private async loadAddressLookupTableAccounts(): Promise<
+    AddressLookupTableAccount[]
+  > {
+    const altAddresses = this.addresses.altAddresses;
+    if (!altAddresses) {
+      return [];
+    }
+
+    const connection = this.getProvider();
+    const addresses = [
+      new PublicKey(altAddresses.core),
+      ...altAddresses.warpSpecific.map((a) => new PublicKey(a)),
+    ];
+
+    const results = await Promise.all(
+      addresses.map((addr) => connection.getAddressLookupTable(addr)),
+    );
+    return results.map((r, i) => {
+      assert(
+        r.value,
+        `Sealevel ALT not found on chain: ${addresses[i].toBase58()}`,
+      );
+      return r.value;
+    });
   }
 
   /// Cached beneficiary owner pubkey from the fee_account. Used to derive

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -38,7 +38,10 @@ import {
   SealevelIgpProgramAdapter,
   SealevelOverheadIgpAdapter,
 } from '../../gas/adapters/SealevelIgpAdapter.js';
-import { SealevelInterchainGasPaymasterType } from '../../gas/adapters/serialization.js';
+import {
+  SealevelIgpFeeConfig,
+  SealevelInterchainGasPaymasterType,
+} from '../../gas/adapters/serialization.js';
 import type { MultiProviderAdapter } from '../../providers/MultiProviderAdapter.js';
 import { ChainName } from '../../types.js';
 import {
@@ -52,10 +55,17 @@ import {
   IHypTokenAdapter,
   ITokenAdapter,
   InterchainGasQuote,
+  Quote,
   QuoteTransferRemoteParams,
   TransferParams,
   TransferRemoteParams,
 } from './ITokenAdapter.js';
+import {
+  simulateFeeQuoteAccountMetas,
+  simulateIgpQuote,
+  simulateIgpQuoteAccountMetas,
+  simulateWarpFee,
+} from './sealevelFee.js';
 import {
   SealevelHypTokenInstruction,
   SealevelHyperlaneTokenData,
@@ -393,6 +403,86 @@ export abstract class SealevelHypTokenAdapter
     return fee_config;
   }
 
+  /// Cached inner-Igp state. Used to decide new-flow vs legacy IGP quoting
+  /// and to build the new-flow QuoteGasPayment account list. For OverheadIgp
+  /// routes the inner Igp address is resolved via an extra RPC on the
+  /// OverheadIgp PDA.
+  protected readonly innerIgpFeeState = new LazyAsync(() =>
+    this.loadInnerIgpFeeState(),
+  );
+
+  private async loadInnerIgpFeeState(): Promise<
+    | {
+        innerIgpAccount: PublicKey;
+        // Set only when the token's IGP config is OverheadIgp; appended
+        // after the cascade on the new-flow QuoteGasPayment / PayForGas
+        // account list.
+        overheadIgpAccount?: PublicKey;
+        feeConfig: SealevelIgpFeeConfig | undefined;
+      }
+    | undefined
+  > {
+    const tokenData = await this.getTokenAccountData();
+    const igpConfig = tokenData.interchain_gas_paymaster;
+    if (!igpConfig || igpConfig.igp_account_pub_key === undefined) {
+      return undefined;
+    }
+
+    let innerIgpAccount: PublicKey;
+    let overheadIgpAccount: PublicKey | undefined;
+    if (igpConfig.type === SealevelInterchainGasPaymasterType.Igp) {
+      innerIgpAccount = igpConfig.igp_account_pub_key;
+    } else if (
+      igpConfig.type === SealevelInterchainGasPaymasterType.OverheadIgp
+    ) {
+      overheadIgpAccount = igpConfig.igp_account_pub_key;
+      const overheadIgp = new SealevelOverheadIgpAdapter(
+        this.chainName,
+        this.multiProvider,
+        {
+          overheadIgp: overheadIgpAccount.toBase58(),
+          programId: igpConfig.program_id_pubkey.toBase58(),
+        },
+      );
+      const overheadData = await overheadIgp.getAccountInfo();
+      innerIgpAccount = overheadData.inner_pub_key;
+    } else {
+      return undefined;
+    }
+
+    const innerIgp = new SealevelIgpAdapter(
+      this.chainName,
+      this.multiProvider,
+      {
+        igp: innerIgpAccount.toBase58(),
+        programId: igpConfig.program_id_pubkey.toBase58(),
+      },
+    );
+    const innerInfo = await innerIgp.getAccountInfo();
+    return {
+      innerIgpAccount,
+      overheadIgpAccount,
+      feeConfig: innerInfo.fee_config,
+    };
+  }
+
+  /**
+   * Address-or-denom value used for `tokenFeeQuote.addressOrDenom`. The
+   * on-chain fee is deducted from the warp token; native adapters override
+   * to return undefined (SOL sentinel).
+   */
+  protected getFeeTokenAddressOrDenom(): string | undefined {
+    return this.tokenMintPubKey.toBase58();
+  }
+
+  /**
+   * target_router H256 for fee simulation. Non-CC modes use H256::zero()
+   * per the on-chain seed macros; CC overrides this.
+   */
+  protected getTargetRouterBytes(): Uint8Array {
+    return new Uint8Array(32);
+  }
+
   private async loadTokenAccountData(): Promise<SealevelHyperlaneTokenData> {
     const tokenPda = this.deriveHypTokenAccount();
     const accountInfo = await this.getProvider().getAccountInfo(tokenPda);
@@ -463,27 +553,159 @@ export abstract class SealevelHypTokenAdapter
   async quoteTransferRemoteGas({
     destination,
     sender,
+    recipient,
+    amount,
   }: QuoteTransferRemoteParams): Promise<InterchainGasQuote> {
     const tokenData = await this.getTokenAccountData();
+
+    // -------- Warp fee quote (only when token.fee_config is set) --------
+    let tokenFeeQuote: Quote | undefined;
+    if (tokenData.fee_config) {
+      assert(
+        sender && recipient && amount !== undefined,
+        'sender, recipient, and amount required for Sealevel warp-fee quote',
+      );
+      tokenFeeQuote = await this.quoteWarpFee({
+        feeConfig: tokenData.fee_config,
+        payer: new PublicKey(sender),
+        destination,
+        recipient,
+        amount,
+      });
+    }
+
+    // -------- IGP fee quote --------
     const destinationGas = tokenData.destination_gas?.get(destination);
-    if (isNullish(destinationGas)) {
-      return { igpQuote: { amount: 0n } };
+    let igpQuote: Quote = { amount: 0n };
+    if (!isNullish(destinationGas)) {
+      const igpAdapter = this.getIgpAdapter(tokenData);
+      if (igpAdapter) {
+        assert(
+          sender,
+          'Sender required for Sealevel transfer remote gas quote',
+        );
+        const senderPubKey = new PublicKey(sender);
+        const igpState = await this.innerIgpFeeState.get();
+        const igpProgramId =
+          tokenData.interchain_gas_paymaster?.program_id_pubkey;
+        if (igpState?.feeConfig && igpProgramId) {
+          igpQuote = {
+            amount: await this.quoteIgpNewFlow({
+              igpProgramId,
+              innerIgpAccount: igpState.innerIgpAccount,
+              overheadIgpAccount: igpState.overheadIgpAccount,
+              payer: senderPubKey,
+              destination,
+              gasAmount: destinationGas,
+            }),
+          };
+        } else {
+          igpQuote = {
+            amount: await igpAdapter.quoteGasPayment(
+              destination,
+              destinationGas,
+              senderPubKey,
+            ),
+          };
+        }
+      }
     }
 
-    const igp = this.getIgpAdapter(tokenData);
-    if (!igp) {
-      return { igpQuote: { amount: 0n } };
-    }
+    return tokenFeeQuote ? { igpQuote, tokenFeeQuote } : { igpQuote };
+  }
 
-    assert(sender, 'Sender required for Sealevel transfer remote gas quote');
-
-    const igpPayment = await igp.quoteGasPayment(
-      destination,
-      destinationGas,
-      new PublicKey(sender),
+  private async quoteWarpFee({
+    feeConfig,
+    payer,
+    destination,
+    recipient,
+    amount,
+  }: {
+    feeConfig: SealevelTokenFeeConfig;
+    payer: PublicKey;
+    destination: Domain;
+    recipient: Address;
+    amount: bigint;
+  }): Promise<Quote> {
+    const targetRouter = this.getTargetRouterBytes();
+    const metas = await simulateFeeQuoteAccountMetas(
+      this.getProvider(),
+      feeConfig.feeProgram,
+      feeConfig.feeAccount,
+      payer,
+      { destinationDomain: destination, targetRouter },
     );
+    // Slot 1 of the simulation output is a payer placeholder
+    // (Pubkey::default()) — substitute with the real payer before invoking
+    // QuoteFee.
+    const accounts = metas.map((m, i) =>
+      i === 1 ? { ...m, pubkey: payer } : m,
+    );
+    const feeAmount = await simulateWarpFee(
+      this.getProvider(),
+      feeConfig.feeProgram,
+      payer,
+      accounts,
+      {
+        destinationDomain: destination,
+        recipient: padBytesToLength(addressToBytes(recipient), 32),
+        amount,
+        targetRouter,
+      },
+    );
+    return {
+      amount: feeAmount,
+      addressOrDenom: this.getFeeTokenAddressOrDenom(),
+    };
+  }
 
-    return { igpQuote: { amount: igpPayment } };
+  private async quoteIgpNewFlow({
+    igpProgramId,
+    innerIgpAccount,
+    overheadIgpAccount,
+    payer,
+    destination,
+    gasAmount,
+  }: {
+    igpProgramId: PublicKey;
+    innerIgpAccount: PublicKey;
+    overheadIgpAccount?: PublicKey;
+    payer: PublicKey;
+    destination: Domain;
+    gasAmount: bigint;
+  }): Promise<bigint> {
+    // Discover the standing cascade tail via on-chain simulation on the
+    // inner Igp. simulateIgpQuoteAccountMetas returns the PayForGas-shaped
+    // list; slots 0..7 are the static prefix, slot 8+ is the cascade.
+    const igpMetas = await simulateIgpQuoteAccountMetas(
+      this.getProvider(),
+      igpProgramId,
+      innerIgpAccount,
+      payer,
+      { destinationDomain: destination, sender: this.warpProgramPubKey },
+    );
+    const cascadeTail = igpMetas.slice(8);
+
+    // QuoteGasPayment new-flow direct-call layout:
+    //   [system, inner_igp, quoted_sender, ...cascade, optional_overhead_igp]
+    const accounts: AccountMeta[] = [
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      { pubkey: innerIgpAccount, isSigner: false, isWritable: false },
+      { pubkey: this.warpProgramPubKey, isSigner: false, isWritable: false },
+      ...cascadeTail,
+    ];
+    if (overheadIgpAccount) {
+      accounts.push({
+        pubkey: overheadIgpAccount,
+        isSigner: false,
+        isWritable: false,
+      });
+    }
+
+    return simulateIgpQuote(this.getProvider(), igpProgramId, payer, accounts, {
+      destinationDomain: destination,
+      gasAmount,
+    });
   }
 
   async populateTransferRemoteTx({
@@ -779,6 +1001,11 @@ export class SealevelHypNativeAdapter extends SealevelHypTokenAdapter {
   // rust/sealevel/programs/hyperlane-sealevel-token-native/src/plugin.rs.
   protected readonly pluginDataSize = 1;
   public readonly wrappedNative: SealevelNativeTokenAdapter;
+
+  // Native warp fees are deducted from the native collateral PDA → SOL.
+  protected override getFeeTokenAddressOrDenom(): string | undefined {
+    return undefined;
+  }
 
   constructor(
     public readonly chainName: ChainName,

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -12,10 +12,12 @@ import {
   AddressLookupTableAccount,
   ComputeBudgetProgram,
   Keypair,
+  MessageV0,
   PublicKey,
   SystemProgram,
   Transaction,
   TransactionInstruction,
+  VersionedTransaction,
 } from '@solana/web3.js';
 import { deserializeUnchecked, serialize } from 'borsh';
 
@@ -373,7 +375,7 @@ interface HypTokenAddresses {
 
 export abstract class SealevelHypTokenAdapter
   extends SealevelTokenAdapter
-  implements IHypTokenAdapter<Transaction>
+  implements IHypTokenAdapter<Transaction | VersionedTransaction>
 {
   public readonly warpProgramPubKey: PublicKey;
   public readonly addresses: HypTokenAddresses;
@@ -898,7 +900,7 @@ export abstract class SealevelHypTokenAdapter
     recipient,
     fromAccountOwner,
     extraSigners,
-  }: TransferRemoteParams): Promise<Transaction> {
+  }: TransferRemoteParams): Promise<Transaction | VersionedTransaction> {
     if (!fromAccountOwner)
       throw new Error('fromAccountOwner required for Sealevel');
     const randomWallet = extraSigners?.length
@@ -978,16 +980,46 @@ export abstract class SealevelHypTokenAdapter
       await this.getProvider().getLatestBlockhash('finalized')
     ).blockhash;
 
-    // @ts-ignore Workaround for bug in the web3 lib, sometimes uses recentBlockhash and sometimes uses blockhash
-    const tx = new Transaction({
-      feePayer: fromWalletPubKey,
-      blockhash: recentBlockhash,
-      recentBlockhash,
-    })
-      .add(setComputeLimitInstruction)
-      .add(setPriorityFeeInstruction)
-      .add(transferRemoteInstruction);
-    tx.partialSign(randomWallet);
+    let tx: Transaction | VersionedTransaction;
+    if (this.addresses.altAddresses) {
+      // ALT path: when the route registers ALT addresses, compile a v0
+      // message so the on-chain account-key list stays under Solana's
+      // 1232-byte tx limit (40+ accounts on new-flow fee + IGP routes).
+      const instructions = [
+        setComputeLimitInstruction,
+        setPriorityFeeInstruction,
+        transferRemoteInstruction,
+      ];
+
+      const addressLookupTableAccounts =
+        await this.addressLookupTableAccounts.get();
+      const message = MessageV0.compile({
+        payerKey: fromWalletPubKey,
+        instructions,
+        recentBlockhash,
+        addressLookupTableAccounts,
+      });
+
+      const versionedTx = new VersionedTransaction(message);
+      // Only fills the randomWallet's slot; the user wallet's slot stays
+      // empty for the wallet-adapter chain to populate later.
+      versionedTx.sign([randomWallet]);
+      tx = versionedTx;
+    } else {
+      // Legacy path — unchanged for routes without ALT.
+      // @ts-ignore Workaround for bug in the web3 lib, sometimes uses recentBlockhash and sometimes uses blockhash
+      tx = new Transaction({
+        feePayer: fromWalletPubKey,
+        blockhash: recentBlockhash,
+        recentBlockhash,
+      })
+        .add(setComputeLimitInstruction)
+        .add(setPriorityFeeInstruction)
+        .add(transferRemoteInstruction);
+
+      tx.partialSign(randomWallet);
+    }
+
     return tx;
   }
 

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -475,14 +475,6 @@ export abstract class SealevelHypTokenAdapter
     return this.tokenMintPubKey.toBase58();
   }
 
-  /**
-   * target_router H256 for fee simulation. Non-CC modes use H256::zero()
-   * per the on-chain seed macros; CC overrides this.
-   */
-  protected getTargetRouterBytes(): Uint8Array {
-    return new Uint8Array(32);
-  }
-
   private async loadTokenAccountData(): Promise<SealevelHyperlaneTokenData> {
     const tokenPda = this.deriveHypTokenAccount();
     const accountInfo = await this.getProvider().getAccountInfo(tokenPda);
@@ -556,6 +548,34 @@ export abstract class SealevelHypTokenAdapter
     recipient,
     amount,
   }: QuoteTransferRemoteParams): Promise<InterchainGasQuote> {
+    return this.quoteTransferGas({
+      destination,
+      sender,
+      recipient,
+      amount,
+      // Non-CC routes pass H256::zero() per the fee program's seed macros.
+      targetRouter: new Uint8Array(32),
+    });
+  }
+
+  /// Core quote orchestration shared by quoteTransferRemoteGas (non-CC) and
+  /// quoteTransferRemoteToGas (CC override). `targetRouter` is the 32-byte
+  /// H256 used in the fee program's standing-quote PDA seeds: H256::zero
+  /// for Leaf / Routing modes, destination warp router for
+  /// CrossCollateralRouting.
+  protected async quoteTransferGas({
+    destination,
+    sender,
+    recipient,
+    amount,
+    targetRouter,
+  }: {
+    destination: Domain;
+    sender?: Address;
+    recipient?: Address;
+    amount?: bigint;
+    targetRouter: Uint8Array;
+  }): Promise<InterchainGasQuote> {
     const tokenData = await this.getTokenAccountData();
 
     // -------- Warp fee quote (only when token.fee_config is set) --------
@@ -571,6 +591,7 @@ export abstract class SealevelHypTokenAdapter
         destination,
         recipient,
         amount,
+        targetRouter,
       });
     }
 
@@ -620,14 +641,15 @@ export abstract class SealevelHypTokenAdapter
     destination,
     recipient,
     amount,
+    targetRouter,
   }: {
     feeConfig: SealevelTokenFeeConfig;
     payer: PublicKey;
     destination: Domain;
     recipient: Address;
     amount: bigint;
+    targetRouter: Uint8Array;
   }): Promise<Quote> {
-    const targetRouter = this.getTargetRouterBytes();
     const metas = await simulateFeeQuoteAccountMetas(
       this.getProvider(),
       feeConfig.feeProgram,

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -67,6 +67,8 @@ import {
   simulateWarpFee,
 } from './sealevelFee.js';
 import {
+  SealevelFeeAccountPrefix,
+  SealevelFeeAccountPrefixSchema,
   SealevelHypTokenInstruction,
   SealevelHyperlaneTokenData,
   SealevelHyperlaneTokenDataSchema,
@@ -475,6 +477,128 @@ export abstract class SealevelHypTokenAdapter
     return this.tokenMintPubKey.toBase58();
   }
 
+  /// Cached beneficiary owner pubkey from the fee_account. Used to derive
+  /// the terminal fee_beneficiary spliced into the warp transfer_remote
+  /// fee section. Resolves to undefined when the token has no fee_config.
+  protected readonly feeAccountBeneficiaryOwner = new LazyAsync(() =>
+    this.loadFeeAccountBeneficiaryOwner(),
+  );
+
+  private async loadFeeAccountBeneficiaryOwner(): Promise<
+    PublicKey | undefined
+  > {
+    const tokenData = await this.getTokenAccountData();
+    if (!tokenData.fee_config) return undefined;
+    const info = await this.getProvider().getAccountInfo(
+      tokenData.fee_config.feeAccount,
+    );
+    assert(
+      info,
+      `Fee account ${tokenData.fee_config.feeAccount.toBase58()} not found on chain`,
+    );
+    const wrappedData = deserializeUnchecked(
+      SealevelFeeAccountPrefixSchema,
+      SealevelAccountDataWrapper,
+      info.data,
+    );
+    const data = wrappedData.data;
+    assert(
+      data instanceof SealevelFeeAccountPrefix,
+      'Decoded wrapper.data is not SealevelFeeAccountPrefix',
+    );
+    return data.beneficiary_pub_key;
+  }
+
+  /**
+   * Per-token-type derivation of the terminal `fee_beneficiary` spliced into
+   * the warp transfer_remote fee section. Matches
+   * `HyperlaneSealevelTokenPlugin::fee_beneficiary_pubkey` on chain.
+   */
+  protected abstract deriveFeeBeneficiary(
+    beneficiaryOwner: PublicKey,
+  ): Promise<PublicKey>;
+
+  /**
+   * Build the fee-section account list. Spliced into the warp transfer_remote
+   * after the dispatched-message PDA, when `token.fee_config` is Some.
+   *   [feeProgram, feeAccount, ...passThrough, feeBeneficiary(w)]
+   */
+  protected async buildFeeSectionKeys({
+    feeConfig,
+    payer,
+    destination,
+    targetRouter,
+  }: {
+    feeConfig: SealevelTokenFeeConfig;
+    payer: PublicKey;
+    destination: Domain;
+    targetRouter: Uint8Array;
+  }): Promise<AccountMeta[]> {
+    const metas = await simulateFeeQuoteAccountMetas(
+      this.getProvider(),
+      feeConfig.feeProgram,
+      feeConfig.feeAccount,
+      payer,
+      { destinationDomain: destination, targetRouter },
+    );
+    // Drop slots 0 (fee_account) and 1 (payer placeholder) — both appear
+    // elsewhere in the warp transfer_remote tx.
+    const passThrough = metas.slice(2);
+    const beneficiaryOwner = await this.feeAccountBeneficiaryOwner.get();
+    assert(
+      beneficiaryOwner,
+      'fee_account beneficiary owner unavailable; token.fee_config missing',
+    );
+    const feeBeneficiary = await this.deriveFeeBeneficiary(beneficiaryOwner);
+    return [
+      { pubkey: feeConfig.feeProgram, isSigner: false, isWritable: false },
+      { pubkey: feeConfig.feeAccount, isSigner: false, isWritable: false },
+      ...passThrough,
+      { pubkey: feeBeneficiary, isSigner: false, isWritable: true },
+    ];
+  }
+
+  /**
+   * Build the quoted-mode IGP extension. Spliced into the IGP section between
+   * the gas-payment PDA and the configured IGP account when the inner Igp
+   * has `fee_config` set:
+   *   [dispatchAuthority, warpProgramId, ...cascade]
+   *
+   * The dispatch authority is the warp's `invoke_signed` PDA at runtime; it
+   * is NOT marked as a signer at the outer-instruction level.
+   */
+  protected async buildIgpQuotedSectionKeys({
+    igpProgramId,
+    innerIgpAccount,
+    payer,
+    destination,
+  }: {
+    igpProgramId: PublicKey;
+    innerIgpAccount: PublicKey;
+    payer: PublicKey;
+    destination: Domain;
+  }): Promise<AccountMeta[]> {
+    const igpMetas = await simulateIgpQuoteAccountMetas(
+      this.getProvider(),
+      igpProgramId,
+      innerIgpAccount,
+      payer,
+      { destinationDomain: destination, sender: this.warpProgramPubKey },
+    );
+    // GetIgpQuoteAccountMetas returns the PayForGas-shaped list. We re-emit
+    // the quoted-mode prefix from local state and use the simulation's tail
+    // (slot 8+) for the cascade PDAs.
+    return [
+      {
+        pubkey: this.deriveMessageDispatchAuthorityAccount(),
+        isSigner: false,
+        isWritable: false,
+      },
+      { pubkey: this.warpProgramPubKey, isSigner: false, isWritable: false },
+      ...igpMetas.slice(8),
+    ];
+  }
+
   private async loadTokenAccountData(): Promise<SealevelHyperlaneTokenData> {
     const tokenPda = this.deriveHypTokenAccount();
     const accountInfo = await this.getProvider().getAccountInfo(tokenPda);
@@ -745,11 +869,38 @@ export abstract class SealevelHypTokenAdapter
     const fromWalletPubKey = new PublicKey(fromAccountOwner);
     const mailboxPubKey = new PublicKey(this.addresses.mailbox);
 
+    const tokenData = await this.getTokenAccountData();
+    const igpState = await this.innerIgpFeeState.get();
+
+    // Non-CC routes pass H256::zero() per the fee program's seed macros; CC
+    // override its own populateTransferRemoteToTx.
+    const feeSection = tokenData.fee_config
+      ? await this.buildFeeSectionKeys({
+          feeConfig: tokenData.fee_config,
+          payer: fromWalletPubKey,
+          destination,
+          targetRouter: new Uint8Array(32),
+        })
+      : undefined;
+
+    const igpProgramId = tokenData.interchain_gas_paymaster?.program_id_pubkey;
+    const igpQuotedSection =
+      igpState?.feeConfig && igpProgramId
+        ? await this.buildIgpQuotedSectionKeys({
+            igpProgramId,
+            innerIgpAccount: igpState.innerIgpAccount,
+            payer: fromWalletPubKey,
+            destination,
+          })
+        : undefined;
+
     const keys = await this.getTransferInstructionKeyList({
       sender: fromWalletPubKey,
       mailbox: mailboxPubKey,
       randomWallet: randomWallet.publicKey,
       igp: await this.getIgpKeys(),
+      feeSection,
+      igpQuotedSection,
     });
 
     const value = new SealevelInstructionWrapper({
@@ -814,6 +965,8 @@ export abstract class SealevelHypTokenAdapter
     mailbox,
     randomWallet,
     igp,
+    feeSection,
+    igpQuotedSection,
   }: KeyListParams): Promise<Array<AccountMeta>> {
     let keys = [
       // 0.   [executable] The system program.
@@ -855,18 +1008,22 @@ export abstract class SealevelHypTokenAdapter
         isWritable: true,
       },
     ];
+    // Fee section — spliced when token.fee_config is Some on chain.
+    if (feeSection) {
+      keys = [...keys, ...feeSection];
+    }
     if (igp) {
       keys = [
         ...keys,
-        // 9.    [executable] The IGP program.
+        // [executable] The IGP program.
         { pubkey: igp.programId, isSigner: false, isWritable: false },
-        // 10.   [writeable] The IGP program data.
+        // [writeable] The IGP program data.
         {
           pubkey: SealevelOverheadIgpAdapter.deriveIgpProgramPda(igp.programId),
           isSigner: false,
           isWritable: true,
         },
-        // 11.   [writeable] Gas payment PDA.
+        // [writeable] Gas payment PDA.
         {
           pubkey: SealevelOverheadIgpAdapter.deriveGasPaymentPda(
             igp.programId,
@@ -876,10 +1033,16 @@ export abstract class SealevelHypTokenAdapter
           isWritable: true,
         },
       ];
+      // Quoted-mode extension — spliced when the inner Igp has fee_config Some
+      // on chain. Placed BEFORE the optional overhead IGP and the terminal
+      // configured IGP, matching the on-chain transfer_remote layout.
+      if (igpQuotedSection) {
+        keys = [...keys, ...igpQuotedSection];
+      }
       if (igp.overheadIgpAccount) {
         keys = [
           ...keys,
-          // 12.   [] OPTIONAL - The Overhead IGP account, if the configured IGP is an Overhead IGP
+          // [] OPTIONAL - The Overhead IGP account, if the configured IGP is an Overhead IGP
           {
             pubkey: igp.overheadIgpAccount,
             isSigner: false,
@@ -889,7 +1052,7 @@ export abstract class SealevelHypTokenAdapter
       }
       keys = [
         ...keys,
-        // 13.   [writeable] The Overhead's inner IGP account (or the normal IGP account if there's no Overhead IGP).
+        // [writeable] The Overhead's inner IGP account (or the normal IGP account if there's no Overhead IGP).
         {
           pubkey: igp.igpAccount,
           isSigner: false,
@@ -1029,6 +1192,13 @@ export class SealevelHypNativeAdapter extends SealevelHypTokenAdapter {
     return undefined;
   }
 
+  // Native fee_beneficiary = beneficiary wallet directly (lamports recipient).
+  protected override async deriveFeeBeneficiary(
+    beneficiaryOwner: PublicKey,
+  ): Promise<PublicKey> {
+    return beneficiaryOwner;
+  }
+
   constructor(
     public readonly chainName: ChainName,
     public readonly multiProvider: MultiProviderAdapter,
@@ -1116,6 +1286,18 @@ export class SealevelHypCollateralAdapter extends SealevelHypTokenAdapter {
   // rust/sealevel/programs/hyperlane-sealevel-token-collateral/src/plugin.rs.
   protected readonly pluginDataSize = 98;
 
+  // Collateral fee_beneficiary = ATA(beneficiary_owner, mint, spl_token_program).
+  protected override async deriveFeeBeneficiary(
+    beneficiaryOwner: PublicKey,
+  ): Promise<PublicKey> {
+    return getAssociatedTokenAddressSync(
+      this.tokenMintPubKey,
+      beneficiaryOwner,
+      false,
+      await this.getTokenProgramId(),
+    );
+  }
+
   async getBalance(owner: Address): Promise<bigint> {
     // Special case where the owner is the warp route program ID.
     // This is because collateral warp routes don't hold escrowed collateral
@@ -1172,6 +1354,18 @@ export class SealevelHypSyntheticAdapter extends SealevelHypTokenAdapter {
   // SyntheticPlugin = [Pubkey mint, u8 mint_bump, u8 ata_payer_bump]. Matches
   // rust/sealevel/programs/hyperlane-sealevel-token/src/plugin.rs.
   protected readonly pluginDataSize = 34;
+
+  // Synthetic fee_beneficiary = ATA(beneficiary_owner, synthetic_mint, token_2022).
+  protected override async deriveFeeBeneficiary(
+    beneficiaryOwner: PublicKey,
+  ): Promise<PublicKey> {
+    return getAssociatedTokenAddressSync(
+      this.deriveMintAuthorityAccount(),
+      beneficiaryOwner,
+      false,
+      TOKEN_2022_PROGRAM_ID,
+    );
+  }
 
   override async getTransferInstructionKeyList(
     params: KeyListParams,
@@ -1244,4 +1438,16 @@ interface KeyListParams {
   mailbox: PublicKey;
   randomWallet: PublicKey;
   igp?: IgpPaymentKeys;
+  /**
+   * Optional fee section spliced after the dispatched-message PDA when the
+   * token has `fee_config` set. Layout:
+   *   [feeProgram, feeAccount, ...passThrough, feeBeneficiary(w)]
+   */
+  feeSection?: AccountMeta[];
+  /**
+   * Optional quoted-mode IGP extension spliced between the gas-payment PDA
+   * and the configured IGP account when the inner Igp has `fee_config` set:
+   *   [dispatchAuthority, warpProgramId, ...cascade]
+   */
+  igpQuotedSection?: AccountMeta[];
 }

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -60,8 +60,10 @@ import {
   SealevelHypTokenInstruction,
   SealevelHyperlaneTokenData,
   SealevelHyperlaneTokenDataSchema,
+  SealevelTokenFeeConfig,
   SealevelTransferRemoteInstruction,
   SealevelTransferRemoteSchema,
+  decodeTrailingFeeConfig,
 } from './serialization.js';
 
 const NON_EXISTENT_ACCOUNT_ERROR = 'could not find account';
@@ -362,6 +364,11 @@ export abstract class SealevelHypTokenAdapter
 {
   public readonly warpProgramPubKey: PublicKey;
   public readonly addresses: HypTokenAddresses;
+  /// Plugin data length in bytes (token-type specific). Required to locate
+  /// the optional trailing fee_config in raw account data. Mirrors the
+  /// per-plugin struct sizes from
+  /// rust/sealevel/programs/hyperlane-sealevel-token-*.
+  protected abstract readonly pluginDataSize: number;
   protected readonly tokenAccountData = new LazyAsync(() =>
     this.loadTokenAccountData(),
   );
@@ -380,6 +387,12 @@ export abstract class SealevelHypTokenAdapter
     return this.tokenAccountData.get();
   }
 
+  async getFeeConfig(): Promise<SealevelTokenFeeConfig | undefined> {
+    const { fee_config } = await this.getTokenAccountData();
+
+    return fee_config;
+  }
+
   private async loadTokenAccountData(): Promise<SealevelHyperlaneTokenData> {
     const tokenPda = this.deriveHypTokenAccount();
     const accountInfo = await this.getProvider().getAccountInfo(tokenPda);
@@ -389,7 +402,24 @@ export abstract class SealevelHypTokenAdapter
       SealevelAccountDataWrapper,
       accountInfo.data,
     );
-    return wrappedData.data as SealevelHyperlaneTokenData;
+
+    const data = wrappedData.data;
+    assert(
+      data instanceof SealevelHyperlaneTokenData,
+      'Decoded wrapper.data is not SealevelHyperlaneTokenData',
+    );
+
+    const consumedSize = serialize(
+      SealevelHyperlaneTokenDataSchema,
+      wrappedData,
+    ).length;
+    data.fee_config = decodeTrailingFeeConfig(
+      Buffer.from(accountInfo.data),
+      consumedSize,
+      this.pluginDataSize,
+    );
+
+    return data;
   }
 
   override async getMetadata(): Promise<TokenMetadata> {
@@ -745,6 +775,9 @@ export abstract class SealevelHypTokenAdapter
 
 // Interacts with Hyp Native token programs
 export class SealevelHypNativeAdapter extends SealevelHypTokenAdapter {
+  // NativePlugin = [u8 native_collateral_bump]. Matches
+  // rust/sealevel/programs/hyperlane-sealevel-token-native/src/plugin.rs.
+  protected readonly pluginDataSize = 1;
   public readonly wrappedNative: SealevelNativeTokenAdapter;
 
   constructor(
@@ -829,6 +862,11 @@ export class SealevelHypNativeAdapter extends SealevelHypTokenAdapter {
 
 // Interacts with Hyp Collateral token programs
 export class SealevelHypCollateralAdapter extends SealevelHypTokenAdapter {
+  // CollateralPlugin = [Pubkey spl_token_program, Pubkey mint, Pubkey escrow,
+  // u8 escrow_bump, u8 ata_payer_bump]. Matches
+  // rust/sealevel/programs/hyperlane-sealevel-token-collateral/src/plugin.rs.
+  protected readonly pluginDataSize = 98;
+
   async getBalance(owner: Address): Promise<bigint> {
     // Special case where the owner is the warp route program ID.
     // This is because collateral warp routes don't hold escrowed collateral
@@ -882,6 +920,10 @@ export class SealevelHypCollateralAdapter extends SealevelHypTokenAdapter {
 
 // Interacts with Hyp Synthetic token programs (aka 'HypTokens')
 export class SealevelHypSyntheticAdapter extends SealevelHypTokenAdapter {
+  // SyntheticPlugin = [Pubkey mint, u8 mint_bump, u8 ata_payer_bump]. Matches
+  // rust/sealevel/programs/hyperlane-sealevel-token/src/plugin.rs.
+  protected readonly pluginDataSize = 34;
+
   override async getTransferInstructionKeyList(
     params: KeyListParams,
   ): Promise<Array<AccountMeta>> {

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -115,6 +115,15 @@ const MINIMUM_PRIORITY_FEE = 100_000;
  */
 const IGP_QUOTE_METAS_CASCADE_OFFSET = 8;
 
+/**
+ * Offset of the quoted-mode IGP section within the PayForGas-shaped list from
+ * `GetIgpQuoteAccountMetas`: [6] igp_quote_authority, [7] quoted_sender (warp
+ * program id), [8+] cascade PDAs. Must stay in lockstep with
+ * `get_igp_quote_account_metas` in
+ * rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs.
+ */
+const IGP_QUOTE_METAS_AUTHORITY_OFFSET = 6;
+
 // Interacts with native currencies
 export class SealevelNativeTokenAdapter
   extends BaseSealevelAdapter
@@ -640,18 +649,15 @@ export abstract class SealevelHypTokenAdapter
       payer,
       { destinationDomain: destination, sender: this.warpProgramPubKey },
     );
-    // GetIgpQuoteAccountMetas returns the PayForGas-shaped list. We re-emit
-    // the quoted-mode prefix from local state and use the simulation's cascade
-    // tail for the cascade PDAs.
-    return [
-      {
-        pubkey: this.deriveIgpQuoteAuthorityAccount(),
-        isSigner: false,
-        isWritable: false,
-      },
-      { pubkey: this.warpProgramPubKey, isSigner: false, isWritable: false },
-      ...igpMetas.slice(IGP_QUOTE_METAS_CASCADE_OFFSET),
-    ];
+    // GetIgpQuoteAccountMetas already returns the correctly-derived
+    // igp_quote_authority at [6] and quoted_sender (the warp program id) at
+    // [7], followed by the cascade PDAs. Reuse that section verbatim and only
+    // force the authority non-signer — the warp signs it via invoke_signed at
+    // runtime, so it must not be a required signer at the outer level.
+    const [authority, ...rest] = igpMetas.slice(
+      IGP_QUOTE_METAS_AUTHORITY_OFFSET,
+    );
+    return [{ ...authority, isSigner: false }, ...rest];
   }
 
   private async loadTokenAccountData(): Promise<SealevelHyperlaneTokenData> {
@@ -1157,20 +1163,6 @@ export abstract class SealevelHypTokenAdapter
   deriveMessageDispatchAuthorityAccount(): PublicKey {
     return super.derivePda(
       ['hyperlane_dispatcher', '-', 'dispatch_authority'],
-      this.warpProgramPubKey,
-    );
-  }
-
-  /**
-   * IGP quote authority PDA under the warp route program. Authorizes quoted
-   * IGP gas payments and is deliberately distinct from the mailbox dispatch
-   * authority so a malicious IGP cannot replay the forwarded signer into a
-   * Mailbox dispatch. Seeds match `igp_quote_authority_pda_seeds!` in
-   * rust/sealevel/programs/hyperlane-sealevel-igp/src/pda_seeds.rs.
-   */
-  deriveIgpQuoteAuthorityAccount(): PublicKey {
-    return super.derivePda(
-      ['hyperlane_dispatcher', '-', 'igp_quote_authority'],
       this.warpProgramPubKey,
     );
   }

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -106,6 +106,15 @@ const PRIORITY_FEE_PADDING_FACTOR = 2;
  */
 const MINIMUM_PRIORITY_FEE = 100_000;
 
+/**
+ * Number of static prefix accounts in the PayForGas-shaped list returned by
+ * `GetIgpQuoteAccountMetas`: `[system, payer, program_data, unique_gas_payment,
+ * gas_payment_pda, igp, sender_authority, quoted_sender]`. Slot 8+ is the
+ * quoted-fee cascade tail. Must stay in lockstep with `get_igp_quote_account_metas`
+ * in rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs.
+ */
+const IGP_QUOTE_METAS_CASCADE_OFFSET = 8;
+
 // Interacts with native currencies
 export class SealevelNativeTokenAdapter
   extends BaseSealevelAdapter
@@ -487,6 +496,12 @@ export abstract class SealevelHypTokenAdapter
   /// under Solana's 1232-byte transaction size limit when the new fee +
   /// IGP-quoted-mode sections push the count past what a legacy
   /// `Transaction` can carry.
+  ///
+  /// Cached for the adapter's lifetime with no invalidation: if a configured
+  /// ALT is extended or deactivated on-chain after first load, this instance
+  /// keeps the stale snapshot. Adapters are constructed per warp operation, so
+  /// a fresh adapter always re-fetches; only a long-lived, reused instance
+  /// would observe staleness.
   protected readonly addressLookupTableAccounts = new LazyAsync(() =>
     this.loadAddressLookupTableAccounts(),
   );
@@ -602,9 +617,9 @@ export abstract class SealevelHypTokenAdapter
    * Build the quoted-mode IGP extension. Spliced into the IGP section between
    * the gas-payment PDA and the configured IGP account when the inner Igp
    * has `fee_config` set:
-   *   [dispatchAuthority, warpProgramId, ...cascade]
+   *   [igpQuoteAuthority, warpProgramId, ...cascade]
    *
-   * The dispatch authority is the warp's `invoke_signed` PDA at runtime; it
+   * The IGP quote authority is the warp's `invoke_signed` PDA at runtime; it
    * is NOT marked as a signer at the outer-instruction level.
    */
   protected async buildIgpQuotedSectionKeys({
@@ -626,16 +641,16 @@ export abstract class SealevelHypTokenAdapter
       { destinationDomain: destination, sender: this.warpProgramPubKey },
     );
     // GetIgpQuoteAccountMetas returns the PayForGas-shaped list. We re-emit
-    // the quoted-mode prefix from local state and use the simulation's tail
-    // (slot 8+) for the cascade PDAs.
+    // the quoted-mode prefix from local state and use the simulation's cascade
+    // tail for the cascade PDAs.
     return [
       {
-        pubkey: this.deriveMessageDispatchAuthorityAccount(),
+        pubkey: this.deriveIgpQuoteAuthorityAccount(),
         isSigner: false,
         isWritable: false,
       },
       { pubkey: this.warpProgramPubKey, isSigner: false, isWritable: false },
-      ...igpMetas.slice(8),
+      ...igpMetas.slice(IGP_QUOTE_METAS_CASCADE_OFFSET),
     ];
   }
 
@@ -862,7 +877,7 @@ export abstract class SealevelHypTokenAdapter
   }): Promise<bigint> {
     // Discover the standing cascade tail via on-chain simulation on the
     // inner Igp. simulateIgpQuoteAccountMetas returns the PayForGas-shaped
-    // list; slots 0..7 are the static prefix, slot 8+ is the cascade.
+    // list; the static prefix precedes the cascade tail.
     const igpMetas = await simulateIgpQuoteAccountMetas(
       this.getProvider(),
       igpProgramId,
@@ -870,7 +885,7 @@ export abstract class SealevelHypTokenAdapter
       payer,
       { destinationDomain: destination, sender: this.warpProgramPubKey },
     );
-    const cascadeTail = igpMetas.slice(8);
+    const cascadeTail = igpMetas.slice(IGP_QUOTE_METAS_CASCADE_OFFSET);
 
     // QuoteGasPayment new-flow direct-call layout:
     //   [system, inner_igp, quoted_sender, ...cascade, optional_overhead_igp]
@@ -1142,6 +1157,20 @@ export abstract class SealevelHypTokenAdapter
   deriveMessageDispatchAuthorityAccount(): PublicKey {
     return super.derivePda(
       ['hyperlane_dispatcher', '-', 'dispatch_authority'],
+      this.warpProgramPubKey,
+    );
+  }
+
+  /**
+   * IGP quote authority PDA under the warp route program. Authorizes quoted
+   * IGP gas payments and is deliberately distinct from the mailbox dispatch
+   * authority so a malicious IGP cannot replay the forwarded signer into a
+   * Mailbox dispatch. Seeds match `igp_quote_authority_pda_seeds!` in
+   * rust/sealevel/programs/hyperlane-sealevel-igp/src/pda_seeds.rs.
+   */
+  deriveIgpQuoteAuthorityAccount(): PublicKey {
+    return super.derivePda(
+      ['hyperlane_dispatcher', '-', 'igp_quote_authority'],
       this.warpProgramPubKey,
     );
   }

--- a/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/SealevelTokenAdapter.ts
@@ -814,7 +814,7 @@ export abstract class SealevelHypTokenAdapter
     return tokenFeeQuote ? { igpQuote, tokenFeeQuote } : { igpQuote };
   }
 
-  private async quoteWarpFee({
+  protected async quoteWarpFee({
     feeConfig,
     payer,
     destination,

--- a/typescript/sdk/src/token/adapters/sealevelFee.test.ts
+++ b/typescript/sdk/src/token/adapters/sealevelFee.test.ts
@@ -1,0 +1,133 @@
+import { PublicKey, SystemProgram } from '@solana/web3.js';
+import { expect } from 'chai';
+import { serialize } from 'borsh';
+
+import { SealevelInstructionWrapper } from '../../utils/sealevelSerialization.js';
+
+import {
+  SealevelFeeInstruction,
+  SealevelGetQuoteAccountMetasInstruction,
+  SealevelGetQuoteAccountMetasSchema,
+  SealevelQuoteFeeInstruction,
+  SealevelQuoteFeeSchema,
+  deriveFeeAccountPda,
+  deriveFeeStandingQuotePda,
+  deriveIgpStandingQuotePda,
+} from './sealevelFee.js';
+
+const TEST_PROGRAM = new PublicKey(
+  'AyD8sj1iCNDmF7QKytrkF35cE9NipJ4UNkCJSiPnEKAQ',
+);
+const TEST_FEE_ACCOUNT = new PublicKey(
+  '9Ngnk7jVz9LFmddRPm3JknUYsbDpVQqJj1Sb3upDtRfQ',
+);
+
+describe('SealevelQuoteFeeSchema', () => {
+  it('encodes QuoteFee with the expected byte layout', () => {
+    const recipient = new Uint8Array(32).fill(0x11);
+    const targetRouter = new Uint8Array(32).fill(0x22);
+    const wrapped = new SealevelInstructionWrapper({
+      instruction: SealevelFeeInstruction.QuoteFee,
+      data: new SealevelQuoteFeeInstruction({
+        destination_domain: 1337,
+        recipient,
+        amount: 1000n,
+        target_router: targetRouter,
+      }),
+    });
+    const bytes = serialize(SealevelQuoteFeeSchema, wrapped);
+    expect(bytes.length).to.equal(1 + 4 + 32 + 8 + 32);
+    expect(bytes[0]).to.equal(SealevelFeeInstruction.QuoteFee);
+  });
+});
+
+describe('SealevelGetQuoteAccountMetasSchema', () => {
+  it('encodes the standing variant (scoped_salt = null) as 38 bytes', () => {
+    const wrapped = new SealevelInstructionWrapper({
+      instruction: SealevelFeeInstruction.GetQuoteAccountMetas,
+      data: new SealevelGetQuoteAccountMetasInstruction({
+        destination_domain: 42,
+        target_router: new Uint8Array(32).fill(0x33),
+        scoped_salt: null,
+      }),
+    });
+    const bytes = serialize(SealevelGetQuoteAccountMetasSchema, wrapped);
+    expect(bytes.length).to.equal(1 + 4 + 32 + 1);
+    expect(bytes[0]).to.equal(SealevelFeeInstruction.GetQuoteAccountMetas);
+    expect(bytes[bytes.length - 1]).to.equal(0); // Option::None tag
+  });
+
+  it('encodes the transient variant (scoped_salt = Some) as 70 bytes', () => {
+    const wrapped = new SealevelInstructionWrapper({
+      instruction: SealevelFeeInstruction.GetQuoteAccountMetas,
+      data: new SealevelGetQuoteAccountMetasInstruction({
+        destination_domain: 42,
+        target_router: new Uint8Array(32).fill(0x33),
+        scoped_salt: new Uint8Array(32).fill(0x44),
+      }),
+    });
+    const bytes = serialize(SealevelGetQuoteAccountMetasSchema, wrapped);
+    expect(bytes.length).to.equal(1 + 4 + 32 + 1 + 32);
+    expect(bytes[1 + 4 + 32]).to.equal(1); // Option::Some tag
+  });
+});
+
+describe('PDA derivers', () => {
+  const salt = new Uint8Array(32).fill(0x99);
+
+  it('deriveFeeAccountPda is deterministic', () => {
+    const a = deriveFeeAccountPda(TEST_PROGRAM, salt);
+    const b = deriveFeeAccountPda(TEST_PROGRAM, salt);
+    expect(a.toBase58()).to.equal(b.toBase58());
+  });
+
+  it('deriveFeeStandingQuotePda uses H256::zero() sentinel for Leaf/Routing', () => {
+    const leafPda = deriveFeeStandingQuotePda(
+      TEST_PROGRAM,
+      TEST_FEE_ACCOUNT,
+      10,
+      null,
+    );
+    const explicitZero = deriveFeeStandingQuotePda(
+      TEST_PROGRAM,
+      TEST_FEE_ACCOUNT,
+      10,
+      new Uint8Array(32),
+    );
+    expect(leafPda.toBase58()).to.equal(explicitZero.toBase58());
+  });
+
+  it('deriveFeeStandingQuotePda differentiates Leaf vs CC by target_router', () => {
+    const leafPda = deriveFeeStandingQuotePda(
+      TEST_PROGRAM,
+      TEST_FEE_ACCOUNT,
+      10,
+      null,
+    );
+    const ccPda = deriveFeeStandingQuotePda(
+      TEST_PROGRAM,
+      TEST_FEE_ACCOUNT,
+      10,
+      new Uint8Array(32).fill(0xab),
+    );
+    expect(leafPda.toBase58()).to.not.equal(ccPda.toBase58());
+  });
+
+  it('deriveIgpStandingQuotePda includes fee_token_mint in seeds', () => {
+    const native = deriveIgpStandingQuotePda(
+      TEST_PROGRAM,
+      TEST_FEE_ACCOUNT,
+      SystemProgram.programId,
+      10,
+      TEST_PROGRAM,
+    );
+    const spl = deriveIgpStandingQuotePda(
+      TEST_PROGRAM,
+      TEST_FEE_ACCOUNT,
+      new PublicKey('Fefw54S6NDdwNbPngPePvW4tiFTFQDT7gBPvFoDFeGqg'),
+      10,
+      TEST_PROGRAM,
+    );
+    expect(native.toBase58()).to.not.equal(spl.toBase58());
+  });
+});

--- a/typescript/sdk/src/token/adapters/sealevelFee.test.ts
+++ b/typescript/sdk/src/token/adapters/sealevelFee.test.ts
@@ -13,6 +13,7 @@ import {
   deriveFeeAccountPda,
   deriveFeeStandingQuotePda,
   deriveIgpStandingQuotePda,
+  parseSimulationAccountMetas,
 } from './sealevelFee.js';
 
 const TEST_PROGRAM = new PublicKey(
@@ -129,5 +130,50 @@ describe('PDA derivers', () => {
       TEST_PROGRAM,
     );
     expect(native.toBase58()).to.not.equal(spl.toBase58());
+  });
+});
+
+describe('parseSimulationAccountMetas', () => {
+  it('decodes a vec with multiple entries', () => {
+    const k1 = Buffer.alloc(32, 0xaa);
+    const k2 = Buffer.alloc(32, 0xbb);
+    const data = Buffer.concat([
+      Buffer.from([0x02, 0x00, 0x00, 0x00]), // len = 2
+      k1,
+      Buffer.from([0x01, 0x00]), // signer=true, writable=false
+      k2,
+      Buffer.from([0x00, 0x01]), // signer=false, writable=true
+    ]);
+    const metas = parseSimulationAccountMetas(data);
+    expect(metas.length).to.equal(2);
+    expect(metas[0].isSigner).to.equal(true);
+    expect(metas[0].isWritable).to.equal(false);
+    expect(metas[1].isSigner).to.equal(false);
+    expect(metas[1].isWritable).to.equal(true);
+    expect(metas[0].pubkey.toBuffer().equals(k1)).to.equal(true);
+    expect(metas[1].pubkey.toBuffer().equals(k2)).to.equal(true);
+  });
+
+  it('decodes an empty vec', () => {
+    const metas = parseSimulationAccountMetas(
+      Buffer.from([0x00, 0x00, 0x00, 0x00]),
+    );
+    expect(metas).to.deep.equal([]);
+  });
+
+  it('throws on truncated length prefix', () => {
+    expect(() => parseSimulationAccountMetas(Buffer.from([0x00]))).to.throw(
+      'Simulation return data too short',
+    );
+  });
+
+  it('throws on truncated vec body', () => {
+    const data = Buffer.concat([
+      Buffer.from([0x02, 0x00, 0x00, 0x00]), // claims 2 entries
+      Buffer.alloc(34, 0xaa), // only 1 entry follows
+    ]);
+    expect(() => parseSimulationAccountMetas(data)).to.throw(
+      'Truncated Vec<SerializableAccountMeta>',
+    );
   });
 });

--- a/typescript/sdk/src/token/adapters/sealevelFee.ts
+++ b/typescript/sdk/src/token/adapters/sealevelFee.ts
@@ -1,7 +1,29 @@
-import { PublicKey } from '@solana/web3.js';
+import {
+  AccountMeta,
+  Connection,
+  Message,
+  PublicKey,
+  TransactionInstruction,
+  VersionedTransaction,
+} from '@solana/web3.js';
+import { deserializeUnchecked, serialize } from 'borsh';
+
+import { assert } from '@hyperlane-xyz/utils';
 
 import { BaseSealevelAdapter } from '../../app/MultiProtocolApp.js';
-import { SealevelInstructionWrapper } from '../../utils/sealevelSerialization.js';
+import {
+  SealevelGetIgpQuoteAccountMetasInstruction,
+  SealevelGetIgpQuoteAccountMetasSchema,
+  SealevelIgpInstruction,
+  SealevelIgpQuoteGasPaymentInstruction,
+  SealevelIgpQuoteGasPaymentResponse,
+  SealevelIgpQuoteGasPaymentResponseSchema,
+  SealevelIgpQuoteGasPaymentSchema,
+} from '../../gas/adapters/serialization.js';
+import {
+  SealevelAccountDataWrapper,
+  SealevelInstructionWrapper,
+} from '../../utils/sealevelSerialization.js';
 
 // ============================================================================
 // Fee program instructions
@@ -201,4 +223,239 @@ export function deriveIgpStandingQuotePda(
     ],
     programId,
   );
+}
+
+// ============================================================================
+// Simulation helpers
+// ============================================================================
+
+// SerializableAccountMeta = [pubkey: 32, is_signer: u8, is_writable: u8] = 34
+// bytes. Matches serializable_account_meta::SerializableAccountMeta in the
+// Rust workspace.
+const SERIALIZABLE_ACCOUNT_META_SIZE = 34;
+
+/**
+ * Parse a borsh-encoded `Vec<SerializableAccountMeta>` (u32 LE length prefix
+ * + N * 34 bytes) into the @solana/web3.js AccountMeta shape.
+ */
+export function parseSimulationAccountMetas(data: Buffer): AccountMeta[] {
+  assert(
+    data.length >= 4,
+    `Simulation return data too short for length prefix: ${data.length}`,
+  );
+  const count = data.readUInt32LE(0);
+  const expectedLength = 4 + count * SERIALIZABLE_ACCOUNT_META_SIZE;
+  assert(
+    data.length >= expectedLength,
+    `Truncated Vec<SerializableAccountMeta>: expected ${expectedLength}, got ${data.length}`,
+  );
+  const metas: AccountMeta[] = [];
+  for (let i = 0; i < count; i++) {
+    const off = 4 + i * SERIALIZABLE_ACCOUNT_META_SIZE;
+    metas.push({
+      pubkey: new PublicKey(data.subarray(off, off + 32)),
+      isSigner: data[off + 32] !== 0,
+      isWritable: data[off + 33] !== 0,
+    });
+  }
+  return metas;
+}
+
+async function simulateAndReadReturnData(
+  connection: Connection,
+  ix: TransactionInstruction,
+  payer: PublicKey,
+  label: string,
+): Promise<Buffer> {
+  const message = Message.compile({
+    recentBlockhash: PublicKey.default.toBase58(),
+    instructions: [ix],
+    payerKey: payer,
+  });
+  const sim = await connection.simulateTransaction(
+    new VersionedTransaction(message),
+    {
+      replaceRecentBlockhash: true,
+      sigVerify: false,
+    },
+  );
+  assert(
+    !sim.value.err,
+    `${label} simulation failed: ${JSON.stringify(sim.value.err)}\nLogs: ${sim.value.logs?.join('\n')}`,
+  );
+  const base64 = sim.value.returnData?.data?.[0];
+  assert(base64, `${label} simulation returned no data`);
+  return Buffer.from(base64, 'base64');
+}
+
+/**
+ * Simulation-only: returns the account metas required for a `QuoteFee` call
+ * on the fee program. Slot 0 of the returned vector is the fee account,
+ * slot 1 is a payer placeholder (Pubkey::default()) that callers must
+ * substitute with the real payer before passing into `simulateWarpFee` or a
+ * `transfer_remote` instruction.
+ */
+export async function simulateFeeQuoteAccountMetas(
+  connection: Connection,
+  feeProgram: PublicKey,
+  feeAccount: PublicKey,
+  payer: PublicKey,
+  params: {
+    destinationDomain: number;
+    targetRouter: Uint8Array;
+    scopedSalt?: Uint8Array;
+  },
+): Promise<AccountMeta[]> {
+  const wrapped = new SealevelInstructionWrapper({
+    instruction: SealevelFeeInstruction.GetQuoteAccountMetas,
+    data: new SealevelGetQuoteAccountMetasInstruction({
+      destination_domain: params.destinationDomain,
+      target_router: params.targetRouter,
+      scoped_salt: params.scopedSalt ?? null,
+    }),
+  });
+  const ix = new TransactionInstruction({
+    keys: [{ pubkey: feeAccount, isSigner: false, isWritable: false }],
+    programId: feeProgram,
+    data: Buffer.from(serialize(SealevelGetQuoteAccountMetasSchema, wrapped)),
+  });
+  const returnData = await simulateAndReadReturnData(
+    connection,
+    ix,
+    payer,
+    'GetQuoteAccountMetas',
+  );
+  return parseSimulationAccountMetas(returnData);
+}
+
+/**
+ * Simulation-only: returns the account metas required for a `QuoteGasPayment`
+ * call in the new-flow IGP path. The returned vector starts with system
+ * program, payer placeholder, program_data, unique_gas_payment placeholder,
+ * gas_payment_pda placeholder, IGP account, then the cascade PDAs. Callers
+ * must substitute placeholders before passing accounts into a real call.
+ */
+export async function simulateIgpQuoteAccountMetas(
+  connection: Connection,
+  igpProgram: PublicKey,
+  igpAccount: PublicKey,
+  payer: PublicKey,
+  params: {
+    destinationDomain: number;
+    sender: PublicKey;
+    scopedSalt?: Uint8Array;
+  },
+): Promise<AccountMeta[]> {
+  const wrapped = new SealevelInstructionWrapper({
+    instruction: SealevelIgpInstruction.GetIgpQuoteAccountMetas,
+    data: new SealevelGetIgpQuoteAccountMetasInstruction({
+      destination_domain: params.destinationDomain,
+      sender: params.sender.toBytes(),
+      scoped_salt: params.scopedSalt ?? null,
+    }),
+  });
+  const ix = new TransactionInstruction({
+    keys: [{ pubkey: igpAccount, isSigner: false, isWritable: false }],
+    programId: igpProgram,
+    data: Buffer.from(
+      serialize(SealevelGetIgpQuoteAccountMetasSchema, wrapped),
+    ),
+  });
+  const returnData = await simulateAndReadReturnData(
+    connection,
+    ix,
+    payer,
+    'GetIgpQuoteAccountMetas',
+  );
+  return parseSimulationAccountMetas(returnData);
+}
+
+/**
+ * Simulation-only: invokes `QuoteFee` on the fee program with the provided
+ * account list and returns the u64 LE fee amount via return data. The
+ * accounts must mirror the layout from `simulateFeeQuoteAccountMetas` with
+ * the payer placeholder (slot 1) replaced by the real payer.
+ */
+export async function simulateWarpFee(
+  connection: Connection,
+  feeProgram: PublicKey,
+  payer: PublicKey,
+  accounts: AccountMeta[],
+  params: {
+    destinationDomain: number;
+    recipient: Uint8Array;
+    amount: bigint;
+    targetRouter: Uint8Array;
+  },
+): Promise<bigint> {
+  const wrapped = new SealevelInstructionWrapper({
+    instruction: SealevelFeeInstruction.QuoteFee,
+    data: new SealevelQuoteFeeInstruction({
+      destination_domain: params.destinationDomain,
+      recipient: params.recipient,
+      amount: params.amount,
+      target_router: params.targetRouter,
+    }),
+  });
+  const ix = new TransactionInstruction({
+    keys: accounts,
+    programId: feeProgram,
+    data: Buffer.from(serialize(SealevelQuoteFeeSchema, wrapped)),
+  });
+  const returnData = await simulateAndReadReturnData(
+    connection,
+    ix,
+    payer,
+    'QuoteFee',
+  );
+  assert(
+    returnData.length >= 8,
+    `QuoteFee return data truncated: expected u64 LE, got ${returnData.length} bytes`,
+  );
+  return returnData.readBigUInt64LE(0);
+}
+
+/**
+ * Simulation-only: invokes the IGP's `QuoteGasPayment` with the provided
+ * account list (legacy or new-flow) and returns the u64 quote amount.
+ */
+export async function simulateIgpQuote(
+  connection: Connection,
+  igpProgram: PublicKey,
+  payer: PublicKey,
+  accounts: AccountMeta[],
+  params: {
+    destinationDomain: number;
+    gasAmount: bigint;
+  },
+): Promise<bigint> {
+  const wrapped = new SealevelInstructionWrapper({
+    instruction: SealevelIgpInstruction.QuoteGasPayment,
+    data: new SealevelIgpQuoteGasPaymentInstruction({
+      destination_domain: params.destinationDomain,
+      gas_amount: params.gasAmount,
+    }),
+  });
+  const ix = new TransactionInstruction({
+    keys: accounts,
+    programId: igpProgram,
+    data: Buffer.from(serialize(SealevelIgpQuoteGasPaymentSchema, wrapped)),
+  });
+  const returnData = await simulateAndReadReturnData(
+    connection,
+    ix,
+    payer,
+    'QuoteGasPayment',
+  );
+  const quote = deserializeUnchecked(
+    SealevelIgpQuoteGasPaymentResponseSchema,
+    SealevelAccountDataWrapper,
+    returnData,
+  );
+  const data = quote.data;
+  assert(
+    data instanceof SealevelIgpQuoteGasPaymentResponse,
+    'Decoded QuoteGasPayment response is not SealevelIgpQuoteGasPaymentResponse',
+  );
+  return data.payment_quote;
 }

--- a/typescript/sdk/src/token/adapters/sealevelFee.ts
+++ b/typescript/sdk/src/token/adapters/sealevelFee.ts
@@ -412,7 +412,11 @@ export async function simulateWarpFee(
     returnData.length >= 8,
     `QuoteFee return data truncated: expected u64 LE, got ${returnData.length} bytes`,
   );
-  return returnData.readBigUInt64LE(0);
+  return new DataView(
+    returnData.buffer,
+    returnData.byteOffset,
+    returnData.byteLength,
+  ).getBigUint64(0, true);
 }
 
 /**

--- a/typescript/sdk/src/token/adapters/sealevelFee.ts
+++ b/typescript/sdk/src/token/adapters/sealevelFee.ts
@@ -1,0 +1,204 @@
+import { PublicKey } from '@solana/web3.js';
+
+import { BaseSealevelAdapter } from '../../app/MultiProtocolApp.js';
+import { SealevelInstructionWrapper } from '../../utils/sealevelSerialization.js';
+
+// ============================================================================
+// Fee program instructions
+// ============================================================================
+
+// Should match Instruction in
+// rust/sealevel/programs/hyperlane-sealevel-fee/src/instruction.rs.
+export enum SealevelFeeInstruction {
+  InitFee,
+  QuoteFee,
+  SetRemoteFeeRoute,
+  RemoveRemoteFeeRoute,
+  UpdateFeeParams,
+  SetBeneficiary,
+  TransferOwnership,
+  SetQuoteSigner,
+  SetMinIssuedAt,
+  SetWildcardQuoteSigners,
+  SubmitQuote,
+  CloseTransientQuote,
+  PruneExpiredQuotes,
+  GetQuoteAccountMetas,
+  GetSubmitQuoteAccountMetas,
+}
+
+/// QuoteFee instruction data. CPI'd from the warp program during a
+/// transfer_remote when the token's fee_config is set; the fee program
+/// returns the fee amount as u64 LE via set_return_data.
+export class SealevelQuoteFeeInstruction {
+  destination_domain!: number;
+  recipient!: Uint8Array; // 32 bytes (H256)
+  amount!: bigint;
+  target_router!: Uint8Array; // 32 bytes (H256)
+
+  constructor(fields: any) {
+    Object.assign(this, fields);
+  }
+}
+
+export const SealevelQuoteFeeSchema = new Map<any, any>([
+  [
+    SealevelInstructionWrapper,
+    {
+      kind: 'struct',
+      fields: [
+        ['instruction', 'u8'],
+        ['data', SealevelQuoteFeeInstruction],
+      ],
+    },
+  ],
+  [
+    SealevelQuoteFeeInstruction,
+    {
+      kind: 'struct',
+      fields: [
+        ['destination_domain', 'u32'],
+        ['recipient', [32]],
+        ['amount', 'u64'],
+        ['target_router', [32]],
+      ],
+    },
+  ],
+]);
+
+/// Simulation-only instruction returning the variable pass-through account
+/// metas required for a QuoteFee call. The first slot in the returned vector
+/// is the fee account; the last is the fee beneficiary. Standing-cascade
+/// callers pass scoped_salt = null.
+export class SealevelGetQuoteAccountMetasInstruction {
+  destination_domain!: number;
+  target_router!: Uint8Array; // 32 bytes
+  scoped_salt!: Uint8Array | null; // 32 bytes if Some, null = standing only
+
+  constructor(fields: any) {
+    Object.assign(this, fields);
+  }
+}
+
+export const SealevelGetQuoteAccountMetasSchema = new Map<any, any>([
+  [
+    SealevelInstructionWrapper,
+    {
+      kind: 'struct',
+      fields: [
+        ['instruction', 'u8'],
+        ['data', SealevelGetQuoteAccountMetasInstruction],
+      ],
+    },
+  ],
+  [
+    SealevelGetQuoteAccountMetasInstruction,
+    {
+      kind: 'struct',
+      fields: [
+        ['destination_domain', 'u32'],
+        ['target_router', [32]],
+        ['scoped_salt', { kind: 'option', type: [32] }],
+      ],
+    },
+  ],
+]);
+
+// ============================================================================
+// PDA helpers
+// ============================================================================
+
+const FEE_PROGRAM_SEED = Buffer.from('hyperlane_fee');
+const IGP_PROGRAM_SEED = Buffer.from('hyperlane_igp');
+const SEP = Buffer.from('-');
+const FEE_SEG = Buffer.from('fee');
+const STANDING_SEG = Buffer.from('standing');
+const STANDING_QUOTE_SEG = Buffer.from('standing_quote');
+const H256_ZERO = Buffer.alloc(32, 0);
+
+function u32LeBuf(value: number): Buffer {
+  const buf = Buffer.alloc(4);
+  buf.writeUInt32LE(value, 0);
+  return buf;
+}
+
+/**
+ * Derive a fee account PDA. Seeds:
+ * ["hyperlane_fee", "-", "fee", "-", salt].
+ * Matches `fee_account_pda_seeds` in
+ * rust/sealevel/programs/hyperlane-sealevel-fee/src/pda_seeds.rs.
+ */
+export function deriveFeeAccountPda(
+  programId: PublicKey,
+  salt: Uint8Array,
+): PublicKey {
+  return BaseSealevelAdapter.derivePda(
+    [FEE_PROGRAM_SEED, SEP, FEE_SEG, SEP, Buffer.from(salt)],
+    programId,
+  );
+}
+
+/**
+ * Derive a fee standing quote PDA. Seeds:
+ * ["hyperlane_fee", "-", "standing", "-", fee_account, "-", domain_le, "-", target_router].
+ *
+ * For Leaf/Routing modes pass `targetRouter = null`; the helper substitutes
+ * the H256::zero() sentinel per the on-chain seed macro. For CrossCollateral
+ * routing pass the actual remote router H256.
+ */
+export function deriveFeeStandingQuotePda(
+  programId: PublicKey,
+  feeAccount: PublicKey,
+  destinationDomain: number,
+  targetRouter: Uint8Array | null,
+): PublicKey {
+  const target = targetRouter ? Buffer.from(targetRouter) : H256_ZERO;
+  return BaseSealevelAdapter.derivePda(
+    [
+      FEE_PROGRAM_SEED,
+      SEP,
+      STANDING_SEG,
+      SEP,
+      feeAccount.toBuffer(),
+      SEP,
+      u32LeBuf(destinationDomain),
+      SEP,
+      target,
+    ],
+    programId,
+  );
+}
+
+/**
+ * Derive an IGP standing quote PDA. Seeds:
+ * ["hyperlane_igp", "-", "standing_quote", "-", igp_account, "-",
+ *  fee_token_mint, "-", dest_domain_le, "-", sender].
+ *
+ * Use Pubkey::default() (= SystemProgram.programId on the JS side, both are
+ * the all-zero pubkey) for SOL-paying routes. The sender is the warp route
+ * program ID.
+ */
+export function deriveIgpStandingQuotePda(
+  programId: PublicKey,
+  igpAccount: PublicKey,
+  feeTokenMint: PublicKey,
+  destinationDomain: number,
+  sender: PublicKey,
+): PublicKey {
+  return BaseSealevelAdapter.derivePda(
+    [
+      IGP_PROGRAM_SEED,
+      SEP,
+      STANDING_QUOTE_SEG,
+      SEP,
+      igpAccount.toBuffer(),
+      SEP,
+      feeTokenMint.toBuffer(),
+      SEP,
+      u32LeBuf(destinationDomain),
+      SEP,
+      sender.toBuffer(),
+    ],
+    programId,
+  );
+}

--- a/typescript/sdk/src/token/adapters/sealevelHyp.ts
+++ b/typescript/sdk/src/token/adapters/sealevelHyp.ts
@@ -1,6 +1,7 @@
 import { assert } from '@hyperlane-xyz/utils';
 
 import type { MultiProviderAdapter } from '../../providers/MultiProviderAdapter.js';
+import type { WarpCoreConfig } from '../../warp/types.js';
 
 import {
   SealevelHypCollateralAdapter,
@@ -18,6 +19,7 @@ import { SealevelHypCrossCollateralAdapter } from './SealevelCrossCollateralAdap
 export function createSealevelHypAdapter(
   multiProvider: MultiProviderAdapter<{ mailbox?: string }>,
   token: HypTokenAdapterInput,
+  warpCoreOptions?: WarpCoreConfig['options'],
 ): IHypTokenAdapter<unknown> | undefined {
   const { standard, chainName, addressOrDenom, collateralAddressOrDenom } =
     token;
@@ -27,6 +29,7 @@ export function createSealevelHypAdapter(
   }
 
   const mailbox = multiProvider.getChainMetadata(chainName).mailbox;
+  const altAddresses = warpCoreOptions?.sealevel?.altAddresses?.[chainName];
 
   switch (standard) {
     case TokenStandard.SealevelHypNative:
@@ -34,6 +37,7 @@ export function createSealevelHypAdapter(
       return new SealevelHypNativeAdapter(chainName, multiProvider, {
         warpRouter: addressOrDenom,
         mailbox,
+        altAddresses,
       });
     case TokenStandard.SealevelHypCollateral:
       assert(mailbox, 'Mailbox required for Sealevel hyp tokens');
@@ -45,6 +49,7 @@ export function createSealevelHypAdapter(
         warpRouter: addressOrDenom,
         token: collateralAddressOrDenom,
         mailbox,
+        altAddresses,
       });
     case TokenStandard.SealevelHypSynthetic:
       assert(mailbox, 'Mailbox required for Sealevel hyp tokens');
@@ -56,6 +61,7 @@ export function createSealevelHypAdapter(
         warpRouter: addressOrDenom,
         token: collateralAddressOrDenom,
         mailbox,
+        altAddresses,
       });
     case TokenStandard.SealevelHypCrossCollateral:
       assert(mailbox, 'Mailbox required for Sealevel hyp tokens');
@@ -67,6 +73,7 @@ export function createSealevelHypAdapter(
         warpRouter: addressOrDenom,
         token: collateralAddressOrDenom,
         mailbox,
+        altAddresses,
       });
     default:
       return undefined;

--- a/typescript/sdk/src/token/adapters/serialization.test.ts
+++ b/typescript/sdk/src/token/adapters/serialization.test.ts
@@ -1,0 +1,74 @@
+import { PublicKey } from '@solana/web3.js';
+import { expect } from 'chai';
+
+import {
+  SealevelTokenFeeConfig,
+  decodeTrailingFeeConfig,
+} from './serialization.js';
+
+describe('decodeTrailingFeeConfig', () => {
+  const HEADER_SIZE = 50;
+  const PLUGIN_SIZE = 98;
+  const FEE_PROGRAM = new PublicKey(
+    'AyD8sj1iCNDmF7QKytrkF35cE9NipJ4UNkCJSiPnEKAQ',
+  );
+  const FEE_ACCOUNT = new PublicKey(
+    '9Ngnk7jVz9LFmddRPm3JknUYsbDpVQqJj1Sb3upDtRfQ',
+  );
+
+  function build(trailing: Buffer | null): Buffer {
+    const header = Buffer.alloc(HEADER_SIZE, 0xff);
+    const plugin = Buffer.alloc(PLUGIN_SIZE, 0xaa);
+    return trailing
+      ? Buffer.concat([header, plugin, trailing])
+      : Buffer.concat([header, plugin]);
+  }
+
+  it('returns undefined for pre-upgrade accounts (no trailing bytes)', () => {
+    expect(
+      decodeTrailingFeeConfig(build(null), HEADER_SIZE, PLUGIN_SIZE),
+    ).to.equal(undefined);
+  });
+
+  it('returns undefined for explicit None (lone 0u8 trailing)', () => {
+    expect(
+      decodeTrailingFeeConfig(
+        build(Buffer.from([0])),
+        HEADER_SIZE,
+        PLUGIN_SIZE,
+      ),
+    ).to.equal(undefined);
+  });
+
+  it('decodes Some fee_config from 65 trailing bytes', () => {
+    const trailing = Buffer.concat([
+      Buffer.from([1]),
+      FEE_PROGRAM.toBuffer(),
+      FEE_ACCOUNT.toBuffer(),
+    ]);
+    const decoded: SealevelTokenFeeConfig | undefined = decodeTrailingFeeConfig(
+      build(trailing),
+      HEADER_SIZE,
+      PLUGIN_SIZE,
+    );
+    expect(decoded?.feeProgram.toBase58()).to.equal(FEE_PROGRAM.toBase58());
+    expect(decoded?.feeAccount.toBase58()).to.equal(FEE_ACCOUNT.toBase58());
+  });
+
+  it('throws on invalid Option tag', () => {
+    expect(() =>
+      decodeTrailingFeeConfig(
+        build(Buffer.from([5])),
+        HEADER_SIZE,
+        PLUGIN_SIZE,
+      ),
+    ).to.throw('Invalid fee_config Option tag: 5');
+  });
+
+  it('throws on truncated Some payload', () => {
+    const trailing = Buffer.concat([Buffer.from([1]), Buffer.alloc(40, 0)]);
+    expect(() =>
+      decodeTrailingFeeConfig(build(trailing), HEADER_SIZE, PLUGIN_SIZE),
+    ).to.throw('Truncated fee_config');
+  });
+});

--- a/typescript/sdk/src/token/adapters/serialization.test.ts
+++ b/typescript/sdk/src/token/adapters/serialization.test.ts
@@ -9,6 +9,8 @@ import {
 describe('decodeTrailingFeeConfig', () => {
   const HEADER_SIZE = 50;
   const PLUGIN_SIZE = 98;
+  // `FeeConfig::DISCRIMINATOR` in hyperlane-sealevel-token/src/accounts.rs.
+  const DISCRIMINATOR = Buffer.from('TOKFEEV1', 'ascii');
   const FEE_PROGRAM = new PublicKey(
     'AyD8sj1iCNDmF7QKytrkF35cE9NipJ4UNkCJSiPnEKAQ',
   );
@@ -30,7 +32,7 @@ describe('decodeTrailingFeeConfig', () => {
     ).to.equal(undefined);
   });
 
-  it('returns undefined for explicit None (lone 0u8 trailing)', () => {
+  it('returns undefined for a tail shorter than the discriminator', () => {
     expect(
       decodeTrailingFeeConfig(
         build(Buffer.from([0])),
@@ -40,9 +42,17 @@ describe('decodeTrailingFeeConfig', () => {
     ).to.equal(undefined);
   });
 
-  it('decodes Some fee_config from 65 trailing bytes', () => {
+  it('returns undefined for a stale non-matching tail', () => {
+    // Over-allocated account with stale bytes that must not be read as Some.
+    const stale = Buffer.alloc(72, 0x01);
+    expect(
+      decodeTrailingFeeConfig(build(stale), HEADER_SIZE, PLUGIN_SIZE),
+    ).to.equal(undefined);
+  });
+
+  it('decodes Some fee_config from discriminator + 64 payload bytes', () => {
     const trailing = Buffer.concat([
-      Buffer.from([1]),
+      DISCRIMINATOR,
       FEE_PROGRAM.toBuffer(),
       FEE_ACCOUNT.toBuffer(),
     ]);
@@ -55,18 +65,24 @@ describe('decodeTrailingFeeConfig', () => {
     expect(decoded?.feeAccount.toBase58()).to.equal(FEE_ACCOUNT.toBase58());
   });
 
-  it('throws on invalid Option tag', () => {
-    expect(() =>
-      decodeTrailingFeeConfig(
-        build(Buffer.from([5])),
-        HEADER_SIZE,
-        PLUGIN_SIZE,
-      ),
-    ).to.throw('Invalid fee_config Option tag: 5');
+  it('decodes Some even when stale bytes trail the payload', () => {
+    const trailing = Buffer.concat([
+      DISCRIMINATOR,
+      FEE_PROGRAM.toBuffer(),
+      FEE_ACCOUNT.toBuffer(),
+      Buffer.alloc(16, 0xcc), // stale over-allocated tail
+    ]);
+    const decoded = decodeTrailingFeeConfig(
+      build(trailing),
+      HEADER_SIZE,
+      PLUGIN_SIZE,
+    );
+    expect(decoded?.feeProgram.toBase58()).to.equal(FEE_PROGRAM.toBase58());
+    expect(decoded?.feeAccount.toBase58()).to.equal(FEE_ACCOUNT.toBase58());
   });
 
-  it('throws on truncated Some payload', () => {
-    const trailing = Buffer.concat([Buffer.from([1]), Buffer.alloc(40, 0)]);
+  it('throws on a matching discriminator with a truncated payload', () => {
+    const trailing = Buffer.concat([DISCRIMINATOR, Buffer.alloc(40, 0)]);
     expect(() =>
       decodeTrailingFeeConfig(build(trailing), HEADER_SIZE, PLUGIN_SIZE),
     ).to.throw('Truncated fee_config');

--- a/typescript/sdk/src/token/adapters/serialization.ts
+++ b/typescript/sdk/src/token/adapters/serialization.ts
@@ -67,6 +67,48 @@ export function decodeTrailingFeeConfig(
 }
 
 /**
+ * Prefix of a fee account sufficient to extract the beneficiary owner.
+ * Mirrors `FeeAccountPrefix` in
+ * rust/sealevel/programs/hyperlane-sealevel-fee/src/accounts.rs.
+ * Trailing fields (fee_data, domain_id, min_issued_at) are left for
+ * `deserializeUnchecked` to skip — borsh-js 0.7 lacks i64 support so a
+ * full FeeAccount decoder isn't viable here.
+ */
+export class SealevelFeeAccountPrefix {
+  bump_seed!: number;
+  owner?: Uint8Array | null;
+  owner_pub_key?: PublicKey;
+  beneficiary!: Uint8Array;
+  beneficiary_pub_key!: PublicKey;
+
+  constructor(fields: any) {
+    Object.assign(this, fields);
+    this.beneficiary_pub_key = new PublicKey(this.beneficiary);
+    this.owner_pub_key = this.owner ? new PublicKey(this.owner) : undefined;
+  }
+}
+
+export const SealevelFeeAccountPrefixSchema = new Map<any, any>([
+  [
+    SealevelAccountDataWrapper,
+    // [8] = FEE_ACCT discriminator (consumed; not explicitly verified, same
+    // convention as SealevelIgpDataSchema).
+    getSealevelAccountDataSchema(SealevelFeeAccountPrefix, [8]),
+  ],
+  [
+    SealevelFeeAccountPrefix,
+    {
+      kind: 'struct',
+      fields: [
+        ['bump_seed', 'u8'],
+        ['owner', { kind: 'option', type: [32] }],
+        ['beneficiary', [32]],
+      ],
+    },
+  ],
+]);
+
+/**
  * Hyperlane Token Borsh Schema
  */
 // Should match https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/rust/sealevel/libraries/hyperlane-sealevel-token/src/accounts.rs#L25C12-L25C26

--- a/typescript/sdk/src/token/adapters/serialization.ts
+++ b/typescript/sdk/src/token/adapters/serialization.ts
@@ -13,6 +13,60 @@ import {
 } from '../../utils/sealevelSerialization.js';
 
 /**
+ * Optional warp fee configuration. Mirrors `FeeConfig` in
+ * rust/sealevel/libraries/hyperlane-sealevel-token/src/accounts.rs
+ * (introduced in the SVM fee-flow upgrade).
+ */
+export interface SealevelTokenFeeConfig {
+  feeProgram: PublicKey;
+  feeAccount: PublicKey;
+}
+
+const FEE_CONFIG_OPTION_NONE_TAG = 0;
+const FEE_CONFIG_OPTION_SOME_TAG = 1;
+const FEE_CONFIG_SOME_TRAILING_SIZE = 65; // 1 (tag) + 32 (feeProgram) + 32 (feeAccount)
+
+/**
+ * Decode the optional trailing FeeConfig from a Hyperlane token PDA's raw
+ * account data. Returns undefined for pre-upgrade accounts and for accounts
+ * where fee_config is explicitly None.
+ *
+ * On-chain layout: [SealevelHyperlaneTokenData (variable)] [plugin_data
+ * (fixed per token type)] [optional fee_config trailing]. Trailing is one
+ * of: empty (pre-upgrade), `[0u8]` (defensive None — handled even though
+ * the current on-chain serializer skips it), or `[1u8, 32B, 32B]` (Some).
+ * Mirrors `read_optional_trailing` in
+ * rust/sealevel/libraries/account-utils/src/lib.rs.
+ */
+export function decodeTrailingFeeConfig(
+  rawAccountData: Buffer,
+  consumedSize: number,
+  pluginDataSize: number,
+): SealevelTokenFeeConfig | undefined {
+  const trailingOffset = consumedSize + pluginDataSize;
+  if (rawAccountData.length <= trailingOffset) return undefined;
+
+  const tag = rawAccountData[trailingOffset];
+  if (tag === FEE_CONFIG_OPTION_NONE_TAG) return undefined;
+  assert(
+    tag === FEE_CONFIG_OPTION_SOME_TAG,
+    `Invalid fee_config Option tag: ${tag}`,
+  );
+  assert(
+    rawAccountData.length >= trailingOffset + FEE_CONFIG_SOME_TRAILING_SIZE,
+    `Truncated fee_config: expected ${FEE_CONFIG_SOME_TRAILING_SIZE} bytes from offset ${trailingOffset}, got ${rawAccountData.length - trailingOffset}`,
+  );
+  return {
+    feeProgram: new PublicKey(
+      rawAccountData.subarray(trailingOffset + 1, trailingOffset + 33),
+    ),
+    feeAccount: new PublicKey(
+      rawAccountData.subarray(trailingOffset + 33, trailingOffset + 65),
+    ),
+  };
+}
+
+/**
  * Hyperlane Token Borsh Schema
  */
 // Should match https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/rust/sealevel/libraries/hyperlane-sealevel-token/src/accounts.rs#L25C12-L25C26
@@ -46,6 +100,9 @@ export class SealevelHyperlaneTokenData {
   /// Remote routers.
   remote_routers?: Map<Domain, Uint8Array>;
   remote_router_pubkeys: Map<Domain, PublicKey>;
+  /// Trailing optional warp fee configuration. Hydrated post-decode via
+  /// `decodeTrailingFeeConfig`; NOT part of SealevelHyperlaneTokenDataSchema.
+  fee_config?: SealevelTokenFeeConfig;
   constructor(public readonly fields: any) {
     Object.assign(this, fields);
     this.mailbox_pubkey = new PublicKey(this.mailbox);

--- a/typescript/sdk/src/token/adapters/serialization.ts
+++ b/typescript/sdk/src/token/adapters/serialization.ts
@@ -10,6 +10,7 @@ import {
   SealevelAccountDataWrapper,
   SealevelInstructionWrapper,
   getSealevelAccountDataSchema,
+  readOptionalDiscriminatedTrailing,
 } from '../../utils/sealevelSerialization.js';
 
 /**
@@ -22,47 +23,39 @@ export interface SealevelTokenFeeConfig {
   feeAccount: PublicKey;
 }
 
-const FEE_CONFIG_OPTION_NONE_TAG = 0;
-const FEE_CONFIG_OPTION_SOME_TAG = 1;
-const FEE_CONFIG_SOME_TRAILING_SIZE = 65; // 1 (tag) + 32 (feeProgram) + 32 (feeAccount)
+/// `FeeConfig::DISCRIMINATOR` in hyperlane-sealevel-token/src/accounts.rs.
+const FEE_CONFIG_DISCRIMINATOR = Buffer.from('TOKFEEV1', 'ascii');
+const FEE_CONFIG_PAYLOAD_SIZE = 64; // 32 (feeProgram) + 32 (feeAccount)
 
 /**
  * Decode the optional trailing FeeConfig from a Hyperlane token PDA's raw
  * account data. Returns undefined for pre-upgrade accounts and for accounts
- * where fee_config is explicitly None.
+ * where fee_config is absent.
  *
  * On-chain layout: [SealevelHyperlaneTokenData (variable)] [plugin_data
- * (fixed per token type)] [optional fee_config trailing]. Trailing is one
- * of: empty (pre-upgrade), `[0u8]` (defensive None — handled even though
- * the current on-chain serializer skips it), or `[1u8, 32B, 32B]` (Some).
- * Mirrors `read_optional_trailing` in
- * rust/sealevel/libraries/account-utils/src/lib.rs.
+ * (fixed per token type)] [optional fee_config trailing]. The trailing field
+ * is an `OptionalDiscriminatedData<FeeConfig>`: empty when absent, or
+ * `[DISCRIMINATOR (8)][feeProgram (32)][feeAccount (32)]` when present.
  */
 export function decodeTrailingFeeConfig(
   rawAccountData: Buffer,
   consumedSize: number,
   pluginDataSize: number,
 ): SealevelTokenFeeConfig | undefined {
-  const trailingOffset = consumedSize + pluginDataSize;
-  if (rawAccountData.length <= trailingOffset) return undefined;
-
-  const tag = rawAccountData[trailingOffset];
-  if (tag === FEE_CONFIG_OPTION_NONE_TAG) return undefined;
-  assert(
-    tag === FEE_CONFIG_OPTION_SOME_TAG,
-    `Invalid fee_config Option tag: ${tag}`,
+  const payload = readOptionalDiscriminatedTrailing(
+    rawAccountData,
+    consumedSize + pluginDataSize,
+    FEE_CONFIG_DISCRIMINATOR,
   );
+  if (payload === undefined) return undefined;
+
   assert(
-    rawAccountData.length >= trailingOffset + FEE_CONFIG_SOME_TRAILING_SIZE,
-    `Truncated fee_config: expected ${FEE_CONFIG_SOME_TRAILING_SIZE} bytes from offset ${trailingOffset}, got ${rawAccountData.length - trailingOffset}`,
+    payload.length >= FEE_CONFIG_PAYLOAD_SIZE,
+    `Truncated fee_config: expected ${FEE_CONFIG_PAYLOAD_SIZE} payload bytes, got ${payload.length}`,
   );
   return {
-    feeProgram: new PublicKey(
-      rawAccountData.subarray(trailingOffset + 1, trailingOffset + 33),
-    ),
-    feeAccount: new PublicKey(
-      rawAccountData.subarray(trailingOffset + 33, trailingOffset + 65),
-    ),
+    feeProgram: new PublicKey(payload.subarray(0, 32)),
+    feeAccount: new PublicKey(payload.subarray(32, 64)),
   };
 }
 

--- a/typescript/sdk/src/utils/sealevelSerialization.ts
+++ b/typescript/sdk/src/utils/sealevelSerialization.ts
@@ -1,3 +1,45 @@
+import { assert } from '@hyperlane-xyz/utils';
+
+/**
+ * Length of the self-describing discriminator prefixed to a present
+ * `OptionalDiscriminatedData<T>` trailing field. Mirrors
+ * `Discriminator::LENGTH` in rust/sealevel/libraries/account-utils.
+ */
+export const SEALEVEL_DISCRIMINATOR_SIZE = 8;
+
+/**
+ * Read a self-describing optional trailing field, mirroring
+ * `OptionalDiscriminatedData<T>::deserialize_reader` in
+ * rust/sealevel/libraries/account-utils/src/discriminator.rs.
+ *
+ * A present value is serialized on-chain as `[T::DISCRIMINATOR][payload]` and
+ * an absent one as zero bytes. On read the tail is the value's payload only if
+ * it begins with exactly `discriminator`; an empty tail, a tail shorter than
+ * the discriminator, or any non-matching tail (e.g. stale bytes in an
+ * over-allocated account) all decode to `undefined` rather than erroring.
+ *
+ * Returns the payload bytes following the discriminator, or `undefined` when
+ * absent. A matching discriminator with a truncated payload is the caller's
+ * responsibility to detect.
+ */
+export function readOptionalDiscriminatedTrailing(
+  rawAccountData: Buffer,
+  offset: number,
+  discriminator: Buffer,
+): Buffer | undefined {
+  assert(
+    discriminator.length === SEALEVEL_DISCRIMINATOR_SIZE,
+    `Discriminator must be ${SEALEVEL_DISCRIMINATOR_SIZE} bytes`,
+  );
+  const payloadOffset = offset + SEALEVEL_DISCRIMINATOR_SIZE;
+  // Empty or too-short tail => the field is absent (None), not an error.
+  if (rawAccountData.length < payloadOffset) return undefined;
+  const tail = rawAccountData.subarray(offset, payloadOffset);
+  // Stale / non-matching tail => absent, matching on-chain behaviour.
+  if (!tail.equals(discriminator)) return undefined;
+  return rawAccountData.subarray(payloadOffset);
+}
+
 export class SealevelInstructionWrapper<Instr> {
   instruction!: number;
   data!: Instr;

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -128,11 +128,14 @@ export class WarpCore {
     const parsedConfig = WarpCoreConfigSchema.parse(config);
     const tokens = parsedConfig.tokens.map(
       (token) =>
-        new Token({
-          ...token,
-          addressOrDenom: token.addressOrDenom || '',
-          connections: undefined,
-        }),
+        new Token(
+          {
+            ...token,
+            addressOrDenom: token.addressOrDenom || '',
+            connections: undefined,
+          },
+          parsedConfig.options,
+        ),
     );
 
     parsedConfig.tokens.forEach((config, i) => {

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -131,7 +131,7 @@ export class WarpCore {
         new Token(
           {
             ...token,
-            addressOrDenom: token.addressOrDenom || '',
+            addressOrDenom: token.addressOrDenom ?? '',
             connections: undefined,
           },
           parsedConfig.options,


### PR DESCRIPTION
### Description

  Brings the four SVM token adapters (`SealevelHypNative`/`Collateral`/`Synthetic`/`CrossCollateral`) to on-chain fee-flow parity with the new fee + IGP programs, while preserving exact behavior for routes whose programs predate the fee
  flow.

  Highlights:
  - **A.** Plumb `WarpCoreConfig.options` through `Token` → adapter factory, so each protocol's adapter can read its own scoped options (Sealevel reads `options.sealevel.altAddresses[chainName]`). No new protocol-specific fields on `Token`
   or the VM-agnostic interfaces.
  - **B.** Decode the optional trailing `fee_config` on the Sealevel token PDA and on the IGP account. Old programs decode unchanged.
  - **C.** New `sealevelFee.ts` duplicating the codec / PDA / simulation surface from `@hyperlane-xyz/svm-sdk` (no new dependency on svm-sdk from the main SDK — follows the `simulateHandleLocalAccountMetas` precedent).
  - **D.** `quoteTransferRemoteGas` / `quoteTransferRemoteToGas` now return `{ igpQuote, tokenFeeQuote? }`. `tokenFeeQuote` populated only when `fee_config` is set on chain. Legacy routes: no shape change.
  - **E.** Splice the on-chain new-flow fee section and new-flow IGP section into `transfer_remote` / CC `transfer_remote_to` account lists when the corresponding fee configs are set on chain.
  - **F.** When the route registers ALT addresses, compile a v0 `VersionedTransaction` so the 40+ account new-flow list fits under Solana's 1232-byte tx limit. Routes without ALTs continue producing legacy `Transaction`.
  - **G.** Two post-testing fixes:
    - CC adapter overrides `quoteTransferRemoteGas` / `populateTransferRemoteTx` to resolve the destination warp router from on-chain `remote_routers` (base impl seeds the standing-quote PDA with `H256::zero()`, which fails on chain with
  `InvalidTransientSlot` for CC routes).
    - Two `Buffer.readBigUInt64LE` / `readBigInt64LE` reads swapped to `DataView.getBig{Uint,Int}64` — the Node Buffer BigInt methods are missing from the Turbopack browser polyfill.

  Deferred to a follow-up: offchain-signed (transient) quote submission. The EVM analog (`quoted-calls/`) is heavily EVM-shaped (Permit2, viem ABI builder, wrapper contract), so a VM-agnostic refactor adds scope beyond this PR.

  > Note: PR is built on top of `xeno/svm-warp-alt-support` — merge the base PR first.

  ### Drive-by changes

  - Widen `SolTransaction` provider type and SVM signers (`solana-web3js`, `turnkey`) to accept `Transaction | VersionedTransaction`. `signTransaction` is generic over the union; versioned txs go through `partialSign`/`sign([signer])`
  branches.

  ### Related issues

  <!-- none -->

  ### Backward compatibility

  Yes. Routes whose on-chain `fee_config` is `None` (i.e., all pre-fee-flow deployments) take exactly the legacy code path:
  - token PDA / IGP account decode the same as before (trailing `Option<...>` is absent),
  - quote shape stays `{ igpQuote }`,
  - transfer instruction emits the legacy account list,
  - transaction is a legacy `Transaction` (no `VersionedTransaction` unless `altAddresses` is set on the route).

  The `Token` constructor takes an optional new `warpCoreOptions` param; existing callers passing `undefined` get the prior behavior.

  ### Testing

  Manual + unit:
  - Unit tests for the new codecs, PDA derivers, decoders, account-list splicing, and quote-shape matrix (legacy / warp-fee-only / IGP-new-flow-only / both).
  - Manual: USDCFEE warp route on solanamainnet → base via the CC adapter. Verified both legacy `Transaction` (no ALT) and `VersionedTransaction` (with ALT) paths against the on-chain fee program, including a real mainnet broadcast and a
  successful UI transfer through the linked SDK in the nexus-fee template.