### PR TITLE
feat: expose net flow rate limited ISM in TypeScript

### DIFF
--- a/.changeset/netflow-sdk-surface.md
+++ b/.changeset/netflow-sdk-surface.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/sdk': minor
+'@hyperlane-xyz/relayer': minor
+---
+
+Net flow rate limited ISM support was added to the TypeScript SDK and relayer metadata handling.

--- a/typescript/fee-quoting/FeeQuotingServer.ts
+++ b/typescript/fee-quoting/FeeQuotingServer.ts
@@ -10,6 +10,7 @@ import {
   type ChainMetadata,
   EvmHookReader,
   EvmWarpRouteReader,
+  type HookConfig,
   HyperlaneCore,
   MultiProvider,
 } from '@hyperlane-xyz/sdk';
@@ -33,6 +34,10 @@ import {
   QuoteService,
   type ChainQuoteContext,
 } from './src/services/quoteService.js';
+
+type DerivedHookHolder = {
+  hook: HookConfig;
+};
 
 export class FeeQuotingServer {
   app: Express;
@@ -214,28 +219,27 @@ export class FeeQuotingServer {
         const reader = new EvmWarpRouteReader(multiProvider, chainName);
         const derivedConfig =
           await reader.deriveWarpRouteConfig(warpRouteAddress);
+        const derivedHook = derivedConfig as unknown as DerivedHookHolder;
 
         // Resolve hook with Mailbox default fallback when router hook is unset
         if (
-          typeof derivedConfig.hook === 'string' &&
-          isZeroishAddress(derivedConfig.hook)
+          typeof derivedHook.hook === 'string' &&
+          isZeroishAddress(derivedHook.hook)
         ) {
           const hookAddress = await core.getHook(
             chainName,
             warpRouteAddress as Address,
           );
           const hookReader = new EvmHookReader(multiProvider, chainName);
-          derivedConfig.hook = await hookReader.deriveHookConfig(hookAddress);
+          derivedHook.hook = await hookReader.deriveHookConfig(hookAddress);
         }
+        const hook = derivedHook.hook;
 
         this.logger.info(
           {
             chainName,
             warpRoute: warpRouteAddress,
-            hookType:
-              typeof derivedConfig.hook === 'string'
-                ? 'address'
-                : derivedConfig.hook.type,
+            hookType: typeof hook === 'string' ? 'address' : hook.type,
             hasFee: !!derivedConfig.tokenFee,
             feeType: derivedConfig.tokenFee?.type,
           },

--- a/typescript/fee-quoting/src/services/quoteService.ts
+++ b/typescript/fee-quoting/src/services/quoteService.ts
@@ -403,15 +403,19 @@ const isIgp = (v: object): v is WithAddress<IgpHookConfig> =>
   v.type === HookType.INTERCHAIN_GAS_PAYMASTER &&
   'address' in v;
 
+const getHook = (config: unknown): HookConfig =>
+  (config as { hook: HookConfig }).hook;
+
 function resolveIgp(
   config: DerivedTokenRouterConfig,
   destChainName: string,
   signer: Address,
 ): ResolveResult {
-  if (typeof config.hook === 'string')
+  const hook = getHook(config);
+  if (typeof hook === 'string')
     return { resolved: false, reason: 'not_configured' };
 
-  const destHook = resolveDestinationHook(config.hook, destChainName);
+  const destHook = resolveDestinationHook(hook, destChainName);
   const igp = destHook && deepFind(destHook as object, isIgp);
   if (!igp) return { resolved: false, reason: 'not_configured' };
 

--- a/typescript/relayer/src/metadata/builder.ts
+++ b/typescript/relayer/src/metadata/builder.ts
@@ -66,6 +66,7 @@ export class BaseMetadataBuilder implements MetadataBuilder {
       case IsmType.OP_STACK:
       case IsmType.PAUSABLE:
       case IsmType.CCIP:
+      case IsmType.NET_FLOW_RATE_LIMITED:
       case IsmType.RATE_LIMITED:
         return this.nullMetadataBuilder.build({ ...context, ism });
 

--- a/typescript/relayer/src/metadata/types.ts
+++ b/typescript/relayer/src/metadata/types.ts
@@ -120,6 +120,7 @@ export interface NullMetadataBuildResult extends BaseMetadataBuildResult {
     | typeof IsmType.OP_STACK
     | typeof IsmType.PAUSABLE
     | typeof IsmType.CCIP
+    | typeof IsmType.NET_FLOW_RATE_LIMITED
     | typeof IsmType.RATE_LIMITED;
   /** Always present for null ISMs */
   metadata: string;

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -416,6 +416,13 @@ export async function executeWarpDeploy(
     }
   }
 
+  await applyPostDeployNetFlowRateLimitConfigs({
+    deployedContracts,
+    multiProvider,
+    registryAddresses,
+    warpDeployConfig,
+  });
+
   return deployedContracts;
 }
 
@@ -501,6 +508,19 @@ async function resolveWarpIsmAndHook(
         throw new Error(`Registry factory addresses not found for ${chain}.`);
       }
 
+      if (EvmWarpModule.hasNetFlowRateLimitedConfig(config)) {
+        EvmWarpModule.assertValidNetFlowRateLimitedConfig(config);
+        assert(
+          multiProvider.getProtocol(chain) === ProtocolType.Ethereum,
+          'netFlowRateLimitedHook/netFlowRateLimitedIsm is only supported for EVM warp routes',
+        );
+        return {
+          ...config,
+          hook: undefined,
+          interchainSecurityModule: undefined,
+        };
+      }
+
       const ism = await createWarpIsm({
         ccipContractCache,
         chain,
@@ -534,6 +554,62 @@ async function resolveWarpIsmAndHook(
       };
     }),
   );
+}
+
+async function applyPostDeployNetFlowRateLimitConfigs({
+  deployedContracts,
+  multiProvider,
+  registryAddresses,
+  warpDeployConfig,
+}: {
+  deployedContracts: ChainMap<Address>;
+  multiProvider: MultiProvider;
+  registryAddresses: ChainMap<ChainAddresses>;
+  warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
+}): Promise<void> {
+  for (const chain of objKeys(warpDeployConfig)) {
+    const config = warpDeployConfig[chain];
+    if (!EvmWarpModule.hasNetFlowRateLimitedConfig(config)) {
+      continue;
+    }
+    EvmWarpModule.assertValidNetFlowRateLimitedConfig(config);
+    assert(
+      multiProvider.getProtocol(chain) === ProtocolType.Ethereum,
+      'netFlowRateLimitedHook/netFlowRateLimitedIsm is only supported for EVM warp routes',
+    );
+    if (config.foreignDeployment) {
+      continue;
+    }
+
+    const deployedTokenRoute = deployedContracts[chain];
+    assert(
+      deployedTokenRoute,
+      `Expected deployed token route for net flow rate limited warp route on ${chain}`,
+    );
+
+    const addresses = registryAddresses[chain];
+    assert(addresses, `Registry factory addresses not found for ${chain}.`);
+
+    const warpModule = new EvmWarpModule(multiProvider, {
+      chain,
+      config,
+      addresses: {
+        ...extractIsmAndHookFactoryAddresses(addresses),
+        deployedTokenRoute,
+      },
+    });
+
+    const actualConfig = await warpModule.read();
+    const updateTxs = await warpModule.update({
+      ...actualConfig,
+      hook: config.hook,
+      interchainSecurityModule: config.interchainSecurityModule,
+    });
+
+    for (const tx of updateTxs) {
+      await multiProvider.sendTransaction(chain, tx);
+    }
+  }
 }
 
 /**

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -12,6 +12,7 @@ import {
   IPostDispatchHook__factory,
   InterchainGasPaymaster__factory,
   MerkleTreeHook__factory,
+  NetFlowRateLimitedHookIsm__factory,
   OPStackHook__factory,
   PausableHook__factory,
   ProtocolFee__factory,
@@ -50,6 +51,7 @@ import {
   IgpHookConfig,
   MailboxDefaultHookConfig,
   MerkleTreeHookConfig,
+  NetFlowRateLimitedHookConfig,
   OnchainHookType,
   OpStackHookConfig,
   PausableHookConfig,
@@ -85,6 +87,9 @@ export interface HookReader {
   derivePausableConfig(
     address: Address,
   ): Promise<WithAddress<PausableHookConfig>>;
+  deriveNetFlowRateLimitedConfig(
+    address: Address,
+  ): Promise<WithAddress<NetFlowRateLimitedHookConfig>>;
   deriveIdAuthIsmConfig(address: Address): Promise<DerivedHookConfig>;
   deriveCcipConfig(address: Address): Promise<WithAddress<CCIPHookConfig>>;
   deriveRateLimitedHookConfig(
@@ -738,6 +743,32 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
       threshold: threshold.toNumber(),
       lowerHook: lowerHookConfig,
       upperHook: upperHookConfig,
+    };
+
+    this._cache.set(address, config);
+
+    return config;
+  }
+
+  async deriveNetFlowRateLimitedConfig(
+    address: Address,
+  ): Promise<WithAddress<NetFlowRateLimitedHookConfig>> {
+    const hook = NetFlowRateLimitedHookIsm__factory.connect(
+      address,
+      this.provider,
+    );
+
+    const [hookType, maxFlowBps] = await Promise.all([
+      hook.hookType(),
+      hook.maxFlowBps(),
+    ]);
+
+    this.assertHookType(hookType, OnchainHookType.RATE_LIMITED);
+
+    const config: WithAddress<NetFlowRateLimitedHookConfig> = {
+      address,
+      type: HookType.NET_FLOW_RATE_LIMITED,
+      maxFlowBps: maxFlowBps.toNumber(),
     };
 
     this._cache.set(address, config);

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -53,6 +53,7 @@ export const HookType = {
   ROUTING: 'domainRoutingHook',
   FALLBACK_ROUTING: 'fallbackRoutingHook',
   AMOUNT_ROUTING: 'amountRoutingHook',
+  NET_FLOW_RATE_LIMITED: 'netFlowRateLimitedHook',
   PAUSABLE: 'pausableHook',
   ARB_L2_TO_L1: 'arbL2ToL1Hook',
   MAILBOX_DEFAULT: 'defaultHook',
@@ -80,6 +81,7 @@ export type DeployableHookType = Exclude<
   | typeof HookType.PREDICATE
   | typeof HookType.UNKNOWN
   | typeof HookType.CCTP
+  | typeof HookType.NET_FLOW_RATE_LIMITED
 >;
 
 export const HookTypeToContractNameMap: Record<DeployableHookType, string> = {
@@ -129,6 +131,9 @@ export type AmountRoutingHookConfig = {
   lowerHook: HookConfig;
   upperHook: HookConfig;
 };
+export type NetFlowRateLimitedHookConfig = z.infer<
+  typeof NetFlowRateLimitedHookSchema
+>;
 
 export type HookConfig = z.infer<typeof HookConfigSchema>;
 
@@ -229,6 +234,11 @@ export const AmountRoutingHookConfigSchema: z.ZodSchema<AmountRoutingHookConfig>
     }),
   );
 
+export const NetFlowRateLimitedHookSchema = z.object({
+  type: z.literal(HookType.NET_FLOW_RATE_LIMITED),
+  maxFlowBps: z.number().int().nonnegative(),
+});
+
 export const AggregationHookConfigSchema: z.ZodSchema<AggregationHookConfig> =
   z.lazy(() =>
     z.object({
@@ -328,6 +338,7 @@ export const HookConfigSchema = z.union([
   DomainRoutingHookConfigSchema,
   FallbackRoutingHookConfigSchema,
   AmountRoutingHookConfigSchema,
+  NetFlowRateLimitedHookSchema,
   AggregationHookConfigSchema,
   ArbL2ToL1HookSchema,
   MailboxDefaultHookSchema,

--- a/typescript/sdk/src/hook/updates.ts
+++ b/typescript/sdk/src/hook/updates.ts
@@ -52,6 +52,11 @@ export async function getEvmHookUpdateTransactions(
     rateLimitedSender,
   } = updateHookParams;
 
+  const currentHookAddress =
+    typeof actualHookConfig === 'string'
+      ? actualHookConfig
+      : actualHookConfig.address;
+
   const hookModule = new EvmHookModule(
     multiProvider,
     {
@@ -61,10 +66,7 @@ export async function getEvmHookUpdateTransactions(
         ...hookAndIsmFactories,
         mailbox,
         proxyAdmin: proxyAdminAddress,
-        deployedHook:
-          typeof actualHookConfig === 'string'
-            ? actualHookConfig
-            : actualHookConfig.address,
+        deployedHook: currentHookAddress,
         ...(rateLimitedSender ? { rateLimitedSender } : {}),
       },
     },
@@ -74,7 +76,7 @@ export async function getEvmHookUpdateTransactions(
 
   // Get the current hook address before applying the txs to identify if
   // a new hook was deployed during the update process
-  const { deployedHook: currentHookAddress } = hookModule.serialize();
+  const { deployedHook: moduleCurrentHookAddress } = hookModule.serialize();
 
   logger.info(
     `Comparing target Hook config with current one for ${evmChainName} chain`,
@@ -83,7 +85,7 @@ export async function getEvmHookUpdateTransactions(
   const { deployedHook: newHookAddress } = hookModule.serialize();
 
   // If a new Hook is deployed, push the tx to set the hook on the client contract
-  if (!eqAddress(currentHookAddress, newHookAddress)) {
+  if (!eqAddress(moduleCurrentHookAddress, newHookAddress)) {
     updateTransactions.push({
       chainId: updateHookParams.multiProvider.getEvmChainId(
         updateHookParams.evmChainName,

--- a/typescript/sdk/src/ism/types.ts
+++ b/typescript/sdk/src/ism/types.ts
@@ -69,6 +69,7 @@ export const IsmType = {
   PAUSABLE: 'pausableIsm',
   TRUSTED_RELAYER: 'trustedRelayerIsm',
   ARB_L2_TO_L1: 'arbL2ToL1Ism',
+  NET_FLOW_RATE_LIMITED: 'netFlowRateLimitedIsm',
   WEIGHTED_MERKLE_ROOT_MULTISIG: 'weightedMerkleRootMultisigIsm',
   WEIGHTED_MESSAGE_ID_MULTISIG: 'weightedMessageIdMultisigIsm',
   CCIP: 'ccipIsm',
@@ -81,7 +82,9 @@ export type IsmType = (typeof IsmType)[keyof typeof IsmType];
 
 export type DeployableIsmType = Exclude<
   IsmType,
-  typeof IsmType.CUSTOM | typeof IsmType.UNKNOWN
+  | typeof IsmType.CUSTOM
+  | typeof IsmType.UNKNOWN
+  | typeof IsmType.NET_FLOW_RATE_LIMITED
 >;
 
 // ISM types that can be updated in-place
@@ -143,6 +146,7 @@ export function ismTypeToModuleType(ismType: IsmType): ModuleType {
     case IsmType.TRUSTED_RELAYER:
     case IsmType.CCIP:
     case IsmType.RATE_LIMITED:
+    case IsmType.NET_FLOW_RATE_LIMITED:
       return ModuleType.NULL;
     case IsmType.ARB_L2_TO_L1:
       return ModuleType.ARB_L2_TO_L1;
@@ -180,6 +184,9 @@ export type TrustedRelayerIsmConfig = z.infer<
 export type CCIPIsmConfig = z.infer<typeof CCIPIsmConfigSchema>;
 export type ArbL2ToL1IsmConfig = z.infer<typeof ArbL2ToL1IsmConfigSchema>;
 export type RateLimitedIsmConfig = z.infer<typeof RateLimitedIsmConfigSchema>;
+export type NetFlowRateLimitedIsmConfig = z.infer<
+  typeof NetFlowRateLimitedIsmConfigSchema
+>;
 
 export type OffchainLookupIsmConfig = z.infer<
   typeof OffchainLookupIsmConfigSchema
@@ -190,8 +197,9 @@ export type NullIsmConfig =
   | PausableIsmConfig
   | OpStackIsmConfig
   | TrustedRelayerIsmConfig
-  | CCIPIsmConfig
-  | RateLimitedIsmConfig;
+  | NetFlowRateLimitedIsmConfig
+  | RateLimitedIsmConfig
+  | CCIPIsmConfig;
 
 type BaseRoutingIsmConfig<
   T extends
@@ -258,6 +266,7 @@ export type DeployedIsmType = {
   [IsmType.TEST_ISM]: TestIsm;
   [IsmType.PAUSABLE]: PausableIsm;
   [IsmType.TRUSTED_RELAYER]: TrustedRelayerIsm;
+  [IsmType.NET_FLOW_RATE_LIMITED]: IInterchainSecurityModule;
   [IsmType.CCIP]: CCIPIsm;
   [IsmType.ARB_L2_TO_L1]: ArbL2ToL1Ism;
   [IsmType.WEIGHTED_MERKLE_ROOT_MULTISIG]: IStaticWeightedMultisigIsm;
@@ -326,6 +335,11 @@ export const RateLimitedIsmConfigSchema = z
     }
     return val;
   });
+
+export const NetFlowRateLimitedIsmConfigSchema = z.object({
+  type: z.literal(IsmType.NET_FLOW_RATE_LIMITED),
+  maxFlowBps: z.number().int().nonnegative(),
+});
 
 export const CCIPIsmConfigSchema = z.object({
   type: z.literal(IsmType.CCIP),
@@ -466,6 +480,7 @@ export const IsmConfigSchema = z.union([
   OpStackIsmConfigSchema,
   PausableIsmConfigSchema,
   TrustedRelayerIsmConfigSchema,
+  NetFlowRateLimitedIsmConfigSchema,
   CCIPIsmConfigSchema,
   RateLimitedIsmConfigSchema,
   MultisigIsmConfigSchema,

--- a/typescript/sdk/src/token/EvmWarpModule.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.ts
@@ -10,6 +10,7 @@ import {
   IERC20__factory,
   MailboxClient__factory,
   MovableCollateralRouter__factory,
+  NetFlowRateLimitedHookIsm__factory,
   PredicateRouterWrapper__factory,
   ProxyAdmin__factory,
   StaticAggregationHook__factory,
@@ -26,6 +27,7 @@ import {
   ZERO_ADDRESS_HEX_32,
   addressToBytes32,
   assert,
+  deepCopy,
   deepEquals,
   difference,
   eqAddress,
@@ -61,15 +63,15 @@ import { EvmTokenFeeModule } from '../fee/EvmTokenFeeModule.js';
 import { TokenFeeReaderParams } from '../fee/EvmTokenFeeReader.js';
 import { getEvmHookUpdateTransactions } from '../hook/updates.js';
 import { stripPredicateSubHook } from '../hook/utils.js';
-import { DerivedHookConfig, OnchainHookType } from '../hook/types.js';
+import { DerivedHookConfig, HookType, OnchainHookType } from '../hook/types.js';
 import { EvmIsmModule } from '../ism/EvmIsmModule.js';
+import { IsmType } from '../ism/types.js';
 import { PredicateWrapperDeployer } from '../predicate/PredicateDeployer.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
 import { RemoteRouters, resolveRouterMapConfig } from '../router/types.js';
 import { ChainName, ChainNameOrId } from '../types.js';
 import { scalesEqual } from '../utils/decimals.js';
-import { IsmType } from '../ism/types.js';
 import {
   extractIsmAndHookFactoryAddresses,
   ismTreeContainsRateLimited,
@@ -130,6 +132,45 @@ export class EvmWarpModule extends HyperlaneModule<
   HypTokenRouterConfig,
   WarpRouteAddresses
 > {
+  public static hasNetFlowRateLimitedConfig(
+    config: HypTokenRouterConfig,
+  ): boolean {
+    return (
+      !!EvmWarpModule.findConfigByType(
+        config.hook,
+        HookType.NET_FLOW_RATE_LIMITED,
+      ) ||
+      !!EvmWarpModule.findConfigByType(
+        config.interchainSecurityModule,
+        IsmType.NET_FLOW_RATE_LIMITED,
+      )
+    );
+  }
+
+  public static assertValidNetFlowRateLimitedConfig(
+    config: HypTokenRouterConfig,
+  ): void {
+    const hookConfig = EvmWarpModule.findConfigByType(
+      config.hook,
+      HookType.NET_FLOW_RATE_LIMITED,
+    );
+    const ismConfig = EvmWarpModule.findConfigByType(
+      config.interchainSecurityModule,
+      IsmType.NET_FLOW_RATE_LIMITED,
+    );
+
+    if (!hookConfig && !ismConfig) return;
+
+    assert(
+      hookConfig && ismConfig,
+      'netFlowRateLimitedHook and netFlowRateLimitedIsm must be configured together',
+    );
+    assert(
+      hookConfig.maxFlowBps === ismConfig.maxFlowBps,
+      'netFlowRateLimitedHook and netFlowRateLimitedIsm maxFlowBps mismatch',
+    );
+  }
+
   protected logger = rootLogger.child({
     module: 'EvmWarpModule',
   });
@@ -222,6 +263,11 @@ export class EvmWarpModule extends HyperlaneModule<
       xerc20Txs = await module.update(config);
     }
 
+    expectedConfig = await this.replaceNetFlowRateLimitedConfigs(
+      actualConfig,
+      expectedConfig,
+    );
+
     /**
      * @remark
      * The order of operations matter
@@ -288,6 +334,147 @@ export class EvmWarpModule extends HyperlaneModule<
     );
 
     return transactions;
+  }
+
+  private async replaceNetFlowRateLimitedConfigs(
+    actualConfig: DerivedTokenRouterConfig,
+    expectedConfig: HypTokenRouterConfig,
+  ): Promise<HypTokenRouterConfig> {
+    const hookConfig = this.findNetFlowRateLimitedHookConfig(
+      expectedConfig.hook,
+    );
+    const ismConfig = this.findNetFlowRateLimitedIsmConfig(
+      expectedConfig.interchainSecurityModule,
+    );
+
+    if (!hookConfig && !ismConfig) return expectedConfig;
+    EvmWarpModule.assertValidNetFlowRateLimitedConfig(expectedConfig);
+    assert(hookConfig, 'netFlowRateLimitedHook must be configured');
+
+    const actualHookConfig = this.findNetFlowRateLimitedHookConfig(
+      actualConfig.hook,
+    );
+    let netFlowAddress = actualHookConfig?.address;
+
+    if (
+      !netFlowAddress ||
+      actualHookConfig?.maxFlowBps !== hookConfig.maxFlowBps
+    ) {
+      const mailbox = actualConfig.mailbox;
+      const tokenRoute = this.args.addresses.deployedTokenRoute;
+      assert(mailbox, 'mailbox must be configured');
+      assert(tokenRoute, 'deployedTokenRoute must be configured');
+
+      const netFlow = await this.multiProvider.handleDeploy(
+        this.chainName,
+        new NetFlowRateLimitedHookIsm__factory(),
+        [mailbox, tokenRoute, hookConfig.maxFlowBps],
+      );
+      netFlowAddress = netFlow.address;
+    }
+    assert(netFlowAddress, 'netFlowRateLimitedHook address must be set');
+
+    const expandedConfig = deepCopy(expectedConfig);
+    expandedConfig.hook = this.replaceNetFlowRateLimitedHookConfig(
+      expandedConfig.hook,
+      netFlowAddress,
+    );
+    expandedConfig.interchainSecurityModule =
+      this.replaceNetFlowRateLimitedIsmConfig(
+        expandedConfig.interchainSecurityModule,
+        netFlowAddress,
+      );
+
+    return expandedConfig;
+  }
+
+  private findNetFlowRateLimitedHookConfig(
+    config: unknown,
+  ): { maxFlowBps: number; address?: Address } | undefined {
+    return EvmWarpModule.findConfigByType(
+      config,
+      HookType.NET_FLOW_RATE_LIMITED,
+    );
+  }
+
+  private findNetFlowRateLimitedIsmConfig(
+    config: unknown,
+  ): { maxFlowBps: number; address?: Address } | undefined {
+    return EvmWarpModule.findConfigByType(
+      config,
+      IsmType.NET_FLOW_RATE_LIMITED,
+    );
+  }
+
+  private static findConfigByType(
+    config: unknown,
+    type: string,
+  ): { maxFlowBps: number; address?: Address } | undefined {
+    if (!config || typeof config !== 'object') return undefined;
+
+    if (
+      'type' in config &&
+      config.type === type &&
+      'maxFlowBps' in config &&
+      typeof config.maxFlowBps === 'number'
+    ) {
+      return {
+        address:
+          'address' in config && typeof config.address === 'string'
+            ? config.address
+            : undefined,
+        maxFlowBps: config.maxFlowBps,
+      };
+    }
+
+    for (const value of Object.values(config)) {
+      if (typeof value !== 'object') continue;
+      const result = Array.isArray(value)
+        ? value
+            .map((item) => EvmWarpModule.findConfigByType(item, type))
+            .find(Boolean)
+        : EvmWarpModule.findConfigByType(value, type);
+      if (result) return result;
+    }
+    return undefined;
+  }
+
+  private replaceNetFlowRateLimitedHookConfig<T>(
+    config: T,
+    address: Address,
+  ): T {
+    return this.replaceConfigByType(
+      config,
+      HookType.NET_FLOW_RATE_LIMITED,
+      address,
+    );
+  }
+
+  private replaceNetFlowRateLimitedIsmConfig<T>(
+    config: T,
+    address: Address,
+  ): T {
+    return this.replaceConfigByType(
+      config,
+      IsmType.NET_FLOW_RATE_LIMITED,
+      address,
+    );
+  }
+
+  private replaceConfigByType<T>(config: T, type: string, address: Address): T {
+    if (!config || typeof config !== 'object') return config;
+    if ('type' in config && config.type === type) return address as T;
+    if (Array.isArray(config)) {
+      return config.map((item) =>
+        this.replaceConfigByType(item, type, address),
+      ) as T;
+    }
+    return Object.fromEntries(
+      Object.entries(config).map(([key, value]) => [
+        key,
+        this.replaceConfigByType(value, type, address),
+      ]),
+    ) as T;
   }
 
   /**


### PR DESCRIPTION
## Summary

Draft split from #8706.

Adds TypeScript SDK config/reader/deployer support for net-flow rate limited ISMs and hooks, plus relayer metadata handling and fee-quoting typing support. This is intentionally separate from the Solidity audit PR while the broader SDK type surface is reviewed.

- Base: `audit-q3-2026`
- Head: `5a10e99534`
- Draft PR: expected to need follow-up on CLI/SDK union type inference before merge.

## Changeset

- `.changeset/netflow-sdk-surface.md`
- `@hyperlane-xyz/sdk`: minor
- `@hyperlane-xyz/relayer`: minor

## Verification

- `pnpm -C typescript/sdk build`
  - passed
- `pnpm -C typescript/fee-quoting build`
  - passed
- `pnpm -C typescript/relayer build`
  - reaches existing Hardhat test typing errors for `hre.ethers` after the net-flow metadata errors are gone
