### PR TITLE
fix: handle Safe API key rate limits

### DIFF
--- a/.changeset/safe-api-key-rate-limits.md
+++ b/.changeset/safe-api-key-rate-limits.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Safe API Kit requests to Safe's hosted gateway were updated to use the SDK's authenticated default service resolution instead of forcing an explicit transaction service URL.

--- a/typescript/infra/scripts/safes/parse-txs.ts
+++ b/typescript/infra/scripts/safes/parse-txs.ts
@@ -6,6 +6,7 @@ import { AnnotatedEV5Transaction } from '@hyperlane-xyz/sdk';
 import {
   LogFormat,
   LogLevel,
+  assert,
   configureRootLogger,
   rootLogger,
 } from '@hyperlane-xyz/utils';
@@ -76,6 +77,7 @@ async function main() {
           chalk.gray.italic(`Reading tx ${fullTxHash} on ${chain}`),
         );
         const safeTx = await getSafeTx(chain, multiProvider, fullTxHash);
+        assert(safeTx, `Safe transaction ${fullTxHash} not found on ${chain}`);
         const tx: AnnotatedEV5Transaction = {
           to: safeTx.to,
           data: safeTx.data,

--- a/typescript/infra/src/utils/safe.ts
+++ b/typescript/infra/src/utils/safe.ts
@@ -1,7 +1,5 @@
 import { JsonRpcSigner } from '@ethersproject/providers';
-import SafeApiKit, {
-  SafeMultisigTransactionListResponse,
-} from '@safe-global/api-kit';
+import { SafeMultisigTransactionListResponse } from '@safe-global/api-kit';
 import Safe from '@safe-global/protocol-kit';
 import {
   MetaTransactionData,
@@ -22,6 +20,7 @@ import {
   getSafe,
   getSafeService,
 } from '@hyperlane-xyz/sdk';
+import { normalizeSafeTxServiceUrl } from '@hyperlane-xyz/sdk/utils/gnosisSafe';
 import {
   Address,
   CallData,
@@ -43,18 +42,7 @@ const SAFE_API_MAX_RETRIES = 10;
 const SAFE_API_MIN_DELAY_MS = 1000;
 const SAFE_API_MAX_DELAY_MS = 3000;
 
-function getSafeServiceForChain(
-  chain: ChainNameOrId,
-  multiProvider: MultiProvider,
-): SafeApiKit.default {
-  return getSafeService(chain, multiProvider);
-}
-
-function normalizeSafeTxServiceUrl(txServiceUrl: string): string {
-  const trimmedUrl = txServiceUrl.replace(/\/+$/, '');
-  if (trimmedUrl.endsWith('/api')) return trimmedUrl;
-  return `${trimmedUrl}/api`;
-}
+type SafeService = ReturnType<typeof getSafeService>;
 
 /**
  * Retry helper for Safe API calls with random delay between 1-3 seconds.
@@ -95,7 +83,7 @@ export async function getSafeAndService(
   multiProvider: MultiProvider,
   safeAddress: Address,
 ) {
-  let safeService: SafeApiKit.default;
+  let safeService: SafeService;
   try {
     safeService = getSafeService(chain, multiProvider);
   } catch (error) {
@@ -218,7 +206,7 @@ export async function createSafeTransaction(
 export async function proposeSafeTransaction(
   chain: ChainNameOrId,
   safeSdk: Safe.default,
-  safeService: SafeApiKit.default,
+  safeService: SafeService,
   safeTransaction: SafeTransaction,
   safeAddress: Address,
   signer: ethers.Signer,
@@ -247,7 +235,7 @@ export async function deleteAllPendingSafeTxs(
   multiProvider: MultiProvider,
   safeAddress: Address,
 ): Promise<void> {
-  const safeService = getSafeServiceForChain(chain, multiProvider);
+  const safeService = getSafeService(chain, multiProvider);
   const pendingTxs: SafeMultisigTransactionListResponse['results'] = [];
   const limit = 100;
   let offset = 0;
@@ -291,7 +279,7 @@ export async function getSafeTx(
   multiProvider: MultiProvider,
   safeTxHash: string,
 ): Promise<any> {
-  const safeService = getSafeServiceForChain(chain, multiProvider);
+  const safeService = getSafeService(chain, multiProvider);
 
   try {
     return await retrySafeApi(() => safeService.getTransaction(safeTxHash));
@@ -313,7 +301,7 @@ export async function deleteSafeTx(
 ): Promise<void> {
   const signer = multiProvider.getSigner(chain);
   const chainId = multiProvider.getEvmChainId(chain);
-  const safeService = getSafeServiceForChain(chain, multiProvider);
+  const safeService = getSafeService(chain, multiProvider);
   const { gnosisSafeTransactionServiceUrl } =
     multiProvider.getChainMetadata(chain);
   assert(
@@ -394,7 +382,8 @@ export async function deleteSafeTx(
       typedData.message,
     );
 
-    // Make the API call to delete the transaction
+    // API Kit exposes no transaction-delete method, so use Safe's authenticated
+    // Transaction Service endpoint directly.
     const deleteUrl = `${txServiceUrl}/v2/multisig-transactions/${safeTxHash}/`;
     await retrySafeApi(async () => {
       const res = await fetch(deleteUrl, {
@@ -696,7 +685,7 @@ export async function getPendingTxsForChains(
       }
 
       let safeSdk: Safe.default;
-      let safeService: SafeApiKit.default;
+      let safeService: SafeService;
       try {
         ({ safeSdk, safeService } = await getSafeAndService(
           chain,

--- a/typescript/infra/src/utils/safe.ts
+++ b/typescript/infra/src/utils/safe.ts
@@ -43,6 +43,9 @@ const SAFE_API_MIN_DELAY_MS = 1000;
 const SAFE_API_MAX_DELAY_MS = 3000;
 
 type SafeService = ReturnType<typeof getSafeService>;
+type SafeMultisigTransactionResponse = Awaited<
+  ReturnType<SafeService['getTransaction']>
+>;
 
 /**
  * Retry helper for Safe API calls with random delay between 1-3 seconds.
@@ -278,7 +281,7 @@ export async function getSafeTx(
   chain: ChainNameOrId,
   multiProvider: MultiProvider,
   safeTxHash: string,
-): Promise<any> {
+): Promise<SafeMultisigTransactionResponse | undefined> {
   const safeService = getSafeService(chain, multiProvider);
 
   try {

--- a/typescript/infra/src/utils/safe.ts
+++ b/typescript/infra/src/utils/safe.ts
@@ -19,8 +19,8 @@ import {
   MultiProvider,
   getSafe,
   getSafeService,
+  normalizeSafeTxServiceUrl,
 } from '@hyperlane-xyz/sdk';
-import { normalizeSafeTxServiceUrl } from '@hyperlane-xyz/sdk/utils/gnosisSafe';
 import {
   Address,
   CallData,

--- a/typescript/infra/src/utils/safe.ts
+++ b/typescript/infra/src/utils/safe.ts
@@ -25,6 +25,7 @@ import {
 import {
   Address,
   CallData,
+  assert,
   deepCopy,
   eqAddress,
   rootLogger,
@@ -41,6 +42,19 @@ const MIN_SAFE_API_VERSION = '5.18.0';
 const SAFE_API_MAX_RETRIES = 10;
 const SAFE_API_MIN_DELAY_MS = 1000;
 const SAFE_API_MAX_DELAY_MS = 3000;
+
+function getSafeServiceForChain(
+  chain: ChainNameOrId,
+  multiProvider: MultiProvider,
+): SafeApiKit.default {
+  return getSafeService(chain, multiProvider);
+}
+
+function normalizeSafeTxServiceUrl(txServiceUrl: string): string {
+  const trimmedUrl = txServiceUrl.replace(/\/+$/, '');
+  if (trimmedUrl.endsWith('/api')) return trimmedUrl;
+  return `${trimmedUrl}/api`;
+}
 
 /**
  * Retry helper for Safe API calls with random delay between 1-3 seconds.
@@ -74,23 +88,6 @@ export async function retrySafeApi<T>(runner: () => Promise<T>): Promise<T> {
     }
   }
   throw new Error('Unreachable');
-}
-
-async function fetchSafeApi<T>(url: string, safeApiKey: string): Promise<T> {
-  return retrySafeApi(async () => {
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': 'node-fetch',
-        Authorization: `Bearer ${safeApiKey}`,
-      },
-    });
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    return response.json();
-  });
 }
 
 export async function getSafeAndService(
@@ -250,28 +247,37 @@ export async function deleteAllPendingSafeTxs(
   multiProvider: MultiProvider,
   safeAddress: Address,
 ): Promise<void> {
-  const txServiceUrl =
-    multiProvider.getChainMetadata(chain).gnosisSafeTransactionServiceUrl;
-  const safeApiKey = await getSafeApiKey();
+  const safeService = getSafeServiceForChain(chain, multiProvider);
+  const pendingTxs: SafeMultisigTransactionListResponse['results'] = [];
+  const limit = 100;
+  let offset = 0;
 
   // Fetch all pending transactions
-  const pendingTxsUrl = `${txServiceUrl}/api/v2/safes/${safeAddress}/multisig-transactions/?executed=false&limit=100`;
-  let pendingTxs;
-  try {
-    pendingTxs = await fetchSafeApi<{ results: { safeTxHash: string }[] }>(
-      pendingTxsUrl,
-      safeApiKey,
-    );
-  } catch (error) {
-    rootLogger.error(
-      chalk.red(`Failed to fetch pending transactions for ${safeAddress}`),
-      error,
-    );
-    return;
+  while (true) {
+    let page: SafeMultisigTransactionListResponse;
+    try {
+      page = await retrySafeApi(() =>
+        safeService.getMultisigTransactions(safeAddress, {
+          executed: false,
+          limit,
+          offset,
+        }),
+      );
+    } catch (error) {
+      rootLogger.error(
+        chalk.red(`Failed to fetch pending transactions for ${safeAddress}`),
+        error,
+      );
+      return;
+    }
+
+    pendingTxs.push(...page.results);
+    if (page.results.length < limit) break;
+    offset += limit;
   }
 
   // Delete each pending transaction
-  for (const tx of pendingTxs.results) {
+  for (const tx of pendingTxs) {
     await deleteSafeTx(chain, multiProvider, safeAddress, tx.safeTxHash);
   }
 
@@ -285,14 +291,10 @@ export async function getSafeTx(
   multiProvider: MultiProvider,
   safeTxHash: string,
 ): Promise<any> {
-  const txServiceUrl =
-    multiProvider.getChainMetadata(chain).gnosisSafeTransactionServiceUrl;
-  const safeApiKey = await getSafeApiKey();
-
-  const txDetailsUrl = `${txServiceUrl}/api/v2/multisig-transactions/${safeTxHash}/`;
+  const safeService = getSafeServiceForChain(chain, multiProvider);
 
   try {
-    return await fetchSafeApi(txDetailsUrl, safeApiKey);
+    return await retrySafeApi(() => safeService.getTransaction(safeTxHash));
   } catch (error) {
     rootLogger.error(
       chalk.red(
@@ -311,17 +313,23 @@ export async function deleteSafeTx(
 ): Promise<void> {
   const signer = multiProvider.getSigner(chain);
   const chainId = multiProvider.getEvmChainId(chain);
-  const txServiceUrl =
-    multiProvider.getChainMetadata(chain).gnosisSafeTransactionServiceUrl;
+  const safeService = getSafeServiceForChain(chain, multiProvider);
+  const { gnosisSafeTransactionServiceUrl } =
+    multiProvider.getChainMetadata(chain);
+  assert(
+    gnosisSafeTransactionServiceUrl,
+    `Missing gnosisSafeTransactionServiceUrl for chain: ${chain}`,
+  );
+  const txServiceUrl = normalizeSafeTxServiceUrl(
+    gnosisSafeTransactionServiceUrl,
+  );
   const safeApiKey = await getSafeApiKey();
 
   // Fetch the transaction details to get the proposer
-  const txDetailsUrl = `${txServiceUrl}/api/v2/multisig-transactions/${safeTxHash}/`;
   let txDetails;
   try {
-    txDetails = await fetchSafeApi<{ proposer?: string }>(
-      txDetailsUrl,
-      safeApiKey,
+    txDetails = await retrySafeApi(() =>
+      safeService.getTransaction(safeTxHash),
     );
   } catch (error) {
     rootLogger.error(
@@ -387,7 +395,7 @@ export async function deleteSafeTx(
     );
 
     // Make the API call to delete the transaction
-    const deleteUrl = `${txServiceUrl}/api/v2/multisig-transactions/${safeTxHash}/`;
+    const deleteUrl = `${txServiceUrl}/v2/multisig-transactions/${safeTxHash}/`;
     await retrySafeApi(async () => {
       const res = await fetch(deleteUrl, {
         method: 'DELETE',

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -960,6 +960,7 @@ export {
   getSafe,
   getSafeDelegates,
   getSafeService,
+  normalizeSafeTxServiceUrl,
   safeApiKeyRequired,
 } from './utils/gnosisSafe.js';
 export { HyperlaneReader } from './utils/HyperlaneReader.js';

--- a/typescript/sdk/src/utils/gnosisSafe.test.ts
+++ b/typescript/sdk/src/utils/gnosisSafe.test.ts
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+
+import {
+  getSafeApiKitConfig,
+  isSafeGlobalTxServiceUrl,
+  normalizeSafeTxServiceUrl,
+} from './gnosisSafe.js';
+
+describe('gnosisSafe utils', () => {
+  describe('normalizeSafeTxServiceUrl', () => {
+    it('appends api to transaction service URLs', () => {
+      expect(
+        normalizeSafeTxServiceUrl('https://api.safe.global/tx-service/base'),
+      ).to.equal('https://api.safe.global/tx-service/base/api');
+    });
+
+    it('preserves URLs that already end in api', () => {
+      expect(
+        normalizeSafeTxServiceUrl(
+          'https://api.safe.global/tx-service/base/api/',
+        ),
+      ).to.equal('https://api.safe.global/tx-service/base/api');
+    });
+  });
+
+  describe('isSafeGlobalTxServiceUrl', () => {
+    it('matches the hosted Safe transaction service gateway', () => {
+      expect(
+        isSafeGlobalTxServiceUrl('https://api.safe.global/tx-service/base'),
+      ).to.equal(true);
+    });
+
+    it('does not match custom Safe transaction service hosts', () => {
+      expect(
+        isSafeGlobalTxServiceUrl('https://safe-transaction-blast.safe.global'),
+      ).to.equal(false);
+    });
+  });
+
+  describe('getSafeApiKitConfig', () => {
+    it('omits txServiceUrl for authenticated Safe global gateway requests', () => {
+      const config = getSafeApiKitConfig(
+        8453,
+        'https://api.safe.global/tx-service/base',
+        'safe-api-key',
+      );
+
+      expect(config.chainId).to.equal(8453n);
+      expect(config.apiKey).to.equal('safe-api-key');
+      expect(config.txServiceUrl).to.equal(undefined);
+    });
+
+    it('keeps txServiceUrl for custom services', () => {
+      const config = getSafeApiKitConfig(
+        81457,
+        'https://safe-transaction-blast.safe.global',
+        'safe-api-key',
+      );
+
+      expect(config.chainId).to.equal(81457n);
+      expect(config.apiKey).to.equal('safe-api-key');
+      expect(config.txServiceUrl).to.equal(
+        'https://safe-transaction-blast.safe.global/api',
+      );
+    });
+  });
+});

--- a/typescript/sdk/src/utils/gnosisSafe.ts
+++ b/typescript/sdk/src/utils/gnosisSafe.ts
@@ -17,6 +17,8 @@ type SafeApiKitInstance = SafeApiKit.default;
 type SafeApiKitConstructor = new (
   config: SafeApiKitConfig,
 ) => SafeApiKitInstance;
+// CAST: Safe API Kit's declarations expose the class under the default type,
+// while Node ESM imports the default export as the constructor at runtime.
 const SafeApiKitCtor = SafeApiKit as unknown as SafeApiKitConstructor;
 
 export function safeApiKeyRequired(txServiceUrl: string): boolean {
@@ -240,7 +242,7 @@ export async function canProposeSafeTransactions(
   let safeService: SafeApiKitInstance;
   try {
     safeService = getSafeService(chain, multiProvider);
-  } catch (e) {
+  } catch (e: unknown) {
     rootLogger.error('Failed to get Safe service for chain', {
       chain,
       chainName: multiProvider.tryGetChainName(chain),

--- a/typescript/sdk/src/utils/gnosisSafe.ts
+++ b/typescript/sdk/src/utils/gnosisSafe.ts
@@ -5,7 +5,7 @@ import {
   getMultiSendDeployment,
 } from '@safe-global/safe-deployments';
 
-import { Address, assert, retryAsync } from '@hyperlane-xyz/utils';
+import { Address, assert, retryAsync, rootLogger } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainName, ChainNameOrId } from '../types.js';
@@ -240,7 +240,13 @@ export async function canProposeSafeTransactions(
   let safeService: SafeApiKitInstance;
   try {
     safeService = getSafeService(chain, multiProvider);
-  } catch {
+  } catch (e) {
+    rootLogger.error('Failed to get Safe service for chain', {
+      chain,
+      chainName: multiProvider.tryGetChainName(chain),
+      knownChains: multiProvider.getKnownChainNames(),
+      error: e,
+    });
     return false;
   }
   const safe = await getSafe(chain, multiProvider, safeAddress);

--- a/typescript/sdk/src/utils/gnosisSafe.ts
+++ b/typescript/sdk/src/utils/gnosisSafe.ts
@@ -1,4 +1,4 @@
-import SafeApiKit from '@safe-global/api-kit';
+import SafeApiKit, { type SafeApiKitConfig } from '@safe-global/api-kit';
 import Safe, { SafeProviderConfig } from '@safe-global/protocol-kit';
 import {
   getMultiSendCallOnlyDeployment,
@@ -8,7 +8,7 @@ import {
 import { Address, retryAsync } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../providers/MultiProvider.js';
-import { ChainName } from '../types.js';
+import { ChainName, ChainNameOrId } from '../types.js';
 
 export const SAFE_API_RETRIES = 10;
 export const SAFE_API_BASE_RETRY_MS = 1000;
@@ -17,26 +17,59 @@ export function safeApiKeyRequired(txServiceUrl: string): boolean {
   return /safe\.global|5afe\.dev/.test(txServiceUrl);
 }
 
+export function normalizeSafeTxServiceUrl(txServiceUrl: string): string {
+  const trimmedUrl = txServiceUrl.replace(/\/+$/, '');
+  if (trimmedUrl.endsWith('/api')) return trimmedUrl;
+  return `${trimmedUrl}/api`;
+}
+
+export function isSafeGlobalTxServiceUrl(txServiceUrl: string): boolean {
+  try {
+    const url = new URL(normalizeSafeTxServiceUrl(txServiceUrl));
+    return (
+      ['api.safe.global', 'api.5afe.dev'].includes(url.hostname) &&
+      /^\/tx-service\/[^/]+\/api$/.test(url.pathname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function getSafeApiKitConfig(
+  chainId: number,
+  txServiceUrl: string,
+  gnosisSafeApiKey?: string,
+): SafeApiKitConfig {
+  const normalizedTxServiceUrl = normalizeSafeTxServiceUrl(txServiceUrl);
+  const apiKey = safeApiKeyRequired(normalizedTxServiceUrl)
+    ? gnosisSafeApiKey
+    : undefined;
+  const baseConfig = {
+    chainId: BigInt(chainId),
+    apiKey,
+  };
+
+  // Safe's hosted gateway authenticates API-key traffic correctly when API Kit
+  // derives the service URL from chainId. Supplying txServiceUrl can hit lower
+  // unauthenticated rate limits on some endpoints.
+  if (apiKey && isSafeGlobalTxServiceUrl(normalizedTxServiceUrl)) {
+    return baseConfig;
+  }
+
+  return {
+    ...baseConfig,
+    txServiceUrl: normalizedTxServiceUrl,
+  };
+}
+
 export function getSafeService(
-  chain: ChainName,
+  chain: ChainNameOrId,
   multiProvider: MultiProvider,
 ): SafeApiKit.default {
   const { gnosisSafeTransactionServiceUrl, gnosisSafeApiKey } =
     multiProvider.getChainMetadata(chain);
-  let txServiceUrl = gnosisSafeTransactionServiceUrl;
-  if (!txServiceUrl) {
+  if (!gnosisSafeTransactionServiceUrl) {
     throw new Error(`must provide tx service url for ${chain}`);
-  }
-
-  // Ensure txServiceUrl ends with /api
-  if (
-    !txServiceUrl.endsWith('/api') &&
-    !txServiceUrl.endsWith('/api/') &&
-    !txServiceUrl.endsWith('api')
-  ) {
-    // Remove trailing slash if present to avoid double slashes
-    txServiceUrl = txServiceUrl.replace(/\/+$/, '');
-    txServiceUrl = `${txServiceUrl}/api`;
   }
 
   const chainId = multiProvider.getEvmChainId(chain);
@@ -44,13 +77,23 @@ export function getSafeService(
     throw new Error(`Chain is not an EVM chain: ${chain}`);
   }
 
-  // @ts-ignore
-  return new SafeApiKit({
-    chainId: BigInt(chainId),
-    txServiceUrl,
-    // Only provide apiKey if the url contains safe.global or 5afe.dev
-    apiKey: safeApiKeyRequired(txServiceUrl) ? gnosisSafeApiKey : undefined,
-  });
+  const txServiceUrl = normalizeSafeTxServiceUrl(
+    gnosisSafeTransactionServiceUrl,
+  );
+  const config = getSafeApiKitConfig(chainId, txServiceUrl, gnosisSafeApiKey);
+  try {
+    // @ts-ignore
+    return new SafeApiKit(config);
+  } catch (error) {
+    if (!config.txServiceUrl && isSafeGlobalTxServiceUrl(txServiceUrl)) {
+      // @ts-ignore
+      return new SafeApiKit({
+        ...config,
+        txServiceUrl,
+      });
+    }
+    throw error;
+  }
 }
 
 // This is the version of the Safe contracts that the SDK is compatible with.

--- a/typescript/sdk/src/utils/gnosisSafe.ts
+++ b/typescript/sdk/src/utils/gnosisSafe.ts
@@ -5,13 +5,19 @@ import {
   getMultiSendDeployment,
 } from '@safe-global/safe-deployments';
 
-import { Address, retryAsync } from '@hyperlane-xyz/utils';
+import { Address, assert, retryAsync } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainName, ChainNameOrId } from '../types.js';
 
 export const SAFE_API_RETRIES = 10;
 export const SAFE_API_BASE_RETRY_MS = 1000;
+
+type SafeApiKitInstance = SafeApiKit.default;
+type SafeApiKitConstructor = new (
+  config: SafeApiKitConfig,
+) => SafeApiKitInstance;
+const SafeApiKitCtor = SafeApiKit as unknown as SafeApiKitConstructor;
 
 export function safeApiKeyRequired(txServiceUrl: string): boolean {
   return /safe\.global|5afe\.dev/.test(txServiceUrl);
@@ -65,29 +71,33 @@ export function getSafeApiKitConfig(
 export function getSafeService(
   chain: ChainNameOrId,
   multiProvider: MultiProvider,
-): SafeApiKit.default {
+): SafeApiKitInstance {
   const { gnosisSafeTransactionServiceUrl, gnosisSafeApiKey } =
     multiProvider.getChainMetadata(chain);
-  if (!gnosisSafeTransactionServiceUrl) {
-    throw new Error(`must provide tx service url for ${chain}`);
-  }
+  assert(
+    gnosisSafeTransactionServiceUrl,
+    `must provide tx service url for ${chain}`,
+  );
 
   const chainId = multiProvider.getEvmChainId(chain);
-  if (!chainId) {
-    throw new Error(`Chain is not an EVM chain: ${chain}`);
-  }
+  assert(chainId, `Chain is not an EVM chain: ${chain}`);
 
   const txServiceUrl = normalizeSafeTxServiceUrl(
     gnosisSafeTransactionServiceUrl,
   );
   const config = getSafeApiKitConfig(chainId, txServiceUrl, gnosisSafeApiKey);
   try {
-    // @ts-ignore
-    return new SafeApiKit(config);
+    return new SafeApiKitCtor(config);
   } catch (error) {
-    if (!config.txServiceUrl && isSafeGlobalTxServiceUrl(txServiceUrl)) {
-      // @ts-ignore
-      return new SafeApiKit({
+    if (
+      error instanceof TypeError &&
+      error.message.includes(
+        'There is no transaction service available for chainId',
+      ) &&
+      !config.txServiceUrl &&
+      isSafeGlobalTxServiceUrl(txServiceUrl)
+    ) {
+      return new SafeApiKitCtor({
         ...config,
         txServiceUrl,
       });
@@ -210,7 +220,7 @@ export async function getSafe(
 }
 
 export async function getSafeDelegates(
-  service: SafeApiKit.default,
+  service: SafeApiKitInstance,
   safeAddress: Address,
 ): Promise<string[]> {
   const delegateResponse = await retryAsync(
@@ -227,7 +237,7 @@ export async function canProposeSafeTransactions(
   multiProvider: MultiProvider,
   safeAddress: Address,
 ): Promise<boolean> {
-  let safeService: SafeApiKit.default;
+  let safeService: SafeApiKitInstance;
   try {
     safeService = getSafeService(chain, multiProvider);
   } catch {

--- a/typescript/sdk/src/utils/gnosisSafe.ts
+++ b/typescript/sdk/src/utils/gnosisSafe.ts
@@ -14,12 +14,12 @@ export const SAFE_API_RETRIES = 10;
 export const SAFE_API_BASE_RETRY_MS = 1000;
 
 type SafeApiKitInstance = SafeApiKit.default;
-type SafeApiKitConstructor = new (
-  config: SafeApiKitConfig,
-) => SafeApiKitInstance;
-// CAST: Safe API Kit's declarations expose the class under the default type,
-// while Node ESM imports the default export as the constructor at runtime.
-const SafeApiKitCtor = SafeApiKit as unknown as SafeApiKitConstructor;
+
+function isSafeApiKitConstructor(
+  value: unknown,
+): value is typeof SafeApiKit.default {
+  return typeof value === 'function';
+}
 
 export function safeApiKeyRequired(txServiceUrl: string): boolean {
   return /safe\.global|5afe\.dev/.test(txServiceUrl);
@@ -89,8 +89,12 @@ export function getSafeService(
     gnosisSafeTransactionServiceUrl,
     gnosisSafeApiKey,
   );
+  assert(
+    isSafeApiKitConstructor(SafeApiKit),
+    '@safe-global/api-kit default export is not a constructor',
+  );
   try {
-    return new SafeApiKitCtor(config);
+    return new SafeApiKit(config);
   } catch (error) {
     if (
       error instanceof TypeError &&
@@ -100,7 +104,7 @@ export function getSafeService(
       !config.txServiceUrl &&
       isSafeGlobalTxServiceUrl(gnosisSafeTransactionServiceUrl)
     ) {
-      return new SafeApiKitCtor({
+      return new SafeApiKit({
         ...config,
         txServiceUrl: normalizeSafeTxServiceUrl(
           gnosisSafeTransactionServiceUrl,

--- a/typescript/sdk/src/utils/gnosisSafe.ts
+++ b/typescript/sdk/src/utils/gnosisSafe.ts
@@ -84,10 +84,11 @@ export function getSafeService(
   const chainId = multiProvider.getEvmChainId(chain);
   assert(chainId, `Chain is not an EVM chain: ${chain}`);
 
-  const txServiceUrl = normalizeSafeTxServiceUrl(
+  const config = getSafeApiKitConfig(
+    chainId,
     gnosisSafeTransactionServiceUrl,
+    gnosisSafeApiKey,
   );
-  const config = getSafeApiKitConfig(chainId, txServiceUrl, gnosisSafeApiKey);
   try {
     return new SafeApiKitCtor(config);
   } catch (error) {
@@ -97,11 +98,13 @@ export function getSafeService(
         'There is no transaction service available for chainId',
       ) &&
       !config.txServiceUrl &&
-      isSafeGlobalTxServiceUrl(txServiceUrl)
+      isSafeGlobalTxServiceUrl(gnosisSafeTransactionServiceUrl)
     ) {
       return new SafeApiKitCtor({
         ...config,
-        txServiceUrl,
+        txServiceUrl: normalizeSafeTxServiceUrl(
+          gnosisSafeTransactionServiceUrl,
+        ),
       });
     }
     throw error;


### PR DESCRIPTION
## Problem

Safe support indicated that passing an explicit `txServiceUrl` into `SafeApiKit` for `api.safe.global/tx-service/...` can route calls through the lower unauthenticated endpoint behavior, even when an API key is present. That matches the observed 429s on Base, Arbitrum, Optimism, and BSC despite using the same Safe API key that worked on Ethereum.

The infra Safe helpers also built raw `.../api/v2/...` URLs for read paths, so `deleteAllPendingSafeTxs` could hit the same low-rate path while fetching pending transaction data.

## Fix

- Added Safe transaction service URL helpers in the SDK.
- For authenticated `api.safe.global` / `api.5afe.dev` gateway URLs, `getSafeService` now lets `SafeApiKit` derive the service URL from `chainId` instead of forcing `txServiceUrl`.
- Kept a fallback to the explicit URL for Safe-hosted chains not yet known to the installed API Kit.
- Routed infra pending-transaction and transaction-detail reads through `SafeApiKit` instead of manual fetches.
- Kept the manual DELETE call for Safe transaction deletion because API Kit does not expose that endpoint, while normalizing the URL consistently.
- Added focused unit coverage for the Safe URL/config behavior.

## Validation

- `typescript/sdk/node_modules/.bin/mocha --config typescript/sdk/.mocharc.json 'typescript/sdk/src/utils/gnosisSafe.test.ts' --exit`
- `typescript/infra/node_modules/.bin/tsc -p typescript/infra/tsconfig.json --noEmit`
- Pre-commit hook ran `gitleaks` and `lint-staged` successfully.

Note: full SDK `tsc --noEmit` still fails on existing Aleo provider type errors in `typescript/sdk/src/core/adapters/AleoCoreAdapter.ts`; not introduced by this PR.