### PR TITLE
chore: bump ethereum min usd cost to 0.12

### DIFF
--- a/typescript/infra/src/config/gas-oracle.ts
+++ b/typescript/infra/src/config/gas-oracle.ts
@@ -300,7 +300,7 @@ function getMinUsdCost(local: ChainName, remote: ChainName): number {
 
     // skunkchain special
     solanamainnet: 0.35,
-    ethereum: 0.07,
+    ethereum: 0.12,
     arbitrum: 0.09,
     optimism: 0.05,
     base: 0.05,


### PR DESCRIPTION
## Summary
- Bumps `ethereum` entry in `getMinUsdCost` from `0.07` to `0.12`.

## Test plan
- [ ] CI passes